### PR TITLE
WDS: Use read_response class method

### DIFF
--- a/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
+++ b/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
@@ -165,7 +165,7 @@ class Metasploit3 < Msf::Auxiliary
 
     vprint_status("Sending #{architecture[0]} Client Unattend request ...")
     dcerpc.call(0, wdsc_packet, false)
-    timeout = datastore['Timeout'] || 3
+    timeout = datastore['DCERPC::ReadTimeout']
     response = Rex::Proto::DCERPC::Client.read_response(self.dcerpc.socket, timeout)
 
     if (response and response.stub_data)

--- a/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
+++ b/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
@@ -164,11 +164,13 @@ class Metasploit3 < Msf::Auxiliary
     wdsc_packet = packet.create
 
     vprint_status("Sending #{architecture[0]} Client Unattend request ...")
-    response = dcerpc.call(0, wdsc_packet)
+    dcerpc.call(0, wdsc_packet, false)
+    timeout = datastore['Timeout'] || 3
+    response = Rex::Proto::DCERPC::Client.read_response(self.dcerpc.socket, timeout)
 
-    if (dcerpc.last_response != nil and dcerpc.last_response.stub_data != nil)
+    if (response and response.stub_data)
       vprint_status('Received response ...')
-      data = dcerpc.last_response.stub_data
+      data = response.stub_data
 
       # Check WDSC_Operation_Header OpCode-ErrorCode is success 0x000000
       op_error_code = data.unpack('v*')[19]


### PR DESCRIPTION
Looks like this was never implemented in other modules, but it collects
data from the socket in the usual get_once sort of way.

Related to #1420 and #2511.

With this fix, I never race, and I'm getting the data consistently for both unattend files.

```
msf auxiliary(windows_deployment_services) > run
[*] Binding to 1A927394-352E-4553-AE3F-7CF4AAFCA620:1.0@ncacn_ip_tcp:192.168.145.60[5040] ...
[+] Bound to 1A927394-352E-4553-AE3F-7CF4AAFCA620:1.0@ncacn_ip_tcp:192.168.145.60[5040]
[*] Sending X64 Client Unattend request ...
[*] Received response ...
[*] Received X64 unattend file ...
[*] Raw version of X64 saved as: /home/todb/.msf4/loot/20131014172300_default_192.168.145.60_windows.unattend_447915.txt
[+] Retrived wds credentials for X64
[*] Sending X86 Client Unattend request ...
[*] Received response ...
[*] Received X86 unattend file ...
[*] Raw version of X86 saved as: /home/todb/.msf4/loot/20131014172300_default_192.168.145.60_windows.unattend_278318.txt
[+] Retrived wds credentials for X86
[*] Sending IA64 Client Unattend request ...
[*] Received response ...
[-] No Unattend received for IA64 architecture
[*] Skipping ARM architecture due to adv option

Windows Deployment Services
===========================

 Architecture  Type  Domain        Username         Password
 ------------  ----  ------        --------         --------
 X64           wds   Fabrikam.com  my_username-x64  my_password-x64
 X86           wds   Fabrikam.com  my_username_x86  my_password_x86

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
