### PR TITLE
Improved reliability of Taint analysis

### DIFF
--- a/lib/msf/core/auxiliary/web.rb
+++ b/lib/msf/core/auxiliary/web.rb
@@ -133,7 +133,7 @@ module Auxiliary::Web
 	# Override it if you need more complex processing, but remember to return
 	# the proof as a String.
 	#
-	# response - Net::HTTPResponse
+	# response - Auxiliary::Web::HTTP::Response
 	# element - the submitted element
 	#
 	def find_proof( response, element )

--- a/lib/msf/core/auxiliary/web/analysis/taint.rb
+++ b/lib/msf/core/auxiliary/web/analysis/taint.rb
@@ -20,10 +20,14 @@ module Analysis::Taint
 	# opts - Options Hash (default: {})
 	#
 	def taint_analysis( opts = {} )
-	return if fuzzed? :type => :taint
-	fuzzed :type => :taint
+		return if fuzzed? :type => :taint
+		fuzzed :type => :taint
 
-	fuzz_async do |response, permutation|
+		# if we get a result without injecting anything then bail out to avoid
+		# an FP
+		return if fuzzer.find_proof( submit, self )
+
+		fuzz_async do |response, permutation|
 			next if !response || !(proof = fuzzer.find_proof( response, permutation ))
 			fuzzer.process_vulnerability( permutation, proof )
 		end

--- a/lib/msf/core/auxiliary/web/fuzzable.rb
+++ b/lib/msf/core/auxiliary/web/fuzzable.rb
@@ -43,9 +43,9 @@ class Fuzzable
 	end
 
 	def submit( opts = {} )
-		fuzzer.increment_request_counter
+		fuzzer.increment_request_counter if fuzzer
 
-		resp = http.request_async( *request( opts ) )
+		resp = http.request( *request( opts ) )
 		handle_response( resp )
 		resp
 	end
@@ -90,6 +90,8 @@ class Fuzzable
 	end
 
 	def handle_response( resp )
+		return if !fuzzer || !resp
+
 		str = "    #{fuzzer.shortname}: #{resp.code} - #{method.to_s.upcase}" +
 			" #{action} #{params}"
 

--- a/lib/msf/core/auxiliary/web/fuzzable.rb
+++ b/lib/msf/core/auxiliary/web/fuzzable.rb
@@ -45,16 +45,13 @@ class Fuzzable
 	def submit( opts = {} )
 		fuzzer.increment_request_counter if fuzzer
 
-		resp = http.request( *request( opts ) )
-		handle_response( resp )
-		resp
+		http.request( *request( opts ) )
 	end
 
 	def submit_async( opts = {}, &callback )
 		fuzzer.increment_request_counter
 
 		http.request_async( *request( opts ) ) do |resp|
-			handle_response( resp )
 			callback.call resp if callback
 		end
 
@@ -86,22 +83,6 @@ class Fuzzable
 		self.fuzzer ||= cfuzzer
 		permutations.each do |p|
 			block.call p
-		end
-	end
-
-	def handle_response( resp )
-		return if !fuzzer || !resp
-
-		str = "    #{fuzzer.shortname}: #{resp.code} - #{method.to_s.upcase}" +
-			" #{action} #{params}"
-
-		case resp.code.to_i
-			when 200,404,301,302,303
-				#fuzzer.print_status str
-			when 500,503,401,403
-				fuzzer.print_good str
-			else
-				fuzzer.print_error str
 		end
 	end
 


### PR DESCRIPTION
- Taint analysis now checks if the module's `#find_proof` returns a result before us even injecting a payload and if so, it doesn't progress to the actual injection in order to avoid FPs.
- Tiny bugfix  in Fuzzable's `#submit`, now delegates to the proper HTTP class method (`#request`) -- fixes [7559](https://dev.metasploit.com/redmine/issues/7559).
