### PR TITLE
Update Http Client Rspec

### DIFF
--- a/spec/lib/msf/core/exploit/http/client_spec.rb
+++ b/spec/lib/msf/core/exploit/http/client_spec.rb
@@ -6,8 +6,26 @@ require 'msf/core/exploit/http/client'
 describe Msf::Exploit::Remote::HttpClient do
 
   let(:http_response) { Rex::Proto::Http::Response.new }
+  let(:rhost)         { '127.0.0.1' }
+  let(:rport)         { 80 }
 
   subject do
+
+    datastore_opts = {
+      'SSL'                         => false,
+      'UserAgent'                   => 'useragent',
+      'RHOST'                       => rhost,
+      'RPORT'                       => rport,
+      'HTTP::uri_encode_mode'       => 'u-normal',
+      'HTTP::uri_full_url'          => '/',
+      'HTTP::pad_method_uri_count'  => 0,
+      'HTTP::pad_uri_version_count' => 0,
+      'HTTP::pad_method_uri_type'   => 'tab',
+      'HTTP::pad_uri_version_type'  => 'tab',
+      'FingerprintCheck'            => true
+    }
+    datastore_opts.stub(:default?).and_return(true)
+
     db = double(Msf::DBManager)
     db.stub(:active).and_return(true)
     framework = double(Msf::Framework)
@@ -24,10 +42,9 @@ describe Msf::Exploit::Remote::HttpClient do
     mod = Module.new
     mod.extend described_class
     mod.stub(:framework).and_return(framework)
-    mod.stub(:connect).with(an_instance_of(Hash))
-    mod.stub(:send_request_raw).with(an_instance_of(Hash)).and_return(http_response)
     mod.stub(:report_web_site).with(an_instance_of(Hash))
     mod.stub(:fail_with).with(anything, an_instance_of(String)).and_raise(RuntimeError)
+    mod.stub(:datastore).and_return(datastore_opts)
 
     return mod
   end
@@ -35,11 +52,94 @@ describe Msf::Exploit::Remote::HttpClient do
   context "Methods" do
     context ".validate_fingerprint" do
       it "should raise an error for an invalid match" do
-        opts = {'FingerprintCheck'=>true}
-        opts.stub(:default?).and_return(true)
-        subject.stub(:datastore).and_return(opts)
+        subject.stub(:connect).with(an_instance_of(Hash))
+        subject.stub(:send_request_raw).with(an_instance_of(Hash)).and_return(http_response)
         stub_const('HttpFingerprint', {:pattern => [/pattern/]})
         expect { subject.validate_fingerprint }.to raise_error(RuntimeError)
+      end
+    end
+
+    context ".connect" do
+      it "should connect" do
+        Rex::Proto::Http::Client.stub(:set_config)
+        subject.connect.should be_a_kind_of(Rex::Proto::Http::Client)
+      end
+    end
+
+    context "HTTP requests" do
+      let(:cli) do
+        Rex::Proto::Http::Client.new(rhost, rport)
+      end
+
+      it ".send_request_raw" do
+        cli.stub(:send_recv).and_return('')
+        subject.stub(:connect).with(an_instance_of(Hash)).and_return(cli)
+        subject.send_request_raw({'uri'=>'/'}, 1).should be_empty
+      end
+
+      it "should return nil due to a timeout (raw request)" do
+        cli.stub(:send_recv).and_raise(Timeout::Error)
+        subject.stub(:connect).with(an_instance_of(Hash)).and_return(cli)
+        subject.send_request_raw({'uri'=>'/'}, 1).should be_nil
+      end
+
+      it ".send_request_cgi" do
+        cli.stub(:send_recv).and_return('')
+        subject.stub(:connect).with(an_instance_of(Hash)).and_return(cli)
+        subject.send_request_cgi({'uri'=>'/'}, 1).should be_empty
+      end
+
+      it "should return nil due to a timeout (cgi request)" do
+        cli.stub(:send_recv).and_raise(Timeout::Error)
+        subject.stub(:connect).with(an_instance_of(Hash)).and_return(cli)
+        subject.send_request_cgi({'uri'=>'/'}, 1).should be_nil
+      end
+    end
+
+    context ".basic_auth" do
+      it "should return a basic_auth string" do
+        username = 'user'
+        password = 'pass'
+        base64_auth_str = ''
+        subject.basic_auth(username, password).should eq('Basic dXNlcjpwYXNz')
+      end
+    end
+
+    context ".target_uri" do
+      it "should return a uri object" do
+        subject.target_uri.should be_a_kind_of(URI)
+      end
+    end
+
+    context ".full_uri" do
+      it "should return a full uri" do
+        subject.full_uri.should eq("http://#{rhost}/")
+      end
+    end
+
+    context ".path_from_uri" do
+      it "should return a path from uri" do
+        path = '/dir/file.php'
+        subject.path_from_uri(path).should eq(path)
+      end
+    end
+
+    context ".strip_tags" do
+      it "should remove html tags" do
+        expected_message = 'hello, world'
+        html = %Q|
+        <html>
+        #{expected_message}
+        </html>
+        |
+
+        subject.strip_tags(html).should eq(expected_message)
+      end
+    end
+
+    context ".peer" do
+      it "should return rhost:rport" do
+        subject.peer.should eq("#{rhost}:#{rport}")
       end
     end
 

--- a/spec/lib/msf/core/exploit/http/client_spec.rb
+++ b/spec/lib/msf/core/exploit/http/client_spec.rb
@@ -1,200 +1,198 @@
 # -*- coding:binary -*-
 require 'spec_helper'
-
 require 'msf/core'
 require 'msf/core/exploit/http/client'
 
 describe Msf::Exploit::Remote::HttpClient do
+
+  let(:http_response) { Rex::Proto::Http::Response.new }
+
   subject do
