### PR TITLE
Fix OptInt's valid?() function

### DIFF
--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -441,7 +441,7 @@ class OptInt < OptBase
 	def valid?(value)
 		return false if empty_required_value?(value)
 
-		if value and not normalize(value).to_s.match(/^\d+$/)
+		if value and not value.to_s.match(/^\d+$/)
 			return false
 		end
 


### PR DESCRIPTION
[FixRM #7539] - The valid?() function will first normalize() the user-supplied input before validation.  The problem is that the normalize() function will ALWAYS convert data to integer, therefore whatever you validate, you will always get true.

For example: 
when I do "yomama".to_i, that returns 0, and of course will pass  integer validation.

Ticket can be found here:
http://dev.metasploit.com/redmine/issues/7539
