### PR TITLE
Aux Module - interface_fingerprinter

### DIFF
--- a/data/interface_fingerprints/cameras.yml
+++ b/data/interface_fingerprints/cameras.yml
@@ -1,0 +1,151 @@
+# See readme.yml for the parameter information
+
+# Network Cameras, DVRs, and VOIP
+- title: GeoHttpServer Webcam
+  fingerprint_page: [/, /index.html]
+  post_to: /phoneinfo
+  fingerprint: action="phoneinfo" method="POST"
+  login_params: $$$user$$$&pwd=$$$pass$$$&ImageType=1&send=Submit
+  creds: admin:admin
+  success: $$$$TODO$$$$
+  # need success string
+
+- title: DTT OnSite Camera
+  fingerprint_page: [/, /index.html]
+  fingerprint: (IDS_WEB_WEBCAM_LOGIN|IDS_WEB_ID)
+  post_to: /webcam_login
+  login_params: id=$$$user$$$&pwd=$$$pass$$$&x=12&y=20
+  creds: admin:admin
+  success: $$$$TODO$$$$
+  # need success string
+
+- title: Samsung DVR
+  fingerprint_page: /webviewer.js
+  post_to: /webviewer.js
+  fingerprint: (GoAhead-Webs)(.)+(?!Samsung DVR)+
+  basic_auth: true
+  creds: admin:4321
+  success: writeObjCtr
+
+- title: Unknown GeoHttpServer Webcam
+  fingerprint_page: /Language.js
+  fingerprint: IDS_WEB_SUBMIT
+  post_to: /password
+  login_params: id=$$$user$$$&pwd=$$$pass$$$&send=Submit
+  success: $$$$TODO$$$$
+  creds: admin:admin
+  # need success string
+
+- title: Vilar IPCamera Login
+  fingerprint_page:  /chs/setup/
+  fingerprint: <title>Vilar IPCamera Login
+  creds: admin:123456
+  basic_auth: true
+
+- title: SQ Webcam
+  fingerprint_page: /index.htm
+  fingerprint: SQ-WEBCAM
+  post_to: /home.htm
+  login_params: username=$$$user$$$&password=$$$pass$$$&Submit=Submit
+  success: OnClick="DeviceConnect
+  creds: admin:admin
+
+- title: SMC Network Camera Manager
+  fingerprint_page: /index.html
+  fingerprint: Ipcam manager
+  basic_auth: true
+  creds: admin:null
+
+- title: Softwell Wit-eye
+  fingerprint_page: /cgi-bin/login.cgi
+  fingerprint: <title>DVR Remote
+  creds: admin:admin
+  success: (<frame src|/cgi-bin/common.cgi)
+  login_params: name=$$$user$$$&password=$$$pass$$$&login=1&logout=
+  
+- title: Tandberg RX8000
+  fingerprint_page: [/, /index.html]
+  fingerprint: RX8000
+  basic_auth: true
+  creds:  [tandberg:tandberg, admin:admin, tandberg:null]
+
+# this needs a better success string
+- title: Vivotek Networki Camera Unauthenticated
+  fingerprint_page: [/, /index.html]
+  fingerprint: Vivotek Network
+  creds: nocreds:nocreds
+
+- title: VPort Video Server
+  fingerprint_page: /
+  fingerprint: (VPort [0-9]* Video Server)
+  basic_auth: true
+  creds: root:null
+  # actually the default password is the mac but no programitic way to do this
+
+- title: VPort Video Server Unauthenticated
+  fingerprint_page: /basicinfo.asp
+  fingerprint: (Model Name)(.)+(VPort [0-9]*)+
+  creds: nocreds:nocreds
+
+- title: Tivo Unauthenticated
+  fingerprint_page: /index.html
+  fingerprint: (<title>TiVo DVR</title>|<title>Congratulations!</title>)(.)+(successfully connected your TiVo)+
+  creds: nocreds:nocreds
+
+- title: Tandberg TT Series Unauthenticated
+  fingerprint_page: /tcf?cgi=show&%24path=/Status
+  fingerprint: (Name</td>)(.)+(TT[0-9]*)+
+  creds: nocreds:nocreds
+
+- title: Harmonic Divicom Ion Unauthenticated
+  fingerprint_page: /cgi-bin/sag2/?page_non_xml=Home.html
+  fingerprint: (idAlarmHistory)(.)+(idRebuildPsi)+
+  creds: nocreds:nocreds
+  
+- title: AxisTV Digital Signage Software
+  fingerprint_page: /Welcome.aspx
+  post_to: /Default.aspx
+  fingerprint: (<title>AxisTV</title>)
+  creds: [administrator:tech, axistvuser:TechTech1!]
+  login_params: userId=$$$user$$$&password=$$$pass$$$&login=+++++++++++++++++++++++++
+  success: (Welcome)(.)+(Media Bulletin)+(.)
+  hidden_id: [__VIEWSTATE, __EVENTVALIDATION]
+
+- title: DCS DLink Camera Unauthenticated
+  fingerprint_page: /top.htm?Currenttime=
+  fingerprint: (fast ethernet internet camera)
+  creds: nocreds:nocreds
+
+- title: Embedded Device (likely Camera) Unauthenticated
+  fingerprint_page: /
+  fingerprint: (Auther(.)+(Steven Wu)+)
+  creds: nocreds:nocreds
+
+- title: CS-XX Camera Unauthenticated
+  fingerprint_page: /top.htm?Currenttime=
+  fingerprint: (welcome to the internet camera)
+  creds: nocreds:nocreds
+
+- title: DCS Dlink Camera
+  fingerprint_page: /
+  fingerprint: (Basic realm(.)+(DCS-)+)
+  creds: [admin:null, admin:admin, admin:password, admin:dlink]
+  basic_auth: true
+
+- title: Polycom Soundpoint IP Telephone Configuration Unauthenticated
+  fingerprint_page: /
+  fingerprint: (Welcome to the SoundPoint IP Configuration Utility)
+  creds: nocreds:nocreds
+
+- title: Polycom Soundpoint IP Telephone Configuration
+  fingerprint_page: /netConf.htm
+  fingerprint: (Polycom SoundPoint IP Telephone HTTPd)
+  success: (802.1Q User Priority(.)+(RTP Port)+)
+  creds: Polycom:456
+  basic_auth: true
+
+- title: LG DVR Server Unauthenticated
+  fingerprint_page: /dvr/wwwroot/login.cgi
+  fingerprint: ((<!-- PTZ -->)(.)+(<!-- Play controls -->)+)
+  creds: nocreds:nocreds
+

--- a/data/interface_fingerprints/cameras.yml
+++ b/data/interface_fingerprints/cameras.yml
@@ -2,150 +2,208 @@
 
 # Network Cameras, DVRs, and VOIP
 - title: GeoHttpServer Webcam
-  fingerprint_page: [/, /index.html]
+  fingerprint_page:
+    - /
+    - /index.html
   post_to: /phoneinfo
   fingerprint: action="phoneinfo" method="POST"
   login_params: $$$user$$$&pwd=$$$pass$$$&ImageType=1&send=Submit
-  creds: admin:admin
+  creds:
+    - admin:admin
   success: $$$$TODO$$$$
   # need success string
 
 - title: DTT OnSite Camera
-  fingerprint_page: [/, /index.html]
+  fingerprint_page:
+    - /
+    - /index.html
   fingerprint: (IDS_WEB_WEBCAM_LOGIN|IDS_WEB_ID)
   post_to: /webcam_login
   login_params: id=$$$user$$$&pwd=$$$pass$$$&x=12&y=20
-  creds: admin:admin
+  creds:
+    - admin:admin
   success: $$$$TODO$$$$
   # need success string
 
 - title: Samsung DVR
-  fingerprint_page: /webviewer.js
+  fingerprint_page:
+    - /webviewer.js
   post_to: /webviewer.js
   fingerprint: (GoAhead-Webs)(.)+(?!Samsung DVR)+
   basic_auth: true
-  creds: admin:4321
+  creds:
+    - admin:4321
   success: writeObjCtr
 
 - title: Unknown GeoHttpServer Webcam
-  fingerprint_page: /Language.js
+  fingerprint_page:
+    - /Language.js
   fingerprint: IDS_WEB_SUBMIT
   post_to: /password
   login_params: id=$$$user$$$&pwd=$$$pass$$$&send=Submit
   success: $$$$TODO$$$$
-  creds: admin:admin
+  creds:
+    - admin:admin
   # need success string
 
 - title: Vilar IPCamera Login
-  fingerprint_page:  /chs/setup/
+  fingerprint_page:
+    - /chs/setup/
   fingerprint: <title>Vilar IPCamera Login
-  creds: admin:123456
+  creds:
+    - admin:123456
   basic_auth: true
 
 - title: SQ Webcam
-  fingerprint_page: /index.htm
+  fingerprint_page:
+    - /index.htm
   fingerprint: SQ-WEBCAM
   post_to: /home.htm
   login_params: username=$$$user$$$&password=$$$pass$$$&Submit=Submit
   success: OnClick="DeviceConnect
-  creds: admin:admin
+  creds:
+    - admin:admin
 
 - title: SMC Network Camera Manager
-  fingerprint_page: /index.html
+  fingerprint_page:
+    - /index.html
   fingerprint: Ipcam manager
   basic_auth: true
-  creds: admin:null
+  creds:
+    - admin:null
 
 - title: Softwell Wit-eye
-  fingerprint_page: /cgi-bin/login.cgi
+  fingerprint_page:
+    - /cgi-bin/login.cgi
   fingerprint: <title>DVR Remote
-  creds: admin:admin
+  creds:
+    - admin:admin
   success: (<frame src|/cgi-bin/common.cgi)
   login_params: name=$$$user$$$&password=$$$pass$$$&login=1&logout=
   
 - title: Tandberg RX8000
-  fingerprint_page: [/, /index.html]
+  fingerprint_page:
+    - /
+    - /index.html
   fingerprint: RX8000
   basic_auth: true
-  creds:  [tandberg:tandberg, admin:admin, tandberg:null]
+  creds:
+    - tandberg:tandberg
+    - admin:admin
+    - tandberg:null
 
 # this needs a better success string
 - title: Vivotek Networki Camera Unauthenticated
