### PR TITLE
Ipmi verbosity

### DIFF
--- a/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Auxiliary
 		@res[shost] ||= info
 
 		if info.error_code == 0
-			print_good("#{shost}:#{sport} VULNERABLE: Accepted a session open request for cipher zero")
+			print_good("#{shost}:#{sport} - IPMI - VULNERABLE: Accepted a session open request for cipher zero")
 			report_vuln(
 				:host  => shost,
 				:port  => datastore['RPORT'].to_i,
@@ -77,7 +77,7 @@ class Metasploit3 < Msf::Auxiliary
 				:refs  => self.references
 			)
 		else
-			vprint_status("#{shost}:#{sport} NOT VULNERABLE: Rejected cipher zero with error code #{info.error_code}")
+			vprint_status("#{shost}:#{sport} - IPMI - NOT VULNERABLE: Rejected cipher zero with error code #{info.error_code}")
 		end
 	end
 end

--- a/modules/auxiliary/scanner/ipmi/ipmi_version.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_version.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Auxiliary
 
 		banner = info.to_banner
 
-		print_status("#{shost}:#{rport} #{banner}")
+		print_good("#{shost}:#{rport} - IPMI - #{banner}")
 
 		report_service(
 			:host  => shost,

--- a/modules/auxiliary/scanner/ipmi/ipmi_version.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_version.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Auxiliary
 
 	def scan_host(ip)
 		vprint_status "#{ip}:#{rport} - IPMI - Probe sent"
-		scanner_send(Rex::Proto::IPMI::Utils.create_ipmi_getchannel_probe, ip, datastore['RPORT'])
+		scanner_send(Rex::Proto::IPMI::Utils.create_ipmi_getchannel_probe, ip, rport)
 	end
 
 	def scanner_process(data, shost, sport)
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Auxiliary
 		# Ignore invalid responses
 		return unless info
 		unless info.ipmi_command == 56
-			vprint_error "#{ip}:#{rport} - IPMI - Invalid response"
+			vprint_error "#{shost}:#{rport} - IPMI - Invalid response"
 			return
 		end
 
@@ -64,11 +64,11 @@ class Metasploit3 < Msf::Auxiliary
 
 		banner = info.to_banner
 
-		print_status("#{shost}:#{datastore['RPORT']} #{banner}")
+		print_status("#{shost}:#{rport} #{banner}")
 
 		report_service(
 			:host  => shost,
-			:port  => datastore['RPORT'],
+			:port  => rport,
 			:proto => 'udp',
 			:name  => 'ipmi',
 			:info  => banner


### PR DESCRIPTION
Normalizing the messages generated by IPMI scanners; scanners indicate what they are doing a little more precisely. This is handy when you're running several scanners in a scripted way and want to be able to tell quickly what messages are being generated from what modules.

This modifies PR #2047 , targeting the modules/add-ipmi-scanners branch.
## Verification
- [x] Ensure verbosity is set with `set VERBOSE true`
- [x] Run each of the edited modules against against a suitable IPMI host
- [x] See that status messages are generated with the format of "address:port - IPMI - text"
