### PR TITLE
Correct msftidy disclosure date check

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -324,7 +324,7 @@ class Msftidy
   end
 
   def check_disclosure_date
-    return if @source =~ /Generic Payload Handler/ or @source !~ / \< Msf::Exploit/
+    return if @source =~ /Generic Payload Handler/
 
     # Check disclosure date format
     if @source =~ /["']DisclosureDate["'].*\=\>[\x0d\x20]*['\"](.+)['\"]/
@@ -343,7 +343,7 @@ class Msftidy
         error('Incorrect disclosure date format')
       end
     else
-      error('Exploit is missing a disclosure date')
+      error('Exploit is missing a disclosure date') if @source =~ / \< Msf::Exploit/
     end
   end
 


### PR DESCRIPTION
This correct msftidy's disclosure date check to do the following (they also serve as verification steps):
- [x] If the module has a disclosure date, the check should kick in.
- [x] If the module is an exploit, and doesn't have a disclosure date, then it will be flagged.
- [x]  If the module is an auxiliary, and doesn't have a disclosure date, then it will NOT be flagged (because not all aux modules target bugs/vulns like exploits do).
