### PR TITLE
really limit packet count and data size in linux sniffer

### DIFF
--- a/external/source/meterpreter/source/extensions/sniffer/sniffer.c
+++ b/external/source/meterpreter/source/extensions/sniffer/sniffer.c
@@ -500,8 +500,11 @@ void packet_handler(u_char *user, const struct pcap_pkthdr *h, const u_char *byt
 
 	if(j->idx_pkts >= j->max_pkts) j->idx_pkts = 0;
 
-	if(j->pkts[j->idx_pkts]) free((void*)(j->pkts[j->idx_pkts]));
-
+	if(j->pkts[j->idx_pkts]) {
+		j->cur_pkts--;
+		j->cur_bytes -= ((PeterPacket *)(j->pkts[j->idx_pkts]))->h.caplen;
+		free((void*)(j->pkts[j->idx_pkts]));
+	}
 	j->pkts[j->idx_pkts++] = pkt;
 
 	lock_release(snifferm);


### PR DESCRIPTION
without this patch, when specifying a packet limit (500 for instance), packet count captured and data bytes captured kept increasing above 500.
For instance, meterpreter reported to metasploit that he had captured 10000 packets worth 30 Mb whereas he had only stored 500 packets.

What isn't clear with packet count is what we want when we specify 500 for example :
- 500 packets from the moment we start (so the 500 first packets, so we could stop capturing packets and have a fixed "number of bytes captured")
- maximum 500 packets until we finish (so the 500 last packets, so the number of bytes captured will vary because we free old packets and store new ones that don't have the same size)

Currently, solution 2 is implemented. 
