### PR TITLE
Adds EHLO domain to smtp deliver

### DIFF
--- a/lib/msf/core/exploit/smtp_deliver.rb
+++ b/lib/msf/core/exploit/smtp_deliver.rb
@@ -31,6 +31,7 @@ module Exploit::Remote::SMTPDeliver
 				OptString.new('SUBJECT', [ true, 'Subject line of the email' ]),
 				OptString.new('USERNAME', [ false, 'SMTP Username for sending email', '' ]),
 				OptString.new('PASSWORD', [ false, 'SMTP Password for sending email', '' ]),
+				OptString.new('DOMAIN', [false, 'SMTP Domain to EHLO to', '']),
 				OptString.new('VERBOSE', [ false, 'Display verbose information' ]),
 			], Msf::Exploit::Remote::SMTPDeliver)
 		register_autofilter_ports([ 25, 465, 587, 2525, 25025, 25000])
@@ -72,7 +73,11 @@ module Exploit::Remote::SMTPDeliver
 		print_verbose("Connecting to SMTP server #{rhost}:#{rport}...")
 		nsock = connect(global)
 
-		domain = Rex::Text.rand_text_alpha(rand(32)+1)
+		if datastore['DOMAIN'] and not datastore['DOMAIN'] == ''
+			domain = datastore['DOMAIN']
+		else
+			domain = Rex::Text.rand_text_alpha(rand(32)+1)
+		end
 
 		res = raw_send_recv("EHLO #{domain}\r\n", nsock)
 		if res =~ /STARTTLS/


### PR DESCRIPTION
Allow the user to set the EHLO domain for the smtp deliver module.
This is needed for Pro functionality

[story #41549217]
