### PR TITLE
Add support to scan a range of IPs for the check command

### DIFF
--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -57,7 +57,7 @@ module ModuleCommandDispatcher
       end
 
       # Restore the original rhost if set
-      mod.datastore['RHOST'] = last_rhost_opt if last_rhost_opt
+      mod.datastore['RHOST'] = last_rhost_opt
     end
   end
 
@@ -81,13 +81,15 @@ module ModuleCommandDispatcher
     rescue ::Interrupt
       raise $!
     rescue ::Exception => e
-      print_error("#{rhost}:#{rport} - Exploit check failed: #{e.class} #{e}")
       if(e.class.to_s != 'Msf::OptionValidateError')
+        print_error("Exploit check failed: #{e.class} #{e}")
         print_error("Call stack:")
         e.backtrace.each do |line|
           break if line =~ /lib.msf.base.simple/
           print_error("  #{line}")
         end
+      else
+        print_error("#{rhost}:#{rport} - Exploit check failed: #{e.class} #{e}")
       end
     end
   end

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -51,13 +51,15 @@ module ModuleCommandDispatcher
     else
       # Check a range
       last_rhost_opt = mod.rhost
-      hosts.each do |ip|
-        mod.datastore['RHOST'] = ip
-        check_simple
+      begin
+        hosts.each do |ip|
+          mod.datastore['RHOST'] = ip
+          check_simple
+        end
+      ensure
+        # Restore the original rhost if set
+        mod.datastore['RHOST'] = last_rhost_opt
       end
-
-      # Restore the original rhost if set
-      mod.datastore['RHOST'] = last_rhost_opt
     end
   end
 


### PR DESCRIPTION
This allows the check command to scan multiple hosts. It is related to the following redmine ticket:
http://dev.metasploit.com/redmine/issues/8737

It is also related to these pull requests: #2894, #2896, and #2905. They're all part of the feature package.
### Basic Usage Example:

```
msf> use exploit/windows/smb/ms08_067_netapi 
msf exploit(ms08_067_netapi) > check 192.168.0.0/24
```
### Verification 1: Make sure an exploit check can scan multiple hosts:
- [x] Start up msfconsole
- [x] Use the ms08-067 module for testing: `use exploit/windows/smb/ms08_067_netapi`
- [x] Supply an IP range: `check [IP range]`
- [x] Confirm that the module is indeed scanning a range of hosts.
### Verification 2: Make sure msfconsole remembers the last RHOST datastore option if previously specified:
- [x] Start up msfconsole
- [x] Use the ms08-067 module for testing: `use exploit/windows/smb/ms08_067_netapi`
- [x] Set a fake RHOST: `set RHOST [IP]`
- [x] Supply an IP range: `check [IP range]`
- [x] Press [Ctrl]+[C] to abort the scan.
- [x] Enter `show options`
- [ ] Confirm that the RHOST option is the same one you set.
### Verification 3: Make sure msfconsole can still scan a single host:
- [x] Start up msfconsole
- [x] Use the ms08-067 module for testing: `use exploit/windows/smb/ms08_067_netapi`
- [x] `set RHOST [IP]`
- [x] `check`
- [x] Confirm that it's scanning the IP you want
### Verification 4: Make sure the same feature works for an auxiliary module:
- [x] Make sure you have a fake web server for testing for this. For example: `ruby -run -e httpd . -p 8181`
- [x] Do `use auxiliary/dos/http/nodejs_pipelining`
- [x] Do `check [IP]`
- [x] Confirm that the check works

Note: Without the #2905 patch, you will see a lot of output while scanning multiple IPs. This is normal.
