### PR TITLE
Add a default Samsung community string

### DIFF
--- a/data/wordlists/snmp_default_pass.txt
+++ b/data/wordlists/snmp_default_pass.txt
@@ -92,6 +92,7 @@ root
 router
 rw
 rwa
+s!a@m#n$p%c
 san-fran
 sanfran
 scotty


### PR DESCRIPTION
See http://www.kb.cert.org/vuls/id/281284

and

http://www.h-online.com/security/news/item/Samsung-network-printer-vulnerability-discovered-Update-2-1757967.html
