### PR TITLE
Clear report_data on each host report

### DIFF
--- a/lib/rex/parser/foundstone_nokogiri.rb
+++ b/lib/rex/parser/foundstone_nokogiri.rb
@@ -55,6 +55,7 @@ module Rex
         end
         # Reset the state once we close a host
         @state.delete_if {|k| k != :current_tag}
+        @report_data = {:wspace => args[:wspace]}
       when "Port"
         @state[:has_text] = false
         collect_port


### PR DESCRIPTION
## Verification
- [x] Grab a recent Foundstone Network Inventory XML report
- [x] Create a test workspace.
- [x] Edit the xml to add a service on the first host that is unique to that host. E.g., remove any <Service /> with <Port>22</Port> except for on the first.
### Expected result:

Before the fix, you will see the same unique service added to every host.

After the fix, that unique service will stick to that one host (as you'd expect)