-  fingerprint_page: [/, /index.html]
+  fingerprint_page:
+    - /
+    - /index.html
   fingerprint: Vivotek Network
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
 
 - title: VPort Video Server
-  fingerprint_page: /
+  fingerprint_page:
+    - /
   fingerprint: (VPort [0-9]* Video Server)
   basic_auth: true
-  creds: root:null
+  creds:
+    - root:null
   # actually the default password is the mac but no programitic way to do this
 
 - title: VPort Video Server Unauthenticated
-  fingerprint_page: /basicinfo.asp
+  fingerprint_page:
+    - /basicinfo.asp
   fingerprint: (Model Name)(.)+(VPort [0-9]*)+
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
 
 - title: Tivo Unauthenticated
-  fingerprint_page: /index.html
+  fingerprint_page:
+    - /index.html
   fingerprint: (<title>TiVo DVR</title>|<title>Congratulations!</title>)(.)+(successfully connected your TiVo)+
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
 
 - title: Tandberg TT Series Unauthenticated
-  fingerprint_page: /tcf?cgi=show&%24path=/Status
+  fingerprint_page:
+    - /tcf?cgi=show&%24path=/Status
   fingerprint: (Name</td>)(.)+(TT[0-9]*)+
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
 
 - title: Harmonic Divicom Ion Unauthenticated
-  fingerprint_page: /cgi-bin/sag2/?page_non_xml=Home.html
+  fingerprint_page:
+    - /cgi-bin/sag2/?page_non_xml=Home.html
   fingerprint: (idAlarmHistory)(.)+(idRebuildPsi)+
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
   
 - title: AxisTV Digital Signage Software
-  fingerprint_page: /Welcome.aspx
+  fingerprint_page:
+    - /Welcome.aspx
   post_to: /Default.aspx
   fingerprint: (<title>AxisTV</title>)
-  creds: [administrator:tech, axistvuser:TechTech1!]
+  creds:
+    - administrator:tech
+    - axistvuser:TechTech1!
   login_params: userId=$$$user$$$&password=$$$pass$$$&login=+++++++++++++++++++++++++
   success: (Welcome)(.)+(Media Bulletin)+(.)
-  hidden_id: [__VIEWSTATE, __EVENTVALIDATION]
+  hidden_id:
+    - __VIEWSTATE
+    - __EVENTVALIDATION
 
 - title: DCS DLink Camera Unauthenticated
-  fingerprint_page: /top.htm?Currenttime=
+  fingerprint_page:
+    - /top.htm?Currenttime=
   fingerprint: (fast ethernet internet camera)
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
 
 - title: Embedded Device (likely Camera) Unauthenticated
-  fingerprint_page: /
+  fingerprint_page:
+    - /
   fingerprint: (Auther(.)+(Steven Wu)+)
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
 
 - title: CS-XX Camera Unauthenticated
-  fingerprint_page: /top.htm?Currenttime=
+  fingerprint_page:
+    - /top.htm?Currenttime=
   fingerprint: (welcome to the internet camera)
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
 
 - title: DCS Dlink Camera
-  fingerprint_page: /
+  fingerprint_page:
+    - /
   fingerprint: (Basic realm(.)+(DCS-)+)
-  creds: [admin:null, admin:admin, admin:password, admin:dlink]
+  creds:
+    - admin:null
+    - admin:admin
+    - admin:password
+    - admin:dlink
   basic_auth: true
 
 - title: Polycom Soundpoint IP Telephone Configuration Unauthenticated
-  fingerprint_page: /
+  fingerprint_page:
+    - /
   fingerprint: (Welcome to the SoundPoint IP Configuration Utility)
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
 
 - title: Polycom Soundpoint IP Telephone Configuration
-  fingerprint_page: /netConf.htm
+  fingerprint_page:
+    - /netConf.htm
   fingerprint: (Polycom SoundPoint IP Telephone HTTPd)
   success: (802.1Q User Priority(.)+(RTP Port)+)
-  creds: Polycom:456
+  creds:
+    - Polycom:456
   basic_auth: true
 
 - title: LG DVR Server Unauthenticated
-  fingerprint_page: /dvr/wwwroot/login.cgi
+  fingerprint_page:
+    - /dvr/wwwroot/login.cgi
   fingerprint: ((<!-- PTZ -->)(.)+(<!-- Play controls -->)+)
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
 

--- a/data/interface_fingerprints/enterprise.yml
+++ b/data/interface_fingerprints/enterprise.yml
@@ -1,0 +1,69 @@
+# See readme.yml for the parameter information
+# Enterprise focused products
+
+- title: McAffee EPO
+  fingerprint_page: /core/orionSplashScreen.do
+  fingerprint: (EPOCore/images/mcafee)
+  post_to: /core/j_security_check
+  creds: [mcafee:mcafee]
+  login_params: j_username=$$$user$$$&j_password=$$$pass$$$
+  success: (core/images/spinner.gif)
+  res_code: 408
+
+# Password Management
+- title: Secret Server
+  fingerprint_page: /ss/Login.aspx
+  fingerprint: (thycotic.com)
+  post_to: /ss/Login.aspx
+  creds: [secret:secret]
+  login_params: LoginUserControl1%24UserNameTextBox=$$$user$$$&LoginUserControl1%24PasswordTextBox=$$$pass$$$&LoginUserControl1%24DomainDropDownList=0&LoginUserControl1%24AcceptPolicyCheckBox=on&LoginUserControl1%24LoginButton=Login&LoginUserControl1%24LoginDialog_IsCollapsed=0  
+  success: (/ss/default.aspx)
+  res_code: 302
+  hidden_id: [__VIEWSTATE, __EVENTVALIDATION, __SCROLLPOSITIONX, __SCROLLPOSITIONY]
+
+# Mobile Device Management
+- title: Good Mobile Device Management
+  fingerprint_page: /login.do
+  fingerprint: (Sign in to Good Mobile Control)
+  post_to: /login.do
+  creds: [good:good]
+  login_params: command=login&username=$$$user$$$&password=$$$pass$$$&domain=$$$domain$$$
+  success: (home.do)
+  res_code: 302
+
+# Based on owa_login
+- title: Outlook Web Access 2010
+  fingerprint_page: /owa/auth/logon.aspx
+  fingerprint: (OutlookSession)
+  post_to: /owa/auth.owa
+  follow_302: true
+  cookie: PBack=0; owacsdc=1
+  login_headers: { Content-Type: application/x-www-form-urlencoded }
+  login_params: destination=https%3A%2F%2F$$$vhost$$$%2Fowa%2F&flags=0&forcedownlevel=0&trusted=0&username=$$$domain$$$\$$$user$$$&password=$$$pass$$$&isUtf8=1
+  success: (Junk)
+  
+# Based on owa_login, untested
+- title: Outlook Web Access 2007
+  fingerprint_page: /owa/auth/owaauth.dll
+  fingerprint: (OutlookSession)
+  follow_302: true
+  cookie: PBack=0; 
+  login_headers: { Content-Type: application/x-www-form-urlencoded }
+  login_params: destination=https%3A%2F%2F$$$vhost$$$%2Fowa%2F&flags=0&forcedownlevel=0&trusted=0&username=$$$domain$$$\$$$user$$$&password=$$$pass$$$&isUtf8=1
+  success: (addrbook.gif)
+
+# Based on owa_login, untested
+- title: Outlook Web Access 2003
+  fingerprint_page: /exchweb/bin/auth/owaauth.dll
+  fingerprint: (OutlookSession)
+  follow_302: true
+  cookie: PBack=0; 
+  login_headers: { Content-Type: application/x-www-form-urlencoded }
+  login_params: destination=https%3A%2F%2F$$$vhost$$$%2Fowa%2F&flags=0&forcedownlevel=0&trusted=0&username=$$$domain$$$\$$$user$$$&password=$$$pass$$$&isUtf8=1
+  success: (Inbox)
+
+# This needs a correct fingerprint
+- title: SeaGate BlackArmor Backdoor Unauthenticated
+  fingerprint_page: /d41d8cd98f00b204e9800998ecf8427e.php
+  fingerprint: (admin)
+  creds: nocreds:nocreds

--- a/data/interface_fingerprints/enterprise.yml
+++ b/data/interface_fingerprints/enterprise.yml
@@ -2,68 +2,86 @@
 # Enterprise focused products
 
 - title: McAffee EPO
-  fingerprint_page: /core/orionSplashScreen.do
+  fingerprint_page:
+    - /core/orionSplashScreen.do
   fingerprint: (EPOCore/images/mcafee)
   post_to: /core/j_security_check
-  creds: [mcafee:mcafee]
+  creds:
+    - mcafee:mcafee
   login_params: j_username=$$$user$$$&j_password=$$$pass$$$
   success: (core/images/spinner.gif)
   res_code: 408
 
 # Password Management
 - title: Secret Server
-  fingerprint_page: /ss/Login.aspx
+  fingerprint_page:
+    - /ss/Login.aspx
   fingerprint: (thycotic.com)
   post_to: /ss/Login.aspx
-  creds: [secret:secret]
+  creds:
+    - secret:secret
   login_params: LoginUserControl1%24UserNameTextBox=$$$user$$$&LoginUserControl1%24PasswordTextBox=$$$pass$$$&LoginUserControl1%24DomainDropDownList=0&LoginUserControl1%24AcceptPolicyCheckBox=on&LoginUserControl1%24LoginButton=Login&LoginUserControl1%24LoginDialog_IsCollapsed=0  
   success: (/ss/default.aspx)
   res_code: 302
-  hidden_id: [__VIEWSTATE, __EVENTVALIDATION, __SCROLLPOSITIONX, __SCROLLPOSITIONY]
+  hidden_id:
+    - __VIEWSTATE
+    - __EVENTVALIDATION
+    - __SCROLLPOSITIONX
+    - __SCROLLPOSITIONY
 
 # Mobile Device Management
 - title: Good Mobile Device Management
-  fingerprint_page: /login.do
+  fingerprint_page:
+    - /login.do
   fingerprint: (Sign in to Good Mobile Control)
   post_to: /login.do
-  creds: [good:good]
+  creds:
+    - good:good
   login_params: command=login&username=$$$user$$$&password=$$$pass$$$&domain=$$$domain$$$
   success: (home.do)
   res_code: 302
 
 # Based on owa_login
 - title: Outlook Web Access 2010
