### PR TITLE
Added support for Gemfile.local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .bundle
+Gemfile.local
+Gemfile.local.lock
 # Rubymine project directory
 .idea
 # Sublime Text project directory (not created by ST by default)

--- a/lib/msfenv.rb
+++ b/lib/msfenv.rb
@@ -2,11 +2,25 @@
 # Use bundler to load dependencies
 #
 
-gemfile_base = ::File.expand_path(::File.join(::File.dirname(__FILE__), ".."))
-if File.readable?(::File.join(gemfile_base,"Gemfile.local"))
-  ENV['BUNDLE_GEMFILE'] ||= ::File.join(gemfile_base, "Gemfile.local")
-else
-  ENV['BUNDLE_GEMFILE'] ||= ::File.join(gemfile_base, "Gemfile")
+GEMFILE_EXTENSIONS = [
+  '.local',
+  ''
+]
+
+unless ENV['BUNDLE_GEMFILE']
+  require 'pathname'
+
+  msfenv_real_pathname = Pathname.new(__FILE__).realpath
+  root = msfenv_real_pathname.parent.parent
+
+  GEMFILE_EXTENSIONS.each do |extension|
+    extension_pathname = root.join("Gemfile#{extension}")
+
+    if extension_pathname.readable?
+      ENV['BUNDLE_GEMFILE'] = extension_pathname.to_path
+      break
+    end
+  end
 end
 
 begin

--- a/lib/msfenv.rb
+++ b/lib/msfenv.rb
@@ -2,7 +2,13 @@
 # Use bundler to load dependencies
 #
 
-ENV['BUNDLE_GEMFILE'] ||= ::File.expand_path(::File.join(::File.dirname(__FILE__), "..", "Gemfile"))
+gemfile_base = ::File.expand_path(::File.join(::File.dirname(__FILE__), ".."))
+if File.readable?(::File.join(gemfile_base,"Gemfile.local"))
+  ENV['BUNDLE_GEMFILE'] ||= ::File.join(gemfile_base, "Gemfile.local")
+else
+  ENV['BUNDLE_GEMFILE'] ||= ::File.join(gemfile_base, "Gemfile")
+end
+
 begin
   require 'bundler/setup'
 rescue ::LoadError


### PR DESCRIPTION
This is a second attempt at PR #3020 .
This PR changes msfenv.rb so that the framework can use a custom Gemfile. Users can create a custom Gemfile.local file and then install it with `bundle install --gemfile Gemfile.local`

Users can create a Gemfile.local to include all groups in the framework's Gemfile along with custom groups.

``` ruby
msf_gemfile = File.join(File.dirname(__FILE__), 'Gemfile')
if File.readable?(msf_gemfile)
  instance_eval(File.read(msf_gemfile))
end

group :local do
  gem 'pry'
  gem 'pry-debugger'
  gem 'lab'
end
```

Changes to the Gemfile.local file should not change Gemfile or Gemfile.lock

See also:
- PR #2687
- https://dev.metasploit.com/redmine/issues/8701
