### PR TITLE
Get msfconsole running under 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'http://rubygems.org'
 gem 'activesupport', '>= 3.0.0'
 # Needed for Msf::DbManager
 gem 'activerecord'
+# Needed for Ruby 2.0.0
+gem 'iconv'
 # Needed for some admin modules (scrutinizer_add_user.rb)
 gem 'json'
 # Database models shared between framework and Pro.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
     coderay (1.0.8)
     diff-lcs (1.1.3)
     i18n (0.6.1)
+    iconv (1.0.2)
     json (1.7.7)
     method_source (0.8.1)
     msgpack (0.5.2)
@@ -64,6 +65,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord
   activesupport (>= 3.0.0)
+  iconv
   json
   metasploit_data_models!
   msgpack

--- a/lib/rkelly/visitors/evaluation_visitor.rb
+++ b/lib/rkelly/visitors/evaluation_visitor.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module RKelly
   module Visitors
     class EvaluationVisitor < Visitor


### PR DESCRIPTION
Given the pile of rspec tests that fail when you're running Ruby 2.0,
this is far from over. Thus, the namespace of Ruby-2.0

But, this at least gets you going to try to resolve those bugs.
