### PR TITLE
Fix how some module handle send_request_* and get_once()'s nil return value

### DIFF
--- a/modules/auxiliary/admin/2wire/xslt_password_reset.rb
+++ b/modules/auxiliary/admin/2wire/xslt_password_reset.rb
@@ -54,6 +54,11 @@ class Metasploit3 < Msf::Auxiliary
 			'uri'     => '/xslt?PAGE=A07',
 		}, 25)
 
+		if not res
+			print_error("No response from server")
+			return
+		end
+
 		#check to see if we get HTTP OK
 		if (res.code == 200)
 			print_status("Okay, Got an HTTP 200 (okay) code. Verifying Server header")
@@ -114,7 +119,7 @@ class Metasploit3 < Msf::Auxiliary
 			'uri'     => '/xslt?PAGE=H04',
 		}, 25)
 
-		if ( res.code == 200 and res.body.match(/<title>System Setup - Password<\/title>/i))
+		if ( res and res.code == 200 and res.body.match(/<title>System Setup - Password<\/title>/i))
 			print_status("Found password reset page. Attempting to reset admin password to #{datastore['PASSWORD']}")
 
 			data  = 'PAGE=H04_POST'
@@ -131,7 +136,7 @@ class Metasploit3 < Msf::Auxiliary
 				'data'    => data,
 			}, 25)
 
-			if res.code == 200
+			if res and res.code == 200
 				if (res.headers['Set-Cookie'] and res.headers['Set-Cookie'].match(/(.*); path=\//))
 					cookie= $1
 					print_status("Got cookie #{cookie}. Password reset was successful!\n")

--- a/modules/auxiliary/admin/cisco/vpn_3000_ftp_bypass.rb
+++ b/modules/auxiliary/admin/cisco/vpn_3000_ftp_bypass.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Auxiliary
 	def run
 		connect
 		res = sock.get_once
-		if (res =~ /220 Session will be terminated after/)
+		if (res and res =~ /220 Session will be terminated after/)
 			print_status("Target appears to be a Cisco VPN Concentrator 3000 series.")
 
 			test = Rex::Text.rand_text_alphanumeric(8)

--- a/modules/auxiliary/admin/edirectory/edirectory_dhost_cookie.rb
+++ b/modules/auxiliary/admin/edirectory/edirectory_dhost_cookie.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Auxiliary
 			disconnect
 
 			cookie = nil
-			if(res =~ /Cookie:\s*([^\s]+)\s*/mi)
+			if(res and res =~ /Cookie:\s*([^\s]+)\s*/mi)
 				cookie = $1
 				cookie,junk = cookie.split(';')
 				name,cookie = cookie.split('=')

--- a/modules/auxiliary/admin/emc/alphastor_devicemanager_exec.rb
+++ b/modules/auxiliary/admin/emc/alphastor_devicemanager_exec.rb
@@ -56,9 +56,9 @@ class Metasploit3 < Msf::Auxiliary
 		# try to suck it all in.
 		select(nil,nil,nil,5)
 
-		res = sock.get_once
+		res = sock.get_once || ''
 
-		res.each do |info|
+		res.each_line do |info|
 			print_status("#{info.gsub(/[^[:print:]]+/,"")}") # hack.
 		end
 

--- a/modules/auxiliary/admin/hp/hp_data_protector_cmd.rb
+++ b/modules/auxiliary/admin/hp/hp_data_protector_cmd.rb
@@ -88,7 +88,7 @@ class Metasploit3 < Msf::Auxiliary
 			connect
 			sock.put(packet)
 			res = sock.get_once
-			print_status(res.to_s) if not res.empty?
+			print_status(res.to_s) if res and not res.empty?
 		rescue
 			print_error("#{rhost}:#{rport} - Unable to connect")
 		ensure

--- a/modules/auxiliary/admin/http/tomcat_administration.rb
+++ b/modules/auxiliary/admin/http/tomcat_administration.rb
@@ -96,7 +96,7 @@ class Metasploit3 < Msf::Auxiliary
 									'data'         => post_data,
 								}, 25)
 
-								if (res.code == 302)
+								if (res and res.code == 302)
 
 									res = send_request_cgi({
 										'uri'     => "/admin/",
@@ -104,7 +104,7 @@ class Metasploit3 < Msf::Auxiliary
 										'cookie'  => "JSESSIONID=#{jsessionid}",
 									}, 25)
 
-									if (res.code == 302)
+									if (res and res.code == 302)
 
 										res = send_request_cgi({
 											'uri'     => "/admin/frameset.jsp",
@@ -112,7 +112,7 @@ class Metasploit3 < Msf::Auxiliary
 											'cookie'  => "JSESSIONID=#{jsessionid}",
 										}, 25)
 
-										if (res.code == 200)
+										if (res and res.code == 200)
 											print_status("http://#{target_host}:#{rport}/admin [#{res.headers['Server']}] [#{ver}] [Tomcat Server Administration] [#{username}/#{password}]")
 										end
 

--- a/modules/auxiliary/admin/maxdb/maxdb_cons_exec.rb
+++ b/modules/auxiliary/admin/maxdb/maxdb_cons_exec.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Auxiliary
 		sock.get_once
 		sock.put(db_version)
 
-		ver = sock.get_once
+		ver = sock.get_once || ''
 
 		info = ver[27,2000]
 		if (info.length > 0)

