### PR TITLE
Added 301 Redirect option to Basic Auth module

### DIFF
--- a/modules/auxiliary/server/capture/http_basic.rb
+++ b/modules/auxiliary/server/capture/http_basic.rb
@@ -39,7 +39,8 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         OptPort.new('SRVPORT', [ true, "The local port to listen on.", 80 ]),
-        OptString.new('REALM', [ true, "The authentication realm you'd like to present.", "Secure Site" ])
+        OptString.new('REALM', [ true, "The authentication realm you'd like to present.", "Secure Site" ]),
+        OptString.new('RedirectURL', [ false, "The page to redirect users to after they enter basic auth creds"])
       ], self.class)
   end
 
@@ -73,7 +74,14 @@ class Metasploit3 < Msf::Auxiliary
       )
 
       print_good("#{cli.peerhost} - Credential collected: \"#{user}:#{pass}\" => #{req.resource}")
-      send_not_found(cli)
+      if datastore['RedirectURL']
+        print_status("Sending redirect to client")
+        response = create_response(301, "Moved Permanently")
+        response.headers['Location'] = datastore['RedirectURL']
+        cli.send_response(response)
+      else
+        send_not_found(cli)
+      end
     else
       print_status("Sending 401 to client")
       response = create_response(401, "Unauthorized")

--- a/modules/auxiliary/server/capture/http_basic.rb
+++ b/modules/auxiliary/server/capture/http_basic.rb
@@ -75,15 +75,13 @@ class Metasploit3 < Msf::Auxiliary
 
       print_good("#{cli.peerhost} - Credential collected: \"#{user}:#{pass}\" => #{req.resource}")
       if datastore['RedirectURL']
-        print_status("Sending redirect to client")
-        response = create_response(301, "Moved Permanently")
-        response.headers['Location'] = datastore['RedirectURL']
-        cli.send_response(response)
+        print_status("Redirecting client #{cli.peerhost} to #{datastore['RedirectURL']}")
+        send_redirect(cli,datastore['RedirectURL'])
       else
         send_not_found(cli)
       end
     else
-      print_status("Sending 401 to client")
+      print_status("Sending 401 to client #{cli.peerhost}")
       response = create_response(401, "Unauthorized")
       response.headers['WWW-Authenticate'] = "Basic realm=\"#{@realm}\""
       cli.send_response(response)


### PR DESCRIPTION
This change adds an optional RedirectURL option to the auxiliary/server/capture/http_basic module. When set, this option causes the server to send a 302 redirect to the connecting client once they have provided basic auth credentials. This is useful when a tester/attacker wants to redirect users to a legitimate site (to reduce suspicion) or to another attack site (e.g. browser_autopwn).

Notes:
- The module output was changed to include the IP of the connecting client. This (IMHO) makes the output more readable. Requiring that the _VERBOSE_ option be set to _true_ before outputting anything but the _print_good_ on line 76 may further help readability.
- This change was tested using a Firefox 27.0.1 and Chrome 32.0 on a Linux host and Firefox 27.0.1 and IE 10.0.9200.16798 using a Windows host.
- Msftidy did not return any output when given the updated module.
