### PR TITLE
Improve Postgres CVE-2013-1899 to detect unauthorized connections

### DIFF
--- a/modules/auxiliary/scanner/postgres/postgres_dbname_flag_injection.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_dbname_flag_injection.rb
@@ -67,6 +67,8 @@ class Metasploit3 < Msf::Auxiliary
 				:info	=> "Vulnerable: " + proof,
 				:refs   => self.references
 			})
+    elsif resp.to_s =~ /pg_hba.conf/
+      print_error("#{rhost}:#{rport} does not allow connections from us")
 		else
 			print_status("#{rhost}:#{rport} does not appear to be vulnerable to CVE-2013-1899")
 		end


### PR DESCRIPTION
The check as written will identify targets with a restrictive pg_hba.conf as invulnerable, which is slightly incorrect
