### PR TITLE
Fix enum_configs

### DIFF
--- a/modules/post/linux/gather/enum_configs.rb
+++ b/modules/post/linux/gather/enum_configs.rb
@@ -7,6 +7,8 @@ require 'msf/core'
 
 class Metasploit3 < Msf::Post
 
+  include Msf::Post::Linux::System
+
   def initialize(info={})
     super( update_info( info,
       'Name'          => 'Linux Gather Configurations',


### PR DESCRIPTION
The module was forgetting the `Msf::Post::Linux::System` and was generating an exception like that:

```
msf post(enum_configs) > set session 1
session => 1
msf post(enum_configs) > run

[-] Post failed: NameError undefined local variable or method `get_sysinfo' for #<Msf::Modules::Mod706f73742f6c696e75782f6761746865722f656e756d5f636f6e66696773::Metasploit3:0x007fde9947f200>
[-] Call stack:
[-]   /Users/juan/Projects/git/metasploit-framework/modules/post/linux/gather/enum_configs.rb:30:in `run'
```

After patch:

```
msf post(enum_configs) > reload
[*] Reloading module...
run
msf post(enum_configs) > run

[*] Running module against ubuntu
[*] Info:
[*]     Ubuntu 10.04.4 LTS  
[*]     Linux ubuntu 2.6.32-38-generic #83-Ubuntu SMP Wed Jan 4 11:13:04 UTC 2012 i686 GNU/Linux
[*] apache2.conf stored in /Users/juan/.msf4/loot/20140214083139_default_192.168.172.136_linux.enum.conf_206085.txt
[*] ports.conf stored in /Users/juan/.msf4/loot/20140214083140_default_192.168.172.136_linux.enum.conf_876398.txt
[*] my.cnf stored in /Users/juan/.msf4/loot/20140214083140_default_192.168.172.136_linux.enum.conf_681142.txt
[*] ufw.conf stored in /Users/juan/.msf4/loot/20140214083141_default_192.168.172.136_linux.enum.conf_757967.txt
[*] sysctl.conf stored in /Users/juan/.msf4/loot/20140214083141_default_192.168.172.136_linux.enum.conf_691414.txt
[*] shells stored in /Users/juan/.msf4/loot/20140214083142_default_192.168.172.136_linux.enum.conf_037043.txt
[*] sepermit.conf stored in /Users/juan/.msf4/loot/20140214083142_default_192.168.172.136_linux.enum.conf_549486.txt
[*] ca-certificates.conf stored in /Users/juan/.msf4/loot/20140214083142_default_192.168.172.136_linux.enum.conf_029729.txt
[*] access.conf stored in /Users/juan/.msf4/loot/20140214083142_default_192.168.172.136_linux.enum.conf_055706.txt
[*] rpc stored in /Users/juan/.msf4/loot/20140214083143_default_192.168.172.136_linux.enum.conf_743344.txt
[*] debian.cnf stored in /Users/juan/.msf4/loot/20140214083143_default_192.168.172.136_linux.enum.conf_637898.txt
[*] logrotate.conf stored in /Users/juan/.msf4/loot/20140214083144_default_192.168.172.136_linux.enum.conf_276192.txt
[*] smb.conf stored in /Users/juan/.msf4/loot/20140214083145_default_192.168.172.136_linux.enum.conf_990818.txt
[*] ldap.conf stored in /Users/juan/.msf4/loot/20140214083145_default_192.168.172.136_linux.enum.conf_108176.txt
[*] sysctl.conf stored in /Users/juan/.msf4/loot/20140214083146_default_192.168.172.136_linux.enum.conf_657482.txt
[*] snmp.conf stored in /Users/juan/.msf4/loot/20140214083146_default_192.168.172.136_linux.enum.conf_598139.txt
[*] Post module execution completed
```

Bug discovered by a Rapid7 Community user, see thread here:

https://community.rapid7.com/thread/4285
