### PR TITLE
Banner encoding fix when running against dd-wrt on ruby 1.9.3

### DIFF
--- a/modules/auxiliary/scanner/telnet/telnet_version.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_version.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Auxiliary
 			::Timeout.timeout(to) do
 				res = connect
 				# This makes db_services look a lot nicer.
-				banner_santized = Rex::Text.to_hex_ascii(banner.to_s)
+				banner_santized = Rex::Text.to_hex_ascii(banner.to_s.unpack('C*').pack('U*'))
 				print_status("#{ip}:#{rport} TELNET #{banner_santized}")
 				report_service(:host => rhost, :port => rport, :name => "telnet", :info => banner_santized)
 			end


### PR DESCRIPTION
This came from RageLtMan -- it seems harmless, but speaks to possibly a much more serious bug when it comes to to_s'ing banners from all kinds of services.
