### PR TITLE
Added auto LHOST to msfvenom and msfpayload

### DIFF
--- a/msfpayload
+++ b/msfpayload
@@ -119,9 +119,8 @@ end
 
 # if LHOST is not set auto set it
 if options['LHOST'].nil?
-  options['LHOST'] = "#{Rex::Socket.source_address('50.50.50.50')}"
+  options['LHOST'] = Rex::Socket.source_address
 end
-
 
 payload.datastore.merge! options
 

--- a/msfpayload
+++ b/msfpayload
@@ -114,8 +114,14 @@ cmd = rest.pop.downcase
 options = {}
 rest.each do |x|
   k,v = x.split("=", 2)
-  options[k] = v.to_s
+  options[k.upcase] = v.to_s
 end
+
+# if LHOST is not set auto set it
+if options['LHOST'].nil?
+  options['LHOST'] = "#{Rex::Socket.source_address('50.50.50.50')}"
+end
+
 
 payload.datastore.merge! options
 

--- a/msfpayload
+++ b/msfpayload
@@ -118,9 +118,10 @@ rest.each do |x|
 end
 
 # if LHOST is not set auto set it
-if options['LHOST'].nil?
+if payload_name =~ /[\_\/]reverse/ and options['LHOST'].nil?
   options['LHOST'] = Rex::Socket.source_address
 end
+
 
 payload.datastore.merge! options
 

--- a/msfvenom
+++ b/msfvenom
@@ -152,8 +152,10 @@ require 'msf/core/payload_generator'
         k,v = x.split('=', 2)
         datastore[k.upcase] = v.to_s
       end
+
+      # if LHOST is not set auto set it
       if datastore['LHOST'].nil?
-        datastore['LHOST'] = "#{Rex::Socket.source_address('50.50.50.50')}"
+        datastore['LHOST'] = Rex::Socket.source_address
       end
     end
 

--- a/msfvenom
+++ b/msfvenom
@@ -152,9 +152,7 @@ require 'msf/core/payload_generator'
         k,v = x.split('=', 2)
         datastore[k.upcase] = v.to_s
       end
-
-      # if LHOST is not set auto set it
-      if datastore['LHOST'].nil?
+      if opts[:payload].to_s =~ /[\_\/]reverse/ and datastore['LHOST'].nil?
         datastore['LHOST'] = Rex::Socket.source_address
       end
     end

--- a/msfvenom
+++ b/msfvenom
@@ -152,6 +152,9 @@ require 'msf/core/payload_generator'
         k,v = x.split('=', 2)
         datastore[k.upcase] = v.to_s
       end
+      if datastore['LHOST'].nil?
+        datastore['LHOST'] = "#{Rex::Socket.source_address('50.50.50.50')}"
+      end
     end
 
     if opts[:payload].nil? # if no payload option is selected assume we are reading it from stdin


### PR DESCRIPTION
I changed the code on both msfpayload, and msfvenom to check if LHOST was set or not. If it is leave it alone, if its not set it with "#{Rex::Socket.source_address('50.50.50.50')}". 

The only issues I can think of causing any problems would be setting LHOST with payloads that don't require it. 

msfpayload without added changes:

```
root@sho-luv:~/mydev/mytasploit# ./msfpayload windows/meterpreter/reverse_tcp X > test.exe
Error generating payload: The following options failed to validate: LHOST.
root@sho-luv:~/mydev/mytasploit#
```

msfpayload with added changes:

```
root@sho-luv:~/mydev/mytasploit# ./msfpayload windows/meterpreter/reverse_tcp X > test.exe
Created by msfpayload (http://www.metasploit.com).
Payload: windows/meterpreter/reverse_tcp
 Length: 287
Options: {"LHOST"=>"10.0.0.113"}
root@sho-luv:~/mydev/mytasploit# 
```

msfvenom without added changes:

```
root@sho-luv:~/mydev/mytasploit# ./msfvenom -p windows/meterpreter/reverse_tcp -f exe > test.exe
No platform was selected, choosing Msf::Module::Platform::Windows from the payload
No Arch selected, selecting Arch: x86 from the payload
The following options failed to validate: LHOST.
root@sho-luv:~/mydev/mytasploit#
```

msfvenom with added changes:

```
root@sho-luv:~/mydev/mytasploit# ./msfvenom -p windows/meterpreter/reverse_tcp -f exe > test.exe
No platform was selected, choosing Msf::Module::Platform::Windows from the payload
No Arch selected, selecting Arch: x86 from the payload
Found 0 compatible encoders
root@sho-luv:~/mydev/mytasploit#
```
