### PR TITLE
Adding Windows User Password Hint Decoding to Hashdump Tools

### DIFF
--- a/modules/post/windows/gather/hashdump.rb
+++ b/modules/post/windows/gather/hashdump.rb
@@ -201,7 +201,7 @@ class Metasploit3 < Msf::Post
 			#Attempt to get Hints (from WinXP Location) only if it's not set yet
 			if users[rid][:UserPasswordHint].nil?	
 				begin
-					uk_hint = @client.sys.registry.open_key(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Hints\\#{usr}", KEY_READ)
+					uk_hint = session.sys.registry.open_key(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Hints\\#{usr}", KEY_READ)
 					users[rid][:UserPasswordHint] = uk_hint.query_value("").data
 				rescue ::Rex::Post::Meterpreter::RequestError
 					users[rid][:UserPasswordHint] = nil

--- a/modules/post/windows/gather/smart_hashdump.rb
+++ b/modules/post/windows/gather/smart_hashdump.rb
@@ -163,7 +163,7 @@ class Metasploit3 < Msf::Post
 			#Attempt to get Hints (from WinXP Location) only if it's not set yet
 			if users[rid][:UserPasswordHint].nil?	
 				begin
-					uk_hint = @client.sys.registry.open_key(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Hints\\#{usr}", KEY_READ)
+					uk_hint = session.sys.registry.open_key(HKEY_LOCAL_MACHINE, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Hints\\#{usr}", KEY_READ)
 					users[rid][:UserPasswordHint] = uk_hint.query_value("").data
 				rescue ::Rex::Post::Meterpreter::RequestError
 					users[rid][:UserPasswordHint] = nil
@@ -307,11 +307,11 @@ class Metasploit3 < Msf::Post
 			users.keys.sort{|a,b| a<=>b}.each do |rid|
 				#If we have a hint then print it
 				if !users[rid][:UserPasswordHint].nil? && users[rid][:UserPasswordHint].length > 0
-					print_good("#{users[rid][:Name]}:\"#{users[rid][:UserPasswordHint]}\"")
+					print_good("\t#{users[rid][:Name]}:\"#{users[rid][:UserPasswordHint]}\"")
 					hint_count += 1
 				end	
 			end
-			print_good("No users with password hints on this system") if hint_count == 0
+			print_good("\tNo users with password hints on this system") if hint_count == 0
 
 			print_status("\tDumping password hashes...")
 			users.keys.sort{|a,b| a<=>b}.each do |rid|


### PR DESCRIPTION
- UserPasswordHint, a key that is used to store the users password
  hint, can be easily decoded to clear-text to get the users hint
  (Example: "My Favorite Color")
- Added decode_windows_hint() method to perform the decode process
- Added decoded hint output for hashdump.rb and smart_hashdump.rb

Heres an example of how the output would change...

http://postimage.org/image/k2ul69z2v/
