### PR TITLE
Added opt delay to file_dropper

### DIFF
--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -3,6 +3,15 @@
 module Msf
 module Exploit::FileDropper
 
+	def initialize(info = {})
+		super
+
+		register_advanced_options(
+			[
+				OptInt.new( 'FileDropperDelay', [ false, 'Time, in s, to wait before attempting file cleanup' ])
+			], self.class)
+	end
+
 	#
 	# When a new session is created, attempt to delete any files that the
 	# exploit created.
@@ -88,6 +97,12 @@ module Exploit::FileDropper
 		end
 
 		if respond_to?(:file_rm)
+			delay = datastore['FileDropperDelay']
+			if delay
+				print_status("Waiting #{delay}s before file cleanup...")
+				select(nil,nil,nil,delay)
+			end
+
 			@dropped_files.delete_if do |file|
 				begin
 					file_rm(file)


### PR DESCRIPTION
In relation to: https://github.com/rapid7/metasploit-framework/issues/1764

This adds a delay to the file_dropper, and allows modules that run an InitialAutoRunScript migrate -f time to migrate away from the original executable before attempting to delete that executable.
