### PR TITLE
Prevent datastore corruption on the Auxiliary::AuthBrute mixin

### DIFF
--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -74,6 +74,13 @@ module Auxiliary::AuthBrute
 			initialize_class_variables(this_service,credentials)
 		end
 
+		# Save original datastore values because they are going to be
+		# modified while the credentials.each loop
+		original_values = {
+			'USERNAME' => datastore['USERNAME'],
+			'PASSWORD' => datastore['PASSWORD']
+		}
+
 		credentials.each do |u, p|
 			# Explicitly be able to set a blank (zero-byte) username by setting the
 			# username to <BLANK>. It's up to the caller to handle this if it's not
@@ -137,6 +144,12 @@ module Auxiliary::AuthBrute
 			end
 
 		end
+
+		# Restore the datastore
+		original_values.each do |k, v|
+			datastore[k] = v unless datastore[k] == v
+		end
+
 	end
 
 	def counters_expired?(this_service,credentials)

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -147,7 +147,7 @@ module Auxiliary::AuthBrute
 
 		# Restore the datastore
 		original_values.each do |k, v|
-			datastore[k] = v unless datastore[k] == v
+			datastore[k] = v
 		end
 
 	end


### PR DESCRIPTION
While review of #2267 I've noticed which the Auxiliary::AuthBrute corrupts datastore values (USERNAME and PASSWORD) while the each_user_pass method. Because of that, modules using the mixin can have unexpected behaviour, when using the datastore 'USERNAME' and 'PASSWORD' options after calling each_user_pass.

A sample is the wordpress_login_enum module, check the behavior before this pull request. Even when the PASSWORD option is set, it's not used when "Brute-forcing previously found accounts..." because the PASSWORD datastore option has been modified by the mixin:

```
msf auxiliary(wordpress_login_enum) > set rhosts 192.168.172.162
rhosts => 192.168.172.162
msf auxiliary(wordpress_login_enum) > set URI /wordpress/wp-login.php
URI => /wordpress/wp-login.php
msf auxiliary(wordpress_login_enum) > set PASSWORD admin
PASSWORD => admin
msf auxiliary(wordpress_login_enum) > run

[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=1
[+] http://192.168.172.162:80/wordpress/wp-login.php - Found user 'admin' with id 1
[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=2
[-] http://192.168.172.162:80/wordpress/wp-login.php - Unknown error. HTTP 200
[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=3
[*] http://192.168.172.162:80/wordpress/wp-login.php - No user with id 3 found
[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=4
[*] http://192.168.172.162:80/wordpress/wp-login.php - No user with id 4 found
[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=5
[*] http://192.168.172.162:80/wordpress/wp-login.php - No user with id 5 found
[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=6
[*] http://192.168.172.162:80/wordpress/wp-login.php - No user with id 6 found
[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=7
[*] http://192.168.172.162:80/wordpress/wp-login.php - No user with id 7 found
[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=8
[*] http://192.168.172.162:80/wordpress/wp-login.php - No user with id 8 found
[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=9
[*] http://192.168.172.162:80/wordpress/wp-login.php - No user with id 9 found
[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=10
[*] http://192.168.172.162:80/wordpress/wp-login.php - No user with id 10 found
[*] http://192.168.172.162:80/wordpress/wp-login.php - Usernames stored in: /Users/juan/.msf4/loot/20130828113609_default_192.168.172.162_wordpress.users_616193.txt
[*] 192.168.172.162:80 WORDPRESS - /wordpress/wp-login.php - WordPress Enumeration - Running User Enumeration
[*] http://192.168.172.162:80/wordpress/wp-login.php - WordPress Enumeration - Checking Username:''
[-] 192.168.172.162:80 WORDPRESS - [1/2] - /wordpress/wp-login.php - WordPress Enumeration - Invalid Username: ''
[*] 192.168.172.162:80 WORDPRESS - [2/2] - /wordpress/wp-login.php - WordPress Brute Force - Running Bruteforce
[*] http://192.168.172.162:80/wordpress/wp-login.php - Brute-forcing previously found accounts...
[*] 192.168.172.162:80 WORDPRESS - [2/1] - /wordpress/wp-login.php - WordPress Brute Force - Trying username:'admin' with password:'' <====== VIP, PASSWORD is empty
[-] 192.168.172.162:80 WORDPRESS - [2/1] - /wordpress/wp-login.php - WordPress Brute Force - Failed to login as 'admin'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

```

After this pull request, the PASSWORD option is restored, so the user provided password is user when "Brute-forcing previously found accounts":

```
msf auxiliary(wordpress_login_enum) > set rhosts 192.168.172.162
rhosts => 192.168.172.162
msf auxiliary(wordpress_login_enum) > set URI /wordpress/wp-login.php
URI => /wordpress/wp-login.php
msf auxiliary(wordpress_login_enum) > set PASSWORD admin
PASSWORD => admin
msf auxiliary(wordpress_login_enum) > run

[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=1
[+] http://192.168.172.162:80/wordpress/wp-login.php - Found user 'admin' with id 1
[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=2
[-] http://192.168.172.162:80/wordpress/wp-login.php - Unknown error. HTTP 200
[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=3
[*] http://192.168.172.162:80/wordpress/wp-login.php - No user with id 3 found
[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=4
[*] http://192.168.172.162:80/wordpress/wp-login.php - No user with id 4 found
[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=5
[*] http://192.168.172.162:80/wordpress/wp-login.php - No user with id 5 found
[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=6
[*] http://192.168.172.162:80/wordpress/wp-login.php - No user with id 6 found
[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=7
[*] http://192.168.172.162:80/wordpress/wp-login.php - No user with id 7 found
[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=8
[*] http://192.168.172.162:80/wordpress/wp-login.php - No user with id 8 found
[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=9
[*] http://192.168.172.162:80/wordpress/wp-login.php - No user with id 9 found
[*] http://192.168.172.162:80/wordpress/wp-login.php - Requesting /wordpress/index.php?author=10
[*] http://192.168.172.162:80/wordpress/wp-login.php - No user with id 10 found
[*] http://192.168.172.162:80/wordpress/wp-login.php - Usernames stored in: /Users/juan/.msf4/loot/20130828132248_default_192.168.172.162_wordpress.users_483942.txt
[*] 192.168.172.162:80 WORDPRESS - /wordpress/wp-login.php - WordPress Enumeration - Running User Enumeration
[*] http://192.168.172.162:80/wordpress/wp-login.php - WordPress Enumeration - Checking Username:''
[-] 192.168.172.162:80 WORDPRESS - [1/2] - /wordpress/wp-login.php - WordPress Enumeration - Invalid Username: ''
[*] 192.168.172.162:80 WORDPRESS - [2/2] - /wordpress/wp-login.php - WordPress Brute Force - Running Bruteforce
[*] http://192.168.172.162:80/wordpress/wp-login.php - Brute-forcing previously found accounts...
[*] 192.168.172.162:80 WORDPRESS - [3/2] - /wordpress/wp-login.php - WordPress Brute Force - Trying username:'admin' with password:'admin' <====== VIP
[+] http://192.168.172.162:80/wordpress/wp-login.php - WordPress Brute Force - SUCCESSFUL login for 'admin' : 'admin' <========= VIP 
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

```
