### PR TITLE
Fix for importing OpenVAS XML reports

### DIFF
--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -2975,7 +2975,7 @@ class DBManager
 		elsif (firstline.index("<get_reports_response status=\"200\" status_text=\"OK\">"))
 			@import_filedata[:type] = "OpenVAS XML"
 			return :openvas_new_xml
-		elsif (firstline.index("<report id=\""))
+		elsif (firstline.index("<report id=\"") or firstline.index("<report id=\'"))
 			@import_filedata[:type] = "OpenVAS XML"
 			return :openvas_new_xml
 		elsif (firstline.index("<NessusClientData>"))

--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -2893,7 +2893,7 @@ class DBManager
 		elsif (firstline.index("<get_reports_response status=\"200\" status_text=\"OK\">"))
 			@import_filedata[:type] = "OpenVAS XML"
 			return :openvas_new_xml
-		elsif (firstline.index("<report id=\""))
+		elsif (firstline.index("<report id=\"") or firstline.index("<report id=\'"))
 			@import_filedata[:type] = "OpenVAS XML"
 			return :openvas_new_xml
 		elsif (firstline.index("<NessusClientData>"))


### PR DESCRIPTION
In OpenVAS 5 the XML format was changed to use single quotes around some
of the attributes, which caused the db_import to fail. Tod modified db.rb to
recognize the single quotes as well as the double quotes. I tested the fix and
it works.
