### PR TITLE
fixes RM7676 migrate -h doesn't produce help

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -329,8 +329,11 @@ class Console::CommandDispatcher::Core
 	#
 	# Migrates the server to the supplied process identifier.
 	#
+	# @param args [Array<String>] Commandline arguments, only -h or a pid
+	# @return [void]
+
 	def cmd_migrate(*args)
-		if (args.length == 0)
+		if ( args.length == 0 or args.include?("-h") )
 			cmd_migrate_help
 			return true
 		end


### PR DESCRIPTION
also adds YARD doc to cmd_migrate in collusion with egypt.
low threat change, but still tested on Win7-32 sp0, ruby 1.9.3-p125,
Framework Version: 4.6.0-dev just for kicks
[fixes RM7676]
