### PR TITLE
Allow meterpreter sessions to resolve L3 address

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -317,7 +317,8 @@ class Meterpreter < Rex::Post::Meterpreter::Client
           # Take best guess at L3 using the peer address. This does not
           # address the problems posed by 6to4/4to6 translation.
           if Rex::Socket.is_ipv4?(shost)
-            routes.select { |r| r.subnet == "0.0.0.0" }.each do |r|
+            routes.each do |r|
+              next unless r.subnet == "0.0.0.0"
               ifaces.each do |iface|
                 if iface.index == r.interface
                   nhost = iface.ip
@@ -343,8 +344,8 @@ class Meterpreter < Rex::Post::Meterpreter::Client
             if iface.length > 0
               # One last shot at L3 propriety
               nhost = iface.find { |i| 
-                ( Rex::Socket.is_ipv4?(shost) and Rex::Socket.is_ipv4?(ip) ) or
-                ( Rex::Socket.is_ipv6?(shost) and Rex::Socket.is_ipv6?(ip) )
+                ( Rex::Socket.is_ipv4?(shost) and Rex::Socket.is_ipv4?(i.ip) ) or
+                ( Rex::Socket.is_ipv6?(shost) and Rex::Socket.is_ipv6?(i.ip) )
               }.ip
               nhost ||= iface.first.ip
             end

--- a/lib/rex/post/meterpreter/extensions/stdapi/net/config.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/net/config.rb
@@ -186,14 +186,15 @@ class Config
 
     # Build out the array of routes
     # Note: This will include both IPv4 and IPv6 routes
-    response.each(TLV_TYPE_NETWORK_ROUTE) { |route|
+    response.each(TLV_TYPE_NETWORK_ROUTE) do |route|
       routes << Route.new(
-          route.get_tlv_value(TLV_TYPE_SUBNET),
-          route.get_tlv_value(TLV_TYPE_NETMASK),
-          route.get_tlv_value(TLV_TYPE_GATEWAY),
-          route.get_tlv_value(TLV_TYPE_STRING),
-          route.get_tlv_value(TLV_TYPE_ROUTE_METRIC))
-    }
+        route.get_tlv_value(TLV_TYPE_SUBNET),
+        route.get_tlv_value(TLV_TYPE_NETMASK),
+        route.get_tlv_value(TLV_TYPE_GATEWAY),
+        route.get_tlv_value(TLV_TYPE_STRING),
+        route.get_tlv_value(TLV_TYPE_ROUTE_METRIC)
+      )
+    end
 
     return routes
   end


### PR DESCRIPTION
With stdapi now resolving IPv6 for interfaces, remote hosts behind
NAT are often returning an IPv6 session_host  due to it coming up
first in the available interfaces list.

Filter out available default routes based on the peer's IP address.
This does not address 6to4/4to6 tunnels, but should resolve the
issue with most sessions.
