### PR TITLE
Add another default owa url

### DIFF
--- a/data/wordlists/http_owa_common.txt
+++ b/data/wordlists/http_owa_common.txt
@@ -1,5 +1,6 @@
 aspnet_client/
 Autodiscover/
+exchange/
 ecp/
 EWS/
 Microsoft-Server-ActiveSync/


### PR DESCRIPTION
Its not default, but not uncommon to find /exchange/ NTLM protected
