### PR TITLE
Allow TFTP server to take a host/port argument

### DIFF
--- a/modules/auxiliary/server/tftp.rb
+++ b/modules/auxiliary/server/tftp.rb
@@ -32,20 +32,34 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options(
       [
+        OptAddress.new('SRVHOST',   [ true, "The local host to listen on.", '0.0.0.0' ]),
+        OptPort.new('SRVPORT',      [ true, "The local port to listen on.", 69 ]),
         OptString.new('TFTPROOT',   [ false,  "The TFTP root directory to serve files from" ]),
         OptString.new('OUTPUTPATH', [ false, "The directory in which uploaded files will be written." ])
       ], self.class)
   end
 
+  def srvhost
+    datastore['SRVHOST'] || '0.0.0.0'
+  end
+
+  def srvport
+    datastore['SRVPORT'] || 69
+  end
+
   def run
-    if not datastore['OUTPUTPATH'] and not datastore['TFTPROOT']
+    if datastore['OUTPUTPATH'] and datastore['TFTPROOT']
+      print_status("Starting TFTP server on #{srvhost}:#{srvport}...")
+    else
       print_error("You must set TFTPROOT and/or OUTPUTPATH to use this module.")
       return
     end
 
-    @tftp = Rex::Proto::TFTP::Server.new
-
-    print_status("Starting TFTP server...")
+    @tftp = Rex::Proto::TFTP::Server.new(
+      srvport,
+      srvhost,
+      {}
+    )
 
     if datastore['TFTPROOT']
       print_status("Files will be served from #{datastore['TFTPROOT']}")

--- a/modules/auxiliary/server/tftp.rb
+++ b/modules/auxiliary/server/tftp.rb
@@ -49,12 +49,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run
-    if datastore['OUTPUTPATH'] and datastore['TFTPROOT']
-      print_status("Starting TFTP server on #{srvhost}:#{srvport}...")
-    else
-      print_error("You must set TFTPROOT and/or OUTPUTPATH to use this module.")
-      return
-    end
+    print_status("Starting TFTP server on #{srvhost}:#{srvport}...")
 
     @tftp = Rex::Proto::TFTP::Server.new(
       srvport,
@@ -62,16 +57,11 @@ class Metasploit3 < Msf::Auxiliary
       {}
     )
 
-    if datastore['TFTPROOT']
-      print_status("Files will be served from #{datastore['TFTPROOT']}")
-      @tftp.set_tftproot(datastore['TFTPROOT'])
-    end
+    @tftp.set_tftproot(datastore['TFTPROOT'])
+    print_status("Files will be served from #{datastore['TFTPROOT']}")
 
-    # register output directory
-    if datastore['OUTPUTPATH']
-      print_status("Uploaded files will be saved in #{datastore['OUTPUTPATH']}")
-      @tftp.set_output_dir(datastore['OUTPUTPATH'])
-    end
+    @tftp.set_output_dir(datastore['OUTPUTPATH'])
+    print_status("Uploaded files will be saved in #{datastore['OUTPUTPATH']}")
 
     # Individual virtual files can be served here -
     #@tftp.register_file("ays", "A" * 2048) # multiple of 512 on purpose
@@ -81,7 +71,7 @@ class Metasploit3 < Msf::Auxiliary
 
     # Wait for finish..
     while @tftp.thread.alive?
-      select(nil, nil, nil, 2)
+      sleep 3
     end
 
     vprint_status("Stopping TFTP server")

--- a/modules/auxiliary/server/tftp.rb
+++ b/modules/auxiliary/server/tftp.rb
@@ -35,8 +35,8 @@ class Metasploit3 < Msf::Auxiliary
       [
         OptAddress.new('SRVHOST',   [ true, "The local host to listen on.", '0.0.0.0' ]),
         OptPort.new('SRVPORT',      [ true, "The local port to listen on.", 69 ]),
-        OptString.new('TFTPROOT',   [ true, "The TFTP root directory to serve files from", Dir.tmpdir  ]),
-        OptString.new('OUTPUTPATH', [ true, "The directory in which uploaded files will be written.", Dir.tmpdir ])
+        OptPath.new('TFTPROOT',   [ true, "The TFTP root directory to serve files from", Dir.tmpdir  ]),
+        OptPath.new('OUTPUTPATH', [ true, "The directory in which uploaded files will be written.", Dir.tmpdir ])
       ], self.class)
   end
 

