### PR TITLE
mozilla_mchannel.rb undefined agent variable

### DIFF
--- a/modules/exploits/windows/browser/mozilla_mchannel.rb
+++ b/modules/exploits/windows/browser/mozilla_mchannel.rb
@@ -110,10 +110,11 @@ class Metasploit3 < Msf::Exploit::Remote
 		js_ppppr             = rand_text_alpha(rand(10) + 5)
 		js_filler            = rand_text_alpha(rand(10) + 5)
 
+		agent = request.headers['User-Agent']
+
 		# Set target manually or automatically
 		my_target = target
 		if my_target.name == 'Automatic'
-		agent = request.headers['User-Agent']
 			if agent =~ /NT 5\.1/ and agent =~ /Firefox\/3\.6\.16/
 				my_target = targets[1]
 			elsif agent =~ /NT 6\.1/ and agent =~ /Firefox\/3\.6\.16/


### PR DESCRIPTION
If the TARGET is chosen instead of using the default
automatic, the agent variable will be undefined, which
causes the exploit to fail.
