### PR TITLE
Exploit::Remote::Web#perform_request: timeout set to 10

### DIFF
--- a/lib/msf/core/exploit/web.rb
+++ b/lib/msf/core/exploit/web.rb
@@ -99,7 +99,7 @@ module Exploit::Remote::Web
 			'vars_post' => post,
 			'headers'   => headers,
 			'cookie'    => cookies
-		}, 0.01 )
+		}, 10 )
 	end
 
 	#


### PR DESCRIPTION
Some payloads need time to execute, HTTP request timeout had to be increased.
