### PR TITLE
This commit allows ssh_login to use socks proxies.

### DIFF
--- a/lib/net/ssh.rb
+++ b/lib/net/ssh.rb
@@ -72,7 +72,8 @@ module Net
       :rekey_limit, :rekey_packet_limit, :timeout, :verbose,
       :global_known_hosts_file, :user_known_hosts_file, :host_key_alias,
       :host_name, :user, :properties, :passphrase, :msframework, :msfmodule,
-      :record_auth_info, :skip_private_keys, :accepted_key_callback, :disable_agent
+      :record_auth_info, :skip_private_keys, :accepted_key_callback, :disable_agent,
+      :proxies
     ]
 
     # The standard means of starting a new SSH connection. When used with a

--- a/lib/net/ssh/transport/session.rb
+++ b/lib/net/ssh/transport/session.rb
@@ -74,7 +74,7 @@ module Net; module SSH; module Transport
           Rex::Socket::Tcp.create(
           	'PeerHost' => @host,
           	'PeerPort' => @port,
-		'Proxies' => options[:proxies],
+            'Proxies' => options[:proxies],
           	'Context'  => {
           	  'Msf'          => options[:msframework],
           	  'MsfExploit'   => options[:msfmodule]

--- a/lib/net/ssh/transport/session.rb
+++ b/lib/net/ssh/transport/session.rb
@@ -74,6 +74,7 @@ module Net; module SSH; module Transport
           Rex::Socket::Tcp.create(
           	'PeerHost' => @host,
           	'PeerPort' => @port,
+		'Proxies' => options[:proxies],
           	'Context'  => {
           	  'Msf'          => options[:msframework],
           	  'MsfExploit'   => options[:msfmodule]

--- a/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
@@ -44,7 +44,8 @@ class Metasploit3 < Msf::Auxiliary
 		register_options(
 			[
 				Opt::RPORT(22),
-				OptPath.new('KEY_FILE', [false, 'Filename of one or several cleartext public keys.'])
+				OptPath.new('KEY_FILE', [false, 'Filename of one or several cleartext public keys.']),
+				Opt::Proxies
 			], self.class
 		)
 
@@ -54,7 +55,8 @@ class Metasploit3 < Msf::Auxiliary
 				OptBool.new('SSH_BYPASS', [ false, 'Verify that authentication was not bypassed when keys are found', false]),
 				OptString.new('SSH_KEYFILE_B64', [false, 'Raw data of an unencrypted SSH public key. This should be used by programmatic interfaces to this module only.', '']),
 				OptPath.new('KEY_DIR', [false, 'Directory of several keys. Filenames must not begin with a dot in order to be read.']),
-				OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30])
+				OptInt.new('SSH_TIMEOUT', [ false, 'Specify the maximum time to negotiate a SSH session', 30]),
+				Opt
 			]
 		)
 
@@ -203,7 +205,8 @@ class Metasploit3 < Msf::Auxiliary
 				:record_auth_info  => true,
 				:skip_private_keys => true,
 				:config =>false,
-				:accepted_key_callback => Proc.new {|key| accepted << key }
+				:accepted_key_callback => Proc.new {|key| accepted << key },
+				:proxies	  => datastore['Proxies']
 			}
 
 			opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -70,7 +70,8 @@ class Metasploit3 < Msf::Auxiliary
 			:port          => port,
 			:disable_agent => true,
 			:password      => pass,
-			:config        => false
+			:config        => false,
+			:proxies       => datastore['Proxies']
 		}
 
 		opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -41,7 +41,8 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options(
 			[
-				Opt::RPORT(22)
+				Opt::RPORT(22),
+				Opt::Proxies
 			], self.class
 		)
 

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -47,7 +47,8 @@ class Metasploit3 < Msf::Auxiliary
 		register_options(
 			[
 				Opt::RPORT(22),
-				OptPath.new('KEY_FILE', [false, 'Filename of one or several cleartext private keys.'])
+				OptPath.new('KEY_FILE', [false, 'Filename of one or several cleartext private keys.']),
+				Opt::Proxies
 			], self.class
 		)
 
@@ -179,7 +180,8 @@ class Metasploit3 < Msf::Auxiliary
 				:key_data     => key_data,
 				:disable_agent => true,
 				:config => false,
-				:record_auth_info => true
+				:record_auth_info => true,
+				:proxies	=> datastore['Proxies']
 			}
 			opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
 			begin

--- a/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
+++ b/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
@@ -52,6 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				# Since we don't include Tcp, we have to register this manually
 				Opt::RHOST(),
 				Opt::RPORT(22),
+				Opt::Proxies
 			], self.class
 		)
 
@@ -81,7 +82,8 @@ class Metasploit3 < Msf::Exploit::Remote
 			:key_data     => [ key_data ],
 			:disable_agent => true,
 			:config => false,
-			:record_auth_info => true
+			:record_auth_info => true,
+			:proxies => datastore['Proxies']
 		}
 		opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
 		begin

--- a/modules/exploits/windows/ssh/sysax_ssh_username.rb
+++ b/modules/exploits/windows/ssh/sysax_ssh_username.rb
@@ -217,7 +217,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				{
 					:password  => pass,
 					:port      => datastore['RPORT'],
-					:timeout   => 1
+					:timeout   => 1,
+					:proxies   => datastore['Proxies']
 				})
 
 			::Timeout.timeout(1) {ssh.close} rescue nil


### PR DESCRIPTION
 Net::SSH::Transport::Session could take a :proxy option, but it expects a factory object not a string, when setting :proxy => datastore['Proxies'] user got: "Auxiliary failed: NoMethodError private method `open' called for \"socks4:localhost:1080\":String." 

VALID_OPTIONS in ssh.rb now accepts :proxies option which is passed to the Rex socket in Net::SSH::Transport::Session.new. 

Testing: block all outgoing to SSH server, try to connect with a proxy. Try with :proxy option,
then merge this pull request and try again (:proxies is now automatically set from the datastore of ssh_login).
