### PR TITLE
Change datastore options names for consistency

### DIFF
--- a/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
+++ b/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
@@ -46,8 +46,8 @@ class Metasploit4 < Msf::Exploit::Remote
 			[
 				Opt::RPORT(443),
 				OptBool.new('SSL', [true, 'Use SSL', true]),
-				OptString.new('MYUSERNAME', [true, 'Your username', 'admin']),
-				OptString.new('MYPASSWORD', [true, 'Your password', 'changeme']),
+				OptString.new('USERNAME', [true, 'Your username', 'admin']),
+				OptString.new('PASSWORD', [true, 'Your password', 'changeme']),
 				OptString.new('TARGETURI', [ true, 'The path to the application', '/']),
 			], self.class
 		)
@@ -59,8 +59,8 @@ class Metasploit4 < Msf::Exploit::Remote
 			'method'    => 'POST',
 			'uri'       => normalize_uri(target_uri.path, 'users', 'login'),
 			'vars_post' => {
-				'login[login]'    => datastore['MYUSERNAME'],
-				'login[password]' => datastore['MYPASSWORD']
+				'login[login]'    => datastore['USERNAME'],
+				'login[password]' => datastore['PASSWORD']
 			}
 		)
 


### PR DESCRIPTION
Just change datastore options names for consistency :) USERNAME and PASSWORD are the common names on modules which need authentication. 

On the other hand in this way it's using the same options names than auxiliary/admin/http/foreman_openstack_satellite_priv_esc.rb
