### PR TITLE
Modified output for smb_enumshares

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -32,7 +32,8 @@ class Metasploit3 < Msf::Auxiliary
         [
           'hdm',
           'nebulus',
-          'sinn3r'
+          'sinn3r',
+          'r3dy'
         ],
       'License'        => MSF_LICENSE,
       'DefaultOptions' =>

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -362,8 +362,10 @@ class Metasploit3 < Msf::Auxiliary
         if shares.empty?
           print_status("#{ip}:#{rport} - No shares collected")
         else
-          shares_info = shares.map{|x| "#{x[0]} - #{x[2]} (#{x[1]})" }.join(", ")
-          print_status("#{ip}:#{rport} - #{shares_info}")
+          shares_info = shares.map{|x| "#{ip}:  #{x[0]} - (#{x[1]}) #{x[2]}" }.join(", ")
+          shares_info.split(", ").each { |share|
+            print_good share
+          }
           report_note(
             :host   => ip,
             :proto  => 'tcp',


### PR DESCRIPTION
I modified the output of this module to be more useful.

What it does now is displays each share for a particular host on a separate line with a green [+] this makes it much easier to grep from a spool file and create a list of all observed shares.

The previous version displayed all shares on a single line separated by commas.  Not good for sorting results.

Let me know if you have any questions or objections.

Sample Output:

<pre>
msf auxiliary(smb_enumshares) > run

[*] 169.10.124.122:139 - Unix Samba 3.5.10-125.el6 (Unknown)
[+] 169.10.124.122:  weblogs - (DISK) 
[+] 169.10.124.122:  scriptlogs - (DISK) 
[+] 169.10.124.122:  webdocs - (DISK) 
[+] 169.10.124.122:  plugin - (DISK) 
[+] 169.10.124.122:  webserver - (DISK) 
[+] 169.10.124.122:  IPC$ - (IPC) IPC Service (sapgwebnp02xx - CIFS (Samba) Server 3.5.10-125.el6)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(smb_enumshares) > exit
</pre>
