### PR TITLE
Bug/8730 rescue instead of crash

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -128,6 +128,8 @@ class Metasploit3 < Msf::Auxiliary
       status_code = e.get_error(e.error_code)
     rescue ::Rex::Proto::SMB::Exceptions::LoginError => e
       status_code = e.error_reason
+    rescue ::Rex::Proto::SMB::Exceptions::InvalidWordCount => e
+      status_code = e.error_reason
     ensure
       disconnect()
     end

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -130,6 +130,7 @@ class Metasploit3 < Msf::Auxiliary
       status_code = e.error_reason
     rescue ::Rex::Proto::SMB::Exceptions::InvalidWordCount => e
       status_code = e.error_reason
+    rescue ::Rex::Proto::SMB::Exceptions::NoReply
     ensure
       disconnect()
     end


### PR DESCRIPTION
This intends to fix the bug described at:

https://dev.metasploit.com/redmine/issues/8730

This bug was all tangled up in #2656 but that PR ended up going nowhere. Regardless, the bug should still get fixed.

Unfortunately, it's tricky to reproduce, because we're not quite sure how to elicit an InvalidWordCount error from a target SMB server.

So.... here are some kind of lame verification steps, partially lifted from #2656:
## Verification
- [x] Run this module against target network that includes an SMB server with a known user
- [x] Ensure that the module does not crash on the run.
- [x] Ensure that the known user is reported correctly with the `creds` command, like so:

```
msf > creds

Credentials
===========

host        port  user  pass      type      proof  active?
----        ----  ----  ----      ----      -----  -------
10.6.0.118  445   bob   trustno1  password         true
```
