### PR TITLE
Make use of print_debug() instead of print_status()

### DIFF
--- a/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
@@ -70,6 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def on_new_session(client)
+		print_debug("Deleting 'temp.php'")
 		if client.type == "meterpreter"
 			client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
 			client.fs.file.rm("temp.php")

--- a/modules/exploits/linux/http/vcms_upload.rb
+++ b/modules/exploits/linux/http/vcms_upload.rb
@@ -76,6 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def on_new_session(client)
+		print_debug("Deleting '#{@payload_name}'")
 		if client.type == "meterpreter"
 			client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
 			client.fs.file.rm(@payload_name)

--- a/modules/exploits/linux/http/webid_converter.rb
+++ b/modules/exploits/linux/http/webid_converter.rb
@@ -109,7 +109,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		res = client.fs.file.search(nil, "currencies.php", true, -1)
 		res.each do |hit|
 			filename = "#{hit['path']}/#{hit['name']}"
-			print_status("#{peer} - Restoring #{filename}")
+			print_debug("#{peer} - Restoring #{filename}")
 			client.fs.file.rm(filename)
 			fd = client.fs.file.new(filename, "wb")
 			fd.write(currencies_php)

--- a/modules/exploits/multi/http/auxilium_upload_exec.rb
+++ b/modules/exploits/multi/http/auxilium_upload_exec.rb
@@ -93,13 +93,14 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		@clean_files.each do |f|
-			print_status("#{@peer} - Removing: #{f}")
+			print_debug("#{@peer} - Removing: #{f}")
 			begin
 				if cli.type == 'meterpreter'
 					cli.fs.file.rm(f)
 				else
 					cli.shell_command_token("rm #{f}")
 				end
+				print_debug("#{@peer} - Removed: #{f}")
 			rescue ::Exception => e
 				print_error("#{@peer} - Unable to remove #{f}: #{e.message}")
 			end

--- a/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
+++ b/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
@@ -70,6 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def on_new_session(client)
+		print_debug("Removing '#{@var_hexfile}.txt' and '#{@jsp_name}.jsp'...")
 		if client.type == "meterpreter"
 			client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
 			client.fs.file.rm("../#{@var_hexfile}.txt")
@@ -83,6 +84,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				client.shell_command_token("del ..\\#{@jsp_name}.jsp")
 			end
 		end
+
+		print_debug("Files removed")
 	end
 
 	def exploit

--- a/modules/exploits/multi/http/mobilecartly_upload_exec.rb
+++ b/modules/exploits/multi/http/mobilecartly_upload_exec.rb
@@ -94,13 +94,14 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		@clean_files.each do |f|
-			print_status("#{@peer} - Removing: #{f}")
 			begin
+				print_debug("#{@peer} - Removing: #{f}")
 				if cli.type == 'meterpreter'
 					cli.fs.file.rm(f)
 				else
 					cli.shell_command_token("rm #{f}")
 				end
+				print_debug("#{@peer} - Removed: #{f}")
 			rescue ::Exception => e
 				print_error("#{@peer} - Unable to remove #{f}: #{e.message}")
 			end

--- a/modules/exploits/multi/http/qdpm_upload_exec.rb
+++ b/modules/exploits/multi/http/qdpm_upload_exec.rb
@@ -94,13 +94,14 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		@clean_files.each do |f|
-			print_status("#{@peer} - Removing: #{f}")
 			begin
+				print_debug("#{@peer} - Removing: #{f}")
 				if cli.type == 'meterpreter'
 					cli.fs.file.rm(f)
 				else
 					cli.shell_command_token("rm #{f}")
 				end
+				print_debug("#{@peer} - Removed: #{f}")
 			rescue ::Exception => e
 				print_error("#{@peer} - Unable to remove #{f}: #{e.message}")
 			end

--- a/modules/exploits/multi/http/sflog_upload_exec.rb
+++ b/modules/exploits/multi/http/sflog_upload_exec.rb
@@ -102,13 +102,14 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		@clean_files.each do |f|
-			print_status("#{@peer} - Removing: #{f}")
 			begin
+				print_debug("#{@peer} - Removing: #{f}")
 				if cli.type == 'meterpreter'
 					cli.fs.file.rm(f)
 				else
 					cli.shell_command_token("rm #{f}")
 				end
