### PR TITLE
Fix ActiveRecord::ConnectionNotEstablished

### DIFF
--- a/lib/msf/core/auxiliary/nmap.rb
+++ b/lib/msf/core/auxiliary/nmap.rb
@@ -241,7 +241,7 @@ def nmap_hosts(&block)
   fh = self.nmap_log[0]
   nmap_data = fh.read(fh.stat.size)
   # fh.unlink
-  if Rex::Parser.nokogiri_loaded
+  if Rex::Parser.nokogiri_loaded && framework.db.active
     wspace = framework.db.find_workspace(datastore['WORKSPACE'])
     wspace ||= framework.db.workspace
     import_args = { :data => nmap_data, :wspace => wspace }


### PR DESCRIPTION
**Problem description:**

https://github.com/rapid7/metasploit-framework/pull/3171#issuecomment-39289232 -> https://dev.metasploit.com/redmine/issues/8780 cc @FireFart

**Verification steps:**

Pre-fix:
- [x] Disconnect from the database
- [x] Use `auxiliary/scanner/oracle/oracle_login`
- [x] Set `RHOSTS` to something valid
- [x] Set `RPORTS` to something valid
- [x] Run the module
- [x] See the `ActiveRecord::ConnectionNotEstablished` error

Post-fix:
- [x] Disconnect from the database
- [x] Use `auxiliary/scanner/oracle/oracle_login`
- [x] Set `RHOSTS` to something valid
- [x] Set `RPORTS` to something valid
- [x] Run the module
- [x] See no error

**Sample run:**

Pre-fix:

```
msf > db_disconnect
msf > use auxiliary/scanner/oracle/oracle_login
msf auxiliary(oracle_login) > set RHOSTS 172.16.126.129
RHOSTS => 172.16.126.129
msf auxiliary(oracle_login) > set RPORTS 4,8,15,16,23,42
RPORTS => 4,8,15,16,23,42
msf auxiliary(oracle_login) > run

[*] Nmap: Setting up credential file...
[*] Nmap: Starting Oracle bruteforce with 568 credentials against SID 'XE'...
[*] Using RPORTS range 4,8,15,16,23,42
[*] Nmap: Starting nmap with pid 26185
[*] Nmap: Starting Nmap 6.40 ( http://nmap.org ) at 2014-04-02 01:02 CDT
[*] Nmap: NSE: Loaded 1 scripts for scanning.
[*] Nmap: NSE: Script Pre-scanning.
[*] Nmap: Initiating Connect Scan at 01:02
[*] Nmap: Scanning 172.16.126.129 [6 ports]
[*] Nmap: Discovered open port 23/tcp on 172.16.126.129
[*] Nmap: Completed Connect Scan at 01:02, 0.00s elapsed (6 total ports)
[*] Nmap: NSE: Script scanning 172.16.126.129.
[*] Nmap: Nmap scan report for 172.16.126.129
[*] Nmap: Host is up (0.00053s latency).
[*] Nmap: PORT   STATE  SERVICE
[*] Nmap: 4/tcp  closed unknown
[*] Nmap: 8/tcp  closed unknown
[*] Nmap: 15/tcp closed netstat
[*] Nmap: 16/tcp closed unknown
[*] Nmap: 23/tcp open   telnet
[*] Nmap: 42/tcp closed nameserver
[*] Nmap: NSE: Script Post-scanning.
[*] Nmap: Read data files from: /usr/bin/../share/nmap
[*] Nmap: Nmap done: 1 IP address (1 host up) scanned in 0.04 seconds
[-] Auxiliary failed: ActiveRecord::ConnectionNotEstablished ActiveRecord::ConnectionNotEstablished
[-] Call stack:
[-]   /home/wvu/.rvm/gems/ruby-1.9.3-p484@metasploit-framework/gems/activerecord-3.2.14/lib/active_record/connection_adapters/abstract/connection_specification.rb:167:in `connection_pool'
[-]   /home/wvu/metasploit-framework/lib/msf/core/db.rb:239:in `find_workspace'
[-]   /home/wvu/metasploit-framework/lib/msf/core/auxiliary/nmap.rb:245:in `nmap_hosts'
[-]   /home/wvu/metasploit-framework/modules/auxiliary/scanner/oracle/oracle_login.rb:65:in `run'
[*] Auxiliary module execution completed
msf auxiliary(oracle_login) >
```

Post-fix:

```
msf > db_disconnect
msf > use auxiliary/scanner/oracle/oracle_login
msf auxiliary(oracle_login) > set RHOSTS 172.16.126.129
RHOSTS => 172.16.126.129
msf auxiliary(oracle_login) > set RPORTS 4,8,15,16,23,42
RPORTS => 4,8,15,16,23,42
msf auxiliary(oracle_login) > run

[*] Nmap: Setting up credential file...
[*] Nmap: Starting Oracle bruteforce with 568 credentials against SID 'XE'...
[*] Using RPORTS range 4,8,15,16,23,42
[*] Nmap: Starting nmap with pid 26232
[*] Nmap: Starting Nmap 6.40 ( http://nmap.org ) at 2014-04-02 01:03 CDT
[*] Nmap: NSE: Loaded 1 scripts for scanning.
[*] Nmap: NSE: Script Pre-scanning.
[*] Nmap: Initiating Connect Scan at 01:03
[*] Nmap: Scanning 172.16.126.129 [6 ports]
[*] Nmap: Discovered open port 23/tcp on 172.16.126.129
[*] Nmap: Completed Connect Scan at 01:03, 0.00s elapsed (6 total ports)
[*] Nmap: NSE: Script scanning 172.16.126.129.
[*] Nmap: Nmap scan report for 172.16.126.129
[*] Nmap: Host is up (0.00093s latency).
[*] Nmap: PORT   STATE  SERVICE
[*] Nmap: 4/tcp  closed unknown
[*] Nmap: 8/tcp  closed unknown
[*] Nmap: 15/tcp closed netstat
[*] Nmap: 16/tcp closed unknown
[*] Nmap: 23/tcp open   telnet
[*] Nmap: 42/tcp closed nameserver
[*] Nmap: NSE: Script Post-scanning.
[*] Nmap: Read data files from: /usr/bin/../share/nmap
[*] Nmap: Nmap done: 1 IP address (1 host up) scanned in 0.04 seconds
[*] Auxiliary module execution completed
msf auxiliary(oracle_login) >
```
