### PR TITLE
Fixed a typo in the skype_enum module 

### DIFF
--- a/modules/post/multi/gather/skype_enum.rb
+++ b/modules/post/multi/gather/skype_enum.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Post
 						process_db(db_in_loot,p['name'])
 					end
 				end
-			elsif (session.platfom =~ /win/ and session.type =~ /meter/)
+			elsif (session.platform =~ /win/ and session.type =~ /meter/)
 				# Iterate thru each user profile in a Windows System using Meterpreter Post API
 				grab_user_profiles().each do |p|
 					if check_skype(p['AppData'],p['UserName'])


### PR DESCRIPTION
"platfom" instead of "platform" fixed. This prevented the module from working on Windows.
