### PR TITLE
Use the platform when encoding the payload

### DIFF
--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -746,7 +746,7 @@ class Exploit < Msf::Module
     c_arch     = (target and target.arch)     ? target.arch     : (arch == []) ? nil : arch
 
     framework.encoders.each_module_ranked(
-      'Arch' => c_arch) { |name, mod|
+      'Arch' => c_arch, 'Platform' => c_platform) { |name, mod|
 
       encoders << [ name, mod ]
     }

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -414,7 +414,7 @@ class Payload < Msf::Module
     encoders = []
 
     framework.encoders.each_module_ranked(
-      'Arch' => self.arch) { |name, mod|
+      'Arch' => self.arch, 'Platform' => self.platform) { |name, mod|
       encoders << [ name, mod ]
     }
 

--- a/modules/encoders/cmd/generic_sh.rb
+++ b/modules/encoders/cmd/generic_sh.rb
@@ -20,7 +20,8 @@ class Metasploit3 < Msf::Encoder
       tricks to avoid commonly restricted characters.
       },
       'Author'           => 'hdm',
-      'Arch'             => ARCH_CMD)
+      'Arch'             => ARCH_CMD,
+      'Platform'         => 'unix')
   end
 
 

--- a/modules/encoders/cmd/ifs.rb
+++ b/modules/encoders/cmd/ifs.rb
@@ -21,7 +21,8 @@ class Metasploit3 < Msf::Encoder
         to avoid spaces without being overly fancy.
       },
       'Author'           => 'egypt',
-      'Arch'             => ARCH_CMD)
+      'Arch'             => ARCH_CMD,
+      'Platform'         => 'unix')
   end
 
 

--- a/modules/encoders/cmd/printf_php_mq.rb
+++ b/modules/encoders/cmd/printf_php_mq.rb
@@ -30,6 +30,7 @@ class Metasploit3 < Msf::Encoder
       },
       'Author'           => 'jduck',
       'Arch'             => ARCH_CMD,
+      'Platform'         => 'unix',
       'EncoderType'      => Msf::Encoder::Type::PrintfPHPMagicQuotes)
   end
 


### PR DESCRIPTION
While handling https://github.com/rapid7/metasploit-framework/pull/2939 figured out which the Platform isn't had into account when selecting compatible encoders :. Because of that, for example, is hard to write an ARCH_CMD exploit for Windows Platforms, because non compatible encoders apply, even when payload.raw can be used still it doesn't look like the correct solution.

I see two options to fix the thing:

1) Have into account the platform when selecting the encoder : I feel like it should be the correct solution, but dangerous. This pull request, indeed, tries to do it. I guess I should be forgetting things, so please, review carefully, probably feedback from @jlee-r7 / @todb-r7 is needed.
2) Tweak the ARCH_CMD encoders to just raise an exception if the target platform isn't unix: It would be just a patch, but I guess would be safer, shouldn't break nothing. It could be done by defining the `init_platform` method on the ARCH_CMD encoders and raise an exception if the platform isn't unix.

Thoughts and feedback is super welcome!
