### PR TITLE
Msftidy: use binary on File.open always

### DIFF
--- a/modules/post/osx/capture/keylog_recorder.rb
+++ b/modules/post/osx/capture/keylog_recorder.rb
@@ -113,7 +113,7 @@ class Metasploit3 < Msf::Post
 								"keylog", "text/plain", session, log, "keylog.log", "OSX keylog"
 							)
 						else
-							File.open(self.loot_path, 'a') { |f| f.write(log) }
+							File.open(self.loot_path, 'ab') { |f| f.write(log) }
 						end
 						print_status(log_a.map{ |a| a=~/([^\s]+)\s*$/; $1 }.join)
 						print_status "Saved to #{self.loot_path}"


### PR DESCRIPTION
msftidy is complaining, here:

keylog_recorder.rb:116 - [WARNING] File.open without binary mode

Not sure how this managed to hit upstream/master with msftidy warnings.
Protip, use an msftidy pre-commit hook. We have just such a hook script
in tools/dev, as a matter of fact, so it's just a symlink away:

https://github.com/rapid7/metasploit-framework/blob/master/tools/dev/pre-commit-hook.rb
