### PR TITLE
Support Python when generating payloads via msfpayload

### DIFF
--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -22,8 +22,8 @@ module Buffer
 	def self.transform(buf, fmt = "ruby")
 		case fmt
 			when 'raw'
-            when 'python', 'py'
-                buf = Rex::Text.to_python(buf)
+			when 'python', 'py'
+				buf = Rex::Text.to_python(buf)
 			when 'ruby', 'rb'
 				buf = Rex::Text.to_ruby(buf)
 			when 'perl', 'pl'

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -22,6 +22,8 @@ module Buffer
 	def self.transform(buf, fmt = "ruby")
 		case fmt
 			when 'raw'
+            when 'python', 'py'
+                buf = Rex::Text.to_python(buf)
 			when 'ruby', 'rb'
 				buf = Rex::Text.to_ruby(buf)
 			when 'perl', 'pl'
@@ -50,7 +52,7 @@ module Buffer
 	def self.comment(buf, fmt = "ruby")
 		case fmt
 			when 'raw'
-			when 'ruby', 'rb'
+			when 'ruby', 'rb', 'python', 'py'
 				buf = Rex::Text.to_ruby_comment(buf)
 			when 'perl', 'pl'
 				buf = Rex::Text.to_perl_comment(buf)
@@ -73,7 +75,7 @@ module Buffer
 	# Returns the list of supported formats
 	#
 	def self.transform_formats
-		['raw','ruby','rb','perl','pl','bash','sh','c','js_be','js_le','java']
+		['raw','ruby','rb','perl','pl','bash','sh','c','js_be','js_le','java','python','py']
 	end
 
 end

--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -104,6 +104,13 @@ module Text
 	end
 
 	#
+	# Converts a raw string into a python buffer
+	#
+	def self.to_python(str, wrap = DefaultWrap, name = "buf")
+		return hexify(str, wrap, "#{name} += \"", '"', "#{name} =  \"\"\n", '"')
+	end
+
+	#
 	# Converts a raw string into a Bash buffer
 	#
 	def self.to_bash(str, wrap = DefaultWrap, name = "buf")

--- a/msfpayload
+++ b/msfpayload
@@ -30,7 +30,7 @@ $args = Rex::Parser::Arguments.new(
 #
 def usage
 	$stderr.puts("\n" +
-		"    Usage: #{$0} [<options>] <payload> [var=val] <[S]ummary|C|[P]erl|Rub[y]|[R]aw|[J]s|e[X]e|[D]ll|[V]BA|[W]ar>\n" +
+		"    Usage: #{$0} [<options>] <payload> [var=val] <[S]ummary|C|[P]erl|Rub[y]|[R]aw|[J]s|e[X]e|[D]ll|[V]BA|[W]ar|Pytho[N]>\n" +
 		$args.usage)
 	exit
 end
@@ -119,7 +119,7 @@ end
 
 payload.datastore.merge! options
 
-if (cmd =~ /^(p|y|r|d|c|j|x|b|v|w)/)
+if (cmd =~ /^(p|y|r|d|c|j|x|b|v|w|n)/)
 	fmt = 'perl' if (cmd =~ /^p/)
 	fmt = 'ruby' if (cmd =~ /^y/)
 	fmt = 'raw' if (cmd =~ /^(r|x|d)/)
@@ -129,6 +129,7 @@ if (cmd =~ /^(p|y|r|d|c|j|x|b|v|w)/)
 	fmt = 'js_le' if (cmd =~ /^j/ and ! fmt)
 	fmt = 'java'  if (cmd =~ /^b/)
 	fmt = 'raw' if (cmd =~ /^w/)
+    fmt = 'python' if (cmd =~ /^n/)
 	enc = options['ENCODER']
 
 	begin

--- a/msfpayload
+++ b/msfpayload
@@ -129,7 +129,7 @@ if (cmd =~ /^(p|y|r|d|c|j|x|b|v|w|n)/)
 	fmt = 'js_le' if (cmd =~ /^j/ and ! fmt)
 	fmt = 'java'  if (cmd =~ /^b/)
 	fmt = 'raw' if (cmd =~ /^w/)
-    fmt = 'python' if (cmd =~ /^n/)
+	fmt = 'python' if (cmd =~ /^n/)
 	enc = options['ENCODER']
 
 	begin


### PR DESCRIPTION
There's no reason we should hate Python users. This enables copy-pasta abilities for them so they can make their Python exploits that use ripped Metasploit payloads that much easier =)
