### PR TITLE
maxthon_history_xcs.rb - fix User-agent string

### DIFF
--- a/modules/exploits/windows/browser/maxthon_history_xcs.rb
+++ b/modules/exploits/windows/browser/maxthon_history_xcs.rb
@@ -51,8 +51,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def on_request_uri(cli, request)
-		if request.headers['User-agent'] !~ /Maxthon\/3/ or request.headers['User-agent'] !~ /AppleWebKit\/534.12/
-			print_status("Sending 404 for User-Agent #{request.headers['User-agent']}")
+		if request.headers['User-Agent'] !~ /Maxthon\/3/ or request.headers['User-Agent'] !~ /AppleWebKit\/534.12/
+			print_status("Sending 404 for User-Agent #{request.headers['User-Agent']}")
 			send_not_found(cli)
 			return
 		end


### PR DESCRIPTION
request.headers['User-agent'] is incorrect, it should be
request.headers['User-Agent'].

Downloaded following version from oldapps.com to confirm
the exploit code is wrong.

Supported Systems Windows 98, 2000 (Maxthon 2.5.15 Build
  1000), XP, Vista, 7, 8
MD5 Checksum F3791637C886A46940876211209F82F4
SHA1 Checksum 039BB218245E5DC1BAB0F57298C68AC487F86323

Release Date 20 October, 2011 (2 years ago )
