### PR TITLE
get_workspace fails no method 'modified_at'

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -208,7 +208,7 @@ public
 			w = {}
 			w[:name] = wspace.name
 			w[:created_at] = wspace.created_at.to_i
-			w[:modified_at] = wspace.modified_at.to_i
+			w[:updated_at] = wspace.updated_at.to_i
 			ret[:workspace] << w
 		end
 		ret


### PR DESCRIPTION
References to :modified_at should be changed to :updated_at.
