### PR TITLE
Feature/go pro

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2651,14 +2651,14 @@ class Core
 	protected
 
 	#
-	# Go_pro methods -- these are used to start and connect to the
-	# web UI.
+	# Go_pro methods -- these are used to start and connect to
+	# Metasploit Community / Pro.
 
 	def launch_metasploit_browser
 		cmd = "/usr/bin/xdg-open"
 		unless ::File.executable_real? cmd
 			print_warning "Can't figure out your default browser, please visit https://localhost:3790"
-			print_warning "to start the web UI version of Metasploit."
+			print_warning "to start Metasploit Community / Pro."
 			return false
 		end
 		svc_log = File.expand_path(File.join(msfbase_dir, ".." , "engine", "prosvc_stdout.log"))
@@ -2673,14 +2673,14 @@ class Core
 			really_started = log_data =~ /^\[\*\] Ready/ # This is webserver ready
 			if really_started
 				print_line
-				print_good "The web UI is up and running, connecting with your default browser."
+				print_good "Metasploit Community / Pro is up and running, connecting now."
 				print_good "If this is your first time connecting, you will be presented with"
 				print_good "a self-signed certificate warning. Accept it to create a new user."
 				select(nil,nil,nil,7)
 				system(cmd, "https://localhost:3790")
 			elsif timeout >= 200 # 200 * 3 seconds is 10 minutes and that is tons of time.
 				print_line
-				print_warning "For some reason, the web UI didn't start in a timely fashion."
+				print_warning "For some reason, Community / Pro didn't start in a timely fashion."
 				print_warning "You might want to restart the Metasploit services by typing"
 				print_warning "'service metasploit restart' . Sorry it didn't work out."
 				return false

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -68,6 +68,9 @@ class Core
 	@@search_opts = Rex::Parser::Arguments.new(
 		"-h" => [ false, "Help banner."                                   ])
 
+	@@go_pro_opts = Rex::Parser::Arguments.new(
+		"-h" => [ false, "Help banner."                                   ])
+
 	# The list of data store elements that cannot be set when in defanged
 	# mode.
 	DefangedProhibitedDataStoreElements = [ "MsfModulePaths" ]
@@ -82,6 +85,7 @@ class Core
 			"connect"  => "Communicate with a host",
 			"color"    => "Toggle color",
 			"exit"     => "Exit the console",
+			"go_pro"   => "Launch Metasploit web UI",
 			"help"     => "Help menu",
 			"info"     => "Displays information about one or more module",
 			"irb"      => "Drop into irb scripting mode",
@@ -2573,6 +2577,17 @@ class Core
 		end
 
 		return res
+	end
+
+	def cmd_go_pro_help
+		print_line "Usage: go_pro"
+		print_line
+		print_line "Launch the Metasploit web UI"
+		print_line
+	end
+
+	def cmd_go_pro(*args)
+		print_line "Hey now it's pro time"
 	end
 
 protected

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2619,8 +2619,9 @@ class Core
 			return false
 		end
 		unless is_metasploit_debian_package_installed
-			print_warning " You will want to install the 'metasploit' package first."
-			print_warning " Type 'apt-get install metasploit' to do this now, then try 'go_pro' again."
+			print_warning "You needs to install the 'metasploit' package first."
+			print_warning "Type 'apt-get install metasploit' to do this now, then exit"
+			print_warning "and restart msfconsole to try again."
 			return false
 		end
 		# If I've gotten this far, I know that this is apt-installed
@@ -2633,6 +2634,8 @@ class Core
 			select(nil,nil,nil,3)
 			if is_metasploit_service_running
 				launch_metasploit_browser
+			else
+				print_error "Metasploit services aren't running. Type 'service start metasploit' and try again."
 			end
 		end
 		@@go_pro_opts.parse(args) do |opt, idx, val|

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2701,13 +2701,7 @@ class Core
 
 	def is_metasploit_service_running
 		cmd = "/usr/sbin/service"
