### PR TITLE
Fix "failed to generate" error when passing a preferred encoder to "payload.generate" method using RPC from, for example, the GUI on Windows.

### DIFF
--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -107,6 +107,10 @@ class EncodedPayload
 		if reqs['BadChars'] or reqs['Encoder'] or reqs['ForceEncode']
 			encoders = pinst.compatible_encoders
 
+			# Fix encoding issue
+			if reqs['Encoder']
+				reqs['Encoder'] = reqs['Encoder'].encode(framework.encoders.keys[0].encoding)
+			end
 			# If the caller had a preferred encoder, use this encoder only
 			if ((reqs['Encoder']) and (preferred = framework.encoders[reqs['Encoder']]))
 				encoders = [ [reqs['Encoder'], preferred] ]


### PR DESCRIPTION
framework.encoders[reqs['Encoder']] returns nil when, for example, reqs['Encoder'] is in UTF-8 encoding and the corresponding key of the framework.encoders hash in US-ASCII encoding. (when the platform encoding doesn't match the msgpack encoding)

And yes, that's confusing. The encoding of the Encoder option doesn't match the encoding of the encoders hash keys. phew!
