### PR TITLE
Make gsubs compliant with the new indentation standard

### DIFF
--- a/modules/auxiliary/admin/edirectory/edirectory_edirutil.rb
+++ b/modules/auxiliary/admin/edirectory/edirectory_edirutil.rb
@@ -130,7 +130,7 @@ class Metasploit3 < Msf::Auxiliary
     </SOAP-ENV:Body>
     </SOAP-ENV:Envelope>|
 
-    template = template.gsub(/^\t\t/, '')
+    template = template.gsub(/^ {4}/, '')
     template = template.gsub(/\n/, '')
 
     connect

--- a/modules/exploits/linux/http/webid_converter.rb
+++ b/modules/exploits/linux/http/webid_converter.rb
@@ -99,7 +99,7 @@ class Metasploit3 < Msf::Exploit::Remote
       );
       ?>
     eof
-    currencies_php = currencies_php.gsub(/^\t\t\t/, '')
+    currencies_php = currencies_php.gsub(/^ {6}/, '')
 
     pwd = client.fs.dir.pwd
     print_status("#{peer} - Searching currencies.php file from #{pwd}")

--- a/modules/exploits/multi/browser/java_storeimagearray.rb
+++ b/modules/exploits/multi/browser/java_storeimagearray.rb
@@ -127,7 +127,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </body>
     </html>
     |
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
     return html
   end
 

--- a/modules/exploits/multi/browser/opera_historysearch.rb
+++ b/modules/exploits/multi/browser/opera_historysearch.rb
@@ -166,7 +166,7 @@ class Metasploit3 < Msf::Exploit::Remote
       send_not_found(cli)
       return
     end
-    content.gsub!(/^\t{4}/, '')
+    content.gsub!(/^ {8}/, '')
     content.gsub!(/\t/, ' ')
 
     send_response_html(cli, content, headers)

--- a/modules/exploits/multi/http/qdpm_upload_exec.rb
+++ b/modules/exploits/multi/http/qdpm_upload_exec.rb
@@ -83,7 +83,7 @@ class Metasploit3 < Msf::Exploit::Remote
     exec("#{fname}");
     ?>
     |
-    php = php.gsub(/^\t\t/, '').gsub(/\n/, ' ')
+    php = php.gsub(/^ {4}/, '').gsub(/\n/, ' ')
     return php
   end
 

--- a/modules/exploits/osx/browser/mozilla_mchannel.rb
+++ b/modules/exploits/osx/browser/mozilla_mchannel.rb
@@ -147,7 +147,7 @@ class Metasploit3 < Msf::Exploit::Remote
     HTML
 
     # remove the extra tabs
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
     print_status("Sending #{self.name}")
     send_response_html(cli, html, { 'Content-Type' => 'text/html' })
 

--- a/modules/exploits/windows/browser/adobe_flash_mp4_cprt.rb
+++ b/modules/exploits/windows/browser/adobe_flash_mp4_cprt.rb
@@ -263,7 +263,7 @@ pluginspage="http://www.macromedia.com/go/getflashplayer">
 </html>
     |
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending html")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/adobe_flash_otf_font.rb
+++ b/modules/exploits/windows/browser/adobe_flash_otf_font.rb
@@ -200,7 +200,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     |
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending HTML")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/adobe_flash_rtmp.rb
+++ b/modules/exploits/windows/browser/adobe_flash_rtmp.rb
@@ -415,7 +415,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     |
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending html")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/adobe_flash_sps.rb
+++ b/modules/exploits/windows/browser/adobe_flash_sps.rb
@@ -163,7 +163,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     |
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending HTML")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/adobe_flashplayer_arrayindexing.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_arrayindexing.rb
@@ -164,7 +164,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     EOS
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending #{self.name} HTML")
     send_response(cli, html, { 'Content-Type' => 'text/html' })

--- a/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
@@ -259,7 +259,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     EOS
 
-    html = html.gsub(/^\t\t/, "")
+    html = html.gsub(/^ {4}/, "")
 
     print_status("Sending HTML to...")
     send_response(cli, html, {'Content-Type' => "text/html"} )

