### PR TITLE
Move optional gems to bundler groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,22 +2,28 @@ source 'http://rubygems.org'
 
 # Need 3+ for ActiveSupport::Concern
 gem 'activesupport', '>= 3.0.0'
-# Needed for Msf::DbManager
-gem 'activerecord'
 # Needed for some admin modules (scrutinizer_add_user.rb)
 gem 'json'
-# Database models shared between framework and Pro.
-gem 'metasploit_data_models', '~> 0.6.14'
 # Needed by msfgui and other rpc components
 gem 'msgpack'
 # Needed by anemone crawler
 gem 'nokogiri'
-# Needed for module caching in Mdm::ModuleDetails
-gem 'pg', '>= 0.11'
 # Needed by anemone crawler
 gem 'robots'
-# For sniffer and raw socket modules
-gem 'pcaprub'
+
+group :db do
+  # Needed for Msf::DbManager
+  gem 'activerecord'
+  # Database models shared between framework and Pro.
+  gem 'metasploit_data_models', '~> 0.6.14'
+  # Needed for module caching in Mdm::ModuleDetails
+  gem 'pg', '>= 0.11'
+end
+
+group :pcap do
+  # For sniffer and raw socket modules
+  gem 'pcaprub'
+end
 
 group :development do
   # Markdown formatting for yard

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'rubygems'
 require 'bundler'
-Bundler.require(:default, :test)
+Bundler.require(:default, :test, :db)
 
 # add project lib directory to load path
 spec_pathname = Pathname.new(__FILE__).dirname


### PR DESCRIPTION
Some users are having trouble installing pcap.  Others want postgres to
remain optional.  The move to requiring bundler in a git environment has
made this hard.

This commit provides a path for these users.  By default, bundler will
install all gems, including postgres and pcaprub.  If it fails to
install some, Metasploit will not function.  But there is hope.  Users
can explicitly exclude the gem groups they don't want.

For example:

```
bundle install --without db pcap
```

will exclude the pcap and postgres gems (and their depedencies).

```
bundle install --without db pcap development test
```

will exclude all non-essential gems.

The good news is that the user only needs to use the `--without` option
once.  Bundler will remember it.  So future runs can still do `bundle
install` (or simply `bundle`) and the gems will still be excluded.  And
if the user changes their mind and wants the optional gems, they can
remove their stored _without_ preference using:

```
bundle config --delete without
```

[FIXRM #7891]
