### PR TITLE
mozilla_mchannel vprint_error to print_error

### DIFF
--- a/modules/exploits/windows/browser/mozilla_mchannel.rb
+++ b/modules/exploits/windows/browser/mozilla_mchannel.rb
@@ -128,7 +128,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# check for non vulnerable targets
 		if agent !~ /NT 5\.1/ or agent !~ /NT 6\.1/ and agent !~ /Firefox\/3\.6\.16/
-			vprint_error("Target not supported: #{agent}")
+			print_error("Target not supported: #{agent}")
 			send_not_found(cli)
 			return
 		end


### PR DESCRIPTION
Changed vprint_error to print_error in the check for non-vulnerable agents
