### PR TITLE
Prefer Ruby style for single word collections

### DIFF
--- a/modules/exploits/hpux/lpd/cleanup_exec.rb
+++ b/modules/exploits/hpux/lpd/cleanup_exec.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://archives.neohapsis.com/archives/hp/2002-q3/0064.html'],
 
         ],
-      'Platform'       => [ 'unix', 'hpux' ],
+      'Platform'       => %w{ hpux unix },
       'Arch'           => ARCH_CMD,
       'Payload'        =>
         {

--- a/modules/exploits/irix/lpd/tagprinter_exec.rb
+++ b/modules/exploits/irix/lpd/tagprinter_exec.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['URL',   'http://www.lsd-pl.net/code/IRIX/irx_lpsched.c'],
         ],
       'Privileged'     => false,
-      'Platform'       => ['unix', 'irix'],
+      'Platform'       => %w{ irix unix },
       'Arch'           => ARCH_CMD,
       'Payload'        =>
         {

--- a/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => 'Mar 05 2013',
       'Privileged'     => true,
-      'Platform'       => ['linux','unix'],
+      'Platform'       => %w{ linux unix },
       'Payload'        =>
         {
           'DisableNops' => true

--- a/modules/exploits/linux/http/dlink_dir615_up_exec.rb
+++ b/modules/exploits/linux/http/dlink_dir615_up_exec.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => 'Feb 07 2013',
       'Privileged'     => true,
-      'Platform'       => ['linux','unix'],
+      'Platform'       => %w{ linux unix },
       'Payload'        =>
         {
           'DisableNops' => true

--- a/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => 'Jul 05 2013',
       'Privileged'     => true,
-      'Platform'       => ['linux','unix'],
+      'Platform'       => %w{ linux unix },
       'Payload'        =>
         {
           'DisableNops' => true,

--- a/modules/exploits/linux/http/dolibarr_cmd_exec.rb
+++ b/modules/exploits/linux/http/dolibarr_cmd_exec.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'PayloadType' => 'cmd'
         },
-      'Platform'       => ['unix', 'linux'],
+      'Platform'       => %w{ linux unix },
       'Targets'        =>
         [
           # Older versions are probably also vulnerable according to

--- a/modules/exploits/linux/http/dreambox_openpli_shell.rb
+++ b/modules/exploits/linux/http/dreambox_openpli_shell.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://openpli.org/wiki/Webif' ],
           [ 'URL', 'http://www.s3cur1ty.de/m1adv2013-007' ]
         ],
-      'Platform'	   => ['unix', 'linux'],
+      'Platform'	   => %w{ linux unix },
       'Arch'         => ARCH_CMD,
       'Privileged'   => true,
       'Payload'      =>

--- a/modules/exploits/linux/http/groundwork_monarch_cmd_exec.rb
+++ b/modules/exploits/linux/http/groundwork_monarch_cmd_exec.rb
@@ -51,7 +51,7 @@ class Metasploit3 < Msf::Exploit::Remote
           # Based on the default Ubuntu 10.04 VM appliance
           'RequiredCmd' => 'generic telnet netcat perl python'
         },
-      'Platform'       => ['unix', 'linux'],
+      'Platform'       => %w{ linux unix },
       'Targets'        =>
         [
           ['GroundWork 6.7.0', {}]

--- a/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => 'Feb 05 2013',
       'Privileged'     => true,
-      'Platform'       => ['linux','unix'],
+      'Platform'       => %w{ linux unix },
       'Payload'        =>
         {
           'DisableNops' => true

--- a/modules/exploits/linux/http/linksys_wrt160nv2_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt160nv2_apply_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => 'Feb 11 2013',
       'Privileged'     => true,
-      'Platform'       => ['linux','unix'],
+      'Platform'       => %w{ linux unix },
       'Payload'        =>
         {
           'DisableNops' => true

--- a/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => 'Jan 18 2013',
       'Privileged'     => true,
-      'Platform'       => ['linux','unix'],
+      'Platform'       => %w{ linux unix },
       'Payload'	=>
         {
           'DisableNops' => true

--- a/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => 'Feb 06 2013',
       'Privileged'     => true,
-      'Platform'       => ['linux','unix'],
+      'Platform'       => %w{ linux unix },
       'Payload'        =>
         {
           'DisableNops' => true

--- a/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => 'Feb 15 2013',
       'Privileged'     => true,
-      'Platform'       => ['linux','unix'],
+      'Platform'       => %w{ linux unix },
       'Payload'        =>
         {
           'DisableNops' => true

--- a/modules/exploits/linux/http/webcalendar_settings_exec.rb
+++ b/modules/exploits/linux/http/webcalendar_settings_exec.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['EDB', '18775']
         ],
       'Arch'           => ARCH_CMD,
-      'Platform'       => ['unix', 'linux'],
+      'Platform'       => %w{ linux unix },
       'Compat'         =>
         {
           'PayloadType' => 'cmd'

--- a/modules/exploits/linux/local/zpanel_zsudo.rb
+++ b/modules/exploits/linux/local/zpanel_zsudo.rb
@@ -29,7 +29,7 @@ class Metasploit4 < Msf::Exploit::Local
         'License'       => MSF_LICENSE,
         'Author'        => [ 'sinn3r', 'juan vazquez' ],
         'DisclosureDate' => 'Jun 07 2013',
-        'Platform'      => [ 'unix', 'linux'],
+        'Platform'      => %w{ linux unix },
         'Arch'          => [ ARCH_CMD, ARCH_X86 ],
         'SessionTypes'  => [ 'shell', 'meterpreter' ],
         'Targets'       =>

--- a/modules/exploits/linux/misc/hp_data_protector_cmd_exec.rb
+++ b/modules/exploits/linux/misc/hp_data_protector_cmd_exec.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'https://community.rapid7.com/thread/2253' ]
         ],
       'DisclosureDate'  => 'Feb 7 2011',
-      'Platform'        => [ 'unix','linux'],
+      'Platform'        => %w{ linux unix },
       'Arch'            => ARCH_CMD,
       'Payload'         =>
         {

--- a/modules/exploits/linux/samba/setinfopolicy_heap.rb
+++ b/modules/exploits/linux/samba/setinfopolicy_heap.rb
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'DisableNops' => true,
           'Space'       => 600,
         },
-      'Platform'      => ['unix', 'linux'],
+      'Platform'      => %w{ linux unix },
       # smbd process is killed soon after being exploited, need fork with meterpreter
       'DefaultOptions' => { "PrependSetreuid" => true, "PrependSetregid" => true, "PrependFork" => true, "AppendExit" => true, "WfsDelay" => 5},
       'Targets'        =>

--- a/modules/exploits/multi/browser/firefox_svg_plugin.rb
+++ b/modules/exploits/multi/browser/firefox_svg_plugin.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'Automatic',
             {
-              'Platform' => ['win', 'linux', 'osx'],
+              'Platform' => %w{ linux osx win },
               'Arch'     => ARCH_X86
             }
           ],

--- a/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
+++ b/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://dvlabs.tippingpoint.com/blog/2007/06/27/xpi-the-next-malware-vector' ]
         ],
       'DisclosureDate' => 'Jun 27 2007',
-      'Platform'      => [ 'java', 'win', 'osx', 'linux', 'solaris' ],
+      'Platform'      => %w{ java linux osx solaris win },
       'Payload'       => { 'BadChars' => '', 'DisableNops' => true },
       'Targets'       =>
         [

--- a/modules/exploits/multi/browser/java_atomicreferencearray.rb
+++ b/modules/exploits/multi/browser/java_atomicreferencearray.rb
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2012-0507'],
           ['URL', 'https://community.rapid7.com/community/metasploit/blog/2012/03/29/cve-2012-0507--java-strikes-again']
         ],
-      'Platform'       => [ 'java', 'win', 'osx', 'linux', 'solaris' ],
+      'Platform'       => %w{ java linux osx solaris win },
       'Payload'        => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },
       'Targets'        =>
         [

--- a/modules/exploits/multi/browser/java_calendar_deserialize.rb
+++ b/modules/exploits/multi/browser/java_calendar_deserialize.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [ 'URL', 'http://blog.cr0.org/2009/05/write-once-own-everyone.html' ],
         [ 'URL', 'http://sunsolve.sun.com/search/document.do?assetkey=1-26-244991-1' ]
       ],
-      'Platform'      => [ 'win', 'osx', 'linux', 'solaris' ],
+      'Platform'      => %w{ linux osx solaris win },
       'Payload'       => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },
       'Targets'       =>
         [

--- a/modules/exploits/multi/browser/java_getsoundbank_bof.rb
+++ b/modules/exploits/multi/browser/java_getsoundbank_bof.rb
@@ -60,7 +60,7 @@ No automatic targetting for now ...
 
           [ 'J2SE 1.6_16 Automatic',
             {
-              'Platform' => ['win', 'linux', 'osx'],
+              'Platform' => %w{ linux osx win },
               'Arch' => [ARCH_X86, ARCH_PPC]
             }
           ],

--- a/modules/exploits/multi/browser/java_jre17_driver_manager.rb
+++ b/modules/exploits/multi/browser/java_jre17_driver_manager.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://immunityproducts.blogspot.com/2013/04/yet-another-java-security-warning-bypass.html' ],
           [ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-13-076/' ]
         ],
-      'Platform'      => [ 'java', 'win', 'osx', 'linux' ],
+      'Platform'      => %w{ java linux osx win },
       'Payload'       => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },
       'Targets'       =>
         [

--- a/modules/exploits/multi/browser/java_jre17_exec.rb
+++ b/modules/exploits/multi/browser/java_jre17_exec.rb
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2012/08/27/lets-start-the-week-with-a-new-java-0day' ],
           [ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=852051']
         ],
-      'Platform'      => [ 'java', 'win', 'linux' ],
+      'Platform'      => %w{ java linux win },
       'Payload'       => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },
       'Targets'       =>
         [

--- a/modules/exploits/multi/browser/java_jre17_glassfish_averagerangestatisticimpl.rb
+++ b/modules/exploits/multi/browser/java_jre17_glassfish_averagerangestatisticimpl.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2012-5076' ],
           [ 'URL', 'http://www.security-explorations.com/materials/se-2012-01-report.pdf' ]
         ],
-      'Platform'      => [ 'java', 'win', 'osx', 'linux' ],
+      'Platform'      => %w{ java linux osx win },
       'Payload'       => { 'Space' => 20480, 'DisableNops' => true },
       'Targets'       =>
         [

--- a/modules/exploits/multi/browser/java_jre17_jaxws.rb
+++ b/modules/exploits/multi/browser/java_jre17_jaxws.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://malware.dontneedcoffee.com/2012/11/cool-ek-hello-my-friend-cve-2012-5067.html' ],
           [ 'URL', 'http://blogs.technet.com/b/mmpc/archive/2012/11/15/a-technical-analysis-on-new-java-vulnerability-cve-2012-5076.aspx' ]
         ],
-      'Platform'      => [ 'java', 'win' ],
+      'Platform'      => %w{ java win },
       'Payload'       => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },
       'Targets'       =>
         [

--- a/modules/exploits/multi/browser/java_jre17_jmxbean.rb
+++ b/modules/exploits/multi/browser/java_jre17_jmxbean.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://labs.alienvault.com/labs/index.php/2013/new-year-new-java-zeroday/' ],
           [ 'URL', 'http://pastebin.com/cUG2ayjh' ]  #Who authored the code on pastebin?  I can't read Russian :-(
         ],
-      'Platform'      => [ 'java', 'win', 'osx', 'linux' ],
+      'Platform'      => %w{ java linux osx win },
       'Payload'       => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },
       'Targets'       =>
         [

--- a/modules/exploits/multi/browser/java_jre17_jmxbean_2.rb
+++ b/modules/exploits/multi/browser/java_jre17_jmxbean_2.rb
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://pastebin.com/QWU1rqjf' ],
           [ 'URL', 'http://malware.dontneedcoffee.com/2013/02/cve-2013-0431-java-17-update-11.html' ]
         ],
