### PR TITLE
Fixup on description and some option descrips

### DIFF
--- a/modules/auxiliary/gather/ibm_sametime_enumerate_users.rb
+++ b/modules/auxiliary/gather/ibm_sametime_enumerate_users.rb
@@ -16,8 +16,9 @@ class Metasploit3 < Msf::Auxiliary
     super(update_info(info,
       'Name'           => 'IBM Lotus Notes Sametime User Enumeration',
       'Description'    => %q{
-        This module extracts users using the IBM Lotus Notes Sametime web
-        interface using either brute-force or dictionary based attack.
+        This module extracts usernames using the IBM Lotus Notes Sametime web
+        interface using either a dictionary attack (which is preferred), or a
+        bruteforce attack trying all usernames of MAXDEPTH length or less.
       },
       'Author'         =>
         [
@@ -38,7 +39,7 @@ class Metasploit3 < Msf::Auxiliary
          OptEnum.new('CHARSET', [true, 'Charset to use for enumeration', 'alpha', ['alpha', 'alphanum', 'num'] ]),
         OptEnum.new('TYPE', [true, 'Specify UID or EMAIL', 'UID', ['UID', 'EMAIL'] ]),
         OptPath.new('DICT', [ false,  'Path to dictionary file to use', '']),
-        OptInt.new('MAXDEPTH', [ true,  'Maximum depth to check during brute-force', 2])
+        OptInt.new('MAXDEPTH', [ true,  'Maximum depth to check during bruteforce', 2])
       ], self.class)
 
     register_advanced_options(
@@ -74,7 +75,7 @@ class Metasploit3 < Msf::Auxiliary
           @charset.push(Rex::Text.uri_encode(spec))
         end
       end
-      print_status("#{peer} - Performing Brute-Force based attack")
+      print_status("#{peer} - Performing Bruteforce attack")
       vprint_status("#{peer} - Using CHARSET: [#{@charset.join(",")}]")
     else
       print_status("#{peer} - Performing dictionary based attack (#{datastore['DICT']})")
@@ -163,7 +164,7 @@ class Metasploit3 < Msf::Auxiliary
             # provide feedback to user on current test length
             if datastore['DICT'].blank? and test_current.length > test_length
               test_length = test_current.length
-              print_status("#{peer} - Beginning brute_force test for #{test_length} character strings")
+              print_status("#{peer} - Beginning bruteforce test for #{test_length} character strings")
             end
 
             res = make_request(test_current)

--- a/modules/auxiliary/gather/ibm_sametime_room_brute.rb
+++ b/modules/auxiliary/gather/ibm_sametime_room_brute.rb
@@ -14,9 +14,9 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'IBM Lotus Notes Sametime Room Name Brute-Forcer',
+      'Name'           => 'IBM Lotus Notes Sametime Room Name Bruteforce',
       'Description'    => %q{
-        This module brute forces Sametime meeting room names via the IBM
+        This module bruteforces Sametime meeting room names via the IBM
         Lotus Notes Sametime web interface.
       },
       'Author'         =>
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(443),
-        OptString.new('OWNER', [ true,  'The owner to brute-force meeting room names for', '']),
+        OptString.new('OWNER', [ true,  'The owner to bruteforce meeting room names for', '']),
         OptPath.new('DICT', [ true,  'The path to the userinfo script' ]),
         OptString.new('TARGETURI', [ true, 'Path to stmeetings', '/stmeetings/'])
       ], self.class)
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run
-    print_status("#{peer} - Beginning IBM Lotus Notes Sametime Meeting Room Brute-force")
+    print_status("#{peer} - Beginning IBM Lotus Notes Sametime Meeting Room Bruteforce")
     print_status("Using owner: #{datastore['OWNER']}")
 
     # test for expected response code on non-existant meeting room name
@@ -81,10 +81,11 @@ class Metasploit3 < Msf::Auxiliary
     @test_queue = Queue.new
     @output_lock = false
 
+    # TODO: If DICT is unreadable (missing, etc) this will stack trace.
     ::File.open(datastore['DICT']).each { |line| @test_queue.push(line.chomp) }
     vprint_status("Loaded #{@test_queue.length} values from dictionary")
 
-    print_status("#{peer} - Beginning dictionary brute-force using (#{datastore['Threads']} Threads)")
+    print_status("#{peer} - Beginning dictionary bruteforce using (#{datastore['Threads']} Threads)")
 
     while(not @test_queue.empty?)
       t = []

