### PR TITLE
Fix broken spec for Rex::Text.randomize_space

### DIFF
--- a/spec/lib/rex/text_spec.rb
+++ b/spec/lib/rex/text_spec.rb
@@ -118,7 +118,7 @@ describe Rex::Text do
       let (:sample_text) { "The quick brown sploit jumped over the lazy A/V" }
       let (:spaced_text) { described_class.randomize_space(sample_text) }
       it "should return a string with at least one new space characater" do
-        spaced_text.should match /\x09\x0d\x0a/
+        spaced_text.should match /[\x09\x0d\x0a]/
       end
 
       it "should not otherwise be mangled" do


### PR DESCRIPTION
**Problem description:**
#3170 -> https://github.com/rapid7/metasploit-framework/pull/3121#issuecomment-39354215 cc @OJ

**Verification steps:**
- [x] Check out the topic branch
- [x] Run `while rspec spec/lib/rex/text_spec.rb; do continue; done`
- [x] See that there are no failures
- [x] `^C` when you get annoyed at the lack of failures

**Sample run:**

```
wvu@kharak:~/metasploit-framework:beug/randomize_space$ while rspec spec/lib/rex/text_spec.rb; do continue; done
Rex::Text ...............

Finished in 0.00734 seconds
15 examples, 0 failures
[snip]
Rex::Text ...............

Finished in 0.00726 seconds
15 examples, 0 failures
^C
Exiting... Interrupt again to exit immediately.

Finished in 0.00004 seconds
0 examples, 0 failures
wvu@kharak:~/metasploit-framework:beug/randomize_space$ 
```