-      'Platform'      => [ 'java', 'win', 'osx', 'linux' ],
+      'Platform'      => %w{ java linux osx win },
       'Payload'       => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },
       'Targets'       =>
         [

--- a/modules/exploits/multi/browser/java_jre17_method_handle.rb
+++ b/modules/exploits/multi/browser/java_jre17_method_handle.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://www.security-explorations.com/materials/SE-2012-01-ORACLE-5.pdf' ],
           [ 'URL', 'http://www.security-explorations.com/materials/se-2012-01-report.pdf' ]
         ],
-      'Platform'      => [ 'java', 'win', 'osx', 'linux' ],
+      'Platform'      => %w{ java linux osx win },
       'Payload'       => { 'Space' => 20480, 'DisableNops' => true },
       'Targets'       =>
         [

--- a/modules/exploits/multi/browser/java_jre17_provider_skeleton.rb
+++ b/modules/exploits/multi/browser/java_jre17_provider_skeleton.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://www.security-explorations.com/materials/SE-2012-01-ORACLE-12.pdf' ],
           [ 'URL', 'http://www.security-explorations.com/materials/se-2012-01-61.zip' ]
         ],
-      'Platform'      => [ 'java', 'win', 'osx', 'linux' ],
+      'Platform'      => %w{ java linux osx win },
       'Payload'       => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },
       'Targets'       =>
         [

--- a/modules/exploits/multi/browser/java_jre17_reflection_types.rb
+++ b/modules/exploits/multi/browser/java_jre17_reflection_types.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://hg.openjdk.java.net/jdk7u/jdk7u-dev/jdk/rev/b453d9be6b3f' ],
           [ 'URL', 'http://immunityproducts.blogspot.com/2013/04/yet-another-java-security-warning-bypass.html' ]
         ],
-      'Platform'      => [ 'java', 'win', 'osx', 'linux' ],
+      'Platform'      => %w{ java linux osx win },
       'Payload'       => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },
       'Targets'       =>
         [

--- a/modules/exploits/multi/browser/java_rhino.rb
+++ b/modules/exploits/multi/browser/java_rhino.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-11-305/' ],
           [ 'URL', 'http://schierlm.users.sourceforge.net/CVE-2011-3544.html' ],
         ],
-      'Platform'      => [ 'java', 'win', 'linux' ],
+      'Platform'      => %w{ java linux win },
       'Payload'       => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },
       'Targets'       =>
         [

--- a/modules/exploits/multi/browser/java_setdifficm_bof.rb
+++ b/modules/exploits/multi/browser/java_setdifficm_bof.rb
@@ -60,7 +60,7 @@ No automatic targetting for now ...
 
           [ 'J2SE 1.6_16 Automatic',
             {
-              'Platform' => ['win', 'linux', 'osx'],
+              'Platform' => %w{ linux osx win },
               'Arch' => [ARCH_X86, ARCH_PPC]
             }
           ],

--- a/modules/exploits/multi/browser/java_signed_applet.rb
+++ b/modules/exploits/multi/browser/java_signed_applet.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
           # list of trusted Certificate Authorities by java version
           [ 'URL', 'http://www.spikezilla-software.com/blog/?p=21' ]
         ],
-      'Platform'      => [ 'java', 'win', 'osx', 'linux', 'solaris' ],
+      'Platform'      => %w{ java linux osx solaris win },
       'Payload'       => { 'BadChars' => '', 'DisableNops' => true },
       'Targets'       =>
         [

--- a/modules/exploits/multi/browser/java_storeimagearray.rb
+++ b/modules/exploits/multi/browser/java_storeimagearray.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://packetstormsecurity.com/files/122777/' ],
           [ 'URL', 'http://hg.openjdk.java.net/jdk7u/jdk7u-dev/jdk/rev/2a9c79db0040' ]
         ],
-      'Platform'      => [ 'java', 'win', 'linux' ],
+      'Platform'      => %w{ java linux win },
       'Payload'       => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },
       'Targets'       =>
         [

--- a/modules/exploits/multi/browser/java_trusted_chain.rb
+++ b/modules/exploits/multi/browser/java_trusted_chain.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [ 'OSVDB', '63483' ],
         [ 'URL', 'http://slightlyrandombrokenthoughts.blogspot.com/2010/04/java-trusted-method-chaining-cve-2010.html' ],
       ],
