### PR TITLE
Allow the NFS protocol to be specified in the mount scanner

### DIFF
--- a/modules/auxiliary/scanner/nfs/nfsmount.rb
+++ b/modules/auxiliary/scanner/nfs/nfsmount.rb
@@ -26,6 +26,11 @@ class Metasploit3 < Msf::Auxiliary
         ],
       'License'	=> MSF_LICENSE
     )
+
+    register_options([
+      OptEnum.new('PROTOCOL', [ true, 'The protocol to use', 'udp', ['udp', 'tcp']])
+    ])
+
   end
 
   def run_host(ip)
@@ -35,7 +40,7 @@ class Metasploit3 < Msf::Auxiliary
       progver		= 1
       procedure	= 5
 
-      sunrpc_create('udp', program, progver)
+      sunrpc_create(datastore['PROTOCOL'], program, progver)
       sunrpc_authnull()
       resp = sunrpc_call(procedure, "")
 
@@ -44,7 +49,7 @@ class Metasploit3 < Msf::Auxiliary
 
       report_service(
         :host  => ip,
-        :proto => 'udp',
+        :proto => datastore['PROTOCOL'],
         :port  => 2049,
         :name  => 'nfsd',
         :info  => "NFS Daemon #{program} v#{progver}"
@@ -64,7 +69,7 @@ class Metasploit3 < Msf::Auxiliary
         end
         report_note(
           :host => ip,
-          :proto => 'udp',
+          :proto => datastore['PROTOCOL'],
           :port => 2049,
           :type => 'nfs.exports',
           :data => { :exports => shares },


### PR DESCRIPTION
Hey,

Just a simple patch that allows the user to configure the protocol that will be used when scanning nfs mounts.

Cheers,
Russell
