### PR TITLE
Bug #8419 - Added platform info missing on exploits

### DIFF
--- a/modules/exploits/apple_ios/browser/safari_libtiff.rb
+++ b/modules/exploits/apple_ios/browser/safari_libtiff.rb
@@ -50,6 +50,7 @@ class Metasploit3 < Msf::Exploit::Remote
             ].pack("V*")
         },
       'Arch'           => ARCH_ARMLE,
+      'Platform'       => %w{ osx },
       'Targets'        =>
         [
 

--- a/modules/exploits/apple_ios/email/mobilemail_libtiff.rb
+++ b/modules/exploits/apple_ios/email/mobilemail_libtiff.rb
@@ -43,6 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
             },
         },
       'Arch'           => ARCH_ARMLE,
+      'Platform'       => %w{ osx },
       'Targets'        =>
         [
 

--- a/modules/exploits/linux/ids/snortbopre.rb
+++ b/modules/exploits/linux/ids/snortbopre.rb
@@ -35,6 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'    => 1073, #ret : 1069
           'BadChars' => "\x00",
         },
+      'Platform'       => %w{ linux },
       'Targets'        =>
         [
           # Target 0: Debian 3.1 Sarge

--- a/modules/exploits/linux/proxy/squid_ntlm_authenticate.rb
+++ b/modules/exploits/linux/proxy/squid_ntlm_authenticate.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'PrependEncoder' => "\x83\xec\x7f",
 
         },
