### PR TITLE
Fix incorrect network prefix in Java Meterpreter

### DIFF
--- a/external/source/javapayload/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_net_config_get_interfaces_V1_6.java
+++ b/external/source/javapayload/meterpreter/stdapi/src/main/java/com/metasploit/meterpreter/stdapi/stdapi_net_config_get_interfaces_V1_6.java
@@ -24,6 +24,16 @@ public class stdapi_net_config_get_interfaces_V1_6 extends stdapi_net_config_get
 			if (ip == null)
 				continue;
 			int prefixLength = addr.getNetworkPrefixLength();
+			if (prefixLength == -1 && ip.length == 4) {
+				// guess netmask by network class...
+				if ((ip[0] & 0xff) < 0x80) {
+					prefixLength = 8;
+				} else if ((ip[0] & 0xff) < 0xc0) {
+					prefixLength = 16;
+				} else {
+					prefixLength = 24;
+				}
+			}
 			byte[] scopeId = null;
 			if (addr.getAddress() instanceof Inet6Address) {
 				ByteBuffer bb = ByteBuffer.allocate(4);


### PR DESCRIPTION
Apparently, getNetworkPrefixLength can return -1, which confuses the Ruby
side. Therefore fall back to guessing the prefix in this case, as we do it
for Java <= 1.6.

This may cause spurious errors like `warning: in a**b, b may be too big`, and ifconfig command may stop with an error that ~ cannot be applied to -1.
