### PR TITLE
Fix fastlib on 1.8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ rvm:
   - '1.8.7'
   - '1.9.3'
 
-matrix:
-  allow_failures:
-    - rvm: '1.8.7'
-
 notifications:
   irc: "irc.freenode.org#msfnotify"
 

--- a/lib/fastlib.rb
+++ b/lib/fastlib.rb
@@ -204,7 +204,7 @@ class FastLib
 		}
 		
 		dirs.each do |dir|
-			::Find.find(dir).each do |path|
+			::Find.find(dir) do |path|
 				next if not ::File.file?(path)
 				name = fastlib_filter_encode( lib, path.sub( brex, "" ) )
 				

--- a/lib/fastlib.rb
+++ b/lib/fastlib.rb
@@ -8,7 +8,7 @@
 #
 
 #
-# This format was specifically created to improve the performance and 
+# This format was specifically created to improve the performance and
 # AV-resistance of the Metasploit Framework and Rex libraries.
 #
 
@@ -26,7 +26,7 @@ require "find"
 # Copyright (C) 2011 Rapid7. You can redistribute it and/or
 # modify it under the terms of the ruby license.
 #
-# 
+#
 # Roughly based on the rubyzip zip/ziprequire library:
 # 	>> Copyright (C) 2002 Thomas Sondergaard
 # 	>> rubyzip is free software; you can redistribute it and/or
@@ -42,10 +42,10 @@ class FastLib
 
 	FLAG_COMPRESS = 0x01
 	FLAG_ENCRYPT  = 0x02
-	
+
 	@@cache = {}
 	@@has_zlib = false
-	
+
 	#
 	# Load zlib support if possible
 	#
@@ -54,16 +54,16 @@ class FastLib
 		@@has_zlib = true
 	rescue ::LoadError
 	end
-	
+
 	#
 	# This method returns the version of the fastlib library
 	#
 	def self.version
 		VERSION
 	end
-	
+
 	#
-	# This method loads content from a specific archive file by name. If the 
+	# This method loads content from a specific archive file by name. If the
 	# noprocess argument is set to true, the contents will not be expanded to
 	# include workarounds for things such as __FILE__. This is useful when
 	# loading raw binary data where these strings may occur
@@ -72,55 +72,55 @@ class FastLib
 		data = ""
 		load_cache(lib)
 
-		return if not ( @@cache[lib] and @@cache[lib][name] )
-		
-		
+		return unless ( @@cache[lib] and @@cache[lib][name] )
+
+
 		::File.open(lib, "rb") do |fd|
 			fd.seek(
 				@@cache[lib][:fastlib_header][0] +
-				@@cache[lib][:fastlib_header][1] + 
+				@@cache[lib][:fastlib_header][1] +
 				@@cache[lib][name][0]
 			)
 			data = fastlib_filter_decode( lib, fd.read(@@cache[lib][name][1] ))
 		end
-		
+
 		# Return the contents in raw or processed form
 		noprocess ? data : post_process(lib, name, data)
 	end
-	
+
 	#
 	# This method caches the file list and offsets within the archive
 	#
 	def self.load_cache(lib)
 		return if @@cache[lib]
 		@@cache[lib] = {}
-		
+
 		return if not ::File.exists?(lib)
-				
+
 		::File.open(lib, 'rb') do |fd|
 			dict = {}
 			head = fd.read(4)
 			return if head != "FAST"
 			hlen = fd.read(4).unpack("N")[0]
-			flag = fd.read(4).unpack("N")[0]			
-		
+			flag = fd.read(4).unpack("N")[0]
+
 			@@cache[lib][:fastlib_header] = [12, hlen, fd.stat.mtime.utc.to_i ]
 			@@cache[lib][:fastlib_flags]  = flag
-			
+
 			nlen, doff, dlen, tims = fd.read(16).unpack("N*")
-			
+
 			while nlen > 0
 				name = fastlib_filter_decode( lib, fd.read(nlen) )
 				dict[name] = [doff, dlen, tims]
-				
+
 				nlen, doff, dlen, tims = fd.read(16).unpack("N*")
 			end
-			
+
 			@@cache[lib].merge!(dict)
 		end
-		
+
 	end
-	
+
 	#
 	# This method provides compression and encryption capabilities
 	# for the fastlib archive format.
@@ -128,7 +128,7 @@ class FastLib
 	def self.fastlib_filter_decode(lib, buff)
 
 		if (@@cache[lib][:fastlib_flags] & FLAG_ENCRYPT) != 0
-		
+
 			@@cache[lib][:fastlib_decrypt] ||= ::Proc.new do |data|
 				stub = "decrypt_%.8x" % ( @@cache[lib][:fastlib_flags] & 0xfffffff0 )
 				FastLib.send(stub, data)
