### PR TITLE
Add support to detect mshtml build

### DIFF
--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -42,19 +42,20 @@ module Msf
 
     # Requirements a browser module can define in either BrowserRequirements or in targets
     REQUIREMENT_KEY_SET = {
-      :source      => 'source',      # Either 'script' or 'headers'
-      :ua_name     => 'ua_name',     # Example: MSIE
-      :ua_ver      => 'ua_ver',      # Example: 8.0, 9.0
-      :os_name     => 'os_name',     # Example: Microsoft Windows
-      :os_flavor   => 'os_flavor',   # Example: XP, 7
-      :language    => 'language',    # Example: en-us
-      :arch        => 'arch',        # Example: x86
-      :proxy       => 'proxy',       # 'true' or 'false'
-      :silverlight => 'silverlight', # 'true' or 'false'
-      :office      => 'office',      # Example: "2007", "2010"
-      :java        => 'java',        # Example: 1.6, 1.6.0.0
-      :clsid       => 'clsid',       # ActiveX clsid. Also requires the :method key
-      :method      => 'method'       # ActiveX method. Also requires the :clsid key
+      :source       => 'source',      # Either 'script' or 'headers'
+      :ua_name      => 'ua_name',     # Example: MSIE
+      :ua_ver       => 'ua_ver',      # Example: 8.0, 9.0
+      :os_name      => 'os_name',     # Example: Microsoft Windows
+      :os_flavor    => 'os_flavor',   # Example: XP, 7
+      :language     => 'language',    # Example: en-us
+      :arch         => 'arch',        # Example: x86
+      :proxy        => 'proxy',       # 'true' or 'false'
+      :silverlight  => 'silverlight', # 'true' or 'false'
+      :office       => 'office',      # Example: "2007", "2010"
+      :java         => 'java',        # Example: 1.6, 1.6.0.0
+      :clsid        => 'clsid',       # ActiveX clsid. Also requires the :method key
+      :method       => 'method',      # ActiveX method. Also requires the :clsid key
+      :mshtml_build => 'mshtml_build'  # mshtml build. Example: "65535"
     }
 
     def initialize(info={})
@@ -379,6 +380,7 @@ module Msf
 
         <% if os == OperatingSystems::WINDOWS and client == HttpClients::IE %>
           d['<%=REQUIREMENT_KEY_SET[:office]%>'] = window.ie_addons_detect.getMsOfficeVersion();
+          d['<%=REQUIREMENT_KEY_SET[:mshtml_build]%>'] = ScriptEngineBuildVersion().toString();
           <%
             clsid  = @requirements[:clsid]
             method = @requirements[:method]


### PR DESCRIPTION
Some IE vulns are build-specific, in that case we need a way to detect the build version. On IE9 and newer, the build version is the same as the one you see in WinDBG when you do lmv m mshtml (or when you right click mshtml.dll, see Product version/File version). On IE8, it returns something else I don't know.
### Verification
- [x] Prepare an IE 9 or IE10 box
- [x] Right click C:\Windows\System32\mshtml.dll, check the build version (specifically the last 5 digits, for example: 10.0.9200.16843, note 16843.) This also should be the same thing when you use `lmv m mshtml` in WinDBG.
- [x] Use this test case: https://gist.github.com/wchen-r7/3e155cd3c1309d0fc2cc
- [x] In the test case, modify the `mshtml_build` requirement
- [x] Make sure that if IE has the right build, BES should return the "exploit".
- [x] Make sure that if IE doesn't have the right build, BES should return a fake 404.
