### PR TITLE
Load environment before starting msfgui

### DIFF
--- a/msfgui
+++ b/msfgui
@@ -8,15 +8,19 @@
 # $Revision$
 #
 
+msfbase = __FILE__
+while File.symlink?(msfbase)
+	msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
+end
+
+$:.unshift(File.expand_path(File.join(File.dirname(msfbase), 'lib')))
+require 'fastlib'
+require 'msfenv'
+
 begin
 	require 'msgpack'
 rescue LoadError
 	raise LoadError, "Missing msgpack gem, try 'gem install msgpack' to use MSFGui"
-end
-
-msfbase = __FILE__
-while File.symlink?(msfbase)
-	msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
 
 if RUBY_PLATFORM =~ /mswin|mingw/i


### PR DESCRIPTION
msfgui checks for the msgpack gem before spinning up, however if this
gem is installed in lib/gemcache it will not be found.

This commit loads the normal msf environment, including lib/gemcache if
applicable, before starting msfgui.
