### PR TITLE
adds console aliasing (ver2)

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2337,9 +2337,9 @@ class Core
 		when 1
 			return cmd_alias_help if args[0] == "-h" or args[0] == "--help"
 			if @aliases.keys.include?(args[0])
-				print_status("#{args[0]} is aliased to \'#{@aliases[args[0]]}\'")
+				print_status("\'#{args[0]}\' is aliased to \'#{@aliases[args[0]]}\'")
 			else
-				print_status("#{args[0]} is not currently aliased")
+				print_status("\'#{args[0]}\' is not currently aliased")
 			end
 		else
 			force = false
@@ -2447,11 +2447,10 @@ class Core
 	# Provie tab completion for aliases and commands
 	#
 	def tab_complete_aliases_and_commands(str, words)
-		#TODO:  return the same shit that driver.tab_complete essentially returns, but
-		# w/o updating the command line to overwrite the word alias
 		items = []
 		items.concat(driver.commands.keys) if driver.respond_to?('commands')
 		items.concat(driver.aliases.keys) if driver.respond_to?("aliases")
+		items
 	end
 
 	#
@@ -2686,8 +2685,9 @@ protected
 		# value
 
 		# some "safe words" to avoid for the value.  value would have to not match these regexes
+		# this is just basic idiot protection, it's not meant to be "undefeatable"
 		value.strip!
-		safe_words = [/^rm -rf \/.*$/, /^msfconsole$/]
+		safe_words = [/^rm +(-rf|-r +-f|-f +-r) +\/+.*$/, /^msfconsole$/]
 		safe_words.each do |regex|
 			# don't mess around, just return false in this case
 			return false if value =~ regex

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2368,8 +2368,7 @@ class Core
 			# smash everything that's left together
 			value = args.join(" ")
 
-			allow = (@allow_aliases == false) ? false : true
-			if allow
+			if @allow_aliases
 				if is_valid_alias?(name,value)
 					if force or (not Rex::FileUtils.find_full_path(name) and not @aliases.keys.include?(name))
 						@aliases[name] = value

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2369,7 +2369,7 @@ class Core
 			# smash everything that's left together
 			value = args.join(" ")
 
-			if self.allow_aliases
+			if driver.allow_aliases
 				if is_valid_alias?(name,value)
 					if force or (not Rex::FileUtils.find_full_path(name) and not @aliases.keys.include?(name))
 						@aliases[name] = value

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -640,7 +640,7 @@ protected
 	# executable.  This is only allowed if aliases and/or command passthru have been permitted
 	#
 	def unknown_command(method, line)
-		# what should take precedence sys commands or console aliases?  We go with aliases for now.
+		# aliases take precedence
 		aliases = @core.aliases
 		if ( allow_aliases == true and aliases.keys.include?(method) )
 			# we want to run the alias, which may contain options (like sessions -l), plus any newly supplied opts

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -119,7 +119,7 @@ class Driver < Msf::Ui::Driver
 
 		# Add the core command dispatcher as the root of the dispatcher
 		# stack
-		@@core = enstack_dispatcher(CommandDispatcher::Core)
+		@core = enstack_dispatcher(CommandDispatcher::Core)
 
 		# Report readline error if there was one..
 		if not rl_err.nil?
@@ -632,9 +632,6 @@ protected
 
 	attr_writer   :framework # :nodoc:
 	attr_writer   :command_passthru # :nodoc:
-
-	# we could link allow_aliases to the same value as command_passthru to make life easier, but 
-	# let's see if we can make it it's own option for now
 	attr_writer   :allow_aliases #:nodoc:
 	# would it be wise to do a block_command("cmd_alias") in here somewhere?
 
@@ -644,7 +641,7 @@ protected
 	#
 	def unknown_command(method, line)
 		# what should take precedence sys commands or console aliases?  We go with aliases for now.
-		aliases = @@core.aliases || {}
+		aliases = @core.aliases
 		if ( allow_aliases == true and aliases.keys.include?(method) )
 			# we want to run the alias, which may contain options (like sessions -l), plus any newly supplied opts
 			additional_opts = line.sub(method,'')

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -46,11 +46,11 @@ module DispatcherShell
 		# Returns an empty hash for an empty set of aliases.
 		#
 		# This method should be overridden to return a Hash with alias
-		# names for keys and alias values as the hash values.
+		# names for keys and alias values as the hash values. e.g. { 'ses' => 'sessions -l'}
 		#
-		#def aliases
-		#	{}
-		#end
+		def aliases
+			{}
+		end
 
 		#
 		# Returns an empty set of commands.

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -43,6 +43,16 @@ module DispatcherShell
 		end
 
 		#
+		# Returns an empty hash for an empty set of aliases.
+		#
+		# This method should be overridden to return a Hash with alias
+		# names for keys and alias values as the hash values.
+		#
+		#def aliases
+		#	{}
+		#end
+
+		#
 		# Returns an empty set of commands.
 		#
 		# This method should be overridden if the dispatcher has commands that
