### PR TITLE
Fix a typo that broke jboss_maindeployer against x64

### DIFF
--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -350,7 +350,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			arch = $1
 			if (arch =~ /(x86|i386|i686)/i)
 				return ARCH_X86
-			elsif (os =~ /(x86_64|amd64)/i)
+			elsif (arch =~ /(x86_64|amd64)/i)
 				return ARCH_X86
 			end
 		end


### PR DESCRIPTION
https://dev.metasploit.com/redmine/issues/7747
