### PR TITLE
[FixRM:#8131] & [FixRM:#8133] - Fix Base64 func usage

### DIFF
--- a/modules/post/windows/gather/credentials/tortoisesvn.rb
+++ b/modules/post/windows/gather/credentials/tortoisesvn.rb
@@ -9,7 +9,6 @@ require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/priv'
 require 'msf/core/post/windows/registry'
-require 'base64'
 require 'msf/core/auxiliary/report'
 
 class Metasploit3 < Msf::Post
@@ -141,7 +140,7 @@ class Metasploit3 < Msf::Post
 			line.chomp
 			line_num += 1
 			if line_num == 8
-				enc_password = Base64.decode64(line)
+				enc_password = Rex::Text.decode_base64(line)
 				password = decrypt_password(enc_password)
 			elsif line_num == 12
 				if line.match(/<(.*)>.(.*)/)

--- a/modules/post/windows/gather/credentials/trillian.rb
+++ b/modules/post/windows/gather/credentials/trillian.rb
@@ -8,7 +8,6 @@
 require 'msf/core'
 require 'rex'
 require 'rex/parser/ini'
-require 'base64'
 require 'msf/core/post/windows/user_profiles'
 require 'msf/core/post/windows/registry'
 require 'msf/core/auxiliary/report'
@@ -103,7 +102,7 @@ class Metasploit3 < Msf::Post
 		114, 101, 115, 111, 108, 118, 101, 32, 72, 84, 84, 80, 32, 112, 114, 111,
 		120, 0]
 
-		decpass = Base64.decode64(epass)
+		decpass = Rex::Text.decode_base64(epass)
 		plaintext = [decpass].pack("H*").unpack("C*")
 
 		for i in 0 .. plaintext.length-2 do


### PR DESCRIPTION
Instead of using Base64, these modules should use Rex.
