### PR TITLE
Make sure session.target_host gets resolved

### DIFF
--- a/lib/msf/core/session.rb
+++ b/lib/msf/core/session.rb
@@ -260,7 +260,7 @@ module Session
 	def set_from_exploit(m)
 		self.via = { 'Exploit' => m.fullname }
 		self.via['Payload'] = ('payload/' + m.datastore['PAYLOAD'].to_s) if m.datastore['PAYLOAD']
-		self.target_host = m.target_host if (m.target_host.to_s.strip.length > 0)
+		self.target_host = Rex::Socket.getaddress(m.target_host) if (m.target_host.to_s.strip.length > 0)
 		self.target_port = m.target_port if (m.target_port.to_i != 0)
 		self.workspace   = m.workspace
 		self.username    = m.owner


### PR DESCRIPTION
Not sure why this isn't already resolved when we read it out of the
datastore.  May have something to do with the recent options madness.

[Fixes #6567]
