### PR TITLE
Fix NoMethodError if handler has no ParentModule

### DIFF
--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -679,8 +679,8 @@ class DBManager
 		# In the case of multi handler we cannot yet determine the true
 		# exploit responsible. But we can at least show the parent versus
 		# just the generic handler:
-		if session and session.via_exploit == "exploit/multi/handler"
-	  	sess_data[:via_exploit] = sess_data[:datastore]['ParentModule']
+		if session and session.via_exploit == "exploit/multi/handler" and sess_data[:datastore]['ParentModule']
+			sess_data[:via_exploit] = sess_data[:datastore]['ParentModule']
 		end
 
 		s = ::Mdm::Session.new(sess_data)
@@ -696,9 +696,9 @@ class DBManager
 
 			mod = framework.modules.create(session.via_exploit)
 
-			if session.via_exploit == "exploit/multi/handler"
-		  	mod_fullname = sess_data[:datastore]['ParentModule']
-		  	mod_name = ::Mdm::ModuleDetail.find_by_fullname(mod_fullname).name
+			if session.via_exploit == "exploit/multi/handler" and sess_data[:datastore]['ParentModule']
+				mod_fullname = sess_data[:datastore]['ParentModule']
+				mod_name = ::Mdm::ModuleDetail.find_by_fullname(mod_fullname).name
 			else 
 				mod_name = mod.name
 				mod_fullname = mod.fullname
@@ -720,7 +720,7 @@ class DBManager
 
 			vuln = framework.db.report_vuln(vuln_info)
 			
-			if session.via_exploit == "exploit/multi/handler"
+			if session.via_exploit == "exploit/multi/handler" and sess_data[:datastore]['ParentModule']
 				via_exploit = sess_data[:datastore]['ParentModule']
 			else
 				via_exploit = session.via_exploit


### PR DESCRIPTION
db.rb assumes that multi/handler sessions have a ParentModule defined
in their datastore. This assumption breaks when a user sets up a
multi/handler by hand to receive a session from another user (e.g.,
via multi_meter_inject).

When db.rb tries to access a member of a nil ParentModule, a
stacktrace is dumped to framework.log.
