### PR TITLE
Get rid of function that's never used

### DIFF
--- a/modules/auxiliary/scanner/mssql/mssql_ping.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_ping.rb
@@ -26,10 +26,6 @@ class Metasploit3 < Msf::Auxiliary
 		deregister_options('RPORT', 'RHOST')
 	end
 
-	def rport
-		datastore['RPORT']
-	end
-
 	def run_host(ip)
 
 		begin


### PR DESCRIPTION
RPORT datastore option is deregistered, and is never used anywhere in the module, so I don't why we need this rport() function here.
