### PR TITLE
Fixed loot formatting so data is under the proper column

### DIFF
--- a/modules/post/windows/gather/credentials/filezilla_server.rb
+++ b/modules/post/windows/gather/credentials/filezilla_server.rb
@@ -89,10 +89,10 @@ class Metasploit3 < Msf::Post
 		'Indent'    => 1,
 		'Columns'   =>
 		[
-			"User",
-			"Password",
 			"Host",
 			"Port",
+			"User",
+			"Password",
 			"SSL"
 		])
 
@@ -105,14 +105,15 @@ class Metasploit3 < Msf::Post
 			"User",
 			"Dir",
 			"FileRead",
+			"FileWrite",
 			"FileDelete",
 			"FileAppend",
 			"DirCreate",
 			"DirDelete",
 			"DirList",
 			"DirSubdirs",
-			"Home",
-			"AutoCreate"
+			"AutoCreate",
+			"Home"
 		])
 
 		configuration = Rex::Ui::Text::Table.new(


### PR DESCRIPTION
The credentials table was defined with the columns "User", "Password", "Host", "Port", and "SSL".  Credentials were not added in that order, however. They were added in the order "host, port, user, password, ssl" in this line:

credentials << [cred['host'], cred['port'], cred['user'], cred['password'], cred['ssl']]

I changed the order the columns were defined to fix this.

The permissions table had a similar issue. The "FileWrite" column was missing, so I added it. I also moved the "Home" column to after the "AutoCreate" column. Now the line:

permissions << [perm['host'], perm['user'], perm['dir'], perm['fileread'], perm['filewrite'], perm['filedelete'], perm['fileappend'],perm['dircreate'], perm['dirdelete'], perm['dirlist'], perm['dirsubdirs'], perm['autocreate']]

works correctly.
