### PR TITLE
Fix MsfVenom Java Payload Generation

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -229,12 +229,13 @@ module Msf
     # @return [String] Java payload as a JAR or WAR file
     def generate_java_payload
       payload_module = framework.payloads.create(payload)
+      payload_module.datastore.merge!(datastore)
       case format
-        when "raw"
+        when "raw", "jar"
           if payload_module.respond_to? :generate_jar
             payload_module.generate_jar.pack
           else
-            raise InvalidFormat, "#{payload} is not a Java payload"
+            payload_module.generate
           end
         when "war"
           if payload_module.respond_to? :generate_war

--- a/spec/lib/msf/core/payload_generator_spec.rb
+++ b/spec/lib/msf/core/payload_generator_spec.rb
@@ -472,7 +472,7 @@ describe Msf::PayloadGenerator do
     context 'when format is raw' do
       let(:format) { 'raw' }
 
-      context 'if the payload is a valid java payload' do
+      context 'if the payload responds to generate_jar' do
         let(:payload) { "java/meterpreter/reverse_tcp"}
         it 'calls the generate_jar on the payload' do
           java_payload = framework.payloads.create("java/meterpreter/reverse_tcp")
@@ -483,9 +483,19 @@ describe Msf::PayloadGenerator do
         end
       end
 
-      it 'raises an InvalidFormat exception' do
-        expect{payload_generator.generate_java_payload}.to raise_error(Msf::InvalidFormat)
+      context 'if the payload does not respond to generate_jar' do
+        let(:payload) { "java/jsp_shell_reverse_tcp"}
+        it 'calls #generate' do
+          java_payload = framework.payloads.create("java/jsp_shell_reverse_tcp")
+          framework.stub_chain(:payloads, :keys).and_return ["java/jsp_shell_reverse_tcp"]
+          framework.stub_chain(:payloads, :create).and_return(java_payload)
+          java_payload.should_receive(:generate).and_call_original
+          payload_generator.generate_java_payload
+        end
       end
+
+
+
     end
 
     context 'when format is a non-java format' do


### PR DESCRIPTION
This PR fixes a bug in the PayloadGenerator class that caused Java payloads to not be generated correctly.
