### PR TITLE
Infohash cleanups

### DIFF
--- a/modules/auxiliary/admin/ftp/titanftp_xcrc_traversal.rb
+++ b/modules/auxiliary/admin/ftp/titanftp_xcrc_traversal.rb
@@ -35,7 +35,6 @@ class Metasploit3 < Msf::Auxiliary
 			'Author'         => 'jduck',
 			'License'        => MSF_LICENSE,
 			'Version'        => '$Revision$',
-			'Platform'       => [ 'win' ],
 			'References'     =>
 				[
 					[ 'OSVDB', '65533'],

--- a/modules/auxiliary/admin/ftp/titanftp_xcrc_traversal.rb
+++ b/modules/auxiliary/admin/ftp/titanftp_xcrc_traversal.rb
@@ -40,7 +40,6 @@ class Metasploit3 < Msf::Auxiliary
 					[ 'OSVDB', '65533'],
 					[ 'URL', 'http://seclists.org/bugtraq/2010/Jun/160' ]
 				],
-			'Privileged'     => true,
 			'DisclosureDate' => 'Jun 15 2010'
 		)
 

--- a/modules/auxiliary/admin/mssql/mssql_ntlm_stealer.rb
+++ b/modules/auxiliary/admin/mssql/mssql_ntlm_stealer.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'nullbind <scott.sutherland[at]netspi.com>' ],
 			'License'        => MSF_LICENSE,
-			'Platform'      => [ 'win' ],
 			'References'     => [[ 'URL', 'http://en.wikipedia.org/wiki/SMBRelay' ]]
 		))
 

--- a/modules/auxiliary/admin/mssql/mssql_ntlm_stealer_sqli.rb
+++ b/modules/auxiliary/admin/mssql/mssql_ntlm_stealer_sqli.rb
@@ -33,7 +33,6 @@ class Metasploit3 < Msf::Auxiliary
 					[ 'Automatic', { } ],
 				],
 			'DefaultTarget'  => 0,
-			'Platform'      => [ 'win' ],
 			'References'     => [[ 'URL', 'http://en.wikipedia.org/wiki/SMBRelay' ]]
 		))
 

--- a/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
+++ b/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
@@ -45,7 +45,6 @@ class Metasploit3 < Msf::Auxiliary
 					['URL', 'http://sunsolve.sun.com/search/document.do?assetkey=1-77-1000898.1-1']
 				],
 			# Tested OK against sol8.tor 20100624 -jjd
-			'Privileged'     => true,
 			'DisclosureDate' => 'Jan 22 2003')
 
 		register_options(

--- a/modules/auxiliary/dos/pptp/ms02_063_pptp_dos.rb
+++ b/modules/auxiliary/dos/pptp/ms02_063_pptp_dos.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Auxiliary
 			Code execution may be possible however this module is only a DoS.
 			},
 			'Author' 	=> [ 'patrick' ],
-			'Arch'		=> [ ARCH_X86 ],
 			'License'       => MSF_LICENSE,
 			'Version'       => '$Revision$',
 			'References'    =>

--- a/modules/auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof.rb
+++ b/modules/auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof.rb
@@ -43,7 +43,6 @@ class Metasploit3 < Msf::Auxiliary
 					[ 'EDB', 15803 ],
 					[ 'URL', 'http://blogs.technet.com/b/srd/archive/2010/12/22/assessing-an-iis-ftp-7-5-unauthenticated-denial-of-service-vulnerability.aspx' ]
 				],
-			'Platform'       => [ 'win' ],
 			'DisclosureDate' => 'Dec 21 2010'))
 
 		register_options(

--- a/modules/auxiliary/gather/d20pass.rb
+++ b/modules/auxiliary/gather/d20pass.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'K. Reid Wightman <wightman[at]digitalbond.com>' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision: 1 $',
+			'Version'        => '$Revision$',
 			'DisclosureDate' => 'Jan 19 2012'
 			))
 

--- a/modules/auxiliary/scanner/discovery/ipv6_multicast_ping.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_multicast_ping.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 		'Name'        => 'IPv6 Link Local/Node Local Ping Discovery',
-		'Version'     => '$Revision: 13962 $',
+		'Version'     => '$Revision$',
 		'Description' => %q{
 				Send a ICMPv6 ping request to all default multicast addresses, and wait to see who responds.
 		},