-  fingerprint_page: /owa/auth/logon.aspx
+  fingerprint_page:
+    - /owa/auth/logon.aspx
   fingerprint: (OutlookSession)
   post_to: /owa/auth.owa
   follow_302: true
   cookie: PBack=0; owacsdc=1
-  login_headers: { Content-Type: application/x-www-form-urlencoded }
+  login_headers:
+    - Content-Type:application/x-www-form-urlencoded 
   login_params: destination=https%3A%2F%2F$$$vhost$$$%2Fowa%2F&flags=0&forcedownlevel=0&trusted=0&username=$$$domain$$$\$$$user$$$&password=$$$pass$$$&isUtf8=1
   success: (Junk)
   
 # Based on owa_login, untested
 - title: Outlook Web Access 2007
-  fingerprint_page: /owa/auth/owaauth.dll
+  fingerprint_page:
+    - /owa/auth/owaauth.dll
   fingerprint: (OutlookSession)
   follow_302: true
   cookie: PBack=0; 
-  login_headers: { Content-Type: application/x-www-form-urlencoded }
+  login_headers:
+    - Content-Type:application/x-www-form-urlencoded
   login_params: destination=https%3A%2F%2F$$$vhost$$$%2Fowa%2F&flags=0&forcedownlevel=0&trusted=0&username=$$$domain$$$\$$$user$$$&password=$$$pass$$$&isUtf8=1
   success: (addrbook.gif)
 
 # Based on owa_login, untested
 - title: Outlook Web Access 2003
-  fingerprint_page: /exchweb/bin/auth/owaauth.dll
+  fingerprint_page:
+    - /exchweb/bin/auth/owaauth.dll
   fingerprint: (OutlookSession)
   follow_302: true
   cookie: PBack=0; 
-  login_headers: { Content-Type: application/x-www-form-urlencoded }
+  login_headers:
+    - Content-Type:application/x-www-form-urlencoded
   login_params: destination=https%3A%2F%2F$$$vhost$$$%2Fowa%2F&flags=0&forcedownlevel=0&trusted=0&username=$$$domain$$$\$$$user$$$&password=$$$pass$$$&isUtf8=1
   success: (Inbox)
 
 # This needs a correct fingerprint
 - title: SeaGate BlackArmor Backdoor Unauthenticated
-  fingerprint_page: /d41d8cd98f00b204e9800998ecf8427e.php
+  fingerprint_page:
+    - /d41d8cd98f00b204e9800998ecf8427e.php
   fingerprint: (admin)
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds

--- a/data/interface_fingerprints/industrial.yml
+++ b/data/interface_fingerprints/industrial.yml
@@ -1,0 +1,40 @@
+# See readme.yml for the parameter information
+
+# Industrial Control
+- title: Rockwell Automation PLC SLC-5/05
+  fingerprint: 1747-L551
+  fingerprint_page: /user.html
+  creds: nocreds:nocreds
+
+- title: Liebert UPS Unauthenticated
+  fingerprint_page: [/, /index.html]
+  fingerprint: <title>(UPS Monitor|Liebert)
+  creds: nocreds:nocreds
+
+# serial adapter
+- title: Moxa NPort Console Unauthenticated
+  fingerprint_page: /02.htm
+  fingerprint: (<title>Network Settings<\/title>)(.)+(Community Name)+(.)+(SnmpCommunity)+
+  creds: nocreds:nocreds
+
+# serial adapter
+- title: Moxa NPort Console
+  fingerprint_page: /
+  post_to: /main.htm
+  fingerprint: (<title>NPort Web Console<\/title>)(.)+(numofserialports)+
+  login_params: Username=$$$user$$$&Password=$$$pass$$$&MD5Password=&Submit=Login
+  success: (Model name)(.)+(Ethernet)+
+  creds: admin:null
+  hidden_id: [FakeChallenge,Submit.x,Submit.y]
+
+# serial adapter
+- title: Lantronix MSS Unauthenticated
+  fingerprint_page: /
+  fingerprint: (<title>Lantronix)(.)+(netware_mss)+
+  creds: nocreds:nocreds
+
+# serial adapter
+- title: Lantronix UDS Unauthenticated
+  fingerprint_page: /secure/welcome.htm
+  fingerprint: (<title>Lantronix)(.)+(uds)+(.)+(Device Server Configuration Manager)+
+  creds: nocreds:nocreds

--- a/data/interface_fingerprints/industrial.yml
+++ b/data/interface_fingerprints/industrial.yml
@@ -3,38 +3,54 @@
 # Industrial Control
 - title: Rockwell Automation PLC SLC-5/05
   fingerprint: 1747-L551
-  fingerprint_page: /user.html
-  creds: nocreds:nocreds
+  fingerprint_page:
+    - /user.html
+  creds:
+    - nocreds:nocreds
 
 - title: Liebert UPS Unauthenticated
-  fingerprint_page: [/, /index.html]
+  fingerprint_page:
+    - /
+    - /index.html
   fingerprint: <title>(UPS Monitor|Liebert)
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
 
 # serial adapter
 - title: Moxa NPort Console Unauthenticated
-  fingerprint_page: /02.htm
+  fingerprint_page:
+    - /02.htm
   fingerprint: (<title>Network Settings<\/title>)(.)+(Community Name)+(.)+(SnmpCommunity)+
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
 
 # serial adapter
 - title: Moxa NPort Console
-  fingerprint_page: /
+  fingerprint_page:
+    - /
   post_to: /main.htm
   fingerprint: (<title>NPort Web Console<\/title>)(.)+(numofserialports)+
   login_params: Username=$$$user$$$&Password=$$$pass$$$&MD5Password=&Submit=Login
   success: (Model name)(.)+(Ethernet)+
-  creds: admin:null
-  hidden_id: [FakeChallenge,Submit.x,Submit.y]
+  creds:
+    - admin:null
+  hidden_id:
+    - FakeChallenge
+    - Submit.x
+    - Submit.y
 
 # serial adapter
 - title: Lantronix MSS Unauthenticated
-  fingerprint_page: /
+  fingerprint_page:
+    - /
   fingerprint: (<title>Lantronix)(.)+(netware_mss)+
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
 
 # serial adapter
 - title: Lantronix UDS Unauthenticated
-  fingerprint_page: /secure/welcome.htm
+  fingerprint_page:
+    - /secure/welcome.htm
   fingerprint: (<title>Lantronix)(.)+(uds)+(.)+(Device Server Configuration Manager)+
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds

--- a/data/interface_fingerprints/printers.yml
+++ b/data/interface_fingerprints/printers.yml
@@ -1,0 +1,31 @@
+# See readme.yml for the parameter information
+
+# Scanners and Printers
+- title: HP LaserJet Printer Unauthenticated
+  fingerprint: (<title>Banner Frame</title>)(.)+(HP LaserJet|HP Color LaserJet|HP Colour LaserJet)+
+  fingerprint_page: /hp/jetdirect/index_top.htm
+  creds: nocreds:nocreds
+
+- title: Ricoh Savin Multi-Function "Web Monitor" Printer Unauthenticated
+  fingerprint_page: /web/guest/en/websys/webArch/aboutWim.cgi
+  fingerprint: (<title>Version Information</title>)(.)+(RICOH|SAVIN)+
+  creds: nocreds:nocreds
+
+- title: Savin Multi-Function Printer Login
+  fingerprint_page: /web/guest/en/websys/webArch/authForm.cgi
+  fingerprint: (<title>LOGIN<\/title>)(.)+(RICOH|SAVIN)+
+  post_to: /web/guest/en/websys/webArch/login.cgi
+  login_params: userid_work=&userid=$$$base64:user$$$&password_work=&password=$$$base64:pass$$$&open=
+  creds: admin:admin
+  success: $$$$TODO$$$$
+  # need success string
+
+- title: Xerox Document Centre Unauthenticated
+  fingerprint: ((Xerox)(.)+(Document Centre)+)|((<TITLE>Document Centre)(.)+(Status)+)
+  fingerprint_page: /utCurrStat.dhtml
+  creds: nocreds:nocreds
+
+- title: Xerox Workcentre Pro Unauthenticated
+  fingerprint: ((XEROX WORKCENTRE PRO)(.)+(OG\/SEBU\/CSDD\/WebUI)+)
+  fingerprint_page: /properties/index.dhtml
+  creds: nocreds:nocreds

--- a/data/interface_fingerprints/printers.yml
+++ b/data/interface_fingerprints/printers.yml
@@ -3,29 +3,39 @@
 # Scanners and Printers
 - title: HP LaserJet Printer Unauthenticated
   fingerprint: (<title>Banner Frame</title>)(.)+(HP LaserJet|HP Color LaserJet|HP Colour LaserJet)+
-  fingerprint_page: /hp/jetdirect/index_top.htm
-  creds: nocreds:nocreds
+  fingerprint_page:
+    - /hp/jetdirect/index_top.htm
+  creds:
+    - nocreds:nocreds
 
 - title: Ricoh Savin Multi-Function "Web Monitor" Printer Unauthenticated
-  fingerprint_page: /web/guest/en/websys/webArch/aboutWim.cgi
+  fingerprint_page:
+    - /web/guest/en/websys/webArch/aboutWim.cgi
   fingerprint: (<title>Version Information</title>)(.)+(RICOH|SAVIN)+
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
 
 - title: Savin Multi-Function Printer Login
-  fingerprint_page: /web/guest/en/websys/webArch/authForm.cgi
+  fingerprint_page:
+    - /web/guest/en/websys/webArch/authForm.cgi
   fingerprint: (<title>LOGIN<\/title>)(.)+(RICOH|SAVIN)+
   post_to: /web/guest/en/websys/webArch/login.cgi
   login_params: userid_work=&userid=$$$base64:user$$$&password_work=&password=$$$base64:pass$$$&open=
-  creds: admin:admin
+  creds:
+    - admin:admin
   success: $$$$TODO$$$$
   # need success string
 
 - title: Xerox Document Centre Unauthenticated
   fingerprint: ((Xerox)(.)+(Document Centre)+)|((<TITLE>Document Centre)(.)+(Status)+)
-  fingerprint_page: /utCurrStat.dhtml
-  creds: nocreds:nocreds
+  fingerprint_page:
+    - /utCurrStat.dhtml
+  creds:
+    - nocreds:nocreds
 
 - title: Xerox Workcentre Pro Unauthenticated
   fingerprint: ((XEROX WORKCENTRE PRO)(.)+(OG\/SEBU\/CSDD\/WebUI)+)
