### PR TITLE
Bug Fix to "Stamp Out" LM and NTLM Hash Corruption in Hashdump Code

### DIFF
--- a/modules/post/windows/gather/smart_hashdump.rb
+++ b/modules/post/windows/gather/smart_hashdump.rb
@@ -162,28 +162,19 @@ class Metasploit3 < Msf::Post
 		users.each_key do |rid|
 			user = users[rid]
 
-			hashlm_off = nil
-			hashnt_off = nil
-			hashlm_enc = nil
-			hashnt_enc = nil
+			hashlm_enc = ""
+			hashnt_enc = ""
 
 			hoff = user[:V][0x9c, 4].unpack("V")[0] + 0xcc
 
-			# Lanman and NTLM hash available
-			if(hoff + 0x28 < user[:V].length)
-				hashlm_off = hoff +  4
-				hashnt_off = hoff + 24
-				hashlm_enc = user[:V][hashlm_off, 16]
-				hashnt_enc = user[:V][hashnt_off, 16]
-				# No stored lanman hash
-			elsif (hoff + 0x14 < user[:V].length)
-				hashnt_off = hoff + 8
-				hashnt_enc = user[:V][hashnt_off, 16]
-				hashlm_enc = ""
-				# No stored hashes at all
-			else
-				hashnt_enc = hashlm_enc = ""
-			end
+			#Check if hashes exist (if 20, then we've got a hash)
+			lm_exists = user[:V][0x9c+4,4].unpack("V")[0] == 20 ? true : false
+			nt_exists = user[:V][0x9c+16,4].unpack("V")[0] == 20 ? true : false
+
+			#If we have a hashes, then parse them (Note: NT is dependant on LM)
+			hashlm_enc = user[:V][hoff + 4, 16] if lm_exists
+			hashnt_enc = user[:V][(hoff + (lm_exists ? 24 : 8)), 16] if nt_exists
+
 			user[:hashlm] = decrypt_user_hash(rid, hbootkey, hashlm_enc, @sam_lmpass)
 			user[:hashnt] = decrypt_user_hash(rid, hbootkey, hashnt_enc, @sam_ntpass)
 		end

--- a/scripts/meterpreter/hashdump.rb
+++ b/scripts/meterpreter/hashdump.rb
@@ -122,28 +122,19 @@ def decrypt_user_keys(hbootkey, users)
 	users.each_key do |rid|
 		user = users[rid]
 
-		hashlm_off = nil
-		hashnt_off = nil
-		hashlm_enc = nil
-		hashnt_enc = nil
+		hashlm_enc = ""
+		hashnt_enc = ""
 
 		hoff = user[:V][0x9c, 4].unpack("V")[0] + 0xcc
 
-		# Lanman and NTLM hash available
-		if(hoff + 0x28 < user[:V].length)
-			hashlm_off = hoff +  4
-			hashnt_off = hoff + 24
-			hashlm_enc = user[:V][hashlm_off, 16]
-			hashnt_enc = user[:V][hashnt_off, 16]
-		# No stored lanman hash
-		elsif (hoff + 0x14 < user[:V].length)
-			hashnt_off = hoff + 8
-			hashnt_enc = user[:V][hashnt_off, 16]
-			hashlm_enc = ""
-		# No stored hashes at all
-		else
-			hashnt_enc = hashlm_enc = ""
-		end
+		#Check if hashes exist (if 20, then we've got a hash)
+		lm_exists = user[:V][0x9c+4,4].unpack("V")[0] == 20 ? true : false
+		nt_exists = user[:V][0x9c+16,4].unpack("V")[0] == 20 ? true : false
+
+		#If we have a hashes, then parse them (Note: NT is dependant on LM)
+		hashlm_enc = user[:V][hoff + 4, 16] if lm_exists
+		hashnt_enc = user[:V][(hoff + (lm_exists ? 24 : 8)), 16] if nt_exists
+
 		user[:hashlm] = decrypt_user_hash(rid, hbootkey, hashlm_enc, @sam_lmpass)
 		user[:hashnt] = decrypt_user_hash(rid, hbootkey, hashnt_enc, @sam_ntpass)
 	end


### PR DESCRIPTION
-This commit Addresses Metasploit Bug #4402 that notes corrupted (aka: incorrect) hashes yielded from hashdump
-Fail case can be reliably reproduced on a Windows system where (1) a user is not storing an LM hash and (2) password histories are enabled on the system
-This issue along with other extraction tools that are affected in a similar way will be discussed at BlackHat USA 2012 and DEFCON 20 in 2 weeks.

If you have questions, please let us know.

-Jonathan Claudius (@claudijd)
-Ryan Reynolds (@reynoldsrb)