+				print_debug("#{@peer} - Removed: #{f}")
 			rescue ::Exception => e
 				print_error("#{@peer} - Unable to remove #{f}: #{e.message}")
 			end

--- a/modules/exploits/multi/http/struts_code_exec.rb
+++ b/modules/exploits/multi/http/struts_code_exec.rb
@@ -130,11 +130,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_new_session(client)
 		if target['Platform'] == 'linux'
-			print_status("Deleting #{@payload_exe} payload file")
+			print_debug("Deleting #{@payload_exe} payload file")
 			execute_command("/bin/sh@-c@rm #{@payload_exe}")
 		else
-			print_status("Windows does not allow running executables to be deleted")
-			print_status("Delete the #{@payload_exe} file manually after migrating")
+			print_debug("Windows does not allow running executables to be deleted")
+			print_debug("Delete the #{@payload_exe} file manually after migrating")
 		end
 	end
 

--- a/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
+++ b/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
@@ -182,7 +182,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			return
 		end
 
-		print_status("Deleting the #{@payload_exe} file")
+		print_debug("Deleting the #{@payload_exe} file")
 		client.fs.file.rm(@payload_exe)
 
 	end

--- a/modules/exploits/multi/http/testlink_upload_exec.rb
+++ b/modules/exploits/multi/http/testlink_upload_exec.rb
@@ -140,6 +140,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def on_new_session(client)
+		print_debug("Removing: '#{@token}.php'")
 		if client.type == "meterpreter"
 			client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
 			client.fs.file.rm("#{@token}.php")

--- a/modules/exploits/multi/http/webpagetest_upload_exec.rb
+++ b/modules/exploits/multi/http/webpagetest_upload_exec.rb
@@ -81,7 +81,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 		cli.core.use("stdapi") if not cli.ext.aliases.include?("stdapi")
 		cli.fs.file.rm(@target_path)
-		print_status("#{@target_path} removed")
+		print_debug("#{@target_path} removed")
 	end
 
 

--- a/modules/exploits/unix/webapp/xoda_file_upload.rb
+++ b/modules/exploits/unix/webapp/xoda_file_upload.rb
@@ -74,6 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def on_new_session(client)
+		print_debug("Removing #{@payload_name}")
 		if client.type == "meterpreter"
 			client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
 			client.fs.file.rm(@payload_name)

--- a/modules/exploits/windows/browser/hp_easy_printer_care_xmlcachemgr.rb
+++ b/modules/exploits/windows/browser/hp_easy_printer_care_xmlcachemgr.rb
@@ -83,9 +83,9 @@ class Metasploit3 < Msf::Exploit::Remote
 		client.sys.process.execute(cmd, nil, {'Hidden' => true })
 
 		begin
-			print_status("Deleting the vbs payload \"#{@var_vbs_name}.vbs\" ...")
+			print_debug("Deleting the vbs payload \"#{@var_vbs_name}.vbs\" ...")
 			client.fs.file.rm("C:\\windows\\system32\\" + @var_vbs_name + ".vbs")
-			print_status("Deleting the mof file \"#{@var_mof_name}.mof\" ...")
+			print_debug("Deleting the mof file \"#{@var_mof_name}.mof\" ...")
 			client.fs.file.rm("C:\\windows\\system32\\wbem\\mof\\good\\" + @var_mof_name + ".mof")
 		rescue ::Exception => e
 			print_error("Exception: #{e.inspect}")

--- a/modules/exploits/windows/browser/hp_easy_printer_care_xmlsimpleaccessor.rb
+++ b/modules/exploits/windows/browser/hp_easy_printer_care_xmlsimpleaccessor.rb
@@ -88,9 +88,9 @@ class Metasploit3 < Msf::Exploit::Remote
 		client.sys.process.execute(cmd, nil, {'Hidden' => true })
 
 		begin
-			print_status("Deleting the vbs payload \"#{@var_vbs_name}.vbs\" ...")
+			print_debug("Deleting the vbs payload \"#{@var_vbs_name}.vbs\" ...")
 			client.fs.file.rm("C:\\windows\\system32\\" + @var_vbs_name + ".vbs")
