### PR TITLE
Fix fail_with on Exploit::Remote::HttpClient

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -126,7 +126,7 @@ module Exploit::Remote::HttpClient
         opts[:pattern].each do |re|
           if not re.match(info)
             err = "The target server fingerprint \"#{info}\" does not match \"#{re.to_s}\", use 'set FingerprintCheck false' to disable this check."
-            fail_with(Failure::NotFound, err)
+            fail_with(::Msf::Module::Failure::NotFound, err)
           end
         end
       end


### PR DESCRIPTION
Verification
- [x] Run msfconsole WITH database support (the db support is important to repo)
- [x] Select a module which includes Msf::Exploit::Remote::HttpClient and sets the HttpFingerprint constant, I've used the exploit/multi/sap/sap_mgmt_con_osexec_payload exploit module
- [x] Run the module against a NON sap server, so the fingerprint fails. The module should fail with an ugly "Exploit failed: NameError uninitialized constant Msf::Exploit::Remote::HttpClient::Failure" message:

```
[*] Rebuilding the module cache in the background...
msf > use exploit/multi/sap/sap_mgmt_con_osexec_payload 
msf exploit(sap_mgmt_con_osexec_payload) > set rhost 192.168.172.135
rhost => 192.168.172.135
msf exploit(sap_mgmt_con_osexec_payload) > set rport 80
rport => 80
msf exploit(sap_mgmt_con_osexec_payload) > set rhost 192.168.172.133
rhost => 192.168.172.133
msf exploit(sap_mgmt_con_osexec_payload) > set username test
username => test
msf exploit(sap_mgmt_con_osexec_payload) > set PASSWORD test
PASSWORD => test
msf exploit(sap_mgmt_con_osexec_payload) > rexploit
[*] Reloading module...
[*] Exploit running as background job.
msf exploit(sap_mgmt_con_osexec_payload) > 
[-] Exploit failed: NameError uninitialized constant Msf::Exploit::Remote::HttpClient::Failure
```
- [x] Apply the patch
- [x] Run msfconsole WITH database support 
- [x] Select a module which includes Msf::Exploit::Remote::HttpClient and sets the HttpFingerprint constant, I've used the exploit/multi/sap/sap_mgmt_con_osexec_payload exploit module
- [x] Run the module against a NON sap server, so the fingerprint fails. The module should fail as expected this time (showing the fingerprint fail message):

```
[*] Rebuilding the module cache in the background...
msf > use exploit/multi/sap/sap_mgmt_con_osexec_payload 
msf exploit(sap_mgmt_con_osexec_payload) > set USERNAME test
USERNAME => test
msf exploit(sap_mgmt_con_osexec_payload) > set PASSWORD test
PASSWORD => test
msf exploit(sap_mgmt_con_osexec_payload) > set rhost 192.168.172.133
rhost => 192.168.172.133
msf exploit(sap_mgmt_con_osexec_payload) > set rport 80
rport => 80
msf exploit(sap_mgmt_con_osexec_payload) > rexploit
[*] Reloading module...
[*] Exploit running as background job.
msf exploit(sap_mgmt_con_osexec_payload) > 
[-] Exploit failed [not-found]: The target server fingerprint "Apache/2.2.14 (Ubuntu)" does not match "(?-mix:gSOAP\/2.7)", use 'set FingerprintCheck false' to disable this check.
```
