### PR TITLE
[FixRM #8470] - can't convert nil into String

### DIFF
--- a/modules/exploits/windows/browser/ms13_069_caret.rb
+++ b/modules/exploits/windows/browser/ms13_069_caret.rb
@@ -44,7 +44,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Platform'       => 'win',
       'Targets'        =>
         [
-          [ 'Automatic', {} ],
           [
             # Win 7 target on hold until we have a stable custom spray for it
             'IE 8 on Windows XP SP3',
@@ -84,24 +83,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
   def get_target(agent)
-    return target if target.name != 'Automatic'
-
-    nt = agent.scan(/Windows NT (\d\.\d)/).flatten[0] || ''
-    ie = agent.scan(/MSIE (\d)/).flatten[0] || ''
-
-    ie_name = "IE #{ie}"
-
-    case nt
-    when '5.1'
-      os_name = 'Windows XP SP3'
-    end
-
-    targets.each do |t|
-      if (!ie.empty? and t.name.include?(ie_name)) and (!nt.empty? and t.name.include?(os_name))
-        return t
-      end
-    end
-
+    return targets[0] if agent =~ /MSIE 8\.0/ and agent =~ /Windows NT 5\.1/
     nil
   end
 


### PR DESCRIPTION
Target selection bug in ms13_069_caret.rb. Happens when the target is Win 7 + IE8, which actually isn't a suitable target.

[FixRM #8470]
http://dev.metasploit.com/redmine/issues/8470
