### PR TITLE
Added advanced option for temp filenames prefix

### DIFF
--- a/modules/auxiliary/admin/smb/psexec_command.rb
+++ b/modules/auxiliary/admin/smb/psexec_command.rb
@@ -51,6 +51,10 @@ class Metasploit3 < Msf::Auxiliary
 			OptString.new('WINPATH', [true, 'The name of the remote Windows directory', 'WINDOWS']),
 		], self.class)
 
+		register_advanced_options([
+			OptString.new('FILEPREFIX', [false, 'Add a custom prefix to the temporary files','']),
+		], self.class)
+
 		deregister_options('RHOST')
 	end
 
@@ -60,8 +64,8 @@ class Metasploit3 < Msf::Auxiliary
 
 	# This is the main controle method
 	def run_host(ip)
-		text = "\\#{datastore['WINPATH']}\\Temp\\#{Rex::Text.rand_text_alpha(16)}.txt"
-		bat  = "\\#{datastore['WINPATH']}\\Temp\\#{Rex::Text.rand_text_alpha(16)}.bat"
+		text = "\\#{datastore['WINPATH']}\\Temp\\#{datastore['FILEPREFIX']}#{Rex::Text.rand_text_alpha(16)}.txt"
+		bat  = "\\#{datastore['WINPATH']}\\Temp\\#{datastore['FILEPREFIX']}#{Rex::Text.rand_text_alpha(16)}.bat"
 		@smbshare = datastore['SMBSHARE']
 		@ip = ip
 


### PR DESCRIPTION
I added an advanced OptString option of FILEPREFIX. This allows the tester to set a custom prefix to the .txt and .bat temporary files. This is useful for post-engagement cleanup, especially when the module creates temporary files but is not able to remove them. The default value for FILEPREFIX is an empty string.

Not much changed, but I still tested the changes against a Win7 Enterprise host. The module created filenames with prefixes as expected. Command execution still worked as expected.
