### PR TITLE
Add capability to run multiple commands on one line, also fixes rm7705 msfconsole -x escaping issue

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -259,7 +259,7 @@ class Meterpreter < Rex::Post::Meterpreter::Client
 	# Explicitly runs a command in the meterpreter console.
 	#
 	def run_cmd(cmd)
-		console.run_single(cmd)
+		console.run_multiple(cmd)
 	end
 
 	#

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -251,11 +251,7 @@ class Driver < Msf::Ui::Driver
 		end
 
 		# Process any additional startup commands
-		if opts['XCommands'] and opts['XCommands'].kind_of? Array
-			opts['XCommands'].each { |c|
-				run_single(c)
-			}
-		end
+		run_multiple(opts['XCommands']) if opts['XCommands']
 	end
 
 	#
@@ -474,7 +470,7 @@ class Driver < Msf::Ui::Driver
 				end
 			else
 				print_line("resource (#{path})> #{line}")
-				run_single(line)
+				run_multiple(line)
 			end
 		end
 

--- a/lib/msf/ui/web/console.rb
+++ b/lib/msf/ui/web/console.rb
@@ -88,7 +88,7 @@ class WebConsole
 	end
 
 	def execute(cmd)
-		self.console.run_single(cmd)
+		self.console.run_multiple(cmd)
 	end
 
 	def prompt

