### PR TITLE
Update @Meatballs1 and @FireFart in authors.rb

### DIFF
--- a/lib/msf/core/module/author.rb
+++ b/lib/msf/core/module/author.rb
@@ -13,7 +13,7 @@ class Msf::Module::Author
   Known =
     {
       'amaloteaux'       => 'alex_maloteaux' + 0x40.chr + 'metasploit.com',
-      'anonymous'        => 'anonymous-contributor' + 0x40.chr + 'metasploit.com',
+      'anonymous'        => 'Unknown',
       'bannedit'         => 'bannedit' + 0x40.chr + 'metasploit.com',
       'Carlos Perez'     => 'carlos_perez' + 0x40.chr + 'darkoperator.com',
       'cazz'             => 'bmc' + 0x40.chr + 'shmoo.com',
@@ -21,6 +21,7 @@ class Msf::Module::Author
       'ddz'              => 'ddz' + 0x40.chr + 'theta44.org',
       'egypt'            => 'egypt' + 0x40.chr + 'metasploit.com',
       'et'               => 'et' + 0x40.chr + 'metasploit.com',
+      'Christian Mehlmauer' => 'FireFart' + 0x40.chr + 'gmail.com',
       'hdm'              => 'hdm' + 0x40.chr + 'metasploit.com',
       'I)ruid'           => 'druid' +  0x40.chr + 'caughq.org',
       'jcran'            => 'jcran' + 0x40.chr + 'metasploit.com',
@@ -30,6 +31,7 @@ class Msf::Module::Author
       'kf'               => 'kf_list' + 0x40.chr + 'digitalmunition.com',
       'kris katterjohn'  => 'katterjohn' + 0x40.chr + 'gmail.com',
       'MC'               => 'mc' + 0x40.chr + 'metasploit.com',
+      'Ben Campbell'     => 'eat_meatballs' + 0x40.chr + 'hotmail.co.uk',
       'msmith'           => 'msmith' + 0x40.chr + 'metasploit.com',
       'mubix'            => 'mubix' + 0x40.chr + 'hak5.org',
       'natron'           => 'natron' + 0x40.chr + 'metasploit.com',

--- a/modules/auxiliary/dos/http/hashcollision_dos.rb
+++ b/modules/auxiliary/dos/http/hashcollision_dos.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Auxiliary
           'Scott A. Crosby', # original advisory
           'Dan S. Wallach', # original advisory
           'Krzysztof Kotowicz', # payload generator
-          'Christian Mehlmauer <FireFart[at]gmail.com>' # metasploit module
+          'Christian Mehlmauer' # metasploit module
         ],
       'License'       => MSF_LICENSE,
       'References'    =>

--- a/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
+++ b/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Auxiliary
         ],
       'Author'        =>
         [
-          'Christian Mehlmauer <FireFart[at]gmail.com>',  # Metasploit module
+          'Christian Mehlmauer',  # Metasploit module
           'Jason A. Donenfeld <Jason[at]zx2c4.com>'       # POC
         ]
     )

--- a/modules/auxiliary/parser/unattend.rb
+++ b/modules/auxiliary/parser/unattend.rb
@@ -19,7 +19,7 @@ class Metasploit3 < Msf::Auxiliary
       'License'       => MSF_LICENSE,
       'Author'        =>
         [
-          'Ben Campbell <eat_meatballs[at]hotmail.co.uk>',
+          'Ben Campbell',
         ],
       'References'    =>
         [

--- a/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
+++ b/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Auxiliary
         Deployment Services RPC service and parses out the stored credentials.
         Tested against Windows 2008 R2 x64 and Windows 2003 x86.
       },
