### PR TITLE
changed option from string to regex

### DIFF
--- a/modules/auxiliary/scanner/http/cert.rb
+++ b/modules/auxiliary/scanner/http/cert.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(443),
-        OptString.new('ISSUER', [ true,  "Show a warning if the Issuer doesn't match this regex", '.*']),
+        OptRegexp.new('ISSUER', [ true,  "Show a warning if the Issuer doesn't match this regex", '.*']),
         OptBool.new('SHOWALL', [ false, "Show all certificates (issuer,time) regardless of match", false]),
       ], self.class)
   end


### PR DESCRIPTION
This PR changes the option type from String to Regex

Output:

```
firefart@LinuxMint ~/Coding/metasploit-framework $ ./msfcli auxiliary/scanner/http/cert RHOSTS=firefart.net E
[*] Initializing modules...
RHOSTS => firefart.net
/home/firefart/Coding/metasploit-framework/modules/auxiliary/scanner/http/cert.rb:51: warning: flags ignored
[*] 87.230.19.86 - 'www.firefart.net' : '2014-02-05 07:29:10 UTC' - '2015-02-05 18:54:12 UTC'
[*] Scanned 1 of 2 hosts (050% complete)
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed

firefart@LinuxMint ~/Coding/metasploit-framework $ ./msfcli auxiliary/scanner/http/cert RHOSTS=firefart.net 'ISSUER=(' E
[*] Initializing modules...
RHOSTS => firefart.net
ISSUER => (
[-] Auxiliary failed: Msf::OptionValidateError The following options failed to validate: ISSUER.

firefart@LinuxMint ~/Coding/metasploit-framework $ ./msfcli auxiliary/scanner/http/cert RHOSTS=firefart.net 'ISSUER=()' E
[*] Initializing modules...
RHOSTS => firefart.net
ISSUER => ()
/home/firefart/Coding/metasploit-framework/modules/auxiliary/scanner/http/cert.rb:51: warning: flags ignored
[*] 87.230.19.86 - 'www.firefart.net' : '2014-02-05 07:29:10 UTC' - '2015-02-05 18:54:12 UTC'
[*] Scanned 1 of 2 hosts (050% complete)
[*] Scanned 2 of 2 hosts (100% complete)
[*] Auxiliary module execution completed
```
