### PR TITLE
change safari_metadata_archive platform to osx

### DIFF
--- a/modules/exploits/osx/browser/safari_metadata_archive.rb
+++ b/modules/exploits/osx/browser/safari_metadata_archive.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[
 						'Automatic',
 						{
-							'Platform' => [ 'unix' ],
+							'Platform' => [ 'osx' ],
 							'Arch'     => ARCH_CMD,
 						},
 					],


### PR DESCRIPTION
I thought it needed to be ['osx', 'unix'] at first, but it's targeting
Safari on OSX, so I don't think unix is right.  currently it doesn't
even show up in a search because of the 'unix' even tho it's in the osx
directory.
