### PR TITLE
Let's try to be consistent about Rapid7 Inc.

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -11,7 +11,7 @@ are permitted provided that the following conditions are met:
 	  this list of conditions and the following disclaimer in the documentation
 	  and/or other materials provided with the distribution.
 
-    * Neither the name of Rapid7, Inc. nor the names of its contributors
+    * Neither the name of Rapid7 Inc. nor the names of its contributors
 	  may be used to endorse or promote products derived from this software
 	  without specific prior written permission.
 
@@ -30,7 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The Metasploit Framework is provided under the 3-clause BSD license above.
 
-The copyright on this package is held by Rapid7, Inc.
+The copyright on this package is held by Rapid7 Inc.
 
 This license does not apply to several components within the Metasploit
 Framework source tree.  For more details see the LICENSE file.

--- a/LICENSE
+++ b/LICENSE
@@ -8,7 +8,7 @@ License: BSD-3-clause
 # The Metasploit Framework is provided under the 3-clause BSD license provided
 # at the end of this file.
 #
-# The copyright on this package is held by Rapid7 LLC.
+# The copyright on this package is held by Rapid7 Inc.
 #
 # This license does not apply to third-party components detailed below.
 #
@@ -205,7 +205,7 @@ Copyright: Daniel Luz <dev at mernen dot com>
 License: Ruby
 
 Files: metasploit_data_models
-Copyright: 2012 Rapid7, Inc.
+Copyright: 2012 Rapid7 Inc.
 License: MIT
 
 Files: mini_portile
@@ -221,7 +221,7 @@ Copyright: 2010 Michael Bleigh, Josh Kalderimis, Erik Michaels-Ober, and Intride
 License: MIT
 
 Files: network_interface
-Copyright: 2012, Rapid7, Inc.
+Copyright: 2012, Rapid7 Inc.
 License: MIT
 
 Files: nokogiri
@@ -310,7 +310,7 @@ License: BSD-3-clause
      this list of conditions and the following disclaimer in the documentation
      and/or other materials provided with the distribution.
  .
-     * Neither the name of Rapid7 LLC nor the names of its contributors
+     * Neither the name of Rapid7 Inc nor the names of its contributors
      may be used to endorse or promote products derived from this software
      without specific prior written permission.
  .

