### PR TITLE
Added a check for vars_get in msftidy

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -64,7 +64,7 @@ class Msftidy
   # @return status [Integer] Returns WARNINGS unless we already have an
   # error.
   def warn(txt, line=0) line_msg = (line>0) ? ":#{line}" : ''
-    puts "#{@full_filepath}#{line_msg} - [#{'WARNING'.yellow}] #{txt}"
+    puts "#{@full_filepath}#{line_msg} - [#{'WARNING'.yellow}] #{cleanup_text(txt)}"
     @status == ERRORS ? @status = ERRORS : @status = WARNINGS
   end
 
@@ -76,14 +76,14 @@ class Msftidy
   # @return status [Integer] Returns ERRORS
   def error(txt, line=0)
     line_msg = (line>0) ? ":#{line}" : ''
-    puts "#{@full_filepath}#{line_msg} - [#{'ERROR'.red}] #{txt}"
+    puts "#{@full_filepath}#{line_msg} - [#{'ERROR'.red}] #{cleanup_text(txt)}"
     @status = ERRORS
   end
 
   # Currently unused, but some day msftidy will fix errors for you.
   def fixed(txt, line=0)
     line_msg = (line>0) ? ":#{line}" : ''
-    puts "#{@full_filepath}#{line_msg} - [#{'FIXED'.green}] #{txt}"
+    puts "#{@full_filepath}#{line_msg} - [#{'FIXED'.green}] #{cleanup_text(txt)}"
   end
 
 
@@ -469,7 +469,7 @@ class Msftidy
 
       # do not change datastore in code
       if ln =~ /(?<!\.)datastore\[["'][^"']+["']\]\s*=(?![=~>])/
-        error("datastore is modified in code: #{ln.inspect}", idx)
+        error("datastore is modified in code: #{ln}", idx)
       end
     }
   end
@@ -481,6 +481,15 @@ class Msftidy
     end
   end
 
+  def check_vars_get
+    test = @source.scan(/send_request_(?:cgi|raw)\s*\(\s*\{\s*['"]uri['"]\s*=>\s*[^=\}]*?\?[^,\}]+/im)
+    unless test.empty?
+      test.each { |item|
+        warn("Please use vars_get in send_request_cgi and send_request_raw: #{item}")
+      }
+    end
+  end
+
   private
 
   def load_file(file)
@@ -489,6 +498,13 @@ class Msftidy
     buf = f.read(@stat.size)
     f.close
     return buf
+  end
+
+  def cleanup_text(txt)
+    # remove line breaks
+    txt = txt.gsub(/[\r\n]/, ' ')
+    # replace multiple spaces by one space
+    txt.gsub(/\s{2,}/, ' ')
   end
 end
 
@@ -517,6 +533,7 @@ def run_checks(full_filepath)
   tidy.check_snake_case_filename
   tidy.check_comment_splat
   tidy.check_vuln_codes
+  tidy.check_vars_get
   return tidy
 end
 


### PR DESCRIPTION
This PR adds a check for get variables in send_request_cgi and send_request_raw. vars_get should be used instead.
## Regex

The regex currently only works if the first parameter of send_request_\* is "uri". If you have improvements to the regex, please share.
## Steps to reproduce
### Regex Test
- [x] http://rubular.com/r/42ee4ItKWO
- [x] https://www.debuggex.com/r/ChRP9iNkqVdGrwjh
### get_vars_check
- [x] Checkout branch
- [x] run msftidy against module directory
- [x] Check output if uri parameter contains GET parameters and no false positives are catched
### cleanup_text check
- [x] Checkout branch
- [x] run msftidy against module directory
- [x] Make sure no newlines are printed
- [x] Additional: comment out cleanup_text and watch the differences
## Example Output:

```
firefart@LinuxMint ~/Coding/metasploit-framework $ ./tools/msftidy.rb modules/ | grep vars_get
modules/auxiliary/admin/http/iomega_storcenterpro_sessionid.rb - [WARNING] Please use vars_get in send_request_cgi and send_request_raw: send_request_raw({ 'uri' => "/cgi-bin/makecgi-pro?job=show_home&session_id=#{x
modules/auxiliary/scanner/http/manageengine_deviceexpert_traversal.rb - [WARNING] Please use vars_get in send_request_cgi and send_request_raw: send_request_raw({ 'uri' => "/scheduleresult.de/?FileName=#{traverse
modules/auxiliary/scanner/oracle/spy_sid.rb - [WARNING] Please use vars_get in send_request_cgi and send_request_raw: send_request_raw({ 'uri' => '/servlet/Spy?format=raw&loginfo=true'
modules/auxiliary/scanner/sap/sap_smb_relay.rb - [WARNING] Please use vars_get in send_request_cgi and send_request_raw: send_request_raw({ 'uri' => '/sap/bw/xml/soap/xmla?sap-client=' + datastore['CLIENT'] + '&sap-language=EN'
modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb - [WARNING] Please use vars_get in send_request_cgi and send_request_raw: send_request_cgi({ 'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN'
modules/auxiliary/scanner/sap/sap_soap_rfc_brute_login.rb - [WARNING] Please use vars_get in send_request_cgi and send_request_raw: send_request_cgi({ 'uri' => '/sap/bc/soap/rfc?sap-client=' + client + '&sap-language=EN'
modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb - [WARNING] Please use vars_get in send_request_cgi and send_request_raw: send_request_cgi({ 'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN'
modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb - [WARNING] Please use vars_get in send_request_cgi and send_request_raw: send_request_cgi({ 'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN'
modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb - [WARNING] Please use vars_get in send_request_cgi and send_request_raw: send_request_cgi({ 'uri' => '/sap/bc/soap/rfc?sap-client=' + client + '&sap-language=EN'
modules/auxiliary/scanner/sap/sap_soap_rfc_read_table.rb - [WARNING] Please use vars_get in send_request_cgi and send_request_raw: send_request_cgi({ 'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN'
modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb - [WARNING] Please use vars_get in send_request_cgi and send_request_raw: send_request_cgi({ 'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN'
modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_call_system_exec.rb - [WARNING] Please use vars_get in send_request_cgi and send_request_raw: send_request_cgi({ 'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN'
modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_command_exec.rb - [WARNING] Please use vars_get in send_request_cgi and send_request_raw: send_request_cgi({ 'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN'
```
