### PR TITLE
Convert Exploit-DB references to first-tier "EDB-12345" references

### DIFF
--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -720,6 +720,8 @@ class Module
 							match = [t,w] if refs.any? { |ref| ref =~ /^bid\-/i and ref =~ r }
 						when 'osvdb'
 							match = [t,w] if refs.any? { |ref| ref =~ /^osvdb\-/i and ref =~ r }
+						when 'edb'
+							match = [t,w] if refs.any? { |ref| ref =~ /^edb\-/i and ref =~ r }
 					end
 					break if match
 				end

--- a/lib/msf/core/module/reference.rb
+++ b/lib/msf/core/module/reference.rb
@@ -101,6 +101,8 @@ class Msf::Module::SiteReference < Msf::Module::Reference
 			self.site = 'http://www.microsoft.com/technet/security/bulletin/' + in_ctx_val.to_s + '.mspx'
 		elsif (in_ctx_id == 'MIL')
 			self.site = 'http://milw0rm.com/metasploit/' + in_ctx_val.to_s
+		elsif (in_ctx_id == 'EDB')
+			self.site = 'http://www.exploit-db.com/' + in_ctx_val.to_s
 		elsif (in_ctx_id == 'WVE')
 			self.site = 'http://www.wirelessve.org/entries/show/WVE-' + in_ctx_val.to_s
 		elsif (in_ctx_id == 'US-CERT-VU')

--- a/lib/msf/core/module/reference.rb
+++ b/lib/msf/core/module/reference.rb
@@ -102,7 +102,7 @@ class Msf::Module::SiteReference < Msf::Module::Reference
 		elsif (in_ctx_id == 'MIL')
 			self.site = 'http://milw0rm.com/metasploit/' + in_ctx_val.to_s
 		elsif (in_ctx_id == 'EDB')
-			self.site = 'http://www.exploit-db.com/' + in_ctx_val.to_s
+			self.site = 'http://www.exploit-db.com/exploits/' + in_ctx_val.to_s
 		elsif (in_ctx_id == 'WVE')
 			self.site = 'http://www.wirelessve.org/entries/show/WVE-' + in_ctx_val.to_s
 		elsif (in_ctx_id == 'US-CERT-VU')

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1304,6 +1304,7 @@ class Core
 			"cve"      => "Modules with a matching CVE ID",
 			"bid"      => "Modules with a matching Bugtraq ID",
 			"osvdb"    => "Modules with a matching OSVDB ID"
+			"edb"      => "Modules with a matching Exploit-DB ID"
 		}.each_pair do |keyword, description|
 			print_line "  #{keyword.ljust 10}:  #{description}"
 		end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1303,7 +1303,7 @@ class Core
 			"author"   => "Modules written by this author",
 			"cve"      => "Modules with a matching CVE ID",
 			"bid"      => "Modules with a matching Bugtraq ID",
-			"osvdb"    => "Modules with a matching OSVDB ID"
+			"osvdb"    => "Modules with a matching OSVDB ID",
 			"edb"      => "Modules with a matching Exploit-DB ID"
 		}.each_pair do |keyword, description|
 			print_line "  #{keyword.ljust 10}:  #{description}"

--- a/modules/auxiliary/admin/http/trendmicro_dlp_traversal.rb
+++ b/modules/auxiliary/admin/http/trendmicro_dlp_traversal.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Auxiliary
 					[ 'OSVDB', '73447' ],
 					[ 'CVE', '2008-2938' ],
 					[ 'URL', 'http://www.securityfocus.com/archive/1/499926' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/17388' ],
+					[ 'EDB', 17388 ],
 					[ 'BID', '48225' ],
 				],
 			'Author'      => [ 'patrick' ],

--- a/modules/auxiliary/admin/http/typo3_sa_2009_002.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2009_002.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Auxiliary
 					['OSVDB', '52048'],
 					['CVE', '2009-0815'],
 					['URL', 'http://secunia.com/advisories/33829/'],
-					['URL', 'http://www.exploit-db.com/exploits/8038/'],
+					['EDB', 8038],
 					['URL', 'http://typo3.org/teams/security/security-bulletins/typo3-sa-2009-002/'],
 				],
 			'DisclosureDate' => 'Feb 10 2009',

--- a/modules/auxiliary/admin/zend/java_bridge.rb
+++ b/modules/auxiliary/admin/zend/java_bridge.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					[ 'OSVDB', '71420'],
 					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-11-113/' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/17078/' ],
+					[ 'EDB', 17078 ],
 				],
 			'DisclosureDate' => 'Mar 28 2011'))
 

--- a/modules/auxiliary/dos/dhcp/isc_dhcpd_clientid.rb
+++ b/modules/auxiliary/dos/dhcp/isc_dhcpd_clientid.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					[ 'CVE', '2010-2156' ],
 					[ 'OSVDB', '65246'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/14185/']
+					[ 'EDB', 14185]
 				]
 		)
 		register_options(

--- a/modules/auxiliary/dos/hp/data_protector_rds.rb
+++ b/modules/auxiliary/dos/hp/data_protector_rds.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					[ 'CVE', '2011-0514' ],
 					[ 'OSVDB', '70617' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/15940/' ],
+					[ 'EDB', 15940 ],
 				],
 			'DisclosureDate' => 'Jan 8 2011' ))
 

--- a/modules/auxiliary/dos/http/apache_mod_isapi.rb
+++ b/modules/auxiliary/dos/http/apache_mod_isapi.rb
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Auxiliary
 					[ 'URL', 'https://issues.apache.org/bugzilla/show_bug.cgi?id=48509' ],
 					[ 'URL', 'http://www.gossamer-threads.com/lists/apache/cvs/381537' ],
 					[ 'URL', 'http://www.senseofsecurity.com.au/advisories/SOS-10-002' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/11650' ]
+					[ 'EDB', 11650 ]
 				],
 			'DisclosureDate' => 'Mar 05 2010'))
 

--- a/modules/auxiliary/dos/http/apache_range_dos.rb
+++ b/modules/auxiliary/dos/http/apache_range_dos.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					[ 'BID', '49303'],
 					[ 'CVE', '2011-3192'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/17696/'],
+					[ 'EDB', 17696],
 					[ 'OSVDB', '74721' ],
 				],
 			'DisclosureDate' => 'Aug 19 2011'))

--- a/modules/auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof.rb
+++ b/modules/auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Auxiliary
 					[ 'OSVDB', '70167' ],
 					[ 'BID', '45542' ],
 					[ 'MSB', 'MS11-004' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/15803/' ],
+					[ 'EDB', 15803 ],
 					[ 'URL', 'http://blogs.technet.com/b/srd/archive/2010/12/22/assessing-an-iis-ftp-7-5-unauthenticated-denial-of-service-vulnerability.aspx' ]
 				],
 			'Platform'       => [ 'win' ],

--- a/modules/auxiliary/dos/windows/ftp/solarftp_user.rb
+++ b/modules/auxiliary/dos/windows/ftp/solarftp_user.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Auxiliary
 			'Version'        => '$Revision$',
 			'References'     =>
 			[
-				[ 'URL', 'http://www.exploit-db.com/exploits/16204/' ],
+				[ 'EDB', 16204 ],
 			],
 			'DisclosureDate' => 'Feb 22 2011'))
 

