### PR TITLE
avoid the redefinition of Module.target_host

### DIFF
--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -635,7 +635,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def log_success(user,pass)
-		print_good("#{target_host()} - GlassFish - SUCCESSFUL login for '#{user}' : '#{pass}'")
+		print_good("#{my_target_host()} - GlassFish - SUCCESSFUL login for '#{user}' : '#{pass}'")
 		report_auth_info(
 			:host   => rhost,
 			:port   => rport,
@@ -693,7 +693,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		if success == true
 			log_success(user,pass)
 		else
-			msg = "#{target_host()} - GlassFish - Failed to authenticate login for '#{user}' : '#{pass}'"
+			msg = "#{my_target_host()} - GlassFish - Failed to authenticate login for '#{user}' : '#{pass}'"
 			print_error(msg)
 		end
 
@@ -721,7 +721,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		if success == true
-			print_good("#{target_host} - GlassFish - SUCCESSFUL authentication bypass")
+			print_good("#{my_target_host} - GlassFish - SUCCESSFUL authentication bypass")
 			report_auth_info(
 				:host   => rhost,
 				:port   => rport,
@@ -732,22 +732,22 @@ class Metasploit3 < Msf::Exploit::Remote
 				:active => true
 			)
 		else
-			print_error("#{target_host()} - GlassFish - Failed authentication bypass")
+			print_error("#{my_target_host()} - GlassFish - Failed authentication bypass")
 		end
 
 		return success
 	end
 
-	def target_host
+	def my_target_host
 		path        = datastore['PATH']
-		target_host = "http://#{rhost.to_s}:#{rport.to_s}/#{path.to_s}"
+		my_target_host = "http://#{rhost.to_s}:#{rport.to_s}/#{path.to_s}"
 	end
 
 	def exploit
 		user        = datastore['USERNAME']
 		pass        = datastore['PASSWORD']
 		path        = datastore['PATH']
-		target_host = "http://#{rhost.to_s}:#{rport.to_s}/#{path.to_s}"
+		my_target_host = "http://#{rhost.to_s}:#{rport.to_s}/#{path.to_s}"
 		success     = false
 		session     = ''
 		edition     = ''
@@ -826,7 +826,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			print_status("Uploading payload...")
 			res = upload_exec(session, app_base, jsp_name, mytarget, war, edition, version)
 		else
-			print_error("#{target_host()} - GlassFish - Failed to authenticate login")
+			print_error("#{my_target_host()} - GlassFish - Failed to authenticate login")
 		end
 
 	end


### PR DESCRIPTION
Modules show avoid the redefinition of Module.target_host !! which is an important method for the framework working as expected 

Related to:

http://dev.metasploit.com/redmine/issues/7215
