### PR TITLE
Add Rex compatible methods for Net::DNS

### DIFF
--- a/lib/net/dns.rb
+++ b/lib/net/dns.rb
@@ -1,2 +1,5 @@
 # -*- coding: binary -*-
 require "net/dns/resolver"
+
+# Overload Resolver class with Rex::Sockets
+require "net/dns/rex_dns"

--- a/lib/net/dns/resolver.rb
+++ b/lib/net/dns/resolver.rb
@@ -1219,4 +1219,3 @@ end
 class Hash # :nodoc:
   include ExtendHash
 end
-

--- a/lib/net/dns/rex_dns.rb
+++ b/lib/net/dns/rex_dns.rb
@@ -1,0 +1,172 @@
+require 'rex'
+
+##
+# Provides Rex::Sockets compatible methods for Net::DNS::Resolver
+##
+
+module Net # :nodoc:
+  module DNS
+    class Resolver
+
+      def proxies
+        @config[:proxies].inspect
+      end
+
+      def proxies=(arg)
+        if arg.is_a?(String) and arg.strip =~ /^socks/i
+          @config[:proxies] = arg.strip
+          @config[:use_tcp] = true
+          self.tcp_timeout = self.tcp_timeout.to_s.to_i + 250
+          @logger.info "SOCKS proxy set, using TCP, increasing timeout"
+        else
+          raise ResolverError, "Only socks proxies supported"
+        end
+      end
+
+      def send(argument,type=Net::DNS::A,cls=Net::DNS::IN)
+        if @config[:nameservers].size == 0
+          raise ResolverError, "No nameservers specified!"
+        end
+
+        method = self.use_tcp? ? :send_tcp : :send_udp
+
+        if argument.kind_of? Net::DNS::Packet
+          packet = argument
+        else
+          packet = make_query_packet(argument,type,cls)
+        end
+
+        # Store packet_data for performance improvements,
+        # so methods don't keep on calling Packet#data
+        packet_data = packet.data
+        packet_size = packet_data.size
+
+        # Choose whether use TCP, UDP
+        if packet_size > @config[:packet_size] # Must use TCP
+          @logger.info "Sending #{packet_size} bytes using TCP"
+          method = :send_tcp
+        else # Packet size is inside the boundaries
+          if use_tcp? or !(proxies.nil? or proxies.empty?) # User requested TCP
+            @logger.info "Sending #{packet_size} bytes using TCP"
+            method = :send_tcp
+          else # Finally use UDP
+            @logger.info "Sending #{packet_size} bytes using UDP"
+            method = :send_udp unless method == :send_tcp 
+          end
+        end
+
+        if type == Net::DNS::AXFR
+          @logger.warn "AXFR query, switching to TCP" unless method == :send_tcp
+          method = :send_tcp
+        end
+
+        ans = eval "self.#{method.to_s}(packet,packet_data)"
+
+        unless (ans and ans[0].length > 0)
+          @logger.fatal "No response from nameservers list: aborting"
+          raise NoResponseError
+          return nil
+        end
+
+        @logger.info "Received #{ans[0].size} bytes from #{ans[1][2]+":"+ans[1][1].to_s}"
+        response = Net::DNS::Packet.parse(ans[0],ans[1])
+
+        if response.header.truncated? and not ignore_truncated?
+          @logger.warn "Packet truncated, retrying using TCP"
+          self.use_tcp = true
+          begin
+            return send(argument,type,cls)
+          ensure
+            self.use_tcp = false
+          end
+        end
+
+        return response
+      end
+
+      # TODO: figure out how to pass proxies from datastore
+      def send_tcp(packet,packet_data)
+        ans = nil
+        length = [packet_data.size].pack("n")
+        @config[:nameservers].each do |ns|
+          begin
+            buffer = ""
+            @config[:tcp_timeout].timeout do
+              begin
+                begin
+                  socket = Rex::Socket::Tcp.create(
+                    'PeerHost' => ns.to_s,
+                    'PeerPort' => @config[:port].to_i,
+                    'Proxies' => @config[:proxies]
+                  )
+                rescue
+                  @logger.warn "TCP Socket could not be established to #{ns}:#{@config[:port]} #{@config[:proxies]}"
+                  return nil
+                end
+                next unless socket #
+                @logger.info "Contacting nameserver #{ns} port #{@config[:port]}"
+                socket.write(length+packet_data)
+                ans = socket.recv(Net::DNS::INT16SZ)
+                len = ans.unpack("n")[0]
+
+                @logger.info "Receiving #{len} bytes..."
+
+                if len == 0
+                  @logger.warn "Receiving 0 length packet from nameserver #{ns}, trying next."
+                  next
+                end
+
+                while (buffer.size < len)
+                  left = len - buffer.size
+                  temp,from = socket.recvfrom(left)
+                  buffer += temp
+                end
+
+                unless buffer.size == len
+                  @logger.warn "Malformed packet from nameserver #{ns}, trying next."
+                  next
+                end
+              ensure
+                socket.close if socket
+              end
+            end
+            return [buffer,["",@config[:port],ns.to_s,ns.to_s]]
+          rescue Timeout::Error
+            @logger.warn "Nameserver #{ns} not responding within TCP timeout, trying next one"
+            next
+          end
+        end
+      end
+
+      def send_udp(packet,packet_data)
+        ans = nil
+        response = ""
+        @config[:nameservers].each do |ns|
+          begin
+            @config[:udp_timeout].timeout do
+              begin
+                socket = Rex::Socket::Udp.create(
+                  'PeerHost' => ns.to_s,
+                  'PeerPort' => @config[:port].to_i
+                )
+              rescue
+                @logger.warn "UDP Socket could not be established to #{ns}:#{@config[:port]}"
+                return nil
+              end
+              @logger.info "Contacting nameserver #{ns} port #{@config[:port]}"
+              #socket.sendto(packet_data, ns.to_s, @config[:port].to_i, 0)
+              socket.write(packet_data)
+              ans = socket.recvfrom(@config[:packet_size])
+            end
+            break if ans
+          rescue Timeout::Error
+            @logger.warn "Nameserver #{ns} not responding within UDP timeout, trying next one"
+            next
+          end
+        end
+        ans
+      end
+
+    end # class Resolver
+  end # module DNS
+end # module Net

