### PR TITLE
Add option OptUri

### DIFF
--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -1,6 +1,7 @@
 require 'resolv'
 require 'msf/core'
 require 'rex/socket'
+require 'uri'
 
 module Msf
 
@@ -134,6 +135,7 @@ end
 #
 # Core option types.  The core supported option types are:
 #
+# OptUri     - A URI object
 # OptString  - Multi-byte character string
 # OptRaw     - Multi-byte raw string
 # OptBool    - Boolean true or false indication
@@ -147,6 +149,33 @@ end
 # OptRegexp  - Valid Ruby regular expression
 #
 ###
+
+###
+#
+# URI object
+#
+###
+class OptUri < OptBase
+	def type
+		return 'uri'
+	end
+
+	def normalize(value)
+		return false if empty_required_value?(value)
+		begin
+			value = URI(value)
+		rescue
+			value = nil
+		end
+		value
+	end
+
+	def valid?(value=self.value)
+		value = normalize(value)
+		return false if empty_required_value?(value)
+		return super
+	end
+end
 
 ###
 #


### PR DESCRIPTION
This is a patch for feature:
http://dev.metasploit.com/redmine/issues/6508

A test case is also included in the above link

Basically, having a URI object prevents module developers to attempt to parse their own URI, which often results in buggy code.
