### PR TITLE
Fixed bugs in filezilla and migrate modules, and added retry code to smart_hashdump.

### DIFF
--- a/modules/post/windows/gather/credentials/filezilla_server.rb
+++ b/modules/post/windows/gather/credentials/filezilla_server.rb
@@ -186,26 +186,32 @@ class Metasploit3 < Msf::Post
 
 		configuration << [config['ftp_port'], config['ftp_bindip'], config['admin_port'], config['admin_bindip'], config['admin_pass'],
 			config['ssl'], config['ssl_certfile'], config['ssl_keypass']]
-			if session.db_record
-				source_id = session.db_record.id
-			else
-				source_id = nil
-			end
-			# report the goods!
-			report_auth_info(
-				:host  => session,
-				:port => config['admin_port'],
-				:sname => 'filezilla-admin',
-				:proto => 'tcp',
-				:user => 'admin',
-				:pass => config['admin_pass'],
-				:type => "password",
-				:source_id => source_id,
-				:source_type => "exploit",
-				:target_host => config['admin_bindip'],
-				:target_port => config['admin_port']
-			)
-
+		if session.db_record
+			source_id = session.db_record.id
+		else
+			source_id = nil
+		end
+		# report the goods!
+		if config['admin_port'] == "<none>"
+		  #if report_auth_info executes with admin_port equal to "<none>"
+		  #the module will crash with an error.
+		  vprint_status("(No admin information found.)")
+		else
+		  report_auth_info(
+			  :host  => session.sock.peerhost,
+			  :port => config['admin_port'],
+			  :sname => 'filezilla-admin',
+			  :proto => 'tcp',
+			  :user => 'admin',
+			  :pass => config['admin_pass'],
+			  :type => "password",
+			  :source_id => source_id,
+			  :source_type => "exploit",
+			  :target_host => config['admin_bindip'],
+			  :target_port => config['admin_port']
+		  )
+		end
+    
 		p = store_loot("filezilla.server.creds", "text/csv", session, credentials.to_csv,
 			"filezilla_server_credentials.csv", "FileZilla FTP Server Credentials")
 

--- a/modules/post/windows/gather/credentials/filezilla_server.rb
+++ b/modules/post/windows/gather/credentials/filezilla_server.rb
@@ -193,25 +193,25 @@ class Metasploit3 < Msf::Post
 		end
 		# report the goods!
 		if config['admin_port'] == "<none>"
-		  #if report_auth_info executes with admin_port equal to "<none>"
-		  #the module will crash with an error.
-		  vprint_status("(No admin information found.)")
+			#if report_auth_info executes with admin_port equal to "<none>"
+			#the module will crash with an error.
+			vprint_status("(No admin information found.)")
 		else
-		  report_auth_info(
-			  :host  => session.sock.peerhost,
-			  :port => config['admin_port'],
-			  :sname => 'filezilla-admin',
-			  :proto => 'tcp',
-			  :user => 'admin',
-			  :pass => config['admin_pass'],
-			  :type => "password",
-			  :source_id => source_id,
-			  :source_type => "exploit",
-			  :target_host => config['admin_bindip'],
-			  :target_port => config['admin_port']
-		  )
+			report_auth_info(
+				:host  => session.sock.peerhost,
+				:port => config['admin_port'],
+				:sname => 'filezilla-admin',
+				:proto => 'tcp',
+				:user => 'admin',
+				:pass => config['admin_pass'],
+				:type => "password",
+				:source_id => source_id,
+				:source_type => "exploit",
+				:target_host => config['admin_bindip'],
+				:target_port => config['admin_port']
+			)
 		end
-    
+		
 		p = store_loot("filezilla.server.creds", "text/csv", session, credentials.to_csv,
 			"filezilla_server_credentials.csv", "FileZilla FTP Server Credentials")
 

--- a/modules/post/windows/gather/smart_hashdump.rb
+++ b/modules/post/windows/gather/smart_hashdump.rb
@@ -289,6 +289,8 @@ class Metasploit3 < Msf::Post
 	def read_hashdump
 		host,port = session.session_host, session.session_port
 		collected_hashes = ""
+		tries = 0
+		
 		begin
 
 			print_status("\tObtaining the boot key...")
@@ -333,9 +335,20 @@ class Metasploit3 < Msf::Post
 
 		rescue ::Interrupt
 			raise $!
-		rescue ::Rex::Post::Meterpreter::RequestError => e
-			print_error("Meterpreter Exception: #{e.class} #{e}")
-			print_error("This module requires the use of a SYSTEM user context (hint: migrate into service process)")
+		rescue ::Rex::Post::Meterpreter::RequestError => e		
+			# Sometimes we get this invalid handle race condition.
+			# So let's retry a couple of times before giving up.
+			# See bug #6815
+			if tries < 5 and e.to_s =~ /The handle is invalid/
+				print_status("Handle is invalid, retrying...")
+				tries += 1
+				retry
+
+			else
+				print_error("Meterpreter Exception: #{e.class} #{e}")
+				print_error("This script requires the use of a SYSTEM user context (hint: migrate into service process)")
+			end
+			
 		rescue ::Exception => e
 			print_error("Error: #{e.class} #{e} #{e.backtrace}")
 		end

--- a/modules/post/windows/manage/migrate.rb
+++ b/modules/post/windows/manage/migrate.rb
@@ -44,14 +44,14 @@ class Metasploit3 < Msf::Post
 		print_status("Current server process: #{server.name} (#{server.pid})")
 
 		target_pid = nil
-
+    
 		if datastore['SPAWN']
 			print_status("Spawning notepad.exe process to migrate to")
 			target_pid = create_temp_proc
-		elsif datastore['PID']
+		elsif datastore['PID'] != 0
 			target_pid = datastore['PID']
 		elsif datastore['NAME']
-			target_pid = session.sys.process[datstore['NAME']]
+			target_pid = session.sys.process[datastore['NAME']]
 		end
 
 		if not target_pid

--- a/modules/post/windows/manage/migrate.rb
+++ b/modules/post/windows/manage/migrate.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Post
 		print_status("Current server process: #{server.name} (#{server.pid})")
 
 		target_pid = nil
-    
+		
 		if datastore['SPAWN']
 			print_status("Spawning notepad.exe process to migrate to")
 			target_pid = create_temp_proc


### PR DESCRIPTION
filezilla_server.rb would crash if there was no admin information found.
In smart_hashdump.rb I replicated the changes made in hashdump.rb to handle the race condition. (It works, but is still not as reliable as regular hashdump for XP boxes)
In migrate.rb the option PID is an integer, and the line "elseif datastore['PID']" was evaluating as true, even though PID was set to "".  There was also a misspelling of datastore as "datstore" that I fixed.
