### PR TITLE
Fix handling of PAYLOAD_TYPE in persistence

### DIFF
--- a/modules/post/windows/manage/persistence.rb
+++ b/modules/post/windows/manage/persistence.rb
@@ -101,7 +101,7 @@ class Metasploit3 < Msf::Post
 			end
 
 			# Set the proper payload
-			case datastore['STARTUP']
+			case datastore['PAYLOAD_TYPE']
 			when /TCP/i
 				payload = "windows/meterpreter/reverse_tcp"
 			when /HTTP/i


### PR DESCRIPTION
post/windows/manage/persistence incorrectly checked the STARTUP option
to set the payload, which meant it was always the default (reverse_tcp).
Changed to check PAYLOAD_TYPE instead, as intended.
