### PR TITLE
[FixRM: #2100] Rescue TerminateLineInput in irb

### DIFF
--- a/lib/rex/ui/text/irb_shell.rb
+++ b/lib/rex/ui/text/irb_shell.rb
@@ -41,7 +41,11 @@ class IrbShell
 
 		# Trap interrupt
 		old_sigint = trap("SIGINT") do
-			irb.signal_handle
+			begin
+				irb.signal_handle
+			rescue RubyLex::TerminateLineInput
+				print ">> "
+			end
 		end
 
 		# Keep processing input until the cows come home...

--- a/lib/rex/ui/text/irb_shell.rb
+++ b/lib/rex/ui/text/irb_shell.rb
@@ -44,7 +44,7 @@ class IrbShell
 			begin
 				irb.signal_handle
 			rescue RubyLex::TerminateLineInput
-				print ">> "
+				irb.eval_input
 			end
 		end
 


### PR DESCRIPTION
[FixRM: #2100] - In irb, when you hit ^c, you will get an ugly backtrace. This fix handles that exception.

Two-year-old bug too:
http://dev.metasploit.com/redmine/issues/2100
