### PR TITLE
Update check() in auxiliary

### DIFF
--- a/modules/auxiliary/admin/http/intersil_pass_reset.rb
+++ b/modules/auxiliary/admin/http/intersil_pass_reset.rb
@@ -52,12 +52,12 @@ class Metasploit3 < Msf::Auxiliary
       })
 
       if (res and (m = res.headers['Server'].match(/Boa\/(.*)/)))
-        print_status("#{peer} - Boa Version Detected: #{m[1]}")
+        vprint_status("#{peer} - Boa Version Detected: #{m[1]}")
         return Exploit::CheckCode::Safe if (m[1][0].ord-48>0) # boa server wrong version
         return Exploit::CheckCode::Safe if (m[1][3].ord-48>4)
         return Exploit::CheckCode::Vulnerable
       else
-        print_status("#{peer} - Not a Boa Server!")
+        vprint_status("#{peer} - Not a Boa Server!")
         return Exploit::CheckCode::Safe # not a boa server
       end
 

--- a/modules/auxiliary/admin/scada/modicon_password_recovery.rb
+++ b/modules/auxiliary/admin/scada/modicon_password_recovery.rb
@@ -76,7 +76,6 @@ class Metasploit3 < Msf::Auxiliary
       return Exploit::CheckCode::Detected
     else
       vprint_error "#{ip}:#{rport} - FTP - Skipping due to fingerprint mismatch"
-      Exploit::CheckCode::Unknown
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/auxiliary/dos/http/nodejs_pipelining.rb
+++ b/modules/auxiliary/dos/http/nodejs_pipelining.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Auxiliary
   def check
     # http://blog.nodejs.org/2013/08/21/node-v0-10-17-stable/
     # check if we are < 0.10.17 by seeing if a malformed HTTP request is accepted
-    status = Exploit::CheckCode::Unknown
+    status = Exploit::CheckCode::Safe
     connect
     sock.put(http_request("GEM"))
     begin
@@ -56,6 +56,8 @@ class Metasploit3 < Msf::Auxiliary
     rescue EOFError
       # checking against >= 0.10.17 raises EOFError because there is no
       # response to GEM requests
+      vprint_error("Failed to determine the vulnerable state due to an EOFError (no response)")
+      return Msf::Exploit::CheckCode::Unknown
     ensure
       disconnect
     end

--- a/modules/auxiliary/gather/coldfusion_pwd_props.rb
+++ b/modules/auxiliary/gather/coldfusion_pwd_props.rb
@@ -43,7 +43,6 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(80),
-        OptBool.new('CHECK', [false, 'Only check for vulnerability', false]),
         OptString.new("TARGETURI", [true, 'Base path to ColdFusion', '/'])
       ], self.class)
   end
@@ -116,6 +115,14 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def check
+    if check_cf
+      return Msf::Exploit::CheckCode::Vulnerable
+    end
+
+    Msf::Exploit::CheckCode::Safe
+  end
+
+  def check_cf
     vuln = false
     url = '/CFIDE/adminapi/customtags/l10n.cfm'
     res = send_request_cgi({
@@ -171,16 +178,10 @@ class Metasploit3 < Msf::Auxiliary
       return
     end
 
-    if(not check)
+    if(not check_cf)
       print_status("#{peer} can't be exploited (either files missing or permissions block access)")
       return
     end
-
-    if (datastore['CHECK'] )
-      print_good("#{peer} is vulnerable and most likely exploitable") if check
-      return
-    end
-
 
     res = send_request_cgi({
       'method'   => 'GET',

--- a/modules/auxiliary/gather/vbulletin_vote_sqli.rb
+++ b/modules/auxiliary/gather/vbulletin_vote_sqli.rb
@@ -128,21 +128,21 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def check
-    node_id = get_node
-
-    unless node_id.nil?
-      return Msf::Exploit::CheckCode::Vulnerable
-    end
-
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, "index.php")
     })
 
     if res and res.code == 200 and res.body.to_s =~ /"simpleversion": "v=5/
-      return Msf::Exploit::CheckCode::Detected
+      if get_node
+        # Multiple factors determine this LOOKS vulnerable
+        return Msf::Exploit::CheckCode::Appears
+      else
+        # Not enough information about the vuln state, but at least we know this is vbulletin
+        return Msf::Exploit::CheckCode::Detected
+      end
     end
 
-    return Msf::Exploit::CheckCode::Unknown
+    Msf::Exploit::CheckCode::Safe
   end
 
   def run

--- a/modules/auxiliary/scanner/vmware/vmware_http_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_http_login.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Auxiliary
 
 
   def run_host(ip)
-    return unless is_vmware?
+    return unless check == Exploit::CheckCode::Detected
     each_user_pass { |user, pass|
       result = vim_do_login(user, pass)
       case result
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Auxiliary
 
 
   # Mostly taken from the Apache Tomcat service validator
-  def is_vmware?
+  def check
     soap_data =
       %Q|<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <env:Body>
@@ -81,23 +81,26 @@ class Metasploit3 < Msf::Auxiliary
       }, 25)
 
       if res
