### PR TITLE
Eicar update

### DIFF
--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -16,17 +16,26 @@ module Exploit::EXE
     # EncodedPayload#encoded_exe in lib/msf/core/encoded_payload.rb
     register_advanced_options(
       [
+        OptBool.new(   'EXE::EICAR',    [ false, 'Generate an EICAR file instead of regular payload exe']),
         OptPath.new(   'EXE::Custom',   [ false, 'Use custom exe instead of automatically generating a payload exe']),
         OptPath.new(   'EXE::Path',     [ false, 'The directory in which to look for the executable template' ]),
         OptPath.new(   'EXE::Template', [ false, 'The executable template file name.' ]),
         OptBool.new(   'EXE::Inject',   [ false, 'Set to preserve the original EXE function' ]),
         OptBool.new(   'EXE::OldMethod',[ false, 'Set to use the substitution EXE generation method.' ]),
         OptBool.new(   'EXE::FallBack', [ false, 'Use the default template in case the specified one is missing' ]),
+        OptBool.new(   'MSI::EICAR',    [ false, 'Generate an EICAR file instead of regular payload msi']),
         OptPath.new(   'MSI::Custom',   [ false, 'Use custom msi instead of automatically generating a payload msi']),
         OptPath.new(   'MSI::Path',     [ false, 'The directory in which to look for the msi template' ]),
         OptPath.new(   'MSI::Template', [ false, 'The msi template file name' ]),
         OptBool.new(   'MSI::UAC',      [ false, 'Create an MSI with a UAC prompt (elevation to SYSTEM if accepted)' ])
       ], self.class)
+  end
+
+  # Avoid stating the string directly, don't want to get caught by local
+  # antivirus!
+  def get_eicar_exe
+    obfus_eicar = ["x5o!p%@ap[4\\pzx54(p^)7cc)7}$eicar", "standard", "antivirus", "test", "file!$h+h*"]
+    obfus_eicar.join("-").upcase
   end
 
   def get_custom_exe(path=nil)
@@ -41,6 +50,7 @@ module Exploit::EXE
 
   def generate_payload_exe(opts = {})
     return get_custom_exe if datastore.include? 'EXE::Custom'
+    return get_eicar_exe if datastore.include? 'EXE::EICAR'
 
     exe_init_options(opts)
 
@@ -68,6 +78,7 @@ module Exploit::EXE
 
   def generate_payload_exe_service(opts = {})
     return get_custom_exe if datastore.include? 'EXE::Custom'
+    return get_eicar_exe if datastore.include? 'EXE::EICAR'
 
     exe_init_options(opts)
 
@@ -90,6 +101,7 @@ module Exploit::EXE
 
   def generate_payload_dll(opts = {})
     return get_custom_exe if datastore.include? 'EXE::Custom'
+    return get_eicar_exe if datastore.include? 'EXE::EICAR'
 
     exe_init_options(opts)
 
@@ -112,6 +124,7 @@ module Exploit::EXE
 
   def generate_payload_msi(opts = {})
     return get_custom_exe(datastore['MSI::Custom']) if datastore.include? 'MSI::Custom'
+    return get_eicar_exe if datastore.include? 'MSI::EICAR'
 
     exe = generate_payload_exe(opts)
 

--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -50,7 +50,7 @@ module Exploit::EXE
 
   def generate_payload_exe(opts = {})
     return get_custom_exe if datastore.include? 'EXE::Custom'
-    return get_eicar_exe if datastore.include? 'EXE::EICAR'
+    return get_eicar_exe if datastore['EXE::EICAR']
 
     exe_init_options(opts)
 
@@ -78,7 +78,7 @@ module Exploit::EXE
 
   def generate_payload_exe_service(opts = {})
     return get_custom_exe if datastore.include? 'EXE::Custom'
-    return get_eicar_exe if datastore.include? 'EXE::EICAR'
+    return get_eicar_exe if datastore['EXE::EICAR']
 
     exe_init_options(opts)
 
@@ -101,7 +101,7 @@ module Exploit::EXE
 
   def generate_payload_dll(opts = {})
     return get_custom_exe if datastore.include? 'EXE::Custom'
-    return get_eicar_exe if datastore.include? 'EXE::EICAR'
+    return get_eicar_exe if datastore['EXE::EICAR']
 
     exe_init_options(opts)
 
