### PR TITLE
Add print_warning()

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -80,6 +80,12 @@ module Exploit::Remote::HttpServer
 	def print_debug(msg='')
 		(cli) ? super("#{cli.peerhost.ljust(16)} #{self.shortname} - #{msg}") : super
 	end
+	#
+	# :category: print_* overrides
+	# Prepends client and module name if inside a thread with a #cli
+	def print_warning(msg='')
+		(cli) ? super("#{cli.peerhost.ljust(16)} #{self.shortname} - #{msg}") : super
+	end
 
 	# :category: print_* overrides
 	# Prepends client and module name if inside a thread with a #cli
@@ -99,6 +105,11 @@ module Exploit::Remote::HttpServer
 	# :category: print_* overrides
 	# Prepends client and module name if inside a thread with a #cli
 	def vprint_debug(msg='')
+		(cli) ? super("#{cli.peerhost.ljust(16)} #{self.shortname} - #{msg}") : super
+	end
+	# :category: print_* overrides
+	# Prepends client and module name if inside a thread with a #cli
+	def vprint_warning(msg='')
 		(cli) ? super("#{cli.peerhost.ljust(16)} #{self.shortname} - #{msg}") : super
 	end
 

--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -208,6 +208,10 @@ class Module
 		super(print_prefix + msg)
 	end
 
+	def print_warning(msg='')
+		super(print_prefix + msg)
+	end
+
 
 	#
 	# Overwrite the Subscriber print_line to do custom prefixes
@@ -240,6 +244,10 @@ class Module
 	# Verbose version of #print_debug
 	def vprint_debug(msg)
 		print_debug(msg) if datastore['VERBOSE'] || framework.datastore['VERBOSE']
+	end
+	# Verbose version of #print_warning
+	def vprint_warning(msg)
+		print_warning(msg) if datastore['VERBOSE'] || framework.datastore['VERBOSE']
 	end
 
 	#

--- a/lib/msf/core/plugin.rb
+++ b/lib/msf/core/plugin.rb
@@ -141,6 +141,14 @@ class Plugin
 	end
 
 	#
+	# Prints a warning
+	#
+	def print_warning(msg='')
+		output.print_warning(msg) if (output)
+	end
+
+
+	#
 	# Prints a message with no decoration.
 	#
 	def print(msg='')

--- a/lib/rex/io/bidirectional_pipe.rb
+++ b/lib/rex/io/bidirectional_pipe.rb
@@ -98,6 +98,10 @@ class BidirectionalPipe < Rex::Ui::Text::Input
 		print_line('[*] ' + msg)
 	end
 
+	def print_warning(msg='')
+		print_warning('[!] ' + msg)
+	end
+
 	#
 	# Wrappers for the pipe_input methods
 	#

--- a/lib/rex/script/base.rb
+++ b/lib/rex/script/base.rb
@@ -9,6 +9,7 @@ class Base
 		def print_status(msg); end
 		def print_good(msg); end
 		def print_error(msg); end
+		def print_warning(msg); end
 	end
 
 	attr_accessor :client, :framework, :path, :error, :args

--- a/lib/rex/ui/output.rb
+++ b/lib/rex/ui/output.rb
@@ -46,6 +46,12 @@ class Output
 	end
 
 	#
+	# Prints a warning
+	#
+	def print_warning(msg='')
+	end
+
+	#
 	# Prints a message with no decoration.
 	#
 	def print(msg='')

--- a/lib/rex/ui/subscriber.rb
+++ b/lib/rex/ui/subscriber.rb
@@ -67,6 +67,16 @@ module Subscriber
 		end
 
 		#
+		# Wraps user_output.print_warning
+		#
+		def print_warning(msg='')
+			if (user_output)
+				print_blank_line if user_output.prompting?
+				user_output.print_warning(msg)
+			end
+		end
+
+		#
 		# Wraps user_output.print
 		#
 		def print(msg='')

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -82,6 +82,13 @@ module DispatcherShell
 		end
 
 		#
+		# Wraps shell.print_warning
+		#
+		def print_warning(msg = '')
+			shell.print_warning(msg)
+		end
+
+		#
 		# Wraps shell.print
 		#
 		def print(msg = '')

--- a/lib/rex/ui/text/output.rb
+++ b/lib/rex/ui/text/output.rb
@@ -67,6 +67,10 @@ class Output < Rex::Ui::Output
 		print(msg + "\n")
 	end
 
+	def print_warning(msg = '')
+		print_line("%bld%yel[!]%clr #{msg}")
+	end
+
 	def print(msg = '')
 		print_raw(substitute_colors(msg))
 	end

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -304,6 +304,16 @@ module Shell
 	end
 
 	#
+	# Prints a warning message to the output handle.
+	#
+	def print_warning(msg='')
+		return if (disable_output == true)
+
+		self.on_print_proc.call(msg) if self.on_print_proc
+		log_output(output.print_warning(msg))
+	end
+
+	#
 	# Prints a raw message to the output handle.
 	#
 	def print(msg='')


### PR DESCRIPTION
So we've been kind of using print_debug() as warning messages... we should have a real print_warning().

Related to pull request #891

Test case:
http://pastebin.com/B7swyJPv
