### PR TITLE
Fix loading binary modules on Windows

### DIFF
--- a/lib/msf/core/modules/loader/directory.rb
+++ b/lib/msf/core/modules/loader/directory.rb
@@ -73,6 +73,13 @@ class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
   def read_module_content(parent_path, type, module_reference_name)
     full_path = module_path(parent_path, type, module_reference_name)
 
-    ::File.read(full_path)
+    module_content = ''
+
+    # force to read in binary mode so Pro modules won't be truncated on Windows
+    File.open(full_path, 'rb') do |f|
+      module_content = f.read
+    end
+
+    module_content
   end
 end

--- a/lib/msf/core/modules/loader/directory.rb
+++ b/lib/msf/core/modules/loader/directory.rb
@@ -77,7 +77,11 @@ class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
 
     # force to read in binary mode so Pro modules won't be truncated on Windows
     File.open(full_path, 'rb') do |f|
-      module_content = f.read
+      # Pass the size of the file as it leads to faster reads due to fewer buffer resizes. Greatest effect on Windows.
+      # @see http://www.ruby-forum.com/topic/209005
+      # @see https://github.com/ruby/ruby/blob/ruby_1_8_7/io.c#L1205
+      # @see https://github.com/ruby/ruby/blob/ruby_1_9_3/io.c#L2038
+      module_content = f.read(f.stat.size)
     end
 
     module_content


### PR DESCRIPTION
[#36737359, #36401509]

Failed to follow HACKING guideline #5, open files in binary mode, so
Pro modules were being truncated on Windows installs.
