### PR TITLE
Fix a bug in netsparker import

### DIFF
--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -2372,7 +2372,8 @@ class DBManager
 	# +:ssl+::   whether or not SSL is in use on this port
 	#
 	#
-	# Duplicate records for a given web_site, path, method, pname, and name combination will be overwritten
+	# Duplicate records for a given web_site, path, method, pname, and name
+	# combination will be overwritten
 	#
 
 	def report_web_vuln(opts)
@@ -4562,6 +4563,9 @@ class DBManager
 			end
 
 			info = {
+				# XXX: There is a :request attr in the model, but report_web_vuln
+				# doesn't seem to know about it, so this gets ignored.
+				#:request  => vuln['request'],
 				:path     => uri.path,
 				:query    => uri.query,
 				:method   => method,

--- a/lib/rex/parser/netsparker_xml.rb
+++ b/lib/rex/parser/netsparker_xml.rb
@@ -83,7 +83,7 @@ class NetSparkerXMLStreamParser
 
 	# We don't need these methods, but they're necessary to keep REXML happy
 	def xmldecl(version, encoding, standalone); end
-	def cdata; end
+	def cdata(*args); end
 	def comment(str); end
 	def instruction(name, instruction); end
 	def attlist; end

--- a/lib/rex/parser/netsparker_xml.rb
+++ b/lib/rex/parser/netsparker_xml.rb
@@ -24,6 +24,7 @@ class NetSparkerXMLStreamParser
 
 		case name
 		when "vulnerability"
+			@vuln = { 'info' => [] }
 			@vuln['confirmed'] = attributes['confirmed']
 		end
 	end

--- a/lib/rex/parser/netsparker_xml.rb
+++ b/lib/rex/parser/netsparker_xml.rb
@@ -84,7 +84,20 @@ class NetSparkerXMLStreamParser
 
 	# We don't need these methods, but they're necessary to keep REXML happy
 	def xmldecl(version, encoding, standalone); end
-	def cdata(*args); end
+	def cdata(data)
+		puts "cdata for #{@state} (#{data.length})"
+		case @state
+		when :in_rawresponse
+			@vuln["response"] = data
+		when :in_rawrequest
+			@vuln["request"] = data
+		when :in_info
+			if not data.to_s.strip.empty?
+				@vuln['info'] << [@attr['name'] || "Information", data]
+			end
+		end
+	end
+
 	def comment(str); end
 	def instruction(name, instruction); end
 	def attlist; end


### PR DESCRIPTION
Two things:
- `cdata` apparently gets called with arguments sometimes, so this adds *args to avoid an ArgumentError
- The full vuln state was not getting cleared out when a new vuln was found, so URLs were getting concatenated onto whatever the first one was, instead of replacing.
