### PR TITLE
Update modules/exploits/multi/http/rails_json_yaml_code_exec.rb

### DIFF
--- a/modules/exploits/multi/http/rails_json_yaml_code_exec.rb
+++ b/modules/exploits/multi/http/rails_json_yaml_code_exec.rb
@@ -10,7 +10,6 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
 	Rank = ExcellentRanking
 
-	include Msf::Exploit::CmdStagerTFTP
 	include Msf::Exploit::Remote::HttpClient
 
 	def initialize(info = {})


### PR DESCRIPTION
Removes unnecessary include.  Tested on 3.0.19 and 2.3.15.
