### PR TITLE
Fix stdout/stderr check to avoid ruby payloads

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -424,8 +424,8 @@ class Msftidy
       # The rest of these only count if it's not a comment line
       next if ln =~ /[[:space:]]*#/
 
-      if ln =~ /(\$std(?:out|err))/i or ln =~ /[[:space:]]puts/
-        next if ln =~ /^[\s]*[\x22\x27][^\x22\x27]+\$std(?:out|err)/
+      if ln =~ /\$std(?:out|err)/i or ln =~ /[[:space:]]puts/
+        next if ln =~ /^[\s]*["][^"]+\$std(?:out|err)/
         no_stdio = false
         error("Writes to stdout", idx)
       end

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -424,7 +424,7 @@ class Msftidy
       # The rest of these only count if it's not a comment line
       next if ln =~ /[[:space:]]*#/
 
-      if ln =~ /\$std(?:out|err)/i or ln =~ /[[:space:]]puts/
+      if ln =~ /\$[^"']std(?:out|err)/i or ln =~ /[[:space:]]puts/
         no_stdio = false
         error("Writes to stdout", idx)
       end

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -424,7 +424,8 @@ class Msftidy
       # The rest of these only count if it's not a comment line
       next if ln =~ /[[:space:]]*#/
 
-      if ln =~ /\$[^"']std(?:out|err)/i or ln =~ /[[:space:]]puts/
+      if ln =~ /(\$std(?:out|err))/i or ln =~ /[[:space:]]puts/
+        next if ln =~ /^[\s]*[\x22\x27][^\x22\x27]+\$std(?:out|err)/
         no_stdio = false
         error("Writes to stdout", idx)
       end


### PR DESCRIPTION
SeeRM: https://dev.metasploit.com/redmine/issues/8498

This knocks out all the non-datastore editing ERROR messages, so we've got that going for us. Which is nice.

cc @wvu-r7 I couldn't resist playing along too...
