### PR TITLE
PSEXEC Refactor  [FixRM #8690]

### DIFF
--- a/lib/msf/core/exploit/smb/psexec.rb
+++ b/lib/msf/core/exploit/smb/psexec.rb
@@ -72,7 +72,6 @@ module Exploit::Remote::SMB::Psexec
     end
     servicename = Rex::Text.rand_text_alpha(11)
     displayname = Rex::Text.rand_text_alpha(16)
-    holdhandle = scm_handle
     svc_handle = nil
     svc_status = nil
     stubdata =
@@ -93,29 +92,14 @@ module Exploit::Remote::SMB::Psexec
       vprint_status("#{peer} - Creating the service...")
       response = dcerpc.call(0x0c, stubdata)
       if dcerpc.last_response != nil and dcerpc.last_response.stub_data != nil
-        svc_handle = dcerpc.last_response.stub_data[0,20]
+        svc_handle = dcerpc.last_response.stub_data[4,20]
         svc_status = dcerpc.last_response.stub_data[24,4]
       end
     rescue ::Exception => e
       print_error("#{peer} - Error creating service: #{e}")
       return false
     end
-    vprint_status("#{peer} - Closing service handle...")
-    begin
-      response = dcerpc.call(0x0, svc_handle)
-    rescue ::Exception
-    end
-    vprint_status("#{peer} - Opening service...")
-    begin
-      stubdata = scm_handle + NDR.wstring(servicename) + NDR.long(0xF01FF)
-      response = dcerpc.call(0x10, stubdata)
-      if dcerpc.last_response != nil and dcerpc.last_response.stub_data != nil
-        svc_handle = dcerpc.last_response.stub_data[0,20]
-      end
-    rescue ::Exception => e
-      print_error("#{peer} - Error opening service: #{e}")
-      return false
-    end
+
     vprint_status("#{peer} - Starting the service...")
     stubdata = svc_handle + NDR.long(0) + NDR.long(0)
     begin


### PR DESCRIPTION
The PSEXEC module doesn't use the PSEXEC mixin. Nor does psexec_loggedinusers.

Fixes an issue where NTLM::UseNTLMv2 wasn't being set for some modules (it defaults to True when its mixed in properly, but is nil if not) often causing login failures on later OS's

~~N.B. This doesn't fix anything to do with RM8698 or 8690. Need to investigate why they dont get shown by chained includes but setting them works:~~
## Verification
- [x] PSEXEC modules show the correct options and advanced options (e.g. NTLM)
- [ ] PSEXEC versus x86
- [x] PSEXEC versus x64 (nb this may not work until https://github.com/rapid7/metasploit-framework/pull/2661)
- [x] auxiliary/admin/smb/psexec_command still works
- [x] auxiliary/admin/smb/psexec_ntdsgrab still works
- [x] auxiliary/scanner/smb/psexec_loggedinusers still works
- [x] exploit/windows/smb/psexec_psh still works
