### PR TITLE
Allow meterpreter transport ssl version selection

### DIFF
--- a/lib/msf/base/sessions/meterpreter_options.rb
+++ b/lib/msf/base/sessions/meterpreter_options.rb
@@ -15,7 +15,8 @@ module MeterpreterOptions
 				OptString.new('InitialAutoRunScript', [false, "An initial script to run on session creation (before AutoRunScript)", '']),
 				OptString.new('AutoRunScript', [false, "A script to run automatically on session creation.", '']),
 				OptBool.new('AutoSystemInfo', [true, "Automatically capture system information on initialization.", true]),
-				OptBool.new('EnableUnicodeEncoding', [true, "Automatically encode UTF-8 strings as hexadecimal", true])
+				OptBool.new('EnableUnicodeEncoding', [true, "Automatically encode UTF-8 strings as hexadecimal", true]),
+				OptEnum.new('TransportSSLVersion', [false, "Use SSLv3 or TLSv1 for meterpreter session", 'TLSv1', %w(TLSv1 SSLv3)])
 			], self.class)
 	end
 

--- a/lib/msf/base/sessions/meterpreter_options.rb
+++ b/lib/msf/base/sessions/meterpreter_options.rb
@@ -16,7 +16,7 @@ module MeterpreterOptions
 				OptString.new('AutoRunScript', [false, "A script to run automatically on session creation.", '']),
 				OptBool.new('AutoSystemInfo', [true, "Automatically capture system information on initialization.", true]),
 				OptBool.new('EnableUnicodeEncoding', [true, "Automatically encode UTF-8 strings as hexadecimal", true]),
-				OptEnum.new('TransportSSLVersion', [false, "Use SSLv3 or TLSv1 for meterpreter session", 'TLSv1', %w(TLSv1 SSLv3)])
+				OptEnum.new('TransportSSLVersion', [false, "Use SSLv3 or TLSv1 for meterpreter session", 'SSLv3', %w(TLSv1 SSLv3)])
 			], self.class)
 	end
 

--- a/lib/msf/base/sessions/meterpreter_options.rb
+++ b/lib/msf/base/sessions/meterpreter_options.rb
@@ -16,7 +16,7 @@ module MeterpreterOptions
 				OptString.new('AutoRunScript', [false, "A script to run automatically on session creation.", '']),
 				OptBool.new('AutoSystemInfo', [true, "Automatically capture system information on initialization.", true]),
 				OptBool.new('EnableUnicodeEncoding', [true, "Automatically encode UTF-8 strings as hexadecimal", true]),
-				OptEnum.new('TransportSSLVersion', [false, "Use SSLv3 or TLSv1 for meterpreter session", 'SSLv3', %w(TLSv1 SSLv3)])
+				OptEnum.new('TransportSSLVersion', [false, "Use SSLv3 or TLSv1 for meterpreter session", 'TLSv1', %w(TLSv1 SSLv3)])
 			], self.class)
 	end
 

--- a/lib/msf/core/payload/stager.rb
+++ b/lib/msf/core/payload/stager.rb
@@ -185,6 +185,11 @@ module Msf::Payload::Stager
 	# @param (see Handler#create_session)
 	# @return (see Handler#create_session)
 	def handle_connection_stage(conn, opts={})
+		# Allow passing session transport information down from user level
+		# At present only used with standard meterpreters to switch between TLS and SSL
+		if datastore['TransportSSLVersion'] and not opts.has_key?(:transport_ssl_version)
+			opts.merge!({:transport_ssl_version => datastore['TransportSSLVersion'].intern})
+		end
 		create_session(conn, opts)
 	end
 

--- a/lib/rex/post/meterpreter/client.rb
+++ b/lib/rex/post/meterpreter/client.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # -*- coding: binary -*-
 
 require 'socket'
@@ -34,456 +33,453 @@ end
 ###
 class Client
 
-	include Rex::Post::Meterpreter::PacketDispatcher
-	include Rex::Post::Meterpreter::ChannelContainer
+  include Rex::Post::Meterpreter::PacketDispatcher
+  include Rex::Post::Meterpreter::ChannelContainer
 
