### PR TITLE
Update for enum_prefetch post module

### DIFF
--- a/modules/post/windows/gather/enum_prefetch.rb
+++ b/modules/post/windows/gather/enum_prefetch.rb
@@ -111,8 +111,6 @@ class Metasploit3 < Msf::Post
           fpath_entry_filename = fpath_entry_data.last
           if not fpath_entry_filename.nil?
             fpath_name = fpath_entry_filename.gsub(/\0/, '')
-            #r_filename = name.gsub(/\0/, '')
-            #print_status(fpath_name.inspect)
             if name == fpath_name[0..29]
               fpath_path = path.gsub(/\0/, '')
               filepath = fpath_path

--- a/modules/post/windows/gather/enum_prefetch.rb
+++ b/modules/post/windows/gather/enum_prefetch.rb
@@ -101,7 +101,8 @@ class Metasploit3 < Msf::Post
       # This part will extract the filepath so that we can find and
       # compare its contents to the filename we found previously. This
       # allows us to find the filepath used to execute the program
-      # referenced in the prefetch-file.
+      # referenced in the prefetch-file (among other paths which won't
+      # be showed though).
 
       if not filepath_data.nil? or not filepath_data.emtpy?
         fpath_data_array = filepath_data.split("\x00\x00\x00")

--- a/modules/post/windows/gather/enum_prefetch.rb
+++ b/modules/post/windows/gather/enum_prefetch.rb
@@ -3,10 +3,10 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
 require 'rex'
-class Metasploit3 < Msf::Post
+require 'msf/core'
 
+class Metasploit3 < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Registry
@@ -15,12 +15,13 @@ class Metasploit3 < Msf::Post
     super(update_info(info,
       'Name'          => 'Windows Gather Prefetch File Information',
       'Description'   => %q{
-        This module gathers prefetch file information from WinXP, Win2k3 and Win7 systems.
-        Run count, hash and filename information is collected from each prefetch file while
-        Last Modified and Create times are file MACE values.
+        This module gathers prefetch file information from WinXP, Win2k3 and Win7 systems
+        and current values of related registry keys. From each prefetch file we'll collect
+        filetime (converted to utc) of the last execution, file path hash, run count, filename
+        and the execution path.
       },
       'License'       => MSF_LICENSE,
-      'Author'        => ['TJ Glad <fraktaali[at]gmail.com>'],
+      'Author'        => ['TJ Glad <tjglad[at]cmail.nu>'],
       'Platform'      => ['win'],
       'SessionType'   => ['meterpreter']
     ))
@@ -43,7 +44,7 @@ class Metasploit3 < Msf::Post
   end
 
   def print_timezone_key_values(key_value)
-    # Looks for timezone from registry
+    # Looks for timezone information from registry.
     timezone = registry_getvaldata("HKLM\\SYSTEM\\CurrentControlSet\\Control\\TimeZoneInformation", key_value)
     tz_bias = registry_getvaldata("HKLM\\SYSTEM\\CurrentControlSet\\Control\\TimeZoneInformation", "Bias")
     if timezone.nil? or tz_bias.nil?
@@ -60,36 +61,64 @@ class Metasploit3 < Msf::Post
     end
   end
 
-  def gather_pf_info(name_offset, hash_offset, runcount_offset, filename)
-    # We'll load the file and parse information from the offsets
+  def gather_pf_info(name_offset, hash_offset, runcount_offset, filetime_offset, filename)
+    # Collects the desired information from each prefetch file found
+    # from the system.
+
     prefetch_file = read_file(filename)
     if prefetch_file.empty? or prefetch_file.nil?
       print_error("Couldn't read file: #{filename}")
       return nil
     else
-      # First we'll get the filename
+      # First we extract the saved filename
       pf_filename = prefetch_file[name_offset..name_offset+60]
       idx = pf_filename.index("\x00\x00")
       name = Rex::Text.to_ascii(pf_filename.slice(0..idx))
-      # Next we'll get the run count
+
+      # Then we get the runcount
       run_count = prefetch_file[runcount_offset..runcount_offset+4].unpack('L*')[0].to_s
-      # Then file path hash
+
+      # Then the filepath hash
       path_hash = prefetch_file[hash_offset..hash_offset+4].unpack('h8')[0].reverse.upcase.to_s
