### PR TITLE
Add another testcase for matching a range of browser versions for BES

### DIFF
--- a/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
@@ -68,9 +68,20 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       server.get_bad_requirements(fake_profile)
     end
 
-    context 'when given the expected profile' do
+    context 'when given a profile' do
       it "should not contain any bad requirements" do
         server.get_bad_requirements(expected_profile).should eq([])
+      end
+
+      it "should not contain any bad requirements with a range of browser versions" do
+        basic_profile =
+        {
+          :source  => 'script',
+          :ua_name => "firefox/15.0",
+          :ua_ver  => lambda { |ver| ver.to_i.between?(5, 15) }
+        }
+
+        server.get_bad_requirements(basic_profile).should eq([])
       end
     end
 


### PR DESCRIPTION
Instead of specifying one particular version, the BrowserExploitServer mixin now also supports matching a range of versions using Proc. Need to add this to rspec.

Test:

```
$ rspec spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb 
Msf::Exploit::Remote::BrowserExploitServer ..................

Finished in 3.02 seconds
18 examples, 0 failures
```
