### PR TITLE
added SIP Testing Modules with a SIP Library

### DIFF
--- a/lib/sipsocket.rb
+++ b/lib/sipsocket.rb
@@ -1,0 +1,458 @@
+# -*- coding: binary -*-
+# $Id: gsiplib.rb 15548 2012-06-29 06:08:20Z rapid7 $
+#Gamasec SIP Library
+#Author : Fatih Ozavci - gamasec.net/fozavci
+#Github : github.com/fozavci/gamasec-sipmodules
+
+require 'rex/socket'
+require 'timeout'
+
+module SIP
+
+#
+#
+#
+#SIP Socket Class
+#
+#
+#
+
+class Socket
+	attr_accessor :listen_addr, :listen_port, :context
+	attr_accessor :sock, :thread, :dest_addr, :dest_port
+	
+	def initialize(listen_port = 5060, listen_addr = '0.0.0.0', dest_port = 5060, dest_addr = nil, context = {})
+        
+		self.listen_addr = listen_addr
+		self.listen_port = listen_port
+		if dest_addr == nil 
+			raise ::Rex::ArgumentError, 'Destination IP Address Required'
+		else
+			self.dest_addr = dest_addr
+		end
+		self.dest_port = dest_port
+        self.context = context
+		self.sock = nil	
+        start	
+	end
+    
+	#
+	# Start the SIPSocket 
+	#    
+	def start
+		self.sock = Rex::Socket::Udp.create(
+			'LocalHost' => listen_addr,
+			'LocalPort' => listen_port,
+			'Context'   => context
+			)
+	end
+
+
+	#
+	# Stop the SIPSocket 
+	#
+	def stop
+		self.thread.kill
+		self.sock.close rescue nil # might be closed already
+	end
+
+	#
+	#Converting Errors to Message
+	#
+	def convert_error(err)
+		case err
+			when :cred_required
+				return "Credentials Required"
+			when :no_response
+				return "No Response"
+			when :succeed_withoutlogin
+				return "Request Succeed without Login Information"			
+            when :ringing
+				return "Ringing"
+            when :user_busy
+				return "User is Busy"
+            when :succeed
+				return "Request Succeed"
+			when :failed
+				return "Authentication Failed"
+			when :send_error
+				return "Request Sending is Failed"
+			when :server_error
+				return "Internal Server Error"
+			when :nodigest
+				return "No Digest Found in '401 Unauthorized' Response"
+			when :authorization_error
+				return "Authorization Error"
+			when :decline_error
+				return "Server Declined"
+			when :protocol_error
+				return "Protocol Error"
+		else
+			return "Unknown Error #{err}"
+		end	
+	end
+	
+	#
+	# Sending Register
+	# 
+    def register(req_options={})        
+	    login = req_options["login"] || false
+	    result,rdata,rdebug,rawdata,callopts=generic_request("REGISTER",req_options)
+	    if :received and rdata != nil
+		    case rdata['resp']
+			    when "200"
+				    result=:succeed_withoutlogin
+			    when "401"
+				    if login
+					    result,rdata,rdebug,rawdata,callopts=auth("REGISTER",rdata,rdebug,rawdata,req_options,callopts)
+				    else
+					    result=:cred_required
+				    end
+			    when /^60/
+				    result=:decline_error
+			    else
+				    result=:protocol_error
+		    end
+	    end
+	    return result,rdata,rdebug,rawdata,callopts
+    end
+	
+	#
+	# Sending Options
+	#    
+    def send_options(req_options={})        
+        return generic_request("OPTIONS",req_options)
+    end
+	
+	#
+	# Sending Subscribe
+	#    
+    def send_subscribe(req_options={})
+	    return generic_request("SUBSCRIBE",req_options)
+    end		
+
+	#
+	# Sending ACK
+	#    
+    def send_ack(req_options={})
+	    return generic_request("ACK",req_options,no_response=true)
+    end		
+
+  	#
+	# Sending Invite
+	#    
+    def send_invite(req_options={})
+        login = req_options["login"] || false
+        loginmethod = req_options["loginmethod"] || "INVITE"
+
+        if login and loginmethod == "REGISTER"
+            #From and TO fields should be same for REGISTER
+            regopts=req_options.clone
+            regopts['from']=regopts['user']
+            regopts['to']=regopts['user']
+            reg_result,rdata,rdebug,rawdata,callopts=register(regopts)
+
+            req_options['callopts']=callopts if callopts != nil
+
+            # Cleaning Old Session Data
+            req_options['nonce'] = nil
+            req_options['callopts'].delete('seq')
+            req_options['callopts'].delete('callid')
+            req_options['callopts'].delete('tag')
+        end
+        
+
+
+        result,rdata,rdebug,rawdata,callopts=generic_request("INVITE",req_options)
+
+
+        if :received and rdata != nil 
+            result = parse_rescode(rdata)
+            case result
+            when :cred_required
+                if login
+                    ack_options=req_options.clone
+                    ack_options['callopts']=callopts.clone
+                    ack_options['callopts'].delete('seq')
+                    send_ack(ack_options)
+                    
+                    result,rdata,rdebug,rawdata,callopts=auth("INVITE",rdata,rdebug,rawdata,req_options,callopts) 
+                    if :received and rdata != nil 
+                        result = parse_rescode(rdata)
+                    else
+                        result = :protocol_error
+                    end
+                end
+            when :succeed
+                result = :succeed_withoutlogin if reg_result != :succeed and result == :succeed            
+    	    else
+		        result = :protocol_error
+            end
+	    end
+        return result,rdata,rdebug,rawdata,callopts
+    end			
+
+protected
+
+
+	#
+	#Result Code Parsing
+	#
+    def parse_rescode(rdata)
+	    case rdata['resp']
+	    when "200"
+		    result=:succeed
+	    when "180"
+		    result=:ringing
+	    when "401"
+		    result=:cred_required			    
+	    when "486"
+		    result=:user_busy	
+	    when /^60/
+		    result=:decline_error
+	    when /^50/
+		    result=:server_error
+	    else
+		    result=:protocol_error
+	    end
+    end
+
+
+	#
+	#Generic SIP Request Sending
+	#	
+	def generic_request(method,req_options={},no_response=false)
+		callopts,send_state=send_data(method,req_options)
+        return nil if no_response
+		return :send_error if send_state == :error
+    
+        rdata,rdebug,rawdata=resp_get(method)		
+		if rdata == nil 
+			return :no_response
+		else
+			return :received,rdata,rdebug,rawdata,callopts
+        end
+    end
+	
+	
+	#
+	#Authentication
+	#
+	def auth(method,rdata,rdebug,rawdata,req_options,callopts=nil)
+		if rdata['digest']
+			req_options['nonce']=rdata['digest']['nonce']
+			req_options['digest_realm']=rdata['digest']['realm']
+			req_options['callopts']=callopts if callopts != nil
+
+			#Sending Request with Nonce
+			callopts,send_state=send_data(method,req_options)
+			return :send_error,rdata,rdebug,rawdata,callopts if send_state == :error
+			
+			#Receiving Authentication Response
+			rdata,rdebug,rawdata=resp_get(method,rdebug)		
+			return :no_response,rdata,rdebug,rawdata,callopts if rdata == nil
+			
+			case rdata['resp']
+				when "200"
+					return :succeed,rdata,rdebug,rawdata,callopts
+				when "/^48/"
+					return :succeed,rdata,rdebug,rawdata,callopts
+				when "/^18/"
+					return :succeed,rdata,rdebug,rawdata,callopts
+				when /^401/
+					return :failed,rdata,rdebug,rawdata,callopts
+				else
+					return :authorization_error,rdata,rdebug,rawdata,callopts
+			end
+		else
+			return :nodigest,rdata,rdebug,rawdata,callopts
+		end
+	end
+	
+	#
+	# Receiving Data
+	#    
+	def recv_data
+            r = self.sock.recvfrom(65535, 3)
+            rdata,rawdata=parse_reply(r)
+            return rdata,rawdata
+    end
+	
+	#Response Check
+	def resp_get(method,rdebug=[])
+        possible= /^18|^20|^40|^48|^60|^50/
+        rdata,rawdata=recv_data
+		while (rdata != nil and !(rdata['resp'] =~ possible))			
+			rdebug << rdata
+			rdata,rawdata=recv_data
+			break if rdebug.length > 9
+		end		
+		return rdata,rdebug,rawdata
+	end
+		
+ 	#
+	# Nonce Calculation
+	#
+	def	nonce_resp(user,realm,password,nonce,uri,req_type)
+		hash1 = Digest::MD5.hexdigest("#{user}:#{realm}:#{password}")
+        hash2 = Digest::MD5.hexdigest("#{req_type}:#{uri}")
+        response=Digest::MD5.hexdigest("#{hash1}:#{nonce}:#{hash2}")
+	end
+
+      
+	#
+	# Sending Data
+	#    
+    def send_data(req_type,req_options)
+        data,callopts = create_req(req_type,req_options)
+        begin
+          self.sock.sendto(data, dest_addr, dest_port, 0)
+            send_state=:success
+        rescue ::Interrupt
+            send_state=:error
+            raise $!
+        rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionRefused
+            send_state=:error
+          nil
+        end
+        return callopts,send_state
+    end
+
+
+    #
+	# Prepare Request
+	#    
+    def create_req(req_type,req_options)
+        realm=req_options['realm'] || dest_addr
+        user=req_options['user'] 
+        from=req_options['from']  || user
+        fromname=req_options['fromname']  || nil
+        to=req_options['to'] || user           
+        password=req_options['password'] || nil
+        nonce=req_options['nonce'] || nil 
+        callopts=req_options['callopts'] || {}
+        seq=callopts['seq'].to_i+1 || seq=1
+        callid=callopts['callid'] || callid="call#{Rex::Text.rand_text_alphanumeric(30)}"
+        tag=callopts['tag'] || tag="tag#{Rex::Text.rand_text_alphanumeric(20)}"
+        branch=callopts['branch'] || branch="branch#{Rex::Text.rand_text_alphanumeric(50)}"
+        
+		case req_type 
+        when 'SUBSCRIBE' 
+			uri="sip:#{user}@#{realm}"
+        when 'INVITE'
+            uri="sip:#{to}@#{realm}"
+		else
+			uri="sip:#{realm}"
+		end
+
+        data = "#{req_type} #{uri} SIP/2.0\r\n"
+        data << "Via: SIP/2.0/UDP #{listen_addr}:#{listen_port};branch=#{branch};rport\r\n" 
+        data << "Max-Forwards: 20\r\n"
+        data << "To: <sip:#{to}@#{realm}>\r\n"
+        data << "From: \"#{fromname}\" <sip:#{from}@#{realm}>;tag=#{tag}\r\n"
+        data << "Call-ID: #{callid}@#{listen_addr}\r\n"
+        data << "CSeq: #{seq} #{req_type}\r\n"
+        data << "Contact: <sip:#{from}@#{listen_addr}:#{listen_port}>\r\n"
+        data << "User-Agent: Test Agent\r\n"
+        data << "Supported: 100rel,replaces\r\n"       
+        data << "Allow: INVITE,ACK,OPTIONS,BYE,CANCEL,SUBSCRIBE,NOTIFY,REFER,MESSAGE,INFO,PING,PRACK\r\n"
+        data << "Expires: 3600\r\n"
+		
+        if req_options['headers']
+	        req_options['headers'].split("|||").each { |h|
+		        data << "#{h}\r\n"
+	        }
+        end
+
+        if req_type == 'SUBSCRIBE'
+	        data << "Event: message-summary\r\n"
+	        data << "Accept: application/simple-message-summary\r\n"
+        end
+
+        if nonce !=nil
+            resp=nonce_resp(user,req_options['digest_realm'],password,nonce,uri,req_type)
+            data << "Authorization: Digest username=\"#{user}\",realm=\"#{req_options['digest_realm']}\",nonce=\"#{nonce}\",uri=\"#{uri}\",response=\"#{resp}\"\r\n"
+        end
+        
+        if req_type == 'INVITE'
+            sdp_ID=Rex::Text.rand_text_numeric(9)
+            s="Source"
+
+            idata = "v=0\r\n"
+            idata << "o=- #{sdp_ID} #{sdp_ID} IN IP4 #{listen_addr}\r\n"
+            idata << "s=#{s}\r\n"
+            idata << "c=IN IP4 #{listen_addr}\r\n"
+            idata << "t=0 0\r\n"
+            idata << "m=audio 8000 RTP/AVP 0 8 96 3 13 101\r\n"
+            idata << "a=rtpmap:0 PCMU/8000\r\n"
+            idata << "a=rtpmap:8 PCMA/8000\r\n"
+            idata << "a=rtpmap:96 G726-32/8000\r\n"
+            idata << "a=rtpmap:3 GSM/8000\r\n"
+            idata << "a=rtpmap:13 CN/8000\r\n"
+            idata << "a=rtpmap:101 telephone-event/8000\r\n"
+            idata << "a=fmtp:101 0-16\r\n"
+            idata << "a=sendrecv\r\n"
+            idata << "a=direction:active\r\n"
+            idata << "\r\n"
+
+            data << "Content-Type: application/sdp\r\n"
+            data << "Content-Length: #{idata.length}\r\n\r\n"
+            data << idata
+
+        else
+            data << "Content-Length: 0\r\n\r\n"
+        end
+        
+        callopts={ "callid" => callid, "seq" =>seq, "tag" => tag, "branch" => branch }
+        return data,callopts
+    end    
+    
+	#
+	# Parsing Response
+	#  
+	
+	def parse_reply(pkt)
+
+		return if not pkt[1]
+		rdata={}
+		rawdata=pkt[0]
+
+		rdata["source"] = "#{pkt[1].split(":")[3]}:#{pkt[2]}"
+
+		rdata["resp"] = pkt[0].split(/\s+/)[1]
+        rdata["resp_msg"] = pkt[0].split("\r")[0]
+
+
+		if(pkt[0] =~ /^User-Agent:\s*(.*)$/i)
+			rdata["agent"] = "#{$1.strip}"
+		end
+
+		if(pkt[0] =~ /^Allow:\s+(.*)$/i)
+			rdata["verbs"] = "#{$1.strip}"
+		end
+
+		if(pkt[0] =~ /^Server:\s+(.*)$/)
+			rdata["server"] = "#{$1.strip}"
+		end
+
+		if(pkt[0] =~ /^Proxy-Require:\s+(.*)$/)
+			rdata["proxy"] = "#{$1.strip}"
+		end
+		
+		if(pkt[0] =~ /^WWW-Authenticate:\s*(.*)$/i)
+			data="#{$1.strip.gsub("Digest ","")}"
+			rdata["digest"] = {}
+			data.split(",").each { |d| rdata["digest"][d.split("=")[0].gsub(" ","")]=d.split("=")[1].gsub("\"",'')}
+		end
+        if(pkt[0] =~ /^From:\s+(.*)$/)
+			rdata["from"] = "#{$1.strip.split(";")[0].gsub(/[<sip:|>]/,"")}"
+		end
+        if(pkt[0] =~ /^To:\s+(.*)$/)
+			rdata["to"] = "#{$1.strip.split(";")[0].gsub(/[<sip:|>]/,"")}"
+		end
+		return rdata,rawdata
+	end    
+      
+end
+
+end

