### PR TITLE
Rex sleep

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -38,9 +38,8 @@ interactive session type specific for the type of exploit.
 
 3. Don't use "sleep". It has been known to cause issues with
 multi-threaded programs on various platforms running an older version of
-Ruby such as 1.8. Instead, we use "select(nil, nil, nil, <time>)" or
-Rex.sleep() throughout the framework. We have found this works around
-the underlying issue.
+Ruby such as 1.8. Instead, we use Rex.sleep() throughout the framework.
+We have found this works around the underlying issue.
 
 4. Always use Rex sockets, not ruby sockets.  This includes
 third-party libraries such as Net::Http.  There are several very good

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -425,7 +425,7 @@ module Auxiliary::AuthBrute
       when 4; 0.1
       else; 0
     end
-    ::IO.select(nil,nil,nil,sleep_time) unless sleep_time == 0
+    Rex.sleep(sleep_time) unless sleep_time == 0
   end
 
   # Provides a consistant way to display messages about AuthBrute-mixed modules.

--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -86,7 +86,7 @@ module Auxiliary::UDPScanner
 
       scanner_recv(0.1)
 
-      ::IO.select(nil, nil, nil, 0.25)
+      Rex.sleep(0.25)
 
       retry
 

--- a/lib/msf/core/exploit/cmdstager.rb
+++ b/lib/msf/core/exploit/cmdstager.rb
@@ -45,7 +45,7 @@ module Exploit::CmdStager
 
       # In cases where a server has multiple threads, we want to be sure that
       # commands we execute happen in the correct (serial) order.
-      ::IO.select(nil, nil, nil, delay)
+      Rex.sleep(delay)
 
       progress(total_bytes, sent)
     end

--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -104,7 +104,7 @@ module Exploit::FileDropper
       delay = datastore['FileDropperDelay']
       if delay
         print_status("Waiting #{delay}s before file cleanup...")
-        select(nil,nil,nil,delay)
+        Rex.sleep(delay)
       end
 
       @dropped_files.delete_if do |file|

--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -1185,7 +1185,7 @@ module Exploit::Remote::HttpServer::PHPInclude
     begin
       print_status("PHP include server started.");
       php_exploit
-      ::IO.select(nil, nil, nil, 5)
+      Rex.sleep(5)
     rescue ::Interrupt
       raise $!
     ensure

--- a/lib/msf/core/exploit/smb/psexec.rb
+++ b/lib/msf/core/exploit/smb/psexec.rb
@@ -142,7 +142,7 @@ module Exploit::Remote::SMB::Psexec
     rescue ::Exception => e
       print_error("#{peer} - Error closing service handle: #{e}")
     end
-    select(nil, nil, nil, 1.0)
+    Rex.sleep(1.0)
     simple.disconnect("\\\\#{datastore['RHOST']}\\IPC$")
     return true
   end

--- a/lib/msf/core/exploit/tcp.rb
+++ b/lib/msf/core/exploit/tcp.rb
@@ -22,7 +22,7 @@ module EvasiveTCP
     while(idx < buf.length)
 
       if(@_send_delay and idx > 0)
-        ::IO.select(nil, nil, nil, @_send_delay)
+        Rex.sleep(@_send_delay)
       end
 
       pkt = buf[idx, len]

--- a/lib/msf/core/exploit/vim_soap.rb
+++ b/lib/msf/core/exploit/vim_soap.rb
@@ -526,7 +526,7 @@ module Exploit::Remote::VIMSoap
         state = res['RetrievePropertiesResponse']['returnval']['propSet']['val']['state']
         case state
         when 'running'
-          select(nil, nil, nil, 5)
+          Rex.sleep(5)
         when 'error'
           if res['RetrievePropertiesResponse']['returnval']['propSet']['val']['error']['fault']['existingState'] == 'poweredOn'
             return 'alreadyON'
@@ -558,7 +558,7 @@ module Exploit::Remote::VIMSoap
         state = res['RetrievePropertiesResponse']['returnval']['propSet']['val']['state']
         case state
         when 'running'
-          select(nil, nil, nil, 5)
+          Rex.sleep(5)
         when 'error'
           if res['RetrievePropertiesResponse']['returnval']['propSet']['val']['error']['fault']['existingState'] == 'poweredOn'
             return 'alreadyON'

--- a/lib/msf/core/post_mixin.rb
+++ b/lib/msf/core/post_mixin.rb
@@ -50,7 +50,7 @@ module Msf::PostMixin
     until session.sys or session_ready_count > tries
       session_ready_count += 1
       back_off_period = (session_ready_count**2)/10.0
-      select(nil,nil,nil,back_off_period)
+      Rex.sleep(back_off_period)
     end
     session_ready = !!session.sys
     raise "Could not get a hold of the session." unless session_ready

--- a/lib/msf/core/rpc/v10/rpc_auth.rb
+++ b/lib/msf/core/rpc/v10/rpc_auth.rb
@@ -31,7 +31,7 @@ end
     if fail
       # Introduce a random delay in the response to annoy brute forcers
       delay = [ ( rand(3000) / 1000.0 ), 0.50 ].max
-      ::IO.select(nil, nil, nil, delay)
+      Rex.sleep(delay)
 
       # Send back a 401 denied error
       error(401, "Login Failed")

--- a/lib/msf/core/session_manager.rb
+++ b/lib/msf/core/session_manager.rb
@@ -151,7 +151,7 @@ class SessionManager < Hash
         elog("Exception #{respawn_cnt}/#{respawn_max} in monitor thread #{e.class} #{e}")
         elog("Call stack: \n#{e.backtrace.join("\n")}")
         if respawn_cnt < respawn_max
-          ::IO.select(nil, nil, nil, 10.0)
+          Rex.sleep(10.0)
           retry
         end
       end

--- a/lib/msf/core/task_manager.rb
+++ b/lib/msf/core/task_manager.rb
@@ -39,7 +39,7 @@ class TaskManager
 
     def wait
       while self.status == :new
-        ::IO.select(nil,nil,nil,0.10)
+        Rex.sleep(0.10)
       end
       return self.status
     end
@@ -180,7 +180,7 @@ class TaskManager
       spin = (cnt == 0) ? (spin + 1) : 0
 
       if spin > 10
-        ::IO.select(nil, nil, nil, 0.25)
+        Rex.sleep(0.25)
       end
 
     end

--- a/lib/msf/core/thread_manager.rb
+++ b/lib/msf/core/thread_manager.rb
@@ -69,7 +69,7 @@ class ThreadManager < Array
       ::Thread.current[:tm_crit] = true
 
       while true
-        ::IO.select(nil, nil, nil, 1.0)
+        Rex.sleep(1.0)
         self.each_index do |i|
           state = self[i].alive? rescue false
           self[i] = nil if not state

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2910,7 +2910,7 @@ class Core
     else
       print_status "Starting the Metasploit services. This can take a little time."
       start_metasploit_service
-      select(nil,nil,nil,3)
+      Rex.sleep(3)
       if is_metasploit_service_running
         launch_metasploit_browser
       else
@@ -2945,7 +2945,7 @@ class Core
     # shouldn't really matter that we open and close it a few times.
     timeout = 0
     until really_started
-      select(nil,nil,nil,3)
+      Rex.sleep(3)
       log_data = ::File.open(svc_log, "rb") {|f| f.read f.stat.size}
       really_started = log_data =~ /Ready/ # This is webserver ready
       if really_started
@@ -2953,7 +2953,7 @@ class Core
         print_good "Metasploit Community / Pro is up and running, connecting now."
         print_good "If this is your first time connecting, you will be presented with"
         print_good "a self-signed certificate warning. Accept it to create a new user."
-        select(nil,nil,nil,7)
+        Rex.sleep(7)
         browser_pid = ::Process.spawn(cmd, "https://localhost:3790")
         ::Process.detach(browser_pid)
       elsif timeout >= 200 # 200 * 3 seconds is 10 minutes and that is tons of time.

--- a/lib/msf/ui/console/framework_event_manager.rb
+++ b/lib/msf/ui/console/framework_event_manager.rb
@@ -30,7 +30,7 @@ module FrameworkEventManager
   # Called when a session is registered with the framework.
   #
   def on_session_open(session)
-    select(nil,nil,nil,0.125) # Give the session time enough to register itself properly.
+    Rex.sleep(0.125) # Give the session time enough to register itself properly.
     output.print_status("#{session.desc} session #{session.name} opened (#{session.tunnel_to_s}) at #{Time.now}")
     if (Msf::Logging.session_logging_enabled? == true)
       Msf::Logging.start_session_log(session)

--- a/lib/net/ssh/command_stream.rb
+++ b/lib/net/ssh/command_stream.rb
@@ -97,7 +97,7 @@ class CommandStream
   def verify_channel
     while ! self.channel
       raise EOFError if ! self.thread.alive?
-      ::IO.select(nil, nil, nil, 0.10)
+      Rex.sleep(0.10)
     end
   end
 

--- a/lib/rex/io/ring_buffer.rb
+++ b/lib/rex/io/ring_buffer.rb
@@ -262,7 +262,7 @@ class RingBuffer
           if self.buff.length >= len
             return self.buff.slice!(0,len)
           else
-            IO.select(nil, nil, nil, 0.25)
+            IO.Rex.sleep(0.25)
             next
           end
         end

--- a/lib/rex/io/stream_server.rb
+++ b/lib/rex/io/stream_server.rb
@@ -147,7 +147,7 @@ protected
         cli = accept
         if not cli
           elog("The accept() returned nil in stream server listener monitor:  #{fd.inspect}")
-          ::IO.select(nil, nil, nil, 0.10)
+          Rex.sleep(0.10)
           next
         end
 

