### PR TITLE
adds ability to use '!$' in msfconsole just like in bash

### DIFF
--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -426,7 +426,9 @@ module DispatcherShell
 					return self.busy = false
 				else
 					arguments[spot] = parse_line(Readline::HISTORY[his_len-2]).last
-					# we use -2 because -1 is the last one in history, which is actually the currently executing command
+					# we use -2 above because -1 is the last one in history, which is actually the currently executing command
+					# update the history file itself so consecutive uses of !$ don't return '!$' instead of replaced value
+					Readline::HISTORY[his_len-1] = "#{method} #{arguments.join(' ')}"
 				end
 			end
 			dispatcher.send('cmd_' + method, *arguments)

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -417,6 +417,18 @@ module DispatcherShell
 		if(blocked_command?(method))
 			print_error("The #{method} command has been disabled.")
 		else
+			# check for and replace '!$'
+			his_len = Readline::HISTORY.length
+			spot = arguments.index('!$')
+			if spot
+				if his_len < 1
+					print_error('No commands in history to use for !$ substitution')
+					return self.busy = false
+				else
+					arguments[spot] = parse_line(Readline::HISTORY[his_len-2]).last
+					# we use -2 because -1 is the last one in history, which is actually the currently executing command
+				end
+			end
 			dispatcher.send('cmd_' + method, *arguments)
 		end
 		self.busy = false


### PR DESCRIPTION
usage:
msf > set SRVHOST 192..168.101.102
SRVHOST => 192..168.101.102
msf > set LHOST !$
LHOST => 192..168.101.102
msf > set ReverseListenerBindAddress !$
ReverseListenerBindAddress => 1.1.1.1

History will reflect the replaced value, not the '!$'
