### PR TITLE
Fix rspec for Rex::Exploitation::RopDb

### DIFF
--- a/spec/lib/rex/exploitation/ropdb_spec.rb
+++ b/spec/lib/rex/exploitation/ropdb_spec.rb
@@ -11,31 +11,35 @@ describe Rex::Exploitation::RopDb do
     end
 
     context ".has_rop?" do
-      ropdb = Rex::Exploitation::RopDb.new
+      let(:ropdb) do
+        Rex::Exploitation::RopDb.new
+      end
 
       it "should find the msvcrt ROP database" do
-        ropdb.has_rop?("msvcrt").should eq(true)
+        ropdb.has_rop?("msvcrt").should be_true
       end
 
       it "should find the java ROP database" do
-        ropdb.has_rop?("java").should eq(true)
+        ropdb.has_rop?("java").should be_true
       end
 
       it "should find the hxds ROP database" do
-        ropdb.has_rop?("hxds").should eq(true)
+        ropdb.has_rop?("hxds").should be_true
       end
 
       it "should find the flash ROP database" do
-        ropdb.has_rop?("flash").should eq(true)
+        ropdb.has_rop?("flash").should be_true
       end
 
       it "should return false when I supply an invalid database" do
-        ropdb.has_rop?("sinn3r").should eq(false)
+        ropdb.has_rop?("sinn3r").should be_false
       end
     end
 
     context ".select_rop" do
-      ropdb = Rex::Exploitation::RopDb.new
+      let(:ropdb) do
+        Rex::Exploitation::RopDb.new
+      end
 
       it "should return msvcrt gadgets" do
         gadgets = ropdb.select_rop('msvcrt')
@@ -56,7 +60,9 @@ describe Rex::Exploitation::RopDb do
     end
 
     context ".generate_rop_payload" do
-      ropdb = Rex::Exploitation::RopDb.new
+      let(:ropdb) do
+        Rex::Exploitation::RopDb.new
+      end
 
       it "should generate my ROP payload" do
         ropdb.generate_rop_payload('msvcrt', 'AAAA').should =~ /AAAA$/
@@ -68,7 +74,9 @@ describe Rex::Exploitation::RopDb do
     end
 
     context ".get_safe_size" do
-      ropdb = Rex::Exploitation::RopDb.new
+      let(:ropdb) do
+        Rex::Exploitation::RopDb.new
+      end
 
       it "should return 0xfffffed0 (value does not need to be modified to avoid null bytes)" do
         ropdb.send(:get_safe_size, 304).should eq(0xfffffed0)
@@ -80,7 +88,9 @@ describe Rex::Exploitation::RopDb do
     end
 
     context ".get_unsafe_size" do
-      ropdb = Rex::Exploitation::RopDb.new
+      let(:ropdb) do
+        Rex::Exploitation::RopDb.new
+      end
 
       it "should return 0xfffffc00 (contains a null byte)" do
         ropdb.send(:get_unsafe_size, 1024).should eq(0xfffffc00)

--- a/spec/lib/rex/exploitation/ropdb_spec.rb
+++ b/spec/lib/rex/exploitation/ropdb_spec.rb
@@ -1,20 +1,20 @@
 require 'rex/exploitation/ropdb'
 
 describe Rex::Exploitation::RopDb do
+
+  subject(:ropdb) do
+    described_class.new
+  end
+
   context "Class methods" do
 
     context ".initialize" do
       it "should initialize with a path of the ROP database ready" do
-        ropdb = Rex::Exploitation::RopDb.new
         ropdb.instance_variable_get(:@base_path).should =~ /data\/ropdb\/$/
       end
     end
 
     context ".has_rop?" do
-      let(:ropdb) do
-        Rex::Exploitation::RopDb.new
-      end
-
       it "should find the msvcrt ROP database" do
         ropdb.has_rop?("msvcrt").should be_true
       end
@@ -37,10 +37,6 @@ describe Rex::Exploitation::RopDb do
     end
 
     context ".select_rop" do
-      let(:ropdb) do
-        Rex::Exploitation::RopDb.new
-      end
-
       it "should return msvcrt gadgets" do
         gadgets = ropdb.select_rop('msvcrt')
         gadgets.length.should > 0
@@ -60,10 +56,6 @@ describe Rex::Exploitation::RopDb do
     end
 
     context ".generate_rop_payload" do
-      let(:ropdb) do
-        Rex::Exploitation::RopDb.new
-      end
-
       it "should generate my ROP payload" do
         ropdb.generate_rop_payload('msvcrt', 'AAAA').should =~ /AAAA$/
       end
@@ -74,10 +66,6 @@ describe Rex::Exploitation::RopDb do
     end
 
     context ".get_safe_size" do
-      let(:ropdb) do
-        Rex::Exploitation::RopDb.new
-      end
-
       it "should return 0xfffffed0 (value does not need to be modified to avoid null bytes)" do
         ropdb.send(:get_safe_size, 304).should eq(0xfffffed0)
       end
@@ -88,10 +76,6 @@ describe Rex::Exploitation::RopDb do
     end
 
     context ".get_unsafe_size" do
-      let(:ropdb) do
-        Rex::Exploitation::RopDb.new
-      end
-
       it "should return 0xfffffc00 (contains a null byte)" do
         ropdb.send(:get_unsafe_size, 1024).should eq(0xfffffc00)
       end


### PR DESCRIPTION
Obviously I suck at rspec and failed to correctly handle the rspec going with #2467. This pull request tries to add the feedback from @limhoff-r7 and available on the pull request.

Probably review from @limhoff-r7 and @wchen-r7 is needed here before landing it.

Verification:
- [ ] Wait for the @limhoff-r7 and @wchen-r7's okey to it.
- [ ] run `rspec spec/lib/rex/exploitation/ropdb_spec.rb`. Ensure the rspec runs ok:

```
$ rspec spec/lib/rex/exploitation/ropdb_spec.rb 

Rex::Exploitation::RopDb
  Class methods
    .initialize
      should initialize with a path of the ROP database ready
    .has_rop?
      should find the msvcrt ROP database
      should find the java ROP database
      should find the hxds ROP database
      should find the flash ROP database
      should return false when I supply an invalid database
    .select_rop
      should return msvcrt gadgets
      should return msvcrt gadgets for windows server 2003
      should return msvcrt gadgets with a new base
    .generate_rop_payload
      should generate my ROP payload
      should generate my ROP payload with my stack pivot
    .get_safe_size
      should return 0xfffffed0 (value does not need to be modified to avoid null bytes)
      should return 0xfffffeff (value is modified to avoid null bytes)
    .get_unsafe_size
      should return 0xfffffc00 (contains a null byte)

Finished in 0.1009 seconds
14 examples, 0 failures

```
