### PR TITLE
Record successful passwordless access to mongodb

### DIFF
--- a/modules/auxiliary/scanner/mongodb/mongodb_login.rb
+++ b/modules/auxiliary/scanner/mongodb/mongodb_login.rb
@@ -46,6 +46,14 @@ class Metasploit3 < Msf::Auxiliary
           do_login(user, pass)
         }
       else
+        report_vuln(
+          :host         => rhost,
+          :port         => rport,
+          :name         => self.name,
+          :refs         => self.references,
+          :exploited_at => Time.now.utc,
+          :info         => "Mongo server has no authentication."
+        )
         print_good("Mongo server #{ip.to_s} dosn't use authentication")
       end
       disconnect


### PR DESCRIPTION
This patch causes the mongodb scanner to record any passwordless services that it finds in the credentials table.
