### PR TITLE
Add a -quick option for VirusTotalUtility

### DIFF
--- a/spec/tools/virustotal_spec.rb
+++ b/spec/tools/virustotal_spec.rb
@@ -7,7 +7,7 @@ require 'msfenv'
 require 'msf/base'
 require 'digest/sha2'
 
-describe "virustotal.rb" do
+describe VirusTotalUtility do
 
   context "Classes" do
     let(:api_key) do
@@ -22,11 +22,11 @@ describe "virustotal.rb" do
       'DATA'
     end
 
-    describe ToolConfig do
+    describe VirusTotalUtility::ToolConfig do
       context "Class methods" do
 
         let(:tool_config) do
-          ToolConfig.new
+          VirusTotalUtility::ToolConfig.new
         end
 
         context ".Initializer" do
@@ -41,7 +41,7 @@ describe "virustotal.rb" do
       end
     end
 
-    describe VirusTotal do
+    describe VirusTotalUtility::VirusTotal do
       context "Class methods" do
 
         let(:malware_sha256) do
@@ -88,7 +88,7 @@ describe "virustotal.rb" do
         let(:vt) do
           file = double(File, read: malware_data)
           File.stub(:open).with(filename, 'rb') {|&block| block.yield file}
-          VirusTotal.new({'api_key'=>api_key, 'sample'=>filename})
+          VirusTotalUtility::VirusTotal.new({'api_key'=>api_key, 'sample'=>filename})
         end
 
         context ".Initializer" do
@@ -172,7 +172,7 @@ describe "virustotal.rb" do
     end
 
 
-    describe Driver do
+    describe VirusTotalUtility::Driver do
       # Get stdout:
       # http://stackoverflow.com/questions/11349270/test-output-to-command-line-with-rspec
       def get_stdout(&block)
@@ -202,11 +202,11 @@ describe "virustotal.rb" do
           'delay'   => 60
         }
 
-        OptsConsole.stub(:parse).with(anything).and_return(options)
+        VirusTotalUtility::OptsConsole.stub(:parse).with(anything).and_return(options)
 
 
         tool_config = double("tool_config")
-        ToolConfig.stub(:new).and_return(tool_config)
+        VirusTotalUtility::ToolConfig.stub(:new).and_return(tool_config)
         tool_config.stub(:has_privacy_waiver?).and_return(true)
         tool_config.stub(:load_api_key).and_return(api_key)
         tool_config.stub(:save_privacy_waiver)
@@ -215,7 +215,7 @@ describe "virustotal.rb" do
         d = nil
 
         out = get_stdout {
-          d = Driver.new
+          d = VirusTotalUtility::Driver.new
         }
 
         d
@@ -225,7 +225,7 @@ describe "virustotal.rb" do
 
         context ".initialize" do
           it "should return a Driver object" do
-            driver.class.should eq(Driver)
+            driver.class.should eq(VirusTotalUtility::Driver)
           end
         end
 

--- a/spec/tools/virustotal_spec.rb
+++ b/spec/tools/virustotal_spec.rb
@@ -237,21 +237,13 @@ describe "virustotal.rb" do
           end
         end
 
-        context ".upload_sample" do
-          it "should upload a sample" do
-            vt = double(VirusTotal)
-            vt.stub(:scan_sample).and_return({})
-            out = get_stdout { driver.upload_sample(vt, filename) }
-            out.should match(/Please wait while I upload/)
-          end
-        end
-
         context ".generate_report" do
           it "should show a report" do
             res = {
               "scans" => {
                 "Bkav" => { "detected" => false, "version" => "1.3.0.4613", "result" => nil, "update" => "20140107" }
-              }
+              },
+              "response_code" => 1
             }
 
             out = get_stdout { driver.generate_report(res, filename) }

--- a/tools/virustotal.rb
+++ b/tools/virustotal.rb
@@ -59,6 +59,8 @@ def print_error(msg='')
 end
 
 
+module VirusTotalUtility
+
 class ToolConfig
 
   def initialize
@@ -545,13 +547,15 @@ class Driver
 
 end
 
+end # VirusTotalUtility
+
 
 #
 # main
 #
 if __FILE__ == $PROGRAM_NAME
   begin
-    driver = Driver.new
+    driver = VirusTotalUtility::Driver.new
     if driver.opts['quick']
       driver.scan_by_checksum
     else

--- a/tools/virustotal.rb
+++ b/tools/virustotal.rb
@@ -43,6 +43,21 @@ require 'optparse'
 require 'json'
 require 'timeout'
 
+#
+# Prints a status message
+#
+def print_status(msg='')
+  $stdout.puts "[*] #{msg}"
+end
+
+
+#
+# Prints an error message
+#
+def print_error(msg='')
+  $stdout.puts "[-] #{msg}"
+end
+
 
 class ToolConfig
 
@@ -266,24 +281,7 @@ Content-Type: application/octet-stream
 
 end
 
-class DriverBase
-  #
-  # Prints a status message
-  #
-  def print_status(msg='')
-    $stdout.puts "[*] #{msg}"
-  end
-
-
-  #
-  # Prints an error message
-  #
-  def print_error(msg='')
-    $stdout.puts "[-] #{msg}"
-  end
-end
-
-class OptsConsole < DriverBase
+class OptsConsole
   #
   # Return a hash describing the options.
   #
