### PR TITLE
MSFTIDY cleanup #1 - auxiliary

### DIFF
--- a/modules/auxiliary/admin/2wire/xslt_password_reset.rb
+++ b/modules/auxiliary/admin/2wire/xslt_password_reset.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/2wire/xslt_password_reset.rb
+++ b/modules/auxiliary/admin/2wire/xslt_password_reset.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 				configuration changes (such as resetting the password) as administrators.
 			},
 			'License'        => MSF_LICENSE,
-			'Version'        => "$Revision$",
 			'Author'         =>
 				[
 					'hkm [at] hakim.ws',              #Initial discovery, poc

--- a/modules/auxiliary/admin/backupexec/dump.rb
+++ b/modules/auxiliary/admin/backupexec/dump.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/backupexec/dump.rb
+++ b/modules/auxiliary/admin/backupexec/dump.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'hdm', 'Unknown' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['CVE', '2005-2611'],

--- a/modules/auxiliary/admin/backupexec/registry.rb
+++ b/modules/auxiliary/admin/backupexec/registry.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/backupexec/registry.rb
+++ b/modules/auxiliary/admin/backupexec/registry.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'hdm' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'OSVDB', '17627' ],

--- a/modules/auxiliary/admin/cisco/cisco_secure_acs_bypass.rb
+++ b/modules/auxiliary/admin/cisco/cisco_secure_acs_bypass.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/cisco/cisco_secure_acs_bypass.rb
+++ b/modules/auxiliary/admin/cisco/cisco_secure_acs_bypass.rb
@@ -16,7 +16,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize(info = {})
 		super(update_info(info,
 			'Name'         => 'Cisco Secure ACS Version < 5.1.0.44.5 or 5.2.0.26.2 Unauthorized Password Change',
-			'Version'      => '$Revision$',
 			'Description'  => %q{
 				This module exploits an authentication bypass issue which allows arbitrary
 				password change requests to be issued for any user in the local store.

--- a/modules/auxiliary/admin/cisco/vpn_3000_ftp_bypass.rb
+++ b/modules/auxiliary/admin/cisco/vpn_3000_ftp_bypass.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/cisco/vpn_3000_ftp_bypass.rb
+++ b/modules/auxiliary/admin/cisco/vpn_3000_ftp_bypass.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'		=> [ 'patrick' ],
 			'License'		=> MSF_LICENSE,
-			'Version'		=> '$Revision$',
 			'References'	=>
 				[
 					[ 'BID', '19680' ],

--- a/modules/auxiliary/admin/db2/db2rcmd.rb
+++ b/modules/auxiliary/admin/db2/db2rcmd.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/db2/db2rcmd.rb
+++ b/modules/auxiliary/admin/db2/db2rcmd.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2004-0795' ],

--- a/modules/auxiliary/admin/edirectory/edirectory_dhost_cookie.rb
+++ b/modules/auxiliary/admin/edirectory/edirectory_dhost_cookie.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/edirectory/edirectory_dhost_cookie.rb
+++ b/modules/auxiliary/admin/edirectory/edirectory_dhost_cookie.rb
@@ -27,8 +27,7 @@ class Metasploit3 < Msf::Auxiliary
 					['OSVDB', '60035'],
 				],
 			'Author'         => 'hdm',
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 
 		register_options([

--- a/modules/auxiliary/admin/emc/alphastor_devicemanager_exec.rb
+++ b/modules/auxiliary/admin/emc/alphastor_devicemanager_exec.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/emc/alphastor_devicemanager_exec.rb
+++ b/modules/auxiliary/admin/emc/alphastor_devicemanager_exec.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'http://labs.idefense.com/intelligence/vulnerabilities/display.php?id=703' ],

--- a/modules/auxiliary/admin/emc/alphastor_librarymanager_exec.rb
+++ b/modules/auxiliary/admin/emc/alphastor_librarymanager_exec.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/emc/alphastor_librarymanager_exec.rb
+++ b/modules/auxiliary/admin/emc/alphastor_librarymanager_exec.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'http://labs.idefense.com/intelligence/vulnerabilities/display.php?id=703' ],

--- a/modules/auxiliary/admin/ftp/titanftp_xcrc_traversal.rb
+++ b/modules/auxiliary/admin/ftp/titanftp_xcrc_traversal.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/ftp/titanftp_xcrc_traversal.rb
+++ b/modules/auxiliary/admin/ftp/titanftp_xcrc_traversal.rb
@@ -30,7 +30,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => 'jduck',
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'OSVDB', '65533'],

--- a/modules/auxiliary/admin/http/contentkeeper_fileaccess.rb
+++ b/modules/auxiliary/admin/http/contentkeeper_fileaccess.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/http/contentkeeper_fileaccess.rb
+++ b/modules/auxiliary/admin/http/contentkeeper_fileaccess.rb
@@ -15,7 +15,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'ContentKeeper Web Appliance mimencode File Access',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				This module abuses the 'mimencode' binary present within
 				ContentKeeper Web filtering appliances to retrieve arbitrary

--- a/modules/auxiliary/admin/http/hp_web_jetadmin_exec.rb
+++ b/modules/auxiliary/admin/http/hp_web_jetadmin_exec.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/http/hp_web_jetadmin_exec.rb
+++ b/modules/auxiliary/admin/http/hp_web_jetadmin_exec.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'patrick' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'OSVDB', '5798' ],

--- a/modules/auxiliary/admin/http/iomega_storcenterpro_sessionid.rb
+++ b/modules/auxiliary/admin/http/iomega_storcenterpro_sessionid.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/http/iomega_storcenterpro_sessionid.rb
+++ b/modules/auxiliary/admin/http/iomega_storcenterpro_sessionid.rb
@@ -15,7 +15,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Iomega StorCenter Pro NAS Web Authentication Bypass',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				The Iomega StorCenter Pro Network Attached Storage device web interface increments sessions IDs,
 				allowing for simple brute force attacks to bypass authentication and gain administrative

--- a/modules/auxiliary/admin/http/tomcat_administration.rb
+++ b/modules/auxiliary/admin/http/tomcat_administration.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/http/tomcat_administration.rb
+++ b/modules/auxiliary/admin/http/tomcat_administration.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Tomcat Administration Tool Default Access',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect the Tomcat administration interface.',
 			'References'  =>
 				[

--- a/modules/auxiliary/admin/http/tomcat_utf8_traversal.rb
+++ b/modules/auxiliary/admin/http/tomcat_utf8_traversal.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/http/tomcat_utf8_traversal.rb
+++ b/modules/auxiliary/admin/http/tomcat_utf8_traversal.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Tomcat UTF-8 Directory Traversal Vulnerability',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				This module tests whether a directory traversal vulnerablity is present
 				in versions of Apache Tomcat 4.1.0 - 4.1.37, 5.5.0 - 5.5.26 and 6.0.0

--- a/modules/auxiliary/admin/http/trendmicro_dlp_traversal.rb
+++ b/modules/auxiliary/admin/http/trendmicro_dlp_traversal.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/http/trendmicro_dlp_traversal.rb
+++ b/modules/auxiliary/admin/http/trendmicro_dlp_traversal.rb
@@ -15,7 +15,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'TrendMicro Data Loss Prevention 5.5 Directory Traversal',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				This module tests whether a directory traversal vulnerablity is present
 				in Trend Micro DLP (Data Loss Prevention) Appliance v5.5 build <= 1294.

--- a/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
@@ -15,7 +15,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'TYPO3 sa-2009-001 Weak Encryption Key File Disclosure',
-			'Version'        => '$Revision$',
 			'Description'    => %q{
 				This module exploits a flaw in TYPO3 encryption ey creation process to allow for
 				file disclosure in the jumpUrl mechanism. This flaw can be used to read any file

--- a/modules/auxiliary/admin/http/typo3_sa_2009_002.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2009_002.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/http/typo3_sa_2009_002.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2009_002.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'spinbad <spinbad.security[at]googlemail.com>' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['OSVDB', '52048'],

--- a/modules/auxiliary/admin/http/typo3_sa_2010_020.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2010_020.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/http/typo3_sa_2010_020.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2010_020.rb
@@ -16,7 +16,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'TYPO3 sa-2010-020 Remote File Disclosure',
-			'Version'        => '$Revision$',
 			'Description'    => %q{
 				This module exploits a flaw in the way the TYPO3 jumpurl feature matches hashes.
 				Due to this flaw a Remote File Disclosure is possible by matching the juhash of 0.

--- a/modules/auxiliary/admin/http/typo3_winstaller_default_enc_keys.rb
+++ b/modules/auxiliary/admin/http/typo3_winstaller_default_enc_keys.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/http/typo3_winstaller_default_enc_keys.rb
+++ b/modules/auxiliary/admin/http/typo3_winstaller_default_enc_keys.rb
@@ -15,7 +15,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'TYPO3 Winstaller default Encryption Keys',
-			'Version'        => '$Revision$',
 			'Description'    => %q{
 				This module exploits known default encryption keys found in the TYPO3 Winstaller.
 				This flaw allows for file disclosure in the jumpUrl mechanism. This issue can be

--- a/modules/auxiliary/admin/maxdb/maxdb_cons_exec.rb
+++ b/modules/auxiliary/admin/maxdb/maxdb_cons_exec.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/maxdb/maxdb_cons_exec.rb
+++ b/modules/auxiliary/admin/maxdb/maxdb_cons_exec.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['OSVDB', '40210' ],

--- a/modules/auxiliary/admin/motorola/wr850g_cred.rb
+++ b/modules/auxiliary/admin/motorola/wr850g_cred.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/motorola/wr850g_cred.rb
+++ b/modules/auxiliary/admin/motorola/wr850g_cred.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => 'kris katterjohn',
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     => [
 					[ 'CVE', '2004-1550' ],
 					[ 'OSVDB', '10232' ],

--- a/modules/auxiliary/admin/ms/ms08_059_his2006.rb
+++ b/modules/auxiliary/admin/ms/ms08_059_his2006.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/ms/ms08_059_his2006.rb
+++ b/modules/auxiliary/admin/ms/ms08_059_his2006.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
 				},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'MSB', 'MS08-059' ],

--- a/modules/auxiliary/admin/mssql/mssql_enum.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/mssql/mssql_enum.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum.rb
@@ -22,8 +22,7 @@ class Metasploit3 < Msf::Auxiliary
 				supplied.
 			},
 			'Author'         => [ 'Carlos Perez <carlos_perez [at] darkoperator.com>' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 	end
 

--- a/modules/auxiliary/admin/mssql/mssql_exec.rb
+++ b/modules/auxiliary/admin/mssql/mssql_exec.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/mssql/mssql_exec.rb
+++ b/modules/auxiliary/admin/mssql/mssql_exec.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'tebo <tebo[at]attackresearch.com>' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'http://msdn.microsoft.com/en-us/library/cc448435(PROT.10).aspx'],

--- a/modules/auxiliary/admin/mssql/mssql_idf.rb
+++ b/modules/auxiliary/admin/mssql/mssql_idf.rb
@@ -34,7 +34,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'Robin Wood <robin[at]digininja.org>' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'http://www.digininja.org/metasploit/mssql_idf.php' ],

--- a/modules/auxiliary/admin/mssql/mssql_idf.rb
+++ b/modules/auxiliary/admin/mssql/mssql_idf.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # Author: Robin Wood <robin@digininja.org> <http://www.digininja.org>
 # Version: 0.1
 #

--- a/modules/auxiliary/admin/mssql/mssql_sql.rb
+++ b/modules/auxiliary/admin/mssql/mssql_sql.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/mssql/mssql_sql.rb
+++ b/modules/auxiliary/admin/mssql/mssql_sql.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'tebo <tebo [at] attackresearch [dot] com>' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'http://www.attackresearch.com' ],

--- a/modules/auxiliary/admin/mysql/mysql_enum.rb
+++ b/modules/auxiliary/admin/mysql/mysql_enum.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/mysql/mysql_enum.rb
+++ b/modules/auxiliary/admin/mysql/mysql_enum.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 				},
 				'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
 				'License'       => MSF_LICENSE,
-				'Version'       => '$Revision$',
 				'References'    =>
 				[
 					[ 'URL', 'https://cisecurity.org/benchmarks.html' ]

--- a/modules/auxiliary/admin/mysql/mysql_sql.rb
+++ b/modules/auxiliary/admin/mysql/mysql_sql.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/mysql/mysql_sql.rb
+++ b/modules/auxiliary/admin/mysql/mysql_sql.rb
@@ -21,8 +21,7 @@ class Metasploit3 < Msf::Auxiliary
 					against a MySQL instance given the appropriate credentials.
 			},
 			'Author'		=> [ 'Bernardo Damele A. G. <bernardo.damele[at]gmail.com>' ],
-			'License'		=> MSF_LICENSE,
-			'Version'		=> '$Revision$'
+			'License'		=> MSF_LICENSE
 		))
 
 		register_options(

--- a/modules/auxiliary/admin/officescan/tmlisten_traversal.rb
+++ b/modules/auxiliary/admin/officescan/tmlisten_traversal.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/officescan/tmlisten_traversal.rb
+++ b/modules/auxiliary/admin/officescan/tmlisten_traversal.rb
@@ -15,7 +15,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'TrendMicro OfficeScanNT Listener Traversal Arbitrary File Access',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 					This module tests for directory traversal vulnerability in the UpdateAgent
 				function in the OfficeScanNT Listener (TmListen.exe) service in Trend Micro

--- a/modules/auxiliary/admin/oracle/ora_ntlm_stealer.rb
+++ b/modules/auxiliary/admin/oracle/ora_ntlm_stealer.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/oracle/ora_ntlm_stealer.rb
+++ b/modules/auxiliary/admin/oracle/ora_ntlm_stealer.rb
@@ -25,7 +25,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'Sh2kerr <research[ad]dsecrg.com>' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'http://dsecrg.com/pages/pub/show.php?id=17' ],

--- a/modules/auxiliary/admin/oracle/oracle_login.rb
+++ b/modules/auxiliary/admin/oracle/oracle_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/oracle/oracle_login.rb
+++ b/modules/auxiliary/admin/oracle/oracle_login.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'http://www.petefinnigan.com/default/oracle_default_passwords.csv' ],

--- a/modules/auxiliary/admin/oracle/oracle_sql.rb
+++ b/modules/auxiliary/admin/oracle/oracle_sql.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/oracle/oracle_sql.rb
+++ b/modules/auxiliary/admin/oracle/oracle_sql.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'https://www.metasploit.com/users/mc' ],

--- a/modules/auxiliary/admin/oracle/oraenum.rb
+++ b/modules/auxiliary/admin/oracle/oraenum.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/oracle/oraenum.rb
+++ b/modules/auxiliary/admin/oracle/oraenum.rb
@@ -22,8 +22,7 @@ class Metasploit3 < Msf::Auxiliary
 				run.
 			},
 			'Author'         => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 
 	end

--- a/modules/auxiliary/admin/oracle/osb_execqr.rb
+++ b/modules/auxiliary/admin/oracle/osb_execqr.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/oracle/osb_execqr.rb
+++ b/modules/auxiliary/admin/oracle/osb_execqr.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2008-5448' ],

--- a/modules/auxiliary/admin/oracle/osb_execqr2.rb
+++ b/modules/auxiliary/admin/oracle/osb_execqr2.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/oracle/osb_execqr2.rb
+++ b/modules/auxiliary/admin/oracle/osb_execqr2.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2009-1977' ],

--- a/modules/auxiliary/admin/oracle/osb_execqr3.rb
+++ b/modules/auxiliary/admin/oracle/osb_execqr3.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/oracle/osb_execqr3.rb
+++ b/modules/auxiliary/admin/oracle/osb_execqr3.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2010-0904' ],

--- a/modules/auxiliary/admin/oracle/post_exploitation/win32exec.rb
+++ b/modules/auxiliary/admin/oracle/post_exploitation/win32exec.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/oracle/post_exploitation/win32exec.rb
+++ b/modules/auxiliary/admin/oracle/post_exploitation/win32exec.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'https://www.metasploit.com/users/mc' ],

--- a/modules/auxiliary/admin/oracle/post_exploitation/win32upload.rb
+++ b/modules/auxiliary/admin/oracle/post_exploitation/win32upload.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/oracle/post_exploitation/win32upload.rb
+++ b/modules/auxiliary/admin/oracle/post_exploitation/win32upload.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'CG' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'http://www.argeniss.com/research/oraclesqlinj.zip' ],

--- a/modules/auxiliary/admin/oracle/sid_brute.rb
+++ b/modules/auxiliary/admin/oracle/sid_brute.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/oracle/sid_brute.rb
+++ b/modules/auxiliary/admin/oracle/sid_brute.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'https://www.metasploit.com/users/mc' ],

--- a/modules/auxiliary/admin/oracle/tnscmd.rb
+++ b/modules/auxiliary/admin/oracle/tnscmd.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/oracle/tnscmd.rb
+++ b/modules/auxiliary/admin/oracle/tnscmd.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => ['MC'],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'DisclosureDate' => 'Feb 1 2009'
 		))
 

--- a/modules/auxiliary/admin/pop2/uw_fileretrieval.rb
+++ b/modules/auxiliary/admin/pop2/uw_fileretrieval.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/pop2/uw_fileretrieval.rb
+++ b/modules/auxiliary/admin/pop2/uw_fileretrieval.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'patrick' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'OSVDB', '368' ],

--- a/modules/auxiliary/admin/postgres/postgres_readfile.rb
+++ b/modules/auxiliary/admin/postgres/postgres_readfile.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/postgres/postgres_readfile.rb
+++ b/modules/auxiliary/admin/postgres/postgres_readfile.rb
@@ -27,8 +27,7 @@ class Metasploit3 < Msf::Auxiliary
 			'References'     =>
 				[
 					[ 'URL', 'http://michaeldaw.org/sql-injection-cheat-sheet#postgres' ]
-				],
-			'Version'        => '$Revision$'
+				]
 		))
 
 		register_options(

--- a/modules/auxiliary/admin/postgres/postgres_sql.rb
+++ b/modules/auxiliary/admin/postgres/postgres_sql.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/postgres/postgres_sql.rb
+++ b/modules/auxiliary/admin/postgres/postgres_sql.rb
@@ -24,8 +24,7 @@ class Metasploit3 < Msf::Auxiliary
 			'References'     =>
 				[
 					[ 'URL', 'www.postgresql.org' ]
-				],
-			'Version'        => '$Revision$'
+				]
 		))
 
 		#register_options( [ ], self.class) # None needed.

--- a/modules/auxiliary/admin/sap/sap_mgmt_con_osexec.rb
+++ b/modules/auxiliary/admin/sap/sap_mgmt_con_osexec.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/sap/sap_mgmt_con_osexec.rb
+++ b/modules/auxiliary/admin/sap/sap_mgmt_con_osexec.rb
@@ -16,7 +16,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'         => 'SAP Management Console OSExecute',
-			'Version'      => '$Revision$',
 			'Description'  => %q{
 				This module allows execution of operating system commands through the SAP
 				Management Console SOAP Interface. A valid username and password must be

--- a/modules/auxiliary/admin/scada/igss_exec_17.rb
+++ b/modules/auxiliary/admin/scada/igss_exec_17.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/scada/igss_exec_17.rb
+++ b/modules/auxiliary/admin/scada/igss_exec_17.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'Luigi Auriemma', 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2011-1566'],

--- a/modules/auxiliary/admin/scada/modicon_command.rb
+++ b/modules/auxiliary/admin/scada/modicon_command.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					[ 'URL', 'http://www.digitalbond.com/tools/basecamp/metasploit-modules/' ]
 				],
-			'Version'        => '$Revision$',
 			'DisclosureDate' => 'Apr 5 2012'
 			))
 		register_options(

--- a/modules/auxiliary/admin/scada/modicon_password_recovery.rb
+++ b/modules/auxiliary/admin/scada/modicon_password_recovery.rb
@@ -31,7 +31,6 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					[ 'URL', 'http://www.digitalbond.com/tools/basecamp/metasploit-modules/' ]
 				],
-			'Version'	=> '$Revision$',
 			'DisclosureDate'=> 'Jan 19 2012'
 			))
 

--- a/modules/auxiliary/admin/scada/modicon_stux_transfer.rb
+++ b/modules/auxiliary/admin/scada/modicon_stux_transfer.rb
@@ -35,7 +35,6 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					[ 'URL', 'http://www.digitalbond.com/tools/basecamp/metasploit-modules/' ]
 				],
-			'Version'        => '$Revision$',
 			'DisclosureDate' => 'Apr 5 2012'
 			))
 

--- a/modules/auxiliary/admin/scada/multi_cip_command.rb
+++ b/modules/auxiliary/admin/scada/multi_cip_command.rb
@@ -34,7 +34,6 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					[ 'URL', 'http://www.digitalbond.com/tools/basecamp/metasploit-modules/' ]
 				],
