### PR TITLE
Bumps MDM version to latest

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :db do
   # Needed for Msf::DbManager
   gem 'activerecord'
   # Database models shared between framework and Pro.
-  gem 'metasploit_data_models', '~> 0.6.15'
+gem 'metasploit_data_models', :git => 'git://github.com/rapid7/metasploit_data_models.git', :tag => 'v0.6.15'
   # Needed for module caching in Mdm::ModuleDetails
   gem 'pg', '>= 0.11'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :db do
   # Needed for Msf::DbManager
   gem 'activerecord'
   # Database models shared between framework and Pro.
-  gem 'metasploit_data_models', '~> 0.6.14'
+  gem 'metasploit_data_models', '~> 0.6.15'
   # Needed for module caching in Mdm::ModuleDetails
   gem 'pg', '>= 0.11'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
       activesupport (>= 3.0.0)
     i18n (0.6.1)
     json (1.7.7)
-    metasploit_data_models (0.6.14)
+    metasploit_data_models (0.6.15)
       activerecord (>= 3.2.13)
       activesupport
       pg
@@ -56,7 +56,7 @@ DEPENDENCIES
   database_cleaner
   factory_girl (>= 4.1.0)
   json
-  metasploit_data_models (~> 0.6.14)
+  metasploit_data_models (~> 0.6.15)
   msgpack
   nokogiri
   pcaprub

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: git://github.com/rapid7/metasploit_data_models.git
+  revision: 30b060b85b1ea3ed4460ae92708017403a600b7b
+  tag: v0.6.15
+  specs:
+    metasploit_data_models (0.6.15)
+      activerecord (>= 3.2.13)
+      activesupport
+      pg
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -20,10 +30,6 @@ GEM
       activesupport (>= 3.0.0)
     i18n (0.6.1)
     json (1.7.7)
-    metasploit_data_models (0.6.15)
-      activerecord (>= 3.2.13)
-      activesupport
-      pg
     msgpack (0.5.4)
     multi_json (1.0.4)
     nokogiri (1.5.9)
@@ -56,7 +62,7 @@ DEPENDENCIES
   database_cleaner
   factory_girl (>= 4.1.0)
   json
-  metasploit_data_models (~> 0.6.15)
+  metasploit_data_models!
   msgpack
   nokogiri
   pcaprub


### PR DESCRIPTION
https://github.com/rapid7/metasploit_data_models/pull/15  must be landed first
