### PR TITLE
Add a missing require

### DIFF
--- a/modules/auxiliary/gather/shodan_search.rb
+++ b/modules/auxiliary/gather/shodan_search.rb
@@ -7,6 +7,7 @@
 
 require 'msf/core'
 require 'rex'
+require 'net/dns'
 
 class Metasploit4 < Msf::Auxiliary
 


### PR DESCRIPTION
This adds a missing require for net/dns to the shodan module, identified by mezzendo on freenode, caused a stack trace if this was the first module used with an existing cache.
