### PR TITLE
change vprint_error to print_error

### DIFF
--- a/modules/exploits/windows/browser/mozilla_reduceright.rb
+++ b/modules/exploits/windows/browser/mozilla_reduceright.rb
@@ -94,7 +94,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def on_request_uri(cli, request)
 		agent = request.headers['User-Agent']
 		if agent !~ /Firefox\/3\.6\.[16|17]/
-			vprint_error("This browser is not supported: #{agent.to_s}")
+			print_error("This browser is not supported: #{agent.to_s}")
 			send_not_found(cli)
 			return
 		end


### PR DESCRIPTION
Low priority update.
exploits/windows/browser/mozilla_reduceright does not tell you when an
incompatible browser connects like most other browser exploits do
(unless verbose is true).  This change just changes the vprint_error to print_error
to be more consistent w/other browser exploits
