### PR TITLE
Fix to results print out in post/creds/epo_sql

### DIFF
--- a/modules/post/windows/gather/credentials/epo_sql.rb
+++ b/modules/post/windows/gather/credentials/epo_sql.rb
@@ -133,7 +133,7 @@ class Metasploit3 < Msf::Post
 			print_good("Domain: #{user_domain}");
 			full_user = "#{user_domain}\\#{user_name}"
 		end
-		print_good("User: #{user_name}")
+		print_good("User: #{full_user}")
 		print_good("Password: #{plaintext_passwd}")
 
 		if (db_ip)


### PR DESCRIPTION
Small fix to my epo_sql post module to print out the full username (including domain if applicable). The existing db reporting was correct, but prefer to have the status print out match the db.
