### PR TITLE
Use a LIKE test instead of equality

### DIFF
--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -666,11 +666,11 @@ class DBManager
             formatted_values = value_set.collect { |value|
               prefix = keyword.upcase
 
-              "#{prefix}-#{value}"
+              "#{prefix}-%#{value}%"
             }
 
             query = query.includes(:refs)
-            union_conditions << Mdm::Module::Ref.arel_table[:name].eq_any(formatted_values)
+            union_conditions << Mdm::Module::Ref.arel_table[:name].matches_any(formatted_values)
         end
       end
 


### PR DESCRIPTION
Fixes the ability to search for CVE (as well as other reference types)
with a non-exact match

[SeeRM #7989]
