### PR TITLE
Fix hex output in share names

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -181,6 +181,12 @@ class Metasploit3 < Msf::Auxiliary
 				end
 
 				if not @shares.empty?
+					# Share names end up in hex quite often, clean up
+					@shares = @shares.map do |share|
+						share.map do |s| 
+							s =~ /\x00\x00/ ? Rex::Text.to_ascii(s).chop : s
+						end
+					end
 					print_status("#{ip}:#{rport} #{@shares.map{|x| "#{x[0]} - #{x[2]} (#{x[1]})" }.join(", ")}")
 					report_note(
 						:host => ip,


### PR DESCRIPTION
Enumshares occasionally returns share names as hex instead of
ascii/text output. This commit checks the individual strings
returned by the module for \x00\x00 and converts those matching
the pattern to text (Rex::Text.to_ascii(str)).

Testing:
  Run against win7 x64 workstations and review output, apply patch
  repeat.

Possible TODO: find a better way to ID hex strings as \x00\x00 may
not always be present, although it has been so far in tests
