### PR TITLE
Unscrew the author name

### DIFF
--- a/modules/post/windows/gather/forensics/browser_history.rb
+++ b/modules/post/windows/gather/forensics/browser_history.rb
@@ -25,7 +25,9 @@ class Metasploit3 < Msf::Post
           Gathers Skype chat logs, Firefox history, and Chrome history data from the target machine.
         },
         'License' => MSF_LICENSE,
-        'Author' => [ 'Joshua Harper (@JonValt) <josh at radixtx dot com>' ],
+        'Author' => [
+          'Joshua Harper <josh[at]radixtx.com>' # @JonValt
+        ],
         'Platform' => %w{ win },
         'SessionTypes' => [ 'meterpreter' ]
       ))


### PR DESCRIPTION
- No twitter handles in author names. the `<blank>@name` screws up some parsers
- Should be in the form of `name[at]domain.tld`, not `name at domain dot tld`
## Verification:

```

msf > info post/windows/gather/forensics/browser_history 

       Name: Windows Gather Skype, Firefox, and Chrome Artifacts
     Module: post/windows/gather/forensics/browser_history
   Platform: Windows
       Arch: 
       Rank: Normal

Provided by:
  Joshua Harper <josh@radixtx.com>

Description:
  Gathers Skype chat logs, Firefox history, and Chrome history data 
  from the target machine.


```
