### PR TITLE
Fix a backwards disasm bug which stomps on the depth option

### DIFF
--- a/lib/rex/ropbuilder/rop.rb
+++ b/lib/rex/ropbuilder/rop.rb
@@ -197,14 +197,13 @@ class RopCollect < RopBase
 	def process_gadgets(rets, num)
 		ret = {}
 		gadgets = []
-		tmp = []
 		rets.each do |ea|
 			insn = @disassembler.disassemble_instruction(ea)
 			next if not insn
 
 			xtra = insn.bin_length
 
-			1.upto(num) do |x|
+			num.step(0, -1) do |x|
 				addr = ea - x
 
 				# get the disassembled instruction at this address
@@ -229,11 +228,6 @@ class RopCollect < RopBase
 					addr = addr + di.bin_length
 				end
 
-				if not tmp.include?(ea)
-					tmp << ea
-				else
-					next
-				end
 				# otherwise, we create a new tailchunk and add it to the list
 				ret = {:file => @file, :address => ("0x%08x" % (ea - x)), :raw => buf, :disasm => dasm}
 				gadgets << ret


### PR DESCRIPTION
This fixes a bug where the user specifies a depth as the number of bytes to backwards disassemble but rop.rb only gives back the first successful disassembly.

The problem is mainly caused by the loop which iterates through the depth value from 0..value. This means the very first good backwards disassembly is the only one used. This results in 2 instruction gadgets rather than the expected multiple instruction gadgets. Reversing the iterator using value..0 gives the first good multiple instruction disassembly instead. Thus fixing the problem.