--- a/lib/rex/job_container.rb
+++ b/lib/rex/job_container.rb
@@ -31,7 +31,7 @@ class Job
     if (async)
       self.job_thread = Rex::ThreadFactory.spawn("JobID(#{jid})-#{name}", false) {
         # Deschedule our thread momentarily
-        ::IO.select(nil, nil, nil, 0.01)
+        Rex.sleep(0.01)
 
         begin
           run_proc.call(ctx)

--- a/lib/rex/post/meterpreter/client.rb
+++ b/lib/rex/post/meterpreter/client.rb
@@ -162,7 +162,7 @@ class Client
 
       # Ruby 1.8.7 and 1.9.0/1.9.1 uses a standard Errno
       rescue ::Errno::EAGAIN, ::Errno::EWOULDBLOCK
-          IO::select(nil, nil, nil, 0.10)
+          IO::Rex.sleep(0.10)
           retry
 
       # Ruby 1.9.2+ uses IO::WaitReadable/IO::WaitWritable

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -272,7 +272,7 @@ class ClientCore < Extension
     if client.passive_service
       # Sleep for 5 seconds to allow the full handoff, this prevents
       # the original process from stealing our loadlib requests
-      ::IO.select(nil, nil, nil, 5.0)
+      Rex.sleep(5.0)
     else
       # Prevent new commands from being sent while we finish migrating
       client.comm_mutex.synchronize do

--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -310,7 +310,7 @@ module PacketDispatcher
       # thread above.
       while(not @finish)
         if(@pqueue.empty?)
-          ::IO.select(nil, nil, nil, 0.10)
+          Rex.sleep(0.10)
           next
         end
 
@@ -375,7 +375,7 @@ module PacketDispatcher
         # handled. Sleep here to treat that situation as though the
         # queue is empty.
         if (backlog.length > 0 && backlog.length == incomplete.length)
-          ::IO.select(nil, nil, nil, 0.10)
+          Rex.sleep(0.10)
         end
 
         @pqueue.unshift(*incomplete)

--- a/lib/rex/post/meterpreter/packet_response_waiter.rb
+++ b/lib/rex/post/meterpreter/packet_response_waiter.rb
@@ -60,13 +60,13 @@ class PacketResponseWaiter
   def wait(interval)
     if( interval and interval == -1 )
       while(not self.done)
-        ::IO.select(nil, nil, nil, 0.1)
+        Rex.sleep(0.1)
       end
     else
       begin
         Timeout.timeout(interval) {
           while(not self.done)
-            ::IO.select(nil, nil, nil, 0.1)
+            Rex.sleep(0.1)
           end
         }
       rescue Timeout::Error

--- a/lib/rex/proto/smb/client.rb
+++ b/lib/rex/proto/smb/client.rb
@@ -135,7 +135,7 @@ NTLM_UTILS = Rex::Proto::NTLM::Utils
       while ( (chunk = data.slice!(0, size)).length > 0 )
         ret = self.socket.put(chunk)
         if (wait > 0)
-          ::IO.select(nil, nil, nil, wait)
+          Rex.sleep(wait)
         end
       end
       return ret

--- a/lib/rex/proto/tftp/server.rb
+++ b/lib/rex/proto/tftp/server.rb
@@ -66,7 +66,7 @@ class Server
     # Wait a maximum of 30 seconds for all transfers to finish.
     start = ::Time.now
     while (self.transfers.length > 0)
-      ::IO.select(nil, nil, nil, 0.5)
+      Rex.sleep(0.5)
       dur = ::Time.now - start
       break if (dur > 30)
     end

--- a/lib/rex/socket/ssl_tcp.rb
+++ b/lib/rex/socket/ssl_tcp.rb
@@ -113,7 +113,7 @@ begin
 
         # Ruby 1.8.7 and 1.9.0/1.9.1 uses a standard Errno
         rescue ::Errno::EAGAIN, ::Errno::EWOULDBLOCK
-            IO::select(nil, nil, nil, 0.10)
+            IO::Rex.sleep(0.10)
             retry
 
         # Ruby 1.9.2+ uses IO::WaitReadable/IO::WaitWritable

--- a/lib/rex/socket/ssl_tcp_server.rb
+++ b/lib/rex/socket/ssl_tcp_server.rb
@@ -68,7 +68,7 @@ module Rex::Socket::SslTcpServer
 
         # Ruby 1.8.7 and 1.9.0/1.9.1 uses a standard Errno
         rescue ::Errno::EAGAIN, ::Errno::EWOULDBLOCK
-            IO::select(nil, nil, nil, 0.10)
+            IO::Rex.sleep(0.10)
             retry
 
         # Ruby 1.9.2+ uses IO::WaitReadable/IO::WaitWritable

--- a/lib/rex/sync/thread_safe.rb
+++ b/lib/rex/sync/thread_safe.rb
@@ -73,7 +73,7 @@ module ThreadSafe
   # expires.
   #
   def self.sleep(seconds=nil)
-    self.select(nil, nil, nil, seconds)
+    self.Rex.sleep(seconds)
 
     seconds
   end

--- a/lib/rex/ui/interactive.rb
+++ b/lib/rex/ui/interactive.rb
@@ -94,7 +94,7 @@ module Interactive
     if (self.interacting)
       self.interacting = false
       while(not self.completed)
-        ::IO.select(nil, nil, nil, 0.25)
+        Rex.sleep(0.25)
       end
     end
   end

--- a/modules/auxiliary/admin/emc/alphastor_devicemanager_exec.rb
+++ b/modules/auxiliary/admin/emc/alphastor_devicemanager_exec.rb
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Auxiliary
     sock.put(pkt)
 
     # try to suck it all in.
-    select(nil,nil,nil,5)
+    Rex.sleep(5)
 
     res = sock.get_once || ''
 

--- a/modules/auxiliary/admin/emc/alphastor_librarymanager_exec.rb
+++ b/modules/auxiliary/admin/emc/alphastor_librarymanager_exec.rb
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Auxiliary
     print_status("Sending command: #{datastore['CMD']}")
     sock.put(pkt)
 
-    select(nil,nil,nil,1)
+    Rex.sleep(1)
 
     sock.get_once
 

--- a/modules/auxiliary/admin/oracle/sid_brute.rb
+++ b/modules/auxiliary/admin/oracle/sid_brute.rb
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Auxiliary
       end
 
       sock.put(pkt)
-      select(nil,nil,nil,s.to_i)
+      Rex.sleep(s.to_i)
       res = sock.get_once(-1,3)
       disconnect
 

--- a/modules/auxiliary/admin/oracle/tnscmd.rb
+++ b/modules/auxiliary/admin/oracle/tnscmd.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Auxiliary
       sock.put(pkt)
       print_status("writing #{pkt.length} bytes.")
 
-      select(nil,nil,nil,0.5)
+      Rex.sleep(0.5)
 
       print_status("reading")
       res = sock.get_once(-1,5) || ''

--- a/modules/auxiliary/admin/tftp/tftp_transfer_util.rb
+++ b/modules/auxiliary/admin/tftp/tftp_transfer_util.rb
@@ -158,7 +158,7 @@ class Metasploit3 < Msf::Auxiliary
       print_error "Unknown action: '#{action.name}'"
     end
     while not @tftp_client.complete
-      select(nil,nil,nil,1)
+      Rex.sleep(1)
       print_status [rtarget,"TFTP transfer operation complete."].join
       save_downloaded_file() if action.name == 'Download'
       break
@@ -172,7 +172,7 @@ class Metasploit3 < Msf::Auxiliary
   def cleanup
     if @tftp_client and @tftp_client.respond_to? :complete
       while not @tftp_client.complete
-        select(nil,nil,nil,1)
+        Rex.sleep(1)
         vprint_status "Cleaning up the TFTP client ports and threads."
         @tftp_client.stop
       end

--- a/modules/auxiliary/bnat/bnat_router.rb
+++ b/modules/auxiliary/bnat/bnat_router.rb
@@ -114,7 +114,7 @@ class Metasploit3 < Msf::Auxiliary
 
           #Trigger Cisco SPI Vulnerability by Double-tapping the SYN
           if packet.tcp_flags.syn == 1 && packet.tcp_flags.ack == 0
-            select(nil, nil, nil, 0.75)
+            Rex.sleep(0.75)
             inj.a2w(:array => [packet.to_s])
           end
           print_status("outpacket processed")
@@ -143,7 +143,7 @@ class Metasploit3 < Msf::Auxiliary
         arp_response = PacketFu::Packet.parse(cap.array[0])
         target_mac = arp_response.arp_saddr_mac if arp_response.arp_saddr_ip = target_ip
       end
-      select(nil, nil, nil, 0.1) # Check for a response ten times per second.
+      Rex.sleep(0.1) # Check for a response ten times per second.
     end
     return target_mac
   end

--- a/modules/auxiliary/client/smtp/emailer.rb
+++ b/modules/auxiliary/client/smtp/emailer.rb
@@ -218,7 +218,7 @@ class Metasploit3 < Msf::Auxiliary
       end
 
       send_message(mime_msg.to_s)
-      select(nil,nil,nil,wait)
+      Rex.sleep(wait)
     end
 
     print_status("Email sent..")

--- a/modules/auxiliary/dos/http/monkey_headers.rb
+++ b/modules/auxiliary/dos/http/monkey_headers.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Auxiliary
     dos
 
     print_status("#{rhost}:#{rport} - Checking server status...")
-    select(nil, nil, nil, 1)
+    Rex.sleep(1)
 
     if is_alive?
       print_error("#{rhost}:#{rport} - Server is still alive")

--- a/modules/auxiliary/dos/misc/dopewars.rb
+++ b/modules/auxiliary/dos/misc/dopewars.rb
@@ -47,7 +47,7 @@ class Metasploit4 < Msf::Auxiliary
     disconnect
 
     print_status("Checking for success...")
-    select(nil, nil, nil, 2)
+    Rex.sleep(2)
     begin
       connect
     rescue ::Interrupt

--- a/modules/auxiliary/dos/misc/memcached.rb
+++ b/modules/auxiliary/dos/misc/memcached.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Auxiliary
     disconnect
 
     print_status("#{rhost}:#{rport} - Checking host status...")
-    select(nil, nil, nil, 1)
+    Rex.sleep(1)
 
     if is_alive?
       print_error("#{rhost}:#{rport} - The DoS attempt did not work, host is still alive")

--- a/modules/auxiliary/dos/scada/igss9_dataserver.rb
+++ b/modules/auxiliary/dos/scada/igss9_dataserver.rb
@@ -89,10 +89,10 @@ class Metasploit3 < Msf::Auxiliary
       end
 
       if infinite
-        select(nil, nil, nil, snore)
+        Rex.sleep(snore)
         times += 1
       else
-        select(nil, nil, nil, snore) if count > 1
+        Rex.sleep(snore) if count > 1
         count -= 1
         times += 1
       end

--- a/modules/auxiliary/dos/smtp/sendmail_prescan.rb
+++ b/modules/auxiliary/dos/smtp/sendmail_prescan.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Auxiliary
       # because we send our own malicious RCPT.
       # however we want to make use of MAILFROM
       # and raw_send_recv()
-      #select(nil,nil,nil,23) # so we can attach gdb to the child PID
+      #Rex.sleep(23) # so we can attach gdb to the child PID
 
       sploit = ("A" * 255 + ";") * 4 + "A" * 217 + ";" + "\x5c\xff" * 28
 

--- a/modules/auxiliary/dos/wifi/netgear_ma521_rates.rb
+++ b/modules/auxiliary/dos/wifi/netgear_ma521_rates.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Auxiliary
 
     while (stime + rtime > Time.now.to_i)
       wifi.write(frame)
-      select(nil, nil, nil, 0.10) if (count % 100 == 0)
+      Rex.sleep(0.10) if (count % 100 == 0)
       count += 1
     end
 

--- a/modules/auxiliary/dos/wifi/netgear_wg311pci.rb
+++ b/modules/auxiliary/dos/wifi/netgear_wg311pci.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Auxiliary
 
     while (stime + rtime > Time.now.to_i)
       wifi.write(frame)
-      select(nil, nil, nil, 0.10) if (count % 100 == 0)
+      Rex.sleep(0.10) if (count % 100 == 0)
       count += 1
     end
 

--- a/modules/auxiliary/dos/windows/ftp/iis_list_exhaustion.rb
+++ b/modules/auxiliary/dos/windows/ftp/iis_list_exhaustion.rb
@@ -108,7 +108,7 @@ class Metasploit3 < Msf::Auxiliary
     rescue ::EOFError
       data = nil
     end
-    select(nil,nil,nil,1)
+    Rex.sleep(1)
     # close data channel so command channel updates
     data_disconnect
     # get status of transfer

--- a/modules/auxiliary/dos/windows/ftp/titan626_site.rb
+++ b/modules/auxiliary/dos/windows/ftp/titan626_site.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Auxiliary
     return unless connect_login
     print_status("Sending command...")
     raw_send("SITE WHO\r\n")
-    select(nil,nil,nil,1)
+    Rex.sleep(1)
     disconnect
   end
 end

--- a/modules/auxiliary/dos/windows/smb/ms10_054_queryfs_pool_overflow.rb
+++ b/modules/auxiliary/dos/windows/smb/ms10_054_queryfs_pool_overflow.rb
@@ -110,7 +110,7 @@ class Metasploit3 < Msf::Auxiliary
     malformed_trans2(0x03, params[idx])
 
     print_status("The target should encounter a blue screen error now.")
-    select(nil, nil, nil, 0.5)
+    Rex.sleep(0.5)
 
   end
 

--- a/modules/auxiliary/fuzzers/ftp/ftp_pre_post.rb
+++ b/modules/auxiliary/fuzzers/ftp/ftp_pre_post.rb
@@ -107,7 +107,7 @@ class Metasploit3 < Msf::Auxiliary
             pkt = prepend + evil + "\r\n"
             send_pkt(pkt, true)
             sock.put("QUIT\r\n")
-            select(nil, nil, nil, datastore['DELAY'])
+            Rex.sleep(datastore['DELAY'])
             disconnect
 
             count += datastore['STEPSIZE']
@@ -128,7 +128,7 @@ class Metasploit3 < Msf::Auxiliary
                 return
               else
                 print_status("Exception triggered, need #{@nr_errors - @error_cnt} more exception(s) before interrupting process")
-                select(nil,nil,nil,3)  #wait 3 seconds
+                Rex.sleep(3)  #wait 3 seconds
               end
             end
             if @error_cnt >= @nr_errors
@@ -225,7 +225,7 @@ class Metasploit3 < Msf::Auxiliary
                 ecount += 1
                 pkt = cmd + " " + evil + "\r\n"
                 send_pkt(pkt, true)
-                select(nil, nil, nil, datastore['DELAY'])
+                Rex.sleep(datastore['DELAY'])
                 @error_cnt = 0
               end
             rescue ::Exception => e
@@ -239,7 +239,7 @@ class Metasploit3 < Msf::Auxiliary
                   return
                 else
                   print_status("Exception triggered, need #{@nr_errors - @error_cnt} more exception(s) before interrupting process")
-                  select(nil,nil,nil,3)  #wait 3 seconds
+                  Rex.sleep(3)  #wait 3 seconds
                 end
               end
               if @error_cnt >= @nr_errors
@@ -249,7 +249,7 @@ class Metasploit3 < Msf::Auxiliary
             count += datastore['STEPSIZE']
           end
           sock.put("QUIT\r\n")
-          select(nil, nil, nil, datastore['DELAY'])
+          Rex.sleep(datastore['DELAY'])
           disconnect
         end
       end

--- a/modules/auxiliary/fuzzers/http/http_form_field.rb
+++ b/modules/auxiliary/fuzzers/http/http_form_field.rb
@@ -207,7 +207,7 @@ class Metasploit3 < Msf::Auxiliary
           end
           if datastore['DELAY'] > 0
             print_status("      (Sleeping for #{datastore['DELAY']} seconds...)")
-            select(nil,nil,nil,datastore['DELAY'])
+            Rex.sleep(datastore['DELAY'])
           end
           incr_fuzzsize()
         end
@@ -258,7 +258,7 @@ class Metasploit3 < Msf::Auxiliary
       end
       if datastore['DELAY'] > 0
         print_status("      (Sleeping for #{datastore['DELAY']} seconds...)")
-        select(nil,nil,nil,datastore['DELAY'])
+        Rex.sleep(datastore['DELAY'])
       end
     end
   end

--- a/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
+++ b/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
@@ -172,7 +172,7 @@ class Metasploit3 < Msf::Auxiliary
 
     # As long as we have the http_service object, we will keep the ftp server alive
     while @http_service
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
     end
   end
 

--- a/modules/auxiliary/gather/d20pass.rb
+++ b/modules/auxiliary/gather/d20pass.rb
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Auxiliary
   def cleanup
     if @tftp_client and @tftp_client.respond_to? :complete
       while not @tftp_client.complete
-        select(nil,nil,nil,1)
+        Rex.sleep(1)
         vprint_status "Cleaning up the TFTP client ports and threads."
         @tftp_client.stop
       end
@@ -87,7 +87,7 @@ class Metasploit3 < Msf::Auxiliary
     end
     # Wait for GET to finish
     while not @tftp_client.complete
-      select(nil, nil, nil, 0.1)
+      Rex.sleep(0.1)
     end
     fh = @tftp_client.recv_tempfile
     return fh

--- a/modules/auxiliary/scanner/dect/call_scanner.rb
+++ b/modules/auxiliary/scanner/dect/call_scanner.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Auxiliary
         next_channel
 
         vprint_status("Switching to channel: #{channel}")
-        select(nil,nil,nil,1)
+        Rex.sleep(1)
       end
     ensure
       print_status("Closing interface")

--- a/modules/auxiliary/scanner/dect/station_scanner.rb
+++ b/modules/auxiliary/scanner/dect/station_scanner.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Auxiliary
         next_channel
 
         vprint_status("Switching to channel: #{channel}")
-        select(nil,nil,nil,1)
+        Rex.sleep(1)
       end
     ensure
       print_status("Closing interface")

--- a/modules/auxiliary/scanner/discovery/arp_sweep.rb
+++ b/modules/auxiliary/scanner/discovery/arp_sweep.rb
@@ -84,7 +84,7 @@ class Metasploit3 < Msf::Auxiliary
         report_host(:host => reply.arp_saddr_ip, :mac=>reply.arp_saddr_mac)
         report_note(:host  => reply.arp_saddr_ip, :type  => "mac_oui", :data  => company)
       end
-      Kernel.select(nil, nil, nil, 0.50)
+      Kernel.Rex.sleep(0.50)
     end
 
     ensure
@@ -107,7 +107,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def getreply
     pkt_bytes = capture.next
-    Kernel.select(nil,nil,nil,0.1)
+    Kernel.Rex.sleep(0.1)
     return unless pkt_bytes
     pkt = PacketFu::Packet.parse(pkt_bytes)
     return unless pkt.is_arp?

--- a/modules/auxiliary/scanner/discovery/arp_sweep.rb
+++ b/modules/auxiliary/scanner/discovery/arp_sweep.rb
@@ -84,7 +84,7 @@ class Metasploit3 < Msf::Auxiliary
         report_host(:host => reply.arp_saddr_ip, :mac=>reply.arp_saddr_mac)
         report_note(:host  => reply.arp_saddr_ip, :type  => "mac_oui", :data  => company)
       end
-      Kernel.Rex.sleep(0.50)
+      Rex.sleep(0.50)
     end
 
     ensure
@@ -107,7 +107,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def getreply
     pkt_bytes = capture.next
-    Kernel.Rex.sleep(0.1)
+    Rex.sleep(0.1)
     return unless pkt_bytes
     pkt = PacketFu::Packet.parse(pkt_bytes)
     return unless pkt.is_arp?

--- a/modules/auxiliary/scanner/discovery/ipv6_multicast_ping.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_multicast_ping.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Auxiliary
 
     while(::Time.now.to_i < max_epoch)
       pkt_bytes = capture.next()
-      Kernel.Rex.sleep(0.1)
+      Rex.sleep(0.1)
       next if not pkt_bytes
       p = PacketFu::Packet.parse(pkt_bytes)
       # Don't bother checking if it's an echo reply, since Neighbor Solicitations

--- a/modules/auxiliary/scanner/discovery/ipv6_multicast_ping.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_multicast_ping.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Auxiliary
 
     while(::Time.now.to_i < max_epoch)
       pkt_bytes = capture.next()
-      Kernel.select(nil,nil,nil,0.1)
+      Kernel.Rex.sleep(0.1)
       next if not pkt_bytes
       p = PacketFu::Packet.parse(pkt_bytes)
       # Don't bother checking if it's an echo reply, since Neighbor Solicitations

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
@@ -92,7 +92,7 @@ class Metasploit3 < Msf::Auxiliary
           end
         end
 
-        ::IO.Rex.sleep(0.50)
+        Rex.sleep(0.50)
       end
 
     ensure
@@ -129,7 +129,7 @@ class Metasploit3 < Msf::Auxiliary
         probe = buildsolicitation(smac, shost, neigh)
 
         capture.inject(probe)
-        Kernel.Rex.sleep(0.1)
+        Rex.sleep(0.1)
 
         while(adv = getadvertisement())
           next unless adv.is_ipv6?
@@ -158,7 +158,7 @@ class Metasploit3 < Msf::Auxiliary
 
           print_status(sprintf("  %16s maps to %s",addr[:ipv4], addr[:ipv6]))
         end
-        ::IO.Rex.sleep(0.50)
+        Rex.sleep(0.50)
       end
 
     ensure
@@ -180,7 +180,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def getreply
     pkt = capture.next
-    Kernel.Rex.sleep(0.1)
+    Rex.sleep(0.1)
     return if not pkt
     p = PacketFu::Packet.parse(pkt)
     return unless p.is_arp?
@@ -210,7 +210,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def getadvertisement
     pkt = capture.next
-    Kernel.Rex.sleep(0.1)
+    Rex.sleep(0.1)
     return if not pkt
     p = PacketFu::Packet.parse(pkt)
     return unless p.is_ipv6?

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
@@ -92,7 +92,7 @@ class Metasploit3 < Msf::Auxiliary
           end
         end
 
-        ::IO.select(nil, nil, nil, 0.50)
+        ::IO.Rex.sleep(0.50)
       end
 
     ensure
@@ -129,7 +129,7 @@ class Metasploit3 < Msf::Auxiliary
         probe = buildsolicitation(smac, shost, neigh)
 
         capture.inject(probe)
-        Kernel.select(nil,nil,nil,0.1)
+        Kernel.Rex.sleep(0.1)
 
         while(adv = getadvertisement())
           next unless adv.is_ipv6?
@@ -158,7 +158,7 @@ class Metasploit3 < Msf::Auxiliary
 
           print_status(sprintf("  %16s maps to %s",addr[:ipv4], addr[:ipv6]))
         end
-        ::IO.select(nil, nil, nil, 0.50)
+        ::IO.Rex.sleep(0.50)
       end
 
     ensure
@@ -180,7 +180,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def getreply
     pkt = capture.next
-    Kernel.select(nil,nil,nil,0.1)
+    Kernel.Rex.sleep(0.1)
     return if not pkt
     p = PacketFu::Packet.parse(pkt)
     return unless p.is_arp?
@@ -210,7 +210,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def getadvertisement
     pkt = capture.next
-    Kernel.select(nil,nil,nil,0.1)
+    Kernel.Rex.sleep(0.1)
     return if not pkt
     p = PacketFu::Packet.parse(pkt)
     return unless p.is_ipv6?

--- a/modules/auxiliary/scanner/emc/alphastor_devicemanager.rb
+++ b/modules/auxiliary/scanner/emc/alphastor_devicemanager.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Auxiliary
 
     sock.put(pkt)
 
-    select(nil,nil,nil,0.25)
+    Rex.sleep(0.25)
 
     data = sock.get_once
 

--- a/modules/auxiliary/scanner/emc/alphastor_librarymanager.rb
+++ b/modules/auxiliary/scanner/emc/alphastor_librarymanager.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Auxiliary
 
     sock.put(pkt)
 
-    select(nil,nil,nil,1)
+    Rex.sleep(1)
 
     data = sock.get_once
 

--- a/modules/auxiliary/scanner/http/soap_xml.rb
+++ b/modules/auxiliary/scanner/http/soap_xml.rb
@@ -191,7 +191,7 @@ class Metasploit3 < Msf::Auxiliary
               end
             end
           end
-          select(nil, nil, nil, datastore['SLEEP']) if (datastore['SLEEP'] > 0)
+          Rex.sleep(datastore['SLEEP']) if (datastore['SLEEP'] > 0)
         end
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE => e

--- a/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
@@ -152,7 +152,7 @@ class Metasploit3 < Msf::Auxiliary
       # Remove any dead threads from the set
       cur_threads.delete(nil)
 
-      ::IO.Rex.sleep(0.25)
+      Rex.sleep(0.25)
     end
 
     # Clean up any remaining threads

--- a/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
@@ -152,7 +152,7 @@ class Metasploit3 < Msf::Auxiliary
       # Remove any dead threads from the set
       cur_threads.delete(nil)
 
-      ::IO.select(nil, nil, nil, 0.25)
+      ::IO.Rex.sleep(0.25)
     end
 
     # Clean up any remaining threads

--- a/modules/auxiliary/scanner/nessus/nessus_ntp_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_ntp_login.rb
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Auxiliary
       if (con)
         @connected=false
         connect
-        select(nil,nil,nil,0.4)
+        Rex.sleep(0.4)
       end
       @connected=true
       sock.put(data)

--- a/modules/auxiliary/scanner/netbios/nbname_probe.rb
+++ b/modules/auxiliary/scanner/netbios/nbname_probe.rb
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Auxiliary
       while (r = udp_sock.recvfrom(65535, 0.1) and r[1])
         parse_reply(r)
       end
-      select(nil, nil, nil, 0.25)
+      Rex.sleep(0.25)
     rescue ::Exception => e
       print_error("Unknown error: #{e.class} #{e}")
     end

--- a/modules/auxiliary/scanner/openvas/openvas_omp_login.rb
+++ b/modules/auxiliary/scanner/openvas/openvas_omp_login.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Auxiliary
       if (con)
         @connected=false
         connect
-        select(nil,nil,nil,0.4)
+        Rex.sleep(0.4)
       end
       @connected=true
       sock.put(data)

--- a/modules/auxiliary/scanner/openvas/openvas_otp_login.rb
+++ b/modules/auxiliary/scanner/openvas/openvas_otp_login.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Auxiliary
       if (con)
         @connected=false
         connect
-        select(nil,nil,nil,0.4)
+        Rex.sleep(0.4)
       end
       @connected=true
       sock.put(data)

--- a/modules/auxiliary/scanner/oracle/sid_enum.rb
+++ b/modules/auxiliary/scanner/oracle/sid_enum.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Auxiliary
 
       sock.put(pkt)
 
-      select(nil,nil,nil,0.5)
+      Rex.sleep(0.5)
 
       data = sock.get_once
 

--- a/modules/auxiliary/scanner/oracle/spy_sid.rb
+++ b/modules/auxiliary/scanner/oracle/spy_sid.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Auxiliary
       }, 5)
 
       if res and res.body =~ /SERVICE_NAME=/
