### PR TITLE
change doc to doc/ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 coverage
 data/meterpreter/ext_server_pivot.dll
 data/meterpreter/ext_server_pivot.x64.dll
-doc
+doc/
 external/source/meterpreter/java/bin
 external/source/meterpreter/java/build
 external/source/meterpreter/java/extensions


### PR DESCRIPTION
I _think_ this is more inline with what's intended, if not just kill this PR, but
according to http://www.kernel.org/pub/software/scm/git/docs/gitignore.html 

"If the pattern ends with a slash, it is removed for the purpose of the following description, but it would
only find a match with a directory. In other words, foo/ will match a directory foo and paths underneath it,
but will not match a regular file or a symbolic link foo (this is consistent with the way how pathspec works
in general in git).

If the pattern does not contain a slash /, git treats it as a shell glob pattern and checks for a match 
against the pathname relative to the location of the .gitignore file (relative to the toplevel of the work tree 
if not from a .gitignore file)."