--- a/modules/auxiliary/scanner/h323/h323_version.rb
+++ b/modules/auxiliary/scanner/h323/h323_version.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'H.323 Version Scanner',
-			'Version'     => '$Revision: 9804 $',
+			'Version'     => '$Revision$',
 			'Description' => 'Detect H.323 Version.',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
@@ -16,7 +16,7 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'         => 'Atlassian Crowd XML Entity Expansion Remote File Access',
-			'Version'      => '$Revision: $',
+			'Version'      => '$Revision$',
 			'Description'  =>  %q{
 					This module simply attempts to read a remote file from the server using a
 				vulnerability in the way Atlassian Crowd handles XML files. The vulnerability

--- a/modules/auxiliary/server/capture/drda.rb
+++ b/modules/auxiliary/server/capture/drda.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Authentication Capture: DRDA (DB2, Informix, Derby)',
-			'Version'        => '$Revision: 14774 $',
+			'Version'        => '$Revision$',
 			'Description'    => %q{
 				This module provides a fake DRDA (DB2, Informix, Derby) server
 			that is designed to capture authentication credentials.

--- a/modules/auxiliary/server/http_ntlmrelay.rb
+++ b/modules/auxiliary/server/http_ntlmrelay.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize(info = {})
 		super(update_info(info,
 			'Name'        => 'HTTP Client MS Credential Relayer',
-			'Version'     => '$Revision:$',
+			'Version'     => '$Revision$',
 			'Description' => %q{
 					This module relays negotiated NTLM Credentials from an HTTP server to multiple
 					protocols. Currently, this module supports relaying to SMB and HTTP.
@@ -52,7 +52,6 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					'Rich Lundeen <richard.lundeen[at]gmail.com>',
 				],
-			'Version'     => '$Revision:$',
 			'License'     => MSF_LICENSE,
 			'Actions'     =>
 				[

--- a/modules/auxiliary/vsploit/pii/web_pii.rb
+++ b/modules/auxiliary/vsploit/pii/web_pii.rb
@@ -25,7 +25,7 @@ class Metasploit3 < Msf::Auxiliary
 			'Description'    => 'This module emulates a webserver leaking PII data',
 			'License'        => MSF_LICENSE,
 			'Author'         => 'MJC',
-			'Version'        => '$Revision: $',
+			'Version'        => '$Revision$',
 			'References' =>
 			[
 				[ 'URL', 'http://www.metasploit.com'],

--- a/modules/encoders/x86/context_cpuid.rb
+++ b/modules/encoders/x86/context_cpuid.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Encoder::XorAdditiveFeedback
 	def initialize
 		super(
 			'Name'             => 'CPUID-based Context Keyed Payload Encoder',
-			'Version'          => '$Revision: 1$',
+			'Version'          => '$Revision$',
 			'Description'      => %q{
 				This is a Context-Keyed Payload Encoder based on CPUID and Shikata Ga Nai.
 			},

--- a/modules/exploits/freebsd/tacacs/xtacacsd_report.rb
+++ b/modules/exploits/freebsd/tacacs/xtacacsd_report.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'PrependEncoder' => "\x83\xec\x7f",
 					'DisableNops'   =>  'True',
 				},
-			'Platform'       => 'BSD',
+			'Platform'       => 'bsd',
 			'Arch'           => ARCH_X86,
 			'Targets'        =>
 				[

--- a/modules/exploits/linux/http/webid_converter.rb
+++ b/modules/exploits/linux/http/webid_converter.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'OSVDB', '73609' ],
 					[ 'EDB', '17487' ]
 				],
-			'Version'        => '$Revision: $',
+			'Version'        => '$Revision$',
 			'Privileged'     => false,
 			'Platform'       => ['php'],
 			'Arch'           => ARCH_PHP,

--- a/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
+++ b/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'Brendan Coles <bcoles[at]gmail.com>', # Discovery and exploit
 				],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision: 3 $',
+			'Version'        => '$Revision$',
 			'Privileged'     => false,
 			'Arch'           => ARCH_CMD,
 			'Platform'       => 'unix',

--- a/modules/exploits/linux/local/udev_netlink.rb
+++ b/modules/exploits/linux/local/udev_netlink.rb
@@ -60,7 +60,7 @@ class Metasploit4 < Msf::Exploit::Local
 						[ 'Linux x64',       { 'Arch' => ARCH_X86_64 } ],
 						#[ 'Command payload', { 'Arch' => ARCH_CMD } ],
 					],
-				'DefaultOptons' => { 'WfsDelay' => 2 },
+				'DefaultOptions' => { 'WfsDelay' => 2 },
 				'DefaultTarget' => 0,
 				'DisclosureDate' => "Apr 16 2009",
 			}

--- a/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
+++ b/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			},
 			'Author'      => [ 'MC', 'Jacob Giannantonio', 'Patrick Hof', 'h0ng10' ],
 			'License'     => MSF_LICENSE,
-			'Version'     => '$Revision: 15620 $',
+			'Version'     => '$Revision$',
 			'References'  =>
 				[
 					[ 'CVE', '2010-0738' ], # by using VERB other than GET/POST

--- a/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
+++ b/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'mihi' # ARCH_JAVA support
 				],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision: $',
+			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2012-0391'],

--- a/modules/exploits/osx/rtsp/quicktime_rtsp_content_type.rb
+++ b/modules/exploits/osx/rtsp/quicktime_rtsp_content_type.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		super(update_info(info,
 			'Name' => 'MacOS X QuickTime RTSP Content-Type Overflow',
 			# Description?
-			# Author?
+			'Author' => 'unknown',
 			'Version'  => '$Revision$',
 			'Platform' => 'osx',
 			'References' =>

--- a/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
+++ b/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'TecR0c <roccogiovannicalvi[at]gmail.com>', # Metasploit module
 					'mr_me <steventhomasseeley[at]gmail.com>'  # Metasploit module
 				],
-			'Version'        => '$Revision: $',
+			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'EDB', 15668 ],

--- a/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
+++ b/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'TecR0c <roccogiovannicalvi[at]gmail.com>',  # Metasploit module
 					'mr_me <steventhomasseeley[at]gmail.com>' # Metasploit module
 				],
