### PR TITLE
Implements RM#3311 - CmdStager selection

### DIFF
--- a/lib/msf/core/exploit/cmdstager.rb
+++ b/lib/msf/core/exploit/cmdstager.rb
@@ -3,6 +3,16 @@
 require 'rex/exploitation/cmdstager'
 require 'msf/core/exploit/exe'
 
+# The various CmdStager exploit mixins
+require 'msf/core/exploit/cmdstager/vbs'
+require 'msf/core/exploit/cmdstager/adodb'
+require 'msf/core/exploit/cmdstager/debugwrite'
+require 'msf/core/exploit/cmdstager/debugasm'
+require 'msf/core/exploit/cmdstager/tftp'
+require 'msf/core/exploit/cmdstager/bourne'
+require 'msf/core/exploit/cmdstager/echo'
+
+
 module Msf
 
 ###
@@ -15,12 +25,84 @@ module Exploit::CmdStager
   include Msf::Exploit::EXE
 
   #
+  # This is all of the valid CmdStagers
+  #
+  SUPPORTED_CMD_STAGERS = [
+    'VBS',
+    'ADODB',
+    'DebugWrite',
+    'DebugAsm',
+    'TFTP',
+    'Bourne',
+    'Echo'
+  ]
+
+  #
   # Creates an instance of an exploit that uses an CmdStager overwrite.
   #
   def initialize(info = {})
     super
+
+    register_options(
+      [
+        OptString.new('CmdStager', [ true, "The flavor of CmdStager to use", 'vbs' ]),
+      ], self.class
+    )
+
     @cmd_list = nil
     @stager_instance = nil
+    @stager_extended = nil
+  end
+
+
+  #
+  # Called when someone does "set cmdstager"
+  #
+  def cmdstager_validate(value)
+    val = value.downcase
+
+    # is it one of the supported CmdStagers ?
+    return false if not SUPPORTED_CMD_STAGERS.map { |e| e.downcase }.include? val
+
+    #
+    # NOTE: undoing the extension is not possible. This may lead to some
+    # unexpected behavior. For example, switching between CmdStager settings 
+    # multiple time may not behave correctly.
+    #
+    if @stager_extended and @stager_extended != val
+      print_error("CmdStager can only be assigned once. Try 'back' then 'use' again.")
+      return false
+    end
+
+    case val
+      when 'vbs'
+        extend Msf::Exploit::CmdStager::VBS
+
+      when 'adodb'
+        extend Msf::Exploit::CmdStager::ADODB
+
+      when 'debugwrite'
+        extend Msf::Exploit::CmdStager::DebugWrite
+
+      when 'debugasm'
+        extend Msf::Exploit::CmdStager::DebugAsm
+
+      when 'tftp'
+        extend Msf::Exploit::CmdStager::TFTP
+
+      when 'bourne'
+        extend Msf::Exploit::CmdStager::Bourne
+
+      when 'echo'
+        extend Msf::Exploit::CmdStager::Echo
+
+      else
+        return false
+
+    end
+
+    @stager_extended = val
+    true
   end
 
 

--- a/lib/msf/core/exploit/cmdstager/adodb.rb
+++ b/lib/msf/core/exploit/cmdstager/adodb.rb
@@ -1,7 +1,5 @@
 # -*- coding: binary -*-
 
-require 'msf/core/exploit/cmdstager'
-
 module Msf
 
 ###
@@ -9,22 +7,21 @@ module Msf
 # This mixin provides an interface for staging cmd to arbitrary payloads
 #
 ###
-module Exploit::CmdStagerDebugWrite
-
-  include Msf::Exploit::CmdStager
+module Exploit::CmdStager
+module ADODB
 
   def initialize(info = {})
     super
 
     register_advanced_options(
       [
-        OptString.new( 'DECODERSTUB',  [ true, 'The debug.exe file-writing decoder stub to use.',
-          File.join(Msf::Config.install_root, "data", "exploits", "cmdstager", "debug_write")]),
+        OptString.new( 'DECODERSTUB',  [ true, 'The VBS base64 file decoder stub to use.',
+          File.join(Msf::Config.install_root, "data", "exploits", "cmdstager", "vbs_b64_adodb")]),
       ], self.class)
   end
 
   def create_stager(exe)
