### PR TITLE
psexec_command - Unable to execute specified command: can't convert nil ...

### DIFF
--- a/modules/auxiliary/admin/smb/psexec_command.rb
+++ b/modules/auxiliary/admin/smb/psexec_command.rb
@@ -263,7 +263,7 @@ class Metasploit3 < Msf::Auxiliary
 		end
 
 		select(nil, nil, nil, 1.0)
-		simple.disconnect("IPC$")
+		simple.disconnect("\\\\#{datastore['RHOST']}\\IPC$")
 		return true
 	end
 


### PR DESCRIPTION
...into Integer

Patched as described in Redmine bug #7680
https://dev.metasploit.com/redmine/issues/7680
