### PR TITLE
Add DNS/TCP to enum_dns

### DIFF
--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -54,6 +54,7 @@ class Metasploit3 < Msf::Auxiliary
 			[
 				OptInt.new('RETRY', [ false, "Number of times to try to resolve a record if no response is received", 2]),
 				OptInt.new('RETRY_INTERVAL', [ false, "Number of seconds to wait before doing a retry", 2]),
+				OptBool.new('TCP_DNS', [false, "Run queries over TCP", false]),
 			], self.class)
 	end
 
@@ -468,6 +469,10 @@ class Metasploit3 < Msf::Auxiliary
 
 	def run
 		@res = Net::DNS::Resolver.new()
+		if datastore['TCP_DNS']
+	                vprint_good("Using DNS/TCP")
+                	@res.use_tcp = true
+                end 
 		@res.retry = datastore['RETRY'].to_i
 		@res.retry_interval = datastore['RETRY_INTERVAL'].to_i
 		@threadnum = datastore['THREADS'].to_i

--- a/modules/auxiliary/scanner/telnet/telnet_version.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_version.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Auxiliary
 			::Timeout.timeout(to) do
 				res = connect
 				# This makes db_services look a lot nicer.
-				banner_santized = Rex::Text.to_hex_ascii(banner.to_s.unpack('C*').pack('U*'))
+				banner_santized = Rex::Text.to_hex_ascii(banner.to_s)
 				print_status("#{ip}:#{rport} TELNET #{banner_santized}")
 				report_service(:host => rhost, :port => rport, :name => "telnet", :info => banner_santized)
 			end


### PR DESCRIPTION
Quick fix which adds use_tcp = true to the Net::DNS::Resolver object. 

TODO: Convert Net::DNS to use Rex::Socket, which starts the process for creating DNS handlers on Rex::Socket listeners, allows use of proxies, routes, etc.
