### PR TITLE
Set default target to 0 because there's only one

### DIFF
--- a/modules/exploits/windows/http/ultraminihttp_bof.rb
+++ b/modules/exploits/windows/http/ultraminihttp_bof.rb
@@ -55,8 +55,9 @@ class Metasploit3 < Msf::Exploit::Remote
 					]
 				],
 			'Privileged'     => false,
-			'DisclosureDate' => 'Jul 10 2013'
-			))
+			'DisclosureDate' => 'Jul 10 2013',
+			'DefaultTarget'  => 0
+		))
 	end
 
 	def exploit


### PR DESCRIPTION
For PR #2210, because I forgot to add a default target before pushing it to master.
