### PR TITLE
fix for ssh forwarding not handling the eof packet type

### DIFF
--- a/lib/net/ssh/service/forward.rb
+++ b/lib/net/ssh/service/forward.rb
@@ -214,6 +214,10 @@ module Net; module SSH; module Service
           session.stop_listening_to(ch[:socket])
         end
 
+        channel.on_eof do |ch|
+          ch.close
+        end
+
         channel.on_process do |ch|
           if ch[:socket].closed?
             ch.info { "#{type} forwarded connection closed" }


### PR DESCRIPTION
This is a simple bug fix for the ssh lib bundled with metasploit not handling an ssh EOF packet on a forwarded channel. Currently the channel will stay open even after the remote socket has closed. 
