### PR TITLE
Add session_port to the mdm object

### DIFF
--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -721,17 +721,18 @@ class DBManager
 			h_opts[:workspace] = wspace
 			host = find_or_create_host(h_opts)
 			sess_data = {
-				:host_id => host.id,
-				:stype => session.type,
-				:desc => session.info,
-				:platform => session.platform,
-				:via_payload => session.via_payload,
-				:via_exploit => session.via_exploit,
-				:routes => [],
-				:datastore => session.exploit_datastore.to_h,
-				:opened_at => Time.now.utc,
-				:last_seen => Time.now.utc,
-				:local_id => session.sid
+          :host_id     => host.id,
+          :stype       => session.type,
+          :desc        => session.info,
+          :platform    => session.platform,
+          :via_payload => session.via_payload,
+          :via_exploit => session.via_exploit,
+          :routes      => [],
+          :datastore   => session.exploit_datastore.to_h,
+          :port        => session.session_port,
+          :opened_at   => Time.now.utc,
+          :last_seen   => Time.now.utc,
+          :local_id    => session.sid
 			}
 		elsif opts[:host]
 			raise ArgumentError.new("Invalid :host, expected Host object") unless opts[:host].kind_of? ::Mdm::Host


### PR DESCRIPTION
Mdm::Session was not being passed the session_port
FIXRM #7281

Verification Steps
- [x] Open a Session on any host
- [x] open irb in msfconsole
- [x] session = Mdm::Session.last
- [x] VERIFY session.port is filled in with the correct port
