### PR TITLE
Increase exploit reliability

### DIFF
--- a/modules/exploits/windows/http/intrasrv_bof.rb
+++ b/modules/exploits/windows/http/intrasrv_bof.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				{
 					'Space' => 4660,
 					'StackAdjustment' => -3500,
-					'BadChars' => "\x00"
+					'BadChars' => "\x00\x0d\x0a"
 				},
 			'DefaultOptions'  =>
 				{


### PR DESCRIPTION
From some limited testing, it appears that this exploit is
missing \x0d\x0a in the bad chars. If the generated payload / hunter
or egg contain that combination, it seems to cause reliability issues
and exploitation fails.

The home page for this software can be found at
http://www.leighb.com/intrasrv.htm
