### PR TITLE
Update Exploit Checks and a msftidy to go with it

### DIFF
--- a/modules/exploits/freebsd/ftp/proftp_telnet_iac.rb
+++ b/modules/exploits/freebsd/ftp/proftp_telnet_iac.rb
@@ -106,15 +106,15 @@ class Metasploit3 < Msf::Exploit::Remote
         if rel.length > 0
           if rel[0,2] == 'rc'
             if rel[2,rel.length].to_i >= 3
-              status = CheckCode::Vulnerable
+              status = CheckCode::Appears
             end
           else
-            status = CheckCode::Vulnerable
+            status = CheckCode::Appears
           end
         end
       when '3'
         # 1.3.3+ defaults to vulnerable (until >= 1.3.3c)
-        status = CheckCode::Vulnerable
+        status = CheckCode::Appears
         if rel.length > 0
           if rel[0,2] != 'rc' and rel[0,1] > 'b'
             status = CheckCode::Safe

--- a/modules/exploits/irix/lpd/tagprinter_exec.rb
+++ b/modules/exploits/irix/lpd/tagprinter_exec.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if (resp =~ /IRIX/)
-      print_status("Response: #{resp.strip}")
+      vprint_status("Response: #{resp.strip}")
       return Exploit::CheckCode::Vulnerable
     end
     return Exploit::CheckCode::Safe

--- a/modules/exploits/linux/ftp/proftp_sreplace.rb
+++ b/modules/exploits/linux/ftp/proftp_sreplace.rb
@@ -119,7 +119,7 @@ class Metasploit3 < Msf::Exploit::Remote
     ret = connect
 
     # We just want the banner to check against our targets..
-    print_status("FTP Banner: #{banner.strip}")
+    vprint_status("FTP Banner: #{banner.strip}")
 
     status = CheckCode::Safe
 

--- a/modules/exploits/linux/ftp/proftp_sreplace.rb
+++ b/modules/exploits/linux/ftp/proftp_sreplace.rb
@@ -129,16 +129,16 @@ class Metasploit3 < Msf::Exploit::Remote
       relv = rel.slice!(0,1)
       case relv
       when '2'
-        status = CheckCode::Vulnerable
+        status = CheckCode::Appears
 
       when '3'
         # 1.3.x before 1.3.1 is vulnerable
-        status = CheckCode::Vulnerable
+        status = CheckCode::Appears
         if rel.length > 0
           if rel.to_i > 0
             status = CheckCode::Safe
           else
-            status = CheckCode::Vulnerable
+            status = CheckCode::Appears
           end
         end
       end

--- a/modules/exploits/linux/ftp/proftp_telnet_iac.rb
+++ b/modules/exploits/linux/ftp/proftp_telnet_iac.rb
@@ -274,7 +274,7 @@ class Metasploit3 < Msf::Exploit::Remote
     banner = sock.get_once || ''
 
     # We just want the banner to check against our targets..
-    print_status("FTP Banner: #{banner.strip}")
+    vprint_status("FTP Banner: #{banner.strip}")
 
     status = CheckCode::Safe
     if banner =~ /ProFTPD (1\.3\.[23][^ ])/i

--- a/modules/exploits/linux/ftp/proftp_telnet_iac.rb
+++ b/modules/exploits/linux/ftp/proftp_telnet_iac.rb
@@ -286,15 +286,15 @@ class Metasploit3 < Msf::Exploit::Remote
         if rel.length > 0
           if rel[0,2] == 'rc'
             if rel[2,rel.length].to_i >= 3
-              status = CheckCode::Vulnerable
+              status = CheckCode::Appears
             end
           else
-            status = CheckCode::Vulnerable
+            status = CheckCode::Appears
           end
         end
       when '3'
         # 1.3.3+ defaults to vulnerable (until >= 1.3.3c)
-        status = CheckCode::Vulnerable
+        status = CheckCode::Appears
         if rel.length > 0
           if rel[0,2] != 'rc' and rel[0,1] > 'b'
             status = CheckCode::Safe

--- a/modules/exploits/linux/games/ut2004_secure.rb
+++ b/modules/exploits/linux/games/ut2004_secure.rb
@@ -92,23 +92,23 @@ class Metasploit3 < Msf::Exploit::Remote
     vers = ut_version
 
     if (not vers)
-      print_status("Could not detect Unreal Tournament Server")
-      return
+      vprint_status("Could not detect Unreal Tournament Server")
+      return Exploit::CheckCode::Unknown
     end
 
     print_status("Detected Unreal Tournament Server Version: #{vers}")
     if (vers =~ /^(3120|3186|3204)$/)
-      print_status("This system appears to be exploitable")
+      vprint_status("This system appears to be exploitable")
       return Exploit::CheckCode::Appears
     end
 
 
     if (vers =~ /^(2...)$/)
-      print_status("This system appears to be running UT2003")
+      vprint_status("This system appears to be running UT2003")
       return Exploit::CheckCode::Detected
     end
 
-    print_status("This system appears to be patched")
+    vprint_status("This system appears to be patched")
     return Exploit::CheckCode::Safe
   end
 

--- a/modules/exploits/linux/http/astium_sqli_upload.rb
+++ b/modules/exploits/linux/http/astium_sqli_upload.rb
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def check
     # Check version
-    print_status("#{peer} - Trying to detect Astium")
+    vprint_status("#{peer} - Trying to detect Astium")
 
     res = send_request_cgi({
       'method' => 'GET',

--- a/modules/exploits/linux/http/dlink_dir605l_captcha_bof.rb
+++ b/modules/exploits/linux/http/dlink_dir605l_captcha_bof.rb
@@ -81,7 +81,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     res = send_request_cgi({ 'uri' => '/comm.asp' })
     if res and res.code == 200 and res.body =~ /var modelname="DIR-605L"/ and res.headers["Server"] and res.headers["Server"] =~ /Boa\/0\.94\.14rc21/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/linux/http/hp_system_management.rb
+++ b/modules/exploits/linux/http/hp_system_management.rb
@@ -71,7 +71,10 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri' => "/cpqlogin.htm"
     })
 
-    if res and res.code == 200 and res.body =~ /"HP System Management Homepage v(.*)"/
+    if res.nil?
+      vprint_error("Connection timed out")
+      return Exploit::CheckCode::Unknown
+    elsif res.code == 200 and res.body =~ /"HP System Management Homepage v(.*)"/
       version = $1
       return Exploit::CheckCode::Appears if version <= "7.1.1.1"
     end

--- a/modules/exploits/linux/http/hp_system_management.rb
+++ b/modules/exploits/linux/http/hp_system_management.rb
@@ -73,7 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res and res.code == 200 and res.body =~ /"HP System Management Homepage v(.*)"/
       version = $1
-      return Exploit::CheckCode::Vulnerable if version <= "7.1.1.1"
+      return Exploit::CheckCode::Appears if version <= "7.1.1.1"
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     if res and res.code == 200 and res.body =~ /<ModelName>WRT110<\/ModelName>/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
@@ -57,7 +57,8 @@ class Metasploit3 < Msf::Exploit::Remote
         'uri' => '/HNAP1/'
       })
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Safe
+      vprint_error("A connection error has occured")
+      return Exploit::CheckCode::Unknown
     end
 
     if res and res.code == 200 and res.body =~ /<ModelName>WRT110<\/ModelName>/

--- a/modules/exploits/linux/http/mutiny_frontend_upload.rb
+++ b/modules/exploits/linux/http/mutiny_frontend_upload.rb
@@ -128,7 +128,10 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri.path, "interface",  "/"),
     })
 
-    if res and res.body =~ /var currentMutinyVersion = "Version ([0-9\.-]*)/
+    if res.nil?
+      vprint_error("Connection timed out")
+      return Exploit::CheckCode::Unknown
+    if res.body =~ /var currentMutinyVersion = "Version ([0-9\.-]*)/
       version = $1
     end
 

--- a/modules/exploits/linux/http/mutiny_frontend_upload.rb
+++ b/modules/exploits/linux/http/mutiny_frontend_upload.rb
@@ -133,7 +133,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     if version and version >= "5" and version <= "5.0-1.07"
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/linux/http/nginx_chunked_size.rb
+++ b/modules/exploits/linux/http/nginx_chunked_size.rb
@@ -88,10 +88,11 @@ class Metasploit4 < Msf::Exploit::Remote
       end
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{peer} - Connection failed")
+      vprint_error("#{peer} - Connection failed")
+      return Exploit::CheckCode::Unknown
     end
 
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Safe
   end
 
   #

--- a/modules/exploits/linux/http/openfiler_networkcard_exec.rb
+++ b/modules/exploits/linux/http/openfiler_networkcard_exec.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def check
     # retrieve software version from login page
-    print_status("#{peer} - Sending check")
+    vprint_status("#{peer} - Sending check")
     begin
       res = send_request_cgi({
         'uri' => '/'
@@ -83,10 +83,10 @@ class Metasploit3 < Msf::Exploit::Remote
       end
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{peer} - Connection failed")
+      vprint_error("#{peer} - Connection failed")
+      return Exploit::CheckCode::Unknown
     end
-    return Exploit::CheckCode::Unknown
-
+    return Exploit::CheckCode::Safe
   end
 
   def on_new_session(client)

--- a/modules/exploits/linux/http/pineapp_livelog_exec.rb
+++ b/modules/exploits/linux/http/pineapp_livelog_exec.rb
@@ -78,7 +78,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'nsserver' => Rex::Text.encode_base64("127.0.0.1")
       }
     })
-    if res and res.code == 200 and res.body =~ /NS Query result for 127.0.0.1/
+    if res and res.code == 200 and res.body =~ /NS Query result for 127\.0\.0\.1/
       return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe

--- a/modules/exploits/linux/http/smt_ipmi_close_window_bof.rb
+++ b/modules/exploits/linux/http/smt_ipmi_close_window_bof.rb
@@ -89,7 +89,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Safe
     end
 
-    return Exploit::CheckCode::Vulnerable
+    return Exploit::CheckCode::Appears
   end
 
   def target_smt_x9_214

--- a/modules/exploits/linux/http/synology_dsm_sliceupload_exec_noauth.rb
+++ b/modules/exploits/linux/http/synology_dsm_sliceupload_exec_noauth.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    print_status("#{peer} - Trying to detect installed version")
+    vprint_status("#{peer} - Trying to detect installed version")
 
     res = send_request_cgi({
       'method'   => 'GET',
@@ -80,21 +80,21 @@ class Metasploit3 < Msf::Exploit::Remote
       model = $~[:model].sub(/^[a-z]+/) { |s| s[0].upcase }
       model = "DS#{model}" unless model =~ /^[A-Z]/
     else
-      print_status("#{peer} - Detection failed")
+      vprint_status("#{peer} - Detection failed")
       return Exploit::CheckCode::Unknown
     end
 
-    print_status("#{peer} - Model #{model} with version #{version}-#{build} detected")
+    vprint_status("#{peer} - Model #{model} with version #{version}-#{build} detected")
 
     case version
     when '4.0'
-      return Exploit::CheckCode::Vulnerable if build < '2259'
+      return Exploit::CheckCode::Appears if build < '2259'
     when '4.1'
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     when '4.2'
-      return Exploit::CheckCode::Vulnerable if build < '3243'
+      return Exploit::CheckCode::Appears if build < '3243'
     when '4.3'
-      return Exploit::CheckCode::Vulnerable if build < '3810'
+      return Exploit::CheckCode::Appears if build < '3810'
       return Exploit::CheckCode::Detected if build == '3810'
     end
 

--- a/modules/exploits/linux/http/wanem_exec.rb
+++ b/modules/exploits/linux/http/wanem_exec.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
     data  = "pc=127.0.0.1; "
     data << Rex::Text.uri_encode("echo #{fingerprint}")
     data << "%26"
-    print_status("#{peer} - Sending check")
+    vprint_status("#{peer} - Sending check")
 
     begin
       res = send_request_cgi({
@@ -78,7 +78,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'data'   => data
       }, 25)
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{peer} - Connection failed")
+      vprint_error("#{peer} - Connection failed")
       return Exploit::CheckCode::Unknown
     end
 

--- a/modules/exploits/linux/http/webcalendar_settings_exec.rb
+++ b/modules/exploits/linux/http/webcalendar_settings_exec.rb
@@ -60,8 +60,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri'    => "#{uri}/login.php"
     })
 
-    if res and res.body =~ /WebCalendar v1.2.\d/
-      return Exploit::CheckCode::Vulnerable
+    if res and res.body =~ /WebCalendar v1\.2\.\d/
+      return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/linux/http/zabbix_sqli.rb
+++ b/modules/exploits/linux/http/zabbix_sqli.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def check
     # Check version
-    print_status("#{peer} - Trying to detect installed version")
+    vprint_status("#{peer} - Trying to detect installed version")
 
     res = send_request_cgi({
       'method' => 'GET',
@@ -72,10 +72,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res and res.code == 200 and res.body =~ /(STATUS OF WEB MONITORING)/ and res.body =~ /(?<=Zabbix )(.*)(?= Copyright)/
       version = $1
-      print_status("#{peer} - Zabbix version #{version} detected")
+      vprint_status("#{peer} - Zabbix version #{version} detected")
     else
       # If this fails, guest access may not be enabled
-      print_status("#{peer} - Unable to access httpmon.php")
+      vprint_status("#{peer} - Unable to access httpmon.php")
       return Exploit::CheckCode::Unknown
     end
 

--- a/modules/exploits/linux/http/zen_load_balancer_exec.rb
+++ b/modules/exploits/linux/http/zen_load_balancer_exec.rb
@@ -66,23 +66,23 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def check
     # retrieve software version from config file
-    print_status("#{peer} - Sending check")
+    vprint_status("#{peer} - Sending check")
     begin
       res = send_request_cgi({
         'uri' => '/config/global.conf'
       })
 
-      if    res and res.code == 200 and res.body =~ /#version ZEN\s+\$version=\"(2|3\.0\-rc1)/
+      if res and res.code == 200 and res.body =~ /#version ZEN\s+\$version=\"(2|3\.0\-rc1)/
         return Exploit::CheckCode::Appears
       elsif res and res.code == 200 and res.body =~ /zenloadbalancer/
         return Exploit::CheckCode::Detected
       end
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{peer} - Connection failed")
+      vprint_error("#{peer} - Connection failed")
+      return Exploit::CheckCode::Unknown
     end
-    return Exploit::CheckCode::Unknown
-
+    return Exploit::CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
+++ b/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
@@ -69,14 +69,14 @@ class Metasploit3 < Msf::Exploit::Remote
         'method' => "GET",
         'uri'    => "/zport/acl_users/cookieAuthHelper/login_form"
       })
-      return Exploit::CheckCode::Vulnerable if res.body =~ /<p>Copyright &copy; 2005-20[\d]{2} Zenoss, Inc\. \| Version\s+<span>3\./
+      return Exploit::CheckCode::Appears if res.body =~ /<p>Copyright &copy; 2005-20[\d]{2} Zenoss, Inc\. \| Version\s+<span>3\./
       return Exploit::CheckCode::Detected   if res.body =~ /<link rel="shortcut icon" type="image\/x\-icon" href="\/zport\/dmd\/favicon\.ico" \/>/
       return Exploit::CheckCode::Safe
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeoutp
-      print_error("#{peer} - Connection failed")
+      vprint_error("#{peer} - Connection failed")
+      return Exploit::CheckCode::Unknown
     end
-    return Exploit::CheckCode::Unknown
-
+    return Exploit::CheckCode::Save
   end
 
   def exploit

--- a/modules/exploits/linux/imap/imap_uw_lsub.rb
+++ b/modules/exploits/linux/imap/imap_uw_lsub.rb
@@ -61,8 +61,8 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     disconnect
 
-    if (banner =~ /IMAP4rev1 v12.264/)
-      return Exploit::CheckCode::Vulnerable
+    if (banner =~ /IMAP4rev1 v12\.264/)
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
 

--- a/modules/exploits/linux/local/sophos_wpa_clear_keys.rb
+++ b/modules/exploits/linux/local/sophos_wpa_clear_keys.rb
@@ -62,7 +62,7 @@ class Metasploit4 < Msf::Exploit::Local
       return CheckCode::Detected
     end
 
-    return CheckCode::Unknown
+    return CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/linux/local/vmware_mount.rb
+++ b/modules/exploits/linux/local/vmware_mount.rb
@@ -57,7 +57,7 @@ class Metasploit4 < Msf::Exploit::Local
 
   def check
     if setuid?("/usr/bin/vmware-mount")
-      CheckCode::Vulnerable
+      CheckCode::Appears
     else
       CheckCode::Safe
     end

--- a/modules/exploits/linux/local/zpanel_zsudo.rb
+++ b/modules/exploits/linux/local/zpanel_zsudo.rb
@@ -51,7 +51,7 @@ class Metasploit4 < Msf::Exploit::Local
       return CheckCode::Detected
     end
 
-    return CheckCode::Unknown
+    return CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/linux/misc/hp_vsa_login_bof.rb
+++ b/modules/exploits/linux/misc/hp_vsa_login_bof.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     connect
     packet = generate_packet("login:/global$agent/L0CAlu53R/Version \"#{target['Version']}\"")
-    print_status("#{rhost}:#{rport} Sending login packet to check...")
+    vprint_status("#{rhost}:#{rport} Sending login packet to check...")
     sock.put(packet)
     res = sock.get_once
     disconnect

--- a/modules/exploits/linux/misc/hp_vsa_login_bof.rb
+++ b/modules/exploits/linux/misc/hp_vsa_login_bof.rb
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if res and res=~ /OK/ and res =~ /Login/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     elsif res and res =~ /FAILED/ and res =~ /version/
       return Exploit::CheckCode::Detected
     end

--- a/modules/exploits/linux/misc/nagios_nrpe_arguments.rb
+++ b/modules/exploits/linux/misc/nagios_nrpe_arguments.rb
@@ -124,7 +124,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    print_status("Checking if remote NRPE supports command line arguments")
+    vprint_status("Checking if remote NRPE supports command line arguments")
 
     begin
       # send query asking to run "fake_check" command with command substitution in arguments
@@ -141,7 +141,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Safe
     rescue Errno::ECONNRESET => reset
       unless datastore['NRPESSL'] or @force_ssl
-        print_status("Retrying with ADH SSL")
+        vprint_status("Retrying with ADH SSL")
         @force_ssl = true
         retry
       end

--- a/modules/exploits/linux/misc/sercomm_exec.rb
+++ b/modules/exploits/linux/misc/sercomm_exec.rb
@@ -141,14 +141,14 @@ class Metasploit3 < Msf::Exploit::Remote
 
     case fprint
     when 'BE'
-      print_status("Detected Big Endian")
+      vprint_status("Detected Big Endian")
       return Msf::Exploit::CheckCode::Vulnerable
     when 'LE'
-      print_status("Detected Little Endian")
+      vprint_status("Detected Little Endian")
       return Msf::Exploit::CheckCode::Vulnerable
     end
 
-    return Msf::Exploit::CheckCode::Unknown
+    return Msf::Exploit::CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/linux/misc/sercomm_exec.rb
+++ b/modules/exploits/linux/misc/sercomm_exec.rb
@@ -142,10 +142,10 @@ class Metasploit3 < Msf::Exploit::Remote
     case fprint
     when 'BE'
       vprint_status("Detected Big Endian")
-      return Msf::Exploit::CheckCode::Vulnerable
+      return Msf::Exploit::CheckCode::Appears
     when 'LE'
       vprint_status("Detected Little Endian")
-      return Msf::Exploit::CheckCode::Vulnerable
+      return Msf::Exploit::CheckCode::Appears
     end
 
     return Msf::Exploit::CheckCode::Safe

--- a/modules/exploits/linux/misc/zabbix_server_exec.rb
+++ b/modules/exploits/linux/misc/zabbix_server_exec.rb
@@ -82,17 +82,17 @@ class Metasploit3 < Msf::Exploit::Remote
     cmd = "echo #{clue}"
 
     connect
