### PR TITLE
rails_xml_yaml_scanner.rb improvements

### DIFF
--- a/modules/auxiliary/scanner/http/rails_xml_yaml_scanner.rb
+++ b/modules/auxiliary/scanner/http/rails_xml_yaml_scanner.rb
@@ -47,18 +47,25 @@ class Metasploit3 < Msf::Auxiliary
 	def run_host(ip)
 
 		res1 = send_probe("string", "hello")
-		res2 = send_probe("yaml", "--- !ruby/object:Time {}\n")
-		res3 = send_probe("yaml", "--- !ruby/object:\x00")
 
 		unless res1
 			vprint_status("#{rhost}:#{rport} No reply to the initial XML request")
 			return
 		end
 
+		if res1.code.to_s =~ /^[5]/
+			vprint_status("#{rhost}:#{rport} The server replied with #{res1.code} for our initial XML request, double check URIPATH")
+			return
+		end
+
+		res2 = send_probe("yaml", "--- !ruby/object:Time {}\n")
+
 		unless res2
 			vprint_status("#{rhost}:#{rport} No reply to the initial YAML probe")
 			return
 		end
+
+		res3 = send_probe("yaml", "--- !ruby/object:\x00")
 
 		unless res3
 			vprint_status("#{rhost}:#{rport} No reply to the second YAML probe")
@@ -67,9 +74,6 @@ class Metasploit3 < Msf::Auxiliary
 
 		vprint_status("Probe response codes: #{res1.code} / #{res2.code} / #{res3.code}")
 
-		if res1.code.to_s =~ /^[5]/
-			vprint_status("#{rhost}:#{rport} The server replied with #{res1.code} for our initial XML request, double check URIPATH")
-		end
 
 		if (res2.code == res1.code) and (res3.code != res2.code) and (res3.code != 200)
 			print_good("#{rhost}:#{rport} is likely vulnerable due to a #{res3.code} reply for invalid YAML")
@@ -82,7 +86,7 @@ class Metasploit3 < Msf::Auxiliary
 				:refs   => self.references
 			})
 		else
-			vprint_status("#{rhost}:#{rport} is not likely to be vulnerable or URIPATH must be set")
+			vprint_status("#{rhost}:#{rport} is not likely to be vulnerable or URIPATH & HTTP_METHOD must be set")
 		end
 	end
 

--- a/modules/auxiliary/scanner/http/rails_xml_yaml_scanner.rb
+++ b/modules/auxiliary/scanner/http/rails_xml_yaml_scanner.rb
@@ -65,11 +65,13 @@ class Metasploit3 < Msf::Auxiliary
 			return
 		end
 
-		if res1.code.to_s =~ /^[45]/
+		vprint_status("Probe response codes: #{res1.code} / #{res2.code} / #{res3.code}")
+
+		if res1.code.to_s =~ /^[5]/
 			vprint_status("#{rhost}:#{rport} The server replied with #{res1.code} for our initial XML request, double check URIPATH")
 		end
 
-		if res2.code.to_s =~ /^[23]/ and res3.code != res2.code and res3.code != 200
+		if (res2.code == res1.code) and (res3.code != res2.code) and (res3.code != 200)
 			print_good("#{rhost}:#{rport} is likely vulnerable due to a #{res3.code} reply for invalid YAML")
 			report_vuln({
 				:host	=> rhost,

--- a/modules/auxiliary/scanner/http/rails_xml_yaml_scanner.rb
+++ b/modules/auxiliary/scanner/http/rails_xml_yaml_scanner.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options([
 			OptString.new('URIPATH', [true, "The URI to test", "/"]),
-			OptString.new('HTTP_METHOD', [ true, 'The HTTP request method (GET, POST, PUT typically work)', "POST"])
+			OptEnum.new('HTTP_METHOD', [true, 'HTTP Method', 'POST', ['GET', 'POST', 'PUT'] ]),
 		], self.class)
 	end
 

--- a/modules/auxiliary/scanner/http/rails_xml_yaml_scanner.rb
+++ b/modules/auxiliary/scanner/http/rails_xml_yaml_scanner.rb
@@ -29,7 +29,8 @@ class Metasploit3 < Msf::Auxiliary
 		))
 
 		register_options([
-			OptString.new('URIPATH', [true, "The URI to test", "/"])
+			OptString.new('URIPATH', [true, "The URI to test", "/"]),
+			OptString.new('HTTP_METHOD', [ true, 'The HTTP request method (GET, POST, PUT typically work)', "POST"])
 		], self.class)
 	end
 
@@ -37,7 +38,7 @@ class Metasploit3 < Msf::Auxiliary
 		odata = %Q^<?xml version="1.0" encoding="UTF-8"?>\n<probe type="#{ptype}"><![CDATA[\n#{pdata}\n]]></probe>^
 		res = send_request_cgi({
 			'uri'    => datastore['URIPATH'] || "/",
-			'method' => 'POST',
+			'method' => datastore['HTTP_METHOD'],
 			'ctype'  => 'application/xml',
 			'data'   => odata
 		}, 25)

--- a/modules/auxiliary/scanner/http/rails_xml_yaml_scanner.rb
+++ b/modules/auxiliary/scanner/http/rails_xml_yaml_scanner.rb
@@ -19,7 +19,10 @@ class Metasploit3 < Msf::Auxiliary
 				This module attempts to identify Ruby on Rails instances vulnerable to
 				an arbitrary object instantiation flaw in the XML request processor.
 			},
-			'Author'      => 'hdm',
+			'Author'      => [
+					  'hdm', #author
+					  'jjarmoc' #improvements
+					  ],
 			'License'     => MSF_LICENSE,
 			'References'  =>
 				[


### PR DESCRIPTION
Some adjustments to HD's scanner for CVE-2013-0156.
- Allows scanning of URIPATH's that return 404 or other 4xx, so long as they're processed by rails on the backend.
- Re-ordered logic to send less traffic in failure conditions (speeds scanning large subnets)
- Makes HTTP_METHOD configurable (PUT and GET are valid in addition to POST.)

I've tested this thoroughly, especially the 4xx response code changes which are the most significant.  Results appear correct on the following versions of rails;
- 3.2.10 (vulnerable)
- 3.2.11 (not vulnerable)
- 3.1.9 (vulnerable)
- 3.1.10 (not vulnerable)
- 3.0.18 (vulnerable)
- 3.0.19 (not vulnerable)

I've tested on URIPATH's that return both 200 and 404 on each of those versions.

Have _not_ tested on 2.x versions, or when running w/ Ruby 1.8.