@@ -298,9 +308,13 @@ module DispatcherShell
 		# Enumerate each entry in the dispatcher stack
 		dispatcher_stack.each { |dispatcher|
 
-			# If no command is set and it supports commands, add them all
-			if (tab_words.empty? and dispatcher.respond_to?('commands'))
+			# TODO:  update this to use the new is_valid_dispatcher_command methods
+			# If no command is set and it supports commands, add them all and aliases
+			# Or if the command is alias and aliases are supported, add all
+			if ( (tab_words.empty? and dispatcher.respond_to?('commands')) or
+				(tab_words[0] == "alias" and dispatcher.respond_to?("aliases")) )
 				items.concat(dispatcher.commands.keys)
+				items.concat(dispatcher.aliases.keys) if dispatcher.respond_to?("aliases")
 			end
 
 			# If the dispatcher exports a tab completion function, use it
@@ -346,7 +360,7 @@ module DispatcherShell
 
 		tabs_meth = "cmd_#{words[0]}_tabs"
 		# Is the user trying to tab complete one of our commands?
-		if (dispatcher.commands.include?(words[0]) and dispatcher.respond_to?(tabs_meth))
+		if ( is_valid_dispatcher_command?(words[0],dispatcher,false) and dispatcher.respond_to?(tabs_meth) )
 			res = dispatcher.send(tabs_meth, str, words)
 			return [] if res.nil?
 			items.concat(res)
@@ -359,13 +373,45 @@ module DispatcherShell
 	end
 
 	#
+	# determine if a given method (command) is valid
+	#
+	def is_valid_dispatcher_command?(method,specific_dispatcher=nil,include_deprecated=false)
+		if specific_dispatcher
+			dispatchers = [specific_dispatcher]
+		else
+			dispatchers = dispatcher_stack
+		end
+		dispatchers.each do |dispatcher|
+			next if not dispatcher.respond_to?('commands')
+			if include_deprecated
+				if (dispatcher.commands.has_key?(method) or dispatcher.deprecated_commands.include?(method))
+					return true
+				end
+			elsif dispatcher.commands.has_key?(method)
+				return true
+			end
+		end
+		return false
+	end
+
+	#
+	# find the dispatcher that responds to the given method (command) if any
+	#
+	def get_responding_dispatcher(method,include_deprecated=true)
+		dispatcher_stack.each do |dispatcher|
+			next if not dispatcher.respond_to?('commands') # don't bother if it doesn't have any commands
+			return dispatcher if is_valid_dispatcher_command?(method,dispatcher,include_deprecated)
+		end
+		# otherwise, we didn't find a winner
+		return nil
+	end
+
+	#
 	# Run a single command line.
 	#
 	def run_single(line)
 		arguments = parse_line(line)
 		method    = arguments.shift
-		found     = false
-		error     = false
 
 		# If output is disabled output will be nil
 		output.reset_color if (output)
@@ -373,39 +419,30 @@ module DispatcherShell
 		if (method)
 			entries = dispatcher_stack.length
 
-			dispatcher_stack.each { |dispatcher|
-				next if not dispatcher.respond_to?('commands')
-
+			# to avoid walking the dispatcher stack twice, and we need the responding dispatcher
+			# we don't use is_valid_command? but rather get_responding_dispatcher
+			dispatcher = get_responding_dispatcher(method)
+			if dispatcher
 				begin
-					if (dispatcher.commands.has_key?(method) or dispatcher.deprecated_commands.include?(method))
-						self.on_command_proc.call(line.strip) if self.on_command_proc
-						run_command(dispatcher, method, arguments)
-						found = true
-					end
+					self.on_command_proc.call(line.strip) if self.on_command_proc
+					run_command(dispatcher, method, arguments)
+					return true
 				rescue
 					error = $!
-
 					print_error(
 						"Error while running command #{method}: #{$!}" +
 						"\n\nCall stack:\n#{$@.join("\n")}")
 				rescue ::Exception
 					error = $!
-
 					print_error(
 						"Error while running command #{method}: #{$!}")
 				end
-
-				# If the dispatcher stack changed as a result of this command,
-				# break out
-				break if (dispatcher_stack.length != entries)
-			}
-
-			if (found == false and error == false)
+			else
 				unknown_command(method, line)
 			end
+			return false
 		end
-
-		return found
+		return false
 	end
 
 	#

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -308,7 +308,7 @@ module DispatcherShell
 		# Enumerate each entry in the dispatcher stack
 		dispatcher_stack.each { |dispatcher|
 
-			# TODO:  update this to use the new is_valid_dispatcher_command methods
+			# TODO:  update this to use is_valid_dispatcher_command methods?
 			# If no command is set and it supports commands, add them all and aliases
 			# Or if the command is alias and aliases are supported, add all
 			if ( (tab_words.empty? and dispatcher.respond_to?('commands')) or


### PR DESCRIPTION
see commit history for details, but adds the 'alias' command to msfconsole.
Some other changes:
adds alias (cmd_alias) to core.rb
basically anything can be aliased using -f, except a few safe words like rm -rf and msfconsole, additionally an alias can't have the name alias otherwise a user could end up in a state where one cannot unalias an overaliased core command like 'set'.

Aliases will tab complete, and the alias command will tab complete with any loaded command or current alias (you can also alias an alias)
adds @aliases to core, accessed via an attr_reader and changed via the cmd_alias method
adds @allow_aliases, accessed via an attr_reader and set as a protected attr_writer by initialization and defangedness
allow_aliases follows the same relationship that command_passthru has

in order to allow cmd_alias to verify valid aliases, some changes were made to dispatcher_shell:
is_valid_dispatcher_command? was added which can search all or a specified dispatcher and has an option for whether to search deprecated commands. This provides the basis for
get_responding_dispatcher, which was also added. As a result, run_single was simplified by updating it to use get_responding_dispatcher. Possibly some other code could be updated with these methods, but I didn't want to go too nuts.

Updated after some comments from egypt.  Old PR was #637.