-		return unless ::File.executable_real? cmd
-		services = %x{#{cmd} metasploit status}
-		expected = "Metasploit %s server is running."
-		%w{web rpc}.each do |svc|
-			return false unless services.include?(expected % svc)
-		end
-		return true
+		system(cmd, "metasploit", "status") # Both running returns true, otherwise, false.
 	end
 
 	def is_metasploit_debian_package_installed

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -365,7 +365,7 @@ class Core
 				"Using notepad to track pentests? Have Metasploit Pro report on hosts,\nservices, sessions and evidence -- type ‘go_pro’ to launch it now.",
 				"Tired of typing ‘set RHOSTS’? Click & pwn with Metasploit Pro\n-- type ‘go_pro’ to launch it now."
 			]
-			banner << content.sample
+			banner << content.sample # Ruby 1.9-ism!
 			banner << "\n\n"
 		end
 
@@ -2614,9 +2614,24 @@ class Core
 
 	def cmd_go_pro(*args)
 		unless is_apt
-			print_line " This command is only available on apt-based installations,"
+			print_line " This command is only available on deb package installations,"
 			print_line " such as Kali Linux."
 			return false
+		end
+		unless metasploit_debian_package_installed
+			print_warning " You will want to install the 'metasploit' package first."
+			print_warning " Type 'apt-get install metasploit' to do this now."
+			return false
+		end
+		# If I've gotten this far, I know that this is apt-installed
+		# and the packages I need are here.
+		if metasploit_service_running
+			print_good " Metasploit services are running, launching a browser..."
+			launch_metasploit_browser
+		else
+			print_warning " Starting the Metasploit services. This will take a few minutes."
+			start_metasploit_service
+			launch_metasploit_browser
 		end
 		@@go_pro_opts.parse(args) do |opt, idx, val|
 			case opt
@@ -2626,6 +2641,18 @@ class Core
 			end
 		end
 		return true
+	end
+
+	def launch_metasploit_browser
+	end
+
+	def start_metasploit_service
+	end
+
+	def metasploit_service_running
+	end
+
+	def metasploit_debian_package_installed
 	end
 
 	# Determines if this is an apt-based install

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -85,7 +85,7 @@ class Core
 			"connect"  => "Communicate with a host",
 			"color"    => "Toggle color",
 			"exit"     => "Exit the console",
-			"go_pro"   => "Launch Metasploit web UI",
+			"go_pro"   => "Launch Metasploit web GUI",
 			"help"     => "Help menu",
 			"info"     => "Displays information about one or more module",
 			"irb"      => "Drop into irb scripting mode",
@@ -135,6 +135,17 @@ class Core
 	#
 	def name
 		"Core"
+	end
+
+	# Indicates the base dir where Metasploit Framework is installed.
+	def msfbase_dir
+		base = __FILE__
+		while File.symlink?(base)
+			base = File.expand_path(File.readlink(base), File.dirname(base))
+		end
+		File.expand_path(
+			File.join(File.dirname(base), "..","..","..","..","..")
+		)
 	end
 
 	def cmd_color_help
@@ -2582,12 +2593,29 @@ class Core
 	def cmd_go_pro_help
 		print_line "Usage: go_pro"
 		print_line
-		print_line "Launch the Metasploit web UI"
+		print_line "Launch the Metasploit web GUI"
 		print_line
 	end
 
 	def cmd_go_pro(*args)
-		print_line "Hey now it's pro time"
+		unless is_apt
+			print_line " This command is only available on apt-based installations,"
+			print_line " such as Kali Linux."
+			return false
+		end
+		@@go_pro_opts.parse(args) do |opt, idx, val|
+			case opt
+			when "-h"
+				cmd_go_pro_help
+				return false
+			end
+		end
+		return true
+	end
+
+	# Determines if this is an apt-based install
+	def is_apt
+		File.exists?(File.expand_path(File.join(msfbase_dir, '.apt')))
 	end
 
 protected

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2613,19 +2613,26 @@ class Core
 	end
 
 	def cmd_go_pro(*args)
+		@@go_pro_opts.parse(args) do |opt, idx, val|
+			case opt
+			when "-h"
+				cmd_go_pro_help
+				return false
+			end
+		end
 		unless is_apt
 			print_line " This command is only available on deb package installations,"
 			print_line " such as Kali Linux."
 			return false
 		end
 		unless is_metasploit_debian_package_installed
