### PR TITLE
Remove trailing colon and GID from password and unlink temp files

### DIFF
--- a/modules/auxiliary/analyze/jtr_linux.rb
+++ b/modules/auxiliary/analyze/jtr_linux.rb
@@ -111,7 +111,7 @@ class Metasploit3 < Msf::Auxiliary
       if v[0] == "NO PASSWORD"
         passwd=""
       else
-        passwd=v[0]
+        passwd=v[0].sub /:[0-9]+/, ''
       end
       print_good("Host: #{v.last}  User: #{k} Pass: #{passwd}")
       report_auth_info(
@@ -122,5 +122,7 @@ class Metasploit3 < Msf::Auxiliary
         :pass => passwd
       )
     end
+    ::File.unlink(wordlist.path)
+    ::File.unlink(hashlist.path)
   end
 end


### PR DESCRIPTION
Bug leaves trailing :(GID) on passwords and does not remove temporary wordlist and hashlist files.

Tested against latest, fully updated AMD64 Kali release on 01 Apr 2014.

Steps to duplicate bugs:
- [ ] Install Kali and update to the latest version
- [ ] load msfconsule
- [ ] use auxiliary/scanner/ssh/ssh_login
- [ ] set username root
- [ ] set passwoed toor
- [ ] set rhosts (local IP address, not loopback)
- [ ] exploit -j
- [ ] use post/linux/gather/hashdump
- [ ] set session 1
- [ ] exploit -j
- [ ] use auxiliary/analyze/jtr_linux
- [ ] set crypt true
- [ ] exploit -j
- [ ] creds

Note that creds will now show a password of "toor:0" for root. Also note that there are now 2 temporary files in /tmp/ beginning with jtrtmp.