--- a/modules/auxiliary/server/tftp.rb
+++ b/modules/auxiliary/server/tftp.rb
@@ -5,6 +5,7 @@
 
 require 'msf/core'
 require 'rex/proto/tftp'
+require 'tmpdir'
 
 class Metasploit3 < Msf::Auxiliary
 
@@ -17,7 +18,7 @@ class Metasploit3 < Msf::Auxiliary
       'Description'    => %q{
         This module provides a TFTP service
       },
-      'Author'      => [ 'jduck' ],
+      'Author'      => [ 'jduck', 'todb' ],
       'License'     => MSF_LICENSE,
       'Actions'     =>
         [
@@ -34,8 +35,8 @@ class Metasploit3 < Msf::Auxiliary
       [
         OptAddress.new('SRVHOST',   [ true, "The local host to listen on.", '0.0.0.0' ]),
         OptPort.new('SRVPORT',      [ true, "The local port to listen on.", 69 ]),
-        OptString.new('TFTPROOT',   [ false,  "The TFTP root directory to serve files from" ]),
-        OptString.new('OUTPUTPATH', [ false, "The directory in which uploaded files will be written." ])
+        OptString.new('TFTPROOT',   [ true, "The TFTP root directory to serve files from", Dir.tmpdir  ]),
+        OptString.new('OUTPUTPATH', [ true, "The directory in which uploaded files will be written.", Dir.tmpdir ])
       ], self.class)
   end
 


### PR DESCRIPTION
This PR enables the user to bind the TFTP server to a particular IP address and port. Without these options, the user will often end up binding to the general IPv6 interface at address `::::` and the udp6 port of 69. This is bad for several reasons, such as requiring msfconsole being run as root and the inability to use udp (as opposed to udp6).

There is a lot more that could be done with this module, such as informing the user when files arrive, storing files in a more normal location with `store_loot`, and several other nice-to-haves.

I may or may not implement that later today, but this is the bare minimum needed to get this server module in a useful state for some upcoming demos.
## Verification
- [x] In msfconsole, `use auxiliary/server/tftp` and set options as below.
- [x] Transfer a file, as below, using a normal tftp client.
- [x] Note the binary option on the client side.
- [x] Ensure that the file is written correctly using md5sum or sha1sum.
- [x] Monitor the wire traffic to ensure it's actually IPv4 traffic: `tcpdump -n -X -s 60 -i vmnet8 host 192.168.145.193 and host 192.168.145.1`
## Proof

_On the Metasploit console_

```
/ \    /\         __                         _   __  /_/ __
| |\  / | _____   \ \           ___   _____ | | /  \ _   \ \
| | \/| | | ___\ |- -|   /\    / __\ | -__/ | || | || | |- -|
|_|   | | | _|__  | |_  / -\ __\ \   | |    | | \__/| |  | |_
      |/  |____/  \___\/ /\ \\___/   \/     \__|    |_\  \___\


       =[ metasploit v4.9.0-dev [core:4.9 api:1.0] ]
+ -- --=[ 1271 exploits - 697 auxiliary - 202 post ]
+ -- --=[ 331 payloads - 33 encoders - 8 nops      ]

msf > use auxiliary/server/tftp 
msf auxiliary(tftp) > show options

Module options (auxiliary/server/tftp):

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   OUTPUTPATH                   no        The directory in which uploaded files will be written.
   SRVHOST     0.0.0.0          yes       The local host to listen on.
   SRVPORT     69               yes       The local port to listen on.
   TFTPROOT                     no        The TFTP root directory to serve files from

msf auxiliary(tftp) > set TFTPROOT /tmp/
TFTPROOT => /tmp/
msf auxiliary(tftp) > set OUTPUTPATH /tmp/
OUTPUTPATH => /tmp/
msf auxiliary(tftp) > set SRVHOST 192.168.145.1
SRVHOST => 192.168.145.1
msf auxiliary(tftp) > set SRVPORT 6969
SRVPORT => 6969
msf auxiliary(tftp) > run
[*] Auxiliary module execution completed
msf auxiliary(tftp) > run
[*] Auxiliary module execution completed
msf auxiliary(tftp) > 
[*] Starting TFTP server on 192.168.145.1:6969...
[*] Files will be served from /tmp/
[*] Uploaded files will be saved in /tmp/

msf auxiliary(tftp) > md5sum /tmp/old-msf.jpg
[*] exec: md5sum /tmp/old-msf.jpg

c0f411b6d04892de92a68397b35beaff  /tmp/old-msf.jpg
msf auxiliary(tftp) > 
```

