### PR TITLE
Update modules/post/windows/gather/tcpnetstat.rb

### DIFF
--- a/modules/post/windows/gather/tcpnetstat.rb
+++ b/modules/post/windows/gather/tcpnetstat.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Post
 		print_status("Total TCP Entries: #{entries}")
 
 		rtable = Rex::Ui::Text::Table.new(
-			'Header' => 'Routing Table',
+			'Header' => 'Connection Table',
 			'Indent' => 2,
 			'Columns' => ['STATE', 'LHOST', 'LPORT', 'RHOST', 'RPORT']
 		)


### PR DESCRIPTION
forgot to change table name with table code reuse
'connection table' is a better table header than
'routing table'.
