### PR TITLE
Update modules/exploits/unix/ssh/tectia_passwd_changereq.rb

### DIFF
--- a/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
+++ b/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
@@ -170,7 +170,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def do_login(user)
-		opts       = {:user=>user, :record_auth_info=>true}
+		opts       = {:user=>user, :record_auth_info=>true, :port=>rport}
 		options    = Net::SSH::Config.for(rhost, Net::SSH::Config.default_files).merge(opts)
 		transport  = Net::SSH::Transport::Session.new(rhost, options)
 		connection = Net::SSH::Connection::Session.new(transport, options)


### PR DESCRIPTION
Fixed bug for when target server is not running on standard port 22.  Net::SSH defaults to port 22 when the port is not passed in via its associated constructors.