--- a/modules/auxiliary/scanner/sip/gsipbruteforce.rb
+++ b/modules/auxiliary/scanner/sip/gsipbruteforce.rb
@@ -1,0 +1,154 @@
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+
+require 'msf/core'
+require 'digest/md5'
+require 'sipsocket'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::Scanner
+    include SIP
+	include Msf::Auxiliary::AuthBrute
+
+	def initialize
+		super(
+			'Name'        => 'SIP User and Password Brute Forcer (UDP)',
+			'Version'     => '1',
+			'Description' => 'Brute Force Module for SIP Services',
+			'Author'      => 'Fatih Ozavci <gamasec.net/fozavci>',
+			'License'     => MSF_LICENSE
+		)
+
+		deregister_options('RHOSTS')
+
+		register_options(
+		[
+			OptInt.new('NUMERIC_MIN',   [true, 'Starting extension',0]),
+			OptInt.new('NUMERIC_MAX',   [true, 'Ending extension', 9999]),
+			OptBool.new('NUMERIC_USERS',   [true, 'Numeric Username Bruteforcing', false]),
+		    OptString.new('METHOD',   [ true, "The method for Brute Forcing (REGISTER)", "REGISTER"]),
+			OptString.new('USERNAME',   [ false, "The login username to probe", "NOUSER"]),
+			OptString.new('PASSWORD',   [ false, "The login password to probe", "NOPASSWORD"]),
+			OptString.new('REALM',   [ true, "The login realm to probe", "realm.com.tr"]),
+			OptString.new('TO',   [ false, "The destination username to probe", "1000"]),
+			OptString.new('FROM',   [ false, "The source username to probe", "1000"]),
+			OptBool.new('USER_AS_PASS', [false, 'Try the username as the password for all users', false]),
+			OptBool.new('USER_AS_FROM_and_TO', [true, 'Try the username as the from/to for all users', true]),
+			OptBool.new('DEREGISTER', [true, 'DeRegister After Successful Login', false]),
+			Opt::RHOST,
+			Opt::RPORT(5060),
+			Opt::CHOST,	
+			Opt::CPORT(5065)
+		], self.class)
+
+		register_advanced_options(
+		[
+			OptBool.new('DEBUG',   [ false, "Verbose Level", false]),
+			OptBool.new('VERBOSE',   [ false, "Verbose Level", false])
+		], self.class)
+	end
+
+	def run
+		udp_sock = nil
+
+		realm = datastore['REALM']
+		method = datastore['METHOD']
+		from = datastore['FROM']
+		to = datastore['TO']		
+		listen_addr = datastore['CHOST']
+		listen_port = datastore['CPORT'].to_i 
+		dest_addr =datastore['RHOST']  
+		dest_port = datastore['RPORT'].to_i 
+		
+		sipsocket = SIP::Socket.new(listen_port,listen_addr,dest_port,dest_addr)
+
+		 if datastore['NUMERIC_USERS'] == true
+		    passwords=load_password_vars
+		    exts=(datastore['NUMERIC_MIN']..datastore['NUMERIC_MAX']).to_a
+		    exts.each { |ext|
+		        ext=ext.to_s
+		        from=to=ext if datastore['USER_AS_FROM_and_TO']
+		        passwords.each {|password|
+		            do_login(ext,password,realm,from,to,dest_addr,sipsocket,method)
+		        }
+		        
+		    }       
+		else
+		    each_user_pass { |user, password|
+		        from=to=user if datastore['USER_AS_FROM_and_TO']
+		        do_login(user,password,realm,from,to,dest_addr,sipsocket,method)
+		    }
+		end
+	end
+	def do_login(user,password,realm,from,to,dest_addr,sipsocket,method)
+		vprint_status("Trying username:'#{user}' with password:'#{password}'")
+
+		result,rdata,rdebug,rawdata = sipsocket.register(
+			'login'  	=> true,	
+			'user'     	=> user,
+			'password'	=> password,
+			'realm' 		=> realm,
+			'from'    	=> from,
+			'to'    		=> to
+		)  
+
+		if  result =~ /succeed/ 
+			print_good("user : #{user} \tpassword : #{password} \tresult : #{sipsocket.convert_error(result)}")
+
+			#Saving User to DB
+			report_auth_info(
+				:host	=> dest_addr,
+				:port	=> datastore['RPORT'],
+				:sname	=> 'sip',
+				:user	=> user,
+				:pass	=> password,
+				:proof  => nil,
+				:source_type => "user_supplied",
+				:active => true
+			)
+
+			if datastore['DEREGISTER'] ==true
+				#De-Registering User
+				sipsocket.register(
+				'login'  	=> datastore['LOGIN'],
+				'user'     	=> user,
+				'password'	=> password,
+				'realm'     	=> realm,
+				'from'    	=> from,
+				'to'    	    => to,
+				'expire'    	=> 0
+				) 
+			end 
+		else
+			if rdata !=nil
+				vprint_status("#{rdata["source"]}\t #{sipsocket.convert_error(result)} : #{rdata['resp_msg']}") 
+			else 
+				vprint_status("#{dest_addr}")
+			end
+		end
+
+
+		#Debug
+		if datastore['DEBUG']
+			if rdata !=nil
+				print_debug("#{rdata['source']}\tresponse: #{rdata['resp_msg'].split(" ")[1,5].join(" ")}")
+				print_debug("Server \t: #{rdata['server']}") if rdata['server']
+				print_debug("User-Agent \t: #{rdata['agent']}")	if rdata['agent']
+				print_debug("Realm \t: #{rdata['digest']['realm']}") if rdata['digest']
+			end
+
+			rawdata.split("\n").each { |r| print_debug("Response Details: #{r}") } if rdata != nil
+			rdebug.each { |r| print_debug("Irrelevant Responses :  #{r['resp']} #{r['resp_msg']}") } if rdebug
+		end	
+    end
+end
+

