### PR TITLE
Fix lotus_domino_hashes not working.

### DIFF
--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -162,7 +162,7 @@ class Metasploit3 < Msf::Auxiliary
       if (res and res.body)
         short_name = res.body.scan(/<INPUT NAME=\"ShortName\" TYPE=(?:.*) VALUE=\"([^\s]+)"/i).join
         user_mail = res.body.scan(/<INPUT NAME=\"InternetAddress\" TYPE=(?:.*) VALUE=\"([^\s]+)"/i).join
-        pass_hash = res.body.scan(/<INPUT NAME=\"dspHTTPPassword\" TYPE=(?:.*) VALUE=\"([^\s]+)"/i).join
+        pass_hash = res.body.scan(/<INPUT NAME=\"\$?dspHTTPPassword\" TYPE=(?:.*) VALUE=\"([^\s]+)"/i).join
 
         if short_name.to_s.strip.empty?
           short_name = 'NULL'


### PR DESCRIPTION
Some Lotus Domino servers prefix the "dspHTTPPassword" field
with a dollar sign. Updated regex to take this into account.

Observed on Lotus Domio 8.5.2.0.
