### PR TITLE
Sercomm scanner

### DIFF
--- a/modules/auxiliary/scanner/misc/sercomm_backdoor_scanner.rb
+++ b/modules/auxiliary/scanner/misc/sercomm_backdoor_scanner.rb
@@ -50,11 +50,11 @@ class Metasploit3 < Msf::Auxiliary
       elsif (res && res.start_with?("ScMM"))
         print_good("#{ip}:#{rport} - Possible backdoor detected - Little Endian")
       else
-        print_error("#{ip}:#{rport} - Backdoor not detected.")
+        vprint_error("#{ip}:#{rport} - Backdoor not detected.")
       end
 
     rescue Rex::ConnectionError => e
-      print_error("Connection failed: #{e.class}: #{e}")
+      vprint_error("Connection failed: #{e.class}: #{e}")
     end
 
   end

--- a/modules/auxiliary/scanner/misc/sercomm_backdoor_scanner.rb
+++ b/modules/auxiliary/scanner/misc/sercomm_backdoor_scanner.rb
@@ -1,0 +1,52 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'        => 'SerComm Network Device Backdoor Detection',
+      'Description' => %q{
+        This module can identify SerComm manufactured network devices which
+        contain a backdoor, allowing command injection or account disclosure.
+      },
+      'Author'      => 'Matt "hostess" Andreko <mandreko[at]accuvant.com>',
+      'License'     => MSF_LICENSE
+    ))
+
+    register_options([
+        Opt::RPORT(32764)
+      ])
+  end
+
+  def run_host(ip)
+
+    begin
+      connect
+
+      sock.put(Rex::Text.rand_text(5))
+      res = sock.get_once
+
+      disconnect
+
+      if (res && res.start_with?("MMcS"))
+        print_good("#{ip}:#{rport} - Possible backdoor detected - Big Endian")
+      elsif (res && res.start_with?("ScMM"))
+        print_good("#{ip}:#{rport} - Possible backdoor detected - Little Endian")
+      else
+        print_error("#{ip}:#{rport} - Backdoor not detected.")
+      end
+
+    rescue Rex::ConnectionError => e
+      print_error("Connection failed: #{e.class}: #{e}")
+    end
+
+  end
+end

--- a/modules/auxiliary/scanner/misc/sercomm_backdoor_scanner.rb
+++ b/modules/auxiliary/scanner/misc/sercomm_backdoor_scanner.rb
@@ -17,9 +17,18 @@ class Metasploit3 < Msf::Auxiliary
         This module can identify SerComm manufactured network devices which
         contain a backdoor, allowing command injection or account disclosure.
       },
-      'Author'      => 'Matt "hostess" Andreko <mandreko[at]accuvant.com>',
-      'License'     => MSF_LICENSE
-    ))
+      'Author'         =>
+        [
+          'Eloi Vanderbeken <eloi.vanderbeken[at]gmail.com>', # Initial discovery, poc
+          'Matt "hostess" Andreko <mandreko[at]accuvant.com>' # Msf module
+        ],
+        'License'     => MSF_LICENSE,
+        'References'     =>
+        [
+          [ 'OSVDB', '101653' ],
+          [ 'URL', 'https://github.com/elvanderb/TCP-32764' ]
+        ],
+        'DisclosureDate' => "Dec 31 2013" ))
 
     register_options([
         Opt::RPORT(32764)


### PR DESCRIPTION
Based on the awesome SerComm backdoor work found at https://github.com/elvanderb/TCP-32764 I made a quick and easy scanner module to find vulnerable hosts.

To test (since I don't have multiple devices), I ran zmap for port 32764/TCP for a few minutes, and fed the output into this module.
