### PR TITLE
Outpost24 importer

### DIFF
--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -41,6 +41,7 @@ require 'rex/parser/nexpose_simple_nokogiri'
 require 'rex/parser/nmap_nokogiri'
 require 'rex/parser/openvas_nokogiri'
 require 'rex/parser/wapiti_nokogiri'
+require 'rex/parser/outpost24_nokogiri'
 
 # Legacy XML parsers -- these will be converted some day
 require 'rex/parser/ip360_aspl_xml'
@@ -2926,7 +2927,7 @@ class DBManager
   # Returns one of: :nexpose_simplexml :nexpose_rawxml :nmap_xml :openvas_xml
   # :nessus_xml :nessus_xml_v2 :qualys_scan_xml, :qualys_asset_xml, :msf_xml :nessus_nbe :amap_mlog
   # :amap_log :ip_list, :msf_zip, :libpcap, :foundstone_xml, :acunetix_xml, :appscan_xml
-  # :burp_session, :ip360_xml_v3, :ip360_aspl_xml, :nikto_xml
+  # :burp_session, :ip360_xml_v3, :ip360_aspl_xml, :nikto_xml, :outpost24_xml
   # If there is no match, an error is raised instead.
   def import_filetype_detect(data)
 
@@ -3059,6 +3060,9 @@ class DBManager
             @import_filedata[:type] = "CI"
             return :ci_xml
           end
+        when "main"
+          @import_filedata[:type] = "Outpost24 XML"
+          return :outpost24_xml
         else
           # Give up if we haven't hit the root tag in the first few lines
           break if line_count > 10
@@ -5918,6 +5922,36 @@ class DBManager
       doc = Rex::Parser::CIDocument.new(args,framework.db) {|type, data| yield type,data }
     else
       doc = Rex::Parser::CI.new(args,self)
+    end
+    parser = ::Nokogiri::XML::SAX::Parser.new(doc)
+    parser.parse(args[:data])
+  end
+
+  def import_outpost24_xml(args={}, &block)
+    bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
+    wspace = args[:wspace] || workspace
+    if Rex::Parser.nokogiri_loaded
+      parser = "Nokogiri v#{::Nokogiri::VERSION}"
+      noko_args = args.dup
+      noko_args[:blacklist] = bl
+      noko_args[:wspace] = wspace
+      if block
+        yield(:parser, parser)
+        import_outpost24_noko_stream(noko_args) {|type, data| yield type,data}
+      else
+        import_outpost24_noko_stream(noko_args)
+      end
+      return true
+    else # Sorry
+      raise DBImportError.new("Could not import due to missing Nokogiri parser. Try 'gem install nokogiri'.")
+    end
+  end
+
+  def import_outpost24_noko_stream(args={},&block)
+    if block
+      doc = Rex::Parser::Outpost24Document.new(args,framework.db) {|type, data| yield type,data }
+    else
+      doc = Rex::Parser::Outpost24Document.new(args,self)
     end
     parser = ::Nokogiri::XML::SAX::Parser.new(doc)
     parser.parse(args[:data])

--- a/lib/rex/parser/outpost24_nokogiri.rb
+++ b/lib/rex/parser/outpost24_nokogiri.rb
@@ -11,46 +11,45 @@ load_nokogiri && class Outpost24Document < Nokogiri::XML::SAX::Document
     @state[:current_tag][name] = true
     case name
     when "hostlist"
-      @report_data[:hosts] = []
+      record_hosts
     when "portlist"
-      @report_data[:services] = []
+      record_services
     when "detaillist"
-      @report_data[:vulns] = []
+      record_vulns
     when "host"
       return unless in_tag("hostlist")
-      @host = {}
+      record_host
     when "portinfo"
       return unless in_tag("portlist")
       return unless in_tag("portlist-host")
-      @service = {}
+      record_service
     when "detail"
       return unless in_tag("detaillist")
-      @vuln = {}
-      @refs = []
+      record_vuln
     when "report", "ip"
-      @state[:has_text] = true
+      record_text
     when "name"
       return unless in_tag("hostlist") || in_tag("detaillist")
       return unless in_tag("host") || in_tag("detail")
-      @state[:has_text] = true
+      record_text
     when "platform"
       return unless in_tag("hostlist")
       return unless in_tag("host")
-      @state[:has_text] = true
+      record_text
     when "portnumber", "protocol", "service"
       return unless in_tag("portlist")
       return unless in_tag("portlist-host")
       return unless in_tag("portinfo")