--- a/documentation/users_guide.tex
+++ b/documentation/users_guide.tex
@@ -878,7 +878,7 @@ The Metasploit Framework is distributed under the modified-BSD license defined b
 
 {\footnotesize
 \begin{verbatim}
-Copyright (c) 2008, Rapid7 LLC
+Copyright (c) 2008, Rapid7 Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
@@ -891,7 +891,7 @@ are permitted provided that the following conditions are met:
 	  this list of conditions and the following disclaimer in the documentation
 	  and/or other materials provided with the distribution.
 
-    * Neither the name of Rapid7 LLC nor the names of its contributors 
+    * Neither the name of Rapid7, Inc. nor the names of its contributors 
 	  may be used to endorse or promote products derived from this software 
 	  without specific prior written permission.
 

--- a/external/ruby-kissfft/ext/kissfft/main.c
+++ b/external/ruby-kissfft/ext/kissfft/main.c
@@ -1,6 +1,6 @@
 /*
 	ruby-kissfft: a simple ruby module embedding the Kiss FFT library
-	Copyright (C) 2009-2010 Rapid7 LLC - H D Moore <hdm[at]metasploit.com>
+	Copyright (C) 2009-2010 Rapid7 Inc - H D Moore <hdm[at]metasploit.com>
 	
 	Derived from "psdpng.c" from the KissFFT tools directory
 	Copyright (C) 2003-2006 Mark Borgerding

--- a/external/ruby-lorcon/Lorcon.c
+++ b/external/ruby-lorcon/Lorcon.c
@@ -33,7 +33,7 @@
 */
 
 /*	
-	All ruby-lorcon/rubyisms are by Rapid7 LLC (C) 2006-2007
+	All ruby-lorcon/rubyisms are by Rapid7 Inc (C) 2006-2007
 		http://metasploit.com/ - msfdev[at]metasploit.com
 */
 

--- a/external/source/DLLHijackAuditKit/analyze.js
+++ b/external/source/DLLHijackAuditKit/analyze.js
@@ -1,4 +1,4 @@
-/* DLLHijackAuditKit (C) 2010 Rapid7 LLC */
+/* DLLHijackAuditKit (C) 2010 Rapid7 Inc */
 
 var oFso = new ActiveXObject("Scripting.FileSystemObject");
 var oShl = new ActiveXObject("WScript.Shell");

--- a/external/source/DLLHijackAuditKit/audit.js
+++ b/external/source/DLLHijackAuditKit/audit.js
@@ -1,4 +1,4 @@
-/* DLLHijackAuditKit (C) 2010 Rapid7 LLC */
+/* DLLHijackAuditKit (C) 2010 Rapid7 Inc */
 
 function print_status(msg) {
 	try {

--- a/external/source/shellcode/windows/stager_bind_ipv6_tcp_nx.asm
+++ b/external/source/shellcode/windows/stager_bind_ipv6_tcp_nx.asm
@@ -1,6 +1,6 @@
 ;      Title:  Windows Bind Stager (NX, IPv6)
 ;  Platforms:  Windows NT 4.0, Windows 2000, Windows XP, Windows 2003
-;     Author:  Rapid7 LLC
+;     Author:  Rapid7 Inc
 
 [BITS 32]
 

--- a/external/source/shellcode/windows/stager_reverse_ipv6_tcp_nx.asm
+++ b/external/source/shellcode/windows/stager_reverse_ipv6_tcp_nx.asm
@@ -1,6 +1,6 @@
 ;      Title:  Windows Reverse Connect Stager (NX, IPv6)
 ;  Platforms:  Windows NT 4.0, Windows 2000, Windows XP, Windows 2003, Windows Vista
-;     Author:  Rapid7 LLC
+;     Author:  Rapid7 Inc
 
 [BITS 32]
 

--- a/external/source/vncdll/vncdll/LICENSE.txt
+++ b/external/source/vncdll/vncdll/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2006-2010, Rapid7 LLC
+Copyright (C) 2006-2010, Rapid7 Inc
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
@@ -11,7 +11,7 @@ are permitted provided that the following conditions are met:
 	  this list of conditions and the following disclaimer in the documentation
 	  and/or other materials provided with the distribution.
 
-    * Neither the name of Rapid7 LLC nor the names of its contributors
+    * Neither the name of Rapid7 Inc nor the names of its contributors
 	  may be used to endorse or promote products derived from this software
 	  without specific prior written permission.
 

--- a/external/source/vncdll/vncdll/context.h
+++ b/external/source/vncdll/vncdll/context.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2006-2010, Rapid7 LLC
+// Copyright (C) 2006-2010, Rapid7 Inc
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
@@ -11,7 +11,7 @@
 //       this list of conditions and the following disclaimer in the documentation
 //       and/or other materials provided with the distribution.
 //
-//     * Neither the name of Rapid7 LLC nor the names of its contributors
+//     * Neither the name of Rapid7 Inc nor the names of its contributors
 //       may be used to endorse or promote products derived from this software
 //       without specific prior written permission.
 //

--- a/external/source/vncdll/vncdll/inject.h
+++ b/external/source/vncdll/vncdll/inject.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2006-2010, Rapid7 LLC
+// Copyright (C) 2006-2010, Rapid7 Inc
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
@@ -11,7 +11,7 @@
 //       this list of conditions and the following disclaimer in the documentation
 //       and/or other materials provided with the distribution.
 //
-//     * Neither the name of Rapid7 LLC nor the names of its contributors
+//     * Neither the name of Rapid7 Inc nor the names of its contributors
 //       may be used to endorse or promote products derived from this software
 //       without specific prior written permission.
 //

--- a/external/source/vncdll/vncdll/loader.h
+++ b/external/source/vncdll/vncdll/loader.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2006-2010, Rapid7 LLC
+// Copyright (C) 2006-2010, Rapid7 Inc
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
@@ -11,7 +11,7 @@
 //       this list of conditions and the following disclaimer in the documentation
 //       and/or other materials provided with the distribution.
 //
-//     * Neither the name of Rapid7 LLC nor the names of its contributors
+//     * Neither the name of Rapid7 Inc nor the names of its contributors
 //       may be used to endorse or promote products derived from this software
 //       without specific prior written permission.
 //

--- a/external/source/vncdll/vncdll/ps.h
+++ b/external/source/vncdll/vncdll/ps.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2006-2010, Rapid7 LLC
+// Copyright (C) 2006-2010, Rapid7 Inc
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
@@ -11,7 +11,7 @@
 //       this list of conditions and the following disclaimer in the documentation
 //       and/or other materials provided with the distribution.
 //
-//     * Neither the name of Rapid7 LLC nor the names of its contributors
+//     * Neither the name of Rapid7 Inc nor the names of its contributors
 //       may be used to endorse or promote products derived from this software
 //       without specific prior written permission.
 //

--- a/external/source/vncdll/vncdll/session.h
+++ b/external/source/vncdll/vncdll/session.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2006-2010, Rapid7 LLC
+// Copyright (C) 2006-2010, Rapid7 Inc
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification,
@@ -11,7 +11,7 @@
 //       this list of conditions and the following disclaimer in the documentation
 //       and/or other materials provided with the distribution.
 //
-//     * Neither the name of Rapid7 LLC nor the names of its contributors
+//     * Neither the name of Rapid7 Inc nor the names of its contributors
 //       may be used to endorse or promote products derived from this software
 //       without specific prior written permission.
 //

--- a/lib/rapid7/nexpose.rb
+++ b/lib/rapid7/nexpose.rb
@@ -3,7 +3,7 @@
 #
 =begin
 
-Copyright (C) 2009-2012, Rapid7 LLC
+Copyright (C) 2009-2012, Rapid7 Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
@@ -16,7 +16,7 @@ are permitted provided that the following conditions are met:
     this list of conditions and the following disclaimer in the documentation
     and/or other materials provided with the distribution.
 
-    * Neither the name of Rapid7 LLC nor the names of its contributors
+    * Neither the name of Rapid7 Inc. nor the names of its contributors
     may be used to endorse or promote products derived from this software
     without specific prior written permission.
 

--- a/lib/rex.rb
+++ b/lib/rex.rb
@@ -2,7 +2,7 @@
 
 The Metasploit Rex library is provided under the 3-clause BSD license.
 
-Copyright (c) 2005-2010, Rapid7 LLC
+Copyright (c) 2005-2010, Rapid7 Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
@@ -15,7 +15,7 @@ are permitted provided that the following conditions are met:
    this list of conditions and the following disclaimer in the documentation 
    and/or other materials provided with the distribution.
    
- * Neither the name of Rapid7 LLC nor the names of its contributors may be 
+ * Neither the name of Rapid7 Inc. nor the names of its contributors may be 
    used to endorse or promote products derived from this software without 
    specific prior written permission.
 

--- a/lib/rex/LICENSE
+++ b/lib/rex/LICENSE
@@ -1,6 +1,6 @@
 The Metasploit Rex library is provided under the 3-clause BSD license.
 
-Copyright (c) 2005-2006, Rapid7 LLC
+Copyright (c) 2005-2006, Rapid7 Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
@@ -13,7 +13,7 @@ are permitted provided that the following conditions are met:
    this list of conditions and the following disclaimer in the documentation 
    and/or other materials provided with the distribution.
    
- * Neither the name of Rapid7 LLC nor the names of its contributors may be 
+ * Neither the name of Rapid7 Inc. nor the names of its contributors may be 
    used to endorse or promote products derived from this software without 
    specific prior written permission.
 


### PR DESCRIPTION
According to

http://www.sec.gov/Archives/edgar/data/1560327/000156032712000001/0001560327-12-000001.txt

Rapid7 is actually "Rapid7 Inc" not "Rapid7, LLC" any more.

This does not address the few copyright/license statements around "Metasploit LLC," whatever that is.
## Verification Steps
- [x] See the documentation does not say "Rapid7 LLC"
- [x] See the documentation does not say "Rapid7, LLC"
- [x] See the documentation does not say "Rapid7, Inc"
- [x] See the documentation **does** say "Rapid7 Inc"

I don't really care one way or another about the trailing period. Some formats say "Inc" and others say "Inc."