-    print_status("#{peer} - Sending 'Command' request...")
+    vprint_status("#{peer} - Sending 'Command' request...")
     res = send_command(sock, node_id, cmd)
     disconnect
 
     if res
-      print_status(res)
+      vprint_status(res)
       if res =~ /#{clue}/
         return Exploit::CheckCode::Vulnerable
       elsif res =~ /-1/ and res=~ /NODE (\d*)/
         node_id = $1
-        print_good("#{peer} - Node ID #{node_id} discovered")
+        vprint_good("#{peer} - Node ID #{node_id} discovered")
       else
         return Exploit::CheckCode::Safe
       end
@@ -102,7 +102,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # Retry with the good node_id
     connect
-    print_status("#{peer} - Sending 'Command' request with discovered Node ID...")
+    vprint_status("#{peer} - Sending 'Command' request with discovered Node ID...")
     res = send_command(sock, node_id, cmd)
     disconnect
     if res and res =~ /#{clue}/

--- a/modules/exploits/linux/postgres/postgres_payload.rb
+++ b/modules/exploits/linux/postgres/postgres_payload.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
     version = postgres_fingerprint
 
     if version[:auth]
-      return CheckCode::Vulnerable
+      return CheckCode::Appears
     else
       print_error "Authentication failed. #{version[:preauth] || version[:unknown]}"
       return CheckCode::Safe

--- a/modules/exploits/linux/samba/setinfopolicy_heap.rb
+++ b/modules/exploits/linux/samba/setinfopolicy_heap.rb
@@ -282,7 +282,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       version = smb_peer_lm().scan(/Samba (\d\.\d.\d*)/).flatten[0]
       minor   = version.scan(/\.(\d*)$/).flatten[0].to_i
-      print_status("Version found: #{version}")
+      vprint_status("Version found: #{version}")
 
       return Exploit::CheckCode::Appears if version =~ /^3\.4/ and minor < 16
       return Exploit::CheckCode::Appears if version =~ /^3\.5/ and minor < 14

--- a/modules/exploits/multi/ftp/wuftpd_site_exec_format.rb
+++ b/modules/exploits/multi/ftp/wuftpd_site_exec_format.rb
@@ -111,7 +111,7 @@ class Metasploit3 < Msf::Exploit::Remote
     ret = connect_login
 
     # We just want the banner to check against our targets..
-    print_status("FTP Banner: #{banner.strip}")
+    vprint_status("FTP Banner: #{banner.strip}")
     status = Exploit::CheckCode::Safe
     if banner =~ /Version wu-2\.(4|5)/
       status = Exploit::CheckCode::Appears

--- a/modules/exploits/multi/http/activecollab_chat.rb
+++ b/modules/exploits/multi/http/activecollab_chat.rb
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Exploit::Remote
     if (cms and cms.body =~ /powered by activeCollab/)
       # detect the chat module
       if (chat and chat.code == 200)
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Detected
       end
     end
     return Exploit::CheckCode::Safe

--- a/modules/exploits/multi/http/apprain_upload_exec.rb
+++ b/modules/exploits/multi/http/apprain_upload_exec.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body.empty?
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/multi/http/auxilium_upload_exec.rb
+++ b/modules/exploits/multi/http/auxilium_upload_exec.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri' => normalize_uri("#{base}/admin/sitebanners/upload_banners.php")
     })
     if res and res.body =~ /\<title\>Pet Rate Admin \- Banner Manager\<\/title\>/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Detected
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/multi/http/cisco_dcnm_upload.rb
+++ b/modules/exploits/multi/http/cisco_dcnm_upload.rb
@@ -88,6 +88,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     unless res
+      vprint_error("Connection timed out")
       return Exploit::CheckCode::Unknown
     end
 
@@ -95,19 +96,18 @@ class Metasploit3 < Msf::Exploit::Remote
         res.body.to_s =~ /Data Center Network Manager/ and
         res.body.to_s =~ /<div class="productVersion">Version: (.*)<\/div>/
       version = $1
-      print_status("Cisco Primer Data Center Network Manager version #{version} found")
-    elsif res.code == 200 and
-        res.body.to_s =~ /Data Center Network Manager/
+      vprint_status("Cisco Primer Data Center Network Manager version #{version} found")
+      if version =~ /6\.1/
+        return Exploit::CheckCode::Appears
+      else
+        return Exploit::CheckCode::Detected
+      end
+
+    elsif res.code == 200 and res.body.to_s =~ /Data Center Network Manager/
       return Exploit::CheckCode::Detected
-    else
-      return Exploit::CheckCode::Safe
     end
 
-    if version =~ /6\.1/
-      return Exploit::CheckCode::Vulnerable
-    end
-
-    return Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/multi/http/coldfusion_rds.rb
+++ b/modules/exploits/multi/http/coldfusion_rds.rb
@@ -82,7 +82,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body.to_s =~ /ColdFusion Administrator Login/
-       print_good "#{peer} - Administrator access available"
+       vprint_good "#{peer} - Administrator access available"
     else
       return Exploit::CheckCode::Safe
     end
@@ -97,7 +97,7 @@ class Metasploit3 < Msf::Exploit::Remote
     imghash = "596b3fc4f1a0b818979db1cf94a82220"
 
     if img == imghash
-      print_good "#{peer} - ColdFusion 9 Detected"
+      vprint_good "#{peer} - ColdFusion 9 Detected"
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/multi/http/cuteflow_upload_exec.rb
+++ b/modules/exploits/multi/http/cuteflow_upload_exec.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res.body =~ /\<strong style\=\"font\-size\:8pt\;font\-weight\:normal\"\>Version 2\.11\.2\<\/strong\>\<br\>/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     elsif res.body =~ /\<a href\=\"http\:\/\/cuteflow\.org" target\=\"\_blank\"\>/
       return Exploit::CheckCode::Detected
     else

--- a/modules/exploits/multi/http/eaton_nsm_code_exec.rb
+++ b/modules/exploits/multi/http/eaton_nsm_code_exec.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = execute_php_code("phpinfo();die();")
 
     if not res or res.code != 200
-      print_error("Failed: Error requesting page")
+      vprint_error("Failed: Error requesting page")
       return CheckCode::Unknown
     end
 

--- a/modules/exploits/multi/http/extplorer_upload_exec.rb
+++ b/modules/exploits/multi/http/extplorer_upload_exec.rb
@@ -71,7 +71,7 @@ class Metasploit3 < Msf::Exploit::Remote
       end
 
       if res.body =~ /<version>2\.1\.(0RC\d|0|1|2)<\/version>/
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Appears
       end
 
       if res.body =~ /eXtplorer/
@@ -79,9 +79,10 @@ class Metasploit3 < Msf::Exploit::Remote
       end
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{peer} - Connection failed")
+      vprint_error("#{peer} - Connection failed")
+      return Exploit::CheckCode::Unknown
     end
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Safe
 
   end
 

--- a/modules/exploits/multi/http/glossword_upload_exec.rb
+++ b/modules/exploits/multi/http/glossword_upload_exec.rb
@@ -59,18 +59,18 @@ class Metasploit3 < Msf::Exploit::Remote
       res = login(base, user, pass)
       if res
         if res.code == 200
-          print_error("#{peer} - Authentication failed")
+          vprint_error("#{peer} - Authentication failed")
           return Exploit::CheckCode::Unknown
         elsif res.code == 301 and res.headers['set-cookie'] =~ /sid([\da-f]+)=([\da-f]{32})/
-          print_good("#{peer} - Authenticated successfully")
+          vprint_good("#{peer} - Authenticated successfully")
           return Exploit::CheckCode::Appears
         end
       end
-      return Exploit::CheckCode::Safe
+
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{peer} - Connection failed")
+      vprint_error("#{peer} - Connection failed")
     end
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Safe
 
   end
 

--- a/modules/exploits/multi/http/glpi_install_rce.rb
+++ b/modules/exploits/multi/http/glpi_install_rce.rb
@@ -69,10 +69,10 @@ class Metasploit3 < Msf::Exploit::Remote
     m = Regexp.new(re, Regexp::IGNORECASE)
     matched = m.match(res.body)
     if matched and matched[3] =~ /0.(8[0-4].[0-1])|([0-7][0-9].[0-9])/
-      print_good("Detected Version : #{matched[3]}")
+      vprint_good("Detected Version : #{matched[3]}")
       return Exploit::CheckCode::Appears
     elsif matched
-      print_error("Version #{matched[3]} is not vulnerable")
+      vprint_error("Version #{matched[3]} is not vulnerable")
     end
     return Exploit::CheckCode::Safe
 

--- a/modules/exploits/multi/http/hp_sys_mgmt_exec.rb
+++ b/modules/exploits/multi/http/hp_sys_mgmt_exec.rb
@@ -77,12 +77,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
     res = send_command(cmd)
     if not res
-      print_error("#{peer} - Connection timed out")
+      vprint_error("#{peer} - Connection timed out")
       return Exploit::CheckCode::Unknown
     end
 
     if res.code == 200 && res.body =~ /#{sig}/
-      print_good("#{peer} - Running with user '#{res.body.split(sig)[1].strip}'")
+      vprint_good("#{peer} - Running with user '#{res.body.split(sig)[1].strip}'")
       return Exploit::CheckCode::Vulnerable
     end
 

--- a/modules/exploits/multi/http/hyperic_hq_script_console.rb
+++ b/modules/exploits/multi/http/hyperic_hq_script_console.rb
@@ -105,20 +105,20 @@ class Metasploit3 < Msf::Exploit::Remote
     pass = datastore['PASSWORD']
 
     # login
-    print_status("#{peer} - Authenticating as '#{user}'")
+    vprint_status("#{peer} - Authenticating as '#{user}'")
     res  = login(user, pass)
     if res and res.code == 302 and res.headers['location'] !~ /authfailed/
-      print_good("#{peer} - Authenticated successfully as '#{user}'")
+      vprint_good("#{peer} - Authenticated successfully as '#{user}'")
       # check access to the console
-      print_status("#{peer} - Checking access to the script console")
+      vprint_status("#{peer} - Checking access to the script console")
       get_nonce
       if @nonce.nil?
         return Exploit::CheckCode::Detected
       else
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Appears
       end
     elsif res.headers.include?('X-Jenkins') or res.headers['location'] =~ /authfailed/
-      print_error("#{peer} - Authentication failed")
+      vprint_error("#{peer} - Authentication failed")
       return Exploit::CheckCode::Detected
     else
       return Exploit::CheckCode::Safe

--- a/modules/exploits/multi/http/ispconfig_php_exec.rb
+++ b/modules/exploits/multi/http/ispconfig_php_exec.rb
@@ -52,9 +52,6 @@ class Metasploit4 < Msf::Exploit::Remote
       ], self.class)
   end
 
-  def check
-  end
-
   def lng
     datastore['LANGUAGE']
   end

--- a/modules/exploits/multi/http/jboss_invoke_deploy.rb
+++ b/modules/exploits/multi/http/jboss_invoke_deploy.rb
@@ -90,20 +90,20 @@ class Metasploit4 < Msf::Exploit::Remote
   def check
     res = send_serialized_request('version.bin')
     if res.nil?
-      print_error("Connection timed out")
+      vprint_error("Connection timed out")
       return Exploit::CheckCode::Unknown
     elsif res.code != 200
-      print_error("Unable to request version, returned http code is: #{res.code.to_s}")
+      vprint_error("Unable to request version, returned http code is: #{res.code.to_s}")
       return Exploit::CheckCode::Unknown
     end
 
     # Check if the version is supported by this exploit
-    return Exploit::CheckCode::Vulnerable if res.body =~ /CVSTag=Branch_4_/
-    return Exploit::CheckCode::Vulnerable if res.body =~ /SVNTag=JBoss_4_/
-    return Exploit::CheckCode::Vulnerable if res.body =~ /SVNTag=JBoss_5_/
+    return Exploit::CheckCode::Appears if res.body =~ /CVSTag=Branch_4_/
+    return Exploit::CheckCode::Appears if res.body =~ /SVNTag=JBoss_4_/
+    return Exploit::CheckCode::Appears if res.body =~ /SVNTag=JBoss_5_/
 
     if res.body =~ /ServletException/	# Simple check, if we caused an exception.
-      print_status("Target seems vulnerable, but the used JBoss version is not supported by this exploit")
+      vprint_status("Target seems vulnerable, but the used JBoss version is not supported by this exploit")
       return Exploit::CheckCode::Appears
     end
 

--- a/modules/exploits/multi/http/kordil_edms_upload_exec.rb
+++ b/modules/exploits/multi/http/kordil_edms_upload_exec.rb
@@ -57,17 +57,18 @@ class Metasploit3 < Msf::Exploit::Remote
       })
       if res and res.code == 200
         if res.body =~ /<center><font face="Arial" size="2">Kordil EDMS v2\.2\.60/
-          return Exploit::CheckCode::Vulnerable
+          return Exploit::CheckCode::Appears
         elsif res.body =~ /Kordil EDMS v/
           return Exploit::CheckCode::Detected
         end
       end
-      return Exploit::CheckCode::Safe
-    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{peer} - Connection failed")
-    end
-    return Exploit::CheckCode::Unknown
 
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+      vprint_error("#{peer} - Connection failed")
+      return Exploit::CheckCode::Unknown
+    end
+
+    return Exploit::CheckCode::Safe
   end
 
   def upload(base, file)

--- a/modules/exploits/multi/http/lcms_php_exec.rb
+++ b/modules/exploits/multi/http/lcms_php_exec.rb
@@ -95,7 +95,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     target_url
     if @uri.empty? or @arg.empty?
-      print_error("Unable to get the page parameter, please reconfigure URI")
+      vprint_error("Unable to get the page parameter, please reconfigure URI")
       return
     end
 
@@ -110,10 +110,10 @@ class Metasploit3 < Msf::Exploit::Remote
     }, 20)
 
     if response and response.body =~ /#{signature}/
-      print_status("Signature: #{signature}")
+      vprint_status("Signature: #{signature}")
       return Exploit::CheckCode::Vulnerable
     else
-      print_error("Signature was not detected")
+      vprint_error("Signature was not detected")
       return Exploit::CheckCode::Safe
     end
   end

--- a/modules/exploits/multi/http/manageengine_search_sqli.rb
+++ b/modules/exploits/multi/http/manageengine_search_sqli.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = sqli_exec(Rex::Text.rand_text_alpha(1))
 
     if res and res.body =~ /Error during search/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Vulnerable
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/multi/http/movabletype_upgrade_exec.rb
+++ b/modules/exploits/multi/http/movabletype_upgrade_exec.rb
@@ -70,7 +70,7 @@ class Metasploit4 < Msf::Exploit::Remote
 
   def check
     fingerprint = rand_text_alpha(5)
-    print_status("#{peer} - Sending check...")
+    vprint_status("#{peer} - Sending check...")
     begin
       res = http_send_raw(fingerprint)
     rescue Rex::ConnectionError

--- a/modules/exploits/multi/http/op5_license.rb
+++ b/modules/exploits/multi/http/op5_license.rb
@@ -54,8 +54,8 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    print_status("Attempting to detect if the OP5 Monitor is vulnerable...")
-    print_status("Sending request to https://#{rhost}:#{rport}#{datastore['URI']}")
+    vprint_status("Attempting to detect if the OP5 Monitor is vulnerable...")
+    vprint_status("Sending request to https://#{rhost}:#{rport}#{datastore['URI']}")
 
     # Try running/timing 'ping localhost' to determine is system is vulnerable
     start = Time.now

--- a/modules/exploits/multi/http/op5_welcome.rb
+++ b/modules/exploits/multi/http/op5_welcome.rb
@@ -54,8 +54,8 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    print_status("Attempting to detect if the OP5 Monitor is vulnerable...")
-    print_status("Sending request to https://#{rhost}:#{rport}#{datastore['URI']}")
+    vprint_status("Attempting to detect if the OP5 Monitor is vulnerable...")
+    vprint_status("Sending request to https://#{rhost}:#{rport}#{datastore['URI']}")
 
     # Try running/timing 'ping localhost' to determine is system is vulnerable
     start = Time.now

--- a/modules/exploits/multi/http/openfire_auth_bypass.rb
+++ b/modules/exploits/multi/http/openfire_auth_bypass.rb
@@ -97,18 +97,18 @@ class Metasploit3 < Msf::Exploit::Remote
       })
 
     if (not res) or (res.code != 200)
-      print_error("Unable to make a request to: #{path}")
+      vprint_error("Unable to make a request to: #{path}")
       return Exploit::CheckCode::Unknown
     end
 
     versioncheck = res.body =~ /Openfire, \D*: (\d)\.(\d).(\d)\s*<\/div>/
 
     if versioncheck.nil? then
-      print_error("Unable to detect Openfire version")
+      vprint_error("Unable to detect Openfire version")
       return Exploit::CheckCode::Unknown
     end
 
-    print_status("Detected version: #{$1}.#{$2}.#{$3}")
+    vprint_status("Detected version: #{$1}.#{$2}.#{$3}")
     version = "#{$1}#{$2}#{$3}".to_i
 
     return Exploit::CheckCode::Safe if version > 360

--- a/modules/exploits/multi/http/openfire_auth_bypass.rb
+++ b/modules/exploits/multi/http/openfire_auth_bypass.rb
@@ -125,7 +125,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown
     end
 
-    Exploit::CheckCode::Vulnerable
+    Exploit::CheckCode::Appears
   end
 
   def get_plugin_jar(plugin_name)

--- a/modules/exploits/multi/http/openx_backdoor_php.rb
+++ b/modules/exploits/multi/http/openx_backdoor_php.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
     if response.nil?
       CheckCode::Unknown
     elsif response.body =~ /#{token} ((:?\d\.?)+)/
-      print_status("PHP Version #{$1}")
+      vprint_status("PHP Version #{$1}")
       return CheckCode::Vulnerable
     end
     return CheckCode::Safe

--- a/modules/exploits/multi/http/php_cgi_arg_injection.rb
+++ b/modules/exploits/multi/http/php_cgi_arg_injection.rb
@@ -66,12 +66,12 @@ class Metasploit3 < Msf::Exploit::Remote
   #   -s               Display colour syntax highlighted source.
   def check
 
-    print_status("Checking uri #{uri}")
+    vprint_status("Checking uri #{uri}")
 
     response = send_request_raw({ 'uri' => uri })
 
     if response and response.code == 200 and response.body =~ /\<code\>\<span style.*\&lt\;\?/mi and not datastore['PLESK']
-      print_error("Server responded in a way that was ambiguous, could not determine whether it was vulnerable")
+      vprint_error("Server responded in a way that was ambiguous, could not determine whether it was vulnerable")
       return Exploit::CheckCode::Unknown
     end
 
@@ -84,7 +84,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Appears
     end
 
-    print_error("Server responded indicating it was not vulnerable")
+    vprint_error("Server responded indicating it was not vulnerable")
     return Exploit::CheckCode::Safe
   end
 