-      'Author'         => [ 'Ben Campbell <eat_meatballs[at]hotmail.co.uk>' ],
+      'Author'         => [ 'Ben Campbell' ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [

--- a/modules/auxiliary/scanner/http/http_header.rb
+++ b/modules/auxiliary/scanner/http/http_header.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Auxiliary
       'Description' => %q{ This module shows HTTP Headers returned by the scanned systems. },
       'Author'      =>
       [
-        'Christian Mehlmauer <FireFart[at]gmail.com>',
+        'Christian Mehlmauer',
         'rick2600'
       ],
       'References'  =>

--- a/modules/auxiliary/scanner/http/typo3_bruteforce.rb
+++ b/modules/auxiliary/scanner/http/typo3_bruteforce.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Auxiliary
     super(
       'Name'        => 'Typo3 Login Bruteforcer',
       'Description' => 'This module attempts to bruteforce Typo3 logins.',
-      'Author'      => [ 'Christian Mehlmauer <FireFart[at]gmail.com>' ],
+      'Author'      => [ 'Christian Mehlmauer' ],
       'License'     => MSF_LICENSE
     )
   end

--- a/modules/auxiliary/scanner/http/wordpress_login_enum.rb
+++ b/modules/auxiliary/scanner/http/wordpress_login_enum.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Auxiliary
           'Alligator Security Team',
           'Tiago Ferreira <tiago.ccna[at]gmail.com>',
           'Zach Grace <zgrace[at]404labs.com>',
-          'Christian Mehlmauer <FireFart[at]gmail.com'
+          'Christian Mehlmauer'
         ],
       'References'     =>
         [

--- a/modules/auxiliary/scanner/http/wordpress_pingback_access.rb
+++ b/modules/auxiliary/scanner/http/wordpress_pingback_access.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Auxiliary
         [
           'Thomas McCarthy "smilingraccoon" <smilingraccoon[at]gmail.com>',
           'Brandon McCann "zeknox" <bmccann[at]accuvant.com>' ,
-          'Christian Mehlmauer "FireFart" <FireFart[at]gmail.com>' # Original PoC
+          'Christian Mehlmauer' # Original PoC
         ],
       'License' => MSF_LICENSE,
       'References'  =>

--- a/modules/auxiliary/scanner/http/wordpress_scanner.rb
+++ b/modules/auxiliary/scanner/http/wordpress_scanner.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Auxiliary
     super(
       'Name'        => 'Wordpress Scanner',
       'Description' => 'Detects Wordpress installations and their version number',
-      'Author'      => [ 'Christian Mehlmauer <FireFart[at]gmail.com>' ],
+      'Author'      => [ 'Christian Mehlmauer' ],
       'License'     => MSF_LICENSE
     )
   end

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Auxiliary
       'Author'         =>
         [
           'tebo <tebo [at] attackresearch [dot] com>', # Original
-          'Ben Campbell <eat_meatballs [at] hotmail.co.uk>' # Refactoring
+          'Ben Campbell' # Refactoring
         ],
       'References'     =>
         [

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -97,7 +97,7 @@ class Metasploit3 < Msf::Auxiliary
         'Matti', # Vulnerability discovery
         'Jared Stafford <jspenguin[at]jspenguin.org>', # Original Proof of Concept. This module is based on it.
         'FiloSottile', # PoC site and tool
-        'Christian Mehlmauer <FireFart[at]gmail.com>', # Msf module
+        'Christian Mehlmauer', # Msf module
         'wvu', # Msf module
         'juan vazquez' # Msf module
       ],

--- a/modules/exploits/multi/http/mediawiki_thumb.rb
+++ b/modules/exploits/multi/http/mediawiki_thumb.rb
@@ -25,7 +25,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Netanel Rubin', # from Check Point - Discovery
           'Brandon Perry', # Metasploit Module
           'Ben Harris', # Metasploit Module
-          'Ben Campbell <eat_meatballs[at]hotmail.co.uk>' # Metasploit Module
+          'Ben Campbell' # Metasploit Module
         ],
       'License' => MSF_LICENSE,
       'References' =>

--- a/modules/exploits/multi/http/phpmyadmin_preg_replace.rb
+++ b/modules/exploits/multi/http/phpmyadmin_preg_replace.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Author' =>
         [
           'Janek "waraxe" Vind', # Discovery
-          'Ben Campbell <eat_meatballs[at]hotmail.co.uk>' # Metasploit Module
+          'Ben Campbell' # Metasploit Module
         ],
       'License' => MSF_LICENSE,
       'References' =>

--- a/modules/exploits/windows/browser/ie_unsafe_scripting.rb
+++ b/modules/exploits/windows/browser/ie_unsafe_scripting.rb
@@ -42,7 +42,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Author'         =>
         [
           'natron',
-          'Ben Campbell <eat_meatballs[at]hotmail.co.uk>' # PSH and remove ADODB.Stream
+          'Ben Campbell' # PSH and remove ADODB.Stream
         ],
         'References'     =>
         [

--- a/modules/exploits/windows/browser/ubisoft_uplay_cmd_exec.rb
+++ b/modules/exploits/windows/browser/ubisoft_uplay_cmd_exec.rb
@@ -25,7 +25,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Author'         =>
         [
           'Tavis Ormandy <taviso[at]cmpxchg8b.com>', # Initial discovery
-          'Ben Campbell <eat_meatballs[at]hotmail.co.uk>',
+          'Ben Campbell',
           'phillips321 <phillips321[at]phillips321.co.uk>',
           'Richard Hicks <scriptmonkeyblog[at]gmail.com>'
         ],

--- a/modules/exploits/windows/local/always_install_elevated.rb
+++ b/modules/exploits/windows/local/always_install_elevated.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Exploit::Local
       'License'       => MSF_LICENSE,
       'Author'        =>
         [
-          'Ben Campbell <eat_meatballs[at]hotmail.co.uk>',
+          'Ben Campbell',
           'Parvez Anwar' # discovery?/inspiration
         ],
       'Arch'          => [ ARCH_X86, ARCH_X86_64 ],

--- a/modules/exploits/windows/local/bypassuac_injection.rb
+++ b/modules/exploits/windows/local/bypassuac_injection.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Local
           'David Kennedy "ReL1K" <kennedyd013[at]gmail.com>',
           'mitnick',
           'mubix', # Port to local exploit
-          'Ben Campbell <eat_meatballs[at]hotmail.co.uk' # In memory technique
+          'Ben Campbell' # In memory technique
         ],
       'Platform'      => [ 'win' ],
       'SessionTypes'  => [ 'meterpreter' ],

--- a/modules/exploits/windows/local/ikeext_service.rb
+++ b/modules/exploits/windows/local/ikeext_service.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Local
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'Ben Campbell <eat_meatballs@hotmail.co.uk>'
+          'Ben Campbell'
         ],
       'Platform'       => [ 'win'],
       'Targets'        =>

