### PR TITLE
Bug/fix go pro

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2695,9 +2695,9 @@ class Core
 	end
 
 	def start_metasploit_service
-		cmd = "/usr/sbin/service"
+		cmd = File.expand_path(File.join(msfbase_dir, '..', '..', '..', 'scripts', 'start.sh'))
 		return unless ::File.executable_real? cmd
-		%x{#{cmd} metasploit start}.each_line do |line|
+		%x{#{cmd}}.each_line do |line|
 			print_status line.chomp
 		end
 	end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2704,7 +2704,7 @@ class Core
 
 	def is_metasploit_service_running
 		cmd = "/usr/sbin/service"
-		system(cmd, "metasploit", "status") # Both running returns true, otherwise, false.
+		system("#{cmd} metasploit status >/dev/null") # Both running returns true, otherwise, false.
 	end
 
 	def is_metasploit_debian_package_installed

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2642,7 +2642,7 @@ class Core
 			if is_metasploit_service_running
 				launch_metasploit_browser
 			else
-				print_error "Metasploit services aren't running. Type 'service start metasploit' and try again."
+				print_error "Metasploit services aren't running. Type 'service metasploit start' and try again."
 			end
 		end
 		return true


### PR DESCRIPTION
This fixes an issue when using the new `go_pro` command when Postgres is not started.  This changes `go_pro` to use `/opt/metasploit/scripts/start.sh` instead of `service metasploit start`.  The `start.sh` script (installed with Community/Pro apt installs) takes care of starting dependencies.
