### PR TITLE
Release time fixes to modules

### DIFF
--- a/modules/auxiliary/scanner/sap/sap_hostctrl_getcomputersystem.rb
+++ b/modules/auxiliary/scanner/sap/sap_hostctrl_getcomputersystem.rb
@@ -20,7 +20,7 @@ class Metasploit4 < Msf::Auxiliary
       'Name' => 'SAP Host Agent Information Disclosure',
       'Description' => %q{
         This module attempts to retrieve Computer and OS info from Host Agent
-        through the SAP HostControl service
+        through the SAP HostControl service.
         },
       'References' =>
         [

--- a/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
@@ -70,14 +70,14 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    test_login!
+    test_login
 
     execute_cmdstager
   end
 
   # Sends an HTTP request with authorization header to the router
   # Raises an exception unless the login is successful
-  def test_login!
+  def test_login
     print_status("#{rhost}:#{rport} - Trying to login with #{user}:#{pass}")
 
     res = send_auth_request_cgi({

--- a/modules/exploits/windows/browser/ms13_080_cdisplaypointer.rb
+++ b/modules/exploits/windows/browser/ms13_080_cdisplaypointer.rb
@@ -33,11 +33,11 @@ class Metasploit3 < Msf::Exploit::Remote
         multiple research companies and the vendor until the October patch release.
 
         This issue is a use-after-free vulnerability in CDisplayPointer via the use of a
-        "onpropertychange" event handler. To setup the appropriate buggy conditions, we first craft
+        "onpropertychange" event handler. To set up the appropriate buggy conditions, we first craft
         the DOM tree in a specific order, where a CBlockElement comes after the CTextArea element.
         If we use a select() function for the CTextArea element, two important things will happen:
         a CDisplayPointer object will be created for CTextArea, and it will also trigger another
-        event called "onselect". The "onselect" event will allow us to setup for the actual event
+        event called "onselect". The "onselect" event will allow us to set up for the actual event
         handler we want to abuse - the "onpropertychange" event. Since the CBlockElement is a child
         of CTextArea, if we do a node swap of CBlockElement in "onselect", this will trigger
         "onpropertychange".  During "onpropertychange" event handling, a free of the CDisplayPointer

--- a/modules/exploits/windows/misc/hp_dataprotector_crs.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_crs.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Name'           => 'HP Data Protector Cell Request Service Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack-based buffer overflow in the Hewlett-Packard Data Protector
-        product. The vulnerability, due to the insecure usage of _swprintf, exist at the Cell
+        product. The vulnerability, due to the insecure usage of _swprintf, exists at the Cell
         Request Service (crs.exe) when parsing packets with opcode 211. This module has been tested
         successfully on HP Data Protector 6.20 and 7.00 on Windows XP SP3.
       },

--- a/modules/post/multi/gather/resolve_hosts.rb
+++ b/modules/post/multi/gather/resolve_hosts.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Post
 
   def initialize(info={})
     super( update_info( info,
-      'Name'          => 'Resolve Hosts',
+      'Name'          => 'Multi Gather Resolve Hosts',
       'Description'   => %q{
         Resolves hostnames to either IPv4 or IPv6 addresses from the perspective of the remote host.
       },


### PR DESCRIPTION
- Period at the end of a description.
- Methods shouldn't be meth_name! unless the method is destructive.
- "Setup" is a noun, "set up" is a verb.
- Use the clunky post module naming convention.
