### PR TITLE
added -o,--options to list the options for a payload

### DIFF
--- a/msfvenom
+++ b/msfvenom
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 #
-# $Id$
-# $Revision$
+# $Id: msfvenom 14815 2012-02-27 02:12:04Z rapid7 $
+# $Revision: 14815 $
 #
 msfbase = __FILE__
 while File.symlink?(msfbase)
@@ -94,6 +94,10 @@ def parse_args
 
 	opt.on('-k', '--keep', 'Preserve the template behavior and inject the payload as a new thread') do
 		opts[:inject] = true
+	end
+	
+	opt.on('-o', '--options', 'List the payload\'s standard options') do 
+		opts[:list_options] = true
 	end
 
 	opt.on_tail('-h', '--help', 'Show this message') do
@@ -273,6 +277,11 @@ if opts[:payload]
 		payload = $framework.payloads.create(opts[:payload])
 		if payload.nil?
 			print_error("Invalid payload: #{opts[:payload]}")
+			exit
+		end
+		if opts[:list_options]
+			print_status("Options for #{payload.fullname}\n\n" + 
+				::Msf::Serializer::ReadableText.dump_options(payload,'    '))
 			exit
 		end
 	end


### PR DESCRIPTION
per request from egypt
note: uses ::Msf::Serializer::ReadableText.dump_options to dump options

usage:  
/msf# ./msfvenom -p "windows/meterpreter/reverse_tcp" -o
[*] Options for payload/windows/meterpreter/reverse_tcp

```
Name         Current Setting  Required  Description
----              ---------------         --------      -----------
EXITFUNC  process            yes         Exit technique: seh, thread, process, none
LHOST        10.100.10.201   yes        The listen address
LPORT        6868                yes         The listen port
```
