### PR TITLE
Call super() in regenerate_payload with correct args.

### DIFF
--- a/lib/msf/core/exploit/tcp.rb
+++ b/lib/msf/core/exploit/tcp.rb
@@ -475,7 +475,7 @@ module Exploit::Remote::TcpServer
 			datastore['RHOST'] = cli.peerhost
 			datastore['RPORT'] = cli.peerport
 
-			if ((p = super(arch, platform, target)) == nil)
+			if ((p = super(platform, arch, target)) == nil)
 				print_error("Failed to generate payload")
 				return nil
 			end


### PR DESCRIPTION
In core/exploit/tcp.rb:478, in the method "regenerate_payload", super() is invoked:

`if ((p = super(arch, platform, target)) == nil)`

However, in core/exploit.rb, regenerate_payload's method def looks like:

`def regenerate_payload(platform = nil, arch = nil, explicit_target = nil)`

So the arch and platform args were swapped in the super call, which can result in the exception:

`Exception handling request: No classes in Msf::Module::Platform for x86!`
