### PR TITLE
added 2 new output types for msfencode: num and dword

### DIFF
--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -64,7 +64,7 @@ module Buffer
     case fmt
       when 'raw'
       when 'num', 'dword', 'dw'
-        buf = Rex::Text.to_num_comment(buf)
+        buf = Rex::Text.to_js_comment(buf)
       when 'ruby', 'rb', 'python', 'py'
         buf = Rex::Text.to_ruby_comment(buf)
       when 'perl', 'pl'

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -90,22 +90,29 @@ module Buffer
   # Returns the list of supported formats
   #
   def self.transform_formats
-    ['raw',
-    'num',
-    'dword','dw',
-    'ruby','rb',
-    'perl','pl',
-    'bash','sh',
-    'c',
-    'csharp',
-    'js_be',
-    'js_le',
-    'java',
-    'python','py',
-    'powershell','ps1',
-    'vbscript',
-    'vbapplication'
-    ].sort
+    [
+      'bash',
+      'c',
+      'csharp',
+      'dw',
+      'dword',
+      'java',
+      'js_be',
+      'js_le',
+      'num',
+      'perl',
+      'pl',
+      'powershell',
+      'ps1',
+      'py',
+      'python',
+      'raw',
+      'rb',
+      'ruby',
+      'sh',
+      'vbapplication',
+      'vbscript'
+    ]
   end
 
 end

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -105,7 +105,7 @@ module Buffer
     'powershell','ps1',
     'vbscript',
     'vbapplication'
-    ]
+    ].sort
   end
 
 end

--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -16,11 +16,15 @@ module Buffer
 
   #
   # Serializes a buffer to a provided format.  The formats supported are raw,
-  # ruby, perl, bash, c, js_be, js_le, java and psh
+  # num, dword, ruby, python, perl, bash, c, js_be, js_le, java and psh
   #
   def self.transform(buf, fmt = "ruby")
     case fmt
       when 'raw'
+      when 'num'
+        buf = Rex::Text.to_num(buf)
+      when 'dword', 'dw'
+        buf = Rex::Text.to_dword(buf)
       when 'python', 'py'
         buf = Rex::Text.to_python(buf)
       when 'ruby', 'rb'
@@ -54,11 +58,13 @@ module Buffer
 
   #
   # Creates a comment using the supplied format.  The formats supported are
-  # raw, ruby, perl, bash, js_be, js_le, c, and java.
+  # raw, ruby, python, perl, bash, js_be, js_le, c, and java.
   #
   def self.comment(buf, fmt = "ruby")
     case fmt
       when 'raw'
+      when 'num', 'dword', 'dw'
+        buf = Rex::Text.to_num_comment(buf)
       when 'ruby', 'rb', 'python', 'py'
         buf = Rex::Text.to_ruby_comment(buf)
       when 'perl', 'pl'
@@ -85,6 +91,8 @@ module Buffer
   #
   def self.transform_formats
     ['raw',
+    'num',
+    'dword','dw',
     'ruby','rb',
     'perl','pl',
     'bash','sh',

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1729,9 +1729,26 @@ def self.to_vba(framework,code,opts={})
 
   def self.to_executable_fmt_formats
     [
-      'dll','exe','exe-service','exe-small','exe-only','elf','macho','vba','vba-exe',
-      'vbs','loop-vbs','asp','aspx', 'aspx-exe','war','psh','psh-net', 'msi', 'msi-nouac'
-    ].sort
+      "asp",
+      "aspx",
+      "aspx-exe",
+      "dll",
+      "elf",
+      "exe",
+      "exe-only",
+      "exe-service",
+      "exe-small",
+      "loop-vbs",
+      "macho",
+      "msi",
+      "msi-nouac",
+      "psh",
+      "psh-net",
+      "vba",
+      "vba-exe",
+      "vbs",
+      "war"
+    ]
   end
 
   #

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1731,7 +1731,7 @@ def self.to_vba(framework,code,opts={})
     [
       'dll','exe','exe-service','exe-small','exe-only','elf','macho','vba','vba-exe',
       'vbs','loop-vbs','asp','aspx', 'aspx-exe','war','psh','psh-net', 'msi', 'msi-nouac'
-    ]
+    ].sort
   end
 
   #

--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -116,6 +116,52 @@ module Text
   end
 
   #
+  # Creates a comma separated list of numbers
+  #
+  def self.to_num(str, wrap = DefaultWrap)
+    code = str.unpack('C*')
+    buff = ""
+    0.upto(code.length-1) do |byte|
+      if(byte % 15 == 0) and (buff.length > 0)
+        buff << "\r\n"
+      end
+      buff << sprintf('0x%.2x, ', code[byte])
+    end
+    # strip , at the end
+    buff = buff.chomp(', ')
+    buff << "\r\n"
+    return buff
+  end
+
+  #
+  # Creates a comma separated list of dwords
+  #
+  def self.to_dword(str, wrap = DefaultWrap)
+    code = str
+    alignnr = str.length % 4
+    if (alignnr > 0)
+      code << "\x00" * (4 - alignnr)
+    end
+    codevalues = Array.new
+    code.split("").each_slice(4) do |chars4|
+      chars4 = chars4.join("")
+      dwordvalue = chars4.unpack('*V')
+      codevalues.push(dwordvalue[0])
+    end
+    buff = ""
+    0.upto(codevalues.length-1) do |byte|
+      if(byte % 8 == 0) and (buff.length > 0)
+        buff << "\r\n"
+      end
+      buff << sprintf('0x%.8x, ', codevalues[byte])
+    end
+     # strip , at the end
+    buff = buff.chomp(', ')
+    buff << "\r\n"
+    return buff
+  end
+
+  #
   # Creates a ruby-style comment
   #
   def self.to_ruby_comment(str, wrap = DefaultWrap)

--- a/msfvenom
+++ b/msfvenom
@@ -147,9 +147,9 @@ class MsfVenom
     opt.on_tail('--help-formats', String, "List available formats") do
       init_framework(:module_types => [])
       msg = "Executable formats\n" +
-            "\t" + ::Msf::Util::EXE.to_executable_fmt_formats.join(", ") + "\n" +
+            "\t" + ::Msf::Util::EXE.to_executable_fmt_formats.sort.join(", ") + "\n" +
             "Transform formats\n" +
-            "\t" + ::Msf::Simple::Buffer.transform_formats.join(", ")
+            "\t" + ::Msf::Simple::Buffer.transform_formats.sort.join(", ")
       raise UsageError, msg
     end
 

--- a/msfvenom
+++ b/msfvenom
@@ -147,9 +147,9 @@ class MsfVenom
     opt.on_tail('--help-formats', String, "List available formats") do
       init_framework(:module_types => [])
       msg = "Executable formats\n" +
-            "\t" + ::Msf::Util::EXE.to_executable_fmt_formats.sort.join(", ") + "\n" +
+            "\t" + ::Msf::Util::EXE.to_executable_fmt_formats.join(", ") + "\n" +
             "Transform formats\n" +
-            "\t" + ::Msf::Simple::Buffer.transform_formats.sort.join(", ")
+            "\t" + ::Msf::Simple::Buffer.transform_formats.join(", ")
       raise UsageError, msg
     end
 


### PR DESCRIPTION
This PR adds 2 new output types:
- num : spits out payload in a comma separated list of bytes
- dword : spits out payload in a comma separated list of dwords
