### PR TITLE
Allow exploits to provide encoder Compat options

### DIFF
--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -125,6 +125,13 @@ class EncodedPayload
         self.encoder = encmod.new
         self.encoded = nil
 
+        # If the encoding is requested by an exploit check compatibility
+        # options first of all. For the 'generic/none' encoder compatibility
+        # options don't apply.
+        if reqs['Exploit']
+          next unless reqs['Exploit'].compatible?(self.encoder) || encname =~ /generic\/none/
+        end
+
         # If there is an encoder type restriction, check to see if this
         # encoder matches with what we're searching for.
         if ((reqs['EncoderType']) and

--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -129,7 +129,7 @@ class EncodedPayload
         # options first of all. For the 'generic/none' encoder compatibility
         # options don't apply.
         if (reqs['Exploit'] &&
-            reqs['Exploit'].compatible?(self.encoder) == false &&
+            !reqs['Exploit'].compatible?(self.encoder) &&
             encname !~ /generic\/none/)
           wlog("#{pinst.refname}: Encoder #{encoder.refname} doesn't match the exploit Compat options",
             'core', LEV_1)

--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -128,8 +128,12 @@ class EncodedPayload
         # If the encoding is requested by an exploit check compatibility
         # options first of all. For the 'generic/none' encoder compatibility
         # options don't apply.
-        if reqs['Exploit']
-          next unless reqs['Exploit'].compatible?(self.encoder) || encname =~ /generic\/none/
+        if (reqs['Exploit'] &&
+            reqs['Exploit'].compatible?(self.encoder) == false &&
+            encname !~ /generic\/none/)
+          wlog("#{pinst.refname}: Encoder #{encoder.refname} doesn't match the exploit Compat options",
+            'core', LEV_1)
+          next
         end
 
         # If there is an encoder type restriction, check to see if this

--- a/lib/msf/core/exploit.rb
+++ b/lib/msf/core/exploit.rb
@@ -532,6 +532,7 @@ class Exploit < Msf::Module
     reqs['EncoderType']     = payload_encoder_type(explicit_target)
     reqs['EncoderOptions']  = payload_encoder_options(explicit_target)
     reqs['ExtendedOptions'] = payload_extended_options(explicit_target)
+    reqs['Exploit']         = self
 
     # Pass along the encoder don't fall through flag
     reqs['EncoderDontFallThrough'] = datastore['EncoderDontFallThrough']


### PR DESCRIPTION
Requirement (re)discovered while processing #2964, where a ARCH_CMD encoder would require the powershell command in order to work. Would be neat if exploits can provide a list of "Compat" options to have into account when selecting the encoder.
## Verification

At this moment nothing should change, because any module provides Compat options for the encoder... so just ensure all works as before. Tests:
- [x] Use msfpayload to generate any payload you can imagine, should work as before
- [x] Use msfvenom to generate any encoded payload you can imagine, should work as before.
- [x] Use any exploit you can imagine, should work as before.