--- a/modules/auxiliary/gather/ibm_sametime_version.rb
+++ b/modules/auxiliary/gather/ibm_sametime_version.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Auxiliary
       'Name'           => 'IBM Lotus Sametime Version Enumeration',
       'Description' => %q{
         This module scans an IBM Lotus Sametime web interface to enumerate
-        the version and configuration information.
+        the application's version and configuration information.
       },
       'Author'         =>
         [

--- a/modules/auxiliary/scanner/http/a10networks_ax_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/a10networks_ax_directory_traversal.rb
@@ -19,10 +19,11 @@ class Metasploit3 < Msf::Auxiliary
         (Soft) AX Loadbalancer version 2.6.1-GR1-P5/2.7.0 or less.  When
         handling a file download request, the xml/downloads class fails to
         properly check the 'filename' parameter, which can be abused to read
-        any file outside the  virtual directory. Important files include SSL
+        any file outside the virtual directory. Important files include SSL
         certificates. This module works on both the hardware devices and the
-        Virtual Machine appliances.  IMPORTANT NOTE: This will also delete the
-        file on the device after downloading it.
+        Virtual Machine appliances. IMPORTANT NOTE: This module will also delete the
+        file on the device after downloading it. Because of this, the CONFIRM_DELETE
+        option must be set to 'true' either manually or by script.
       },
       'References'     =>
         [
@@ -49,7 +50,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def run
     unless datastore['CONFIRM_DELETE']
-      print_error("This module will delete files on vulnerable systems. Please, set CONFIRM in order to run it.")
+      print_error("This module will delete files on vulnerable systems. Please, set CONFIRM_DELETE in order to run it.")
       return
     end
 

--- a/modules/exploits/linux/http/kloxo_sqli.rb
+++ b/modules/exploits/linux/http/kloxo_sqli.rb
@@ -23,10 +23,10 @@ class Metasploit3 < Msf::Exploit::Remote
       'Description'    => %q{
         This module exploits an unauthenticated SQL injection vulnerability affecting Kloxo, as
         exploited in the wild on January 2014. The SQL injection issue can be abused in order to
-        retrieve the kloxo admin clear text password from the database. With admin access to the
+        retrieve the Kloxo admin cleartext password from the database. With admin access to the
         web control panel, remote PHP code execution can be achieved by abusing the Command Center
-        function. The module tries to find the first server in the tree view , unless the server
-        information is provided, and executes the payload there.
+        function. The module tries to find the first server in the tree view, unless the server
+        information is provided, in which case it executes the payload there.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/linux/http/pandora_fms_exec.rb
+++ b/modules/exploits/linux/http/pandora_fms_exec.rb
@@ -17,7 +17,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Description'    => %q{
         This module exploits a vulnerability found in Pandora FMS 5.0RC1 and lower.
         It will leverage an unauthenticated command injection in the Anyterm service on
-        port 8023. Commands are executed as the user "pandora". In Pandora FMS 4.1 and 5.0RC1
+        port 8023/TCP. Commands are executed as the user "pandora". In Pandora FMS 4.1 and 5.0RC1
         the user "artica" is not assigned a password by default, which makes it possible to su
         to this user from the "pandora" user. The "artica" user has access to sudo without a
         password, which makes it possible to escalate privileges to root. However, Pandora FMS 4.0

--- a/modules/exploits/windows/browser/wellintech_kingscada_kxclientdownload.rb
+++ b/modules/exploits/windows/browser/wellintech_kingscada_kxclientdownload.rb
@@ -15,11 +15,11 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'KingScada kxClientDownload.ocx ActiveX Remote Code Execution',
       'Description'    => %q{
-        This module abuses the kxClientDownload.ocx distributed with WellingTech KingScada.
+        This module abuses the kxClientDownload.ocx ActiveX control distributed with WellingTech KingScada.
         The ProjectURL property can be abused to download and load arbitrary DLLs from
         arbitrary locations, leading to arbitrary code execution, because of a dangerous
         usage of LoadLibrary. Due to the nature of the vulnerability, this module will work
-        only when there isn't Protected Mode.
+        only when Protected Mode is not present or not enabled.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/post/windows/gather/enum_ad_user_comments.rb
+++ b/modules/post/windows/gather/enum_ad_user_comments.rb
@@ -15,8 +15,9 @@ class Metasploit3 < Msf::Post
     super( update_info( info,
         'Name'	       => 'Windows Gather Active Directory User Comments',
         'Description'  => %Q{
-          This module will enumerate user accounts in the default AD directory. Which
-        contain 'pass' in their description or comment (case-insensitive) by default.
+          This module will enumerate user accounts in the default Active Domain (AD) directory which
+        contain 'pass' in their description or comment (case-insensitive) by default. In some cases,
+        such users have their passwords specified in these fields.
         },
         'License'      => MSF_LICENSE,
         'Author'       => [ 'Ben Campbell <eat_meatballs[at]hotmail.co.uk>' ],


### PR DESCRIPTION
Also there's a TODO in there about needing to do some checks about the presence and readability of a dictionary file, @jvazquez-r7 . I'm not a fan of having a required file option that doesn't point at a file that we already know is there -- perhaps you can pick out the unix user list that lives in data/wordlists and prepopulate that? It just makes it harder to run this module automatically.

Not a blocker for release, unless you care to commit in the next 15 mins.
