### PR TITLE
Add the require boilerplate

### DIFF
--- a/modules/exploits/osx/local/sudo_password_bypass.rb
+++ b/modules/exploits/osx/local/sudo_password_bypass.rb
@@ -5,6 +5,11 @@
 #
 # http://metasploit.com/
 ##
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/common'
+require 'msf/core/post/file'
+require 'msf/core/exploit/exe'
 require 'shellwords'
 
 class Metasploit3 < Msf::Exploit::Local


### PR DESCRIPTION
Fixes a bug that sometimes comes up with load order on this module. I
know @jlee-r7 is working on a better overall solution but this should
solve for the short term. I'm happy to race.

Note, since the problem is practically machine-specific. @jlee-r7
suggested rm'ing all modules but the one under test. Doing that exposes
the bug, and I've verified this fix in that way.
### Verification
- [ ] `rm -rf modules/exploits/* modules/auxiliary/* modules/post/*`
- [ ] `git checkout upstream/pr/2303 modules/exploits/osx/local/sudo_password_bypass.rb`
- [ ] `./msfcli exploit/osx/local/sudo_password_bypass S`

Should load fine. If you instead `git checkout upstream/master modules/exploits/osx/local/sudo_password_bypass.rb` right now, you should hit the load error.