-			'Version'        => '$Revision$',
 			'DisclosureDate' => 'Jan 19 2012'))
 
 		register_options(

--- a/modules/auxiliary/admin/serverprotect/file.rb
+++ b/modules/auxiliary/admin/serverprotect/file.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/serverprotect/file.rb
+++ b/modules/auxiliary/admin/serverprotect/file.rb
@@ -28,7 +28,6 @@ class Metasploit3 < Msf::Auxiliary
 				},
 			'Author'         => [ 'toto' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2007-6507' ],

--- a/modules/auxiliary/admin/smb/check_dir_file.rb
+++ b/modules/auxiliary/admin/smb/check_dir_file.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/smb/check_dir_file.rb
+++ b/modules/auxiliary/admin/smb/check_dir_file.rb
@@ -25,7 +25,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SMB Scanner Check File/Directory Utility',
-			'Version'     => '$Revision$',
 			'Description' => %Q{
 				This module is useful when checking an entire network
 				of SMB hosts for the presence of a known file or directory.

--- a/modules/auxiliary/admin/smb/list_directory.rb
+++ b/modules/auxiliary/admin/smb/list_directory.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/smb/list_directory.rb
+++ b/modules/auxiliary/admin/smb/list_directory.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SMB Directory Listing Utility',
-			'Version'     => '$Revision$',
 			'Description' => %Q{
 				This module lists the directory of a target share and path. The only reason
 			to use this module is if your existing SMB client is not able to support the features

--- a/modules/auxiliary/admin/smb/samba_symlink_traversal.rb
+++ b/modules/auxiliary/admin/smb/samba_symlink_traversal.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/smb/samba_symlink_traversal.rb
+++ b/modules/auxiliary/admin/smb/samba_symlink_traversal.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Samba Symlink Directory Traversal',
-			'Version'     => '$Revision$',
 			'Description' => %Q{
 				This module exploits a directory traversal flaw in the Samba
 			CIFS server. To exploit this flaw, a writeable share must be specified.

--- a/modules/auxiliary/admin/smb/upload_file.rb
+++ b/modules/auxiliary/admin/smb/upload_file.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/smb/upload_file.rb
+++ b/modules/auxiliary/admin/smb/upload_file.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SMB File Upload Utility',
-			'Version'     => '$Revision$',
 			'Description' => %Q{
 				This module uploads a file to a target share and path. The only reason
 			to use this module is if your existing SMB client is not able to support the features

--- a/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
+++ b/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
+++ b/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
@@ -31,7 +31,6 @@ class Metasploit3 < Msf::Auxiliary
 					'jduck'  # Ported to MSF v3
 				],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['CVE', '2003-0027'],

--- a/modules/auxiliary/admin/tikiwiki/tikidblib.rb
+++ b/modules/auxiliary/admin/tikiwiki/tikidblib.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/tikiwiki/tikidblib.rb
+++ b/modules/auxiliary/admin/tikiwiki/tikidblib.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'Matteo Cantoni <goony[at]nothink.org>' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['OSVDB', '30172'],

--- a/modules/auxiliary/admin/vmware/poweroff_vm.rb
+++ b/modules/auxiliary/admin/vmware/poweroff_vm.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/vmware/poweron_vm.rb
+++ b/modules/auxiliary/admin/vmware/poweron_vm.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/vmware/tag_vm.rb
+++ b/modules/auxiliary/admin/vmware/tag_vm.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/vmware/terminate_esx_sessions.rb
+++ b/modules/auxiliary/admin/vmware/terminate_esx_sessions.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/vnc/realvnc_41_bypass.rb
+++ b/modules/auxiliary/admin/vnc/realvnc_41_bypass.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/vnc/realvnc_41_bypass.rb
+++ b/modules/auxiliary/admin/vnc/realvnc_41_bypass.rb
@@ -28,7 +28,6 @@ class Metasploit3 < Msf::Auxiliary
 					'theLightCosine'
 				],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['BID', '17978'],

--- a/modules/auxiliary/admin/vxworks/apple_airport_extreme_password.rb
+++ b/modules/auxiliary/admin/vxworks/apple_airport_extreme_password.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/vxworks/apple_airport_extreme_password.rb
+++ b/modules/auxiliary/admin/vxworks/apple_airport_extreme_password.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'hdm'],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['OSVDB', '66842'],

--- a/modules/auxiliary/admin/vxworks/dlink_i2eye_autoanswer.rb
+++ b/modules/auxiliary/admin/vxworks/dlink_i2eye_autoanswer.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/vxworks/dlink_i2eye_autoanswer.rb
+++ b/modules/auxiliary/admin/vxworks/dlink_i2eye_autoanswer.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'hdm'],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['OSVDB', '66842'],

--- a/modules/auxiliary/admin/vxworks/wdbrpc_memory_dump.rb
+++ b/modules/auxiliary/admin/vxworks/wdbrpc_memory_dump.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/vxworks/wdbrpc_memory_dump.rb
+++ b/modules/auxiliary/admin/vxworks/wdbrpc_memory_dump.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'hdm'],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['OSVDB', '66842'],

--- a/modules/auxiliary/admin/vxworks/wdbrpc_reboot.rb
+++ b/modules/auxiliary/admin/vxworks/wdbrpc_reboot.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/vxworks/wdbrpc_reboot.rb
+++ b/modules/auxiliary/admin/vxworks/wdbrpc_reboot.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'hdm'],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['OSVDB', '66842'],

--- a/modules/auxiliary/admin/webmin/file_disclosure.rb
+++ b/modules/auxiliary/admin/webmin/file_disclosure.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/webmin/file_disclosure.rb
+++ b/modules/auxiliary/admin/webmin/file_disclosure.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'Matteo Cantoni <goony[at]nothink.org>' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['OSVDB', '26772'],

--- a/modules/auxiliary/admin/zend/java_bridge.rb
+++ b/modules/auxiliary/admin/zend/java_bridge.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/admin/zend/java_bridge.rb
+++ b/modules/auxiliary/admin/zend/java_bridge.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'ikki', 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'OSVDB', '71420'],

--- a/modules/auxiliary/analyze/jtr_aix.rb
+++ b/modules/auxiliary/analyze/jtr_aix.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/analyze/jtr_aix.rb
+++ b/modules/auxiliary/analyze/jtr_aix.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'            => 'John the Ripper AIX Password Cracker',
-			'Version'         => '$Revision$',
 			'Description'     => %Q{
 					This module uses John the Ripper to identify weak passwords that have been
 				acquired from passwd files on AIX systems.

--- a/modules/auxiliary/analyze/jtr_crack_fast.rb
+++ b/modules/auxiliary/analyze/jtr_crack_fast.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/analyze/jtr_crack_fast.rb
+++ b/modules/auxiliary/analyze/jtr_crack_fast.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'				=> 'John the Ripper Password Cracker (Fast Mode)',
-			'Version'           => '$Revision$',
 			'Description'       => %Q{
 					This module uses John the Ripper to identify weak passwords that have been
 				acquired as hashed files (loot) or raw LANMAN/NTLM hashes (hashdump). The goal

--- a/modules/auxiliary/analyze/jtr_linux.rb
+++ b/modules/auxiliary/analyze/jtr_linux.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/analyze/jtr_linux.rb
+++ b/modules/auxiliary/analyze/jtr_linux.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'            => 'John the Ripper Linux Password Cracker',
-			'Version'         => '$Revision$',
 			'Description'     => %Q{
 					This module uses John the Ripper to identify weak passwords that have been
 				acquired from unshadowed passwd files from Unix systems. The module will only crack

--- a/modules/auxiliary/analyze/jtr_mssql_fast.rb
+++ b/modules/auxiliary/analyze/jtr_mssql_fast.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/analyze/jtr_mssql_fast.rb
+++ b/modules/auxiliary/analyze/jtr_mssql_fast.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'John the Ripper MS SQL Password Cracker (Fast Mode)',
-			'Version'        => "$Revision$",
 			'Description'    => %Q{
 					This module uses John the Ripper to identify weak passwords that have been
 				acquired from the mssql_hashdump module. Passwords that have been successfully

--- a/modules/auxiliary/analyze/jtr_mysql_fast.rb
+++ b/modules/auxiliary/analyze/jtr_mysql_fast.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/analyze/jtr_mysql_fast.rb
+++ b/modules/auxiliary/analyze/jtr_mysql_fast.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'          => 'John the Ripper MySQL Password Cracker (Fast Mode)',
-			'Version'       => '$Revision$',
 			'Description'   => %Q{
 					This module uses John the Ripper to identify weak passwords that have been
 				acquired from the mysql_hashdump module. Passwords that have been successfully

--- a/modules/auxiliary/analyze/jtr_oracle_fast.rb
+++ b/modules/auxiliary/analyze/jtr_oracle_fast.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/analyze/jtr_oracle_fast.rb
+++ b/modules/auxiliary/analyze/jtr_oracle_fast.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'John the Ripper Oracle Password Cracker (Fast Mode)',
-			'Version'        => "$Revision$",
 			'Description'    => %Q{
 					This module uses John the Ripper to identify weak passwords that have been
 				acquired from the oracle_hashdump module. Passwords that have been successfully

--- a/modules/auxiliary/analyze/jtr_unshadow.rb
+++ b/modules/auxiliary/analyze/jtr_unshadow.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/analyze/jtr_unshadow.rb
+++ b/modules/auxiliary/analyze/jtr_unshadow.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'              => 'Unix Unshadow Utility',
-			'Version'           => "$Revision$",
 			'Description'       => %Q{
 					This module takes a passwd and shadow file and 'unshadows'
 					them and saves them as linux.hashes loot.

--- a/modules/auxiliary/analyze/postgres_md5_crack.rb
+++ b/modules/auxiliary/analyze/postgres_md5_crack.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/analyze/postgres_md5_crack.rb
+++ b/modules/auxiliary/analyze/postgres_md5_crack.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Postgres SQL md5 Password Cracker',
-			'Version'        => '$Revision$',
 			'Description'    => %Q{
 					This module attempts to crack Postgres SQL md5 password hashes.
 				It creates hashes based on information saved in the MSF Database

--- a/modules/auxiliary/bnat/bnat_router.rb
+++ b/modules/auxiliary/bnat/bnat_router.rb
@@ -1,7 +1,3 @@
-###
-# $Id$
-###
-
 ##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit

--- a/modules/auxiliary/bnat/bnat_router.rb
+++ b/modules/auxiliary/bnat/bnat_router.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'         => 'BNAT Router',
-			'Version'      => '$Revision$',
 			'Description'  => %q{
 					This module will properly route BNAT traffic and allow for connections to be
 				established to machines on ports which might not otherwise be accessible.},

--- a/modules/auxiliary/bnat/bnat_scan.rb
+++ b/modules/auxiliary/bnat/bnat_scan.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'         => 'BNAT Scanner',
-			'Version'      => '$Revision$',
 			'Description'  => %q{
 					This module is a scanner which can detect Broken NAT (network address translation)
 				implementations, which could result in a inability to reach ports on remote

--- a/modules/auxiliary/bnat/bnat_scan.rb
+++ b/modules/auxiliary/bnat/bnat_scan.rb
@@ -1,7 +1,3 @@
-###
-# $Id$
-###
-
 ##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit

--- a/modules/auxiliary/client/smtp/emailer.rb
+++ b/modules/auxiliary/client/smtp/emailer.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/client/smtp/emailer.rb
+++ b/modules/auxiliary/client/smtp/emailer.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Auxiliary
 				engineering.
 			},
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'http://spl0it.org/' ],

--- a/modules/auxiliary/crawler/msfcrawler.rb
+++ b/modules/auxiliary/crawler/msfcrawler.rb
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 #
-# $Id$
-#
 # Web Crawler.
 #
 # Author:  Efrain Torres   et [at] metasploit.com 2010

--- a/modules/auxiliary/crawler/msfcrawler.rb
+++ b/modules/auxiliary/crawler/msfcrawler.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize(info = {})
 		super(update_info(info,
 			'Name'			=> 'Metasploit Web Crawler',
-			'Version'           => '$Revision$',
 			'Description'       => 'This auxiliary module is a modular web crawler, to be used in conjuntion with wmap (someday) or standalone.',
 			'Author'			=> 'et',
 			'License'			=> MSF_LICENSE

--- a/modules/auxiliary/dos/cisco/ios_http_percentpercent.rb
+++ b/modules/auxiliary/dos/cisco/ios_http_percentpercent.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/cisco/ios_http_percentpercent.rb
+++ b/modules/auxiliary/dos/cisco/ios_http_percentpercent.rb
@@ -25,7 +25,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author' 		=> [ 'Patrick Webster <patrick[at]aushack.com>' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'BID', '1154'],

--- a/modules/auxiliary/dos/dhcp/isc_dhcpd_clientid.rb
+++ b/modules/auxiliary/dos/dhcp/isc_dhcpd_clientid.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/dhcp/isc_dhcpd_clientid.rb
+++ b/modules/auxiliary/dos/dhcp/isc_dhcpd_clientid.rb
@@ -28,7 +28,6 @@ class Metasploit3 < Msf::Auxiliary
 						'theLightCosine' # msf module
 					],
 			'License'       => MSF_LICENSE,
-			'Version'       => '$Revision$',
 			'References'    =>
 				[
 					[ 'CVE', '2010-2156' ],

--- a/modules/auxiliary/dos/freebsd/nfsd/nfsd_mount.rb
+++ b/modules/auxiliary/dos/freebsd/nfsd/nfsd_mount.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/freebsd/nfsd/nfsd_mount.rb
+++ b/modules/auxiliary/dos/freebsd/nfsd/nfsd_mount.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'http://lists.immunitysec.com/pipermail/dailydave/2006-February/002982.html' ],

--- a/modules/auxiliary/dos/hp/data_protector_rds.rb
+++ b/modules/auxiliary/dos/hp/data_protector_rds.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/hp/data_protector_rds.rb
+++ b/modules/auxiliary/dos/hp/data_protector_rds.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Auxiliary
 					'sinn3r',                            #msf
 				],
 			'License'     => MSF_LICENSE,
-			'Version'     => '$Revision$',
 			'References'  =>
 				[
 					[ 'CVE', '2011-0514' ],

--- a/modules/auxiliary/dos/http/3com_superstack_switch.rb
+++ b/modules/auxiliary/dos/http/3com_superstack_switch.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/http/3com_superstack_switch.rb
+++ b/modules/auxiliary/dos/http/3com_superstack_switch.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'patrick' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					# patrickw - I am not sure if these are correct, but the closest match!

--- a/modules/auxiliary/dos/http/apache_mod_isapi.rb
+++ b/modules/auxiliary/dos/http/apache_mod_isapi.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/http/apache_mod_isapi.rb
+++ b/modules/auxiliary/dos/http/apache_mod_isapi.rb
@@ -39,7 +39,6 @@ class Metasploit3 < Msf::Auxiliary
 					'Brett Gervasoni',  # original discovery
 					'jduck'
 				],
-			'Version'        => '$Revision$',
 			'License'        => MSF_LICENSE,
 			'References'     =>
 				[

--- a/modules/auxiliary/dos/http/apache_range_dos.rb
+++ b/modules/auxiliary/dos/http/apache_range_dos.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/http/apache_range_dos.rb
+++ b/modules/auxiliary/dos/http/apache_range_dos.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Auxiliary
 					'Masashi Fujiwara' #metasploit module
 				],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'BID', '49303'],

--- a/modules/auxiliary/dos/http/apache_tomcat_transfer_encoding.rb
+++ b/modules/auxiliary/dos/http/apache_tomcat_transfer_encoding.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/http/apache_tomcat_transfer_encoding.rb
+++ b/modules/auxiliary/dos/http/apache_tomcat_transfer_encoding.rb
@@ -28,7 +28,6 @@ class Metasploit3 < Msf::Auxiliary
 					'Paulino Calderon <calderon [at] websec {dot} mx>', #metasploit module
 				],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2010-2227' ],

--- a/modules/auxiliary/dos/http/dell_openmanage_post.rb
+++ b/modules/auxiliary/dos/http/dell_openmanage_post.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/http/dell_openmanage_post.rb
+++ b/modules/auxiliary/dos/http/dell_openmanage_post.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'patrick' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'http://archives.neohapsis.com/archives/bugtraq/2004-02/0650.html' ],

--- a/modules/auxiliary/dos/http/hashcollision_dos.rb
+++ b/modules/auxiliary/dos/http/hashcollision_dos.rb
@@ -36,7 +36,6 @@ class Metasploit3 < Msf::Auxiliary
 					'Christian Mehlmauer <FireFart[at]gmail.com>' # metasploit module
 				],
 			'License'       => MSF_LICENSE,
-			'Version'       => '$Revision$',
 			'References'    =>
 				[
 					['URL', 'http://www.ocert.org/advisories/ocert-2011-003.html'],

--- a/modules/auxiliary/dos/http/sonicwall_ssl_format.rb
+++ b/modules/auxiliary/dos/http/sonicwall_ssl_format.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/http/sonicwall_ssl_format.rb
+++ b/modules/auxiliary/dos/http/sonicwall_ssl_format.rb
@@ -25,7 +25,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'patrick' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     => [
 				[ 'BID', '35145' ],
 				#[ 'CVE', '' ], # no CVE?

--- a/modules/auxiliary/dos/http/webrick_regex.rb
+++ b/modules/auxiliary/dos/http/webrick_regex.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/http/webrick_regex.rb
+++ b/modules/auxiliary/dos/http/webrick_regex.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => 'kris katterjohn',
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     => [
 				[ 'BID', '30644'],
 				[ 'CVE', '2008-3656'],

--- a/modules/auxiliary/dos/mdns/avahi_portzero.rb
+++ b/modules/auxiliary/dos/mdns/avahi_portzero.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/mdns/avahi_portzero.rb
+++ b/modules/auxiliary/dos/mdns/avahi_portzero.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'      => 'kris katterjohn',
 			'License'     => MSF_LICENSE,
-			'Version'     => '$Revision$',
 			'References'  => [
 				[ 'CVE', '2008-5081' ],
 				[ 'OSVDB', '50929' ],

--- a/modules/auxiliary/dos/ntp/ntpd_reserved_dos.rb
+++ b/modules/auxiliary/dos/ntp/ntpd_reserved_dos.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/ntp/ntpd_reserved_dos.rb
+++ b/modules/auxiliary/dos/ntp/ntpd_reserved_dos.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'todb' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'BID', '37255' ],

--- a/modules/auxiliary/dos/pptp/ms02_063_pptp_dos.rb
+++ b/modules/auxiliary/dos/pptp/ms02_063_pptp_dos.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/pptp/ms02_063_pptp_dos.rb
+++ b/modules/auxiliary/dos/pptp/ms02_063_pptp_dos.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author' 	=> [ 'patrick' ],
 			'License'       => MSF_LICENSE,
-			'Version'       => '$Revision$',
 			'References'    =>
 			[
 				[ 'BID', '5807' ],

--- a/modules/auxiliary/dos/samba/lsa_addprivs_heap.rb
+++ b/modules/auxiliary/dos/samba/lsa_addprivs_heap.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/samba/lsa_addprivs_heap.rb
+++ b/modules/auxiliary/dos/samba/lsa_addprivs_heap.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'hdm' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['CVE', '2007-2446'],

--- a/modules/auxiliary/dos/samba/lsa_transnames_heap.rb
+++ b/modules/auxiliary/dos/samba/lsa_transnames_heap.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/samba/lsa_transnames_heap.rb
+++ b/modules/auxiliary/dos/samba/lsa_transnames_heap.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'hdm' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['CVE', '2007-2446'],

--- a/modules/auxiliary/dos/scada/beckhoff_twincat.rb
+++ b/modules/auxiliary/dos/scada/beckhoff_twincat.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/scada/beckhoff_twincat.rb
+++ b/modules/auxiliary/dos/scada/beckhoff_twincat.rb
@@ -25,7 +25,6 @@ class Metasploit3 < Msf::Auxiliary
 					'jfa',            # Metasploit module
 				],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2011-3486' ],

--- a/modules/auxiliary/dos/scada/d20_tftp_overflow.rb
+++ b/modules/auxiliary/dos/scada/d20_tftp_overflow.rb
@@ -43,7 +43,6 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					[ 'URL', 'http://www.digitalbond.com/tools/basecamp/metasploit-modules/' ]
 				],
-			'Version'        => '$Revision$',
 			'DisclosureDate' => 'Jan 19 2012'
 			))
 

--- a/modules/auxiliary/dos/smtp/sendmail_prescan.rb
+++ b/modules/auxiliary/dos/smtp/sendmail_prescan.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/smtp/sendmail_prescan.rb
+++ b/modules/auxiliary/dos/smtp/sendmail_prescan.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
 				bytes can be used, limiting the likelihood for arbitrary code execution.
 			},
 			'Author'         => [ 'patrick' ],
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'OSVDB', '2577' ],

--- a/modules/auxiliary/dos/solaris/lpd/cascade_delete.rb
+++ b/modules/auxiliary/dos/solaris/lpd/cascade_delete.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/solaris/lpd/cascade_delete.rb
+++ b/modules/auxiliary/dos/solaris/lpd/cascade_delete.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'hdm', 'Optyx <optyx[at]uberhax0r.net>' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2005-4797' ],

--- a/modules/auxiliary/dos/ssl/dtls_changecipherspec.rb
+++ b/modules/auxiliary/dos/ssl/dtls_changecipherspec.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/ssl/dtls_changecipherspec.rb
+++ b/modules/auxiliary/dos/ssl/dtls_changecipherspec.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Auxiliary
 						'theLightCosine' # metasploit module
 						],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2009-1386' ],

--- a/modules/auxiliary/dos/syslog/rsyslog_long_tag.rb
+++ b/modules/auxiliary/dos/syslog/rsyslog_long_tag.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/syslog/rsyslog_long_tag.rb
+++ b/modules/auxiliary/dos/syslog/rsyslog_long_tag.rb
@@ -25,7 +25,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE,
-			'Version'     => '$Revision$',
 			'References'  =>
 				[
 					[ 'CVE', '2011-3200'],

--- a/modules/auxiliary/dos/tcp/junos_tcp_opt.rb
+++ b/modules/auxiliary/dos/tcp/junos_tcp_opt.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/tcp/junos_tcp_opt.rb
+++ b/modules/auxiliary/dos/tcp/junos_tcp_opt.rb
@@ -30,8 +30,7 @@ class Metasploit3 < Msf::Auxiliary
 					['BID', '37670'],
 					['OSVDB', '61538'],
 					['URL','http://praetorianprefect.com/archives/2010/01/junos-juniper-flaw-exposes-core-routers-to-kernal-crash/']
-				],
-			'Version'     => '$Revision$' # 02/02/2010
+				]
 		)
 
 		register_options([

--- a/modules/auxiliary/dos/tcp/synflood.rb
+++ b/modules/auxiliary/dos/tcp/synflood.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/tcp/synflood.rb
+++ b/modules/auxiliary/dos/tcp/synflood.rb
@@ -17,8 +17,7 @@ class Metasploit3 < Msf::Auxiliary
 			'Name'        => 'TCP SYN Flooder',
 			'Description' => 'A simple TCP SYN flooder',
 			'Author'      => 'kris katterjohn',
-			'License'     => MSF_LICENSE,
-			'Version'     => '$Revision$' # 03/13/2009
+			'License'     => MSF_LICENSE
 		)
 
 		register_options([

--- a/modules/auxiliary/dos/wifi/apple_orinoco_probe_response.rb
+++ b/modules/auxiliary/dos/wifi/apple_orinoco_probe_response.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/wifi/apple_orinoco_probe_response.rb
+++ b/modules/auxiliary/dos/wifi/apple_orinoco_probe_response.rb
@@ -33,8 +33,7 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					['CVE', '2006-5710'],
 					['OSVDB', '30180'],
-				],
-			'Version'        => '$Revision$'
+				]
 		))
 		register_options(
 			[

--- a/modules/auxiliary/dos/wifi/cts_rts_flood.rb
+++ b/modules/auxiliary/dos/wifi/cts_rts_flood.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/wifi/cts_rts_flood.rb
+++ b/modules/auxiliary/dos/wifi/cts_rts_flood.rb
@@ -20,8 +20,7 @@ class Metasploit3 < Msf::Auxiliary
 				using the specified source address,
 			},
 			'Author'	=> [ 'Brad Antoniewicz' ],
-			'License'	=> MSF_LICENSE,
-			'Version'	=> '$Revision$'
+			'License'	=> MSF_LICENSE
 			))
 
 		register_options(

--- a/modules/auxiliary/dos/wifi/deauth.rb
+++ b/modules/auxiliary/dos/wifi/deauth.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/wifi/deauth.rb
+++ b/modules/auxiliary/dos/wifi/deauth.rb
@@ -21,8 +21,7 @@ class Metasploit3 < Msf::Auxiliary
 			},
 
 			'Author'	=> [ 'Brad Antoniewicz' ],
