### PR TITLE
Fix `john_show_passwords` colon handling

### DIFF
--- a/lib/msf/core/auxiliary/jtr.rb
+++ b/lib/msf/core/auxiliary/jtr.rb
@@ -142,12 +142,11 @@ module Auxiliary::JohnTheRipper
           res[:uncracked] = $2.to_i
         end
 
+        # XXX: If the password had : characters in it, we're screwed
+
         bits = line.split(':', -1)
 
-        # If the password had : characters in it, put them back together
-        while bits.length > 7
-          bits[1,2] = bits[1,2].join(":")
-        end
+        # Skip blank passwords
         next if not bits[2]
 
         if (format== 'lm' or format == 'nt')

--- a/modules/auxiliary/analyze/jtr_linux.rb
+++ b/modules/auxiliary/analyze/jtr_linux.rb
@@ -47,25 +47,25 @@ class Metasploit3 < Msf::Auxiliary
     myloots = myworkspace.loots.where('ltype=?', 'linux.hashes')
     return if myloots.nil? or myloots.empty?
 
-    loot_data = ''
+    loot_data = []
 
     myloots.each do |myloot|
       usf = ''
       begin
         File.open(myloot.path, "rb") do |f|
-          usf = f.read
+          usf = f.read(f.stat.size)
         end
       rescue Exception => e
         print_error("Unable to read #{myloot.path} \n #{e}")
       end
       usf.each_line do |row|
-        row.gsub!(/\n/, ":#{myloot.host.address}\n")
+        row.gsub!("\n", ":#{myloot.host.address}\n")
         loot_data << row
       end
     end
 
     @hashlist = Rex::Quickfile.new("jtrtmp")
-    @hashlist.write(loot_data)
+    @hashlist.write(loot_data.join)
     @hashlist.close
 
     print_status("HashList: #{@hashlist.path}")

--- a/modules/auxiliary/analyze/jtr_linux.rb
+++ b/modules/auxiliary/analyze/jtr_linux.rb
@@ -47,26 +47,7 @@ class Metasploit3 < Msf::Auxiliary
     myloots = myworkspace.loots.where('ltype=?', 'linux.hashes')
     return if myloots.nil? or myloots.empty?
 
-    loot_data = []
-
-    myloots.each do |myloot|
-      usf = ''
-      begin
-        File.open(myloot.path, "rb") do |f|
-          usf = f.read(f.stat.size)
-        end
-      rescue Exception => e
-        print_error("Unable to read #{myloot.path} \n #{e}")
-      end
-      usf.each_line do |row|
-        row.gsub!("\n", ":#{myloot.host.address}\n")
-        loot_data << row
-      end
-    end
-
-    @hashlist = Rex::Quickfile.new("jtrtmp")
-    @hashlist.write(loot_data.join)
-    @hashlist.close
+    build_hashlist(myloots)
 
     print_status("HashList: #{@hashlist.path}")
 
@@ -103,6 +84,29 @@ class Metasploit3 < Msf::Auxiliary
     john_crack(@hashlist.path, :incremental => "All4", :format => format)
     print_status("Trying Format:#{format} Rule: Digits5...")
     john_crack(@hashlist.path, :incremental => "Digits5", :format => format)
+  end
+
+  def build_hashlist(myloots)
+    loot_data = []
+
+    myloots.each do |myloot|
+      usf = ''
+      begin
+        File.open(myloot.path, "rb") do |f|
+          usf = f.read(f.stat.size)
+        end
+      rescue Exception => e
+        print_error("Unable to read #{myloot.path} \n #{e}")
+      end
+      usf.each_line do |row|
+        row.gsub!("\n", ":#{myloot.host.address}\n")
+        loot_data << row
+      end
+    end
+
+    @hashlist = Rex::Quickfile.new("jtrtmp")
+    @hashlist.write(loot_data.join)
+    @hashlist.close
   end
 
 end


### PR DESCRIPTION
A more general solution than #3169.

Attempting to re-join passwords with colons is a task that will require some more thought. The implementation I went with for #2515 was flawed in cases where a shadow file didn't have exactly 7 `:`s, which is almost always.

[MSP-9778]

On a  side note, this bug taught me that you can generate md5 passwords for use in a shadow file with

``` bash
openssl passwd -1 "password"
```
## Verification

Starting with an empty workspace:
- [x] echo smithj:Ep6mckrOLChF.:10063:0:99999:7::: > /tmp/foo
- [x] loot -a -i linux.hashes -t linux.hashes -f /tmp/foo 127.1.1.1
- [x] use auxiliary/analyze/jtr_linux
- [x] run 
- [x] **before** see `[+] Host: 127.1.1.1 User: smithj Pass: baseball:10063:0:99999`
     **after** see `[+] Host: 127.1.1.1  User: smithj Pass: baseball`