--- a/lib/rex/post/meterpreter/ui/console.rb
+++ b/lib/rex/post/meterpreter/ui/console.rb
@@ -58,14 +58,14 @@ class Console
 
 		# Run queued commands
 		commands.delete_if { |ent|
-			run_single(ent)
+			run_multiple(ent)
 			true
 		}
 
 		# Run the interactive loop
 		run { |line|
 			# Run the command
-			run_single(line)
+			run_multiple(line)
 
 			# If a block was supplied, call it, otherwise return false
 			if (block)

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -776,7 +776,7 @@ class Console::CommandDispatcher::Core
 						next if line[0,1] == "#"
 						begin
 							print_status("Running #{line}")
-							client.console.run_single(line)
+							client.console.run_multiple(line)
 						rescue ::Exception => e
 							print_error("Error Running Command #{line}: #{e.class} #{e}")
 						end

--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -367,14 +367,31 @@ module DispatcherShell
 	end
 
 	#
-	# Run multiple commands from one input line of the format cmd1;cmd2;"cmd3 = funky;da;ta;"
-	#  the line is parsed w/the ruby CSV engine using the ';' as the separator instead of ','
-	#  See the builtin ruby CSV parser for more information.
+	# Run multiple commands from one input line
 	#
+	# @see CSV#new Line is parsed with native Ruby CSV parser using ';' as the separator
+	# @note The CSV parser essentially escapes an entire field when it is surrounded by the quote char
+	#   It's very similar to quoting an entire file path if it contains a space vs only escaping the
+	#   space in the file path using a single escape character.  Addtionally Ruby itself requires
+	#   one to escape an unmatched single or double quote and shell requires one to escape commands
+	#   containing spaces which can lead to complex cases depending on the command sep and quoting
+	#   char used, therefore pre-processed +line+ examples are worth providing
+	# 	Msfconsole example, simple case, multiple commands and no escaping required
+	#     set RHOST 1.1.1.1;set LHOST 1.1.1.2
+	#   Msfconsole example, scaping (quoting) one or more instances of the command separator
+	#     "set SMBUser f;oo;bar";"set SMBPass fu;bar";set LPORT 443
+	#   Msfconsole example, escaping (quoting) command sep while Ruby escaping unmatched single quote
+	#     "set SMBPass foo\';bar";set LPORT 443
+	#   Msfconsole example, escaping (quoting) the command separator and the quoting character
+	#     "set SMBPass foo\"";bar";set LPORT 443
+	# 	Shell example, escaping multiline command when one cmd contains the cmd separator
+	#     msfconsole -x 'set SMBUser admin;"set SMBPass foo;bar"'
+	# @see https://gist.github.com/kernelsmith/5822064 for full examples and elaboration
 	# @param line [String] The data to be parsed
-	# @param separator [String] The separator used to delimit the data, defaults to ;
-	# @param quote_char [String] The quoting escape character(1 char only) used to escape +separator+, defaults to "
-	# @return [Boolean] Returns true if all commands succeeded, otherwise false
+	# @param separator [String] The separator used to delimit the data
+	# @param quote_char [String] The quoting escape character (1 char only) used to escape +separator+
+	# @return [true] if all commands succeeded
+	# @return [false] otherwise
 	def run_multiple(line, separator = ';', quote_char = '"')
 		lines = []
 		# handle a multi-command line (lines with cmd;other_cmd)

--- a/lib/rex/ui/text/shell.rb
+++ b/lib/rex/ui/text/shell.rb
@@ -189,7 +189,7 @@ module Shell
 				if (block)
 					break if (line == nil or block.call(line))
 				elsif(input.eof? or line == nil)
-				# If you have sessions active, this will give you a shot to exit gravefully
+				# If you have sessions active, this will give you a shot to exit gracefully
 				# If you really are ambitious, 2 eofs will kick this out
 					self.stop_count += 1
 					next if(self.stop_count > 1)
@@ -197,7 +197,7 @@ module Shell
 				else
 				# Otherwise, call what should be an overriden instance method to
 				# process the line.
-					ret = run_single(line)
+					ret = run_multiple(line)
 					# don't bother saving lines that couldn't be found as a
 					# command, create the file if it doesn't exist
 					if ret and self.histfile
@@ -245,7 +245,7 @@ module Shell
 			end
 
 			if mode
-			  new_prompt = prompt + (new_prompt_char || prompt_char) + ' '
+				new_prompt = prompt + (new_prompt_char || prompt_char) + ' '
 			end
 
 			# Save the prompt before any substitutions

--- a/modules/post/multi/gather/run_console_rc_file.rb
+++ b/modules/post/multi/gather/run_console_rc_file.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Post
 				next if cmd[0,1] == "#"
 				begin
 					print_status "Running command #{cmd.chomp}"
-					session.console.run_single(cmd.chomp)
+					session.console.run_multiple(cmd.chomp)
 				rescue ::Exception => e
 					print_status("Error Running Command #{cmd.chomp}: #{e.class} #{e}")
 				end

--- a/msfconsole
+++ b/msfconsole
@@ -100,7 +100,7 @@ class OptsConsole
 				options['DatabaseMigrationPaths'] ||= []
 				options['DatabaseMigrationPaths'] << m
 			end
-			
+
 			opts.on("-e", "--environment <production|development>", "Specify the database environment to load from the YAML") do |m|
 				options['DatabaseEnv'] = m
 			end
@@ -123,8 +123,7 @@ class OptsConsole
 			end
 
 			opts.on("-x", "-x <command>", "Execute the specified string as console commands (use ; for multiples)") do |s|
-				options['XCommands'] ||= []
-				options['XCommands'] += s.split(/\s*;\s*/)
+				options['XCommands'] = s
 			end
 
 			opts.separator ""


### PR DESCRIPTION
This is a resubmit of #1336 after much discussion on the best way to implement run_multiple, specifically the parsing.  The conclusion was to use the builtin ruby CSV parser but change the separator from ',' to ';'.  Therefore, due to the escaping syntax of the CSV parser, you use a quote char to escape an entire field (ie command in this case).  The default quote char is " (double quotes).  To escape the quote char, you must double it up (so "" in this case).  The methods added support calls which specify there own sep and quote char, but currently there's no way for the user to change them at run time.  This could be solved by making those values advanced or basic options of msfconsole, but this has not been implemented in this PR.

This PR also fixes https://dev.metasploit.com/redmine/issues/7705.  For test results and some example corner case oddities of the syntax, see https://gist.github.com/kernelsmith/5822064

Altho this PR changes 10 files, most of those are just refactors from run_single to run_multiple (tho not all calls to run_single had to be replaced).

To test this PR, apply it and just run various attempts to run multiple commands on a single line and via msfconsole -x.  You can reference some of the stranger examples via the gist link above.  If you run into cases where you don't think the escaping is working correctly, it's probably due to the strange way the CSV parser escapes things.  Reference the commentary above as well as the gist and/or the ruby docs on the CSV parser.
