### PR TITLE
Add support for Silverlight

### DIFF
--- a/data/js/detect/misc_addons.js
+++ b/data/js/detect/misc_addons.js
@@ -1,5 +1,51 @@
 window.misc_addons_detect = { };
 
+
+/**
+ * Detects whether the browser supports Silverlight or not
+ **/
+window.misc_addons_detect.hasSilverlight = function () {
+	var found = false;
+
+	//
+	// When on IE, we can use AgControl.AgControl to actually detect the version too.
+	// But this ability is specific to IE, so we fall back to just true/false response
+	//
+	try {
+		var ax = new ActiveXObject('AgControl.AgControl');
+		found = true;
+	} catch(e) {}
+
+	//
+	// ActiveX didn't get anything, try looking in MIMEs
+	//
+	if (!found) {
+		var mimes = window.navigator.mimeTypes;
+		for (var i=0; i < mimes.length; i++) {
+			if (/x\-silverlight/.test(mimes[i].type)) {
+				found = true;
+				break;
+			}
+		}
+	}
+
+	//
+	// MIMEs didn't work either. Try navigator.
+	//
+	if (!found) {
+		var count = navigator.plugins.length;
+		for (var i=0; i < count; i++) {
+			var pluginName = navigator.plugins[i].name;
+			if (/Silverlight Plug\-In/.test(pluginName)) {
+				found = true;
+				break;
+			}
+		}
+	}
+
+	return found;
+}
+
 /**
  * Returns the Java version
  **/

--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -37,18 +37,19 @@ module Msf
 
     # Requirements a browser module can define in either BrowserRequirements or in targets
     REQUIREMENT_KEY_SET = {
-      :source    => 'source',    # Either 'script' or 'headers'
-      :ua_name   => 'ua_name',   # Example: MSIE
-      :ua_ver    => 'ua_ver',    # Example: 8.0, 9.0
-      :os_name   => 'os_name',   # Example: Microsoft Windows
-      :os_flavor => 'os_flavor', # Example: XP, 7
-      :language  => 'language',  # Example: en-us
-      :arch      => 'arch',      # Example: x86
-      :proxy     => 'proxy',     # 'true' or 'false'
-      :office    => 'office',    # Example: "2007", "2010"
-      :java      => 'java',      # Example: 1.6, 1.6.0.0
-      :clsid     => 'clsid',     # ActiveX clsid. Also requires the :method key
-      :method    => 'method'     # ActiveX method. Also requires the :clsid key
+      :source      => 'source',      # Either 'script' or 'headers'
+      :ua_name     => 'ua_name',     # Example: MSIE
+      :ua_ver      => 'ua_ver',      # Example: 8.0, 9.0
+      :os_name     => 'os_name',     # Example: Microsoft Windows
+      :os_flavor   => 'os_flavor',   # Example: XP, 7
+      :language    => 'language',    # Example: en-us
+      :arch        => 'arch',        # Example: x86
+      :proxy       => 'proxy',       # 'true' or 'false'
+      :silverlight => 'silverlight', # 'true' or 'false'
+      :office      => 'office',      # Example: "2007", "2010"
+      :java        => 'java',        # Example: 1.6, 1.6.0.0
+      :clsid       => 'clsid',       # ActiveX clsid. Also requires the :method key
+      :method      => 'method'       # ActiveX method. Also requires the :clsid key
     }
 
     def initialize(info={})
