### PR TITLE
Put a bandaid over getsockname

### DIFF
--- a/lib/msf/core/handler/bind_tcp.rb
+++ b/lib/msf/core/handler/bind_tcp.rb
@@ -127,7 +127,7 @@ module BindTcp
 				rescue Rex::ConnectionRefused
 					# Connection refused is a-okay
 				rescue ::Exception
-					wlog("Exception caught in bind handler: #{$!}")
+					wlog("Exception caught in bind handler: #{$!.class} #{$!}")
 				end
 
 				break if client
@@ -138,7 +138,6 @@ module BindTcp
 
 			# Valid client connection?
 			if (client)
-
 				# Increment the has connection counter
 				self.pending_connections += 1
 

--- a/lib/rex/io/stream_abstraction.rb
+++ b/lib/rex/io/stream_abstraction.rb
@@ -149,6 +149,9 @@ protected
 							closed = true
 							wlog("monitor_rsock: closed remote socket due to nil read")
 						end
+					rescue EOFError => e
+						closed = true
+						dlog("monitor_rsock: EOF in rsock")
 					rescue ::Exception => e
 						closed = true
 						wlog("monitor_rsock: exception during read: #{e.class} #{e}")

--- a/lib/rex/post/meterpreter/client.rb
+++ b/lib/rex/post/meterpreter/client.rb
@@ -154,7 +154,7 @@ class Client
 		ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
 
 		# Use non-blocking OpenSSL operations on Windows
-		if not ( ssl.respond_to?(:accept_nonblock) and Rex::Compat.is_windows )
+		if !( ssl.respond_to?(:accept_nonblock) and Rex::Compat.is_windows )
 			ssl.accept
 		else
 			begin
@@ -211,12 +211,19 @@ class Client
 		cert.version = 2
 		cert.serial  = rand(0xFFFFFFFF)
 
+		# Depending on how the socket was created, getsockname will
+		# return either a struct sockaddr as a String (the default ruby
+		# Socket behavior) or an Array (the extend'd Rex::Socket::Tcp
+		# behavior). Avoid the ambiguity by always picking a random
+		# hostname. See #7350.
+		subject_cn = Rex::Text.rand_hostname
+
 		subject = OpenSSL::X509::Name.new([
 				["C","US"],
 				['ST', Rex::Text.rand_state()],
 				["L", Rex::Text.rand_text_alpha(rand(20) + 10)],
 				["O", Rex::Text.rand_text_alpha(rand(20) + 10)],
-				["CN", self.sock.getsockname[1] || Rex::Text.rand_hostname],
+				["CN", subject_cn],
 			])
 		issuer = OpenSSL::X509::Name.new([
 				["C","US"],


### PR DESCRIPTION
Depending on how a socket was created, #getsockname will return either a
struct sockaddr as a String (the default ruby Socket behavior) or an
Array (the extend'd Rex::Socket::Tcp behavior). Avoid the ambiguity when
generating SSL certificates for meterpreter handlers by always picking a
random hostname.

This is by no means a proper fix for the underlying problem of
Socket#getsockname having ambiguous behavior before and after being
extended with Rex::Socket::Tcp. It does, however, solve the immediate
problem of not being able to create tunneled meterpreter sessions over
http(s) sessions.

[SeeRM #7350]
