### PR TITLE
Microsoft module name changes

### DIFF
--- a/modules/exploits/windows/dcerpc/ms03_026_dcom.rb
+++ b/modules/exploits/windows/dcerpc/ms03_026_dcom.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft RPC DCOM Interface Overflow',
+      'Name'           => 'MS03-026 Microsoft RPC DCOM Interface Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in the RPCSS service, this vulnerability
         was originally found by the Last Stage of Delirium research group and has been

--- a/modules/exploits/windows/dcerpc/ms05_017_msmq.rb
+++ b/modules/exploits/windows/dcerpc/ms05_017_msmq.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft Message Queueing Service Path Overflow',
+      'Name'           => 'MS05-017 Microsoft Message Queueing Service Path Overflow',
       'Description'    => %q{
         This module exploits a stack buffer overflow in the RPC interface
         to the Microsoft Message Queueing service. The offset to the

--- a/modules/exploits/windows/dcerpc/ms07_029_msdns_zonename.rb
+++ b/modules/exploits/windows/dcerpc/ms07_029_msdns_zonename.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft DNS RPC Service extractQuotedChar() Overflow (TCP)',
+      'Name'           => 'MS07-029 Microsoft DNS RPC Service extractQuotedChar() Overflow (TCP)',
       'Description'    => %q{
           This module exploits a stack buffer overflow in the RPC interface
         of the Microsoft DNS service. The vulnerability is triggered

--- a/modules/exploits/windows/dcerpc/ms07_065_msmq.rb
+++ b/modules/exploits/windows/dcerpc/ms07_065_msmq.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft Message Queueing Service DNS Name Path Overflow',
+      'Name'           => 'MS07-065 Microsoft Message Queueing Service DNS Name Path Overflow',
       'Description'    => %q{
         This module exploits a stack buffer overflow in the RPC interface
       to the Microsoft Message Queueing service. This exploit requires

--- a/modules/exploits/windows/fileformat/ms09_067_excel_featheader.rb
+++ b/modules/exploits/windows/fileformat/ms09_067_excel_featheader.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft Excel Malformed FEATHEADER Record Vulnerability',
+      'Name'           => 'MS09-067 Microsoft Excel Malformed FEATHEADER Record Vulnerability',
       'Description'    => %q{
             This module exploits a vulnerability in the handling of the FEATHEADER record
           by Microsoft Excel. Revisions of Office XP and later prior to the release of the

--- a/modules/exploits/windows/fileformat/ms10_004_textbytesatom.rb
+++ b/modules/exploits/windows/fileformat/ms10_004_textbytesatom.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft PowerPoint Viewer TextBytesAtom Stack Buffer Overflow',
+      'Name'           => 'MS10-004 Microsoft PowerPoint Viewer TextBytesAtom Stack Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow vulnerability in the handling of
         the TextBytesAtom records by Microsoft PowerPoint Viewer. According to Microsoft,

--- a/modules/exploits/windows/fileformat/ms10_087_rtf_pfragments_bof.rb
+++ b/modules/exploits/windows/fileformat/ms10_087_rtf_pfragments_bof.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft Word RTF pFragments Stack Buffer Overflow (File Format)',
+      'Name'           => 'MS10-087 Microsoft Word RTF pFragments Stack Buffer Overflow (File Format)',
       'Description'    => %q{
           This module exploits a stack-based buffer overflow in the handling of the
         'pFragments' shape property within the Microsoft Word RTF parser. All versions

--- a/modules/exploits/windows/fileformat/ms11_006_createsizeddibsection.rb
+++ b/modules/exploits/windows/fileformat/ms11_006_createsizeddibsection.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft Windows CreateSizedDIBSECTION Stack Buffer Overflow',
+      'Name'           => 'MS11-006 Microsoft Windows CreateSizedDIBSECTION Stack Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack-based buffer overflow in the handling of thumbnails
         within .MIC files and various Office documents. When processing a thumbnail bitmap

--- a/modules/exploits/windows/ftp/ms09_053_ftpd_nlst.rb
+++ b/modules/exploits/windows/ftp/ms09_053_ftpd_nlst.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft IIS FTP Server NLST Response Overflow',
+      'Name'           => 'MS09-053 Microsoft IIS FTP Server NLST Response Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow flaw in the Microsoft IIS FTP
         service. The flaw is triggered when a special NLST argument is passed

--- a/modules/exploits/windows/iis/ms01_023_printer.rb
+++ b/modules/exploits/windows/iis/ms01_023_printer.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft IIS 5.0 Printer Host Header Overflow',
+      'Name'           => 'MS01-023 Microsoft IIS 5.0 Printer Host Header Overflow',
       'Description'    => %q{
           This exploits a buffer overflow in the request processor of
         the Internet Printing Protocol ISAPI module in IIS. This

--- a/modules/exploits/windows/iis/ms01_026_dbldecode.rb
+++ b/modules/exploits/windows/iis/ms01_026_dbldecode.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft IIS/PWS CGI Filename Double Decode Command Execution',
+      'Name'           => 'MS01-026 Microsoft IIS/PWS CGI Filename Double Decode Command Execution',
       'Description'    => %q{
           This module will execute an arbitrary payload on a Microsoft IIS installation
         that is vulnerable to the CGI double-decode vulnerability of 2001.

--- a/modules/exploits/windows/iis/ms01_033_idq.rb
+++ b/modules/exploits/windows/iis/ms01_033_idq.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft IIS 5.0 IDQ Path Overflow',
+      'Name'           => 'MS01-033 Microsoft IIS 5.0 IDQ Path Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in the IDQ ISAPI handler for
         Microsoft Index Server.

--- a/modules/exploits/windows/iis/ms02_018_htr.rb
+++ b/modules/exploits/windows/iis/ms02_018_htr.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft IIS 4.0 .HTR Path Overflow',
+      'Name'           => 'MS02-018 Microsoft IIS 4.0 .HTR Path Overflow',
       'Description'    => %q{
           This exploits a buffer overflow in the ISAPI ISM.DLL used to
         process HTR scripting in IIS 4.0. This module works against

--- a/modules/exploits/windows/iis/ms02_065_msadc.rb
+++ b/modules/exploits/windows/iis/ms02_065_msadc.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize
     super(
-      'Name'        => 'Microsoft IIS MDAC msadcs.dll RDS DataStub Content-Type Overflow',
+      'Name'        => 'MS02-065 Microsoft IIS MDAC msadcs.dll RDS DataStub Content-Type Overflow',
       'Description' => %q{
           This module can be used to execute arbitrary code on IIS servers
           that expose the /msadc/msadcs.dll Microsoft Data Access Components

--- a/modules/exploits/windows/iis/ms03_007_ntdll_webdav.rb
+++ b/modules/exploits/windows/iis/ms03_007_ntdll_webdav.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft IIS 5.0 WebDAV ntdll.dll Path Overflow',
+      'Name'           => 'MS03-007 Microsoft IIS 5.0 WebDAV ntdll.dll Path Overflow',
       'Description'    => %q{
         This exploits a buffer overflow in NTDLL.dll on Windows 2000
         through the SEARCH WebDAV method in IIS. This particular

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize
     super(
-      'Name'           => 'Microsoft IIS MDAC msadcs.dll RDS Arbitrary Remote Command Execution',
+      'Name'           => 'MS99-025 Microsoft IIS MDAC msadcs.dll RDS Arbitrary Remote Command Execution',
       'Description'    => %q{
           This module can be used to execute arbitrary commands on IIS servers
           that expose the /msadc/msadcs.dll Microsoft Data Access Components

--- a/modules/exploits/windows/isapi/ms00_094_pbserver.rb
+++ b/modules/exploits/windows/isapi/ms00_094_pbserver.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft IIS Phone Book Service Overflow',
+      'Name'           => 'MS00-094 Microsoft IIS Phone Book Service Overflow',
       'Description'    => %q{
           This is an exploit for the Phone Book Service /pbserver/pbserver.dll
         described in MS00-094. By sending an overly long URL argument

--- a/modules/exploits/windows/isapi/ms03_022_nsiislog_post.rb
+++ b/modules/exploits/windows/isapi/ms03_022_nsiislog_post.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft IIS ISAPI nsiislog.dll ISAPI POST Overflow',
+      'Name'           => 'MS03-022 Microsoft IIS ISAPI nsiislog.dll ISAPI POST Overflow',
       'Description'    => %q{
           This exploits a buffer overflow found in the nsiislog.dll
         ISAPI filter that comes with Windows Media Server. This

--- a/modules/exploits/windows/isapi/ms03_051_fp30reg_chunked.rb
+++ b/modules/exploits/windows/isapi/ms03_051_fp30reg_chunked.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft IIS ISAPI FrontPage fp30reg.dll Chunked Overflow',
+      'Name'           => 'MS03-051 Microsoft IIS ISAPI FrontPage fp30reg.dll Chunked Overflow',
       'Description'    => %q{
           This is an exploit for the chunked encoding buffer overflow
         described in MS03-051 and originally reported by Brett

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Local
 
   def initialize(info={})
     super(update_info(info, {
-      'Name'          => 'Microsoft Windows ndproxy.sys Local Privilege Escalation',
+      'Name'          => 'MS14-002 Microsoft Windows ndproxy.sys Local Privilege Escalation',
       'Description'    => %q{
         This module exploits a flaw in the ndproxy.sys driver on Windows XP SP3 and Windows 2003
         SP2 systems, exploited in the wild in November, 2013. The vulnerability exists while
@@ -70,6 +70,7 @@ class Metasploit3 < Msf::Exploit::Local
       'References'    =>
         [
           [ 'CVE', '2013-5065' ],
+          [ 'MSB', 'MS14-002' ],
           [ 'OSVDB' , '100368'],
           [ 'BID', '63971' ],
           [ 'EDB', '30014' ],

--- a/modules/exploits/windows/misc/ms07_064_sami.rb
+++ b/modules/exploits/windows/misc/ms07_064_sami.rb
@@ -10,7 +10,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft DirectX DirectShow SAMI Buffer Overflow',
+      'Name'           => 'MS07-064 Microsoft DirectX DirectShow SAMI Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in the DirectShow Synchronized
         Accessible Media Interchanged (SAMI) parser in quartz.dll. This module

--- a/modules/exploits/windows/misc/ms10_104_sharepoint.rb
+++ b/modules/exploits/windows/misc/ms10_104_sharepoint.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize
     super(
-      'Name'        => 'Microsoft Office SharePoint Server 2007 Remote Code Execution',
+      'Name'        => 'MS10-104 Microsoft Office SharePoint Server 2007 Remote Code Execution',
       'Description'    => %q{
           This module exploits a vulnerability found in SharePoint Server 2007 SP2. The
         software contains a directory traversal, that allows a remote attacker to write

--- a/modules/exploits/windows/mssql/ms02_039_slammer.rb
+++ b/modules/exploits/windows/mssql/ms02_039_slammer.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft SQL Server Resolution Overflow',
+      'Name'           => 'MS02-039 Microsoft SQL Server Resolution Overflow',
       'Description'    => %q{
           This is an exploit for the SQL Server 2000 resolution
         service buffer overflow. This overflow is triggered by

--- a/modules/exploits/windows/mssql/ms02_056_hello.rb
+++ b/modules/exploits/windows/mssql/ms02_056_hello.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft SQL Server Hello Overflow',
+      'Name'           => 'MS02-056 Microsoft SQL Server Hello Overflow',
       'Description'    => %q{
           By sending malformed data to TCP port 1433, an
         unauthenticated remote attacker could overflow a buffer and

--- a/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin.rb
+++ b/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def initialize(info = {})
 
     super(update_info(info,
-      'Name'           => 'Microsoft SQL Server sp_replwritetovarbin Memory Corruption',
+      'Name'           => 'MS09-004 Microsoft SQL Server sp_replwritetovarbin Memory Corruption',
       'Description'    => %q{
           A heap-based buffer overflow can occur when calling the undocumented
         "sp_replwritetovarbin" extended stored procedure. This vulnerability affects

--- a/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin_sqli.rb
+++ b/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin_sqli.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def initialize(info = {})
 
     super(update_info(info,
-      'Name'           => 'Microsoft SQL Server sp_replwritetovarbin Memory Corruption via SQL Injection',
+      'Name'           => 'MS09-004 Microsoft SQL Server sp_replwritetovarbin Memory Corruption via SQL Injection',
       'Description'    => %q{
           A heap-based buffer overflow can occur when calling the undocumented
         "sp_replwritetovarbin" extended stored procedure. This vulnerability affects

--- a/modules/exploits/windows/nntp/ms05_030_nntp.rb
+++ b/modules/exploits/windows/nntp/ms05_030_nntp.rb
@@ -11,7 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft Outlook Express NNTP Response Parsing Buffer Overflow',
+      'Name'           => 'MS05-030 Microsoft Outlook Express NNTP Response Parsing Buffer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in the news reader of Microsoft
         Outlook Express.

--- a/modules/exploits/windows/smb/ms03_049_netapi.rb
+++ b/modules/exploits/windows/smb/ms03_049_netapi.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft Workstation Service NetAddAlternateComputerName Overflow',
+      'Name'           => 'MS03-049 Microsoft Workstation Service NetAddAlternateComputerName Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in the NetApi32 NetAddAlternateComputerName
         function using the Workstation service in Windows XP.

--- a/modules/exploits/windows/smb/ms04_007_killbill.rb
+++ b/modules/exploits/windows/smb/ms04_007_killbill.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft ASN.1 Library Bitstring Heap Overflow',
+      'Name'           => 'MS04-007 Microsoft ASN.1 Library Bitstring Heap Overflow',
       'Description'    => %q{
           This is an exploit for a previously undisclosed
         vulnerability in the bit string decoding code in the

--- a/modules/exploits/windows/smb/ms04_011_lsass.rb
+++ b/modules/exploits/windows/smb/ms04_011_lsass.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft LSASS Service DsRolerUpgradeDownlevelServer Overflow',
+      'Name'           => 'MS04-011 Microsoft LSASS Service DsRolerUpgradeDownlevelServer Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in the LSASS service, this vulnerability
         was originally found by eEye. When re-exploiting a Windows XP system, you will need

--- a/modules/exploits/windows/smb/ms04_031_netdde.rb
+++ b/modules/exploits/windows/smb/ms04_031_netdde.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft NetDDE Service Overflow',
+      'Name'           => 'MS04-031 Microsoft NetDDE Service Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in the NetDDE service, which is the
         precursor to the DCOM interface.  This exploit effects only operating systems

--- a/modules/exploits/windows/smb/ms05_039_pnp.rb
+++ b/modules/exploits/windows/smb/ms05_039_pnp.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft Plug and Play Service Overflow',
+      'Name'           => 'MS05-039 Microsoft Plug and Play Service Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in the Windows Plug
         and Play service. This vulnerability can be exploited on

--- a/modules/exploits/windows/smb/ms06_025_rasmans_reg.rb
+++ b/modules/exploits/windows/smb/ms06_025_rasmans_reg.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft RRAS Service RASMAN Registry Overflow',
+      'Name'           => 'MS06-025 Microsoft RRAS Service RASMAN Registry Overflow',
       'Description'    => %q{
           This module exploits a registry-based stack buffer overflow in the Windows Routing
         and Remote Access Service. Since the service is hosted inside svchost.exe,

--- a/modules/exploits/windows/smb/ms06_025_rras.rb
+++ b/modules/exploits/windows/smb/ms06_025_rras.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft RRAS Service Overflow',
+      'Name'           => 'MS06-025 Microsoft RRAS Service Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in the Windows Routing and Remote
         Access Service. Since the service is hosted inside svchost.exe, a failed

--- a/modules/exploits/windows/smb/ms06_040_netapi.rb
+++ b/modules/exploits/windows/smb/ms06_040_netapi.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft Server Service NetpwPathCanonicalize Overflow',
+      'Name'           => 'MS06-040 Microsoft Server Service NetpwPathCanonicalize Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in the NetApi32 CanonicalizePathName() function
         using the NetpwPathCanonicalize RPC call in the Server Service. It is likely that

--- a/modules/exploits/windows/smb/ms06_066_nwapi.rb
+++ b/modules/exploits/windows/smb/ms06_066_nwapi.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft Services MS06-066 nwapi32.dll Module Exploit',
+      'Name'           => 'MS06-066 Microsoft Services nwapi32.dll Module Exploit',
       'Description'    => %q{
           This module exploits a stack buffer overflow in the svchost service when the netware
         client service is running. This specific vulnerability is in the nwapi32.dll module.

--- a/modules/exploits/windows/smb/ms06_066_nwwks.rb
+++ b/modules/exploits/windows/smb/ms06_066_nwwks.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft Services MS06-066 nwwks.dll Module Exploit',
+      'Name'           => 'MS06-066 Microsoft Services nwwks.dll Module Exploit',
       'Description'    => %q{
           This module exploits a stack buffer overflow in the svchost service, when the netware
         client service is running. This specific vulnerability is in the nwapi32.dll module.

--- a/modules/exploits/windows/smb/ms06_070_wkssvc.rb
+++ b/modules/exploits/windows/smb/ms06_070_wkssvc.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft Workstation Service NetpManageIPCConnect Overflow',
+      'Name'           => 'MS06-070 Microsoft Workstation Service NetpManageIPCConnect Overflow',
       'Description'    => %q{
           This module exploits a stack buffer overflow in the NetApi32 NetpManageIPCConnect
         function using the Workstation service in Windows 2000 SP4 and Windows XP SP2.

--- a/modules/exploits/windows/smb/ms07_029_msdns_zonename.rb
+++ b/modules/exploits/windows/smb/ms07_029_msdns_zonename.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft DNS RPC Service extractQuotedChar() Overflow (SMB)',
+      'Name'           => 'MS07-029 Microsoft DNS RPC Service extractQuotedChar() Overflow (SMB)',
       'Description'    => %q{
           This module exploits a stack buffer overflow in the RPC interface
         of the Microsoft DNS service. The vulnerability is triggered

--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -17,7 +17,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft Server Service Relative Path Stack Corruption',
+      'Name'           => 'MS08-067 Microsoft Server Service Relative Path Stack Corruption',
       'Description'    => %q{
           This module exploits a parsing flaw in the path canonicalization code of
         NetAPI32.dll through the Server Service. This module is capable of bypassing

--- a/modules/exploits/windows/smb/ms09_050_smb2_negotiate_func_index.rb
+++ b/modules/exploits/windows/smb/ms09_050_smb2_negotiate_func_index.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft SRV2.SYS SMB Negotiate ProcessID Function Table Dereference',
+      'Name'           => 'MS09-050 Microsoft SRV2.SYS SMB Negotiate ProcessID Function Table Dereference',
       'Description'    => %q{
           This module exploits an out of bounds function table dereference in the SMB
         request validation code of the SRV2.SYS driver included with Windows Vista, Windows 7

--- a/modules/exploits/windows/smb/ms10_061_spoolss.rb
+++ b/modules/exploits/windows/smb/ms10_061_spoolss.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft Print Spooler Service Impersonation Vulnerability',
+      'Name'           => 'MS10-061 Microsoft Print Spooler Service Impersonation Vulnerability',
       'Description'    => %q{
           This module exploits the RPC service impersonation vulnerability detailed in
         Microsoft Bulletin MS10-061. By making a specific DCE RPC request to the

--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft Windows SMB Relay Code Execution',
+      'Name'           => 'MS08-068 Microsoft Windows SMB Relay Code Execution',
       'Description'    => %q{
           This module will relay SMB authentication requests to another
         host, gaining access to an authenticated SMB session if successful.

--- a/modules/exploits/windows/ssl/ms04_011_pct.rb
+++ b/modules/exploits/windows/ssl/ms04_011_pct.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft Private Communications Transport Overflow',
+      'Name'           => 'MS04-011 Microsoft Private Communications Transport Overflow',
       'Description'    => %q{
           This module exploits a buffer overflow in the Microsoft
         Windows SSL PCT protocol stack. This code is based on Johnny

--- a/modules/exploits/windows/wins/ms04_045_wins.rb
+++ b/modules/exploits/windows/wins/ms04_045_wins.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Microsoft WINS Service Memory Overwrite',
+      'Name'           => 'MS04-045 Microsoft WINS Service Memory Overwrite',
       'Description'    => %q{
         This module exploits an arbitrary memory write flaw in the
         WINS service. This exploit has been tested against Windows

--- a/spec/lib/msf/core/modules/loader/directory_spec.rb
+++ b/spec/lib/msf/core/modules/loader/directory_spec.rb
@@ -55,7 +55,7 @@ describe Msf::Modules::Loader::Directory do
 
           created_module = module_manager.create(module_full_name)
 
-          created_module.name.should == 'Microsoft Server Service Relative Path Stack Corruption'
+          created_module.name.should == 'MS08-067 Microsoft Server Service Relative Path Stack Corruption'
         end
 
         context 'with module previously loaded' do


### PR DESCRIPTION
So after making changes for MSIE modules (see #3161), I decided to take a look at all MS modules, and then I ended up changing most of them. Reason is the same: if you list modules in an ordered list, this is a little bit easier to see for your eyes.
