### PR TITLE
Add vprint_debug to show what requirements are being compared

### DIFF
--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -175,6 +175,8 @@ module Msf
         # Special keys to ignore because the script registers this as [:activex] = true or false
         next if k == :clsid or k == :method
 
+        vprint_debug("Comparing requirement: #{k}=#{v} vs k=#{profile[k.to_sym]}")
+
         if v.is_a? Regexp
           bad_reqs << k if profile[k.to_sym] !~ v
         elsif v.is_a? Proc


### PR DESCRIPTION
Requested by @todb-r7 

Verification Steps:
- [x] Set up a Win XP SP3 box with IE8
- [x] Use the `exploit/windows/browser/ms13_090_cardspacesigninhelper` exploit
- [x] Do: `set verbose true`
- [x] Let the exploit run against the vuln host. You should see requirements being compared.
