### PR TITLE
Display the session IP in the console when the session closes.

### DIFF
--- a/lib/msf/ui/console/framework_event_manager.rb
+++ b/lib/msf/ui/console/framework_event_manager.rb
@@ -48,7 +48,7 @@ module FrameworkEventManager
 		# If logging had been enabled for this session, stop it now.
 		Msf::Logging::stop_session_log(session)
 
-		msg = "#{session.desc} session #{session.name} closed."
+		msg = "#{session.desc} session #{session.name} (#{session.session_host})closed."
 		if reason and reason.length > 0
 			msg << "  Reason: #{reason}"
 		end


### PR DESCRIPTION
Includes the session host IP when displaying closed sessions. Useful for users who have large numbers of sessions open.
