### PR TITLE
Updates firefox javascript version detection to work with FF > 12

### DIFF
--- a/lib/rex/exploitation/javascriptosdetect.js
+++ b/lib/rex/exploitation/javascriptosdetect.js
@@ -45,6 +45,13 @@ window.os_detect.getVersion = function(){
 	var version = "";
 	var unknown_fingerprint = null;
 
+	var css_is_valid = function(prop, propCamelCase, css) {
+		if (!document.createElement) return false;
+		var d = document.createElement('div');
+		d.setAttribute('style', prop+": "+css+";")
+		return d.style[propCamelCase] === css;
+	}
+
 	//--
 	// Client
 	//--
@@ -179,12 +186,15 @@ window.os_detect.getVersion = function(){
 		if (!ua_version || 0 == ua_version.length) {
 			ua_is_lying = true;
 		}
-	} else if (!document.all && navigator.taintEnabled) {
+	} else if (!document.all && navigator.taintEnabled ||
+	            'MozBlobBuilder' in window) {
 		// Use taintEnabled to identify FF since other recent browsers
 		// implement window.getComputedStyle now.  For some reason, checking for
 		// taintEnabled seems to cause IE 6 to stop parsing, so make sure this
 		// isn't IE first.
-		//
+
+		// Also check MozBlobBuilder because FF 9.0.1 does not support taintEnabled
+
 		// Then this is a Gecko derivative, assume Firefox since that's the
 		// only one we have sploits for.  We may need to revisit this in the
 		// future.  This works for multi/browser/mozilla_compareto against
@@ -201,19 +211,20 @@ window.os_detect.getVersion = function(){
 			ua_version = '21.0'
 		} else if ('imul' in Math) {
 			ua_version = '20.0'
-		} else if ('HTMLCanvasElement' in window &&
-			                  'toBlob' in HTMLCanvasElement.prototype) {
+		} else if (css_is_valid('font-size', 'fontSize', '23vmax')) {
+			// this is fuxored
 			ua_version = '19.0'
 		} else if ('devicePixelRatio' in window) {
 			ua_version = '18.0'
-		} else if ('HTMLIFrameElement' in window &&
-			                 'sandbox' in HTMLIFrameElement.prototype) {
+		} else if ('createElement' in document &&
+		           document.createElement('iframe') &&
+                   'sandbox' in document.createElement('iframe')) {
 			ua_version = '17.0'
-		} else if ('CSS2Properties' in window &&
-		                'animation' in CSS2Properties.prototype) {
+		} else if ('mozApps' in navigator && 'install' in navigator.mozApps) {
 			ua_version = '16.0'
 		} else if ('HTMLSourceElement' in window && 
-		                       'media' in HTMLSourceElement.prototype) {
+		           HTMLSourceElement.prototype &&
+		           'media' in HTMLSourceElement.prototype) {
 			ua_version = '15.0'
 		} else if ('mozRequestPointerLock' in document.body) {
 			ua_version = '14.0'
@@ -223,7 +234,9 @@ window.os_detect.getVersion = function(){
 			ua_version = "12.0";
 		} else if ('mozVibrate' in navigator) {
 			ua_version = "11.0";
-		} else if ('mozCancelFullScreen' in document) {
+		} else if (css_is_valid('-moz-backface-visibility', 'MozBackfaceVisibility', 'preserve-3d')) {
+			ua_version = "10.0";
+		} else if ('doNotTrack' in navigator) {
 			ua_version = "9.0";
 		} else if ('insertAdjacentHTML' in document.body) {
 			ua_version = "8.0";
@@ -248,7 +261,6 @@ window.os_detect.getVersion = function(){
 		} else {
 			ua_version = "1";
 		}
-
 		if (navigator.oscpu != navigator.platform) {
 			ua_is_lying = true;
 		}

--- a/lib/rex/exploitation/javascriptosdetect.js
+++ b/lib/rex/exploitation/javascriptosdetect.js
@@ -192,7 +192,34 @@ window.os_detect.getVersion = function(){
 		ua_name = clients_ff;
 		// Thanks to developer.mozilla.org "Firefox for developers" series for most
 		// of these.
-		if ('mozConnection' in navigator) {
+		// Release changelogs: http://www.mozilla.org/en-US/firefox/releases/
+		if ('HTMLTimeElement' in window) {
+			ua_version = '22.0'
+		} else if ('createElement' in document &&
+		           document.createElement('main') &&
+		           document.createElement('main').constructor === window['HTMLElement']) {
+			ua_version = '21.0'
+		} else if ('imul' in Math) {
+			ua_version = '20.0'
+		} else if ('HTMLCanvasElement' in window &&
+			                  'toBlob' in HTMLCanvasElement.prototype) {
+			ua_version = '19.0'
+		} else if ('devicePixelRatio' in window) {
+			ua_version = '18.0'
+		} else if ('HTMLIFrameElement' in window &&
+			                 'sandbox' in HTMLIFrameElement.prototype) {
+			ua_version = '17.0'
+		} else if ('CSS2Properties' in window &&
+		                'animation' in CSS2Properties.prototype) {
+			ua_version = '16.0'
+		} else if ('HTMLSourceElement' in window && 
+		                       'media' in HTMLSourceElement.prototype) {
+			ua_version = '15.0'
+		} else if ('mozRequestPointerLock' in document.body) {
+			ua_version = '14.0'
+		} else if ('Map' in window) {
+			ua_version = "13.0"
+		} else if ('mozConnection' in navigator) {
 			ua_version = "12.0";
 		} else if ('mozVibrate' in navigator) {
 			ua_version = "11.0";

--- a/lib/rex/exploitation/javascriptosdetect.js
+++ b/lib/rex/exploitation/javascriptosdetect.js
@@ -212,13 +212,12 @@ window.os_detect.getVersion = function(){
 		} else if ('imul' in Math) {
 			ua_version = '20.0'
 		} else if (css_is_valid('font-size', 'fontSize', '23vmax')) {
-			// this is fuxored
 			ua_version = '19.0'
 		} else if ('devicePixelRatio' in window) {
 			ua_version = '18.0'
 		} else if ('createElement' in document &&
 		           document.createElement('iframe') &&
-                   'sandbox' in document.createElement('iframe')) {
+		           'sandbox' in document.createElement('iframe')) {
 			ua_version = '17.0'
 		} else if ('mozApps' in navigator && 'install' in navigator.mozApps) {
 			ua_version = '16.0'
@@ -234,7 +233,7 @@ window.os_detect.getVersion = function(){
 			ua_version = "12.0";
 		} else if ('mozVibrate' in navigator) {
 			ua_version = "11.0";
-		} else if (css_is_valid('-moz-backface-visibility', 'MozBackfaceVisibility', 'preserve-3d')) {
+		} else if (css_is_valid('-moz-backface-visibility', 'MozBackfaceVisibility', 'hidden')) {
 			ua_version = "10.0";
 		} else if ('doNotTrack' in navigator) {
 			ua_version = "9.0";


### PR DESCRIPTION
### RM #6994
### Verified with browsershots:

Set 1: http://browsershots.org/http://jsbin.com/uleher/17
Set 2: http://browsershots.org/websites/906333970f0137608aa0759e0f1871e7/9150463
### Manual spot checking:
1. Copy the entire source of `lib/rex/exploitation/javascriptosdetect.js`
2. Open your version of Firefox, press cmd/ctrl-option-k (or Tools->Web Developer->Web Console).
3. Paste the js into the console and hit enter. Run the following console cmd: `os_detect.getVersion()`, and look at the `ua_version` attribute.
