### PR TITLE
Allow RPC clients to discover supported encoding formats.

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_module.rb
+++ b/lib/msf/core/rpc/v10/rpc_module.rb
@@ -149,6 +149,11 @@ class RPC_Module < RPC_Base
 
 	end
 
+	def rpc_encode_formats
+		# Supported formats
+		Msf::Simple::Buffer.transform_formats + Msf::Util::EXE.to_executable_fmt_formats
+	end
+
 	def rpc_encode(data, encoder, options)
 		# Load supported formats
 		supported_formats = Msf::Simple::Buffer.transform_formats + Msf::Util::EXE.to_executable_fmt_formats


### PR DESCRIPTION
When new encoding formats are created ('vba-exe' ... 'vbsmem'...) UI's like msfgui would not require changes to support them if they could automatically see what is available.
