### PR TITLE
Fix misleading statement in Outlook post module

### DIFF
--- a/modules/post/windows/gather/credentials/outlook.rb
+++ b/modules/post/windows/gather/credentials/outlook.rb
@@ -342,7 +342,7 @@ class Metasploit3 < Msf::Post
     end
 
     if outlook_exists == 0
-      print_status("Microsoft Outlook not installed.")
+      print_status("Microsoft Outlook not installed or Exchange accounts are being used.")
     elsif saved_accounts == 0
       print_status("Microsoft Outlook installed however no accounts stored in Registry.")
     end


### PR DESCRIPTION
Since this module doesn't retrieve domain exchange information as it isn't stored there it shouldn't say that Outlook isn't installed at all.
