### PR TITLE
Add support for offline updates via msfupdate (and make msfupdate testable)

### DIFF
--- a/msfupdate
+++ b/msfupdate
@@ -15,11 +15,13 @@ end
 
 
 class Msfupdate
+  attr_reader :stdin
   attr_reader :stdout
   attr_reader :stderr
 
-  def initialize(msfbase_dir, stdout=$stdout, stderr=$stderr)
+  def initialize(msfbase_dir, stdin=$stdin, stdout=$stdout, stderr=$stderr)
     @msfbase_dir = msfbase_dir
+    @stdin = stdin
     @stdout = stdout
     @stderr = stderr
   end

--- a/msfupdate
+++ b/msfupdate
@@ -16,9 +16,50 @@ end
 @orig_dir = Dir.pwd
 @msfbase_dir = File.dirname(msfbase)
 
-@args = ARGV.dup
-
 Dir.chdir(@msfbase_dir)
+
+def print_usage
+  puts <<-EOF
+usage: msfupdate [--git-remote=<remote>] [--git-branch=<branch>] [--offline-file=<file>]
+Options:
+-h, --help               show help
+    --git-remote REMOTE  git remote to use (default upstream)
+    --git-branch BRANCH  git branch to use (default master)
+    --offline-file FILE  offline update file to use
+    EOF
+end
+
+require 'getoptlong'
+opts = GetoptLong.new(
+  ['--help', '-h', GetoptLong::NO_ARGUMENT],
+  ['--git-remote', GetoptLong::REQUIRED_ARGUMENT],
+  ['--git-branch', GetoptLong::REQUIRED_ARGUMENT],
+  ['--offline-file', GetoptLong::REQUIRED_ARGUMENT],
+)
+
+begin
+  opts.each do |opt, arg|
+    case opt
+    when '--help'
+      print_usage
+      exit
+    when '--git-remote'
+      @git_remote = arg
+    when '--git-branch'
+      @git_branch = arg
+    when '--offline-file'
+      @offline_file = File.expand_file(arg, @orig_dir)
+    end
+  end
+rescue GetoptLong::Error
+  $stderr.puts "#{$0}: try 'msfupdate --help' for more information"
+  exit 0x20
+end
+
+# Handle the old wait/nowait argument behavior
+if ARGV[0] == 'wait' || ARGV[0] == 'nowait'
+  @actually_wait = (ARGV.shift == 'wait')
+end
 
 $stderr.puts "[*]"
 $stderr.puts "[*] Attempting to update the Metasploit Framework..."
@@ -84,28 +125,6 @@ def apt_upgrade_available(package)
   end
 end
 
-@args.each_with_index do |arg,i|
-  case arg
-    # Handle the old wait/nowait argument behavior
-  when "wait", "nowait"
-    @wait_index = i
-    @actually_wait = (arg == "wait")
-  when /--git-remote=([^\s]*)?/
-    @git_remote = $1
-    @git_remote_index = i
-  when /--git-branch=([^\s]*)?/
-    @git_branch = $1
-    @git_branch_index = i
-  end
-end
-
-@args[@wait_index] = nil      if @wait_index
-
-@args[@git_remote_index] = nil if @git_remote_index
-@args[@git_branch_index] = nil if @git_branch_index
-
-@args = @args.compact
-
 ####### Since we're Git, do it all that way #######
 if is_git
   $stdout.puts "[*] Checking for updates via git"
@@ -157,9 +176,8 @@ if is_installed
   product_key =   File.expand_path(File.join(@msfbase_dir, "..", "engine", "license", "product.key"))
   if File.exists? product_key
     if File.readable? product_key
-      # if given, assume first argument is an offline update path (possibly a relative path)
-      if (@args[0])
-        system("ruby", update_script, File.expand_path(@args[0], @orig_dir))
+      if (@offline_file)
+        system("ruby", update_script, @offline_file)
       else
         system("ruby", update_script)
       end

--- a/msfupdate
+++ b/msfupdate
@@ -13,13 +13,19 @@ while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
 
-@orig_dir = Dir.pwd
-@msfbase_dir = File.dirname(msfbase)
 
-Dir.chdir(@msfbase_dir)
+class Msfupdate
+  attr_reader :stdout
+  attr_reader :stderr
 
-def print_usage
-  puts <<-EOF
+  def initialize(msfbase_dir, stdout=$stdout, stderr=$stderr)
+    @msfbase_dir = msfbase_dir
+    @stdout = stdout
+    @stderr = stderr
+  end
+
+  def usage(io=stdout)
+    io.puts <<-EOF
 usage: msfupdate [--git-remote=<remote>] [--git-branch=<branch>] [--offline-file=<file>]
 Options:
 -h, --help               show help
@@ -27,206 +33,237 @@ Options:
     --git-branch BRANCH  git branch to use (default master)
     --offline-file FILE  offline update file to use
     EOF
-end
+  end
 
