### PR TITLE
Allow for msfupdate over git

### DIFF
--- a/msfupdate
+++ b/msfupdate
@@ -38,8 +38,10 @@ def is_svn
 end
 
 # TODO
-def print_depreciation_warning
-
+def print_deprecation_warning
+	$stdout.puts "[*] Deprecation : The next version of Metasploit will update over the git"
+  $stdout.puts "[*] protocol, which requires outbound access to github.com:9418/TCP."
+  $stdout.puts "[*] Please adjust your egress firewall rules accordingly."
 end
 
 # Some of these args are meaningful for SVN, some for Git,
@@ -77,7 +79,7 @@ end
 
 ####### Since we're SVN, do it all this way #######
 if is_svn
-	print_depreciation_warning
+	print_deprecation_warning
 	@args.push("--config-dir=#{@configdir}")
 	@args.push("--non-interactive")
 

--- a/msfupdate
+++ b/msfupdate
@@ -37,7 +37,6 @@ def is_svn
 	File.directory?(File.join(@msfbase_dir, ".svn"))
 end
 
-# TODO
 def print_deprecation_warning
 	$stdout.puts "[*] Deprecation Note: The next version of Metasploit will"
 	$stdout.puts "[*] update over the git protocol, which requires outbound"

--- a/msfupdate
+++ b/msfupdate
@@ -101,11 +101,17 @@ end
 if is_git
 	remote = @git_remote || "origin"
 	branch = @git_branch || "master"
-	# Always lose any local changes, but not unchecked files
-	# This is actually safer than the old svn way of msfupdate
-	# which would happily just generate conflicts over changes.
-	# TODO: Allow for git stash and git stash pop
-	res = system("git", "reset", "HEAD", "--hard")
+	# This will save local changes in a stash, but won't
+	# attempt to reapply them. If the user wants them back
+	# they can always git stash pop them, and that presumes
+	# they know what they're doing when they're editing local
+	# checkout, which presumes they're not using msfupdate 
+	# to begin with.
+	#
+	# Note, this requires at least user.name and user.email
+	# to be configured in the global git config. Installers should
+	# take care that this is done. TODO: Enforce this in msfupdate
+	res = system("git", "stash")
 	if res.nil?
 		$stderr.puts "[-] ERROR: Failed to run git"
 		$stderr.puts ""
@@ -115,6 +121,7 @@ if is_git
 		exit 1
 	end
 
+	system("git", "reset", "HEAD", "--hard")
 	system("git", "checkout", branch)
 	system("git", "fetch")
 	system("git", "merge", "#{remote}/#{branch}")

--- a/msfupdate
+++ b/msfupdate
@@ -9,14 +9,14 @@ while File.symlink?(msfbase)
 	msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
 
-msfbase_dir = File.dirname(msfbase)
+@msfbase_dir = File.dirname(msfbase)
 
 @args = ARGV.dup
 
 # May be changed
 @configdir = File.expand_path(File.join(File.dirname(msfbase), "data", "svn"))
 
-Dir.chdir(msfbase_dir)
+Dir.chdir(@msfbase_dir)
 
 $stderr.puts "[*]"
 $stderr.puts "[*] Attempting to update the Metasploit Framework..."
@@ -29,12 +29,12 @@ if not (Process.uid == 0 or File.stat(msfbase).owned?)
 end
 
 
-def is_git(msfbase_dir)
-	File.directory?(File.join(msfbase_dir, ".git"))
+def is_git
+	File.directory?(File.join(@msfbase_dir, ".git"))
 end
 
-def is_svn(msfbase_dir)
-	File.directory?(File.join(msfbase_dir, ".svn"))
+def is_svn
+	File.directory?(File.join(@msfbase_dir, ".svn"))
 end
 
 # TODO
@@ -108,7 +108,7 @@ if is_git
 end
 
 unless is_svn || is_git
-	raise RuntimeError, "Cannot determine checkout type: `#{msfbase_dir}'"
+	raise RuntimeError, "Cannot determine checkout type: `#{@msfbase_dir}'"
 end
 
 if @actually_wait

