### PR TITLE
Fix a bug in RangeWalker when resolution fails

### DIFF
--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -361,17 +361,12 @@ module Socket
   #
   # Converts an integer address into ascii
   #
+  # @param (see #addr_iton)
+  # @return (see #addr_ntoa)
   def self.addr_itoa(addr, v6=false)
-
     nboa = addr_iton(addr, v6)
 
-    # IPv4
-    if (addr < 0x100000000 and not v6)
-      addr_ntoa(nboa)
-    # IPv6
-    else
-      addr_ntoa(nboa)
-    end
+    addr_ntoa(nboa)
   end
 
   #
@@ -384,6 +379,8 @@ module Socket
   #
   # Converts a network byte order address to ascii
   #
+  # @param addr [String] Packed network-byte-order address
+  # @return [String] Human readable IP address.
   def self.addr_ntoa(addr)
     # IPv4
     if (addr.length == 4)
@@ -401,8 +398,11 @@ module Socket
   #
   # Implement zero compression for IPv6 addresses.
   # Uses the compression method from Marco Ceresa's IPAddress GEM
-  #	https://github.com/bluemonk/ipaddress/blob/master/lib/ipaddress/ipv6.rb
   #
+  # @see https://github.com/bluemonk/ipaddress/blob/master/lib/ipaddress/ipv6.rb
+  #
+  # @param addr [String] Human readable IPv6 address
+  # @return [String] Human readable IPv6 address with runs of 0s removed
   def self.compress_address(addr)
     return addr unless is_ipv6?(addr)
     addr = addr.dup
@@ -442,6 +442,8 @@ module Socket
   #
   # Converts an integer into a network byte order address
   #
+  # @param addr [Numeric] The address as a number
+  # @param v6 [Boolean] Whether +addr+ is IPv6
   def self.addr_iton(addr, v6=false)
     if(addr < 0x100000000 and not v6)
       return [addr].pack('N')

--- a/lib/rex/socket/range_walker.rb
+++ b/lib/rex/socket/range_walker.rb
@@ -193,10 +193,11 @@ class RangeWalker
   def next_ip
     return false if not valid?
     if (@curr_addr > @ranges[@curr_range].stop)
-      if (@curr_range >= @ranges.length - 1)
-        return nil
-      end
       @curr_range += 1
+
+      # Are we finished?
+      return nil if (@curr_range >= @ranges.length)
+
       @curr_addr = @ranges[@curr_range].start
     end
     addr = Rex::Socket.addr_itoa(@curr_addr, @ranges[@curr_range].ipv6?)

--- a/lib/rex/socket/range_walker.rb
+++ b/lib/rex/socket/range_walker.rb
@@ -13,12 +13,31 @@ module Socket
 # show-stoppingly inefficient when storing a bunch of non-consecutive
 # addresses, which should be a somewhat unusual case.
 #
+# @example
+#   r = RangeWalker.new("10.1,3.1-7.1-255")
+#   r.include?("10.3.7.255") #=> true
+#   r.length #=> 3570
+#   r.each do |addr|
+#     # do something with the address
+#   end
 ###
 class RangeWalker
 
+  # The total number of IPs within the range
   #
+  # @return [Fixnum]
+  attr_reader :length
+
+  # for backwards compatibility
+  alias :num_ips :length
+
+  # A list of the {Range ranges} held in this RangeWalker
+  # @return [Array]
+  attr_reader :ranges
+
   # Initializes a walker instance using the supplied range
   #
+  # @param parseme [RangeWalker,String]
   def initialize(parseme)
     if parseme.is_a? RangeWalker
       @ranges = parseme.ranges.dup
@@ -33,6 +52,7 @@ class RangeWalker
   #
   # This is basically only useful for determining if a range can be parsed
   #
+  # @return (see #parse)
   def self.parse(parseme)
     self.new.parse(parseme)
   end
@@ -41,19 +61,22 @@ class RangeWalker
   # Turn a human-readable range string into ranges we can step through one address at a time.
   #
   # Allow the following formats:
-  #	"a.b.c.d e.f.g.h"
-  #	"a.b.c.d, e.f.g.h"
-  # where each chunk is CIDR notation, (e.g. '10.1.1.0/24') or a range in nmap format (see expand_nmap)
+  #   "a.b.c.d e.f.g.h"
+  #   "a.b.c.d, e.f.g.h"
+  # where each chunk is CIDR notation, (e.g. '10.1.1.0/24') or a range in nmap format (see {#expand_nmap})
   #
   # OR this format
