### PR TITLE
[FixRM #8525] undefined method `+' for nil:NilClass in enum_ie

### DIFF
--- a/modules/post/windows/gather/enum_ie.rb
+++ b/modules/post/windows/gather/enum_ie.rb
@@ -319,13 +319,14 @@ class Metasploit3 < Msf::Post
         if val_arr.include?(hash)
           data = registry_getvaldata(regpath, hash)
           dec = decrypt_reg(url, data)
-          #decode data and add to creds array
-          header = dec.unpack("VVVVVV")
 
           # If CryptUnprotectData fails, decrypt_reg() will return "", and unpack() will end up
           # returning an array of nils. If this happens, we can cause an "undefined method
           # `+' for NilClass." when we try to calculate the offset, and this causes the module to die.
-          next if header == [nil, nil, nil, nil, nil, nil]
+          next if dec.empty?
+
+          #decode data and add to creds array
+          header = dec.unpack("VVVVVV")
 
           offset = header[0] + header[1] #offset to start of data
           cnt = header[5]/2 # of username/password combinations

--- a/modules/post/windows/gather/enum_ie.rb
+++ b/modules/post/windows/gather/enum_ie.rb
@@ -321,6 +321,12 @@ class Metasploit3 < Msf::Post
           dec = decrypt_reg(url, data)
           #decode data and add to creds array
           header = dec.unpack("VVVVVV")
+
+          # If CryptUnprotectData fails, decrypt_reg() will return "", and unpack() will end up
+          # returning an array of nils. If this happens, we can cause an "undefined method
+          # `+' for NilClass." when we try to calculate the offset, and this causes the module to die.
+          next if header == [nil, nil, nil, nil, nil, nil]
+
           offset = header[0] + header[1] #offset to start of data
           cnt = header[5]/2 # of username/password combinations
           secrets = dec[offset,dec.length-(offset + 1)].split("\x00\x00")


### PR DESCRIPTION
Looks like for some reason if CryptUnprotectData fails, the decrypt_reg() method will return "". And when you unpack "", you produce an array of nils. Since you cannot add something to nil, this should cause an
"undefined method `+' for nil:NilClass" error.

This will check if we get an array of nils, we jump to the next iteration.

See RM 8525:
http://dev.metasploit.com/redmine/issues/8525
