### PR TITLE
Fixed very small typo

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -370,7 +370,7 @@ class Db
 
 				when '-h','--help'
 					print_line
-					print_line "Usage: services [-h] [-u] [-a] [-r <proto>] [-p <port1,port2>] [-n <name1,name2>] [-o <filename>] [addr1 addr2 ...]"
+					print_line "Usage: services [-h] [-u] [-a] [-r <proto>] [-p <port1,port2>] [-s <name1,name2>] [-o <filename>] [addr1 addr2 ...]"
 					print_line
 					print_line "  -a,--add          Add the services instead of searching"
 					print_line "  -d,--delete       Delete the services instead of searching"


### PR DESCRIPTION
There is a very small type in the usage-text of the db command dispatcher.

Usage: services xxxx [-n <name1,name2>] xxxx

^-- Use '-n' for names

vs.

  -s <name1,name2>  Search for a list of service names
^--- use '-s' for names
