### PR TITLE
Update firefox svg exploit description to be more accurate.

### DIFF
--- a/modules/exploits/multi/browser/firefox_svg_plugin.rb
+++ b/modules/exploits/multi/browser/firefox_svg_plugin.rb
@@ -17,8 +17,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		super(update_info(info,
 			'Name'           => 'Firefox 17.0.1 Flash Privileged Code Injection',
 			'Description'    => %q{
-				This exploit gains remote code execution on Firefox 17.0.1 and all previous
-				versions, provided the user has installed Flash. No memory corruption is used.
+				This exploit gains remote code execution on Firefox 17 and 17.0.1, provided
+				the user has installed Flash. No memory corruption is used.
 
 				First, a Flash object is cloned into the anonymous content of the SVG
 				"use" element in the <body> (CVE-2013-0758). From there, the Flash object


### PR DESCRIPTION
As pointed out in this community thread: https://community.rapid7.com/message/8912#8912

The method I am using to inject into the chrome frame fails on FF < 17, will need to take a look at alternative uxss injection exploits in ff.