_On the tftp client_ 

```
todb@ubuntu:~$ tftp
tftp> connect 192.168.145.1:6969
192.168.145.1:6969: unknown host
tftp> connect    
(to) 192.168.145.1
tftp> connect
(to) 192.168.145.1 6969
tftp> binary
tftp> put old-msf.jpg
Sent 53476 bytes in 0.1 seconds
tftp> q
todb@ubuntu:~$ md5sum old-msf.jpg 
c0f411b6d04892de92a68397b35beaff  old-msf.jpg
```

_On either machine_

```
todb@mazikeen:/tmp
$ tcpdump -n -X -s 60 -i vmnet8 host 192.168.145.193 and host 192.168.145.1 | head -20
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on vmnet8, link-type EN10MB (Ethernet), capture size 60 bytes
10:31:03.982960 IP 192.168.145.193.33307 > 192.168.145.1.6969: UDP, length 20
    0x0000:  4500 0030 0000 4000 4011 96a9 c0a8 91c1  E..0..@.@.......
    0x0010:  c0a8 9101 821b 1b39 001c edd5 0002 6f6c  .......9......ol
    0x0020:  642d 6d73 662e 6a70 6700 6f63            d-msf.jpg.oc
10:31:03.983451 IP 192.168.145.1.6969 > 192.168.145.193.33307: UDP, length 4
    0x0000:  4500 0020 ab5f 4000 4011 eb59 c0a8 9101  E...._@.@..Y....
    0x0010:  c0a8 91c1 1b39 821b 000c be69 0004 0000  .....9.....i....
10:31:03.983694 IP 192.168.145.193.33307 > 192.168.145.1.6969: UDP, length 516
    0x0000:  4500 0220 0000 4000 4011 94b9 c0a8 91c1  E.....@.@.......
    0x0010:  c0a8 9101 821b 1b39 020c e037 0003 0001  .......9...7....
    0x0020:  ffd8 ffe0 0010 4a46 4946 0001            ......JFIF..
10:31:03.984019 IP 192.168.145.1.6969 > 192.168.145.193.33307: UDP, length 4
    0x0000:  4500 0020 ab60 4000 4011 eb58 c0a8 9101  E....`@.@..X....
    0x0010:  c0a8 91c1 1b39 821b 000c be68 0004 0001  .....9.....h....
10:31:03.984198 IP 192.168.145.193.33307 > 192.168.145.1.6969: UDP, length 516
    0x0000:  4500 0220 0000 4000 4011 94b9 c0a8 91c1  E.....@.@.......
    0x0010:  c0a8 9101 821b 1b39 020c dd9c 0003 0002  .......9........
    0x0020:  53bc a748 e773 b23a e345 dc94            S..H.s.:.E..
10:31:03.984512 IP 192.168.145.1.6969 > 192.168.145.193.33307: UDP, length 4
    0x0000:  4500 0020 ab61 4000 4011 eb57 c0a8 9101  E....a@.@..W....
34 packets captured
35 packets received by filter
```
