### PR TITLE
Add ff 27 support to os.js

### DIFF
--- a/data/js/detect/os.js
+++ b/data/js/detect/os.js
@@ -210,7 +210,9 @@ window.os_detect.getVersion = function(){
 		// Thanks to developer.mozilla.org "Firefox for developers" series for most
 		// of these.
 		// Release changelogs: http://www.mozilla.org/en-US/firefox/releases/
-		if (css_is_valid('image-orientation',
+		if (css_is_valid('cursor', 'cursor', 'grab')) {
+			ua_version = '27.0';
+		} else if (css_is_valid('image-orientation',
 		                 'imageOrientation',
 		                 '0deg')) {
 			ua_version = '26.0';


### PR DESCRIPTION
Verification:
- [x] On firefox 26 or lower, paste os.js into the web console (cmd-opt-k), and hit enter. Then execute `os_detect.getVersion().ua_version` and ensure you get the right version
- [x] Try again on firefox 27, ensure you get 27.0 as your version
