### PR TITLE
Feature/task associations/cred service host

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :db do
 	# Needed for Msf::DbManager
 	gem 'activerecord'
 	# Database models shared between framework and Pro.
-	gem 'metasploit_data_models', '~> 0.14.3'
+	gem 'metasploit_data_models', '~> 0.15.0'
 	# Needed for module caching in Mdm::ModuleDetails
 	gem 'pg', '>= 0.11'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
     i18n (0.6.1)
     json (1.7.7)
     metaclass (0.0.1)
-    metasploit_data_models (0.14.3)
+    metasploit_data_models (0.15.0)
       activerecord (>= 3.2.13)
       activesupport
       pg
@@ -65,7 +65,7 @@ DEPENDENCIES
   database_cleaner
   factory_girl (>= 4.1.0)
   json
-  metasploit_data_models (~> 0.14.3)
+  metasploit_data_models (~> 0.15.0)
   msgpack
   nokogiri
   pcaprub

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130516204810) do
+ActiveRecord::Schema.define(:version => 20130522041110) do
 
   create_table "api_keys", :force => true do |t|
     t.text     "token"
@@ -425,6 +425,27 @@ ActiveRecord::Schema.define(:version => 20130516204810) do
     t.boolean  "critical",                       :default => false, :null => false
     t.datetime "created_at",                                        :null => false
     t.datetime "updated_at",                                        :null => false
+  end
+
+  create_table "task_creds", :force => true do |t|
+    t.integer  "task_id",    :null => false
+    t.integer  "cred_id",    :null => false
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  create_table "task_hosts", :force => true do |t|
+    t.integer  "task_id",    :null => false
+    t.integer  "host_id",    :null => false
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  create_table "task_services", :force => true do |t|
+    t.integer  "task_id",    :null => false
+    t.integer  "service_id", :null => false
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
   end
 
   create_table "tasks", :force => true do |t|

--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -21,7 +21,17 @@ module Auxiliary::Report
 
 	def myworkspace
 		@myworkspace = framework.db.find_workspace(self.workspace)
-	end
+  end
+
+  def mytask
+    if self[:task]
+      return self[:task].record
+    elsif @task && @task.class == Mdm::Task
+      return @task
+    else
+      return nil
+    end
+  end
 
 	def inside_workspace_boundary?(ip)
 		return true if not framework.db.active
@@ -41,7 +51,10 @@ module Auxiliary::Report
 	#
 	def report_host(opts)
 		return if not db
-		opts = {:workspace => myworkspace}.merge(opts)
+		opts = {
+      :workspace => myworkspace,
+      :task => mytask
+    }.merge(opts)
 		framework.db.report_host(opts)
 	end
 
@@ -63,7 +76,10 @@ module Auxiliary::Report
 	#
 	def report_client(opts={})
 		return if not db
-		opts = {:workspace => myworkspace}.merge(opts)
+    opts = {
+        :workspace => myworkspace,
+        :task => mytask
+    }.merge(opts)
 		framework.db.report_client(opts)
 	end
 
@@ -78,25 +94,37 @@ module Auxiliary::Report
 	#
 	def report_service(opts={})
 		return if not db
-		opts = {:workspace => myworkspace}.merge(opts)
+    opts = {
+        :workspace => myworkspace,
+        :task => mytask
+    }.merge(opts)
 		framework.db.report_service(opts)
 	end
 
 	def report_note(opts={})
 		return if not db
-		opts = {:workspace => myworkspace}.merge(opts)
+    opts = {
+        :workspace => myworkspace,
+        :task => mytask
+    }.merge(opts)
 		framework.db.report_note(opts)
 	end
 
 	def report_auth_info(opts={})
 		return if not db
-		opts = {:workspace => myworkspace}.merge(opts)
+    opts = {
+        :workspace => myworkspace,
+        :task => mytask
+    }.merge(opts)
 		framework.db.report_auth_info(opts)
 	end
 
 	def report_vuln(opts={})
 		return if not db
-		opts = {:workspace => myworkspace}.merge(opts)
+    opts = {
+        :workspace => myworkspace,
+        :task => mytask
+    }.merge(opts)
 		framework.db.report_vuln(opts)
 	end
 
@@ -104,37 +132,55 @@ module Auxiliary::Report
 	# is no longer implemented.
 	def report_exploit(opts={})
 		return if not db
-		opts = {:workspace => myworkspace}.merge(opts)
+    opts = {
+        :workspace => myworkspace,
+        :task => mytask
+    }.merge(opts)
 		framework.db.report_exploit(opts)
 	end
 
 	def report_loot(opts={})
 		return if not db
-		opts = {:workspace => myworkspace}.merge(opts)
+    opts = {
+        :workspace => myworkspace,
+        :task => mytask
+    }.merge(opts)
 		framework.db.report_loot(opts)
 	end
 
 	def report_web_site(opts={})
 		return if not db
-		opts = {:workspace => myworkspace}.merge(opts)
+    opts = {
+        :workspace => myworkspace,
+        :task => mytask
+    }.merge(opts)
 		framework.db.report_web_site(opts)
 	end
 
 	def report_web_page(opts={})
 		return if not db
-		opts = {:workspace => myworkspace}.merge(opts)
+    opts = {
+        :workspace => myworkspace,
+        :task => mytask
+    }.merge(opts)
 		framework.db.report_web_page(opts)
 	end
 
 	def report_web_form(opts={})
 		return if not db
-		opts = {:workspace => myworkspace}.merge(opts)
+    opts = {
+        :workspace => myworkspace,
+        :task => mytask
+    }.merge(opts)
 		framework.db.report_web_form(opts)
 	end
 
 	def report_web_vuln(opts={})
 		return if not db
-		opts = {:workspace => myworkspace}.merge(opts)
+    opts = {
+        :workspace => myworkspace,
+        :task => mytask
+    }.merge(opts)
 		framework.db.report_web_vuln(opts)
 	end
 