+    db = double(Msf::DBManager)
+    db.stub(:active).and_return(true)
+    framework = double(Msf::Framework)
+    framework.stub(:db).and_return(db)
+
+    # Fake a connection
+    conn_block = double('conn_block')
+    conn_pool = double("pool")
+    conn_pool.stub(:with_connection)
+    ar_base = double('Base')
+    ar_base.stub(:connection_pool).and_return(conn_pool)
+    stub_const('ActiveRecord::Base', ar_base)
+
     mod = Module.new
     mod.extend described_class
+    mod.stub(:framework).and_return(framework)
+    mod.stub(:connect).with(an_instance_of(Hash))
+    mod.stub(:send_request_raw).with(an_instance_of(Hash)).and_return(http_response)
+    mod.stub(:report_web_site).with(an_instance_of(Hash))
+    mod.stub(:fail_with).with(anything, an_instance_of(String)).and_raise(RuntimeError)
 
-    mod
+    return mod
   end
 
-  describe '#normalize_uri' do
-    let(:expected_normalized_uri) do
-      '/a/b/c'
-    end
-
-    let(:normalized_uri) do
-      subject.normalize_uri(unnormalized_uri)
-    end
-
-    context "with just '/'" do
-      let(:unnormalized_uri) do
-        '/'
-      end
-
-      it "should be '/'" do
-        unnormalized_uri.should == '/'
-      end
-
-      it "should return '/'" do
-        normalized_uri.should == '/'
+  context "Methods" do
+    context ".validate_fingerprint" do
+      it "should raise an error for an invalid match" do
+        opts = {'FingerprintCheck'=>true}
+        opts.stub(:default?).and_return(true)
+        subject.stub(:datastore).and_return(opts)
+        stub_const('HttpFingerprint', {:pattern => [/pattern/]})
+        expect { subject.validate_fingerprint }.to raise_error(RuntimeError)
       end
     end
 
-    context "with starting '/'" do
-      let(:unnormalized_uri) do
-        expected_normalized_uri
-      end
+    context '.normalize_uri' do
+      let(:expected_normalized_uri) { '/a/b/c' }
+      let(:normalized_uri)          { subject.normalize_uri(unnormalized_uri) }
 
-      it "should start with '/'" do
-        unnormalized_uri[0, 1].should == '/'
-      end
+      context "with just '/'" do
+        let(:unnormalized_uri) { '/' }
 
-      it "should not add another starting '/'" do
-        normalized_uri.should == expected_normalized_uri
-      end
-
-      context "with multiple internal '/'" do
-        let(:unnormalized_uri) do
-          "/#{expected_normalized_uri.gsub("/", "////")}"
+        it "should be '/'" do
+          unnormalized_uri.should eq('/')
         end
 
-        it "should remove doubled internal '/'" do
-          normalized_uri.should == expected_normalized_uri
+        it "should return '/'" do
+          normalized_uri.should eq('/')
         end
       end
 
-      context "with multiple starting '/'" do
-        let(:unnormalized_uri) do
-          "/#{expected_normalized_uri}"
+      context "with starting '/'" do
+        let(:unnormalized_uri) { expected_normalized_uri }
+
+        it "should start with '/'" do
+          unnormalized_uri[0, 1].should eq('/')
         end
 
-        it "should have at least 2 starting '/'" do
-          unnormalized_uri[0, 2].should == '//'
-        end
-
-        it "should return with one starting '/'" do
-          normalized_uri.should == expected_normalized_uri
-        end
-      end
-
-      context "with trailing '/'" do
-        let(:expected_normalized_uri) do
-          '/a/b/c/'
-        end
-
-        let(:unnormalized_uri) do
-          "#{expected_normalized_uri}/"
-        end
-
-        it "should end with '/'" do
-          normalized_uri[-1, 1].should == '/'
-        end
-
-        context "with multiple trailing '/'" do
-          let(:unnormalized_uri) do
-            "#{expected_normalized_uri}/"
-          end
-
-          it "should have multiple trailing '/'" do
-            unnormalized_uri[-2,2].should == '//'
-          end
-
-          it "should return only one trailing '/'" do
-            normalized_uri.should == expected_normalized_uri
-          end
-        end
-      end
-
-      context "without trailing '/'" do
-        let(:unnormalized_uri) do
-          expected_normalized_uri
-        end
-
-        it "should not have a trailing '/'" do
-          unnormalized_uri[-1, 1].should_not == '/'
-        end
-
-        it "should return original string" do
-          normalized_uri.should == expected_normalized_uri
-        end
-      end
-    end
-
-    context "without starting '/'" do
-      context "with trailing '/'" do
-        let(:unnormalized_uri) do
-          'a/b/c/'
-        end
-        let(:expected_normalized_uri) do
-          '/a/b/c/'
-        end
-
-        it "should have trailing '/'" do
-          unnormalized_uri[-1, 1].should == '/'
-        end
-
-        it "should add starting '/'" do
-          normalized_uri[0, 1].should == '/'
-        end
-
-        it "should not remove trailing '/'" do
-          normalized_uri[-1, 1].should == '/'
-        end
-
-        it 'should normalize the uri' do
-          normalized_uri.should == "#{expected_normalized_uri}"
+        it "should not add another starting '/'" do
+          normalized_uri.should eq(expected_normalized_uri)
         end
 
         context "with multiple internal '/'" do
