### PR TITLE
adds check for empty data before sending to parser [fixes RM7269]

### DIFF
--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -4869,7 +4869,7 @@ class DBManager
 	# If you have Nokogiri installed, you'll be shunted over to
 	# that. Otherwise, you'll hit the old NmapXMLStreamParser.
 	def import_nmap_xml(args={}, &block)
-		return nil if args[:data].empty?
+		return nil if args[:data].nil? or args[:data].empty?
 		wspace = args[:wspace] || workspace
 		bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
 

--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -4869,6 +4869,7 @@ class DBManager
 	# If you have Nokogiri installed, you'll be shunted over to
 	# that. Otherwise, you'll hit the old NmapXMLStreamParser.
 	def import_nmap_xml(args={}, &block)
+		return nil if args[:data].empty?
 		wspace = args[:wspace] || workspace
 		bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
 


### PR DESCRIPTION
[fixes RM7269]
we discussed the solution to this bug a lot on IRC and in the ticket
itself, the consensus was to fix it as far upstream as possible before
sending to the parsers so as to avoid any future bugs of the same
nature, so this commit adds a check to import_nmap_xml to see if the
data is empty before passing it on to the parser, whether that parser
is nokogiri or the legacy parser.

db_nmap -h now produces the expected output and db_nmap still works as
expected.
