### PR TITLE
CVE 2014-0160 Added feature to dump leaked memory to a file

### DIFF
--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -305,7 +305,7 @@ class Metasploit3 < Msf::Auxiliary
           "openssl.heartbleed.server",
           "application/octet-stream",
           ip,
-          heartbeat_data,
+          match_data,
           nil,
           "OpenSSL Heartbleed server memory"
         )

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -122,8 +122,8 @@ class Metasploit3 < Msf::Auxiliary
         Opt::RPORT(443),
         OptEnum.new('STARTTLS', [true, 'Protocol to use with STARTTLS, None to avoid STARTTLS ', 'None', [ 'None', 'SMTP', 'IMAP', 'JABBER', 'POP3', 'FTP' ]]),
         OptEnum.new('TLSVERSION', [true, 'TLS version to use', '1.0', ['1.0', '1.1', '1.2']]),
-        OptBool.new('STOREDUMP', [true, "Store leaked memory in a file", false]),
-        OptRegexp.new('DUMPFILTER', [false, "Pattern to filter leaked memory before storing", nil])
+        OptBool.new('STOREDUMP', [true, 'Store leaked memory in a file', false]),
+        OptRegexp.new('DUMPFILTER', [false, 'Pattern to filter leaked memory before storing', nil])
       ], self.class)
 
     register_advanced_options(


### PR DESCRIPTION
Added a small feature in oder to allow to save memory dump to file.
The feature is enabled setting a boolean option STOREDUMP  to true.
It's also possible to filter via a regexpr pattern what we would like to dump.
regexpr is set via option PATTERN_FILTER
This option is a string, so user has to pay attention while filling the pattern (i.e. escape character like '/' and so on)
