### PR TITLE
Fix Mdm::Module::Detail#stance bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :db do
 	# Needed for Msf::DbManager
 	gem 'activerecord'
 	# Database models shared between framework and Pro.
-	gem 'metasploit_data_models', '~> 0.14.1'
+	gem 'metasploit_data_models', '~> 0.14.3'
 	# Needed for module caching in Mdm::ModuleDetails
 	gem 'pg', '>= 0.11'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
     i18n (0.6.1)
     json (1.7.7)
     metaclass (0.0.1)
-    metasploit_data_models (0.14.1)
+    metasploit_data_models (0.14.3)
       activerecord (>= 3.2.13)
       activesupport
       pg
@@ -65,7 +65,7 @@ DEPENDENCIES
   database_cleaner
   factory_girl (>= 4.1.0)
   json
-  metasploit_data_models (~> 0.14.1)
+  metasploit_data_models (~> 0.14.3)
   msgpack
   nokogiri
   pcaprub

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130515172727) do
+ActiveRecord::Schema.define(:version => 20130516204810) do
 
   create_table "api_keys", :force => true do |t|
     t.text     "token"
@@ -511,7 +511,7 @@ ActiveRecord::Schema.define(:version => 20130515172727) do
 
   add_index "vulns", ["name"], :name => "index_vulns_on_name"
 
-  create_table "vulns_refs", :id => false, :force => true do |t|
+  create_table "vulns_refs", :force => true do |t|
     t.integer "ref_id"
     t.integer "vuln_id"
   end

--- a/spec/lib/msf/db_manager_spec.rb
+++ b/spec/lib/msf/db_manager_spec.rb
@@ -1430,7 +1430,7 @@ describe Msf::DBManager do
 		end
 
 		let(:module_set) do
-			framework.exploits
+			framework.modules.module_set(module_type)
 		end
 
 		let(:module_type) do
@@ -1776,6 +1776,28 @@ describe Msf::DBManager do
 					end
 				end
 			end
+
+			it_should_behave_like 'Msf::DBManager#update_module_details with module',
+														:reference_name => 'admin/2wire/xslt_password_reset',
+														:type => 'auxiliary'
+
+			it_should_behave_like 'Msf::DBManager#update_module_details with module',
+														:reference_name => 'generic/none',
+														:type => 'encoder'
+
+			it_should_behave_like 'Msf::DBManager#update_module_details with module',
+														:reference_name => 'windows/smb/ms08_067_netapi',
+														:type => 'exploit'
+
+			it_should_behave_like 'Msf::DBManager#update_module_details with module',
+														:reference_name => 'x64/simple',
+														:type => 'nop'
+
+			# @todo determine how to load a single payload to test payload type outside of msfconsole
+
+ 			it_should_behave_like 'Msf::DBManager#update_module_details with module',
+														:reference_name => 'windows/escalate/screen_unlock',
+														:type => 'post'
 		end
 
 		context 'without migrated' do

--- a/spec/support/shared/examples/msf/db_manager/update_module_details_with_module_type.rb
+++ b/spec/support/shared/examples/msf/db_manager/update_module_details_with_module_type.rb
@@ -1,0 +1,26 @@
+shared_examples_for 'Msf::DBManager#update_module_details with module' do |options={}|
+	options.assert_valid_keys(:reference_name, :type)
+
+	reference_name = options.fetch(:reference_name)
+	type = options.fetch(:type)
+
+	context "with #{type.inspect}" do
+		let(:module_reference_name) do
+			reference_name
+		end
+
+		let(:module_type) do
+			type
+		end
+
+		it "should use module_instance with #{type.inspect} type" do
+			module_instance.type.should == type
+		end
+
+		it 'should not raise error' do
+			expect {
+				update_module_details
+			}.to_not raise_error
+		end
+	end
+end


### PR DESCRIPTION
[#49858419]
[SEERM #7958]

metasploit_data_models 0.14.3 relaxes the validation on
Mdm::Module::Detail#stance so it only needs to be in
Mdm::Module::Detail::STANCES if Mdm::Module::Detail#mtype is 'auxiliary'
or 'exploit' as framework only supplies a stance for those types when
using Mdm::Module::Detail.
