### PR TITLE
Fix use of URI option for glassfish_login

### DIFF
--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Auxiliary
 		register_options(
 			[
 				Opt::RPORT(4848),
-				OptString.new('URI', [true, 'The URI path of the GlassFish Server', '/']),
+				OptString.new('TARGETURI', [true, 'The URI path of the GlassFish Server', '/']),
 				OptString.new('USERNAME',[true, 'A specific username to authenticate as','admin']),
 			], self.class)
 	end
@@ -104,7 +104,7 @@ class Metasploit3 < Msf::Auxiliary
 		headers['Content-Length'] = data.length if data != nil
 
 		res = send_request_raw({
-			'uri'	  => path,
+			'uri'	  => "#{target_uri.path}#{path}".gsub(/\/\//, '/'),
 			'method'  => method,
 			'data'	  => data,
 			'headers' => headers,


### PR DESCRIPTION
auxiliary/scanner/http/glassfish_login offers URI option to set the path
where Glassfish is installed, but it doesn't work. Replaced it with
TARGETURI and call target_uri.path to get a base path.
