### PR TITLE
Added Module for enumerating indexes in Elastic Search Indices

### DIFF
--- a/modules/auxiliary/scanner/elasticsearch/es_enum.rb
+++ b/modules/auxiliary/scanner/elasticsearch/es_enum.rb
@@ -3,35 +3,32 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 require 'msf/core'
-
 
 class Metasploit3 < Msf::Auxiliary
 
-  # Exploit mixins should be called first
   include Msf::Exploit::Remote::HttpClient
-  # Scanner mixin should be near last
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
 
-  def initialize
-    super(
-      'Name'        => 'ElasticSearch Enum Utility',
-      'Description' => 'Send a request to enumerate ElasticSearch indices',
-      'Author'       => ['Silas Cutler <Silas.Cutler [at] BlackListThisDomain.com'],
-      'License'     => MSF_LICENSE
-    )
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'         => 'ElasticSearch Enum Utility',
+      'Description'  => %q{ Send a request to enumerate ElasticSearch indices},
+      'Author'         =>
+        [
+          'Silas Cutler <Silas.Cutler [at] BlackListThisDomain.com>'
+        ],
+      'License'      => MSF_LICENSE
+    ))    
+    
     register_options(
       [
         Opt::RPORT(9200)
-      ]
-    )
-
+      ], self.class)
   end
 
-  def run_host(target_host)
-
+  def run_host(ip)
     begin
       res = send_request_raw({
         'uri'     => '/_aliases',
@@ -39,32 +36,23 @@ class Metasploit3 < Msf::Auxiliary
         'version' => '1.0',
       }, 10)
 
-    if res.nil?
-      print_error("No response for #{target_host}")
-      return nil
-    end
-
     begin
-      temp = JSON.parse(res.body)
+      json_body = JSON.parse(res.body)
     rescue JSON::ParserError
       print_error("Unable to parse JSON")
       return
     end
 
-
-    if (res.code == 200)
-      temp.each do |index|
+    if res and res.code == 200  and res.body.length > 0
+      json_body.each do |index|
           print_good("Index : " + index[0])
       end
-    end
 
-    if res and res.code == 200 and res.headers['Content-Type'] and res.body.length > 0
-      path = store_loot("elasticsearch.enum.file", "text/plain", rhost, res.body, "ElasticSearch Enum Results")
-      print_status("Results saved to #{path}")
+      path = store_loot("elasticsearch.enum.file", "text/plain", ip, res.body, "ElasticSearch Enum Results")
+      print_good("Results saved to #{path}")
     else
       print_error("Failed to save the result")
     end
-
 
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
     rescue ::Timeout::Error, ::Errno::EPIPE

--- a/modules/auxiliary/scanner/elasticsearch/es_enum.rb
+++ b/modules/auxiliary/scanner/elasticsearch/es_enum.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Auxiliary
           'Silas Cutler <Silas.Cutler [at] BlackListThisDomain.com>'
         ],
       'License'      => MSF_LICENSE
-    ))    
+    ))
     
     register_options(
       [

--- a/modules/auxiliary/scanner/elasticsearch/es_enum.rb
+++ b/modules/auxiliary/scanner/elasticsearch/es_enum.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Auxiliary
       'License'     => MSF_LICENSE
     )
     register_options(
-      [ 
+      [
         Opt::RPORT(9200)
       ]
     )
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Auxiliary
 
     if (res.code == 200)
       temp.each do |index|
-	print_good("Index : " + index[0])
+          print_good("Index : " + index[0])
       end
     end
 

--- a/modules/auxiliary/scanner/elasticsearch/es_enum.rb
+++ b/modules/auxiliary/scanner/elasticsearch/es_enum.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     if res and res.code == 200 and res.headers['Content-Type'] and res.body.length > 0
-      path = store_loot("couchdb.enum.file", "text/plain", rhost, res.body, "CouchDB Enum Results")
+      path = store_loot("elasticsearch.enum.file", "text/plain", rhost, res.body, "ElasticSearch Enum Results")
       print_status("Results saved to #{path}")
     else
       print_error("Failed to save the result")

--- a/modules/auxiliary/scanner/elasticsearch/es_enum.rb
+++ b/modules/auxiliary/scanner/elasticsearch/es_enum.rb
@@ -1,0 +1,73 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+
+require 'msf/core'
+
+
+class Metasploit3 < Msf::Auxiliary
+
+  # Exploit mixins should be called first
+  include Msf::Exploit::Remote::HttpClient
+  # Scanner mixin should be near last
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize
+    super(
+      'Name'        => 'ElasticSearch Enum Utility',
+      'Description' => 'Send a request to enumerate ElasticSearch indices',
+      'Author'       => ['Silas Cutler <Silas.Cutler [at] BlackListThisDomain.com'],
+      'License'     => MSF_LICENSE
+    )
+    register_options(
+      [ 
+        Opt::RPORT(9200)
+      ]
+    )
+
+  end
+
+  def run_host(target_host)
+
+    begin
+      res = send_request_raw({
+        'uri'     => '/_aliases',
+        'method'  => 'GET',
+        'version' => '1.0',
+      }, 10)
+
+    if res.nil?
+      print_error("No response for #{target_host}")
+      return nil
+    end
+
+    begin
+      temp = JSON.parse(res.body)
+    rescue JSON::ParserError
+      print_error("Unable to parse JSON")
+      return
+    end
+
+
+    if (res.code == 200)
+      temp.each do |index|
+	print_good("Index : " + index[0])
+      end
+    end
+
+    if res and res.code == 200 and res.headers['Content-Type'] and res.body.length > 0
+      path = store_loot("couchdb.enum.file", "text/plain", rhost, res.body, "CouchDB Enum Results")
+      print_status("Results saved to #{path}")
+    else
+      print_error("Failed to save the result")
+    end
+
+
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+    rescue ::Timeout::Error, ::Errno::EPIPE
+    end
+  end
+end

--- a/modules/auxiliary/scanner/elasticsearch/es_enum.rb
+++ b/modules/auxiliary/scanner/elasticsearch/es_enum.rb
@@ -33,8 +33,7 @@ class Metasploit3 < Msf::Auxiliary
       res = send_request_raw({
         'uri'     => '/_aliases',
         'method'  => 'GET',
-        'version' => '1.0',
-      }, 10)
+      })
 
     begin
       json_body = JSON.parse(res.body)
@@ -54,8 +53,7 @@ class Metasploit3 < Msf::Auxiliary
       print_error("Failed to save the result")
     end
 
-    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-    rescue ::Timeout::Error, ::Errno::EPIPE
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable
     end
   end
 end


### PR DESCRIPTION
Added Module for enumerating indexes in Elastic Search Instances.
## Example Run

```
 msf auxiliary(es_enum) > exploit

 [+] Index : TestIndex
 [+] Index : TestIndex-dev
 [*] Results saved to  /home/test/.msf4/loot/20140317132025_default_172.16.100.50_couchdb.enum.fil_319450.txt
 [*] Scanned 1 of 1 hosts (100% complete)
 [*] Auxiliary module execution completed
 msf auxiliary(es_enum) > exit
```