-      @state[:has_text] = true
+      record_text
     when "description", "information"
       return unless in_tag("detaillist")
       return unless in_tag("detail")
-      @state[:has_text] = true
+      record_text
     when "id"
       return unless in_tag("detaillist")
       return unless in_tag("detail")
       return unless in_tag("cve")
-      @state[:has_text] = true
+      record_text
     end
   end
 
@@ -102,6 +101,35 @@ load_nokogiri && class Outpost24Document < Nokogiri::XML::SAX::Document
       collect_vuln_data(name)
     end
     @state[:current_tag].delete(name)
+  end
+
+  def record_hosts
+    @report_data[:hosts] = []
+  end
+
+  def record_services
+    @report_data[:services] = []
+  end
+
+  def record_vulns
+    @report_data[:vulns] = []
+  end
+
+  def record_host
+    @host = {}
+  end
+
+  def record_service
+    @service = {}
+  end
+
+  def record_vuln
+    @vuln = {}
+    @refs = []
+  end
+
+  def record_text
+    @state[:has_text] = true
   end
 
   def collect_host

--- a/lib/rex/parser/outpost24_nokogiri.rb
+++ b/lib/rex/parser/outpost24_nokogiri.rb
@@ -44,7 +44,7 @@ load_nokogiri && class Outpost24Document < Nokogiri::XML::SAX::Document
       return unless in_tag("portlist-host")
       return unless in_tag("portinfo")
       @state[:has_text] = true
-    when "description"
+    when "description", "information"
       return unless in_tag("detaillist")
       return unless in_tag("detail")
       @state[:has_text] = true
@@ -93,7 +93,7 @@ load_nokogiri && class Outpost24Document < Nokogiri::XML::SAX::Document
       return unless in_tag("portlist-host")
       return unless in_tag("portinfo")
       collect_service_data(name)
-    when "description"
+    when "description", "information"
       return unless in_tag("detaillist")
       return unless in_tag("detail")
       collect_vuln_data(name)
@@ -175,6 +175,8 @@ load_nokogiri && class Outpost24Document < Nokogiri::XML::SAX::Document
       @state[:vname] = @text.strip if @text
     elsif name == "description"
       @state[:vinfo] = @text.strip if @text
+    elsif name == "information"
+      @state[:vinfo] << " #{@text.strip if @text}"
     elsif name == "id"
       @state[:ref] = @text.strip if @text
       @refs << normalize_ref("CVE", @state[:ref])

--- a/lib/rex/parser/outpost24_nokogiri.rb
+++ b/lib/rex/parser/outpost24_nokogiri.rb
@@ -10,8 +10,6 @@ load_nokogiri && class Outpost24Document < Nokogiri::XML::SAX::Document
   def start_element(name, attrs)
     @state[:current_tag][name] = true
     case name
-    when "report"
-      @state[:has_text] = true
     when "hostlist"
       @report_data[:hosts] = []
     when "portlist"
@@ -29,7 +27,7 @@ load_nokogiri && class Outpost24Document < Nokogiri::XML::SAX::Document
       return unless in_tag("detaillist")
       @vuln = {}
       @refs = []
-    when "ip"
+    when "report", "ip"
       @state[:has_text] = true
     when "name"
       return unless in_tag("hostlist") || in_tag("detaillist")
@@ -58,8 +56,6 @@ load_nokogiri && class Outpost24Document < Nokogiri::XML::SAX::Document
 
   def end_element(name)
     case name
-    when "report"
-      collect_product
     when "hostlist"
       report_hosts
     when "portlist"
@@ -76,6 +72,8 @@ load_nokogiri && class Outpost24Document < Nokogiri::XML::SAX::Document
     when "detail"
       return unless in_tag("detaillist")
       collect_vuln
+    when "report"
+      collect_product
     when "ip"
       collect_ip
     when "name"
@@ -106,12 +104,6 @@ load_nokogiri && class Outpost24Document < Nokogiri::XML::SAX::Document
     @state[:current_tag].delete(name)
   end
 
-  def collect_product
-    @state[:has_text] = false
-    @state[:pinfo] = @text.strip if @text
-    @text = nil
-  end
-
   def collect_host
     @host[:host] = @state[:host]
     @host[:name] = @state[:hname]
