### PR TITLE
remove peer and rport methods since they are already defined in Msf::Exploit::Remote::HttpClient

### DIFF
--- a/modules/auxiliary/admin/cisco/cisco_secure_acs_bypass.rb
+++ b/modules/auxiliary/admin/cisco/cisco_secure_acs_bypass.rb
@@ -45,10 +45,6 @@ class Metasploit4 < Msf::Auxiliary
       ], self.class)
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     soapenv='http://schemas.xmlsoap.org/soap/envelope/'
     soapenvenc='http://schemas.xmlsoap.org/soap/encoding/'

--- a/modules/auxiliary/admin/sap/sap_mgmt_con_osexec.rb
+++ b/modules/auxiliary/admin/sap/sap_mgmt_con_osexec.rb
@@ -41,10 +41,6 @@ class Metasploit4 < Msf::Auxiliary
     register_autofilter_ports([ 50013 ])
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     # Check version information to confirm Win/Lin
 

--- a/modules/auxiliary/dos/http/novell_file_reporter_heap_bof.rb
+++ b/modules/auxiliary/dos/http/novell_file_reporter_heap_bof.rb
@@ -38,10 +38,6 @@ class Metasploit3 < Msf::Auxiliary
 
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run
     record = "<RECORD>"
     record << "<NAME>SRS</NAME><OPERATION>4</OPERATION><CMD>7</CMD>" # Operation

--- a/modules/auxiliary/dos/http/novell_file_reporter_heap_bof.rb
+++ b/modules/auxiliary/dos/http/novell_file_reporter_heap_bof.rb
@@ -42,10 +42,6 @@ class Metasploit3 < Msf::Auxiliary
     datastore['RPORT']
   end
 
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
   def run
     record = "<RECORD>"
     record << "<NAME>SRS</NAME><OPERATION>4</OPERATION><CMD>7</CMD>" # Operation

--- a/modules/auxiliary/gather/coldfusion_pwd_props.rb
+++ b/modules/auxiliary/gather/coldfusion_pwd_props.rb
@@ -50,10 +50,6 @@ class Metasploit3 < Msf::Auxiliary
       ], self.class)
   end
 
-  def peer
-    "#{datastore['RHOST']}:#{datastore['RPORT']}"
-  end
-
   def fingerprint(response)
 
     if(response.headers.has_key?('Server') )

--- a/modules/auxiliary/gather/eaton_nsm_creds.rb
+++ b/modules/auxiliary/gather/eaton_nsm_creds.rb
@@ -41,10 +41,6 @@ class Metasploit3 < Msf::Auxiliary
       ], self.class)
   end
 
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
   def execute_php_code(code, opts = {})
     param_name = Rex::Text.rand_text_alpha(6)
     padding    = Rex::Text.rand_text_alpha(6)

--- a/modules/auxiliary/gather/hp_snac_domain_creds.rb
+++ b/modules/auxiliary/gather/hp_snac_domain_creds.rb
@@ -47,10 +47,6 @@ class Metasploit3 < Msf::Auxiliary
       ], self.class)
   end
 
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
   def get_domain_info(session)
     res = send_request_cgi({
       'uri' => "/RegWeb/RegWeb/GetDomainControllerServlet",

--- a/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
@@ -52,10 +52,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     uri = normalize_uri(target_uri.path)
     res = send_request_cgi({

--- a/modules/auxiliary/scanner/http/concrete5_member_list.rb
+++ b/modules/auxiliary/scanner/http/concrete5_member_list.rb
@@ -39,10 +39,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
   def run_host(rhost)
     url = normalize_uri(datastore['URI'], '/index.php/members')
 

--- a/modules/auxiliary/scanner/http/hp_sitescope_getfileinternal_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_getfileinternal_fileaccess.rb
@@ -48,10 +48,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     @peer = "#{rhost}:#{rport}"
     @uri = normalize_uri(target_uri.path)

--- a/modules/auxiliary/scanner/http/hp_sitescope_getsitescopeconfiguration.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_getsitescopeconfiguration.rb
@@ -49,10 +49,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     @peer = "#{rhost}:#{rport}"
     @uri = normalize_uri(target_uri.path)

--- a/modules/auxiliary/scanner/http/hp_sitescope_loadfilecontent_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_loadfilecontent_fileaccess.rb
@@ -48,10 +48,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     @peer = "#{rhost}:#{rport}"
     @uri = normalize_uri(target_uri.path)

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -37,11 +37,6 @@ class Metasploit3 < Msf::Auxiliary
       ], self.class)
   end
 
-
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
   def anonymous_access?
     res = send_request_raw({'uri' => '/'})
     return true if res and res.body =~ /username = "hpsmh_anonymous"/

--- a/modules/auxiliary/scanner/http/joomla_pages.rb
+++ b/modules/auxiliary/scanner/http/joomla_pages.rb
@@ -29,10 +29,6 @@ class Metasploit3 < Msf::Auxiliary
       ], self.class)
   end
 
