### PR TITLE
Adds new JavaScript function "js_download"

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -792,6 +792,56 @@ protected
 		return js
 	end
 
+
+	#
+	# Downloads data using ajax
+	#
+	# Supported argumnets:
+	# method => Optional. HTTP Verb (eg. GET/POST)
+	# path   => Relative path to the file. In IE, you can actually use an URI. But in Firefox, you
+	#           must use a relative path, otherwise you will be blocked by the browser.
+	# data   => Optional. Data to pass to the server
+	#
+	# Example of using the ajax_download() function:
+	# For IE, your web server has to return this header to download binary data:
+	# "text/plain; charset=x-user-defined"
+	# <script>
+	# #{js_download}
+	#
+	# ajax_download({path:"/test.bin"});
+	# </script>
+	#
+	def js_download
+		%Q|function ajax_download(oArg) {
+			method = oArg.method;
+			path   = oArg.path;
+			data   = oArg.data;
+
+			if (method == undefined) { method = "GET"; }
+			if (method == path)      { throw "Missing parameter 'path'"; }
+			if (data   == undefined) { data = null; }
+
+			if (window.XMLHttpRequest) {
+				xmlHttp = new XMLHttpRequest();
+			}
+			else {
+				xmlHttp = new ActiveXObject("Microsoft.XMLHTTP");
+			}
+
+			if (xmlHttp.overrideMimeType) {
+				xmlHttp.overrideMimeType("text/plain; charset=x-user-defined");
+			}
+
+			xmlHttp.open(method, path, false);
+			xmlHttp.send(data);
+			if (xmlHttp.readyState == 4 && xmlHttp.status == 200) {
+				return xmlHttp.responseText;
+			}
+			return null;
+		}
+		|
+	end
+
 	#
 	# This heap spray technique takes advantage of MSHTML's SetStringProperty (or SetProperty)
 	# function to trigger allocations by ntdll!RtlAllocateHeap.  It is based on Corelan's

--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -796,7 +796,7 @@ protected
 	#
 	# Downloads data using ajax
 	#
-	# Supported argumnets:
+	# Supported arguments:
 	# method => Optional. HTTP Verb (eg. GET/POST)
 	# path   => Relative path to the file. In IE, you can actually use an URI. But in Firefox, you
 	#           must use a relative path, otherwise you will be blocked by the browser.
@@ -805,13 +805,13 @@ protected
 	# Example of using the ajax_download() function:
 	# For IE, your web server has to return this header to download binary data:
 	# "text/plain; charset=x-user-defined"
-	# <script>
-	# #{js_download}
+	#    <script>
+	#    #{js_download}
 	#
-	# ajax_download({path:"/test.bin"});
-	# </script>
+	#    ajax_download({path:"/test.bin"});
+	#    </script>
 	#
-	def js_download
+	def js_ajax_download
 		%Q|function ajax_download(oArg) {
 			method = oArg.method;
 			path   = oArg.path;

--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -806,7 +806,7 @@ protected
 	# For IE, your web server has to return this header to download binary data:
 	# "text/plain; charset=x-user-defined"
 	#    <script>
-	#    #{js_download}
+	#    #{js_ajax_download}
 	#
 	#    ajax_download({path:"/test.bin"});
 	#    </script>


### PR DESCRIPTION
"js_download" is a JavaScript function used to download data (text or binary) from the web server.

You can download the test case here -- you should be able to see a hexdump that shows what was sent.:
https://gist.github.com/wchen-r7/e4755de1b29f0b22cc80

Tested on:
- \- IE6 + Windows XP SP3
- \- IE7 + Windows XP SP3
- \- IE9 + Windows 7
- \- Firefox + Windows 7
- \- Chrome + Windows XP SP3
- \- Chrome + OSX
- \- Safari + OSX
