### PR TITLE
Fix 1.8 compat with Module#const_defined?

### DIFF
--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -370,13 +370,14 @@ class Msf::Modules::Loader::Base
   # @return [Module] module that wraps the previously loaded content from {#read_module_content}.
   # @return [nil] if any module name along the chain does not exist.
   def current_module(module_names)
-    # don't look at ancestors for constant
-    inherit = false
-
     # Don't want to trigger ActiveSupport's const_missing, so can't use constantize.
     named_module = module_names.inject(Object) { |parent, module_name|
-      if parent.const_defined?(module_name, inherit)
-        parent.const_get(module_name, inherit)
+			# Since we're searching parent namespaces first anyway, this is
+			# semantically equivalent to providing false for the 1.9-only
+			# "inherit" parameter to const_defined?. If we ever drop 1.8
+			# support, we can save a few cycles here by adding it back.
+      if parent.const_defined?(module_name)
+        parent.const_get(module_name)
       else
         break
       end

--- a/lib/msf/core/modules/namespace.rb
+++ b/lib/msf/core/modules/namespace.rb
@@ -11,10 +11,15 @@ module Msf::Modules::Namespace
   def metasploit_class
     metasploit_class = nil
     # don't search ancestors for the metasploit_class
-    inherit = false
+    #inherit = false
 
     ::Msf::Framework::Major.downto(1) do |major|
-      if const_defined?("Metasploit#{major}", inherit)
+			# Since we really only care about the deepest namespace, we don't
+			# need to look for parents' constants. However, the "inherit"
+			# parameter for const_defined? only exists after 1.9. If we ever
+			# drop 1.8 support, we can save a few cycles here by passing false
+			# here.
+      if const_defined?("Metasploit#{major}")
         metasploit_class = const_get("Metasploit#{major}")
 
         break


### PR DESCRIPTION
Before 1.9, const_defined? only takes one parameter.
