### PR TITLE
Windows CMD Payloads - Missing RequiredCmd

### DIFF
--- a/modules/payloads/singles/cmd/windows/adduser.rb
+++ b/modules/payloads/singles/cmd/windows/adduser.rb
@@ -31,6 +31,7 @@ module Metasploit3
       'Handler'     => Msf::Handler::None,
       'Session'     => Msf::Sessions::CommandShell,
       'PayloadType' => 'cmd',
+      'RequiredCmd' => 'generic',
       'Payload'     =>
         {
           'Offsets' => { },

--- a/modules/payloads/singles/cmd/windows/bind_perl.rb
+++ b/modules/payloads/singles/cmd/windows/bind_perl.rb
@@ -24,6 +24,7 @@ module Metasploit3
       'Handler'       => Msf::Handler::BindTcp,
       'Session'       => Msf::Sessions::CommandShell,
       'PayloadType'   => 'cmd',
+      'RequiredCmd'   => 'perl',
       'Payload'       =>
         {
           'Offsets' => { },

--- a/modules/payloads/singles/cmd/windows/bind_perl_ipv6.rb
+++ b/modules/payloads/singles/cmd/windows/bind_perl_ipv6.rb
@@ -24,6 +24,7 @@ module Metasploit3
       'Handler'       => Msf::Handler::BindTcp,
       'Session'       => Msf::Sessions::CommandShell,
       'PayloadType'   => 'cmd',
+      'RequiredCmd'   => 'perl',
       'Payload'       =>
         {
           'Offsets' => { },

--- a/modules/payloads/singles/cmd/windows/bind_ruby.rb
+++ b/modules/payloads/singles/cmd/windows/bind_ruby.rb
@@ -24,6 +24,7 @@ module Metasploit3
       'Handler'     => Msf::Handler::BindTcp,
       'Session'     => Msf::Sessions::CommandShell,
       'PayloadType' => 'cmd',
+      'RequiredCmd' => 'ruby',
       'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
     ))
   end

--- a/modules/payloads/singles/cmd/windows/download_eval_vbs.rb
+++ b/modules/payloads/singles/cmd/windows/download_eval_vbs.rb
@@ -24,6 +24,7 @@ module Metasploit3
       'Handler'     => Msf::Handler::None,
       'Session'     => Msf::Sessions::CommandShell,
       'PayloadType' => 'cmd',
+      'RequiredCmd' => 'wscript',
       'Payload'     =>
         {
           'Offsets' => { },

--- a/modules/payloads/singles/cmd/windows/download_exec_vbs.rb
+++ b/modules/payloads/singles/cmd/windows/download_exec_vbs.rb
@@ -23,6 +23,7 @@ module Metasploit3
       'Handler'     => Msf::Handler::None,
       'Session'     => Msf::Sessions::CommandShell,
       'PayloadType' => 'cmd',
+      'RequiredCmd' => 'wscript',
       'Payload'     =>
         {
           'Offsets' => { },

--- a/modules/payloads/singles/cmd/windows/reverse_perl.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_perl.rb
@@ -24,6 +24,7 @@ module Metasploit3
       'Handler'       => Msf::Handler::ReverseTcp,
       'Session'       => Msf::Sessions::CommandShell,
       'PayloadType'   => 'cmd',
+      'RequiredCmd'   => 'perl',
       'Payload'       =>
         {
           'Offsets' => { },

--- a/modules/payloads/singles/cmd/windows/reverse_ruby.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_ruby.rb
@@ -24,6 +24,7 @@ module Metasploit3
       'Handler'     => Msf::Handler::ReverseTcp,
       'Session'     => Msf::Sessions::CommandShell,
       'PayloadType' => 'cmd',
+      'RequiredCmd' => 'ruby',
       'Payload'     => { 'Offsets' => {}, 'Payload' => '' }
     ))
   end


### PR DESCRIPTION
These payloads didn't have a RequiredCmd set, and as such were not listed as compatible windows cmd payloads.
