### PR TITLE
Patch for [SeeRM #8315]

### DIFF
--- a/lib/msf/core/auxiliary/jtr.rb
+++ b/lib/msf/core/auxiliary/jtr.rb
@@ -101,10 +101,17 @@ module Auxiliary::JohnTheRipper
 	def john_show_passwords(hfile, format=nil)
 		res = {:cracked => 0, :uncracked => 0, :users => {} }
 
+		john_command = john_binary_path
+
+		if john_command.nil?
+			print_error("John the Ripper executable not found")
+			return res
+		end
+
 		pot  = john_pot_file
 		conf = ::File.join(john_base_path, "confs", "john.conf")
 
-		cmd = [ john_binary_path,  "--show", "--conf=#{conf}", "--pot=#{pot}", hfile]
+		cmd = [ john_command,  "--show", "--conf=#{conf}", "--pot=#{pot}", hfile]
 
 		if format
 			cmd << "--format=" + format
@@ -140,6 +147,13 @@ module Auxiliary::JohnTheRipper
 
 		retval=""
 
+		john_command = john_binary_path
+
+		if john_command.nil?
+			print_error("John the Ripper executable not found")
+			return nil
+		end
+
 		if File.exists?(passwd_file)
 			unless File.readable?(passwd_file)
 				print_error("We do not have permission to read #{passwd_file}")
@@ -161,7 +175,7 @@ module Auxiliary::JohnTheRipper
 		end
 
 
-		cmd = [ john_binary_path.gsub(/john$/, "unshadow"), passwd_file , shadow_file ]
+		cmd = [ john_command.gsub(/john$/, "unshadow"), passwd_file , shadow_file ]
 
 		if RUBY_VERSION =~ /^1\.8\./
 			cmd = cmd.join(" ")
@@ -237,9 +251,16 @@ module Auxiliary::JohnTheRipper
 
 		res = {:cracked => 0, :uncracked => 0, :users => {} }
 
+		john_command = john_binary_path
+
+		if john_command.nil?
+			print_error("John the Ripper executable not found")
+			return nil
+		end
+
 		# Don't bother making a log file, we'd just have to rm it when we're
 		# done anyway.
-		cmd = [ john_binary_path,  "--session=" + john_session_id, "--nolog"]
+		cmd = [ john_command,  "--session=" + john_session_id, "--nolog"]
 
 		if opts[:conf]
 			cmd << ( "--conf=" + opts[:conf] )


### PR DESCRIPTION
My try to solve http://dev.metasploit.com/redmine/issues/8315, see the RM ticket for explanations.
- Test after the patch, on a macosx system, where there isn't binay for by default, and nothing is configured manually:

```
msf auxiliary(jtr_linux) > run

[*] Seeding wordlist with DB schema info... 0 words added
[*] Seeding with MSSQL Instance Names....0 words added
[*] Seeding with hostnames....0 words added
[*] Seeding with found credentials....22 words added
[*] Seeding with cracked passwords from John....0 words added
[*] Seeding with default John wordlist...88395 words added
[*] De-duping the wordlist....
[*] Wordlist Seeded with 88407 words
[*] HashList: /var/folders/36/syfyhgjs5g7679944nxfn3lw0000gn/T/jtrtmp20130819-4727-1dh6r7d
[*] Trying Format:md5 Wordlist: /var/folders/36/syfyhgjs5g7679944nxfn3lw0000gn/T/jtrtmp20130819-4727-f9mmu1
[-] John the Ripper executable not found
[*] Trying Format:md5 Rule: All4...
[-] John the Ripper executable not found
[*] Trying Format:md5 Rule: Digits5...
[-] John the Ripper executable not found
[*] Trying Format:des Wordlist: /var/folders/36/syfyhgjs5g7679944nxfn3lw0000gn/T/jtrtmp20130819-4727-f9mmu1
[-] John the Ripper executable not found
[*] Trying Format:des Rule: All4...
[-] John the Ripper executable not found
[*] Trying Format:des Rule: Digits5...
[-] John the Ripper executable not found
[*] Trying Format:bsdi Wordlist: /var/folders/36/syfyhgjs5g7679944nxfn3lw0000gn/T/jtrtmp20130819-4727-f9mmu1
[-] John the Ripper executable not found
[*] Trying Format:bsdi Rule: All4...
[-] John the Ripper executable not found
[*] Trying Format:bsdi Rule: Digits5...
[-] John the Ripper executable not found
[-] John the Ripper executable not found
[*] 0 hashes were cracked!
[*] Auxiliary module execution completed

```
