### PR TITLE
mozilla_reduceright.rb - fix regex error.

### DIFF
--- a/modules/exploits/windows/browser/mozilla_reduceright.rb
+++ b/modules/exploits/windows/browser/mozilla_reduceright.rb
@@ -88,7 +88,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def on_request_uri(cli, request)
 		agent = request.headers['User-Agent']
-		if agent !~ /Firefox\/3\.6\.[16|17]/
+		if agent !~ /Firefox\/3\.6\.(16|17)/
 			print_error("This browser is not supported: #{agent.to_s}")
 			send_not_found(cli)
 			return


### PR DESCRIPTION
[] is character class, and will match on 1, 6, 7, and |.
Where as (16|17) will match on either 16, or 17.

irb(main):053:0> y = /Firefox\/3.6.[16|17]/
=> /Firefox\/3.6.[16|17]/
irb(main):054:0> x = "Firefox/3.6.13"
=> "Firefox/3.6.13"
irb(main):055:0> x =~ y
=> 0
irb(main):056:0> y = /Firefox\/3.6.(16|17)/
=> /Firefox\/3.6.(16|17)/
irb(main):057:0> x =~ y
=> nil
