### PR TITLE
Added regex option to validate options

### DIFF
--- a/modules/auxiliary/fuzzers/ftp/client_ftp.rb
+++ b/modules/auxiliary/fuzzers/ftp/client_ftp.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
       OptPort.new('SRVPORT', [ true, "The local port to listen on.", 21 ]),
-      OptString.new('FUZZCMDS', [ true, "Comma separated list of commands to fuzz.", "LIST,NLST,LS,RETR" ]),
+      OptString.new('FUZZCMDS', [ true, "Comma separated list of commands to fuzz (Uppercase).", "LIST,NLST,LS,RETR", nil, /(?:[A-Z]+,?)+/ ]),
       OptInt.new('STARTSIZE', [ true, "Fuzzing string startsize.",1000]),
       OptInt.new('ENDSIZE', [ true, "Max Fuzzing string size.",200000]),
       OptInt.new('STEPSIZE', [ true, "Increment fuzzing string each attempt.",1000]),


### PR DESCRIPTION
This PR adds the ability to add a regex to validate an option.
I modified the `modules/auxiliary/fuzzers/ftp/client_ftp` module as a sample.

Sample output:
Invalid regex in module:

```
firefart@LinuxMint ~/Coding/metasploit-framework $ ./msfcli auxiliary/fuzzers/ftp/client_ftp E
[*] Initializing modules...
/home/firefart/Coding/metasploit-framework/lib/msf/core/option_container.rb:43:in `rescue in initialize': Invalid Regex ^((?:[A-Z]+,?)+$: end pattern with unmatched parenthesis: /^((?:[A-Z]+,?)+$/ (RuntimeError)
    from /home/firefart/Coding/metasploit-framework/lib/msf/core/option_container.rb:39:in `initialize'
    from /home/firefart/Coding/metasploit-framework/modules/auxiliary/fuzzers/ftp/client_ftp.rb:33:in `new'
    from /home/firefart/Coding/metasploit-framework/modules/auxiliary/fuzzers/ftp/client_ftp.rb:33:in `initialize'
    from /home/firefart/Coding/metasploit-framework/lib/msf/core/module_set.rb:55:in `new'
    from /home/firefart/Coding/metasploit-framework/lib/msf/core/module_set.rb:55:in `create'
    from ./msfcli:314:in `init_modules'
    from ./msfcli:538:in `run!'
    from ./msfcli:560:in `<main>'
```

Invalid value (only lowercase):

```
firefart@LinuxMint ~/Coding/metasploit-framework $ ./msfcli auxiliary/fuzzers/ftp/client_ftp FUZZCMDS=asdf E
[*] Initializing modules...
FUZZCMDS => asdf
[-] Auxiliary failed: Msf::OptionValidateError The following options failed to validate: FUZZCMDS.
```