-			print_status("Deleting the mof file \"#{@var_mof_name}.mof\" ...")
+			print_debug("Deleting the mof file \"#{@var_mof_name}.mof\" ...")
 			client.fs.file.rm("C:\\windows\\system32\\wbem\\mof\\good\\" + @var_mof_name + ".mof")
 		rescue ::Exception => e
 			print_error("Exception: #{e.inspect}")

--- a/modules/exploits/windows/browser/keyhelp_launchtripane_exec.rb
+++ b/modules/exploits/windows/browser/keyhelp_launchtripane_exec.rb
@@ -86,7 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def on_new_session(client)
-		print_status("The exe payload (C:\\windows\\system32\\msfmsf.exe) and mof file (C:\\windows\\system32\\wbem\\mof\\good\\msfmsf.mof) must be removed manually.")
+		print_debug("The exe payload (C:\\windows\\system32\\msfmsf.exe) and mof file (C:\\windows\\system32\\wbem\\mof\\good\\msfmsf.mof) must be removed manually.")
 	end
 
 	def auto_target(cli, request)

--- a/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
+++ b/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
@@ -73,14 +73,14 @@ class Metasploit3 < Msf::Exploit::Remote
 		client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
 
 		begin
-			print_status("Deleting the vbs payload \"#{@stager_name}\" ...")
+			print_debug("Deleting the vbs payload \"#{@stager_name}\" ...")
 			client.fs.file.rm("#{@temp_folder}/#{@stager_name}")
 			print_good("The vbs stager has been deleted successfully")
-			print_status("The exe payload #{@temp_folder}/#{@payload_name}.exe must be removed manually")
+			print_debug("The exe payload #{@temp_folder}/#{@payload_name}.exe must be removed manually")
 		rescue ::Exception => e
 			print_error("Problems while the clenaup")
-			print_status("The vbs stager #{@temp_folder}/#{@stager_name} must be removed manually")
-			print_status("The exe payload #{@temp_folder}/#{@payload_name}.exe must be removed manually")
+			print_debug("The vbs stager #{@temp_folder}/#{@stager_name} must be removed manually")
+			print_debug("The exe payload #{@temp_folder}/#{@payload_name}.exe must be removed manually")
 			print_error("Exception: #{e.inspect}")
 			return
 		end

--- a/modules/exploits/windows/http/oracle_btm_writetofile.rb
+++ b/modules/exploits/windows/http/oracle_btm_writetofile.rb
@@ -102,9 +102,9 @@ class Metasploit3 < Msf::Exploit::Remote
 		client.sys.process.execute(cmd, nil, {'Hidden' => true })
 
 		begin
-			print_status("Deleting the vbs payload \"#{@var_vbs_name}.vbs\" ...")
+			print_debug("Deleting the vbs payload \"#{@var_vbs_name}.vbs\" ...")
 			client.fs.file.rm("C:\\windows\\system32\\" + @var_vbs_name + ".vbs")
-			print_status("Deleting the mof file \"#{@var_mof_name}.mof\" ...")
+			print_debug("Deleting the mof file \"#{@var_mof_name}.mof\" ...")
 			client.fs.file.rm("C:\\windows\\system32\\wbem\\mof\\good\\" + @var_mof_name + ".mof")
 		rescue ::Exception => e
 			print_error("Exception: #{e.inspect}")

