### PR TITLE
Fix module init failure due to missing require

### DIFF
--- a/modules/exploits/unix/webapp/havalite_upload_exec.rb
+++ b/modules/exploits/unix/webapp/havalite_upload_exec.rb
@@ -6,6 +6,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/php_exe'
 
 class Metasploit3 < Msf::Exploit::Remote
 	Rank = ExcellentRanking


### PR DESCRIPTION
```
[06/19/2013 15:56:12] [e(0)] core: /path/to/metasploit-framework/modules/exploits/unix/webapp/havalite_upload_exec.rb failed to load due to the following error: 
NameError
uninitialized constant Msf::Exploit::PhpEXE
Call stack:
/path/to/metasploit-framework/modules/exploits/unix/webapp/havalite_upload_exec.rb:14:in `<class:Metasploit3>'
/path/to/metasploit-framework/modules/exploits/unix/webapp/havalite_upload_exec.rb:10:in `module_eval_with_lexical_scope'
/path/to/metasploit-framework/lib/msf/core/modules/loader/base.rb:54:in `module_eval'
/path/to/metasploit-framework/lib/msf/core/modules/loader/base.rb:54:in `module_eval_with_lexical_scope'
/path/to/metasploit-framework/lib/msf/core/modules/loader/base.rb:147:in `block in load_module'
/path/to/metasploit-framework/lib/msf/core/modules/loader/base.rb:544:in `call'
/path/to/metasploit-framework/lib/msf/core/modules/loader/base.rb:544:in `namespace_module_transaction'
/path/to/metasploit-framework/lib/msf/core/modules/loader/base.rb:201:in `load_module'
/path/to/metasploit-framework/lib/msf/core/modules/loader/base.rb:262:in `block in load_modules'
/path/to/metasploit-framework/lib/msf/core/modules/loader/directory.rb:52:in `block (2 levels) in each_module_reference_name'
/path/to/metasploit-framework/lib/rex/file.rb:80:in `block in find'
/path/to/metasploit-framework/lib/rex/file.rb:79:in `catch'
/path/to/metasploit-framework/lib/rex/file.rb:79:in `find'
/path/to/metasploit-framework/lib/msf/core/modules/loader/directory.rb:43:in `block in each_module_reference_name'
/path/to/metasploit-framework/lib/msf/core/modules/loader/directory.rb:27:in `foreach'
/path/to/metasploit-framework/lib/msf/core/modules/loader/directory.rb:27:in `each_module_reference_name'
/path/to/metasploit-framework/lib/msf/core/modules/loader/base.rb:260:in `load_modules'
/path/to/metasploit-framework/lib/msf/core/module_manager/loading.rb:117:in `block in load_modules'
/path/to/metasploit-framework/lib/msf/core/module_manager/loading.rb:115:in `each'
/path/to/metasploit-framework/lib/msf/core/module_manager/loading.rb:115:in `load_modules'
/path/to/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:54:in `block in add_module_path'
/path/to/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:53:in `each'
/path/to/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:53:in `add_module_path'
/path/to/metasploit-framework/lib/msf/base/simple/framework/module_paths.rb:14:in `init_module_paths'
/path/to/metasploit-framework/lib/msf/ui/console/driver.rb:228:in `initialize'
./msfconsole:169:in `new'
./msfconsole:169:in `<main>'
```
