### PR TITLE
Add a mixin for marking deprecated modules

### DIFF
--- a/lib/msf/core/module/deprecated.rb
+++ b/lib/msf/core/module/deprecated.rb
@@ -1,0 +1,58 @@
+
+module Msf::Module::Deprecated
+
+	# Additional class methods for deprecated modules
+	module ClassMethods
+		# Mark this module as deprecated
+		#
+		# Any time this module is run it will print warnings to that effect.
+		#
+		# @param deprecation_date [Date,#to_s] The date on which this module will
+		#   be removed
+		# @param replacement_module [String] The name of a module that users
+		#   should be using instead of this deprecated one
+		# @return [void]
+		def deprecated(deprecation_date=nil, replacement_module=nil)
+			# Yes, class instance variables.
+			@replacement_module = replacement_module
+			@deprecation_date = deprecation_date
+		end
+
+		# The name of a module that users should be using instead of this
+		# deprecated one
+		#
+		# @return [String,nil]
+		# @see ClassMethods#deprecated
+		def replacement_module; @replacement_module; end
+
+		# The date on which this module will be removed
+		#
+		# @return [Date,nil]
+		# @see ClassMethods#deprecated
+		def deprecation_date; @deprecation_date; end
+	end
+
+	# (see ClassMethods#replacement_module)
+	def replacement_module; self.class.replacement_module; end
+	# (see ClassMethods#deprecation_date)
+	def deprecation_date; self.class.deprecation_date; end
+
+	# Extends with {ClassMethods}
+	def self.included(base)
+		base.extend(ClassMethods)
+	end
+
+	def setup
+		print_warning("*"*72)
+		print_warning("*%red"+"This module is deprecated!".center(70)+"%clr*")
+		if deprecation_date
+			print_warning("*"+"It will be removed on or about #{deprecation_date}".center(70)+"*")
+		end
+		if replacement_module
+			print_warning("*"+"Use #{replacement_module} instead".center(70)+"*")
+		end
+		print_warning("*"*72)
+		super
+	end
+
+end

--- a/modules/post/windows/escalate/bypassuac.rb
+++ b/modules/post/windows/escalate/bypassuac.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.
@@ -14,6 +10,10 @@ require 'rex'
 
 class Metasploit3 < Msf::Post
 
+	require 'msf/core/module/deprecated'
+	include Msf::Module::Deprecated
+	deprecated Date.new(2013,1,4), "exploit/windows/local/bypassuac"
+
 	def initialize(info={})
 		super( update_info( info,
 			'Name'          => 'Windows Escalate UAC Protection Bypass',
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Post
 			},
 			'License'       => MSF_LICENSE,
 			'Author'        => [ 'David Kennedy "ReL1K" <kennedyd013[at]gmail.com>', 'mitnick' ],
-			'Version'       => '$Revision$',
 			'Platform'      => [ 'win' ],
 			'SessionTypes'  => [ 'meterpreter' ],
 			'References'    => [
@@ -41,12 +40,6 @@ class Metasploit3 < Msf::Post
 	end
 
 	def run
-		print_error("***********************************************")
-		print_error("*                                             *")
-		print_error("* Module will be depricated on Jan 4 2013     *")
-		print_error("* Please use exploits/windows/local/bypassuac *")
-		print_error("*                                             *")
-		print_error("***********************************************")
 		vuln = false
 		sysinfo = session.sys.config.sysinfo
 		winver = sysinfo["OS"]

--- a/modules/post/windows/escalate/ms10_092_schelevator.rb
+++ b/modules/post/windows/escalate/ms10_092_schelevator.rb
@@ -13,8 +13,7 @@ require 'zlib'
 
 class Metasploit3 < Msf::Post
 
-	#require 'msf/core/module/deprecated'
-	load 'lib/msf/core/module/deprecated.rb'
+	require 'msf/core/module/deprecated'
 	include Msf::Module::Deprecated
 	deprecated Date.new(2013,6,1), "exploit/windows/local/ms10_092_schelevator"
 

--- a/modules/post/windows/escalate/ms10_092_schelevator.rb
+++ b/modules/post/windows/escalate/ms10_092_schelevator.rb
@@ -12,6 +12,12 @@ require 'zlib'
 
 
 class Metasploit3 < Msf::Post
+
+	#require 'msf/core/module/deprecated'
+	load 'lib/msf/core/module/deprecated.rb'
+	include Msf::Module::Deprecated
+	deprecated Date.new(2013,6,1), "exploit/windows/local/ms10_092_schelevator"
+
 	include Msf::Post::Common
 
 	def initialize(info={})

--- a/modules/post/windows/escalate/ms10_092_schelevator.rb
+++ b/modules/post/windows/escalate/ms10_092_schelevator.rb
@@ -34,7 +34,6 @@ class Metasploit3 < Msf::Post
 			},
 			'License'       => MSF_LICENSE,
 			'Author'        => [ 'jduck' ],
-			'Version'       => '$Revision$',
 			'Platform'      => [ 'win' ],
 			'SessionTypes'  => [ 'meterpreter' ],
 			'References'    =>

--- a/modules/post/windows/escalate/service_permissions.rb
+++ b/modules/post/windows/escalate/service_permissions.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.
@@ -12,9 +8,12 @@
 require 'msf/core'
 require 'msf/core/post/windows/services'
 require 'rex'
-require 'msf/core//post/windows/services'
 
 class Metasploit3 < Msf::Post
+
+	require 'msf/core/module/deprecated'
+	include Msf::Module::Deprecated
+	deprecated Date.new(2013,1,10), "exploit/windows/local/service_permissions"
 
 	include ::Msf::Post::Windows::Services
 	def initialize(info={})
@@ -32,7 +31,6 @@ class Metasploit3 < Msf::Post
 			},
 			'License'       => MSF_LICENSE,
 			'Author'        => [ 'scriptjunkie' ],
-			'Version'       => '$Revision$',
 			'Platform'      => [ 'win' ],
 			'SessionTypes'  => [ 'meterpreter' ]
 		))
@@ -47,12 +45,6 @@ class Metasploit3 < Msf::Post
 	end
 
 	def run
-		print_error("*********************************************************")
-		print_error("*                                                       *")
-		print_error("*       Module will be depricated on Jan 10 2013        *")
-		print_error("* Please use exploits/windows/local/service_permissions *")
-		print_error("*                                                       *")
-		print_error("*********************************************************")
 		print_status("running")
 
 		lhost = datastore["LHOST"] || Rex::Socket.source_address


### PR DESCRIPTION
- This mixin standardizes the previously ad-hoc deprecation warnings on
  modules that have been moved.
- Uses the mixin in 3 existing modules that already have (or should have
  had) deprecation warnings.
