### PR TITLE
Add Domain notes to smb_version

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -101,6 +101,8 @@ class Metasploit3 < Msf::Auxiliary
 
 				conf[:os_sp]   = res['sp']   if res['sp']
 				conf[:os_lang] = res['lang'] if res['os'] =~ /Windows/
+				conf[:SMBName] = simple.client.default_name if simple.client.default_name
+				conf[:SMBDomain] = simple.client.default_domain if simple.client.default_domain
 
 				report_note(
 					:host  => ip,


### PR DESCRIPTION
This is a super small patch.  When smb_version runs it prints out the name and domain but does not record this information.  This match allows it to store this information in the Notes area with the other inf it stores in notes.  This can help automation of windows networks by first running smb_version than using the results for attacks that need to know the proper SMBDomain when attacking.
