### PR TITLE
Fix typo in Stefan's last name (for cve-2012-1723)

### DIFF
--- a/modules/exploits/multi/browser/java_verifier_field_access.rb
+++ b/modules/exploits/multi/browser/java_verifier_field_access.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'License'        => MSF_LICENSE,
 			'Author'         =>
 				[
-					'Stefan Cornellius',     # Discoverer
+					'Stefan Cornelius',      # Discoverer
 					'mihi',                  # Vuln analysis
 					'littlelightlittlefire', # metasploit module
 					'juan vazquez',          # merged code (overlapped)


### PR DESCRIPTION
I mistyped his last name, as noticed by [mihi](https://github.com/rapid7/metasploit-framework/commit/e9ac90f7b0d1ae1f075811431dfa7deae86985e0#commitcomment-1562146).