@@ -124,7 +124,7 @@ module Exploit::EXE
 
   def generate_payload_msi(opts = {})
     return get_custom_exe(datastore['MSI::Custom']) if datastore.include? 'MSI::Custom'
-    return get_eicar_exe if datastore.include? 'MSI::EICAR'
+    return get_eicar_exe if datastore['MSI::EICAR']
 
     exe = generate_payload_exe(opts)
 

--- a/modules/encoders/generic/eicar.rb
+++ b/modules/encoders/generic/eicar.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Encoder
   end
 
   # TODO: add an option to merely prepend and not delete, using
-  # prepend_buf. Now, techiically, EICAR should be all by itself
+  # prepend_buf. Now, technically, EICAR should be all by itself
   # and not part of a larger whole. Problem is, OptBool is
   # acting funny here as an encoder option.
   #

--- a/modules/encoders/generic/eicar.rb
+++ b/modules/encoders/generic/eicar.rb
@@ -1,0 +1,49 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Encoder
+
+  # Set to ManualRanking because actually using ths encoder will
+  # certainly destroy any possibility of a successful shell.
+  #
+  Rank = ManualRanking
+
+  def initialize
+    super(
+      'Name'             => 'The EICAR Encoder',
+      'Description'      => %q{
+        This encoder merely tacks the EICAR test string to the beginning of
+        the payload. Note, this is sure to ruin your payload.
+
+        Any content-aware firewall, proxy, IDS, or IPS that follows anti-virus
+        standards should alert and do what it would normally do when malware is
+        transmitted across the wire.
+      },
+      'Author'           => 'todb',
+      'License'          => MSF_LICENSE,
+      'Arch'             => ARCH_ALL,
+      'EncoderType'      => Msf::Encoder::Type::Unspecified)
+
+  end
+
+  # Avoid stating the string directly, don't want to get caught by local
+  # antivirus!
+  def eicar_test_string
+    obfus_eicar = ["x5o!p%@ap[4\\pzx54(p^)7cc)7}$eicar", "standard", "antivirus", "test", "file!$h+h*"]
+    obfus_eicar.join("-").upcase
+  end
+
+  # TODO: add an option to merely prepend and not delete, using
+  # prepend_buf. Now, techiically, EICAR should be all by itself
+  # and not part of a larger whole. Problem is, OptBool is
+  # acting funny here as an encoder option.
+  #
+  def encode_block(state, buf)
+    buf = eicar_test_string
+  end
+
+end


### PR DESCRIPTION
This adds EICAR payload encoding, EXE::EICAR, and MSI::EICAR options to the EXE generator.
## Validation

**EICAR payload encoding**
- [x] Run the following command: `./msfvenom -p osx/x64/shell_bind_tcp -f raw -e generic/eicar`
- [x] See the expected EICAR string (with no linefeed at the end)

**EXE generator when EXE::EICAR is FALSE**
- [x] `use exploit/windows/smb/psexec`
- [x] Configure the psexec per normal -- set RHOST, SMBUser, and SMBPass
- [x] Fire up ngrep and search for EICAR: `ngrep -d vmnet8 EICAR port 445`
- [x] run `exploit`
- [x] See the lack of EICAR, like so:

```
root@mazikeen:~/git/rapid7/metasploit-framework
# ngrep -d vmnet8 EICAR port 445
interface: vmnet8 (192.168.145.0/255.255.255.0)
filter: (ip or ip6) and ( port 445 )
match: EICAR
###############################################################################################################################
```
- [x] Note that a shell session is created.

**EXE generator when EXE::EICAR is TRUE**
- [x] Set `EXE::EICAR true`
- [x] See the presence of EICAR:

```
root@mazikeen:~/git/rapid7/metasploit-framework
# ngrep -d vmnet8 EICAR port 445
interface: vmnet8 (192.168.145.0/255.255.255.0)
filter: (ip or ip6) and ( port 445 )
match: EICAR
#################
T 192.168.145.1:55936 -> 192.168.145.60:445 [AP]
  .....SMB/......(..l....fX.....j..PM*.................D...D.?.....D.X5O!P%@A
  P[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*               
####################################################
```
- [x] Note that no shell session is created.
