### PR TITLE
Pre-release fixup

### DIFF
--- a/modules/auxiliary/scanner/printer/printer_download_file.rb
+++ b/modules/auxiliary/scanner/printer/printer_download_file.rb
@@ -16,7 +16,8 @@ class Metasploit4 < Msf::Auxiliary
     super(update_info(info,
       "Name" => "Printer File Download Scanner",
       "Description" => %q{
-        This module downloads a file from a printer using PJL.
+        This module downloads a file from a set of printers using the
+        Printer Job Lanaguage (PJL) protocol.
       },
       "Author" => [
         "wvu", # This implementation
@@ -50,8 +51,7 @@ class Metasploit4 < Msf::Auxiliary
     disconnect
 
     if file
-      print_good("#{ip}:#{rport} - #{pathname}")
-      store_loot(
+      res = store_loot(
         "printer.file",
         "application/octet-stream",
         ip,
@@ -59,6 +59,7 @@ class Metasploit4 < Msf::Auxiliary
         pathname,
         "Printer file"
       )
+      print_good("#{ip}:#{rport} - Saved #{pathname} as #{res}")
     end
   end
 

--- a/modules/auxiliary/scanner/printer/printer_env_vars.rb
+++ b/modules/auxiliary/scanner/printer/printer_env_vars.rb
@@ -16,7 +16,8 @@ class Metasploit4 < Msf::Auxiliary
     super(update_info(info,
       "Name" => "Printer Environment Variables Scanner",
       "Description" => %q{
-        This module scans for printer environment variables using PJL.
+        This module scans for printer environment variables using the
+        Printer Job Language (PJL) protocol.
       },
       "Author" => [
         "wvu", # This implementation
@@ -46,7 +47,7 @@ class Metasploit4 < Msf::Auxiliary
     disconnect
 
     if env_vars
-      print_good("#{ip}:#{rport}\n#{env_vars}")
+      print_good("#{ip}:#{rport} - #{env_vars}")
       report_note({
         :host => ip,
         :port => rport,

--- a/modules/auxiliary/scanner/printer/printer_list_dir.rb
+++ b/modules/auxiliary/scanner/printer/printer_list_dir.rb
@@ -16,7 +16,8 @@ class Metasploit4 < Msf::Auxiliary
     super(update_info(info,
       "Name" => "Printer Directory Listing Scanner",
       "Description" => %q{
-        This module lists a directory on a printer using PJL.
+        This module lists a directory on a set of printers using the
+        Printer Job Language (PJL) protocol.
       },
       "Author" => [
         "wvu", # This implementation
@@ -50,7 +51,7 @@ class Metasploit4 < Msf::Auxiliary
     disconnect
 
     if listing
-      print_good("#{ip}:#{rport}\n#{listing}")
+      print_good("#{ip}:#{rport} - #{listing}")
       report_note({
         :host => ip,
         :port => rport,

--- a/modules/auxiliary/scanner/printer/printer_list_volumes.rb
+++ b/modules/auxiliary/scanner/printer/printer_list_volumes.rb
@@ -16,7 +16,8 @@ class Metasploit4 < Msf::Auxiliary
     super(update_info(info,
       "Name" => "Printer Volume Listing Scanner",
       "Description" => %q{
-        This module lists the volumes on a printer using PJL.
+        This module lists the volumes on a set of printers using the
+        Printer Job Language (PJL) protocol.
       },
       "Author" => [
         "wvu", # This implementation
@@ -47,7 +48,7 @@ class Metasploit4 < Msf::Auxiliary
     disconnect
 
     if listing
-      print_good("#{ip}:#{rport}\n#{listing}")
+      print_good("#{ip}:#{rport} - #{listing}")
       report_note({
         :host => ip,
         :port => rport,

--- a/modules/auxiliary/scanner/printer/printer_ready_message.rb
+++ b/modules/auxiliary/scanner/printer/printer_ready_message.rb
@@ -16,7 +16,8 @@ class Metasploit4 < Msf::Auxiliary
     super(update_info(info,
       "Name" => "Printer Ready Message Scanner",
       "Description" => %q{
-        This module scans for and can change printer ready messages using PJL.
+        This module scans for and optionally changes the printer ready message on
+        a set of printers using the Printer Job Language (PJL) protocol.
       },
       "Author" => [
         "wvu", # This implementation

--- a/modules/auxiliary/scanner/printer/printer_version_info.rb
+++ b/modules/auxiliary/scanner/printer/printer_version_info.rb
@@ -16,7 +16,8 @@ class Metasploit4 < Msf::Auxiliary
     super(update_info(info,
       "Name" => "Printer Version Information Scanner",
       "Description" => %q{
-        This module scans for printer version information using PJL.
+        This module scans for printer version information using the
+        Printer Job Language (PJL) protocol.
       },
       "Author" => [
         "wvu", # This implementation

--- a/modules/exploits/windows/misc/hp_dataprotector_traversal.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_traversal.rb
@@ -20,9 +20,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'Name'           => 'HP Data Protector Backup Client Service Directory Traversal',
       'Description'    => %q{
         This module exploits a directory traversal vulnerability in the Hewlett-Packard Data
-        Protector product. The vulnerability exists at the Backup Client Service (OmniInet.exe)
-        when parsing packets with opcode 42. This module has been tested successfully on HP Data
-        Protector 6.20 on Windows 2003 SP2 and Windows XP SP3.
+        Protector product. The vulnerability exists in the Backup Client Service (OmniInet.exe)
+        and is triggered when parsing packets with opcode 42. This module has been tested
+        successfully on HP Data Protector 6.20 on Windows 2003 SP2 and Windows XP SP3.
       },
       'Author'         =>
         [


### PR DESCRIPTION
- Updated descriptions to be a little more descriptive.
- Updated store_loot calls to inform the user where the
  loot is stored.
- Removed newlines in print_\* statments -- these will screw
  up Scanner output when dealing with multiple hosts.

Of the fixed newlines, I haven't see any output, so I'm not sure what
the actual message is going to look like -- I expect it's a whole bunch
of newlines in there so it'll be kinda ugly as is (not a blocker for
this but should clean up eventually)
