### PR TITLE
[FixRM #8350] - Fix undefined method 'body' error due to a timeout

### DIFF
--- a/modules/auxiliary/admin/edirectory/edirectory_edirutil.rb
+++ b/modules/auxiliary/admin/edirectory/edirectory_edirutil.rb
@@ -148,6 +148,11 @@ class Metasploit3 < Msf::Auxiliary
 				}
 		}, 25)
 
+		if res.nil?
+			print_error("Connection timed out")
+			return
+		end
+
 		raw_data = res.body.scan(/#{action.opts['PATTERN']}/).flatten[0]
 		print_line("\n" + Rex::Text.decode_base64(raw_data))
 


### PR DESCRIPTION
Needs to check nil before using method 'body', see:
http://dev.metasploit.com/redmine/issues/8350
