### PR TITLE
Update retab util

### DIFF
--- a/tools/dev/retab.rb
+++ b/tools/dev/retab.rb
@@ -24,33 +24,33 @@ raise ArgumentError, "Need a filename or directory" unless (dir and File.readabl
 Find.find(dir) do |infile|
   next unless File.file? infile
   next unless infile =~ /rb$/
-outfile = infile
+  outfile = infile
 
-if keep_backups
-  backup = "#{infile}.notab"
-  FileUtils.cp infile, backup
-end
-
-data = File.open(infile, "rb") {|f| f.read f.stat.size}
-fixed = []
-data.each_line do |line|
-  fixed << line
-  next unless line =~ /^\x09/
-  index = []
-  i = 0
-  line.each_char do |char|
-    break unless char =~ /[\x20\x09]/
-    index << i if char == "\x09"
-    i += 1
+  if keep_backups
+    backup = "#{infile}.notab"
+    FileUtils.cp infile, backup
   end
-  index.reverse.each do |idx|
-    line[idx] = "  "
-  end
-  fixed[-1] = line
-end
 
-fh = File.open(outfile, "wb")
-fh.write fixed.join
-fh.close
-puts "Retabbed #{fh.path}"
+  data = File.open(infile, "rb") {|f| f.read f.stat.size}
+  fixed = []
+  data.each_line do |line|
+    fixed << line
+    next unless line =~ /^\x09/
+    index = []
+    i = 0
+    line.each_char do |char|
+      break unless char =~ /[\x20\x09]/
+      index << i if char == "\x09"
+      i += 1
+    end
+    index.reverse.each do |idx|
+      line[idx] = "  "
+    end
+    fixed[-1] = line
+  end
+
+  fh = File.open(outfile, "wb")
+  fh.write fixed.join
+  fh.close
+  puts "Retabbed #{fh.path}"
 end

--- a/tools/dev/retab.rb
+++ b/tools/dev/retab.rb
@@ -21,9 +21,23 @@ puts "Keeping .notab backups" if keep_backups
 
 raise ArgumentError, "Need a filename or directory" unless (dir and File.readable? dir)
 
+def is_ruby?(fname)
+  file_util = ""
+  begin
+    file_util = %x{which file}.to_s.chomp
+  rescue Errno::ENOENT
+  end
+  if File.executable? file_util
+    file_fingerprint = %x{#{file_util} #{fname}}
+    !!(file_fingerprint =~ /Ruby script/)
+  else
+    !!(fname =~ /\.rb$/)
+  end
+end
+
 Find.find(dir) do |infile|
   next unless File.file? infile
-  next unless infile =~ /rb$/
+  next unless is_ruby? infile
   outfile = infile
 
   if keep_backups

--- a/tools/dev/retab.rb
+++ b/tools/dev/retab.rb
@@ -22,6 +22,7 @@ puts "Keeping .notab backups" if keep_backups
 raise ArgumentError, "Need a filename or directory" unless (dir and File.readable? dir)
 
 def is_ruby?(fname)
+  return true if fname =~ /\.rb$/
   file_util = ""
   begin
     file_util = %x{which file}.to_s.chomp
@@ -30,8 +31,6 @@ def is_ruby?(fname)
   if File.executable? file_util
     file_fingerprint = %x{#{file_util} #{fname}}
     !!(file_fingerprint =~ /Ruby script/)
-  else
-    !!(fname =~ /\.rb$/)
   end
 end
 


### PR DESCRIPTION
For `retab.rb`, Instead of just relying on a filename of *.rb, use a file utility to determine file type.

For systems that lack 'which' and 'file', fall back to filename matching.

This is useful for retabbing things like 'msfconsole' that don't have a .rb extension.
## Verification

This will demonstrate that retabbing works sensibly for .rb files, files that do parse out as Ruby, and will avoid retabbing non-Ruby files.
### Check that files that parse out as Ruby get retabbed:
- [x] In the framework top-level, `tools/dev/retab.rb msfconsole`
- [x] See the return message, `Retabbed msfconsole`
- [x] `git checkout -- msfconsole` to avoid committing a retabbed msfconsole with this.
### Check that files that end in .rb get retabbed (assumes it's ruby and doesn't bother testing)
- [x] `echo hello world > test.rb`
- [x] 'tools/dev/retab.rb test.rb`
- [x] See the result message, `Retabbed test.rb`
- [x] `rm test.rb` to clean up your top level dir.
### Check that files that are not  parse out as Ruby get retabbed:
- [x] `tools/dev/retab.rb data/vncdll.dll`
- [x] See no return message.
- [x] `git status data/` to see that there are no changes.

Once this PR lands, @tabassassin can then retab all of Metasploit without having to name specific files or directories. This will pick up spec, top-level utilities, external libraries, data, etc.
