### PR TITLE
Msf scripts - autocrawler

### DIFF
--- a/scripts/resource/autocrawler.rc
+++ b/scripts/resource/autocrawler.rc
@@ -7,8 +7,10 @@
 # some basic jobhandling to not kill our own machine is included - check the maxjobs and threadspercrawler variables
 
 <ruby>
-if (framework.datastore['VERBOSE'] == "true")
+if (framework.datastore['VERBOSE'] == "true")	#we look in the global datastore for a global VERBOSE option and use it
 	verbose = "true"
+else
+	verbose = "false"
 end
 
 threadspercrawler = "4"

--- a/scripts/resource/autocrawler.rc
+++ b/scripts/resource/autocrawler.rc
@@ -1,8 +1,9 @@
 # autocrawler.rc
 # Author: m-1-k-3 (Web: http://www.s3cur1ty.de / Twitter: @s3cur1ty_de)
 
-# this Metasploit RC-File could be used to crawl webapps automatically
+# This Metasploit RC-File could be used to crawl webapps automatically
 # it uses the allready discovered webservers - "services -s http" / "services -s https"
+# you could use db_nmap or http_version for discovering the werbservers
 # some basic jobhandling to not kill our own machine is included - check the maxjobs and threadspercrawler variables
 
 <ruby>

--- a/scripts/resource/autocrawler.rc
+++ b/scripts/resource/autocrawler.rc
@@ -7,7 +7,10 @@
 # some basic jobhandling to not kill our own machine is included - check the maxjobs and threadspercrawler variables
 
 <ruby>
-verbose = "true"
+if (framework.datastore['VERBOSE'] == "true")
+	verbose = "true"
+end
+
 threadspercrawler = "4"
 
 def jobwaiting()	#thread handling for poor guys ...
@@ -25,16 +28,11 @@ framework.db.workspace.hosts.each do |host|
 		next if (serv.name !~ /http/)
 		
 		if(verbose == "true")
-			print_status("")
-                        print_status("====================================")
-			print_status("Host: #{serv.host[:address]}")
-			print_status("Servicename: #{serv.name}")
-			print_status("Service Port: #{serv.port.to_i}")
-			print_status("Service Protocol: #{serv.proto}")
-			print_status("OS: #{host.os_name}")
-			print_status("IP: #{host.address}")
-                        print_status("====================================")
-			print_status("")
+			print_line("IP: #{host.address}")
+			print_line("OS: #{host.os_name}")
+			print_line("Servicename: #{serv.name}")
+			print_line("Service Port: #{serv.port.to_i}")
+			print_line("Service Protocol: #{serv.proto}")
 		end
 		run_single("use auxiliary/scanner/http/crawler")
 		run_single("set MAX_THREADS #{threadspercrawler}")

--- a/scripts/resource/autocrawler.rc
+++ b/scripts/resource/autocrawler.rc
@@ -1,0 +1,57 @@
+# autocrawler.rc
+# Author: m-1-k-3 (Web: http://www.s3cur1ty.de / Twitter: @s3cur1ty_de)
+
+# this Metasploit RC-File could be used to crawl webapps automatically
+# it uses the allready discovered webservers - "services -s http" / "services -s https"
+# some basic jobhandling to not kill our own machine is included - check the maxjobs and threadspercrawler variables
+
+<ruby>
+verbose = "true"
+threadspercrawler = "4"
+
+def jobwaiting()	#thread handling for poor guys ...
+        maxjobs=15      #throttling if we get too much jobs
+        while(framework.jobs.keys.length >= maxjobs)
+                ::IO.select(nil, nil, nil, 2.5)
+                print_error("waiting for finishing some modules... active jobs: #{framework.jobs.keys.length} / threads: #{framework.threads.length}")
+        end
+end
+
+framework.db.workspace.hosts.each do |host|
+	host.services.each do |serv|
+		next if not serv.host
+		next if (serv.state != ServiceState::Open)
+		next if (serv.name !~ /http/)
+		
+		if(verbose == "true")
+			print_status("")
+                        print_status("====================================")
+			print_status("Host: #{serv.host[:address]}")
+			print_status("Servicename: #{serv.name}")
+			print_status("Service Port: #{serv.port.to_i}")
+			print_status("Service Protocol: #{serv.proto}")
+			print_status("OS: #{host.os_name}")
+			print_status("IP: #{host.address}")
+                        print_status("====================================")
+			print_status("")
+		end
+		run_single("use auxiliary/scanner/http/crawler")
+		run_single("set MAX_THREADS #{threadspercrawler}")
+		run_single("set RHOST #{host.address}")
+		run_single("set RPORT #{serv.port.to_i}")
+		if(serv.name == "https")
+			run_single("set SSL true")
+		else
+			run_single("set SSL false")
+		end
+		if(verbose == "true")
+                       	run_single("set VERBOSE true")
+                        run_single("run -j")
+                else
+                     	run_single("run -j -q")
+                end
+		run_single("back")
+		jobwaiting()
+	end
+end
+</ruby>

--- a/scripts/resource/portscan.rc
+++ b/scripts/resource/portscan.rc
@@ -1,0 +1,39 @@
+# portscan.rc
+# Author: m-1-k-3 (Web: http://www.s3cur1ty.de / Twitter: @s3cur1ty_de)
+
+# This Metasploit RC-File could be used to portscan the network via nmap or via the internal portscanner module 
+# it also uses the udp_sweep module
+# RHOSTS is used from the global datastore
+
+<ruby>
+
+if (framework.datastore['RHOSTS'] == nil)
+        print_status("you have to set RHOSTS globally ... exiting")
+        return
+end
+
+if (framework.datastore['THREADS'] == nil)	#default to 100 Threads
+	run_single("setg THREADS 100")
+end
+
+if (framework.datastore['NMAP'] == nil)		#default usage of nmap as portscanner
+	nmap = "true"
+end
+
+print_line("")
+print_line("starting portscanners ...")
+print_line("")
+print_line("Module: udp_sweep")
+run_single("use auxiliary/scanner/discovery/udp_sweep")
+run_single("run -j")
+
+if ( nmap == "true")
+        print_line("Module: db_nmap")
+        run_single("db_nmap -v -n -PN -P0 -O -sSV #{framework.datastore['RHOSTS']}")
+else
+        print_line("Module: portscan/tcp")
+        run_single("use auxiliary/scanner/portscan/tcp")
+        run_single("set PORTS 7,21,22,23,25,43,50,53,67,68,79,80,109,110,111,123,135,137,138,139,143,161,264,265,389,443,445,500,631,901,995,1241,1352,1433,1434,1521,1720,1723,3306,3389,3780,4662,5800,5801,5802,5803,5900,5901,5902,5903,6000,6666,8000,8080,8443,10000,10043,27374,27665")
+	run_single("run -j")
+end
+</ruby>

--- a/scripts/resource/portscan.rc
+++ b/scripts/resource/portscan.rc
@@ -6,7 +6,6 @@
 # RHOSTS is used from the global datastore
 
 <ruby>
-
 if (framework.datastore['RHOSTS'] == nil)
         print_status("you have to set RHOSTS globally ... exiting")
         return


### PR DESCRIPTION
This Metasploit RC-File could be used to crawl webapps automatically
it uses the allready discovered webservers - "services -s http" / "services -s https"
you could use db_nmap or http_version for discovering the werbservers
some basic jobhandling to not kill our own machine is included - check the maxjobs and threadspercrawler variables
