### PR TITLE
Survey Banner Link

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -431,7 +431,7 @@ class Core
     # We're running a two week survey to gather feedback from users.
     # Let's make sure we reach regular msfconsole users.
     # TODO: Get rid of this sometime after 2014-01-23
-    survey_expires = Time.new(2014,"Jan",24,23,59,59,"-06:00")
+    survey_expires = Time.new(2014,"Jan",22,23,59,59,"-05:00")
     if Time.now.to_i < survey_expires.to_i
       banner << "+ -- --=[ Answer Q's about Metasploit and win a WiFi Pineapple Mk5   ]\n"
       banner << "+ -- --=[ http://bit.ly/msfsurvey (Expires #{survey_expires.ctime}) ]\n"

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -397,15 +397,15 @@ class Core
       banner << "\n\n"
     end
 
-    banner << "       =[ %yelmetasploit v#{Msf::Framework::Version} [core:#{Msf::Framework::VersionCore} api:#{Msf::Framework::VersionAPI}]%clr\n"
+    banner << "       =[ %yelmetasploit v#{Msf::Framework::Version} [core:#{Msf::Framework::VersionCore} api:#{Msf::Framework::VersionAPI}%clr  ]\n"
     banner << "+ -- --=[ "
-    banner << "#{framework.stats.num_exploits} exploits - #{framework.stats.num_auxiliary} auxiliary - #{framework.stats.num_post} post\n"
+    banner << "#{framework.stats.num_exploits} exploits - #{framework.stats.num_auxiliary} auxiliary - #{framework.stats.num_post} post ]\n"
     banner << "+ -- --=[ "
 
     oldwarn = nil
     avdwarn = nil
 
-    banner << "#{framework.stats.num_payloads} payloads - #{framework.stats.num_encoders} encoders - #{framework.stats.num_nops} nops\n"
+    banner << "#{framework.stats.num_payloads} payloads - #{framework.stats.num_encoders} encoders - #{framework.stats.num_nops} nops      ]\n"
     if ( ::Msf::Framework::RepoRevision.to_i > 0 and ::Msf::Framework::RepoUpdatedDate)
       tstamp = ::Msf::Framework::RepoUpdatedDate.strftime("%Y.%m.%d")
       banner << "       =[ svn r#{::Msf::Framework::RepoRevision} updated #{::Msf::Framework::RepoUpdatedDaysNote} (#{tstamp})\n"

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -428,6 +428,15 @@ class Core
       avdwarn << ""
     end
 
+    # We're running a two week survey to gather feedback from users.
+    # Let's make sure we reach regular msfconsole users.
+    # TODO: Get rid of this sometime after 2014-01-23
+    survey_expires = Time.new(2014,"Jan",24,23,59,59,"-06:00")
+    if Time.now.to_i < survey_expires.to_i
+      banner << "+ -- --=[ Answer Q's about Metasploit and win a WiFi Pineapple Mk5   ]\n"
+      banner << "+ -- --=[ http://bit.ly/msfsurvey (Expires #{survey_expires.ctime}) ]\n"
+    end
+
     # Display the banner
     print_line(banner)
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -397,7 +397,7 @@ class Core
       banner << "\n\n"
     end
 
-    banner << "       =[ %yelmetasploit v#{Msf::Framework::Version} [core:#{Msf::Framework::VersionCore} api:#{Msf::Framework::VersionAPI}%clr  ]\n"
+    banner << "       =[ %yelmetasploit v#{Msf::Framework::Version} [core:#{Msf::Framework::VersionCore} api:#{Msf::Framework::VersionAPI}]%clr ]\n"
     banner << "+ -- --=[ "
     banner << "#{framework.stats.num_exploits} exploits - #{framework.stats.num_auxiliary} auxiliary - #{framework.stats.num_post} post ]\n"
     banner << "+ -- --=[ "


### PR DESCRIPTION
Rapid7 is currently running a user survey about Metasploit users and their use cases for a couple weeks. In order to ensure Framework folks don't miss out and have a shot at both guiding MSF development priorities and winning that sweet, sweet Pineapple Mk5, our wise marketing department suggested a banner splat.
## Verification
- [x] See the banner displays the link:

```
       =[ metasploit v4.9.0-dev [core:4.9 api:1.0] ]
+ -- --=[ 1249 exploits - 678 auxiliary - 199 post ]
+ -- --=[ 324 payloads - 32 encoders - 8 nops      ]
+ -- --=[ Answer Q's about Metasploit and win a WiFi Pineapple Mk5   ]
+ -- --=[ http://bit.ly/msfsurvey (Expires Wed Jan 22 23:59:59 2014) ]

```
- [x] Set your local system time to some point after Jan 22.
- [x] See that the link is not shown:

```
$ date
Fri Feb  7 14:41:21 CST 2014
[ruby-1.9.3-p484@metasploit-framework] (marketing-scumbag-banner-spam) 
todb@mazikeen:~/git/rapid7/metasploit-framework
$ ./msfconsole -L

Unable to handle kernel NULL pointer dereference at virtual address 0xd34db33f
EFLAGS: 00010046
# ....snip....

       =[ metasploit v4.9.0-dev [core:4.9 api:1.0  ]
+ -- --=[ 1249 exploits - 678 auxiliary - 199 post ]
+ -- --=[ 324 payloads - 32 encoders - 8 nops      ]

```
- [x] Remember to reset your clock or you're going to have a bad time.
