### PR TITLE
linksys_wrt54gl_exec : trying to fix problems with authentication handling

### DIFF
--- a/modules/auxiliary/admin/http/linksys_wrt54gl_exec.rb
+++ b/modules/auxiliary/admin/http/linksys_wrt54gl_exec.rb
@@ -133,12 +133,13 @@ class Metasploit3 < Msf::Auxiliary
 		vprint_status("using the following target URL: #{uri}")
 
 		begin
+			auth_str = pass + ":" + pass
 			res = send_request_cgi({
 				'uri'	=> uri,
 				'method' => 'POST',
-				'basic_auth' => "#{pass}:#{pass}",
+				#'basic_auth' => "#{pass}:#{pass}",
+				'headers' => { 'Authorization' => "Basic #{Rex::Text.encode_base64(auth_str)}" },
 				#'data' => data_cmd,
-
 				'vars_post' => {
 					'submit_button' => "index",
 					'change_action' => "1",

--- a/modules/auxiliary/admin/http/linksys_wrt54gl_exec.rb
+++ b/modules/auxiliary/admin/http/linksys_wrt54gl_exec.rb
@@ -133,7 +133,7 @@ class Metasploit3 < Msf::Auxiliary
 		vprint_status("using the following target URL: #{uri}")
 
 		begin
-			auth_str = pass + ":" + pass
+			auth_str = user + ":" + pass
 			res = send_request_cgi({
 				'uri'	=> uri,
 				'method' => 'POST',


### PR DESCRIPTION
@m-1-k-3 has reported which linksys_wrt54gl_exec is failing with this call stack: 

```
Exploiting Demo - 192.168.178.105 / 0 auxiliary(linksys_wrt54gl_exec) > run

[*] Trying to login with xxx / xxx
[+] SUCCESSFUL LOGIN. 'xxx' : 'xxx'
[*] Sending remote command: ping 192.168.178.105
[*] using the following target URL: /apply.cgi
[-] Auxiliary failed: Errno::ECONNRESET Connection reset by peer
[-] Call stack:
[-]   /root/msf-git/metasploit-framework/lib/rex/io/stream.rb:72:in `read_nonblock'
[-]   /root/msf-git/metasploit-framework/lib/rex/io/stream.rb:72:in `read'
[-]   /root/msf-git/metasploit-framework/lib/rex/io/stream.rb:202:in `get_once'
[-]   /root/msf-git/metasploit-framework/lib/rex/proto/http/client.rb:762:in `block in read_response'
[-]   /usr/lib/ruby/1.9.2/timeout.rb:57:in `timeout'
[-]   /root/msf-git/metasploit-framework/lib/rex/proto/http/client.rb:752:in `read_response'
[-]   /root/msf-git/metasploit-framework/lib/rex/proto/http/client.rb:403:in `_send_recv'
[-]   /root/msf-git/metasploit-framework/lib/rex/proto/http/client.rb:383:in `send_recv'
[-]   /root/msf-git/metasploit-framework/lib/msf/core/exploit/http/client.rb:282:in `send_request_cgi'
[-]   /root/msf-git/metasploit-framework/modules/auxiliary/admin/http/linksys_wrt54gl_exec.rb:190:in `run'
[*] Auxiliary module execution completed

```

After discussing with him seems like connection reset by peer is due to server not asking as expected to the POST request when there isn't a Basic auth header. This "new" crash could be due to the changes introduced by #1444 . This pull try to fix linksys_wrt54gl_exec by forcing the post request to send the basic authentication header.
