### PR TITLE
Add Metasploit blogs as references, because they're useful.

### DIFF
--- a/modules/auxiliary/dos/windows/rdp/ms12_020_maxchannelids.rb
+++ b/modules/auxiliary/dos/windows/rdp/ms12_020_maxchannelids.rb
@@ -30,7 +30,8 @@ class Metasploit3 < Msf::Auxiliary
 					[ 'URL', 'http://pastie.org/private/4egcqt9nucxnsiksudy5dw' ],
 					[ 'URL', 'http://pastie.org/private/feg8du0e9kfagng4rrg' ],
 					[ 'URL', 'http://stratsec.blogspot.com.au/2012/03/ms12-020-vulnerability-for-breakfast.html' ],
-					[ 'EDB', 18606 ]
+					[ 'EDB', 18606 ],
+					[ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/03/21/metasploit-update' ]
 				],
 			'Author'         =>
 				[

--- a/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
@@ -33,7 +33,8 @@ class Metasploit3 < Msf::Auxiliary
 				],
 			'References'     => [
 					['CVE', '2012-2122'],
-					['OSVDB', '82804']
+					['OSVDB', '82804'],
+					['URL', 'https://community.rapid7.com/community/metasploit/blog/2012/06/11/cve-2012-2122-a-tragically-comedic-security-flaw-in-mysql']
 				],
 			'DisclosureDate' => 'Jun 09 2012',
 			'License'        => MSF_LICENSE

--- a/modules/auxiliary/scanner/telnet/telnet_encrypt_overflow.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_encrypt_overflow.rb
@@ -28,7 +28,8 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					['BID', '51182'],
 					['CVE', '2011-4862'],
-					['EDB', 18280]
+					['EDB', 18280],
+					['URL', 'https://community.rapid7.com/community/metasploit/blog/2011/12/28/more-fun-with-bsd-derived-telnet-daemons']
 				]
 		)
 		register_options(

--- a/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
+++ b/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
@@ -40,7 +40,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'URL', 'https://www.trustmatta.com/advisories/MATTA-2012-002.txt' ],
 					[ 'CVE', '2012-1493' ],
-					[ 'OSVDB', '82780' ]
+					[ 'OSVDB', '82780' ],
+					[ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/06/25/press-f5-for-root-shell' ]
 				],
 			'DisclosureDate' => "Jun 11 2012",
 			'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },

--- a/modules/exploits/multi/browser/java_atomicreferencearray.rb
+++ b/modules/exploits/multi/browser/java_atomicreferencearray.rb
@@ -43,7 +43,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					['URL', 'http://weblog.ikvm.net/PermaLink.aspx?guid=cd48169a-9405-4f63-9087-798c4a1866d3'],
 					['URL', 'http://blogs.technet.com/b/mmpc/archive/2012/03/20/an-interesting-case-of-jre-sandbox-breach-cve-2012-0507.aspx'],
 					['URL', 'http://schierlm.users.sourceforge.net/TypeConfusion.html'],
-					['URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2012-0507']
+					['URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2012-0507'],
+					['URL', 'https://community.rapid7.com/community/metasploit/blog/2012/03/29/cve-2012-0507--java-strikes-again']
 				],
 			'Platform'       => [ 'java', 'win', 'osx', 'linux', 'solaris' ],
 			'Payload'        => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },

--- a/modules/exploits/multi/browser/java_jre17_exec.rb
+++ b/modules/exploits/multi/browser/java_jre17_exec.rb
@@ -50,7 +50,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'URL', 'http://www.deependresearch.org/2012/08/java-7-vulnerability-analysis.html' ],
 					[ 'URL', 'http://labs.alienvault.com/labs/index.php/2012/new-java-0day-exploited-in-the-wild/' ],
 					[ 'URL', 'http://www.deependresearch.org/2012/08/java-7-0-day-vulnerability-information.html' ],
-					[ 'URL', 'http://www.oracle.com/technetwork/topics/security/alert-cve-2012-4681-1835715.html' ]
+					[ 'URL', 'http://www.oracle.com/technetwork/topics/security/alert-cve-2012-4681-1835715.html' ],
+					[ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/08/27/lets-start-the-week-with-a-new-java-0day' ]
 				],
 			'Platform'      => [ 'java', 'win', 'linux' ],
 			'Payload'       => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },

--- a/modules/exploits/windows/browser/adobe_flash_otf_font.rb
+++ b/modules/exploits/windows/browser/adobe_flash_otf_font.rb
@@ -38,7 +38,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'URL', 'http://labs.alienvault.com/labs/index.php/2012/cve-2012-1535-adobe-flash-being-exploited-in-the-wild/' ],
 					[ 'URL', 'http://vrt-blog.snort.org/2012/08/cve-2012-1535-flash-0-day-in-wild.html' ],
 					[ 'URL', 'https://developer.apple.com/fonts/TTRefMan/RM06/Chap6.html' ],
