### PR TITLE
Fix smb capture error

### DIFF
--- a/modules/auxiliary/server/capture/smb.rb
+++ b/modules/auxiliary/server/capture/smb.rb
@@ -529,7 +529,7 @@ class Metasploit3 < Msf::Auxiliary
 			print_status(capturelogmessage)
 			lm_text = (lm_hash + lm_cli_challenge.to_s).empty? ? "00" * 24 : lm_hash + lm_cli_challenge.to_s
 			nt_text = (nt_hash + nt_cli_challenge.to_s).empty? ? "00" * 24 : nt_hash + nt_cli_challenge.to_s
-			pass = "#{smb[:domain]}:#{lm_text}:#{nt_text}:#{datastore['CHALLENGE'].to_s}" 
+			pass = "#{smb[:domain]}:#{lm_text}:#{nt_text}:#{datastore['CHALLENGE'].to_s}"
 
 			# DB reporting
 			report_auth_info(
@@ -575,7 +575,7 @@ class Metasploit3 < Msf::Auxiliary
 							smb[:username],
 							smb[:domain] ? smb[:domain] : "NULL",
 							@challenge.unpack("H*")[0],
-							lm_hash.empty? ? "0" * 48 : lm_hash, 
+							lm_hash.empty? ? "0" * 48 : lm_hash,
 							nt_hash.empty? ? "0" * 48 : nt_hash
 						].join(":").gsub(/\n/, "\\n")
 					)

--- a/modules/auxiliary/server/capture/smb.rb
+++ b/modules/auxiliary/server/capture/smb.rb
@@ -527,9 +527,8 @@ class Metasploit3 < Msf::Auxiliary
 			end
 
 			print_status(capturelogmessage)
-
-			lm_text = lm_hash + lm_cli_challenge.to_s ? lm_hash + lm_cli_challenge.to_s : "00" * 24
-			nt_text = nt_hash + nt_cli_challenge.to_s ? nt_hash + nt_cli_challenge.to_s :  "00" * 24
+			lm_text = (lm_hash + lm_cli_challenge.to_s).length > 0 ? lm_hash + lm_cli_challenge.to_s : "00" * 24
+			nt_text = (nt_hash + nt_cli_challenge.to_s).length > 0 ? nt_hash + nt_cli_challenge.to_s :  "00" * 24
 			pass = "#{smb[:domain]}:#{lm_text}:#{nt_text}:#{datastore['CHALLENGE'].to_s}" 
 
 			# DB reporting
@@ -593,8 +592,8 @@ class Metasploit3 < Msf::Auxiliary
 						[
 							smb[:username],"",
 							smb[:domain] ? smb[:domain] : "NULL",
-							lm_hash ? lm_hash : "0" * 48,
-							nt_hash ? nt_hash : "0" * 48,
+							lm_hash.length > 0 ? lm_hash : "0" * 48,
+							nt_hash.length > 0 ? nt_hash : "0" * 48,
 							@challenge.unpack("H*")[0]
 						].join(":").gsub(/\n/, "\\n")
 					)
@@ -607,7 +606,7 @@ class Metasploit3 < Msf::Auxiliary
 							smb[:username],"",
 							smb[:domain] ? smb[:domain] : "NULL",
 							@challenge.unpack("H*")[0],
-							lm_hash ? lm_hash : "0" * 32,
+							lm_hash.length > 0 ? lm_hash : "0" * 32,
 							lm_cli_challenge ? lm_cli_challenge : "0" * 16
 						].join(":").gsub(/\n/, "\\n")
 					)
@@ -619,7 +618,7 @@ class Metasploit3 < Msf::Auxiliary
 							smb[:username],"",
 							smb[:domain] ? smb[:domain] : "NULL",
 							@challenge.unpack("H*")[0],
-							nt_hash ? nt_hash : "0" * 32,
+							nt_hash.length > 0 ? nt_hash : "0" * 32,
 							nt_cli_challenge ? nt_cli_challenge : "0" * 160
 						].join(":").gsub(/\n/, "\\n")
 					)

