### PR TITLE
Cleanup Opt::RPORT(80) since it is already registered by Msf::Exploit::Remote::HttpClient

### DIFF
--- a/modules/auxiliary/admin/2wire/xslt_password_reset.rb
+++ b/modules/auxiliary/admin/2wire/xslt_password_reset.rb
@@ -41,7 +41,6 @@ class Metasploit3 < Msf::Auxiliary
 
 			register_options(
 				[
-					Opt::RPORT(80),
 					OptString.new('PASSWORD', [ true, 'The password to reset to', 'admin'])
 				], self.class)
 	end

--- a/modules/auxiliary/admin/http/contentkeeper_fileaccess.rb
+++ b/modules/auxiliary/admin/http/contentkeeper_fileaccess.rb
@@ -35,7 +35,6 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options(
 			[
-				Opt::RPORT(80),
 				OptString.new('FILE', [ true, 'The file to traverse for', '/etc/passwd']),
 				OptString.new('URL', [ true, 'The path to mimencode', '/cgi-bin/ck/mimencode']),
 			], self.class)

--- a/modules/auxiliary/admin/http/iomega_storcenterpro_sessionid.rb
+++ b/modules/auxiliary/admin/http/iomega_storcenterpro_sessionid.rb
@@ -36,7 +36,6 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options(
 			[
-				Opt::RPORT(80),
 				OptInt.new('SID_MAX', [true, 'Maximum Session ID', 100])
 			], self.class)
 	end

