### PR TITLE
Removed requirement for note.data to be present

### DIFF
--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -1283,13 +1283,13 @@ class DBManager
 	# Report a Note to the database.  Notes can be tied to a ::Mdm::Workspace, Host, or Service.
 	#
 	# opts MUST contain
-	# +:data+::  whatever it is you're making a note of
 	# +:type+::  The type of note, e.g. smb_peer_os
 	#
 	# opts can contain
 	# +:workspace+::  the workspace to associate with this Note
 	# +:host+::       an IP address or a Host object to associate with this Note
 	# +:service+::    a Service object to associate with this Note
+	# +:data+::       whatever it is you're making a note of
 	# +:port+::       along with +:host+ and +:proto+, a service to associate with this Note
 	# +:proto+::      along with +:host+ and +:port+, a service to associate with this Note
 	# +:update+::     what to do in case a similar Note exists, see below
@@ -1369,7 +1369,7 @@ class DBManager
 		end
 =end
 		ntype  = opts.delete(:type) || opts.delete(:ntype) || (raise RuntimeError, "A note :type or :ntype is required")
-		data   = opts[:data] || (raise RuntimeError, "Note :data is required")
+		data   = opts[:data]
 		method = nil
 		args   = []
 		note   = nil


### PR DESCRIPTION
https://dev.metasploit.com/redmine/issues/5840
https://www.pivotaltracker.com/story/show/53702805
### Steps to verify
- [x] Check out MSF branch, Pro should be on develop and up to date
- [x] Have some workspace in your Pro DB with hosts and notes (add a note on a host if you lack one)
- [x] cd pro/engine && ./msfpro
- [x] Be in the workspace that has hosts and notes, run `db_export /tmp/foo`
- [x] Once complete, edit the file, find a <note> element; within it, find a <data> element and remove any text between the start and end tags. I.e. you should end up with <note>...<data></data>...</note>
- [x] Back in msfpro, import your edited file with `db_import /tmp/foo`
- [x] There should be no errors, import should complete