-      'Platform'      => [ 'java', 'win', 'linux' ],
+      'Platform'      => %w{ java linux win },
       'Payload'       => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },
       'Targets'       =>
         [

--- a/modules/exploits/multi/browser/java_verifier_field_access.rb
+++ b/modules/exploits/multi/browser/java_verifier_field_access.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['URL', 'http://icedtea.classpath.org/hg/release/icedtea7-forest-2.1/hotspot/rev/253e7c32def9'],
           ['URL', 'http://icedtea.classpath.org/hg/release/icedtea7-forest-2.1/hotspot/rev/8f86ad60699b']
         ],
-      'Platform'       => [ 'java', 'win', 'osx', 'linux', 'solaris' ],
+      'Platform'       => %w{ java linux osx solaris win },
       'Payload'        => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },
       'Targets'        =>
         [

--- a/modules/exploits/multi/fileformat/maple_maplet.rb
+++ b/modules/exploits/multi/fileformat/maple_maplet.rb
@@ -81,7 +81,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['Universal CMD',
             {
               'Arch'      => ARCH_CMD,
-              'Platform'       => ['unix', 'win', 'linux']
+              'Platform'       => %w{ linux unix win }
             }
           ]
 

--- a/modules/exploits/multi/fileformat/peazip_command_injection.rb
+++ b/modules/exploits/multi/fileformat/peazip_command_injection.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://peazip.sourceforge.net/' ],
           [ 'EDB', '8881' ]
         ],
-      'Platform'       => ['unix', 'win', 'linux'],
+      'Platform'       => %w{ linux unix win },
       'Arch'           => ARCH_CMD,
       'Payload'        =>
         {

--- a/modules/exploits/multi/handler.rb
+++ b/modules/exploits/multi/handler.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars'    => '',
           'DisableNops' => true,
         },
-      'Platform'       => [ 'win', 'linux', 'solaris', 'unix', 'osx', 'bsd', 'php', 'java', 'ruby', 'js', 'python', 'android' ],
+      'Platform'       => %w{ android bsd java js linux osx php python ruby solaris unix win },
       'Arch'           => ARCH_ALL,
       'Targets'        => [ [ 'Wildcard Target', { } ] ],
       'DefaultTarget'  => 0

--- a/modules/exploits/multi/http/ajaxplorer_checkinstall_exec.rb
+++ b/modules/exploits/multi/http/ajaxplorer_checkinstall_exec.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'RequiredCmd' => 'generic perl ruby python bash telnet'
             }
         },
-      'Platform'       => ['unix', 'bsd', 'linux', 'osx', 'win'],
+      'Platform'       => %w{ bsd linux osx unix win },
       'Arch'           => ARCH_CMD,
       'Targets'        => [[ 'AjaXplorer 2.5.5 or older', { }]],
       'DisclosureDate' => 'Apr 4 2010',

--- a/modules/exploits/multi/http/auxilium_upload_exec.rb
+++ b/modules/exploits/multi/http/auxilium_upload_exec.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'BadChars' => "\x00"
         },
-      'Platform'       => ['linux', 'php'],
+      'Platform'       => %w{ linux php },
       'Targets'        =>
         [
           [ 'Generic (PHP Payload)', { 'Arch' => ARCH_PHP, 'Platform' => 'php' }  ],

--- a/modules/exploits/multi/http/axis2_deployer.rb
+++ b/modules/exploits/multi/http/axis2_deployer.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2010-0219' ],
           [ 'OSVDB', '68662' ]
         ],
-      'Platform'        => [ 'java', 'win', 'linux' ], # others?
+      'Platform'        => %w{ java linux win }, # others?
       'Targets'         =>
         [
           [ 'Java', {

--- a/modules/exploits/multi/http/eaton_nsm_code_exec.rb
+++ b/modules/exploits/multi/http/eaton_nsm_code_exec.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'DisableNops' => true,
           'Space'       => 4000
         },
-      'Platform'       => ['php', 'linux'],
+      'Platform'       => %w{ linux php },
       'Arch'           => ARCH_PHP,
 
       'Targets'        =>

--- a/modules/exploits/multi/http/familycms_less_exec.rb
+++ b/modules/exploits/multi/http/familycms_less_exec.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Exploit::Remote
             'RequiredCmd'  => 'generic telnet perl ruby python',
           }
         },
-      'Platform'       => ['unix', 'linux'],
+      'Platform'       => %w{ linux unix },
       'Arch'           => ARCH_CMD,
       'Targets'        => [['Automatic',{}]],
       'DisclosureDate' => 'Nov 29 2011',

--- a/modules/exploits/multi/http/gitorious_graph.rb
+++ b/modules/exploits/multi/http/gitorious_graph.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'PayloadType' => 'cmd',
             }
         },
-      'Platform'       => [ 'unix', 'linux' ],
+      'Platform'       => %w{ linux unix },
       'Arch'           => ARCH_CMD,
       'DefaultTarget'  => 0,
       'Targets'        => [[ 'Automatic', { }]],

--- a/modules/exploits/multi/http/horde_href_backdoor.rb
+++ b/modules/exploits/multi/http/horde_href_backdoor.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'PayloadType' => 'cmd',
             }
         },
-      'Platform'       => [ 'unix', 'linux' ],
+      'Platform'       => %w{ linux unix },
       'Arch'           => ARCH_CMD,
       'DefaultTarget'  => 0,
       'Targets'        => [[ 'Automatic', { }]],

--- a/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
+++ b/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-12-175/' ]
         ],
       'Privileged'  => true,
-      'Platform'    => [ 'win', 'linux' ],
+      'Platform'    => %w{ linux win },
       'Targets'     =>
         [
           [ 'HP SiteScope 11.20 / Windows 2003 SP2',

--- a/modules/exploits/multi/http/jboss_bshdeployer.rb
+++ b/modules/exploits/multi/http/jboss_bshdeployer.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=574105' ],
         ],
       'Privileged'   => true,
-      'Platform'     => ['java', 'win', 'linux' ],
+      'Platform'     => %w{ java linux win },
       'Stance'       => Msf::Exploit::Stance::Aggressive,
       'Targets'     =>
         [

--- a/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
+++ b/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'https://bugzilla.redhat.com/show_bug.cgi?id=574105' ],
         ],
       'Privileged'  => false,
-      'Platform'    => ['java', 'linux', 'win' ],
+      'Platform'    => %w{ java linux win },
       'Targets'     =>
         [
           #

--- a/modules/exploits/multi/http/jboss_invoke_deploy.rb
+++ b/modules/exploits/multi/http/jboss_invoke_deploy.rb
@@ -40,7 +40,7 @@ class Metasploit4 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => 'Feb 20 2007',
       'Privileged'  => true,
-      'Platform'    => ['java', 'win', 'linux' ],
+      'Platform'    => %w{ java linux win },
       'Stance'      => Msf::Exploit::Stance::Aggressive,
       'Targets'     =>
         [

--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => 'Feb 20 2007',
       'Privileged'  => true,
-      'Platform'    => [ 'java', 'win', 'linux' ],
+      'Platform'    => %w{ java linux win },
       'Stance'      => Msf::Exploit::Stance::Aggressive,
       'Targets'     =>
         [

--- a/modules/exploits/multi/http/manageengine_search_sqli.rb
+++ b/modules/exploits/multi/http/manageengine_search_sqli.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['EDB','22094'],
           ['BID', '56138']
         ],
-      'Platform'       => ['win', 'linux'],
+      'Platform'       => %w{ linux win },
       'Targets'        =>
         [
           ['Automatic', {}],

--- a/modules/exploits/multi/http/mobilecartly_upload_exec.rb
+++ b/modules/exploits/multi/http/mobilecartly_upload_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'       => 8000,
           'DisableNops' => true
         },
-      'Platform'       => ['linux', 'php'],
+      'Platform'       => %w{ linux php },
       'Targets'        =>
         [
           [ 'Generic (PHP Payload)', { 'Arch' => ARCH_PHP, 'Platform' => 'php' }  ],

--- a/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
+++ b/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['URL', 'http://obscuresecurity.blogspot.com.es/2012/10/mutiny-command-injection-and-cve-2012.html']
         ],
       'Privileged'     => true,
-      'Platform'       => [ 'unix', 'linux' ],
+      'Platform'       => %w{ linux unix },
       'Payload'        =>
         {
           'DisableNops' => true,

--- a/modules/exploits/multi/http/op5_welcome.rb
+++ b/modules/exploits/multi/http/op5_welcome.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'RequiredCmd' => 'perl ruby python',
             }
         },
-      'Platform'       => [ 'unix', 'linux' ],
+      'Platform'       => %w{ linux unix },
       'Arch'           => ARCH_CMD,
       'Targets'        => [[ 'Automatic', { }]],
       'DisclosureDate' => 'Jan 05 2012',

--- a/modules/exploits/multi/http/openfire_auth_bypass.rb
+++ b/modules/exploits/multi/http/openfire_auth_bypass.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => 'Nov 10 2008',
       'Privileged'  => true,
-      'Platform'    => ['java', 'win', 'linux' ],
+      'Platform'    => %w{ java linux win },
       'Stance'      => Msf::Exploit::Stance::Aggressive,
       'Targets'     =>
         [

--- a/modules/exploits/multi/http/phptax_exec.rb
+++ b/modules/exploits/multi/http/phptax_exec.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
             'RequiredCmd'    => 'generic perl ruby bash telnet python'
           }
         },
