### PR TITLE
Lantronix telnet password bugfixes

### DIFF
--- a/modules/auxiliary/scanner/telnet/lantronix_telnet_password.rb
+++ b/modules/auxiliary/scanner/telnet/lantronix_telnet_password.rb
@@ -68,6 +68,10 @@ class Metasploit4 < Msf::Auxiliary
 		end
 
 		if password
+			if password == "\x00\x00\x00\x00"
+				password = "(not used, or secure)"
+			end
+
 			print_good("#{rhost} - Telnet password found: #{password.to_s}")
 			report_auth_info({
 				:host         => rhost,

--- a/modules/auxiliary/scanner/telnet/lantronix_telnet_password.rb
+++ b/modules/auxiliary/scanner/telnet/lantronix_telnet_password.rb
@@ -84,7 +84,7 @@ class Metasploit4 < Msf::Auxiliary
 		setup_record = pkt[0]
 
 		# If response is a setup record, extract password bytes 13-16
-		if setup_record[3].ord == 0xF9
+		if setup_record[3] and setup_record[3].ord == 0xF9
 			return setup_record[12,4]
 		else
 			return nil


### PR DESCRIPTION
Fixed a bug where .ord was being called on a potentially empty object.

Changed the behavior to explicitly indicate when a password is unset (or using the enhanced password feature instead) rather than registering the password as an empty string.
