### PR TITLE
Modules shouldn't use Nokogiri

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -105,6 +105,18 @@ class Msftidy
     end
   end
 
+  def check_nokogiri
+    msg = "Requiring Nokogiri in modules can be risky, use REXML instead."
+    has_nokogiri = false
+    @source.each_line do |line|
+      if line =~ /^\s*(require|load)\s+['"]nokogiri['"]/
+        has_nokogiri = true
+        break
+      end
+    end
+    error(msg) if has_nokogiri
+  end
+
   def check_ref_identifiers
     in_super = false
     in_refs  = false
@@ -489,6 +501,7 @@ def run_checks(full_filepath)
   tidy = Msftidy.new(full_filepath)
   tidy.check_mode
   tidy.check_shebang
+  tidy.check_nokogiri
   tidy.check_ref_identifiers
   tidy.check_old_keywords
   tidy.check_verbose_option


### PR DESCRIPTION
Nokogiri has a habit of shipping vulnerable builds of libxml2. For example, see this:

http://www.ubuntu.com/usn/usn-1904-1/

and compare to Nokogiri's bundled requirements:

https://github.com/sparklemotion/nokogiri/blob/master/dependencies.yml

While Nokogiri is quite pleasant to use, it really shouldn't be trusted to handle potentially malicious data. Imagine if a "vulnerable" target was actually a malicious honeypot, lying in wait for a poor Metasploit user to come along and parse out its payload. (OT: does such a thing have a clever name? If not, I propose "beehive" to imply the offensive capabilities of such a honeypot.)

Nokogiri is used elsewhere in Metasploit, but those functions handle data sourced from the Metasploit user herself, so those XML hunks are nominally trustworthy.
## Verification steps

**Pre-patch**
- [x] Run `tools/msftidy.rb modules | grep Nokogiri` and note the lack of hits.

**Post-patch**
- [x] Run `tools/msftidy.rb modules | grep Nokogiri` and note two hits -- one on `canon_wireless.rb` and one on `mswin_tiff_overflow.rb`
## TODO:
- Once this lands, those modules should be re-written to use `REXML` rather than `nokogiri` in order to excise the existing Nokogiri usages in modules.
- A module that exploits the existing Canon Wireless module by pretending to be vulnerable. It's unclear to me right this second if `Nokogiri::HTML()` provides a path to code execution.

Note the other use of Nokogiri is merely using Nokogiri to build an XML file in the context of a `FILEFORMAT` module, so it looks impossible to exploit.
