### PR TITLE
Payload defaults

### DIFF
--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -133,8 +133,10 @@ protected
 
     # Prefer the target's platform/architecture information, but use
     # the module's if no target specific information exists
+    opts[:platform] ||= payload_instance.platform if self.respond_to? payload_instance
     opts[:platform] ||= target_platform  if self.respond_to? :target_platform
     opts[:platform] ||= platform         if self.respond_to? :platform
+    opts[:arch] ||= payload_instance.arch if self.respond_to? :payload_instance
     opts[:arch] ||= target_arch          if self.respond_to? :target_arch
     opts[:arch] ||= arch                 if self.respond_to? :arch
   end

--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -133,7 +133,8 @@ protected
 
     # Prefer the target's platform/architecture information, but use
     # the module's if no target specific information exists
-    opts[:platform] ||= payload_instance.platform if self.respond_to? payload_instance
+    puts "here!"
+    opts[:platform] ||= payload_instance.platform if self.respond_to? :payload_instance
     opts[:platform] ||= target_platform  if self.respond_to? :target_platform
     opts[:platform] ||= platform         if self.respond_to? :platform
     opts[:arch] ||= payload_instance.arch if self.respond_to? :payload_instance

--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -133,7 +133,6 @@ protected
 
     # Prefer the target's platform/architecture information, but use
     # the module's if no target specific information exists
-    puts "here!"
     opts[:platform] ||= payload_instance.platform if self.respond_to? :payload_instance
     opts[:platform] ||= target_platform  if self.respond_to? :target_platform
     opts[:platform] ||= platform         if self.respond_to? :platform


### PR DESCRIPTION
We don't care what people have set as their target, as they can always choose a payload that doesn't match the target.

E.g. it is easy to `set payload windows/x64/meterpreter/reverse_tcp` without bothering to change the target from x86 -> x64.

Payloads will NEVER work if they are embedded in the wrong architecture exe/dll but modules MAY work if the payload doesn't match the target. Therefore we should always use the PAYLOAD to determine default arch/platform if possible. 
