### PR TITLE
Add detection code MS Office

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -4,6 +4,7 @@ require 'rex/exploitation/obfuscatejs'
 require 'rex/exploitation/encryptjs'
 require 'rex/exploitation/heaplib'
 require 'rex/exploitation/javascriptosdetect'
+require 'rex/exploitation/javascriptaddonsdetect'
 
 module Msf
 

--- a/lib/rex/exploitation/javascriptaddonsdetect.js
+++ b/lib/rex/exploitation/javascriptaddonsdetect.js
@@ -6,7 +6,7 @@ window.addons_detect = { };
 window.addons_detect.getMsOfficeVersion = function () {
   var version;
   var types = new Array();
-  for (i=1; i <= 5; i++) {
+  for (var i=1; i <= 5; i++) {
     try {
       types[i-1] = typeof(new ActiveXObject("SharePoint.OpenDocuments." + i.toString()));
     }

--- a/lib/rex/exploitation/javascriptaddonsdetect.js
+++ b/lib/rex/exploitation/javascriptaddonsdetect.js
@@ -1,0 +1,51 @@
+window.addons_detect = { };
+
+/**
+ * Returns the version of Microsoft Office. If not found, returns null.
+ **/
+window.addons_detect.getMsOfficeVersion = function () {
+  var version;
+  var types = new Array();
+  for (i=1; i <= 5; i++) {
+    try {
+      types[i-1] = typeof(new ActiveXObject("SharePoint.OpenDocuments." + i.toString()));
+    }
+    catch (e) {
+      types[i-1] = null;
+    }
+  }
+
+  if (types[0] == 'object' && types[1] == 'object' && types[2] == 'object' &&
+      types[3] == 'object' && types[4] == 'object')
+  {
+    version = "2012";
+  }
+  else if (types[0] == 'object' && types[1] == 'object' && types[2] == 'object' &&
+           types[3] == 'object' && types[4] == null)
+  {
+    version = "2010";
+  }
+  else if (types[0] == 'object' && types[1] == 'object' && types[2] == 'object' &&
+           types[3] == null && types[4] == null)
+  {
+    version = "2007";
+  }
+  else if (types[0] == 'object' && types[1] == 'object' && types[2] == null &&
+           types[3] == null && types[4] == null)
+  {
+    version = "2003";
+  }
+  else if (types[0] == 'object' && types[1] == null && types[2] == null &&
+           types[3] == null && types[4] == null)
+  {
+    // If run for the first time, you must manullay allow the "Microsoft Office XP"
+    // add-on to run. However, this prompt won't show because the ActiveXObject statement
+    // is wrapped in an exception handler.
+    version = "xp";
+  }
+  else {
+    version = null;
+  }
+
+  return version;
+}

--- a/lib/rex/exploitation/javascriptaddonsdetect.rb
+++ b/lib/rex/exploitation/javascriptaddonsdetect.rb
@@ -1,0 +1,29 @@
+# -*- coding: binary -*-
+
+require 'msf/core'
+require 'rex/text'
+require 'rex/exploitation/jsobfu'
+
+module Rex
+module Exploitation
+
+#
+# Provides javascript functions to determine addon information.
+#
+# getMsOfficeVersion(): Returns the version for Microsoft Office
+#
+class JavascriptAddonsDetect < JSObfu
+
+  def initialize(custom_js = '', opts = {})
+    @js = custom_js
+    @js += ::File.read(::File.join(::File.dirname(__FILE__), "javascriptaddonsdetect.js"))
+
+    super @js
+
+    return @js
+  end
+
+end
+end
+
+end


### PR DESCRIPTION
[SeeRM #8413] Add detection code for MS Office XP, 2003, 2007, 2010, and 2012.

Here's how to test this:
- [ ] Dump the detection code to /tmp/addons.js using msfconsole:

```
$ msfconsole -q
msf > irb
[*] Starting IRB shell...

>> File.write("/tmp/addons.js", ::Rex::Exploitation::JavascriptAddonsDetect.new)
=> 1086
```
- [ ] Create the following html file and the save it as /tmp/test.html:

```
<script src="addons.js"></script>
<script>
var v = window.addons_detect.getMsOfficeVersion();
if (v == null) {
    document.write("Office not installed or not enabled");
}
else {
    document.write("You are using Office " + v);
}
</script>
```
- [ ] Start a web server under directory /tmp:

```
$ ruby -run -e httpd /tmp/ -p 8181
```
- [ ] And now you're ready to test, make sure you're using Internet Explorer and browse to: http://[your ip]:8181/test.html. You should try to test the following setups: Office 2012 , Office 2010, Office 2007, Office 2003, Office XP, and an IE+Windows setup without Office installed.
