### PR TITLE
fix winrm poke method

### DIFF
--- a/lib/msf/core/exploit/winrm.rb
+++ b/lib/msf/core/exploit/winrm.rb
@@ -35,21 +35,8 @@ module Exploit::Remote::WinRM
 	end
 
 	def winrm_poke(timeout = 20)
-		opts = {
-			'uri' => datastore['URI'],
-			'data' => Rex::Text.rand_text_alpha(8)
-		}
-		c = connect(opts)
-		to = opts[:timeout] || timeout
-		ctype = "application/soap+xml;charset=UTF-8"
-		resp = send_winrm_request(opts.merge({
-			'uri' => opts['uri'],
-			'method' => 'POST',
-			'ctype'     => ctype,
-			'data'        => opts['data']
-		}), to)
-		return resp
-	end
+		send_winrm_request(Rex::Text.rand_text_alpha(8), timeout)
+  end
 
 	def parse_auth_methods(resp)
 		return [] unless resp and resp.code == 401


### PR DESCRIPTION
The winrm poke method was borken during the rex http refactor. This corrects the issue.. High priority fix