--- a/msfupdate
+++ b/msfupdate
@@ -57,14 +57,22 @@ end
 	when /--config-dir=(.*)?/
 		# Spaces in the directory should be fine since this whole thing is passed
 		# as a single argument via the multi-arg syntax for system() below.
-		# TODO: Test this spaces business. I don't buy it. -todb
 		@configdir = $1
 		@configdir_index = i
+	when /--git-remote=([^\s]*)?/
+		@git_remote = $1
+		@git_remote_index = i
+	when /--git-branch=([^\s]*)?/
+		@git_branch = $1
+		@git_branch_index = i
 	end
 end
 
 @args[@wait_index] = nil      if @wait_index
 @args[@configdir_index] = nil if @configdir_index
+
+@args[@git_remote_index] = nil if @git_remote_index
+@args[@git_branch_index] = nil if @git_branch_index
 @args = @args.compact
 
 ####### Since we're SVN, do it all this way #######
@@ -89,7 +97,11 @@ end
 
 ####### Since we're Git, do it all that way #######
 if is_git
+	remote = @git_remote || "origin"
+	branch = @git_branch || "master"
 	# Always lose any local changes, but not unchecked files
+	# This is actually safer than the old svn way of msfupdate
+	# which would happily just generate conflicts over changes.
 	# TODO: Allow for git stash and git stash pop
 	res = system("git", "reset", "HEAD", "--hard")
 	if res.nil?
@@ -101,10 +113,9 @@ if is_git
 		exit 1
 	end
 
-	# TODO: Allow msfupdate to take a branch argument
-	system("git", "checkout", "master")
+	system("git", "checkout", branch)
 	system("git", "fetch")
-	system("git", "merge", "origin/master")
+	system("git", "merge", "#{remote}/#{branch}")
 end
 
 unless is_svn || is_git

--- a/msfupdate
+++ b/msfupdate
@@ -33,7 +33,7 @@ def is_git(msfbase_dir)
 	File.directory?(File.join(msfbase_dir, ".git"))
 end
 
-def is_svn
+def is_svn(msfbase_dir)
 	File.directory?(File.join(msfbase_dir, ".svn"))
 end
 

--- a/msfupdate
+++ b/msfupdate
@@ -39,9 +39,10 @@ end
 
 # TODO
 def print_deprecation_warning
-	$stdout.puts "[*] Deprecation : The next version of Metasploit will update over the git"
-  $stdout.puts "[*] protocol, which requires outbound access to github.com:9418/TCP."
-  $stdout.puts "[*] Please adjust your egress firewall rules accordingly."
+	$stdout.puts "[*] Deprecation Note: The next version of Metasploit will"
+	$stdout.puts "[*] update over the git protocol, which requires outbound"
+	$stdout.puts "[*] access to github.com:9418/TCP."
+	$stdout.puts "[*] Please adjust your egress firewall rules accordingly."
 end
 
 # Some of these args are meaningful for SVN, some for Git,

--- a/msfupdate
+++ b/msfupdate
@@ -9,12 +9,14 @@ while File.symlink?(msfbase)
 	msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
 
+msfbase_dir = File.dirname(msfbase)
+
 @args = ARGV.dup
 
 # May be changed
 @configdir = File.expand_path(File.join(File.dirname(msfbase), "data", "svn"))
 
-Dir.chdir(File.dirname(msfbase))
+Dir.chdir(msfbase_dir)
 
 $stderr.puts "[*]"
 $stderr.puts "[*] Attempting to update the Metasploit Framework..."
@@ -26,16 +28,32 @@ if not (Process.uid == 0 or File.stat(msfbase).owned?)
 	$stderr.puts "Please run msfupdate as the same user who installed metasploit."
 end
 
+
+def is_git(msfbase_dir)
+	File.directory?(File.join(msfbase_dir, ".git"))
+end
+
+def is_svn
+	File.directory?(File.join(msfbase_dir, ".svn"))
+end
+
+# TODO
+def print_depreciation_warning
+
+end
+
+# Some of these args are meaningful for SVN, some for Git,
+# some for both. Fun times.
 @args.each_with_index do |arg,i|
 	case arg
