### PR TITLE
DB_ALL_CREDS should be disabled by default

### DIFF
--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -22,7 +22,7 @@ module Auxiliary::AuthBrute
       OptBool.new('VERBOSE', [ true, "Whether to print output for all attempts", true]),
       OptBool.new('BLANK_PASSWORDS', [ false, "Try blank passwords for all users", true]),
       OptBool.new('USER_AS_PASS', [ false, "Try the username as the password for all users", true]),
-      OptBool.new('DB_ALL_CREDS', [false,"Try each user/password couple stored in the current database",true]),
+      OptBool.new('DB_ALL_CREDS', [false,"Try each user/password couple stored in the current database",false]),
       OptBool.new('DB_ALL_USERS', [false,"Add all users in the current database to the list",false]),
       OptBool.new('DB_ALL_PASS', [false,"Add all passwords in the current database to the list",false]),
       OptBool.new('STOP_ON_SUCCESS', [ true, "Stop guessing when a credential works for a host", false]),


### PR DESCRIPTION
Apparently, people hate this. See:

https://twitter.com/f8lerror/status/403991959959642112

Man, I wish we had a bug tracker so people wouldn't have to complain on Twitter... oh wait, we do!

Fixes http://dev.metasploit.com/redmine/issues/8699
