### PR TITLE
Make AR a soft dependency again

### DIFF
--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -19,7 +19,7 @@ class DBManager
 
 	# Mainly, it's Ruby 1.9.1 that cause a lot of problems now, along with Ruby 1.8.6.
 	# Ruby 1.8.7 actually seems okay, but why tempt fate? Let's say 1.9.3 and beyond.
-	def self.warn_about_rubies
+	def warn_about_rubies
 		if ::RUBY_VERSION =~ /^1\.9\.[012]($|[^\d])/
 			$stderr.puts "**************************************************************************************"
 			$stderr.puts "Metasploit requires at least Ruby 1.9.3. For an easy upgrade path, see https://rvm.io/"
@@ -118,7 +118,9 @@ class DBManager
 		# If Mdm::Host is defined, the dynamically created classes
 		# are already in the object space
 		begin
-			include MetasploitDataModels unless defined? Mdm::Host
+			unless defined? Mdm::Host
+				self.class.send :include, MetasploitDataModels
+			end
 		rescue NameError => e
 			warn_about_rubies
 			raise e

--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -1,19 +1,10 @@
 # -*- coding: binary -*-
-require "active_record"
 
 require 'msf/core'
 require 'msf/core/db'
 require 'msf/core/task_manager'
 require 'fileutils'
 require 'shellwords'
-
-# Provide access to ActiveRecord models shared w/ commercial versions
-require "metasploit_data_models"
-
-# Patches issues with ActiveRecord
-require "msf/core/patches/active_record"
-
-
 
 module Msf
 
@@ -34,16 +25,6 @@ class DBManager
 			$stderr.puts "Metasploit requires at least Ruby 1.9.3. For an easy upgrade path, see https://rvm.io/"
 			$stderr.puts "**************************************************************************************"
 		end
-	end
-
-	# Only include Mdm if we're not using Metasploit commercial versions
-	# If Mdm::Host is defined, the dynamically created classes
-	# are already in the object space
-	begin
-    include MetasploitDataModels unless defined? Mdm::Host
-	rescue NameError => e
-	warn_about_rubies
-	raise e
 	end
 
 	# Provides :framework and other accessors
@@ -117,12 +98,30 @@ class DBManager
 			# Database drivers can reset our KCODE, do not let them
 			$KCODE = 'NONE' if RUBY_VERSION =~ /^1\.8\./
 
+			require "active_record"
+
+			# Provide access to ActiveRecord models shared w/ commercial versions
+			require "metasploit_data_models"
+
+			# Patches issues with ActiveRecord
+			require "msf/core/patches/active_record"
+
 			@usable = true
 
 		rescue ::Exception => e
 			self.error = e
 			elog("DB is not enabled due to load error: #{e}")
 			return false
+		end
+
+		# Only include Mdm if we're not using Metasploit commercial versions
+		# If Mdm::Host is defined, the dynamically created classes
+		# are already in the object space
+		begin
+			include MetasploitDataModels unless defined? Mdm::Host
+		rescue NameError => e
+			warn_about_rubies
+			raise e
 		end
 
 		#

--- a/lib/msf/core/module_manager/module_paths.rb
+++ b/lib/msf/core/module_manager/module_paths.rb
@@ -2,6 +2,8 @@
 # Gems
 #
 require 'active_support/concern'
+require 'active_support/core_ext/hash'
+require 'active_support/core_ext/module'
 
 # Deals with module paths in the {Msf::ModuleManager}
 module Msf::ModuleManager::ModulePaths


### PR DESCRIPTION
Ensures that the absence of activerecord does not prevent msfconsole
from loading. This returns us to the previous state of affairs where it
is possible to use the framework entirely without a database.

To test:
1. rm -rf lib/gemcache/ruby/1.9.1/gems/activerecord*
2. remove any locally installed versions of activerecord
3. msfconsole

msfconsole should load up with a warning like so:

[-] ***
[-] \* WARNING: No database support: LoadError cannot load such file -- active_record
[-] ***

... and should still be functional.
