### PR TITLE
Multi-threaded check command, plus aux scanner support

### DIFF
--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -32,6 +32,13 @@ def initialize(info = {})
 end
 
 
+def check
+  nmod = self.replicant
+  code = nmod.check_host(datastore['RHOST'])
+  code
+end
+
+
 #
 # The command handler when launched from the console
 #

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -33,12 +33,11 @@ end
 
 
 def check
-  nmod = self.replicant
+  nmod = replicant
   begin
-    code = nmod.check_host(datastore['RHOST'])
-    return code
+    nmod.check_host(datastore['RHOST'])
   rescue NoMethodError
-    return Exploit::CheckCode::Unsupported
+    Exploit::CheckCode::Unsupported
   end
 end
 

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -34,8 +34,12 @@ end
 
 def check
   nmod = self.replicant
-  code = nmod.check_host(datastore['RHOST'])
-  code
+  begin
+    code = nmod.check_host(datastore['RHOST'])
+    return code
+  rescue NoMethodError
+    return Exploit::CheckCode::Unsupported
+  end
 end
 
 

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -89,7 +89,7 @@ def run
 
     @tl = []
 
-    while (true)
+    loop do
       # Spawn threads for each host
       while (@tl.length < threads_max)
         ip = ar.next_ip

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -104,9 +104,9 @@ class Exploit < Msf::Module
     Vulnerable  = [ 'vulnerable', "The target is vulnerable." ]
 
     #
-    # The exploit does not support the check method.
+    # The module does not support the check method.
     #
-    Unsupported = [ 'unsupported', "This exploit does not support check." ]
+    Unsupported = [ 'unsupported', "This module does not support check." ]
   end
 
   #

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -109,10 +109,7 @@ module ModuleCommandDispatcher
     hosts = Rex::Socket::RangeWalker.new(ip_range_arg)
 
     begin
-      if hosts.ranges.blank? and mod.datastore['RHOST'].blank?
-        print_error("No host specified")
-        return
-      elsif hosts.ranges.blank?
+      if hosts.ranges.blank?
         # Check a single rhost
         check_simple
       else
@@ -153,17 +150,10 @@ module ModuleCommandDispatcher
       end
     rescue ::Rex::ConnectionError, ::Rex::ConnectionProxyError, ::Errno::ECONNRESET, ::Errno::EINTR, ::Rex::TimeoutError, ::Timeout::Error
     rescue ::RuntimeError
+    rescue Msf::OptionValidateError => e
+      print_error("Check failed: #{e.message}")
     rescue ::Exception => e
-      if(e.class.to_s != 'Msf::OptionValidateError')
-        print_error("Check failed: #{e.class} #{e}")
-        print_error("Call stack:")
-        e.backtrace.each do |line|
-          break if line =~ /lib.msf.base.simple/
-          print_error("  #{line}")
-        end
-      else
-        print_error("#{rhost}:#{rport} - Check failed: #{e.class} #{e}")
-      end
+      print_error("#{rhost}:#{rport} - Check failed: #{e.class} #{e}")
     end
   end
 

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -103,7 +103,11 @@ module ModuleCommandDispatcher
       begin
         @tl.first.join
       rescue ::Exception => exception
-        elog("#{exception} #{exception.class}:\n#{exception.backtrace.join("\n")}")
+        if exception.kind_of?(::Interrupt)
+          raise exception
+        else
+          elog("#{exception} #{exception.class}:\n#{exception.backtrace.join("\n")}")
+        end
       end
 
       @tl.delete_if { |t| not t.alive? }

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -58,19 +58,19 @@ module ModuleCommandDispatcher
     @range_done    = 0
     @range_percent = 0
 
-    threads_max = (framework.datastore['THREADS'] || mod.datastore['THREADS'] || nil).to_i
+    threads_max = (framework.datastore['THREADS'] || mod.datastore['THREADS'] || 1).to_i
     @tl = []
 
 
     if Rex::Compat.is_windows
-      if threads_max == 0 or threads_max > 16
+      if threads_max > 16
         vprint_warning("Thread count has been adjusted to 16")
         threads_max = 16
       end
     end
 
     if Rex::Compat.is_cygwin
