### PR TITLE
Fix x64 dll/service creation

### DIFF
--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -75,7 +75,10 @@ module Exploit::EXE
     pl = opts[:code]
     pl ||= payload.encoded
 
-    if opts[:arch] and (opts[:arch] == ARCH_X64 or opts[:arch] == ARCH_X86_64)
+    #Ensure opts[:arch] is an array
+    opts[:arch] = [opts[:arch]] unless opts[:arch].kind_of? Array
+
+    if opts[:arch] and (opts[:arch].index(ARCH_X64) or opts[:arch].index(ARCH_X86_64))
       exe = Msf::Util::EXE.to_win64pe_service(framework, pl, opts)
     else
       exe = Msf::Util::EXE.to_win32pe_service(framework, pl, opts)
@@ -94,7 +97,10 @@ module Exploit::EXE
     pl = opts[:code]
     pl ||= payload.encoded
 
-    if opts[:arch] and (opts[:arch] == ARCH_X64 or opts[:arch] == ARCH_X86_64)
+    #Ensure opts[:arch] is an array
+    opts[:arch] = [opts[:arch]] unless opts[:arch].kind_of? Array
+
+    if opts[:arch] and (opts[:arch].index(ARCH_X64) or opts[:arch].index(ARCH_X86_64))
       dll = Msf::Util::EXE.to_win64pe_dll(framework, pl, opts)
     else
       dll = Msf::Util::EXE.to_win32pe_dll(framework, pl, opts)


### PR DESCRIPTION
Redo @todb-r7 Exploit::EXE fixes without additional baggage:

Using the spec https://github.com/todb-r7/metasploit-framework/blob/46d5cfc58cfcbc258cd9ce78a9322743836ca181/spec/lib/msf/core/exploit/exe_spec.rb we get the following results:

```
Msf::Exploit::EXE ..*....

Pending:
  Msf::Exploit::EXE can generate a 32-bit/64-bit payload exe
    # Need to figure out how to build the opts right (SeeRM #8367)
    # ./spec/lib/msf/core/exploit/exe_spec.rb:26

Finished in 3.01 seconds
7 examples, 0 failures, 1 pending

Coverage report generated for RSpec to /root/git/metasploit-framework/coverage. 14535 / 95710 LOC (15.19%) covered.
```
