### PR TITLE
normalize_uri fixes (double slashes and trailing slash)

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -536,15 +536,21 @@ module Exploit::Remote::HttpClient
 	end
 
 	#
-	# Make sure the URI starts with a slash and doesn't end with one
+	# Returns a modified version of the URI that:
+	# 1. Always has a starting slash
+	# 2. Removes all the double slashes
+	# 3. Removes the trailing slash
 	#
 	def normalize_uri(str)
-
+		# Makes sure there's a starting slash
 		unless str.to_s[0,1] == "/"
 			str = "/" + str.to_s
 		end
 
-		str = str.gsub(/^\/+/, '/')
+		# Removes all double slashes
+		str = str.gsub!("//", "/") while str.index("//")
+
+		# Makes sure there's no trailing slash
 		unless str.length == 1
 			str = str.gsub(/\/+$/, '')
 		end

--- a/modules/auxiliary/admin/cisco/cisco_secure_acs_bypass.rb
+++ b/modules/auxiliary/admin/cisco/cisco_secure_acs_bypass.rb
@@ -75,6 +75,7 @@ class Metasploit4 < Msf::Auxiliary
 
 		begin
 			uri = normalize_uri(target_uri.path)
+			uri << '/' if uri[-1,1] != '/'
 			res = send_request_cgi({
 				'uri'     => uri,
 				'method'  => 'POST',

--- a/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
+++ b/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
@@ -55,9 +55,17 @@ class Metasploit3 < Msf::Auxiliary
 
 	# Call the User site, so the db statement will be cached
 	def cache_user_info(user_id)
-		user_url = normalize_uri("/#{wordpress_url}?author=#{user_id}")
+		user_url = normalize_uri(wordpress_url)
 		begin
-			send_request_cgi({ "uri" => user_url, "method" => "GET" })
+			send_request_cgi(
+				{
+					"uri"      => user_url,
+					"method"   => "GET",
+					"vars_get" => {
+						"author" => user_id
+					}
+				})
+
 		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
 			vprint_error("Unable to connect to #{url}")
 			return nil
@@ -83,7 +91,8 @@ class Metasploit3 < Msf::Auxiliary
 				key="w3tc_#{host}_#{site_id}_sql_#{query_md5}"
 				key_md5 = ::Rex::Text.md5(key)
 				hash_path = "/#{key_md5[0,1]}/#{key_md5[1,1]}/#{key_md5[2,1]}/#{key_md5}"
-				url = normalize_uri("/#{wordpress_url}#{datastore["WP_CONTENT_DIR"]}/w3tc/dbcache#{hash_path}")
+				url = normalize_uri("/#{wordpress_url}#{datastore["WP_CONTENT_DIR"]}/w3tc/dbcache")
+				uri << hash_path
 
 				result = nil
 				begin

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Auxiliary
 		headers['Content-Type'] = ctype if ctype != nil
 		headers['Content-Length'] = data.length if data != nil
 
-		uri = normalize_uri(target_uri)
+		uri = normalize_uri(target_uri.path)
 		res = send_request_raw({
 			'uri'	  => "#{uri}#{path}",
 			'method'  => method,

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -218,7 +218,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		#Get GlassFish version
 		edition, version, banner = get_version(res)
-		path = normalize_uri(datastore['PATH'])
+		path = normalize_uri(target_uri)
 		target_url = "http://#{rhost.to_s}:#{rport.to_s}/#{path.to_s}"
 		print_status("#{target_url} - GlassFish - Attempting authentication")
 

--- a/modules/auxiliary/scanner/http/vcms_login.rb
+++ b/modules/auxiliary/scanner/http/vcms_login.rb
@@ -89,7 +89,7 @@ class Metasploit3 < Msf::Auxiliary
 				return :skip_user
 			when /Invalid password/
 				vprint_status("#{@peer} - Username found: #{user}")
-			else /\<a href="process.php\?logout=1"\>/
+			else /\<a href="process\.php\?logout=1"\>/
 				print_good("#{@peer} - Successful login: \"#{user}:#{pass}\"")
 				report_auth_info({
 					:host        => rhost,

--- a/modules/exploits/linux/http/dolibarr_cmd_exec.rb
+++ b/modules/exploits/linux/http/dolibarr_cmd_exec.rb
@@ -61,6 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		uri = normalize_uri(target_uri.path)
+		uri << '/' if uri[-1,1] != '/'
 		res = send_request_raw({
 			'method' => 'GET',
 			'uri'    => uri

--- a/modules/exploits/linux/http/vcms_upload.rb
+++ b/modules/exploits/linux/http/vcms_upload.rb
@@ -63,6 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		uri = normalize_uri(target_uri.path)
+		uri << '/' if uri[-1,1] != '/'
 		res = send_request_raw({
 			'uri'   => uri,
 			'method' => 'GET'

--- a/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
+++ b/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
@@ -73,6 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 		tmp_rport = datastore['RPORT']
 		uri = normalize_uri(target_uri.host)
+		uri << '/' if uri[-1,1] != '/'
 		datastore['RPORT'] = datastore['HTTPPORT']
 		res = send_request_raw({'uri'=>uri})
 		datastore['RPORT'] = tmp_rport


### PR DESCRIPTION
This pull request fixes mainly two issues:
1. One of the intended behaviors for normalize_uri() is to eliminate all double slashes, but all it does is it removes the first one.  So this pull request addresses the correct behavior.  I also added more comments to better explain what the function does.
2. Another problem is normalize_uri() removes the trailing slash, but sometimes that slash is actually needed. For example: if a module wants TARGETURI to be a directory, you should NOT strip the trailing slash.  If you do, you may end up getting a 301 or 404 instead of 200 (expected output).  This pull request only modifies those that need TARGETURI to be a directory.

Related to the following ticket:
http://dev.metasploit.com/redmine/issues/7727#change-34153
