### PR TITLE
lib/rex/proto/smb/client.rb find_next throws exception

### DIFF
--- a/lib/rex/proto/smb/client.rb
+++ b/lib/rex/proto/smb/client.rb
@@ -1909,14 +1909,13 @@ NTLM_UTILS = Rex::Proto::NTLM::Utils
 
 	# Supplements find_first if file/dir count exceeds max search count
 	def find_next(sid, resume_key, last_filename)
-
 		parm = [
 			sid, # Search ID
 			20, # Maximum search count (Size of 20 keeps response to 1 packet)
 			260, # Level of interest
 			resume_key,   # Resume key from previous (Last name offset)
 			6,   # Close search if end of search
-		].pack('vvvVv') + last_filename + "\x00" # Last filename returned from find_first or find_next
+		].pack('vvvVv') + "#{last_filename}" + "\x00" # Last filename returned from find_first or find_next
 		resp = trans2(CONST::TRANS2_FIND_NEXT2, parm, '')
 		return resp # Returns the FIND_NEXT2 response packet for parsing by the find_first function
 	end


### PR DESCRIPTION
While testing my smb_enumshares_rw.rb module, kept getting an exception and traced it back to the smb client library. 

Line 1918 references last_name and will throw an exception when last_name is nil (from what I can tell, the first time through find_next).

Stack trace (from debugging):
[-] Error: '192.168.9.3' 'TypeError' 'can't convert nil into String' '["/opt/framework/lib/rex/proto/smb/client.rb:1919:in `+'", "/opt/framework/lib/rex/proto/smb/client.rb:1919:in`find_next'", "/opt/framework/lib/rex/proto/smb/client.rb:1899:in `find_first'", "/opt/framework/modules/auxiliary/scanner/smb/smb_enumshares_rw.rb:117:in`eval_host'"
<snip>

Changing        ].pack('vvvVv') + last_filename + "\x00" # Last filename returned from find_first or find_next
to:         ].pack('vvvVv') + "#{last_filename}" + "\x00" # Last filename returned from find_first or find_next

Stops the exception from happening and allows the assessment to continue.

Note the exception being thrown did not stop execution of the module, so its mostly cosmetic in not having to see the caught exception in the module.