--- a/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
+++ b/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
@@ -95,9 +95,9 @@ class Metasploit3 < Msf::Exploit::Remote
 		begin
 			jsp = @outpath.gsub(/\//, "\\\\")
 			jsp = jsp.gsub(/"/, "")
-			vprint_status("#{rhost}:#{rport} - Deleting: #{jsp}")
+			print_debug("#{rhost}:#{rport} - Deleting: #{jsp}")
 			cli.fs.file.rm(jsp)
-			print_status("#{rhost}:#{rport} - #{@jsp_name + '.jsp'} deleted")
+			print_debug("#{rhost}:#{rport} - #{@jsp_name + '.jsp'} deleted")
 		rescue ::Exception => e
 			print_error("Unable to delete #{@jsp_name + '.jsp'}: #{e.message}")
 		end

--- a/modules/exploits/windows/http/umbraco_upload_aspx.rb
+++ b/modules/exploits/windows/http/umbraco_upload_aspx.rb
@@ -71,7 +71,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		begin
 			aspx = @upload_random + '.aspx'
 
-			print_status("#{@peer} - Searching: #{aspx}")
+			print_debug("#{@peer} - Searching: #{aspx}")
 			files = cli.fs.file.search("\\", aspx)
 			if not files or files.empty?
 				print_error("Unable to find #{aspx}. Please manually remove it.")
@@ -82,7 +82,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				print_status("#{@peer} - Deleting: #{f['path'] + "\\" + f['name']}")
 				cli.fs.file.rm(f['path'] + "\\" + f['name'])
 			}
-			print_status("#{@peer} - #{aspx} deleted")
+			print_debug("#{@peer} - #{aspx} deleted")
 		rescue ::Exception => e
 			print_error("Unable to delete #{aspx}: #{e.message}")
 		end

--- a/modules/exploits/windows/iis/ms01_026_dbldecode.rb
+++ b/modules/exploits/windows/iis/ms01_026_dbldecode.rb
@@ -230,7 +230,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
 
 		# Delete the copied CMD.exe
-		print_status("Deleting copy of CMD.exe \"#{@exe_cmd_copy}\" ...")
+		print_debug("Deleting copy of CMD.exe \"#{@exe_cmd_copy}\" ...")
 		client.fs.file.rm(@exe_cmd_copy)
 
 		# Migrate so  that we can delete the payload exe
@@ -241,11 +241,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		delete_me_too = "C:\\inetpub\\scripts\\" + @exe_payload
 
-		print_status("Changing permissions on #{delete_me_too} ...")
+		print_debug("Changing permissions on #{delete_me_too} ...")
 		cmd = "C:\\#{@win_dir}\\system32\\attrib.exe -r -h -s " + delete_me_too
 		client.sys.process.execute(cmd, nil, {'Hidden' => true })
 
-		print_status("Deleting #{delete_me_too} ...")
+		print_debug("Deleting #{delete_me_too} ...")
 		begin
 			client.fs.file.rm(delete_me_too)
 		rescue ::Exception => e

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -362,7 +362,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
 
 		# Delete the copied CMD.exe
-		print_status("Deleting copy of CMD.exe \"#{@exe_cmd_copy}\" ...")
+		print_debug("Deleting copy of CMD.exe \"#{@exe_cmd_copy}\" ...")
 		client.fs.file.rm(@exe_cmd_copy)
 
 		# Migrate so  that we can delete the payload exe
@@ -373,11 +373,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		delete_me_too = "C:\\inetpub\\scripts\\" + @exe_payload # C:\ ?
 
-		print_status("Changing permissions on #{delete_me_too} ...")
+		print_debug("Changing permissions on #{delete_me_too} ...")
 		cmd = "C:\\#{sysdir[0]}\\system32\\attrib.exe -r -h -s " + delete_me_too # winnt ?
 		client.sys.process.execute(cmd, nil, {'Hidden' => true })
 
-		print_status("Deleting #{delete_me_too} ...")
+		print_debug("Deleting #{delete_me_too} ...")
 		begin
 			client.fs.file.rm(delete_me_too)
 		rescue ::Exception => e

--- a/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
+++ b/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
@@ -146,14 +146,14 @@ class Metasploit3 < Msf::Exploit::Remote
 		cli.core.use("stdapi") if not cli.ext.aliases.include?("stdapi")
 
 		begin
-			print_status("Deleting #{@php_fname}")
+			print_debug("Deleting #{@php_fname}")
 			cli.fs.file.rm(@php_fname)
 		rescue ::Exception => e
 			print_error("Please note: #{@php_fname} is stil on disk.")
 		end
 
 		begin
-			print_status("Deleting #{@exe_fname}")
+			print_debug("Deleting #{@exe_fname}")
 			cli.fs.file.rm(@exe_fname)
 		rescue ::Exception => e
 			print_error("Please note: #{@exe_fname} is still on disk.")


### PR DESCRIPTION
When an exploit is doing something to the victim's file system after a session is created, we should use print_debug() instead of print_status() in order to make the warning more obvious.
