### PR TITLE
fix an undefined variable bug in the DTP module

### DIFF
--- a/modules/auxiliary/spoof/cisco/dtp.rb
+++ b/modules/auxiliary/spoof/cisco/dtp.rb
@@ -17,7 +17,7 @@ class Metasploit3 < Msf::Auxiliary
 			'Description'	=> %q{
 				This module forges DTP packets to initialize a trunk port.
 			},
-			'Author'		=> [ 'Spencer McIntyre <zerosteiner [at] gmail.com>' ],
+			'Author'		=> [ 'Spencer McIntyre' ],
 			'License'		=> MSF_LICENSE,
 			'Actions'     =>
 				[
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Auxiliary
 
 	def smac
 		@spoof_mac ||= datastore['SMAC']
-		@spoof_mac ||= get_mac(interface) if netifaces_implemented?
+		@spoof_mac ||= get_mac(datastore['INTERFACE']) if netifaces_implemented?
 		return @spoof_mac
 	end
 
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Auxiliary
 		unless smac()
 			print_error 'Source MAC (SMAC) should be defined'
 		else
-			unless is_mac? smac()
+			unless is_mac? smac
 				print_error "Source MAC (SMAC) `#{smac}' is badly formatted."
 			else
 				print_status "Starting DTP spoofing service..."


### PR DESCRIPTION
There's been a bug in the DTP module for a while now, not sure when it originated.  Basically the smac function fails if netifaces_implemented? evaluates to true because 'interface' is undefined.

```
msf > use auxiliary/spoof/cisco/dtp 
msf auxiliary(dtp) > show options 

Module options (auxiliary/spoof/cisco/dtp):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   FILTER                      no        The filter string for capturing traffic
   INTERFACE                   no        The name of the interface
   SMAC                        no        The spoofed mac (if unset, derived from netifaces)
   SNAPLEN    65535            yes       The number of bytes to capture
   TIMEOUT    500              yes       The number of seconds to wait for new data

msf auxiliary(dtp) > set INTERFACE em1
INTERFACE => em1
msf auxiliary(dtp) > exploit
[*] Auxiliary module execution completed

[-] Auxiliary failed: NameError undefined local variable or method `interface' for #<Msf::Modules::Mod617578696c696172792f73706f6f662f636973636f2f647470::Metasploit3:0x0000000b735478>
[-] Call stack:
[-]   /home/user/repos/msf3-git/modules/auxiliary/spoof/cisco/dtp.rb:57:in `smac'
[-]   /home/user/repos/msf3-git/modules/auxiliary/spoof/cisco/dtp.rb:62:in `run'
msf auxiliary(dtp) > 
```

This pull request fixes the bug and removes my email address.

After the fix:

```
msf > use auxiliary/spoof/cisco/dtp 
msf auxiliary(dtp) > show options 

Module options (auxiliary/spoof/cisco/dtp):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   FILTER                      no        The filter string for capturing traffic
   INTERFACE                   no        The name of the interface
   SMAC                        no        The spoofed mac (if unset, derived from netifaces)
   SNAPLEN    65535            yes       The number of bytes to capture
   TIMEOUT    500              yes       The number of seconds to wait for new data

msf auxiliary(dtp) > set INTERFACE em1
INTERFACE => em1
msf auxiliary(dtp) > exploit
[*] Auxiliary module execution completed

[*] Starting DTP spoofing service...
msf auxiliary(dtp) > 
```
