### PR TITLE
Prevent Rex::Proto::Http::Client from raising on close.

### DIFF
--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -198,14 +198,7 @@ class Client
   def close
     if (self.conn)
       self.conn.shutdown
-
-      begin
-        self.conn.close
-      rescue IOError => e
-        # sometimes, the socket might already be closed, which will
-        # cause conn.close to raise an IOError. Since we just care
-        # about the socket closing itself here, we ignore the exception.
-      end
+      self.conn.close unless self.conn.closed?
     end
 
     self.conn = nil

--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -198,7 +198,14 @@ class Client
   def close
     if (self.conn)
       self.conn.shutdown
-      self.conn.close
+
+      begin
+        self.conn.close
+      rescue IOError => e
+        # sometimes, the socket might already be closed, which will
+        # cause conn.close to raise an IOError. Since we just care
+        # about the socket closing itself here, we ignore the exception.
+      end
     end
 
     self.conn = nil

--- a/spec/lib/rex/proto/http/client_spec.rb
+++ b/spec/lib/rex/proto/http/client_spec.rb
@@ -112,6 +112,7 @@ describe Rex::Proto::Http::Client do
       conn.stub(:put)
       conn.stub(:shutdown)
       conn.stub(:close)
+      conn.stub(:closed? => false)
 
       conn.should_receive(:get_once).and_return(first_response, authed_response)
       conn.should_receive(:put) do |str_request|


### PR DESCRIPTION
This was causing problems in Pro. I don't think Rex::Proto::Http::Client#close should care about the socket state, but I could be wrong there.
