### PR TITLE
Add support for dumping MySQL challenge-response pairs in JtR format

### DIFF
--- a/modules/auxiliary/server/capture/mysql.rb
+++ b/modules/auxiliary/server/capture/mysql.rb
@@ -19,7 +19,8 @@ class Metasploit3 < Msf::Auxiliary
 			'Description'    => %q{
 				This module provides a fake MySQL service that is designed to
 				capture authentication credentials. It captures	challenge and
-				response pairs that can be supplied to Cain for	cracking.
+				response pairs that can be supplied to Cain or JtR (faster and
+				multi-core capable) for cracking.
 			},
 			'Author'         => 'Patrik Karlsson <patrik[at]cqure.net>',
 			'License'        => MSF_LICENSE,
@@ -34,6 +35,7 @@ class Metasploit3 < Msf::Auxiliary
 				OptString.new('CHALLENGE', [ true, "The 16 byte challenge", "112233445566778899AABBCCDDEEFF1122334455" ]),
 				OptString.new('SRVVERSION', [ true, "The server version to report in the greeting response", "5.5.16" ]),
 				OptString.new('CAINPWFILE',  [ false, "The local filename to store the hashes in Cain&Abel format", nil ]),
+				OptString.new('JOHNPWFILE',  [ false, "The prefix to the local filename to store the hashes in JOHN format", nil ]),
 			], self.class)
 	end
 
@@ -169,6 +171,13 @@ class Metasploit3 < Msf::Auxiliary
 					"SHA1"
 				].join("\t").gsub(/\n/, "\\n")
 				)
+				fd.close
+			end
+
+			if(datastore['JOHNPWFILE'])
+				john_hash_line = "#{info[:username]}:$mysqlna$#{@challenge.unpack("H*")[0]}*#{info[:response].unpack('H*')[0]}"
+				fd = ::File.open(datastore['JOHNPWFILE'] + '_mysqlna' , "ab")
+				fd.puts john_hash_line
 				fd.close
 			end
 		else


### PR DESCRIPTION
Hi,

JtR (magnum-jumbo version) now supports cracking MySQL challenge-response pairs. Please test with latest code from https://github.com/magnumripper/JohnTheRipper

JtR is faster than Cain & Abel (at this task) and is also multi-core capable.

Thanks,
Dhiru
