### PR TITLE
update open_browser functionality

### DIFF
--- a/lib/rex/compat.rb
+++ b/lib/rex/compat.rb
@@ -133,7 +133,7 @@ def self.open_browser(url='http://metasploit.com/')
 		if defined? ENV['PATH']
 			# "sensible-browser" opens the "default" browser in Ubuntu and others, so try that first
 			#  but also provide fallbacks
-			['sensible-browser', 'firefox', 'opera', 'chromium-browser', 'konqueror'].each do |browser|
+			['xdg-open', 'sensible-browser', 'firefox', 'firefox-bin', 'opera', 'konqueror', 'chromium-browser'].each do |browser|
 				ENV['PATH'].split(':').each do |path|
 					# Does the browser exists?
 					if File.exists?("#{path}/#{browser}")
@@ -143,9 +143,6 @@ def self.open_browser(url='http://metasploit.com/')
 				end
 			end
 		end
-
-		# If nothing else worked, default to firefox
-		system("firefox #{url} &")
 	end
 end
 


### PR DESCRIPTION
open_browser didn't support xdg-open or firefox-bin.  xdg-open was made the default as it is the most likely to succeed afaik.

the fallback to firefox was removed because since we check for the existence of firefox is makes no sense to try to run it after we failed to find it.  This will silently fail if no supported browser is found due to suggestions from the msf team:

< Zero_Chaos> more importantly, it would be great if someone told me how to spit out a message to the user
< Zero_Chaos> because I have no clue :-)
@egypt Zero_Chaos: it's in rex, so the answer is "don't"
