### PR TITLE
cleaned up module, renamed it, and added railgun definitions to base defs

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_netapi32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_netapi32.rb
@@ -22,6 +22,18 @@ class Def_netapi32
 			["PDWORD","BufferType","out"]
 			])
 
+		dll.add_function('NetServerEnum', 'DWORD',[
+			["PBLOB","servername","in"],
+			["DWORD","level","in"],
+			["PDWORD","bufptr","out"],
+			["DWORD","prefmaxlen","in"],
+			["PDWORD","entriesread","out"],
+			["PDWORD","totalentries","out"],
+			["DWORD","servertype","in"],
+			["PWCHAR","domain","in"],
+			["DWORD","resume_handle","inout"]
+			])
+
 		return dll
 	end
 

--- a/modules/post/windows/recon/net_discovery.rb
+++ b/modules/post/windows/recon/net_discovery.rb
@@ -1,9 +1,4 @@
 ##
-# $Id$
-##
-
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # Framework web site for more information on licensing and terms of use.
@@ -19,7 +14,7 @@ class Metasploit3 < Msf::Post
 
 	def initialize(info={})
 		super( update_info( info,
-				'Name'          => 'Post Windows Recon Computer Browser Discovery',
+				'Name'          => 'Post Windows Recon Net Discovery',
 				'Description'   => %q{ This module uses railgun to discover hostnames and IPs on the network.
 					LTYPE should be set to one of the following values: WK (all workstations), SVR (all servers),
 					SQL (all SQL servers), DC (all Domain Controllers), DCBKUP (all Domain Backup Servers),
@@ -65,35 +60,7 @@ class Metasploit3 < Msf::Post
 	end
 
 	def run
-		### MAIN ###
 		client = session
-
-=begin
-NET_API_STATUS NetUserEnum(
-  __in     LPCWSTR servername,
-  __in     DWORD level,
-  __in     DWORD filter,
-  __out    LPBYTE *bufptr,
-  __in     DWORD prefmaxlen,
-  __out    LPDWORD entriesread,
-  __out    LPDWORD totalentries,
-  __inout  LPDWORD resume_handle
-);
-
-client.railgun.add_function( 'netapi32', 'NetUserEnum', 'DWORD',[
-["PWCHAR","servername","in"],
-["DWORD","level","in"],
-["DWORD","filter","in"],
-["PDWORD","bufptr","out"],
-["DWORD","prefmaxlen","in"],
-["PDWORD","entriesread","out"],
-["PDWORD","totalentries","out"],
-["PDWORD","resume_handle","inout"]])
-
-=end
-
-		client.railgun.add_function( 'netapi32', 'NetServerEnum', 'DWORD',[["PBLOB","servername","in"],["DWORD","level","in"],["PDWORD","bufptr","out"],["DWORD","prefmaxlen","in"],["PDWORD","entriesread","out"],["PDWORD","totalentries","out"],["DWORD","servertype","in"],["PWCHAR","domain","in"],["DWORD","resume_handle","inout"]])
-		client.railgun.add_function( 'ws2_32', 'getaddrinfo', 'DWORD',[["PCHAR","pNodeName","in"],["PCHAR","pServiceName","in"],["PDWORD","pHints","in"],["PDWORD","ppResult","out"]])
 
 		domain = nil
 


### PR DESCRIPTION
'Computer Browser Discovery' didn't really make sense. It uses NetEnum and performs much like 'net view' with ip lookup. Having 'browser' in the name makes it pretty confusing to anyone who doesn't know about the Windows browser service/functions.