--- a/modules/auxiliary/admin/mysql/mysql_enum.rb
+++ b/modules/auxiliary/admin/mysql/mysql_enum.rb
@@ -88,7 +88,7 @@ class Metasploit3 < Msf::Auxiliary
 		print_status("Enumerating Accounts:")
 		query = "select user, host, password from mysql.user"
 		res = mysql_query(query)
-		if res.size > 0
+		if res and res.size > 0
 			print_status("\tList of Accounts with Password Hashes:")
 			res.each do |row|
 				print_status("\t\tUser: #{row[0]} Host: #{row[1]} Password Hash: #{row[2]}")
@@ -110,7 +110,7 @@ class Metasploit3 < Msf::Auxiliary
 		end
 		query = "select user, host from mysql.user where Grant_priv = 'Y'"
 		res = mysql_query(query)
-		if res.size > 0
+		if res and res.size > 0
 			print_status("\tThe following users have GRANT Privilege:")
 			res.each do |row|
 				print_status("\t\tUser: #{row[0]} Host: #{row[1]}")
@@ -119,7 +119,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		query = "select user, host from mysql.user where Create_user_priv = 'Y'"
 		res = mysql_query(query)
-		if res.size > 0
+		if res and res.size > 0
 			print_status("\tThe following users have CREATE USER Privilege:")
 			res.each do |row|
 				print_status("\t\tUser: #{row[0]} Host: #{row[1]}")
@@ -127,7 +127,7 @@ class Metasploit3 < Msf::Auxiliary
 		end
 		query = "select user, host from mysql.user where Reload_priv = 'Y'"
 		res = mysql_query(query)
-		if res.size > 0
+		if res and res.size > 0
 			print_status("\tThe following users have RELOAD Privilege:")
 			res.each do |row|
 				print_status("\t\tUser: #{row[0]} Host: #{row[1]}")
@@ -135,7 +135,7 @@ class Metasploit3 < Msf::Auxiliary
 		end
 		query = "select user, host from mysql.user where Shutdown_priv = 'Y'"
 		res = mysql_query(query)
-		if res.size > 0
+		if res and res.size > 0
 			print_status("\tThe following users have SHUTDOWN Privilege:")
 			res.each do |row|
 				print_status("\t\tUser: #{row[0]} Host: #{row[1]}")
@@ -143,7 +143,7 @@ class Metasploit3 < Msf::Auxiliary
 		end
 		query = "select user, host from mysql.user where Super_priv = 'Y'"
 		res = mysql_query(query)
-		if res.size > 0
+		if res and res.size > 0
 			print_status("\tThe following users have SUPER Privilege:")
 			res.each do |row|
 				print_status("\t\tUser: #{row[0]} Host: #{row[1]}")
@@ -151,7 +151,7 @@ class Metasploit3 < Msf::Auxiliary
 		end
 		query = "select user, host from mysql.user where FILE_priv = 'Y'"
 		res = mysql_query(query)
-		if res.size > 0
+		if res and res.size > 0
 			print_status("\tThe following users have FILE Privilege:")
 			res.each do |row|
 				print_status("\t\tUser: #{row[0]} Host: #{row[1]}")
@@ -159,7 +159,7 @@ class Metasploit3 < Msf::Auxiliary
 		end
 		query = "select user, host from mysql.user where Process_priv = 'Y'"
 		res = mysql_query(query)
-		if res.size > 0
+		if res and res.size > 0
 			print_status("\tThe following users have PROCESS Privilege:")
 			res.each do |row|
 				print_status("\t\tUser: #{row[0]} Host: #{row[1]}")
@@ -174,7 +174,7 @@ class Metasploit3 < Msf::Auxiliary
 				(Create_priv = 'Y') or
 				(Drop_priv = 'Y')|
 		res = mysql_query(queryinmysql)
-		if res.size > 0
+		if res and res.size > 0
 			print_status("\tThe following accounts have privileges to the mysql database:")
 			res.each do |row|
 				print_status("\t\tUser: #{row[0]} Host: #{row[1]}")
@@ -185,7 +185,7 @@ class Metasploit3 < Msf::Auxiliary
 		# Anonymous Account Check
 		queryanom = "select user, host from mysql.user where user = ''"
 		res = mysql_query(queryanom)
-		if res.size > 0
+		if res and res.size > 0
 			print_status("\tAnonymous Accounts are Present:")
 			res.each do |row|
 				print_status("\t\tUser: #{row[0]} Host: #{row[1]}")
@@ -195,7 +195,7 @@ class Metasploit3 < Msf::Auxiliary
 		# Blank Password Check
 		queryblankpass = "select user, host, password from mysql.user where length(password) = 0 or password is null"
 		res = mysql_query(queryblankpass)
-		if res.size > 0
+		if res and res.size > 0
 			print_status("\tThe following accounts have empty passwords:")
 			res.each do |row|
 				print_status("\t\tUser: #{row[0]} Host: #{row[1]}")
@@ -205,7 +205,7 @@ class Metasploit3 < Msf::Auxiliary
 		# Wildcard host
 		querywildcrd = 'select user, host from mysql.user where host = "%"'
 		res = mysql_query(querywildcrd)
