### PR TITLE
Added HSTS scanner for HTTPS sites

### DIFF
--- a/modules/auxiliary/scanner/http/http_hsts.rb
+++ b/modules/auxiliary/scanner/http/http_hsts.rb
@@ -1,0 +1,45 @@
+require 'rex/proto/http'
+require 'msf/core'
+
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Auxiliary::Scanner
+
+	def initialize
+		super(
+			'Name'        => 'HTTP HSTS Detection',
+			'Version'     => '$Revision$',
+			'Description' => 'Display HTTP Strict Transport Security (HSTS) information about each system.',
+			'Author'      => 'Matt "hostess" Andreko <mandreko@accuvant.com>',
+			'License'     => MSF_LICENSE
+		)
+
+		register_options([
+				OptBool.new('SSL', [ true, "Negotiate SSL for outgoing connections", true]),
+				OptInt.new('RPORT', [true, "The target port", 443]),
+			])
+	end
+
+	def run_host(ip)
+		begin
+			connect
+
+			res = send_request_cgi({
+				'uri'	=>	'/',
+				'method'	=>	'GET',
+				}, 25)
+			return if not res
+
+			if res.headers['Strict-Transport-Security']
+				print_good("#{ip}:#{rport} Strict-Transport-Security:#{res.headers['Strict-Transport-Security']}")
+			else
+				print_error("#{ip}:#{rport} No HSTS found.")
+			end
+
+		rescue ::Timeout::Error, ::Errno::EPIPE
+		end
+	end
+
+end

--- a/modules/auxiliary/scanner/http/http_hsts.rb
+++ b/modules/auxiliary/scanner/http/http_hsts.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options([
 				OptBool.new('SSL', [ true, "Negotiate SSL for outgoing connections", true]),
-				OptInt.new('RPORT', [true, "The target port", 443]),
+				Opt::RPORT(443)
 			])
 	end
 


### PR DESCRIPTION
In doing pentests, I find it quite useful to be able to report on if sites have HSTS enabled on their webservers.  This simple module scans for the HTTP header and reports back if it's found or not.
