### PR TITLE
Fix for issue #6012;  post/windows/manage/enable_rdp broken

### DIFF
--- a/modules/post/windows/manage/enable_rdp.rb
+++ b/modules/post/windows/manage/enable_rdp.rb
@@ -19,6 +19,7 @@ class Metasploit3 < Msf::Post
 
 	include Msf::Post::Windows::Accounts
 	include Msf::Post::Windows::Registry
+	include Msf::Post::Windows::WindowsServices
 	include Msf::Post::Common
 	include Msf::Post::File
 


### PR DESCRIPTION
Fix for issue #6012 (Post module enable rdp broken), written by Boris Lukashev. Patch adds an include of Msf::Post::Windows::WindowsServices in order to provide function service_change_startup
