### PR TITLE
Windows Deployment Services (x86)

### DIFF
--- a/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
+++ b/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
@@ -171,7 +171,7 @@ class Metasploit3 < Msf::Auxiliary
       data = dcerpc.last_response.stub_data
 
       # Check WDSC_Operation_Header OpCode-ErrorCode is success 0x000000
-      op_error_code = data.unpack('v*')[19]
+      op_error_code = data.unpack('V*')[15]
       if op_error_code == 0
         if data.length < 277
           vprint_error("No Unattend received for #{architecture[0]} architecture")

--- a/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
+++ b/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
@@ -64,8 +64,6 @@ class Metasploit3 < Msf::Auxiliary
 
   def query_host(rhost)
     # Create a handler with our UUID and Transfer Syntax
-    ndr86 = DCERPCUUID.xfer_syntax_uuid
-    version = DCERPCUUID.xfer_syntax_vers
 
     self.handle = Rex::Proto::DCERPC::Handle.new(
       [


### PR DESCRIPTION
@todb-r7 

There's really no point supporting NDR64 syntax as x64 systems will talk NDR32 without issue. So dropped back to the default syntax and corrected the module. Also performed various tidyup tasks after ~12 months more MSF dev experience.

Should play nicely with 2k3 x86 -> 2k8 x64 and I assume 2k12... 
