### PR TITLE
Fix migrate from 32- to 64-bit processes

### DIFF
--- a/lib/msf/core/payload/windows.rb
+++ b/lib/msf/core/payload/windows.rb
@@ -12,8 +12,20 @@ require 'msf/core'
 module Msf::Payload::Windows
 
   require 'msf/core/payload/windows/prepend_migrate'
+
   # Provides the #prepends method
+  # XXX: For some unfathomable reason, the order of requires here is
+  # important. If this include happens after require'ing the files
+  # below, it causes the windows/exec payload (and probably others) to
+  # somehow not have PrependMigrate despite having Payload::Windows,
+  # which leads to a NoMethodError on #prepends
   include Msf::Payload::Windows::PrependMigrate
+
+  require 'msf/core/payload/windows/dllinject'
+  require 'msf/core/payload/windows/exec'
+  require 'msf/core/payload/windows/loadlibrary'
+  require 'msf/core/payload/windows/reflectivedllinject'
+  require 'msf/core/payload/windows/x64/reflectivedllinject'
 
   #
   # ROR hash associations for some of the exit technique routines.

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -4,6 +4,9 @@
 require 'rex/post/meterpreter/packet'
 require 'rex/post/meterpreter/extension'
 require 'rex/post/meterpreter/client'
+
+# Used to generate a reflective DLL when migrating. This is yet another
+# argument for moving the meterpreter client into the Msf namespace.
 require 'msf/core/payload/windows'
 
 module Rex


### PR DESCRIPTION
In some cases, it was possible to end up in a situation where the x64
reflective library hadn't been loaded by the time a user typed migrate.
If the target process was 64-bit, msfconsole would error out with a
NoMethodError and much sadness would ensue.

[See #2356]

I would love to have confirmation from @MosDefAssassin that this works.
