### PR TITLE
Updating definintion of sleep to allow for nil arguments

### DIFF
--- a/lib/rex.rb
+++ b/lib/rex.rb
@@ -91,7 +91,7 @@ require 'rex/platforms'
 
 # Overload the Kernel.sleep() function to be thread-safe
 Kernel.class_eval("
-	def sleep(seconds)
+	def sleep(seconds=nil)
 		Rex::ThreadSafe.sleep(seconds)
 	end
 ")

--- a/lib/rex/sync/thread_safe.rb
+++ b/lib/rex/sync/thread_safe.rb
@@ -72,7 +72,7 @@ module ThreadSafe
 	# Simulates a sleep operation by selecting on nil until a timeout period
 	# expires.
 	#
-	def self.sleep(seconds)
+	def self.sleep(seconds=nil)
 		self.select(nil, nil, nil, seconds)
 
 		seconds


### PR DESCRIPTION
Updates class_eval of Kernal#sleep to allow nil arguments.

I was trying to get the metasploit msfrpc-client to work with siqekiq and it kept failing on startup when sidekiq called

```
sleep
```

Investigation revealed the Rex overwrites Kernel#sleep, but does not allow for the nil argument case (infinite sleep).  I just added nil as the default argument in lib/rex.rb and lib/rex/sync/thread_safe#sleep.

Since  lib/rex/sync/thread_safe#select already defaults the t param to nil, I believe this should work.
