### PR TITLE
Make the title of the Heartbleed module searchable

### DIFF
--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -83,7 +83,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'           => 'OpenSSL Heartbeat Information Leak',
+      'Name'           => 'OpenSSL Heartbeat (Heartbleed) Information Leak',
       'Description'    => %q{
         This module implements the OpenSSL Heartbleed attack. The problem
         exists in the handling of heartbeat requests, where a fake length can


### PR DESCRIPTION
Right now, the title does not actually tie the Heartbeat check to the
Heartbleed attack, so people searching strictly on module title are not
going to get a hit for this module.
## Verification
- [x] See the title change

@jvazquez-r7 or @wvu-r7 can I get you to land this toot sweet?