-		if res.size > 0
+		if res and res.size > 0
 			print_status("\tThe following accounts are not restricted by source:")
 			res.each do |row|
 				print_status("\t\tUser: #{row[0]} Host: #{row[1]}")

--- a/modules/auxiliary/admin/oracle/tnscmd.rb
+++ b/modules/auxiliary/admin/oracle/tnscmd.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Auxiliary
 			select(nil,nil,nil,0.5)
 
 			print_status("reading")
-			res = sock.get_once(-1,5)
+			res = sock.get_once(-1,5) || ''
 			res = res.tr("[\200-\377]","[\000-\177]")
 			res = res.tr("[\000-\027\]",".")
 			res = res.tr("\177",".")

--- a/modules/auxiliary/admin/sap/sap_mgmt_con_osexec.rb
+++ b/modules/auxiliary/admin/sap/sap_mgmt_con_osexec.rb
@@ -153,7 +153,7 @@ class Metasploit4 < Msf::Auxiliary
 					}
 			}, 60)
 
-			if res.code == 200
+			if res and res.code == 200
 				success = true
 				body = CGI::unescapeHTML(res.body)
 				if body.match(/<exitcode>(.*)<\/exitcode>/i)
@@ -165,7 +165,7 @@ class Metasploit4 < Msf::Auxiliary
 				if body.match(/<lines>(.*)<\/lines>/i)
 					items = body.scan(/<item>(.*?)<\/item>/i)
 				end
-			elsif res.code == 500
+			elsif res and res.code == 500
 				case res.body
 				when /<faultstring>(.*)<\/faultstring>/i
 					faultcode = "#{$1}"

--- a/modules/auxiliary/admin/zend/java_bridge.rb
+++ b/modules/auxiliary/admin/zend/java_bridge.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		print_status("Creating the Java Object 'java.lang.Runtime'")
 		sock.put(java_object)
-		res = sock.get_once()
+		res = sock.get_once() || ''
 		classid = res[5,4]
 
 		runtime =  [0x16000000].pack('V') + classid + [0x0a000000].pack('V')
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		print_status("Invoking static method 'getRuntime()'")
 		sock.put(runtime)
-		res = sock.get_once()
+		res = sock.get_once() || ''
 		methodid = res[5,4]
 
 		exec =  [0x00].pack('n') + [21 + cmd.length].pack('n') + methodid
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		print_status("Invoking method 'exec()' with parameter '#{cmd}'")
 		sock.put(exec)
-		success = sock.get_once()
+		success = sock.get_once() || ''
 		if (success =~ /\x00\x00\x00/)
 			print_status("Cleaning up the JVM")
 			rm =  [0x11000000].pack('V') + [0xffffffff].pack('V')

--- a/modules/auxiliary/dos/windows/ftp/solarftp_user.rb
+++ b/modules/auxiliary/dos/windows/ftp/solarftp_user.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Auxiliary
 	def run
 		connect
 
-		banner = sock.get_once(-1, 10)
+		banner = sock.get_once(-1, 10) || ''
 		print_status("Banner: #{banner.strip}")
 
 		buf  = Rex::Text.pattern_create(50)

--- a/modules/auxiliary/dos/windows/smtp/ms06_019_exchange.rb
+++ b/modules/auxiliary/dos/windows/smtp/ms06_019_exchange.rb
@@ -116,7 +116,7 @@ class Metasploit3 < Msf::Auxiliary
 		print_status("Sending message...")
 		sock.put(mail)
 		sock.put("QUIT\r\n")
-		print "<< " + sock.get_once
+		print "<< " + (sock.get_once || '')
 		disconnect
 	end
 

--- a/modules/auxiliary/gather/checkpoint_hostname.rb
+++ b/modules/auxiliary/gather/checkpoint_hostname.rb
@@ -55,11 +55,11 @@ class Metasploit3 < Msf::Auxiliary
 		sock.put("\x51\x00\x00\x00")
 		sock.put("\x00\x00\x00\x21")
 		res = sock.get_once(4)
-		if (res == "Y\x00\x00\x00")
+		if (res and res == "Y\x00\x00\x00")
 			print_good("Appears to be a CheckPoint Firewall...")
 			sock.put("\x00\x00\x00\x0bsecuremote\x00")
 			res = sock.get_once
-			if (res =~ /CN=(.+),O=(.+)\./i)
+			if (res and res =~ /CN=(.+),O=(.+)\./i)
 				fw_hostname = $1
 				sc_hostname = $2
 				print_good("Firewall Host: #{fw_hostname}")

--- a/modules/auxiliary/scanner/finger/finger_users.rb
+++ b/modules/auxiliary/scanner/finger/finger_users.rb
@@ -137,7 +137,7 @@ class Metasploit3 < Msf::Auxiliary
 	def finger_slurp_data
 		buff = ""
 		begin
-			while(res = sock.get_once(-1, 5))
+			while(res = sock.get_once(-1, 5) || '')
 				buff << res
 				break if buff.length > (1024*1024)
 			end

--- a/modules/auxiliary/scanner/http/frontpage_login.rb
+++ b/modules/auxiliary/scanner/http/frontpage_login.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Auxiliary
 				"Connection: Keep-Alive, TE\r\n" + "Host: #{target_host}\r\n" + "User-Agent: " +
 				datastore['UserAgent'] + "\r\n\r\n")
 
