### PR TITLE
Add pymeterpreter support for stdapi_net_resolve_host.

### DIFF
--- a/data/meterpreter/ext_server_stdapi.py
+++ b/data/meterpreter/ext_server_stdapi.py
@@ -149,6 +149,8 @@ TLV_TYPE_NETWORK_INTERFACE =   TLV_META_TYPE_GROUP   | 1433
 TLV_TYPE_SUBNET_STRING =       TLV_META_TYPE_STRING  | 1440
 TLV_TYPE_NETMASK_STRING =      TLV_META_TYPE_STRING  | 1441
 TLV_TYPE_GATEWAY_STRING =      TLV_META_TYPE_STRING  | 1442
+TLV_TYPE_ROUTE_METRIC =        TLV_META_TYPE_UINT    | 1443
+TLV_TYPE_ADDR_TYPE =           TLV_META_TYPE_UINT    | 1444
 
 # Socket
 TLV_TYPE_PEER_HOST =           TLV_META_TYPE_STRING  | 1500
@@ -273,6 +275,9 @@ ERROR_FAILURE = 1
 # errors.
 ERROR_CONNECTION_ERROR = 10000
 
+WIN_AF_INET  = 2
+WIN_AF_INET6 = 23
+
 def get_stat_buffer(path):
 	si = os.stat(path)
 	rdev = 0
@@ -289,6 +294,27 @@ def get_stat_buffer(path):
 	st_buf += struct.pack('<IIII', si.st_size, si.st_atime, si.st_mtime, si.st_ctime)
 	st_buf += struct.pack('<II', blksize, blocks)
 	return st_buf
+
+def inet_pton(family, address):
+	if hasattr(socket, 'inet_pton'):
+		return socket.inet_pton(family, address)
+	elif has_windll:
+		WSAStringToAddress = ctypes.windll.ws2_32.WSAStringToAddressA
+		lpAddress = (ctypes.c_ubyte * 28)()
+		lpAddressLength = ctypes.c_int(ctypes.sizeof(lpAddress))
+		if WSAStringToAddress(address, family, None, ctypes.byref(lpAddress), ctypes.byref(lpAddressLength)) != 0:
+			raise Exception('WSAStringToAddress failed')
+		if family == socket.AF_INET:
+			return ''.join(map(chr, lpAddress[4:8]))
+		elif family == socket.AF_INET6:
+			return ''.join(map(chr, lpAddress[8:24]))
+	raise Exception('no suitable inet_pton functionality is available')
+
+def resolve_host(hostname, family):
+	address_info = socket.getaddrinfo(hostname, 0, family, socket.SOCK_DGRAM, socket.IPPROTO_UDP)[0]
+	family = address_info[0]
+	address = address_info[4][0]
+	return {'family':family, 'address':address, 'packed_address':inet_pton(family, address)}
 
 def windll_GetNativeSystemInfo():
 	if not has_windll:
@@ -685,6 +711,37 @@ def stdapi_fs_stat(request, response):
 	path = packet_get_tlv(request, TLV_TYPE_FILE_PATH)['value']
 	st_buf = get_stat_buffer(path)
 	response += tlv_pack(TLV_TYPE_STAT_BUF, st_buf)
+	return ERROR_SUCCESS, response
+
+@meterpreter.register_function
+def stdapi_net_resolve_host(request, response):
+	hostname = packet_get_tlv(request, TLV_TYPE_HOST_NAME)['value']
+	family = packet_get_tlv(request, TLV_TYPE_ADDR_TYPE)['value']
+	if family == WIN_AF_INET:
+		family = socket.AF_INET
+	elif family == WIN_AF_INET6:
+		family = socket.AF_INET6
+	else:
+		raise Exception('invalid family')
+	result = resolve_host(hostname, family)
+	response += tlv_pack(TLV_TYPE_IP, result['packed_address'])
+	response += tlv_pack(TLV_TYPE_ADDR_TYPE, result['family'])
+	return ERROR_SUCCESS, response
+
+@meterpreter.register_function
+def stdapi_net_resolve_hosts(request, response):
+	family = packet_get_tlv(request, TLV_TYPE_ADDR_TYPE)['value']
+	if family == WIN_AF_INET:
+		family = socket.AF_INET
+	elif family == WIN_AF_INET6:
+		family = socket.AF_INET6
+	else:
+		raise Exception('invalid family')
+	for hostname in packet_enum_tlvs(request, TLV_TYPE_HOST_NAME):
+		hostname = hostname['value']
+		result = resolve_host(hostname, family)
+		response += tlv_pack(TLV_TYPE_IP, result['packed_address'])
+		response += tlv_pack(TLV_TYPE_ADDR_TYPE, result['family'])
 	return ERROR_SUCCESS, response
 
 @meterpreter.register_function

--- a/data/meterpreter/ext_server_stdapi.py
+++ b/data/meterpreter/ext_server_stdapi.py
@@ -739,7 +739,10 @@ def stdapi_net_resolve_hosts(request, response):
 		raise Exception('invalid family')
 	for hostname in packet_enum_tlvs(request, TLV_TYPE_HOST_NAME):
 		hostname = hostname['value']
