### PR TITLE
Add OSVDB reference 92867 for Memcached DoS module

### DIFF
--- a/modules/auxiliary/dos/misc/memcached.rb
+++ b/modules/auxiliary/dos/misc/memcached.rb
@@ -21,11 +21,11 @@ class Metasploit3 < Msf::Auxiliary
 				This module send specially-crafted packet causing a
 				segmentation fault in memcached  v1.4.15 or earlier versions.
 			},
-
 			'References' =>
 				[
 					[ 'URL', 'https://code.google.com/p/memcached/issues/detail?id=192' ],
 					[ 'CVE', '2011-4971' ],
+					[ 'OSVDB', '92867' ]
 				],
 			'Author'       => [ 'Gregory Man <man.gregory[at]gmail.com>' ],
 			'License'      => MSF_LICENSE


### PR DESCRIPTION
Missing OSVDB reference 92867.  For wvu.