--- a/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
+++ b/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Local
         [
           'Tavis Ormandy', # Discovery
           'Axel Souchet',  # @0vercl0k POC
-          'Ben Campbell <eat_meatballs[at]hotmail.co.uk>' # Metasploit module
+          'Ben Campbell' # Metasploit module
         ],
       'Platform'	=> [ 'win' ],
       'SessionTypes'	=> [ 'meterpreter' ],

--- a/modules/exploits/windows/local/nvidia_nvsvc.rb
+++ b/modules/exploits/windows/local/nvidia_nvsvc.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Local
       'Author'          =>
         [
           'Peter Wintersmith', # Original exploit
-          'Ben Campbell <eat_meatballs[at]hotmail.co.uk>',   # Metasploit integration
+          'Ben Campbell',   # Metasploit integration
         ],
       'Arch'            => ARCH_X86_64,
       'Platform'        => 'win',

--- a/modules/exploits/windows/local/powershell_cmd_upgrade.rb
+++ b/modules/exploits/windows/local/powershell_cmd_upgrade.rb
@@ -21,7 +21,7 @@ class Metasploit3 < Msf::Exploit::Local
         },
         'License'       => MSF_LICENSE,
         'Author'        => [
-            'Ben Campbell <eat_meatballs[at]hotmail.co.uk>'
+            'Ben Campbell'
           ],
         'DefaultOptions' =>
             {

--- a/modules/exploits/windows/local/ppr_flatten_rec.rb
+++ b/modules/exploits/windows/local/ppr_flatten_rec.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Local
           'Keebie4e',     # Metasploit integration
           'egypt',        # Metasploit integration
           'sinn3r',       # Metasploit integration
-          'Meatballs',    # Metasploit integration
+          'Ben Campbell',    # Metasploit integration
           'juan vazquez', # Metasploit integration
           'OJ Reeves'     # Metasploit integration
         ],

--- a/modules/exploits/windows/local/wmi.rb
+++ b/modules/exploits/windows/local/wmi.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Exploit::Local
         },
         'License'       => MSF_LICENSE,
         'Author'        => [
-            'Ben Campbell <eat_meatballs[at]hotmail.co.uk>'
+            'Ben Campbell'
           ],
         'References'    =>
           [

--- a/modules/exploits/windows/misc/psh_web_delivery.rb
+++ b/modules/exploits/windows/misc/psh_web_delivery.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'	 => MSF_LICENSE,
       'Author'	 =>
         [
-          'Ben Campbell <eat_meatballs[at]hotmail.co.uk>',
+          'Ben Campbell',
           'Chris Campbell' #@obscuresec - Inspiration n.b. no relation!
         ],
       'References'	 =>

--- a/modules/post/multi/gather/resolve_hosts.rb
+++ b/modules/post/multi/gather/resolve_hosts.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Post
         Resolves hostnames to either IPv4 or IPv6 addresses from the perspective of the remote host.
       },
       'License'       => MSF_LICENSE,
-      'Author'        => [ 'Ben Campbell <eat_meatballs[at]hotmail.co.uk>' ],
+      'Author'        => [ 'Ben Campbell' ],
       'Platform'      => %w{ win python },
       'SessionTypes'  => [ 'meterpreter' ]
     ))

