### PR TITLE
MSFTidy: Warn for tabbed indentation

### DIFF
--- a/modules/auxiliary/scanner/http/ektron_cms400net.rb
+++ b/modules/auxiliary/scanner/http/ektron_cms400net.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
     def gen_blank_passwords(users, credentials)
-    	return credentials
+      return credentials
     end
 
   def run_host(ip)

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -361,10 +361,14 @@ class Msftidy
         warn("Spaces at EOL", idx)
       end
 
-      # Allow tabs or spaces as indent characters, but not both.
-      # This should check for spaces only on October 8, 2013
+      # Check for mixed tab/spaces. Upgrade this to an error() soon.
       if (ln.length > 1) and (ln =~ /^([\t ]*)/) and ($1.match(/\x20\x09|\x09\x20/))
         warn("Space-Tab mixed indent: #{ln.inspect}", idx)
+      end
+
+      # Check for tabs. Upgrade this to an error() soon.
+      if (ln.length > 1) and (ln =~ /^\x09/)
+        warn("Tabbed indent: #{ln.inspect}", idx)
       end
 
       if ln =~ /\r$/


### PR DESCRIPTION
This will start yelling at people for using tabbed indentation. Since we just switched over (see http://r-7.co/MSF-TABS), it'd be best to just fix it for people when it comes in. After October, feel free to start rejecting new PRs that use tab indentation or have mixed space/tab indents. IOW, it's a WARN now, and should be fixed; soon it will be an ERROR, and should be rejected.
## Verification
- [x] `tools/msftidy.rb modules | grep -e "Tabbed" -e "Space-Tab"` should return no results.
- [x] Fetch a module with some tabbed and mixed tab/space lines: `curl -L -o /tmp/test.rb curl -L -o /tmp/test.rb https://gist.github.com/todb-r7/91926d98240db767c66f/raw/58f907dbfa354dd02b9fc6698532575b6f2b4b46/http_version.rb`
- [x] See the results by running `tools/msftidy.rb /tmp/test.rb`

```
$ tools/msftidy.rb /tmp/test.rb test.rb:14 - [WARNING] Tabbed indent: "\t# Exploit mixins should be called first\n"
test.rb:15 - [WARNING] Tabbed indent: "\tinclude Msf::Exploit::Remote::HttpClient\n"
test.rb:16 - [WARNING] Tabbed indent: "\tinclude Msf::Auxiliary::WmapScanServer\n"
test.rb:17 - [WARNING] Tabbed indent: "\t# Scanner mixin should be near last\n"
test.rb:18 - [WARNING] Tabbed indent: "\tinclude Msf::Auxiliary::Scanner\n"
test.rb:22 - [WARNING] Space-Tab mixed indent: "   \t   'Name'        => 'HTTP Version Detection',\n"
test.rb:23 - [WARNING] Space-Tab mixed indent: "  \t   'Description' => 'Display version information about each system',\n"
test.rb:24 - [WARNING] Space-Tab mixed indent: "  \t   'Author'      => 'hdm',\n"
test.rb:25 - [WARNING] Space-Tab mixed indent: "  \t   'License'     => MSF_LICENSE\n"
test.rb:34 - [WARNING] Tabbed indent: "\t# Fingerprint a single host\n"
test.rb:35 - [WARNING] Tabbed indent: "\tdef run_host(ip)\n"
test.rb:36 - [WARNING] Tabbed indent: "\t\tbegin\n"
test.rb:37 - [WARNING] Tabbed indent: "\t\t\tconnect\n"
```