-	#
-	# Extension name to class hash.
-	#
-	@@ext_hash = {}
+  #
+  # Extension name to class hash.
+  #
+  @@ext_hash = {}
 
-	#
-	# Cached SSL certificate (required to scale)
-	#
-	@@ssl_ctx = nil
+  #
+  # Cached SSL certificate (required to scale)
+  #
+  @@ssl_ctx = nil
 
-	#
-	# Mutex to synchronize class-wide operations
-	#
-	@@ssl_mutex = ::Mutex.new
+  #
+  # Mutex to synchronize class-wide operations
+  #
+  @@ssl_mutex = ::Mutex.new
 
-	#
-	# Lookup the error that occurred
-	#
-	def self.lookup_error(code)
-		code
-	end
+  #
+  # Lookup the error that occurred
+  #
+  def self.lookup_error(code)
+    code
+  end
 
-	#
-	# Checks the extension hash to see if a class has already been associated
-	# with the supplied extension name.
-	#
-	def self.check_ext_hash(name)
-		@@ext_hash[name]
-	end
+  #
+  # Checks the extension hash to see if a class has already been associated
+  # with the supplied extension name.
+  #
+  def self.check_ext_hash(name)
+    @@ext_hash[name]
+  end
 
-	#
-	# Stores the name to class association for the supplied extension name.
-	#
-	def self.set_ext_hash(name, klass)
-		@@ext_hash[name] = klass
-	end
+  #
+  # Stores the name to class association for the supplied extension name.
+  #
+  def self.set_ext_hash(name, klass)
+    @@ext_hash[name] = klass
+  end
 
-	#
-	# Initializes the client context with the supplied socket through
-	# which communication with the server will be performed.
-	#
-	def initialize(sock,opts={})
-		init_meterpreter(sock, opts)
-	end
+  #
+  # Initializes the client context with the supplied socket through
+  # which communication with the server will be performed.
+  #
+  def initialize(sock,opts={})
+    init_meterpreter(sock, opts)
+  end
 
-	#
-	# Cleans up the meterpreter instance, terminating the dispatcher thread.
-	#
-	def cleanup_meterpreter
-		ext.aliases.each_value do | extension |
-			extension.cleanup if extension.respond_to?( 'cleanup' )
-		end
-		dispatcher_thread.kill if dispatcher_thread
-		core.shutdown rescue nil
-		shutdown_passive_dispatcher
-	end
+  #
+  # Cleans up the meterpreter instance, terminating the dispatcher thread.
+  #
+  def cleanup_meterpreter
+    ext.aliases.each_value do | extension |
+      extension.cleanup if extension.respond_to?( 'cleanup' )
+    end
+    dispatcher_thread.kill if dispatcher_thread
+    core.shutdown rescue nil
+    shutdown_passive_dispatcher
+  end
 
-	#
-	# Initializes the meterpreter client instance
-	#
-	def init_meterpreter(sock,opts={})
-		self.sock         = sock
-		self.parser       = PacketParser.new
-		self.ext          = ObjectAliases.new
-		self.ext_aliases  = ObjectAliases.new
-		self.alive        = true
-		self.target_id    = opts[:target_id]
-		self.capabilities = opts[:capabilities] || {}
-		self.commands     = []
+  #
+  # Initializes the meterpreter client instance
+  #
+  def init_meterpreter(sock,opts={})
+    self.sock         = sock
+    self.parser       = PacketParser.new
+    self.ext          = ObjectAliases.new
+    self.ext_aliases  = ObjectAliases.new
+    self.alive        = true
+    self.target_id    = opts[:target_id]
+    self.capabilities = opts[:capabilities] || {}
+    self.commands     = []
 
 
-		self.conn_id      = opts[:conn_id]
-		self.url          = opts[:url]
-		self.ssl          = opts[:ssl]
-		self.expiration   = opts[:expiration]
-		self.comm_timeout = opts[:comm_timeout]
-		self.passive_dispatcher = opts[:passive_dispatcher]
+    self.conn_id      = opts[:conn_id]
+    self.url          = opts[:url]
+    self.ssl          = opts[:ssl]
+    self.expiration   = opts[:expiration]
+    self.comm_timeout = opts[:comm_timeout]
+    self.passive_dispatcher = opts[:passive_dispatcher]
 
