### PR TITLE
cmd_db_connect: Expand path to database config

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1546,7 +1546,8 @@ class Db
         return
       end
       file = args[1] || ::File.join(Msf::Config.get_config_root, "database.yml")
-      if (::File.exists? ::File.expand_path(file))
+      file = ::File.expand_path(file)
+      if (::File.exists? file)
         db = YAML.load(::File.read(file))['production']
         framework.db.connect(db)
 


### PR DESCRIPTION
Do not only check whether the expanded path for the database config file
exists, but also use it.
