### PR TITLE
Fix NoMethodError for nil:NilClass bug

### DIFF
--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -29,8 +29,8 @@ module Exploit::Remote::SMTPDeliver
 				OptString.new('MAILFROM', [ true, 'The FROM address of the e-mail', 'random@example.com' ]),
 				OptString.new('MAILTO', [ true, 'The TO address of the email' ]),
 				OptString.new('SUBJECT', [ true, 'Subject line of the email' ]),
-				OptString.new('USERNAME', [ false, 'SMTP Username for sending email' ]),
-				OptString.new('PASSWORD', [ false, 'SMTP Password for sending email' ]),
+				OptString.new('USERNAME', [ false, 'SMTP Username for sending email', '' ]),
+				OptString.new('PASSWORD', [ false, 'SMTP Password for sending email', '' ]),
 				OptString.new('VERBOSE', [ false, 'Display verbose information' ]),
 			], Msf::Exploit::Remote::SMTPDeliver)
 		register_autofilter_ports([ 25, 465, 587, 2525, 25025, 25000])


### PR DESCRIPTION
The 'unless' statement expects there's always a value for USERNAME and PASSWORD. We might as well just set '' as the default value to avoid the NoMethodError mistake.  Related to bug #7140.

Note: USERNAME and PASSWORD are only used in the login function.
