### PR TITLE
Tweak impl of add_process and add_channel

### DIFF
--- a/data/meterpreter/meterpreter.py
+++ b/data/meterpreter/meterpreter.py
@@ -212,16 +212,12 @@ class PythonMeterpreter(object):
 			self.register_function(func)
 
 	def add_channel(self, channel):
-		idx = 0
-		while idx in self.channels:
-			idx += 1
+		idx = len(self.channels)
 		self.channels[idx] = channel
 		return idx
 
 	def add_process(self, process):
-		idx = 0
-		while idx in self.processes:
-			idx += 1
+		idx = len(self.processes)
 		self.processes[idx] = process
 		return idx
 


### PR DESCRIPTION
These two functions were using an O(n) based approach to adding new processes and channels. This instead uses `len()`, which is O(1), to achieve the same thing. It's not a biggie, but it does make things ever-so-slightly quicker and ever-so-slightly more Pythony.
