### PR TITLE
Add support for specific builds of MSIE 9 on Win 7 SP1

### DIFF
--- a/data/js/detect/os.js
+++ b/data/js/detect/os.js
@@ -877,6 +877,42 @@ window.os_detect.getVersion = function(){
 				os_flavor = "7";
 				os_sp = "SP1";
 				break;
+			case "9016502":
+				// IE 9.0.8112.16502 / Windows 7 SP1
+				ua_version = "9.0";
+				os_flavor = "7";
+				os_sp = "SP1";
+				break;
+			case "9016506":
+				// IE 9.0.8112.16506 / Windows 7 SP1
+				ua_version = "9.0";
+				os_flavor = "7";
+				os_sp = "SP1";
+				break;
+			case "9016514":
+				// IE 9.0.8112.16514 / Windows 7 SP1
+				ua_version = "9.0";
+				os_flavor = "7";
+				os_sp = "SP1";
+				break;
+			case "9016520":
+				// IE 9.0.8112.16520 / Windows 7 SP1
+				ua_version = "9.0";
+				os_flavor = "7";
+				os_sp = "SP1";
+				break;
+			case "9016526":
+				// IE 9.0.8112.16526 / Windows 7 SP1
+				ua_version = "9.0";
+				os_flavor = "7";
+				os_sp = "SP1";
+				break;
+			case "9016533":
+				// IE 9.0.8112.16533 / Windows 7 SP1
+				ua_version = "9.0";
+				os_flavor = "7";
+				os_sp = "SP1";
+				break;
 			case "10016720":
 				// IE 10.0.9200.16721 / Windows 7 SP1
 				ua_version = "10.0";


### PR DESCRIPTION
These IE9 versions are vulnerable to MS14-012 (see #3120). If we don't add them, then os_detect might recognize the target as IE 8, and fail.

Before you test, make sure you have these IE patches (for 32-bit Win 7 SP1):
- [ ] IE9-Windows6.1-KB2909921-x86
- [ ] IE9-Windows6.1-KB2898785-x86
- [ ] IE9-Windows6.1-KB2888505-x86
- [ ] IE9-Windows6.1-KB2879017-x86
- [ ] IE9-Windows6.1-KB2870699-x86
- [ ] IE9-Windows6.1-KB2862772-x86

You'll have to install them individually in order to test:
- [x] Copy everything from os.js
- [x] And paste it in your IE's developer's tool
- [x] When you use `os_detect.getVersion()`, it should show you that your IE is IE9 on Win 7 SP1.
