### PR TITLE
Fix nil deref in spool command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1516,8 +1516,13 @@ class Core
 		# Restore color and prompt
 		driver.output.config[:color] = color
 		prompt = framework.datastore['Prompt'] || Msf::Ui::Console::Driver::DefaultPrompt
+		if active_module
+			# intentionally += and not << because we don't want to modify
+			# datastore or the constant DefaultPrompt
+			prompt += " #{active_module.type}(%bld%red#{active_module.shortname}%clr)"
+		end
 		prompt_char = framework.datastore['PromptChar'] || Msf::Ui::Console::Driver::DefaultPromptChar
-		driver.update_prompt("#{prompt} #{active_module.type}(%bld%red#{active_module.shortname}%clr) ", prompt_char, true)
+		driver.update_prompt("#{prompt} ", prompt_char, true)
 
 		print_status(msg)
 		return


### PR DESCRIPTION
Occurs when no module is currently `use`d
### Verification:
- [x] type `back` to get out of any module context
- [x] type `spool whatever`
#### before

see `[-] Error while running command spool: undefined method `type' for nil:NilClass`
#### after

see expected successful output `[*] Spooling to file whatever...`
