### PR TITLE
Update on the usage of sleep()

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -37,9 +37,10 @@ need user input, you can either register an option or expose an
 interactive session type specific for the type of exploit.
 
 3. Don't use "sleep". It has been known to cause issues with
-multi-threaded programs on various platforms. Instead, we use
-"select(nil, nil, nil, <time>)" throughout the framework. We have
-found this works around the underlying issue.
+multi-threaded programs on various platforms running an older version of
+Ruby such as 1.8. Instead, we use "select(nil, nil, nil, <time>)" or
+Rex::sleep() throughout the framework. We have found this works around
+the underlying issue.
 
 4. Always use Rex sockets, not ruby sockets.  This includes
 third-party libraries such as Net::Http.  There are several very good

--- a/HACKING
+++ b/HACKING
@@ -39,7 +39,7 @@ interactive session type specific for the type of exploit.
 3. Don't use "sleep". It has been known to cause issues with
 multi-threaded programs on various platforms running an older version of
 Ruby such as 1.8. Instead, we use "select(nil, nil, nil, <time>)" or
-Rex::sleep() throughout the framework. We have found this works around
+Rex.sleep() throughout the framework. We have found this works around
 the underlying issue.
 
 4. Always use Rex sockets, not ruby sockets.  This includes


### PR DESCRIPTION
sleep() used to cause issues on an older version of Ruby. This is no longer the case since 1.9, and we also actually have Rex::sleep() that's just a wrapper for select().  We should mention all this in HACKING.
