### PR TITLE
Change how ms11_006_createsizeddibsection comes up with the outputpath

### DIFF
--- a/modules/exploits/windows/fileformat/ms11_006_createsizeddibsection.rb
+++ b/modules/exploits/windows/fileformat/ms11_006_createsizeddibsection.rb
@@ -108,7 +108,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		register_options(
 			[
 				OptString.new('FILENAME', [ true, 'The file name.',  'msf.doc']),
-				OptString.new('OUTPUTPATH', [ true, 'The output path to use.', Msf::Config.config_directory + "/data/exploits/"]),
+				OptString.new('OUTPUTPATH', [ true, 'The output path to use.', Msf::Config.config_directory + "/local/"]),
 			], self.class)
 	end
 
@@ -116,7 +116,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		print_status("Creating '#{datastore['FILENAME']}' file ...")
 
-		out = ::File.expand_path(::File.join(datastore['OUTPUTPATH'], datastore['FILENAME']))
+		fname = datastore['FILENAME']
+		ltype = "exploit.fileformat.ms11_006"
+		out = store_local(ltype, nil, '', fname)
+
 		stg = Rex::OLE::Storage.new(out, Rex::OLE::STGM_WRITE)
 		if (not stg)
 			fail_with(Exploit::Failure::BadConfig, 'Unable to create output file')
@@ -131,7 +134,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		stg.close
 
-		print_status("Generated output file #{out}")
+		print_good("#{datastore['FILENAME']} created at #{out}")
 
 	end
 

--- a/modules/exploits/windows/fileformat/ms11_006_createsizeddibsection.rb
+++ b/modules/exploits/windows/fileformat/ms11_006_createsizeddibsection.rb
@@ -107,8 +107,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		register_options(
 			[
-				OptString.new('FILENAME', [ true, 'The file name.',  'msf.doc']),
-				OptString.new('OUTPUTPATH', [ true, 'The output path to use.', Msf::Config.config_directory + "/local/"]),
+				OptString.new('FILENAME', [ true, 'The file name.',  'msf.doc'])
 			], self.class)
 	end
 


### PR DESCRIPTION
The default outputpath for ms11_006_createsizeddibsection is invalid for systems such as OSX and Kali Linux, we should stop using that.

[See RM 8272]
http://dev.metasploit.com/redmine/issues/8272
