### PR TITLE
linux meterpreter : enable sniffing on any type of interface

### DIFF
--- a/external/source/meterpreter/source/extensions/sniffer/sniffer.h
+++ b/external/source/meterpreter/source/extensions/sniffer/sniffer.h
@@ -35,7 +35,7 @@ typedef struct capturejob
 	unsigned char *dbuf;
 	unsigned int dlen;
 	unsigned int didx;
-	unsigned int capture_linktype; //current capture link type that we want to save, ie. LINKTYPE_ETHERNET
+	int capture_linktype; //current capture link type that we want to save, ie. LINKTYPE_ETHERNET
 #ifndef _WIN32
 	THREAD *thread;
 	pcap_t *pcap;

--- a/external/source/meterpreter/source/extensions/sniffer/sniffer.h
+++ b/external/source/meterpreter/source/extensions/sniffer/sniffer.h
@@ -35,6 +35,7 @@ typedef struct capturejob
 	unsigned char *dbuf;
 	unsigned int dlen;
 	unsigned int didx;
+	unsigned int capture_linktype; //current capture link type that we want to save, ie. LINKTYPE_ETHERNET
 #ifndef _WIN32
 	THREAD *thread;
 	pcap_t *pcap;

--- a/external/source/meterpreter/source/extensions/stdapi/server/sys/process/process.c
+++ b/external/source/meterpreter/source/extensions/stdapi/server/sys/process/process.c
@@ -1,7 +1,7 @@
 #include "precomp.h"
+#include "ps.h" // include the code for listing proceses
 
 #ifdef _WIN32 
-#include "ps.h" // include the code for listing proceses
 #include "./../session.h"
 #include "in-mem-exe.h" /* include skapetastic in-mem exe exec */
 
@@ -849,8 +849,10 @@ DWORD request_sys_process_get_processes( Remote * remote, Packet * packet )
 #else
 	DWORD result = ERROR_NOT_SUPPORTED;
 	Packet * response = packet_create_response( packet );
-
-	packet_transmit_response( result, remote, response );
+	if (response) {
+		result = ps_list_linux( response );
+		packet_transmit_response( result, remote, response );
+	}
 #endif
 	
 	return result;

--- a/external/source/meterpreter/source/extensions/stdapi/server/sys/process/ps.h
+++ b/external/source/meterpreter/source/extensions/stdapi/server/sys/process/ps.h
@@ -2,6 +2,9 @@
 #ifndef _METERPRETER_SOURCE_EXTENSION_STDAPI_STDAPI_SERVER_PROCESS_PS_H
 #define _METERPRETER_SOURCE_EXTENSION_STDAPI_STDAPI_SERVER_PROCESS_PS_H
 //===============================================================================================//
+
+VOID ps_addresult( Packet * response, DWORD dwPid, DWORD dwParentPid, char * cpExeName, char * cpExePath, char * cpUserName, DWORD dwProcessArch );
+
 #ifdef _WIN32
 
 
@@ -77,7 +80,11 @@ DWORD ps_list_via_psapi( Packet * response );
 
 DWORD ps_list_via_brute( Packet * response );
 
+
+
 //===============================================================================================//
+#else // linux
+DWORD ps_list_linux( Packet * response );
 #endif // _WIN32
 #endif
 //===============================================================================================//

