### PR TITLE
Add rspec for Browser Autopwn options

### DIFF
--- a/spec/lib/msf/core/exploit/browser_autopwn_spec.rb
+++ b/spec/lib/msf/core/exploit/browser_autopwn_spec.rb
@@ -6,7 +6,7 @@ describe Msf::Exploit::Remote::BrowserAutopwn::AutopwnClassMethods do
 
     include Msf::Exploit::Remote::BrowserAutopwn::AutopwnClassMethods
 
-    context ".autopwn_info" do
+    describe ".autopwn_info" do
       opts = {
         :ua_name      => 'ua_name',
         :ua_minver    => 'ua_minver',

--- a/spec/lib/msf/core/exploit/browser_autopwn_spec.rb
+++ b/spec/lib/msf/core/exploit/browser_autopwn_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'msf/core'
+require 'msf/core/exploit/browser_autopwn'
+
+describe Msf::Exploit::Remote::BrowserAutopwn::AutopwnClassMethods do
+
+    include Msf::Exploit::Remote::BrowserAutopwn::AutopwnClassMethods
+
+    context ".autopwn_info" do
+      opts = {
+        :ua_name      => 'ua_name',
+        :ua_minver    => 'ua_minver',
+        :ua_maxver    => 'ua_maxver',
+        :ua_ver       => 'ua_ver',
+        :classid      => 'classid',
+        :method       => 'method',
+        :javascript   => 'javascript',
+        :os_name      => 'os_name',
+        :os_ver       => 'os_ver',
+        :postfix_html => 'postfix_html',
+        :prefix_html  => 'prefix_html',
+        :vuln_test    => 'vuln_test',
+        :rank         => 'rank'
+      }
+
+      it "should have every specific option configured" do
+        autopwn_info(opts)
+        autopwn_opts.should eq(opts)
+      end
+    end
+end

--- a/spec/lib/msf/core/exploit/browser_autopwn_spec.rb
+++ b/spec/lib/msf/core/exploit/browser_autopwn_spec.rb
@@ -6,7 +6,7 @@ describe Msf::Exploit::Remote::BrowserAutopwn::AutopwnClassMethods do
 
     include Msf::Exploit::Remote::BrowserAutopwn::AutopwnClassMethods
 
-    describe ".autopwn_info" do
+    describe "#autopwn_info" do
       opts = {
         :ua_name      => 'ua_name',
         :ua_minver    => 'ua_minver',


### PR DESCRIPTION
rspec for browser autopwn options, that way we can make sure they're never lost. A lost key may cause lots of broken modules.

Verification steps:
- [x] Enter this command: `rspec spec/lib/msf/core/exploit/browser_autopwn_spec.rb`
- [x] Confirm the test case passes the test like the following example:

```
$ rspec spec/lib/msf/core/exploit/browser_autopwn_spec.rb
Msf::Exploit::Remote::BrowserAutopwn::AutopwnClassMethods .

Finished in 1.03 seconds
1 example, 0 failures
```