-        fingerprint_vmware(res)
+        return Exploit::CheckCode::Detected if fingerprint_vmware(res)
       else
-        vprint_error("#{rhost}:#{rport} Error: no response")
+        vprint_error("Error: no response")
+        return Exploit::CheckCode::Unknown
       end
 
     rescue ::Rex::ConnectionError => e
-      vprint_error("#{rhost}:#{rport} Error: could not connect")
-      return false
+      vprint_error("Error: could not connect")
+      return Exploit::CheckCode::Unknown
     rescue
-      vprint_error("#{rhost}:#{rport} Error: #{e}")
-      return false
+      vprint_error("Error: #{e}")
+      return Exploit::CheckCode::Unknown
     end
+
+    return Exploit::CheckCode::Safe
   end
 
   def fingerprint_vmware(res)
     unless res
-      vprint_error("#{rhost}:#{rport} Error: no response")
+      vprint_error("Error: no response")
       return false
     end
     return false unless res.body.include?('<vendor>VMware, Inc.</vendor>')
@@ -108,7 +111,7 @@ class Metasploit3 < Msf::Auxiliary
     full_match = res.body.match(/<fullName>([\w\s\.\-]+)<\/fullName>/)
 
     if full_match
-      print_good "#{rhost}:#{rport} - Identified #{full_match[1]}"
+      vprint_good "Identified #{full_match[1]}"
       report_service(:host => rhost, :port => rport, :proto => 'tcp', :sname => 'https', :info => full_match[1])
     end
 
@@ -118,7 +121,7 @@ class Metasploit3 < Msf::Auxiliary
       end
       return true
     else
-      vprint_error("#{rhost}:#{rport} Error: Could not identify as VMWare")
+      vprint_error("Error: Could not identify as VMWare")
       return false
     end
 

--- a/modules/auxiliary/scanner/vmware/vmware_http_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_http_login.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Auxiliary
 
 
   def run_host(ip)