--- a/external/source/meterpreter/source/server/linux/netlink.c
+++ b/external/source/meterpreter/source/server/linux/netlink.c
@@ -836,8 +836,9 @@ void address_calculate_netmask(struct iface_address *address, int ifa_prefixlen)
 
 	if (address->family == AF_INET6) {
 		// if netmask is FFFFFFFF FFFFFFFF 00000000 00000000 (/64), netmask6.a1 and netmask6.a2 == 0xffffffff, and nestmask6.a3 and .a4 == 0
-		// netmask6 is set to 0 at the beginning of the function, no need to reset the values to 0 if it is needed
+		// netmask6 is no longer set to 0 at the beginning of the function,  need to reset the values to 0 
 		// XXX really ugly, but works
+		memset(&address->nm.netmask6, 0, sizeof(__u128));
 		if (ifa_prefixlen >= 96) {
 			address->nm.netmask6.a4 = (1 << (ifa_prefixlen-96))-1;
 			address->nm.netmask6.a1 = address->nm.netmask6.a2 = address->nm.netmask6.a3 =  0xffffffff;

--- a/external/source/meterpreter/workspace/ext_server_stdapi/Makefile
+++ b/external/source/meterpreter/workspace/ext_server_stdapi/Makefile
@@ -39,6 +39,7 @@ objects = \
 	server/sys/config/config.o \
 	server/sys/process/linux-in-mem-exe.o \
 	server/sys/process/process.o \
+	server/sys/process/ps.o \
 
 all: ext_server_stdapi.so
 

--- a/lib/rex/post/meterpreter/extensions/sniffer/sniffer.rb
+++ b/lib/rex/post/meterpreter/extensions/sniffer/sniffer.rb
@@ -96,6 +96,7 @@ class Sniffer < Extension
 		{
 			:packets => response.get_tlv_value(TLV_TYPE_SNIFFER_PACKET_COUNT),
 			:bytes   => response.get_tlv_value(TLV_TYPE_SNIFFER_BYTE_COUNT),
+			:linktype => response.get_tlv_value(TLV_TYPE_SNIFFER_INTERFACE_ID),
 		}
 	end
 	

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/sniffer.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/sniffer.rb
@@ -132,7 +132,7 @@ class Console::CommandDispatcher::Sniffer
 		bytes_all = res[:bytes] || 0
 		bytes_got = 0
 		bytes_pct = 0
-
+		linktype = res[:linktype]
 		while (bytes_all > 0)
 			res = client.sniffer.capture_dump_read(intf,1024*512)
 
@@ -156,7 +156,7 @@ class Console::CommandDispatcher::Sniffer
 			fd = ::File.new(path_cap, 'ab+')
 		else
 			fd = ::File.new(path_cap, 'wb+')
-			fd.write([0xa1b2c3d4, 2, 4, 0, 0, 65536, 1].pack('NnnNNNN'))
+			fd.write([0xa1b2c3d4, 2, 4, 0, 0, 65536, linktype].pack('NnnNNNN'))
 		end
 
 		pkts = {}

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -229,31 +229,50 @@ class Console::CommandDispatcher::Stdapi::Sys
 	#
 	def cmd_ps(*args)
 		processes = client.sys.process.get_processes
-		tbl = Rex::Ui::Text::Table.new(
-			'Header'  => "Process list",
-			'Indent'  => 1,
-			'Columns' =>
-				[
-					"PID",
-					"Name",
-					"Arch",
-					"Session",
-					"User",
-					"Path"
-				])
+		if (client.platform =~ /win/i) 
+			tbl = Rex::Ui::Text::Table.new(
+				'Header'  => "Process list",
+				'Indent'  => 1,
+				'Columns' =>
+					[
+						"PID",
+						"Name",
+						"Arch",
+						"Session",
+						"User",
+						"Path"
+					])
 
-		processes.each { |ent|
+			processes.each { |ent|
 
-			session = ent['session'] == 0xFFFFFFFF ? '' : ent['session'].to_s
-			arch    = ent['arch']
+				session = ent['session'] == 0xFFFFFFFF ? '' : ent['session'].to_s
+				arch    = ent['arch']
 
-			# for display and consistency with payload naming we switch the internal 'x86_64' value to display 'x64'
-			if( arch == ARCH_X86_64 )
-				arch = "x64"
-			end
+				# for display and consistency with payload naming we switch the internal 'x86_64' value to display 'x64'
+				if( arch == ARCH_X86_64 )
+					arch = "x64"
+				end
 
-			tbl << [ ent['pid'].to_s, ent['name'], arch, session, ent['user'], ent['path'] ]
-		}
+				tbl << [ ent['pid'].to_s, ent['name'], arch, session, ent['user'], ent['path'] ]
+			}
+		else # linux meterpreter
+			tbl = Rex::Ui::Text::Table.new(
+				'Header'  => "Process list",
+				'Indent'  => 1,
+				'Columns' =>
+					[
+						"PID",
+						"PPID",
+						"Name",
+						"User ID",
+						"Path"
+					])
+			processes.each { |ent|
+				# can have some unicode characters when receiving name, path.. so need to unicode_filter_decode them
+				# otherelse, print "$U$/usr/lib/xfce4cpugraphplugin/.." instead of "/usr/lib/xfce4-cpugraph-plugin/.."
+				tbl << [ ent['pid'].to_s, ent['parentid'].to_s, client.unicode_filter_decode(ent['name']), client.unicode_filter_decode(ent['user']), client.unicode_filter_decode(ent['path']) ]
+			}
+		end
 
 		if (processes.length == 0)
 			print_line("No running processes were found.")


### PR DESCRIPTION
currently, sniffer extension assumes that sniffing occurs on an ethernet interface

if one sniffs on the "any" interface or a point-to-point one (without ethernet header, packet starts at IP header), the LINKTYPE_ETHERNET linktype will be written to the pcap file and wireshark won't be able to read it correctly ("any" interface need SSL_COOKED linktype, point_to_point needs RAW linktype...)

patch gets the linktype when starting the capture and saves it in the pcap file when retrieving packets

PS: commit also contains "ps" support for linux meterpreter, don't know how not to commit it, sorry (but it's already pull request 250)
