### PR TITLE
Require's for all the include's

### DIFF
--- a/modules/exploits/linux/local/sock_sendpage.rb
+++ b/modules/exploits/linux/local/sock_sendpage.rb
@@ -13,6 +13,7 @@ require 'msf/core/post/linux/priv'
 require 'msf/core/exploit/local/linux_kernel'
 require 'msf/core/exploit/local/linux'
 require 'msf/core/exploit/local/unix'
+require 'msf/core/exploit/exe'
 
 #load 'lib/msf/core/post/file.rb'
 #load 'lib/msf/core/exploit/local/unix.rb'

--- a/modules/exploits/linux/local/udev_netlink.rb
+++ b/modules/exploits/linux/local/udev_netlink.rb
@@ -13,6 +13,7 @@ require 'msf/core/post/linux/priv'
 require 'msf/core/exploit/local/linux_kernel'
 require 'msf/core/exploit/local/linux'
 require 'msf/core/exploit/local/unix'
+require 'msf/core/exploit/exe'
 
 #load 'lib/msf/core/post/file.rb'
 #load 'lib/msf/core/exploit/local/unix.rb'

--- a/modules/exploits/unix/local/setuid_nmap.rb
+++ b/modules/exploits/unix/local/setuid_nmap.rb
@@ -10,6 +10,7 @@ require 'rex'
 require 'msf/core/post/common'
 require 'msf/core/post/file'
 require 'msf/core/post/linux/priv'
+require 'msf/core/exploit/exe'
 
 
 class Metasploit4 < Msf::Exploit::Local

--- a/modules/exploits/windows/local/ask.rb
+++ b/modules/exploits/windows/local/ask.rb
@@ -10,6 +10,9 @@
 ##
 
 require 'msf/core'
+require 'msf/core/post/common'
+require 'msf/core/exploit/exe'
+require 'msf/core/post/file'
 
 class Metasploit3 < Msf::Exploit::Local
 	Rank = ExcellentRanking

--- a/modules/exploits/windows/local/bypassuac.rb
+++ b/modules/exploits/windows/local/bypassuac.rb
@@ -10,6 +10,9 @@
 ##
 
 require 'msf/core'
+require 'msf/core/post/common'
+require 'msf/core/exploit/exe'
+require 'msf/core/post/file'
 
 class Metasploit3 < Msf::Exploit::Local
 	Rank = ExcellentRanking

--- a/modules/exploits/windows/local/current_user_psexec.rb
+++ b/modules/exploits/windows/local/current_user_psexec.rb
@@ -14,6 +14,7 @@ require 'rex'
 require 'msf/core/post/windows/services'
 require 'msf/core/post/common'
 require 'msf/core/post/file'
+require 'msf/core/exploit/exe'
 
 class Metasploit3 < Msf::Exploit::Local
 	Rank = ExcellentRanking

--- a/modules/exploits/windows/local/ms10_092_schelevator.rb
+++ b/modules/exploits/windows/local/ms10_092_schelevator.rb
@@ -9,6 +9,8 @@ require 'msf/core'
 require 'msf/core/post/common'
 require 'rex'
 require 'zlib'
+require 'msf/core/exploit/exe'
+require 'msf/core/post/file'
 
 
 class Metasploit3 < Msf::Exploit::Local

--- a/modules/exploits/windows/local/trusted_service_path.rb
+++ b/modules/exploits/windows/local/trusted_service_path.rb
@@ -8,6 +8,8 @@
 require 'msf/core'
 require 'msf/core/post/common'
 require 'msf/core/post/windows/services'
+require 'msf/core/exploit/exe'
+require 'msf/core/post/file'
 
 class Metasploit3 < Msf::Exploit::Local
 	Rank = ExcellentRanking

--- a/modules/post/multi/gather/dns_srv_lookup.rb
+++ b/modules/post/multi/gather/dns_srv_lookup.rb
@@ -12,6 +12,7 @@
 require 'msf/core'
 require 'rex'
 require 'msf/core/post/common'
+require 'msf/core/auxiliary/report'
 
 
 class Metasploit3 < Msf::Post

--- a/modules/post/osx/gather/enum_adium.rb
+++ b/modules/post/osx/gather/enum_adium.rb
@@ -9,6 +9,7 @@ require 'msf/core'
 require 'rex'
 require 'msf/core/post/common'
 require 'msf/core/post/file'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/osx/gather/enum_osx.rb
+++ b/modules/post/osx/gather/enum_osx.rb
@@ -11,9 +11,10 @@
 
 require 'msf/core'
 require 'rex'
