### PR TITLE
Re-do 'exe-small' for scripting payloads.

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1604,14 +1604,14 @@ def self.to_vba(framework,code,opts={})
 
     case fmt
     when 'asp'
-      exe = to_executable_fmt(framework, arch, plat, code, 'exe', exeopts)
+      exe = to_executable_fmt(framework, arch, plat, code, 'exe-small', exeopts)
       output = Msf::Util::EXE.to_exe_asp(exe, exeopts)
 
     when 'aspx'
         output = Msf::Util::EXE.to_mem_aspx(framework, code, exeopts)
 
     when 'aspx-exe'
-      exe = to_executable_fmt(framework, arch, plat, code, 'exe', exeopts)
+      exe = to_executable_fmt(framework, arch, plat, code, 'exe-small', exeopts)
       output = Msf::Util::EXE.to_exe_aspx(exe, exeopts)
 
     when 'dll'
@@ -1620,6 +1620,7 @@ def self.to_vba(framework,code,opts={})
         when ARCH_X86_64  then to_win64pe_dll(framework, code, exeopts)
         when ARCH_X64     then to_win64pe_dll(framework, code, exeopts)
         end
+
     when 'exe'
       output = case arch
         when ARCH_X86,nil then to_win32pe(framework, code, exeopts)
@@ -1637,6 +1638,7 @@ def self.to_vba(framework,code,opts={})
     when 'exe-small'
       output = case arch
         when ARCH_X86,nil then to_win32pe_old(framework, code, exeopts)
+        when ARCH_X86_64,ARCH_X64 then to_win64pe(framework, code, exeopts)
         end
 
     when 'exe-only'
@@ -1698,15 +1700,15 @@ def self.to_vba(framework,code,opts={})
       output = Msf::Util::EXE.to_vba(framework, code, exeopts)
 
     when 'vba-exe'
-      exe = to_executable_fmt(framework, arch, plat, code, 'exe', exeopts)
+      exe = to_executable_fmt(framework, arch, plat, code, 'exe-small', exeopts)
       output = Msf::Util::EXE.to_exe_vba(exe)
 
     when 'vbs'
-      exe = to_executable_fmt(framework, arch, plat, code, 'exe', exeopts)
+      exe = to_executable_fmt(framework, arch, plat, code, 'exe-small', exeopts)
       output = Msf::Util::EXE.to_exe_vbs(exe, exeopts.merge({ :persist => false }))
 
     when 'loop-vbs'
-      exe = exe = to_executable_fmt(framework, arch, plat, code, 'exe', exeopts)
+      exe = exe = to_executable_fmt(framework, arch, plat, code, 'exe-small', exeopts)
       output = Msf::Util::EXE.to_exe_vbs(exe, exeopts.merge({ :persist => true }))
 
     when 'war'


### PR DESCRIPTION
Fall back to default x64 exe for ARCH_X86_64 (this is pretty small anyway)
