### PR TITLE
natpimp -- some tools for playing with NAT-PMP devices

### DIFF
--- a/lib/rex/proto/natpmp.rb
+++ b/lib/rex/proto/natpmp.rb
@@ -1,0 +1,14 @@
+##
+# $Id: $
+##
+
+##
+#
+# NAT-PMP protocol support
+#
+# by Jon Hart <jhart@spoofed.org>
+#
+##
+
+require 'rex/proto/natpmp/constants'
+require 'rex/proto/natpmp/packet'

--- a/lib/rex/proto/natpmp/constants.rb
+++ b/lib/rex/proto/natpmp/constants.rb
@@ -13,22 +13,10 @@
 module Rex
 module Proto
 module NATPMP
-
-DefaultPort = 5351
-Version = 0
-
-	# Protocols that can be mapped
-	class ProtocolType
-		TCP = 2
-		UDP = 1
-
-		def self.to_s(num)
-			self.constants.each { |c|
-				return c.to_s if self.const_get(c) == num
-			}
-			'Unknown'
-		end
-	end
+	DefaultPort = 5351
+	Version = 0
+	TCP = 2
+	UDP = 1
 end
 end
 end

--- a/lib/rex/proto/natpmp/constants.rb
+++ b/lib/rex/proto/natpmp/constants.rb
@@ -1,0 +1,35 @@
+##
+# $Id: $
+##
+
+##
+#
+# NAT-PMP constants
+#
+# by Jon Hart <jhart@spoofed.org>
+#
+##
+
+module Rex
+module Proto
+module NATPMP
+
+DefaultPort = 5351
+Version = 0
+
+	# Protocols that can be mapped
+	class ProtocolType
+		TCP = 2
+		UDP = 1
+
+		def self.to_s(num)
+			self.constants.each { |c|
+				return c.to_s if self.const_get(c) == num
+			}
+			'Unknown'
+		end
+	end
+end
+end
+end
+# vim: set ts=4 noet sw=4:

--- a/lib/rex/proto/natpmp/packet.rb
+++ b/lib/rex/proto/natpmp/packet.rb
@@ -1,0 +1,49 @@
+##
+# $Id: $
+##
+
+##
+#
+# NAT-PMP protocol support
+#
+# by Jon Hart <jhart@spoofed.org>
+#
+##
+
+module Rex
+module Proto
+module NATPMP
+
+	# Return a NAT-PMP request to get the external address.
+	def self.external_address_request
+		[ 0, 0 ].pack('nn')
+	end
+
+	# Parse a NAT-PMP external address response +resp+.
+	# Returns the decoded parts of the response as an array.
+	def self.parse_external_address_response(resp)
+		(ver, op, result, epoch, addr) = resp.unpack("CCSLN")
+		[ ver, op, result, epoch, Rex::Socket::addr_itoa(addr) ]
+	end
+
+	# Return a NAT-PMP request to map remote port +rport+/+protocol+ to local port +lport+ for +lifetime+ ms
+	def self.map_port_request(lport, rport, protocol, lifetime)
+		[   Rex::Proto::NATPMP::Version, # version
+			protocol, # opcode, which is now the protocol we are asking to forward
+			0, # reserved
+			lport,
+			rport,
+			lifetime
+		].pack("ccnnnN")
+	end
+
+	# Parse a NAT-PMP mapping response +resp+.
+	# Returns the decoded parts as an array.
+	def self.parse_map_port_response(resp)
+		resp.unpack("CCSLnnN")
+	end
+end
+
+end
+end
+# vim: set ts=4 noet sw=4:

--- a/modules/auxiliary/admin/natpmp/natpmp_map.rb
+++ b/modules/auxiliary/admin/natpmp/natpmp_map.rb
@@ -8,9 +8,9 @@ class Metasploit3 < Msf::Auxiliary
 
 	def initialize
 		super(
-			'Name'        => 'NAT-PMP External address scanner',
+			'Name'        => 'NAT-PMP port mapper',
 			'Version'     => '1',
-			'Description' => 'Scan for NAT devices for their external address using NAT-PMP',
+			'Description' => 'Map (forward) TCP and UDP ports on NAT devices using NAT-PMP',
 			'Author'      => 'jhart@spoofed.org',
 			'License'     => MSF_LICENSE
 		)

