### PR TITLE
Ensure checksum* methods return a Fixnum

### DIFF
--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -1563,24 +1563,34 @@ protected
 		@@codepage_map_cache = map
 	end
 
+	# @param str [String] Data to checksum
+	# @return [Fixnum] 8-bit checksum
 	def self.checksum8(str)
-		str.unpack("C*").inject(:+) % 0x100
+		(str.unpack("C*").inject(:+) || 0) % 0x100
 	end
 
+	# @param str [String] Little-endian data to checksum
+	# @return [Fixnum] 16-bit checksum
 	def self.checksum16_le(str)
-		str.unpack("v*").inject(:+) % 0x10000
+		(str.unpack("v*").inject(:+) || 0) % 0x10000
 	end
 
+	# @param str [String] Big-endian data to checksum
+	# @return [Fixnum] 16-bit checksum
 	def self.checksum16_be(str)
-		str.unpack("n*").inject(:+) % 0x10000
+		(str.unpack("n*").inject(:+) || 0) % 0x10000
 	end
 
+	# @param str [String] Little-endian data to checksum
+	# @return [Fixnum] 32-bit checksum
 	def self.checksum32_le(str)
-		str.unpack("V*").inject(:+) % 0x100000000
+		(str.unpack("V*").inject(:+) || 0) % 0x100000000
 	end
 
+	# @param str [String] Big-endian data to checksum
+	# @return [Fixnum] 32-bit checksum
 	def self.checksum32_be(str)
-		str.unpack("N*").inject(:+) % 0x100000000
+		(str.unpack("N*").inject(:+) || 0) % 0x100000000
 	end
 
 end


### PR DESCRIPTION
Fixes a bug in reverse_http\* stagers where requests for the root URI
(i.e., "/") cause a NoMethodError on nil returned by checksum8.

[See #2216]
