### PR TITLE
add rename_file method to Msf::Post::File

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -298,6 +298,15 @@ module Msf::Post::File
 		end
 	end
 
+	#
+	# Rename a remote file
+	#
+	def rename_file(new_file, old_file)
+		write_file(new_file, (read_file(old_file))
+		rm_f(old_file)
+	end
+	alias :move_file :rename_file
+	alias :mv_file :rename_file
 
 protected
 	#


### PR DESCRIPTION
Came up on IRC, I'm not attached to it, but this commit adds the
rename_file method to lib/msf/core/post/file.rb and aliases it to
move_file and mv_file
