### PR TITLE
SSO/Mimikatz module overwrites password with N/A

### DIFF
--- a/modules/post/windows/gather/credentials/sso.rb
+++ b/modules/post/windows/gather/credentials/sso.rb
@@ -99,6 +99,7 @@ class Metasploit3 < Msf::Post
 
   def report_creds(domain, user, pass)
     return if (user.empty? or pass.empty?)
+    return if pass.include?("n.a.")
 
     if session.db_record
       source_id = session.db_record.id


### PR DESCRIPTION
Database stores:

```
10.0.1.22  445   HACKTHIS-AB8350\HACKME  n.a. (tspkg KO)  password         true
```

when it should have:

```
10.0.1.22  445   HACKTHIS-AB8350\HACKME  password123  password         true
```

This will prevent some passwords being stored if they happen to have n.a. but this shouldn't be too common... Hopefully mimikatz v2.0 implementation will be able to handle these situations better

Reported by J Grace
