### PR TITLE
Require the powershell mixin explicitly

### DIFF
--- a/modules/exploits/windows/http/oracle_endeca_exec.rb
+++ b/modules/exploits/windows/http/oracle_endeca_exec.rb
@@ -6,6 +6,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/powershell'
 
 class Metasploit3 < Msf::Exploit::Remote
 	Rank = ExcellentRanking


### PR DESCRIPTION
Race condition with requires sometimes produces this error:

```
$ ./msfconsole -L
[-] WARNING! The following modules could not be loaded!
[-]     /home/todb/git/rapid7/metasploit-framework/modules/exploits/windows/http/oracle_endeca_exec.rb:
NameError uninitialized constant Msf::Exploit::Powershell
```

Fixed by explicitly requiring the powerhsell mixin.
## Verification
- [ ] Start `msfconsole`
- [ ] `info exploit/windows/http/oracle_endeca_exec` should produce results.

Note, expressing this bug tends to depend on path load orders, so often will not be triggered (eg, when Metasploit Pro / Community Edition loads, requires tend to be pulled in ahead of time).
