### PR TITLE
Release fixes

### DIFF
--- a/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
+++ b/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
@@ -1,8 +1,6 @@
 ##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# web site for more information on licensing and terms of use.
-#   http://metasploit.com/
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 require 'msf/core'
@@ -17,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Remote
   # unmount after the attack and not leave a trace on user's machine.
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Safari User-Assisted Download & Run Attack',
+      'Name'           => 'Safari User-Assisted Download and Run Attack',
       'Description'    => %q{
         This module abuses some Safari functionality to force the download of a
         zipped .app OSX application containing our payload. The app is then
@@ -57,6 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ]
         ],
       'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Mar 10 2014',
       'Author'         => [ 'joev' ],
       'BrowserRequirements' => {
         :source  => 'script',

--- a/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
+++ b/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Remote
         developer." To work around this issue, you will need to manually build and sign
         an OSX app containing your payload with a custom URL handler called "openurl".
 
-        You can put newlines & unicode in your APP_NAME, although you must be careful not
+        You can put newlines and unicode in your APP_NAME, although you must be careful not
         to create a prompt that is too tall, or the user will not be able to click
         the buttons, and will have to either logout or kill the CoreServicesUIAgent
         process.

--- a/test/modules/auxiliary/test/heaplib2.rb
+++ b/test/modules/auxiliary/test/heaplib2.rb
@@ -12,13 +12,13 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "heaplib2 test",
+      'Name'           => "Heaplib2 Test",
       'Description'    => %q{
-        This tests heaplib2
+        This tests heaplib2. Since it is a test module, it's not intended to do much useful work in the field.
       },
       'License'        => MSF_LICENSE,
       'Author'         => [ 'sinn3r' ],
-      'References'     => 
+      'References'     =>
         [
           [ 'URL', 'http://metasploit.com' ]
         ],


### PR DESCRIPTION
Note that the Safari module was not passing msftidy. I strongly encourage @jvennix-r7 and whomever landed this to use an msftidy pre-commit hook when committing to framework:

https://github.com/rapid7/metasploit-framework/blob/master/tools/dev/pre-commit-hook.rb

Thanks!

Travis should have caught this, but alas, we suspect the commit depth limiter is making it less than automatic. Should be solved (by @wvu-r7) some day.
