### PR TITLE
Hp sys mgmt anonymous

### DIFF
--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_anonymous_access.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_anonymous_access.rb
@@ -6,7 +6,7 @@ class Metasploit3 < Msf::Auxiliary
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
-#  include Msf::Auxiliary::AuthBrute
+
   def initialize(info={})
     super(update_info(info,
       'Name'            => 'HP System Management Login Anonymous Access Scanner',

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_anonymous_access.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_anonymous_access.rb
@@ -37,7 +37,6 @@ end
       print_status("#{target_host} - Testing for Anonymous Access")
     res = send_request_cgi({
   'method' => 'POST',
-  #'uri'         => '/proxy/ssllogin',
   'uri' => '/',
   'vars_post' => {
   'redirecturl'         => '',

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_anonymous_access.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_anonymous_access.rb
@@ -1,0 +1,65 @@
+require 'msf/core'
+
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+#  include Msf::Auxiliary::AuthBrute
+  def initialize(info={})
+    super(update_info(info,
+      'Name'            => 'HP System Management Login Anonymous Access Scanner',
+      'Description'     => %q{
+This module checks to see if anonymous access is allowed for HP System Management Login
+web interface. hp_sys_mgmt_exec exploit is dependent upon anonymous access. Anonymous access can also disclose server configuration and SNMP community vaules.
+This was made into a scanner to be able to quickly test large networks. SSL is enabled by default.},
+      'Author'          => [ 'g1ldedm1n1on(at)gmail.com' ],
+      'License'         => MSF_LICENSE,
+      'DefaultOptions' => { 'SSL' => TRUE }
+   ))
+
+    register_options(
+  [
+    Opt::RPORT(2381)
+  ], self.class)
+end
+
+ def anonymous_access?
+    res = send_request_raw({'uri' => '/'})
+    return true if res and res.body =~ /username = "hpsmh_anonymous"/
+    false
+  end
+
+
+  def run_host(target_host)
+  begin
+      print_status("#{target_host} - Testing for Anonymous Access")
+    res = send_request_cgi({
+  'method' => 'POST',
+  #'uri'         => '/proxy/ssllogin',
+  'uri' => '/',
+  'vars_post' => {
+  'redirecturl'         => '',
+  'redirectquerystring'   => '',
+  }
+  })
+
+   if not res
+  vprint_error("#{target_host} - Failed to Connect")
+  return :abort
+    end
+  rescue ::Rex::ConnectionError, Errno::ECONNREFUSED
+  vprint_error("#{target_host} - Failed to responed")
+  return :abort
+end
+
+#def run
+  if not anonymous_access?
+    vprint_error("#{target_host} - Server does not allow anonymous access")
+ else
+    print_good("#{target_host} - System allows anonymous access")
+return
+end
+end
+end

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_anonymous_access.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_anonymous_access.rb
@@ -27,7 +27,7 @@ end
 
  def anonymous_access?
     res = send_request_raw({'uri' => '/'})
-    return true if res and res.body =~ /username = "hpsmh_anonymous"/
+    res and res.body =~ /username = "hpsmh_anonymous"/
     false
   end
 
@@ -44,7 +44,7 @@ end
   }
   })
 
-   if not res
+   unless res
   vprint_error("#{target_host} - Failed to Connect")
   return :abort
     end
@@ -54,7 +54,7 @@ end
 end
 
 #def run
-  if not anonymous_access?
+  unless anonymous_access?
     vprint_error("#{target_host} - Server does not allow anonymous access")
  else
     print_good("#{target_host} - System allows anonymous access")


### PR DESCRIPTION
Module will scan for Anonymous access to HP System Management Homepage (HPSMH). auxiliary/scanner/http/hp_sys_mgmt_login can not scan large network spaces and using RHOST only. exploit/multi/http/hp_sys_mgmt_exec requires anonymous access to be enabled.  Anonymous access can lead to information disclosure of server info and SNMP community strings in use.
