### PR TITLE
Fix in_super-reliant msftidy checks

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -95,7 +95,7 @@ class Msftidy
     in_refs  = false
 
     @source.each_line do |line|
-      if !in_super and line =~ /[\n\t]+super\(/
+      if !in_super and line =~ /\s+super\(/
         in_super = true
       elsif in_super and line =~ /[[:space:]]*def \w+[\(\w+\)]*/
         in_super = false
@@ -204,7 +204,7 @@ class Msftidy
       #
       # Mark our "super" code block
       #
-      if !in_super and line =~ /[\n\t]+super\(/
+      if !in_super and line =~ /\s+super\(/
         in_super = true
       elsif in_super and line =~ /[[:space:]]*def \w+[\(\w+\)]*/
         in_super = false


### PR DESCRIPTION
The conversion from hard tabs to two-space soft tabs broke a few checks.

```
wvu@kharak:~/metasploit-framework:master$ tools/msftidy.rb modules | grep ERROR | grep -v datastore
wvu@kharak:~/metasploit-framework:master$ git checkout -q beug/in_super && !!
git checkout -q beug/in_super && tools/msftidy.rb modules/ | grep ERROR | grep -v datastore
modules/auxiliary/admin/cisco/cisco_secure_acs_bypass.rb - [ERROR] '<' is a bad character in module title.
[snip]
wvu@kharak:~/metasploit-framework:beug/in_super$ 
```
- [x] Run `tools/msftidy.rb modules | grep ERROR | grep -v datastore`
- [x] See no errors
- [x] Check out the topic branch
- [x] Run `msftidy` again
- [x] Verify that there are errors

The test above accounts for only `check_badchars`. You can test `check_ref_identifiers` using the following method:

```
wvu@kharak:~/metasploit-framework:master$ git checkout -b dev -t master
Branch dev set up to track local branch master.
Switched to a new branch 'dev'
wvu@kharak:~/metasploit-framework:dev$ git merge --no-ff --no-edit 99a7630b0da301b27ac495cb027009a8cd9e2caf
Merge made by the 'recursive' strategy.
 .travis.yml                                                 |  2 ++
 modules/auxiliary/scanner/printer/printer_version_info.rb   |  2 +-
 modules/exploits/windows/misc/hp_dataprotector_traversal.rb |  6 +++++-
 modules/payloads/stagers/linux/mipsle/reverse_tcp.rb        |  4 ++--
 tools/dev/pre-commit-hook.rb                                | 26 +++++++++++++++++---------
 tools/msftidy.rb                                            |  9 ++++++++-
 6 files changed, 35 insertions(+), 14 deletions(-)
wvu@kharak:~/metasploit-framework:dev$ tools/msftidy.rb modules/exploits/windows/misc/hp_dataprotector_traversal.rb
modules/exploits/windows/misc/hp_dataprotector_traversal.rb - [WARNING] Poorly designed argument list in 'fakemeth()'. Try a hash.
wvu@kharak:~/metasploit-framework:dev$ git merge --no-ff --no-edit beug/in_super 
Auto-merging tools/msftidy.rb
Merge made by the 'recursive' strategy.
 tools/msftidy.rb | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
wvu@kharak:~/metasploit-framework:dev$ tools/msftidy.rb modules/exploits/windows/misc/hp_dataprotector_traversal.rb
modules/exploits/windows/misc/hp_dataprotector_traversal.rb - [WARNING] Invalid CVE format: '2013-zz-6194'
modules/exploits/windows/misc/hp_dataprotector_traversal.rb - [WARNING] Poorly designed argument list in 'fakemeth()'. Try a hash.
wvu@kharak:~/metasploit-framework:dev$ 
```
- [x] Check out a clean development branch
- [x] Merge 99a7630b0da301b27ac495cb027009a8cd9e2caf from #2932
- [x] Run `tools/msftidy.rb modules/exploits/windows/misc/hp_dataprotector_traversal.rb`
- [x] See no CVE format warning
- [x] Merge the topic branch
- [x] Run `msftidy` again
- [x] Verify that there is an invalid CVE format warning
