### PR TITLE
Adds a new findpids command to meterpreter

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -58,6 +58,7 @@ class Console::CommandDispatcher::Stdapi::Sys
 			"getuid"      => "Get the user that the server is running as",
 			"kill"        => "Terminate a process",
 			"ps"          => "List running processes",
+			"findpids"    => "Find Processes by name",
 			"reboot"      => "Reboots the remote computer",
 			"reg"         => "Modify and interact with the remote registry",
 			"rev2self"    => "Calls RevertToSelf() on the remote machine",
@@ -75,6 +76,7 @@ class Console::CommandDispatcher::Stdapi::Sys
 			"getuid"      => [ "stdapi_sys_config_getuid" ],
 			"kill"        => [ "stdapi_sys_process_kill" ],
 			"ps"          => [ "stdapi_sys_process_get_processes" ],
+			"findpids"    => [ "stdapi_sys_process_get_processes" ],
 			"reboot"      => [ "stdapi_sys_power_exitwindows" ],
 			"reg"         => [
 				"stdapi_registry_load_key",
@@ -280,6 +282,34 @@ class Console::CommandDispatcher::Stdapi::Sys
 			print_line
 			print_line(processes.to_table("Indent" => 1).to_s)
 			print_line
+		end
+		return true
+	end
+
+	def cmd_findpids(*args)
+		if args.empty? or args.include? "-h"
+			print_line "You must supply one or more process name to search for"
+			print_line "e.g. findpids explorer.exe notepad.exe"
+			return true
+		end
+		processes = client.sys.process.get_processes
+		if (processes.length == 0)
+			print_line("No running processes were found.")
+		else
+			searched_procs = Rex::Post::Meterpreter::Extensions::Stdapi::Sys::ProcessList.new
+			processes.each do |proc| 
+				if args.include? proc["name"]
+					searched_procs << proc 
+				end
+			end
+			searched_procs.compact!
+			if searched_procs.length == 0
+				print_line("No running processes were found matching the supplied names.")
+			else
+				print_line
+				print_line(searched_procs.to_table("Indent" => 1).to_s)
+				print_line
+			end
 		end
 		return true
 	end


### PR DESCRIPTION
findpids calls client.sys.process.get_processes like ps
but then filters out any processes that do not match
one of the process names supplied as arguments to the command.
`findpids explorer.exe notepad.exe` will return all processes
named explorer.exe or notepad.exe Allows for quick searching for
the pid you want. ideal for migration
