### PR TITLE
Adds ability to load post modules in msfcli

### DIFF
--- a/msfcli
+++ b/msfcli
@@ -312,6 +312,8 @@ class Msfcli
       modules[:module] = @framework.exploits.create($1)
     elsif module_name =~ /auxiliary\/(.*)/
       modules[:module] = @framework.auxiliary.create($1)
+    elsif module_name =~ /post\/(.*)/
+      modules[:module] = @framework.post.create($1)
     else
       modules[:module] = @framework.exploits.create(module_name)
       if modules[:module].nil?

--- a/spec/msfcli_spec.rb
+++ b/spec/msfcli_spec.rb
@@ -222,6 +222,37 @@ describe Msfcli do
     end
 
     context ".init_modules" do
+
+      it "should inititalize an exploit module" do
+        args = 'exploit/windows/smb/psexec S'
+        m = ''
+        stdout = get_stdout {
+          cli = Msfcli.new(args.split(' '))
+          m = cli.init_modules
+        }
+        m[:module].class.to_s.should start_with("Msf::Modules::Mod")
+      end
+
+      it "should inititalize an auxiliary module" do
+        args = 'auxiliary/server/browser_autopwn S'
+        m = ''
+        stdout = get_stdout {
+          cli = Msfcli.new(args.split(' '))
+          m = cli.init_modules
+        }
+        m[:module].class.to_s.should start_with("Msf::Modules::Mod")
+      end
+
+      it "should inititalize a post module" do
+        args = 'post/windows/gather/credentials/gpp S'
+        m = ''
+        stdout = get_stdout {
+          cli = Msfcli.new(args.split(' '))
+          m = cli.init_modules
+        }
+        m[:module].class.to_s.should start_with("Msf::Modules::Mod")
+      end
+
       it "should have multi/handler module initialized" do
         args = "multi/handler payload=windows/meterpreter/reverse_tcp lhost=127.0.0.1 E"
         m    = ''


### PR DESCRIPTION
This is mainly important for normal load testing. It'd be unusual to
actually want to use this functionality with msfcli since post modules
already need established sessions in order to do something.

https://dev.metasploit.com/redmine/issues/8719

@kgray-r7 noticed this today.
## Verficiation
- [x] See the rspec tests pass.
- [x] Test manually with : `msfcli post/multi/gather/firefox_creds S` and see the description.
## Example:

```
[ruby-1.9.3-p484@metasploit-framework] (bug/8179-msfcli-load-post) 
todb@mazikeen:~/git/rapid7/metasploit-framework
$ ./msfcli post/windows/gather/cachedump S
[*] Initializing modules...


       Name: Windows Gather Credential Cache Dump
     Module: post/windows/gather/cachedump
   Platform: Windows
       Arch: 
       Rank: Normal

Provided by:
   Maurizio Agazzini <inode@mediaservice.net>
   mubix <mubix@hak5.org>

Description:
  This module uses the registry to extract the stored domain hashes 
  that have been cached as a result of a GPO setting. The default 
  setting on Windows is to store the last ten successful logins.

References:
   http://lab.mediaservice.net/code/cachedump.rb



[ruby-1.9.3-p484@metasploit-framework] (bug/8179-msfcli-load-post) 
todb@mazikeen:~/git/rapid7/metasploit-framework

```
