### PR TITLE
Allow guest login option for psexec.

### DIFF
--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -81,6 +81,7 @@ class Metasploit3 < Msf::Exploit::Remote
       [
         OptBool.new('DB_REPORT_AUTH', [true, "Report an auth_note upon a successful connection", true]),
         OptBool.new('MOF_UPLOAD_METHOD', [true, "Use WBEM instead of RPC, ADMIN$ share will be mandatory. ( Not compatible with Vista+ )", false]),
+        OptBool.new('ALLOW_GUEST', [true, "Keep trying if only given guest access", false]),
         OptString.new('SERVICE_FILENAME', [false, "Filename to to be used on target for the service binary",nil])
       ], self.class)
   end
@@ -93,7 +94,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Authenticating to #{smbhost} as user '#{splitname(datastore['SMBUser'])}'...")
     smb_login()
 
-    if (not simple.client.auth_user)
+    if not simple.client.auth_user and not datastore['ALLOW_GUEST']
       print_line(" ")
       print_error(
         "FAILED! The remote host has only provided us with Guest privileges. " +


### PR DESCRIPTION
This enables obtaining or maintaining access to properly misconfigured
systems through the Guest account.
