### PR TITLE
Allow HttpClient to remember my cookie

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -92,6 +92,10 @@ module Exploit::Remote::HttpClient
     # Used by digest auth
     @cnonce = make_cnonce
     @nonce_count = -1
+
+    # Remember my cookies in this format:
+    # @cookies['127.0.0.1:80'] = 'value'
+    @cookies = {}
   end
 
 
@@ -254,6 +258,24 @@ module Exploit::Remote::HttpClient
   end
 
   #
+  # Saves the cookie, save the world
+  # @param req [Request]
+  #
+  def remember_cookie(req)
+    if req.headers['Set-Cookie']
+      @cookies[peer] = req.headers['Set-Cookie']
+    end
+  end
+
+  #
+  # Retreives the cookie info if found
+  #
+  def get_cookie
+    @cookies[peer]
+  end
+
+
+  #
   # Connects to the server, creates a request, sends the request, reads the response
   #
   # Passes +opts+ through directly to Rex::Proto::Http::Client#request_raw.
@@ -274,10 +296,17 @@ module Exploit::Remote::HttpClient
   # Passes +opts+ through directly to Rex::Proto::Http::Client#request_cgi.
   #
   def send_request_cgi(opts={}, timeout = 20)
+    last_cookie = get_cookie
+    if opts['cookie'].nil? and last_cookie
+      opts['cookie'] = last_cookie
+    end
+
     begin
       c = connect(opts)
       r = c.request_cgi(opts)
-      c.send_recv(r, opts[:timeout] ? opts[:timeout] : timeout)
+      res = c.send_recv(r, opts[:timeout] ? opts[:timeout] : timeout)
+      remember_cookie(res)
+      return res
     rescue ::Errno::EPIPE, ::Timeout::Error
       nil
     end

--- a/test/modules/auxiliary/test/cookie_test.rb
+++ b/test/modules/auxiliary/test/cookie_test.rb
@@ -1,0 +1,79 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'HttpClient Cookie Tester',
+      'Description'    => %q{C is for cookie},
+      'References'     =>
+        [
+          [ 'URL', 'http://metasploit.com' ],
+        ],
+      'Author'         => [ 'sinn3r' ],
+      'License'        => MSF_LICENSE,
+      'DisclosureDate' => "Nov 26 2013"
+    ))
+  end
+
+  #
+  # This tests against a single host
+  #
+  def test1
+    # This request doesn't have a cookie sent, so the server will set one for us
+    print_status("Sending a normal request")
+    res = send_request_cgi({'uri'=>'/'})
+
+    # This time will send a cookie from what the server gave us.
+    res = send_request_cgi({'uri'=>'/'})
+
+    # This time we've decided to be naughty. We modify the cookie and send it to the server
+    cookie = res.headers['cookie']
+    print_status("Original cookie: #{cookie.inspect}")
+    cookie = "JSESSIONID=MSFTEST; Path=/; HttpOnly"
+    print_status("Sending this cookie: #{cookie}")
+    send_request_cgi({
+      'uri'    => '/',
+      'cookie' => cookie
+    })
+  end
+
+  #
+  # This tests against multiple hosts
+  # We don't really recommend people to do something like this, but HttpClient is capable.
+  # Host A's cookie shouldn't be sent to Host B by the mixin.
+  #
+  def test2
+    print_status("Getting a cookie from host A")
+    res = send_request_cgi({'uri'=>'/'})
+
+    print_status("Getting a cookie from google.com")
+    datastore['RHOST'] = "74.125.30.101"
+    res = send_request_cgi({'uri'=>'/'})
+
+    print_status("Sending another HTTP request")
+    res = send_request_cgi({'uri'=>'/'})
+  end
+
+  def run
+    print_status("You'll need to run a traffic sniffer to verify this")
+
+    print_status("Testing against a single host")
+    test1
+
+    print_line
+    print_line
+    print_line
+
+    print_status("Testing against multiple hosts")
+    test2
+  end
+
+end


### PR DESCRIPTION
When the target host sets a cookie, the Httpclient should remember it. That way in the module I won't have to manually extract it, and then put it in the next request.

If some for reason the module decides to send to different hosts, the HttpClient mixin should know which one to use. Also, as you can see only send_request_cgi() uses this feature, I don't think send_request_raw should be using it because it's supposed to be the most basic form of send_request_*.

For testing, use test/modules/auxiliary/test/cookie_test.rb, and then you'll have to use wireshark to verify it's working properly. You can set the rhost to 208.118.237.137 if you want, that's metasploit.com.

[SeeRM #8706]
