### PR TITLE
Fix ms10_004_textbyteatoms.rb

### DIFF
--- a/modules/exploits/windows/fileformat/ms10_004_textbytesatom.rb
+++ b/modules/exploits/windows/fileformat/ms10_004_textbytesatom.rb
@@ -107,6 +107,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		register_options(
 			[
 				OptString.new('FILENAME', [ true, 'The file name.',  'msf.ppt']),
+				OptString.new('OUTPUTPATH', [ true, 'Path to output the file', Msf::Config.local_directory ])
 			], self.class)
 	end
 
@@ -219,7 +220,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 		# Create the output file
-		out = datastore['FILENAME']
+		out = File.join(datastore['OUTPUTPATH'], datastore['FILENAME'])
 		stg = Rex::OLE::Storage.new(out, Rex::OLE::STGM_WRITE)
 		if (not stg)
 			fail_with(Exploit::Failure::Unknown, 'Unable to create output file')


### PR DESCRIPTION
ms10_004_textbytesatom.rb does not write to the local data directory,
instead it writes to the metasploit path (at least, that's where I
started msfrpcd).

This fixes it by using Msf::Config.local_directory
