### PR TITLE
Windows Post Module - Insecure Path Enumeration

### DIFF
--- a/modules/post/windows/escalate/insecure_path.rb
+++ b/modules/post/windows/escalate/insecure_path.rb
@@ -1,0 +1,87 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'rex'
+
+class Metasploit3 < Msf::Post
+
+	include Msf::Post::File
+	include Msf::Post::Windows::Priv
+	include Msf::Post::Windows::Registry
+
+	def initialize(info={})
+		super( update_info( info,
+			'Name'          => 'Current User Insecure Path Enumeration',
+			'Description'   => %q{
+				This module checks every directory in the system PATH for write permissions.
+				This can be used to help escalate privileges through the process of binary planting
+				due to the way DLLs are loaded within windows.
+			},
+			'License'       => MSF_LICENSE,
+			'Author'        => [ 'Ben Campbell <eat_meatballs[at]hotmail.co.uk>' ],
+			'Version'       => '$Revision$',
+			'Platform'      => [ 'windows' ],
+			'SessionTypes'  => [ 'meterpreter' ],
+			'References'    => [
+				[ 'URL', 'http://www.binaryplanting.com' ]
+			]
+		))
+
+			register_options([
+				OptBool.new("VERBOSE",   [ false, "Verbose", false])
+			])
+	end
+
+	def run
+		if is_uac_enabled?
+			# write_file and file_exist? will return true as windows
+			# returns a handle for files even though UAC popup is pending.
+			print_error("Unable to process with UAC enabled.")
+			return
+		end
+
+		if is_admin?
+			print_error("Current user is an admin, aborting.")
+			return
+		end
+
+		if is_system?
+			print_error("Current user is SYSTEM, aborting.")
+			return
+		end
+
+		print_status("Checking SYSTEM PATH folders for write access...")
+		result  = registry_getvaldata('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment', 'Path')
+		paths = result.split(';')
+
+		paths.each do |p|
+			path = expand_path(p)
+			if exist?(path)
+				filename = "#{path}\\#{Rex::Text.rand_text_alpha(10)}"
+				vprint_status("Creating file #{filename}")
+				begin
+					if write_file(filename, "") and file_exist?(filename) # This will not work against UAC
+						print_good("Write permissions in #{path}")
+						begin
+								file_rm(filename)
+								vprint_status("Deleted file #{filename}")
+						rescue ::Exception => e
+							print_error("Error deleting #{filename} : #{e}") # Warn users if cleanup fails
+						end
+					end
+				rescue ::Exception => e
+					vprint_status("Unable to create #{filename} : #{e}")
+				end
+			else
+				# User may be able to create the path!
+				# exist? appears to have some false positives
+				print_good("Path #{path} does not exist...")
+			end
+		end
+	end
+end

--- a/modules/post/windows/escalate/insecure_path.rb
+++ b/modules/post/windows/escalate/insecure_path.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Post
 			'Description'   => %q{
 				This module checks every directory in the system PATH for write permissions.
 				This can be used to help escalate privileges through the process of binary planting
-				due to the way DLLs are loaded within windows.
+				due to the way DLLs are loaded within Windows.
 			},
 			'License'       => MSF_LICENSE,
 			'Author'        => [ 'Ben Campbell <eat_meatballs[at]hotmail.co.uk>' ],
@@ -31,10 +31,6 @@ class Metasploit3 < Msf::Post
 				[ 'URL', 'http://www.binaryplanting.com' ]
 			]
 		))
-
-			register_options([
-				OptBool.new("VERBOSE",   [ false, "Verbose", false])
-			])
 	end
 
 	def run
@@ -57,6 +53,12 @@ class Metasploit3 < Msf::Post
 
 		print_status("Checking SYSTEM PATH folders for write access...")
 		result  = registry_getvaldata('HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment', 'Path')
+		
+		if result.nil?
+			print_error("Unable to retrieve path from registry, aborting...")
+			return
+		end
+		
 		paths = result.split(';')
 
 		paths.each do |p|


### PR DESCRIPTION
Checks folders in the system PATH environment variable for current user write access.

This module is an aid to help discover binary planting/dll hijacking issues on a host in an attempt to escalate privileges. The path environment variable is the last thing searched for by the LoadLibrary functions to find DLLs. It may contain user writable directories from insecure installations of third party applications.

This module does not work if UAC is enabled: file_exists? and write_file give false positives when the user has a popup and return true. Even using railgun with CreateFileA returns a handle so I suspect this is due to how Windows handles file creation. The only dirty way to get around this seemed to be to call a shell command like type and check the response for an error...

Windows PrivEsc Example: https://www.htbridge.com/advisory/HTB23108

I have attempted to do a local exploit for the above which builds on this module but could not get it to successfully load the DLL (it does inspect the dll but moves on):

https://github.com/Meatballs1/metasploit-framework/blob/local_win_priv_keyring/modules/exploits/windows/local/ipsec_keyring_service.rb

If anyone can work out why please feel free to grab code or poke me to finish it! Nb the POC  from HTBridge didn't work either - work but it did have LoadImage called on it by the service - metasploit generated DLLs didn't... 
