### PR TITLE
Re-enable stage encoding

### DIFF
--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -41,6 +41,7 @@ class EncodedPayload
 	# This method generates the full encoded payload and returns the encoded
 	# payload buffer.
 	#
+	# @return [String] The encoded payload.
 	def generate(raw = nil)
 		self.raw           = raw
 		self.encoded       = nil
@@ -86,8 +87,9 @@ class EncodedPayload
 
 	#
 	# Generates the raw payload from the payload instance.  This populates the
-	# raw attribute.
+	# {#raw} attribute.
 	#
+	# @return [String] The raw, unencoded payload.
 	def generate_raw
 		self.raw = (reqs['Prepend'] || '') + pinst.generate + (reqs['Append'] || '')
 
@@ -216,7 +218,7 @@ class EncodedPayload
 			# If the encoded payload is nil, raise an exception saying that we
 			# suck at life.
 			if (self.encoded == nil)
-				encoder = nil
+				self.encoder = nil
 
 				raise NoEncodersSucceededError,
 					"#{pinst.refname}: All encoders failed to encode.",

--- a/lib/msf/core/encoder.rb
+++ b/lib/msf/core/encoder.rb
@@ -308,7 +308,12 @@ class Encoder < Module
 			while (offset < state.buf.length)
 				block = state.buf[offset, decoder_block_size]
 
-				state.encoded += encode_block(state,
+				# Append here (String#<<) instead of creating a new string with
+				# String#+ because the allocations kill performance with large
+				# buffers. This isn't usually noticeable on most shellcode, but
+				# when doing stage encoding on meterpreter (~750k bytes) the
+				# difference is 2 orders of magnitude.
+				state.encoded << encode_block(state,
 						block + ("\x00" * (decoder_block_size - block.length)))
 
 				offset += decoder_block_size

--- a/lib/msf/core/encoder/xor.rb
+++ b/lib/msf/core/encoder/xor.rb
@@ -26,6 +26,9 @@ class Msf::Encoder::Xor < Msf::Encoder
 	# Finds keys that are incompatible with the supplied bad character list.
 	#
 	def find_bad_keys(buf, badchars)
+		# Short circuit if there are no badchars
+		return super if badchars.length == 0
+
 		bad_keys = Array.new(decoder_key_size) { Hash.new }
 		byte_idx = 0
 

--- a/lib/msf/core/payload/stager.rb
+++ b/lib/msf/core/payload/stager.rb
@@ -174,7 +174,7 @@ module Msf::Payload::Stager
 	# Override to deal with sending the final stage in cases where
 	# {#generate_stage} is not the whole picture, such as when uploading
 	# an executable. The default is to simply attempt to create a session
-	# on the given +conn+ socket with {Handler#create_session}.
+	# on the given +conn+ socket with {Msf::Handler#create_session}.
 	#
 	# @param (see Handler#create_session)
 	# @return (see Handler#create_session)
@@ -191,6 +191,7 @@ module Msf::Payload::Stager
 	end
 
 	# Encodes the stage prior to transmission
+	# @return [String] Encoded version of +stg+
 	def encode_stage(stg)
 		return stg unless encode_stage?
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2365,6 +2365,7 @@ class Core
 			return option_values_payloads() if opt.upcase == 'PAYLOAD'
 			return option_values_targets()  if opt.upcase == 'TARGET'
 			return option_values_nops()     if opt.upcase == 'NOPS'
+			return option_values_encoders() if opt.upcase == 'StageEncoder'
 		end
 
 		# Well-known option names specific to auxiliaries

--- a/modules/encoders/x86/shikata_ga_nai.rb
+++ b/modules/encoders/x86/shikata_ga_nai.rb
@@ -111,10 +111,10 @@ protected
 
 		# Clear the counter register
 		clear_register = Rex::Poly::LogicalBlock.new('clear_register',
-			"\x31\xc9",
-			"\x29\xc9",
-			"\x33\xc9",
-			"\x2b\xc9")
+			"\x31\xc9",  # xor ecx,ecx
+			"\x29\xc9",  # sub ecx,ecx
+			"\x33\xc9",  # xor ecx,ecx
+			"\x2b\xc9")  # sub ecx,ecx
 
 		# Initialize the counter after zeroing it
 		init_counter = Rex::Poly::LogicalBlock.new('init_counter')
@@ -126,8 +126,10 @@ protected
 
 		if (length <= 255)
 			init_counter.add_perm("\xb1" + [ length ].pack('C'))
-		else
+		elsif (length <= 65536)
 			init_counter.add_perm("\x66\xb9" + [ length ].pack('v'))
+		else
+			init_counter.add_perm("\xb9" + [ length ].pack('V'))
 		end
 
 		# Key initialization block

--- a/spec/lib/rex/encoding/xor/byte.rb
+++ b/spec/lib/rex/encoding/xor/byte.rb
@@ -1,0 +1,7 @@
+
+require 'rex/encoding/xor/byte'
+require 'spec_helper'
+
+describe Rex::Encoding::Xor::Byte do
+	it_behaves_like "an xor encoder", 1
+end

--- a/spec/lib/rex/encoding/xor/dword.rb
+++ b/spec/lib/rex/encoding/xor/dword.rb
@@ -1,0 +1,7 @@
+
+require 'rex/encoding/xor/dword'
+require 'spec_helper'
+
+describe Rex::Encoding::Xor::Dword do
+	it_behaves_like "an xor encoder", 4
+end

--- a/spec/lib/rex/encoding/xor/qword.rb
+++ b/spec/lib/rex/encoding/xor/qword.rb
@@ -1,0 +1,7 @@
+
+require 'rex/encoding/xor/qword'
+require 'spec_helper'
+
+describe Rex::Encoding::Xor::Qword do
+	it_behaves_like "an xor encoder", 8
+end

--- a/spec/lib/rex/encoding/xor/word.rb
+++ b/spec/lib/rex/encoding/xor/word.rb
@@ -1,0 +1,7 @@
+
+require 'rex/encoding/xor/word'
+require 'spec_helper'
+
+describe Rex::Encoding::Xor::Word do
+	it_behaves_like "an xor encoder", 2
+end

--- a/spec/support/shared/examples/xor_encoder.rb
+++ b/spec/support/shared/examples/xor_encoder.rb
@@ -1,0 +1,20 @@
+shared_examples_for 'an xor encoder' do |keysize|
+
+	it "should encode one block" do
+		# Yup it returns one of its arguments in an array... Because spoon.
+		encoded, key = described_class.encode("A"*keysize, "A"*keysize)
+		encoded.should eql("\x00"*keysize)
+
+		encoded, key = described_class.encode("\x0f"*keysize, "\xf0"*keysize)
+		encoded.should eql("\xff"*keysize)
+
+		encoded, key = described_class.encode("\xf7"*keysize, "\x7f"*keysize)
+		encoded.should eql("\x88"*keysize)
+	end
+
+	it "should encode multiple blocks" do
+		encoded, key = described_class.encode("\xf7"*keysize*40, "\x7f"*keysize)
+		encoded.should eql("\x88"*keysize*40)
+	end
+
+end


### PR DESCRIPTION
Vastly improves performance of xor-based x86 encoders and re-enables stage encoding.  This makes it possible to send a much more random buffer over the wire instead of a raw metsrv.dll when staging.

See #905
