### PR TITLE
Make use of print_warning

### DIFF
--- a/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
+++ b/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
@@ -136,8 +136,8 @@ class Metasploit3 < Msf::Auxiliary
 		sunrpc_destroy
 
 	rescue ::Rex::Proto::SunRPC::RPCTimeout
-		print_status 'Warning: ' + $!
-		print_status 'Exploit may or may not have succeeded.'
+		print_warning 'Warning: ' + $!
+		print_warning 'Exploit may or may not have succeeded.'
 	end
 
 

--- a/modules/auxiliary/scanner/discovery/arp_sweep.rb
+++ b/modules/auxiliary/scanner/discovery/arp_sweep.rb
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		@netifaces = true
 		if not netifaces_implemented?
-			print_error("WARNING : Pcaprub is not uptodate, some functionality will not be available")
+			print_warning("WARNING : Pcaprub is not uptodate, some functionality will not be available")
 			@netifaces = false
 		end
 

--- a/modules/auxiliary/scanner/discovery/ipv6_multicast_ping.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_multicast_ping.rb
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		@netifaces = true
 		if not netifaces_implemented?
-			print_error("WARNING : Pcaprub is not uptodate, some functionality will not be available")
+			print_warning("WARNING : Pcaprub is not uptodate, some functionality will not be available")
 			@netifaces = false
 		end
 

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		@netifaces = true
 		if not netifaces_implemented?
-			print_error("WARNING : Pcaprub is not uptodate, some functionality will not be available")
+			print_warning("WARNING : Pcaprub is not uptodate, some functionality will not be available")
 			@netifaces = false
 		end
 

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
@@ -154,7 +154,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		@netifaces = true
 		if not netifaces_implemented?
-			print_error("WARNING : Pcaprub is not uptodate, some functionality will not be available")
+			print_warning("WARNING : Pcaprub is not uptodate, some functionality will not be available")
 			@netifaces = false
 		end
 

--- a/modules/auxiliary/scanner/http/ssl.rb
+++ b/modules/auxiliary/scanner/http/ssl.rb
@@ -69,7 +69,7 @@ class Metasploit4 < Msf::Auxiliary
 				alg = cert.signature_algorithm
 
 				if alg.downcase.include? "md5"
-					print_status("#{ip}:#{rport} WARNING: Signature algorithm using MD5 (#{alg})")
+					print_warning("#{ip}:#{rport} WARNING: Signature algorithm using MD5 (#{alg})")
 				end
 
 				vhostn = nil

--- a/modules/auxiliary/spoof/arp/arp_poisoning.rb
+++ b/modules/auxiliary/spoof/arp/arp_poisoning.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Auxiliary
 		open_pcap({'SNAPLEN' => 68, 'FILTER' => "arp[6:2] == 0x0002"})
 		@netifaces = true
 		if not netifaces_implemented?
-			print_error("WARNING : Pcaprub is not uptodate, some functionality will not be available")
+			print_warning("WARNING : Pcaprub is not uptodate, some functionality will not be available")
 			@netifaces = false
 		end
 		@spoofing = false

--- a/modules/auxiliary/spoof/dns/bailiwicked_domain.rb
+++ b/modules/auxiliary/spoof/dns/bailiwicked_domain.rb
@@ -144,7 +144,7 @@ class Metasploit3 < Msf::Auxiliary
 		end
 
 		if(reps < 30)
-			print_status("WARNING: This server did not reply to all of our requests")
+			print_warning("WARNING: This server did not reply to all of our requests")
 		end
 
 		if(random)
@@ -198,7 +198,7 @@ class Metasploit3 < Msf::Auxiliary
 
 						print_status("Switching to target port #{sport} based on Metasploit service")
 						if target != t_addr
-							print_status("Warning: target address #{target} is not the same as the nameserver's query source address #{t_addr}!")
+							print_warning("Warning: target address #{target} is not the same as the nameserver's query source address #{t_addr}!")
 						end
 					end
 				end

