### PR TITLE
Really fix payload recalculation

### DIFF
--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -69,8 +69,7 @@ module Exploit
 
 			# Make sure parameters are valid.
 			if (opts['Payload'] == nil)
-				raise MissingPayloadError,
-					"You must specify a payload.", caller
+				raise MissingPayloadError.new, caller
 			end
 
 			# Verify the options
@@ -81,7 +80,7 @@ module Exploit
 
 			# Initialize the driver instance
 			driver.exploit    = exploit
-			driver.payload    = exploit.framework.modules.create(opts['Payload'])
+			driver.payload    = exploit.framework.payloads.create(opts['Payload'])
 			
 			# Set the force wait for session flag if the caller requested force
 			# blocking.  This is so that passive exploits can be blocked on from

--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -375,7 +375,6 @@ class DBManager
 		refresh.each  {|md| md.destroy }
 		refresh = nil
 
-		stime = Time.now.to_f
 		[
 			[ 'exploit',   framework.exploits  ],
 			[ 'auxiliary', framework.auxiliary ],

--- a/lib/msf/core/module_manager.rb
+++ b/lib/msf/core/module_manager.rb
@@ -18,7 +18,7 @@ module Msf
   # of loading and instantiation.
   #
   # @todo add unload support
-  class ModuleManager #< ModuleSet
+  class ModuleManager
     include Msf::Framework::Offspring
 
     require 'msf/core/payload_set'
@@ -75,24 +75,24 @@ module Msf
         type = TYPE_BY_DIRECTORY[potential_type_or_directory]
       end
 
-      m = nil
+      module_instance = nil
       if type
         module_set = module_set_by_type[type]
 
         # First element in names is the type, so skip it
         module_reference_name = names[1 .. -1].join("/")
-        m = module_set.create(module_reference_name)
+        module_instance = module_set.create(module_reference_name)
       else
         # Then we don't have a type, so we have to step through each set
         # to see if we can create this module.
         module_set_by_type.each do |_, set|
           module_reference_name = names.join("/")
-          m = set.create(module_reference_name)
-          break if m
+          module_instance = set.create(module_reference_name)
+          break if module_instance
         end
       end
 
-      m
+      module_instance
     end
 
 

--- a/lib/msf/core/module_manager/cache.rb
+++ b/lib/msf/core/module_manager/cache.rb
@@ -24,8 +24,8 @@ module Msf::ModuleManager::Cache
   def load_cached_module(type, reference_name)
     loaded = false
 
-    module_info = self.module_info_by_path.values.find { |module_info|
-      module_info[:type] == type and module_info[:reference_name] == reference_name
+    module_info = self.module_info_by_path.values.find { |inner_info|
+      inner_info[:type] == type and inner_info[:reference_name] == reference_name
     }
 
     if module_info
@@ -116,8 +116,9 @@ module Msf::ModuleManager::Cache
 
         typed_module_set = module_set(type)
 
-        # Don't want to trigger as {Msf::ModuleSet#create} so check for key instead of using ||= which would call
-        # {Msf::ModuleSet#[]} which would potentially call {Msf::ModuleSet#create}.
+        # Don't want to trigger as {Msf::ModuleSet#create} so check for
+        # key instead of using ||= which would call {Msf::ModuleSet#[]}
+        # which would potentially call {Msf::ModuleSet#create}.
         unless typed_module_set.has_key? reference_name
           typed_module_set[reference_name] = Msf::SymbolicModule
         end

--- a/lib/msf/core/module_manager/loading.rb
+++ b/lib/msf/core/module_manager/loading.rb
@@ -57,21 +57,16 @@ module Msf::ModuleManager::Loading
   # categorized accordingly.
   #
   def on_module_load(mod, type, name, modinfo)
-    # Payload modules require custom loading as the individual files
-    # may not directly contain a logical payload that a user would
-    # reference, such as would be the case with a payload stager or
-    # stage.  As such, when payload modules are loaded they are handed
-    # off to a special payload set.  The payload set, in turn, will
-    # automatically create all the permutations after all the payload
-    # modules have been loaded.
+    dup = module_set_by_type[type].add_module(mod, name, modinfo)
 
-    if (type != Msf::MODULE_PAYLOAD)
-      # Add the module class to the list of modules and add it to the
-      # type separated set of module classes
-      add_module(mod, name, modinfo)
-    end
+    # Automatically subscribe a wrapper around this module to the necessary
+    # event providers based on whatever events it wishes to receive.
+    auto_subscribe_module(dup)
 
-    module_set_by_type[type].add_module(mod, name, modinfo)
+    # Notify the framework that a module was loaded
+    framework.events.on_module_load(name, dup)
+
+    dup
   end
 
   protected

--- a/lib/msf/core/module_manager/module_sets.rb
+++ b/lib/msf/core/module_manager/module_sets.rb
@@ -39,7 +39,7 @@ module Msf::ModuleManager::ModuleSets
     self.enablement_by_type[type] = true
     case type
       when Msf::MODULE_PAYLOAD
-        instance = Msf::PayloadSet.new(self)
+        instance = Msf::PayloadSet.new
       else
         instance = Msf::ModuleSet.new(type)
     end

--- a/lib/msf/core/module_set.rb
+++ b/lib/msf/core/module_set.rb
@@ -33,8 +33,9 @@ class Msf::ModuleSet < Hash
 
   # Create an instance of the supplied module by its name
   #
-  # @param [String] name the module reference name.
-  # @return [Msf::Module] instance of the named module.
+  # @param name [String] The module reference name.
+  # @return [Msf::Module,nil] Instance of the named module or nil if it
+  #   could not be created.
   def create(name)
     klass = fetch(name, nil)
     instance = nil
@@ -42,15 +43,7 @@ class Msf::ModuleSet < Hash
     # If there is no module associated with this class, then try to demand
     # load it.
     if klass.nil? or klass == Msf::SymbolicModule
-      # If we are the root module set, then we need to try each module
-      # type's demand loading until we find one that works for us.
-      if module_type.nil?
-        Msf::MODULE_TYPES.each { |type|
-          framework.modules.load_cached_module(type, name)
-        }
-      else
-        framework.modules.load_cached_module(module_type, name)
-      end
+      framework.modules.load_cached_module(module_type, name)
 
       recalculate
 
@@ -168,17 +161,6 @@ class Msf::ModuleSet < Hash
   def on_module_reload(mod)
   end
 
-  # @!attribute [rw] postpone_recalc
-  #   Whether or not recalculations should be postponed.  This is used
-  #   from the context of the {#each_module_list} handler in order to
-  #   prevent the demand loader from calling recalc for each module if
-  #   it's possible that more than one module may be loaded.  This field
-  #   is not initialized until used.
-  #
-  #   @return [true] if {#recalculate} should not be called immediately
-  #   @return [false] if {#recalculate} should be called immediately
-  attr_accessor :postpone_recalculate
-
   # Dummy placeholder to recalculate aliases and other fun things.
   #
   # @return [void]
@@ -193,8 +175,6 @@ class Msf::ModuleSet < Hash
     create(name)
     (self[name]) ? true : false
   end
-
-  protected
 
   # Adds a module with a the supplied name.
   #
@@ -226,25 +206,24 @@ class Msf::ModuleSet < Hash
     mod
   end
 
+  protected
+
   # Load all modules that are marked as being symbolic.
   #
   # @return [void]
   def demand_load_modules
+    found_symbolics = false
     # Pre-scan the module list for any symbolic modules
     self.each_pair { |name, mod|
       if (mod == Msf::SymbolicModule)
-        self.postpone_recalculate = true
-
+        found_symbolics = true
         mod = create(name)
-
         next if (mod.nil?)
       end
     }
 
     # If we found any symbolic modules, then recalculate.
-    if (self.postpone_recalculate)
-      self.postpone_recalculate = false
-
+    if (found_symbolics)
       recalculate
     end
   end

--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -63,15 +63,17 @@ class Msf::Modules::Loader::Base
   # Regex that can distinguish regular ruby source from unit test source.
   UNIT_TEST_REGEX = /rb\.(ut|ts)\.rb$/
 
-  # @param [Msf::ModuleManager] module_manager The module manager that caches the loaded modules.
+  # @param [Msf::ModuleManager] module_manager The module manager that
+  #   caches the loaded modules.
   def initialize(module_manager)
     @module_manager = module_manager
   end
 
   # Returns whether the path can be loaded this module loader.
   #
-  # @abstract Override and determine from properties of the path or the file to which the path points whether it is
-  #   loadable using {#load_modules} for the subclass.
+  # @abstract Override and determine from properties of the path or the
+  #   file to which the path points whether it is loadable using
+  #   {#load_modules} for the subclass.
   #
   # @param path (see #load_modules)
   # @return [Boolean]
@@ -81,22 +83,33 @@ class Msf::Modules::Loader::Base
 
   # Loads a module from the supplied path and module_reference_name.
   #
-  # @param [String] parent_path The path under which the module exists.  This is not necessarily the same path as passed
-  #   to {#load_modules}: it may just be derived from that path.
+  # @param [String] parent_path The path under which the module exists.
+  #   This is not necessarily the same path as passed to
+  #   {#load_modules}: it may just be derived from that path.
   # @param [String] type The type of module.
-  # @param [String] module_reference_name The canonical name for referring to the module.
-  # @param [Hash] options Options used to force loading and track statistics
-  # @option options [Hash{String => Integer}] :count_by_type Maps the module type to the number of module loaded
-  # @option options [Boolean] :force (false) whether to force loading of the module even if the module has not changed.
-  # @option options [Hash{String => Boolean}] :recalculate_by_type Maps type to whether its
-  #   {Msf::ModuleManager::ModuleSets#module_set} needs to be recalculated.
+  # @param [String] module_reference_name The canonical name for
+  #   referring to the module.
+  # @param [Hash] options Options used to force loading and track
+  #   statistics
+  # @option options [Hash{String => Integer}] :count_by_type Maps the
+  #   module type to the number of module loaded
+  # @option options [Boolean] :force (false) whether to force loading of
+  #   the module even if the module has not changed.
+  # @option options [Hash{String => Boolean}] :recalculate_by_type Maps
+  #   type to whether its {Msf::ModuleManager::ModuleSets#module_set}
+  #   needs to be recalculated.
   # @option options [Boolean] :reload (false) whether this is a reload.
+  #
   # @return [false] if :force is false and parent_path has not changed.
-  # @return [false] if exception encountered while parsing module content
-  # @return [false] if the module is incompatible with the Core or API version.
-  # @return [false] if the module does not implement a Metasploit(\d+) class.
+  # @return [false] if exception encountered while parsing module
+  #   content
+  # @return [false] if the module is incompatible with the Core or API
+  #   version.
+  # @return [false] if the module does not implement a Metasploit(\d+)
+  #   class.
   # @return [false] if the module's is_usable method returns false.
-  # @return [true] if all those condition pass and the module is successfully loaded.
+  # @return [true] if all those condition pass and the module is
+  #   successfully loaded.
   #
   # @see #read_module_content
   # @see Msf::ModuleManager::Loading#file_changed?
@@ -121,8 +134,8 @@ class Msf::Modules::Loader::Base
     module_content = read_module_content(parent_path, type, module_reference_name)
 
     if module_content.empty?
-	    # read_module_content is responsible for calling {#load_error}, so just return here.
-	    return false
+      # read_module_content is responsible for calling {#load_error}, so just return here.
+      return false
     end
 
     try_eval_module = lambda { |namespace_module|
@@ -139,9 +152,9 @@ class Msf::Modules::Loader::Base
         begin
           namespace_module.version_compatible!(module_path, module_reference_name)
         rescue Msf::Modules::VersionCompatibilityError => version_compatibility_error
-	        load_error(module_path, version_compatibility_error)
+          load_error(module_path, version_compatibility_error)
         else
-	        load_error(module_path, error)
+          load_error(module_path, error)
         end
 
         return false
@@ -150,17 +163,17 @@ class Msf::Modules::Loader::Base
       begin
         namespace_module.version_compatible!(module_path, module_reference_name)
       rescue Msf::Modules::VersionCompatibilityError => version_compatibility_error
-	      load_error(module_path, version_compatibility_error)
+        load_error(module_path, version_compatibility_error)
 
         return false
       end
 
       begin
-	      metasploit_class = namespace_module.metasploit_class!(module_path, module_reference_name)
+        metasploit_class = namespace_module.metasploit_class!(module_path, module_reference_name)
       rescue Msf::Modules::MetasploitClassCompatibilityError => error
-	      load_error(module_path, error)
+        load_error(module_path, error)
 
-	      return false
+        return false
       end
 
       unless usable?(metasploit_class)
@@ -227,12 +240,15 @@ class Msf::Modules::Loader::Base
 
   # Loads all of the modules from the supplied path.
   #
-  # @note Only paths where {#loadable?} returns true should be passed to this method.
+  # @note Only paths where {#loadable?} returns true should be passed to
+  #   this method.
   #
   # @param [String] path Path under which there are modules
   # @param [Hash] options
-  # @option options [Boolean] force (false) whether to force loading of the module even if the module has not changed.
-  # @return [Hash{String => Integer}] Maps module type to number of modules loaded
+  # @option options [Boolean] force (false) Whether to force loading of
+  #   the module even if the module has not changed.
+  # @return [Hash{String => Integer}] Maps module type to number of
+  #   modules loaded
   def load_modules(path, options={})
     options.assert_valid_keys(:force)
 
@@ -396,28 +412,28 @@ class Msf::Modules::Loader::Base
     raise ::NotImplementedError
   end
 
-	# Records the load error to {Msf::ModuleManager::Loading#module_load_error_by_path} and the log.
-	#
-	# @param [String] module_path Path to the module as returned by {#module_path}.
-	# @param [Exception, #class, #to_s, #backtrace] error the error that cause the module not to load.
-	# @return [void]
-	#
-	# @see #module_path
-	def load_error(module_path, error)
-		# module_load_error_by_path does not get the backtrace because the value is echoed to the msfconsole where
-		# backtraces should not appear.
-	  module_manager.module_load_error_by_path[module_path] = "#{error.class} #{error}"
+  # Records the load error to {Msf::ModuleManager::Loading#module_load_error_by_path} and the log.
+  #
+  # @param [String] module_path Path to the module as returned by {#module_path}.
+  # @param [Exception, #class, #to_s, #backtrace] error the error that cause the module not to load.
+  # @return [void]
+  #
+  # @see #module_path
+  def load_error(module_path, error)
+    # module_load_error_by_path does not get the backtrace because the value is echoed to the msfconsole where
+    # backtraces should not appear.
+    module_manager.module_load_error_by_path[module_path] = "#{error.class} #{error}"
 
-		log_lines = []
-	  log_lines << "#{module_path} failed to load due to the following error:"
-		log_lines << error.class.to_s
-		log_lines << error.to_s
-		log_lines << "Call stack:"
-		log_lines += error.backtrace
+    log_lines = []
+    log_lines << "#{module_path} failed to load due to the following error:"
+    log_lines << error.class.to_s
+    log_lines << error.to_s
+    log_lines << "Call stack:"
+    log_lines += error.backtrace
 
-		log_message = log_lines.join("\n")
-		elog(log_message)
-	end
+    log_message = log_lines.join("\n")
+    elog(log_message)
+  end
 
   # @return [Msf::ModuleManager] The module manager for which this loader is loading modules.
   attr_reader :module_manager
@@ -480,11 +496,14 @@ class Msf::Modules::Loader::Base
     namespace_module_name
   end
 
-  # Returns an Array of names to make a fully qualified module name to wrap the Metasploit(1|2|3) class so that it
-  # doesn't overwrite other (metasploit) module's classes.  Invalid module name characters are escaped by using 'H*'
-  # unpacking and prefixing each code with X so the code remains a valid module name when it starts with a digit.
+  # Returns an Array of names to make a fully qualified module name to
+  # wrap the Metasploit(1|2|3) class so that it doesn't overwrite other
+  # (metasploit) module's classes.  Invalid module name characters are
+  # escaped by using 'H*' unpacking and prefixing each code with X so
+  # the code remains a valid module name when it starts with a digit.
   #
-  # @param [String] uniq_module_reference_name The unique canonical name for the module including type.
+  # @param [String] uniq_module_reference_name The unique canonical name
+  #   for the module including type.
   # @return [Array<String>] {NAMESPACE_MODULE_NAMES} + <derived-constant-safe names>
   #
   # @see namespace_module
@@ -513,8 +532,9 @@ class Msf::Modules::Loader::Base
     end
 
     namespace_module = create_namespace_module(namespace_module_names)
-    # Get the parent module from the created module so that restore_namespace_module can remove namespace_module's
-    # constant if needed.
+    # Get the parent module from the created module so that
+    # restore_namespace_module can remove namespace_module's constant if
+    # needed.
     parent_module = namespace_module.parent
 
     begin
@@ -557,21 +577,21 @@ class Msf::Modules::Loader::Base
     if parent_module
       # If there is a current module with relative_name
       if parent_module.const_defined?(relative_name)
-	      # if the current value isn't the value to be restored.
-	      if parent_module.const_get(relative_name) != namespace_module
-		      # remove_const is private, so use send to bypass
-		      parent_module.send(:remove_const, relative_name)
+        # if the current value isn't the value to be restored.
+        if parent_module.const_get(relative_name) != namespace_module
+          # remove_const is private, so use send to bypass
+          parent_module.send(:remove_const, relative_name)
 
-		      # if there was a previous module, not set it to the name
-		      if namespace_module
-			      parent_module.const_set(relative_name, namespace_module)
-		      end
-	      end
+          # if there was a previous module, not set it to the name
+          if namespace_module
+            parent_module.const_set(relative_name, namespace_module)
+          end
+        end
       else
-	      # if there was a previous module, but there isn't a current module, then restore the previous module
-	      if namespace_module
-		      parent_module.const_set(relative_name, namespace_module)
-	      end
+        # if there was a previous module, but there isn't a current module, then restore the previous module
+        if namespace_module
+          parent_module.const_set(relative_name, namespace_module)
+        end
       end
     end
   end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1859,7 +1859,7 @@ class Core
 		end
 
 		if (mod.exploit? and mod.datastore['PAYLOAD'])
-			p = framework.modules.create(mod.datastore['PAYLOAD'])
+			p = framework.payloads.create(mod.datastore['PAYLOAD'])
 			if (p)
 				p.options.sorted.each { |e|
 					name, opt = e
@@ -2389,7 +2389,7 @@ class Core
 
 		# How about the selected payload?
 		if (mod.exploit? and mod.datastore['PAYLOAD'])
-			p = framework.modules.create(mod.datastore['PAYLOAD'])
+			p = framework.payloads.create(mod.datastore['PAYLOAD'])
 			if (p and p.options.include?(opt))
 				res.concat(option_values_dispatch(p.options[opt], str, words))
 			end
@@ -2623,7 +2623,7 @@ protected
 		# If it's an exploit and a payload is defined, create it and
 		# display the payload's options
 		if (mod.exploit? and mod.datastore['PAYLOAD'])
-			p = framework.modules.create(mod.datastore['PAYLOAD'])
+			p = framework.payloads.create(mod.datastore['PAYLOAD'])
 
 			if (!p)
 				print_error("Invalid payload defined: #{mod.datastore['PAYLOAD']}\n")
@@ -2688,7 +2688,7 @@ protected
 		# If it's an exploit and a payload is defined, create it and
 		# display the payload's options
 		if (mod.exploit? and mod.datastore['PAYLOAD'])
-			p = framework.modules.create(mod.datastore['PAYLOAD'])
+			p = framework.payloads.create(mod.datastore['PAYLOAD'])
 
 			if (!p)
 				print_error("Invalid payload defined: #{mod.datastore['PAYLOAD']}\n")
@@ -2711,7 +2711,7 @@ protected
 		# If it's an exploit and a payload is defined, create it and
 		# display the payload's options
 		if (mod.exploit? and mod.datastore['PAYLOAD'])
-			p = framework.modules.create(mod.datastore['PAYLOAD'])
+			p = framework.payloads.create(mod.datastore['PAYLOAD'])
 
 			if (!p)
 				print_error("Invalid payload defined: #{mod.datastore['PAYLOAD']}\n")

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -528,7 +528,7 @@ class Driver < Msf::Ui::Driver
 			framework.modules.module_load_error_by_path.each do |path, error|
 				print_error("\t#{path}: #{error}")
 			end
-    end
+		end
 
 		framework.events.on_ui_start(Msf::Framework::Revision)
 
@@ -551,7 +551,7 @@ class Driver < Msf::Ui::Driver
 		case var.downcase
 			when "payload"
 
-				if (framework and framework.modules.valid?(val) == false)
+				if (framework and framework.payloads.valid?(val) == false)
 					return false
 				elsif (active_module)
 					active_module.datastore.clear_non_user_defined


### PR DESCRIPTION
Instead of deleting all non-symbolics before the re-adding phase of
PayloadSet#recalculate, store a list of old module names, populate a
list of new ones during the re-adding phase, and finally remove any
non-symbolic module that was in the old list but wasn't in the new list.

Also includes a minor refactoring to make ModuleManager its own thing
instead of being an awkard subclass of ModuleSet. Now PayloadSet doesn't
need to know about the existence of framework.modules, which makes the
separation a little more natural.

[FixRM #7037]
