### PR TITLE
Fix 2782 with 2961 and stop stack-tracing download_exec

### DIFF
--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -176,7 +176,8 @@ module Msf::Post::Common
     when /shell/
       result = {}
       envs.each do |env|
-        result[env] = get_env(env)
+        res = get_env(env)
+        result[env] = res unless res.blank?
       end
 
       return result

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -136,4 +136,54 @@ module Msf::Post::Common
     report_host(vm_data)
   end
 
+  #
+  # Returns the value of the environment variable +env+
+  #
+  def get_env(env)
+    case session.type
+    when /meterpreter/
+      return session.sys.config.getenv(env)
+    when /shell/
+      if session.platform =~ /win/
+        if env[0,1] == '%'
+          unless env[-1,1] == '%'
+            env << '%'
+          end
+        else
+          env = "%#{env}%"
+        end
+
+        return cmd_exec("echo #{env}")
+      else
+        unless env[0,1] == '$'
+          env = "$#{env}"
+        end
+
+        return cmd_exec("echo \"#{env}\"")
+      end
+    end
+
+    nil
+  end
+
+  #
+  # Returns a hash of environment variables +envs+
+  #
+  def get_envs(*envs)
+    case session.type
+    when /meterpreter/
+      return session.sys.config.getenvs(*envs)
+    when /shell/
+      result = {}
+      envs.each do |env|
+        result[env] = get_env(env)
+      end
+
+      return result
+    end
+
+    nil
+  end
+
 end
+

--- a/modules/post/linux/manage/download_exec.rb
+++ b/modules/post/linux/manage/download_exec.rb
@@ -45,13 +45,19 @@ class Metasploit3 < Msf::Post
   end
 
   def exists_exe?(exe)
-    path = session.sys.config.getenv("PATH")
+    vprint_status "Searching for #{exe} in the current $PATH..."
+    path = get_env("PATH")
     if path.nil? or path.empty?
       return false
+      vprint_error "No local $PATH set!"
+    else
+      vprint_status "$PATH is #{path.strip!}"
     end
 
     path.split(":").each{ |p|
-      return true if file_exist?(p + "/" + exe)
+      full_path = p + "/" + exe
+      vprint_status "Searching for '#{full_path}' ..."
+      return true if file_exist?(full_path)
     }
 
     return false

--- a/test/modules/post/test/get_env.rb
+++ b/test/modules/post/test/get_env.rb
@@ -1,0 +1,61 @@
+
+$:.push "test/lib" unless $:.include? "test/lib"
+require 'module_test'
+
+#load 'test/lib/module_test.rb'
+#load 'lib/rex/text.rb'
+#load 'lib/msf/core/post/common.rb'
+
+class Metasploit4 < Msf::Post
+
+  include Msf::ModuleTest::PostTest
+  include Msf::Post::Common
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'Testing Get Envs',
+        'Description'   => %q{ This module will test Post::Common get envs API methods },
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'Ben Campbell'],
+        'Platform'      => [ 'windows', 'linux', 'java', 'python' ],
+        'SessionTypes'  => [ 'meterpreter', 'shell' ]
+      ))
+  end
+
+  def test_get_env_windows
+    if session.platform =~ /win/i
+      it "should return windows path" do
+        path = get_env('WINDIR')
+        path =~ /windows/i
+      end
+
+      it "should handle % signs" do
+        path = get_env('%WINDIR%')
+        path =~ /windows/i
+      end
+    end
+  end
+
+  def test_get_env_nix
+    unless session.platform =~ /win/i
+      it "should return user" do
+        user = get_env('USER')
+        !user.blank?
+     end
+
+      it "should handle $ sign" do
+        user = get_env('$USER')
+        !user.blank?
+      end
+    end
+  end
+
+  def test_get_envs
+    it "should return multiple envs" do
+      res = get_envs('PATH','USERNAME')
+      !res['PATH'].blank? && !res['USERNAME'].blank?
+    end
+  end
+
+end
+


### PR DESCRIPTION
In #2782, @Meatballs1 feared that this change would disrupt Linux shell sessions, and gave the example of breaking download_exec for Linux shells.

As far as I can tell, this is the /only/ example of breakage, so this PR fixes that by:
- Including #2961. Note, there don't seem to be any holdups over there.
- Updating download_exec for #2961's `get_env` command

Now, keep in mind that download_exec already seems kinda broken -- that's what https://dev.metasploit.com/redmine/issues/8777 is all about. I am unable to use it normally on an Ubuntu 10.04 target, due to a mismatch on the shell command tokens. See that bug for details.

So, verification is easy, and lifted from @Meatballs1's report on #2782:
## Verification
- [x] Run the below on a SSH / Telnet shell session

```
use post/linux/manage/download_exec
set VERBOSE true
set SESSION 1
set URL http://google.com
run
```
- [x] See the lack of exceptions.
- [ ] Landing this will also land #2961, so make sure that happens.

If there is more brokennes introduced by #2782 that I'm not detecting, then feel free to pile on this PR, however, a grep through with the below turned up no other cases of linux shells getting left out in the cold: `grep -r "session.sys.config.getenv" modules/post/`
