### PR TITLE
Quickfix: missing require in post/windows/escalate/getsystem.rb

### DIFF
--- a/modules/post/windows/escalate/getsystem.rb
+++ b/modules/post/windows/escalate/getsystem.rb
@@ -12,6 +12,7 @@
 require 'msf/core'
 require 'rex'
 require 'metasm'
+require 'msf/core/post/windows/priv'
 
 
 class Metasploit3 < Msf::Post


### PR DESCRIPTION
Resolves:
[-] WARNING! The following modules could not be loaded!
[-]     contrib/metasploit-framework/modules/post/windows/escalate/getsystem.rb: NameError uninitialized constant Msf::Post::Windows
