### PR TITLE
Pass datastore['Proxies'] to Anemone init options

### DIFF
--- a/lib/msf/core/auxiliary/crawler.rb
+++ b/lib/msf/core/auxiliary/crawler.rb
@@ -263,6 +263,7 @@ module Auxiliary::HttpCrawler
 		opts[:framework]           = framework
 		opts[:module]              = self
 		opts[:timeout]             = get_connection_timeout
+		opts[:proxies]		= datastore['Proxies']
 
 		if (t[:headers] and t[:headers].length > 0)
 			opts[:inject_headers] = t[:headers]


### PR DESCRIPTION
Anemone is not part of lib/msf so it doesnt take the datastore
options implicitly. Try crawling through a proxy right now with
outbound access to the target blocked, then try it with the
pull request.