--- a/modules/auxiliary/spoof/dns/bailiwicked_host.rb
+++ b/modules/auxiliary/spoof/dns/bailiwicked_host.rb
@@ -134,7 +134,7 @@ class Metasploit3 < Msf::Auxiliary
 		end
 
 		if(reps < 30)
-			print_status("WARNING: This server did not reply to all of our requests")
+			print_warning("WARNING: This server did not reply to all of our requests")
 		end
 
 		if(random)
@@ -190,7 +190,7 @@ class Metasploit3 < Msf::Auxiliary
 
 						print_status("Switching to target port #{sport} based on Metasploit service")
 						if target != t_addr
-							print_status("Warning: target address #{target} is not the same as the nameserver's query source address #{t_addr}!")
+							print_warning("Warning: target address #{target} is not the same as the nameserver's query source address #{t_addr}!")
 						end
 					end
 				end

--- a/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
@@ -70,6 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def on_new_session(client)
+		print_warning("Removing temp.php")
 		if client.type == "meterpreter"
 			client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
 			client.fs.file.rm("temp.php")

--- a/modules/exploits/linux/http/webid_converter.rb
+++ b/modules/exploits/linux/http/webid_converter.rb
@@ -104,19 +104,19 @@ class Metasploit3 < Msf::Exploit::Remote
 		currencies_php = currencies_php.gsub(/^\t\t\t/, '')
 
 		pwd = client.fs.dir.pwd
-		print_status("#{peer} - Searching currencies.php file from #{pwd}")
+		print_warning("#{peer} - Searching currencies.php file from #{pwd}")
 
 		res = client.fs.file.search(nil, "currencies.php", true, -1)
 		res.each do |hit|
 			filename = "#{hit['path']}/#{hit['name']}"
-			print_status("#{peer} - Restoring #{filename}")
+			print_warning("#{peer} - Restoring #{filename}")
 			client.fs.file.rm(filename)
 			fd = client.fs.file.new(filename, "wb")
 			fd.write(currencies_php)
 			fd.close
 		end
 
-		print_status("#{peer} - Cleanup finished")
+		print_good("#{peer} - Cleanup finished")
 
 	end
 

--- a/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
+++ b/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
@@ -70,6 +70,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def on_new_session(client)
+		print_warning("Removing #{@var_hexfile}.txt and #{@jsp_name}.jsp")
+
 		if client.type == "meterpreter"
 			client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
 			client.fs.file.rm("../#{@var_hexfile}.txt")

--- a/modules/exploits/multi/http/jboss_bshdeployer.rb
+++ b/modules/exploits/multi/http/jboss_bshdeployer.rb
@@ -222,10 +222,10 @@ EOT
 		print_status("Undeploying #{uri} by deleting the WAR file via BSHDeployer...")
 		res = invoke_bshscript(delete_script, @pkg)
 		if !res
-			print_error("WARNING: Unable to remove WAR [No Response]")
+			print_warning("WARNING: Unable to remove WAR [No Response]")
 		end
 		if (res.code < 200 || res.code >= 300)
-			print_error("WARNING: Unable to remove WAR [#{res.code} #{res.message}]")
+			print_warning("WARNING: Unable to remove WAR [#{res.code} #{res.message}]")
 		end
 
 		handler
@@ -307,7 +307,7 @@ EOT
 		if (res.code < 200 || res.code >= 300)
 			case res.code
 				when 401
-					print_error("Warning: The web site asked for authentication: #{res.headers['WWW-Authenticate'] || res.headers['Authentication']}")
+					print_warning("Warning: The web site asked for authentication: #{res.headers['WWW-Authenticate'] || res.headers['Authentication']}")
 					fail_with(Exploit::Failure::NoAccess, "Authentication requested: #{res.headers['WWW-Authenticate'] || res.headers['Authentication']}")
 				end
 

--- a/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
+++ b/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
@@ -248,9 +248,9 @@ EOT
 			delete_res << delete_file('./', Rex::Text.uri_encode(app_base) + '.war', '')
 			delete_res.each do |res|
 				if !res
