### PR TITLE
Add specs for Opt* classes

### DIFF
--- a/spec/lib/msf/core/data_store_spec.rb
+++ b/spec/lib/msf/core/data_store_spec.rb
@@ -1,0 +1,45 @@
+
+require 'spec_helper'
+require 'msf/core/data_store'
+
+shared_examples "datastore" do
+	it "should have options" do
+		subject["foo"].should == "bar"
+		subject["fizz"].should == "buzz"
+	end
+	it "should have case-insensitive keys" do
+		# Sorted by gray code, just for fun
+		subject["foo"].should == "bar"
+		subject["Foo"].should == "bar"
+		subject["FOo"].should == "bar"
+		subject["fOo"].should == "bar"
+		subject["fOO"].should == "bar"
+		subject["FOO"].should == "bar"
+		subject["FoO"].should == "bar"
+		subject["foO"].should == "bar"
+	end
+end
+
+describe Msf::DataStore do
+
+	describe "#import_options_from_hash" do
+		subject do
+			hash = { "foo" => "bar", "fizz" => "buzz" }
+			s = described_class.new
+			s.import_options_from_hash(hash)
+			s
+		end
+		it_behaves_like "datastore"
+	end
+
+	describe "#import_options_from_s" do
+		subject do
+			str = "foo=bar fizz=buzz"
+			s = described_class.new
+			s.import_options_from_s(str)
+			s
+		end
+		it_behaves_like "datastore"
+	end
+
+end

--- a/spec/lib/msf/core/data_store_spec.rb
+++ b/spec/lib/msf/core/data_store_spec.rb
@@ -18,9 +18,24 @@ shared_examples "datastore" do
 		subject["FoO"].should == "bar"
 		subject["foO"].should == "bar"
 	end
+	context "#to_h" do
+		it "should return a Hash with correct values" do
+			subject.to_h.should == { "foo" => "bar", "fizz" => "buzz" }
+		end
+	end
 end
 
 describe Msf::DataStore do
+
+	describe "#import_option" do
+		subject do
+			s = described_class.new
+			s.import_option("foo", "bar")
+			s.import_option("fizz", "buzz")
+			s
+		end
+		it_behaves_like "datastore"
+	end
 
 	describe "#import_options_from_hash" do
 		subject do
@@ -41,5 +56,23 @@ describe Msf::DataStore do
 		end
 		it_behaves_like "datastore"
 	end
+
+	describe "#from_file" do
+		subject do
+			ini_instance = double
+			ini_instance.stub(:group?).and_return(true)
+			ini_instance.stub(:[]).and_return( { "foo" => "bar", "fizz" => "buzz" } )
+
+			ini = stub_const("Rex::Parser::Ini", Class.new)
+			ini.stub(:from_file).and_return(ini_instance)
+
+			s = described_class.new
+			s.from_file("path")
+			s
+		end
+
+		it_behaves_like "datastore"
+	end
+
 
 end

--- a/spec/lib/msf/core/option_container_spec.rb
+++ b/spec/lib/msf/core/option_container_spec.rb
@@ -1,0 +1,25 @@
+
+require 'spec_helper'
+require 'msf/core/option_container'
+
+describe Msf::OptionContainer do
+  it "should create new options for it's args" do
+    foo_inst = mock("foo_inst")
+    foo_inst.stub(:advanced=)
+    foo_inst.stub(:evasion=)
+    foo_inst.stub(:owner=)
+
+    foo_class = mock("opt_class")
+    foo_class.should_receive(:new).and_return(foo_inst)
+
+    foo_inst.should_receive(:name).and_return("thing")
+
+    subject = described_class.new({
+      'thing' => [ foo_class, true, nil, false ]
+    })
+    subject["thing"].should == foo_inst
+
+  end
+
+
+end

