### PR TITLE
Add feature detection logic for FF 23 and 24 to jsosdetect

### DIFF
--- a/lib/rex/exploitation/javascriptosdetect.js
+++ b/lib/rex/exploitation/javascriptosdetect.js
@@ -209,7 +209,7 @@ window.os_detect.getVersion = function(){
 		// Thanks to developer.mozilla.org "Firefox for developers" series for most
 		// of these.
 		// Release changelogs: http://www.mozilla.org/en-US/firefox/releases/
-		if ('DeviceStorage' in window && 'default' in window.DeviceStorage) {
+		if ('DeviceStorage' in window && 'default' in window.DeviceStorage.prototype) {
 			// https://bugzilla.mozilla.org/show_bug.cgi?id=874213
 			ua_version = '24.0'
 		} else if (input_type_is_valid('range')) {

--- a/lib/rex/exploitation/javascriptosdetect.js
+++ b/lib/rex/exploitation/javascriptosdetect.js
@@ -52,6 +52,12 @@ window.os_detect.getVersion = function(){
 		return d.style[propCamelCase] === css;
 	}
 
+	var input_type_is_valid = function(input_type) {
+		var input = document.createElement('input');
+		input.setAttribute('type', input_type);
+		return input.type == input_type;
+	}
+
 	//--
 	// Client
 	//--
@@ -203,7 +209,12 @@ window.os_detect.getVersion = function(){
 		// Thanks to developer.mozilla.org "Firefox for developers" series for most
 		// of these.
 		// Release changelogs: http://www.mozilla.org/en-US/firefox/releases/
-		if ('HTMLTimeElement' in window) {
+		if ('DeviceStorage' in window && 'default' in window.DeviceStorage) {
+			// https://bugzilla.mozilla.org/show_bug.cgi?id=874213
+			ua_version = '24.0'
+		} else if (input_type_is_valid('range')) {
+			ua_version = '23.0'
+		} else if ('HTMLTimeElement' in window) {
 			ua_version = '22.0'
 		} else if ('createElement' in document &&
 		           document.createElement('main') &&

--- a/lib/rex/exploitation/javascriptosdetect.js
+++ b/lib/rex/exploitation/javascriptosdetect.js
@@ -209,7 +209,8 @@ window.os_detect.getVersion = function(){
 		// Thanks to developer.mozilla.org "Firefox for developers" series for most
 		// of these.
 		// Release changelogs: http://www.mozilla.org/en-US/firefox/releases/
-		if ('DeviceStorage' in window && 'default' in window.DeviceStorage.prototype) {
+		if ('DeviceStorage' in window && window.DeviceStorage &&
+				'default' in window.DeviceStorage.prototype) {
 			// https://bugzilla.mozilla.org/show_bug.cgi?id=874213
 			ua_version = '24.0'
 		} else if (input_type_is_valid('range')) {

--- a/lib/rex/exploitation/javascriptosdetect.js
+++ b/lib/rex/exploitation/javascriptosdetect.js
@@ -53,6 +53,7 @@ window.os_detect.getVersion = function(){
 	}
 
 	var input_type_is_valid = function(input_type) {
+		if (!document.createElement) return false;
 		var input = document.createElement('input');
 		input.setAttribute('type', input_type);
 		return input.type == input_type;


### PR DESCRIPTION
### Verification steps:
- [x] Dump the jsosdetect script to your hd somewhere:

```
msf> irb
[*] Starting IRB shell...
File.write('/Users/joe/Desktop/jsosdetect.js', ::Rex::Exploitation::JavascriptOSDetect.new)
```
- [x] Download Firefox 22, 23, and 24, one by one run them, open Web Console (cmd-opt-k) and paste the contents of `jsosdetect.js` then run `window.os_detect.getVersion().ua_version`
- [x] Verify that the correct version is output for 22, 23, and 24.