-					print_error("WARNING: Unable to remove WAR [No Response]")
+					print_warning("WARNING: Unable to remove WAR [No Response]")
 				elsif (res.code < 200 || res.code >= 300)
-					print_error("WARNING: Unable to remove WAR [#{res.code} #{res.message}]")
+					print_warning("WARNING: Unable to remove WAR [#{res.code} #{res.message}]")
 				end
 			end
 

--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -211,7 +211,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		if (res.code < 200 or res.code >= 300)
 			case res.code
 			when 401
-				print_error("Warning: The web site asked for authentication: #{res.headers['WWW-Authenticate'] || res.headers['Authentication']}")
+				print_warning("Warning: The web site asked for authentication: #{res.headers['WWW-Authenticate'] || res.headers['Authentication']}")
 			end
 			fail_with(Exploit::Failure::Unknown, "Upload to deploy WAR archive [#{res.code} #{res.message}]")
 		end
@@ -291,12 +291,12 @@ class Metasploit3 < Msf::Exploit::Remote
 				}
 		}, 30)
 		if (! res)
-			print_error("WARNING: Undeployment failed on #{app_base} [No Response]")
+			print_warning("WARNING: Undeployment failed on #{app_base} [No Response]")
 		elsif (res.code == 500 and datastore['VERB'] == 'POST')
 			# POST requests result in a http 500 error, but the payload is removed..."
-			print_status("WARNING: Undeployment might have failed (unlikely)")
+			print_warning("WARNING: Undeployment might have failed (unlikely)")
 		elsif (res.code < 200 or res.code >= 300)
-			print_error("WARNING: Undeployment failed on #{app_base} [#{res.code} #{res.message}]")
+			print_warning("WARNING: Undeployment failed on #{app_base} [#{res.code} #{res.message}]")
 		end
 
 		handler

--- a/modules/exploits/multi/http/openfire_auth_bypass.rb
+++ b/modules/exploits/multi/http/openfire_auth_bypass.rb
@@ -195,7 +195,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		})
 
 
-		print_error("Warning: got no response from the upload, continuing...") if !res
+		print_warning("Warning: got no response from the upload, continuing...") if !res
 
 		# Delete the uploaded JAR file
 		if datastore['REMOVE_PLUGIN']

--- a/modules/exploits/multi/http/qdpm_upload_exec.rb
+++ b/modules/exploits/multi/http/qdpm_upload_exec.rb
@@ -94,7 +94,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		@clean_files.each do |f|
-			print_status("#{@peer} - Removing: #{f}")
+			print_warning("#{@peer} - Removing: #{f}")
 			begin
 				if cli.type == 'meterpreter'
 					cli.fs.file.rm(f)

--- a/modules/exploits/multi/http/struts_code_exec.rb
+++ b/modules/exploits/multi/http/struts_code_exec.rb
@@ -130,11 +130,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_new_session(client)
 		if target['Platform'] == 'linux'
-			print_status("Deleting #{@payload_exe} payload file")
+			print_warning("Deleting #{@payload_exe} payload file")
 			execute_command("/bin/sh@-c@rm #{@payload_exe}")
 		else
-			print_status("Windows does not allow running executables to be deleted")
-			print_status("Delete the #{@payload_exe} file manually after migrating")
+			print_warning("Windows does not allow running executables to be deleted")
+			print_warning("Delete the #{@payload_exe} file manually after migrating")
 		end
 	end
 

--- a/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
+++ b/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
@@ -177,12 +177,12 @@ class Metasploit3 < Msf::Exploit::Remote
 		client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
 
 		if client.sys.config.sysinfo["OS"] =~ /Windows/
-			print_error("Windows does not allow running executables to be deleted")
-			print_error("The #{@payload_exe} file must be removed manually after migrating")
+			print_warning("Windows does not allow running executables to be deleted")
+			print_warning("The #{@payload_exe} file must be removed manually after migrating")
 			return
 		end
 
