### PR TITLE
Ax the arbitrary long line warning

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -38,8 +38,6 @@ end
 
 class Msftidy
 
-  LONG_LINE_LENGTH = 200 # From 100 to 200 which is stupidly long
-
   # Status codes
   OK       = 0x00
   WARNINGS = 0x10
@@ -423,10 +421,6 @@ class Msftidy
 
       if ln =~ /[\x00-\x08\x0b\x0c\x0e-\x19\x7f-\xff]/
         error("Unicode detected: #{ln.inspect}", idx)
-      end
-
-      if (ln.length > LONG_LINE_LENGTH)
-        warn("Line exceeding #{LONG_LINE_LENGTH} bytes", idx)
       end
 
       if ln =~ /[ \t]$/


### PR DESCRIPTION
**Problem description:**

We could increase it to 300, but really? :)

Personally, I prefer 80 or 132, but that's not a realistic expectation:

```
wvu@kharak:~/metasploit-framework:master$ vi tools/msftidy.rb
wvu@kharak:~/metasploit-framework:master$ tools/msftidy.rb modules | grep -c Line
22690
wvu@kharak:~/metasploit-framework:master$ vi tools/msftidy.rb
wvu@kharak:~/metasploit-framework:master$ tools/msftidy.rb modules | grep -c Line
1103
wvu@kharak:~/metasploit-framework:master$ git reset --hard
HEAD is now at 8393a49 Land #3098, check command host selection fix
wvu@kharak:~/metasploit-framework:master$
```

**Verification steps:**
- [x] Check out the topic branch
- [x] Run `tools/msftidy.rb modules | grep -c Line`
- [x] See that the warning count is 0

**Sample run:**

```
wvu@kharak:~/metasploit-framework:master$ tools/msftidy.rb modules | grep -c Line
22
wvu@kharak:~/metasploit-framework:master$ git checkout beug/line
Switched to branch 'beug/line'
Your branch is ahead of 'master' by 1 commit.
  (use "git push" to publish your local commits)
wvu@kharak:~/metasploit-framework:beug/line$ tools/msftidy.rb modules | grep -c Line
0
wvu@kharak:~/metasploit-framework:beug/line$
```
