### PR TITLE
Improve check_title_format

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -212,7 +212,7 @@ class Msftidy
 		if @source =~ /'Name'[[:space:]]*=>[[:space:]]*['|"](.+)['|"],*$/
 			words = $1.split
 			words.each do |word|
-				if word =~ /^['"].+['"]$/ or word =~ /^[a-z].*[A-Z].+$/
+				if word =~ /^['"].+['"]$/ or word =~ /^[a-z].*[A-Z].+$/ or word =~ /^.+\(\)$/
 					next
 				elsif %w{and or the for via}.include?(word)
 					next

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -324,16 +324,16 @@ end
 
 def run_checks(f_rel)
 	tidy = Msftidy.new(f_rel)
-	#tidy.check_old_keywords
-	#tidy.check_badchars
-	#tidy.check_extname
-	#tidy.test_old_rubies(f_rel)
-	#tidy.check_ranking
-	#tidy.check_disclosure_date
+	tidy.check_old_keywords
+	tidy.check_badchars
+	tidy.check_extname
+	tidy.test_old_rubies(f_rel)
+	tidy.check_ranking
+	tidy.check_disclosure_date
 	tidy.check_title_format
-	#tidy.check_bad_terms
-	#tidy.check_function_basics
-	#tidy.check_lines
+	tidy.check_bad_terms
+	tidy.check_function_basics
+	tidy.check_lines
 end
 
 ##

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -209,13 +209,12 @@ class Msftidy
 	end
 
 	def check_title_format
-		if @source =~ /'Name'\s+=>\s[\x22\x27](.+)[\x22\x27],\s*$/
-			name = $1
+		if @source =~ /'Name'[[:space:]]*=>[[:space:]]*['|"](.+)['|"],*$/
 			words = $1.split
-			[words.first, words.last].each do |word|
-				if word[0,1] =~ /[a-z]/ and word[1,1] !~ /[A-Z0-9]/
-					next if word =~ /php[A-Z]/
-					next if %w{iseemedia activePDF freeFTPd osCommerce myBB qdPM inetd wallet.dat}.include? word
+			words.each do |word|
+				if word =~ /^['"].+['"]$/ or word =~ /^[a-z].*[A-Z].+$/
+					next
+				elsif word =~ /^[a-z]+$/
 					warn("Improper capitalization in module title: '#{word}...'")
 				end
 			end
@@ -323,16 +322,16 @@ end
 
 def run_checks(f_rel)
 	tidy = Msftidy.new(f_rel)
-	tidy.check_old_keywords
-	tidy.check_badchars
-	tidy.check_extname
-	tidy.test_old_rubies(f_rel)
-	tidy.check_ranking
-	tidy.check_disclosure_date
+	#tidy.check_old_keywords
+	#tidy.check_badchars
+	#tidy.check_extname
+	#tidy.test_old_rubies(f_rel)
+	#tidy.check_ranking
+	#tidy.check_disclosure_date
 	tidy.check_title_format
-	tidy.check_bad_terms
-	tidy.check_function_basics
-	tidy.check_lines
+	#tidy.check_bad_terms
+	#tidy.check_function_basics
+	#tidy.check_lines
 end
 
 ##

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -212,7 +212,7 @@ class Msftidy
 		if @source =~ /'Name'[[:space:]]*=>[[:space:]]*['|"](.+)['|"],*$/
 			words = $1.split
 			words.each do |word|
-				if word =~ /^['"].+['"]$/ or word =~ /^[a-z].*[A-Z].+$/ or word =~ /^.+\(\)$/
+				if word =~ /^['"].+['"]$/ or word =~ /^[a-z].*[A-Z].+$/ or word =~ /^.+\(\)$/ or word =~ /^[vb][\d\.\-r]+$/
 					next
 				elsif %w{and or the for via to}.include?(word)
 					next

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -216,7 +216,7 @@ class Msftidy
 					next
 				elsif %w{and or the for via to}.include?(word)
 					next
-				elsif word =~ /^[a-z]+$/
+				elsif word[0, 1] == word[0, 1].capitalize
 					warn("Improper capitalization in module title: '#{word}...'")
 				end
 			end

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -216,7 +216,7 @@ class Msftidy
 					next
 				elsif %w{and or the for via to}.include?(word)
 					next
-				elsif word[0, 1] == word[0, 1].capitalize
+				elsif word[0, 1] != word[0, 1].capitalize
 					warn("Improper capitalization in module title: '#{word}...'")
 				end
 			end

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -214,6 +214,8 @@ class Msftidy
 			words.each do |word|
 				if word =~ /^['"].+['"]$/ or word =~ /^[a-z].*[A-Z].+$/
 					next
+				elsif %w{and or the for via}.include?(word)
+					next
 				elsif word =~ /^[a-z]+$/
 					warn("Improper capitalization in module title: '#{word}...'")
 				end

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -214,7 +214,7 @@ class Msftidy
 			words.each do |word|
 				if word =~ /^['"].+['"]$/ or word =~ /^[a-z].*[A-Z].+$/ or word =~ /^.+\(\)$/
 					next
-				elsif %w{and or the for via}.include?(word)
+				elsif %w{and or the for via to}.include?(word)
 					next
 				elsif word =~ /^[a-z]+$/
 					warn("Improper capitalization in module title: '#{word}...'")


### PR DESCRIPTION
Sometimes it's not always technically correct to upper-case the first letter of a word.  Some examples:
- A word that's in a quote (all filenames should be in a quote)
- A name like freeFTPd.
- A function name like "helloWorld()"
- A version number like: v14

When we see those, we should ignore them.  Also, other words like and, or, the, to, etc should be ignored as well.
