### PR TITLE
Fixed a "NameError uninitialized constant" error.

### DIFF
--- a/modules/exploits/freebsd/local/mmap.rb
+++ b/modules/exploits/freebsd/local/mmap.rb
@@ -6,6 +6,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/post/common'
 
 class Metasploit4 < Msf::Exploit::Local
 	Rank = GreatRanking


### PR DESCRIPTION
On startup of msfconsole, the following error occurred:

  modules/exploits/freebsd/local/mmap.rb: NameError uninitialized constant Msf::Post::Common

The addition of a corresponding 'require' line removed that error.

Signed-off-by: Thorsten Fischer thorsten@froschi.org
