### PR TITLE
Minor updates for release

### DIFF
--- a/modules/exploits/firefox/local/exec_shellcode.rb
+++ b/modules/exploits/firefox/local/exec_shellcode.rb
@@ -15,9 +15,9 @@ class Metasploit3 < Msf::Exploit::Local
     super(update_info(info,
       'Name'          => 'Firefox Exec Shellcode from Privileged Javascript Shell',
       'Description'   => %q{
-        Allows execution of native payloads from a privileged Firefox Javascript shell.
-        Puts the specified payload into memory, adds the necessary protection flags,
-        and calls it. Useful for upgrading a Firefox javascript shell to a Meterpreter
+        This module allows execution of native payloads from a privileged Firefox Javascript shell.
+        It places the specified payload into memory, adds the necessary protection flags,
+        and calls it, which can be useful for upgrading a Firefox javascript shell to a Meterpreter
         session without touching the disk.
       },
       'License'       => MSF_LICENSE,
@@ -41,6 +41,7 @@ class Metasploit3 < Msf::Exploit::Local
   end
 
   def exploit
+    print_status "Running the Javascript shell..."
     session.shell_write("[JAVASCRIPT]#{js_payload}[/JAVASCRIPT]")
     results = session.shell_read_until_token("[!JAVASCRIPT]", 0, datastore['TIMEOUT'])
     print_warning(results) if results.present?

--- a/modules/exploits/windows/fileformat/mplayer_m3u_bof.rb
+++ b/modules/exploits/windows/fileformat/mplayer_m3u_bof.rb
@@ -19,8 +19,8 @@ class Metasploit3 < Msf::Exploit::Remote
         MPlayer Lite r33064, caused by improper bounds checking of an URL entry.
 
         By persuading the victim to open a specially-crafted .M3U file, specifically by
-        drag-and-dropping it to the player, a remote attacker could execute arbitrary
-        code on the system or cause the application to crash.
+        drag-and-dropping it to the player, a remote attacker can execute arbitrary
+        code on the system.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>


### PR DESCRIPTION
Fixes some title/desc action.
Adds a print_status on the firefox module so it's not just silent.
Avoids the use of "puts" in the description b/c this freaks out msftidy
(it's a false positive but easily worked around).
## Verification
- [ ] See that the two named modules in the diff stats on the PR load
- [ ] Amaze at the descriptions that include complete sentences.
