### PR TITLE
Fix typo in HttpUknownRequestResponse variable

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -155,7 +155,7 @@ module ReverseHttp
 				OptString.new('MeterpreterUserAgent', [ false, 'The user-agent that the payload should use for communication', 'Mozilla/4.0 (compatible; MSIE 6.1; Windows NT)' ]),
 				OptString.new('MeterpreterServerName', [ false, 'The server header that the handler will send in response to requests', 'Apache' ]),
 				OptAddress.new('ReverseListenerBindAddress', [ false, 'The specific IP address to bind to on the local system']),
-				OptString.new('HttpUknownRequestResponse', [ false, 'The returned HTML response body when the handler receives a request that is not from a payload', '<html><body><h1>It works!</h1></body></html>'  ])
+				OptString.new('HttpUnknownRequestResponse', [ false, 'The returned HTML response body when the handler receives a request that is not from a payload', '<html><body><h1>It works!</h1></body></html>'  ])
 			], Msf::Handler::ReverseHttp)
 	end
 
@@ -360,7 +360,7 @@ protected
 				print_status("#{cli.peerhost}:#{cli.peerport} Unknown request to #{uri_match} #{req.inspect}...")
 				resp.code    = 200
 				resp.message = "OK"
-				resp.body    = datastore['HttpUknownRequestResponse'].to_s
+				resp.body    = datastore['HttpUnknownRequestResponse'].to_s
 		end
 
 		cli.send_response(resp) if (resp)


### PR DESCRIPTION
Typo found by @schierlm but mentioned after the commit of pull request #1187
Info: https://github.com/rapid7/metasploit-framework/pull/1187#commitcomment-2340457
