### PR TITLE
Extend Travis's depth a bit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ notifications:
   irc: "irc.freenode.org#msfnotify"
 
 git:
-  depth: 1
+  depth: 5


### PR DESCRIPTION
Instead of depth=1, try depth=5. This way, if something gets landed
before travis had a chance to build, it'll still get tested, at least
post-facto.

This is the root cause of the build failure at

https://travis-ci.org/rapid7/metasploit-framework/builds/11436293

That commit is not available because the HEAD pointer moved past it with
the next commit; IOW, we landed too quick for Travis to rspec each
change, which is generating failed build messages.

If there was really a failure in there, it'd be a pain now to determine
which commit actually broke the build.
