### PR TITLE
Unbreak the URL refs add nmonkee as ref and author

### DIFF
--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -49,15 +49,15 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'     => MSF_LICENSE,
       'Author'      => [
         'jduck', # original msf module
-        'joev'   # static server
+        'joev',   # static server
+        'nmonkee' # a python exploit written well ahead of this, see https://twitter.com/HenryHoggard/status/431412814687645696
       ],
       'References'     => [
-        ['URL', 'http://blog.trustlook.com/2013/09/04/alert-android-webview-'+
-                'addjavascriptinterface-code-execution-vulnerability/'],
+        ['URL', 'http://blog.trustlook.com/2013/09/04/alert-android-webview-addjavascriptinterface-code-execution-vulnerability/'],
         ['URL', 'https://labs.mwrinfosecurity.com/blog/2012/04/23/adventures-with-android-webviews/'],
         ['URL', 'http://50.56.33.56/blog/?p=314'],
-        ['URL', 'https://labs.mwrinfosecurity.com/advisories/2013/09/24/webview-'+
-                'addjavascriptinterface-remote-code-execution/']
+        ['URL', 'https://labs.mwrinfosecurity.com/advisories/2013/09/24/webview-addjavascriptinterface-remote-code-execution/'],
+        ['URL', 'https://github.com/mwrlabs/drozer/blob/bcadf5c3fd08c4becf84ed34302a41d7b5e9db63/src/drozer/modules/exploit/mitm/addJavaScriptInterface.py']
       ],
       'Platform'       => 'linux',
       'Arch'           => ARCH_ARMLE,

--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -49,8 +49,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'     => MSF_LICENSE,
       'Author'      => [
         'jduck', # original msf module
-        'joev',   # static server
-        'nmonkee' # a python exploit written well ahead of this, see https://twitter.com/HenryHoggard/status/431412814687645696
+        'joev'   # static server
       ],
       'References'     => [
         ['URL', 'http://blog.trustlook.com/2013/09/04/alert-android-webview-addjavascriptinterface-code-execution-vulnerability/'],


### PR DESCRIPTION
While @nmonkee didn't actually contribute to #2942, he did publish a python exploit that leverages WebView ~~, so given our policy of being loose with author credit, I added him~~.

Also added a ref to @nmonkee's thing.

@jduck @jvennix-r7 if you have a problem with this, please do say so. ~~I don't think adding @nmonkee in any way diminishes your work, and I don't want to appear like we're secretly ripping off people's work. I know you aren't on this or any other module, and I know @nmonkee doesn't think that either.~~ Doesn't matter, @nmonkee is resisting author credit anyway. See: https://twitter.com/metall0id/status/434064448504864768

Still want the new ref and the unsplit URLs
