### PR TITLE
Fix msftidy warning: Suspect capitalization in module title: 'encoder'

### DIFF
--- a/modules/encoders/x86/opt_sub.rb
+++ b/modules/encoders/x86/opt_sub.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Encoder
 
   def initialize
     super(
-      'Name'             => 'Sub encoder (optimised)',
+      'Name'             => 'Sub Encoder (optimised)',
       'Description'      => %q{
         Encodes a payload using a series of SUB instructions and writing the
         encoded value to ESP. This concept is based on the known SUB encoding


### PR DESCRIPTION
This fixes a build error:
https://travis-ci.org/rapid7/metasploit-framework/builds/19512905

due to:

```
modules/encoders/x86/opt_sub.rb - [WARNING] Suspect capitalization in module title: 'encoder'
```
