### PR TITLE
Always Use LHOST for Full URL in HTTP/S Stage

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -409,27 +409,6 @@ protected
     port > 0 ? port : datastore['LPORT'].to_i
   end
 
-  def bind_address
-    # Switch to IPv6 ANY address if the LHOST is also IPv6
-    addr = Rex::Socket.resolv_nbo(datastore['LHOST'])
-    # First attempt to bind LHOST. If that fails, the user probably has
-    # something else listening on that interface. Try again with ANY_ADDR.
-    any = (addr.length == 4) ? "0.0.0.0" : "::0"
-
-    addrs = [ Rex::Socket.addr_ntoa(addr), any  ]
-
-    if not datastore['ReverseListenerBindAddress'].to_s.empty?
-      # Only try to bind to this specific interface
-      addrs = [ datastore['ReverseListenerBindAddress'] ]
-
-      # Pick the right "any" address if either wildcard is used
-      addrs[0] = any if (addrs[0] == "0.0.0.0" or addrs == "::0")
-    end
-
-    addrs
-  end
-
-
 end
 
 end

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -83,7 +83,6 @@ module ReverseHttp
   # addresses.
   #
   def full_uri
-    addrs = bind_address
     local_port = bind_port
     scheme = (ssl?) ? "https" : "http"
     "#{scheme}://#{datastore['LHOST']}:#{local_port}/"
@@ -175,12 +174,18 @@ module ReverseHttp
     end
 
     local_port = bind_port
-    addrs = bind_address
+
+    # Determine where to bind the HTTP(S) server to
+    bindaddrs = ipv6 ? '::' : '0.0.0.0'
+
+    if not datastore['ReverseListenerBindAddress'].to_s.empty?
+      bindaddrs = datastore['ReverseListenerBindAddress']
+    end
 
     # Start the HTTPS server service on this host/port
     self.service = Rex::ServiceManager.start(Rex::Proto::Http::Server,
       local_port,
-      addrs[0],
+      bindaddrs,
       ssl?,
       {
         'Msf'        => framework,

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -86,7 +86,7 @@ module ReverseHttp
     addrs = bind_address
     local_port = bind_port
     scheme = (ssl?) ? "https" : "http"
-    "#{scheme}://#{addrs[0]}:#{local_port}/"
+    "#{scheme}://#{datastore['LHOST']}:#{local_port}/"
   end
 
   #

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -85,7 +85,7 @@ module ReverseHttp
   def full_uri
     local_port = bind_port
     scheme = (ssl?) ? "https" : "http"
-    "#{scheme}://#{datastore['LHOST']}:#{local_port}/"
+    "#{scheme}://#{datastore['LHOST']}:#{datastore['LPORT']}/"
   end
 
   #


### PR DESCRIPTION
Redmine #8726 documents a change where the reverse HTTP/S
tries to bind LHOST and if it can not it does a hard stop

If it's expected that users will use ReverseListenerBind-
-Address then this commit addresses #8726 by patching the
HTTP/S stage with the host provided by the user in LHOST.

Currently ReverseListenerBindAddress (if used) is patched
into the stage. This makes for a broken HTTP/S session if
the user sets this option to 0.0.0.0.

With this commit--users can provide any LHOST they like
and set ReverseListenerBindAddress to 0.0.0.0 and things
will work.

This commit does not attempt to bring the HTTP/S handler
back to the old behavior of falling back to 0.0.0.0 when
it can't bind LHOST. I'd welcome the old behavior but I
leave it to you to decide what makes sense. :)
