### PR TITLE
Raise Msf::OptionValidateError when the PORTS option is invalid

### DIFF
--- a/modules/auxiliary/bnat/bnat_scan.rb
+++ b/modules/auxiliary/bnat/bnat_scan.rb
@@ -77,6 +77,10 @@ class Metasploit3 < Msf::Auxiliary
 
     ports = Rex::Socket.portspec_crack(datastore['PORTS'])
 
+    if ports.empty?
+      raise Msf::OptionValidateError.new(['PORTS'])
+    end
+
     ports.each_with_index do |port,i|
       p.tcp_dst = port
       p.tcp_src = rand(64511)+1024

--- a/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
+++ b/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
@@ -56,6 +56,10 @@ class Metasploit3 < Msf::Auxiliary
         dead = false
         portlist = Rex::Socket.portspec_crack(datastore['PORTS'])
 
+        if portlist.empty?
+          raise Msf::OptionValidateError.new(['PORTS'])
+        end
+
         vprint_status("[#{rhost}] Verifying manual testing is not required...")
 
         manual = false

--- a/modules/auxiliary/scanner/portscan/ack.rb
+++ b/modules/auxiliary/scanner/portscan/ack.rb
@@ -50,8 +50,7 @@ class Metasploit3 < Msf::Auxiliary
     ports = Rex::Socket.portspec_crack(datastore['PORTS'])
 
     if ports.empty?
-      print_error("Error: No valid ports specified")
-      return
+      raise Msf::OptionValidateError.new(['PORTS'])
     end
 
     to = (datastore['TIMEOUT'] || 500).to_f / 1000.0

--- a/modules/auxiliary/scanner/portscan/ftpbounce.rb
+++ b/modules/auxiliary/scanner/portscan/ftpbounce.rb
@@ -43,8 +43,7 @@ class Metasploit3 < Msf::Auxiliary
     ports = Rex::Socket.portspec_crack(datastore['PORTS'])
 
     if ports.empty?
-      print_error("Error: No valid ports specified")
-      return
+      raise Msf::OptionValidateError.new(['PORTS'])
     end
 
     datastore['RHOST'] = datastore['BOUNCEHOST']

--- a/modules/auxiliary/scanner/portscan/syn.rb
+++ b/modules/auxiliary/scanner/portscan/syn.rb
@@ -48,8 +48,7 @@ class Metasploit3 < Msf::Auxiliary
     ports = Rex::Socket.portspec_crack(datastore['PORTS'])
 
     if ports.empty?
-      print_error("Error: No valid ports specified")
-      return
+      raise Msf::OptionValidateError.new(['PORTS'])
     end
 
     to = (datastore['TIMEOUT'] || 500).to_f / 1000.0

--- a/modules/auxiliary/scanner/portscan/tcp.rb
+++ b/modules/auxiliary/scanner/portscan/tcp.rb
@@ -41,8 +41,7 @@ class Metasploit3 < Msf::Auxiliary
     ports = Rex::Socket.portspec_crack(datastore['PORTS'])
 
     if ports.empty?
-      print_error("Error: No valid ports specified")
-      return
+      raise Msf::OptionValidateError.new(['PORTS'])
     end
 
     while(ports.length > 0)

--- a/modules/auxiliary/scanner/portscan/xmas.rb
+++ b/modules/auxiliary/scanner/portscan/xmas.rb
@@ -50,8 +50,7 @@ class Metasploit3 < Msf::Auxiliary
     ports = Rex::Socket.portspec_crack(datastore['PORTS'])
 
     if ports.empty?
-      print_error("Error: No valid ports specified")
-      return
+      raise Msf::OptionValidateError.new(['PORTS'])
     end
 
     to = (datastore['TIMEOUT'] || 500).to_f / 1000.0

--- a/modules/auxiliary/scanner/sap/sap_router_portscanner.rb
+++ b/modules/auxiliary/scanner/sap/sap_router_portscanner.rb
@@ -282,8 +282,7 @@ class Metasploit3 < Msf::Auxiliary
     ports = build_sap_ports(ports)
 
     if ports.empty?
-      print_error('Error: No valid ports specified')
-      return
+      raise Msf::OptionValidateError.new(['PORTS'])
     end
 
     print_status("Scanning #{ip}")


### PR DESCRIPTION
Instead of print_error for invalid ports, modules should be raising Msf::OptionValidateError to warn the user about the invalid input.
