### PR TITLE
Honor the PID argument in the Process mixin execute_shellcode function.

### DIFF
--- a/lib/msf/core/post/windows/process.rb
+++ b/lib/msf/core/post/windows/process.rb
@@ -28,10 +28,10 @@ module Process
       return false
     end
 
-    vprint_status("Creating the thread to execute in 0x#{shell_addr.to_s(16)} (pid=#{pid.to_s})")
-    ret = session.railgun.kernel32.CreateThread(nil, 0, shell_addr, nil, 0, nil)
+    vprint_status("Creating the thread to execute in 0x#{shell_addr.to_s(16).rjust(8, '0')} (pid=#{pid.to_s})")
+    ret = session.railgun.kernel32.CreateRemoteThread(host.handle, nil, 0, shell_addr, nil, 0, nil)
     if ret['return'] < 1
-      vprint_error("Unable to CreateThread")
+      vprint_error("Unable to create thread")
       return false
     end
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_kernel32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_kernel32.rb
@@ -11,7 +11,7 @@ class Def_kernel32
 
   def self.create_dll(dll_path = 'kernel32')
     dll = DLL.new(dll_path, ApiConstants.manager)
-    
+
     dll.add_function( 'GetConsoleWindow', 'LPVOID',[])
 
     dll.add_function( 'ActivateActCtx', 'BOOL',[
@@ -496,7 +496,7 @@ class Def_kernel32
       ["HANDLE","hProcess","in"],
       ["PBLOB","lpThreadAttributes","in"],
       ["DWORD","dwStackSize","in"],
-      ["PBLOB","lpStartAddress","in"],
+      ["LPVOID","lpStartAddress","in"],
       ["PBLOB","lpParameter","in"],
       ["DWORD","dwCreationFlags","in"],
       ["PDWORD","lpThreadId","out"],


### PR DESCRIPTION
This PR fixes the execute_shellcode function to honor the pid argument.  Without this change, the execute_shellcode function will start a local thread at an invalid address when trying to inject shellcode into another process.

This PR also changes the lpStartAddress type in the railgun definition file for the CreateRemoteThread function.  The CreateThread lpStartAddress type is LPVOID, and the changing the CreateRemoteThread lpStartAddress type to the same allows the function to be called specifying an address instead of a string.  A quick grep seems to imply that CreateRemoteThread is not called through railgun.
