### PR TITLE
Free up URIPATH resources on exploit death (RM#7692)

### DIFF
--- a/lib/msf/core/exploit_driver.rb
+++ b/lib/msf/core/exploit_driver.rb
@@ -320,6 +320,16 @@ protected
 		# Ensure that, no matter what, clean up of the handler occurs
 		payload.stop_handler
 
+		# If a URIPATH was used, clear it for future use
+		if exploit.datastore['URIPATH']
+			# If exploit dies before HTTP server is setup, this will
+			# throw a no method error, so catch it
+			begin
+				exploit.remove_resource(exploit.datastore['URIPATH'])
+			rescue NoMethodError
+			end
+		end
+
 		exploit.framework.events.on_module_complete(exploit)
 
 		# Allow the exploit to cleanup after itself, that messy bugger.


### PR DESCRIPTION
This update forces URIPATH resources to be released during cleanup processing when a job/exploit is killed or otherwise dies and is related to redmine issue #7692:
http://dev.metasploit.com/redmine/issues/7692

The issue was actually more pervasive than the redmine bug indicates, as it will occur even when a single uripath is used in an exploit, killed and then an attempt to re-use is made (not just for multiple exploits co-existing).

The fix was placed in exploit_driver.rb as it appears to be the best place to catch the exit via existing cleanup setups without having to modify every module using Msf::Exploit::Remote::HttpServer::HTML (and others) to add a cleanup function.

Testing was done in a number of scenarios including before and after PR for single exploit/kill/exploit chains and situations more parallel to that in the redmine issue (as demonstrated in the testing output below). Additional testing and error handling was added for other failure modes related to exploit initialization and kills (i.e. port already bound).

**Original Version**:
msf > use exploit/multi/browser/java_jre17_jmxbean
msf  exploit(java_jre17_jmxbean) > set LHOST 192.168.1.135
LHOST => 192.168.1.135
msf  exploit(java_jre17_jmxbean) > set LPORT 808
LPORT => 808
msf  exploit(java_jre17_jmxbean) > set URIPATH /test
URIPATH => /test
msf  exploit(java_jre17_jmxbean) > set PAYLOAD java/meterpreter/reverse_tcp 
PAYLOAD => java/meterpreter/reverse_tcp
msf  exploit(java_jre17_jmxbean) > exploit
[_] Exploit running as background job.
msf  exploit(java_jre17_jmxbean) > 
[_] Started reverse handler on 192.168.1.135:808 
[_] Using URL: http://0.0.0.0:8080/test
[_]  Local IP: http://192.168.1.135:8080/test
[_] Server started.
set LPORT 443
LPORT => 443
msf  exploit(java_jre17_jmxbean) > set URIPATH /test2
URIPATH => /test2
msf  exploit(java_jre17_jmxbean) > exploit
[_] Exploit running as background job.
msf  exploit(java_jre17_jmxbean) > 
[_] Started reverse handler on 192.168.1.135:443 
[_] Using URL: http://0.0.0.0:8080/test2
[_]  Local IP: http://192.168.1.135:8080/test2
[_] Server started.
jobs

Jobs
\=\=\=\=

  Id  Name

---

  0   Exploit: multi/browser/java_jre17_jmxbean
  1   Exploit: multi/browser/java_jre17_jmxbean

msf  exploit(java_jre17_jmxbean) > kill 1
Stopping job: 1...

[_] Server stopped.
msf  exploit(java_jre17_jmxbean) > exploit
[_] Exploit running as background job.
msf  exploit(java_jre17_jmxbean) > 
[_] Started reverse handler on 192.168.1.135:443 
[_] Using URL: http://0.0.0.0:8080/test2
[_]  Local IP: http://192.168.1.135:8080/test2
*_[-] Exploit failed: Rex::RuntimeError The supplied resource '/test2' is already added.**
[*] Server stopped.

**New Version**:
msf > use exploit/multi/browser/java_jre17_jmxbean
msf  exploit(java_jre17_jmxbean) > set LHOST 192.168.1.135
LHOST => 192.168.1.135
msf  exploit(java_jre17_jmxbean) > set LPORT 808
LPORT => 808
msf  exploit(java_jre17_jmxbean) > set URIPATH /test
URIPATH => /test
msf  exploit(java_jre17_jmxbean) > set PAYLOAD java/meterpreter/reverse_tcp 
PAYLOAD => java/meterpreter/reverse_tcp
msf  exploit(java_jre17_jmxbean) > exploit
[_] Exploit running as background job.
msf  exploit(java_jre17_jmxbean) > 
[_] Started reverse handler on 192.168.1.135:808 
[_] Using URL: http://0.0.0.0:8080/test
[_]  Local IP: http://192.168.1.135:8080/test
[_] Server started.
set LPORT 443
LPORT => 443
msf  exploit(java_jre17_jmxbean) > set URIPATH /test2
URIPATH => /test2
msf  exploit(java_jre17_jmxbean) > exploit
[_] Exploit running as background job.
msf  exploit(java_jre17_jmxbean) > 
[_] Started reverse handler on 192.168.1.135:443 
[_] Using URL: http://0.0.0.0:8080/test2
[_]  Local IP: http://192.168.1.135:8080/test2
[_] Server started.
jobs

Jobs
\=\=\=\=

  Id  Name

---

  0   Exploit: multi/browser/java_jre17_jmxbean
  1   Exploit: multi/browser/java_jre17_jmxbean

msf  exploit(java_jre17_jmxbean) > kill 1
Stopping job: 1...

[_] Server stopped.
msf  exploit(java_jre17_jmxbean) > exploit
[_] Exploit running as background job.
msf  exploit(java_jre17_jmxbean) > 
[_] Started reverse handler on 192.168.1.135:443 
[_] Using URL: http://0.0.0.0:8080/test2
[_]  Local IP: http://192.168.1.135:8080/test2
*_[_] Server started._*
msf  exploit(java_jre17_jmxbean) >