--- a/modules/auxiliary/server/capture/smb.rb
+++ b/modules/auxiliary/server/capture/smb.rb
@@ -339,7 +339,7 @@ class Metasploit3 < Msf::Auxiliary
 				begin
 					smb_get_hash(smb,arg,true)
 				rescue ::Exception => e
-					print_status("SMB Capture - Error processing Hash from #{smb[:name]} - #{smb[:ip]} : #{e.class} #{e} #{e.backtrace}")
+					print_error("SMB Capture - Error processing Hash from #{smb[:name]} - #{smb[:ip]} : #{e.class} #{e} #{e.backtrace}")
 				end
 
 				smb_error(CONST::SMB_COM_SESSION_SETUP_ANDX, c, CONST::SMB_STATUS_LOGON_FAILURE, true)
@@ -401,7 +401,7 @@ class Metasploit3 < Msf::Auxiliary
 				smb_get_hash(smb,arg,false)
 
 			rescue ::Exception => e
-				print_status("SMB Capture - Error processing Hash from #{smb[:name]} : #{e.class} #{e} #{e.backtrace}")
+				print_error("SMB Capture - Error processing Hash from #{smb[:name]} : #{e.class} #{e} #{e.backtrace}")
 			end
 
 			smb_error(CONST::SMB_COM_SESSION_SETUP_ANDX, c, CONST::SMB_STATUS_LOGON_FAILURE, true)
@@ -528,16 +528,17 @@ class Metasploit3 < Msf::Auxiliary
 
 			print_status(capturelogmessage)
 
+			lm_text = lm_hash + lm_cli_challenge.to_s ? lm_hash + lm_cli_challenge.to_s : "00" * 24
+			nt_text = nt_hash + nt_cli_challenge.to_s ? nt_hash + nt_cli_challenge.to_s :  "00" * 24
+			pass = "#{smb[:domain]}:#{lm_text}:#{nt_text}:#{datastore['CHALLENGE'].to_s}" 
+
 			# DB reporting
 			report_auth_info(
 				:host  => smb[:ip],
 				:port => datastore['SRVPORT'],
 				:sname => 'smb_challenge',
 				:user => smb[:username],
-				:pass => smb[:domain] + ":" +
-					( lm_hash + lm_cli_challenge.to_s ? lm_hash + lm_cli_challenge.to_s : "00" * 24 ) + ":" +
-					( nt_hash + nt_cli_challenge.to_s ? nt_hash + nt_cli_challenge.to_s :  "00" * 24 ) + ":" +
-					datastore['CHALLENGE'].to_s,
+				:pass => pass,
 				:type => smb_db_type_hash,
 				:proof => "NAME=#{smb[:nbsrc]} DOMAIN=#{smb[:domain]} OS=#{smb[:peer_os]}",
 				:source_type => "captured",

--- a/modules/auxiliary/server/capture/smb.rb
+++ b/modules/auxiliary/server/capture/smb.rb
@@ -527,8 +527,8 @@ class Metasploit3 < Msf::Auxiliary
 			end
 
 			print_status(capturelogmessage)
-			lm_text = (lm_hash + lm_cli_challenge.to_s).length > 0 ? lm_hash + lm_cli_challenge.to_s : "00" * 24
-			nt_text = (nt_hash + nt_cli_challenge.to_s).length > 0 ? nt_hash + nt_cli_challenge.to_s :  "00" * 24
+			lm_text = (lm_hash + lm_cli_challenge.to_s).empty? ? "00" * 24 : lm_hash + lm_cli_challenge.to_s
+			nt_text = (nt_hash + nt_cli_challenge.to_s).empty? ? "00" * 24 : nt_hash + nt_cli_challenge.to_s
 			pass = "#{smb[:domain]}:#{lm_text}:#{nt_text}:#{datastore['CHALLENGE'].to_s}" 
 
 			# DB reporting
@@ -575,8 +575,8 @@ class Metasploit3 < Msf::Auxiliary
 							smb[:username],
 							smb[:domain] ? smb[:domain] : "NULL",
 							@challenge.unpack("H*")[0],
-							lm_hash ? lm_hash : "0" * 48,
-							nt_hash ? nt_hash : "0" * 48
+							lm_hash.empty? ? "0" * 48 : lm_hash, 
+							nt_hash.empty? ? "0" * 48 : nt_hash
 						].join(":").gsub(/\n/, "\\n")
 					)
 					fd.close
