### PR TITLE
Check STATUS_ACCESS_DENIED properly

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -101,7 +101,8 @@ class Metasploit3 < Msf::Auxiliary
 
 		begin
 			smb_login()
-		rescue ::Rex::Proto::SMB::Exceptions::LoginError => e
+		rescue ::Rex::Proto::SMB::Exceptions::LoginError
+		rescue ::Rex::Proto::SMB::Exceptions::ErrorCode
 		end
 
 		begin
@@ -135,7 +136,8 @@ class Metasploit3 < Msf::Auxiliary
 
 		begin
 			smb_login()
-		rescue ::Rex::Proto::SMB::Exceptions::LoginError => e
+		rescue ::Rex::Proto::SMB::Exceptions::LoginError
+		rescue ::Rex::Proto::SMB::Exceptions::ErrorCode
 		end
 
 		disconnect()
@@ -155,6 +157,7 @@ class Metasploit3 < Msf::Auxiliary
 		begin
 			smb_login()
 		rescue ::Rex::Proto::SMB::Exceptions::LoginError => e
+		rescue ::Rex::Proto::SMB::Exceptions::ErrorCode
 		end
 		disconnect()
 		datastore['SMBDomain'] = orig_domain

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -156,7 +156,7 @@ class Metasploit3 < Msf::Auxiliary
 		connect()
 		begin
 			smb_login()
-		rescue ::Rex::Proto::SMB::Exceptions::LoginError => e
+		rescue ::Rex::Proto::SMB::Exceptions::LoginError
 		rescue ::Rex::Proto::SMB::Exceptions::ErrorCode
 		end
 		disconnect()


### PR DESCRIPTION
When Samba throws STATUS_ACCESS_DENIED, the exception that's throwin is actually Rex::Proto::SMB::Exception::ErrorCode, not as LoginError.  It was handled correctly in try_user_pass(), but not in other functions that also use smb_login().
