### PR TITLE
[FixRM #8419] Add module platform to ms04_011_pct

### DIFF
--- a/modules/exploits/windows/ssl/ms04_011_pct.rb
+++ b/modules/exploits/windows/ssl/ms04_011_pct.rb
@@ -49,6 +49,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars' => "",
           'StackAdjustment' => -3500,
         },
+      'Platform' => 'win',
       'Targets'        =>
         [
           [


### PR DESCRIPTION
While reviewing, redmine looks like https://dev.metasploit.com/redmine/issues/8419 has been already fixed, but not this module
- Verification:
- [x] Prior fix: Run the command above, ms04_011_pct should appear

```
framework.exploits.each_module { |name, mod| puts name if mod.new.platform.platforms.empty? }; nil
```
- [x] After fix: Run the same command, should return nil
