### PR TITLE
Anemone::Page#links: removed upwards dir traversal

### DIFF
--- a/lib/anemone/page.rb
+++ b/lib/anemone/page.rb
@@ -96,32 +96,7 @@ module Anemone
      # MODIFIED: Dig URLs from elements other than "A" refs
      #
     def links
-      return @links if @links
-      @links = []
-      return @links if !doc
-
-      @links = run_extractors
-
-      @links |= @links.map do |u|
-          # back-off to the parent dir
-          to_absolute( URI( u.path.gsub( /(.*\/)[^\/]+$/, "\\1" ) ) ) rescue next
-      end.uniq.compact
-
-      nlinks = []
-      @links.each do |u|
-	      bits = u.path.split('/')
-	      while(bits.length > 0)
-		      bits.pop
-		      j = bits.join('/')
-		      j = '/' if j.empty?
-		      nlinks << to_absolute(URI(j)) rescue next
-	      end
-      end
-      @links |= nlinks
-
-      @links.flatten!
-      @links.uniq!
-      @links
+      @links ||= run_extractors
     end
 
     #


### PR DESCRIPTION
Turns out we don't actually want this anymore.
- [x] Scan Mutillidae on Metasploitable2.
- [x] VERIFY: Crawler doesn't get out of `/mutillidae/`.

(PT: https://www.pivotaltracker.com/story/show/47241427)