-		res = sock.get_once
+		res = sock.get_once || ''
 
 		disconnect
 

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Auxiliary
 	#
 	def get_version(res)
 		#Extract banner from response
-		banner = res.headers['Server']
+		banner = res.headers['Server'] || ''
 
 		#Default value for edition and glassfish version
 		edition = 'Commercial'

--- a/modules/auxiliary/scanner/http/http_traversal.rb
+++ b/modules/auxiliary/scanner/http/http_traversal.rb
@@ -103,7 +103,7 @@ class Metasploit3 < Msf::Auxiliary
 					req = ini_request(datastore['PATH'] + trigger + f)
 					vprint_status("Trying: http://#{rhost}:#{rport}#{req['uri']}")
 					res = send_request_cgi(req, 25)
-					return trigger if res.to_s =~ datastore['PATTERN']
+					return trigger if res and res.to_s =~ datastore['PATTERN']
 				end
 			end
 		end
@@ -182,7 +182,7 @@ class Metasploit3 < Msf::Auxiliary
 			req = ini_request(uri)
 			vprint_status("Trying: http://#{rhost}:#{rport}#{uri}")
 			res = send_request_cgi(req, 25)
-			found = true if res.to_s =~ datastore['PATTERN']
+			found = true if res and res.to_s =~ datastore['PATTERN']
 		end
 
 		# Reporting
@@ -223,7 +223,7 @@ class Metasploit3 < Msf::Auxiliary
 			vprint_status("#{res.code.to_s} for http://#{rhost}:#{rport}#{uri}")
 
 			# Only download files that are withint our interest
-			if res.to_s =~ datastore['PATTERN']
+			if res and res.to_s =~ datastore['PATTERN']
 				# We assume the string followed by the last '/' is our file name
 				fname = f.split("/")[-1].chop
 				loot = store_loot("lfi.data","text/plain",rhost, res.body,fname)
@@ -267,7 +267,7 @@ class Metasploit3 < Msf::Auxiliary
 		res = send_request_cgi(req, 25)
 
 		# Did we get it?
-		if res.body =~ /#{unique_str}/
+		if res and res.body =~ /#{unique_str}/
 			print_good("WRITE is possible on #{rhost}:#{rport}")
 		else
 			print_error("WRITE seems unlikely")

--- a/modules/auxiliary/scanner/http/netdecision_traversal.rb
+++ b/modules/auxiliary/scanner/http/netdecision_traversal.rb
@@ -62,7 +62,12 @@ class Metasploit3 < Msf::Auxiliary
 			'uri'    => uri
 		}, 25)
 
-		print_status("#{ip}:#{rport} returns: #{res.code.to_s}")
+		if res
+			print_status("#{ip}:#{rport} returns: #{res.code.to_s}")
+		else
+			print_error("#{ip}:#{rport} - No response")
+			return
+		end
 
 		if res.body.empty?
 			print_error("No file to download (empty)")

--- a/modules/auxiliary/scanner/http/sap_businessobjects_version_enum.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_version_enum.rb
@@ -88,7 +88,7 @@ class Metasploit3 < Msf::Auxiliary
 					}
 			}, 15)
 
-			if res.code == 200
+			if res and res.code == 200
 				case res.body
 				when nil
 					# Nothing

--- a/modules/auxiliary/scanner/http/sockso_traversal.rb
+++ b/modules/auxiliary/scanner/http/sockso_traversal.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		print_status("#{ip}:#{rport} returns: #{res.code.to_s}")
 
-		if res.body.empty?
+		if res and res.body.empty?
 			print_error("No file to download (empty)")
 		else
 			fname = File.basename(datastore['FILEPATH'])

--- a/modules/auxiliary/scanner/misc/ib_service_mgr_info.rb
+++ b/modules/auxiliary/scanner/misc/ib_service_mgr_info.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Auxiliary
 			'Author'	=>
 				[
 					'ramon',
-					'Adriano Lima <adriano@risesecurity.org>',
+					'Adriano Lima <adriano[at]risesecurity.org>',
 				],
 			'License'	=> MSF_LICENSE
 		)

--- a/modules/auxiliary/scanner/oracle/sid_brute.rb
+++ b/modules/auxiliary/scanner/oracle/sid_brute.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Auxiliary
 	def check_sid(sid,ip)
 		pkt = build_sid_request(sid,ip)
 		sock.put(pkt)
-		data = sock.get_once
+		data = sock.get_once || ''
 		parse_response(data)
 	end
 

--- a/modules/auxiliary/scanner/rservices/rexec_login.rb
+++ b/modules/auxiliary/scanner/rservices/rexec_login.rb
@@ -100,7 +100,7 @@ class Metasploit3 < Msf::Auxiliary
 		)
 
 		# Read the expected nul byte response.
-		buf = sock.get_once(1)
+		buf = sock.get_once(1) || ''
 		if buf != "\x00"
 			buf = sock.get_once(-1) || ""
 			vprint_error("Result: #{buf.gsub(/[[:space:]]+/, ' ')}")

--- a/modules/auxiliary/scanner/rservices/rsh_login.rb
+++ b/modules/auxiliary/scanner/rservices/rsh_login.rb
@@ -167,7 +167,7 @@ class Metasploit3 < Msf::Auxiliary
 		)
 
 		# Read the expected nul byte response.
