### PR TITLE
Try to [FixRM #8510]

### DIFF
--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -47,19 +47,20 @@ module Exploit::FileDropper
           false
         end
       else
-        cmds = [
+        win_cmds = [
             %Q|attrib.exe -r "#{win_file}"|,
-            %Q|del.exe /f /q "#{win_file}"|,
-            %Q|rm -f "#{file}" >/dev/null|,
-          ]
-
+            %Q|del.exe /f /q "#{win_file}"|
+        ]
         # We need to be platform-independent here. Since we can't be
         # certain that {#target} is accurate because exploits with
-        # automatic targets frequently change it, we just go ahead and
-        # run both a windows and a unixy command in the same line. One
-        # of them will definitely fail and the other will probably
-        # succeed. Doing it this way saves us an extra round-trip.
-        session.shell_command_token(cmds.join(" ; "))
+        # automatic targets frequently change it we just go ahead and
+        # run one unix command and one windows command. One of them
+        # will definitely fail and the other will probably succeed.
+        # Two commands are executed because the character separator is
+        # different on Windows and Unix ('&' vs ';') as we learned on
+        # https://dev.metasploit.com/redmine/issues/8510
+        session.shell_command_token("rm -f \"#{file}\" >/dev/null")
+        session.shell_command_token(win_cmds.join(" & "))
         print_good("Deleted #{file}")
         true
       end

--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -53,14 +53,12 @@ module Exploit::FileDropper
         ]
         # We need to be platform-independent here. Since we can't be
         # certain that {#target} is accurate because exploits with
-        # automatic targets frequently change it we just go ahead and
-        # run one unix command and one windows command. One of them
-        # will definitely fail and the other will probably succeed.
-        # Two commands are executed because the character separator is
-        # different on Windows and Unix ('&' vs ';') as we learned on
-        # https://dev.metasploit.com/redmine/issues/8510
-        session.shell_command_token("rm -f \"#{file}\" >/dev/null")
-        session.shell_command_token(win_cmds.join(" & "))
+        # automatic targets frequently change it, we just go ahead and
+        # run both a windows and a unixy command in the same line. One
+        # of them will definitely fail and the other will probably
+        # succeed. Doing it this way saves us an extra round-trip.
+        # Trick shared by @mihi42
+        session.shell_command_token("rm -f \"#{file}\" >/dev/null ; echo ' & #{win_cmds.join(" & ")} & echo \" ' >/dev/null")
         print_good("Deleted #{file}")
         true
       end


### PR DESCRIPTION
The history can be read here: https://dev.metasploit.com/redmine/issues/8510

Thanks to @schierlm for feedback.

As a summary: There are exploits, like modules/exploits/windows/http/hp_imc_bims_upload (probably also on some multiplatforms exploits), where the session.platform (on shell sessions) isn't well detected. In these cases FileDropper is not working as expected because the bad command separator is used ("&") vs (";")  

This fix tries to make it on the easy way, which is to make two trips: one shell command for Unix, another one for Windows, using & as command separator. 

The patch is still not perfect, because there is an "echo" command, added by the shell_command API, which is concatenated with the bad command separator in these cases where session.platform isn't detected okey. But with this patch FileDropper is working properly on shell sessions.

**Verification**:
- [ ] Verify the problem, the FileDropper deletion command using " ; " as separator on a windows cmd:

```
C:\>echo metasploit > test.txt

C:\>attrib +r test.txt

C:\>attrib -r "test.txt" ; del.exe /f /q "test.txt" ;echo wvraaRqOuMUOwzFuAdUwqlaSPanRHyVg
Parameter format not correct -

C:\>type test.txt
metasploit
```
- [ ] Verify the resulting command after the patch on a windows cmd:

```
C:\>attrib.exe -r "test.txt" & del.exe /f /q "test.txt";echo wvraaRqOuMUOwzFuAdU
wqlaSPanRHyVg

C:\>type test.txt
The system cannot find the file specified.
```

Even when the result isn't the expected, the echo command has not been executed as expected, the file has been deleted.
- [ ] As an extra step after patch test the modules/exploits/windows/http/hp_imc_bims_upload. FileDropper should work as expected.

```
msf exploit(hp_imc_bims_upload) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444
[*] 192.168.172.133:8080 - Uploading the JSP payload...
[*] 192.168.172.133:8080 - JSP payload uploaded successfully
[*] 192.168.172.133:8080 - Executing payload...
[*] Command shell session 1 opened (192.168.172.1:4444 -> 192.168.172.133:1607) at 2013-10-22 08:39:32 -0500
[*] session platoform

[+] Deleted ..\web\apps\upload\6j97ArhjNnWuBeBFvvhHdylbSCR28pV.jsp

Microsoft Windows [Version 5.2.3790]
(C) Copyright 1985-2003 Microsoft Corp.

C:\Program Files\iMC\client\bin>echo 1695752959;echo QvGqSVAHTmfyFxwqCOyBoADfDPzeZyLO
1695752959;echo QvGqSVAHTmfyFxwqCOyBoADfDPzeZyLO

C:\Program Files\iMC\client\bin>rm -f "..\web\apps\upload\6j97ArhjNnWuBeBFvvhHdylbSCR28pV.jsp" >/dev/null;echo SFvdFvAwbtooVndoVbrRhaVdxzudQjxu

C:\Program Files\iMC\client\bin>attrib.exe -r "..\web\apps\upload\6j97ArhjNnWuBeBFvvhHdylbSCR28pV.jsp" & del.exe /f /q "..\web\apps\upload\6j97ArhjNnWuBeBFvvhHdylbSCR28pV.jsp";echo wvraaRqOuMUOwzFuAdUwqlaSPanRHyVg
```
