### PR TITLE
Updates module description, and uses the proper func for hex dump

### DIFF
--- a/modules/post/windows/gather/memory_grep.rb
+++ b/modules/post/windows/gather/memory_grep.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Post
 		regex = Regexp.new(datastore['REGEX'])
 		target_pid = client.sys.process[name]
 
-		if not target_pid
+		unless target_pid
 			print_error("Could not access the target process")
 			return
 		end

--- a/modules/post/windows/gather/memory_grep.rb
+++ b/modules/post/windows/gather/memory_grep.rb
@@ -116,8 +116,8 @@ class Metasploit3 < Msf::Post
 			if idx != nil
 				print_status("Match found!")
 				print_line
-				data = mem['Data'][idx, 512], mem['Address']+idx
-				print_line(Rex::Text.to_hex_dump(data[0]))
+				data = mem['Data'][idx, 512]
+				print_line(Rex::Text.to_hex_dump(data))
 			end
 		end
 
@@ -127,8 +127,8 @@ class Metasploit3 < Msf::Post
 			if idx != nil
 				print_status("Match found")
 				print_line
-				data = mem['Data'][idx, 512], mem['Address']+idx
-				print_line(Rex::Text.to_hex_dump(data[0]))
+				data = mem['Data'][idx, 512]
+				print_line(Rex::Text.to_hex_dump(data))
 			end
 		end
 	end


### PR DESCRIPTION
As an user, it's important to know that using this module may result a lost session because it must migrate to grep memory, but does not migrate back.

The module also has its own hex dump routine, which is no longer needed because we have a built-in Rex::Text.to_hex_dump.