--- a/modules/auxiliary/dos/windows/http/ms10_065_ii6_asp_dos.rb
+++ b/modules/auxiliary/dos/windows/http/ms10_065_ii6_asp_dos.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Auxiliary
 					[ 'CVE', '2010-1899' ],
 					[ 'OSVDB', '67978'],
 					[ 'MSB', 'MS10-065'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/15167/' ]
+					[ 'EDB', 15167 ]
 				],
 			'DisclosureDate' => 'Sep 14 2010'))
 

--- a/modules/auxiliary/dos/windows/rdp/ms12_020_maxchannelids.rb
+++ b/modules/auxiliary/dos/windows/rdp/ms12_020_maxchannelids.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Auxiliary
 					[ 'URL', 'http://pastie.org/private/4egcqt9nucxnsiksudy5dw' ],
 					[ 'URL', 'http://pastie.org/private/feg8du0e9kfagng4rrg' ],
 					[ 'URL', 'http://stratsec.blogspot.com.au/2012/03/ms12-020-vulnerability-for-breakfast.html' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/18606/' ]
+					[ 'EDB', 18606 ]
 				],
 			'Author'         =>
 				[

--- a/modules/auxiliary/dos/windows/smb/ms11_019_electbowser.rb
+++ b/modules/auxiliary/dos/windows/smb/ms11_019_electbowser.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Auxiliary
 					[ 'BID', '46360' ],
 					[ 'OSVDB', '70881' ],
 					[ 'MSB', 'MS11-019' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/16166/' ],
+					[ 'EDB', 16166 ],
 					[ 'URL', 'http://seclists.org/fulldisclosure/2011/Feb/285' ]
 				],
 			'Author'         => [ 'Cupidon-3005', 'jduck' ],

--- a/modules/auxiliary/dos/windows/tftp/solarwinds.rb
+++ b/modules/auxiliary/dos/windows/tftp/solarwinds.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					[ 'CVE', '2010-2115' ],
 					[ 'OSVDB', '64845' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/12683' ]
+					[ 'EDB', 12683 ]
 				],
 			'DisclosureDate' => 'May 21 2010'))
 

--- a/modules/auxiliary/scanner/http/axis_local_file_include.rb
+++ b/modules/auxiliary/scanner/http/axis_local_file_include.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'References'     =>
 				[
-					['URL', 'http://www.exploit-db.com/exploits/12721/'],
+					['EDB', 12721],
 					['OSVDB', '59001'],
 				],
 			'Author'         =>

--- a/modules/auxiliary/scanner/http/barracuda_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/barracuda_directory_traversal.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					['OSVDB', '68301'],
 					['URL', 'http://secunia.com/advisories/41609/'],
-					['URL', 'http://www.exploit-db.com/exploits/15130/']
+					['EDB', 15130]
 				],
 			'Author'         =>
 				[

--- a/modules/auxiliary/scanner/http/litespeed_source_disclosure.rb
+++ b/modules/auxiliary/scanner/http/litespeed_source_disclosure.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Auxiliary
 					[ 'CVE', '2010-2333' ],
 					[ 'OSVDB', '65476' ],
 					[ 'BID', '40815' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/13850/' ]
+					[ 'EDB', 13850 ]
 				],
 			'Author'         =>
 				[

--- a/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Auxiliary
 					['CVE', '2011-0063'],
 					['URL', 'https://sitewat.ch/en/Advisory/View/1'],
 					['URL', 'http://sotiriu.de/adv/NSOADV-2011-003.txt'],
-					['URL', 'http://www.exploit-db.com/exploits/16103/']
+					['EDB', 16103]
 				],
 			'DisclosureDate' => 'Mar 08 2011',
 			'License'        =>  MSF_LICENSE

--- a/modules/auxiliary/scanner/http/nginx_source_disclosure.rb
+++ b/modules/auxiliary/scanner/http/nginx_source_disclosure.rb
@@ -31,8 +31,8 @@ class Metasploit3 < Msf::Auxiliary
 					[ 'CVE', '2010-2263' ],
 					[ 'OSVDB', '65531' ],
 					[ 'BID', '40760' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/13818/' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/13822/' ]
+					[ 'EDB', 13818 ],
+					[ 'EDB', 13822 ]
 				],
 			'Author'         =>
 				[

--- a/modules/auxiliary/scanner/telnet/telnet_encrypt_overflow.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_encrypt_overflow.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					['BID', '51182'],
 					['CVE', '2011-4862'],
-					['URL', 'http://www.exploit-db.com/exploits/18280/']
+					['EDB', 18280]
 				]
 		)
 		register_options(

--- a/modules/auxiliary/scanner/tftp/ipswitch_whatsupgold_tftp.rb
+++ b/modules/auxiliary/scanner/tftp/ipswitch_whatsupgold_tftp.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					['OSVDB', '77455'],
 					['BID', '50890'],
-					['URL', 'http://www.exploit-db.com/exploits/18189/'],
+					['EDB', 18189],
 					['URL', 'http://secpod.org/advisories/SecPod_Ipswitch_TFTP_Server_Dir_Trav.txt']
 				],
 			'DisclosureDate' => "Dec 12 2011"

--- a/modules/exploits/freebsd/telnet/telnet_encrypt_keyid.rb
+++ b/modules/exploits/freebsd/telnet/telnet_encrypt_keyid.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					['CVE', '2011-4862'],
 					['OSVDB', '78020'],
 					['BID', '51182'],
-					['URL', 'http://www.exploit-db.com/exploits/18280/']
+					['EDB', 18280]
 				],
 			'Privileged'     => true,
 			'Platform'       => 'bsd',

--- a/modules/exploits/linux/misc/lprng_format_string.rb
+++ b/modules/exploits/linux/misc/lprng_format_string.rb
@@ -40,9 +40,9 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'US-CERT-VU', '382365' ],
 					[ 'URL', 'http://www.cert.org/advisories/CA-2000-22.html' ],
 					[ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=17756' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/226' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/227' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/230' ]
+					[ 'EDB', 226 ],
+					[ 'EDB', 227 ],
+					[ 'EDB', 230 ]
 				],
 			'Platform'       => 'linux',
 			'Arch'           => ARCH_X86,

--- a/modules/exploits/linux/misc/netsupport_manager_agent.rb
+++ b/modules/exploits/linux/misc/netsupport_manager_agent.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'OSVDB', '70408' ],
 					[ 'BID', '45728' ],
 					[ 'URL', 'http://seclists.org/fulldisclosure/2011/Jan/90' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/15937/' ]
+					[ 'EDB', 15937 ]
 				],
 			'Privileged'     => true,
 			'Platform'       => 'linux',

--- a/modules/exploits/linux/pop3/cyrus_pop3d_popsubfolders.rb
+++ b/modules/exploits/linux/pop3/cyrus_pop3d_popsubfolders.rb
@@ -42,8 +42,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2006-2502' ],
 					[ 'OSVDB', '25853' ],
 					[ 'BID', '18056' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/2053' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/2185' ],