-			'Version'        => '$Revision: $',
+			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2010-0356' ],

--- a/modules/exploits/windows/fileformat/csound_getnum_bof.rb
+++ b/modules/exploits/windows/fileformat/csound_getnum_bof.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'Secunia', # Vulnerability discovery
 					'juan vazquez' # Metasploit module
 				],
-			'Version' => '$Revision: $',
+			'Version' => '$Revision$',
 			'References' =>
 				[
 					[ 'CVE', '2012-0270' ],

--- a/modules/exploits/windows/fileformat/foxit_reader_launch.rb
+++ b/modules/exploits/windows/fileformat/foxit_reader_launch.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'Francisco Falcon',  # Discovery
 					'bannedit'           # Metasploit module
 				],
-			'Version'        => '$Revision: 14069 $',
+			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE' , '2009-0837' ],

--- a/modules/exploits/windows/fileformat/mini_stream_pls_bof.rb
+++ b/modules/exploits/windows/fileformat/mini_stream_pls_bof.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'Tiago Henriques',  # metasploit module
 					'James Fitts'       # clean ups
 				],
-			'Version'        => '$Revision: $',
+			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'EDB', 14373 ],

--- a/modules/exploits/windows/fileformat/mplayer_sami_bof.rb
+++ b/modules/exploits/windows/fileformat/mplayer_sami_bof.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				'Jacques Louw', # Vulnerability Discovery and PoC
 				'juan vazquez' # Metasploit module
 			],
-			'Version'        => '$Revision: $',
+			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'BID', '49149' ],

--- a/modules/exploits/windows/fileformat/ms12_005.rb
+++ b/modules/exploits/windows/fileformat/ms12_005.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					['CVE', '2012-0013'],
 					['OSVDB', '78207'],