--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -377,7 +377,7 @@ class DBManager
 		end
 
     if opts[:task]
-      Mdm::TaskHost.new(
+      Mdm::TaskHost.create(
           :task => opts[:task],
           :host => host
       )
@@ -602,7 +602,7 @@ class DBManager
     end
 
     if opts[:task]
-      Mdm::TaskService.new(
+      Mdm::TaskService.create(
           :task => opts[:task],
           :service => service
       )
@@ -1605,10 +1605,9 @@ class DBManager
 			cred.save!
     end
 
+
     if opts[:task]
-      require 'pry'
-      binding.pry
-      Mdm::TaskCred.new(
+      Mdm::TaskCred.create(
           :task => opts[:task],
           :cred => cred
       )

--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -3119,14 +3119,15 @@ class DBManager
 						desc_text = item.elements['description'].text
 						next if desc_text.nil? or desc_text.empty?
 						desc_data = {
-							:workspace => wspace,
-							:host => addr,
-							:type => "service.nikto.scan.description",
-							:data => desc_text,
-							:proto => "tcp",
-							:port => port.to_i,
-							:sname => uri.scheme,
-							:update => :unique_data
+                :workspace => wspace,
+                :host      => addr,
+                :type      => "service.nikto.scan.description",
+                :data      => desc_text,
+                :proto     => "tcp",
+                :port      => port.to_i,
+                :sname     => uri.scheme,
+                :update    => :unique_data,
+                :task      => args[:task]
 						}
 						# Always report it as a note.
 						report_note(desc_data)
@@ -3231,13 +3232,27 @@ class DBManager
 			next if (bl | [saddr,daddr]).size == bl.size # Both hosts are blacklisted, skip everything.
 			unless( bl.include?(saddr) || rfc3330_reserved(saddr))
 				yield(:address,saddr) if block and !seen_hosts.keys.include?(saddr)
-				report_host(:workspace => wspace, :host => saddr, :state => Msf::HostState::Alive) unless seen_hosts[saddr]
+        unless seen_hosts[saddr]
+          report_host(
+              :workspace => wspace,
+              :host      => saddr,
+              :state     => Msf::HostState::Alive,
+              :task      => args[:task]
+          )
+        end
 				seen_hosts[saddr] ||= []
 
 			end
 			unless( bl.include?(daddr) || rfc3330_reserved(daddr))
 				yield(:address,daddr) if block and !seen_hosts.keys.include?(daddr)
-				report_host(:workspace => wspace, :host => daddr, :state => Msf::HostState::Alive) unless seen_hosts[daddr]
+        unless seen_hosts[daddr]
+          report_host(
+              :workspace => wspace,
+              :host      => daddr,
+              :state     => Msf::HostState::Alive,
+              :task      => args[:task]
+          )
+        end
 				seen_hosts[daddr] ||= []
 			end
 
@@ -3247,9 +3262,10 @@ class DBManager
 					if seen_hosts[saddr]
 						unless seen_hosts[saddr].include? [pkt.tcp_src,"tcp"]
 							report_service(
-								:workspace => wspace, :host => saddr,
-								:proto => "tcp", :port => pkt.tcp_src,
-								:state => Msf::ServiceState::Open
+                  :workspace => wspace, :host => saddr,
+                  :proto     => "tcp", :port => pkt.tcp_src,
+                  :state     => Msf::ServiceState::Open,
+                  :task      => args[:task]
 							)
 							seen_hosts[saddr] << [pkt.tcp_src,"tcp"]
 							yield(:service,"%s:%d/%s" % [saddr,pkt.tcp_src,"tcp"])
@@ -3262,9 +3278,10 @@ class DBManager
 						if seen_hosts[xaddr]
 							unless seen_hosts[xaddr].include? [pkt.udp_src,"udp"]
 								report_service(
-									:workspace => wspace, :host => xaddr,
-									:proto => "udp", :port => pkt.udp_src,
-									:state => Msf::ServiceState::Open
+                    :workspace => wspace, :host => xaddr,
+                    :proto     => "udp", :port => pkt.udp_src,
+                    :state     => Msf::ServiceState::Open,
+                    :task      => args[:task]
 								)
 								seen_hosts[xaddr] << [pkt.udp_src,"udp"]
 								yield(:service,"%s:%d/%s" % [xaddr,pkt.udp_src,"udp"])
@@ -3275,9 +3292,10 @@ class DBManager
 					if seen_hosts[saddr]
 						unless seen_hosts[saddr].include? [pkt.udp_src,"udp"]
 							report_service(
-								:workspace => wspace, :host => saddr,
-								:proto => "udp", :port => pkt.udp_src,
-								:state => Msf::ServiceState::Open
+                  :workspace => wspace, :host => saddr,
+                  :proto     => "udp", :port => pkt.udp_src,
+                  :state     => Msf::ServiceState::Open,
+                  :task      => args[:task]
 							)
 							seen_hosts[saddr] << [pkt.udp_src,"udp"]
 							yield(:service,"%s:%d/%s" % [saddr,pkt.udp_src,"udp"])
@@ -3286,7 +3304,7 @@ class DBManager
 				end
 			end # tcp or udp
 
-			inspect_single_packet(pkt,wspace)
+			inspect_single_packet(pkt,wspace,args[:task])
 
 		end # data.body.map
 
@@ -3299,29 +3317,30 @@ class DBManager
 	# Do all the single packet analysis we can while churning through the pcap
 	# the first time. Multiple packet inspection will come later, where we can
 	# do stream analysis, compare requests and responses, etc.
-	def inspect_single_packet(pkt,wspace)
+	def inspect_single_packet(pkt,wspace,task=nil)
 		if pkt.is_tcp? or pkt.is_udp?
-			inspect_single_packet_http(pkt,wspace)
+			inspect_single_packet_http(pkt,wspace,task)
 		end
 	end
 
 	# Checks for packets that are headed towards port 80, are tcp, contain an HTTP/1.0
 	# line, contains an Authorization line, contains a b64-encoded credential, and
 	# extracts it. Reports this credential and solidifies the service as HTTP.
-	def inspect_single_packet_http(pkt,wspace)
+	def inspect_single_packet_http(pkt,wspace,task=nil)
 		# First, check the server side (data from port 80).
 		if pkt.is_tcp? and pkt.tcp_src == 80 and !pkt.payload.nil? and !pkt.payload.empty?
 			if pkt.payload =~ /^HTTP\x2f1\x2e[01]/
 				http_server_match = pkt.payload.match(/\nServer:\s+([^\r\n]+)[\r\n]/)
 				if http_server_match.kind_of?(MatchData) and http_server_match[1]
 					report_service(
-						:workspace => wspace,
-						:host => pkt.ip_saddr,
-						:port => pkt.tcp_src,
-						:proto => "tcp",
-						:name => "http",
-						:info => http_server_match[1],
-						:state => Msf::ServiceState::Open
+              :workspace => wspace,
+              :host      => pkt.ip_saddr,
+              :port      => pkt.tcp_src,
+              :proto     => "tcp",
+              :name      => "http",
+              :info      => http_server_match[1],
+              :state     => Msf::ServiceState::Open,
+              :task      => task
 					)
 					# That's all we want to know from this service.
 					return :something_significant
@@ -3344,21 +3363,23 @@ class DBManager
 				# to come later.
 				user,pass = b64_cred.unpack("m*").first.split(/:/,2)
 				report_service(
-					:workspace => wspace,
-					:host => pkt.ip_daddr,
-					:port => pkt.tcp_dst,
-					:proto => "tcp",
-					:name => "http"
+            :workspace => wspace,
+            :host      => pkt.ip_daddr,
+            :port      => pkt.tcp_dst,
+            :proto     => "tcp",
+            :name      => "http",
+            :task      => task
 				)
 				report_auth_info(
-					:workspace => wspace,
-					:host => pkt.ip_daddr,
-					:port => pkt.tcp_dst,
-					:proto => "tcp",
-					:type => "password",
-					:active => true, # Once we can build a stream, determine if the auth was successful. For now, assume it is.
-					:user => user,
-					:pass => pass
+            :workspace => wspace,
+            :host      => pkt.ip_daddr,
+            :port      => pkt.tcp_dst,
+            :proto     => "tcp",
+            :type      => "password",
+            :active    => true, # Once we can build a stream, determine if the auth was successful. For now, assume it is.
+            :user      => user,
+            :pass      => pass,
+            :task      => task
 				)
 				# That's all we want to know from this service.
 				return :something_significant
@@ -3387,7 +3408,8 @@ class DBManager
 			conf = {
 			:workspace => wspace,
 			:host      => ip,
-			:name      => name
+			:name      => name,
+      :task      => args[:task]
 			}
 
 			conf[:os_name] = os if os
@@ -3476,12 +3498,13 @@ class DBManager
 			end
 
 			cred_info = {
-				:host => addr,
-				:port => port,
-				:user => user,
-				:pass => pass,
-				:type => ptype,
-				:workspace => wspace
+				:host      => addr,
+				:port      => port,
+				:user      => user,
+				:pass      => pass,
+				:type      => ptype,
+				:workspace => wspace,
+        :task      => args[:task]
 			}
 			cred_info[:proto] = proto if proto
 			cred_info[:sname] = sname if sname
@@ -3651,17 +3674,18 @@ class DBManager
 		# Import Loot
 		doc.elements.each("/#{btag}/loots/loot") do |loot|
 			next if bl.include? host_info[loot.elements["host-id"].text.to_s.strip]
-			loot_info = {}
-			loot_info[:host] = host_info[loot.elements["host-id"].text.to_s.strip]
-			loot_info[:workspace] = args[:wspace]
-			loot_info[:ctype] = nils_for_nulls(loot.elements["content-type"].text.to_s.strip)
-			loot_info[:info] = nils_for_nulls(unserialize_object(loot.elements["info"], allow_yaml))
-			loot_info[:ltype] = nils_for_nulls(loot.elements["ltype"].text.to_s.strip)
-			loot_info[:name] = nils_for_nulls(loot.elements["name"].text.to_s.strip)
-			loot_info[:created_at] = nils_for_nulls(loot.elements["created-at"].text.to_s.strip)
-			loot_info[:updated_at] = nils_for_nulls(loot.elements["updated-at"].text.to_s.strip)
-			loot_info[:name] = nils_for_nulls(loot.elements["name"].text.to_s.strip)
-			loot_info[:orig_path] = nils_for_nulls(loot.elements["path"].text.to_s.strip)
+      loot_info              = {}
+      loot_info[:host]       = host_info[loot.elements["host-id"].text.to_s.strip]
+      loot_info[:workspace]  = args[:wspace]
+      loot_info[:ctype]      = nils_for_nulls(loot.elements["content-type"].text.to_s.strip)
+      loot_info[:info]       = nils_for_nulls(unserialize_object(loot.elements["info"], allow_yaml))
+      loot_info[:ltype]      = nils_for_nulls(loot.elements["ltype"].text.to_s.strip)
+      loot_info[:name]       = nils_for_nulls(loot.elements["name"].text.to_s.strip)
+      loot_info[:created_at] = nils_for_nulls(loot.elements["created-at"].text.to_s.strip)
+      loot_info[:updated_at] = nils_for_nulls(loot.elements["updated-at"].text.to_s.strip)
+      loot_info[:name]       = nils_for_nulls(loot.elements["name"].text.to_s.strip)
+      loot_info[:orig_path]  = nils_for_nulls(loot.elements["path"].text.to_s.strip)
+      loot_info[:task]       = args[:task]
 			tmp = args[:ifd][:zip_tmp]
 			loot_info[:orig_path].gsub!(/^\./,tmp) if loot_info[:orig_path]
 			if !loot.elements["service-id"].text.to_s.strip.empty?
@@ -3746,18 +3770,18 @@ class DBManager
 
 		# Import Reports
 		doc.elements.each("/#{btag}/reports/report") do |report|
-			report_info = {}
-			report_info[:workspace] = args[:wspace]
-			# Should user be imported (original) or declared (the importing user)?
-			report_info[:user] = nils_for_nulls(report.elements["created-by"].text.to_s.strip)
-			report_info[:options] = nils_for_nulls(report.elements["options"].text.to_s.strip)
-			report_info[:rtype] = nils_for_nulls(report.elements["rtype"].text.to_s.strip)
-			report_info[:created_at] = nils_for_nulls(report.elements["created-at"].text.to_s.strip)
-			report_info[:updated_at] = nils_for_nulls(report.elements["updated-at"].text.to_s.strip)
-
-			report_info[:orig_path] = nils_for_nulls(report.elements["path"].text.to_s.strip)
-			tmp = args[:ifd][:zip_tmp]
-			report_info[:orig_path].gsub!(/^\./,tmp) if report_info[:orig_path]
+      tmp = args[:ifd][:zip_tmp]
+      report_info              = {}
+      report_info[:workspace]  = args[:wspace]
+      # Should user be imported (original) or declared (the importing user)?
+      report_info[:user]       = nils_for_nulls(report.elements["created-by"].text.to_s.strip)
+      report_info[:options]    = nils_for_nulls(report.elements["options"].text.to_s.strip)
+      report_info[:rtype]      = nils_for_nulls(report.elements["rtype"].text.to_s.strip)
+      report_info[:created_at] = nils_for_nulls(report.elements["created-at"].text.to_s.strip)
+      report_info[:updated_at] = nils_for_nulls(report.elements["updated-at"].text.to_s.strip)
+      report_info[:orig_path]  = nils_for_nulls(report.elements["path"].text.to_s.strip)
+      report_info[:task]       = args[:task]
+      report_info[:orig_path].gsub!(/^\./, tmp) if report_info[:orig_path]
 
 			# Only report a report if we actually have it.
 			# TODO: Copypasta. Seperate this out.
@@ -3841,7 +3865,8 @@ class DBManager
 			conf = {
 				:workspace => wspace,
 				:host      => addr,
-				:state     => Msf::HostState::Alive
+				:state     => Msf::HostState::Alive,
+        :task      => args[:task]
 			}
 
 			host = report_host(conf)
@@ -3851,7 +3876,8 @@ class DBManager
 				:workspace => wspace,
 				:host      => host,
 				:type      => 'host.os.nexpose_fingerprint',
-				:data      => fprint
+				:data      => fprint,
+        :task      => args[:task]
 			)
 
 			# Load vulnerabilities not associated with a service
@@ -3864,7 +3890,8 @@ class DBManager
 					:host      => host,
 					:name      => 'NEXPOSE-' + vid,
 					:info      => vid,
-					:refs      => refs
+					:refs      => refs,
+          :task      => args[:task]
 				)
 			end
 
@@ -3883,9 +3910,24 @@ class DBManager
 				end
 
 				if(sname.downcase != '<unknown>')
-					report_service(:workspace => wspace, :host => host, :proto => sprot, :port => sport, :name => name, :info => info)
+					report_service(
+              :workspace => wspace,
+              :host      => host,
+              :proto     => sprot,
+              :port      => sport,
+              :name      => name,
+              :info      => info,
+              :task      => args[:task]
+          )
 				else
-					report_service(:workspace => wspace, :host => host, :proto => sprot, :port => sport, :info => info)
+					report_service(
+              :workspace => wspace,
+              :host      => host,
+              :proto     => sprot,
+              :port      => sport,
+              :info      => info,
+              :task      => args[:task]
+          )
 				end
 
 				# Load vulnerabilities associated with this service
@@ -3894,13 +3936,14 @@ class DBManager
 					refs = process_nexpose_data_sxml_refs(vuln)
 					next if not refs
 					report_vuln(
-						:workspace => wspace,
-						:host => host,
-						:port => sport,
-						:proto => sprot,
-						:name => 'NEXPOSE-' + vid,
-						:info => vid,
-						:refs => refs
+              :workspace => wspace,
+              :host      => host,
+              :port      => sport,
+              :proto     => sprot,
+              :name      => 'NEXPOSE-' + vid,
+              :info      => vid,
+              :refs      => refs,
+              :task      => args[:task]
 					)
 				end
 			end
@@ -4018,7 +4061,7 @@ class DBManager
 
 	# Takes a Host object, an array of vuln structs (generated by nexpose_refs_to_struct()),
 	# and a workspace, and reports the vulns on that host.
-	def nexpose_host_from_rawxml(h, vstructs, wspace)
+	def nexpose_host_from_rawxml(h, vstructs, wspace,task=nil)
 		hobj = nil
 		data = {:workspace => wspace}
 		if h["addr"]
@@ -4047,11 +4090,12 @@ class DBManager
 
 		if h["notes"]
 			note = {
-				:workspace => wspace,
-				:host => (hobj || addr),
-				:type => "host.vuln.nexpose_keys",
-				:data => {},
-				:mode => :unique_data
+          :workspace => wspace,
+          :host      => (hobj || addr),
+          :type      => "host.vuln.nexpose_keys",
+          :data      => {},
+          :mode      => :unique_data,
+          :task      => task
 			}
 			h["notes"].each do |v,k|
 				note[:data][v] ||= []
@@ -4063,13 +4107,14 @@ class DBManager
 
 		if h["os_family"]
 			note = {
-				:workspace => wspace,
-				:host => hobj || addr,
-				:type => 'host.os.nexpose_fingerprint',
-				:data => {
-					:family    => h["os_family"],
-					:certainty => h["os_certainty"]
-				}
+          :workspace => wspace,
+          :host      => hobj || addr,
+          :type      => 'host.os.nexpose_fingerprint',
+          :task      => task,
+          :data      => {
+              :family    => h["os_family"],
+              :certainty => h["os_certainty"]
+          }
 			}
 			note[:data][:vendor]  = h["os_vendor"]  if h["os_vendor"]
 			note[:data][:product] = h["os_product"] if h["os_product"]
@@ -4090,13 +4135,14 @@ class DBManager
 			# XXX This should probably be handled in a more standard way
 			# extra << "(" + p["certainty"] + " certainty) " if p["certainty"]
 
-			data = {}
-			data[:workspace] = wspace
-			data[:proto] = p["protocol"].downcase
-			data[:port]  = p["port"].to_i
-			data[:state] = p["status"]
-			data[:host]  = hobj || addr
-			data[:info]  = extra if not extra.empty?
+      data             = {}
+      data[:workspace] = wspace
+      data[:proto]     = p["protocol"].downcase
+      data[:port]      = p["port"].to_i
+      data[:state]     = p["status"]
+      data[:host]      = hobj || addr
+      data[:info]      = extra if not extra.empty?
+      data[:task]      = task
 			if p["name"] != "<unknown>"
 				data[:name] = p["name"]
 			end
@@ -4108,14 +4154,15 @@ class DBManager
 			next if v["status"] !~ /^vulnerable/
 			vstruct = vstructs.select {|vs| vs.id.to_s.downcase == v["id"].to_s.downcase}.first
 			next unless vstruct
-			data = {}
-			data[:workspace] = wspace
-			data[:host] = hobj || addr
-			data[:proto] = v["protocol"].downcase if v["protocol"]
-			data[:port] = v["port"].to_i if v["port"]
-			data[:name] = "NEXPOSE-" + v["id"]
-			data[:info] = vstruct.title
-			data[:refs] = vstruct.refs
+      data             = {}
+      data[:workspace] = wspace
+      data[:host]      = hobj || addr
+      data[:proto]     = v["protocol"].downcase if v["protocol"]
+      data[:port]      = v["port"].to_i if v["port"]
+      data[:name]      = "NEXPOSE-" + v["id"]
+      data[:info]      = vstruct.title
+      data[:refs]      = vstruct.refs
+      data[:task]      = task
 			report_vuln(data)
 		}
 	end
