### PR TITLE
Actually use the argument

### DIFF
--- a/modules/exploits/linux/local/vmware_mount.rb
+++ b/modules/exploits/linux/local/vmware_mount.rb
@@ -78,7 +78,7 @@ class Metasploit4 < Msf::Exploit::Local
   end
 
   def setuid?(remote_file)
-    !!(cmd_exec("test -u /usr/bin/vmware-mount && echo true").index "true")
+    !!(cmd_exec("test -u #{remote_file.strip} && echo true").index "true")
   end
 
 end


### PR DESCRIPTION
The vmware_mount local exploit has a nifty method for determining existence and setuid status of the vulnerable utility. For some reason it ignores its argument and hardcodes the filename a second time. So... don't do that.

The `setuid?` method should probably go in `Post::File` at some point.
