### PR TITLE
Adjust the getenv API

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/config.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/config.rb
@@ -37,7 +37,7 @@ class Config
   # Returns a hash of requested environment variables, along with their values.
   # If a requested value doesn't exist in the response, then the value wasn't found.
   #
-  def getenv(var_names)
+  def getenvs(*var_names)
     request = Packet.create_request('stdapi_sys_config_getenv')
 
     var_names.each do |v|
@@ -54,6 +54,13 @@ class Config
     end
 
     return result
+  end
+
+  #
+  # Returns the value of a single requested environment variable name
+  #
+  def getenv(var_name)
+    getenvs(var_name)[var_name]
   end
 
   #

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/sys.rb
@@ -279,8 +279,11 @@ class Console::CommandDispatcher::Stdapi::Sys
     print_line("Server username: #{client.sys.config.getuid}")
   end
 
+  #
+  # Get the value of one or more environment variables from the target.
+  #
   def cmd_getenv(*args)
-    vars = client.sys.config.getenv(args)
+    vars = client.sys.config.getenvs(*args)
 
     if vars.length == 0
       print_error("None of the specified environment variables were found/set.")


### PR DESCRIPTION
The `getenv` call in `sys/config.rb` was renamed to `getenvs` and now uses the splat operator so that arrays don't have to be passed in. A new function called `getenv` was added which takes a single argument and returns a single value back (for ease of use).

This PR was pulled out of https://github.com/rapid7/metasploit-framework/pull/2782/ so that the change can be included prior to all the other modules being tested.

Sample run from the session prompt:

```
meterpreter > getenv USERPROFILE TEMP USERNAME

Environment Variables
=====================

Variable     Value
--------     -----
USERPROFILE  C:\Users\OJ
TEMP         C:\Users\OJ\AppData\Local\Temp
USERNAME     OJ
```

And here's what it looks like in irb:

```
meterpreter > irb
[*] Starting IRB shell
[*] The 'client' variable holds the meterpreter client

>> client.sys.config.getenv('TEMP')
=> "C:\\Users\\OJ\\AppData\\Local\\Temp"
>> client.sys.config.getenvs('TEMP', 'USERPROFILE')
=> {"TEMP"=>"C:\\Users\\OJ\\AppData\\Local\\Temp", "USERPROFILE"=>"C:\\Users\\OJ"}
>> client.sys.config.getenv('DOESNOTEXIST')
=> nil
```
