### PR TITLE
Handle connect_login return value properly

### DIFF
--- a/modules/auxiliary/scanner/ftp/titanftp_xcrc_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/titanftp_xcrc_traversal.rb
@@ -54,7 +54,8 @@ class Metasploit3 < Msf::Auxiliary
 
 	def run_host(ip)
 
-		connect_login
+		c = connect_login
+		return if not c
 
 		path = datastore['TRAVERSAL'] + datastore['PATH']
 

--- a/modules/exploits/windows/ftp/ability_server_stor.rb
+++ b/modules/exploits/windows/ftp/ability_server_stor.rb
@@ -91,7 +91,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		connect_login
+		c = connect_login
+		return if not c
 
 		myhost = datastore['LHOST'] == '0.0.0.0' ? Rex::Socket.source_address : datastore['LHOST']
 

--- a/modules/exploits/windows/ftp/cesarftp_mkd.rb
+++ b/modules/exploits/windows/ftp/cesarftp_mkd.rb
@@ -70,7 +70,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		connect_login
+		c = connect_login
+		return if not c
 
 		sploit =  "\n" * 671 + rand_text_english(3, payload_badchars)
 		sploit << [target.ret].pack('V') + make_nops(40) + payload.encoded

--- a/modules/exploits/windows/ftp/filecopa_list_overflow.rb
+++ b/modules/exploits/windows/ftp/filecopa_list_overflow.rb
@@ -47,7 +47,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def exploit
-		connect_login
+		c = connect_login
+		return if not c
 
 		print_status("Trying target #{target.name}...")
 

--- a/modules/exploits/windows/ftp/globalscapeftp_input.rb
+++ b/modules/exploits/windows/ftp/globalscapeftp_input.rb
@@ -51,7 +51,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		connect_login
+		c = connect_login
+		return if not c
 
 		buf           = make_nops(3047)
 		buf[2043, 4]  = [ target.ret ].pack('V')

--- a/modules/exploits/windows/ftp/httpdx_tolog_format.rb
+++ b/modules/exploits/windows/ftp/httpdx_tolog_format.rb
@@ -173,7 +173,8 @@ For now, that will have to be done manually.
 		end
 
 		# proceed with chosen target...
-		connect_login
+		c = connect_login
+		return if not c
 
 		# '<ip>\n PWD '
 		ip_length = Rex::Socket.source_address(datastore['RHOST']).length

--- a/modules/exploits/windows/ftp/oracle9i_xdb_ftp_unlock.rb
+++ b/modules/exploits/windows/ftp/oracle9i_xdb_ftp_unlock.rb
@@ -76,7 +76,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		connect_login
+		c = connect_login
+		return if not c
 
 		print_status("Trying target #{target.name}...")
 

--- a/modules/exploits/windows/ftp/servu_chmod.rb
+++ b/modules/exploits/windows/ftp/servu_chmod.rb
@@ -67,7 +67,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def exploit
-		connect_login
+		c = connect_login
+		return if not c
 
 		eggoptions =
 		{

--- a/modules/exploits/windows/ftp/servu_mdtm.rb
+++ b/modules/exploits/windows/ftp/servu_mdtm.rb
@@ -129,8 +129,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-
-		connect_login
+		c = connect_login
+		return if not c
 
 		print_status("Trying target #{target.name}...")
 

--- a/modules/exploits/windows/ftp/slimftpd_list_concat.rb
+++ b/modules/exploits/windows/ftp/slimftpd_list_concat.rb
@@ -53,6 +53,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def exploit
 		connect_login
+		c = connect_login
+		return if not c
 
 		print_status("Trying target #{target.name}...")
 

--- a/modules/exploits/windows/ftp/slimftpd_list_concat.rb
+++ b/modules/exploits/windows/ftp/slimftpd_list_concat.rb
@@ -52,7 +52,6 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		connect_login
 		c = connect_login
 		return if not c
 

--- a/modules/exploits/windows/ftp/turboftp_port.rb
+++ b/modules/exploits/windows/ftp/turboftp_port.rb
@@ -145,7 +145,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		print_status("Selected Target: #{my_target.name}")
-		connect_login
+		c = connect_login
+		return if not c
 
 		rop_chain = create_rop_chain(target['ver'])
 		rop = rop_chain.unpack('C*').join(',')

--- a/modules/exploits/windows/ftp/wftpd_size.rb
+++ b/modules/exploits/windows/ftp/wftpd_size.rb
@@ -50,7 +50,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		connect_login
+		c = connect_login
+		return if not c
 
 		sploit =  "/" + make_nops(525 - payload.encoded.length)
 		sploit << payload.encoded + [target.ret].pack('V')

--- a/modules/exploits/windows/ftp/wsftp_server_503_mkd.rb
+++ b/modules/exploits/windows/ftp/wsftp_server_503_mkd.rb
@@ -62,7 +62,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		connect_login
+		c = connect_login
+		return if not c
 
 		print_status("Trying target #{target.name}...")
 

--- a/modules/exploits/windows/ftp/wsftp_server_505_xmd5.rb
+++ b/modules/exploits/windows/ftp/wsftp_server_505_xmd5.rb
@@ -56,7 +56,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		connect_login
+		c = connect_login
+		return if not c
 
 		print_status("Trying target #{target.name}...")
 


### PR DESCRIPTION
Some modules ignore connect_login's return value, which may result an EOF if send_cmd() is used later on.  All the modules fixed are the ones require auth according to the module description, or CVE/vendor/OSVDB info.