-          let(:unnormalized_uri) do
-            "/#{expected_normalized_uri.gsub("/", "////")}"
-          end
+          let(:unnormalized_uri) { "/#{expected_normalized_uri.gsub("/", "////")}" }
 
           it "should remove doubled internal '/'" do
-            normalized_uri.should == expected_normalized_uri
+            normalized_uri.should eq(expected_normalized_uri)
+          end
+        end
+
+        context "with multiple starting '/'" do
+          let(:unnormalized_uri) { "/#{expected_normalized_uri}" }
+
+          it "should have at least 2 starting '/'" do
+            unnormalized_uri[0, 2].should eq('//')
+          end
+
+          it "should return with one starting '/'" do
+            normalized_uri.should eq(expected_normalized_uri)
+          end
+        end
+
+        context "with trailing '/'" do
+          let(:expected_normalized_uri) { '/a/b/c/' }
+          let(:unnormalized_uri)        { "#{expected_normalized_uri}/" }
+
+          it "should end with '/'" do
+            normalized_uri[-1, 1].should eq('/')
+          end
+
+          context "with multiple trailing '/'" do
+            let(:unnormalized_uri) { "#{expected_normalized_uri}/" }
+
+            it "should have multiple trailing '/'" do
+              unnormalized_uri[-2,2].should eq('//')
+            end
+
+            it "should return only one trailing '/'" do
+              normalized_uri.should eq(expected_normalized_uri)
+            end
+          end
+        end
+
+        context "without trailing '/'" do
+          let(:unnormalized_uri) { expected_normalized_uri }
+
+          it "should not have a trailing '/'" do
+            unnormalized_uri[-1, 1].should_not eq('/')
+          end
+
+          it "should return original string" do
+            normalized_uri.should eq(expected_normalized_uri)
           end
         end
       end
 
-      context "without trailing '/'" do
-        let(:unnormalized_uri) do
-          'a/b/c'
+      context "without starting '/'" do
+        context "with trailing '/'" do
+          let(:unnormalized_uri)        { 'a/b/c/' }
+          let(:expected_normalized_uri) { '/a/b/c/' }
+
+          it "should have trailing '/'" do
+            unnormalized_uri[-1, 1].should eq('/')
+          end
+
+          it "should add starting '/'" do
+            normalized_uri[0, 1].should eq('/')
+          end
+
+          it "should not remove trailing '/'" do
+            normalized_uri[-1, 1].should eq('/')
+          end
+
+          it 'should normalize the uri' do
+            normalized_uri.should eq("#{expected_normalized_uri}")
+          end
+
+          context "with multiple internal '/'" do
+            let(:unnormalized_uri) { "/#{expected_normalized_uri.gsub("/", "////")}" }
+
+            it "should remove doubled internal '/'" do
+              normalized_uri.should eq(expected_normalized_uri)
+            end
+          end
         end
 
-        it "should not have trailing '/'" do
-          unnormalized_uri[-1, 1].should_not == '/'
+        context "without trailing '/'" do
+          let(:unnormalized_uri) { 'a/b/c' }
+
+          it "should not have trailing '/'" do
+            unnormalized_uri[-1, 1].should_not eq('/')
+          end
+
+          it "should add starting '/'" do
+            normalized_uri[0, 1].should eq('/')
+          end
+
+          it "should add trailing '/'" do
+            normalized_uri[-1, 1].should_not eq('/')
+          end
+        end
+      end
+
+      context 'with empty string' do
+        let(:unnormalized_uri) { '' }
+
+        it "should be empty" do
+          unnormalized_uri.should be_empty
         end
 
-        it "should add starting '/'" do
-          normalized_uri[0, 1].should == '/'
-        end
-
-        it "should add trailing '/'" do
-          normalized_uri[-1, 1].should_not == '/'
+        it "should return '/'" do
+          normalized_uri.should eq('/')
         end
       end
-    end
 
-    context 'with empty string' do
-      let(:unnormalized_uri) do
-        ''
-      end
+      context 'with nil' do
+        let(:unnormalized_uri) { nil }
 
-      it "should be empty" do
-        unnormalized_uri.should be_empty
-      end
+        it 'should be nil' do
+          unnormalized_uri.should be_nil
+        end
 
-      it "should return '/'" do
-        normalized_uri.should == '/'
-      end
-    end
-
-    context 'with nil' do
-      let(:unnormalized_uri) do
-        nil
-      end
-
-      it 'should be nil' do
-        unnormalized_uri.should be_nil
-      end
-
-      it "should return '/" do
-        normalized_uri.should == '/'
+        it "should return '/" do
+          normalized_uri.should eq('/')
+        end
       end
     end
   end

--- a/spec/lib/msf/core/exploit/http/client_spec.rb
+++ b/spec/lib/msf/core/exploit/http/client_spec.rb
@@ -49,7 +49,7 @@ describe Msf::Exploit::Remote::HttpClient do
     return mod
   end
 
-  context "Methods" do
+  describe "Methods" do
     context ".validate_fingerprint" do
       it "should raise an error for an invalid match" do
         subject.stub(:connect).with(an_instance_of(Hash))
@@ -66,7 +66,7 @@ describe Msf::Exploit::Remote::HttpClient do
       end
     end
 
-    context "HTTP requests" do
+    describe "HTTP requests" do
       let(:cli) do
         Rex::Proto::Http::Client.new(rhost, rport)
       end
@@ -143,7 +143,7 @@ describe Msf::Exploit::Remote::HttpClient do
       end
     end
 
-    context '.normalize_uri' do
+    describe '.normalize_uri' do
       let(:expected_normalized_uri) { '/a/b/c' }
       let(:normalized_uri)          { subject.normalize_uri(unnormalized_uri) }
 
@@ -159,7 +159,7 @@ describe Msf::Exploit::Remote::HttpClient do
         end
       end
 
-      context "with starting '/'" do
+      describe "with starting '/'" do
         let(:unnormalized_uri) { expected_normalized_uri }
 
         it "should start with '/'" do
@@ -178,7 +178,7 @@ describe Msf::Exploit::Remote::HttpClient do
           end
         end
 
-        context "with multiple starting '/'" do
+        describe "with multiple starting '/'" do
           let(:unnormalized_uri) { "/#{expected_normalized_uri}" }
 
           it "should have at least 2 starting '/'" do
@@ -190,7 +190,7 @@ describe Msf::Exploit::Remote::HttpClient do
           end
         end
 
-        context "with trailing '/'" do
+        describe "with trailing '/'" do
           let(:expected_normalized_uri) { '/a/b/c/' }
           let(:unnormalized_uri)        { "#{expected_normalized_uri}/" }
 
@@ -211,7 +211,7 @@ describe Msf::Exploit::Remote::HttpClient do
           end
         end
 
-        context "without trailing '/'" do
+        describe "without trailing '/'" do
           let(:unnormalized_uri) { expected_normalized_uri }
 
           it "should not have a trailing '/'" do
@@ -224,8 +224,8 @@ describe Msf::Exploit::Remote::HttpClient do
         end
       end
 
-      context "without starting '/'" do
-        context "with trailing '/'" do
+      describe "without starting '/'" do
+        describe "with trailing '/'" do
           let(:unnormalized_uri)        { 'a/b/c/' }
           let(:expected_normalized_uri) { '/a/b/c/' }
 
@@ -254,7 +254,7 @@ describe Msf::Exploit::Remote::HttpClient do
           end
         end
 
-        context "without trailing '/'" do
+        describe "without trailing '/'" do
           let(:unnormalized_uri) { 'a/b/c' }
 
           it "should not have trailing '/'" do
@@ -271,7 +271,7 @@ describe Msf::Exploit::Remote::HttpClient do
         end
       end
 
-      context 'with empty string' do
+      describe 'with empty string' do
         let(:unnormalized_uri) { '' }
 
         it "should be empty" do
@@ -283,7 +283,7 @@ describe Msf::Exploit::Remote::HttpClient do
         end
       end
 
-      context 'with nil' do
+      describe 'with nil' do
         let(:unnormalized_uri) { nil }
 
         it 'should be nil' do

--- a/spec/lib/rex/proto/http/client_request_spec.rb
+++ b/spec/lib/rex/proto/http/client_request_spec.rb
@@ -180,8 +180,8 @@ describe Rex::Proto::Http::ClientRequest do
 
   subject(:client_request) { Rex::Proto::Http::ClientRequest.new(default_options) }
 
-  context "protected methods" do
-    context ".set_method" do
+  describe "protected methods" do
+    describe ".set_method" do
       subject { client_request.opts['method'] = 'GET' }
 
       it "should return a random valid HTTP method" do
@@ -200,7 +200,7 @@ describe Rex::Proto::Http::ClientRequest do
       end
     end
 
-    context ".set_method_uri_spacer" do
+    describe ".set_method_uri_spacer" do
       subject { opts['pad_method_uri_count'] = 1 }
 
       it "should return a 'tab' space" do
@@ -214,7 +214,7 @@ describe Rex::Proto::Http::ClientRequest do
       end
     end
 
-    context "\.set_uri_prepend" do
+    describe "\.set_uri_prepend" do
       it "should return a fake params start" do
         client_request.opts['uri_fake_params_start'] = true
         client_request.send(:set_uri_prepend).should eq('/%3fa=b/../')
@@ -227,7 +227,7 @@ describe Rex::Proto::Http::ClientRequest do
     end
   end
 
-  context ".set_version" do
+  describe ".set_version" do
     subject {
       client_request.opts['proto']   = 'http'
       client_request.opts['version'] = '1.1'
@@ -249,7 +249,7 @@ describe Rex::Proto::Http::ClientRequest do
     end
   end
 
-  context ".set_uri_version_spacer" do
+  describe ".set_uri_version_spacer" do
     subject { opts['pad_method_uri_count'] = 1 }
 
     it "should return a tab" do
@@ -263,7 +263,7 @@ describe Rex::Proto::Http::ClientRequest do
     end
   end
 
-  context ".set_body" do
+  describe ".set_body" do
     it "should return a body with chunked_size " do
       body = 'http_body'
       client_request.opts['chunked_size'] = 1024
@@ -271,7 +271,7 @@ describe Rex::Proto::Http::ClientRequest do
     end
   end
 
-  context "with requests" do
+  describe "with requests" do
     subject(:client_request) {
       options_with_params = default_options.merge({
         'uri_encode_mode' => encode_mode,
@@ -313,7 +313,7 @@ describe Rex::Proto::Http::ClientRequest do
       end
     end
 
-    context "with 'vars_post'" do
+    describe "with 'vars_post'" do
       let(:encode_params) { true }
 
       it "should pad post params" do
@@ -348,7 +348,7 @@ describe Rex::Proto::Http::ClientRequest do
       end
     end
 
-    context "with 'encode_params'" do
+    describe "with 'encode_params'" do
       let(:encode_params) { true }
       context "and 'uri_encode_mode' = default (hex-normal)" do
         it "should encode special chars" do

--- a/spec/lib/rex/proto/http/client_request_spec.rb
+++ b/spec/lib/rex/proto/http/client_request_spec.rb
@@ -1,8 +1,13 @@
 # -*- coding:binary -*-
-require 'spec_helper'
+#require 'spec_helper'
 
 require 'rex/proto/http/client_request'
 
+##
+#
+# Testing protected methods
+#
+##
 
 shared_context "with no evasions" do
   before(:each) do
@@ -12,7 +17,7 @@ shared_context "with no evasions" do
   end
 
   it "should return the unmodified uri" do
-    client_request.send(:set_uri).should == "/"
+    client_request.send(:set_uri).should eq("/")
   end
 end
 
@@ -38,9 +43,7 @@ shared_context "with 'uri_dir_fake_relative'" do
     client_request.send(:set_uri).should include("../")
     client_request.to_s.should include("../")
   end
-
 end
-
 
 shared_context "with 'uri_full_url'" do
 
@@ -81,17 +84,23 @@ shared_examples "uri_full_url" do
 end
 
 
+##
+#
+# Testing ClientRequest
+#
+##
+
 describe Rex::Proto::Http::ClientRequest do
 
   default_options = {
     # All of these should be what you get when you pass in empty
     # options, but of course that would make it too easy
-    'uri' => '/',
-    'method' => "GET",
-    'proto' => "HTTP",
+    'uri'        => '/',
+    'method'     => "GET",
+    'proto'      => "HTTP",
     'connection' => "close",
-    'version' => "1.1",
-    'port' => 80,
+    'version'    => "1.1",
+    'port'       => 80
   }
 
   [
@@ -161,13 +170,20 @@ describe Rex::Proto::Http::ClientRequest do
         result = things[:result]
         describe "##{meth}" do
           it "should return #{result.inspect}" do
-            client_request.send(meth, *args).should == result
+            client_request.send(meth, *args).should eq(result)
           end
         end
       end
 
     end
   end
+
+
+##
+#
+# Testing to_s
+#
+##
 
   subject(:client_request) { Rex::Proto::Http::ClientRequest.new(default_options) }
 
@@ -199,10 +215,10 @@ describe Rex::Proto::Http::ClientRequest do
         client_request.opts['pad_get_params'] = true
 
         client_request.opts['pad_get_params_count'] = 0
-        client_request.to_s.split("&").length.should == vars_get.length
+        client_request.to_s.split("&").length.should eq(vars_get.length)
 
         client_request.opts['pad_get_params_count'] = 10
-        client_request.to_s.split("&").length.should == vars_get.length + 10
+        client_request.to_s.split("&").length.should eq(vars_get.length + 10)
 
         client_request.opts['pad_get_params'] = old
       end
@@ -241,7 +257,7 @@ describe Rex::Proto::Http::ClientRequest do
 
       describe "#to_s" do
         it "should produce same values if called multiple times with same options" do
-          client_request.to_s.should == client_request.to_s
+          client_request.to_s.should eq(client_request.to_s)
         end
       end
 

--- a/spec/lib/rex/proto/http/client_request_spec.rb
+++ b/spec/lib/rex/proto/http/client_request_spec.rb
@@ -1,5 +1,5 @@
 # -*- coding:binary -*-
-require 'spec_helper'
+#require 'spec_helper'
 require 'rex/proto/http/client_request'
 
 ##
@@ -185,7 +185,8 @@ describe Rex::Proto::Http::ClientRequest do
       subject { client_request.opts['method'] = 'GET' }
 
       it "should return a random valid HTTP method" do
-        client_request.send(:set_method).should eq('GET')
+        client_request.opts['method_random_valid'] = true
+        client_request.send(:set_method).should match(/GET|POST|HEAD/)
       end
 
       it "should return a rand_text_lpha" do
@@ -207,7 +208,7 @@ describe Rex::Proto::Http::ClientRequest do
         client_request.send(:set_method_uri_spacer).should eq("\t")
       end
 
-      it "should return a 'apache' space" do
+      it "should return a 'apache' spacer" do
         client_request.opts['pad_method_uri_type'] = 'apache'
         client_request.send(:set_method_uri_spacer).should_not be_empty
       end
@@ -223,6 +224,50 @@ describe Rex::Proto::Http::ClientRequest do
         client_request.opts['uri_fake_end'] = true
         client_request.send(:set_uri_prepend).should eq('/%20HTTP/1.0/../../')
       end
+    end
+  end
+
+  context ".set_version" do
+    subject {
+      client_request.opts['proto']   = 'http'
+      client_request.opts['version'] = '1.1'
+    }
+
+    it "should do version_random_id" do
+      client_request.opts['version_random_id'] = true
+      client_request.send(:set_version).should match(/.+\r\n$/)
+    end
+
+    it "should do version_random_invalid" do
+      client_request.opts['version_random_invalid'] = true
+      client_request.send(:set_version).should match(/.+\r\n$/)
+    end
+
+    it "should version_random_case" do
+      client_request.opts['version_random_case'] = true
+      client_request.send(:set_version).should match(/.+\r\n$/)
+    end
+  end
+
+  context ".set_uri_version_spacer" do
+    subject { opts['pad_method_uri_count'] = 1 }
+
+    it "should return a tab" do
+      client_request.opts['pad_uri_version_type'] = 'tab'
+      client_request.send(:set_uri_version_spacer).should_not be_empty
+    end
+
+    it "should return apache spacers" do
+      client_request.opts['pad_uri_version_type'] = 'apache'
+      client_request.send(:set_uri_version_spacer).should_not be_empty
+    end
+  end
+
+  context ".set_body" do
+    it "should return a body with chunked_size " do
+      body = 'http_body'
+      client_request.opts['chunked_size'] = 1024
+      client_request.send(:set_body, body).should match(/#{body}/)
     end
   end
 

--- a/spec/lib/rex/proto/http/client_spec.rb
+++ b/spec/lib/rex/proto/http/client_spec.rb
@@ -146,6 +146,24 @@ describe Rex::Proto::Http::Client do
         cli.send_auth(res, opts, 1, false).code.should eq(401)
       end
 
+      it "should set the username and password to nil if the username is nil" do
+        opts = { 'username' => nil, 'password' => nil }
+        cli.send_auth(res, opts, 1, false).code.should eq(401)
+      end
+
+      it "should use the user and pass set in the mixin if the user doesn't supply one" do
+        opts = { 'username' => '', 'password' => '' }
+        cli.stub(:username).and_return(user)
+        cli.stub(:password).and_return(pass)
+        res.stub(:headers).and_return({'WWW-Authenticate' => ''})
+        cli.stub(:_send_recv).with(an_instance_of(
+          Rex::Proto::Http::ClientRequest),
+          an_instance_of(Fixnum),
+          an_instance_of(false.class)
+        ).and_return(res)
+        cli.send_auth(res, opts, 1, false).code.should eq(401)
+      end
+
       it "should do NTLM authentication" do
         res.stub(:headers).and_return({'WWW-Authenticate' => 'NTLM'})
         cli.stub(:_send_recv).with(an_instance_of(
@@ -163,7 +181,7 @@ describe Rex::Proto::Http::Client do
           return params
         end
 
-        def test_send_auth(digest_params)
+        def test_digest_auth(digest_params)
           params = hash_to_params(digest_params)
           res.stub(:headers).and_return({'WWW-Authenticate' => %Q|Digest #{params}|})
           cli.stub(:_send_recv).with(any_args).and_return(res)
@@ -180,40 +198,40 @@ describe Rex::Proto::Http::Client do
         end
 
         it "should do Digest authentication" do
-          test_send_auth(digest_opts)
+          test_digest_auth(digest_opts)
         end
 
         it "should set the algorithm to MD5" do
-          test_send_auth(digest_opts.merge({'algorithm'=>'MD5'})).code.should eq(401)
+          test_digest_auth(digest_opts.merge({'algorithm'=>'MD5'})).code.should eq(401)
         end
 
         it "should set the algorithm to SHA1" do
-          test_send_auth(digest_opts.merge({'algorithm'=>'SHA1'})).code.should eq(401)
+          test_digest_auth(digest_opts.merge({'algorithm'=>'SHA1'})).code.should eq(401)
         end
 
         it "should set the algorithm to SHA2" do
-          test_send_auth(digest_opts.merge({'algorithm'=>'SHA2'})).code.should eq(401)
+          test_digest_auth(digest_opts.merge({'algorithm'=>'SHA2'})).code.should eq(401)
         end
 
         it "should set the algorithm to SHA256" do
-          test_send_auth(digest_opts.merge({'algorithm'=>'SHA256'})).code.should eq(401)
+          test_digest_auth(digest_opts.merge({'algorithm'=>'SHA256'})).code.should eq(401)
         end
 
         it "should set the algorithm to SHA384" do
-          test_send_auth(digest_opts.merge({'algorithm'=>'SHA384'})).code.should eq(401)
+          test_digest_auth(digest_opts.merge({'algorithm'=>'SHA384'})).code.should eq(401)
         end
 
         it "should set the algorithm to SHA512" do
-          test_send_auth(digest_opts.merge({'algorithm'=>'SHA512'})).code.should eq(401)
+          test_digest_auth(digest_opts.merge({'algorithm'=>'SHA512'})).code.should eq(401)
         end
 
         it "should set the algorithm to RMD160" do
-          test_send_auth(digest_opts.merge({'algorithm'=>'RMD160'})).code.should eq(401)
+          test_digest_auth(digest_opts.merge({'algorithm'=>'RMD160'})).code.should eq(401)
         end
 
         it "should raise an error due to an unknown algorithm" do
           expect {
-            test_send_auth(digest_opts.merge({'algorithm'=>'UNKNOWN'}))
+            test_digest_auth(digest_opts.merge({'algorithm'=>'UNKNOWN'}))
           }.to raise_error(Exception)
         end
 

--- a/spec/lib/rex/proto/http/client_spec.rb
+++ b/spec/lib/rex/proto/http/client_spec.rb
@@ -163,7 +163,14 @@ describe Rex::Proto::Http::Client do
           return params
         end
 
-        let(:digest_params) do
+        def test_send_auth(digest_params)
+          params = hash_to_params(digest_params)
+          res.stub(:headers).and_return({'WWW-Authenticate' => %Q|Digest #{params}|})
+          cli.stub(:_send_recv).with(any_args).and_return(res)
+          return cli.send_auth(res, opts, 1, false)
+        end
+
+        let(:digest_opts) do
           {
             'username' => %Q|"#{user}"|,
             'realm'    => %Q|"admin@example.com"|,
@@ -173,66 +180,41 @@ describe Rex::Proto::Http::Client do
         end
 
         it "should do Digest authentication" do
-          params = hash_to_params(digest_params)
-          res.stub(:headers).and_return({'WWW-Authenticate' => %Q|Digest #{params}|})
-          cli.stub(:_send_recv).with(any_args).and_return(res)
-          cli.send_auth(res, opts, 1, false).code.should eq(401)
+          test_send_auth(digest_opts)
         end
 
         it "should set the algorithm to MD5" do
-          params = hash_to_params(digest_params.merge({'algorithm'=>'MD5'}))
-          res.stub(:headers).and_return({'WWW-Authenticate' => %Q|Digest #{params}|})
-          cli.stub(:_send_recv).with(any_args).and_return(res)
-          cli.send_auth(res, opts, 1, false).code.should eq(401)
+          test_send_auth(digest_opts.merge({'algorithm'=>'MD5'})).code.should eq(401)
         end
 
         it "should set the algorithm to SHA1" do
-          params = hash_to_params(digest_params.merge({'algorithm'=>'SHA1'}))
-          res.stub(:headers).and_return({'WWW-Authenticate' => %Q|Digest #{params}|})
-          cli.stub(:_send_recv).with(any_args).and_return(res)
-          cli.send_auth(res, opts, 1, false).code.should eq(401)
+          test_send_auth(digest_opts.merge({'algorithm'=>'SHA1'})).code.should eq(401)
         end
 
         it "should set the algorithm to SHA2" do
-          params = hash_to_params(digest_params.merge({'algorithm'=>'SHA2'}))
-          res.stub(:headers).and_return({'WWW-Authenticate' => %Q|Digest #{params}|})
-          cli.stub(:_send_recv).with(any_args).and_return(res)
-          cli.send_auth(res, opts, 1, false).code.should eq(401)
+          test_send_auth(digest_opts.merge({'algorithm'=>'SHA2'})).code.should eq(401)
         end
 
         it "should set the algorithm to SHA256" do
-          params = hash_to_params(digest_params.merge({'algorithm'=>'SHA256'}))
-          res.stub(:headers).and_return({'WWW-Authenticate' => %Q|Digest #{params}|})
-          cli.stub(:_send_recv).with(any_args).and_return(res)
-          cli.send_auth(res, opts, 1, false).code.should eq(401)
+          test_send_auth(digest_opts.merge({'algorithm'=>'SHA256'})).code.should eq(401)
         end
 
         it "should set the algorithm to SHA384" do
-          params = hash_to_params(digest_params.merge({'algorithm'=>'SHA384'}))
-          res.stub(:headers).and_return({'WWW-Authenticate' => %Q|Digest #{params}|})
-          cli.stub(:_send_recv).with(any_args).and_return(res)
-          cli.send_auth(res, opts, 1, false).code.should eq(401)
+          test_send_auth(digest_opts.merge({'algorithm'=>'SHA384'})).code.should eq(401)
         end
 
         it "should set the algorithm to SHA512" do
-          params = hash_to_params(digest_params.merge({'algorithm'=>'SHA512'}))
-          res.stub(:headers).and_return({'WWW-Authenticate' => %Q|Digest #{params}|})
-          cli.stub(:_send_recv).with(any_args).and_return(res)
-          cli.send_auth(res, opts, 1, false).code.should eq(401)
+          test_send_auth(digest_opts.merge({'algorithm'=>'SHA512'})).code.should eq(401)
         end
 
         it "should set the algorithm to RMD160" do
-          params = hash_to_params(digest_params.merge({'algorithm'=>'RMD160'}))
-          res.stub(:headers).and_return({'WWW-Authenticate' => %Q|Digest #{params}|})
-          cli.stub(:_send_recv).with(any_args).and_return(res)
-          cli.send_auth(res, opts, 1, false).code.should eq(401)
+          test_send_auth(digest_opts.merge({'algorithm'=>'RMD160'})).code.should eq(401)
         end
 
         it "should raise an error due to an unknown algorithm" do
-          params = hash_to_params(digest_params.merge({'algorithm'=>'UNKNOWN'}))
-          res.stub(:headers).and_return({'WWW-Authenticate' => %Q|Digest #{params}|})
-          cli.stub(:_send_recv).with(any_args).and_return(res)
-          expect { cli.send_auth(res, opts, 1, false) }.to raise_error(Exception)
+          expect {
+            test_send_auth(digest_opts.merge({'algorithm'=>'UNKNOWN'}))
+          }.to raise_error(Exception)
         end
 
       end
@@ -279,19 +261,6 @@ describe Rex::Proto::Http::Client do
     cli.stub(:conn).and_return(conn)
     cli.send_request("req")
   end
-
-#
-# We don't even remember why this test case exists, but I'll keep this here until we find a
-# a reaspon for uncomment it.
-#
-#  it "should test for credentials" do
-#    pending "Should actually respond to :has_creds" do
-#      cli.should_not have_creds
-#      this_cli = described_class.new("127.0.0.1", 1, {}, false, nil, nil, "user1", "pass1" )
-#      this_cli.should have_creds
-#    end
-#  end
-#
 
   it "should continue to read more data if the HTTP body begins with 'HTTP'" do
     body = ''

--- a/spec/lib/rex/proto/http/request_spec.rb
+++ b/spec/lib/rex/proto/http/request_spec.rb
@@ -1,0 +1,179 @@
+require 'spec_helper'
+require 'rex/proto/http/request'
+
+describe Rex::Proto::Http::Request do
+
+  let(:resource)    { '/test.php' }
+  let(:method)      { 'GET' }
+  let(:qstring)     { '?id=1' }
+  let(:get_request) { "#{method} #{resource}#{qstring} HTTP/1.1" }
+
+  context Rex::Proto::Http::Request::Get do
+    it "should initialize" do
+      Rex::Proto::Http::Request::Get.new
+    end
+  end
+
+  context Rex::Proto::Http::Request::Post do
+    it "should initialize" do
+      Rex::Proto::Http::Request::Post.new
+    end
+  end
+
+  context Rex::Proto::Http::Request::Put do
+    it "should initialize" do
+      Rex::Proto::Http::Request::Put.new
+    end
+  end
+
+  context "Class Request" do
+    subject(:cli) { Rex::Proto::Http::Request.new(method, resource) }
+
+    context "Methods" do
+      context ".update_cmd_parts" do
+        it "should update uri parts" do
+          cli.update_cmd_parts(get_request).should eq(resource)
+        end
+
+        it "should raise a RuntimeError due to an invalid request command string" do
+          expect { cli.update_cmd_parts("") }.to raise_error(RuntimeError)
+        end
+      end
+
+      context ".update_uri_parts" do
+        it "should get the parts from a query string" do
+          cli.raw_uri = get_request
+          cli.update_uri_parts.should eq("#{method} #{resource}")
+        end
+
+        it "should set the URI the same as the resource being requested" do
+          cli.raw_uri = ''
+          cli.update_uri_parts.should be_empty
+        end
+      end
+
+      context ".normalize!" do
+        it "should remove a double slash in the URI" do
+          cli.normalize!(qstring).should eq(0)
+        end
+      end
+
+      context ".uri" do
+        subject { cli.uri_parts['Resource'] = resource }
+        it "should return an uri with junk_self_referring_directories" do
+          cli.stub(:junk_self_referring_directories).and_return(true)
+          cli.uri.should match(/[\.\/]+#{resource}/)
+        end
+
+        it "should return an uri with junk_param_start" do
+          cli.stub(:junk_param_start).and_return(true)
+          cli.uri.should match(/\/%3f.+#{resource}$/)
+        end
+
+        it "should return an uri with junk_directories" do
+          cli.stub(:junk_directories).and_return(true)
+          cli.uri.should match(/.+#{resource}/)
+        end
+
+        it "should return an uri with junk_slashes" do
+          cli.stub(:junk_slashes).and_return(true)
+          cli.uri_parts['Resource'] = "/#{resource}"
+          cli.uri.should eq(resource)
+        end
+
+        it "should return an uri with junk_end_of_uri" do
+          cli.stub(:junk_end_of_uri).and_return(true)
+          cli.uri.should eq("/%20HTTP/1.0%0d%0a/../..#{resource}")
+        end
+
+      end
+
+      context ".param_string" do
+        it "should return params with junk_params" do
+          cli.uri_parts['QueryString'] = {'param' => ['1'] }
+          cli.stub(:junk_params).and_return(true)
+          cli.param_string.should match(/.+=.+/)
+        end
+
+        it "should return params with with a value" do
+          cli.uri_parts['QueryString'] = {'param' => '1' }
+          cli.param_string.should eq('param=1')
+        end
+
+        it "should return a param with out a value" do
+          cli.uri_parts['QueryString'] = {'param' => nil }
+          cli.param_string.should eq('param')
+        end
+
+      end
+
+      context ".uri=" do
+        it "should update the underlying URI structure" do
+          uri = cli.uri=(resource)
+          uri.should eq(resource)
+        end
+      end
+
+      context ".to_s" do
+        it "should return a request packet with junk_pipeline" do
+          cli.stub(:junk_pipeline).and_return(1)
+          cli.headers['Host'] = 'Host'
+          cli.to_s.should match(resource)
+        end
+      end
+
+      context ".body" do
+        it "should return a body" do
+          cli.body.should eq('')
+        end
+
+        it "should return a param_string" do
+          cli.stub(:method).and_return('POST')
+          cli.body.should eq('')
+        end
+      end
+
+      context ".cmd_string" do
+        it "should return the command string" do
+          cli.cmd_string.should match(/#{resource}/)
+        end
+      end
+
+      context ".resource" do
+        it "should return a resource" do
+          cli.resource.should match(/#{resource}/)
+        end
+      end
+
+      context ".resource=" do
+        it "should return an user-specified resource" do
+          tmp_resource = '/test_resource.php'
+          cli.resource=(tmp_resource).should eq(tmp_resource)
+        end
+      end
+
+      context ".qstring" do
+        it "should return a query string" do
+          test_string = 'test'
+          cli.uri_parts['QueryString'] = test_string
+          cli.qstring.should eq(test_string)
+        end
+      end
+
+      context ".parse_cgi_qstring" do
+        it "should parse and return a CGI qstring" do
+          qstring_opts = {
+            'id'       => '1',
+            'username' => 'user'
+          }
+
+          tmp = []
+          qstring_opts.each_pair { |k, v| tmp << "#{k}=#{v}" }
+          qstring = tmp * "&"
+          cli.parse_cgi_qstring(qstring).should eq(qstring_opts)
+        end
+      end
+    end
+  end
+
+end

--- a/spec/lib/rex/proto/http/request_spec.rb
+++ b/spec/lib/rex/proto/http/request_spec.rb
@@ -30,7 +30,7 @@ describe Rex::Proto::Http::Request do
     subject(:cli) { Rex::Proto::Http::Request.new(method, resource) }
 
     describe "Methods" do
-      context ".update_cmd_parts" do
+      describe ".update_cmd_parts" do
         it "should update uri parts" do
           cli.update_cmd_parts(get_request).should eq(resource)
         end
@@ -40,7 +40,7 @@ describe Rex::Proto::Http::Request do
         end
       end
 
-      context ".update_uri_parts" do
+      describe ".update_uri_parts" do
         it "should get the parts from a query string" do
           cli.raw_uri = get_request
           cli.update_uri_parts.should eq("#{method} #{resource}")
@@ -58,7 +58,7 @@ describe Rex::Proto::Http::Request do
         end
       end
 
-      context ".uri" do
+      describe ".uri" do
         subject { cli.uri_parts['Resource'] = resource }
         it "should return an uri with junk_self_referring_directories" do
           cli.stub(:junk_self_referring_directories).and_return(true)
@@ -88,7 +88,7 @@ describe Rex::Proto::Http::Request do
 
       end
 
-      context ".param_string" do
+      describe ".param_string" do
         it "should return params with junk_params" do
           cli.uri_parts['QueryString'] = {'param' => ['1'] }
           cli.stub(:junk_params).and_return(true)
@@ -122,7 +122,7 @@ describe Rex::Proto::Http::Request do
         end
       end
 
-      context ".body" do
+      describe ".body" do
         it "should return a body" do
           cli.body.should eq('')
         end

--- a/spec/lib/rex/proto/http/request_spec.rb
+++ b/spec/lib/rex/proto/http/request_spec.rb
@@ -26,10 +26,10 @@ describe Rex::Proto::Http::Request do
     end
   end
 
-  context "Class Request" do
+  describe "Class Request" do
     subject(:cli) { Rex::Proto::Http::Request.new(method, resource) }
 
-    context "Methods" do
+    describe "Methods" do
       context ".update_cmd_parts" do
         it "should update uri parts" do
           cli.update_cmd_parts(get_request).should eq(resource)

--- a/spec/lib/rex/proto/http/request_spec.rb
+++ b/spec/lib/rex/proto/http/request_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+#require 'spec_helper'
 require 'rex/proto/http/request'
 
 describe Rex::Proto::Http::Request do
@@ -10,19 +10,19 @@ describe Rex::Proto::Http::Request do
 
   context Rex::Proto::Http::Request::Get do
     it "should initialize" do
-      Rex::Proto::Http::Request::Get.new
+      Rex::Proto::Http::Request::Get.new.should be_a_kind_of(Rex::Proto::Http::Request::Get)
     end
   end
 
   context Rex::Proto::Http::Request::Post do
     it "should initialize" do
-      Rex::Proto::Http::Request::Post.new
+      Rex::Proto::Http::Request::Post.new.should be_a_kind_of(Rex::Proto::Http::Request::Post)
     end
   end
 
   context Rex::Proto::Http::Request::Put do
     it "should initialize" do
-      Rex::Proto::Http::Request::Put.new
+      Rex::Proto::Http::Request::Put.new.should be_a_kind_of(Rex::Proto::Http::Request::Put)
     end
   end
 


### PR DESCRIPTION
This updates Http Client's Rspec. Fixed all pending cases, and a lot more code coverage than ever.

Verification step:
- [x] Since there are 4 of them I suggest you just run 'rspec' and make sure you get no failures.