--- a/modules/exploits/multi/http/phpldapadmin_query_engine.rb
+++ b/modules/exploits/multi/http/phpldapadmin_query_engine.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
       }, 3)
 
     if (res and res.body =~ /phpLDAPadmin \(1\.2\.[0|1]\.\d/i)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/multi/http/phpmyadmin_preg_replace.rb
+++ b/modules/exploits/multi/http/phpmyadmin_preg_replace.rb
@@ -64,18 +64,18 @@ class Metasploit3 < Msf::Exploit::Remote
     begin
       res = send_request_cgi({ 'uri' => normalize_uri(target_uri.path, '/js/messages.php') })
     rescue
-      print_error("Unable to connect to server.")
+      vprint_error("Unable to connect to server.")
       return CheckCode::Unknown
     end
 
     if res.code != 200
-      print_error("Unable to query /js/messages.php")
+      vprint_error("Unable to query /js/messages.php")
       return CheckCode::Unknown
     end
 
     php_version = res['X-Powered-By']
     if php_version
-      print_status("PHP Version: #{php_version}")
+      vprint_status("PHP Version: #{php_version}")
       if php_version =~ /PHP\/(\d)\.(\d)\.(\d)/
         if $1.to_i > 5
           return CheckCode::Safe
@@ -90,7 +90,7 @@ class Metasploit3 < Msf::Exploit::Remote
         end
       end
     else
-      print_status("Unknown PHP Version")
+      vprint_status("Unknown PHP Version")
     end
 
     if res.body =~ /pmaversion = '(.*)';/
@@ -105,9 +105,11 @@ class Metasploit3 < Msf::Exploit::Remote
             return CheckCode::Vulnerable
           end
 
-          return CheckCode::Unknown
+          return CheckCode::Detected
       end
     end
+
+    CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/multi/http/phpmyadmin_preg_replace.rb
+++ b/modules/exploits/multi/http/phpmyadmin_preg_replace.rb
@@ -99,10 +99,10 @@ class Metasploit3 < Msf::Exploit::Remote
         when '3.5.8.1', '4.0.0-rc3'
           return CheckCode::Safe
         when '4.0.0-alpha1', '4.0.0-alpha2', '4.0.0-beta1', '4.0.0-beta2', '4.0.0-beta3', '4.0.0-rc1', '4.0.0-rc2'
-          return CheckCode::Vulnerable
+          return CheckCode::Appears
         else
           if $1.starts_with? '3.5.'
-            return CheckCode::Vulnerable
+            return CheckCode::Appears
           end
 
           return CheckCode::Detected

--- a/modules/exploits/multi/http/phpscheduleit_start_date.rb
+++ b/modules/exploits/multi/http/phpscheduleit_start_date.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
     uri = normalize_uri(datastore['URI'])
     uri << '/' if uri[-1,1] != '/'
 
-    print_status("Checking uri #{uri}")
+    vprint_status("Checking uri #{uri}")
 
     response = send_request_cgi({
       'method' => "POST",

--- a/modules/exploits/multi/http/phptax_exec.rb
+++ b/modules/exploits/multi/http/phptax_exec.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
     if res and res.body =~ /PHPTAX by William L\. Berggren/
       return Exploit::CheckCode::Detected
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Safe
     end
   end
 

--- a/modules/exploits/multi/http/plone_popen2.rb
+++ b/modules/exploits/multi/http/plone_popen2.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'uri'       => uri
       }, 25)
     if (res.headers['Bobo-Exception-Type'].to_s =~ /zExceptions.BadRequest/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     # patched == zExceptions.NotFound
     return Exploit::CheckCode::Safe

--- a/modules/exploits/multi/http/pmwiki_pagelist.rb
+++ b/modules/exploits/multi/http/pmwiki_pagelist.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
       }, 25)
 
     if (res and res.body =~ /pmwiki-2.[0.00-2.34]/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/multi/http/polarcms_upload_exec.rb
+++ b/modules/exploits/multi/http/polarcms_upload_exec.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if not res or res.code != 200
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Safe
     end
 
     return Exploit::CheckCode::Appears

--- a/modules/exploits/multi/http/processmaker_exec.rb
+++ b/modules/exploits/multi/http/processmaker_exec.rb
@@ -127,7 +127,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # send check
     fingerprint = Rex::Text.rand_text_alphanumeric(rand(10)+10)
-    print_status("#{peer} - Sending check")
+    vprint_status("#{peer} - Sending check")
     begin
       res = execute_command("echo #{fingerprint}")
       if res and res.body =~ /#{fingerprint}/
@@ -136,9 +136,10 @@ class Metasploit3 < Msf::Exploit::Remote
         return Exploit::CheckCode::Safe
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE
-      print_error("#{peer} - Connection failed")
+      vprint_error("#{peer} - Connection failed")
+      return Exploit::CheckCode::Unknown
     end
-    return Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Safe
   end
 
   #

--- a/modules/exploits/multi/http/qdpm_upload_exec.rb
+++ b/modules/exploits/multi/http/qdpm_upload_exec.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = send_request_raw({'uri'=>normalize_uri(base, "/index.php")})
     if res and res.body =~ /<div id\=\"footer\"\>.+qdPM ([\d])\.([\d]).+\<\/div\>/m
       major, minor = $1, $2
-      return Exploit::CheckCode::Vulnerable if (major+minor).to_i <= 70
+      return Exploit::CheckCode::Appears if (major+minor).to_i <= 70
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/multi/http/sit_file_upload.rb
+++ b/modules/exploits/multi/http/sit_file_upload.rb
@@ -70,10 +70,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if (res and res.body =~ /SiT! Support Incident Tracker v(\d)\.(\d\d)/)
       ver = [ $1.to_i, $2.to_i ]
-      print_status("SiT! #{ver[0]}.#{ver[1]}")
+      vprint_status("SiT! #{ver[0]}.#{ver[1]}")
 
       if (ver[0] == 3 and ver[1] == 65)
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Appears
       elsif (ver[0] == 3 and ver[1] < 65)
         return Exploit::CheckCode::Appears
       end

--- a/modules/exploits/multi/http/sonicwall_gms_upload.rb
+++ b/modules/exploits/multi/http/sonicwall_gms_upload.rb
@@ -151,9 +151,9 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     if install_path.include?("\\")
-      print_status("Target looks like Windows")
+      vprint_status("Target looks like Windows")
     else
-      print_status("Target looks like Linux")
+      vprint_status("Target looks like Linux")
     end
     return Exploit::CheckCode::Vulnerable
   end

--- a/modules/exploits/multi/http/splunk_upload_app_exec.rb
+++ b/modules/exploits/multi/http/splunk_upload_app_exec.rb
@@ -182,7 +182,7 @@ class Metasploit3 < Msf::Exploit::Remote
     }, 25)
 
     if res and res.body =~ /Splunk Inc\. Splunk/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Detected
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/multi/http/struts_code_exec_parameters.rb
+++ b/modules/exploits/multi/http/struts_code_exec_parameters.rb
@@ -146,7 +146,7 @@ class Metasploit3 < Msf::Exploit::Remote
     sleep_time = datastore['CHECK_SLEEPTIME']
     check_cmd = "@java.lang.Thread@sleep(#{sleep_time * 1000})"
     t1 = Time.now
-    print_status("Asking remote server to sleep for #{sleep_time} seconds")
+    vprint_status("Asking remote server to sleep for #{sleep_time} seconds")
     response = execute_command(check_cmd)
     t2 = Time.now
     delta = t2 - t1

--- a/modules/exploits/multi/http/struts_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_default_action_mapper.rb
@@ -149,7 +149,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res.nil? or res.code != 200
-      print_error("#{rhost}:#{rport} - Check needs a valid action, returning 200, as TARGETURI")
+      vprint_error("#{rhost}:#{rport} - Check needs a valid action, returning 200, as TARGETURI")
       return Exploit::CheckCode::Unknown
     end
 
@@ -164,7 +164,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Vulnerable
     end
 
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Safe
   end
 
   def auto_target

--- a/modules/exploits/multi/http/struts_include_params.rb
+++ b/modules/exploits/multi/http/struts_include_params.rb
@@ -176,11 +176,11 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     #initialise some base vars
     @inject = "${#_memberAccess[\"allowStaticMethodAccess\"]=true,CMD}"
-    print_status("Performing Check...")
+    vprint_status("Performing Check...")
     sleep_time = datastore['CHECK_SLEEPTIME']
     check_cmd = "@java.lang.Thread@sleep(#{sleep_time * 1000})"
     t1 = Time.now
-    print_status("Asking remote server to sleep for #{sleep_time} seconds")
+    vprint_status("Asking remote server to sleep for #{sleep_time} seconds")
     response = execute_command(check_cmd)
     t2 = Time.now
     delta = t2 - t1
@@ -191,7 +191,7 @@ class Metasploit3 < Msf::Exploit::Remote
     elsif delta < sleep_time
       return Exploit::CheckCode::Safe
     else
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Vulnerable
     end
   end
 

--- a/modules/exploits/multi/http/testlink_upload_exec.rb
+++ b/modules/exploits/multi/http/testlink_upload_exec.rb
@@ -73,7 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
       if res
         if res.code == 200
           if res.body =~ /<p><img alt="Company logo" title="logo" style="width: 115px; height: 53px;"\s+src="[^"]+" \/>\s+<br \/>TestLink 1\.9\.3/
-            return Exploit::CheckCode::Vulnerable
+            return Exploit::CheckCode::Appears
           end
         end
       end
@@ -81,9 +81,10 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Detected if res and res.body =~ /TestLink project <a href="http:\/\/testlink\.sourceforge\.net\/docs\/testLink\.php">Home<\/a><br \/>/
       return Exploit::CheckCode::Safe
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{peer} - Connection failed")
+      vprint_error("#{peer} - Connection failed")
+      return Exploit::CheckCode::Unknown
     end
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Safe
 
   end
 

--- a/modules/exploits/multi/http/tomcat_mgr_deploy.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_deploy.rb
@@ -114,7 +114,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
     return CheckCode::Unknown if res.nil?
     if (res.code.between?(400, 499))
-      print_error("Server rejected the credentials")
+      vprint_error("Server rejected the credentials")
       return CheckCode::Unknown
     end
 
@@ -128,8 +128,8 @@ class Metasploit3 < Msf::Exploit::Remote
       :active => true
     )
 
-    print_status("Target is #{detect_platform(res.body)} #{detect_arch(res.body)}")
-    return CheckCode::Vulnerable
+    vprint_status("Target is #{detect_platform(res.body)} #{detect_arch(res.body)}")
+    return CheckCode::Appears
   end
 
   def auto_target

--- a/modules/exploits/multi/http/traq_plugin_exec.rb
+++ b/modules/exploits/multi/http/traq_plugin_exec.rb
@@ -1,4 +1,4 @@
-##
+f##
 # This module requires Metasploit: http//metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
       }, 25)
 
     if (res and res.body =~ /Powered by Traq 2.[0-3]/ )
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/multi/http/traq_plugin_exec.rb
+++ b/modules/exploits/multi/http/traq_plugin_exec.rb
@@ -1,4 +1,4 @@
-f##
+##
 # This module requires Metasploit: http//metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##

--- a/modules/exploits/multi/http/uptime_file_upload.rb
+++ b/modules/exploits/multi/http/uptime_file_upload.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Appears
     end
 
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Safe
 
   end
 

--- a/modules/exploits/multi/http/vtiger_php_exec.rb
+++ b/modules/exploits/multi/http/vtiger_php_exec.rb
@@ -57,26 +57,26 @@ class Metasploit3 < Msf::Exploit::Remote
     begin
       res = send_request_cgi({ 'uri' => normalize_uri(target_uri.path, '/index.php') })
     rescue
-      print_error("Unable to access the index.php file")
+      vprint_error("Unable to access the index.php file")
       return CheckCode::Unknown
     end
 
     if res and res.code != 200
-      print_error("Error accessing the index.php file")
+      vprint_error("Error accessing the index.php file")
       return CheckCode::Unknown
     end
 
     if res.body =~ /<div class="poweredBy">Powered by vtiger CRM - (.*)<\/div>/i
-      print_status("vTiger CRM version: " + $1)
+      vprint_status("vTiger CRM version: " + $1)
       case $1
       when '5.4.0', '5.3.0'
-        return CheckCode::Vulnerable
+        return CheckCode::Appears
       else
-        return CheckCode::Safe
+        return CheckCode::Detected
       end
     end
 
-    return CheckCode::Unknown
+    return CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/multi/http/webpagetest_upload_exec.rb
+++ b/modules/exploits/multi/http/webpagetest_upload_exec.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res1 and res1.body =~ /WebPagetest \- Website Performance and Optimization Test/ and
       res2 and res2.code == 200
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/multi/http/zabbix_script_exec.rb
+++ b/modules/exploits/multi/http/zabbix_script_exec.rb
@@ -60,14 +60,14 @@ class Metasploit4 < Msf::Exploit::Remote
     })
 
     if !init or init.code != 200
-      print_error("Could not connect to server")
+      vprint_error("Could not connect to server")
       return Exploit::CheckCode::Unknown
     end
 
     if init.body =~ /Zabbix (2\.0\.(\d)) Copyright/
       if $1 >= "2.0.0" and $1 <= "2.0.8"
-      print_good("Version #{$1} is vulnerable.")
-      return Exploit::CheckCode::Vulnerable
+      vprint_good("Version #{$1} is vulnerable.")
+      return Exploit::CheckCode::Appears
       end
     end
     return Exploit::CheckCode::Safe

--- a/modules/exploits/multi/misc/openview_omniback_exec.rb
+++ b/modules/exploits/multi/misc/openview_omniback_exec.rb
@@ -83,12 +83,12 @@ class Metasploit3 < Msf::Exploit::Remote
       disconnect
 
       if !(res and res.length > 0)
-        print_status("The remote service did not reply to our request")
+        vprint_status("The remote service did not reply to our request")
         return Exploit::CheckCode::Safe
       end
 
       if (res =~ /passwd|group|resolv/)
-        print_status("The remote service is exploitable")
+        vprint_status("The remote service is exploitable")
         return Exploit::CheckCode::Vulnerable
       end
 

--- a/modules/exploits/multi/misc/pbot_exec.rb
+++ b/modules/exploits/multi/misc/pbot_exec.rb
@@ -72,13 +72,13 @@ class Metasploit3 < Msf::Exploit::Remote
 
     response = register(sock)
     if response =~ /463/ or response =~ /464/
-      print_error("#{rhost}:#{rport} - Connection to the IRC Server not allowed")
+      vprint_error("#{rhost}:#{rport} - Connection to the IRC Server not allowed")
       return Exploit::CheckCode::Unknown
     end
 
     response = join(sock)
     if not response =~ /353/ and not response =~ /366/
-      print_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
+      vprint_error("#{rhost}:#{rport} - Error joining the #{datastore['CHANNEL']} channel")
       return Exploit::CheckCode::Unknown
     end
     response = pbot_login(sock)

--- a/modules/exploits/multi/misc/ra1nx_pubcall_exec.rb
+++ b/modules/exploits/multi/misc/ra1nx_pubcall_exec.rb
@@ -86,7 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     response = register(sock)
     if response =~ /463/ or response =~ /464/
-      print_error("#{rhost}:#{rport} - Connection to the IRC Server not allowed")
+      vprint_error("#{rhost}:#{rport} - Connection to the IRC Server not allowed")
       return Exploit::CheckCode::Unknown
     end
 

--- a/modules/exploits/multi/php/php_unserialize_zval_cookie.rb
+++ b/modules/exploits/multi/php/php_unserialize_zval_cookie.rb
@@ -202,7 +202,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
   def check
-    print_status("Checking for a vulnerable PHP version...")
+    vprint_status("Checking for a vulnerable PHP version...")
 
     #
     # Pick the URI and Cookie name
@@ -226,14 +226,14 @@ class Metasploit3 < Msf::Exploit::Remote
     php_bug = false
 
     if (not res)
-      print_status("No response from the server")
-      return Exploit::CheckCode::Safe
+      vprint_status("No response from the server")
+      return Exploit::CheckCode::Unknown # User should try again
     end
 
     http_fingerprint({ :response => res })  # check method
 
     if (res.code != 200)
-      print_status("The server returned #{res.code} #{res.message}")
+      vprint_status("The server returned #{res.code} #{res.message}")
       return Exploit::CheckCode::Safe
     end
 
@@ -246,24 +246,24 @@ class Metasploit3 < Msf::Exploit::Remote
       php_ver = php_raw.split('.')
 
       if (php_ver[0].to_i == 4 and php_ver[1] and php_ver[2] and php_ver[1].to_i < 5)
-        print_status("The server runs a vulnerable version of PHP (#{php_raw})")
+        vprint_status("The server runs a vulnerable version of PHP (#{php_raw})")
         php_bug = true
       else
-        print_status("The server runs a non-vulnerable version of PHP (#{php_raw})")
+        vprint_status("The server runs a non-vulnerable version of PHP (#{php_raw})")
         return Exploit::CheckCode::Safe
       end
     end
 
     # Detect the phpBB cookie name
     if (res.headers['Set-Cookie'] and res.headers['Set-Cookie'] =~ /(.*)_(sid|data)=/)
-      print_status("The server may require a cookie name of '#{$1}_data'")
+      vprint_status("The server may require a cookie name of '#{$1}_data'")
     end
 
     if(target and target['Signature'])
       if (res.body and res.body.match(target['Signature']))
-        print_status("Detected target #{target.name}")
+        vprint_status("Detected target #{target.name}")
       else
-        print_status("Did not detect target #{target.name}")
+        vprint_status("Did not detect target #{target.name}")
       end
 
     end

--- a/modules/exploits/multi/php/php_unserialize_zval_cookie.rb
+++ b/modules/exploits/multi/php/php_unserialize_zval_cookie.rb
@@ -268,7 +268,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     end
 
-    return php_bug ? Exploit::CheckCode::Vulnerable : Exploit::CheckCode::Appears
+    return php_bug ? Exploit::CheckCode::Appears : Exploit::CheckCode::Detected
   end
 
 

--- a/modules/exploits/multi/realserver/describe.rb
+++ b/modules/exploits/multi/realserver/describe.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     info = http_fingerprint({ :response => res })  # check method / Custom server check
     if res and res['Server']
-      print_status("Found RTSP: #{res['Server']}")
+      vprint_status("Found RTSP: #{res['Server']}")
       return Exploit::CheckCode::Detected
     end
     Exploit::CheckCode::Safe

--- a/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
+++ b/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
@@ -93,7 +93,7 @@ class Metasploit4 < Msf::Exploit::Remote
     end
 
     if res and res.code == 200 and res.headers['Server'] =~ /gSOAP/ and res.body =~ /OSExecuteResponse/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     elsif res and res.code == 500 and (res.body =~ /Invalid Credentials/ or res.body =~ /Permission denied/)
       return Exploit::CheckCode::Detected
     elsif res and res.headers['Server'] =~ /gSOAP/

--- a/modules/exploits/multi/svn/svnserve_date.rb
+++ b/modules/exploits/multi/svn/svnserve_date.rb
@@ -85,9 +85,6 @@ class Metasploit3 < Msf::Exploit::Remote
       ], self.class)
   end
 
-  def check
-  end
-
   def brute_exploit(addresses)
     connect
 

--- a/modules/exploits/osx/arkeia/type77.rb
+++ b/modules/exploits/osx/arkeia/type77.rb
@@ -61,18 +61,18 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Safe
     end
 
-    print_status("Arkeia Server Information:")
+    vprint_status("Arkeia Server Information:")
     info.each_pair { |k,v|
-      print_status("   #{k + (" " * (30-k.length))} = #{v}")
+      vprint_status("   #{k + (" " * (30-k.length))} = #{v}")
     }
 
     if (info['System'] !~ /Darwin/)
