### PR TITLE
Re-enable pry command

### DIFF
--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -77,11 +77,13 @@ module ModuleCommandDispatcher
 	end
 
 	def cmd_pry(*args)
-		begin
-			require 'pry'
-		rescue LoadError
-			print_error("Failed to load pry, try 'gem install pry'")
-			return
+		unless mod.respond_to? :pry
+			begin
+				require 'pry'
+			rescue LoadError
+				print_error("Failed to load pry, try 'gem install pry'")
+				return
+			end
 		end
 		mod.pry
 	end


### PR DESCRIPTION
The switch to bundler broke pry. This change, along with starting
msfconsole with a command like: `ruby -r pry ./msfconsole`, makes using
it possible again.
## Verification
- [x] gem install pry
- [x] start msfconsole with `ruby -r pry ./msfconsole`
- [x] use a module
- [x] type `pry`
- [x] verify working pry console
