### PR TITLE
Fix typo in seattlelab_pass.rb exploit.

### DIFF
--- a/modules/exploits/windows/pop3/seattlelab_pass.rb
+++ b/modules/exploits/windows/pop3/seattlelab_pass.rb
@@ -95,8 +95,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		sock.put("USER #{rand_text_alphanumeric(10)}\r\n")
-		res = sock.get_once
-		if banner !~ /^\+OK (.*) welcome here$/
+		banner = sock.get_once
+		if banner !~ /^\+OK (.*) welcome here/
 			print_error("POP3 server rejected username")
 			return
 		end


### PR DESCRIPTION
Also remove the $ from the end of the regex which stopped
the exploit from being executed.
