### PR TITLE
Fixes error message for badchar in nmap mixin

### DIFF
--- a/lib/msf/core/auxiliary/nmap.rb
+++ b/lib/msf/core/auxiliary/nmap.rb
@@ -224,7 +224,7 @@ def nmap_validate_arg(str)
 	disallowed_characters = /([\x00-\x19\x21\x23-\x26\x28\x29\x3b\x3e\x60\x7b\x7c\x7d\x7e-\xff])/n
 	badchar = str[disallowed_characters]
 	if badchar
-		print_error "Malformed nmap arguments (contains '#{c}'): #{str}"
+		print_error "Malformed nmap arguments (contains '#{badchar}'): #{str}"
 		return false
 	end
 	# Check for commas outside of quoted arguments


### PR DESCRIPTION
Note that only a custom module that allows for users to pass arguments
to nmap would be capable of hitting the error condition. Right now, only
auxiliary/scanner/oracle/oracle_login traverses the codepath, and that
doesn't allow for arbitrary args passed to nmap.

So... without contriving an example, it should be impossible to
experience or test.

[FixRM #7641]
