### PR TITLE
Speed up msfcli help

### DIFF
--- a/msfcli
+++ b/msfcli
@@ -16,15 +16,7 @@ while File.symlink?(msfbase)
 end
 
 $:.unshift(File.expand_path(File.join(File.dirname(msfbase), 'lib')))
-require 'fastlib'
-require 'msfenv'
-
-
-$:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
-
 require 'rex'
-require 'msf/ui'
-require 'msf/base'
 
 Indent = '   '
 
@@ -61,6 +53,12 @@ module_class = "exploit"
 
 if(exploit_name == "-h")
 	usage()
+else
+	$:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
+	require 'fastlib'
+	require 'msfenv'
+	require 'msf/ui'
+	require 'msf/base'
 end
 
 # Initialize the simplified framework instance.


### PR DESCRIPTION
If the user only wants to see help, then no point to load things that will actually never be used by msfcli.  Only rex is needed.  On my box, this shaves off about a second:

```
Switched to branch 'upstream-master'
$ time msfcli -h
Usage: /Users/wchen/rapid7/msf/msfcli <exploit_name> <option=value> [mode]
==========================================================================

    Mode           Description
    ----           -----------
    (A)dvanced     Show available advanced options for this module
    (AC)tions      Show available actions for this auxiliary module
    (C)heck        Run the check routine of the selected module
    (E)xecute      Execute the selected module
    (H)elp         You're looking at it baby!
    (I)DS Evasion  Show available ids evasion options for this module
    (O)ptions      Show available options for this module
    (P)ayloads     Show available payloads for this module
    (S)ummary      Show information about this module
    (T)argets      Show available targets for this exploit module


real    0m1.661s
user    0m1.482s
sys 0m0.180s

$ git checkout faster_msfcli_help
Switched to branch 'faster_msfcli_help'

$ time msfcli -h
Usage: /Users/wchen/rapid7/msf/msfcli <exploit_name> <option=value> [mode]
==========================================================================

    Mode           Description
    ----           -----------
    (A)dvanced     Show available advanced options for this module
    (AC)tions      Show available actions for this auxiliary module
    (C)heck        Run the check routine of the selected module
    (E)xecute      Execute the selected module
    (H)elp         You're looking at it baby!
    (I)DS Evasion  Show available ids evasion options for this module
    (O)ptions      Show available options for this module
    (P)ayloads     Show available payloads for this module
    (S)ummary      Show information about this module
    (T)argets      Show available targets for this exploit module


real    0m0.398s
user    0m0.358s
sys 0m0.036s
```
