### PR TITLE
Add subdomain input file for VHOST scanner

### DIFF
--- a/modules/auxiliary/scanner/http/vhost_scanner.rb
+++ b/modules/auxiliary/scanner/http/vhost_scanner.rb
@@ -51,22 +51,26 @@ require 'cgi'
 		end
 
 		def run_host(ip)
-			valstr = ::File.file?(datastore['SUBDOM_LIST']) ?
-			IO.readlines(datastore['SUBDOM_LIST']).map {|e| e.gsub(".#{datastore['DOMAIN']}", "").chomp} :
-			 [
-				"admin",
-				"services",
-				"webmail",
-				"console",
-				"apps",
-				"mail",
-				"intranet",
-				"intra",
-				"spool",
-				"corporate",
-				"www",
-				"web"
-			]
+			if ::File.file?(datastore['SUBDOM_LIST'])
+				valstr = IO.readlines(datastore['SUBDOM_LIST']).map {
+					|e| e.gsub(".#{datastore['DOMAIN']}", "").chomp
+				}
+			else
+				 valstr = [
+					"admin",
+					"services",
+					"webmail",
+					"console",
+					"apps",
+					"mail",
+					"intranet",
+					"intra",
+					"spool",
+					"corporate",
+					"www",
+					"web"
+				]
+			end
 
 			datastore['QUERY'] ? tquery = queryparse(datastore['QUERY']): nil
 			datastore['HEADERS'] ? thead = headersparse(datastore['HEADERS']) : nil

--- a/modules/auxiliary/scanner/http/vhost_scanner.rb
+++ b/modules/auxiliary/scanner/http/vhost_scanner.rb
@@ -45,13 +45,15 @@ require 'cgi'
 				OptString.new('QUERY', [ false,  "HTTP URI Query", '']),
 				OptString.new('DOMAIN', [ true,  "Domain name", '']),
 				OptString.new('HEADERS', [ false,  "HTTP Headers", '']),
+				OptPath.new('SUBDOM_LIST', [false, "Path to text file with subdomains"]),
 			], self.class)
 
 		end
 
 		def run_host(ip)
-
-			valstr = [
+			valstr = ::File.file?(datastore['SUBDOM_LIST']) ?
+			IO.readlines(datastore['SUBDOM_LIST']).map {|e| e.gsub(".#{datastore['DOMAIN']}", "").chomp} :
+			 [
 				"admin",
 				"services",
 				"webmail",
@@ -102,7 +104,8 @@ require 'cgi'
 				print_error("[#{ip}] Unable to identify error response")
 				return
 			end
-
+			
+			vprint_status("Running with #{valstr.length} sudomains")
 			valstr.each do |astr|
 				thost = astr+"."+datastore['DOMAIN']
 


### PR DESCRIPTION
This commit allows the vhost scanner to take subdomains from a
text file, one subdomain per line. Lines are stripped of the top
level domain name if present before testing.