-      # Last is mace value for timestamps
-      mtimes = client.priv.fs.get_file_mace(filename)
-      if mtimes.nil? or mtimes.empty?
-        last_modified = "Error reading value"
-        created = "Error reading value"
-      else
-        last_modified = mtimes['Modified'].utc.to_s
-        created = mtimes['Created'].utc.to_s
+
+      # Last we get the latest execution time
+      filetime_a = prefetch_file[filetime_offset..(filetime_offset+16)].unpack('q32')
+      filetime = filetime_a[0] + filetime_a[1]
+      last_exec = Time.at((filetime - 116444736000000000) / 10000000).utc.to_s
+
+      # This is for reading file paths of the executable from
+      # the prefetch file. We'll use this to find out from where the
+      # file was executed.
+      # First we'll use specific offsets for finding out the location
+      # and length of the filepath.
+      filepath = []
+      fpath_offset = prefetch_file[0x64..0x68].unpack('h4')[0].reverse.to_i(16)
+      fpath_length = prefetch_file[0x68..0x6C].unpack('h4')[0].reverse.to_i(16)
+      filepath_data = prefetch_file[fpath_offset..(fpath_offset+fpath_length)]
+      if not filepath_data.nil? or not filepath_data.empty?
+        r_filename = name.gsub(/\0/, '')
+        fpath_data_array = filepath_data.split("\x00\x00\x00")
+        fpath_data_array.each do |path|
+          fpath_full_file = path.split("\\")
+          fpath_file = fpath_full_file.last
+          if not fpath_file.nil?
+            fpath_fname = fpath_file.gsub(/\0/, '')
+              if r_filename == fpath_fname
+                fpath_path = path.gsub(/\0/, '')
+                if not fpath_path.empty?
+                  filepath = fpath_path
+                end
+              end
+          end
+        end
       end
-      return [last_modified, created, run_count, path_hash, name]
     end
+    return [last_exec, path_hash, run_count, name, filepath]
   end
 
   def run
     print_status("Prefetch Gathering started.")
+
     # Check to see what Windows Version is running.
     # Needed for offsets.
     # Tested on WinXP, Win2k3 and Win7 systems.
@@ -100,18 +129,18 @@ class Metasploit3 < Msf::Post
     error_msg = "You don't have enough privileges. Try getsystem."
 
     if sysnfo =~/(Windows XP|2003|.NET)/
-      # For some reason we need system privileges to read file
-      # mace time on XP/2003 while we can do the same only
-      # as admin on Win7.
-      if not is_system?
+
+      if not is_admin?
         print_error(error_msg)
         return nil
       end
+
       # Offsets for WinXP & Win2k3
       print_good("Detected #{sysnfo} (max 128 entries)")
       name_offset = 0x10
       hash_offset = 0x4C
       runcount_offset = 0x90
+      filetime_offset = 0x78
       # Registry key for timezone
       key_value = "StandardName"
 
@@ -120,14 +149,15 @@ class Metasploit3 < Msf::Post
         print_error(error_msg)
         return nil
       end
+
       # Offsets for Win7
       print_good("Detected #{sysnfo} (max 128 entries)")
       name_offset = 0x10
       hash_offset = 0x4C
       runcount_offset = 0x98
+      filetime_offset = 0x78
       # Registry key for timezone
       key_value = "TimeZoneKeyName"
-
     else
       print_error("No offsets for the target Windows version. Currently works only on WinXP, Win2k3 and Win7.")
       return nil
@@ -138,12 +168,13 @@ class Metasploit3 < Msf::Post
       'Indent'  => 1,
       'Columns' =>
       [
-        "Modified (mace)",
-        "Created (mace)",
+        "Last execution (filetime)",
         "Run Count",
         "Hash",
-        "Filename"
+        "Filename",
+        "Filepath"
       ])
+
     print_prefetch_key_value
     print_timezone_key_values(key_value)
     print_good("Current UTC Time: %s" % Time.now.utc)
@@ -165,7 +196,7 @@ class Metasploit3 < Msf::Post
           next
         else
           filename = ::File.join(file['path'], file['name'])