@@ -136,7 +136,7 @@ class FastLib
 
 			buff = @@cache[lib][:fastlib_decrypt].call( buff )
 		end
-		
+
 		if (@@cache[lib][:fastlib_flags] & FLAG_COMPRESS) != 0
 			if not @@has_zlib
 				raise ::RuntimeError, "zlib is required to open this archive"
@@ -145,9 +145,9 @@ class FastLib
 			z = Zlib::Inflate.new
 			buff = z.inflate(buff)
 			buff << z.finish
-			z.close	
+			z.close
 		end
-		
+
 		buff
 	end
 
@@ -156,7 +156,7 @@ class FastLib
 	# for the fastlib archive format.
 	#
 	def self.fastlib_filter_encode(lib, buff)
-		
+
 		if (@@cache[lib][:fastlib_flags] & FLAG_COMPRESS) != 0
 			if not @@has_zlib
 				raise ::RuntimeError, "zlib is required to open this archive"
@@ -165,11 +165,11 @@ class FastLib
 			z = Zlib::Deflate.new
 			buff = z.deflate(buff)
 			buff << z.finish
-			z.close	
+			z.close
 		end
 
 		if (@@cache[lib][:fastlib_flags] & FLAG_ENCRYPT) != 0
-		
+
 			@@cache[lib][:fastlib_encrypt] ||= ::Proc.new do |data|
 				stub = "encrypt_%.8x" % ( @@cache[lib][:fastlib_flags] & 0xfffffff0 )
 				FastLib.send(stub, data)
@@ -177,7 +177,7 @@ class FastLib
 
 			buff = @@cache[lib][:fastlib_encrypt].call( buff )
 		end
-		
+
 		buff
 	end
 
@@ -185,54 +185,57 @@ class FastLib
 	# This method provides a way to create a FASTLIB archive programatically.
 	#
 	# @param [String] lib the output path for the archive
-	# @param [String] flag a string containing the hex values for the flags ({FLAG_COMPRESS} and {FLAG_ENCRYPT}).
-	# @param [String] bdir the path to the base directory which will be stripped from all paths included in the archive
-	# @param [Array<String>] dirs list of directories/files to pack into the archive.  All dirs should be under bdir so
-	#   that the paths are stripped correctly.
+	# @param [String] flag a string containing the hex values for the
+	#   flags ({FLAG_COMPRESS} and {FLAG_ENCRYPT}).
+	# @param [String] bdir the path to the base directory which will be
+	#   stripped from all paths included in the archive
+	# @param [Array<String>] dirs list of directories/files to pack into
+	#   the archive.  All dirs should be under bdir so that the paths are
+	#   stripped correctly.
 	# @return [void]
 	def self.dump(lib, flag, bdir, *dirs)
 		head = ""
 		data = ""
 		hidx = 0
 		didx = 0
-		
+
 		bdir = bdir.gsub(/\/$/, '')
 		brex = /^#{Regexp.escape(bdir)}\//
-		
+
 		@@cache[lib] = {
 			:fastlib_flags => flag.to_i(16)
 		}
-		
+
 		dirs.each do |dir|
 			::Find.find(dir) do |path|
 				next if not ::File.file?(path)
 				name = fastlib_filter_encode( lib, path.sub( brex, "" ) )
-				
+
 				buff = ""
 				::File.open(path, "rb") do |fd|
 					buff = fastlib_filter_encode(lib, fd.read(fd.stat.size))
 				end
-				
+
 
 				head << [ name.length, didx, buff.length, ::File.stat(path).mtime.utc.to_i ].pack("NNNN")
 				head << name
 				hidx = hidx + 16 + name.length
-			
+
 				data << buff
 				didx = didx + buff.length
 			end
 		end
-		
+
 		head << [0,0,0].pack("NNN")
-		
+
 		::File.open(lib, "wb") do |fd|
 			fd.write("FAST")
 			fd.write( [ head.length, flag.to_i(16) ].pack("NN") )
 			fd.write( head )
 			fd.write( data )
-		end	
+		end
 	end
-	
+
 	#
 	# This archive provides a way to list the contents of an archive
 	# file, returning the names only in sorted order.
@@ -241,7 +244,7 @@ class FastLib
 		load_cache(lib)
 		( @@cache[lib] || {} ).keys.map{|x| x.to_s }.sort.select{ |x| @@cache[lib][x] }
 	end
-	
+
 	#
 	# This method is called on the loaded is required to expand __FILE__
 	# and other inline dynamic constants to map to the correct location.
@@ -249,7 +252,7 @@ class FastLib
 	def self.post_process(lib, name, data)
 		data.gsub('__FILE__', "'#{ ::File.expand_path(::File.join(::File.dirname(lib), name)) }'")
 	end
