### PR TITLE
tomcat_mgr_deploy may report successful creds - Tested and running ^^

### DIFF
--- a/modules/exploits/multi/http/tomcat_mgr_deploy.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_deploy.rb
@@ -222,7 +222,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			raise RuntimeError, "Upload failed on #{path_tmp} [#{res.code} #{res.message}]"
 		end
 
-                report_auth_info(
+		report_auth_info(
 			:host   => rhost,
 			:port   => rport,
 			:sname  => (ssl ? "https" : "http"),
@@ -230,7 +230,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			:pass   => datastore['BasicAuthPass'],
 			:proof  => "WEBAPP=\"Tomcat Manager App\", VHOST=#{vhost}, PATH=#{datastore['PATH']}",
 			:active => true
-                )
+		)
 
 		#
 		# EXECUTE

--- a/modules/exploits/multi/http/tomcat_mgr_deploy.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_deploy.rb
@@ -128,6 +128,16 @@ class Metasploit3 < Msf::Exploit::Remote
 			return CheckCode::Unknown
 		end
 
+		report_auth_info(
+			:host   => rhost,
+			:port   => rport,
+			:sname  => (ssl ? "https" : "http"),
+			:user   => datastore['BasicAuthUser'],
+			:pass   => datastore['BasicAuthPass'],
+			:proof  => "WEBAPP=\"Tomcat Manager App\", VHOST=#{vhost}, PATH=#{datastore['PATH']}",
+			:active => true
+		)
+
 		print_status("Target is #{detect_platform(res.body)} #{detect_arch(res.body)}")
 		return CheckCode::Vulnerable
 	end
@@ -211,6 +221,16 @@ class Metasploit3 < Msf::Exploit::Remote
 			end
 			raise RuntimeError, "Upload failed on #{path_tmp} [#{res.code} #{res.message}]"
 		end
+
+                report_auth_info(
+			:host   => rhost,
+			:port   => rport,
+			:sname  => (ssl ? "https" : "http"),
+			:user   => datastore['BasicAuthUser'],
+			:pass   => datastore['BasicAuthPass'],
+			:proof  => "WEBAPP=\"Tomcat Manager App\", VHOST=#{vhost}, PATH=#{datastore['PATH']}",
+			:active => true
+                )
 
 		#
 		# EXECUTE


### PR DESCRIPTION
Using following code for 'check' as 'exploit':
               report_auth_info(
                       :host   => rhost,
                       :port   => rport,
                       :sname  => (ssl ? "https" : "http"),
                       :user   => datastore['BasicAuthUser'],
                       :pass   => datastore['BasicAuthPass'],
                       :proof  => "WEBAPP=\"Tomcat Manager App\", VHOST=#{vhost}, PATH=#{datastore['PATH']}",
                       :active => true
               )

Resulting in:
# Credentials

host           port  user    pass    type      active?

---

192.168.x.xxx  8080  tomcat  s3cret  password  true
