### PR TITLE
Add the missing CVE reference

### DIFF
--- a/modules/exploits/windows/local/novell_client_nicm.rb
+++ b/modules/exploits/windows/local/novell_client_nicm.rb
@@ -62,6 +62,7 @@ class Metasploit3 < Msf::Exploit::Local
 				},
 			'References'     =>
 				[
+					[ 'CVE',  '2013-3956' ],
 					[ 'OSVDB', '93718' ],
 					[ 'URL', 'http://www.novell.com/support/kb/doc.php?id=7012497' ],
 					[ 'URL', 'http://pastebin.com/GB4iiEwR' ]


### PR DESCRIPTION
Was looking at all the 2013 exploit modules for missing CVE references
