### PR TITLE
uuid returned from module.execute()

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -247,7 +247,10 @@ private
 			'RunAsJob' => true,
 			'Options'  => opts
 		})
-		{ "job_id" => mod.job_id }
+		{
+			"job_id" => mod.job_id,
+			"uuid" => mod.uuid
+		}
 	end
 
 	def _run_auxiliary(mod, opts)
@@ -256,7 +259,10 @@ private
 			'RunAsJob' => true,
 			'Options'  => opts
 		})
-		{ "job_id" => mod.job_id }
+		{
+			"job_id" => mod.job_id,
+			"uuid" => mod.uuid
+		}
 	end
 
 	def _run_post(mod, opts)
@@ -264,7 +270,10 @@ private
 			'RunAsJob' => true,
 			'Options'  => opts
 		})
-		{ "job_id" => mod.job_id }
+		{
+			"job_id" => mod.job_id,
+			"uuid" => mod.uuid
+		}
 	end
 	
 	def _run_payload(mod, opts)


### PR DESCRIPTION
module.execute() now returns a 'uuid' element which can be cross-referenced with the 'exploit_uuid' element returned in each entry in session.list.

this was hdm's preferred solution.
