### PR TITLE
Retry shell without thread impersonation

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -236,7 +236,15 @@ class Console::CommandDispatcher::Stdapi::Sys
     when /win/
       path = client.fs.file.expand_path("%COMSPEC%")
       path = (path and not path.empty?) ? path : "cmd.exe"
-      cmd_execute("-f", path, "-c", "-H", "-i", "-t")
+
+      # attempt the shell with thread impersonation
+      begin
+        cmd_execute("-f", path, "-c", "-H", "-i", "-t")
+      rescue
+        # if this fails, then we attempt without impersonation
+        print_error( "Failed to spawn shell with thread impersonation. Retrying without it." )
+        cmd_execute("-f", path, "-c", "-H", "-i")
+      end
     when /linux/
       # Don't expand_path() this because it's literal anyway
       path = "/bin/sh"


### PR DESCRIPTION
In certain scenarios on Windows XP there are times when creating a
shell fails with the error `ERROR_PRIVILEGE_NOT_HELD`. When this
happens the user will usuall fallback to a non-impersonated shell
via the command: `execute -f cmd.exe -H -i -c`

This patch catches the error, warns the use of the failure and then retries
to create the interactive shell without the `-t` flag.

Sample run:

```
meterpreter > shell
[-] Failed to spawn shell with thread impersonation. Retrying without it.
Process 228 created.
Channel 4 created.
Microsoft Windows XP [Version 5.1.2600]
(C) Copyright 1985-2001 Microsoft Corp.

C:\Documents and Settings\Owner\Desktop>
```

Windows XP SP0 is the operating system version that was causing the problem for me.