-        select(nil,nil,nil,2)
+        Rex.sleep(2)
         sid = res.body.scan(/SERVICE_NAME=([^\)]+)/)
           report_note(
               :host	=> ip,

--- a/modules/auxiliary/scanner/oracle/tnslsnr_version.rb
+++ b/modules/auxiliary/scanner/oracle/tnslsnr_version.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Auxiliary
 
       sock.put(pkt)
 
-      select(nil,nil,nil,0.5)
+      Rex.sleep(0.5)
 
       data = sock.get_once
 

--- a/modules/auxiliary/scanner/pcanywhere/pcanywhere_login.rb
+++ b/modules/auxiliary/scanner/pcanywhere/pcanywhere_login.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Auxiliary
         )
         return if datastore['STOP_ON_SUCCESS']
         print_status "Waiting to Re-Negotiate Connection (this may take a minute)..."
-        select(nil, nil, nil, 40)
+        Rex.sleep(40)
         connect
         hsr = pca_handshake(ip)
         return if hsr == :handshake_failed
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Auxiliary
       when :reset
         print_status "#{ip}:#{rport} Login Failure #{user}:#{pass}"
         print_status "Connection Reset Attempting to reconnect in 1 second"
-        select(nil, nil, nil, 1)
+        Rex.sleep(1)
         connect
         hsr = pca_handshake(ip)
         return if hsr == :handshake_failed

--- a/modules/auxiliary/scanner/pop3/pop3_login.rb
+++ b/modules/auxiliary/scanner/pop3/pop3_login.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Auxiliary
       if (con)
         @connected=false
         connect
-        select(nil,nil,nil,0.4)
+        Rex.sleep(0.4)
       end
       @connected=true
       sock.put(data)

--- a/modules/auxiliary/scanner/rservices/rlogin_login.rb
+++ b/modules/auxiliary/scanner/rservices/rlogin_login.rb
@@ -163,7 +163,7 @@ class Metasploit3 < Msf::Auxiliary
     while this_attempt <= 3 and (ret.nil? or ret == :refused)
       if this_attempt > 0
         # power of 2 back-off
-        select(nil, nil, nil, 2**this_attempt)
+        Rex.sleep(2**this_attempt)
         vprint_error "#{rhost}:#{rport} rlogin - Retrying '#{user}':#{pass.inspect} from '#{luser}' due to reset"
       end
       ret = do_login(user, pass, luser, status)

--- a/modules/auxiliary/scanner/rservices/rsh_login.rb
+++ b/modules/auxiliary/scanner/rservices/rsh_login.rb
@@ -133,7 +133,7 @@ class Metasploit3 < Msf::Auxiliary
     while this_attempt <= 3 and (ret.nil? or ret == :refused)
       if this_attempt > 0
         # power of 2 back-off
-        select(nil, nil, nil, 2**this_attempt)
+        Rex.sleep(2**this_attempt)
         vprint_error "#{rhost}:#{rport} rsh - Retrying '#{user}' from '#{luser}' due to reset"
       end
       ret = connect_from_privileged_port

--- a/modules/auxiliary/scanner/scada/modbus_findunitid.rb
+++ b/modules/auxiliary/scanner/scada/modbus_findunitid.rb
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Auxiliary
       sploit  = start
       sploit += [counter].pack("C")
       sploit += theend
-      select(nil,nil,nil,datastore['BENICE'])
+      Rex.sleep(datastore['BENICE'])
       connect()
       sock.put(sploit)
 

--- a/modules/auxiliary/scanner/smb/psexec_loggedin_users.rb
+++ b/modules/auxiliary/scanner/smb/psexec_loggedin_users.rb
@@ -336,7 +336,7 @@ class Metasploit3 < Msf::Auxiliary
       print_error("#{peer} - Error: #{e}")
     end
 
-    select(nil, nil, nil, 1.0)
+    Rex.sleep(1.0)
     simple.disconnect("IPC$")
     return true
   end

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -398,7 +398,7 @@ class Metasploit3 < Msf::Auxiliary
         next if not shares.empty? and rport == 139 # no results, try again
       rescue Errno::ENOPROTOOPT
         print_status("Wait 5 seconds before retrying...")
-        select(nil, nil, nil, 5)
+        Rex.sleep(5)
         retry
       rescue ::Exception => e
         next if e.to_s =~ /execution expired/

--- a/modules/auxiliary/scanner/snmp/cisco_config_tftp.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_config_tftp.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Auxiliary
     if ::Thread.current == @main_thread
       # Wait 5 seconds for background transfers to complete
       print_status("Providing some time for transfers to complete...")
-      ::IO.Rex.sleep(5.0)
+      Rex.sleep(5.0)
 
       print_status("Shutting down the TFTP service...")
       if @tftp

--- a/modules/auxiliary/scanner/snmp/cisco_config_tftp.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_config_tftp.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Auxiliary
     if ::Thread.current == @main_thread
       # Wait 5 seconds for background transfers to complete
       print_status("Providing some time for transfers to complete...")
-      ::IO.select(nil, nil, nil, 5.0)
+      ::IO.Rex.sleep(5.0)
 
       print_status("Shutting down the TFTP service...")
       if @tftp

--- a/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Auxiliary
     if ::Thread.current == @main_thread
       # Wait 5 seconds for background transfers to complete
       print_status("Providing some time for transfers to complete...")
-      ::IO.select(nil, nil, nil, 5.0)
+      ::IO.Rex.sleep(5.0)
 
       print_status("Shutting down the TFTP service...")
       if @tftp

--- a/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Auxiliary
     if ::Thread.current == @main_thread
       # Wait 5 seconds for background transfers to complete
       print_status("Providing some time for transfers to complete...")
-      ::IO.Rex.sleep(5.0)
+      Rex.sleep(5.0)
 
       print_status("Shutting down the TFTP service...")
       if @tftp

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -169,7 +169,7 @@ class Metasploit3 < Msf::Auxiliary
       ret = nil
       while this_attempt <=3 and (ret.nil? or ret == :connection_error or ret == :connection_disconnect)
         if this_attempt > 0
-          select(nil,nil,nil,2**this_attempt)
+          Rex.sleep(2**this_attempt)
           print_brute :level => :verror, :ip => ip, :msg => "Retrying '#{user}':'#{pass}' due to connection error"
         end
         ret,proof = do_login(ip,user,pass,rport)

--- a/modules/auxiliary/scanner/telephony/wardial.rb
+++ b/modules/auxiliary/scanner/telephony/wardial.rb
@@ -326,7 +326,7 @@ class Metasploit3 < Msf::Auxiliary
           when /NO DIAL *TONE/i
             nextnum = false
             modem.hangup
-            select(nil,nil,nil,1)
+            Rex.sleep(1)
             next
           when nil
             modem.hangup
@@ -337,8 +337,8 @@ class Metasploit3 < Msf::Auxiliary
         Object.save_to_file(dialrange, datfile)
         #dialrange.save_to_file(datfile)
         nextnum = true
-        select(nil,nil,nil,1) # we need at least a little buffer for the modem to hangup/reset
-        select(nil,nil,nil,dialdelay-1) if dialdelay >= 1
+        Rex.sleep(1) # we need at least a little buffer for the modem to hangup/reset
+        Rex.sleep(dialdelay-1) if dialdelay >= 1
       end
 
     rescue ::Interrupt

--- a/modules/auxiliary/scanner/telnet/telnet_login.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_login.rb
@@ -77,7 +77,7 @@ class Metasploit3 < Msf::Auxiliary
     ret = nil
     while this_attempt <=3 and (ret.nil? or ret == :refused)
       if this_attempt > 0
-        select(nil,nil,nil,2**this_attempt)
+        Rex.sleep(2**this_attempt)
         vprint_error "#{rhost}:#{rport} Telnet - Retrying '#{user}':'#{pass}' due to reset"
       end
       ret = do_login(user,pass)

--- a/modules/auxiliary/scanner/vnc/vnc_login.rb
+++ b/modules/auxiliary/scanner/vnc/vnc_login.rb
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Auxiliary
 
           delay = (2**(n+1)) + 1
           vprint_status("Retrying in #{delay} seconds...")
-          select(nil, nil, nil, delay)
+          Rex.sleep(delay)
         }
         # If we tried all these attempts, and we still got a retry condition,
         # we'll just give up.. Must be that nasty blacklist algorithm kicking

--- a/modules/auxiliary/scanner/voice/recorder.rb
+++ b/modules/auxiliary/scanner/voice/recorder.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Auxiliary
           lstate = c.state
           while c.state != :hangup
             print_status("  Number: #{number}  State: #{c.state}  Frames: #{c.audio_buff.length}  DTMF: '#{c.dtmf}'")
-            ::IO.Rex.sleep(1.0)
+            Rex.sleep(1.0)
           end
         end
       rescue ::Timeout::Error

--- a/modules/auxiliary/scanner/voice/recorder.rb
+++ b/modules/auxiliary/scanner/voice/recorder.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Auxiliary
           lstate = c.state
           while c.state != :hangup
             print_status("  Number: #{number}  State: #{c.state}  Frames: #{c.audio_buff.length}  DTMF: '#{c.dtmf}'")
-            ::IO.select(nil, nil, nil, 1.0)
+            ::IO.Rex.sleep(1.0)
           end
         end
       rescue ::Timeout::Error

--- a/modules/auxiliary/server/dhcp.rb
+++ b/modules/auxiliary/server/dhcp.rb
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Auxiliary
 
     # Wait for finish..
     while @dhcp.thread.alive?
-      select(nil, nil, nil, 2)
+      Rex.sleep(2)
     end
 
     print_status("Stopping DHCP server...")

--- a/modules/auxiliary/server/tftp.rb
+++ b/modules/auxiliary/server/tftp.rb
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Auxiliary
 
     # Wait for finish..
     while @tftp.thread.alive?
-      select(nil, nil, nil, 2)
+      Rex.sleep(2)
     end
 
     vprint_status("Stopping TFTP server")

--- a/modules/auxiliary/spoof/arp/arp_poisoning.rb
+++ b/modules/auxiliary/spoof/arp/arp_poisoning.rb
@@ -120,7 +120,7 @@ class Metasploit3 < Msf::Auxiliary
                   vprint_status("Sending arp packet for #{shost} to #{dhost}")
                   reply = buildreply(shost, smac, dhost, dmac)
                   inject(reply)
-                  Kernel.select(nil, nil, nil, (datastore['PKT_DELAY'] * 1.0 )/1000)
+                  Kernel.Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
                 end
               end
             else
@@ -129,7 +129,7 @@ class Metasploit3 < Msf::Auxiliary
                   vprint_status("Sending arp request for #{shost} to #{dhost}")
                   request = buildprobe(dhost, dmac, shost)
                   inject(request)
-                  Kernel.select(nil, nil, nil, (datastore['PKT_DELAY'] * 1.0 )/1000)
+                  Kernel.Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
                 end
               end
             end
@@ -143,7 +143,7 @@ class Metasploit3 < Msf::Auxiliary
                   vprint_status("Sending arp packet for #{dhost} to #{shost}")
                   reply = buildreply(dhost, dmac, shost, smac)
                   inject(reply)
-                  Kernel.select(nil, nil, nil, (datastore['PKT_DELAY'] * 1.0 )/1000)
+                  Kernel.Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
                 end
               end
             end
@@ -161,7 +161,7 @@ class Metasploit3 < Msf::Auxiliary
         vprint_status("Sending arp packet for #{shost} address")
         reply = buildreply(shost, @smac, '0.0.0.0', 'ff:ff:ff:ff:ff:ff')
         inject(reply)
-        Kernel.select(nil, nil, nil, (datastore['PKT_DELAY'] * 1.0 )/1000)
+        Kernel.Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
       end
     end
   end
@@ -203,7 +203,7 @@ class Metasploit3 < Msf::Auxiliary
           @dsthosts_cache[reply.arp_saddr_ip] = reply.arp_saddr_mac
         end
       end
-      Kernel.select(nil, nil, nil, 0.50)
+      Kernel.Rex.sleep(0.50)
     end
     raise RuntimeError, "No hosts found" unless @dsthosts_cache.length > 0
 
@@ -240,7 +240,7 @@ class Metasploit3 < Msf::Auxiliary
             @srchosts_cache[reply.arp_saddr_ip] = reply.arp_saddr_mac
           end
         end
-        Kernel.select(nil, nil, nil, 0.50)
+        Kernel.Rex.sleep(0.50)
       end
       raise RuntimeError, "No hosts found" unless @srchosts_cache.length > 0
     end
@@ -280,7 +280,7 @@ class Metasploit3 < Msf::Auxiliary
               vprint_status("Sending arp packet for #{shost} to #{dhost}")
               reply = buildreply(shost, @smac, dhost, dmac)
               inject(reply)
-              Kernel.select(nil, nil, nil, (datastore['PKT_DELAY'] * 1.0 )/1000)
+              Kernel.Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
             end
           end
         else
@@ -289,7 +289,7 @@ class Metasploit3 < Msf::Auxiliary
               vprint_status("Sending arp packet for #{shost} to #{dhost}")
               reply = buildreply(shost, @smac, dhost, dmac)
               inject(reply)
-              Kernel.select(nil, nil, nil, (datastore['PKT_DELAY'] * 1.0 )/1000)
+              Kernel.Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
             end
           end
         end
@@ -304,7 +304,7 @@ class Metasploit3 < Msf::Auxiliary
               vprint_status("Sending arp packet for #{dhost} to #{shost}")
               reply = buildreply(dhost, @smac, shost, smac)
               inject(reply)
-              Kernel.select(nil, nil, nil, (datastore['PKT_DELAY'] * 1.0 )/1000)
+              Kernel.Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
             end
           end
         end

--- a/modules/auxiliary/spoof/arp/arp_poisoning.rb
+++ b/modules/auxiliary/spoof/arp/arp_poisoning.rb
@@ -120,7 +120,7 @@ class Metasploit3 < Msf::Auxiliary
                   vprint_status("Sending arp packet for #{shost} to #{dhost}")
                   reply = buildreply(shost, smac, dhost, dmac)
                   inject(reply)
-                  Kernel.Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
+                  Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
                 end
               end
             else
@@ -129,7 +129,7 @@ class Metasploit3 < Msf::Auxiliary
                   vprint_status("Sending arp request for #{shost} to #{dhost}")
                   request = buildprobe(dhost, dmac, shost)
                   inject(request)
-                  Kernel.Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
+                  Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
                 end
               end
             end
@@ -143,7 +143,7 @@ class Metasploit3 < Msf::Auxiliary
                   vprint_status("Sending arp packet for #{dhost} to #{shost}")
                   reply = buildreply(dhost, dmac, shost, smac)
                   inject(reply)
-                  Kernel.Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
+                  Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
                 end
               end
             end
@@ -161,7 +161,7 @@ class Metasploit3 < Msf::Auxiliary
         vprint_status("Sending arp packet for #{shost} address")
         reply = buildreply(shost, @smac, '0.0.0.0', 'ff:ff:ff:ff:ff:ff')
         inject(reply)
