### PR TITLE
Get rid of callcc

### DIFF
--- a/lib/rex/sync/event.rb
+++ b/lib/rex/sync/event.rb
@@ -61,22 +61,12 @@ class Event
   # Waits for the event to become signaled.  Timeout is measured in
   # seconds.  Raises TimeoutError if the condition does not become signaled.
   #
-
-  begin
-    # XXX: we need to replace this code
-    #      continuations slow down YARV
-    require "continuation" if not defined? callcc
-  rescue ::LoadError
-  end
-
   def wait(t = Infinite)
-    callcc { |ctx|
-      self.mutex.synchronize {
-        ctx.call if (self.state == true)
+    self.mutex.synchronize {
+      break if (self.state == true)
 
-        Timeout.timeout(t) {
-          self.cond.wait(self.mutex)
-        }
+      Timeout.timeout(t) {
+        self.cond.wait(self.mutex)
       }
     }
 


### PR DESCRIPTION
When a handler is receiving a bunch of connections all at once, sometimes you get deadlock exceptions, causing all manner of trouble.

I'm pretty sure this patch fixes the issue, but it is in core code that hasn't been touched in years, it is critical to session creation, and callcc is inherently kinda weird anyway, so I'd really love some more eyeballs on this.

See https://dev.metasploit.com/redmine/issues/8407
