### PR TITLE
Convert gendocs.sh to use rake yard

### DIFF
--- a/documentation/gendocs.sh
+++ b/documentation/gendocs.sh
@@ -1,15 +1,1 @@
-OPTS="-x .ut.rb -x .ts.rb -x samples -q"
-BASE="$(dirname "$0")"
-MSFDIR="${BASE}/.."
-DOCDIR="${BASE}/api"
-doc=$(which sdoc)
-
-if [ -z $doc ]; then
-    doc=$(which rdoc)
-fi
-
-echo "Using ${doc} for doc generation"
-echo "Putting docs in ${DOCDIR}"
-
-$doc $OPTS -t "Metasploit Documentation" -o ${DOCDIR} ${MSFDIR}/lib/rex ${MSFDIR}/lib/msf
-
+rake yard


### PR DESCRIPTION
Instead of sdoc, let's just use YARD docs which we promote as a documentation standard anyway.
## Verification

From the top of the metasploit-framework checkout:
- [x] Run the command `documentation/gendocs.sh`
- [x] See that documentation is generated in `doc/`
- [ ] Take a break while it runs. A few errors will be thrown but nothing disastrous.
- [ ] `xdg-open doc/index.html` (or firefox or safari or whatever)