-					['MSB', 'ms12-005'],
+					['MSB', 'MS12-005'],
 					['BID', '51284'],
 					['URL', 'http://support.microsoft.com/default.aspx?scid=kb;EN-US;2584146'],
 					['URL', 'http://exploitshop.wordpress.com/2012/01/14/ms12-005-embedded-object-package-allow-arbitrary-code-execution/']

--- a/modules/exploits/windows/fileformat/orbit_download_failed_bof.rb
+++ b/modules/exploits/windows/fileformat/orbit_download_failed_bof.rb
@@ -28,7 +28,6 @@ class Metasploit3 < Msf::Exploit::Remote
 					'Diego Juarez', # Vulnerability discovery
 					'juan vazquez', # Metasploit module
 				],
-			'Version'        => '$ $',
 			'References'     =>
 				[
 					[ 'BID', '28541' ],

--- a/modules/exploits/windows/fileformat/vlc_realtext.rb
+++ b/modules/exploits/windows/fileformat/vlc_realtext.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'SkD', # Exploit
 					'juan vazquez' # Metasploit Module
 				],
-			'Version'        => '$Revision: $',
+			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'OSVDB', '49809' ],

--- a/modules/exploits/windows/ftp/sasser_ftpd_port.rb
+++ b/modules/exploits/windows/ftp/sasser_ftpd_port.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					This module exploits the FTP server component of the Sasser worm.
 				By sending an overly long PORT command the stack can be overwritten.
 			},
-			'Author'	=> [ 'valsmith [at] metasploit.com>', 'chamuco [at] gmail.com>', 'patrick' ],
+			'Author'	=> [ '<valsmith [at] metasploit.com>', '<chamuco [at] gmail.com>', 'patrick' ],
 			'Arch'		=> [ ARCH_X86 ],
 			'License'	=> MSF_LICENSE,
 			'Version'	=> '$Revision$',

--- a/modules/exploits/windows/http/bea_weblogic_post_bof.rb
+++ b/modules/exploits/windows/http/bea_weblogic_post_bof.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'KingCope', # Vulnerability Discovery and PoC
 					'juan vazquez', # Metasploit Module
 				],
-			'Version'        => '$Revision: $',
+			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2008-3257' ],

--- a/modules/exploits/windows/http/landesk_thinkmanagement_upload_asp.rb
+++ b/modules/exploits/windows/http/landesk_thinkmanagement_upload_asp.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				'Andrea Micalizzi', # aka rgod - Vulnerability Discovery and PoC
 				'juan vazquez' # Metasploit module
 			],
-			'Version'     => '$Revision: $',
+			'Version'     => '$Revision$',
 			'Platform'    => 'win',
 			'References'  =>
 				[

--- a/modules/exploits/windows/http/sap_mgmt_con_osexec_payload.rb
+++ b/modules/exploits/windows/http/sap_mgmt_con_osexec_payload.rb
@@ -43,7 +43,7 @@ class Metasploit4 < Msf::Exploit::Remote
 				{
 				'BadChars' => "\x00\x3a\x3b\x3d\x3c\x3e\x0a\x0d\x22\x26\x27\x2f\x60\xb4",
 				},
-			'Platforms'      => [ 'win' ],
+			'Platform'      => [ 'win' ],
 			'Targets'        =>
 				[
 					[

--- a/modules/exploits/windows/iis/ms02_065_msadc.rb
+++ b/modules/exploits/windows/iis/ms02_065_msadc.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					['OSVDB', '14502'],
 					['BID', '6214'],
 					['CVE', '2002-1142'],
-					['MSB', 'ms02-065'],
+					['MSB', 'MS02-065'],
 					['URL', 'http://archives.neohapsis.com/archives/vulnwatch/2002-q4/0082.html']
 				],
 			'Privileged'     => false,

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -42,8 +42,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					['OSVDB', '272'],
 					['BID', '529'],
 					['CVE', '1999-1011'],
-					['MSB', 'ms98-004'],
-					['MSB', 'ms99-025']
+					['MSB', 'MS98-004'],
+					['MSB', 'MS99-025']
 				],
 			'Targets'        =>
 				[

--- a/modules/exploits/windows/local/ask.rb
+++ b/modules/exploits/windows/local/ask.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Local
 			'References'    => [
 				[ 'URL', 'http://www.room362.com/blog/2012/1/3/uac-user-assisted-compromise.html' ]
 			],
-			'DisclosureDate'=> "Jan 3, 2012"
+			'DisclosureDate'=> "Jan 3 2012"
 		))
 
 		register_options([

--- a/modules/exploits/windows/local/bypassuac.rb
+++ b/modules/exploits/windows/local/bypassuac.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Local
 			'References'    => [
 				[ 'URL', ' http://www.trustedsec.com/december-2010/bypass-windows-uac/' ]
 			],
-			'DisclosureDate'=> "Dec 31, 2010"
+			'DisclosureDate'=> "Dec 31 2010"
 		))
 
 	end