-		self.response_timeout = opts[:timeout] || self.class.default_timeout
-		self.send_keepalives  = true
-		# self.encode_unicode   = opts.has_key?(:encode_unicode) ? opts[:encode_unicode] : true
-		self.encode_unicode = false
-		self.transport_ssl_version    = (opts[:transport_ssl_version] || :SSLv3).intern
+    self.response_timeout = opts[:timeout] || self.class.default_timeout
+    self.send_keepalives  = true
+    # self.encode_unicode   = opts.has_key?(:encode_unicode) ? opts[:encode_unicode] : true
+    self.encode_unicode = false
 
-		if opts[:passive_dispatcher]
-			initialize_passive_dispatcher
+    if opts[:passive_dispatcher]
+      initialize_passive_dispatcher
 
-			register_extension_alias('core', ClientCore.new(self))
+      register_extension_alias('core', ClientCore.new(self))
 
-			initialize_inbound_handlers
-			initialize_channels
+      initialize_inbound_handlers
+      initialize_channels
 
-			# Register the channel inbound packet handler
-			register_inbound_handler(Rex::Post::Meterpreter::Channel)
-		else
-			# Switch the socket to SSL mode and receive the hello if needed
-			if capabilities[:ssl] and not opts[:skip_ssl]
-				swap_sock_plain_to_ssl()
-			end
+      # Register the channel inbound packet handler
+      register_inbound_handler(Rex::Post::Meterpreter::Channel)
+    else
+      # Switch the socket to SSL mode and receive the hello if needed
+      if capabilities[:ssl] and not opts[:skip_ssl]
+        swap_sock_plain_to_ssl()
+      end
 
-			register_extension_alias('core', ClientCore.new(self))
+      register_extension_alias('core', ClientCore.new(self))
 
-			initialize_inbound_handlers
-			initialize_channels
+      initialize_inbound_handlers
+      initialize_channels
 
-			# Register the channel inbound packet handler
-			register_inbound_handler(Rex::Post::Meterpreter::Channel)
+      # Register the channel inbound packet handler
+      register_inbound_handler(Rex::Post::Meterpreter::Channel)
 
-			monitor_socket
-		end
-	end
+      monitor_socket
+    end
+  end
 
-	def swap_sock_plain_to_ssl
-		# Create a new SSL session on the existing socket
-		ctx = generate_ssl_context()
-		ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
+  def swap_sock_plain_to_ssl
+    # Create a new SSL session on the existing socket
+    ctx = generate_ssl_context()
+    ssl = OpenSSL::SSL::SSLSocket.new(sock, ctx)
 
-		# Use non-blocking OpenSSL operations on Windows
-		if !( ssl.respond_to?(:accept_nonblock) and Rex::Compat.is_windows )
-			ssl.accept
-		else
-			begin
-				ssl.accept_nonblock
+    # Use non-blocking OpenSSL operations on Windows
+    if !( ssl.respond_to?(:accept_nonblock) and Rex::Compat.is_windows )
+      ssl.accept
+    else
+      begin
+        ssl.accept_nonblock
 
-			# Ruby 1.8.7 and 1.9.0/1.9.1 uses a standard Errno
-			rescue ::Errno::EAGAIN, ::Errno::EWOULDBLOCK
-					IO::select(nil, nil, nil, 0.10)
-					retry
+      # Ruby 1.8.7 and 1.9.0/1.9.1 uses a standard Errno
+      rescue ::Errno::EAGAIN, ::Errno::EWOULDBLOCK
+          IO::select(nil, nil, nil, 0.10)
+          retry
 
