### PR TITLE
Add more checking to handle MySQL strict mode

### DIFF
--- a/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
@@ -99,6 +99,16 @@ class Metasploit3 < Msf::Auxiliary
 				:proto => 'tcp',
 				:update => :unique_data
 			)
+		rescue ::RbMysql::DataTooLong, ::RbMysql::TruncatedWrongValueForField
+			print_good("#{peer} - #{dir} is a file and exists")
+			report_note(
+				:host  => rhost,
+				:type  => "filesystem.file",
+				:data  => "#{dir} is a file and exists",
+				:port  => rport,
+				:proto => 'tcp',
+				:update => :unique_data
+			)
 		rescue ::RbMysql::ServerError
 			vprint_warning("#{peer} - #{dir} does not exist")
 		rescue ::RbMysql::Error => e


### PR DESCRIPTION
I just tested this against a server which has strict mode enabled and it failed to detect files which exist because of errors with either wrong data type or insufficient space when trying to insert the file into the table. I've added checks for those two errors and it is now detecting files again.
