### PR TITLE
Add a more readable #inspect

### DIFF
--- a/lib/rex/proto/http/server.rb
+++ b/lib/rex/proto/http/server.rb
@@ -113,6 +113,14 @@ class Server
 		self.server_name = DefaultServer
 	end
 
+	# More readable inspect that only shows the url and resources
+	# @return [String]
+	def inspect
+		resources_str = resources.keys.map{|r| r.inspect }.join ", "
+
+		"#<#{self.class} http#{ssl ? "s" : ""}://#{listen_host}:#{listen_port} [ #{resources_str} ]>"
+	end
+
 	#
 	# Returns the hardcore alias for the HTTP service
 	#


### PR DESCRIPTION
Before this change, it's a huge text dump because it shows all sorts of stuff including the datastore and instance vars of the associated module.

```
15:06:37 0 0 exploit(java_signed_applet) > exploit
[*] Exploit running as background job.
15:06:39 1 0 exploit(java_signed_applet) >
[*] Started reverse handler on 0.0.0.0:4444
[*] Using URL: http://0.0.0.0:8080/
[*]  Local IP: http://10.6.0.86:8080/
[*] Server started.

15:06:40 1 0 exploit(java_signed_applet) > irb
[*] Starting IRB shell...

Loaded ~/.irbrc
>> framework.jobs.values.first.ctx.first.send :service
=> #<Rex::Proto::Http::Server http://0.0.0.0:8080 [ "/" ]>
```

Now it's nice and pretty.
