### PR TITLE
Adds Notes to Creds

### DIFF
--- a/data/sql/migrate/20121020000001_add_note_to_creds.rb
+++ b/data/sql/migrate/20121020000001_add_note_to_creds.rb
@@ -2,7 +2,7 @@ class AddNotesToCreds < ActiveRecord::Migration
 
 	def self.up
 		add_column :creds, :note_id, :integer
-		add_comumn :notes, :cred_id, :integer
+		add_column :notes, :cred_id, :integer
 	end
 
 	def self.down

--- a/data/sql/migrate/20121020000001_add_note_to_creds.rb
+++ b/data/sql/migrate/20121020000001_add_note_to_creds.rb
@@ -1,0 +1,12 @@
+class AddNotesToCreds < ActiveRecord::Migration
+
+	def self.up
+		add_column :creds, :note_id, :integer
+		add_comumn :notes, :cred_id, :integer
+	end
+
+	def self.down
+		remove_column :creds, :note_id
+		remove_column :notes, :cred_id
+	end
+end

--- a/lib/gemcache/ruby/1.9.1/gems/metasploit_data_models-0.0.2.43DEV/lib/metasploit_data_models/active_record_models/cred.rb
+++ b/lib/gemcache/ruby/1.9.1/gems/metasploit_data_models-0.0.2.43DEV/lib/metasploit_data_models/active_record_models/cred.rb
@@ -2,6 +2,7 @@ module MetasploitDataModels::ActiveRecordModels::Cred
   def self.included(base)
     base.class_eval{
       belongs_to :service, :class_name => "Mdm::Service"
+      has_many :notes, :dependent => :destroy, :class_name => "Mdm::Note"
 
       unless defined? PTYPES
         const_def =<<-CONST_DEF 

--- a/lib/gemcache/ruby/1.9.1/gems/metasploit_data_models-0.0.2.43DEV/lib/metasploit_data_models/active_record_models/note.rb
+++ b/lib/gemcache/ruby/1.9.1/gems/metasploit_data_models-0.0.2.43DEV/lib/metasploit_data_models/active_record_models/note.rb
@@ -6,6 +6,7 @@ module MetasploitDataModels::ActiveRecordModels::Note
       belongs_to :workspace, :class_name => "Mdm::Workspace"
       belongs_to :host, :class_name => "Mdm::Host", :counter_cache => :note_count
       belongs_to :service, :class_name => "Mdm::Service"
+      belongs_to :cred, :class_name => "Mdm::Cred"
       serialize :data, ::MetasploitDataModels::Base64Serializer.new
 
       scope :flagged, where('critical = true AND seen = false')

--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -1190,6 +1190,7 @@ class DBManager
 		crit = opts.delete(:critical) || false
 		host = nil
 		addr = nil
+		cred = nil
 		# Report the host so it's there for the Proc to use below
 		if opts[:host]
 			if opts[:host].kind_of? ::Mdm::Host
@@ -1221,6 +1222,18 @@ class DBManager
 				}
 				sopts[:name] = sname if sname
 				report_service(sopts)
+				# Add Creds if they are also specified
+				if (opts[:user] and opts[:pass])
+					copts = {
+						:workspace => wspace,
+						:host => host,
+						:port => opts[:port],
+						:user => opts[:user],
+						:pass => opts[:pass],
+					}
+					copts[:sname] = opts[:sname] if opts[:sname]
+					cred = report_auth_info(copts)
+				end
 			end
 		end
 		# Update Modes can be :unique, :unique_data, :insert
@@ -1235,6 +1248,9 @@ class DBManager
 			service = get_service(wspace, host, opts[:proto], opts[:port])
 		elsif opts[:service] and opts[:service].kind_of? ::Mdm::Service
 			service = opts[:service]
+		end
+		if opts[:cred] and opts[:cred].kind_of? ::Mdm::Cred
+			cred = opts[:cred]
 		end
 =begin
 		if host
@@ -1252,6 +1268,7 @@ class DBManager
 		conditions = { :ntype => ntype }
 		conditions[:host_id] = host[:id] if host
 		conditions[:service_id] = service[:id] if service
+		conditions[:cred_id] = cred[:id] if cred
 
 		case mode
 		when :unique


### PR DESCRIPTION
This requires a small modification to the gem metasploit_data_models.
This branch patches the cache but the changes are also in a forked
version of the gem here: https://github.com/zombieCraig/metasploit_data_models.git

I couldn't figure out how to initiate a migration but it is a small change that should work.

Original commit notes below:
This adds notes to Creds.  This is useful
for recording meta information about an account
such as groups an account belongs to or other things
from post intel gathering.  The migration file in
data/sql should work but was unaware of the proper method
to trigger a migration.

This patch allows for seamless integration when
specifying :user and :pass when calling report_note
