### PR TITLE
Add VERBOSE option check to msftidy.rb

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -145,6 +145,12 @@ class Msftidy
 		end
 	end
 
+	def check_verbose_option	
+		if @source =~ /Opt(Bool|String).new\([[:space:]]*('|")VERBOSE('|")[[:space:]]*,[[:space:]]*\[[[:space:]]*/
+			warn("VERBOSE Option is already part of advanced settings, no need to add it manually.")
+		end
+	end
+
 	def check_badchars
 		badchars = %Q|&<=>|
 
@@ -390,6 +396,7 @@ def run_checks(f_rel)
 	tidy = Msftidy.new(f_rel)
 	tidy.check_ref_identifiers
 	tidy.check_old_keywords
+	tidy.check_verbose_option
 	tidy.check_badchars
 	tidy.check_extname
 	tidy.test_old_rubies(f_rel)

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -145,7 +145,7 @@ class Msftidy
 		end
 	end
 
-	def check_verbose_option	
+	def check_verbose_option
 		if @source =~ /Opt(Bool|String).new\([[:space:]]*('|")VERBOSE('|")[[:space:]]*,[[:space:]]*\[[[:space:]]*/
 			warn("VERBOSE Option is already part of advanced settings, no need to add it manually.")
 		end


### PR DESCRIPTION
This pull requests adds a check for manual VERBOSE Options to msftidy.rb.
According to the wiki page [Common Metasploit Module Coding Mistakes](https://github.com/rapid7/metasploit-framework/wiki/Common-Metasploit-Module-Coding-Mistakes) this should be avoided.

I tested the commit with the following Strings, which are all detected:

```
OptString.new('VERBOSE',[ false, 'XXXXX', false ])
OptBool.new('VERBOSE',[ false, 'XXXXX', false ])
OptBool.new('VERBOSE',[false, 'XXXXX', false ])
OptBool.new("VERBOSE",[ false, 'XXXXX', false ])
OptBool.new( 'VERBOSE' ,  [ false, 'XXXXX', false ])
OptBool.new(    "VERBOSE" ,  [ true, 'XXXXX', false ])
```

Output:

```
./msftidy.rb ../../../verbose_test.rb
verbose_test.rb - [WARNING] VERBOSE Option is already part of advanced settings, no need to add it manually.
```

If you have any questions, please let me know.
