### PR TITLE
Fix unused ADDR_DST option in fuzz_beacon

### DIFF
--- a/modules/auxiliary/fuzzers/wifi/fuzz_beacon.rb
+++ b/modules/auxiliary/fuzzers/wifi/fuzz_beacon.rb
@@ -100,7 +100,7 @@ class Metasploit3 < Msf::Auxiliary
 			"\x80" +                      # type/subtype
 			"\x00" +                      # flags
 			"\x00\x00" +                  # duration
-			"\xff\xff\xff\xff\xff\xff" +  # dst
+			eton(datastore['ADDR_DST']) + # dst
 			bssid +                       # src
 			bssid +                       # bssid
 			seq   +                       # seq


### PR DESCRIPTION
auxiliary/fuzzers/wifi/fuzz_beacon offers ADDR_DST option, probably
copy-pasted from some other wifi modules, but does not use it, likely
because beacons are meant to be sent to broadcast address only. Since
this is a fuzzer, changing the destination address may be desirable.
Used the option in building the frame to be sent.
