### PR TITLE
Fixed http proxies option

### DIFF
--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -669,6 +669,10 @@ class Client
 			prefix << '/%20HTTP/1.0/../../'
 		end
 
+		if (self.port != 443 and proxies)
+			prefix << "http://#{hostname}"
+		end
+
 		prefix
 	end
 

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -669,8 +669,8 @@ class Client
 			prefix << '/%20HTTP/1.0/../../'
 		end
 
-		if (self.port != 443 and proxies)
-			prefix << "http://#{hostname}"
+		if (self.ssl == false and proxies)
+			prefix << "http://#{hostname}:#{port}"
 		end
 
 		prefix

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -669,7 +669,7 @@ class Client
 			prefix << '/%20HTTP/1.0/../../'
 		end
 
-		if (self.ssl == false and proxies)
+		if (self.proxies.split(':')[0] == 'httponly')
 			prefix << "http://#{hostname}:#{port}"
 		end
 

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -346,7 +346,6 @@ class Rex::Socket::Comm::Local
 
 	def self.proxy(sock, type, host, port)
 
-		#$stdout.print("PROXY\n")
 		case type.downcase
 		when 'httponly'
 			return

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -323,7 +323,7 @@ class Rex::Socket::Comm::Local
 					|proxy, i|
 					next_hop = chain[i + 1]
 					if next_hop
-						proxy(sock, proxy[0], next_hop[1], next_hop[2], param.ssl)
+						proxy(sock, proxy[0], next_hop[1], next_hop[2])
 					end
 				}
 			end
@@ -344,16 +344,14 @@ class Rex::Socket::Comm::Local
 		sock
 	end
 
-	def self.proxy(sock, type, host, port, ssl)
+	def self.proxy(sock, type, host, port)
 
 		#$stdout.print("PROXY\n")
 		case type.downcase
+		when 'httponly'
+			return
 		when 'http'
-			if ssl
-				setup = "CONNECT #{host}:#{port} HTTP/1.0\r\n\r\n"
-			else
-				return
-			end
+			setup = "CONNECT #{host}:#{port} HTTP/1.0\r\n\r\n"
 			size = sock.put(setup)
 			if (size != setup.length)
 				raise Rex::ConnectionProxyError.new(host, port, type, "Failed to send the entire request to the proxy"), caller

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -349,7 +349,11 @@ class Rex::Socket::Comm::Local
 		#$stdout.print("PROXY\n")
 		case type.downcase
 		when 'http'
-			setup = "CONNECT #{host}:#{port} HTTP/1.0\r\n\r\n"
+			if port == 443
+				setup = "CONNECT #{host}:#{port} HTTP/1.0\r\n\r\n"
+			else
+				return
+			end
 			size = sock.put(setup)
 			if (size != setup.length)
 				raise Rex::ConnectionProxyError.new(host, port, type, "Failed to send the entire request to the proxy"), caller

--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -323,7 +323,7 @@ class Rex::Socket::Comm::Local
 					|proxy, i|
 					next_hop = chain[i + 1]
 					if next_hop
-						proxy(sock, proxy[0], next_hop[1], next_hop[2])
+						proxy(sock, proxy[0], next_hop[1], next_hop[2], param.ssl)
 					end
 				}
 			end
@@ -344,12 +344,12 @@ class Rex::Socket::Comm::Local
 		sock
 	end
 
-	def self.proxy(sock, type, host, port)
+	def self.proxy(sock, type, host, port, ssl)
 
 		#$stdout.print("PROXY\n")
 		case type.downcase
 		when 'http'
-			if port == 443
+			if ssl
 				setup = "CONNECT #{host}:#{port} HTTP/1.0\r\n\r\n"
 			else
 				return

--- a/modules/auxiliary/scanner/http/http_put.rb
+++ b/modules/auxiliary/scanner/http/http_put.rb
@@ -66,7 +66,7 @@ class Metasploit4 < Msf::Auxiliary
 					'uri'    => path,
 					'method' => 'GET',
 					'ctype'  => 'text/plain',
-					'data'   => data,
+					'data'   => '',
 				}, 20
 			).to_s
 		rescue ::Exception => e


### PR DESCRIPTION
The Proxies option uses the CONNECT method for all ports,  most proxies today only support this method for ssl connections (tested: burp, paros/zap, squid default install)

With this patch it now only uses CONNECT if the port is 443, so now it works for plain http and you can use burp or other proxy to easily inspect the http traffic being sent by the msf module.
