### PR TITLE
Auxiliary::Web: fixed confidence calculation in log methods

### DIFF
--- a/lib/msf/core/auxiliary/web.rb
+++ b/lib/msf/core/auxiliary/web.rb
@@ -179,7 +179,7 @@ module Auxiliary::Web
 			:blame		=> details[:blame],
 			:category	=> details[:category],
 			:description => details[:description],
-			:confidence  => details[:category] || opts[:confidence] || 100,
+			:confidence  => calculate_confidence( parent.vulns[mode][vhash] ),
 			:owner	  => self
 		}
 
@@ -211,7 +211,7 @@ module Auxiliary::Web
 			:blame		 => details[:blame],
 			:category	 => details[:category],
 			:description => details[:description],
-			:confidence  => details[:category] || opts[:confidence] || 100,
+			:confidence  => calculate_confidence( parent.vulns[mode][vhash] ),
 			:owner		 => self
 		}
 


### PR DESCRIPTION
Leftover code in 2 webvuln logging methods caused confidence to not be stored properly.

PS. I just realized that bugfix branches need to be prefixed with "bug/" instead of "bugfix/", sorry about that.
