### PR TITLE
Fix broken reload_modules function

### DIFF
--- a/lib/msf/core/module_manager.rb
+++ b/lib/msf/core/module_manager.rb
@@ -498,17 +498,17 @@ class ModuleManager < ModuleSet
 			init_module_set(type)
 		end
 
-		# The counts loaded modules in the following categories:
+		# The number of loaded modules in the following categories:
 		# auxiliary/encoder/exploit/nop/payload/post
-		counts = 0
+		count = 0
 		module_paths.each do |path|
 			mods = load_modules(path, true)
-			mods.each_value {|c| counts += c}
+			mods.each_value {|c| count += c}
 		end
 
 		rebuild_cache
 
-		counts
+		count
 	end
 
 	#

--- a/lib/msf/core/module_manager.rb
+++ b/lib/msf/core/module_manager.rb
@@ -292,6 +292,7 @@ protected
 	attr_accessor :mod_arch_hash, :mod_platform_hash
 	attr_accessor :mod_sorted, :mod_ranked
 	attr_accessor :mod_extensions, :mod_ambiguous
+	attr_accessor :module_history
 
 end
 
@@ -497,12 +498,16 @@ class ModuleManager < ModuleSet
 			init_module_set(type)
 		end
 
+		# The counts loaded modules in the following categories:
+		# auxiliary/encoder/exploit/nop/payload/post
+		counts = 0
 		module_paths.each do |path|
-			counts = load_modules(path, true)
+			mods = load_modules(path, true)
+			mods.each_value {|c| counts += c}
 		end
 
 		rebuild_cache
-		
+
 		counts
 	end
 


### PR DESCRIPTION
This fixes 2 issues:
1) undefined method `module_history=' 

2) Return the number of the modules reloaded.  Since there's no documentation regarding exactly what type of data this function should be returning, I assume it's actually trying to return the total.
