### PR TITLE
'Protected' shouldn't be needed.

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -604,7 +604,6 @@ module Exploit::Remote::HttpServer::HTML
 
 	include Msf::Exploit::Remote::HttpServer
 
-protected
 
 	def initialize(info = {})
 		super


### PR DESCRIPTION
If Protected is used, yard doc cannot document the functions.
