### PR TITLE
Fix bug: TypeError can't convert Fixnum into String

### DIFF
--- a/lib/msf/core/auxiliary/wmapmodule.rb
+++ b/lib/msf/core/auxiliary/wmapmodule.rb
@@ -71,7 +71,7 @@ module Auxiliary::WmapModule
 		else
 			res << datastore['VHOST']
 		end
-		res << ":" + wmap_target_port
+		res << ":" + wmap_target_port.to_s
 		res
 	end
 


### PR DESCRIPTION
wmap_target_port is retrieved from datastore['RPORT'], and that's a Fixnum. But wmap_base_url is treating that like a String, so when a module uses that function, it's doomed.

See:
http://dev.metasploit.com/redmine/issues/7748
