### PR TITLE
Use print_line instead of print

### DIFF
--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocesslist.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocesslist.rb
@@ -139,7 +139,7 @@ class Metasploit4 < Msf::Auxiliary
 				saptbl << [ output[0], output[1], output[3], output[4], output[5] ]
 				end
 
-			print(saptbl.to_s)
+			print_line(saptbl.to_s) # This needs to be print_line
 			return
 		elsif fault
 			print_error("#{rhost}:#{rport} [SAP] Error code: #{faultcode}")

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocesslist.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocesslist.rb
@@ -139,7 +139,7 @@ class Metasploit4 < Msf::Auxiliary
 				saptbl << [ output[0], output[1], output[3], output[4], output[5] ]
 				end
 
-			print_line(saptbl.to_s) # This needs to be print_line
+			print_line(saptbl.to_s)
 			return
 		elsif fault
 			print_error("#{rhost}:#{rport} [SAP] Error code: #{faultcode}")

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
@@ -152,7 +152,7 @@ class Metasploit4 < Msf::Auxiliary
 				saptbl << [ output[0], output[1], output[2] ]
 			end
 
-			print_line(saptbl.to_s)  # Needs to be print_line
+			print_line(saptbl.to_s)
 			return
 
 		elsif fault

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
@@ -146,12 +146,13 @@ class Metasploit4 < Msf::Auxiliary
 					"sap_listlogfiles.xml",
 					"SAP #{datastore['FILETYPE'].downcase}"
 			)
+			# Report to the user where this is stored
 
 			env.each do |output|
 				saptbl << [ output[0], output[1], output[2] ]
 			end
 
-			print(saptbl.to_s)
+			print_line(saptbl.to_s)  # Needs to be print_line
 			return
 
 		elsif fault

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
@@ -138,7 +138,7 @@ class Metasploit4 < Msf::Auxiliary
 				"Timestamp"
 			])
 
-			store_loot(
+			f = store_loot(
 				"sap.#{datastore['FILETYPE'].downcase}file",
 				"text/xml",
 					rhost,
@@ -146,7 +146,7 @@ class Metasploit4 < Msf::Auxiliary
 					"sap_listlogfiles.xml",
 					"SAP #{datastore['FILETYPE'].downcase}"
 			)
-			# Report to the user where this is stored
+			vprint_status("sap_listlogfiles.xml stored in: #{f}")
 
 			env.each do |output|
 				saptbl << [ output[0], output[1], output[2] ]

--- a/modules/auxiliary/scanner/sap/sap_router_info_request.rb
+++ b/modules/auxiliary/scanner/sap/sap_router_info_request.rb
@@ -173,7 +173,7 @@ class Metasploit4 < Msf::Auxiliary
 			end
 			disconnect
 		# TODO: This data should be saved somewhere. A note on the host would be nice.
-		print_line(saptbl.to_s) # Should be print_line
+		print_line(saptbl.to_s)
 		end
 	end
 end

--- a/modules/auxiliary/scanner/sap/sap_router_info_request.rb
+++ b/modules/auxiliary/scanner/sap/sap_router_info_request.rb
@@ -173,7 +173,7 @@ class Metasploit4 < Msf::Auxiliary
 			end
 			disconnect
 		# TODO: This data should be saved somewhere. A note on the host would be nice.
-		print(saptbl.to_s)
+		print_line(saptbl.to_s) # Should be print_line
 		end
 	end
 end


### PR DESCRIPTION
These modules should be using print_line instead of print.

I also decided to shove a vprint_status() to display where store_loot() saves a file in sap_mgmt_con_listlogfiles, figured the change is small enough I can just shove it in here.
