### PR TITLE
Missing require statement in current_user_psexec.rb

### DIFF
--- a/modules/exploits/windows/local/current_user_psexec.rb
+++ b/modules/exploits/windows/local/current_user_psexec.rb
@@ -9,6 +9,7 @@ require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/services'
 require 'msf/core/post/common'
+require 'msf/core/exploit/powershell'
 require 'msf/core/post/file'
 require 'msf/core/exploit/exe'
 


### PR DESCRIPTION
The module/exploit/windows/local/current_user_psexec.rb file missing the require statement at the top and include the powershell gem which results in an uninitialized powershell error. 
