### PR TITLE
Msftidy: check comma at end (ruby 1.8 compatibility)

### DIFF
--- a/modules/auxiliary/admin/http/hp_web_jetadmin_exec.rb
+++ b/modules/auxiliary/admin/http/hp_web_jetadmin_exec.rb
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Auxiliary
 		send_request_cgi({
 				'uri'     => '/plugins/framework/script/content.hts',
 				'method'  => 'POST',
-				'data'    => 'obj=Httpd:ExecuteFile(,cmd.exe,/c,' + cmd + ',)'
+				'data'    => 'obj=Httpd:ExecuteFile(,cmd.exe,/c,' + cmd + ',' + ')'
 			}, 3)
 	end
 

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -372,10 +372,10 @@ class Msftidy
 		comma_match = @source.match(/[^\n\r]*(?<m>,\s*[\)\}\]])[^\n\r]*/)
 		unless comma_match.nil?
 			# inspect replaces special chars, but surrounds the string with ""
-			match_string = comma_match[:m].to_s.inspect.sub(/"(?<foo>.*)"/, '\k<foo>')
-			comma_match_2 = comma_match.to_s.inspect.sub(/"(?<foo>.*)"/, '\k<foo>')
+			match_string = comma_match[:m].to_s.inspect.sub(/^"(?<foo>.*)"$/, '\k<foo>')
+			comma_match_2 = comma_match.to_s.inspect.sub(/^"(?<foo>.*)"$/, '\k<foo>')
 			# colorize the match
-			colorized_string = comma_match_2.gsub(match_string, "\e[33m#{match_string}\e[0m").strip
+			colorized_string = comma_match_2.gsub(match_string, "\e[31m#{match_string}\e[0m").strip
 			error("Comma at end of definition: #{colorized_string}")
 		end
 	end

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -369,7 +369,7 @@ class Msftidy
 	end
 
 	def check_comma
-		comma_match = @source.match(/[^\n\r]*(?<m>,\s*[\)\}\]])[^\n\r]*/)
+		comma_match = @source.match(/[^\n\r]*(?<m>,\s*[\)])[^\n\r]*/)
 		unless comma_match.nil?
 			# inspect replaces special chars, but surrounds the string with ""
 			match_string = comma_match[:m].to_s.inspect.sub(/^"(?<foo>.*)"$/, '\k<foo>')

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -368,6 +368,18 @@ class Msftidy
 		}
 	end
 
+	def check_comma
+		comma_match = @source.match(/[^\n\r]*(?<m>,\s*[\)\}\]])[^\n\r]*/)
+		unless comma_match.nil?
+			# inspect replaces special chars, but surrounds the string with ""
+			match_string = comma_match[:m].to_s.inspect.sub(/"(?<foo>.*)"/, '\k<foo>')
+			comma_match_2 = comma_match.to_s.inspect.sub(/"(?<foo>.*)"/, '\k<foo>')
+			# colorize the match
+			colorized_string = comma_match_2.gsub(match_string, "\e[33m#{match_string}\e[0m").strip
+			error("Comma at end of definition: #{colorized_string}")
+		end
+	end
+
 	private
 
 	def load_file(file)
@@ -391,6 +403,7 @@ def run_checks(f_rel)
 	tidy.check_bad_terms
 	tidy.check_function_basics
 	tidy.check_lines
+  tidy.check_comma
 end
 
 ##

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -368,6 +368,7 @@ class Msftidy
 		}
 	end
 
+	# breaks ruby 1.8 compatibility
 	def check_comma
 		comma_match = @source.match(/[^\n\r]*(?<m>,\s*[\)])[^\n\r]*/)
 		unless comma_match.nil?
@@ -375,7 +376,7 @@ class Msftidy
 			match_string = comma_match[:m].to_s.inspect.sub(/^"(?<foo>.*)"$/, '\k<foo>')
 			comma_match_2 = comma_match.to_s.inspect.sub(/^"(?<foo>.*)"$/, '\k<foo>')
 			# colorize the match
-			colorized_string = comma_match_2.gsub(match_string, "\e[31m#{match_string}\e[0m").strip
+			colorized_string = comma_match_2.gsub(match_string, match_string.red)
 			error("Comma at end of definition: #{colorized_string}")
 		end
 	end


### PR DESCRIPTION
This commit adds a check to msftidy to detect commas at the end of definitions since this breaks ruby 1.8 compatibility

example

``` ruby
'Payload' =>
{
  'Space'    => 1024,
  'BadChars' => "\x00",
  'MinNops'  => 512, <--
}
```
