### PR TITLE
fix generating war files for Java payloads from within msfconsole

### DIFF
--- a/lib/msf/base/simple/payload.rb
+++ b/lib/msf/base/simple/payload.rb
@@ -74,6 +74,10 @@ module Payload
 		len = e.encoded.length
 
 
+		if arch.index(ARCH_JAVA) and fmt == 'war'
+			return e.encoded_war.pack
+		end
+
 		output = Msf::Util::EXE.to_executable_fmt(framework, arch, plat, e.encoded, fmt, exeopts)
 
 		if not output


### PR DESCRIPTION
This fixes this use case:
use payload/java/meterpreter/reverse_tcp
generate -t war -f filename.war
