### PR TITLE
Removed random bracket

### DIFF
--- a/scripts/meterpreter/vnc.rb
+++ b/scripts/meterpreter/vnc.rb
@@ -98,7 +98,7 @@ if (tunnel)
 	pay.datastore['LPORT'] = rport
 	pay.datastore['VNCPORT'] = vport
 else
-	print_status("Creating a VNC reverse tcp stager: LHOST=#{rhost} LPORT=#{rport})")
+	print_status("Creating a VNC reverse tcp stager: LHOST=#{rhost} LPORT=#{rport}")
 	payload = "windows/vncinject/reverse_tcp"
 
 	pay = client.framework.payloads.create(payload)


### PR DESCRIPTION
The VNC script had a random bracket
Output:
[*] Creating a VNC reverse tcp stager: LHOST=192.168.0.4 LPORT=4545)
