### PR TITLE
XML report import for OpenVAS Plugin

### DIFF
--- a/plugins/openvas.rb
+++ b/plugins/openvas.rb
@@ -530,7 +530,7 @@ class Plugin::OpenVAS < Msf::Plugin
 				end
 			else
 				print_status("Usage: openvas_report_import <report_id> <format_id>")
-				print_status("Only the NBE format is supported for importing.")
+				print_status("Only the NBE and XML formats are supported for importing.")
 			end
 		end
 


### PR DESCRIPTION
The framework has support for importing OpenVAS XML files. The OpenVAS plugin states that only NBE importing is supported. I modified the usage statement to say that XML format is supported as well.
