### PR TITLE
Allow self-destruct via "kill -s"

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -329,13 +329,20 @@ class Console::CommandDispatcher::Stdapi::Sys
       return true
     end
 
-    # validate all the proposed pids first so we can bail if one is bogus
-    valid_pids = validate_pids(args)
-    args.uniq!
-    diff = args - valid_pids.map {|e| e.to_s}
-    if not diff.empty? # then we had an invalid pid
-      print_error("The following pids are not valid:  #{diff.join(", ").to_s}.  Quitting")
-      return false
+    self_destruct = args.include?("-s")
+
+    if self_destruct
+      valid_pids = [client.sys.process.getpid.to_i]
+    else
+      valid_pids = validate_pids(args)
+
+      # validate all the proposed pids first so we can bail if one is bogus
+      args.uniq!
+      diff = args - valid_pids.map {|e| e.to_s}
+      if not diff.empty? # then we had an invalid pid
+        print_error("The following pids are not valid:  #{diff.join(", ").to_s}.  Quitting")
+        return false
+      end
     end
 
     # kill kill kill
@@ -348,8 +355,9 @@ class Console::CommandDispatcher::Stdapi::Sys
   # help for the kill command
   #
   def cmd_kill_help
-    print_line("Usage: kill pid1 pid2 pid3 ...")
+    print_line("Usage: kill [pid1 [pid2 [pid3 ...]]] [-s]")
     print_line("Terminate one or more processes.")
+    print_line(" -s : Kills the pid associated with the current session.")
   end
 
   #


### PR DESCRIPTION
HTTP(s) payloads don't exit cleanly at the moment. This is an issue that's being addressed through other work. However, there's a need to be able to terminate the current HTTP(s) session forcefully in certain cases.

This PR add a `-s` option to kill, which (when specified) will kill the current session. This makes session on the MSF side hang, but that can be terminated manually.
