### PR TITLE
Please review module enhancements for master commit.

### DIFF
--- a/modules/post/windows/manage/run_as.rb
+++ b/modules/post/windows/manage/run_as.rb
@@ -9,6 +9,11 @@
 #   http://metasploit.com/
 ##
 
+# Runas that allows quoted arguments, chained commands, commands with arguments, running with domain accounts, 
+# and does not require any privileges to run.  Also correctly handles cases where cmdout is set to true, but the 
+# command returns no output (original version throws a nasty error).  Original version also does not work unless you
+# initiate the module from SYSTEM (even though it claims to be able to run as an administrator).
+
 require 'msf/core'
 require 'rex'
 require 'msf/core/post/file'
@@ -20,77 +25,32 @@ class Metasploit3 < Msf::Post
 
 	def initialize(info={})
 		super(update_info(info,
-			'Name'                 => "Windows Manage Run Command As User",
+			'Name'                 => "Windows Managed Run Command As User",
 			'Description'          => %q{
 				This module will login with the specified username/password and execute the
 				supplied command as a hidden process. Output is not returned by default, by setting
 				CMDOUT to false output will be redirected to a temp file and read back in to
-				display.By setting advanced option SETPASS to true, it will reset the users
-				password and then execute the command.
+				display.
 			},
 			'License'              => MSF_LICENSE,
-			'Version'              => '$Revision$',
-			'Platform'             => ['win'],
+			'Version'              => '$Revision: 14774 $',
+			'Platform'             => ['windows'],
 			'SessionTypes'         => ['meterpreter'],
-			'Author'               => ['Kx499']
+			'Author'               => ['shellster (based on version by Kx499)']
 		))
 
 		register_options(
 			[
-				OptString.new('USER', [true, 'Username to reset/login with' ]),
+				OptString.new('DOMAIN', [true, 'Domain login with' ]),
+				OptString.new('USER', [true, 'Username to login with' ]),
 				OptString.new('PASS', [true, 'Password to use' ]),
 				OptString.new('CMD', [true, 'Command to execute' ]),
-				OptBool.new('CMDOUT', [false, 'Retrieve command output', false]),
+				OptBool.new('CMDOUT', [false, 'Retrieve command output', true]),
 			], self.class)
-
-		register_advanced_options(
-			[
-				OptBool.new('SETPASS', [false, 'Reset password', false])
-			], self.class)
-	end
-
-	# Check if sufficient privileges are present for certain actions and run getprivs for system
-	# If you elevated privs to system,the SeAssignPrimaryTokenPrivilege will not be assigned. You
-	# need to migrate to a process that is running as
-	# system. If you don't have privs, this exits script.
-
-	def priv_check
-		if is_system?
-			privs = session.sys.config.getprivs
-			if privs.include?("SeAssignPrimaryTokenPrivilege") and privs.include?("SeIncreaseQuotaPrivilege")
-				@isadmin = false
-				return true
-			else
-				return false
-			end
-		elsif is_admin?
-			@isadmin = true
-			return true
-		else
-			return false
-		end
-	end
-
-	def reset_pass(user,pass)
-		begin
-			tmpout = ""
-			cmd = "cmd.exe /c net user " + user + " " + pass
-			r = session.sys.process.execute(cmd, nil, {'Hidden' => true, 'Channelized' => true})
-			while(d = r.channel.read)
-				tmpout << d
-				break if d == ""
-			end
-			r.channel.close
-			return true if tmpout.include?("successfully")
-			return false
-		rescue
-			return false
-		end
 	end
 
 	def run
 		# set some instance vars
-		@IsAdmin = false
 		@host_info = session.sys.config.sysinfo
 
 		# Make sure we meet the requirements before running the script, note no need to return
@@ -98,70 +58,57 @@ class Metasploit3 < Msf::Post
 		return 0 if session.type != "meterpreter"
 
 		# check/set vars
-		setpass = datastore["SETPASS"]
 		cmdout = datastore["CMDOUT"]
+		domain = datastore["DOMAIN"] || nil
 		user = datastore["USER"] || nil
 		pass = datastore["PASS"] || nil
 		cmd = datastore["CMD"] || nil
 		rg_adv = session.railgun.advapi32
-
-		# reset user pass if setpass is true
-		if datastore["SETPASS"]
-			print_status("Setting user password")
-			if !reset_pass(user,pass)
-				print_error("Error resetting password")
-				return 0
-			end
-		end
-
+		
 		# set profile paths
 		sysdrive = session.fs.file.expand_path("%SYSTEMDRIVE%")
 		os = @host_info['OS']
-		profiles_path = sysdrive + "\\Documents and Settings\\"
-		profiles_path = sysdrive + "\\Users\\" if os =~ /(Windows 7|2008|Vista)/
-		path = profiles_path + user + "\\"
+		path = sysdrive + "\\Windows\\Temp\\"
 		outpath =  path + "out.txt"
