### PR TITLE
Fixed msfvenom NoMethodError with alpha_mixed encoder.

### DIFF
--- a/modules/encoders/x86/alpha_mixed.rb
+++ b/modules/encoders/x86/alpha_mixed.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Encoder::Alphanum
 	# Configure SEH getpc code on Windows
 	#
 	def init_platform(platform)
-		if(platform.supports?(::Msf::Module::PlatformList.win32))
+		if(::Msf::Module::PlatformList.from_a(platform).supports?(::Msf::Module::PlatformList.win32))
 			datastore['AllowWin32SEH'] = true
 		end
 	end


### PR DESCRIPTION
The issue was reported on Github[1] and Redmine[2].

The error consisted of trying to use the supports?() method
on an Array instead of a PlatformList.

[1] https://github.com/rapid7/metasploit-framework/issues/357
[2] http://dev.metasploit.com/redmine/issues/6826

Reported by: Brandon Perry
Signed off by: Silviu Popescu silviupopescu1990@gmail.com
