### PR TITLE
Fix payload ambiguity with php/bind_tcp_ipv6 stager

### DIFF
--- a/modules/payloads/stagers/php/bind_tcp_ipv6.rb
+++ b/modules/payloads/stagers/php/bind_tcp_ipv6.rb
@@ -18,6 +18,10 @@ module Metasploit3
 	include Msf::Payload::Stager
 	include Msf::Payload::Php
 
+	def self.handler_type_alias
+		"bind_tcp_ipv6"
+	end
+
 	def initialize(info = {})
 		super(merge_info(info,
 			'Name'          => 'Bind TCP Stager IPv6',


### PR DESCRIPTION
Was seeing this in framework.log:

[w(0)] core: The module php/meterpreter/bind_tcp is ambiguous with
php/meterpreter/bind_tcp.

Added handler_type_alias based on windows/bind_ipv6_tcp stager.