-			'License'	=> MSF_LICENSE,
-			'Version'	=> '$Revision$'
+			'License'	=> MSF_LICENSE
 		))
 
 		register_options(

--- a/modules/auxiliary/dos/wifi/fakeap.rb
+++ b/modules/auxiliary/dos/wifi/fakeap.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/wifi/fakeap.rb
+++ b/modules/auxiliary/dos/wifi/fakeap.rb
@@ -25,8 +25,7 @@ class Metasploit3 < Msf::Auxiliary
 			},
 
 			'Author'         => [ 'hdm', 'kris katterjohn' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 
 		register_options([

--- a/modules/auxiliary/dos/wifi/file2air.rb
+++ b/modules/auxiliary/dos/wifi/file2air.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/wifi/file2air.rb
+++ b/modules/auxiliary/dos/wifi/file2air.rb
@@ -25,8 +25,7 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			# 11/03/2008
 			'Author'      => 'kris katterjohn',
-			'License'     => MSF_LICENSE,
-			'Version'     => '$Revision$'
+			'License'     => MSF_LICENSE
 		))
 
 		register_options([

--- a/modules/auxiliary/dos/wifi/netgear_ma521_rates.rb
+++ b/modules/auxiliary/dos/wifi/netgear_ma521_rates.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/wifi/netgear_ma521_rates.rb
+++ b/modules/auxiliary/dos/wifi/netgear_ma521_rates.rb
@@ -30,7 +30,6 @@ class Metasploit3 < Msf::Auxiliary
 				(external/ruby-lorcon/README) for more information.
 			},
 			'Author'         => [ 'Laurent Butti <0x9090 [at] gmail.com>' ], # initial discovery and metasploit module
-			'Version'        => '$Revision$',
 			'License'        => MSF_LICENSE,
 			'References'     =>
 				[

--- a/modules/auxiliary/dos/wifi/netgear_wg311pci.rb
+++ b/modules/auxiliary/dos/wifi/netgear_wg311pci.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/wifi/netgear_wg311pci.rb
+++ b/modules/auxiliary/dos/wifi/netgear_wg311pci.rb
@@ -28,7 +28,6 @@ class Metasploit3 < Msf::Auxiliary
 				(external/ruby-lorcon/README) for more information.
 			},
 			'Author'         => [ 'Laurent Butti <0x9090 [at] gmail.com>' ], # initial discovery and metasploit module
-			'Version'        => '$Revision$',
 			'License'        => MSF_LICENSE,
 			'References'     =>
 				[

--- a/modules/auxiliary/dos/wifi/probe_resp_null_ssid.rb
+++ b/modules/auxiliary/dos/wifi/probe_resp_null_ssid.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/wifi/probe_resp_null_ssid.rb
+++ b/modules/auxiliary/dos/wifi/probe_resp_null_ssid.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Auxiliary
 
 			'Author'         => [ 'hdm' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 			[
 				['URL', 'http://802.11ninja.net/papers/firmware_attack.pdf'],

--- a/modules/auxiliary/dos/wifi/ssidlist_beacon.rb
+++ b/modules/auxiliary/dos/wifi/ssidlist_beacon.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/wifi/ssidlist_beacon.rb
+++ b/modules/auxiliary/dos/wifi/ssidlist_beacon.rb
@@ -29,8 +29,7 @@ class Metasploit3 < Msf::Auxiliary
 			},
 
 			'Author'         => [ 'joswr1ght', 'hdm' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 		register_options(
 			[

--- a/modules/auxiliary/dos/wifi/wifun.rb
+++ b/modules/auxiliary/dos/wifi/wifun.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/wifi/wifun.rb
+++ b/modules/auxiliary/dos/wifi/wifun.rb
@@ -23,8 +23,7 @@ class Metasploit3 < Msf::Auxiliary
 			},
 
 			'Author'         => [ 'hdm' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 	end
 

--- a/modules/auxiliary/dos/windows/appian/appian_bpm.rb
+++ b/modules/auxiliary/dos/windows/appian/appian_bpm.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/appian/appian_bpm.rb
+++ b/modules/auxiliary/dos/windows/appian/appian_bpm.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
 
 			'Author'         => [ 'guiness.stout <guinness.stout[at]gmail.com>' ],
 			'License'        => BSD_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['CVE', '2007-6509'],

--- a/modules/auxiliary/dos/windows/browser/ms09_065_eot_integer.rb
+++ b/modules/auxiliary/dos/windows/browser/ms09_065_eot_integer.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/browser/ms09_065_eot_integer.rb
+++ b/modules/auxiliary/dos/windows/browser/ms09_065_eot_integer.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         => 'hdm',
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2009-2514' ],

--- a/modules/auxiliary/dos/windows/ftp/filezilla_admin_user.rb
+++ b/modules/auxiliary/dos/windows/ftp/filezilla_admin_user.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/ftp/filezilla_admin_user.rb
+++ b/modules/auxiliary/dos/windows/ftp/filezilla_admin_user.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author' 		=> [ 'patrick' ],
 			'License'        	=> MSF_LICENSE,
-			'Version'        	=> '$Revision$',
 			'References'     =>
 				[
 					[ 'BID', '15346' ],

--- a/modules/auxiliary/dos/windows/ftp/filezilla_server_port.rb
+++ b/modules/auxiliary/dos/windows/ftp/filezilla_server_port.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/ftp/filezilla_server_port.rb
+++ b/modules/auxiliary/dos/windows/ftp/filezilla_server_port.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author' 		=> [ 'patrick' ],
 			'License'        	=> MSF_LICENSE,
-			'Version'        	=> '$Revision$',
 			'References'     =>
 				[
 					[ 'BID', '21542' ],

--- a/modules/auxiliary/dos/windows/ftp/guildftp_cwdlist.rb
+++ b/modules/auxiliary/dos/windows/ftp/guildftp_cwdlist.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/ftp/guildftp_cwdlist.rb
+++ b/modules/auxiliary/dos/windows/ftp/guildftp_cwdlist.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => 'kris katterjohn',
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2008-4572' ],

--- a/modules/auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof.rb
+++ b/modules/auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof.rb
+++ b/modules/auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof.rb
@@ -29,7 +29,6 @@ class Metasploit3 < Msf::Auxiliary
 					'jduck'            # Metasploit module
 				],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2010-3972' ],

--- a/modules/auxiliary/dos/windows/ftp/solarftp_user.rb
+++ b/modules/auxiliary/dos/windows/ftp/solarftp_user.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/ftp/solarftp_user.rb
+++ b/modules/auxiliary/dos/windows/ftp/solarftp_user.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Auxiliary
 				'sinn3r',                                  #Metasploit edit/commit
 			],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 			[
 				[ 'EDB', '16204' ],

--- a/modules/auxiliary/dos/windows/ftp/titan626_site.rb
+++ b/modules/auxiliary/dos/windows/ftp/titan626_site.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/ftp/titan626_site.rb
+++ b/modules/auxiliary/dos/windows/ftp/titan626_site.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => 'kris katterjohn',
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2008-6082'],

--- a/modules/auxiliary/dos/windows/ftp/vicftps50_list.rb
+++ b/modules/auxiliary/dos/windows/ftp/vicftps50_list.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/ftp/vicftps50_list.rb
+++ b/modules/auxiliary/dos/windows/ftp/vicftps50_list.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => 'kris katterjohn',
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2008-2031' ],

--- a/modules/auxiliary/dos/windows/ftp/winftp230_nlst.rb
+++ b/modules/auxiliary/dos/windows/ftp/winftp230_nlst.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/ftp/winftp230_nlst.rb
+++ b/modules/auxiliary/dos/windows/ftp/winftp230_nlst.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => 'kris katterjohn',
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2008-5666' ],

--- a/modules/auxiliary/dos/windows/ftp/xmeasy560_nlst.rb
+++ b/modules/auxiliary/dos/windows/ftp/xmeasy560_nlst.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/ftp/xmeasy560_nlst.rb
+++ b/modules/auxiliary/dos/windows/ftp/xmeasy560_nlst.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => 'kris katterjohn',
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2008-5626'],

--- a/modules/auxiliary/dos/windows/ftp/xmeasy570_nlst.rb
+++ b/modules/auxiliary/dos/windows/ftp/xmeasy570_nlst.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/ftp/xmeasy570_nlst.rb
+++ b/modules/auxiliary/dos/windows/ftp/xmeasy570_nlst.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => 'kris katterjohn',
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     => [
 				[ 'CVE', '2008-5626'],
 				[ 'OSVDB', '50837'],

--- a/modules/auxiliary/dos/windows/games/kaillera.rb
+++ b/modules/auxiliary/dos/windows/games/kaillera.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/games/kaillera.rb
+++ b/modules/auxiliary/dos/windows/games/kaillera.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => ["Sil3nt_Dre4m"],
 			'License'        => MSF_LICENSE,
-			'Version'        => "$Revision$",
 			'References'     =>
 				[
 					[ 'URL', 'http://kaillerahacks.blogspot.com/2011/07/kaillera-server-086-dos-vulnerability.html' ]

--- a/modules/auxiliary/dos/windows/http/ms10_065_ii6_asp_dos.rb
+++ b/modules/auxiliary/dos/windows/http/ms10_065_ii6_asp_dos.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/http/ms10_065_ii6_asp_dos.rb
+++ b/modules/auxiliary/dos/windows/http/ms10_065_ii6_asp_dos.rb
@@ -28,7 +28,6 @@ class Metasploit3 < Msf::Auxiliary
 					'Leandro Oliveira <leadro[at]alligatorteam.org>'
 				],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2010-1899' ],

--- a/modules/auxiliary/dos/windows/http/pi3web_isapi.rb
+++ b/modules/auxiliary/dos/windows/http/pi3web_isapi.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/http/pi3web_isapi.rb
+++ b/modules/auxiliary/dos/windows/http/pi3web_isapi.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => 'kris katterjohn',
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     => [
 				[ 'CVE', '2008-6938'],
 				[ 'OSVDB', '49998'],

--- a/modules/auxiliary/dos/windows/llmnr/ms11_030_dnsapi.rb
+++ b/modules/auxiliary/dos/windows/llmnr/ms11_030_dnsapi.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/llmnr/ms11_030_dnsapi.rb
+++ b/modules/auxiliary/dos/windows/llmnr/ms11_030_dnsapi.rb
@@ -29,7 +29,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'      => 'jduck',
 			'License'     => MSF_LICENSE,
-			'Version'     => '$Revision$',
 			'References'  =>
 				[
 					[ 'CVE', '2011-0657' ],

--- a/modules/auxiliary/dos/windows/nat/nat_helper.rb
+++ b/modules/auxiliary/dos/windows/nat/nat_helper.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/nat/nat_helper.rb
+++ b/modules/auxiliary/dos/windows/nat/nat_helper.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'OSVDB', '30096'],

--- a/modules/auxiliary/dos/windows/smb/ms05_047_pnp.rb
+++ b/modules/auxiliary/dos/windows/smb/ms05_047_pnp.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/smb/ms05_047_pnp.rb
+++ b/modules/auxiliary/dos/windows/smb/ms05_047_pnp.rb
@@ -27,7 +27,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'hdm' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2005-2120' ],

--- a/modules/auxiliary/dos/windows/smb/ms06_035_mailslot.rb
+++ b/modules/auxiliary/dos/windows/smb/ms06_035_mailslot.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/smb/ms06_035_mailslot.rb
+++ b/modules/auxiliary/dos/windows/smb/ms06_035_mailslot.rb
@@ -28,7 +28,6 @@ class Metasploit3 < Msf::Auxiliary
 
 			'Author'         => [ 'hdm' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['BID', '19215'],

--- a/modules/auxiliary/dos/windows/smb/ms06_063_trans.rb
+++ b/modules/auxiliary/dos/windows/smb/ms06_063_trans.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/smb/ms06_063_trans.rb
+++ b/modules/auxiliary/dos/windows/smb/ms06_063_trans.rb
@@ -25,7 +25,6 @@ class Metasploit3 < Msf::Auxiliary
 
 			'Author'         => [ 'hdm' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['OSVDB', '27644' ],

--- a/modules/auxiliary/dos/windows/smb/ms09_001_write.rb
+++ b/modules/auxiliary/dos/windows/smb/ms09_001_write.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/smb/ms09_001_write.rb
+++ b/modules/auxiliary/dos/windows/smb/ms09_001_write.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 
 			'Author'         => [ 'j.v.vallejo[at]gmail.com' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References' =>
 				[
 					['MSB', 'MS09-001'],

--- a/modules/auxiliary/dos/windows/smb/ms09_050_smb2_negotiate_pidhigh.rb
+++ b/modules/auxiliary/dos/windows/smb/ms09_050_smb2_negotiate_pidhigh.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/smb/ms09_050_smb2_negotiate_pidhigh.rb
+++ b/modules/auxiliary/dos/windows/smb/ms09_050_smb2_negotiate_pidhigh.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 
 			'Author'         => [ 'Laurent Gaffie <laurent.gaffie[at]gmail.com>', 'hdm' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References' =>
 				[
 					['CVE', '2009-3103'],

--- a/modules/auxiliary/dos/windows/smb/ms09_050_smb2_session_logoff.rb
+++ b/modules/auxiliary/dos/windows/smb/ms09_050_smb2_session_logoff.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/smb/ms09_050_smb2_session_logoff.rb
+++ b/modules/auxiliary/dos/windows/smb/ms09_050_smb2_session_logoff.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'sf' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2009-3103'],

--- a/modules/auxiliary/dos/windows/smb/ms10_006_negotiate_response_loop.rb
+++ b/modules/auxiliary/dos/windows/smb/ms10_006_negotiate_response_loop.rb
@@ -30,8 +30,7 @@ class Metasploit3 < Msf::Auxiliary
 					['URL', 'http://g-laurent.blogspot.com/2009/11/windows-7-server-2008r2-remote-kernel.html']
 				],
 			'Author'         => [ 'Laurent Gaffie <laurent.gaffie[at]gmail.com>', 'hdm' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 
 		register_options([

--- a/modules/auxiliary/dos/windows/smb/ms10_006_negotiate_response_loop.rb
+++ b/modules/auxiliary/dos/windows/smb/ms10_006_negotiate_response_loop.rb
@@ -1,9 +1,5 @@
 
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/smb/ms10_054_queryfs_pool_overflow.rb
+++ b/modules/auxiliary/dos/windows/smb/ms10_054_queryfs_pool_overflow.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/smb/ms10_054_queryfs_pool_overflow.rb
+++ b/modules/auxiliary/dos/windows/smb/ms10_054_queryfs_pool_overflow.rb
@@ -29,8 +29,7 @@ class Metasploit3 < Msf::Auxiliary
 					['URL', 'http://seclists.org/fulldisclosure/2010/Aug/122']
 				],
 			'Author'         => [ 'Laurent Gaffie <laurent.gaffie[at]gmail.com>', 'jduck' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 
 		register_options(

--- a/modules/auxiliary/dos/windows/smb/ms11_019_electbowser.rb
+++ b/modules/auxiliary/dos/windows/smb/ms11_019_electbowser.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/smb/ms11_019_electbowser.rb
+++ b/modules/auxiliary/dos/windows/smb/ms11_019_electbowser.rb
@@ -43,8 +43,7 @@ class Metasploit3 < Msf::Auxiliary
 					[ 'URL', 'http://seclists.org/fulldisclosure/2011/Feb/285' ]
 				],
 			'Author'         => [ 'Cupidon-3005', 'jduck' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 
 		register_options(

--- a/modules/auxiliary/dos/windows/smb/rras_vls_null_deref.rb
+++ b/modules/auxiliary/dos/windows/smb/rras_vls_null_deref.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/smb/rras_vls_null_deref.rb
+++ b/modules/auxiliary/dos/windows/smb/rras_vls_null_deref.rb
@@ -28,7 +28,6 @@ class Metasploit3 < Msf::Auxiliary
 
 			'Author'         => [ 'hdm' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'OSVDB', '64340'],

--- a/modules/auxiliary/dos/windows/smb/vista_negotiate_stop.rb
+++ b/modules/auxiliary/dos/windows/smb/vista_negotiate_stop.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/smb/vista_negotiate_stop.rb
+++ b/modules/auxiliary/dos/windows/smb/vista_negotiate_stop.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 
 			'Author'         => [ 'hdm' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'OSVDB', '64341'],

--- a/modules/auxiliary/dos/windows/smtp/ms06_019_exchange.rb
+++ b/modules/auxiliary/dos/windows/smtp/ms06_019_exchange.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/smtp/ms06_019_exchange.rb
+++ b/modules/auxiliary/dos/windows/smtp/ms06_019_exchange.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'pusscat' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'BID', '17908'],

--- a/modules/auxiliary/dos/windows/tftp/pt360_write.rb
+++ b/modules/auxiliary/dos/windows/tftp/pt360_write.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/tftp/pt360_write.rb
+++ b/modules/auxiliary/dos/windows/tftp/pt360_write.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => 'kris katterjohn',
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2008-1311'],

--- a/modules/auxiliary/dos/windows/tftp/solarwinds.rb
+++ b/modules/auxiliary/dos/windows/tftp/solarwinds.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/windows/tftp/solarwinds.rb
+++ b/modules/auxiliary/dos/windows/tftp/solarwinds.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => 'Nullthreat',
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2010-2115' ],

--- a/modules/auxiliary/dos/wireshark/chunked.rb
+++ b/modules/auxiliary/dos/wireshark/chunked.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/wireshark/chunked.rb
+++ b/modules/auxiliary/dos/wireshark/chunked.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author' 	=> [ 'Matteo Cantoni <goony[at]nothink.org>' ],
 			'License'       => MSF_LICENSE,
-			'Version'       => '$Revision$',
 			'References'    =>
 				[
 					[ 'CVE', '2007-3389'],

--- a/modules/auxiliary/dos/wireshark/cldap.rb
+++ b/modules/auxiliary/dos/wireshark/cldap.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/wireshark/cldap.rb
+++ b/modules/auxiliary/dos/wireshark/cldap.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => ['joernchen <joernchen[at]phenoelit.de> (Phenoelit)'],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2011-1140'],

--- a/modules/auxiliary/dos/wireshark/ldap.rb
+++ b/modules/auxiliary/dos/wireshark/ldap.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/dos/wireshark/ldap.rb
+++ b/modules/auxiliary/dos/wireshark/ldap.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'      => ['MC'],
 			'License'     => MSF_LICENSE,
-			'Version'     => '$Revision$',
 			'References'  =>
 				[
 					[ 'CVE', '2008-1562' ],

--- a/modules/auxiliary/fuzzers/ftp/client_ftp.rb
+++ b/modules/auxiliary/fuzzers/ftp/client_ftp.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/ftp/client_ftp.rb
+++ b/modules/auxiliary/fuzzers/ftp/client_ftp.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'corelanc0d3r <peter.ve[at]corelan.be>' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => "$Revision$",
 			'References'     =>
 				[
 					[ 'URL', 'http://www.corelan.be:8800/index.php/2010/10/12/death-of-an-ftp-client/' ],

--- a/modules/auxiliary/fuzzers/ftp/ftp_pre_post.rb
+++ b/modules/auxiliary/fuzzers/ftp/ftp_pre_post.rb
@@ -23,8 +23,7 @@ class Metasploit3 < Msf::Auxiliary
 				This module will connect to a FTP server and perform pre- and post-authentication fuzzing
 			},
 			'Author'         => [ 'corelanc0d3r <peter.ve[at]corelan.be>', 'jduck' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 			)
 
 		register_options(

--- a/modules/auxiliary/fuzzers/ftp/ftp_pre_post.rb
+++ b/modules/auxiliary/fuzzers/ftp/ftp_pre_post.rb
@@ -1,13 +1,9 @@
-# $Id$
-##
-
 ##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.
 #   http://metasploit.com/
 ##
-
 
 require 'msf/core'
 

--- a/modules/auxiliary/fuzzers/http/http_form_field.rb
+++ b/modules/auxiliary/fuzzers/http/http_form_field.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/http/http_form_field.rb
+++ b/modules/auxiliary/fuzzers/http/http_form_field.rb
@@ -31,7 +31,6 @@ class Metasploit3 < Msf::Auxiliary
 				'Paulino Calderon <calderon[at]websec.mx>' #Added cookie handling
 				],
 			'License'       => MSF_LICENSE,
-			'Version'       => '$Revision$',
 			'References'    =>
 				[
 					['URL','http://www.corelan.be:8800/index.php/2010/11/12/metasploit-module-http-form-field-fuzzer'],

--- a/modules/auxiliary/fuzzers/http/http_get_uri_long.rb
+++ b/modules/auxiliary/fuzzers/http/http_get_uri_long.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/http/http_get_uri_long.rb
+++ b/modules/auxiliary/fuzzers/http/http_get_uri_long.rb
@@ -20,8 +20,7 @@ class Metasploit3 < Msf::Auxiliary
 				This module sends a series of HTTP GET request with incrementing URL lengths.
 			},
 			'Author'         => [ 'nullthreat' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 		register_options([
 			Opt::RPORT(80),

--- a/modules/auxiliary/fuzzers/http/http_get_uri_strings.rb
+++ b/modules/auxiliary/fuzzers/http/http_get_uri_strings.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/http/http_get_uri_strings.rb
+++ b/modules/auxiliary/fuzzers/http/http_get_uri_strings.rb
@@ -20,8 +20,7 @@ class Metasploit3 < Msf::Auxiliary
 				This module sends a series of HTTP GET request with malicious URIs.
 			},
 			'Author'         => [ 'nullthreat' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 		register_options([
 			Opt::RPORT(80),

--- a/modules/auxiliary/fuzzers/smb/smb2_negotiate_corrupt.rb
+++ b/modules/auxiliary/fuzzers/smb/smb2_negotiate_corrupt.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/smb/smb2_negotiate_corrupt.rb
+++ b/modules/auxiliary/fuzzers/smb/smb2_negotiate_corrupt.rb
@@ -21,8 +21,7 @@ class Metasploit3 < Msf::Auxiliary
 			SMB2 dialect with corrupted bytes.
 			},
 			'Author'         => [ 'hdm' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 		register_options([
 			Opt::RPORT(445),

--- a/modules/auxiliary/fuzzers/smb/smb_create_pipe.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_create_pipe.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/smb/smb_create_pipe.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_create_pipe.rb
@@ -21,8 +21,7 @@ class Metasploit3 < Msf::Auxiliary
 			requests using malicious strings.
 			},
 			'Author'         => [ 'hdm' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 	end
 

--- a/modules/auxiliary/fuzzers/smb/smb_create_pipe_corrupt.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_create_pipe_corrupt.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/smb/smb_create_pipe_corrupt.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_create_pipe_corrupt.rb
@@ -20,8 +20,7 @@ class Metasploit3 < Msf::Auxiliary
 				This module sends a series of SMB create pipe requests with corrupted bytes.
 			},
 			'Author'         => [ 'hdm' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 		register_options([
 			OptInt.new('MAXDEPTH', [false, 'Specify a maximum byte depth to test']),

--- a/modules/auxiliary/fuzzers/smb/smb_negotiate_corrupt.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_negotiate_corrupt.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/smb/smb_negotiate_corrupt.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_negotiate_corrupt.rb
@@ -20,8 +20,7 @@ class Metasploit3 < Msf::Auxiliary
 				This module sends a series of SMB negiotiate requests with corrupted bytes
 			},
 			'Author'         => [ 'hdm' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 		register_options([
 			Opt::RPORT(445),

--- a/modules/auxiliary/fuzzers/smb/smb_ntlm1_login_corrupt.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_ntlm1_login_corrupt.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/smb/smb_ntlm1_login_corrupt.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_ntlm1_login_corrupt.rb
@@ -21,8 +21,7 @@ class Metasploit3 < Msf::Auxiliary
 			the NTLMv1 protocol with corrupted bytes.
 			},
 			'Author'         => [ 'hdm' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 		register_options([
 			Opt::RPORT(445),

--- a/modules/auxiliary/fuzzers/smb/smb_tree_connect.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_tree_connect.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/smb/smb_tree_connect.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_tree_connect.rb
@@ -21,8 +21,7 @@ class Metasploit3 < Msf::Auxiliary
 			requests using malicious strings.
 			},
 			'Author'         => [ 'hdm' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 	end
 

--- a/modules/auxiliary/fuzzers/smb/smb_tree_connect_corrupt.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_tree_connect_corrupt.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/smb/smb_tree_connect_corrupt.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_tree_connect_corrupt.rb
@@ -20,8 +20,7 @@ class Metasploit3 < Msf::Auxiliary
 				This module sends a series of SMB tree connect requests with corrupted bytes.
 			},
 			'Author'         => [ 'hdm' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 		register_options([
 			OptInt.new('MAXDEPTH', [false, 'Specify a maximum byte depth to test']),

--- a/modules/auxiliary/fuzzers/smtp/smtp_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/smtp/smtp_fuzzer.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # A Very simple Module to fuzzer some SMTP commands.
 # It allows to respect the order or just throw everything at it....
 ##

--- a/modules/auxiliary/fuzzers/smtp/smtp_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/smtp/smtp_fuzzer.rb
@@ -14,7 +14,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SMTP Simple Fuzzer',
-			'Version'     => '$Revision$',
 			'Description' => 'SMTP Simple Fuzzer',
 			'References'  =>
 				[

--- a/modules/auxiliary/fuzzers/ssh/ssh_kexinit_corrupt.rb
+++ b/modules/auxiliary/fuzzers/ssh/ssh_kexinit_corrupt.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/ssh/ssh_kexinit_corrupt.rb
+++ b/modules/auxiliary/fuzzers/ssh/ssh_kexinit_corrupt.rb
@@ -20,8 +20,7 @@ class Metasploit3 < Msf::Auxiliary
 				This module sends a series of SSH requests with a corrupted initial key exchange payload.
 			},
 			'Author'         => [ 'hdm' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 		register_options([
 			Opt::RPORT(22),

--- a/modules/auxiliary/fuzzers/ssh/ssh_version_15.rb
+++ b/modules/auxiliary/fuzzers/ssh/ssh_version_15.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/ssh/ssh_version_15.rb
+++ b/modules/auxiliary/fuzzers/ssh/ssh_version_15.rb
@@ -20,8 +20,7 @@ class Metasploit3 < Msf::Auxiliary
 				This module sends a series of SSH requests with malicious version strings.
 			},
 			'Author'         => [ 'hdm' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 		register_options([
 			Opt::RPORT(22)

--- a/modules/auxiliary/fuzzers/ssh/ssh_version_2.rb
+++ b/modules/auxiliary/fuzzers/ssh/ssh_version_2.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/ssh/ssh_version_2.rb
+++ b/modules/auxiliary/fuzzers/ssh/ssh_version_2.rb
@@ -20,8 +20,7 @@ class Metasploit3 < Msf::Auxiliary
 				This module sends a series of SSH requests with malicious version strings.
 			},
 			'Author'         => [ 'hdm' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 		register_options([
 			Opt::RPORT(22)

--- a/modules/auxiliary/fuzzers/ssh/ssh_version_corrupt.rb
+++ b/modules/auxiliary/fuzzers/ssh/ssh_version_corrupt.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/ssh/ssh_version_corrupt.rb
+++ b/modules/auxiliary/fuzzers/ssh/ssh_version_corrupt.rb
@@ -20,8 +20,7 @@ class Metasploit3 < Msf::Auxiliary
 				This module sends a series of SSH requests with a corrupted version string
 			},
 			'Author'         => [ 'hdm' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 		register_options([
 			Opt::RPORT(22),

--- a/modules/auxiliary/fuzzers/tds/tds_login_corrupt.rb
+++ b/modules/auxiliary/fuzzers/tds/tds_login_corrupt.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/tds/tds_login_corrupt.rb
+++ b/modules/auxiliary/fuzzers/tds/tds_login_corrupt.rb
@@ -20,8 +20,7 @@ class Metasploit3 < Msf::Auxiliary
 				This module sends a series of malformed TDS login requests.
 			},
 			'Author'         => [ 'hdm' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 	end
 

--- a/modules/auxiliary/fuzzers/tds/tds_login_username.rb
+++ b/modules/auxiliary/fuzzers/tds/tds_login_username.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/tds/tds_login_username.rb
+++ b/modules/auxiliary/fuzzers/tds/tds_login_username.rb
@@ -20,8 +20,7 @@ class Metasploit3 < Msf::Auxiliary
 				This module sends a series of malformed TDS login requests.
 			},
 			'Author'         => [ 'hdm' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 	end
 

--- a/modules/auxiliary/fuzzers/wifi/fuzz_beacon.rb
+++ b/modules/auxiliary/fuzzers/wifi/fuzz_beacon.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/wifi/fuzz_beacon.rb
+++ b/modules/auxiliary/fuzzers/wifi/fuzz_beacon.rb
@@ -22,8 +22,7 @@ class Metasploit3 < Msf::Auxiliary
 			},
 
 			'Author'         => [ 'hdm' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 		register_options(
 			[

--- a/modules/auxiliary/fuzzers/wifi/fuzz_proberesp.rb
+++ b/modules/auxiliary/fuzzers/wifi/fuzz_proberesp.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/fuzzers/wifi/fuzz_proberesp.rb
+++ b/modules/auxiliary/fuzzers/wifi/fuzz_proberesp.rb
@@ -22,8 +22,7 @@ class Metasploit3 < Msf::Auxiliary
 			},
 
 			'Author'         => [ 'hdm' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 		register_options(
 			[

--- a/modules/auxiliary/gather/android_htmlfileprovider.rb
+++ b/modules/auxiliary/gather/android_htmlfileprovider.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/gather/android_htmlfileprovider.rb
+++ b/modules/auxiliary/gather/android_htmlfileprovider.rb
@@ -15,7 +15,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize(info = {})
 		super(update_info(info,
 			'Name'        => 'Android Content Provider File Disclosure',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 					This module exploits a cross-domain issue within the Android web browser to
 				exfiltrate files from a vulnerable device.
@@ -25,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
 					'Thomas Cannon',   # Original discovery, partial disclsoure
 					'jduck'            # Metasploit module
 				],
-			'Version'     => '$Revision$',
 			'License'     => MSF_LICENSE,
 			'Actions'     =>
 				[

--- a/modules/auxiliary/gather/citrix_published_applications.rb
+++ b/modules/auxiliary/gather/citrix_published_applications.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/gather/citrix_published_applications.rb
+++ b/modules/auxiliary/gather/citrix_published_applications.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 				a published list of applications.
 			},
 			'Author'         => [ 'patrick' ],
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'http://www.securiteam.com/exploits/5CP0B1F80S.html' ],

--- a/modules/auxiliary/gather/citrix_published_bruteforce.rb
+++ b/modules/auxiliary/gather/citrix_published_bruteforce.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/gather/citrix_published_bruteforce.rb
+++ b/modules/auxiliary/gather/citrix_published_bruteforce.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 				Metaframe ICA server.
 			},
 			'Author'         => [ 'patrick' ],
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'OSVDB', '50617' ],

--- a/modules/auxiliary/gather/d20pass.rb
+++ b/modules/auxiliary/gather/d20pass.rb
@@ -31,7 +31,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'K. Reid Wightman <wightman[at]digitalbond.com>' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'DisclosureDate' => 'Jan 19 2012'
 			))
 

--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'		=> [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
 			'License'		=> MSF_LICENSE,
-			'Version'		=> '$Revision$',
 			'References' 	=>
 				[
 					['CVE', '1999-0532'],

--- a/modules/auxiliary/gather/search_email_collector.rb
+++ b/modules/auxiliary/gather/search_email_collector.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/gather/search_email_collector.rb
+++ b/modules/auxiliary/gather/search_email_collector.rb
@@ -19,8 +19,7 @@ class Metasploit3 < Msf::Auxiliary
 				valid email addresses for the target domain.
 			},
 			'Author' => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
-			'License' => MSF_LICENSE,
-			'Version' => '$Revision$'))
+			'License' => MSF_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/pdf/foxit/authbypass.rb
+++ b/modules/auxiliary/pdf/foxit/authbypass.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/pdf/foxit/authbypass.rb
+++ b/modules/auxiliary/pdf/foxit/authbypass.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         => [ 'MC', 'Didier Stevens <didier.stevens[at]gmail.com>', ],
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2009-0836' ],

--- a/modules/auxiliary/scanner/backdoor/energizer_duo_detect.rb
+++ b/modules/auxiliary/scanner/backdoor/energizer_duo_detect.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/backdoor/energizer_duo_detect.rb
+++ b/modules/auxiliary/scanner/backdoor/energizer_duo_detect.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Energizer DUO Trojan Scanner',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect instances of the Energizer DUO trojan horse software on port 7777',
 			'Author'      => 'hdm',
 			'References'  =>

--- a/modules/auxiliary/scanner/db2/db2_auth.rb
+++ b/modules/auxiliary/scanner/db2/db2_auth.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/db2/db2_auth.rb
+++ b/modules/auxiliary/scanner/db2/db2_auth.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'DB2 Authentication Brute Force Utility',
-			'Version'        => '$Revision$',
 			'Description'    => %q{This module attempts to authenticate against a DB2
 				instance using username and password combinations indicated by the
 				USER_FILE, PASS_FILE, and USERPASS_FILE options.},

--- a/modules/auxiliary/scanner/db2/db2_version.rb
+++ b/modules/auxiliary/scanner/db2/db2_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/db2/db2_version.rb
+++ b/modules/auxiliary/scanner/db2/db2_version.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'DB2 Probe Utility',
-			'Version'        => '$Revision$',
 			'Description'    => 'This module queries a DB2 instance information.',
 			'Author'         => ['todb'],
 			'License'        => MSF_LICENSE

--- a/modules/auxiliary/scanner/db2/discovery.rb
+++ b/modules/auxiliary/scanner/db2/discovery.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/db2/discovery.rb
+++ b/modules/auxiliary/scanner/db2/discovery.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'DB2 Discovery Service Detection',
-			'Version'        => '$Revision$',
 			'Description'    => 'This module simply queries the DB2 discovery service for information.',
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE

--- a/modules/auxiliary/scanner/dcerpc/endpoint_mapper.rb
+++ b/modules/auxiliary/scanner/dcerpc/endpoint_mapper.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/dcerpc/endpoint_mapper.rb
+++ b/modules/auxiliary/scanner/dcerpc/endpoint_mapper.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Endpoint Mapper Service Discovery',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				This module can be used to obtain information from the
 				Endpoint Mapper service.

--- a/modules/auxiliary/scanner/dcerpc/hidden.rb
+++ b/modules/auxiliary/scanner/dcerpc/hidden.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/dcerpc/hidden.rb
+++ b/modules/auxiliary/scanner/dcerpc/hidden.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Hidden DCERPC Service Discovery',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				This module will query the endpoint mapper and make a list
 			of all ncacn_tcp RPC services. It will then connect to each of

--- a/modules/auxiliary/scanner/dcerpc/management.rb
+++ b/modules/auxiliary/scanner/dcerpc/management.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/dcerpc/management.rb
+++ b/modules/auxiliary/scanner/dcerpc/management.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Remote Management Interface Discovery',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				This module can be used to obtain information from the Remote
 				Management Interface DCERPC service.

--- a/modules/auxiliary/scanner/dcerpc/tcp_dcerpc_auditor.rb
+++ b/modules/auxiliary/scanner/dcerpc/tcp_dcerpc_auditor.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/dcerpc/tcp_dcerpc_auditor.rb
+++ b/modules/auxiliary/scanner/dcerpc/tcp_dcerpc_auditor.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'DCERPC TCP Service Auditor',
-			'Version'     => '$Revision$',
 			'Description' => 'Determine what DCERPC services are accessible over a TCP port',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/dect/call_scanner.rb
+++ b/modules/auxiliary/scanner/dect/call_scanner.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/dect/call_scanner.rb
+++ b/modules/auxiliary/scanner/dect/call_scanner.rb
@@ -14,7 +14,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'DECT Call Scanner',
-			'Version'        => '$Revision$',
 			'Description'    => 'This module scans for active DECT calls',
 			'Author'         => [ 'DK <privilegedmode[at]gmail.com>' ],
 			'License'        => MSF_LICENSE,

--- a/modules/auxiliary/scanner/dect/station_scanner.rb
+++ b/modules/auxiliary/scanner/dect/station_scanner.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/dect/station_scanner.rb
+++ b/modules/auxiliary/scanner/dect/station_scanner.rb
@@ -14,7 +14,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'DECT Base Station Scanner',
-			'Version'        => '$Revision$',
 			'Description'    => 'This module scans for DECT base stations',
 			'Author'         => [ 'DK <privilegedmode[at]gmail.com>' ],
 			'License'        => MSF_LICENSE,

--- a/modules/auxiliary/scanner/discovery/arp_sweep.rb
+++ b/modules/auxiliary/scanner/discovery/arp_sweep.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/discovery/arp_sweep.rb
+++ b/modules/auxiliary/scanner/discovery/arp_sweep.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'ARP Sweep Local Network Discovery',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				Enumerate alive Hosts in local network using ARP requests.
 			},

--- a/modules/auxiliary/scanner/discovery/ipv6_multicast_ping.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_multicast_ping.rb
@@ -13,7 +13,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 		'Name'        => 'IPv6 Link Local/Node Local Ping Discovery',
-		'Version'     => '$Revision$',
 		'Description' => %q{
 				Send a ICMPv6 ping request to all default multicast addresses, and wait to see who responds.
 		},

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'IPv6 Local Neighbor Discovery',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				Enumerate local IPv6 hosts which respond to Neighbor Solicitations with a link-local address.
 				Note, that like ARP scanning, this usually cannot be performed beyond the local

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
@@ -8,7 +8,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 		'Name'        => 'IPv6 Local Neighbor Discovery Using Router Advertisement',
-		'Version'     => '$Revision$',
 		'Description' => %q{
 				Send a spoofed router advertisement with high priority to force hosts to
 				start the IPv6 address auto-config. Monitor for IPv6 host advertisements,

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
@@ -1,7 +1,3 @@
-##
-# $Id$
-##
-
 require 'msf/core'
 
 class Metasploit3 < Msf::Auxiliary

--- a/modules/auxiliary/scanner/discovery/udp_probe.rb
+++ b/modules/auxiliary/scanner/discovery/udp_probe.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/discovery/udp_probe.rb
+++ b/modules/auxiliary/scanner/discovery/udp_probe.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'UDP Service Prober',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect common UDP services using sequential probes',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/discovery/udp_sweep.rb
+++ b/modules/auxiliary/scanner/discovery/udp_sweep.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/discovery/udp_sweep.rb
+++ b/modules/auxiliary/scanner/discovery/udp_sweep.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'UDP Service Sweeper',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect interesting UDP services',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/emc/alphastor_devicemanager.rb
+++ b/modules/auxiliary/scanner/emc/alphastor_devicemanager.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/emc/alphastor_devicemanager.rb
+++ b/modules/auxiliary/scanner/emc/alphastor_devicemanager.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'EMC AlphaStor Device Manager Service',
-			'Version'        => '$Revision$',
 			'Description'    => 'This module queries the remote host for the EMC Alphastor Device Management Service.',
 			'Author'         => 'MC',
 			'License'        => MSF_LICENSE

--- a/modules/auxiliary/scanner/emc/alphastor_librarymanager.rb
+++ b/modules/auxiliary/scanner/emc/alphastor_librarymanager.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/emc/alphastor_librarymanager.rb
+++ b/modules/auxiliary/scanner/emc/alphastor_librarymanager.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'EMC AlphaStor Library Manager Service',
-			'Version'        => '$Revision$',
 			'Description'    => 'This module queries the remote host for the EMC Alphastor Library Management Service.',
 			'Author'         => 'MC',
 			'License'        => MSF_LICENSE

--- a/modules/auxiliary/scanner/finger/finger_users.rb
+++ b/modules/auxiliary/scanner/finger/finger_users.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/finger/finger_users.rb
+++ b/modules/auxiliary/scanner/finger/finger_users.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Finger Service User Enumerator',
-			'Version'     => '$Revision$',
 			'Description' => 'Identify valid users through the finger service using a variety of tricks',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/ftp/anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/anonymous.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/ftp/anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/anonymous.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Anonymous FTP Access Detection',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect anonymous (read/write) FTP server access.',
 			'References'  =>
 				[

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'FTP Authentication Scanner',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				This module will test FTP logins on a range of machines and
 				report successful logins.  If you have loaded a database plugin

--- a/modules/auxiliary/scanner/ftp/ftp_version.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/ftp/ftp_version.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_version.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'FTP Version Scanner',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect FTP Version.',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/h323/h323_version.rb
+++ b/modules/auxiliary/scanner/h323/h323_version.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'H.323 Version Scanner',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect H.323 Version.',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/adobe_xml_inject.rb
+++ b/modules/auxiliary/scanner/http/adobe_xml_inject.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/adobe_xml_inject.rb
+++ b/modules/auxiliary/scanner/http/adobe_xml_inject.rb
@@ -15,7 +15,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Adobe XML External Entity Injection',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 					Multiple Adobe Products -- XML External Entity Injection. Affected Sofware: BlazeDS 3.2 and
 				earlier versions, LiveCycle 9.0, 8.2.1, and 8.0.1, LiveCycle Data Services 3.0, 2.6.1, and

--- a/modules/auxiliary/scanner/http/apache_userdir_enum.rb
+++ b/modules/auxiliary/scanner/http/apache_userdir_enum.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/apache_userdir_enum.rb
+++ b/modules/auxiliary/scanner/http/apache_userdir_enum.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Apache "mod_userdir" User Enumeration',
-			'Version'        => '$Revision$',
 			'Description'    => %q{Apache with the UserDir directive enabled generates different error
 			codes when a username exists and there is no public_html directory and when the username
 			does not exist, which could allow remote attackers to determine valid usernames on the

--- a/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
@@ -16,7 +16,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'         => 'Atlassian Crowd XML Entity Expansion Remote File Access',
-			'Version'      => '$Revision$',
 			'Description'  =>  %q{
 					This module simply attempts to read a remote file from the server using a
 				vulnerability in the way Atlassian Crowd handles XML files. The vulnerability

--- a/modules/auxiliary/scanner/http/axis_local_file_include.rb
+++ b/modules/auxiliary/scanner/http/axis_local_file_include.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/axis_local_file_include.rb
+++ b/modules/auxiliary/scanner/http/axis_local_file_include.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Apache Axis2 v1.4.1 Local File Inclusion',
-			'Version'        => '$Revision$',
 			'Description'    => %q{
 					This module exploits an Apache Axis2 v1.4.1 local file inclusion (LFI) vulnerability.
 				By loading a local XML file which contains a cleartext username and password, attackers can trivially

--- a/modules/auxiliary/scanner/http/axis_login.rb
+++ b/modules/auxiliary/scanner/http/axis_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/axis_login.rb
+++ b/modules/auxiliary/scanner/http/axis_login.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Apache Axis2 v1.4.1 Brute Force Utility',
-			'Version'        => '$Revision$',
 			'Description'    => %q{This module attempts to login to an Apache Axis2 v1.4.1
 				instance using username and password combindations indicated by the USER_FILE,
 				PASS_FILE, and USERPASS_FILE options.

--- a/modules/auxiliary/scanner/http/backup_file.rb
+++ b/modules/auxiliary/scanner/http/backup_file.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/backup_file.rb
+++ b/modules/auxiliary/scanner/http/backup_file.rb
@@ -25,8 +25,7 @@ class Metasploit3 < Msf::Auxiliary
 				of a specific file in a given path.
 			},
 			'Author' 		=> [ 'et [at] cyberspace.org' ],
-			'License'		=> BSD_LICENSE,
-			'Version'		=> '$Revision$'))
+			'License'		=> BSD_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/barracuda_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/barracuda_directory_traversal.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/barracuda_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/barracuda_directory_traversal.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Barracuda Multiple Product "locale" Directory Traversal',
-			'Version'        => '$Revision$',
 			'Description'    => %q{
 					This module exploits a directory traversal vulnerability present in
 				serveral Barracuda products, including the Barracuda Spam and Virus Firewall,

--- a/modules/auxiliary/scanner/http/blind_sql_query.rb
+++ b/modules/auxiliary/scanner/http/blind_sql_query.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/blind_sql_query.rb
+++ b/modules/auxiliary/scanner/http/blind_sql_query.rb
@@ -27,8 +27,7 @@ class Metasploit3 < Msf::Auxiliary
 				in GET/POST Query parameters values.
 			},
 			'Author' 		=> [ 'et [at] cyberspace.org' ],
-			'License'		=> BSD_LICENSE,
-			'Version'		=> '$Revision$'))
+			'License'		=> BSD_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/brute_dirs.rb
+++ b/modules/auxiliary/scanner/http/brute_dirs.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/brute_dirs.rb
+++ b/modules/auxiliary/scanner/http/brute_dirs.rb
@@ -25,8 +25,7 @@ class Metasploit3 < Msf::Auxiliary
 
 			},
 			'Author' 		=> [ 'et' ],
-			'License'		=> BSD_LICENSE,
-			'Version'		=> '$Revision$'))
+			'License'		=> BSD_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/cert.rb
+++ b/modules/auxiliary/scanner/http/cert.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/cert.rb
+++ b/modules/auxiliary/scanner/http/cert.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'HTTP SSL Certificate Checker',
-			'Version'     => '$Revision$',
 			'Author'      => 'nebulus',
 			'License'     => MSF_LICENSE,
 			'Description' => %q{

--- a/modules/auxiliary/scanner/http/cisco_device_manager.rb
+++ b/modules/auxiliary/scanner/http/cisco_device_manager.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/cisco_device_manager.rb
+++ b/modules/auxiliary/scanner/http/cisco_device_manager.rb
@@ -31,7 +31,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'		=> [ 'hdm' ],
 			'License'		=> MSF_LICENSE,
-			'Version'		=> '$Revision$',
 			'References'	=>
 				[
 					[ 'BID', '1846'],

--- a/modules/auxiliary/scanner/http/cisco_ios_auth_bypass.rb
+++ b/modules/auxiliary/scanner/http/cisco_ios_auth_bypass.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/cisco_ios_auth_bypass.rb
+++ b/modules/auxiliary/scanner/http/cisco_ios_auth_bypass.rb
@@ -33,7 +33,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'		=> [ 'Patrick Webster <patrick[at]aushack.com>', 'hdm' ],
 			'License'		=> MSF_LICENSE,
-			'Version'		=> '$Revision$',
 			'References'	=>
 				[
 					[ 'BID', '2936'],

--- a/modules/auxiliary/scanner/http/cisco_nac_manager_traversal.rb
+++ b/modules/auxiliary/scanner/http/cisco_nac_manager_traversal.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/cisco_nac_manager_traversal.rb
+++ b/modules/auxiliary/scanner/http/cisco_nac_manager_traversal.rb
@@ -15,7 +15,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Cisco Network Access Manager Directory Traversal Vulnerability',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				This module tests whether a directory traversal vulnerablity is present
 				in versions of Cisco Network Access Manager 4.8.x You may wish to change

--- a/modules/auxiliary/scanner/http/cold_fusion_version.rb
+++ b/modules/auxiliary/scanner/http/cold_fusion_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/cold_fusion_version.rb
+++ b/modules/auxiliary/scanner/http/cold_fusion_version.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'ColdFusion Version Scanner',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 					This module attempts identify various flavors of ColdFusion as well as the underlying OS
 			},

--- a/modules/auxiliary/scanner/http/coldfusion_locale_traversal.rb
+++ b/modules/auxiliary/scanner/http/coldfusion_locale_traversal.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/coldfusion_locale_traversal.rb
+++ b/modules/auxiliary/scanner/http/coldfusion_locale_traversal.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'ColdFusion Server Check',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 					This module attempts to exploit the directory traversal in the 'locale'
 				attribute.  According to the advisory the following versions are vulnerable:

--- a/modules/auxiliary/scanner/http/copy_of_file.rb
+++ b/modules/auxiliary/scanner/http/copy_of_file.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/copy_of_file.rb
+++ b/modules/auxiliary/scanner/http/copy_of_file.rb
@@ -25,8 +25,7 @@ class Metasploit3 < Msf::Auxiliary
 				of a specific file in a given path.
 			},
 			'Author' 		=> [ 'et [at] cyberspace.org' ],
-			'License'		=> BSD_LICENSE,
-			'Version'		=> '$Revision$'))
+			'License'		=> BSD_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/crawler.rb
+++ b/modules/auxiliary/scanner/http/crawler.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/crawler.rb
+++ b/modules/auxiliary/scanner/http/crawler.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Web Site Crawler',
-			'Version'     => '$Revision$',
 			'Description' => 'Crawl a web site and store information about what was found',
 			'Author'      => %w(hdm tasos),
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/dell_idrac.rb
+++ b/modules/auxiliary/scanner/http/dell_idrac.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name' => 'Dell iDRAC default Login',
-			'Version' => '$Revision$',
 			'Description' => %q{
 				This module attempts to login to a iDRAC webserver instance using
 				default username and password.  Tested against Dell Remote Access

--- a/modules/auxiliary/scanner/http/dir_listing.rb
+++ b/modules/auxiliary/scanner/http/dir_listing.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/dir_listing.rb
+++ b/modules/auxiliary/scanner/http/dir_listing.rb
@@ -24,8 +24,7 @@ class Metasploit3 < Msf::Auxiliary
 				in a given directory path.
 			},
 			'Author' 		=> [ 'et' ],
-			'License'		=> BSD_LICENSE,
-			'Version'		=> '$Revision$'))
+			'License'		=> BSD_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/dir_scanner.rb
+++ b/modules/auxiliary/scanner/http/dir_scanner.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/dir_scanner.rb
+++ b/modules/auxiliary/scanner/http/dir_scanner.rb
@@ -25,8 +25,7 @@ class Metasploit3 < Msf::Auxiliary
 				in a given directory path.
 			},
 			'Author' 		=> [ 'et [at] metasploit.com' ],
-			'License'		=> BSD_LICENSE,
-			'Version'		=> '$Revision$'))
+			'License'		=> BSD_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/dir_webdav_unicode_bypass.rb
+++ b/modules/auxiliary/scanner/http/dir_webdav_unicode_bypass.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/dir_webdav_unicode_bypass.rb
+++ b/modules/auxiliary/scanner/http/dir_webdav_unicode_bypass.rb
@@ -36,8 +36,7 @@ class Metasploit3 < Msf::Auxiliary
 					[ 'CVE', '2009-1122' ],
 					[ 'OSVDB', '54555' ],
 					[ 'BID', '34993' ],
-				],
-			'Version'		=> '$Revision$'))
+				]))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/enum_wayback.rb
+++ b/modules/auxiliary/scanner/http/enum_wayback.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/enum_wayback.rb
+++ b/modules/auxiliary/scanner/http/enum_wayback.rb
@@ -19,8 +19,7 @@ class Metasploit3 < Msf::Auxiliary
 				replaying during a web assessment. Finding unlinked and old pages.
 			},
 			'Author' => [ 'mubix' ],
-			'License' => MSF_LICENSE,
-			'Version' => '$Revision$'
+			'License' => MSF_LICENSE
 		))
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/error_sql_injection.rb
+++ b/modules/auxiliary/scanner/http/error_sql_injection.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/error_sql_injection.rb
+++ b/modules/auxiliary/scanner/http/error_sql_injection.rb
@@ -24,8 +24,7 @@ class Metasploit3 < Msf::Auxiliary
 
 			},
 			'Author' 		=> [ 'et [at] cyberspace.org' ],
-			'License'		=> BSD_LICENSE,
-			'Version'		=> '$Revision$'))
+			'License'		=> BSD_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/file_same_name_dir.rb
+++ b/modules/auxiliary/scanner/http/file_same_name_dir.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/file_same_name_dir.rb
+++ b/modules/auxiliary/scanner/http/file_same_name_dir.rb
@@ -27,8 +27,7 @@ class Metasploit3 < Msf::Auxiliary
 				Only works if PATH is differenet than '/'.
 			},
 			'Author' 		=> [ 'et [at] metasploit.com' ],
-			'License'		=> BSD_LICENSE,
-			'Version'		=> '$Revision$'))
+			'License'		=> BSD_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/files_dir.rb
+++ b/modules/auxiliary/scanner/http/files_dir.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/files_dir.rb
+++ b/modules/auxiliary/scanner/http/files_dir.rb
@@ -24,8 +24,7 @@ class Metasploit3 < Msf::Auxiliary
 				in a given directory path.
 			},
 			'Author' 		=> [ 'et' ],
-			'License'		=> BSD_LICENSE,
-			'Version'		=> '$Revision$'))
+			'License'		=> BSD_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/frontpage_login.rb
+++ b/modules/auxiliary/scanner/http/frontpage_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/frontpage_login.rb
+++ b/modules/auxiliary/scanner/http/frontpage_login.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'FrontPage Server Extensions Anonymous Login Scanner',
-			'Version'     => '$Revision$',
 			'Description' => 'This module queries the FrontPage Server Extensions and determines whether anonymous access is allowed.',
 			'References'  =>
 				[

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'GlassFish Brute Force Utility',
-			'Version'        => '$Revision$',
 			'Description'    => %q{
 				This module attempts to login to GlassFish instance using username
 				and password combindations indicated by the USER_FILE, PASS_FILE,

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'HTTP Login Utility',
-			'Version'        => '$Revision$',
 			'Description'    => 'This module attempts to authenticate to an HTTP service.',
 			'References'  =>
 				[

--- a/modules/auxiliary/scanner/http/http_put.rb
+++ b/modules/auxiliary/scanner/http/http_put.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/http_put.rb
+++ b/modules/auxiliary/scanner/http/http_put.rb
@@ -17,7 +17,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'HTTP Writable Path PUT/DELETE File Access',
-			'Version'     => '$Revision$',
 			'Description'    => %q{
 				This module can abuse misconfigured web servers to upload and delete web content
 				via PUT and DELETE HTTP requests. Set ACTION to either PUT or DELETE.

--- a/modules/auxiliary/scanner/http/http_version.rb
+++ b/modules/auxiliary/scanner/http/http_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/http_version.rb
+++ b/modules/auxiliary/scanner/http/http_version.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'HTTP Version Detection',
-			'Version'     => '$Revision$',
 			'Description' => 'Display version information about each system',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/httpbl_lookup.rb
+++ b/modules/auxiliary/scanner/http/httpbl_lookup.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/httpbl_lookup.rb
+++ b/modules/auxiliary/scanner/http/httpbl_lookup.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author' 		=> [ 'mubix' ],
 			'License'		=> MSF_LICENSE,
-			'Version'		=> '$Revision$',
 			'References' 	=>
 				[
 					['URL', 'http://www.projecthoneypot.org/httpbl_api.php'],

--- a/modules/auxiliary/scanner/http/impersonate_ssl.rb
+++ b/modules/auxiliary/scanner/http/impersonate_ssl.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/jboss_vulnscan.rb
+++ b/modules/auxiliary/scanner/http/jboss_vulnscan.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/jboss_vulnscan.rb
+++ b/modules/auxiliary/scanner/http/jboss_vulnscan.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 			'Description'   => %q{
 				This module scans a JBoss instance for a few vulnerablities.
 			},
-			'Version'               => '$Revision$',
 			'Author'                => [ 'Tyler Krpata' ],
 			'References'            =>
 				[

--- a/modules/auxiliary/scanner/http/litespeed_source_disclosure.rb
+++ b/modules/auxiliary/scanner/http/litespeed_source_disclosure.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/litespeed_source_disclosure.rb
+++ b/modules/auxiliary/scanner/http/litespeed_source_disclosure.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 					This module exploits a source code disclosure/download vulnerability in
 				versions 4.0.14 and prior of LiteSpeed.
 			},
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2010-2333' ],

--- a/modules/auxiliary/scanner/http/lucky_punch.rb
+++ b/modules/auxiliary/scanner/http/lucky_punch.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/lucky_punch.rb
+++ b/modules/auxiliary/scanner/http/lucky_punch.rb
@@ -26,8 +26,7 @@ class Metasploit3 < Msf::Auxiliary
 				XSS attack to redirect user browser to a attacker controller website.
 			},
 			'Author'         => [ 'et' ],
-			'License'        => BSD_LICENSE,
-			'Version'        => '$Revision$'))
+			'License'        => BSD_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 				module will attempt to download the Majordomo config.pl file.
 			},
 			'Author'         =>	['Nikolas Sotiriu'],
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['OSVDB', '70762'],

--- a/modules/auxiliary/scanner/http/mod_negotiation_brute.rb
+++ b/modules/auxiliary/scanner/http/mod_negotiation_brute.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/mod_negotiation_brute.rb
+++ b/modules/auxiliary/scanner/http/mod_negotiation_brute.rb
@@ -26,8 +26,7 @@ class Metasploit3 < Msf::Auxiliary
 				files found will be displayed.
 			},
 			'Author' 		=> [ 'diablohorn [at] gmail.com' ],
-			'License'		=> MSF_LICENSE,
-			'Version'		=> '$Revision$'))
+			'License'		=> MSF_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/mod_negotiation_scanner.rb
+++ b/modules/auxiliary/scanner/http/mod_negotiation_scanner.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/mod_negotiation_scanner.rb
+++ b/modules/auxiliary/scanner/http/mod_negotiation_scanner.rb
@@ -20,8 +20,7 @@ class Metasploit3 < Msf::Auxiliary
 				If the webserver has mod_negotiation enabled, the IP address will be displayed.
 			},
 			'Author' 		=> [ 'diablohorn [at] gmail.com' ],
-			'License'		=> MSF_LICENSE,
-			'Version'		=> '$Revision$'))
+			'License'		=> MSF_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/ms09_020_webdav_unicode_bypass.rb
+++ b/modules/auxiliary/scanner/http/ms09_020_webdav_unicode_bypass.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/ms09_020_webdav_unicode_bypass.rb
+++ b/modules/auxiliary/scanner/http/ms09_020_webdav_unicode_bypass.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
 				protected folder requires either Basic, Digest or NTLM authentication.
 			},
 			'Author' 		=> [ 'et', 'patrick' ],
-			'Version'		=> '$Revision$',
 			'License'		=> MSF_LICENSE,
 			'References'   =>
 				[

--- a/modules/auxiliary/scanner/http/nginx_source_disclosure.rb
+++ b/modules/auxiliary/scanner/http/nginx_source_disclosure.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/nginx_source_disclosure.rb
+++ b/modules/auxiliary/scanner/http/nginx_source_disclosure.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Nginx Source Code Disclosure/Download',
-			'Version'        => '$Revision$',
 			'Description'    => %q{
 					This module exploits a source code disclosure/download vulnerability in
 				versions 0.7 and 0.8 of the nginx web server. Versions 0.7.66 and 0.8.40

--- a/modules/auxiliary/scanner/http/open_proxy.rb
+++ b/modules/auxiliary/scanner/http/open_proxy.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/open_proxy.rb
+++ b/modules/auxiliary/scanner/http/open_proxy.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize(info = {})
 		super(update_info(info,
 			'Name'        => 'HTTP Open Proxy Detection',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 					Checks if an HTTP proxy is open. False positive are avoided
 				verifing the HTTP return code and matching a pattern.

--- a/modules/auxiliary/scanner/http/options.rb
+++ b/modules/auxiliary/scanner/http/options.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/options.rb
+++ b/modules/auxiliary/scanner/http/options.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'HTTP Options Detection',
-			'Version'     => '$Revision$',
 			'Description' => 'Display available HTTP options for each system',
 			'Author'       => ['CG'],
 			'License'     => MSF_LICENSE,

--- a/modules/auxiliary/scanner/http/prev_dir_same_name_file.rb
+++ b/modules/auxiliary/scanner/http/prev_dir_same_name_file.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/prev_dir_same_name_file.rb
+++ b/modules/auxiliary/scanner/http/prev_dir_same_name_file.rb
@@ -25,8 +25,7 @@ class Metasploit3 < Msf::Auxiliary
 				following files /backup/files.ext .
 			},
 			'Author' 		=> [ 'et [at] metasploit.com' ],
-			'License'		=> BSD_LICENSE,
-			'Version'		=> '$Revision$'))
+			'License'		=> BSD_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/replace_ext.rb
+++ b/modules/auxiliary/scanner/http/replace_ext.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/replace_ext.rb
+++ b/modules/auxiliary/scanner/http/replace_ext.rb
@@ -27,8 +27,7 @@ class Metasploit3 < Msf::Auxiliary
 
 			},
 			'Author' 		=> [ 'et [at] cyberspace.org' ],
-			'License'		=> BSD_LICENSE,
-			'Version'		=> '$Revision$'))
+			'License'		=> BSD_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/rewrite_proxy_bypass.rb
+++ b/modules/auxiliary/scanner/http/rewrite_proxy_bypass.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/rewrite_proxy_bypass.rb
+++ b/modules/auxiliary/scanner/http/rewrite_proxy_bypass.rb
@@ -14,7 +14,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Apache Reverse Proxy Bypass Vulnerability Scanner',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				Scan for poorly configured reverse proxy servers.
 				By default, this module attempts to force the server to make

--- a/modules/auxiliary/scanner/http/robots_txt.rb
+++ b/modules/auxiliary/scanner/http/robots_txt.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/robots_txt.rb
+++ b/modules/auxiliary/scanner/http/robots_txt.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'HTTP Robots.txt Content Scanner',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect robots.txt files and analize its content',
 			'Author'       => ['et'],
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/sap_businessobjects_user_brute.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_user_brute.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/sap_businessobjects_user_brute.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_user_brute.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'		   => 'SAP BusinessObjects User Bruteforcer',
-			'Version'		=> '$Revision$',
 			'Description'	=> 'This module attempts to bruteforce SAP BusinessObjects users.
 				The dswsbobje interface is only used to verify valid credentials for CmcApp.
 				Therefore, any valid credentials that have been identified can be leveraged by

--- a/modules/auxiliary/scanner/http/sap_businessobjects_user_brute_web.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_user_brute_web.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/sap_businessobjects_user_brute_web.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_user_brute_web.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'		   => 'SAP BusinessObjects Web User Bruteforcer',
-			'Version'		=> '$Revision$',
 			'Description'	=> 'This module simply attempts to bruteforce SAP BusinessObjects users by using CmcApp.',
 			'References'  =>
 				[

--- a/modules/auxiliary/scanner/http/sap_businessobjects_user_enum.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_user_enum.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/sap_businessobjects_user_enum.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_user_enum.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'		   => 'SAP BusinessObjects User Enumeration',
-			'Version'		=> '$Revision$',
 			'Description'	=> %Q{
 				This module simply attempts to enumerate SAP BusinessObjects
 				users.The dswsbobje interface is only used to verify valid

--- a/modules/auxiliary/scanner/http/sap_businessobjects_version_enum.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_version_enum.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/sap_businessobjects_version_enum.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_version_enum.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'		   => 'SAP BusinessObjects Version Detection',
-			'Version'		=> '$Revision$',
 			'Description'	=> 'This module simply attempts to identify the version of SAP BusinessObjects.',
 			'References'  =>
 				[

--- a/modules/auxiliary/scanner/http/scraper.rb
+++ b/modules/auxiliary/scanner/http/scraper.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/scraper.rb
+++ b/modules/auxiliary/scanner/http/scraper.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'HTTP Page Scraper',
-			'Version'     => '$Revision$',
 			'Description' => 'Scrap defined data from a specific web page based on a regular expresion',
 			'Author'       => ['et'],
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/soap_xml.rb
+++ b/modules/auxiliary/scanner/http/soap_xml.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/soap_xml.rb
+++ b/modules/auxiliary/scanner/http/soap_xml.rb
@@ -24,8 +24,7 @@ class Metasploit3 < Msf::Auxiliary
 				hidden methods.
 			},
 			'Author'      => [ 'patrick' ],
-			'License'     => MSF_LICENSE,
-			'Version'     => '$Revision$'))
+			'License'     => MSF_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/sqlmap.rb
+++ b/modules/auxiliary/scanner/http/sqlmap.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/sqlmap.rb
+++ b/modules/auxiliary/scanner/http/sqlmap.rb
@@ -32,7 +32,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'	    => [ 'Bernardo Damele A. G. <bernardo.damele[at]gmail.com>' ],
 			'License'		=> BSD_LICENSE,
-			'Version'		=> '$Revision$',
 			'References'	=>
 				[
 					['URL', 'http://sqlmap.sourceforge.net'],

--- a/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
+++ b/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
+++ b/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
@@ -33,7 +33,6 @@ class Metasploit3 < Msf::Auxiliary
 					the attack to pivot to another part of the network).
 			},
 			'Author'	       => ['willis'],
-			'Version'       => '$Revision$',
 			'References'	 =>
 				[
 							'URL','http://wiki.squid-cache.org/SquidFaq/SecurityPitfalls'

--- a/modules/auxiliary/scanner/http/squiz_matrix_user_enum.rb
+++ b/modules/auxiliary/scanner/http/squiz_matrix_user_enum.rb
@@ -33,7 +33,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'Troy Rose <troy[at]osisecurity.com.au>', 'patrick' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'http://www.osisecurity.com.au/advisories/' ],

--- a/modules/auxiliary/scanner/http/squiz_matrix_user_enum.rb
+++ b/modules/auxiliary/scanner/http/squiz_matrix_user_enum.rb
@@ -1,7 +1,3 @@
-##
-# $Id$
-##
-
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/ssl.rb
+++ b/modules/auxiliary/scanner/http/ssl.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/ssl.rb
+++ b/modules/auxiliary/scanner/http/ssl.rb
@@ -19,7 +19,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'HTTP SSL Certificate Information',
-			'Version'     => '$Revision$',
 			'Description' => 'Parse the server SSL certificate to obtain the common name and signature algorithm',
 			'Author'      =>
 				[

--- a/modules/auxiliary/scanner/http/svn_scanner.rb
+++ b/modules/auxiliary/scanner/http/svn_scanner.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/svn_scanner.rb
+++ b/modules/auxiliary/scanner/http/svn_scanner.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'HTTP Subversion Scanner',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect subversion directories and files and analize its content. Only SVN Version > 7 supported',
 			'Author'       => ['et'],
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/tomcat_enum.rb
+++ b/modules/auxiliary/scanner/http/tomcat_enum.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/tomcat_enum.rb
+++ b/modules/auxiliary/scanner/http/tomcat_enum.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Apache Tomcat User Enumeration',
-			'Version'        => '$Revision$',
 			'Description'    => %q{
 					Apache Tomcat user enumeration utility, for Apache Tomcat servers prior to version
 				6.0.20, 5.5.28, and 4.1.40.

--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Tomcat Application Manager Login Utility',
-			'Version'        => '$Revision$',
 			'Description'    => 'This module simply attempts to login to a Tomcat Application Manager instance using a specific user/pass.',
 			'References'     =>
 				[

--- a/modules/auxiliary/scanner/http/trace.rb
+++ b/modules/auxiliary/scanner/http/trace.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'HTTP TRACE Detection',
-			'Version'     => '$Revision$',
 			'Description' => 'Test if TRACE is actually enabled.  405 (Apache) 501(IIS) if its disabled, 200 if it is',
 			'Author'       => ['CG'],
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/trace_axd.rb
+++ b/modules/auxiliary/scanner/http/trace_axd.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/trace_axd.rb
+++ b/modules/auxiliary/scanner/http/trace_axd.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'HTTP trace.axd Content Scanner',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect trace.axd files and analize its content',
 			'Author'       => ['c4an'],
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/verb_auth_bypass.rb
+++ b/modules/auxiliary/scanner/http/verb_auth_bypass.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/verb_auth_bypass.rb
+++ b/modules/auxiliary/scanner/http/verb_auth_bypass.rb
@@ -27,8 +27,7 @@ class Metasploit3 < Msf::Auxiliary
 
 			},
 			'Author' 		=> [ 'et [at] metasploit.com' ],
-			'License'		=> BSD_LICENSE,
-			'Version'		=> '$Revision$'))
+			'License'		=> BSD_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/vhost_scanner.rb
+++ b/modules/auxiliary/scanner/http/vhost_scanner.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/vhost_scanner.rb
+++ b/modules/auxiliary/scanner/http/vhost_scanner.rb
@@ -32,8 +32,7 @@ require 'cgi'
 
 					},
 				'Author' 		=> [ 'et [at] cyberspace.org' ],
-				'License'		=> BSD_LICENSE,
-				'Version'		=> '$Revision$'))
+				'License'		=> BSD_LICENSE))
 
 			register_options(
 			[

--- a/modules/auxiliary/scanner/http/vmware_server_dir_trav.rb
+++ b/modules/auxiliary/scanner/http/vmware_server_dir_trav.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/vmware_server_dir_trav.rb
+++ b/modules/auxiliary/scanner/http/vmware_server_dir_trav.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'VMware Server Directory Traversal Vulnerability',
-			'Version'     => '$Revision$',
 			'Description' => 'This modules exploits the VMware Server Directory Traversal
 				vulnerability in VMware Server 1.x before 1.0.10 build 203137 and 2.x before
 				2.0.2 build 203138 on Linux, VMware ESXi 3.5, and VMware ESX 3.0.3 and 3.5
@@ -27,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
 				the gueststealer tool.',
 			'Author'      => 'CG' ,
 			'License'     => MSF_LICENSE,
-			'Version'     => '$Revision$',
 			'References'	=>
 				[
 					[ 'URL', 'http://www.vmware.com/security/advisories/VMSA-2009-0015.html' ],

--- a/modules/auxiliary/scanner/http/web_vulndb.rb
+++ b/modules/auxiliary/scanner/http/web_vulndb.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/web_vulndb.rb
+++ b/modules/auxiliary/scanner/http/web_vulndb.rb
@@ -22,8 +22,7 @@ class Metasploit3 < Msf::Auxiliary
 				This module identifies common vulnerable files or cgis.
 			},
 			'Author' 		=> [ 'et' ],
-			'License'		=> BSD_LICENSE,
-			'Version'		=> '$Revision$'))
+			'License'		=> BSD_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/http/webdav_internal_ip.rb
+++ b/modules/auxiliary/scanner/http/webdav_internal_ip.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/webdav_internal_ip.rb
+++ b/modules/auxiliary/scanner/http/webdav_internal_ip.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'HTTP WebDAV Internal IP Scanner',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect webservers internal IPs though WebDAV',
 			'Author'       => ['et'],
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/webdav_scanner.rb
+++ b/modules/auxiliary/scanner/http/webdav_scanner.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/webdav_scanner.rb
+++ b/modules/auxiliary/scanner/http/webdav_scanner.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'HTTP WebDAV Scanner',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect webservers with WebDAV enabled',
 			'Author'       => ['et'],
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/webdav_website_content.rb
+++ b/modules/auxiliary/scanner/http/webdav_website_content.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/webdav_website_content.rb
+++ b/modules/auxiliary/scanner/http/webdav_website_content.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'HTTP WebDAV Website Content Scanner',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect webservers disclosing its content though WebDAV',
 			'Author'       => ['et'],
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/xpath.rb
+++ b/modules/auxiliary/scanner/http/xpath.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/http/xpath.rb
+++ b/modules/auxiliary/scanner/http/xpath.rb
@@ -22,8 +22,7 @@ class Metasploit3 < Msf::Auxiliary
 				This module exploits blind XPATH 1.0 injections over HTTP GET requests.
 			},
 			'Author' 		=> [ 'et [at] metasploit . com' ],
-			'License'		=> BSD_LICENSE,
-			'Version'		=> '$Revision$'))
+			'License'		=> BSD_LICENSE))
 
 		register_options(
 			[

--- a/modules/auxiliary/scanner/imap/imap_version.rb
+++ b/modules/auxiliary/scanner/imap/imap_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/imap/imap_version.rb
+++ b/modules/auxiliary/scanner/imap/imap_version.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'IMAP4 Banner Grabber',
-			'Version'     => '$Revision$',
 			'Description' => 'IMAP4 Banner Grabber',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/ip/ipidseq.rb
+++ b/modules/auxiliary/scanner/ip/ipidseq.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/ip/ipidseq.rb
+++ b/modules/auxiliary/scanner/ip/ipidseq.rb
@@ -31,8 +31,7 @@ class Metasploit3 < Msf::Auxiliary
 				classified as "Incremental" or "Broken little-endian incremental".
 			},
 			'Author'      => 'kris katterjohn',
-			'License'     => MSF_LICENSE,
-			'Version'     => '$Revision$'
+			'License'     => MSF_LICENSE
 		)
 
 		register_options([

--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Lotus Domino Password Hash Collector',
-			'Version'        => '$Revision$',
 			'Description'    => 'Get users passwords hashes from names.nsf page',
 			'Author'         => 'Tiago Ferreira <tiago.ccna[at]gmail.com>',
 			'License'        => MSF_LICENSE

--- a/modules/auxiliary/scanner/lotus/lotus_domino_login.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/lotus/lotus_domino_login.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_login.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Lotus Domino Brute Force Utility',
-			'Version'        => '$Revision$',
 			'Description'    => 'Lotus Domino Authentication Brute Force Utility',
 			'Author'         => 'Tiago Ferreira <tiago.ccna[at]gmail.com>',
 			'License'        =>  MSF_LICENSE

--- a/modules/auxiliary/scanner/lotus/lotus_domino_version.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/lotus/lotus_domino_version.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_version.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Lotus Domino Version',
-			'Version'     => '$Revision$',
 			'Description' => 'Several checks to determine Lotus Domino Server Version.',
 			'Author'       => ['CG'],
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/misc/ib_service_mgr_info.rb
+++ b/modules/auxiliary/scanner/misc/ib_service_mgr_info.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/misc/ib_service_mgr_info.rb
+++ b/modules/auxiliary/scanner/misc/ib_service_mgr_info.rb
@@ -25,7 +25,6 @@ class Metasploit3 < Msf::Auxiliary
 				and implementation of the InterBase server from InterBase
 				Services Manager.
 			},
-			'Version'	=> '$Revision$',
 			'Author'	=>
 				[
 					'Ramon de C Valle',

--- a/modules/auxiliary/scanner/misc/java_rmi_server.rb
+++ b/modules/auxiliary/scanner/misc/java_rmi_server.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/misc/java_rmi_server.rb
+++ b/modules/auxiliary/scanner/misc/java_rmi_server.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Java RMI Server Insecure Endpoint Code Execution Scanner',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect Java RMI endpoints',
 			'Author'     => ['mihi', 'hdm'],
 			'License'     => MSF_LICENSE,

--- a/modules/auxiliary/scanner/misc/redis_server.rb
+++ b/modules/auxiliary/scanner/misc/redis_server.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/misc/redis_server.rb
+++ b/modules/auxiliary/scanner/misc/redis_server.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize(info={})
 		super(update_info(info,
 			'Name'         => 'Redis-server Scanner',
-			'Version'      => '$Revision$',
 			'Description'  => %q{
 					This module scans for Redis server. By default Redis has no auth. If auth
 				(password only) is used, it is then possible to execute a brute force attack on

--- a/modules/auxiliary/scanner/misc/rosewill_rxs3211_passwords.rb
+++ b/modules/auxiliary/scanner/misc/rosewill_rxs3211_passwords.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/misc/rosewill_rxs3211_passwords.rb
+++ b/modules/auxiliary/scanner/misc/rosewill_rxs3211_passwords.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Rosewill RXS-3211 IP Camera Password Retriever',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 					This module takes advantage of a protocol design issue with the Rosewill admin
 				executable in order to retrieve passwords, allowing remote attackers to take

--- a/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
+++ b/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
+++ b/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 				program entries and their running port numbers.
 			},
 			'Author'	       => ['<tebo [at] attackresearch.com>'],
-			'Version'       => '$Revision$',
 			'References'	 =>
 				[
 					['URL',	'http://www.ietf.org/rfc/rfc1057.txt'],

--- a/modules/auxiliary/scanner/motorola/timbuktu_udp.rb
+++ b/modules/auxiliary/scanner/motorola/timbuktu_udp.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/motorola/timbuktu_udp.rb
+++ b/modules/auxiliary/scanner/motorola/timbuktu_udp.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => ['MC'],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'DisclosureDate' => 'Sep 25 2009'
 		))
 

--- a/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'MSSQL Password Hashdump',
-			'Version'        => '$Revision$',
 			'Description'    => %Q{
 					This module extracts the usernames and encrypted password
 				hashes from a MSSQL server and stores them for later cracking.

--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'MSSQL Login Utility',
-			'Version'        => '$Revision$',
 			'Description'    => 'This module simply queries the MSSQL instance for a specific user/pass (default is sa with blank).',
 			'Author'         => 'MC',
 			'References'     =>

--- a/modules/auxiliary/scanner/mssql/mssql_ping.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_ping.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/mssql/mssql_ping.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_ping.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'MSSQL Ping Utility',
-			'Version'        => '$Revision$',
 			'Description'    => 'This module simply queries the MSSQL instance for information.',
 			'Author'         => 'MC',
 			'License'        => MSF_LICENSE

--- a/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'MySQL Authentication Bypass Password Dump',
-			'Version'        => '$Revision$',
 			'Description'    => %Q{
 					This module exploits a password bypass vulnerability in MySQL in order
 				to extract the usernames and encrypted password hashes from a MySQL server.

--- a/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'MYSQL Password Hashdump',
-			'Version'        => '$Revision$',
 			'Description'    => %Q{
 					This module extracts the usernames and encrypted password
 				hashes from a MySQL server and stores them for later cracking.

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -26,8 +26,7 @@ class Metasploit3 < Msf::Auxiliary
 			'References'     =>
 				[
 					[ 'CVE', '1999-0502'] # Weak password
-				],
-			'Version'		=> '$Revision$'
+				]
 		))
 	end
 

--- a/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'MYSQL Schema Dump',
-			'Version'        => '$Revision$',
 			'Description'    => %Q{
 					This module extracts the schema information from a
 					MySQL DB server.

--- a/modules/auxiliary/scanner/mysql/mysql_version.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/mysql/mysql_version.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_version.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 			'Description' => %q{
 				Enumerates the version of MySQL servers
 			},
-			'Version'     => '$Revision$',
 			'Author'      => 'kris katterjohn',
 			'License'     => MSF_LICENSE
 		)

--- a/modules/auxiliary/scanner/netbios/nbname.rb
+++ b/modules/auxiliary/scanner/netbios/nbname.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/netbios/nbname.rb
+++ b/modules/auxiliary/scanner/netbios/nbname.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'NetBIOS Information Discovery',
-			'Version'     => '$Revision$',
 			'Description' => 'Discover host information through NetBIOS',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/netbios/nbname_probe.rb
+++ b/modules/auxiliary/scanner/netbios/nbname_probe.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/netbios/nbname_probe.rb
+++ b/modules/auxiliary/scanner/netbios/nbname_probe.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'NetBIOS Information Discovery Prober',
-			'Version'     => '$Revision$',
 			'Description' => 'Discover host information using sequential NetBIOS Probes',
 			'Author'      => ['hdm', 'todb'],
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/nfs/nfsmount.rb
+++ b/modules/auxiliary/scanner/nfs/nfsmount.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/nfs/nfsmount.rb
+++ b/modules/auxiliary/scanner/nfs/nfsmount.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 				This module scans NFS mounts and their permissions.
 			},
 			'Author'	       => ['<tebo[at]attackresearch.com>'],
-			'Version'       => '$Revision$',
 			'References'	 =>
 				[
 					['CVE', '1999-0170'],

--- a/modules/auxiliary/scanner/ntp/ntp_monlist.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_monlist.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/ntp/ntp_monlist.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_monlist.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'NTP Monitor List Scanner',
-			'Version'     => '$Revision$',
 			'Description' => 'Obtain the list of recent clients from an NTP server',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/oracle/emc_sid.rb
+++ b/modules/auxiliary/scanner/oracle/emc_sid.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/oracle/emc_sid.rb
+++ b/modules/auxiliary/scanner/oracle/emc_sid.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 					This module makes a request to the Oracle  Enterprise Manager Control Console
 				in an attempt to discover the SID.
 			},
-			'Version'     => '$Revision$',
 			'References'  =>
 				[
 					[ 'URL', 'http://dsecrg.com/files/pub/pdf/Different_ways_to_guess_Oracle_database_SID_(eng).pdf' ],

--- a/modules/auxiliary/scanner/oracle/isqlplus_login.rb
+++ b/modules/auxiliary/scanner/oracle/isqlplus_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/oracle/isqlplus_login.rb
+++ b/modules/auxiliary/scanner/oracle/isqlplus_login.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Oracle iSQL*Plus Login Utility',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				This module attempts to authenticate against an Oracle ISQL*Plus
 				administration web site using username and password combinations indicated

--- a/modules/auxiliary/scanner/oracle/isqlplus_sidbrute.rb
+++ b/modules/auxiliary/scanner/oracle/isqlplus_sidbrute.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/oracle/isqlplus_sidbrute.rb
+++ b/modules/auxiliary/scanner/oracle/isqlplus_sidbrute.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Oracle isqlplus SID Check',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				This module attempts to bruteforce the SID on the Oracle application server iSQL*Plus
 				login pages.  It does this by testing Oracle error responses returned in the HTTP response.

--- a/modules/auxiliary/scanner/oracle/oracle_hashdump.rb
+++ b/modules/auxiliary/scanner/oracle/oracle_hashdump.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/oracle/oracle_hashdump.rb
+++ b/modules/auxiliary/scanner/oracle/oracle_hashdump.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Oracle Password Hashdump',
-			'Version'        => '$Revision$',
 			'Description'    => %Q{
 					This module dumps the usernames and password hashes
 					from Oracle given the proper Credentials and SID.

--- a/modules/auxiliary/scanner/oracle/oracle_login.rb
+++ b/modules/auxiliary/scanner/oracle/oracle_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/oracle/oracle_login.rb
+++ b/modules/auxiliary/scanner/oracle/oracle_login.rb
@@ -33,8 +33,7 @@ class Metasploit3 < Msf::Auxiliary
 					[ 'URL', 'http://www.oracle.com/us/products/database/index.html' ],
 					[ 'CVE', '1999-0502'], # Weak password CVE
 					[ 'URL', 'http://nmap.org/nsedoc/scripts/oracle-brute.html']
-				],
-			'Version'        => '$Revision$'
+				]
 		))
 
 		register_options(

--- a/modules/auxiliary/scanner/oracle/sid_brute.rb
+++ b/modules/auxiliary/scanner/oracle/sid_brute.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/oracle/sid_brute.rb
+++ b/modules/auxiliary/scanner/oracle/sid_brute.rb
@@ -25,8 +25,7 @@ class Metasploit3 < Msf::Auxiliary
 				SIDs read from the named file will be attempted in sequence instead.
 			},
 			'Author'         => [ 'todb' ],
