### PR TITLE
fixed timestamps inside meterpreter.jar / ext_server_stdapi.jar

### DIFF
--- a/external/source/meterpreter/java/build.xml
+++ b/external/source/meterpreter/java/build.xml
@@ -42,7 +42,10 @@
 			<fileset dir="extensions/tmp" includes="**/*"/>
 		</touch>
 		<delete file="extensions/meterpreter.jar" />
-		<zip destfile="extensions/meterpreter.jar" basedir="extensions/tmp"/>
+		<zip destfile="extensions/meterpreter.jar">
+			<fileset dir="extensions/tmp" includes="META-INF/**" />
+			<fileset dir="extensions/tmp" excludes="META-INF/**" />
+		</zip>
 		<delete dir="extensions/tmp"/>
 
 		<mkdir dir="extensions/tmp"/>
@@ -51,7 +54,10 @@
 			<fileset dir="extensions/tmp" includes="**/*"/>
 		</touch>
 		<delete file="extensions/ext_server_stdapi.jar" />
-		<zip destfile="extensions/ext_server_stdapi.jar" basedir="extensions/tmp"/>
+		<zip destfile="extensions/ext_server_stdapi.jar">
+			<fileset dir="extensions/tmp" includes="META-INF/**" />
+			<fileset dir="extensions/tmp" excludes="META-INF/**" />
+		</zip>
 		<delete dir="extensions/tmp"/>
 	</target>
 

--- a/external/source/meterpreter/java/build.xml
+++ b/external/source/meterpreter/java/build.xml
@@ -34,8 +34,28 @@
 			</manifest>
 		</jar>
 	</target>
+	
+	<target name="fix-timestamps" depends="jar">
+		<mkdir dir="extensions/tmp"/>
+		<unzip src="extensions/meterpreter.jar" dest="extensions/tmp"/>
+		<touch datetime="01/01/2000 00:00 AM">
+			<fileset dir="extensions/tmp" includes="**/*"/>
+		</touch>
+		<delete file="extensions/meterpreter.jar" />
+		<zip destfile="extensions/meterpreter.jar" basedir="extensions/tmp"/>
+		<delete dir="extensions/tmp"/>
 
-	<target name="deploy" depends="jar">
+		<mkdir dir="extensions/tmp"/>
+		<unzip src="extensions/ext_server_stdapi.jar" dest="extensions/tmp"/>
+		<touch datetime="01/01/2000 00:00 AM">
+			<fileset dir="extensions/tmp" includes="**/*"/>
+		</touch>
+		<delete file="extensions/ext_server_stdapi.jar" />
+		<zip destfile="extensions/ext_server_stdapi.jar" basedir="extensions/tmp"/>
+		<delete dir="extensions/tmp"/>
+	</target>
+
+	<target name="deploy" depends="fix-timestamps">
 		<copy todir="../../../../data/meterpreter">
 			<fileset dir="extensions">
 			</fileset>


### PR DESCRIPTION
This pull request does not include the binaries, since it complicates merging for no real reason. Whoever applies this pull request may regenerate the binaries after applying so that they all have fixed timestamps inside :)