-      print_status("This module only supports Mac OS X targets")
+      vprint_status("This module only supports Mac OS X targets")
       return Exploit::CheckCode::Detected
     end
 
     if (info['Version'] =~ /Backup (4\.|5\.([012]\.|3\.[0123]$))/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/osx/local/setuid_tunnelblick.rb
+++ b/modules/exploits/osx/local/setuid_tunnelblick.rb
@@ -57,7 +57,7 @@ class Metasploit4 < Msf::Exploit::Local
 
   def check
     if not file?(datastore["Tunnelblick"])
-      print_error "openvpnstart not found"
+      vprint_error "openvpnstart not found"
       return CheckCode::Safe
     end
 

--- a/modules/exploits/osx/local/setuid_viscosity.rb
+++ b/modules/exploits/osx/local/setuid_viscosity.rb
@@ -57,7 +57,7 @@ class Metasploit4 < Msf::Exploit::Local
 
   def check
     if not file?(datastore["Viscosity"])
-      print_error "ViscosityHelper not found"
+      vprint_error "ViscosityHelper not found"
       return CheckCode::Safe
     end
 

--- a/modules/exploits/osx/local/sudo_password_bypass.rb
+++ b/modules/exploits/osx/local/sudo_password_bypass.rb
@@ -107,16 +107,16 @@ class Metasploit3 < Msf::Exploit::Local
       # check vn between 1.6.0 through 1.7.10p6
       # and 1.8.0 through 1.8.6p6
       if not vn_bt(sudo_vn, VULNERABLE_VERSION_RANGES)
-        print_error "sudo version #{sudo_vn} not vulnerable."
+        vprint_error "sudo version #{sudo_vn} not vulnerable."
         return Exploit::CheckCode::Safe
       end
     else
-      print_error "sudo not detected on the system."
+      vprint_error "sudo not detected on the system."
       return Exploit::CheckCode::Safe
     end
 
     if not user_in_admin_group?
-      print_error "sudo version is vulnerable, but user is not in the admin group (necessary to change the date)."
+      vprint_error "sudo version is vulnerable, but user is not in the admin group (necessary to change the date)."
       return Exploit::CheckCode::Safe
     end
     # one root for you sir

--- a/modules/exploits/unix/local/setuid_nmap.rb
+++ b/modules/exploits/unix/local/setuid_nmap.rb
@@ -56,7 +56,7 @@ class Metasploit4 < Msf::Exploit::Local
   def check
     stat = session.fs.file.stat(datastore["Nmap"])
     if stat and stat.file? and stat.setuid?
-      print_good("#{stat.prettymode} #{datastore["Nmap"]}")
+      vprint_good("#{stat.prettymode} #{datastore["Nmap"]}")
       return CheckCode::Vulnerable
     end
     return CheckCode::Safe

--- a/modules/exploits/unix/misc/qnx_qconn_exec.rb
+++ b/modules/exploits/unix/misc/qnx_qconn_exec.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # send check
     fingerprint = Rex::Text.rand_text_alphanumeric(rand(8)+4)
-    print_status("#{@peer} - Sending check")
+    vprint_status("#{@peer} - Sending check")
     connect
     req  = "service launcher\n"
     req << "start/flags run /bin/echo /bin/echo #{fingerprint}\n"
@@ -84,7 +84,7 @@ class Metasploit3 < Msf::Exploit::Remote
     elsif res and res =~ /QCONN/
       return Exploit::CheckCode::Detected
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Safe
     end
 
   end

--- a/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
+++ b/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     connect
     banner = sock.get_once.strip
-    print_status("#{rhost}:#{rport} - Banner: #{banner}")
+    vprint_status("#{rhost}:#{rport} - Banner: #{banner}")
     disconnect
 
     # Vulnerable version info obtained from CVE

--- a/modules/exploits/unix/webapp/arkeia_upload_exec.rb
+++ b/modules/exploits/unix/webapp/arkeia_upload_exec.rb
@@ -69,14 +69,14 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown
     end
 
-    print_status("#{peer} - Version #{version} detected")
+    vprint_status("#{peer} - Version #{version} detected")
 
     if version > "10.0.10"
       return Exploit::CheckCode::Safe
     end
 
     # Check for vulnerable component
-    print_status("#{peer} - Trying to detect the vulnerable component")
+    vprint_status("#{peer} - Trying to detect the vulnerable component")
 
     res = send_request_cgi({
       'method' => 'GET',
@@ -85,7 +85,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body =~ /Les versions brutes des messages est affichee ci-dessous/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/unix/webapp/clipbucket_upload_exec.rb
+++ b/modules/exploits/unix/webapp/clipbucket_upload_exec.rb
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # Check version
     peer = "#{rhost}:#{rport}"
 
-    print_status("#{peer} - Trying to detect installed version")
+    vprint_status("#{peer} - Trying to detect installed version")
 
     res = send_request_cgi({
      'method' => 'GET',
@@ -67,12 +67,12 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown
     end
 
-    print_status("#{peer} - Version #{version} detected")
+    vprint_status("#{peer} - Version #{version} detected")
 
     if version > "2.6"
       return Exploit::CheckCode::Safe
     else
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/unix/webapp/coppermine_piceditor.rb
+++ b/modules/exploits/unix/webapp/coppermine_piceditor.rb
@@ -73,7 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
     }, 25)
 
     if (res and res.body =~ /Coppermine Picture Editor/i)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/unix/webapp/egallery_upload_exec.rb
+++ b/modules/exploits/unix/webapp/egallery_upload_exec.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body.empty?
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/unix/webapp/flashchat_upload_exec.rb
+++ b/modules/exploits/unix/webapp/flashchat_upload_exec.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = send_request_raw({'uri' => uri})
 
     if not res
-      print_error("#{peer} - Connection timed out")
+      vprint_error("#{peer} - Connection timed out")
       return Exploit::CheckCode::Unknown
     end
 
@@ -71,10 +71,10 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown
     end
 
-    print_status("#{peer} - Version found: #{version}")
+    vprint_status("#{peer} - Version found: #{version}")
 
     if version =~ /6\.0\.(2|4|5|6|7|8)/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     elsif version <= "6.0.8"
       return Exploit::CheckCode::Detected
     else

--- a/modules/exploits/unix/webapp/foswiki_maketext.rb
+++ b/modules/exploits/unix/webapp/foswiki_maketext.rb
@@ -164,11 +164,11 @@ class Metasploit3 < Msf::Exploit::Remote
       if version <= "1.1.6"
         return Exploit::CheckCode::Appears
       else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Detected
       end
     end
 
-    return Exploit::CheckCode::Detected
+    return Exploit::CheckCode::Safe
   end
 
 

--- a/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
+++ b/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
@@ -73,15 +73,14 @@ class Metasploit3 < Msf::Exploit::Remote
     }, 10)
 
     if (res and res.body =~ /cannot be resolved to an ip address/)
-      print_status("This system appears to be vulnerable")
-      return Exploit::CheckCode::Vulnerable
+      vprint_status("This system appears to be vulnerable")
+      return Exploit::CheckCode::Appears
     end
 
     if (res and res.body =~ /ERROR: Unable to fetch the stylesheet/)
-      print_status("This system appears to be patched")
+      vprint_status("This system appears to be patched")
     end
 
-    print_status("This system is not exploitable")
     return Exploit::CheckCode::Safe
   end
 

--- a/modules/exploits/unix/webapp/hastymail_exec.rb
+++ b/modules/exploits/unix/webapp/hastymail_exec.rb
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Exploit::Remote
     login
 
     if not @session_id or @session_id.empty?
-      print_error "#{peer} - Authentication failed"
+      vprint_error "#{peer} - Authentication failed"
       return Exploit::CheckCode::Unknown
     end
 

--- a/modules/exploits/unix/webapp/havalite_upload_exec.rb
+++ b/modules/exploits/unix/webapp/havalite_upload_exec.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = send_request_raw({'uri' => uri})
 
     if not res
-      print_error("#{peer} - Connection timed out")
+      vprint_error("#{peer} - Connection timed out")
       return Exploit::CheckCode::Unknown
     end
 
@@ -69,11 +69,11 @@ class Metasploit3 < Msf::Exploit::Remote
     version = js_src.scan(/var myVersion = '(.+)';/).flatten[0] || ''
 
     if not version.empty? and version =~ /1\.1\.7/
-      print_status("#{peer} - Version found: #{version}")
-      return Exploit::CheckCode::Vulnerable
+      vprint_status("#{peer} - Version found: #{version}")
+      return Exploit::CheckCode::Appears
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Safe
   end
 
 

--- a/modules/exploits/unix/webapp/instantcms_exec.rb
+++ b/modules/exploits/unix/webapp/instantcms_exec.rb
@@ -52,18 +52,11 @@ class Metasploit3 < Msf::Exploit::Remote
       }
     })
 
-    if res
-      if res.body.match(/Build Date/)
-        return Exploit::CheckCode::Vulnerable
-      else
-        return Exploit::CheckCode::Safe
-      end
-    else
-      return Exploit::CheckCode::Unknown
+    if res and res.body.match(/Build Date/)
+      return Exploit::CheckCode::Vulnerable
     end
 
-  rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-    return Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/unix/webapp/joomla_comjce_imgmanager.rb
+++ b/modules/exploits/unix/webapp/joomla_comjce_imgmanager.rb
@@ -86,7 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
     version = ( get_version || '').to_s
 
     if (version.match(%r{1\.5\.7\.1[0-4]?}))
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/unix/webapp/joomla_media_upload_exec.rb
+++ b/modules/exploits/unix/webapp/joomla_media_upload_exec.rb
@@ -70,10 +70,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res and (res.code == 200 or res.code == 302)
       if res.body =~ /You are not authorised to view this resource/
-        print_status("#{peer} - Joomla Media Manager Found but authentication required")
+        vprint_status("#{peer} - Joomla Media Manager Found but authentication required")
         return Exploit::CheckCode::Detected
       elsif res.body =~ /<form action="(.*)" id="uploadForm"/
-        print_status("#{peer} - Joomla Media Manager Found and authentication isn't required")
+        vprint_status("#{peer} - Joomla Media Manager Found and authentication isn't required")
         return Exploit::CheckCode::Detected
       end
     end

--- a/modules/exploits/unix/webapp/joomla_tinybrowser.rb
+++ b/modules/exploits/unix/webapp/joomla_tinybrowser.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
       }, 25)
 
     if (res and res.body =~ /flexupload.swf/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/unix/webapp/kimai_sqli.rb
+++ b/modules/exploits/unix/webapp/kimai_sqli.rb
@@ -63,21 +63,19 @@ class Metasploit3 < Msf::Exploit::Remote
   # Checks if target is Kimai version 0.9.2.x
   #
   def check
-    print_status("#{peer} - Checking version...")
+    vprint_status("#{peer} - Checking version...")
     res = send_request_raw({ 'uri' => normalize_uri(target_uri.path, "index.php") })
     if not res
-      print_error("#{peer} - Request timed out")
+      vprint_error("#{peer} - Request timed out")
       return Exploit::CheckCode::Unknown
     elsif res.body =~ /Kimai/ and res.body =~ /(0\.9\.[\d\.]+)<\/strong>/
       version = "#{$1}"
       print_good("#{peer} - Found version: #{version}")
       if version >= "0.9.2" and version <= "0.9.2.1306"
-        return Exploit::CheckCode::Detected
-      else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Appears
       end
     end
-    Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/unix/webapp/libretto_upload_exec.rb
+++ b/modules/exploits/unix/webapp/libretto_upload_exec.rb
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     res = send_request_raw({'uri' => normalize_uri(target_uri.path)})
     if not res
-      print_error("#{peer} - Connection timed out")
+      vprint_error("#{peer} - Connection timed out")
       return Exploit::CheckCode::Unknown
     end
 

--- a/modules/exploits/unix/webapp/mybb_backdoor.rb
+++ b/modules/exploits/unix/webapp/mybb_backdoor.rb
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    print_status("Checking target")
+    vprint_status("Checking target")
     res = send_request_raw({
       'method' => 'GET',
       'uri' => uri

--- a/modules/exploits/unix/webapp/nagios3_history_cgi.rb
+++ b/modules/exploits/unix/webapp/nagios3_history_cgi.rb
@@ -164,16 +164,16 @@ class Metasploit3 < Msf::Exploit::Remote
     mytarget = select_target(banner, version)
 
     if mytarget.nil?
-      print_error("No matching target")
+      vprint_error("No matching target")
       return CheckCode::Unknown
     end
 
     if alert.nil?
-      print_error("At least one ALERT is needed in order to exploit")
+      vprint_error("At least one ALERT is needed in order to exploit")
       return CheckCode::Detected
     end
 
-    return CheckCode::Vulnerable
+    return CheckCode::Appears
   end
 
   def exploit

--- a/modules/exploits/unix/webapp/nagios_graph_explorer.rb
+++ b/modules/exploits/unix/webapp/nagios_graph_explorer.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res and res.code == 404
-      print_error("Remote host does not have Graph Explorer installed.")
+      vprint_error("Remote host does not have Graph Explorer installed.")
     elsif res and res.body =~ /Your session has timed out/
       return Exploit::CheckCode::Detected
     end

--- a/modules/exploits/unix/webapp/narcissus_backend_exec.rb
+++ b/modules/exploits/unix/webapp/narcissus_backend_exec.rb
@@ -83,14 +83,14 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     sig = rand_text_alpha(rand(10) + 5)  #The string to check
 
-    print_status("#{peer} - Looking for signature '#{sig}'...")
+    vprint_status("#{peer} - Looking for signature '#{sig}'...")
     res = remote_exe("echo #{sig}")
 
     if res and res.body =~ /#{sig}/
-      print_status("#{peer} - Signature '#{sig}' found.")
+      vprint_status("#{peer} - Signature '#{sig}' found.")
       return Exploit::CheckCode::Vulnerable
     else
-      print_status("#{peer} - Signature not found")
+      vprint_status("#{peer} - Signature not found")
       return Exploit::CheckCode::Safe
     end
   end

--- a/modules/exploits/unix/webapp/open_flash_chart_upload_exec.rb
+++ b/modules/exploits/unix/webapp/open_flash_chart_upload_exec.rb
@@ -77,13 +77,13 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri'    => normalize_uri(target_uri.path, "ofc_upload_image.php"),
     })
     if not res
-      print_error("#{peer} - Connection timed out")
+      vprint_error("#{peer} - Connection timed out")
       return Exploit::CheckCode::Unknown
     elsif res.code.to_i == 404
-      print_error("#{peer} - No ofc_upload_image.php found")
+      vprint_error("#{peer} - No ofc_upload_image.php found")
     elsif res and res.code == 200 and res.body =~ /Saving your image to/
       vprint_status("#{peer} - Found ofc_upload_image.php")
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/unix/webapp/openemr_sqli_privesc_upload.rb
+++ b/modules/exploits/unix/webapp/openemr_sqli_privesc_upload.rb
@@ -69,10 +69,10 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown
     end
 
-    print_status("#{peer} - Version #{version} detected")
+    vprint_status("#{peer} - Version #{version} detected")
 
     if version < "4.1.2"
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/unix/webapp/openemr_upload_exec.rb
+++ b/modules/exploits/unix/webapp/openemr_upload_exec.rb
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Exploit::Remote
     peer = "#{rhost}:#{rport}"
 
     # Check version
-    print_status("#{peer} - Trying to detect installed version")
+    vprint_status("#{peer} - Trying to detect installed version")
 
     res = send_request_cgi({
       'method' => 'GET',
@@ -69,14 +69,14 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown
     end
 
-    print_status("#{peer} - Version #{version} detected")
+    vprint_status("#{peer} - Version #{version} detected")
 
     if version > "4.1.1"
       return Exploit::CheckCode::Safe
     end
 
     # Check for vulnerable component
-    print_status("#{peer} - Trying to detect the vulnerable component")
+    vprint_status("#{peer} - Trying to detect the vulnerable component")
 
     res = send_request_cgi({
       'method' => 'GET',
@@ -84,7 +84,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body =~ /Saving your image to/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/unix/webapp/opensis_modname_exec.rb
+++ b/modules/exploits/unix/webapp/opensis_modname_exec.rb
@@ -113,7 +113,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     return Exploit::CheckCode::Unknown unless login(datastore['USERNAME'], datastore['PASSWORD'])
     fingerprint = Rex::Text.rand_text_alphanumeric(rand(10)+10)
-    print_status("#{peer} - Sending check")
+    vprint_status("#{peer} - Sending check")
     res = execute_command("echo #{fingerprint}")
     if res and res.body =~ /align=center>#{fingerprint}/
       return Exploit::CheckCode::Vulnerable

--- a/modules/exploits/unix/webapp/openx_banner_edit.rb
+++ b/modules/exploits/unix/webapp/openx_banner_edit.rb
@@ -78,7 +78,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Safe if (vers[0] > 2)
       return Exploit::CheckCode::Safe if (vers[1] > 8)
       return Exploit::CheckCode::Safe if (vers[0] == 2 && vers[1] == 8 && vers[2] >= 2)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/unix/webapp/php_charts_exec.rb
+++ b/modules/exploits/unix/webapp/php_charts_exec.rb
@@ -79,14 +79,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
       if res and res.body =~ /#{fingerprint}/
         return Exploit::CheckCode::Vulnerable
-      else
-        return Exploit::CheckCode::Safe
       end
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{peer} - Connection failed")
+      vprint_error("#{peer} - Connection failed")
+      return Exploit::CheckCode::Unknown
     end
-    return Exploit::CheckCode::Unknown
-
+    return Exploit::CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/unix/webapp/php_eval.rb
+++ b/modules/exploits/unix/webapp/php_eval.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
     if response.code == 200
       return Exploit::CheckCode::Detected
     end
-    print_error("Server responded with #{response.code}")
+    vprint_error("Server responded with #{response.code}")
     return Exploit::CheckCode::Safe
   end
 

--- a/modules/exploits/unix/webapp/php_include.rb
+++ b/modules/exploits/unix/webapp/php_include.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
             print_status("Checking uri #{rhost+tpath+uri}")
             response = send_request_raw({ 'uri' => tpath+uri})
             return Exploit::CheckCode::Detected if response.code == 200
-            print_error("Server responded with #{response.code}")
+            vprint_error("Server responded with #{response.code}")
             return Exploit::CheckCode::Safe
         else
             return Exploit::CheckCode::Unknown

--- a/modules/exploits/unix/webapp/php_wordpress_total_cache.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_total_cache.rb
@@ -183,14 +183,14 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     res = wordpress_and_online?
     unless res
-      print_error("#{peer} does not seeem to be Wordpress site")
+      vprint_error("#{peer} does not seeem to be Wordpress site")
       return Exploit::CheckCode::Unknown
     end
 
     if res.headers['X-Powered-By'] and res.headers['X-Powered-By'] =~ /W3 Total Cache\/([0-9\.]*)/
       version = $1
       if version <= "0.9.2.8"
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Appears
       else
         return Exploit::CheckCode::Safe
       end
@@ -200,7 +200,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Detected
     end
 
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Safe
 
   end
 end

--- a/modules/exploits/unix/webapp/projectpier_upload_exec.rb
+++ b/modules/exploits/unix/webapp/projectpier_upload_exec.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
       })
 
     if res and res.body =~ /Welcome to ProjectPier 0\.8\.[0-8]/ and res.headers['Server'] =~ /^Apache/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/unix/webapp/sphpblog_file_upload.rb
+++ b/modules/exploits/unix/webapp/sphpblog_file_upload.rb
@@ -61,13 +61,13 @@ class Metasploit3 < Msf::Exploit::Remote
     if (res and res.body =~ /Simple PHP Blog (\d)\.(\d)\.(\d)/)
 
       ver = [ $1.to_i, $2.to_i, $3.to_i ]
-      print_status("Simple PHP Blog #{ver.join('.')}")
+      vprint_status("Simple PHP Blog #{ver.join('.')}")
 
       if (ver[0] == 0 and ver[1] < 5)
         if (ver[1] == 4 and ver[2] > 0)
           return Exploit::CheckCode::Safe
         end
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Appears
       end
     end
 

--- a/modules/exploits/unix/webapp/spip_connect_exec.rb
+++ b/modules/exploits/unix/webapp/spip_connect_exec.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
     vprint_status("SPIP Version detected: #{version}")
 
     if version =~ /^2\.0/ and version < "2.0.21"
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     elsif version =~ /^2\.1/ and version < "2.1.16"
       return Exploit::CheckCode::Appears
     elsif version =~ /^3\.0/ and version < "3.0.3"

--- a/modules/exploits/unix/webapp/squash_yaml_exec.rb
+++ b/modules/exploits/unix/webapp/squash_yaml_exec.rb
@@ -51,7 +51,7 @@ class Metasploit3 < Msf::Exploit::Remote
       })
 
     if response.code == 422
-      print_status("Got HTTP 422 result, target may be vulnerable")
+      vprint_status("Got HTTP 422 result, target may be vulnerable")
       return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe

--- a/modules/exploits/unix/webapp/tikiwiki_graph_formula_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_graph_formula_exec.rb
@@ -83,7 +83,7 @@ class Metasploit3 < Msf::Exploit::Remote
         return Exploit::CheckCode::Safe if (ver2 > 8)
         return Exploit::CheckCode::Safe if (ver2 == 8 and ver3 > 0)
       end
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     Exploit::CheckCode::Safe
   end

--- a/modules/exploits/unix/webapp/tikiwiki_jhot_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_jhot_exec.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
     http_fingerprint({ :response => res })  # check method
 
     if (res and res.code == 200 and res.body.match(/TikiWiki 1\.9\.4/))
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     Exploit::CheckCode::Safe
   end

--- a/modules/exploits/unix/webapp/trixbox_langchoice.rb
+++ b/modules/exploits/unix/webapp/trixbox_langchoice.rb
@@ -62,37 +62,37 @@ class Metasploit3 < Msf::Exploit::Remote
     uri = normalize_uri(datastore['URI'])
     target_code = 200
 
-    print_status "Attempting to POST to #{uri}"
+    vprint_status "Attempting to POST to #{uri}"
     response = send_request_cgi({'uri' => uri, 'method' => 'POST'})
 
     unless defined? response
-      print_error 'Server did not respond to HTTP POST request'
-      return Exploit::CheckCode::Safe
+      vprint_error 'Server did not respond to HTTP POST request'
+      return Exploit::CheckCode::Unknown
     end
 
     code = response.code
 
     unless code == target_code
-      print_error "Expected HTTP code #{target_code}, but got #{code}."
+      vprint_error "Expected HTTP code #{target_code}, but got #{code}."
       return Exploit::CheckCode::Safe
     end
 
-    print_status "We received the expected HTTP code #{target_code}"
+    vprint_status "We received the expected HTTP code #{target_code}"
 
     # We will need the cookie PHPSESSID to continue
     cookies = response.headers['Set-Cookie']
 
     # Make sure cookies were set
     if defined? cookies and cookies =~ PHPSESSID_REGEX
-      print_status "We were successfully sent a PHPSESSID of '#{$1}'"
+      vprint_status "We were successfully sent a PHPSESSID of '#{$1}'"
     else
-      print_error 'The server did not send us the cookie we were looking for'
+      vprint_error 'The server did not send us the cookie we were looking for'
       return Exploit::CheckCode::Safe
     end
 
     # Okay, at this point we're just being silly and hackish.
     unless response.body =~ /langChoice/
-      print_error 'The page does not appear to contain a langChoice field'
+      vprint_error 'The page does not appear to contain a langChoice field'
       return Exploit::CheckCode::Safe
     end
 
@@ -109,17 +109,17 @@ class Metasploit3 < Msf::Exploit::Remote
     # Example footer: v2.6.1 &copy;2008 Fonality
 #		if response.body =~ /(v2\.(?:[0-5]\.\d|6\.[0-1]))\s{2}&copy;200[0-8] Fonality/
     if response.body =~ /(v2\.6\.1)\s{2}&copy;2008 Fonality/
-      print_status "Trixbox #{$1} detected!"
-      return Exploit::CheckCode::Vulnerable
+      vprint_status "Trixbox #{$1} detected!"
+      return Exploit::CheckCode::Appears
     end
 
-    print_status 'The target may be skinned making detection too difficult'
+    vprint_status 'The target may be skinned making detection too difficult'
 
     if response.body =~ /trixbox - User Mode/
       return Exploit::CheckCode::Detected
-    else
-      return Exploit::CheckCode::Unknown
     end
+
+    return Exploit::CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/unix/webapp/twiki_history.rb
+++ b/modules/exploits/unix/webapp/twiki_history.rb
@@ -67,12 +67,12 @@ class Metasploit3 < Msf::Exploit::Remote
         'uri' => test_url
       }, 25)
     if (not res) or (res.code != 404)
