### PR TITLE
Split of enum_dns in to single modules - Reverse Lookup

### DIFF
--- a/modules/auxiliary/gather/dns_reverse_lookup.rb
+++ b/modules/auxiliary/gather/dns_reverse_lookup.rb
@@ -14,9 +14,9 @@ class Metasploit3 < Msf::Auxiliary
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'		   => 'DNS reverse lookup',
+			'Name'		   => 'DNS Reverse Lookup Enumeration Module',
 			'Description'	=> %q{
-					The module performs a reverse rookup against a given IP range.
+					This module performs a reverse rookup against a given IP range.
 			},
 			'Author'		=> [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
 			'License'		=> BSD_LICENSE

--- a/modules/auxiliary/gather/dns_reverse_lookup.rb
+++ b/modules/auxiliary/gather/dns_reverse_lookup.rb
@@ -33,14 +33,21 @@ class Metasploit3 < Msf::Auxiliary
 			[
 				OptInt.new('RETRY', [ false, "Number of times to try to resolve a record if no response is received", 2]),
 				OptInt.new('RETRY_INTERVAL', [ false, "Number of seconds to wait before doing a retry", 2]),
-				OptInt.new('THREADS', [ false, "Number of seconds to wait before doing a retry", 2]),
+				OptInt.new('THREADS', [ true, "Number of seconds to wait before doing a retry", 2]),
 			], self.class)
 	end
 
 	def run
 		@res = Net::DNS::Resolver.new()
-		@res.retry = datastore['RETRY'].to_i
-		@res.retry_interval = datastore['RETRY_INTERVAL'].to_i
+
+		if datastore['RETRY']
+			@res.retry = datastore['RETRY'].to_i
+		end
+
+		if datastore['RETRY_INTERVAL']
+			@res.retry_interval = datastore['RETRY_INTERVAL'].to_i
+		end
+
 		@threadnum = datastore['THREADS'].to_i
 		switchdns() if not datastore['NS'].nil?
 		reverselkp(datastore['RANGE'])
@@ -72,7 +79,6 @@ class Metasploit3 < Msf::Auxiliary
 					rescue ::Rex::ConnectionError
 					rescue ::Exception => e
 						print_error("Error: #{tip}: #{e.message}")
-						elog("Error running against host #{tip}: #{e.message}\n#{e.backtrace.join("\n")}")
 					end
 				end
 			end

--- a/modules/auxiliary/gather/dns_reverse_lookup.rb
+++ b/modules/auxiliary/gather/dns_reverse_lookup.rb
@@ -92,3 +92,4 @@ class Metasploit3 < Msf::Auxiliary
 		@nsinuse = datastore['NS']
 	end
 end
+

