### PR TITLE
Console alias plugin

### DIFF
--- a/plugins/alias.rb
+++ b/plugins/alias.rb
@@ -85,7 +85,7 @@ class Plugin::Alias < Msf::Plugin
 				# We prevent the user from naming the alias "alias" cuz they could end up unable to clear the aliases,
 				# for example you 'alias -f set unset and then 'alias -f alias sessions', now you're screwed.  The byproduct
 				# of this is that it prevents you from aliasing 'alias' to 'alias -f' etc, but that's acceptable
-				reserved_words = [/^alias/i]
+				reserved_words = [/^alias$/i]
 				reserved_words.each do |regex|
 					if name =~ regex
 						print_error "You cannot use #{name} as the name for an alias, sorry"
@@ -113,7 +113,7 @@ class Plugin::Alias < Msf::Plugin
 				# smash everything that's left together
 				value = args.join(" ")
 				value.strip!
-				# valule can NEVER be certain bad words like 'rm -rf /', add any other reserved words here
+				# value can NEVER be certain bad words like 'rm -rf /', add any other reserved words here
 				# this is basic idiot protection, not meant to be impervious to subversive intentions
 				reserved_words = [/^rm +(-rf|-r +-f|-f +-r) +\/.*$/]
 				reserved_words.each do |regex|

--- a/plugins/alias.rb
+++ b/plugins/alias.rb
@@ -54,6 +54,7 @@ class Plugin::Alias < Msf::Plugin
 						'Postfix' => "\n",
 						'Columns' => [ '', 'Alias Name', 'Alias Value' ]
 					)
+					# add 'alias' in front of each row so that the output can be copy pasted into an rc file if desired
 					@aliases.each_pair do |key,val|
 						tbl << ["alias",key,val]
 					end

--- a/plugins/alias.rb
+++ b/plugins/alias.rb
@@ -52,10 +52,10 @@ class Plugin::Alias < Msf::Plugin
 						'Header'  => "Current Aliases",
 						'Prefix'  => "\n",
 						'Postfix' => "\n",
-						'Columns' => [ 'Alias Name', 'Alias Value' ]
+						'Columns' => [ '', 'Alias Name', 'Alias Value' ]
 					)
 					@aliases.each_pair do |key,val|
-						tbl << [key,val]
+						tbl << ["alias",key,val]
 					end
 					return print(tbl.to_s)
 				end

--- a/plugins/alias.rb
+++ b/plugins/alias.rb
@@ -45,7 +45,7 @@ class Plugin::Alias < Msf::Plugin
 			# we parse args manually instead of using @@alias.opts.parse to handle special cases
 			case args.length
 			when 0 # print the list of current aliases