-require 'getoptlong'
-opts = GetoptLong.new(
-  ['--help', '-h', GetoptLong::NO_ARGUMENT],
-  ['--git-remote', GetoptLong::REQUIRED_ARGUMENT],
-  ['--git-branch', GetoptLong::REQUIRED_ARGUMENT],
-  ['--offline-file', GetoptLong::REQUIRED_ARGUMENT],
-)
+  def parse_args(args)
+    begin
+      # GetoptLong uses ARGV, but we want to use the args parameter
+      # Copy args into ARGV, then restore ARGV after GetoptLong
+      real_args = ARGV.clone
+      ARGV.clear
+      args.each {|arg| ARGV << arg}
 
-begin
-  opts.each do |opt, arg|
-    case opt
-    when '--help'
-      print_usage
-      exit
-    when '--git-remote'
-      @git_remote = arg
-    when '--git-branch'
-      @git_branch = arg
-    when '--offline-file'
-      @offline_file = File.expand_file(arg, @orig_dir)
+      require 'getoptlong'
+      opts = GetoptLong.new(
+        ['--help', '-h', GetoptLong::NO_ARGUMENT],
+        ['--git-remote', GetoptLong::REQUIRED_ARGUMENT],
+        ['--git-branch', GetoptLong::REQUIRED_ARGUMENT],
+        ['--offline-file', GetoptLong::REQUIRED_ARGUMENT],
+      )
+
+      begin
+        opts.each do |opt, arg|
+          case opt
+          when '--help'
+            usage
+            exit
+          when '--git-remote'
+            @git_remote = arg
+          when '--git-branch'
+            @git_branch = arg
+          when '--offline-file'
+            @offline_file = File.expand_path(arg)
+          end
+        end
+      rescue GetoptLong::Error
+        stderr.puts "#{$0}: try 'msfupdate --help' for more information"
+        exit 0x20
+      end
+
+      # Handle the old wait/nowait argument behavior
+      if ARGV[0] == 'wait' || ARGV[0] == 'nowait'
+        @actually_wait = (ARGV.shift == 'wait')
+      end
+
+    ensure
+      # Restore the original ARGV value
+      ARGV.clear
+      real_args.each {|arg| ARGV << arg}
     end
   end
-rescue GetoptLong::Error
-  $stderr.puts "#{$0}: try 'msfupdate --help' for more information"
-  exit 0x20
-end
 
-# Handle the old wait/nowait argument behavior
-if ARGV[0] == 'wait' || ARGV[0] == 'nowait'
-  @actually_wait = (ARGV.shift == 'wait')
-end
-
-$stderr.puts "[*]"
-$stderr.puts "[*] Attempting to update the Metasploit Framework..."
-$stderr.puts "[*]"
-$stderr.puts ""
-
-# Bail right away, no waiting around for consoles.
-if not (Process.uid == 0 or File.stat(msfbase).owned?)
-  $stderr.puts "[-] ERROR: User running msfupdate does not own the Metasploit installation"
-  $stderr.puts "[-] Please run msfupdate as the same user who installed Metasploit."
-  exit 0x10
-end
-
-def is_apt
-  File.exists?(File.expand_path(File.join(@msfbase_dir, '.apt')))
-end
-
-# Are you an installer, or did you get here via a source checkout?
-def is_installed
-  File.exists?(File.expand_path(File.join(@msfbase_dir, "..", "engine", "update.rb"))) && !is_apt
-end
-
-def is_git
-  File.directory?(File.join(@msfbase_dir, ".git"))
-end
-
-# Adding an upstream enables msfupdate to pull updates from
-# Rapid7's metasploit-framework repo instead of the repo
-# the user originally cloned or forked.
-def add_git_upstream
-  $stdout.puts "[*] Attempting to add remote 'upstream' to your local git repository."
-  system("git", "remote", "add", "upstream", "git://github.com/rapid7/metasploit-framework.git")
-  $stdout.puts "[*] Added remote 'upstream' to your local git repository."
-end
-
-# This only exits if you actually pass a wait option, otherwise
-# just returns nil. This is likely unexpected, revisit this.
-def maybe_wait_and_exit(exit_code=0)
-  if @actually_wait
-    $stdout.puts ""
-    $stdout.puts "[*] Please hit enter to exit"
-    $stdout.puts ""
-    $stdin.readline
-    exit exit_code
+  def apt?
+    File.exists?(File.expand_path(File.join(@msfbase_dir, '.apt')))
   end
-end
 
-def apt_upgrade_available(package)
-  require 'open3'
-  installed = nil
-  upgrade = nil
-  ::Open3.popen3({'LANG'=>'en_US.UTF-8'}, "apt-cache", "policy", package) do |stdin, stdout, stderr|
-    stdout.each do |line|
-      installed = $1 if line =~ /Installed: ([\w\-+.:~]+)$/
-      upgrade = $1 if line =~ /Candidate: ([\w\-+.:~]+)$/
-      break if installed && upgrade
+  # Are you an installer, or did you get here via a source checkout?
+  def binary_install?
+    File.exists?(File.expand_path(File.join(@msfbase_dir, "..", "engine", "update.rb"))) && !apt?
+  end
+
+  def git?
+    File.directory?(File.join(@msfbase_dir, ".git"))
+  end
+
+  def run!
+    stderr.puts "[*]"
+    stderr.puts "[*] Attempting to update the Metasploit Framework..."
+    stderr.puts "[*]"
+    stderr.puts ""
+
+    # Bail right away, no waiting around for consoles.
+    if not (Process.uid == 0 or File.stat(@msfbase_dir).owned?)
+      stderr.puts "[-] ERROR: User running msfupdate does not own the Metasploit installation"
+      stderr.puts "[-] Please run msfupdate as the same user who installed Metasploit."
+      exit 0x10
     end
