### PR TITLE
Add default detection for IE 9 and IE 10

### DIFF
--- a/data/js/detect/os.js
+++ b/data/js/detect/os.js
@@ -946,9 +946,10 @@ window.os_detect.getVersion = function(){
 			// The ScriptEngine functions failed us, try some object detection
 			if (document.documentElement && (typeof document.documentElement.style.maxHeight)!="undefined") {
 				// IE 10 detection using nodeName
-				if (document.createElement("badname").nodeName == "BADNAME") {
-					ua_version = "10.0";
-				}
+				try {
+					var badNode = document.createElement && document.createElement("badname");
+					if (badNode && badNode.nodeName === "BADNAME") { ua_version = "10.0"; }
+				} catch(e) {}
 
 				// IE 9 detection based on a "Object doesn't support property or method" error
 				if (!ua_version) {

--- a/data/js/detect/os.js
+++ b/data/js/detect/os.js
@@ -964,13 +964,10 @@ window.os_detect.getVersion = function(){
 
 				// IE8 detection straight from IEBlog.  Thank you Microsoft.
 				if (!ua_version) {
-					try {
-						ua_version = "8.0";
-						document.documentElement.style.display = "table-cell";
-					} catch(e) {
-						// This executes in IE7,
-						// but not IE8, regardless of mode
-						ua_version = "7.0";
+					if (css_is_valid('display', 'display', 'table-cell')) {
+						ua_version = '8.0';
+					} else {
+						ua_version = '7.0';
 					}
 				}
 			} else if (document.compatMode) {

--- a/data/js/detect/os.js
+++ b/data/js/detect/os.js
@@ -964,10 +964,13 @@ window.os_detect.getVersion = function(){
 
 				// IE8 detection straight from IEBlog.  Thank you Microsoft.
 				if (!ua_version) {
-					if (css_is_valid('display', 'display', 'table-cell')) {
-						ua_version = '7.0';
-					} else {
-						ua_version = '8.0';
+					try {
+						ua_version = "8.0";
+						document.documentElement.style.display = "table-cell";
+					} catch(e) {
+						// This executes in IE7,
+						// but not IE8, regardless of mode
+						ua_version = "7.0";
 					}
 				}
 			} else if (document.compatMode) {

--- a/data/js/detect/os.js
+++ b/data/js/detect/os.js
@@ -965,9 +965,9 @@ window.os_detect.getVersion = function(){
 				// IE8 detection straight from IEBlog.  Thank you Microsoft.
 				if (!ua_version) {
 					if (css_is_valid('display', 'display', 'table-cell')) {
-						ua_version = '8.0';
-					} else {
 						ua_version = '7.0';
+					} else {
+						ua_version = '8.0';
 					}
 				}
 			} else if (document.compatMode) {

--- a/data/js/detect/os.js
+++ b/data/js/detect/os.js
@@ -945,14 +945,32 @@ window.os_detect.getVersion = function(){
 		if (!ua_version) {
 			// The ScriptEngine functions failed us, try some object detection
 			if (document.documentElement && (typeof document.documentElement.style.maxHeight)!="undefined") {
+				// IE 10 detection using nodeName
+				if (document.createElement("badname").nodeName == "BADNAME") {
+					ua_version = "10.0";
+				}
+
+				// IE 9 detection based on a "Object doesn't support property or method" error
+				if (!ua_version) {
+					try {
+						document.BADNAME();
+					} catch(e) {
+						if (e.message.indexOf("BADNAME") > 0) {
+							ua_version = "9.0";
+						}
+					}
+				}
+
 				// IE8 detection straight from IEBlog.  Thank you Microsoft.
-				try {
-					ua_version = "8.0";
-					document.documentElement.style.display = "table-cell";
-				} catch(e) {
-					// This executes in IE7,
-					// but not IE8, regardless of mode
-					ua_version = "7.0";
+				if (!ua_version) {
+					try {
+						ua_version = "8.0";
+						document.documentElement.style.display = "table-cell";
+					} catch(e) {
+						// This executes in IE7,
+						// but not IE8, regardless of mode
+						ua_version = "7.0";
+					}
 				}
 			} else if (document.compatMode) {
 				ua_version = "6.0";


### PR DESCRIPTION
How this is done:

On IE10, which should come first before the IE 9 check, the nodeName function always returns the name in uppercase.

One IE9, the "Object doesn't support property or method" error always repeats the name of the invalid method.
### Verification
- [ ] Copy code from line 947 to 988. This is the block that figures out which version of IE you're on if the ScriptEngine functions fail.
- [ ] Paste the code to the following template:

``` javascript
var ua_version;

/* the code you copied */

console.log(ua_version);
```
- [ ] Test the code in IE's Developer's Tools. Make sure you test all the way to IE10.

If you're feeling lazy step 1 & 2, you can use the following:
https://gist.github.com/wchen-r7/bd810a33e791b9ad27f8
