### PR TITLE
checkpoint_hostname raise an error because Report module is not included in the source

### DIFF
--- a/modules/auxiliary/gather/checkpoint_hostname.rb
+++ b/modules/auxiliary/gather/checkpoint_hostname.rb
@@ -10,6 +10,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Auxiliary
 
 	include Msf::Exploit::Remote::Tcp
+	include Msf::Auxiliary::Report
 
 	def initialize(info = {})
 		super(update_info(info,


### PR DESCRIPTION
The module raise an error when executed because Report module is not included in the source (include Msf::Auxiliary::Report).

msf auxiliary(checkpoint_hostname) > run
[*] Attempting to contact Checkpoint FW1 SecuRemote Topology service...
[+] Appears to be a CheckPoint Firewall...
[+] Firewall Host: fw-1
[+] SmartCenter Host: XXXXXXXXXXx.
[-] Auxiliary failed: NoMethodError undefined method `report_host' for #<#<Module:0xb5ad95c>::Metasploit3:0xe284d54>
[-] Call stack:
[-] /opt/metasploit/msf3/modules/auxiliary/gather/checkpoint_hostname.rb:88:in`report_info'
[-] /opt/metasploit/msf3/modules/auxiliary/gather/checkpoint_hostname.rb:72:in `run' 
