### PR TITLE
Add RPORT to the list of DCERPC ports to check

### DIFF
--- a/lib/msf/core/exploit/dcerpc_epm.rb
+++ b/lib/msf/core/exploit/dcerpc_epm.rb
@@ -43,26 +43,20 @@ module Exploit::Remote::DCERPC_EPM
     print_status("Connecting to the endpoint mapper service...")
     begin
       eps   = nil
-      dport = nil
+      dport = datastore['RPORT'] || 135
 
-      [datastore['RPORT'], 135, 593,].uniq.each do |i|
-        dport = i
-        begin
-          eps = Rex::Socket::Tcp.create(
+      begin
+        eps = Rex::Socket::Tcp.create(
           'PeerHost'  => rhost,
           'PeerPort'  => dport,
           'Proxies'   => proxies,
           'Context'   =>
-            {
-              'Msf'        => framework,
-              'MsfExploit' => self,
-            }
-          )
-
-          break
-
-        rescue ::Exception
-        end
+          {
+            'Msf'        => framework,
+            'MsfExploit' => self,
+          }
+        )
+      rescue ::Exception
       end
 
       if (not eps)

--- a/lib/msf/core/exploit/dcerpc_epm.rb
+++ b/lib/msf/core/exploit/dcerpc_epm.rb
@@ -45,7 +45,7 @@ module Exploit::Remote::DCERPC_EPM
       eps   = nil
       dport = nil
 
-      [135, 593].each do |i|
+      [datastore['RPORT'], 135, 593,].uniq.each do |i|
         dport = i
         begin
           eps = Rex::Socket::Tcp.create(


### PR DESCRIPTION
## Validation steps
- [ ] Start a DCERPC service on a port other than 135 or 593. WDS is delightful for this purpose, see #1420 for instructions from @Meatballs1
- [ ] Set the RPORT on auxiliary/scanner/dcerpc/endpoint_mapper to 5040 (assuming you go with WDS)
- [ ] Start wireshark or tcpdump with a BPF filter of "port 5040"

Without patch:
- [ ] See no traffic on port 5040.

With patch:
- [ ] See traffic on port 5040.
