### PR TITLE
Several fixes for smb, mainly win 8 compatibility

### DIFF
--- a/lib/rex/proto/smb/client.rb
+++ b/lib/rex/proto/smb/client.rb
@@ -1046,6 +1046,7 @@ NTLM_UTILS = Rex::Proto::NTLM::Utils
 
 		pkt = CONST::SMB_TREE_CONN_PKT.make_struct
 		self.smb_defaults(pkt['Payload']['SMB'])
+		pkt['Payload']['SMB'].v['TreeID'] = 0
 
 		pkt['Payload']['SMB'].v['Command'] = CONST::SMB_COM_TREE_CONNECT_ANDX
 		pkt['Payload']['SMB'].v['Flags1'] = 0x18

--- a/modules/auxiliary/admin/smb/list_directory.rb
+++ b/modules/auxiliary/admin/smb/list_directory.rb
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Auxiliary
 			connect()
 			smb_login()
 			print_status("Mounting the remote share \\\\#{datastore['RHOST']}\\#{datastore['SMBSHARE']}'...")
-						self.simple.connect("#{datastore['SMBSHARE']}")
+						self.simple.connect("\\\\#{datastore['RHOST']}\\#{datastore['SMBSHARE']}")
 			if datastore['RPATH']
 				print_status("Listing \\\\#{datastore['RHOST']}\\#{datastore['SMBSHARE']}\\#{datastore['RPATH']}'...")
 			end

--- a/modules/auxiliary/admin/smb/psexec_command.rb
+++ b/modules/auxiliary/admin/smb/psexec_command.rb
@@ -83,7 +83,7 @@ class Metasploit3 < Msf::Auxiliary
 			execute = "%COMSPEC% /C echo #{datastore['COMMAND']} ^> %SYSTEMDRIVE%#{text} > #{bat} & %COMSPEC% /C start cmd.exe /C #{bat}"
 			print_status("#{peer} - Executing the command...")
 			return psexec(execute)
-		rescue StandardError => exec_command_cerror
+		rescue StandardError => exec_command_error
 			print_error("#{peer} - Unable to execute specified command: #{exec_command_error}")
 			return false
 		end
@@ -149,7 +149,7 @@ class Metasploit3 < Msf::Auxiliary
 	# Instead of uploading and runing a binary.  This method runs a single windows command fed into the COMMAND paramater
 	def psexec(command)
 
-		simple.connect("IPC$")
+		simple.connect("\\\\#{datastore['RHOST']}\\IPC$")
 
 		handle = dcerpc_handle('367abb81-9844-35f1-ad32-98f038001003', '2.0', 'ncacn_np', ["\\svcctl"])
 		vprint_status("#{peer} - Binding to #{handle} ...")

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -107,7 +107,7 @@ class Metasploit3 < Msf::Auxiliary
 
 	def srvsvc_netshareenum
 
-		simple.connect("IPC$")
+		simple.connect("\\\\#{rhost}\\IPC$")
 		handle = dcerpc_handle('4b324fc8-1670-01d3-1278-5a47bf6ee188', '3.0', 'ncacn_np', ["\\srvsvc"])
 		begin
 			dcerpc_bind(handle)

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -172,11 +172,11 @@ class Metasploit3 < Msf::Exploit::Remote
 				folder_list = smbshare.split(/[\\\/]/)
 				smbshare = folder_list[0]
 				fileprefix = folder_list[1..-1].map {|a| a + "\\"}.join.gsub(/\\$/,"") if folder_list.length > 1
-				simple.connect(smbshare)
+				simple.connect("\\\\#{datastore['RHOST']}\\#{smbshare}")
 				fd = smb_open("\\#{fileprefix}\\#{filename}", 'rwct')
 			else
 				subfolder = false
-				simple.connect(smbshare)
+				simple.connect("\\\\#{datastore['RHOST']}\\#{smbshare}")
 				fd = smb_open("\\#{filename}", 'rwct')
 			end
 			exe = ''
@@ -196,10 +196,9 @@ class Metasploit3 < Msf::Exploit::Remote
 			end
 
 			# Disconnect from the share
-			simple.disconnect(smbshare)
-
+			simple.disconnect("\\\\#{datastore['RHOST']}\\#{smbshare}")
 			# Connect to the IPC service
-			simple.connect("IPC$")
+			simple.connect("\\\\#{datastore['RHOST']}\\IPC$")
 
 
 			# Bind to the service
@@ -350,10 +349,10 @@ class Metasploit3 < Msf::Exploit::Remote
 			select(nil, nil, nil, 1.0)
 			#This is not really useful but will prevent double \\ on the wire :)
 			if datastore['SHARE'] =~ /.[\\\/]/
-				simple.connect(smbshare)
+				simple.connect("\\\\#{datastore['RHOST']}\\#{smbshare}")
 				simple.delete("\\#{fileprefix}\\#{filename}")
 			else
-				simple.connect(smbshare)
+				simple.connect("\\\\#{datastore['RHOST']}\\#{smbshare}")
 				simple.delete("\\#{filename}")
 			end
 


### PR DESCRIPTION
Correct some bugs in the way tree_connect is called in psexec, list_directory,  and smb_enumshares modules.

This keeps compatibility with all version of windows and prevent win 8 to send SMB_DUPLICATE_NAME error .
