### PR TITLE
Use array sample in rex text

### DIFF
--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -1386,12 +1386,12 @@ module Text
   # Randomize the whitespace in a string
   #
   def self.randomize_space(str)
+    set = ["\x09", "\x20", "\x0d", "\x0a"]
     str.gsub(/\s+/) { |s|
       len = rand(50)+2
-      set = "\x09\x20\x0d\x0a"
       buf = ''
       while (buf.length < len)
-        buf << set[rand(set.length),1]
+        buf << set.sample
       end
 
       buf

--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -1582,37 +1582,37 @@ module Text
     (rand(5) + 1).times {
       host.push(Rex::Text.rand_text_alphanumeric(rand(10) + 1))
     }
-    host.push(TLDs[rand(TLDs.size)])
+    host.push(TLDs.sample)
     host.join('.').downcase
   end
 
   # Generate a state
   def self.rand_state()
-    States[rand(States.size)]
+    States.sample
   end
 
   # Generate a surname
   def self.rand_surname
-    Surnames[rand(Surnames.size)]
+    Surnames.sample
   end
 
   # Generate a name
   def self.rand_name
     if rand(10) % 2 == 0
-      Names_Male[rand(Names_Male.size)]
+      Names_Male.sample
     else
-      Names_Female[rand(Names_Female.size)]
+      Names_Female.sample
     end
   end
 
   # Generate a male name
   def self.rand_name_male
-    Names_Male[rand(Names_Male.size)]
+    Names_Male.sample
   end
 
   # Generate a female name
   def self.rand_name_female
-    Names_Female[rand(Names_Female.size)]
+    Names_Female.sample
   end
 
   # Generate a random mail address

--- a/spec/lib/rex/text_spec.rb
+++ b/spec/lib/rex/text_spec.rb
@@ -114,6 +114,19 @@ describe Rex::Text do
       end
     end
 
+    context ".randomize_space" do
+      let (:sample_text) { "The quick brown sploit jumped over the lazy A/V" }
+      let (:spaced_text) { described_class.randomize_space(sample_text) }
+      it "should return a string with at least one new space characater" do
+        spaced_text.should match /\x09\x0d\x0a/
+      end
+
+      it "should not otherwise be mangled" do
+        normalized_text = spaced_text.gsub(/[\x20\x09\x0d\x0a]+/m, " ")
+        normalized_text.should eq(sample_text)
+      end
+    end
+
   end
 end
 


### PR DESCRIPTION
This is a follow-on from #2969. Mostly recycled the rspecs since nothing actually changed there.

Looked for other cases in `Rex::Text` where `Array#sample` would be a better fit -- found one where the source of the random set was a string instead of an array, so a) fixed that and b) added a spec around randomize_whitespace.
## Verification Steps
- [x] See that `rspec spec/lib/rex/text_spec.rb` passes
- [x] Like #2969, fire up IRB from within an `msfconsole` session and see for yourself reasonable results:
- [x] Verify that `Rex::Text.rand_name_male` returns a random gender-expected Anglo first name.
- [x] Verify that `Rex::Text.rand_name_female` returns a random gender-expected Anglo first name.
- [x] Verify that `Rex::Text.rand_surname` returns a random Anglo surname.
- [x] Verify that `Rex::Text.rand_name` returns a random Anglo name
- [x] Verify that `Rex::Text.rand_mail_address` returns a well-formatted e-mail address
- [x] `a =  "here is a string with a bunch of spaces and words."`
- [x] Verify that `Rex::Text.randomize_space(a)` returns a string with tons of extra funny space characters.
