### PR TITLE
Stop crawler from reporting 404 pages

### DIFF
--- a/modules/auxiliary/scanner/http/crawler.rb
+++ b/modules/auxiliary/scanner/http/crawler.rb
@@ -123,7 +123,7 @@ class Metasploit3 < Msf::Auxiliary
 		end
 
 		# Report the web page to the database
-		report_web_page(info)
+		report_web_page(info) unless page.code == 404
 
 		# Only process interesting response codes
 		return if not [302, 301, 200, 500, 401, 403, 404].include?(page.code)


### PR DESCRIPTION
The crawler currently reports web pages which have a 404 response.
This means that the default test targets come out as "pages" in the
DB when in fact the're just 404 reponses. It is thus possible to
have pages reported for a website which is nothing more than a bare
HTTP server. Since we can always get a 404 response by issuing a
request to a random URI this behavior appears detrimental, or at
least pointless.

If the behavior does serve a purpose, then it may be prudent to
create a datastore conditional to switch it on if required.
