### PR TITLE
[FixRM #8316] - Escape characters correctly

### DIFF
--- a/modules/auxiliary/admin/cisco/vpn_3000_ftp_bypass.rb
+++ b/modules/auxiliary/admin/cisco/vpn_3000_ftp_bypass.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Auxiliary
 					print_status("\tAttempting to delete directory: RMD #{test}")
 					sock.put("RMD #{test}\r\n")
 					res = sock.get(-1,5)
-					if (res =~ /250 RMD command successful./)
+					if (res =~ /250 RMD command successful\./)
 						print_status("\tDirectory #{test} reportedly deleted. Verifying with SIZE #{test}")
 						sock.put("SIZE #{test}\r\n")
 						res = sock.get(-1,5)

--- a/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
+++ b/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Auxiliary
 				})
 
 			return if res.nil?
-			return if (res.headers['Server'].nil? or res.headers['Server'] !~ /DIR-645 Ver 1.0/)
+			return if (res.headers['Server'].nil? or res.headers['Server'] !~ /DIR-645 Ver 1\.0/)
 			return if (res.code == 404)
 
 			if res.body =~ /<password>(.*)<\/password>/

--- a/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
@@ -67,12 +67,12 @@ class Metasploit4 < Msf::Auxiliary
 	case datastore['RFILE']
 	when nil
 		# Nothing
-	when /localconf.php$/i
+	when /localconf\.php$/i
 		jumpurl = "#{datastore['RFILE']}%00/."
 		jumpurl_len = (jumpurl.length) -2 #Account for difference in length with null byte
 		jumpurl_enc = jumpurl.sub("%00", "\00") #Replace %00 with \00 to correct null byte format
 		print_status("Adding padding to end of #{datastore['RFILE']} to avoid TYPO3 security filters")
-	when /^..(\/|\\)/i
+	when /^\.\.(\/|\\)/i
 		print_error("Directory traversal detected... you might want to start that with a /.. or \\..")
 	else
 		jumpurl_len = (datastore['RFILE'].length)

--- a/modules/auxiliary/admin/http/typo3_sa_2010_020.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2010_020.rb
@@ -53,9 +53,9 @@ class Metasploit4 < Msf::Auxiliary
 	case datastore['RFILE']
 	when nil
 		# Nothing
-	when /localconf.php$/i
+	when /localconf\.php$/i
 		jumpurl = "#{datastore['RFILE']}%00/."
-	when /^..(\/|\\)/i
+	when /^\.\.(\/|\\)/i
 		print_error("Directory traversal detected... you might want to start that with a /.. or \\..")
 	else
 		jumpurl = "#{datastore['RFILE']}"

--- a/modules/auxiliary/admin/http/typo3_winstaller_default_enc_keys.rb
+++ b/modules/auxiliary/admin/http/typo3_winstaller_default_enc_keys.rb
@@ -71,12 +71,12 @@ class Metasploit4 < Msf::Auxiliary
 	case datastore['RFILE']
 	when nil
 		# Nothing
-	when /localconf.php$/i
+	when /localconf\.php$/i
 		jumpurl = "#{datastore['RFILE']}%00/."
 		jumpurl_len = (jumpurl.length) -2 #Account for difference in length with null byte
 		jumpurl_enc = jumpurl.sub("%00", "\00") #Replace %00 with \00 to correct null byte format
 		print_status("Adding padding to end of #{datastore['RFILE']} to avoid TYPO3 security filters")
-	when /^..(\/|\\)/i
+	when /^\.\.(\/|\\)/i
 		print_error("Directory traversal detected... you might want to start that with a /.. or \\..")
 	else
 		jumpurl_len = (datastore['RFILE'].length)


### PR DESCRIPTION
dots need to be escaped. See:
http://dev.metasploit.com/redmine/issues/8316
