### PR TITLE
Fix database connection leaks

### DIFF
--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -1512,6 +1512,7 @@ class DBManager
 			raise ArgumentError.new("Invalid address or object for :host (#{opts[:host].inspect})")
 		end
 
+	::ActiveRecord::Base.connection_pool.with_connection {
 		host = opts.delete(:host)
 		ptype = opts.delete(:type) || "password"
 		token = [opts.delete(:user), opts.delete(:pass)]
@@ -1623,6 +1624,7 @@ class DBManager
     end
 
 		ret[:cred] = cred
+	}
 	end
 
 	alias :report_cred :report_auth_info
@@ -1922,8 +1924,10 @@ class DBManager
 	# Note that this *can* update data across workspaces
 	#
 	def update_vuln_details(details)
+	::ActiveRecord::Base.connection_pool.with_connection {
 		criteria = details.delete(:key) || {}
 		::Mdm::VulnDetail.update(key, details)
+	}
 	end
 
 	#

--- a/lib/msf/core/session_manager.rb
+++ b/lib/msf/core/session_manager.rb
@@ -107,13 +107,17 @@ class SessionManager < Hash
 					# processing time for large session lists from skewing our update interval.
 
 					last_seen_timer = Time.now.utc
-					values.each do |s|
-						# Update the database entry on a regular basis, marking alive threads
-						# as recently seen.  This notifies other framework instances that this
-						# session is being maintained.
-						if framework.db.active and s.db_record
-							s.db_record.last_seen = Time.now.utc
-							s.db_record.save
+					if framework.db.active
+						::ActiveRecord::Base.connection_pool.with_connection do
+							values.each do |s|
+								# Update the database entry on a regular basis, marking alive threads
+								# as recently seen.  This notifies other framework instances that this
+								# session is being maintained.
+								if s.db_record
+									s.db_record.last_seen = Time.now.utc
+									s.db_record.save
+								end
+							end
 						end
 					end
 				end


### PR DESCRIPTION
This fixes a couple of database connection leaks that were causing deadlocks in Pro.

Verification Steps:
- [x] Start `msfconsole` with database support
- [x] Try to get a psexec session with a bad password:
  
  ```
  use exploit/windows/smb/psexec
  set RHOST 192.168.1.105  # A windows target
  set SMBPass wrongpass
  set SMBUser administrator
  exploit -z
  ```
- [x] VERIFY: Exploit failed
- [x] Enter IRB shell: `irb`
- [x] Run this nifty command to show ActiveRecord connections associated with framework threads:
  
  ```
  ActiveRecord::Base.connection_pool.instance_variable_get("@reserved_connections").map {|key, val| thread = Thread.list.find {|t| t.object_id == key}; "#{key}: #{thread ? "#{thread[:tm_name]} #{thread.inspect}" : "Unknown" }" }
  ```
- [x] VERIFY: Only one connection exists.  If a second connection associated with the ModuleCacheRebuild thread exists, that's ok - you are a faster typer then me ;)
- [x] Exit out of IRB.  `exit`
- [x] Get a session.  For example, on Metasploitable2:
  
  ```
  use exploit/unix/ftp/vsftpd_234_backdoor
  set RHOST 192.168.1.101  # A Metasploitable target
  exploit -z
  ```
- [x] VERIFY: You get a session
- [x] Drop back into irb: `irb`
- [x] List the ActiveRecord connections:
  
  ```
  ActiveRecord::Base.connection_pool.instance_variable_get("@reserved_connections").map {|key, val| thread = Thread.list.find {|t| t.object_id == key}; "#{key}: #{thread ? "#{thread[:tm_name]} #{thread.inspect}" : "Unknown" }" }
  ```
- [x] VERIFY: Only one thread exists.
