### PR TITLE
Fix "A payload has not been selected."

### DIFF
--- a/modules/exploits/multi/samba/nttrans.rb
+++ b/modules/exploits/multi/samba/nttrans.rb
@@ -34,6 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
 					[ 'URL', 'http://www.samba.org/samba/history/samba-2.2.7a.html' ]
 				],
 			'Privileged'     => true,
+			'Platform'       => 'linux',			
 			'Payload'        =>
 				{
 					'Space'    => 1024,


### PR DESCRIPTION
Since platform definition is missing, exploitation fails.

This small diff fixes it by adding Platform definition.
