### PR TITLE
[posix meterpreter] fix netstat program name

### DIFF
--- a/external/source/meterpreter/source/extensions/stdapi/server/net/config/netstat.c
+++ b/external/source/meterpreter/source/extensions/stdapi/server/net/config/netstat.c
@@ -681,7 +681,7 @@ DWORD linux_proc_get_program_name(struct connection_entry * connection, unsigned
 
 	// /proc/PID/cmdline failed, try /proc/PID/status
 	if (do_status == 1) {
-		snprintf(buffer, sizeof(buffer), "/proc/%s/status", pid);
+		snprintf(buffer, sizeof(buffer)-1, "/proc/%s/status", pid);
 		fd = fopen(buffer, "r");
 
 		// will try /proc/PID/status

--- a/external/source/meterpreter/source/extensions/stdapi/server/net/config/netstat.c
+++ b/external/source/meterpreter/source/extensions/stdapi/server/net/config/netstat.c
@@ -659,13 +659,11 @@ DWORD linux_proc_get_program_name(struct connection_entry * connection, unsigned
 			break;
 		}
 		if (fgets(buffer_file, sizeof(buffer_file), fd) == NULL) {
-      			fclose(fd);
 			do_status = 1;
 			break;
 		}
 		// each entry in cmdline is seperated by '\0' so buffer_file contains first the path of the executable launched
 		if ((bname = basename(buffer_file)) == NULL) {
-	      		fclose(fd);
 			do_status = 1;
 			break;
 		}


### PR DESCRIPTION
/proc/PID/status might be different from  /proc/PID/cmdline with linked program such as busybox.

netstat would report program name = busybox whereas we'd want httpd/tftpd...

read cmdline first and fallback to status