-  fingerprint_page: /properties/index.dhtml
-  creds: nocreds:nocreds
+  fingerprint_page:
+    - /properties/index.dhtml
+  creds:
+    - nocreds:nocreds

--- a/data/interface_fingerprints/readme.yml
+++ b/data/interface_fingerprints/readme.yml
@@ -1,0 +1,52 @@
+#######
+# This is a default yml fingerprint file. It mostly servers to host parameter
+#   information and other required notes about the scanner.
+
+####### Thoughts ####
+#
+# - A fingerprint with no success string is preferred over no fingerprint at all.
+#       However if a success string is added please be very confident as otherwise
+#       false results are fed into the database.
+# - Unfortunately two ports cannot be done at once at this time (e.g. 80 and 443)
+# - A page that redirects from 80 to 443 will break the checks.
+ 
+
+#### Comments on parameters ####
+# Those with !! are required.
+#
+#!!   title: The title of the check. 
+#!!   fingerprint_page: The URI to check when detecting what the interface is.
+#!!   fingerprint: regex of initial response used to fingerprint the page. This is
+#           a required page or it won't detect any pages.
+#     post_to: page to send login creds to if different from fingerprint_page. 
+#     login_params: string containing login params
+#           !!NOTE!! use $$$user$$$and $$$pass$$$  for the username and pass. These
+#           will be replaced with the real creds and automatically URL encoded.
+#	    $$$domain$$$ will also add in the domain from the datastore 
+#     success: Check the login response for this string to signify a successful attempt (regex)
+#     references: places to read more about what can be done from here 
+#     method: HTTP Method to use when sending login_params, defaults to POST
+#     creds: default credentials to check for. Using null for user or pass will
+#           be replaced with a blank string. Set to nocreds:nocreds if the interface
+#           does not require credentials to login. To use multiple creds, use an array.
+#     basic_auth: if the page uses basic_auth,this must be set for basic to be attempted.
+#     hidden_id: An array of hidden params that are read from the fingerprint page
+#           and submitted with the request. Common examples are __VIEWSTATE or a CSRF token
+#           which can be read from the page and submitted with the request. The source page
+#           will need to have labeled these as <input type="hidden" for them to get picked up.
+#     cookie: Add anything you want from the cookie, this only applies to login attempts.
+#		using $$$vhost$$$ will replace the vhost in the cookie itself. 
+#     fp_headers: Add additional header strings to the fingerprint; must be YAML hash
+#     login_headers: Add additional header strings to the login attempt; must be YAML hash
+#     res_code: A success code other than 200.
+#     follow_302: After a login attempt if a 302 or 301 should be followed to check for success.
+#           This is common but not always necessary for a good fingerprint.
+
+# Test check
+# modeled after the tomcat_mgr_login aux module
+- title: Apache Tomcat
+  fingerprint_page: [/manager/html/, /tomcat/manager/html/]
+  fingerprint: Apache.*(Coyote|Tomcat)
+  creds: [tomcat:tomcat, admin:admin, manager:manager]
+  basic_auth: true
+  

--- a/data/interface_fingerprints/readme.yml
+++ b/data/interface_fingerprints/readme.yml
@@ -45,8 +45,12 @@
 # Test check
 # modeled after the tomcat_mgr_login aux module
 - title: Apache Tomcat
-  fingerprint_page: [/manager/html/, /tomcat/manager/html/]
+  creds:
+    - tomcat:tomcat
+    - admin:admin
+    - manager:manager
+  fingerprint_page:
+    - /manager/html/
+    - /tomcat/manager/html/
   fingerprint: Apache.*(Coyote|Tomcat)
-  creds: [tomcat:tomcat, admin:admin, manager:manager]
   basic_auth: true
-  

--- a/data/interface_fingerprints/routers.yml
+++ b/data/interface_fingerprints/routers.yml
@@ -1,0 +1,123 @@
+# See readme.yml for the parameter information
+
+# Routers
+- title: AddPac
+  fingerprint_page: [/, /index.html]
+  fingerprint: AddPac
+  basic_auth: true
+  creds: root:router
+
+# Based on cisco_device_manager module
+- title: Cisco Device Manager Unauthenticated
+  fingerprint_page: /exec/show/version/CR
+  fingerprint: (Cisco (Internetwork Operating System|IOS) Software)
+  creds: nocreds:nocreds
+  
+# Based on cisco_device_manager module
+- title: Cisco Device Manager
+  fingerprint_page: /exec/show/version/CR
+  fingerprint: (Cisco (Internetwork Operating System|IOS) Software)
+  basic_auth: true
+  creds: [cisco:cisco, Cisco:Cisco]
+    
+- title: Cisco Wireless Control System
+  fingerprint_page: /webacs/loginAction.do
+  fingerprint: /webacs/welcomeAction.do
+  login_params: action=login&requestUrl=/webacs/FwelcomeAction.do&username=$$$user$$$&password=$$$pass$$$
+  creds: Cisco:Cisco
+
+- title: Netgear DG834
+  fingerprint: DG834
+  fingerprint_page: [/, /index.html]
+  basic_auth: true
+  creds: admin:password
+
+- title: Netgear DGN1000
+  fingerprint: DGN1000
+  fingerprint_page: [/, /index.html]
+  basic_auth: true
+  creds: admin:password
+
+- title: SpeedStream Web Interface Configuration
+  fingerprint_page: /pflogin.htm
+  fingerprint: function fCheckLogin
+  login_params: password=$$$pass$$$&username=$$$user$$$
+  creds: admin:admin
+  post_to: /pflogin.cgi
+  success: (Code removed because|Profile Logout for)
+
+- title: WindWeb Server
+  fingerprint: RomPager/4.07 UPnP/1.0
+  fingerprint_page: /index.asp
+  basic_auth: true
+  creds: vxworks:vxworks
+
+- title: Zhone SLMS Web Interface
+  fingerprint: Basic realm="Zhone SLMS Web Interface"
+  fingerprint_page: [/, /index.html]
+  basic_auth: true
+  creds: admin:zhone
+
+- title: HUWAEI router
+  fingerprint: SmartAX MT882
+  fingerprint_page: [/, /index.html]
+  basic_auth: true
+  creds: admin:admin
+
+- title: 3Com Device
+  fingerprint_page: [/, /index.html]
+  fingerprint: 3Com\/v1.0
+  basic_auth: true
+  creds: [admin:admin, debug:synnet, tech:tech, adm:null, null:PASSWORD, adminttd:adminttd, admin:comcomcom, security:security, null:ADMIN]
+
+- title: Alvarion
+  fingerprint_page: [/, /index.html]
+  fingerprint: Alvarion-Webs
+  basic_auth: true
+  creds: [admin:admin, admin:user, admin:installer, admin:alvarion]
+
+- title: Pannaway Gateway NID
+  fingerprint_page: /includes/phone.css
+  fingerprint: phoneLayout
+  post_to: /cgi-bin/PanConfig
+  login_params: ID=UL1&LN=L1&userName=$$$user$$$&password=$$$pass$$$&login.x=29&login.y=10&login=submit
+  creds: Admin:pannaway
+  success: (var userNam=)
+
+- title: F5 BIG-IP Configuration Utility
+  fingerprint_page: /tmui/login.jsp
+  fingerprint: logo_f5.png
+  post_to: /tmui/logmein.html
+  login_params: username=$$$user$$$&passwd=$$$pass$$$
+  creds: admin:admin
+  success: (The document has moved <a href="/">here)
+  res_code: 302
+  # a failure will redirect back to login, unfortunately success and failure are both 302s
+
+- title: GoAhead Webs Webserver
+  fingerprint_page: /index.asp
+  post_to: /index.asp
+  fingerprint: GoAhead-Webs
+  basic_auth: true
+  creds: [admin:1234, admin:4321]
+  
+- title: Sunny WebBox
+  fingerprint_page: /home.htm
+  post_to: /login
+  fingerprint: (<title>Sunny WebBox<\/title>)(.)+(Language)+
+  creds: null:sma
+  success: (plant_devices_|home_menue.htm)
+  login_params: Language=en&Password=$$$pass$$$&ButtonLogin=Submit
+
+- title: Tahoe Frame Relay Router Unauthenticated
+  fingerprint_page: /
+  fingerprint: ((Tahoe 18xx V.35)(.)+(Frame Relay Router)+(.)+(Interface)+)
+  creds: nocreds:nocreds
+
+- title: ZyXel Zywall General
+  fingerprint_page: /
+  fingerprint: ((loginPassword.value)(.)+(ZyXEL ZyWALL Series)+)
+  creds: [admin:1234, webadmin:1234, null:admin, null:1234]
+  post_to: /Forms/rpAuth_1
+  login_params: LoginPassword=ZyXEL+ZyWALL+Series&hiddenPassword=$$$base64:pass$$$&Prestige_Login=Login
+  success: (Please select Wizard or Advanced mode)

--- a/data/interface_fingerprints/routers.yml
+++ b/data/interface_fingerprints/routers.yml
@@ -2,122 +2,182 @@
 
 # Routers
 - title: AddPac
-  fingerprint_page: [/, /index.html]
+  fingerprint_page:
+    - /
+    - /index.html
   fingerprint: AddPac
   basic_auth: true
-  creds: root:router
+  creds:
+    - root:router
 
 # Based on cisco_device_manager module
 - title: Cisco Device Manager Unauthenticated
-  fingerprint_page: /exec/show/version/CR
+  fingerprint_page:
+    - /exec/show/version/CR
   fingerprint: (Cisco (Internetwork Operating System|IOS) Software)
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
   
 # Based on cisco_device_manager module
 - title: Cisco Device Manager
-  fingerprint_page: /exec/show/version/CR
+  fingerprint_page:
+    - /exec/show/version/CR
   fingerprint: (Cisco (Internetwork Operating System|IOS) Software)
   basic_auth: true
-  creds: [cisco:cisco, Cisco:Cisco]
+  creds:
+    - cisco:cisco
+    - Cisco:Cisco
     
 - title: Cisco Wireless Control System
-  fingerprint_page: /webacs/loginAction.do
+  fingerprint_page:
+    - /webacs/loginAction.do
   fingerprint: /webacs/welcomeAction.do
   login_params: action=login&requestUrl=/webacs/FwelcomeAction.do&username=$$$user$$$&password=$$$pass$$$
