### PR TITLE
Post::Windows - Enum AD Computers Performance Improvements

### DIFF
--- a/lib/msf/core/post/windows/ldap.rb
+++ b/lib/msf/core/post/windows/ldap.rb
@@ -305,7 +305,7 @@ module LDAP
   # @return [LDAP Session Handle]
   def bind_default_ldap_server(size_limit)
     vprint_status ("Initializing LDAP connection.")
-    init_result = wldap32.ldap_sslinitA("test.local", 389, 0)
+    init_result = wldap32.ldap_sslinitA("\x00\x00\x00\x00", 389, 0)
     session_handle = init_result['return']
     if session_handle == 0
       raise RuntimeError.new("Unable to initialize ldap server: #{init_result["ErrorMessage"]}")

--- a/modules/post/windows/gather/enum_ad_computers.rb
+++ b/modules/post/windows/gather/enum_ad_computers.rb
@@ -49,7 +49,6 @@ class Metasploit3 < Msf::Post
       ))
 
     register_options([
-      OptInt.new('MAX_SEARCH', [true, 'Maximum values to retrieve, 0 for all.', 50]),
       OptBool.new('STORE_LOOT', [true, 'Store file in loot.', false]),
       OptBool.new('STORE_DB', [true, 'Store file in DB (performance hit resolving IPs).', false]),
       OptString.new('FIELDS', [true, 'FIELDS to retrieve.', 'dNSHostName,distinguishedName,description,operatingSystem,operatingSystemServicePack']),


### PR DESCRIPTION
This now includes ADSI extapi techniques where available.

Timing:

This new method takes 20 seconds to pull down 50 results in testing. The old method takes 15 seconds to pull down just 5, which makes a big difference on larger domains! 

Previously for each value we had to call the API to get a ppValue then a pValue then ValueLength and Value for each attribute (default 4) for each entry (number of computers found).

This causes a large number of packets to perform small memreads. 

Now I just pull down the raw structure for each entry and search for the attributes and values in one go.

I have also made it report hosts to the database by default which should give a very comprehensive list of domain computers...

These changes should make the module more viable in practice - usable on x86 and much quicker to retrieve. 

Have now included the IP resolution included in STDAPI to reduce the number of requests.