-        Kernel.Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
+        Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
       end
     end
   end
@@ -203,7 +203,7 @@ class Metasploit3 < Msf::Auxiliary
           @dsthosts_cache[reply.arp_saddr_ip] = reply.arp_saddr_mac
         end
       end
-      Kernel.Rex.sleep(0.50)
+      Rex.sleep(0.50)
     end
     raise RuntimeError, "No hosts found" unless @dsthosts_cache.length > 0
 
@@ -240,7 +240,7 @@ class Metasploit3 < Msf::Auxiliary
             @srchosts_cache[reply.arp_saddr_ip] = reply.arp_saddr_mac
           end
         end
-        Kernel.Rex.sleep(0.50)
+        Rex.sleep(0.50)
       end
       raise RuntimeError, "No hosts found" unless @srchosts_cache.length > 0
     end
@@ -280,7 +280,7 @@ class Metasploit3 < Msf::Auxiliary
               vprint_status("Sending arp packet for #{shost} to #{dhost}")
               reply = buildreply(shost, @smac, dhost, dmac)
               inject(reply)
-              Kernel.Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
+              Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
             end
           end
         else
@@ -289,7 +289,7 @@ class Metasploit3 < Msf::Auxiliary
               vprint_status("Sending arp packet for #{shost} to #{dhost}")
               reply = buildreply(shost, @smac, dhost, dmac)
               inject(reply)
-              Kernel.Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
+              Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
             end
           end
         end
@@ -304,7 +304,7 @@ class Metasploit3 < Msf::Auxiliary
               vprint_status("Sending arp packet for #{dhost} to #{shost}")
               reply = buildreply(dhost, @smac, shost, smac)
               inject(reply)
-              Kernel.Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
+              Rex.sleep((datastore['PKT_DELAY'] * 1.0 )/1000)
             end
           end
         end

--- a/modules/auxiliary/spoof/cisco/dtp.rb
+++ b/modules/auxiliary/spoof/cisco/dtp.rb
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Auxiliary
         @run = true
         while @run
           capture.inject(dtp.to_s)
-          select(nil, nil, nil, 60)
+          Rex.sleep(60)
         end
         close_pcap
       end

--- a/modules/auxiliary/spoof/dns/bailiwicked_host.rb
+++ b/modules/auxiliary/spoof/dns/bailiwicked_host.rb
@@ -220,7 +220,7 @@ class Metasploit3 < Msf::Auxiliary
               print_error("Failure: This hostname is already in the target cache: #{name}")
               print_error("         Cache entry expires on #{t}... sleeping.")
               cached = true
-              select(nil,nil,nil,ttl)
+              Rex.sleep(ttl)
             end
           end
 

--- a/modules/auxiliary/spoof/llmnr/llmnr_response.rb
+++ b/modules/auxiliary/spoof/llmnr/llmnr_response.rb
@@ -187,7 +187,7 @@ attr_accessor :sock, :thread
     add_socket(self.sock)
 
     while thread.alive?
-      select(nil, nil, nil, 0.25)
+      Rex.sleep(0.25)
     end
 
     self.thread.kill

--- a/modules/auxiliary/spoof/replay/pcap_replay.rb
+++ b/modules/auxiliary/spoof/replay/pcap_replay.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Auxiliary
       vprint_status("Sending file (loop : #{count = count + 1})")
       inject_pcap(filename, file_filter, pkt_delay )
       loop -= 1 unless infinity
-      Kernel.Rex.sleep((delay * 1.0)/1000) if loop > 0 or infinity
+      Rex.sleep((delay * 1.0)/1000) if loop > 0 or infinity
     end
     close_pcap
   end

--- a/modules/auxiliary/spoof/replay/pcap_replay.rb
+++ b/modules/auxiliary/spoof/replay/pcap_replay.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Auxiliary
       vprint_status("Sending file (loop : #{count = count + 1})")
       inject_pcap(filename, file_filter, pkt_delay )
       loop -= 1 unless infinity
-      Kernel.select(nil, nil, nil, (delay * 1.0)/1000) if loop > 0 or infinity
+      Kernel.Rex.sleep((delay * 1.0)/1000) if loop > 0 or infinity
     end
     close_pcap
   end

--- a/modules/auxiliary/voip/asterisk_login.rb
+++ b/modules/auxiliary/voip/asterisk_login.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Auxiliary
       if (!@connected)
         connect
         @connected = true
-        select(nil,nil,nil,0.4)
+        Rex.sleep(0.4)
       end
       sock.put(command)
       @result = sock.get_once || ''

--- a/modules/auxiliary/vsploit/malware/dns/dns_mariposa.rb
+++ b/modules/auxiliary/vsploit/malware/dns/dns_mariposa.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Auxiliary
         time = Time.new
         time = time.strftime("%Y-%m-%d %H:%M:%S")
         print_status("#{time} - Waiting #{datastore['DELAY']} seconds to query")
-        select(nil, nil, nil, datastore['DELAY'])
+        Rex.sleep(datastore['DELAY'])
       end
       count += 1
     end

--- a/modules/auxiliary/vsploit/malware/dns/dns_query.rb
+++ b/modules/auxiliary/vsploit/malware/dns/dns_query.rb
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Auxiliary
         time = Time.new
         time = time.strftime("%Y-%m-%d %H:%M:%S")
         print_status("#{time} - Waiting #{datastore['DELAY']} seconds to beacon")
-        select(nil, nil, nil, datastore['DELAY'])
+        Rex.sleep(datastore['DELAY'])
       end
       count += 1
     end

--- a/modules/auxiliary/vsploit/malware/dns/dns_zeus.rb
+++ b/modules/auxiliary/vsploit/malware/dns/dns_zeus.rb
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Auxiliary
         time = Time.new
         time = time.strftime("%Y-%m-%d %H:%M:%S")
         print_status("#{time} - Waiting #{datastore['DELAY']} seconds to query")
-        select(nil, nil, nil, datastore['DELAY'])
+        Rex.sleep(datastore['DELAY'])
       end
       count += 1
     end

--- a/modules/exploits/aix/rpc_cmsd_opcode21.rb
+++ b/modules/exploits/aix/rpc_cmsd_opcode21.rb
@@ -94,7 +94,7 @@ class Metasploit3 < Msf::Exploit::Remote
         sunrpc_call(7, xdr, 2)
       }
 
-      #print_status("ATTACH DEBUGGER NOW!"); select(nil,nil,nil,5)
+      #print_status("ATTACH DEBUGGER NOW!"); Rex.sleep(5)
 
       buf = rand_text_alphanumeric(payload_space)
       buf << [brute_target['Ret']].pack('N')

--- a/modules/exploits/dialup/multi/login/manyargs.rb
+++ b/modules/exploits/dialup/multi/login/manyargs.rb
@@ -186,7 +186,7 @@ class Metasploit3 < Msf::Exploit::Remote
 #				puts Rex::Text.to_hex_dump("\x04")
 #				dialup_puts("\x04") if len > 0
 #			end
-      select(nil,nil,nil,0.5)
+      Rex.sleep(0.5)
     end
 
     # wait for password prompt

--- a/modules/exploits/freebsd/telnet/telnet_encrypt_keyid.rb
+++ b/modules/exploits/freebsd/telnet/telnet_encrypt_keyid.rb
@@ -114,7 +114,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     # Some delay between each request seems necessary in some cases
-    ::IO.Rex.sleep(0.5)
+    Rex.sleep(0.5)
 
     # The second request results in the pointer being called
     print_status("Sending second payload...")
@@ -122,7 +122,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     handler
 
-    ::IO.Rex.sleep(0.5)
+    Rex.sleep(0.5)
     disconnect
   end
 

--- a/modules/exploits/freebsd/telnet/telnet_encrypt_keyid.rb
+++ b/modules/exploits/freebsd/telnet/telnet_encrypt_keyid.rb
@@ -114,7 +114,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     # Some delay between each request seems necessary in some cases
-    ::IO.select(nil, nil, nil, 0.5)
+    ::IO.Rex.sleep(0.5)
 
     # The second request results in the pointer being called
     print_status("Sending second payload...")
@@ -122,7 +122,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     handler
 
-    ::IO.select(nil, nil, nil, 0.5)
+    ::IO.Rex.sleep(0.5)
     disconnect
   end
 

--- a/modules/exploits/linux/http/ddwrt_cgibin_exec.rb
+++ b/modules/exploits/linux/http/ddwrt_cgibin_exec.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Giving the handler time to run...")
     handler
 
-    select(nil, nil, nil, 10.0)
+    Rex.sleep(10.0)
   end
 
 end

--- a/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
@@ -169,7 +169,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # wait for payload download
     if (datastore['DOWNHOST'])
       print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the D-Link device to download the payload")
-      select(nil, nil, nil, datastore['HTTP_DELAY'])
+      Rex.sleep(datastore['HTTP_DELAY'])
     else
       wait_linux_payload
     end
@@ -215,7 +215,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     waited = 0
     while (not @elf_sent)
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
       waited += 1
       if (waited > datastore['HTTP_DELAY'])
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Target didn't request request the ELF payload -- Maybe it can't connect back to us?")

--- a/modules/exploits/linux/http/dlink_dir615_up_exec.rb
+++ b/modules/exploits/linux/http/dlink_dir615_up_exec.rb
@@ -200,14 +200,14 @@ class Metasploit3 < Msf::Exploit::Remote
     # wait for payload download
     if (datastore['DOWNHOST'])
       print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the D-Link device to download the payload")
-      select(nil, nil, nil, datastore['HTTP_DELAY'])
+      Rex.sleep(datastore['HTTP_DELAY'])
     else
       wait_linux_payload
     end
     register_file_for_cleanup("/tmp/#{filename}")
 
     print_status("#{rhost}:#{rport} - Waiting #{@timeout} seconds for reloading the configuration")
-    select(nil, nil, nil, @timeout)
+    Rex.sleep(@timeout)
 
     #
     # chmod
@@ -219,7 +219,7 @@ class Metasploit3 < Msf::Exploit::Remote
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
     end
     print_status("#{rhost}:#{rport} - Waiting #{@timeout} seconds for reloading the configuration")
-    select(nil, nil, nil, @timeout)
+    Rex.sleep(@timeout)
 
     #
     # execute
@@ -251,7 +251,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     waited = 0
     while (not @elf_sent)
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
       waited += 1
       if (waited > datastore['HTTP_DELAY'])
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Target didn't request request the ELF payload -- Maybe it cant connect back to us?")

--- a/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
@@ -164,7 +164,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # wait for payload download
     if (datastore['DOWNHOST'])
       print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the D-Link device to download the payload")
-      select(nil, nil, nil, datastore['HTTP_DELAY'])
+      Rex.sleep(datastore['HTTP_DELAY'])
     else
       wait_linux_payload
     end
@@ -252,7 +252,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     waited = 0
     while (not @elf_sent)
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
       waited += 1
       if (waited > datastore['HTTP_DELAY'])
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Target didn't request request the ELF payload -- Maybe it can't connect back to us?")

--- a/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
@@ -198,7 +198,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # wait for payload download
     if (datastore['DOWNHOST'])
       print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the Linksys device to download the payload")
-      select(nil, nil, nil, datastore['HTTP_DELAY'])
+      Rex.sleep(datastore['HTTP_DELAY'])
     else
       wait_linux_payload
     end
@@ -244,7 +244,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     waited = 0
     while (not @elf_sent)
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
       waited += 1
       if (waited > datastore['HTTP_DELAY'])
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Target didn't request request the ELF payload -- Maybe it cant connect back to us?")

--- a/modules/exploits/linux/http/linksys_wrt160nv2_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt160nv2_apply_exec.rb
@@ -172,7 +172,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # wait for payload download
     if (datastore['DOWNHOST'])
       print_status("#{rhost}:#{rport} - Giving #{datastore['DELAY']} seconds to the Linksys device to download the payload")
-      select(nil, nil, nil, datastore['DELAY'])
+      Rex.sleep(datastore['DELAY'])
     else
       wait_linux_payload
     end
@@ -207,7 +207,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     waited = 0
     while (not @tftp.files.length == 0)
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
       waited += 1
       if (waited > datastore['DELAY'])
         @tftp.stop

--- a/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
@@ -175,7 +175,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     #the device needs around 10 seconds to apply our current configuration
     print_status("#{rhost}:#{rport} - Waiting #{@timeout} seconds for reloading the configuration")
-    select(nil, nil, nil, @timeout)
+    Rex.sleep(@timeout)
   end
 
   def request(cmd,user,pass,uri)
@@ -290,7 +290,7 @@ class Metasploit3 < Msf::Exploit::Remote
         print_status("#{rhost}:#{rport} - Blind Exploitation - unknown Exploitation state")
       end
       print_status("#{rhost}:#{rport} - Waiting #{@timeout} seconds for reloading the configuration")
-      select(nil, nil, nil, @timeout)
+      Rex.sleep(@timeout)
       restore_conf(user,pass,uri) if restore
       return
     end
@@ -352,7 +352,7 @@ class Metasploit3 < Msf::Exploit::Remote
     if (datastore['DOWNHOST'])
       #waiting some time so we could be sure that the device got the payload from our third party server
       print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the Linksys device to download the payload")
-      select(nil, nil, nil, datastore['HTTP_DELAY'])
+      Rex.sleep(datastore['HTTP_DELAY'])
     else
       wait_linux_payload
     end
@@ -369,7 +369,7 @@ class Metasploit3 < Msf::Exploit::Remote
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
     end
     print_status("#{rhost}:#{rport} - Waiting #{@timeout} seconds for reloading the configuration")
-    select(nil, nil, nil, @timeout)
+    Rex.sleep(@timeout)
 
     #
     # execute
@@ -382,7 +382,7 @@ class Metasploit3 < Msf::Exploit::Remote
       fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to deploy payload")
     end
     print_status("#{rhost}:#{rport} - Waiting #{@timeout} seconds for reloading the configuration")
-    select(nil, nil, nil, @timeout)
+    Rex.sleep(@timeout)
 
     #
     #reload original configuration
@@ -410,7 +410,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     waited = 0
     while (not @elf_sent)
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
       waited += 1
       if (waited > datastore['HTTP_DELAY'])
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Target didn't request request the ELF payload -- Maybe it cant connect back to us?")

--- a/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
@@ -202,7 +202,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # wait for payload download
     if (datastore['DOWNHOST'])
       print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the Netgear device to download the payload")
-      select(nil, nil, nil, datastore['HTTP_DELAY'])
+      Rex.sleep(datastore['HTTP_DELAY'])
     else
       wait_linux_payload
     end
@@ -248,7 +248,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     waited = 0
     while (not @elf_sent)
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
       waited += 1
       if (waited > datastore['HTTP_DELAY'])
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Target didn't request request the ELF payload -- Maybe it cant connect back to us?")

--- a/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
@@ -143,7 +143,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     print_status("#{rhost}:#{rport} - Waiting #{@timeout} seconds for reloading the configuration")
-    select(nil, nil, nil, @timeout)
+    Rex.sleep(@timeout)
   end
 
   def request(cmd,user,pass,uri)
@@ -319,7 +319,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # wait for payload download
     if (datastore['DOWNHOST'])
       print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the Netgear device to download the payload")
-      select(nil, nil, nil, datastore['HTTP_DELAY'])
+      Rex.sleep(datastore['HTTP_DELAY'])
     else
       wait_linux_payload
     end
@@ -354,7 +354,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     waited = 0
     while (not @elf_sent)
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
       waited += 1
       if (waited > datastore['HTTP_DELAY'])
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Target didn't request request the ELF payload -- Maybe it cant connect back to us?")

--- a/modules/exploits/linux/http/symantec_web_gateway_lfi.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_lfi.rb
@@ -90,7 +90,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri'    => "/#{php}"
     })
 
-    select(nil, nil, nil, 1)
+    Rex.sleep(1)
 
     # Use the directory traversal to load the PHP code
     # access_log takes a long time to retrieve
@@ -102,7 +102,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("#{peer} - Waiting for a session, may take some time...")
 
-    select(nil, nil, nil, 1)
+    Rex.sleep(1)
 
     handler
   end

--- a/modules/exploits/linux/madwifi/madwifi_giwscan_cb.rb
+++ b/modules/exploits/linux/madwifi/madwifi_giwscan_cb.rb
@@ -119,7 +119,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     while (stime + rtime > Time.now.to_i)
       wifi.write(frame)
-      select(nil, nil, nil, 0.10) if (count % 100 == 0)
+      Rex.sleep(0.10) if (count % 100 == 0)
       count += 1
       break if session_created? and datastore['SINGLESHOT']
     end

--- a/modules/exploits/linux/misc/lprng_format_string.rb
+++ b/modules/exploits/linux/misc/lprng_format_string.rb
@@ -160,7 +160,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     connect
     #print_status("Sleeping, attach now!!")
-    #select(nil,nil,nil,5)
+    #Rex.sleep(5)
 
     sock.put(fmtbuf)
 

--- a/modules/exploits/linux/misc/netsupport_manager_agent.rb
+++ b/modules/exploits/linux/misc/netsupport_manager_agent.rb
@@ -163,19 +163,19 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("Sending A")
     sock.put(triggerA)
