### PR TITLE
Fix jboss modules wrong local variable

### DIFF
--- a/modules/exploits/multi/http/jboss_bshdeployer.rb
+++ b/modules/exploits/multi/http/jboss_bshdeployer.rb
@@ -426,7 +426,7 @@ EOT
 			arch = $1
 			if (arch =~ /(x86|i386|i686)/i)
 				return ARCH_X86
-			elsif (os =~ /(x86_64|amd64)/i)
+			elsif (arch =~ /(x86_64|amd64)/i)
 				return ARCH_X86
 			end
 		end

--- a/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
+++ b/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
@@ -414,7 +414,7 @@ EOT
 			arch = $1
 			if (arch =~ /(x86|i386|i686)/i)
 				return ARCH_X86
-			elsif (os =~ /(x86_64|amd64)/i)
+			elsif (arch =~ /(x86_64|amd64)/i)
 				return ARCH_X86
 			end
 		end


### PR DESCRIPTION
Someone reported:

```

---

msf  exploit(jboss_deploymentfilerepository) > set RHOST X.X.X.X
RHOST => X.X.X.X
msf  exploit(jboss_deploymentfilerepository) > exploit

[*] Started reverse handler on Y.Y.Y.Y:4444      
[*] Attempting to automatically select a target...
[-] Exploit failed: NameError undefined local variable or method `os' for #<Msf::Modules::Mod6578706c6f69742f6d756c74692f687474702f6a626f73735f6465706c6f796d656e7466696c657265706f7369746f7279::Metasploit3:0xf5ccf10>
msf  exploit(jboss_deploymentfilerepository) >

---

msf  exploit(jboss_bshdeployer) > set RHOST X.X.X.X
RHOST => X.X.X.X
msf  exploit(jboss_bshdeployer) > exploit

[*] Started reverse handler on Y.Y.Y.Y:4444      
[*] Attempting to automatically select a target...
[-] Exploit failed: NameError undefined local variable or method `os' for #<Msf::Modules::Mod6578706c6f69742f6d756c74692f687474702f6a626f73735f6273686465706c6f796572::Metasploit3:0xe25b170>
msf  exploit(jboss_bshdeployer) > search jboss

---
```

This patch tries to fix the errors. Updating the pull request with testing results in a while.
