### PR TITLE
Grammar fixes in descriptions

### DIFF
--- a/modules/exploits/windows/http/hp_sitescope_runomagentcommand.rb
+++ b/modules/exploits/windows/http/hp_sitescope_runomagentcommand.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Exploit::Remote
         The vulnerability exists on the opcactivate.vbs script, which
         is reachable from the APIBSMIntegrationImpl AXIS service, and
         uses WScript.Shell.run() to execute cmd.exe with user provided
-        data. Note which the opcactivate.vbs component is installed
+        data. Note that the opcactivate.vbs component is installed
         with the (optional) HP Operations Agent component. The module
         has been tested successfully on HP SiteScope 11.20 (with HP
         Operations Agent) over Windows 2003 SP2.

--- a/modules/post/multi/escalate/cups_root_file_read.rb
+++ b/modules/post/multi/escalate/cups_root_file_read.rb
@@ -23,12 +23,8 @@ class Metasploit3 < Msf::Post
         Error Log page in the web interface, the cupsd daemon (running with setuid root)
         reads the Error Log path and echoes it as plaintext.
 
-        This module is known to work on:
-
-        - Mac OS X < 10.8.4
-        - Ubuntu Desktop <= 12.0.4
-
-        ...as long as the session is in the lpadmin group.
+        This module is known to work on Mac OS X < 10.8.4 and Ubuntu Desktop <= 12.0.4
+        as long as the session is in the lpadmin group.
 
         Warning: if the user has set up a custom path to the CUPS error log,
         this module might fail to reset that path correctly. You can specify

--- a/modules/post/windows/capture/lockout_keylogger.rb
+++ b/modules/post/windows/capture/lockout_keylogger.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Post
       'Name'         => 'Windows Capture Winlogon Lockout Credential Keylogger',
       'Description'  => %q{
           This module migrates and logs Microsoft Windows user's passwords via
-          Winlogon.exe. Using idle time and natural system changes to give a
+          Winlogon.exe using idle time and natural system changes to give a
           false sense of security to the user.},
       'License'      => MSF_LICENSE,
       'Author'       => [ 'mubix', 'cg' ],


### PR DESCRIPTION
Fixup on grammar for recently touched modules:
- modules/exploits/windows/http/hp_sitescope_runomagentcommand.rb
- modules/post/multi/escalate/cups_root_file_read.rb
- modules/post/windows/capture/lockout_keylogger.rb
