### PR TITLE
FixRM:8716, session upgrade script

### DIFF
--- a/scripts/shell/spawn_meterpreter.rb
+++ b/scripts/shell/spawn_meterpreter.rb
@@ -85,7 +85,7 @@ begin
   end
   opts = {
     :linemax => linemax,
-    :decoder => File.join(Msf::Config.data_directory, "data", "exploits", "cmdstager", "vbs_b64"),
+    :decoder => File.join(Msf::Config.data_directory, "exploits", "cmdstager", "vbs_b64"),
     #:nodelete => true # keep temp files (for debugging)
   }
   exe = Msf::Util::EXE.to_executable(framework, larch, lplat, buf)


### PR DESCRIPTION
Doesn't appear to be any other issues similar following https://github.com/rapid7/metasploit-framework/pull/2426:

`root@kali:~/git/metasploit-framework# grep -r -i "data_directory, \"data" .`

`./scripts/shell/spawn_meterpreter.rb:    :decoder => File.join(Msf::Config.data_directory, "data", "exploits", "cmdstager", "vbs_b64"),`

`root@kali:~/git/metasploit-framework# grep -r -i "data_directory, 'data" .`
