### PR TITLE
Fix target name on desktopcentral_file_upload

### DIFF
--- a/modules/exploits/windows/http/desktopcentral_file_upload.rb
+++ b/modules/exploits/windows/http/desktopcentral_file_upload.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Arch'           => ARCH_X86,
       'Targets'        =>
         [
-          [ 'Manage Desktop Central 8 server / Windows', {} ]
+          [ 'ManageEngine DesktopCentral 8 server / Windows', {} ]
         ],
       'Privileged'     => true,
       'DefaultTarget'  => 0,


### PR DESCRIPTION
The original author, @pnegry , warned which the target name was wrong, sorry, may fault while cleaning the module :)

It should fix! 
