### PR TITLE
added multiple payload and stage encoding in msfconsole

### DIFF
--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -67,9 +67,25 @@ class EncodedPayload
 			# Generate the raw version of the payload first
 			generate_raw() if self.raw.nil?
 
-			# Encode the payload
-			encode()
 
+			if self.reqs["StageEncoders"]
+				encodersList=self.reqs["StageEncoders"].split(',')
+				for i in encodersList
+					reqs['Encoder']=i
+					encode()
+					self.raw=self.encoded
+				end
+			elsif self.pinst.datastore["EncodersList"]
+				encodersList=self.pinst.datastore["EncodersList"].split(',')
+				for i in encodersList
+					reqs['Encoder']=i
+					encode()
+					self.raw=self.encoded
+				end
+			else
+			# Encode the payload
+				encode()
+			end
 			# Build the NOP sled
 			generate_sled()
 

--- a/lib/msf/core/payload/stager.rb
+++ b/lib/msf/core/payload/stager.rb
@@ -76,7 +76,7 @@ module Msf::Payload::Stager
 		substitute_vars(p, stage_offsets) if (stage_offsets)
 
 		# Encode the stage of stage encoding is enabled
-		#p = encode_stage(p)
+		p = encode_stage(p)
 
 		return p
 	end
@@ -147,20 +147,23 @@ module Msf::Payload::Stager
 	# Encodes the stage prior to transmission
 	def encode_stage(stg)
 
-		# If DisableStageEncoding is set, we do not encode the stage
-		return stg if datastore['DisableStageEncoding'] =~ /^(y|1|t)/i
+		if datastore['StageEncodersList']
+			print_status("Encoding stage...")
 
-		# Generate an encoded version of the stage.  We tell the encoding system
-		# to save edi to ensure that it does not get clobbered.
-		encp = Msf::EncodedPayload.create(
-			self,
-			'Raw'           => stg,
-			'SaveRegisters' => ['edi'],
-			'ForceEncode'   => true)
+			# Generate an encoded version of the stage.  We tell the encoding system
+			# to save edi to ensure that it does not get clobbered.
+			encp = Msf::EncodedPayload.create(
+				self,
+				'Raw'           => stg,
+				'StageEncoders'	=> datastore['StageEncodersList'],
+				'SaveRegisters' => ['edi'],
+				'ForceEncode'   => true)	
+			print_status("Stage successfully encoded")
+			return encp.encoded
+			else
+				return stg
+			end
 
-		# If the encoding succeeded, use the encoded buffer.  Otherwise, fall
-		# back to using the non-encoded stage
-		encp.encoded || stg
 	end
 
 	# Aliases


### PR DESCRIPTION
set EncodersList x86/shikata_ga_nai,x86/alpha_upper
will encode the payload directly in msfconsole with shikata_ga_nai then alpha_upper.

metsvc.dll can be detected by IDS.
With StageEncodersList variable, you can add a list of custom encoder to your stage.
(Just tested with meterpreter)
Warning, encode the dll with shikata_ga_nai can take a very long time (almost 4 min)
set StageEncodersList x86/custom_encoder,x86/custom_encoder2
