### PR TITLE
Mysql login exceptions

### DIFF
--- a/lib/msf/core/exploit/mysql.rb
+++ b/lib/msf/core/exploit/mysql.rb
@@ -40,16 +40,32 @@ module Exploit::Remote::MYSQL
 		disconnect if self.sock
 		connect
 
-		@mysql_handle = ::RbMysql.connect({
-			:host           => rhost,
-			:port           => rport,
-			:read_timeout   => 300,
-			:write_timeout  => 300,
-			:socket         => sock,
-			:user           => user,
-			:password       => pass,
-			:db             => db
-		})
+		begin
+			@mysql_handle = ::RbMysql.connect({
+				:host           => rhost,
+				:port           => rport,
+				:read_timeout   => 300,
+				:write_timeout  => 300,
+				:socket         => sock,
+				:user           => user,
+				:password       => pass,
+				:db             => db
+			})
+		rescue Errno::ECONNREFUSED
+			vprint_error("Connection refused")
+			return false
+		rescue RbMysql::ClientError
+			vprint_error("Connection timedout")
+			return false
+		rescue Errno::ETIMEDOUT
+			vprint_error("Operation timedout")
+			return false
+		rescue RbMysql::AccessDeniedError
+			vprint_error("Access denied")
+			return false
+		end
+
+		return true
 	end
 
 	def mysql_logoff

--- a/lib/msf/core/exploit/mysql.rb
+++ b/lib/msf/core/exploit/mysql.rb
@@ -52,19 +52,19 @@ module Exploit::Remote::MYSQL
 				:db             => db
 			})
 		rescue Errno::ECONNREFUSED
-			vprint_error("Connection refused")
+			print_error("Connection refused")
 			return false
 		rescue RbMysql::ClientError
-			vprint_error("Connection timedout")
+			print_error("Connection timedout")
 			return false
 		rescue Errno::ETIMEDOUT
-			vprint_error("Operation timedout")
+			print_error("Operation timedout")
 			return false
 		rescue RbMysql::HostNotPrivileged
-			vprint_error("Unable to login from this host due to policy")
+			print_error("Unable to login from this host due to policy")
 			return false
 		rescue RbMysql::AccessDeniedError
-			vprint_error("Access denied")
+			print_error("Access denied")
 			return false
 		end
 

--- a/lib/msf/core/exploit/mysql.rb
+++ b/lib/msf/core/exploit/mysql.rb
@@ -78,7 +78,7 @@ module Exploit::Remote::MYSQL
 			res = mysql_login(datastore['USERNAME'], datastore['PASSWORD'])
 		rescue Rex::ConnectionTimeout => e
 			print_error("Timeout: #{e.message}")
-			res = nil
+			res = false
 		end
 
 		return res

--- a/lib/msf/core/exploit/mysql.rb
+++ b/lib/msf/core/exploit/mysql.rb
@@ -60,6 +60,9 @@ module Exploit::Remote::MYSQL
 		rescue Errno::ETIMEDOUT
 			vprint_error("Operation timedout")
 			return false
+		rescue RbMysql::HostNotPrivileged
+			vprint_error("Unable to login from this host due to policy")
+			return false
 		rescue RbMysql::AccessDeniedError
 			vprint_error("Access denied")
 			return false

--- a/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
@@ -29,7 +29,6 @@ class Metasploit3 < Msf::Auxiliary
 	def run_host(ip)
 
 		if (not mysql_login_datastore)
-			print_error("Invalid MySQL Server credentials")
 			return
 		end
 

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -103,7 +103,9 @@ class Metasploit3 < Msf::Auxiliary
 
 		vprint_status("#{rhost}:#{rport} Trying username:'#{user}' with password:'#{pass}'")
 		begin
-			mysql_login(user, pass)
+			m = mysql_login(user, pass)
+			return :fail if not m
+
 			print_good("#{rhost}:#{rport} - SUCCESSFUL LOGIN '#{user}' : '#{pass}'")
 			report_auth_info(
 				:host   => rhost,
@@ -115,10 +117,6 @@ class Metasploit3 < Msf::Auxiliary
 				:active => true
 			)
 			return :next_user
