### PR TITLE
msfvenom and exe-small fmt bug fix

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -402,6 +402,7 @@ require 'digest/sha1'
 
 	def self.to_win32pe_old(framework, code, opts={})
 
+		payload = code.dup
 		# Allow the user to specify their own EXE template
 		set_template_default(opts, "template_x86_windows_old.exe")
 
@@ -410,17 +411,17 @@ require 'digest/sha1'
 			pe = fd.read(fd.stat.size)
 		}
 
-		if(code.length < 2048)
-			code << Rex::Text.rand_text(2048-code.length)
+		if(payload.length < 2048)
+			payload << Rex::Text.rand_text(2048-payload.length)
 		end
 
-		if(code.length > 2048)
+		if(payload.length > 2048)
 			raise RuntimeError, "The EXE generator now has a max size of 2048 bytes, please fix the calling module"
 		end
 
 		bo = pe.index('PAYLOAD:')
 		raise RuntimeError, "Invalid Win32 PE OLD EXE template: missing \"PAYLOAD:\" tag" if not bo
-		pe[bo, code.length] = code
+		pe[bo, payload.length] = payload
 
 		pe[136, 4] = [rand(0x100000000)].pack('V')
 

--- a/msfvenom
+++ b/msfvenom
@@ -376,7 +376,6 @@ if opts[:encode]
 			if not opts[:iterations]
 				opts[:iterations] = 1
 			end
-			#puts opts[:badchars].inspect
 
 			1.upto(opts[:iterations].to_i) do |iteration|
 					begin
@@ -400,7 +399,7 @@ if opts[:encode]
 					end
 			end
 			next if skip
-			exe = Msf::Util::EXE.to_executable_fmt($framework, opts[:arch], opts[:platform], payload_raw, opts[:format], exeopts)
+
 		rescue ::Errno::ENOENT, ::Errno::EINVAL
 			print_error("#{enc.refname} failed: #{$!}")
 			break


### PR DESCRIPTION
1) prevent exe-small fmt from mangling the original payload
2) remove an unecessary call to EXE.to_executable_fmt in msfvenom