-		print_status("Deleting the #{@payload_exe} file")
+		print_warning("Deleting the #{@payload_exe} file")
 		client.fs.file.rm(@payload_exe)
 
 	end

--- a/modules/exploits/multi/http/testlink_upload_exec.rb
+++ b/modules/exploits/multi/http/testlink_upload_exec.rb
@@ -140,6 +140,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def on_new_session(client)
+		print_warning("Removing #{@token}.php")
 		if client.type == "meterpreter"
 			client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
 			client.fs.file.rm("#{@token}.php")

--- a/modules/exploits/multi/http/tomcat_mgr_deploy.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_deploy.rb
@@ -217,7 +217,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		if (res.code < 200 or res.code >= 300)
 			case res.code
 			when 401
-				print_error("Warning: The web site asked for authentication: #{res.headers['WWW-Authenticate'] || res.headers['Authentication']}")
+				print_warning("Warning: The web site asked for authentication: #{res.headers['WWW-Authenticate'] || res.headers['Authentication']}")
 			end
 			fail_with(Exploit::Failure::Unknown, "Upload failed on #{path_tmp} [#{res.code} #{res.message}]")
 		end
@@ -259,7 +259,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'method'       => 'GET'
 		}, 20)
 		if (! res)
-			print_error("WARNING: Undeployment failed on #{path} [No Response]")
+			print_warning("WARNING: Undeployment failed on #{path} [No Response]")
 		elsif (res.code < 200 or res.code >= 300)
 			print_error("Deletion failed on #{path} [#{res.code} #{res.message}]")
 		end

--- a/modules/exploits/multi/http/webpagetest_upload_exec.rb
+++ b/modules/exploits/multi/http/webpagetest_upload_exec.rb
@@ -81,7 +81,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 		cli.core.use("stdapi") if not cli.ext.aliases.include?("stdapi")
 		cli.fs.file.rm(@target_path)
-		print_status("#{@target_path} removed")
+		print_good("#{@target_path} removed")
 	end
 
 

--- a/modules/exploits/osx/browser/safari_file_policy.rb
+++ b/modules/exploits/osx/browser/safari_file_policy.rb
@@ -274,6 +274,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		path = datastore['URIPATH'] || rand_text_alphanumeric(8+rand(8))
 		path = '/' + path if path !~ /^\//
 		datastore['URIPATH'] = path
+		print_warning("URIPATH modified: #{datastore['URIPATH']}")
 		return path
 	end
 

--- a/modules/exploits/solaris/sunrpc/ypupdated_exec.rb
+++ b/modules/exploits/solaris/sunrpc/ypupdated_exec.rb
@@ -85,7 +85,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		print_status('No Errors, appears to have succeeded!')
 	rescue ::Rex::Proto::SunRPC::RPCTimeout
-		print_error('Warning: ' + $!)
+		print_warning('Warning: ' + $!)
 	end
 
 end

--- a/modules/exploits/unix/webapp/openx_banner_edit.rb
+++ b/modules/exploits/unix/webapp/openx_banner_edit.rb
@@ -157,7 +157,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Delete the banner :)
 		if (not openx_banner_delete(uri_base, cookie, adv_id, camp_id, ban_id))
-			print_error("WARNING: Unable to automatically delete the banner :-/")
+			print_warning("WARNING: Unable to automatically delete the banner :-/")
 		else
 			print_status("Successfully deleted banner # #{ban_id}")
 		end

--- a/modules/exploits/unix/webapp/twiki_history.rb
+++ b/modules/exploits/unix/webapp/twiki_history.rb
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				'uri' => test_url
 			}, 25)
 		if (not res) or (res.code != 404)
-			print_error("WARNING: The test file exists already!")
+			print_warning("WARNING: The test file exists already!")
 			return Exploit::CheckCode::Safe
 		end
 
@@ -103,7 +103,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				'uri' => cmd_base + Rex::Text.uri_encode(rev)
 			}, 25)
 		if (not res) or (res.code != 200)
