### PR TITLE
Fix payload_generator.format_payload rspec

### DIFF
--- a/spec/lib/msf/core/payload_generator_spec.rb
+++ b/spec/lib/msf/core/payload_generator_spec.rb
@@ -443,7 +443,7 @@ describe Msf::PayloadGenerator do
       let(:format) { 'exe' }
 
       it 'applies the appropriate executable format' do
-        ::Msf::Util::EXE.should_receive(:to_executable_fmt).with(framework, arch, platform, shellcode, format, payload_generator.exe_options)
+        ::Msf::Util::EXE.should_receive(:to_executable_fmt).with(framework, arch, kind_of(payload_generator.platform_list.class), shellcode, format, payload_generator.exe_options)
         payload_generator.format_payload(shellcode)
       end
     end


### PR DESCRIPTION
The platform should match.

It was broken due to:
f51cbfffb8e75f31fd7dc7bdc11089289829edc3

No redmine ticket or PR for the above fix.

Error:

```
Msf::PayloadGenerator ...........................................*..................F.......
  1) Msf::PayloadGenerator#format_payload when format is an executable format applies the appropriate executable format
     Failure/Error: payload_generator.format_payload(shellcode)
       <Msf::Util::EXE (class)> received :to_executable_fmt with unexpected arguments
         expected: (#<Framework (0 sessions, 0 jobs, 0 plugins)>, "x86", "Windows", "PQXY", "exe", {:inject=>false, :template_path=>"/Users/wchen/rapid7/msf/data/templates", :template=>"template_x86_windows.exe"})
              got: (#<Framework (0 sessions, 0 jobs, 0 plugins)>, "x86", #<Msf::Module::PlatformList:0x007fee499f3ed8 @platforms=[Msf::Module::Platform::Windows]>, "PQXY", "exe", {:inject=>false, :template_path=>"/Users/wchen/rapid7/msf/data/templates", :template=>"template_x86_windows.exe"})
```
