### PR TITLE
Fix multi-meter_inject error msg

### DIFF
--- a/modules/post/windows/manage/multi_meterpreter_inject.rb
+++ b/modules/post/windows/manage/multi_meterpreter_inject.rb
@@ -92,7 +92,7 @@ class Metasploit3 < Msf::Post
       print_good("Successfully injected Meterpreter in to process: #{target_pid}")
     rescue::Exception => e
       print_error("Failed to Inject Payload to #{target_pid}!")
-      print_error(e)
+      print_error(e.message)
     end
   end
 


### PR DESCRIPTION
Was trying to coerce the exception class
to string rather than calling .message
Results in a stacktrace.

FIXRM #8460