-          pf_entry = gather_pf_info(name_offset, hash_offset, runcount_offset, filename)
+          pf_entry = gather_pf_info(name_offset, hash_offset, runcount_offset, filetime_offset, filename)
           if not pf_entry.nil?
             table << pf_entry
           end

--- a/modules/post/windows/gather/enum_prefetch.rb
+++ b/modules/post/windows/gather/enum_prefetch.rb
@@ -82,7 +82,7 @@ class Metasploit3 < Msf::Post
       path_hash = prefetch_file[hash_offset..hash_offset+4].unpack('h8')[0].reverse.upcase.to_s
 
       # Last we get the latest execution time
-      filetime_a = prefetch_file[filetime_offset..(filetime_offset+16)].unpack('q32')
+      filetime_a = prefetch_file[filetime_offset..(filetime_offset+16)].unpack('q*')
       filetime = filetime_a[0] + filetime_a[1]
       last_exec = Time.at((filetime - 116444736000000000) / 10000000).utc.to_s
 

--- a/modules/post/windows/gather/enum_prefetch.rb
+++ b/modules/post/windows/gather/enum_prefetch.rb
@@ -89,10 +89,9 @@ class Metasploit3 < Msf::Post
       # This is for reading file paths of the executable from
       # the prefetch file. We'll use this to find out from where the
       # file was executed.
-      #
+
       # First we'll use specific offsets for finding out the location
       # and length of the filepath so that we can find it.
-
       filepath = []
       fpath_offset = prefetch_file[0x64..0x68].unpack('h4')[0].reverse.to_i(16)
       fpath_length = prefetch_file[0x68..0x6C].unpack('h4')[0].reverse.to_i(16)
@@ -100,9 +99,9 @@ class Metasploit3 < Msf::Post
 
       # This part will extract the filepath so that we can find and
       # compare its contents to the filename we found previously. This
-      # allows us to find the filepath used to execute the program
-      # referenced in the prefetch-file (among other paths which won't
-      # be showed though).
+      # allows us to find the filepath (if it can be found inside the
+      # prefetch file) used to execute the program
+      # referenced in the prefetch-file.
 
       if not filepath_data.nil? or not filepath_data.emtpy?
         fpath_data_array = filepath_data.split("\x00\x00\x00")


### PR DESCRIPTION
Hi.

This is an update for my enum_prefetch post module. The main changes are how & where the module collects timestamp information. I've also added a function that collects the executable file paths saved in the prefetch files and prints the file path that matches with the executable filename stored inside the prefetch file. 

Timestamps:
-  Old: Previous version timestamp information was collected by getting MACE-times from the actual executables stored wherever they were stored.
- New: This version collects timestamp information from inside the prefetch file. It takes the last run 64bit FILETIME and convert it to UTC which will be presented to the user. This also means enum_prefetch no longer requires SYSTEM privileges on WinXP and it'll work as ADMIN (but also that it contains only the last run timestamp).

Filepaths:
- New: I've added a function that searches for the offsets where each prefetch file saves the file path data and uses  that to find the execution path of the executable. This allows the user to see from where the files that have a prefetch file have been executed.

msftidy & rspec:

```
(prefetch_update) debian@debian-msf:~/Github/metasploit-framework$ ./tools/msftidy.rb ./modules/post/windows/gather/enum_prefetch.rb 
(prefetch_update) debian@debian-msf:~/Github/metasploit-framework$

(prefetch_update) debian@debian-msf:~/Github/metasploit-framework$ rake spec/
(prefetch_update) debian@debian-msf:~/Github/metasploit-framework$
```

Testrun as restricted user on WinXP:

```
meterpreter > run post/windows/gather/enum_prefetch 

[*] Prefetch Gathering started.
[-] You don't have enough privileges. Try getsystem.
meterpreter > sysinfo 
Computer        : XP-E49FE0852877
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > getuid
Server username: XP-E49FE0852877\restricted_user
meterpreter > 
```

Testrun as admin on WinXP:

