### PR TITLE
Fix x64 dll/service creation

### DIFF
--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -98,7 +98,10 @@ opts[:arch].index(ARCH_X86_64))
     pl = opts[:code]
     pl ||= payload.encoded
 
-    if opts[:arch] and (opts[:arch] == ARCH_X64 or opts[:arch] == ARCH_X86_64)
+    #Ensure opts[:arch] is an array
+    opts[:arch] = [opts[:arch]] unless opts[:arch].kindof? Array
+
+    if opts[:arch] and (opts[:arch].index(ARCH_X64) or opts[:arch].index(ARCH_X86_64))
       dll = Msf::Util::EXE.to_win64pe_dll(framework, pl, opts)
     else
       dll = Msf::Util::EXE.to_win32pe_dll(framework, pl, opts)

--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -76,7 +76,7 @@ module Exploit::EXE
     pl ||= payload.encoded
 
     #Ensure opts[:arch] is an array
-    opts[:arch] = [opts[:arch]] unless opts[:arch].kindof? Array
+    opts[:arch] = [opts[:arch]] unless opts[:arch].kind_of? Array
 
     if opts[:arch] and (opts[:arch].index(ARCH_X64) or
 opts[:arch].index(ARCH_X86_64))
@@ -99,7 +99,7 @@ opts[:arch].index(ARCH_X86_64))
     pl ||= payload.encoded
 
     #Ensure opts[:arch] is an array
-    opts[:arch] = [opts[:arch]] unless opts[:arch].kindof? Array
+    opts[:arch] = [opts[:arch]] unless opts[:arch].kind_of? Array
 
     if opts[:arch] and (opts[:arch].index(ARCH_X64) or opts[:arch].index(ARCH_X86_64))
       dll = Msf::Util::EXE.to_win64pe_dll(framework, pl, opts)

--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -75,7 +75,11 @@ module Exploit::EXE
     pl = opts[:code]
     pl ||= payload.encoded
 
-    if opts[:arch] and (opts[:arch] == ARCH_X64 or opts[:arch] == ARCH_X86_64)
+    #Ensure opts[:arch] is an array
+    opts[:arch] = [opts[:arch]] unless opts[:arch].kindof? Array
+
+    if opts[:arch] and (opts[:arch].index(ARCH_X64) or
+opts[:arch].index(ARCH_X86_64))
       exe = Msf::Util::EXE.to_win64pe_service(framework, pl, opts)
     else
       exe = Msf::Util::EXE.to_win32pe_service(framework, pl, opts)

--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -78,8 +78,7 @@ module Exploit::EXE
     #Ensure opts[:arch] is an array
     opts[:arch] = [opts[:arch]] unless opts[:arch].kind_of? Array
 
-    if opts[:arch] and (opts[:arch].index(ARCH_X64) or
-opts[:arch].index(ARCH_X86_64))
+    if opts[:arch] and (opts[:arch].index(ARCH_X64) or opts[:arch].index(ARCH_X86_64))
       exe = Msf::Util::EXE.to_win64pe_service(framework, pl, opts)
     else
       exe = Msf::Util::EXE.to_win32pe_service(framework, pl, opts)

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1604,14 +1604,14 @@ def self.to_vba(framework,code,opts={})
 
     case fmt
     when 'asp'
-      exe = to_executable_fmt(framework, arch, plat, code, 'exe', exeopts)
+      exe = to_executable_fmt(framework, arch, plat, code, 'exe-small', exeopts)
       output = Msf::Util::EXE.to_exe_asp(exe, exeopts)
 
     when 'aspx'
         output = Msf::Util::EXE.to_mem_aspx(framework, code, exeopts)
 
     when 'aspx-exe'
-      exe = to_executable_fmt(framework, arch, plat, code, 'exe', exeopts)
+      exe = to_executable_fmt(framework, arch, plat, code, 'exe-small', exeopts)
       output = Msf::Util::EXE.to_exe_aspx(exe, exeopts)
 
     when 'dll'
@@ -1620,6 +1620,7 @@ def self.to_vba(framework,code,opts={})
         when ARCH_X86_64  then to_win64pe_dll(framework, code, exeopts)
         when ARCH_X64     then to_win64pe_dll(framework, code, exeopts)
         end
+
     when 'exe'
       output = case arch
         when ARCH_X86,nil then to_win32pe(framework, code, exeopts)
@@ -1637,6 +1638,7 @@ def self.to_vba(framework,code,opts={})
     when 'exe-small'
       output = case arch
         when ARCH_X86,nil then to_win32pe_old(framework, code, exeopts)
+        when ARCH_X86_64,ARCH_X64 then to_win64pe(framework, code, exeopts)
         end
 
     when 'exe-only'
@@ -1698,15 +1700,15 @@ def self.to_vba(framework,code,opts={})
       output = Msf::Util::EXE.to_vba(framework, code, exeopts)
 
     when 'vba-exe'
-      exe = to_executable_fmt(framework, arch, plat, code, 'exe', exeopts)
+      exe = to_executable_fmt(framework, arch, plat, code, 'exe-small', exeopts)
       output = Msf::Util::EXE.to_exe_vba(exe)
 
     when 'vbs'
-      exe = to_executable_fmt(framework, arch, plat, code, 'exe', exeopts)
+      exe = to_executable_fmt(framework, arch, plat, code, 'exe-small', exeopts)
       output = Msf::Util::EXE.to_exe_vbs(exe, exeopts.merge({ :persist => false }))
 
     when 'loop-vbs'
-      exe = exe = to_executable_fmt(framework, arch, plat, code, 'exe', exeopts)
+      exe = exe = to_executable_fmt(framework, arch, plat, code, 'exe-small', exeopts)
       output = Msf::Util::EXE.to_exe_vbs(exe, exeopts.merge({ :persist => true }))
 
     when 'war'


### PR DESCRIPTION
Redo @todb-r7 Exploit::EXE fixes without additional baggage:

Using the spec https://github.com/todb-r7/metasploit-framework/blob/46d5cfc58cfcbc258cd9ce78a9322743836ca181/spec/lib/msf/core/exploit/exe_spec.rb we get the following results:

```
Msf::Exploit::EXE ..*....

Pending:
  Msf::Exploit::EXE can generate a 32-bit/64-bit payload exe
    # Need to figure out how to build the opts right (SeeRM #8367)
    # ./spec/lib/msf/core/exploit/exe_spec.rb:26

Finished in 3.01 seconds
7 examples, 0 failures, 1 pending

Coverage report generated for RSpec to /root/git/metasploit-framework/coverage. 14535 / 95710 LOC (15.19%) covered.
```
