### PR TITLE
Add railgun definitions for local exploit relevant functions.

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_kernel32.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_kernel32.rb
@@ -11,7 +11,7 @@ class Def_kernel32
 
   def self.create_dll(dll_path = 'kernel32')
     dll = DLL.new(dll_path, ApiConstants.manager)
-    
+
     dll.add_function( 'GetConsoleWindow', 'LPVOID',[])
 
     dll.add_function( 'ActivateActCtx', 'BOOL',[
@@ -496,7 +496,7 @@ class Def_kernel32
       ["HANDLE","hProcess","in"],
       ["PBLOB","lpThreadAttributes","in"],
       ["DWORD","dwStackSize","in"],
-      ["PBLOB","lpStartAddress","in"],
+      ["LPVOID","lpStartAddress","in"],
       ["PBLOB","lpParameter","in"],
       ["DWORD","dwCreationFlags","in"],
       ["PDWORD","lpThreadId","out"],

--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_ntdll.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/def/def_ntdll.rb
@@ -12,6 +12,15 @@ class Def_ntdll
   def self.create_dll(dll_path = 'ntdll')
     dll = DLL.new(dll_path, ApiConstants.manager)
 
+    dll.add_function('NtAllocateVirtualMemory', 'DWORD',[
+      ["DWORD","ProcessHandle","in"],
+      ["PBLOB","BaseAddress","inout"],
+      ["PDWORD","ZeroBits","in"],
+      ["PBLOB","RegionSize","inout"],
+      ["DWORD","AllocationType","in"],
+      ["DWORD","Protect","in"]
+      ])
+
     dll.add_function('NtClose', 'DWORD',[
       ["DWORD","Handle","in"],
       ])
@@ -33,13 +42,13 @@ class Def_ntdll
     dll.add_function('NtDeviceIoControlFile', 'DWORD',[
       ["DWORD","FileHandle","in"],
       ["DWORD","Event","in"],
-      ["PBLOB","ApcRoutine","in"],
-      ["PBLOB","ApcContext","in"],
-      ["PBLOB","IoStatusBlock","inout"],
+      ["LPVOID","ApcRoutine","in"],
+      ["LPVOID","ApcContext","in"],
+      ["PDWORD","IoStatusBlock","out"],
       ["DWORD","IoControlCode","in"],
-      ["PBLOB","InputBuffer","in"],
+      ["LPVOID","InputBuffer","in"],
       ["DWORD","InputBufferLength","in"],
-      ["PBLOB","OutputBuffer","inout"],
+      ["LPVOID","OutputBuffer","in"],
       ["DWORD","OutputBufferLength","in"],
       ])
 
@@ -66,6 +75,11 @@ class Def_ntdll
       ["PBLOB","ThreadInformation","inout"],
       ["DWORD","ThreadInformationLength","in"],
       ["PDWORD","ReturnLength","inout"],
+      ])
+
+    dll.add_function('NtQueryIntervalProfile', 'DWORD',[
+      ["DWORD","ProfileSource","in"],
+      ["PDWORD","Interval","out"],
       ])
 
     dll.add_function('NtQuerySystemInformation', 'DWORD',[


### PR DESCRIPTION
This PR updates the parameter types of CreateRemoteThread and NtDeviceIoControlFile and adds NtAllocateVirtualMemory and NtQueryIntervalProfile.

These functions are used in a few windows local exploit modules including ms11_080_afdjoinleaf, novell_client_nwfs, novell_client_nicm, and ms_ndproxy (not yet landed PR #2755).

It looks like the code has been copied and pasted across these modules so the usage of these functions, primarily NtAllocateVirutalMemory, NtDeviceIoControlFile and NtQueryIntervalProfile, are all consistent.
