### PR TITLE
Use Fivemat formatting for rspec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
 --color
---format documentation
+--format Fivemat

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ group :development, :test do
 	# Version 4.1.0 or newer is needed to support generate calls without the
 	# 'FactoryGirl.' in factory definitions syntax.
 	gem 'factory_girl', '>= 4.1.0'
+# Make rspec output shorter and more useful
+	gem 'fivemat', '1.2.1'
 	# running documentation generation tasks and rspec tasks
 	gem 'rake', '>= 10.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
     diff-lcs (1.2.4)
     factory_girl (4.2.0)
       activesupport (>= 3.0.0)
+    fivemat (1.2.1)
     i18n (0.6.5)
     json (1.8.0)
     metasploit_data_models (0.16.6)
@@ -62,6 +63,7 @@ DEPENDENCIES
   activesupport (>= 3.0.0)
   database_cleaner
   factory_girl (>= 4.1.0)
+  fivemat (= 1.2.1)
   json
   metasploit_data_models (~> 0.16.6)
   msgpack


### PR DESCRIPTION
Makes the whole thing more pleasant to look at.

Incidentally, travis-ci has a line length limit for logging, so this gives us plenty of room.

See: https://travis-ci.org/rapid7/metasploit-framework/builds/12893359 (the build report for this PR)