-
 require 'msf/core/post/common'
 require 'msf/core/post/file'
+require 'msf/core/auxiliary/report'
+
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/osx/gather/hashdump.rb
+++ b/modules/post/osx/gather/hashdump.rb
@@ -11,9 +11,10 @@
 
 require 'msf/core'
 require 'rex'
-
 require 'msf/core/post/common'
 require 'msf/core/post/file'
+require 'msf/core/auxiliary/report'
+
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/escalate/service_permissions.rb
+++ b/modules/post/windows/escalate/service_permissions.rb
@@ -12,6 +12,7 @@
 require 'msf/core'
 require 'msf/core/post/windows/services'
 require 'rex'
+require 'msf/core//post/windows/services'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/arp_scanner.rb
+++ b/modules/post/windows/gather/arp_scanner.rb
@@ -12,6 +12,7 @@
 require 'msf/core'
 require 'rex'
 require 'msf/core/post/common'
+require 'msf/core/auxiliary/report'
 
 
 class Metasploit3 < Msf::Post

--- a/modules/post/windows/gather/bitcoin_jacker.rb
+++ b/modules/post/windows/gather/bitcoin_jacker.rb
@@ -10,6 +10,7 @@
 require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/user_profiles'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 	include Msf::Auxiliary::Report

--- a/modules/post/windows/gather/credentials/coreftp.rb
+++ b/modules/post/windows/gather/credentials/coreftp.rb
@@ -13,6 +13,7 @@ require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/registry'
 require 'msf/core/post/windows/user_profiles'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 	include Msf::Post::Windows::Registry

--- a/modules/post/windows/gather/credentials/credential_collector.rb
+++ b/modules/post/windows/gather/credentials/credential_collector.rb
@@ -12,6 +12,7 @@
 require 'msf/core'
 require 'rex'
 require 'msf/core/post/common'
+require 'msf/core/auxiliary/report'
 
 
 class Metasploit3 < Msf::Post

--- a/modules/post/windows/gather/credentials/dyndns.rb
+++ b/modules/post/windows/gather/credentials/dyndns.rb
@@ -10,6 +10,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/credentials/enum_picasa_pwds.rb
+++ b/modules/post/windows/gather/credentials/enum_picasa_pwds.rb
@@ -13,6 +13,7 @@ require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/registry'
 require 'msf/core/post/windows/priv'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/credentials/epo_sql.rb
+++ b/modules/post/windows/gather/credentials/epo_sql.rb
@@ -13,6 +13,7 @@ require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/registry'
 require "net/dns/resolver"
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/credentials/flashfxp.rb
+++ b/modules/post/windows/gather/credentials/flashfxp.rb
@@ -11,6 +11,8 @@ require 'msf/core'
 require 'rex'
 require 'rex/parser/ini'
 require 'msf/core/post/windows/user_profiles'
+require 'msf/core/post/windows/registry'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/credentials/ftpnavigator.rb
+++ b/modules/post/windows/gather/credentials/ftpnavigator.rb
@@ -12,6 +12,7 @@
 require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/registry'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/credentials/gpp.rb
+++ b/modules/post/windows/gather/credentials/gpp.rb
@@ -10,6 +10,7 @@ require 'rex'
 require 'rexml/document'
 require 'msf/core/post/windows/registry'
 require 'msf/core/post/windows/priv'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 	include Msf::Auxiliary::Report

--- a/modules/post/windows/gather/credentials/idm.rb
+++ b/modules/post/windows/gather/credentials/idm.rb
@@ -11,6 +11,7 @@
 
 require 'msf/core'
 require 'msf/core/post/windows/registry'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 	include Msf::Post::Windows::Registry

--- a/modules/post/windows/gather/credentials/imail.rb
+++ b/modules/post/windows/gather/credentials/imail.rb
@@ -11,6 +11,7 @@
 
 require 'msf/core'
 require 'msf/core/post/windows/registry'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/credentials/imvu.rb
+++ b/modules/post/windows/gather/credentials/imvu.rb
@@ -14,6 +14,7 @@
 require 'msf/core'
 require 'msf/core/post/windows/registry'
 require 'msf/core/post/windows/user_profiles'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/credentials/meebo.rb
+++ b/modules/post/windows/gather/credentials/meebo.rb
@@ -11,6 +11,7 @@
 
 require 'msf/core'
 require 'msf/core/post/windows/user_profiles'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 	include Msf::Auxiliary::Report

