### PR TITLE
Fix how fail_with() is used

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -126,7 +126,7 @@ module Exploit::Remote::HttpClient
 				opts[:pattern].each do |re|
 					if not re.match(info)
 						err = "The target server fingerprint \"#{info}\" does not match \"#{re.to_s}\", use 'set FingerprintCheck false' to disable this check."
-						fail_with(Msf::Exploit::Failure::NotFound, err)
+						raise RuntimeError, err
 					end
 				end
 			end

--- a/lib/msf/core/exploit/mssql_sqli.rb
+++ b/lib/msf/core/exploit/mssql_sqli.rb
@@ -144,7 +144,7 @@ module Exploit::Remote::MSSQL_SQLI
 		if (datastore['METHOD'] == 'GET')
 
 			unless datastore['GET_PATH'].index("[SQLi]")
-				fail_with(Exploit::Failure::NoTarget, "The SQL injection parameter was not specified in the GET path")
+				raise RuntimeError, "The SQL injection parameter was not specified in the GET path"
 			end
 
 			uri = datastore['GET_PATH'].gsub("[SQLi]", Rex::Text.uri_encode(sqla))
@@ -160,7 +160,7 @@ module Exploit::Remote::MSSQL_SQLI
 		else
 
 			unless datastore['DATA'].index("[SQLi]")
-				fail_with(Exploit::Failure::NoTarget, "The SQL injection parameter was not specified in the POST data")
+				raise RuntimeError, "The SQL injection parameter was not specified in the POST data"
 			end
 
 			post_data = datastore['DATA'].gsub("[SQLi]", Rex::Text.uri_encode(sqla))

--- a/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
+++ b/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
@@ -93,7 +93,7 @@ class Metasploit3 < Msf::Auxiliary
 	#
 	def use_zlib
 		if (!Rex::Text.zlib_present? and datastore['HTTP::compression'] == true)
-			fail_with(Exploit::Failure::Unknown, "zlib support was not detected, yet the HTTP::compression option was set.  Don't do that!")
+			raise RuntimeError, "zlib support was not detected, yet the HTTP::compression option was set.  Don't do that!"
 		end
 	end
 


### PR DESCRIPTION
fail_with() is a function in lib/msf/core/exploit.rb, which indicates that this is meant to be used only for exploit modules. Because of that, it should NOT be seen in places like mixins or auxiliary modules, otherwise you will get a "NoMethodError undefined method `fail_with'" error - [See RM 8265] for example.

Instead of using fail_with(), the closest replacement for that is to fall back to raise Runtime, which is also something we used a lot before fail_with was created.
