### PR TITLE
Fix up rev_http handler

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -93,7 +93,7 @@ module ReverseHttp
 			[
 				OptString.new('LHOST', [ true, "The local listener hostname" ]),
 				OptPort.new('LPORT', [ true, "The local listener port", 8443 ])
-			], Msf::Handler::ReverseHttps
+			], Msf::Handler::ReverseHttp)
 
 		register_advanced_options(
 			[


### PR DESCRIPTION
Fixes http handler after last night's modifications (fixes 551).
In my testing, rev_http and rev_https still not produce live sessions - check 534
