### PR TITLE
Fix typo in cmd_notes

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -939,7 +939,7 @@ class Db
 			end
 			if search_term
 				note_list.delete_if do |n|
-					!!n.attribute_names.any? { |a| n[a.intern].to_s.match(search_term) }
+					!n.attribute_names.any? { |a| n[a.intern].to_s.match(search_term) }
 				end
 			end
 			# Now display them


### PR DESCRIPTION
Fixes a typo that inverts the logic of the "notes -S" functionality.

Redmine #7959
GitHub Issue #1811