--- a/modules/auxiliary/scanner/http/apache_userdir_enum.rb
+++ b/modules/auxiliary/scanner/http/apache_userdir_enum.rb
@@ -44,7 +44,6 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options(
 			[
-				Opt::RPORT(80),
 				OptString.new('URI', [true, 'The path to users Home Page', '/']),
 				OptPath.new('USER_FILE',  [ true, "File containing users, one per line",
 					File.join(Msf::Config.install_root, "data", "wordlists", "unix_users.txt") ]),

--- a/modules/auxiliary/scanner/http/dolibarr_login.rb
+++ b/modules/auxiliary/scanner/http/dolibarr_login.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options(
 			[
-				Opt::RPORT(80),
 				OptPath.new('USERPASS_FILE',  [ false, "File containing users and passwords separated by space, one pair per line",
 					File.join(Msf::Config.install_root, "data", "wordlists", "http_default_userpass.txt") ]),
 				OptPath.new('USER_FILE',  [ false, "File containing users, one per line",

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -41,7 +41,6 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options(
 			[
-				Opt::RPORT(80),
 				OptPath.new('USERPASS_FILE',  [ false, "File containing users and passwords separated by space, one pair per line",
 					File.join(Msf::Config.install_root, "data", "wordlists", "http_default_userpass.txt") ]),
 				OptPath.new('USER_FILE',  [ false, "File containing users, one per line",

--- a/modules/auxiliary/scanner/http/http_traversal.rb
+++ b/modules/auxiliary/scanner/http/http_traversal.rb
@@ -48,7 +48,6 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options(
 			[
-				Opt::RPORT(80),
 				OptEnum.new('METHOD',    [true, 'HTTP Request Method', 'GET', ['GET', 'POST', 'HEAD', 'PUT']]),
 				OptString.new('PATH',    [true, 'Vulnerable path. Ex: /foo/index.php?pg=', '/']),
 				OptString.new('DATA',    [false,'HTTP body data', '']),

--- a/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
@@ -42,7 +42,6 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options(
 			[
-				Opt::RPORT(80),
 				OptString.new('FILE', [ true,  "Define the remote file to view, ex:/etc/passwd", 'config.pl']),
 				OptString.new('URI', [true, 'Majordomo vulnerable URI path', '/cgi-bin/mj_wwwusr/domain=domain?user=&passw=&func=help&extra=']),
 				OptInt.new('DEPTH', [true, 'Define the max traversal depth', 8]),

--- a/modules/auxiliary/scanner/http/squiz_matrix_user_enum.rb
+++ b/modules/auxiliary/scanner/http/squiz_matrix_user_enum.rb
@@ -46,7 +46,6 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options(
 			[
-				Opt::RPORT(80),
 				OptString.new('URI', [true, 'The path to users Squiz Matrix installation', '/']),
 				OptInt.new('ASSETBEGIN',  [ true, "Asset ID to start at", 1]),
 				OptInt.new('ASSETEND',  [ true, "Asset ID to stop at", 100]),

--- a/modules/auxiliary/scanner/http/vcms_login.rb
+++ b/modules/auxiliary/scanner/http/vcms_login.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options(
 			[
-				Opt::RPORT(80),
 				OptPath.new('USERPASS_FILE',  [ false, "File containing users and passwords separated by space, one pair per line",
 					File.join(Msf::Config.install_root, "data", "wordlists", "http_default_userpass.txt") ]),
 				OptPath.new('USER_FILE',  [ false, "File containing users, one per line",

--- a/modules/auxiliary/scanner/http/wordpress_login_enum.rb
+++ b/modules/auxiliary/scanner/http/wordpress_login_enum.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Auxiliary
 		)
 
 		register_options(
-			[ Opt::RPORT(80),
+			[
 				OptString.new('URI', [false, 'Define the path to the wp-login.php file', '/wp-login.php']),
 				OptBool.new('VALIDATE_USERS', [ true, "Enumerate usernames", true ]),
 				OptBool.new('BRUTEFORCE', [ true, "Perform brute force authentication", true ]),

--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Auxiliary
 		)
 
 	register_options(
-		[ Opt::RPORT(80),
+		[
 			OptString.new('NOTES_USER', [false, 'The username to authenticate as', '']),
 			OptString.new('NOTES_PASS', [false, 'The password for the specified username' ]),
 			OptString.new('URI', [false, 'Define the path to the names.nsf file', '/names.nsf']),

--- a/modules/exploits/linux/http/linksys_apply_cgi.rb
+++ b/modules/exploits/linux/http/linksys_apply_cgi.rb
@@ -58,7 +58,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		register_options(
 			[
-				Opt::RPORT(80),
 				Opt::RHOST('192.168.1.1')
 			], self.class)
 	end

--- a/modules/exploits/multi/http/freenas_exec_raw.rb
+++ b/modules/exploits/multi/http/freenas_exec_raw.rb
@@ -49,11 +49,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Arch' => ARCH_PHP,
 			'DisclosureDate' => 'Nov 6 2010',
 			'DefaultTarget' => 0))
-
-		register_options(
-			[
-				Opt::RPORT(80),
-			], self.class)
 	end
 
 	def exploit

--- a/modules/exploits/multi/http/lcms_php_exec.rb
+++ b/modules/exploits/multi/http/lcms_php_exec.rb
@@ -55,8 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		register_options(
 		[
-			OptString.new('URI', [true, 'URI', '/lcms/']),
-			Opt::RPORT(80),
+			OptString.new('URI', [true, 'URI', '/lcms/'])
 		], self.class)
 	end
 

--- a/modules/exploits/unix/webapp/mitel_awc_exec.rb
+++ b/modules/exploits/unix/webapp/mitel_awc_exec.rb
@@ -55,7 +55,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		register_options(
 			[
-				Opt::RPORT(80),
 				OptString.new('URIPATH', [ true,  "The path to the vcs cgi-bin binary", "/awcuser/cgi-bin/vcs" ])
 			], self.class)
 	end

--- a/modules/exploits/windows/http/belkin_bulldog.rb
+++ b/modules/exploits/windows/http/belkin_bulldog.rb
@@ -52,8 +52,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DefaultTarget'  => 0,
 			'DisclosureDate' => 'Mar 8 2009'))
-
-		register_options( [ Opt::RPORT(80) ], self.class )
 	end
 
 	def exploit

--- a/modules/exploits/windows/http/coldfusion_fckeditor.rb
+++ b/modules/exploits/windows/http/coldfusion_fckeditor.rb
@@ -52,7 +52,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		register_options(
 			[
-				Opt::RPORT(80),
 				OptString.new('FCKEDITOR_DIR', [ false, 'The path to upload.cfm ', '/CFIDE/scripts/ajax/FCKeditor/editor/filemanager/connectors/cfm/upload.cfm' ]),
 			], self.class )
 	end

--- a/modules/exploits/windows/http/hp_nnm_getnnmdata_hostname.rb
+++ b/modules/exploits/windows/http/hp_nnm_getnnmdata_hostname.rb
@@ -60,8 +60,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DefaultTarget'  => 0,
 			'DisclosureDate' => 'May 11 2010'))
-
-		register_options( [ Opt::RPORT(80) ], self.class )
 	end
 
 	def exploit

--- a/modules/exploits/windows/http/hp_nnm_getnnmdata_icount.rb
+++ b/modules/exploits/windows/http/hp_nnm_getnnmdata_icount.rb
@@ -60,8 +60,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DefaultTarget'  => 0,
 			'DisclosureDate' => 'May 11 2010'))
-
-		register_options( [ Opt::RPORT(80) ], self.class )
 	end
 
 	def exploit

--- a/modules/exploits/windows/http/hp_nnm_getnnmdata_maxage.rb
+++ b/modules/exploits/windows/http/hp_nnm_getnnmdata_maxage.rb
@@ -60,8 +60,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DefaultTarget'  => 0,
 			'DisclosureDate' => 'May 11 2010'))
-
-		register_options( [ Opt::RPORT(80) ], self.class )
 	end
 
 	def exploit

--- a/modules/exploits/windows/http/hp_nnm_nnmrptconfig_nameparams.rb
+++ b/modules/exploits/windows/http/hp_nnm_nnmrptconfig_nameparams.rb
@@ -70,8 +70,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'Privileged'     => false,
 			'DisclosureDate' => "Jan 10 2011"))
-
-			register_options( [Opt::RPORT(80),], self.class )
 	end
 
 	def exploit

--- a/modules/exploits/windows/http/hp_nnm_nnmrptconfig_schdparams.rb
+++ b/modules/exploits/windows/http/hp_nnm_nnmrptconfig_schdparams.rb
@@ -55,8 +55,6 @@ class Metasploit3 < Msf::Exploit::Remote
 					}],
 				],
 			'DisclosureDate' => "Jan 10 2011"))
-
-			register_options( [Opt::RPORT(80)], self.class )
 	end
 
 	def exploit

--- a/modules/exploits/windows/http/hp_nnm_ovalarm_lang.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovalarm_lang.rb
@@ -71,8 +71,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DefaultTarget'  => 0,
 			'DisclosureDate' => 'Dec 9 2009'))
-
-		register_options( [ Opt::RPORT(80) ], self.class )
 	end
 
 	def exploit

--- a/modules/exploits/windows/http/hp_nnm_ovbuildpath_textfile.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovbuildpath_textfile.rb
@@ -82,11 +82,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DefaultTarget' => 0,
 			'DisclosureDate' => 'Nov 01 2011'))
-
-		register_options(
-			[
-				Opt::RPORT(80),
-			], self.class)
 	end
 
 	# The following code allows to migrate if having into account

--- a/modules/exploits/windows/http/hp_nnm_ovwebhelp.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovwebhelp.rb
@@ -51,8 +51,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DefaultTarget'  => 0,
 			'DisclosureDate' => 'Dec 9 2009'))
-
-		register_options( [ Opt::RPORT(80) ], self.class )
 	end
 
 	def exploit

--- a/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_main.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_main.rb
@@ -88,11 +88,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DefaultTarget'  => 0,
 			'DisclosureDate' => 'Jun 16 2010'))
