### PR TITLE
Add codeclimate button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 
-Metasploit
-[![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/rapid7/metasploit-framework)
+Metasploit [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/rapid7/metasploit-framework)
 ==
 The Metasploit Framework is released under a BSD-style license. See
 COPYING for more details.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 Metasploit
+[![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/rapid7/metasploit-framework)
 ==
 The Metasploit Framework is released under a BSD-style license. See
 COPYING for more details.


### PR DESCRIPTION
Add the codeclimate button so users can quickly jump to the code quality
metrics.  This keeps metasploit-framework inline with other open source
ruby projects like https://github.com/rspec/rspec-rails that also uses
the codeclimate button.
