### PR TITLE
Fix console notes search via -S

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -940,9 +940,9 @@ class Db
 					end
 				end
 			end
-			if search_term
-				note_list.delete_if do |n|
-					!!n.attribute_names.any? { |a| n[a.intern].to_s.match(search_term) }
+			if search_term and search_term.to_s != "(?-mix:)"
+				note_list = note_list.keep_if do |n|
+					n.attribute_names.any? { |a| n[a.intern].to_s.match(search_term) }
 				end
 			end
 			# Now display them


### PR DESCRIPTION
This commit fixes msfconsole's notes -S functionality which
filters output of the notes command, leaving only entries which
match Regexp.new(search_term), with search_term being any argument
passed after the -S flag.

Testing:
  Before applying patch, search for text in a note via the -S flag
  Apply the patch, rinse, repeat.
