### PR TITLE
New module for Rails JSON/YAML vuln CVE-2013-0333

### DIFF
--- a/modules/auxiliary/scanner/http/rails_json_yaml_scanner.rb
+++ b/modules/auxiliary/scanner/http/rails_json_yaml_scanner.rb
@@ -31,14 +31,14 @@ class Metasploit3 < Msf::Auxiliary
 		))
 
 		register_options([
-			OptString.new('URIPATH', [true, "The URI to test", "/"]),
+			OptString.new('TARGETURI', [true, "The URI to test", "/"]),
 			OptEnum.new('HTTP_METHOD', [true, 'HTTP Method', 'POST', ['GET', 'POST', 'PUT']]),
 		], self.class)
 	end
 
 	def send_probe(pdata)
 		res = send_request_cgi({
-			'uri'    => datastore['URIPATH'] || "/",
+			'uri'    => datastore['TARGETURI'],
 			'method' => datastore['HTTP_METHOD'],
 			'ctype'  => 'application/json',
 			'data'   => pdata
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		if res1.code.to_s =~ /^[5]/
 			print_error("#{rhost}:#{rport} The server replied with #{res1.code} for our initial JSON request")
-			print_error("\t\tDouble check URIPATH and HTTP_METHOD")
+			print_error("\t\tDouble check TARGETURI and HTTP_METHOD")
 			return
 		end
 
@@ -94,7 +94,7 @@ class Metasploit3 < Msf::Auxiliary
 			})
 		else
 			# Otherwise we're not likely vulnerable.
-			vprint_status("#{rhost}:#{rport} is not likely to be vulnerable or URIPATH must be set")
+			vprint_status("#{rhost}:#{rport} is not likely to be vulnerable or TARGETURI must be set")
 		end
 	end
 

--- a/modules/auxiliary/scanner/http/rails_json_yaml_scanner.rb
+++ b/modules/auxiliary/scanner/http/rails_json_yaml_scanner.rb
@@ -1,0 +1,101 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Auxiliary::Scanner
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'        => 'Ruby on Rails JSON Processor YAML Deserialization Scanner',
+			'Description' => %q{
+				This module attempts to identify Ruby on Rails instances vulnerable to
+				an arbitrary object instantiation flaw in the JSON request processor.
+			},
+			'Author'      => [
+						'jjarmoc',	# scanner module
+						'hdm'		# CVE-2013-0156 scanner, basis of this technique.
+						],
+			'License'     => MSF_LICENSE,
+			'References'  =>
+				[
+					['CVE', '2013-0333'],
+				]
+		))
+
+		register_options([
+			OptString.new('URIPATH', [true, "The URI to test", "/"]),
+			OptEnum.new('HTTP_METHOD', [true, 'HTTP Method', 'POST', ['GET', 'POST', 'PUT']]),
+		], self.class)
+	end
+
+	def send_probe(pdata)
+		res = send_request_cgi({
+			'uri'    => datastore['URIPATH'] || "/",
+			'method' => datastore['HTTP_METHOD'],
+			'ctype'  => 'application/json',
+			'data'   => pdata
+		}, 25)
+	end
+
+	def run_host(ip)
+
+		# Straight JSON as a baseline
+		res1 = send_probe(
+			"{ \"#{Rex::Text.rand_text_alpha(rand(8)+1)}\" : \"#{Rex::Text.rand_text_alpha(rand(8)+1)}\" }"
+			)
+
+		unless res1
+			vprint_status("#{rhost}:#{rport} No reply to the initial JSON request")
+			return
+		end
+
+		if res1.code.to_s =~ /^[5]/
+			print_error("#{rhost}:#{rport} The server replied with #{res1.code} for our initial JSON request")
+			print_error("\t\tDouble check URIPATH and HTTP_METHOD")
+			return
+		end
+
+		# Deserialize a hash, this should work if YAML deserializes.
+		res2 = send_probe("--- {}\n".gsub(':', '\u003a'))
+
+		unless res2
+			vprint_status("#{rhost}:#{rport} No reply to the initial YAML probe")
+			return
+		end
+
+		# Deserialize a malformed object, inducing an error.
+		res3 = send_probe("--- !ruby/object:\x00".gsub(':', '\u003a'))
+
+		unless res3
+			vprint_status("#{rhost}:#{rport} No reply to the second YAML probe")
+			return
+		end
+
+		vprint_status("Probe response codes: #{res1.code} / #{res2.code} / #{res3.code}")
+
+		if (res2.code == res1.code) and (res3.code != res2.code) and (res3.code != 200)
+			# If first and second requests are the same, and the third is different but not a 200, we're vulnerable.
+			print_good("#{rhost}:#{rport} is likely vulnerable due to a #{res3.code} reply for invalid YAML")
+			report_vuln({
+				:host	=> rhost,
+				:port	=> rport,
+				:proto  => 'tcp',
+				:name	=> self.name,
+				:info	=> "Module triggered a #{res3.code} reply",
+				:refs   => self.references
+			})
+		else
+			# Otherwise we're not likely vulnerable.
+			vprint_status("#{rhost}:#{rport} is not likely to be vulnerable or URIPATH must be set")
+		end
+	end
+
+end


