### PR TITLE
Fix potential nil in last_filename

### DIFF
--- a/lib/rex/proto/smb/client.rb
+++ b/lib/rex/proto/smb/client.rb
@@ -1881,7 +1881,7 @@ NTLM_UTILS = Rex::Proto::NTLM::Utils
 						'C'+	# Short File Name Length
 						'C' 	# Reserved
 					)
-					name = resp_data[didx + 70 + 24, info[15]].sub!(/\x00+$/, '')
+					name = resp_data[didx + 70 + 24, info[15]].sub(/\x00+$/, '')
 					files[name] =
 					{
 						'type' => ((info[14] & 0x10)==0x10) ? 'D' : 'F',
@@ -1916,7 +1916,7 @@ NTLM_UTILS = Rex::Proto::NTLM::Utils
 			260, # Level of interest
 			resume_key,   # Resume key from previous (Last name offset)
 			6,   # Close search if end of search
-		].pack('vvvVv') + last_filename + "\x00" # Last filename returned from find_first or find_next
+		].pack('vvvVv') + last_filename.to_s + "\x00" # Last filename returned from find_first or find_next
 		resp = trans2(CONST::TRANS2_FIND_NEXT2, parm, '')
 		return resp # Returns the FIND_NEXT2 response packet for parsing by the find_first function
 	end


### PR DESCRIPTION
Replacing #2060.

It is possible to get a nil in last_filename if the sub! function doesn't find any 0x00s to replace, so instead
it's best to use sub(), which should at least return the original filename.  To make sure we don't hit any other unknown conditions that may result in nil last_filename, it's also convert with to_s to make sure it's always a string.
