### PR TITLE
Fix AXFR support in auxiliary/gather/enum_dns

### DIFF
--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -369,8 +369,8 @@ class Metasploit3 < Msf::Auxiliary
 				begin
 					@res.nameserver=(nssrvip)
 					zone = []
-					zone = @res.query(target,Net::DNS::AXFR)
-					if zone.answer.length != 0
+					zone = @res.axfr(target)
+					if zone.length != 0
 						print_status("Zone transfer successful")
 						report_note(:host => nssrvip,
 							:proto => 'udp',
@@ -379,80 +379,86 @@ class Metasploit3 < Msf::Auxiliary
 							:type => 'dns.enum',
 							:data => "Zone transfer successful")
 						#Prints each record according to its type
-						zone.answer.each do |rr|
-							case rr.type
-							when "A"
-								print_status("Name: #{rr.name} IP address: #{rr.address} Record: A ")
-								report_note(:host => rr.address.to_s,
-									:proto => 'udp',
-									:sname => 'dns',
-									:port => 53 ,
-									:type => 'dns.enum',
-									:data => "#{rr.address.to_s},#{rr.name},A")
-							when "SOA"
-								print_status("Name: #{rr.mname} Record: SOA")
-								report_note(:host => nssrvip,
-									:proto => 'udp',
-									:sname => 'dns',
-									:port => 53 ,
-									:type => 'dns.enum',
-									:data => "#{rr.name},SOA")
-							when "MX"
-								print_status("Name: #{rr.exchange} Preference: #{rr.preference} Record: MX")
-								report_note(:host => nssrvip,
-									:proto => 'udp',
-									:sname => 'dns',
-									:port => 53 ,
-									:type => 'dns.enum',
-									:data => "#{rr.exchange},MX")
-							when "CNAME"
-								print_status("Name: #{rr.cname} Record: CNAME")
-								report_note(:host => nssrvip,
-									:proto => 'udp',
-									:sname => 'dns',
-									:port => 53 ,
-									:type => 'dns.enum',
-									:data => "#{rr.cname},CNAME")
-							when "HINFO"
-								print_status("CPU: #{rr.cpu} OS: #{rr.os} Record: HINFO")
-								report_note(:host => nssrvip,
-									:proto => 'udp',
-									:sname => 'dns',
-									:port => 53 ,
-									:type => 'dns.enum',
-									:data => "CPU:#{rr.cpu},OS:#{rr.os},HINFO")
-							when "AAAA"
-								print_status("IPv6 Address: #{rr.address} Record: AAAA")
-								report_note(:host => rr.address.to_s,
-									:proto => 'udp',
-									:sname => 'dns',
-									:port => 53 ,
-									:type => 'dns.enum',
-									:data => "#{rr.address.to_s}, AAAA")
-							when "NS"
-								print_status("Name: #{rr.nsdname} Record: NS")
-								report_note(:host =>  nssrvip,
-									:proto => 'udp',
-									:sname => 'dns',
-									:port => 53 ,
-									:type => 'dns.enum',
-									:data => "#{rr.nsdname},NS")
-							when "TXT"
-								print_status("Text: #{rr.inspect}")
-								report_note(:host =>  nssrvip,
-									:proto => 'udp',
-									:sname => 'dns',
-									:port => 53 ,
-									:type => 'dns.enum',
-									:data => rr.inspect)
-							when "SRV"
-								print_status("Host: #{rr.host} Port: #{rr.port} Priority: #{rr.priority} Record: SRV")
-								report_note(:host =>  nssrvip,
-									:proto => 'udp',
-									:sname => 'dns',
-									:port => 53 ,
-									:type => 'dns.enum',
-									:data => "#{rr.host},#{rr.port},#{rr.priority},SRV")
+						zone.each do |response|
+							response.answer.each do |rr|
+								begin
+								case rr.type
+								when "A"
+									print_status("Name: #{rr.name} IP address: #{rr.address} Record: A ")
+									report_note(:host => rr.address.to_s,
+										:proto => 'udp',
+										:sname => 'dns',
+										:port => 53 ,
+										:type => 'dns.enum',
+										:data => "#{rr.address.to_s},#{rr.name},A")
+								when "SOA"
+									print_status("Name: #{rr.mname} Record: SOA")
+									report_note(:host => nssrvip,
+										:proto => 'udp',
+										:sname => 'dns',
+										:port => 53 ,
+										:type => 'dns.enum',
+										:data => "#{rr.name},SOA")
+								when "MX"
+									print_status("Name: #{rr.exchange} Preference: #{rr.preference} Record: MX")
+									report_note(:host => nssrvip,
+										:proto => 'udp',
+										:sname => 'dns',
+										:port => 53 ,
+										:type => 'dns.enum',
+										:data => "#{rr.exchange},MX")
+								when "CNAME"
+									print_status("Name: #{rr.cname} Record: CNAME")
+									report_note(:host => nssrvip,
+										:proto => 'udp',
+										:sname => 'dns',
+										:port => 53 ,
+										:type => 'dns.enum',
+										:data => "#{rr.cname},CNAME")
+								when "HINFO"
+									print_status("CPU: #{rr.cpu} OS: #{rr.os} Record: HINFO")
+									report_note(:host => nssrvip,
+										:proto => 'udp',
+										:sname => 'dns',
+										:port => 53 ,
+										:type => 'dns.enum',
+										:data => "CPU:#{rr.cpu},OS:#{rr.os},HINFO")
+								when "AAAA"
+									print_status("IPv6 Address: #{rr.address} Record: AAAA")
+									report_note(:host => rr.address.to_s,
+										:proto => 'udp',
+										:sname => 'dns',
+										:port => 53 ,
+										:type => 'dns.enum',
+										:data => "#{rr.address.to_s}, AAAA")
+								when "NS"
+									print_status("Name: #{rr.nsdname} Record: NS")
+									report_note(:host =>  nssrvip,
+										:proto => 'udp',
+										:sname => 'dns',
+										:port => 53 ,
+										:type => 'dns.enum',
+										:data => "#{rr.nsdname},NS")
+								when "TXT"
+									print_status("Text: #{rr.inspect}")
+									report_note(:host =>  nssrvip,
+										:proto => 'udp',
+										:sname => 'dns',
+										:port => 53 ,
+										:type => 'dns.enum',
+										:data => rr.inspect)
+								when "SRV"
+									print_status("Host: #{rr.host} Port: #{rr.port} Priority: #{rr.priority} Record: SRV")
+									report_note(:host =>  nssrvip,
+										:proto => 'udp',
+										:sname => 'dns',
+										:port => 53 ,
+										:type => 'dns.enum',
+										:data => "#{rr.host},#{rr.port},#{rr.priority},SRV")
+								end
+								rescue ActiveRecord::RecordInvalid
+									#Do nothing. Probably tried to store :host => 127.0.0.1
+								end
 							end
 						end
 					else

