### PR TITLE
Reset column information after running migrations

### DIFF
--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -3,6 +3,7 @@
 require 'msf/base/config'
 require 'msf/core'
 require 'msf/core/db'
+require 'msf/core/db_manager/migration'
 require 'msf/core/task_manager'
 require 'fileutils'
 require 'shellwords'
@@ -17,6 +18,9 @@ module Msf
 ###
 
 class DBManager
+	# Provides :framework and other accessors
+	include Msf::DBManager::Migration
+	include Msf::Framework::Offspring
 
 	# Mainly, it's Ruby 1.9.1 that cause a lot of problems now, along with Ruby 1.8.6.
 	# Ruby 1.8.7 actually seems okay, but why tempt fate? Let's say 1.9.3 and beyond.
@@ -27,9 +31,6 @@ class DBManager
 			$stderr.puts "**************************************************************************************"
 		end
 	end
-
-	# Provides :framework and other accessors
-	include Framework::Offspring
 
 	# Returns true if we are ready to load/store data
 	def active
@@ -52,9 +53,6 @@ class DBManager
 
 	# Stores a TaskManager for serializing database events
 	attr_accessor :sink
-
-	# Flag to indicate database migration has completed
-	attr_accessor :migrated
 
 	# Flag to indicate that modules are cached
 	attr_accessor :modules_cached
@@ -276,33 +274,6 @@ class DBManager
 			# Database drivers can reset our KCODE, do not let them
 			$KCODE = 'NONE' if RUBY_VERSION =~ /^1\.8\./
 		end
-	end
-
-	# Migrate database to latest schema version.
-	#
-	# @param verbose [Boolean] see ActiveRecord::Migration.verbose
-	# @return [Array<ActiveRecord::MigrationProxy] List of migrations that ran.
-	#
-	# @see ActiveRecord::Migrator.migrate
-	def migrate(verbose=false)
-		ran = []
-		ActiveRecord::Migration.verbose = verbose
-
-		ActiveRecord::Base.connection_pool.with_connection do
-			begin
-				ran = ActiveRecord::Migrator.migrate(
-						ActiveRecord::Migrator.migrations_paths
-				)
-			# ActiveRecord::Migrator#migrate rescues all errors and re-raises them as
-			# StandardError
-			rescue StandardError => error
-				self.error = error
-				elog("DB.migrate threw an exception: #{error}")
-				dlog("Call stack:\n#{error.backtrace.join "\n"}")
-			end
-		end
-
-		return ran
 	end
 
 	def workspace=(workspace)

--- a/lib/msf/core/db_manager/migration.rb
+++ b/lib/msf/core/db_manager/migration.rb
@@ -1,0 +1,38 @@
+module Msf
+	class DBManager
+		module Migration
+			# Migrate database to latest schema version.
+			#
+			# @param verbose [Boolean] see ActiveRecord::Migration.verbose
+			# @return [Array<ActiveRecord::MigrationProxy] List of migrations that
+			#   ran.
+			#
+			# @see ActiveRecord::Migrator.migrate
+			def migrate(verbose=false)
+				ran = []
+				ActiveRecord::Migration.verbose = verbose
+
+				ActiveRecord::Base.connection_pool.with_connection do
+					begin
+						ran = ActiveRecord::Migrator.migrate(
+								ActiveRecord::Migrator.migrations_paths
+						)
+					# ActiveRecord::Migrator#migrate rescues all errors and re-raises them
+					# as StandardError
+					rescue StandardError => error
+						self.error = error
+						elog("DB.migrate threw an exception: #{error}")
+						dlog("Call stack:\n#{error.backtrace.join "\n"}")
+					end
+				end
+
+				return ran
+			end
+
+			# Flag to indicate database migration has completed
+			#
+			# @return [Boolean]
+			attr_accessor :migrated
+		end
+	end
+end

--- a/lib/msf/core/db_manager/migration.rb
+++ b/lib/msf/core/db_manager/migration.rb
@@ -26,6 +26,13 @@ module Msf
 					end
 				end
 
+				# Since the connections that existed before the migrations ran could
+				# have outdated column information, reset column information for all
+				# ActiveRecord::Base descendents to prevent missing method errors for
+				# column methods for columns created in migrations after the column
+				# information was cached.
+				reset_column_information
+
 				return ran
 			end
 