-			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$'
+			'License'        => MSF_LICENSE
 		))
 
 		register_options(

--- a/modules/auxiliary/scanner/oracle/sid_enum.rb
+++ b/modules/auxiliary/scanner/oracle/sid_enum.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/oracle/sid_enum.rb
+++ b/modules/auxiliary/scanner/oracle/sid_enum.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'CG', 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'DisclosureDate' => 'Jan 7 2009'
 		))
 

--- a/modules/auxiliary/scanner/oracle/spy_sid.rb
+++ b/modules/auxiliary/scanner/oracle/spy_sid.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/oracle/spy_sid.rb
+++ b/modules/auxiliary/scanner/oracle/spy_sid.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 					This module makes a request to the Oracle Application Server
 				in an attempt to discover the SID.
 			},
-			'Version'     => '$Revision$',
 			'References'  =>
 				[
 					[ 'URL', 'http://dsecrg.com/files/pub/pdf/Different_ways_to_guess_Oracle_database_SID_(eng).pdf' ],

--- a/modules/auxiliary/scanner/oracle/tnslsnr_version.rb
+++ b/modules/auxiliary/scanner/oracle/tnslsnr_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/oracle/tnslsnr_version.rb
+++ b/modules/auxiliary/scanner/oracle/tnslsnr_version.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => ['CG'],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'DisclosureDate' => 'Jan 7 2009'))
 
 		register_options(

--- a/modules/auxiliary/scanner/oracle/xdb_sid.rb
+++ b/modules/auxiliary/scanner/oracle/xdb_sid.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/oracle/xdb_sid.rb
+++ b/modules/auxiliary/scanner/oracle/xdb_sid.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 					This module simply makes a authenticated request to retrieve
 					the sid from the Oracle XML DB httpd server.
 			},
