### PR TITLE
Fix undefined variable 'path' for http_login

### DIFF
--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -86,7 +86,7 @@ class Metasploit3 < Msf::Auxiliary
 			return path
 		end
 
-		return path
+		return nil
 	end
 
 	def target_url


### PR DESCRIPTION
This fixes an undefined variable for 'path' bug.

If no auth uri found, the find_auth_uri func should return a nil (at least that seems to be the original intention), so that run_host can bail like this:

```
@uri = find_auth_uri
if ! @uri
    print_error("#{target_url} No URI found that asks for HTTP authentication")
    return
end
```

[See RM 8279]
http://dev.metasploit.com/redmine/issues/8279