-  creds: Cisco:Cisco
+  creds:
+    - Cisco:Cisco
 
 - title: Netgear DG834
   fingerprint: DG834
-  fingerprint_page: [/, /index.html]
+  fingerprint_page:
+    - /
+    - /index.html
   basic_auth: true
-  creds: admin:password
+  creds:
+    - admin:password
 
 - title: Netgear DGN1000
   fingerprint: DGN1000
-  fingerprint_page: [/, /index.html]
+  fingerprint_page:
+    - /
+    - /index.html
   basic_auth: true
-  creds: admin:password
+  creds:
+    - admin:password
 
 - title: SpeedStream Web Interface Configuration
-  fingerprint_page: /pflogin.htm
+  fingerprint_page:
+    - /
+    - pflogin.htm
   fingerprint: function fCheckLogin
   login_params: password=$$$pass$$$&username=$$$user$$$
-  creds: admin:admin
+  creds:
+    - admin:admin
   post_to: /pflogin.cgi
   success: (Code removed because|Profile Logout for)
 
 - title: WindWeb Server
   fingerprint: RomPager/4.07 UPnP/1.0
-  fingerprint_page: /index.asp
+  fingerprint_page:
+    - /index.asp
   basic_auth: true
-  creds: vxworks:vxworks
+  creds:
+    - vxworks:vxworks
 
 - title: Zhone SLMS Web Interface
   fingerprint: Basic realm="Zhone SLMS Web Interface"
-  fingerprint_page: [/, /index.html]
+  fingerprint_page:
+    - /
+    - /index.html
   basic_auth: true
-  creds: admin:zhone
+  creds:
+    - admin:zhone
 
 - title: HUWAEI router
   fingerprint: SmartAX MT882
-  fingerprint_page: [/, /index.html]
+  fingerprint_page:
+    - /
+    - /index.html
   basic_auth: true
-  creds: admin:admin
+  creds:
+    - admin:admin
 
 - title: 3Com Device
-  fingerprint_page: [/, /index.html]
+  fingerprint_page:
+    - /
+    - /index.html
   fingerprint: 3Com\/v1.0
   basic_auth: true
-  creds: [admin:admin, debug:synnet, tech:tech, adm:null, null:PASSWORD, adminttd:adminttd, admin:comcomcom, security:security, null:ADMIN]
+  creds:
+    - admin:admin
+    - debug:synnet
+    - tech:tech
+    - adm:null
+    - null:PASSWORD
+    - adminttd:adminttd
+    - admin:comcomcom
+    - security:security
+    - null:ADMIN
 
 - title: Alvarion
-  fingerprint_page: [/, /index.html]
+  fingerprint_page:
+    - /
+    - /index.html
   fingerprint: Alvarion-Webs
   basic_auth: true
-  creds: [admin:admin, admin:user, admin:installer, admin:alvarion]
+  creds:
+    - admin:admin
+    - admin:user
+    - admin:installer
+    - admin:alvarion
 
 - title: Pannaway Gateway NID
-  fingerprint_page: /includes/phone.css
+  fingerprint_page:
+    - /includes/phone.css
   fingerprint: phoneLayout
   post_to: /cgi-bin/PanConfig
   login_params: ID=UL1&LN=L1&userName=$$$user$$$&password=$$$pass$$$&login.x=29&login.y=10&login=submit
-  creds: Admin:pannaway
+  creds:
+    - Admin:pannaway
   success: (var userNam=)
 
 - title: F5 BIG-IP Configuration Utility
-  fingerprint_page: /tmui/login.jsp
+  fingerprint_page:
+    - /tmui/login.jsp
   fingerprint: logo_f5.png
   post_to: /tmui/logmein.html
   login_params: username=$$$user$$$&passwd=$$$pass$$$
-  creds: admin:admin
+  creds:
+    - admin:admin
   success: (The document has moved <a href="/">here)
   res_code: 302
   # a failure will redirect back to login, unfortunately success and failure are both 302s
 
 - title: GoAhead Webs Webserver
-  fingerprint_page: /index.asp
+  fingerprint_page:
+    - /index.asp
   post_to: /index.asp
   fingerprint: GoAhead-Webs
   basic_auth: true
-  creds: [admin:1234, admin:4321]
+  creds:
+    - admin:1234
+    - admin:4321
   
 - title: Sunny WebBox
-  fingerprint_page: /home.htm
+  fingerprint_page:
+    - /home.htm
   post_to: /login
   fingerprint: (<title>Sunny WebBox<\/title>)(.)+(Language)+
-  creds: null:sma
+  creds:
+    - null:sma
   success: (plant_devices_|home_menue.htm)
   login_params: Language=en&Password=$$$pass$$$&ButtonLogin=Submit
 
 - title: Tahoe Frame Relay Router Unauthenticated
-  fingerprint_page: /
+  fingerprint_page:
+    - /
   fingerprint: ((Tahoe 18xx V.35)(.)+(Frame Relay Router)+(.)+(Interface)+)
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
 
 - title: ZyXel Zywall General
-  fingerprint_page: /
+  fingerprint_page:
+    - /
   fingerprint: ((loginPassword.value)(.)+(ZyXEL ZyWALL Series)+)
-  creds: [admin:1234, webadmin:1234, null:admin, null:1234]
+  creds:
+    - admin:1234
+    - webadmin:1234
+    - null:admin
+    - null:1234
   post_to: /Forms/rpAuth_1
   login_params: LoginPassword=ZyXEL+ZyWALL+Series&hiddenPassword=$$$base64:pass$$$&Prestige_Login=Login
   success: (Please select Wizard or Advanced mode)

--- a/data/interface_fingerprints/web_administration.yml
+++ b/data/interface_fingerprints/web_administration.yml
@@ -1,0 +1,110 @@
+# See readme.yml for the parameter information
+
+# Web Administration and CMS
+# Based on the tomcat_mgr_login aux module
+- title: Apache Tomcat
+  fingerprint_page: [/manager/html/, /tomcat/manager/html/]
+  fingerprint: Apache.*(Coyote|Tomcat)
+  creds: [tomcat:tomcat, admin:admin, manager:manager]
+  basic_auth: true
+
+# Based on axis_login aux module
+- title: Apache Axis2
+  fingerprint_page: [/axis/axis2-admin/, /axis2/axis2-admin/, /dswsbobje/]
+  fingerprint: Apache.*(Coyote|Tomcat)
+  post_to: /axis2/axis2-admin/login
+  login_params: userName=$$$user$$$&password=$$$pass$$$&submit=+Login+
+  creds: [admin:axis2, admin:admin]
+  success: (/upload)
+
+# Based on part of frontpage_login aux module
+- title: FrontPage Author Unauthenticated
+  fingerprint_page: /_vti_inf.html
+  fp_headers: { TE: deflate\,gzip;q=0.3, Keep-Alive: 300, Connection: Keep-Alive\,TE }
+  fingerprint: FPAuthorScriptUrl=
+  creds: nocreds:nocreds
+
+# Based on part of frontpage_login aux module
+- title: FrontPage Access Version Unauthenticated 
+  fingerprint_page: /_vti_inf.html
+  fp_headers: { TE: deflate\,gzip;q=0.3, Keep-Alive: 300, Connection: Keep-Alive\,TE }
+  fingerprint: FPVersion=
+  creds: nocreds:nocreds
+
+- title: Parallels Plesk Panel
+  fingerprint_page: /login_up.php3
+  fingerprint: Plesk Control Panel
+  creds: admin:setup
+  login_params: passwd=$$$pass$$$&locale_id=default&login_name=$$$user$$$
+  success: $$$$TODO$$$$
+  # add a success string
+
+- title: Nagios Basic Authentication Access
+  fingerprint_page: /
+  fingerprint: Nagios Access
+  creds: [nagios:nagios, nagios:nagiosadmin]
+  success: ""
+  basic_auth: true
+
+- title: Nagios XI
+  fingerprint_page: /nagiosxi/
+  fingerprint: Powered by the Nagios Synthesis Framework
+  creds: [nagiosadmin:nagios, nagiosadmin:welcome, nagios:nagios]
+  post_to: /nagiosxi/login.php
+  login_params: page=auth&debug=&pageopt=login&username=$$$user$$$&password=$$$pass$$$&loginButton=Login
+  success: (Set-Cookie)(.)+(nagiosxi)
+  res_code: 302
+  
+- title: VTiger CRM 5
+  fingerprint_page: /vtigercrm/index.php
+  fingerprint: <title>vtiger CRM
+  login_params: module=Users&action=Authenticate&return_module=Users&return_action=Login&user_name=$$$user$$$&user_password=$$$pass$$$&login_theme=softed&Login=++Login++
+  creds: admin:admin
+  hidden_id: [Login.x,Login.y]
+  success: $$$$TODO$$$$
+  # add a success string
+  
+# Based on glassfish_login
+- title: Glassfish 2.x,9.x Authentication Bypass
+  fingerprint_page: /applications/upload.jsf
+  fingerprint: <title>Deploy Enterprise Applications\/Modules
+  creds: nocreds:nocreds
+  
+# Based on glassfish_login
+- title: Glassfish 3.x Authentication Bypass
+  fingerprint_page: /common/applications/uploadFrame.jsf
+  fingerprint: <title>Deploy Applications or Modules
+  creds: nocreds:nocreds
+  
+# Based on glassfish_login
+- title: Glassfish 2.x,9.x,3.x Login
+  fingerprint_page: /common/index.jsf
+  fingerprint: (Open Source|Sun GlassFish Enterprise Server|Sun Java System Application Server)
+  post_to: /j_security_check
+  login_headers: { Content-Type: application/x-www-form-urlencoded }
+  params: j_username=$$$user$$$&j_password=$$$pass$$$&loginButton=login
+  follow_302: true
+  success: (<title>Deploy Enterprise Applications|<title>Deploy Applications or Modules)
+
+# Based on glassfish_login
+- title: Glassfish 2.x,9.x,3.x Login
+  fingerprint_page: /login.jsf
+  fingerprint: (Open Source|Sun GlassFish Enterprise Server|Sun Java System Application Server)
+  post_to: /j_security_check
+  login_headers: { Content-Type: application/x-www-form-urlencoded }
+  params: j_username=$$$user$$$&j_password=$$$pass$$$&loginButton=login
+  follow_302: true
+  success: (<title>Deploy Enterprise Applications|<title>Deploy Applications or Modules)
+
+# Based on wordpress_login bruteforce section
+# This needs a better initial fingerprint, it just assumes that
+#   finding wp-login.php is good enough
+- title: Wordpress Login
+  fingerprint_page: /wp-login.php
+  fingerprint: log
+  success: wordpress_logged_in_
+  res_code: 302
+  login_params: log=$$$user$$$&pwd=$$$pass$$$&wp-submit=Login
+  
+
+

