### PR TITLE
Fix "poorly designed argument list" msftidy warnings

### DIFF
--- a/modules/auxiliary/scanner/h323/h323_version.rb
+++ b/modules/auxiliary/scanner/h323/h323_version.rb
@@ -377,7 +377,7 @@ class Metasploit3 < Msf::Auxiliary
     vendor_id = opts[:vendor_id]
     callee_host = opts[:callee_host]
     callee_port = opts[:callee_port]
-    caller_host = opts[caller_host]
+    caller_host = opts[:caller_host]
     caller_port = opts[:caller_port]
     conf_guid = opts[:conf_guid]
     call_guid = opts[:call_guid]

--- a/modules/auxiliary/scanner/h323/h323_version.rb
+++ b/modules/auxiliary/scanner/h323/h323_version.rb
@@ -51,7 +51,17 @@ class Metasploit3 < Msf::Auxiliary
     conf_guid   = Rex::Text.rand_text(16)
     call_guid   = Rex::Text.rand_text(16)
 
-    pkt_setup = h323_setup_call(caller_name, h323_id, vendor_id, callee_host, callee_port, caller_host, caller_port, conf_guid, call_guid)
+    pkt_setup = h323_setup_call({
+      :caller_name => caller_name,
+      :h323_id => h323_id,
+      :vendor_id => vendor_id,
+      :callee_host => callee_host,
+      :callee_port => callee_port,
+      :caller_host => caller_host,
+      :caller_port => caller_port,
+      :conf_guid => conf_guid,
+      :call_guid => call_guid
+    })
 
     res = sock.put(pkt_setup) rescue nil
     if not res
@@ -88,7 +98,17 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     # Make sure the call was shut down cleanly
-    pkt_release = h323_release_call(caller_name, h323_id, vendor_id, callee_host, callee_port, caller_host, caller_port, conf_guid, call_guid)
+    pkt_release = h323_release_call({
+      :caller_name => caller_name,
+      :h323_id => h323_id,
+      :vendor_id => vendor_id,
+      :callee_host => callee_host,
+      :callee_port => callee_port,
+      :caller_host => caller_host,
+      :caller_port => caller_port,
+      :conf_guid => conf_guid,
+      :call_guid => call_guid
+    })
     sock.put(pkt_release) rescue nil
 
     # End timeout block
@@ -352,7 +372,16 @@ class Metasploit3 < Msf::Auxiliary
   #
   # This is ugly. Doing it properly requires a PER capable ASN.1 encoder, which is overkill for this task
   #
-  def create_user_info(h323_id, vendor_id, callee_host, callee_port, caller_host, caller_port, conf_guid, call_guid)
+  def create_user_info(opts = {})
+    h323_id = opts[:h323_id]
+    vendor_id = opts[:vendor_id]
+    callee_host = opts[:callee_host]
+    callee_port = opts[:callee_port]
+    caller_host = opts[caller_host]
+    caller_port = opts[:caller_port]
+    conf_guid = opts[:conf_guid]
+    call_guid = opts[:call_guid]
+
     buff = "\x05" # Protocol descriminator: X.208/X.209 coded user information
 
     buff << "\x20\xa8\x06\x00\x08\x91\x4a\x00\x06\x01\x40\x02"
@@ -539,7 +568,17 @@ class Metasploit3 < Msf::Auxiliary
     "\x02\x80\x01\x00"
   end
 
