### PR TITLE
Add functions to normalize Winodws & Unix paths

### DIFF
--- a/lib/rex/file.rb
+++ b/lib/rex/file.rb
@@ -35,14 +35,14 @@ module FileUtils
 		# Filter out double slashes
 		s = s.gsub(/\\\\/, '\\') while s.index('\\\\')
 
+		# Keep the trailing slash if exists
+		trailing_s = ('\\' if s =~ /\\$/) || ''
+
 		# Check the items (fie/dir) individually
 		s = s.split(/\\/)
 
 		# Parse the path prefix
 		prefix = (s[0] || '').gsub(/[\*<>\?\/]/, '')
-		if prefix =~ /^\w:$/ and s.length == 1
-			prefix += '\\'
-		end
 
 		# Delete the original prefix. We want the new one later.
 		s.delete_at(0)
@@ -55,6 +55,9 @@ module FileUtils
 
 		# And then safely join the items
 		s *= '\\'
+
+		# Add the trailing slash back if exists
+		s << trailing_s
 	end
 
 	#

--- a/lib/rex/file.rb
+++ b/lib/rex/file.rb
@@ -14,7 +14,53 @@ module Rex
 module FileUtils
 
 	#
-	# This methods cleans the supplied path of directory traversal sequences
+	# This method joins the paths together in Unix format.
+	#
+	def self.normalize_unix_path(*strs)
+		new_str = strs * '/'
+		new_str = new_str.gsub!("//", "/") while new_str.index("//")
+
+		new_str
+	end
+
+	#
+	# This method joins the paths together in Windows format.
+	# All reserved characters will be filtered out, including:
+	#  " * : < > ? \ / |
+	#
+	def self.normalize_win_path(*strs)
+		# Convert to the same format so the parsing is easier
+		s = strs * '\\'
+
+		# Filter out double slashes
+		s = s.gsub(/\\\\/, '\\') while s.index('\\\\')
+
+		# Check the items (fie/dir) individually
+		s = s.split(/\\/)
+
+		# Parse the path prefix
+		prefix = (s[0] || '').gsub(/[\*<>\?\/]/, '')
+		if prefix.empty?
+			prefix = '\\'
+		elsif prefix =~ /^\w:$/ and s.length == 1
+			prefix += '\\'
+		end
+
+		# Delete the original prefix. We want the new one later.
+		s.delete_at(0)
+
+		# Filter out all the reserved characters
+		s.map! {|e| e.gsub(/["\*:<>\?\\\/|]/, '') }
+
+		# Put the modified prefix back
+		s.insert(0, prefix)
+
+		# And then safely join the items
+		s *= '\\'
+	end
+
+	#
+	# This method cleans the supplied path of directory traversal sequences
 	# It must accept path/with/..a/folder../starting/or/ending/in/two/dots
 	# but clean ../something as well as path/with/..\traversal
 	#

--- a/lib/rex/file.rb
+++ b/lib/rex/file.rb
@@ -40,9 +40,7 @@ module FileUtils
 
 		# Parse the path prefix
 		prefix = (s[0] || '').gsub(/[\*<>\?\/]/, '')
-		if prefix.empty?
-			prefix = '\\'
-		elsif prefix =~ /^\w:$/ and s.length == 1
+		if prefix =~ /^\w:$/ and s.length == 1
 			prefix += '\\'
 		end
 

--- a/spec/lib/rex/file_utils_spec.rb
+++ b/spec/lib/rex/file_utils_spec.rb
@@ -17,6 +17,11 @@ describe Rex::FileUtils do
 				described_class.normalize_win_path('\\temp').should eq("\\temp")
 			end
 
+			it "should keep the trailing slash if exists" do
+				described_class.normalize_win_path('/', 'test', 'me\\').should eq("\\test\\me\\")
+				described_class.normalize_win_path('\\temp\\').should eq("\\temp\\")
+			end
+
 			it "should convert a path without reserved characters" do
 				described_class.normalize_win_path('C:\\', 'Windows:').should eq("C:\\Windows")
 				described_class.normalize_win_path('C:\\Windows???\\test').should eq("C:\\Windows\\test")
@@ -26,6 +31,7 @@ describe Rex::FileUtils do
 				described_class.normalize_win_path('C:\\\\\\', 'Windows').should eq("C:\\Windows")
 				described_class.normalize_win_path('C:\\\\\\Hello World\\\\whatever.txt').should eq("C:\\Hello World\\whatever.txt")
 				described_class.normalize_win_path('C:\\\\').should eq("C:\\")
+				described_class.normalize_win_path('\\test\\\\test\\\\').should eq("\\test\\test\\")
 			end
 		end
 

--- a/spec/lib/rex/file_utils_spec.rb
+++ b/spec/lib/rex/file_utils_spec.rb
@@ -45,6 +45,10 @@ describe Rex::FileUtils do
 				described_class.normalize_unix_path('/etc/passwd').should eq('/etc/passwd')
 			end
 
+			it "should still give me a trailing slash if I have it" do
+				described_class.normalize_unix_path('/etc/folder/').should eq("/etc/folder/")
+			end
+
 			it "should convert a path without double slashes" do
 				described_class.normalize_unix_path('//etc////passwd').should eq("/etc/passwd")
 				described_class.normalize_unix_path('/etc////', 'passwd').should eq('/etc/passwd')

--- a/spec/lib/rex/file_utils_spec.rb
+++ b/spec/lib/rex/file_utils_spec.rb
@@ -1,0 +1,54 @@
+require 'rex/file'
+
+describe Rex::FileUtils do
+	context "Class methods" do
+
+		context ".normalize_win_path" do
+			it "should convert an absolute path as an array into Windows format" do
+				described_class.normalize_win_path('C:\\', 'hello', 'world').should eq("C:\\hello\\world")
+			end
+
+			it "should convert an absolute path as a string into Windows format" do
+				described_class.normalize_win_path('C:\\hello\\world').should eq("C:\\hello\\world")
+			end
+
+			it "should convert a path without reserved characters" do
+				described_class.normalize_win_path('C:\\', 'Windows:').should eq("C:\\Windows")
+				described_class.normalize_win_path('C:\\Windows???\\test').should eq("C:\\Windows\\test")
+			end
+
+			it "should convert a path without double slashes" do
+				described_class.normalize_win_path('C:\\\\\\', 'Windows').should eq("C:\\Windows")
+				described_class.normalize_win_path('C:\\\\\\Hello World\\\\whatever.txt').should eq("C:\\Hello World\\whatever.txt")
+				described_class.normalize_win_path('C:\\\\').should eq("C:\\")
+			end
+
+			it "should parse UNC path format as an array" do
+				described_class.normalize_win_path('\\\\127.0.0.1', 'C$').should eq("\\\\127.0.0.1\\C$")
+				described_class.normalize_win_path('\\\\127.0.0.1\\C$').should eq("\\\\127.0.0.1\\C$")
+			end
+
+			it "should parse a relative path in Windows format" do
+				described_class.normalize_win_path('\\\\127.0.0.1', 'C$').should eq("\\\\127.0.0.1\\C$")
+				described_class.normalize_win_path('\\\\127.0.0.1\\C$').should eq("\\\\127.0.0.1\\C$")
+			end
+		end
+
+		context ".normalize_unix_path" do
+			it "should convert an absolute path as an array into Unix format" do
+				described_class.normalize_unix_path('/etc', '/passwd').should eq("/etc/passwd")
+			end
+
+			it "should convert an absolute path as a string into Windows format" do
+				described_class.normalize_unix_path('/etc/passwd').should eq('/etc/passwd')
+			end
+
+			it "should convert a path without double slashes" do
+				described_class.normalize_unix_path('//etc////passwd').should eq("/etc/passwd")
+				described_class.normalize_unix_path('/etc////', 'passwd').should eq('/etc/passwd')
+			end
+		end
+
+	end
+end
+

--- a/spec/lib/rex/file_utils_spec.rb
+++ b/spec/lib/rex/file_utils_spec.rb
@@ -41,7 +41,7 @@ describe Rex::FileUtils do
 				described_class.normalize_unix_path('/etc', '/passwd').should eq("/etc/passwd")
 			end
 
-			it "should convert an absolute path as a string into Windows format" do
+			it "should convert an absolute path as a string into Unix format" do
 				described_class.normalize_unix_path('/etc/passwd').should eq('/etc/passwd')
 			end
 

--- a/spec/lib/rex/file_utils_spec.rb
+++ b/spec/lib/rex/file_utils_spec.rb
@@ -23,7 +23,7 @@ describe Rex::FileUtils do
 				described_class.normalize_win_path('C:\\\\').should eq("C:\\")
 			end
 
-			it "should parse UNC path format as an array" do
+			it "should parse UNC path format as an array or a string" do
 				described_class.normalize_win_path('\\\\127.0.0.1', 'C$').should eq("\\\\127.0.0.1\\C$")
 				described_class.normalize_win_path('\\\\127.0.0.1\\C$').should eq("\\\\127.0.0.1\\C$")
 			end

--- a/spec/lib/rex/file_utils_spec.rb
+++ b/spec/lib/rex/file_utils_spec.rb
@@ -15,6 +15,7 @@ describe Rex::FileUtils do
 			it "should convert a relative path" do
 				described_class.normalize_win_path('/', 'test', 'me').should eq("\\test\\me")
 				described_class.normalize_win_path('\\temp').should eq("\\temp")
+				described_class.normalize_win_path('temp').should eq("temp")
 			end
 
 			it "should keep the trailing slash if exists" do

--- a/spec/lib/rex/file_utils_spec.rb
+++ b/spec/lib/rex/file_utils_spec.rb
@@ -12,6 +12,11 @@ describe Rex::FileUtils do
 				described_class.normalize_win_path('C:\\hello\\world').should eq("C:\\hello\\world")
 			end
 
+			it "should convert a relative path" do
+				described_class.normalize_win_path('/', 'test', 'me').should eq("\\test\\me")
+				described_class.normalize_win_path('\\temp').should eq("\\temp")
+			end
+
 			it "should convert a path without reserved characters" do
 				described_class.normalize_win_path('C:\\', 'Windows:').should eq("C:\\Windows")
 				described_class.normalize_win_path('C:\\Windows???\\test').should eq("C:\\Windows\\test")
@@ -21,16 +26,6 @@ describe Rex::FileUtils do
 				described_class.normalize_win_path('C:\\\\\\', 'Windows').should eq("C:\\Windows")
 				described_class.normalize_win_path('C:\\\\\\Hello World\\\\whatever.txt').should eq("C:\\Hello World\\whatever.txt")
 				described_class.normalize_win_path('C:\\\\').should eq("C:\\")
-			end
-
-			it "should parse UNC path format as an array or a string" do
-				described_class.normalize_win_path('\\\\127.0.0.1', 'C$').should eq("\\\\127.0.0.1\\C$")
-				described_class.normalize_win_path('\\\\127.0.0.1\\C$').should eq("\\\\127.0.0.1\\C$")
-			end
-
-			it "should parse a relative path in Windows format" do
-				described_class.normalize_win_path('\\\\127.0.0.1', 'C$').should eq("\\\\127.0.0.1\\C$")
-				described_class.normalize_win_path('\\\\127.0.0.1\\C$').should eq("\\\\127.0.0.1\\C$")
 			end
 		end
 


### PR DESCRIPTION
The purpose of these functions is to be able to join file/dir paths safely without trailing slashes, basically for the same reason as normalize_uri.  Some modules are really buggy when merging paths, so instead of letting them do it, it's better to use these functions.

To test these functions, simply do:

```
$ rspec file_utils_spec.rb 
.........

Finished in 0.00207 seconds
9 examples, 0 failures
```