-    select(nil, nil, nil, 1)
+    Rex.sleep(1)
 
     print_status("Sending B")
     sock.put(triggerB)
-    select(nil, nil, nil, 1)
+    Rex.sleep(1)
 
     print_status("Sending C")
     sock.put(triggerC)
-    select(nil, nil, nil, 1)
+    Rex.sleep(1)
 
     print_status("Sending D")
     sock.put(triggerD)
-    select(nil, nil, nil, 1)
+    Rex.sleep(1)
 
     disconnect
   end

--- a/modules/exploits/linux/samba/chain_reply.rb
+++ b/modules/exploits/linux/samba/chain_reply.rb
@@ -140,7 +140,7 @@ class Metasploit3 < Msf::Exploit::Remote
         connect
         self.simple.client.session_id = rand(31337)
 
-        #select(nil,nil,nil,2)
+        #Rex.sleep(2)
         #puts "press any key"; $stdin.gets
 
         #
@@ -208,7 +208,7 @@ class Metasploit3 < Msf::Exploit::Remote
         disconnect
 
         # See if we won yet..
-        select(nil,nil,nil, 1)
+        Rex.sleep( 1)
         break if session_created?
       }
   end

--- a/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
+++ b/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     waited = 0
     while (not @elf_sent)
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
       waited += 1
       if (waited > datastore['HTTP_DELAY'])
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Target didn't request request the ELF payload -- Maybe it cant connect back to us?")
@@ -207,7 +207,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # wait for payload download
     if (datastore['DOWNHOST'])
       print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the Linksys device to download the payload")
-      select(nil, nil, nil, datastore['HTTP_DELAY'])
+      Rex.sleep(datastore['HTTP_DELAY'])
     else
       wait_linux_payload
     end

--- a/modules/exploits/linux/telnet/telnet_encrypt_keyid.rb
+++ b/modules/exploits/linux/telnet/telnet_encrypt_keyid.rb
@@ -104,14 +104,14 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     # Some delay between each request seems necessary in some cases
-    ::IO.select(nil, nil, nil, 0.5)
+    ::IO.Rex.sleep(0.5)
 
     # The second request results in the pointer being called
     print_status("Sending second payload...")
     sock.put(sploit)
     handler
 
-    ::IO.select(nil, nil, nil, 0.5)
+    ::IO.Rex.sleep(0.5)
     disconnect
   end
 

--- a/modules/exploits/linux/telnet/telnet_encrypt_keyid.rb
+++ b/modules/exploits/linux/telnet/telnet_encrypt_keyid.rb
@@ -104,14 +104,14 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     # Some delay between each request seems necessary in some cases
-    ::IO.Rex.sleep(0.5)
+    Rex.sleep(0.5)
 
     # The second request results in the pointer being called
     print_status("Sending second payload...")
     sock.put(sploit)
     handler
 
-    ::IO.Rex.sleep(0.5)
+    Rex.sleep(0.5)
     disconnect
   end
 

--- a/modules/exploits/multi/ftp/wuftpd_site_exec_format.rb
+++ b/modules/exploits/multi/ftp/wuftpd_site_exec_format.rb
@@ -221,7 +221,7 @@ class Metasploit3 < Msf::Exploit::Remote
     return if mytarget.name == "Debug"
 
     #print_status("ATTACH!")
-    #select(nil,nil,nil,5)
+    #Rex.sleep(5)
 
     fmtstr_detect_caps
 

--- a/modules/exploits/multi/handler.rb
+++ b/modules/exploits/multi/handler.rb
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Exploit::Remote
       break if session_created? and datastore['ExitOnSession']
       break if ( datastore['ListenerTimeout'].to_i > 0 and (stime + datastore['ListenerTimeout'].to_i < Time.now.to_f) )
 
-      select(nil,nil,nil,1)
+      Rex.sleep(1)
     end
   end
 

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -598,7 +598,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     #Sleep for a bit before cleanup
-    select(nil, nil, nil, 5)
+    Rex.sleep(5)
 
     #Start undeploying
     print_status("Getting information to undeploy...")

--- a/modules/exploits/multi/http/jboss_bshdeployer.rb
+++ b/modules/exploits/multi/http/jboss_bshdeployer.rb
@@ -356,7 +356,7 @@ EOT
       if (attempt < num_attempts - 1)
         msg << ", retrying in 5 seconds..."
         print_status(msg) if datastore['VERBOSE']
-        select(nil, nil, nil, 5)
+        Rex.sleep(5)
       else
         print_error(msg)
         return res

--- a/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
+++ b/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
@@ -347,7 +347,7 @@ EOT
       if (attempt < num_attempts - 1)
         msg << ", retrying in 5 seconds..."
         print_status(msg) if datastore['VERBOSE']
-        select(nil, nil, nil, 5)
+        Rex.sleep(5)
       else
         print_error(msg)
         return res

--- a/modules/exploits/multi/http/jboss_invoke_deploy.rb
+++ b/modules/exploits/multi/http/jboss_invoke_deploy.rb
@@ -292,7 +292,7 @@ EOT
       if (attempt < num_attempts - 1)
         msg << ", retrying in 5 seconds..."
         print_status(msg) if datastore['VERBOSE']
-        select(nil, nil, nil, 5)
+        Rex.sleep(5)
       else
         print_error(msg)
         return res

--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -212,7 +212,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Waiting for the server to request the WAR archive....")
     waited = 0
     while (not @war_sent)
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
       waited += 1
       if (waited > 30)
         fail_with(Failure::Unknown, 'Server did not request WAR archive -- Maybe it cant connect back to us?')
@@ -258,7 +258,7 @@ class Metasploit3 < Msf::Exploit::Remote
         msg << ", retrying in 3 seconds..."
         print_error(msg)
 
-        select(nil, nil, nil, 3)
+        Rex.sleep(3)
       else
         print_error(msg)
       end

--- a/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
+++ b/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
@@ -141,7 +141,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     waited = 0
     while (not @elf_sent)
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
       waited += 1
       if (waited > datastore['HTTP_DELAY'])
         fail_with(Failure::Unknown, "Target didn't request request the ELF payload -- Maybe it cant connect back to us?")
@@ -149,7 +149,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     #print_status("#{peer} - Giving time to the payload to execute...")
-    #select(nil, nil, nil, 20) unless session_created?
+    #Rex.sleep(20) unless session_created?
 
     print_status("#{peer} - Shutting down the web service...")
     stop_service

--- a/modules/exploits/multi/http/sonicwall_gms_upload.rb
+++ b/modules/exploits/multi/http/sonicwall_gms_upload.rb
@@ -194,7 +194,7 @@ class Metasploit3 < Msf::Exploit::Remote
     upload_and_run_jsp(dropper_filename, dropper)
 
     10.times do
-      select(nil, nil, nil, 2)
+      Rex.sleep(2)
 
       # Now make a request to trigger the newly deployed war
       print_status("#{@peer} - Attempting to launch payload in deployed WAR...")

--- a/modules/exploits/multi/http/splunk_upload_app_exec.rb
+++ b/modules/exploits/multi/http/splunk_upload_app_exec.rb
@@ -151,7 +151,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       # wait a short time to let the output be produced
       print_status("Waiting for #{command_output_delay} seconds to retrieve command output")
-      select(nil,nil,nil,command_output_delay)
+      Rex.sleep(command_output_delay)
       job_output = fetch_job_output(job_id)
       if job_output.body.match(/Waiting for data.../)
         print_status("No output returned in time")

--- a/modules/exploits/multi/http/struts_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_default_action_mapper.rb
@@ -344,7 +344,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     waited = 0
     while (not @pl_sent)
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
       waited += 1
       if (waited > datastore['HTTP_DELAY'])
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Target didn't request request the ELF payload -- Maybe it cant connect back to us?")

--- a/modules/exploits/multi/http/zenworks_control_center_upload.rb
+++ b/modules/exploits/multi/http/zenworks_control_center_upload.rb
@@ -117,7 +117,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     # Wait to ensure the uploaded war is deployed
-    select(nil, nil, nil, 20)
+    Rex.sleep(20)
 
     print_status("Triggering payload at '/#{app_base}/#{jsp_name}.jsp' ...")
     send_request_cgi({

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -123,7 +123,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # Wait for the request to be handled
     1.upto(120) do
       break if session_created?
-      select(nil, nil, nil, 0.25)
+      Rex.sleep(0.25)
       handler()
     end
 

--- a/modules/exploits/multi/misc/ra1nx_pubcall_exec.rb
+++ b/modules/exploits/multi/misc/ra1nx_pubcall_exec.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if data and data =~ /020.*wait/
       print_status("#{rhost}:#{rport} - Connection successful, giving 3 seconds to IRC server to process our connection...")
-      select(nil, nil, nil, 3)
+      Rex.sleep(3)
     end
   end
 

--- a/modules/exploits/multi/misc/wireshark_lwres_getaddrbyname_loop.rb
+++ b/modules/exploits/multi/misc/wireshark_lwres_getaddrbyname_loop.rb
@@ -217,7 +217,7 @@ class Metasploit3 < Msf::Exploit::Remote
       while true
         break if session_created? and datastore['ExitOnSession']
         capture_sendto(p, rhost)
-        select(nil,nil,nil,datastore['DELAY'])
+        Rex.sleep(datastore['DELAY'])
       end
 
       close_pcap
@@ -233,7 +233,7 @@ class Metasploit3 < Msf::Exploit::Remote
         connect_udp
         udp_sock.put(sploit)
         disconnect_udp
-        select(nil,nil,nil,datastore['DELAY'])
+        Rex.sleep(datastore['DELAY'])
       end
     end
 

--- a/modules/exploits/multi/misc/zend_java_bridge.rb
+++ b/modules/exploits/multi/misc/zend_java_bridge.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
     sock.put(java_require)
     res = sock.get_once
 
-    select(nil, nil, nil, 5) # wait for the request to be handled
+    Rex.sleep(5) # wait for the request to be handled
     create_and_exec
   end
 

--- a/modules/exploits/multi/ntp/ntp_overflow.rb
+++ b/modules/exploits/multi/ntp/ntp_overflow.rb
@@ -77,15 +77,15 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("Sending hunter")
     udp_sock.put(sploit)
-    select(nil,nil,nil,0.5)
+    Rex.sleep(0.5)
 
     print_status("Sending payload")
     udp_sock.put(pkt1 + egg)
-    select(nil,nil,nil,0.5)
+    Rex.sleep(0.5)
 
     print_status("Calling overflow trigger")
     udp_sock.put(pkt2)
-    select(nil,nil,nil,0.5)
+    Rex.sleep(0.5)
 
     handler
     disconnect_udp

--- a/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
+++ b/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
@@ -264,7 +264,7 @@ class Metasploit4 < Msf::Exploit::Remote
     # wait for payload download
     if (datastore['DOWNHOST'])
       print_status("#{rhost}:#{rport} - Giving #{datastore['HTTP_DELAY']} seconds to the SAP Management Console to download the payload")
-      select(nil, nil, nil, datastore['HTTP_DELAY'])
+      Rex.sleep(datastore['HTTP_DELAY'])
     else
       wait_linux_payload
     end
@@ -314,7 +314,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
     waited = 0
     while (not @elf_sent)
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
       waited += 1
       if (waited > datastore['HTTP_DELAY'])
         fail_with(Failure::Unknown, "#{rhost}:#{rport} - Target didn't request request the ELF payload -- Maybe it cant connect back to us?")

--- a/modules/exploits/multi/upnp/libupnp_ssdp_overflow.rb
+++ b/modules/exploits/multi/upnp/libupnp_ssdp_overflow.rb
@@ -153,7 +153,7 @@ class Metasploit3 < Msf::Exploit::Remote
     r = udp_sock.sendto(pkt, rhost, rport, 0)
 
     1.upto(5) do
-      ::IO.select(nil, nil, nil, 1)
+      ::IO.Rex.sleep(1)
       break if session_created?
     end
 

--- a/modules/exploits/multi/upnp/libupnp_ssdp_overflow.rb
+++ b/modules/exploits/multi/upnp/libupnp_ssdp_overflow.rb
@@ -153,7 +153,7 @@ class Metasploit3 < Msf::Exploit::Remote
     r = udp_sock.sendto(pkt, rhost, rport, 0)
 
     1.upto(5) do
-      ::IO.Rex.sleep(1)
+      Rex.sleep(1)
       break if session_created?
     end
 

--- a/modules/exploits/multi/wyse/hagent_untrusted_hsdata.rb
+++ b/modules/exploits/multi/wyse/hagent_untrusted_hsdata.rb
@@ -207,7 +207,7 @@ class Metasploit3 < Msf::Exploit::Remote
     stime = Time.now.to_f
     while(not @exe_sent)
       break if (stime + 90 < Time.now.to_f)
-      select(nil, nil, nil, 0.25)
+      Rex.sleep(0.25)
     end
 
     if(not @exe_sent)

--- a/modules/exploits/osx/browser/safari_file_policy.rb
+++ b/modules/exploits/osx/browser/safari_file_policy.rb
@@ -225,7 +225,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # As long as we have the http_service object, we will keep the ftp server alive
     while @http_service
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
     end
   end
 

--- a/modules/exploits/osx/mdns/upnp_location.rb
+++ b/modules/exploits/osx/mdns/upnp_location.rb
@@ -221,7 +221,7 @@ class Metasploit3 < Msf::Exploit::Remote
     socket.put(upnp_reply)
 
     print_status("Sleeping to give mDNSDaemonIdle() a chance to run")
-    select(nil,nil,nil,10)
+    Rex.sleep(10)
 
     handler()
     disconnect_udp()

--- a/modules/exploits/osx/rtsp/quicktime_rtsp_content_type.rb
+++ b/modules/exploits/osx/rtsp/quicktime_rtsp_content_type.rb
@@ -166,7 +166,7 @@ class Metasploit3 < Msf::Exploit::Remote
     client.put(header + body)
 
     print_status("Sleeping...")
-    select(nil,nil,nil,1)
+    Rex.sleep(1)
 
     print_status("Starting handler...")
     handler(client)

--- a/modules/exploits/solaris/lpd/sendmail_exec.rb
+++ b/modules/exploits/solaris/lpd/sendmail_exec.rb
@@ -140,7 +140,7 @@ class Metasploit3 < Msf::Exploit::Remote
     sock2.close
 
     print_status("Waiting up to 60 seconds for the payload to execute...")
-    select(nil,nil,nil,60)
+    Rex.sleep(60)
 
     handler
   end

--- a/modules/exploits/solaris/sunrpc/sadmind_exec.rb
+++ b/modules/exploits/solaris/sunrpc/sadmind_exec.rb
@@ -93,7 +93,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return
     else
       print_status('exploit did not give us an error, this is good...')
-      select(nil,nil,nil,1)
+      Rex.sleep(1)
       handler
     end
   end

--- a/modules/exploits/solaris/telnet/fuser.rb
+++ b/modules/exploits/solaris/telnet/fuser.rb
@@ -95,11 +95,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
     sock.put(req)
     sock.get_once
-    select(nil,nil,nil,0.25)
+    Rex.sleep(0.25)
 
     sock.put("nohup " + payload.encoded + " >/dev/null 2>&1\n")
 
-    select(nil,nil,nil,0.25)
+    Rex.sleep(0.25)
 
     handler
   end

--- a/modules/exploits/solaris/telnet/ttyprompt.rb
+++ b/modules/exploits/solaris/telnet/ttyprompt.rb
@@ -81,7 +81,7 @@ class Metasploit3 < Msf::Exploit::Remote
       "\xff\xf0"
 
     sock.put(req)
-    select(nil,nil,nil,0.25)
+    Rex.sleep(0.25)
 
     print_status('Sending username...')
 
@@ -91,12 +91,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
     sock.put(req + "\n\n\n")
 
-    select(nil,nil,nil,0.25)
+    Rex.sleep(0.25)
     sock.get_once
 
     sock.put("nohup " + payload.encoded + " >/dev/null 2>&1\n")
 
-    select(nil,nil,nil,0.25)
+    Rex.sleep(0.25)
 
     handler
   end

--- a/modules/exploits/unix/http/contentkeeperweb_mimencode.rb
+++ b/modules/exploits/unix/http/contentkeeperweb_mimencode.rb
@@ -99,7 +99,7 @@ class Metasploit3 < Msf::Exploit::Remote
     sock.put(sploit + body + "\r\n\r\n")
     disconnect
 
-    select(nil,nil,nil,3) # Wait a few seconds..
+    Rex.sleep(3) # Wait a few seconds..
     print_status("Calling payload...")
     connect
     req = "GET /cgi-bin/ck/#{datastore['OVERWRITE']} HTTP/1.1\r\n" # Almost all files are owned by root, chmod'ed 777 :) rwx
@@ -108,7 +108,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     handler
     disconnect
-    select(nil,nil,nil,3) # Wait for session creation.
+    Rex.sleep(3) # Wait for session creation.
     if not datastore['SkipEscalation'] and session_created? and datastore['PAYLOAD'] =~ /perl/
       print_status("Privilege escalation appears to have worked!")
       print_status("/bin/bash is now root setuid! Type 'bash -p' to get root.")

--- a/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
+++ b/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
@@ -71,7 +71,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # Wait for the request to be handled
     1.upto(120) do
       break if session_created?
-      select(nil, nil, nil, 0.25)
+      Rex.sleep(0.25)
       handler()
     end
     disconnect

--- a/modules/exploits/unix/smtp/exim4_string_format.rb
+++ b/modules/exploits/unix/smtp/exim4_string_format.rb
@@ -294,7 +294,7 @@ class Metasploit3 < Msf::Exploit::Remote
       print_status("Looking for Perl to facilitate escalation...")
       # Check for Perl as a way to escalate our payload
       sock.put("perl -V\n")
-      select(nil, nil, nil, 3.0)
+      Rex.sleep(3.0)
       resp = sock.get_once(-1, 10.0)
     end
 
@@ -344,7 +344,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     # Give some time for the payload to be consumed
-    select(nil, nil, nil, 4)
+    Rex.sleep(4)
 
     handler
     disconnect

--- a/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
+++ b/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
@@ -134,7 +134,7 @@ class Metasploit3 < Msf::Exploit::Remote
     if (res)
       print_status("The server returned: #{res.code} #{res.message}")
       print_status("Waiting on the payload to execute...")
-      select(nil,nil,nil,20)
+      Rex.sleep(20)
     else
       print_status("No response from the server")
     end

--- a/modules/exploits/windows/antivirus/ams_hndlrsvc.rb
+++ b/modules/exploits/windows/antivirus/ams_hndlrsvc.rb
@@ -146,7 +146,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     sock.put(packet)
 
-    select(nil,nil,nil,3)
+    Rex.sleep(3)
     disconnect
   end
 

--- a/modules/exploits/windows/backupexec/name_service.rb
+++ b/modules/exploits/windows/backupexec/name_service.rb
@@ -104,7 +104,7 @@ class Metasploit3 < Msf::Exploit::Remote
     sock.put(payload.encoded)
 
     print_status("Waiting for the payload to execute...")
-    select(nil,nil,nil,2)
+    Rex.sleep(2)
 
     handler
     disconnect

--- a/modules/exploits/windows/brightstor/mediasrv_sunrpc.rb
+++ b/modules/exploits/windows/brightstor/mediasrv_sunrpc.rb
@@ -272,7 +272,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     begin
       ret = sunrpc_call(0xf5, request)
-      select(nil,nil,nil,20)
+      Rex.sleep(20)
     rescue
     end
 

--- a/modules/exploits/windows/brightstor/universal_agent.rb
+++ b/modules/exploits/windows/brightstor/universal_agent.rb
@@ -96,7 +96,7 @@ class Metasploit3 < Msf::Exploit::Remote
       disconnect
 
       # Give the process time to recover from each exception
-      select(nil,nil,nil,0.1);
+      Rex.sleep(0.1);
     }
 
     handler

--- a/modules/exploits/windows/browser/cisco_anyconnect_exec.rb
+++ b/modules/exploits/windows/browser/cisco_anyconnect_exec.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       print_status("Client requested: #{request.uri}. Sending vpndownloader.exe")
       send_response(cli, exe, { 'Content-Type' => 'application/octet-stream' })
-      select(nil, nil, nil, 5) # let the file download
+      Rex.sleep(5) # let the file download
       handler(cli)
       return
     end

--- a/modules/exploits/windows/driver/broadcom_wifi_ssid.rb
+++ b/modules/exploits/windows/driver/broadcom_wifi_ssid.rb
@@ -110,10 +110,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
     while (stime + datastore['RUNTIME'].to_i > Time.now.to_i)
 
-      select(nil, nil, nil, 0.02)
+      Rex.sleep(0.02)
       wifi.write(create_response)
 
-      select(nil, nil, nil, 0.01)
+      Rex.sleep(0.01)
       wifi.write(create_beacon)
 
       break if session_created?

--- a/modules/exploits/windows/driver/dlink_wifi_rates.rb
+++ b/modules/exploits/windows/driver/dlink_wifi_rates.rb
@@ -133,7 +133,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Sending exploit beacons for #{datastore['RUNTIME']} seconds...")
     while (stime + rtime > Time.now.to_i)
       wifi.write(create_beacon)
-      select(nil, nil, nil, 0.10) if (count % 100 == 0)
+      Rex.sleep(0.10) if (count % 100 == 0)
 
       count += 1
 

--- a/modules/exploits/windows/driver/netgear_wg111_beacon.rb
+++ b/modules/exploits/windows/driver/netgear_wg111_beacon.rb
@@ -123,7 +123,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Sending exploit beacons for #{datastore['RUNTIME']} seconds...")
     while (stime + rtime > Time.now.to_i)
       wifi.write(create_beacon)
-      select(nil, nil, nil, 0.10) if (count % 100 == 0)
+      Rex.sleep(0.10) if (count % 100 == 0)
 
       count += 1
 

--- a/modules/exploits/windows/firewall/blackice_pam_icq.rb
+++ b/modules/exploits/windows/firewall/blackice_pam_icq.rb
@@ -130,7 +130,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       print_status("Sleeping (giving exception handler time to recover)")
 
-      select(nil,nil,nil,5)
+      Rex.sleep(5)
     }
   end
 

