### PR TITLE
Bundler redirection

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,3 @@
+---
+BUNDLE_PATH: ./vendor/bundle
+BUNDLE_DISABLE_SHARED_GEMS: '1'

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-.bundle
+# Ignore local Bundler settings
+.bundle/
+# ... except the config, which set the path explicitly
+!.bundle/config
 # Rubymine project directory
 .idea
 # Sublime Text project directory (not created by ST by default)

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ tags
 # ignore release/debug folders for exploits
 external/source/exploits/**/Debug
 external/source/exploits/**/Release
+
+# ignore locally installed gems
+vendor/bundle

--- a/spec/bundle_spec.rb
+++ b/spec/bundle_spec.rb
@@ -5,23 +5,29 @@ require 'bundler'
 describe Bundler do
 
   context '#bundle_path' do
-
     subject(:bundle_path) do
       described_class.bundle_path.realpath
     end
 
-    before(:all) do
-      root_dir = Metasploit::Framework.root
+    let(:root_dir) do
+      Metasploit::Framework.root
     end
 
     it { should be_directory }
 
     it { should be_writable }
 
-    it.to_s { should include 'vendor/bundle' }
+    it 'should be local' do
+      bundle_path.relative_path_from(root_dir).to_s.should_not include '..'
+    end
 
-    it.to_s { should_not include '..' }
+    context '#to_s' do
+      subject(:to_s) do
+        bundle_path.to_s
+      end
 
+      it { should include 'vendor/bundle' }
+
+    end
   end
-
 end

--- a/spec/bundle_spec.rb
+++ b/spec/bundle_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+require 'bundler'
+
+
+
+describe Bundler do
+  context '#bundle_path' do
+
+    path = described_class.bundle_path.realpath
+    root_dir = Metasploit::Framework.root #.to_s
+
+    it 'should point to a directory' do
+      path.should be_directory
+    end
+
+    it 'should point to a vendor/bundle directory' do
+      path.to_s.should =~ /vendor\/bundle/
+    end
+
+    it 'should be local to the installation' do
+      path.relative_path_from(root_dir).to_s.should_not =~ /\.\./
+    end
+
+    it 'should point to a writable directory' do
+      path.should be_writable
+    end
+
+  end
+end

--- a/spec/bundle_spec.rb
+++ b/spec/bundle_spec.rb
@@ -1,29 +1,27 @@
 require 'spec_helper'
+
 require 'bundler'
 
-
-
 describe Bundler do
+
   context '#bundle_path' do
 
-    path = described_class.bundle_path.realpath
-    root_dir = Metasploit::Framework.root #.to_s
-
-    it 'should point to a directory' do
-      path.should be_directory
+    subject(:bundle_path) do
+      described_class.bundle_path.realpath
     end
 
-    it 'should point to a vendor/bundle directory' do
-      path.to_s.should =~ /vendor\/bundle/
+    before(:all) do
+      root_dir = Metasploit::Framework.root
     end
 
-    it 'should be local to the installation' do
-      path.relative_path_from(root_dir).to_s.should_not =~ /\.\./
-    end
+    it { should be_directory }
 
-    it 'should point to a writable directory' do
-      path.should be_writable
-    end
+    it { should be_writable }
+
+    it.to_s { should include 'vendor/bundle' }
+
+    it.to_s { should_not include '..' }
 
   end
+
 end


### PR DESCRIPTION
This PR sets bundler to always install gems to $MSF_ROOT/vendor/bundle. This achieves some desirable effects:
- We know for sure you can write to this directory.
- If Metasploit's gems cause your A/V to false positive on Metasploit files (likely in the future), you can simply whitelist your git checkout and not worry about whitelisting your usual $GEM_PATH or specific gems.
- You can keep your git checkout of Metasploit framework more completely on a USB drive if you have a temporary OS. (Doesn't address the ~/.msf4 creation, though, so this is only mostly complete)

Some undesirable effects:
- If you have a local .bundle/config, this will overwrite/conflict with that.

No Metasploit developer has ever claimed (to me) to have configured bundler explicitly this way, though. I'm not sure this is a practical concern.
## Verification
- [ ] In this branch, see that your gems are now missing:

```
$ ./msfconsole -L
Could not find rake-10.1.0 in any of the sources
Run `bundle install` to install missing gems.
```
- [ ] Ensure you are using a developer gemset: `rvm gemset list | grep =` or `rvm-prompt` . This should be set automatically by `.ruby-gemset` if you are using RVM (or rbenv?)
- [ ] In this branch (or after merging), run 'bundle install'
- [ ] See that gems are installed to the local vendor/bundle path by spot-checking: `bundle show network_interface` . It should have a result like so:

```
$ bundle show network_interface
/home/todb/git/rapid7/metasploit-framework/vendor/bundle/ruby/1.9.1/gems/network_interface-0.0.1
```
- [ ] See that msfconsole starts normally (iow, required gems are findable again)
- [ ] Verify `rake spec` passes.
