### PR TITLE
Allow deletion of multiple WMAP sites

### DIFF
--- a/plugins/wmap.rb
+++ b/plugins/wmap.rb
@@ -138,9 +138,9 @@ class Plugin::Wmap < Msf::Plugin
 						print_error("Unable to create site")
 					end
 				when '-d'
-					del_idx = args.shift
+					del_idx = args
 					if del_idx
-						delete_site(del_idx.to_i)
+						delete_site(del_idx.split(/\s|,|\;/).map(&:to_i).uniq)
 					else
 						print_error("Provide index of site to delete")
 					end
@@ -204,7 +204,7 @@ class Plugin::Wmap < Msf::Plugin
 					print_status("Usage: wmap_sites [options]")
 					print_line("\t-h        Display this help text")
 					print_line("\t-a [url]  Add site (vhost,url)")
-					print_line("\t-d [id]   Delete site")
+					print_line("\t-d [ids]  Delete sites (separate ids by ',|\\s|;')")
 					print_line("\t-l        List all available sites")
 					print_line("\t-s [id]   Display site structure (vhost,url|ids) (level)")
 
@@ -1239,7 +1239,7 @@ class Plugin::Wmap < Msf::Plugin
 			self.framework.db.hosts.each do |bdhost|
 				bdhost.services.each do |serv|
 					serv.web_sites.each do |web|
-						if idx == wmap_index
+						if wmap_index.any? {|w| w == idx}
 							web.delete
 							print_status("Deleted #{web.vhost} on #{bdhost.address} at index #{idx}")
 							return

--- a/plugins/wmap.rb
+++ b/plugins/wmap.rb
@@ -140,7 +140,7 @@ class Plugin::Wmap < Msf::Plugin
 				when '-d'
 					del_idx = args
 					if del_idx
-						delete_sites(del_idx.map(&:to_i).uniq)
+						delete_sites(del_idx.select {|d| d =~ /^[0-9]*$/}.map(&:to_i).uniq)
 						return
 					else
 						print_error("Provide index of site to delete")
@@ -205,7 +205,7 @@ class Plugin::Wmap < Msf::Plugin
 					print_status("Usage: wmap_sites [options]")
 					print_line("\t-h        Display this help text")
 					print_line("\t-a [url]  Add site (vhost,url)")
-					print_line("\t-d [ids]  Delete sites (separate ids with \\s )")
+					print_line("\t-d [ids]  Delete sites (separate ids with space)")
 					print_line("\t-l        List all available sites")
 					print_line("\t-s [id]   Display site structure (vhost,url|ids) (level)")
 

--- a/plugins/wmap.rb
+++ b/plugins/wmap.rb
@@ -140,7 +140,8 @@ class Plugin::Wmap < Msf::Plugin
 				when '-d'
 					del_idx = args
 					if del_idx
-						delete_site(del_idx.split(/\s|,|\;/).map(&:to_i).uniq)
+						delete_sites(del_idx.map(&:to_i).uniq)
+						return
 					else
 						print_error("Provide index of site to delete")
 					end
@@ -204,7 +205,7 @@ class Plugin::Wmap < Msf::Plugin
 					print_status("Usage: wmap_sites [options]")
 					print_line("\t-h        Display this help text")
 					print_line("\t-a [url]  Add site (vhost,url)")
-					print_line("\t-d [ids]  Delete sites (separate ids by ',|\\s|;')")
+					print_line("\t-d [ids]  Delete sites (separate ids with \\s )")
 					print_line("\t-l        List all available sites")
 					print_line("\t-s [id]   Display site structure (vhost,url|ids) (level)")
 
@@ -1233,20 +1234,25 @@ class Plugin::Wmap < Msf::Plugin
 			print_status tbl.to_s + "\n"
 		end
 
-		def delete_site(wmap_index)
-			print_status("Deleting site #{wmap_index}")
+		def delete_sites(wmap_index)
 			idx  = 0
+			to_del = {}
+			# Rebuild the index from wmap_sites -l
 			self.framework.db.hosts.each do |bdhost|
 				bdhost.services.each do |serv|
 					serv.web_sites.each do |web|
-						if wmap_index.any? {|w| w == idx}
-							web.delete
-							print_status("Deleted #{web.vhost} on #{bdhost.address} at index #{idx}")
-							return
-						else
-							idx += 1
-						end
+						# If the index of this site matches any deletion index,
+						# add to our hash, saving the index for later output
+						to_del[idx] = web if wmap_index.any? {|w| w.to_i == idx}
+						idx += 1
 					end
+				end
+			end
+			to_del.each do |widx,wsite|
+				if wsite.delete
+					print_status("Deleted #{wsite.vhost} on #{wsite.service.host.address} at index #{widx}")
+				else
+					print_error("Could note delete {wsite.vhost} on #{wsite.service.host.address} at index #{widx}")
 				end
 			end
 		end


### PR DESCRIPTION
More deletion with fewer keystrokes. 

Testing scenario:

```
load wmap
use auxiliary/scanner/http/crawler
set rhost www.metasploit.com
run
set rhost www.rapid7.com
run
set rhost critical.io
run
wmap sites -l
wmap_sites -d 0 2
wmap_sites -l 
```