-		buf = sock.get_once(1)
+		buf = sock.get_once(1) || ''
 		if buf != "\x00"
 			buf = sock.get_once(-1)
 			if buf.nil?

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_abaplog.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_abaplog.rb
@@ -94,9 +94,9 @@ class Metasploit4 < Msf::Auxiliary
 					}
 			}, 60)
 
-			if res.code == 200
+			if res and res.code == 200
 				success = true
-			elsif res.code == 500
+			elsif res and res.code == 500
 				case res.body
 				when /<faultstring>(.*)<\/faultstring>/i
 					faultcode = $1.strip

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_extractusers.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_extractusers.rb
@@ -103,7 +103,7 @@ class Metasploit4 < Msf::Auxiliary
 
 			env = []
 
-			if res.code == 200
+			if res and res.code == 200
 				case res.body
 				when nil
 					# Nothing
@@ -114,7 +114,7 @@ class Metasploit4 < Msf::Auxiliary
 					users = users.uniq
 					success = true
 				end
-			elsif res.code == 500
+			elsif res and res.code == 500
 				case res.body
 				when /<faultstring>(.*)<\/faultstring>/i
 					faultcode = "#{$1}"

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getaccesspoints.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getaccesspoints.rb
@@ -101,7 +101,7 @@ class Metasploit4 < Msf::Auxiliary
 			}, 30)
 
 			env = []
-			if res.code == 200
+			if res and res.code == 200
 				case res.body
 				when nil
 					# Nothing
@@ -111,7 +111,7 @@ class Metasploit4 < Msf::Auxiliary
 					env = body.scan(/<address>(.*?)<\/address><port>(.*?)<\/port><protocol>(.*?)<\/protocol><processname>(.*?)<\/processname><active>(.*?)<\/active>/i)
 					success = true
 				end
-			elsif res.code == 500
+			elsif res and res.code == 500
 				case res.body
 				when /<faultstring>(.*)<\/faultstring>/i
 					faultcode = $1.strip

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getenv.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getenv.rb
@@ -102,7 +102,7 @@ class Metasploit4 < Msf::Auxiliary
 
 			env = []
 
-			if res.code == 200
+			if res and res.code == 200
 				case res.body
 				when nil
 					# Nothing
@@ -112,7 +112,7 @@ class Metasploit4 < Msf::Auxiliary
 					env = body.scan(/<item>([^<]+)<\/item>/i)
 					success = true
 				end
-			elsif res.code == 500
+			elsif res and  res.code == 500
 				case res.body
 				when /<faultstring>(.*)<\/faultstring>/i
 					faultcode = $1.strip

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getlogfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getlogfiles.rb
@@ -112,7 +112,7 @@ class Metasploit4 < Msf::Auxiliary
 
 			env = []
 
-			if res.code == 200
+			if res and res.code == 200
 				case res.body
 				when nil
 					# Nothing
@@ -131,7 +131,7 @@ class Metasploit4 < Msf::Auxiliary
 					success = true
 				end
 
-			elsif res.code == 500
+			elsif res and res.code == 500
 				case res.body
 				when /<faultstring>(.*)<\/faultstring>/i
 					faultcode = $1.strip

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
@@ -108,7 +108,7 @@ class Metasploit4 < Msf::Auxiliary
 			}, 30)
 
 			env = []
-			if res.code == 200
+			if res and res.code == 200
 				case res.body
 				when nil
 					# Nothing
@@ -118,7 +118,7 @@ class Metasploit4 < Msf::Auxiliary
 					env = body.scan(/<filename>(.*?)<\/filename><size>(.*?)<\/size><modtime>(.*?)<\/modtime>/i)
 					success = true
 				end
-			elsif res.code == 500
+			elsif res and res.code == 500
 				case res.body
 				when /<faultstring>(.*)<\/faultstring>/i
 					faultcode = $1.strip

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_startprofile.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_startprofile.rb
@@ -100,7 +100,7 @@ class Metasploit4 < Msf::Auxiliary
 
 			env = []
 
-			if res.code == 200
+			if res and res.code == 200
 				case res.body
 				when nil
 					# Nothing
@@ -119,7 +119,7 @@ class Metasploit4 < Msf::Auxiliary
 						success = true
 				end
 
-			elsif res.code == 500
+			elsif res and res.code == 500
 				case res.body
 				when /<faultstring>(.*)<\/faultstring>/i
 					faultcode = $1.strip

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_version.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_version.rb
@@ -98,7 +98,7 @@ class Metasploit4 < Msf::Auxiliary
 					}
 			}, 15)
 
-			if res.code == 200
+			if res and res.code == 200
 				body = res.body
 				if body.match(/<VersionInfo>([^<]+)<\/VersionInfo>/)
 					version = $1
@@ -110,7 +110,7 @@ class Metasploit4 < Msf::Auxiliary
 				else
 					sapsid = "Unknown"
 				end
-			elsif res.code == 500
+			elsif res and res.code == 500
 				case res.body
 				when /<faultstring>(.*)<\/faultstring>/i
 						faultcode = $1

--- a/modules/auxiliary/scanner/vmware/vmauthd_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmauthd_login.rb
@@ -105,7 +105,7 @@ class Metasploit3 < Msf::Auxiliary
 			return ret_msg
 		end
 		nsock.put("PASS #{pass}\r\n")
