### PR TITLE
[FixRM:#8127] - Remove junk code that checks ARTIFACTS again

### DIFF
--- a/modules/post/windows/gather/enum_artifacts.rb
+++ b/modules/post/windows/gather/enum_artifacts.rb
@@ -48,7 +48,7 @@ class Metasploit3 < Msf::Post
 
 		# Load artifacts from yaml file. Artifacts are organized by what they
 		# are evidence of.
-		yaml = YAML::load_file(filename)
+		yaml = YAML::load_file(datastore['ARTIFACTS'])
 		yaml.each_key do |key|
 			print_status("Searching for artifacts of #{key}")
 			files = yaml[key]['files']

--- a/modules/post/windows/gather/enum_artifacts.rb
+++ b/modules/post/windows/gather/enum_artifacts.rb
@@ -46,13 +46,6 @@ class Metasploit3 < Msf::Post
 		# Store any found artifacts so they can be written to loot
 		evidence = {}
 
-		# Check artifacts file path
-		filename = datastore['ARTIFACTS']
-		if not ::File.exists?(filename)
-			print_error("Artifacts file does not exist!")
-			return
-		end
-
 		# Load artifacts from yaml file. Artifacts are organized by what they
 		# are evidence of.
 		yaml = YAML::load_file(filename)


### PR DESCRIPTION
ARTIFACTS uses OptPath, which already checks the path. We don't need to do this again.
