### PR TITLE
Retab should optionally keep local backups

### DIFF
--- a/tools/dev/retab.rb
+++ b/tools/dev/retab.rb
@@ -4,19 +4,32 @@
 # Replace leading tabs with 2-width spaces.
 # I'm sure there's a sed/awk/perl oneliner that's
 # a million times better but this is more readable for me.
+# 
+# Usage:
+# metasploit-framework$ ./tools/dev/retab.rb [path]
+#
+# If local backups are desired, prepend with "MSF_RETAB_BACKUPS" set,
+# like so:
+# metasploit-framework$ MSF_RETAB_BACKUPS=1 ./tools/dev/retab.rb [path]
 
 require 'fileutils'
 require 'find'
 
 dir = ARGV[0] || "."
+keep_backups = !!(ENV['MSF_RETAB_BACKUPS'] || ENV['MSF_RETAB_BACKUP'])
+puts "Keeping .notab backups" if keep_backups
+
 raise ArgumentError, "Need a filename or directory" unless (dir and File.readable? dir)
 
 Find.find(dir) do |infile|
   next unless File.file? infile
   next unless infile =~ /rb$/
 outfile = infile
-backup = "#{infile}.notab"
-FileUtils.cp infile, backup
+
+if keep_backups
+  backup = "#{infile}.notab"
+  FileUtils.cp infile, backup
+end
 
 data = File.open(infile, "rb") {|f| f.read f.stat.size}
 fixed = []


### PR DESCRIPTION
Local backups are generally not needed since you can just git checkout
old versions anyway before committing. It was nice to have during dev
but generally shouldn't be done now.

This also adds some usage comment docs.
