### PR TITLE
Smb login update

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -194,9 +194,9 @@ class Metasploit3 < Msf::Auxiliary
 		if domain.empty? || domain == "."
 			domain_part = ""
 		else
-			domain_part = " \\\\#{domain} "
+			domain_part = " \\\\#{domain}"
 		end
-		output_message = "#{rhost}:#{rport}#{domain_part}- %s (#{smb_peer_os}) #{user} : #{pass} [#{status}]"
+		output_message = "#{rhost}:#{rport}#{domain_part} - %s (#{smb_peer_os}) #{user} : #{pass} [#{status}]"
 
 		case status
 		when 'STATUS_SUCCESS'


### PR DESCRIPTION
Fixed unset SMBDomain which caused false negatives with valid credentials (domain was being passed as Nil rather than "")

The module now responds with a print_status rather than an error if valid credentials are used but unable to login. This provides testers valuable feedback as to correct username password combinations. If physical access or RDP is available they may be able to utilise these credentials. They are stored in creds as inactive:
"STATUS_INVALID_LOGON_HOURS",
"STATUS_ACCOUNT_RESTRICTION",
"STATUS_ACCOUNT_EXPIRED",
"STATUS_ACCOUNT_DISABLED",
"STATUS_PASSWORD_EXPIRED",
"STATUS_PASSWORD_MUST_CHANGE"

Changed bogus domain to check per user rather than per host - local accounts in windows do not require the domain to be correct but domain logins will so this did not make sense to be set per host.

Moved away from smb_login to simple.login to allow parameters to be specified.
Removed the simple.connect() method which did not appear to be needed to check logins.

A lot of refactoring to stop datastore[] munging that was currently in place.

I still dont quite fathom the difference between bogus logins and guest logins, and I'm not sure how to configure a test environment to replicate these so I have (mostly) left them alone.

I have only tested on a limited scenario of a Win2k12 DC, would definitely need verification against earlier LM and linux services.
