### PR TITLE
Add wrt100 support to wrt110 exploit

### DIFF
--- a/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
@@ -13,10 +13,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => 'Linksys WRT110 Remote Command Execution',
+      'Name'        => 'Linksys WRT100/WRT110 Remote Command Execution',
       'Description' => %q{
-        The Linksys WRT110 consumer router is vulnerable to a command injection
-        exploit in the ping field of the web interface.
+        The Linksys WRT100 and WRT110 consumer routers are vulnerable to a command
+        injection exploit in the ping field of the web interface.
       },
       'Author'      =>
         [


### PR DESCRIPTION
The wrt110 and wrt100 share the same firmware, and are both vulnerable to this bug. The firmware is `FW_WRT110_WRT100_1.0.07.002_EN_20091123.bin`
