### PR TITLE
SyntaxError fixes (maybe ruby 1.8 only)

### DIFF
--- a/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
+++ b/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Auxiliary
 			'References' => [
 				[ 'URL', 'http://sourceforge.net/projects/smbexec' ],
 				[ 'URL', 'http://www.accuvant.com/blog/2012/11/13/owning-computers-without-shell-access' ]
-			],
+			]
 		))
 
 		register_options([

--- a/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
 						}
 					],
 				],
-			'DefaultTarget'  => 1,
+			'DefaultTarget'  => 1
 			))
 
 		register_options(

--- a/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
 						}
 					],
 				],
-			'DefaultTarget'  => 1,
+			'DefaultTarget'  => 1
 			))
 
 		register_options(

--- a/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
 						}
 					],
 				],
-			'DefaultTarget'  => 1,
+			'DefaultTarget'  => 1
 			))
 
 		register_options(

--- a/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
 						}
 					],
 				],
-			'DefaultTarget'  => 1,
+			'DefaultTarget'  => 1
 			))
 
 		register_options(

--- a/modules/post/windows/gather/word_unc_injector.rb
+++ b/modules/post/windows/gather/word_unc_injector.rb
@@ -181,7 +181,7 @@ class Metasploit3 < Msf::Post
 				"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 				rhost,
 				org_file_data,
-				datastore['FILE'],
+				datastore['FILE']
 			)
 			print_status("Local backup kept at #{@org_file}")
 			#Store information in note database so its obvious what we changed, were we stored the backup file..


### PR DESCRIPTION
With ruby 1.8 I have the following errors:
[-] WARNING! The following modules could not be loaded!
[-]     /data/work/metasploit-framework/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb: SyntaxError compile error
/data/work/metasploit-framework/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb:66: syntax error, unexpected ')'
            ))
             ^
[-]     /data/work/metasploit-framework/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb: SyntaxError compile error
/data/work/metasploit-framework/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb:66: syntax error, unexpected ')'
            ))
             ^
[-]     /data/work/metasploit-framework/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb: SyntaxError compile error
/data/work/metasploit-framework/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb:44: syntax error, unexpected ')'
[-]     /data/work/metasploit-framework/modules/exploits/linux/http/linksys_e1500_apply_exec.rb: SyntaxError compile error
/data/work/metasploit-framework/modules/exploits/linux/http/linksys_e1500_apply_exec.rb:64: syntax error, unexpected ')'
            ))
             ^
[-]     /data/work/metasploit-framework/modules/post/windows/gather/word_unc_injector.rb: SyntaxError compile error
/data/work/metasploit-framework/modules/post/windows/gather/word_unc_injector.rb:185: syntax error, unexpected ')'
[-]     /data/work/metasploit-framework/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb: SyntaxError compile error
/data/work/metasploit-framework/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb:66: syntax error, unexpected ')'
            ))
             ^
