### PR TITLE
Windows 7 SP1 and newer fail when forcing IPv6 sockets

### DIFF
--- a/lib/rex/socket/comm/local.rb
+++ b/lib/rex/socket/comm/local.rb
@@ -131,8 +131,8 @@ class Rex::Socket::Comm::Local
       # Force IPv6 mode for non-connected UDP sockets
       if (type == ::Socket::SOCK_DGRAM and not param.peerhost)
         # FreeBSD allows IPv6 socket creation, but throws an error on sendto()
-
-        if (not Rex::Compat.is_freebsd())
+        # Windows 7 SP1 and newer also fail to sendto with IPv6 udp sockets
+        unless Rex::Compat.is_freebsd or Rex::Compat.is_windows
           usev6 = true
         end
       end


### PR DESCRIPTION
Tries to solve https://dev.metasploit.com/redmine/issues/8304

Apparently, Windows 7 SP1 and newer also fails on sendto when forcing IPv6 sockets. 

After applying this patch ipmi_version should work again on Win7SP1 (and hopefully newer) only tested WIN7 SP1.

In oder to test, just apply the patch provided here to the framework and follow the steps on  https://dev.metasploit.com/redmine/issues/8304 to test ipmi_version, udp packets should be shown again on Wireshark.

Please, criticize, I suck on OS internals .... I could have broken something. Hopefully not.
