### PR TITLE
change sniffer behaviour when stopping capture. workaround if pcap_finda...

### DIFF
--- a/external/source/meterpreter/source/common/common.h
+++ b/external/source/meterpreter/source/common/common.h
@@ -38,7 +38,7 @@ typedef struct ___u128 {
 }__u128;
 
 struct iface_entry {
-	unsigned char name[IFNAMSIZ+1];
+	char name[IFNAMSIZ+1];
 	__u32 addr;
 	__u32 netmask;
 	unsigned char hwaddr[6];
@@ -46,7 +46,7 @@ struct iface_entry {
 	__u128 netmask6;
 	uint32_t mtu;
 	uint32_t index;
-	unsigned char flags[FLAGS_LEN+1];
+	char flags[FLAGS_LEN+1];
 };
 
 struct ifaces_list {
@@ -58,16 +58,16 @@ struct ipv4_route_entry {
 	__u32 dest;
 	__u32 netmask;
 	__u32 nexthop;
-    unsigned char interface[IFNAMSIZ+1];
-    __u32 metric;
+	char interface[IFNAMSIZ+1];
+	__u32 metric;
 };
 
 struct ipv6_route_entry {
 	__u128 dest6;
 	__u128 netmask6;
 	__u128 nexthop6;
-    unsigned char interface[IFNAMSIZ+1];
-    __u32 metric;
+	char interface[IFNAMSIZ+1];
+	__u32 metric;
 };
 
 struct ipv4_routing_table {

--- a/lib/rex/post/meterpreter/extensions/sniffer/sniffer.rb
+++ b/lib/rex/post/meterpreter/extensions/sniffer/sniffer.rb
@@ -59,12 +59,27 @@ class Sniffer < Extension
 	def capture_stop(intf)
 		request = Packet.create_request('sniffer_capture_stop')
 		request.add_tlv(TLV_TYPE_SNIFFER_INTERFACE_ID, intf.to_i)
-		response = client.send_request(request)	
+		response = client.send_request(request)
+		{
+			:packets => response.get_tlv_value(TLV_TYPE_SNIFFER_PACKET_COUNT),
+			:bytes   => response.get_tlv_value(TLV_TYPE_SNIFFER_BYTE_COUNT),
+		}
 	end
 	
 	# Retrieve stats about a current capture
 	def capture_stats(intf)
 		request = Packet.create_request('sniffer_capture_stats')
+		request.add_tlv(TLV_TYPE_SNIFFER_INTERFACE_ID, intf.to_i)
+		response = client.send_request(request)
+		{
+			:packets => response.get_tlv_value(TLV_TYPE_SNIFFER_PACKET_COUNT),
+			:bytes   => response.get_tlv_value(TLV_TYPE_SNIFFER_BYTE_COUNT),
+		}
+	end
+
+	# Release packets from a current capture
+	def capture_release(intf)
+		request = Packet.create_request('sniffer_capture_release')
 		request.add_tlv(TLV_TYPE_SNIFFER_INTERFACE_ID, intf.to_i)
 		response = client.send_request(request)
 		{

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/sniffer.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/sniffer.rb
@@ -33,6 +33,7 @@ class Console::CommandDispatcher::Sniffer
 			"sniffer_stop"  => "Stop packet capture on a specific interface",
 			"sniffer_stats" => "View statistics of an active capture",
 			"sniffer_dump"  => "Retrieve captured packet data to PCAP file",
+			"sniffer_release" => "Free captured packets on a specific interface instead of downloading them",
 		}
 	end
 
@@ -70,19 +71,21 @@ class Console::CommandDispatcher::Sniffer
 	end
 	
 	def cmd_sniffer_stop(*args)
-	   intf = args[0].to_i
+		intf = args[0].to_i
 		if (intf == 0)
 			print_error("Usage: sniffer_stop [interface-id]")
 			return
 		end
 		
-		client.sniffer.capture_stop(intf)
+		res = client.sniffer.capture_stop(intf)
 		print_status("Capture stopped on interface #{intf}")
+		print_status("There are #{res[:packets]} packets (#{res[:bytes]} bytes) remaining")
+		print_status("Download or release them using 'sniffer_dump' or 'sniffer_release'")
 		return true
 	end
 	
 	def cmd_sniffer_stats(*args)
-	   intf = args[0].to_i
+		intf = args[0].to_i
 		if (intf == 0)
 			print_error("Usage: sniffer_stats [interface-id]")
 			return
@@ -96,9 +99,22 @@ class Console::CommandDispatcher::Sniffer
 		
 		return true		
 	end
+
+	def cmd_sniffer_release(*args)
+		intf = args[0].to_i
+		if (intf == 0)
+			print_error("Usage: sniffer_stats [interface-id]")
+			return
+		end
+		
+		res = client.sniffer.capture_release(intf)
+		print_status("Flushed #{res[:packets]} packets (#{res[:bytes]} bytes) from interface #{intf}")
+		
+		return true		
+	end
 	
 	def cmd_sniffer_dump(*args)
-	   intf = args[0].to_i
+		intf = args[0].to_i
 		if (intf == 0 or not args[1])
 			print_error("Usage: sniffer_dump [interface-id] [pcap-file]")
 			return


### PR DESCRIPTION
...lldev fails

When doing sniffer_stop, packets are no longer discarded. User has to download them (they are then released) or release them (released and not downloaded)

see http://dev.metasploit.com/redmine/issues/6369

also workaround if pcap_findalldevs fails, fallback to netlink socket.