--- a/modules/exploits/windows/ftp/comsnd_ftpd_fmtstr.rb
+++ b/modules/exploits/windows/ftp/comsnd_ftpd_fmtstr.rb
@@ -189,7 +189,7 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     sock.get_once(1024)
     sock.put(sploit)
-    select(nil, nil, nil, 2)
+    Rex.sleep(2)
     handler
     disconnect
 

--- a/modules/exploits/windows/ftp/dreamftp_format.rb
+++ b/modules/exploits/windows/ftp/dreamftp_format.rb
@@ -68,12 +68,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def exploit
     connect
-    select(nil,nil,nil,0.25)
+    Rex.sleep(0.25)
     sploit = "\xeb\x29"
     sploit << "%8x%8x%8x%8x%8x%8x%8x%8x%" + target['Offset'].to_s + "d%n%n"
     sploit << "@@@@@@@@" + payload.encoded
     sock.put(sploit + "\r\n")
-    select(nil,nil,nil,0.25)
+    Rex.sleep(0.25)
     handler
     disconnect
   end

--- a/modules/exploits/windows/ftp/freefloatftp_wbem.rb
+++ b/modules/exploits/windows/ftp/freefloatftp_wbem.rb
@@ -87,7 +87,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
   def upload(filename)
-    select(nil, nil, nil, 1)
+    Rex.sleep(1)
 
     peer = "#{rhost}:#{rport}"
     print_status("#{peer} - Trying to upload #{::File.basename(filename)}")

--- a/modules/exploits/windows/ftp/goldenftp_pass_bof.rb
+++ b/modules/exploits/windows/ftp/goldenftp_pass_bof.rb
@@ -83,7 +83,7 @@ class Metasploit3 < Msf::Exploit::Remote
     raw_send(shortjmp + "\n")
     send_user(datastore['FTPUSER'])
     send_cmd(['PASS', sploit], false)
-    select(nil,nil,nil,2)
+    Rex.sleep(2)
     handler
     disconnect
   end

--- a/modules/exploits/windows/ftp/ms09_053_ftpd_nlst.rb
+++ b/modules/exploits/windows/ftp/ms09_053_ftpd_nlst.rb
@@ -158,7 +158,7 @@ class Metasploit3 < Msf::Exploit::Remote
       res   = send_cmd( ['NLST', pre+pst + "*/../" + pre + "*/"], true )
       print_status(res.strip) if res
 
-      select(nil,nil,nil,2)
+      Rex.sleep(2)
 
       handler
       disconnect

--- a/modules/exploits/windows/ftp/open_ftpd_wbem.rb
+++ b/modules/exploits/windows/ftp/open_ftpd_wbem.rb
@@ -95,7 +95,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   # Largely stolen from freefloatftp_wbem.rb
   def upload(filename)
-    select(nil, nil, nil, 1)
+    Rex.sleep(1)
 
     peer = "#{rhost}:#{rport}"
     print_status("#{peer} - Trying to upload #{::File.basename(filename)}")

--- a/modules/exploits/windows/ftp/quickshare_traversal_write.rb
+++ b/modules/exploits/windows/ftp/quickshare_traversal_write.rb
@@ -95,7 +95,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
   def upload(filename)
-    select(nil, nil, nil, 1)
+    Rex.sleep(1)
 
     peer = "#{rhost}:#{rport}"
     print_status("#{peer} - Trying to upload #{::File.basename(filename)}")

--- a/modules/exploits/windows/ftp/wftpd_size.rb
+++ b/modules/exploits/windows/ftp/wftpd_size.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Trying target #{target.name}...")
 
     send_cmd(['SIZE', sploit], false)
-    select(nil,nil,nil,2)
+    Rex.sleep(2)
 
     handler
     disconnect

--- a/modules/exploits/windows/http/edirectory_imonitor.rb
+++ b/modules/exploits/windows/http/edirectory_imonitor.rb
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Exploit::Remote
     uri << "B" * 0xD0
 
     res = c.send_request(c.request_raw({ 'uri' => uri }))
-    select(nil,nil,nil,4)
+    Rex.sleep(4)
 
     handler
     disconnect

--- a/modules/exploits/windows/http/hp_power_manager_filename.rb
+++ b/modules/exploits/windows/http/hp_power_manager_filename.rb
@@ -111,7 +111,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # Wait for a bit longer. For some reason it may take some time for the process to start
     # handling our request.
-    select(nil, nil, nil, 7)
+    Rex.sleep(7)
 
     handler
     disconnect

--- a/modules/exploits/windows/http/hp_power_manager_login.rb
+++ b/modules/exploits/windows/http/hp_power_manager_login.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
       }
     }, 10)
 
-    select(nil,nil,nil,5)
+    Rex.sleep(5)
     handler
   end
 

--- a/modules/exploits/windows/http/httpdx_tolog_format.rb
+++ b/modules/exploits/windows/http/httpdx_tolog_format.rb
@@ -210,7 +210,7 @@ For now, that will have to be done manually.
     disconnect
 
     # connect again to trigger shellcode
-    select(nil, nil, nil, 1.5)
+    Rex.sleep(1.5)
     print_status(" triggering shellcode now")
     print_status("Please be patient, the egg hunter may take a while...")
     connect

--- a/modules/exploits/windows/http/maxdb_webdbm_database.rb
+++ b/modules/exploits/windows/http/maxdb_webdbm_database.rb
@@ -77,7 +77,7 @@ class Metasploit3 < Msf::Exploit::Remote
     sock.put(res)
 
     #give wahttp.exe a bit to recover...
-    select(nil,nil,nil,2)
+    Rex.sleep(2)
 
     handler
     disconnect

--- a/modules/exploits/windows/http/servu_session_cookie.rb
+++ b/modules/exploits/windows/http/servu_session_cookie.rb
@@ -126,7 +126,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Trying target #{target.name}..." % target['Ret'])
     sock.put(req)
 
-    select(nil, nil, nil, 1.5)
+    Rex.sleep(1.5)
     handler
     disconnect
   end

--- a/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
+++ b/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
@@ -167,7 +167,7 @@ class Metasploit3 < Msf::Exploit::Remote
   #
   def inject_exec
     # This little lag is meant to ensure the TCP server runs first before the requests
-    select(nil, nil, nil, 1)
+    Rex.sleep(1)
 
     # Inject our JSP payload
     print_status("#{rhost}:#{rport} - Sending JSP payload")

--- a/modules/exploits/windows/http/sybase_easerver.rb
+++ b/modules/exploits/windows/http/sybase_easerver.rb
@@ -78,7 +78,7 @@ class Metasploit3 < Msf::Exploit::Remote
     }, 5)
 
     print_status("Overflow request sent, sleeping for four seconds")
-    select(nil,nil,nil,4)
+    Rex.sleep(4)
   end
 
 end

--- a/modules/exploits/windows/http/zenworks_assetmgmt_uploadservlet.rb
+++ b/modules/exploits/windows/http/zenworks_assetmgmt_uploadservlet.rb
@@ -160,7 +160,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("Uploading #{war_data.length} bytes as #{app_base}.war ...")
 
-    select(nil, nil, nil, 10)
+    Rex.sleep(10)
 
     if (res.code == 500)
       print_status("Triggering payload at '/#{app_base}/#{jsp_name}.jsp' ...")

--- a/modules/exploits/windows/http/zenworks_uploadservlet.rb
+++ b/modules/exploits/windows/http/zenworks_uploadservlet.rb
@@ -81,7 +81,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("Uploading #{war_data.length} bytes as #{app_base}.war ...")
 
-    select(nil, nil, nil, 20)
+    Rex.sleep(20)
 
     if (res.code == 200)
       print_status("Triggering payload at '/#{app_base}/#{jsp_name}.jsp' ...")

--- a/modules/exploits/windows/iis/ms03_007_ntdll_webdav.rb
+++ b/modules/exploits/windows/iis/ms03_007_ntdll_webdav.rb
@@ -157,7 +157,7 @@ class Metasploit3 < Msf::Exploit::Remote
       end
 
       1.upto(8) { |i|
-        select(nil,nil,nil,0.25)
+        Rex.sleep(0.25)
         return if self.session_created?
       }
 
@@ -177,7 +177,7 @@ class Metasploit3 < Msf::Exploit::Remote
         send_request_raw({'uri' => '/'}, 5)
       rescue
         print_error("Connection failed (#{i} of 20)...")
-        select(nil,nil,nil,2)
+        Rex.sleep(2)
         next
       end
       return true

--- a/modules/exploits/windows/imap/mdaemon_cram_md5.rb
+++ b/modules/exploits/windows/imap/mdaemon_cram_md5.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = sock.get_once
 
     print_status("Received LOGOUT reply: #{res.chomp}")
-    select(nil,nil,nil,1)
+    Rex.sleep(1)
 
     handler
     disconnect

--- a/modules/exploits/windows/imap/mercury_login.rb
+++ b/modules/exploits/windows/imap/mercury_login.rb
@@ -87,7 +87,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Trying target #{target.name}...")
 
     sock.put(sploit)
-    select(nil,nil,nil,1)
+    Rex.sleep(1)
 
     handler
     disconnect

--- a/modules/exploits/windows/isapi/ms03_022_nsiislog_post.rb
+++ b/modules/exploits/windows/isapi/ms03_022_nsiislog_post.rb
@@ -94,7 +94,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'data'         => pst
     }, 5)
 
-    select(nil,nil,nil,1)
+    Rex.sleep(1)
 
     handler
     disconnect

--- a/modules/exploits/windows/isapi/ms03_051_fp30reg_chunked.rb
+++ b/modules/exploits/windows/isapi/ms03_051_fp30reg_chunked.rb
@@ -103,7 +103,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       handler
 
-      select(nil,nil,nil,1)
+      Rex.sleep(1)
     end
   end
 

--- a/modules/exploits/windows/local/ikeext_service.rb
+++ b/modules/exploits/windows/local/ikeext_service.rb
@@ -294,7 +294,7 @@ class Metasploit3 < Msf::Exploit::Local
           print_status("Unable to start service, handler running waiting for a reboot...")
           while(true)
             break if session_created?
-            select(nil,nil,nil,1)
+            Rex.sleep(1)
           end
         else
           fail_with(Exploit::Failure::Unknown, "Unable to start service, use exploit -j to run as a background job and wait for a reboot...")

--- a/modules/exploits/windows/lotus/lotusnotes_lzh.rb
+++ b/modules/exploits/windows/lotus/lotusnotes_lzh.rb
@@ -161,7 +161,7 @@ class Metasploit3 < Msf::Exploit::Remote
       break if session_created? and datastore['ExitOnSession']
       break if ( datastore['ListenerTimeout'].to_i > 0 and (stime + datastore['ListenerTimeout'].to_i < Time.now.to_f) )
 
-      select(nil,nil,nil,1)
+      Rex.sleep(1)
     end
   end
 end

--- a/modules/exploits/windows/lpd/wincomlpd_admin.rb
+++ b/modules/exploits/windows/lpd/wincomlpd_admin.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Trying target #{target.name}...")
 
     sock.puts(sploit)
-    select(nil,nil,nil,5)
+    Rex.sleep(5)
 
     handler
     disconnect

--- a/modules/exploits/windows/misc/agentxpp_receive_agentx.rb
+++ b/modules/exploits/windows/misc/agentxpp_receive_agentx.rb
@@ -87,7 +87,7 @@ class Metasploit3 < Msf::Exploit::Remote
     sock.put(hdr)
 
     # Wait to make sure it processed that chunk.
-    select(nil, nil, nil, 0.5)
+    Rex.sleep(0.5)
     #print_status("press enter to trigger..."); x = $stdin.gets
 
     # Send the rest (smashed!)

--- a/modules/exploits/windows/misc/asus_dpcproxy_overflow.rb
+++ b/modules/exploits/windows/misc/asus_dpcproxy_overflow.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("Trying target #{target.name}...")
     sock.put(sploit)
-    select(nil,nil,nil,3) # =(
+    Rex.sleep(3) # =(
 
     handler
     disconnect

--- a/modules/exploits/windows/misc/bakbone_netvault_heap.rb
+++ b/modules/exploits/windows/misc/bakbone_netvault_heap.rb
@@ -131,7 +131,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     print_status("Overflow request sent, sleeping fo four seconds (#{try} tries)")
-    select(nil,nil,nil,4)
+    Rex.sleep(4)
 
     print_status("Attempting to trigger memory overwrite by reconnecting...")
 

