### PR TITLE
Oraenum - added error handling

### DIFF
--- a/modules/auxiliary/admin/oracle/oraenum.rb
+++ b/modules/auxiliary/admin/oracle/oraenum.rb
@@ -656,7 +656,11 @@ class Metasploit3 < Msf::Auxiliary
 						)
 					end
 				end
-			end
+      end
+    rescue => e
+      if e.to_s =~ /ORA-00942: table or view does not exist/
+        print_error("It appears you do not have sufficient rights to perform the check")
+      end
 		end
 	end
 end


### PR DESCRIPTION
The oraenum module has errror handling to catch instances where the user used to run the checks doesn't have the appropriate rights, however in one place (The default password check) the error handling code isn't included.  This patch just adds the same check for that code.
