### PR TITLE
added a vbs line to replace double spaces, shouldnt affect current at al...

### DIFF
--- a/data/exploits/cmdstager/vbs_b64
+++ b/data/exploits/cmdstager/vbs_b64
@@ -4,6 +4,7 @@ echo If file.Size Then >>decode_stub
 echo Set fd = fs.OpenTextFile("ENCODED", 1) >>decode_stub
 echo data = fd.ReadAll >>decode_stub
 echo data = Replace(data, vbCrLf, "") >>decode_stub
+echo data = Replace(data, "  ", "") >>decode_stub
 echo data = base64_decode(data) >>decode_stub
 echo fd.Close >>decode_stub
 echo Set ofs = CreateObject("Scripting.FileSystemObject").OpenTextFile("DECODED", 2, True) >>decode_stub


### PR DESCRIPTION
I needed a cmdStagerVBS payload that would work with my Oracle bug. This fix will not affect other exploits and just ensures the b64 string is clean before decoding it. This was tested on Windows Server 2003.

Kind regards,

mr_me
