### PR TITLE
Add requires to portproxy

### DIFF
--- a/modules/post/windows/manage/portproxy.rb
+++ b/modules/post/windows/manage/portproxy.rb
@@ -5,6 +5,10 @@
 #   http://metasploit.com/framework/
 ##
 
+require 'msf/core'
+require 'msf/core/post/windows/priv'
+require 'msf/core/post/common'
+
 class Metasploit3 < Msf::Post
 
   include Msf::Post::Windows::Priv


### PR DESCRIPTION
TheColonial spotted it:

```
18:11 < TheColonial> Is anyone seeing this on MSF/master:
18:11 < TheColonial> [-] WARNING! The following modules could not be loaded!
18:11 < TheColonial> [-]     /home/oj/code/metasploit-framework/modules/post/windows/manage/portproxy.rb: NameError uninitialized 
                     constant Msf::Post::Windows

```

Hope this pull request fixes the problem until #2354 is landed
