### PR TITLE
Added support for Gemfile.local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bundle
+Gemfile.local
 # Rubymine project directory
 .idea
 # Sublime Text project directory (not created by ST by default)

--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,13 @@ group :test do
   # Manipulate Time.now in specs
   gem 'timecop'
 end
+
+
+group :local do
+  # Makes it possible to add other gems to the bundle without without editing this file.
+  gemfile_local = File.join(File.dirname(__FILE__), 'Gemfile.local')
+  if File.readable?(gemfile_local)
+    instance_eval(File.read(gemfile_local))
+  end
+end
+


### PR DESCRIPTION
Prior to this change, there were two ways to make use of gems that were not included in the Gemfile:
  1) Change the gemfile and rerun bundle install
     - This forces the user to have a Gemfile that is out of sync with the master framework
  2) Start the console with 'ruby -r pry msfconsole.rb'
    - This is hackish and doesn't always work well from outside of the metasploit-framework base folder

This pull request will allow users to make use of certain features present in the framework (e.g. cmd_pry, lab plugin) or make use of other gems for in custom modules, without changing the Gemfile. This PR allows users to create a Gemfile.local file and define custom gems.
