### PR TITLE
SMS Plugin

### DIFF
--- a/plugins/sms.rb
+++ b/plugins/sms.rb
@@ -71,14 +71,21 @@ class Plugin::SessionSMS < Msf::Plugin
       sysinfo = session.sys.config.sysinfo
       computer = sysinfo['Computer']
       os = sysinfo['OS']
+
+      # Strip domain if local user
       user = session.sys.config.getuid.gsub("#{computer}\\",'')
 
       time = Time.now.strftime("%Y-%m-%d %H:%M")
 
       print_line("Sending SMS... Response: ") if @verbose
 
-      message = URI.escape("#{time}\nSession #{session.sid} from #{session.exploit.name}\n#{user}@#{computer}\n#{session.session_host}\n#{os}")
-      request_url = @url.gsub('MSFCONTENT', message)
+      message = "#{time}\nSession #{session.sid} from #{session.exploit.name}\n"
+      message << "#{user}\n"
+      message << "#{computer}\n"
+      message << "#{session.session_host}\n"
+      message << "#{os}"
+
+      request_url = @url.gsub('MSFCONTENT', URI.escape(message))
       uri = URI.parse(request_url)
       result = uri.read
       print_line(result) if @verbose

--- a/plugins/sms.rb
+++ b/plugins/sms.rb
@@ -1,0 +1,117 @@
+require 'open-uri'
+require 'time'
+
+module Msf
+
+###
+#
+# This class hooks all session creation events and sends an SMS when
+# a new session is initiated.
+#
+# Ben Campbell <eat_meatballs[at]hotmail.co.uk>
+#
+# Configure an sms.yml in .msf4/ with the HTTP GET API request
+# where the MSFCONTENT will be replaced by the message
+# e.g.
+#
+# url: https://api.clockworksms.com/http/send.aspx?key=KEY&to=44123456789&content=MSFCONTENT
+#
+###
+
+class Plugin::SessionSMS < Msf::Plugin
+
+  include Msf::SessionEvent
+
+  def initialize(framework, opts)
+    super
+    add_console_dispatcher(SMSCommandDispatcher)
+    self.framework.events.remove_session_subscriber(SMSCommandDispatcher)
+  end
+
+  def cleanup
+    remove_console_dispatcher('SMS')
+  end
+
+  def desc
+    "Automatically sends SMS on new session"
+  end
+
+  def name
+    "sms"
+  end
+
+  class SMSCommandDispatcher
+
+    include Msf::Ui::Console::CommandDispatcher
+
+    def initialize(console_driver)
+      super
+      @verbose = false
+
+      config_path = ::File.join(Msf::Config.get_config_root, "sms.yml")
+      sms_config = YAML.load_file(config_path)
+      @url = sms_config['url']
+      uri = URI.parse(@url)
+
+      if @url.empty?
+        print_error("Unable to read config file #{config_path}")
+      else
+        print_status("Using SMS API: #{uri.host}")
+        print_status("Start SMS Messaging with sms_start")
+      end
+
+      if uri.scheme == 'http'
+        print_warning("#{uri.host} API is running over HTTP")
+      end
+    end
+
+    def on_session_open(session)
+      return unless session.type == 'meterpreter'
+      session.core.use('stdapi')
+      sysinfo = session.sys.config.sysinfo
+      computer = sysinfo['Computer']
+      os = sysinfo['OS']
+      user = session.sys.config.getuid.gsub("#{computer}\\",'')
+
+      time = Time.now.strftime("%Y-%m-%d %H:%M")
+
+      print_line("Sending SMS... Response: ") if @verbose
+
+      message = URI.escape("#{time}\nSession #{session.sid} from #{session.exploit.name}\n#{user}@#{computer}\n#{session.session_host}\n#{os}")
+      request_url = @url.gsub('MSFCONTENT', message)
+      uri = URI.parse(request_url)
+      result = uri.read
+      print_line(result) if @verbose
+    end
+
+    def name
+      "SMS"
+    end
+
+    def commands
+      {
+          'sms_start'   => "Start SMS",
+          'sms_stop'    => "Stop SMS",
+          'sms_verbose' => "Toggle Verbosity"
+      }
+    end
+
+    def cmd_sms_start
+      print_status "Starting SMS Messages"
+      self.framework.events.add_session_subscriber(self)
+    end
+
+    def cmd_sms_stop
+      print_status("Stopping SMS Messages")
+      self.framework.events.remove_session_subscriber(self)
+    end
+
+    def cmd_sms_verbose
+      @verbose = !@verbose
+      print_status("SMS Verbose: #{@verbose}. Please stop and restart messaging")
+    end
+  end
+
+end
+end
+

--- a/plugins/sms.rb
+++ b/plugins/sms.rb
@@ -82,7 +82,8 @@ class Plugin::SessionSMS < Msf::Plugin
 
       print_line("Sending SMS... Response: ") if @verbose
 
-      message = "#{time}\nSession #{session.sid} from #{session.exploit.name}\n"
+      message = "#{time}\n"
+      message << "#{session.type.humanize} Session #{session.sid} from #{session.exploit.name}\n"
       message << "#{user}\n" if meterpreter
       message << "#{computer}\n" if meterpreter
       message << "#{session.session_host}\n"

--- a/plugins/sms.rb
+++ b/plugins/sms.rb
@@ -20,16 +20,15 @@ module Msf
 
 class Plugin::SessionSMS < Msf::Plugin
 
-  include Msf::SessionEvent
 
   def initialize(framework, opts)
     super
-    add_console_dispatcher(SMSCommandDispatcher)
-    self.framework.events.remove_session_subscriber(SMSCommandDispatcher)
+    @inst = add_console_dispatcher(SMSCommandDispatcher)
   end
 
   def cleanup
     remove_console_dispatcher('SMS')
+    self.framework.events.remove_session_subscriber(@inst)
   end
 
   def desc
@@ -42,6 +41,7 @@ class Plugin::SessionSMS < Msf::Plugin
 
   class SMSCommandDispatcher
 
+    include Msf::SessionEvent
     include Msf::Ui::Console::CommandDispatcher
 
     def initialize(console_driver)


### PR DESCRIPTION
Sends an SMS when you get a session using an SMS HTTP GET API.

Configure API URL in .msf4/sms.yml. MSFCONTENT will be replaced with the SMS Bodytext

```
url: https://api.clockworksms.com/http/send.aspx?key=API_KEY&to=44123456&content=MSFCONTENT
```

If you want an API key to use clockworksms I can create you one briefly for testing... There's probably plenty of other ones available with free texts to begin with.

Load module:

```
msf exploit(psh_web_delivery) > load sms
[*] Using SMS API: api.clockworksms.com
[*] Start SMS Messaging with sms_start
[*] Successfully loaded plugin: sms
```

Start messaging, enabling verbose for debugging...

```
sms_verbose
sms_start
```

Get a shell:
![metasploit_sms](https://f.cloud.github.com/assets/1854557/1789972/0a7f9aca-6968-11e3-93c5-d65dc959a5c3.jpg)
