### PR TITLE
Auxiliary::Web::Path.from_model: inputs => form.inputs

### DIFF
--- a/lib/msf/core/auxiliary/web/path.rb
+++ b/lib/msf/core/auxiliary/web/path.rb
@@ -118,7 +118,7 @@ class Path  < Fuzzable
 	end
 
 	def self.from_model( form )
-		e = new( :action => "#{form.path}?#{form.query}", :input => inputs[0][1] )
+		e = new( :action => "#{form.path}?#{form.query}", :input => form.inputs[0][1] )
 		e.model = form
 		e
 	end


### PR DESCRIPTION
Fixed uninitialized variable error.
