### PR TITLE
Fix three minor issues in the Python Meterpreter

### DIFF
--- a/data/meterpreter/ext_server_stdapi.py
+++ b/data/meterpreter/ext_server_stdapi.py
@@ -303,6 +303,7 @@ def channel_create_stdapi_fs_file(request, response):
 	fmode = packet_get_tlv(request, TLV_TYPE_FILE_MODE)
 	if fmode:
 		fmode = fmode['value']
+		fmode = fmode.replace('bb', 'b')
 	else:
 		fmode = 'rb'
 	file_h = open(fpath, fmode)
@@ -320,6 +321,7 @@ def channel_create_stdapi_net_tcp_client(request, response):
 	connected = False
 	for i in range(retries + 1):
 		sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+		sock.settimeout(3.0)
 		if local_host.get('value') and local_port.get('value'):
 			sock.bind((local_host['value'], local_port['value']))
 		try:
@@ -380,7 +382,7 @@ def stdapi_sys_process_execute(request, response):
 	if len(cmd) == 0:
 		return ERROR_FAILURE, response
 	if os.path.isfile('/bin/sh'):
-		args = ['/bin/sh', '-c', cmd, raw_args]
+		args = ['/bin/sh', '-c', cmd + ' ' + raw_args]
 	else:
 		args = [cmd]
 		args.extend(shlex.split(raw_args))

--- a/data/meterpreter/meterpreter.py
+++ b/data/meterpreter/meterpreter.py
@@ -404,5 +404,7 @@ class PythonMeterpreter(object):
 		return resp
 
 if not hasattr(os, 'fork') or (hasattr(os, 'fork') and os.fork() == 0):
+	if hasattr(os, 'setsid'):
+		os.setsid()
 	met = PythonMeterpreter(s)
 	met.run()


### PR DESCRIPTION
This fixes three issues in the Python Meterpreter:
- Work around the second 'b' being appended when files are opened in binary mode on Windows (this was pointed out by @Meatballs1 and seems to be an issue originating from https://github.com/rapid7/metasploit-framework/blob/master/lib/rex/post/meterpreter/channels/pools/file.rb#L44)
- Set the socket timeout to the more reasonable value of 3.0 seconds to avoid meterpreter timing out
- Call os.setsid() when it's available, presumably on Unix/Linux systems to start a new session
