### PR TITLE
Fix unintelligible error when importing empty file

### DIFF
--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -2797,6 +2797,9 @@ class DBManager
 		::File.open(filename, 'rb') do |f|
 			data = f.read(4)
 		end
+		if data.nil?
+			raise DBImportError.new("Zero-length file")
+		end
 
 		case data[0,4]
 		when "PK\x03\x04"


### PR DESCRIPTION
IO#read returns nil for an empty file if given a length argument, which
caused a stack trace when attempting to import a file instead of a
useful error 
### Verification steps
- [x] `touch empty_file` and then attempt to `db_import` it.
- [x] see useful error message instead of stack trace
