### PR TITLE
Add a maxver for the safari_metadata_archive exploit.

### DIFF
--- a/modules/exploits/osx/browser/safari_metadata_archive.rb
+++ b/modules/exploits/osx/browser/safari_metadata_archive.rb
@@ -21,10 +21,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	include Msf::Exploit::Remote::BrowserAutopwn
 	autopwn_info({
-		# Untested.  What versions of Safari does this work against?
 		:ua_name => HttpClients::SAFARI,
+		:ua_maxver => '2.0.2',
 		:os_name => [ OperatingSystems::MAC_OSX ],
-		:javascript => true,
+		:javascript => false,
 		:rank => ExcellentRanking, # reliable cmd execution
 		:vuln_test => nil,
 	})


### PR DESCRIPTION
This issue was fixed by Apple Security Update 2006-001 (http://support.apple.com/kb/TA23971). The update was released for 10.4.5, where safari 2.0.3 is default browser. So 2.0.2 and below are affected by this. 
