### PR TITLE
rename non existent local variable 'options' to correct session.options

### DIFF
--- a/lib/net/ssh/service/forward.rb
+++ b/lib/net/ssh/service/forward.rb
@@ -249,11 +249,11 @@ module Net; module SSH; module Service
           'PeerHost' => remote.host,
           'PeerPort' => remote.port,
           'Context'  => {
-             'Msf'        => options[:msframework],
-             'MsfExploit' => options[:msfmodule]
+             'Msf'        => session.options[:msframework],
+             'MsfExploit' => session.options[:msfmodule]
           }
         )
-        options[:msfmodule].add_socket(client) if options[:msfmodule]
+        options[:msfmodule].add_socket(client) if session.options[:msfmodule]
 
         info { "connected #{connected_address}:#{connected_port} originator #{originator_address}:#{originator_port}" }
 


### PR DESCRIPTION
fix lib/net/ssh/service/forward.rb throwing exception on remote forwarding due to references to a non-existent local variable options, this should be session.options
