### PR TITLE
Automatically choosing exploit payload for WMAP-enabled exploit modules.

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -140,7 +140,7 @@ class Exploit
 		end
 
 		if not payload
-			payload = exploit_choose_payload(mod, target)
+			payload = Exploit.choose_payload(mod, target)
 		end
 
 		begin
@@ -236,7 +236,7 @@ class Exploit
 	#
 	# Picks a reasonable payload and minimally configures it
 	#
-	def exploit_choose_payload(mod, target)
+	def self.choose_payload(mod, target)
 
 		# Choose either the real target or an invalid address
 		# This is used to determine the LHOST value

--- a/plugins/wmap.rb
+++ b/plugins/wmap.rb
@@ -1689,6 +1689,10 @@ class Plugin::Wmap < Msf::Plugin
 						'Options'  => opts
 					})
 				when 'exploit'
+					if not opts['PAYLOAD']
+						opts['PAYLOAD'] = WmapCommandDispatcher::Exploit.choose_payload(modinst, opts['TARGET'])
+					end
+
 					sess = Msf::Simple::Exploit.exploit_simple(modinst, {
 						'Payload'  => opts['PAYLOAD'],
 						'Target'   => opts['TARGET'],


### PR DESCRIPTION
I exposed the exploit_choose_payload method as class method in the class `Msf::Ui::Console::CommandDispatcher::Exploit`, and reused it in WMAP so that it can automatically configure payloads for WMAP-enabled exploit modules.
I hope this use of class methods is permissible in MSF, and thought this would be the easiest way to reuse the code.
BTW, I think this method can lose its second argument as it seems to only need/use the datastore in the module instance.
Please review my patch.
