### PR TITLE
Make error handling consistent in SNMP modules

### DIFF
--- a/modules/auxiliary/scanner/misc/oki_scanner.rb
+++ b/modules/auxiliary/scanner/misc/oki_scanner.rb
@@ -106,7 +106,7 @@ class Metasploit3 < Msf::Auxiliary
 		rescue ::Interrupt
 			raise $!
 		rescue ::Exception => e
-			print_error("#{ip} Error: #{e.class} #{e} #{e.backtrace}"
+			print_error("#{ip} Error: #{e.class} #{e} #{e.backtrace}")
 		ensure
 			disconnect_snmp
 		end

--- a/modules/auxiliary/scanner/misc/oki_scanner.rb
+++ b/modules/auxiliary/scanner/misc/oki_scanner.rb
@@ -101,13 +101,13 @@ class Metasploit3 < Msf::Auxiliary
 			end
 		end
 
-		disconnect_snmp()
-
-		rescue SNMP::RequestTimeout
-			print_status("#{ip}, SNMP request timeout.")
+		# No need to make noise about timeouts
+		rescue ::Rex::ConnectionError, ::SNMP::RequestTimeout, ::SNMP::UnsupportedVersion
 		rescue ::Interrupt
 			raise $!
 		rescue ::Exception => e
-			print_status("Unknown error: #{e.class} #{e}")
+			print_error("#{ip} Error: #{e.class} #{e} #{e.backtrace}"
+		ensure
+			disconnect_snmp
 		end
 end

--- a/modules/auxiliary/scanner/snmp/aix_version.rb
+++ b/modules/auxiliary/scanner/snmp/aix_version.rb
@@ -69,8 +69,11 @@ class Metasploit3 < Msf::Auxiliary
 
 				print_status(status)
 			end
-			disconnect_snmp
-		rescue SNMP::RequestTimeout, Rex::ConnectionError, ::Errno::ECONNREFUSED
+
+		# No need to make noise about timeouts
+		rescue ::Rex::ConnectionError, ::SNMP::RequestTimeout, ::SNMP::UnsupportedVersion
+		rescue ::Interrupt
+			raise $!
 		rescue Exception => e
 			print_error("#{ip} #{e.class}, #{e.message}")
 		ensure

--- a/modules/auxiliary/scanner/snmp/cisco_config_tftp.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_config_tftp.rb
@@ -153,14 +153,14 @@ class Metasploit3 < Msf::Auxiliary
 			varbind = SNMP::VarBind.new("#{cccopyentryrowstatus}#{session}", SNMP::Integer.new(6))
 			value = snmp.set(varbind)
 
-			disconnect_snmp
-
 		# No need to make noise about timeouts
-		rescue ::SNMP::RequestTimeout, ::Rex::ConnectionRefused
+		rescue ::Rex::ConnectionError, ::SNMP::RequestTimeout, ::SNMP::UnsupportedVersion
 		rescue ::Interrupt
 			raise $!
 		rescue ::Exception => e
 			print_error("#{ip} Error: #{e.class} #{e} #{e.backtrace}")
+		ensure
+			disconnect_snmp
 		end
 	end
 

--- a/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
@@ -127,14 +127,16 @@ class Metasploit3 < Msf::Auxiliary
 			varbind = SNMP::VarBind.new("#{ciscoFlashCopyEntryStatus}#{session}" , SNMP::Integer.new(1))
 			value = snmp.set(varbind)
 
-			disconnect_snmp
+
 
 		# No need to make noise about timeouts
-		rescue ::SNMP::RequestTimeout, ::Rex::ConnectionRefused
+		rescue ::Rex::ConnectionError, ::SNMP::RequestTimeout, ::SNMP::UnsupportedVersion
 		rescue ::Interrupt
 			raise $!
 		rescue ::Exception => e
 			print_error("#{ip} Error: #{e.class} #{e} #{e.backtrace}")
+		ensure
+			disconnect_snmp
 		end
 	end
 

--- a/modules/auxiliary/scanner/snmp/snmp_enum.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enum.rb
@@ -951,20 +951,22 @@ class Metasploit3 < Msf::Auxiliary
 
 			print_line('')
 
-			disconnect_snmp
+
 
 		rescue SNMP::RequestTimeout
-			vprint_status("#{ip}, SNMP request timeout.")
-		rescue Errno::ECONNREFUSED
-			print_status("#{ip}, Connection refused.")
+			vprint_status("#{ip} SNMP request timeout.")
+		rescue Rex::ConnectionError
+			print_status("#{ip} Connection refused.")
 		rescue SNMP::InvalidIpAddress
-			print_status("#{ip}, Invalid Ip Address. Check it with 'snmpwalk tool'.")
+			print_status("#{ip} Invalid IP Address. Check it with 'snmpwalk tool'.")
 		rescue SNMP::UnsupportedVersion
-			print_status("Unsupported SNMP version specified. Select from '1' or '2c'.")
+			print_status("#{ip} Unsupported SNMP version specified. Select from '1' or '2c'.")
 		rescue ::Interrupt
 			raise $!
 		rescue ::Exception => e
 			print_status("Unknown error: #{e.class} #{e}")
+		ensure
+			disconnect_snmp
 		end
 	end
 

--- a/modules/auxiliary/scanner/snmp/snmp_enumshares.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enumshares.rb
@@ -59,12 +59,13 @@ class Metasploit3 < Msf::Auxiliary
 				)
 			end
 
-		rescue ::SNMP::UnsupportedVersion
-		rescue ::SNMP::RequestTimeout
+		rescue ::Rex::ConnectionError, ::SNMP::RequestTimeout, ::SNMP::UnsupportedVersion
 		rescue ::Interrupt
 			raise $!
 		rescue ::Exception => e
-			print_error("Unknown error: #{e.class} #{e}")
+			print_error("#{ip} Unknown error: #{e.class} #{e}")
+		ensure
+			disconnect_snmp
 		end
 
 	end

--- a/modules/auxiliary/scanner/snmp/snmp_set.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_set.rb
@@ -84,11 +84,9 @@ class Metasploit3 < Msf::Auxiliary
 				print_status("#{ip} - OID not writable or does not provide WRITE access with community '#{comm}'")
 			end
 
-			disconnect_snmp
-
 		rescue ::SNMP::RequestTimeout
 			print_error("#{ip} - SNMP request timeout with community '#{comm}'.")
-		rescue ::Rex::ConnectionRefused
+		rescue ::Rex::ConnectionError
 			print_error("#{ip} - 'Connection Refused'")
 		rescue SNMP::UnsupportedVersion
 			print_error("#{ip} - Unsupported SNMP version specified. Select from '1' or '2c'.")
@@ -96,6 +94,8 @@ class Metasploit3 < Msf::Auxiliary
 			raise $!
 		rescue ::Exception => e
 			print_error("#{ip} Error: #{e.class} #{e} #{e.backtrace}")
+		ensure
+			disconnect_snmp
 		end
 	end
 

--- a/modules/auxiliary/scanner/snmp/xerox_workcentre_enumusers.rb
+++ b/modules/auxiliary/scanner/snmp/xerox_workcentre_enumusers.rb
@@ -58,16 +58,14 @@ class Metasploit3 < Msf::Auxiliary
 				end
 			end
 
-			disconnect_snmp
-
 		# No need to make noise about timeouts
-		rescue ::SNMP::UnsupportedVersion
-		rescue ::SNMP::RequestTimeout
-		rescue ::Rex::ConnectionRefused
+		rescue ::Rex::ConnectionError, ::SNMP::RequestTimeout, ::SNMP::UnsupportedVersion
 		rescue ::Interrupt
 			raise $!
 		rescue ::Exception => e
 			print_error("#{ip} Error: #{e.class} #{e} #{e.backtrace}")
+		ensure
+			disconnect_snmp
 		end
 	end
 end


### PR DESCRIPTION
The Net-SNMP class and its usage have other problems, but this fixes a series of bugs that can prevent the modules from working if an unhandled error is thrown early.