--- a/spec/lib/msf/core/options/opt_address_range_spec.rb
+++ b/spec/lib/msf/core/options/opt_address_range_spec.rb
@@ -1,0 +1,36 @@
+
+require 'spec_helper'
+require 'msf/core/option_container'
+
+describe Msf::OptAddressRange do
+	# Normalized values are just the original value for OptAddressRange
+	valid_values = [
+		"192.0.2.0/24",
+		"192.0.2.0-255",
+		"192.0.2.0,1-255",
+		"192.0.2.*",
+		"192.0.2.0-192.0.2.255",
+	].map{|a| [a, a]}
+	invalid_values = [
+		# Too many dots
+		"192.0.2.0.0",
+		"192.0.2.0.0,1",
+		"192.0.2.0.0,1-2",
+		# CIDR apparently doesn't validate before sending to addr_atoi
+		#"192.0.2.0.0/24",
+		# Not enough dots
+		"192.0.2",
+		"192.0.2,1",
+		"192.0.2,1-2",
+		# CIDR apparently doesn't validate before sending to addr_atoi
+		#"192.0.2/24", # Not enough dots, cidr
+		# Can't mix ranges and CIDR
+		"192.0.2.0,1/24",
+		"192.0.2.0-1/24",
+		"192.0.2.0,1-2/24",
+	]
+
+	it_behaves_like "an option", valid_values, invalid_values
+end
+
+

--- a/spec/lib/msf/core/options/opt_address_range_spec.rb
+++ b/spec/lib/msf/core/options/opt_address_range_spec.rb
@@ -5,29 +5,29 @@ require 'msf/core/option_container'
 describe Msf::OptAddressRange do
 	# Normalized values are just the original value for OptAddressRange
 	valid_values = [
-		"192.0.2.0/24",
-		"192.0.2.0-255",
-		"192.0.2.0,1-255",
-		"192.0.2.*",
-		"192.0.2.0-192.0.2.255",
-	].map{|a| [a, a]}
+		{ :value => "192.0.2.0/24",    :normalized => "192.0.2.0/24" },
+		{ :value => "192.0.2.0-255",   :normalized => "192.0.2.0-255" },
+		{ :value => "192.0.2.0,1-255", :normalized => "192.0.2.0,1-255" },
+		{ :value => "192.0.2.*",       :normalized => "192.0.2.*" },
+		{ :value => "192.0.2.0-192.0.2.255", :normalized => "192.0.2.0-192.0.2.255" },
+	]
 	invalid_values = [
 		# Too many dots
-		"192.0.2.0.0",
-		"192.0.2.0.0,1",
-		"192.0.2.0.0,1-2",
-		# CIDR apparently doesn't validate before sending to addr_atoi
-		#"192.0.2.0.0/24",
+		{ :value => "192.0.2.0.0" },
+		{ :value => "192.0.2.0.0,1" },
+		{ :value => "192.0.2.0.0,1-2" },
+		{ :pending => "Redmine #7536", :value => "192.0.2.0.0/24" },
 		# Not enough dots
-		"192.0.2",
-		"192.0.2,1",
-		"192.0.2,1-2",
-		# CIDR apparently doesn't validate before sending to addr_atoi
-		#"192.0.2/24", # Not enough dots, cidr
+		{ :value => "192.0.2" },
+		{ :value => "192.0.2,1" },
+		{ :value => "192.0.2,1-2" },
+		{ :pending => "Redmine #7536", :value => "192.0.2/24" },
 		# Can't mix ranges and CIDR
-		"192.0.2.0,1/24",
-		"192.0.2.0-1/24",
-		"192.0.2.0,1-2/24",
+		{ :value => "192.0.2.0,1/24" },
+		{ :value => "192.0.2.0-1/24" },
+		{ :value => "192.0.2.0,1-2/24" },
+		{ :value => "192.0.2.0/1-24" },
+		{ :value => "192.0.2.0-192.0.2.1-255", },
 	]
 
 	it_behaves_like "an option", valid_values, invalid_values

--- a/spec/lib/msf/core/options/opt_address_spec.rb
+++ b/spec/lib/msf/core/options/opt_address_spec.rb
@@ -1,0 +1,21 @@
+
+require 'spec_helper'
+require 'msf/core/option_container'
+
+describe Msf::OptAddress do
+	valid_values = [
+		"192.0.2.0", "127.0.0.1", "2001:db8::", "::1"
+	# Normalized values are just the original value
+	].map{|a| { :value => a, :normalized => a } }
+
+	invalid_values = [
+		# Too many dots
+		{ :value => "192.0.2.0.0" },
+		# Not enough
+    { :pending => "Redmine #7537", :value => "192.0.2" }
+	]
+
+	it_behaves_like "an option", valid_values, invalid_values
+end
+
+

