### PR TITLE
Warn about svn deprecation in msfconsole

### DIFF
--- a/msfconsole
+++ b/msfconsole
@@ -40,7 +40,9 @@ def print_deprecation_warning
 	$stdout.puts "[*] source checkouts will NO LONGER update over SVN, but will be using"
 	$stdout.puts "[*] GitHub exclusively. You should either download a new Metasploit"
 	$stdout.puts "[*] installer, or use a git clone of Metasploit Framework before"
-	$stdout.puts "[*] then. You will also need outbound access to github.com:9418/TCP."
+	$stdout.puts "[*] then. You will also need outbound access to github.com on"
+	$stdout.puts "[*] TCP port 9418 (git), 22 (ssh) or 443 (https), depending on the"
+	$stdout.puts "[*] protocol used to clone Metasploit Framework (usually, git protocol)."
 end
 
 if is_svn

--- a/msfconsole
+++ b/msfconsole
@@ -14,11 +14,11 @@ while File.symlink?(msfbase)
 	msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
 
+@msfbase_dir = File.expand_path(File.dirname(msfbase))
+
 $:.unshift(File.expand_path(File.join(File.dirname(msfbase), 'lib')))
 require 'fastlib'
 require 'msfenv'
-
-
 
 $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 
@@ -29,6 +29,24 @@ if(RUBY_PLATFORM =~ /mswin32/)
 	$stderr.puts "    interpreter. Things will break, exploits will fail, payloads will not\n"
 	$stderr.puts "    be handled correctly. Please install Cygwin or use Linux in VMWare.\n\n"
 end
+
+def is_svn
+	File.directory?(File.join(@msfbase_dir, ".svn"))
+end
+
+def print_deprecation_warning
+	$stdout.puts ""
+	$stdout.puts "[*] Deprecation Note: After 2013-02-28 (February 28, 2013), Metasploit"
+	$stdout.puts "[*] source checkouts will NO LONGER update over SVN, but will be using"
+	$stdout.puts "[*] GitHub exclusively. You should either download a new Metasploit"
+	$stdout.puts "[*] installer, or use a git clone of Metasploit Framework before"
+	$stdout.puts "[*] then. You will also need outbound access to github.com:9418/TCP."
+end
+
+if is_svn
+	print_deprecation_warning
+end
+
 
 class OptsConsole
 	#

--- a/msfconsole
+++ b/msfconsole
@@ -36,7 +36,7 @@ end
 
 def print_deprecation_warning
 	$stdout.puts ""
-	$stdout.puts "[*] Deprecation Note: After 2013-02-28 (February 28, 2013), Metasploit"
+	$stdout.puts "[*] Deprecation Note: After 2013-03-15 (March 15, 2013), Metasploit"
 	$stdout.puts "[*] source checkouts will NO LONGER update over SVN, but will be using"
 	$stdout.puts "[*] GitHub exclusively. You should either download a new Metasploit"
 	$stdout.puts "[*] installer, or use a git clone of Metasploit Framework before"

--- a/msfupdate
+++ b/msfupdate
@@ -53,10 +53,13 @@ def add_git_upstream
 end
 
 def print_deprecation_warning
-	$stdout.puts "[*] Deprecation Note: The next version of Metasploit will"
-	$stdout.puts "[*] update over the git protocol, which requires outbound"
-	$stdout.puts "[*] access to github.com:9418/TCP."
-	$stdout.puts "[*] Please adjust your egress firewall rules accordingly."
+	$stdout.puts ""
+	$stdout.puts "[*] Deprecation Note: After 2013-02-28 (February 28, 2013), Metasploit"
+	$stdout.puts "[*] source checkouts will NO LONGER update over SVN, but will be using"
+	$stdout.puts "[*] GitHub exclusively. You should either download a new Metasploit"
+	$stdout.puts "[*] installer, or use a git clone of Metasploit Framework before"
+	$stdout.puts "[*] then. You will also need outbound access to github.com:9418/TCP."
+	$stdout.puts ""
 end
 
 def maybe_wait_and_exit(exit_code=0)


### PR DESCRIPTION
Msfupdate has been warning about SVN deprecation for months, it's high time the console did the same.

Deadline is set to March 15. If it takes too long for this PR to land then it'll probably have to move out farther.
