### PR TITLE
Add function to check if reg key exists

### DIFF
--- a/lib/msf/core/post/windows/registry.rb
+++ b/lib/msf/core/post/windows/registry.rb
@@ -15,9 +15,9 @@ module Registry
   #
   def registry_loadkey(key,file)
     if session_has_registry_ext
-      retval=meterpreter_registry_loadkey(key,file)
+      retval = meterpreter_registry_loadkey(key,file)
     else
-      retval=shell_registry_loadkey(key,file)
+      retval = shell_registry_loadkey(key,file)
     end
     return retval
   end
@@ -27,11 +27,28 @@ module Registry
   #
   def registry_unloadkey(key)
     if session_has_registry_ext
-      retval=meterpreter_registry_unloadkey(key)
+      retval = meterpreter_registry_unloadkey(key)
     else
-      retval=shell_registry_unloadkey(key)
+      retval = shell_registry_unloadkey(key)
     end
     return retval
+  end
+
+  # Whether a remote key exists
+  #
+  # @example
+  #   registry_key_exist?("HKCU\\Environment") # => true
+  #   registry_key_exist?("HKEY_CURRENT_USER\\Environment") # => true
+  #   registry_key_exist?("HKLM\\Non\\Existent\\Key") # => false
+  #
+  # @param key [String] A registry key name including the root
+  def registry_key_exist?(key)
+    if session_has_registry_ext
+      return meterpreter_registry_key_exist?(key)
+    else
+      # XXX implement for shell
+      raise RuntimeError, "Unsupported session"
+    end
   end
 
   #
@@ -445,7 +462,7 @@ protected
   #
   # Check if a registry key exists
   #
-  def meterpreter_registry_checkkeyexists(key)
+  def meterpreter_registry_key_exist?(key)
     begin
       root_key, base_key = session.sys.registry.splitkey(key)
       return session.sys.registry.check_key_exists(root_key, base_key)

--- a/lib/msf/core/post/windows/registry.rb
+++ b/lib/msf/core/post/windows/registry.rb
@@ -443,6 +443,18 @@ protected
   end
 
   #
+  # Check if a registry key exists
+  #
+  def meterpreter_registry_checkkeyexists(key)
+    begin
+      root_key, base_key = session.sys.registry.splitkey(key)
+      return session.sys.registry.check_key_exists(root_key, base_key)
+    rescue Rex::Post::Meterpreter::RequestError => e
+      return nil
+    end
+  end
+
+  #
   # Create a new registry key
   #
   def meterpreter_registry_createkey(key)

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/registry.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/registry.rb
@@ -34,6 +34,15 @@ class Registry
   #
   ##
 
+  def Registry.check_key_exists(root_key, base_key)
+    request = Packet.create_request('stdapi_registry_check_key_exists')
+    request.add_tlv(TLV_TYPE_ROOT_KEY, root_key)
+    request.add_tlv(TLV_TYPE_BASE_KEY, base_key)
+
+    response = client.send_request(request)
+    return response.get_tlv(TLV_TYPE_BOOL).value
+  end
+
   #
   # Opens the supplied registry key relative to the root key with
   # the supplied permissions.  Right now this is merely a wrapper around

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/registry_key.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/registry_key.rb
@@ -81,6 +81,13 @@ class RegistryKey
   ##
 
   #
+  # Checks to see if a registry key exists
+  #
+  def check_key_exists(base_key)
+    return self.client.sys.registry.check_key_exists(self.hkey, base_key)
+  end
+
+  #
   # Opens a registry key that is relative to this registry key.
   #
   def open_key(base_key, perm = KEY_READ)

--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/remote_registry_key.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/registry_subsystem/remote_registry_key.rb
@@ -80,6 +80,13 @@ class RemoteRegistryKey
   ##
 
   #
+  # Checks to see if a registry key exists
+  #
+  def check_key_exists(base_key)
+    return self.client.sys.registry.check_key_exists(self.hkey, base_key)
+  end
+
+  #
   # Opens a registry key that is relative to this registry key.
   #
   def open_key(base_key, perm = KEY_READ)

--- a/scripts/meterpreter/win32-sshserver.rb
+++ b/scripts/meterpreter/win32-sshserver.rb
@@ -223,13 +223,10 @@ end
 # Check for OpenSSH/Cygwin - Regkeys first and bail out if they exist
 #
 root_key, base_key = client.sys.registry.splitkey("HKLM\\Software\\Cygnus\ Solutions")
-open_key = client.sys.registry.open_key(root_key, base_key)
-keys = open_key.enum_key
-if ( keys.length > 0)
-  if not forced
-    print_error(warning)
-    raise Rex::Script::Completed
-  end
+key_exists = client.sys.registry.check_key_exists(root_key, base_key)
+if (!key_exists && !forced)
+  print_error(warning)
+  raise Rex::Script::Completed
 end
 
 #

--- a/test/modules/post/test/registry.rb
+++ b/test/modules/post/test/registry.rb
@@ -1,9 +1,7 @@
 
 ##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# Framework web site for more information on licensing and terms of use.
-# http://metasploit.com/framework/
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 require 'msf/core'
@@ -32,7 +30,7 @@ class Metasploit3 < Msf::Post
   end
 
   def test_0_registry_read
-    pending "should evaluate key existence" do
+    it "should evaluate key existence" do
       # these methods are not implemented
       k_exists = registry_key_exist?(%q#HKCU\Environment#)
       k_dne    = registry_key_exist?(%q#HKLM\\Non\Existent\Key#)


### PR DESCRIPTION
Added functionality which allows for users to check if a reg key exists without first having to open and enumerate keys. This wouldn't work anyway because opening keys that don't exist result in failures. This new functionality just returns a boolean to indicate if the key is present on the remote host.

Commit also fixes issue where the openssh server install script was failing, as per [RM 8283](https://dev.metasploit.com/redmine/issues/8283).

There is new Meterpreter functionality required to make this work, [PR here](https://github.com/rapid7/meterpreter/pull/55).

[SeeRM #8283]
