### PR TITLE
RPC multithreading

### DIFF
--- a/lib/msf/core/rpc/v10/service.rb
+++ b/lib/msf/core/rpc/v10/service.rb
@@ -63,7 +63,8 @@ class Service
 			self.options[:ssl],
 			self.options[:context],
 			self.options[:comm],
-			self.options[:cert]
+			self.options[:cert],
+			true
 		)
 
 		self.service.add_resource(self.uri, {

--- a/lib/rex/proto/http/server.rb
+++ b/lib/rex/proto/http/server.rb
@@ -99,13 +99,14 @@ class Server
 	# Initializes an HTTP server as listening on the provided port and
 	# hostname.
 	#
-	def initialize(port = 80, listen_host = '0.0.0.0', ssl = false, context = {}, comm = nil, ssl_cert = nil)
+	def initialize(port = 80, listen_host = '0.0.0.0', ssl = false, context = {}, comm = nil, ssl_cert = nil, threaded = false)
 		self.listen_host = listen_host
 		self.listen_port = port
 		self.ssl         = ssl
 		self.context     = context
 		self.comm        = comm
 		self.ssl_cert    = ssl_cert
+		self.threaded    = threaded
 
 		self.listener    = nil
 		self.resources   = {}
@@ -137,7 +138,8 @@ class Server
 			'Context'   => self.context,
 			'SSL'		=> self.ssl,
 			'SSLCert'	=> self.ssl_cert,
-			'Comm'      => self.comm
+			'Comm'      => self.comm,
+			'Threaded'  => self.threaded
 		)
 
 		# Register callbacks
@@ -260,7 +262,7 @@ class Server
 	end
 
 	attr_accessor :listen_port, :listen_host, :server_name, :context, :ssl, :comm, :ssl_cert
-	attr_accessor :listener, :resources
+	attr_accessor :listener, :resources, :threaded
 
 protected
 

--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -673,6 +673,9 @@ module Socket
 			self.localport = params.localport
 			self.context   = params.context || {}
 			self.ipv       = params.v6 ? 6 : 4
+			if (self.respond_to?('threaded'))
+				self.threaded = params.threaded?
+			end
 		end
 	end
 

--- a/lib/rex/socket/parameters.rb
+++ b/lib/rex/socket/parameters.rb
@@ -97,6 +97,11 @@ class Rex::Socket::Parameters
 	#
 	# 	The number of seconds before a connection should time out
 	#
+	# Threaded
+	#
+	#   Whether the server is to spin off a new thread for each client.
+	#
+
 	
 	def initialize(hash)
 		if (hash['PeerHost'])
@@ -138,7 +143,13 @@ class Rex::Socket::Parameters
 		else
 			self.ssl = false
 		end
-		
+
+		if (hash['Threaded'] and hash['Threaded'].to_s =~ /^(t|y|1)/i)
+			self.threaded = true
+		else
+			self.threaded = false
+		end
+
 		if (hash['SSLVersion'] and hash['SSLVersion'].to_s =~ /^(SSL2|SSL3|TLS1)$/i)
 			self.ssl_version = hash['SSLVersion']
 		end
@@ -273,6 +284,12 @@ class Rex::Socket::Parameters
 		return v6
 	end
 
+	#
+	# Returns true if Multithreading has been enabled
+	#
+	def threaded?
+		return threaded
+	end
 
 	##
 	#
@@ -344,6 +361,10 @@ class Rex::Socket::Parameters
 	# Whether we should use IPv6
 	#
 	attr_accessor :v6
+	#
+	# Whether we should be multithreaded
+	#
+	attr_accessor :threaded
 
 
 	attr_accessor :proxies


### PR DESCRIPTION
Add an optional multithreading to stream server, and enable multithreading (one thread per client) to the RPC server. Reference feature #3630 https://dev.metasploit.com/redmine/issues/3630 of historical significance.