+					[ 'EDB', 2053 ],
+					[ 'EDB', 2185 ],
 					[ 'URL', 'http://archives.neohapsis.com/archives/fulldisclosure/2006-05/0527.html' ],
 				],
 			'Payload'	=>

--- a/modules/exploits/linux/telnet/telnet_encrypt_keyid.rb
+++ b/modules/exploits/linux/telnet/telnet_encrypt_keyid.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					['CVE', '2011-4862'],
 					['OSVDB', '78020'],
 					['BID', '51182'],
-					['URL', 'http://www.exploit-db.com/exploits/18280/']
+					['EDB', 18280]
 				],
 			'Privileged'     => true,
 			'Platform'       => 'linux',

--- a/modules/exploits/multi/fileformat/peazip_command_injection.rb
+++ b/modules/exploits/multi/fileformat/peazip_command_injection.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2009-2261' ],
 					[ 'OSVDB', '54966' ],
 					[ 'URL', 'http://peazip.sourceforge.net/' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/8881' ]
+					[ 'EDB', 8881 ]
 				],
 			'Platform'       => ['unix', 'win', 'linux'],
 			'Arch'           => ARCH_CMD,

--- a/modules/exploits/multi/http/familycms_less_exec.rb
+++ b/modules/exploits/multi/http/familycms_less_exec.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'URL', 'https://www.familycms.com/blog/2011/11/security-vulnerability-fcms-2-5-2-7-1/' ],
 					[ 'URL', 'http://sourceforge.net/apps/trac/fam-connections/ticket/407' ],
 					[ 'URL', 'http://rwx.biz.nf/advisories/fc_cms_rce_adv.html' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/18198/' ]
+					[ 'EDB', 18198 ]
 				],
 			'Privileged'     => false,
 			'Payload'        =>

--- a/modules/exploits/multi/http/phpldapadmin_query_engine.rb
+++ b/modules/exploits/multi/http/phpldapadmin_query_engine.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					['OSVDB', '76594'],
 					['BID', '50331'],
 					['URL', 'http://sourceforge.net/support/tracker.php?aid=3417184'],
-					['URL', 'http://www.exploit-db.com/exploits/18021/'],
+					['EDB', 18021],
 				],
 			'Privileged'     => false,
 			'Payload'        =>

--- a/modules/exploits/multi/http/phpscheduleit_start_date.rb
+++ b/modules/exploits/multi/http/phpscheduleit_start_date.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					['CVE', '2008-6132'],
 					['OSVDB', '48797'],
 					['BID', '31520'],
-					['URL', 'http://www.exploit-db.com/exploits/6646/'],
+					['EDB', 6646],
 				],
 			'Privileged'     => false,
 			'Platform'       => ['php'],

--- a/modules/exploits/multi/http/plone_popen2.rb
+++ b/modules/exploits/multi/http/plone_popen2.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					['CVE', '2011-3587'],
 					['OSVDB', '76105'],
-					['URL', 'http://www.exploit-db.com/exploits/18262/'],
+					['EDB', 18262],
 					['URL', 'http://plone.org/products/plone/security/advisories/20110928']
 				],
 			'Privileged'     => false,

--- a/modules/exploits/multi/http/pmwiki_pagelist.rb
+++ b/modules/exploits/multi/http/pmwiki_pagelist.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					['CVE', '2011-4453'],
 					['BID', '50776'],
 					['OSVDB', '77261'],
-					['URL', 'http://www.exploit-db.com/exploits/18149/'],
+					['EDB', 18149],
 					['URL', 'http://www.pmwiki.org/wiki/PITS/01271']
 				],
 			'Privileged'     => false,

--- a/modules/exploits/multi/http/struts_code_exec.rb
+++ b/modules/exploits/multi/http/struts_code_exec.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'CVE', '2010-1870'],
 					[ 'OSVDB', '66280'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/14360/' ],
+					[ 'EDB', 14360 ],
 				],
 			'Platform'      => [ 'win', 'linux'],
 			'Privileged'     => true,

--- a/modules/exploits/multi/http/traq_plugin_exec.rb
+++ b/modules/exploits/multi/http/traq_plugin_exec.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '77556'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/18213/' ],
+					[ 'EDB', 18213 ],
 					[ 'URL', 'http://traqproject.org/' ],
 				],
 			'Privileged'     => false,

--- a/modules/exploits/multi/http/vbseo_proc_deutf.rb
+++ b/modules/exploits/multi/http/vbseo_proc_deutf.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					['OSVDB', '78508'],
 					['BID', '51647'],
 					['URL', 'http://www.vbseo.com/f5/vbseo-security-bulletin-all-supported-versions-patch-release-52783/'],
-					['URL', 'http://www.exploit-db.com/exploits/18424/']
+					['EDB', 18424]
 				],
 			'Privileged'     => false,
 			'Payload'        =>

--- a/modules/exploits/multi/misc/zend_java_bridge.rb
+++ b/modules/exploits/multi/misc/zend_java_bridge.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'OSVDB', '71420'],
 					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-11-113/'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/17078/' ],
+					[ 'EDB', 17078 ],
 				],
 			'Platform'       => ['java'], # win
 			'Arch'           => ARCH_JAVA,

--- a/modules/exploits/osx/http/evocam_webserver.rb
+++ b/modules/exploits/osx/http/evocam_webserver.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					['CVE', '2010-2309'],
 					['OSVDB', '65043'],
-					['URL', 'http://www.exploit-db.com/exploits/12835'],
+					['EDB', 12835],
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/osx/misc/ufo_ai.rb
+++ b/modules/exploits/osx/misc/ufo_ai.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References' =>
 				[
 					[ 'OSVDB', '65689' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/14013' ]
+					[ 'EDB', 14013 ]
 				],
 			'Payload' =>
 				{

--- a/modules/exploits/unix/webapp/awstats_migrate_exec.rb
+++ b/modules/exploits/unix/webapp/awstats_migrate_exec.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					['OSVDB', '25284'],
 					['BID', '17844'],
 					['URL', 'http://awstats.sourceforge.net/awstats_security_news.php'],
-					['URL', 'http://www.exploit-db.com/exploits/1755/'],
+					['EDB', 1755],
 				],
 			'Privileged'     => false,
 			'Payload'        =>

--- a/modules/exploits/unix/webapp/coppermine_piceditor.rb
+++ b/modules/exploits/unix/webapp/coppermine_piceditor.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'CVE', '2008-0506' ],
 					[ 'OSVDB', '41676' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/5019' ],
+					[ 'EDB', 5019 ],
 					[ 'URL', 'http://forum.coppermine-gallery.net/index.php?topic=50103.0' ]
 				],
 			'Privileged'     => true, # web server context

--- a/modules/exploits/unix/webapp/joomla_tinybrowser.rb
+++ b/modules/exploits/unix/webapp/joomla_tinybrowser.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					['OSVDB', '64578'],
-					['URL', 'http://www.exploit-db.com/exploits/9296/'],
+					['EDB', 9296],
 					['URL', 'http://developer.joomla.org/security/news/301-20090722-core-file-upload.html'],
 				],
 			'Privileged'     => false,