@@ -345,12 +346,13 @@ module Msf
       window.onload = function() {
         var osInfo = window.os_detect.getVersion();
         var d = {
-          "<%=REQUIREMENT_KEY_SET[:os_name]%>"   : osInfo.os_name,
-          "<%=REQUIREMENT_KEY_SET[:os_flavor]%>" : osInfo.os_flavor,
-          "<%=REQUIREMENT_KEY_SET[:ua_name]%>"   : osInfo.ua_name,
-          "<%=REQUIREMENT_KEY_SET[:ua_ver]%>"    : osInfo.ua_version,
-          "<%=REQUIREMENT_KEY_SET[:arch]%>"      : osInfo.arch,
-          "<%=REQUIREMENT_KEY_SET[:java]%>"      : window.misc_addons_detect.getJavaVersion()
+          "<%=REQUIREMENT_KEY_SET[:os_name]%>"     : osInfo.os_name,
+          "<%=REQUIREMENT_KEY_SET[:os_flavor]%>"   : osInfo.os_flavor,
+          "<%=REQUIREMENT_KEY_SET[:ua_name]%>"     : osInfo.ua_name,
+          "<%=REQUIREMENT_KEY_SET[:ua_ver]%>"      : osInfo.ua_version,
+          "<%=REQUIREMENT_KEY_SET[:arch]%>"        : osInfo.arch,
+          "<%=REQUIREMENT_KEY_SET[:java]%>"        : window.misc_addons_detect.getJavaVersion(),
+          "<%=REQUIREMENT_KEY_SET[:silverlight]%>" : window.misc_addons_detect.hasSilverlight()
         };
 
         <% if os == OperatingSystems::WINDOWS and client == HttpClients::IE %>

--- a/lib/rex/exploitation/js/detect.rb
+++ b/lib/rex/exploitation/js/detect.rb
@@ -54,6 +54,7 @@ class Detect
   # Provides javascript functions that work for all browsers to determine addon information
   #
   # getJavaVersion(): Returns the Java version
+  # hasSilverlight(): Returns whether Silverlight is enabled or not
   #
   def self.misc_addons(custom_js = '')
     js  = custom_js

--- a/modules/exploits/windows/browser/ms13_022_silverlight_script_object.rb
+++ b/modules/exploits/windows/browser/ms13_022_silverlight_script_object.rb
@@ -58,20 +58,21 @@ class Metasploit3 < Msf::Exploit::Remote
       'Arch'           => [ARCH_X86, ARCH_X86_64],
       'BrowserRequirements' =>
         {
-          :source  => /script|headers/i,
-          :os_name => Msf::OperatingSystems::WINDOWS,
-          :ua_name => Msf::HttpClients::IE
+          :source      => /script|headers/i,
+          :os_name     => Msf::OperatingSystems::WINDOWS,
+          :ua_name     => Msf::HttpClients::IE,
+          :silverlight => "true"
         },
       'Targets'        =>
         [
           [ 'Windows x86',
             {
-              'arch'      => ARCH_X86
+              'arch' => ARCH_X86
             }
           ],
           [ 'Windows x64',
             {
-              'arch'      => ARCH_X86_64
+              'arch' => ARCH_X86_64
             }
           ]
         ],

--- a/test/modules/exploits/test/browserexploitserver.rb
+++ b/test/modules/exploits/test/browserexploitserver.rb
@@ -96,7 +96,8 @@ class Metasploit3 < Msf::Exploit::Remote
     UA name: #{target_info[:ua_name]}<br>
     UA version: #{target_info[:ua_ver]}<br>
     Java version: #{target_info[:java]}<br>
-    Office version: #{target_info[:office]}
+    Office version: #{target_info[:office]}<br>
+    Silverlight enabled: #{target_info[:silverlight]}
     |
 
     return template, binding()
@@ -116,7 +117,8 @@ class Metasploit3 < Msf::Exploit::Remote
     UA name: #{target_info[:ua_name]}<br>
     UA version: #{target_info[:ua_ver]}<br>
     Java version: #{target_info[:java]}<br>
-    Office version: #{target_info[:office]}
+    Office version: #{target_info[:office]}<br>
+    Silverlight enabled: #{target_info[:silverlight]}
     |
   end
 


### PR DESCRIPTION
Add support for Silverlight exploitation. [SeeRM #8705]

I decided that the check is probably best just returning true or false, because you can only detect the version with ActiveX, and that's an IE thing. To support multiple browsers, the best you can do is detect if the plugin is installed or not. So when setting your browser exploitable requirements, make sure you do :silverlight => "true" or "false". Several files are updated, including the recent MS13-022 exploit.

I also tested the check against these setups:

Windows: IE 8/9, latest Safari, Mozilla Firefox, Opera, Google Chrome.
OS X: Safari, Firefox, Google Chrome.
