### PR TITLE
Tabassassin msftidy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ tags
 *.orig
 *.rej
 *~
+# Ignore backups of retabbed files
+*.notab

--- a/test/modules/auxiliary/test/space-check.rb
+++ b/test/modules/auxiliary/test/space-check.rb
@@ -1,0 +1,47 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+	    'Name'           => "Check Test",
+	  	'Description'    => %q{
+		   This module ensures that 'check' actually functions for Auxiilary modules.
+      },
+      'References'     =>
+        [
+          [ 'OSVDB', '0' ]
+        ],
+      'Author'         =>
+        [
+          'todb'
+        ],
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(80)
+      ], self.class)
+  end
+
+  def check
+    print_debug "Check is successful"
+    return Msf::Exploit::CheckCode::Vulnerable
+  end
+
+  def run
+    print_debug "Run is successful."
+  end
+
+end

--- a/test/modules/auxiliary/test/space-check.rb
+++ b/test/modules/auxiliary/test/space-check.rb
@@ -9,11 +9,11 @@ require 'msf/core'
 
 class Metasploit3 < Msf::Auxiliary
 
-  include Msf::Auxiliary::Report
-  include Msf::Exploit::Remote::HttpClient
+	include Msf::Auxiliary::Report
+	include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
-    super(update_info(info,
+		super(update_info(info,
 	    'Name'           => "Check Test",
 	  	'Description'    => %q{
 		   This module ensures that 'check' actually functions for Auxiilary modules.

--- a/tools/dev/retab.rb
+++ b/tools/dev/retab.rb
@@ -1,0 +1,43 @@
+#!/usr/bin/env ruby
+# -*- coding: binary -*-
+
+# Replace leading tabs with 2-width spaces.
+# I'm sure there's a sed/awk/perl oneliner that's
+# a million times better but this is more readable for me.
+
+require 'fileutils'
+require 'find'
+
+dir = ARGV[0] || "."
+raise ArgumentError, "Need a filename or directory" unless (dir and File.readable? dir)
+
+Find.find(dir) do |infile|
+  next unless File.file? infile
+  next unless infile =~ /rb$/
+outfile = infile
+backup = "#{infile}.notab"
+FileUtils.cp infile, backup
+
+data = File.open(infile, "rb") {|f| f.read f.stat.size}
+fixed = []
+data.each_line do |line|
+  fixed << line
+  next unless line =~ /^\x09/
+  index = []
+  i = 0
+  line.each_char do |char|
+    break unless char =~ /[\x20\x09]/
+    index << i if char == "\x09"
+    i += 1
+  end
+  index.reverse.each do |idx|
+    line[idx] = "  "
+  end
+  fixed[-1] = line
+end
+
+fh = File.open(outfile, "wb")
+fh.write fixed.join
+fh.close
+puts "Retabbed #{fh.path}"
+end

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -353,8 +353,10 @@ class Msftidy
 				warn("Spaces at EOL", idx)
 			end
 
-			if (ln.length > 1) and (ln =~ /^([\t ]*)/) and ($1.include?(' '))
-				warn("Bad indent: #{ln.inspect}", idx)
+			# Allow tabs or spaces as indent characters, but not both.
+			# This should check for spaces only on October 8, 2013
+			if (ln.length > 1) and (ln =~ /^([\t ]*)/) and ($1.match(/\x20\x09|\x09\x20/))
+				warn("Space-Tab mixed indent: #{ln.inspect}", idx)
 			end
 
 			if ln =~ /\r$/


### PR DESCRIPTION
Adds a retabbing utility (that keeps a local backup of retabbed files) and a test module.

For more details, please see 

https://github.com/rapid7/metasploit-framework/wiki/Indentation-Standards
## Verification
- [x] Run `tools/msftidy.rb test/modules/auxiliary/test/space-check.rb` after landing
- [x] Note three WARNINGS, as seen below:

```
$ tools/msftidy.rb test/modules/auxiliary/test/space-check.rb
space-check.rb:17 - [WARNING] Space-Tab mixed indent: "\t    'Name'           => \"Check Test\",\n"
space-check.rb:18 - [WARNING] Space-Tab mixed indent: "\t  \t'Description'    => %q{\n"
space-check.rb:19 - [WARNING] Space-Tab mixed indent: "\t\t   This module ensures that 'check' actually functions for Auxiilary modules.\n"
```

Note that regular users should **not** run `tools/dev/retab.rb` over large chunks of the codebase; please allow @tabassassin to fulfill that role. In this way, whitespace changes are contained on one committer, making commands such as `git blame` and `git shortlog` easier for humans to comprehend. Retabbing your own, uncommitted new modules is of course fine, once this PR lands.

Note that once @tabassassin does his (my) thing, `diff -b` (and `git diff -b`) should be pretty standard for diff checking to ignore leading whitespace changes when tracking down bugs.

**Note to landing committer** each of the commits has comments explaining the file changes so there's hopefully no misunderstanding.
