### PR TITLE
ACTION on persistence.rb should be an OptEnum

### DIFF
--- a/modules/post/windows/manage/persistence.rb
+++ b/modules/post/windows/manage/persistence.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Post
 				OptString.new('TEMPLATE', [false, 'Alternate template Windows PE File to use.']),
 				OptString.new('REXE',[false, 'The remote executable to use.','']),
 				OptString.new('REXENAME',[false, 'The name to call exe on remote system','']),
-				OptString.new('ACTION',[true, 'Use TEMPLATE or REXE mode.','TEMPLATE']),
+				OptEnum.new('ACTION',[true, 'Use TEMPLATE or REXE mode.','TEMPLATE', ['TEMPLATE', 'REXE']]),
 				OptEnum.new('PAYLOAD_TYPE', [true, 'Meterpreter Payload Type.', 'TCP',['TCP','HTTP','HTTPS']])
 			], self.class)
 

--- a/modules/post/windows/manage/persistence.rb
+++ b/modules/post/windows/manage/persistence.rb
@@ -60,7 +60,6 @@ class Metasploit3 < Msf::Post
 				OptString.new('TEMPLATE', [false, 'Alternate template Windows PE File to use.']),
 				OptString.new('REXE',[false, 'The remote executable to use.','']),
 				OptString.new('REXENAME',[false, 'The name to call exe on remote system','']),
-				OptEnum.new('ACTION',[true, 'Use TEMPLATE or REXE mode.','TEMPLATE', ['TEMPLATE', 'REXE']]),
 				OptEnum.new('PAYLOAD_TYPE', [true, 'Meterpreter Payload Type.', 'TCP',['TCP','HTTP','HTTPS']])
 			], self.class)
 


### PR DESCRIPTION
That way, upcase / downcase problems get caught on option validation,
rather than down in the module's guts.

I believe this will resolve the problem discussed on IRC.