-			# Ruby 1.9.2+ uses IO::WaitReadable/IO::WaitWritable
-			rescue ::Exception => e
-				if ::IO.const_defined?('WaitReadable') and e.kind_of?(::IO::WaitReadable)
-					IO::select( [ ssl ], nil, nil, 0.10 )
-					retry
-				end
+      # Ruby 1.9.2+ uses IO::WaitReadable/IO::WaitWritable
+      rescue ::Exception => e
+        if ::IO.const_defined?('WaitReadable') and e.kind_of?(::IO::WaitReadable)
+          IO::select( [ ssl ], nil, nil, 0.10 )
+          retry
+        end
 
-				if ::IO.const_defined?('WaitWritable') and e.kind_of?(::IO::WaitWritable)
-					IO::select( nil, [ ssl ], nil, 0.10 )
-					retry
-				end
+        if ::IO.const_defined?('WaitWritable') and e.kind_of?(::IO::WaitWritable)
+          IO::select( nil, [ ssl ], nil, 0.10 )
+          retry
+        end
 
-				raise e
-			end
-		end
+        raise e
+      end
+    end
 
-		self.sock.extend(Rex::Socket::SslTcp)
-		self.sock.sslsock = ssl
-		self.sock.sslctx  = ctx
+    self.sock.extend(Rex::Socket::SslTcp)
+    self.sock.sslsock = ssl
+    self.sock.sslctx  = ctx
 
