### PR TITLE
Lower ranking because they cannot auto-target

### DIFF
--- a/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
+++ b/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
@@ -8,7 +8,7 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-	Rank = ExcellentRanking
+	Rank = GoodRanking
 
 	HttpFingerprint = { :pattern => [ /Apache-Coyote/ ] }
 

--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -8,7 +8,7 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-	Rank = ExcellentRanking
+	Rank = GoodRanking
 
 	include Msf::Exploit::Remote::HttpClient
 	include Msf::Exploit::CmdStagerVBS

--- a/modules/exploits/multi/http/splunk_upload_app_exec.rb
+++ b/modules/exploits/multi/http/splunk_upload_app_exec.rb
@@ -8,7 +8,7 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-	Rank = ExcellentRanking
+	Rank = GoodRanking
 
 	include Msf::Exploit::Remote::HttpClient
 

--- a/modules/exploits/multi/http/struts_code_exec.rb
+++ b/modules/exploits/multi/http/struts_code_exec.rb
@@ -8,7 +8,7 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-	Rank = ExcellentRanking
+	Rank = GoodRanking
 
 	include Msf::Exploit::CmdStagerTFTP
 	include Msf::Exploit::Remote::HttpClient


### PR DESCRIPTION
In order to be qualified as ExcellentRanking, auto-target is a must, or the module has to default to a payload that's universal for multiple platforms.  See:
http://dev.metasploit.com/redmine/issues/7722
