### PR TITLE
Correct emails for aux and exploit modules

### DIFF
--- a/modules/auxiliary/dos/solaris/lpd/cascade_delete.rb
+++ b/modules/auxiliary/dos/solaris/lpd/cascade_delete.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Auxiliary
 				system files. Tested on Solaris 2.6, 7, 8, 9, and 10.
 
 			},
-			'Author'         => [ 'hdm', 'Optyx <optyx@uberhax0r.net>' ],
+			'Author'         => [ 'hdm', 'Optyx <optyx[at]uberhax0r.net>' ],
 			'License'        => MSF_LICENSE,
 			'Version'        => '$Revision$',
 			'References'     =>

--- a/modules/auxiliary/scanner/snmp/aix_version.rb
+++ b/modules/auxiliary/scanner/snmp/aix_version.rb
@@ -25,7 +25,7 @@ class Metasploit3 < Msf::Auxiliary
 			'Description' => 'AIX SNMP Scanner Auxiliary Module',
 			'Author'      =>
 				[
-					'Adriano Lima <adriano@risesecurity.org>',
+					'Adriano Lima <adriano[at]risesecurity.org>',
 					'ramon'
 				],
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/snmp/cisco_config_tftp.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_config_tftp.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'      =>
 				[
-					'pello <fropert@packetfault.org>', 'hdm'
+					'pello <fropert[at]packetfault.org>', 'hdm'
 				],
 			'License'     => MSF_LICENSE
 		)

--- a/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Auxiliary
 				},
 			'Author'      =>
 				[
-					'pello <fropert@packetfault.org>'
+					'pello <fropert[at]packetfault.org>'
 				],
 			'License'     => MSF_LICENSE
 		)

--- a/modules/auxiliary/spoof/nbns/nbns_response.rb
+++ b/modules/auxiliary/spoof/nbns/nbns_response.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Auxiliary
 
 					This module must be run as root and will bind to tcp/137 on all interfaces.
 			},
-			'Author'     => [ 'Tim Medin <tim@securitywhole.com>' ],
+			'Author'     => [ 'Tim Medin <tim[at]securitywhole.com>' ],
 			'License'    => MSF_LICENSE,
 			'Version'    => '$Revision$',
 			'References' =>

--- a/modules/auxiliary/voip/sip_invite_spoof.rb
+++ b/modules/auxiliary/voip/sip_invite_spoof.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Auxiliary
 			'Name'           => 'SIP Invite Spoof',
 			'Version'        => '$Revision$',
 			'Description'    => 'This module will create a fake SIP invite request making the targeted device ring and display fake caller id information.',
-			'Author'         => 'David Maynor <dave@erratasec.com>',
+			'Author'         => 'David Maynor <dave[at]erratasec.com>',
 			'License'        =>  MSF_LICENSE
 		)
 


### PR DESCRIPTION
Some modules still use @ instead of [at].
