### PR TITLE
Update modules/auxiliary/admin/smb/psexec_command.rb

### DIFF
--- a/modules/auxiliary/admin/smb/psexec_command.rb
+++ b/modules/auxiliary/admin/smb/psexec_command.rb
@@ -45,6 +45,7 @@ class Metasploit3 < Msf::Auxiliary
 			OptString.new('SMBSHARE', [true, 'The name of a writeable share on the server', 'C$']),
 			OptString.new('COMMAND', [true, 'The command you want to execute on the remote host', 'net group "Domain Admins" /domain']),
 			OptString.new('RPORT', [true, 'The Target port', 445]),
+			OptString.new('WINPATH', [true, 'The name of the remote Windows directory', 'WINDOWS']),
 		], self.class)
 
 		deregister_options('RHOST')
@@ -52,7 +53,7 @@ class Metasploit3 < Msf::Auxiliary
 
 	# This is the main controle method
 	def run_host(ip)
-		text = "\\WINDOWS\\Temp\\#{Rex::Text.rand_text_alpha(16)}.txt"
+		text = "\\#{datastore['WINPATH']}\\Temp\\#{Rex::Text.rand_text_alpha(16)}.txt"
 		bat = "%WINDIR%\\Temp\\#{Rex::Text.rand_text_alpha(16)}.bat"
 		smbshare = datastore['SMBSHARE']
 


### PR DESCRIPTION
Fixed static path to Windows directory.  This causes problems with directory is 'WINNT' for example.

So I've noticed on some systems such as Windows 2000 or systems where the Sys Admin has got creative the directory to the windows OS is not called 'WINDOWS' and therefore this module will not work.

This pull request fixes that issue by adding an option to specify a different name such as 'WINNT' this appears to fix this issue in my testing.