-      'Platform'   => 'linux',
+      'Platform'   => %w{ linux },
       'Targets'        =>
         [
           [ 'Linux Bruteforce',

--- a/modules/exploits/linux/proxy/squid_ntlm_authenticate.rb
+++ b/modules/exploits/linux/proxy/squid_ntlm_authenticate.rb
@@ -42,6 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'PrependEncoder' => "\x83\xec\x7f",
 
         },
+      'Platform'   => 'linux',
       'Targets'        =>
         [
           [ 'Linux Bruteforce',

--- a/modules/exploits/multi/browser/firefox_escape_retval.rb
+++ b/modules/exploits/multi/browser/firefox_escape_retval.rb
@@ -55,6 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'    => 1000 + (rand(256).to_i * 4),
           'BadChars' => "\x00",
         },
+      'Platform'       => %w{ win osx },
       'Targets'        =>
         [
           [ 'Firefox 3.5.0 on Windows XP SP0-SP3',

--- a/modules/exploits/multi/browser/firefox_queryinterface.rb
+++ b/modules/exploits/multi/browser/firefox_queryinterface.rb
@@ -38,6 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'    => 1000 + (rand(256).to_i * 4),
           'BadChars' => "\x00",
         },
+      'Platform'       => %w{ osx linux },
       'Targets'        =>
         [
           [ 'Firefox 1.5.0.0 Mac OS X',

--- a/modules/exploits/multi/browser/firefox_svg_plugin.rb
+++ b/modules/exploits/multi/browser/firefox_svg_plugin.rb
@@ -33,6 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
         with script access should be able to trigger it.
       },
       'License'        => MSF_LICENSE,
+      'Platform'       => %w{ linux osx win },
       'Targets'        =>
         [
           [ 'Automatic',

--- a/modules/exploits/multi/browser/itms_overflow.rb
+++ b/modules/exploits/multi/browser/itms_overflow.rb
@@ -57,6 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'BufferOffset' => 3,  # See the comments below
             },
         },
+      'Platform'      => %w{ osx },
       'Targets'	=>
         [
           [

--- a/modules/exploits/multi/browser/java_getsoundbank_bof.rb
+++ b/modules/exploits/multi/browser/java_getsoundbank_bof.rb
@@ -52,6 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => '',
           'DisableNops' => true,
         },
+      'Platform'       => %w{ win osx },
       'Targets'        =>
         [
 =begin

--- a/modules/exploits/multi/browser/java_setdifficm_bof.rb
+++ b/modules/exploits/multi/browser/java_setdifficm_bof.rb
@@ -52,6 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => '',
           'DisableNops' => true,
         },
+      'Platform'       => %w{ win osx },
       'Targets'        =>
         [
 =begin

--- a/modules/exploits/multi/browser/mozilla_compareto.rb
+++ b/modules/exploits/multi/browser/mozilla_compareto.rb
@@ -50,6 +50,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'    => 400,
           'BadChars' => "\x00",
         },
+      'Platform'       => %w{ win },
       'Targets'        =>
         [
           # Tested against Firefox 1.0.4 and Mozilla 1.7.1 on

--- a/modules/exploits/multi/browser/mozilla_navigatorjava.rb
+++ b/modules/exploits/multi/browser/mozilla_navigatorjava.rb
@@ -51,6 +51,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'    => 512,
           'BadChars' => "",
         },
+      'Platform'       => %w{ win linux osx },
       'Targets'        =>
         [
           [ 'Firefox 1.5.0.4 Windows x86',

--- a/modules/exploits/multi/browser/opera_configoverwrite.rb
+++ b/modules/exploits/multi/browser/opera_configoverwrite.rb
@@ -50,6 +50,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'DisableNops' => true,
           'BadChars' => " ",
         },
+      'Platform'       => %w{ unix },
       'Targets'        =>
         [
           #[ 'Opera < 9.10 Windows',

--- a/modules/exploits/multi/browser/opera_historysearch.rb
+++ b/modules/exploits/multi/browser/opera_historysearch.rb
@@ -61,6 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'RequiredCmd' => 'generic perl ruby telnet',
             }
         },
+      'Platform'       => %w{ unix },
       'Targets'        =>
         [
           #[ 'Automatic', {  } ],

--- a/modules/exploits/multi/browser/qtjava_pointer.rb
+++ b/modules/exploits/multi/browser/qtjava_pointer.rb
@@ -44,6 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'    => 1024,
           'BadChars' => ''
         },
+      'Platform'       => %w{ win osx },
       'Targets'        =>
         [
 #

--- a/modules/exploits/multi/fileformat/adobe_u3d_meshcont.rb
+++ b/modules/exploits/multi/fileformat/adobe_u3d_meshcont.rb
@@ -46,6 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars'      => "\x00",
           'DisableNops'	 => true
         },
+      'Platform'       => %w{ win linux },
       'Targets'        =>
         [
           # test results (on Windows XP SP3)

--- a/modules/exploits/multi/fileformat/maple_maplet.rb
+++ b/modules/exploits/multi/fileformat/maple_maplet.rb
@@ -48,6 +48,7 @@ class Metasploit3 < Msf::Exploit::Remote
 #							'RequiredCmd' => 'generic perl telnet',
 #						}
         },
+      'Platform'       => %w{ win linux unix },
       'Targets'        =>
         [
           [ 'Windows',

--- a/modules/exploits/multi/http/hp_sys_mgmt_exec.rb
+++ b/modules/exploits/multi/http/hp_sys_mgmt_exec.rb
@@ -38,6 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'SSL' => true
         },
+      'Platform'       => %w{ linux win },
       'Targets'        =>
         [
           ['Linux', {

--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -34,6 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['URL', 'https://wiki.jenkins-ci.org/display/JENKINS/Jenkins+Script+Console']
         ],
+      'Platform'  => %w{ win linux unix },
       'Targets'		=>
         [
           ['Windows',  {'Arch'  => ARCH_X86, 'Platform' => 'win'}],

--- a/modules/exploits/multi/http/netwin_surgeftp_exec.rb
+++ b/modules/exploits/multi/http/netwin_surgeftp_exec.rb
@@ -32,6 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '89105' ],
           [ 'EDB', '23522' ]
         ],
+      'Platform'       => %w{ win unix },
       'Targets'        =>
         [
           [ 'Windows', { 'Arch'=>ARCH_X86, 'Platform'=>'win'}  ],

--- a/modules/exploits/multi/http/splunk_mappy_exec.rb
+++ b/modules/exploits/multi/http/splunk_mappy_exec.rb
@@ -47,6 +47,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Badchars'    => '',
           'DisableNops' => true
         },
+      'Platform'       => %w{ linux unix win },
       'Targets'        =>
         [
           [

--- a/modules/exploits/multi/http/splunk_upload_app_exec.rb
+++ b/modules/exploits/multi/http/splunk_upload_app_exec.rb
@@ -43,6 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'       => 1024,
           'DisableNops' => true
         },
+      'Platform'       => %w{ linux unix win },
       'Targets'        =>
         [
           [ 'Splunk 5.0.1 / Linux',

--- a/modules/exploits/multi/ids/snort_dce_rpc.rb
+++ b/modules/exploits/multi/ids/snort_dce_rpc.rb
@@ -54,6 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars'      => "\x00",
           'DisableNops'   => true,
         },
+      'Platform'        => %w{ win linux },
       'Targets'         =>
         [
           [

--- a/modules/exploits/multi/misc/wireshark_lwres_getaddrbyname.rb
+++ b/modules/exploits/multi/misc/wireshark_lwres_getaddrbyname.rb
@@ -61,6 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars'    => "\x00",
           'DisableNops' => true,
         },
+      'Platform'       => %w{ linux osx win },
       'Targets'        =>
         [
           [ 'tshark 1.0.2-3+lenny7 on Debian 5.0.3 (x86)',

--- a/modules/exploits/multi/misc/wireshark_lwres_getaddrbyname_loop.rb
+++ b/modules/exploits/multi/misc/wireshark_lwres_getaddrbyname_loop.rb
@@ -63,6 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'DisableNops' => true,
         },
       'DefaultTarget'	=> 4,
+      'Platform'  => %w{ linux osx win },
       'Targets'		=>
         [
           [ 'tshark 1.0.2-3+lenny7 on Debian 5.0.3 (x86)',

--- a/modules/exploits/multi/php/php_unserialize_zval_cookie.rb
+++ b/modules/exploits/multi/php/php_unserialize_zval_cookie.rb
@@ -51,6 +51,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'Space'       => 1024,
         },
+      'Platform'       => %w{ linux },
       'Targets'        =>
         [
 

--- a/modules/exploits/multi/realserver/describe.rb
+++ b/modules/exploits/multi/realserver/describe.rb
@@ -35,6 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'    => 2000,
           'BadChars' => "\x00\x0a\x0d\x25\x2e\x2f\x5c\xff\x20\x3a\x26\x3f\x2e\x3d"
         },
+      'Platform'       => %w{ bsd linux win },
       'Targets'        =>
         [
           [

--- a/modules/exploits/multi/wyse/hagent_untrusted_hsdata.rb
+++ b/modules/exploits/multi/wyse/hagent_untrusted_hsdata.rb
@@ -47,6 +47,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'EXITFUNC' => 'process',
         },
+      'Platform'       => %w{ win linux },
       'Targets'        =>
         [
           [ 'Windows XPe x86',{'Platform' => 'win',}],

--- a/modules/exploits/osx/afp/loginext.rb
+++ b/modules/exploits/osx/afp/loginext.rb
@@ -41,6 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'ConnectionType' => "+find"
             }
         },
+      'Platform'       => %w{ osx },
       'Targets'        =>
         [
           # Target 0

--- a/modules/exploits/osx/arkeia/type77.rb
+++ b/modules/exploits/osx/arkeia/type77.rb
@@ -41,6 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
             'ConnectionType' => '-find',
           },
         },
+      'Platform'       => %w{ osx },
       'Targets'        =>
         [
           [

--- a/modules/exploits/osx/browser/safari_metadata_archive.rb
+++ b/modules/exploits/osx/browser/safari_metadata_archive.rb
@@ -54,6 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'RequiredCmd' => 'generic perl ruby telnet',
             }
         },
+      'Platform'       => %w{ unix },
       'Targets'        =>
         [
           # Target 0: Automatic

--- a/modules/exploits/osx/email/mailapp_image_exec.rb
+++ b/modules/exploits/osx/email/mailapp_image_exec.rb
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'ConnectionType' => '-bind -find',
             },
         },
-
+      'Platform'       => %w{ unix osx },
       'Targets'        =>
         [
           [ 'Mail.app - Command Payloads',

--- a/modules/exploits/osx/ftp/webstar_ftp_user.rb
+++ b/modules/exploits/osx/ftp/webstar_ftp_user.rb
@@ -39,6 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'ConnectionType' => "+find"
             },
         },
+      'Platform'      => %w{ osx },
       'Targets'        =>
         [
           [

--- a/modules/exploits/windows/arkeia/type77.rb
+++ b/modules/exploits/windows/arkeia/type77.rb
@@ -41,6 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "\x00",
           'StackAdjustment' => -3500,
         },
+      'Platform'      => %w{ win },
       'Targets'        =>
         [
           ['Arkeia 5.3.3 and 5.2.27 Windows (All)',  { 'Platform' => 'win', 'Rets' => [ 0x004130a2, 5 ] }], # arkeiad.exe

--- a/modules/exploits/windows/backupexec/name_service.rb
+++ b/modules/exploits/windows/backupexec/name_service.rb
@@ -46,6 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'MinNops'  => 512,
           'StackAdjustment' => -3500,
         },
+      'Platform'       => %w{ win },
       'Targets'        =>
         [
           [

--- a/modules/exploits/windows/backupexec/remote_agent.rb
+++ b/modules/exploits/windows/backupexec/remote_agent.rb
@@ -44,6 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "\x00",
           'StackAdjustment' => -3500,
         },
+      'Platform'       => %w{ win },
       'Targets'        =>
         [
           [

--- a/modules/exploits/windows/brightstor/discovery_tcp.rb
+++ b/modules/exploits/windows/brightstor/discovery_tcp.rb
@@ -42,6 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "\x00",
           'StackAdjustment' => -3500,
         },
+      'Platform'       => %w{ win },
       'Targets'        =>
         [
           [

--- a/modules/exploits/windows/brightstor/discovery_udp.rb
+++ b/modules/exploits/windows/brightstor/discovery_udp.rb
@@ -38,6 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "\x00",
           'StackAdjustment' => -3500,
         },
+      'Platform'      => %w{ win },
       'Targets'        =>
         [
           [

--- a/modules/exploits/windows/brightstor/sql_agent.rb
+++ b/modules/exploits/windows/brightstor/sql_agent.rb
@@ -37,6 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "\x00",
           'StackAdjustment' => -3500,
         },
+      'Platform'      => %w{ win },
       'Targets'        =>
         [
           # This exploit requires a jmp esp for return

--- a/modules/exploits/windows/brightstor/universal_agent.rb
+++ b/modules/exploits/windows/brightstor/universal_agent.rb
@@ -38,6 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "\x00",
           'StackAdjustment' => -3500,
         },
+      'Platform'       => %w{ win },
       'Targets'        =>
         [
           [

--- a/modules/exploits/windows/browser/aim_goaway.rb
+++ b/modules/exploits/windows/browser/aim_goaway.rb
@@ -46,6 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "\x00\x09\x0a\x0d\x20\x22\x25\x26\x27\x2b\x2f\x3a\x3c\x3e\x3f\x40",
           'StackAdjustment' => -3500,
         },
+      'Platform'      => %w{ win },
       'Targets'        =>
         [
           # Target 0: Automatic

--- a/modules/exploits/windows/browser/mcafee_mcsubmgr_vsprintf.rb
+++ b/modules/exploits/windows/browser/mcafee_mcsubmgr_vsprintf.rb
@@ -44,6 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'BufferOffset' => 0x8
             }
         },
+      'Platform'       => %{ win },
       'Targets'        =>
         [
           # Target 0: Automatic

--- a/modules/exploits/windows/browser/mozilla_interleaved_write.rb
+++ b/modules/exploits/windows/browser/mozilla_interleaved_write.rb
@@ -59,6 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Space'    => 1024,
           'BadChars' => "",
         },
+      'Platform'      => %w{ win },
       'Targets'        =>
         [
           # Tested against Firefox 3.6.8, 3.6.9, 3.6.10, and 3.6.11 on WinXP and Windows Server 2003

--- a/modules/exploits/windows/browser/mozilla_nstreerange.rb
+++ b/modules/exploits/windows/browser/mozilla_nstreerange.rb
@@ -61,6 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'Space'    => 0x1000, # depending on the spray size it's actually a lot more
         },
+      'Platform'       => %w{ win },
       'Targets'        =>
         [
           [ 'Auto (Direct attack against Windows XP, otherwise through Java, if enabled)',

--- a/modules/exploits/windows/browser/ms03_020_ie_objecttype.rb
+++ b/modules/exploits/windows/browser/ms03_020_ie_objecttype.rb
@@ -36,6 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "\x8b\xe2", # Prevent UTF-8-ification
           'StackAdjustment' => -3500,
         },
+      'Platform'       => %w{ win },
       'Targets'        =>
         [
           # Target 0: Automatic

--- a/modules/exploits/windows/browser/ms10_026_avi_nsamplespersec.rb
+++ b/modules/exploits/windows/browser/ms10_026_avi_nsamplespersec.rb
@@ -50,6 +50,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'InitialAutoRunScript' => 'migrate -f',
         },
+      'Platform'       => %w{ win },
       'Targets'        =>
         [
           # Target 0: Automatic

--- a/modules/exploits/windows/dcerpc/ms03_026_dcom.rb
+++ b/modules/exploits/windows/dcerpc/ms03_026_dcom.rb
@@ -42,6 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "\x00\x0a\x0d\x5c\x5f\x2f\x2e",
           'StackAdjustment' => -3500
         },
+      'Platform'       => %w{ win },
       'Targets'        =>
         [
           # Target 0: Universal

--- a/modules/exploits/windows/dcerpc/ms05_017_msmq.rb
+++ b/modules/exploits/windows/dcerpc/ms05_017_msmq.rb
@@ -44,6 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'StackAdjustment' => -3500,
 
         },
+      'Platform'       => %w{ win },
       'Targets'        =>
         [
           [

--- a/modules/exploits/windows/dcerpc/ms07_065_msmq.rb
+++ b/modules/exploits/windows/dcerpc/ms07_065_msmq.rb
@@ -43,6 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'StackAdjustment' => -3500,
 
         },
+      'Platform'      => %w{ win },
       'Targets'        =>
         [
           [

--- a/modules/exploits/windows/ftp/3cdaemon_ftp_user.rb
+++ b/modules/exploits/windows/ftp/3cdaemon_ftp_user.rb
@@ -52,6 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'ConnectionType' => "-find"
             }
         },
+      'Platform'       => %w{ win },
       'Targets'        =>
         [
           [

--- a/modules/exploits/windows/ftp/freeftpd_user.rb
+++ b/modules/exploits/windows/ftp/freeftpd_user.rb
@@ -37,6 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "\x00\x20\x0a\x0d",
           'StackAdjustment' => -3500,
         },
+      'Platform'       => %w{ win },
       'Targets'        =>
         [
           [

--- a/modules/exploits/windows/ftp/oracle9i_xdb_ftp_pass.rb
+++ b/modules/exploits/windows/ftp/oracle9i_xdb_ftp_pass.rb
@@ -43,6 +43,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "\x00\x09\x0a\x0d\x20\x22\x25\x26\x27\x2b\x2f\x3a\x3c\x3e\x3f\x40",
           'PrependEncoder' => "\x81\xc4\xff\xef\xff\xff\x44",
         },
+      'Platform'      => %w{ win },
       'Targets'        =>
         [
           [

--- a/modules/exploits/windows/ftp/servu_mdtm.rb
+++ b/modules/exploits/windows/ftp/servu_mdtm.rb
@@ -46,6 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "\x00\x7e\x2b\x26\x3d\x25\x3a\x22\x0a\x0d\x20\x2f\x5c\x2e",
           'StackAdjustment' => -3500,
         },
+      'Platform'      => %w{ win },
       'Targets'        =>
         [
           [

--- a/modules/exploits/windows/ftp/warftpd_165_pass.rb
+++ b/modules/exploits/windows/ftp/warftpd_165_pass.rb
@@ -46,6 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'ConnectionType' => "-find"
             }
         },
+      'Platform'      => %w{ win },
       'Targets'        =>
         [
           # Target 0

--- a/modules/exploits/windows/novell/zenworks_desktop_agent.rb
+++ b/modules/exploits/windows/novell/zenworks_desktop_agent.rb
@@ -36,6 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "\x00",
           'StackAdjustment' => -3500,
         },
+      'Platform'      => %w{ win },
       'Targets'        =>
         [
           [

--- a/modules/exploits/windows/unicenter/cam_log_security.rb
+++ b/modules/exploits/windows/unicenter/cam_log_security.rb
@@ -36,6 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "\x00",
           'StackAdjustment' => -3500,
         },
+      'Platform'      => %w{ win },
       'Targets'        =>
         [
           # W2API.DLL @ 0x01950000 - return to ESI

--- a/modules/exploits/windows/wins/ms04_045_wins.rb
+++ b/modules/exploits/windows/wins/ms04_045_wins.rb
@@ -45,6 +45,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'StackAdjustment' => -3500,
 
         },
+      'Platform'      => %w{ win },
       'Targets'        =>
         [
           [


### PR DESCRIPTION
Did the grunt work on filling in platform information for the 57 exploits that were missing it based on target platform information.
