### PR TITLE
Avoid crashing when msftidy'ing missing files

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -481,10 +481,14 @@ if dirs.length < 1
 end
 
 dirs.each do |dir|
-  Find.find(dir) do |full_filepath|
-    next if full_filepath =~ /\.git[\x5c\x2f]/
-    next unless File.file? full_filepath
-    next unless full_filepath =~ /\.rb$/
-    run_checks(full_filepath)
+  begin
+    Find.find(dir) do |full_filepath|
+      next if full_filepath =~ /\.git[\x5c\x2f]/
+      next unless File.file? full_filepath
+      next unless full_filepath =~ /\.rb$/
+      run_checks(full_filepath)
+    end
+  rescue Errno::ENOENT
+    $stderr.puts "#{File.basename(__FILE__)}: #{dir}: No such file or directory"
   end
 end


### PR DESCRIPTION
While testing if `@source` would ever be `nil` (good catch, @todb-r7), a more obvious bug appeared.

```
wvu@kharak:~/metasploit-framework$ tools/msftidy.rb nope modules/exploits/{aix,hpux,irix}
/home/wvu/.rvm/rubies/ruby-1.9.3-p448/lib/ruby/1.9.1/find.rb:38:in `block in find': No such file or directory (Errno::ENOENT)
        from /home/wvu/.rvm/rubies/ruby-1.9.3-p448/lib/ruby/1.9.1/find.rb:38:in `collect!'
        from /home/wvu/.rvm/rubies/ruby-1.9.3-p448/lib/ruby/1.9.1/find.rb:38:in `find'
        from tools/msftidy.rb:484:in `block in <main>'
        from tools/msftidy.rb:483:in `each'
        from tools/msftidy.rb:483:in `<main>'
wvu@kharak:~/metasploit-framework$ 
```

vs.

```
wvu@kharak:~/metasploit-framework$ tools/msftidy.rb nope modules/exploits/{aix,hpux,irix}
msftidy.rb: nope: No such file or directory
modules/exploits/aix/rpc_cmsd_opcode21.rb:76 - [ERROR] datastore is modified in code: "      datastore['AIX'] = target['AIX']\n"
modules/exploits/aix/rpc_ttdbserverd_realpath.rb:240 - [ERROR] datastore is modified in code: "      datastore['AIX'] = target['AIX']\n"
modules/exploits/irix/lpd/tagprinter_exec.rb - [WARNING] Suspect capitalization in module title: 'tagprinter'
wvu@kharak:~/metasploit-framework$ 
```