--- a/data/interface_fingerprints/web_administration.yml
+++ b/data/interface_fingerprints/web_administration.yml
@@ -3,95 +3,136 @@
 # Web Administration and CMS
 # Based on the tomcat_mgr_login aux module
 - title: Apache Tomcat
-  fingerprint_page: [/manager/html/, /tomcat/manager/html/]
+  fingerprint_page:
+    - /manager/html/
+    - /tomcat/manager/html/
   fingerprint: Apache.*(Coyote|Tomcat)
-  creds: [tomcat:tomcat, admin:admin, manager:manager]
+  creds:
+    - tomcat:tomcat
+    - admin:admin
+    - manager:manager
   basic_auth: true
 
 # Based on axis_login aux module
 - title: Apache Axis2
-  fingerprint_page: [/axis/axis2-admin/, /axis2/axis2-admin/, /dswsbobje/]
+  fingerprint_page:
+    - /axis/axis2-admin/
+    - /axis2/axis2-admin/
+    - /dswsbobje/
   fingerprint: Apache.*(Coyote|Tomcat)
   post_to: /axis2/axis2-admin/login
   login_params: userName=$$$user$$$&password=$$$pass$$$&submit=+Login+
-  creds: [admin:axis2, admin:admin]
+  creds:
+    - admin:axis2
+    - admin:admin
   success: (/upload)
 
 # Based on part of frontpage_login aux module
 - title: FrontPage Author Unauthenticated
-  fingerprint_page: /_vti_inf.html
-  fp_headers: { TE: deflate\,gzip;q=0.3, Keep-Alive: 300, Connection: Keep-Alive\,TE }
+  fingerprint_page:
+    - /_vti_inf.html
+  fp_headers:
+    - TE:deflate\,gzip;q=0.3
+    - Keep-Alive:300
+    - Connection:Keep-Alive\,TE
   fingerprint: FPAuthorScriptUrl=
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
 
 # Based on part of frontpage_login aux module
 - title: FrontPage Access Version Unauthenticated 
-  fingerprint_page: /_vti_inf.html
-  fp_headers: { TE: deflate\,gzip;q=0.3, Keep-Alive: 300, Connection: Keep-Alive\,TE }
+  fingerprint_page:
+    - /_vti_inf.html
+  fp_headers:
+    - TE:deflate\,gzip;q=0.3
+    - Keep-Alive:300
+    - Connection:Keep-Alive\,TE
   fingerprint: FPVersion=
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
 
 - title: Parallels Plesk Panel
-  fingerprint_page: /login_up.php3
+  fingerprint_page:
+    - /login_up.php3
   fingerprint: Plesk Control Panel
-  creds: admin:setup
+  creds:
+    - admin:setup
   login_params: passwd=$$$pass$$$&locale_id=default&login_name=$$$user$$$
   success: $$$$TODO$$$$
   # add a success string
 
 - title: Nagios Basic Authentication Access
-  fingerprint_page: /
+  fingerprint_page:
+    - /
   fingerprint: Nagios Access
-  creds: [nagios:nagios, nagios:nagiosadmin]
+  creds:
+    - nagios:nagios
+    - nagios:nagiosadmin
   success: ""
   basic_auth: true
 
 - title: Nagios XI
-  fingerprint_page: /nagiosxi/
+  fingerprint_page:
+    - /nagiosxi/
   fingerprint: Powered by the Nagios Synthesis Framework
-  creds: [nagiosadmin:nagios, nagiosadmin:welcome, nagios:nagios]
+  creds:
+    - nagiosadmin:nagios
+    - nagiosadmin:welcome
+    - nagios:nagios
   post_to: /nagiosxi/login.php
   login_params: page=auth&debug=&pageopt=login&username=$$$user$$$&password=$$$pass$$$&loginButton=Login
   success: (Set-Cookie)(.)+(nagiosxi)
   res_code: 302
   
 - title: VTiger CRM 5
-  fingerprint_page: /vtigercrm/index.php
+  fingerprint_page:
+    - /vtigercrm/index.php
   fingerprint: <title>vtiger CRM
   login_params: module=Users&action=Authenticate&return_module=Users&return_action=Login&user_name=$$$user$$$&user_password=$$$pass$$$&login_theme=softed&Login=++Login++
-  creds: admin:admin
-  hidden_id: [Login.x,Login.y]
+  creds:
+    - admin:admin
+  hidden_id:
+    - Login.x
+    - Login.y
   success: $$$$TODO$$$$
   # add a success string
   
 # Based on glassfish_login
 - title: Glassfish 2.x,9.x Authentication Bypass
-  fingerprint_page: /applications/upload.jsf
+  fingerprint_page:
+    - /applications/upload.jsf
   fingerprint: <title>Deploy Enterprise Applications\/Modules
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
   
 # Based on glassfish_login
 - title: Glassfish 3.x Authentication Bypass
-  fingerprint_page: /common/applications/uploadFrame.jsf
+  fingerprint_page:
+    - /common/applications/uploadFrame.jsf
   fingerprint: <title>Deploy Applications or Modules
-  creds: nocreds:nocreds
+  creds:
+    - nocreds:nocreds
   
 # Based on glassfish_login
 - title: Glassfish 2.x,9.x,3.x Login
-  fingerprint_page: /common/index.jsf
+  fingerprint_page:
+    - /common/index.jsf
   fingerprint: (Open Source|Sun GlassFish Enterprise Server|Sun Java System Application Server)
   post_to: /j_security_check
-  login_headers: { Content-Type: application/x-www-form-urlencoded }
+  login_headers:
+    - Content-Type:application/x-www-form-urlencoded
   params: j_username=$$$user$$$&j_password=$$$pass$$$&loginButton=login
   follow_302: true
   success: (<title>Deploy Enterprise Applications|<title>Deploy Applications or Modules)
 
 # Based on glassfish_login
 - title: Glassfish 2.x,9.x,3.x Login
-  fingerprint_page: /login.jsf
+  fingerprint_page:
+    - /login.jsf
   fingerprint: (Open Source|Sun GlassFish Enterprise Server|Sun Java System Application Server)
   post_to: /j_security_check
-  login_headers: { Content-Type: application/x-www-form-urlencoded }
+  login_headers:
+    - Content-Type:application/x-www-form-urlencoded
   params: j_username=$$$user$$$&j_password=$$$pass$$$&loginButton=login
   follow_302: true
   success: (<title>Deploy Enterprise Applications|<title>Deploy Applications or Modules)
@@ -100,7 +141,8 @@
 # This needs a better initial fingerprint, it just assumes that
 #   finding wp-login.php is good enough
 - title: Wordpress Login
-  fingerprint_page: /wp-login.php
+  fingerprint_page:
+    - /wp-login.php
   fingerprint: log
   success: wordpress_logged_in_
   res_code: 302

