### PR TITLE
Deprecate windows persistence post module in favor of local exploit module

### DIFF
--- a/modules/post/windows/manage/persistence.rb
+++ b/modules/post/windows/manage/persistence.rb
@@ -16,7 +16,7 @@ require 'msf/core/post/windows/services'
 class Metasploit3 < Msf::Post
   require 'msf/core/module/deprecated'
   include Msf::Module::Deprecated
-  deprecated Date.new(2013, 11, 12), '/exploit/windows/local/persistence'
+  deprecated Date.new(2013, 11, 12), 'exploit/windows/local/persistence'
 
   include Msf::Post::Common
   include Msf::Post::File

--- a/modules/post/windows/manage/persistence.rb
+++ b/modules/post/windows/manage/persistence.rb
@@ -14,6 +14,9 @@ require 'msf/core/post/windows/registry'
 require 'msf/core/post/windows/services'
 
 class Metasploit3 < Msf::Post
+  require 'msf/core/module/deprecated'
+  include Msf::Module::Deprecated
+  deprecated Date.new(2013, 11, 12), '/exploit/windows/local/persistence'
 
   include Msf::Post::Common
   include Msf::Post::File


### PR DESCRIPTION
Deprecation date set as Nov 12, 2013. Verification steps:

```
> use post/windows/manage/persistence
> set LHOST 1.1.1.1
> set LPORT 5555
> set SESSION 1
> run
```
- [x] Ensure that you get a large "This module is deprecated" banner in the console output