-	
+
 	#
 	# This is a stub crypto handler that performs a basic XOR
 	# operation against a fixed one byte key. The two usable IDs
@@ -258,25 +261,25 @@ class FastLib
 	def self.encrypt_12345600(data)
 		encrypt_00000000(data)
 	end
-	
+
 	def self.decrypt_12345600(data)
 		encrypt_00000000(data)
 	end
-	
+
 	def self.encrypt_00000000(data)
 		data.unpack("C*").map{ |c| c ^ 0x90 }.pack("C*")
 	end
-	
+
 	def self.decrypt_00000000(data)
 		encrypt_00000000(data)
 	end
-		
+
 	#
 	# Expose the cache to callers
 	#
 	def self.cache
 		@@cache
-	end	
+	end
 end
 
 
@@ -290,7 +293,7 @@ if __FILE__ == $0
 		$stderr.puts "Usage: #{$0} [dump|list|version] <arguments>"
 		exit(0)
 	end
-	
+
 	case cmd
 	when "store"
 		dst = ARGV.shift
@@ -302,7 +305,7 @@ if __FILE__ == $0
 			exit(0)
 		end
 		FastLib.dump(dst, flg, dir, *src)
-	
+
 	when "list"
 		src = ARGV.shift
 		unless src
@@ -321,7 +324,7 @@ if __FILE__ == $0
 	when "version"
 		$stdout.puts "FastLib Version #{FastLib.version}"
 	end
-	
+
 	exit(0)
 end
 
@@ -338,7 +341,7 @@ end
 	* The header entries always consist of 16 bytes + name length (no alignment)
 	* The header name data may be encoded, compressed, or transformed
 	* The data entries may be encoded, compressed, or transformed too
-	
+
 
 	4 bytes: "FAST"
 	4 bytes: NBO header length
@@ -356,7 +359,7 @@ end
 
 module Kernel #:nodoc:all
 	alias :fastlib_original_require :require
-	
+
 	#
 	# Store the CWD when were initially loaded
 	# required for resolving relative paths
@@ -366,11 +369,11 @@ module Kernel #:nodoc:all
 	#
 	# This method hooks the original Kernel.require to support
 	# loading files within FASTLIB archives
-	#	
+	#
 	def require(name)
 		fastlib_require(name) || fastlib_original_require(name)
 	end
-	
+
 	#
 	# This method handles the loading of FASTLIB archives
 	#
@@ -379,24 +382,24 @@ module Kernel #:nodoc:all
 		return false if fastlib_already_loaded?(name)
 		return false if fastlib_already_tried?(name)
 
-		# XXX Implement relative search paths within archives 
-		$:.map{ |path| 
+		# XXX Implement relative search paths within archives
+		$:.map{ |path|
 			(path =~ /^([A-Za-z]\:|\/)/ ) ? path : ::File.expand_path( ::File.join(@@fastlib_base_cwd, path) )
 		}.map{  |path| ::Dir["#{path}/*.fastlib"] }.flatten.uniq.each do |lib|
 			data = FastLib.load(lib, name)
 			next if not data
 			$" << name
-			
+
 			Object.class_eval(data, lib + "::" + name)
 
 			return true
 		end
-		
-		$fastlib_miss << name 	
+
+		$fastlib_miss << name
 
 		false
 	end
-	
+
 	#
 	# This method determines whether the specific file name
 	# has already been loaded ($LOADED_FEATURES aka $")
@@ -414,11 +417,11 @@ module Kernel #:nodoc:all
 	# TODO: Ensure that this only applies to known FASTLIB
 	#       archives and that newly included archives will
 	#       be searched appropriately.
-	#	
+	#
 	def fastlib_already_tried?(name)
 		$fastlib_miss ||= []
 		$fastlib_miss.include?(name)
-	end	
+	end
 end
 
 

--- a/spec/lib/msf/core/task_manager_spec.rb
+++ b/spec/lib/msf/core/task_manager_spec.rb
@@ -1,4 +1,5 @@
 
+require 'msf/core'
 require 'msf/core/task_manager'
 
 describe Msf::TaskManager do
@@ -87,11 +88,11 @@ describe Msf::TaskManager do
     t.status.should == :dropped
     t.exception.class.should == ::NoMethodError
 
-    t = Msf::TaskManager::Task.new(Proc.new { return 12345 })
+    t = Msf::TaskManager::Task.new(Proc.new { eval "'" })
     tm.queue_task(t)
     t.wait
     t.status.should == :dropped
-    t.exception.should be_a ::LocalJumpError
+    t.exception.should be_a ::SyntaxError
   end
 end
 


### PR DESCRIPTION
::File.find did not return an Enumerable when not given a block in
1.8.7; instead it un-idiomatically just raised an exception.  The
solution is just to give the block directly to .find instead of trying
to call #each on its return value.
