### PR TITLE
[FixRM:#4704] - Fix EOFError in filezilla_server_port

### DIFF
--- a/modules/auxiliary/dos/windows/ftp/filezilla_server_port.rb
+++ b/modules/auxiliary/dos/windows/ftp/filezilla_server_port.rb
@@ -35,7 +35,17 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def run
-		connect_login
+		begin
+			c = connect_login
+		rescue Rex::ConnectionRefused
+			print_error("Connection refused.")
+			return
+		rescue Rex::ConnectionTimeout
+			print_error("Connection timed out")
+			return
+		end
+
+		return if not c
 
 		send_cmd(['PASV', 'A*'], true) # Assigns PASV port
 		send_cmd(['PORT', 'A*'], true) # Rejected but seems to assign NULL to pointer


### PR DESCRIPTION
If login fails, the module shouldn't continue sending commands to the server, otherwise this causes an EOF.
