### PR TITLE
Print all the creds! All your base are belong to us.

### DIFF
--- a/modules/auxiliary/gather/apache_rave_creds.rb
+++ b/modules/auxiliary/gather/apache_rave_creds.rb
@@ -184,7 +184,7 @@ class Metasploit3 < Msf::Auxiliary
 
 			print_status("#{rhost}:#{rport} - Recovering Hashes...")
 			json_info["result"]["resultSet"].each { |result|
-				vprint_good("#{rhost}:#{rport} - Found cred: #{result["username"]}:#{result["password"]}")
+				print_good("#{rhost}:#{rport} - Found cred: #{result["username"]}:#{result["password"]}")
 				report_auth_info(
 					:host => rhost,
 					:port => rport,


### PR DESCRIPTION
After a short discussion with Tod, we think it's best to print the creds by default.  If some dude runs Metasploit in a public place, dumps passwords, and gets shoulder surfed, well, sucks for them :-p
