### PR TITLE
Fix check command host selection behavior

### DIFF
--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -88,7 +88,7 @@ module ModuleCommandDispatcher
           # datastore option
           instance = mod.replicant
           instance.datastore['RHOST'] = tip.dup
-          framework.events.on_module_created(instance)
+          Msf::Simple::Framework.simplify_module(instance, false)
           check_simple(instance)
         }
       end
@@ -124,7 +124,7 @@ module ModuleCommandDispatcher
   def cmd_check(*args)
     defanged?
 
-    ip_range_arg = args.shift || framework.datastore['RHOSTS'] || mod.datastore['RHOSTS'] || ''
+    ip_range_arg = args.shift || mod.datastore['RHOSTS'] || framework.datastore['RHOSTS'] || ''
     hosts = Rex::Socket::RangeWalker.new(ip_range_arg)
 
     begin


### PR DESCRIPTION
[SeeRM #8768] Instead of using the saved value for host, the check command should use whatever the user specifies.
### Please verify the following

Scenario: The check command should use the RHOST option you specify instead of using whatever is in the config file.
- [x] Make sure you have a Win XP SP3 that's vulnerable to ms08_067_netapi for testing.
- [x] Run `msfconsole`
- [x] Enter: `use exploit/windows/smb/ms08_067_netapi`
- [x] Enter: `set RHOST [IP 1]`
- [x] Enter: `save`
- [x] Enter: `set RHOST [IP 2]`
- [x] Enter: `check`
- [x] Confirm that the check command runs against IP 2, and not IP 1.

Scenario: The check command should still use the saved option if it isn't specified by the user.
- [x] Make sure you still have the saved RHOST option (IP 1) from the previous test.
- [x] Make sure you're in `msfconsole`
- [x] Make sure you're in `exploit/windows/smb/ms08_067_netapi`
- [x] Enter: `check`
- [x] Confirm that the check command runs against IP 1.
