### PR TITLE
Correct ZDI ref to match new scheme

### DIFF
--- a/modules/exploits/windows/emc/replication_manager_exec.rb
+++ b/modules/exploits/windows/emc/replication_manager_exec.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '70853' ],
           [ 'BID', '46235' ],
           [ 'URL', 'http://www.securityfocus.com/archive/1/516260' ],
-          [ 'URL', 'http://www.zerodayinitiative.com/advisories/ZDI-11-061/' ]
+          [ 'ZDI', '11-061/' ]
         ],
       'DisclosureDate' => 'Feb 07 2011',
       'Platform'       => 'win',


### PR DESCRIPTION
Following #2560 pull request commit, correct the ZDI ref within the EMC exploit (#2536)

This is my first commit, so hopefully, this respect R7 standard :)
