### PR TITLE
Use start.sh to start Pro via msfupdate command

### DIFF
--- a/msfupdate
+++ b/msfupdate
@@ -224,7 +224,10 @@ if is_apt
 	else
 		$stdout.puts "[*] Updating to version #{pro_version || framework_version}"
 		system("apt-get", "install", "--assume-yes", *packages)
-		system("/etc/init.d/metasploit start") if packages.include?('metasploit')
+		if packages.include?('metasploit')
+			start_cmd = File.expand_path(File.join(@msfbase_dir, '..', '..', '..', 'scripts', 'start.sh'))
+			system(start_cmd) if ::File.executable_real? start_cmd
+		end
 	end
 end
 


### PR DESCRIPTION
This fixes an issue when using `msfupdate` in an apt environment when Postgres is not started. This changes `msfupdate` to use `/opt/metasploit/scripts/start.sh` instead of `/etc/init.d/metasploit start`. The `start.sh` script (installed with Community/Pro apt installs) takes care of starting dependencies.
