### PR TITLE
Demonstrates bug #7292

### DIFF
--- a/modules/auxiliary/array/foo.rb
+++ b/modules/auxiliary/array/foo.rb
@@ -1,0 +1,46 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Foo module',
+			'Description'    => %q{
+				This module demos a bug.
+			},
+			'Author'         => [ 'todb' ],
+			'License'        => MSF_LICENSE,
+			'Version'        => '$Revision$',
+			'References'     =>
+				[
+					[ 'BID', '1234' ]
+				],
+			'DisclosureDate' => 'Oct 04 2009'))
+
+			register_options(
+				[
+					OptAddress.new('LHOST', [true, "The spoofed address of a vulnerable ntpd server" ])
+				], self.class)
+
+			deregister_options('FILTER','PCAPFILE')
+
+	end
+
+	def run
+		this_array = Array.new
+		this_array << "bug"
+		print_status this_array.join
+	end
+
+end


### PR DESCRIPTION
Thanks to Egypt for the hint.

```
msf  auxiliary(foo) > run

[-] Auxiliary failed: NoMethodError undefined method `new' for
Msf::Modules::Array:Module
[-] Call stack:
[-]
/home/todb/git/todb-r7/metasploit-framework/modules/auxiliary/array/foo.rb:41:in
`run'
[*] Auxiliary module execution completed
```

Please don't merge this as is, but something like this needs to be invented or identified as a test case.

[SeeRM #7292]
