### PR TITLE
Fix condition in order to fix Firefox module

### DIFF
--- a/modules/exploits/windows/browser/mozilla_firefox_onreadystatechange.rb
+++ b/modules/exploits/windows/browser/mozilla_firefox_onreadystatechange.rb
@@ -92,7 +92,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			return
 		end
 
-		if agent !~ /Firefox\/17/ or agent !~ /Firefox\/21/
+		if agent !~ /Firefox\/17/ and agent !~ /Firefox\/21/
 			print_error("Browser not supported, sending 404: #{agent}")
 			send_not_found(cli)
 			return


### PR DESCRIPTION
The actual condition is wrong, the not found should be sent if firefox isn't 17 AND firefox isn't 21, because the module supports Firefox 17 and 21 atm.
