### PR TITLE
Default to ethernet if the server doesn't specify

### DIFF
--- a/lib/rex/post/meterpreter/extensions/sniffer/sniffer.rb
+++ b/lib/rex/post/meterpreter/extensions/sniffer/sniffer.rb
@@ -96,7 +96,7 @@ class Sniffer < Extension
 		{
 			:packets => response.get_tlv_value(TLV_TYPE_SNIFFER_PACKET_COUNT),
 			:bytes   => response.get_tlv_value(TLV_TYPE_SNIFFER_BYTE_COUNT),
-			:linktype => response.get_tlv_value(TLV_TYPE_SNIFFER_INTERFACE_ID),
+			:linktype => response.get_tlv_value(TLV_TYPE_SNIFFER_INTERFACE_ID) || 1,
 		}
 	end
 


### PR DESCRIPTION
Still need to recompile sniffer, but this will fix the immediate problem
of stack traces and failing to save the pcap.

Fixes redmine #6893