--- a/modules/exploits/windows/browser/apple_quicktime_rdrf.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_rdrf.rb
@@ -98,7 +98,7 @@ class Metasploit4 < Msf::Exploit::Remote
     </html>
     |
 
-    html.gsub(/^\t\t/, '')
+    html.gsub(/^ {4}/, '')
   end
 
 

--- a/modules/exploits/windows/browser/blackice_downloadimagefileurl.rb
+++ b/modules/exploits/windows/browser/blackice_downloadimagefileurl.rb
@@ -128,7 +128,7 @@ class Metasploit3 < Msf::Exploit::Remote
     EOS
 
     #Clear the extra tabs
-    content = content.gsub(/^\t\t/, '')
+    content = content.gsub(/^ {4}/, '')
 
     print_status("Sending exploit HTML")
     send_response_html(cli, content)

--- a/modules/exploits/windows/browser/cisco_playerpt_setsource.rb
+++ b/modules/exploits/windows/browser/cisco_playerpt_setsource.rb
@@ -251,7 +251,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     MYHTML
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending html")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/cisco_playerpt_setsource_surl.rb
+++ b/modules/exploits/windows/browser/cisco_playerpt_setsource_surl.rb
@@ -429,7 +429,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     MYHTML
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending html")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/citrix_gateway_actx.rb
+++ b/modules/exploits/windows/browser/citrix_gateway_actx.rb
@@ -184,7 +184,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     EOS
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending #{self.name} HTML")
     send_response(cli, html, { 'Content-Type' => 'text/html' })

--- a/modules/exploits/windows/browser/clear_quest_cqole.rb
+++ b/modules/exploits/windows/browser/clear_quest_cqole.rb
@@ -108,7 +108,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     EOS
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("#{cli.peerhost}:#{cli.peerport} - Sending html")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/crystal_reports_printcontrol.rb
+++ b/modules/exploits/windows/browser/crystal_reports_printcontrol.rb
@@ -306,7 +306,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     html = load_exploit_html(my_target, cli)
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
     print_status("Sending HTML...")
     send_response(cli, html, {'Content-Type'=>'text/html'})
   end

--- a/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
+++ b/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
@@ -262,7 +262,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     html = load_exploit_html(my_target, cli)
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
     print_status("Sending HTML...")
     send_response(cli, html, {'Content-Type'=>'text/html'})
   end

--- a/modules/exploits/windows/browser/hp_loadrunner_writefilebinary.rb
+++ b/modules/exploits/windows/browser/hp_loadrunner_writefilebinary.rb
@@ -248,7 +248,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     html = load_exploit_html(my_target, cli)
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
     print_status("Sending HTML...")
     send_response(cli, html, {'Content-Type'=>'text/html'})
   end

--- a/modules/exploits/windows/browser/hp_loadrunner_writefilestring.rb
+++ b/modules/exploits/windows/browser/hp_loadrunner_writefilestring.rb
@@ -142,7 +142,7 @@ class Metasploit3 < Msf::Exploit::Remote
       send_not_found(cli)
       return
     end
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
     print_status("Sending HTML...")
     send_response(cli, html, {'Content-Type'=>'text/html'})
   end

--- a/modules/exploits/windows/browser/ibm_spss_c1sizer.rb
+++ b/modules/exploits/windows/browser/ibm_spss_c1sizer.rb
@@ -375,7 +375,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     html = load_exploit_html(my_target, cli)
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
     print_status("Sending HTML...")
     send_response(cli, html, {'Content-Type'=>'text/html'})
   end

--- a/modules/exploits/windows/browser/ibm_tivoli_pme_activex_bof.rb
+++ b/modules/exploits/windows/browser/ibm_tivoli_pme_activex_bof.rb
@@ -231,7 +231,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     HTML
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending html")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/ie_cbutton_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cbutton_uaf.rb
@@ -247,7 +247,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     html = load_exploit_html(my_target, cli)
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
     print_status("Sending HTML...")
     send_response(cli, html, {'Content-Type'=>'text/html'})
   end

--- a/modules/exploits/windows/browser/ie_cgenericelement_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cgenericelement_uaf.rb
@@ -227,7 +227,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     html = load_exploit_html(my_target, cli)
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
     print_status("Sending HTML...")
     send_response(cli, html, {'Content-Type'=>'text/html'})
   end

