### PR TITLE
[FixRM:#8129] - Fix undefined method error in enum_services.rb

### DIFF
--- a/modules/post/windows/gather/enum_services.rb
+++ b/modules/post/windows/gather/enum_services.rb
@@ -74,7 +74,8 @@ class Metasploit3 < Msf::Post
 					if qpath and ! srv_conf['Command'].downcase.include? qpath.downcase
 						isgood = false
 					end
-					if qtype and ! srv_conf['Startup'].downcase.include? qtype.downcase
+					# There may not be a 'Startup', need to check nil
+					if qtype and ! (srv_conf['Startup'] || '').downcase.include? qtype.downcase
 						isgood = false
 					end
 


### PR DESCRIPTION
srv_conf may not have the 'Startup' key because it's only assigned in service_info() when srvstart is 4, therefore it's possible to cause an undefined method 'downcase' error.