-      'Platform'       => ['unix', 'linux'],
+      'Platform'       => %w{ linux unix },
       'Targets'        =>
         [
           ['PhpTax 0.8', {}]

--- a/modules/exploits/multi/http/plone_popen2.rb
+++ b/modules/exploits/multi/http/plone_popen2.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'RequiredCmd'  => 'generic telnet perl ruby python',
         }
       },
-      'Platform'       => ['unix', 'linux'],
+      'Platform'       => %w{ linux unix },
       'Arch'           => ARCH_CMD,
       'Targets'        => [['Automatic',{}]],
       'DisclosureDate' => 'Oct 04 2011',

--- a/modules/exploits/multi/http/qdpm_upload_exec.rb
+++ b/modules/exploits/multi/http/qdpm_upload_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'ExitFunction' => "none"
         },
-      'Platform'       => ['linux', 'php'],
+      'Platform'       => %w{ linux php },
       'Targets'        =>
         [
           [ 'Generic (PHP Payload)', { 'Arch' => ARCH_PHP, 'Platform' => 'php' }  ],

--- a/modules/exploits/multi/http/sflog_upload_exec.rb
+++ b/modules/exploits/multi/http/sflog_upload_exec.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'BadChars' => "\x00"
         },
-      'Platform'       => ['linux', 'php'],
+      'Platform'       => %w{ linux php },
       'Targets'        =>
         [
         [ 'Generic (PHP Payload)', { 'Arch' => ARCH_PHP, 'Platform' => 'php' }  ],

--- a/modules/exploits/multi/http/snortreport_exec.rb
+++ b/modules/exploits/multi/http/snortreport_exec.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'RequiredCmd'  => 'generic perl ruby bash telnet python',
         }
       },
-      'Platform'       => ['unix', 'linux'],
+      'Platform'       => %w{ linux unix },
       'Arch'           => ARCH_CMD,
       'Targets'        => [['Automatic',{}]],
       'DisclosureDate' => 'Sep 19 2011',

--- a/modules/exploits/multi/http/sonicwall_gms_upload.rb
+++ b/modules/exploits/multi/http/sonicwall_gms_upload.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'EDB', '24204' ]
         ],
       'Privileged'  => true,
-      'Platform'    => [ 'win', 'linux' ],
+      'Platform'    => %w{ linux win },
       'Targets'     =>
         [
           [ 'SonicWALL GMS 6.0 Viewpoint / Java Universal',

--- a/modules/exploits/multi/http/splunk_mappy_exec.rb
+++ b/modules/exploits/multi/http/splunk_mappy_exec.rb
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Exploit::Remote
             'Universal CMD',
             {
               'Arch'     => ARCH_CMD,
-              'Platform' => ['unix', 'win', 'linux']
+              'Platform' => %w{ linux unix win }
             }
           ]
         ],

--- a/modules/exploits/multi/http/splunk_upload_app_exec.rb
+++ b/modules/exploits/multi/http/splunk_upload_app_exec.rb
@@ -48,7 +48,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'Splunk 5.0.1 / Linux',
             {
               'Arch'     => ARCH_CMD,
-              'Platform' => [ 'linux', 'unix' ]
+              'Platform' => %w{ linux unix }
             }
           ],
           [ 'Splunk 5.0.1 / Windows',

--- a/modules/exploits/multi/http/spree_search_exec.rb
+++ b/modules/exploits/multi/http/spree_search_exec.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'PayloadType' => 'cmd',
             }
         },
-      'Platform'       => [ 'unix', 'linux' ],
+      'Platform'       => %w{ linux unix },
       'Arch'           => ARCH_CMD,
       'Targets'        => [[ 'Automatic', { }]],
       'DisclosureDate' => 'Oct 05 2011',

--- a/modules/exploits/multi/http/spree_searchlogic_exec.rb
+++ b/modules/exploits/multi/http/spree_searchlogic_exec.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'PayloadType' => 'cmd',
             }
         },
-      'Platform'       => [ 'unix', 'linux' ],
+      'Platform'       => %w{ linux unix },
       'Arch'           => ARCH_CMD,
       'Targets'        => [[ 'Automatic', { }]],
       'DisclosureDate' => 'Apr 19 2011',

--- a/modules/exploits/multi/http/struts_code_exec.rb
+++ b/modules/exploits/multi/http/struts_code_exec.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '66280'],
           [ 'EDB', '14360' ],
         ],
-      'Platform'      => [ 'win', 'linux'],
+      'Platform'      => %w{ linux win },
       'Privileged'     => true,
       'Targets'        =>
         [

--- a/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
+++ b/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'EDB', '18329'],
           [ 'URL', 'https://www.sec-consult.com/files/20120104-0_Apache_Struts2_Multiple_Critical_Vulnerabilities.txt']
         ],
-      'Platform'      => [ 'win', 'linux', 'java'],
+      'Platform'      => %w{ java linux win },
       'Privileged'     => true,
       'Targets'        =>
         [

--- a/modules/exploits/multi/http/struts_code_exec_parameters.rb
+++ b/modules/exploits/multi/http/struts_code_exec_parameters.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://blog.o0o.nu/2012/01/cve-2011-3923-yet-another-struts2.html'],
           [ 'URL', 'https://cwiki.apache.org/confluence/display/WW/S2-009']
         ],
-      'Platform'      => [ 'win', 'linux', 'java'],
+      'Platform'      => %w{ java linux win },
       'Privileged'     => true,
       'Targets'        =>
         [

--- a/modules/exploits/multi/http/struts_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_default_action_mapper.rb
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'BID', '61189' ],
           [ 'URL', 'http://struts.apache.org/release/2.3.x/docs/s2-016.html' ]
         ],
-      'Platform'       => [ 'win', 'linux'],
+      'Platform'       => %w{ linux win },
       'Targets'         =>
         [
           ['Automatic', {}],

--- a/modules/exploits/multi/http/struts_include_params.rb
+++ b/modules/exploits/multi/http/struts_include_params.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'https://cwiki.apache.org/confluence/display/WW/S2-014'],
           [ 'URL', 'http://struts.apache.org/development/2.x/docs/s2-013.html']
         ],
-      'Platform'      => [ 'win', 'linux', 'java'],
+      'Platform'      => %w{ java linux win },
       'Privileged'     => true,
       'Targets'        =>
         [

--- a/modules/exploits/multi/http/stunshell_exec.rb
+++ b/modules/exploits/multi/http/stunshell_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'PayloadType' => 'cmd'
             }
         },
-      'Platform'       => ['unix', 'win'],
+      'Platform'       => %w{ unix win },
       'Arch'           => ARCH_CMD,
       'Targets'        =>
         [

--- a/modules/exploits/multi/http/sun_jsws_dav_options.rb
+++ b/modules/exploits/multi/http/sun_jsws_dav_options.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://intevydis.blogspot.com/2010/01/sun-java-system-web-server-70u7-webdav.html' ],
           [ 'URL', 'http://sunsolve.sun.com/search/document.do?assetkey=1-66-275850-1' ]
         ],
-      'Platform'       => [ 'win' ], #, 'linux', 'solaris', 'win' ],
+      'Platform'       => [ 'win' ]
       'Privileged'     => true,
       'Payload'        =>
         {

--- a/modules/exploits/multi/http/tomcat_mgr_deploy.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_deploy.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
           # tomcat docs
           [ 'URL', 'http://tomcat.apache.org/tomcat-5.5-doc/manager-howto.html' ]
         ],