-      print_warning("WARNING: The test file exists already!")
-      return Exploit::CheckCode::Safe
+      vprint_warning("WARNING: The test file exists already!")
+      return Exploit::CheckCode::Unknown # Need to try again
     end
 
     # try to create it
-    print_status("Attempting to create #{test_url} ...")
+    vprint_status("Attempting to create #{test_url} ...")
     rev = rand_text_numeric(1+rand(5)) + ' `touch ' + test_file + '`#'
     res = send_request_raw({
         'uri' => cmd_base + Rex::Text.uri_encode(rev)
@@ -96,7 +96,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'uri' => cmd_base + Rex::Text.uri_encode(rev)
       }, 25)
     if (not res) or (res.code != 200)
-      print_warning("WARNING: unable to remove test file (#{test_file})")
+      vprint_warning("WARNING: unable to remove test file (#{test_file})")
     end
 
     return Exploit::CheckCode::Vulnerable

--- a/modules/exploits/unix/webapp/twiki_maketext.rb
+++ b/modules/exploits/unix/webapp/twiki_maketext.rb
@@ -153,15 +153,15 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res.body =~ /This site is running TWiki version.*TWiki-(\d\.\d\.\d)/
       version = $1
-      print_status("Version found: #{version}")
+      vprint_status("Version found: #{version}")
       if version < "5.1.3"
         return Exploit::CheckCode::Appears
       else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Detected
       end
     end
 
-    return Exploit::CheckCode::Detected
+    return Exploit::CheckCode::Safe
   end
 
 

--- a/modules/exploits/unix/webapp/twiki_search.rb
+++ b/modules/exploits/unix/webapp/twiki_search.rb
@@ -62,12 +62,12 @@ class Metasploit3 < Msf::Exploit::Remote
         'uri' => test_url
       }, 25)
     if (not res) or (res.body.match(content))
-      print_warning("WARNING: The test file exists already!")
-      return Exploit::CheckCode::Safe
+      vprint_warning("The test file exists already!")
+      return Exploit::CheckCode::Unknown # Need to try again with a different file
     end
 
     # try to create it
-    print_status("Attempting to create #{test_url} ...")
+    vprint_status("Attempting to create #{test_url} ...")
     search = rand_text_numeric(1+rand(5)) + "\';echo${IFS}" + content + "${IFS}>" + test_file + ".txt;#\'"
     res = send_request_raw({
         'uri' => cmd_base + Rex::Text.uri_encode(search)
@@ -91,7 +91,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'uri' => cmd_base + Rex::Text.uri_encode(search)
       }, 25)
     if (not res) or (res.code != 200)
-      print_warning("WARNING: unable to remove test file (#{test_file})")
+      vprint_warning("WARNING: unable to remove test file (#{test_file})")
     end
 
     return Exploit::CheckCode::Vulnerable

--- a/modules/exploits/unix/webapp/vbulletin_vote_sqli_exec.rb
+++ b/modules/exploits/unix/webapp/vbulletin_vote_sqli_exec.rb
@@ -343,7 +343,7 @@ class Metasploit3 < Msf::Exploit::Remote
     node_id = get_node
 
     unless node_id.nil?
-      return Msf::Exploit::CheckCode::Vulnerable
+      return Msf::Exploit::CheckCode::Appears
     end
 
     res = send_request_cgi({
@@ -351,10 +351,10 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body.to_s =~ /"simpleversion": "v=5/
-      return Msf::Exploit::CheckCode::Detected
+      return Msf::Exploit::CheckCode::Appears
     end
 
-    return Msf::Exploit::CheckCode::Unknown
+    return Msf::Exploit::CheckCode::Safe
   end
 
   def on_new_session(session)

--- a/modules/exploits/unix/webapp/vicidial_manager_send_cmd_exec.rb
+++ b/modules/exploits/unix/webapp/vicidial_manager_send_cmd_exec.rb
@@ -164,7 +164,7 @@ class Metasploit3 < Msf::Exploit::Remote
       end
     end
 
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/unix/webapp/webmin_show_cgi_exec.rb
+++ b/modules/exploits/unix/webapp/webmin_show_cgi_exec.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     peer = "#{rhost}:#{rport}"
 
-    print_status("#{peer} - Attempting to login...")
+    vprint_status("#{peer} - Attempting to login...")
 
     data = "page=%2F&user=#{datastore['USERNAME']}&pass=#{datastore['PASSWORD']}"
 
@@ -76,14 +76,14 @@ class Metasploit3 < Msf::Exploit::Remote
       }, 25)
 
     if res and res.code == 302 and res.headers['Set-Cookie'] =~ /sid/
-      print_good "#{peer} - Authentication successful"
+      vprint_good "#{peer} - Authentication successful"
       session = res.headers['Set-Cookie'].split("sid=")[1].split(";")[0]
     else
-      print_error "#{peer} - Authentication failed"
-      return Exploit::CheckCode::Unknown
+      vprint_error "#{peer} - Service found, but authentication failed"
+      return Exploit::CheckCode::Detected
     end
 
-    print_status("#{peer} - Attempting to execute...")
+    vprint_status("#{peer} - Attempting to execute...")
 
     command = "echo #{rand_text_alphanumeric(rand(5) + 5)}"
 
@@ -95,7 +95,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
     if res and res.code == 200 and res.message =~ /Document follows/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Vulnerable
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/unix/webapp/webtester_exec.rb
+++ b/modules/exploits/unix/webapp/webtester_exec.rb
@@ -59,16 +59,16 @@ class Metasploit3 < Msf::Exploit::Remote
     res = send_request_raw({ 'uri' => normalize_uri(target_uri.path) })
 
     if not res
-      print_error("#{peer} - Connection timed out")
+      vprint_error("#{peer} - Connection timed out")
       return Exploit::CheckCode::Unknown
     end
 
     if res.body =~ /Eppler Software/
       if res.body =~ / - v5\.1\.20101016/
-        print_status("#{peer} - Found version: 5.1.20101016")
-        return Exploit::CheckCode::Vulnerable
+        vprint_status("#{peer} - Found version: 5.1.20101016")
+        return Exploit::CheckCode::Appears
       elsif res.body =~ / - v(5\.[\d\.]+)/
-        print_status("#{peer} - Found version: #{$1}")
+        vprint_status("#{peer} - Found version: #{$1}")
         return Exploit::CheckCode::Appears
       else
         return Exploit::CheckCode::Detected

--- a/modules/exploits/unix/webapp/wp_advanced_custom_fields_exec.rb
+++ b/modules/exploits/unix/webapp/wp_advanced_custom_fields_exec.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res and res.code == 200
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/unix/webapp/wp_google_document_embedder_exec.rb
+++ b/modules/exploits/unix/webapp/wp_google_document_embedder_exec.rb
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res and res.code == 200
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/unix/webapp/xoda_file_upload.rb
+++ b/modules/exploits/unix/webapp/xoda_file_upload.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res and res.code == 200 and res.body =~ /Upload a file/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/unix/webapp/zeroshell_exec.rb
+++ b/modules/exploits/unix/webapp/zeroshell_exec.rb
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     unless password.nil?
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/unix/webapp/zoneminder_packagecontrol_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_packagecontrol_exec.rb
@@ -81,19 +81,19 @@ class Metasploit3 < Msf::Exploit::Remote
       })
       if res and res.code == 200
         if res.body =~ /<title>ZM - Login<\/title>/
-          print_error("#{peer} - Authentication failed")
-          return Exploit::CheckCode::Unknown
+          vprint_error("#{peer} - Service found, but authentication failed")
+          return Exploit::CheckCode::Detected
         elsif res.body =~ /v1.2(4\.\d+|5\.0)/
           return Exploit::CheckCode::Appears
         elsif res.body =~ /<title>ZM/
           return Exploit::CheckCode::Detected
         end
       end
-      return Exploit::CheckCode::Safe
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeoutp
-      print_error("#{peer} - Connection failed")
+      vprint_error("#{peer} - Connection failed")
+      return Exploit::CheckCode::Unknown
     end
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Safe
 
   end
 

--- a/modules/exploits/unix/webapp/zpanel_username_exec.rb
+++ b/modules/exploits/unix/webapp/zpanel_username_exec.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     res = send_request_raw({'uri' => normalize_uri(target_uri.path)})
     if not res
-      print_error("#{peer} - Connection timed out")
+      vprint_error("#{peer} - Connection timed out")
       return Exploit::CheckCode::Unknown
     end
 

--- a/modules/exploits/windows/arkeia/type77.rb
+++ b/modules/exploits/windows/arkeia/type77.rb
@@ -64,18 +64,18 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Safe
     end
 
-    print_status("Arkeia Server Information:")
+    vprint_status("Arkeia Server Information:")
     info.each_pair { |k,v|
-      print_status("   #{k + (" " * (30-k.length))} = #{v}")
+      vprint_status("   #{k + (" " * (30-k.length))} = #{v}")
     }
 
     if (info['System'] !~ /Windows/)
