### PR TITLE
Add a bind port setting to reverse listeners

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -83,8 +83,8 @@ module ReverseHttp
   # addresses.
   #
   def full_uri
-    addrs = bind_address(datastore)
-    local_port = bind_port(datastore)
+    addrs = bind_address
+    local_port = bind_port
     scheme = (ssl?) ? "https" : "http"
     "#{scheme}://#{addrs[0]}:#{local_port}/"
   end
@@ -174,8 +174,8 @@ module ReverseHttp
       comm = nil
     end
 
-    local_port = bind_port(datastore)
-    addrs = bind_address(datastore)
+    local_port = bind_port
+    addrs = bind_address
 
     # Start the HTTPS server service on this host/port
     self.service = Rex::ServiceManager.start(Rex::Proto::Http::Server,
@@ -399,12 +399,12 @@ protected
 
 protected
 
-  def bind_port(datastore)
+  def bind_port
     port = datastore['ReverseListenerBindPort'].to_i
     port > 0 ? port : datastore['LPORT'].to_i
   end
 
-  def bind_address(datastore)
+  def bind_address
     # Switch to IPv6 ANY address if the LHOST is also IPv6
     addr = Rex::Socket.resolv_nbo(datastore['LHOST'])
     # First attempt to bind LHOST. If that fails, the user probably has

--- a/lib/msf/core/handler/reverse_https_proxy.rb
+++ b/lib/msf/core/handler/reverse_https_proxy.rb
@@ -42,12 +42,16 @@ module ReverseHttpsProxy
         OptPort.new('LPORT', [ true, "The local listener port", 8443 ]),
         OptString.new('PROXYHOST', [true, "The address of the http proxy to use" ,"127.0.0.1"]),
         OptInt.new('PROXYPORT', [ false, "The Proxy port to connect to", 8080 ]),
-        OptString.new('HIDDENHOST', [false, "The tor hidden host to connect to, when set it will be used instead of LHOST for stager generation"]),
-        OptInt.new('HIDDENPORT', [ false, "The hidden port to connect to, when set it will be used instead of LPORT for stager generation"]),
         OptEnum.new('PROXY_TYPE', [true, 'Http or Socks4 proxy type', 'HTTP', ['HTTP', 'SOCKS']]),
         OptString.new('PROXY_USERNAME', [ false, "An optional username for HTTP proxy authentification"]),
         OptString.new('PROXY_PASSWORD', [ false, "An optional password for HTTP proxy authentification"])
  			], Msf::Handler::ReverseHttpsProxy)
+
+    register_advanced_options(
+      [
+        OptAddress.new('ReverseListenerBindAddress', [ false, 'The specific IP address to bind to on the local system']),
+        OptInt.new('ReverseListenerBindPort', [ false, 'The port to bind to on the local system if different from LPORT' ])
+      ], Msf::Handler::ReverseHttpsProxy)
 
   end
 

--- a/lib/msf/core/handler/reverse_tcp.rb
+++ b/lib/msf/core/handler/reverse_tcp.rb
@@ -53,8 +53,9 @@ module ReverseTcp
       [
         OptInt.new('ReverseConnectRetries', [ true, 'The number of connection attempts to try before exiting the process', 5 ]),
         OptAddress.new('ReverseListenerBindAddress', [ false, 'The specific IP address to bind to on the local system']),
+        OptInt.new('ReverseListenerBindPort', [ false, 'The port to bind to on the local system if different from LPORT' ]),
         OptString.new('ReverseListenerComm', [ false, 'The specific communication channel to use for this listener']),
-        OptBool.new('ReverseAllowProxy', [ true, 'Allow reverse tcp even with Proxies specified. Connect back will NOT go through proxy but directly to LHOST', false]),
+        OptBool.new('ReverseAllowProxy', [ true, 'Allow reverse tcp even with Proxies specified. Connect back will NOT go through proxy but directly to LHOST', false])
       ], Msf::Handler::ReverseTcp)
 
 
@@ -72,13 +73,6 @@ module ReverseTcp
     end
 
     ex = false
