### PR TITLE
PDF Parser fix related to adobe_pdf_embedded_exe

### DIFF
--- a/lib/msf/core/exploit/pdf_parse.rb
+++ b/lib/msf/core/exploit/pdf_parse.rb
@@ -34,7 +34,9 @@ module Exploit::PDF_Parse
 	def trailer_parse(xref_trailer)
 		trailer = Hash.new()
 
-		trailer["Size"] = xref_trailer.match(/Size (\d+)/m)[1]
+		if match = xref_trailer.match(/Size (\d+)/m)
+			trailer['Size'] = match[1]
+		end
 
 		if match = xref_trailer.match(/Root (\d+ \d)/m)
 			trailer["Root"] = match[1]

--- a/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
+++ b/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
@@ -79,10 +79,14 @@ class Metasploit3 < Msf::Exploit::Remote
 		startxrefs	= pdf_objects[2]
 		root_obj	= pdf_objects[3]
 
-		output = basic_social_engineering_exploit(xref_trailers,root_obj,stream,trailers,file_name,exe_name,startxrefs.last)
+		begin
+			output = basic_social_engineering_exploit(xref_trailers,root_obj,stream,trailers,file_name,exe_name,startxrefs.last)
 
-		print_status("Creating '#{datastore['FILENAME']}' file...")
-		file_create(output)
+			print_status("Creating '#{datastore['FILENAME']}' file...")
+			file_create(output)
+		rescue KeyError => e
+			print_error("Incompatible PDF structure: #{e.message}. Please try a different PDF.")
+		end
 	end
 
 


### PR DESCRIPTION
This addresses 2 issues while using adobe_pdf_embedded_exe:

1) In some PDFs, the Size field may not exist. And that can trigger a undefined method `[]' for nil:NilClass bug.  The exploit does NOT need this field to function.

2) In some PDFs, other fields (such as 'Info' during my test) also may not exist.  This can cause a "KeyError key not found" error, which can be sort of confusing.  To make this message more understandable, we catch this exception, and do a more user-friendly warning that the user-supplied PDF is not compatible.