@@ -592,8 +592,8 @@ class Metasploit3 < Msf::Auxiliary
 						[
 							smb[:username],"",
 							smb[:domain] ? smb[:domain] : "NULL",
-							lm_hash.length > 0 ? lm_hash : "0" * 48,
-							nt_hash.length > 0 ? nt_hash : "0" * 48,
+							lm_hash.empty? ? "0" * 48 : lm_hash,
+							nt_hash.empty? ? "0" * 48 : nt_hash,
 							@challenge.unpack("H*")[0]
 						].join(":").gsub(/\n/, "\\n")
 					)
@@ -606,8 +606,8 @@ class Metasploit3 < Msf::Auxiliary
 							smb[:username],"",
 							smb[:domain] ? smb[:domain] : "NULL",
 							@challenge.unpack("H*")[0],
-							lm_hash.length > 0 ? lm_hash : "0" * 32,
-							lm_cli_challenge ? lm_cli_challenge : "0" * 16
+							lm_hash.empty? ? "0" * 32 : lm_hash,
+							lm_cli_challenge.empty? ? "0" * 16 : lm_cli_challenge
 						].join(":").gsub(/\n/, "\\n")
 					)
 					fd.close
@@ -618,8 +618,8 @@ class Metasploit3 < Msf::Auxiliary
 							smb[:username],"",
 							smb[:domain] ? smb[:domain] : "NULL",
 							@challenge.unpack("H*")[0],
-							nt_hash.length > 0 ? nt_hash : "0" * 32,
-							nt_cli_challenge ? nt_cli_challenge : "0" * 160
+							nt_hash.empty? ? "0" * 32 : nt_hash,
+							nt_cli_challenge ? "0" * 160 : nt_cli_challenge
 						].join(":").gsub(/\n/, "\\n")
 					)
 					fd.close


### PR DESCRIPTION
The following error is observed in the auxiliary/server/capture/smb.rb when running Nessus with credentials against the SMB capture module:

[*] SMB Capture - Error processing Hash from 192.168.1.103:40389 : NoMethodError undefined method `+' for nil:NilClass ["/opt/metasploit/msf3/modules/auxiliary/server/capture/smb.rb:537:in`smb_get_hash'", "/opt/metasploit/msf3/modules/auxiliary/server/capture/smb.rb:401:in `smb_cmd_session_setup'", "/opt/metasploit/msf3/modules/auxiliary/server/capture/smb.rb:119:in`smb_cmd_dispatch'", "/opt/metasploit/msf3/lib/msf/core/exploit/smb.rb:748:in `smb_recv'", "/opt/metasploit/msf3/lib/msf/core/exploit/smb.rb:679:in`on_client_data'", "/opt/metasploit/msf3/lib/msf/core/exploit/tcp.rb:389:in `block in start_service'", "/opt/metasploit/msf3/lib/rex/io/stream_server.rb:48:in`call'", "/opt/metasploit/msf3/lib/rex/io/stream_server.rb:48:in `on_client_data'", "/opt/metasploit/msf3/lib/rex/io/stream_server.rb:192:in`block in monitor_clients'", "/opt/metasploit/msf3/lib/rex/io/stream_server.rb:190:in `each'", "/opt/metasploit/msf3/lib/rex/io/stream_server.rb:190:in`monitor_clients'", "/opt/metasploit/msf3/lib/rex/io/stream_server.rb:73:in `block in start'", "/opt/metasploit/msf3/lib/rex/thread_factory.rb:22:in`call'", "/opt/metasploit/msf3/lib/rex/thread_factory.rb:22:in `block in spawn'", "/opt/metasploit/msf3/lib/msf/core/thread_manager.rb:100:in`call'", "/opt/metasploit/msf3/lib/msf/core/thread_manager.rb:100:in `block in spawn'"]
