### PR TITLE
Exploits MS13-005 - Low Integrity to Medium Integrity Local Priv Esc

### DIFF
--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -8,9 +8,9 @@ module Exploit::Powershell
 		super
 		register_options(
 		[
-				OptBool.new('PSH::PERSIST', [true, 'Run the payload in a loop', false]),
-				OptBool.new('PSH::OLD_METHOD', [true, 'Use powershell 1.0', false]),
-				OptBool.new('PSH::RUN_WOW64', [
+				OptBool.new('PERSIST', [true, 'Run the payload in a loop', false]),
+				OptBool.new('PSH_OLD_METHOD', [true, 'Use powershell 1.0', false]),
+				OptBool.new('RUN_WOW64', [
 					true,
 					'Execute powershell in 32bit compatibility mode, payloads need native arch',
 					false

--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -131,7 +131,7 @@ EOS
 	#
 	# Creates cmd script to execute psh payload
 	#
-	def cmd_psh_payload(pay, old_psh=datastore['PSH::OLD_METHOD'], wow64=datastore['PSH::RUN_WOW64'])
+	def cmd_psh_payload(pay, old_psh=datastore['PSH_OLD_METHOD'], wow64=datastore['RUN_WOW64'])
 		# Allow powershell 1.0 format
 		if old_psh
 			psh_payload = Msf::Util::EXE.to_win32pe_psh(framework, pay)
@@ -139,7 +139,7 @@ EOS
 			psh_payload = Msf::Util::EXE.to_win32pe_psh_net(framework, pay)
 		end
 		# Run our payload in a while loop
-		if datastore['PSH::PERSIST']
+		if datastore['PERSIST']
 			fun_name = Rex::Text.rand_text_alpha(rand(2)+2)
 			sleep_time = rand(5)+5
 			psh_payload  = "function #{fun_name}{#{psh_payload}};"


### PR DESCRIPTION
Tested on IE8-Win7 VM from: http://www.modern.ie/en-US/virtualization-tools#downloads

Its pretty fun to watch: http://www.youtube.com/watch?v=Vw8ylvTOlBQ

Also tested on the Vista but that doesn't support the spawning of a shell as no shortcut so the only attack vector there is if the victim spawns a cmd prompt (or powershell) for you.

To test:

```
icacls meterp.exe /setintegritylevel low
```

ProcExp can tell you if a process is medium or low integrity for success.

Possible Improvements:
The low integrity check could possibly be refactored into Post::Accounts? But that's pending in another PR. It would also benefit from being railgunned.

Would the typing go faster if we did a multi railgun call?

Could add an option to just write the whole payload command rather than web download - but you'd definitely want to time this for the small hours of the morning. I expect that'd be better in a separate module? If we're getting in as a low integrity process we probably exploiting IE anyway so have web access...