--- a/modules/post/windows/gather/credentials/gpp.rb
+++ b/modules/post/windows/gather/credentials/gpp.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Post
       },
       'License'       => MSF_LICENSE,
       'Author'        =>[
-        'Ben Campbell <eat_meatballs[at]hotmail.co.uk>',
+        'Ben Campbell',
         'Loic Jaquemet <loic.jaquemet+msf[at]gmail.com>',
         'scriptmonkey <scriptmonkey[at]owobble.co.uk>',
         'theLightCosine',

--- a/modules/post/windows/gather/credentials/sso.rb
+++ b/modules/post/windows/gather/credentials/sso.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Post
       in the database.
           },
       'License'      => MSF_LICENSE,
-      'Author'       => ['Ben Campbell <eat_meatballs[at]hotmail.co.uk>'],
+      'Author'       => ['Ben Campbell'],
       'Platform'     => ['win'],
       'SessionTypes' => ['meterpreter' ]
     ))

--- a/modules/post/windows/gather/enum_ad_computers.rb
+++ b/modules/post/windows/gather/enum_ad_computers.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Post
             (&(objectCategory=computer)(operatingSystem=*server*)) # All Servers
         },
         'License'      => MSF_LICENSE,
-        'Author'       => [ 'Ben Campbell <eat_meatballs[at]hotmail.co.uk>' ],
+        'Author'       => [ 'Ben Campbell' ],
         'Platform'     => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
         'References'	=>

--- a/modules/post/windows/gather/enum_ad_service_principal_names.rb
+++ b/modules/post/windows/gather/enum_ad_service_principal_names.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Post
       'License'      => MSF_LICENSE,
       'Author'       =>
         [
-          'Ben Campbell <ben.campbell[at]mwrinfosecurity.com>', #Metasploit Module
+          'Ben Campbell', #Metasploit Module
           'Scott Sutherland' #Original Powershell Code
         ],
       'Platform'     => [ 'win' ],

--- a/modules/post/windows/gather/enum_ad_user_comments.rb
+++ b/modules/post/windows/gather/enum_ad_user_comments.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Post
         such users have their passwords specified in these fields.
         },
         'License'      => MSF_LICENSE,
-        'Author'       => [ 'Ben Campbell <eat_meatballs[at]hotmail.co.uk>' ],
+        'Author'       => [ 'Ben Campbell' ],
         'Platform'     => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ],
         'References'	=>

--- a/modules/post/windows/gather/enum_dirperms.rb
+++ b/modules/post/windows/gather/enum_dirperms.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Post
       'Author'         =>
         [
           'Kx499',
-          'Ben Campbell <eat_meatballs[at]hotmail.co.uk>',
+          'Ben Campbell',
           'sinn3r'
         ]
     ))

--- a/modules/post/windows/gather/enum_domain_users.rb
+++ b/modules/post/windows/gather/enum_domain_users.rb
@@ -21,9 +21,9 @@ class Metasploit3 < Msf::Post
           logged into that host will be returned.'
         },
         'License'      => MSF_LICENSE,
-        'Author'       => [ 
+        'Author'       => [
           'Etienne Stalmans <etienne[at]sensepost.com>',
-          'Ben Campbell <eat_meatballs[at]hotmail.co.uk>'
+          'Ben Campbell'
         ],
         'Platform'     => [ 'win' ],
         'SessionTypes' => [ 'meterpreter' ]

--- a/modules/post/windows/gather/enum_unattend.rb
+++ b/modules/post/windows/gather/enum_unattend.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Post
         [
           'Sean Verity <veritysr1980[at]gmail.com>',
           'sinn3r',
-          'Ben Campbell <eat_meatballs[at]hotmail.co.uk>'
+          'Ben Campbell'
         ],
       'References'    =>
         [

--- a/modules/post/windows/manage/reflective_dll_inject.rb
+++ b/modules/post/windows/manage/reflective_dll_inject.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Post
         This module will inject into the memory of a process a specified Reflective DLL.
       },
       'License'      => MSF_LICENSE,
-      'Author'       => [ 'Ben Campbell <eat_meatballs[at]hotmail.co.uk>'],
+      'Author'       => [ 'Ben Campbell'],
       'Platform'     => [ 'win' ],
       'SessionTypes' => [ 'meterpreter' ],
       'References'   =>


### PR DESCRIPTION
Over the time that contributors @Meatballs1 and @FireFart have been pumping out modules, sometimes they use slightly different names and e-mail addresses. This screws up their scoreboards.

This PR normalizes all of that by adding them to `authors.rb` and fixing to one e-mail address.
## Verification
- [x] Run `msfconsole -L` and see that no modules fail to load
- [x] Run `tools/module_author.rb -rs | grep -i firefart` and see uniformity of name and e-mail address
- [x] Run `tools/module_author.rb -rs | grep -i meatballs` and see uniformity of name and e-mail address
