### PR TITLE
Add more ZDI references for QuickTime

### DIFF
--- a/modules/exploits/windows/fileformat/apple_quicktime_texml.rb
+++ b/modules/exploits/windows/fileformat/apple_quicktime_texml.rb
@@ -35,7 +35,10 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'OSVDB', '81934' ],
 					[ 'CVE', '2012-0663' ],
 					[ 'BID', '53571' ],
+					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-12-095/' ],
 					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-12-107/' ],
+					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-12-108/' ],
+					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-12-109/' ],
 					[ 'URL', 'http://support.apple.com/kb/HT1222' ]
 				],
 			'Payload'        =>


### PR DESCRIPTION
All these ZDI advisories are really talking about the same buggy code being reused all over the place. They all have the same CVE, so we'll just add all these under the same module.
