### PR TITLE
08-067: Rescue when the service is crashed

### DIFF
--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -807,8 +807,18 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 
-		connect()
-		smb_login()
+		begin
+			connect()
+			smb_login()
+		rescue Rex::Proto::SMB::Exceptions::LoginError => e
+			if (e.message =~ /Connection reset/)
+				print_error("Connection reset during login")
+				print_error("This most likely means a previous exploit attempt caused the service to crash")
+				return
+			else
+				raise e
+			end
+		end
 
 		# Use a copy of the target
 		mytarget = target
@@ -1052,6 +1062,14 @@ class Metasploit3 < Msf::Exploit::Remote
 		rescue Rex::ConnectionError => e
 			print_error("Connection failed: #{e.class}: #{e}")
 			return
+		rescue Rex::Proto::SMB::Exceptions::LoginError => e
+			if (e.message =~ /Connection reset/)
+				print_error("Connection reset during login")
+				print_error("This most likely means a previous exploit attempt caused the service to crash")
+				return Msf::Exploit::CheckCode::Unknown
+			else
+				raise e
+			end
 		end
 
 		#


### PR DESCRIPTION
Failed exploit attempts leave the service in a state where the port is
still open but login attmempts reset the connection. Rescue that and
give the user an indication of what's going on.