--- a/modules/exploits/windows/browser/ie_execcommand_uaf.rb
+++ b/modules/exploits/windows/browser/ie_execcommand_uaf.rb
@@ -334,7 +334,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return
     end
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     send_response(cli, html, {'Content-Type'=>'text/html'})
 

--- a/modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb
+++ b/modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb
@@ -276,7 +276,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     html = load_exploit_html(my_target, cli)
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
     print_status("Sending HTML...")
     send_response(cli, html, {'Content-Type'=>'text/html'})
   end

--- a/modules/exploits/windows/browser/inotes_dwa85w_bof.rb
+++ b/modules/exploits/windows/browser/inotes_dwa85w_bof.rb
@@ -281,7 +281,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     html = load_exploit_html(my_target, cli)
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
     print_status("Sending HTML...")
     send_response(cli, html, {'Content-Type'=>'text/html'})
   end

--- a/modules/exploits/windows/browser/intrust_annotatex_add.rb
+++ b/modules/exploits/windows/browser/intrust_annotatex_add.rb
@@ -240,7 +240,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Sending #{self.name}")
 
     #Remove the extra tabs from content
-    content = content.gsub(/^\t\t/, '')
+    content = content.gsub(/^ {4}/, '')
 
     # Transmit the response to the client
     send_response_html(cli, content)

--- a/modules/exploits/windows/browser/java_mixer_sequencer.rb
+++ b/modules/exploits/windows/browser/java_mixer_sequencer.rb
@@ -181,7 +181,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     |
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending HTML")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/mozilla_mchannel.rb
+++ b/modules/exploits/windows/browser/mozilla_mchannel.rb
@@ -339,7 +339,7 @@ class Metasploit3 < Msf::Exploit::Remote
     HTML
 
     #Remove the extra tabs
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
     print_status("Sending HTML...")
     send_response_html(cli, html, { 'Content-Type' => 'text/html' })
 

--- a/modules/exploits/windows/browser/mozilla_reduceright.rb
+++ b/modules/exploits/windows/browser/mozilla_reduceright.rb
@@ -221,7 +221,7 @@ class Metasploit3 < Msf::Exploit::Remote
       obj.reduceRight(f,1,2,3);
       JS
 
-      js = js.gsub(/^\t\t/, '')
+      js = js.gsub(/^ {4}/, '')
 
       if datastore['OBFUSCATE']
         js = ::Rex::Exploitation::JSObfu.new(js)
@@ -313,7 +313,7 @@ class Metasploit3 < Msf::Exploit::Remote
         js.obfuscate
       end
 
-      js = js.gsub(/^\t\t/, '')
+      js = js.gsub(/^ {4}/, '')
 
       html = <<-HTML
       <html>
@@ -330,7 +330,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     end
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending #{self.name}")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/ms10_026_avi_nsamplespersec.rb
+++ b/modules/exploits/windows/browser/ms10_026_avi_nsamplespersec.rb
@@ -150,7 +150,7 @@ class Metasploit3 < Msf::Exploit::Remote
       </html>
       |
 
-      html = html.gsub(/^\t\t\t/, '')
+      html = html.gsub(/^ {6}/, '')
 
       print_status("Sending trigger loader")
       send_response_html(cli, html)
@@ -212,7 +212,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     |
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending #{self.name}")
     send_response_html(cli, html)

--- a/modules/exploits/windows/browser/ms11_081_option.rb
+++ b/modules/exploits/windows/browser/ms11_081_option.rb
@@ -230,7 +230,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     html = load_exploit_html(my_target, cli)
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
     print_status("Sending HTML...")
     send_response(cli, html, {'Content-Type'=>'text/html'})
   end

--- a/modules/exploits/windows/browser/ms11_093_ole32.rb
+++ b/modules/exploits/windows/browser/ms11_093_ole32.rb
@@ -165,7 +165,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     |
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending html")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/ms12_004_midi.rb
+++ b/modules/exploits/windows/browser/ms12_004_midi.rb
@@ -323,7 +323,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     |
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending html to #{cli.peerhost}:#{cli.peerport}...")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/ms12_037_same_id.rb
+++ b/modules/exploits/windows/browser/ms12_037_same_id.rb
@@ -264,7 +264,7 @@ class Metasploit3 < Msf::Exploit::Remote
       </HTML>
     |
 
