### PR TITLE
Auxiliary::Web::HTTP#_request: print_error => elog

### DIFF
--- a/lib/msf/core/auxiliary/web/http.rb
+++ b/lib/msf/core/auxiliary/web/http.rb
@@ -313,8 +313,8 @@ class Auxiliary::Web::HTTP
 	# This is bad but we can't anticipate the gazilion different types of network
 	# i/o errors between Rex and Errno.
 	rescue => e
-		print_error e.to_s
-		e.backtrace.each { |l| print_error l }
+		elog e.to_s
+		e.backtrace.each { |l| elog l }
 		Response.empty
 	end
 


### PR DESCRIPTION
Reverted earlier commit.

Callback exceptions still print the backtrace.

(Redmine: https://dev.metasploit.com/redmine/issues/7839)