-		res = nsock.get_once
+		res = nsock.get_once || ''
 		if res.start_with? "530"
 			return :failed
 		elsif res.start_with? "230"

--- a/modules/auxiliary/scanner/vmware/vmauthd_version.rb
+++ b/modules/auxiliary/scanner/vmware/vmauthd_version.rb
@@ -97,7 +97,7 @@ class Metasploit3 < Msf::Auxiliary
 			return ret_msg
 		end
 		nsock.put("PASS #{pass}\r\n")
-		res = nsock.get_once
+		res = nsock.get_once || ''
 		if res.start_with? "530"
 			return :failed
 		elsif res.start_with? "230"

--- a/modules/auxiliary/voip/asterisk_login.rb
+++ b/modules/auxiliary/voip/asterisk_login.rb
@@ -73,7 +73,7 @@ class Metasploit3 < Msf::Auxiliary
 				select(nil,nil,nil,0.4)
 			end
 			sock.put(command)
-			@result = sock.get_once
+			@result = sock.get_once || ''
 		rescue ::Exception => err
 			print_error("Error: #{err.to_s}")
 		end

--- a/modules/exploits/linux/ftp/proftp_telnet_iac.rb
+++ b/modules/exploits/linux/ftp/proftp_telnet_iac.rb
@@ -278,7 +278,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 		# NOTE: We don't care if the login failed here...
 		ret = connect
-		banner = sock.get_once
+		banner = sock.get_once || ''
 
 		# We just want the banner to check against our targets..
 		print_status("FTP Banner: #{banner.strip}")
@@ -317,7 +317,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		connect
-		banner = sock.get_once
+		banner = sock.get_once || ''
 
 		# Use a copy of the target
 		mytarget = target

--- a/modules/exploits/linux/mysql/mysql_yassl_getname.rb
+++ b/modules/exploits/linux/mysql/mysql_yassl_getname.rb
@@ -87,7 +87,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# read the mysql server hello :)
 		version = nil
-		if (buf = sock.get_once(-1, 5))
+		if (buf = sock.get_once(-1, 5) || '')
 			#print_status("\n" + Rex::Text.to_hex_dump(buf))
 			if (buf =~ /is not allowed to connect/)
 				raise RuntimeError, 'The server refused our connection!'

--- a/modules/exploits/multi/http/activecollab_chat.rb
+++ b/modules/exploits/multi/http/activecollab_chat.rb
@@ -96,13 +96,13 @@ class Metasploit3 < Msf::Exploit::Remote
 			}, 40)
 
 		# response handling
-		if res.code == 302
+		if res and res.code == 302
 			if (res.headers['Set-Cookie'] =~ /ac_ActiveCollab_sid_eaM4h3LTIZ=(.*); expires=/)
 				acsession = $1
 			end
-		elsif res.body =~ /Failed to log you in/
+		elsif res and res.body =~ /Failed to log you in/
 			print_error("#{rhost}:#{rport} Could not login to the target application as #{user}:#{pass}")
-		elsif res.code != 200 or res.code != 302
+		elsif res and res.code != 200 or res.code != 302
 			print_error("#{rhost}:#{rport} Server returned a failed status code: (#{res.code})")
 		end
 

--- a/modules/exploits/multi/http/splunk_mappy_exec.rb
+++ b/modules/exploits/multi/http/splunk_mappy_exec.rb
@@ -107,7 +107,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'method'  => 'GET'
 		}, 25)
 
-		if res.body =~ /Splunk Inc\. Splunk 4\.[0-2]\.[0-4] build [\d+]/
+		if res and res.body =~ /Splunk Inc\. Splunk 4\.[0-2]\.[0-4] build [\d+]/
 			return Exploit::CheckCode::Appears
 		else
 			return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/brightstor/lgserver_multi.rb
+++ b/modules/exploits/windows/brightstor/lgserver_multi.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		disconnect
 
-		if ( ver =~ /11.1.742/ )
+		if ( ver and ver =~ /11.1.742/ )
 				return Exploit::CheckCode::Vulnerable
 		end
 

--- a/modules/exploits/windows/brightstor/lgserver_rxrlogin.rb
+++ b/modules/exploits/windows/brightstor/lgserver_rxrlogin.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		disconnect
 
-		if ( ver =~ /11.1.742/ )
+		if ( ver and ver =~ /11.1.742/ )
 			return Exploit::CheckCode::Vulnerable
 		end
 		return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/brightstor/lgserver_rxssetdatagrowthscheduleandfilter.rb
+++ b/modules/exploits/windows/brightstor/lgserver_rxssetdatagrowthscheduleandfilter.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		disconnect
 
-		if ( ver =~ /11.1.742/ )
+		if ( ver and ver =~ /11.1.742/ )
 				return Exploit::CheckCode::Vulnerable
 		end
 

--- a/modules/exploits/windows/brightstor/lgserver_rxsuselicenseini.rb
+++ b/modules/exploits/windows/brightstor/lgserver_rxsuselicenseini.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		disconnect
 
-		if ( ver =~ /11.1.742/ )
+		if ( ver and ver =~ /11.1.742/ )
 				return Exploit::CheckCode::Vulnerable
 		end
 

--- a/modules/exploits/windows/http/sap_mgmt_con_osexec_payload.rb
+++ b/modules/exploits/windows/http/sap_mgmt_con_osexec_payload.rb
@@ -131,10 +131,10 @@ class Metasploit4 < Msf::Exploit::Remote
 						}
 				}, 60)
 