--- a/modules/exploits/windows/misc/bcaaa_bof.rb
+++ b/modules/exploits/windows/misc/bcaaa_bof.rb
@@ -132,7 +132,7 @@ class Metasploit3 < Msf::Exploit::Remote
       print_status("Sending request to #{rhost}. Attempt ##{(i+1).to_s}...")
       sock.put(buffer)
       handler
-      select(nil, nil, nil, 2)
+      Rex.sleep(2)
       disconnect
     end
   end

--- a/modules/exploits/windows/misc/citrix_streamprocess.rb
+++ b/modules/exploits/windows/misc/citrix_streamprocess.rb
@@ -82,7 +82,7 @@ class Metasploit3 < Msf::Exploit::Remote
     connect_udp
     udp_sock.put(sploit)
     print_status("Exploit sent, wait for egghunter.")
-    select(nil, nil, nil, 4) # takes about 8 seconds in tests
+    Rex.sleep(4) # takes about 8 seconds in tests
 
     handler(udp_sock)
     disconnect_udp

--- a/modules/exploits/windows/misc/fb_isc_attach_database.rb
+++ b/modules/exploits/windows/misc/fb_isc_attach_database.rb
@@ -166,7 +166,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       sock.put(buf)
 
-      select(nil,nil,nil,4)
+      Rex.sleep(4)
 
       handler
 

--- a/modules/exploits/windows/misc/fb_isc_create_database.rb
+++ b/modules/exploits/windows/misc/fb_isc_create_database.rb
@@ -166,7 +166,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       sock.put(buf)
 
-      select(nil,nil,nil,4)
+      Rex.sleep(4)
 
       handler
 

--- a/modules/exploits/windows/misc/fb_svc_attach.rb
+++ b/modules/exploits/windows/misc/fb_svc_attach.rb
@@ -130,7 +130,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       sock.put(buf)
 
-      #select(nil,nil,nil,4)
+      #Rex.sleep(4)
 
       handler
 

--- a/modules/exploits/windows/misc/hp_omniinet_3.rb
+++ b/modules/exploits/windows/misc/hp_omniinet_3.rb
@@ -120,7 +120,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Trying #{target.name}...")
     sock.put(packet)
 
-    select(nil,nil,nil,10)
+    Rex.sleep(10)
     handler
     disconnect
 

--- a/modules/exploits/windows/misc/hp_omniinet_4.rb
+++ b/modules/exploits/windows/misc/hp_omniinet_4.rb
@@ -152,7 +152,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     #Data Protector lags before triggering the vuln code
     #Long delay seems necessary to ensure we get a shell back
-    select(nil,nil,nil,20)
+    Rex.sleep(20)
 
     handler
     disconnect

--- a/modules/exploits/windows/misc/hp_ovtrace.rb
+++ b/modules/exploits/windows/misc/hp_ovtrace.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Trying target #{target.name}...")
     sock.put(sploit)
 
-    select(nil,nil,nil,3) # =(
+    Rex.sleep(3) # =(
 
     handler
     disconnect

--- a/modules/exploits/windows/misc/ib_isc_attach_database.rb
+++ b/modules/exploits/windows/misc/ib_isc_attach_database.rb
@@ -169,7 +169,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       sock.put(buf)
 
-      select(nil,nil,nil,4)
+      Rex.sleep(4)
 
       handler
 

--- a/modules/exploits/windows/misc/ib_isc_create_database.rb
+++ b/modules/exploits/windows/misc/ib_isc_create_database.rb
@@ -169,7 +169,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       sock.put(buf)
 
-      select(nil,nil,nil,4)
+      Rex.sleep(4)
 
       handler
 

--- a/modules/exploits/windows/misc/ib_svc_attach.rb
+++ b/modules/exploits/windows/misc/ib_svc_attach.rb
@@ -175,7 +175,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       sock.put(buf)
 
-      select(nil,nil,nil,4)
+      Rex.sleep(4)
 
       handler
 

--- a/modules/exploits/windows/misc/ibm_tsm_cad_ping.rb
+++ b/modules/exploits/windows/misc/ibm_tsm_cad_ping.rb
@@ -87,7 +87,7 @@ class Metasploit3 < Msf::Exploit::Remote
       rescue
         print_status("Hrm, the service is probably in the wrong state, stand by...")
         disconnect
-        select(nil, nil, nil, 5)
+        Rex.sleep(5)
         next
       end
       got_it = true

--- a/modules/exploits/windows/misc/mirc_privmsg_server.rb
+++ b/modules/exploits/windows/misc/mirc_privmsg_server.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def on_client_data(client)
     client.get_once
-    select(nil,nil,nil,2)
+    Rex.sleep(2)
     sploit = ":" + Rex::Text.rand_text_alphanumeric(307) + [target['Rets'][0]].pack('V') + [target['Rets'][1]].pack('V')
     sploit << make_nops(4) + [target['Rets'][2]].pack('V') + make_nops(4) + "B" * 12
     sploit << Rex::Arch::X86.jmp_short(3) +Rex::Text.rand_text_alphanumeric(2)

--- a/modules/exploits/windows/misc/poisonivy_bof.rb
+++ b/modules/exploits/windows/misc/poisonivy_bof.rb
@@ -170,7 +170,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # The disconnection triggers the exploit
     print_status("Sending exploit...")
     sock.put(xploit)
-    select(nil,nil,nil,5)
+    Rex.sleep(5)
     disconnect
   end
 

--- a/modules/exploits/windows/misc/pxexploit.rb
+++ b/modules/exploits/windows/misc/pxexploit.rb
@@ -115,7 +115,7 @@ class Metasploit3 < Msf::Exploit::Remote
       while (true) do
         begin
           # get stats every 20s
-          select(nil, nil, nil, 20)
+          Rex.sleep(20)
           client.lanattacks.dhcp_log.each do |item|
             print_status("Served PXE attack to #{item[0].unpack('H2H2H2H2H2H2').join(':')} "+
                 "(#{Rex::Socket.addr_ntoa(item[1])})")

--- a/modules/exploits/windows/misc/sap_2005_license.rb
+++ b/modules/exploits/windows/misc/sap_2005_license.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("Trying target #{target.name}...")
     sock.put(sploit)
-    select(nil,nil,nil,1)
+    Rex.sleep(1)
 
     handler
     disconnect

--- a/modules/exploits/windows/misc/wireshark_packet_dect.rb
+++ b/modules/exploits/windows/misc/wireshark_packet_dect.rb
@@ -164,7 +164,7 @@ class Metasploit3 < Msf::Exploit::Remote
       while true
         break if session_created? and datastore['ExitOnSession']
         inject(pkt)
-        select(nil,nil,nil,datastore['DELAY'])
+        Rex.sleep(datastore['DELAY'])
       end
     else
       inject(pkt)

--- a/modules/exploits/windows/motorola/timbuktu_fileupload.rb
+++ b/modules/exploits/windows/motorola/timbuktu_fileupload.rb
@@ -81,29 +81,29 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Connecting to #{rhost} on port #{rport}...")
 
     sock.put(pkt1)
-    select(nil,nil,nil,0.15)
+    Rex.sleep(0.15)
 
     sock.put("\xFF")
-    select(nil,nil,nil,0.15)
+    Rex.sleep(0.15)
 
     sock.put(pkt3)
-    select(nil,nil,nil,0.15)
+    Rex.sleep(0.15)
 
     sock.put("\xF9\x00")
-    select(nil,nil,nil,0.15)
+    Rex.sleep(0.15)
 
     print_status("Sending EXE payload '#{exe}' to #{rhost}:#{rport}...")
     sock.put("\xF8" + [data.length].pack('n') + data)
-    select(nil,nil,nil,5)
+    Rex.sleep(5)
 
     sock.put("\xF7")
-    select(nil,nil,nil,0.15)
+    Rex.sleep(0.15)
 
     sock.put("\xFA")
-    select(nil,nil,nil,0.15)
+    Rex.sleep(0.15)
 
     sock.put("\xFE")
-    select(nil,nil,nil,0.08)
+    Rex.sleep(0.08)
 
     print_status("Done!")
     disconnect

--- a/modules/exploits/windows/mssql/mssql_payload_sqli.rb
+++ b/modules/exploits/windows/mssql/mssql_payload_sqli.rb
@@ -119,7 +119,7 @@ class Metasploit3 < Msf::Exploit::Remote
       end
     end
     print_status("Almost there, the stager takes a while to execute. Waiting 50 seconds...")
-    select(nil,nil,nil,50)
+    Rex.sleep(50)
     handler
     disconnect
   end

--- a/modules/exploits/windows/novell/groupwisemessenger_client.rb
+++ b/modules/exploits/windows/novell/groupwisemessenger_client.rb
@@ -109,7 +109,7 @@ class Metasploit3 < Msf::Exploit::Remote
     client.put(res)
     handler(client)
 
-    select(nil,nil,nil,2)
+    Rex.sleep(2)
     service.close_client(client)
   end
 

--- a/modules/exploits/windows/novell/netiq_pum_eval.rb
+++ b/modules/exploits/windows/novell/netiq_pum_eval.rb
@@ -278,7 +278,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     waited = 0
     while (not @exe_sent)
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
       waited += 1
       if (waited > datastore['HTTP_DELAY'])
         fail_with(Failure::Unknown, "Target didn't request request the EXE payload -- Maybe it cant connect back to us?")
@@ -286,7 +286,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     print_status("Giving time to the payload to execute...")
-    select(nil, nil, nil, 20)
+    Rex.sleep(20)
 
     print_status("Shutting down the web service...")
     stop_service

--- a/modules/exploits/windows/novell/zenworks_desktop_agent.rb
+++ b/modules/exploits/windows/novell/zenworks_desktop_agent.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
     sock.put("\x00\x24" + ("A" * 0x20) + [ target.ret ].pack('V'))
 
     print_status("Overflow request sent, sleeping for four seconds")
-    select(nil,nil,nil,4)
+    Rex.sleep(4)
 
     handler
     disconnect

--- a/modules/exploits/windows/scada/codesys_gateway_server_traversal.rb
+++ b/modules/exploits/windows/scada/codesys_gateway_server_traversal.rb
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
     #Taken from the spooler exploit writen byt jduck and HDMoore
     cnt = 1
     while session_created? == false and cnt < 25
-      ::IO.Rex.sleep(0.25)
+      Rex.sleep(0.25)
       cnt += 1
     end
   end

--- a/modules/exploits/windows/scada/codesys_gateway_server_traversal.rb
+++ b/modules/exploits/windows/scada/codesys_gateway_server_traversal.rb
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
     #Taken from the spooler exploit writen byt jduck and HDMoore
     cnt = 1
     while session_created? == false and cnt < 25
-      ::IO.select(nil, nil, nil, 0.25)
+      ::IO.Rex.sleep(0.25)
       cnt += 1
     end
   end

--- a/modules/exploits/windows/scada/factorylink_csservice.rb
+++ b/modules/exploits/windows/scada/factorylink_csservice.rb
@@ -132,7 +132,7 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     sock.put(pkt)
     handler
-    select(nil, nil, nil, 6)
+    Rex.sleep(6)
     disconnect
   end
 end

--- a/modules/exploits/windows/scada/factorylink_vrn_09.rb
+++ b/modules/exploits/windows/scada/factorylink_vrn_09.rb
@@ -83,7 +83,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     handler
 
-    select(nil,nil,nil,1)
+    Rex.sleep(1)
     disconnect
 
   end

--- a/modules/exploits/windows/scada/igss9_igssdataserver_rename.rb
+++ b/modules/exploits/windows/scada/igss9_igssdataserver_rename.rb
@@ -305,7 +305,7 @@ class Metasploit3 < Msf::Exploit::Remote
     handler
 
     #egghunter takes a few seconds, wait a bit before disconnect
-    select(nil, nil, nil, 3)
+    Rex.sleep(3)
     disconnect
   end
 

--- a/modules/exploits/windows/scada/igss9_misc.rb
+++ b/modules/exploits/windows/scada/igss9_misc.rb
@@ -165,7 +165,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     #We must delay disconnect() for a bit, otherwise dc.exe won't call
     #kernel32!CreateProcessA
-    select(nil, nil, nil, 1)
+    Rex.sleep(1)
     disconnect
   end
 end

--- a/modules/exploits/windows/scada/realwin_on_fc_binfile_a.rb
+++ b/modules/exploits/windows/scada/realwin_on_fc_binfile_a.rb
@@ -78,7 +78,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("Trying target #{target.name}...")
     sock.put(data)
-    select(nil,nil,nil,0.5)
+    Rex.sleep(0.5)
 
     handler
     disconnect

--- a/modules/exploits/windows/scada/realwin_on_fcs_login.rb
+++ b/modules/exploits/windows/scada/realwin_on_fcs_login.rb
@@ -80,7 +80,7 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     print_status("Trying target #{target.name}...")
     sock.put(data)
-    select(nil,nil,nil,0.5)
+    Rex.sleep(0.5)
     handler
     disconnect
   end

--- a/modules/exploits/windows/scada/winlog_runtime_2.rb
+++ b/modules/exploits/windows/scada/winlog_runtime_2.rb
@@ -81,7 +81,7 @@ class Metasploit3 < Msf::Exploit::Remote
     shellcode << egg
     sock.put(shellcode)
 
-    select(nil,nil,nil,1)
+    Rex.sleep(1)
 
     buffer = rand_text_alpha(20)
     buffer << "\x14" * 10 	#trigger the crash

--- a/modules/exploits/windows/smb/ms09_050_smb2_negotiate_func_index.rb
+++ b/modules/exploits/windows/smb/ms09_050_smb2_negotiate_func_index.rb
@@ -136,7 +136,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     while( stime + wtime > Time.now.to_i )
-      select(nil, nil, nil, 0.25)
+      Rex.sleep(0.25)
       break if session_created?
     end
 

--- a/modules/exploits/windows/smb/ms10_061_spoolss.rb
+++ b/modules/exploits/windows/smb/ms10_061_spoolss.rb
@@ -168,7 +168,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     cnt = 1
     while session_created? == false and cnt < 25
-      ::IO.select(nil, nil, nil, 0.25)
+      ::IO.Rex.sleep(0.25)
       cnt += 1
     end
 

--- a/modules/exploits/windows/smb/ms10_061_spoolss.rb
+++ b/modules/exploits/windows/smb/ms10_061_spoolss.rb
@@ -168,7 +168,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     cnt = 1
     while session_created? == false and cnt < 25
-      ::IO.Rex.sleep(0.25)
+      Rex.sleep(0.25)
       cnt += 1
     end
 

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -342,7 +342,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       begin
       print_status("Deleting \\#{filename}...")
-      select(nil, nil, nil, 1.0)
+      Rex.sleep(1.0)
       #This is not really useful but will prevent double \\ on the wire :)
       if datastore['SHARE'] =~ /.[\\\/]/
         simple.connect("\\\\#{datastore['RHOST']}\\#{smbshare}")

--- a/modules/exploits/windows/smtp/mercury_cram_md5.rb
+++ b/modules/exploits/windows/smtp/mercury_cram_md5.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
     sock.put("AUTH CRAM-MD5\r\n")
 
     sock.get_once
-    select(nil,nil,nil,0.25)
+    Rex.sleep(0.25)
 
     buffer =  rand_text_alpha_upper(204) + [target.ret].pack('V')
     buffer << payload.encoded + rand_text_alpha_upper(1075 - payload.encoded.length)

--- a/modules/exploits/windows/smtp/ms03_046_exchange2000_xexch50.rb
+++ b/modules/exploits/windows/smtp/ms03_046_exchange2000_xexch50.rb
@@ -104,7 +104,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Exploit attempt ##{count}")
 
     connect
-    select(nil,nil,nil,1)
+    Rex.sleep(1)
     banner = sock.get_once || ''
     print_status("Connected to SMTP server: #{banner.to_s}")
 
@@ -113,9 +113,9 @@ class Metasploit3 < Msf::Exploit::Remote
       return
     end
 
-    select(nil,nil,nil,5)
+    Rex.sleep(5)
     sock.put("EHLO X\r\n")
-    select(nil,nil,nil,7)
+    Rex.sleep(7)
     res = sock.get_once || ''
 
     if (res !~ /XEXCH50/)
@@ -124,10 +124,10 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     sock.put("MAIL FROM: #{datastore['MAILFROM']}\r\n")
-    select(nil,nil,nil,3)
+    Rex.sleep(3)
 
     sock.put("RCPT TO: #{datastore['MAILTO']}\r\n")
-    select(nil,nil,nil,3)
+    Rex.sleep(3)
 
   end
 
@@ -152,7 +152,7 @@ class Metasploit3 < Msf::Exploit::Remote
         end
 
         sock.put("XEXCH50 2 2\r\n")
-        select(nil,nil,nil,3)
+        Rex.sleep(3)
         res = sock.get(-1,3)
         print_status("#{res}")
         if (res !~ /Send binary data/)
@@ -167,7 +167,7 @@ class Metasploit3 < Msf::Exploit::Remote
         size = 1024 * 1024 * 32
 
         sock.put("XEXCH50 #{size} 2\r\n")
-        select(nil,nil,nil,3)
+        Rex.sleep(3)
 
         sploit = (([target['Ret']].pack('V')) * 256 * 1024 + payload.encoded + ("X" * 1024)) * 4 + "BEEF"
 
