### PR TITLE
Fixes bug in search reported by d0rm0us3

### DIFF
--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -666,11 +666,11 @@ class DBManager
             formatted_values = value_set.collect { |value|
               prefix = keyword.upcase
 
-              "#{prefix}-#{value}"
+              "#{prefix}-#{value}%"
             }
 
             query = query.includes(:refs)
-            union_conditions << Mdm::Module::Ref.arel_table[:name].eq_any(formatted_values)
+            union_conditions << Mdm::Module::Ref.arel_table[:name].matches_any(formatted_values)
         end
       end
 


### PR DESCRIPTION
Fix for [FixRM #7989]. Made database search use matches (LIKE) instead
of equality for cve/bid/osvdb, since this is how the slow search does
it. Left it anchored at the beginning, so query is something like:

```
SELECT * from X WHERE id LIKE 'CVE-2013%'
```

for a query of: search cve:2013
