### PR TITLE
Changed OptString to OptRegexp

### DIFF
--- a/modules/auxiliary/spoof/nbns/nbns_response.rb
+++ b/modules/auxiliary/spoof/nbns/nbns_response.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options([
       OptAddress.new('SPOOFIP', [ true, "IP address with which to poison responses", "127.0.0.1"]),
-      OptString.new('REGEX', [ true, "Regex applied to the NB Name to determine if spoofed reply is sent", '.*']),
+      OptRegexp.new('REGEX', [ true, "Regex applied to the NB Name to determine if spoofed reply is sent", '.*']),
     ])
 
     register_advanced_options([


### PR DESCRIPTION
Same as in PR #3186

```
firefart@LinuxMint ~/Coding/metasploit-framework $ ./msfcli auxiliary/spoof/nbns/nbns_response 'REGEX=(' E
[*] Initializing modules...
REGEX => (
[-] Auxiliary failed: Msf::OptionValidateError The following options failed to validate: REGEX.

firefart@LinuxMint ~/Coding/metasploit-framework $ ./msfcli auxiliary/spoof/nbns/nbns_response 'REGEX=()' E
[*] Initializing modules...
REGEX => ()
[*] Auxiliary module execution completed

[-] Auxiliary failed: Errno::EACCES Permission denied - bind(2)
[-] Call stack:
[-]   /home/firefart/Coding/metasploit-framework/modules/auxiliary/spoof/nbns/nbns_response.rb:60:in `bind'
[-]   /home/firefart/Coding/metasploit-framework/modules/auxiliary/spoof/nbns/nbns_response.rb:60:in `run'
msf auxiliary(nbns_response) > exit
```
