### PR TITLE
Add netboot auxiliary

### DIFF
--- a/lib/rex/proto/dhcp/constants.rb
+++ b/lib/rex/proto/dhcp/constants.rb
@@ -29,6 +29,10 @@ OpPXEConfigFile = 0xD1
 OpPXEPathPrefix = 0xD2
 OpPXERebootTime = 0xD3
 
+OpVendorClassID = 0x3C
+OpVendorEncapOpts = 0x2B
+OpRootPath = 0x11
+
 end
 end
 end

--- a/lib/rex/proto/dhcp/server.rb
+++ b/lib/rex/proto/dhcp/server.rb
@@ -15,6 +15,9 @@ module DHCP
 #
 # extended to support testing/exploiting CVE-2011-0997
 # - apconole@yahoo.com
+#
+# extended to support Mac clients
+# - snare / snare@ragequ.it
 ##
 
 class Server
@@ -126,7 +129,8 @@ class Server
 		allowed_options = [
 			:serveOnce, :pxealtconfigfile, :servePXE, :relayip, :leasetime, :dnsserv,
 			:pxeconfigfile, :pxepathprefix, :pxereboottime, :router,
-			:give_hostname, :served_hostname, :served_over, :serveOnlyPXE
+			:give_hostname, :served_hostname, :served_over, :serveOnlyPXE,
+			:vendor_class_id, :vendor_encap_opts, :root_path
 		]
 
 		opts.each_pair { |k,v|
@@ -155,6 +159,7 @@ class Server
 	attr_accessor :current_ip, :start_ip, :end_ip, :broadcasta, :netmaskn
 	attr_accessor :servePXE, :pxeconfigfile, :pxealtconfigfile, :pxepathprefix, :pxereboottime, :serveOnlyPXE
 	attr_accessor :give_hostname, :served_hostname, :served_over, :reporter
+	attr_accessor :vendor_class_id, :vendor_encap_opts, :root_path
 
 protected
 
@@ -317,6 +322,19 @@ protected
 				pkt << dhcpoption(OpHostname, send_hostname)
 			end
 		end
+
+		if (self.vendor_class_id)
+			pkt << dhcpoption(OpVendorClassID, self.vendor_class_id)
+		end
+
+		if (self.vendor_encap_opts)
+			pkt << dhcpoption(OpVendorEncapOpts, self.vendor_encap_opts)
+		end
+
+		if (self.root_path)
+			pkt << dhcpoption(OpRootPath, self.root_path)
+		end
+
 		pkt << dhcpoption(OpEnd)
 
 		pkt << ("\x00" * 32) #padding

--- a/lib/rex/proto/dhcp/server.rb
+++ b/lib/rex/proto/dhcp/server.rb
@@ -97,6 +97,10 @@ class Server
 		self.pxealtconfigfile = "update0"
 		self.pxepathprefix = ""
 		self.pxereboottime = 2000
+
+		if (hash['ROOTPATH'])
+			self.root_path = hash['ROOTPATH']
+		end
 	end
 
 	def report(&block)
@@ -225,6 +229,7 @@ protected
 
 		messageType = 0
 		pxeclient = false
+		resType = "Unknown"
 
 		# options parsing loop
 		spot = 240
@@ -271,6 +276,7 @@ protected
 		pkt << "\x35\x01" #Option
 
 		if messageType == DHCPDiscover  #DHCP Discover - send DHCP Offer
+			resType = "DHCP Offer"
 			pkt << [DHCPOffer].pack('C')
 			# check if already served an Ack based on hw addr (MAC address)
 			# if serveOnce & PXE, don't reply to another PXE request 
@@ -280,6 +286,7 @@ protected
 				return
 			end
 		elsif messageType == DHCPRequest #DHCP Request - send DHCP ACK
+			resType = "DHCP ACK"
 			pkt << [DHCPAck].pack('C')
 			# now we ignore their discovers (but we'll respond to requests in case a packet was lost)
 			if ( self.served_over != 0 )
@@ -307,7 +314,7 @@ protected
 			else
 				# We are handing out an IP and our PXE attack
 				if(self.reporter)
-					self.reporter.call(buf[28..43],self.ipstring)
+					self.reporter.call(buf[28..43],self.ipstring, resType)
 				end
 				pkt << dhcpoption(OpPXEConfigFile, self.pxeconfigfile)
 			end

--- a/modules/auxiliary/server/netboot.rb
+++ b/modules/auxiliary/server/netboot.rb
@@ -1,0 +1,85 @@
+require 'msf/core'
+require 'rex/proto/tftp'
+require 'rex/proto/dhcp'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::TFTPServer
+	include Msf::Auxiliary::Report
+
+	def initialize
+		super(
+			'Name'        => 'Mac NetBoot Server',
+			'Version'     => '$Revision$',
+			'Description'    => %q{
+				This module provides a NetBoot server for network booting of Intel-based Macs.
+				It does this by providing a specially-configured DHCP server to configure the
+				target's network stack and a TFTP server to serve an EFI bootloader.
+
+				Based on the `pxexploit' module by scriptjunkie. 
+			},
+			'Author'      => [ 'snare' ],
+			'License'     => MSF_LICENSE,
+			'Actions'     =>
+				[
+					[ 'Service' ]
+				],
+			'PassiveActions' =>
+				[
+					'Service'
+				],
+			'DefaultAction'  => 'Service'
+		)
+
+		register_options(
+			[
+				OptString.new('TFTPROOT',	[false, 'The TFTP root directory from which to serve files', '/tftp']),
+				OptString.new('SRVHOST',	[true,	'The IP of the DHCP server']),
+				OptString.new('SRVNAME',	[false, 'The hostname of the DHCP server']),
+				OptString.new('FILENAME',	[true,	'The filename of the bootloader', 'boot.efi']),
+				OptString.new('ROOTPATH',	[false, 'The path to the root filesystem image']),
+				OptString.new('NETMASK',	[false, 'The netmask of the local subnet', '255.255.255.0']),
+				OptString.new('DHCPIPSTART',[false, 'The first IP to give out']),
+				OptString.new('DHCPIPEND',	[false, 'The last IP to give out']),
+			], self.class)
+	end
+
+	def run
+		if not datastore['TFTPROOT']
+			datastore['TFTPROOT'] = File.join(Msf::Config.data_directory, 'auxiliary', 'netboot')
+		end
+		datastore['SERVEONCE'] = true
+
+		print_status("Starting TFTP server...")
+		@tftp = Rex::Proto::TFTP::Server.new
+		@tftp.set_tftproot(datastore['TFTPROOT'])
+		@tftp.start
+
+		print_status("Starting DHCP server...")
+		@dhcp = Rex::Proto::DHCP::Server.new( datastore )
+
+		# Set vendor options to identify as a NetBoot server. Only supports Intel Macs, but could
+		# be extended to support PPC without too much effort (I don't have one handy to test on).
+		# See http://www.afp548.com/article.php?story=20061220102102611 for more info
+		@dhcp.vendor_class_id = "AAPLBSDPC/i386"
+		@dhcp.vendor_encap_opts = "\x08\x04\x81\x00\x00\x67"
+		@dhcp.root_path = datastore['ROOTPATH']
+
+		@dhcp.report do |mac, ip|
+			print_status("Serving NetBoot attack to #{mac.unpack('H2H2H2H2H2H2').join(':')} "+
+					"(#{Rex::Socket.addr_ntoa(ip)})")
+			report_note(
+				:type => 'NetBoot.client',
+				:data => mac.unpack('H2H2H2H2H2H2').join(':')
+			)
+		end
+		@dhcp.start
+
+		# Wait for finish..
+		@tftp.thread.join
+		@dhcp.thread.join
+
+	end
+
+end
+


### PR DESCRIPTION
I added the auxiliary/server/netboot module. It's based on the pxexploit module, but sets some other vendor-specific DHCP options necessary for it to be recognised by Macs as a NetBoot server. I had to add support for those options to the Rex DHCP server module, and extended the report function to get some more detailed status updates. I also added the beginnings of a similar status update function to the TFTP server module so it will at least report what files it gets read requests for. 