-  #	"a.b.c.d-e.f.g.h"
+  #   "a.b.c.d-e.f.g.h"
   # where a.b.c.d and e.f.g.h are single IPs and the second must be
   # bigger than the first.
   #
+  # @param parseme [String]
+  # @return [self]
+  # @return [false] if +parseme+ cannot be parsed
   def parse(parseme)
     return nil if not parseme
     ranges = []
-    parseme.split(', ').map{ |a| a.split(' ') }.flatten.each { |arg|
+    parseme.split(', ').map{ |a| a.split(' ') }.flatten.each do |arg|
       opts = {}
 
       # Handle IPv6 first (support ranges, but not CIDR)
@@ -67,7 +90,7 @@ class RangeWalker
 
           return false unless Rex::Socket.is_ipv6?(addr)
           addr = Rex::Socket.addr_atoi(addr)
-          ranges.push [addr, addr, true, opts]
+          ranges.push(Range.new(addr, addr, true, opts))
           next
         end
 
@@ -77,13 +100,14 @@ class RangeWalker
         addr2, scope_id = addrs[0].split('%')
         ( opts[:scope_id] ||= scope_id ) if scope_id
 
-        return false if not (Rex::Socket.is_ipv6?(addr1) and Rex::Socket.is_ipv6?(addr2))
+        # Both have to be IPv6 for this to work
+        return false unless (Rex::Socket.is_ipv6?(addr1) && Rex::Socket.is_ipv6?(addr2))
 
         # Handle IPv6 ranges in the form of 2001::1-2001::10
         addr1 = Rex::Socket.addr_atoi(addr1)
         addr2 = Rex::Socket.addr_atoi(addr2)
 
-        ranges.push [addr1, addr2, true, opts]
+        ranges.push(Range.new(addr1, addr2, true, opts))
         next
 
       # Handle IPv4 CIDR
@@ -116,19 +140,20 @@ class RangeWalker
         # Then it's a domain name and we should send it on to addr_atoi
         # unmolested to force a DNS lookup.
         begin
-          Rex::Socket.addr_atoi_list(arg).each { |addr| ranges.push [addr, addr, false, opts] }
+          ranges += Rex::Socket.addr_atoi_list(arg).map { |a| Range.new(a, a, false, opts) }
         rescue Resolv::ResolvError, ::SocketError, Errno::ENOENT
           return false
         end
 
       # Handle IPv4 ranges
       elsif arg =~ /^([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})-([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})$/
+
         # Then it's in the format of 1.2.3.4-5.6.7.8
         # Note, this will /not/ deal with DNS names, or the fancy/obscure 10...1-10...2
         begin
-          addrs = [Rex::Socket.addr_atoi($1), Rex::Socket.addr_atoi($2)]
-          return false if addrs[0] > addrs[1] # The end is greater than the beginning.
-          ranges.push [addrs[0], addrs[1], false, opts]
+          start, stop = Rex::Socket.addr_atoi($1), Rex::Socket.addr_atoi($2)
+          return false if start > stop # The end is greater than the beginning.
+          ranges.push(Range.new(start, stop, false, opts))
         rescue Resolv::ResolvError, ::SocketError, Errno::ENOENT
           return false
         end
@@ -139,7 +164,7 @@ class RangeWalker
           expanded.each { |r| ranges.push(r) }
         end
       end
-    }
+    end
 
     # Remove any duplicate ranges
     ranges = ranges.uniq
@@ -150,51 +175,58 @@ class RangeWalker
   #
   # Resets the subnet walker back to its original state.
   #
+  # @return [self]
   def reset
     return false if not valid?
     @curr_range = 0
-    @curr_addr = @ranges[0][0]
+    @curr_addr = @ranges.first.start
     @length = 0
-    @ranges.each { |r| @length += r[1] - r[0] + 1 }
+    @ranges.each { |r| @length += r.length }
+
+    self
   end
 
-  #
   # Returns the next IP address.
   #
+  # @return [String] The next address in the range
   def next_ip
     return false if not valid?
-    if (@curr_addr > @ranges[@curr_range][1])
+    if (@curr_addr > @ranges[@curr_range].stop)
       if (@curr_range >= @ranges.length - 1)
         return nil
       end
       @curr_range += 1
