### PR TITLE
Update modules/auxiliary/scanner/http/wordpress_login_enum.rb

### DIFF
--- a/modules/auxiliary/scanner/http/wordpress_login_enum.rb
+++ b/modules/auxiliary/scanner/http/wordpress_login_enum.rb
@@ -138,8 +138,7 @@ class Metasploit3 < Msf::Auxiliary
 					:sname => (ssl ? 'https' : 'http'),
 					:user => user,
 					:port => rport,
-					:proof => "WEBAPP=\"Wordpress\", VHOST=#{vhost}",
-					
+					:proof => "WEBAPP=\"Wordpress\", VHOST=#{vhost}"
 				)
 
 				@users_found[user] = :reported


### PR DESCRIPTION
Simple fix for msfconsole start error. Just removed a , to prevent error: 

[-] WARNING! The following modules could not be loaded!
[-]     metasploit-framework/modules/auxiliary/scanner/http/wordpress_login_enum.rb: SyntaxError compile error
/metasploit-framework/modules/auxiliary/scanner/http/wordpress_login_enum.rb:143: syntax error, unexpected ')'
