### PR TITLE
Updated smb_login.rb to check if user has admin_access

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -238,21 +238,7 @@ class Metasploit3 < Msf::Auxiliary
 
 			return :next_user
 
-		when 'ADMIN_ACCESS'
-			# Auth user indicates if the login was as a guest or not
-			if(simple.client.auth_user)
-				print_good(output_message % "SUCCESSFUL LOGIN")
-				validuser_case_sensitive?(domain, user, pass)
-				report_creds(domain,user,pass,true)
-			else
-				if datastore['RECORD_GUEST']
-					print_status(output_message % "GUEST LOGIN")
-					report_creds(domain,user,pass,true)
-				elsif datastore['VERBOSE']
-						print_status(output_message % "GUEST LOGIN")
-				end
-			end
-		when 'NOT_ADMIN'
+		when 'ADMIN_ACCESS', 'NOT_ADMIN'
 			# Auth user indicates if the login was as a guest or not
 			if(simple.client.auth_user)
 				print_good(output_message % "SUCCESSFUL LOGIN")

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -151,6 +151,8 @@ class Metasploit3 < Msf::Auxiliary
 			)
 
 			# Windows SMB will return an error code during Session Setup, but nix Samba requires a Tree Connect:
+			simple.connect("\\\\#{datastore['RHOST']}\\IPC$")
+			
 			status_code = check_login_rights(domain, user, pass)
 		rescue ::Rex::Proto::SMB::Exceptions::ErrorCode => e
 			status_code = e.get_error(e.error_code)

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -120,19 +120,19 @@ class Metasploit3 < Msf::Auxiliary
 				{:use_spn => datastore['NTLM::SendSPN'], :name =>  self.rhost}
 			)
 
-			# Windows SMB will return an error code during Session Setup, but nix Samba requires a Tree Connect:
-			simple.connect("\\\\#{datastore['RHOST']}\\IPC$")
-			status_code = "STATUS_SUCCESS"
+		# Windows SMB will return an error code during Session Setup, but nix Samba requires a Tree Connect:
+		simple.connect("\\\\#{datastore['RHOST']}\\IPC$")
+		status_code = "STATUS_SUCCESS"
 
-            if datastore['CHECK_ADMIN']
-                status_code = "NOT_ADMIN"
-                begin
-                    simple.connect("\\\\#{datastore['RHOST']}\\admin$")
-                    status_code = 'ADMIN_ACCESS'
-                rescue
-                    status_code = "NOT_ADMIN"
-                end
-            end
+		if datastore['CHECK_ADMIN']
+			status_code = "NOT_ADMIN"
+			begin
+				simple.connect("\\\\#{datastore['RHOST']}\\admin$")
+				status_code = 'ADMIN_ACCESS'
+			rescue
+				status_code = "NOT_ADMIN"
+			end
+		end
 
 		rescue ::Rex::Proto::SMB::Exceptions::ErrorCode => e
 			status_code = e.get_error(e.error_code)

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -118,7 +118,7 @@ class Metasploit3 < Msf::Auxiliary
 								{:use_spn => datastore['NTLM::SendSPN'], :name =>  self.rhost})
 			# check if account has ability to access admin share
 			simple.connect("\\\\#{datastore['RHOST']}\\admin$")
-			status_code = 'REMOTE_ACCESS'
+			status_code = 'ADMIN_ACCESS'
 		rescue
 			return status_code
 		rescue ::Rex::Proto::SMB::Exceptions::LoginError => e
@@ -256,7 +256,7 @@ class Metasploit3 < Msf::Auxiliary
 
 			return :next_user
 
-		when 'REMOTE_ACCESS'
+		when 'ADMIN_ACCESS'
 			# Auth user indicates if the login was as a guest or not
 			if(simple.client.auth_user)
 				print_good(output_message % "SUCCESSFUL LOGIN")


### PR DESCRIPTION
The current smb_login.rb will only determine if the credentials are valid and will not determine if the account is able to remotely login. This pull request will perform an additional check to see if the account is able to remotely login to the device over SMB. Not only is it nice to know if the credentials are valid, but also if the account has the ability to remotely login.

For additional details see:  http://www.pentestgeek.com/2013/01/17/diamond-in-the-rough-get-da-before-launching-a-payload/

Module output for account without local admin privs:

<pre>
msf  auxiliary(smb_login) > show options

Module options (auxiliary/scanner/smb/smb_login):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   BLANK_PASSWORDS   true             no        Try blank passwords for all users
   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
   PASS_FILE                          no        File containing passwords, one per line
   PRESERVE_DOMAINS  true             no        Respect a username that contains a domain name.
   RECORD_GUEST      false            no        Record guest-privileged random logins to the database
   RHOSTS                             yes       The target address range or CIDR identifier
   RPORT             445              yes       Set the SMB service port
   SMBDomain                          no        SMB Domain
   SMBPass                            no        SMB Password
   SMBUser                            no        SMB Username
   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
   THREADS           1                yes       The number of concurrent threads
   USERPASS_FILE                      no        File containing users and passwords separated by space, one pair per line
   USER_AS_PASS      true             no        Try the username as the password for all users
   USER_FILE                          no        File containing usernames, one per line
   VERBOSE           true             yes       Whether to print output for all attempts

msf  auxiliary(smb_login) > set RHOSTS 10.10.10.10
RHOSTS => 10.10.10.10
msf  auxiliary(smb_login) > set smbuser test
smbuser => test
msf  auxiliary(smb_login) > set smbpass test
smbpass => test
msf  auxiliary(smb_login) > run

[*] 10.10.10.10:445 SMB - Starting SMB login bruteforce
[*] 10.10.10.10 - This system allows guest sessions with any credentials, these instances will not be recorded.
[-] 10.10.10.10:445 SMB - [1/2] - FAILED LOGIN (Windows Server 2003 3790 Service Pack 2) test :  [STATUS_LOGON_FAILURE]
[+] 10.10.10.10:445 - SUCCESSFUL LOGIN (Windows Server 2003 3790 Service Pack 2) test : test [STATUS_SUCCESS]
[*] Username is case insensitive
[*] Domain is ignored
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
</pre>


Module output for account with local admin privs (notice it displays the REMOTE_ACCESS):

<pre>
msf  auxiliary(smb_login) > run

[*] 10.10.10.10:445 SMB - Starting SMB login bruteforce
[*] 10.10.10.10 - This system allows guest sessions with any credentials, these instances will not be recorded.
[-] 10.10.10.10:445 SMB - [1/2] - FAILED LOGIN (Windows Server 2003 3790 Service Pack 2) test :  [STATUS_LOGON_FAILURE]
[+] 10.10.10.10:445 - SUCCESSFUL LOGIN (Windows Server 2003 3790 Service Pack 2) test : test [REMOTE_ACCESS]
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
</pre>