-      @curr_addr = @ranges[@curr_range][0]
+      @curr_addr = @ranges[@curr_range].start
     end
-    addr = Rex::Socket.addr_itoa(@curr_addr, @ranges[@curr_range][2])
+    addr = Rex::Socket.addr_itoa(@curr_addr, @ranges[@curr_range].ipv6)
 
-    if @ranges[@curr_range][3][:scope_id]
-      addr = addr + '%' + @ranges[@curr_range][3][:scope_id]
+    if @ranges[@curr_range].options[:scope_id]
+      addr = addr + '%' + @ranges[@curr_range].options[:scope_id]
     end
 
     @curr_addr += 1
     return addr
   end
 
+  alias :next :next_ip
+
+  # Whether this RangeWalker's ranges are valid
   def valid?
-    (@ranges and not @ranges.empty?)
+    (@ranges && !@ranges.empty?)
   end
 
-  #
   # Returns true if the argument is an ip address that falls within any of
   # the stored ranges.
   #
+  # @return [true] if this RangeWalker contains +addr+
+  # @return [false] if not
   def include?(addr)
     return false if not @ranges
     if (addr.is_a? String)
       addr = Rex::Socket.addr_atoi(addr)
     end
     @ranges.map { |r|
-      if r[0] <= addr and addr <= r[1]
+      if addr.between?(r.start, r.stop)
         return true
       end
     }
@@ -202,35 +234,45 @@ class RangeWalker
   end
 
   #
-  # Returns true if this RangeWalker includes all of the addresses in the
+  # Returns true if this RangeWalker includes *all* of the addresses in the
   # given RangeWalker
   #
-  def include_range?(range_walker)
-    return false if ((not @ranges) or @ranges.empty?)
-    return false if not range_walker.ranges
+  # @param other [RangeWalker]
+  def include_range?(other)
+    return false if (!@ranges || @ranges.empty?)
+    return false if !other.ranges || other.ranges.empty?
 
-    range_walker.ranges.all? do |start, stop|
-      ranges.any? do |self_start, self_stop|
-        r = (self_start..self_stop)
-        r.include?(start) and r.include?(stop)
+    # Check that all the ranges in +other+ fall within at least one of
+    # our ranges.
+    other.ranges.all? do |other_range|
+      ranges.any? do |range|
+        other_range.start.between?(range.start, range.stop) && other_range.stop.between?(range.start, range.stop)
       end
     end
   end
 
   #
   # Calls the given block with each address. This is basically a wrapper for
-  # #next_ip
+  # {#next_ip}
   #
+  # @return [self]
   def each(&block)
     while (ip = next_ip)
       block.call(ip)
     end
+    reset
+
+    self
   end
 
   #
-  # Returns an array with one element, a Range defined by the given CIDR
+  # Returns an Array with one element, a {Range} defined by the given CIDR
   # block.
   #
+  # @see Rex::Socket.cidr_crack
+  # @param arg [String] A CIDR range
+  # @return [Range]
+  # @return [false] if +arg+ is not valid CIDR notation
   def expand_cidr(arg)
     start,stop = Rex::Socket.cidr_crack(arg)
     if !start or !stop
@@ -373,27 +415,43 @@ class RangeWalker
     return ranges
   end
 
-  #
-  # The total number of IPs within the range
-  #
-  attr_reader :length
-
-  # for backwards compatibility
-  alias :num_ips :length
-
-  attr_reader :ranges
-
 end
 
-class Range < Array # :nodoc: all
-  def start; self[0]; end
-  def stop;  self[1]; end
-  def ipv6;  self[2]; end
-  def options; self[3]; end
-  def start=(val); self[0] = val; end
-  def stop=(val);  self[1] = val; end
-  def ipv6=(val);  self[2] = val; end
-  def options=(val); self[3] = val; end
+# A range of IP addresses
+class Range
+  def initialize(start=nil, stop=nil, ipv6=nil, options=nil)
+    @start = start
+    @stop = stop
+    @ipv6 = ipv6
+    @options = options
+  end
+
+  # Compare attributes with +other+
+  # @param other [Range]
+  def ==(other)
+    (other.start == start && other.stop == stop && other.ipv6 == ipv6 && other.options == options)
+  end
+
+  # The number of addresses in this Range
+  def length
+    stop - start + 1
+  end
+
+  #@!attribute start
+  #   The first address in this range, as a number
+  #   @return [Fixnum]
+  attr_accessor :start
+  #@!attribute stop
+  #   The last address in this range, as a number
+  #   @return [Fixnum]
+  attr_accessor :stop
+  #@!attribute ipv6
+  #   Whether this Range contains IPv6 or IPv4 addresses
+  #   @return [Boolean]
+  attr_accessor :ipv6
+  #@!attribute options
+  #   @return [Hash]
+  attr_accessor :options
 end
 
 end

