### PR TITLE
Allow OptInt to pass "" for special reasons

### DIFF
--- a/lib/msf/core/option_container.rb
+++ b/lib/msf/core/option_container.rb
@@ -443,6 +443,7 @@ class OptInt < OptBase
 	end
 
 	def valid?(value)
+		return super if !required and value and value.empty?
 		return false if empty_required_value?(value)
 
 		if value and not value.to_s.match(/^0x[0-9a-fA-F]+$|^-?\d+$/)


### PR DESCRIPTION
For Pro because Pro likes to pass "" even if no default value is set.