-			print_warning "You needs to install the 'metasploit' package first."
-			print_warning "Type 'apt-get install metasploit' to do this now, then exit"
+			print_warning "You need to install the 'metasploit' package first."
+			print_warning "Type 'apt-get install -y metasploit' to do this now, then exit"
 			print_warning "and restart msfconsole to try again."
 			return false
 		end
-		# If I've gotten this far, I know that this is apt-installed
-		# and the packages I need are here.
+		# If I've gotten this far, I know that this is apt-installed, the
+		# metasploit package is here, and I'm ready to rock.
 		if is_metasploit_service_running
 			launch_metasploit_browser
 		else
@@ -2638,15 +2645,14 @@ class Core
 				print_error "Metasploit services aren't running. Type 'service start metasploit' and try again."
 			end
 		end
-		@@go_pro_opts.parse(args) do |opt, idx, val|
-			case opt
-			when "-h"
-				cmd_go_pro_help
-				return false
-			end
-		end
 		return true
 	end
+
+	protected
+
+	#
+	# Go_pro methods -- these are used to start and connect to the
+	# web UI.
 
 	def launch_metasploit_browser
 		cmd = "/usr/bin/xdg-open"
@@ -2708,8 +2714,6 @@ class Core
 	def is_apt
 		File.exists?(File.expand_path(File.join(msfbase_dir, '.apt')))
 	end
-
-protected
 
 	#
 	# Module list enumeration

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -355,6 +355,20 @@ class Core
 	#
 	def cmd_banner(*args)
 		banner  = "%cya" + Banner.to_s + "%clr\n\n"
+
+		if is_apt
+			content = [
+				"Large pentest? List, sort, group, tag and search your hosts and services\nin Metasploit Pro -- type ‘go_pro’ to launch it now.",
+				"Frustrated with proxy pivoting? Upgrade to layer-2 VPN pivoting with\nMetasploit Pro -- type ‘go_pro’ to launch it now.",
+				"Save your shells from AV! Upgrade to advanced AV evasion using dynamic\nexe templates with Metasploit Pro -- type ‘go_pro’ to launch it now.",
+				"Easy phishing: Set up email templates, landing pages and listeners\nin Metasploit Pro’s wizard -- type ‘go_pro’ to launch it now.",
+				"Using notepad to track pentests? Have Metasploit Pro report on hosts,\nservices, sessions and evidence -- type ‘go_pro’ to launch it now.",
+				"Tired of typing ‘set RHOSTS’? Click & pwn with Metasploit Pro\n-- type ‘go_pro’ to launch it now."
+			]
+			banner << content.sample
+			banner << "\n\n"
+		end
+
 		banner << "       =[ %yelmetasploit v#{Msf::Framework::Version} [core:#{Msf::Framework::VersionCore} api:#{Msf::Framework::VersionAPI}]%clr\n"
 		banner << "+ -- --=[ "
 		banner << "#{framework.stats.num_exploits} exploits - #{framework.stats.num_auxiliary} auxiliary - #{framework.stats.num_post} post\n"
@@ -362,6 +376,7 @@ class Core
 
 		oldwarn = nil
 		avdwarn = nil
+
 		banner << "#{framework.stats.num_payloads} payloads - #{framework.stats.num_encoders} encoders - #{framework.stats.num_nops} nops\n"
 		if ( ::Msf::Framework::RepoRevision.to_i > 0 and ::Msf::Framework::RepoUpdatedDate)
 			tstamp = ::Msf::Framework::RepoUpdatedDate.strftime("%Y.%m.%d")

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2653,7 +2653,9 @@ class Core
 	#
 	# Go_pro methods -- these are used to start and connect to
 	# Metasploit Community / Pro.
+	#
 
+	# Note that this presumes a default port.
 	def launch_metasploit_browser
 		cmd = "/usr/bin/xdg-open"
 		unless ::File.executable_real? cmd
@@ -2677,7 +2679,8 @@ class Core
 				print_good "If this is your first time connecting, you will be presented with"
 				print_good "a self-signed certificate warning. Accept it to create a new user."
 				select(nil,nil,nil,7)
