### PR TITLE
Skip also max-age from cookies

### DIFF
--- a/lib/rex/proto/http/response.rb
+++ b/lib/rex/proto/http/response.rb
@@ -73,6 +73,7 @@ class Response < Packet
 				next if name == 'path'
 				next if name == 'expires'
 				next if name == 'domain'
+				next if name == 'max-age'
 				cookies << "#{k}=#{v}; "
 			end
 		end


### PR DESCRIPTION
Since it's skipping expires I guess max-age should be skipped too. Noticed while developing a module for an application which uses the Max-Age field. Trying to use get_cookies in this situation requires this patch. 
