### PR TITLE
Add more Exploit::Failure constatns

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -155,9 +155,19 @@ class Exploit < Msf::Module
 		UserInterrupt   = 'user-interrupt'
 
 		#
-		# The application replied indication we do not have access
+		# The application replied indication we're not able to access the resource
 		#
 		NoAccess        = 'no-access'
+
+		#
+		# The application replied indication we're not authorized
+		#
+		NoAuthorization = 'no-authorization'
+
+		#
+		# The application replied indication we're not authenticated
+		#
+		NoAuthentication = 'no-authentication'
 
 		#
 		# The target is not compatible with this exploit or settings

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -155,7 +155,7 @@ class Exploit < Msf::Module
 		UserInterrupt   = 'user-interrupt'
 
 		#
-		# The application replied indication we're not able to access the resource
+		# The application replied indication we do not have access
 		#
 		NoAccess        = 'no-access'
 


### PR DESCRIPTION
The Exploit::Failure module should cover these specific scenarios because they are really common:
- NoAuthorization: Used when the attacker is authenticated, but his credential does not grant him access to certain resources, or actions.
- NoAuthentication: Used when the attacker fails to login.

I left NoAccess untouched because of these two reasons:
- The framework is already using that.
- In case for some reason you don't have access to the resource, but you shouldn't need to auth, either. Example: chmod improperly set on a web resource.
