### PR TITLE
Vnc inject default options are dumb

### DIFF
--- a/lib/msf/base/sessions/vncinject.rb
+++ b/lib/msf/base/sessions/vncinject.rb
@@ -152,14 +152,20 @@ class VncInject
   # Note that this says nothing about whether it worked, only that we found
   # the file.
   #
-  def autovnc
+  def autovnc(viewonly=true)
     vnc =
       Rex::FileUtils::find_full_path('vncviewer') ||
       Rex::FileUtils::find_full_path('vncviewer.exe')
 
     if (vnc)
+      if viewonly
+        vo = "-viewonly "
+      else
+        vo = ""
+      end
+
       self.view = framework.threads.spawn("VncViewerWrapper", false) {
-        system("vncviewer #{vlhost}::#{vlport}")
+        system("vncviewer #{vo}#{vlhost}::#{vlport}")
       }
 
       return true

--- a/lib/msf/base/sessions/vncinject.rb
+++ b/lib/msf/base/sessions/vncinject.rb
@@ -158,14 +158,12 @@ class VncInject
       Rex::FileUtils::find_full_path('vncviewer.exe')
 
     if (vnc)
-      if viewonly
-        vo = "-viewonly "
-      else
-        vo = ""
-      end
+      args = []
+      args.push '-viewonly' if viewonly
+      args.push "#{vlhost}::#{vlport}"
 
       self.view = framework.threads.spawn("VncViewerWrapper", false) {
-        system("vncviewer #{vo}#{vlhost}::#{vlport}")
+        system(vnc, *args)
       }
 
       return true

--- a/lib/msf/base/sessions/vncinject_options.rb
+++ b/lib/msf/base/sessions/vncinject_options.rb
@@ -22,6 +22,18 @@ module VncInjectOptions
             "The local host to use for the VNC proxy",
             '127.0.0.1'
           ]),
+        OptBool.new('DisableCourtesyShell',
+          [
+            false,
+            "Disables the Metasploit Courtesy shell",
+            true
+          ]),
+        OptBool.new('VIEW_ONLY',
+          [
+            false,
+            "Runs the viewer in view mode",
+            true
+          ]),
         OptBool.new('AUTOVNC',
           [
             true,
@@ -32,12 +44,6 @@ module VncInjectOptions
 
     register_advanced_options(
       [
-        OptBool.new('DisableCourtesyShell',
-          [
-            false,
-            "Disables the Metasploit Courtesy shell",
-            false
-          ]),
         OptBool.new('DisableSessionTracking',
           [
             false,
@@ -79,7 +85,7 @@ module VncInjectOptions
 
     # If the AUTOVNC flag is set, launch VNC viewer.
     if (datastore['AUTOVNC'] == true)
-      if (session.autovnc)
+      if (session.autovnc(datastore['VIEW_ONLY']))
         print_status("Launched vncviewer.")
       else
         print_error("Failed to launch vncviewer.  Is it installed and in your path?")

--- a/lib/msf/base/sessions/vncinject_options.rb
+++ b/lib/msf/base/sessions/vncinject_options.rb
@@ -28,7 +28,7 @@ module VncInjectOptions
             "Disables the Metasploit Courtesy shell",
             true
           ]),
-        OptBool.new('VIEW_ONLY',
+        OptBool.new('ViewOnly',
           [
             false,
             "Runs the viewer in view mode",
@@ -85,7 +85,7 @@ module VncInjectOptions
 
     # If the AUTOVNC flag is set, launch VNC viewer.
     if (datastore['AUTOVNC'] == true)
-      if (session.autovnc(datastore['VIEW_ONLY']))
+      if (session.autovnc(datastore['ViewOnly']))
         print_status("Launched vncviewer.")
       else
         print_error("Failed to launch vncviewer.  Is it installed and in your path?")


### PR DESCRIPTION
Popping a big Metasploit command prompt on a user's screen by default is not particularly useful default behaviour.

No option to autolaunch in view-only mode sucked. Now it sucks less :)