-      'Platform'    => [ 'java', 'win', 'linux' ], # others?
+      'Platform'    => %w{ java linux win }, # others?
       'Targets'     =>
         [
           #

--- a/modules/exploits/multi/http/v0pcr3w_exec.rb
+++ b/modules/exploits/multi/http/v0pcr3w_exec.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'PayloadType' => 'cmd'
             }
         },
-      'Platform'       => ['unix', 'win'],
+      'Platform'       => %w{ unix win },
       'Arch'           => ARCH_CMD,
       'Targets'        =>
         [

--- a/modules/exploits/multi/http/zenworks_control_center_upload.rb
+++ b/modules/exploits/multi/http/zenworks_control_center_upload.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://www.novell.com/support/kb/doc.php?id=7011812' ]
         ],
       'Privileged'  => false,
-      'Platform'    => [ 'win', 'linux' ],
+      'Platform'    => %w{ linux win },
       'Targets'     =>
         [
           [ 'ZENworks Configuration Management 10 SP3 and 11 SP2 / Windows 2003 SP2',

--- a/modules/exploits/multi/misc/batik_svg_java.rb
+++ b/modules/exploits/multi/misc/batik_svg_java.rb
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'ExitFunction' => "none"
         },
-      'Platform'       => ['win', 'linux', 'java'],
+      'Platform'       => %w{ java linux win },
       'Targets'        =>
         [
           [ 'Generic (Java Payload)',

--- a/modules/exploits/multi/misc/hp_vsa_exec.rb
+++ b/modules/exploits/multi/misc/hp_vsa_exec.rb
@@ -48,7 +48,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'ExitFunction' => "none"
         },
-      'Platform'       => ['unix', 'linux'],
+      'Platform'       => %w{ linux unix },
       'Arch'           => ARCH_CMD,
       'Targets'        =>
         [

--- a/modules/exploits/multi/misc/indesign_server_soap.rb
+++ b/modules/exploits/multi/misc/indesign_server_soap.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'juan vazquez' # MacOSX target
         ],
       'License'        => MSF_LICENSE,
-      'Platform'       => ['win', 'osx'],
+      'Platform'       => %w{ osx win },
       'Privileged'     => false,
       'DisclosureDate' => 'Nov 11 2012',
       'References'     =>

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'MSF', 'java_rmi_server']
         ],
       'DisclosureDate' => 'Oct 15 2011',
-      'Platform'       => ['java', 'win', 'osx', 'linux', 'solaris'],
+      'Platform'       => %w{ java linux osx solaris win },
       'Privileged'     => true,
       'Payload'       => { 'BadChars' => '', 'DisableNops' => true },
       'Stance'        => Msf::Exploit::Stance::Aggressive,

--- a/modules/exploits/multi/misc/pbot_exec.rb
+++ b/modules/exploits/multi/misc/pbot_exec.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://offensivecomputing.net/?q=node/1417'],
           [ 'URL', 'http://resources.infosecinstitute.com/pbot-analysis/']
         ],
-      'Platform'       => [ 'unix', 'win'],
+      'Platform'       => %w{ unix win },
       'Arch'           => ARCH_CMD,
       'Payload'        =>
         {

--- a/modules/exploits/multi/misc/ra1nx_pubcall_exec.rb
+++ b/modules/exploits/multi/misc/ra1nx_pubcall_exec.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['URL', 'https://defense.ballastsecurity.net/decoding/index.php?hash=69401ac90262f3855c23cd143d7d2ae0'],
           ['URL', 'http://ddecode.com/phpdecoder/?results=8c6ba611ea2a504da928c6e176a6537b']
         ],
-      'Platform'       => [ 'unix', 'win'],
+      'Platform'       => %w{ unix win },
       'Arch'           => ARCH_CMD,
       'Payload'        =>
         {

--- a/modules/exploits/multi/misc/veritas_netbackup_cmdexec.rb
+++ b/modules/exploits/multi/misc/veritas_netbackup_cmdexec.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
         ],
       'Privileged'     => true,
-      'Platform'       => ['unix', 'win', 'linux'],
+      'Platform'       => %w{ linux unix win },
       'Arch'           => ARCH_CMD,
       'Payload'        =>
         {

--- a/modules/exploits/multi/realserver/describe.rb
+++ b/modules/exploits/multi/realserver/describe.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [
             'Universal',
             {
-              'Platform' => [ 'linux', 'bsd', 'win' ]
+              'Platform' => %w{ bsd linux win }
             },
           ],
         ],

--- a/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
+++ b/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
@@ -46,7 +46,7 @@ class Metasploit4 < Msf::Exploit::Remote
         {
           'BadChars' => "\x00\x3a\x3b\x3d\x3c\x3e\x0a\x0d\x22\x26\x27\x2f\x60\xb4",
         },
