### PR TITLE
[FixRM:#8134] - Handle registry_getvaldata return value properly

### DIFF
--- a/modules/post/windows/gather/credentials/windows_autologin.rb
+++ b/modules/post/windows/gather/credentials/windows_autologin.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Post
 				'License'       => MSF_LICENSE,
 				'Author'        =>
 					[
-						'Myo Soe <YGN Ethical Hacker Group, http://yehg.net>'
+						'Myo Soe' #YGN Ethical Hacker Group, http://yehg.net
 					],
 				'Platform'      => [ 'win' ],
 				'SessionTypes'  => [ 'meterpreter' ],
@@ -60,15 +60,15 @@ class Metasploit3 < Msf::Post
 		# DefaultDomainName, DefaultUserName, DefaultPassword
 		# AltDefaultDomainName, AltDefaultUserName, AltDefaultPassword
 		logon_key = "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\"
-		al = registry_getvaldata(logon_key, "AutoAdminLogon")
+		al = registry_getvaldata(logon_key, "AutoAdminLogon")        || ''
 
-		do1 = registry_getvaldata(logon_key, "DefaultDomainName")
-		du1 = registry_getvaldata(logon_key, "DefaultUserName")
-		dp1 = registry_getvaldata(logon_key, "DefaultPassword")
+		do1 = registry_getvaldata(logon_key, "DefaultDomainName")    || ''
+		du1 = registry_getvaldata(logon_key, "DefaultUserName")      || ''
+		dp1 = registry_getvaldata(logon_key, "DefaultPassword")      || ''
 
-		do2 = registry_getvaldata(logon_key, "AltDefaultDomainName")
-		du2 = registry_getvaldata(logon_key, "AltDefaultUserName")
-		dp2 = registry_getvaldata(logon_key, "AltDefaultPassword")
+		do2 = registry_getvaldata(logon_key, "AltDefaultDomainName") || ''
+		du2 = registry_getvaldata(logon_key, "AltDefaultUserName")   || ''
+		dp2 = registry_getvaldata(logon_key, "AltDefaultPassword")   || ''
 
 		if do1 != '' and  du1 != '' and dp1 == '' and al == '1'
 			has_al = 1


### PR DESCRIPTION
registry_getvaldata can return nil, can't always assume it's gonna throw a string.
