### PR TITLE
Fix Android payload certificate issue

### DIFF
--- a/modules/payloads/stagers/android/reverse_tcp.rb
+++ b/modules/payloads/stagers/android/reverse_tcp.rb
@@ -74,7 +74,8 @@ module Metasploit3
     # requirement. You can not upload an application if it is signed
     # with a key whose validity expires before that date.
     # """
-    cert.not_after = cert.not_before + 3600*24*365*20 # 20 years
+    # The timestamp 0x78045d81 equates to 2033-10-22 00:00:01 UTC
+    cert.not_after = Time.at( 0x78045d81  + ( 0x7fffffff - 0x78045d81 ))
 
     jar.sign(key, cert, [cert])
 

--- a/modules/payloads/stagers/android/reverse_tcp.rb
+++ b/modules/payloads/stagers/android/reverse_tcp.rb
@@ -75,7 +75,7 @@ module Metasploit3
     # with a key whose validity expires before that date.
     # """
     # The timestamp 0x78045d81 equates to 2033-10-22 00:00:01 UTC
-    cert.not_after = Time.at( 0x78045d81  + ( 0x7fffffff - 0x78045d81 ))
+    cert.not_after = Time.at( 0x78045d81  + rand( 0x7fffffff - 0x78045d81 ))
 
     jar.sign(key, cert, [cert])
 


### PR DESCRIPTION
There is a narrow range of time values that are after October 22nd, 2022 and before the signed 32-bit wrap time. This commit ensures that a valid timestamp is selected that will not represent a Bignum and throw an error on Java and Win32 versions of Ruby.
