### PR TITLE
[posix meterpreter] Various fixes for pre-NPTL threads and zombie reaper

### DIFF
--- a/external/source/meterpreter/source/common/base.c
+++ b/external/source/meterpreter/source/common/base.c
@@ -212,23 +212,6 @@ VOID command_throtle( int maxthreads )
 }
 */
 
-#ifndef _WIN32
-/*
- * Reap child zombie threads on linux 2.4 (before NPTL)
- * each thread appears as a process and pthread_join don't necessarily reap it
- * threads are created using the clone syscall, so use special __WCLONE flag in waitpid
- */
-
-VOID reap_zombie_thread(void * param)
-{
-	while(1) {
-		waitpid(-1, NULL, __WCLONE);
-		// on 2.6 kernels, don't chew 100% CPU
-		usleep(500000);
-	}
-}
-#endif
-
 /*
  * Process a single command in a seperate thread of execution.
  */
@@ -260,11 +243,6 @@ DWORD THREADCALL command_process_thread( THREAD * thread )
 		commandThreadList = list_create();
 		if( commandThreadList == NULL )
 			return ERROR_INVALID_HANDLE;
-#ifndef _WIN32
-		pthread_t tid;
-		pthread_create(&tid, NULL, reap_zombie_thread, NULL);
-		dprintf("reap_zombie_thread created, thread_id : 0x%x",tid);
-#endif
 	}
 
 	list_add( commandThreadList, thread );

--- a/external/source/meterpreter/source/common/base.c
+++ b/external/source/meterpreter/source/common/base.c
@@ -246,7 +246,12 @@ DWORD THREADCALL command_process_thread( THREAD * thread )
 	}
 
 	list_add( commandThreadList, thread );
-
+/*
+#ifndef _WIN32
+	pthread_internal_t * ptr = (pthread_internal_t *)(thread->pid); 
+	dprintf("getpid : %d , getppid : %d, gettid : %d, kernel_id : %d", getpid(), getppid(), gettid(), ptr->kernel_id); 
+#endif
+*/
 	__try
 	{
 		do

--- a/external/source/meterpreter/source/common/common.h
+++ b/external/source/meterpreter/source/common/common.h
@@ -174,7 +174,10 @@ struct connection_table {
 #define METERPRETER_TRANSPORT_HTTP 1
 #define METERPRETER_TRANSPORT_HTTPS 2
 
-#ifdef _WIN32
+#ifndef _WIN32
+extern LIST * commandThreadListPID;
+
+#else // if _WIN32
 
 
 #include <wininet.h>

--- a/external/source/meterpreter/source/common/thread.c
+++ b/external/source/meterpreter/source/common/thread.c
@@ -6,6 +6,24 @@
 int __futex_wait(volatile void *ftx, int val, const struct timespec *timeout);
 int __futex_wake(volatile void *ftx, int count);
 
+/*
+ *  are we running on a linux 2.4 kernel ?
+ * if this is the case, as we're using pthread, a "few" things might not work
+ * pthread_join will return immediately (sys_futex3 returns immediately as there's no support for futex in 2.4 kernels)
+ * terminated threads end up as zombies in the system, we need to reap them
+ * ...
+ * empiric way observed during testing : if getpid() == getppid(), we're on a 2.4 kernel (didn't happen during testing on a 2.6/3.x kernel)
+ */
+
+int is_kernel_24 = -1;
+pthread_t reaper_tid = 0;
+/*
+ * A list of all command threads PID currenlty executing.
+ */
+LIST * commandThreadListPID = NULL;
+
+
+
 #include <time.h>
 #include <signal.h>
 
@@ -317,20 +335,6 @@ void *__paused_thread(void *req)
 	return funk(thread);	
 }
 
-/*
- * Reap child zombie threads on linux 2.4 (before NPTL)
- * each thread appears as a process and pthread_join don't necessarily reap it
- * threads are created using the clone syscall, so use special __WCLONE flag in waitpid
- */
-
-VOID reap_zombie_thread(void * param)
-{
-        while(1) {
-                waitpid(-1, NULL, __WCLONE);
-                // on 2.6 kernels, don't chew 100% CPU
-                usleep(500000);
-        }
-}
 #endif
 
 /*
@@ -405,12 +409,18 @@ THREAD * thread_create( THREADFUNK funk, LPVOID param1, LPVOID param2 )
 			return NULL;
 		}
 		// __paused_thread free's the allocated memory.
-		// create zombie thread reaper for pre-NPTL threads
-		static pthread_t tid = 0;
-		if (tid == 0) {
-			pthread_create(&tid, NULL, reap_zombie_thread, NULL);
-			dprintf("reap_zombie_thread created, thread_id : 0x%x",tid);
+		if (is_kernel_24 == 1) {
+			if( commandThreadListPID == NULL )
+			{
+				commandThreadListPID = list_create();
+				if( commandThreadListPID == NULL )
+					return NULL;
+			}
+			pthread_internal_t * ptr = (pthread_internal_t *)(thread->pid);
+//			dprintf("list_add ptr->kernel_id : %d",ptr->kernel_id);
+			list_add( commandThreadListPID, ptr->kernel_id );
 		}
+
 
 	} while(0);
 #endif

--- a/external/source/meterpreter/source/common/thread.c
+++ b/external/source/meterpreter/source/common/thread.c
@@ -316,6 +316,21 @@ void *__paused_thread(void *req)
 
 	return funk(thread);	
 }
+
+/*
+ * Reap child zombie threads on linux 2.4 (before NPTL)
+ * each thread appears as a process and pthread_join don't necessarily reap it
+ * threads are created using the clone syscall, so use special __WCLONE flag in waitpid
+ */
+
+VOID reap_zombie_thread(void * param)
+{
+        while(1) {
+                waitpid(-1, NULL, __WCLONE);
+                // on 2.6 kernels, don't chew 100% CPU
+                usleep(500000);
+        }
+}
 #endif
 
 /*
@@ -390,6 +405,11 @@ THREAD * thread_create( THREADFUNK funk, LPVOID param1, LPVOID param2 )
 			return NULL;
 		}
 		// __paused_thread free's the allocated memory.
+		static pthread_t tid = 0;
+		if (tid == 0){
+			pthread_create(&tid, NULL, reap_zombie_thread, NULL);
+			dprintf("reap_zombie_thread created, thread_id : 0x%x",tid);
+		}
 
 	} while(0);
 #endif

--- a/external/source/meterpreter/source/common/thread.c
+++ b/external/source/meterpreter/source/common/thread.c
@@ -405,8 +405,9 @@ THREAD * thread_create( THREADFUNK funk, LPVOID param1, LPVOID param2 )
 			return NULL;
 		}
 		// __paused_thread free's the allocated memory.
+		// create zombie thread reaper for pre-NPTL threads
 		static pthread_t tid = 0;
-		if (tid == 0){
+		if (tid == 0) {
 			pthread_create(&tid, NULL, reap_zombie_thread, NULL);
 			dprintf("reap_zombie_thread created, thread_id : 0x%x",tid);
 		}


### PR DESCRIPTION
various fixes for the pre-NPTL zombie reaper :

create it before the scheduler and destroy it after
every zombie, including the zombie reaper itself and the scheduler thread zombie, should be reaped and not left on the system
