### PR TITLE
Fixes smart_migrate for a TypeError bug

### DIFF
--- a/modules/post/windows/manage/smart_migrate.rb
+++ b/modules/post/windows/manage/smart_migrate.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Post
 			return true
 		rescue ::Exception => e
 			print_error("Could not migrate in to process.")
-			print_error(e)
+			print_error(e.to_s)
 			return false
 		end
 	end


### PR DESCRIPTION
Bug is: TypeError can't convert Rex::RuntimeError into String, occurs when you hit an exception during migration.

[SeeRM: #7984]
http://dev.metasploit.com/redmine/issues/7984
