### PR TITLE
Fixed "Drupal Views User Enum Module only writes to the database"

### DIFF
--- a/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
+++ b/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
@@ -91,9 +91,9 @@ class Metasploit3 < Msf::Auxiliary
 			if (res and res.message == "OK")
 				user_list = res.body.scan(/\w+/)
 				if user_list.empty?
-					vprint_status("\tFound: Nothing")
+					vprint_line("\tFound: Nothing")
 				else
-					vprint_status("\tFound: #{user_list.inspect}")
+					vprint_line("\tFound: #{user_list.inspect}")
 					results << user_list
 				end
 			else

--- a/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
+++ b/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
@@ -24,7 +24,8 @@ class Metasploit3 < Msf::Auxiliary
 			'Author'         =>
 				[
 					'Justin Klein Keane', #Original Discovery
-					'Robin Francois <rof[at]navixia.com>'
+					'Robin Francois <rof[at]navixia.com>',
+					'Brandon McCann "zeknox" <bmccann [at] accuvant.com>'
 				],
 			'License'        => MSF_LICENSE,
 			'References'     =>
@@ -90,9 +91,9 @@ class Metasploit3 < Msf::Auxiliary
 			if (res and res.message == "OK")
 				user_list = res.body.scan(/\w+/)
 				if user_list.empty?
-					vprint_line("\tFound: Nothing")
+					vprint_status("\tFound: Nothing")
 				else
-					vprint_line("\tFound: #{user_list.inspect}")
+					vprint_status("\tFound: #{user_list.inspect}")
 					results << user_list
 				end
 			else
@@ -106,11 +107,15 @@ class Metasploit3 < Msf::Auxiliary
 		print_status("Done. " + final_results.length.to_s + " usernames found...")
 
 		final_results.each do |user|
-			report_auth_info(
-				:host => Rex::Socket.getaddress(datastore['RHOST']),
-				:port => datastore['RPORT'],
-				:user => user,
-				:type => "drupal_user"
+			print_good("Found User: #{user}")
+
+			store_loot(
+				type,
+				'text/plain',
+				Rex::Socket.getaddress(datastore['RHOST']),
+				user,
+				'drupal_user.txt',
+				user
 			)
 		end
 	end


### PR DESCRIPTION
Fixed the Drupal Views User Enum Module only writes to the database Issue #1010 referenced here:
https://github.com/rapid7/metasploit-framework/issues/1010

The module will not display to the console and also log to the loot database as requested in the ticket.

Output can be seen below:

<pre>
msf  auxiliary(drupal_views_user_enum) > rexploit
[*] Reloading module...

[*] Begin enumerating users at 192.168.0.13
[*] Done. 2 usernames found...
[+] Found User: Anonymous
[+] Found User: root
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf  auxiliary(drupal_views_user_enum) > notes
msf  auxiliary(drupal_views_user_enum) > loot

Loot
====

host          service  type       name             content     info       path
----          -------  ----       ----             -------     ----       ----
192.168.0.13           auxiliary  drupal_user.txt  text/plain  root       /root/.msf4/loot/20121106053042_default_192.168.0.13_auxiliary_070390.txt
192.168.0.13           auxiliary  drupal_user.txt  text/plain  Anonymous  /root/.msf4/loot/20121106053042_default_192.168.0.13_auxiliary_351503.txt

msf  auxiliary(drupal_views_user_enum) > 
</pre>
