### PR TITLE
Added a message when backgrounding a session

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -83,6 +83,7 @@ class Console::CommandDispatcher::Core
 	end
 
 	def cmd_background
+		print_status "Backgrounding session #{client.name}..."
 		client.interacting = false
 	end
 


### PR DESCRIPTION
I'd guess I'm not the only one who gets a bit confused which shell they just backgrounded with 'background'. CTRL-Z states which you are backgrounding, about time the command did the same. ;-)
