### PR TITLE
[FixRM #8312] Fix file handle leaks

### DIFF
--- a/modules/auxiliary/analyze/jtr_aix.rb
+++ b/modules/auxiliary/analyze/jtr_aix.rb
@@ -51,6 +51,8 @@ class Metasploit3 < Msf::Auxiliary
 					row.gsub!(/\n/, ":#{myloot.host.address}\n")
 					hashlist.write(row)
 				end
+
+				usf.close
 			end
 			hashlist.close
 

--- a/modules/auxiliary/analyze/jtr_linux.rb
+++ b/modules/auxiliary/analyze/jtr_linux.rb
@@ -58,6 +58,8 @@ class Metasploit3 < Msf::Auxiliary
 					row.gsub!(/\n/, ":#{myloot.host.address}\n")
 					hashlist.write(row)
 				end
+
+				usf.close
 			end
 			hashlist.close
 

--- a/modules/auxiliary/client/smtp/emailer.rb
+++ b/modules/auxiliary/client/smtp/emailer.rb
@@ -75,6 +75,8 @@ class Metasploit3 < Msf::Auxiliary
 		msf_change_ext  = yamlconf['msf_change_ext']
 		msf_payload_ext = yamlconf['msf_payload_ext']
 
+		fileconf.close
+
 
 		tmp = Dir.tmpdir
 

--- a/modules/auxiliary/gather/d20pass.rb
+++ b/modules/auxiliary/gather/d20pass.rb
@@ -240,19 +240,23 @@ class Metasploit3 < Msf::Auxiliary
 
 	def parse(fh)
 		print_status("Parsing file")
-		f = File.open(fh.path, 'rb')
-		used = f.read(4)
-		if used != "USED"
-			print_error "Invalid Configuration File!"
-			return
-		end
-		f.seek(0x38)
-		start = makefptr(f.read(4))
-		userptr = findentry(f, "B014USER", start)
-		if userptr != nil
-			parseusers(f, userptr)
-		else
-			print_error "Error finding the user table in the configuration."
+		begin
+			f = File.open(fh.path, 'rb')
+			used = f.read(4)
+			if used != "USED"
+				print_error "Invalid Configuration File!"
+				return
+			end
+			f.seek(0x38)
+			start = makefptr(f.read(4))
+			userptr = findentry(f, "B014USER", start)
+			if userptr != nil
+				parseusers(f, userptr)
+			else
+				print_error "Error finding the user table in the configuration."
+			end
+		ensure
+			f.close
 		end
 	end
 

--- a/modules/auxiliary/scanner/sap/sap_icm_urlscan.rb
+++ b/modules/auxiliary/scanner/sap/sap_icm_urlscan.rb
@@ -81,9 +81,13 @@ class Metasploit3 < Msf::Auxiliary
 
 			# Load URLs
 			urls_to_check = []
-			f = File.open(url_file)
-			f.each_line do |line|
-				urls_to_check.push line
+			begin
+				f = File.open(url_file)
+				f.each_line do |line|
+					urls_to_check.push line
+				end
+			ensure
+				f.close
 			end
 
 			print_status("#{rhost}:#{rport} Beginning URL check")

--- a/modules/post/windows/gather/enum_chrome.rb
+++ b/modules/post/windows/gather/enum_chrome.rb
@@ -84,10 +84,17 @@ class Metasploit3 < Msf::Post
 
 
 	def parse_prefs(username, filepath)
-		f = File.open(filepath, 'rb')
-		until f.eof
-			prefs = f.read
+		prefs = ''
+
+		begin
+			f = File.open(filepath, 'rb')
+			until f.eof
+				prefs = f.read
+			end
+		ensure
+			f.close
 		end
+
 		results = ActiveSupport::JSON.decode(prefs)
 		print_status("Extensions installed: ")
 		results['extensions']['settings'].each do |name,values|


### PR DESCRIPTION
When file.open() is used, module must make sure it's closed, otherwise as long as you have the console running, you are leaking.

See:
http://dev.metasploit.com/redmine/issues/8311
