### PR TITLE
Support more options in cmd_exec()

### DIFF
--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -38,7 +38,7 @@ module Common
 	#
 	# Returns a (possibly multi-line) String.
 	#
-	def cmd_exec(cmd, args=nil, time_out=15)
+	def cmd_exec(cmd, args=nil, time_out=15, opts={})
 		case session.type
 		when /meterpreter/
 			#
@@ -64,7 +64,8 @@ module Common
 			end
 
 			session.response_timeout = time_out
-			process = session.sys.process.execute(cmd, args, {'Hidden' => true, 'Channelized' => true})
+			opts.merge!({'Hidden' => true, 'Channelized' => true})
+			process = session.sys.process.execute(cmd, args, opts)
 			o = ""
 			while (d = process.channel.read)
 				break if d == ""


### PR DESCRIPTION
When cmd_exec() uses Process.execute(), it should be able to pass all the possible options supported by Process.execute():
- Hidden
- Channelized
- Suspended
- UseThreadToken
- Desktop
- Session
- InMemory

The source code for Process.execute() can be found here:
https://github.com/rapid7/metasploit-framework/blob/master/lib/rex/post/meterpreter/extensions/stdapi/sys/process.rb#L117

Also, since the original cmd_exec() wants Hidden and Channelized set to true, those options are still enforced for now.
