### PR TITLE
Added error handling to msfvenom when generating payloads

### DIFF
--- a/msfvenom
+++ b/msfvenom
@@ -295,11 +295,6 @@ if opts[:payload]
 			print_error("Invalid payload: #{opts[:payload]}")
 			exit
 		end
-		if opts[:list_options]
-			print_status("Options for #{payload.fullname}\n\n" +
-				::Msf::Serializer::ReadableText.dump_options(payload,'    '))
-			exit
-		end
 		payload.datastore.merge! datastore
 	end
 end
@@ -339,9 +334,15 @@ else
 	encoders = get_encoders(opts[:arch], opts[:encoder])
 end
 
+if opts[:list_options]
+    print_status("Options for #{payload.fullname}\n\n" +
+        ::Msf::Serializer::ReadableText.dump_options(payload,'    '))
+    exit
+end
+
 if payload_raw.nil? or payload_raw.empty?
 	begin
-        payload_raw = payload.generate_simple(
+		payload_raw = payload.generate_simple(
 				'Format'        => fmt,
 				'Options'       => datastore,
 				'Encoder'       => nil)

--- a/msfvenom
+++ b/msfvenom
@@ -340,10 +340,15 @@ else
 end
 
 if payload_raw.nil? or payload_raw.empty?
-	payload_raw = payload.generate_simple(
+	begin
+        payload_raw = payload.generate_simple(
 				'Format'        => fmt,
 				'Options'       => datastore,
 				'Encoder'       => nil)
+	rescue
+		$stderr.puts "Error generating payload: #{$!}"
+		exit
+	end
 end
 
 if opts[:template]

--- a/msfvenom
+++ b/msfvenom
@@ -335,8 +335,7 @@ else
 end
 
 if opts[:list_options]
-    print_status("Options for #{payload.fullname}\n\n" +
-        ::Msf::Serializer::ReadableText.dump_options(payload,'    '))
+    puts Msf::Serializer::ReadableText.dump_module(payload)
     exit
 end
 

--- a/msfvenom
+++ b/msfvenom
@@ -48,7 +48,7 @@ def parse_args
 		opts[:nopsled] = n.to_i
 	end
 
-	opt.on('-f', '--format     [format]', String, "Output format (use --help-formats for a list)") do |f|
+	opt.on('-f', '--format     [format]', String, 'Output format (use --help-formats for a list)') do |f|
 		opts[:format] = f
 	end
 
@@ -69,19 +69,19 @@ def parse_args
 		opts[:space] = s
 	end
 
-	opt.on('-b', '--bad-chars  [list] ', String, 'The list of characters to avoid example: \'\x00\xff\'') do |b|
+	opt.on('-b', '--bad-chars  [list]', String, 'The list of characters to avoid example: \'\x00\xff\'') do |b|
 		opts[:badchars] = b
 	end
 
-	opt.on('-i', '--iterations [count] ', Integer, 'The number of times to encode the payload') do |i|
+	opt.on('-i', '--iterations [count]', Integer, 'The number of times to encode the payload') do |i|
 		opts[:iterations] = i
 	end
 
-	opt.on('-c', '--add-code   [path] ', String, 'Specify an additional win32 shellcode file to include') do |x|
+	opt.on('-c', '--add-code   [path]', String, 'Specify an additional win32 shellcode file to include') do |x|
 		opts[:addshellcode] = x
 	end
 
-	opt.on('-x', '--template   [path] ', String, 'Specify a custom executable file to use as a template') do |x|
+	opt.on('-x', '--template   [path]', String, 'Specify a custom executable file to use as a template') do |x|
 		opts[:template] = x
 		unless File.exist?(x)
 			$stderr.puts "Template file (#{x}) does not exist"
@@ -93,7 +93,7 @@ def parse_args
 		opts[:inject] = true
 	end
 
-	opt.on('-o', '--options', "List the payload's standard options") do
+	opt.on('-o', '--options', 'List the payload\'s standard options') do
 		opts[:list_options] = true
 	end
 
@@ -102,7 +102,7 @@ def parse_args
 		exit(1)
 	end
 
-	opt.on_tail('--help-formats', String, "List available formats") do
+	opt.on_tail('--help-formats', String, 'List available formats') do
 		require 'rex'
 		require 'msf/ui'
 		require 'msf/base'

--- a/msfvenom
+++ b/msfvenom
@@ -128,7 +128,7 @@ def parse_args
 	if args
 		args.each do |x|
 			k,v = x.split('=', 2)
-			datastore[k] = v.to_s
+			datastore[k.upcase] = v.to_s
 		end
 	end
 
@@ -298,7 +298,6 @@ if opts[:payload]
 		payload.datastore.merge! datastore
 	end
 end
-
 
 # Normalize the options
 opts[:platform] = Msf::Module::PlatformList.transform(opts[:platform]) if opts[:platform]


### PR DESCRIPTION
### Added error handling to msfvenom when generating payloads

_Ugly error messages_

```
root@kali ~/metasploit-framework$ ./msfvenom -p windows/meterpreter/reverse_tcp                                                                                                          1 ↵ master
/root/metasploit-framework/lib/msf/core/module.rb:620:in `validate': The following options failed to validate: LHOST. (Msf::OptionValidateError)
     from /root/metasploit-framework/lib/msf/core/encoded_payload.rb:65:in `generate'
     from /root/metasploit-framework/lib/msf/core/encoded_payload.rb:25:in `create'
     from /root/metasploit-framework/lib/msf/base/simple/payload.rb:53:in `generate_simple'
     from /root/metasploit-framework/lib/msf/base/simple/payload.rb:137:in `generate_simple'
     from ./msfvenom:343:in `<main>'

root@kali ~/metasploit-framework$   
```
### Fixed msfvenom when displaying options

_Doesn't display information regarding command line arguments_

```
root@kali ~/metasploit-framework$ ./msfvenom -p windows/meterpreter/reverse_tcp LHOST=127.0.0.1 LPORT=4321 -o                                                                                                        ✹master
[*] Options for payload/windows/meterpreter/reverse_tcp

    Name      Current Setting  Required  Description
    ----      ---------------  --------  -----------
    EXITFUNC  process          yes       Exit technique: seh, thread, process, none
    LHOST                      yes       The listen address
    LPORT     4444             yes       The listen port
root@kali ~/metasploit-framework$               
```
### Altered msfvenom options to match msfpayload summary

_Wasn't displaying as much information_

```
root@kali ~/metasploit-framework$ ./msfvenom -p windows/meterpreter/reverse_tcp LHOST=127.0.0.1 LPORT=4321 -o                                                                             ✹master

       Name: Windows Meterpreter (Reflective Injection), Reverse TCP Stager
     Module: payload/windows/meterpreter/reverse_tcp
    Version: $Revision$
   Platform: Windows
       Arch: x86
Needs Admin: No
 Total size: 290
       Rank: Normal

Provided by:
  skape <mmiller@hick.org>
  sf <stephen_fewer@harmonysecurity.com>
  hdm <hdm@metasploit.com>

Basic options:
Name      Current Setting  Required  Description
----      ---------------  --------  -----------
EXITFUNC  process          yes       Exit technique: seh, thread, process, none
LHOST     127.0.0.1        yes       The listen address
LPORT     4321             yes       The listen port

Description:
  Connect back to the attacker, Inject the meterpreter server DLL via
  the Reflective Dll Injection payload (staged)


root@kali ~/metasploit-framework$
```
### Arguments are not case sensitive

_Lower/mixed case wouldn't work_

```
root@kali ~/metasploit-framework$ ./msfvenom -p windows/meterpreter/reverse_tcp LHOST=127.0.0.1 lport=4321 -o
---snip---
Basic options:
Name      Current Setting  Required  Description
----      ---------------  --------  -----------
EXITFUNC  process          yes       Exit technique: seh, thread, process, none
LHOST     127.0.0.1        yes       The listen address
LPORT     4444             yes       The listen port
---snip---
root@kali ~/metasploit-framework$
```