--- a/modules/auxiliary/gather/dns_reverse_lookup.rb
+++ b/modules/auxiliary/gather/dns_reverse_lookup.rb
@@ -14,9 +14,9 @@ class Metasploit3 < Msf::Auxiliary
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'		   => 'DNS Reverse Lookup',
+			'Name'		   => 'DNS reverse lookup',
 			'Description'	=> %q{
-					This module performs a Reverse Lookup against a given IP Range.
+					The module performs a reverse rookup against a given IP range.
 			},
 			'Author'		=> [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
 			'License'		=> BSD_LICENSE
@@ -24,16 +24,16 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options(
 			[
-				OptAddressRange.new('RANGE', [true, 'IP Range to perform reverse lookup against.', nil]),
-				OptAddress.new('NS', [ false, "Specify the nameserver to use for queries, otherwise use the system DNS" ]),
+				OptAddressRange.new('RANGE', [true, 'IP range to perform reverse lookup against.', nil]),
+				OptAddress.new('NS', [ false, "Specify the nameserver to use for queries, otherwise use the system DNS." ]),
 
 			], self.class)
 
 		register_advanced_options(
 			[
-				OptInt.new('RETRY', [ false, "Number of times to try to resolve a record if no response is received", 2]),
-				OptInt.new('RETRY_INTERVAL', [ false, "Number of seconds to wait before doing a retry", 2]),
-				OptInt.new('THREADS', [ true, "Number of seconds to wait before doing a retry", 2]),
+				OptInt.new('RETRY', [ false, "Number of tries to resolve a record if no response is received.", 2]),
+				OptInt.new('RETRY_INTERVAL', [ false, "Number of seconds to wait before doing a retry.", 2]),
+				OptInt.new('THREADS', [ true, "Number of seconds to wait before doing a retry.", 2]),
 			], self.class)
 	end
 
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Auxiliary
 
 	#-------------------------------------------------------------------------------
 	def reverselkp(iprange)
-		print_status("Running Reverse Lookup against ip range #{iprange}")
+		print_status("Running reverse lookup against IP range #{iprange}")
 		ar = Rex::Socket::RangeWalker.new(iprange)
 		tl = []
 		while (true)
@@ -93,7 +93,7 @@ class Metasploit3 < Msf::Auxiliary
 
 	#---------------------------------------------------------------------------------
 	def switchdns()
-		print_status("Using DNS Server: #{datastore['NS']}")
+		print_status("Using DNS server: #{datastore['NS']}")
 		@res.nameserver=(datastore['NS'])
 		@nsinuse = datastore['NS']
 	end

--- a/modules/auxiliary/gather/dns_reverse_lookup.rb
+++ b/modules/auxiliary/gather/dns_reverse_lookup.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Auxiliary
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'		   => 'DNS Reverse Lookup Enumeration Module',
+			'Name'		   => 'DNS Reverse Lookup Enumeration',
 			'Description'	=> %q{
 					This module performs a reverse rookup against a given IP range.
 			},

--- a/modules/auxiliary/gather/dns_reverse_lookup.rb
+++ b/modules/auxiliary/gather/dns_reverse_lookup.rb
@@ -1,0 +1,94 @@
+##
+# ## This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require "net/dns/resolver"
+require 'rex'
+
+class Metasploit3 < Msf::Auxiliary
+	include Msf::Auxiliary::Report
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'		   => 'DNS Reverse Lookup',
+			'Description'	=> %q{
+					This module performs a Reverse Lookup against a given IP Range.
+			},
+			'Author'		=> [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
+			'License'		=> BSD_LICENSE
+			))
+
+		register_options(
+			[
+				OptAddressRange.new('RANGE', [true, 'IP Range to perform reverse lookup against.', nil]),
+				OptAddress.new('NS', [ false, "Specify the nameserver to use for queries, otherwise use the system DNS" ]),
+
+			], self.class)
+
+		register_advanced_options(
+			[
+				OptInt.new('RETRY', [ false, "Number of times to try to resolve a record if no response is received", 2]),
+				OptInt.new('RETRY_INTERVAL', [ false, "Number of seconds to wait before doing a retry", 2]),
+				OptInt.new('THREADS', [ false, "Number of seconds to wait before doing a retry", 2]),
+			], self.class)
+	end
+
+	def run
+		@res = Net::DNS::Resolver.new()
+		@res.retry = datastore['RETRY'].to_i
+		@res.retry_interval = datastore['RETRY_INTERVAL'].to_i
+		@threadnum = datastore['THREADS'].to_i
+		switchdns() if not datastore['NS'].nil?
+		reverselkp(datastore['RANGE'])
+	end
+
+	#-------------------------------------------------------------------------------
+	def reverselkp(iprange)
+		print_status("Running Reverse Lookup against ip range #{iprange}")
+		ar = Rex::Socket::RangeWalker.new(iprange)
+		tl = []
+		while (true)
+			# Spawn threads for each host
+			while (tl.length <= @threadnum)
+				ip = ar.next_ip
+				break if not ip
+				tl << framework.threads.spawn("Module(#{self.refname})-#{ip}", false, ip.dup) do |tip|
+					begin
+						query = @res.query(tip)
+						query.each_ptr do |addresstp|
+							print_status("Host Name: #{addresstp} IP Address: #{tip.to_s}")
+
+							report_host(
+							:host => tip.to_s,
+							:name => addresstp
+							)
+						end
+					rescue ::Interrupt
+						raise $!
+					rescue ::Rex::ConnectionError
+					rescue ::Exception => e
+						print_error("Error: #{tip}: #{e.message}")
+						elog("Error running against host #{tip}: #{e.message}\n#{e.backtrace.join("\n")}")
+					end
+				end
+			end
+			# Exit once we run out of hosts
+			if(tl.length == 0)
+				break
+			end
+			tl.first.join
+			tl.delete_if { |t| not t.alive? }
+		end
+	end
+
+	#---------------------------------------------------------------------------------
+	def switchdns()
+		print_status("Using DNS Server: #{datastore['NS']}")
+		@res.nameserver=(datastore['NS'])
+		@nsinuse = datastore['NS']
+	end
+end


### PR DESCRIPTION
Long time ago I got as a request from Jcran while he was still at R7 to split the enum_dns module in to easier to maintain modules and refactor them for better use and reporting of data this is the split of the Reverse Lookup part.
