### PR TITLE
Split of enum_dns in to single modules - Service Record Enumeration

### DIFF
--- a/modules/auxiliary/gather/dns_srv.rb
+++ b/modules/auxiliary/gather/dns_srv.rb
@@ -14,9 +14,9 @@ class Metasploit3 < Msf::Auxiliary
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'		   => 'DNS Reverse Lookup',
+			'Name'		   => 'DNS service record lookup',
 			'Description'	=> %q{
-					The module enumerates common DNS Service Records.
+					The module enumerates common DNS service records.
 			},
 			'Author'		=> [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
 			'License'		=> BSD_LICENSE

--- a/modules/auxiliary/gather/dns_srv.rb
+++ b/modules/auxiliary/gather/dns_srv.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Auxiliary
 		super(update_info(info,
 			'Name'		   => 'DNS Reverse Lookup',
 			'Description'	=> %q{
-					This module enumerates common DNS Service Records.
+					The module enumerates common DNS Service Records.
 			},
 			'Author'		=> [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
 			'License'		=> BSD_LICENSE
@@ -24,14 +24,14 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options(
 			[
-				OptString.new('DOMAIN', [ true, "The target domain name"]),
-				OptBool.new(  'ALL_NS', [ false, "Run against all Nameservers for the given domain",false]),
+				OptString.new('DOMAIN', [ true, "The target domain name."]),
+				OptBool.new(  'ALL_NS', [ false, "Run against all name servers for the given domain.",false]),
 			], self.class)
 
 		register_advanced_options(
 			[
-				OptInt.new('RETRY', [ false, "Number of times to try to resolve a record if no response is received", 3]),
-				OptInt.new('RETRY_INTERVAL', [ false, "Number of seconds to wait before doing a retry", 4]),
+				OptInt.new('RETRY', [ false, "Number of times to try to resolve a record if no response is received.", 3]),
+				OptInt.new('RETRY_INTERVAL', [ false, "Number of seconds to wait before doing a retry.", 4]),
 			], self.class)
 	end
 

--- a/modules/auxiliary/gather/dns_srv.rb
+++ b/modules/auxiliary/gather/dns_srv.rb
@@ -38,8 +38,13 @@ class Metasploit3 < Msf::Auxiliary
 	def run
 		records = []
 		@res = Net::DNS::Resolver.new()
-		@res.retry = datastore['RETRY'].to_i
-		@res.retry_interval = datastore['RETRY_INTERVAL'].to_i
+		if datastore['RETRY']
+			@res.retry = datastore['RETRY'].to_i
+		end
+
+		if datastore['RETRY_INTERVAL']
+			@res.retry_interval = datastore['RETRY_INTERVAL'].to_i
+		end
 
 		print_status("Enumerating SRV Records for #{datastore['DOMAIN']}")
 		records = records + srvqry(datastore['DOMAIN'])

--- a/modules/auxiliary/gather/dns_srv.rb
+++ b/modules/auxiliary/gather/dns_srv.rb
@@ -1,0 +1,221 @@
+##
+# ## This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require "net/dns/resolver"
+require 'rex'
+
+class Metasploit3 < Msf::Auxiliary
+	include Msf::Auxiliary::Report
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'		   => 'DNS Reverse Lookup',
+			'Description'	=> %q{
+					This module enumerates common DNS Service Records.
+			},
+			'Author'		=> [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
+			'License'		=> BSD_LICENSE
+			))
+
+		register_options(
+			[
+				OptString.new('DOMAIN', [ true, "The target domain name"]),
+				OptBool.new(  'ALL_NS', [ false, "Run against all Nameservers for the given domain",false]),
+			], self.class)
+
+		register_advanced_options(
+			[
+				OptInt.new('RETRY', [ false, "Number of times to try to resolve a record if no response is received", 3]),
+				OptInt.new('RETRY_INTERVAL', [ false, "Number of seconds to wait before doing a retry", 4]),
+			], self.class)
+	end
+
+	def run
+		records = []
+		@res = Net::DNS::Resolver.new()
+		@res.retry = datastore['RETRY'].to_i
+		@res.retry_interval = datastore['RETRY_INTERVAL'].to_i
+
+		print_status("Enumerating SRV Records for #{datastore['DOMAIN']}")
+		records = records + srvqry(datastore['DOMAIN'])
+		if datastore["ALL_NS"]
+			get_soa(datastore['DOMAIN']).each do |s|
+				switchdns(s[:address])
+				records = records + srvqry(datastore['DOMAIN'])
+			end
+			get_ns(datastore['DOMAIN']).each do |ns|
+				switchdns(ns[:address])
+				records =records + srvqry(datastore['DOMAIN'])
+			end
+		end
+		records.uniq!
+		records.each do |r|
+			print_good("Host: #{r[:host]} IP: #{r[:address].to_s} Service: #{r[:service]} Protocol: #{r[:proto]} Port: #{r[:port]}")
+			report_service(
+				:host=> r[:address].to_s,
+				:port => r[:port].to_i,
+				:proto => r[:proto],
+				:name => r[:service],
+				:host_name => r[:host]
+			)
+			report_host(
+				:host => r[:address].to_s,
+				:name => r[:host]
+			)
+		end
+
+	end
+	#---------------------------------------------------------------------------------
+	def get_soa(target)
+		results = []
+		query = @res.query(target, "SOA")
+		if (query)
+			(query.answer.select { |i| i.class == Net::DNS::RR::SOA}).each do |rr|
+				if Rex::Socket.dotted_ip?(rr.mname)
+					record = {}
+					record[:host] = rr.mname
+					record[:type] = "SOA"
+					record[:address] = rr.mname
+					results << record
+				else
+					get_ip(rr.mname).each do |ip|
+						record = {}
+						record[:host] = rr.mname.gsub(/\.$/,'')
+						record[:type] = "SOA"
+						record[:address] = ip[:address].to_s
+						results << record
+					end
+				end
+			end
+		end
+		return results
+	end
+	#-------------------------------------------------------------------------------
+	def srvqry(dom)
+		results = []
+		#Most common SRV Records
+		srvrcd = [
+			'_gc._tcp.', '_kerberos._tcp.', '_kerberos._udp.', '_ldap._tcp.',
+			'_test._tcp.', '_sips._tcp.', '_sip._udp.', '_sip._tcp.', '_aix._tcp.',
+			'_aix._tcp.', '_finger._tcp.', '_ftp._tcp.', '_http._tcp.', '_nntp._tcp.',
+			'_telnet._tcp.', '_whois._tcp.', '_h323cs._tcp.', '_h323cs._udp.',
+			'_h323be._tcp.', '_h323be._udp.', '_h323ls._tcp.',
+			'_h323ls._udp.', '_sipinternal._tcp.', '_sipinternaltls._tcp.',
+			'_sip._tls.', '_sipfederationtls._tcp.', '_jabber._tcp.',
+			'_xmpp-server._tcp.', '_xmpp-client._tcp.', '_imap.tcp.',
+			'_certificates._tcp.', '_crls._tcp.', '_pgpkeys._tcp.',
+			'_pgprevokations._tcp.', '_cmp._tcp.', '_svcp._tcp.', '_crl._tcp.',
+			'_ocsp._tcp.', '_PKIXREP._tcp.', '_smtp._tcp.', '_hkp._tcp.',
+			'_hkps._tcp.', '_jabber._udp.','_xmpp-server._udp.', '_xmpp-client._udp.',
+			'_jabber-client._tcp.', '_jabber-client._udp.','_kerberos.tcp.dc._msdcs.',
+			'_ldap._tcp.ForestDNSZones.', '_ldap._tcp.dc._msdcs.', '_ldap._tcp.pdc._msdcs.',
+			'_ldap._tcp.gc._msdcs.','_kerberos._tcp.dc._msdcs.','_kpasswd._tcp.','_kpasswd._udp.'
+		]
+
+		srvrcd.each do |srvt|
+			trg = "#{srvt}#{dom}"
+			begin
+
+				query = @res.query(trg , Net::DNS::SRV)
+				if query
+					query.answer.each do |srv|
+						if Rex::Socket.dotted_ip?(srv.host)
+							record = {}
+							srv_info = srvt.scan(/^_(\S*)\._(tcp|udp)\./)[0]
+							record[:host] = srv.host.gsub(/\.$/,'')
+							record[:type] = "SRV"
+							record[:address] = srv.host
+							record[:srv] = srvt
+							record[:service] = srv_info[0]
+							record[:proto] = srv_info[1]
+							record[:port] = srv.port
+							record[:priority] = srv.priority
+							results << record
+							vprint_status("SRV Record: #{trg} Host: #{srv.host.gsub(/\.$/,'')} IP: #{srv.host} Port: #{srv.port} Priority: #{srv.priority}")
+						else
+							get_ip(srv.host.gsub(/\.$/,'')).each do |ip|
+								record = {}
+								srv_info = srvt.scan(/^_(\S*)\._(tcp|udp)\./)[0]
+								record[:host] = srv.host.gsub(/\.$/,'')
+								record[:type] = "SRV"
+								record[:address] = ip[:address]
+								record[:srv] = srvt
+								record[:service] = srv_info[0]
+								record[:proto] = srv_info[1]
+								record[:port] = srv.port
+								record[:priority] = srv.priority
+								results << record
+								vprint_status("SRV Record: #{trg} Host: #{srv.host} IP: #{ip[:address]} Port: #{srv.port} Priority: #{srv.priority}")
+							end
+						end
+					end
+				end
+			rescue
+			end
+		end
+		return results
+	end
+
+	#---------------------------------------------------------------------------------
+	def get_ip(host)
+		results = []
+		query = @res.search(host, "A")
+		if (query)
+			query.answer.each do |rr|
+				if rr.type == "CNAME"
+					results = results + get_ip(rr.cname)
+				else
+					record = {}
+					record[:host] = host
+					record[:type] = "AAAA"
+					record[:address] = rr.address.to_s
+					results << record
+				end
+			end
+		end
+		query1 = @res.search(host, "AAAA")
+		if (query1)
+			query1.answer.each do |rr|
+				if rr.type == "CNAME"
+					results = results + get_ip(rr.cname)
+				else
+					record = {}
+					record[:host] = host
+					record[:type] = "AAAA"
+					record[:address] = rr.address.to_s
+					results << record
+				end
+			end
+		end
+		return results
+	end
+	#---------------------------------------------------------------------------------
+	def switchdns(ns)
+		vprint_status("Enumerating SRV Records on: #{ns}")
+		@res.nameserver=(ns)
+		@nsinuse = ns
+	end
+
+	#---------------------------------------------------------------------------------
+	def get_ns(target)
+		results = []
+		query = @res.query(target, "NS")
+		if (query)
+			(query.answer.select { |i| i.class == Net::DNS::RR::NS}).each do |rr|
+				get_ip(rr.nsdname).each do |r|
+					record = {}
+					record[:host] = rr.nsdname.gsub(/\.$/,'')
+					record[:type] = "NS"
+					record[:address] = r[:address].to_s
+					results << record
+				end
+			end
+		end
+		return results
+	end
+end

--- a/modules/auxiliary/gather/dns_srv.rb
+++ b/modules/auxiliary/gather/dns_srv.rb
@@ -14,9 +14,9 @@ class Metasploit3 < Msf::Auxiliary
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'		   => 'DNS service record lookup',
+			'Name'		   => 'DNS Common Service Record Enumeration',
 			'Description'	=> %q{
-					The module enumerates common DNS service records.
+					This module enumerates common DNS service records.
 			},
 			'Author'		=> [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
 			'License'		=> BSD_LICENSE

--- a/modules/auxiliary/gather/dns_srv.rb
+++ b/modules/auxiliary/gather/dns_srv.rb
@@ -219,3 +219,4 @@ class Metasploit3 < Msf::Auxiliary
 		return results
 	end
 end
+


### PR DESCRIPTION
Long time ago I got as a request from Jcran while he was still at R7 to split the enum_dns module in to easier to maintain modules and refactor them for better use and reporting of data this is the split of the SRV record enumeration part.
