### PR TITLE
Avoid specific versions in module names

### DIFF
--- a/modules/exploits/multi/http/vtiger_soap_upload.rb
+++ b/modules/exploits/multi/http/vtiger_soap_upload.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'vTigerCRM v5.4.0 SOAP AddEmailAttachment Arbitrary File Upload',
+      'Name'           => 'vTiger CRM SOAP AddEmailAttachment Arbitrary File Upload',
       'Description'    => %q{
           vTiger CRM allows an user to bypass authentication when requesting SOAP services.
           In addition, arbitrary file upload is possible through the AddEmailAttachment SOAP


### PR DESCRIPTION
They tend to be a lie and give people the idea that only that version is
vulnerable.
