### PR TITLE
Fix require errors with windows local exploits

### DIFF
--- a/modules/exploits/windows/local/ask.rb
+++ b/modules/exploits/windows/local/ask.rb
@@ -10,6 +10,8 @@
 ##
 
 require 'msf/core'
+require 'msf/core/post/common'
+require 'msf/core/post/file'
 
 class Metasploit3 < Msf::Exploit::Local
 	Rank = ExcellentRanking

--- a/modules/exploits/windows/local/bypassuac.rb
+++ b/modules/exploits/windows/local/bypassuac.rb
@@ -10,6 +10,8 @@
 ##
 
 require 'msf/core'
+require 'msf/core/post/common'
+require 'msf/core/post/file'
 
 class Metasploit3 < Msf::Exploit::Local
 	Rank = ExcellentRanking


### PR DESCRIPTION
$ ./msfconsole
[-] WARNING! The following modules could not be loaded!
[-]
/home/miller/forks/metasploit-framework/modules/exploits/windows/local/bypassuac.rb:
NameError uninitialized constant Msf::Post::Common
[-]
/home/miller/forks/metasploit-framework/modules/exploits/windows/local/ask.rb:
NameError uninitialized constant Msf::Post::Common
