### PR TITLE
Related to #885 , allow Prepend* for osx/x86/exec payload

### DIFF
--- a/modules/payloads/singles/osx/x86/exec.rb
+++ b/modules/payloads/singles/osx/x86/exec.rb
@@ -24,6 +24,7 @@ require 'msf/core'
 module Metasploit3
 
 	include Msf::Payload::Single
+	include Msf::Payload::Osx
 
 	def initialize(info = {})
 		super(merge_info(info,
@@ -45,7 +46,7 @@ module Metasploit3
 	#
 	# Dynamically builds the exec payload based on the user's options.
 	#
-	def generate
+	def generate_stage
 		cmd     = datastore['CMD'] || ''
 		len     = cmd.length + 1
 		payload =


### PR DESCRIPTION
Spotted while reviewing #885. These changes allow to use the Prepend\* options in the osx/x86/exec payload.

Before this the module was defining his own "generate" method and not including the osx mixin. I think it's useful  to allow prepending in the exec payload (only for testing it's super useful I think).

Asking for review from more experienced developers.

Proof of working:

<pre>
Juans-MacBook-Pro:metasploit-framework juan$ ./msfpayload osx/x86/exec CMD=/bin/bash PrependSetgid=true X > osx_x86.elfCreated by msfpayload (http://www.metasploit.com).
Payload: osx/x86/exec
 Length: 47
Options: {"CMD"=>"/bin/bash", "PrependSetgid"=>"true"}

sh-3.2# chown root osx_x86.elf
sh-3.2# chown :wheel osx_x86.elf
sh-3.2# chmod +s osx_x86.elf 
sh-3.2# ls -la osx_x86.elf 
-rwsr-sr-x  1 root  wheel  20800 Oct 16 16:44 osx_x86.elf

Juans-MacBook-Pro:metasploit-framework juan$ ./osx_x86.elf 
bash-3.2$ id -g
0
bash-3.2$ id -gr
0
</pre>
