### PR TITLE
Name changes for IE modules

### DIFF
--- a/modules/exploits/windows/browser/ie_cbutton_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cbutton_uaf.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Microsoft Internet Explorer CButton Object Use-After-Free Vulnerability",
+      'Name'           => "MS13-008 Microsoft Internet Explorer CButton Object Use-After-Free Vulnerability",
       'Description'    => %q{
           This module exploits a vulnerability found in Microsoft Internet Explorer. A
         use-after-free condition occurs when a CButton object is freed, but a reference

--- a/modules/exploits/windows/browser/ie_createobject.rb
+++ b/modules/exploits/windows/browser/ie_createobject.rb
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Internet Explorer COM CreateObject Code Execution',
+      'Name'           => 'MS06-014 Microsoft Internet Explorer COM CreateObject Code Execution',
       'Description'    => %q{
           This module exploits a generic code execution vulnerability in Internet
         Explorer by abusing vulnerable ActiveX objects.

--- a/modules/exploits/windows/browser/ie_iscomponentinstalled.rb
+++ b/modules/exploits/windows/browser/ie_iscomponentinstalled.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Internet Explorer isComponentInstalled Overflow',
+      'Name'           => 'Microsoft Internet Explorer isComponentInstalled Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in Internet Explorer. This bug was
         patched in Windows 2000 SP4 and Windows XP SP1 according to MSRC.

--- a/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
+++ b/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Microsoft Internet Explorer SetMouseCapture Use-After-Free",
+      'Name'           => "MS13-080 Microsoft Internet Explorer SetMouseCapture Use-After-Free",
       'Description'    => %q{
           This module exploits a use-after-free vulnerability that currents targets Internet
           Explorer 9 on Windows 7, but the flaw should exist in versions 6/7/8/9/10/11.

--- a/modules/exploits/windows/browser/ie_unsafe_scripting.rb
+++ b/modules/exploits/windows/browser/ie_unsafe_scripting.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Internet Explorer Unsafe Scripting Misconfiguration',
+      'Name'           => 'Microsoft Internet Explorer Unsafe Scripting Misconfiguration',
       'Description'    => %q{
         This exploit takes advantage of the "Initialize and script ActiveX controls not
       marked safe for scripting" setting within Internet Explorer.  When this option is set,

--- a/modules/exploits/windows/browser/ms03_020_ie_objecttype.rb
+++ b/modules/exploits/windows/browser/ms03_020_ie_objecttype.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'MS03-020 Internet Explorer Object Type',
+      'Name'           => 'MS03-020 Microsoft Internet Explorer Object Type',
       'Description'    => %q{
           This module exploits a vulnerability in Internet Explorer's
         handling of the OBJECT type attribute.

--- a/modules/exploits/windows/browser/ms06_013_createtextrange.rb
+++ b/modules/exploits/windows/browser/ms06_013_createtextrange.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Internet Explorer createTextRange() Code Execution',
+      'Name'           => 'MS06-013 Microsoft Internet Explorer createTextRange() Code Execution',
       'Description'    => %q{
           This module exploits a code execution vulnerability in Microsoft Internet Explorer.
         Both IE6 and IE7 (Beta 2) are vulnerable. It will corrupt memory  in a way, which, under

--- a/modules/exploits/windows/browser/ms06_055_vml_method.rb
+++ b/modules/exploits/windows/browser/ms06_055_vml_method.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Internet Explorer VML Fill Method Code Execution',
+      'Name'           => 'MS06-055 Microsoft Internet Explorer VML Fill Method Code Execution',
       'Description'    => %q{
           This module exploits a code execution vulnerability in Microsoft Internet Explorer using
         a buffer overflow in the VML processing code (VGX.dll). This module has been tested on

--- a/modules/exploits/windows/browser/ms06_057_webview_setslice.rb
+++ b/modules/exploits/windows/browser/ms06_057_webview_setslice.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Internet Explorer WebViewFolderIcon setSlice() Overflow',
+      'Name'           => 'MS06-057 Microsoft Internet Explorer WebViewFolderIcon setSlice() Overflow',
       'Description'    => %q{
         This module exploits a flaw in the WebViewFolderIcon ActiveX control
       included with Windows 2000, Windows XP, and Windows 2003. This flaw was published

--- a/modules/exploits/windows/browser/ms06_067_keyframe.rb
+++ b/modules/exploits/windows/browser/ms06_067_keyframe.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Internet Explorer Daxctle.OCX KeyFrame Method Heap Buffer Overflow Vulnerability',
+      'Name'           => 'MS06-067 Microsoft Internet Explorer Daxctle.OCX KeyFrame Method Heap Buffer Overflow Vulnerability',
       'Description'    => %q{
         This module exploits a heap overflow vulnerability in the KeyFrame method of the
         direct animation ActiveX control.  This is a port of the exploit implemented by

--- a/modules/exploits/windows/browser/ms06_071_xml_core.rb
+++ b/modules/exploits/windows/browser/ms06_071_xml_core.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Internet Explorer XML Core Services HTTP Request Handling',
+      'Name'           => 'MS06-071 Microsoft Internet Explorer XML Core Services HTTP Request Handling',
       'Description'    => %q{
           This module exploits a code execution vulnerability in Microsoft XML Core Services which
         exists in the XMLHTTP ActiveX control. This module is the modifed version of

--- a/modules/exploits/windows/browser/ms08_078_xml_corruption.rb
+++ b/modules/exploits/windows/browser/ms08_078_xml_corruption.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Internet Explorer Data Binding Memory Corruption',
+      'Name'           => 'MS08-078 Microsoft Internet Explorer Data Binding Memory Corruption',
       'Description'    => %q{
         This module exploits a vulnerability in the data binding feature of Internet
       Explorer. In order to execute code reliably, this module uses the .NET DLL

--- a/modules/exploits/windows/browser/ms09_002_memory_corruption.rb
+++ b/modules/exploits/windows/browser/ms09_002_memory_corruption.rb
@@ -25,7 +25,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Internet Explorer 7 CFunctionPointer Uninitialized Memory Corruption',
+      'Name'           => 'MS09-002 Microsoft Internet Explorer 7 CFunctionPointer Uninitialized Memory Corruption',
       'Description'    => %q{
         This module exploits an error related to the CFunctionPointer function when attempting
         to access uninitialized memory. A remote attacker could exploit this vulnerability to

--- a/modules/exploits/windows/browser/ms09_072_style_object.rb
+++ b/modules/exploits/windows/browser/ms09_072_style_object.rb
@@ -25,7 +25,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Internet Explorer Style getElementsByTagName Memory Corruption',
+      'Name'           => 'MS09-072 Microsoft Internet Explorer Style getElementsByTagName Memory Corruption',
       'Description'    => %q{
         This module exploits a vulnerability in the getElementsByTagName function
       as implemented within Internet Explorer.

--- a/modules/exploits/windows/browser/ms10_002_aurora.rb
+++ b/modules/exploits/windows/browser/ms10_002_aurora.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Internet Explorer "Aurora" Memory Corruption',
+      'Name'           => 'MS10-002 Microsoft Internet Explorer "Aurora" Memory Corruption',
       'Description'    => %q{
           This module exploits a memory corruption flaw in Internet Explorer. This
         flaw was found in the wild and was a key component of the "Operation Aurora"

--- a/modules/exploits/windows/browser/ms10_002_ie_object.rb
+++ b/modules/exploits/windows/browser/ms10_002_ie_object.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "MS10-002 Internet Explorer Object Memory Use-After-Free",
+      'Name'           => "MS10-002 Microsoft Internet Explorer Object Memory Use-After-Free",
       'Description'    => %q{
           This module exploits a vulnerability found in Internet Explorer's
         mshtml component.  Due to the way IE handles objects in memory, it is

--- a/modules/exploits/windows/browser/ms10_018_ie_behaviors.rb
+++ b/modules/exploits/windows/browser/ms10_018_ie_behaviors.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Internet Explorer DHTML Behaviors Use After Free',
+      'Name'           => 'MS10-018 Microsoft Internet Explorer DHTML Behaviors Use After Free',
       'Description'    => %q{
           This module exploits a use-after-free vulnerability within the DHTML behaviors
         functionality of Microsoft Internet Explorer versions 6 and 7. This bug was

--- a/modules/exploits/windows/browser/ms10_018_ie_tabular_activex.rb
+++ b/modules/exploits/windows/browser/ms10_018_ie_tabular_activex.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Internet Explorer Tabular Data Control ActiveX Memory Corruption',
+      'Name'           => 'MS10-018 Microsoft Internet Explorer Tabular Data Control ActiveX Memory Corruption',
       'Description'    => %q{
           This module exploits a memory corruption vulnerability in the Internet Explorer
         Tabular Data ActiveX Control. Microsoft reports that version 5.01 and 6 of Internet

--- a/modules/exploits/windows/browser/ms10_022_ie_vbscript_winhlp32.rb
+++ b/modules/exploits/windows/browser/ms10_022_ie_vbscript_winhlp32.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Internet Explorer Winhlp32.exe MsgBox Code Execution',
+      'Name'           => 'MS10-022 Microsoft Internet Explorer Winhlp32.exe MsgBox Code Execution',
       'Description'    => %q{
           This module exploits a code execution vulnerability that occurs when a user
         presses F1 on MessageBox originated from VBscript within a web page. When the

--- a/modules/exploits/windows/browser/ms10_090_ie_css_clip.rb
+++ b/modules/exploits/windows/browser/ms10_090_ie_css_clip.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Internet Explorer CSS SetUserClip Memory Corruption',
+      'Name'           => 'MS10-090 Microsoft Internet Explorer CSS SetUserClip Memory Corruption',
       'Description'    => %q{
           Thie module exploits a memory corruption vulnerability within Microsoft's
         HTML engine (mshtml). When parsing an HTML page containing a specially

--- a/modules/exploits/windows/browser/ms11_003_ie_css_import.rb
+++ b/modules/exploits/windows/browser/ms11_003_ie_css_import.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Internet Explorer CSS Recursive Import Use After Free',
+      'Name'           => 'MS11-003 Microsoft Internet Explorer CSS Recursive Import Use After Free',
       'Description'    => %q{
           This module exploits a memory corruption vulnerability within Microsoft\'s
         HTML engine (mshtml). When parsing an HTML page containing a recursive CSS

--- a/modules/exploits/windows/browser/ms11_081_option.rb
+++ b/modules/exploits/windows/browser/ms11_081_option.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "Microsoft Internet Explorer Option Element Use-After-Free",
+      'Name'           => "MS11-081 Microsoft Internet Explorer Option Element Use-After-Free",
       'Description'    => %q{
           This module exploits a vulnerability in Microsoft Internet Explorer.  A memory
         corruption may occur when the Option cache isn't updated properly, which allows

--- a/modules/exploits/windows/browser/ms12_037_ie_colspan.rb
+++ b/modules/exploits/windows/browser/ms12_037_ie_colspan.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft Internet Explorer Fixed Table Col Span Heap Overflow',
+      'Name'           => 'MS12-037 Microsoft Internet Explorer Fixed Table Col Span Heap Overflow',
       'Description'    => %q{
           This module exploits a heap overflow vulnerability in Internet Explorer caused
         by an incorrect handling of the span attribute for col elements from a fixed table,

--- a/modules/exploits/windows/browser/ms12_037_same_id.rb
+++ b/modules/exploits/windows/browser/ms12_037_same_id.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "MS12-037 Internet Explorer Same ID Property Deleted Object Handling Memory Corruption",
+      'Name'           => "MS12-037 Microsoft Internet Explorer Same ID Property Deleted Object Handling Memory Corruption",
       'Description'    => %q{
           This module exploits a memory corruption flaw in Internet Explorer 8 when
         handling objects with the same ID property. At the moment this module targets

--- a/modules/exploits/windows/browser/ms14_012_textrange.rb
+++ b/modules/exploits/windows/browser/ms14_012_textrange.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "MS14-012 Internet Explorer TextRange Use-After-Free",
+      'Name'           => "MS14-012 Microsoft Internet Explorer TextRange Use-After-Free",
       'Description'    => %q{
         This module exploits a use-after-free vulnerability found in Internet Explorer. The flaw
         was most likely introduced in 2013, therefore only certain builds of MSHTML are


### PR DESCRIPTION
While searching through existing MSIE modules, I realized sometimes we'd name modules like this format:

```
[MSB] Microsoft Internet Explorer [something]
```

And then sometimes we'd do:

```
Internet Explorer [something]
```

or:

```
Microsoft Internet Explorer [something]
```

I tried to make this more consistent by following the first format. It would be easier to find stuff that way especially on a GUI (when displayed as an ordered list).
