### PR TITLE
Correct the use of the platform argument

### DIFF
--- a/modules/encoders/x86/alpha_mixed.rb
+++ b/modules/encoders/x86/alpha_mixed.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Encoder::Alphanum
 	# Configure SEH getpc code on Windows
 	#
 	def init_platform(platform)
-		if(::Msf::Module::PlatformList.from_a(platform).supports?(::Msf::Module::PlatformList.win32))
+		if(platform.supports?(::Msf::Module::PlatformList.win32))
 			datastore['AllowWin32SEH'] = true
 		end
 	end

--- a/msfvenom
+++ b/msfvenom
@@ -375,7 +375,8 @@ if opts[:encode]
 
 			1.upto(opts[:iterations].to_i) do |iteration|
 					begin
-						raw = enc.encode(payload_raw.dup, opts[:badchars], nil, opts[:platform])
+						plist = ::Msf::Module::PlatformList.from_a(opts[:platform])
+						raw = enc.encode(payload_raw.dup, opts[:badchars], nil, plist)
 					rescue Msf::EncodingError
 						print_error("#{enc.refname} failed: #{$!.class} : #{$!}")
 						skip = true

--- a/msfvenom
+++ b/msfvenom
@@ -310,7 +310,7 @@ opts[:badchars] = Rex::Text.hex_to_raw(opts[:badchars])                if opts[:
 # set the defaults unless something is already set by the user
 if opts[:payload] != 'stdin'
 	opts[:arch]     ||= payload.arch[0]
-	opts[:platform] ||= payload.platform.platforms
+	opts[:platform] ||= Msf::Module::PlatformList.transform(payload.platform.platforms)
 else
 	# defaults for stdin payloads users should define them
 	unless opts[:arch]
@@ -375,8 +375,7 @@ if opts[:encode]
 
 			1.upto(opts[:iterations].to_i) do |iteration|
 					begin
-						plist = ::Msf::Module::PlatformList.from_a(opts[:platform])
-						raw = enc.encode(payload_raw.dup, opts[:badchars], nil, plist)
+						raw = enc.encode(payload_raw.dup, opts[:badchars], nil, opts[:platform])
 					rescue Msf::EncodingError
 						print_error("#{enc.refname} failed: #{$!.class} : #{$!}")
 						skip = true


### PR DESCRIPTION
The platform argument is meant to be a PlatformList object, not as an array:
http://dev.metasploit.com/redmine/issues/6826
This commit undoes the last change to init_platform() in alpha_mixed and modifies msfvenom to use it as intended.