-  def peer
-    return "#{rhost}:#{rport}"
-  end
-
   def run_host(ip)
     tpath = normalize_uri(target_uri.path)
     if tpath[-1,1] != '/'

--- a/modules/auxiliary/scanner/http/joomla_plugins.rb
+++ b/modules/auxiliary/scanner/http/joomla_plugins.rb
@@ -31,10 +31,6 @@ class Metasploit3 < Msf::Auxiliary
       ], self.class)
   end
 
-  def peer
-    return "#{rhost}:#{rport}"
-  end
-
   def run_host(ip)
     tpath = normalize_uri(target_uri.path)
     if tpath[-1,1] != '/'

--- a/modules/auxiliary/scanner/http/joomla_version.rb
+++ b/modules/auxiliary/scanner/http/joomla_version.rb
@@ -30,10 +30,6 @@ class Metasploit3 < Msf::Auxiliary
       ], self.class)
   end
 
-  def peer
-    return "#{rhost}:#{rport}"
-  end
-
   def os_fingerprint(response)
     if not response.headers.has_key?('Server')
       return "Unkown OS (No Server Header)"

--- a/modules/auxiliary/scanner/http/mediawiki_svg_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/mediawiki_svg_fileaccess.rb
@@ -56,14 +56,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
-  def peer(rhost)
-    "#{rhost}:#{rport}"
-  end
-
   def get_first_session
     res = send_request_cgi({
       'uri'      => normalize_uri(target_uri.to_s, "index.php"),

--- a/modules/auxiliary/scanner/http/novell_file_reporter_fsfui_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/novell_file_reporter_fsfui_fileaccess.rb
@@ -46,14 +46,6 @@ class Metasploit4 < Msf::Auxiliary
 
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
   def run_host(ip)
 
     traversal = "..\\" * datastore['DEPTH']

--- a/modules/auxiliary/scanner/http/novell_file_reporter_srs_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/novell_file_reporter_srs_fileaccess.rb
@@ -47,14 +47,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
   def run_host(ip)
 
     record = "<RECORD><NAME>SRS</NAME><OPERATION>4</OPERATION><CMD>103</CMD><PATH>#{datastore['RFILE']}</PATH></RECORD>"

--- a/modules/auxiliary/scanner/http/ntlm_info_enumeration.rb
+++ b/modules/auxiliary/scanner/http/ntlm_info_enumeration.rb
@@ -32,10 +32,6 @@ class Metasploit3 < Msf::Auxiliary
       ], self.class)
   end
 
-  def peer
-    return "#{rhost}:#{rport}"
-  end
-
   def run_host(ip)
     File.open(datastore['TARGETURIS'], 'rb').each_line do |line|
       test_uri = line.chomp

