### PR TITLE
Prevent duplicate migrations_paths

### DIFF
--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -163,7 +163,16 @@ class DBManager
 				'db',
 				'migrate'
 		)
-		ActiveRecord::Migrator.migrations_paths << metasploit_data_model_migrations_pathname.to_s
+		metasploit_data_model_migrations_path = metasploit_data_model_migrations_pathname.to_s
+
+		# Since ActiveRecord::Migrator.migrations_paths can persist between
+		# instances of Msf::DBManager, such as in specs,
+		# metasploit_data_models_migrations_path may already be part of
+		# migrations_paths, in which case it should not be added or multiple
+		# migrations with the same version number errors will occur.
+		unless ActiveRecord::Migrator.migrations_paths.include? metasploit_data_model_migrations_path
+			ActiveRecord::Migrator.migrations_paths << metasploit_data_model_migrations_path
+		end
 	end
 
 	#

--- a/spec/lib/msf/db_manager_spec.rb
+++ b/spec/lib/msf/db_manager_spec.rb
@@ -20,6 +20,24 @@ describe Msf::DBManager do
 
 	it_should_behave_like 'Msf::DBManager::ImportMsfXml'
 
+	context '#initialize_metasploit_data_models' do
+		def initialize_metasploit_data_models
+			db_manager.initialize_metasploit_data_models
+		end
+
+		it 'should not add duplicate paths to ActiveRecord::Migrator.migrations_paths' do
+			initialize_metasploit_data_models
+
+			expect {
+				initialize_metasploit_data_models
+			}.to_not change {
+				ActiveRecord::Migrator.migrations_paths.length
+			}
+
+			ActiveRecord::Migrator.migrations_paths.uniq.should == ActiveRecord::Migrator.migrations_paths
+		end
+	end
+
 	context '#purge_all_module_details' do
 		def purge_all_module_details
 			db_manager.purge_all_module_details


### PR DESCRIPTION
[#50099107]

If Msf::DBManager#initialize_metasploit_data_models is run multiple
times, such as during specs, ActiveRecord::Migrator.migrations_paths was
getting populated with multiple copies of the metasploit_data_models
db/migrate path, which would lead to 'DB.migrate threw an exception:
Multiple migrations have the version number 0' errors in framework.log.