--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -10,7 +10,8 @@
 ##
 
 require 'msf/core'
-require "net/dns/resolver"
+require "net/dns"
+require "net/dns/rex_dns"
 
 class Metasploit3 < Msf::Auxiliary
 	include Msf::Auxiliary::Report
@@ -45,7 +46,7 @@ class Metasploit3 < Msf::Auxiliary
 				OptBool.new('ENUM_RVL', [ true, 'Reverse lookup a range of IP addresses', false]),
 				OptBool.new('ENUM_SRV', [ true, 'Enumerate the most common SRV records', true]),
 				OptPath.new('WORDLIST', [ false, "Wordlist for domain name bruteforcing", ::File.join(Msf::Config.install_root, "data", "wordlists", "namelist.txt")]),
-				OptAddress.new('NS', [ false, "Specify the nameserver to use for queries (default is system DNS)" ]),
+				OptAddress.new('NS', [ true, "Specify the nameserver to use for queries (default is system DNS)" ]),
 				OptAddressRange.new('IPRANGE', [false, "The target address range or CIDR identifier"]),
 				OptBool.new('STOP_WLDCRD', [ true, 'Stops bruteforce enumeration if wildcard resolution is detected', false])
 			], self.class)
@@ -468,8 +469,10 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def run
-		@res = Net::DNS::Resolver.new()
-		if datastore['TCP_DNS']
+		@res = Net::DNS::Resolver.new
+		@res.proxies=datastore['Proxies'] if datastore['Proxies']
+		@res.nameservers = datastore['NS'].split(/\s|,/)
+		if datastore['TCP_DNS'] || datastore['Proxies']
 			vprint_status("Using DNS/TCP")
 			@res.use_tcp = true
 		end


### PR DESCRIPTION
This pull request adds a Rex compatible set of methods
to Net::DNS::Resolver. Standard sockets have been replaced
with Rex::Socket classes and methods for setting/getting proxies
have been added. Additional changes to net/dns should not invoke
new socket calls but instead use the send method (or if need be
use protocol specific send methods).

The enum DNS module has been modified accordingly to make use of
the overload. Secondly, the module was modified to set the provided NS
immediately on initializing the resolver. The resolver was attempting
resolution with the system default NS before the options were passed
to it (this was caught by blocking the sytem NS while building proxy support).
Net::DNS::Resolver should be initialized, have all required options set at
the module level or a Rex library, then allowed to perform any operations
as data leakage may occur with prior implementation.

Testing: Open a framework session and get a meterpreter session
into an isolated network. Add the appropriate routes, and run
against the internal NS' with the internal domain set to test
pivot functionality. Once complete start the socks proxy module.

Open a second instance of the framework, repeat enumeration with
the proxy option set to the first framework's proxy server
(option not included in module due to issues with Opt::Proxy
causing framework errors - see ssh proxy commits).

Proxy testing requires that the NS respond to DNS/TCP.
