### PR TITLE
Fixed smb_enumshares to support dir list in SRVSVC

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Auxiliary
 		register_options(
 			[
 				OptBool.new('DIR_SHARE',      [true, 'Show all the folders and files', false ]),
-				OptBool.new('USE_SRVSVC_ONLY', [true, 'List shares with SRVSVC', false ])
+				OptBool.new('USE_SRVSVC_ONLY', [true, 'List shares only with SRVSVC', false ])
 			], self.class)
 
 		deregister_options('RPORT', 'RHOST')

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -80,9 +80,7 @@ class Metasploit3 < Msf::Auxiliary
 		read = write = false
 
 		# srvsvc adds a null byte that needs to be removed
-		if datastore['USE_SRVSVC_ONLY']
-			share = share[0..-2]
-		end
+		share = share.chomp("\x00")
 
 		return false,false,nil,nil if share == 'IPC$'
 


### PR DESCRIPTION
There's a kind of "by design" bug with smb_enumshares where it wasn't listing directories when using srvsvc, which some environments need by default. After some debugging, it seems like the problem is because srvsvc adds a null byte. When accounting for this, it seems to work. 

Tested with and without USE_SRVSVC_ONLY with windows xp, and with server 2008 r2.