-  def h323_release_call(caller_name, h323_id, vendor_id, callee_host, callee_port, caller_host, caller_port, conf_guid, call_guid)
+  def h323_release_call(opts = {})
+    caller_name = opts[:caller_name]
+    h323_id = opts[:h323_id]
+    vendor_id = opts[:vendor_id]
+    callee_host = opts[:callee_host]
+    callee_port = opts[:callee_port]
+    caller_host = opts[:caller_host]
+    caller_port = opts[:caller_port]
+    conf_guid = opts[:conf_guid]
+    call_guid = opts[:call_guid]
+
     encap_tpkt(3,
       encap_q225_release(
         create_ie_display(caller_name) +
@@ -550,13 +589,32 @@ class Metasploit3 < Msf::Auxiliary
     )
   end
 
-  def h323_setup_call(caller_name, h323_id, vendor_id, callee_host, callee_port, caller_host, caller_port, conf_guid, call_guid)
+  def h323_setup_call(opts = {})
+    caller_name = opts[:caller_name]
+    h323_id = opts[:h323_id]
+    vendor_id = opts[:vendor_id]
+    callee_host = opts[:callee_host]
+    callee_port = opts[:callee_port]
+    caller_host = opts[:caller_host]
+    caller_port = opts[:caller_port]
+    conf_guid = opts[:conf_guid]
+    call_guid = opts[:call_guid]
+
     encap_tpkt(3,
       encap_q225_setup(
         create_ie_bearer_capability() +
         create_ie_display(caller_name) +
         create_ie_user_user(
-          create_user_info( h323_id, vendor_id, callee_host, callee_port, caller_host, caller_port, conf_guid, call_guid )
+          create_user_info({
+            :h323_id => h323_id,
+            :vendor_id => vendor_id,
+            :callee_host => callee_host,
+            :callee_port => callee_port,
+            :caller_host => caller_host,
+            :caller_port => caller_port,
+            :conf_guid => conf_guid,
+            :call_guid => call_guid
+          })
         )
       )
     )

--- a/modules/auxiliary/scanner/h323/h323_version.rb
+++ b/modules/auxiliary/scanner/h323/h323_version.rb
@@ -100,13 +100,6 @@ class Metasploit3 < Msf::Auxiliary
     # Make sure the call was shut down cleanly
     pkt_release = h323_release_call({
       :caller_name => caller_name,
-      :h323_id => h323_id,
-      :vendor_id => vendor_id,
-      :callee_host => callee_host,
-      :callee_port => callee_port,
-      :caller_host => caller_host,
-      :caller_port => caller_port,
-      :conf_guid => conf_guid,
       :call_guid => call_guid
     })
     sock.put(pkt_release) rescue nil
@@ -570,13 +563,6 @@ class Metasploit3 < Msf::Auxiliary
 
   def h323_release_call(opts = {})
     caller_name = opts[:caller_name]
-    h323_id = opts[:h323_id]
-    vendor_id = opts[:vendor_id]
-    callee_host = opts[:callee_host]
-    callee_port = opts[:callee_port]
-    caller_host = opts[:caller_host]
-    caller_port = opts[:caller_port]
-    conf_guid = opts[:conf_guid]
     call_guid = opts[:call_guid]
 
     encap_tpkt(3,

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -514,7 +514,6 @@ class Metasploit3 < Msf::Exploit::Remote
     session = opts[:session]
     app_base = opts[:app_base]
     jsp_name = opts[:jsp_name]
-    target = opts[:target]
     war = opts[:war]
     edition = opts[:edition]
     version = opts[:version]
@@ -846,7 +845,6 @@ class Metasploit3 < Msf::Exploit::Remote
         :session => session,
         :app_base => app_base,
         :jsp_name => jsp_name,
-        :target => mytarget,
         :war => war,
         :edition => edition,
         :version => version

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -364,7 +364,16 @@ class Metasploit3 < Msf::Exploit::Remote
   #
   # Return POST data and data length, based on GlassFish edition
   #
-  def get_upload_data(boundary, version, war, app_base, typefield='', status_checkbox='', start='', viewstate='')
+  def get_upload_data(opts = {})
+    boundary = opts[:boundary]
+    version = opts[:version]
+    war = opts[:war]
+    app_base = opts[:app_base]
+    typefield = opts[:typefield]
+    status_checkbox = opts[:status_checkbox]
+    start = opts[:start]
+    viewstate = opts[:viewstate]
+
     data = ''
 
     if version == '3.0'
@@ -501,7 +510,15 @@ class Metasploit3 < Msf::Exploit::Remote
   # Upload our payload, and execute it.  This function will also try to automatically
   # clean up after itself.
   #
-  def upload_exec(session, app_base, jsp_name, target, war, edition, version)
+  def upload_exec(opts = {})
+    session = opts[:session]
+    app_base = opts[:app_base]
+    jsp_name = opts[:jsp_name]
+    target = opts[:target]
+    war = opts[:war]
+    edition = opts[:edition]
+    version = opts[:version]
+
     if version == '2.x' or version == '9.x'
       path = "/applications/upload.jsf?appType=webApp"
       res = send_request(path, @verbs['GET'], session)
@@ -553,7 +570,16 @@ class Metasploit3 < Msf::Exploit::Remote
       ctype = "multipart/form-data; boundary=---------------------------#{boundary}"
     end
 
-    post_data = get_upload_data(boundary, version, war, app_base, typefield, status_checkbox, start, viewstate)
+    post_data = get_upload_data({
+      :boundary => boundary,
+      :version => version,
+      :war => war,
+      :app_base => app_base,
+      :typefield => typefield,
+      :status_checkbox => status_checkbox,
+      :start => start,
+      :viewstate => viewstate
+    })
 
     #Upload our payload
     if version == '2.x' or version == '9.x'
@@ -816,7 +842,15 @@ class Metasploit3 < Msf::Exploit::Remote
 
       #Upload, execute, cleanup, winning
       print_status("Uploading payload...")
-      res = upload_exec(session, app_base, jsp_name, mytarget, war, edition, version)
+      res = upload_exec({
+        :session => session,
+        :app_base => app_base,
+        :jsp_name => jsp_name,
+        :target => mytarget,
+        :war => war,
+        :edition => edition,
+        :version => version
+      })
     else
       print_error("#{my_target_host()} - GlassFish - Failed to authenticate login")
     end

--- a/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
+++ b/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
@@ -74,7 +74,15 @@ class Metasploit3 < Msf::Exploit::Remote
       startxrefs       = pdf_objects[2]
       root_obj         = pdf_objects[3]
 
-      output = basic_social_engineering_exploit(xref_trailers,root_obj,stream,trailers,file_name,exe_name,startxrefs.last)
+      output = basic_social_engineering_exploit({
+        :xref_trailers => xref_trailers,
+        :root_obj => root_obj,
+        :stream => stream,
+        :trailers => trailers,
+        :file_name => file_name,
+        :exe_name => exe_name,
+        :startxref => startxrefs.last
+      })
 
       print_status("Parsing Successful. Creating '#{datastore['FILENAME']}' file...")
       file_create(output)
@@ -165,7 +173,15 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
 
-  def basic_social_engineering_exploit(xref_trailers,root_obj,stream,trailers,file_name,exe_name,startxref)
+  def basic_social_engineering_exploit(opts = {})
+
+    xref_trailers = opts[:xref_trailers]
+    root_obj = opts[:root_obj]
+    stream = opts[:stream]
+    trailers = opts[:trailers]
+    file_name = opts[:file_name]
+    exe_name = opts[:exe_name]
+    startxref = opts[:startxref]
 
     file_name = file_name.split(/\//).pop.to_s
 


### PR DESCRIPTION
#2916 imploded.

```
wvu@kharak:~/metasploit-framework:master$ tools/msftidy.rb modules | grep hash
modules/auxiliary/scanner/h323/h323_version.rb - [WARNING] Poorly designed argument list in 'create_user_info()'. Try a hash.
modules/auxiliary/scanner/h323/h323_version.rb - [WARNING] Poorly designed argument list in 'h323_release_call()'. Try a hash.
modules/auxiliary/scanner/h323/h323_version.rb - [WARNING] Poorly designed argument list in 'h323_setup_call()'. Try a hash.
modules/exploits/multi/http/glassfish_deployer.rb - [WARNING] Poorly designed argument list in 'get_upload_data()'. Try a hash.
modules/exploits/multi/http/glassfish_deployer.rb - [WARNING] Poorly designed argument list in 'upload_exec()'. Try a hash.
modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb - [WARNING] Poorly designed argument list in 'basic_social_engineering_exploit()'. Try a hash.
wvu@kharak:~/metasploit-framework:master$ git checkout -q beug/hash && !!
git checkout -q beug/hash && tools/msftidy.rb modules | grep hash
wvu@kharak:~/metasploit-framework:beug/hash$
```
- [x] Run `tools/msftidy.rb modules | grep hash`
- [x] See the "poorly designed argument list" warning
- [x] Check out the topic branch
- [x] Run `msftidy` again
- [x] Verify that there are no warnings
- [x] Make sure the modules work as before

One step closer to resolving all `msftidy` warnings. Thanks for the simplified fix, @todb-r7.

https://dev.metasploit.com/redmine/issues/8498