### PR DESCRIPTION
This is a new scanner module for the Rails JSON/YAML vuln CVE-2013-0333.

Based heavily on the scanner for CVE-2013-0156.  Here's output from a number of different rails versions, also demonstrating that it works on URIPATH's that are 404.

Vulnerable - Rails 3.0.19 w/ working URIPATH;
[_] Probe response codes 200 / 200 / 500
[+] 127.0.0.1:3000 is likely vulnerable due to a 500 reply for invalid YAML
[_] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

Vulnerable - Rails 3.0.19 w/ 404 URIPATH;
[_] Probe response codes 404 / 404 / 500
[+] 127.0.0.1:3000 is likely vulnerable due to a 500 reply for invalid YAML
[_] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

Vulnerable - Rails 3.0.18 w/ 404 URIPath;
[_] Probe response codes 404 / 404 / 500
[+] 127.0.0.1:3000 is likely vulnerable due to a 500 reply for invalid YAML
[_] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

Vulnerable - Rails 3.0.18 w/ working URIPath;
[_] Probe response codes 200 / 200 / 500
[+] 127.0.0.1:3000 is likely vulnerable due to a 500 reply for invalid YAML
[_] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

Not vulnerable - Rails 3.0.20 w/ 404 URIPath;
[_] Probe response codes 404 / 500 / 500
[_] 127.0.0.1:3000 is not likely to be vulnerable or URIPATH must be set
[_] Scanned 1 of 1 hosts (100% complete)
[_] Auxiliary module execution completed

Not vulnerable - Rails 3.0.20 w/ 404 URIPath;
[_] Probe response codes 200 / 500 / 500
[_] 127.0.0.1:3000 is not likely to be vulnerable or URIPATH must be set
[_] Scanned 1 of 1 hosts (100% complete)
[_] Auxiliary module execution completed

Vulnerable - Rails 2.3.15 w/ working URIPath;
[_] Probe response codes 200 / 200 / 500
[+] 127.0.0.1:3000 is likely vulnerable due to a 500 reply for invalid YAML
[_] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

Vulnerable - Rails 2.3.15 w/ 404 URIPath;
[_] Probe response codes 404 / 404 / 500
[+] 127.0.0.1:3000 is likely vulnerable due to a 500 reply for invalid YAML
[_] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

Not Vulnerable - Rails 2.3.15 w/ 404 URIPath;
[_] Probe response codes 404 / 500 / 500
[_] 127.0.0.1:3000 is not likely to be vulnerable or URIPATH must be set
[_] Scanned 1 of 1 hosts (100% complete)
[_] Auxiliary module execution completed

Not Vulnerable - Rails 2.3.15 w/ working URIPath;
[_] Probe response codes 200 / 500 / 500
[_] 127.0.0.1:3000 is not likely to be vulnerable or URIPATH must be set
[_] Scanned 1 of 1 hosts (100% complete)
[_] Auxiliary module execution completed

Error - HTTP_METHOD set to 'BLARGH' 
(Note, this doesn't actually work anymore due to OptEnum on HTTP_METHOD, but demonstrates what happens in an error condition.)
[-] 127.0.0.1:3000 The server replied with 500 for our initial JSON request
[-]         Double check URIPATH and HTTP_METHOD
[_] Scanned 1 of 1 hosts (100% complete)
[_] Auxiliary module execution completed
