### PR TITLE
Single Payloads Cache Assembled Payload Improperly

### DIFF
--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -515,7 +515,10 @@ protected
 			return x.dup
 		end
 
-		cache_key   = refname + suffix
+		# single payloads generate new assembly each time with the options 
+		# substituted in already. It's not appropriate to just use the module
+		# as the cache key.
+		cache_key   = refname + suffix + asm.hash.to_s
 		cache_entry = framework.payloads.check_blob_cache(cache_key)
 
 		off.each_pair { |option, val|


### PR DESCRIPTION
An earlier change to the framework (prepend_migrate) forced single
payloads to use the internal_generate method of payload.rb.

internal_generate calls build which has a cache to track assembled
payloads. This method assumes that a payload only needs to be
assembled once, with optional values patched in later.

Single payloads do not work this way. Each time they are generated
new assembly source is created with the options hardcoded in.

This fix updates build to use the hashcode of the assembly code as
part of the cache key.

This fixes #7898 -- a bug that prevents a user from generating
multiple variations of a single payload without a restart.
