### PR TITLE
Add a link to explain about unmet exploit requirements

### DIFF
--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -493,7 +493,7 @@ module Msf
           if bad_reqs.empty?
             method(:on_request_exploit).call(cli, request, profile)
           else
-            print_warning("Exploit requirement(s) not met: #{bad_reqs * ', '}")
+            print_warning("Exploit requirement(s) not met: #{bad_reqs * ', '}. For more info: http://r-7.co/PVbcgx")
             send_not_found(cli)
           end
         end


### PR DESCRIPTION
As an user, if you encounter an unmet exploit requirement, sometimes you don't necessarily know what it means, and it's impossible for us to explain everything in the console. So I decided create a wiki about it, and put a link in the `print_warning`. The r-7.co URL is from bitly, which is created/managed under our account, so we can always be sure it won't be lost.
### Verification
- [ ] Make sure http://r-7.co/PVbcgx goes the the correct wiki that explains about unmet requirements.
