### PR TITLE
Move print of my_target.name to after nil check

### DIFF
--- a/modules/exploits/windows/browser/adobe_flash_otf_font.rb
+++ b/modules/exploits/windows/browser/adobe_flash_otf_font.rb
@@ -159,8 +159,6 @@ class Metasploit3 < Msf::Exploit::Remote
 	def on_request_uri(cli, request)
 		agent = request.headers['User-Agent']
 		my_target = get_target(agent)
-		print_status("Target selected: #{my_target.name}")
-		print_status("Client requesting: #{request.uri}")
 
 		# Avoid the attack if the victim doesn't have the same setup we're targeting
 		if my_target.nil?
@@ -168,6 +166,9 @@ class Metasploit3 < Msf::Exploit::Remote
 			send_not_found(cli)
 			return
 		end
+
+		print_status("Target selected: #{my_target.name}")
+		print_status("Client requesting: #{request.uri}")
 
 		# The SWF request itself
 		if request.uri =~ /\.swf$/


### PR DESCRIPTION
Avoids
  "Exception handling request: undefined method `name' for nil:NilClass"
when we don't have a target for the connecting browser.

[FixRM #7593]
