### PR TITLE
Remove Auto target from Firefox 17 rce.

### DIFF
--- a/modules/exploits/multi/browser/firefox_svg_plugin.rb
+++ b/modules/exploits/multi/browser/firefox_svg_plugin.rb
@@ -6,7 +6,7 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-  Rank = ExcellentRanking
+  Rank = GreatRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::EXE

--- a/modules/exploits/multi/browser/firefox_svg_plugin.rb
+++ b/modules/exploits/multi/browser/firefox_svg_plugin.rb
@@ -34,12 +34,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Platform'       => %w{ linux osx win },
       'Targets'        =>
         [
-          [ 'Automatic',
-            {
-              'Platform' => %w{ linux osx win },
-              'Arch'     => ARCH_X86
-            }
-          ],
           [ 'Windows x86 (Native Payload)',
             {
               'Platform' => 'win',


### PR DESCRIPTION
It was always a lie and never worked for anything besides windows anyways :-/
This is because the listener must be decided and spun up at initialization time,
so we can't be waiting for the request to make that decision.

As a fix for this problem, we might consider spinning up one handler per target
at launch time, and dishing out the payload ports correctly. But that would take
some rewiring.

For now I will just disable auto targeting from this module so I stop forgetting
that it doesn't actually work. I've debugged this a couple times now before remembering :)
#### Verification steps
- [ ] Run the module, making sure to set TARGET to the platform you're testing:
  
  ```
  msf> use exploit/multi/browser/firefox_svg_plugin
  msf> set TARGET 1
  msf> run
  ```
- [ ] Download firefox 17 on your platform, open it and browse to the URL printed in your log
- [ ] You get a shell.
