### PR TITLE
Fix a stack trace when module_payloads.rb is run

### DIFF
--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -449,7 +449,7 @@ class Module
       ch = self.compat['Nop']
     elsif (mod.type == MODULE_PAYLOAD)
       ch = self.compat['Payload']
-      if self.respond_to?("target") and self.target['Payload'] and self.target['Payload']['Compat']
+      if self.respond_to?("target") and self.target and self.target['Payload'] and self.target['Payload']['Compat']
         ch = ch.merge(self.target['Payload']['Compat'])
       end
     else


### PR DESCRIPTION
This fixes a missing check for self.target being nil in the compatible? method
