### PR TITLE
Fully deprecates msfupdate over SVN

### DIFF
--- a/msfconsole
+++ b/msfconsole
@@ -36,13 +36,14 @@ end
 
 def print_deprecation_warning
 	$stdout.puts ""
-	$stdout.puts "[*] Deprecation Note: After 2013-03-15 (March 15, 2013), Metasploit"
-	$stdout.puts "[*] source checkouts will NO LONGER update over SVN, but will be using"
-	$stdout.puts "[*] GitHub exclusively. You should either download a new Metasploit"
-	$stdout.puts "[*] installer, or use a git clone of Metasploit Framework before"
-	$stdout.puts "[*] then. You will also need outbound access to github.com on"
-	$stdout.puts "[*] TCP port 9418 (git), 22 (ssh) or 443 (https), depending on the"
-	$stdout.puts "[*] protocol used to clone Metasploit Framework (usually, git protocol)."
+	$stdout.puts "[-] Deprecation Note: Metasploit source checkouts NO LONGER update"
+	$stdout.puts "[-] over SVN. You will need to reinstall Metasploit using"
+	$stdout.puts "[-] binary installers (from http://www.metasploit.com/download ),"
+	$stdout.puts "[-] Debian packages (currently only supported on Kali Linux), or"
+	$stdout.puts "[-] a development source checkout from GitHub (see http://r-7.co/ZLhA8P )"
+	$stdout.puts "[-] "
+	$stdout.puts "[-] For more on msfupdate and migrating off of SVN, see http://r-7.co/MSF-UP"
+	$stdout.puts ""
 end
 
 if is_svn

--- a/msfupdate
+++ b/msfupdate
@@ -58,12 +58,15 @@ end
 
 def print_deprecation_warning
 	$stdout.puts ""
-	$stdout.puts "[*] Deprecation Note: After 2013-02-28 (February 28, 2013), Metasploit"
-	$stdout.puts "[*] source checkouts will NO LONGER update over SVN, but will be using"
-	$stdout.puts "[*] GitHub exclusively. You should either download a new Metasploit"
-	$stdout.puts "[*] installer, or use a git clone of Metasploit Framework before"
-	$stdout.puts "[*] then. You will also need outbound access to github.com:9418/TCP."
+	$stdout.puts "[-] Deprecation Note: Metasploit source checkouts NO LONGER update"
+	$stdout.puts "[-] over SVN. You will need to reinstall Metasploit using"
+	$stdout.puts "[-] binary installers (from http://www.metasploit.com/download ),"
+	$stdout.puts "[-] Debian packages (currently only supported on Kali Linux), or"
+	$stdout.puts "[-] a development source checkout from GitHub (see http://r-7.co/ZLhA8P )"
+	$stdout.puts "[-] "
+	$stdout.puts "[-] For more on msfupdate and migrating off of SVN, see http://r-7.co/MSF-UP"
 	$stdout.puts ""
+	maybe_wait_and_exit 0x11
 end
 
 def maybe_wait_and_exit(exit_code=0)

--- a/msfupdate
+++ b/msfupdate
@@ -66,9 +66,10 @@ def print_deprecation_warning
 	$stdout.puts "[-] "
 	$stdout.puts "[-] For more on msfupdate and migrating off of SVN, see http://r-7.co/MSF-UP"
 	$stdout.puts ""
-	maybe_wait_and_exit 0x11
 end
 
+# This only exits if you actually pass a wait option, otherwise
+# just returns nil. This is likely unexpected, revisit this.
 def maybe_wait_and_exit(exit_code=0)
 	if @actually_wait
 		$stdout.puts ""
@@ -132,7 +133,13 @@ end
 
 ####### Since we're SVN, do it all this way #######
 if is_svn
+	# We're fully deprecated now, so just exit.
+	# Leaving in the commented code in case someone wants to
+	# get a last-chance at msfupdate before the SVN server goes
+	# off line, which will be ANY DAY NOW. Seriously.
 	print_deprecation_warning
+	$stdin.readline if @actually_wait
+	exit(0x11) # Comment this to get old functionality back.
 	@args.push("--config-dir=#{@configdir}")
 	@args.push("--non-interactive")
 


### PR DESCRIPTION
Once this lands, SVN users will no longer be able to update over SVN. Please don't merge this unless and until you want to permanently break msfupdate for SVN users!

After landing this, the msfupdate command for SVN checkouts will exit with code 0x11. These users can still sneak around it by issuing a 'svn update' in the correct svn checkout, but users with old Windows installations who are used to picking "Update Framework" from the start menu will simply see the error and exit out.
# Verification
- [x] Have an svn checkout. This is usually a painful experience (this is why SVN is going away), so it might be best to just use the SVN checkout from Metasploit 4.3 or earlier.
- [x] Replace `msfupdate` with this one
- [x] Run `msfupdate` on the command line, and see that you get a warning and an exit.
- [x] Run "Update Framework" from the Windows start menu (if using 4.3 or earlier), see that you get the message, a pause, then exits.
