### PR TITLE
Include 'msf/core/exploit/powershell'

### DIFF
--- a/modules/exploits/windows/misc/hp_dataprotector_exec_bar.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_exec_bar.rb
@@ -5,6 +5,7 @@
 
 
 require 'msf/core'
+require 'msf/core/exploit/powershell'
 
 
 class Metasploit3 < Msf::Exploit::Remote


### PR DESCRIPTION
Part of #3066

Prevent:

```
[-]     /pentest/exploit/metasploit-framework/modules/exploits/windows/misc/hp_dataprotector_exec_bar.rb: NameError uninitialized constant Msf::Exploit::Powershell
```