--- a/modules/auxiliary/scanner/http/interface_fingerprinter.rb
+++ b/modules/auxiliary/scanner/http/interface_fingerprinter.rb
@@ -1,0 +1,577 @@
+##
+# $
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+
+require 'msf/core'
+require 'yaml'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Auxiliary::AuthBrute
+	include Msf::Auxiliary::Scanner
+
+	def initialize
+		super(
+			'Name'           => 'Interface Fingerprinter',
+			'Version'        => '',
+			'Description'    => %q{This module attempts to identify known web
+			application interfaces and login with default credentials or those
+			provided through the normal means. The fingerprints to use are
+			controlled by the CONFIG parameter. },
+			'Author'         =>
+				[
+					'willis'
+				],
+			'References'     =>
+				[
+					[ 'www.metasploit.com' ],
+				],
+			'License'        => MSF_LICENSE
+		)
+
+		register_options(
+			[ OptString.new('CONFIG', [false, 'Path to the Interface fingerprinter db', "#{Msf::Config.install_root}/data/interface_fingerprints/readme.yml"]),
+			OptString.new('SingleInterface', [false, 'A single web interface to check for.', ""]),
+			OptString.new('DIR', [false, 'To check in a non default directory (e.g. /admin/', ""]),
+		], self.class)
+		register_advanced_options(
+			[OptBool.new('NoDefault', [false, 'Do not attempt the default credentials', false]),
+			OptInt.new('Delay', [false, 'Wait n seconds between requests', 0]),
+		], self.class)
+	end
+
+	def run_host(ip)
+		print_status("#{target_url} Reading configuration file #{datastore['CONFIG']}...")
+
+		# Load the Configuration file
+		# It would be nice to support multiple configuration files at once
+		@config = YAML.load_file(datastore['CONFIG'])
+
+		# Initialize global vars
+		@responses = {}
+		@successful_login_responses = {}
+		@fails = 0
+		@success = false
+		@hidden_params = ""
+
+		# Load the URIs and attempt to connect
+		init_responses()
+
+		if (too_many_failed_attempts())
+			print_error("#{target_url}: Aborting. #{@fails} or more failed connection attempts.")
+			return nil
+		end
+
+		# Fingerprint the responses and authenticate if possible.
+		fingerprinter()
+
+		# Store all responses
+		write_data()
+	end
+
+	def init_responses()
+		# First we pull in all of the unique URIs from the configuration
+		#	file.
+		@config.each do |interface|
+			interface['fingerprint_page'].each do |login|
+				next if not login
+				if (!@responses.include?(login))
+					if (interface['title'].scan(datastore['SingleInterface']).length != 0)
+						@responses["#{datastore['Dir']}#{login}"] = interface
+					end
+				end
+			end
+		end
+
+		print_status("#{target_url}  #{@responses.size} unique login pages in scope, requesting each. Please wait.")
+
+		# Make a request to each of the URIs and store the responses.
+		@responses.each do |login,fingerprint_page|
+			acquire_response(login,fingerprint_page)
+		end
+	end
+
+	def acquire_response(login,fingerprint_page)
+
+		# Adding a delay can be helpful not to overwhelm the target
+		select(nil,nil,nil,datastore['Delay'])
+
+		# Skip this server if there are too many failed attempts
+		return if too_many_failed_attempts()
+
+		vprint_status("#{target_url}#{login} - Attempting Connection")
+		headers = {}
+
+		if fingerprint_page
+			if fingerprint_page.is_a?(Net::HTTPResponse)
+				# This is needed in case the first request is a 302 and sets some values that
+				#	the client needs in later requests.
+				referrer =  fingerprint_page.headers["Referrer"] ? "http://www.google.com" : fingerprint_page.headers["Referrer"]
+				cookie = fingerprint_page.headers["Set-Cookie"] ? "" : fingerprint_page.headers["Set-Cookie"]
+				headers = {
+					['Cookie'] => cookie,
+					['Referrer'] => referrer
+				}
+			else
+				# A user can add their own headers for the initial request and they will be respected
+				#	with a 302.
+				headers = fingerprint_page['fp_headers'] if fingerprint_page['fp_headers']
+			end
+		end
+
+		begin
+			# Request the URI
+			res = send_request_raw({
+				'uri'     => login,
+				'method'  => 'GET',
+				'headers' => headers,
+			}, 20)
+			return :abort if not res
+
+			rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable
+			rescue ::Rex::ConnectionTimeout
+			rescue ::Timeout::Error, ::Errno::EPIPE
+		end
+
+		if not res
+			print_error("#{target_url} Could not connect.")
+			@fails = @fails + 1
+			return
+		end
+
+		case res.code
+		when 302
+			# This will break if the page redirects from http to https.
+
+			# Grab the new location form the header and follow the 302, wheeee
+			rhost = res.headers["Location"].split("/")[2]
+			location = "/#{res.headers["Location"].split("/").drop(3).join('/')}"
+
+			# If we have already followed the 302, don't follow it
+			#	again; delete the page and don't go to it again.
+			if @responses.include?(location)
+				@responses.delete(login)
+			else
+				vprint_status("#{target_url}#{login} Received 302 =>(unless visited) going to #{location}..")
+				acquire_response(location,res) unless login == location
+			end
+		when 404
+			vprint_status("#{target_url}#{login} - Found a 404, tossing it..")
+
+			# Uncomment this to save 404 responses which are usually useless
+			#	This will add overhead.
+			#@responses[login] = res unless res.body == @last_response
+			#@last_response = res.body
+		else
+			if (res.body != @last_response or (login == "/" or login == "/index.html"))
+				vprint_status("#{target_url}#{login} - Storing response")
+				@responses[login] = res
+			else
+				vprint_status("#{target_url}#{login} - Duplicate response, not storing.")
+			end
+
+			@last_response = res.body
+		end
+	end
+
+	def fingerprinter()
+		vprint_status("#{target_url} - Testing all responses against the fingerprints.")
+
+		@responses.each do |login,response|
+			next unless response
+			# We only want to fingerprint Net::HTTPResponse
+			next if response.class == Hash
+
+			@response = response
+
+			# Check if the response matches in the fingerprint list.
+			@config.each do |interface|
+				# In case a user only wants a single interface
+				next unless interface['title'].include?(datastore['SingleInterface'])
+
+				# An interface can have multiple fingerprints
+				interface['fingerprint_page'].each do |fp|
+					# Remove this next line if you want more responses, but more False P's
+					next unless fp == login or response.code != 302
+					@interface = interface
+					@post_to = (not interface['post_to']) ? login : interface['post_to']
+
+					login_response_actions(fp)
+					return if @success
+				end
+			end
+		end
+
+	end
+
+	def login_response_actions(fp)
+		# If the interface has already been tested with creds
+		#	don't retest creds against it.
+		return if @interface['tested']
+
+		case @response.code
+			when 200
+				if(check_fingerprint(@response,@interface['fingerprint']))
+
+					print_status("#{target_url}#{@post_to} - Recieved a #{@response.code} from #{fp} and fingerprint matched, onward...")
+
+					# Check for hidden_id's if it is part of the configuration file.
+					#	VIEWSTATE is a common example.
+					if(@interface['hidden_id'])
+						@interface['hidden_id'].each{ |id|
+							if(@response.body =~ /#{id}/)
+								value = Rex::Text.uri_encode(@response.body.split("id=\"#{id}\" value=\"")[1].split("\"")[0])
+								value = value.gsub('/','%2F')
+								@hidden_params << "&#{id}=#{value}"
+							end
+						}
+					end
+
+					# It is very common for multiple pages to match the same fingerprint
+					#	especially if a redirect is added to the URI (i.e &redir=...). To prevent this
+					#	we mark the interface as previously tested. Create multiple interfaces
+					#	if two pages matching the same fingerprint should be tested twice
+					#	(e.g. Glassfish Authentication Bypass and Normal Auth Glassfish need
+					#	two interfaces)
+					@interface['tested'] = true
+
+					# Exit if the user says not to test creds. A used may do this if they just want
+					#	to identify target pages for later.
+					return if datastore['NoDefault']
+
+					# Skip if there are no default creds to test
+					if @interface['creds']
+						# First try the default credentials in the config file
+						if @interface['basic_auth']
+							@interface['creds'].each do |cred|
+								do_login_basic(cred.split(":")[0],cred.split(":")[1])
+							end
+						else
+							@interface['creds'].each do |cred|
+								do_login(cred.split(":")[0],cred.split(":")[1])
+							end
+						end
+					else
+						vprint_error("#{target_url} - No default credentials were provided in the fingerprint, assuming user assigned.")
+					end
+
+					# Attempt the datastore usernames and passwords
+					if @interface['basic_auth']
+						each_user_pass do |user, pass|
+								do_login_basic(user, pass)
+							end
+					else
+						each_user_pass do |user, pass|
+							do_login(user, pass)
+						end
+					end
+				end
+			when 401
+				if(@interface['basic_auth'] and check_fingerprint(@response,@interface['fingerprint']))
+					vprint_status("#{target_url} - Received 401 and interface requires basic auth, attempting login..")
+
+					# It is very common for multiple pages to match the same fingerprint
+					#	especially if a redirect is added to the URI. To prevent this
+					#	we mark the interface as previously tested.
+					@interface['tested'] = true
+
+					# Skip login attempts if the user says so
+					if @interface['creds'] and not datastore['NoDefault']
+						# First try the default credentials in the config file
+						@interface['creds'].each do |cred|
+							do_login_basic(cred.split(":")[0],cred.split(":")[1])
+						end
+					end
+
+					# Attempt the datastore usernames and passwords
+					each_user_pass do |user, pass|
+						do_login_basic(user, pass)
+					end
+				end
+			end
+	end
+
+	def do_login(user=nil,pass=nil)
+		# A user can provide a special response code, verb, or referrer in the configuration file
+		res_code = (not @interface['res_code']) ? 200 : @interface['res_code'].to_i
+		method = (not @interface['method']) ? 'POST' : @interface['method']
+		referrer =  @response.headers["Referrer"] ? "http://www.google.com" : @response.headers["Referrer"]
+
+		if (pass=="nocreds" and user=="nocreds")
+			print_good("#{target_url}#{@interface['fingerprint_page']} - No creds are required for #{@interface['title']}")
+			report_creds(nil,nil)
+			@success = false
+			return
+		end
+
+		# URI Encode the username and password from the POST params
+		login_params = @interface['login_params'].gsub('$$$user$$$',Rex::Text.uri_encode(user.to_s))
+		login_params = login_params.gsub('$$$pass$$$',Rex::Text.uri_encode(pass.to_s))
+		login_params << @hidden_params
+
+		# Some logins require the creds to be Base64 encoded
+		if @interface['login_params'].include?("$$$base64:user$$$")
+			login_params = login_params.gsub("$$$base64:user$$$",Rex::Text.uri_encode(Rex::Text.encode_base64(user.to_s)))
+			login_params = login_params.gsub("$$$base64:pass$$$",Rex::Text.uri_encode(Rex::Text.encode_base64(pass.to_s)))
+		end
+
+		# Some logins include an AD Domain in the POST params
+		if @interface['login_params'].include?("$$$domain$$$")
+			login_params = login_params.gsub("$$$domain$$$",datastore['DOMAIN'])
+		end
+
+		# Some logins replace the vhost in login params
+		if @interface['login_params'].include?("$$$vhost$$$")
+			login_params = login_params.gsub("$$$vhost$$$",Rex::Text.uri_encode(datastore['VHOST']))
+		end
+
+		# Commonly a cookie value will require the vhost
+		if @interface['cookie']
+			set_cookie = @interface['cookie'].gsub("$$$vhost$$$",@datastore['vhost'])
+		else
+			set_cookie = ""
+		end
+
+		# Pull in cookie information after the first request
+		cookie_headers = "#{@response.headers["Set-Cookie"]};#{set_cookie}"
+		headers =
+			{
+				['Cookie'] => cookie_headers,
+				['Referrer'] => referrer,
+			}
+
+		# A user can headers into the login process, useful for strange interfaces
+		headers = headers.merge(@interface['login_headers']) if @interface['login_headers']
+
+		user = "" if user == "null"
+		pass = "" if pass == "null"
+
+		print_status("#{target_url}#{@post_to} - #{@interface['title']} - Trying username:'#{user}' with password:'#{pass}'")
+
+		begin
+			# Attempt the login
+			res = send_request_cgi({
+				'method'  => method,
+				'uri'     => @post_to,
+				'headers' => headers,
+				'data'    => login_params
+			}, 20)
+
+			print_error("#{target_url} Failed when connecting") if not res
+			return :abort if not res
+
+			if (@interface['follow_302'] and (res.code == 302 or res.code == 301))
+				# Some success fingerprints depend on following a 302 or 301
+				#  Follow and get the new result page to check for success fingerprint
+				res = follow_302(res,headers)
+			end
+
+			if (res and res.code == res_code and (check_fingerprint(res,@interface['success'])))
+				# BOOMY! FACE PUNCH!!
+				print_good("#{target_url}#{@post_to} - #{@interface['title']} - SUCCESSFUL login for #{user}:#{pass}")
+				@success = false
+				# Autopwn here
+
+				report_creds(user,pass)
+			else
+				print_error("#{target_url}#{@post_to} - #{@interface['title']} - Failed to login as #{user}:#{pass}")
+			end
+			@successful_login_responses["#{@post_to}-LOGIN-RESPONSE-#{user}:#{pass}"] = res
+
+		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+		rescue ::Timeout::Error, ::Errno::EPIPE
+		end
+	end
+
+	def follow_302(res,headers)
+		# Some login responses use 302s to forward to the correct page, this method is
+		#	a helper for that situation
+		location = "#{res.headers["Location"].split("/").drop(3).join('/')}"
+
+		# Grab the cookie info
+		if (res.headers["Set-Cookie"])
+			headers = {
+				['Cookie'] => res.headers["Set-Cookie"]
+			}
+		end
+
+		# This is for a strange bug where pulling set-cookie values can
+		#	add in a , for new lines therefore mucking up the proper
+		#	cookie value.
+		headers.each{ |k,v|
+			headers[k] = v.gsub(",",";")
+		}
+
+		vprint_status("#{target_url} - Following 302 to /#{location}/ after login attempt.")
+
+		begin
+			# Request the URI
+			res = send_request_raw({
+				'uri'     => "/#{location}/",
+				'method'  => 'GET',
+				'headers' => headers,
+			}, 20)
+			return :abort if not res
+
+			rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable
+			rescue ::Rex::ConnectionTimeout
+			rescue ::Timeout::Error, ::Errno::EPIPE
+		end
+
+		case res.code
+		when 200
+			return res
+		when 301
+			follow_302(res,headers)
+		when 302
+			follow_302(res,headers)
+		when 404
+			vprint_status("Received a 404 after login seemed successful, proceeding as if it was a good thing.")
+			return res
+		else
+			vprint_status("Unknown response code #{res.code} after login redirect, proceeding as if it's a good thing.")
+			return res
+		end
+	end
+
+	def do_login_basic(user=nil, pass=nil)
+		# Attempt an http basic login
+		user = "" if user == "null"
+		pass = "" if pass == "null"
+
+		success = (not @interface['success']) ? " " : @interface['success']
+
+		print_status("#{target_url}#{@post_to} - #{@interface['title']} - Trying username:'#{user}' with password:'#{pass}'")
+
+		begin
+			res = send_request_raw({
+				'method'  => 'GET',
+				'uri'	  => @post_to,
+				'basic_auth' => "#{user.to_s}:#{pass.to_s}"
+				}, 20)
+			rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+			rescue ::Timeout::Error, ::Errno::EPIPE
+		end
+
+		print_error("#{target_url} Failed when connecting") if not res
+
+		if res
+			case res.code
+				when 200
+					if(check_fingerprint(res,success))
+						print_good("#{target_url}#{@post_to} - #{@interface['title']} - Basic Auth SUCCESSFUL '#{user}':'#{pass}'")
+						@success = false
+						report_creds(user,pass)
+					end
+				when 302
+					print_good("#{target_url}#{@post_to} - Received 302, assuming SUCCESSFUL #{title} login for '#{user}':'#{pass}'")
+					report_creds(user,pass)
+				when 401
+					print_error("#{target_url}#{@post_to} - #{@interface['title']} - Failed to login as '#{user}'")
+				when 404
+					print_error("#{target_url}#{@post_to} - Received a 404, how odd.")
+				else
+					print_status("#{target_url}#{@post_to} - Response code #{res.code} undefined.")
+			end
+		end
+	end
+
+	def write_data()
+		# The goal here is that page responses could be saved and could be parsed offline
+		#	Successful responses (if they exist) are stored in an other hash and need
+		#	to be merged.
+
+		responses = @responses.merge(@successful_login_responses)
+
+		responses.each do |login,res|
+			next if not res
+			next if res.class == Hash
+
+			save_responses(login,res)
+		end
+	end
+
+	def too_many_failed_attempts()
+		return true if @fails > 2
+	end
+
+	def report_creds(user,pass)
+		report_hash = {
+				:host   => target_url.split(":")[0],
+				:port   => datastore['RPORT'],
+				:sname  => @interface['title'],
+				:user   => user,
+				:pass   => pass,
+				:active => true,
+				:source_type => "interface_fingerprinter",
+				:type => 'password'
+			}
+		report_auth_info(report_hash)
+	end
+
+	def save_responses(login,res)
+		# Below is stolen from crawler.rb
+
+		info = {
+			:web_site => "#{target_url}",
+			:path     => login,
+			:code     => res.code,
+			:body     => res.body,
+			:headers  => res.headers.to_s,
+			:host => rhost,
+			:port => rport
+		}
+
+		if res.headers['content-type']
+			info[:ctype] = res.headers['content-type']
+		end
+
+		if res.headers['set-cookie']
+			info[:cookie] = res.headers['set-cookie']
+		end
+
+		if res.headers['authorization']
+			info[:auth] = res.headers['authorization']
+		end
+
+		if res.headers['location']
+			info[:location] = res.headers['location']
+		end
+
+		if res.headers['last-modified']
+			info[:mtime] = res.headers['last-modified']
+		end
+
+		# Report the web page to the database
+		report_web_page(info)
+	end
+
+		def target_url
+		vhost = rhost if not vhost
+		"#{vhost}:#{rport}#{datastore['Dir']}"
+	end
+
+	def check_fingerprint(res,regex)
+		# Check the server response against the configuration regex
+		pattern = Regexp.new(regex,Regexp::IGNORECASE | Regexp::MULTILINE)
+
+		if (res.body.to_s =~ pattern)
+			vprint_status("#{target_url}#{@post_to} - Response matched #{pattern} in the body")
+			return true
+		elsif (res.headers.to_s =~ pattern)
+			vprint_status("#{target_url}#{@post_to} - Response matched #{pattern} in the headers")
+			return true
+		end
+		return false
+	end
+
+end

--- a/modules/auxiliary/scanner/http/interface_fingerprinter.rb
+++ b/modules/auxiliary/scanner/http/interface_fingerprinter.rb
@@ -182,7 +182,7 @@ class Metasploit3 < Msf::Auxiliary
 				vprint_status("#{target_url}#{login} - Storing response")
 				
 				# This is updates the login with the response. It's kind of ugly but
-				#	had to do it for ruby1.9.2 support
+				#	had to do it for ruby1.9.3 support
 				@responses = @responses.merge({ login => res})
 			else
 				vprint_status("#{target_url}#{login} - Duplicate response, not storing.")
@@ -297,7 +297,7 @@ class Metasploit3 < Msf::Auxiliary
 					if @interface['creds'] and not datastore['NoDefault']
 						# First try the default credentials in the config file
 						@interface['creds'].each do |cred|
-							do_login_basic(cred.to_s.split(":")[0],cred.split(":")[1])
+							do_login_basic(cred.split(":")[0],cred.split(":")[1])
 						end
 					end
 

--- a/modules/auxiliary/scanner/http/interface_fingerprinter.rb
+++ b/modules/auxiliary/scanner/http/interface_fingerprinter.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Auxiliary
 		)
 
 		register_options(
-			[ OptString.new('CONFIG', [false, 'Path to the Interface fingerprinter db', "#{Msf::Config.install_root}/data/interface_fingerprints/readme.yml"]),
+			[ OptPath.new('CONFIG', [false, 'Path to the Interface fingerprinter db', "#{Msf::Config.install_root}/data/interface_fingerprints/readme.yml"]),
 			OptString.new('SingleInterface', [false, 'A single web interface to check for.', ""]),
 			OptString.new('DIR', [false, 'To check in a non default directory (e.g. /admin/', ""]),
 		], self.class)
@@ -47,6 +47,9 @@ class Metasploit3 < Msf::Auxiliary
 			[OptBool.new('NoDefault', [false, 'Do not attempt the default credentials', false]),
 			OptInt.new('Delay', [false, 'Wait n seconds between requests', 0]),
 		], self.class)
