### PR TITLE
msfvenom bug : exe-small and exe-only format are not created

### DIFF
--- a/msfvenom
+++ b/msfvenom
@@ -508,9 +508,8 @@ when /^dll$/i
 	end
 
 	$stdout.write dll
-when /^exe$/i
+when /^exe(.)*$/i
 	$stdout.write exe
-when /^exe-small$/i
 when /^vba$/i
 	vba = Msf::Util::EXE.to_vba($framework, payload_raw)
 	$stdout.puts vba


### PR DESCRIPTION
msfvenom bug : exe-small and exe-only format are not created