--- a/modules/auxiliary/admin/natpmp/natpmp_map.rb
+++ b/modules/auxiliary/admin/natpmp/natpmp_map.rb
@@ -1,0 +1,126 @@
+require 'msf/core'
+require 'rex/proto/natpmp'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::Scanner
+
+	def initialize
+		super(
+			'Name'        => 'NAT-PMP External address scanner',
+			'Version'     => '1',
+			'Description' => 'Scan for NAT devices for their external address using NAT-PMP',
+			'Author'      => 'jhart@spoofed.org',
+			'License'     => MSF_LICENSE
+		)
+
+		register_options(
+			[
+				Opt::LPORT,
+				Opt::RPORT,
+				OptInt.new('NATPMPPORT', [true, "NAT-PMP port to use", Rex::Proto::NATPMP::DefaultPort]),
+				OptInt.new('LIFETIME', [true, "Time in ms to keep this port forwarded", 3600000]),
+				OptString.new('PROTOCOL', [true, "Protocol to forward", 'TCP', %w(TCP UDP)]),
+				Opt::CHOST,
+			],
+			self.class
+		)
+	end
+
+	def run_host(host)
+		begin
+
+			udp_sock = Rex::Socket::Udp.create(
+				{   'LocalHost' => datastore['CHOST'] || nil,
+					'Context' => {'Msf' => framework, 'MsfExploit' => self}
+			})
+			add_socket(udp_sock)
+
+			# get the external address first
+			print_status "#{host} - NATPMP - Probing for external address" if (datastore['VERBOSE'])
+			req = Rex::Proto::NATPMP.external_address_request
+			udp_sock.sendto(req, host, datastore['NATPMPPORT'], 0)
+			external_address = nil
+			while (r = udp_sock.recvfrom(65535, 0.25) and r[1])
+				(ver, op, result, epoch, external_address) = Rex::Proto::NATPMP.parse_external_address_response(r[0])
+			end
+
+			# now map
+			print_status "#{host} - NATPMP - Probing for external address" if (datastore['VERBOSE'])
+
+			case datastore['PROTOCOL']
+			when "UDP"
+				protocol = 1
+			when "TCP"
+				protocol = 2
+			end
+
+			req = Rex::Proto::NATPMP.map_port_request(
+					datastore['LPORT'].to_i, datastore['RPORT'].to_i,
+					protocol, datastore['LIFETIME']
+			)
+			udp_sock.sendto(req, host, datastore['NATPMPPORT'], 0)
+			while (r = udp_sock.recvfrom(65535, 0.25) and r[1])
+				handle_reply(host, external_address, r)
+			end
+		rescue ::Interrupt
+			raise $!
+		rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionRefused
+			nil
+		rescue ::Exception => e
+			print_error("Unknown error: #{e.class} #{e}")
+		end
+	end
+
+	def handle_reply(host, external_address, pkt)
+		return if not pkt[1]
+
+		if(pkt[1] =~ /^::ffff:/)
+			pkt[1] = pkt[1].sub(/^::ffff:/, '')
+		end
+
+		(ver, op, result, epoch, internal_port, external_port, lifetime) = Rex::Proto::NATPMP.parse_map_port_response(pkt[0])
+
+		if (result == 0)
+			if (datastore['RPORT'].to_i != external_port)
+				print_status(	"#{external_address} " +
+								"#{datastore['RPORT']}/#{datastore['PROTOCOL']} -> " +
+								"#{datastore['LHOST']} couldn't be forwarded")
+			end
+			print_status(	"#{external_address} " +
+							"#{external_port}/#{datastore['PROTOCOL']} -> #{datastore['LHOST']} " +
+							"#{internal_port}/#{datastore['PROTOCOL']} forwarded")
+		end
+
+		# report the host we scanned as alive
+		report_host(
+			:host   => host,
+			:state => "alive"
+		)
+
+		# also report its external address as alive
+		report_host(
+			:host   => external_address,
+			:state => "alive"
+		)
+
+		# report NAT-PMP as being open
+		report_service(
+			:host   => host,
+			:port   => pkt[2],
+			:proto  => 'udp',
+			:name  => 'natpmp',
+			:state => "open"
+		)
+
+		# report the external port as being open
+		report_service(
+			:host   => external_address,
+			:port   => external_port,
+			:proto  => datastore['protocol'].downcase,
+			:state => "open"
+		)
+	end
+end
+# vim: set ts=4 noet sw=4:

