### PR TITLE
fix fail_with usage on Exploit::Remote::MSSQL_SQLI

### DIFF
--- a/lib/msf/core/exploit/mssql_sqli.rb
+++ b/lib/msf/core/exploit/mssql_sqli.rb
@@ -144,7 +144,7 @@ module Exploit::Remote::MSSQL_SQLI
     if (datastore['METHOD'] == 'GET')
 
       unless datastore['GET_PATH'].index("[SQLi]")
-        fail_with(Failure::NoTarget, "The SQL injection parameter was not specified in the GET path")
+        fail_with(::Msf::Module::Failure::NoTarget, "The SQL injection parameter was not specified in the GET path")
       end
 
       uri = datastore['GET_PATH'].gsub("[SQLi]", Rex::Text.uri_encode(sqla))
@@ -160,7 +160,7 @@ module Exploit::Remote::MSSQL_SQLI
     else
 
       unless datastore['DATA'].index("[SQLi]")
-        fail_with(Failure::NoTarget, "The SQL injection parameter was not specified in the POST data")
+        fail_with(::Msf::Module::Failure::NoTarget, "The SQL injection parameter was not specified in the POST data")
       end
 
       post_data = datastore['DATA'].gsub("[SQLi]", Rex::Text.uri_encode(sqla))


### PR DESCRIPTION
Same history than #2702

Verification: use exploit/windows/mssql/mssql_payload_sqli
- [x] Before patch: Error message "NameError uninitialized constant Msf::Exploit::Remote::MSSQL_SQLI::Failure"

```
msf > use exploit/windows/mssql/mssql_payload_sqli
msf exploit(mssql_payload_sqli) > set rhost 192.168.172.133
rhost => 192.168.172.133
msf exploit(mssql_payload_sqli) > show options

Module options (exploit/windows/mssql/mssql_payload_sqli):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   COOKIE                     no        Cookie value
   DATA                       no        POST data, if necessary, with [SQLi] indicating the injection
   DELIVERY  OLD              yes       Payload delivery method (accepted: PS, CMD, OLD)
   GET_PATH  /                yes       The complete path with [SQLi] indicating the injection
   METHOD    GET              yes       GET or POST
   Proxies                    no        Use a proxy chain
   RHOST     192.168.172.133  yes       The target address
   RPORT     80               yes       The target port
   VHOST                      no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(mssql_payload_sqli) > run

[*] Started reverse handler on 192.168.172.1:4444 
[*] Warning: This module will leave TFyyxgzt.exe in the SQL Server %TEMP% directory
[*] Writing the debug.com loader to the disk...
[-] Exploit failed: NameError uninitialized constant Msf::Exploit::Remote::MSSQL_SQLI::Failure
```
- [x] After patch: "The SQL injection parameter was not specified...." correct fail_with message

```
msf exploit(mssql_payload) > use exploit/windows/mssql/mssql_payload_sqli 
smsf exploit(mssql_payload_sqli) > show options

Module options (exploit/windows/mssql/mssql_payload_sqli):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   COOKIE                     no        Cookie value
   DATA                       no        POST data, if necessary, with [SQLi] indicating the injection
   DELIVERY  OLD              yes       Payload delivery method (accepted: PS, CMD, OLD)
   GET_PATH  /                yes       The complete path with [SQLi] indicating the injection
   METHOD    GET              yes       GET or POST
   Proxies                    no        Use a proxy chain
   RHOST                      yes       The target address
   RPORT     80               yes       The target port
   VHOST                      no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(mssql_payload_sqli) > set rhost 192.168.172.133
rhost => 192.168.172.133
msf exploit(mssql_payload_sqli) > run

[*] Started reverse handler on 192.168.172.1:4444 
[*] Warning: This module will leave uwNWwypu.exe in the SQL Server %TEMP% directory
[*] Writing the debug.com loader to the disk...
[-] Exploit failed [no-target]: The SQL injection parameter was not specified in the GET path
^Cmsf exploit(mssql_payload_sqli) > 
```
