### PR TITLE
Start with a random username to test 401 codes

### DIFF
--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -75,7 +75,8 @@ class Metasploit3 < Msf::Auxiliary
 			uri = normalize_uri(datastore['URI'])
 			res = send_request_cgi({
 				'uri'     => uri,
-				'method'  => 'GET'
+				'method'  => 'GET',
+				'username' => Rex::Text.rand_text_alpha(8)
 				}, 25)
 			http_fingerprint({ :response => res })
 		rescue ::Rex::ConnectionError => e


### PR DESCRIPTION
This addresses redmine bug 7991.

While this fixes the specific case of tomcat_mgr_login, it doesn't
address the general case where modules are attempting to test code 401
responses in order to determine if bruteforcing should continue. So, this pull request should be landed to fix the immediate problem, but do not resolve the associated bug quite yet.
## Verification steps
- [x] Set up a Tomcat server with known creds.
- [x] In msfconsole, `use auxiliary/scanner/http/tomcat_mgr_login`
- [x] Set the following options (assuming admin:admin is a valid cred)

```
set USERNAME admin
set PASSWORD admin
set STOP_ON_SUCCESS true
set PASS_FILE ""
set USER_FILE ""
set USERPASS_FILE ""
```
- [x] Verify that a success message is generated:

```
[*] 1.2.3.4:8080 TOMCAT_MGR - [1/2] - Trying username:'admin' with password:''
[-] 1.2.3.4:8080 TOMCAT_MGR - [1/2] - /manager/html [Apache-Coyote/1.1] [Tomcat Application Manager] failed to login as 'admin'
[*] 1.2.3.4.:8080 TOMCAT_MGR - [2/2] - Trying username:'admin' with password:'admin'
[+] http://1.2.3.4:8080/manager/html [Apache-Coyote/1.1] [Tomcat Application Manager] successful login 'admin' : 'admin'
```
