### PR TITLE
Add more rspec coverage for BrowserExploitServer

### DIFF
--- a/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
@@ -88,7 +88,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     server.start_service
   end
 
-  describe ".get_module_resource" do
+  describe "#get_module_resource" do
     it "should give me a URI to access the exploit page" do
       ivar_exploit_page = server.instance_variable_get(:@exploit_receiver_page)
       module_resource = server.get_module_resource
@@ -96,13 +96,13 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     end
   end
 
-  describe ".get_module_uri" do
+  describe "#get_module_uri" do
     it "should return a module URI" do
       server.get_module_uri.should match(/http/)
     end
   end
 
-  describe ".get_bad_requirements" do
+  describe "#get_bad_requirements" do
     let(:rejected_requirements) do
       server.get_bad_requirements(fake_profile)
     end
@@ -169,7 +169,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     end
   end
 
-  describe ".init_profile" do
+  describe "#init_profile" do
     it "should initialize an empety profile for tag 'random'" do
       server.init_profile(profile_name)
       ivar_target_profile = server.instance_variable_get(:@target_profiles)
@@ -177,7 +177,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     end
   end
 
-  describe ".retrieve_tag" do
+  describe "#retrieve_tag" do
     let(:client_request) do
       double(Rex::Proto::Http::Request)
     end
@@ -211,7 +211,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     end
   end
 
