### PR TITLE
Use metasploit_data_models from rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'activerecord'
 # Needed for some admin modules (scrutinizer_add_user.rb)
 gem 'json'
 # Database models shared between framework and Pro.
-gem 'metasploit_data_models', :git => 'git://github.com/rapid7/metasploit_data_models.git', :tag => '0.6.4'
+gem 'metasploit_data_models', '~> 0.6.14'
 # Needed by msfgui and other rpc components
 gem 'msgpack'
 # Needed by anemone crawler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,3 @@
-GIT
-  remote: git://github.com/rapid7/metasploit_data_models.git
-  revision: d6af3cf0413c1ad317c16c143791097bd0a5afff
-  tag: 0.6.4
-  specs:
-    metasploit_data_models (0.6.4)
-      activerecord (>= 3.2.13)
-      activesupport
-      pg
-
 GEM
   remote: http://rubygems.org/
   specs:
@@ -30,6 +20,10 @@ GEM
       activesupport (>= 3.0.0)
     i18n (0.6.1)
     json (1.7.7)
+    metasploit_data_models (0.6.14)
+      activerecord (>= 3.2.13)
+      activesupport
+      pg
     msgpack (0.5.4)
     multi_json (1.0.4)
     nokogiri (1.5.9)
@@ -62,7 +56,7 @@ DEPENDENCIES
   database_cleaner
   factory_girl (>= 4.1.0)
   json
-  metasploit_data_models!
+  metasploit_data_models (~> 0.6.14)
   msgpack
   nokogiri
   pcaprub


### PR DESCRIPTION
MDM is now on rubygems.  This simplifies the framework Gemfile by removing git dependencies.

All specs passed.  @limhoff-r7 has made some changes to MDM lately (mostly testing stuff) but they shouldn't negatively affect framework.
