### PR TITLE
Fix report_note fail @ L77 when vendor MAC is not in OUI list

### DIFF
--- a/lib/rex/mac_oui.rb
+++ b/lib/rex/mac_oui.rb
@@ -9,7 +9,7 @@ module Oui
 		if oui
 			fullname = oui[0]
 			fullname = oui[0] + ' / ' + oui[1] if oui[1] != ""
-			
+			return fullname
 		else
 			return 'UNKNOWN'
 		end 
@@ -22,6 +22,7 @@ module Oui
 		if oui
 			fullname = oui[0]
 			fullname = oui[1] if oui[1] != ""
+			return fullname
 		else
 			return 'UNKNOWN'
 		end 

--- a/modules/auxiliary/scanner/discovery/arp_sweep.rb
+++ b/modules/auxiliary/scanner/discovery/arp_sweep.rb
@@ -71,7 +71,7 @@ class Metasploit3 < Msf::Auxiliary
 
 				while(reply = getreply())
 					next unless reply.is_arp?
-					company = OUI_LIST::lookup_oui_company_name(reply.arp_saddr_mac) || 'Vendor Unknown'
+					company = OUI_LIST::lookup_oui_company_name(reply.arp_saddr_mac)
 					print_status("#{reply.arp_saddr_ip} appears to be up (#{company}).")
 					report_host(:host => reply.arp_saddr_ip, :mac=>reply.arp_saddr_mac)
 					report_note(:host  => reply.arp_saddr_ip, :type  => "mac_oui", :data  => company) 

--- a/modules/auxiliary/scanner/discovery/arp_sweep.rb
+++ b/modules/auxiliary/scanner/discovery/arp_sweep.rb
@@ -71,7 +71,7 @@ class Metasploit3 < Msf::Auxiliary
 
 				while(reply = getreply())
 					next unless reply.is_arp?
-					company = OUI_LIST::lookup_oui_company_name(reply.arp_saddr_mac)
+					company = OUI_LIST::lookup_oui_company_name(reply.arp_saddr_mac) || 'Vendor Unknown'
 					print_status("#{reply.arp_saddr_ip} appears to be up (#{company}).")
 					report_host(:host => reply.arp_saddr_ip, :mac=>reply.arp_saddr_mac)
 					report_note(:host  => reply.arp_saddr_ip, :type  => "mac_oui", :data  => company) 


### PR DESCRIPTION
arp_sweep fails to report a host when OUI_LIST::lookup_oui_company_name fails to find the MAC address' vendor name. Resolves by setting company variable to 'Vendor Unknown' if the lookup fails. 

Is there any sense in logging these failures to add things to the OUI_LIST?
