### PR TITLE
Include the post requires until #2354 lands

### DIFF
--- a/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
+++ b/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
@@ -9,6 +9,7 @@ require 'msf/core'
 require 'rex'
 require 'msf/core/exploit/exe'
 require 'msf/core/exploit/powershell'
+require 'msf/core/post/file'
 
 class Metasploit3 < Msf::Exploit::Local
   Rank = ExcellentRanking


### PR DESCRIPTION
Another one that needs the manual require. See #2354, which will solve this once and for all on Sep 24,2013.

In the meantime, **please** ensure that if you're using `Msf::Post` mixins, you require the appropriate mixin **in the module**.
## Verification

Set up a test branch. Don't ever land this branch upstream since it's destructive.
- [x] `git checkout upstream-master`
- [x] `git checkout -b test-2354` # Don't land this branch since you're deleting stuff.
- [x] `git rm -rf modules/post/*`
- [x] `git commit -m "Never land this"`

Test the failure condition:
- [x] `git checkout upstream-master modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb`
- [x] See the error on loading as reported by d0rmous3: http://pastebin.com/8XaJxbdz

Test the fix:
- [x] `git fetch upstream`
- [x] `git checkout upstream/pr/2394 modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb`
- [x] See no error.
- [x] Get info on the module: `msf > info exploit/windows/local/ms13_005_hwnd_broadcast`

Switch back to master, and then land this PR as normal.
