### PR TITLE
[FixRM #7673] "Failed to reload" error.

### DIFF
--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -269,6 +269,7 @@ class DBManager
 		begin
 			ActiveRecord::Base.remove_connection
 			self.migrated = false
+			self.modules_cached = false
 		rescue ::Exception => e
 			self.error = e
 			elog("DB.disconnect threw an exception: #{e}")

--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -268,6 +268,7 @@ class DBManager
 	def disconnect
 		begin
 			ActiveRecord::Base.remove_connection
+			self.migrated = false
 		rescue ::Exception => e
 			self.error = e
 			elog("DB.disconnect threw an exception: #{e}")


### PR DESCRIPTION
When db_disconnect is issued, this funtion does not update the status of self.migrated to false.  So when another reload command is used, the update_module_details function will still try to connect to the database, which causes the "Failed to reload" error.

Please see the following ticket for more info:
http://dev.metasploit.com/redmine/issues/7673
