### PR TITLE
Set GEM_PATH when using built-in gemcache

### DIFF
--- a/lib/msf/env/gemcache.rb
+++ b/lib/msf/env/gemcache.rb
@@ -11,6 +11,7 @@ class Gemcache
 	@@gembase = ::File.join(@@msfbase, "lib/gemcache")
 	@@gemarch = ( RUBY_PLATFORM =~ /mingw/ ? 'win32' : ( RUBY_PLATFORM =~ /x86_64.*linux/ ? 'linux64' : (RUBY_PLATFORM =~ /i\d86.*linux/ ? 'linux32' : 'unknown') ) )
 	@@rubvers =	'1.9.1'
+	@@gempath = "#{@@gembase}/ruby/#{@@rubvers}"
 
 	def self.configure
 		return if not ::File.exist?(@@gembase)
@@ -18,10 +19,11 @@ class Gemcache
 		# The gemcache directory is a modified version of the output created by
 		# $ bundle install --path=lib/gemcache from within the Pro environment
 
-		::Dir["#{@@gembase}/ruby/#{@@rubvers}/gems/*/lib"].each { |lib| $:.unshift(lib) }
+		ENV['GEM_PATH'] = ENV['GEM_PATH'] ? "#{ENV['GEM_PATH']}:#{@@gempath}" : "#{@@gempath}"
+		::Dir["#{@@gempath}/gems/*/lib"].each { |lib| $:.unshift(lib) }
 
 		if ENV['MSF_BUNDLE_BINARY_GEMS'].to_s.downcase =~ /^[yt1]/
-			::Dir["#{@@gembase}/ruby/#{@@rubvers}/arch/#{@@gemarch}/*/lib"].each { |lib| $:.unshift(lib) }
+			::Dir["#{@@gempath}/arch/#{@@gemarch}/*/lib"].each { |lib| $:.unshift(lib) }
 		end
 
 		# Handle a specific corner case where SVN was used to update, but the installer is generation-1
@@ -32,7 +34,7 @@ class Gemcache
 		   ::File.directory?( File.join( File.dirname(__FILE__), "..", "..", "..", "..", "apps", "pro") ) and # Confirmed
 		   ::File.exists?( File.join( File.dirname(__FILE__), "..", "..", "..", "..", "apps", "pro", "ui", "script", "console") ) # Rails2 artifact
 			# Load the arch-old gem directories before the system paths to get an updated pg gem
-			::Dir["#{@@gembase}/ruby/#{@@rubvers}/arch-old/#{@@gemarch}/*/lib"].each { |lib| $:.unshift(lib) }
+			::Dir["#{@@gempath}/arch-old/#{@@gemarch}/*/lib"].each { |lib| $:.unshift(lib) }
 
 			# Patch up the gem command to always return true for certain gems
 			::Object.class_eval %q|


### PR DESCRIPTION
This allows rubygems to work with gems loaded from lib/gemcache.

Specifically, without this the [`Kernel.gem`](http://ruby-doc.org/stdlib-1.9.2/libdoc/rubygems/rdoc/Kernel.html#method-i-gem) will not activate gems in `lib/gemcache` correctly.

This can cause problems if you manually install certain gems (such as `pg`) to `lib/gemcache` instead of an RVM gemset or system location.