--- a/spec/lib/rex/socket/range_walker_spec.rb
+++ b/spec/lib/rex/socket/range_walker_spec.rb
@@ -2,12 +2,36 @@
 require 'rex/socket/range_walker'
 
 describe Rex::Socket::RangeWalker do
-  it "should have a num_ips attribute" do
-    walker = Rex::Socket::RangeWalker.new("")
-    walker.should respond_to("num_ips")
-    walker.should respond_to("length")
-    walker.num_ips.should == walker.length
+
+  let(:args) { "::1" }
+  subject(:walker) { described_class.new(args) }
+
+  it { should respond_to(:num_ips) }
+  it { should respond_to(:length) }
+  it { should respond_to(:valid?) }
+
+  context "with a hostname" do
+    let(:args) { "localhost" }
+    it { should be_valid }
+    it "should have one address" do
+      walker.length.should == 1
+    end
   end
+
+  context "with a hostname and CIDR" do
+    let(:args) { "localhost/24" }
+    it { should be_valid }
+    it "should have 256 addresses" do
+      walker.length.should == 256
+    end
+  end
+
+  context "with an invalid hostname" do
+    let(:args) { "asdf.foo." }
+    it { should_not be_valid }
+  end
+
+
   it "should handle single ipv6 addresses" do
     walker = Rex::Socket::RangeWalker.new("::1")
     walker.should be_valid

--- a/spec/lib/rex/socket/range_walker_spec.rb
+++ b/spec/lib/rex/socket/range_walker_spec.rb
@@ -6,134 +6,150 @@ describe Rex::Socket::RangeWalker do
   let(:args) { "::1" }
   subject(:walker) { described_class.new(args) }
 
-  it { should respond_to(:num_ips) }
   it { should respond_to(:length) }
   it { should respond_to(:valid?) }
+  it { should respond_to(:each) }
 
-  context "with a hostname" do
-    let(:args) { "localhost" }
-    it { should be_valid }
-    it "should have one address" do
+  describe '.new' do
+
+    context "with a hostname" do
+      let(:args) { "localhost" }
+      it { should be_valid }
+      it "should have one address" do
+        walker.length.should == 1
+      end
+    end
+
+    context "with a hostname and CIDR" do
+      let(:args) { "localhost/24" }
+      it { should be_valid }
+      it "should have 256 addresses" do
+        walker.length.should == 256
+      end
+    end
+
+    context "with an invalid hostname" do
+      let(:args) { "asdf.foo." }
+      it { should_not be_valid }
+    end
+
+    context "with an invalid hostname and CIDR" do
+      let(:args) { "asdf.foo./24" }
+      it { should_not be_valid }
+    end
+
+    it "should handle single ipv6 addresses" do
+      walker = Rex::Socket::RangeWalker.new("::1")
+      walker.should be_valid
       walker.length.should == 1
     end
-  end
 
-  context "with a hostname and CIDR" do
-    let(:args) { "localhost/24" }
-    it { should be_valid }
-    it "should have 256 addresses" do
+    it "should handle longform ranges" do
+      walker = Rex::Socket::RangeWalker.new("10.1.1.1-10.1.1.2")
+      walker.should be_valid
+      walker.length.should == 2
+      walker.next_ip.should == "10.1.1.1"
+    end
+
+
+    it "should handle ranges" do
+      walker = Rex::Socket::RangeWalker.new("10.1.1.1-2")
+      walker.should be_valid
+      walker.length.should == 2
+      walker.next_ip.should == "10.1.1.1"
+      walker = Rex::Socket::RangeWalker.new("10.1-2.1.1-2")
+      walker.should be_valid
+      walker.length.should == 4
+      walker = Rex::Socket::RangeWalker.new("10.1-2.3-4.5-6")
+      walker.should be_valid
+      walker.length.should == 8
+      walker.should include("10.1.3.5")
+    end
+
+    it 'should reject CIDR ranges with missing octets' do
+      walker = Rex::Socket::RangeWalker.new('192.168/24')
+      walker.should_not be_valid
+    end
+
+    it 'should reject a CIDR range with too many octets' do
+      walker = Rex::Socket::RangeWalker.new('192.168.1.2.0/24')
+      walker.should_not be_valid
+    end
+
+    it "should default the lower bound of a range to 0" do
+      walker = Rex::Socket::RangeWalker.new("10.1.3.-17")
+      walker.should be_valid
+      walker.length.should == 18
+      walker = Rex::Socket::RangeWalker.new("10.1.3.-255")
+      walker.should be_valid
       walker.length.should == 256
     end
