### PR TITLE
Module should use OptRegexp for regex pattern option

### DIFF
--- a/modules/auxiliary/scanner/http/scraper.rb
+++ b/modules/auxiliary/scanner/http/scraper.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Auxiliary
 		register_options(
 			[
 				OptString.new('PATH', [ true,  "The test path to the page to analize", '/']),
-				OptRegexp.new('REGEX', [ true,  "The regex to use (default regex is a sample to grab page title)", '\<title\>(.*)\<\/title\>'])
+				OptRegexp.new('PATTERN', [ true,  "The regex to use (default regex is a sample to grab page title)", %r{<title>(.*)</title>}i])
 
 			], self.class)
 
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Auxiliary
 				return
 			end
 
-			result = res.body.scan(datastore['REGEX']).flatten.map{ |s| s.strip }.uniq
+			result = res.body.scan(datastore['PATTERN']).flatten.map{ |s| s.strip }.uniq
 
 			result.each do |u|
 				print_status("[#{target_host}] #{tpath} [#{u}]")

--- a/modules/auxiliary/scanner/http/scraper.rb
+++ b/modules/auxiliary/scanner/http/scraper.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Auxiliary
 				return
 			end
 
-			result = res.body.scan(aregex).flatten.map{ |s| s.strip }.uniq
+			result = res.body.scan(datastore['REGEX']).flatten.map{ |s| s.strip }.uniq
 
 			result.each do |u|
 				print_status("[#{target_host}] #{tpath} [#{u}]")

--- a/modules/auxiliary/scanner/http/scraper.rb
+++ b/modules/auxiliary/scanner/http/scraper.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Auxiliary
 		register_options(
 			[
 				OptString.new('PATH', [ true,  "The test path to the page to analize", '/']),
-				OptString.new('REGEX', [ true,  "The regex to use (default regex is a sample to grab page title)", '\<title\>(.*)\<\/title\>']),
+				OptRegexp.new('REGEX', [ true,  "The regex to use (default regex is a sample to grab page title)", '\<title\>(.*)\<\/title\>'])
 
 			], self.class)
 
@@ -56,8 +56,6 @@ class Metasploit3 < Msf::Auxiliary
 				print_error("[#{target_host}] #{tpath} - No response")
 				return
 			end
-
-			aregex = Regexp.new(datastore['REGEX'].to_s,Regexp::IGNORECASE)
 
 			result = res.body.scan(aregex).flatten.map{ |s| s.strip }.uniq
 


### PR DESCRIPTION
Instead of using OptString, OptRegexp should be used because this datastore option is a regex pattern.