-    # Switch to IPv6 ANY address if the LHOST is also IPv6
-    addr = Rex::Socket.resolv_nbo(datastore['LHOST'])
-    # First attempt to bind LHOST. If that fails, the user probably has
-    # something else listening on that interface. Try again with ANY_ADDR.
-    any = (addr.length == 4) ? "0.0.0.0" : "::0"
-
-    addrs = [ Rex::Socket.addr_ntoa(addr), any  ]
 
     comm  = datastore['ReverseListenerComm']
     if comm.to_s == "local"
@@ -87,19 +81,15 @@ module ReverseTcp
       comm = nil
     end
 
-    if not datastore['ReverseListenerBindAddress'].to_s.empty?
-      # Only try to bind to this specific interface
-      addrs = [ datastore['ReverseListenerBindAddress'] ]
+    local_port = bind_port(datastore)
+    addrs = bind_address(datastore)
 
-      # Pick the right "any" address if either wildcard is used
-      addrs[0] = any if (addrs[0] == "0.0.0.0" or addrs == "::0")
-    end
     addrs.each { |ip|
       begin
 
         self.listener_sock = Rex::Socket::TcpServer.create(
           'LocalHost' => ip,
-          'LocalPort' => datastore['LPORT'].to_i,
+          'LocalPort' => local_port,
           'Comm'      => comm,
           'Context'   =>
             {
@@ -119,11 +109,11 @@ module ReverseTcp
           via = ""
         end
 
-        print_status("Started reverse handler on #{ip}:#{datastore['LPORT']} #{via}")
+        print_status("Started reverse handler on #{ip}:#{local_port} #{via}")
         break
       rescue
         ex = $!
-        print_error("Handler failed to bind to #{ip}:#{datastore['LPORT']}")
+        print_error("Handler failed to bind to #{ip}:#{local_port}")
       end
     }
     raise ex if (ex)
@@ -140,7 +130,8 @@ module ReverseTcp
   # Starts monitoring for an inbound connection.
   #
   def start_handler
-    self.listener_thread = framework.threads.spawn("ReverseTcpHandlerListener-#{datastore['LPORT']}", false) {
+    local_port = bind_port(datastore)
+    self.listener_thread = framework.threads.spawn("ReverseTcpHandlerListener-#{local_port}", false) {
       client = nil
 
       begin
@@ -159,7 +150,7 @@ module ReverseTcp
       end while true
     }
 
-    self.handler_thread = framework.threads.spawn("ReverseTcpHandlerWorker-#{datastore['LPORT']}", false) {
+    self.handler_thread = framework.threads.spawn("ReverseTcpHandlerWorker-#{local_port}", false) {
       while true
         client = self.handler_queue.pop
         begin
@@ -240,6 +231,31 @@ module ReverseTcp
   end
 
 protected
+
+  def bind_port(datastore)
+    port = datastore['ReverseListenerBindPort'].to_i
+    port > 0 ? port : datastore['LPORT'].to_i
+  end
+
+  def bind_address(datastore)
+    # Switch to IPv6 ANY address if the LHOST is also IPv6
+    addr = Rex::Socket.resolv_nbo(datastore['LHOST'])
+    # First attempt to bind LHOST. If that fails, the user probably has
+    # something else listening on that interface. Try again with ANY_ADDR.
+    any = (addr.length == 4) ? "0.0.0.0" : "::0"
+
+    addrs = [ Rex::Socket.addr_ntoa(addr), any  ]
+
+    if not datastore['ReverseListenerBindAddress'].to_s.empty?
+      # Only try to bind to this specific interface
+      addrs = [ datastore['ReverseListenerBindAddress'] ]
+
+      # Pick the right "any" address if either wildcard is used
+      addrs[0] = any if (addrs[0] == "0.0.0.0" or addrs == "::0")
+    end
+
+    addrs
+  end
 
   attr_accessor :listener_sock # :nodoc:
   attr_accessor :listener_thread # :nodoc:

--- a/lib/msf/core/handler/reverse_tcp.rb
+++ b/lib/msf/core/handler/reverse_tcp.rb
@@ -81,8 +81,8 @@ module ReverseTcp
       comm = nil
     end
 
-    local_port = bind_port(datastore)
-    addrs = bind_address(datastore)
+    local_port = bind_port
+    addrs = bind_address
 
     addrs.each { |ip|
       begin
@@ -130,7 +130,7 @@ module ReverseTcp
   # Starts monitoring for an inbound connection.
   #
   def start_handler
-    local_port = bind_port(datastore)
+    local_port = bind_port
     self.listener_thread = framework.threads.spawn("ReverseTcpHandlerListener-#{local_port}", false) {
       client = nil
 
@@ -232,12 +232,12 @@ module ReverseTcp
 
 protected
 
-  def bind_port(datastore)
+  def bind_port
     port = datastore['ReverseListenerBindPort'].to_i
     port > 0 ? port : datastore['LPORT'].to_i
   end
 
-  def bind_address(datastore)
+  def bind_address
     # Switch to IPv6 ANY address if the LHOST is also IPv6
     addr = Rex::Socket.resolv_nbo(datastore['LHOST'])
     # First attempt to bind LHOST. If that fails, the user probably has

--- a/lib/msf/core/handler/reverse_tcp_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_ssl.rb
@@ -69,8 +69,8 @@ module ReverseTcpSsl
       comm = nil
     end
 
-    local_port = bind_port(datastore)
-    addrs = bind_address(datastore)
+    local_port = bind_port
+    addrs = bind_address
 
     addrs.each { |ip|
       begin
@@ -111,12 +111,12 @@ module ReverseTcpSsl
 
 protected
 
-  def bind_port(datastore)
+  def bind_port
     port = datastore['ReverseListenerBindPort'].to_i
     port > 0 ? port : datastore['LPORT'].to_i
   end
 
-  def bind_address(datastore)
+  def bind_address
     # Switch to IPv6 ANY address if the LHOST is also IPv6
     addr = Rex::Socket.resolv_nbo(datastore['LHOST'])
     # First attempt to bind LHOST. If that fails, the user probably has

--- a/lib/msf/core/handler/reverse_tcp_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_ssl.rb
@@ -43,7 +43,9 @@ module ReverseTcpSsl
     super
     register_advanced_options(
       [
-        OptPath.new('SSLCert',    [ false, 'Path to a custom SSL certificate (default is randomly generated)'])
+        OptPath.new('SSLCert',    [ false, 'Path to a custom SSL certificate (default is randomly generated)']),
+        OptAddress.new('ReverseListenerBindAddress', [ false, 'The specific IP address to bind to on the local system']),
+        OptInt.new('ReverseListenerBindPort', [ false, 'The port to bind to on the local system if different from LPORT' ])
       ], Msf::Handler::ReverseTcpSsl)
 
   end
@@ -59,13 +61,6 @@ module ReverseTcpSsl
     end
 
     ex = false
-    # Switch to IPv6 ANY address if the LHOST is also IPv6
-    addr = Rex::Socket.resolv_nbo(datastore['LHOST'])
-    # First attempt to bind LHOST. If that fails, the user probably has
-    # something else listening on that interface. Try again with ANY_ADDR.
-    any = (addr.length == 4) ? "0.0.0.0" : "::0"
-
-    addrs = [ Rex::Socket.addr_ntoa(addr), any  ]
 
     comm  = datastore['ReverseListenerComm']
     if comm.to_s == "local"
@@ -74,20 +69,16 @@ module ReverseTcpSsl
       comm = nil
     end
 
-    if not datastore['ReverseListenerBindAddress'].to_s.empty?
-      # Only try to bind to this specific interface
-      addrs = [ datastore['ReverseListenerBindAddress'] ]
+    local_port = bind_port(datastore)
+    addrs = bind_address(datastore)
 
-      # Pick the right "any" address if either wildcard is used
-      addrs[0] = any if (addrs[0] == "0.0.0.0" or addrs == "::0")
-    end
     addrs.each { |ip|
       begin
 
         comm.extend(Rex::Socket::SslTcp)
         self.listener_sock = Rex::Socket::SslTcpServer.create(
-        'LocalHost' => datastore['LHOST'],
-        'LocalPort' => datastore['LPORT'].to_i,
+        'LocalHost' => ip,
+        'LocalPort' => local_port,
         'Comm'      => comm,
         'SSLCert'	=> datastore['SSLCert'],
         'Context'   =>
@@ -108,14 +99,41 @@ module ReverseTcpSsl
           via = ""
         end
 
-        print_status("Started reverse SSL handler on #{ip}:#{datastore['LPORT']} #{via}")
+        print_status("Started reverse SSL handler on #{ip}:#{local_port} #{via}")
         break
       rescue
         ex = $!
-        print_error("Handler failed to bind to #{ip}:#{datastore['LPORT']}")
+        print_error("Handler failed to bind to #{ip}:#{local_port}")
       end
     }
     raise ex if (ex)
+  end
+
+protected
+
+  def bind_port(datastore)
+    port = datastore['ReverseListenerBindPort'].to_i
+    port > 0 ? port : datastore['LPORT'].to_i
+  end
+
+  def bind_address(datastore)
+    # Switch to IPv6 ANY address if the LHOST is also IPv6
+    addr = Rex::Socket.resolv_nbo(datastore['LHOST'])
+    # First attempt to bind LHOST. If that fails, the user probably has
+    # something else listening on that interface. Try again with ANY_ADDR.
+    any = (addr.length == 4) ? "0.0.0.0" : "::0"
+
+    addrs = [ Rex::Socket.addr_ntoa(addr), any  ]
+
+    if not datastore['ReverseListenerBindAddress'].to_s.empty?
+      # Only try to bind to this specific interface
+      addrs = [ datastore['ReverseListenerBindAddress'] ]
+
+      # Pick the right "any" address if either wildcard is used
+      addrs[0] = any if (addrs[0] == "0.0.0.0" or addrs == "::0")
+    end
+
+    addrs
   end
 
 end

--- a/modules/payloads/stagers/windows/reverse_https_proxy.rb
+++ b/modules/payloads/stagers/windows/reverse_https_proxy.rb
@@ -134,11 +134,7 @@ module Metasploit3
     p[p.length - 4, 4] = [p[p.length - 4, 4].unpack("l")[0] + jmp_offset].pack("V")
 
     # patch the LPORT
-    unless datastore['HIDDENPORT'].nil? or datastore['HIDDENPORT'] == 0
-      lport = datastore['HIDDENPORT']
-    else
-      lport = datastore['LPORT']
-    end
+    lport = bind_port
 
     lportloc = p.index("\x68\x5c\x11\x00\x00")  # PUSH DWORD 4444
     p[lportloc+1] = [lport.to_i].pack('V')[0]
@@ -148,11 +144,7 @@ module Metasploit3
 
     # append LHOST and return payload
 
-    unless datastore['HIDDENHOST'].nil? or datastore['HIDDENHOST'].empty?
-      lhost = datastore['HIDDENHOST']
-    else
-      lhost = datastore['LHOST']
-    end
+    lhost = bind_address
     p + lhost.to_s + "\x00"
 
   end
@@ -163,5 +155,33 @@ module Metasploit3
   def wfs_delay
     20
   end
+
+protected
+
+  def bind_port
+    port = datastore['ReverseListenerBindPort'].to_i
+    port > 0 ? port : datastore['LPORT'].to_i
+  end
+
+  def bind_address
+    # Switch to IPv6 ANY address if the LHOST is also IPv6
+    addr = Rex::Socket.resolv_nbo(datastore['LHOST'])
+    # First attempt to bind LHOST. If that fails, the user probably has
+    # something else listening on that interface. Try again with ANY_ADDR.
+    any = (addr.length == 4) ? "0.0.0.0" : "::0"
+
+    addrs = [ Rex::Socket.addr_ntoa(addr), any  ]
+
+    if not datastore['ReverseListenerBindAddress'].to_s.empty?
+      # Only try to bind to this specific interface
+      addrs = [ datastore['ReverseListenerBindAddress'] ]
+
+      # Pick the right "any" address if either wildcard is used
+      addrs[0] = any if (addrs[0] == "0.0.0.0" or addrs == "::0")
+    end
+
+    addrs
+  end
+
 end
 


### PR DESCRIPTION
This adds a `ReverseListenerBindPort` advanced setting to the reverse listeners whic
allows for the local bind port to be separated from the `LPORT` setting used in the
payload. This means that listeners can bind to different ports in cases where the
attacker isn't able to listen on the same port that the victim can call out on, but
there are NATs/portforwards/whatever in place that allow the connection to happen.
#### Validation
- [x] When `ReverseListenerBindPort` is not set, `LPORT` should be used by default.
- [x] When `ReverseListenerBindPort` is set, but the _unset_, `LPORT` should be used by default.
- [x] When `ReverseListenerBindPort` is set, the value is used as the local listen port but it doesn't affect the generated payload that is sent to the victim.
