### PR TITLE
Add IRC notifications and allow 1.8.7 to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
 language: ruby
 rvm:
-#  - '1.8.7'
+  - '1.8.7'
   - '1.9.3'
+
+matrix:
+  allow_failures:
+    - rvm: '1.8.7'
+
+notifications:
+  irc: "irc.freenode.org#msfnotify"
+


### PR DESCRIPTION
This should tell travis to run the tests against 1.8.7 but not to
consider the whole build broken if it fails (which it currently does)
