### PR TITLE
fixes RM7926 msfconsole search busted

### DIFF
--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -596,7 +596,7 @@ class DBManager
 					where_v << [ kv ]
 				when 'app'
 					where_q << ' ( module_details.stance = ? )'
-					where_v << [ ( kv == "client") ? "passive" : "active"  ]
+					where_v << [ ( kv == "client") ? "passive" : "aggressive"  ]
 				when 'ref'
 					where_q << ' ( module_refs.name ILIKE ? )'
 					where_v << [ '%' + kv + '%' ]


### PR DESCRIPTION
fixes http://dev.metasploit.com/redmine/issues/7926 which prevented a
proper search using:
msf> search exploit:type app:server
## Verification
### before
- [ ] msf> search type:exploit app:server returns nothing, but app:client returns lots
### after
- [x] msf> search type:exploit app:server returns lots; app:client returns lots
  further confirmation:  
- [x] msf > grep ms11_050 search type:exploit app:client
  => returns 1 module, which is indeed a "client-side"
- [x] msf> grep netapi search type:exploit app:server
  => returns 3 "server-side" exploits
