### PR TITLE
Update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,8 +28,12 @@ GEM
     coderay (1.0.8)
     diff-lcs (1.1.3)
     i18n (0.6.1)
+    json (1.7.7)
     method_source (0.8.1)
+    msgpack (0.5.2)
     multi_json (1.0.4)
+    nokogiri (1.5.6)
+    pcaprub (0.11.3)
     pg (0.14.1)
     pry (0.9.10)
       coderay (~> 1.0.5)
@@ -37,6 +41,7 @@ GEM
       slop (~> 3.3.1)
     rake (10.0.2)
     redcarpet (2.2.2)
+    robots (0.10.1)
     rspec (2.12.0)
       rspec-core (~> 2.12.0)
       rspec-expectations (~> 2.12.0)
@@ -57,10 +62,17 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord
   activesupport (>= 3.0.0)
+  json
   metasploit_data_models!
+  msgpack
+  nokogiri
+  pcaprub
+  pg (>= 0.11)
   rake
   redcarpet
+  robots
   rspec (>= 2.12)
   simplecov (= 0.5.4)
   yard


### PR DESCRIPTION
When @jlee-r7 updated the Gemfile, he didn't update Gemfile.lock as well. Now it changes every time you rspec.

I expect this was intended, just overlooked. @bturner-r7 should take a peek as well.

I wonder if this is why Travis-CI has been failing a bunch lately.
