### PR TITLE
Fixed auxiliary/scanner/http/frontpage_login error.

### DIFF
--- a/modules/auxiliary/scanner/http/frontpage_login.rb
+++ b/modules/auxiliary/scanner/http/frontpage_login.rb
@@ -78,7 +78,7 @@ class Metasploit3 < Msf::Auxiliary
 					# Fix for Bug #6354.
 					# Check if port is "" or if it begins with ":".
 					if port == ""
-						port = "N/A"
+						port = "0"
 					else
 						port.slice!(0)
 					end

--- a/modules/auxiliary/scanner/http/frontpage_login.rb
+++ b/modules/auxiliary/scanner/http/frontpage_login.rb
@@ -81,6 +81,7 @@ class Metasploit3 < Msf::Auxiliary
 						port = "N/A"
 					else
 						port.slice!(0)
+					end
 					report_note(
 						:host	=> target_host,
 						:proto => 'tcp',

--- a/modules/auxiliary/scanner/http/frontpage_login.rb
+++ b/modules/auxiliary/scanner/http/frontpage_login.rb
@@ -75,6 +75,12 @@ class Metasploit3 < Msf::Auxiliary
 					fpauthor = $1
 					print_status("#{info} FrontPage Author: #{info}#{fpauthor}")
 					# Add Report
+					# Fix for Bug #6354.
+					# Check if port is "" or if it begins with ":".
+					if port == ""
+						port = "N/A"
+					else
+						port.slice!(0)
 					report_note(
 						:host	=> target_host,
 						:proto => 'tcp',

--- a/modules/auxiliary/scanner/http/frontpage_login.rb
+++ b/modules/auxiliary/scanner/http/frontpage_login.rb
@@ -77,19 +77,15 @@ class Metasploit3 < Msf::Auxiliary
 					# Add Report
 					# Fix for Bug #6354.
 					# Check if port is "" or if it begins with ":".
-					if port == ""
-						port = "0"
-					else
-						port.slice!(0)
-					end
-					report_note(
-						:host	=> target_host,
+					opts = {
+						:host  => target_host,
 						:proto => 'tcp',
 						:sname => (ssl ? 'https' : 'http'),
-						:port	=> port,
-						:type	=> 'FrontPage Author',
-						:data	=> "#{info}#{fpauthor}"
-					)
+						:type  => 'FrontPage Author',
+						:data  => "#{info}#{fpauthor}"
+					}
+					opts[:port] = port.slice!(0) if not port.empty?
+					report_note(opts)
 				end
 				check_account(info, fpversion, target_host)
 			end


### PR DESCRIPTION
This is a fix of Bug #6354 of the Metasploit Issue Tracker. There
was an error when trying to write results in the database with an
empty port number.

The code has been modified to write a value if port is empty and
to write the port value without the colon at the beginning if it is
not empty.

Reported by: Nelson LeBlanc
Signed off by: Silviu Popescu silviupopescu1990@gmail.com
