### PR TITLE
Make the conditional correct for print_prefix

### DIFF
--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -179,9 +179,8 @@ class Module
 	#
 
 	def print_prefix
-		if framework && (
-			datastore['TimestampOutput'] =~ /^(t|y|1)/i or
-			framework.datastore['TimestampOutput'] =~ /^(t|y|1)/i
+		if (datastore['TimestampOutput'] =~ /^(t|y|1)/i) || (
+			framework && framework.datastore['TimestampOutput'] =~ /^(t|y|1)/i
 		)
 			prefix = "[#{Time.now.strftime("%Y.%m.%d-%H:%M:%S")}] "
 


### PR DESCRIPTION
Fixes a bug introduced on #1936.

Incidentally, converts from `&&` and `or` to `&&` and `||`

thx @jlee-r7 for spotting