-    Rex::Exploitation::CmdStagerDebugWrite.new(exe)
+    Rex::Exploitation::CmdStagerVBS.new(exe)
   end
 
   def execute_cmdstager(opts = {})
@@ -38,4 +35,5 @@ module Exploit::CmdStagerDebugWrite
   end
 end
 
+end
 end

--- a/lib/msf/core/exploit/cmdstager/bourne.rb
+++ b/lib/msf/core/exploit/cmdstager/bourne.rb
@@ -1,7 +1,5 @@
 # -*- coding: binary -*-
 
-require 'msf/core/exploit/cmdstager'
-
 module Msf
 
 ###
@@ -9,13 +7,13 @@ module Msf
 # This mixin provides an interface for staging cmd to arbitrary payloads
 #
 ###
-module Exploit::CmdStagerBourne
-
-  include Msf::Exploit::CmdStager
+module Exploit::CmdStager
+module Bourne
 
   def create_stager(exe)
     Rex::Exploitation::CmdStagerBourne.new(exe)
   end
 end
 
+end
 end

--- a/lib/msf/core/exploit/cmdstager/debugasm.rb
+++ b/lib/msf/core/exploit/cmdstager/debugasm.rb
@@ -1,7 +1,5 @@
 # -*- coding: binary -*-
 
-require 'msf/core/exploit/cmdstager'
-
 module Msf
 
 ###
@@ -9,9 +7,8 @@ module Msf
 # This mixin provides an interface for staging cmd to arbitrary payloads
 #
 ###
-module Exploit::CmdStagerDebugAsm
-
-  include Msf::Exploit::CmdStager
+module Exploit::CmdStager
+module DebugAsm
 
   def initialize(info = {})
     super
@@ -38,4 +35,5 @@ module Exploit::CmdStagerDebugAsm
   end
 end
 
+end
 end

--- a/lib/msf/core/exploit/cmdstager/debugwrite.rb
+++ b/lib/msf/core/exploit/cmdstager/debugwrite.rb
@@ -1,7 +1,5 @@
 # -*- coding: binary -*-
 
-require 'msf/core/exploit/cmdstager'
-
 module Msf
 
 ###
@@ -9,22 +7,21 @@ module Msf
 # This mixin provides an interface for staging cmd to arbitrary payloads
 #
 ###
-module Exploit::CmdStagerVBS
-
-  include Msf::Exploit::CmdStager
+module Exploit::CmdStager
+module DebugWrite
 
   def initialize(info = {})
     super
 
     register_advanced_options(
       [
-        OptString.new( 'DECODERSTUB',  [ true, 'The VBS base64 file decoder stub to use.',
-          File.join(Msf::Config.install_root, "data", "exploits", "cmdstager", "vbs_b64")]),
+        OptString.new( 'DECODERSTUB',  [ true, 'The debug.exe file-writing decoder stub to use.',
+          File.join(Msf::Config.install_root, "data", "exploits", "cmdstager", "debug_write")]),
       ], self.class)
   end
 
   def create_stager(exe)
-    Rex::Exploitation::CmdStagerVBS.new(exe)
+    Rex::Exploitation::CmdStagerDebugWrite.new(exe)
   end
 
   def execute_cmdstager(opts = {})
@@ -38,4 +35,5 @@ module Exploit::CmdStagerVBS
   end
 end
 
+end
 end

--- a/lib/msf/core/exploit/cmdstager/echo.rb
+++ b/lib/msf/core/exploit/cmdstager/echo.rb
@@ -1,7 +1,5 @@
 # -*- coding: binary -*-
 
