### PR TITLE
Fix msfupdate for #7297

### DIFF
--- a/msfupdate
+++ b/msfupdate
@@ -28,8 +28,11 @@ end
 
 @args.each_with_index do |arg,i|
 	case arg
-	when "wait"
+	# Handle the old wait/nowait argument behavior
+	when "wait", "nowait"
 		@wait_index = i
+		@actually_wait = (arg == "wait")
+	# Handle passing a config-dir especially
 	when /--config-dir/
 		# Spaces in the directory should be fine since this whole thing is passed
 		# as a single argument via the multi-arg syntax for system() below.
@@ -54,7 +57,7 @@ else
 	system("svn", "update", *@args)
 end
 
-if @wait_index
+if @actually_wait
 	$stderr.puts ""
 	$stderr.puts "[*] Please hit enter to exit"
 	$stderr.puts ""

--- a/msfupdate
+++ b/msfupdate
@@ -32,17 +32,23 @@ end
 	when "wait", "nowait"
 		@wait_index = i
 		@actually_wait = (arg == "wait")
-	# Handle passing a config-dir especially
-	when /--config-dir/
+	# An empty or absent config-dir means a default config-dir
+	when "--config-dir"
+		@configdir_index = i
+	# A defined config dir means a defined config-dir
+	when /--config-dir=(.*)?/
 		# Spaces in the directory should be fine since this whole thing is passed
 		# as a single argument via the multi-arg syntax for system() below.
 		# TODO: Test this spaces business. I don't buy it. -todb
+		@configdir = $1
 		@configdir_index = i
 	end
 end
 
-@args.delete_at @wait_index if @wait_index
-@args.push("--config-dir=#{@configdir}") unless @configdir_index
+@args[@wait_index] = nil      if @wait_index
+@args[@configdir_index] = nil if @configdir_index
+@args = @args.compact
+@args.push("--config-dir=#{@configdir}")
 @args.push("--non-interactive")
 
 res = system("svn", "cleanup")


### PR DESCRIPTION
Fixes Redmine issue 7297 completely.

See

https://dev.metasploit.com/redmine/issues/7297

Tested on Windows installed metasploit via Framework Update Start Menu option, Linux binary installed via `sudo msfupdate` as well as `sudo msfupdate nowait --config-dir=/opt/metasploit-4.3.0/msf3/data/svn`, and Linux svn checkout with and without wait, nowait, named config-dir and missing config-dir.

That should cover all the bases.
