### PR TITLE
Add Adobe security bulletin references

### DIFF
--- a/modules/exploits/windows/browser/adobe_flash_otf_font.rb
+++ b/modules/exploits/windows/browser/adobe_flash_otf_font.rb
@@ -39,7 +39,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'URL', 'http://vrt-blog.snort.org/2012/08/cve-2012-1535-flash-0-day-in-wild.html' ],
 					[ 'URL', 'https://developer.apple.com/fonts/TTRefMan/RM06/Chap6.html' ],
 					[ 'URL', 'http://contagiodump.blogspot.com.es/2012/08/cve-2012-1535-samples-and-info.html' ],
-					[ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/08/17/adobe-flash-player-exploit-cve-2012-1535-now-available-for-metasploit' ]
+					[ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/08/17/adobe-flash-player-exploit-cve-2012-1535-now-available-for-metasploit' ],
+					[ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb12-18.html']
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/browser/adobe_geticon.rb
+++ b/modules/exploits/windows/browser/adobe_geticon.rb
@@ -39,6 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2009-0927' ],
 					[ 'OSVDB', '53647' ],
 					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-09-014/' ],
+					[ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb09-04.html']
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/browser/adobe_jbig2decode.rb
+++ b/modules/exploits/windows/browser/adobe_jbig2decode.rb
@@ -40,6 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE' , '2009-0658' ],
 					[ 'OSVDB', '52073' ],
 					[ 'URL', 'http://bl4cksecurity.blogspot.com/2009/03/adobe-acrobatreader-universal-exploit.html'],
+					[ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb09-04.html']
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/browser/adobe_media_newplayer.rb
+++ b/modules/exploits/windows/browser/adobe_media_newplayer.rb
@@ -39,7 +39,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'CVE', '2009-4324' ],
 					[ 'BID', '37331' ],
-					[ 'OSVDB', '60980' ]
+					[ 'OSVDB', '60980' ],
+					[ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb10-02.html' ]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/browser/adobe_shockwave_rcsl_corruption.rb
+++ b/modules/exploits/windows/browser/adobe_shockwave_rcsl_corruption.rb
@@ -32,6 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2010-3653'],
 					[ 'OSVDB', '68803'],
 					[ 'URL', 'http://www.exploit-db.com/sploits/Adobe_Shockwave_Director_rcsL_Chunk_Memory_Corruption.zip' ],
+					[ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb10-25.html' ]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
+++ b/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
@@ -38,7 +38,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'OSVDB', '63667' ],
 					[ 'URL', 'http://blog.didierstevens.com/2010/04/06/update-escape-from-pdf/' ],
 					[ 'URL', 'http://blog.didierstevens.com/2010/03/31/escape-from-foxit-reader/' ],
-					[ 'URL', 'http://blog.didierstevens.com/2010/03/29/escape-from-pdf/' ]
+					[ 'URL', 'http://blog.didierstevens.com/2010/03/29/escape-from-pdf/' ],
+					[ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb10-15.html' ]
 				],
 			'DisclosureDate' => 'Mar 29 2010',
 			'Payload'	=>

--- a/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe_nojs.rb
+++ b/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe_nojs.rb
@@ -49,7 +49,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'OSVDB', '63667' ],
 					[ 'URL', 'http://blog.didierstevens.com/2010/04/06/update-escape-from-pdf/' ],
 					[ 'URL', 'http://blog.didierstevens.com/2010/03/31/escape-from-foxit-reader/' ],
-					[ 'URL', 'http://blog.didierstevens.com/2010/03/29/escape-from-pdf/' ]
+					[ 'URL', 'http://blog.didierstevens.com/2010/03/29/escape-from-pdf/' ],
+					[ 'URL', 'http://www.adobe.com/support/security/bulletins/apsb10-15.html' ]
 				],
 			'Payload'	=>
 				{


### PR DESCRIPTION
Add references to Adobe Security bulletins, in case users need that info.
