### PR TITLE
[FixRM 8482] Fix uninit constant Rex::Exploitation::JavascriptOSDetect

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -3,6 +3,7 @@ require 'rex/service_manager'
 require 'rex/exploitation/obfuscatejs'
 require 'rex/exploitation/encryptjs'
 require 'rex/exploitation/heaplib'
+require 'rex/exploitation/javascriptosdetect'
 
 module Msf
 


### PR DESCRIPTION
This fixes an uninit constant Rex::Exploitation::JavascriptOSDetect while using a module with js_os_detect. It was originally reported by Metasploit user @viniciuskmax

[FixRM 8482]