@@ -33,6 +40,19 @@ module Msf
 			#
 			# @return [Boolean]
 			attr_accessor :migrated
+
+			private
+
+			# Resets the column information for all descendants of ActiveRecord::Base
+			# since some of the migrations may have cached column information that
+			# has been updated by later migrations.
+			#
+			# @return [void]
+			def reset_column_information
+				ActiveRecord::Base.descendants.each do |descendant|
+					descendant.reset_column_information
+				end
+			end
 		end
 	end
 end

--- a/spec/lib/msf/db_manager_spec.rb
+++ b/spec/lib/msf/db_manager_spec.rb
@@ -18,6 +18,7 @@ describe Msf::DBManager do
 		db_manager
 	end
 
+	it_should_behave_like 'Msf::DBManager::Migration'
 	it_should_behave_like 'Msf::DBManager::ImportMsfXml'
 
 	context '#purge_all_module_details' do

--- a/spec/support/shared/examples/msf/db_manager/migration.rb
+++ b/spec/support/shared/examples/msf/db_manager/migration.rb
@@ -1,0 +1,109 @@
+shared_examples_for 'Msf::DBManager::Migration' do
+	it { should be_a Msf::DBManager::Migration }
+
+	context '#migrate' do
+		def migrate
+			db_manager.migrate
+		end
+
+		it 'should create a connection' do
+			ActiveRecord::Base.connection_pool.should_receive(:with_connection).twice
+
+			migrate
+		end
+
+		it 'should call ActiveRecord::Migrator.migrate' do
+			ActiveRecord::Migrator.should_receive(:migrate).with(
+					ActiveRecord::Migrator.migrations_paths
+			)
+
+			migrate
+		end
+
+		it 'should return migrations that were ran from ActiveRecord::Migrator.migrate' do
+			migrations = [mock('Migration 1')]
+			ActiveRecord::Migrator.stub(:migrate => migrations)
+
+			migrate.should == migrations
+		end
+
+		context 'with StandardError from ActiveRecord::Migration.migrate' do
+			let(:error) do
+				StandardError.new(message)
+			end
+
+			let(:message) do
+				"Error during migration"
+			end
+
+			before(:each) do
+				ActiveRecord::Migrator.stub(:migrate).and_raise(error)
+			end
+
+			it 'should set Msf::DBManager#error' do
+				migrate
+
+				db_manager.error.should == error
+			end
+
+			it 'should log error message at error level' do
+				db_manager.should_receive(:elog) do |error_message|
+					error_message.should include(error.to_s)
+				end
+
+				migrate
+			end
+
+			it 'should log error backtrace at debug level' do
+				db_manager.should_receive(:dlog) do |debug_message|
+					debug_message.should include('Call stack')
+				end
+
+				migrate
+			end
+		end
+
+		context 'with verbose' do
+			def migrate
+				db_manager.migrate(verbose)
+			end
+
+			context 'false' do
+				let(:verbose) do
+					false
+				end
+
+				it 'should set ActiveRecord::Migration.verbose to false' do
+					ActiveRecord::Migration.should_receive(:verbose=).with(verbose)
+
+					migrate
+				end
+			end
+
+			context 'true' do
+				let(:verbose) do
+					true
+				end
+
+				it 'should set ActiveRecord::Migration.verbose to true' do
+					ActiveRecord::Migration.should_receive(:verbose=).with(verbose)
+
+					migrate
+				end
+			end
+		end
+
+		context 'without verbose' do
+			it 'should set ActiveRecord::Migration.verbose to false' do
+				ActiveRecord::Migration.should_receive(:verbose=).with(false)
+
+				db_manager.migrate
+			end
+		end
+	end
+
+	context '#migrated' do
+		it { should respond_to :migrated }
+		it { should respond_to :migrated= }
+	end
+end


### PR DESCRIPTION
Because metasploit-framework runs migrations with the same process and with the same connection as it later accesses the database, the column information can become cached prematurely and be incorrect by the end of the migrations.  Fix the bad cache by automatically resetting the column information for all model classes after the migrations have run.
