### PR TITLE
Fixes #8732, sessions -c truncates output on osx python meterpreter session

### DIFF
--- a/data/meterpreter/meterpreter.py
+++ b/data/meterpreter/meterpreter.py
@@ -158,15 +158,10 @@ class STDProcessBuffer(threading.Thread):
 		self.data_lock = threading.RLock()
 
 	def run(self):
-		while self.is_alive():
-			byte = self.std.read(1)
+		for byte in iter(lambda: self.std.read(1), ''):
 			self.data_lock.acquire()
 			self.data += byte
 			self.data_lock.release()
-		data = self.std.read()
-		self.data_lock.acquire()
-		self.data += data
-		self.data_lock.release()
 
 	def is_read_ready(self):
 		return len(self.data) != 0
@@ -185,6 +180,7 @@ class STDProcessBuffer(threading.Thread):
 
 class STDProcess(subprocess.Popen):
 	def __init__(self, *args, **kwargs):
+		kwargs['bufsize'] = 0    # disable buffering on stdout/err
 		subprocess.Popen.__init__(self, *args, **kwargs)
 
 	def start(self):

--- a/data/meterpreter/meterpreter.py
+++ b/data/meterpreter/meterpreter.py
@@ -180,7 +180,6 @@ class STDProcessBuffer(threading.Thread):
 
 class STDProcess(subprocess.Popen):
 	def __init__(self, *args, **kwargs):
-		kwargs['bufsize'] = 0    # disable buffering on stdout/err
 		subprocess.Popen.__init__(self, *args, **kwargs)
 
 	def start(self):


### PR DESCRIPTION
So it seems like it takes a while on my osx machine for output to appear on the `stdout` python buffer. Simply waiting for the process to end, then reading any available output does not seem to work. I also tried adding a `self.std.flush` before the final read, but it made no effect. Instead I changed it to read until a '' is returned. From the [docs](http://docs.python.org/2/library/stdtypes.html?highlight=read#file.read): "An empty string is returned when EOF is encountered immediately."

Verification steps:
- [ ] Regenerate the python meterpreter payload
- [ ] Verify you can get a python meterpreter session on a windows box. Ensure you can run a command and the output is present: `sessions -i 1 -c ping`
- [ ] Verify you can get a python meterpreter session on an osx box. Ensure you can run a command and the output is present: `sessions -i 1 -c ping`
- [ ] Verify you can get a python meterpreter session on a linux box. Ensure you can run a command and the output is present: `sessions -i 1 -c ping`