-			print_error("WARNING: unable to remove test file (#{test_file})")
+			print_warning("WARNING: unable to remove test file (#{test_file})")
 		end
 
 		return Exploit::CheckCode::Vulnerable

--- a/modules/exploits/unix/webapp/twiki_search.rb
+++ b/modules/exploits/unix/webapp/twiki_search.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				'uri' => test_url
 			}, 25)
 		if (not res) or (res.body.match(content))
-			print_error("WARNING: The test file exists already!")
+			print_warning("WARNING: The test file exists already!")
 			return Exploit::CheckCode::Safe
 		end
 
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				'uri' => cmd_base + Rex::Text.uri_encode(search)
 			}, 25)
 		if (not res) or (res.code != 200)
-			print_error("WARNING: unable to remove test file (#{test_file})")
+			print_warning("WARNING: unable to remove test file (#{test_file})")
 		end
 
 		return Exploit::CheckCode::Vulnerable

--- a/modules/exploits/unix/webapp/xoda_file_upload.rb
+++ b/modules/exploits/unix/webapp/xoda_file_upload.rb
@@ -74,6 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def on_new_session(client)
+		print_warning("Removing #{@payload_name}")
 		if client.type == "meterpreter"
 			client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
 			client.fs.file.rm(@payload_name)

--- a/modules/exploits/windows/browser/adobe_flash_otf_font.rb
+++ b/modules/exploits/windows/browser/adobe_flash_otf_font.rb
@@ -221,7 +221,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		datastore['URIPATH'] = datastore['URIPATH'] || random_uri
 		datastore['URIPATH'] = '/' + datastore['URIPATH'] if datastore['URIPATH'] !~ /^\//
 		datastore['URIPATH'] = datastore['URIPATH'][0,3] if datastore['URIPATH'].length > 3
-		print_debug("URIPATH set to #{datastore['URIPATH']}")
+		print_warning("URIPATH set to #{datastore['URIPATH']}")
 
 		super
 	end

--- a/modules/exploits/windows/browser/hp_easy_printer_care_xmlcachemgr.rb
+++ b/modules/exploits/windows/browser/hp_easy_printer_care_xmlcachemgr.rb
@@ -83,9 +83,9 @@ class Metasploit3 < Msf::Exploit::Remote
 		client.sys.process.execute(cmd, nil, {'Hidden' => true })
 
 		begin
-			print_status("Deleting the vbs payload \"#{@var_vbs_name}.vbs\" ...")
+			print_warning("Deleting the vbs payload \"#{@var_vbs_name}.vbs\" ...")
 			client.fs.file.rm("C:\\windows\\system32\\" + @var_vbs_name + ".vbs")
-			print_status("Deleting the mof file \"#{@var_mof_name}.mof\" ...")
+			print_warning("Deleting the mof file \"#{@var_mof_name}.mof\" ...")
 			client.fs.file.rm("C:\\windows\\system32\\wbem\\mof\\good\\" + @var_mof_name + ".mof")
 		rescue ::Exception => e
 			print_error("Exception: #{e.inspect}")

--- a/modules/exploits/windows/browser/keyhelp_launchtripane_exec.rb
+++ b/modules/exploits/windows/browser/keyhelp_launchtripane_exec.rb
@@ -86,7 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def on_new_session(client)
-		print_status("The exe payload (C:\\windows\\system32\\msfmsf.exe) and mof file (C:\\windows\\system32\\wbem\\mof\\good\\msfmsf.mof) must be removed manually.")
+		print_warning("The exe payload (C:\\windows\\system32\\msfmsf.exe) and mof file (C:\\windows\\system32\\wbem\\mof\\good\\msfmsf.mof) must be removed manually.")
 	end
 
 	def auto_target(cli, request)

--- a/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
+++ b/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
@@ -73,14 +73,14 @@ class Metasploit3 < Msf::Exploit::Remote
 		client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
 
 		begin
-			print_status("Deleting the vbs payload \"#{@stager_name}\" ...")
+			print_warning("Deleting the vbs payload \"#{@stager_name}\" ...")
 			client.fs.file.rm("#{@temp_folder}/#{@stager_name}")
 			print_good("The vbs stager has been deleted successfully")
