### PR TITLE
Small fix: RPC client exception handling

### DIFF
--- a/lib/msf/core/rpc/v10/client.rb
+++ b/lib/msf/core/rpc/v10/client.rb
@@ -71,7 +71,7 @@ class Client
 			resp = MessagePack.unpack(res.body)
 
 			if resp and resp.kind_of?(::Hash) and resp['error'] == true
-				raise Msf::RPC::ServerException.new(res.code, resp['error_message'] || resp['error_string'], resp['error_class'], resp['error_backtrace'])
+				raise Msf::RPC::ServerException.new(resp['error_code'], resp['error_message'] || resp['error_string'], resp['error_class'], resp['error_backtrace'])
 			end
 
 			return resp


### PR DESCRIPTION
IMHO rpc client should transform the error code from Msf::RPC::Exception
into it's own Msf::RPC::ServerException and should not take the msgpack
response code.

In deep:
I ran into a '401 invalid auth token' after a token timeout (300s).
RPC Daemon raised a 401 - invalid auth token as expected but rpc client
transformed it to a '200 - invalid auth token' using the successful http
transaction to transport the exception.