@@ -307,6 +305,10 @@ class OptsConsole < DriverBase
         end
 
         options['delay'] = v.to_i
+      end
+
+      opts.on("-q", "-quick", "(Optional) Do a checksum search without uploading the sample") do |v|
+        options['quick'] = true
       end
 
       opts.on("-f", "-files <filenames>", "Files to scan") do |v|
@@ -341,6 +343,14 @@ class OptsConsole < DriverBase
     end
 
     # Set default
+    if options['samples'].nil?
+      options['samples'] = []
+    end
+
+    if options['quick'].nil?
+      options['quick'] = false
+    end
+
     if options['delay'].nil?
       options['delay'] = 60
     end
@@ -354,12 +364,12 @@ class OptsConsole < DriverBase
     begin
       opts.parse!(args)
     rescue OptionParser::InvalidOption
-      print_error "Invalid option, try -h for usage"
+      print_error("Invalid option, try -h for usage")
       exit
     end
 
     if options.empty?
-      print_error "No options specified, try -h for usage"
+      print_error("No options specified, try -h for usage")
       exit
     end
 
@@ -367,7 +377,10 @@ class OptsConsole < DriverBase
   end
 end
 
-class Driver < DriverBase
+class Driver
+
+  attr_reader :opts
+
   def initialize
     opts = {}
 
@@ -423,24 +436,6 @@ class Driver < DriverBase
 
 
   #
-  # Submits a malware sample to VirusTotal
-  # @param vt [VirusTotal] VirusTotal object
-  # @param sample [String] The malware sample name
-  # @return [Hash] VirusTotal response of the upload
-  #
-  def upload_sample(vt, sample)
-    print_status("Please wait while I upload #{sample}...")
-    res = vt.scan_sample
-    print_status("VirusTotal: #{res['verbose_msg']}")
-    print_status("Sample MD5 checksum: #{res['md5']}")
-    print_status("Sample SHA256 checksum: #{res['sha256']}")
-    print_status("Analysis link: #{res['permalink']}")
-
-    res
-  end
-
-
-  #
   # Retrieves a report from VirusTotal
   # @param vt [VirusTotal] VirusTotal object
   # @param res [Hash] Last submission response
@@ -478,13 +473,19 @@ class Driver < DriverBase
   # @return [void]
   #
   def generate_report(res, sample)
+    if res['response_code'] != 1
+      print_status("VirusTotal: #{res['verbose_msg']}")
+      return
+    end
+
+    short_filename = File.basename(sample)
     tbl = Rex::Ui::Text::Table.new(
-      'Header'  => "Analysis Report: #{sample} (#{res['positives']} / #{res['total']}): #{res['sha256']}",
+      'Header'  => "Analysis Report: #{short_filename} (#{res['positives']} / #{res['total']}): #{res['sha256']}",
       'Indent'  => 1,
       'Columns' => ['Antivirus', 'Detected', 'Version', 'Result', 'Update']
     )
 
-    res['scans'].each do |result|
+    (res['scans'] || []).each do |result|
       product  = result[0]
       detected = result[1]['detected'].to_s
       version  = result[1]['version'] || ''
@@ -499,13 +500,43 @@ class Driver < DriverBase
 
 
   #
-  # Executes a scan and produces a report
+  # Displays checksums
   #
-  def scan
+  def show_checksums(res)
+    print_status("Sample MD5 checksum    : #{res['md5']}")     if res['md5']
+    print_status("Sample SHA1 checksum   : #{res['sha1']}")    if res['sha1']
+    print_status("Sample SHA256 checksum : #{res['sha256']}")  if res['sha256']
+    print_status("Analysis link: #{res['permalink']}")         if res['permalink']
+  end
+
+
+  #
+  # Executes a scan by uploading a sample and produces a report
+  #
+  def scan_by_upload
     @opts['samples'].each do |sample|
       vt = VirusTotal.new({'api_key' => @opts['api_key'], 'sample' => sample})
-      res = upload_sample(vt, sample)
+      print_status("Please wait while I upload #{sample}...")
+      res = vt.scan_sample
+      print_status("VirusTotal: #{res['verbose_msg']}")
+      show_checksums(res)
       res = wait_report(vt, res, @opts['delay'])
+      generate_report(res, sample) if res
+
+      puts
+    end
+  end
+
+
+  #
+  # Executes a checksum search and produces a report
+  #
+  def scan_by_checksum
+    @opts['samples'].each do |sample|
+      vt = VirusTotal.new({'api_key' => @opts['api_key'], 'sample' => sample})
+      print_status("Please wait I look for a report for #{sample}...")
+      res = vt.retrieve_report
+      show_checksums(res)
       generate_report(res, sample) if res
 
       puts
@@ -521,7 +552,11 @@ end
 if __FILE__ == $PROGRAM_NAME
   begin
     driver = Driver.new