-			print_status("The exe payload #{@temp_folder}/#{@payload_name}.exe must be removed manually")
+			print_warning("The exe payload #{@temp_folder}/#{@payload_name}.exe must be removed manually")
 		rescue ::Exception => e
 			print_error("Problems while the clenaup")
-			print_status("The vbs stager #{@temp_folder}/#{@stager_name} must be removed manually")
-			print_status("The exe payload #{@temp_folder}/#{@payload_name}.exe must be removed manually")
+			print_error("The vbs stager #{@temp_folder}/#{@stager_name} must be removed manually")
+			print_error("The exe payload #{@temp_folder}/#{@payload_name}.exe must be removed manually")
 			print_error("Exception: #{e.inspect}")
 			return
 		end

--- a/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
+++ b/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
@@ -154,7 +154,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		lines = []
 		launch_message.gsub(/.{1,80}(?:\s|\Z)/) { lines << $& }
 		if (lines.length > 2)
-			print_status("Warning: the LAUNCH_MESSAGE is more than 2 lines. It may not display correctly.")
+			print_warning("Warning: the LAUNCH_MESSAGE is more than 2 lines. It may not display correctly.")
 		end
 
 		output << "&"+

--- a/modules/exploits/windows/http/cyclope_ess_sqli.rb
+++ b/modules/exploits/windows/http/cyclope_ess_sqli.rb
@@ -89,21 +89,21 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_new_session(cli)
 		if cli.type != 'meterpreter'
-			print_error("Please remember to manually remove #{@exe_fname} and #{@php_fname}")
+			print_warning("Please remember to manually remove #{@exe_fname} and #{@php_fname}")
 			return
 		end
 
 		cli.core.use("stdapi") if not cli.ext.aliases.include?("stdapi")
 
 		begin
-			print_status("Deleting #{@php_fname}")
+			print_warning("Deleting #{@php_fname}")
 			cli.fs.file.rm(@php_fname)
 		rescue ::Exception => e
 			print_error("Please note: #{@php_fname} is stil on disk.")
 		end
 
 		begin
-			print_status("Deleting #{@exe_fname}")
+			print_warning("Deleting #{@exe_fname}")
 			cli.fs.file.rm(@exe_fname)
 		rescue ::Exception => e
 			print_error("Please note: #{@exe_fname} is still on disk.")

--- a/modules/exploits/windows/http/hp_nnm_ovbuildpath_textfile.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovbuildpath_textfile.rb
@@ -113,12 +113,12 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		# run hidden
-		print_status("Spawning #{cmd.split("\\").last} process to migrate to")
+		print_warning("Spawning #{cmd.split("\\").last} process to migrate to")
 		proc = client.sys.process.execute(cmd, nil, {'Hidden' => true })
 		target_pid = proc.pid
 
 		begin
-			print_good("Migrating to #{target_pid}")
+			print_warning("Migrating to #{target_pid}")
 			client.core.migrate(target_pid)
 			print_good("Successfully migrated to process #{target_pid}")
 		rescue ::Exception => e

--- a/modules/exploits/windows/http/oracle_btm_writetofile.rb
+++ b/modules/exploits/windows/http/oracle_btm_writetofile.rb
@@ -102,9 +102,9 @@ class Metasploit3 < Msf::Exploit::Remote
 		client.sys.process.execute(cmd, nil, {'Hidden' => true })
 
 		begin
-			print_status("Deleting the vbs payload \"#{@var_vbs_name}.vbs\" ...")
+			print_warning("Deleting the vbs payload \"#{@var_vbs_name}.vbs\" ...")
 			client.fs.file.rm("C:\\windows\\system32\\" + @var_vbs_name + ".vbs")
-			print_status("Deleting the mof file \"#{@var_mof_name}.mof\" ...")
+			print_warning("Deleting the mof file \"#{@var_mof_name}.mof\" ...")
 			client.fs.file.rm("C:\\windows\\system32\\wbem\\mof\\good\\" + @var_mof_name + ".mof")
 		rescue ::Exception => e
 			print_error("Exception: #{e.inspect}")

