### PR TITLE
Change CVE text format

### DIFF
--- a/modules/auxiliary/dos/http/novell_file_reporter_heap_bof.rb
+++ b/modules/auxiliary/dos/http/novell_file_reporter_heap_bof.rb
@@ -25,7 +25,7 @@ class Metasploit3 < Msf::Auxiliary
 			'Author'         => [ 'juan vazquez' ],
 			'License'        => MSF_LICENSE,
 			'References'     => [
-				[ 'CVE', 'CVE-2012-4956' ],
+				[ 'CVE', '2012-4956' ],
 				[ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/11/16/nfr-agent-buffer-vulnerabilites-cve-2012-4959' ]
 			],
 			'DisclosureDate' => 'Nov 16 2012'))

--- a/modules/auxiliary/scanner/http/novell_file_reporter_fsfui_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/novell_file_reporter_fsfui_fileaccess.rb
@@ -25,7 +25,7 @@ class Metasploit4 < Msf::Auxiliary
 			},
 			'References'   =>
 				[
-					[ 'CVE', 'CVE-2012-4958' ],
+					[ 'CVE', '2012-4958' ],
 					[ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/11/16/nfr-agent-buffer-vulnerabilites-cve-2012-4959' ]
 				],
 			'Author'       =>

--- a/modules/auxiliary/scanner/http/novell_file_reporter_srs_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/novell_file_reporter_srs_fileaccess.rb
@@ -25,7 +25,7 @@ class Metasploit4 < Msf::Auxiliary
 			},
 			'References'   =>
 				[
-					[ 'CVE', 'CVE-2012-4957' ],
+					[ 'CVE', '2012-4957' ],
 					[ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/11/16/nfr-agent-buffer-vulnerabilites-cve-2012-4959' ]
 				],
 			'Author'       =>

--- a/modules/exploits/windows/novell/file_reporter_fsfui_upload.rb
+++ b/modules/exploits/windows/novell/file_reporter_fsfui_upload.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'References'     =>
 				[
-					[ 'CVE', 'CVE-2012-4959'],
+					[ 'CVE', '2012-4959'],
 					[ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/11/16/nfr-agent-buffer-vulnerabilites-cve-2012-4959' ]
 				],
 			'Payload'        =>


### PR DESCRIPTION
Although the original text should work perfectly fine, for better consistency, it's best to remove the "CVE" part. This may not be a big deal in framework, but stands out a lot in Pro.
