### PR TITLE
Fixed unchecked Errno::ECONNRESET errors in web-module HTTP lib

### DIFF
--- a/lib/msf/core/auxiliary/web/http.rb
+++ b/lib/msf/core/auxiliary/web/http.rb
@@ -123,7 +123,12 @@ class Auxiliary::Web::HTTP
 			# Spawn threads for each host
 			while tl.size <= (opts[:max_threads] || 5) && !@queue.empty? && (req = @queue.pop)
 				tl << framework.threads.spawn( "#{self.class.name} - #{req})", false, req ) do |request|
-					request.handle_response request( request.url, request.opts )
+					begin
+						request.handle_response request( request.url, request.opts )
+					rescue => e
+						print_error e.to_s
+						e.backtrace.each { |l| print_error "-- #{l}" }
+					end
 				end
 			end
 

--- a/lib/msf/core/auxiliary/web/http.rb
+++ b/lib/msf/core/auxiliary/web/http.rb
@@ -123,12 +123,7 @@ class Auxiliary::Web::HTTP
 			# Spawn threads for each host
 			while tl.size <= (opts[:max_threads] || 5) && !@queue.empty? && (req = @queue.pop)
 				tl << framework.threads.spawn( "#{self.class.name} - #{req})", false, req ) do |request|
-					begin
-						request.handle_response request( request.url, request.opts )
-					rescue => e
-						print_error e.to_s
-						e.backtrace.each { |l| print_error "-- #{l}" }
-					end
+					request.handle_response request( request.url, request.opts )
 				end
 			end
 
@@ -296,7 +291,7 @@ class Auxiliary::Web::HTTP
 		Response.from_rex_response c.send_recv( c.request_cgi( opts ), timeout )
 	rescue ::Timeout::Error
 		Response.timed_out
-	rescue ::Errno::EPIPE, Rex::ConnectionTimeout
+	rescue ::Errno::EPIPE, ::Errno::ECONNRESET, Rex::ConnectionTimeout
 		Response.empty
 	end
 


### PR DESCRIPTION
Auxiliary::Web::HTTP lib updated to return empty responses on Errno::ECONNRESET errors.