+		
+		# To support older versions of ruby
+		YAML::ENGINE.yamler= 'syck'
 	end
 
 	def run_host(ip)


### PR DESCRIPTION
This auxiliary module attempts to fingerprint common or known web interfaces and attempt to bruteforce the login. The goal is to provide a module that can be used to scan a large swath of IPs looking for known interfaces with weak or no password /and/ simplify the creation of interface fingerprints.

At a high level the way it works for one host is:
1. Pulls in all unique URIs from the YAML configuration file.
2. Scans the target attempting all of the URIs
3. Responses are handeled: 
    - 302s are followed until they hit a 200 and then see below
    - 404s are tossed out
    - All other responses are saved unless they match the previous response (meant to avoid situations where all pages are responding the same and we are still storing it)
4. After all URIs responses are saved, each response is compared against the interface fingerprints
5. If a match is found and, unless otherwise specified, a login attempt is performed. First, the default creds from the YAML file are attempted and then the user provided credentials.
6. The response is compared against success regex in the YAML file. Succesful creds are stored in the database.
7. All responses from above are stored in the database. 

 For example, the following fingerprint should cover the bruteforce of tomcat_mgr_login (not the exploit portion). Github crushes the YAML syntax but should be clear:
- title: Apache Tomcat
- fingerprint_page: [/manager/html/, /tomcat/manager/html/]
- fingerprint: Apache.*(Coyote|Tomcat)
- creds: [tomcat:tomcat, admin:admin, manager:manager]
- basic_auth: true

A more complicated fingerprint would be using info from owa_login (OWA 2010):
- title: Outlook Web Access 2010
- fingerprint_page: /owa/auth/logon.aspx
- fingerprint: (OutlookSession)
- post_to: /owa/auth.owa
- follow_302: true
- cookie: PBack=0; owacsdc=1
- login_headers: { Content-Type: application/x-www-form-urlencoded }
- login_params: destination=https%3A%2F%2F$$$vhost$$$%2Fowa%2F&flags=0&forcedownlevel=0&trusted=0&username=$$$domain$$$\$$$user$$$&password=$$$pass$$$&isUtf8=1
- success: (Junk)

The fingerprints are stored in YAML files depending on the type of device (e.g. web interface).I've added fingerprints for some of the current aux http scanner login modules; only the bruteforce portion is added not anything else (e.g. username enumeration based on error messages):
- axis_login
- frontpage_login
- glassfish_login 
- owa_login
- tomcat_mgr_login
- wordpress_enum  
