### PR TITLE
quoting ip to avoid php complaining

### DIFF
--- a/modules/payloads/singles/php/reverse_php.rb
+++ b/modules/payloads/singles/php/reverse_php.rb
@@ -69,7 +69,7 @@ module Metasploit3
 		end		
 
 		shell=<<-END_OF_PHP_CODE
-		$ipaddr=#{ipaddr};
+		$ipaddr='#{ipaddr}';
 		$port=#{port};
 		#{php_preamble({:disabled_varname => "$dis"})}
 


### PR DESCRIPTION
While testing the SugarCRM unserialize() RCE php_reverse_tcp complained about the IP:

[Mon Jun 25 03:13:14 2012] [error] [client 192.168.1.157] PHP Parse
error:  syntax error, unexpected T_DNUMBER in
/var/www/sugarsuite/pathCache.php on line 1

Putting in quotes the string fixed this.
