### PR TITLE
Bring a little sanity to msfupdate

### DIFF
--- a/msfupdate
+++ b/msfupdate
@@ -23,27 +23,24 @@ if not (Process.uid == 0 or File.stat(msfbase).owned?)
 	$stderr.puts "Please run msfupdate as the same user who installed metasploit."
 end
 
-configdir = nil
-wait_index = nil
-
 @args.each_with_index do |arg,i|
 	case arg
 	when "wait"
-		wait_index = i
+		@wait_index = i
 	when /--config-dir/
 		# Spaces in the directory should be fine since this whole thing is passed
 		# as a single argument via the multi-arg syntax for system() below.
 		# TODO: Test this spaces business. I don't buy it. -todb
-		configdir = File.join(File.dirname(msfbase), "data", "svn")
-		configdir_index = i
+		@configdir_index = i
+		@configdir = File.join(File.dirname(msfbase), "data", "svn")
 	end
 end
 
-@args.delete_at wait_index if wait_index
-@args.delete_at configdir_index if configdir_index
+@args.delete_at @wait_index if @wait_index
+@args.delete_at @configdir_index if @configdir_index
 
 @args.push("--non-interactive")
-@args.push("--config-dir=#{configdir}") if configdir
+@args.push("--config-dir=#{@configdir}") if @configdir_index
 
 res = system("svn", "cleanup")
 if res.nil?
@@ -57,7 +54,7 @@ else
 	system("svn", "update", *@args)
 end
 
-if wait_index
+if @wait_index
 	$stderr.puts ""
 	$stderr.puts "[*] Please hit enter to exit"
 	$stderr.puts ""

--- a/msfupdate
+++ b/msfupdate
@@ -23,12 +23,18 @@ if not (Process.uid == 0 or File.stat(msfbase).owned?)
 	$stderr.puts "Please run msfupdate as the same user who installed metasploit."
 end
 
-wait = (@args.shift.to_s == "wait")
-
 have_configdir = false
-@args.each do |arg|
+wait_index = nil
+@args.each_with_index do |arg,i|
+	if arg == "wait"
+		wait_index = i
+	end
 	next unless arg =~ /--config-dir/
 	have_configdir = true
+end
+
+if wait_index
+	@args.delete_at wait_index
 end
 
 unless have_configdir
@@ -49,11 +55,10 @@ if res.nil?
 	$stderr.puts "[-] to ensure a proper environment."
 else
 	# Cleanup worked, go ahead and update
-	$stderr.puts "DEBUG: Going with *@args: #{@args.inspect}"
 	system("svn", "update", *@args)
 end
 
-if wait
+if wait_index
 	$stderr.puts ""
 	$stderr.puts "[*] Please hit enter to exit"
 	$stderr.puts ""

--- a/msfupdate
+++ b/msfupdate
@@ -5,7 +5,7 @@
 # $Revision$
 
 msfbase = __FILE__
-while File.symlink?(msfbase)
+while File.symlink?(msfbase) # Why is this a while and not an if? -todb
 	msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
 

--- a/msfupdate
+++ b/msfupdate
@@ -9,6 +9,7 @@ while File.symlink?(msfbase)
 	msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
 
+@args = ARGV.dup
 
 Dir.chdir(File.dirname(msfbase))
 
@@ -22,10 +23,10 @@ if not (Process.uid == 0 or File.stat(msfbase).owned?)
 	$stderr.puts "Please run msfupdate as the same user who installed metasploit."
 end
 
-wait = (ARGV.shift.to_s == "wait")
+wait = (@args.shift.to_s == "wait")
 
 have_configdir = false
-ARGV.each do |arg|
+@args.each do |arg|
 	next unless arg =~ /--config-dir/
 	have_configdir = true
 end
@@ -34,10 +35,10 @@ unless have_configdir
 	configdir = File.join(File.dirname(msfbase), "data", "svn")
 	# Spaces in the directory should be fine since this whole thing is passed
 	# as a single argument via the multi-arg syntax for system() below.
-	ARGV.push("--config-dir=#{configdir}")
+	@args.push("--config-dir=#{configdir}")
 end
 
-ARGV.push("--non-interactive")
+@args.push("--non-interactive")
 
 res = system("svn", "cleanup")
 if res.nil?
@@ -48,7 +49,8 @@ if res.nil?
 	$stderr.puts "[-] to ensure a proper environment."
 else
 	# Cleanup worked, go ahead and update
-	system("svn", "update", *ARGV)
+	$stderr.puts "DEBUG: Going with *@args: #{@args.inspect}"
+	system("svn", "update", *@args)
 end
 
 if wait

--- a/msfupdate
+++ b/msfupdate
@@ -23,28 +23,27 @@ if not (Process.uid == 0 or File.stat(msfbase).owned?)
 	$stderr.puts "Please run msfupdate as the same user who installed metasploit."
 end
 
-have_configdir = false
+configdir = nil
 wait_index = nil
+
 @args.each_with_index do |arg,i|
-	if arg == "wait"
+	case arg
+	when "wait"
 		wait_index = i
+	when /--config-dir/
+		# Spaces in the directory should be fine since this whole thing is passed
+		# as a single argument via the multi-arg syntax for system() below.
+		# TODO: Test this spaces business. I don't buy it. -todb
+		configdir = File.join(File.dirname(msfbase), "data", "svn")
+		configdir_index = i
 	end
-	next unless arg =~ /--config-dir/
-	have_configdir = true
 end
 
-if wait_index
-	@args.delete_at wait_index
-end
-
-unless have_configdir
-	configdir = File.join(File.dirname(msfbase), "data", "svn")
-	# Spaces in the directory should be fine since this whole thing is passed
-	# as a single argument via the multi-arg syntax for system() below.
-	@args.push("--config-dir=#{configdir}")
-end
+@args.delete_at wait_index if wait_index
+@args.delete_at configdir_index if configdir_index
 
 @args.push("--non-interactive")
+@args.push("--config-dir=#{configdir}") if configdir
 
 res = system("svn", "cleanup")
 if res.nil?

--- a/msfupdate
+++ b/msfupdate
@@ -5,7 +5,7 @@
 # $Revision$
 
 msfbase = __FILE__
-while File.symlink?(msfbase) # Why is this a while and not an if? -todb
+while File.symlink?(msfbase)
 	msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
 


### PR DESCRIPTION
This fixes up some things that bug me about msfupdate. Favoring instance variables over explicit assignment of nil, avoiding `Array#push` and `Array#shift` on `ARGV` directly, little things like that.

This all came up while testing and grokking msfupdate. Turns out, svn.metasploit.com is really, really slow. Git SVN looks very promising, and working out how to switch out an active SVN repository to github without too much disruption.

That all is for another pull request. This PR just tries to make things more sane.