-
-		rescue ::RbMysql::AccessDeniedError
-			vprint_status("#{rhost}:#{rport} failed to login as '#{user}' with password '#{pass}'")
-			return :fail
 
 		rescue ::RbMysql::Error => e
 			vprint_error("#{rhost}:#{rport} failed to login: #{e.class} #{e}")

--- a/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
@@ -35,7 +35,6 @@ class Metasploit3 < Msf::Auxiliary
 	def run_host(ip)
 
 		if (not mysql_login_datastore)
-			print_error("Invalid MySQL Server credentials")
 			return
 		end
 		mysql_schema = get_schema

--- a/modules/exploits/windows/mysql/mysql_mof.rb
+++ b/modules/exploits/windows/mysql/mysql_mof.rb
@@ -55,12 +55,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		begin
-			m = mysql_login(datastore['USERNAME'], datastore['PASSWORD'])
-		rescue RbMysql::AccessDeniedError
-			print_error("#{peer} - Access denied.")
-			return Exploit::CheckCode::Safe
-		end
+		m = mysql_login(datastore['USERNAME'], datastore['PASSWORD'])
+		return Exploit::CheckCode::Safe if not m
 
 		return Exploit::CheckCode::Appears if is_windows?
 		return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/mysql/mysql_payload.rb
+++ b/modules/exploits/windows/mysql/mysql_payload.rb
@@ -65,7 +65,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def login_and_get_sys_exec
-		mysql_login(username,password,'mysql')
+		m = mysql_login(username,password,'mysql')
+		return if not m
 		@mysql_arch = mysql_get_arch
 		@mysql_sys_exec_available = mysql_check_for_sys_exec()
 		if !@mysql_sys_exec_available || datastore['FORCE_UDF_UPLOAD']
@@ -74,6 +75,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		else
 			print_status "sys_exec() already available, using that (override with FORCE_UDF_UPLOAD)."
 		end
+
+		return m
 	end
 
 	def execute_command(cmd, opts)
@@ -81,10 +84,9 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		login_and_get_sys_exec()
+		m = login_and_get_sys_exec()
 
-		if not @mysql_handle
-			print_status("Invalid MySQL credentials")
+		if not m
 			return
 		elsif not [:win32,:win64].include?(@mysql_arch)
 			print_status("Incompatible MySQL target architecture: '#{@mysql_arch}'")

--- a/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
+++ b/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
@@ -109,9 +109,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Login
 		h = mysql_login(datastore['USERNAME'], datastore['PASSWORD'])
-
-		# The lib throws its own error message anyway:
-		# "Exploit failed [no-access]: RbMysql::AccessDeniedError"
 		return false if not h
 
 		tmp = mysql_get_temp_dir


### PR DESCRIPTION
This add more exception handling for the mysql_login function.  Related to the following ticket:
http://dev.metasploit.com/redmine/issues/7668

Tested on the following:

Demo for mysql_hashdump:

```
msf  auxiliary(mysql_hashdump) > run

[+] Saving HashString as Loot: root:*[----------------Removed---------------]
[+] Saving HashString as Loot: root:*[----------------Removed---------------]
[+] Saving HashString as Loot: root:*[----------------Removed---------------]
[+] Saving HashString as Loot: debian-sys-maint:*[----------------Removed---------------]
[*] Hash Table has been saved: /Users/sinn3r/.msf4/loot/20130107161618_default_10.0.1.22_mysql.hashes_135309.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Demo for mysql_login:

```
msf  auxiliary(mysql_login) > run

[*] 10.0.1.22:3306 MYSQL - Found remote MySQL version 5.1.66
[*] 10.0.1.22:3306 MYSQL - [1/1] - Trying username:'root' with password:'root'
[+] 10.0.1.22:3306 - SUCCESSFUL LOGIN 'root' : 'root'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Demo for mysql_schemadump:

```
msf  auxiliary(mysql_schemadump) > run

[*] Schema stored in: /Users/sinn3r/.msf4/loot/20130107161907_default_10.0.1.22_mysql_schema_185685.txt
[+] MySQL Server Schema 
 Host: 10.0.1.22 
 Port: 3306 
 ====================

--- []
```

Demo for mysql_mof:

```
msf  exploit(mysql_mof) > exploit

[*] Started reverse handler on 10.0.1.3:4444 
[*] 10.0.1.10:3306 - Attempting to login as 'sa:blah'
[-] Access denied
[*] Exploit completed, but no session was created.
```
