### PR TITLE
Convert user/pass tokens to ASCII in db.rb

### DIFF
--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -1426,8 +1426,16 @@ class DBManager
 		service = opts.delete(:service) || report_service(:host => host, :port => port, :proto => proto, :name => sname, :workspace => wspace)
 
 		# Non-US-ASCII usernames are tripping up the database at the moment, this is a temporary fix until we update the tables
-		( token[0] = token[0].gsub(/[\x00-\x1f\x7f-\xff]/){|m| "\\x%.2x" % m.unpack("C")[0] } ) if token[0]
-		( token[1] = token[1].gsub(/[\x00-\x1f\x7f-\xff]/){|m| "\\x%.2x" % m.unpack("C")[0] } ) if token[1]
+		if (token[0])
+			# convert the token to US-ASCII from UTF-8 to prevent an error
+			token[0] = token[0].unpack("C*").pack("C*")
+			token[0] = token[0].gsub(/[\x00-\x1f\x7f-\xff]/){|m| "\\x%.2x" % m.unpack("C")[0] }
+		end
+
+		if (token[1])
+			token[1] = token[1].unpack("C*").pack("C*")
+			token[1] = token[1].gsub(/[\x00-\x1f\x7f-\xff]/){|m| "\\x%.2x" % m.unpack("C")[0] }
+		end
 
 		ret = {}
 


### PR DESCRIPTION
This commit fixes an Encoding::CompatibilityError incompatible
encoding regexp match (ASCII-8BIT regexp with UTF-8 string) when
sanitizing non-printable tokens from a user/pass string.

The UTF-8 strings are derived from strings passed through the
module.execute RPC call.
