### PR TITLE
Remove vestiges of ModuleManager's ModuleSet origins

### DIFF
--- a/lib/msf/core/module_manager/reloading.rb
+++ b/lib/msf/core/module_manager/reloading.rb
@@ -21,9 +21,6 @@ module Msf::ModuleManager::Reloading
   #
   # @return (see Msf::ModuleManager::Loading#load_modules)
   def reload_modules
-    self.module_history = {}
-    self.clear
-
     self.enablement_by_type.each_key do |type|
       module_set_by_type[type].clear
       init_module_set(type)

--- a/lib/msf/core/module_set.rb
+++ b/lib/msf/core/module_set.rb
@@ -305,7 +305,6 @@ class Msf::ModuleSet < Hash
   #
   #   @return [String] type of modules
   attr_writer   :module_type
-  attr_accessor :module_history
 
   # Ranks modules based on their constant rank value, if they have one.  Modules without a Rank are treated as if they
   # had {Msf::NormalRanking} for Rank.


### PR DESCRIPTION
Fixes a stack trace in msfconsole when running `reload_all`.  Thanks thelightcosine for reporting.
