### PR TITLE
Fix encoding of strings from MSFRPC 

### DIFF
--- a/lib/msf/core/module_set.rb
+++ b/lib/msf/core/module_set.rb
@@ -37,6 +37,7 @@ class Msf::ModuleSet < Hash
   # @return [Msf::Module,nil] Instance of the named module or nil if it
   #   could not be created.
   def create(name)
+    name = name.encode(''.encoding.name)
     klass = fetch(name, nil)
     instance = nil
 


### PR DESCRIPTION
Fixes an issue that causes exploits to fail if the PAYLOAD option is 
the last option to get marshalled in an MSFRPC dictionary. The patch
adjusts the string's encoding to match the internal default encoding
used by Ruby. Hence, making fetch() succeed.
