### PR TITLE
Add more checking to handle MySQL strict mode

### DIFF
--- a/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
@@ -18,27 +18,39 @@ class Metasploit3 < Msf::Auxiliary
 		super(
 			'Name'           => 'MYSQL File/Directory Enumerator',
 			'Description'    => %Q{
-					Enumerate files and directories using the MySQL load_file feature, for more information see the URL in the references.
+					Enumerate files and directories using the MySQL load_file feature, for more
+				information see the URL in the references.
 			},
 			'Author'         => [ 'Robin Wood <robin[at]digininja.org>' ],
 			'References'  => [
-								[ 'URL', 'http://pauldotcom.com/2013/01/mysql-file-system-enumeration.html' ],
-								[ 'URL', 'http://www.digininja.org/projects/mysql_file_enum.php' ]
-							],
+				[ 'URL', 'http://pauldotcom.com/2013/01/mysql-file-system-enumeration.html' ],
+				[ 'URL', 'http://www.digininja.org/projects/mysql_file_enum.php' ]
+			],
 			'License'        => MSF_LICENSE
 		)
 
 		register_options([
 			OptPath.new('FILE_LIST', [ true, "List of directories to enumerate", '' ]),
-			OptString.new('DATABASE_NAME', [ true, "Name of database to use", 'test' ]),
+			OptString.new('DATABASE_NAME', [ true, "Name of database to use", 'mysql' ]),
 			OptString.new('TABLE_NAME', [ true, "Name of table to use - Warning, if the table already exists its contents will be corrupted", Rex::Text.rand_text_alpha(8) ]),
 			OptString.new('USERNAME', [ true, 'The username to authenticate as', "root" ])
-			])
+		])
 
 	end
 
+	# This function does not handle any errors, if you use this
+	# make sure you handle the errors yourself
+	def mysql_query_no_handle(sql)
+		res = @mysql_handle.query(sql)
+		res
+	end
+
+	def peer
+		"#{rhost}:#{rport}"
+	end
+
 	def run_host(ip)
-		print_status("Checking " + ip)
+		vprint_status("#{peer} - Login...")
 
 		if (not mysql_login_datastore)
 			return
@@ -47,10 +59,10 @@ class Metasploit3 < Msf::Auxiliary
 		begin
 			mysql_query_no_handle("USE " + datastore['DATABASE_NAME'])
 		rescue ::RbMysql::Error => e
-			print_error("MySQL Error: #{e.class} #{e.to_s}")
+			vprint_error("#{peer} - MySQL Error: #{e.class} #{e.to_s}")
 			return
 		rescue Rex::ConnectionTimeout => e
-			print_error("Timeout: #{e.message}")
+			vprint_error("#{peer} - Timeout: #{e.message}")
 			return
 		end
 
@@ -58,7 +70,7 @@ class Metasploit3 < Msf::Auxiliary
 		table_exists = (res.size == 1)
 
 		if !table_exists
-			print_status("Table doesn't exist so creating it")
+			vprint_status("#{peer} - Table doesn't exist so creating it")
 			mysql_query("CREATE TABLE " + datastore['TABLE_NAME'] + " (brute int);")
 		end
 
@@ -66,9 +78,10 @@ class Metasploit3 < Msf::Auxiliary
 		file.each_line do |line|
 			check_dir(line.chomp)
 		end
+		file.close
 
 		if !table_exists
-			print_status("Cleaning up the temp table")
+			vprint_status("#{peer} - Cleaning up the temp table")
 			mysql_query("DROP TABLE " + datastore['TABLE_NAME'])
 		end
 	end
@@ -77,19 +90,44 @@ class Metasploit3 < Msf::Auxiliary
 		begin
 			res = mysql_query_no_handle("LOAD DATA INFILE '" + dir + "' INTO TABLE " + datastore['TABLE_NAME'])
 		rescue ::RbMysql::TextfileNotReadable
-			print_good(dir + " is a directory and exists")
+			print_good("#{peer} - #{dir} is a directory and exists")
+			report_note(
+				:host  => rhost,
+				:type  => "filesystem.dir",
+				:data  => "#{dir} is a directory and exists",
+				:port  => rport,
+				:proto => 'tcp',
+				:update => :unique_data
+			)
+		rescue ::RbMysql::DataTooLong, ::RbMysql::TruncatedWrongValueForField
+			print_good("#{peer} - #{dir} is a file and exists")
+			report_note(
+				:host  => rhost,
+				:type  => "filesystem.file",
+				:data  => "#{dir} is a file and exists",
+				:port  => rport,
+				:proto => 'tcp',
+				:update => :unique_data
+			)
 		rescue ::RbMysql::ServerError
-			print_warning(dir + " does not exist")
+			vprint_warning("#{peer} - #{dir} does not exist")
 		rescue ::RbMysql::Error => e
-			print_error("MySQL Error: #{e.class} #{e.to_s}")
+			vprint_error("#{peer} - MySQL Error: #{e.class} #{e.to_s}")
 			return
 		rescue Rex::ConnectionTimeout => e
-			print_error("Timeout: #{e.message}")
+			vprint_error("#{peer} - Timeout: #{e.message}")
 			return
 		else
-			print_good(dir + " is a file and exists")
+			print_good("#{peer} - #{dir} is a file and exists")
+			report_note(
+				:host  => rhost,
+				:type  => "filesystem.file",
+				:data  => "#{dir} is a file and exists",
+				:port  => rport,
+				:proto => 'tcp',
+				:update => :unique_data
+			)
 		end
-		#puts res.inspect
 
 		return
 	end


### PR DESCRIPTION
I just tested this against a server which has strict mode enabled and it failed to detect files which exist because it errored with either wrong data type or insufficient space when trying to insert the file into the table. I've added checks for those two errors and it is now detecting files again.
