### PR TITLE
Fix up proxy/socks4a.rb

### DIFF
--- a/lib/rex/proto/proxy/socks4a.rb
+++ b/lib/rex/proto/proxy/socks4a.rb
@@ -1,4 +1,5 @@
 # -*- coding: binary -*-
+#
 # sf - Sept 2010
 #
 require 'thread'


### PR DESCRIPTION
From #2618.

Just restore the comment header and remove carriage returns.
