### PR TITLE
[FixRM #8319] - Properly disable BLANK_PASSWORDS for ektron_cms400net

### DIFF
--- a/modules/auxiliary/scanner/http/ektron_cms400net.rb
+++ b/modules/auxiliary/scanner/http/ektron_cms400net.rb
@@ -39,6 +39,7 @@ class Metasploit3 < Msf::Auxiliary
 					])
 			], self.class)
 
+		# "Set to false to prevent account lockouts - it will!"
 		deregister_options('BLANK_PASSWORDS')
 	end
 
@@ -58,22 +59,22 @@ class Metasploit3 < Msf::Auxiliary
 		end
 	end
 
-	def cleanup
-		datastore['BLANK_PASSWORDS'] = @blank_pass
-	end
+    def gen_blank_passwords(users, credentials)
+    	return credentials
+    end
 
 	def run_host(ip)
-		# "Set to false to prevent account lockouts - it will!"
-		# Therefore we shouldn't present BLANK_PASSWORDS as an option
-		@blank_pass = datastore['BLANK_PASSWORDS']
-		datastore['BLANK_PASSWORDS'] = false
-
 		begin
 			res = send_request_cgi(
 			{
 				'method'  => 'GET',
 				'uri'     => normalize_uri(datastore['URI'])
 			}, 20)
+
+			if res.nil?
+				print_error("Connection timed out")
+				return
+			end
 
 			#Check for HTTP 200 response.
 			#Numerous versions and configs make if difficult to further fingerprint.
@@ -105,7 +106,7 @@ class Metasploit3 < Msf::Auxiliary
 			end
 
 		rescue
-			print_error ("Ektron CMS400.NET login page not found at #{target_url}  [HTTP #{res.code rescue '= No response'}]")
+			print_error ("Ektron CMS400.NET login page not found at #{target_url}  [HTTP #{res.code}]")
 			return
 		end
 	end


### PR DESCRIPTION
In module ektron_cms400net.rb, datastore option "BLANK_PASSWORDS" is set to false by default, because according to the original author, a blank password will result in account lockouts. Since the user should never set "BLANK_PASSWORDS" to true, this option should never be presented as an option (when issuing the "show options").

See:
http://dev.metasploit.com/redmine/issues/8319

While fixing #8319, I also noticed another bug at line 108, where res.code is used when res could be nil due to a timeout, so I ended up fixing it, too.
