### PR TITLE
Updates js_property_spray documentation

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -924,7 +924,9 @@ protected
 	#
 	# This heap spray technique takes advantage of MSHTML's SetStringProperty (or SetProperty)
 	# function to trigger allocations by ntdll!RtlAllocateHeap.  It is based on Corelan's
-	# publication on "DEPS – Precise Heap Spray on Firefox and IE10".
+	# publication on "DEPS – Precise Heap Spray on Firefox and IE10".  In IE, the shellcode
+	# should land at address 0x0c0d2020, as this is the most consistent location across
+	# various versions.
 	#
 	# The "sprayHeap" JavaScript function supports the following arguments:
 	#   shellcode     => The shellcode to spray in JavaScript.  Note: Avoid null bytes.


### PR DESCRIPTION
After many tests, it turns out address 0x0c0d2020 is the most consistent location acorss various IE versions.  For dev purposes, it's rather important to have this documented somewhere.

Thanks to corelanc0d3r for the data.
