### PR TITLE
Fix nil bug in jboss_invoke_deploy.rb

### DIFF
--- a/modules/exploits/multi/http/jboss_invoke_deploy.rb
+++ b/modules/exploits/multi/http/jboss_invoke_deploy.rb
@@ -89,7 +89,11 @@ class Metasploit4 < Msf::Exploit::Remote
 
   def check
     res = send_serialized_request('version.bin')
-    if (res.nil?) or (res.code != 200)
+    if res.nil?
+      print_error("Connection timed out")
+      return Exploit::CheckCode::Unknown
+
+    elsif res.code != 200
       print_error("Unable to request version, returned http code is: #{res.code.to_s}")
       return Exploit::CheckCode::Unknown
     end


### PR DESCRIPTION
If there is a connection timeout, the module shouldn't access the "code" method because that does not exist.

Verification step(s):

Option 1: You can either do it this way:
- [x] Set up a webserver that times out
- [x] Run the module against that web server to reproduce the issue
- [x] Run the patched version of the module against that web server
- [x] Confirm you no longer see the same error.

Option 2: Or you can just do it this way:
- [x] See the diff and confirm that the unpatched version does indeed try to access the 'code' method if res is nil