-		result = resolve_host(hostname, family)
+		try:
+			result = resolve_host(hostname, family)
+		except socket.error:
+			result = {'family':family, 'packed_address':''}
 		response += tlv_pack(TLV_TYPE_IP, result['packed_address'])
 		response += tlv_pack(TLV_TYPE_ADDR_TYPE, result['family'])
 	return ERROR_SUCCESS, response

--- a/data/meterpreter/meterpreter.py
+++ b/data/meterpreter/meterpreter.py
@@ -111,6 +111,24 @@ def packet_get_tlv(pkt, tlv_type):
 		offset += tlv[0]
 	return {}
 
+def packet_enum_tlvs(pkt, tlv_type = None):
+	offset = 0
+	while (offset < len(pkt)):
+		tlv = struct.unpack('>II', pkt[offset:offset+8])
+		if (tlv_type == None) or ((tlv[1] & ~TLV_META_TYPE_COMPRESSED) == tlv_type):
+			val = pkt[offset+8:(offset+8+(tlv[0] - 8))]
+			if (tlv[1] & TLV_META_TYPE_STRING) == TLV_META_TYPE_STRING:
+				val = val.split('\x00', 1)[0]
+			elif (tlv[1] & TLV_META_TYPE_UINT) == TLV_META_TYPE_UINT:
+				val = struct.unpack('>I', val)[0]
+			elif (tlv[1] & TLV_META_TYPE_BOOL) == TLV_META_TYPE_BOOL:
+				val = bool(struct.unpack('b', val)[0])
+			elif (tlv[1] & TLV_META_TYPE_RAW) == TLV_META_TYPE_RAW:
+				pass
+			yield {'type':tlv[1], 'length':tlv[0], 'value':val}
+		offset += tlv[0]
+	raise StopIteration()
+
 def tlv_pack(*args):
 	if len(args) == 2:
 		tlv = {'type':args[0], 'value':args[1]}
@@ -271,7 +289,7 @@ class PythonMeterpreter(object):
 		if (data_tlv['type'] & TLV_META_TYPE_COMPRESSED) == TLV_META_TYPE_COMPRESSED:
 			return ERROR_FAILURE
 		preloadlib_methods = self.extension_functions.keys()
-		i = code.InteractiveInterpreter({'meterpreter':self, 'packet_get_tlv':packet_get_tlv, 'tlv_pack':tlv_pack, 'STDProcess':STDProcess})
+		i = code.InteractiveInterpreter({'meterpreter':self, 'packet_enum_tlvs':packet_enum_tlvs, 'packet_get_tlv':packet_get_tlv, 'tlv_pack':tlv_pack, 'STDProcess':STDProcess})
 		i.runcode(compile(data_tlv['value'], '', 'exec'))
 		postloadlib_methods = self.extension_functions.keys()
 		new_methods = filter(lambda x: x not in preloadlib_methods, postloadlib_methods)

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/resolve.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/resolve.rb
@@ -48,7 +48,7 @@ class Resolve
   def resolve_hosts(hostnames, family=AF_INET)
     request = Packet.create_request('stdapi_net_resolve_hosts')
     request.add_tlv(TLV_TYPE_ADDR_TYPE, family)
-    
+
     hostnames.each do |hostname|
       request.add_tlv(TLV_TYPE_HOST_NAME, hostname)
     end
@@ -84,7 +84,7 @@ class Resolve
     end
 
     if raw.empty?
-      ip = ""
+      ip = nil
     else
       if type == AF_INET
         ip = Rex::Socket.addr_ntoa(raw[0..3])

--- a/modules/post/multi/gather/resolve_hosts.rb
+++ b/modules/post/multi/gather/resolve_hosts.rb
@@ -10,10 +10,6 @@ require 'rex'
 
 class Metasploit3 < Msf::Post
 
-  require 'msf/core/module/deprecated'
-  include Msf::Module::Deprecated
-  deprecated Date.new(2013, 12, 9), 'post/multi/gather/resolve_hosts'
-
   def initialize(info={})
     super( update_info( info,
       'Name'          => 'Windows Resolve Hosts',
@@ -22,7 +18,7 @@ class Metasploit3 < Msf::Post
       },
       'License'       => MSF_LICENSE,
       'Author'        => [ 'Ben Campbell <eat_meatballs[at]hotmail.co.uk>' ],
-      'Platform'      => [ 'win' ],
+      'Platform'      => %w{ win python },
       'SessionTypes'  => [ 'meterpreter' ]
     ))
 

--- a/modules/post/multi/gather/resolve_hosts.rb
+++ b/modules/post/multi/gather/resolve_hosts.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Post
 
   def initialize(info={})
     super( update_info( info,
-      'Name'          => 'Windows Resolve Hosts',
+      'Name'          => 'Resolve Hosts',
       'Description'   => %q{
         Resolves hostnames to either IPv4 or IPv6 addresses from the perspective of the remote host.
       },


### PR DESCRIPTION
This PR adds support for stdapi_net_resolve_host and stdapi_net_resolve_hosts to the python meterpreter.  This works cross platform, it's been tested on Linux, OSX, Windows XP and Windows 7.  The AF_INET6 constant is different on Linux and Windows and this code expects to get the Windows value which is already use by post/windows/gather/resolve_hosts.  Only AF_INET and AF_INET6 are supported for the AI_FAMILY value.

To test use the post/windows/gather/resolve_hosts module, it works whether the session is Linux, OSX or Windows.
