### PR TITLE
Kill meterpreter support for osx webcam/mic modules.

### DIFF
--- a/modules/post/osx/manage/record_mic.rb
+++ b/modules/post/osx/manage/record_mic.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Post
       'License'       => MSF_LICENSE,
       'Author'        => [ 'joev'],
       'Platform'      => [ 'osx'],
-      'SessionTypes'  => [ 'shell', 'meterpreter' ],
+      'SessionTypes'  => [ 'shell' ],
       'Actions'       => [
         [ 'LIST',     { 'Description' => 'Show a list of microphones' } ],
         [ 'RECORD', { 'Description' => 'Record from a selected audio input' } ]

--- a/modules/post/osx/manage/webcam.rb
+++ b/modules/post/osx/manage/webcam.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Post
       'License'       => MSF_LICENSE,
       'Author'        => [ 'joev'],
       'Platform'      => [ 'osx'],
-      'SessionTypes'  => [ 'shell', 'meterpreter' ],
+      'SessionTypes'  => [ 'shell' ],
       'Actions'       => [
         [ 'LIST',     { 'Description' => 'Show a list of webcams' } ],
         [ 'SNAPSHOT', { 'Description' => 'Take a snapshot with the webcam' } ],


### PR DESCRIPTION
There is some bug (RM #8457) that I haven't been able to track down that causes the
osx call to run the event queue to just hang on latest OSX + Java/python
meterpreter. I tried rewriting these modules using OSX's new Media API,
but I run into the same problem. Until I find a solution, we should mark
these shell-only.
