### PR TITLE
update to ie_execcommand_uaf's info to add ROP info

### DIFF
--- a/modules/exploits/windows/browser/ie_execcommand_uaf.rb
+++ b/modules/exploits/windows/browser/ie_execcommand_uaf.rb
@@ -30,6 +30,10 @@ class Metasploit3 < Msf::Exploit::Remote
 				to a use-after-free condition.  Please note that this vulnerability has
 				been exploited in the wild since Sep 14 2012, and there is currently no official
 				patch for it.
+
+				This module requires the following dependencies on the target for the ROP chain to function.
+				For WinXP SP3 with IE8, msvcrt must be present (which it is on default installs).  For 
+				Vista/Win7 with IE8 or Win7 with IE9, jre 1.6.x or below must be installed.
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         =>


### PR DESCRIPTION
This module requires the following dependencies on the target for the
ROP chain to function.  For WinXP SP3 with IE8, msvcrt must be present
(which it is on default installs).  For Vista/Win7 with IE8 or Win7
with IE9, ire 1.6.x or below must be installed.
