### PR TITLE
Check whether systemsetup is actually runnable

### DIFF
--- a/modules/exploits/osx/local/sudo_password_bypass.rb
+++ b/modules/exploits/osx/local/sudo_password_bypass.rb
@@ -108,7 +108,7 @@ class Metasploit3 < Msf::Exploit::Local
 			return Exploit::CheckCode::Safe
 		end
 
-		if not user_in_admin_group? 
+		if not user_in_admin_group?
 			print_error "sudo version is vulnerable, but user is not in the admin group (necessary to change the date)."
 			return Exploit::CheckCode::Safe
 		end

--- a/modules/exploits/osx/local/sudo_password_bypass.rb
+++ b/modules/exploits/osx/local/sudo_password_bypass.rb
@@ -113,10 +113,10 @@ class Metasploit3 < Msf::Exploit::Local
 			return Exploit::CheckCode::Safe
 		end
 
-        if not can_run_systemsetup?
-            print_error "the user is not allowed to run #{SYSTEMSETUP_PATH}"
-            return Exploit::CheckCode::Safe
-        end
+		if not can_run_systemsetup?
+			print_error "the user is not allowed to run #{SYSTEMSETUP_PATH}"
+			return Exploit::CheckCode::Safe
+		end
 
 		# one root for you sir
 		Exploit::CheckCode::Vulnerable
@@ -126,9 +126,9 @@ class Metasploit3 < Msf::Exploit::Local
 		if not user_in_admin_group?
 			fail_with(Exploit::Failure::NotFound, "User is not in the 'admin' group, bailing.")
 		end
-        if not can_run_systemsetup?
-            fail_with(Exploit::Failure::NotFound, "The user can't run #{SYSTEMSETUP_PATH}")
-        end
+		if not can_run_systemsetup?
+			fail_with(Exploit::Failure::NotFound, "The user can't run #{SYSTEMSETUP_PATH}")
+		end
 		# "remember" the current system time/date/network/zone
 		print_good("User is an admin, continuing...")
 
@@ -223,10 +223,10 @@ class Metasploit3 < Msf::Exploit::Local
 		cmd_exec("groups `whoami`").split(/\s+/).include?(SUDOER_GROUP)
 	end
 
-    # checks that the user can run systemsetup
-    def can_run_systemsetup?
-        cmd_exec("#{SYSTEMSETUP_PATH}") != "You need administrator access to run this tool... exiting!"
-    end
+	# checks that the user can run systemsetup
+	def can_run_systemsetup?
+		cmd_exec("#{SYSTEMSETUP_PATH}") != "You need administrator access to run this tool... exiting!"
+	end
 
 	# helper methods for dealing with sudo's vn num
 	def parse_vn(vn_str); vn_str.split(/[\.p]/).map(&:to_i); end

--- a/modules/exploits/osx/local/sudo_password_bypass.rb
+++ b/modules/exploits/osx/local/sudo_password_bypass.rb
@@ -108,10 +108,16 @@ class Metasploit3 < Msf::Exploit::Local
 			return Exploit::CheckCode::Safe
 		end
 
-		if not user_in_admin_group?
+		if not user_in_admin_group? 
 			print_error "sudo version is vulnerable, but user is not in the admin group (necessary to change the date)."
-			Exploit::CheckCode::Safe
+			return Exploit::CheckCode::Safe
 		end
+
+        if not can_run_systemsetup?
+            print_error "the user is not allowed to run #{SYSTEMSETUP_PATH}"
+            return Exploit::CheckCode::Safe
+        end
+
 		# one root for you sir
 		Exploit::CheckCode::Vulnerable
 	end
@@ -120,6 +126,9 @@ class Metasploit3 < Msf::Exploit::Local
 		if not user_in_admin_group?
 			fail_with(Exploit::Failure::NotFound, "User is not in the 'admin' group, bailing.")
 		end
+        if not can_run_systemsetup?
+            fail_with(Exploit::Failure::NotFound, "The user can't run #{SYSTEMSETUP_PATH}")
+        end
 		# "remember" the current system time/date/network/zone
 		print_good("User is an admin, continuing...")
 
@@ -213,6 +222,11 @@ class Metasploit3 < Msf::Exploit::Local
 	def user_in_admin_group?
 		cmd_exec("groups `whoami`").split(/\s+/).include?(SUDOER_GROUP)
 	end
+
+    # checks that the user can run systemsetup
+    def can_run_systemsetup?
+        cmd_exec("#{SYSTEMSETUP_PATH}") != "You need administrator access to run this tool... exiting!"
+    end
 
 	# helper methods for dealing with sudo's vn num
 	def parse_vn(vn_str); vn_str.split(/[\.p]/).map(&:to_i); end


### PR DESCRIPTION
On my system (10.8.4) I pass the admin check, but still fail to run systemsetup.
$ /usr/sbin/systemsetup
You need administrator access to run this tool... exiting!

Added a check for this.

Also made user_in_admin_group in "check" return Exploit::CheckCode::Safe, which it didn't do before and I assume it was supposed to.
