### PR TITLE
Add :config => false to sysax_ssh_username

### DIFF
--- a/modules/exploits/windows/ssh/sysax_ssh_username.rb
+++ b/modules/exploits/windows/ssh/sysax_ssh_username.rb
@@ -216,7 +216,8 @@ class Metasploit3 < Msf::Exploit::Remote
           :password  => pass,
           :port      => datastore['RPORT'],
           :timeout   => 1,
-          :proxies   => datastore['Proxies']
+          :proxies   => datastore['Proxies'],
+          :config    => false
         })
 
       ::Timeout.timeout(1) {ssh.close} rescue nil


### PR DESCRIPTION
See #2812.

From the `net-ssh` docs:

":config => set to true to load the default OpenSSH config files (~/.ssh/config, /etc/ssh_config), or to false to not load them, or to a file-name (or array of file-names) to load those specific configuration files. Defaults to true."

We don't want that.
