### PR TITLE
HTTP::ClientRequest: Should handle nils in params

### DIFF
--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -111,6 +111,9 @@ class ClientRequest
 			end
 
 			opts['vars_get'].each_pair do |var,val|
+				var = var.to_s
+				val = val.to_s
+
 				qstr << '&' if qstr.length > 0
 				qstr << (opts['encode_params'] ? set_encode_uri(var) : var)
 				qstr << '='
@@ -129,6 +132,9 @@ class ClientRequest
 			end
 
 			opts['vars_post'].each_pair do |var,val|
+				var = var.to_s
+				val = val.to_s
+
 				pstr << '&' if pstr.length > 0
 				pstr << (opts['encode_params'] ? set_encode_uri(var) : var)
 				pstr << '='
@@ -220,7 +226,7 @@ class ClientRequest
 	end
 
 	def set_encode_uri(str)
-		a = str.dup
+		a = str.to_s.dup
 		opts['uri_encode_count'].times {
 			a = Rex::Text.uri_encode(a, opts['uri_encode_mode'])
 		}


### PR DESCRIPTION
When hashes for params contain nils, they should be converted to empty
strings instead of crashing.
- #to_s: Calls #to_s on vars_get and vars_post data
- #set_encode_uri: Calls #to_s on its arg
