### PR TITLE
Fix MIPS encoder architecture

### DIFF
--- a/modules/encoders/mipsle/byte_xori.rb
+++ b/modules/encoders/mipsle/byte_xori.rb
@@ -25,7 +25,7 @@ class Metasploit3 < Msf::Encoder::Xor
           'Julien Tinnes <julien at cr0.org>', # original longxor encoder, which this one is based on
           'juan vazquez' # byte_xori encoder
         ],
-      'Arch'             => ARCH_MIPSBE,
+      'Arch'             => ARCH_MIPSLE,
       'License'          => MSF_LICENSE,
       'Decoder'          =>
         {


### PR DESCRIPTION
This is fixing the issues @mandreko is finding while working on this pr #2823. Basically, the encoder has a bad arch in the metadata, which makes the framework to select it as valid encoder for a MIPS BE payload, which isn't true at all! 
