### PR TITLE
Update to MDM 0.16.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :db do
 	# Needed for Msf::DbManager
 	gem 'activerecord'
 	# Database models shared between framework and Pro.
-	gem 'metasploit_data_models', '~> 0.16.1'
+	gem 'metasploit_data_models', '~> 0.16.6'
 	# Needed for module caching in Mdm::ModuleDetails
 	gem 'pg', '>= 0.11'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
     i18n (0.6.1)
     json (1.7.7)
     metaclass (0.0.1)
-    metasploit_data_models (0.16.1)
+    metasploit_data_models (0.16.6)
       activerecord (>= 3.2.13)
       activesupport
       pg
@@ -67,7 +67,7 @@ DEPENDENCIES
   database_cleaner
   factory_girl (>= 4.1.0)
   json
-  metasploit_data_models (~> 0.16.1)
+  metasploit_data_models (~> 0.16.6)
   msgpack
   network_interface (~> 0.0.1)
   nokogiri

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,36 +11,12 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130604145732) do
+ActiveRecord::Schema.define(:version => 20130717150737) do
 
   create_table "api_keys", :force => true do |t|
     t.text     "token"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
-  end
-
-  create_table "attachments", :force => true do |t|
-    t.string  "name",         :limit => 512
-    t.binary  "data"
-    t.string  "content_type", :limit => 512
-    t.boolean "inline",                      :default => true,  :null => false
-    t.boolean "zip",                         :default => false, :null => false
-    t.integer "campaign_id"
-  end
-
-  create_table "attachments_email_templates", :id => false, :force => true do |t|
-    t.integer "attachment_id"
-    t.integer "email_template_id"
-  end
-
-  create_table "campaigns", :force => true do |t|
-    t.integer  "workspace_id",                               :null => false
-    t.string   "name",         :limit => 512
-    t.text     "prefs"
-    t.integer  "status",                      :default => 0
-    t.datetime "started_at"
-    t.datetime "created_at",                                 :null => false
-    t.datetime "updated_at",                                 :null => false
   end
 
   create_table "clients", :force => true do |t|
@@ -63,24 +39,6 @@ ActiveRecord::Schema.define(:version => 20130604145732) do
     t.string   "ptype",       :limit => 256
     t.integer  "source_id"
     t.string   "source_type"
-  end
-
-  create_table "email_addresses", :force => true do |t|
-    t.integer  "campaign_id",                                   :null => false
-    t.string   "first_name",  :limit => 512
-    t.string   "last_name",   :limit => 512
-    t.string   "address",     :limit => 512
-    t.boolean  "sent",                       :default => false, :null => false
-    t.datetime "clicked_at"
-  end
-
-  create_table "email_templates", :force => true do |t|
-    t.string  "name",        :limit => 512
-    t.string  "subject",     :limit => 1024
-    t.text    "body"
-    t.integer "parent_id"
-    t.integer "campaign_id"
-    t.text    "prefs"
   end
 
   create_table "events", :force => true do |t|
@@ -581,14 +539,6 @@ ActiveRecord::Schema.define(:version => 20130604145732) do
   add_index "web_sites", ["options"], :name => "index_web_sites_on_options"
   add_index "web_sites", ["vhost"], :name => "index_web_sites_on_vhost"
 
-  create_table "web_templates", :force => true do |t|
-    t.string  "name",        :limit => 512
-    t.string  "title",       :limit => 512
-    t.string  "body",        :limit => 524288
-    t.integer "campaign_id"
-    t.text    "prefs"
-  end
-
   create_table "web_vulns", :force => true do |t|
     t.integer  "web_site_id",                 :null => false
     t.datetime "created_at",                  :null => false
@@ -596,7 +546,7 @@ ActiveRecord::Schema.define(:version => 20130604145732) do
     t.text     "path",                        :null => false
     t.string   "method",      :limit => 1024, :null => false
     t.text     "params",                      :null => false
-    t.text     "pname",                       :null => false
+    t.text     "pname"
     t.integer  "risk",                        :null => false
     t.string   "name",        :limit => 1024, :null => false
     t.text     "query"


### PR DESCRIPTION
Removes pname validation; assorted schema updates from older migrations

Part of: https://github.com/rapid7/metasploit_data_models/pull/33

Read that first!
