### PR TITLE
ReflectiveLoader x64 compiler optimization edge case

### DIFF
--- a/external/source/meterpreter/source/ReflectiveDLLInjection/ReflectiveLoader.c
+++ b/external/source/meterpreter/source/ReflectiveDLLInjection/ReflectiveLoader.c
@@ -32,7 +32,11 @@ HINSTANCE hAppInstance = NULL;
 //===============================================================================================//
 #ifdef _WIN64
 #pragma intrinsic( _ReturnAddress )
-UINT_PTR eip( VOID ) { return (UINT_PTR)_ReturnAddress(); }
+// This function can not be inlined by the compiler or we will not get the address we expect. Ideally 
+// this code will be compiled with the /O2 and /Ob1 switches. Bonus points if we could take advantage of 
+// RIP relative addressing in this instance but I dont believe we can do so with the compiler intrinsics 
+// available (and no inline asm available under x64).
+__declspec(noinline) UINT_PTR eip( VOID ) { return (UINT_PTR)_ReturnAddress(); }
 #endif
 //===============================================================================================//
 


### PR DESCRIPTION
This is a tiny change to the ReflectiveLoader to help avoid an edge case when being compiled under x64 with  certain compiler optimization flags being used in some meterpreter extensions (which force the eip() function to be incorrectly inlined, introducing unexpected behavior).

I haven't updated the bins as I can't build the sniffer extension, which was the one HD mentioned was borking, however espia seems fine though.

Somebody who can reproduce the initial problem will need to rebuild the offending extension(s) and confirm the patch works! ...otherwise I'll keep digging :)
