### PR TITLE
Remove variable 'overflow' because it's not used

### DIFF
--- a/modules/exploits/windows/browser/aladdin_choosefilepath_bof.rb
+++ b/modules/exploits/windows/browser/aladdin_choosefilepath_bof.rb
@@ -148,7 +148,6 @@ class Metasploit3 < Msf::Exploit::Remote
 		for (var i=1; i < 0x300; i++) {
 			heap_obj.alloc(block);
 		}
-		var overflow = nops.substring(0, 10);
 		|
 
 		js = heaplib(js, {:noobfu => true})

--- a/modules/exploits/windows/browser/crystal_reports_printcontrol.rb
+++ b/modules/exploits/windows/browser/crystal_reports_printcontrol.rb
@@ -157,7 +157,6 @@ class Metasploit3 < Msf::Exploit::Remote
 		for (var i=1; i < 0x300; i++) {
 			heap_obj.alloc(block);
 		}
-		var overflow = nops.substring(0, 10);
 		|
 
 		js = heaplib(js, {:noobfu => true})

--- a/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
+++ b/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
@@ -164,7 +164,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			for (var i=1; i < 0x300; i++) {
 				heap_obj.alloc(block);
 			}
-			var overflow = nops.substring(0, 10);
 			|
 
 		end

--- a/modules/exploits/windows/browser/ibm_spss_c1sizer.rb
+++ b/modules/exploits/windows/browser/ibm_spss_c1sizer.rb
@@ -150,7 +150,6 @@ class Metasploit3 < Msf::Exploit::Remote
 		for (var i=1; i < 0x300; i++) {
 			heap_obj.alloc(block);
 		}
-		var overflow = nops.substring(0, 10);
 		|
 
 		js = heaplib(js, {:noobfu => true})

--- a/modules/exploits/windows/browser/ie_execcommand_uaf.rb
+++ b/modules/exploits/windows/browser/ie_execcommand_uaf.rb
@@ -234,8 +234,6 @@ class Metasploit3 < Msf::Exploit::Remote
 		for (var i=1; i < 0x300; i++) {
 			heap_obj.alloc(block);
 		}
-
-		var overflow = nops.substring(0, 10);
 		JS
 	end
 

--- a/modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb
+++ b/modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb
@@ -174,7 +174,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			for (var i=1; i < 0x300; i++) {
 				heap_obj.alloc(block);
 			}
-			var overflow = nops.substring(0, 10);
 			|
 
 		end

--- a/modules/exploits/windows/browser/inotes_dwa85w_bof.rb
+++ b/modules/exploits/windows/browser/inotes_dwa85w_bof.rb
@@ -179,7 +179,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			for (var i=1; i < 0x300; i++) {
 				heap_obj.alloc(block);
 			}
-			var overflow = nops.substring(0, 10);
 			|
 
 		end

--- a/modules/exploits/windows/browser/ms11_081_option.rb
+++ b/modules/exploits/windows/browser/ms11_081_option.rb
@@ -111,7 +111,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			for (var i=1; i < 0x300; i++) {
 				heap_obj.alloc(block);
 			}
-			var overflow = nops.substring(0, 10);
 		}
 		|
 

--- a/modules/exploits/windows/browser/ms13_009_ie_slayoutrun_uaf.rb
+++ b/modules/exploits/windows/browser/ms13_009_ie_slayoutrun_uaf.rb
@@ -102,8 +102,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			for (var i=1; i < 0x300; i++) {
 				heap_obj.alloc(block);
 			}
-			var overflow = nops.substring(0, 10);
-
 		|
 
 		js = heaplib(js, {:noobfu => true})

--- a/modules/exploits/windows/browser/novell_groupwise_gwcls1_actvx.rb
+++ b/modules/exploits/windows/browser/novell_groupwise_gwcls1_actvx.rb
@@ -174,7 +174,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			for (var i=1; i < 0x300; i++) {
 				heap_obj.alloc(block);
 			}
-			var overflow = nops.substring(0, 10);
 			|
 
 		end

--- a/modules/exploits/windows/browser/quickr_qp2_bof.rb
+++ b/modules/exploits/windows/browser/quickr_qp2_bof.rb
@@ -177,7 +177,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			for (var i=1; i < 0x300; i++) {
 				heap_obj.alloc(block);
 			}
-			var overflow = nops.substring(0, 10);
 			|
 
 		end


### PR DESCRIPTION
The 'overflow' variable isn't needed.  This is just what happens when we copy and paste code.
