### PR TITLE
Auxiliary::Web::HTTP#_request: elog => print_error

### DIFF
--- a/lib/msf/core/auxiliary/web/http.rb
+++ b/lib/msf/core/auxiliary/web/http.rb
@@ -252,11 +252,6 @@ class Auxiliary::Web::HTTP
 
 	private
 
-	def print_error( message )
-		return if !@parent
-		@parent.print_error message
-	end
-
 	def call_after_run_blocks
 		while block = @after_run_blocks.pop
 			block.call
@@ -318,9 +313,14 @@ class Auxiliary::Web::HTTP
 	# This is bad but we can't anticipate the gazilion different types of network
 	# i/o errors between Rex and Errno.
 	rescue => e
-		elog e.to_s
-		e.backtrace.each { |l| elog l }
+		print_error e.to_s
+		e.backtrace.each { |l| print_error l }
 		Response.empty
+	end
+
+	def print_error( message )
+		return if !@parent
+		@parent.print_error message
 	end
 
 end


### PR DESCRIPTION
Switched form `#elog` to `#print_error` to make reporting bugs easier on users.

(Redmine: https://dev.metasploit.com/redmine/issues/7815)
