### PR TITLE
Fix an endianess issue in pymeterpreter registry_query_value.

### DIFF
--- a/data/meterpreter/ext_server_stdapi.py
+++ b/data/meterpreter/ext_server_stdapi.py
@@ -902,9 +902,12 @@ def stdapi_registry_query_value(request, response):
 		if value_type.value == REG_SZ:
 			response += tlv_pack(TLV_TYPE_VALUE_DATA, ctypes.string_at(value_data) + '\x00')
 		elif value_type.value == REG_DWORD:
-			response += tlv_pack(TLV_TYPE_VALUE_DATA, ''.join(value_data.value)[:4])
+			value = value_data[:4]
+			value.reverse()
+			value = ''.join(map(chr, value))
+			response += tlv_pack(TLV_TYPE_VALUE_DATA, value)
 		else:
-			response += tlv_pack(TLV_TYPE_VALUE_DATA, ''.join(value_data.value)[:value_data_sz.value])
+			response += tlv_pack(TLV_TYPE_VALUE_DATA, ctypes.string_at(value_data, value_data_sz.value))
 		return ERROR_SUCCESS, response
 	return ERROR_FAILURE, response
 


### PR DESCRIPTION
This PR addresses an endianess issue in the registry query value function.  DWORD values need to be changed to big endian apparently.

```
msf4-git (S:2 J:1)  post(registry) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer     : ERMAHGERD
OS           : Windows 7 6.1.7601
Architecture : x86_64
Meterpreter  : python/python
meterpreter > background 
[*] Backgrounding session 1...
msf4-git (S:2 J:1)  post(registry) > set SESSION 1
SESSION => 1
msf4-git (S:2 J:1)  post(registry) > run

[*] Running against session 1
[*] Session type is meterpreter and platform is python/python
[*] PENDING: should evaluate key existence
[*] PENDING: should evaluate value existence
[+] should read values
[+] should return normalized values
[+] should enumerate keys and values
[+] should create keys
[+] should write REG_SZ values
[+] should write REG_DWORD values
[+] should delete keys
[*] Testing complete in 2.915975545
[*] Passed: 7; Failed: 0
[*] Post module execution completed
msf4-git (S:2 J:1)  post(registry) > 
```