```
meterpreter > sysinfo 
Computer        : XP-E49FE0852877
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > getuid
Server username: XP-E49FE0852877\xp-user
meterpreter > run post/windows/gather/enum_prefetch 

[*] Prefetch Gathering started.
[+] Detected Windows XP (Build 2600, Service Pack 3). (max 128 entries)
[+] EnablePrefetcher Value: (3) = Applaunch and boot enabled (Default Value, excl. Win2k3).
[+] Remote: Timezone is FLE Standard Time.
[+] Remote: Localtime bias to UTC: +119 minutes.
[+] Current UTC Time: 2013-12-08 16:49:32 UTC
[*] Gathering information from remote system. This will take awhile..

Prefetch Information
====================

 Last execution (filetime)  Run Count  Hash  Filename                       Filepath
 -------------------------  ---------  ----  --------                       --------
 2013-11-10 20:38:46 UTC    085CFFDE   1     NETSH.EXE                      \DEVICE\HARDDISKVOLUME1\WINDOWS\SYSTEM32\NETSH.EXE
 2013-11-10 20:44:08 UTC    2395F30B   8     IPCONFIG.EXE                   \DEVICE\HARDDISKVOLUME1\WINDOWS\SYSTEM32\IPCONFIG.EXE
 2013-11-11 06:30:07 UTC    282F76A7   1     SPOOLSV.EXE                    \DEVICE\HARDDISKVOLUME1\WINDOWS\SYSTEM32\SPOOLSV.EXE
 2013-11-11 06:30:16 UTC    3530F672   3     SVCHOST.EXE                    \DEVICE\HARDDISKVOLUME1\WINDOWS\SYSTEM32\SVCHOST.EXE
 2013-11-11 06:30:16 UTC    20DB6D1B   1     LSASS.EXE                      []
 2013-11-11 06:30:20 UTC    30411B02   1     MSOOBE.EXE                     \DEVICE\HARDDISKVOLUME1\WINDOWS\SYSTEM32\OOBE\MSOOBE.EXE
 2013-11-11 06:30:30 UTC    0F138680   1     ALG.EXE                        \DEVICE\HARDDISKVOLUME1\WINDOWS\SYSTEM32\ALG.EXE
 2013-11-11 06:30:32 UTC    002E45AB   1     AGENTSVR.EXE                   \DEVICE\HARDDISKVOLUME1\WINDOWS\MSAGENT\AGENTSVR.EXE
 2013-11-11 06:30:58 UTC    1C8143D1   1     DPSFNSHR.EXE                   \DEVICE\HARDDISKVOLUME1\DPSFNSHR.EXE
 2013-11-11 06:30:59 UTC    3189D4D7   4     DEVCON.EXE                     \DEVICE\HARDDISKVOLUME1\DEVCON.EXE
 2013-11-11 06:31:23 UTC    1E854676   1     RUNDLL32.EXE                   \DEVICE\HARDDISKVOLUME1\WINDOWS\SYSTEM32\RUNDLL32.EXE
 2013-11-11 06:31:25 UTC    49F747DB   1     RUNDLL32.EXE                   \DEVICE\HARDDISKVOLUME1\WINDOWS\SYSTEM32\RUNDLL32.EXE

[...SNIP...]

2013-12-08 16:51:05 UTC    082F38A9   11    EXPLORER.EXE                   \DEVICE\HARDDISKVOLUME1\WINDOWS\EXPLORER.EXE
 2013-12-08 16:51:06 UTC    34E05E26   10    VBOXTRAY.EXE                   \DEVICE\HARDDISKVOLUME1\WINDOWS\SYSTEM32\VBOXTRAY.EXE
 2013-12-08 16:51:06 UTC    3667BD89   31    VERCLSID.EXE                   \DEVICE\HARDDISKVOLUME1\WINDOWS\SYSTEM32\VERCLSID.EXE
 2013-12-08 16:51:06 UTC    0E17969B   11    CTFMON.EXE                     \DEVICE\HARDDISKVOLUME1\WINDOWS\SYSTEM32\CTFMON.EXE
 2013-12-08 16:51:08 UTC    087B4001   44    CMD.EXE                        \DEVICE\HARDDISKVOLUME1\WINDOWS\SYSTEM32\CMD.EXE
 2013-12-08 16:51:14 UTC    0E5F0F72   56    METERPRETER_REVERSE_TCP.EXE    \DEVICE\HARDDISKVOLUME1\DOCUMENTS AND SETTINGS\XP-USER\DESKTOP\METERPRETER_REVERSE_TCP.EXE
 2013-12-08 16:51:20 UTC    399A8E72   27    WUAUCLT.EXE                    \DEVICE\HARDDISKVOLUME1\WINDOWS\SYSTEM32\WUAUCLT.EXE


[*] Finished gathering information from prefetch files.
[*] Results stored in: /home/debian/.msf4/loot/20131208185007_development_10.2.2.12_prefetch_info_299743.txt
meterpreter > 

```

