### PR TITLE
loot add/remove for msfconsole

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+#
 require 'rexml/document'
 require 'rex/parser/nmap_xml'
 require 'msf/core/db_export'

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -978,7 +978,7 @@ class Db
 			print_line "Usage: loot [-h] [addr1 addr2 ...] [-t <type1,type2>]"
 			print_line
 			print_line "  -a,--add          Add a loot to the list of addresses, instead of listing"
-			print_line "  -d,--delete       Delete the hosts instead of searching"
+			print_line "  -d,--delete       Delete *all* the loot associated with hosts, instead of searching"
 			print_line "  -f --file         File with contents of the loot to add"
 			print_line "  -i --info         Info of the loot to add"
 			print_line "  -t <type1,type2>  Search for a list of types"

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1,5 +1,3 @@
-# -*- coding: binary -*-
-
 require 'rexml/document'
 require 'rex/parser/nmap_xml'
 require 'msf/core/db_export'
@@ -977,6 +975,10 @@ class Db
 		def cmd_loot_help
 			print_line "Usage: loot [-h] [addr1 addr2 ...] [-t <type1,type2>]"
 			print_line
+			print_line "  -a,--add          Add a loot to the list of addresses, instead of listing"
+			print_line "  -d,--delete       Delete the hosts instead of searching"
+			print_line "  -f --file         File with contents of the loot to add"
+			print_line "  -i --info         Info of the loot to add"
 			print_line "  -t <type1,type2>  Search for a list of types"
 			print_line "  -h,--help         Show this help information"
 			print_line "  -S,--search       Search string to filter by"
@@ -991,31 +993,52 @@ class Db
 			types = nil
 			delete_count = 0
 			search_term = nil
+			file = nil
+			name = nil
+			info = nil
 
 			while (arg = args.shift)
 				case arg
-				when '-d','--delete'
-					mode = :delete
-				when '-t'
-					typelist = args.shift
-					if(!typelist)
-						print_status("Invalid type list")
+					when '-a','--add'
+						mode = :add
+					when '-d','--delete'
+						mode = :delete
+					when '-f','--file'
+						filename = args.shift
+						if(!filename)
+							print_error("Can't make loot with no filename")
+							return
+						end
+						if (!File.exists?(filename) or !File.readable?(filename))
+							print_error("Can't read file")
+							return
+						end
+					when '-i','--info'
+						info = args.shift
+						if(!info)
+							print_error("Can't make loot with no info")
 						return
 					end
-					types = typelist.strip().split(",")
-				when '-S', '--search'
-					search_term = /#{args.shift}/nmi
-				when '-h','--help'
-					cmd_loot_help
-					return
-				else
-					# Anything that wasn't an option is a host to search for
-					unless (arg_host_range(arg, host_ranges))
+					when '-t'
+						typelist = args.shift
+						if(!typelist)
+							print_error("Invalid type list")
+							return
+						end
+						types = typelist.strip().split(",")
+					when '-S', '--search'
+						search_term = /#{args.shift}/nmi
+					when '-h','--help'
+						cmd_loot_help
+						return
+					else
+						# Anything that wasn't an option is a host to search for
+						unless (arg_host_range(arg, host_ranges))
 						return
 					end
 				end
-
 			end
+
 			tbl = Rex::Ui::Text::Table.new({
 					'Header'  => "Loot",
 					'Columns' => [ 'host', 'service', 'type', 'name', 'content', 'info', 'path' ],
@@ -1023,6 +1046,32 @@ class Db
 
 			# Sentinal value meaning all
 			host_ranges.push(nil) if host_ranges.empty?
+
+		if mode == :add
+			if info.nil?
+				print_error("Info required")
+				return
+			end
+			if filename.nil?
+				print_error("Loot file required")
+				return
+			end
+			if types.nil? or types.size != 1
+				print_error("Exactly one note type is required")
+				return
+			end
+			type = types.first
+			name = File.basename(filename)
+			host_ranges.each do |range|
+				range.each do |host|
+					file = File.open(filename, "rb")
+					contents = file.read
+					lootfile = framework.db.find_or_create_loot(:type => type, :host => host,:info => info, :data => contents,:path => filename,:name => name)
+					print_status "Added loot #{host}"
+				end
+			end
+			return
+		end
 
 			each_host_range_chunk(host_ranges) do |host_search|
 				framework.db.hosts(framework.db.workspace, false, host_search).each do |host|


### PR DESCRIPTION
Here is an example:

msf  exploit(handler) > loot --file /tmp/testing.txt -i Test -t cracked  -a 192.168.10.100
[*] Added loot 192.168.10.100
msf  exploit(handler) > loot -d 192.168.10.100
# Loot

host            service  type     name         content     info  path

---

192.168.10.100           cracked  testing.txt  text/plain  Test  /tmp/testing.txt

[*] Deleted 1 loots
msf  exploit(handler) > loot -h
Usage: loot [-h] [addr1 addr2 ...] [-t <type1,type2>]

  -a,--add          Add a loot to the list of addresses, instead of listing
  -d,--delete       Delete the hosts instead of searching
  -f --file         File with contents of the loot to add
  -i --info         Info of the loot to add
  -t <type1,type2>  Search for a list of types
  -h,--help         Show this help information
  -S,--search       Search string to filter by
