### PR TITLE
fix typo in msfvenom

### DIFF
--- a/msfvenom
+++ b/msfvenom
@@ -265,7 +265,7 @@ if __FILE__ == $0
         when "payloads"
           $stderr.puts dump_payloads
         when "encoders"
-          $stderr.puts dump_encoders(opts[:arch])
+          $stderr.puts dump_encoders(generator_opts[:arch])
         when "nops"
           $stderr.puts dump_nops
         when "all"


### PR DESCRIPTION
typo caused list encoders to fail
FIXRM #8778