@@ -4182,12 +4229,13 @@ class DBManager
 			# Import OS fingerprint
 			if host["os"]
 				note = {
-					:workspace => wspace,
-					:host => addr,
-					:type => 'host.os.retina_fingerprint',
-					:data => {
-						:os => host["os"]
-					}
+            :workspace => wspace,
+            :host      => addr,
+            :type      => 'host.os.retina_fingerprint',
+            :task      => args[:task],
+            :data      => {
+                :os => host["os"]
+            }
 				}
 				report_note(note)
 			end
@@ -4198,11 +4246,12 @@ class DBManager
 				refs << "RETINA-#{vuln['rthid']}" if vuln['rthid']
 
 				vuln_info = {
-					:workspace => wspace,
-					:host => addr,
-					:name => vuln['name'],
-					:info => vuln['description'],
-					:refs => refs
+            :workspace => wspace,
+            :host      => addr,
+            :name      => vuln['name'],
+            :info      => vuln['description'],
+            :refs      => refs,
+            :task      => args[:task]
 				}
 
 				report_vuln(vuln_info)
@@ -4294,7 +4343,8 @@ class DBManager
 						:query    => uri.query,
 						:code     => code,
 						:body     => body,
-						:headers  => headers
+						:headers  => headers,
+            :task     => args[:task]
 					}
 					info.merge!(data)
 
