### PR TITLE
Minor fixes to tomcat_enum

### DIFF
--- a/modules/auxiliary/scanner/http/tomcat_enum.rb
+++ b/modules/auxiliary/scanner/http/tomcat_enum.rb
@@ -56,18 +56,12 @@ class Metasploit3 < Msf::Auxiliary
 
 	def run_host(ip)
 		@users_found = {}
-		results = ""
 
 		each_user_pass { |user,pass|
-			results = do_login(user)
-			if results == "NetworkError"
-				break
-			end
+			do_login(user)
 		}
-
-		if results == "NetworkError"
-			print_error("#{target_url} - UNREACHABLE")		
-		elsif(@users_found.empty?)
+	
+		if(@users_found.empty?)
 			print_status("#{target_url} - No users found.")
 		else
 			print_good("#{target_url} - Users found: #{@users_found.keys.sort.join(", ")}")
@@ -105,10 +99,9 @@ class Metasploit3 < Msf::Auxiliary
 				return :abort
 			end
 
-		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-			return "NetworkError"
-		rescue ::Timeout::Error, ::Errno::EPIPE
-			return "NetworkError"
+		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE
+			print_error("#{target_url} - UNREACHABLE")
+			return :abort
 		end
 	end
 

--- a/modules/auxiliary/scanner/http/tomcat_enum.rb
+++ b/modules/auxiliary/scanner/http/tomcat_enum.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Auxiliary
 		each_user_pass { |user,pass|
 			do_login(user)
 		}
-	
+
 		if(@users_found.empty?)
 			print_status("#{target_url} - No users found.")
 		else


### PR DESCRIPTION
tomcat_enum fails to deregister USER_AS_PASS which causes it to attempt user names twice without reason. Additionally, if there is an issue connecting to a specified host, the module continues to attempt every username in the list.

This PR resolves both of these issues.

**Before PR with server available or unavailable:**
```
msf auxiliary(tomcat_enum) > run

[_] 192.168.56.101:8180  - [1/4] - /admin/j_security_check - Apache Tomcat - Trying name: 'tomcat'
[_] 192.168.56.101:8180  - [2/4] - /admin/j_security_check - Apache Tomcat - Trying name: 'garbage'
[_] 192.168.56.101:8180  - [3/4] - /admin/j_security_check - Apache Tomcat - Trying name: 'tomcat'
[_] 192.168.56.101:8180  - [4/4] - /admin/j_security_check - Apache Tomcat - Trying name: 'garbage'
[_] http://192.168.56.101:8180/admin/j_security_check - No users found.
[_] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
**After PR with server available:**
```
msf auxiliary(tomcat_enum) > run

[_] 192.168.56.101:8180  - [1/2] - /admin/j_security_check - Apache Tomcat - Trying name: 'tomcat'
[_] 192.168.56.101:8180  - [2/2] - /admin/j_security_check - Apache Tomcat - Trying name: 'garbage'
[_] http://192.168.56.101:8180/admin/j_security_check - No users found.
[_] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
**After PR with server unavailable:**
```
msf auxiliary(tomcat_enum) > run

[_] 192.168.56.101:8180  - [1/2] - /admin/j_security_check - Apache Tomcat - Trying name: 'tomcat'
[-] http://192.168.56.101:8180/admin/j_security_check - UNREACHABLE
[_] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```