### PR TITLE
Exploit::Remote::HttpServer NameError

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -429,7 +429,7 @@ module Exploit::Remote::HttpServer
 			host = datastore["LHOST"]
 		else
 			if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
-				if (sock and sock.peerhost)
+				if (defined? sock and sock and sock.peerhost)
 					host = Rex::Socket.source_address(sock.peerhost)
 				else
 					host = Rex::Socket.source_address


### PR DESCRIPTION
The variable "sock" doesn't seems to exist in this context.
This cause the method to throw a "NameError" (when using the "get_uri" method, in my case).

I'm not sure if this variable never exist in the context, so I just added a verification.
