### PR TITLE
Fix require error for firefox payload

### DIFF
--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -29,6 +29,7 @@ class Payload < Msf::Module
   require 'msf/core/payload/netware'
   require 'msf/core/payload/java'
   require 'msf/core/payload/dalvik'
+  require 'msf/core/payload/firefox'
 
   ##
   #

--- a/modules/payloads/singles/firefox/exec.rb
+++ b/modules/payloads/singles/firefox/exec.rb
@@ -4,7 +4,6 @@
 ##
 
 require 'msf/core'
-require 'msf/core/payload/firefox'
 
 module Metasploit3
 

--- a/modules/payloads/singles/firefox/shell_bind_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_bind_tcp.rb
@@ -5,7 +5,6 @@
 
 require 'msf/core'
 require 'msf/core/handler/bind_tcp'
-require 'msf/core/payload/firefox'
 require 'msf/base/sessions/command_shell'
 
 module Metasploit3

--- a/modules/payloads/singles/firefox/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_reverse_tcp.rb
@@ -5,7 +5,6 @@
 
 require 'msf/core'
 require 'msf/core/handler/reverse_tcp'
-require 'msf/core/payload/firefox'
 require 'msf/base/sessions/command_shell'
 
 module Metasploit3

--- a/modules/post/firefox/gather/xss.rb
+++ b/modules/post/firefox/gather/xss.rb
@@ -5,6 +5,7 @@
 
 require 'msf/core'
 require 'json'
+require 'msf/core/payload/firefox'
 
 class Metasploit3 < Msf::Post
 
@@ -62,7 +63,7 @@ class Metasploit3 < Msf::Post
 
         hiddenWindow[key] = true;
         hiddenWindow.location = "#{datastore['URL']}";
-        
+
         var evt = function() {
           if (hiddenWindow[key]) {
             setTimeout(evt, 200);


### PR DESCRIPTION
Oops. I missed a require in `post/firefox/gather/xss`. I moved the explicit requires in the other FF payloads into `msf/core/payload.rb` and added the correct require to the post module.

Verification:
- [x] can start msfconsole on a linux machine without the following error:
  
  ```
  joe@ubuntu:~/metasploit-framework$ 
  joe@ubuntu:~/metasploit-framework$ ./msfconsole
  [-] WARNING! The following modules could not be loaded!
  [-]     /home/joe/metasploit-framework/modules/post/firefox/gather/xss.rb: NameError uninitialized constant Msf::Payload::Firefox
  ```
