### PR TITLE
Fixed architecture detection in bypassuac modules

### DIFF
--- a/modules/exploits/windows/local/bypassuac.rb
+++ b/modules/exploits/windows/local/bypassuac.rb
@@ -136,7 +136,7 @@ class Metasploit3 < Msf::Exploit::Local
 
 		# decide, x86 or x64
 		bpexe = nil
-		if sysinfo["Architecture"] =~ /wow64/i
+		if sysinfo["Architecture"] =~ /x64/i
 			bpexe = ::File.join(path, "bypassuac-x64.exe")
 		else
 			bpexe = ::File.join(path, "bypassuac-x86.exe")

--- a/modules/post/windows/escalate/bypassuac.rb
+++ b/modules/post/windows/escalate/bypassuac.rb
@@ -94,7 +94,7 @@ class Metasploit3 < Msf::Post
 
 		# decide, x86 or x64
 		bpexe = nil
-		if payload =~ /x64/ or sysinfo["Architecture"] =~ /wow64/i
+		if sysinfo["Architecture"] =~ /x64/i
 			bpexe = ::File.join(path, "bypassuac-x64.exe")
 		else
 			bpexe = ::File.join(path, "bypassuac-x86.exe")


### PR DESCRIPTION
The module did not detect properly x64 operating systems if the meterpreter session process was a native x64 and not an x86 (WOW64 emulated). As a result, bypassuac-x86.exe was deployed on the target machine instead of the bypassuac-x64.exe. As such, an elevated meterpreter session was not gained.