-
-		register_options(
-			[
-				Opt::RPORT(80),
-			], self.class)
 	end
 
 	def exploit

--- a/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_ovutil.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_ovutil.rb
@@ -95,11 +95,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DefaultTarget'  => 0,
 			'DisclosureDate' => 'Jun 16 2010'))
-
-		register_options(
-			[
-				Opt::RPORT(80),
-			], self.class)
 	end
 
 	def exploit

--- a/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_uro.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_uro.rb
@@ -85,11 +85,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DefaultTarget'  => 0,
 			'DisclosureDate' => 'Jun 08 2010'))
-
-		register_options(
-			[
-				Opt::RPORT(80),
-			], self.class)
 	end
 
 	def exploit

--- a/modules/exploits/windows/http/hp_nnm_snmp.rb
+++ b/modules/exploits/windows/http/hp_nnm_snmp.rb
@@ -51,8 +51,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DefaultTarget'  => 0,
 			'DisclosureDate' => 'Dec 9 2009'))
-
-		register_options( [ Opt::RPORT(80) ], self.class )
 	end
 
 	def exploit

--- a/modules/exploits/windows/http/hp_nnm_snmpviewer_actapp.rb
+++ b/modules/exploits/windows/http/hp_nnm_snmpviewer_actapp.rb
@@ -91,11 +91,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DefaultTarget'  => 0,
 			'DisclosureDate' => 'May 11 2010'))
-
-		register_options(
-			[
-				Opt::RPORT(80),
-			], self.class)
 	end
 
 	def exploit

