### PR TITLE
Fix msfvenom to correctly generate elf binaries for bsd and solaris platform

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1870,12 +1870,20 @@ End Sub
 			end
 
 		when 'elf'
-			if (not arch or (arch.index(ARCH_X86)))
-				output = Msf::Util::EXE.to_linux_x86_elf(framework, code, exeopts)
-			end
-
-			if (arch and (arch.index( ARCH_X86_64 ) or arch.index( ARCH_X64 )))
-				output = Msf::Util::EXE.to_linux_x64_elf(framework, code, exeopts)
+			if (not plat or (plat.index(Msf::Module::Platform::Linux)))
+				if (not arch or (arch.index(ARCH_X86)))
+					output = Msf::Util::EXE.to_linux_x86_elf(framework, code, exeopts)
+				elsif (arch and (arch.index( ARCH_X86_64 ) or arch.index( ARCH_X64 )))
+					output = Msf::Util::EXE.to_linux_x64_elf(framework, code, exeopts)
+				end
+			elsif(plat and (plat.index(Msf::Module::Platform::BSD)))
+				if (not arch or (arch.index(ARCH_X86)))
+					output = Msf::Util::EXE.to_bsd_x86_elf(framework, code, exeopts)
+				end
+			elsif(plat and (plat.index(Msf::Module::Platform::Solaris)))
+				if (not arch or (arch.index(ARCH_X86)))
+					output = Msf::Util::EXE.to_solaris_x86_elf(framework, code, exeopts)
+				end
 			end
 
 		when 'macho'

--- a/msfvenom
+++ b/msfvenom
@@ -448,15 +448,31 @@ when /java/i
 		print_error("Could not generate payload format")
 	end
 when /elf/i
-	if opts[:arch] =~ /x64/
-		elf = Msf::Util::EXE.to_linux_x64_elf($framework, payload_raw, exeopts)
-	elsif opts[:arch] =~ /x86/
-		elf = Msf::Util::EXE.to_linux_x86_elf($framework, payload_raw, exeopts)
-	elsif opts[:arch] =~ /arm/
-		elf = Msf::Util::EXE.to_linux_armle_elf($framework, payload_raw, exeopts)
-	else
-		print_error("This format does not support that architecture")
-		exit
+	if (not opts[:platform] or (opts[:platform].index(Msf::Module::Platform::Linux)))
+		if opts[:arch] =~ /x64/
+			elf = Msf::Util::EXE.to_linux_x64_elf($framework, payload_raw, exeopts)
+		elsif opts[:arch] =~ /x86/
+			elf = Msf::Util::EXE.to_linux_x86_elf($framework, payload_raw, exeopts)
+		elsif opts[:arch] =~ /arm/
+			elf = Msf::Util::EXE.to_linux_armle_elf($framework, payload_raw, exeopts)
+		else
+			print_error("This format does not support that architecture")
+			exit
+		end
+	elsif(opts[:platform].index(Msf::Module::Platform::BSD))
+		if opts[:arch] =~ /x86/
+			elf = Msf::Util::EXE.to_bsd_x86_elf($framework, payload_raw, exeopts)
+		else
+			print_error("This format does not support that architecture")
+			exit
+		end
+	elsif(opts[:platform].index(Msf::Module::Platform::Solaris))
+		if opts[:arch] =~ /x86/
+			elf = Msf::Util::EXE.to_solaris_x86_elf($framework, payload_raw, exeopts)
+		else
+			print_error("This format does not support that architecture")
+			exit
+		end
 	end
 	$stdout.write elf
 when /macho/i


### PR DESCRIPTION
needed for an upcoming pull request

nb : 

when generating elf binaries with x86/shikata_ga_nai encoder the binary file is not really stable on linux platform, However this is not related to this patch.
