### PR TITLE
fixes missing word in descript. of rails exploit

### DIFF
--- a/modules/exploits/multi/http/rails_xml_yaml_code_exec.rb
+++ b/modules/exploits/multi/http/rails_xml_yaml_code_exec.rb
@@ -24,8 +24,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
 				This module has been tested across multiple versions of RoR 3.x and RoR 2.x
 
-				The technique used by this module requires the target to be running a fairly version
-				of Ruby 1.9 (since 2011 or so). Applications using Ruby 1.8 may still be
+				The technique used by this module requires the target to be running a fairly recent
+				version of Ruby 1.9 (since 2011 or so). Applications using Ruby 1.8 may still be
 				exploitable using the init_with() method, but this has not been demonstrated.
 
 			},


### PR DESCRIPTION
simple omission fix in description.  my branch is misnamed but I have enough problems with git and am not going to bother
