### PR TITLE
added 'from' PID to meterpreter migrate message

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -342,7 +342,8 @@ class Console::CommandDispatcher::Core
 			return
 		end
 
-		print_status("Migrating to #{pid}...")
+		server = client.sys.process.open
+		print_status("Migrating from #{server.pid} to #{pid}...")
 
 		# Do this thang.
 		client.core.migrate(pid)


### PR DESCRIPTION
When executing a migrate from the meterpreter, this changes the "Migrating to {new_pid}..." message to "Migrating from {old_pid} to {new_pid}...".  This feature was requested by Rob Fuller in request #4335 (https://dev.metasploit.com/redmine/issues/4335).
