### PR TITLE
Avoid require race with powershell

### DIFF
--- a/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
+++ b/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
@@ -8,6 +8,7 @@
 require 'msf/core'
 require 'rex'
 require 'msf/core/exploit/exe'
+require 'msf/core/exploit/powershell'
 
 class Metasploit3 < Msf::Exploit::Local
 	Rank = ExcellentRanking


### PR DESCRIPTION
The Powershell exploit lib needs to be required directly, otherwise differences in load order will cause a missing constant error.
### Verification
- [x] `./msfconsole -Lq -x "sleep 3; info exploit/windows/local/ms13_005_hwnd_broadcast"`
- [x] See that the module is loaded.

Note, the error condition may or may not reproduce for you, it depends largely on ruby system path ordering.
