### PR TITLE
Include missing require for powershell

### DIFF
--- a/modules/exploits/windows/local/powershell_cmd_upgrade.rb
+++ b/modules/exploits/windows/local/powershell_cmd_upgrade.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/powershell'
 
 class Metasploit3 < Msf::Exploit::Local
   Rank = ExcellentRanking


### PR DESCRIPTION
## Verification
- [ ] Before patch, on Linux:

```
todb@mazikeen:~/git/rapid7/metasploit-framework
$ ./msfconsole -L
[-] WARNING! The following modules could not be loaded!
[-]     /home/todb/git/rapid7/metasploit-framework/modules/exploits/windows/local/powershell_cmd_upgrade.rb: NameError uninitialized constant Msf::Exploit::Powershell
```
- [ ] After patch: no errors
