### PR TITLE
Update CheckCode Documentation

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -65,6 +65,8 @@ class Exploit < Msf::Module
   ##
   #
   # The various check codes that can be returned from the ``check'' routine.
+  # Please read the following wiki to learn how these codes are used:
+  # https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-check()-method
   #
   ##
   module CheckCode

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -89,7 +89,7 @@ class Exploit < Msf::Module
 
     #
     # The target appears to be vulnerable. This is recommended if the vulnerability is determined
-    # based on non-explicit checking. For example: version, banner grabbing, or having the resource
+    # based on passive reconnaissance. For example: version, banner grabbing, or having the resource
     # that's known to be vulnerable.
     #
     Appears     = [ 'appears', "The target appears to be vulnerable." ]

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -70,28 +70,34 @@ class Exploit < Msf::Module
   module CheckCode
 
     #
-    # Can't tell if the target is exploitable or not.
+    # Can't tell if the target is exploitable or not. This is recommended if the module fails to
+    # retrieve enough information from the target machine, such as due to a timeout.
     #
     Unknown     = [ 'unknown', "Cannot reliably check exploitability."]
 
     #
-    # The target is safe and is therefore not exploitable.
+    # The target is safe and is therefore not exploitable. This is recommended after the check
+    # fails to trigger the vulnerability, or even detect the service.
     #
     Safe        = [ 'safe', "The target is not exploitable." ]
 
     #
-    # The target is running the service in question but may not be
-    # exploitable.
+    # The target is running the service in question, but the check fails to determine whether
+    # the target is vulnerable or not.
     #
     Detected    = [ 'detected', "The target service is running, but could not be validated." ]
 
     #
-    # The target appears to be vulnerable.
+    # The target appears to be vulnerable. This is recommended if the vulnerability is determined
+    # based on non-explicit checking. For example: version, banner grabbing, or having the resource
+    # that's known to be vulnerable.
     #
     Appears     = [ 'appears', "The target appears to be vulnerable." ]
 
     #
-    # The target is vulnerable.
+    # The target is vulnerable. Only used if the check is able to actually exploit the bug,
+    # and obtain hard evidence. For example: executing a command on the target machine, and
+    # retrieve the output.
     #
     Vulnerable  = [ 'vulnerable', "The target is vulnerable." ]
 

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -95,8 +95,8 @@ class Exploit < Msf::Module
     Appears     = [ 'appears', "The target appears to be vulnerable." ]
 
     #
-    # The target is vulnerable. Only used if the check is able to actually exploit the bug,
-    # and obtain hard evidence. For example: executing a command on the target machine, and
+    # The target is vulnerable. Only used if the check is able to actually take advantage of the
+    # bug, and obtain hard evidence. For example: executing a command on the target machine, and
     # retrieve the output.
     #
     Vulnerable  = [ 'vulnerable', "The target is vulnerable." ]


### PR DESCRIPTION
An example of the biggest confusion module developers face is not actually knowing the difference between Detected vs Appears vs Vulnerable. For example: a module might flag something as a vulnerable by simply doing a banner check, but this is often unreliable because either 1) that banner can be fooled, or 2) the patch does not actually update the banner. More reasons may apply. Just because the banner LOOKS vulnearble doesn't mean it is.

Being able to accurately determine the vulnerable state is also important to the user. It's not uncommon for pentesters to first run a vuln scan, and then use Metasploit checks to find out which ones are "exploitable", and then target those first.

This PR should be reviewed by at least the following people:
- @jvazquez-r7: The guidelines emphasize on the quality of explicit checks, meaning it implies some of the existing checks should be lowered to CheckCode::Appears. For example: The HP Data Protector modules. Even though they seem to do just fine flagging a target as vulnerable with version checking, they're not actually explicit checks.
- @todb-r7: just because he's the fearless leader.

Verification:
- [x] Run `yard`
- [x] Make sure you can see the updated documentation.