@@ -135,6 +127,12 @@ load_nokogiri && class Outpost24Document < Nokogiri::XML::SAX::Document
     @vuln[:info] = @state[:vinfo]
     @vuln[:refs] = @refs
     @report_data[:vulns] << @vuln
+  end
+
+  def collect_product
+    @state[:has_text] = false
+    @state[:pinfo] = @text.strip if @text
+    @text = nil
   end
 
   def collect_ip

--- a/lib/rex/parser/outpost24_nokogiri.rb
+++ b/lib/rex/parser/outpost24_nokogiri.rb
@@ -1,0 +1,165 @@
+require "rex/parser/nokogiri_doc_mixin"
+
+module Rex
+module Parser
+
+load_nokogiri && class Outpost24Document < Nokogiri::XML::SAX::Document
+
+  include NokogiriDocMixin
+
+  def start_element(name, attrs)
+    @state[:current_tag][name] = true
+    case name
+    when "hostlist"
+      @report_data[:hosts] = []
+    when "portlist"
+      @report_data[:services] = []
+    when "detaillist"
+      @report_data[:vulns] = []
+    when "host"
+      return unless in_tag("hostlist")
+      @host = {}
+    when "portinfo"
+      return unless in_tag("portlist")
+      return unless in_tag("portlist-host")
+      @service = {}
+    when "detail"
+      return unless in_tag("detaillist")
+      @vuln = {}
+    when "ip"
+      @state[:has_text] = true
+    when "platform"
+      return unless in_tag("hostlist")
+      return unless in_tag("host")
+      @state[:has_text] = true
+    when "portnumber", "protocol", "service"
+      return unless in_tag("portlist")
+      return unless in_tag("portlist-host")
+      return unless in_tag("portinfo")
+      @state[:has_text] = true
+    when "name", "description"
+      return unless in_tag("detaillist")
+      return unless in_tag("detail")
+      @state[:has_text] = true
+    end
+  end
+
+  def end_element(name)
+    case name
+    when "hostlist"
+      report_hosts
+    when "portlist"
+      report_services
+    when "detaillist"
+      report_vulns
+    when "host"
+      return unless in_tag("hostlist")
+      collect_host
+    when "portinfo"
+      return unless in_tag("portlist")
+      return unless in_tag("portlist-host")
+      collect_service
+    when "detail"
+      return unless in_tag("detaillist")
+      collect_vuln
+    when "ip"
+      collect_ip
+    when "platform"
+      return unless in_tag("hostlist")
+      return unless in_tag("host")
+      collect_host_data(name)
+    when "portnumber", "protocol", "service"
+      return unless in_tag("portlist")
+      return unless in_tag("portlist-host")
+      return unless in_tag("portinfo")
+      collect_service_data(name)
+    when "name", "description"
+      return unless in_tag("detaillist")
+      return unless in_tag("detail")
+      collect_vuln_data(name)
+    end
+    @state[:current_tag].delete(name)
+  end
+
+  def collect_host
+    @host[:host] = @state[:host]
+    @host[:os_name] = @state[:os_name]
+    @report_data[:hosts] << @host
+  end
+
+  def collect_service
+    @service[:host] = @state[:host]
+    @service[:port] = @state[:port]
+    @service[:proto] = @state[:proto]
+    @service[:name] = @state[:sname]
+    @report_data[:services] << @service
+  end
+
+  def collect_vuln
+    @vuln[:host] = @state[:host]
+    @vuln[:name] = @state[:name]
+    @vuln[:info] = @state[:info]
+    @report_data[:vulns] << @vuln
+  end
+
+  def collect_ip
+    @state[:has_text] = false
+    @state[:host] = @text.strip if @text
+    @text = nil
+  end
+
+  def collect_host_data(name)
+    @state[:has_text] = false
+    if name == "platform"
+      if @text
+        @state[:os_name] = @text.strip
+      else
+        @state[:os_name] = Msf::OperatingSystems::UNKNOWN
+      end
+    end
+    @text = nil
+  end
+
+  def collect_service_data(name)
+    @state[:has_text] = false
+    if name == "portnumber"
+      @state[:port] = @text.strip if @text
+    elsif name == "protocol"
+      @state[:proto] = @text.strip.downcase if @text
+    elsif name == "service"
+      @state[:sname] = @text.strip if @text
+    end
+    @text = nil
+  end
+
+  def collect_vuln_data(name)
+    @state[:has_text] = false
+    if name == "name"
+      @state[:name] = @text.strip if @text
+    elsif name == "description"
+      @state[:info] = @text.strip if @text
+    end
+    @text = nil
+  end
+
+  def report_hosts
+    @report_data[:hosts].each do |host|
+      db_report(:host, host)
+    end
+  end
+
+  def report_services
+    @report_data[:services].each do |service|
+      db_report(:service, service)
+    end
+  end
+
+  def report_vulns
+    @report_data[:vulns].each do |vuln|
+      db_report(:vuln, vuln)
+    end
+  end
+
+end
+end
+end