-				if @aliases.length == 0 
+				if @aliases.length == 0
 					return print_status("No aliases currently defined")
 				else
 					tbl = Rex::Ui::Text::Table.new(
@@ -86,7 +86,7 @@ class Plugin::Alias < Msf::Plugin
 				# for example you 'alias -f set unset and then 'alias -f alias sessions', now you're screwed.  The byproduct
 				# of this is that it prevents you from aliasing 'alias' to 'alias -f' etc, but that's acceptable
 				reserved_words = [/^alias/i]
-				reserved_words.each do |regex|	
+				reserved_words.each do |regex|
 					if name =~ regex
 						print_error "You cannot use #{name} as the name for an alias, sorry"
 						return false
@@ -150,7 +150,7 @@ class Plugin::Alias < Msf::Plugin
 		def cmd_alias_help
 			print_line "Usage: alias [options] [name [value]]"
 			print_line
-			print(@@alias_opts.usage())	
+			print(@@alias_opts.usage())
 		end
 
 		#
@@ -204,7 +204,7 @@ class Plugin::Alias < Msf::Plugin
 					driver.run_single("help #{value}")
 				end
 			end
-			# add the alias to the list 
+			# add the alias to the list
 			@aliases[name] = value
 		end
 
@@ -213,7 +213,7 @@ class Plugin::Alias < Msf::Plugin
 		#
 		def deregister_alias(name)
 			self.class_eval do
-				# remove the class methods we created when the alias was registered 
+				# remove the class methods we created when the alias was registered
 				remove_method("cmd_#{name}")
 				remove_method("cmd_#{name}_tabs")
 				remove_method("cmd_#{name}_help")
@@ -223,7 +223,7 @@ class Plugin::Alias < Msf::Plugin
 		end
 
 		#
-		# Validate a proposed alias
+		# Validate a proposed alias with the +name+ and having the value +value+
 		#
 		def is_valid_alias?(name,value)
 			#print_good "Assessing validay for #{name} and #{value}"
@@ -343,4 +343,4 @@ class Plugin::Alias < Msf::Plugin
 	end
 
 end ## End Plugin Class
-end ## End Module	
+end ## End Module

--- a/plugins/alias.rb
+++ b/plugins/alias.rb
@@ -1,0 +1,288 @@
+##
+# $Id$
+# $Revision$
+##
+
+require 'rex/ui/text/table'
+
+module Msf
+
+class Plugin::Alias < Msf::Plugin
+	class AliasCommandDispatcher
+		include Msf::Ui::Console::CommandDispatcher
+
+		attr_reader :aliases
+		def initialize(driver)
+			super(driver)
+			@aliases = {}
+		end
+
+		def name
+			"Alias"
+		end
+
+		@@alias_opts = Rex::Parser::Arguments.new(
+			"-h" => [ false, "Help banner."                    ],
+			"-c" => [ true, "Clear an alias (* to clear all)."],
+			"-f" => [ true,  "Force an alias assignment."      ]
+		)
+		#
+		# Returns the hash of commands supported by this dispatcher.
+		#
+		def commands # driver.dispatcher_stack[3].commands
+			{
+				"alias" => "create or view an alias."
+	#			"alias_clear" => "clear an alias (or all aliases).",
+	#			"alias_force" => "Force an alias (such as to override)"
+			}.merge(aliases) # make aliased commands available as commands of their own
+		end
+
+		#
+		# the main alias command handler
+		#
+		# usage: alias [options] [name [value]]
+		def cmd_alias(*args)
+			# we parse args manually instead of using @@alias.opts.parse to handle special cases
+			case args.length
+			when 0 # print the list of current aliases
+				if @aliases.length == 0 
+					return print_status("No aliases currently defined")
+				else
+					tbl = Rex::Ui::Text::Table.new(
+						'Header'  => "Current Aliases",
+						'Prefix'  => "\n",
+						'Postfix' => "\n",
+						'Columns' => [ 'Alias Name', 'Alias Value' ]
+					)
+					@aliases.each_pair do |key,val|
+						tbl << [key,val]
+					end
+					return print(tbl.to_s)
+				end
+			when 1 # display the alias if one matches this name (or help)
+				return cmd_alias_help if args[0] == "-h" or args[0] == "--help"
+				if @aliases.keys.include?(args[0])
+					print_status("\'#{args[0]}\' is aliased to \'#{@aliases[args[0]]}\'")
+				else
+					print_status("\'#{args[0]}\' is not currently aliased")
+				end
+			else # let's see if we can assign or clear the alias
+				force = false
+				clear = false
+				# if using -f or -c, they must be the first arg, because -f/-c may also show up in the alias
+				# value so we can't do something like if args.include("-f") or delete_if etc
+				# we sould never have to force and clear simultaneously.
+				if args[0] == "-f"
+					force = true
+					args.shift
+				elsif args[0] == "-c"
+					clear = true
+					args.shift
+				end
+				name = args.shift
+				print_good "The alias name is #{name}"
+				if clear
+					# clear all aliases if "*"
+					if name == "*"
+						@aliases.keys.each do |a|
+							deregister_alias(a)
+						end
+						print_status "Cleared all aliases"
+					else # clear the named alias if it exists
+						print_status "Checking alias #{name} for clear"
+						deregister_alias(name) if @aliases.keys.include?(name)
+						print_status "Cleared alias #{name}"
+					end
+					return
+				end
+				# smash everything that's left together
+				value = args.join(" ")
+
+				if is_valid_alias?(name,value)
+					if force or (not Rex::FileUtils.find_full_path(name) and not @aliases.keys.include?(name))
+						register_alias(name, value)
+					else
+						print_error("#{name} already exists as system command or current alias, use -f to force")
+					end
+				else
+					print_error("\'#{name}\' is not a permitted name or \'#{value}\' is not a valid/permitted console or system command")
+				end
+			end
+		end
+
+		def cmd_alias_help
+			print_line "Usage: alias [options] [name [value]]"
+			print_line
+			print(@@alias_opts.usage())	
+		end
+
+		#
+		# Tab completion for the alias command
+		#
+		def cmd_alias_tabs(str, words)
+			if words.length <= 1
+				return @@alias_opts.fmt.keys + tab_complete_aliases_and_commands(str, words)
+			else
+				return tab_complete_aliases_and_commands(str, words)
+			end
+		end
+
+		private
+		#
+		# do everything needed to add an alias of +name+ having the value +value+
+		#
+		def register_alias(name, value)
+			#TODO:  begin rescue?
+			#TODO:  security concerns since we are using eval
+
+			# define some class instance methods
+			self.class_eval do
+				# define a class instance method that will respond for the alias
+				define_method "cmd_#{name}" do |*args|
+					# just replace the alias w/the alias' value and run that
+					driver.run_single("#{value} #{args.join(' ')}")
+				end
+				# define a class instance method that will tab complete the aliased command
+				# we just proxy to the top-level tab complete function and let them handle it
+				define_method "cmd_#{name}_tabs" do |str, words|
+					#print_good "Creating cmd_#{name}_tabs as driver.tab_complete(#{value} #{words.join(' ')})"
+					#driver.tab_complete("MONKEY")
+					words.delete(name)
+					driver.tab_complete("#{value} #{words.join(' ')}")
+				end
+				# we don't need a cmd_#{name}_help method, we just let the original handle that
+			end
+			# add the alias to the list 
+			@aliases[name] = value
+		end
+
+		#
+		# do everything required to remove an alias of name +name+
+		#
+		def deregister_alias(name)
+			self.class_eval do
+				# remove the methods we defined for this alias
+				remove_method("cmd_#{name}")
+				remove_method("cmd_#{name}_tab")
+			end
+		end
+
+		#
+		# Validate a proposed alias
+		#
+		def is_valid_alias?(name,value)
+			# some "bad words" to avoid for the value.  value would have to not match these regexes
+			# this is just basic idiot protection, it's not meant to be "undefeatable"
+			value.strip!
+			bad_words = [/^rm +(-rf|-r +-f|-f +-r) +\/+.*$/, /^msfconsole$/]
+			bad_words.each do |regex|
+				# don't mess around, just return false if we match
+				return false if value =~ regex
+			end
+			# we're only gonna validate the first part of the cmd, e.g. just ls from "ls -lh"
+			value = value.split(" ").first
+			valid_value = false
+
+			# value is considered valid if it's a ref to a valid console command or
+			#  a system executable or existing alias
+
+			# gather all the current commands the driver's dispatcher's have & check 'em
+			driver.dispatcher_stack.each do |dispatcher|
+				next unless dispatcher.respond_to?(:commands)
+				next if (dispatcher.commands.nil?)
+				next if (dispatcher.commands.length == 0)
+
+				if dispatcher.respond_to?("cmd_#{value.split(" ").first}")
+					valid_value = true
+					break
+				end
+			end
+			if not valid_value # then check elsewhere
+				if @aliases.keys.include?(value)
+					valid_value = true
+				else
+					[value, value+".exe"].each do |cmd|
+						if Rex::FileUtils.find_full_path(cmd)
+							valid_value = true
+						end
+					end
+				end
+			end
+			# go ahead and return false at this point if the value isn't valid
+			return false if not valid_value
+
+			# we don't check if this alias name exists or if it's a console command already etc as
+			#  -f can override that so those need to be checked externally.
+			#  We pretty much just check to see if the name is sane
+			valid_name = true
+			name.strip!
+			bad_words = [/^alias$/,/\*/]
+			# there are probably a bunch of others that need to be added here.  We prevent the user
+			#  from naming the alias "alias" cuz they can end up unable to clear the aliases
+			# for example you 'alias -f set unse't and then 'alias -f alias sessions', now you're 
+			#  screwed.  This prevents you from aliasing alias to alias -f etc, but no biggie.
+			bad_words.each do |regex|
+				# don't mess around, just return false in this case, prevents wasted processing
+				return false if name =~ regex
+			end
+
+			return valid_name
+		end
+
+		#
+		# Provide tab completion list for aliases and commands
+		#
+		def tab_complete_aliases_and_commands(str, words)
+			items = []
+			items.concat(driver.commands.keys) if driver.respond_to?('commands')
+			items.concat(@aliases.keys)
+			items
+		end
+
+	end # end AliasCommandDispatcher class
+
+	#
+	# The constructor is called when an instance of the plugin is created.  The
+	# framework instance that the plugin is being associated with is passed in
+	# the framework parameter.  Plugins should call the parent constructor when
+	# inheriting from Msf::Plugin to ensure that the framework attribute on
+	# their instance gets set.
+	#
+	attr_accessor :controller
+	
+	def initialize(framework, opts)
+		super
+
+		## Register the commands above
+		add_console_dispatcher(AliasCommandDispatcher)
+	end
+
+
+	#
+	# The cleanup routine for plugins gives them a chance to undo any actions
+	# they may have done to the framework.  For instance, if a console
+	# dispatcher was added, then it should be removed in the cleanup routine.
+	#
+	def cleanup
+		# If we had previously registered a console dispatcher with the console,
+		# deregister it now.
+		remove_console_dispatcher('Alias')
+	end
+
+	#
+	# This method returns a short, friendly name for the plugin.
+	#
+	def name
+		"Alias"
+	end
+
+	#
+	# This method returns a brief description of the plugin.  It should be no
+	# more than 60 characters, but there are no hard limits.
+	#
+	def desc
+		"Adds the ability to alias console commands"
+	end
+
+end ## End Plugin Class
+end ## End Module	


### PR DESCRIPTION
I converted my msfconsole aliasing code into a plugin so that msfconsole internals would not have changes requiring deep review and avoiding any dragons thar be.  It actually made for a better solution I believe and also makes it much more portable.

```
Usage: alias [options] [name [value]]

OPTIONS:

    -c <opt>  Clear an alias (* to clear all).
    -f <opt>  Force an alias assignment.
    -h        Help banner.
```

Example:

```
    msf > load alias
    [*] Successfully loaded plugin: alias
    msf > alias s sessions -l -v
    msf > alias si sessions -i
    msf > alias sk sessions -K
    msf > alias -f sk sessions -k
    msf > alias
     
    Current Aliases
    ===============
    
            Alias Name  Alias Value
            ----------         -----------
    alias  s                sessions -l -v
    alias  si               sessions -i
    alias  sk              sessions -k
    
    msf > alias -c *
    [*] Cleared all aliases
    
    msf > alias n00b rm -rf /
    [-] You cannot use rm -rf / as the value for an alias, sorry
    msf > alias -f n00b rm -rf /
    [-] You cannot use rm -rf / as the value for an alias, sorry
    msf > alias i ifconfig
    msf > alias ifconfig sessions
    [-] ifconfig already exists as a system command, use -f to force override
    msf > alias -f ifconfig sessions
    msf > alias
    
    Current Aliases
    ===============
    
           Alias Name  Alias Value
            ----------        -----------
    alias  i                ifconfig
    alias  ifconfig      sessions
    
    msf > i
    
    Active sessions
    ===============
    
    No active sessions.
    
    msf > alias -c ifconfig
    [*] Cleared alias ifconfig
    msf > i
    [*] exec: ifconfig 
    
    <snipped ifconfig output>
```

The output format is copy pasteable into an rc file (thanks for the idea egypt), and the plugin exposes the aliases method so the framework or other plugins can get the list of active plugins by calling pluginobj.aliases.  Useful if we want to add the aliases to what gets saved using the save command etc.

Basically anything can be aliased, even shell commands, and using -f to force for overriding, except a few safe "words" like 'alias', 'rm -rf' and msfconsole etc. An alias can't have the name alias otherwise a user could end up in a state where one cannot unalias an overaliased core command like 'set'.

Aliases will tab complete, and the alias command will tab complete with any loaded command or current alias (you can also alias an alias)

This is super handy (see http://pastebin.com/rrS06amv) and can even be used to "translate" msfconsole commands into other (ASCII-based) languages (see http://pastebin.com/tMYWwSGH)