-require 'msf/core/exploit/cmdstager'
-
 module Msf
 
 ####
@@ -18,9 +16,8 @@ module Msf
 #
 ####
 
-module Exploit::CmdStagerEcho
-
-  include Msf::Exploit::CmdStager
+module Exploit::CmdStager
+module Echo
 
   # Initializes a CmdStagerEcho instance for the supplied payload
   #
@@ -31,4 +28,5 @@ module Exploit::CmdStagerEcho
   end
 end
 
+end
 end

--- a/lib/msf/core/exploit/cmdstager/tftp.rb
+++ b/lib/msf/core/exploit/cmdstager/tftp.rb
@@ -2,7 +2,6 @@
 
 require 'rex/text'
 require 'msf/core/exploit/tftp'
-require 'msf/core/exploit/cmdstager'
 
 module Msf
 
@@ -11,9 +10,9 @@ module Msf
 # This mixin provides an interface for staging cmd to arbitrary payloads
 #
 ###
-module Exploit::CmdStagerTFTP
+module Exploit::CmdStager
+module TFTP
 
-  include Msf::Exploit::CmdStager
   include Msf::Exploit::TFTPServer
 
   def initialize(info = {})
@@ -64,4 +63,5 @@ module Exploit::CmdStagerTFTP
 
 end
 
+end
 end

--- a/lib/msf/core/exploit/cmdstager/vbs.rb
+++ b/lib/msf/core/exploit/cmdstager/vbs.rb
@@ -1,7 +1,5 @@
 # -*- coding: binary -*-
 
-require 'msf/core/exploit/cmdstager'
-
 module Msf
 
 ###
@@ -9,9 +7,8 @@ module Msf
 # This mixin provides an interface for staging cmd to arbitrary payloads
 #
 ###
-module Exploit::CmdStagerVBS::ADODB
-
-  include Msf::Exploit::CmdStager
+module Exploit::CmdStager
+module VBS
 
   def initialize(info = {})
     super
@@ -19,7 +16,7 @@ module Exploit::CmdStagerVBS::ADODB
     register_advanced_options(
       [
         OptString.new( 'DECODERSTUB',  [ true, 'The VBS base64 file decoder stub to use.',
-          File.join(Msf::Config.install_root, "data", "exploits", "cmdstager", "vbs_b64_adodb")]),
+          File.join(Msf::Config.install_root, "data", "exploits", "cmdstager", "vbs_b64")]),
       ], self.class)
   end
 
@@ -38,4 +35,5 @@ module Exploit::CmdStagerVBS::ADODB
   end
 end
 
+end
 end

--- a/lib/msf/core/exploit/mixins.rb
+++ b/lib/msf/core/exploit/mixins.rb
@@ -19,13 +19,6 @@ require 'msf/core/exploit/php_exe'
 
 # CmdStagers
 require 'msf/core/exploit/cmdstager'
-require 'msf/core/exploit/cmdstager_vbs'
-require 'msf/core/exploit/cmdstager_vbs_adodb'
-require 'msf/core/exploit/cmdstager_debug_write'
-require 'msf/core/exploit/cmdstager_debug_asm'
-require 'msf/core/exploit/cmdstager_tftp'
-require 'msf/core/exploit/cmdstager_bourne'
-require 'msf/core/exploit/cmdstager_echo'
 
 # Protocol
 require 'msf/core/exploit/tcp'

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -547,18 +547,21 @@ class Driver < Msf::Ui::Driver
   # Called when a variable is set to a specific value.  This allows the
   # console to do extra processing, such as enabling logging or doing
   # some other kind of task.  If this routine returns false it will indicate
-  # that the variable is not being set to a valid value.
+  # that the variable is not being set due to an invalid value.
   #
   def on_variable_set(glob, var, val)
     case var.downcase
       when "payload"
-
         if (framework and framework.payloads.valid?(val) == false)
           return false
         elsif (active_module)
           active_module.datastore.clear_non_user_defined
         elsif (framework)
           framework.datastore.clear_non_user_defined
