### PR TITLE
modified handler/reverse_http.rb with "resp.body" as a variable instead of static string

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -154,7 +154,8 @@ module ReverseHttp
 				OptInt.new('SessionCommunicationTimeout', [ false, 'The number of seconds of no activity before this session should be killed', 300]),
 				OptString.new('MeterpreterUserAgent', [ false, 'The user-agent that the payload should use for communication', 'Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)' ]),
 				OptString.new('MeterpreterServerName', [ false, 'The server header that the handler will send in response to requests', 'Apache' ]),
-				OptAddress.new('ReverseListenerBindAddress', [ false, 'The specific IP address to bind to on the local system'])
+				OptAddress.new('ReverseListenerBindAddress', [ false, 'The specific IP address to bind to on the local system']),
+				OptString.new('HttpUknownRequestResponse', [ false, 'The returned HTML response body when the handler receives a request that is not from a payload', '<html><body><h1>It works!</h1></body></html>'  ])
 			], Msf::Handler::ReverseHttp)
 	end
 
@@ -359,7 +360,7 @@ protected
 				print_status("#{cli.peerhost}:#{cli.peerport} Unknown request to #{uri_match} #{req.inspect}...")
 				resp.code    = 200
 				resp.message = "OK"
-				resp.body    = "<h3>No site configured at this address</h3>"
+				resp.body    = "#{datastore['HttpUknownRequestResponse']}"
 		end
 
 		cli.send_response(resp) if (resp)


### PR DESCRIPTION
created a new advanced option "HttpUknownRequestResponse" that will be sent back in the HTML body of unknown requests instead of the old static "No site configured at this address" message.