--- a/modules/auxiliary/scanner/sip/gsipenumerator.rb
+++ b/modules/auxiliary/scanner/sip/gsipenumerator.rb
@@ -1,0 +1,145 @@
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+
+require 'msf/core'
+require 'digest/md5'
+require 'sipsocket'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::Scanner
+    include SIP
+	include Msf::Auxiliary::AuthBrute
+
+	def initialize
+		super(
+			'Name'        => 'SIP User Enumerator (UDP)',
+			'Version'     => '1',
+			'Description' => 'Enumeration Module for SIP Services',
+			'Author'      => 'Fatih Ozavci <gamasec.net/fozavci>',
+			'License'     => MSF_LICENSE
+		)
+	
+		deregister_options('RHOSTS','USER_AS_PASS','USERPASS_FILE','PASS_FILE','PASSWORD','BLANK_PASSWORDS')
+
+		register_options(
+		[
+			OptInt.new('NUMERIC_MIN',   [true, 'Starting extension',0]),
+			OptInt.new('NUMERIC_MAX',   [true, 'Ending extension', 9999]),
+			OptBool.new('NUMERIC_USERS',   [true, 'Numeric Username Bruteforcing', false]),
+            OptString.new('METHOD',   [ true, "Method for Brute Force (SUBSCRIBE,REGISTER,INVITE)", "SUBSCRIBE"]),
+			OptString.new('USERNAME',   [ false, "The login username to probe at each host", "NOUSER"]),
+			OptString.new('REALM',   [ true, "The login realm to probe at each host", "realm.com.tr"]),
+			OptString.new('TO',   [ false, "The destination username to probe at each host", "1000"]),
+			OptString.new('FROM',   [ false, "The source username to probe at each host", "1000"]),
+			OptBool.new('USER_AS_FROM_and_TO', [true, 'Try the username as the password for all users', true]),
+			Opt::RHOST,
+			Opt::RPORT(5060),
+			Opt::CHOST,	
+			Opt::CPORT(5065),
+		], self.class)
+		register_advanced_options(
+		[
+			OptBool.new('DEBUG',   [ false, "Verbose Level", false]),
+			OptBool.new('VERBOSE',   [ false, "Verbose Level", false])
+		], self.class)
+	end
+	def run
+		udp_sock = nil
+        if datastore['METHOD'] =~ /[SUBSCRIBE|REGISTER|INVITE]/
+			method = datastore['METHOD']
+		else
+			print_error("Brute Force METHOD must be defined")
+		end
+
+        realm = datastore['REALM']
+        from = datastore['FROM']
+        to = datastore['TO']		
+        listen_addr = datastore['CHOST']
+        listen_port = datastore['CPORT'].to_i 
+        dest_addr =datastore['RHOST']  
+        dest_port = datastore['RPORT'].to_i 
+		
+        sipsocket = SIP::Socket.new(listen_port,listen_addr,dest_port,dest_addr)
+        if datastore['NUMERIC_USERS'] == true
+            exts=(datastore['NUMERIC_MIN']..datastore['NUMERIC_MAX']).to_a
+            exts.each { |ext|
+                ext=ext.to_s
+                from=to=ext if datastore['USER_AS_FROM_and_TO']
+                do_login(ext,realm,from,to,dest_addr,sipsocket,method)
+            }      
+        else
+            
+            each_user_pass { |user, password|
+                from=to=user if datastore['USER_AS_FROM_and_TO']
+                do_login(user,realm,from,to,dest_addr,sipsocket,method)
+            }
+        end
+	end
+	def do_login(user,realm,from,to,dest_addr,sipsocket,method)
+		vprint_status("Trying username:'#{user}'")
+        
+        cred={
+            'login'     => false,	
+            'user'      => user,
+            'password'  => nil,
+            'realm'     => realm,
+            'from'      => from,
+            'to'        => to          
+        }
+
+		case method
+        when "REGISTER"
+		    result,rdata,rdebug,rawdata = sipsocket.register(cred)
+		    possible = /^200/
+        when "SUBSCRIBE"
+		    result,rdata,rdebug,rawdata = sipsocket.send_subscribe(cred)
+		    possible = /^40[0-3]/
+	    #when "OPTIONS"
+		    #result,rdata,rdebug,rawdata = sipsocket.send_options(cred)
+		    #possible = /^40[0-3]/
+        when "INVITE"
+		    result,rdata,rdebug,rawdata = sipsocket.send_invite(cred)
+		    possible = /^40[0-3]/ #/^200/
+		end
+
+		if rdata != nil and rdata['resp'] =~ possible
+            user=rdata['from'].gsub("@#{realm}","").gsub("\"","") if rdata["from"]
+             
+            print_good("User #{user} is Found, Server Response: #{rdata['resp_msg'].split(" ")[1,5].join(" ")}")
+
+            #Saving User to DB
+			report_auth_info(
+				:host	=> dest_addr,
+				:port	=> datastore['RPORT'],
+				:sname	=> 'sip',
+				:user	=> user,
+				:proof  => nil,
+				:source_type => "user_supplied",
+				:active => true
+			)
+
+		else	
+			vprint_status("User #{user} is not found") 
+		end
+
+		#Debug
+		if datastore['DEBUG']
+			print_debug("#{rdata['source']}\tresponse: #{rdata['resp_msg'].split(" ")[1,5].join(" ")}") if rdata !=nil
+			print_debug("---------------------------------Details--------------------------------")	
+			rawdata.split("\n").each { |r| print_debug("#{r}") } if rdata != nil
+			print_debug("-------------------------Irrelevant Responses---------------------------")	
+			rdebug.each { |r| print_debug("#{r['resp']} #{r['resp_msg']}") } if rdebug
+		end
+			
+    end
+end
+

