### PR TITLE
Wordpress Scanner

### DIFF
--- a/modules/auxiliary/scanner/http/wordpress_scanner.rb
+++ b/modules/auxiliary/scanner/http/wordpress_scanner.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Auxiliary
     if wordpress_and_online?
       version = wordpress_version
       version_string = version ? version : '(no version detected)'
-      print_good("#{target_host} running Wordpress #{version}")
+      print_good("#{target_host} running Wordpress #{version_string}")
       report_note(
           {
               :host   => target_host,

--- a/modules/auxiliary/scanner/http/wordpress_scanner.rb
+++ b/modules/auxiliary/scanner/http/wordpress_scanner.rb
@@ -1,0 +1,39 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+  include Msf::HTTP::Wordpress
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize
+    super(
+        'Name'        => 'Wordpress Scanner',
+        'Description' => 'Detects Wordpress Installations and their version number',
+        'Author'     => [ 'Christian Mehlmauer <FireFart[at]gmail.com>' ],
+        'License'     => MSF_LICENSE
+    )
+  end
+
+  def run_host(target_host)
+    print_status("Trying ip #{target_host}")
+    if wordpress_and_online?
+      version = wordpress_version
+      version_string = version ? version : '(no version detected)'
+      print_good("#{target_host} running Wordpress #{version}")
+      report_note(
+          {
+              :host   => target_host,
+              :proto  => 'tcp',
+              :sname => (ssl ? 'https' : 'http'),
+              :port   => rport,
+              :type   => "Wordpress #{version_string}",
+              :data   => target_uri
+          })
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a Wordpress Scanner to find Wordpress versions on the network.
This should replace PR #2621 from @0pc0deFR

Wasn't sure which report info should be used. I wanted to use the report_web_site, but it looks like there is no option for a path. Maybe you have some feedback on this.

Output from this module:

```
msf auxiliary(wordpress_scanner) > run
[*] Trying ip 192.168.18.127
[-] 192.168.18.127:80 - Error connecting to /wordpress/
[*] Scanned 1 of 4 hosts (025% complete)
[*] Trying ip 192.168.18.128
[-] 192.168.18.128:80 - Error connecting to /wordpress/
[*] Scanned 2 of 4 hosts (050% complete)
[*] Trying ip 192.168.18.129
[+] 192.168.18.129 running Wordpress 3.6.1
[*] Scanned 3 of 4 hosts (075% complete)
[*] Trying ip 192.168.18.130
[-] 192.168.18.130:80 - Error connecting to /wordpress/
[*] Scanned 4 of 4 hosts (100% complete)
[*] Auxiliary module execution completed
```
