### PR TITLE
Actually test alternate rubies.

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -226,9 +226,7 @@ class Msftidy
 		puts "Checking syntax for #{f_rel}."
 		rubies ||= RVM.list_strings
 		res = %x{rvm all do ruby -c #{f_rel}}.split("\n").select {|msg| msg =~ /Syntax OK/}
-		rubies.size == res.size
-
-		error("Fails alternate Ruby version check") if rubies.size
+		error("Fails alternate Ruby version check") if rubies.size != res.size
 	end
 
 	def check_ranking


### PR DESCRIPTION
Looks like this is used so infrequently that the check wouldn't have worked anyway.

Now, it does.

```
$ MSF_CHECK_OLD_RUBIES=true tools/msftidy.rb modules/auxiliary/scanner/rdp/ms12-020_check.rb
This is going to take a while, depending on the number of Rubies you have installed.
Checking syntax for ms12-020_check.rb.
ms12-020_check.rb:37: syntax error, unexpected ')'
ms12-020_check.rb - [ERROR] Fails alternate Ruby version check

```
