### PR TITLE
Fix [SeeRM #8239] NoMethodError undefined method

### DIFF
--- a/modules/exploits/multi/http/phpldapadmin_query_engine.rb
+++ b/modules/exploits/multi/http/phpldapadmin_query_engine.rb
@@ -114,7 +114,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		data = "cmd=query_engine&query=none&search=1&orderby=#{php_code}\r\n\r\n"
 		session = get_session
 
-		uri normalize_uri(datastore['URI'])
+		uri = normalize_uri(datastore['URI'])
 		uri << '/' if uri[-1,1] != '/'
 		uri << 'cmd.php'
 


### PR DESCRIPTION
Jus tries to fix the next error:

```
Exploit failed: NoMethodError undefined method `uri' for #<Msf::Modules::Mod6578706c6f69742f6d756c74692f687474702f7068706c64617061646d696e5f71756572795f656e67696e65::Metasploit3:0xb4d045e4>

```