-			'Version'     => '$Revision$',
 			'References'  =>
 				[
 					[ 'URL', 'http://dsecrg.com/files/pub/pdf/Different_ways_to_guess_Oracle_database_SID_(eng).pdf' ],

--- a/modules/auxiliary/scanner/oracle/xdb_sid_brute.rb
+++ b/modules/auxiliary/scanner/oracle/xdb_sid_brute.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/oracle/xdb_sid_brute.rb
+++ b/modules/auxiliary/scanner/oracle/xdb_sid_brute.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 					This module attempts to retrieve the sid from the Oracle XML DB httpd server,
 					utilizing Pete Finnigan's default oracle password list.
 			},
-			'Version'     => '$Revision$',
 			'References'  =>
 				[
 					[ 'URL', 'http://dsecrg.com/files/pub/pdf/Different_ways_to_guess_Oracle_database_SID_(eng).pdf' ],

--- a/modules/auxiliary/scanner/pcanywhere/pcanywhere_login.rb
+++ b/modules/auxiliary/scanner/pcanywhere/pcanywhere_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/pcanywhere/pcanywhere_login.rb
+++ b/modules/auxiliary/scanner/pcanywhere/pcanywhere_login.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'PcAnywhere Login Scanner',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				This module will test pcAnywhere logins on a range of machines and
 				report successful logins.

--- a/modules/auxiliary/scanner/pcanywhere/pcanywhere_tcp.rb
+++ b/modules/auxiliary/scanner/pcanywhere/pcanywhere_tcp.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/pcanywhere/pcanywhere_tcp.rb
+++ b/modules/auxiliary/scanner/pcanywhere/pcanywhere_tcp.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'PcAnywhere TCP Service Discovery',
-			'Version'     => '$Revision$',
 			'Description' => 'Discover active pcAnywhere services through TCP',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/pcanywhere/pcanywhere_udp.rb
+++ b/modules/auxiliary/scanner/pcanywhere/pcanywhere_udp.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/pcanywhere/pcanywhere_udp.rb
+++ b/modules/auxiliary/scanner/pcanywhere/pcanywhere_udp.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'PcAnywhere UDP Service Discovery',
-			'Version'     => '$Revision$',
 			'Description' => 'Discover active pcAnywhere services through UDP',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE,

--- a/modules/auxiliary/scanner/pop3/pop3_login.rb
+++ b/modules/auxiliary/scanner/pop3/pop3_login.rb
@@ -1,7 +1,3 @@
-##
-# $Id$
-##
-
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/pop3/pop3_login.rb
+++ b/modules/auxiliary/scanner/pop3/pop3_login.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	super(
 		'Name'        => 'POP3 Login Utility',
 		'Description' => 'This module attempts to authenticate to an POP3 service.',
-		'Version'     => '$Revision$',
 		'Author'      =>
 		[
 			'==[ Alligator Security Team ]==',

--- a/modules/auxiliary/scanner/pop3/pop3_version.rb
+++ b/modules/auxiliary/scanner/pop3/pop3_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/pop3/pop3_version.rb
+++ b/modules/auxiliary/scanner/pop3/pop3_version.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'POP3 Banner Grabber',
-			'Version'     => '$Revision$',
 			'Description' => 'POP3 Banner Grabber',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/portscan/ack.rb
+++ b/modules/auxiliary/scanner/portscan/ack.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/portscan/ack.rb
+++ b/modules/auxiliary/scanner/portscan/ack.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 				not in place for them.
 			},
 			'Author'      => 'kris katterjohn',
-			'Version'     => '$Revision$', # 03/26/2009
 			'License'     => MSF_LICENSE
 		)
 

--- a/modules/auxiliary/scanner/portscan/ftpbounce.rb
+++ b/modules/auxiliary/scanner/portscan/ftpbounce.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/portscan/ftpbounce.rb
+++ b/modules/auxiliary/scanner/portscan/ftpbounce.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'FTP Bounce Port Scanner',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				Enumerate TCP services via the FTP bounce PORT/LIST
 				method, which can still come in handy every once in

--- a/modules/auxiliary/scanner/portscan/syn.rb
+++ b/modules/auxiliary/scanner/portscan/syn.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/portscan/syn.rb
+++ b/modules/auxiliary/scanner/portscan/syn.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 				Enumerate open TCP services using a raw SYN scan.
 			},
 			'Author'      => 'kris katterjohn',
