### PR TITLE
Resolve workspace rename issues (RM7883)

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -153,8 +153,8 @@ class Db
 
 				workspace = framework.db.find_workspace(old)
 
-				old_is_active = true if framework.db.workspace == workspace
-				recreate_default = true if workspace.default?
+				old_is_active = (framework.db.workspace == workspace)
+				recreate_default = workspace.default?
 
 				if workspace.nil?
 					print_error("Workspace not found: #{name}")

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -148,8 +148,6 @@ class Db
 					return
 				end
 				old, new = names
-				recreate_default = false
-				old_is_active = false
 
 				workspace = framework.db.find_workspace(old)
 

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -165,7 +165,7 @@ class Db
 					print_error("Workspace exists: #{new}")
 					return
 				end
-				
+
 				workspace.name = new
 				workspace.save!
 
@@ -1545,7 +1545,7 @@ class Db
 				print_error("The database is not connected")
 				return
 			end
-					
+
 			print_status("Purging and rebuilding the module cache in the background...")
 			framework.threads.spawn("ModuleCacheRebuild", true) do
 				framework.db.purge_all_module_details


### PR DESCRIPTION
Resolves RM7883:
https://dev.metasploit.com/redmine/issues/7883

by re-creating the default workspace when it is being renamed.

Also resolves an issue when renaming the active workspace and then listing workspaces. The error was independently verified by bonsaiviking:
http://pastebin.com/HMw92Xxk

and is resolved by switching to the new workspace name if the old workspace is active.
