### PR TITLE
Updates fingerprint() for Cold Fusion 10

### DIFF
--- a/modules/auxiliary/scanner/http/cold_fusion_version.rb
+++ b/modules/auxiliary/scanner/http/cold_fusion_version.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Auxiliary
 			if(response.headers['Server'] =~ /IIS/ or response.headers['Server'] =~ /\(Windows/)
 				os = "Windows (#{response.headers['Server']})"
 			elsif(response.headers['Server'] =~ /Apache\//)
-					os = "Unix (#{response.headers['Server']})"
+				os = "Unix (#{response.headers['Server']})"
 			else
 				os = response.headers['Server']
 			end
@@ -48,10 +48,10 @@ class Metasploit3 < Msf::Auxiliary
 			title = $1
 			title.gsub!(/\s/, '')
 		end
-		return nil  if( title == 'Not Found' or not title =~ /ColdFusionAdministrator/)
+
+		return nil if( title == 'Not Found' or not title =~ /ColdFusionAdministrator/)
 
 		out = nil
-
 
 		if(response.body =~ />\s*Version:\s*(.*)<\/strong\><br\s\//)
 			v = $1
@@ -64,7 +64,8 @@ class Metasploit3 < Msf::Auxiliary
 			response.body =~ /1997\-2012 Adobe Systems Incorporated and its licensors/)
 			out = "Adobe ColdFusion 10"
 		elsif(response.body =~ /<meta name=\"Author\" content=\"Copyright \(c\) 1995\-2010 Adobe/ or
-			response.body =~ /<meta name=\"Author\" content=\"Copyright \(c\) 1995\-2009 Adobe Systems\, Inc\. All rights reserved/)
+			response.body =~ /<meta name=\"Author\" content=\"Copyright \(c\) 1995\-2009 Adobe Systems\, Inc\. All rights reserved/ or
+			response.body =~ /<meta name=\"Author\" content=\"Copyright \(c\) 1997\-2012 Adobe Systems\, Inc\. All rights reserved/)
 			out = "Adobe ColdFusion 9"
 		elsif(response.body =~ /<meta name=\"Keywords\" content=\"(.*)\">\s+<meta name/)
 			out = $1.split(/,/)[0]
@@ -85,8 +86,8 @@ class Metasploit3 < Msf::Auxiliary
 		url = '/CFIDE/administrator/index.cfm'
 
 		res = send_request_cgi({
-				'uri' => url,
-				'method' => 'GET',
+			'uri' => url,
+			'method' => 'GET',
 		})
 
 		return if not res or not res.body or not res.code

--- a/modules/auxiliary/scanner/http/cold_fusion_version.rb
+++ b/modules/auxiliary/scanner/http/cold_fusion_version.rb
@@ -17,8 +17,8 @@ class Metasploit3 < Msf::Auxiliary
 		super(
 			'Name'        => 'ColdFusion Version Scanner',
 			'Description' => %q{
-				This module attempts identify various flavors of ColdFusion such as version 9
-				and 10, as well as the underlying OS.
+				This module attempts identify various flavors of ColdFusion up to version 10
+				as well as the underlying OS.
 			},
 			'Author'      =>
 				[

--- a/modules/auxiliary/scanner/http/cold_fusion_version.rb
+++ b/modules/auxiliary/scanner/http/cold_fusion_version.rb
@@ -17,11 +17,38 @@ class Metasploit3 < Msf::Auxiliary
 		super(
 			'Name'        => 'ColdFusion Version Scanner',
 			'Description' => %q{
-					This module attempts identify various flavors of ColdFusion as well as the underlying OS
+				This module attempts identify various flavors of ColdFusion such as version 9
+				and 10, as well as the underlying OS.
 			},
-			'Author'      => [ 'nebulus' ],
+			'Author'      =>
+				[
+					'nebulus',  # Original
+					'sinn3r'    # Fingerprint() patch for Cold Fusion 10
+				],
 			'License'     => MSF_LICENSE
 		)
+	end
+
+
+	#
+	# Checks loginbackground.jpg for Cold Fusion 10.  This is a patch to be able to detect
+	# Cold Fusion 10 correctly.  We haven't been able to replace fingerprint(), because we
+	# don't have all the MD5s for loginbackground.jpg, not to mention some versions don't
+	# actually have it.
+	#
+	def cf10?
+		res = send_request_cgi({
+			'uri'    => '/CFIDE/administrator/images/loginbackground.jpg',
+			'method' => 'GET'
+		})
+
+		# Not the response we want at all, then let's assume it's not cf10
+		return false if not res or res.code.to_i != 200
+
+		jpg_md5 = Rex::Text.md5(res.body)
+		return true if jpg_md5 == 'a4c81b7a6289b2fc9b36848fa0cae83c'
+
+		false
 	end
 
 	def fingerprint(response)
@@ -47,6 +74,8 @@ class Metasploit3 < Msf::Auxiliary
 
 		out = nil
 
+
+
 		if(response.body =~ />\s*Version:\s*(.*)<\/strong\><br\s\//)
 			v = $1
 			out = (v =~ /^6/) ? "Adobe ColdFusion MX6 #{v}" : "Adobe ColdFusion MX7 #{v}"
@@ -54,6 +83,9 @@ class Metasploit3 < Msf::Auxiliary
 			out = "Adobe ColdFusion MX7"
 		elsif(response.body =~ /<meta name=\"Author\" content=\"Copyright \(c\) 1995\-2006 Adobe/)
 			out = "Adobe ColdFusion 8"
+		elsif cf10?
+			# Must check for Cold Fusion 10 before 9 to avoid FP
+			out = "Adobe ColdFusion 10"
 		elsif(response.body =~ /<meta name=\"Author\" content=\"Copyright \(c\) 1995\-2010 Adobe/ or
 			response.body =~ /<meta name=\"Author\" content=\"Copyright \(c\) 1995\-2009 Adobe Systems\, Inc\. All rights reserved/)
 			out = "Adobe ColdFusion 9"

--- a/modules/auxiliary/scanner/http/cold_fusion_version.rb
+++ b/modules/auxiliary/scanner/http/cold_fusion_version.rb
@@ -29,28 +29,6 @@ class Metasploit3 < Msf::Auxiliary
 		)
 	end
 
-
-	#
-	# Checks loginbackground.jpg for Cold Fusion 10.  This is a patch to be able to detect
-	# Cold Fusion 10 correctly.  We haven't been able to replace fingerprint(), because we
-	# don't have all the MD5s for loginbackground.jpg, not to mention some versions don't
-	# actually have it.
-	#
-	def cf10?
-		res = send_request_cgi({
-			'uri'    => '/CFIDE/administrator/images/loginbackground.jpg',
-			'method' => 'GET'
-		})
-
-		# Not the response we want at all, then let's assume it's not cf10
-		return false if not res or res.code.to_i != 200
-
-		jpg_md5 = Rex::Text.md5(res.body)
-		return true if jpg_md5 == 'a4c81b7a6289b2fc9b36848fa0cae83c'
-
-		false
-	end
-
 	def fingerprint(response)
 
 		if(response.headers.has_key?('Server') )
@@ -75,7 +53,6 @@ class Metasploit3 < Msf::Auxiliary
 		out = nil
 
 
-
 		if(response.body =~ />\s*Version:\s*(.*)<\/strong\><br\s\//)
 			v = $1
 			out = (v =~ /^6/) ? "Adobe ColdFusion MX6 #{v}" : "Adobe ColdFusion MX7 #{v}"
@@ -83,8 +60,8 @@ class Metasploit3 < Msf::Auxiliary
 			out = "Adobe ColdFusion MX7"
 		elsif(response.body =~ /<meta name=\"Author\" content=\"Copyright \(c\) 1995\-2006 Adobe/)
 			out = "Adobe ColdFusion 8"
-		elsif cf10?
-			# Must check for Cold Fusion 10 before 9 to avoid FP
+		elsif(response.body =~ /<meta name=\"Author\" content=\"Copyright \(c\) 1995\-2010 Adobe/ and
+			response.body =~ /1997\-2012 Adobe Systems Incorporated and its licensors/)
 			out = "Adobe ColdFusion 10"
 		elsif(response.body =~ /<meta name=\"Author\" content=\"Copyright \(c\) 1995\-2010 Adobe/ or
 			response.body =~ /<meta name=\"Author\" content=\"Copyright \(c\) 1995\-2009 Adobe Systems\, Inc\. All rights reserved/)


### PR DESCRIPTION
This patch updates the fingerprint() function in order to be able to detect Cold Fusion 10 correctly.  Demo:

Test on Cold Fusion 10:

```
msf auxiliary(cold_fusion_version) > run

[+] 10.0.1.78: Adobe ColdFusion 10 (Apache-Coyote/1.1)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(cold_fusion_version) > 
```

Test on Cold Fusion 9:

```
msf auxiliary(cold_fusion_version) > run

[+] 10.0.1.56: Adobe ColdFusion 9 (Windows (Microsoft-IIS/6.0))
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(cold_fusion_version) >
```
