### PR TITLE
Missing config false flag

### DIFF
--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -98,6 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
       :msfmodule     => self,
       :port          => port,
       :disable_agent => true,
+      :config        => false,
       :password      => pass
     }
 


### PR DESCRIPTION
the sshexec exploit was missing the flag
that tells net:ssh to not use the user's
local config . This can cuase ugly problem

MSP-9262