-  end
-  if installed && installed != upgrade
-    upgrade
-  else
-    nil
-  end
-end
 
-####### Since we're Git, do it all that way #######
-if is_git
-  $stdout.puts "[*] Checking for updates via git"
-  $stdout.puts "[*] Note: Updating from bleeding edge"
-  out = `git remote show upstream` # Actually need the output for this one.
-  add_git_upstream unless $?.success? and out =~ %r{(https|git|git@github\.com):(//github\.com/)?(rapid7/metasploit-framework\.git)}
-
-  remote = @git_remote || "upstream"
-  branch = @git_branch || "master"
-
-  # This will save local changes in a stash, but won't
-  # attempt to reapply them. If the user wants them back
-  # they can always git stash pop them, and that presumes
-  # they know what they're doing when they're editing local
-  # checkout, which presumes they're not using msfupdate
-  # to begin with.
-  #
-  # Note, this requires at least user.name and user.email
-  # to be configured in the global git config. Installers should
-  # take care that this is done. TODO: Enforce this in msfupdate
-  committed = system("git", "diff", "--quiet", "HEAD")
-  if committed.nil?
-    $stderr.puts "[-] ERROR: Failed to run git"
-    $stderr.puts ""
-    $stderr.puts "[-] If you used a binary installer, make sure you run the symlink in"
-    $stderr.puts "[-] /usr/local/bin instead of running this file directly (e.g.: ./msfupdate)"
-    $stderr.puts "[-] to ensure a proper environment."
-    maybe_wait_and_exit 1
-  elsif not committed
-    system("git", "stash")
-    $stdout.puts "[*] Stashed local changes to avoid merge conflicts."
-    $stdout.puts "[*] Run `git stash pop` to reapply local changes."
-  end
-
-  system("git", "reset", "HEAD", "--hard")
-  system("git", "checkout", branch)
-  system("git", "fetch", remote)
-  system("git", "merge", "#{remote}/#{branch}")
-
-  $stdout.puts "[*] Updating gems..."
-  require 'bundler'
-  Bundler.with_clean_env do
-    system("bundle", "install")
-  end
-end
-
-if is_installed
-  update_script = File.expand_path(File.join(@msfbase_dir, "..", "engine", "update.rb"))
-  product_key =   File.expand_path(File.join(@msfbase_dir, "..", "engine", "license", "product.key"))
-  if File.exists? product_key
-    if File.readable? product_key
-      if (@offline_file)
-        system("ruby", update_script, @offline_file)
+    Dir.chdir(@msfbase_dir) do
+      if git?
+        update_git!
+      elsif binary_install?
+        update_binary_install!
+      elsif apt?
+        update_apt!
       else
-        system("ruby", update_script)
+        raise RuntimeError, "Cannot determine checkout type: `#{@msfbase_dir}'"
+      end
+    end
+
+    maybe_wait_and_exit(0)
+  end
+
+  def update_git!
+    ####### Since we're Git, do it all that way #######
+    stdout.puts "[*] Checking for updates via git"
+    stdout.puts "[*] Note: Updating from bleeding edge"
+    out = `git remote show upstream` # Actually need the output for this one.
+    add_git_upstream unless $?.success? and out =~ %r{(https|git|git@github\.com):(//github\.com/)?(rapid7/metasploit-framework\.git)}
+
+    remote = @git_remote || "upstream"
+    branch = @git_branch || "master"
+
+    # This will save local changes in a stash, but won't
+    # attempt to reapply them. If the user wants them back
+    # they can always git stash pop them, and that presumes
+    # they know what they're doing when they're editing local
+    # checkout, which presumes they're not using msfupdate
+    # to begin with.
+    #
+    # Note, this requires at least user.name and user.email
+    # to be configured in the global git config. Installers should
+    # take care that this is done. TODO: Enforce this in msfupdate
+    committed = system("git", "diff", "--quiet", "HEAD")
+    if committed.nil?
+      stderr.puts "[-] ERROR: Failed to run git"
+      stderr.puts ""
+      stderr.puts "[-] If you used a binary installer, make sure you run the symlink in"
+      stderr.puts "[-] /usr/local/bin instead of running this file directly (e.g.: ./msfupdate)"
+      stderr.puts "[-] to ensure a proper environment."
+      maybe_wait_and_exit 1
+    elsif not committed
+      system("git", "stash")
+      stdout.puts "[*] Stashed local changes to avoid merge conflicts."
+      stdout.puts "[*] Run `git stash pop` to reapply local changes."
+    end
+
+    system("git", "reset", "HEAD", "--hard")
+    system("git", "checkout", branch)
+    system("git", "fetch", remote)
+    system("git", "merge", "#{remote}/#{branch}")
+
+    stdout.puts "[*] Updating gems..."
+    require 'bundler'
+    Bundler.with_clean_env do
+      system("bundle", "install")
+    end
+  end
+
+  def update_binary_install!
+    update_script = File.expand_path(File.join(@msfbase_dir, "..", "engine", "update.rb"))
+    product_key =   File.expand_path(File.join(@msfbase_dir, "..", "engine", "license", "product.key"))
+    if File.exists? product_key
+      if File.readable? product_key
+        if (@offline_file)
+          system("ruby", update_script, @offline_file)
+        else
+          system("ruby", update_script)
+        end
+      else
+        stdout.puts "[-] ERROR: Failed to update Metasploit installation"
+        stdout.puts ""
+        stdout.puts "[-] You must be able to read the product key for the"
+        stdout.puts "[-]	Metasploit installation in order to run msfupdate."
+        stdout.puts "[-] Usually, this means you must be root (EUID 0)."
+        maybe_wait_and_exit 10
       end
     else
-      $stdout.puts "[-] ERROR: Failed to update Metasploit installation"
-      $stdout.puts ""
-      $stdout.puts "[-] You must be able to read the product key for the"
-      $stdout.puts "[-]	Metasploit installation in order to run msfupdate."
-      $stdout.puts "[-] Usually, this means you must be root (EUID 0)."
-      maybe_wait_and_exit 10
+      stdout.puts "[-] ERROR: Failed to update Metasploit installation"
+      stdout.puts ""
+      stdout.puts "[-] In order to update your Metasploit installation,"
+      stdout.puts "[-] you must first register it through the UI, here:"
+      stderr.puts "[-] https://localhost:3790"
+      stderr.puts "[-] (Note: Metasploit Community Edition is totally"
+      stderr.puts "[-] free and takes just a few seconds to register!)"
+      maybe_wait_and_exit 11
     end
-  else
-    $stdout.puts "[-] ERROR: Failed to update Metasploit installation"
-    $stdout.puts ""
-    $stdout.puts "[-] In order to update your Metasploit installation,"
-    $stdout.puts "[-] you must first register it through the UI, here:"
-    $stderr.puts "[-] https://localhost:3790"
-	$stderr.puts "[-] (Note: Metasploit Community Edition is totally"
-	$stderr.puts "[-] free and takes just a few seconds to register!)"
-    maybe_wait_and_exit 11
+  end
+
+  def update_apt!
+    # For more information, see here:
+    #   	https://community.rapid7.com/community/metasploit/blog/2013/01/17/metasploit-updates-and-msfupdate
+    stdout.puts "[*] Checking for updates via the APT repository"
+    stdout.puts "[*] Note: expect weekly(ish) updates using this method"
+    system("apt-get", "-qq", "update")
+
+    packages = []
+    packages << 'metasploit-framework' if framework_version = apt_upgrade_available('metasploit-framework')
+    packages << 'metasploit' if pro_version = apt_upgrade_available('metasploit')
+
+    if packages.empty?
+      stdout.puts "[*] No updates available"
+    else
+      stdout.puts "[*] Updating to version #{pro_version || framework_version}"
+      system("apt-get", "install", "--assume-yes", *packages)
+      if packages.include?('metasploit')
+        start_cmd = File.expand_path(File.join(@msfbase_dir, '..', '..', '..', 'scripts', 'start.sh'))
+        system(start_cmd) if ::File.executable_real? start_cmd
+      end
+    end
+  end
+
+  # Adding an upstream enables msfupdate to pull updates from
+  # Rapid7's metasploit-framework repo instead of the repo
+  # the user originally cloned or forked.
+  def add_git_upstream
+    stdout.puts "[*] Attempting to add remote 'upstream' to your local git repository."
+    system("git", "remote", "add", "upstream", "git://github.com/rapid7/metasploit-framework.git")
+    stdout.puts "[*] Added remote 'upstream' to your local git repository."
+  end
+
+  # This only exits if you actually pass a wait option, otherwise
+  # just returns nil. This is likely unexpected, revisit this.
+  def maybe_wait_and_exit(exit_code=0)
+    if @actually_wait
+      stdout.puts ""
+      stdout.puts "[*] Please hit enter to exit"
+      stdout.puts ""
+      stdin.readline
+      exit exit_code
+    end
+  end
+
+  def apt_upgrade_available(package)
+    require 'open3'
+    installed = nil
+    upgrade = nil
+    ::Open3.popen3({'LANG'=>'en_US.UTF-8'}, "apt-cache", "policy", package) do |stdin, stdout, stderr|
+      stdout.each do |line|
+        installed = $1 if line =~ /Installed: ([\w\-+.:~]+)$/
+        upgrade = $1 if line =~ /Candidate: ([\w\-+.:~]+)$/
+        break if installed && upgrade
+      end
+    end
+    if installed && installed != upgrade
+      upgrade
+    else
+      nil
+    end
   end
 end
 
-if is_apt
-  # For more information, see here:
-  #   	https://community.rapid7.com/community/metasploit/blog/2013/01/17/metasploit-updates-and-msfupdate
-  $stdout.puts "[*] Checking for updates via the APT repository"
-  $stdout.puts "[*] Note: expect weekly(ish) updates using this method"
-  system("apt-get", "-qq", "update")
-
-  packages = []
-  packages << 'metasploit-framework' if framework_version = apt_upgrade_available('metasploit-framework')
-  packages << 'metasploit' if pro_version = apt_upgrade_available('metasploit')
-
-  if packages.empty?
-    $stdout.puts "[*] No updates available"
-  else
-    $stdout.puts "[*] Updating to version #{pro_version || framework_version}"
-    system("apt-get", "install", "--assume-yes", *packages)
-    if packages.include?('metasploit')
-      start_cmd = File.expand_path(File.join(@msfbase_dir, '..', '..', '..', 'scripts', 'start.sh'))
-      system(start_cmd) if ::File.executable_real? start_cmd
-    end
-  end
+if __FILE__ == $PROGRAM_NAME
+  cli = Msfupdate.new(File.dirname(msfbase))
+  cli.parse_args(ARGV.dup)
+  cli.run!
 end
-
-unless is_git || is_installed || is_apt
-  raise RuntimeError, "Cannot determine checkout type: `#{@msfbase_dir}'"
-end
-
-maybe_wait_and_exit(0)
-

--- a/msfupdate
+++ b/msfupdate
@@ -57,7 +57,7 @@ class Msfupdate
           case opt
           when '--help'
             usage
-            exit
+            maybe_wait_and_exit
           when '--git-remote'
             @git_remote = arg
           when '--git-branch'
@@ -68,7 +68,7 @@ class Msfupdate
         end
       rescue GetoptLong::Error
         stderr.puts "#{$0}: try 'msfupdate --help' for more information"
-        exit 0x20
+        maybe_wait_and_exit 0x20
       end
 
       # Handle the old wait/nowait argument behavior
@@ -129,7 +129,7 @@ class Msfupdate
     if not (Process.uid == 0 or File.stat(@msfbase_dir).owned?)
       stderr.puts "[-] ERROR: User running msfupdate does not own the Metasploit installation"
       stderr.puts "[-] Please run msfupdate as the same user who installed Metasploit."
-      exit 0x10
+      maybe_wait_and_exit 0x10
     end
 
     Dir.chdir(@msfbase_dir) do

--- a/msfupdate
+++ b/msfupdate
@@ -25,14 +25,13 @@ class Msfupdate
   end
 
   def usage(io=stdout)
-    io.puts <<-EOF
-usage: msfupdate [--git-remote=<remote>] [--git-branch=<branch>] [--offline-file=<file>]
-Options:
--h, --help               show help
-    --git-remote REMOTE  git remote to use (default upstream)
-    --git-branch BRANCH  git branch to use (default master)
-    --offline-file FILE  offline update file to use
-    EOF
+    help = "usage: msfupdate [options...]\n"
+    help << "Options:\n"
+    help << "-h, --help               show help\n"
+    help << "    --git-remote REMOTE  git remote to use (default upstream)\n" if git?
+    help << "    --git-branch BRANCH  git branch to use (default master)\n" if git?
+    help << "    --offline-file FILE  offline update file to use\n" if binary_install?
+    io.print help
   end
 
   def parse_args(args)
@@ -86,17 +85,17 @@ Options:
     valid = true
     if binary_install? || apt?
       if @git_branch
-        stderr.puts "[-] git-branch is not supported on this installation"
+        stderr.puts "[-] ERROR: git-branch is not supported on this installation"
         valid = false
       end
       if @git_remote
-        stderr.puts "[-] git-remote is not supported on this installation"
+        stderr.puts "[-] ERROR: git-remote is not supported on this installation"
         valid = false
       end
     end
     if apt? || git?
       if @offline_file
-        stderr.puts "[-] offline-file option is not supported on this installations"
+        stderr.puts "[-] ERROR: offline-file option is not supported on this installation"
         valid = false
       end
     end

--- a/msfupdate
+++ b/msfupdate
@@ -13,6 +13,7 @@ while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
 end
 
+@orig_dir = Dir.pwd
 @msfbase_dir = File.dirname(msfbase)
 
 @args = ARGV.dup
@@ -156,7 +157,12 @@ if is_installed
   product_key =   File.expand_path(File.join(@msfbase_dir, "..", "engine", "license", "product.key"))
   if File.exists? product_key
     if File.readable? product_key
-      system("ruby", update_script)
+      # if given, assume first argument is an offline update path (possibly a relative path)
+      if (@args[0])
+        system("ruby", update_script, File.expand_path(@args[0], @orig_dir))
+      else
+        system("ruby", update_script)
+      end
     else
       $stdout.puts "[-] ERROR: Failed to update Metasploit installation"
       $stdout.puts ""

--- a/msfupdate
+++ b/msfupdate
@@ -119,8 +119,6 @@ Options:
         raise RuntimeError, "Cannot determine checkout type: `#{@msfbase_dir}'"
       end
     end
-
-    maybe_wait_and_exit(0)
   end
 
   def update_git!
@@ -240,6 +238,8 @@ Options:
       stdout.puts ""
       stdin.readline
       exit exit_code
+    else
+      exit exit_code
     end
   end
 
@@ -266,4 +266,5 @@ if __FILE__ == $PROGRAM_NAME
   cli = Msfupdate.new(File.dirname(msfbase))
   cli.parse_args(ARGV.dup)
   cli.run!
+  cli.maybe_wait_and_exit
 end

--- a/msfupdate
+++ b/msfupdate
@@ -82,6 +82,27 @@ Options:
     end
   end
 
+  def validate_args
+    valid = true
+    if binary_install? || apt?
+      if @git_branch
+        stderr.puts "[-] git-branch is not supported on this installation"
+        valid = false
+      end
+      if @git_remote
+        stderr.puts "[-] git-remote is not supported on this installation"
+        valid = false
+      end
+    end
+    if apt? || git?
+      if @offline_file
+        stderr.puts "[-] offline-file option is not supported on this installations"
+        valid = false
+      end
+    end
+    valid
+  end
+
   def apt?
     File.exists?(File.expand_path(File.join(@msfbase_dir, '.apt')))
   end
@@ -96,6 +117,8 @@ Options:
   end
 
   def run!
+    validate_args || maybe_wait_and_exit(0x13)
+
     stderr.puts "[*]"
     stderr.puts "[*] Attempting to update the Metasploit Framework..."
     stderr.puts "[*]"

--- a/spec/msfupdate_spec.rb
+++ b/spec/msfupdate_spec.rb
@@ -49,7 +49,7 @@ describe Msfupdate do
     # By default, we want to ensure tests never actually try to execute any
     # of the update methods unless we are explicitly testing them
     subject.stub(:update_apt!)
-    subject.stub(:update_binary_installer!)
+    subject.stub(:update_binary_install!)
     subject.stub(:update_git!)
   end
 

--- a/spec/msfupdate_spec.rb
+++ b/spec/msfupdate_spec.rb
@@ -24,11 +24,12 @@ describe Msfupdate do
     dummy_git_pathname
   end
 
+  let(:stdin)  { StringIO.new("", "rb") }
   let(:stdout) { StringIO.new("", "wb") }
   let(:stderr) { StringIO.new("", "wb") }
 
   subject do
-    Msfupdate.new(msfbase_dir, stdout, stderr)
+    Msfupdate.new(msfbase_dir, stdin, stdout, stderr)
   end
 
   before(:all) do

--- a/spec/msfupdate_spec.rb
+++ b/spec/msfupdate_spec.rb
@@ -166,12 +166,56 @@ describe Msfupdate do
     end
   end
 
+  context "#run!" do
+    before(:each) do
+      subject.parse_args(args)
+    end
+    let(:args) { [] }
+
+    it "calls validate_args" do
+      subject.should_receive(:validate_args) { true }
+      subject.run!
+    end
+
+    it "exits if arguments are invalid" do
+      subject.stub(:validate_args) { false }
+      subject.should_receive(:maybe_wait_and_exit).and_raise(SystemExit)
+      expect { subject.run! }.to raise_error(SystemExit)
+    end
+  end
+
   context "in an apt installation" do
     let(:msfbase_dir) { dummy_apt_pathname }
 
     its(:apt?) { should == true }
     its(:binary_install?) { should == false }
     its(:git?) { should == false }
+
+    context "#validate_args" do
+      before(:each) do
+        subject.parse_args(args)
+      end
+
+      context "with no args" do
+        let(:args) { [] }
+        its(:validate_args) { should == true }
+      end
+
+      context "with --git-remote" do
+        let(:args) { ['--git-remote', 'foo'] }
+        its(:validate_args) { should == false }
+      end
+
+      context "with --git-branch" do
+        let(:args) { ['--git-branch', 'foo'] }
+        its(:validate_args) { should == false }
+      end
+
+      context "with --offline-file" do
+        let(:args) { ['--offline-file', 'foo'] }
+        its(:validate_args) { should == false }
+      end
+    end
 
     context "#run!" do
       it "calls update_apt!" do
@@ -200,6 +244,32 @@ describe Msfupdate do
     its(:binary_install?) { should == true }
     its(:git?) { should == false }
 
+    context "#validate_args" do
+      before(:each) do
+        subject.parse_args(args)
+      end
+
+      context "with no args" do
+        let(:args) { [] }
+        its(:validate_args) { should == true }
+      end
+
+      context "with --git-remote" do
+        let(:args) { ['--git-remote', 'foo'] }
+        its(:validate_args) { should == false }
+      end
+
+      context "with --git-branch" do
+        let(:args) { ['--git-branch', 'foo'] }
+        its(:validate_args) { should == false }
+      end
+
+      context "with --offline-file" do
+        let(:args) { ['--offline-file', 'foo'] }
+        its(:validate_args) { should == true }
+      end
+    end
+
     context "#run!" do
       it "does not call update_apt!" do
         subject.should_not_receive(:update_apt!)
@@ -226,6 +296,32 @@ describe Msfupdate do
     its(:apt?) { should == false }
     its(:binary_install?) { should == false }
     its(:git?) { should == true }
+
+    context "#validate_args" do
+      before(:each) do
+        subject.parse_args(args)
+      end
+
+      context "with no args" do
+        let(:args) { [] }
+        its(:validate_args) { should == true }
+      end
+
+      context "with --git-remote" do
+        let(:args) { ['--git-remote', 'foo'] }
+        its(:validate_args) { should == true }
+      end
+
+      context "with --git-branch" do
+        let(:args) { ['--git-branch', 'foo'] }
+        its(:validate_args) { should == true }
+      end
+
+      context "with --offline-file" do
+        let(:args) { ['--offline-file', 'foo'] }
+        its(:validate_args) { should == false }
+      end
+    end
 
     context "#run!" do
       it "does not call update_apt!" do

--- a/spec/msfupdate_spec.rb
+++ b/spec/msfupdate_spec.rb
@@ -148,6 +148,22 @@ describe Msfupdate do
         end
       end
     end
+
+    context "with wait" do
+      let(:args) { ['wait'] }
+      it "sets @actually_wait" do
+        subject.parse_args(args)
+        subject.instance_variable_get(:@actually_wait).should == true
+      end
+    end
+
+    context "with nowait" do
+      let(:args) { ['nowait'] }
+      it "sets @actually_wait" do
+        subject.parse_args(args)
+        subject.instance_variable_get(:@actually_wait).should == false
+      end
+    end
   end
 
   context "in an apt installation" do

--- a/spec/msfupdate_spec.rb
+++ b/spec/msfupdate_spec.rb
@@ -1,0 +1,234 @@
+require 'spec_helper'
+
+load Metasploit::Framework.root.join('msfupdate').to_path
+
+describe Msfupdate do
+
+  def dummy_pathname
+    Pathname.new(File.dirname(__FILE__)).join('dummy')
+  end
+
+  def dummy_git_pathname
+    dummy_pathname.join('gitbase')
+  end
+
+  def dummy_install_pathname
+    dummy_pathname.join('installbase').join('msf3')
+  end
+
+  def dummy_apt_pathname
+    dummy_pathname.join('aptbase')
+  end
+
+  let(:msfbase_dir) do
+    dummy_git_pathname
+  end
+
+  let(:stdout) { StringIO.new("", "wb") }
+  let(:stderr) { StringIO.new("", "wb") }
+
+  subject do
+    Msfupdate.new(msfbase_dir, stdout, stderr)
+  end
+
+  before(:all) do
+    # Create some fake directories to mock our different install environments
+    dummy_pathname.mkpath
+    dummy_apt_pathname.join('.apt').mkpath
+    dummy_git_pathname.join('.git').mkpath
+    dummy_install_pathname.mkpath
+    dummy_install_pathname.join('..', 'engine').mkpath
+    FileUtils.touch(dummy_install_pathname.join('..', 'engine', 'update.rb'))
+  end
+
+  after(:all) do
+    dummy_pathname.rmtree
+  end
+
+  before(:each) do
+    # By default, we want to ensure tests never actually try to execute any
+    # of the update methods unless we are explicitly testing them
+    subject.stub(:update_apt!)
+    subject.stub(:update_binary_installer!)
+    subject.stub(:update_git!)
+  end
+
+  context "#parse_args" do
+    it "doesn't alter ARGV" do
+      ARGV.clear
+      ARGV << 'foo'
+      subject.parse_args(['x', 'y'])
+      ARGV.should == ['foo']
+    end
+
+    context "with --help" do
+      let(:args) { ['--help'] }
+
+      it "calls usage" do
+        expect(subject).to receive(:usage)
+        begin
+          subject.parse_args(args)
+        rescue SystemExit
+        end
+      end
+
+      it "exits before updating" do
+        expect {subject.parse_args(args)}.to raise_error(SystemExit)
+      end
+    end
+
+    context "with --git-branch" do
+      let(:git_branch) { 'foo' }
+      let(:args) { ['--git-branch', git_branch] }
+
+      it "sets @git_branch" do
+        subject.parse_args(args)
+        subject.instance_variable_get(:@git_branch).should == git_branch
+      end
+
+      context "without a space" do
+        let(:args) { ["--git-branch=#{git_branch}"] }
+
+        it "sets @git_branch" do
+          subject.parse_args(args)
+          subject.instance_variable_get(:@git_branch).should == git_branch
+        end
+      end
+    end
+
+    context "with --git-remote" do
+      let(:git_remote) { 'foo' }
+      let(:args) { ['--git-remote', git_remote] }
+
+      it "sets @git_remote" do
+        subject.parse_args(args)
+        subject.instance_variable_get(:@git_remote).should == git_remote
+      end
+
+      context "without a space" do
+        let(:args) { ["--git-remote=#{git_remote}"] }
+
+        it "sets @git_remote" do
+          subject.parse_args(args)
+          subject.instance_variable_get(:@git_remote).should == git_remote
+        end
+      end
+    end
+
+    context "with --offline-file" do
+      let(:offline_file) { 'foo' }
+      let(:args) { ['--offline-file', offline_file] }
+
+      it "sets @offline_file" do
+        subject.parse_args(args)
+        subject.instance_variable_get(:@offline_file).should =~ Regexp.new(Regexp.escape(offline_file))
+      end
+
+      context "with relative path" do
+        it "transforms argument into an absolute path" do
+          subject.parse_args(args)
+          subject.instance_variable_get(:@offline_file).should == File.join(Dir.pwd, offline_file)
+        end
+      end
+
+      context "with absolute path" do
+        let(:offline_file) { '/tmp/foo' }
+        it "accepts an absolute path" do
+          subject.parse_args(args)
+          subject.instance_variable_get(:@offline_file).should == offline_file
+        end
+      end
+
+      context "without a space" do
+        let(:args) { ["--offline-file=#{offline_file}"] }
+
+        it "sets @offline_file" do
+          subject.parse_args(["--offline-file=#{offline_file}"])
+          subject.instance_variable_get(:@offline_file).should =~ Regexp.new(Regexp.escape(offline_file))
+        end
+      end
+    end
+  end
+
+  context "in an apt installation" do
+    let(:msfbase_dir) { dummy_apt_pathname }
+
+    its(:apt?) { should == true }
+    its(:binary_install?) { should == false }
+    its(:git?) { should == false }
+
+    context "#run!" do
+      it "calls update_apt!" do
+        subject.should_receive(:update_apt!)
+        subject.run!
+      end
+      it "does not call update_binary_install!" do
+        subject.should_not_receive(:update_binary_install!)
+        subject.run!
+      end
+      it "does not call update_git!" do
+        subject.should_not_receive(:update_git!)
+        subject.run!
+      end
+    end
+
+    context "#update_apt!" do
+      # TODO: Add more tests!
+    end
+  end
+
+  context "in a binary installation" do
+    let(:msfbase_dir) { dummy_install_pathname }
+
+    its(:apt?) { should == false }
+    its(:binary_install?) { should == true }
+    its(:git?) { should == false }
+
+    context "#run!" do
+      it "does not call update_apt!" do
+        subject.should_not_receive(:update_apt!)
+        subject.run!
+      end
+      it "calls update_binary_install!" do
+        subject.should_receive(:update_binary_install!)
+        subject.run!
+      end
+      it "does not call update_git!" do
+        subject.should_not_receive(:update_git!)
+        subject.run!
+      end
+    end
+
+    context "#update_binary_install!" do
+      # TODO: Add more tests!
+    end
+  end
+
+  context "in a git installation" do
+    let(:msfbase_dir) { dummy_git_pathname }
+
+    its(:apt?) { should == false }
+    its(:binary_install?) { should == false }
+    its(:git?) { should == true }
+
+    context "#run!" do
+      it "does not call update_apt!" do
+        subject.should_not_receive(:update_apt!)
+        subject.run!
+      end
+      it "does not call update_binary_install!" do
+        subject.should_not_receive(:update_binary_install!)
+        subject.run!
+      end
+      it "calls update_git!" do
+        subject.should_receive(:update_git!)
+        subject.run!
+      end
+    end
+
+    context "#update_git!" do
+      # TODO: Add more tests!
+    end
+  end
+
+end


### PR DESCRIPTION
Some users using the binary installer in _air-gapped_ networks (no external internet access) apply updates via an offline update file.  This is currently only supported in the pro/community UI.  This PR adds support for doing this via `msfupdate` as well.

Not only does this make it nice for air-gapped command line users, it is also much easier to script/automate in testing environments.
## Verification Steps:
### `msfupdate` still works in git installs
- [x] Checkout this branch (bturner-r7/feature/msfupdate-offline) via git
- [x] Run msfupdate
- [x] VERFIY: No errors.  You'll be moved to the upstream master branch, but that is as designed
### `msfupdate` still works in binary installer using online update
- [x] Install Metasploit in a virtual machine using a [binary installer](https://github.com/rapid7/metasploit-framework/wiki/Downloads-by-Version)
- [x] Manually replace `/opt/metasploit/apps/pro/msf3/msfupdate` using the `msfupdate` from this pull request: https://raw.github.com/bturner-r7/metasploit-framework/feature/msfupdate-offline/msfupdate
- [x] Create a powered-on snapshot (you'll need it later)
- [x] Run `msfupdate`
- [x] VERIFY: Update installs successfully.
### `msfupdate` works with an offline update
- [x] Restore the VM snapshot you created earlier
- [x] Obtain an offline update.  @bturner-r7 can help you locate one
- [x] Run `msfupdate --offline-file offline-update.bin` (where "offline-update.bin" is the path to the offline update file)
- [x] VERIFY: You see a `Installing update <path>` message (where "<path>" is the full path to the offline update)
- [x] VERIFY: Update installs successfully.

NOTE: Offline update via msfupdate doesn't work on Windows.  This will take an additional change to the pro repository.

ALSO: This PR makes msfupdate testable.  This required refactoring `msfupdate` into an object that can be mocked and tested.  I tried not to modify the actual behavior of the script, but we should still verify:
- [x] Run rspec spec/msfupdate_spec.rb
- [x] Test msfupdate in a git install.  VERIFY: it still works.
- [x] Test msfupdate in a binary install.  VERIFY: it still works.
- [x] Test msfupdate in an apt/kali install.  VERIFY: it still works.
