### PR TITLE
Mark broken Util::EXE tests as pending

### DIFF
--- a/spec/lib/msf/util/exe_spec.rb
+++ b/spec/lib/msf/util/exe_spec.rb
@@ -12,6 +12,8 @@ describe Msf::Util::EXE do
     described_class
   end
 
+  before { pending "Pending RM#8463, fix all these these tests up." }
+
   $framework = Msf::Simple::Framework.create(
     :module_types => [ Msf::MODULE_NOP ],
     'DisableDatabase' => true


### PR DESCRIPTION
These tests are broken a few different ways.

[SeeRM #8463]

Also see: https://github.com/rapid7/metasploit-framework/pull/2477
