### PR TITLE
svn scanner should print good and rport for found svn entries

### DIFF
--- a/modules/auxiliary/scanner/http/svn_scanner.rb
+++ b/modules/auxiliary/scanner/http/svn_scanner.rb
@@ -117,7 +117,7 @@ class Metasploit3 < Msf::Auxiliary
 					print_status("[#{target_host}] NOT Found. #{tpath} #{res.code}")
 				end
 			else
-				print_status("[#{target_host}] SVN Entries file found.")
+				print_good("[#{target_host}:#{rport}] SVN Entries file found.")
 
 				report_web_vuln(
 					:host	=> target_host,


### PR DESCRIPTION
minor change but to stay consistent with outher modules and to make the scannign piece easier.

svn scanner should print_good and also show IP:RPORT for found svn entries
