### PR TITLE
Disable default sorting on MSSQL results

### DIFF
--- a/lib/msf/core/exploit/mssql.rb
+++ b/lib/msf/core/exploit/mssql.rb
@@ -694,9 +694,10 @@ module Exploit::Remote::MSSQL
     if(info[:rows] and not info[:rows].empty?)
 
       tbl = Rex::Ui::Text::Table.new(
-        'Indent'  => 1,
-        'Header'  => "",
-        'Columns' => info[:colnames]
+        'Indent'    => 1,
+        'Header'    => "",
+        'Columns'   => info[:colnames],
+        'SortIndex' => -1
       )
 
       info[:rows].each do |row|


### PR DESCRIPTION
When printing output using the `mssql_print_reply`, the output gets sorted by default by the first column. This can distort the output, especially when the row order is crucial like in case of executing external commands with `mssql_xpcmdshell`.

This patch disables sorting by initializing Rex::Ui::Text::Table with SortIndex = -1.
