### PR TITLE
added macho support to msfvenom and fixed overly aggressive regex

### DIFF
--- a/msfvenom
+++ b/msfvenom
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 #
-# $Id: msfvenom 14815 2012-02-27 02:12:04Z rapid7 $
-# $Revision: 14815 $
+# $Id: msfvenom 14909 2012-03-10 06:50:03Z rapid7 $
+# $Revision: 14909 $
 #
 msfbase = __FILE__
 while File.symlink?(msfbase)
@@ -107,6 +107,7 @@ def parse_args
 
 	begin
 		opt.parse!
+		
 	rescue OptionParser::InvalidOption, OptionParser::MissingArgument
 		puts "Invalid option, try -h for usage"
 		exit(1)
@@ -297,10 +298,10 @@ else
 	opts[:arch] ||= "x86"
 	opts[:platform] ||= Msf::Module::PlatformList.transform("Windows")
 end
+
 opts[:format]   ||= 'ruby'
 opts[:encoder]  ||= nil
 opts[:encode]   ||= !(opts[:badchars].nil? or opts[:badchars].empty?)
-
 
 if opts[:encoder].nil?
 	fmt = 'raw'
@@ -392,12 +393,13 @@ if opts[:nopsled]
 end
 
 $stdout.binmode
+
 if opts[:format] !~/ruby|rb|perl|pl|bash|sh|c|js|dll|elf/i
 	exe = Msf::Util::EXE.to_executable_fmt($framework, opts[:arch], opts[:platform], payload_raw, opts[:format], exeopts)
 end
 
 case opts[:format]
-when /ruby|rb|perl|pl|bash|sh|c|js_le|raw/i
+when /ruby|rb|perl|pl|bash|sh|^c$|js_le|raw/i
 	$stdout.write Msf::Simple::Buffer.transform(payload_raw, opts[:format])
 when /asp$/
 	asp = Msf::Util::EXE.to_win32pe_asp($framework, payload_raw, exeopts)
@@ -433,6 +435,20 @@ when /elf/i
 		exit
 	end
 	$stdout.write elf
+when /macho/i
+	if opts[:arch] =~ /x64/
+		bin = Msf::Util::EXE.to_osx_x64_macho($framework, payload_raw, exeopts)
+	elsif opts[:arch] =~ /x86/
+		bin = Msf::Util::EXE.to_osx_x86_macho($framework, payload_raw, exeopts)
+	elsif opts[:arch] =~ /arm/
+		bin = Msf::Util::EXE.to_osx_arm_macho($framework, payload_raw, exeopts)
+	elsif opts[:arch] =~ /ppc/
+		bin = Msf::Util::EXE.to_osx_ppc_macho($framework, payload_raw, exeopts)
+	else
+		print_error("This format does not support that architecture")
+		exit
+	end
+	$stdout.write bin
 when /dll/i
 	if opts[:arch] == "x86"
 		dll = Msf::Util::EXE.to_win32pe_dll($framework, payload_raw)


### PR DESCRIPTION
fixes http://dev.metasploit.com/redmine/issues/6535

adds macho support to msfvenom
While doing so, also found a subtle'ish regex problem at line 400 where:
when /ruby|rb|perl|pl|bash|sh|c|js_le|raw/i
matches macho, due to the |c|
changed that to |^c$| with this patch
