### PR TITLE
Add object detection for IE11

### DIFF
--- a/data/js/detect/os.js
+++ b/data/js/detect/os.js
@@ -945,11 +945,18 @@ window.os_detect.getVersion = function(){
 		if (!ua_version) {
 			// The ScriptEngine functions failed us, try some object detection
 			if (document.documentElement && (typeof document.documentElement.style.maxHeight)!="undefined") {
-				// IE 10 detection using nodeName
+				// IE 11 detection, see: http://msdn.microsoft.com/en-us/library/ie/bg182625(v=vs.85).aspx
 				try {
-					var badNode = document.createElement && document.createElement("badname");
-					if (badNode && badNode.nodeName === "BADNAME") { ua_version = "10.0"; }
-				} catch(e) {}
+					if (document.__proto__ != undefined) { ua_version = "11.0"; }
+				} catch (e) {}
+
+				// IE 10 detection using nodeName
+				if (!ua_version) {
+					try {
+						var badNode = document.createElement && document.createElement("badname");
+						if (badNode && badNode.nodeName === "BADNAME") { ua_version = "10.0"; }
+					} catch(e) {}
+				}
 
 				// IE 9 detection based on a "Object doesn't support property or method" error
 				if (!ua_version) {


### PR DESCRIPTION
While working on some stuff with IE11, I realized this is very necessary. The way this works is based the following documentation from Microsoft:
http://msdn.microsoft.com/en-us/library/ie/bg182625(v=vs.85).aspx
### Verification
- [x] Copy code from line 947 to 996.
- [x] Paste the code to the following template:

```
var ua_version;

/* the code you copied */

console.log(ua_version);
```
- [x] Test the code in IE's Developer's Tools.
