### PR TITLE
Add refs to android file stealer

### DIFF
--- a/modules/auxiliary/gather/android_htmlfileprovider.rb
+++ b/modules/auxiliary/gather/android_htmlfileprovider.rb
@@ -31,6 +31,11 @@ class Metasploit3 < Msf::Auxiliary
         [
           'WebServer'
         ],
+      'References' =>
+        [
+          [ 'CVE', '2010-4804' ],
+          [ 'URL', 'http://thomascannon.net/blog/2010/11/android-data-stealing-vulnerability/' ]
+        ]
       'DefaultAction'  => 'WebServer'))
 
     register_options(

--- a/modules/auxiliary/gather/android_htmlfileprovider.rb
+++ b/modules/auxiliary/gather/android_htmlfileprovider.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'CVE', '2010-4804' ],
           [ 'URL', 'http://thomascannon.net/blog/2010/11/android-data-stealing-vulnerability/' ]
-        ]
+        ],
       'DefaultAction'  => 'WebServer'))
 
     register_options(


### PR DESCRIPTION
Saw this randomly on cvedetails and remembered we have a module for it.

Verification:

```
msf> use auxiliary/gather/android_htmlfileprovider
msf> info
```
