### PR TITLE
[posix meterpreter] create reaper thread as child of master thread

### DIFF
--- a/external/source/meterpreter/source/common/base.c
+++ b/external/source/meterpreter/source/common/base.c
@@ -212,23 +212,6 @@ VOID command_throtle( int maxthreads )
 }
 */
 
-#ifndef _WIN32
-/*
- * Reap child zombie threads on linux 2.4 (before NPTL)
- * each thread appears as a process and pthread_join don't necessarily reap it
- * threads are created using the clone syscall, so use special __WCLONE flag in waitpid
- */
-
-VOID reap_zombie_thread(void * param)
-{
-	while(1) {
-		waitpid(-1, NULL, __WCLONE);
-		// on 2.6 kernels, don't chew 100% CPU
-		usleep(500000);
-	}
-}
-#endif
-
 /*
  * Process a single command in a seperate thread of execution.
  */
@@ -260,11 +243,6 @@ DWORD THREADCALL command_process_thread( THREAD * thread )
 		commandThreadList = list_create();
 		if( commandThreadList == NULL )
 			return ERROR_INVALID_HANDLE;
-#ifndef _WIN32
-		pthread_t tid;
-		pthread_create(&tid, NULL, reap_zombie_thread, NULL);
-		dprintf("reap_zombie_thread created, thread_id : 0x%x",tid);
-#endif
 	}
 
 	list_add( commandThreadList, thread );

--- a/external/source/meterpreter/source/common/thread.c
+++ b/external/source/meterpreter/source/common/thread.c
@@ -316,6 +316,21 @@ void *__paused_thread(void *req)
 
 	return funk(thread);	
 }
+
+/*
+ * Reap child zombie threads on linux 2.4 (before NPTL)
+ * each thread appears as a process and pthread_join don't necessarily reap it
+ * threads are created using the clone syscall, so use special __WCLONE flag in waitpid
+ */
+
+VOID reap_zombie_thread(void * param)
+{
+        while(1) {
+                waitpid(-1, NULL, __WCLONE);
+                // on 2.6 kernels, don't chew 100% CPU
+                usleep(500000);
+        }
+}
 #endif
 
 /*
@@ -390,6 +405,11 @@ THREAD * thread_create( THREADFUNK funk, LPVOID param1, LPVOID param2 )
 			return NULL;
 		}
 		// __paused_thread free's the allocated memory.
+		static pthread_t tid = 0;
+		if (tid == 0){
+			pthread_create(&tid, NULL, reap_zombie_thread, NULL);
+			dprintf("reap_zombie_thread created, thread_id : 0x%x",tid);
+		}
 
 	} while(0);
 #endif

--- a/external/source/meterpreter/source/common/thread.c
+++ b/external/source/meterpreter/source/common/thread.c
@@ -405,8 +405,9 @@ THREAD * thread_create( THREADFUNK funk, LPVOID param1, LPVOID param2 )
 			return NULL;
 		}
 		// __paused_thread free's the allocated memory.
+		// create zombie thread reaper for pre-NPTL threads
 		static pthread_t tid = 0;
-		if (tid == 0){
+		if (tid == 0) {
 			pthread_create(&tid, NULL, reap_zombie_thread, NULL);
 			dprintf("reap_zombie_thread created, thread_id : 0x%x",tid);
 		}


### PR DESCRIPTION
Move reaper thread creation . Otherelse, reaper thread is created in a "child" thread and could become child of meterpreter parent process (instead of meterpreter child) and not be reaped when exiting.
