### PR TITLE
Fix first chunk of msftidy "bad char" errors

### DIFF
--- a/modules/auxiliary/admin/cisco/cisco_secure_acs_bypass.rb
+++ b/modules/auxiliary/admin/cisco/cisco_secure_acs_bypass.rb
@@ -13,7 +13,7 @@ class Metasploit4 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'         => 'Cisco Secure ACS Version < 5.1.0.44.5 or 5.2.0.26.2 Unauthorized Password Change',
+      'Name'         => 'Cisco Secure ACS Unauthorized Password Change',
       'Description'  => %q{
         This module exploits an authentication bypass issue which allows arbitrary
         password change requests to be issued for any user in the local store.

--- a/modules/auxiliary/dos/http/apache_mod_isapi.rb
+++ b/modules/auxiliary/dos/http/apache_mod_isapi.rb
@@ -12,25 +12,28 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Apache mod_isapi <= 2.2.14 Dangling Pointer',
+      'Name'           => 'Apache mod_isapi Dangling Pointer',
       'Description'    => %q{
-          This module triggers a use-after-free vulnerability in the Apache Software
-        Foundation mod_isapi extension. In order to reach the vulnerable code, the
-        target server must have an ISAPI module installed and configured.
+        This module triggers a use-after-free vulnerability in the Apache
+        Software Foundation mod_isapi extension for versions 2.2.14 and earlier.
+        In order to reach the vulnerable code, the target server must have an
+        ISAPI module installed and configured.
 
-        By making a request that terminates abnormally (either an aborted TCP connection or
-        an unsatisfied chunked request), mod_isapi will unload the ISAPI extension. Later,
-        if another request comes for that ISAPI module, previously obtained pointers will
-        be used resulting in an access violation or potentially arbitrary code execution.
+        By making a request that terminates abnormally (either an aborted TCP
+        connection or an unsatisfied chunked request), mod_isapi will unload the
+        ISAPI extension. Later, if another request comes for that ISAPI module,
+        previously obtained pointers will be used resulting in an access
+        violation or potentially arbitrary code execution.
 
-        Although arbitrary code execution is theoretically possible, a real-world method of
-        invoking this consequence has not been proven. In order to do so, one would need to
-        find a situation where a particular ISAPI module loads at an image base address
-        that can be re-allocated by a remote attacker.
+        Although arbitrary code execution is theoretically possible, a
+        real-world method of invoking this consequence has not been proven. In
+        order to do so, one would need to find a situation where a particular
+        ISAPI module loads at an image base address that can be re-allocated by
+        a remote attacker.
 
-        Limited success was encountered using two separate ISAPI modules. In this scenario,
-        a second ISAPI module was loaded into the same memory area as the previously
-        unloaded module.
+        Limited success was encountered using two separate ISAPI modules. In
+        this scenario, a second ISAPI module was loaded into the same memory
+        area as the previously unloaded module.
       },
       'Author'         =>
         [

--- a/modules/auxiliary/dos/mdns/avahi_portzero.rb
+++ b/modules/auxiliary/dos/mdns/avahi_portzero.rb
@@ -12,10 +12,10 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'Avahi < 0.6.24 Source Port 0 DoS',
+      'Name'        => 'Avahi Source Port 0 DoS',
       'Description' => %q{
         Avahi-daemon versions prior to 0.6.24 can be DoS'd
-        with an mDNS packet with a source port of 0
+        with an mDNS packet with a source port of 0.
       },
       'Author'      => 'kris katterjohn',
       'License'     => MSF_LICENSE,

--- a/modules/auxiliary/dos/smtp/sendmail_prescan.rb
+++ b/modules/auxiliary/dos/smtp/sendmail_prescan.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Sendmail SMTP Address prescan <= 8.12.8 Memory Corruption',
+      'Name'           => 'Sendmail SMTP Address prescan Memory Corruption',
       'Description'    => %q{
         This is a proof of concept denial of service module for Sendmail versions
         8.12.8 and earlier. The vulnerability is within the prescan() method when

--- a/modules/auxiliary/dos/ssl/dtls_changecipherspec.rb
+++ b/modules/auxiliary/dos/ssl/dtls_changecipherspec.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'		=> 'OpenSSL < 0.9.8i DTLS ChangeCipherSpec Remote DoS',
+      'Name'		=> 'OpenSSL DTLS ChangeCipherSpec Remote DoS',
       'Description'	=> %q{
           This module performs a Denial of Service Attack against Datagram TLS in OpenSSL
         version 0.9.8i and earlier. OpenSSL crashes under these versions when it recieves a

--- a/modules/auxiliary/dos/windows/ftp/filezilla_server_port.rb
+++ b/modules/auxiliary/dos/windows/ftp/filezilla_server_port.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'		=> 'FileZilla FTP Server <=0.9.21 Malformed PORT Denial of Service',
+      'Name'		=> 'FileZilla FTP Server Malformed PORT Denial of Service',
       'Description'	=> %q{
         This module triggers a Denial of Service condition in the FileZilla FTP
         Server versions 0.9.21 and earlier. By sending a malformed PORT command

--- a/modules/auxiliary/dos/windows/ftp/iis_list_exhaustion.rb
+++ b/modules/auxiliary/dos/windows/ftp/iis_list_exhaustion.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft IIS FTP Server <= 7.0 LIST Stack Exhaustion',
+      'Name'           => 'Microsoft IIS FTP Server LIST Stack Exhaustion',
       'Description'    => %q{
           This module triggers Denial of Service condition in the Microsoft Internet
         Information Services (IIS) FTP Server 5.0 through 7.0 via a list (ls) -R command

--- a/modules/auxiliary/dos/windows/ftp/solarftp_user.rb
+++ b/modules/auxiliary/dos/windows/ftp/solarftp_user.rb
@@ -12,11 +12,12 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => 'Solar FTP Server <= 2.1.1 Malformed (User) Denial of Service',
+      'Name'           => 'Solar FTP Server Malformed USER Denial of Service',
       'Description'    => %q{
-        This module will send a format string as USER to Solar FTP, causing a READ
-        violation in function "__output_1()" found in "sfsservice.exe" while trying to
-        calculate the length of the string.
+        This module will send a format string as USER to Solar FTP, causing a
+        READ violation in function "__output_1()" found in "sfsservice.exe"
+        while trying to calculate the length of the string. This vulnerability
+        affects versions 2.1.1 and earlier.
       },
       'Author'         =>
       [

--- a/modules/auxiliary/dos/windows/http/pi3web_isapi.rb
+++ b/modules/auxiliary/dos/windows/http/pi3web_isapi.rb
@@ -12,12 +12,12 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Pi3Web <=2.0.13 ISAPI DoS',
+      'Name'           => 'Pi3Web ISAPI DoS',
       'Description'    => %q{
-        The Pi3Web HTTP server crashes when a request is made
-        for an invalid DLL file in /isapi.  By default, the
-        non-DLLs in this directory after installation are
-        users.txt, install.daf and readme.daf.
+        The Pi3Web HTTP server crashes when a request is made for an invalid DLL
+        file in /isapi for versions 2.0.13 and earlier. By default, the non-DLLs
+        in this directory after installation are users.txt, install.daf and
+        readme.daf.
       },
       'Author'         => 'kris katterjohn',
       'License'        => MSF_LICENSE,

--- a/modules/auxiliary/gather/eaton_nsm_creds.rb
+++ b/modules/auxiliary/gather/eaton_nsm_creds.rb
@@ -12,12 +12,14 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Network Shutdown Module <= 3.21 (sort_values) Credential Dumper',
+      'Name'           => 'Network Shutdown Module sort_values Credential Dumper',
       'Description'    => %q{
-        This module will extract user credentials from Network Shutdown Module by exploiting
-        a vulnerability found in lib/dbtools.inc, which uses unsanitized user input inside a
-        eval() call.  Please note that in order to extract credentials,the vulnerable service
-        must have at least one USV module (an entry in the "nodes" table in mgedb.db)
+        This module will extract user credentials from Network Shutdown Module
+        versions 3.21 and earlier by exploiting a vulnerability found in
+        lib/dbtools.inc, which uses unsanitized user input inside a eval() call.
+        Please note that in order to extract credentials,the vulnerable service
+        must have at least one USV module (an entry in the "nodes" table in
+        mgedb.db).
       },
       'References'     =>
         [

--- a/modules/auxiliary/scanner/http/dolibarr_login.rb
+++ b/modules/auxiliary/scanner/http/dolibarr_login.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Dolibarr ERP & CRM 3 Login Utility',
+      'Name'           => 'Dolibarr ERP/CRM Login Utility',
       'Description'    => %q{
         This module attempts to authenticate to a Dolibarr ERP/CRM's admin web interface,
         and should only work against version 3.1.1 or older, because these versions do not

--- a/modules/exploits/freebsd/tacacs/xtacacsd_report.rb
+++ b/modules/exploits/freebsd/tacacs/xtacacsd_report.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'XTACACSD <= 4.1.2 report() Buffer Overflow',
+      'Name'           => 'XTACACSD report() Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in XTACACSD <= 4.1.2. By
         sending a specially crafted XTACACS packet with an overly long

--- a/modules/exploits/linux/http/dolibarr_cmd_exec.rb
+++ b/modules/exploits/linux/http/dolibarr_cmd_exec.rb
@@ -12,9 +12,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Dolibarr ERP & CRM 3 Post-Auth OS Command Injection",
+      'Name'           => "Dolibarr ERP/CRM Post-Auth OS Command Injection",
       'Description'    => %q{
-          This module exploits a vulnerability found in Dolibarr ERP/CRM's
+          This module exploits a vulnerability found in Dolibarr ERP/CRM 3's
         backup feature.  This software is used to manage a company's business
         information such as contacts, invoices, orders, stocks, agenda, etc.
         When processing a database backup request, the export.php function

--- a/modules/exploits/linux/http/peercast_url.rb
+++ b/modules/exploits/linux/http/peercast_url.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'PeerCast <= 0.1216 URL Handling Buffer Overflow (linux)',
+      'Name'           => 'PeerCast URL Handling Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in PeerCast <= v0.1216.
         The vulnerability is caused due to a boundary error within the

--- a/modules/exploits/multi/browser/mozilla_compareto.rb
+++ b/modules/exploits/multi/browser/mozilla_compareto.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Mozilla Suite/Firefox InstallVersion->compareTo() Code Execution',
+      'Name'           => 'Mozilla Suite/Firefox compareTo() Code Execution',
       'Description'    => %q{
           This module exploits a code execution vulnerability in the Mozilla
         Suite, Mozilla Firefox, and Mozilla Thunderbird applications. This exploit

--- a/modules/exploits/multi/fileformat/peazip_command_injection.rb
+++ b/modules/exploits/multi/fileformat/peazip_command_injection.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'PeaZip <= 2.6.1 Zip Processing Command Injection',
+      'Name'           => 'PeaZip Zip Processing Command Injection',
       'Description'    => %q{
           This module exploits a command injection vulnerability in PeaZip. All
         versions prior to 2.6.2 are suspected vulnerable. Testing was conducted with

--- a/modules/exploits/multi/http/activecollab_chat.rb
+++ b/modules/exploits/multi/http/activecollab_chat.rb
@@ -12,11 +12,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => 'Active Collab "chat module" <= 2.3.8 Remote PHP Code Injection Exploit',
+      'Name'           => 'Active Collab "chat module" Remote PHP Code Injection Exploit',
       'Description'    => %q{
-        This module exploits an arbitrary code injection vulnerability in the chat module
-        that is part of Active Collab by abusing a preg_replace() using the /e modifier and
-        its replacement string using double quotes. The vulnerable function can be found in
+        This module exploits an arbitrary code injection vulnerability in the
+        chat module that is part of Active Collab versions 2.3.8 and earlier by
+        abusing a preg_replace() using the /e modifier and its replacement
+        string using double quotes. The vulnerable function can be found in
         activecollab/application/modules/chat/functions/html_to_text.php.
       },
       'License'        => MSF_LICENSE,

--- a/modules/exploits/multi/http/phpldapadmin_query_engine.rb
+++ b/modules/exploits/multi/http/phpldapadmin_query_engine.rb
@@ -12,12 +12,13 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'phpLDAPadmin <= 1.2.1.1 (query_engine) Remote PHP Code Injection',
+      'Name'           => 'phpLDAPadmin query_engine Remote PHP Code Injection',
       'Description'    => %q{
-          This module exploits a vulnerability in the lib/functions.php that allows
-        attackers input parsed directly to the create_function() php function. A patch was
-        issued that uses a whitelist regex expression to check the user supplied input
-        before being parsed to the create_function() call.
+        This module exploits a vulnerability in the lib/functions.php for
+        phpLDAPadmin versions 1.2.1.1 and earlier that allows attackers input
+        parsed directly to the create_function() php function. A patch was
+        issued that uses a whitelist regex expression to check the user supplied
+        input before being parsed to the create_function() call.
       },
       'Author'         =>
         [

--- a/modules/exploits/multi/http/pmwiki_pagelist.rb
+++ b/modules/exploits/multi/http/pmwiki_pagelist.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => 'PmWiki <= 2.2.34 pagelist.php Remote PHP Code Injection Exploit',
+      'Name'           => 'PmWiki pagelist.php Remote PHP Code Injection Exploit',
       'Description'    => %q{
         This module exploits an arbitrary command execution vulnerability
         in PmWiki from 2.0.0 to 2.2.34. The vulnerable function is

--- a/modules/exploits/multi/http/sit_file_upload.rb
+++ b/modules/exploits/multi/http/sit_file_upload.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Support Incident Tracker <= 3.65 Remote Command Execution',
+      'Name'           => 'Support Incident Tracker Remote Command Execution',
       'Description'    => %q{
           This module combines two separate issues within Support Incident Tracker (<= 3.65)
         application to upload arbitrary data and thus execute a shell. The two issues exist

--- a/modules/exploits/multi/http/spree_searchlogic_exec.rb
+++ b/modules/exploits/multi/http/spree_searchlogic_exec.rb
@@ -14,11 +14,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Spreecommerce < 0.50.0 Arbitrary Command Execution',
+      'Name'           => 'Spreecommerce Arbitrary Command Execution',
       'Description'    => %q{
-          This module exploits an arbitrary command execution vulnerability in the
-          Spreecommerce API searchlogic. Unvalidated input is called via the
-          Ruby send method allowing command execution.
+          This module exploits an arbitrary command execution vulnerability in
+          the Spreecommerce API searchlogic for versions 0.50.0 and earlier.
+          Unvalidated input is called via the Ruby send method allowing command
+          execution.
       },
       'Author'         => [ 'joernchen <joernchen[at]phenoelit.de>' ], #Phenoelit
       'License'        => MSF_LICENSE,

--- a/modules/exploits/multi/http/struts_code_exec.rb
+++ b/modules/exploits/multi/http/struts_code_exec.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Apache Struts < 2.2.0 Remote Command Execution',
+      'Name'           => 'Apache Struts Remote Command Execution',
       'Description'    => %q{
           This module exploits a remote command execution vulnerability in
         Apache Struts versions < 2.2.0. This issue is caused by a failure to properly

--- a/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
+++ b/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Apache Struts <= 2.2.1.1 Remote Command Execution',
+      'Name'           => 'Apache Struts Remote Command Execution',
       'Description'    => %q{
           This module exploits a remote command execution vulnerability in
         Apache Struts versions < 2.2.1.1. This issue is caused because the

--- a/modules/exploits/multi/http/vbseo_proc_deutf.rb
+++ b/modules/exploits/multi/http/vbseo_proc_deutf.rb
@@ -12,13 +12,14 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'vBSEO <= 3.6.0 proc_deutf() Remote PHP Code Injection',
+      'Name'           => 'vBSEO proc_deutf() Remote PHP Code Injection',
       'Description'    => %q{
-          This module exploits a vulnerability in the 'proc_deutf()' function
-        defined in /includes/functions_vbseocp_abstract.php. User input passed through
-        'char_repl' POST parameter isn't properly sanitized before being used in a call
-        to preg_replace() function which uses the 'e' modifier. This can be exploited to
-        inject and execute arbitrary code leveraging the PHP's complex curly syntax.
+        This module exploits a vulnerability in the 'proc_deutf()' function
+        defined in /includes/functions_vbseocp_abstract.php for vBSEO versions
+        3.6.0 and earlier. User input passed through 'char_repl' POST parameter
+        isn't properly sanitized before being used in a call to preg_replace()
+        function which uses the 'e' modifier. This can be exploited to inject
+        and execute arbitrary code leveraging the PHP's complex curly syntax.
       },
       'Author'         => 'EgiX <n0b0d13s[at]gmail.com>', # originally reported by the vendor
       'License'        => MSF_LICENSE,

--- a/modules/exploits/unix/smtp/exim4_string_format.rb
+++ b/modules/exploits/unix/smtp/exim4_string_format.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Exim4 <= 4.69 string_format Function Heap Buffer Overflow',
+      'Name'           => 'Exim4 string_format Function Heap Buffer Overflow',
       'Description'    => %q{
           This module exploits a heap buffer overflow within versions of Exim prior to
         version 4.69. By sending a specially crafted message, an attacker can corrupt the

--- a/modules/exploits/unix/webapp/awstatstotals_multisort.rb
+++ b/modules/exploits/unix/webapp/awstatstotals_multisort.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'AWStats Totals <= v1.14 multisort Remote Command Execution',
+      'Name'           => 'AWStats Totals multisort Remote Command Execution',
       'Description'    => %q{
           This module exploits an arbitrary command execution vulnerability in the
           AWStats Totals PHP script. AWStats Totals version v1.0 - v1.14 are vulnerable.

--- a/modules/exploits/unix/webapp/cakephp_cache_corruption.rb
+++ b/modules/exploits/unix/webapp/cakephp_cache_corruption.rb
@@ -12,12 +12,13 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'CakePHP <= 1.3.5 / 1.2.8 Cache Corruption Code Execution',
+      'Name'           => 'CakePHP Cache Corruption Code Execution',
       'Description'    => %q{
-          CakePHP is a popular PHP framework for building web applications.
-        The Security component of CakePHP is vulnerable to an unserialize attack which
-        could be abused to allow unauthenticated attackers to execute arbitrary
-        code with the permissions of the webserver.
+        CakePHP is a popular PHP framework for building web applications.  The
+        Security component of CakePHP versions 1.3.5 and earlier and 1.2.8 and
+        earlier is vulnerable to an unserialize attack which could be abused to
+        allow unauthenticated attackers to execute arbitrary code with the
+        permissions of the webserver.
       },
       'Author'	=>
         [

--- a/modules/exploits/unix/webapp/coppermine_piceditor.rb
+++ b/modules/exploits/unix/webapp/coppermine_piceditor.rb
@@ -14,15 +14,16 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Coppermine Photo Gallery <= 1.4.14 picEditor.php Command Execution',
+      'Name'           => 'Coppermine Photo Gallery picEditor.php Command Execution',
       'Description'    => %q{
-          This module exploits a vulnerability in the picEditor.php script of Coppermine
-        Photo Gallery. When configured to use the ImageMagick library, the 'quality', 'angle',
-        and 'clipval' parameters are not properly escaped before being passed to the PHP
+        This module exploits a vulnerability in the picEditor.php script of
+        Coppermine Photo Gallery versions 1.4.14 and earlier. When configured to
+        use the ImageMagick library, the 'quality', 'angle', and 'clipval'
+        parameters are not properly escaped before being passed to the PHP
         'exec' command.
 
-        In order to reach the vulnerable 'exec' call, the input must pass several validation
-        steps.
+        In order to reach the vulnerable 'exec' call, the input must pass
+        several validation steps.
 
         The vulnerabilities actually reside in the following functions:
 
@@ -32,8 +33,8 @@ class Metasploit3 < Msf::Exploit::Remote
         include/imageObjectIM.class.php: imageObject::resizeImage(...)
         include/picmgmt.inc.php: resize_image(...)
 
-        NOTE: Use of the ImageMagick library is a non-default option. However, a user can
-        specify its use at installation time.
+        NOTE: Use of the ImageMagick library is a non-default option. However, a
+        user can specify its use at installation time.
       },
       'Author'         =>
         [

--- a/modules/exploits/unix/webapp/sphpblog_file_upload.rb
+++ b/modules/exploits/unix/webapp/sphpblog_file_upload.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Simple PHP Blog <= 0.4.0 Remote Command Execution',
+      'Name'           => 'Simple PHP Blog Remote Command Execution',
       'Description'    => %q{
           This module combines three separate issues within The Simple PHP Blog (<= 0.4.0)
         application to upload arbitrary data and thus execute a shell. The first

--- a/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'SugarCRM <= 6.3.1 unserialize() PHP Code Execution',
+      'Name'           => 'SugarCRM unserialize() PHP Code Execution',
       'Description'    => %q{
           This module exploits a php unserialize() vulnerability in SugarCRM <= 6.3.1
         which could be abused to allow authenticated SugarCRM users to execute arbitrary

--- a/modules/exploits/unix/webapp/tikiwiki_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_unserialize_exec.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Tiki Wiki <= 8.3 unserialize() PHP Code Execution',
+      'Name'           => 'Tiki Wiki unserialize() PHP Code Execution',
       'Description'    => %q{
           This module exploits a php unserialize() vulnerability in Tiki Wiki <= 8.3
         which could be abused to allow unauthenticated users to execute arbitrary code

--- a/modules/exploits/windows/brightstor/lgserver.rb
+++ b/modules/exploits/windows/brightstor/lgserver.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'CA BrightStor ARCserve for Laptops & Desktops LGServer Buffer Overflow',
+      'Name'           => 'CA BrightStor ARCserve for Laptops and Desktops LGServer Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Computer Associates BrightStor ARCserve Backup
         for Laptops & Desktops 11.1. By sending a specially crafted request, an attacker could

--- a/modules/exploits/windows/brightstor/lgserver_multi.rb
+++ b/modules/exploits/windows/brightstor/lgserver_multi.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'CA BrightStor ARCserve for Laptops & Desktops LGServer Multiple Commands Buffer Overflow',
+      'Name'           => 'CA BrightStor ARCserve for Laptops and Desktops LGServer Multiple Commands Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Computer Associates BrightStor ARCserve Backup
         for Laptops & Desktops 11.1. By sending a specially crafted request to multiple commands,

--- a/modules/exploits/windows/brightstor/lgserver_rxrlogin.rb
+++ b/modules/exploits/windows/brightstor/lgserver_rxrlogin.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'CA BrightStor ARCserve for Laptops & Desktops LGServer Buffer Overflow',
+      'Name'           => 'CA BrightStor ARCserve for Laptops and Desktops LGServer Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Computer Associates BrightStor ARCserve Backup
         for Laptops & Desktops 11.1. By sending a specially crafted request, an attacker could

--- a/modules/exploits/windows/brightstor/lgserver_rxssetdatagrowthscheduleandfilter.rb
+++ b/modules/exploits/windows/brightstor/lgserver_rxssetdatagrowthscheduleandfilter.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'CA BrightStor ARCserve for Laptops & Desktops LGServer (rxsSetDataGrowthScheduleAndFilter) Buffer Overflow',
+      'Name'           => 'CA BrightStor ARCserve for Laptops and Desktops LGServer rxsSetDataGrowthScheduleAndFilter Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Computer Associates BrightStor ARCserve Backup
         for Laptops & Desktops 11.1. By sending a specially crafted request (rxsSetDataGrowthScheduleAndFilter),

--- a/modules/exploits/windows/brightstor/lgserver_rxsuselicenseini.rb
+++ b/modules/exploits/windows/brightstor/lgserver_rxsuselicenseini.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'CA BrightStor ARCserve for Laptops & Desktops LGServer Buffer Overflow',
+      'Name'           => 'CA BrightStor ARCserve for Laptops and Desktops LGServer Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Computer Associates BrightStor ARCserve Backup
         for Laptops & Desktops 11.1. By sending a specially crafted request (rxsUseLicenseIni), an

--- a/modules/exploits/windows/browser/dxstudio_player_exec.rb
+++ b/modules/exploits/windows/browser/dxstudio_player_exec.rb
@@ -14,21 +14,21 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Worldweaver DX Studio Player <= 3.0.29 shell.execute() Command Execution',
+      'Name'           => 'Worldweaver DX Studio Player shell.execute() Command Execution',
       'Description'    => %q{
-          This module exploits a command execution vulnerability within the
-        DX Studio Player from Worldweaver. The player is a browser plugin for
-        IE (ActiveX) and Firefox (dll). When an unsuspecting user visits a web
-        page referring to a specially crafted .dxstudio document, an attacker can
-        execute arbitrary commands.
+        This module exploits a command execution vulnerability within the DX
+        Studio Player from Worldweaver for versions 3.0.29 and earlier. The
+        player is a browser plugin for IE (ActiveX) and Firefox (dll). When an
+        unsuspecting user visits a web page referring to a specially crafted
+        .dxstudio document, an attacker can execute arbitrary commands.
 
-        Testing was conducted using plugin version 3.0.29.0 for Firefox 2.0.0.20 and
-        IE 6 on Windows XP SP3. In IE, the user will be prompted if they wish to allow
-        the plug-in to access local files. This prompt appears to occur only once per
-        server host.
+        Testing was conducted using plugin version 3.0.29.0 for Firefox 2.0.0.20
+        and IE 6 on Windows XP SP3. In IE, the user will be prompted if they
+        wish to allow the plug-in to access local files. This prompt appears to
+        occur only once per server host.
 
-        NOTE: This exploit uses additionally dangerous script features to write to
-        local files!
+        NOTE: This exploit uses additionally dangerous script features to write
+        to local files!
       },
       'License'        => MSF_LICENSE,
       'Author'         => [ 'jduck' ],

--- a/modules/exploits/windows/browser/mozilla_nssvgvalue.rb
+++ b/modules/exploits/windows/browser/mozilla_nssvgvalue.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Firefox 7/8 (<= 8.0.1) nsSVGValue Out-of-Bounds Access Vulnerability',
+      'Name'           => 'Firefox nsSVGValue Out-of-Bounds Access Vulnerability',
       'Description'    => %q{
         This module exploits an out-of-bounds access flaw in Firefox 7 and 8 (<= 8.0.1).
         The notification of nsSVGValue observers via nsSVGValue::NotifyObservers(x,y)

--- a/modules/exploits/windows/browser/novelliprint_getdriversettings_2.rb
+++ b/modules/exploits/windows/browser/novelliprint_getdriversettings_2.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super( update_info(info,
-      'Name'           => 'Novell iPrint Client ActiveX Control <= 5.52 Buffer Overflow',
+      'Name'           => 'Novell iPrint Client ActiveX Control Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Novell iPrint Client 5.52. When
         sending an overly long string to the GetDriverSettings() property of ienipp.ocx

--- a/modules/exploits/windows/browser/teechart_pro.rb
+++ b/modules/exploits/windows/browser/teechart_pro.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super( update_info(info,
-      'Name'           => 'TeeChart Professional ActiveX Control <= 2010.0.0.3 Trusted Integer Dereference',
+      'Name'           => 'TeeChart Professional ActiveX Control Trusted Integer Dereference',
       'Description'    => %q{
           This module exploits a integer overflow in TeeChart Pro ActiveX control. When
         sending an overly large/negative integer value to the AddSeries() property of

--- a/modules/exploits/windows/fileformat/cain_abel_4918_rdp.rb
+++ b/modules/exploits/windows/fileformat/cain_abel_4918_rdp.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Cain & Abel <= v4.9.24 RDP Buffer Overflow',
+      'Name'           => 'Cain and Abel RDP Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack-based buffer overflow in the Cain & Abel v4.9.24
         and below. An attacker must send the file to victim, and the victim must open

--- a/modules/exploits/windows/fileformat/esignal_styletemplate_bof.rb
+++ b/modules/exploits/windows/fileformat/esignal_styletemplate_bof.rb
@@ -13,13 +13,14 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'eSignal and eSignal Pro <= 10.6.2425.1208 File Parsing Buffer Overflow in QUO',
+      'Name'           => 'eSignal and eSignal Pro File Parsing Buffer Overflow in QUO',
       'Description'    => %q{
-        The software is unable to handle the "<StyleTemplate>" files (even
-        those original included in the program) like those with the registered
-        extensions QUO, SUM and POR. Successful exploitation of this vulnerability
-        may take up to several seconds due to the use of egghunter.  Also, DEP
-        bypass is unlikely due to the limited space for payload.
+        The software is unable to handle the "<StyleTemplate>" files (even those
+        original included in the program) like those with the registered
+        extensions QUO, SUM and POR. Successful exploitation of this
+        vulnerability may take up to several seconds due to the use of
+        egghunter. Also, DEP bypass is unlikely due to the limited space for
+        payload. This vulnerability affects versions 10.6.2425.1208 and earlier.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/windows/fileformat/feeddemon_opml.rb
+++ b/modules/exploits/windows/fileformat/feeddemon_opml.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'FeedDemon <= 3.1.0.12 Stack Buffer Overflow',
+      'Name'           => 'FeedDemon Stack Buffer Overflow',
       'Description'    => %q{
           This module exploits a buffer overflow in FeedDemon v3.1.0.12. When the application
         is used to import a specially crafted opml file, a buffer overflow occurs allowing

--- a/modules/exploits/windows/fileformat/irfanview_jpeg2000_bof.rb
+++ b/modules/exploits/windows/fileformat/irfanview_jpeg2000_bof.rb
@@ -13,18 +13,19 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Irfanview JPEG2000 <= v4.3.2.0 jp2 Stack Buffer Overflow',
+      'Name'           => 'Irfanview JPEG2000 jp2 Stack Buffer Overflow',
       'Description'    => %q{
-          This module exploits a stack-based buffer overflow vulnerability in
-        version <= 4.3.2.0 of Irfanview's JPEG2000.dll plugin. This exploit has been
-        tested on a specific version of irfanview (v4.3.2), although other versions may
-        work also. The vulnerability is triggered via parsing an invalid qcd chunk
-        structure and specifying a malformed qcd size and data.
+        This module exploits a stack-based buffer overflow vulnerability in
+        version <= 4.3.2.0 of Irfanview's JPEG2000.dll plugin. This exploit has
+        been tested on a specific version of irfanview (v4.3.2), although other
+        versions may work also. The vulnerability is triggered via parsing an
+        invalid qcd chunk structure and specifying a malformed qcd size and
+        data.
 
-        Payload delivery and vulnerability trigger can be executed in multiple ways.
-        The user can double click the file, use the file dialog, open via the icon
-        and drag/drop the file into Irfanview\'s window. An egg hunter is used for
-        stability.
+        Payload delivery and vulnerability trigger can be executed in multiple
+        ways. The user can double click the file, use the file dialog, open via
+        the icon and drag/drop the file into Irfanview's window. An egg hunter
+        is used for stability.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/windows/fileformat/scadaphone_zip.rb
+++ b/modules/exploits/windows/fileformat/scadaphone_zip.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'ScadaTEC ScadaPhone <= v5.3.11.1230 Stack Buffer Overflow',
+      'Name'           => 'ScadaTEC ScadaPhone Stack Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack-based buffer overflow vulnerability in
         version 5.3.11.1230 of scadaTEC's ScadaPhone.

--- a/modules/exploits/windows/fileformat/videospirit_visprj.rb
+++ b/modules/exploits/windows/fileformat/videospirit_visprj.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'VeryTools Video Spirit Pro <= 1.70',
+      'Name'           => 'VeryTools Video Spirit Pro',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Video Spirit <= 1.70.
         When opening a malicious project file (.visprj), a stack buffer overflow occurs,

--- a/modules/exploits/windows/fileformat/wireshark_packet_dect.rb
+++ b/modules/exploits/windows/fileformat/wireshark_packet_dect.rb
@@ -12,13 +12,13 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Wireshark <= 1.4.4 packet-dect.c Stack Buffer Overflow (local)',
+      'Name'           => 'Wireshark packet-dect.c Stack Buffer Overflow (local)',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Wireshark <= 1.4.4
         When opening a malicious .pcap file in Wireshark, a stack buffer occurs,
         resulting in arbitrary code execution.
 
-        Note: To exploit the vulnerability remotely with Scapy: sendp(rdpcap("file"))
+        Note: To exploit the vulnerability remotely with Scapy: sendp(rdpcap("file")).
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/windows/ftp/easyftp_cwd_fixret.rb
+++ b/modules/exploits/windows/ftp/easyftp_cwd_fixret.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'EasyFTP Server <= 1.7.0.11 CWD Command Stack Buffer Overflow',
+      'Name'           => 'EasyFTP Server CWD Command Stack Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack-based buffer overflow in EasyFTP Server 1.7.0.11
         and earlier. EasyFTP fails to check input size when parsing 'CWD' commands, which

--- a/modules/exploits/windows/ftp/easyftp_list_fixret.rb
+++ b/modules/exploits/windows/ftp/easyftp_list_fixret.rb
@@ -21,7 +21,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'EasyFTP Server <= 1.7.0.11 LIST Command Stack Buffer Overflow',
+      'Name'           => 'EasyFTP Server LIST Command Stack Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack-based buffer overflow in EasyFTP Server 1.7.0.11.
         credit goes to Karn Ganeshan.

--- a/modules/exploits/windows/ftp/easyftp_mkd_fixret.rb
+++ b/modules/exploits/windows/ftp/easyftp_mkd_fixret.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'EasyFTP Server <= 1.7.0.11 MKD Command Stack Buffer Overflow',
+      'Name'           => 'EasyFTP Server MKD Command Stack Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack-based buffer overflow in EasyFTP Server 1.7.0.11
         and earlier. EasyFTP fails to check input size when parsing 'MKD' commands, which

--- a/modules/exploits/windows/ftp/scriptftp_list.rb
+++ b/modules/exploits/windows/ftp/scriptftp_list.rb
@@ -12,14 +12,16 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'ScriptFTP <= 3.3 Remote Buffer Overflow (LIST)',
+      'Name'           => 'ScriptFTP LIST Remote Buffer Overflow',
       'Description'    => %q{
-          AmmSoft's ScriptFTP client is susceptible to a remote buffer overflow
-        vulnerability that is triggered when processing a sufficiently long filename during
-        a FTP LIST command resulting in overwriting the exception handler. Social engineering
-        of executing a specially crafted ftp file by double click will result in connecting to
-        our malcious server and perform arbitrary code execution which allows the attacker
-        to gain the same rights as the user running ScriptFTP.
+        AmmSoft's ScriptFTP client is susceptible to a remote buffer overflow
+        vulnerability that is triggered when processing a sufficiently long
+        filename during a FTP LIST command resulting in overwriting the
+        exception handler. Social engineering of executing a specially crafted
+        ftp file by double click will result in connecting to our malcious
+        server and perform arbitrary code execution which allows the attacker to
+        gain the same rights as the user running ScriptFTP. This vulnerability
+        affects versions 3.3 and earlier.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/windows/ftp/servu_chmod.rb
+++ b/modules/exploits/windows/ftp/servu_chmod.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Serv-U FTP Server < 4.2 Buffer Overflow',
+      'Name'           => 'Serv-U FTP Server Buffer Overflow',
       'Description'    => %q{
         This module exploits a stack buffer overflow in the site chmod command
         in versions of Serv-U FTP Server prior to 4.2.

--- a/modules/exploits/windows/http/easyftp_list.rb
+++ b/modules/exploits/windows/http/easyftp_list.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'EasyFTP Server <= 1.7.0.11 list.html path Stack Buffer Overflow',
+      'Name'           => 'EasyFTP Server list.html path Stack Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack-based buffer overflow in EasyFTP Server 1.7.0.11
         and earlier. EasyFTP fails to check input size when parsing the 'path' parameter

--- a/modules/exploits/windows/http/ezserver_http.rb
+++ b/modules/exploits/windows/http/ezserver_http.rb
@@ -14,11 +14,13 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'EZHomeTech EzServer <= 6.4.017 Stack Buffer Overflow Vulnerability',
+      'Name'           => 'EZHomeTech EzServer Stack Buffer Overflow Vulnerability',
       'Description'    => %q{
-        This module exploits a stack buffer overflow in the EZHomeTech EZServer. If a malicious
-        user sends packets containing an overly long string, it may be possible to execute a
-        payload remotely. Due to size constraints, this module uses the Egghunter technique.
+        This module exploits a stack buffer overflow in the EZHomeTech EZServer
+        for versions 6.4.017 and earlier. If a malicious user sends packets
+        containing an overly long string, it may be possible to execute a
+        payload remotely. Due to size constraints, this module uses the
+        Egghunter technique.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/windows/http/icecast_header.rb
+++ b/modules/exploits/windows/http/icecast_header.rb
@@ -12,23 +12,20 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Icecast (<= 2.0.1) Header Overwrite (win32)',
+      'Name'           => 'Icecast Header Overwrite',
       'Description'    => %q{
-          This module exploits a buffer overflow in the header parsing
-        of icecast, discovered by Luigi Auriemma.  Sending 32 HTTP
-        headers will cause a write one past the end of a pointer
-        array.  On win32 this happens to overwrite the saved
-        instruction pointer, and on linux (depending on compiler,
-        etc) this seems to generally overwrite nothing crucial (read
-        not exploitable).
+        This module exploits a buffer overflow in the header parsing of icecast
+        versions 2.0.1 and earlier, discovered by Luigi Auriemma. Sending 32
+        HTTP headers will cause a write one past the end of a pointer array. On
+        win32 this happens to overwrite the saved instruction pointer, and on
+        linux (depending on compiler, etc) this seems to generally overwrite
+        nothing crucial (read not exploitable).
 
-        !! This exploit uses ExitThread(), this will leave icecast
-        thinking the thread is still in use, and the thread counter
-        won't be decremented.  This means for each time your payload
-        exits, the counter will be left incremented, and eventually
-        the threadpool limit will be maxed.  So you can multihit,
-        but only till you fill the threadpool.
-
+        This exploit uses ExitThread(), this will leave icecast thinking the
+        thread is still in use, and the thread counter won't be decremented.
+        This means for each time your payload exits, the counter will be left
+        incremented, and eventually the threadpool limit will be maxed. So you
+        can multihit, but only till you fill the threadpool.
       },
       'Author'         => [ 'spoonm', 'Luigi Auriemma <aluigi[at]autistici.org>' ],
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/http/kolibri_http.rb
+++ b/modules/exploits/windows/http/kolibri_http.rb
@@ -15,8 +15,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Kolibri <= v2.0 HTTP Server HEAD Buffer Overflow',
-      'Description'    => %q{This exploits a stack buffer overflow in version 2 of the Kolibri HTTP server.},
+      'Name'           => 'Kolibri HTTP Server HEAD Buffer Overflow',
+      'Description'    => %q{
+        This exploits a stack buffer overflow in version 2 of the Kolibri HTTP server.
+      },
       'Author'         =>
           [
             'mr_me <steventhomasseeley[at]gmail.com>', # msf

--- a/modules/exploits/windows/http/mdaemon_worldclient_form2raw.rb
+++ b/modules/exploits/windows/http/mdaemon_worldclient_form2raw.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'		=> 'MDaemon <= 6.8.5 WorldClient form2raw.cgi Stack Buffer Overflow',
+      'Name'		=> 'MDaemon WorldClient form2raw.cgi Stack Buffer Overflow',
       'Description'	=> %q{
       This module exploits a stack buffer overflow in Alt-N MDaemon SMTP server for
       versions 6.8.5 and earlier. When WorldClient HTTP server is installed (default),

--- a/modules/exploits/windows/http/peercast_url.rb
+++ b/modules/exploits/windows/http/peercast_url.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'PeerCast <= 0.1216 URL Handling Buffer Overflow (win32)',
+      'Name'           => 'PeerCast URL Handling Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in PeerCast <= v0.1216.
         The vulnerability is caused due to a boundary error within the

--- a/modules/exploits/windows/http/shttpd_post.rb
+++ b/modules/exploits/windows/http/shttpd_post.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'SHTTPD <= 1.34 URI-Encoded POST Request Overflow (win32)',
+      'Name'           => 'SHTTPD URI-Encoded POST Request Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in SHTTPD <= 1.34.
         The vulnerability is caused due to a boundary error within the

--- a/modules/exploits/windows/http/steamcast_useragent.rb
+++ b/modules/exploits/windows/http/steamcast_useragent.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Streamcast <= 0.9.75 HTTP User-Agent Buffer Overflow',
+      'Name'           => 'Streamcast HTTP User-Agent Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Streamcast <= 0.9.75. By sending
           an overly long User-Agent in an HTTP GET request, an attacker may be able to

--- a/modules/exploits/windows/imap/mercury_login.rb
+++ b/modules/exploits/windows/imap/mercury_login.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Mercury/32 <= 4.01b LOGIN Buffer Overflow',
+      'Name'           => 'Mercury/32 LOGIN Buffer Overflow',
       'Description'    => %q{
         This module exploits a stack buffer overflow in Mercury/32 <= 4.01b IMAPD
         LOGIN verb. By sending a specially crafted login command, a buffer

--- a/modules/exploits/windows/imap/novell_netmail_append.rb
+++ b/modules/exploits/windows/imap/novell_netmail_append.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Novell NetMail <= 3.52d IMAP APPEND Buffer Overflow',
+      'Name'           => 'Novell NetMail IMAP APPEND Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Novell's Netmail 3.52 IMAP APPEND
         verb. By sending an overly long string, an attacker can overwrite the

--- a/modules/exploits/windows/imap/novell_netmail_auth.rb
+++ b/modules/exploits/windows/imap/novell_netmail_auth.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Novell NetMail <=3.52d IMAP AUTHENTICATE Buffer Overflow',
+      'Name'           => 'Novell NetMail IMAP AUTHENTICATE Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Novell's NetMail 3.52 IMAP AUTHENTICATE
         GSSAPI command. By sending an overly long string, an attacker can overwrite the

--- a/modules/exploits/windows/imap/novell_netmail_status.rb
+++ b/modules/exploits/windows/imap/novell_netmail_status.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Novell NetMail <= 3.52d IMAP STATUS Buffer Overflow',
+      'Name'           => 'Novell NetMail IMAP STATUS Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Novell's Netmail 3.52 IMAP STATUS
         verb. By sending an overly long string, an attacker can overwrite the

--- a/modules/exploits/windows/imap/novell_netmail_subscribe.rb
+++ b/modules/exploits/windows/imap/novell_netmail_subscribe.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Novell NetMail <= 3.52d IMAP SUBSCRIBE Buffer Overflow',
+      'Name'           => 'Novell NetMail IMAP SUBSCRIBE Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Novell's NetMail 3.52 IMAP SUBSCRIBE
         verb. By sending an overly long string, an attacker can overwrite the

--- a/modules/exploits/windows/lpd/wincomlpd_admin.rb
+++ b/modules/exploits/windows/lpd/wincomlpd_admin.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'WinComLPD <= 3.0.2 Buffer Overflow',
+      'Name'           => 'WinComLPD Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in WinComLPD <= 3.0.2.
         By sending an overly long authentication packet to the remote

--- a/modules/exploits/windows/misc/mercury_phonebook.rb
+++ b/modules/exploits/windows/misc/mercury_phonebook.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Mercury/32 <= v4.01b PH Server Module Buffer Overflow',
+      'Name'           => 'Mercury/32 PH Server Module Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack-based buffer overflow in
         Mercury/32 <= v4.01b PH Server Module. This issue is

--- a/modules/exploits/windows/misc/mirc_privmsg_server.rb
+++ b/modules/exploits/windows/misc/mirc_privmsg_server.rb
@@ -11,7 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'mIRC <= 6.34 PRIVMSG Handling Stack Buffer Overflow',
+      'Name'           => 'mIRC PRIVMSG Handling Stack Buffer Overflow',
       'Description'    => %q{
           This module exploits a buffer overflow in the mIRC IRC Client v6.34 and earlier.
         By enticing a mIRC user to connect to this server module, an excessively long PRIVMSG

--- a/modules/exploits/windows/misc/poisonivy_bof.rb
+++ b/modules/exploits/windows/misc/poisonivy_bof.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => "Poison Ivy 2.3.2 C&C Server Buffer Overflow",
+      'Name'           => "Poison Ivy Server Buffer Overflow",
       'Description'    => %q{
         This module exploits a stack buffer overflow in Poison Ivy 2.3.2 C&C server.
         The exploit does not need to know the password chosen for the bot/server

--- a/modules/exploits/windows/misc/trendmicro_cmdprocessor_addtask.rb
+++ b/modules/exploits/windows/misc/trendmicro_cmdprocessor_addtask.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "TrendMicro Control Manger <= v5.5 CmdProcessor.exe Stack Buffer Overflow",
+      'Name'           => "TrendMicro Control Manger CmdProcessor.exe Stack Buffer Overflow",
       'Description'    => %q{
           This module exploits a vulnerability in the CmdProcessor.exe component of Trend
         Micro Control Manger up to version 5.5.

--- a/modules/exploits/windows/misc/wireshark_packet_dect.rb
+++ b/modules/exploits/windows/misc/wireshark_packet_dect.rb
@@ -12,10 +12,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Wireshark <= 1.4.4 packet-dect.c Stack Buffer Overflow (remote)',
+      'Name'           => 'Wireshark packet-dect.c Stack Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Wireshark <= 1.4.4
-        by sending an malicious packet.)
+        by sending an malicious packet.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/windows/novell/nmap_stor.rb
+++ b/modules/exploits/windows/novell/nmap_stor.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Novell NetMail <= 3.52d NMAP STOR Buffer Overflow',
+      'Name'           => 'Novell NetMail NMAP STOR Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Novell's Netmail 3.52 NMAP STOR
         verb. By sending an overly long string, an attacker can overwrite the

--- a/modules/exploits/windows/proxy/ccproxy_telnet_ping.rb
+++ b/modules/exploits/windows/proxy/ccproxy_telnet_ping.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'		=> 'CCProxy <= v6.2 Telnet Proxy Ping Overflow',
+      'Name'		=> 'CCProxy Telnet Proxy Ping Overflow',
       'Description'	=> %q{
           This module exploits the YoungZSoft CCProxy <= v6.2 suite
         Telnet service. The stack is overwritten when sending an overly

--- a/modules/exploits/windows/scada/codesys_web_server.rb
+++ b/modules/exploits/windows/scada/codesys_web_server.rb
@@ -12,10 +12,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'            => 'SCADA 3S CoDeSys CmpWebServer <= v3.4 SP4 Patch 2 Stack Buffer Overflow',
+      'Name'            => 'SCADA 3S CoDeSys CmpWebServer Stack Buffer Overflow',
       'Description'     => %q{
         This module exploits a remote stack buffer overflow vulnerability in
-        3S-Smart Software Solutions product CoDeSys Scada Web Server Version 1.1.9.9.
+        3S-Smart Software Solutions product CoDeSys Scada Web Server Version
+        1.1.9.9. This vulnerability affects versions 3.4 SP4 Patch 2 and
+        earlier.
       },
       'License'         => MSF_LICENSE,
       'Author'          =>

--- a/modules/exploits/windows/scada/igss9_igssdataserver_listall.rb
+++ b/modules/exploits/windows/scada/igss9_igssdataserver_listall.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "7-Technologies IGSS <= v9.00.00 b11063 IGSSdataServer.exe Stack Buffer Overflow",
+      'Name'           => "7-Technologies IGSS IGSSdataServer.exe Stack Buffer Overflow",
       'Description'    => %q{
           This module exploits a vulnerability in the igssdataserver.exe component of 7-Technologies
         IGSS up to version 9.00.00 b11063. While processing a ListAll command, the application

--- a/modules/exploits/windows/scada/procyon_core_server.rb
+++ b/modules/exploits/windows/scada/procyon_core_server.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Procyon Core Server HMI <= v1.13 Coreservice.exe Stack Buffer Overflow",
+      'Name'           => "Procyon Core Server HMI Coreservice.exe Stack Buffer Overflow",
       'Description'    => %q{
           This module exploits a vulnerability in the coreservice.exe component of Proycon
         Core Server <= v1.13. While processing a password, the application

--- a/modules/exploits/windows/scada/scadapro_cmdexe.rb
+++ b/modules/exploits/windows/scada/scadapro_cmdexe.rb
@@ -14,12 +14,13 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Measuresoft ScadaPro <= 4.0.0 Remote Command Execution',
+      'Name'           => 'Measuresoft ScadaPro Remote Command Execution',
       'Description'    => %q{
-          This module allows remote attackers to execute arbitray commands on
-        the affected system by abusing via Directory Traversal attack when using the 'xf'
-        command (execute function). An attacker can execute system() from msvcrt.dll to
-        upload a backdoor and gain remote code execution.
+        This module allows remote attackers to execute arbitray commands on the
+        affected system by abusing via Directory Traversal attack when using the
+        'xf' command (execute function). An attacker can execute system() from
+        msvcrt.dll to upload a backdoor and gain remote code execution. This
+        vulnerability affects version 4.0.0 and earlier.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/windows/smb/timbuktu_plughntcommand_bof.rb
+++ b/modules/exploits/windows/smb/timbuktu_plughntcommand_bof.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Timbuktu <= 8.6.6 PlughNTCommand Named Pipe Buffer Overflow',
+      'Name'           => 'Timbuktu PlughNTCommand Named Pipe Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack based buffer overflow in Timbuktu Pro version <= 8.6.6
         in a pretty novel way.

--- a/modules/exploits/windows/ssh/putty_msg_debug.rb
+++ b/modules/exploits/windows/ssh/putty_msg_debug.rb
@@ -10,10 +10,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'PuTTy.exe <= v0.53 Buffer Overflow',
+      'Name'           => 'PuTTY Buffer Overflow',
       'Description'    => %q{
-          This module exploits a buffer overflow in the PuTTY SSH client that is triggered
-        through a validation error in SSH.c.
+        This module exploits a buffer overflow in the PuTTY SSH client that is
+        triggered through a validation error in SSH.c. This vulnerability
+        affects versions 0.53 and earlier.
       },
       'Author'         => 'MC',
       'License'        => MSF_LICENSE,

--- a/modules/exploits/windows/ssh/securecrt_ssh1.rb
+++ b/modules/exploits/windows/ssh/securecrt_ssh1.rb
@@ -10,7 +10,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'SecureCRT <= 4.0 Beta 2 SSH1 Buffer Overflow',
+      'Name'           => 'SecureCRT SSH1 Buffer Overflow',
       'Description'    => %q{
           This module exploits a buffer overflow in SecureCRT <= 4.0
         Beta 2. By sending a vulnerable client an overly long

--- a/modules/exploits/windows/telnet/goodtech_telnet.rb
+++ b/modules/exploits/windows/telnet/goodtech_telnet.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'GoodTech Telnet Server <= 5.0.6 Buffer Overflow',
+      'Name'           => 'GoodTech Telnet Server Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in GoodTech Systems Telnet Server
         versions prior to 5.0.7. By sending an overly long string, an attacker can

--- a/modules/exploits/windows/tftp/tftpd32_long_filename.rb
+++ b/modules/exploits/windows/tftp/tftpd32_long_filename.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'TFTPD32 <= 2.21 Long Filename Buffer Overflow',
+      'Name'           => 'TFTPD32 Long Filename Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in TFTPD32 version 2.21
         and prior. By sending a request for an overly long file name

--- a/modules/exploits/windows/vnc/winvnc_http_get.rb
+++ b/modules/exploits/windows/vnc/winvnc_http_get.rb
@@ -13,7 +13,7 @@ require 'msf/core'
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'		=> 'WinVNC Web Server <= v3.3.3r7 GET Overflow',
+      'Name'		=> 'WinVNC Web Server GET Overflow',
       'Description'	=> %q{
         This module exploits a buffer overflow in the AT&T WinVNC version
         <= v3.3.3r7 web server. When debugging mode with logging is


### PR DESCRIPTION
About a third of the way through.

**Verification steps**:
- [ ] Read through the title and associated description changes
- [ ] Make sure everything looks good

You should be able to replicate the following behavior:

```
wvu@kharak:~/metasploit-framework:beug/badchar$ tools/msftidy.rb modules | grep "bad char"
wvu@kharak:~/metasploit-framework:beug/badchar$
```