-					[ 'URL', 'http://contagiodump.blogspot.com.es/2012/08/cve-2012-1535-samples-and-info.html' ]
+					[ 'URL', 'http://contagiodump.blogspot.com.es/2012/08/cve-2012-1535-samples-and-info.html' ],
+					[ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/08/17/adobe-flash-player-exploit-cve-2012-1535-now-available-for-metasploit' ]
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/browser/adobe_flash_rtmp.rb
+++ b/modules/exploits/windows/browser/adobe_flash_rtmp.rb
@@ -50,7 +50,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'OSVDB', '81656'],
 					[ 'BID', '53395' ],
 					[ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb12-09.html'], # Patch info
-					[ 'URL', 'http://contagiodump.blogspot.com.es/2012/05/may-3-cve-2012-0779-world-uyghur.html' ]
+					[ 'URL', 'http://contagiodump.blogspot.com.es/2012/05/may-3-cve-2012-0779-world-uyghur.html' ],
+					[ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/06/22/the-secret-sauce-to-cve-2012-0779-adobe-flash-object-confusion-vulnerability' ]
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/browser/clear_quest_cqole.rb
+++ b/modules/exploits/windows/browser/clear_quest_cqole.rb
@@ -44,6 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'OSVDB', '81443'],
 					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-12-113/' ],
 					[ 'URL', 'http://www-304.ibm.com/support/docview.wss?uid=swg21591705' ],
+					[ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/07/11/it-isnt-always-about-buffer-overflow' ]
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/browser/ms12_037_same_id.rb
+++ b/modules/exploits/windows/browser/ms12_037_same_id.rb
@@ -36,7 +36,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2012-1875' ],
 					[ 'OSVDB', '82865'],
 					[ 'URL', 'http://labs.alienvault.com/labs/index.php/2012/ongoing-attacks-exploiting-cve-2012-1875/'],
-					[ 'URL', 'https://twitter.com/binjo/status/212795802974830592' ] # Exploit found in the wild
+					[ 'URL', 'https://twitter.com/binjo/status/212795802974830592' ], # Exploit found in the wild
+					[ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/06/18/metasploit-exploits-critical-microsoft-vulnerabilities']
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
+++ b/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
@@ -47,7 +47,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'MSB', 'MS12-043'],
 					[ 'URL', 'http://technet.microsoft.com/en-us/security/advisory/2719615' ],
 					[ 'URL', 'http://www.zdnet.com/blog/security/state-sponsored-attackers-using-ie-zero-day-to-hijack-gmail-accounts/12462' ],
-					[ 'URL', 'http://hi.baidu.com/inking26/blog/item/9c2ab11c4784e5aa86d6b6c1.html' ]
+					[ 'URL', 'http://hi.baidu.com/inking26/blog/item/9c2ab11c4784e5aa86d6b6c1.html' ],
+					[ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/06/18/metasploit-exploits-critical-microsoft-vulnerabilities' ]
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/browser/oracle_autovue_setmarkupmode.rb
+++ b/modules/exploits/windows/browser/oracle_autovue_setmarkupmode.rb
@@ -52,7 +52,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'BID', '53077' ],
 					[ 'OSVDB', '81439' ],
 					[ 'URL', 'http://dvlabs.tippingpoint.com/advisory/TPTI-12-05' ],
-					[ 'URL', 'http://www.oracle.com/technetwork/topics/security/cpuapr2012-366314.html' ]
+					[ 'URL', 'http://www.oracle.com/technetwork/topics/security/cpuapr2012-366314.html' ],
+					[ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/08/15/the-stack-cookies-bypass-on-cve-2012-0549' ]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/misc/hp_dataprotector_new_folder.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_new_folder.rb
@@ -43,7 +43,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2012-0124' ],
 					[ 'OSVDB', '80105' ],
 					[ 'BID', '52431' ],
-					[ 'URL', 'http://h20000.www2.hp.com/bizsupport/TechSupport/Document.jsp?objectID=c03229235' ]
+					[ 'URL', 'http://h20000.www2.hp.com/bizsupport/TechSupport/Document.jsp?objectID=c03229235' ],
+					[ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/07/06/an-example-of-egghunting-to-exploit-cve-2012-0124' ]
 				],
 			'Payload'        =>
 				{


### PR DESCRIPTION
Some of the Metasploit blogs have lots of information regarding technical details or how-tos, should be useful for users.
