### PR TITLE
Revert "Merge branch 'todb-r7-fix-msfupdate' into rapid7"

### DIFF
--- a/msfupdate
+++ b/msfupdate
@@ -9,7 +9,6 @@ while File.symlink?(msfbase)
 	msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
 
-@args = ARGV.dup
 
 Dir.chdir(File.dirname(msfbase))
 
@@ -23,24 +22,22 @@ if not (Process.uid == 0 or File.stat(msfbase).owned?)
 	$stderr.puts "Please run msfupdate as the same user who installed metasploit."
 end
 
-@args.each_with_index do |arg,i|
-	case arg
-	when "wait"
-		@wait_index = i
-	when /--config-dir/
-		# Spaces in the directory should be fine since this whole thing is passed
-		# as a single argument via the multi-arg syntax for system() below.
-		# TODO: Test this spaces business. I don't buy it. -todb
-		@configdir_index = i
-		@configdir = File.join(File.dirname(msfbase), "data", "svn")
-	end
+wait = (ARGV.shift.to_s == "wait")
+
+have_configdir = false
+ARGV.each do |arg|
+	next unless arg =~ /--config-dir/
+	have_configdir = true
 end
 
-@args.delete_at @wait_index if @wait_index
-@args.delete_at @configdir_index if @configdir_index
+unless have_configdir
+	configdir = File.join(File.dirname(msfbase), "data", "svn")
+	# Spaces in the directory should be fine since this whole thing is passed
+	# as a single argument via the multi-arg syntax for system() below.
+	ARGV.push("--config-dir=#{configdir}")
+end
 
-@args.push("--non-interactive")
-@args.push("--config-dir=#{@configdir}") if @configdir_index
+ARGV.push("--non-interactive")
 
 res = system("svn", "cleanup")
 if res.nil?
@@ -51,10 +48,10 @@ if res.nil?
 	$stderr.puts "[-] to ensure a proper environment."
 else
 	# Cleanup worked, go ahead and update
-	system("svn", "update", *@args)
+	system("svn", "update", *ARGV)
 end
 
-if @wait_index
+if wait
 	$stderr.puts ""
 	$stderr.puts "[*] Please hit enter to exit"
 	$stderr.puts ""


### PR DESCRIPTION
Hold off on this. The config dir option is more magical than first
expected, and didn't manifest with initial testing.

This reverts commit 44d7ab8ca28ae330230725f79646824742f99fbc, reversing
changes made to 114b7886fa1e31e39230e2f11aa3bcd3e30347a0.

Bug reported here:

http://twitter.com/info_dox/status/255744881782304769

Note that this does not appear to manifest in either svn checkouts, or in the Windows install. This seems to come up only for the Linux installer.

Note, the workaround is to pass --config-dir to msfupdate.
