### PR TITLE
Fixes 2 issues: Forgotten datastore options, and invalid BufferRegister

### DIFF
--- a/lib/rex/encoder/alpha2/unicode_mixed.rb
+++ b/lib/rex/encoder/alpha2/unicode_mixed.rb
@@ -39,7 +39,12 @@ class UnicodeMixed < Generic
 			'EDI'   => 'WWYA' + mod,         # push edi, pop edi
 		}
 
-		return regprefix[reg]	
+		prefix = regprefix[reg.upcase]
+		if prefix.nil?
+			raise "Critical: Invalid register"
+		end
+
+		return prefix
 	end
 
 	def self.gen_decoder(reg, offset)

--- a/msfvenom
+++ b/msfvenom
@@ -369,7 +369,7 @@ if opts[:encode]
 		next if not enc
 		begin
 			break if done
-			#enc.datastore.import_options_from_s(datastore, '_|_')
+			enc.datastore.import_options_from_hash(datastore)
 			skip = false
 			raw = nil
 


### PR DESCRIPTION
The 1st bug is msfvenom forgot to import datastore options to encoders, which may cause a backtrace depending on which encoder you're using.  We caught this bug using cucumber, so all you gotta do is run the encoders.feature test case, and then you will reproduce the bug:

```
cucumber test/features/encoders.feature
```

Or, if you don't have cucumber setup, you can just run this to reproduce it -- same thing:

```
msfvenom -p windows/shell/bind_tcp -e x86/unicode_mixed -i 1 BufferRegister=eax
```

Reported on redmine here:
http://dev.metasploit.com/redmine/issues/7681

The 2nd bug is the unicode_mixed encoder does not handle the BufferRegister's casing properly.  So if you supply BufferRegister=eax, it won't understand what that register is.  Instead, you must do BufferRegister=EAX, which is annoying.  The fix also checks if BufferRegister is a valid register or not.

Also reported on redmine here:
http://dev.metasploit.com/redmine/issues/7684
