### PR TITLE
[FixRM #8749] - Make spawn_meterpreter respect lport/lhost options

### DIFF
--- a/scripts/shell/spawn_meterpreter.rb
+++ b/scripts/shell/spawn_meterpreter.rb
@@ -35,7 +35,7 @@ end
 #
 lhost = framework.datastore['LHOST']
 unless lhost
-  lhost = Rex::Socket.source_address('50.50.50.50')
+  lhost = Rex::Socket.source_address
 end
 
 #


### PR DESCRIPTION
[FixRM #8749] Basically the spawn_meterpreter script doesn't actually allow the user to set their own LHOST/LPORT datastore options, because they come from the session object, not from the active module or the framework object.

Issue originally found by Dennis Distler.

The fix is to allow the user to config them from framework. But if they forget to do this (because naturally people probably assume that active module datastore options are the same as the ones set in framework), then for LHOST we default to whatever we get from Rex::Socket.source_address. As for LPORT, we'll pick a one that's not used by any of the sessions.

Bug ticket: http://dev.metasploit.com/redmine/issues/8749
### To reproduce the issue:
- [x] Create a windows/shell_reverse_tcp executable
- [x] Configure a handler for windows/shell_reverse_tcp, with option: `exitonsession false`.
- [x] `run -j`, and make sure you have a session. Assuming this is session 1 for you.
- [x] Run `sessions -u 1`
- [x] Confirm that you end up getting another shell session, and not a meterpreter session (this is because the same lhost and lport are reused)
### To verify the patch:
- [x] Setup the payload/handler exactly the same as above
- [x] Confirm that instead of getting another shell session, you should get a meterpreter session.
