### PR TITLE
Change the .text-too-small error message.

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -257,7 +257,8 @@ require 'digest/sha1'
 
 		p_length = payload.length + 256
 		if(text.size < p_length)
-			msg  = "The .text section is too small. "
+			fname = ::File.basename(opts[:template])
+			msg  = "The .text section for '#{fname}' is too small. "
 			msg << "Minimum is #{p_length.to_s} bytes, your .text section is #{text.size.to_s} bytes"
 			raise RuntimeError, msg
 		end

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -255,8 +255,11 @@ require 'digest/sha1'
 			raise RuntimeError, "The .text section does not contain an entry point"
 		end
 
-		if(text.size < (payload.length + 256))
-			raise RuntimeError, "The .text section is too small to be usable"
+		p_length = payload.length + 256
+		if(text.size < p_length)
+			msg  = "The .text section is too small. "
+			msg << "Minimum is #{p_length.to_s} bytes, your .text section is #{text.size.to_s} bytes"
+			raise RuntimeError, msg
 		end
 
 		# Store some useful offsets


### PR DESCRIPTION
The original error message apparently doesn't mean anything to users, and this can be easily improved.  See the following:
https://community.rapid7.com/thread/2356

The updated version will display an error like this:

```
[*] x86/shikata_ga_nai succeeded with size 53308 (iteration=1)

[*] x86/shikata_ga_nai succeeded with size 53337 (iteration=2)

[*] x86/shikata_ga_nai succeeded with size 53366 (iteration=3)

[*] x86/shikata_ga_nai succeeded with size 53395 (iteration=4)

[*] x86/shikata_ga_nai succeeded with size 53424 (iteration=5)

[-] x86/shikata_ga_nai failed: The .text section is too small. Minimum is 54908 bytes, your .text size is 45056 bytes
[-] No encoders succeeded.
```

And then at that point, they will know why it's not working for them.