-				system(cmd, "https://localhost:3790")
+				browser_pid = ::Process.spawn(cmd, "https://localhost:3790")
+				::Process.detach(browser_pid)
 			elsif timeout >= 200 # 200 * 3 seconds is 10 minutes and that is tons of time.
 				print_line
 				print_warning "For some reason, Community / Pro didn't start in a timely fashion."

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -358,12 +358,12 @@ class Core
 
 		if is_apt
 			content = [
-				"Large pentest? List, sort, group, tag and search your hosts and services\nin Metasploit Pro -- type ‘go_pro’ to launch it now.",
-				"Frustrated with proxy pivoting? Upgrade to layer-2 VPN pivoting with\nMetasploit Pro -- type ‘go_pro’ to launch it now.",
-				"Save your shells from AV! Upgrade to advanced AV evasion using dynamic\nexe templates with Metasploit Pro -- type ‘go_pro’ to launch it now.",
-				"Easy phishing: Set up email templates, landing pages and listeners\nin Metasploit Pro’s wizard -- type ‘go_pro’ to launch it now.",
-				"Using notepad to track pentests? Have Metasploit Pro report on hosts,\nservices, sessions and evidence -- type ‘go_pro’ to launch it now.",
-				"Tired of typing ‘set RHOSTS’? Click & pwn with Metasploit Pro\n-- type ‘go_pro’ to launch it now."
+				"Large pentest? List, sort, group, tag and search your hosts and services\nin Metasploit Pro -- type 'go_pro' to launch it now.",
+				"Frustrated with proxy pivoting? Upgrade to layer-2 VPN pivoting with\nMetasploit Pro -- type 'go_pro' to launch it now.",
+				"Save your shells from AV! Upgrade to advanced AV evasion using dynamic\nexe templates with Metasploit Pro -- type 'go_pro' to launch it now.",
+				"Easy phishing: Set up email templates, landing pages and listeners\nin Metasploit Pro’s wizard -- type 'go_pro' to launch it now.",
+				"Using notepad to track pentests? Have Metasploit Pro report on hosts,\nservices, sessions and evidence -- type 'go_pro' to launch it now.",
+				"Tired of typing ‘set RHOSTS’? Click & pwn with Metasploit Pro\n-- type 'go_pro' to launch it now."
 			]
 			banner << content.sample # Ruby 1.9-ism!
 			banner << "\n\n"


### PR DESCRIPTION
This allows for launching the Metasploit web UI (aka Metasploit Community or Metasploit Pro) from the msfconsole. It does a few things:
- Checks to see that this is a debian-packaged version of Metasploit Framework (this won't work otherwise ATM, but can be extended)
- Checks if the web UI is actually installed in the debian fashion.
- Checks if the attendant metasploit services are running (the web and rpc interfaces)
- Launches the browser.

Notably, none of this will happen if this is a binary installed version of Metasploit (aka, the usual windows/linux installers) or a source install (and the user will be politely informed as such).

Screen shot of the whole process in action, here:

https://gist.github.com/todb-r7/c8e83c7ab4a1abce79e2 (you won't see the browser launch in a console cut-n-paste, obviously, but it happens).

I'm specifically interested in feedback from @hmoore-r7 and @bturner-r7 -- HD mentioned that this framework-then-pro sequence of installation can cause some trouble in the database schema, but after clicking around, I'm unable to reproduce any problems. I'm inclined now to believe that Brandon anticipated this in the packaging, but a confirm from either would be good.

Also for everyone else, unless you have access to the secret betas of the Metasploit debian packages, you won't be able to test or see this in action. Coming soon, though!

Things I'm not super pleased with:
- msfconsole is getting pretty big, lacks unit tests, and needs to be split up like db.rb
- There's not a whole lot of messaging in the case of failure along the way. The user should be able to see what happens since we echo out the stdout of all the commands, but this can still confuse people in unanticipated ways.
- There's a lot of shelling out going on, so it's not exactly cross-platform. This is strictly for the one environment. Someday (soon) the binary installers and (later) the source install should pick up this functionality as well.
