### PR TITLE
Increase duration timeout task manager

### DIFF
--- a/spec/lib/msf/core/task_manager_spec.rb
+++ b/spec/lib/msf/core/task_manager_spec.rb
@@ -78,7 +78,7 @@ describe Msf::TaskManager do
     t.wait
 
     t.status.should == :timeout
-    t.duration.should <= 1.0
+    t.duration.should <= 5.0
   end
 
   it "should handle task exceptions" do


### PR DESCRIPTION
Sometimes, Jenkins or Travis is slow, and can't hit that 1 second timeout. This increases to 5 seconds to account for local slowness.
## Verification
- [x] Run `rspec --format=d spec/lib/msf/core/task_manager_spec.rb`
- [x] See success on, 'should handle task timeouts'

If you can figure out how to simulate a slow machine, feel free to post here. I suppose you can do this on a VM with restricted resources, like low RAM, one proc, etc.
