### PR TITLE
ipv6 and arp_scanner fix

### DIFF
--- a/modules/auxiliary/scanner/discovery/ipv6_multicast_ping.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_multicast_ping.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Auxiliary
 			next unless p.is_ipv6?
 			host_addr = p.ipv6_saddr
 			host_mac = p.eth_saddr
-			next if host_mac == smac
+			next if host_mac == @smac
 			unless hosts[host_addr] == host_mac
 				hosts[host_addr] = host_mac
 				print_status("   |*| #{host_addr} => #{host_mac}")
@@ -55,33 +55,44 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def smac
-		datastore['SMAC'].to_s.empty? ? ipv6_mac : datastore['SMAC']
+		smac  = datastore['SMAC']
+		smac ||= get_mac(@interface) if @netifaces
+		smac ||= ipv6_mac
+		smac
 	end
 
 	def run
 		# Start capture
 		open_pcap({'FILTER' => "icmp6"})
 
+		@netifaces = true
+		if not netifaces_implemented?
+			print_error("WARNING : Pcaprub is not uptodate, some functionality will not be available")
+			@netifaces = false
+		end
+
+		@interface = datastore['INTERFACE'] || Pcap.lookupdev
+
 		# Send ping
 		print_status("Sending multicast pings...")
 		dmac = "33:33:00:00:00:01"
-
+		@smac = smac
 		# Figure out our source address by the link-local interface
 		shost = ipv6_link_address
 
 		# m-1-k-3: added some more multicast addresses from wikipedia: https://en.wikipedia.org/wiki/Multicast_address#IPv6
-		ping6("FF01::1", {"DMAC" => dmac, "SHOST" => shost, "WAIT" => false})    #node-local all nodes
-		ping6("FF01::2", {"DMAC" => dmac, "SHOST" => shost, "WAIT" => false})    #node-local all routers
-		ping6("FF02::1", {"DMAC" => dmac, "SHOST" => shost, "WAIT" => false})    #All nodes on the local network segment
-		ping6("FF02::2", {"DMAC" => dmac, "SHOST" => shost, "WAIT" => false})    #All routers on the local network segment
-		ping6("FF02::5", {"DMAC" => dmac, "SHOST" => shost, "WAIT" => false})    #OSPFv3 AllSPF routers
-		ping6("FF02::6", {"DMAC" => dmac, "SHOST" => shost, "WAIT" => false})    #OSPFv3 AllDR routers
-		ping6("FF02::9", {"DMAC" => dmac, "SHOST" => shost, "WAIT" => false})    #RIP routers
-		ping6("FF02::a", {"DMAC" => dmac, "SHOST" => shost, "WAIT" => false})    #EIGRP routers
-		ping6("FF02::d", {"DMAC" => dmac, "SHOST" => shost, "WAIT" => false})    #PIM routers
-		ping6("FF02::16", {"DMAC" => dmac, "SHOST" => shost, "WAIT" => false})   #MLDv2 reports (defined in RFC 3810)
-		ping6("ff02::1:2", {"DMAC" => dmac, "SHOST" => shost, "WAIT" => false})  #All DHCP servers and relay agents on the local network site (defined in RFC 3315)
-		ping6("ff05::1:3", {"DMAC" => dmac, "SHOST" => shost, "WAIT" => false})  #All DHCP servers on the local network site (defined in RFC 3315)
+		ping6("FF01::1", {"DMAC" => dmac, "SHOST" => shost, "SMAC" =>  @smac, "WAIT" => false})    #node-local all nodes
+		ping6("FF01::2", {"DMAC" => dmac, "SHOST" => shost, "SMAC" =>  @smac, "WAIT" => false})    #node-local all routers
+		ping6("FF02::1", {"DMAC" => dmac, "SHOST" => shost, "SMAC" =>  @smac, "WAIT" => false})    #All nodes on the local network segment
+		ping6("FF02::2", {"DMAC" => dmac, "SHOST" => shost, "SMAC" =>  @smac, "WAIT" => false})    #All routers on the local network segment
+		ping6("FF02::5", {"DMAC" => dmac, "SHOST" => shost, "SMAC" =>  @smac, "WAIT" => false})    #OSPFv3 AllSPF routers
+		ping6("FF02::6", {"DMAC" => dmac, "SHOST" => shost, "SMAC" =>  @smac, "WAIT" => false})    #OSPFv3 AllDR routers
+		ping6("FF02::9", {"DMAC" => dmac, "SHOST" => shost, "SMAC" =>  @smac, "WAIT" => false})    #RIP routers
+		ping6("FF02::a", {"DMAC" => dmac, "SHOST" => shost, "SMAC" =>  @smac, "WAIT" => false})    #EIGRP routers
+		ping6("FF02::d", {"DMAC" => dmac, "SHOST" => shost, "SMAC" =>  @smac, "WAIT" => false})    #PIM routers
+		ping6("FF02::16", {"DMAC" => dmac, "SHOST" => shost, "SMAC" =>  @smac, "WAIT" => false})   #MLDv2 reports (defined in RFC 3810)
+		ping6("ff02::1:2", {"DMAC" => dmac, "SHOST" => shost, "SMAC" =>  @smac, "WAIT" => false})  #All DHCP servers and relay agents on the local network site (defined in RFC 3315)
+		ping6("ff05::1:3", {"DMAC" => dmac, "SHOST" => shost, "SMAC" =>  @smac, "WAIT" => false})  #All DHCP servers on the local network site (defined in RFC 3315)
 
 		# Listen for host advertisments
 		print_status("Listening for responses...")

--- a/modules/post/windows/gather/arp_scanner.rb
+++ b/modules/post/windows/gather/arp_scanner.rb
@@ -19,6 +19,7 @@ class Metasploit3 < Msf::Post
 	include Msf::Post::Common
 	include Msf::Auxiliary::Report
 
+	OUI_LIST = Rex::Oui
 
 	def initialize(info={})
 		super( update_info( info,
@@ -69,8 +70,10 @@ class Metasploit3 < Msf::Post
 						h = iphlp.SendARP(ip,0,6,6)
 						if h["return"] == client.railgun.const("NO_ERROR")
 							mac_text = h["pMacAddr"].unpack('C*').map { |e| "%02x" % e }.join(':')
-							print_status("\tIP: #{ip_text} MAC #{mac_text}")
+							company = OUI_LIST::lookup_oui_company_name(mac_text )
+							print_status("\tIP: #{ip_text} MAC #{mac_text} (#{company})")
 							report_host(:host => ip_text,:mac => mac_text)
+							report_note(:host  => ip_text, :type  => "mac_oui", :data  => company) 
 						end
 					})
 				i += 1


### PR DESCRIPTION
this small fix add mac_oui lookup to arp_scanner post module and correct some bug in the ipv6 auxiliary modules by using the netifaces extension of pcaprub.
