### PR TITLE
Added a check for Set-Cookie header in msftidy

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -467,7 +467,7 @@ class Msftidy
       end
 
       # do not read Set-Cookie header
-      if ln =~ /\[['"]Set-Cookie['"]\]/
+      if ln =~ /\[['"]Set-Cookie['"]\]/i
         warn("Do not read Set-Cookie header directly, use res.get_cookies instead: #{ln}", idx)
       end
     }

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -465,6 +465,11 @@ class Msftidy
       if ln =~ /(?<!\.)datastore\[["'][^"']+["']\]\s*=(?![=~>])/
         error("datastore is modified in code: #{ln}", idx)
       end
+
+      # do not read Set-Cookie header
+      if ln =~ /\[['"]Set-Cookie['"]\]/
+        warn("Do not read Set-Cookie header directly, use res.get_cookies instead: #{ln}", idx)
+      end
     }
   end
 


### PR DESCRIPTION
This PR adds a check for reading the Set-Cookie header. resp.get_cookies should be used instead.
## Verify Steps
- [x] Checkout branch
- [x] run msftidy
- [x] check output for false positives
## Sample Output

```
firefart@LinuxMint ~/Coding/metasploit-framework $ ./tools/msftidy.rb modules/ | grep -i set-cookie
modules/auxiliary/admin/2wire/xslt_password_reset.rb:133 - [WARNING] Do not read Set-Cookie header, use res.get_cookies instead: if (res.headers['Set-Cookie'] and res.headers['Set-Cookie'].match(/(.*); path=\//)) 
modules/auxiliary/admin/http/axigen_file_access.rb:170 - [WARNING] Do not read Set-Cookie header, use res.get_cookies instead: if res.headers['Set-Cookie'] =~ /_hadmin=([a-f0-9]*)/ 
modules/auxiliary/admin/http/cfme_manageiq_evm_pass_reset.rb:116 - [WARNING] Do not read Set-Cookie header, use res.get_cookies instead: session = $1 if res.headers['Set-Cookie'] =~ /_vmdb_session=(\h*)/ 
modules/auxiliary/admin/http/foreman_openstack_satellite_priv_esc.rb:70 - [WARNING] Do not read Set-Cookie header, use res.get_cookies instead: session = $1 if res.headers['Set-Cookie'] =~ /_session_id=([0-9a-f]*)/ 
modules/auxiliary/admin/http/mutiny_frontend_read_delete.rb:142 - [WARNING] Do not read Set-Cookie header, use res.get_cookies instead: if res and res.code == 200 and res.headers['Set-Cookie'] =~ /JSESSIONID=(.*);/ 
modules/auxiliary/admin/http/mutiny_frontend_read_delete.rb:168 - [WARNING] Do not read Set-Cookie header, use res.get_cookies instead: if res and res.code == 200 and res.headers['Set-Cookie'] =~ /JSESSIONID=(.*);/ 
modules/auxiliary/admin/http/tomcat_administration.rb:78 - [WARNING] Do not read Set-Cookie header, use res.get_cookies instead: if (res.headers['Set-Cookie'] and res.headers['Set-Cookie'].match(/JSESSIONID=(.*);(.*)/i)) 
modules/auxiliary/admin/oracle/osb_execqr2.rb:52 - [WARNING] Do not read Set-Cookie header, use res.get_cookies instead: if (res and res.headers['Set-Cookie'] and res.headers['Set-Cookie'].match(/PHPSESSID=(.*);(.*)/i)) 
modules/auxiliary/admin/oracle/osb_execqr2.rb:54 - [WARNING] Do not read Set-Cookie header, use res.get_cookies instead: sessionid = res.headers['Set-Cookie'].split(';')[0] 
modules/auxiliary/admin/oracle/osb_execqr3.rb:49 - [WARNING] Do not read Set-Cookie header, use res.get_cookies instead: if (res and res.headers['Set-Cookie'] and res.headers['Set-Cookie'].match(/PHPSESSID=(.*);(.*)/i)) 
```