-			'Version'     => '$Revision$', # 03/26/2009
 			'License'     => MSF_LICENSE
 		)
 

--- a/modules/auxiliary/scanner/portscan/tcp.rb
+++ b/modules/auxiliary/scanner/portscan/tcp.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/portscan/tcp.rb
+++ b/modules/auxiliary/scanner/portscan/tcp.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'TCP Port Scanner',
-			'Version'     => '$Revision$',
 			'Description' => 'Enumerate open TCP services',
 			'Author'      => [ 'hdm', 'kris katterjohn' ],
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/portscan/xmas.rb
+++ b/modules/auxiliary/scanner/portscan/xmas.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/portscan/xmas.rb
+++ b/modules/auxiliary/scanner/portscan/xmas.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 				PSH and URG flags.
 			},
 			'Author'      => 'kris katterjohn',
-			'Version'     => '$Revision$', # 04/08/2009
 			'License'     => MSF_LICENSE
 		)
 

--- a/modules/auxiliary/scanner/postgres/postgres_hashdump.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_hashdump.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/postgres/postgres_hashdump.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_hashdump.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Postgres Password Hashdump',
-			'Version'        => '$Revision$',
 			'Description'    => %Q{
 					This module extracts the usernames and encrypted password
 				hashes from a Postgres server and stores them for later cracking.

--- a/modules/auxiliary/scanner/postgres/postgres_login.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/postgres/postgres_login.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_login.rb
@@ -30,8 +30,7 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					[ 'URL', 'http://www.postgresql.org' ],
 					[ 'CVE', '1999-0502'] # Weak password
-				],
-			'Version'        => '$Revision$'
+				]
 		))
 
 		register_options(

--- a/modules/auxiliary/scanner/postgres/postgres_schemadump.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_schemadump.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/postgres/postgres_schemadump.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_schemadump.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Postgres Schema Dump',
-			'Version'        => '$Revision$',
 			'Description'    => %Q{
 					This module extracts the schema information from a
 					Postgres server.

--- a/modules/auxiliary/scanner/postgres/postgres_version.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/postgres/postgres_version.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_version.rb
@@ -26,8 +26,7 @@ class Metasploit3 < Msf::Auxiliary
 			'References'     =>
 				[
 					[ 'URL', 'http://www.postgresql.org' ]
-				],
-			'Version'        => '$Revision$' # 2009-02-05
+				]
 		))
 
 		register_options([ ], self.class) # None needed.

