### PR TITLE
Fix NameError for "r" in Msf::Auxiliary::Nmap

### DIFF
--- a/lib/msf/core/auxiliary/nmap.rb
+++ b/lib/msf/core/auxiliary/nmap.rb
@@ -184,7 +184,6 @@ def nmap_validate_rports
   if datastore['RPORT'] && (datastore['RPORT'].kind_of?(Fixnum) || !datastore['RPORT'].empty?)
     return true
   end
-  bad_port = false
   if rports.nil? || rports.empty?
     print_error "Missing RPORTS"
     return false
@@ -193,13 +192,9 @@ def nmap_validate_rports
     if r =~ /^([TU]:)?[0-9]*-?[0-9]*$/
       next
     else
-      bad_port = true
-      break
+      print_error "Malformed nmap port: #{r}"
+      return false
     end
-  end
-  if bad_port
-    print_error "Malformed nmap port: #{r}"
-    return false
   end
   print_status "Using RPORTS range #{datastore['RPORTS']}"
   return true


### PR DESCRIPTION
**Problem description:**

Variable `r` is used outside its scope, causing a `NameError`.

**Verification steps:**

Pre-fix:
- [x] Use `auxiliary/scanner/oracle/oracle_login`
- [x] Set `RHOSTS` to something valid
- [x] Set `RPORTS` to something invalid
- [x] Run the module
- [x] See the `NameError`

Post-fix:
- [x] Use `auxiliary/scanner/oracle/oracle_login`
- [x] Set `RHOSTS` to something valid
- [x] Set `RPORTS` to something invalid
- [x] Run the module
- [x] See the correct `RuntimeError`

**Sample run:**

Pre-fix:

```
msf > use auxiliary/scanner/oracle/oracle_login
msf auxiliary(oracle_login) > set RHOSTS 172.168.126.129
RHOSTS => 172.168.126.129
msf auxiliary(oracle_login) > set RPORTS help computer
RPORTS => help computer
msf auxiliary(oracle_login) > run

[*] Nmap: Setting up credential file...
[*] Nmap: Starting Oracle bruteforce with 568 credentials against SID 'XE'...
[-] Auxiliary failed: NameError undefined local variable or method `r' for #<Msf::Modules::Mod617578696c696172792f7363616e6e65722f6f7261636c652f6f7261636c655f6c6f67696e::Metasploit3:0x00000005e98270>
[-] Call stack:
[-]   /home/wvu/metasploit-framework/lib/msf/core/auxiliary/nmap.rb:201:in `nmap_validate_rports'
[-]   /home/wvu/metasploit-framework/lib/msf/core/auxiliary/nmap.rb:161:in `nmap_add_ports'
[-]   /home/wvu/metasploit-framework/lib/msf/core/auxiliary/nmap.rb:48:in `set_nmap_cmd'
[-]   /home/wvu/metasploit-framework/lib/msf/core/auxiliary/nmap.rb:91:in `nmap_run'
[-]   /home/wvu/metasploit-framework/modules/auxiliary/scanner/oracle/oracle_login.rb:62:in `run'
[*] Auxiliary module execution completed
msf auxiliary(oracle_login) >
```

Post-fix:

```
msf > use auxiliary/scanner/oracle/oracle_login
msf auxiliary(oracle_login) > set RHOSTS 172.16.126.129
RHOSTS => 172.16.126.129
msf auxiliary(oracle_login) > set RPORTS help computer
RPORTS => help computer
msf auxiliary(oracle_login) > run

[*] Nmap: Setting up credential file...
[*] Nmap: Starting Oracle bruteforce with 568 credentials against SID 'XE'...
[-] Malformed nmap port: help computer
[-] Auxiliary failed: RuntimeError Cannot continue without a valid port list.
[-] Call stack:
[-]   /home/wvu/metasploit-framework/lib/msf/core/auxiliary/nmap.rb:162:in `nmap_add_ports'
[-]   /home/wvu/metasploit-framework/lib/msf/core/auxiliary/nmap.rb:48:in `set_nmap_cmd'
[-]   /home/wvu/metasploit-framework/lib/msf/core/auxiliary/nmap.rb:91:in `nmap_run'
[-]   /home/wvu/metasploit-framework/modules/auxiliary/scanner/oracle/oracle_login.rb:62:in `run'
[*] Auxiliary module execution completed
msf auxiliary(oracle_login) >
```