--- a/spec/lib/msf/core/options/opt_bool_spec.rb
+++ b/spec/lib/msf/core/options/opt_bool_spec.rb
@@ -1,0 +1,19 @@
+
+require 'spec_helper'
+require 'msf/core/option_container'
+
+describe Msf::OptBool do
+  valid_values =
+    [
+      ["true",  true ],
+      ["yes",   true ],
+      ["1",     true ],
+      ["false", false],
+      ["no",    false],
+      ["0",     false],
+    ]
+  invalid_values =
+    [ "yer mom", "123", "012" ]
+  it_behaves_like "an option", valid_values, invalid_values
+end
+

--- a/spec/lib/msf/core/options/opt_bool_spec.rb
+++ b/spec/lib/msf/core/options/opt_bool_spec.rb
@@ -3,17 +3,19 @@ require 'spec_helper'
 require 'msf/core/option_container'
 
 describe Msf::OptBool do
-  valid_values =
-    [
-      ["true",  true ],
-      ["yes",   true ],
-      ["1",     true ],
-      ["false", false],
-      ["no",    false],
-      ["0",     false],
-    ]
-  invalid_values =
-    [ "yer mom", "123", "012" ]
+  valid_values = [
+    { :value => "true",  :normalized => true  },
+    { :value => "yes",   :normalized => true  },
+    { :value => "1",     :normalized => true  },
+    { :value => "false", :normalized => false },
+    { :value => "no",    :normalized => false },
+    { :value => "0",     :normalized => false },
+  ]
+  invalid_values = [
+    { :value => "yer mom" },
+    { :value => "012"     },
+    { :value => "123"     },
+  ]
   it_behaves_like "an option", valid_values, invalid_values
 end
 

--- a/spec/lib/msf/core/options/opt_int_spec.rb
+++ b/spec/lib/msf/core/options/opt_int_spec.rb
@@ -1,0 +1,19 @@
+
+require 'spec_helper'
+require 'msf/core/option_container'
+
+describe Msf::OptInt do
+  valid_values = [
+    "1", "10", "0", 
+    #"-1", # Negatives don't work
+  ].map{|v| [ v, v.to_i ] }
+  valid_values.push([ "0x10", 16 ])
+  invalid_values = [
+    #"yer mom", # to_i makes this 0
+    #"0.1", # to_i makes this 0
+  ]
+
+  it_behaves_like "an option", valid_values, invalid_values
+end
+
+

--- a/spec/lib/msf/core/options/opt_int_spec.rb
+++ b/spec/lib/msf/core/options/opt_int_spec.rb
@@ -4,13 +4,15 @@ require 'msf/core/option_container'
 
 describe Msf::OptInt do
   valid_values = [
-    "1", "10", "0", 
-    #"-1", # Negatives don't work
-  ].map{|v| [ v, v.to_i ] }
-  valid_values.push([ "0x10", 16 ])
+    { :value => "1",    :normalized => 1  },
+    { :value => "10",   :normalized => 10 },
+    { :value => "0",    :normalized => 0  },
+    { :value => "0x10", :normalized => 16 },
+    { :pending => "Redmine #7540", :value => "-1", :normalized => -1 }
+  ]
   invalid_values = [
-    #"yer mom", # to_i makes this 0
-    #"0.1", # to_i makes this 0
+    { :pending => "Redmine #7539", :value => "yer mom", },
+    { :pending => "Redmine #7539", :value => "0.1",     },
   ]
 
   it_behaves_like "an option", valid_values, invalid_values

--- a/spec/lib/msf/core/options/opt_path_spec.rb
+++ b/spec/lib/msf/core/options/opt_path_spec.rb
@@ -2,17 +2,16 @@
 require 'spec_helper'
 require 'msf/core/option_container'
 