--- a/modules/exploits/unix/webapp/sphpblog_file_upload.rb
+++ b/modules/exploits/unix/webapp/sphpblog_file_upload.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					['CVE', '2005-2733'],
 					['OSVDB', '19012'],
 					['BID', '14667'],
-					['URL', 'http://www.exploit-db.com/exploits/1191/'],
+					['EDB', 1191],
 				],
 			'Privileged'     => false,
 			'Payload'        =>

--- a/modules/exploits/unix/webapp/trixbox_langchoice.rb
+++ b/modules/exploits/unix/webapp/trixbox_langchoice.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					['OSVDB'   => '50421'],
 					['CVE'     => '2008-6825'],
 					['BID'     => '30135'],
-					['URL'     => 'http://www.exploit-db.com/exploits/6026/'],
+					['EDB'     => '6026' ],
 					['URL'     => 'http://www.trixbox.org/']
 				],
 			'Payload'     =>

--- a/modules/exploits/windows/browser/baofeng_storm_onbeforevideodownload.rb
+++ b/modules/exploits/windows/browser/baofeng_storm_onbeforevideodownload.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2009-1612' ],
 					[ 'OSVDB', '54169' ],
 					[ 'BID', '34789' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/8579' ]
+					[ 'EDB', 8579 ]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/browser/blackice_downloadimagefileurl.rb
+++ b/modules/exploits/windows/browser/blackice_downloadimagefileurl.rb
@@ -51,7 +51,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2008-2683'],
 					[ 'OSVDB', '46007'],
 					[ 'BID', '29577'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/5750/' ],
+					[ 'EDB', 5750 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/browser/chilkat_crypt_writefile.rb
+++ b/modules/exploits/windows/browser/chilkat_crypt_writefile.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2008-5002' ],
 					[ 'OSVDB', '49510' ],
 					[ 'BID', '32073' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/6963' ]
+					[ 'EDB', 6963 ]
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/browser/communicrypt_mail_activex.rb
+++ b/modules/exploits/windows/browser/communicrypt_mail_activex.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '64839' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/12663' ],
+					[ 'EDB', 12663 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/browser/dxstudio_player_exec.rb
+++ b/modules/exploits/windows/browser/dxstudio_player_exec.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2009-2011' ],
 					[ 'BID', '35273' ],
 					[ 'OSVDB', '54969' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/8922' ],
+					[ 'EDB', 8922 ],
 					[ 'URL', 'http://dxstudio.com/guide.aspx' ]
 				],
 			'Payload'        =>

--- a/modules/exploits/windows/browser/greendam_url.rb
+++ b/modules/exploits/windows/browser/greendam_url.rb
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					['OSVDB', '55126'],
 					['URL', 'http://www.cse.umich.edu/~jhalderm/pub/gd/'],		# Analysis of the Green Dam Censorware System
-					['URL', 'http://www.exploit-db.com/exploits/8938/'],		# Original exploit by seer[N.N.U]
+					['EDB', 8938],		# Original exploit by seer[N.N.U]
 					['URL', 'http://taossa.com/archive/bh08sotirovdowd.pdf'],	# .NET DLL memory technique
 				],
 			'DefaultOptions' =>

--- a/modules/exploits/windows/browser/hyleos_chemviewx_activex.rb
+++ b/modules/exploits/windows/browser/hyleos_chemviewx_activex.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2010-0679' ],
 					[ 'OSVDB', '62276' ],
 					[ 'URL', 'http://www.security-assessment.com/files/advisories/2010-02-11_ChemviewX_Activex.pdf' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/11422/' ]
+					[ 'EDB', 11422 ]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
+++ b/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Version'        => '$Revision: $',
 			'References'     =>
 				[
-					[ 'URL', 'http://www.exploit-db.com/exploits/15668/' ],
+					[ 'EDB', 15668 ],
 					[ 'URL', 'http://secunia.com/advisories/42445/' ],
 					[ 'URL', 'http://xforce.iss.net/xforce/xfdb/63666' ]
 				],

--- a/modules/exploits/windows/browser/ms09_043_owc_msdso.rb
+++ b/modules/exploits/windows/browser/ms09_043_owc_msdso.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'OSVDB', '55806' ],
 					[ 'MSB', 'MS09-043' ],
 					[ 'URL', 'http://ahmed.obied.net/software/code/exploits/ie_owc.py' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/9163/' ],
+					[ 'EDB', 9163 ],
 					# broken: [ 'URL', 'http://xeye.us/blog/2009/07/one-0day/' ],
 					[ 'URL', 'http://www.microsoft.com/technet/security/advisory/973472.mspx' ],
 				],

--- a/modules/exploits/windows/browser/ms10_090_ie_css_clip.rb
+++ b/modules/exploits/windows/browser/ms10_090_ie_css_clip.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'OSVDB', '68987' ],
 					[ 'BID', '44536' ],
 					[ 'URL', 'http://www.microsoft.com/technet/security/advisory/2458511.mspx' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/15421/' ],
+					[ 'EDB', 15421 ],
 					[ 'MSB', 'MS10-090' ]
 				],
 			'DefaultOptions' =>

--- a/modules/exploits/windows/browser/novelliprint_callbackurl.rb
+++ b/modules/exploits/windows/browser/novelliprint_callbackurl.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2010-1527' ],
 					[ 'OSVDB', '67411'],
 					[ 'URL', 'http://secunia.com/secunia_research/2010-104/' ],	# Carsten Eiram, Secunia Research
-					[ 'URL', 'http://www.exploit-db.com/exploits/15042/' ],		# MOAUB #19
+					[ 'EDB', 15042 ],		# MOAUB #19
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/browser/novelliprint_executerequest_dbg.rb
+++ b/modules/exploits/windows/browser/novelliprint_executerequest_dbg.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2010-3106' ],
 					[ 'OSVDB', '66960'],
 					[ 'URL', 'http://dvlabs.tippingpoint.com/advisory/TPTI-10-06' ],	# Aaron Portnoy, TippingPoint DVLabs
-					[ 'URL', 'http://www.exploit-db.com/exploits/15001/' ],				# MOAUB #14
+					[ 'EDB', 15001 ],				# MOAUB #14
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/browser/novelliprint_getdriversettings_2.rb
+++ b/modules/exploits/windows/browser/novelliprint_getdriversettings_2.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'BID', '44966' ],
 					[ 'OSVDB', '69357' ],
 					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-10-256/' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/16014/' ],
+					[ 'EDB', 16014 ],
 					[ 'URL', 'http://www.novell.com/support/viewContent.do?externalId=7007234' ],
 				],
 			'DefaultOptions' =>

--- a/modules/exploits/windows/browser/real_arcade_installerdlg.rb
+++ b/modules/exploits/windows/browser/real_arcade_installerdlg.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '71559' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/17105/' ]
+					[ 'EDB', 17105 ]
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/browser/trendmicro_extsetowner.rb
+++ b/modules/exploits/windows/browser/trendmicro_extsetowner.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2010-3189' ],
 					[ 'OSVDB', '67561'],
 					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-10-165/' ],	# Andrea Micalizzi aka rgod via Zero Day Initiative
