### PR TITLE
Fix bug on missing hosts for SunRPC Portmap

### DIFF
--- a/lib/msf/core/exploit/sunrpc.rb
+++ b/lib/msf/core/exploit/sunrpc.rb
@@ -68,11 +68,11 @@ module Exploit::Remote::SunRPC
     end
 
     ret = rpcobj.create
-    return print_error("#{rhost} - No response to SunRPC PortMap request") unless ret
+    return print_error("#{rhost}:#{rport} - SunRPC - No response to Portmap request") unless ret
 
     arr = XDR.decode!(ret, Integer, Integer, Integer, String, Integer, Integer)
     if arr[1] != MSG_ACCEPTED || arr[4] != SUCCESS || arr[5] == 0
-      err = "#{rhost} - SunRPC PortMap request failed: "
+      err = "#{rhost}:#{rport} - SunRPC - Portmap request failed: "
       err << 'Message not accepted'  if arr[1] != MSG_ACCEPTED
       err << 'RPC did not execute'   if arr[4] != SUCCESS
       err << 'Program not available' if arr[5] == 0
@@ -87,7 +87,7 @@ module Exploit::Remote::SunRPC
 
   def sunrpc_call(proc, buf, timeout=20)
     ret = rpcobj.call(proc, buf, timeout)
-    return print_error("#{rhost} - No response to SunRPC call for procedure: #{proc}") unless ret
+    return print_error("#{rhost}:#{rport} - SunRPC - No response to SunRPC call for procedure: #{proc}") unless ret
 
     arr = Rex::Encoder::XDR.decode!(ret, Integer, Integer, Integer, String, Integer)
     if arr[1] != MSG_ACCEPTED || arr[4] != SUCCESS
@@ -105,7 +105,7 @@ module Exploit::Remote::SunRPC
           else err << "Unknown Error"
         end
       end
-      print_error("#{rhost} - #{err}")
+      print_error("#{rhost}:#{rport} - SunRPC - #{err}")
       return nil
     end
     return ret
@@ -134,7 +134,7 @@ module Exploit::Remote::SunRPC
     arr = Rex::Encoder::XDR.decode!(ret, Integer, Integer, Integer, String, Integer)
     if arr[1] != MSG_ACCEPTED || arr[4] != SUCCESS || arr[5] == 0
       progname = progresolv(rpcobj.program)
-      err = "SunRPC query for program #{rpcobj.program} [#{progname}] failed: "
+      err = "Query for program #{rpcobj.program} [#{progname}] failed: "
       case arr[4]
         when PROG_UMAVAIL  then err << "Program Unavailable"
         when PROG_MISMATCH then err << "Program Version Mismatch"
@@ -142,7 +142,7 @@ module Exploit::Remote::SunRPC
         when GARBAGE_ARGS  then err << "Garbage Arguments"
         else err << "Unknown Error"
       end
-      print_error("#{rhost} - #{err}")
+      print_error("#{rhost}:#{rport} - SunRPC - #{err}")
       return nil
     end
 

--- a/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
+++ b/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
@@ -32,6 +32,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run_host(ip)
+    vprint_status "#{ip}:#{rport} - SunRPC - Enumerating programs"
 
     begin
       program		= 100000
@@ -43,9 +44,9 @@ class Metasploit3 < Msf::Auxiliary
       resp = sunrpc_call(procedure, "")
 
       progs = resp[3,1].unpack('C')[0]
+      maps = []
       if (progs == 0x01)
-        print_good("#{ip} - Programs available")
-        maps = []
+        print_good("#{ip}:#{rport} - Programs available")
         while XDR.decode_int!(resp) == 1 do
           map = XDR.decode!(resp, Integer, Integer, Integer, Integer)
           maps << map


### PR DESCRIPTION
Also cleans up and normalizes the print messages to follow the
conventions of "host:port - proto - message"

[FixRM #8409], reported by Chris F.
## Verification
- [x] Run `auxiliary/scanner/misc/sunrpc_portmapper` against a host that's not listening on UDP/111.
- [x] See the lack of a raise, as below.
- [x] See the more beautiful status messages, as below.

Post-fix screen:

```
msf auxiliary(sunrpc_portmapper) > set rhosts www.metasploit.com
rhosts => www.metasploit.com
msf auxiliary(sunrpc_portmapper) > set verbose true
verbose => true
msf auxiliary(sunrpc_portmapper) > run

[*] 208.118.237.137:111 - SunRPC - Enumerating programs
[-] 208.118.237.137:111 - SunRPC - No response to Portmap request
[-] 208.118.237.137:111 - SunRPC - No response to SunRPC call for procedure: 4
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(sunrpc_portmapper) > exit
```
