### PR TITLE
Get cookies with empty values

### DIFF
--- a/lib/rex/proto/http/response.rb
+++ b/lib/rex/proto/http/response.rb
@@ -66,7 +66,7 @@ class Response < Packet
     cookies = ""
     if (self.headers.include?('Set-Cookie'))
       set_cookies = self.headers['Set-Cookie']
-      key_vals = set_cookies.scan(/\s?([^, ;]+?)=([^, ;]+?);/)
+      key_vals = set_cookies.scan(/\s?([^, ;]+?)=([^, ;]*?);/)
       key_vals.each do |k, v|
         # Dont downcase actual cookie name as may be case sensitive
         name = k.downcase


### PR DESCRIPTION
Fixes:

https://travis-ci.org/rapid7/metasploit-framework/builds/11790225
#2267 modified the get_cookies method, looked okey, unfortunately wasn't catching empty cookies values, thanks rspec and travis!

rspec passed! Dont paste output because body goes too much big.