-describe Msf::OptPort do
+describe Msf::OptPath do
   valid_values = [
-    { :pending => "Redmine #7535", :value => "0",    :normalized => 0     },
-    { :pending => "Redmine #7535", :value => "65536",:normalized => 65536 },
-    { :pending => "Redmine #7535", :value => "80",   :normalized => 80    },
+    { :value => __FILE__, :normalized => __FILE__   },
   ]
   invalid_values = [
     { :value => "yer mom", },
     { :value => "0.1",     },
     { :value => "-1",      },
     { :value => "65536",   },
+    { :value => "$",    },
   ]
 
   it_behaves_like "an option", valid_values, invalid_values

--- a/spec/lib/msf/core/options/opt_port_spec.rb
+++ b/spec/lib/msf/core/options/opt_port_spec.rb
@@ -8,7 +8,7 @@ describe Msf::OptPort do
 		# falls back to just returning the original value
 		[ v, v ]
 	}
-  invalid_values = [ "yer mom", "0.1", "-1" "65536" ]
+  invalid_values = [ "yer mom", "0.1", "-1", "65536" ]
 
   it_behaves_like "an option", valid_values, invalid_values
 end

--- a/spec/lib/msf/core/options/opt_port_spec.rb
+++ b/spec/lib/msf/core/options/opt_port_spec.rb
@@ -1,0 +1,15 @@
+
+require 'spec_helper'
+require 'msf/core/option_container'
+
+describe Msf::OptPort do
+  valid_values = [ "0",  "1", "80", "65535" ].map{|v|
+		# This is bogus, but OptPort doesn't implement #normalize, so it
+		# falls back to just returning the original value
+		[ v, v ]
+	}
+  invalid_values = [ "yer mom", "0.1", "-1" "65536" ]
+
+  it_behaves_like "an option", valid_values, invalid_values
+end
+

--- a/spec/support/shared/examples/options.rb
+++ b/spec/support/shared/examples/options.rb
@@ -5,18 +5,34 @@ shared_examples_for "an option" do |valid_values, invalid_values|
   end
 
   context "with valid values" do
-    valid_values.each do |valid_value, normalized_value|
+    valid_values.each do |vhash|
+			valid_value = vhash[:value]
+			normalized_value = vhash[:normalized]
+
       it "should be valid and normalize appropriately: #{valid_value}" do
-        subject.valid?(valid_value).should be_true
-        subject.normalize(valid_value).should == normalized_value
+				block = Proc.new {
+					subject.normalize(valid_value).should == normalized_value
+					subject.valid?(valid_value).should be_true
+				}
+				if vhash[:pending]
+					pending(vhash[:pending], &block)
+				else
+					block.call
+				end
       end
     end
   end
 
   context "with invalid values" do
-    invalid_values.each do |invalid_value|
+    invalid_values.each do |vhash|
+			invalid_value = vhash[:value]
       it "should not be valid: #{invalid_value}" do
-        subject.valid?(invalid_value).should be_false
+        block = Proc.new { subject.valid?(invalid_value).should be_false }
+				if vhash[:pending]
+					pending(vhash[:pending], &block)
+				else
+					block.call
+				end
       end
     end
   end

--- a/spec/support/shared/examples/options.rb
+++ b/spec/support/shared/examples/options.rb
@@ -1,0 +1,25 @@
+
+shared_examples_for "an option" do |valid_values, invalid_values|
+  subject do
+    described_class.new("name")
+  end
+
+  context "with valid values" do
+    valid_values.each do |valid_value, normalized_value|
+      it "should be valid and normalize appropriately: #{valid_value}" do
+        subject.valid?(valid_value).should be_true
+        subject.normalize(valid_value).should == normalized_value
+      end
+    end
+  end
+
+  context "with invalid values" do
+    invalid_values.each do |invalid_value|
+      it "should not be valid: #{invalid_value}" do
+        subject.valid?(invalid_value).should be_false
+      end
+    end
+  end
+
+end
+


### PR DESCRIPTION
Quite a bit left to do for spec'ing datastore and associated things, but this is a first step to making it possible to modify that code without so much fear of breaking everything.