-  end
 
-  context "with an invalid hostname" do
-    let(:args) { "asdf.foo." }
-    it { should_not be_valid }
-  end
-
-
-  it "should handle single ipv6 addresses" do
-    walker = Rex::Socket::RangeWalker.new("::1")
-    walker.should be_valid
-    walker.length.should == 1
-  end
-
-  it "should handle ranges" do
-    walker = Rex::Socket::RangeWalker.new("10.1.1.1-2")
-    walker.should be_valid
-    walker.length.should == 2
-    walker.next_ip.should == "10.1.1.1"
-    walker = Rex::Socket::RangeWalker.new("10.1-2.1.1-2")
-    walker.should be_valid
-    walker.length.should == 4
-    walker = Rex::Socket::RangeWalker.new("10.1-2.3-4.5-6")
-    walker.should be_valid
-    walker.length.should == 8
-    walker.should include("10.1.3.5")
-  end
-
-  it 'should reject CIDR ranges with missing octets' do
-    walker = Rex::Socket::RangeWalker.new('192.168/24')
-    walker.should_not be_valid
-  end
-
-  it 'should reject a CIDR range with too many octets' do
-    walker = Rex::Socket::RangeWalker.new('192.168.1.2.0/24')
-    walker.should_not be_valid
-  end
-
-  it "should default the lower bound of a range to 0" do
-    walker = Rex::Socket::RangeWalker.new("10.1.3.-17")
-    walker.should be_valid
-    walker.length.should == 18
-    walker = Rex::Socket::RangeWalker.new("10.1.3.-255")
-    walker.should be_valid
-    walker.length.should == 256
-  end
-
-  it "should default the upper bound of a range to 255" do
-    walker = Rex::Socket::RangeWalker.new("10.1.3.254-")
-    walker.should be_valid
-    walker.length.should == 2
-  end
-
-  it "should take * to mean 0-255" do
-    walker = Rex::Socket::RangeWalker.new("10.1.3.*")
-    walker.should be_valid
-    walker.length.should == 256
-    walker.next_ip.should == "10.1.3.0"
-    walker.should include("10.1.3.255")
-    walker = Rex::Socket::RangeWalker.new("10.1.*.3")
-    walker.should be_valid
-    walker.length.should == 256
-    walker.next_ip.should == "10.1.0.3"
-    walker.should include("10.1.255.3")
-  end
-
-  it "should handle lists" do
-    #walker = Rex::Socket::RangeWalker.new("10.1.1.1,2")
-    #walker.should be_valid
-    #walker.length.should == 2
-    walker = Rex::Socket::RangeWalker.new("10.1.1.1")
-    walker.should be_valid
-    walker.length.should == 1
-    walker = Rex::Socket::RangeWalker.new("10.1.1.1,3")
-    walker.should be_valid
-    walker.length.should == 2
-    walker.should_not include("10.1.1.2")
-  end
-
-  it "should produce the same ranges with * and 0-255" do
-    a = Rex::Socket::RangeWalker.new("10.1.3.*")
-    b = Rex::Socket::RangeWalker.new("10.1.3.0-255")
-    a.ranges.should eq(b.ranges)
-  end
-
-  it "should handle ranges and lists together" do
-    walker = Rex::Socket::RangeWalker.new("10.1.1.1-2,3")
-    walker.should be_valid
-    walker.length.should == 3
-    walker = Rex::Socket::RangeWalker.new("10.1-2.1.1,2")
-    walker.should be_valid
-    walker.length.should == 4
-    walker = Rex::Socket::RangeWalker.new("10.1,2.3,4.5,6")
-    walker.length.should == 8
-  end
-
-  it "should handle cidr" do
-    31.downto 16 do |bits|
-      walker = Rex::Socket::RangeWalker.new("10.1.1.1/#{bits}")
+    it "should default the upper bound of a range to 255" do
+      walker = Rex::Socket::RangeWalker.new("10.1.3.254-")
       walker.should be_valid