-    driver.scan
+    if driver.opts['quick']
+      driver.scan_by_checksum
+    else
+      driver.scan_by_upload
+    end
   rescue Interrupt
     $stdout.puts
     $stdout.puts "Good bye"

--- a/tools/virustotal.rb
+++ b/tools/virustotal.rb
@@ -187,7 +187,7 @@ class VirusTotal < Msf::Auxiliary
 
 
   #
-  # Returns the report of a specific malware checksum
+  # Returns the report of a specific malware hash
   # @return [Hash] JSON response
   #
   def retrieve_report
@@ -234,7 +234,7 @@ class VirusTotal < Msf::Auxiliary
   #
   # Returns malware sample information
   # @param sample [String] The sample path to load
-  # @return [Hash] Information about the sample (including the raw data, and SHA256 checksum)
+  # @return [Hash] Information about the sample (including the raw data, and SHA256 hash)
   #
   def _load_sample(sample)
     info = {
@@ -300,7 +300,7 @@ class OptsConsole
         options['api_key'] = v
       end
 
-      opts.on("-d", "-delay <seconds>", "(Optional) Number of seconds to wait for the report") do |v|
+      opts.on("-d", "-d <seconds>", "(Optional) Number of seconds to wait for the report") do |v|
         if v !~ /^\d+$/
           print_error("Invalid input for -d. It must be a number.")
           exit
@@ -309,11 +309,11 @@ class OptsConsole
         options['delay'] = v.to_i
       end
 
-      opts.on("-q", nil, "(Optional) Do a checksum search without uploading the sample") do |v|
+      opts.on("-q", nil, "(Optional) Do a hash search without uploading the sample") do |v|
         options['quick'] = true
       end
 
-      opts.on("-f", "-files <filenames>", "Files to scan") do |v|
+      opts.on("-f", "-f <filenames>", "Files to scan") do |v|
         files = v.split.delete_if { |e| e.nil? }
         bad_files = []
         files.each do |f|
@@ -502,12 +502,12 @@ class Driver
 
 
   #
-  # Displays checksums
+  # Displays hashes
   #
-  def show_checksums(res)
-    print_status("Sample MD5 checksum    : #{res['md5']}")     if res['md5']
-    print_status("Sample SHA1 checksum   : #{res['sha1']}")    if res['sha1']
-    print_status("Sample SHA256 checksum : #{res['sha256']}")  if res['sha256']
+  def show_hashes(res)
+    print_status("Sample MD5 hash    : #{res['md5']}")     if res['md5']
+    print_status("Sample SHA1 hash   : #{res['sha1']}")    if res['sha1']
+    print_status("Sample SHA256 hash : #{res['sha256']}")  if res['sha256']
     print_status("Analysis link: #{res['permalink']}")         if res['permalink']
   end
 
@@ -521,7 +521,7 @@ class Driver
       print_status("Please wait while I upload #{sample}...")
       res = vt.scan_sample
       print_status("VirusTotal: #{res['verbose_msg']}")
-      show_checksums(res)
+      show_hashes(res)
       res = wait_report(vt, res, @opts['delay'])
       generate_report(res, sample) if res
 
@@ -531,14 +531,14 @@ class Driver
 
 
   #
-  # Executes a checksum search and produces a report
+  # Executes a hash search and produces a report
   #
-  def scan_by_checksum
+  def scan_by_hash
     @opts['samples'].each do |sample|
       vt = VirusTotal.new({'api_key' => @opts['api_key'], 'sample' => sample})
       print_status("Please wait I look for a report for #{sample}...")
       res = vt.retrieve_report
-      show_checksums(res)
+      show_hashes(res)
       generate_report(res, sample) if res
 
       puts
@@ -557,7 +557,7 @@ if __FILE__ == $PROGRAM_NAME
   begin
     driver = VirusTotalUtility::Driver.new
     if driver.opts['quick']
-      driver.scan_by_checksum
+      driver.scan_by_hash
     else
       driver.scan_by_upload
     end

--- a/tools/virustotal.rb
+++ b/tools/virustotal.rb
@@ -309,7 +309,7 @@ class OptsConsole
         options['delay'] = v.to_i
       end
 
-      opts.on("-q", "-quick", "(Optional) Do a checksum search without uploading the sample") do |v|
+      opts.on("-q", nil, "(Optional) Do a checksum search without uploading the sample") do |v|
         options['quick'] = true
       end
 


### PR DESCRIPTION
This adds a -quick option that allows the user to check a malware sample (based on its checksum) without actually uploading to VirusTotal.

To verify:
-  [x] First you should generate a payload: `msfpayload windows/meterpreter/reverse_tcp lhost=[LHOST] lport=[LPORT] X > /tmp/test.exe`
- [x] Upload the sample: `tools/virustotal.rb -f /tmp/test.exe`
- [x] You should get a report from VirusTotal
- [x] Now use the "-quick" option: `tools/virustotal.rb -quick -f /tmp/test.exe`
- [x] You should again see the same report, but quicker

Rspec:
- [x] Enter this command: `rspec spec/tools/virustotal_spec.rb`
- [x] You should see the following output:

```
VirusTotalUtility ................

Finished in 1.73 seconds
16 examples, 0 failure
```