-      'Platform'       => ['win', 'linux'],
+      'Platform'       => %w{ linux win },
       'Targets'        =>
         [
           [ 'Linux',

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
@@ -47,7 +47,7 @@ class Metasploit4 < Msf::Exploit::Remote
           [ 'URL', 'http://labs.mwrinfosecurity.com/tools/2012/04/27/sap-metasploit-modules/' ]
         ],
       'DisclosureDate' => 'Mar 26 2013',
-      'Platform'       => ['win', 'unix'],
+      'Platform'       => %w{ unix win },
       'Targets' => [
         [ 'Linux',
           {

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_command_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_command_exec.rb
@@ -48,7 +48,7 @@ class Metasploit4 < Msf::Exploit::Remote
           [ 'URL', 'https://service.sap.com/sap/support/notes/1341333' ]
         ],
       'DisclosureDate' => 'May 8 2012',
-      'Platform'       => ['win', 'unix'],
+      'Platform'       => %w{ unix win },
       'Targets' => [
         [ 'Linux',
           {

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "",
           'DisableNops' => true
         },
-      'Platform'    => [ 'osx', 'linux' ],
+      'Platform'    => %w{ linux osx },
       'Targets'     =>
         [
           [ 'Linux x86',

--- a/modules/exploits/multi/svn/svnserve_date.rb
+++ b/modules/exploits/multi/svn/svnserve_date.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'SaveRegisters'  => [ 'esp' ],
       'Arch'           => 'x86',
-      'Platform'       => [ 'linux', 'bsd' ],
+      'Platform'       => %w{ bsd linux },
       'Targets'        =>
         [
           [

--- a/modules/exploits/osx/browser/safari_file_policy.rb
+++ b/modules/exploits/osx/browser/safari_file_policy.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'EXITFUNC' => "none",
         },
-      'Platform'       => [ 'unix', 'osx', 'java' ],
+      'Platform'       => %w{ java osx unix },
       'Arch'           => [ ARCH_CMD, ARCH_JAVA ],
       'Targets'        =>
         [

--- a/modules/exploits/solaris/lpd/sendmail_exec.rb
+++ b/modules/exploits/solaris/lpd/sendmail_exec.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '15131'],
           [ 'BID', '3274'],
         ],
-      'Platform'       => ['unix', 'solaris'],
+      'Platform'       => %w{ solaris unix },
       'Arch'           => ARCH_CMD,
       'Payload'        =>
         {

--- a/modules/exploits/solaris/sunrpc/sadmind_exec.rb
+++ b/modules/exploits/solaris/sunrpc/sadmind_exec.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['URL', 'http://lists.insecure.org/lists/vulnwatch/2003/Jul-Sep/0115.html'],
         ],
       'Privileged'     => true,
-      'Platform'       => ['unix', 'solaris'],
+      'Platform'       => %w{ solaris unix },
       'Arch'           => ARCH_CMD,
       'Payload'        =>
         {

--- a/modules/exploits/solaris/sunrpc/ypupdated_exec.rb
+++ b/modules/exploits/solaris/sunrpc/ypupdated_exec.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['BID', '1749'],
         ],
       'Privileged'     => true,
-      'Platform'       => ['unix', 'solaris'],
+      'Platform'       => %w{ solaris unix },
       'Arch'           => ARCH_CMD,
       'Payload'        =>
         {

--- a/modules/exploits/solaris/telnet/fuser.rb
+++ b/modules/exploits/solaris/telnet/fuser.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'BID', '22512' ],
         ],
       'Privileged'     => false,
-      'Platform'       => ['unix', 'solaris'],
+      'Platform'       => %w{ solaris unix },
       'Arch'           => ARCH_CMD,
       'Payload'        =>
         {

--- a/modules/exploits/solaris/telnet/ttyprompt.rb
+++ b/modules/exploits/solaris/telnet/ttyprompt.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
         ],
       'Privileged'     => false,
-      'Platform'       => ['unix', 'solaris'],
+      'Platform'       => %w{ solaris unix },
       'Arch'           => ARCH_CMD,
       'Payload'        =>
         {

--- a/modules/exploits/unix/local/setuid_nmap.rb
+++ b/modules/exploits/unix/local/setuid_nmap.rb
@@ -34,7 +34,7 @@ class Metasploit4 < Msf::Exploit::Local
         'License'       => MSF_LICENSE,
         'Author'        => [ 'egypt' ],
         'DisclosureDate' => 'Jul 19 2012',
-        'Platform'      => [ 'unix', 'linux', 'bsd' ],
+        'Platform'      => %w{ bsd linux unix },
         'Arch'          => [ ARCH_CMD, ARCH_X86 ],
         'SessionTypes'  => [ 'shell', 'meterpreter' ],
         'Targets'       =>

--- a/modules/exploits/unix/webapp/basilic_diff_exec.rb
+++ b/modules/exploits/unix/webapp/basilic_diff_exec.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '83719' ],
           [ 'BID', '54234' ]
         ],
-      'Platform'       => ['linux', 'unix'],
+      'Platform'       => %w{ linux unix },
       'Arch'           => ARCH_CMD,
       'Privileged'     => true,
       'Payload'        =>

--- a/modules/exploits/unix/webapp/guestbook_ssi_exec.rb
+++ b/modules/exploits/unix/webapp/guestbook_ssi_exec.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'RequiredCmd' => 'generic perl ruby python bash telnet',
             }
         },
-      'Platform'       => [ 'unix', 'win', 'linux' ],
+      'Platform'       => %w{ linux unix win },
       'Arch'           => ARCH_CMD,
       'Targets'        => [[ 'Automatic', { }]],
       'DisclosureDate' => 'Nov 05 1999',

--- a/modules/exploits/unix/webapp/havalite_upload_exec.rb
+++ b/modules/exploits/unix/webapp/havalite_upload_exec.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'BadChars' => "\x00"
         },
-      'Platform'       => ['linux', 'php'],
+      'Platform'       => %w{ linux php },
       'Targets'        =>
         [
           [ 'Generic (PHP Payload)', { 'Arch' => ARCH_PHP, 'Platform' => 'php' }  ],

--- a/modules/exploits/unix/webapp/libretto_upload_exec.rb
+++ b/modules/exploits/unix/webapp/libretto_upload_exec.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'BadChars' => "\x00"
         },
-      'Platform'       => ['linux', 'php'],
+      'Platform'       => %w{ linux php },
       'Targets'        =>
         [
           [ 'Generic (PHP Payload)', { 'Arch' => ARCH_PHP, 'Platform' => 'php' }  ],

--- a/modules/exploits/unix/webapp/mitel_awc_exec.rb
+++ b/modules/exploits/unix/webapp/mitel_awc_exec.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
       #		['CVE',   ''],
       #		['BID',   '']
         ],
-      'Platform'       => ['unix', 'linux'],
+      'Platform'       => %w{ linux unix },
       'Arch'           => ARCH_CMD,
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/unix/webapp/nagios3_history_cgi.rb
+++ b/modules/exploits/unix/webapp/nagios3_history_cgi.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'EDB', '24084' ],
           [ 'URL', 'http://lists.grok.org.uk/pipermail/full-disclosure/2012-December/089125.html' ]
         ],
-      'Platform'       => ['unix', 'linux'],
+      'Platform'       => %w{ linux unix },
       'Arch'           => [ ARCH_X86 ],
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/unix/webapp/narcissus_backend_exec.rb
+++ b/modules/exploits/unix/webapp/narcissus_backend_exec.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'BadChars' => "\x00\x0d\x0a"
         },
-      'Platform'       => ['unix', 'linux'],
+      'Platform'       => %w{ linux unix },
       'Arch'           => ARCH_CMD,
       'Compat'         =>
         {

--- a/modules/exploits/unix/webapp/oracle_vm_agent_utl.rb
+++ b/modules/exploits/unix/webapp/oracle_vm_agent_utl.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['BID', '44047']
         ],
       'Privileged'     => true,
-      'Platform'       => ['unix', 'linux'],
+      'Platform'       => %w{ linux unix },
       'Arch'           => ARCH_CMD,
       'Payload'        =>
         {

--- a/modules/exploits/unix/webapp/projectpier_upload_exec.rb
+++ b/modules/exploits/unix/webapp/projectpier_upload_exec.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['EDB', '21929'],
           ['URL', 'http://packetstormsecurity.org/files/117070/ProjectPier-0.8.8-Shell-Upload.html']
         ],
-      'Platform'       => ['linux', 'php'],
+      'Platform'       => %w{ linux php },
       'Targets'        =>
         [
           [ 'Generic (PHP Payload)', { 'Arch' => ARCH_PHP, 'Platform' => 'php' }  ],

--- a/modules/exploits/windows/browser/java_basicservice_impl.rb
+++ b/modules/exploits/windows/browser/java_basicservice_impl.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [ 'OSVDB', '69043' ],
         [ 'URL', 'http://mk41ser.blogspot.com' ],
       ],
-      'Platform'      => [ 'java', 'win' ],
+      'Platform'      => %w{ java win },
       'Payload'       => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },
       'Targets'       =>
         [

--- a/modules/exploits/windows/browser/java_cmm.rb
+++ b/modules/exploits/windows/browser/java_cmm.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://www.oracle.com/technetwork/topics/security/alert-cve-2013-1493-1915081.html' ],
           [ 'URL', 'http://pastie.org/pastes/6581034' ]
         ],
-      'Platform'      => [ 'win', 'java' ],
+      'Platform'      => %w{ java win },
       'Payload'       => { 'Space' => 20480, 'BadChars' => '', 'DisableNops' => true },
       'Targets'       =>
         [

--- a/modules/exploits/windows/browser/java_codebase_trust.rb
+++ b/modules/exploits/windows/browser/java_codebase_trust.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://fhoguin.com/2011/03/oracle-java-unsigned-applet-applet2classloader-remote-code-execution-vulnerability-zdi-11-084-explained/' ],
           [ 'URL', 'http://www.oracle.com/technetwork/topics/security/javacpufeb2011-304611.html' ]
         ],
