### PR TITLE
Add support for firefox 28 to os.js

### DIFF
--- a/data/js/detect/os.js
+++ b/data/js/detect/os.js
@@ -212,7 +212,9 @@ window.os_detect.getVersion = function(){
 		// Thanks to developer.mozilla.org "Firefox for developers" series for most
 		// of these.
 		// Release changelogs: http://www.mozilla.org/en-US/firefox/releases/
-		if (css_is_valid('cursor', 'cursor', 'grab')) {
+		if (css_is_valid('flex-wrap', 'flexWrap', 'nowrap')) {
+			ua_version = '28.0';
+		} else if (css_is_valid('cursor', 'cursor', 'grab')) {
 			ua_version = '27.0';
 		} else if (css_is_valid('image-orientation',
 		                 'imageOrientation',


### PR DESCRIPTION
Verification
- [x] Open FF 27, cmd-opt-k to open web console, copy and paste `data/js/detect/os.js` into the console
- [x] Running `os_detect.getVersion().ua_version` should return "27.0"
- [x] Open FF 28, cmd-opt-k to open web console, copy and paste `data/js/detect/os.js` into the console
- [x] Running `os_detect.getVersion().ua_version` should return "28.0"
