### PR TITLE
Don't use Pcap.lookupaddrs any more

### DIFF
--- a/modules/auxiliary/server/icmp_exfil.rb
+++ b/modules/auxiliary/server/icmp_exfil.rb
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Auxiliary
       # this is needed on windows cause we send interface directly to Pcap functions
       @interface = get_interface_guid(@interface)
       @iface_ip = datastore['LOCALIP']
-      @iface_ip ||= Pcap.lookupaddrs(@interface)[0] if netifaces
+      @iface_ip ||= get_ipv4_addr(@interface) if netifaces
       raise "Interface IP is not defined and can not be guessed" unless @iface_ip
 
       # start with blank slate


### PR DESCRIPTION
Quick fix to make icmp_exfil functional again.
