### PR TITLE
Fix posix execute

### DIFF
--- a/external/source/meterpreter/source/extensions/stdapi/server/sys/process/process.c
+++ b/external/source/meterpreter/source/extensions/stdapi/server/sys/process/process.c
@@ -553,11 +553,12 @@ DWORD request_sys_process_execute(Remote *remote, Packet *packet)
 #else
 	PCHAR path, arguments;;
 	DWORD flags;
-	char *argv[64], *p;
+	char *argv[8], *command_line;
+	int cl_len = 0;
 	int in[2] = { -1, -1 }, out[2] = {-1, -1}; // file descriptors
 	int master = -1, slave = -1;
 	int devnull = -1;
-	int idx;
+	int idx, i;
 	pid_t pid;
 	int have_pty = -1;
 
@@ -585,18 +586,26 @@ DWORD request_sys_process_execute(Remote *remote, Packet *packet)
 
 		idx = 0;
 		if(arguments) {
-			p = arguments;
-			argv[idx++] = path;
-			argv[idx++] = arguments;
-			for(p = strchr(p, ' '); p && idx < 63; p = strchr(p, ' ')) {
-				*p++ = 0;
-				argv[idx++] = p;
-			}
-			argv[idx++] = NULL;
+			// Add one for the null, one for the space
+			cl_len = strlen(path) + strlen(arguments) + 2;
+			command_line = malloc(cl_len);
+			memset(command_line, 0, cl_len);
+			strcat(command_line, path);
+			strcat(command_line, " ");
+			strcat(command_line, arguments);
+
+			argv[idx++] = "sh";
+			argv[idx++] = "-c";
+			argv[idx++] = command_line;
+			path = "/bin/sh";
 		} else {
 			argv[idx++] = path;
-			argv[idx++] = NULL;
 		}	
+		argv[idx++] = NULL;
+
+		//for (i = 0; i < idx; i++) {
+		//	dprintf("  argv[%d] = %s", i, argv[i]);
+		//}
 
 		// If the channelized flag is set, create a pipe for stdin/stdout/stderr
 		// such that input can be directed to and from the remote endpoint
@@ -684,7 +693,6 @@ DWORD request_sys_process_execute(Remote *remote, Packet *packet)
 		pid = fork();
 		switch(pid) {
 
-			int i;
 		case -1:
 			result = errno;
 			break;
@@ -735,8 +743,10 @@ DWORD request_sys_process_execute(Remote *remote, Packet *packet)
 			exit(EXIT_FAILURE);
 		default:
 			dprintf("child pid is %d\n", pid);
+			packet_add_tlv_uint(response, TLV_TYPE_PID,(DWORD)pid);
 			if (flags & PROCESS_EXECUTE_FLAG_CHANNELIZED) {
 				if(have_pty) {
+					dprintf("child channelized\n");
 					close(slave);
 				} else {
 					close(in[0]);

--- a/lib/rex/post/meterpreter/channels/pools/stream_pool.rb
+++ b/lib/rex/post/meterpreter/channels/pools/stream_pool.rb
@@ -49,14 +49,14 @@ class StreamPool < Rex::Post::Meterpreter::Channels::Pool
 	# This method returns the current offset into the pool.
 	#
 	def tell
-		throw NotImplementedError
+		raise NotImplementedError
 	end
 
 	#
 	# This method seeks to an offset in the pool.
 	#
 	def seek
-		throw NotImplementedError
+		raise NotImplementedError
 	end
 
 	#


### PR DESCRIPTION
In posix, a command like `echo 'foo bar'` would previously get parsed
out into arguments for execve like `[ "echo", "'foo", "bar'" ]` which
obviously isn't what you want. After this commit, it sticks the whole
thing in an arg to sh so the execve call ends up looking like (strace output)
    `execve("/bin/sh", ["sh", "-c", "echo 'foo bar'"], [/* 26 vars */]) = 0`
This is still a little less than ideal because shell escapes become a
problem; fortunately, that's easy to deal with on the client side as
long as module developers take it into account.