-      'Platform'      => [ 'java' ], #, 'win' ],
+      'Platform'      => [ 'java' ],
       'Payload'       =>
         {
           'Space' => 20480,

--- a/modules/exploits/windows/http/apache_mod_rewrite_ldap.rb
+++ b/modules/exploits/windows/http/apache_mod_rewrite_ldap.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Apache module mod_rewrite LDAP protocol Buffer Overflow',
+      'Name'           => 'Apache Module mod_rewrite LDAP Protocol Buffer Overflow',
       'Description'    => %q{
         This module exploits the mod_rewrite LDAP protocol scheme handling
         flaw discovered by Mark Dowd, which produces an off-by-one overflow.
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'EXITFUNC' => 'thread',
         },
       'Privileged'     => true,
-      'Platform'       => ['win'], # 'linux'],
+      'Platform'       => ['win']
       'Payload'        =>
         {
           'Space'    => 636,

--- a/modules/exploits/windows/http/oracle_btm_writetofile.rb
+++ b/modules/exploits/windows/http/oracle_btm_writetofile.rb
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'           => 2048,
           'StackAdjustment' => -3500
         },
-      'Platform'       => [ 'java', 'win' ],
+      'Platform'       => %w{ java win },
       'Targets'        =>
         [
           [ 'Oracle BTM 12.1.0.7 / Weblogic 12.1.1 with Samples Domain / Java',

--- a/modules/exploits/windows/http/zenworks_uploadservlet.rb
+++ b/modules/exploits/windows/http/zenworks_uploadservlet.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://www.novell.com/support/kb/doc.php?id=7005573' ]
         ],
       'Privileged'  => true,
-      'Platform'    => [ 'java', 'win', 'linux' ],
+      'Platform'    => %w{ java linux win },
       'Targets'     =>
         [
           [ 'Java Universal',

--- a/modules/payloads/singles/generic/debug_trap.rb
+++ b/modules/payloads/singles/generic/debug_trap.rb
@@ -19,7 +19,7 @@ module Metasploit3
       'Name'          => 'Generic x86 Debug Trap',
       'Description'   => 'Generate a debug trap in the target process',
       'Author'        => 'robert <robertmetasploit[at]gmail.com>',
-      'Platform'	=> [ 'win', 'linux', 'bsd', 'solaris', 'bsdi', 'osx' ],
+      'Platform'	=> %w{ bsd bsdi linux osx solaris win },
       'License'       => MSF_LICENSE,
       'Arch'		=> ARCH_X86,
       'Payload'	=>

--- a/modules/payloads/singles/generic/tight_loop.rb
+++ b/modules/payloads/singles/generic/tight_loop.rb
@@ -17,7 +17,7 @@ module Metasploit3
       'Name'          => 'Generic x86 Tight Loop',
       'Description'   => 'Generate a tight loop in the target process',
       'Author'        => 'jduck',
-      'Platform'	    => [ 'win', 'linux', 'bsd', 'solaris', 'bsdi', 'osx' ],
+      'Platform'	    => %w{ bsd bsdi linux osx solaris win },
       'License'       => MSF_LICENSE,
       'Arch'		    => ARCH_X86,
       'Payload'	    =>

--- a/modules/payloads/singles/java/jsp_shell_bind_tcp.rb
+++ b/modules/payloads/singles/java/jsp_shell_bind_tcp.rb
@@ -21,7 +21,7 @@ module Metasploit3
       'Description'   => 'Listen for a connection and spawn a command shell',
       'Author'        => [ 'sf' ],
       'License'       => MSF_LICENSE,
-      'Platform'      => [ 'win', 'osx', 'linux', 'unix', 'solaris' ],
+      'Platform'      => %w{ linux osx solaris unix win },
       'Arch'          => ARCH_JAVA,
       'Handler'       => Msf::Handler::BindTcp,
       'Session'       => Msf::Sessions::CommandShell,

--- a/modules/payloads/singles/java/jsp_shell_reverse_tcp.rb
+++ b/modules/payloads/singles/java/jsp_shell_reverse_tcp.rb
@@ -21,7 +21,7 @@ module Metasploit3
       'Description'   => 'Connect back to attacker and spawn a command shell',
       'Author'        => [ 'sf' ],
       'License'       => MSF_LICENSE,
-      'Platform'      => [ 'win', 'osx', 'linux', 'unix', 'solaris' ],
+      'Platform'      => %w{ linux osx solaris unix win },
       'Arch'          => ARCH_JAVA,
       'Handler'       => Msf::Handler::ReverseTcp,
       'Session'       => Msf::Sessions::CommandShell,

--- a/modules/post/multi/escalate/cups_root_file_read.rb
+++ b/modules/post/multi/escalate/cups_root_file_read.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Post
           "joev <jvennix[at]rapid7.com>" # metasploit module
         ],
       'DisclosureDate' => 'Nov 20 2012',
-      'Platform'       => ['osx', 'linux']
+      'Platform'       => %w{ linux osx }
     }))
     register_options([
       OptString.new("FILE", [true, "The file to steal.", "/etc/shadow"]),

--- a/modules/post/multi/escalate/metasploit_pcaplog.rb
+++ b/modules/post/multi/escalate/metasploit_pcaplog.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Post
         },
         'License'       => MSF_LICENSE,
         'Author'	=> [ '0a29406d9794e4f9b30b3c5d6702c708'],
-        'Platform'      => [ 'linux','unix','bsd' ],
+        'Platform'      => %w{ bsd linux unix },
         'SessionTypes'  => [ 'shell', 'meterpreter' ],
         'References'    =>
           [

--- a/modules/post/multi/gather/apple_ios_backup.rb
+++ b/modules/post/multi/gather/apple_ios_backup.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Post
           'hdm',
           'bannedit' # Based on bannedit's pidgin_cred module structure
         ],
-      'Platform'       => ['win', 'osx'],
+      'Platform'       => %w{ osx win },
       'SessionTypes'   => ['meterpreter', 'shell']
     ))
     register_options(

--- a/modules/post/multi/gather/dns_bruteforce.rb
+++ b/modules/post/multi/gather/dns_bruteforce.rb
@@ -19,7 +19,7 @@ class Metasploit3 < Msf::Post
         },
         'License'       => MSF_LICENSE,
         'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
-        'Platform'      => [ 'win','linux', 'osx', 'bsd', 'solaris' ],
+        'Platform'      => %w{ bsd linux osx solaris win },
         'SessionTypes'  => [ 'meterpreter', 'shell' ]
       ))
     register_options(

--- a/modules/post/multi/gather/dns_reverse_lookup.rb
+++ b/modules/post/multi/gather/dns_reverse_lookup.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Post
         },
         'License'       => MSF_LICENSE,
         'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
-        'Platform'      => [ 'win','linux', 'osx', 'bsd', 'solaris' ],
+        'Platform'      => %w{ bsd linux osx solaris win },
         'SessionTypes'  => [ 'meterpreter', 'shell' ]
       ))
     register_options(

--- a/modules/post/multi/gather/dns_srv_lookup.rb
+++ b/modules/post/multi/gather/dns_srv_lookup.rb
@@ -19,7 +19,7 @@ class Metasploit3 < Msf::Post
         },
         'License'       => MSF_LICENSE,
         'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
-        'Platform'      => [ 'win','linux', 'osx', 'bsd', 'solaris' ],
+        'Platform'      => %w{ bsd linux osx solaris win },
         'SessionTypes'  => [ 'meterpreter','shell' ]
       ))
     register_options(

--- a/modules/post/multi/gather/enum_vbox.rb
+++ b/modules/post/multi/gather/enum_vbox.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Post
                 },
       'License'        => MSF_LICENSE,
       'Author'         => ['theLightCosine'],
-      'Platform'       => ['unix', 'bsd', 'linux', 'osx', 'win'],
+      'Platform'       => %w{ bsd linux osx unix win },
       'SessionTypes'   => ['shell', 'meterpreter' ]
     ))
   end

--- a/modules/post/multi/gather/env.rb
+++ b/modules/post/multi/gather/env.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Post
       'Description'   => %q{ This module prints out the operating system environment variables },
       'License'       => MSF_LICENSE,
       'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>', 'egypt' ],
-      'Platform'      => [ 'linux', 'win' ],
+      'Platform'      => %w{ linux win },
       'SessionTypes'  => [ 'shell', 'meterpreter' ]
     ))
     @ltype = 'generic.environment'

--- a/modules/post/multi/gather/fetchmailrc_creds.rb
+++ b/modules/post/multi/gather/fetchmailrc_creds.rb
@@ -21,7 +21,7 @@ class Metasploit3 < Msf::Post
       },
       'License'       => MSF_LICENSE,
       'Author'        => [ 'Jon Hart <jhart[at]spoofed.org>' ],
-      'Platform'      => [ 'bsd', 'linux', 'osx', 'unix' ],
+      'Platform'      => %w{ bsd linux osx unix },
       'SessionTypes'  => [ 'shell' ]
     ))
   end

--- a/modules/post/multi/gather/filezilla_client_cred.rb
+++ b/modules/post/multi/gather/filezilla_client_cred.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Post
           'bannedit', # post port, added support for shell sessions
           'Carlos Perez <carlos_perez[at]darkoperator.com>' # original meterpreter script
         ],
-      'Platform'       => ['unix', 'bsd', 'linux', 'osx', 'win'],
+      'Platform'       => %w{ bsd linux osx unix win },
       'SessionTypes'   => ['shell', 'meterpreter' ]
     ))
   end

--- a/modules/post/multi/gather/find_vmx.rb
+++ b/modules/post/multi/gather/find_vmx.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Post
       },
       'License'        => MSF_LICENSE,
       'Author'         => ['theLightCosine'],
-      'Platform'       => ['unix', 'bsd', 'linux', 'osx', 'win'],
+      'Platform'       => %w{ bsd linux osx unix win },
       'SessionTypes'   => ['shell', 'meterpreter' ]
     ))
   end

