### PR TITLE
Created Regexp option type

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -312,9 +312,9 @@ class ReadableText
 			next if (opt.advanced?)
 			next if (opt.evasion?)
 
-			val = mod.datastore[name] || opt.default.to_s
+			val_display = opt.display_value(mod.datastore[name] || opt.default)
 
-			tbl << [ name, val.to_s, opt.required? ? "yes" : "no", opt.desc ]
+			tbl << [ name, val_dislay, opt.required? ? "yes" : "no", opt.desc ]
 		}
 
 		return tbl.to_s

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -314,7 +314,7 @@ class ReadableText
 
 			val_display = opt.display_value(mod.datastore[name] || opt.default)
 
-			tbl << [ name, val_dislay, opt.required? ? "yes" : "no", opt.desc ]
+			tbl << [ name, val_display, opt.required? ? "yes" : "no", opt.desc ]
 		}
 
 		return tbl.to_s

--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -82,6 +82,13 @@ class OptBase
 	end
 
 	#
+	# Returns a string representing a user-friendly display of the chosen value
+	#
+	def display_value(value)
+		value.to_s
+	end
+	
+	#
 	# The name of the option.
 	#
 	attr_reader   :name
@@ -137,6 +144,7 @@ end
 # OptEnum    - Select from a set of valid values
 # OptAddressRange - A subnet or range of addresses
 # OptSession - A session identifier
+# OptRegexp  - Valid Ruby regular expression
 #
 ###
 
@@ -440,6 +448,44 @@ class OptInt < OptBase
 	end
 end
 
+###
+#
+# Regexp option
+#
+###
+class OptRegexp < OptBase
+	def type
+		return 'regexp'
+	end
+
+	def valid?(value)
+		unless super
+			return false
+		end
+
+		begin
+			Regexp.compile(value)
+
+			return true
+		rescue RegexpError => e
+			return false
+		end
+	end
+
+	def normalize(value)
+		return Regexp.compile(value)
+	end
+
+	def display_value(value)
+		if value.kind_of?(Regexp)
+			return value.source
+		elsif value.kind_of?(String)
+			return display_value(normalize(value))
+		end
+
+		return super
+	end
+end
 
 ###
 #

--- a/test/modules/post/test/railgun_reverse_lookups.rb
+++ b/test/modules/post/test/railgun_reverse_lookups.rb
@@ -1,4 +1,3 @@
-
 ##
 # $Id$
 ##
@@ -12,8 +11,11 @@
 
 require 'msf/core'
 require 'rex'
+require 'msf/core/post/windows/railgun'
 
 class Metasploit3 < Msf::Post
+
+	include Msf::Post::Windows::Railgun
 
 	def initialize(info={})
 		super( update_info( info,
@@ -28,26 +30,25 @@ class Metasploit3 < Msf::Post
 		[
 				OptInt.new("ERR_CODE" , [true, "Error code to reverse lookup", 0x420]),
 				OptInt.new("WIN_CONST", [true, "Windows constant to reverse lookup", 4]),
-				OptString.new("WCREGEX", [false,"Regexp to apply to constant rev lookup", "^SERVICE"]),
-				OptString.new("ECREGEX", [false,"Regexp to apply to error code lookup", "^ERROR_SERVICE_"]),
+				OptRegexp.new("WCREGEX", [false,"Regexp to apply to constant rev lookup", '^SERVICE']),
+				OptRegexp.new("ECREGEX", [false,"Regexp to apply to error code lookup", '^ERROR_SERVICE_']),
 			], self.class)
 
 	end
 
 	def run
+		print_debug datastore['ECREGEX']
 		print_status("Running against session #{datastore["SESSION"]}")
 		print_status("Session type is #{session.type}")
 
-		@rg = session.railgun
-
 		print_status()
-		print_status("TESTING:  const_reverse_lookup on #{datastore['WIN_CONST']} filtering by #{datastore['WCREGEX'].to_s}")
-		results = @rg.const_reverse_lookup(datastore['WIN_CONST'],datastore['WCREGEX'])
+		print_status("TESTING:  select_const_names on #{datastore['WIN_CONST']} filtering by #{datastore['WCREGEX'].to_s}")
+		results = select_const_names(datastore['WIN_CONST'],datastore['WCREGEX'])
 		print_status("RESULTS:  #{results.class} #{results.pretty_inspect}")
 		
 		print_status()
 		print_status("TESTING:  error_lookup on #{datastore['ERR_CODE']} filtering by #{datastore['ECREGEX'].to_s}")
-		results = @rg.error_lookup(datastore['ERR_CODE'],datastore['ECREGEX'])
+		results = lookup_error(datastore['ERR_CODE'],datastore['ECREGEX'])
 		print_status("RESULTS:  #{results.class} #{results.inspect}")
 		
 		print_status()


### PR DESCRIPTION
I created a module option called OptRegexp. It only accepts well formed regexp strings from users. Module developers can pass Regexp objects. I also then updated test/modules/post/test/railgun_reverse_lookups.rb (not mine) to use it. Also added an "display_value" method to OptBase which then gets called when dumping options instead of the previous way which was to just call .to_s on the value.
