### PR TITLE
Add a defined? check to fix older versions of OpenSSL.

### DIFF
--- a/lib/rex/socket/ssl_tcp_server.rb
+++ b/lib/rex/socket/ssl_tcp_server.rb
@@ -154,11 +154,15 @@ module Rex::Socket::SslTcpServer
     ctx.cert = cert
     ctx.options = 0
 
-    # enable/disable the SSL/TLS-level compression
-    if params.ssl_compression
-      ctx.options &= ~OpenSSL::SSL::OP_NO_COMPRESSION
-    else
-      ctx.options |= OpenSSL::SSL::OP_NO_COMPRESSION
+
+    # Older versions of OpenSSL do not export the OP_NO_COMPRESSION symbol
+    if defined?(OpenSSL::SSL::OP_NO_COMPRESSION)
+      # enable/disable the SSL/TLS-level compression
+      if params.ssl_compression
+        ctx.options &= ~OpenSSL::SSL::OP_NO_COMPRESSION
+      else
+        ctx.options |= OpenSSL::SSL::OP_NO_COMPRESSION
+      end
     end
 
     ctx.session_id_context = Rex::Text.rand_text(16)


### PR DESCRIPTION
Older versions of OpenSSL did not export the OP_NO_COMPRESSION constant, so users running metasploit on systems with old copies of openssl would throw a NameError since the constant did not exist.
#### Verification
- [ ] Run a browser exploit with SSL=true, ensure that the page is served correctly
