### PR TITLE
[SeeRM #8313] - Print where files are stored

### DIFF
--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_startprofile.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_startprofile.rb
@@ -127,7 +127,7 @@ class Metasploit4 < Msf::Auxiliary
 
 		if success
 			print_good("#{rhost}:#{rport} [SAP] Startup Profile Extracted: #{name}")
-			store_loot(
+			f = store_loot(
 				"sap.profile",
 				"text/xml",
 				rhost,
@@ -135,6 +135,7 @@ class Metasploit4 < Msf::Auxiliary
 				"sap_profile.xml",
 				"SAP Profile XML"
 			)
+			vprint_status("Response stored in: #{f}")
 
 			env.each do |output|
 				print_status("#{output[0]}")

--- a/modules/auxiliary/scanner/vmware/vmware_enum_permissions.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_permissions.rb
@@ -81,7 +81,9 @@ class Metasploit3 < Msf::Auxiliary
 					tmp_perms << [perm['principal'], perm['group'], role_name , role_summary]
 				end
 				print_good tmp_perms.to_s
-				store_loot('host.vmware.permissions', "text/plain", datastore['RHOST'], tmp_perms.to_csv , "#{datastore['RHOST']}_esx_permissions.txt", "VMWare ESX Permissions")
+
+				f = store_loot('host.vmware.permissions', "text/plain", datastore['RHOST'], tmp_perms.to_csv , "#{datastore['RHOST']}_esx_permissions.txt", "VMWare ESX Permissions")
+				vprint_status("Permission info stored in: #{f}")
 			end
 		else
 			print_error "Login Failure on #{ip}"

--- a/modules/auxiliary/scanner/vmware/vmware_enum_sessions.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_sessions.rb
@@ -67,7 +67,8 @@ class Metasploit3 < Msf::Auxiliary
 					output << tmp_line
 				end
 				unless output.empty?
-					store_loot("host.vmware.sessions", "text/plain", datastore['RHOST'], output, "vmware_sessions.txt", "Login Sessions for VMware")
+					f = store_loot("host.vmware.sessions", "text/plain", datastore['RHOST'], output, "vmware_sessions.txt", "Login Sessions for VMware")
+					vprint_status("Login sessions stored in: #{f}")
 				end
 			end
 		else

--- a/modules/auxiliary/scanner/vmware/vmware_enum_users.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_users.rb
@@ -119,9 +119,12 @@ class Metasploit3 < Msf::Auxiliary
 							end
 						end
 						print_good tmp_dgroups.to_s
-						store_loot('domain.groups', "text/plain", datastore['RHOST'], tmp_dgroups.to_csv , "#{domain}_esx_groups.txt", "VMWare ESX #{domain} Domain User Groups")
+
+						f = store_loot('domain.groups', "text/plain", datastore['RHOST'], tmp_dgroups.to_csv , "#{domain}_esx_groups.txt", "VMWare ESX #{domain} Domain User Groups")
+						vprint_status("VMWare domain user groups stored in: #{f}")
 						print_good tmp_dusers.to_s
-						store_loot('domain.users', "text/plain", datastore['RHOST'], tmp_dgroups.to_csv , "#{domain}_esx_users.txt", "VMWare ESX #{domain} Domain Users")
+						f = store_loot('domain.users', "text/plain", datastore['RHOST'], tmp_dgroups.to_csv , "#{domain}_esx_users.txt", "VMWare ESX #{domain} Domain Users")
+						vprint_status("VMWare users stored in: #{f}")
 					end
 				end
 			end

--- a/modules/auxiliary/scanner/vmware/vmware_enum_vms.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_vms.rb
@@ -73,7 +73,9 @@ class Metasploit3 < Msf::Auxiliary
 					print_good "Screenshot Saved to #{ss_path}"
 				end
 			end
-			store_loot('host.vmware.vms', "text/plain", datastore['RHOST'], YAML.dump(virtual_machines) , "#{datastore['RHOST']}_esx_vms.txt", "VMWare ESX Virtual Machines")
+
+			f = store_loot('host.vmware.vms', "text/plain", datastore['RHOST'], YAML.dump(virtual_machines) , "#{datastore['RHOST']}_esx_vms.txt", "VMWare ESX Virtual Machines")
+			vprint_status("VM info stored in: #{f}")
 		else
 			print_error "Login Failure on #{ip}"
 			return

--- a/modules/auxiliary/scanner/vmware/vmware_host_details.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_host_details.rb
@@ -46,7 +46,9 @@ class Metasploit3 < Msf::Auxiliary
 			host_summary = vim_get_all_host_summary(datastore['HW_DETAILS'])
 			output << YAML.dump(host_summary)
 			print_good output
-			store_loot('vmware_host_details', "text/plain", datastore['RHOST'], output, "#{datastore['RHOST']}_vmware_host.txt", "VMWare Host Details")
+
+			f = store_loot('vmware_host_details', "text/plain", datastore['RHOST'], output, "#{datastore['RHOST']}_vmware_host.txt", "VMWare Host Details")
+			vprint_status("Host details stored in: #{f}")
 		else
 			print_error "Login Failure on #{ip}"
 			return


### PR DESCRIPTION
As an user, I want to be able to see where my file is stored when the module I'm using runs a store_loot().

Ticket:
http://dev.metasploit.com/redmine/issues/8313
