### PR TITLE
Update to metasploit_data_models 0.14.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :db do
 	# Needed for Msf::DbManager
 	gem 'activerecord'
 	# Database models shared between framework and Pro.
-	gem 'metasploit_data_models', '~> 0.14.0'
+	gem 'metasploit_data_models', '~> 0.14.1'
 	# Needed for module caching in Mdm::ModuleDetails
 	gem 'pg', '>= 0.11'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :db do
 	# Needed for Msf::DbManager
 	gem 'activerecord'
 	# Database models shared between framework and Pro.
-	gem 'metasploit_data_models', '~> 0.12.0'
+	gem 'metasploit_data_models', '~> 0.13.0'
 	# Needed for module caching in Mdm::ModuleDetails
 	gem 'pg', '>= 0.11'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :db do
 	# Needed for Msf::DbManager
 	gem 'activerecord'
 	# Database models shared between framework and Pro.
-	gem 'metasploit_data_models', '~> 0.13.0'
+	gem 'metasploit_data_models', '~> 0.14.0'
 	# Needed for module caching in Mdm::ModuleDetails
 	gem 'pg', '>= 0.11'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
     i18n (0.6.1)
     json (1.7.7)
     metaclass (0.0.1)
-    metasploit_data_models (0.14.0)
+    metasploit_data_models (0.14.1)
       activerecord (>= 3.2.13)
       activesupport
       pg
@@ -65,7 +65,7 @@ DEPENDENCIES
   database_cleaner
   factory_girl (>= 4.1.0)
   json
-  metasploit_data_models (~> 0.14.0)
+  metasploit_data_models (~> 0.14.1)
   msgpack
   nokogiri
   pcaprub

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
     i18n (0.6.1)
     json (1.7.7)
     metaclass (0.0.1)
-    metasploit_data_models (0.13.0)
+    metasploit_data_models (0.14.0)
       activerecord (>= 3.2.13)
       activesupport
       pg
@@ -65,7 +65,7 @@ DEPENDENCIES
   database_cleaner
   factory_girl (>= 4.1.0)
   json
-  metasploit_data_models (~> 0.13.0)
+  metasploit_data_models (~> 0.14.0)
   msgpack
   nokogiri
   pcaprub

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
     i18n (0.6.1)
     json (1.7.7)
     metaclass (0.0.1)
-    metasploit_data_models (0.12.0)
+    metasploit_data_models (0.13.0)
       activerecord (>= 3.2.13)
       activesupport
       pg
@@ -65,7 +65,7 @@ DEPENDENCIES
   database_cleaner
   factory_girl (>= 4.1.0)
   json
-  metasploit_data_models (~> 0.12.0)
+  metasploit_data_models (~> 0.13.0)
   msgpack
   nokogiri
   pcaprub

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130430162145) do
+ActiveRecord::Schema.define(:version => 20130515172727) do
 
   create_table "api_keys", :force => true do |t|
     t.text     "token"
@@ -581,7 +581,7 @@ ActiveRecord::Schema.define(:version => 20130430162145) do
     t.string   "name",        :limit => 1024, :null => false
     t.text     "query"
     t.text     "category",                    :null => false
-    t.text     "confidence",                  :null => false
+    t.integer  "confidence",                  :null => false
     t.text     "description"
     t.text     "blame"
     t.binary   "request"


### PR DESCRIPTION
MRI + JRuby compatbile Mdm::WebVuln#params validation so params that can't be exported won't be saved.
