### PR TITLE
Removes hash rockets from references.

### DIFF
--- a/modules/exploits/multi/http/processmaker_exec.rb
+++ b/modules/exploits/multi/http/processmaker_exec.rb
@@ -25,9 +25,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'Author'         => 'Brendan Coles <bcoles[at]gmail.com>',
       'References'     =>
         [
-          ['OSVDB'     => '99199'],
-          ['BID'       => '63411'],
-          ['URL'       => 'http://bugs.processmaker.com/view.php?id=13436']
+          ['OSVDB',     '99199'],
+          ['BID',       '63411'],
+          ['URL',       'http://bugs.processmaker.com/view.php?id=13436']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/unix/webapp/kimai_sqli.rb
+++ b/modules/exploits/unix/webapp/kimai_sqli.rb
@@ -31,8 +31,8 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          ['EDB'       => '25606'],
-          ['OSVDB'     => '93547'],
+          ['EDB',       '25606'],
+          ['OSVDB',     '93547'],
         ],
       'Payload'        =>
         {

--- a/modules/exploits/unix/webapp/webtester_exec.rb
+++ b/modules/exploits/unix/webapp/webtester_exec.rb
@@ -26,8 +26,8 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          ['OSVDB'     => '98750'],
-          ['URL'       => 'https://sourceforge.net/p/webtesteronline/bugs/3/']
+          ['OSVDB',    '98750'],
+          ['URL',      'https://sourceforge.net/p/webtesteronline/bugs/3/']
         ],
       'Payload'        =>
         {


### PR DESCRIPTION
Occasionally people get confused about how to write Arrays.
## Validation

Before fix:
- [x] Affected modules appear to have no references when the following commands are run:

`./msfcli exploit/multi/http/processmaker_exec S`
`./msfcli exploit/unix/webapp/kimai_sqli S`
`./msfcli exploit/unix/webapp/webtester_exec S`

After fix:
- [x] Affected modules now have references:

`./msfcli exploit/multi/http/processmaker_exec S`
`./msfcli exploit/unix/webapp/kimai_sqli S`
`./msfcli exploit/unix/webapp/webtester_exec S`

When landing this, please use the magic words on the merge commit:

```
[FixRM #8776]
```

...since this fixes https://dev.metasploit.com/redmine/issues/8776
