### PR TITLE
Add sorting functionality to cmd_notes

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -847,17 +847,19 @@ class Db
 		def cmd_notes_help
 			print_line "Usage: notes [-h] [-t <type1,type2>] [-n <data string>] [-a] [addr range]"
 			print_line
-			print_line "  -a,--add          Add a note to the list of addresses, instead of listing"
-			print_line "  -d,--delete       Delete the hosts instead of searching"
-			print_line "  -n,--note <data>  Set the data for a new note (only with -a)"
-			print_line "  -t <type1,type2>  Search for a list of types"
-			print_line "  -h,--help         Show this help information"
-			print_line "  -R,--rhosts       Set RHOSTS from the results of the search"
-			print_line "  -S,--search       Search string to filter by"
+			print_line "  -a,--add                  Add a note to the list of addresses, instead of listing"
+			print_line "  -d,--delete               Delete the hosts instead of searching"
+			print_line "  -n,--note <data>          Set the data for a new note (only with -a)"
+			print_line "  -t <type1,type2>          Search for a list of types"
+			print_line "  -h,--help                 Show this help information"
+			print_line "  -R,--rhosts               Set RHOSTS from the results of the search"
+			print_line "  -S,--search               Regular expression to match for search"
+			print_line "  --sort <field1,field2>    Fields to sort by (case sensitive)"
 			print_line
 			print_line "Examples:"
 			print_line "  notes --add -t apps -n 'winzip' 10.1.1.34 10.1.20.41"
 			print_line "  notes -t smb.fingerprint 10.1.1.34 10.1.20.41"
+			print_line "  notes -S 'nmap.nse.(http|rtsp)' --sort type,output"
 			print_line
 		end
 
@@ -892,10 +894,12 @@ class Db
 						return
 					end
 					types = typelist.strip().split(",")
-				when '-R','--rhosts'
+				when '-R', '--rhosts'
 					set_rhosts = true
 				when '-S', '--search'
 					search_term = /#{args.shift}/nmi
+				when '--sort'
+					sort_term = args.shift
 				when '-h','--help'
 					cmd_notes_help
 					return
@@ -942,6 +946,43 @@ class Db
 					!n.attribute_names.any? { |a| n[a.intern].to_s.match(search_term) }
 				end
 			end
+
+			# Sort the notes based on the sort_term provided
+			if sort_term != nil
+				sort_terms = sort_term.split(",")
+				note_list.sort_by! do |note|
+					orderlist = []
+					sort_terms.each do |term|
+						term = "ntype" if term == "type"
+						term = "created_at" if term == "time"
+						if term == nil
+							orderlist << ""
+						elsif term == "service"
+							if note.service != nil
+								orderlist << make_sortable(note.service.name)
+							end
+						elsif term == "port"
+							if note.service != nil
+								orderlist << make_sortable(note.service.port)
+							end
+						elsif term == "output"
+							orderlist << make_sortable(note.data["output"])
+						elsif note.respond_to?(term)
+							orderlist << make_sortable(note.send(term))
+						elsif note.respond_to?(term.to_sym)
+							orderlist << make_sortable(note.send(term.to_sym))
+						elsif note.respond_to?("data") && note.send("data").respond_to?(term)
+							orderlist << make_sortable(note.send("data").send(term))
+						elsif note.respond_to?("data") && note.send("data").respond_to?(term.to_sym)
+							orderlist << make_sortable(note.send("data").send(term.to_sym))
+						else
+							orderlist << ""
+						end
+					end
+					orderlist
+				end
+			end
+
 			# Now display them
 			note_list.each do |note|
 				next if(types and types.index(note.ntype).nil?)
@@ -972,6 +1013,22 @@ class Db
 
 			print_status("Deleted #{delete_count} note#{delete_count == 1 ? "" : "s"}") if delete_count > 0
 		}
+		end
+
+		def make_sortable(input)
+			case input.class
+			when String
+				input = input.downcase
+			when Fixnum
+				input = "%016" % input
+			when Time
+				input = input.strftime("%Y%m%d%H%M%S%L")
+			when NilClass
+				input = ""
+			else
+				input = input.inspect.downcase
+			end
+			input
 		end
 
 		def cmd_loot_help


### PR DESCRIPTION
- Added sorting to cmd_notes
- Added make_sortable function so that sorts work happily even
  when the disparate notes don't have content of the same types
  in the fields the sort is requested over.

Redmine Feature Request #7965