-      if threads_max == 0 or threads_max > 200
+      if threads_max > 200
         vprint_warning("Thread count has been adjusted to 200")
         threads_max = 200
       end

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -152,7 +152,7 @@ module ModuleCommandDispatcher
         print_error("#{rhost}:#{rport} - Check failed: The state could not be determined.")
       end
     rescue ::Rex::ConnectionError, ::Rex::ConnectionProxyError, ::Errno::ECONNRESET, ::Errno::EINTR, ::Rex::TimeoutError, ::Timeout::Error
-    rescue ::NoMethodError, ::RuntimeError, ::ArgumentError, ::NameError
+    rescue ::RuntimeError
     rescue ::Exception => e
       if(e.class.to_s != 'Msf::OptionValidateError')
         print_error("Check failed: #{e.class} #{e}")

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -78,7 +78,7 @@ module ModuleCommandDispatcher
       end
     end
 
-    while (true)
+    loop do
       while (@tl.length < threads_max)
         ip = hosts.next_ip
         break unless ip

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -42,7 +42,7 @@ module ModuleCommandDispatcher
   def cmd_check(*args)
     defanged?
 
-    ip_range_arg = args.shift || ''
+    ip_range_arg = args.shift || datastore['RHOSTS'] || ''
     hosts = Rex::Socket::RangeWalker.new(ip_range_arg)
 
     if hosts.ranges.blank?

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -64,14 +64,14 @@ module ModuleCommandDispatcher
 
     if Rex::Compat.is_windows
       if threads_max > 16
-        vprint_warning("Thread count has been adjusted to 16")
+        print_warning("Thread count has been adjusted to 16")
         threads_max = 16
       end
     end
 
     if Rex::Compat.is_cygwin
       if threads_max > 200
-        vprint_warning("Thread count has been adjusted to 200")
+        print_warning("Thread count has been adjusted to 200")
         threads_max = 200
       end
     end

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -109,7 +109,10 @@ module ModuleCommandDispatcher
     hosts = Rex::Socket::RangeWalker.new(ip_range_arg)
 
     begin
-      if hosts.ranges.blank?
+      if hosts.ranges.blank? and mod.datastore['RHOST'].blank?
+        print_error("No host specified")
+        return
+      elsif hosts.ranges.blank?
         # Check a single rhost
         check_simple
       else

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -126,6 +126,9 @@ module ModuleCommandDispatcher
         end
       end
     rescue ::Interrupt
+      if @tl
+        @tl.each { |t| t.kill }
+      end
       print_status("Caught interrupt from the console...")
       return
     end

--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -83,10 +83,10 @@ module ModuleCommandDispatcher
         ip = hosts.next_ip
         break unless ip
 
-        @tl << framework.threads.spawn("CheckHost-#{ip}", false, ip.dup) do |tip|
+        @tl << framework.threads.spawn("CheckHost-#{ip}", false, ip.dup) { |tip|
           mod.datastore['RHOST'] = tip
           check_simple
-        end
+        }
       end
 
       break if @tl.length == 0

--- a/modules/auxiliary/scanner/smb/ms08_067_check.rb
+++ b/modules/auxiliary/scanner/smb/ms08_067_check.rb
@@ -4,6 +4,7 @@
 ##
 
 require "msf/core"
+require 'msf/core/module/deprecated'
 
 class Metasploit4 < Msf::Auxiliary
 
