### PR TITLE
Patch for string encoding issues with `msgpack`

### DIFF
--- a/lib/msf/core/rpc/v10/service.rb
+++ b/lib/msf/core/rpc/v10/service.rb
@@ -23,7 +23,7 @@ class Service
 
 	attr_accessor :service, :srvhost, :srvport, :uri, :options
 	attr_accessor :handlers, :default_handler, :tokens, :users, :framework
-	attr_accessor :dispatcher_timeout, :token_timeout, :debug
+	attr_accessor :dispatcher_timeout, :token_timeout, :debug, :str_encoding
 
 	def initialize(framework, options={})
 		self.framework = framework
@@ -36,6 +36,7 @@ class Service
 			:port => 3790
 		}.merge(options)
 
+		self.str_encoding = ''.encoding.name
 		self.srvhost = self.options[:host]
 		self.srvport = self.options[:port]
 		self.uri     = self.options[:uri]
@@ -120,6 +121,8 @@ class Service
 			if not (msg and msg.kind_of?(::Array) and msg.length > 0)
 				raise ArgumentError, "Invalid Message Format"
 			end
+
+			msg.map { |a| a.respond_to?("force_encoding")?a.force_encoding(self.str_encoding):a }
 
 			group, funct = msg.shift.split(".", 2)
 


### PR DESCRIPTION
Fixes an issue that causes exploits to fail if the PAYLOAD option is the last option to get marshalled in an MSFRPC dictionary. The patch adjusts the string's encoding to match the internal default encoding used by Ruby. Hence, making `fetch()` succeed.
