### PR TITLE
check function reports to database

### DIFF
--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -1063,6 +1063,15 @@ class Metasploit3 < Msf::Exploit::Remote
 		disconnect
 
 		if (error == 0x0052005c) # \R :)
+			framework.db.report_vuln(
+				{
+				:host   => datastore['RHOST'],
+				:port   => datastore['RPORT'],
+				:proto  => 'tcp',
+				:name   => self.fullname,
+				:refs   => self.references
+				}
+			)
 			return Msf::Exploit::CheckCode::Vulnerable
 		else
 			print_status("System is not vulnerable (status: 0x%08x)" % error) if error


### PR DESCRIPTION
added some lines to report the vulnerability to the database 

10.8.28.2 - (Sessions: 0 Jobs: 0) exploit(ms08_067_netapi) > check

[_] [2012.01.26-09:49:15] Verifying vulnerable status... (path: 0x0000005a)
[+] The target is vulnerable.
10.8.28.2 - (Sessions: 0 Jobs: 0) exploit(ms08_067_netapi) > vulns
[_] Time: 2012-01-26 08:35:20 UTC Vuln: host=10.8.28.125 port=445 proto=tcp name=exploit/windows/smb/ms08_067_netapi refs=CVE-2008-4250,OSVDB-49243,MSB-MS08-067,URL-http://www.rapid7.com/vulndb/lookup/dcerpc-ms-netapi-netpathcanonicalize-dos

pls have a look if this is the right way. Afterwards I could add this to the other exploits.

have a good day,
mIke
