### PR TITLE
Fix issue with getenv failing

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/sys/config.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/sys/config.rb
@@ -30,7 +30,7 @@ class Config
   def getuid
     request  = Packet.create_request('stdapi_sys_config_getuid')
     response = client.send_request(request)
-    return client.unicode_filter_encode( response.get_tlv_value(TLV_TYPE_USER_NAME) )
+    client.unicode_filter_encode( response.get_tlv_value(TLV_TYPE_USER_NAME) )
   end
 
   #
@@ -53,14 +53,15 @@ class Config
       result[var_name] = var_value
     end
 
-    return result
+    result
   end
 
   #
   # Returns the value of a single requested environment variable name
   #
   def getenv(var_name)
-    getenvs(var_name)[var_name]
+    _, value = getenvs(var_name).first
+    value
   end
 
   #
@@ -92,7 +93,7 @@ class Config
     req = Packet.create_request('stdapi_sys_config_steal_token')
     req.add_tlv(TLV_TYPE_PID, pid.to_i)
     res = client.send_request(req)
-    return client.unicode_filter_encode( res.get_tlv_value(TLV_TYPE_USER_NAME) )
+    client.unicode_filter_encode( res.get_tlv_value(TLV_TYPE_USER_NAME) )
   end
 
   #
@@ -101,7 +102,7 @@ class Config
   def drop_token
     req = Packet.create_request('stdapi_sys_config_drop_token')
     res = client.send_request(req)
-    return client.unicode_filter_encode( res.get_tlv_value(TLV_TYPE_USER_NAME) )
+    client.unicode_filter_encode( res.get_tlv_value(TLV_TYPE_USER_NAME) )
   end
 
   #
@@ -114,7 +115,7 @@ class Config
     res.each(TLV_TYPE_PRIVILEGE) do |p|
       ret << p.value
     end
-    return ret
+    ret
   end
 
 protected


### PR DESCRIPTION
The call to `getenv` failed when `%` or `$` were used because of the differences between Meterpreter handling and MSF handling.

Meterpreter effectively ignores (ie. strips out) the platform-specific characters which are used for environment variables. In the `getenv` call, MSF was invoking `getenvs` and getting a full hash of values, then attempting to index into the hash using a string which may be "polluted" with those platform-specific characters. This meant that there was a discrepency between what was returned and what was used to index and as a result, the value would come out as `nil`.

For example, calling `getenv('%FOO%')` would result in a hash with `{'FOO'=>'bar'}`, so looking for `%FOO%` in this result would yield nothing.

This commit changes this so that the name is ignored and the first value is returned.

Functionality in Meterpreter should remain as-is so that it maximises the possibility of returning meaningful data to the user. It is up to the caller to make sure that they handle the result set correctly.

Here's a sample run:

```
meterpreter > getenv username

Environment Variables
=====================

Variable  Value
--------  -----
username  OJ

meterpreter > getenv %USERNAME%

Environment Variables
=====================

Variable  Value
--------  -----
USERNAME  OJ

meterpreter > getenv DOESNOTEXIST
[-] None of the specified environment variables were found/set.
meterpreter > irb
[*] Starting IRB shell
[*] The 'client' variable holds the meterpreter client

>> client.sys.config.getenv('username')
=> "OJ"
>> client.sys.config.getenv('%username%')
=> "OJ"
>> client.sys.config.getenv('%DOESNOTEXIST%')
=> nil
```