--- a/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
+++ b/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
@@ -95,9 +95,9 @@ class Metasploit3 < Msf::Exploit::Remote
 		begin
 			jsp = @outpath.gsub(/\//, "\\\\")
 			jsp = jsp.gsub(/"/, "")
-			vprint_status("#{rhost}:#{rport} - Deleting: #{jsp}")
+			print_warning("#{rhost}:#{rport} - Deleting: #{jsp}")
 			cli.fs.file.rm(jsp)
-			print_status("#{rhost}:#{rport} - #{@jsp_name + '.jsp'} deleted")
+			print_good("#{rhost}:#{rport} - #{@jsp_name + '.jsp'} deleted")
 		rescue ::Exception => e
 			print_error("Unable to delete #{@jsp_name + '.jsp'}: #{e.message}")
 		end

--- a/modules/exploits/windows/http/umbraco_upload_aspx.rb
+++ b/modules/exploits/windows/http/umbraco_upload_aspx.rb
@@ -71,7 +71,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		begin
 			aspx = @upload_random + '.aspx'
 
-			print_status("#{@peer} - Searching: #{aspx}")
+			print_warning("#{@peer} - Searching: #{aspx}")
 			files = cli.fs.file.search("\\", aspx)
 			if not files or files.empty?
 				print_error("Unable to find #{aspx}. Please manually remove it.")
@@ -79,10 +79,10 @@ class Metasploit3 < Msf::Exploit::Remote
 			end
 
 			files.each { |f|
-				print_status("#{@peer} - Deleting: #{f['path'] + "\\" + f['name']}")
+				print_warning("#{@peer} - Deleting: #{f['path'] + "\\" + f['name']}")
 				cli.fs.file.rm(f['path'] + "\\" + f['name'])
 			}
-			print_status("#{@peer} - #{aspx} deleted")
+			print_good("#{@peer} - #{aspx} deleted")
 		rescue ::Exception => e
 			print_error("Unable to delete #{aspx}: #{e.message}")
 		end

--- a/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
+++ b/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			print_error("Upload failed on #{path_tmp} [#{res.code} #{res.message}]")
 			case res.code
 			when 401
-				print_status("Warning: The web site asked for authentication: #{res.headers['WWW-Authenticate'] || res.headers['Authentication']}")
+				print_warning("Warning: The web site asked for authentication: #{res.headers['WWW-Authenticate'] || res.headers['Authentication']}")
 			end
 			return
 		end
@@ -101,9 +101,9 @@ class Metasploit3 < Msf::Exploit::Remote
 			print_error("Move failed on #{path_tmp} [#{res.code} #{res.message}]")
 			case res.code
 			when 401
-				print_status("Warning: The web site asked for authentication: #{res.headers['WWW-Authenticate'] || res.headers['Authentication']}")
+				print_warning("Warning: The web site asked for authentication: #{res.headers['WWW-Authenticate'] || res.headers['Authentication']}")
 			when 403
-				print_status("Warning: The web site may not allow 'Script Source Access', which is required to upload executable content.")
+				print_warning("Warning: The web site may not allow 'Script Source Access', which is required to upload executable content.")
 			end
 			return
 		end

--- a/modules/exploits/windows/iis/ms01_026_dbldecode.rb
+++ b/modules/exploits/windows/iis/ms01_026_dbldecode.rb
@@ -230,7 +230,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
 
 		# Delete the copied CMD.exe
-		print_status("Deleting copy of CMD.exe \"#{@exe_cmd_copy}\" ...")
+		print_warning("Deleting copy of CMD.exe \"#{@exe_cmd_copy}\" ...")
 		client.fs.file.rm(@exe_cmd_copy)
 
 		# Migrate so  that we can delete the payload exe
@@ -241,11 +241,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		delete_me_too = "C:\\inetpub\\scripts\\" + @exe_payload
 
-		print_status("Changing permissions on #{delete_me_too} ...")
+		print_warning("Changing permissions on #{delete_me_too} ...")
 		cmd = "C:\\#{@win_dir}\\system32\\attrib.exe -r -h -s " + delete_me_too
 		client.sys.process.execute(cmd, nil, {'Hidden' => true })
 
-		print_status("Deleting #{delete_me_too} ...")
+		print_warning("Deleting #{delete_me_too} ...")
 		begin
 			client.fs.file.rm(delete_me_too)
 		rescue ::Exception => e

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -373,11 +373,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		delete_me_too = "C:\\inetpub\\scripts\\" + @exe_payload # C:\ ?
 
-		print_status("Changing permissions on #{delete_me_too} ...")
+		print_warning("Changing permissions on #{delete_me_too} ...")
 		cmd = "C:\\#{sysdir[0]}\\system32\\attrib.exe -r -h -s " + delete_me_too # winnt ?
 		client.sys.process.execute(cmd, nil, {'Hidden' => true })
 
-		print_status("Deleting #{delete_me_too} ...")
+		print_warning("Deleting #{delete_me_too} ...")
 		begin
 			client.fs.file.rm(delete_me_too)
 		rescue ::Exception => e

--- a/modules/exploits/windows/local/current_user_psexec.rb
+++ b/modules/exploits/windows/local/current_user_psexec.rb
@@ -118,9 +118,9 @@ class Metasploit3 < Msf::Exploit::Local
 					print_status("#{server.ljust(16)} Deleting the service")
 					service_delete(name, server)
 				rescue
-					print_error("Exception running payload: #{$!.class} : #{$!}")
-					print_error("#{server.ljust(16)} WARNING: May have failed to clean up!")
-					print_error("#{server.ljust(16)} Try a command like: sc \\\\#{server}\\ delete #{name}")
+					print_warning("Exception running payload: #{$!.class} : #{$!}")
+					print_warning("#{server.ljust(16)} WARNING: May have failed to clean up!")
+					print_warning("#{server.ljust(16)} Try a command like: sc \\\\#{server}\\ delete #{name}")
 					next
 				end
 			end

--- a/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
+++ b/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
@@ -146,14 +146,14 @@ class Metasploit3 < Msf::Exploit::Remote
 		cli.core.use("stdapi") if not cli.ext.aliases.include?("stdapi")
 
 		begin
-			print_status("Deleting #{@php_fname}")
+			print_warning("Deleting #{@php_fname}")
 			cli.fs.file.rm(@php_fname)
 		rescue ::Exception => e
 			print_error("Please note: #{@php_fname} is stil on disk.")
 		end
 
 		begin
-			print_status("Deleting #{@exe_fname}")
+			print_warning("Deleting #{@exe_fname}")
 			cli.fs.file.rm(@exe_fname)
 		rescue ::Exception => e
 			print_error("Please note: #{@exe_fname} is still on disk.")

--- a/modules/exploits/windows/ssl/ms04_011_pct.rb
+++ b/modules/exploits/windows/ssl/ms04_011_pct.rb
@@ -148,7 +148,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			resp = sock.get_once
 
 			if (resp and resp !~ /^220/)
-				print_status("Warning: this server may not support STARTTLS")
+				print_warning("Warning: this server may not support STARTTLS")
 			end
 
 		end

--- a/modules/exploits/windows/wins/ms04_045_wins.rb
+++ b/modules/exploits/windows/wins/ms04_045_wins.rb
@@ -101,7 +101,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# this system, or something major happened to the heap that will probably
 		# prevent this exploit from working.
 		if (not ret[3])
-			print_status("Warning: the leaked heap address indicates that this attack may fail");
+			print_warning("Warning: the leaked heap address indicates that this attack may fail");
 		end
 
 		# The base address of our structure in memory


### PR DESCRIPTION
Some warning messages should be using print_warning(). Also, when an exploit is making changes to our framework settings, or changes on the victim machine's file system, we should be warning the user too.
