### PR TITLE
Rex::Socket::SslTcp set cipher and verify_mode

### DIFF
--- a/lib/msf/core/exploit/tcp.rb
+++ b/lib/msf/core/exploit/tcp.rb
@@ -63,6 +63,8 @@ module Exploit::Remote::Tcp
 			[
 				OptBool.new('SSL',        [ false, 'Negotiate SSL for outgoing connections', false]),
 				OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'SSL3', ['SSL2', 'SSL3', 'TLS1']]),
+				OptEnum.new('SSLVerifyMode',  [ false, 'SSL verification method', 'PEER', %W{CLIENT_ONCE FAIL_IF_NO_PEER_CERT NONE PEER}]),
+				OptString.new('SSLCipher',    [ false, 'String for SSL cipher - "DHE-RSA-AES256-SHA" or "ADH"']),
 				Opt::Proxies,
 				Opt::CPORT,
 				Opt::CHOST,

--- a/lib/rex/socket/parameters.rb
+++ b/lib/rex/socket/parameters.rb
@@ -145,6 +145,11 @@ class Rex::Socket::Parameters
 			self.ssl_version = hash['SSLVersion']
 		end
 
+		supported_ssl_verifiers = %W{CLIENT_ONCE FAIL_IF_NO_PEER_CERT NONE PEER}
+		if (hash['SSLVerifyMode'] and supported_ssl_verifiers.include? hash['SSLVerifyMode'])
+			self.ssl_verify_mode = hash['SSLVerifyMode']
+		end
+
 		if (hash['SSLCipher'])
 			self.ssl_cipher = hash['SSLCipher']
 		end

--- a/lib/rex/socket/parameters.rb
+++ b/lib/rex/socket/parameters.rb
@@ -68,6 +68,14 @@ class Rex::Socket::Parameters
 	#
 	# 	A file containing an SSL certificate (for server sockets)
 	#
+	# [SSLCipher]
+	#
+	#   Specify SSL cipher to use for context
+	#
+	# [SSLVerifyMode]
+	#
+	# 	Specify SSL cerificate verification mechanism
+	#
 	# [Proxies]
 	#
 	#	List of proxies to use.
@@ -355,7 +363,11 @@ class Rex::Socket::Parameters
 	#
 	# The SSL certificate, in pem format, stored as a string.  See +SslTcpServer#make_ssl+
 	#
-	attr_accessor :ssl_cert
+	attr_accessor :ssl_certa
+	#
+	# The SSL context verification mechanism
+	#
+	attr_accessor :ssl_verify_mode
 	#
 	# Whether we should use IPv6
 	#

--- a/lib/rex/socket/parameters.rb
+++ b/lib/rex/socket/parameters.rb
@@ -363,7 +363,7 @@ class Rex::Socket::Parameters
 	#
 	# The SSL certificate, in pem format, stored as a string.  See +SslTcpServer#make_ssl+
 	#
-	attr_accessor :ssl_certa
+	attr_accessor :ssl_cert
 	#
 	# The SSL context verification mechanism
 	#

--- a/lib/rex/socket/ssl_tcp.rb
+++ b/lib/rex/socket/ssl_tcp.rb
@@ -78,7 +78,12 @@ begin
 		#  VERIFY_FAIL_IF_NO_PEER_CERT
 		#  VERIFY_NONE
 		#  VERIFY_PEER
-		self.sslctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
+		if params.ssl_verify_mode
+			self.sslctx.verify_mode = OpenSSL::SSL.const_get("VERIFY_#{params.ssl_verify_mode}".intern)
+		else
+			# Could also do this as graceful faildown in case a passed verify_mode is not supported
+			self.sslctx.verify_mode = OpenSSL::SSL::VERIFY_PEER
+		end
 		self.sslctx.options = OpenSSL::SSL::OP_ALL
 		if params.ssl_cipher
 			self.sslctx.ciphers = params.ssl_cipher

--- a/lib/rex/socket/ssl_tcp.rb
+++ b/lib/rex/socket/ssl_tcp.rb
@@ -72,7 +72,7 @@ begin
 		self.sslctx  = OpenSSL::SSL::SSLContext.new(version)
 
 		# Configure the SSL context
-		# TODO: Allow the user to specify the verify mode and callback
+		# TODO: Allow the user to specify the verify mode callback
 		# Valid modes:
 		#  VERIFY_CLIENT_ONCE
 		#  VERIFY_FAIL_IF_NO_PEER_CERT


### PR DESCRIPTION
Update Rex::Socket::SslTcp to accept verification mode string from
Rex::Socket::Parameters, which has been modified accordingly.
Add SSLVerifyMode and SSLCipher options (params and socket work
were done before, but the option was not exposed) to
Msf::Exploit::Tcp.

Testing:

```
>> sock = Rex::Socket::Tcp.create('PeerHost'=>'10.1.1.1','PeerPort'
=>443,'SSL' => true, 'SSLVerifyMode' => 'NONE')
>> sock.sslctx.verify_mode
=> 0
>> sock.close
=> nil
>> sock = Rex::Socket::Tcp.create('PeerHost'=>'10.1.1.1','PeerPort'
=>443,'SSL' => true, 'SSLVerifyMode' => 'PEER')
=> #<Socket:fd 13>
>> sock.sslctx.verify_mode
=> 1
```

Note: this should be able to resolve the recent SSL socket hackery
of exploit/linux/misc/nagios_nrpe_arguments.
