### PR TITLE
Fix return of prepend_nops

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -348,9 +348,8 @@ module Msf
             return raw + shellcode
           end
         end
-      else
-        shellcode
       end
+      shellcode
     end
 
     # This method runs a specified encoder, for a number of defined iterations against the shellcode.


### PR DESCRIPTION
prepend_nops in the payload generator could potentially return nil due to bad conditional logic
