### PR TITLE
remove unnecessary parens and better comments

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -299,10 +299,11 @@ module Msf::Post::File
 	end
 
 	#
-	# Rename a remote file
+	# Rename a remote file.  This is a stopgap until a proper API version is added.
 	#
 	def rename_file(new_file, old_file)
-		write_file(new_file, (read_file(old_file)))
+		#TODO:  this is not ideal as the file contents are sent to meterp server and back to the client
+		write_file(new_file, read_file(old_file)) 
 		rm_f(old_file)
 	end
 	alias :move_file :rename_file


### PR DESCRIPTION
removes unnecessary parens (and yes I confirmed they are properly
paired), and adds some comments regarding this as not being an ideal
solution, but rather a stopgap.  Sorry about the last one sinner, not sure
how that extra paren got in there last time
