### PR TITLE
Fix Meterpreter edit command file removal

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -324,7 +324,8 @@ class Console::CommandDispatcher::Stdapi::Fs
 		end
 
 		# Get rid of that pesky temporary file
-		temp_path.close(true)
+		::File.delete(temp_path)
+		#temp_path.close(true)
 	end
 
 	#

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -324,7 +324,7 @@ class Console::CommandDispatcher::Stdapi::Fs
 		end
 
 		# Get rid of that pesky temporary file
-		::File.delete(temp_path)
+		::File.delete(temp_path) rescue nil
 	end
 
 	#

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -325,7 +325,6 @@ class Console::CommandDispatcher::Stdapi::Fs
 
 		# Get rid of that pesky temporary file
 		::File.delete(temp_path)
-		#temp_path.close(true)
 	end
 
 	#


### PR DESCRIPTION
fs.rb was originally attempting to call the "close" method on a
string holding the temporary path to the file being editted.
Replaced with ::File.delete(temp_path).
