### PR TITLE
SimpleCov Groups and better Rubymine compatibility

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,3 +1,11 @@
+# RM_INFO is set when using Rubymine.  In Rubymine, starting SimpleCov is
+# controlled by running with coverage, so don't explicitly start coverage (and
+# therefore generate a report) when in Rubymine.  This _will_ generate a report
+# whenever `rake spec` is run.
+unless ENV['RM_INFO']
+	SimpleCov.start
+end
+
 SimpleCov.configure do
   # ignore this file
 	add_filter '.simplecov'

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,50 @@
+SimpleCov.configure do
+  # ignore this file
+	add_filter '.simplecov'
+
+	#
+	# Changed Files in Git Group
+	# @see http://fredwu.me/post/35625566267/simplecov-test-coverage-for-changed-files-only
+	#
+
+	untracked = `git ls-files --exclude-standard --others`
+	unstaged = `git diff --name-only`
+	staged = `git diff --name-only --cached`
+	all = untracked + unstaged + staged
+	changed_filenames = all.split("\n")
+
+	add_group 'Changed' do |source_file|
+		changed_filenames.detect { |changed_filename|
+			source_file.filename.end_with?(changed_filename)
+		}
+	end
+
+	#
+	# Framework (msf) related groups
+	#
+
+	add_group 'Metasploit Framework', 'lib/msf'
+	add_group 'Metasploit Framework (Base)', 'lib/msf/base'
+	add_group 'Metasploit Framework (Core)', 'lib/msf/core'
+
+	#
+	# Other library groups
+	#
+
+	add_group 'Fastlib', 'lib/fastlib'
+	add_group 'Metasm', 'lib/metasm'
+	add_group 'PacketFu', 'lib/packetfu'
+	add_group 'Rex', 'lib/rex'
+	add_group 'RKelly', 'lib/rkelly'
+	add_group 'Ruby Mysql', 'lib/rbmysql'
+	add_group 'Ruby Postgres', 'lib/postgres'
+	add_group 'SNMP', 'lib/snmp'
+	add_group 'Zip', 'lib/zip'
+
+	#
+	# Specs are reported on to ensure that all examples are being run and all
+	# lets, befores, afters, etc are being used.
+	#
+
+	add_group 'Specs', 'spec'
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,12 +11,6 @@ $LOAD_PATH.unshift(lib_pathname.to_s)
 # must be first require and started before any other requires so that it can measure coverage of all following required
 # code.  It is after the rubygems and bundler only because Bundler.setup supplies the LOAD_PATH to simplecov.
 require 'simplecov'
-# Ensure the coverage directory is always the same no matter where the individual spec is in the hierarchy when using
-# Rubymine to run one spec.
-#
-# @see https://github.com/colszowka/simplecov/issues/95
-SimpleCov.root(root_pathname)
-SimpleCov.start
 
 require 'rspec/core'
 


### PR DESCRIPTION
Add Changed group that will show the coverage for any untracked, unstaged, or staged file so developers can more easily see if that their changes are covered.

Other groups added for different libraries under lib.

For Rubymine compatibility, make coverage collection controllable using Rubymine and reporting only occur when requests. Coverage collection and reporting remains unaffected when running `rake spec` from outside Rubymine as Rubymine is detected using the RM_INFO environment variable.
