### PR TITLE
EXITFUNC option in Msf::Payload::Windows mixin should be an OptEnum

### DIFF
--- a/lib/msf/core/payload/windows.rb
+++ b/lib/msf/core/payload/windows.rb
@@ -72,7 +72,7 @@ module Msf::Payload::Windows
 
     register_options(
       [
-        Msf::OptRaw.new('EXITFUNC', [ true, "Exit technique: #{@@exit_types.keys.join(", ")}", 'process' ])
+        Msf::OptEnum.new('EXITFUNC', [true, 'Exit technique', 'process', @@exit_types.keys])
       ], Msf::Payload::Windows )
     ret
   end


### PR DESCRIPTION
Verification:

```
$ ./msfconsole
msf> use exploit/multi/handler
msf> set payload windows/meterpreter/reverse_tcp
msf> show options
```
- [x] Verify EXITFUNC shows up, along with a list of accepted values

```
msf> set EXITFUNC asdasdasd
msf> run
```
- [x] Verify you get a datastore validation error

```
msf> set EXITFUNC none
msf> run
```
- [x] Verify it runs
