### PR TITLE
Don't set BUNDLE_GEMFILE env var if already set

### DIFF
--- a/lib/msfenv.rb
+++ b/lib/msfenv.rb
@@ -22,7 +22,7 @@ end
 if not _msf_gemcache
 	# The user is running outside of the installer environment and not using
 	# our bundled gemset, so we fallback on bundler instead
-	ENV['BUNDLE_GEMFILE'] = ::File.expand_path(::File.join(::File.dirname(__FILE__), "..", "Gemfile"))
+	ENV['BUNDLE_GEMFILE'] ||= ::File.expand_path(::File.join(::File.dirname(__FILE__), "..", "Gemfile"))
 	begin
 		require 'bundler/setup'
 	rescue ::LoadError


### PR DESCRIPTION
This allows setting BUNDLE_GEMFILE with `bundle exec` or some other
command in special cases.
