### PR TITLE
Set command tab completion improvements

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2033,6 +2033,11 @@ class Core
       end
     end
 
+    unless str.blank?
+      res = res.select { |term| term.upcase.start_with?(str.upcase) }
+      res = res.map { |term| str << term[str.length..-1] }
+    end
+
     return res
   end
 
@@ -2737,6 +2742,8 @@ class Core
       p = framework.payloads.create(mod.datastore['PAYLOAD'])
       if (p and p.options.include?(opt))
         res.concat(option_values_dispatch(p.options[opt], str, words))
+      elsif (p and p.options.include?(opt.upcase))
+        res.concat(option_values_dispatch(p.options[opt.upcase], str, words))
       end
     end
 
@@ -2770,8 +2777,10 @@ class Core
         end
 
       when 'Msf::OptAddressRange'
-
         case str
+          when /^file:(.*)/
+            files = tab_complete_filenames($1,words)
+            res += files.map { |f| "file:" << f } if files
           when /\/$/
             res << str+'32'
             res << str+'24'
@@ -2802,9 +2811,20 @@ class Core
         o.enums.each do |val|
           res << val
         end
+
       when 'Msf::OptPath'
         files = tab_complete_filenames(str,words)
         res += files if files
+
+      when 'Msf::OptBool'
+        res << 'true'
+        res << 'false'
+
+      when 'Msf::OptString'
+        if (str =~ /^file:(.*)/)
+          files = tab_complete_filenames($1,words)
+          res += files.map { |f| "file:" << f } if files
+        end
     end
 
     return res

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2035,7 +2035,15 @@ class Core
 
     unless str.blank?
       res = res.select { |term| term.upcase.start_with?(str.upcase) }
-      res = res.map { |term| str + term[str.length..-1] }
+      res = res.map { |term|
+        if str == str.upcase
+          str + term[str.length..-1].upcase
+        elsif str == str.downcase
+          str + term[str.length..-1].downcase
+        else
+          str + term[str.length..-1]
+        end
+      }
     end
 
     return res

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2035,7 +2035,7 @@ class Core
 
     unless str.blank?
       res = res.select { |term| term.upcase.start_with?(str.upcase) }
-      res = res.map { |term| str << term[str.length..-1] }
+      res = res.map { |term| str + term[str.length..-1] }
     end
 
     return res
@@ -2735,6 +2735,8 @@ class Core
     # Is this option used by the active module?
     if (mod.options.include?(opt))
       res.concat(option_values_dispatch(mod.options[opt], str, words))
+    elsif (mod.options.include?(opt.upcase))
+      res.concat(option_values_dispatch(mod.options[opt.upcase], str, words))
     end
 
     # How about the selected payload?
@@ -2779,8 +2781,8 @@ class Core
       when 'Msf::OptAddressRange'
         case str
           when /^file:(.*)/
-            files = tab_complete_filenames($1,words)
-            res += files.map { |f| "file:" << f } if files
+            files = tab_complete_filenames($1, words)
+            res += files.map { |f| "file:" + f } if files
           when /\/$/
             res << str+'32'
             res << str+'24'
@@ -2813,7 +2815,7 @@ class Core
         end
 
       when 'Msf::OptPath'
-        files = tab_complete_filenames(str,words)
+        files = tab_complete_filenames(str, words)
         res += files if files
 
       when 'Msf::OptBool'
@@ -2822,8 +2824,8 @@ class Core
 
       when 'Msf::OptString'
         if (str =~ /^file:(.*)/)
-          files = tab_complete_filenames($1,words)
-          res += files.map { |f| "file:" << f } if files
+          files = tab_complete_filenames($1, words)
+          res += files.map { |f| "file:" + f } if files
         end
     end
 


### PR DESCRIPTION
This PR adds some new tab completion features for msfconsole's set command.

The datastore options are not case sensitive when being set so this tries to tab complete options which do not begin with the correct case. This tries to be more forgiving on the user.

```
msf4-git (S:0 J:0)> use exploit/windows/smb/psexec
msf4-git (S:0 J:0) exploit(psexec) > set rh<tab>ost 192.168.90.160
rhost => 192.168.90.160
msf4-git (S:0 J:0) exploit(psexec) > set pay<tab>load windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf4-git (S:0 J:0) exploit(psexec) > set lho<tab>st 192.168.90.1
lhost => 192.168.90.1
msf4-git (S:0 J:0) exploit(psexec) > 
```

This also adds support for tab completing boolean options, valid values are true and false.

```
msf4-git (S:0 J:0)> use auxiliary/scanner/http/http_version 
msf4-git (S:0 J:0) auxiliary(http_version) > set RPORT 443
RPORT => 443
msf4-git (S:0 J:0) auxiliary(http_version) > set SSL <tab>
set SSL false  set SSL true   
msf4-git (S:0 J:0) auxiliary(http_version) > set SSL t<tab>rue 
SSL => true
msf4-git (S:0 J:0) auxiliary(http_version) > run

[*] 192.168.90.15:443 Apache
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf4-git (S:0 J:0) auxiliary(http_version) >
```

And finally this adds tab support for options that support files via "file:", specifically OptString and OptAddressRange.

```
msf4-git (S:0 J:0) auxiliary(http_version) > set RHOSTS file:<tab>
set RHOSTS file:.bundle         set RHOSTS file:.ruby-version   set RHOSTS file:Gemfile.lock    set RHOSTS file:data            set RHOSTS file:msfcli          set RHOSTS file:msfpescan       set RHOSTS file:scripts
set RHOSTS file:.git            set RHOSTS file:.simplecov      set RHOSTS file:HACKING         set RHOSTS file:db              set RHOSTS file:msfconsole      set RHOSTS file:msfrop          set RHOSTS file:spec
set RHOSTS file:.gitignore      set RHOSTS file:.travis.yml     set RHOSTS file:LICENSE         set RHOSTS file:documentation   set RHOSTS file:msfd            set RHOSTS file:msfrpc          set RHOSTS file:test
set RHOSTS file:.gitmodules     set RHOSTS file:.yardopts       set RHOSTS file:README.md       set RHOSTS file:external        set RHOSTS file:msfelfscan      set RHOSTS file:msfrpcd         set RHOSTS file:tools
set RHOSTS file:.mailmap        set RHOSTS file:CONTRIBUTING.md set RHOSTS file:Rakefile        set RHOSTS file:lib             set RHOSTS file:msfencode       set RHOSTS file:msfupdate       
set RHOSTS file:.rspec          set RHOSTS file:COPYING         set RHOSTS file:config          set RHOSTS file:modules         set RHOSTS file:msfmachscan     set RHOSTS file:msfvenom        
set RHOSTS file:.ruby-gemset    set RHOSTS file:Gemfile         set RHOSTS file:coverage        set RHOSTS file:msfbinscan      set RHOSTS file:msfpayload      set RHOSTS file:plugins         
msf4-git (S:0 J:0) auxiliary(http_version) > set RHOSTS file:/home/steiner/super_awesome_targets_list.txt 
RHOSTS => file:/home/steiner/super_awesome_targets_list.txt
msf4-git (S:0 J:0) auxiliary(http_version) >
```

Verification Steps:
- [x] check new tab completion features for the set command
- [x] make sure pre-existing tab completion features continue to work
