### PR TITLE
[SeeRM #8446] Ignore unexpected DNS answers

### DIFF
--- a/modules/auxiliary/gather/dns_info.rb
+++ b/modules/auxiliary/gather/dns_info.rb
@@ -124,6 +124,7 @@ class Metasploit3 < Msf::Auxiliary
     query = @res.search(host, "A")
     if query
       query.answer.each do |rr|
+        next unless rr.type == "A"
         record = {}
         record[:host] = host
         record[:type] = "A"
@@ -134,6 +135,7 @@ class Metasploit3 < Msf::Auxiliary
     query1 = @res.search(host, "AAAA")
     if query1
       query1.answer.each do |rr|
+        next unless rr.type == "AAAA"
         record = {}
         record[:host] = host
         record[:type] = "AAAA"
@@ -189,6 +191,7 @@ class Metasploit3 < Msf::Auxiliary
     query = @res.query(target, "TXT")
     return results if not query
     query.answer.each do |rr|
+      next unless rr.type == "TXT"
       record = {}
       record[:host] = target
       record[:text] = rr.txt


### PR DESCRIPTION
The module auxiliary/gather/dns_info fails to parse "unexpected" DNS answers. The crash is easy to reproduce:
- [x] Rune msfconsole
- [x] use use auxiliary/gather/dns_info
- [x] set DOMAIN www.terra.es
- [x] run the module, should trigger an unhandled Exception

```
msf > use auxiliary/gather/dns_info 
msf auxiliary(dns_info) > set DOMAIN www.terra.es
DOMAIN => www.terra.es
msf auxiliary(dns_info) > run

[*] Enumerating www.terra.es
[-] Auxiliary failed: NoMethodError undefined method `address' for www.terra.es.           300     IN      CNAME   dynamic.terra.es.:Net::DNS::RR::CNAME
[-] Call stack:
[-]   /Users/juan/Projects/git/metasploit-framework/modules/auxiliary/gather/dns_info.rb:130:in `block in get_ip'
[-]   /Users/juan/Projects/git/metasploit-framework/modules/auxiliary/gather/dns_info.rb:126:in `each'
[-]   /Users/juan/Projects/git/metasploit-framework/modules/auxiliary/gather/dns_info.rb:126:in `get_ip'
[-]   /Users/juan/Projects/git/metasploit-framework/modules/auxiliary/gather/dns_info.rb:57:in `run'
[*] Auxiliary module execution completed

```

This exception is due to the module trying to parse a DNS answer of type CNAME as type A. The query has been "A" in this case.

This patch just tries to avoid parsing unexpected DNS responses. In order to verify:
- [ ] Run msfconsole
- [ ] use use auxiliary/gather/dns_info
- [ ] set DOMAIN www.terra.es
- [ ] run the module, Exception shouldn't trigger:

```
msf auxiliary(dns_info) > run

[*] Enumerating www.terra.es
[+] www.terra.es - Address 208.84.244.10 found. Record type: A
[*] Auxiliary module execution completed

```

Honestly I'm not super happy with this patch. Just tries to save the Exception, but looks like the module needs a lot of refactoring, it's copying and pasting the code to make DNS queries and parse answers again and again, and losing information like in this case, where isn't ready to parse CNAME answers when querying "A".