@@ -181,7 +181,7 @@ class Metasploit3 < Msf::Exploit::Remote
         smtp_setup(count) # Connection 2
 
         sock.put("XEXCH50 -1 2\r\n") # Allocate negative value
-        select(nil,nil,nil,2)
+        Rex.sleep(2)
         res = sock.get_once || ''
 
         if (!res)

--- a/modules/exploits/windows/telnet/gamsoft_telsrv_username.rb
+++ b/modules/exploits/windows/telnet/gamsoft_telsrv_username.rb
@@ -85,7 +85,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     connect
     print_status("Attempting to determine if target is vulnerable...")
-    select(nil,nil,nil,7)
+    Rex.sleep(7)
     banner = sock.get_once(-1,3) || ''
 
     if (banner =~ /TelSrv 1\.5/)
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Trying target #{target.name} on host #{datastore['RHOST']}:#{datastore['RPORT']}...")
     connect
     print_status("Connected to telnet service... waiting several seconds.") # User friendly message due to sleep.
-    select(nil,nil,nil,7) # If unregistered version, you must wait for >5 seconds. Seven is safe. Six is not.
+    Rex.sleep(7) # If unregistered version, you must wait for >5 seconds. Seven is safe. Six is not.
 
     username = rand_text_english(20000, payload_badchars)
     seh = generate_seh_payload(target.ret)
@@ -106,7 +106,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("Sending #{ username.length} byte username as exploit (including #{seh.length} byte payload)...")
     sock.put(username)
-    select(nil,nil,nil,0.25)
+    Rex.sleep(0.25)
     print_status('Exploit sent...')
     handler
     disconnect

--- a/modules/exploits/windows/tftp/distinct_tftp_traversal.rb
+++ b/modules/exploits/windows/tftp/distinct_tftp_traversal.rb
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     ret = tftp_client.send_write_request { |msg| print_status(msg) }
     while not tftp_client.complete
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
       tftp_client.stop
     end
   end
@@ -97,7 +97,7 @@ class Metasploit3 < Msf::Exploit::Remote
     upload("#{levels}WINDOWS\\system32\\#{exe_name}", exe)
 
     # Let the TFTP server idle a bit before sending another file
-    select(nil, nil, nil, 1)
+    Rex.sleep(1)
 
     # Upload the mof file
     print_status("#{peer} - Uploading .mof...")

--- a/modules/exploits/windows/tftp/netdecision_tftp_traversal.rb
+++ b/modules/exploits/windows/tftp/netdecision_tftp_traversal.rb
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     ret = tftp_client.send_write_request { |msg| print_status(msg) }
     while not tftp_client.complete
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
       tftp_client.stop
     end
   end
@@ -97,7 +97,7 @@ class Metasploit3 < Msf::Exploit::Remote
     upload("#{levels}WINDOWS\\system32\\#{exe_name}", exe)
 
     # Let the TFTP server idle a bit before sending another file
-    select(nil, nil, nil, 1)
+    Rex.sleep(1)
 
     # Upload the mof file
     print_status("#{peer} - Uploading .mof...")

--- a/modules/exploits/windows/vpn/safenet_ike_11.rb
+++ b/modules/exploits/windows/vpn/safenet_ike_11.rb
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Trying target #{target.name}...")
     udp_sock.put(sploit)
 
-    select(nil,nil,nil,5)
+    Rex.sleep(5)
     handler
     disconnect_udp
 

--- a/modules/post/multi/manage/record_mic.rb
+++ b/modules/post/multi/manage/record_mic.rb
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Post
         p = ((Float((i == 0) ? 1 : i+1) / duration) * 100).round
         print_status("#{rhost} - #{p.to_s}%...")
       end
-      select(nil, nil, nil, 1)
+      Rex.sleep(1)
     end
   end
 

--- a/modules/post/windows/capture/lockout_keylogger.rb
+++ b/modules/post/windows/capture/lockout_keylogger.rb
@@ -111,7 +111,7 @@ class Metasploit3 < Msf::Post
             outp << " <0x%.2x> " % vk
           end
         end
-        select(nil,nil,nil,2)
+        Rex.sleep(2)
         file_local_write(logfile,"#{outp}\n")
         if outp != nil and outp.chomp.lstrip != "" then
           print_status("Password?: #{outp}")
@@ -132,7 +132,7 @@ class Metasploit3 < Msf::Post
         else
           print_status("System has currently been idle for #{currentidle} seconds and the screensaver is ON")
         end
-        select(nil,nil,nil,keytime.to_i)
+        Rex.sleep(keytime.to_i)
       end
     rescue::Exception => e
       if e.message != 'win'
@@ -213,7 +213,7 @@ class Metasploit3 < Msf::Post
           print_status("Session has been locked out")
         else
           # sleep(keytime.to_i) / hardsleep applied due to missing loging right after lockout.. no good way to solve this
-          select(nil,nil,nil, 2)
+          Rex.sleep( 2)
         end
       end
     else
@@ -221,7 +221,7 @@ class Metasploit3 < Msf::Post
       print_status("System has currently been idle for #{currentidle} seconds")
       while currentidle <= datastore['LOCKTIME'] do
         print_status("Current Idle time: #{currentidle} seconds")
-        select(nil,nil,nil,datastore['HEARTBEAT'])
+        Rex.sleep(datastore['HEARTBEAT'])
         currentidle = session.ui.idle_time
       end
       client.railgun.user32.LockWorkStation()

--- a/modules/post/windows/gather/screen_spy.rb
+++ b/modules/post/windows/gather/screen_spy.rb
@@ -86,7 +86,7 @@ class Metasploit3 < Msf::Post
       leading_zeros = Math::log10(count).round
       file_locations = []
       count.times do |num|
-        select(nil, nil, nil, datastore['DELAY'])
+        Rex.sleep(datastore['DELAY'])
         begin
           data = session.espia.espia_image_get_dev_screen
         rescue RequestError => e
@@ -119,7 +119,7 @@ class Metasploit3 < Msf::Post
     end
     if cmd
       # wait 2 secs so the last file can get opened before deletion
-      select(nil, nil, nil, 2)
+      Rex.sleep(2)
       begin
         ::File.delete(screenshot)
       rescue Exception => e

--- a/modules/post/windows/manage/multi_meterpreter_inject.rb
+++ b/modules/post/windows/manage/multi_meterpreter_inject.rb
@@ -65,13 +65,13 @@ class Metasploit3 < Msf::Post
       if a[1]
         payload = create_payload(datastore['PAYLOAD'],a[0],datastore['LPORT'])
         inject(a[1],payload)
-        select(nil, nil, nil, 5)
+        Rex.sleep(5)
       else
         # if no PID we create a process to host the Meterpreter session
         payload = create_payload(datastore['PAYLOAD'],a[0],datastore['LPORT'])
         pid_num = start_proc(datastore['PROCESSNAME'])
         inject(pid_num,payload)
-        select(nil, nil, nil, 5)
+        Rex.sleep(5)
       end
     end
   end

--- a/modules/post/windows/manage/pxexploit.rb
+++ b/modules/post/windows/manage/pxexploit.rb
@@ -78,7 +78,7 @@ class Metasploit3 < Msf::Post
     while (true) do
       begin
         # get stats every 20s
-        select(nil, nil, nil, 20)
+        Rex.sleep(20)
         client.lanattacks.dhcp_log.each do |item|
           print_status("Served PXE attack to #{item[0].unpack('H2H2H2H2H2H2').join(':')} "+
               "(#{Rex::Socket.addr_ntoa(item[1])})")

--- a/plugins/nexpose.rb
+++ b/plugins/nexpose.rb
@@ -310,7 +310,7 @@ class Plugin::Nexpose < Msf::Plugin
       url = nil
       while(! url)
         url = @nsc.report_last(report.config_id)
-        select(nil, nil, nil, 1.0)
+        Rex.sleep(1.0)
       end
 
       print_status("Downloading the export data...")
@@ -536,7 +536,7 @@ class Plugin::Nexpose < Msf::Plugin
             print_status(" >> #{stat}") if opt_verbose
           end
           prev = stat
-          select(nil, nil, nil, 5.0)
+          Rex.sleep(5.0)
         end
         print_status(" >> Scan has been completed with ID ##{sid}") if opt_verbose
         rescue ::Interrupt
@@ -552,7 +552,7 @@ class Plugin::Nexpose < Msf::Plugin
           url = nil
           while(! url)
             url = @nsc.report_last(report.config_id)
-            select(nil, nil, nil, 1.0)
+            Rex.sleep(1.0)
           end
 
           print_status(" >> Downloading the report data from Nexpose...") if opt_verbose

--- a/plugins/sounds.rb
+++ b/plugins/sounds.rb
@@ -56,7 +56,7 @@ class Plugin::EventSounds < Msf::Plugin
             print_status("Warning: sound file not found: #{path}")
           end
         end
-        select(nil, nil, nil, 0.25)
+        Rex.sleep(0.25)
       end
       rescue ::Exception => e
         print_status("Sound plugin: fatal error #{e} #{e.backtrace}")

--- a/plugins/thread.rb
+++ b/plugins/thread.rb
@@ -50,7 +50,7 @@ class Plugin::ThreadTest < Msf::Plugin
       @mythread = ::Thread.new {
         while(true)
           print_line("--- test thread ---")
-          select(nil, nil, nil, 5)
+          Rex.sleep(5)
         end
       }
       print_line("Test thread created")

--- a/scripts/meterpreter/multi_meter_inject.rb
+++ b/scripts/meterpreter/multi_meter_inject.rb
@@ -128,14 +128,14 @@ if multi_ip
       multi_ip.each do |i|
         payload = create_payload(payload_type,i,lport)
         inject(multi_pid[pid_index],payload)
-        select(nil, nil, nil, 5)
+        Rex.sleep(5)
         pid_index = pid_index + 1
       end
     else
       multi_ip.each do |i|
         payload = create_payload(payload_type,i,lport)
         inject(start_proc,payload)
-        select(nil, nil, nil, 2)
+        Rex.sleep(2)
       end
     end
   end

--- a/scripts/meterpreter/scraper.rb
+++ b/scripts/meterpreter/scraper.rb
@@ -30,7 +30,7 @@ require 'fileutils'
 def m_unlink(client, path)
   r = client.sys.process.execute("cmd.exe /c del /F /S /Q " + path, nil, {'Hidden' => 'true'})
   while(r.name)
-    select(nil, nil, nil, 0.10)
+    Rex.sleep(0.10)
   end
   r.close
 end

--- a/scripts/meterpreter/uploadexec.rb
+++ b/scripts/meterpreter/uploadexec.rb
@@ -76,7 +76,7 @@ end
 def m_unlink(session, path)
   r = session.sys.process.execute("cmd.exe /c del /F /S /Q " + path, nil, {'Hidden' => 'true'})
   while(r.name)
-    select(nil, nil, nil, 0.10)
+    Rex.sleep(0.10)
   end
   r.close
 end

--- a/scripts/meterpreter/webcam.rb
+++ b/scripts/meterpreter/webcam.rb
@@ -106,7 +106,7 @@ begin
             fd.write( data )
           end
         end
-        select(nil, nil, nil, interval/1000.0)
+        Rex.sleep(interval/1000.0)
       end
     end
   rescue ::Interrupt

--- a/scripts/meterpreter/winenum.rb
+++ b/scripts/meterpreter/winenum.rb
@@ -322,7 +322,7 @@ def gethash()
   begin
     hash = ''
     @client.core.use("priv")
-    select(nil, nil, nil, 3)
+    Rex.sleep(3)
     hashes = @client.priv.sam_hashes
     hashes.each do |h|
       hash << h.to_s+"\n"

--- a/scripts/resource/auto_brute.rc
+++ b/scripts/resource/auto_brute.rc
@@ -48,7 +48,7 @@ end
 
 def jobwaiting(maxjobs,verbose)	#thread handling for poor guys
 	while(framework.jobs.keys.length >= maxjobs)
-		::IO.select(nil, nil, nil, 2.5)
+		Rex.sleep(2.5)
 		if(verbose == 1)
 			jobs_len    = framework.jobs.keys.length
 			threads_len = framework.threads.length

--- a/scripts/resource/auto_cred_checker.rc
+++ b/scripts/resource/auto_cred_checker.rc
@@ -25,7 +25,7 @@ end
 def jobwaiting(verbose)
 		maxjobs=15  #throtteling if we get too much jobs
 		while(framework.jobs.keys.length >= maxjobs)
-			::IO.select(nil, nil, nil, 2.5)
+			Rex.sleep(2.5)
 			if (verbose == 1)
 				print_error("waiting for finishing some modules... active jobs: #{framework.jobs.keys.length} / threads: #{framework.threads.length}")
 			end

--- a/scripts/resource/autocrawler.rc
+++ b/scripts/resource/autocrawler.rc
@@ -26,7 +26,7 @@ end
 def jobwaiting()	#thread handling for poor guys ...
         maxjobs=15      #throttling if we get too much jobs
         while(framework.jobs.keys.length >= maxjobs)
-                ::IO.select(nil, nil, nil, 2.5)
+                Rex.sleep(2.5)
                 print_error("waiting for finishing some modules... active jobs: #{framework.jobs.keys.length} / threads: #{framework.threads.length}")
         end
 end

--- a/scripts/resource/autoexploit.rc
+++ b/scripts/resource/autoexploit.rc
@@ -140,7 +140,7 @@ def auto_exploit(module_path)
 		run_single("set payload #{get_payload}")
 		run_single("set lhost #{lhost}")
 		run_single("exploit -z")
-		select(nil, nil, nil, 1)
+		Rex.sleep(1)
 		run_single("back")
 	end
 end
@@ -178,7 +178,7 @@ def check_exploit(module_path)
 		run_single("use #{exploit.fullname}")
 		run_single("set RHOST #{vuln.host.address.to_s}")
 		run_single("check")
-		select(nil, nil, nil, 1)
+		Rex.sleep(1)
 		run_single("back")
 		print_line()
 	end

--- a/scripts/resource/basic_discovery.rc
+++ b/scripts/resource/basic_discovery.rc
@@ -55,7 +55,7 @@ end
 
 def jobwaiting(maxjobs,verbose)	#thread handling for poor guys
 	while(framework.jobs.keys.length >= maxjobs)
-		::IO.select(nil, nil, nil, 2.5)
+		Rex.sleep(2.5)
 		if(verbose == 1)
 			print_error("waiting for finishing some modules... active jobs: #{framework.jobs.keys.length} / threads: #{framework.threads.length}")
 		end

--- a/scripts/shell/spawn_meterpreter.rb
+++ b/scripts/shell/spawn_meterpreter.rb
@@ -67,7 +67,7 @@ begin
     # It takes a little time for the resources to get set up, so sleep for
     # a bit to make sure the exploit is fully working.  Without this,
     # mod.get_resource doesn't exist when we need it.
-    select(nil, nil, nil, 0.5)
+    Rex.sleep(0.5)
     if framework.jobs[mh.job_id.to_s].nil?
       raise RuntimeError, "Failed to start multi/handler - is it already running?"
     end
@@ -148,7 +148,7 @@ if (use_handler)
   Thread.new do
     if not aborted
       # Wait up to 10 seconds for the session to come in..
-      select(nil, nil, nil, 10)
+      Rex.sleep(10)
     end
     framework.jobs.stop_job(mh.job_id)
   end

--- a/test/modules/exploits/test/kernel.rb
+++ b/test/modules/exploits/test/kernel.rb
@@ -80,7 +80,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     udp_sock.put(buf)
 
-    select(nil,nil,nil,2)
+    Rex.sleep(2)
 
     disconnect_udp
   end

--- a/test/modules/post/test/services.rb
+++ b/test/modules/post/test/services.rb
@@ -163,7 +163,7 @@ class Metasploit3 < Msf::Post
     print_status("Current status of this service " +
           "#{service_query_ex(datastore['SSERVICE']).pretty_inspect}") if blab
     print_status("Sleeping to give the service a chance to start")
-    select(nil, nil, nil, 2) # give the service time to start, reduces false negatives
+    Rex.sleep(2) # give the service time to start, reduces false negatives
 
     print_status()
     print_status("TESTING service_stop on servicename: #{datastore['SSERVICE']}")

--- a/tools/psexec.rb
+++ b/tools/psexec.rb
@@ -293,7 +293,7 @@ end
 
 begin
   print_status("Deleting \\#{fname}...")
-  select(nil, nil, nil, 1.0)
+  Rex.sleep(1.0)
   simple.connect(smbshare)
   simple.delete("\\#{fname}")
 rescue ::Interrupt


### PR DESCRIPTION
`Rex.sleep` is so much neater than `select(nil,nil,nil`. By replacing this we can also easily change the sleeping mechanism in future in just one place...

```
grep -rl "select(nil,nil,nil," . | xargs sed -i 's/select(nil,nil,nil,/Rex.sleep(/g'
grep -rl "select(nil, nil, nil," . | xargs sed -i 's/select(nil, nil, nil, /Rex.sleep(/g'
grep -rl "::IO.Rex.sleep" . | xargs sed -i 's/::IO.Rex.sleep(/Rex.sleep(/g' 
grep -rl "Kernel.Rex.sleep" . | xargs sed -i 's/Kernel.Rex.sleep(/Rex.sleep(/g'
```
