### PR TITLE
Fixes uictl's disappearance

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
@@ -30,8 +30,7 @@ class Console::CommandDispatcher::Stdapi::Ui
 			"keyscan_stop"  => "Stop capturing keystrokes",
 			"screenshot"    => "Grab a screenshot of the interactive desktop",
 			"setdesktop"    => "Change the meterpreters current desktop",
-			"uictl"         => "Control some of the user interface components",
-
+			"uictl"         => "Control some of the user interface components"
 			#  not working yet
 			# "unlockdesktop" => "Unlock or lock the workstation (must be inside winlogon.exe)",
 		}
@@ -47,8 +46,8 @@ class Console::CommandDispatcher::Stdapi::Ui
 			"setdesktop"    => [ "stdapi_ui_desktop_set" ],
 			"uictl"         => [
 				"stdapi_ui_enable_mouse",
-				"stdapi_ui_enable_keyboard",
-			],
+				"stdapi_ui_enable_keyboard"
+			]
 		}
 
 		all.delete_if do |cmd, desc|

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
@@ -47,9 +47,7 @@ class Console::CommandDispatcher::Stdapi::Ui
 			"setdesktop"    => [ "stdapi_ui_desktop_set" ],
 			"uictl"         => [
 				"stdapi_ui_enable_mouse",
-				"stdapi_ui_disable_mouse",
 				"stdapi_ui_enable_keyboard",
-				"stdapi_ui_disable_keyboard",
 			],
 		}
 


### PR DESCRIPTION
utctl shouldn't check for stdapi_ui_disable_mouse or disable_keyboard
since neither exist.

Removed the check, tested both enable and disable on mouse and keyboard,
uictl seems to work as advertised now.

[FIXRM #7217]
