### PR TITLE
added exploit for metasploit pcap_log priv-esc

### DIFF
--- a/modules/post/multi/escalate/metasploit_pcaplog.rb
+++ b/modules/post/multi/escalate/metasploit_pcaplog.rb
@@ -13,11 +13,6 @@ require 'msf/core/post/linux/priv'
 require 'msf/core/exploit/local/linux'
 require 'msf/core/exploit/local/unix'
 
-load 'lib/msf/core/post/common.rb'
-load 'lib/msf/core/post/file.rb'
-load 'lib/msf/core/exploit/local/unix.rb'
-load 'lib/msf/core/exploit/local/linux.rb'
-
 class Metasploit3 < Msf::Post
 	Rank = ManualRanking
 

--- a/modules/post/multi/escalate/metasploit_pcaplog.rb
+++ b/modules/post/multi/escalate/metasploit_pcaplog.rb
@@ -56,6 +56,7 @@ class Metasploit3 < Msf::Post
 					[
 						[ 'Linux/Unix Universal', {} ],
 					],
+				'Stance' => Msf::Exploit::Stance::Passive,
 				'DefaultTarget' => 0,
 			}
 			))

--- a/modules/post/multi/escalate/metasploit_pcaplog.rb
+++ b/modules/post/multi/escalate/metasploit_pcaplog.rb
@@ -10,7 +10,6 @@ require 'rex'
 require 'msf/core/post/common'
 require 'msf/core/post/file'
 require 'msf/core/post/linux/priv'
-require 'msf/core/exploit/local/linux_kernel'
 require 'msf/core/exploit/local/linux'
 require 'msf/core/exploit/local/unix'
 


### PR DESCRIPTION
Fairly self-explanatory, it's a priv-esc for metasploit. It someone runs the pcap_log plugin you can use this to elevate privileges, through a file-append bug which is then further leveraged by sending data that will appear in the file. I've opted for /etc/passwd, as modern crontabs refuse files that have errors, so it adds a metasploit superuser account.

Aside, the linux meterpreter is farly broken at present (confirmed with egypt) 
