### PR TITLE
Use OptPath instead of OptString to ensure path validation

### DIFF
--- a/modules/auxiliary/admin/oracle/oracle_login.rb
+++ b/modules/auxiliary/admin/oracle/oracle_login.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Auxiliary
 
 			register_options(
 				[
-					Optpath.new('CSVFILE', [ false, 'The file that contains a list of default accounts.', File.join(Msf::Config.install_root, 'data', 'wordlists', 'oracle_default_passwords.csv')]),
+					OptPath.new('CSVFILE', [ false, 'The file that contains a list of default accounts.', File.join(Msf::Config.install_root, 'data', 'wordlists', 'oracle_default_passwords.csv')]),
 				], self.class)
 
 			deregister_options('DBUSER','DBPASS')

--- a/modules/auxiliary/admin/oracle/oracle_login.rb
+++ b/modules/auxiliary/admin/oracle/oracle_login.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Auxiliary
 
 			register_options(
 				[
-					OptString.new('CSVFILE', [ false, 'The file that contains a list of default accounts.', File.join(Msf::Config.install_root, 'data', 'wordlists', 'oracle_default_passwords.csv')]),
+					Optpath.new('CSVFILE', [ false, 'The file that contains a list of default accounts.', File.join(Msf::Config.install_root, 'data', 'wordlists', 'oracle_default_passwords.csv')]),
 				], self.class)
 
 			deregister_options('DBUSER','DBPASS')

--- a/modules/auxiliary/scanner/http/mod_negotiation_brute.rb
+++ b/modules/auxiliary/scanner/http/mod_negotiation_brute.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Auxiliary
 		register_options(
 			[
 				OptString.new('PATH', [ true,  "The path to detect mod_negotiation", '/']),
-				OptString.new('FILEPATH',[true, "path to file with file names",
+				OptPath.new('FILEPATH',[true, "path to file with file names",
 					File.join(Msf::Config.install_root, "data", "wmap", "wmap_files.txt")])
 			], self.class)
 	end

--- a/modules/auxiliary/scanner/pop3/pop3_login.rb
+++ b/modules/auxiliary/scanner/pop3/pop3_login.rb
@@ -32,13 +32,14 @@ class Metasploit3 < Msf::Auxiliary
 	register_options(
 		[
 			Opt::RPORT(110),
+			# Should be OptPath
 			OptString.new('USER_FILE',
 				[
 					false,
 					'The file that contains a list of probable users accounts.',
 					File.join(Msf::Config.install_root, 'data', 'wordlists', 'unix_users.txt')
 				]),
-			OptString.new('PASS_FILE',
+			OptPath.new('PASS_FILE',
 				[
 					false,
 					'The file that contains a list of probable passwords.',

--- a/modules/auxiliary/scanner/pop3/pop3_login.rb
+++ b/modules/auxiliary/scanner/pop3/pop3_login.rb
@@ -32,8 +32,7 @@ class Metasploit3 < Msf::Auxiliary
 	register_options(
 		[
 			Opt::RPORT(110),
-			# Should be OptPath
-			OptString.new('USER_FILE',
+			OptPath.new('USER_FILE',
 				[
 					false,
 					'The file that contains a list of probable users accounts.',


### PR DESCRIPTION
These modules should be using OptPath to ensure path validation.

See:
http://dev.metasploit.com/redmine/issues/8314