-    return unless check
+    return unless is_vmware?
     each_user_pass { |user, pass|
       result = vim_do_login(user, pass)
       case result
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Auxiliary
 
 
   # Mostly taken from the Apache Tomcat service validator
-  def check
+  def is_vmware?
     soap_data =
       %Q|<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       <env:Body>

--- a/modules/auxiliary/spoof/dns/bailiwicked_domain.rb
+++ b/modules/auxiliary/spoof/dns/bailiwicked_domain.rb
@@ -75,14 +75,9 @@ class Metasploit3 < Msf::Auxiliary
     calculate_race(targ, dom)
   end
 
-  def cmd_check(*args)
-    targ = args[0] || rhost()
-    if !(targ and targ.length > 0)
-      print_status("usage: check [dns-server]")
-      return
-    end
+  def check
+    targ = rhost
 
-    print_status("Using the Metasploit service to verify exploitability...")
     srv_sock = Rex::Socket.create_udp(
       'PeerHost' => targ,
       'PeerPort' => 53
@@ -111,7 +106,7 @@ class Metasploit3 < Msf::Auxiliary
           if (name.to_s == txt and data.strings.join('') =~ /^([^\s]+)\s+.*red\.metasploit\.com/m)
             t_addr, t_port = $1.split(':')
 
-            print_status(" >> ADDRESS: #{t_addr}  PORT: #{t_port}")
+            vprint_status(" >> ADDRESS: #{t_addr}  PORT: #{t_port}")
             t_port = t_port.to_i
             if(lport and lport != t_port)
               random = true
@@ -132,24 +127,29 @@ class Metasploit3 < Msf::Auxiliary
     srv_sock.close
 
     if(ports.keys.length == 0)
-      print_error("ERROR: This server is not replying to recursive requests")
-      return
+      vprint_error("ERROR: This server is not replying to recursive requests")
+      return Exploit::CheckCode::Unknown
     end
 
     if(reps < 30)
-      print_warning("WARNING: This server did not reply to all of our requests")
+      vprint_warning("WARNING: This server did not reply to all of our requests")
     end
 
     if(random)
       ports_u = ports.keys.length
       ports_r = ((ports.keys.length/30.0)*100).to_i
-      print_status("PASS: This server does not use a static source port. Randomness: #{ports_u}/30 %#{ports_r}")
+      vprint_status("PASS: This server does not use a static source port. Randomness: #{ports_u}/30 %#{ports_r}")
       if(ports_r != 100)
-        print_status("INFO: This server's source ports are not really random and may still be exploitable, but not by this tool.")
+        vprint_status("INFO: This server's source ports are not really random and may still be exploitable, but not by this tool.")
+        # Not exploitable by this tool, so we lower this to Appears on purpose to lower the user's confidence
+        return Exploit::CheckCode::Appears 
       end
     else
-      print_error("FAIL: This server uses a static source port and is vulnerable to poisoning")
+      vprint_error("FAIL: This server uses a static source port and is vulnerable to poisoning")
+      return Exploit::CheckCode::Vulnerable
     end
+
+    Exploit::CheckCode::Safe
   end
 
   def run

--- a/modules/auxiliary/spoof/dns/bailiwicked_host.rb
+++ b/modules/auxiliary/spoof/dns/bailiwicked_host.rb
@@ -73,14 +73,9 @@ class Metasploit3 < Msf::Auxiliary
     calculate_race(targ, dom)
   end
 
-  def cmd_check(*args)
-    targ = args[0] || rhost()
-    if !(targ and targ.length > 0)
-      print_status("usage: check [dns-server]")
-      return
-    end
+  def check
+    targ = rhost
 
-    print_status("Using the Metasploit service to verify exploitability...")
     srv_sock = Rex::Socket.create_udp(
       'PeerHost' => targ,
       'PeerPort' => 53
@@ -109,7 +104,7 @@ class Metasploit3 < Msf::Auxiliary
           if (name.to_s == txt and data.strings.join('') =~ /^([^\s]+)\s+.*red\.metasploit\.com/m)
             t_addr, t_port = $1.split(':')
 
-            print_status(" >> ADDRESS: #{t_addr}  PORT: #{t_port}")
+            vprint_status(" >> ADDRESS: #{t_addr}  PORT: #{t_port}")
             t_port = t_port.to_i
             if(lport and lport != t_port)
               random = true
@@ -130,12 +125,12 @@ class Metasploit3 < Msf::Auxiliary
     srv_sock.close
 
     if(ports.keys.length == 0)
-      print_error("ERROR: This server is not replying to recursive requests")
-      return
+      vprint_error("ERROR: This server is not replying to recursive requests")
+      return Exploit::CheckCode::Unknown
     end
 
     if(reps < 30)
-      print_warning("WARNING: This server did not reply to all of our requests")
+      vprint_warning("WARNING: This server did not reply to all of our requests")
     end
 
     if(random)
@@ -143,11 +138,16 @@ class Metasploit3 < Msf::Auxiliary
       ports_r = ((ports.keys.length/30.0)*100).to_i
       print_status("PASS: This server does not use a static source port. Randomness: #{ports_u}/30 %#{ports_r}")
       if(ports_r != 100)
-        print_status("INFO: This server's source ports are not really random and may still be exploitable, but not by this tool.")
+        vprint_status("INFO: This server's source ports are not really random and may still be exploitable, but not by this tool.")
+        # Not exploitable by this tool, so we lower this to Appears on purpose to lower the user's confidence
+        return Exploit::CheckCode::Appears 
       end
     else
-      print_error("FAIL: This server uses a static source port and is vulnerable to poisoning")
+      vprint_error("FAIL: This server uses a static source port and is vulnerable to poisoning")
+      return Exploit::CheckCode::Vulnerable
     end
+
+    Exploit::CheckCode::Safe
   end
 
   def run


### PR DESCRIPTION
These check methods are updated mainly because either they wren't real checks (as in a check method not returning a checkcode because we didn't support it in the past), or incorrectly flagged based on the new guidelines in #2894.

Please note: PR #2894 should be landed first before this one.
## Verification steps for vmware_http_login:

The vmware_http_login module can be verified this way:
- [x] Run a fake web server: `ruby -run -e httpd . -p 8181`
- [x] Without the patch, run msfconsole and do: `auxiliary/scanner/vmware/vmware_http_login`
- [x] `set rhosts [IP]`
- [x] `set ssl false`
- [x] `check`
- [x] Confirm you see: "Check failed: The state could not be determined", because there is no CheckCode thrown.

Now, with the patch:
- [x] Repeat the steps above, but this time you should see: "This exploit does not support check"
## Verification steps for vbulletin_vote_sqli
- [x] If you have the vulnerable setup, try run against it. If not, please rely on your mad code review skills. That's just what happens if you don't have a vuln box to test, and no test cases to try.
## Verification steps for other modules:
- [x] Pease just rely on your mad code review skills.