@@ -4354,18 +4404,19 @@ class DBManager
 				# XXX: There is a :request attr in the model, but report_web_vuln
 				# doesn't seem to know about it, so this gets ignored.
 				#:request  => vuln['request'],
-				:path     => uri.path,
-				:query    => uri.query,
-				:method   => method,
-				:params   => params,
-				:pname    => pname.to_s,
-				:proof    => proof,
-				:risk     => details[:risk],
-				:name     => details[:name],
-				:blame    => details[:blame],
-				:category => details[:category],
-				:description => details[:description],
-				:confidence  => details[:confidence],
+        :path        => uri.path,
+        :query       => uri.query,
+        :method      => method,
+        :params      => params,
+        :pname       => pname.to_s,
+        :proof       => proof,
+        :risk        => details[:risk],
+        :name        => details[:name],
+        :blame       => details[:blame],
+        :category    => details[:category],
+        :description => details[:description],
+        :confidence  => details[:confidence],
+        :task        => args[:task]
 			}
 			info.merge!(data)
 
@@ -4703,6 +4754,7 @@ class DBManager
 				data[:mac] = h["addrs"]["mac"]
 			end
 			data[:state] = (h["status"] == "up") ? Msf::HostState::Alive : Msf::HostState::Dead
+      data[:task] = args[:task]
 
 			if ( h["reverse_dns"] )
 				data[:name] = h["reverse_dns"]
