### PR TITLE
Restore file_create

### DIFF
--- a/lib/msf/core/exploit/fileformat.rb
+++ b/lib/msf/core/exploit/fileformat.rb
@@ -30,8 +30,8 @@ module Exploit::FILEFORMAT
 		datastore['FILENAME']
 	end
 
-	def file_create(data, filename = nil)
-		fname = filename || file_format_filename
+	def file_create(data)
+		fname = file_format_filename
 		ltype = "exploit.fileformat.#{self.shortname}"
 		full_path = store_local(ltype, nil, data, fname)
 		print_good "#{fname} stored at #{full_path}"

--- a/modules/exploits/windows/fileformat/ultraiso_ccd.rb
+++ b/modules/exploits/windows/fileformat/ultraiso_ccd.rb
@@ -206,7 +206,18 @@ class Metasploit3 < Msf::Exploit::Remote
 		sploit << idx_line
 
 		file_create(sploit)
-		file_create('', datastore['FILENAME'].gsub(/\.ccd$/, '.img'))
+
+		# This extends the current class, and changes the file_format_name.
+		# This allows us to use the file_create(data) to store the created 
+		# file in the correct directory.
+
+		class << self
+			def file_format_filename
+				datastore['FILENAME'].gsub(/\.ccd$/, '.img')
+			end
+		end
+
+		file_create('')
 	end
 
 end

--- a/modules/exploits/windows/fileformat/ultraiso_cue.rb
+++ b/modules/exploits/windows/fileformat/ultraiso_cue.rb
@@ -111,9 +111,18 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		print_status("Creating '#{datastore['FILENAME']}' using target '#{target.name}' ...")
 		file_create(cue_data)
-		file_create('', datastore['FILENAME'].gsub(/\.cue$/, '.bin'))
 
+		# This extends the current class, and changes the file_format_name.
+		# This allows us to use the file_create(data) to store the created 
+		# file in the correct directory.
 
+		class << self
+			def file_format_filename
+				datastore['FILENAME'].gsub(/\.cue$/, '.bin')
+			end
+		end
+
+		file_create('')
 	end
 
 end


### PR DESCRIPTION
file_create shouldn't have the 'filename' argument, because that defeats the purpose of function 'file_format_filename'.  The code change was committed by accident.  Related to #1934.
