### PR TITLE
[FixRM: #7535] Missing normalize() in OptPort

### DIFF
--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -302,6 +302,10 @@ class OptPort < OptBase
 		return 'port'
 	end
 
+	def normalize(value)
+		value.to_i
+	end
+
 	def valid?(value)
 		return false if empty_required_value?(value)
 


### PR DESCRIPTION
[FixRM: #7535] - Sometimes OptPort can return as a String instead of Fixnum because OptPort is missing the normalize() function.

Before the fix:

```
>> active_module.options.validate(active_module.datastore)
=> true
>> active_module.datastore["RPORT"]
=> "80"
```

After the fix:

```
>> active_module.options.validate(active_module.datastore)
=> true
>> active_module.datastore["RPORT"]
=> 6905
>>
```

Ticket can be found here:
http://dev.metasploit.com/redmine/issues/7535
