### PR TITLE
Be more clear that we dislike certain PDF templates

### DIFF
--- a/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
+++ b/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
@@ -71,21 +71,32 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		print_status("Reading in '#{file_name}'...")
 		stream = read_pdf()
-		print_status("Parsing '#{file_name}'...")
-		pdf_objects = parse_pdf(stream)
-		print_status("Parsing Successful.")
-		xref_trailers 	= pdf_objects[0]
-		trailers	= pdf_objects[1]
-		startxrefs	= pdf_objects[2]
-		root_obj	= pdf_objects[3]
 
 		begin
+			print_status("Parsing '#{file_name}'...")
+			pdf_objects      = parse_pdf(stream)
+			xref_trailers    = pdf_objects[0]
+			trailers         = pdf_objects[1]
+			startxrefs       = pdf_objects[2]
+			root_obj         = pdf_objects[3]
+
 			output = basic_social_engineering_exploit(xref_trailers,root_obj,stream,trailers,file_name,exe_name,startxrefs.last)
 
-			print_status("Creating '#{datastore['FILENAME']}' file...")
+			print_status("Parsing Successful. Creating '#{datastore['FILENAME']}' file...")
 			file_create(output)
 		rescue KeyError => e
-			print_error("Incompatible PDF structure: #{e.message}. Please try a different PDF.")
+			# Lazy fix:
+			# Similar to the problem with NoMethod -- something we need is missing in the PDF.
+			# But really what happens is the module trusts the PDF too much.
+			print_error("Sorry, I'm picky. Incompatible PDF structure: #{e.message}. Please try a different PDF template.")
+			elog("Call stack:\n#{$!.backtrace.join("\n")}")
+		rescue NoMethodError => e
+			# Lazy fix:
+			# When a NoMethod error is hit, that means that something in the PDF is actually missing,
+			# so we can't parse it. If we can't parse it properly, then we can't garantee the exploit
+			# will work, either.  So we might as well just reject it.
+			print_error("Sorry, I'm picky. Incompatible PDF structure, please try a different PDF template.")
+			elog("Call stack:\n#{$!.backtrace.join("\n")}")
 		end
 	end
 
@@ -239,8 +250,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				end
 			end
 		end
-
-
 
 		pages_obj = catalog.match(/Pages (\d+ \d) R/m)[1]
 		pages = parse_object(xref_trailers,pages_obj,stream)


### PR DESCRIPTION
When a KeyError or NoMethodError is hit, that means we there's something we want in the PDF template that's actually missing (ie. root, pages, or kids, etc), if that's the case, we reject the template to avoid a possible broken exploit.  The user should simply try a different PDF.
