### PR TITLE
Undefined variable in tomcat_deploy_mgr.rb

### DIFF
--- a/modules/exploits/multi/http/tomcat_mgr_deploy.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_deploy.rb
@@ -248,9 +248,9 @@ class Metasploit3 < Msf::Exploit::Remote
 			'method'       => 'GET'
 		}, 20)
 		if (! res)
-			print_warning("WARNING: Undeployment failed on #{path} [No Response]")
+			print_warning("WARNING: Undeployment failed on #{path_tmp} [No Response]")
 		elsif (res.code < 200 or res.code >= 300)
-			print_warning("Deletion failed on #{path} [#{res.code} #{res.message}]")
+			print_warning("Deletion failed on #{path_tmp} [#{res.code} #{res.message}]")
 		end
 
 		handler


### PR DESCRIPTION
Exploit failed (multi/http/tomcat_mgr_deploy): NameError undefined
local variable or method `path' for #<Msf...>
[06/04/2013 10:14:03] [d(3)] core: Call stack:
modules/exploits/multi/http/tomcat_mgr_deploy.rb:253:in`exploit'
lib/msf/core/exploit_driver.rb:205:in `job_run_proc'
lib/msf/core/exploit_driver.rb:166:in`run'
lib/msf/base/simple/exploit.rb:136:in `exploit_simple'
lib/msf/base/simple/exploit.rb:161:in`exploit_simple'
lib/msf/ui/console/command_dispatcher/exploit.rb:111:in `cmd_exploit'
lib/rex/ui/text/dispatcher_shell.rb:427:in`run_command'
lib/rex/ui/text/dispatcher_shell.rb:389:in `block in run_single'
lib/rex/ui/text/dispatcher_shell.rb:383:in`each'
lib/rex/ui/text/dispatcher_shell.rb:383:in `run_single'
lib/rex/ui/text/shell.rb:200:in`run'
lib/msf/ui/web/console.rb:71:in `block in initialize'
lib/msf/core/thread_manager.rb:100:in`call'
lib/msf/core/thread_manager.rb:100:in `block in spawn'

Uses path instead of path_tmp in error messages.