-		tag = self.sock.get_once(-1, 30)
-		if(not tag or tag !~ /^GET \//)
-			raise RuntimeError, "Could not read the HTTP hello token"
-		end
-	end
+    tag = self.sock.get_once(-1, 30)
+    if(not tag or tag !~ /^GET \//)
+      raise RuntimeError, "Could not read the HTTP hello token"
+    end
+  end
 
-	def swap_sock_ssl_to_plain
-		# Remove references to the SSLSocket and Context
-		self.sock.sslsock.close
-		self.sock.sslsock = nil
-		self.sock.sslctx  = nil
-		self.sock = self.sock.fd
-		self.sock.extend(::Rex::Socket::Tcp)
-	end
+  def swap_sock_ssl_to_plain
+    # Remove references to the SSLSocket and Context
+    self.sock.sslsock.close
+    self.sock.sslsock = nil
+    self.sock.sslctx  = nil
+    self.sock = self.sock.fd
+    self.sock.extend(::Rex::Socket::Tcp)
+  end
 
-	def generate_ssl_context(key_length=1024)
-		@@ssl_mutex.synchronize do
-		if not @@ssl_ctx
+  def generate_ssl_context(key_length=1024)
+    @@ssl_mutex.synchronize do
+    if not @@ssl_ctx
 
-			wlog("Generating SSL certificate for Meterpreter sessions")
+    wlog("Generating SSL certificate for Meterpreter sessions")
 
-			key  = OpenSSL::PKey::RSA.new(key_length)
-			cert = OpenSSL::X509::Certificate.new
-			cert.version = 2
-			cert.serial  = rand(0xFFFFFFFF)
+    key  = OpenSSL::PKey::RSA.new(key_length){ }
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial  = rand(0xFFFFFFFF)
 
-			# Depending on how the socket was created, getsockname will
-			# return either a struct sockaddr as a String (the default ruby
-			# Socket behavior) or an Array (the extend'd Rex::Socket::Tcp
-			# behavior). Avoid the ambiguity by always picking a random
-			# hostname. See #7350.
-			subject_cn = Rex::Text.rand_hostname
+    # Depending on how the socket was created, getsockname will
+    # return either a struct sockaddr as a String (the default ruby
+    # Socket behavior) or an Array (the extend'd Rex::Socket::Tcp
+    # behavior). Avoid the ambiguity by always picking a random
+    # hostname. See #7350.
+    subject_cn = Rex::Text.rand_hostname
 
-			subject = OpenSSL::X509::Name.new([
-					["C","US"],
-					['ST', Rex::Text.rand_state()],
-					["L", Rex::Text.rand_text_alpha(rand(20) + 10)],
-					["O", Rex::Text.rand_text_alpha(rand(20) + 10)],
-					["CN", subject_cn],
-				])
-			issuer = OpenSSL::X509::Name.new([
-					["C","US"],
-					['ST', Rex::Text.rand_state()],
-					["L", Rex::Text.rand_text_alpha(rand(20) + 10)],
-					["O", Rex::Text.rand_text_alpha(rand(20) + 10)],
-					["CN", Rex::Text.rand_text_alpha(rand(20) + 10)],
-				])
+    subject = OpenSSL::X509::Name.new([
+        ["C","US"],
+        ['ST', Rex::Text.rand_state()],
+        ["L", Rex::Text.rand_text_alpha(rand(20) + 10)],
+        ["O", Rex::Text.rand_text_alpha(rand(20) + 10)],
+        ["CN", subject_cn],
+      ])
+    issuer = OpenSSL::X509::Name.new([
+        ["C","US"],
+        ['ST', Rex::Text.rand_state()],
+        ["L", Rex::Text.rand_text_alpha(rand(20) + 10)],
+        ["O", Rex::Text.rand_text_alpha(rand(20) + 10)],
+        ["CN", Rex::Text.rand_text_alpha(rand(20) + 10)],
+      ])
 
-			cert.subject = subject
-			cert.issuer = issuer
-			cert.not_before = Time.now - (3600 * 365) + rand(3600 * 14)
-			cert.not_after = Time.now + (3600 * 365) + rand(3600 * 14)
-			cert.public_key = key.public_key
-			ef = OpenSSL::X509::ExtensionFactory.new(nil,cert)
-			cert.extensions = [
-				ef.create_extension("basicConstraints","CA:FALSE"),
-				ef.create_extension("subjectKeyIdentifier","hash"),
-				ef.create_extension("extendedKeyUsage","serverAuth"),
-				ef.create_extension("keyUsage","keyEncipherment,dataEncipherment,digitalSignature")
-			]
-			ef.issuer_certificate = cert
-			cert.add_extension ef.create_extension("authorityKeyIdentifier", "keyid:always,issuer:always")
-			cert.sign(key, OpenSSL::Digest::SHA1.new)
-			session_id_context = Rex::Text.rand_text(16)
-			ctx = OpenSSL::SSL::SSLContext.new(self.transport_ssl_version.intern)
-			ctx.key = key
-			ctx.cert = cert
+    cert.subject = subject
+    cert.issuer = issuer
+    cert.not_before = Time.now - (3600 * 365) + rand(3600 * 14)
+    cert.not_after = Time.now + (3600 * 365) + rand(3600 * 14)
+    cert.public_key = key.public_key
+    ef = OpenSSL::X509::ExtensionFactory.new(nil,cert)
+    cert.extensions = [
+      ef.create_extension("basicConstraints","CA:FALSE"),
+      ef.create_extension("subjectKeyIdentifier","hash"),
+      ef.create_extension("extendedKeyUsage","serverAuth"),
+      ef.create_extension("keyUsage","keyEncipherment,dataEncipherment,digitalSignature")
+    ]
+    ef.issuer_certificate = cert
+    cert.add_extension ef.create_extension("authorityKeyIdentifier", "keyid:always,issuer:always")
+    cert.sign(key, OpenSSL::Digest::SHA1.new)
 
-			ctx.session_id_context = Rex::Text.rand_text(16)
+    ctx = OpenSSL::SSL::SSLContext.new(self.transport_ssl_version.intern)
+    ctx.key = key
+    ctx.cert = cert
 
-			wlog("Generated SSL certificate for Meterpreter sessions")
+    ctx.session_id_context = Rex::Text.rand_text(16)
 
-			@@ssl_ctx = ctx
-		else
-			@@ssl_ctx.ssl_version = self.transport_ssl_version.intern
-		end # End of ssl_ctx conditional
-		end # End of mutex.synchronize
+    wlog("Generated SSL certificate for Meterpreter sessions")
 
-		@@ssl_ctx
-	end
+    @@ssl_ctx = ctx
 
-	##
-	#
-	# Accessors
-	#
-	##
+    else
+    @@ssl_ctx.ssl_version = self.transport_ssl_version.intern
 
-	#
-	# Returns the default timeout that request packets will use when
-	# waiting for a response.
-	#
-	def Client.default_timeout
-		return 300
-	end
+    end # End of if not @ssl_ctx
+    end # End of mutex.synchronize
 
-	##
-	#
-	# Alias processor
-	#
-	##
+    @@ssl_ctx
+  end
 
-	#
-	# Translates unhandled methods into registered extension aliases
-	# if a matching extension alias exists for the supplied symbol.
-	#
-	def method_missing(symbol, *args)
-		#$stdout.puts("method_missing: #{symbol}")
-		self.ext_aliases.aliases[symbol.to_s]
-	end
+  ##
+  #
+  # Accessors
+  #
+  ##
 
-	##
-	#
-	# Extension registration
-	#
-	##
+  #
+  # Returns the default timeout that request packets will use when
+  # waiting for a response.
+  #
+  def Client.default_timeout
+    return 300
+  end
 
-	#
-	# Loads the client half of the supplied extension and initializes it as a
-	# registered extension that can be reached through client.ext.[extension].
-	#
-	def add_extension(name, commands=[])
-		self.commands |= commands
+  ##
+  #
+  # Alias processor
+  #
+  ##
 
-		# Check to see if this extension has already been loaded.
-		if ((klass = self.class.check_ext_hash(name.downcase)) == nil)
-			old = Rex::Post::Meterpreter::Extensions.constants
-			require("rex/post/meterpreter/extensions/#{name.downcase}/#{name.downcase}")
-			new = Rex::Post::Meterpreter::Extensions.constants
+  #
+  # Translates unhandled methods into registered extension aliases
+  # if a matching extension alias exists for the supplied symbol.
+  #
+  def method_missing(symbol, *args)
+    #$stdout.puts("method_missing: #{symbol}")
+    self.ext_aliases.aliases[symbol.to_s]
+  end
 
-			# No new constants added?
-			if ((diff = new - old).empty?)
-				diff = [ name.capitalize ]
-			end
+  ##
+  #
+  # Extension registration
+  #
+  ##
 
-			klass = Rex::Post::Meterpreter::Extensions.const_get(diff[0]).const_get(diff[0])
+  #
+  # Loads the client half of the supplied extension and initializes it as a
+  # registered extension that can be reached through client.ext.[extension].
+  #
+  def add_extension(name, commands=[])
+    self.commands |= commands
 
-			# Save the module name to class association now that the code is
-			# loaded.
-			self.class.set_ext_hash(name.downcase, klass)
-		end
+    # Check to see if this extension has already been loaded.
+    if ((klass = self.class.check_ext_hash(name.downcase)) == nil)
+      old = Rex::Post::Meterpreter::Extensions.constants
+      require("rex/post/meterpreter/extensions/#{name.downcase}/#{name.downcase}")
+      new = Rex::Post::Meterpreter::Extensions.constants
 
-		# Create a new instance of the extension
-		inst = klass.new(self)
+      # No new constants added?
+      if ((diff = new - old).empty?)
+        diff = [ name.capitalize ]
+      end
 
-		self.ext.aliases[inst.name] = inst
+      klass = Rex::Post::Meterpreter::Extensions.const_get(diff[0]).const_get(diff[0])
 
-		return true
-	end
+      # Save the module name to class association now that the code is
+      # loaded.
+      self.class.set_ext_hash(name.downcase, klass)
+    end
 
-	#
-	# Deregisters an extension alias of the supplied name.
-	#
-	def deregister_extension(name)
-		self.ext.aliases.delete(name)
-	end
+    # Create a new instance of the extension
+    inst = klass.new(self)
 
-	#
-	# Enumerates all of the loaded extensions.
-	#
-	def each_extension(&block)
-		self.ext.aliases.each(block)
-	end
+    self.ext.aliases[inst.name] = inst
 
-	#
-	# Registers an aliased extension that can be referenced through
-	# client.name.
-	#
-	def register_extension_alias(name, ext)
-		self.ext_aliases.aliases[name] = ext
-		# Whee!  Syntactic sugar, where art thou?
-		#
-		# Create an instance method on this object called +name+ that returns
-		# +ext+.  We have to do it this way instead of simply
-		# self.class.class_eval so that other meterpreter sessions don't get
-		# extension methods when this one does
-		(class << self; self; end).class_eval do
-			define_method(name.to_sym) do
-				ext
-			end
-		end
-		ext
-	end
+    return true
+  end
 
-	#
-	# Registers zero or more aliases that are provided in an array.
-	#
-	def register_extension_aliases(aliases)
-		aliases.each { |a|
-			register_extension_alias(a['name'], a['ext'])
-		}
-	end
+  #
+  # Deregisters an extension alias of the supplied name.
+  #
+  def deregister_extension(name)
+    self.ext.aliases.delete(name)
+  end
 
-	#
-	# Deregisters a previously registered extension alias.
-	#
-	def deregister_extension_alias(name)
-		self.ext_aliases.aliases.delete(name)
-	end
+  #
+  # Enumerates all of the loaded extensions.
+  #
+  def each_extension(&block)
+    self.ext.aliases.each(block)
+  end
 
-	#
-	# Dumps the extension tree.
-	#
-	def dump_extension_tree()
-		items = []
-		items.concat(self.ext.dump_alias_tree('client.ext'))
-		items.concat(self.ext_aliases.dump_alias_tree('client'))
+  #
+  # Registers an aliased extension that can be referenced through
+  # client.name.
+  #
+  def register_extension_alias(name, ext)
+    self.ext_aliases.aliases[name] = ext
+    # Whee!  Syntactic sugar, where art thou?
+    #
+    # Create an instance method on this object called +name+ that returns
+    # +ext+.  We have to do it this way instead of simply
+    # self.class.class_eval so that other meterpreter sessions don't get
+    # extension methods when this one does
+    (class << self; self; end).class_eval do
+      define_method(name.to_sym) do
+        ext
+      end
+    end
+    ext
+  end
 
-		return items.sort
-	end
+  #
+  # Registers zero or more aliases that are provided in an array.
+  #
+  def register_extension_aliases(aliases)
+    aliases.each { |a|
+      register_extension_alias(a['name'], a['ext'])
+    }
+  end
 
-	#
-	# Encodes (or not) a UTF-8 string
-	#
-	def unicode_filter_encode(str)
-		self.encode_unicode ? Rex::Text.unicode_filter_encode(str) : str
-	end
+  #
+  # Deregisters a previously registered extension alias.
+  #
+  def deregister_extension_alias(name)
+    self.ext_aliases.aliases.delete(name)
+  end
 
-	#
-	# Decodes (or not) a UTF-8 string
-	#
-	def unicode_filter_decode(str)
-		self.encode_unicode ? Rex::Text.unicode_filter_decode(str) : str
-	end
+  #
+  # Dumps the extension tree.
+  #
+  def dump_extension_tree()
+    items = []
+    items.concat(self.ext.dump_alias_tree('client.ext'))
+    items.concat(self.ext_aliases.dump_alias_tree('client'))
 
-	#
-	# The extension alias under which all extensions can be accessed by name.
-	# For example:
-	#
-	#    client.ext.stdapi
-	#
-	#
-	attr_reader   :ext
-	#
-	# The socket the client is communicating over.
-	#
-	attr_reader   :sock
-	#
-	# The timeout value to use when waiting for responses.
-	#
-	attr_accessor :response_timeout
-	#
-	# Whether to send pings every so often to determine liveness.
-	#
-	attr_accessor :send_keepalives
-	#
-	# Whether this session is alive.  If the socket is disconnected or broken,
-	# this will be false
-	#
-	attr_accessor :alive
-	#
-	# The unique target identifier for this payload
-	#
-	attr_accessor :target_id
-	#
-	# The libraries available to this meterpreter server
-	#
-	attr_accessor :capabilities
-	#
-	# The Connection ID
-	#
-	attr_accessor :conn_id
-	#
-	# The Connect URL
-	#
-	attr_accessor :url
-	#
-	# Use SSL (HTTPS)
-	#
-	attr_accessor :ssl
-	#
-	# The Session Expiration Timeout
-	#
-	attr_accessor :expiration
-	#
-	# The Communication Timeout
-	#
-	attr_accessor :comm_timeout
-	#
-	# The Passive Dispatcher
-	#
-	attr_accessor :passive_dispatcher
-	#
-	# Flag indicating whether to hex-encode UTF-8 file names and other strings
-	#
-	attr_accessor :encode_unicode
-	#
-	# SSL version to use
-	#
-	attr_accessor :transport_ssl_version
-	#
-	# A list of the commands
-	#
-	attr_reader :commands
+    return items.sort
+  end
+
+  #
+  # Encodes (or not) a UTF-8 string
+  #
+  def unicode_filter_encode(str)
+    self.encode_unicode ? Rex::Text.unicode_filter_encode(str) : str
+  end
+
+  #
+  # Decodes (or not) a UTF-8 string
+  #
+  def unicode_filter_decode(str)
+    self.encode_unicode ? Rex::Text.unicode_filter_decode(str) : str
+  end
+
+  #
+  # The extension alias under which all extensions can be accessed by name.
+  # For example:
+  #
+  #    client.ext.stdapi
+  #
+  #
+  attr_reader   :ext
+  #
+  # The socket the client is communicating over.
+  #
+  attr_reader   :sock
+  #
+  # The timeout value to use when waiting for responses.
+  #
+  attr_accessor :response_timeout
+  #
+  # Whether to send pings every so often to determine liveness.
+  #
+  attr_accessor :send_keepalives
+  #
+  # Whether this session is alive.  If the socket is disconnected or broken,
+  # this will be false
+  #
+  attr_accessor :alive
+  #
+  # The unique target identifier for this payload
+  #
+  attr_accessor :target_id
+  #
+  # The libraries available to this meterpreter server
+  #
+  attr_accessor :capabilities
+  #
+  # The Connection ID
+  #
+  attr_accessor :conn_id
+  #
+  # The Connect URL
+  #
+  attr_accessor :url
+  #
+  # Use SSL (HTTPS)
+  #
+  attr_accessor :ssl
+  #
+  # The Session Expiration Timeout
+  #
+  attr_accessor :expiration
+  #
+  # The Communication Timeout
+  #
+  attr_accessor :comm_timeout
+  #
+  # The Passive Dispatcher
+  #
+  attr_accessor :passive_dispatcher
+  #
+  # Flag indicating whether to hex-encode UTF-8 file names and other strings
+  #
+  attr_accessor :encode_unicode
+  #
+  # A list of the commands
+  #
+  attr_reader :commands
 
 protected
-	attr_accessor :parser, :ext_aliases # :nodoc:
-	attr_writer   :ext, :sock # :nodoc:
-	attr_writer   :commands # :nodoc:
+  attr_accessor :parser, :ext_aliases # :nodoc:
+  attr_writer   :ext, :sock # :nodoc:
+  attr_writer   :commands # :nodoc:
 end
 
 end; end; end


### PR DESCRIPTION
Meterpreter sessions cache the first SSL context generated for
later reuse when multiple sessions need to quickly set up SSL. In
the event that one were to use a TLSv1 transport for meterpreter
on one platform and SSLv3 on another (because they cant build
a working binary..), their sessions would fail on the second
platform as the original one would create and fix the SSL context
for all later sessions.

This can be remedied by passing a datastore option down from the
user interface to Rex meterpreter client class each time the
handler passes the execution context to the stager. Each session
created will either generate a valid SSL context if it is the
first to run, or simply change the context to use its preferred
SSL implementation during the mutex lock.

The same approach can be used to generate individual client certs
or big numbers from the existing SSL context to pass with stage0
as a mutual secret.

Testing: build a TLSv1-using meterpreter and test incoming sessions
with both configurations by starting handlers using
TransportSSLVersion SSLv3 and TLSv1, others to come as we upgrade
OpenSSL on both sides of the session.

@devs: is it feasible to teach meterpreter to recognize when a UDP socket is in use and switch to DTLS? A few blocks of shellcode and DTLS support and we should have working UDP. Apparently it can be done on the Ruby side - https://github.com/ruby/ruby/commit/060184c347822b11dff3db6bef915c04a564c4e4
