### PR TITLE
Travis shouldn't autofail msftidy fails... yet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,12 @@ before_install:
   - rake --version
   - sudo apt-get update -qq
   - sudo apt-get install -qq libpcap-dev
-  - ln -sf ../../tools/dev/pre-commit-hook.rb ./.git/hooks/post-merge
-  - ls -la ./.git/hooks
-  - ./.git/hooks/post-merge
+  # Uncomment when we have fewer shipping msftidy warnings.
+  # Merge committers will still be checking, just not autofailing.
+  # See https://dev.metasploit.com/redmine/issues/8498
+  # - ln -sf ../../tools/dev/pre-commit-hook.rb ./.git/hooks/post-merge
+  # - ls -la ./.git/hooks
+  # - ./.git/hooks/post-merge
 before_script:
   - cp config/database.yml.travis config/database.yml
   - bundle exec rake --version


### PR DESCRIPTION
See https://dev.metasploit.com/redmine/issues/8498

We have about three hundred warnings and failures in shipping modules. We need to get ahead of this if Travis auto-failing builds based on bad msftidy modules is going to be credible.

Committers of Metasploit Framework should have this post-merge hook active, though -- they can use their own judgement if fails and warns are new or are old. That's kind of hard to teach travis.