+        end
+      when "cmdstager"
+        if (active_module and active_module.respond_to?(:cmdstager_validate))
+          active_module.send(:cmdstager_validate, val)
         end
       when "sessionlogging"
         handle_session_logging(val) if (glob)

--- a/modules/exploits/multi/http/hp_sys_mgmt_exec.rb
+++ b/modules/exploits/multi/http/hp_sys_mgmt_exec.rb
@@ -10,7 +10,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info={})

--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -11,7 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = GoodRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/exploits/multi/http/linksys_wrt110_cmd_exec_stager.rb
+++ b/modules/exploits/multi/http/linksys_wrt110_cmd_exec_stager.rb
@@ -11,7 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStagerEcho
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,
@@ -37,6 +37,10 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => true,
       'Platform'       => ['linux'],
       'Arch'           => ARCH_MIPSLE,
+      'DefaultOptions' =>
+        {
+          'CmdStager' => 'echo'
+        },
       'Targets'        =>
         [
             ['Linux mipsel Payload', { } ]

--- a/modules/exploits/multi/http/netwin_surgeftp_exec.rb
+++ b/modules/exploits/multi/http/netwin_surgeftp_exec.rb
@@ -11,7 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = GoodRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/exploits/multi/http/struts_code_exec.rb
+++ b/modules/exploits/multi/http/struts_code_exec.rb
@@ -10,7 +10,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = GoodRanking
 
-  include Msf::Exploit::CmdStagerTFTP
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
@@ -39,6 +39,10 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'Platform'      => %w{ linux win },
       'Privileged'     => true,
+      'DefaultOptions' =>
+        {
+          'CmdStager' => 'tftp'
+        },
       'Targets'        =>
         [
           ['Windows Universal',

--- a/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
+++ b/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
@@ -10,7 +10,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::CmdStagerTFTP
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
@@ -42,6 +42,10 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'Platform'      => %w{ java linux win },
       'Privileged'     => true,
+      'DefaultOptions' =>
+        {
+          'CmdStager' => 'tftp'
+        },
       'Targets'        =>
         [
           ['Windows Universal',

--- a/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
+++ b/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
@@ -14,7 +14,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HttpServer
-  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
@@ -28,7 +28,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
   Rank = GreatRanking
 
-  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::EXE
   include Msf::Exploit::Remote::HttpClient
 

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_command_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_command_exec.rb
@@ -28,7 +28,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
   Rank = GreatRanking
 
-  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::EXE
   include Msf::Exploit::Remote::HttpClient
 

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -11,7 +11,7 @@ require 'net/ssh'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ManualRanking
 
-  include Msf::Exploit::CmdStagerBourne
+  include Msf::Exploit::CmdStager
 
   attr_accessor :ssh_socket
 
@@ -42,6 +42,10 @@ class Metasploit3 < Msf::Exploit::Remote
           'DisableNops' => true
         },
       'Platform'    => %w{ linux osx },
+      'DefaultOptions' =>
+        {
+          'CmdStager' => 'Bourne'
+        },
       'Targets'     =>
         [
           [ 'Linux x86',

--- a/modules/exploits/unix/webapp/zeroshell_exec.rb
+++ b/modules/exploits/unix/webapp/zeroshell_exec.rb
@@ -11,7 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStagerEcho
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::EXE
 
   def initialize(info={})
@@ -37,6 +37,10 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'Platform'        => ['linux'],
       'Arch'            => ARCH_X86,
+      'DefaultOptions' =>
+        {
+          'CmdStager' => 'Echo',
+        },
       'Targets'         =>
         [
           ['ZeroShell 2.0 RC2', {}]

--- a/modules/exploits/windows/antivirus/ams_hndlrsvc.rb
+++ b/modules/exploits/windows/antivirus/ams_hndlrsvc.rb
@@ -11,7 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   Rank = ExcellentRanking
 
-  include Msf::Exploit::CmdStagerTFTP
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
@@ -30,6 +30,10 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'BID', '41959' ],
           [ 'URL', 'http://www.foofus.net/~spider/code/AMS2_072610.txt' ],
         ],
+      'DefaultOptions' =>
+        {
+          'CmdStager' => 'tftp',
+        },
       'Targets'       =>
         [
           [ 'Windows Universal',

--- a/modules/exploits/windows/antivirus/ams_xfr.rb
+++ b/modules/exploits/windows/antivirus/ams_xfr.rb
@@ -11,7 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   Rank = ExcellentRanking
 
-  include Msf::Exploit::CmdStagerTFTP
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::Tcp
 
   def initialize(info = {})
@@ -31,6 +31,10 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-09-060/' ],
           [ 'URL', 'http://www.symantec.com/business/security_response/securityupdates/detail.jsp?fid=security_advisory&pvid=security_advisory&suid=20090428_02' ]
         ],
+      'DefaultOptions' =>
+        {
+          'CmdStager' => 'tftp',
+        },
       'Targets'       =>
         [
           [ 'Windows Universal',

--- a/modules/exploits/windows/browser/dxstudio_player_exec.rb
+++ b/modules/exploits/windows/browser/dxstudio_player_exec.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
-  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/exploits/windows/http/ca_totaldefense_regeneratereports.rb
+++ b/modules/exploits/windows/http/ca_totaldefense_regeneratereports.rb
@@ -10,7 +10,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::CmdStagerTFTP
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
@@ -31,6 +31,10 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '74968'],
           [ 'CVE', '2011-1653' ],
         ],
+      'DefaultOptions' =>
+        {
+          'CmdStager' => 'tftp',
+        },
       'Targets'	=>
         [
           [ 'Windows Universal',

--- a/modules/exploits/windows/http/hp_sitescope_runomagentcommand.rb
+++ b/modules/exploits/windows/http/hp_sitescope_runomagentcommand.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
   HttpFingerprint = { :pattern => [ /Apache-Coyote/ ] }
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/exploits/windows/http/osb_uname_jlist.rb
+++ b/modules/exploits/windows/http/osb_uname_jlist.rb
@@ -10,7 +10,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::CmdStagerTFTP
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::HttpClient
 
   def initialize(info = {})
@@ -32,6 +32,10 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-10-118' ]
           # the jlist vector has not been disclosed or has it?
         ],
+      'DefaultOptions' =>
+        {
+          'CmdStager' => 'tftp',
+        },
       'Targets'	=>
         [
           [ 'Windows Universal',

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -11,7 +11,7 @@ class Metasploit3 < Msf::Exploit
   Rank = GreatRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::FileDropper
 
   def initialize(info = {})

--- a/modules/exploits/windows/http/sap_mgmt_con_osexec_payload.rb
+++ b/modules/exploits/windows/http/sap_mgmt_con_osexec_payload.rb
@@ -18,7 +18,7 @@ class Metasploit4 < Msf::Exploit::Remote
   HttpFingerprint = { :pattern => [ /gSOAP\/2.7/ ] }
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::CmdStager
   include Msf::Exploit::EXE
 
   def initialize(info = {})

--- a/modules/exploits/windows/iis/ms01_026_dbldecode.rb
+++ b/modules/exploits/windows/iis/ms01_026_dbldecode.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
   # NOTE: This cannot be an HttpClient module since the response from the server
   # is not a valid HttpResponse
   include Msf::Exploit::Remote::Tcp
-  include Msf::Exploit::CmdStagerTFTP
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,
@@ -36,6 +36,10 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'http://marc.info/?l=bugtraq&m=98992056521300&w=2' ]
         ],
       'Platform'       => 'win',
+      'DefaultOptions' =>
+        {
+          'CmdStager' => 'tftp',
+        },
       'Targets'        =>
         [
           [ 'Automatic', { } ]

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::CmdStagerTFTP
+  include Msf::Exploit::CmdStager
 
   def initialize
     super(
@@ -45,6 +45,10 @@ class Metasploit3 < Msf::Exploit::Remote
           ['MSB', 'MS98-004'],
           ['MSB', 'MS99-025']
         ],
+      'DefaultOptions' =>
+        {
+          'CmdStager' => 'tftp',
+        },
       'Targets'        =>
         [
           # patrickw tested meterpreter OK 20120601

--- a/modules/exploits/windows/mssql/mssql_linkcrawler.rb
+++ b/modules/exploits/windows/mssql/mssql_linkcrawler.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::MSSQL
   include Msf::Auxiliary::Report
-  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -11,10 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::MSSQL
-  include Msf::Exploit::CmdStagerVBS
-  #include Msf::Exploit::CmdStagerDebugAsm
-  #include Msf::Exploit::CmdStagerDebugWrite
-  #include Msf::Exploit::CmdStagerTFTP
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/exploits/windows/mssql/mssql_payload_sqli.rb
+++ b/modules/exploits/windows/mssql/mssql_payload_sqli.rb
@@ -11,7 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::MSSQL_SQLI
-  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/exploits/windows/mysql/mysql_payload.rb
+++ b/modules/exploits/windows/mysql/mysql_payload.rb
@@ -11,7 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::MYSQL
-  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(

--- a/modules/exploits/windows/oracle/extjob.rb
+++ b/modules/exploits/windows/oracle/extjob.rb
@@ -11,7 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::SMB
-  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/exploits/windows/winrm/winrm_script_exec.rb
+++ b/modules/exploits/windows/winrm/winrm_script_exec.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = ManualRanking
 
   include Msf::Exploit::Remote::WinRM
-  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::CmdStager
 
 
   def initialize(info = {})
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Description'    => %q{
           This module uses valid credentials to login to the WinRM service
           and execute a payload. It has two available methods for payload
-          delivery: Powershell 2.0 and VBS CmdStager.
+          delivery: Powershell 2.0 and CmdStager.
 
           The module will check if Powershell 2.0 is available, and if so uses
           that method. Otherwise it falls back to the VBS Cmdstager which is
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     register_options(
       [
-        OptBool.new('FORCE_VBS', [ true, 'Force the module to use the VBS CmdStager', false]),
+        OptBool.new('FORCE_VBS', [ true, 'Force the module to use the CmdStager', false]),
         OptString.new('USERNAME', [ true, 'A specific username to authenticate as' ]),
         OptString.new('PASSWORD', [ true, 'A specific password to authenticate with' ]),
       ], self.class

--- a/test/modules/exploits/test/cmdweb.rb
+++ b/test/modules/exploits/test/cmdweb.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Exploit::Remote
 	# =( need more targets and perhaps more OS specific return values OS specific would be preferred
 
 	include Msf::Exploit::Remote::HttpClient
-	include Msf::Exploit::CmdStagerVBS
+	include Msf::Exploit::CmdStager
 
 	def initialize(info = {})
 		super(update_info(info,
@@ -30,9 +30,10 @@ class Metasploit3 < Msf::Exploit::Remote
 			'References' =>
 				[
 				],
-			'DefaultOptions' =>
-				{
-				},
+      'DefaultOptions' =>
+        {
+          'CmdStager' => 'tftp',
+        },
 			'Payload' =>
 				{
 				},


### PR DESCRIPTION
I'm mostly submitting this for review. I suspect it might not really be fully ready yet. It could definitely use more testing.

For modules that use the CmdStager mixin, let the end user select which CmdStager to use. Existing consumers of the CmdStager mixins have been updated to expose this new functionality and retain their previous default.

Unfortunately, this patch does not include compat flags that prevent users from shooting themselves from using a Windows CmdStager on UNIX, or vice versa. Perhaps that can be added at a later time.
