### PR TITLE
Allow "base" argument for to_hex_dump

### DIFF
--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -752,7 +752,8 @@ module Text
 	#
 	# @param str [String] The string to convert
 	# @param width [Fixnum] Number of bytes to convert before adding a newline
-	def self.to_hex_dump(str, width=16)
+	# @param base [Fixnum] The base address of the dump
+	def self.to_hex_dump(str, width=16, base=0)
 		buf = ''
 		idx = 0
 		cnt = 0
@@ -762,8 +763,9 @@ module Text
 		while (idx < str.length)
 
 			chunk = str[idx, width]
+			addr = (base == 0) ? '' : "%08x  " %(base + idx)
 			line  = chunk.unpack("H*")[0].scan(/../).join(" ")
-			buf << line
+			buf << addr + line 
 
 			if (lst == 0)
 				lst = line.length
@@ -771,6 +773,8 @@ module Text
 			else
 				buf << " " * ((lst - line.length) + 4).abs
 			end
+
+			buf << "|"
 
 			chunk.unpack("C*").each do |c|
 				if (c >	0x1f and c < 0x7f)
@@ -780,7 +784,7 @@ module Text
 				end
 			end
 
-			buf << "\n"
+			buf << "|\n"
 
 			idx += width
 		end

--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -753,19 +753,20 @@ module Text
 	# @param str [String] The string to convert
 	# @param width [Fixnum] Number of bytes to convert before adding a newline
 	# @param base [Fixnum] The base address of the dump
-	def self.to_hex_dump(str, width=16, base=0)
+	def self.to_hex_dump(str, width=16, base=nil)
 		buf = ''
 		idx = 0
 		cnt = 0
 		snl = false
 		lst = 0
+		lft_col_len = (base.to_i+str.length).to_s(16).length
+		lft_col_len = 8 if lft_col_len < 8
 
 		while (idx < str.length)
-
 			chunk = str[idx, width]
-			addr = (base == 0) ? '' : "%08x  " %(base + idx)
+			addr = base ? "%0#{lft_col_len}x  " %(base.to_i + idx) : ''
 			line  = chunk.unpack("H*")[0].scan(/../).join(" ")
-			buf << addr + line 
+			buf << addr + line
 
 			if (lst == 0)
 				lst = line.length


### PR DESCRIPTION
[SeeRM:#8121] - For debugging purposes, it's useful to be able to specify a base.

I also changed the output format a little to make it look more like the command "hexdump -C".  Here's an example of basic usage.

```
>> puts Rex::Text.to_hex_dump(Rex::Text.rand_text(20))
c3 66 bb a7 11 2d 9b 10 b3 97 e0 50 95 51 2d 3c    |.f...-.....P.Q-<|
8a bc 09 71                                        |...q|
```

Here's an example of specifying the base:

```
>> puts Rex::Text.to_hex_dump(Rex::Text.rand_text(50), 16, 0x00140000)
00140000  b8 d5 1c a6 22 76 2e 78 f2 d6 f7 d5 ec 98 b0 4d    |...."v.x.......M|
00140010  6a db 78 03 51 7a 51 87 f1 eb 05 23 41 73 de d4    |j.x.QzQ....#As..|
00140020  23 79 ae c5 fe ca 6b 5c 6f dd 26 0a 85 18 01 b5    |#y....k\o.&.....|
00140030  e5 19                                              |..|
```

Note: The base argument is placed 3rd, because this maintains the original usage.
