### PR TITLE
Corrected Rex::Text.uri_encode

### DIFF
--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -732,8 +732,8 @@ module Text
     return str if mode == 'none' # fast track no encoding
 
     all = /[^\/\\]+/
-    normal = /[^a-zA-Z0-9\/\\\.\-]+/
-    normal_na = /[a-zA-Z0-9\/\\\.\-]/
+    # http://tools.ietf.org/html/rfc3986#section-2.3
+    normal = /[^a-zA-Z0-9\/\\\.\-_~]+/
 
     case mode
     when 'hex-normal'


### PR DESCRIPTION
Rex::Text.uri_encode currently encodes _ and ~ but it shouldn't:
http://tools.ietf.org/html/rfc3986#section-2.3

See pull request #3094 for an example

The function also skips / and \ which should be encoded too, but I think when we change the slashes this will break a lot of exploits. What do you think?

PS: normal_na was an unused variable