@@ -4726,6 +4778,7 @@ class DBManager
 					:workspace => wspace,
 					:host => hobj || addr,
 					:type => 'host.os.nmap_fingerprint',
+          :task => args[:task],
 					:data => {
 						:os_vendor   => h["os_vendor"],
 						:os_family   => h["os_family"],
@@ -4746,6 +4799,7 @@ class DBManager
 					:workspace => wspace,
 					:host => hobj || addr,
 					:type => 'host.last_boot',
+          :task => args[:task],
 					:data => {
 						:time => h["last_boot"]
 					}
@@ -4766,6 +4820,7 @@ class DBManager
 					:workspace => wspace,
 					:host => hobj || addr,
 					:type => 'host.nmap.traceroute',
+          :task => args[:task],
 					:data => {
 						'port'  => h["trace"]["port"].to_i,
 						'proto' => h["trace"]["proto"].to_s,
@@ -4801,6 +4856,7 @@ class DBManager
 				data[:state] = p["state"]
 				data[:host]  = hobj || addr
 				data[:info]  = extra if not extra.empty?
+        data[:task]  = args[:task]
 				if p["name"] != "unknown"
 					data[:name] = p["name"]
 				end
@@ -4813,6 +4869,7 @@ class DBManager
 						if val =~ /MS08-067: VULNERABLE/
 							vuln_info = {
 								:workspace => wspace,
+                :task => args[:task],
 								:host =>  hobj || addr,
 								:port => 445,
 								:proto => 'tcp',
@@ -4831,6 +4888,7 @@ class DBManager
 						if val =~ /MS06-025: VULNERABLE/
 							vuln_info = {
 								:workspace => wspace,
+                :task => args[:task],
 								:host =>  hobj || addr,
 								:port => 445,
 								:proto => 'tcp',
@@ -4853,6 +4911,7 @@ class DBManager
 						if val =~ /MS07-029: VULNERABLE/
 							vuln_info = {
 								:workspace => wspace,
+                :task => args[:task],
 								:host =>  hobj || addr,
 								:port => 445,
 								:proto => 'tcp',
@@ -4994,7 +5053,7 @@ class DBManager
 				yield(:address,addr) if block
 			end
 
-			hobj_map[ addr ] ||= report_host(:host => addr, :workspace => wspace)
+			hobj_map[ addr ] ||= report_host(:host => addr, :workspace => wspace, :task => args[:task])
 
 			# Match the NBE types with the XML severity ratings
 			case type
@@ -5012,6 +5071,7 @@ class DBManager
 				os = data.match(/The remote host is running (.*)\\n/)[1]
 				report_note(
 					:workspace => wspace,
+          :task => args[:task],
 					:host => hobj_map[ addr ],
 					:type => 'host.os.nessus_fingerprint',
 					:data => {
@@ -5100,7 +5160,8 @@ class DBManager
 
 			hinfo = {
 				:workspace => wspace,
-				:host => addr
+				:host => addr,
+        :task => args[:task]
 			}
 
 			# Record the hostname
@@ -5113,6 +5174,7 @@ class DBManager
 			if os
 				report_note(
 					:workspace => wspace,
+          :task => args[:task],
 					:host => hobj,
 					:type => 'host.os.nessus_fingerprint',
 					:data => {
@@ -5128,7 +5190,7 @@ class DBManager
 				data = item.elements['data'].text
 				severity = item.elements['severity'].text
 
-				handle_nessus(wspace, hobj, port, nasl, plugin_name, severity, data)
+				handle_nessus(wspace, hobj, port, nasl, plugin_name, severity, data, args[:task])
 			end
 		end
 	end
@@ -5176,6 +5238,7 @@ class DBManager
 			host_info = {
 				:workspace => wspace,
 				:host => addr,
+        :task => args[:task]
 			}
 			host_info[:name] = hname.to_s.strip if hname
 			# Short mac, protect against Nessus's habit of saving multiple macs
@@ -5190,6 +5253,7 @@ class DBManager
 			if os
 				report_note(
 					:workspace => wspace,
+          :task => args[:task],
 					:host => hobj,
 					:type => 'host.os.nessus_fingerprint',
 					:data => {
@@ -5215,7 +5279,7 @@ class DBManager
 
 				yield(:port,port) if block
 
-				handle_nessus_v2(wspace, hobj, port, proto, sname, nasl, nasl_name, severity, description, cve, bid, xref, msf)
+				handle_nessus_v2(wspace, hobj, port, proto, sname, nasl, nasl_name, severity, description, cve, bid, xref, msf, args[:task])
 
 			end
 			yield(:end,hname) if block
@@ -5484,6 +5548,7 @@ class DBManager
 			host_hash = {
 				:workspace => wspace,
 				:host => addr,
+        :task => args[:task]
 			}
 			host_hash[:name] = hname.to_s.strip if hname
 			host_hash[:mac]  = mac.to_s.strip.upcase if mac
@@ -5494,6 +5559,7 @@ class DBManager
 			if os
 				report_note(
 					:workspace => wspace,
+          :task => args[:task],
 					:host => hobj,
 					:type => 'host.os.ip360_fingerprint',
 					:data => {
@@ -5506,7 +5572,7 @@ class DBManager
 				port = item['port'].to_s
 				proto = item['proto'].to_s
 
-				handle_ip360_v3_svc(wspace, hobj, port, proto, hname)
+				handle_ip360_v3_svc(wspace, hobj, port, proto, hname, args[:task])
 			end
 
 
@@ -5520,7 +5586,7 @@ class DBManager
 
 				yield(:port, port) if block
 
-				handle_ip360_v3_vuln(wspace, hobj, port, proto, hname, vulnid, vulnname, cves, bids)
+				handle_ip360_v3_vuln(wspace, hobj, port, proto, hname, vulnid, vulnname, cves, bids, args[:task])
 
 			end
 
@@ -5553,7 +5619,7 @@ class DBManager
 			next unless vi.elements["QID"]
 			vi.elements.each("QID") do |qid|
 				next if vuln_refs[qid.text].nil? || vuln_refs[qid.text].empty?
-				handle_qualys(wspace, hobj, nil, nil, qid.text, nil, vuln_refs[qid.text], nil)
+				handle_qualys(wspace, hobj, nil, nil, qid.text, nil, vuln_refs[qid.text], nil,nil, args[:task])
 			end
 		end
 	end
@@ -5573,7 +5639,7 @@ class DBManager
 				else
 					name = match[2].strip
 				end
-				handle_qualys(wspace, hobj, match[0].to_s, proto, 0, nil, nil, name)
+				handle_qualys(wspace, hobj, match[0].to_s, proto, 0, nil, nil, name, nil, args[:task])
 			end
 		end
 	end
@@ -5602,13 +5668,14 @@ class DBManager
 				(host.elements["NETBIOS"].text if host.elements["NETBIOS"]) ||
 			 	(host.elements["DNS"].text if host.elements["DNS"]) ||
 			 	"" )
-			hobj = report_host(:workspace => wspace, :host => addr, :name => hname, :state => Msf::HostState::Alive)
+			hobj = report_host(:workspace => wspace, :host => addr, :name => hname, :state => Msf::HostState::Alive, :task => args[:task])
 			report_import_note(wspace,hobj)
 
 			if host.elements["OPERATING_SYSTEM"]
 				hos = host.elements["OPERATING_SYSTEM"].text
 				report_note(
 					:workspace => wspace,
+          :task => args[:task],
 					:host => hobj,
 					:type => 'host.os.qualys_fingerprint',
 					:data => { :os => hos }
@@ -5657,13 +5724,14 @@ class DBManager
 			end
 			hname = host.attributes['name'] || ''
 
-			hobj = report_host(:workspace => wspace, :host => addr, :name => hname, :state => Msf::HostState::Alive)
+			hobj = report_host(:workspace => wspace, :host => addr, :name => hname, :state => Msf::HostState::Alive, :task => args[:task])
 			report_import_note(wspace,hobj)
 
 			if host.elements["OS"]
 				hos = host.elements["OS"].text
 				report_note(
 					:workspace => wspace,
+          :task => args[:task],
 					:host => hobj,
 					:type => 'host.os.qualys_fingerprint',
 					:data => {
@@ -5681,7 +5749,7 @@ class DBManager
 					else
 						name = match[2].strip
 					end
-					handle_qualys(wspace, hobj, match[0].to_s, 'tcp', 0, nil, nil, name)
+					handle_qualys(wspace, hobj, match[0].to_s, 'tcp', 0, nil, nil, name, nil, args[:task])
 				end
 			end
 			# Open UDP Services List (Qualys ID 82004)
@@ -5693,7 +5761,7 @@ class DBManager
 					else
 						name = match[2].strip
 					end
-					handle_qualys(wspace, hobj, match[0].to_s, 'udp', 0, nil, nil, name)
+					handle_qualys(wspace, hobj, match[0].to_s, 'udp', 0, nil, nil, name, nil, args[:task])
 				end
 			end
 
@@ -5716,7 +5784,7 @@ class DBManager
 						refs.push('BID-' + ref.elements['ID'].text.to_s)
 					end
 
-					handle_qualys(wspace, hobj, port, protocol, qid, severity, refs, nil,title)
+					handle_qualys(wspace, hobj, port, protocol, qid, severity, refs, nil,title, args[:task])
 				end
 			end
 		end
@@ -5745,7 +5813,7 @@ class DBManager
 			else
 				yield(:address,ip) if block
 			end
-			host = find_or_create_host(:workspace => wspace, :host=> ip, :state => Msf::HostState::Alive)
+			host = find_or_create_host(:workspace => wspace, :host=> ip, :state => Msf::HostState::Alive, :task => args[:task])
 		end
 	end
 
@@ -5780,11 +5848,12 @@ class DBManager
 			port   = $2.to_i
 			proto  = $3.downcase
 			name   = $4
-			host = find_or_create_host(:workspace => wspace, :host => addr, :state => Msf::HostState::Alive)
+			host = find_or_create_host(:workspace => wspace, :host => addr, :state => Msf::HostState::Alive, :task => args[:task])
 			next if not host
 			yield(:address,addr) if block
 			info = {
 				:workspace => wspace,
+        :task => args[:task],
 				:host => host,
 				:proto => proto,
 				:port => port
@@ -5814,11 +5883,12 @@ class DBManager
 			name   = r[5]
 			next if status != "open"
 
-			host = find_or_create_host(:workspace => wspace, :host => addr, :state => Msf::HostState::Alive)
+			host = find_or_create_host(:workspace => wspace, :host => addr, :state => Msf::HostState::Alive, :task => args[:task])
 			next if not host
 			yield(:address,addr) if block
 			info = {
 				:workspace => wspace,
+        :task => args[:task],
 				:host => host,
 				:proto => proto,
 				:port => port
@@ -5939,7 +6009,7 @@ protected
 	# This holds all of the shared parsing/handling used by the
 	# Nessus NBE and NESSUS v1 methods
 	#
-	def handle_nessus(wspace, hobj, port, nasl, plugin_name, severity, data)
+	def handle_nessus(wspace, hobj, port, nasl, plugin_name, severity, data,task=nil)
 		addr = hobj.address
 		# The port section looks like:
 		#   http (80/tcp)
@@ -5952,7 +6022,7 @@ protected
 		port = p[2].to_i
 		proto = p[3].downcase
 
-		info = { :workspace => wspace, :host => hobj, :port => port, :proto => proto }
+		info = { :workspace => wspace, :host => hobj, :port => port, :proto => proto, :task => task }
 		if name != "unknown" and name[-1,1] != "?"
 			info[:name] = name
 		end
@@ -6001,7 +6071,8 @@ protected
 			:proto => proto,
 			:name => vuln_name,
 			:info => data,
-			:refs => refs
+			:refs => refs,
+      :task => task,
 		}
 		report_vuln(vuln_info)
 	end
@@ -6010,10 +6081,10 @@ protected
 	# NESSUS v2 file format has a dramatically different layout
 	# for ReportItem data
 	#
-	def handle_nessus_v2(wspace,hobj,port,proto,name,nasl,nasl_name,severity,description,cve,bid,xref,msf)
+	def handle_nessus_v2(wspace,hobj,port,proto,name,nasl,nasl_name,severity,description,cve,bid,xref,msf,task=nil)
 		addr = hobj.address
 
-		info = { :workspace => wspace, :host => hobj, :port => port, :proto => proto }
+		info = { :workspace => wspace, :host => hobj, :port => port, :proto => proto, :task => task }
 
 		unless name =~ /^unknown$|\?$/
 			info[:name] = name
@@ -6060,7 +6131,8 @@ protected
 			:host => hobj,
 			:name => vuln_name,
 			:info => description ? description : "",
-			:refs => refs
+			:refs => refs,
+      :task => task,
 		}
 
 		if port.to_i != 0
@@ -6074,11 +6146,11 @@ protected
 	#
 	# IP360 v3 vuln
 	#
-	def handle_ip360_v3_svc(wspace,hobj,port,proto,hname)
+	def handle_ip360_v3_svc(wspace,hobj,port,proto,hname,task=nil)
 		addr = hobj.address
-		report_host(:workspace => wspace, :host => hobj, :state => Msf::HostState::Alive)
+		report_host(:workspace => wspace, :host => hobj, :state => Msf::HostState::Alive, :task => task)
 
-		info = { :workspace => wspace, :host => hobj, :port => port, :proto => proto }
+		info = { :workspace => wspace, :host => hobj, :port => port, :proto => proto, :task => task }
 		if hname != "unknown" and hname[-1,1] != "?"
 			info[:name] = hname
 		end
@@ -6091,8 +6163,8 @@ protected
 	#
 	# IP360 v3 vuln
 	#
-	def handle_ip360_v3_vuln(wspace,hobj,port,proto,hname,vulnid,vulnname,cves,bids)
-		info = { :workspace => wspace, :host => hobj, :port => port, :proto => proto }
+	def handle_ip360_v3_vuln(wspace,hobj,port,proto,hname,vulnid,vulnname,cves,bids,task=nil)
+		info = { :workspace => wspace, :host => hobj, :port => port, :proto => proto, :task => task }
 		if hname != "unknown" and hname[-1,1] != "?"
 			info[:name] = hname
 		end
@@ -6117,7 +6189,8 @@ protected
 			:host => hobj,
 			:name => vulnname,
 			:info => description ? description : "",
-			:refs => refs
+			:refs => refs,
+      :task => task
 		}
 
 		if port.to_i != 0
@@ -6131,11 +6204,11 @@ protected
 	#
 	# Qualys report parsing/handling
 	#
-	def handle_qualys(wspace, hobj, port, protocol, qid, severity, refs, name=nil, title=nil)
+	def handle_qualys(wspace, hobj, port, protocol, qid, severity, refs, name=nil, title=nil, task=nil)
 		addr = hobj.address
 		port = port.to_i if port
 
-		info = { :workspace => wspace, :host => hobj, :port => port, :proto => protocol }
+		info = { :workspace => wspace, :host => hobj, :port => port, :proto => protocol, :task => task }
 		if name and name != 'unknown' and name != 'No registered hostname'
 			info[:name] = name
 		end
@@ -6161,6 +6234,7 @@ protected
 		if addr
 			report_vuln(
 				:workspace => wspace,
+        :task => task,
 				:host => hobj,
 				:port => port,
 				:proto => protocol,

--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -376,6 +376,13 @@ class DBManager
 			host.save!
 		end
 
+    if opts[:task]
+      Mdm::TaskHost.new(
+          :task => opts[:task],
+          :host => host
+      )
+    end
+
 		host
 	}
 	end
@@ -592,7 +599,15 @@ class DBManager
 		if (service and service.changed?)
 			msf_import_timestamps(opts,service)
 			service.save!
-		end
+    end
+
+    if opts[:task]
+      Mdm::TaskService.new(
+          :task => opts[:task],
+          :service => service
+      )
+    end
+
 		ret[:service] = service
 	}
 	end
@@ -1588,7 +1603,16 @@ class DBManager
 		unless opts[:updated_at] || opts["updated_at"]
 			cred.updated_at = Time.now.utc
 			cred.save!
-		end
+    end
+
+    if opts[:task]
+      require 'pry'
+      binding.pry
+      Mdm::TaskCred.new(
+          :task => opts[:task],
+          :cred => cred
+      )
+    end
 
 		ret[:cred] = cred
 	end

--- a/lib/rex/parser/nokogiri_doc_mixin.rb
+++ b/lib/rex/parser/nokogiri_doc_mixin.rb
@@ -147,8 +147,10 @@ module Parser
 				just_the_facts = nonempty_data
 			else
 				just_the_facts = nonempty_data.select {|k,v| valid_attrs.include? k.to_s.to_sym}
-			end
-			just_the_facts.empty? ? return : db.send("report_#{table}", just_the_facts)
+      end
+      return nil if just_the_facts.empty?
+      just_the_facts[:task] = @args[:task]
+			db.send("report_#{table}", just_the_facts)
 		end
 
 		# XXX: It would be better to either have a single registry of acceptable


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/49167601
Related PRs: https://github.com/rapid7/metasploit_data_models/pull/27
https://github.com/rapid7/pro/pull/720

This adds the backend support to creating the Task association objects for Host,Service, and Cred when reporting on those objects. In a pure framework context this won't do anything since framework doesn't use tasks.

Verification steps
- [x] Complete Verification Steps for https://github.com/rapid7/metasploit_data_models/pull/27
- [x]  Install local gem (gem install path_to_gem_file )
- [x] start up msfconsole
- [x] use auxiliary/scanner/ssh/ssh_login
- [x] set RHOSTS vuln-metasploitable2
- [x] set username msfadmin
- [x] set password msfadmin
- [x] run
- [x] creds
- [x] Verify new cred is saved in the db
- [x] run irb inside msfconsole
- [x] VERIFY Mdm::Cred.last.task_creds returns an empty array
- [x] VERIFY Mdm::Cred.last.tasks returns an empty array
- [x] VERIFY Mdm::Host.last.task_hosts returns an empty array
- [x] VERIFY Mdm::Host.last.tasks returns an empty array
- [x] VERIFY Mdm::Services.last.task_services returns an empty array
- [x] VERIFY Mdm::Services.last.tasks returns an empty array