@@ -11,6 +12,8 @@ class Metasploit4 < Msf::Auxiliary
   include Msf::Exploit::Remote::SMB
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
+  include Msf::Module::Deprecated
+  deprecated Date.new(2014, 2, 26), "exploit/windows/smb/ms08_067_netapi"
 
   def initialize(info = {})
     super(update_info(info,

--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -1091,7 +1091,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return Msf::Exploit::CheckCode::Safe
     end
 
-    print_status("Verifying vulnerable status... (path: 0x%08x)" % path.length)
+    vprint_status("Verifying vulnerable status... (path: 0x%08x)" % path.length)
 
     stub =
       NDR.uwstring(server) +


### PR DESCRIPTION
This PR addresses the following redmine tickets:
- **Multi-threaded support for check:** http://dev.metasploit.com/redmine/issues/8752
- **Aux scanner support:** http://dev.metasploit.com/redmine/issues/8753
- **Deprecate ms08_067_check:** http://dev.metasploit.com/redmine/issues/8755

It is also the final completion of this ticket:
http://dev.metasploit.com/redmine/issues/8737
## Usage:

Basically there are two ways to use this command:

**Example 1:**

`check [an IP or an IP range]`

**Example 2:**

```
> set [RHOST or RHOSTS] IP
> check
```

If you wish to have more threads, then do:

`set threads [number of threads]`

Please note: Having more threads may result in missed opportunities (meaning that even though a host is vulnerable, it may not be flagged).
## Verifications

Before you begin, please make sure you have the following for testing:
- [x] A Windows XP box vulnerable to ms08-067
- [x] A fake web server: `ruby -run -e httpd . -p 8181`
- [x] Have aux_scanner_check_test.rb for testing: https://gist.github.com/wchen-r7/f297c96881f073336208, you should probably place it under: auxiliary/scanner/http because this is a scanner module.

And now let's move on to these scenarios:

**Scenario 1: With ms08_067_netapi, set the RHOST and run check**
- [x] Start `msfconsole`
- [x] Enter command: `use exploit/windows/smb/ms08_067_netapi`
- [x] Enter command: `set rhost [IP]`
- [x] Enter command: `check`
- [x] You should see the check run and flag your test box as vulnerable

**Scenario 2: With ms08_067_netapi, check multiple hosts**
- [x] Start `msfconsole`
- [x] Enter command: `use exploit/windows/smb/ms08_067_netapi`
- [x] Enter command: `check [range]` (keep the range small or it will run for a long time)
- [x] You should see the check run, and eventually flag your test box as vulnerable

**Scenario 3: With ms08_067_netapi, set threads, and run multiple hosts**
- [x] Start `msfconsole`
- [x] Enter command: `use exploit/windows/smb/ms08_067_netapi`
- [x] Enter command: `set threads 10`
- [x] Enter command: `check [range]` (ideally try to keep the range small for faster testing)
- [x] You should see the check to run faster.
- [x] You should also see your test box flagged as vulnerable. However, if you set the threads too high, you might not see that.

**Scenario 4: With ms08_067_netapi, abort scanning while on a multi-threaded scan**
- [x] Start `msfconsole`
- [x] Enter command: `use exploit/windows/smb/ms08_067_netapi`
- [x] Enter command: `set threads 10`
- [x] Enter command: `check [range]` (ideally try to keep the range small for faster testing)
- [x] When the check starts to run, press [CTRL]+[C] to abort
- [x] You should see "Caught interrupt from the console", and no more scan messages.

**Scenario 5: With ms08_067_netapi, run check without any arguments**
- [x] Start `msfconsole`
- [x] Enter command: `use exploit/windows/smb/ms08_067_netapi`
- [x] Enter command: `check`
- [x] You should see an option validation error about "RHOST"

**Scenario 6: Run nodejs_pipelining.rb against the fake web server**
- [x] Start `msfconsole`
- [x] Enter command: `use auxiliary/dos/http/nodejs_pipelining`
- [x] Enter command: `set rport [fake web server PORT]`
- [x] Enter command: `check [fake web server IP]`
- [x] You should see a check message

**Scenario 7: Run aux_scanner_check_test against the web server**
- [x] Start `msfconsole`
- [x] Enter command: `use [path to aux_scanner_check_test.rb]`
- [x] Enter command: `set rport [fake web server rport]`
- [x] Enter command: `check [web server IP]`
- [x] You should see a check message

**Scenario 8: With aux_scanner_check_test, run check without any arguments**
- [x] Start `msfconsole`
- [x] Enter command: `use [path to aux_scanner_check_test.rb]`
- [x] Enter command: `check`
- [x] You should see an option validation error about "RHOSTS"

**Scenario 9: Run a module that does not support check at all**
- [x] Start `msfconsole`
- [x] Enter command: `use auxiliary/scanner/http/soap_xml`
- [x] Enter command: `set rhosts [IP]`
- [x] Enter command: `check`
- [x] You should see: "This module does not support check."
