### PR TITLE
Updated wordpress_login_enum auxilary module.

### DIFF
--- a/modules/auxiliary/scanner/http/wordpress_login_enum.rb
+++ b/modules/auxiliary/scanner/http/wordpress_login_enum.rb
@@ -218,6 +218,12 @@ class Metasploit3 < Msf::Auxiliary
 
 			if (res and res.code == 301)
 				uri = URI(res.headers['Location'])
+				if uri.path =~ /\/author\/([[:print:]]+)\//
+					username = $1
+					print_good "#{uri.path} - Found user '#{username}' with id #{i.to_s}"
+					usernames << username
+					next
+				end
 				uri = "#{uri.path}?#{uri.query}"
 				res = send_request_cgi({
 					'method' => 'GET',


### PR DESCRIPTION
Update wordpress_login_enum to work when the wordpress site redirects
to /author/[authorname]/ rather than displaying the author's name in
the page contents.