Testrun as restricted user on Win7:

```
meterpreter > sysinfo 
Computer        : WIN7-USER-PC
OS              : Windows 7 (Build 7600).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > getuid
Server username: WIN7-USER-PC\user1
meterpreter > run post/windows/gather/enum_prefetch 

[*] Prefetch Gathering started.
[-] You don't have enough privileges. Try getsystem.
meterpreter > 
```

Testrun as admin on Win7:

```
meterpreter > sysinfo 
Computer        : WIN7-USER-PC
OS              : Windows 7 (Build 7600).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > getuid
Server username: WIN7-USER-PC\WIN7-USER
meterpreter > run post/windows/gather/enum_prefetch 

[*] Prefetch Gathering started.
[+] Detected Windows 7 (Build 7600). (max 128 entries)
[+] EnablePrefetcher Value: (3) = Applaunch and boot enabled (Default Value, excl. Win2k3).
[+] Remote: Timezone is FLE Standard Time.
[+] Remote: Localtime bias to UTC: +119 minutes.
[+] Current UTC Time: 2013-12-08 16:59:49 UTC
[*] Gathering information from remote system. This will take awhile..

Prefetch Information
====================

 Last execution (filetime)  Run Count  Hash  Filename                       Filepath
 -------------------------  ---------  ----  --------                       --------
 2013-11-17 14:31:17 UTC    007FEA55   1     SVCHOST.EXE                    \DEVICE\HARDDISKVOLUME2\WINDOWS\SYSTEM32\SVCHOST.EXE
 2013-11-17 14:31:57 UTC    DF44F913   1     NET.EXE                        \DEVICE\HARDDISKVOLUME2\WINDOWS\SYSTEM32\NET.EXE
 2013-11-17 14:31:57 UTC    849DA590   1     NET1.EXE                       \DEVICE\HARDDISKVOLUME2\WINDOWS\SYSTEM32\NET1.EXE
 2013-11-17 14:31:58 UTC    6B089E8B   1     VDSLDR.EXE                     \DEVICE\HARDDISKVOLUME2\WINDOWS\SYSTEM32\VDSLDR.EXE
 2013-11-17 14:31:58 UTC    6E7946F9   1     VDS.EXE                        \DEVICE\HARDDISKVOLUME2\WINDOWS\SYSTEM32\VDS.EXE
 2013-11-17 14:33:24 UTC    2E9C6FE2   1     FINDSTR.EXE                    \DEVICE\HARDDISKVOLUME2\WINDOWS\SYSTEM32\FINDSTR.EXE
 2013-11-17 14:33:25 UTC    A990CB86   1     ATTRIB.EXE                     \DEVICE\HARDDISKVOLUME2\WINDOWS\SYSTEM32\ATTRIB.EXE
 2013-11-17 14:33:26 UTC    1C97BF89   1     BOOTINST.EXE                   \DEVICE\HARDDISKVOLUME2\WINDOWS\SETUP\SCRIPTS\BOOTINST.EXE
 2013-11-17 14:33:27 UTC    9046403A   4     DISKPART.EXE                   \DEVICE\HARDDISKVOLUME2\WINDOWS\SYSTEM32\DISKPART.EXE
 2013-11-17 14:33:28 UTC    E7D5C9CC   2     SHUTDOWN.EXE                   \DEVICE\HARDDISKVOLUME2\WINDOWS\SYSTEM32\SHUTDOWN.EXE
 2013-11-17 14:36:16 UTC    EE01DD11   1     VBOXWINDOWSADDITIONS.EXE       []
 2013-11-17 14:36:21 UTC    C4ADF8B8   1     VBOXWINDOWSADDITIONS-X86.EXE   []
 2013-11-17 14:37:06 UTC    7A9F33D1   1     NSE3F0.TMP                     \DEVICE\HARDDISKVOLUME2\USERS\WIN7-USER\APPDATA\LOCAL\TEMP\NSK360D.TMP\NSE3F0.TMP
 2013-11-17 14:37:06 UTC    945D79AE   2     SC.EXE                         \DEVICE\HARDDISKVOLUME2\WINDOWS\SYSTEM32\SC.EXE

[...SNIP...]

2013-12-08 17:05:34 UTC    A80E4F97   13    EXPLORER.EXE                   \DEVICE\HARDDISKVOLUME2\WINDOWS\EXPLORER.EXE
 2013-12-08 17:05:36 UTC    1D286C83   7     VBOXTRAY.EXE                   \DEVICE\HARDDISKVOLUME2\WINDOWS\SYSTEM32\VBOXTRAY.EXE
 2013-12-08 17:05:42 UTC    4A81B364   18    CMD.EXE                        \DEVICE\HARDDISKVOLUME2\WINDOWS\SYSTEM32\CMD.EXE
 2013-12-08 17:05:42 UTC    1F3E9D7E   29    CONHOST.EXE                    \DEVICE\HARDDISKVOLUME2\WINDOWS\SYSTEM32\CONHOST.EXE
 2013-12-08 17:05:46 UTC    FC0D39BF   20    WMPNSCFG.EXE                   \DEVICE\HARDDISKVOLUME2\PROGRAM FILES\WINDOWS MEDIA PLAYER\WMPNSCFG.EXE
 2013-12-08 17:05:51 UTC    531BD9EA   19    CONSENT.EXE                    []
 2013-12-08 17:06:07 UTC    EBAA25DC   28    METERPRETER_REVERSE_TCP.EXE    \DEVICE\HARDDISKVOLUME2\USERS\WIN7-USER\DESKTOP\METERPRETER_REVERSE_TCP.EXE
 2013-12-08 17:06:19 UTC    05F624AB   14    SVCHOST.EXE                    \DEVICE\HARDDISKVOLUME2\WINDOWS\SYSTEM32\SVCHOST.EXE
 2013-12-08 17:07:07 UTC    1628051C   18    WMIPRVSE.EXE                   \DEVICE\HARDDISKVOLUME2\WINDOWS\SYSTEM32\WBEM\WMIPRVSE.EXE


[*] Finished gathering information from prefetch files.
[*] Results stored in: /home/debian/.msf4/loot/20131208190046_development_10.2.2.14_prefetch_info_624362.txt
meterpreter > 
```

