### PR TITLE
Don't user merge! because can modify self.compat

### DIFF
--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -450,7 +450,7 @@ class Module
     elsif (mod.type == MODULE_PAYLOAD)
       ch = self.compat['Payload']
       if self.respond_to?("target") and self.target['Payload'] and self.target['Payload']['Compat']
-        ch.merge!(self.target['Payload']['Compat'])
+        ch = ch.merge(self.target['Payload']['Compat'])
       end
     else
       return true


### PR DESCRIPTION
This change fixes a "small" issue on #2786. If merge! is used, self.compat['Payload'] is modified and it isn't the intended behaviour.
## Verification
- [x] From master start msfconsole
- [x] use exploit/multi/http/hp_sitescope_issuesiebelcmd
- [x] show targets
- [x] set target 0 (windows)
- [x] set payload [tab][tab]
- [x] Verify there are 114 possibilities

```
msf exploit(hp_sitescope_issuesiebelcmd) > set payload 
Display all 114 possibilities? (y or n)
```
- [x] show targets
- [x] set target 1 (linux)
- [x] set payload [tab][tab]
- [x] Verify there are 11 possibilities:

```
msf exploit(hp_sitescope_issuesiebelcmd) > set payload cmd/unix/
set payload cmd/unix/bind_awk                 set payload cmd/unix/reverse_awk              set payload cmd/unix/reverse_openssl          set payload cmd/unix/reverse_python
set payload cmd/unix/bind_perl                set payload cmd/unix/reverse_bash             set payload cmd/unix/reverse_perl             set payload cmd/unix/reverse_python_ssl
set payload cmd/unix/bind_perl_ipv6           set payload cmd/unix/reverse_bash_telnet_ssl  set payload cmd/unix/reverse_perl_ssl         
```
- [x] set target 0 (windows again)
- [x] set payload [tab][tab]
- [x] VERIFY THERE AREN'T OPTIONS! (it is because self.target['Payload'] has been modified)

Now switch to the branch on this pull request
- [x] From master start msfconsole
- [x] use exploit/multi/http/hp_sitescope_issuesiebelcmd
- [x] show targets
- [x] set target 0 (windows)
- [x] set payload [tab][tab]
- [x] Verify there are 114 possibilities

```
msf exploit(hp_sitescope_issuesiebelcmd) > set payload 
Display all 114 possibilities? (y or n)
```
- [x] show targets
- [x] set target 1 (linux)
- [x] set payload [tab][tab]
- [x] Verify there are 11 possibilities:

```
msf exploit(hp_sitescope_issuesiebelcmd) > set payload cmd/unix/
set payload cmd/unix/bind_awk                 set payload cmd/unix/reverse_awk              set payload cmd/unix/reverse_openssl          set payload cmd/unix/reverse_python
set payload cmd/unix/bind_perl                set payload cmd/unix/reverse_bash             set payload cmd/unix/reverse_perl             set payload cmd/unix/reverse_python_ssl
set payload cmd/unix/bind_perl_ipv6           set payload cmd/unix/reverse_bash_telnet_ssl  set payload cmd/unix/reverse_perl_ssl         
```
- [x] set target 0 (windows again)
- [x] set payload [tab][tab]
- [x] Verify there are 114 options again

```
msf exploit(hp_sitescope_issuesiebelcmd) > set payload 
Display all 114 possibilities? (y or n)

```