--- a/modules/auxiliary/gather/natpmp_external_address.rb
+++ b/modules/auxiliary/gather/natpmp_external_address.rb
@@ -1,0 +1,93 @@
+require 'msf/core'
+require 'rex/proto/natpmp'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::Scanner
+
+	def initialize
+		super(
+			'Name'        => 'NAT-PMP External address scanner',
+			'Version'     => '1',
+			'Description' => 'Scan for NAT devices for their external address using NAT-PMP',
+			'Author'      => 'jhart@spoofed.org',
+			'License'     => MSF_LICENSE
+		)
+
+		register_options(
+			[
+				Opt::RPORT(Rex::Proto::NATPMP::DefaultPort),
+				Opt::CHOST,
+			],
+			self.class
+		)
+	end
+
+	def run_host(host)
+		begin
+
+		udp_sock = Rex::Socket::Udp.create(
+			{   'LocalHost' => datastore['CHOST'] || nil,
+				'Context' => {'Msf' => framework, 'MsfExploit' => self}
+		})
+		add_socket(udp_sock)
+
+		print_status "#{host}:#{datastore['RPORT']} - NATPMP - Probing for external address" if (datastore['VERBOSE'])
+
+		begin
+			udp_sock.sendto(Rex::Proto::NATPMP.external_address_request, host, datastore['RPORT'].to_i, 0)
+		rescue ::Interrupt
+			raise $!
+		rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionRefused
+			nil
+		end
+
+		while (r = udp_sock.recvfrom(65535, 0.25) and r[1])
+			handle_reply(host, r)
+		end
+
+		rescue ::Interrupt
+			raise $!
+		rescue ::Exception => e
+			print_error("Unknown error: #{e.class} #{e}")
+		end
+
+		end
+
+	def handle_reply(host, pkt)
+		return if not pkt[1]
+
+		if(pkt[1] =~ /^::ffff:/)
+			pkt[1] = pkt[1].sub(/^::ffff:/, '')
+		end
+
+		(ver, op, result, epoch, external_address) = Rex::Proto::NATPMP.parse_external_address_response(pkt[0])
+
+		if (result == 0)
+			print_status("#{host} -- external address #{external_address}")
+		end
+
+		# report the host we scanned as alive
+		report_host(
+			:host   => host,
+			:state => "alive"
+		)
+
+		# also report its external address as alive
+		report_host(
+			:host   => external_address,
+			:state => "alive"
+		)
+
+		# report NAT-PMP as being open
+		report_service(
+			:host   => host,
+			:port   => pkt[2],
+			:proto  => 'udp',
+			:name  => 'natpmp',
+			:state => "open"
+		)
+	end
+end
+# vim: set ts=4 noet sw=4:

