### PR TITLE
msfcli - Added job execution

### DIFF
--- a/msfcli
+++ b/msfcli
@@ -246,8 +246,7 @@ case mode.downcase
 				con.run_single("set #{k} #{v}")
 			end
 
-			mode.downcase == 'j' ? con.run_single("exploit -j") :\
-				con.run_single("exploit")
+			con.run_single("exploit #{mode.downcase == 'j' ? "-j" : ""}")
 
 			# If we have sessions or jobs, keep running
 			if $framework.sessions.length > 0 or $framework.jobs.length > 0

--- a/msfcli
+++ b/msfcli
@@ -46,6 +46,7 @@ def usage (str = nil, extra = nil)
 	tbl << ['(AC)tions', 'Show available actions for this auxiliary module']
 	tbl << ['(C)heck', 'Run the check routine of the selected module']
 	tbl << ['(E)xecute', 'Execute the selected module']
+	tbl << ['(J)ob', 'Execute the selected module as a background job']
 
 	$stdout.puts "Error: #{str}\n\n" if str
 	$stdout.puts tbl.to_s + "\n"
@@ -230,7 +231,7 @@ case mode.downcase
 		else
 			$stdout.puts("\nError: This type of module does not support the check feature")
 		end
-	when "e"
+	when "e", "j"
 			con = Msf::Ui::Console::Driver.new(
 				Msf::Ui::Console::Driver::DefaultPrompt,
 				Msf::Ui::Console::Driver::DefaultPromptChar,
@@ -245,7 +246,8 @@ case mode.downcase
 				con.run_single("set #{k} #{v}")
 			end
 
-			con.run_single("exploit")
+			mode.downcase == 'j' ? con.run_single("exploit -j") :\
+				con.run_single("exploit")
 
 			# If we have sessions or jobs, keep running
 			if $framework.sessions.length > 0 or $framework.jobs.length > 0
@@ -253,7 +255,6 @@ case mode.downcase
 			else
 				con.run_single("quit")
 			end
-
 	else
 		usage("Invalid mode #{mode}")
 end


### PR DESCRIPTION
Able now to execute the module as a background job.

Original Idea: https://forum.intern0t.org/offensive-guides-information/3440-meterpreter-handler-persisent-connections.html

```
root@kali ~/metasploit-framework$ ./msfcli exploit/multi/handler PAYLOAD=windows/meterpreter/reverse_tcp LHOST=127.0.0.1 LPORT=4455 J
[*] Please wait while we load the module tree...
  +-------------------------------------------------------+
  |  METASPLOIT by Rapid7                                 |
  +---------------------------+---------------------------+
  |      __________________   |                           |
  |  ==c(______(o(______(_()  | |""""""""""""|======[***  |
  |             )=\           | |  EXPLOIT   \            |
  |            // \\          | |_____________\_______    |
  |           //   \\         | |==[msf >]============\   |
  |          //     \\        | |______________________\  |
  |         // RECON \\       | \(@)(@)(@)(@)(@)(@)(@)/   |
  |        //         \\      |  *********************    |
  +---------------------------+---------------------------+
  |      o O o                |        \'\/\/\/'/         |
  |              o O          |         )======(          |
  |                 o         |       .'  LOOT  '.        |
  | |^^^^^^^^^^^^^^|l___      |      /    _||__   \       |
  | |    PAYLOAD     |""\___, |     /    (_||_     \      |
  | |________________|__|)__| |    |     __||_)     |     |
  | |(@)(@)"""**|(@)(@)**|(@) |    "       ||       "     |
  |  = = = = = = = = = = = =  |     '--------------'      |
  +---------------------------+---------------------------+


       =[ metasploit v4.7.0-dev [core:4.7 api:1.0]
+ -- --=[ 1128 exploits - 638 auxiliary - 180 post
+ -- --=[ 309 payloads - 30 encoders - 8 nops

PAYLOAD => windows/meterpreter/reverse_tcp
LHOST => 127.0.0.1
LPORT => 4455
[*] Exploit running as background job.

[*] Started reverse handler on 127.0.0.1:4455 
[*] Starting the payload handler...
msf exploit(handler) > 
```
