### PR TITLE
ps support for linux meterpreter

### DIFF
--- a/external/source/meterpreter/source/extensions/stdapi/server/sys/process/process.c
+++ b/external/source/meterpreter/source/extensions/stdapi/server/sys/process/process.c
@@ -1,7 +1,7 @@
 #include "precomp.h"
+#include "ps.h" // include the code for listing proceses
 
 #ifdef _WIN32 
-#include "ps.h" // include the code for listing proceses
 #include "./../session.h"
 #include "in-mem-exe.h" /* include skapetastic in-mem exe exec */
 
@@ -849,8 +849,10 @@ DWORD request_sys_process_get_processes( Remote * remote, Packet * packet )
 #else
 	DWORD result = ERROR_NOT_SUPPORTED;
 	Packet * response = packet_create_response( packet );
-
-	packet_transmit_response( result, remote, response );
+	if (response) {
+		result = ps_list_linux( response );
+		packet_transmit_response( result, remote, response );
+	}
 #endif
 	
 	return result;

--- a/external/source/meterpreter/source/extensions/stdapi/server/sys/process/ps.h
+++ b/external/source/meterpreter/source/extensions/stdapi/server/sys/process/ps.h
@@ -2,6 +2,9 @@
 #ifndef _METERPRETER_SOURCE_EXTENSION_STDAPI_STDAPI_SERVER_PROCESS_PS_H
 #define _METERPRETER_SOURCE_EXTENSION_STDAPI_STDAPI_SERVER_PROCESS_PS_H
 //===============================================================================================//
+
+VOID ps_addresult( Packet * response, DWORD dwPid, DWORD dwParentPid, char * cpExeName, char * cpExePath, char * cpUserName, DWORD dwProcessArch );
+
 #ifdef _WIN32
 
 
@@ -77,7 +80,11 @@ DWORD ps_list_via_psapi( Packet * response );
 
 DWORD ps_list_via_brute( Packet * response );
 
+
+
 //===============================================================================================//
+#else // linux
+DWORD ps_list_linux( Packet * response );
 #endif // _WIN32
 #endif
 //===============================================================================================//

--- a/external/source/meterpreter/workspace/ext_server_stdapi/Makefile
+++ b/external/source/meterpreter/workspace/ext_server_stdapi/Makefile
@@ -39,6 +39,7 @@ objects = \
 	server/sys/config/config.o \
 	server/sys/process/linux-in-mem-exe.o \
 	server/sys/process/process.o \
+	server/sys/process/ps.o \
 
 all: ext_server_stdapi.so
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -229,31 +229,50 @@ class Console::CommandDispatcher::Stdapi::Sys
 	#
 	def cmd_ps(*args)
 		processes = client.sys.process.get_processes
-		tbl = Rex::Ui::Text::Table.new(
-			'Header'  => "Process list",
-			'Indent'  => 1,
-			'Columns' =>
-				[
-					"PID",
-					"Name",
-					"Arch",
-					"Session",
-					"User",
-					"Path"
-				])
+		if (client.platform =~ /win/i) 
+			tbl = Rex::Ui::Text::Table.new(
+				'Header'  => "Process list",
+				'Indent'  => 1,
+				'Columns' =>
+					[
+						"PID",
+						"Name",
+						"Arch",
+						"Session",
+						"User",
+						"Path"
+					])
 
-		processes.each { |ent|
+			processes.each { |ent|
 
-			session = ent['session'] == 0xFFFFFFFF ? '' : ent['session'].to_s
-			arch    = ent['arch']
+				session = ent['session'] == 0xFFFFFFFF ? '' : ent['session'].to_s
+				arch    = ent['arch']
 
-			# for display and consistency with payload naming we switch the internal 'x86_64' value to display 'x64'
-			if( arch == ARCH_X86_64 )
-				arch = "x64"
-			end
+				# for display and consistency with payload naming we switch the internal 'x86_64' value to display 'x64'
+				if( arch == ARCH_X86_64 )
+					arch = "x64"
+				end
 
-			tbl << [ ent['pid'].to_s, ent['name'], arch, session, ent['user'], ent['path'] ]
-		}
+				tbl << [ ent['pid'].to_s, ent['name'], arch, session, ent['user'], ent['path'] ]
+			}
+		else # linux meterpreter
+			tbl = Rex::Ui::Text::Table.new(
+				'Header'  => "Process list",
+				'Indent'  => 1,
+				'Columns' =>
+					[
+						"PID",
+						"PPID",
+						"Name",
+						"User ID",
+						"Path"
+					])
+			processes.each { |ent|
+				# can have some unicode characters when receiving name, path.. so need to unicode_filter_decode them
+				# otherelse, print "$U$/usr/lib/xfce4cpugraphplugin/.." instead of "/usr/lib/xfce4-cpugraph-plugin/.."
+				tbl << [ ent['pid'].to_s, ent['parentid'].to_s, client.unicode_filter_decode(ent['name']), client.unicode_filter_decode(ent['user']), client.unicode_filter_decode(ent['path']) ]
+			}
+		end
 
 		if (processes.length == 0)
 			print_line("No running processes were found.")


### PR DESCRIPTION
sample :

meterpreter > ps
# Process list

 PID    PPID   Name             User ID      Path

---

 1      0      init             root         init [2]  
 2      0      [kthreadd]       root  
 3      2      [ksoftirqd/0]    root  
 6      2      [migration/0]    root  
...
 23165  23154  pager            mm      pager -s 
 23681  30938  bash             mm      bash 
 23942  1      chrome           mm      /opt/google/chrome/chrome  
 23947  23942  chrome           mm      /opt/google/chrome/chrome  
 30797  2671   bash             mm      -bash  
 31007  2      [ksoftirqd/2]    root  
 31008  2      [watchdog/2]     root  
 31009  2      [migration/3]    root  
 31011  2      [ksoftirqd/3]    root  
 31012  2      [watchdog/3]     root  
 31077  395    udevd            root    udevd --daemon 
 31088  395    udevd            root    udevd --daemon 
 31295  30938  bash             mm      bash 
