### PR TITLE
[FixRM #4398] Report credentials to database

### DIFF
--- a/modules/auxiliary/admin/mysql/mysql_enum.rb
+++ b/modules/auxiliary/admin/mysql/mysql_enum.rb
@@ -7,6 +7,7 @@ require 'msf/core'
 
 class Metasploit3 < Msf::Auxiliary
 
+  include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::MYSQL
 
   def initialize(info = {})
@@ -85,6 +86,15 @@ class Metasploit3 < Msf::Auxiliary
       print_status("\tList of Accounts with Password Hashes:")
       res.each do |row|
         print_status("\t\tUser: #{row[0]} Host: #{row[1]} Password Hash: #{row[2]}")
+        report_auth_info({
+          :host  => rhost,
+          :port  => rport,
+          :user  => row[0],
+          :pass  => row[2],
+          :type  => "hash",
+          :sname => "mysql",
+          :active => true
+        })
       end
     end
     # Only list accounts that can log in with SSL if SSL is enabled


### PR DESCRIPTION
I'm not able to repro the issue related to mysql_enum stopping when a missed user table, even when access is not granted.

But I'm adding reporting of found credentials, as asked in the same redmine ticket:

_Verification_
- [ ] Just run the module and verify which creds are reported (you need a target mysql awright)

```
msf auxiliary(mysql_enum) > run

[*] Running MySQL Enumerator...
[*] Enumerating Parameters
[*]     MySQL Version: 5.1.63-0ubuntu0.10.04.1
[*]     Compiled for the following OS: debian-linux-gnu
[*]     Architecture: i486
[*]     Server Hostname: ubuntu
[*]     Data Directory: /var/lib/mysql/
[*]     Logging of queries and logins: OFF
[*]     Old Password Hashing Algorithm OFF
[*]     Loading of local files: ON
[*]     Logins with old Pre-4.1 Passwords: OFF
[*]     Allow Use of symlinks for Database Files: YES
[*]     Allow Table Merge:
[*]     SSL Connection: DISABLED
[*] Enumerating Accounts:
[*]     List of Accounts with Password Hashes:
[*]         User: root Host: localhost Password Hash: *81F5E21E35407D884A6CD4A731AEBFB6AF209E1B
[*]         User: root Host: % Password Hash: *81F5E21E35407D884A6CD4A731AEBFB6AF209E1B
[*]         User: root Host: 127.0.0.1 Password Hash: *81F5E21E35407D884A6CD4A731AEBFB6AF209E1B
[*]         User: debian-sys-maint Host: localhost Password Hash: *28B9C7ED26AF5402894342B6BB2373699AC7C79B
[*]         User:  Host: % Password Hash:
[*]     The following users have GRANT Privilege:
[*]         User: root Host: localhost
[*]         User: root Host: %
[*]         User: root Host: 127.0.0.1
[*]         User: debian-sys-maint Host: localhost
[*]     The following users have CREATE USER Privilege:
[*]         User: root Host: localhost
[*]         User: root Host: %
[*]         User: root Host: 127.0.0.1
[*]         User: debian-sys-maint Host: localhost
[*]     The following users have RELOAD Privilege:
[*]         User: root Host: localhost
[*]         User: root Host: %
[*]         User: root Host: 127.0.0.1
[*]         User: debian-sys-maint Host: localhost
[*]     The following users have SHUTDOWN Privilege:
[*]         User: root Host: localhost
[*]         User: root Host: %
[*]         User: root Host: 127.0.0.1
[*]         User: debian-sys-maint Host: localhost
[*]     The following users have SUPER Privilege:
[*]         User: root Host: localhost
[*]         User: root Host: %
[*]         User: root Host: 127.0.0.1
[*]         User: debian-sys-maint Host: localhost
[*]     The following users have FILE Privilege:
[*]         User: root Host: localhost
[*]         User: root Host: %
[*]         User: root Host: 127.0.0.1
[*]         User: debian-sys-maint Host: localhost
[*]     The following users have PROCESS Privilege:
[*]         User: root Host: localhost
[*]         User: root Host: %
[*]         User: root Host: 127.0.0.1
[*]         User: debian-sys-maint Host: localhost
[*]     The following accounts have privileges to the mysql database:
[*]         User: root Host: localhost
[*]         User: root Host: %
[*]         User: root Host: 127.0.0.1
[*]         User: debian-sys-maint Host: localhost
[*]     Anonymous Accounts are Present:
[*]         User:  Host: %
[*]     The following accounts have empty passwords:
[*]         User:  Host: %
[*]     The following accounts are not restricted by source:
[*]         User:  Host: %
[*]         User: root Host: %
[*] Auxiliary module execution completed
msf auxiliary(mysql_enum) > creds

Credentials
===========

host             port  user              pass                                       type  active?
----             ----  ----              ----                                       ----  -------
192.168.172.133  3306  root              *81F5E21E35407D884A6CD4A731AEBFB6AF209E1B  hash  true
192.168.172.133  3306  debian-sys-maint  *28B9C7ED26AF5402894342B6BB2373699AC7C79B  hash  true
192.168.172.133  3306                                                               hash  true
```
