### PR TITLE
msfcli - fixed impcomplete argument parsing

### DIFF
--- a/msfcli
+++ b/msfcli
@@ -141,8 +141,12 @@ exploit.init_ui(
 mode = ARGV.pop || 'h'
 
 # Import options
-exploit.datastore.import_options_from_s(ARGV.join('_|_'), '_|_')
-
+begin
+	exploit.datastore.import_options_from_s(ARGV.join('_|_'), '_|_')
+rescue => e
+	print "[!] Error: #{e}\n\n"
+	exit
+end
 
 # Initialize associated modules
 payload = nil
@@ -152,21 +156,21 @@ nop     = nil
 if (exploit.datastore['PAYLOAD'])
 	payload = $framework.payloads.create(exploit.datastore['PAYLOAD'])
 	if (payload != nil)
-	payload.datastore.import_options_from_s(ARGV.join('_|_'), '_|_')
+		payload.datastore.import_options_from_s(ARGV.join('_|_'), '_|_')
 	end
 end
 
 if (exploit.datastore['ENCODER'])
 	encoder = $framework.encoders.create(exploit.datastore['ENCODER'])
 	if (encoder != nil)
-	encoder.datastore.import_options_from_s(ARGV.join('_|_'), '_|_')
+		encoder.datastore.import_options_from_s(ARGV.join('_|_'), '_|_')
 	end
 end
 
 if (exploit.datastore['NOP'])
 	nop = $framework.nops.create(exploit.datastore['NOP'])
 	if (nop != nil)
-	nop.datastore.import_options_from_s(ARGV.join('_|_'), '_|_')
+		nop.datastore.import_options_from_s(ARGV.join('_|_'), '_|_')
 	end
 end
 
@@ -178,7 +182,6 @@ case mode.downcase
 		$stdout.puts("\n" + Msf::Serializer::ReadableText.dump_module(payload, Indent)) if payload
 		$stdout.puts("\n" + Msf::Serializer::ReadableText.dump_module(encoder, Indent)) if encoder
 		$stdout.puts("\n" + Msf::Serializer::ReadableText.dump_module(nop, Indent)) if nop
-
 	when "o"
 		$stdout.puts("\n" + Msf::Serializer::ReadableText.dump_options(exploit, Indent))
 		$stdout.puts("\n" + Msf::Serializer::ReadableText.dump_options(payload, Indent)) if payload


### PR DESCRIPTION
Before
root@kali ~/metasploit-framework$ msfcli exploit/multi/handler PAYLOAD=windows/meterpreter/reverse_tcp LHOST= E                                                                      ✹msfcli2 
[*] Please wait while we load the module tree...
/opt/metasploit/apps/pro/msf3/lib/msf/core/data_store.rb:91:in `each': The argument could not be parsed correctly. (Rex::ArgumentParseError)
    from /opt/metasploit/apps/pro/msf3/lib/msf/core/data_store.rb:91:in`import_options_from_s'
    from /opt/metasploit/apps/pro/msf3/msfcli:144:in `<main>'
root@kali ~/metasploit-framework$

After
root@kali ~/metasploit-framework$ ./msfcli exploit/multi/handler PAYLOAD=windows/meterpreter/reverse_tcp LHOST= E                                                               1 ↵  ✹msfcli2 
[*] Please wait while we load the module tree...
[!] Error: The argument could not be parsed correctly.

root@kali ~/metasploit-framework$ 
