### PR TITLE
rpc_loots method uses the wrong iteration variable ('n' instead of 'l')

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -756,7 +756,7 @@ public
 		wspace.loots.all(:limit => limit, :offset => offset).each do |l|
 			loot = {}
 			loot[:host] = l.host.address if(l.host)
-			loot[:service] = l.service.name || n.service.port  if(n.service)
+			loot[:service] = l.service.name || l.service.port  if(l.service)
 			loot[:ltype] = l.ltype
 			loot[:ctype] = l.content_type
 			loot[:data] = l.data


### PR DESCRIPTION
n.service.port should be l.service.port
n.service should be l.service
