### PR TITLE
[FixRM:#8012] - Fix message data type to int

### DIFF
--- a/modules/exploits/windows/local/trusted_service_path.rb
+++ b/modules/exploits/windows/local/trusted_service_path.rb
@@ -145,7 +145,7 @@ class Metasploit3 < Msf::Exploit::Local
 				tried = true
 			end
 
-			case s.message
+			case s.message.to_i
 			when 1
 				# Service already started, restart again
 				service_stop(svr_name)


### PR DESCRIPTION
This patch makes sure s.message is actually an int, that way we can properly stop or enable the service.

[FixRM:#8012]
