### PR TITLE
Allow generic/custom payload to generate an exe

### DIFF
--- a/modules/payloads/singles/generic/custom.rb
+++ b/modules/payloads/singles/generic/custom.rb
@@ -38,6 +38,10 @@ module Metasploit3
 	# Construct the payload
 	#
 	def generate
+		if datastore['ARCH']
+			self.arch = actual_arch
+		end
+
 		if datastore['PAYLOADFILE']
 			IO.read(datastore['PAYLOADFILE'])
 		elsif datastore['PAYLOADSTR']


### PR DESCRIPTION
The datastore value of ARCH has no effect on the array of
architectures the generic/custom payload is compatible with.
This commit forces the payload to update its list of compatible
architectures on generation if the ARCH value is set in the
datastore.

See:

http://dev.metasploit.com/redmine/issues/7755