-	# Handle the old wait/nowait argument behavior
+		# Handle the old wait/nowait argument behavior
 	when "wait", "nowait"
 		@wait_index = i
 		@actually_wait = (arg == "wait")
-	# An empty or absent config-dir means a default config-dir
+		# An empty or absent config-dir means a default config-dir
 	when "--config-dir"
 		@configdir_index = i
-	# A defined config dir means a defined config-dir
+		# A defined config dir means a defined config-dir
 	when /--config-dir=(.*)?/
 		# Spaces in the directory should be fine since this whole thing is passed
 		# as a single argument via the multi-arg syntax for system() below.
@@ -48,19 +66,49 @@ end
 @args[@wait_index] = nil      if @wait_index
 @args[@configdir_index] = nil if @configdir_index
 @args = @args.compact
-@args.push("--config-dir=#{@configdir}")
-@args.push("--non-interactive")
 
-res = system("svn", "cleanup")
-if res.nil?
-	$stderr.puts "[-] ERROR: Failed to run svn"
-	$stderr.puts ""
-	$stderr.puts "[-] If you used a binary installer, make sure you run the symlink in"
-	$stderr.puts "[-] /usr/local/bin instead of running this file directly (e.g.: ./msfupdate)"
-	$stderr.puts "[-] to ensure a proper environment."
-else
-	# Cleanup worked, go ahead and update
-	system("svn", "update", *@args)
+####### Since we're SVN, do it all this way #######
+if is_svn
+	print_depreciation_warning
+	@args.push("--config-dir=#{@configdir}")
+	@args.push("--non-interactive")
+
+	res = system("svn", "cleanup")
+	if res.nil?
+		$stderr.puts "[-] ERROR: Failed to run svn"
+		$stderr.puts ""
+		$stderr.puts "[-] If you used a binary installer, make sure you run the symlink in"
+		$stderr.puts "[-] /usr/local/bin instead of running this file directly (e.g.: ./msfupdate)"
+		$stderr.puts "[-] to ensure a proper environment."
+		exit 1
+	else
+		# Cleanup worked, go ahead and update
+		system("svn", "update", *@args)
+	end
+end
+
+####### Since we're Git, do it all that way #######
+if is_git
+	# Always lose any local changes, but not unchecked files
+	# TODO: Allow for git stash and git stash pop
+	res = system("git", "reset", "HEAD", "--hard")
+	if res.nil?
+		$stderr.puts "[-] ERROR: Failed to run git"
+		$stderr.puts ""
+		$stderr.puts "[-] If you used a binary installer, make sure you run the symlink in"
+		$stderr.puts "[-] /usr/local/bin instead of running this file directly (e.g.: ./msfupdate)"
+		$stderr.puts "[-] to ensure a proper environment."
+		exit 1
+	end
+
+	# TODO: Allow msfupdate to take a branch argument
+	system("git", "checkout", "master")
+	system("git", "fetch")
+	system("git", "merge", "origin/master")
+end
+
+unless is_svn || is_git
+	raise RuntimeError, "Cannot determine checkout type: `#{msfbase_dir}'"
 end
 
 if @actually_wait

--- a/msfupdate
+++ b/msfupdate
@@ -119,6 +119,9 @@ if is_git
 		$stderr.puts "[-] /usr/local/bin instead of running this file directly (e.g.: ./msfupdate)"
 		$stderr.puts "[-] to ensure a proper environment."
 		exit 1
+	else
+		$stdout.puts "[*] Stashed local changes (if any) to avoid merge conflicts."
+		$stdout.puts "[*] Run 'git stash pop' to reapply local changes."
 	end
 
 	system("git", "reset", "HEAD", "--hard")


### PR DESCRIPTION
If you've got a git checkout of Metasploit, you should be able to use msfupdate.

Originally proposed by @corelanc0d3r I do believe, but rejected because it solved a problem nobody had. Soon, lots of people will have this problem, after we retire the SVN services on metasploit.com.

The changes to msfupdate are _only_ to make use of git. This change does _not_ handle switching over to Git -- that will be a standalone script, `msfswitch` which is Coming Soon.

[See #37890749]