-					[ 'URL', 'http://www.exploit-db.com/exploits/14878/' ],		# MOAUB #03
+					[ 'EDB', 14878 ],		# MOAUB #03
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/browser/ultraoffice_httpupload.rb
+++ b/modules/exploits/windows/browser/ultraoffice_httpupload.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2008-3878' ],
 					[ 'OSVDB', '47866' ],
 					[ 'BID', '30861' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/6318' ]
+					[ 'EDB', 6318 ]
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
+++ b/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'CVE', '2010-0356' ],
 					[ 'OSVDB', '61634' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/12320/' ],
+					[ 'EDB', 12320 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/browser/webex_ucf_newobject.rb
+++ b/modules/exploits/windows/browser/webex_ucf_newobject.rb
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2008-3558' ],
 					[ 'OSVDB', '47344' ],
 					[ 'BID', '30578' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/6220' ],
+					[ 'EDB', 6220 ],
 					[ 'URL', 'http://labs.idefense.com/intelligence/vulnerabilities/display.php?id=849' ],
 					[ 'URL', 'http://www.trapkit.de/advisories/TKADV2008-009.txt' ],
 					[ 'URL', 'http://tk-blog.blogspot.com/2008/09/vulnerability-rediscovery-xss-and-webex.html' ],

--- a/modules/exploits/windows/fileformat/a-pdf_wav_to_mp3.rb
+++ b/modules/exploits/windows/fileformat/a-pdf_wav_to_mp3.rb
@@ -36,8 +36,8 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '67241' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/14676/' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/14681/' ]
+					[ 'EDB', 14676 ],
+					[ 'EDB', 14681 ]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/adobe_illustrator_v14_eps.rb
+++ b/modules/exploits/windows/fileformat/adobe_illustrator_v14_eps.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'BID', '37192' ],
 					[ 'OSVDB', '60632' ],
 					[ 'URL', 'http://retrogod.altervista.org/9sg_adobe_illuso.html' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/10281' ],
+					[ 'EDB', 10281 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/aol_desktop_linktag.rb
+++ b/modules/exploits/windows/fileformat/aol_desktop_linktag.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '70741'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/16085/' ],
+					[ 'EDB', 16085 ],
 				],
 			'Payload'	     =>
 				{

--- a/modules/exploits/windows/fileformat/aol_phobos_bof.rb
+++ b/modules/exploits/windows/fileformat/aol_phobos_bof.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '61964'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/11204' ],
+					[ 'EDB', 11204 ],
 					[ 'URL', 'http://www.rec-sec.com/2010/01/25/aol-playlist-class-buffer-overflow/' ],
 				],
 			'DefaultOptions' =>

--- a/modules/exploits/windows/fileformat/audio_wkstn_pls.rb
+++ b/modules/exploits/windows/fileformat/audio_wkstn_pls.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'CVE', '2009-0476' ],
 					[ 'OSVDB', '55424' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/10353' ],
+					[ 'EDB', 10353 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/audiotran_pls.rb
+++ b/modules/exploits/windows/fileformat/audiotran_pls.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'CVE', '2009-0476'],
 					[ 'OSVDB', '55424'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/11079' ],
+					[ 'EDB', 11079 ],
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/fileformat/aviosoft_plf_buf.rb
+++ b/modules/exploits/windows/fileformat/aviosoft_plf_buf.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					['OSVDB', '77043'],
-					['URL', 'http://www.exploit-db.com/exploits/18096/'],
+					['EDB', 18096],
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/fileformat/bsplayer_m3u.rb
+++ b/modules/exploits/windows/fileformat/bsplayer_m3u.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'References'     =>
 				[
-					[ 'URL', 'http://www.exploit-db.com/exploits/15934/' ]
+					[ 'EDB', 15934 ]
 				],
 			'DefaultOptions'  =>
 				{

--- a/modules/exploits/windows/fileformat/ccmplayer_m3u_bof.rb
+++ b/modules/exploits/windows/fileformat/ccmplayer_m3u_bof.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					['OSVDB', '77453'],
-					['URL', 'http://www.exploit-db.com/exploits/18178/']
+					['EDB', 18178]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/deepburner_path.rb
+++ b/modules/exploits/windows/fileformat/deepburner_path.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2006-6665' ],
 					[ 'URL', 'http://milw0rm.com/exploits/2950' ],
 					[ 'URL', 'http://milw0rm.com/exploits/8335' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/11315' ]
+					[ 'EDB', 11315 ]
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/fileformat/digital_music_pad_pls.rb
+++ b/modules/exploits/windows/fileformat/digital_music_pad_pls.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'OSVDB', '68178' ],
 					[ 'URL', 'http://secunia.com/advisories/41519/' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/15134' ],
+					[ 'EDB', 15134 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/djstudio_pls_bof.rb
+++ b/modules/exploits/windows/fileformat/djstudio_pls_bof.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'CVE', '2009-4656'],
 					[ 'OSVDB', '58159'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/10827' ]
+					[ 'EDB', 10827 ]
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/fileformat/dvdx_plf_bof.rb
+++ b/modules/exploits/windows/fileformat/dvdx_plf_bof.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2007-3068' ],
 					[ 'OSVDB', '36956' ],
 					[ 'BID', '24278' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/17745' ],
+					[ 'EDB', 17745 ],
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/fileformat/esignal_styletemplate_bof.rb
+++ b/modules/exploits/windows/fileformat/esignal_styletemplate_bof.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'OSVDB', '75456' ],
 					[ 'BID', '49600' ],
 					[ 'URL', 'http://aluigi.altervista.org/adv/esignal_1-adv.txt' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/17837/' ]
+					[ 'EDB', 17837 ]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/ezip_wizard_bof.rb
+++ b/modules/exploits/windows/fileformat/ezip_wizard_bof.rb
@@ -46,8 +46,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'OSVDB', '52815' ],
 					[ 'BID', '34044' ],
 					[ 'URL', 'http://www.edisys.com/' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/8180' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/12059/' ],
+					[ 'EDB', 8180 ],
+					[ 'EDB', 12059 ],
 				],
 			'Platform'          => [ 'win' ],
 			'Payload'           =>

--- a/modules/exploits/windows/fileformat/fatplayer_wav.rb
+++ b/modules/exploits/windows/fileformat/fatplayer_wav.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '57343'],
-					[ 'URL', 'https://www.exploit-db.com/exploits/15279/' ],
+					[ 'EDB', 15279 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/feeddemon_opml.rb
+++ b/modules/exploits/windows/fileformat/feeddemon_opml.rb
@@ -41,9 +41,9 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2009-0546' ],
 					[ 'OSVDB', '51753' ],
 					[ 'BID', '33630' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/7995' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/8010' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/11379' ]
+					[ 'EDB', 7995 ],
+					[ 'EDB', 8010 ],
+					[ 'EDB', 11379 ]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/foxit_title_bof.rb
+++ b/modules/exploits/windows/fileformat/foxit_title_bof.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					#[ 'CVE', '' ],
 					[ 'OSVDB', '68648' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/15532' ],
+					[ 'EDB', 15532 ],
 					[ 'URL', 'http://www.corelan.be:8800/index.php/2010/11/13/offensive-security-exploit-weekend/' ]
 				],
 			'Payload'	=>

--- a/modules/exploits/windows/fileformat/free_mp3_ripper_wav.rb
+++ b/modules/exploits/windows/fileformat/free_mp3_ripper_wav.rb
@@ -32,8 +32,8 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDG', '63349' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/11975' ], #Initial disclosure
-					[ 'URL', 'http://www.exploit-db.com/exploits/17727/' ] #This exploit is based on this poc
+					[ 'EDB', 11975 ], #Initial disclosure
+					[ 'EDB', 17727 ] #This exploit is based on this poc
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/galan_fileformat_bof.rb
+++ b/modules/exploits/windows/fileformat/galan_fileformat_bof.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References' =>
 				[
 					[ 'OSVDB', '60897' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/10339' ],
+					[ 'EDB', 10339 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/gta_samp.rb
+++ b/modules/exploits/windows/fileformat/gta_samp.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Version'        => '$Revision$',
 			'References'     =>
 				[
-					[ 'URL', 'http://www.exploit-db.com/exploits/17893' ]
+					[ 'EDB', 17893 ]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/hhw_hhp_compiledfile_bof.rb
+++ b/modules/exploits/windows/fileformat/hhw_hhp_compiledfile_bof.rb
@@ -32,8 +32,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'CVE', '2006-0564'],
 					[ 'OSVDB', '22941'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/1488' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/1490' ],
+					[ 'EDB', 1488 ],
+					[ 'EDB', 1490 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/hhw_hhp_contentfile_bof.rb
+++ b/modules/exploits/windows/fileformat/hhw_hhp_contentfile_bof.rb
@@ -31,8 +31,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'CVE', '2006-0564' ],
 					[ 'OSVDB', '22941' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/1470' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/1495' ],
+					[ 'EDB', 1470 ],
+					[ 'EDB', 1495 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/hhw_hhp_indexfile_bof.rb
+++ b/modules/exploits/windows/fileformat/hhw_hhp_indexfile_bof.rb
@@ -32,8 +32,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2009-0133' ],
 					[ 'BID', '33189' ],
 					[ 'OSVDB', '22941' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/10323' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/10335' ],
+					[ 'EDB', 10323 ],
+					[ 'EDB', 10335 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/ideal_migration_ipj.rb
+++ b/modules/exploits/windows/fileformat/ideal_migration_ipj.rb
@@ -35,10 +35,10 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'CVE', '2009-4265' ],
 					[ 'OSVDB', '60681' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/10319' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/12403' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/12404' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/12540' ]
+					[ 'EDB', 10319 ],
+					[ 'EDB', 12403 ],
+					[ 'EDB', 12404 ],
+					[ 'EDB', 12540 ]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/microp_mppl.rb
+++ b/modules/exploits/windows/fileformat/microp_mppl.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '73627'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/14720' ],
+					[ 'EDB', 14720 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/millenium_mp3_pls.rb
+++ b/modules/exploits/windows/fileformat/millenium_mp3_pls.rb
@@ -33,8 +33,8 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '56574' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/9618' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/10240' ],
+					[ 'EDB', 9618 ],
+					[ 'EDB', 10240 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/mini_stream_pls_bof.rb
+++ b/modules/exploits/windows/fileformat/mini_stream_pls_bof.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Version'        => '$Revision: $',
 			'References'     =>
 				[
-					[ 'URL', 'http://www.exploit-db.com/exploits/14373/' ],
+					[ 'EDB', 14373 ],
 					[ 'BID', '34514' ],
 				],
 			'DefaultOptions' =>

--- a/modules/exploits/windows/fileformat/mymp3player_m3u.rb
+++ b/modules/exploits/windows/fileformat/mymp3player_m3u.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '64580'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/11791' ],
+					[ 'EDB', 11791 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/orbital_viewer_orb.rb
+++ b/modules/exploits/windows/fileformat/orbital_viewer_orb.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'OSVDB', '62580' ],
 					[ 'CVE', '2010-0688' ],
 					[ 'URL', 'http://www.corelan.be:8800/index.php/forum/security-advisories/corelan-10-011-orbital-viewer-orb-buffer-overflow/' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/11581' ]
+					[ 'EDB', 11581 ]
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/fileformat/proshow_cellimage_bof.rb
+++ b/modules/exploits/windows/fileformat/proshow_cellimage_bof.rb
@@ -31,8 +31,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'CVE', '2009-3214' ],
 					[ 'OSVDB', '57226' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/9483' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/9519' ],
+					[ 'EDB', 9483 ],
+					[ 'EDB', 9519 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/real_networks_netzip_bof.rb
+++ b/modules/exploits/windows/fileformat/real_networks_netzip_bof.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'BID', '46059' ],
 					[ 'URL', 'http://proforma.real.com' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/16083/' ],
+					[ 'EDB', 16083 ],
 				],
 			'Platform'          => [ 'win' ],
 			'DefaultOptions' =>

--- a/modules/exploits/windows/fileformat/scadaphone_zip.rb
+++ b/modules/exploits/windows/fileformat/scadaphone_zip.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					#[ 'CVE', '' ],
 					[ 'OSVDB', '75375' ],
 					[ 'URL', 'http://www.scadatec.com/' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/17817/' ],
+					[ 'EDB', 17817 ],
 				],
 			'Platform'          => [ 'win' ],
 			'Payload'           =>

--- a/modules/exploits/windows/fileformat/somplplayer_m3u.rb
+++ b/modules/exploits/windows/fileformat/somplplayer_m3u.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '64368' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/11219' ],
+					[ 'EDB', 11219 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/subtitle_processor_m3u_bof.rb
+++ b/modules/exploits/windows/fileformat/subtitle_processor_m3u_bof.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'URL', 'http://sourceforge.net/projects/subtitleproc/' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/17217/' ],
+					[ 'EDB', 17217 ],
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/fileformat/tugzip.rb
+++ b/modules/exploits/windows/fileformat/tugzip.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'OSVDB', '49371' ],
 					[ 'CVE', '2008-4779' ],
 					[ 'BID', '31913' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/12008/' ]
+					[ 'EDB', 12008 ]
 				],
 			'Platform'       => [ 'win' ],
 			'Payload'        =>

--- a/modules/exploits/windows/fileformat/ultraiso_ccd.rb
+++ b/modules/exploits/windows/fileformat/ultraiso_ccd.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'BID', '38613' ],
 					# NOTE: The following OSVDB entry seems invalid, the IMG file doesn't appear to trigger any vulnerability.
 					# [ 'OS-VDB', '53425' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/8343' ]
+					[ 'EDB', 8343 ]
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/fileformat/ultraiso_cue.rb
+++ b/modules/exploits/windows/fileformat/ultraiso_cue.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2007-2888' ],
 					[ 'OSVDB', '36570' ],
 					[ 'BID', '24140' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/3978' ]
+					[ 'EDB', 3978 ]
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/fileformat/varicad_dwb.rb
+++ b/modules/exploits/windows/fileformat/varicad_dwb.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'OSVDB', '63067' ],
 					[ 'BID', '38815' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/11789' ]
+					[ 'EDB', 11789 ]
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/fileformat/vlc_smb_uri.rb
+++ b/modules/exploits/windows/fileformat/vlc_smb_uri.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2009-2484' ],
 					[ 'URL', 'http://git.videolan.org/?p=vlc.git;a=commit;h=e60a9038b13b5eb805a76755efc5c6d5e080180f' ],
 					[ 'URL', 'http://milw0rm.com/exploits/9209' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/9029' ]
+					[ 'EDB', 9029 ]
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/fileformat/wireshark_packet_dect.rb
+++ b/modules/exploits/windows/fileformat/wireshark_packet_dect.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'OSVDB', '71848'],
 					[ 'URL', 'https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=5838' ],
 					[ 'URL', 'https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=5836' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/17185' ],
+					[ 'EDB', 17185 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/wm_downloader_m3u.rb
+++ b/modules/exploits/windows/fileformat/wm_downloader_m3u.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '66911'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/14497/' ],
+					[ 'EDB', 14497 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/xenorate_xpl_bof.rb
+++ b/modules/exploits/windows/fileformat/xenorate_xpl_bof.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '57162' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/10371' ],
+					[ 'EDB', 10371 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/xion_m3u_sehbof.rb
+++ b/modules/exploits/windows/fileformat/xion_m3u_sehbof.rb
@@ -41,9 +41,9 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					#[ 'CVE', '' ],
 					[ 'OSVDB', '66912'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/14517' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/14633' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/15598' ]
+					[ 'EDB', 14517 ],
+					[ 'EDB', 14633 ],
+					[ 'EDB', 15598 ]
 				],
 			'Payload'	=>
 				{

--- a/modules/exploits/windows/ftp/ability_server_stor.rb
+++ b/modules/exploits/windows/ftp/ability_server_stor.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'URL', '2004-1626' ],
 					[ 'OSVDB', '11030'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/588/'],
+					[ 'EDB', 588],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/ftp/absolute_ftp_list_bof.rb
+++ b/modules/exploits/windows/ftp/absolute_ftp_list_bof.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					#[ 'OSVDB', '---' ],
 					#[ 'CVE', '---' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/18102/' ]
+					[ 'EDB', 18102 ]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/ftp/easyftp_list_fixret.rb
+++ b/modules/exploits/windows/ftp/easyftp_list_fixret.rb
@@ -46,8 +46,8 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '62134' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/14400/' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/14451/' ]
+					[ 'EDB', 14400 ],
+					[ 'EDB', 14451 ]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/ftp/easyftp_mkd_fixret.rb
+++ b/modules/exploits/windows/ftp/easyftp_mkd_fixret.rb
@@ -43,8 +43,8 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '62134' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/12044/' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/14399/' ]
+					[ 'EDB', 12044 ],
+					[ 'EDB', 14399 ]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/ftp/goldenftp_pass_bof.rb
+++ b/modules/exploits/windows/ftp/goldenftp_pass_bof.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2006-6576'],
 					[ 'OSVDB', '35951'],
 					[ 'BID', '45957'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/16036/'],
+					[ 'EDB', 16036],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/ftp/ms09_053_ftpd_nlst.rb
+++ b/modules/exploits/windows/ftp/ms09_053_ftpd_nlst.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Version'        => '$Revision$',
 			'References'     =>
 				[
-					['URL', 'http://www.exploit-db.com/exploits/9541/'],
+					['EDB', 9541],
 					['CVE', '2009-3023'],
 					['OSVDB', '57589'],
 					['BID', '36189'],

--- a/modules/exploits/windows/ftp/scriptftp_list.rb
+++ b/modules/exploits/windows/ftp/scriptftp_list.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'CVE', '2011-3976' ],
 					[ 'OSVDB', '75633' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/17876/' ],
+					[ 'EDB', 17876 ],
 					[ 'URL', 'http://www.kb.cert.org/vuls/id/440219' ],
 				],
 			'DefaultOptions' =>

--- a/modules/exploits/windows/ftp/trellian_client_pasv.rb
+++ b/modules/exploits/windows/ftp/trellian_client_pasv.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'CVE', '2010-1465'],
 					[ 'OSVDB', '63812'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/12152' ],
+					[ 'EDB', 12152 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/ftp/vermillion_ftpd_port.rb
+++ b/modules/exploits/windows/ftp/vermillion_ftpd_port.rb
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '62163' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/11293' ],
+					[ 'EDB', 11293 ],
 					[ 'URL', 'http://www.global-evolution.info/news/files/vftpd/vftpd.txt' ]
 				],
 			'DefaultOptions' =>

--- a/modules/exploits/windows/ftp/xftp_client_pwd.rb
+++ b/modules/exploits/windows/ftp/xftp_client_pwd.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '63968'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/12332' ],
+					[ 'EDB', 12332 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/http/ca_arcserve_rpc_authbypass.rb
+++ b/modules/exploits/windows/http/ca_arcserve_rpc_authbypass.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Version'        => '$Revision$',
 			'References'     =>
 				[
-					[ 'URL', 'http://www.exploit-db.com/exploits/17574/' ],
+					[ 'EDB', 17574 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/http/easyftp_list.rb
+++ b/modules/exploits/windows/http/easyftp_list.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '66614'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/11500/' ]
+					[ 'EDB', 11500 ]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/http/kolibri_http.rb
+++ b/modules/exploits/windows/http/kolibri_http.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2002-2268' ],
 					[ 'OSVDB', '70808' ],
 					[ 'BID', '6289' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/15834/' ],
+					[ 'EDB', 15834 ],
 				],
 			'Privileged'     => false,
 			'Payload'        =>

--- a/modules/exploits/windows/misc/bigant_server_250.rb
+++ b/modules/exploits/windows/misc/bigant_server_250.rb
@@ -34,8 +34,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					# the v2.2 vuln back in Dec 2008
 					[ 'CVE', '2008-1914'],
 					[ 'OSVDB', '44454'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/9673' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/9690' ]
+					[ 'EDB', 9673 ],
+					[ 'EDB', 9690 ]
 					#[ 'B_ID', '28795' ],
 					#[ 'U_RL', 'http://www.milw0rm.com/exploits/5451'],
 				],

--- a/modules/exploits/windows/misc/bigant_server_usv.rb
+++ b/modules/exploits/windows/misc/bigant_server_usv.rb
@@ -38,8 +38,8 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '61386' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/10765' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/10973' ]
+					[ 'EDB', 10765 ],
+					[ 'EDB', 10973 ]
 				],
 			'Privileged'     => true,
 			'DefaultOptions' =>

--- a/modules/exploits/windows/misc/eureka_mail_err.rb
+++ b/modules/exploits/windows/misc/eureka_mail_err.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'CVE', '2009-3837' ],
 					[ 'OSVDB', '59262' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/10235' ],
+					[ 'EDB', 10235 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/misc/hp_omniinet_4.rb
+++ b/modules/exploits/windows/misc/hp_omniinet_4.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'CVE', '2011-1865' ],
 					[ 'OSVDB', '73571'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/17468/' ],
+					[ 'EDB', 17468 ],
 					[ 'URL', 'http://www.coresecurity.com/content/HP-Data-Protector-multiple-vulnerabilities' ],
 					[ 'URL', 'http://h20000.www2.hp.com/bizsupport/TechSupport/Document.jsp?objectID=c02872182' ],
 				],

--- a/modules/exploits/windows/misc/mini_stream.rb
+++ b/modules/exploits/windows/misc/mini_stream.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References' =>
 				[
 					[ 'OSVDB', '61341' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/10745' ],
+					[ 'EDB', 10745 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/misc/nettransport.rb
+++ b/modules/exploits/windows/misc/nettransport.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '61435' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/10911'],
+					[ 'EDB', 10911],
 				],
 			'Privileged'     => false,
 			'DefaultOptions' =>

--- a/modules/exploits/windows/misc/splayer_content_type.rb
+++ b/modules/exploits/windows/misc/splayer_content_type.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					['OSVDB', '72181'],
-					['URL', 'http://www.exploit-db.com/exploits/17243/'],
+					['EDB', 17243],
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/misc/stream_down_bof.rb
+++ b/modules/exploits/windows/misc/stream_down_bof.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					['BID', '51190'],
 					['URL', 'http://www.dark-masters.tk/'],
 					['URL', 'http://secunia.com/advisories/47343/'],
-					['URL', 'http://www.exploit-db.com/exploits/18283/']
+					['EDB', 18283]
 				],
 			'Privileged'     => false,
 			'DefaultOptions' =>

--- a/modules/exploits/windows/misc/ufo_ai.rb
+++ b/modules/exploits/windows/misc/ufo_ai.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References' =>
 				[
 					[ 'OSVDB', '65689'],
-					[ 'URL', 'http://www.exploit-db.com/exploits/14013' ]
+					[ 'EDB', 14013 ]
 				],
 			'Payload' =>
 				{

--- a/modules/exploits/windows/misc/wireshark_packet_dect.rb
+++ b/modules/exploits/windows/misc/wireshark_packet_dect.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'OSVDB', '71848'],
 					[ 'URL', 'https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=5838' ],
 					[ 'URL', 'https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=5836' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/17185' ],
+					[ 'EDB', 17185 ],
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/scada/codesys_web_server.rb
+++ b/modules/exploits/windows/scada/codesys_web_server.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'OSVDB', '77387'],
 					[ 'URL', 'http://aluigi.altervista.org/adv/codesys_1-adv.txt' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/18187/' ],
+					[ 'EDB', 18187 ],
 					[ 'URL', 'http://www.us-cert.gov/control_systems/pdf/ICS-ALERT-11-336-01A.pdf' ],
 					# The following clearifies why two people are credited for the discovery
 					[ 'URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-12-006-01.pdf']

--- a/modules/exploits/windows/scada/iconics_webhmi_setactivexguid.rb
+++ b/modules/exploits/windows/scada/iconics_webhmi_setactivexguid.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					['OSVDB', '72135'],
 					['URL', 'http://www.security-assessment.com/files/documents/advisory/ICONICS_WebHMI.pdf'],
-					['URL', 'http://www.exploit-db.com/exploits/17240/'],
+					['EDB', 17240],
 					['URL', 'http://www.us-cert.gov/control_systems/pdf/ICS-ALERT-11-080-02.pdf']
 				],
 			'Payload'        =>

--- a/modules/exploits/windows/smtp/njstar_smtp_bof.rb
+++ b/modules/exploits/windows/smtp/njstar_smtp_bof.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'OSVDB', '76728' ],
 					#[ 'CVE', '' ],
 					[ 'URL', 'http://www.njstar.com/cms/njstar-communicator' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/18057/' ]
+					[ 'EDB', 18057 ]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/ssh/sysax_ssh_username.rb
+++ b/modules/exploits/windows/ssh/sysax_ssh_username.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					['OSVDB', '79689'],
 					['URL', 'http://www.pwnag3.com/2012/02/sysax-multi-server-ssh-username-exploit.html'],
-					['URL', 'http://www.exploit-db.com/exploits/18535/']
+					['EDB', 18535]
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/tftp/attftp_long_filename.rb
+++ b/modules/exploits/windows/tftp/attftp_long_filename.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					['CVE', '2006-6184'],
 					['OSVDB', '11350'],
 					['BID', '21320'],
-					['URL','http://www.exploit-db.com/exploits/2887/'],
+					['EDB', 2887],
 					['URL', 'ftp://guest:guest@ftp.alliedtelesyn.co.uk/pub/utilities/at-tftpd19.zip'],
 				],
 			'DefaultOptions' =>

--- a/modules/post/windows/escalate/ms10_073_kbdlayout.rb
+++ b/modules/post/windows/escalate/ms10_073_kbdlayout.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Post
 					[ 'MSB', 'MS10-073' ],
 					[ 'URL', 'http://www.vupen.com/blog/20101018.Stuxnet_Win32k_Windows_Kernel_0Day_Exploit_CVE-2010-2743.php' ],
 					[ 'URL', 'http://www.reversemode.com/index.php?option=com_content&task=view&id=71&Itemid=1' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/15985/' ]
+					[ 'EDB', 15985 ]
 				],
 			'DisclosureDate'=> "Oct 12 2010"
 		))

--- a/modules/post/windows/escalate/ms10_092_schelevator.rb
+++ b/modules/post/windows/escalate/ms10_092_schelevator.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Post
 					[ 'CVE', '2010-3338' ],
 					[ 'BID', '44357' ],
 					[ 'MSB', 'MS10-092' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/15589/' ]
+					[ 'EDB', 15589 ]
 				],
 			'DisclosureDate'=> 'Sep 13 2010'
 		))

--- a/modules/post/windows/escalate/net_runtime_modify.rb
+++ b/modules/post/windows/escalate/net_runtime_modify.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Post
 			'References'    =>
 				[
 					[ 'OSVDB', '71013' ],
-					[ 'URL', 'http://www.exploit-db.com/exploits/16940/' ]
+					[ 'EDB', 16940 ]
 				]
 		))
 

--- a/modules/post/windows/gather/credentials/imail.rb
+++ b/modules/post/windows/gather/credentials/imail.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Post
 				],
 			'References'     =>
 				[
-					['URL', 'http://www.exploit-db.com/exploits/11331/'],
+					['EDB', 11331],
 				],
 			'Platform'       => [ 'win' ],
 			'SessionTypes'   => [ 'meterpreter' ]


### PR DESCRIPTION
There are a bunch (over 100) modules that reference Exploit-DB. It's high time to promote this reference to an indexable, searchable reference, akin to BID, OSVDB, CVE, MSB, etc.

This pull request needs coordination to work with Metasploit Community and Pro (or else the references will look silly in the module runner), so please don't land this pull request without that work in place. However, do comment on the pull request if you ( @jlee-r7 or @wchen-r7 ) happen to review the code.
