### PR TITLE
Fixed a bug in the HSTS module around null headers

### DIFF
--- a/modules/auxiliary/scanner/http/http_hsts.rb
+++ b/modules/auxiliary/scanner/http/http_hsts.rb
@@ -35,18 +35,22 @@ class Metasploit3 < Msf::Auxiliary
 				'method' => 'GET',
 				}, 25)
 
-			hsts = res.headers['Strict-Transport-Security']
+			if res
+				hsts = res.headers['Strict-Transport-Security']
 
-			if res and hsts
-				print_good("#{ip}:#{rport} - Strict-Transport-Security:#{hsts}")
-				report_note({
-					:data => hsts,
-					:type => "hsts.data",
-					:host => ip,
-					:port => rport
-				})
+				if hsts
+					print_good("#{ip}:#{rport} - Strict-Transport-Security:#{hsts}")
+					report_note({
+						:data => hsts,
+						:type => "hsts.data",
+						:host => ip,
+						:port => rport
+					})
+				else
+					print_error("#{ip}:#{rport} No HSTS found.")
+				end
 			else
-				print_error("#{ip}:#{rport} No HSTS found.")
+				print_error("#{ip}:#{rport} No headers were returned.")
 			end
 
 		rescue ::Timeout::Error, ::Errno::EPIPE


### PR DESCRIPTION
A colleague discovered that if an HTTPS server did not return any headers, this module would fail.

An example would be:

```
$ curl -I -k https://11.22.33.44
curl: (52) Empty reply from server
```

This would cause the error in the module:

```
msf auxiliary(http_hsts) > rexploit
[*] Reloading module...

[*] 11.22.33.44:443: 
[-] Auxiliary failed: NoMethodError undefined method `headers' for nil:NilClass
[-] Call stack:
[-]   /usr/local/share/metasploit-framework/modules/auxiliary/scanner/http/http_hsts.rb:39:in `run_host'
[-]   /usr/local/share/metasploit-framework/lib/msf/core/auxiliary/scanner.rb:94:in `block in run'
[-]   /usr/local/share/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `call'
[-]   /usr/local/share/metasploit-framework/lib/msf/core/thread_manager.rb:100:in `block in spawn'
[*] Auxiliary module execution completed
```

To fix this, I just made sure to check that the response was not nil before trying to read the HSTS header.