--- a/modules/auxiliary/scanner/sip/gsipinvite.rb
+++ b/modules/auxiliary/scanner/sip/gsipinvite.rb
@@ -1,0 +1,123 @@
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+
+require 'msf/core'
+require 'digest/md5'
+require 'sipsocket'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::Scanner
+	include SIP
+	include Msf::Auxiliary::AuthBrute
+
+	def initialize
+		super(
+			'Name'        => 'SIP Invite Tester (UDP)',
+			'Version'     => '1',
+			'Description' => 'Invite Testing Module for SIP Services',
+			'Author'      => 'Fatih Ozavci <gamasec.net/fozavci>',
+			'License'     => MSF_LICENSE
+		)
+	
+		deregister_options('RHOSTS','USER_AS_PASS','USERPASS_FILE','PASS_FILE','PASSWORD','BLANK_PASSWORDS')
+
+		register_options(
+		[
+			OptInt.new('NUMERIC_MIN',   [true, 'Starting extension',0]),
+			OptInt.new('NUMERIC_MAX',   [true, 'Ending extension', 9999]),
+			OptBool.new('NUMERIC_USERS',   [true, 'Numeric Username Bruteforcing', false]),
+			OptBool.new('DOS_MODE',   [true, 'Denial of Service Mode', false]),
+ 			OptString.new('USERNAME',   [ true, "The login username to probe at each host", "NOUSER"]),
+			OptString.new('PASSWORD',   [ true, "The login password to probe at each host", "password"]),
+			OptString.new('REALM',   [ true, "The login realm to probe at each host", "realm.com.tr"]),
+			OptString.new('TO',   [ true, "The destination number to probe at each host", "1000"]),
+			OptString.new('FROM',   [ true, "The source number to probe at each host", "1000"]),
+			OptString.new('FROMNAME',   [ false, "Custom Name for Invite Spoofing", nil]),
+			OptBool.new('TO_as_FROM', [true, 'Try the to field as the from field for all users', false]),
+			OptBool.new('LOGIN', [false, 'Login Before Sending Invite', false]),
+			OptString.new('LOGINMETHOD', [false, 'Login Method (REGISTER | INVITE)', "INVITE"]),
+			Opt::RHOST,
+			Opt::RPORT(5060),
+			Opt::CHOST,	
+			Opt::CPORT(5065)
+		], self.class)
+
+		register_advanced_options(
+		[
+			OptBool.new('DEBUG',   [ false, "Verbose Level", false]),
+			OptBool.new('VERBOSE',   [ false, "Verbose Level", false])
+		], self.class)
+	end
+
+	def run
+	    udp_sock = nil
+
+	    # Login Parameters
+	    user = datastore['USERNAME']
+	    password = datastore['PASSWORD']	
+	    realm = datastore['REALM']
+	    from = datastore['FROM']
+	    fromname = datastore['FROMNAME'] || nil
+	    to = datastore['TO']
+	    login = datastore['LOGIN']
+	    logintype = datastore['LOGINTYPE']
+	    listen_addr = datastore['CHOST']
+	    listen_port = datastore['CPORT'].to_i 
+	    dest_addr =datastore['RHOST']  
+	    dest_port = datastore['RPORT'].to_i 
+			
+        sipsocket = SIP::Socket.new(listen_port,listen_addr,dest_port,dest_addr)
+
+        if datastore['DOS_MODE']
+		    if datastore['NUMERIC_USERS']
+		      tos=(datastore['NUMERIC_MIN']..datastore['NUMERIC_MAX']).to_a
+		    else
+		      tos=load_user_vars
+		    end
+        else
+            tos=[to]
+        end
+
+        tos.each do |to|
+            to.to_s
+            from=to if datastore['TO_as_FROM']
+
+            result,rdata,rdebug,rawdata,callopts = sipsocket.send_invite(
+                'login'  	    => login,	
+                'loginmethod'  	=> datastore['LOGINMETHOD']	,
+                'user'     	    => user,
+                'password'	    => password,
+                'realm' 	    => realm,
+                'from'    	    => from,
+                'fromname'      => fromname,
+                'to'    	    => to,
+            )  
+
+            if rdata != nil and rdata['resp'] =~ /^18|^20|^48/ and rawdata.to_s =~ /#{callopts["tag"]}/
+                to=rdata['to'].gsub("@#{realm}","") if rdata["to"]	
+                print_good("Call: #{from} ==> #{to} is Ringing, Server Response: #{rdata['resp_msg'].split(" ")[1,5].join(" ")}")
+            else
+                print_status("Call: #{from} ==> #{to} is Failed")
+                print_status("Server Response: #{rdata['resp_msg'].split(" ")[1,5].join(" ")}") if rdata != nil
+            end
+                      
+            #Debug
+            if datastore['DEBUG']
+                print_debug("---------------------------------Details--------------------------------")	
+                rawdata.split("\n").each { |r| print_debug("#{r}") } if rdata != nil
+                print_debug("-------------------------Irrelevant Responses---------------------------")	
+                rdebug.each { |r| print_debug("#{r['resp']} #{r['resp_msg']}") } if rdebug
+            end
+        end
+    end
+end
+

