### PR TITLE
Deprecate misnamed linksys module and rename to "linux/"

### DIFF
--- a/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
@@ -10,11 +10,6 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  # handle module misnomer
-  require 'msf/core/module/deprecated'
-  include Msf::Module::Deprecated
-  deprecated Date.new(2013, 12, 7), 'exploit/linux/http/linksys_wrt110_cmd_exec'
-
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStagerEcho
 

--- a/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Author'      =>
         [
           'Craig Young', # Vulnerability discovery
-          'joev <jvennix[at]rapid7.com>', # msf module
+          'joev', # msf module
           'juan vazquez' # module help + echo cmd stager
         ],
       'License'     => MSF_LICENSE,

--- a/modules/exploits/multi/http/linksys_wrt110_cmd_exec_stager.rb
+++ b/modules/exploits/multi/http/linksys_wrt110_cmd_exec_stager.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Author'      =>
         [
           'Craig Young', # Vulnerability discovery
-          'joev <jvennix[at]rapid7.com>', # msf module
+          'joev', # msf module
           'juan vazquez' # module help + echo cmd stager
         ],
       'License'     => MSF_LICENSE,


### PR DESCRIPTION
As per conversation with juan and egypt in the irc channel. This linksys exploit should really be in exploit/linux, and the exploit name should describe the vuln, not the exploitation technique (no _stager). 
### Verification
- [x] Use the original module:

```
msf> use exploit/multi/http/linksys_wrt110_cmd_exec_stager
msf> exploit
```
- [x] Verify you see a big DEPRECATED warning
- [x] Verify that the you can run `check` on the new module:

```
msf> use exploit/linux/http/linksys_wrt110_cmd_exec
msf> check
[+] The target is vulnerable.
```