-			if (res.code != 500 and res.code != 200)
+			if (res and res.code != 500 and res.code != 200)
 				print_error("[SAP] An unknown response was received from the server")
 				abort("Invlaid server response")
-			elsif res.code == 500
+			elsif res and res.code == 500
 				body = res.body
 				if body.match(/Invalid Credentials/i)
 					print_error("[SAP] The Supplied credentials are incorrect")

--- a/modules/exploits/windows/iis/ms01_026_dbldecode.rb
+++ b/modules/exploits/windows/iis/ms01_026_dbldecode.rb
@@ -91,8 +91,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# This isn't exactly awesome, but it seems to work..
 		begin
-			headers = sock.get_once(-1, timeout)
-			body = sock.get_once(-1, timeout)
+			headers = sock.get_once(-1, timeout) || ''
+			body = sock.get_once(-1, timeout) || ''
 		rescue ::EOFError
 			# nothing
 		end

--- a/modules/exploits/windows/license/calicserv_getconfig.rb
+++ b/modules/exploits/windows/license/calicserv_getconfig.rb
@@ -77,7 +77,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		connect
 		banner = sock.get_once
 		sock.put("A0 GETCONFIG SELF 0<EOM>")
-		res = sock.get_once
+		res = sock.get_once || ''
 		disconnect
 		if (res =~ /OS\<([^\>]+)/)
 			print_status("CA License Server reports OS: #{$1}")

--- a/modules/exploits/windows/lotus/domino_icalendar_organizer.rb
+++ b/modules/exploits/windows/lotus/domino_icalendar_organizer.rb
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		connect
-		banner = sock.get_once(-1,5).chomp
+		banner = (sock.get_once(-1,5) || '').chomp
 		disconnect
 
 		if banner =~ /Lotus Domino Release 8.5/
@@ -241,7 +241,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		connect
 
 		# Get SMTP Banner
-		res = sock.get_once.chomp
+		res = (sock.get_once || '').chomp
 		print_status("Banner: #{res}")
 
 		# Check banner before trying the exploit
@@ -253,22 +253,22 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Send HELO
 		sock.put(commands[:HELO])
-		res = sock.get_once
+		res = sock.get_once || ''
 		print_status("Received: #{res.chomp}")
 
 		# Set MAIL FROM
 		sock.put(commands[:FROM])
-		res = sock.get_once
+		res = sock.get_once || ''
 		print_status("Received: #{res.chomp}")
 
 		# Set RCPT
 		sock.put(commands[:RCPT])
-		res = sock.get_once
+		res = sock.get_once || ''
 		print_status("Received: #{res.chomp}")
 
 		# Set DATA
 		sock.put(commands[:DATA])
-		res = sock.get_once
+		res = sock.get_once || ''
 		print_status("Received: #{res.chomp}")
 
 		# Send malicious data
@@ -277,7 +277,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# QUIT
 		sock.put(commands[:QUIT])
-		res = sock.get_once
+		res = sock.get_once || ''
 		print_status("Received: #{res.chomp}")
 
 		handler

--- a/modules/exploits/windows/lotus/domino_sametime_stmux.rb
+++ b/modules/exploits/windows/lotus/domino_sametime_stmux.rb
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		req << "User-Agent: Sametime Community Agent\r\n"
 		req << "Host: #{datastore['RHOST']}:#{datastore['RPORT']}\r\n"
 		sock.put(req)
-		res = sock.get_once(-1,3)
+		res = sock.get_once(-1,3) || ''
 
 		disconnect
 
@@ -85,7 +85,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			req << "User-Agent: Sametime Community Agent\r\n"
 			req << "Host: #{datastore['RHOST']}:#{datastore['RPORT']}\r\n"
 			sock.put(req)
-			res = sock.get_once(-1,3)
+			res = sock.get_once(-1,3) || ''
 
 			disconnect
 

--- a/modules/exploits/windows/pop3/seattlelab_pass.rb
+++ b/modules/exploits/windows/pop3/seattlelab_pass.rb
@@ -88,7 +88,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		print_status("Trying #{target.name} using jmp esp at #{"%.8x" % target.ret}")
 
-		banner = sock.get_once
+		banner = sock.get_once || ''
 		if banner !~ /^\+OK POP3 server (.*) ready/
 			print_error("POP3 server does not appear to be running")
 			return

--- a/modules/exploits/windows/proxy/ccproxy_telnet_ping.rb
+++ b/modules/exploits/windows/proxy/ccproxy_telnet_ping.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		connect
-		banner = sock.get_once(-1,3)
+		banner = sock.get_once(-1,3) || ''
 		disconnect
 
 		if (banner =~ /CCProxy Telnet Service Ready/)

--- a/modules/exploits/windows/proxy/qbik_wingate_wwwproxy.rb
+++ b/modules/exploits/windows/proxy/qbik_wingate_wwwproxy.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 		connect
 		sock.put("GET /\r\n\r\n") # Malformed request to get proxy info
-		banner = sock.get_once
+		banner = sock.get_once || ''
 		if (banner =~ /Server:\sWinGate\s6.1.1\s\(Build 1077\)/)
 			return Exploit::CheckCode::Vulnerable
 		end