--- a/modules/auxiliary/scanner/sip/gsipoptions.rb
+++ b/modules/auxiliary/scanner/sip/gsipoptions.rb
@@ -1,0 +1,107 @@
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+
+require 'msf/core'
+require 'digest/md5'
+require 'sipsocket'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::Scanner
+    include SIP
+
+	def initialize
+		super(
+			'Name'        => 'SIP Options Discovery (UDP)',
+			'Version'     => '1',
+			'Description' => 'Options Discovery Module for SIP Services',
+			'Author'      => 'Fatih Ozavci <gamasec.net/fozavci>',
+			'License'     => MSF_LICENSE
+		)
+	
+		register_options(
+		[
+			OptString.new('REALM',   [ true, "The login realm to probe at each host", "realm.com.tr"]),
+			OptString.new('TO',   [ true, "The destination username to probe at each host", "100"]),
+			OptString.new('FROM',   [ true, "The source username to probe at each host", "100"]),
+			Opt::RPORT(5060),
+			Opt::CHOST,	
+			Opt::CPORT(5065)
+		], self.class)
+
+		register_advanced_options(
+		[
+			OptBool.new('DEBUG',   [ false, "Verbose Level", false]),
+			OptBool.new('VERBOSE',   [ false, "Verbose Level", false])
+		], self.class)
+	end
+
+    
+	def run_host(dest_addr)
+
+		udp_sock = nil
+
+		realm = datastore['REALM']
+		from = datastore['FROM']
+		to = datastore['TO']
+		listen_addr = datastore['CHOST']
+		listen_port = datastore['CPORT'].to_i 
+		dest_port = datastore['RPORT'].to_i 
+
+
+
+		sipsocket = SIP::Socket.new(listen_port,listen_addr,dest_port,dest_addr)
+
+		result,rdata,rdebug,rawdata = sipsocket.send_options(
+			'realm'		=> realm,
+			'from'    	=> from,
+			'to'    		=> to
+		)  
+
+		case result
+		when :received
+			print_good("#{rdata['source']}\tResponse: #{rdata['resp_msg'].split(" ")[1,5].join(" ")}")
+			print_good("Server \t: #{rdata['server']}") if rdata['server']
+			print_good("User-Agent \t: #{rdata['agent']}")	if rdata['agent']
+
+			#Debug
+			if datastore['DEBUG'] == true
+				rdebug.each do |r| print_status("debug: #{r['resp']} #{r['resp_msg']}") end
+				rawdata.split("\n").each do |r| print_status("debug: #{r}") end
+			end
+
+			report_auth_info(
+				:host	=> dest_addr,
+				:port	=> datastore['RPORT'],
+				:sname	=> 'sip',
+				:proof  => nil,
+				:source_type => "user_supplied",
+				:active => true
+			)
+		else
+			vprint_status("#{dest_addr}:#{dest_port} : #{sipsocket.convert_error(result)}")
+		end
+
+		#Debug
+		if datastore['DEBUG'] == true
+			if rdata !=nil
+				print_debug("#{rdata['source']}\tresponse: #{rdata['resp_msg'].split(" ")[1,5].join(" ")}")
+				print_debug("Server \t: #{rdata['server']}") if rdata['server']
+				print_debug("User-Agent \t: #{rdata['agent']}")	if rdata['agent']
+				print_debug("Realm \t: #{rdata['digest']['realm']}") if rdata['digest']
+			end
+
+			rawdata.split("\n").each { |r| print_debug("Response Details: #{r}") } if rdata != nil
+			rdebug.each { |r| print_debug("Irrelevant Responses :  #{r['resp']} #{r['resp_msg']}") } if rdebug
+		end	
+    end
+end
+

