### PR TITLE
Enable rhost/rport option overrides in HttpClient

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -149,8 +149,8 @@ module Exploit::Remote::HttpClient
 		client_password = opts['password'] || datastore['PASSWORD'] || ''
 
 		nclient = Rex::Proto::Http::Client.new(
-			rhost,
-			rport.to_i,
+			opts['rhost'] || rhost,
+			(opts['rport'] || rport).to_i,
 			{
 				'Msf'        => framework,
 				'MsfExploit' => self,


### PR DESCRIPTION
This allows callers of the HttpClient mixin to use other mixins too, as well as send HTTP requests on multiple ports within a single module. 