--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -100,7 +100,7 @@ class Metasploit3 < Msf::Auxiliary
 			query.answer.each do |rr|
 				next unless rr.class == Net::DNS::RR::A
 				print_status("Domain: #{target} IP address: #{rr.address} Record: A ")
-				report_note(:host => rr.address.to_s,
+				report_note(:host => @nsinuse.to_s,
 					:proto => 'udp',
 					:sname => 'dns',
 					:port => 53 ,
@@ -115,7 +115,7 @@ class Metasploit3 < Msf::Auxiliary
 				if (query1)
 					query1.answer.each do |ip|
 						print_status("Start of Authority: #{rr.mname} IP address: #{ip.address} Record: SOA")
-						report_note(:host => ip.address.to_s,
+						report_note(:host => @nsinuse.to_s,
 							:proto => 'udp',
 							:sname => 'dns',
 							:port => 53 ,
@@ -133,7 +133,7 @@ class Metasploit3 < Msf::Auxiliary
 					query1.answer.each do |ip|
 						next unless ip.class == Net::DNS::RR::A
 						print_status("Name Server: #{rr.nsdname} IP address: #{ip.address} Record: NS")
-						report_note(:host => ip.address.to_s,
+						report_note(:host => @nsinuse.to_s,
 							:proto => 'udp',
 							:sname => 'dns',
 							:port => 53 ,
@@ -175,6 +175,7 @@ class Metasploit3 < Msf::Auxiliary
 		target.chomp!
 		if not nssrv.nil?
 			@res.nameserver=(nssrv)
+			@nsinuse = nssrv
 		end
 		i, a = 0, []
 		tlds = [
@@ -209,7 +210,7 @@ class Metasploit3 < Msf::Auxiliary
 			if (query1)
 				query1.answer.each do |rr|
 					print_status("Domain: #{target}.#{tld} Name: #{rr.name} IP address: #{rr.address} Record: A ") if rr.class == Net::DNS::RR::A
-					report_note(:host => rr.address.to_s,
+					report_note(:host => @nsinuse.to_s,
 						:proto => 'udp',
 						:sname => 'dns',
 						:port => 53,
@@ -229,13 +230,14 @@ class Metasploit3 < Msf::Auxiliary
 		::File.open(wordlist, "rb").each_line do |line|
 			if not nssrv.nil?
 				@res.nameserver=(nssrv)
+				@nsinuse = nssrv
 			end
 			query1 = @res.search("#{line.chomp}.#{target}")
 			if (query1)
 				query1.answer.each do |rr|
 					if rr.class == Net::DNS::RR::A
 						print_status("Hostname: #{line.chomp}.#{target} IP address: #{rr.address.to_s}")
-						report_note(:host => rr.address.to_s,
+						report_note(:host => @nsinuse.to_s,
 							:proto => 'udp',
 							:sname => 'dns',
 							:port => 53 ,
@@ -256,6 +258,7 @@ class Metasploit3 < Msf::Auxiliary
 		arr = IO.readlines(wordlist)
 		if not nssrv.nil?
 			@res.nameserver=(nssrv)
+			@nsinuse = nssrv
 		end
 		arr.each do |line|
 			query1 = @res.search("#{line.chomp}.#{target}", "AAAA")
@@ -263,7 +266,7 @@ class Metasploit3 < Msf::Auxiliary
 				query1.answer.each do |rr|
 					if rr.class == Net::DNS::RR::AAAA
 						print_status("Hostname: #{line.chomp}.#{target} IPv6 Address: #{rr.address.to_s}")
-						report_note(:host => rr.address.to_s,
+						report_note(:host => @nsinuse.to_s,
 							:proto => 'udp',
 							:sname => 'dns',
 							:port => 53 ,
@@ -284,6 +287,7 @@ class Metasploit3 < Msf::Auxiliary
 		print_status("Running reverse lookup against IP range #{iprange}")
 		if not nssrv.nil?
 			@res.nameserver = (nssrv)
+			@nsinuse = nssrv
 		end
 		ar = Rex::Socket::RangeWalker.new(iprange)
 		tl = []
@@ -297,7 +301,7 @@ class Metasploit3 < Msf::Auxiliary
 						query = @res.query(tip)
 						query.each_ptr do |addresstp|
 							print_status("Hostname: #{addresstp} IP address: #{tip.to_s}")
-							report_note(:host => tip,
+							report_note(:host => @nsinuse.to_s,
 								:proto => 'udp',
 								:sname => 'dns',
 								:port => 53 ,
@@ -354,6 +358,7 @@ class Metasploit3 < Msf::Auxiliary
 		print_status("Performing zone transfer against all nameservers in #{target}")
 		if not nssrv.nil?
 			@res.nameserver=(nssrv)
+			@nsinuse = nssrv
 		end
 		@res.tcp_timeout=15
 		query = @res.query(target, "NS")
@@ -368,6 +373,7 @@ class Metasploit3 < Msf::Auxiliary
 				end
 				begin
 					@res.nameserver=(nssrvip)
+					@nsinuse = nssrvip
 					zone = []
 					zone = @res.axfr(target)
 					if zone.length != 0
@@ -385,7 +391,7 @@ class Metasploit3 < Msf::Auxiliary
 								case rr.type
 								when "A"
 									print_status("Name: #{rr.name} IP address: #{rr.address} Record: A ")
-									report_note(:host => rr.address.to_s,
+									report_note(:host => nssrvip,
 										:proto => 'udp',
 										:sname => 'dns',
 										:port => 53 ,
@@ -425,7 +431,7 @@ class Metasploit3 < Msf::Auxiliary
 										:data => "CPU:#{rr.cpu},OS:#{rr.os},HINFO")
 								when "AAAA"
 									print_status("IPv6 Address: #{rr.address} Record: AAAA")
-									report_note(:host => rr.address.to_s,
+									report_note(:host => nssrvip,
 										:proto => 'udp',
 										:sname => 'dns',
 										:port => 53 ,


### PR DESCRIPTION
Tested against zonetransfer.me. Previously, only the first record (SOA) was returned when zone transfer (AXFR) was requested. Now all records should be returned, though net-dns support for displaying them is lacking. Please see commit messages for more details.
