### PR TITLE
update info on ms10_042 to reflect use of webdav

### DIFF
--- a/modules/exploits/windows/browser/ms10_042_helpctr_xss_cmd_exec.rb
+++ b/modules/exploits/windows/browser/ms10_042_helpctr_xss_cmd_exec.rb
@@ -38,6 +38,9 @@ class Metasploit3 < Msf::Exploit::Remote
 				available and will use one if possible. In the case of both IE8 and WMP11, the
 				exploit defaults to using an iframe on IE8, but is configurable by setting the
 				DIALOGMECH option to "none" or "player".
+
+				This module creates a WebDAV service from which the payload is copied to the
+				victim machine.
 			},
 			'Author'		=>
 				[
@@ -72,8 +75,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		register_options(
 			[
-				OptPort.new(	'SRVPORT',		 [ true, "The daemon port to listen on", 80 ]),
-				OptString.new(	'URIPATH',		 [ true, "The URI to use.", "/" ]),
+				OptPort.new(	'SRVPORT',		 [ true,  "The daemon port to listen on (do not change)", 80 ]),
+				OptString.new(	'URIPATH',		 [ true,  "The URI to use (do not change).", "/" ]),
 				OptString.new(	'DIALOGMECH',	 [ true, "IE8/WMP11 trigger mechanism (none, iframe, or player).", "iframe"])
 			], self.class)
 


### PR DESCRIPTION
ms10_042_helpctr_xss_cmd_exec.rb doesn't tell you that it's going to
use webdav, and it's options dont' have the (Don't change) warning for
SRVPORT and URIPATH.  This update fixes all that.

I have rc scripts that search for webdav in the info or name of the module since they can't be run concurrently.  I'd love to have a better method, but I couldn't figure one out.  So, not having webdav in the info screws up my shiz.  But more importantly the user should be informed webdav will be used so they can understand the consequences of running this module