--- a/modules/auxiliary/scanner/natpmp/natpmp_portscan.rb
+++ b/modules/auxiliary/scanner/natpmp/natpmp_portscan.rb
@@ -1,0 +1,122 @@
+##
+
+require 'msf/core'
+require 'rex/proto/natpmp'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::Scanner
+
+	def initialize
+		super(
+			'Name'        => 'NAT-PMP External port scanner',
+			'Version'     => '1',
+			'Description' => 'Scan for NAT devices for their external listening ports using NAT-PMP',
+			'Author'      => 'jhart@spoofed.org',
+			'License'     => MSF_LICENSE
+			)
+
+		register_options(
+			[
+				Opt::RPORT(Rex::Proto::NATPMP::DefaultPort),
+				OptString.new('PORTS', [true, "Ports to scan (e.g. 22-25,80,110-900)", "1-1000"]),
+				OptString.new('PROTOCOL', [true, "Protocol to forward", 'TCP', %w(TCP UDP)]),
+				Opt::CHOST,
+			], self.class)
+	end
+
+	def run_host(host)
+		begin
+		udp_sock = Rex::Socket::Udp.create(
+			{	'LocalHost' => datastore['CHOST'] || nil,
+				'Context' => {'Msf' => framework, 'MsfExploit' => self} }
+		)
+		add_socket(udp_sock)
+
+		print_status "Scanning #{datastore['PROTOCOL']} ports #{datastore['PORTS']} on #{host} using NATPMP" if (datastore['VERBOSE'])
+
+		case datastore['PROTOCOL']
+		when 'UDP'
+			protocol = 1
+		when 'TCP'
+			protocol = 2
+		end
+
+		begin
+			# first, send a request to get the external address
+			udp_sock.sendto(Rex::Proto::NATPMP.external_address_request, host, datastore['RPORT'].to_i, 0)
+			external_address = nil
+			while (r = udp_sock.recvfrom(65535, 0.25) and r[1])
+				(ver,op,result,epoch,external_address) = Rex::Proto::NATPMP.parse_external_address_response(r[0])
+			end
+
+			print_status("External address of #{host} is #{external_address}")
+			Rex::Socket.portspec_crack(datastore['PORTS']).each do |port|
+				# send one request to clear the mapping if *we've* created it before
+				clear_req = Rex::Proto::NATPMP.map_port_request(port, port, protocol, 0)
+				udp_sock.sendto(clear_req, host, datastore['RPORT'].to_i, 0)
+				while (r = udp_sock.recvfrom(65535, 0.25) and r[1])
+				end
+
+				# now try the real mapping
+				map_req = Rex::Proto::NATPMP.map_port_request(port, port, protocol, 1)
+				udp_sock.sendto(map_req, host, datastore['RPORT'].to_i, 0)
+				while (r = udp_sock.recvfrom(65535, 0.25) and r[1])
+					handle_reply(host, external_address, r)
+				end
+			end
+		rescue ::Interrupt
+			raise $!
+		rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionRefused
+			nil
+		end
+
+		rescue ::Interrupt
+			raise $!
+		rescue ::Exception => e
+			print_error("Unknown error: #{e.class} #{e}")
+		end
+	end
+
+	def handle_reply(host, external_addr, pkt)
+		return if not pkt[1]
+
+		if(pkt[1] =~ /^::ffff:/)
+			pkt[1] = pkt[1].sub(/^::ffff:/, '')
+		end
+		host = pkt[1]
+		protocol = datastore['PROTOCOL'].downcase
+
+		(ver, op, result, epoch, int, ext, lifetime) = Rex::Proto::NATPMP.parse_map_port_response(pkt[0])
+		if (result == 0)
+			# we always ask to map an external port to the same port on us.  If
+			# we get a successful reponse back but the port we requested be forwarded
+			# is different, that means that someone else already has it open
+			if (int != ext)
+				state = "open"
+				print_status("#{external_addr} - #{int}/#{protocol} #{state} because of successful mapping with unmatched ports") if (datastore['VERBOSE'])
+			else
+				state = "closed"
+				print_status("#{external_addr} - #{int}/#{protocol} #{state} because of successful mapping with matched ports") if (datastore['DEBUG'])
+			end
+		else
+			state = "closed"
+			print_status("#{external_addr} - #{int}/#{protocol} #{state} because of code #{result} response") if (datastore['DEBUG'])
+		end
+
+		report_service(
+			:host   => external_addr,
+			:port   => int,
+			:proto  => protocol,
+			:state => state
+		)
+		report_service(
+			:host   => host,
+			:port   => int,
+			:proto  => protocol,
+			:state => 'unknown'
+		)
+	end
+end
+# vim: set ts=4 noet sw=4:


### PR DESCRIPTION
Long story short, I can't seem to remember the password for my Apple Airport, and I didn't feel like resetting it just to forward a port.

So I wrote this instead:

1) Addition to Rex::Proto to support NAT-PMP
2) A module to forward TCP/UDP ports on NAT-PMP capable devices
3) A module to scan TCP/UDP ports using NAT-PMP
4) A module to get the external address of NAT-PMP devices

NAT-PMP is used on many Apple, DD-WRT and other devices.  
