### PR TITLE
Fix nokogiri typo

### DIFF
--- a/modules/exploits/windows/fileformat/mswin_tiff_overflow.rb
+++ b/modules/exploits/windows/fileformat/mswin_tiff_overflow.rb
@@ -5,7 +5,7 @@
 
 require 'msf/core'
 require 'rex/zip'
-require 'Nokogiri'
+require 'nokogiri'
 
 module ::Nokogiri
 module XML


### PR DESCRIPTION
There is no 'Nokogiri,' only 'nokogiri'

[SeeRM #8730]