--- a/modules/post/windows/gather/credentials/mremote.rb
+++ b/modules/post/windows/gather/credentials/mremote.rb
@@ -15,6 +15,7 @@ require 'msf/core'
 require 'rex'
 require 'rexml/document'
 require 'msf/core/post/windows/user_profiles'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 	include Msf::Post::Windows::UserProfiles

--- a/modules/post/windows/gather/credentials/nimbuzz.rb
+++ b/modules/post/windows/gather/credentials/nimbuzz.rb
@@ -11,6 +11,7 @@
 
 require 'msf/core'
 require 'msf/core/post/windows/registry'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 	include Msf::Post::Windows::Registry

--- a/modules/post/windows/gather/credentials/outlook.rb
+++ b/modules/post/windows/gather/credentials/outlook.rb
@@ -11,6 +11,7 @@ require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/registry'
 require 'msf/core/post/windows/priv'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/credentials/razorsql.rb
+++ b/modules/post/windows/gather/credentials/razorsql.rb
@@ -8,6 +8,7 @@
 require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/user_profiles'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/credentials/tortoisesvn.rb
+++ b/modules/post/windows/gather/credentials/tortoisesvn.rb
@@ -3,6 +3,7 @@ require 'rex'
 require 'msf/core/post/windows/priv'
 require 'msf/core/post/windows/registry'
 require 'base64'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/credentials/total_commander.rb
+++ b/modules/post/windows/gather/credentials/total_commander.rb
@@ -11,6 +11,8 @@ require 'msf/core'
 require 'rex'
 require 'rex/parser/ini'
 require 'msf/core/post/windows/user_profiles'
+require 'msf/core/post/windows/registry'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 	include Msf::Post::Windows::Registry

--- a/modules/post/windows/gather/credentials/trillian.rb
+++ b/modules/post/windows/gather/credentials/trillian.rb
@@ -14,6 +14,8 @@ require 'rex'
 require 'rex/parser/ini'
 require 'base64'
 require 'msf/core/post/windows/user_profiles'
+require 'msf/core/post/windows/registry'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/credentials/vnc.rb
+++ b/modules/post/windows/gather/credentials/vnc.rb
@@ -15,6 +15,7 @@ require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/registry'
 require 'msf/core/post/windows/user_profiles'
+require 'msf/core/auxiliary/report'
 
 
 class Metasploit3 < Msf::Post

--- a/modules/post/windows/gather/credentials/windows_autologin.rb
+++ b/modules/post/windows/gather/credentials/windows_autologin.rb
@@ -11,6 +11,7 @@
 
 require 'msf/core'
 require 'msf/core/post/windows/registry'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 	include Msf::Post::Windows::Registry

--- a/modules/post/windows/gather/credentials/winscp.rb
+++ b/modules/post/windows/gather/credentials/winscp.rb
@@ -16,6 +16,7 @@ require 'rex'
 require 'msf/core/post/windows/registry'
 require 'rex/parser/ini'
 require 'msf/core/post/windows/user_profiles'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 	include Msf::Post::Windows::Registry

--- a/modules/post/windows/gather/credentials/wsftp_client.rb
+++ b/modules/post/windows/gather/credentials/wsftp_client.rb
@@ -12,6 +12,7 @@ require 'rex'
 require 'rex/parser/ini'
 require 'msf/core/post/windows/registry'
 require 'msf/core/post/windows/user_profiles'
+require 'msf/core/auxiliary/report'
 
 
 class Metasploit3 < Msf::Post

--- a/modules/post/windows/gather/enum_artifacts.rb
+++ b/modules/post/windows/gather/enum_artifacts.rb
@@ -10,6 +10,7 @@ require 'msf/core'
 require 'msf/core/post/file'
 require 'msf/core/post/windows/registry'
 require 'yaml'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/enum_db.rb
+++ b/modules/post/windows/gather/enum_db.rb
@@ -10,6 +10,7 @@ require 'msf/core'
 require 'msf/core/post/file'
 require 'msf/core/post/common'
 require 'msf/core/post/windows/registry'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/enum_files.rb
+++ b/modules/post/windows/gather/enum_files.rb
@@ -7,6 +7,7 @@
 
 require 'msf/core'
 require 'msf/core/post/file'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/enum_snmp.rb
+++ b/modules/post/windows/gather/enum_snmp.rb
@@ -12,6 +12,7 @@
 require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/registry'
+require 'msf/core/auxiliary/report'
 
 
 class Metasploit3 < Msf::Post