### PR DESCRIPTION
This is an importer for the Outpost24 log format, specifically for the OUTSCAN and HIAB products. The sample data is private, but if you have access to it, you can verify the importer's behavior against the following output:

```
msf > db_import ../OUTSCAN_Example_All_Vuln_Demo_account_Selected_group.xml 
[*] Importing 'Outpost24 XML' data
[*] Import: Parsing with 'Nokogiri v1.6.0'
[*] Importing host 192.168.x.x
[*] Importing host 192.168.y.y
[*] Importing service 192.168.x.x:80/tcp
[*] Importing service 192.168.y.y:22/tcp
[*] Importing service 192.168.y.y:137/udp
[*] Importing service 192.168.y.y:139/tcp
[*] Importing service 192.168.y.y:445/tcp
[*] Importing service 192.168.y.y:8009/tcp
[*] Importing service 192.168.y.y:8080/tcp
[*] Importing vulnerability 'SQL Injection (192.168.x.x)' (1 instance)
[*] Importing vulnerability 'Reflected Cross-Site Scripting (192.168.x.x)' (1 instance)
[*] Importing vulnerability 'Samba: Filename-base Format String Bug (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'Samba: smbd *trans* Request Arbitrary Remote Memory Disclosure (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'SMB Null Sessions Enabled (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'Anonymous SMB Login Enabled (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'Samba Root Filesystem Access Vulnerability (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'Samba: POSIX Access Control Override (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'ICMP Timestamp Request (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'SSH Banner (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'HTTP Detection (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'NetBIOS Name Enumeration (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'SMB Native LanMan Information (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'SMB Login (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'SMB Network Share Enumeration (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'SMB Host Security Identifier (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'Traceroute (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'SSH Supported Authentication Mechanisms (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'SSH Supported Protocol Versions (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'TCP SYN|FIN (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'HTTP Information (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'HTTP Options Supported (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'SMB Host SID Local User Enumeration (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'SMB LanMan Pipe Server Browsing (192.168.y.y)' (1 instance)
[*] Importing vulnerability 'SMB Host Password Policy (192.168.y.y)' (1 instance)
[*] Successfully imported /home/wvu/OUTSCAN_Example_All_Vuln_Demo_account_Selected_group.xml
msf > hosts 

Hosts
=====

address         mac  name               os_name  os_flavor  os_sp  purpose  info                     comments
-------         ---  ----               -------  ---------  -----  -------  ----                     --------
192.168.x.x          web.example.com    Unknown                    device   OUTSCAN Security Report  
192.168.y.y          intra.example.com  Unknown                    device   OUTSCAN Security Report  

msf > services 

Services
========

host            port  proto  name         state  info
----            ----  -----  ----         -----  ----
192.168.x.x     80    tcp    http         open   OUTSCAN Security Report
192.168.y.y     139   tcp    netbios-ssn  open   OUTSCAN Security Report
192.168.y.y     137   udp    netbios-ns   open   OUTSCAN Security Report
192.168.y.y     22    tcp    ssh          open   OUTSCAN Security Report
192.168.y.y     445   tcp    netbios-ssn  open   OUTSCAN Security Report
192.168.y.y     8009  tcp    ajp          open   OUTSCAN Security Report
192.168.y.y     8080  tcp    http         open   OUTSCAN Security Report

msf > vulns -i
[*] Time: 2013-10-18 19:13:19 UTC Vuln: host=192.168.x.x name=SQL Injection refs= info=The application dynamically generates an SQL query based on user input, but it does not sufficiently prevent that input from modifying the intended structure of the query.

Without sufficient removal or quoting of SQL syntax in user-controllable inputs, the generated SQL query can cause those inputs to be interpreted as SQL instead of ordinary user data. This can be used to alter query logic to bypass security checks, or to insert additional statements that modify the back-end database, possibly including execution of system commands.

SQL injection has become a common issue with database-driven web sites. The flaw is easily detected, and easily exploited, and as such, any site or software package with even a minimal user base is likely to be subject to an attempted attack of this kind. This flaw depends on the fact that SQL makes no real distinction between the control and data planes. <rtab><columns>4</columns><hdr><col>Exploit URI</col><col>Exploit POST Data</col><col>Vulnerable Parameter</col><col>Manifestation URI</col></hdr><row><col>http://webapps.outpost24.com/login1.asp</col><col>graphicOption=standard&login=16169963'%20or%201%3d1--%20&password=</col><col>login</col><col></col></row><row><col>http://192.168.x.x/login1.asp</col><col>graphicOption=standard&login=16169963'%20or%201%3d2--%20&password=</col><col>login</col><col></col></row><row><col>http://webapps.outpost24.com/login1.asp</col><col>graphicOption=minimum&login=16169963'%20or%201%3d2--%20&password=</col><col>login</col><col></col></row></rtab>
[*] Time: 2013-10-18 19:13:19 UTC Vuln: host=192.168.x.x name=Reflected Cross-Site Scripting refs= info=The software does not sufficiently validate, filter, escape, and encode user-controllable input before it is placed in output that is used as a web page that is served to other users.

The server reads data directly from the HTTP request and reflects it back in the HTTP response. Reflected XSS exploits occur when an attacker causes a user to supply dangerous content to a vulnerable web application, which is then reflected back to the user and executed by the web browser. The most common mechanism for delivering malicious content is to include it as a parameter in a URL that is posted publicly or e-mailed directly to victims. URLs constructed in this manner constitute the core of many phishing schemes, whereby an attacker convinces victims to visit a URL that refers to a vulnerable site. After the site reflects the attacker's content back to the user, the content is executed and proceeds to transfer private information, such as cookies that may include session information, from the user's machine to the attacker or perform other nefarious activities. <rtab><columns>4</columns><hdr><col>Exploit URI</col><col>Exploit POST Data</col><col>Vulnerable Parameter</col><col>Manifestation URI</col></hdr><row><col>http://webapps.outpost24.com/pcomboindex.asp</col><col>cboPage="%3E%3Cprobe42094bcc2db6000006e7%3E%3C"</col><col>cboPage</col><col></col></row><row><col>http://webapps.outpost24.com/plink.asp?a=<probe42094bcc2db6000005ed/>&c=12</col><col></col><col>a</col><col></col></row><row><col>http://webapps.outpost24.com/plink.asp?a="><probe42094bcc2db6000005f5><"&c=12</col><col></col><col>a</col><col></col></row><row><col>http://webapps.outpost24.com/banklogin.asp?err="><probe42094bcc2db600000981><"</col><col></col><col>err</col><col></col></row><row><col>http://webapps.outpost24.com/banklogin.asp?err=<probe42094bcc2db60000097d/></col><col></col><col>err</col><col></col></row><row><col>http://webapps.outpost24.com/rootlogin.asp</col><col>txtHidden=This was hidden from the user&txtName="%3E%3Cprobe42094bcc2db60000078d%3E%3C"&txtPassPhrase=</col><col>txtName</col><col></col></row><row><col>http://webapps.outpost24.com/plink.asp?a="><probe42094bcc2db6000005f1><"&c=12</col><col></col><col>a</col><col></col></row><row><col>http://webapps.outpost24.com/plink.asp?a=b&c="><probe42094bcc2db6000005f7><"</col><col></col><col>c</col><col></col></row><row><col>http://webapps.outpost24.com/plink.asp?a=b&c=<probe42094bcc2db6000005ef/></col><col></col><col>c</col><col></col></row><row><col>http://webapps.outpost24.com/plink.asp?a=b&c="><probe42094bcc2db6000005f3><"</col><col></col><col>c</col><col></col></row><row><col>http://webapps.outpost24.com/banklogin.asp?err="><probe42094bcc2db60000097f><"</col><col></col><col>err</col><col></col></row></rtab>
[*] Time: 2013-10-18 19:13:19 UTC Vuln: host=192.168.y.y name=Samba: Filename-base Format String Bug refs=CVE-2009-1886 info=Multiple format string vulnerabilities in client/client.c in smbclient in Samba 3.2.0 through 3.2.12 might allow context-dependent attackers to execute arbitrary code via format string specifiers in a filename. This vulnerability was identified because (1) the version of Samba, 3.2.3, is less than or equal to 3.2.12.
[*] Time: 2013-10-18 19:13:19 UTC Vuln: host=192.168.y.y name=Samba: smbd *trans* Request Arbitrary Remote Memory Disclosure refs=CVE-2008-4314 info=smbd in Samba might allow remote attackers to read arbitrary memory and cause a denial of service via crafted (1) trans, (2) trans2, and (3) nttrans requests, related to a "cut&paste error" that causes an improper bounds check to be performed. This vulnerability was identified because (1) the version of Samba, 3.2.3, is greater than or equal to 3.0.29; and (2) the version of Samba, 3.2.3, is less than or equal to 3.2.4.
[*] Time: 2013-10-18 19:13:19 UTC Vuln: host=192.168.y.y name=SMB Null Sessions Enabled refs=CVE-1999-0519 info=This SMB service accepts anonymous connections in the form of Null sessions. If this is an internet facing server, having anonymous access to it is generally a bad idea. 
[*] Time: 2013-10-18 19:13:19 UTC Vuln: host=192.168.y.y name=Anonymous SMB Login Enabled refs= info=Anonymous access to this SMB service is enabled. If this is an internet-facing server, having anonymous access to it is generally a bad idea. 
[*] Time: 2013-10-18 19:13:19 UTC Vuln: host=192.168.y.y name=Samba Root Filesystem Access Vulnerability refs=CVE-2009-0022 info=Samba 3.2.0 through 3.2.6, when registry shares are enabled, allows remote authenticated users to access the root filesystem via a crafted connection request that specifies a blank share name. This vulnerability was identified because (1) the version of Samba, 3.2.3, is greater than or equal to 3.2.0; and (2) the version of Samba, 3.2.3, is less than or equal to 3.2.6.
[*] Time: 2013-10-18 19:13:19 UTC Vuln: host=192.168.y.y name=Samba: POSIX Access Control Override refs=CVE-2009-1888 info=The acl_group_override function in smbd/posix_acls.c in smbd in Samba 3.0.x before 3.0.35, 3.1.x and 3.2.x before 3.2.13, and 3.3.x before 3.3.6, when dos filemode is enabled, allows remote attackers to modify access control lists for files via vectors related to read access to uninitialized memory. This vulnerability was identified because (1) the version of Samba, 3.2.3, is less than or equal to 3.2.12.
[*] Time: 2013-10-18 19:13:19 UTC Vuln: host=192.168.y.y name=ICMP Timestamp Request refs=CVE-1999-0524 info=The remote host replies to ICMP Timestamp requests.

Knowing the exact time on your system may help an attacker
to break time-based authentication systems. 
[*] Time: 2013-10-18 19:13:19 UTC Vuln: host=192.168.y.y name=SSH Banner refs= info=The SSH server banner: SSH-2.0-OpenSSH_5.1p1 Debian-3ubuntu1
[*] Time: 2013-10-18 19:13:19 UTC Vuln: host=192.168.y.y name=HTTP Detection refs= info=An HTTP server was found running on the remote host. Apache-Coyote/1.1
[*] Time: 2013-10-18 19:13:19 UTC Vuln: host=192.168.y.y name=NetBIOS Name Enumeration refs=CVE-1999-0621 info=A NetBIOS service replies to queries on udp port 137. MAC address: 00:00:00:00:00:00 (Probably a SAMBA server)

NetBIOS names found:



<rtab><columns>2</columns><hdr><col>Name</col><col>Description</col></hdr><row><col>UBUNTU810</col><col>computer name</col></row><row><col>UBUNTU810</col><col>messenger service</col></row><row><col>UBUNTU810</col><col>file server service</col></row><row><col>__MSBROWSE__</col><col>master browser</col></row><row><col>WORKGROUP</col><col>master browser</col></row><row><col>WORKGROUP</col><col>browser service elections</col></row><row><col>WORKGROUP</col><col>workgroup / domain name</col></row></rtab>
[*] Time: 2013-10-18 19:13:19 UTC Vuln: host=192.168.y.y name=SMB Native LanMan Information refs= info=Sending an authentication request to this host reveals the following
information: Domain: UBUNTU810
Native LanMan: Samba 3.2.3
Operating System: Unix
[*] Time: 2013-10-18 19:13:19 UTC Vuln: host=192.168.y.y name=SMB Login refs= info=This check attempts to login to the remote SMB service. The following login attempts were successful:

- Null session [ <blank> / <blank> ]
- Anonymous login [ <random> / <random> ]

Selected login type: Anonymous login
[*] Time: 2013-10-18 19:13:20 UTC Vuln: host=192.168.y.y name=SMB Network Share Enumeration refs= info=SMB shares available on this host: <rtab><columns>1</columns><hdr><col>Share name</col></hdr><row><col>print$</col></row><row><col>IPC$</col></row></rtab>
[*] Time: 2013-10-18 19:13:20 UTC Vuln: host=192.168.y.y name=SMB Host Security Identifier refs=CVE-2000-1200 info=It was possible to get the host Security Indentifier (SID) through the
SMB service, by calling LsaQueryInformationPolicy. This can be used to
enumerate local user accounts. SID: 1-5-21-897084493--634054598--2011538493
[*] Time: 2013-10-18 19:13:20 UTC Vuln: host=192.168.y.y name=Traceroute refs= info=This check tries to determine the path; traceroute, between our attacker
and your target host. This path may give an attacker valuable information about
through which routers; hops, traffic passes through. This is not a
vulnerability in itself it is merely considered information, however, an
attacker could possibly use this information to determine what ISP you have and
so forth.

Note:
The path is not static and will most likely change depending on from which host
you perform the traceroute. There is also no way you can fix this problem as it
involves changing configurations on all the hops along the way. host[:dport]/protocol (1 hops)
1 192.168.y.y:53/udp [closed]
[*] Time: 2013-10-18 19:13:20 UTC Vuln: host=192.168.y.y name=SSH Supported Authentication Mechanisms refs= info=The SSH service running on this port supports the following authentication
mechanisms. publickey,password
[*] Time: 2013-10-18 19:13:20 UTC Vuln: host=192.168.y.y name=SSH Supported Protocol Versions refs= info=The remote host is running a version of the SSH protocol. OUTSCAN has
detected that the following is true for the remote host. The SSH service appears to support the protocol version(s): 1.99, 2.0
Hostkey version 2: 33:8f:7c:a6:11:c0:25:5f:1f:f1:8b:ad:18:fb:09:84
[*] Time: 2013-10-18 19:13:20 UTC Vuln: host=192.168.y.y name=TCP SYN|FIN refs= info=The TCP implementation on this host replies to invalid TCP packets.
Packets with both the SYN and the FIN bit set are considered invalid
and should be discarded.

Not doing so could have a negative impact on IDS systems. Depending on
the order in which the flag-bits are parsed, the TCP implementation
of this host's operating system may see the SYN bit first and initiate
a connection while the TCP implementation of the IDS parses the FIN bit
first, making it believe that the connection has just been closed.

Effectively, this could mean that a connection can be established without
the IDS keeping track of it. 
[*] Time: 2013-10-18 19:13:20 UTC Vuln: host=192.168.y.y name=HTTP Information refs= info=HTTP Server Information <rtab><columns>4</columns><hdr><col>HTTP Version</col><col>SSL</col><col>Request Pipelining</col><col>Connection Keep-Alive</col></hdr><row><col>1.1</col><col>no</col><col>yes</col><col>yes</col></row></rtab>
[*] Time: 2013-10-18 19:13:20 UTC Vuln: host=192.168.y.y name=HTTP Options Supported refs= info=The following options are supported by the web server running on this port. GET, HEAD, POST, PUT, DELETE, TRACE, OPTIONS
[*] Time: 2013-10-18 19:13:20 UTC Vuln: host=192.168.y.y name=SMB LanMan Pipe Server Browsing refs= info=This host will reveal the list of other nearby Windows systems
when queried through the LanMan pipe. The following hosts were revealed:

UBUNTU810 (os version: 0.0)
[*] Time: 2013-10-18 19:13:20 UTC Vuln: host=192.168.y.y name=SMB Host Password Policy refs= info=The remote host has a password policy set. This password policy must
conform to the International System Policy. Note: OUTSCAN used the supplied credentials to authenticate

The remote host has the following password policy:

Password history length: 0
Minimum password length: 5
Password aging: 0 days
Password complexity requirements: Enabled
Minimum password age: 0 days
Forced logoff: Disabled
Locked account after: 1800 seconds
Time between failed logons: 1800 seconds
msf > 
```

There are changes to lib/msf/core/db.rb, so please be careful with this PR and check with the Pro team.
