### PR TITLE
[FixRM #8494] Don't try to create war without exe

### DIFF
--- a/msfpayload
+++ b/msfpayload
@@ -215,7 +215,7 @@ if (cmd =~ /^(p|y|r|d|c|h|j|x|b|v|w|n)$/)
     exe  = Msf::Util::EXE.to_executable($framework, arch, plat, buf)
     if(!exe and plat.index(Msf::Module::Platform::Java))
       exe = payload.generate_war.pack
-    else
+    elsif exe
       exe  = Msf::Util::EXE.to_jsp_war(exe)
     end
 


### PR DESCRIPTION
History here: https://dev.metasploit.com/redmine/issues/8494
- Verification 
- [x] Before patch:

```
$ ./msfpayload solaris/sparc/shell_reverse_tcp LHOST=1.2.3.4 W > /tmp/test.war
/Users/juan/Projects/git/metasploit-framework/lib/msf/util/exe.rb:1055:in `to_jsp_war': undefined method `unpack' for nil:NilClass (NoMethodError)
    from ./msfpayload:219:in `<main>'
```
- [x] After patch:

```
$ ./msfpayload solaris/sparc/shell_reverse_tcp LHOST=1.2.3.4 W > /tmp/test.war
No executable format support for this arch/platform
```
