### PR TITLE
Don't save creds of anyuser:anypass

### DIFF
--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -149,7 +149,7 @@ class Metasploit3 < Msf::Auxiliary
 				print_status("#{target_url} - Random passwords are not allowed.")
 			end
 
-      unless user == "anyuser" and pass == "anypass"
+      unless (user == "anyuser" and pass == "anypass")
         report_auth_info(
           :host   => rhost,
           :port   => rport,

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -149,18 +149,20 @@ class Metasploit3 < Msf::Auxiliary
 				print_status("#{target_url} - Random passwords are not allowed.")
 			end
 
-			report_auth_info(
-				:host   => rhost,
-				:port   => rport,
-				:sname => (ssl ? 'https' : 'http'),
-				:user   => user,
-				:pass   => pass,
-				:proof  => "WEBAPP=\"Generic\", PROOF=#{response.to_s}",
-				:source_type => "user_supplied",
-				:active => true
-			)
+      unless user == "anyuser" and pass == "anypass"
+        report_auth_info(
+          :host   => rhost,
+          :port   => rport,
+          :sname => (ssl ? 'https' : 'http'),
+          :user   => user,
+          :pass   => pass,
+          :proof  => "WEBAPP=\"Generic\", PROOF=#{response.to_s}",
+          :source_type => "user_supplied",
+          :active => true
+        )
+      end
 
-			return :abort if ([any_user,any_pass].include? :success)
+	  	return :abort if ([any_user,any_pass].include? :success)
 			return :next_user
 		else
 			vprint_error("#{target_url} - Failed to login as '#{user}'")


### PR DESCRIPTION
If http accepts any user and any pass, it's not a real auth
there is no reason to create cred objects for this.
These creds have been confusing our users
