### PR TITLE
Add jabber fix from @natronkeltner

### DIFF
--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -173,7 +173,7 @@ class Metasploit3 < Msf::Auxiliary
     msg << "<stream:stream xmlns='jabber:client' "
     msg << "xmlns:stream='http://etherx.jabber.org/streams' "
     msg << "version='1.0' "
-    msg << "to='#{rhost}'>"
+    msg << "to='localhost'>"
     sock.put(msg)
     res = sock.get_once
     return nil if res.nil? # SSL not supported

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -172,7 +172,7 @@ class Metasploit3 < Msf::Auxiliary
     msg = "<?xml version='1.0' ?>"
     msg << "<stream:stream xmlns='jabber:client' "
     msg << "xmlns:stream='http://etherx.jabber.org/streams' "
-    msg << "xmlns:tls='http://www.ietf.org/rfc/rfc2595.txt' "
+    msg << "version='1.0' "
     msg << "to='#{rhost}'>"
     sock.put(msg)
     res = sock.get_once


### PR DESCRIPTION
This pull request is added because of #3218. I'm going to ask @natronkeltner to, please, check and share a pcap in order to verify. We haven't a jabber server atm to test :-(

@natronkeltner: Could you share please pcat with msfdev[at]metasploit.com so we can verify the fix.

About the sleep thing commented in #3218, honestly, sounds like a weird behaviour probably targeting a slow server/network :? I couldn't say, get_once by default has a 10 seconds timeout to wait for the answer, so I don't see the real benefit from the sleep before the get_once :? Maybe we could call get_once with a bigger timeout, but honestly 10 seconds looks like good enough. So at the moment I'm avoiding the sleep fix, because I don't use to like the sleep for sync if there isn't a good reason to make it.
