### PR TITLE
Add prepend_migrate? to retreive the status of PrependMigrate

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -1242,6 +1242,13 @@ class Exploit < Msf::Module
 		not datastore['DisablePayloadHandler']
 	end
 
+	#
+	# Check if PrependMigrate is used
+	#
+	def prepend_migrate?
+		datastore['PrependMigrate']
+	end
+
 	##
 	#
 	# Handler interaction


### PR DESCRIPTION
After discussing with egypt and Tod for the 3rd time about pull request 917 ("Add migrate stub option to Windows x86 payloads"), this is the approach we've decided to take:

```
'DefaultOptions'  => { 'PrependMigrate' => true },
```

And then in exploit():

```
if !prepend_migrate?
    print_error("PrependMigrate should not be turned off")
    return
end
```

deregister_options() is no longer recommended, because if we use that, datastore['PrependMigrate'] will always be false.