--- a/modules/exploits/windows/local/bypassuac.rb
+++ b/modules/exploits/windows/local/bypassuac.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Local
 			'Targets'       => [ [ 'Windows', {} ] ],
 			'DefaultTarget' => 0,
 			'References'    => [
-				[ 'URL', ' http://www.trustedsec.com/december-2010/bypass-windows-uac/' ]
+				[ 'URL', 'http://www.trustedsec.com/december-2010/bypass-windows-uac/' ]
 			],
 			'DisclosureDate'=> "Dec 31 2010"
 		))

--- a/modules/exploits/windows/local/service_permissions.rb
+++ b/modules/exploits/windows/local/service_permissions.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Local
 					[ 'Automatic', { } ],
 				],
 			'DefaultTarget' => 0,
-			'DisclosureDate'=> "Oct 15, 2012"
+			'DisclosureDate'=> "Oct 15 2012"
 		))
 
 		register_options([

--- a/modules/exploits/windows/misc/citrix_streamprocess_data_msg.rb
+++ b/modules/exploits/windows/misc/citrix_streamprocess_data_msg.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'AbdulAziz Hariri',             # Initial discovery via ZDI
 					'alino <26alino[at]gmail.com>'  # Metasploit module
 				],
-			'Version'        => '$Revision: $',
+			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['OSVDB', '75780'],

--- a/modules/exploits/windows/misc/citrix_streamprocess_get_boot_record_request.rb
+++ b/modules/exploits/windows/misc/citrix_streamprocess_get_boot_record_request.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'alino <26alino[at]gmail.com>', # citrix_streamprocess_data_msg author
 					'juan vazquez'  # Metasploit module
 				],
-			'Version'        => '$Revision: $',
+			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['OSVDB', '75780'],

--- a/modules/exploits/windows/misc/citrix_streamprocess_get_footer.rb
+++ b/modules/exploits/windows/misc/citrix_streamprocess_get_footer.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'alino <26alino[at]gmail.com>', # citrix_streamprocess_data_msg author
 					'juan vazquez'  # Metasploit module
 				],
-			'Version'        => '$Revision: $',
+			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['OSVDB', '75780'],

--- a/modules/exploits/windows/misc/citrix_streamprocess_get_objects.rb
+++ b/modules/exploits/windows/misc/citrix_streamprocess_get_objects.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'alino <26alino[at]gmail.com>', # citrix_streamprocess_data_msg author
 					'juan vazquez'  # Metasploit module
 				],
-			'Version'        => '$Revision: $',
+			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['OSVDB', '75780'],

--- a/modules/exploits/windows/misc/gimp_script_fu.rb
+++ b/modules/exploits/windows/misc/gimp_script_fu.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'Joseph Sheridan', # Vulnerability Discovery and PoC
 					'juan vazquez' # Metasploit module
 				],
-			'Version'        => '$Revision: $',
+			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2012-2763' ],

--- a/modules/exploits/windows/misc/hp_dataprotector_new_folder.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_new_folder.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'juan vazquez',
 					'sinn3r'
 				],
-			'Version'        => '$Revision: $',
+			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2012-0124' ],

--- a/modules/exploits/windows/smtp/wmailserver.rb
+++ b/modules/exploits/windows/smtp/wmailserver.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'Windows XP Pro SP0/SP1 English', 		{ 'Ret' => 0x71aa32ad } ],
 				],
 			'DefaultTarget'  => 0,
