### PR TITLE
Add new rvm control files to ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .bundle
 # Rubymine project directory
 .idea
+# Portable ruby version files for rvm
+.ruby-gemset
+.ruby-version
 # RVM control file
 .rvmrc
 # YARD cache directory


### PR DESCRIPTION
[#49402505]

rvm stable (1.19.6) has deprecated .rvmrc in favor of the .ruby-version
file used by other ruby version switchers and .ruby-gemset.  These files
only contain strings to be looked up instead of bash or sh code, so it's
also a safer format than the old script in the .rvmrc.
