### PR TITLE
Fix mimikatz error when password is nil

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/mimikatz.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/mimikatz.rb
@@ -106,7 +106,7 @@ class Console::CommandDispatcher::Mimikatz
     )
 
     accounts.each do |acc|
-      table << [acc[:authid], acc[:package], acc[:domain], acc[:user],  acc[:password].gsub("\n","")]
+      table << [acc[:authid], acc[:package], acc[:domain], acc[:user], (acc[:password] || "").gsub("\n","")]
     end
 
     print_line table.to_s


### PR DESCRIPTION
In some cases the password value that comes out of mimikatz results is `nil`, instead of an empty string. This fixes this so that if the string is `nil` is falls back to an empty string, resulting in the call to `gsub` working instead of failing.

Before:

```
meterpreter > ssp
[!] Not currently running as SYSTEM
[*] Attempting to getprivs
[!] Did not get SeDebugPrivilege
[*] Retrieving ssp credentials
ssp credentials
===============

AuthID  Package  Domain  User  Password
------  -------  ------  ----  --------

meterpreter > wdigest
[!] Not currently running as SYSTEM
[*] Attempting to getprivs
[!] Did not get SeDebugPrivilege
[*] Retrieving wdigest credentials
[-] Error running command wdigest: NoMethodError undefined method `gsub' for nil:NilClass
```

After:

```
meterpreter > wdigest
[!] Not currently running as SYSTEM
[*] Attempting to getprivs
[!] Did not get SeDebugPrivilege
[*] Retrieving wdigest credentials
wdigest credentials
===================

AuthID                                                Package  Domain           User       Password
------                                                -------  ------           ----       --------
Erreur : Impossible d'obtenir les donn�es de session  
0;459951                                              NTLM     WIN-LBTGGLV2K4E  XXXXXXXXX  OpenProcess : (0x00000005) Access is denied. n.a. (wdigest KO)
```

[FixRM #8251]
