### PR TITLE
Change default target

### DIFF
--- a/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
+++ b/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					]
 				],
 			'DisclosureDate' => 'Jan 06 2012',
-			'DefaultTarget' => 0))
+			'DefaultTarget' => 2))
 
 			register_options(
 				[


### PR DESCRIPTION
ExcellentRanking requires the module to auto-target. If the payload is universal, that works too.
