### PR TITLE
Alias 'run' to 'exploit'

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -33,7 +33,9 @@ class Exploit
 			"exploit"  => "Launch an exploit attempt",
 			"rcheck"   => "Reloads the module and checks if the target is vulnerable",
 			"rexploit" => "Reloads the module and launches an exploit attempt",
-			"reload"   => "Just reloads the module"
+			"reload"   => "Just reloads the module",
+			"run"      => "Alias for exploit",
+			"rerun"    => "Alias for rexploit",
 		})
 	end
 
@@ -197,12 +199,16 @@ class Exploit
 		end
 	end
 
+	alias cmd_run cmd_exploit
+
 	def cmd_exploit_help
 		print_line "Usage: exploit [options]"
 		print_line
 		print_line "Launches an exploitation attempt."
 		print @@exploit_opts.usage
 	end
+
+	alias cmd_run_help cmd_exploit_help
 
 	#
 	# Reloads an exploit module and checks the target to see if it's
@@ -227,12 +233,16 @@ class Exploit
 		end
 	end
 
+	alias cmd_rerun cmd_rexploit
+
 	def cmd_rexploit_help
 		print_line "Usage: rexploit [options]"
 		print_line
 		print_line "Reloads a module, stopping any associated job, and launches an exploitation attempt."
 		print @@exploit_opts.usage
 	end
+
+	alias cmd_rerun_help cmd_rexploit_help
 
 	#
 	# Picks a reasonable payload and minimally configures it


### PR DESCRIPTION
Allows console users to use the 'run' command for exploits as well as
auxiliary and post, in the same way that 'exploit' works for all three.
Saves some typing and makes it do the right thing so users don't have to
remember what kind of module they're using.
