### PR TITLE
Msftidy checks for file loads

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -208,7 +208,6 @@ class Msftidy
 				end
 			end
 
-			# if ln =~/^[ \t]+load[ \t]+.*?\.rb/
 			if ln =~/^[ \t]*load[ \t]+[\x22\x27]/
 				error("Loading (not requiring) a file: #{ln.inspect}", idx)
 			end

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -208,6 +208,11 @@ class Msftidy
 				end
 			end
 
+			# if ln =~/^[ \t]+load[ \t]+.*?\.rb/
+			if ln =~/^[ \t]*load[ \t]+[\x22\x27]/
+				error("Loading (not requiring) a file: #{ln.inspect}", idx)
+			end
+
 			# The rest of these only count if it's not a comment line
 			next if ln =~ /[[:space:]]*#/
 


### PR DESCRIPTION
This has been coming up more often lately, so msftidy should just check for it and be done. In my experience, it's never correct to `load` a file in a module -- it should be required if it's a library. Here's what it looks like with a contrived example (we don't currently have a test suite for msftidy since it's all procedural):

```
mazikeen:./metasploit-framework$ tools/msftidy.rb test/modules/exploits/test/exploitme.rb 
exploitme.rb - [ERROR] Exploit is missing a disclosure date
exploitme.rb:13 - [ERROR] Loading (not requiring) a file: "load 'msf/core.rb'\n"
exploitme.rb:128 - [ERROR] Writes to stdout
```

Here's the current list for all of `modules/exploits`:

```
$ tools/msftidy.rb modules/exploits/ | grep load
multi/http/glassfish_deployer.rb - [WARNING] Poorly designed argument list in 'get_upload_data()'. Try a hash.
multi/http/glassfish_deployer.rb - [WARNING] Poorly designed argument list in 'upload_exec()'. Try a hash.
multi/http/apprain_upload_exec.rb - [WARNING] Improper capitalization in module title: 'appRain...'

```

(a big fat zero hits for any module calling `load`)
