### PR TITLE
Fix undefined method error for HTTP/HTTPS handler

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -104,6 +104,12 @@ module ReverseHttp
 		# the INIT and CONN request types, based on a checksum
 		uri_strip, uri_conn = uri_match.split('_', 2)
 		uri_strip.sub!(/^\//, '')
+
+		# checksum8 fails if uri_strip is ""
+		if uri_strip == ""
+			return uri_match
+		end
+
 		uri_check = Rex::Text.checksum8(uri_strip)
 
 		# Match specific checksums and map them to static URIs


### PR DESCRIPTION
This commit fixes the following error that may occur when an HTTP or
HTTPS handler is setup and a client connects to the web server to
request the root directory.

The error is:

Proc::on_request: NoMethodError: undefined method `%' for nil:NilClass

The error occurs when Rex::Text.checksum8(uri_strip) is called with an
empty string. This commit adds a check for an empty string and forces
the function to return the original requested URI.