--- a/modules/post/multi/gather/firefox_creds.rb
+++ b/modules/post/multi/gather/firefox_creds.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Post
             'bannedit',
             'xard4s' # added decryption support
         ],
-      'Platform'       => ['win', 'linux', 'bsd', 'unix', 'osx'],
+      'Platform'       => %w{ bsd linux osx unix win },
       'SessionTypes'   => ['meterpreter', 'shell' ]
     ))
 

--- a/modules/post/multi/gather/gpg_creds.rb
+++ b/modules/post/multi/gather/gpg_creds.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Post
       },
       'License'        => MSF_LICENSE,
       'Author'         => ['Dhiru Kholia <dhiru[at]openwall.com>'],
-      'Platform'       => ['linux', 'bsd', 'unix', 'osx'],
+      'Platform'       => %w{ bsd linux osx unix },
       'SessionTypes'   => ['shell']
     ))
   end

--- a/modules/post/multi/gather/multi_command.rb
+++ b/modules/post/multi/gather/multi_command.rb
@@ -17,7 +17,7 @@ class Metasploit3 < Msf::Post
           execute the commands in the specified Meterpreter or shell session.},
         'License'       => MSF_LICENSE,
         'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
-        'Platform'      => [ 'win', 'linux', 'bsd', 'unix', 'osx' ],
+        'Platform'      => %w{ bsd linux osx unix win },
         'SessionTypes'  => [ 'meterpreter','shell' ]
       ))
     register_options(

--- a/modules/post/multi/gather/netrc_creds.rb
+++ b/modules/post/multi/gather/netrc_creds.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Post
         },
         'License'       => MSF_LICENSE,
         'Author'        => [ 'Jon Hart <jhart[at]spoofed.org>' ],
-        'Platform'      => [ 'bsd', 'linux', 'osx', 'unix' ],
+        'Platform'      => %w{ bsd linux osx unix },
         'SessionTypes'  => [ 'shell' ]
       ))
   end

--- a/modules/post/multi/gather/pidgin_cred.rb
+++ b/modules/post/multi/gather/pidgin_cred.rb
@@ -26,7 +26,7 @@ class Metasploit3 < Msf::Post
           'bannedit', # post port, added support for shell sessions
           'Carlos Perez <carlos_perez[at]darkoperator.com>' # original meterpreter script
         ],
-      'Platform'       => ['unix', 'bsd', 'linux', 'osx', 'win'],
+      'Platform'       => %w{ bsd linux osx unix win },
       'SessionTypes'   => ['shell', 'meterpreter' ]
     ))
     register_options(

--- a/modules/post/multi/gather/ping_sweep.rb
+++ b/modules/post/multi/gather/ping_sweep.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Post
         'Description'   => %q{ Performs IPv4 ping sweep using the OS included ping command.},
         'License'       => MSF_LICENSE,
         'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
-        'Platform'      => [ 'win','linux', 'osx', 'bsd', 'solaris' ],
+        'Platform'      => %w{ bsd linux osx solaris win },
         'SessionTypes'  => [ 'meterpreter', 'shell' ]
       ))
     register_options(

--- a/modules/post/multi/gather/skype_enum.rb
+++ b/modules/post/multi/gather/skype_enum.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Post
         },
         'License'       => MSF_LICENSE,
         'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
-        'Platform'      => [ 'win', 'osx' ],
+        'Platform'      => %w{ osx win },
         'SessionTypes'  => [ 'meterpreter', 'shell' ]
       ))
     register_advanced_options(

--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Post
       },
       'License'        => MSF_LICENSE,
       'Author'         => ['Jim Halfpenny'],
-      'Platform'       => ['linux', 'bsd', 'unix', 'osx'],
+      'Platform'       => %w{ bsd linux osx unix },
       'SessionTypes'   => ['meterpreter', 'shell' ]
     ))
   end

--- a/modules/post/multi/gather/thunderbird_creds.rb
+++ b/modules/post/multi/gather/thunderbird_creds.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Post
         [
           'sinn3r',  #Metasploit
         ],
-      'Platform'       => ['win', 'linux', 'osx'],
+      'Platform'       => %w{ linux osx win },
       'SessionTypes'   => ['meterpreter', 'shell']
       ))
 

--- a/modules/post/multi/general/close.rb
+++ b/modules/post/multi/general/close.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Post
       'Description'   => %q{ This module closes the specified session. This can be useful as a finisher for automation tasks },
       'License'       => MSF_LICENSE,
       'Author'        => [ 'hdm' ],
-      'Platform'      => [ 'linux', 'win', 'unix', 'osx' ],
+      'Platform'      => %w{ linux osx unix win },
       'SessionTypes'  => [ 'shell', 'meterpreter' ]
     ))
   end

--- a/modules/post/multi/general/execute.rb
+++ b/modules/post/multi/general/execute.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Post
       'Description'   => %q{ This module executes an arbitrary command line},
       'License'       => MSF_LICENSE,
       'Author'        => [ 'hdm' ],
-      'Platform'      => [ 'linux', 'win', 'unix', 'osx' ],
+      'Platform'      => %w{ linux osx unix win },
       'SessionTypes'  => [ 'shell', 'meterpreter' ]
     ))
     register_options(

--- a/modules/post/multi/manage/multi_post.rb
+++ b/modules/post/multi/manage/multi_post.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Post
         },
         'License'       => MSF_LICENSE,
         'Author'        => [ '<carlos_perez[at]darkoperator.com>'],
-        'Platform'      => [ 'win', 'unix', 'osx', 'linux', 'solaris' ],
+        'Platform'      => %w{ linux osx solaris unix win },
         'SessionTypes'  => [ 'meterpreter','shell' ]
       ))
     register_options(

--- a/modules/post/multi/manage/record_mic.rb
+++ b/modules/post/multi/manage/record_mic.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Post
       },
       'License'       => MSF_LICENSE,
       'Author'        => [ 'sinn3r'],
-      'Platform'      => [ 'win', 'linux', 'osx' ],
+      'Platform'      => %w{ linux osx win },
       'SessionTypes'  => [ 'meterpreter' ]
     ))
 

--- a/modules/post/multi/manage/sudo.rb
+++ b/modules/post/multi/manage/sudo.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Post
             'todb <todb[at]metasploit.com>',
             'Ryan Baxendale <rbaxendale[at]gmail.com>' #added password option
           ],
-        'Platform'      => [ 'linux','unix','osx','solaris','aix' ],
+        'Platform'      => %w{ aix linux osx solaris unix },
         'References'    =>
           [
             # Askpass first added March 2, 2008, looks like

--- a/modules/post/multi/manage/system_session.rb
+++ b/modules/post/multi/manage/system_session.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Post
         },
         'License'       => MSF_LICENSE,
         'Author'        => ['Carlos Perez <carlos_perez[at]darkoperator.com>'],
-        'Platform'      => [ 'unix', 'osx', 'linux'],
+        'Platform'      => %w{ linux osx unix },
         'SessionTypes'  => [ 'meterpreter','shell' ]
       ))
     register_options(

--- a/modules/post/windows/gather/resolve_hosts.rb
+++ b/modules/post/windows/gather/resolve_hosts.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Post
       },
       'License'       => MSF_LICENSE,
       'Author'        => [ 'Ben Campbell <eat_meatballs[at]hotmail.co.uk>' ],
-      'Platform'      => [ 'win', 'linux' ],
+      'Platform'      => %w{ linux win },
       'SessionTypes'  => [ 'meterpreter' ]
     ))
 

--- a/modules/post/windows/gather/resolve_hosts.rb
+++ b/modules/post/windows/gather/resolve_hosts.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Post
       },
       'License'       => MSF_LICENSE,
       'Author'        => [ 'Ben Campbell <eat_meatballs[at]hotmail.co.uk>' ],
-      'Platform'      => %w{ linux win },
+      'Platform'      => [ 'win' ],
       'SessionTypes'  => [ 'meterpreter' ]
     ))
 


### PR DESCRIPTION
According to the Ruby style guide, %w{} collections for arrays of single
words are preferred. They're easier to type, and if you want a quick
grep, they're easier to search.

This change converts all Payloads to this format if there is more than
one payload to choose from.

It also alphabetizes the payloads, so the order can be more predictable,
and for long sets, easier to scan with eyeballs.

See:
  https://github.com/bbatsov/ruby-style-guide#collections
