### PR TITLE
Update meterpreter.rb (Meterpreter Error: Uninitialized Constant Error Prevents a 32bit Meterpreter session from migrating to a 64bit)

### DIFF
--- a/modules/payloads/stages/windows/meterpreter.rb
+++ b/modules/payloads/stages/windows/meterpreter.rb
@@ -8,7 +8,9 @@
 
 require 'msf/core'
 require 'msf/core/payload/windows/reflectivedllinject'
+require 'msf/core/payload/windows/x64/reflectivedllinject'
 require 'msf/base/sessions/meterpreter_x86_win'
+require 'msf/base/sessions/meterpreter_x64_win'
 require 'msf/base/sessions/meterpreter_options'
 
 ###


### PR DESCRIPTION
Meterpreter Error: Uninitialized Constant Error Prevents a 32bit Meterpreter session from migrating to a 64bit process.
Discovered: September 9th 2013
Fixed: September 11th 2013 By MosDefAssassin
Contact: ara1212@gmail.com
Tested Against Windows 2008 R2 SP1 Running as a Domain Controller

Issue:
An issue has been discovered when you have created a simple 32bit windows/meterpreter/reverse_tcp payload and have launched the payload on the victim to obtain a remote meterpreter session. While in this session you attempt to migrate your 32bit process over to a 64bit process in order to take advantage of tools like hashdump or mimikatz or obtain system level access under a 64bit process that runs as system such as dns.exe. However when you attempt to migrate to a 64bit process you receive the following error:

Error running command migrate: NameError uninitialized constant Msf::Payload::Windows::ReflectiveDllInject_x64

Cause and Resolution:
This issue occurs because the meterpreter.rb file that is being called from within
“/opt/metasploit/apps/pro/msf3/modules/payloads/stages/windows/” folder
does not contain the following classes:
require 'msf/core/payload/windows/x64/reflectivedllinject'
require 'msf/base/sessions/meterpreter_x64_win'
Once you add these two classes to the meterpreter.rb file, you will be able to migrate to 64bit processes from a basic msfpayload generated 32bit meterpreter payload.
