### PR TITLE
Add Framework side of stdapi.fs.file.mv

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -204,6 +204,25 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
 		alias delete rm
 	end
 
+        #
+        # Performs a rename from oldname to newname
+        #
+        def File.mv(oldname, newname)
+		request = Packet.create_request('stdapi_fs_file_move')
+
+		request.add_tlv(TLV_TYPE_FILE_NAME, client.unicode_filter_decode( oldname ))
+		request.add_tlv(TLV_TYPE_FILE_PATH, client.unicode_filter_decode( newname ))
+
+		response = client.send_request(request)
+
+		return response
+        end
+
+        class << self
+                alias move mv
+                alias rename mv
+        end
+
 	#
 	# Upload one or more files to the remote remote directory supplied in
 	# +destination+.

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/fs.rb
@@ -49,6 +49,7 @@ class Console::CommandDispatcher::Stdapi::Fs
 			"mkdir"    => "Make directory",
 			"pwd"      => "Print working directory",
 			"rm"       => "Delete the specified file",
+			"mv"	   => "Move source to destination",
 			"rmdir"    => "Remove directory",
 			"search"   => "Search for files",
 			"upload"   => "Upload a file or directory",
@@ -69,6 +70,7 @@ class Console::CommandDispatcher::Stdapi::Fs
 			"pwd"      => [ "stdapi_fs_getwd" ],
 			"rmdir"    => [ "stdapi_fs_delete_dir" ],
 			"rm"       => [ "stdapi_fs_delete_file" ],
+			"mv"       => [ "stdapi_fs_file_move" ],
 			"search"   => [ "stdapi_fs_search" ],
 			"upload"   => [ ],
 		}
@@ -220,6 +222,24 @@ class Console::CommandDispatcher::Stdapi::Fs
 	end
 
 	alias :cmd_del :cmd_rm
+
+        #   
+        # Move source to destination
+        #   
+        def cmd_mv(*args)
+                if (args.length < 2)
+                        print_line("Usage: mv oldfile newfile")
+                        return true
+                end 
+
+                client.fs.file.mv(args[0],args[1])
+
+                return true
+        end 
+
+        alias :cmd_move :cmd_mv
+	alias :cmd_rename :cmd_mv
+
 
 	def cmd_download_help
 		print_line "Usage: download [options] src1 src2 src3 ... destination"


### PR DESCRIPTION
Add the appropriate methods to Rex side of the FS extension and
the commensurate command dispatcher.

Requires https://github.com/rapid7/meterpreter/pull/6 from the
meterpreter repo as well as compiling fresh DLL for
ext_server_stdapi.
