### PR TITLE
Fixes P/P/R for target 1 (BadBlue 2.72b)

### DIFF
--- a/modules/exploits/windows/http/badblue_passthru.rb
+++ b/modules/exploits/windows/http/badblue_passthru.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					# This is the version being distributed on badblue.com as of Jul 7th 2010
 					[ 'BadBlue EE 2.7 Universal', { 'Ret' => 0x10033f44 } ], # pop/pop/ret in ext.dll v1.0.0.1 (06a6dc81924ba94bfbbd00902d054db2)
-					[ 'BadBlue 2.72b Universal', { 'Ret' => 0x1003f2f3 } ]   # pop/pop/ret from ??
+					[ 'BadBlue 2.72b Universal', { 'Ret' => 0x10033f44 } ]   # pop/pop/ret from ext.dll v1.0.0.1
 				],
 			'DefaultTarget'  => 0,
 			'DisclosureDate' => 'Dec 10 2007'))


### PR DESCRIPTION
Target 1, which covers 2.72b, uses an invalid P/P/R from some unknown DLL, and appears to be broken.  Because 2.72b actually uses the same ext.dll as BadBlue EE 2.7 (and that target 0 actually also works against 2.72b), we might as well just use the same P/P/R again.

[FixRM #7875]

To download the vulnerable application for testing, you may get it here:
http://www.badblue.com/down.htm

Ticket for this bug fix (there's also a quick analysis):
http://dev.metasploit.com/redmine/issues/7875
