### PR TITLE
Fix redis communication

### DIFF
--- a/modules/auxiliary/scanner/misc/redis_server.rb
+++ b/modules/auxiliary/scanner/misc/redis_server.rb
@@ -35,21 +35,21 @@ class Metasploit3 < Msf::Auxiliary
   def run_host(ip)
     print_status("Scanning IP: #{ip.to_s}")
     begin
-      pkt = "PING" + "\n"
-      connect()
-      sock.puts(pkt)
-      res = sock.recv(1024)
+      pkt = "PING\r\n"
+      connect
+      sock.put(pkt)
+      res = sock.get_once
 
       if res =~ /PONG/
-        info = "INFO"
-        sock.puts(info)
-        data = sock.recv(1024)
+        info = "INFO\r\n"
+        sock.put(info)
+        data = sock.get_once
         print_status("Redis Server Information #{data}")
         data_sanitized = data.to_s
       elsif res =~ /ERR/
-        auth = "AUTH foobared" + "\n"
-        sock.puts(auth)
-        data = sock.recv(1024)
+        auth = "AUTH foobared\r\n"
+        sock.put(auth)
+        data = sock.get_once
         print_status("Response: #{data.chop}")
         if data =~ /\-ERR\sinvalid\spassword/
           print_status("Redis server is using AUTH")


### PR DESCRIPTION
According to the documentation of the protocol http://redis.io/topics/protocol

"A client connects to a Redis server creating a TCP connection to the port 6379. Every Redis command or data transmitted by the client and the server is terminated by \r\n (CRLF)."

This pull request jus fix the module:

```
msf > use auxiliary/scanner/misc/redis_server
msf auxiliary(redis_server) > set RHOSTS X.X.X.X
RHOSTS => X.X.X.X
msf auxiliary(redis_server) > run

[*] Scanning IP: X.X.X.X
[*] Redis Server Information $1071
redis_version:2.4.11
redis_git_sha1:00000000
redis_git_dirty:0
```
