### PR TITLE
Various meterpreter bugfixes

### DIFF
--- a/external/source/meterpreter/source/common/base.c
+++ b/external/source/meterpreter/source/common/base.c
@@ -212,7 +212,7 @@ VOID command_throtle( int maxthreads )
 }
 */
 
-#ifndef WIN32
+#ifndef _WIN32
 /*
  * Reap child zombie threads on linux 2.4 (before NPTL)
  * each thread appears as a process and pthread_join don't necessarily reap it

--- a/external/source/meterpreter/source/common/base.c
+++ b/external/source/meterpreter/source/common/base.c
@@ -125,7 +125,7 @@ DWORD command_register(Command *command)
 {
 	Command *newCommand;
 
-	dprintf("Registering a new command...");
+	dprintf("Registering a new command (%s)...", command->method);
 	if (!(newCommand = (Command *)malloc(sizeof(Command))))
 		return ERROR_NOT_ENOUGH_MEMORY;
 
@@ -212,6 +212,23 @@ VOID command_throtle( int maxthreads )
 }
 */
 
+#ifndef WIN32
+/*
+ * Reap child zombie threads on linux 2.4 (before NPTL)
+ * each thread appears as a process and pthread_join don't necessarily reap it
+ * threads are created using the clone syscall, so use special __WCLONE flag in waitpid
+ */
+
+VOID reap_zombie_thread(void * param)
+{
+	while(1) {
+		waitpid(-1, NULL, __WCLONE);
+		// on 2.6 kernels, don't chew 100% CPU
+		usleep(500000);
+	}
+}
+#endif
+
 /*
  * Process a single command in a seperate thread of execution.
  */
@@ -243,6 +260,11 @@ DWORD THREADCALL command_process_thread( THREAD * thread )
 		commandThreadList = list_create();
 		if( commandThreadList == NULL )
 			return ERROR_INVALID_HANDLE;
+#ifndef _WIN32
+		pthread_t tid;
+		pthread_create(&tid, NULL, reap_zombie_thread, NULL);
+		dprintf("reap_zombie_thread created, thread_id : 0x%x",tid);
+#endif
 	}
 
 	list_add( commandThreadList, thread );

--- a/external/source/meterpreter/source/common/common.h
+++ b/external/source/meterpreter/source/common/common.h
@@ -15,6 +15,8 @@
 
 #include <fcntl.h>
 
+#include <sys/types.h>
+#include <sys/wait.h>
 #include <sys/select.h>
 #include <sys/endian.h>
 #include <netinet/in.h>

--- a/external/source/meterpreter/source/extensions/sniffer/sniffer.c
+++ b/external/source/meterpreter/source/extensions/sniffer/sniffer.c
@@ -1098,8 +1098,6 @@ DWORD __declspec(dllexport) InitServerExtension(Remote *remote)
 {
 	DWORD index;
 
-	hMetSrv = remote->hMetSrv;
-
 	dprintf("[SERVER] Registering command handlers...");
 	for (index = 0; customCommands[index].method; index++) {
 		dprintf("Registering command index %d", index);
@@ -1112,6 +1110,7 @@ DWORD __declspec(dllexport) InitServerExtension(Remote *remote)
 	memset(open_captures, 0, sizeof(open_captures));
 
 #ifdef _WIN32
+	hMetSrv = remote->hMetSrv;
 	// initialize structures for the packet sniffer sdk
 	hMgr = NULL;
 	hErr = 0;

--- a/external/source/meterpreter/source/extensions/stdapi/server/fs/file.c
+++ b/external/source/meterpreter/source/extensions/stdapi/server/fs/file.c
@@ -85,8 +85,8 @@ static DWORD file_channel_eof(Channel *channel, Packet *request,
 		LPVOID context, LPBOOL isEof)
 {
 	FileContext *ctx = (FileContext *)context;
-	
-	return feof(ctx->fd) ? TRUE : FALSE;
+	*isEof = feof(ctx->fd) ? TRUE : FALSE;
+	return ERROR_SUCCESS;
 }
 
 /*

--- a/external/source/meterpreter/source/extensions/stdapi/server/stdapi.c
+++ b/external/source/meterpreter/source/extensions/stdapi/server/stdapi.c
@@ -326,13 +326,13 @@ Command customCommands[] =
 	  { EMPTY_DISPATCH_HANDLER                                      },
 	},
 
-#ifdef _WIN32
 	// Socket
 	{ "stdapi_net_socket_tcp_shutdown",
 	  { request_net_socket_tcp_shutdown,                   { 0 }, 0 },
 	  { EMPTY_DISPATCH_HANDLER                                      },
 	},
 
+#ifdef _WIN32
 	// UI
 	{ "stdapi_ui_enable_mouse",
 	  { request_ui_enable_mouse,                           { 0 }, 0 },

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -161,11 +161,13 @@ class Console::CommandDispatcher::Stdapi::Fs
 			print_error("#{args[0]} is a directory")
 		else
 			fd = client.fs.file.new(args[0], "rb")
-
-			until fd.eof?
-				print(fd.read)
+			begin
+				until fd.eof?
+					print(fd.read)
+				end
+			# EOFError is raised if file is empty, do nothing, just catch
+			rescue EOFError
 			end
-
 			fd.close
 		end
 


### PR DESCRIPTION
reap zombie thread with 2.4 kernels / fix compilation / permit cat empty file

with 2.4 kernels (before NPTL threads), a thread was actually a process (could appear with ps and in /proc)
and sometimes, they were not reaped when using pthread_join
 (stayed zombie in the system and consumed resources)
Now, create a thread that will reap them using waitpid and __WCLONE
Cause no problem on 2.6 kernels

fix a compilation problem on sniffer extension on linux meterpreter

enable stdapi_net_socket_tcp_shutdown for linux meterpreter too

permit to cat empty files without making meterpreter exit (was en EOFError exception not caught)
see http://dev.metasploit.com/redmine/issues/7042
