### PR TITLE
De-dupe and update .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -2,6 +2,7 @@ bturner-r7 <bturner-r7@github>     Brandon Turner <brandon_turner@rapid7.com>
 dmaloney-r7 <dmaloney-r7@github>   David Maloney <David_Maloney@rapid7.com>
 dmaloney-r7 <dmaloney-r7@github>   David Maloney <DMaloney@rapid7.com> # aka TheLightCosine
 ecarey-r7 <ecarey-r7@github>       Erran Carey <e@ipwnstuff.com>
+farias-r7 <farias-r7@github>       Fernando Arias <fernando_arias@rapid7.com>
 hmoore-r7 <hmoore-r7@github>       HD Moore <hd_moore@rapid7.com>
 hmoore-r7 <hmoore-r7@github>       HD Moore <hdm@digitaloffense.net>
 jlee-r7 <jlee-r7@github>           egypt <egypt@metasploit.com> # aka egypt
@@ -13,14 +14,16 @@ jvazquez-r7 <jvazquez-r7@github>   jvazquez-r7 <juan.vazquez@metasploit.com>
 jvazquez-r7 <jvazquez-r7@github>   jvazquez-r7 <juan_vazquez@rapid7.com>
 limhoff-r7 <limhoff-r7@github>     Luke Imhoff <luke_imhoff@rapid7.com>
 shuckins-r7 <shuckins-r7@github>   Samuel Huckins <samuel_huckins@rapid7.com>
-tasos-r7 <tasos-r7@github>         Tasos Laskos <Tasos_Laskos@rapid7.com>
 todb-r7 <todb-r7@github>           Tod Beardsley <tod_beardsley@rapid7.com>
 todb-r7 <todb-r7@github>           Tod Beardsley <todb@metasploit.com>
+todb-r7 <todb-r7@github>           Tod Beardsley <todb@packetfu.com>
+trosen-r7 <trosen-r7@github>       Trevor Rosen <Trevor_Rosen@rapid7.com>
 wchen-r7 <wchen-r7@github>         sinn3r <msfsinn3r@gmail.com> # aka sinn3r
 wchen-r7 <wchen-r7@github>         sinn3r <wei_chen@rapid7.com>
 wchen-r7 <wchen-r7@github>         Wei Chen <Wei_Chen@rapid7.com>
 wvu-r7 <wvu-r7@github>             William Vu <William_Vu@rapid7.com>
 wvu-r7 <wvu-r7@github>             William Vu <wvu@metasploit.com>
+wvu-r7 <wvu-r7@github>             William Vu <wvu@nmt.edu>
 
 # Above this line are current Rapid7 employees. Below this paragraph are
 # volunteers, former employees, and potential Rapid7 employees who, at
@@ -72,9 +75,18 @@ OJ <oj@github>                         OJ Reeves <oj@buffered.io>
 OJ <oj@github>                         OJ <oj@buffered.io>
 r3dy <r3dy@github>                     Royce Davis <r3dy@Royces-MacBook-Pro.local>
 r3dy <r3dy@github>                     Royce Davis <royce.e.davis@gmail.com>
+Rick Flores <0xnanoquetz9l@gmail.com>  Rick Flores (nanotechz9l) <0xnanoquetz9l@gmail.com>
 rsmudge <rsmudge@github>               Raphael Mudge <rsmudge@gmail.com> # Aka `butane
 schierlm <schierlm@github>             Michael Schierl <schierlm@gmx.de> # Aka mihi
 scriptjunkie <scriptjunkie@github>     Matt Weeks <scriptjunkie@scriptjunkie.us>
 skape <skape@???>                      Matt Miller <mmiller@hick.org>
 spoonm <spoonm@github>                 Spoon M <spoonm@gmail.com>
 swtornio <swtornio@github>             Steve Tornio <swtornio@gmail.com>
+Tasos Laskos <Tasos_Laskos@rapid7.com> Tasos Laskos <Tasos_Laskos@rapid7.com>
+TrustedSec <davek@trustedsec.com>      trustedsec <davek@trustedsec.com>
+
+# Aliases for utility author names. Since they're fake, typos abound
+
+Tab Assassin <tabassassin@metasploit.com> Tabasssassin <tabassassin@metasploit.com>
+Tab Assassin <tabassassin@metasploit.com> Tabassassin <tabassassin@metasploit.com>
+Tab Assassin <tabassassin@metasploit.com> TabAssassin <tabasssassin@metasploit.com>


### PR DESCRIPTION
In the wake of https://community.rapid7.com/community/metasploit/blog/2013/12/31/metasploit-closes-out-2013 I noticed several dupes and failures to note Rapid7 accounts.

This should cover most of the contributors that have multiple `user.name` and `user.email` aliases in their various `.gitconfig` files, so we can correctly score commit counts. 

Like lines of code and hours spent, commit counts are a rock solid way of telling who's productive and who should be fired.