+
+		#set command string based on cmdout vars
+		cmdstr = "cmd.exe /s /c \"#{cmd}\""
+		cmdstr = "cmd.exe /s /c \"#{cmd}\" > #{outpath}" if cmdout
+		# Check privs and execute the correct commands
+		# if local admin use createprocesswithlogon, if system logonuser and createprocessasuser
+		# execute command and get output with a poor mans pipe
 
 		# this is start info struct for a hidden process last two params are std out and in.
 		#for hidden startinfo[12] = 1 = STARTF_USESHOWWINDOW and startinfo[13] = 0 = SW_HIDE
 		startinfo = [0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0]
 		startinfo = startinfo.pack("LLLLLLLLLLLLSSLLLL")
-
-		#set command string based on cmdout vars
-		cmdstr = "cmd.exe /c #{cmd}"
-		cmdstr = "cmd.exe /c #{cmd} > #{outpath}" if cmdout
-		# Check privs and execute the correct commands
-		# if local admin use createprocesswithlogon, if system logonuser and createprocessasuser
-		# execute command and get output with a poor mans pipe
-
-		if priv_check
-			if @isadmin #local admin
-				print_status("Executing CreateProcessWithLogonW...we are Admin")
-				cs = rg_adv.CreateProcessWithLogonW(user,nil,pass,"LOGON_WITH_PROFILE",nil, cmdstr,
-					"CREATE_UNICODE_ENVIRONMENT",nil,path,startinfo,16)
-			else #system with correct token privs enabled
-				print_status("Executing CreateProcessAsUserA...we are SYSTEM")
-				l = rg_adv.LogonUserA(user,nil,pass, "LOGON32_LOGON_INTERACTIVE",
-					"LOGON32_PROVIDER_DEFAULT", 4)
-				cs = rg_adv.CreateProcessAsUserA(l["phToken"], nil, cmdstr, nil, nil, false,
-					"CREATE_NEW_CONSOLE", nil, nil, startinfo, 16)
-			end
+		print_status("Trying to execute: #{cmdstr}")
+		if is_system?
+			print_status("Executing CreateProcessAsUserA...we are SYSTEM")
+			l = rg_adv.LogonUserA(user,domain,pass, "LOGON32_LOGON_INTERACTIVE", "LOGON32_PROVIDER_DEFAULT", 4)
+			cs = rg_adv.CreateProcessAsUserA(l["phToken"], nil, cmdstr, nil, nil, false, "CREATE_NEW_CONSOLE", nil, nil, startinfo, 16)
 		else
-			print_error("Insufficient Privileges, either you are not Admin or system or you elevated")
-			print_error("privs to system and do not have sufficient privileges. If you elevated to")
-			print_error("system, migrate to a process that was started as system (srvhost.exe)")
-			return 0
+			print_status("Executing CreateProcessWithLogonW.")
+			cs = rg_adv.CreateProcessWithLogonW(user, domain, pass,"LOGON_WITH_PROFILE", nil, cmdstr, "CREATE_NEW_CONSOLE",nil,nil,startinfo,32)
 		end
-
+			
 		# Only process file if the process creation was successful, delete when done, give us info
 		# about process
 		if cs["return"]
 			tmpout = ""
 			if cmdout
+				sleep(0.5)
 				outfile = session.fs.file.new(outpath, "rb")
-				until outfile.eof?
-					tmpout << outfile.read
+				
+				begin
+					until outfile.eof?
+						tmpout << outfile.read
+					end
+					
+					rescue EOFError
+						tmpout << "\nThe file was empty.\n"
 				end
+				
 				outfile.close
 				c = session.sys.process.execute("cmd.exe /c del #{outpath}", nil, {'Hidden' => true})
 				c.close

--- a/modules/post/windows/manage/run_as.rb
+++ b/modules/post/windows/manage/run_as.rb
@@ -28,9 +28,9 @@ class Metasploit3 < Msf::Post
 			'Name'                 => "Windows Managed Run Command As User",
 			'Description'          => %q{
 				This module will login with the specified username/password and execute the
-				supplied command as a hidden process. Output is not returned by default, by setting
-				CMDOUT to false output will be redirected to a temp file and read back in to
-				display.
+				supplied command as a hidden process. By setting
+				CMDOUT to true output will be redirected to a temp file and read back into the
+				display.  CMDOUT is set to true by default.
 			},
 			'License'              => MSF_LICENSE,
 			'Version'              => '$Revision: 14774 $',


### PR DESCRIPTION
I've made several enhancements to the current run_as module.

My version has the following improvements:
-- Allows quoted arguments and commands.
-- Allows chained commands. 
-- Allows commands with arguments
-- Allows run as with domain accounts
-- Removes requirement of running module as SYSTEM or Administrator account.

It fixes the following bugs:
-- Due to bugs in the parameters being passed to CreateProcessWithLogonW, the old run_as would always error out unless it was initiated from a process running as SYSTEM.  
-- Fixed a bug where an unhandled EOFError was being thrown if CMDOUT was set to "true" but the command issued, never returned any output.

Other changes:
-- Set CMDOUT to default to "true", as there is no downside (other than a mild delay, since my changes [not true with previous version]).
-- Added a minor delay before attempting to read the output file to make sure that Windows has time to relinquish its handles on the file.
-- Removed password reset functionality which was inexplicably included in a module called "run_as", and which was broken if domain credentials are used.  (The functionality can obviously either be kept by the Metasploit admins, with minor modification to this code, or a user can issue their own "net user" command through this module).
