### PR TITLE
report_loot now sets proper Mdm::Workspace

### DIFF
--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -2102,16 +2102,6 @@ class DBManager
     msf_import_timestamps(opts,loot)
     loot.save!
 
-    if !opts[:created_at]
-=begin
-      if host
-        host.updated_at = host.created_at
-        host.state      = HostState::Alive
-        host.save!
-      end
-=end
-    end
-
     ret[:loot] = loot
   }
   end

--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -2092,12 +2092,13 @@ class DBManager
       loot.service_id = opts[:service][:id]
     end
 
-    loot.path  = path
-    loot.ltype = ltype
+    loot.path         = path
+    loot.ltype        = ltype
     loot.content_type = ctype
-    loot.data  = data
-    loot.name  = name if name
-    loot.info  = info if info
+    loot.data         = data
+    loot.name         = name if name
+    loot.info         = info if info
+    loot.workspace    = wspace
     msf_import_timestamps(opts,loot)
     loot.save!
 


### PR DESCRIPTION
- Uses an Mdm::Workspace for loot association when passed one in conf hash

MSP-9523
### Verification
- [x] call db.rb's report_loot with an Mdm::Workspace object in the opts hash's workspace key
- [x] Use IRB to confirm that Mdm::Loot.last.workspace == the Mdm::Workspace you passed in to report_loot
