### PR TITLE
adobe_flash_sps.rb - resource_uri vs get_resource

### DIFF
--- a/modules/exploits/windows/browser/adobe_flash_sps.rb
+++ b/modules/exploits/windows/browser/adobe_flash_sps.rb
@@ -108,8 +108,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		# Redirect to a trailing slash so relative paths work properly
-		if resource_uri != "/" and not request.uri.index("#{resource_uri}/")
-			uri = resource_uri + "/"
+		if get_resource != "/" and not request.uri.index("#{get_resource}/")
+			uri = get_resource + "/"
 			send_redirect(cli, uri)
 			return
 		end


### PR DESCRIPTION
resource_uri will randomize the returned uri unless
datastore['URIPATH"] is set.

get_resource will return the currently used resource_uri

Since the incorrect type is used, this exploit is completely broken.

Tested fix with both URIPATH set to / and unset, and it works after
redirect.

From debugging this issue:

[_] adobe_flash_sps - on_request_uri, request.uri = /HWshQGYxY
, resource_uri = /LiepLh
[_] adobe_flash_sps - on_request_uri, request.uri = /HWshQGYxY
, resource_uri = /M5gB1pfRGKVjIk
[*] adobe_flash_sps - on_request_uri, request.uri = /HWshQGYxY
, resource_uri = /h4CxozFHkLrf2
