### PR TITLE
Release fixups

### DIFF
--- a/modules/auxiliary/admin/mysql/mysql_enum.rb
+++ b/modules/auxiliary/admin/mysql/mysql_enum.rb
@@ -91,7 +91,7 @@ class Metasploit3 < Msf::Auxiliary
           :port  => rport,
           :user  => row[0],
           :pass  => row[2],
-          :type  => "hash",
+          :type  => "mysql_hash",
           :sname => "mysql",
           :active => true
         })

--- a/modules/auxiliary/admin/smb/delete_file.rb
+++ b/modules/auxiliary/admin/smb/delete_file.rb
@@ -22,16 +22,13 @@ class Metasploit3 < Msf::Auxiliary
     super(
       'Name'        => 'SMB File Delete Utility',
       'Description' => %Q{
-        This module deletes a file from a target share and path. The only reason
-      to use this module is if your existing SMB client is not able to support the features
-      of the Metasploit Framework that you need, like pass-the-hash authentication.
+        This module deletes a file from a target share and path. The usual reason
+      to use this module is to work around limitations in an existing SMB client that may not
+      be able to take advantage of pass-the-hash style authentication.
       },
       'Author'      =>
         [
           'mubix' # copied from hdm upload_file module
-        ],
-      'References'  =>
-        [
         ],
       'License'     => MSF_LICENSE
     )

--- a/modules/auxiliary/admin/smb/download_file.rb
+++ b/modules/auxiliary/admin/smb/download_file.rb
@@ -22,16 +22,13 @@ class Metasploit3 < Msf::Auxiliary
     super(
       'Name'        => 'SMB File Download Utility',
       'Description' => %Q{
-        This module downloads a file from a target share and path. The only reason
-      to use this module is if your existing SMB client is not able to support the features
-      of the Metasploit Framework that you need, like pass-the-hash authentication.
+        This module deletes a file from a target share and path. The usual reason
+      to use this module is to work around limitations in an existing SMB client that may not
+      be able to take advantage of pass-the-hash style authentication.
       },
       'Author'      =>
         [
           'mubix' # copied from hdm upload_file module
-        ],
-      'References'  =>
-        [
         ],
       'License'     => MSF_LICENSE
     )

--- a/modules/auxiliary/dos/http/nodejs_pipelining.rb
+++ b/modules/auxiliary/dos/http/nodejs_pipelining.rb
@@ -13,9 +13,9 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Node.js HTTP Pipelining DoS',
+      'Name'           => 'Node.js HTTP Pipelining Denial of Service',
       'Description'    => %q{
-        This module exploits a DoS in the HTTP parser of Node.js versions
+        This module exploits a Denial of Service (DoS) condition in the HTTP parser of Node.js versions
         released before 0.10.21 and 0.8.26. The attack sends many pipelined
         HTTP requests on a single connection, which causes unbounded memory
         allocation when the client does not read the responses.

--- a/modules/auxiliary/scanner/http/jenkins_enum.rb
+++ b/modules/auxiliary/scanner/http/jenkins_enum.rb
@@ -19,9 +19,10 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => 'Jenkins Vulnerability Scanner',
+      'Name'        => 'Jenkins Enumeration',
       'Description' => %q{
-        This module scans a Jenkins installation for a few vulnerabilities.
+        This module enumerates a remote Jenkins installation in an unauthenticated manner, including
+        host operating system and and Jenkins installation details.
       },
       'Author'      => 'Jeff McCutchan',
       'License'     => MSF_LICENSE

--- a/modules/exploits/linux/http/dlink_dir605l_captcha_bof.rb
+++ b/modules/exploits/linux/http/dlink_dir605l_captcha_bof.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'D-Link DIR-605L Captcha Handling Buffer Overflow',
       'Description'    => %q{
-          This module exploits an anonymous remote code execution on D-Link DIR-605L routers. The
+          This module exploits an anonymous remote code execution vulnerability on D-Link DIR-605L routers. The
         vulnerability exists while handling user supplied captcha information, and is due to the
         insecure usage of sprintf on the getAuthCode() function. This module has been tested
         successfully on DLink DIR-605L Firmware 1.13 under a QEMU environment.

--- a/modules/exploits/osx/local/persistence.rb
+++ b/modules/exploits/osx/local/persistence.rb
@@ -19,9 +19,9 @@ class Metasploit3 < Msf::Exploit::Local
     super( update_info( info,
       'Name'          => 'Mac OS X Persistent Payload Installer',
       'Description'   => %q{
-        This module provides a persistence boot payload by creating a plist entry
+        This module provides a persistent boot payload by creating a plist entry
         in current user's ~/Library/LaunchAgents directory. Whenever the user logs in,
-        the LaunchAgent will be invoked and our dropped payload will run.
+        the LaunchAgent will be invoked and this dropped payload will run.
       },
       'License'       => MSF_LICENSE,
       'Author'        => [ "Marcin 'Icewall' Noga <marcin[at]icewall.pl>", "joev" ],

--- a/modules/exploits/windows/emc/replication_manager_exec.rb
+++ b/modules/exploits/windows/emc/replication_manager_exec.rb
@@ -17,7 +17,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Description'    => %q{
         This module exploits a remote command-injection vulnerability in EMC Replication Manager
         client (irccd.exe). By sending a specially crafted message invoking RunProgram function an
-        attacker may be able to execute arbitrary code commands with SYSTEM privileges. Affected
+        attacker may be able to execute arbitrary commands with SYSTEM privileges. Affected
         products are EMC Replication Manager < 5.3. This module has been successfully tested
         against EMC Replication Manager 5.2.1 on XP/W2003. EMC Networker Module for Microsoft
         Applications 2.1 and 2.2 may be vulnerable too although this module have not been tested

--- a/modules/post/windows/gather/credentials/sso.rb
+++ b/modules/post/windows/gather/credentials/sso.rb
@@ -1,8 +1,6 @@
 ##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# web site for more information on licensing and terms of use.
-#   http://metasploit.com/
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 require 'msf/core'
@@ -15,16 +13,16 @@ class Metasploit3 < Msf::Post
 
   def initialize(info={})
     super( update_info(info,
-      'Name'		 => 'Windows Single Sign On Credential Collector (Mimikatz)',
-      'Description'	 => %q{
+      'Name'         => 'Windows Single Sign On Credential Collector (Mimikatz)',
+      'Description'  => %q{
         This module will collect cleartext Single Sign On credentials from the Local
       Security Authority using the Mimikatz extension. Blank passwords will not be stored
       in the database.
           },
-      'License'	 => MSF_LICENSE,
-      'Author'	 => ['Ben Campbell <eat_meatballs[at]hotmail.co.uk>'],
-      'Platform'	 => ['win'],
-      'SessionTypes'	 => ['meterpreter' ]
+      'License'      => MSF_LICENSE,
+      'Author'       => ['Ben Campbell <eat_meatballs[at]hotmail.co.uk>'],
+      'Platform'     => ['win'],
+      'SessionTypes' => ['meterpreter' ]
     ))
   end
 


### PR DESCRIPTION
Updates modules for grammar and description correctness and clarity.

Also updates the mysql enumeration module to register a password type of mysql_hash. Note, @dmaloney-r7, this should be compatible with Metasploit Pro's normal bruteforcing routines, since password reuse is limited by cred.type, and nothing has ever looked for a cred.type of "mysql_hash".
