### PR TITLE
Find installed 3rd party AV, Firewalls, etc

### DIFF
--- a/modules/post/linux/gather/find_apps.rb
+++ b/modules/post/linux/gather/find_apps.rb
@@ -92,8 +92,7 @@ class Metasploit3 < Msf::Post
 		apps.each do |a|
 			output = which("#{a}")
 			if output
-				found = (output + "\n")
-				installed << found
+				installed = puts [output].join("\n")
 			end
 		end
 		save("Installed applications:", installed) unless installed.empty?

--- a/modules/post/linux/gather/find_apps.rb
+++ b/modules/post/linux/gather/find_apps.rb
@@ -90,10 +90,12 @@ class Metasploit3 < Msf::Post
                	"rkhunter", "tcpdump", "webmin", "jailkit", "pwgen", "proxychains", "bastille",
 		 "psad", "wireshark", "nagios", "nagios", "apparmor"]
 
-		for items in apps
-			output = which(items)
-			installed += [output] unless [output] == nil
-
+		apps.each do |a|
+			output = which("#{a}")
+			if output
+				found = (output + "\n")
+				installed << found
+			end
 		end
 		save("Installed applications:", installed) unless installed == nil
 	end

--- a/modules/post/linux/gather/find_apps.rb
+++ b/modules/post/linux/gather/find_apps.rb
@@ -21,16 +21,14 @@ class Metasploit3 < Msf::Post
 	def initialize(info={})
 		super( update_info( info,
 				'Name'          => 'Linux Find Installed AV, Firewalls, Etc',
-				'Description'   => %q{
-					This module tries to find certain installed applications.
-					We are looking for anti-virus, rootkit detection, IDS/IPS,
-					firewalls and other protection mechanisms.
-				},
+				'Description'   => %q{ This module tries to find certain installed applications.
+						       We are looking for anti-virus, rootkit detection, IDS/IPS,
+					               firewalls and other protection mechanisms.
+						     },
 				'License'       => MSF_LICENSE,
-				'Author'        =>
-					[
+				'Author'        => [
 						'ohdae <bindshell[at]live.com>',
-					],
+					           ],
 				'Version'       => '$Revision$',
 				'Platform'      => [ 'linux' ],
 				'SessionTypes'  => [ 'shell' ]
@@ -49,12 +47,6 @@ class Metasploit3 < Msf::Post
 		vprint_status("Finding installed applications...")
 		find_apps		
 	
-	end
-
-	def save(msg, data, ctype="text/plain")
-		ltype = "linux.find.apps"
-		loot = store_loot(ltype, ctype, session, data, nil, msg)
-		print_status("#{msg} stored in #{loot.to_s}")
 	end
 
 	def get_host
@@ -88,13 +80,17 @@ class Metasploit3 < Msf::Post
                	"chkrootkit", "clamav", "snort", "tiger", "firestarter", "avast", "lynis",
                	"rkhunter", "tcpdump", "webmin", "jailkit", "pwgen", "proxychains", "bastille",
 		 "psad", "wireshark", "nagios", "nagios", "apparmor"]
-
+		
 		apps.each do |a|
 			output = which("#{a}")
-			if output
-				installed = puts [output].join("\n")
+ 			if output
+				installed << ("#{a} found: " + output + "\n")
 			end
 		end
-		save("Installed applications:", installed) unless installed.empty?
+		report_note(:host_name => get_host,
+	                :type => "installed_av",
+			:data => installed
+		)
+		print_status("Installed applications saved to notes.")
 	end
 end

--- a/modules/post/linux/gather/find_apps.rb
+++ b/modules/post/linux/gather/find_apps.rb
@@ -1,0 +1,101 @@
+##
+# ## This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/common'
+require 'msf/core/post/file'
+require 'msf/core/post/linux/system'
+require 'msf/core/post/linux/priv'
+
+class Metasploit3 < Msf::Post
+
+	include Msf::Post::Common
+	include Msf::Post::File
+	include Msf::Post::Linux::System
+
+
+	def initialize(info={})
+		super( update_info( info,
+				'Name'          => 'Linux Find Installed AV, Firewalls, Etc',
+				'Description'   => %q{
+					This module tries to find certain installed applications.
+					We are looking for anti-virus, rootkit detection, IDS/IPS,
+					firewalls and other protection mechanisms.
+				},
+				'License'       => MSF_LICENSE,
+				'Author'        =>
+					[
+						'ohdae <bindshell[at]live.com>',
+					],
+				'Version'       => '$Revision$',
+				'Platform'      => [ 'linux' ],
+				'SessionTypes'  => [ 'shell' ]
+			))
+
+	end
+
+	def run
+		distro = get_sysinfo
+
+		print_good("Info:")
+		print_good("\t#{distro[:version]}")
+		print_good("\t#{distro[:kernel]}")
+		
+		#vprint_status("Finding installed applications...")
+		#ruby = which('ruby')
+		#save("Location", ruby)
+		find_apps		
+	
+	end
+
+	def save(msg, data, ctype="text/plain")
+		ltype = "linux.find.apps"
+		loot = store_loot(ltype, ctype, session, data, nil, msg)
+		print_status("#{msg} stored in #{loot.to_s}")
+	end
+
+	def get_host
+		case session.type
+		when /meterpreter/
+			host = sysinfo["Computer"]
+		when /shell/
+			host = session.shell_command_token("hostname").chomp
+		end
+
+		print_status("Running module against #{host}")
+
+		return host
+	end
+
+	def which(cmd)
+  		exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
+ 		ENV['PATH'].split(::File::PATH_SEPARATOR).each do |path|
+    			exts.each { |ext|
+      				exe = "#{path}/#{cmd}#{ext}"
+      				return exe if ::File.executable? exe
+    			}
+		end
+  		return nil
+
+	end
+
+	def find_apps
+		installed = []
+		apps = ["truecrypt", "bulldog", "ufw", "iptables", "logrotate", "logwatch", 
+               	"chkrootkit", "clamav", "snort", "tiger", "firestarter", "avast", "lynis",
+               	"rkhunter", "tcpdump", "webmin", "jailkit", "pwgen", "proxychains", "bastille",
+		 "psad", "wireshark", "nagios", "nagios", "apparmor"]
+
+		for items in apps
+			output = which(items)
+			installed += [output] unless [output] == nil
+
+		end
+		save("Installed applications:", installed) unless installed == nil
+	end
+end

--- a/modules/post/linux/gather/find_apps.rb
+++ b/modules/post/linux/gather/find_apps.rb
@@ -96,6 +96,6 @@ class Metasploit3 < Msf::Post
 				installed << found
 			end
 		end
-		save("Installed applications:", installed) unless installed == nil
+		save("Installed applications:", installed) unless installed.empty?
 	end
 end

--- a/modules/post/linux/gather/find_apps.rb
+++ b/modules/post/linux/gather/find_apps.rb
@@ -41,13 +41,12 @@ class Metasploit3 < Msf::Post
 	def run
 		distro = get_sysinfo
 
+		get_host
 		print_good("Info:")
 		print_good("\t#{distro[:version]}")
 		print_good("\t#{distro[:kernel]}")
 		
-		#vprint_status("Finding installed applications...")
-		#ruby = which('ruby')
-		#save("Location", ruby)
+		vprint_status("Finding installed applications...")
 		find_apps		
 	
 	end

--- a/modules/post/linux/gather/find_apps.rb
+++ b/modules/post/linux/gather/find_apps.rb
@@ -10,7 +10,6 @@ require 'rex'
 require 'msf/core/post/common'
 require 'msf/core/post/file'
 require 'msf/core/post/linux/system'
-require 'msf/core/post/linux/priv'
 
 class Metasploit3 < Msf::Post
 


### PR DESCRIPTION
Uses a Ruby equivalent of the Linux 'which' command to find installed applications
Focuses on Firewalls, AV, IDS and misc security admin tools
Looks in PATH for:  TrueCrypt, Bulldog, UFW, IPTables, LogRotate, LogWatch, 
                Chkrootkit, ClamAV, Snort, Tiger, Firestarter, Avast AV, Lynis,
                RKHunter, TCPDump, Webmin, JailKit, pwgen, Proxychains, Bastille,
         psad, Wireshark, Nagios, AppArmor

Can add any other applications to the list that would be installed in the system path. Meant to find applications that weren't installed via package manager, whether they were downloaded, installed via CD/DVD, etc.

_Known Issue_ When saving the data, all of the found file locations are added to an array that is saved as the loot file. The problem is, they are all added as one big string. There should be a newline after each array item that's saved to the final output array. Any thoughts?
I tried a few different ways to do this but kept coming up with the error "Cannot add nil to an array". Which makes sense, but I just don't know how to solve this. Any help would be appreciated.