--- a/modules/auxiliary/scanner/sip/gsipregister.rb
+++ b/modules/auxiliary/scanner/sip/gsipregister.rb
@@ -1,0 +1,136 @@
+##
+
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+
+require 'msf/core'
+require 'digest/md5'
+require 'sipsocket'
+
+class Metasploit3 < Msf::Auxiliary
+
+    include Msf::Auxiliary::Report
+    include Msf::Auxiliary::Scanner
+    include SIP
+
+	def initialize
+		super(
+			'Name'        => 'SIP Register Discovery (UDP)',
+			'Version'     => '1',
+			'Description' => 'Register Discovery Module for SIP Services',
+			'Author'      => 'Fatih Ozavci <gamasec.net/fozavci>',
+			'License'     => MSF_LICENSE
+		)
+
+		register_options(
+		[
+			OptString.new('USERNAME',   [ true, "The login username to probe at each host", "NOUSER"]),
+			OptString.new('PASSWORD',   [ true, "The login password to probe at each host", "NOPASSWORD"]),
+			OptString.new('REALM',   [ true, "The login realm to probe at each host", "realm.com.tr"]),
+			OptString.new('TO',   [ false, "The destination username to probe at each host", "1000"]),
+			OptString.new('FROM',   [ false, "The source username to probe at each host", "1000"]),
+			OptBool.new('USER_AS_FROM_and_TO', [false, 'Use the Username for From and To fields', true]),
+			OptBool.new('LOGIN', [true, 'Login Using Credentials', false]),
+			OptBool.new('DEREGISTER', [true, 'DeRegister After Successful Login', false]),
+			Opt::RPORT(5060),
+			Opt::CHOST,	
+			Opt::CPORT(5065)
+		], self.class)
+
+		register_advanced_options(
+		[
+			OptBool.new('DEBUG',   [ false, "Verbose Level", false]),
+			OptBool.new('VERBOSE',   [ false, "Verbose Level", false])
+		], self.class)
+	end
+	
+	def run_host(dest_addr)
+		udp_sock = nil
+
+        # Login Parameters
+	    user = datastore['USERNAME']
+	    password = datastore['PASSWORD']	
+		realm = datastore['REALM']
+		if datastore['USER_AS_FROM_and_TO']
+			from = user
+			to = user
+		else
+			from = datastore['FROM']
+			to = datastore['TO']			
+		end
+		listen_addr = datastore['CHOST']
+		listen_port = datastore['CPORT'].to_i 
+		dest_port = datastore['RPORT'].to_i 
+		
+        sipsocket = SIP::Socket.new(listen_port,listen_addr,dest_port,dest_addr)
+        
+		result,rdata,rdebug,rawdata = sipsocket.register(
+            'login'  	=> datastore['LOGIN'],	
+            'user'     	=> user,
+            'password'	=> password,
+            'realm'		=> realm,
+            'from'    	=> from,
+            'to'    	=> to
+        )  
+
+        
+		if  result =~ /succeed/ and rdata !=nil
+			if result =~ /without/      
+				user="User=NULL,FROM=#{from},TO=#{to}"               
+				password=nil
+			end
+        
+			report_auth_info(
+				:host	=> dest_addr,
+				:port	=> datastore['RPORT'],
+				:sname	=> 'sip',
+				:user	=> user,
+				:pass	=> password,
+				:proof  => nil,
+				:source_type => "user_supplied",
+				:active => true
+			)
+             
+            if datastore['DEREGISTER'] ==true
+                #De-Registering User
+                sipsocket.register(
+                'login'  	=> datastore['LOGIN'],
+                'user'     	=> user,
+                'password'	=> password,
+                'realm'     	=> realm,
+                'from'    	=> from,
+                'to'    	    => to,
+                'expire'    	=> 0
+                ) 
+            end 
+
+            print_good("#{rdata['source']}\tResponse: #{rdata['resp_msg'].split(" ")[1,5].join(" ")}")
+            print_good("Credentials : User => #{user} , Password => #{password}") if !(result =~ /without/)
+            print_good("Server \t: #{rdata['server']}") if rdata['server']
+            print_good("User-Agent \t: #{rdata['agent']}")	if rdata['agent']
+            print_good("Realm \t: #{rdata['digest']['realm']}") if rdata['digest']
+		else
+            if rdata !=nil
+                print_good("#{rdata["source"]}\t #{sipsocket.convert_error(result)} : #{rdata['resp_msg']}") 
+                print_good("Server \t: #{rdata['server']}") if rdata['server']
+                print_good("User-Agent \t: #{rdata['agent']}")	if rdata['agent']
+                print_good("Realm \t: #{rdata['digest']['realm']}") if rdata['digest']
+            else 
+                vprint_status("#{dest_addr}")
+            end
+        end
+		
+		#Debug
+		if datastore['DEBUG'] == true
+			rawdata.split("\n").each { |r| print_debug("Response Details: #{r}") }
+			rdebug.each { |r| print_debug("Irrelevant Responses :  #{r['resp']} #{r['resp_msg']}") }
+		end	
+
+    end
+end
+


### PR DESCRIPTION
I developed a SIP library with 5 demo modules for easy SIP module development.
github.com/fozavci/gamasec-sipmodules repo includes a few basic usage.
VulnVoIP (it's a vulnerable SIP server distribution) could be used to test sample modules.
SIP Library has many SIP features, but I'll plan to extend it.
I will add custom header support, full invite support, SDP support and 
fuzzing support to library. Also a simple SIP proxy could be developed with it.