--- a/modules/exploits/windows/scada/procyon_core_server.rb
+++ b/modules/exploits/windows/scada/procyon_core_server.rb
@@ -76,8 +76,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		connect
-		res = sock.get_once.chomp  #This gives us string "----------------------------"
-		res = sock.get_once.chomp  #This gives us the actual software version
+		res = (sock.get_once || '').chomp  #This gives us string "----------------------------"
+		res = (sock.get_once || '').chomp  #This gives us the actual software version
 		disconnect
 
 		if res =~ /Core Command Interface V1\.(.*)2/

--- a/modules/exploits/windows/smtp/mailcarrier_smtp_ehlo.rb
+++ b/modules/exploits/windows/smtp/mailcarrier_smtp_ehlo.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		connect
-		banner = sock.get_once(-1,3)
+		banner = sock.get_once(-1,3) || ''
 		disconnect
 
 		if (banner =~ /ESMTP TABS Mail Server for Windows NT/)

--- a/modules/exploits/windows/smtp/ms03_046_exchange2000_xexch50.rb
+++ b/modules/exploits/windows/smtp/ms03_046_exchange2000_xexch50.rb
@@ -71,7 +71,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		connect
-		banner = sock.get_once
+		banner = sock.get_once || ''
 
 		if (banner !~ /Microsoft/)
 			print_status("Target does not appear to be an Exchange server.")
@@ -79,20 +79,20 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		sock.put("EHLO #{Rex::Text.rand_text_alpha(1)}\r\n")
-		res = sock.get_once
+		res = sock.get_once || ''
 		if (res !~ /XEXCH50/)
 			print_status("Target does not appear to be an Exchange server.")
 			return Exploit::CheckCode::Safe
 		end
 		sock.put("MAIL FROM: #{datastore['MAILFROM']}\r\n")
-		res = sock.get_once
+		res = sock.get_once || ''
 
 		if (res =~ /Sender OK/)
 			sock.put("RCPT TO: #{datastore['MAILTO']}\r\n")
-			res = sock.get_once
+			res = sock.get_once || ''
 			if (res =~ /250/)
 				sock.put("XEXCH50 2 2\r\n")
-				res = sock.get_once
+				res = sock.get_once || ''
 				if (res !~ /Send binary data/)
 					print_error("Target has been patched!")
 					return Exploit::CheckCode::Detected
@@ -110,7 +110,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		connect
 		select(nil,nil,nil,1)
-		banner = sock.get_once
+		banner = sock.get_once || ''
 		print_status("Connected to SMTP server: #{banner.to_s}")
 
 		if (banner !~ /Microsoft/)
@@ -121,7 +121,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		select(nil,nil,nil,5)
 		sock.put("EHLO X\r\n")
 		select(nil,nil,nil,7)
-		res = sock.get_once
+		res = sock.get_once || ''
 
 		if (res !~ /XEXCH50/)
 			print_status("Target is not running Exchange.")
@@ -187,7 +187,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 				sock.put("XEXCH50 -1 2\r\n") # Allocate negative value
 				select(nil,nil,nil,2)
-				res = sock.get_once
+				res = sock.get_once || ''
 
 				if (!res)
 					print_error("Error - no response")

--- a/modules/exploits/windows/ssh/sysax_ssh_username.rb
+++ b/modules/exploits/windows/ssh/sysax_ssh_username.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 		begin
 			connect
-			banner = sock.get_once(-1,5)
+			banner = sock.get_once(-1,5) || ''
 			disconnect
 			if banner =~ /SSH\-2\.0\-SysaxSSH_1\.0/
 				return Exploit::CheckCode::Vulnerable

--- a/modules/exploits/windows/telnet/gamsoft_telsrv_username.rb
+++ b/modules/exploits/windows/telnet/gamsoft_telsrv_username.rb
@@ -91,7 +91,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		connect
 		print_status("Attempting to determine if target is vulnerable...")
 		select(nil,nil,nil,7)
-		banner = sock.get_once(-1,3)
+		banner = sock.get_once(-1,3) || ''
 
 		if (banner =~ /TelSrv 1\.5/)
 			return Exploit::CheckCode::Vulnerable

--- a/modules/exploits/windows/unicenter/cam_log_security.rb
+++ b/modules/exploits/windows/unicenter/cam_log_security.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		connect
-		ack = sock.get_once
+		ack = sock.get_once || ''
 		disconnect
 
 		(ack == "ACK\x00") ? Exploit::CheckCode::Detected : Exploit::CheckCode::Safe

--- a/modules/post/multi/gather/enum_vbox.rb
+++ b/modules/post/multi/gather/enum_vbox.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Post
 
 	def run
 		if session.platform =~ /win/
-			res = session.shell_command_token_win32('"c:\Program Files\Oracle\VirtualBox\vboxmanage" list -l vms')
+			res = session.shell_command_token_win32('"c:\Program Files\Oracle\VirtualBox\vboxmanage" list -l vms') || ''
 			if res.include? "The system cannot find the path specified"
 				print_error "VirtualBox does not appear to be installed on this machine"
 				return nil


### PR DESCRIPTION
When using send_reques_\* and get_once, some modules don't pay attention to the fact they might return a nil (due to a timeout, for example), which may cause some kind of 'undefined method for NilClass' bug at runtime.