Testrun as restricted user on Win2k3:

```
meterpreter > sysinfo 
Computer        : WIN2K3-A5C2D0FB
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > getuid
Server username: WIN2K3-A5C2D0FB\restricted_user
meterpreter > run post/windows/gather/enum_prefetch 

[*] Prefetch Gathering started.
[-] You don't have enough privileges. Try getsystem.
meterpreter >
```

Testrun as admin on Win2k3:

```
meterpreter > sysinfo 
Computer        : WIN2K3-A5C2D0FB
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > getuid
Server username: WIN2K3-A5C2D0FB\Administrator
meterpreter > run post/windows/gather/enum_prefetch 

[*] Prefetch Gathering started.
[+] Detected Windows .NET Server (Build 3790, Service Pack 2). (max 128 entries)
[+] EnablePrefetcher Value: (2) = Boot prefetching enabled (Non-Default, excl. Win2k3).
[+] Remote: Timezone is Pacific Standard Time.
[+] Remote: Localtime bias to UTC: -480 minutes.
[+] Current UTC Time: 2013-12-08 17:08:31 UTC
[*] Gathering information from remote system. This will take awhile..

Prefetch Information
====================

 Last execution (filetime)  Run Count  Hash  Filename  Filepath
 -------------------------  ---------  ----  --------  --------
 2013-12-09 03:04:53 UTC    B00DFAAD   1     NTOSBOOT  []


[*] Finished gathering information from prefetch files.
[*] Results stored in: /home/debian/.msf4/loot/20131208190832_development_10.2.2.17_prefetch_info_863817.txt
meterpreter >
```
