### PR TITLE
Fixes bug #8296 Nessus Plugin nessus_help command result displayed incorrectly

### DIFF
--- a/plugins/nessus.rb
+++ b/plugins/nessus.rb
@@ -202,9 +202,10 @@ module Msf
 			def cmd_nessus_help(*args)
 				tbl = Rex::Ui::Text::Table.new(
 					'Columns' => [
-						'Command',
-						'Help Text'
-					]
+						"Command",
+						"Help Text"
+					],
+					'SortIndex' => -1
 				)
 				tbl << [ "Generic Commands", "" ]
 				tbl << [ "-----------------", "-----------------"]


### PR DESCRIPTION
In Rex::Ui::Text::Table, to_s will sort the rows before it converts the table into a string, because of this, the rows were printing in the wrong order. The fix simply sets the SortIndex to -1 (disabled).
