### PR TITLE
Remove sleep and constant usage warnings

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -36,12 +36,6 @@ lock up the entire module when called from other interfaces. If you
 need user input, you can either register an option or expose an 
 interactive session type specific for the type of exploit.
 
-3. Don't use "sleep". It has been known to cause issues with
-multi-threaded programs on various platforms running an older version of
-Ruby such as 1.8. Instead, we use "select(nil, nil, nil, <time>)" or
-Rex.sleep() throughout the framework. We have found this works around
-the underlying issue.
-
 4. Always use Rex sockets, not ruby sockets.  This includes
 third-party libraries such as Net::Http.  There are several very good
 reasons for this rule.  First, the framework doesn't get notified on
@@ -91,11 +85,6 @@ for an overview of common and not-so-common Ruby version related gotchas.
 and libraries. If you need a "global" within a specific class, you can
 use @@class_variables, but most modules should use @instance variables
 to store information between methods. 
-
-10. Do not define CONSTANTS within individual modules. This can lead to
-warning messages when the module is reloaded. Try to keep constants
-inside libraries and mixins instead.
-
 
 Creating New Modules
 ====================

--- a/HACKING
+++ b/HACKING
@@ -65,16 +65,17 @@ The '<<' operator is significantly faster. The difference will become
 even more apparent when doing string manipulation in a loop. The
 following table approximates the underlying implementation:
 
-	Ruby 		Pseudo-C
-	----------- 	----------------
-	a = b + c 	a = malloc(b.len+c.len+1);
-			strcpy(a, b);
-			memcpy(a+b.len, c, c.len);
-			a[b.len + c.len] = '\0';
-	a = b 		a = b;
-	a << c 		a = realloc(a, a.len+c.len+1);
-			memcpy(a+a.len, c, c.len);
-			a[a.len + c.len] = '\0';
+        Ruby            Pseudo-C
+        -----------     ----------------
+        a = b + c       a = malloc(b.len+c.len+1);
+                        strcpy(a, b);
+                        memcpy(a+b.len, c, c.len);
+                        a[b.len + c.len] = '\0';
+        a = b           a = b;
+        a << c          a = realloc(a, a.len+c.len+1);
+                        memcpy(a+a.len, c, c.len);
+                        a[a.len + c.len] = '\0';
+
 Note that the original value of 'b' is lost in the second case. Care
 must be taken to duplicate strings that you do not want to modify.
 

--- a/HACKING
+++ b/HACKING
@@ -36,7 +36,7 @@ lock up the entire module when called from other interfaces. If you
 need user input, you can either register an option or expose an 
 interactive session type specific for the type of exploit.
 
-4. Always use Rex sockets, not ruby sockets.  This includes
+3. Always use Rex sockets, not ruby sockets.  This includes
 third-party libraries such as Net::Http.  There are several very good
 reasons for this rule.  First, the framework doesn't get notified on
 the creation of ruby sockets and won't know how to clean them up in
@@ -48,22 +48,23 @@ already implemented with Rex and if the protocol you need is missing,
 porting another library to use them is straight-forward.  See our
 Net::SSH modifications in lib/net/ssh/ for an example.
 
-5. When opening an IO stream, always force binary with "b" mode (or
+4. When opening an IO stream, always force binary with "b" mode (or
 using IO#binmode). This not only helps keep Windows and non-Windows
 runtime environments consistent with each other, but also guarantees
 that files will be treated as ASCII-8BIT instead of UTF-8.
 
-6. Don't use String#[] for a single character.  This returns a Fixnum in
+5. Don't use String#[] for a single character.  This returns a Fixnum in
 ruby 1.8 and a String in 1.9, so it's safer to use the following idiom:
-	str[idx,1]
+  str[idx,1]
 which always returns a String.  If you need the ASCII byte, unpack it like
-so: 
-	str[idx,1].unpack("C")[0]
+so:
+  tr[idx,1].unpack("C")[0]
 
-7. Whenever possible, avoid using '+' or '+=' to concatenate strings.
+6. Whenever possible, avoid using '+' or '+=' to concatenate strings.
 The '<<' operator is significantly faster. The difference will become
 even more apparent when doing string manipulation in a loop. The
 following table approximates the underlying implementation:
+
 	Ruby 		Pseudo-C
 	----------- 	----------------
 	a = b + c 	a = malloc(b.len+c.len+1);
@@ -77,11 +78,11 @@ following table approximates the underlying implementation:
 Note that the original value of 'b' is lost in the second case. Care
 must be taken to duplicate strings that you do not want to modify.
 
-8. For other Ruby 1.8.x/1.9.x compat issues, please see Sam Ruby's
+7. For other Ruby 1.8.x/1.9.x compat issues, please see Sam Ruby's
 excellent slide show at <http://slideshow.rubyforge.org/ruby19.html>
 for an overview of common and not-so-common Ruby version related gotchas.
 
-9. Never, ever use $global variables. This applies to modules, mixins,
+8. Never, ever use $global variables. This applies to modules, mixins,
 and libraries. If you need a "global" within a specific class, you can
 use @@class_variables, but most modules should use @instance variables
 to store information between methods. 


### PR DESCRIPTION
1. It's fine to use `sleep` (by itself) because `sleep` is already being redefined in scope as delegating `Rex::ThreadSafe.sleep` . See https://github.com/rapid7/metasploit-framework/blob/master/lib/rex.rb#L96
2. It's fine to use constants for magic, like you do. The reloading problem disappeared in 1.9, and most people never reload anyway.
