### PR TITLE
Updating msft links to psexec

### DIFF
--- a/modules/exploits/windows/local/current_user_psexec.rb
+++ b/modules/exploits/windows/local/current_user_psexec.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Exploit::Local
 						# same as for windows/smb/psexec
 						[ 'CVE', '1999-0504'], # Administrator with no password (since this is the default)
 						[ 'OSVDB', '3106'],
-						[ 'URL', 'http://www.microsoft.com/technet/sysinternals/utilities/psexec.mspx' ]
+						[ 'URL', 'http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx' ]
 					],
 				'DisclosureDate' => 'Jan 01 1999',
 				'Version'       => '$Revision$',

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'CVE', '1999-0504'], # Administrator with no password (since this is the default)
 					[ 'OSVDB', '3106'],
-					[ 'URL', 'http://www.microsoft.com/technet/sysinternals/utilities/psexec.mspx' ]
+					[ 'URL', 'http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx' ]
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -86,7 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'MSB', 'MS08-068'],
 					[ 'URL', 'http://blogs.technet.com/swi/archive/2008/11/11/smb-credential-reflection.aspx'],
 					[ 'URL', 'http://en.wikipedia.org/wiki/SMBRelay' ],
-					[ 'URL', 'http://www.microsoft.com/technet/sysinternals/utilities/psexec.mspx' ],
+					[ 'URL', 'http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx' ],
 					[ 'URL', 'http://www.xfocus.net/articles/200305/smbrelay.html' ]
 				],
 			'Platform'       => 'win',


### PR DESCRIPTION
Thanks for the spot @shuckins-r7 !

Microsoft changed their URLs to psexec some time ago. This should cover all references to that.
