### PR TITLE
[FixRM:#8130] - Remove invalid metasploit.com references

### DIFF
--- a/modules/auxiliary/vsploit/pii/web_pii.rb
+++ b/modules/auxiliary/vsploit/pii/web_pii.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Auxiliary
 			'Author'         => 'MJC',
 			'References' =>
 			[
-				[ 'URL', 'http://www.metasploit.com'],
+				[ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2011/06/02/vsploit--virtualizing-exploitation-attributes-with-metasploit-framework']
 			],
 			'DefaultOptions' => { 'HTTP::server_name' => 'IIS'}
 			))

--- a/modules/exploits/windows/browser/ie_execcommand_uaf.rb
+++ b/modules/exploits/windows/browser/ie_execcommand_uaf.rb
@@ -53,8 +53,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'MSB', 'MS12-063' ],
 					[ 'URL', 'http://technet.microsoft.com/en-us/security/advisory/2757760' ],
 					[ 'URL', 'http://eromang.zataz.com/2012/09/16/zero-day-season-is-really-not-over-yet/' ],
-					[ 'URL', 'http://blog.vulnhunt.com/index.php/2012/09/17/ie-execcommand-fuction-use-after-free-vulnerability-0day/'],
-					[ 'URL', 'http://metasploit.com' ]
+					[ 'URL', 'http://blog.vulnhunt.com/index.php/2012/09/17/ie-execcommand-fuction-use-after-free-vulnerability-0day/']
 				],
 			'Payload'        =>
 				{

--- a/modules/exploits/windows/fileformat/mcafee_hercules_deletesnapshot.rb
+++ b/modules/exploits/windows/fileformat/mcafee_hercules_deletesnapshot.rb
@@ -26,8 +26,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					[ 'OSVDB', '94540' ],
-					[ 'EDB', '16639' ],
-					[ 'URL', 'http://www.metasploit.com' ]
+					[ 'EDB', '16639' ]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/ftp/freefloatftp_wbem.rb
+++ b/modules/exploits/windows/ftp/freefloatftp_wbem.rb
@@ -35,8 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'     =>
 				[
 					['OSVDB', '88302'],
-					['OSVDB', '88303'],
-					['URL', 'http://metasploit.com']
+					['OSVDB', '88303']
 				],
 			'Platform'       => 'win',
 			'Targets'        =>

--- a/modules/exploits/windows/ftp/xlink_client.rb
+++ b/modules/exploits/windows/ftp/xlink_client.rb
@@ -25,8 +25,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'CVE', '2006-5792' ],
 					[ 'OSVDB', '33969' ],
-					[ 'URL', 'http://www.metasploit.com/' ],
-					[ 'URL', 'http://www.xlink.com' ],
+					[ 'URL', 'http://www.xlink.com' ]
 				],
 			'DefaultOptions' =>
 				{

--- a/modules/exploits/windows/ftp/xlink_server.rb
+++ b/modules/exploits/windows/ftp/xlink_server.rb
@@ -27,8 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'CVE', '2006-5792' ],
 					[ 'OSVDB', '58646' ],
-					[ 'URL', 'http://www.metasploit.com/' ],
-					[ 'URL', 'http://www.xlink.com' ],
+					[ 'URL', 'http://www.xlink.com' ]
 				],
 			'Privileged'     => true,
 			'DefaultOptions' =>


### PR DESCRIPTION
These "metasploit.com" references aren't related to the vulns, shouldn't be in them.