-  describe ".process_browser_info" do
+  describe "#process_browser_info" do
     let(:req) do
       http_headers = {
         'Cookie'     => 'UNIQUE_VALUE',
@@ -238,7 +238,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     end
   end
 
-  describe ".get_profile" do
+  describe "#get_profile" do
     it "should return nil when a profile isn't found" do
       server.init_profile(profile_name)
       p = server.get_profile("non_existent_profile")
@@ -252,7 +252,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     end
   end
 
-  describe ".update_profile" do
+  describe "#update_profile" do
     it "should update my target profile's :os_name information" do
       server.init_profile(profile_name)
       profile = server.get_profile(profile_name)
@@ -262,7 +262,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     end
   end
 
-  describe ".has_proxy" do
+  describe "#has_proxy" do
     it "should return false" do
       req = double(Rex::Proto::Http::Request)
       req.stub(:headers).and_return({})
@@ -270,14 +270,14 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     end
   end
 
-  describe ".get_detection_html" do
+  describe "#get_detection_html" do
     it "should return the detection code that the client will get" do
       html = server.get_detection_html(expected_user_agent)
       html.should_not be_blank
     end
   end
 
-  describe ".on_request_uri" do
+  describe "#on_request_uri" do
     let(:req) do
       http_headers = {
         'Cookie'     => 'UNIQUE_VALUE',
@@ -353,7 +353,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     end
   end
 
-  describe ".on_request_exploit" do
+  describe "#on_request_exploit" do
     it "should raise a NoMethodError if called" do
       fake_cli = nil
       fake_request = nil
@@ -364,7 +364,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     end
   end
 
-  describe ".send_exploit_html" do
+  describe "#send_exploit_html" do
     before do
       server.stub(:send_response).with(
         an_instance_of(sock.class),
@@ -394,14 +394,14 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     end
   end
 
-  describe ".get_target" do
+  describe "#get_target" do
     it "should return a target" do
       server.instance_variable_set(:@target, expected_target)
       server.get_target.instance_variable_get(:@name).should eq(Msf::Module::Target)
     end
   end
 
-  describe ".try_set_target" do
+  describe "#try_set_target" do
     let(:target_object) do
       Msf::Module::Target
     end
@@ -424,7 +424,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     end
   end
 
-  describe ".extract_requirements" do
+  describe "#extract_requirements" do
     it "should find all the recognizable keys" do
       requirements = {:os_flavor=>"XP", :ua_name=>"MSIE", :ua_ver=>"8.0"}
       matches = server.extract_requirements(requirements)
@@ -440,7 +440,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     end
   end
 
-  describe ".get_payload" do
+  describe "#get_payload" do
     it "should generate a payload" do
       fake_payload = "PAYLOAD"
       server.stub(:target).and_return(expected_target)

--- a/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
@@ -266,7 +266,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     it "should return false" do
       req = double(Rex::Proto::Http::Request)
       req.stub(:headers).and_return({})
-      server.has_proxy?(req).should eq(false)
+      server.has_proxy?(req).should be_false
     end
   end
 

--- a/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+#require 'spec_helper'
 require 'msf/core'
 require 'msf/core/exploit/remote/browser_exploit_server'
 
@@ -230,11 +230,11 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     end
 
     it "should update the profile based on source :script" do
-      server.process_browser_info(:script, sock, req)
+      expect { server.process_browser_info(:script, sock, req) }.not_to raise_error
     end
 
     it "should update the profile based on source :headers" do
-      server.process_browser_info(:headers, sock, req)
+      expect { server.process_browser_info(:headers, sock, req) }.not_to raise_error
     end
   end
 
@@ -312,11 +312,11 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       it "should send the detection code to the browser" do
         server.stub(:get_profile).with(an_instance_of(String)).and_return(nil)
         server.stub(:send_response).with(an_instance_of(sock.class), an_instance_of(String), an_instance_of(Hash))
-        server.on_request_uri(sock, req)
+        expect { server.on_request_uri(sock, req) }.not_to raise_error
       end
 
       it "should redirect the user to the exploit page" do
-        server.on_request_uri(sock, req)
+        expect { server.on_request_uri(sock, req) }.not_to raise_error
       end
     end
 
@@ -325,7 +325,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       uri = server.instance_variable_get(:@info_receiver_page)
       resource.stub(:uri).and_return(uri)
       req.stub(:uri).and_return(uri)
-      server.on_request_uri(sock, req)
+      expect { server.on_request_uri(sock, req) }.not_to raise_error
     end
 
     it "should send a response for the noscript info receiver" do
@@ -333,7 +333,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       uri = server.instance_variable_get(:@noscript_receiver_page)
       resource.stub(:uri).and_return(uri)
       req.stub(:uri).and_return(uri)
-      server.on_request_uri(sock, req)
+      expect { server.on_request_uri(sock, req) }.not_to raise_error
     end
 
     it "should send an exploit" do
@@ -342,14 +342,14 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       uri = server.instance_variable_get(:@exploit_receiver_page)
       resource.stub(:uri).and_return(uri)
       req.stub(:uri).and_return(uri)
-      server.on_request_uri(sock, req)
+      expect { server.on_request_uri(sock, req) }.not_to raise_error
     end
 
     it "should send a 404" do
       uri = "BAD"
       resource.stub(:uri).and_return(uri)
       req.stub(:uri).and_return(uri)
-      server.on_request_uri(sock, req)
+      expect { server.on_request_uri(sock, req) }.not_to raise_error
     end
   end
 
@@ -380,7 +380,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       </html>
       |
       
-      server.send_exploit_html(sock, template)
+      expect { server.send_exploit_html(sock, template) }.not_to raise_error
     end
 
     it "should raise a NameError exception due to a bad template" do

--- a/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
@@ -98,7 +98,8 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
 
   describe "#get_module_uri" do
     it "should return a module URI" do
-      server.get_module_uri.should match(/http/)
+      exploit_resource = server.instance_variable_get(:@exploit_receiver_page)
+      server.get_module_uri.should match(/^(https?:\/\/)[\d\.:]+\/[a-zA-Z0-9]+\/#{exploit_resource}$/)
     end
   end
 
@@ -209,6 +210,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       server.stub(:cli).and_return(sock)
       server.retrieve_tag(client_request).should eq(expected_hash)
     end
+
   end
 
   describe "#process_browser_info" do

--- a/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
@@ -128,8 +128,8 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       end
     end
 
-    context 'when attempting to match :ua_ver' do
-      context 'against version 25.0' do
+    describe 'when attempting to match :ua_ver' do
+      describe 'against version 25.0' do
         let(:expected_ua_ver) { '25.0' }
         let(:fake_profile) do
           { :ua_ver => expected_ua_ver }
@@ -303,7 +303,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       server.stub(:report_client).with(an_instance_of(Hash))
     end
 
-    context "info_gathering" do
+    describe "info_gathering" do
       before do
         uri = 'base_uri'
         resource.stub(:uri).and_return(uri)

--- a/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
@@ -31,7 +31,25 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     "Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)"
   end
 
+  # What the module expects
   let(:expected_profile) do
+    {
+      :source=>"script",
+      :os_name=>/win/i,
+      :os_flavor=>"XP",
+      :ua_name=>"MSIE",
+      :ua_ver=>"8.0",
+      :arch=>"x86",
+      :office=>"null",
+      :activex=>"true",
+      :proxy=>false,
+      :language=>"en-us",
+      :tried=>true
+    }
+  end
+
+  # What the client actually returns
+  let(:client_profile) do
     {
       :source=>"script",
       :os_name=>"Microsoft Windows",
@@ -60,6 +78,12 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       ivar_exploit_page = server.instance_variable_get(:@exploit_receiver_page)
       module_resource = server.get_module_resource
       module_resource.should match(ivar_exploit_page)
+    end
+  end
+
+  describe ".get_module_uri" do
+    it "should return a module URI" do
+      server.get_module_uri.should match(/http/)
     end
   end
 
@@ -138,6 +162,46 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     end
   end
 
+  describe ".retrieve_tag" do
+    let(:client_request) do
+      double(Rex::Proto::Http::Request)
+    end
+
+    let(:user_agent) do
+      'USER_AGENT_VALUE'
+    end
+
+    it "should return a cookie-based tag for the client" do
+      unique_cookie_value = 'COOKIE_VALUE'
+
+      http_headers = {
+        'Cookie'     => unique_cookie_value,
+        'User-Agent' => user_agent
+      }
+
+      client_request.stub(:headers).and_return(http_headers)
+      server.retrieve_tag(client_request).should eq(unique_cookie_value)
+    end
+
+    it "should return user-agent + IP-based tag for the client" do
+      peerhost = "127.0.0.1"
+      
+
+      http_headers = {
+        'Cookie'     => '',
+        'User-Agent' => user_agent
+      }
+
+      expected_hash = Rex::Text.md5("#{peerhost}#{user_agent}")
+
+      sock = double(Socket)
+      sock.stub(:peerhost).and_return(peerhost)
+      client_request.stub(:headers).and_return(http_headers)
+      server.stub(:cli).and_return(sock)
+      server.retrieve_tag(client_request).should eq(expected_hash)
+    end
+  end
+
   describe ".get_profile" do
     it "should return nil when a profile isn't found" do
       server.init_profile(profile_name)
@@ -162,6 +226,14 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     end
   end
 
+  describe ".has_proxy" do
+    it "should return false" do
+      req = double(Rex::Proto::Http::Request)
+      req.stub(:headers).and_return({})
+      server.has_proxy?(req).should eq(false)
+    end
+  end
+
   describe ".get_detection_html" do
     it "should return the detection code that the client will get" do
       html = server.get_detection_html(expected_user_agent)
@@ -180,28 +252,59 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     end
   end
 
+  describe ".send_exploit_html" do
+    it "should process an ERB template" do
+      template = %Q|
+      <html>
+      <%='Hello, world'%>
+      </html>
+      |
+      cli = double(Socket)
+      server.stub(:send_response).with(an_instance_of(cli.class), an_instance_of(String), an_instance_of(Hash))
+      server.send_exploit_html(cli, template)
+    end
+
+    it "should raise a NameError exception due to a bad template" do
+      template = %Q|
+      <html>
+      <%=name_error_due_to_bad_var%>
+      </html>
+      |
+
+      cli = double(Socket)
+      server.stub(:send_response).with(an_instance_of(cli.class), an_instance_of(String), an_instance_of(Hash))
+      expect { server.send_exploit_html(cli, template) }.to raise_error(NameError)
+    end
+  end
+
   describe ".get_target" do
     it "should return a target" do
-      #
-      # Using Object for Msf::Module::Target
-      #
-      expected_object = Object
+      expected_object = double(Msf::Module::Target)
       server.instance_variable_set(:@target, expected_object)
-      server.get_target.should eq(expected_object)
+      server.get_target.instance_variable_get(:@name).should eq(Msf::Module::Target)
     end
   end
 
   describe ".try_set_target" do
+    let(:target_object) do
+      Msf::Module::Target
+    end
+
     it "should try to set a target based on requirements" do
-      #
-      # This testcase needs to be better somehow, but not sure how to actually create
-      # a Msf::Module::Target. All we're able to test here is making sure the method
-      # doesn't raise anything by exercising the code.
-      #
-      server.instance_variable_set(:@requirements, {:os_name => /win/i})
-      server.instance_variable_set(:@target, Object)
-      server.try_set_target(expected_profile)
-      server.get_target.should eq(Object)
+      fake_target = double(target_object)
+      fake_target.stub(:opts).and_return(expected_profile)
+      server.stub(:targets).and_return([fake_target])
+      server.try_set_target(client_profile)
+      server.get_target.instance_variable_get(:@name).should eq(target_object)
+    end
+
+    it "should set nothing because there are no met requirements" do
+      expected_profile = {}
+      fake_target = double(target_object)
+      fake_target.stub(:opts).and_return(expected_profile)
+      server.stub(:targets).and_return([fake_target])
+      server.try_set_target(client_profile)
+      server.get_target.should eq(nil)
     end
   end
 

--- a/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
@@ -65,6 +65,10 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     }
   end
 
+  let(:expected_target) do
+    double(Msf::Module::Target)
+  end
+
   let(:peerhost) do
     '127.0.0.1'
   end
@@ -72,6 +76,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
   let(:sock) do
     s = double(Socket)
     s.stub(:peerhost).and_return(peerhost)
+    s.stub(:peerport).and_return(8080)
     return s
   end
 
@@ -296,12 +301,23 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       server.stub(:report_client).with(an_instance_of(Hash))
     end
 
-    it "should send a response for the info gathering stage" do
-      uri = 'base_uri'
-      resource.stub(:uri).and_return(uri)
-      req.stub(:uri).and_return(uri)
-      server.stub(:get_resource).and_return(uri)
-      server.on_request_uri(sock, req)
+    context "info_gathering" do
+      before do
+        uri = 'base_uri'
+        resource.stub(:uri).and_return(uri)
+        req.stub(:uri).and_return(uri)
+        server.stub(:get_resource).and_return(uri)
+      end
+
+      it "should send the detection code to the browser" do
+        server.stub(:get_profile).with(an_instance_of(String)).and_return(nil)
+        server.stub(:send_response).with(an_instance_of(sock.class), an_instance_of(String), an_instance_of(Hash))
+        server.on_request_uri(sock, req)
+      end
+
+      it "should redirect the user to the exploit page" do
+        server.on_request_uri(sock, req)
+      end
     end
 
     it "should send a response for the regular info receiver" do
@@ -324,6 +340,13 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       server.stub(:send_response).with(an_instance_of(sock.class), an_instance_of(String))
       server.stub(:on_request_exploit)
       uri = server.instance_variable_get(:@exploit_receiver_page)
+      resource.stub(:uri).and_return(uri)
+      req.stub(:uri).and_return(uri)
+      server.on_request_uri(sock, req)
+    end
+
+    it "should send a 404" do
+      uri = "BAD"
       resource.stub(:uri).and_return(uri)
       req.stub(:uri).and_return(uri)
       server.on_request_uri(sock, req)
@@ -373,8 +396,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
 
   describe ".get_target" do
     it "should return a target" do
-      expected_object = double(Msf::Module::Target)
-      server.instance_variable_set(:@target, expected_object)
+      server.instance_variable_set(:@target, expected_target)
       server.get_target.instance_variable_get(:@name).should eq(Msf::Module::Target)
     end
   end
@@ -415,6 +437,23 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       matches.each do |k,v|
         k.class.should eq(Symbol)
       end
+    end
+  end
+
+  describe ".get_payload" do
+    it "should generate a payload" do
+      fake_payload = "PAYLOAD"
+      server.stub(:target).and_return(expected_target)
+      p = double('payload')
+      p.stub(:encoded).and_return(fake_payload)
+
+      server.stub(:regenerate_payload).with(
+        an_instance_of(sock.class),
+        an_instance_of(String),
+        an_instance_of(String)
+      ).and_return(p)
+
+      server.get_payload(sock, client_profile).should eq(fake_payload)
     end
   end
 

--- a/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
@@ -34,35 +34,45 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
   # What the module expects
   let(:expected_profile) do
     {
-      :source=>"script",
-      :os_name=>/win/i,
-      :os_flavor=>"XP",
-      :ua_name=>"MSIE",
-      :ua_ver=>"8.0",
-      :arch=>"x86",
-      :office=>"null",
-      :activex=>"true",
-      :proxy=>false,
-      :language=>"en-us",
-      :tried=>true
+      :source    => "script",
+      :os_name   => /win/i,
+      :os_flavor => "XP",
+      :ua_name   => "MSIE",
+      :ua_ver    => "8.0",
+      :arch      => "x86",
+      :office    => "null",
+      :activex   => "true",
+      :proxy     => false,
+      :language  => "en-us",
+      :tried     => true
     }
   end
 
   # What the client actually returns
   let(:client_profile) do
     {
-      :source=>"script",
-      :os_name=>"Microsoft Windows",
-      :os_flavor=>"XP",
-      :ua_name=>"MSIE",
-      :ua_ver=>"8.0",
-      :arch=>"x86",
-      :office=>"null",
-      :activex=>"true",
-      :proxy=>false,
-      :language=>"en-us",
-      :tried=>true
+      :source    => "script",
+      :os_name   => "Microsoft Windows",
+      :os_flavor => "XP",
+      :ua_name   => "MSIE",
+      :ua_ver    => "8.0",
+      :arch      => "x86",
+      :office    => "null",
+      :activex   => "true",
+      :proxy     => false,
+      :language  => "en-us",
+      :tried     => true
     }
+  end
+
+  let(:peerhost) do
+    '127.0.0.1'
+  end
+
+  let(:sock) do
+    s = double(Socket)
+    s.stub(:peerhost).and_return(peerhost)
+    return s
   end
 
   before do
@@ -184,21 +194,42 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
     end
 
     it "should return user-agent + IP-based tag for the client" do
-      peerhost = "127.0.0.1"
-      
-
       http_headers = {
         'Cookie'     => '',
         'User-Agent' => user_agent
       }
 
       expected_hash = Rex::Text.md5("#{peerhost}#{user_agent}")
-
-      sock = double(Socket)
-      sock.stub(:peerhost).and_return(peerhost)
       client_request.stub(:headers).and_return(http_headers)
       server.stub(:cli).and_return(sock)
       server.retrieve_tag(client_request).should eq(expected_hash)
+    end
+  end
+
+  describe ".process_browser_info" do
+    let(:req) do
+      http_headers = {
+        'Cookie'     => 'UNIQUE_VALUE',
+        'User-Agent' => expected_user_agent
+      }
+      req = double(Rex::Proto::Http::Request)
+      req.stub(:headers).and_return(http_headers)
+      req.stub(:body).and_return("")
+      return req
+    end
+
+    before do
+      server.stub(:get_profile).and_return(client_profile)
+      server.stub(:cli).and_return(sock)
+      server.stub(:report_client).with(an_instance_of(Hash))
+    end
+
+    it "should update the profile based on source :script" do
+      server.process_browser_info(:script, sock, req)
+    end
+
+    it "should update the profile based on source :headers" do
+      server.process_browser_info(:headers, sock, req)
     end
   end
 
@@ -237,7 +268,65 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
   describe ".get_detection_html" do
     it "should return the detection code that the client will get" do
       html = server.get_detection_html(expected_user_agent)
-      html.should_not eq('')
+      html.should_not be_blank
+    end
+  end
+
+  describe ".on_request_uri" do
+    let(:req) do
+      http_headers = {
+        'Cookie'     => 'UNIQUE_VALUE',
+        'User-Agent' => expected_user_agent
+      }
+      req = double(Rex::Proto::Http::Request)
+      req.stub(:headers).and_return(http_headers)
+      req.stub(:body).and_return('')
+      return req
+    end
+
+    let(:resource) do
+      double('resource')
+    end
+
+
+    before do
+      server.stub(:send_redirect).with(an_instance_of(sock.class), an_instance_of(String))
+      server.stub(:send_not_found).with(an_instance_of(sock.class))
+      server.stub(:get_profile).with(an_instance_of(String)).and_return(client_profile)
+      server.stub(:report_client).with(an_instance_of(Hash))
+    end
+
+    it "should send a response for the info gathering stage" do
+      uri = 'base_uri'
+      resource.stub(:uri).and_return(uri)
+      req.stub(:uri).and_return(uri)
+      server.stub(:get_resource).and_return(uri)
+      server.on_request_uri(sock, req)
+    end
+
+    it "should send a response for the regular info receiver" do
+      server.stub(:send_response).with(an_instance_of(sock.class), an_instance_of(String))
+      uri = server.instance_variable_get(:@info_receiver_page)
+      resource.stub(:uri).and_return(uri)
+      req.stub(:uri).and_return(uri)
+      server.on_request_uri(sock, req)
+    end
+
+    it "should send a response for the noscript info receiver" do
+      server.stub(:send_response).with(an_instance_of(sock.class), an_instance_of(String))
+      uri = server.instance_variable_get(:@noscript_receiver_page)
+      resource.stub(:uri).and_return(uri)
+      req.stub(:uri).and_return(uri)
+      server.on_request_uri(sock, req)
+    end
+
+    it "should send an exploit" do
+      server.stub(:send_response).with(an_instance_of(sock.class), an_instance_of(String))
+      server.stub(:on_request_exploit)
+      uri = server.instance_variable_get(:@exploit_receiver_page)
+      resource.stub(:uri).and_return(uri)
+      req.stub(:uri).and_return(uri)
+      server.on_request_uri(sock, req)
     end
   end
 
@@ -253,15 +342,22 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
   end
 
   describe ".send_exploit_html" do
+    before do
+      server.stub(:send_response).with(
+        an_instance_of(sock.class),
+        an_instance_of(String),
+        an_instance_of(Hash)
+      )
+    end
+
     it "should process an ERB template" do
       template = %Q|
       <html>
       <%='Hello, world'%>
       </html>
       |
-      cli = double(Socket)
-      server.stub(:send_response).with(an_instance_of(cli.class), an_instance_of(String), an_instance_of(Hash))
-      server.send_exploit_html(cli, template)
+      
+      server.send_exploit_html(sock, template)
     end
 
     it "should raise a NameError exception due to a bad template" do
@@ -271,8 +367,6 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       </html>
       |
 
-      cli = double(Socket)
-      server.stub(:send_response).with(an_instance_of(cli.class), an_instance_of(String), an_instance_of(Hash))
       expect { server.send_exploit_html(cli, template) }.to raise_error(NameError)
     end
   end

--- a/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
@@ -231,11 +231,11 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       server.stub(:report_client).with(an_instance_of(Hash))
     end
 
-    it "should update the profile based on source :script" do
+    it "should update the profile based on source :script without an error" do
       expect { server.process_browser_info(:script, sock, req) }.not_to raise_error
     end
 
-    it "should update the profile based on source :headers" do
+    it "should update the profile based on source :headers without an error" do
       expect { server.process_browser_info(:headers, sock, req) }.not_to raise_error
     end
   end
@@ -311,18 +311,18 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
         server.stub(:get_resource).and_return(uri)
       end
 
-      it "should send the detection code to the browser" do
+      it "should send the detection code to the browser without an error" do
         server.stub(:get_profile).with(an_instance_of(String)).and_return(nil)
         server.stub(:send_response).with(an_instance_of(sock.class), an_instance_of(String), an_instance_of(Hash))
         expect { server.on_request_uri(sock, req) }.not_to raise_error
       end
 
-      it "should redirect the user to the exploit page" do
+      it "should redirect the user to the exploit page without an error" do
         expect { server.on_request_uri(sock, req) }.not_to raise_error
       end
     end
 
-    it "should send a response for the regular info receiver" do
+    it "should send a response for the regular info receiver without an error" do
       server.stub(:send_response).with(an_instance_of(sock.class), an_instance_of(String))
       uri = server.instance_variable_get(:@info_receiver_page)
       resource.stub(:uri).and_return(uri)
@@ -330,7 +330,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       expect { server.on_request_uri(sock, req) }.not_to raise_error
     end
 
-    it "should send a response for the noscript info receiver" do
+    it "should send a response for the noscript info receiver without an error" do
       server.stub(:send_response).with(an_instance_of(sock.class), an_instance_of(String))
       uri = server.instance_variable_get(:@noscript_receiver_page)
       resource.stub(:uri).and_return(uri)
@@ -338,7 +338,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       expect { server.on_request_uri(sock, req) }.not_to raise_error
     end
 
-    it "should send an exploit" do
+    it "should send an exploit without an error" do
       server.stub(:send_response).with(an_instance_of(sock.class), an_instance_of(String))
       server.stub(:on_request_exploit)
       uri = server.instance_variable_get(:@exploit_receiver_page)
@@ -347,7 +347,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       expect { server.on_request_uri(sock, req) }.not_to raise_error
     end
 
-    it "should send a 404" do
+    it "should send a 404 without an error" do
       uri = "BAD"
       resource.stub(:uri).and_return(uri)
       req.stub(:uri).and_return(uri)
@@ -375,7 +375,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
       )
     end
 
-    it "should process an ERB template" do
+    it "should process an ERB template without an error" do
       template = %Q|
       <html>
       <%='Hello, world'%>


### PR DESCRIPTION
This PR makes sure all the methods in BrowserExploitServer are covered.

Verification steps:
- [x] Enter this command: `rspec spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb`
- [x] Confirm all 33 test cases pass like the following example:

```
$ rspec spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb 
Msf::Exploit::Remote::BrowserExploitServer .................................

Finished in 4.96 seconds
33 examples, 0 failures
```
