### PR TITLE
The 'Set-Cookie' header should be checked before accessing it

### DIFF
--- a/modules/exploits/multi/http/splunk_mappy_exec.rb
+++ b/modules/exploits/multi/http/splunk_mappy_exec.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				To exploit this vulnerability, a valid Splunk user with the admin
 				role is required. By default, this module uses the credential of "admin:changeme",
 				the default Administrator credential for Splunk. Note that the Splunk web interface
-				runs as SYSTEM on Windows and as root	on Linux by default.
+				runs as SYSTEM on Windows and as root on Linux by default.
 			},
 			'Author'         =>
 				[
@@ -125,7 +125,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		uid = ''
 		session_id_port =
 		session_id = ''
-		if res and res.code == 200
+		if res and res.code == 200 and res.headers['Set-Cookie']
 			res.headers['Set-Cookie'].split(';').each {|c|
 				c.split(',').each {|v|
 					if v.split('=')[0] =~ /cval/
@@ -146,7 +146,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		{
 			'uri'     => '/en-US/account/login',
 			'method'  => 'POST',
-			'cookie'	=> "uid=#{uid}; #{session_id_port}=#{session_id}; cval=#{cval}",
+			'cookie'  => "uid=#{uid}; #{session_id_port}=#{session_id}; cval=#{cval}",
 			'vars_post' =>
 				{
 					'cval' => cval,


### PR DESCRIPTION
Verified by egypt about the possibility of a header being nil if not actually assigned.  That condition should be checked before using it.
