### PR TITLE
Fix uninitialized constant Msf::Exploit::Powershell

### DIFF
--- a/modules/exploits/windows/local/wmi.rb
+++ b/modules/exploits/windows/local/wmi.rb
@@ -6,6 +6,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/powershell'
 require 'rex'
 
 class Metasploit3 < Msf::Exploit::Local


### PR DESCRIPTION
```
[-] WARNING! The following modules could not be loaded!
[-]     /home/wvu/metasploit-framework/modules/exploits/windows/local/wmi.rb: NameError uninitialized constant Msf::Exploit::Powershell
```

Thanks for the report, @mubix.