-			'DisclosureDate' => 'Jul 11 2005 '))
+			'DisclosureDate' => 'Jul 11 2005'))
 
 		register_options([ Opt::RPORT(25) ], self.class)
 	end

--- a/modules/post/multi/manage/multi_post.rb
+++ b/modules/post/multi/manage/multi_post.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Post
 						of the module against the sessions and validation of the options provided.
 				},
 				'License'       => MSF_LICENSE,
-				'Author'        => [ 'carlos_perez[at]darkoperator.com>'],
+				'Author'        => [ '<carlos_perez[at]darkoperator.com>'],
 				'Version'       => '$Revision$',
 				'Platform'      => [ 'windows', 'unix', 'osx', 'linux', 'solaris' ],
 				'SessionTypes'  => [ 'meterpreter','shell' ]

--- a/modules/post/multi/manage/sudo.rb
+++ b/modules/post/multi/manage/sudo.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Post
 				},
 				'License'       => MSF_LICENSE,
 				'Author'        => [ 'todb <todb[at]metasploit.com>'],
-				'Version'       => '$Revision: $',
+				'Version'       => '$Revision$',
 				'Platform'      => [ 'linux','unix','osx','solaris','aix' ],
 				'References'    =>
 					[

--- a/modules/post/windows/escalate/bypassuac.rb
+++ b/modules/post/windows/escalate/bypassuac.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Post
 			'Platform'      => [ 'windows' ],
 			'SessionTypes'  => [ 'meterpreter' ],
 			'References'    => [
-				[ 'URL', ' http://www.trustedsec.com/december-2010/bypass-windows-uac/' ]
+				[ 'URL', 'http://www.trustedsec.com/december-2010/bypass-windows-uac/' ]
 			],
 			'DisclosureDate'=> "Dec 31 2010"
 		))

--- a/modules/post/windows/escalate/bypassuac.rb
+++ b/modules/post/windows/escalate/bypassuac.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Post
 			'References'    => [
 				[ 'URL', ' http://www.trustedsec.com/december-2010/bypass-windows-uac/' ]
 			],
-			'DisclosureDate'=> "Dec 31, 2010"
+			'DisclosureDate'=> "Dec 31 2010"
 		))
 
 		register_options([

--- a/modules/post/windows/gather/credentials/imvu.rb
+++ b/modules/post/windows/gather/credentials/imvu.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Post
 				'Shubham Dawra <shubham2dawra[at]gmail.com>' # www.SecurityXploded.com
 				],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision: 14100 $',
+			'Version'        => '$Revision$',
 			'Platform' => [ 'windows' ],
 			'SessionTypes' => [ 'meterpreter' ]
 		))

--- a/modules/post/windows/gather/credentials/outlook.rb
+++ b/modules/post/windows/gather/credentials/outlook.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Post
 				},
 				'License'       => MSF_LICENSE,
 				'Author'        => [ 'Justin Cacak'],
-				'Version'       => '$Revision: 14835 $',
+				'Version'       => '$Revision$',
 				'Platform'      => [ 'windows' ],
 				'SessionTypes'  => [ 'meterpreter' ]
 			))

--- a/modules/post/windows/manage/mssql_local_auth_bypass.rb
+++ b/modules/post/windows/manage/mssql_local_auth_bypass.rb
@@ -25,7 +25,7 @@ class Metasploit3 < Msf::Post
 				However, this can be overcome by migrating to the SQL Server process.},
 				'License'       => MSF_LICENSE,
 				'Author'        => [ 'Scott Sutherland <scott.sutherland[at]netspi.com>'],
-				'Platform'      => [ 'Windows' ],
+				'Platform'      => [ 'windows' ],
 				'SessionTypes'  => [ 'meterpreter' ]
 			))
 


### PR DESCRIPTION
This cleans up some stuff my script found in the infohash of various modules.

It does not include renaming architecture "windows" to "win" (as egypt wants that as a separate pull request), but it includes Author, DisclosureDate, References, Platform, Arch, Privileged, Version changes.

Maybe I'll push my check script (which I did as an aux module since I'm lazy) one day too :)

Some fields are not checked by my script yet, so there may come more in the future
