### PR TITLE
If there are no search results, try harder.

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1335,10 +1335,13 @@ class Core
 		}
 
 		if framework.db and framework.db.migrated and framework.db.modules_cached
-			return search_modules_sql(match)
+			sql_results = search_modules_sql(match)
+			eturn sql_results if sql_results # Patches around #7533
+		else
+			print_warning("Database not connected or cache not built.")
 		end
 
-		print_error("Warning: database not connected or cache not built, falling back to slow search")
+		print_warning("Falling back to slow search.")
 
 		tbl = generate_module_table("Matching Modules")
 		[


### PR DESCRIPTION
Sometimes, the database is active but the cache isn't filled out, or
doesn't contain the module you want. This can come up especially when
msfconsole first starts and you are programmatically searching for
modules, for whatever reason.

This allows for falling back to the regular (slow) search in the event
no hits have been returned. It does not actually address the caching
problem seen in QA, but it's generally going to be Good Enough. Search
is getting overhauled Real Soon Now anyway.

[FixRM #7533]
