### PR TITLE
Msfconsole suspend and RM7223

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -737,7 +737,7 @@ class Console::CommandDispatcher::Stdapi::Sys
 	# Suspends or resumes a list of one or more pids
 	# args can optionally be -c to continue on error or -r to resume instead of suspend,
 	# followed by a list of one or more valid pids
-	# TODO:  A suspend which will accept process names, much of that code is done
+	# @todo  A suspend which will accept process names, much of that code is done (kernelsmith)
 	#
 	# @param args [Array] List of one of more pids
 	# @return [Boolean] Returns true if command was successful, else false


### PR DESCRIPTION
This fully [fixes RM7223] and adds the suspend command to the meterpreter
interface.
Suspend allows you to suspend and resume running processes on the
targethost.  It was originally written as a post module (and the dll
version will be submitted as such later), but egypt suggested I add it
to meterpreter.  Tested on Win7 32 & 64bit (tho it's really Win OS independent as it uses the meterpreter api, not the WinAPI or shell commands etc)
