### PR TITLE
Fix os_detect for Internet Explorer 11

### DIFF
--- a/data/js/detect/os.js
+++ b/data/js/detect/os.js
@@ -196,8 +196,7 @@ window.os_detect.getVersion = function(){
 		if (!ua_version || 0 == ua_version.length) {
 			ua_is_lying = true;
 		}
-	} else if (!document.all && navigator.taintEnabled ||
-	            'MozBlobBuilder' in window) {
+	} else if (navigator.oscpu && !document.all && navigator.taintEnabled || 'MozBlobBuilder' in window) {
 		// Use taintEnabled to identify FF since other recent browsers
 		// implement window.getComputedStyle now.  For some reason, checking for
 		// taintEnabled seems to cause IE 6 to stop parsing, so make sure this

--- a/data/js/detect/os.js
+++ b/data/js/detect/os.js
@@ -881,6 +881,18 @@ window.os_detect.getVersion = function(){
 				os_flavor = "7";
 				os_sp = "SP1";
 				break;
+			case "11016428":
+				// IE 11.0.9600.16428 / Windows 7 SP1
+				ua_version = "11.0";
+				os_flavor = "7";
+				os_sp = "SP1";
+				break;
+			case "10016384":
+				// IE 10.0.9200.16384 / Windows 8 x86
+				ua_version = "10.0";
+				os_flavor = "8";
+				os_sp = "SP0";
+				break;
 			case "1000":
 				// IE 10.0.8400.0 (Pre-release + KB2702844), Windows 8 x86 English Pre-release
 				ua_version = "10.0";


### PR DESCRIPTION
[SeeRM #8770] This fixes an issue with IE 11 being recognized as a FF because of these matching conditions: `(!document.all && navigator.taintEnabled || 'MozBlobBuilder' in window)`.

I also added more newer IE targets.

Related to the following ticket:
https://dev.metasploit.com/redmine/issues/8770
### Verification Steps
- [ ] Without the patch, browser autopwn should fail against IE 11. "Fail" as in it's not serving exploits.
- [ ] With the patch, browser autopwn should serve exploits against IE 11.