-      print_status("This module only supports Windows targets")
+      vprint_status("This module only supports Windows targets")
       return Exploit::CheckCode::Detected
     end
 
     if (info['Version'] =~ /Backup (4\.|5\.([012]\.|3\.[0123]$))/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/backupexec/remote_agent.rb
+++ b/modules/exploits/windows/backupexec/remote_agent.rb
@@ -72,12 +72,12 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     info = ndmp_info()
     if (info and info['Version'])
-      print_status(" Vendor: #{info['Vendor']}")
-      print_status("Product: #{info['Product']}")
-      print_status("Version: #{info['Version']}")
+      vprint_status(" Vendor: #{info['Vendor']}")
+      vprint_status("Product: #{info['Product']}")
+      vprint_status("Version: #{info['Version']}")
 
       if (info['Vendor'] =~ /VERITAS/i and info['Version'] =~ /^(4\.2|5\.1)$/)
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Appears
       end
     end
     return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/brightstor/lgserver_multi.rb
+++ b/modules/exploits/windows/brightstor/lgserver_multi.rb
@@ -59,8 +59,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
     disconnect
 
-    if ( ver and ver =~ /11.1.742/ )
-        return Exploit::CheckCode::Vulnerable
+    if ( ver and ver =~ /11\.1\.742/ )
+        return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/brightstor/lgserver_rxrlogin.rb
+++ b/modules/exploits/windows/brightstor/lgserver_rxrlogin.rb
@@ -58,8 +58,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
     disconnect
 
-    if ( ver and ver =~ /11.1.742/ )
-      return Exploit::CheckCode::Vulnerable
+    if ( ver and ver =~ /11\.1\.742/ )
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/brightstor/lgserver_rxssetdatagrowthscheduleandfilter.rb
+++ b/modules/exploits/windows/brightstor/lgserver_rxssetdatagrowthscheduleandfilter.rb
@@ -58,8 +58,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
     disconnect
 
-    if ( ver and ver =~ /11.1.742/ )
-        return Exploit::CheckCode::Vulnerable
+    if ( ver and ver =~ /11\.1\.742/ )
+        return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/brightstor/lgserver_rxsuselicenseini.rb
+++ b/modules/exploits/windows/brightstor/lgserver_rxsuselicenseini.rb
@@ -57,8 +57,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
     disconnect
 
-    if ( ver and ver =~ /11.1.742/ )
-        return Exploit::CheckCode::Vulnerable
+    if ( ver and ver =~ /11\.1\.742/ )
+        return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/ftp/3cdaemon_ftp_user.rb
+++ b/modules/exploits/windows/ftp/3cdaemon_ftp_user.rb
@@ -102,7 +102,7 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     disconnect
     if (banner =~ /3Com 3CDaemon FTP Server Version 2\.0/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ftp/ability_server_stor.rb
+++ b/modules/exploits/windows/ftp/ability_server_stor.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     disconnect
     if banner =~ /Ability Server 2\.34/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     else
       if banner =~ /Ability Server/
         return Exploit::CheckCode::Detected

--- a/modules/exploits/windows/ftp/cesarftp_mkd.rb
+++ b/modules/exploits/windows/ftp/cesarftp_mkd.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /CesarFTP 0\.99g/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
       return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ftp/dreamftp_format.rb
+++ b/modules/exploits/windows/ftp/dreamftp_format.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
     banner = sock.get(-1,3)
     disconnect
     if (banner =~ /Dream FTP Server/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Detected
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ftp/easyfilesharing_pass.rb
+++ b/modules/exploits/windows/ftp/easyfilesharing_pass.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /Easy File Sharing FTP Server/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Detected
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ftp/easyftp_cwd_fixret.rb
+++ b/modules/exploits/windows/ftp/easyftp_cwd_fixret.rb
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /BigFoolCat/) # EasyFTP Server has undergone several name changes
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Detected
     end
       return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ftp/easyftp_list_fixret.rb
+++ b/modules/exploits/windows/ftp/easyftp_list_fixret.rb
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /BigFoolCat/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Detected
     end
     Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ftp/easyftp_mkd_fixret.rb
+++ b/modules/exploits/windows/ftp/easyftp_mkd_fixret.rb
@@ -73,7 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /BigFoolCat/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Detected
     end
       return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ftp/freefloatftp_user.rb
+++ b/modules/exploits/windows/ftp/freefloatftp_user.rb
@@ -57,6 +57,7 @@ class Metasploit4 < Msf::Exploit::Remote
     connect
     disconnect
     if (banner =~ /FreeFloat/)
+      # Software is never updated, so if you run this you're f*cked.
       return Exploit::CheckCode::Vulnerable
     else
       return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/ftp/freefloatftp_wbem.rb
+++ b/modules/exploits/windows/ftp/freefloatftp_wbem.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if banner =~ /FreeFloat/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Detected
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/windows/ftp/freeftpd_pass.rb
+++ b/modules/exploits/windows/ftp/freeftpd_pass.rb
@@ -71,7 +71,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # All versions including and above version 1.0 report "220 Hello, I'm freeFTPd 1.0"
     # when banner grabbing.
     if banner =~ /freeFTPd 1\.0/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
 

--- a/modules/exploits/windows/ftp/freeftpd_user.rb
+++ b/modules/exploits/windows/ftp/freeftpd_user.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     disconnect
     if (banner =~ /freeFTPd 1\.0/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ftp/goldenftp_pass_bof.rb
+++ b/modules/exploits/windows/ftp/goldenftp_pass_bof.rb
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     connect
     disconnect
-    print_status("FTP Banner: #{banner}".strip)
+    vprint_status("FTP Banner: #{banner}".strip)
     if banner =~ /Golden FTP Server ready v(4\.\d{2})/ and $1 == "4.70"
       return Exploit::CheckCode::Appears
     else

--- a/modules/exploits/windows/ftp/httpdx_tolog_format.rb
+++ b/modules/exploits/windows/ftp/httpdx_tolog_format.rb
@@ -125,9 +125,9 @@ For now, that will have to be done manually.
   def check
     connect
     disconnect
-    print_status("FTP Banner: #{banner}".strip)
+    vprint_status("FTP Banner: #{banner}".strip)
     if banner =~ /httpdx.*\(Win32\)/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Detected
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ftp/netterm_netftpd_user.rb
+++ b/modules/exploits/windows/ftp/netterm_netftpd_user.rb
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     disconnect
     if (banner =~ /NetTerm FTP server/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Detected
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ftp/open_ftpd_wbem.rb
+++ b/modules/exploits/windows/ftp/open_ftpd_wbem.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if banner =~ /\*\*        Welcome on       \*\*/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Detected
     else
       return Exploit::CheckCode::Unknown
     end

--- a/modules/exploits/windows/ftp/oracle9i_xdb_ftp_pass.rb
+++ b/modules/exploits/windows/ftp/oracle9i_xdb_ftp_pass.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     disconnect
     if (banner =~ /9\.2\.0\.1\.0/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ftp/oracle9i_xdb_ftp_unlock.rb
+++ b/modules/exploits/windows/ftp/oracle9i_xdb_ftp_unlock.rb
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     disconnect
     if (banner =~ /9\.2\.0\.1\.0/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ftp/pcman_stor.rb
+++ b/modules/exploits/windows/ftp/pcman_stor.rb
@@ -60,10 +60,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if c and banner =~ /220 PCMan's FTP Server 2\.0/
       # Auth is required to exploit
-      print_status("Able to authenticate, and banner shows the vulnerable version")
-      return Exploit::CheckCode::Vulnerable
+      vprint_status("Able to authenticate, and banner shows the vulnerable version")
+      return Exploit::CheckCode::Appears
     elsif not c and banner =~ /220 PCMan's FTP Server 2\.0/
-      print_status("Unable to authenticate, but banner shows the vulnerable version")
+      vprint_status("Unable to authenticate, but banner shows the vulnerable version")
       # Auth failed, but based on version maybe the target is vulnerable
       return Exploit::CheckCode::Appears
     end

--- a/modules/exploits/windows/ftp/ricoh_dl_bof.rb
+++ b/modules/exploits/windows/ftp/ricoh_dl_bof.rb
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     disconnect
     if banner =~ /220 DSC ftpd 1\.0 FTP Server/
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/windows/ftp/sami_ftpd_user.rb
+++ b/modules/exploits/windows/ftp/sami_ftpd_user.rb
@@ -74,8 +74,8 @@ class Metasploit3 < Msf::Exploit::Remote
     banner = sock.get(-1,3)
     disconnect
 
-    if (banner =~ /Sami FTP Server 2.0.2/)
-      return Exploit::CheckCode::Vulnerable
+    if (banner =~ /Sami FTP Server 2\.0\.2/)
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ftp/servu_chmod.rb
+++ b/modules/exploits/windows/ftp/servu_chmod.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /Serv-U FTP Server v((4.(0|1))|3.\d)/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
       return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ftp/servu_mdtm.rb
+++ b/modules/exploits/windows/ftp/servu_mdtm.rb
@@ -100,8 +100,8 @@ class Metasploit3 < Msf::Exploit::Remote
         return Exploit::CheckCode::Appears
 
       when /Serv-U FTP Server v5\.0/
-        vprint_status('Found version 5');
-        return Exploit::CheckCode::Appears
+        vprint_status('Found version 5! 5.0.0.0 may be exploitable, but not 5.0.0.4');
+        return Exploit::CheckCode::Detected
 
       when /Serv-U FTP Server v4\.0/
         vprint_status('Found version 4.0.0.4 or 4.1.0.0, additional check.');

--- a/modules/exploits/windows/ftp/servu_mdtm.rb
+++ b/modules/exploits/windows/ftp/servu_mdtm.rb
@@ -96,31 +96,31 @@ class Metasploit3 < Msf::Exploit::Remote
 
     case banner
       when /Serv-U FTP Server v4\.1/
-        print_status('Found version 4.1.0.3, exploitable')
-        return Exploit::CheckCode::Vulnerable
+        vprint_status('Found version 4.1.0.3, exploitable')
+        return Exploit::CheckCode::Appears
 
       when /Serv-U FTP Server v5\.0/
-        print_status('Found version 5.0.0.0 (exploitable) or 5.0.0.4 (not), try it!');
+        vprint_status('Found version 5');
         return Exploit::CheckCode::Appears
 
       when /Serv-U FTP Server v4\.0/
-        print_status('Found version 4.0.0.4 or 4.1.0.0, additional check.');
+        vprint_status('Found version 4.0.0.4 or 4.1.0.0, additional check.');
         send_user(datastore['USER'])
         send_pass(datastore['PASS'])
         if (double_ff?())
-          print_status('Found version 4.0.0.4, exploitable');
-          return Exploit::CheckCode::Vulnerable
+          vprint_status('Found version 4.0.0.4, exploitable');
+          return Exploit::CheckCode::Appears
         else
-          print_status('Found version 4.1.0.0, exploitable');
-          return Exploit::CheckCode::Vulnerable
+          vprint_status('Found version 4.1.0.0, exploitable');
+          return Exploit::CheckCode::Appears
         end
 
-      when /Serv-U FTP Server/
-        print_status('Found an unknown version, try it!');
+      when /Serv\-U FTP Server/
+        vprint_status('Found an unknown version, try it!');
         return Exploit::CheckCode::Detected
 
       else
-        print_status('We could not recognize the server banner')
+        vprint_status('We could not recognize the server banner')
         return Exploit::CheckCode::Safe
     end
 

--- a/modules/exploits/windows/ftp/turboftp_port.rb
+++ b/modules/exploits/windows/ftp/turboftp_port.rb
@@ -63,9 +63,9 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     disconnect
     if (banner =~ /1\.30\.823/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     elsif (banner =~ /1\.30\.826/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ftp/vermillion_ftpd_port.rb
+++ b/modules/exploits/windows/ftp/vermillion_ftpd_port.rb
@@ -98,9 +98,9 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     connect
     disconnect
-    print_status("FTP Banner: #{banner}".strip)
+    vprint_status("FTP Banner: #{banner}".strip)
     if banner =~ /\(vftpd .*\)/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Detected
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ftp/wsftp_server_503_mkd.rb
+++ b/modules/exploits/windows/ftp/wsftp_server_503_mkd.rb
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     disconnect
     if (banner =~ /5\.0\.3/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ftp/wsftp_server_505_xmd5.rb
+++ b/modules/exploits/windows/ftp/wsftp_server_505_xmd5.rb
@@ -47,8 +47,8 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     connect
     disconnect
-    if (banner =~ /WS_FTP Server 5.0.5/)
-      return Exploit::CheckCode::Vulnerable
+    if (banner =~ /WS_FTP Server 5\.0\.5/)
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ftp/xlink_server.rb
+++ b/modules/exploits/windows/ftp/xlink_server.rb
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /XLINK FTP Server/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Detected
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/games/ut2004_secure.rb
+++ b/modules/exploits/windows/games/ut2004_secure.rb
@@ -97,19 +97,19 @@ class Metasploit3 < Msf::Exploit::Remote
       return
     end
 
-    print_status("Detected Unreal Tournament Server Version: #{vers}")
+    vprint_status("Detected Unreal Tournament Server Version: #{vers}")
     if (vers =~ /^(3120|3186|3204)$/)
-      print_status("This system appears to be exploitable")
+      vprint_status("This system appears to be exploitable")
       return Exploit::CheckCode::Appears
     end
 
 
     if (vers =~ /^(2...)$/)
-      print_status("This system appears to be running UT2003")
+      vprint_status("This system appears to be running UT2003")
       return Exploit::CheckCode::Detected
     end
 
-    print_status("This system appears to be patched")
+    vprint_status("This system appears to be patched")
     return Exploit::CheckCode::Safe
   end
 

--- a/modules/exploits/windows/http/altn_securitygateway.rb
+++ b/modules/exploits/windows/http/altn_securitygateway.rb
@@ -83,7 +83,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def check
     if auto_target
-      Exploit::CheckCode::Vulnerable
+      Exploit::CheckCode::Appears
     end
     Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/http/apache_chunked.rb
+++ b/modules/exploits/windows/http/apache_chunked.rb
@@ -156,8 +156,8 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     response = send_request_raw({'uri' => '/'}, 5)
     if response.nil?
-      print_status("No response to request")
-      return Exploit::CheckCode::Safe
+      vprint_status("No response to request")
+      return Exploit::CheckCode::Unknown
     end
 
     http_fingerprint({ :response => response })  # Custom Server header matching
@@ -166,24 +166,20 @@ class Metasploit3 < Msf::Exploit::Remote
 
     case response['Server']
       when "Oracle HTTP Server Powered by Apache/1.3.12 (Win32) ApacheJServ/1.1 mod_ssl/2.6.4 OpenSSL/0.9.5a mod_perl/1.22"
-        print_status("This looks like an Oracle 8.1.7 Apache service (one-shot only)")
+        vprint_status("This looks like an Oracle 8.1.7 Apache service (one-shot only)")
       when "Oracle HTTP Server Powered by Apache/1.3.12 (Win32) ApacheJServ/1.1 mod_ssl/2.6.4 OpenSSL/0.9.5a mod_perl/1.24"
-        print_status("This looks like an Oracle 9.1.0 Apache service (multiple tries allowed)")
+        vprint_status("This looks like an Oracle 9.1.0 Apache service (multiple tries allowed)")
       when "Oracle HTTP Server Powered by Apache/1.3.22 (Win32) mod_plsql/3.0.9.8.3b mod_ssl/2.8.5 OpenSSL/0.9.6b mod_fastcgi/2.2.12 mod_oprocmgr/1.0 mod_perl/1.25"
-        print_status("This looks like an Oracle 9.2.0 Apache service (multiple tries allowed)")
+        vprint_status("This looks like an Oracle 9.2.0 Apache service (multiple tries allowed)")
       when /IBM_HTTP_SERVER\/1\.3\.(19\.[3-9]|2[0-9]\.)/
-        print_status("IBM backported the patch, this system is not vulnerable")
+        vprint_status("IBM backported the patch, this system is not vulnerable")
         code = Exploit::CheckCode::Safe
       when /Apache(-AdvancedExtranetServer)?\/(1\.([0-2]\.[0-9]|3\.([0-9][^0-9]|[0-1][0-9]|2[0-5]))|2\.0.([0-9][^0-9]|[0-2][0-9]|3[0-8]))/
       else
         code = Exploit::CheckCode::Safe
     end
 
-    if code == Exploit::CheckCode::Appears
-      print_status("Vulnerable server: #{response['Server']}")
-    else
-      print_status("Server is probably not vulnerable: #{response['Server']}")
-    end
+    vprint_status("Server: #{response['Server']}")
 
     return code
   end

--- a/modules/exploits/windows/http/apache_modjk_overflow.rb
+++ b/modules/exploits/windows/http/apache_modjk_overflow.rb
@@ -60,8 +60,8 @@ class Metasploit3 < Msf::Exploit::Remote
     resp = sock.get_once
     disconnect
 
-      if (resp and (m = resp.match(/Server: Apache\/(.*) \(Win32\)(.*) mod_jk\/1.2.20/))) then
-        print_status("Apache version detected : #{m[1]}")
+      if (resp and (m = resp.match(/Server: Apache\/(.*) \(Win32\)(.*) mod_jk\/1\.2\.20/))) then
+        vprint_status("Apache version detected : #{m[1]}")
         return Exploit::CheckCode::Appears
       else
         return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/http/badblue_ext_overflow.rb
+++ b/modules/exploits/windows/http/badblue_ext_overflow.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     info = http_fingerprint  # check method
     if (info =~ /BadBlue\/2\.5/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/http/bea_weblogic_post_bof.rb
+++ b/modules/exploits/windows/http/bea_weblogic_post_bof.rb
@@ -89,7 +89,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     case fingerprint
     when /Version found/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     when /BEA WebLogic connector vulnerable/
       return Exploit::CheckCode::Appears
     when /BEA WebLogic connector undefined/

--- a/modules/exploits/windows/http/cyclope_ess_sqli.rb
+++ b/modules/exploits/windows/http/cyclope_ess_sqli.rb
@@ -60,17 +60,15 @@ class Metasploit3 < Msf::Exploit::Remote
     path = File.dirname("#{target_uri.path}/.")
     b64_version = get_version(path)
     if b64_version.empty?
-      print_error("#{peer} - Unable to determine the version number")
+      vprint_error("#{peer} - Unable to determine the version number")
     else
       b64_version = Rex::Text.decode_base64(b64_version)
       if b64_version =~ /^[0-6]\.1/
-        return Exploit::CheckCode::Vulnerable
-      else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Appears
       end
     end
 
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Safe
   end
 
 

--- a/modules/exploits/windows/http/desktopcentral_file_upload.rb
+++ b/modules/exploits/windows/http/desktopcentral_file_upload.rb
@@ -69,7 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
       build = $1
       print_status("Manage Desktop Central 8 build #{build} found")
       if build < "80293"
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Appears
       else
         return Exploit::CheckCode::Safe
       end

--- a/modules/exploits/windows/http/easyftp_list.rb
+++ b/modules/exploits/windows/http/easyftp_list.rb
@@ -77,8 +77,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def check
     info = http_fingerprint  # check method
-    if info and (info =~ /Easy-Web Server\//)
-      return Exploit::CheckCode::Vulnerable
+    if info and (info =~ /Easy\-Web Server\//)
+      return Exploit::CheckCode::Detected
     end
     Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/http/hp_imc_bims_upload.rb
+++ b/modules/exploits/windows/http/hp_imc_bims_upload.rb
@@ -66,7 +66,8 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     if res.code == 200 and res.headers['Content-Type'] =~ /application\/doc/ and res.body =~ /com\.h3c\.imc\.bims\.acs\.server\.UploadServlet/
-      return Exploit::CheckCode::Vulnerable
+      vprint_status("Upload interface found. Must be tested to verify vulnerable state.")
+      return Exploit::CheckCode::Appears
     elsif res.code == 405 and res.message =~ /Method Not Allowed/
       return Exploit::CheckCode::Appears
     end

--- a/modules/exploits/windows/http/hp_imc_bims_upload.rb
+++ b/modules/exploits/windows/http/hp_imc_bims_upload.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res.nil?
-      print_error("Unable to determine, because the request timed out.")
+      vprint_error("Unable to determine, because the request timed out.")
       return Exploit::CheckCode::Unknown
     end
 

--- a/modules/exploits/windows/http/hp_loadrunner_copyfiletoserver.rb
+++ b/modules/exploits/windows/http/hp_loadrunner_copyfiletoserver.rb
@@ -105,7 +105,7 @@ class Metasploit3 < Msf::Exploit::Remote
     depth = datastore['DEPTH']
     install_path = datastore['INSTALLPATH']
 
-    print_status("#{peer} - Detecting tomcat version...")
+    vprint_status("#{peer} - Detecting tomcat version...")
     tomcat_version = get_tomcat_version
 
     if tomcat_version
@@ -118,19 +118,19 @@ class Metasploit3 < Msf::Exploit::Remote
       res = read_file(depth, location, "index.jsp")
 
       if res and res.code == 200  and res.body.to_s =~ /HP Service Emulation/
-        print_good("#{peer} - Traversal exists and parameters are correct...")
+        vprint_good("#{peer} - Traversal exists and parameters are correct...")
         return Exploit::CheckCode::Vulnerable
       elsif res and res.code == 500 and res.body.to_s =~ /FileNotFoundException/
-        print_warning("#{peer} - Traversal appears to exist, try adjusting parameters DEPTH and INSTALLPATH...")
+        vprint_warning("#{peer} - Traversal appears to exist, try adjusting parameters DEPTH and INSTALLPATH...")
         return Exploit::CheckCode::Appears
       else
-        print_status("#{peer} - Failed to verify the directory traversal...")
+        vprint_status("#{peer} - Failed to verify the directory traversal...")
       end
     else
-      print_error("#{peer} - Tomcat version not detected...")
+      vprint_error("#{peer} - Tomcat version not detected...")
     end
 
-    print_status("#{peer} - Checking if the vulnerable web service and method exist...")
+    vprint_status("#{peer} - Checking if the vulnerable web service and method exist...")
     res = send_request_cgi({
       'uri'    => normalize_uri('ServiceEmulation', 'services', 'EmulationAdmin'),
       'vars_get' => { 'wsdl' => 1 }

--- a/modules/exploits/windows/http/hp_nnm_ovas.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovas.rb
@@ -183,11 +183,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
     resp = send_request_raw({'uri' => '/topology/home'}, 5)
     if resp.nil?
-      print_status("No response to request")
-      return Exploit::CheckCode::Safe
+      vprint_status("No response to request")
+      return Exploit::CheckCode::Unknown
     end
 
-    if (resp.body =~ /NNM Release B.07.53/ || resp.body =~ /NNM Release B.07.52/ || resp.body =~ /NNM Release B.07.51/)
+    if (resp.body =~ /NNM Release B\.07\.53/ || resp.body =~ /NNM Release B\.07\.52/ || resp.body =~ /NNM Release B\.07\.51/)
       return Exploit::CheckCode::Appears
     end
 

--- a/modules/exploits/windows/http/httpdx_handlepeer.rb
+++ b/modules/exploits/windows/http/httpdx_handlepeer.rb
@@ -87,7 +87,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     info = http_fingerprint  # check method
     if info and (info =~ /httpdx\/(.*) \(Win32\)/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Detected
     end
     Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/http/httpdx_tolog_format.rb
+++ b/modules/exploits/windows/http/httpdx_tolog_format.rb
@@ -137,7 +137,7 @@ For now, that will have to be done manually.
     if version
       print_status("HTTPDX version detected : #{version}")
       if (version =~ /1\.4/) or (version == "1.5")
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Appears
       end
     end
     Exploit::CheckCode::Safe

--- a/modules/exploits/windows/http/intrasrv_bof.rb
+++ b/modules/exploits/windows/http/intrasrv_bof.rb
@@ -73,8 +73,8 @@ class Metasploit3 < Msf::Exploit::Remote
     sock.put("GET / HTTP/1.0\r\n\r\n")
     res = sock.get_once
 
-    if res =~ /intrasrv 1.0/
-      return Exploit::CheckCode::Vulnerable
+    if res =~ /intrasrv 1\.0/
+      return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/windows/http/kolibri_http.rb
+++ b/modules/exploits/windows/http/kolibri_http.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     info = http_fingerprint
     if info and (info =~ /kolibri-2\.0/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/http/mailenable_auth_header.rb
+++ b/modules/exploits/windows/http/mailenable_auth_header.rb
@@ -48,7 +48,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     info = http_fingerprint  # check method
     if (info =~ /MailEnable/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Detected
     end
     Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/http/mcafee_epolicy_source.rb
+++ b/modules/exploits/windows/http/mcafee_epolicy_source.rb
@@ -71,7 +71,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     banner = sock.get(-1,3)
 
-    if (banner =~ /Spipe\/1.0/)
+    if (banner =~ /Spipe\/1\.0/)
       return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/http/mdaemon_worldclient_form2raw.rb
+++ b/modules/exploits/windows/http/mdaemon_worldclient_form2raw.rb
@@ -72,9 +72,10 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /WDaemon\/6\.8\.[0-5]/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
-      return Exploit::CheckCode::Safe
+
+    return Exploit::CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/windows/http/miniweb_upload_wbem.rb
+++ b/modules/exploits/windows/http/miniweb_upload_wbem.rb
@@ -71,7 +71,8 @@ class Metasploit3 < Msf::Exploit::Remote
         'uri'     => uri
       })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE
-      fail_with(Failure::Unreachable, "#{peer} - Connection failed")
+      vprint_error("Connection failed")
+      return Exploit::CheckCode::Unknown
     end
 
     if !res or res.headers['Server'].empty?
@@ -80,8 +81,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Detected
     end
 
-    return Exploit::CheckCode::Unknown
-
+    return Exploit::CheckCode::Safe
   end
 
   def upload(filename, filedata)

--- a/modules/exploits/windows/http/navicopa_get_overflow.rb
+++ b/modules/exploits/windows/http/navicopa_get_overflow.rb
@@ -60,8 +60,8 @@ class Metasploit3 < Msf::Exploit::Remote
     resp = sock.get_once
     disconnect
 
-    if (resp =~ /2.01 11th September/)
-      return Exploit::CheckCode::Vulnerable
+    if (resp =~ /2\.01 11th September/)
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/http/netdecision_http_bof.rb
+++ b/modules/exploits/windows/http/netdecision_http_bof.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = send_request_cgi({'uri'=>'/'})
     banner = res.headers['Server']
     if banner =~ /NetDecision\-HTTP\-Server\/1\.0/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/windows/http/novell_mdm_lfi.rb
+++ b/modules/exploits/windows/http/novell_mdm_lfi.rb
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown
     elsif v =~ /^2\.6\.[01]/ or v =~ /^2\.7\.0/
       # Conditions based on OSVDB info
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/http/oracle9i_xdb_pass.rb
+++ b/modules/exploits/windows/http/oracle9i_xdb_pass.rb
@@ -61,8 +61,8 @@ class Metasploit3 < Msf::Exploit::Remote
     resp = sock.get_once
     disconnect
 
-    if (resp =~ /9.2.0.1.0/)
-      return Exploit::CheckCode::Vulnerable
+    if (resp =~ /9\.2\.0\.1\.0/)
+      return Exploit::CheckCode::Appears
     end
       return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/http/oracle_endeca_exec.rb
+++ b/modules/exploits/windows/http/oracle_endeca_exec.rb
@@ -95,15 +95,15 @@ class Metasploit3 < Msf::Exploit::Remote
     version_match = res.body.match(/<serverVersion>Oracle Endeca Server ([0-9\.]*) /)
 
     if version_match.nil?
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Safe
     else
       version = version_match[1]
     end
 
-    print_status("#{peer} - Version found: Oracle Endeca Server #{version}")
+    vprint_status("#{peer} - Version found: Oracle Endeca Server #{version}")
 
     if version =~ /7\.4\.0/ and version <= "7.4.0.787"
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/http/psoproxy91_overflow.rb
+++ b/modules/exploits/windows/http/psoproxy91_overflow.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
     sock.put("GET / HTTP/1.0\r\n\r\n")
     banner = sock.get(-1,3)
     if (banner =~ /PSO Proxy 0\.9/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -64,14 +64,16 @@ class Metasploit3 < Msf::Exploit
     begin
       res = send_evil_request(uri, "whoami", 20)
     rescue
-      Exploit::CheckCode::Unknown
+      vprint_error("An error has occured while sending the malicious request")
+      return Exploit::CheckCode::Unknown
     end
     if !res
-      Exploit::CheckCode::Unknown
+      vprint_error("Connection timed out")
+      return Exploit::CheckCode::Unknown
     elsif res.body.include?("Process created")
-      Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable
     else
-      Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe
     end
   end
 

--- a/modules/exploits/windows/http/sap_host_control_cmd_exec.rb
+++ b/modules/exploits/windows/http/sap_host_control_cmd_exec.rb
@@ -394,7 +394,7 @@ class Metasploit3 < Msf::Exploit::Remote
     }, 10)
 
     if (res and res.code == 500 and res.body =~ /Generic error/)
-      return CheckCode::Appears
+      return CheckCode::Vulnerable
     else
       return CheckCode::Safe
     end

--- a/modules/exploits/windows/http/savant_31_overflow.rb
+++ b/modules/exploits/windows/http/savant_31_overflow.rb
@@ -67,7 +67,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     info = http_fingerprint  # check method
     if info and (info =~ /Savant\/3\.1/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/http/servu_session_cookie.rb
+++ b/modules/exploits/windows/http/servu_session_cookie.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if (res =~ /Server: Serv-U\/9\.0\.0\.5/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     elsif (res =~ /Server: Serv-U/)
       return Exploit::CheckCode::Detected
     end

--- a/modules/exploits/windows/http/shoutcast_format.rb
+++ b/modules/exploits/windows/http/shoutcast_format.rb
@@ -65,14 +65,15 @@ class Metasploit3 < Msf::Exploit::Remote
     m = r.body.match(/Network Audio Server\/([^\s]+)\s+([^<]+)<BR/)
     return Exploit::CheckCode::Safe if not m
 
-    print_status("This system is running SHOUTcast #{m[1]} on #{m[2]}")
+    vprint_status("This system is running SHOUTcast #{m[1]} on #{m[2]}")
 
     # SHOUTcast Distributed Network Audio Server/win32 v1.9.2<BR>
     if (m[1] =~ /v1\.([0-8]\.|9\.[0-3])$/)
       if (m[2] == "win32")
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Appears
+      else
+        return Exploit::CheckCode::Detected
       end
-      print_status("Vulnerable version detected, but not a win32 host")
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/http/sonicwall_scrutinizer_sqli.rb
+++ b/modules/exploits/windows/http/sonicwall_scrutinizer_sqli.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = send_request_raw({'uri'=>'/'}) # Check the base path for version regex
     if res and res.body =~ /\<title\>Scrutinizer\<\/title\>/ and
       res.body =~ /\<div id\=\'.+\'\>Scrutinizer 9\.[0-5]\.[0-1]\<\/div\>/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/http/steamcast_useragent.rb
+++ b/modules/exploits/windows/http/steamcast_useragent.rb
@@ -63,8 +63,8 @@ class Metasploit3 < Msf::Exploit::Remote
     res = sock.get(-1, 3)
     disconnect
 
-    if (res =~ /Steamcast\/0.9.75/)
-      return Exploit::CheckCode::Vulnerable
+    if (res =~ /Steamcast\/0\.9\.75/)
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/http/sws_connection_bof.rb
+++ b/modules/exploits/windows/http/sws_connection_bof.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     res = send_request_raw({'uri'=>'/'})
     if res and res.headers['Server'] =~ /PMSoftware\-SWS\/2\.[0-2]/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/http/trackercam_phparg_overflow.rb
+++ b/modules/exploits/windows/http/trackercam_phparg_overflow.rb
@@ -73,8 +73,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if (res and res.body =~ /fsockopen/)
       fp = fingerprint()
-      print_status("Detected a vulnerable TrackerCam installation on #{fp}")
-      return Exploit::CheckCode::Confirmed
+      vprint_status("Detected a vulnerable TrackerCam installation on #{fp}")
+      return Exploit::CheckCode::Detected
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/http/xitami_if_mod_since.rb
+++ b/modules/exploits/windows/http/xitami_if_mod_since.rb
@@ -65,9 +65,11 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /Xitami/)
-      return Exploit::CheckCode::Appears
+      vprint_status("Banner: #{banner}")
+      return Exploit::CheckCode::Detected
     end
-      return Exploit::CheckCode::Safe
+
+    return Exploit::CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/windows/iis/ms03_007_ntdll_webdav.rb
+++ b/modules/exploits/windows/iis/ms03_007_ntdll_webdav.rb
@@ -85,6 +85,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
 
     if (response and response.body =~ /Server Error\(exception/)
+      vprint_status("We've hit a server error (exception)")
       return Exploit::CheckCode::Vulnerable
     end
 
@@ -92,6 +93,7 @@ class Metasploit3 < Msf::Exploit::Remote
     begin
       send_request_raw({'uri' => '/'}, 5)
     rescue
+      vprint_status("The server stopped accepting requests")
       return Exploit::CheckCode::Vulnerable
     end
 

--- a/modules/exploits/windows/imap/eudora_list.rb
+++ b/modules/exploits/windows/imap/eudora_list.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
     targ = auto_target
     disconnect
 
-    return Exploit::CheckCode::Vulnerable if (targ)
+    return Exploit::CheckCode::Appears if (targ)
     return Exploit::CheckCode::Safe
   end
 

--- a/modules/exploits/windows/imap/mailenable_w3c_select.rb
+++ b/modules/exploits/windows/imap/mailenable_w3c_select.rb
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if (banner and banner =~ /MailEnable Service, Version: 0-1\.54/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/imap/mdaemon_fetch.rb
+++ b/modules/exploits/windows/imap/mdaemon_fetch.rb
@@ -51,8 +51,8 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
     disconnect
 
-    if (banner and banner =~ /IMAP4rev1 MDaemon 9.6.4 ready/)
-      return Exploit::CheckCode::Vulnerable
+    if (banner and banner =~ /IMAP4rev1 MDaemon 9\.6\.4 ready/)
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/imap/mercury_login.rb
+++ b/modules/exploits/windows/imap/mercury_login.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if (resp =~ /Mercury\/32 v4\.01[a-b]/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
       return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/imap/mercury_rename.rb
+++ b/modules/exploits/windows/imap/mercury_rename.rb
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if (resp =~ /Mercury\/32 v4\.01a/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
       return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/isapi/ms00_094_pbserver.rb
+++ b/modules/exploits/windows/isapi/ms00_094_pbserver.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
     }, 5)
 
     if (res and res.code == 400)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Detected
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/isapi/rsa_webagent_redirect.rb
+++ b/modules/exploits/windows/isapi/rsa_webagent_redirect.rb
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
     }, -1)
 
     if (r and r.body and r.body =~ /RSA Web Access Authentication/)
-      return Exploit::CheckCode::Detected
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/isapi/w3who_query.rb
+++ b/modules/exploits/windows/isapi/w3who_query.rb
@@ -84,7 +84,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def check
     if auto_target
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/license/calicserv_getconfig.rb
+++ b/modules/exploits/windows/license/calicserv_getconfig.rb
@@ -73,7 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = sock.get_once || ''
     disconnect
     if (res =~ /OS\<([^\>]+)/)
-      print_status("CA License Server reports OS: #{$1}")
+      vprint_status("CA License Server reports OS: #{$1}")
       return Exploit::CheckCode::Detected
     end
     return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/local/always_install_elevated.rb
+++ b/modules/exploits/windows/local/always_install_elevated.rb
@@ -70,24 +70,24 @@ class Metasploit3 < Msf::Exploit::Local
     local_machine_value = registry_getvaldata(hklm,install_elevated)
 
     if local_machine_value.nil?
-      print_error("#{hklm}\\#{install_elevated} does not exist or is not accessible.")
+      vprint_error("#{hklm}\\#{install_elevated} does not exist or is not accessible.")
       return Msf::Exploit::CheckCode::Safe
     elsif local_machine_value == 0
-      print_error("#{hklm}\\#{install_elevated} is #{local_machine_value}.")
+      vprint_error("#{hklm}\\#{install_elevated} is #{local_machine_value}.")
       return Msf::Exploit::CheckCode::Safe
     else
-      print_good("#{hklm}\\#{install_elevated} is #{local_machine_value}.")
+      vprint_good("#{hklm}\\#{install_elevated} is #{local_machine_value}.")
       current_user_value = registry_getvaldata(hkcu,install_elevated)
     end
 
     if current_user_value.nil?
-      print_error("#{hkcu}\\#{install_elevated} does not exist or is not accessible.")
+      vprint_error("#{hkcu}\\#{install_elevated} does not exist or is not accessible.")
       return Msf::Exploit::CheckCode::Safe
     elsif current_user_value == 0
-      print_error("#{hkcu}\\#{install_elevated} is #{current_user_value}.")
+      vprint_error("#{hkcu}\\#{install_elevated} is #{current_user_value}.")
       return Msf::Exploit::CheckCode::Safe
     else
-      print_good("#{hkcu}\\#{install_elevated} is #{current_user_value}.")
+      vprint_good("#{hkcu}\\#{install_elevated} is #{current_user_value}.")
       return Msf::Exploit::CheckCode::Vulnerable
     end
   end

--- a/modules/exploits/windows/local/ikeext_service.rb
+++ b/modules/exploits/windows/local/ikeext_service.rb
@@ -101,7 +101,7 @@ class Metasploit3 < Msf::Exploit::Local
       return Exploit::CheckCode::Safe
     end
 
-    return Exploit::CheckCode::Vulnerable
+    return Exploit::CheckCode::Appears
   end
 
   def check_search_path

--- a/modules/exploits/windows/local/ikeext_service.rb
+++ b/modules/exploits/windows/local/ikeext_service.rb
@@ -88,13 +88,13 @@ class Metasploit3 < Msf::Exploit::Local
 
     case srv_info['Startup']
     when 'Disabled'
-      print_error("Service startup is Disabled, so will be unable to exploit unless account has correct permissions...")
+      vprint_error("Service startup is Disabled, so will be unable to exploit unless account has correct permissions...")
       return Exploit::CheckCode::Safe
     when 'Manual'
-      print_error("Service startup is Manual, so will be unable to exploit unless account has correct permissions...")
+      vprint_error("Service startup is Manual, so will be unable to exploit unless account has correct permissions...")
       return Exploit::CheckCode::Safe
     when 'Auto'
-      print_good("Service is set to Automatically start...")
+      vprint_good("Service is set to Automatically start...")
     end
 
     if check_search_path

--- a/modules/exploits/windows/local/nvidia_nvsvc.rb
+++ b/modules/exploits/windows/local/nvidia_nvsvc.rb
@@ -82,12 +82,13 @@ class Metasploit3 < Msf::Exploit::Local
 
         begin
           if is_running?
-            print_good("Service is running")
+            vprint_good("Service is running")
           else
-            print_error("Service is not running!")
+            vprint_error("Service is not running!")
           end
         rescue RuntimeError => e
-          print_error("Unable to retrieve service status")
+          vprint_error("Unable to retrieve service status")
+          return Exploit::CheckCode::Unknown
         end
 
         if sysinfo['Architecture'] =~ /WOW64/i

--- a/modules/exploits/windows/local/trusted_service_path.rb
+++ b/modules/exploits/windows/local/trusted_service_path.rb
@@ -56,6 +56,7 @@ class Metasploit3 < Msf::Exploit::Local
     if enum_vuln_services.empty?
       return Exploit::CheckCode::Safe
     else
+      # Found service is running system
       return Exploit::CheckCode::Vulnerable
     end
   end

--- a/modules/exploits/windows/lotus/domino_icalendar_organizer.rb
+++ b/modules/exploits/windows/lotus/domino_icalendar_organizer.rb
@@ -26,7 +26,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Author'         =>
         [
           'A. Plaskett',  #Initial discovery, poc
-          'sinn3r',       #Metasploit
+          'sinn3r'        #Metasploit
         ],
       'References'     =>
         [
@@ -34,14 +34,14 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '68040' ],
           [ 'ZDI', '10-177' ],
           [ 'URL', 'http://labs.mwrinfosecurity.com/advisories/lotus_domino_ical_stack_buffer_overflow/' ],
-          [ 'URL', 'http://www-01.ibm.com/support/docview.wss?rs=475&uid=swg21446515' ],
+          [ 'URL', 'http://www-01.ibm.com/support/docview.wss?rs=475&uid=swg21446515' ]
         ],
       'Payload'        =>
         {
           'BadChars' => [*(0x00..0x08)].pack("C*") + [*(0x10..0x18)].pack("C*") + [*(0x1a..0x1f)].pack("C*") + "\x2c" + [*(0x80..0xff)].pack("C*"),
           'EncoderType' => Msf::Encoder::Type::AlphanumMixed,
           'EncoderOptions' => {'BufferRegister'=>'ECX'},
-          'StackAdjustment' => -3500,
+          'StackAdjustment' => -3500
         },
       'DefaultOptions' =>
         {
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
             {
               'Offset'    => 2374,           #Offset to EIP
               'Ret'       => 0x6030582B,     #JMP ECX
-              'MaxBuffer' => 9010,           #Total buffer size
+              'MaxBuffer' => 9010            #Total buffer size
             }
           ],
           [
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
             {
               'Offset'    => 2374,           #Offset to EIP
               'Ret'       => 0x6030582B,     #JMP ECX (Domino\\nnotes.dll)
-              'MaxBuffer' => 9010,           #Total buffer size
+              'MaxBuffer' => 9010            #Total buffer size
             }
           ],
           [
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'EAX'       => 0x7C35287F,     #Initial CALL VirtualProtect addr to align (MSVCR71.dll)
               'EaxOffset' => 2342,           #Offset to EAX
               'RopOffset' => 24,             #Offset to ROP gadgets
-              'MaxBuffer' => 9010,           #Total buffer size
+              'MaxBuffer' => 9010            #Total buffer size
             }
           ],
         ],
@@ -85,7 +85,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           Opt::RPORT(25),
           OptString.new('MAILFROM', [true, 'Valid Lotus Domino mailbox account', '']),
-          OptString.new('MAILTO',   [true, 'Valid Lotus Domino mailbox account', '']),
+          OptString.new('MAILTO',   [true, 'Valid Lotus Domino mailbox account', ''])
         ], self.class)
   end
 
@@ -94,8 +94,8 @@ class Metasploit3 < Msf::Exploit::Remote
     banner = (sock.get_once(-1,5) || '').chomp
     disconnect
 
-    if banner =~ /Lotus Domino Release 8.5/
-      return Exploit::CheckCode::Vulnerable
+    if banner =~ /Lotus Domino Release 8\.5/
+      return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe
     end

--- a/modules/exploits/windows/misc/altiris_ds_sqli.rb
+++ b/modules/exploits/windows/misc/altiris_ds_sqli.rb
@@ -131,14 +131,14 @@ Processor-Speed=#{processor_speed}
       return Exploit::CheckCode::Safe
     end
 
-    print_status "#{rhost}:#{rport} - Altiris DS Version '#{version}'"
+    vprint_status "#{rhost}:#{rport} - Altiris DS Version '#{version}'"
 
     minor = $1.to_i
     build = $2.to_i
 
     if minor == 8
       if build == 206 || build == 282 || build == 378
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Appears
       elsif build < 390
         return Exploit::CheckCode::Appears
       end

--- a/modules/exploits/windows/misc/bakbone_netvault_heap.rb
+++ b/modules/exploits/windows/misc/bakbone_netvault_heap.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       if ver > 0
         print_status("Detected NetVault Build #{ver}")
-        return Exploit::CheckCode::Detected
+        return Exploit::CheckCode::Appears
       end
     end
 

--- a/modules/exploits/windows/misc/fb_cnct_group.rb
+++ b/modules/exploits/windows/misc/fb_cnct_group.rb
@@ -66,7 +66,8 @@ class Metasploit3 < Msf::Exploit::Remote
     begin
       connect
     rescue
-      return Exploit::CheckCode::Safe
+      vprint_error("Unable to get a connection")
+      return Exploit::CheckCode::Unknown
     end
 
     filename =  "C:\\#{rand_text_alpha(12)}.fdb"
@@ -99,7 +100,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Detected
     end
 
-    return Exploit::CheckCode::Unknown
+    return Exploit::CheckCode::Safe
   end
 
   def stack_pivot_rop_chain

--- a/modules/exploits/windows/misc/hp_dataprotector_crs.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_crs.rb
@@ -153,9 +153,11 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     if fingerprint =~ /HP Data Protector A\.06\.20: INET, internal build 370/
-      return Exploit::CheckCode::Vulnerable
+      # More likely to be exploitable
+      return Exploit::CheckCode::Appears
     elsif fingerprint =~ /HP Data Protector A\.07\.00: INET, internal build 72/
-      return Exploit::CheckCode::Vulnerable
+      # More likely to be exploitable
+      return Exploit::CheckCode::Appears
     elsif fingerprint =~ /HP Data Protector A\.07\.00/
       return Exploit::CheckCode::Appears
     elsif fingerprint =~ /HP Data Protector A\.07\.01/

--- a/modules/exploits/windows/misc/hp_dataprotector_crs.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_crs.rb
@@ -139,16 +139,17 @@ class Metasploit3 < Msf::Exploit::Remote
     fingerprint = get_fingerprint
 
     if fingerprint.nil?
+      vprint_error("Unable to fingerprint")
       return Exploit::CheckCode::Unknown
     end
 
     port = get_crs_port
 
     if port.nil?
-      print_status("HP Data Protector version #{fingerprint}")
-      print_error("But CRS port not found")
+      vprint_status("HP Data Protector version #{fingerprint}")
+      vprint_error("But CRS port not found")
     else
-      print_status("CRS running on port #{port}/TCP, HP Data Protector version #{fingerprint}")
+      vprint_status("CRS running on port #{port}/TCP, HP Data Protector version #{fingerprint}")
     end
 
     if fingerprint =~ /HP Data Protector A\.06\.20: INET, internal build 370/

--- a/modules/exploits/windows/misc/hp_omniinet_1.rb
+++ b/modules/exploits/windows/misc/hp_omniinet_1.rb
@@ -115,7 +115,7 @@ class Metasploit3 < Msf::Exploit::Remote
       major = version[1].to_i
       minor = version[2].to_i
       if ((major < 6) or (major == 6 and minor < 11))
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Appears
       end
 
       if ((major > 6) or (major == 6 and minor >= 11))

--- a/modules/exploits/windows/misc/hp_omniinet_2.rb
+++ b/modules/exploits/windows/misc/hp_omniinet_2.rb
@@ -115,7 +115,7 @@ class Metasploit3 < Msf::Exploit::Remote
       major = version[1].to_i
       minor = version[2].to_i
       if ((major < 6) or (major == 6 and minor < 11))
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Appears
       end
 
       if ((major > 6) or (major == 6 and minor >= 11))

--- a/modules/exploits/windows/misc/hp_omniinet_3.rb
+++ b/modules/exploits/windows/misc/hp_omniinet_3.rb
@@ -80,7 +80,7 @@ class Metasploit3 < Msf::Exploit::Remote
       major = version[1].to_i
       minor = version[2].to_i
       if ((major < 6) or (major == 6 and minor < 11))
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Appears
       end
 
       if ((major > 6) or (major == 6 and minor >= 11))

--- a/modules/exploits/windows/misc/hp_operations_agent_coda_34.rb
+++ b/modules/exploits/windows/misc/hp_operations_agent_coda_34.rb
@@ -82,6 +82,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = ping
 
     if not res
+      vprint_error("No response from target")
       return Exploit::CheckCode::Unknown
     end
 
@@ -92,9 +93,7 @@ class Metasploit3 < Msf::Exploit::Remote
     if res =~ /server:.*coda 11.(\d+)/
       minor = $1.to_i
       if minor < 2
-        return Exploit::CheckCode::Vulnerable
-      else
-        return Exploit::CheckCode::Safe
+        return Exploit::CheckCode::Appears
       end
     end
 

--- a/modules/exploits/windows/misc/hp_operations_agent_coda_8c.rb
+++ b/modules/exploits/windows/misc/hp_operations_agent_coda_8c.rb
@@ -82,6 +82,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = ping
 
     if not res
+      vprint_error("No response from target")
       return Exploit::CheckCode::Unknown
     end
 
@@ -92,7 +93,7 @@ class Metasploit3 < Msf::Exploit::Remote
     if res =~ /server:.*coda 11.(\d+)/
       minor = $1.to_i
       if minor < 2
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Appears
       else
         return Exploit::CheckCode::Safe
       end

--- a/modules/exploits/windows/misc/lianja_db_net.rb
+++ b/modules/exploits/windows/misc/lianja_db_net.rb
@@ -54,7 +54,8 @@ class Metasploit3 < Msf::Exploit::Remote
     begin
       connect
     rescue
-      return Exploit::CheckCode::Safe
+      vprint_error("Unable to connect")
+      return Exploit::CheckCode::Unknown
     end
     sock.put("db_net")
     if sock.recv(4) =~ /\d{1,5}/

--- a/modules/exploits/windows/misc/poisonivy_bof.rb
+++ b/modules/exploits/windows/misc/poisonivy_bof.rb
@@ -113,11 +113,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if datalen == lensig
       if response[0, 16] == sig
-        print_status("Password appears to be \"admin\"")
+        vprint_status("Password appears to be \"admin\"")
+        return Exploit::CheckCode::Appears
       else
-        print_status("Unknown password - Bruteforce target or RANDHEADER can be tried and exploit launched until success.")
+        vprint_status("Unknown password - Bruteforce target or RANDHEADER can be tried and exploit launched until success.")
+        return Exploit::CheckCode::Detected
       end
-      return Exploit::CheckCode::Vulnerable
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin.rb
+++ b/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin.rb
@@ -262,14 +262,14 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("@@version returned:\n\t" + version)
 
     # Any others?
-    return Exploit::CheckCode::Vulnerable if (version =~ /8\.00\.194/)
-    return Exploit::CheckCode::Vulnerable if (version =~ /8\.00\.384/)
-    return Exploit::CheckCode::Vulnerable if (version =~ /8\.00\.534/)
-    return Exploit::CheckCode::Vulnerable if (version =~ /8\.00\.760/)
-    return Exploit::CheckCode::Vulnerable if (version =~ /8\.00\.2039/)
-    return Exploit::CheckCode::Vulnerable if (version =~ /9\.00\.1399\.06/)
-    return Exploit::CheckCode::Vulnerable if (version =~ /9\.00\.2047\.00/)
-    return Exploit::CheckCode::Vulnerable if (version =~ /9\.00\.3042\.00/)
+    return Exploit::CheckCode::Appears if (version =~ /8\.00\.194/)
+    return Exploit::CheckCode::Appears if (version =~ /8\.00\.384/)
+    return Exploit::CheckCode::Appears if (version =~ /8\.00\.534/)
+    return Exploit::CheckCode::Appears if (version =~ /8\.00\.760/)
+    return Exploit::CheckCode::Appears if (version =~ /8\.00\.2039/)
+    return Exploit::CheckCode::Appears if (version =~ /9\.00\.1399\.06/)
+    return Exploit::CheckCode::Appears if (version =~ /9\.00\.2047\.00/)
+    return Exploit::CheckCode::Appears if (version =~ /9\.00\.3042\.00/)
     return Exploit::CheckCode::Safe
   end
 

--- a/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin_sqli.rb
+++ b/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin_sqli.rb
@@ -264,14 +264,14 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("@@version returned:\n\t" + version)
 
     # Any others?
-    return Exploit::CheckCode::Vulnerable if (version =~ /8\.00\.194/)
-    return Exploit::CheckCode::Vulnerable if (version =~ /8\.00\.384/)
-    return Exploit::CheckCode::Vulnerable if (version =~ /8\.00\.534/)
-    return Exploit::CheckCode::Vulnerable if (version =~ /8\.00\.760/)
-    return Exploit::CheckCode::Vulnerable if (version =~ /8\.00\.2039/)
-    return Exploit::CheckCode::Vulnerable if (version =~ /9\.00\.1399\.06/)
-    return Exploit::CheckCode::Vulnerable if (version =~ /9\.00\.2047\.00/)
-    return Exploit::CheckCode::Vulnerable if (version =~ /9\.00\.3042\.00/)
+    return Exploit::CheckCode::Appears if (version =~ /8\.00\.194/)
+    return Exploit::CheckCode::Appears if (version =~ /8\.00\.384/)
+    return Exploit::CheckCode::Appears if (version =~ /8\.00\.534/)
+    return Exploit::CheckCode::Appears if (version =~ /8\.00\.760/)
+    return Exploit::CheckCode::Appears if (version =~ /8\.00\.2039/)
+    return Exploit::CheckCode::Appears if (version =~ /9\.00\.1399\.06/)
+    return Exploit::CheckCode::Appears if (version =~ /9\.00\.2047\.00/)
+    return Exploit::CheckCode::Appears if (version =~ /9\.00\.3042\.00/)
     return Exploit::CheckCode::Safe
   end
 

--- a/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
+++ b/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
     datastore['RPORT'] = tmp_rport
     if res and res.body =~ /\<title\>Scrutinizer\<\/title\>/ and
       res.body =~ /\<div id\=\'.+\'\>Scrutinizer 9\.[0-5]\.[0-2]\<\/div\>/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/novell/netiq_pum_eval.rb
+++ b/modules/exploits/windows/novell/netiq_pum_eval.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'data'    => data,
       })
 
-    if res and res.body =~ /onResult/ and res.body =~ /Invalid user name or password/ and res.body =~ /2.3.1/
+    if res and res.body =~ /onResult/ and res.body =~ /Invalid user name or password/ and res.body =~ /2\.3\.1/
       return Exploit::CheckCode::Vulnerable
     elsif res and res.body =~ /onResult/ and res.body =~ /Invalid user name or password/
       return Exploit::CheckCode::Detected

--- a/modules/exploits/windows/novell/netiq_pum_eval.rb
+++ b/modules/exploits/windows/novell/netiq_pum_eval.rb
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
       })
 
     if res and res.body =~ /onResult/ and res.body =~ /Invalid user name or password/ and res.body =~ /2\.3\.1/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     elsif res and res.body =~ /onResult/ and res.body =~ /Invalid user name or password/
       return Exploit::CheckCode::Detected
     end

--- a/modules/exploits/windows/oracle/client_system_analyzer_upload.rb
+++ b/modules/exploits/windows/oracle/client_system_analyzer_upload.rb
@@ -113,7 +113,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Uploading the CSA#{file_name}.txt file")
     res = upload_file(data)
     if not res or res.code != 200 or (res.body !~ /posted data was written to placeholder file/ and res.body !~ /csaPostStatus=0/)
-      print_error("The test file could not be uploaded")
+      vprint_error("The test file could not be uploaded")
       return Exploit::CheckCode::Safe
     end
 

--- a/modules/exploits/windows/oracle/tns_arguments.rb
+++ b/modules/exploits/windows/oracle/tns_arguments.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if ( res and res =~ /32-bit Windows: Version 8\.1\.7\.0\.0/ )
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/oracle/tns_arguments.rb
+++ b/modules/exploits/windows/oracle/tns_arguments.rb
@@ -52,23 +52,18 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def check
     connect
-
     version = "(CONNECT_DATA=(COMMAND=VERSION))"
-
     pkt = tns_packet(version)
-
     sock.put(pkt)
-
     sock.get_once
-
     res = sock.get_once(-1, 1)
-
     disconnect
 
-      if ( res and res =~ /32-bit Windows: Version 8\.1\.7\.0\.0/ )
-        return Exploit::CheckCode::Vulnerable
-      end
-        return Exploit::CheckCode::Safe
+    if ( res and res =~ /32-bit Windows: Version 8\.1\.7\.0\.0/ )
+      return Exploit::CheckCode::Vulnerable
+    end
+
+    return Exploit::CheckCode::Safe
   end
 
   def exploit

--- a/modules/exploits/windows/oracle/tns_auth_sesskey.rb
+++ b/modules/exploits/windows/oracle/tns_auth_sesskey.rb
@@ -73,7 +73,8 @@ class Metasploit3 < Msf::Exploit::Remote
   def check
     version = tns_version
     if (not version)
-      fail_with(Failure::Unknown, "Unable to detect the Oracle version!")
+      vprint_error("Unable to detect the Oracle version!")
+      return Exploit::CheckCode::Unknown  
     end
     print_status("Oracle version reply: " + version)
     return Exploit::CheckCode::Vulnerable if (version =~ /32-bit Windows: Version 10\.2\.0\.1\.0/)

--- a/modules/exploits/windows/oracle/tns_auth_sesskey.rb
+++ b/modules/exploits/windows/oracle/tns_auth_sesskey.rb
@@ -76,9 +76,9 @@ class Metasploit3 < Msf::Exploit::Remote
       vprint_error("Unable to detect the Oracle version!")
       return Exploit::CheckCode::Unknown  
     end
-    print_status("Oracle version reply: " + version)
-    return Exploit::CheckCode::Vulnerable if (version =~ /32-bit Windows: Version 10\.2\.0\.1\.0/)
-    return Exploit::CheckCode::Vulnerable if (version =~ /32-bit Windows: Version 10\.2\.0\.4\.0/)
+    vprint_status("Oracle version reply: " + version)
+    return Exploit::CheckCode::Appears if (version =~ /32-bit Windows: Version 10\.2\.0\.1\.0/)
+    return Exploit::CheckCode::Appears if (version =~ /32-bit Windows: Version 10\.2\.0\.4\.0/)
     return Exploit::CheckCode::Safe
   end
 

--- a/modules/exploits/windows/oracle/tns_service_name.rb
+++ b/modules/exploits/windows/oracle/tns_service_name.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if ( res and res =~ /32-bit Windows: Version 8\.1\.7\.0\.0/ )
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/postgres/postgres_payload.rb
+++ b/modules/exploits/windows/postgres/postgres_payload.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if version[:auth]
       print_status "Authentication successful. Version: #{version}"
-      return CheckCode::Vulnerable
+      return CheckCode::Appears # WRITE permission needs to be proven to get CheckCode::Vulnerable
     else
       print_error "Authentication failed. #{version[:preauth] || version[:unknown]}"
       return CheckCode::Safe

--- a/modules/exploits/windows/proxy/ccproxy_telnet_ping.rb
+++ b/modules/exploits/windows/proxy/ccproxy_telnet_ping.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /CCProxy Telnet Service Ready/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Detected
     end
       return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/proxy/qbik_wingate_wwwproxy.rb
+++ b/modules/exploits/windows/proxy/qbik_wingate_wwwproxy.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
     sock.put("GET /\r\n\r\n") # Malformed request to get proxy info
     banner = sock.get_once || ''
     if (banner =~ /Server:\sWinGate\s6.1.1\s\(Build 1077\)/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/scada/indusoft_webstudio_exec.rb
+++ b/modules/exploits/windows/scada/indusoft_webstudio_exec.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if app_info =~ /InduSoft Web Studio v6\.1/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     elsif app_info =~ /InduSoft Web Studio/
       return Exploit::CheckCode::Detected
     end

--- a/modules/exploits/windows/scada/procyon_core_server.rb
+++ b/modules/exploits/windows/scada/procyon_core_server.rb
@@ -74,8 +74,9 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if res =~ /Core Command Interface V1\.(.*)2/
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
+
     return Exploit::CheckCode::Safe
   end
 

--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -1053,12 +1053,12 @@ class Metasploit3 < Msf::Exploit::Remote
       connect()
       smb_login()
     rescue Rex::ConnectionError => e
-      print_error("Connection failed: #{e.class}: #{e}")
-      return
+      vprint_error("Connection failed: #{e.class}: #{e}")
+      return Msf::Exploit::CheckCode::Unknown
     rescue Rex::Proto::SMB::Exceptions::LoginError => e
       if (e.message =~ /Connection reset/)
-        print_error("Connection reset during login")
-        print_error("This most likely means a previous exploit attempt caused the service to crash")
+        vprint_error("Connection reset during login")
+        vprint_error("This most likely means a previous exploit attempt caused the service to crash")
         return Msf::Exploit::CheckCode::Unknown
       else
         raise e
@@ -1086,7 +1086,8 @@ class Metasploit3 < Msf::Exploit::Remote
     begin
       # Samba doesn't have this handle and returns an ErrorCode
       dcerpc_bind(handle)
-    rescue Rex::Proto::SMB::Exceptions::ErrorCode
+    rescue Rex::Proto::SMB::Exceptions::ErrorCode => e
+      vprint_error("SMB error: #{e.message.to_s}")
       return Msf::Exploit::CheckCode::Safe
     end
 
@@ -1111,7 +1112,7 @@ class Metasploit3 < Msf::Exploit::Remote
     if (error == 0x0052005c) # \R :)
       return Msf::Exploit::CheckCode::Vulnerable
     else
-      print_status("System is not vulnerable (status: 0x%08x)" % error) if error
+      vprint_error("System is not vulnerable (status: 0x%08x)" % error) if error
       return Msf::Exploit::CheckCode::Safe
     end
   end

--- a/modules/exploits/windows/smtp/mailcarrier_smtp_ehlo.rb
+++ b/modules/exploits/windows/smtp/mailcarrier_smtp_ehlo.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if (banner =~ /ESMTP TABS Mail Server for Windows NT/)
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Detected
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/smtp/ypops_overflow1.rb
+++ b/modules/exploits/windows/smtp/ypops_overflow1.rb
@@ -62,11 +62,11 @@ class Metasploit3 < Msf::Exploit::Remote
     banner.gsub!(/\n/, '')
 
     if banner =~ /YahooPOPs! Simple Mail Transfer Service Ready/
-      print_status("Vulnerable SMTP server: #{banner}")
+      vprint_status("Vulnerable SMTP server: #{banner}")
       return Exploit::CheckCode::Detected
     end
 
-    print_status("Unknown SMTP server: #{banner}")
+    vprint_status("Unknown SMTP server: #{banner}")
     return Exploit::CheckCode::Safe
   end
 

--- a/modules/exploits/windows/ssh/freesshd_authbypass.rb
+++ b/modules/exploits/windows/ssh/freesshd_authbypass.rb
@@ -73,8 +73,8 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
     if banner =~ /SSH\-2\.0\-WeOnlyDo/
       version=banner.split(" ")[1]
-      return Exploit::CheckCode::Vulnerable if version =~ /(2\.1\.3|2\.0\.6)/
-      return Exploit::CheckCode::Appears
+      return Exploit::CheckCode::Appears if version =~ /(2\.1\.3|2\.0\.6)/
+      return Exploit::CheckCode::Detected
     end
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/windows/ssh/sysax_ssh_username.rb
+++ b/modules/exploits/windows/ssh/sysax_ssh_username.rb
@@ -75,10 +75,13 @@ class Metasploit3 < Msf::Exploit::Remote
       connect
       banner = sock.get_once(-1,5) || ''
       disconnect
+      vprint_status("Banner: #{banner}")
       if banner =~ /SSH\-2\.0\-SysaxSSH_1\.0/
-        return Exploit::CheckCode::Vulnerable
+        return Exploit::CheckCode::Appears
       end
     rescue
+      vprint_error("An error has occured while trying to read a response from target")
+      return Exploit::CheckCode::Unknown
     end
 
     return Exploit::CheckCode::Safe

--- a/modules/exploits/windows/telnet/gamsoft_telsrv_username.rb
+++ b/modules/exploits/windows/telnet/gamsoft_telsrv_username.rb
@@ -82,12 +82,13 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def check
     connect
-    print_status("Attempting to determine if target is vulnerable...")
+    print_status("Attempting to determine if target is possibly vulnerable...")
     select(nil,nil,nil,7)
     banner = sock.get_once(-1,3) || ''
+    vprint_status("Banner: #{banner}")
 
     if (banner =~ /TelSrv 1\.5/)
-      return Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Appears
     end
     return Exploit::CheckCode::Safe
   end

--- a/spec/msfcli_spec.rb
+++ b/spec/msfcli_spec.rb
@@ -369,7 +369,7 @@ describe Msfcli do
           m = cli.init_modules
           cli.engage_mode(m)
         }
-        stdout.should =~ /failed/
+        stdout.should =~ /#{Msf::Exploit::CheckCode::Unknown[1].to_s}/
       end
 
       it "should warn my auxiliary module isn't supported by mode 'p' (show payloads)" do

--- a/spec/msfcli_spec.rb
+++ b/spec/msfcli_spec.rb
@@ -369,7 +369,7 @@ describe Msfcli do
           m = cli.init_modules
           cli.engage_mode(m)
         }
-        stdout.should =~ /#{Msf::Exploit::CheckCode::Unknown[1].to_s}/
+        stdout.should =~ /#{Msf::Exploit::CheckCode::Unknown[1]}/
       end
 
       it "should warn my auxiliary module isn't supported by mode 'p' (show payloads)" do

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -57,17 +57,17 @@ class Msftidy
   ##
 
   def warn(txt, line=0)
-    line_msg = (line>0) ? ":#{line.to_s}" : ''
+    line_msg = (line>0) ? ":#{line}" : ''
     puts "#{@full_filepath}#{line_msg} - [#{'WARNING'.yellow}] #{txt}"
   end
 
   def error(txt, line=0)
-    line_msg = (line>0) ? ":#{line.to_s}" : ''
+    line_msg = (line>0) ? ":#{line}" : ''
     puts "#{@full_filepath}#{line_msg} - [#{'ERROR'.red}] #{txt}"
   end
 
   def fixed(txt, line=0)
-    line_msg = (line>0) ? ":#{line.to_s}" : ''
+    line_msg = (line>0) ? ":#{line}" : ''
     puts "#{@full_filepath}#{line_msg} - [#{'FIXED'.green}] #{txt}"
   end
 
@@ -389,7 +389,7 @@ class Msftidy
       end
 
       if (ln.length > LONG_LINE_LENGTH)
-        warn("Line exceeding #{LONG_LINE_LENGTH.to_s} bytes", idx)
+        warn("Line exceeding #{LONG_LINE_LENGTH} bytes", idx)
       end
 
       if ln =~ /[ \t]$/
@@ -440,7 +440,7 @@ class Msftidy
   def check_vuln_codes
     checkcode = @source.scan(/(Exploit::)?CheckCode::(\w+)/).flatten[1]
     if checkcode and checkcode !~ /^Unknown|Safe|Detected|Appears|Vulnerable|Unsupported$/
-      error("Unrecognized checkcode: #{checkcode.to_s}")
+      error("Unrecognized checkcode: #{checkcode}")
     end
   end
 

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -437,6 +437,13 @@ class Msftidy
     }
   end
 
+  def check_vuln_codes
+    checkcode = @source.scan(/(Exploit::)?CheckCode::(\w+)/).flatten[1]
+    if checkcode and checkcode !~ /^Unknown|Safe|Detected|Appears|Vulnerable|Unsupported$/
+      error("Unrecognized checkcode: #{checkcode.to_s}")
+    end
+  end
+
   private
 
   def load_file(file)
@@ -466,6 +473,7 @@ def run_checks(full_filepath)
   tidy.check_lines
   tidy.check_snake_case_filename
   tidy.check_comment_splat
+  tidy.check_vuln_codes
 end
 
 ##


### PR DESCRIPTION
This PR updates all existing checks found in exploits to follow the new guidelines:
https://github.com/rapid7/metasploit-framework/wiki/How-to-write-a-check()-method

Before you actually decide to merge this PR, make sure #2894 is merged first. That one updates the API documentation about how check codes are used.
## Verification Steps:

Obviously there's a lot of files, will take time to review. Make sure to do:
- [x] Run msfconsole, and make sure no modules are broken.
- [x] Run msftidy and look for bad check codes, like so: `tools/msftidy.rb modules/exploits/ |grep checkcode`
