### PR TITLE
Override Ruby's net/http to use Rex::Socket::Tcp

### DIFF
--- a/lib/net/http_rex.rb
+++ b/lib/net/http_rex.rb
@@ -1,0 +1,72 @@
+require 'net/http'
+require 'rex/socket'
+
+#
+# Converts Ruby STD Net::HTTP class to use Rex::Socket
+# Allows pivoting, virtual sockets, etc.
+# This is for development with external libraries which
+# depend on net/http like open-uri or xmlrpc which are
+# heavily used by other interfaces for our targets
+#
+
+class ::Net::HTTP
+ def connect
+      D "opening connection to #{conn_address()}..."
+      # Should find a way of passing framework context here
+      # Not using our SSL socket implementation for compat
+      s = timeout(@open_timeout) {Rex::Socket::Tcp.create(
+	'PeerHost' => conn_address,
+	'PeerPort' => conn_port)}
+      D "opened"
+      if use_ssl?
+        ssl_parameters = Hash.new
+        iv_list = instance_variables
+        SSL_ATTRIBUTES.each do |name|
+          ivname = "@#{name}".intern
+          if iv_list.include?(ivname) and
+             value = instance_variable_get(ivname)
+            ssl_parameters[name] = value
+          end
+        end
+        @ssl_context = OpenSSL::SSL::SSLContext.new
+        @ssl_context.set_params(ssl_parameters)
+	# SSL Verification fails with the Rex Socket.
+	@ssl_context.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        s = OpenSSL::SSL::SSLSocket.new(s, @ssl_context)
+        s.sync_close = true
+      end
+      # Namespacing change as lookup apparears to fail on 1.9.3-p392
+      @socket = Net::BufferedIO.new(s)
+      @socket.read_timeout = @read_timeout
+      @socket.continue_timeout = @continue_timeout
+      @socket.debug_output = @debug_output
+      if use_ssl?
+        begin
+          if proxy?
+            @socket.writeline sprintf('CONNECT %s:%s HTTP/%s',
+                                      @address, @port, HTTPVersion)
+            @socket.writeline "Host: #{@address}:#{@port}"
+            if proxy_user
+              credential = ["#{proxy_user}:#{proxy_pass}"].pack('m')
+              credential.delete!("\r\n")
+              @socket.writeline "Proxy-Authorization: Basic #{credential}"
+            end
+            @socket.writeline ''
+            HTTPResponse.read_new(@socket).value
+          end
+          # Server Name Indication (SNI) RFC 3546
+          s.hostname = @address if s.respond_to? :hostname=
+          timeout(@open_timeout) { s.connect }
+          if @ssl_context.verify_mode != OpenSSL::SSL::VERIFY_NONE
+            s.post_connection_check(@address)
+          end
+        rescue => exception
+          D "Conn close because of connect error #{exception}"
+          @socket.close if @socket and not @socket.closed?
+          raise exception
+        end
+      end
+      on_connect
+    end
+    private :connect
+end


### PR DESCRIPTION
This is primarily for framework developers exploring service APIs
with publicly available gems. In a perfect world we would have
Rex::Proto::HTTP handle all of this, but until then we need to be
able to work over meterpreter routes with libraries not written
for Rex. Other protocols are reasonably easy and simple to patch
on a one-off basis since the gems using them are none too complex.
Standard lib net/http is the foundation for the vast majority of
Ruby native API gems. Attacking those APIs over routed sessions
is now easier.

To use, simply require 'net/http_rex' to override the default
Net::HTTP socket behavior. This will turn off SSL validation for
all future net/http sessions created in the VM runtime unless
you work some magic to unload and rebuild the library in the
language tree (something about the SSL validation callback on a
Rex::Socket apparently doesnt work, not digging into it unless
someone requests it).

This is not a "proper implementation" and not required by default
when framework loads. Its a shim and intended to be used as such
when required.