-    html = html.gsub(/^\t\t\t/, '')
+    html = html.gsub(/^ {6}/, '')
 
     print_status("Sending html")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/ms13_009_ie_slayoutrun_uaf.rb
+++ b/modules/exploits/windows/browser/ms13_009_ie_slayoutrun_uaf.rb
@@ -192,7 +192,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     html = get_exploit(my_target, cli)
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
     print_status "Sending HTML..."
     send_response(cli, html, {'Content-Type'=>'text/html'})
 

--- a/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
+++ b/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
@@ -132,18 +132,18 @@ class Metasploit3 < Msf::Exploit::Remote
     # Land the payload at 0x0c0c0c0c
     # For IE 8
     js = %Q|
-    var heap_obj = new heapLib.ie(0x20000);
-    var code = unescape("#{js_code}");
-    var nops = unescape("#{js_nops}");
-    while (nops.length < 0x80000) nops += nops;
-    var offset = nops.substring(0, #{my_target['Offset']});
-    var shellcode = offset + code + nops.substring(0, 0x800-code.length-offset.length);
-    while (shellcode.length < 0x40000) shellcode += shellcode;
-    var block = shellcode.substring(0, (0x80000-6)/2);
-    heap_obj.gc();
-    for (var i=1; i < 0x300; i++) {
-      heap_obj.alloc(block);
-    }
+var heap_obj = new heapLib.ie(0x20000);
+var code = unescape("#{js_code}");
+var nops = unescape("#{js_nops}");
+while (nops.length < 0x80000) nops += nops;
+var offset = nops.substring(0, #{my_target['Offset']});
+var shellcode = offset + code + nops.substring(0, 0x800-code.length-offset.length);
+while (shellcode.length < 0x40000) shellcode += shellcode;
+var block = shellcode.substring(0, (0x80000-6)/2);
+heap_obj.gc();
+for (var i=1; i < 0x300; i++) {
+  heap_obj.alloc(block);
+}
     |
 
     js = heaplib(js, {:noobfu => true})
@@ -398,7 +398,6 @@ function exploit(){
 
     if my_target['Rop'] == :ntdll and request.uri !~ /#{@second_stage_url}/
       html = html_info_leak
-      html = html.gsub(/^\t\t/, '')
       print_status("Sending HTML to info leak...")
       send_response(cli, html, {'Content-Type'=>'text/html'})
     else
@@ -410,7 +409,6 @@ function exploit(){
 
       if leak == 0
         html = load_exploit_html(my_target, cli)
-        html = html.gsub(/^\t\t/, '')
         print_status("Sending HTML to trigger...")
         send_response(cli, html, {'Content-Type'=>'text/html'})
         return
@@ -433,7 +431,6 @@ function exploit(){
       end
 
       html = load_exploit_html(my_target, cli)
-      html = html.gsub(/^\t\t/, '')
       print_status("Sending HTML to trigger...")
       send_response(cli, html, {'Content-Type'=>'text/html'})
 

--- a/modules/exploits/windows/browser/ms13_059_cflatmarkuppointer.rb
+++ b/modules/exploits/windows/browser/ms13_059_cflatmarkuppointer.rb
@@ -156,7 +156,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     |
 
-    html.gsub(/^\t\t/, '')
+    html.gsub(/^ {4}/, '')
   end
 
   def on_request_uri(cli, request)

--- a/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
+++ b/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
@@ -372,7 +372,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     EOS
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("#{cli.peerhost}:#{cli.peerport} - Sending html")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/novell_groupwise_gwcls1_actvx.rb
+++ b/modules/exploits/windows/browser/novell_groupwise_gwcls1_actvx.rb
@@ -269,7 +269,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     html = load_exploit_html(my_target, cli)
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
     print_status("Sending HTML...")
     send_response(cli, html, {'Content-Type'=>'text/html'})
   end

--- a/modules/exploits/windows/browser/ntr_activex_check_bof.rb
+++ b/modules/exploits/windows/browser/ntr_activex_check_bof.rb
@@ -351,7 +351,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     MYHTML
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending html")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/ntr_activex_stopmodule.rb
+++ b/modules/exploits/windows/browser/ntr_activex_stopmodule.rb
@@ -160,7 +160,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     MYHTML
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending html")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/oracle_autovue_setmarkupmode.rb
+++ b/modules/exploits/windows/browser/oracle_autovue_setmarkupmode.rb
@@ -396,7 +396,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     MYHTML
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending html")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/pcvue_func.rb
+++ b/modules/exploits/windows/browser/pcvue_func.rb
@@ -122,7 +122,7 @@ function main(){
 }
 EOS
 
-    js = js.gsub(/^\t\t/, '')
+    js = js.gsub(/^ {4}/, '')
 
     #JS obfuscation on demand
     if datastore['OBFUSCATE']
@@ -146,7 +146,7 @@ EOS
 EOS
 
     #Remove the extra tabs from content
-    content = content.gsub(/^\t\t/, '')
+    content = content.gsub(/^ {4}/, '')
 
     print_status("Sending #{self.name}")
     send_response(cli, content, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/quickr_qp2_bof.rb
+++ b/modules/exploits/windows/browser/quickr_qp2_bof.rb
@@ -258,7 +258,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     html = load_exploit_html(my_target, cli)
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
     print_status("Sending HTML...")
     send_response(cli, html, {'Content-Type'=>'text/html'})
   end

--- a/modules/exploits/windows/browser/real_arcade_installerdlg.rb
+++ b/modules/exploits/windows/browser/real_arcade_installerdlg.rb
@@ -102,7 +102,7 @@ class Metasploit3 < Msf::Exploit::Remote
     EOS
 
     # Remove extra tabs
-    html = html.gsub(/^\t\t/, "")
+    html = html.gsub(/^ {4}/, "")
 
     print_status("Sending #{self.name}")
     send_response(cli, html, { 'Content-Type' => 'text/html' })

--- a/modules/exploits/windows/browser/safari_xslt_output.rb
+++ b/modules/exploits/windows/browser/safari_xslt_output.rb
@@ -120,7 +120,7 @@ class Metasploit3 < Msf::Exploit::Remote
     EOS
 
     #Clear the extra tabs
-    content = content.gsub(/^\t\t/, '')
+    content = content.gsub(/^ {4}/, '')
 
     print_status("Sending #{self.name}")
     send_response(cli, content, {'Content-Type'=>'application/xml'})

--- a/modules/exploits/windows/browser/samsung_neti_wiewer_backuptoavi_bof.rb
+++ b/modules/exploits/windows/browser/samsung_neti_wiewer_backuptoavi_bof.rb
@@ -150,7 +150,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     EOS
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending html")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/siemens_solid_edge_selistctrlx.rb
+++ b/modules/exploits/windows/browser/siemens_solid_edge_selistctrlx.rb
@@ -490,7 +490,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     html = load_exploit_html(my_target)
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
     print_status("Sending HTML...")
     send_response(cli, html, {'Content-Type'=>'text/html'})
   end

--- a/modules/exploits/windows/browser/synactis_connecttosynactis_bof.rb
+++ b/modules/exploits/windows/browser/synactis_connecttosynactis_bof.rb
@@ -183,7 +183,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     |
 
-    html.gsub(/^\t\t/, '')
+    html.gsub(/^ {4}/, '')
   end
 
   def on_request_uri(cli, request)

--- a/modules/exploits/windows/browser/teechart_pro.rb
+++ b/modules/exploits/windows/browser/teechart_pro.rb
@@ -254,7 +254,7 @@ EOS
     print_status("Sending #{self.name}")
 
     #Remove the extra tabs from content
-    content = content.gsub(/^\t\t/, '')
+    content = content.gsub(/^ {4}/, '')
 
     # Transmit the response to the client
     send_response_html(cli, content)

--- a/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
+++ b/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
@@ -203,7 +203,7 @@ class Metasploit3 < Msf::Exploit::Remote
       var nops_padding = nops.substring(0, 0x73e-code.length-offset.length);
       var shellcode = code + nops_padding + rop_chain + nops_90.substring(0, 0x800-code.length-nops_padding.length-rop_chain.length);
       JS_ROP
-      js_shellcode = js_shellcode.gsub(/^\t\t\t/, '')
+      js_shellcode = js_shellcode.gsub(/^ {6}/, '')
     end
 
     js = <<-JS
@@ -251,7 +251,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     EOS
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending html")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/vlc_amv.rb
+++ b/modules/exploits/windows/browser/vlc_amv.rb
@@ -234,7 +234,7 @@ class Metasploit3 < Msf::Exploit::Remote
     EOS
 
     #Remove extra tabs in HTML
-    html = html.gsub(/^\t\t/, "")
+    html = html.gsub(/^ {4}/, "")
 
     print_status("Sending #{self.name}")
     send_response( cli, html, {'Content-Type' => 'text/html'} )

--- a/modules/exploits/windows/browser/vlc_mms_bof.rb
+++ b/modules/exploits/windows/browser/vlc_mms_bof.rb
@@ -204,7 +204,7 @@ class Metasploit3 < Msf::Exploit::Remote
     EOS
 
     #Remove extra tabs in HTML
-    html = html.gsub(/^\t\t/, "")
+    html = html.gsub(/^ {4}/, "")
 
     print_status("Sending malicious page")
     send_response( cli, html, {'Content-Type' => 'text/html'} )

--- a/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
+++ b/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
@@ -157,7 +157,7 @@ class Metasploit3 < Msf::Exploit::Remote
     EOS
 
     # Remove extra tabs
-    html = html.gsub(/^\t\t/, "")
+    html = html.gsub(/^ {4}/, "")
 
     print_status("Sending #{self.name}")
     send_response(cli, html, { 'Content-Type' => 'text/html' })

--- a/modules/exploits/windows/fileformat/adobe_reader_u3d.rb
+++ b/modules/exploits/windows/fileformat/adobe_reader_u3d.rb
@@ -268,7 +268,7 @@ class Metasploit3 < Msf::Exploit::Remote
     this.pageNum = 2;
     JS
 
-    js = js.gsub(/^\t\t/,'')
+    js = js.gsub(/^ {4}/,'')
 
     if datastore['OBFUSCATE']
       js = ::Rex::Exploitation::JSObfu.new(js)

--- a/modules/exploits/windows/fileformat/adobe_reader_u3d.rb
+++ b/modules/exploits/windows/fileformat/adobe_reader_u3d.rb
@@ -315,7 +315,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </template2>
     </xdp:xdp>|
 
-    xml = xml.gsub(/^\t\t/, '')
+    xml = xml.gsub(/^ {4}/, '')
     return xml
   end
 

--- a/modules/exploits/windows/fileformat/apple_quicktime_texml.rb
+++ b/modules/exploits/windows/fileformat/apple_quicktime_texml.rb
@@ -124,7 +124,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </text3GTrack>
     eos
 
-    texml = texml.gsub(/^\t\t/,'')
+    texml = texml.gsub(/^ {4}/,'')
 
     print_status("Creating '#{datastore['FILENAME']}'.")
     file_create(texml)

--- a/modules/exploits/windows/fileformat/mcafee_showreport_exec.rb
+++ b/modules/exploits/windows/fileformat/mcafee_showreport_exec.rb
@@ -174,7 +174,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </D:response>
     BODY
 
-    body = body.gsub(/^\t\t/, '')
+    body = body.gsub(/^ {4}/, '')
 
     if request["Depth"].to_i > 0
       if path.scan("/").length < 2
@@ -233,7 +233,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </D:propstat>
     </D:response>
     SHARE
-    share = share.gsub(/^\t\t/, '')
+    share = share.gsub(/^ {4}/, '')
     return share
   end
 
@@ -275,7 +275,7 @@ class Metasploit3 < Msf::Exploit::Remote
       FILES
     end
 
-    files = files.gsub(/^\t\t\t/, '')
+    files = files.gsub(/^ {6}/, '')
 
     return files
   end
@@ -316,7 +316,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     HTML
 
-    html = html.gsub(/^\t\t/, '')
+    html = html.gsub(/^ {4}/, '')
     file_create(html)
     print_status("#{datastore['FILENAME']} must be run locally in order to execute our payload")
 

--- a/modules/exploits/windows/fileformat/ms12_005.rb
+++ b/modules/exploits/windows/fileformat/ms12_005.rb
@@ -122,7 +122,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     end
 
-    p = p.gsub(/^\t\t\t/, '')
+    p = p.gsub(/^ {6}/, '')
 
     return p
   end

--- a/modules/exploits/windows/http/cyclope_ess_sqli.rb
+++ b/modules/exploits/windows/http/cyclope_ess_sqli.rb
@@ -119,7 +119,7 @@ class Metasploit3 < Msf::Exploit::Remote
     exec("#{fname}");
     ?>
     |
-    php = php.gsub(/^\t\t/, '').gsub(/\n/, ' ')
+    php = php.gsub(/^ {4}/, '').gsub(/\n/, ' ')
     return php
   end
 

--- a/modules/exploits/windows/misc/itunes_extm3u_bof.rb
+++ b/modules/exploits/windows/misc/itunes_extm3u_bof.rb
@@ -133,7 +133,7 @@ class Metasploit3 < Msf::Exploit::Remote
       </html>
     HTML_REDIR
 
-    ie_redir = ie_redir.gsub(/^\t\t\t/, '')
+    ie_redir = ie_redir.gsub(/^ {6}/, '')
 
     return ie_redir
   end

--- a/modules/exploits/windows/misc/wireshark_lua.rb
+++ b/modules/exploits/windows/misc/wireshark_lua.rb
@@ -179,7 +179,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </D:response>
     BODY
 
-    body = body.gsub(/^\t\t/, '')
+    body = body.gsub(/^ {4}/, '')
 
     if request["Depth"].to_i > 0
       if path.scan("/").length < 2
@@ -242,7 +242,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </D:propstat>
     </D:response>
     SHARE
-    share = share.gsub(/^\t\t/, '')
+    share = share.gsub(/^ {4}/, '')
     return share
   end
 
@@ -284,7 +284,7 @@ class Metasploit3 < Msf::Exploit::Remote
       FILES
     end
 
-    files = files.gsub(/^\t\t\t/, '')
+    files = files.gsub(/^ {6}/, '')
 
     return files
   end
@@ -311,7 +311,7 @@ class Metasploit3 < Msf::Exploit::Remote
     os.execute(#{var_temp_name})
     LUA
 
-    lua_script = lua_script.gsub(/^\t\t/, '')
+    lua_script = lua_script.gsub(/^ {4}/, '')
     return lua_script
   end
 

--- a/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
+++ b/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
@@ -92,7 +92,7 @@ class Metasploit3 < Msf::Exploit::Remote
     exec("#{fname}");
     ?>
     |
-    php = php.gsub(/^\t\t/, '').gsub(/\n/, ' ')
+    php = php.gsub(/^ {4}/, '').gsub(/\n/, ' ')
     return php
   end
 

--- a/modules/exploits/windows/scada/iconics_webhmi_setactivexguid.rb
+++ b/modules/exploits/windows/scada/iconics_webhmi_setactivexguid.rb
@@ -211,7 +211,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     EOS
 
-    html = html.gsub(/^\t\t/, "")
+    html = html.gsub(/^ {4}/, "")
 
     print_status("Sending malicious page")
     send_response(cli, html, {'Content-Type'=>'text/html'})


### PR DESCRIPTION
Indentation Standard changed in the framework to two-space soft tabs on 2013: https://github.com/rapid7/metasploit-framework/wiki/Indentation-Standards

This pull request updates usage of "gsub" on the modules in order to be compliant with the new indentation standard.
# Verification
- [x] Verify msfconsole is able to load all the modules
- [x] Verify any  gsub from /^\t is switched to have into account spaces, but not tabs. Every \t == 2 spaces
- [x] Verify the change on modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb is correct. This module mainly doesn't need gsub for init spaces/tabs so just modifying the module to avoid its usage.