--- a/modules/auxiliary/scanner/http/sap_businessobjects_version_enum.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_version_enum.rb
@@ -37,10 +37,6 @@ class Metasploit3 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     res = send_request_cgi({
       'uri'    => normalize_uri(datastore['URI'], "/services/listServices"),

--- a/modules/auxiliary/scanner/http/symantec_brightmail_logfile.rb
+++ b/modules/auxiliary/scanner/http/symantec_brightmail_logfile.rb
@@ -51,12 +51,6 @@ class Metasploit3 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
-
   def auth(username, password, sid, last_login)
     res = send_request_cgi({
       'method'    => 'POST',

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_abaplog.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_abaplog.rb
@@ -35,10 +35,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     res = send_request_cgi({
       'uri'     => normalize_uri(datastore['URI']),

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_extractusers.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_extractusers.rb
@@ -38,10 +38,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     res = send_request_cgi({
       'uri'     => normalize_uri(datastore['URI']),

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getaccesspoints.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getaccesspoints.rb
@@ -38,10 +38,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     res = send_request_cgi({
       'uri'      => normalize_uri(datastore['URI']),

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getenv.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getenv.rb
@@ -38,10 +38,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     res = send_request_cgi({
       'uri'      => normalize_uri(datastore['URI']),

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getlogfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getlogfiles.rb
@@ -47,10 +47,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     res = send_request_cgi({
       'uri'      => normalize_uri(datastore['URI']),

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocesslist.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocesslist.rb
@@ -41,10 +41,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     res = send_request_cgi({
       'uri'      => normalize_uri(datastore['URI']),

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocessparameter.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocessparameter.rb
@@ -39,10 +39,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     res = send_request_cgi({
       'uri'      => normalize_uri(datastore['URI']),

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb
@@ -38,10 +38,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     res = send_request_cgi({
       'uri'      => normalize_uri(datastore['URI']),

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
@@ -40,10 +40,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     res = send_request_cgi({
       'uri'      => normalize_uri(datastore['URI']),

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_startprofile.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_startprofile.rb
@@ -38,10 +38,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     res = send_request_cgi({
       'uri'      => normalize_uri(datastore['URI']),

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_version.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_version.rb
@@ -38,10 +38,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     res = send_request_cgi({
       'uri'	 => normalize_uri(datastore['URI']),

--- a/modules/auxiliary/scanner/scada/indusoft_ntwebserver_fileaccess.rb
+++ b/modules/auxiliary/scanner/scada/indusoft_ntwebserver_fileaccess.rb
@@ -47,10 +47,6 @@ class Metasploit4 < Msf::Auxiliary
     deregister_options('RHOST')
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def run_host(ip)
     res = send_request_cgi({
       'uri'     => "/",

--- a/modules/exploits/multi/http/hp_sys_mgmt_exec.rb
+++ b/modules/exploits/multi/http/hp_sys_mgmt_exec.rb
@@ -70,12 +70,6 @@ class Metasploit3 < Msf::Exploit::Remote
       ], self.class)
   end
 
-
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
-
   def check
     @cookie = ''
 

--- a/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
+++ b/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
@@ -79,10 +79,6 @@ class Metasploit3 < Msf::Exploit::Remote
       ], self.class)
   end
 
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
   def lookup_lhost()
     # Get the source address
     if datastore['SRVHOST'] == '0.0.0.0'

--- a/modules/exploits/unix/webapp/arkeia_upload_exec.rb
+++ b/modules/exploits/unix/webapp/arkeia_upload_exec.rb
@@ -56,10 +56,6 @@ class Metasploit3 < Msf::Exploit::Remote
     return target_uri.path
   end
 
-  def peer
-    return "#{rhost}:#{rport}"
-  end
-
   def check
     # Check version
     print_status("#{peer} - Trying to detect installed version")

--- a/modules/exploits/unix/webapp/havalite_upload_exec.rb
+++ b/modules/exploits/unix/webapp/havalite_upload_exec.rb
@@ -53,12 +53,6 @@ class Metasploit3 < Msf::Exploit::Remote
         ], self.class)
   end
 
-
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
-
   #
   # Checks if target is running HavaLite CMS 1.1.7
   # We only flag 1.1.7 as vulnerable, because we don't have enough information from

--- a/modules/exploits/unix/webapp/joomla_media_upload_exec.rb
+++ b/modules/exploits/unix/webapp/joomla_media_upload_exec.rb
@@ -65,10 +65,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
   end
 
-  def peer
-    return "#{rhost}:#{rport}"
-  end
-
   def check
     res = get_upload_form
 

--- a/modules/exploits/unix/webapp/libretto_upload_exec.rb
+++ b/modules/exploits/unix/webapp/libretto_upload_exec.rb
@@ -53,12 +53,6 @@ class Metasploit3 < Msf::Exploit::Remote
       ], self.class)
   end
 
-
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
-
   def check
     res = send_request_raw({'uri' => normalize_uri(target_uri.path)})
     if not res

--- a/modules/exploits/unix/webapp/narcissus_backend_exec.rb
+++ b/modules/exploits/unix/webapp/narcissus_backend_exec.rb
@@ -66,10 +66,6 @@ class Metasploit3 < Msf::Exploit::Remote
     return uri
   end
 
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
   def remote_exe(command)
     res = send_request_cgi({
       'uri'      => "#{base}backend.php",

--- a/modules/exploits/unix/webapp/openemr_sqli_privesc_upload.rb
+++ b/modules/exploits/unix/webapp/openemr_sqli_privesc_upload.rb
@@ -52,10 +52,6 @@ class Metasploit3 < Msf::Exploit::Remote
         ], self.class)
   end
 
-  def peer
-    return "#{rhost}:#{rport}"
-  end
-
   def uri
     return target_uri.path
   end

--- a/modules/exploits/unix/webapp/zeroshell_exec.rb
+++ b/modules/exploits/unix/webapp/zeroshell_exec.rb
@@ -55,10 +55,6 @@ class Metasploit3 < Msf::Exploit::Remote
     return target_uri.path
   end
 
-  def peer
-    return "#{rhost}:#{rport}"
-  end
-
   def check
     # Check version
     print_status("#{peer} - Trying to detect ZeroShell")

--- a/modules/exploits/unix/webapp/zpanel_username_exec.rb
+++ b/modules/exploits/unix/webapp/zpanel_username_exec.rb
@@ -56,12 +56,6 @@ class Metasploit3 < Msf::Exploit::Remote
       ], self.class)
   end
 
-
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
-
   def check
     res = send_request_raw({'uri' => normalize_uri(target_uri.path)})
     if not res

--- a/modules/exploits/windows/http/hp_mpa_job_acct.rb
+++ b/modules/exploits/windows/http/hp_mpa_job_acct.rb
@@ -57,10 +57,6 @@ class Metasploit3 < Msf::Exploit::Remote
       ], self.class)
   end
 
-  def peer
-    return "#{rhost}:#{rport}"
-  end
-
   def webfolder_uri
     begin
       u = datastore['WRITEWEBFOLDER']

--- a/modules/exploits/windows/http/hp_pcm_snac_update_certificates.rb
+++ b/modules/exploits/windows/http/hp_pcm_snac_update_certificates.rb
@@ -116,10 +116,6 @@ class Metasploit3 < Msf::Exploit::Remote
     return nil
   end
 
-  def peer
-    return "#{rhost}:#{rport}"
-  end
-
   def exploit
     print_status("#{peer} - Getting a valid session...")
     session = get_session

--- a/modules/exploits/windows/http/hp_pcm_snac_update_domain.rb
+++ b/modules/exploits/windows/http/hp_pcm_snac_update_domain.rb
@@ -114,10 +114,6 @@ class Metasploit3 < Msf::Exploit::Remote
     return nil
   end
 
-  def peer
-    return "#{rhost}:#{rport}"
-  end
-
   def exploit
     print_status("#{peer} - Getting a valid session...")
     session = get_session

--- a/modules/exploits/windows/http/miniweb_upload_wbem.rb
+++ b/modules/exploits/windows/http/miniweb_upload_wbem.rb
@@ -64,10 +64,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
   end
 
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
   def check
 
     begin

--- a/modules/exploits/windows/http/novell_mdm_lfi.rb
+++ b/modules/exploits/windows/http/novell_mdm_lfi.rb
@@ -53,10 +53,6 @@ class Metasploit3 < Msf::Exploit::Remote
     ], self.class)
   end
 
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
   def get_version
     version = nil
 

--- a/modules/exploits/windows/http/oracle_endeca_exec.rb
+++ b/modules/exploits/windows/http/oracle_endeca_exec.rb
@@ -55,10 +55,6 @@ class Metasploit3 < Msf::Exploit::Remote
       ], self.class)
   end
 
-  def peer
-    return "#{rhost}:#{rport}"
-  end
-
   def version_soap
     soap = <<-eos
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns="http://www.endeca.com/endeca-server/control/1/0">

--- a/modules/exploits/windows/novell/file_reporter_fsfui_upload.rb
+++ b/modules/exploits/windows/novell/file_reporter_fsfui_upload.rb
@@ -92,10 +92,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
   end
 
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
   def exploit
 
     # In order to save binary data to the file system the payload is written to a .vbs


### PR DESCRIPTION
Msf::Exploit::Remote::HttpClient already defines the peer and rport methods so a redefinition is not necessary.
