### PR TITLE
 SMB Client find_first errors on dirs with exactly 20 files

### DIFF
--- a/lib/rex/proto/smb/client.rb
+++ b/lib/rex/proto/smb/client.rb
@@ -1894,11 +1894,11 @@ NTLM_UTILS = Rex::Proto::NTLM::Utils
 				last_search_id = sid
 				last_offset = loff
 				last_filename = name
-				if eos != 1 #If we aren't at the end of the search, run find_next
+				if eos == 0 and last_offset != 0 #If we aren't at the end of the search, run find_next
 					resp = find_next(last_search_id, last_offset, last_filename)
 					search_next = 1 # Flip bit so response params will parse correctly
 				end
-			end until eos == 1
+			end until eos != 0 or last_offset == 0 
 		rescue ::Exception
 			raise $!
 		end


### PR DESCRIPTION
Using smb.client.find_first against a directory containing 20 files (including . and ..) will cause a SMB Error: STATUS_INVALID_HANDLE 

http://pastie.org/5075263

This occurs against Windows hosts. 

The bug occurs as we request 20 results from the server, and for some reason, windows tells us we can continue searching. When calling find_next it is succesful (no results are returned), it tells us we can continue searching, but gives us no offset to search from. We perform a second find_next but this results in an error.

As per MS specification:

http://msdn.microsoft.com/en-us/library/ee441704(prot.20).aspx

If EndOfSearch = 0 we can continue searching, but if LastNameOffset is 0 the server cannot resume the search. In this case both values are 0 which seems like MS isn't sticking to the spec properly..?

I have therefore added a check for LastNameOffset as well as EndOfSearch.

I have also adjusted the loop logic slightly to check for 0 rather than != 1 as this is more inline with the specification.

Fix in action:

http://pastie.org/5075338

Related pull: #627
