### PR TITLE
bump mdm version to 0.15.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :db do
 	# Needed for Msf::DbManager
 	gem 'activerecord'
 	# Database models shared between framework and Pro.
-	gem 'metasploit_data_models', '~> 0.15.1'
+	gem 'metasploit_data_models', '~> 0.15.2'
 	# Needed for module caching in Mdm::ModuleDetails
 	gem 'pg', '>= 0.11'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
     i18n (0.6.1)
     json (1.7.7)
     metaclass (0.0.1)
-    metasploit_data_models (0.15.1)
+    metasploit_data_models (0.15.2)
       activerecord (>= 3.2.13)
       activesupport
       pg
@@ -65,7 +65,7 @@ DEPENDENCIES
   database_cleaner
   factory_girl (>= 4.1.0)
   json
-  metasploit_data_models (~> 0.15.1)
+  metasploit_data_models (~> 0.15.2)
   msgpack
   nokogiri
   pcaprub


### PR DESCRIPTION
This changes does not really affect framework
it is a change for pro functionality
just keeping us inline

Related to https://github.com/rapid7/metasploit_data_models/pull/28
