### PR TITLE
Stop aggravating default show screenshot

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/ui.rb
@@ -129,7 +129,7 @@ class Console::CommandDispatcher::Stdapi::Ui
 	def cmd_screenshot( *args )
 		path    = Rex::Text.rand_text_alpha(8) + ".jpeg"
 		quality = 50
-		view    = true
+		view    = false
 
 		screenshot_opts = Rex::Parser::Arguments.new(
 			"-h" => [ false, "Help Banner." ],


### PR DESCRIPTION
A better fix would have it detect default browsers 
as being text only like lynx. But this has got to
go one way or another. Loosing shell because I forgot
to do -v false is wall punch worthy
