### PR TITLE
Update lib/msf/core/auxiliary/login.rb - Fix for Bug #7451.

### DIFF
--- a/lib/msf/core/auxiliary/login.rb
+++ b/lib/msf/core/auxiliary/login.rb
@@ -51,6 +51,7 @@ module Auxiliary::Login
 				(Login ?|User ?)(name|): |
 				^\s*\<[a-f0-9]+\>\s*$ |
 				^\s*220.*FTP
+				not\ allowed
 			)/mix
 
 		@waiting_regex = /(?:


### PR DESCRIPTION
Added 'not\ allowed' to failure_regex
