### PR TITLE
Have Post::File use shiny new session.fs.file.mv

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -299,13 +299,18 @@ module Msf::Post::File
 	end
 
 	#
-	# Rename a remote file.  This is a stopgap until a proper API version is added:
-	# http://dev.metasploit.com/redmine/issues/7288
+	# Rename a remote file.
 	#
-	def rename_file(new_file, old_file)
-		#TODO:  this is not ideal as the file contents are sent to meterp server and back to the client
-		write_file(new_file, read_file(old_file))
-		rm_f(old_file)
+	def rename_file(old_file, new_file)
+		if session.respond_to? :commands and session.commands.include?("stdapi_fs_file_move")
+			session.fs.file.mv(old_file, new_file)
+		else
+				if session.platform =~ /win/
+					cmd_exec(%Q|move /y "#{old_file}" "#{new_file}"|)
+				else
+					cmd_exec(%Q|mv -f "#{old_file}" "#{new_file}"|)
+				end
+		end
 	end
 	alias :move_file :rename_file
 	alias :mv_file :rename_file

--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -13,11 +13,10 @@ class Metasploit4 < Msf::Post
 
 	def initialize(info={})
 		super( update_info( info,
-				'Name'          => 'Testing remote file manipulation',
+				'Name'          => 'Testing Remote File Manipulation',
 				'Description'   => %q{ This module will test Post::File API methods },
 				'License'       => MSF_LICENSE,
 				'Author'        => [ 'egypt'],
-				'Version'       => '$Revision$',
 				'Platform'      => [ 'windows', 'linux', 'java' ],
 				'SessionTypes'  => [ 'meterpreter', 'shell' ]
 			))
@@ -100,6 +99,23 @@ class Metasploit4 < Msf::Post
 			file_rm("pwned")
 
 			not file_exist?("pwned")
+		end
+
+		it "should move files" do
+				# Make sure we don't have leftovers from a previous run
+				file_rm("meterpreter-test") rescue nil
+				file_rm("meterpreter-test-moved") rescue nil
+
+				# touch a new file
+				write_file("meterpreter-test", "")
+
+				rename_file("meterpreter-test", "meterpreter-test-moved")
+				res &&= exist?("meterpreter-test-moved")
+				res &&= !exist?("meterpreter-test")
+
+				# clean up
+				file_rm("meterpreter-test") rescue nil
+				file_rm("meterpreter-test-moved") rescue nil
 		end
 
 	end


### PR DESCRIPTION
Also adds a quick and dirty test. Verified working on Linux shell, Linux
meterpreter, and Windows x86 and x64 meterpreter.

See #1579