--- a/modules/auxiliary/scanner/rogue/rogue_recv.rb
+++ b/modules/auxiliary/scanner/rogue/rogue_recv.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/rogue/rogue_recv.rb
+++ b/modules/auxiliary/scanner/rogue/rogue_recv.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE,
-			'Version'     => '$Revision$',
 			'References'  =>
 				[
 					['URL', 'http://www.metasploit.com/research/projects/rogue_network/'],

--- a/modules/auxiliary/scanner/rogue/rogue_send.rb
+++ b/modules/auxiliary/scanner/rogue/rogue_send.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/rogue/rogue_send.rb
+++ b/modules/auxiliary/scanner/rogue/rogue_send.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE,
-			'Version'     => '$Revision$',
 			'References'  =>
 				[
 					['URL', 'http://www.metasploit.com/research/projects/rogue_network/'],

--- a/modules/auxiliary/scanner/rservices/rexec_login.rb
+++ b/modules/auxiliary/scanner/rservices/rexec_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/rservices/rexec_login.rb
+++ b/modules/auxiliary/scanner/rservices/rexec_login.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'rexec Authentication Scanner',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 					This module will test an rexec service on a range of machines and
 				report successful logins.

--- a/modules/auxiliary/scanner/rservices/rlogin_login.rb
+++ b/modules/auxiliary/scanner/rservices/rlogin_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/rservices/rlogin_login.rb
+++ b/modules/auxiliary/scanner/rservices/rlogin_login.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'rlogin Authentication Scanner',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 					This module will test an rlogin service on a range of machines and
 				report successful logins.

--- a/modules/auxiliary/scanner/rservices/rsh_login.rb
+++ b/modules/auxiliary/scanner/rservices/rsh_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/rservices/rsh_login.rb
+++ b/modules/auxiliary/scanner/rservices/rsh_login.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'rsh Authentication Scanner',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 					This module will test a shell (rsh) service on a range of machines and
 				report successful logins.

--- a/modules/auxiliary/scanner/sap/sap_icm_urlscan.rb
+++ b/modules/auxiliary/scanner/sap/sap_icm_urlscan.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/sap/sap_icm_urlscan.rb
+++ b/modules/auxiliary/scanner/sap/sap_icm_urlscan.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 				This module scans for commonly found SAP Internet Communication Manager URLs
 				and outputs return codes for the user.
 			},
-			'Version'         => '$Revision$',
 			'Author'          => [ 'Chris John Riley' ],
 			'References'      =>
 				[

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_abaplog.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_abaplog.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_abaplog.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_abaplog.rb
@@ -16,7 +16,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'         => 'SAP Management Console ABAP syslog',
-			'Version'      => '$Revision$',
 			'Description'  => %q{ This module simply attempts to extract the ABAP syslog through the SAP Management Console SOAP Interface. },
 			'References'   =>
 				[

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
@@ -17,7 +17,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'SAP Management Console Brute Force',
-			'Version'        => '$Revision$',
 			'Description'    => %q{
 				This module simply attempts to brute force the username |
 				password for the SAP Management Console SOAP Interface. By

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_extractusers.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_extractusers.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_extractusers.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_extractusers.rb
@@ -16,7 +16,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'         => 'SAP Management Console Extract Users',
-			'Version'      => '$Revision$',
 			'Description'  =>  %q{
 				This module simply attempts to extract SAP users from the ABAP
 				Syslog through the SAP Management Console SOAP Interface.

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getaccesspoints.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getaccesspoints.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getaccesspoints.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getaccesspoints.rb
@@ -16,7 +16,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'         => 'SAP Management Console Get Access Points',
-			'Version'      => '$Revision$',
 			'Description'  => %q{
 				This module simply attempts to output a list of SAP access points through the
 				SAP Management Console SOAP Interface.

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getenv.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getenv.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getenv.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getenv.rb
@@ -16,7 +16,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'         => 'SAP Management Console getEnvironment',
-			'Version'      => '$Revision$',
 			'Description'  => %q{
 				This module simply attempts to identify SAP Environment
 				settings through the SAP Management Console SOAP Interface.

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getlogfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getlogfiles.rb
@@ -16,7 +16,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'         => 'SAP Management Console Get Logfile',
-			'Version'      => '$Revision$',
 			'Description'  => %q{
 				This module simply attempts to download available logfiles and
 				developer tracefiles through the SAP Management Console SOAP

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocessparameter.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocessparameter.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocessparameter.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocessparameter.rb
@@ -16,7 +16,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'         => 'SAP Management Console Get Process Parameters',
-			'Version'      => '$Revision$',
 			'Description'  => %q{
 				This module simply attempts to output a SAP process parameters and
 				configuration settings through the SAP Management Console SOAP Interface.

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb
@@ -16,7 +16,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'         => 'SAP Management Console Instance Properties',
-			'Version'      => '$Revision$',
 			'Description'  => %q{
 				This module simply attempts to identify the instance properties
 				through the SAP Management Console SOAP Interface.

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
@@ -16,7 +16,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'         => 'SAP Management Console List Logfiles',
-			'Version'      => '$Revision$',
 			'Description'  => %q{
 				This module simply attempts to output a list of available
 				logfiles and developer tracefiles through the SAP Management

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_startprofile.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_startprofile.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_startprofile.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_startprofile.rb
@@ -16,7 +16,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'         => 'SAP Management Console getStartProfile',
-			'Version'      => '$Revision$',
 			'Description'  => %q{
 				This module simply attempts to acces the SAP startup profile
 				through the SAP Management Console SOAP Interface.

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_version.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_version.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_version.rb
@@ -16,7 +16,6 @@ class Metasploit4 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'         => 'SAP Management Console Version Detection',
-			'Version'      => '$Revision$',
 			'Description'  => %q{
 				This module simply attempts to identify the version of SAP
 				through the SAP Management Console SOAP Interface.

--- a/modules/auxiliary/scanner/scada/digi_addp_reboot.rb
+++ b/modules/auxiliary/scanner/scada/digi_addp_reboot.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/scada/digi_addp_reboot.rb
+++ b/modules/auxiliary/scanner/scada/digi_addp_reboot.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Digi ADDP Remote Reboot Initiator',
-			'Version'     => '$Revision$',
 			'Description' => 'Reboot Digi International based equipment through the ADDP service',
 			'Author'      => 'hdm',
 			'References'  =>

--- a/modules/auxiliary/scanner/scada/digi_addp_version.rb
+++ b/modules/auxiliary/scanner/scada/digi_addp_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/scada/digi_addp_version.rb
+++ b/modules/auxiliary/scanner/scada/digi_addp_version.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Digi ADDP Information Discovery',
-			'Version'     => '$Revision$',
 			'Description' => 'Discover host information through the Digi International ADDP service',
 			'Author'      => 'hdm',
 			'References'  =>

--- a/modules/auxiliary/scanner/scada/digi_realport_serialport_scan.rb
+++ b/modules/auxiliary/scanner/scada/digi_realport_serialport_scan.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/scada/digi_realport_version.rb
+++ b/modules/auxiliary/scanner/scada/digi_realport_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/scada/koyo_login.rb
+++ b/modules/auxiliary/scanner/scada/koyo_login.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Koyo DirectLogic PLC Password Brute Force Utility',
-			'Version'        => '$Revision$',
 			'Description'    => %q{
 					This module attempts to authenticate to a locked Koyo DirectLogic PLC.
 				The PLC uses a restrictive passcode, which can be A0000000 through A9999999.

--- a/modules/auxiliary/scanner/sip/enumerator.rb
+++ b/modules/auxiliary/scanner/sip/enumerator.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/sip/enumerator.rb
+++ b/modules/auxiliary/scanner/sip/enumerator.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SIP Username Enumerator (UDP)',
-			'Version'     => '$Revision$',
 			'Description' => 'Scan for numeric username/extensions using OPTIONS/REGISTER requests',
 			'Author'      => 'et',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/sip/enumerator_tcp.rb
+++ b/modules/auxiliary/scanner/sip/enumerator_tcp.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/sip/enumerator_tcp.rb
+++ b/modules/auxiliary/scanner/sip/enumerator_tcp.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SIP Username Enumerator (TCP)',
-			'Version'     => '$Revision$',
 			'Description' => 'Scan for numeric username/extensions using OPTIONS/REGISTER requests',
 			'Author'      => 'et',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/sip/options.rb
+++ b/modules/auxiliary/scanner/sip/options.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/sip/options.rb
+++ b/modules/auxiliary/scanner/sip/options.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SIP Endpoint Scanner (UDP)',
-			'Version'     => '$Revision$',
 			'Description' => 'Scan for SIP devices using OPTIONS requests',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/sip/options_tcp.rb
+++ b/modules/auxiliary/scanner/sip/options_tcp.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/sip/options_tcp.rb
+++ b/modules/auxiliary/scanner/sip/options_tcp.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SIP Endpoint Scanner (TCP)',
-			'Version'     => '$Revision$',
 			'Description' => 'Scan for SIP devices using OPTIONS requests',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/sip/sipdroid_ext_enum.rb
+++ b/modules/auxiliary/scanner/sip/sipdroid_ext_enum.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/sip/sipdroid_ext_enum.rb
+++ b/modules/auxiliary/scanner/sip/sipdroid_ext_enum.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 			(other versions may be affected).
 				},
 			'Author'         => 'Anibal Aguiar <anibal.aguiar[at]gmail.com>',
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					['BID', '47710'],

--- a/modules/auxiliary/scanner/smb/pipe_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_auditor.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/smb/pipe_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_auditor.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SMB Session Pipe Auditor',
-			'Version'     => '$Revision$',
 			'Description' => 'Determine what named pipes are accessible over SMB',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SMB Session Pipe DCERPC Auditor',
-			'Version'     => '$Revision$',
 			'Description' => 'Determine what DCERPC services are accessible over a SMB pipe',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/smb/smb2.rb
+++ b/modules/auxiliary/scanner/smb/smb2.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/smb/smb2.rb
+++ b/modules/auxiliary/scanner/smb/smb2.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SMB 2.0 Protocol Detection',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect systems that support the SMB 2.0 protocol',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SMB Share Enumeration',
-			'Version'     => '$Revision$',
 			'Description' => 'Determine what shares are provided by the SMB service',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE,

--- a/modules/auxiliary/scanner/smb/smb_enumusers.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/smb/smb_enumusers.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SMB User Enumeration (SAM EnumUsers)',
-			'Version'     => '$Revision$',
 			'Description' => 'Determine what local users exist via the SAM RPC service',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE,

--- a/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
 			'Version'     => '$Revision $',
 			'Description' => 'Determine what domain users are logged into a remote system via a DCERPC to NetWkstaUserEnum.',
 			'Author'      => 'natron',
-			'Version'     => '$Revision$',
 			'References'  =>
 				[
 					[ 'URL', 'http://msdn.microsoft.com/en-us/library/aa370669%28VS.85%29.aspx' ]

--- a/modules/auxiliary/scanner/smb/smb_lookupsid.rb
+++ b/modules/auxiliary/scanner/smb/smb_lookupsid.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/smb/smb_lookupsid.rb
+++ b/modules/auxiliary/scanner/smb/smb_lookupsid.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SMB Local User Enumeration (LookupSid)',
-			'Version'     => '$Revision$',
 			'Description' => 'Determine what local users exist via brute force SID lookups',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE,

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -30,7 +30,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SMB Version Detection',
-			'Version'     => '$Revision$',
 			'Description' => 'Display version information about each system',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/smtp/smtp_enum.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_enum.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/smtp/smtp_enum.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_enum.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SMTP User Enumeration Utility',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				The SMTP service has two internal commands that allow the enumeration
 				of users: VRFY (confirming the names of valid users) and EXPN (which

--- a/modules/auxiliary/scanner/smtp/smtp_version.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/smtp/smtp_version.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_version.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SMTP Banner Grabber',
-			'Version'     => '$Revision$',
 			'Description' => 'SMTP Banner Grabber',
 			'References'  =>
 				[

--- a/modules/auxiliary/scanner/snmp/aix_version.rb
+++ b/modules/auxiliary/scanner/snmp/aix_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/snmp/aix_version.rb
+++ b/modules/auxiliary/scanner/snmp/aix_version.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'AIX SNMP Scanner Auxiliary Module',
-			'Version'     => '$Revision$',
 			'Description' => 'AIX SNMP Scanner Auxiliary Module',
 			'Author'      =>
 				[

--- a/modules/auxiliary/scanner/snmp/cisco_config_tftp.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_config_tftp.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/snmp/cisco_config_tftp.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_config_tftp.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Cisco IOS SNMP Configuration Grabber (TFTP)',
-			'Version'        => '$Revision$',
 			'Description' => %q{
 					This module will download the startup or running configuration
 				from a Cisco IOS device using SNMP and TFTP. A read-write SNMP

--- a/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Cisco IOS SNMP File Upload (TFTP)',
-			'Version'        => '$Revision$',
 			'Description' => %q{
 					This module will copy file to a Cisco IOS device using SNMP and TFTP.
 				A read-write SNMP community is required. The SNMP community scanner module can

--- a/modules/auxiliary/scanner/snmp/snmp_enum.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enum.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/snmp/snmp_enum.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enum.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize(info = {})
 		super(update_info(info,
 			'Name'        => 'SNMP Enumeration Module',
-			'Version'     => '$Revision$',
 			'Description' => 'This module allows enumeration of any devices with SNMP
 				protocol support. It supports hardware, software, and network information.
 				The default community used is "public".',

--- a/modules/auxiliary/scanner/snmp/snmp_enumshares.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enumshares.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/snmp/snmp_enumshares.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enumshares.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SNMP Windows SMB Share Enumeration',
-			'Version'     => '$Revision$',
 			'Description' => "This module will use LanManager OID values to enumerate SMB shares on a Windows system via SNMP",
 			'Author'      => ['tebo[at]attackresearch.com'],
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/snmp/snmp_enumusers.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enumusers.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/snmp/snmp_enumusers.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enumusers.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SNMP Windows Username Enumeration',
-			'Version'     => '$Revision$',
 			'Description' => "This module will use LanManager OID values to enumerate local user accounts on a Windows system via SNMP",
 			'Author'      => ['tebo[at]attackresearch.com'],
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/snmp/snmp_login.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/snmp/snmp_login.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_login.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SNMP Community Scanner',
-			'Version'     => '$Revision$',
 			'Description' => 'Scan for SNMP devices using common community names',
 			'Author'      => 'hdm',
 			'References'     =>

--- a/modules/auxiliary/scanner/snmp/snmp_set.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_set.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/snmp/snmp_set.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_set.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize(info = {})
 		super(update_info(info,
 			'Name'        => 'SNMP Set Module',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 					This module, similar to snmpset tool, uses the SNMP SET request
 					to set information on a network entity. A OID (numeric notation)

--- a/modules/auxiliary/scanner/snmp/xerox_workcentre_enumusers.rb
+++ b/modules/auxiliary/scanner/snmp/xerox_workcentre_enumusers.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/snmp/xerox_workcentre_enumusers.rb
+++ b/modules/auxiliary/scanner/snmp/xerox_workcentre_enumusers.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Xerox WorkCentre User Enumeration (SNMP)',
-			'Version'        => '$Revision$',
 			'Description'    => %q{
 					This module will do user enumeration based on the Xerox WorkCentre present on the network.
 					SNMP is used to extract the usernames.

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SSH Login Check Scanner',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				This module will test ssh logins on a range of machines and
 				report successful logins.  If you have loaded a database plugin

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SSH Public Key Login Scanner',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				This module will test ssh logins on a range of machines using
 				a defined private key file, and report successful logins.

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SSH Version Scanner',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect SSH Version.',
 			'References'  =>
 				[

--- a/modules/auxiliary/scanner/telephony/wardial.rb
+++ b/modules/auxiliary/scanner/telephony/wardial.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/telephony/wardial.rb
+++ b/modules/auxiliary/scanner/telephony/wardial.rb
@@ -44,7 +44,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Wardialer',
-			'Version'     => '$Revision$',
 			'Description' => 'Scan for dial-up systems that are connected to modems and answer telephony indials.',
 			'Author'      => [ 'I)ruid' ],
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/telnet/lantronix_telnet_version.rb
+++ b/modules/auxiliary/scanner/telnet/lantronix_telnet_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/telnet/lantronix_telnet_version.rb
+++ b/modules/auxiliary/scanner/telnet/lantronix_telnet_version.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Lantronix Telnet Service Banner Detection',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect Lantronix telnet services',
 			'Author'      => ['theLightCosine', 'hdm'],
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/telnet/telnet_encrypt_overflow.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_encrypt_overflow.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/telnet/telnet_encrypt_overflow.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_encrypt_overflow.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Telnet Service Encyption Key ID Overflow Detection',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect telnet services vulnerable to the encrypt option Key ID overflow (BSD-derived telnetd)',
 			'Author'      => [ 'Jaime Penalba Estebanez <jpenalbae[at]gmail.com>', 'hdm' ],
 			'License'     => MSF_LICENSE,

--- a/modules/auxiliary/scanner/telnet/telnet_login.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/telnet/telnet_login.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_login.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Telnet Login Check Scanner',
-			#'Version'     => '$Revision$',
+			#
 			'Description' => %q{
 				This module will test a telnet login on a range of machines and
 				report successful logins.  If you have loaded a database plugin

--- a/modules/auxiliary/scanner/telnet/telnet_version.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/telnet/telnet_version.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_version.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Telnet Service Banner Detection',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect telnet services',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/tftp/tftpbrute.rb
+++ b/modules/auxiliary/scanner/tftp/tftpbrute.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/tftp/tftpbrute.rb
+++ b/modules/auxiliary/scanner/tftp/tftpbrute.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 			'Name'        => 'TFTP Brute Forcer',
 			'Description' => 'This module uses a dictionary to brute force valid TFTP image names from a TFTP server.',
 			'Author'      => 'antoine',
-			'Version'     => '$Revision$',
 			'License'     => BSD_LICENSE
 		)
 

--- a/modules/auxiliary/scanner/upnp/ssdp_msearch.rb
+++ b/modules/auxiliary/scanner/upnp/ssdp_msearch.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/upnp/ssdp_msearch.rb
+++ b/modules/auxiliary/scanner/upnp/ssdp_msearch.rb
@@ -15,7 +15,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'UPnP SSDP M-SEARCH Information Discovery',
-			'Version'     => '$Revision$',
 			'Description' => 'Discover information from UPnP-enabled systems',
 			'Author'      => 'todb',
 			'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/vmware/esx_fingerprint.rb
+++ b/modules/auxiliary/scanner/vmware/esx_fingerprint.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/vmware/esx_fingerprint.rb
+++ b/modules/auxiliary/scanner/vmware/esx_fingerprint.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'VMWare ESX/ESXi Fingerprint Scanner',
-			'Version'        => '$Revision$',
 			'Description'    => %Q{
 				This module accesses the web API interfaces for VMware ESX/ESXi servers
 				and attempts to identify version information for that server.

--- a/modules/auxiliary/scanner/vmware/vmauthd_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmauthd_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/vmware/vmauthd_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmauthd_login.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'VMWare Authentication Daemon Login Scanner',
-			'Version'     => '$Revision$',
 			'Description' => %q{This module will test vmauthd logins on a range of machines and
 								report successful logins.
 			},

--- a/modules/auxiliary/scanner/vmware/vmauthd_version.rb
+++ b/modules/auxiliary/scanner/vmware/vmauthd_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/vmware/vmauthd_version.rb
+++ b/modules/auxiliary/scanner/vmware/vmauthd_version.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'VMWare Authentication Daemon Version Scanner',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				This module will identify information about a host through the
 			vmauthd service.

--- a/modules/auxiliary/scanner/vmware/vmware_enum_permissions.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_permissions.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/vmware/vmware_enum_permissions.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_permissions.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'VMWare Enumerate Permissions',
-			'Version'        => '$Revision$',
 			'Description'    => %Q{
 				This module will log into the Web API of VMWare and try to enumerate
 				all the user/group permissions. Unlike enum suers this is only

--- a/modules/auxiliary/scanner/vmware/vmware_enum_sessions.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_sessions.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/vmware/vmware_enum_sessions.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_sessions.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'VMWare Enumerate Active Sessions',
-			'Version'        => '$Revision$',
 			'Description'    => %Q{
 				This module will log into the Web API of VMWare and try to enumerate
 				all the login sessions.

--- a/modules/auxiliary/scanner/vmware/vmware_enum_users.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_users.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/vmware/vmware_enum_users.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_users.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'VMWare Enumerate User Accounts',
-			'Version'        => '$Revision$',
 			'Description'    => %Q{
 				This module will log into the Web API of VMWare and try to enumerate
 				all the user accounts. If the VMware instance is connected to one or

--- a/modules/auxiliary/scanner/vmware/vmware_enum_vms.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_vms.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/vmware/vmware_host_details.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_host_details.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/vmware/vmware_host_details.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_host_details.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'VMWare Enumerate Host Details',
-			'Version'        => '$Revision$',
 			'Description'    => %Q{
 				This module attempts to enumerate information about the host systems through the VMWare web API.
 				This can include information about the hardware installed on the host machine.

--- a/modules/auxiliary/scanner/vmware/vmware_http_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_http_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/vmware/vmware_http_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_http_login.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'VMWare Web Login Scanner',
-			'Version'        => '$Revision$',
 			'Description'    => 'This module attempts to authenticate to the VMWare HTTP service
 				for VmWare Server, ESX, and ESXI',
 			'Author'         => ['theLightCosine'],

--- a/modules/auxiliary/scanner/vmware/vmware_screenshot_stealer.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_screenshot_stealer.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/vmware/vmware_screenshot_stealer.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_screenshot_stealer.rb
@@ -19,7 +19,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'VMWare Screenshot Stealer',
-			'Version'        => '$Revision$',
 			'Description'    => %Q{
 				This module uses supplied login credentials to connect to VMWare via
 				the web interface. It then searches through the datastores looking for screenshots.

--- a/modules/auxiliary/scanner/vnc/vnc_login.rb
+++ b/modules/auxiliary/scanner/vnc/vnc_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/vnc/vnc_login.rb
+++ b/modules/auxiliary/scanner/vnc/vnc_login.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'VNC Authentication Scanner',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 					This module will test a VNC server on a range of machines and
 				report successful logins. Currently it supports RFB protocol

--- a/modules/auxiliary/scanner/vnc/vnc_none_auth.rb
+++ b/modules/auxiliary/scanner/vnc/vnc_none_auth.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/vnc/vnc_none_auth.rb
+++ b/modules/auxiliary/scanner/vnc/vnc_none_auth.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'VNC Authentication None Detection',
-			'Version'     => '$Revision$',
 			'Description' => 'Detect VNC servers that support the "None" authentication method.',
 			'References'  =>
 				[

--- a/modules/auxiliary/scanner/voice/recorder.rb
+++ b/modules/auxiliary/scanner/voice/recorder.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/voice/recorder.rb
+++ b/modules/auxiliary/scanner/voice/recorder.rb
@@ -15,7 +15,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Telephone Line Voice Scanner',
-			'Version'        => '$Revision$',
 			'Description'    => 'This module dials a range of phone numbers and records audio from each answered call',
 			'Author'         => [ 'hdm' ],
 			'License'        => MSF_LICENSE,

--- a/modules/auxiliary/scanner/vxworks/wdbrpc_bootline.rb
+++ b/modules/auxiliary/scanner/vxworks/wdbrpc_bootline.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/vxworks/wdbrpc_bootline.rb
+++ b/modules/auxiliary/scanner/vxworks/wdbrpc_bootline.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'VxWorks WDB Agent Boot Parameter Scanner',
-			'Version'     => '$Revision$',
 			'Description' => 'Scan for exposed VxWorks wdbrpc daemons and dump the boot parameters from memory',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE,

--- a/modules/auxiliary/scanner/vxworks/wdbrpc_version.rb
+++ b/modules/auxiliary/scanner/vxworks/wdbrpc_version.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/vxworks/wdbrpc_version.rb
+++ b/modules/auxiliary/scanner/vxworks/wdbrpc_version.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'VxWorks WDB Agent Version Scanner',
-			'Version'     => '$Revision$',
 			'Description' => 'Scan for exposed VxWorks wdbrpc daemons',
 			'Author'      => 'hdm',
 			'License'     => MSF_LICENSE,

--- a/modules/auxiliary/scanner/winrm/winrm_auth_methods.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_auth_methods.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/winrm/winrm_auth_methods.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_auth_methods.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'WinRM Authentication Method Detection',
-			'Version'        => '$Revision$',
 			'Description'    => %q{
 				This module sends a request to an HTTP/HTTPS service to see if it is a WinRM service.
 				If it is a WinRM service, it also gathers the Authentication Methods supported.

--- a/modules/auxiliary/scanner/winrm/winrm_cmd.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_cmd.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'WinRM Login Utility',
-			'Version'        => '$Revision$',
 			'Description'    => %q{
 				This module attempts to authenticate to a WinRM service. It currently
 				works only if the remote end allows Negotiate(NTLM) authentication.

--- a/modules/auxiliary/scanner/winrm/winrm_wql.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_wql.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/winrm/winrm_wql.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_wql.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'WinRM WQL Query Runner',
-			'Version'        => '$Revision$',
 			'Description'    => %q{
 				This module runs WQL queries against remote WinRM Services.
 				Authentication is required. Currently only works with NTLM auth.

--- a/modules/auxiliary/scanner/x11/open_x11.rb
+++ b/modules/auxiliary/scanner/x11/open_x11.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/scanner/x11/open_x11.rb
+++ b/modules/auxiliary/scanner/x11/open_x11.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'		=> 'X11 No-Auth Scanner',
-			'Version'	=> '$Revision$',
 			'Description'	=> %q{
 				This module scans for X11 servers that allow anyone
 				to connect without authentication.

--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize(info = {})
 		super(update_info(info,
 			'Name'        => 'HTTP Client Automatic Exploiter',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 					This module has three actions.  The first (and the default)
 				is 'WebServer' which uses a combination of client-side and

--- a/modules/auxiliary/server/capture/drda.rb
+++ b/modules/auxiliary/server/capture/drda.rb
@@ -38,7 +38,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Authentication Capture: DRDA (DB2, Informix, Derby)',
-			'Version'        => '$Revision$',
 			'Description'    => %q{
 				This module provides a fake DRDA (DB2, Informix, Derby) server
 			that is designed to capture authentication credentials.

--- a/modules/auxiliary/server/capture/ftp.rb
+++ b/modules/auxiliary/server/capture/ftp.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/capture/ftp.rb
+++ b/modules/auxiliary/server/capture/ftp.rb
@@ -15,7 +15,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Authentication Capture: FTP',
-			'Version'     => '$Revision$',
 			'Description'    => %q{
 					This module provides a fake FTP service that
 				is designed to capture authentication credentials.

--- a/modules/auxiliary/server/capture/http.rb
+++ b/modules/auxiliary/server/capture/http.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/capture/http.rb
+++ b/modules/auxiliary/server/capture/http.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Authentication Capture: HTTP',
-			'Version'     => '$Revision$',
 			'Description'    => %q{
 				This module provides a fake HTTP service that
 			is designed to capture authentication credentials.

--- a/modules/auxiliary/server/capture/http_ntlm.rb
+++ b/modules/auxiliary/server/capture/http_ntlm.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/capture/http_ntlm.rb
+++ b/modules/auxiliary/server/capture/http_ntlm.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize(info = {})
 		super(update_info(info,
 			'Name'        => 'HTTP Client MS Credential Catcher',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 					This module attempts to quietly catch NTLM/LM Challenge hashes.
 				},
@@ -31,7 +30,6 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					'Ryan Linn <sussurro[at]happypacket.net>',
 				],
-			'Version'     => '$Revision$',
 			'License'     => MSF_LICENSE,
 			'Actions'     =>
 				[

--- a/modules/auxiliary/server/capture/imap.rb
+++ b/modules/auxiliary/server/capture/imap.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/capture/imap.rb
+++ b/modules/auxiliary/server/capture/imap.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Authentication Capture: IMAP',
-			'Version'     => '$Revision$',
 			'Description'    => %q{
 				This module provides a fake IMAP service that
 			is designed to capture authentication credentials.

--- a/modules/auxiliary/server/capture/mysql.rb
+++ b/modules/auxiliary/server/capture/mysql.rb
@@ -15,7 +15,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Authentication Capture: MySQL',
-			'Version'        => '$Revision$',
 			'Description'    => %q{
 				This module provides a fake MySQL service that is designed to
 				capture authentication credentials. It captures	challenge and

--- a/modules/auxiliary/server/capture/pop3.rb
+++ b/modules/auxiliary/server/capture/pop3.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/capture/pop3.rb
+++ b/modules/auxiliary/server/capture/pop3.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Authentication Capture: POP3',
-			'Version'     => '$Revision$',
 			'Description'    => %q{
 				This module provides a fake POP3 service that
 			is designed to capture authentication credentials.

--- a/modules/auxiliary/server/capture/printjob_capture.rb
+++ b/modules/auxiliary/server/capture/printjob_capture.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Printjob Capture Service',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				This module is designed to listen for PJL or PostScript print
 				jobs. Once a print job is detected it is saved to loot. The

--- a/modules/auxiliary/server/capture/sip.rb
+++ b/modules/auxiliary/server/capture/sip.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/capture/sip.rb
+++ b/modules/auxiliary/server/capture/sip.rb
@@ -15,7 +15,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Authentication Capture: SIP',
-			'Version'        => '$Revision$',
 			'Description'    => %q{
 				This module provides a fake SIP service that is designed to
 				capture authentication credentials. It captures	challenge and

--- a/modules/auxiliary/server/capture/smb.rb
+++ b/modules/auxiliary/server/capture/smb.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/capture/smb.rb
+++ b/modules/auxiliary/server/capture/smb.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Authentication Capture: SMB',
-			'Version'     => '$Revision$',
 			'Description'    => %q{
 				This module provides a SMB service that can be used to
 			capture the challenge-response password hashes of SMB client

--- a/modules/auxiliary/server/capture/smtp.rb
+++ b/modules/auxiliary/server/capture/smtp.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/capture/smtp.rb
+++ b/modules/auxiliary/server/capture/smtp.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Authentication Capture: SMTP',
-			'Version'     => '$Revision$',
 			'Description'    => %q{
 				This module provides a fake SMTP service that
 			is designed to capture authentication credentials.

--- a/modules/auxiliary/server/capture/telnet.rb
+++ b/modules/auxiliary/server/capture/telnet.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/capture/telnet.rb
+++ b/modules/auxiliary/server/capture/telnet.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'           => 'Authentication Capture: Telnet',
-			'Version'        => '$Revision$',
 			'Description'    => %q{
 				This module provides a fake Telnet service that
 			is designed to capture authentication credentials.  DONTs

--- a/modules/auxiliary/server/dhcp.rb
+++ b/modules/auxiliary/server/dhcp.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/dhcp.rb
+++ b/modules/auxiliary/server/dhcp.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'DHCP Server',
-			'Version'     => '$Revision$',
 			'Description'    => %q{
 				This module provides a DHCP service
 			},

--- a/modules/auxiliary/server/dns/spoofhelper.rb
+++ b/modules/auxiliary/server/dns/spoofhelper.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/dns/spoofhelper.rb
+++ b/modules/auxiliary/server/dns/spoofhelper.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'DNS Spoofing Helper Service',
-			'Version'     => '$Revision$',
 			'Description'    => %q{
 				This module provides a DNS service that returns TXT
 			records indicating information about the querying service.

--- a/modules/auxiliary/server/fakedns.rb
+++ b/modules/auxiliary/server/fakedns.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/fakedns.rb
+++ b/modules/auxiliary/server/fakedns.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Fake DNS Service',
-			'Version'     => '$Revision$',
 			'Description'    => %q{
 				This module provides a DNS service that redirects
 			all queries to a particular address.

--- a/modules/auxiliary/server/ftp.rb
+++ b/modules/auxiliary/server/ftp.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/ftp.rb
+++ b/modules/auxiliary/server/ftp.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'FTP File Server',
-			'Version'     => '$Revision$',
 			'Description'    => %q{
 				This module provides a FTP service
 			},

--- a/modules/auxiliary/server/http_ntlmrelay.rb
+++ b/modules/auxiliary/server/http_ntlmrelay.rb
@@ -35,7 +35,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize(info = {})
 		super(update_info(info,
 			'Name'        => 'HTTP Client MS Credential Relayer',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 					This module relays negotiated NTLM Credentials from an HTTP server to multiple
 					protocols. Currently, this module supports relaying to SMB and HTTP.

--- a/modules/auxiliary/server/pxexploit.rb
+++ b/modules/auxiliary/server/pxexploit.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/pxexploit.rb
+++ b/modules/auxiliary/server/pxexploit.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'PXE Boot Exploit Server',
-			'Version'     => '$Revision$',
 			'Description'    => %q{
 				This module provides a PXE server, running a DHCP and TFTP server.
 				The default configuration loads a linux kernel and initrd into memory that

--- a/modules/auxiliary/server/socks4a.rb
+++ b/modules/auxiliary/server/socks4a.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/socks4a.rb
+++ b/modules/auxiliary/server/socks4a.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Socks4a Proxy Server',
-			'Version'     => '$Revision$',
 			'Description' => 'This module provides a socks4a proxy server that uses the builtin Metasploit routing to relay connections.',
 			'Author'      => 'sf',
 			'License'     => MSF_LICENSE,

--- a/modules/auxiliary/server/socks_unc.rb
+++ b/modules/auxiliary/server/socks_unc.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/socks_unc.rb
+++ b/modules/auxiliary/server/socks_unc.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'SOCKS Proxy UNC Path Redirection',
-			'Version'     => '$Revision$',
 			'Description'    => %q{
 				This module provides a Socks proxy service
 			that redirects all HTTP requests to a web page that

--- a/modules/auxiliary/server/tftp.rb
+++ b/modules/auxiliary/server/tftp.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/tftp.rb
+++ b/modules/auxiliary/server/tftp.rb
@@ -16,7 +16,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'TFTP File Server',
-			'Version'     => '$Revision$',
 			'Description'    => %q{
 				This module provides a TFTP service
 			},

--- a/modules/auxiliary/server/webkit_xslt_dropper.rb
+++ b/modules/auxiliary/server/webkit_xslt_dropper.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/server/webkit_xslt_dropper.rb
+++ b/modules/auxiliary/server/webkit_xslt_dropper.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 				C:\Program Files\
 			},
 			'Author'      => [ 'Nicolas Gregoire' ],
-			'Version'     => '$Revision$',
 			'License'     => MSF_LICENSE,
 			'Actions'     =>
 				[

--- a/modules/auxiliary/sniffer/psnuffle.rb
+++ b/modules/auxiliary/sniffer/psnuffle.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/sniffer/psnuffle.rb
+++ b/modules/auxiliary/sniffer/psnuffle.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'				=> 'pSnuffle Packet Sniffer',
-			'Version'           => '$Revision$',
 			'Description'       => 'This module sniffs passwords like dsniff did in the past',
 			'Author'			=> 'Max Moser  <mmo@remote-exploit.org>',
 			'License'			=> MSF_LICENSE,

--- a/modules/auxiliary/spoof/arp/arp_poisoning.rb
+++ b/modules/auxiliary/spoof/arp/arp_poisoning.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/spoof/arp/arp_poisoning.rb
+++ b/modules/auxiliary/spoof/arp/arp_poisoning.rb
@@ -15,7 +15,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'ARP Spoof',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				Spoof ARP replies and poison remote ARP caches to conduct IP address spoofing or a denial of service.
 			},

--- a/modules/auxiliary/spoof/cisco/dtp.rb
+++ b/modules/auxiliary/spoof/cisco/dtp.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/spoof/cisco/dtp.rb
+++ b/modules/auxiliary/spoof/cisco/dtp.rb
@@ -14,7 +14,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize(info = {})
 		super(
 			'Name'        => 'Forge Cisco DTP Packets',
-			'Version'     => '$Revision$',
 			'Description'	=> %q{
 				This module forges DTP packets to initialize a trunk port.
 			},

--- a/modules/auxiliary/spoof/dns/bailiwicked_domain.rb
+++ b/modules/auxiliary/spoof/dns/bailiwicked_domain.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/spoof/dns/bailiwicked_domain.rb
+++ b/modules/auxiliary/spoof/dns/bailiwicked_domain.rb
@@ -34,7 +34,6 @@ class Metasploit3 < Msf::Auxiliary
 					'Cedric Blancher <sid[at]rstack.org>'
 				],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2008-1447' ],

--- a/modules/auxiliary/spoof/dns/bailiwicked_host.rb
+++ b/modules/auxiliary/spoof/dns/bailiwicked_host.rb
@@ -1,7 +1,3 @@
-##
-# $Id$
-##
-
 require 'msf/core'
 require 'net/dns'
 require 'resolv'

--- a/modules/auxiliary/spoof/dns/bailiwicked_host.rb
+++ b/modules/auxiliary/spoof/dns/bailiwicked_host.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'I)ruid', 'hdm' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2008-1447' ],

--- a/modules/auxiliary/spoof/dns/compare_results.rb
+++ b/modules/auxiliary/spoof/dns/compare_results.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/spoof/dns/compare_results.rb
+++ b/modules/auxiliary/spoof/dns/compare_results.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'hdm' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 				],

--- a/modules/auxiliary/spoof/nbns/nbns_response.rb
+++ b/modules/auxiliary/spoof/nbns/nbns_response.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/spoof/nbns/nbns_response.rb
+++ b/modules/auxiliary/spoof/nbns/nbns_response.rb
@@ -25,7 +25,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'     => [ 'Tim Medin <tim[at]securitywhole.com>' ],
 			'License'    => MSF_LICENSE,
-			'Version'    => '$Revision$',
 			'References' =>
 				[
 					[ 'URL', 'http://www.packetstan.com/2011/03/nbns-spoofing-on-your-way-to-world.html' ]

--- a/modules/auxiliary/spoof/replay/pcap_replay.rb
+++ b/modules/auxiliary/spoof/replay/pcap_replay.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/spoof/replay/pcap_replay.rb
+++ b/modules/auxiliary/spoof/replay/pcap_replay.rb
@@ -14,7 +14,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Pcap Replay Utility',
-			'Version'     => '$Revision$',
 			'Description' => %q{
 				Replay a pcap capture file
 			},

--- a/modules/auxiliary/spoof/wifi/airpwn.rb
+++ b/modules/auxiliary/spoof/wifi/airpwn.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/spoof/wifi/airpwn.rb
+++ b/modules/auxiliary/spoof/wifi/airpwn.rb
@@ -17,7 +17,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'Airpwn TCP Hijack',
-			'Version'     => '$Revision$',
 			'Description'    => %q{
 				TCP streams are 'protected' only in so much as the sequence
 			number is not guessable.

--- a/modules/auxiliary/spoof/wifi/dnspwn.rb
+++ b/modules/auxiliary/spoof/wifi/dnspwn.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/spoof/wifi/dnspwn.rb
+++ b/modules/auxiliary/spoof/wifi/dnspwn.rb
@@ -18,7 +18,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'        => 'DNSpwn DNS Hijack',
-			'Version'     => '$Revision$',
 			'Description'    => %q{
 				Race DNS responses and replace DNS queries
 			},

--- a/modules/auxiliary/sqli/oracle/dbms_cdc_ipublish.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_cdc_ipublish.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/sqli/oracle/dbms_cdc_ipublish.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_cdc_ipublish.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2008-3996' ],

--- a/modules/auxiliary/sqli/oracle/dbms_cdc_publish.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_cdc_publish.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/sqli/oracle/dbms_cdc_publish.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_cdc_publish.rb
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2008-3995' ],

--- a/modules/auxiliary/sqli/oracle/dbms_cdc_publish2.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_cdc_publish2.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/sqli/oracle/dbms_cdc_publish2.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_cdc_publish2.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2010-0870' ],

--- a/modules/auxiliary/sqli/oracle/dbms_cdc_publish3.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_cdc_publish3.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/sqli/oracle/dbms_cdc_publish3.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_cdc_publish3.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2010-2415' ],

--- a/modules/auxiliary/sqli/oracle/dbms_export_extension.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_export_extension.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/sqli/oracle/dbms_export_extension.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_export_extension.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2006-2081' ],

--- a/modules/auxiliary/sqli/oracle/dbms_metadata_get_granted_xml.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_metadata_get_granted_xml.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/sqli/oracle/dbms_metadata_get_granted_xml.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_metadata_get_granted_xml.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'http://www.metasploit.com' ],

--- a/modules/auxiliary/sqli/oracle/dbms_metadata_get_xml.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_metadata_get_xml.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/sqli/oracle/dbms_metadata_get_xml.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_metadata_get_xml.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'http://www.metasploit.com' ],

--- a/modules/auxiliary/sqli/oracle/dbms_metadata_open.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_metadata_open.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/sqli/oracle/dbms_metadata_open.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_metadata_open.rb
@@ -20,7 +20,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'URL', 'http://www.metasploit.com' ],

--- a/modules/auxiliary/sqli/oracle/droptable_trigger.rb
+++ b/modules/auxiliary/sqli/oracle/droptable_trigger.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/sqli/oracle/droptable_trigger.rb
+++ b/modules/auxiliary/sqli/oracle/droptable_trigger.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'Sh2kerr <research[ad]dsec.ru>' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2008-3979' ],

--- a/modules/auxiliary/sqli/oracle/jvm_os_code_10g.rb
+++ b/modules/auxiliary/sqli/oracle/jvm_os_code_10g.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/sqli/oracle/jvm_os_code_10g.rb
+++ b/modules/auxiliary/sqli/oracle/jvm_os_code_10g.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'sid[at]notsosecure.com' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2010-0866'],

--- a/modules/auxiliary/sqli/oracle/jvm_os_code_11g.rb
+++ b/modules/auxiliary/sqli/oracle/jvm_os_code_11g.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/sqli/oracle/jvm_os_code_11g.rb
+++ b/modules/auxiliary/sqli/oracle/jvm_os_code_11g.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'sid[at]notsosecure.com' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2010-0866'],

--- a/modules/auxiliary/sqli/oracle/lt_compressworkspace.rb
+++ b/modules/auxiliary/sqli/oracle/lt_compressworkspace.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/sqli/oracle/lt_compressworkspace.rb
+++ b/modules/auxiliary/sqli/oracle/lt_compressworkspace.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'CG' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2008-3982'],

--- a/modules/auxiliary/sqli/oracle/lt_findricset_cursor.rb
+++ b/modules/auxiliary/sqli/oracle/lt_findricset_cursor.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/sqli/oracle/lt_findricset_cursor.rb
+++ b/modules/auxiliary/sqli/oracle/lt_findricset_cursor.rb
@@ -23,7 +23,6 @@ class Metasploit3 < Msf::Auxiliary
 					},
 			'Author'         => ['CG'],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2007-5511'],

--- a/modules/auxiliary/sqli/oracle/lt_mergeworkspace.rb
+++ b/modules/auxiliary/sqli/oracle/lt_mergeworkspace.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/sqli/oracle/lt_mergeworkspace.rb
+++ b/modules/auxiliary/sqli/oracle/lt_mergeworkspace.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'CG' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2008-3983'],

--- a/modules/auxiliary/sqli/oracle/lt_removeworkspace.rb
+++ b/modules/auxiliary/sqli/oracle/lt_removeworkspace.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/sqli/oracle/lt_removeworkspace.rb
+++ b/modules/auxiliary/sqli/oracle/lt_removeworkspace.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'Sh2kerr <research[ad]dsecrg.com>' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2008-3984' ],

--- a/modules/auxiliary/sqli/oracle/lt_rollbackworkspace.rb
+++ b/modules/auxiliary/sqli/oracle/lt_rollbackworkspace.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/sqli/oracle/lt_rollbackworkspace.rb
+++ b/modules/auxiliary/sqli/oracle/lt_rollbackworkspace.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			},
 			'Author'         => [ 'MC' ],
 			'License'        => MSF_LICENSE,
-			'Version'        => '$Revision$',
 			'References'     =>
 				[
 					[ 'CVE', '2009-0978' ],

--- a/modules/auxiliary/vsploit/malware/dns/dns_mariposa.rb
+++ b/modules/auxiliary/vsploit/malware/dns/dns_mariposa.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/vsploit/malware/dns/dns_mariposa.rb
+++ b/modules/auxiliary/vsploit/malware/dns/dns_mariposa.rb
@@ -12,7 +12,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'         => 'VSploit Mariposa DNS Query Module',
-			'Version'      => '$Revision$',
 			'Description'  => 'This module queries known Mariposa Botnet DNS records.',
 			'Author'       => 'MJC',
 			'License'      => MSF_LICENSE,

--- a/modules/auxiliary/vsploit/malware/dns/dns_query.rb
+++ b/modules/auxiliary/vsploit/malware/dns/dns_query.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 #
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit

--- a/modules/auxiliary/vsploit/malware/dns/dns_query.rb
+++ b/modules/auxiliary/vsploit/malware/dns/dns_query.rb
@@ -13,7 +13,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'         => 'VSploit DNS Beaconing Emulation',
-			'Version'      => '$Revision$',
 			'Description'  => 'This module takes a list and emulates malicious DNS beaconing.',
 			'Author'       => 'MJC',
 			'License'      => MSF_LICENSE

--- a/modules/auxiliary/vsploit/malware/dns/dns_zeus.rb
+++ b/modules/auxiliary/vsploit/malware/dns/dns_zeus.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/vsploit/malware/dns/dns_zeus.rb
+++ b/modules/auxiliary/vsploit/malware/dns/dns_zeus.rb
@@ -12,7 +12,6 @@ class Metasploit3 < Msf::Auxiliary
 	def initialize
 		super(
 			'Name'         => 'VSploit Zeus DNS Query Module',
-			'Version'      => '$Revision$',
 			'Description'  => 'This module queries known Zeus Botnet DNS records.',
 			'Author'       => 'MJC',
 			'License'      => MSF_LICENSE,

--- a/modules/auxiliary/vsploit/pii/email_pii.rb
+++ b/modules/auxiliary/vsploit/pii/email_pii.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/vsploit/pii/email_pii.rb
+++ b/modules/auxiliary/vsploit/pii/email_pii.rb
@@ -23,8 +23,7 @@ class Metasploit3 < Msf::Auxiliary
 			should be flagged via an internal or external SMTP server.
 			},
 			'License'        => MSF_LICENSE,
-			'Author'         =>  ['willis'],
-			'Version'        => '$Revision$'
+			'Author'         =>  ['willis']
 		))
 			register_options(
 				[

--- a/modules/auxiliary/vsploit/pii/web_pii.rb
+++ b/modules/auxiliary/vsploit/pii/web_pii.rb
@@ -1,8 +1,4 @@
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # web site for more information on licensing and terms of use.

--- a/modules/auxiliary/vsploit/pii/web_pii.rb
+++ b/modules/auxiliary/vsploit/pii/web_pii.rb
@@ -21,7 +21,6 @@ class Metasploit3 < Msf::Auxiliary
 			'Description'    => 'This module emulates a webserver leaking PII data',
 			'License'        => MSF_LICENSE,
 			'Author'         => 'MJC',
-			'Version'        => '$Revision$',
 			'References' =>
 			[
 				[ 'URL', 'http://www.metasploit.com'],


### PR DESCRIPTION
The first step in cleaning up the existing modules.
In this commit all $id$ and $revision$ are removed from the auxiliary modules (No functional changes).
What do you think about this cleanup?
The goal would be to make all modules "msftidy compliant" so msftidy can be integrated within the travis builds.
