### PR TITLE
renamed and Name fixed

### DIFF
--- a/modules/exploits/linux/http/dlink_tools_vct_exec.rb
+++ b/modules/exploits/linux/http/dlink_tools_vct_exec.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'        => 'D-Link Devices Unauthenticated Remote Command Execution',
+			'Name'        => 'D-Link Devices Authenticated Remote Command Execution',
 			'Description' => %q{
 				Different D-Link Routers are vulnerable to OS command injection via the web
 				interface. The vulnerability exists in tools_vct.xgi, which is accessible with


### PR DESCRIPTION
This is a module where we need credentials -> Name fixed to "Authenticated"
I think the vulnerability could be also available in other devices so I have changed the name of the module.

Best,
Mike
