### PR TITLE
Moved railgun function definitions into the definitions and out of individual modules where possible  

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_netapi32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_netapi32.rb
@@ -21,6 +21,17 @@ class Def_netapi32
 			["PDWORD","lpNameBugger","out"],
 			["PDWORD","BufferType","out"]
 			])
+		dll.add_function('NetServerEnum', 'DWORD',[
+			["PWCHAR","servername","in"],
+			["DWORD","level","in"],
+			["PDWORD","bufptr","out"],
+			["DWORD","prefmaxlen","in"],
+			["PDWORD","entriesread","out"],
+			["PDWORD","totalentries","out"],
+			["DWORD","servertype","in"],
+			["PWCHAR","domain","in"],
+			["DWORD","resume_handle","inout"]
+		])
 
 		return dll
 	end

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_ws2_32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_ws2_32.rb
@@ -18,6 +18,12 @@ class Def_ws2_32
 			["PDWORD","ppResult","out"]
 			])
 
+		dll.add_function('gethostbyaddr', 'DWORD', [
+			['PCHAR', 'addr', 'in'],
+			['DWORD','len','in'],
+			['DWORD','type','in']
+			])
+
 		dll.add_function('WSAAccept', 'DWORD',[
 			["DWORD","s","in"],
 			["PBLOB","addr","inout"],

--- a/modules/post/windows/escalate/net_runtime_modify.rb
+++ b/modules/post/windows/escalate/net_runtime_modify.rb
@@ -124,16 +124,10 @@ class Metasploit3 < Msf::Post
 
 	def init_railgun
 		begin
-		# load the dlls we need
-			if session.railgun.get_dll("advapi32").nil?
-				print_status("Loading advapi.dll...")
-				session.railgun.add_dll("advapi32", 'C:\\WINDOWS\\system32\\advapi32.dll')
-			end
-
-			if session.railgun.advapi32.functions['DeleteService'].nil?
-				session.railgun.add_function( 'advapi32', 'DeleteService','BOOL',[
-				[ "DWORD", "hService", "in" ]])
-			end
+		rg = session.railgun
+		if (!rg.get_dll('advapi32'))
+			rg.add_dll('advapi32')
+		end
 		rescue Exception => e
 			print_error("Could not initalize railgun")
 			print_error("Railgun Error: #{e}")

--- a/modules/post/windows/escalate/service_permissions.rb
+++ b/modules/post/windows/escalate/service_permissions.rb
@@ -110,12 +110,7 @@ class Metasploit3 < Msf::Post
 		end
 
 		#attempt to make new service
-		client.railgun.kernel32.LoadLibraryA("advapi32.dll")
-		client.railgun.get_dll('advapi32')
-		client.railgun.add_function( 'advapi32', 'DeleteService','BOOL',[
-			[ "DWORD", "hService", "in" ]
-		])
-
+		
 		#SERVICE_NO_CHANGE 0xffffffff for DWORDS or NULL for pointer values leaves the current config
 
 		print_status("Trying to add a new service...")

--- a/modules/post/windows/gather/credentials/enum_picasa_pwds.rb
+++ b/modules/post/windows/gather/credentials/enum_picasa_pwds.rb
@@ -45,18 +45,6 @@ class Metasploit3 < Msf::Post
 		if (!rg.get_dll('crypt32'))
 			rg.add_dll('crypt32')
 		end
-
-		if (!rg.crypt32.functions["CryptUnprotectData"])
-			rg.add_function("crypt32", "CryptUnprotectData", "BOOL", [
-					["PBLOB","pDataIn", "in"],
-					["PWCHAR", "szDataDescr", "out"],
-					["PBLOB", "pOptionalEntropy", "in"],
-					["PDWORD", "pvReserved", "in"],
-					["PBLOB", "pPromptStruct", "in"],
-					["DWORD", "dwFlags", "in"],
-					["PBLOB", "pDataOut", "out"]
-				])
-		end
 	end
 
 

--- a/modules/post/windows/gather/credentials/outlook.rb
+++ b/modules/post/windows/gather/credentials/outlook.rb
@@ -41,18 +41,6 @@ class Metasploit3 < Msf::Post
 		if (!rg.get_dll('crypt32'))
 			rg.add_dll('crypt32')
 		end
-
-		if (!rg.crypt32.functions["CryptUnprotectData"])
-			rg.add_function("crypt32", "CryptUnprotectData", "BOOL", [
-					["PBLOB","pDataIn", "in"],
-					["PWCHAR", "szDataDescr", "out"],
-					["PBLOB", "pOptionalEntropy", "in"],
-					["PDWORD", "pvReserved", "in"],
-					["PBLOB", "pPromptStruct", "in"],
-					["DWORD", "dwFlags", "in"],
-					["PBLOB", "pDataOut", "out"]
-				])
-		end
 	end
 
 

--- a/modules/post/windows/gather/enum_domains.rb
+++ b/modules/post/windows/gather/enum_domains.rb
@@ -25,32 +25,6 @@ class Metasploit3 < Msf::Post
 	end
 
 	def run
-		#structure
-=begin
-		NET_API_STATUS NetServerEnum(
-		  __in_opt     LPCWSTR servername,
-		  __in         DWORD level,
-		  __out        LPBYTE *bufptr,
-		  __in         DWORD prefmaxlen,
-		  __out        LPDWORD entriesread,
-		  __out        LPDWORD totalentries,
-		  __in         DWORD servertype,
-		  __in_opt     LPCWSTR domain,
-		  __inout_opt  LPDWORD resume_handle
-		);
-=end
-
-		client.railgun.add_function('netapi32', 'NetServerEnum', 'DWORD',[
-		['PWCHAR','servername','in'],
-		['DWORD','level','in'],
-		['PDWORD','bufptr','out'],
-		['DWORD','prefmaxlen','in'],
-		['PDWORD','entriesread','out'],
-		['PDWORD','totalentries','out'],
-		['DWORD','servertype','in'],
-		['PWCHAR','domain','in'],
-		['PDWORD','resume_handle','inout']
-		])
 
 		domain_enum = 2147483648 # SV_TYPE_DOMAIN_ENUM =  hex 80000000
 		buffersize = 500

--- a/modules/post/windows/gather/reverse_lookup.rb
+++ b/modules/post/windows/gather/reverse_lookup.rb
@@ -53,12 +53,6 @@ class Metasploit3 < Msf::Post
 			end
 		end
 
-		#Initialize Railgun 'gethostbyaddr' call'
-		session.railgun.add_function('ws2_32', 'gethostbyaddr', 'DWORD', [
-				['PCHAR', 'addr', 'in'],
-				['DWORD','len','in'],
-				['DWORD','type','in']])
-
 		#Generates IP list based on RHOSTS - RangeWalker rocks....
 		iplist = Rex::Socket::RangeWalker.new(datastore['RHOSTS'])
 

--- a/modules/post/windows/recon/computer_browser_discovery.rb
+++ b/modules/post/windows/recon/computer_browser_discovery.rb
@@ -68,47 +68,6 @@ class Metasploit3 < Msf::Post
 		### MAIN ###
 		client = session
 
-=begin
-NET_API_STATUS NetUserEnum(
-  __in     LPCWSTR servername,
-  __in     DWORD level,
-  __in     DWORD filter,
-  __out    LPBYTE *bufptr,
-  __in     DWORD prefmaxlen,
-  __out    LPDWORD entriesread,
-  __out    LPDWORD totalentries,
-  __inout  LPDWORD resume_handle
-);
-
-client.railgun.add_function( 'netapi32', 'NetUserEnum', 'DWORD',[
-["PWCHAR","servername","in"],
-["DWORD","level","in"],
-["DWORD","filter","in"],
-["PDWORD","bufptr","out"],
-["DWORD","prefmaxlen","in"],
-["PDWORD","entriesread","out"],
-["PDWORD","totalentries","out"],
-["PDWORD","resume_handle","inout"]])
-
-=end
-
-		client.railgun.add_function(
-			'netapi32', 'NetServerEnum', 'DWORD',
-			[
-				["PBLOB","servername","in"], ["DWORD","level","in"], ["PDWORD","bufptr","out"],
-				["DWORD","prefmaxlen","in"], ["PDWORD","entriesread","out"], ["PDWORD","totalentries","out"],
-				["DWORD","servertype","in"], ["PWCHAR","domain","in"], ["DWORD","resume_handle","inout"]
-			]
-		)
-
-		client.railgun.add_function(
-			'ws2_32', 'getaddrinfo', 'DWORD',
-			[
-				["PCHAR","pNodeName","in"], ["PCHAR","pServiceName","in"],
-				["PDWORD","pHints","in"], ["PDWORD","ppResult","out"]
-			]
-		)
-
 		domain = nil
 
 		# Default = SV_TYPE_NT

--- a/modules/post/windows/recon/resolve_hostname.rb
+++ b/modules/post/windows/recon/resolve_hostname.rb
@@ -28,7 +28,6 @@ class Metasploit3 < Msf::Post
 
 	def run
 		### MAIN ###
-		client.railgun.add_function( 'ws2_32', 'getaddrinfo', 'DWORD',[["PCHAR","pNodeName","in"],["PCHAR","pServiceName","in"],["PDWORD","pHints","in"],["PDWORD","ppResult","out"]])
 
 		if client.platform =~ /^x64/
 			size = 64


### PR DESCRIPTION
Only ones still holding defs are:

post/windows/capture/lockout_keylogger.rb: SystemParametersInfoA
This module re-defines a function that is different based on it's calling and shouldn't be included in the base definitions.

post/windows/escalate/ms10_073_kbdlayout.rb:KiFastSystemCall
I don't have a system to test this, so I wont move this definition out unless I can make sure it works.
