### PR TITLE
Fix missing require in reverse_powershell

### DIFF
--- a/modules/payloads/singles/cmd/windows/reverse_powershell.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_powershell.rb
@@ -5,6 +5,7 @@
 
 require 'msf/core'
 require 'msf/core/handler/find_shell'
+require 'msf/core/handler/reverse_tcp'
 require 'msf/base/sessions/command_shell'
 require 'msf/base/sessions/command_shell_options'
 


### PR DESCRIPTION
When initializing the db:

<pre>
/opt/metasploit-framework/modules/payloads/singles/cmd/windows/reverse_powershell.rb:34:in `initialize': uninitialized constant Msf::Handler::ReverseTcp (NameError)
    from /opt/metasploit-framework/lib/msf/core/payload_set.rb:198:in `new'
    from /opt/metasploit-framework/lib/msf/core/payload_set.rb:198:in `add_module'
    from /opt/metasploit-framework/lib/msf/core/module_manager/loading.rb:72:in `on_module_load'
    from /opt/metasploit-framework/lib/msf/core/modules/loader/base.rb:207:in `load_module'
    from /opt/metasploit-framework/lib/msf/core/modules/loader/base.rb:271:in `block in load_modules'
    from /opt/metasploit-framework/lib/msf/core/modules/loader/directory.rb:58:in `block (2 levels) in each_module_reference_name'
    from /opt/metasploit-framework/lib/rex/file.rb:127:in `block in find'
    from /opt/metasploit-framework/lib/rex/file.rb:126:in `catch'
    from /opt/metasploit-framework/lib/rex/file.rb:126:in `find'
    from /opt/metasploit-framework/lib/msf/core/modules/loader/directory.rb:45:in `block in each_module_reference_name'
    from /opt/metasploit-framework/lib/msf/core/modules/loader/directory.rb:29:in `foreach'
    from /opt/metasploit-framework/lib/msf/core/modules/loader/directory.rb:29:in `each_module_reference_name'
    from /opt/metasploit-framework/lib/msf/core/modules/loader/base.rb:264:in `load_modules'
    from /opt/metasploit-framework/lib/msf/core/module_manager/loading.rb:118:in `block in load_modules'
    from /opt/metasploit-framework/lib/msf/core/module_manager/loading.rb:116:in `each'
    from /opt/metasploit-framework/lib/msf/core/module_manager/loading.rb:116:in `load_modules'
    from /opt/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:56:in `block in add_module_path'
    from /opt/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:55:in `each'
    from /opt/metasploit-framework/lib/msf/core/module_manager/module_paths.rb:55:in `add_module_path'
    from /opt/metasploit-framework/lib/msf/base/simple/framework/module_paths.rb:14:in `init_module_paths'
    from /opt/metasploit-framework/lib/msf/ui/console/driver.rb:228:in `initialize'
    from /opt/metasploit-framework/msfconsole:148:in `new'
    from /opt/metasploit-framework/msfconsole:148:in `<main>'
</pre>