--- a/modules/exploits/windows/http/hp_nnm_toolbar_01.rb
+++ b/modules/exploits/windows/http/hp_nnm_toolbar_01.rb
@@ -51,8 +51,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DefaultTarget'  => 0,
 			'DisclosureDate' => 'Jan 7 2009'))
-
-		register_options( [ Opt::RPORT(80) ], self.class )
 	end
 
 	def exploit

--- a/modules/exploits/windows/http/hp_nnm_toolbar_02.rb
+++ b/modules/exploits/windows/http/hp_nnm_toolbar_02.rb
@@ -90,8 +90,6 @@ class Metasploit3 < Msf::Exploit::Remote
 					]
 				],
 			'DisclosureDate' => 'Jan 21 2009'))
-
-		register_options( [ Opt::RPORT(80) ], self.class )
 	end
 
 	def exploit

--- a/modules/exploits/windows/http/hp_nnm_webappmon_execvp.rb
+++ b/modules/exploits/windows/http/hp_nnm_webappmon_execvp.rb
@@ -87,11 +87,6 @@ class Metasploit3 < Msf::Exploit::Remote
 					]
 				],
 			'DisclosureDate' => 'Jul 20 2010'))
-
-		register_options(
-			[
-				Opt::RPORT(80),
-			], self.class)
 	end
 
 	def exploit

--- a/modules/exploits/windows/http/hp_nnm_webappmon_ovjavalocale.rb
+++ b/modules/exploits/windows/http/hp_nnm_webappmon_ovjavalocale.rb
@@ -100,7 +100,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 			register_options(
 				[
-					Opt::RPORT(80),
 					OptString.new('COOKIE', [ false, "The Cookie name to use", nil ]),
 					OptString.new('CGI', [ false, "The CGI to use", nil ])
 				], self.class)

--- a/modules/exploits/windows/http/hp_openview_insight_backdoor.rb
+++ b/modules/exploits/windows/http/hp_openview_insight_backdoor.rb
@@ -56,7 +56,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		register_options(
 			[
-				Opt::RPORT(80),
 				OptString.new('USERNAME', [ false, 'The username to authenticate as', 'hch908v' ]),
 				OptString.new('PASSWORD', [ false, 'The password for the specified username', 'z6t0j$+i' ])
 			], self.class )

--- a/modules/exploits/windows/http/hp_power_manager_filename.rb
+++ b/modules/exploits/windows/http/hp_power_manager_filename.rb
@@ -68,8 +68,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Privileged'      => false,
 			'DisclosureDate'  => 'Oct 19 2011',
 			'DefaultTarget'   => 0))
-
-		register_options([Opt::RPORT(80)], self.class)
 	end
 
 	def exploit

--- a/modules/exploits/windows/http/hp_power_manager_login.rb
+++ b/modules/exploits/windows/http/hp_power_manager_login.rb
@@ -53,8 +53,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DefaultTarget'  => 0,
 			'DisclosureDate' => 'Nov 4 2009'))
-
-		register_options( [ Opt::RPORT(80) ], self.class )
 	end
 
 	def exploit

--- a/modules/exploits/windows/http/ipswitch_wug_maincfgret.rb
+++ b/modules/exploits/windows/http/ipswitch_wug_maincfgret.rb
@@ -57,7 +57,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		register_options(
 			[
-				Opt::RPORT(80),
 				OptString.new('HTTPUSER', [ false, 'The username to authenticate as', 'admin']),
 				OptString.new('HTTPPASS', [ false, 'The password to authenticate as', 'admin']),
 			], self.class )

--- a/modules/exploits/windows/http/zenworks_uploadservlet.rb
+++ b/modules/exploits/windows/http/zenworks_uploadservlet.rb
@@ -62,8 +62,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DefaultTarget'  => 0,
 			'DisclosureDate' => 'Mar 30 2010'))
-
-		register_options([Opt::RPORT(80),], self.class)
 	end
 
 	def exploit

--- a/modules/exploits/windows/lotus/domino_http_accept_language.rb
+++ b/modules/exploits/windows/lotus/domino_http_accept_language.rb
@@ -109,8 +109,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 				],
 			'DisclosureDate' => 'May 20 2008'))
-
-		register_options( [ Opt::RPORT(80) ], self.class )
 	end
 
 	def exploit


### PR DESCRIPTION
Opt::RPORT(80) is already registered in the include Msf::Exploit::Remote::HttpClient so it can be removed
