### PR TITLE
[FixRM 8489] undefined method `empty?' for nil:NilClass in msfcli

### DIFF
--- a/msfcli
+++ b/msfcli
@@ -206,6 +206,7 @@ class Msfcli
 
     @args[:params].each { |args|
       var, val = args.split('=', 2)
+      next if val.nil?
 
       case var.downcase
       when 'payload'


### PR DESCRIPTION
This fixes a undefined method `empty?' for nil:NilClass (NoMethodError) in msfcli. [SeeRM 8489]

To reproduce the bug, here's how:

```
$ msfcli multi/handler payload windows/meterpreter/reverse_tcp lhost=10.0.1.11 lport=4444 E
[*] Initializing modules...
/rapid7/msf/msfcli:213:in `block in generate_whitelist': undefined method `empty?' for nil:NilClass (NoMethodError)
    from /rapid7/msf/msfcli:207:in `each'
    from /rapid7/msf/msfcli:207:in `generate_whitelist'
    from /rapid7/msf/msfcli:295:in `init_modules'
    from /rapid7/msf/msfcli:535:in `run!'
    from /rapid7/msf/msfcli:557:in `<main>'
```

The patch should fix the error, and return this message instead:

```
$ msfcli multi/handler payload windows/meterpreter/reverse_tcp lhost=10.0.1.11 lport=4444 E
[*] Initializing modules...
[!] Error: The argument could not be parsed correctly.
```

There's also a rspec for it, here's how:

```
$ rspec spec/msfcli_spec.rb 

Msfcli
  Class methods
    .initialize
      should give me the correct module name in key :module_name after object initialization
      should give me the correct mode in key :mode after object initialization
      should give me the correct module parameters after object initialization
      should give me an exploit name without the prefix 'exploit'
      should give me an exploit name without the prefix 'exploits'
      should set mode 's' (summary)
      should set mode 'h' (help) as default
    .usage
      should see a help menu
    .dump_module_list
      it should dump a list of modules
    .guess_payload_name
      should contain matches nedded for windows/meterpreter/reverse_tcp
      should contain matches needed for windows/shell/reverse_tcp
      should contain matches needed for windows/shell_reverse_tcp
      should contain matches needed for php/meterpreter_reverse_tcp
      should contain matches needed for linux/x86/meterpreter/reverse_tcp
      should contain matches needed for java/meterpreter/reverse_tcp
      should contain matches needed for cmd/unix/reverse
      should contain matches needed for bsd/x86/shell_reverse_tcp
    .guess_encoder_name
      should contain a match for x86/shikata_ga_nai
    .guess_nop_name
      should contain a match for guess_nop_name
    .generate_whitelist
      should generate a whitelist for linux/x86/shell/reverse_tcp with encoder x86/fnstenv_mov
      should generate a whitelist for windows/meterpreter/reverse_tcp with default options
      should generate a whitelist for windows/meterpreter/reverse_tcp with options: encoder='' post='' nop=''
      should generate a whitelist for windows/meterpreter/reverse_tcp with options: encoder= post= nop=
    .init_modules
      should have multi/handler module initialized
      should have my payload windows/meterpreter/reverse_tcp initialized
      should have my modules initialized with the correct parameters
      should give me an empty hash as a result of an invalid module name
    .engage_mode
      should show me the summary of module auxiliary/scanner/http/http_version
      should show me the options of module auxiliary/scanner/http/http_version
      should me the advanced options of module auxiliary/scanner/http/http_version
      should show me the IDS options of module auxiliary/scanner/http/http_version
      should show me the targets available for module windows/browser/ie_cbutton_uaf
      should show me the payloads available for module windows/browser/ie_cbutton_uaf
      should try to run the check function of an exploit
      should warn my auxiliary module isn't supported by mode 'p' (show payloads)
      should warn my auxiliary module isn't supported by mode 't' (show targets)
      should warn my exploit module isn't supported by mode 'ac' (show actions)
      should show actions available for module auxiliary/scanner/http/http_put

Finished in 1 minute 11.39 seconds
38 examples, 0 failures
```