--- a/modules/post/windows/gather/enum_termserv.rb
+++ b/modules/post/windows/gather/enum_termserv.rb
@@ -15,6 +15,7 @@ require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/registry'
 require 'msf/core/post/windows/user_profiles'
+require 'msf/core/auxiliary/report'
 
 
 class Metasploit3 < Msf::Post

--- a/modules/post/windows/gather/enum_tomcat.rb
+++ b/modules/post/windows/gather/enum_tomcat.rb
@@ -11,6 +11,7 @@ require 'msf/core'
 require 'msf/core/post/file'
 require 'msf/core/post/common'
 require 'msf/core/post/windows/registry'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/forensics/duqu_check.rb
+++ b/modules/post/windows/gather/forensics/duqu_check.rb
@@ -9,6 +9,7 @@ require 'msf/core'
 require 'msf/core/post/common'
 require 'msf/core/post/windows/registry'
 require 'msf/core/post/windows/priv'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/hashdump.rb
+++ b/modules/post/windows/gather/hashdump.rb
@@ -12,6 +12,7 @@
 require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/registry'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/smart_hashdump.rb
+++ b/modules/post/windows/gather/smart_hashdump.rb
@@ -16,6 +16,7 @@ require 'msf/core/post/windows/priv'
 require 'msf/core/post/windows/registry'
 require 'msf/core/post/windows/accounts'
 require 'msf/core/post/file'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/gather/tcpnetstat.rb
+++ b/modules/post/windows/gather/tcpnetstat.rb
@@ -12,6 +12,7 @@
 require 'msf/core'
 require 'rex'
 require 'msf/core/post/common'
+require 'msf/core/auxiliary/report'
 
 
 class Metasploit3 < Msf::Post

--- a/modules/post/windows/gather/win_privs.rb
+++ b/modules/post/windows/gather/win_privs.rb
@@ -8,6 +8,7 @@
 require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/priv'
+require 'msf/core/post/common'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/manage/clone_proxy_settings.rb
+++ b/modules/post/windows/manage/clone_proxy_settings.rb
@@ -10,6 +10,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/manage/pxexploit.rb
+++ b/modules/post/windows/manage/pxexploit.rb
@@ -10,6 +10,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/recon/computer_browser_discovery.rb
+++ b/modules/post/windows/recon/computer_browser_discovery.rb
@@ -12,6 +12,7 @@
 
 require 'msf/core'
 require 'rex'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 

--- a/modules/post/windows/wlan/wlan_bss_list.rb
+++ b/modules/post/windows/wlan/wlan_bss_list.rb
@@ -11,6 +11,7 @@
 
 require 'msf/core'
 require 'rex'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 	include Msf::Auxiliary::Report

--- a/modules/post/windows/wlan/wlan_current_connection.rb
+++ b/modules/post/windows/wlan/wlan_current_connection.rb
@@ -11,6 +11,7 @@
 
 require 'msf/core'
 require 'rex'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 	include Msf::Auxiliary::Report

--- a/modules/post/windows/wlan/wlan_disconnect.rb
+++ b/modules/post/windows/wlan/wlan_disconnect.rb
@@ -11,6 +11,7 @@
 
 require 'msf/core'
 require 'rex'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 	include Msf::Auxiliary::Report

--- a/modules/post/windows/wlan/wlan_profile.rb
+++ b/modules/post/windows/wlan/wlan_profile.rb
@@ -11,6 +11,7 @@
 
 require 'msf/core'
 require 'rex'
+require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
 	include Msf::Auxiliary::Report


### PR DESCRIPTION
See #954 and a bajillion others.

Automatically generated with this script:

``` ruby

#!/usr/bin/env ruby

require 'active_support'
require 'active_support/core_ext'

ARGV.each do |file|
  mod = File.read(file)
  reqs = mod.scan(/^require .*/)
  incs = mod.scan(/^\s*include (.*)/).flatten.map(&:strip).map{|f| "require 'msf/core/#{f.underscore.sub("msf/","")}'"}
  # special case because it has an improper class name for the file it
  # lives in.
  incs.map!{|i| i.gsub(/windows_services/, 'services')}
  incs.map!{|i| i.gsub(/shadow_copy/, 'shadowcopy')}

  new_reqs = reqs | incs
  if (new_reqs == reqs)
    next
  end
  File.open(file, "wb+") do |fd|
    found_reqs = false
    mod.each_line { |line|
      if line =~ /^require/
        next if found_reqs
        found_reqs = true
        line = new_reqs.join("\n") + "\n"
      end
      fd.write line
    }
  end
end


```