-      walker.length.should == (2**(32-bits))
+      walker.length.should == 2
     end
-  end
 
-  it "should yield all ips" do
-    walker = Rex::Socket::RangeWalker.new("10.1.1.1,2,3")
-    got = []
-    walker.each { |ip|
-      got.push ip
-    }
-    got.should == ["10.1.1.1", "10.1.1.2", "10.1.1.3"]
+    it "should take * to mean 0-255" do
+      walker = Rex::Socket::RangeWalker.new("10.1.3.*")
+      walker.should be_valid
+      walker.length.should == 256
+      walker.next_ip.should == "10.1.3.0"
+      walker.should include("10.1.3.255")
+      walker = Rex::Socket::RangeWalker.new("10.1.*.3")
+      walker.should be_valid
+      walker.length.should == 256
+      walker.next_ip.should == "10.1.0.3"
+      walker.should include("10.1.255.3")
+    end
+
+    it "should handle lists" do
+      #walker = Rex::Socket::RangeWalker.new("10.1.1.1,2")
+      #walker.should be_valid
+      #walker.length.should == 2
+      walker = Rex::Socket::RangeWalker.new("10.1.1.1")
+      walker.should be_valid
+      walker.length.should == 1
+      walker = Rex::Socket::RangeWalker.new("10.1.1.1,3")
+      walker.should be_valid
+      walker.length.should == 2
+      walker.should_not include("10.1.1.2")
+    end
+
+    it "should produce the same ranges with * and 0-255" do
+      a = Rex::Socket::RangeWalker.new("10.1.3.*")
+      b = Rex::Socket::RangeWalker.new("10.1.3.0-255")
+      a.ranges.should eq(b.ranges)
+    end
+
+    it "should handle ranges and lists together" do
+      walker = Rex::Socket::RangeWalker.new("10.1.1.1-2,3")
+      walker.should be_valid
+      walker.length.should == 3
+      walker = Rex::Socket::RangeWalker.new("10.1-2.1.1,2")
+      walker.should be_valid
+      walker.length.should == 4
+      walker = Rex::Socket::RangeWalker.new("10.1,2.3,4.5,6")
+      walker.length.should == 8
+    end
+
+    it "should handle cidr" do
+      31.downto 16 do |bits|
+        walker = Rex::Socket::RangeWalker.new("10.1.1.1/#{bits}")
+        walker.should be_valid
+        walker.length.should == (2**(32-bits))
+      end
+    end
+
+    it "should yield all ips" do
+      walker = Rex::Socket::RangeWalker.new("10.1.1.1,2,3")
+      got = []
+      walker.each { |ip|
+        got.push ip
+      }
+      got.should == ["10.1.1.1", "10.1.1.2", "10.1.1.3"]
+    end
+
   end
 end

--- a/spec/lib/rex/socket/range_walker_spec.rb
+++ b/spec/lib/rex/socket/range_walker_spec.rb
@@ -15,17 +15,13 @@ describe Rex::Socket::RangeWalker do
     context "with a hostname" do
       let(:args) { "localhost" }
       it { should be_valid }
-      it "should have one address" do
-        walker.length.should == 1
-      end
+      it { should have_at_least(1).address }
     end
 
     context "with a hostname and CIDR" do
       let(:args) { "localhost/24" }
       it { should be_valid }
-      it "should have 256 addresses" do
-        walker.length.should == 256
-      end
+      it { should have(256).addresses }
     end
 
     context "with an invalid hostname" do


### PR DESCRIPTION
## The bug

The `RangeWalker` class is designed to parse a string and either be `valid?` or not depending on how that parsing went. In the situation where you provide an unresolvable hostname, it breaks the contract by raising an exception.
## Verification steps
- [x]  `Rex::Socket::RangeWalker.new("foo.bar.")`
- [x] verify that it does not raise
- [x] verify that `valid?` returns `false`

The commit that actually fixes the bug is in 2ed9772; the rest of this is just cleanup and better docs since I was already elbow deep in it.
