### PR TITLE
Fix loading post modules in test/modules/ 

### DIFF
--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -1,4 +1,5 @@
 
+$:.push "test/lib" unless $:.include? "test/lib"
 require 'module_test'
 
 #load 'test/lib/module_test.rb'

--- a/test/modules/post/test/railgun_reverse_lookups.rb
+++ b/test/modules/post/test/railgun_reverse_lookups.rb
@@ -1,6 +1,3 @@
-##
-# $Id$
-##
 
 ##
 # This file is part of the Metasploit Framework and may be subject to
@@ -13,6 +10,9 @@ require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/railgun'
 
+$:.push "test/lib" unless $:.include? "test/lib"
+require 'module_test'
+
 class Metasploit3 < Msf::Post
 
 	include Msf::ModuleTest::PostTest
@@ -24,7 +24,6 @@ class Metasploit3 < Msf::Post
 				'Description'   => %q{ This module will test railgun code used in post modules},
 				'License'       => MSF_LICENSE,
 				'Author'        => [ 'kernelsmith'],
-				'Version'       => '$Revision$',
 				'Platform'      => [ 'windows' ]
 			))
 

--- a/test/modules/post/test/registry.rb
+++ b/test/modules/post/test/registry.rb
@@ -1,9 +1,5 @@
 
 ##
-# $Id$
-##
-
-##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # Framework web site for more information on licensing and terms of use.
@@ -13,6 +9,9 @@
 require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/registry'
+
+$:.push "test/lib" unless $:.include? "test/lib"
+require 'module_test'
 
 class Metasploit3 < Msf::Post
 
@@ -28,7 +27,6 @@ class Metasploit3 < Msf::Post
 					'kernelsmith', # original
 					'egypt',       # PostTest conversion
 				],
-				'Version'       => '$Revision$',
 				'Platform'      => [ 'windows' ]
 			))
 	end

--- a/test/modules/post/test/services.rb
+++ b/test/modules/post/test/services.rb
@@ -6,6 +6,9 @@ require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/services'
 
+$:.push "test/lib" unless $:.include? "test/lib"
+require 'module_test'
+
 class Metasploit3 < Msf::Post
 
 	include Msf::Post::Windows::Services

--- a/test/modules/post/test/unix.rb
+++ b/test/modules/post/test/unix.rb
@@ -1,5 +1,6 @@
 
-require 'test/lib/module_test'
+$:.push "test/lib" unless $:.include? "test/lib"
+require 'module_test'
 
 #load 'test/lib/module_test.rb'
 #load 'lib/rex/text.rb'
@@ -15,11 +16,10 @@ class Metasploit4 < Msf::Post
 
 	def initialize(info={})
 		super( update_info( info,
-				'Name'          => 'Testing remote unix system manipulation',
+				'Name'          => 'Testing Remote Unix System Manipulation',
 				'Description'   => %q{ This module will test Post::File API methods },
 				'License'       => MSF_LICENSE,
 				'Author'        => [ 'egypt'],
-				'Version'       => '$Revision$',
 				'Platform'      => [ 'linux', 'java' ],
 				'SessionTypes'  => [ 'meterpreter', 'shell' ]
 			))

--- a/test/scripts/test-sessions.rc
+++ b/test/scripts/test-sessions.rc
@@ -1,0 +1,33 @@
+<% old_mod = active_module %>
+
+sessions -v
+
+<ruby>
+def run_for_session(modname, id)
+  print_line(modname)
+  run_single("use #{modname}")
+  run_single("set SESSION #{id}")
+  run_single("run")
+end
+
+framework.sessions.each do |id, s|
+  if s.type == 'meterpreter'
+    run_for_session("post/test/meterpreter", id)
+
+    if s.sys.config.sysinfo["OS"] =~ /win/in
+      run_for_session("post/test/registry", id)
+      run_for_session("post/test/services", id)
+    else
+      run_for_session("post/test/unix", id)
+    end
+
+    if s.railgun
+      run_for_session("post/test/railgun_reverse_lookups", id)
+    end
+  end
+  run_for_session("post/test/file", id)
+end
+</ruby>
+
+<%= old_mod ? "use #{old_mod.refname}" : "back" %>
+


### PR DESCRIPTION
This has annoyed me for awhile, finally got around to tracking it down.
## Verification before
- [x] `loadpath test/modules`, see 2 post modules get loaded
- [x] `loadpath test/modules` again, see 3 more
## Verification after
- [x] `loadpath test/modules`, see 6 post modules
