### PR TITLE
Correct Railgun WriteProcessMemory var type

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_kernel32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_kernel32.rb
@@ -3530,7 +3530,7 @@ class Def_kernel32
 
 		dll.add_function( 'WriteProcessMemory', 'BOOL',[
 			["HANDLE","hProcess","in"],
-			["PBLOB","lpBaseAddress","in"],
+			["LPVOID","lpBaseAddress","in"],
 			["PBLOB","lpBuffer","in"],
 			["DWORD","nSize","in"],
 			["PDWORD","lpNumberOfBytesWritten","out"],


### PR DESCRIPTION
This is described here:
https://dev.metasploit.com/redmine/issues/7237

After change operates as expected.
