### PR TITLE
password list for the dlink backdoor on some telnet services

### DIFF
--- a/data/wordlists/dlink_telnet_backdoor_userpass.txt
+++ b/data/wordlists/dlink_telnet_backdoor_userpass.txt
@@ -1,0 +1,7 @@
+Alphanetworks wrgg19_c_dlwbr_dir300 
+Alphanetworks wrgn49_dlob_dir600b
+Alphanetworks wrgn23_dlwbr_dir600b
+Alphanetworks wrgn22_dlwbr_dir615
+Alphanetworks wrgnd08_dlob_dir815
+Alphanetworks wrgg15_di524
+Alphanetworks wrgn39_dlob.hans_dir645


### PR DESCRIPTION
For #1648, because that one actually tries to delete an existing module
