### PR TITLE
Add a couple new IE fingerprints to osdetect.js

### DIFF
--- a/lib/rex/exploitation/javascriptosdetect.js
+++ b/lib/rex/exploitation/javascriptosdetect.js
@@ -734,24 +734,16 @@ window.os_detect.getVersion = function(){
 				os_sp = "SP3";
 				break;
 			case "5722589":
-				// browsershots.org, MSIE 7.0 / Windows XP
+				// IE 7.0.5730.13, XP Professional SP3 English
 				ua_version = "7.0";
 				os_flavor = "XP";
-				// don't know what the service pack is  =(
+				os_sp = "SP3";
 				break;
 			case "576000":
 				// IE 7.0.6000.16386, Vista Ultimate SP0 English
 				ua_version = "7.0";
 				os_flavor = "Vista";
 				os_sp = "SP0";
-				break;
-			case "5818702":
-				// IE 8.0.6001.18702, XP Professional SP3 English
-			case "5822960":
-				// IE 8.0.6001.18702, XP Professional SP3 Greek
-				ua_version = "8.0";
-				os_flavor = "XP";
-				os_sp = "SP3";
 				break;
 			case "580":
 				// IE 8.0.7100.0, Windows 7 English
@@ -764,6 +756,20 @@ window.os_detect.getVersion = function(){
 				ua_version = "8.0";
 				os_flavor = "7";
 				os_sp = "SP0";
+				break;
+			case "5817514":
+				// IE 8.0.7600.17514, Windows 7 SP1 English
+				ua_version = "8.0";
+				os_flavor = "7";
+				os_sp = "SP1";
+				break;
+			case "5818702":
+				// IE 8.0.6001.18702, XP Professional SP3 English
+			case "5822960":
+				// IE 8.0.6001.18702, XP Professional SP3 Greek
+				ua_version = "8.0";
+				os_flavor = "XP";
+				os_sp = "SP3";
 				break;
 			case "9016406":
 				// IE 9.0.7930.16406, Windows 7 64-bit
@@ -787,8 +793,19 @@ window.os_detect.getVersion = function(){
 			case "9016446":
 				// IE 9.0.8112.16421, Windows 7 English (Update Versions: 9.0.7 (KB2699988)
 				// Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; MASA; InfoPath.3; MS-RTC LM 8; BRI/2)Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; MASA; InfoPath.3; MS-RTC LM 8; BRI/2)
-				os_flavor = "7";
 				ua_version = "9.0";
+				os_flavor = "7";
+				os_sp = "SP1";
+				break;
+			case "9016464":
+				// browsershots.org, MSIE 7.0 / Windows 2008 R2
+				os_flavor = "2008R2";
+				ua_version = "9.0";
+				break;
+			case "9016470":
+				// IE 9.0.8112.16421 / Windows 7 SP1
+				ua_version = "9.0";
+				os_flavor = "7";
 				os_sp = "SP1";
 				break;
 			case "1000":


### PR DESCRIPTION
One of them comes from browsershots:
http://api.browsershots.org/png/original/9b/9b58c81b728b06403dc67cbba8c2b32c.png

The others from random virtual machines I had lying around.
