### PR TITLE
Fix a few things in the Heartbleed modules

### DIFF
--- a/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
+++ b/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
@@ -265,7 +265,14 @@ class Metasploit3 < Msf::Auxiliary
   def store_captured_heartbeats(c)
     if @state[c][:heartbeats].length > 0
       begin
-        path = store_loot("openssl_memory_dump", "octet/stream", c.peerhost, @state[c][:heartbeats], "openssl_client_memory_dump.bin", "OpenSSL Heartbeat Client Memory Dump")
+        path = store_loot(
+          "openssl.heartbleed.client",
+          "application/octet-stream",
+          @state[c][:ip],
+          @state[c][:heartbeats],
+          nil,
+          "OpenSSL Heartbleed client memory"
+        )
         print_status("#{@state[c][:name]} Heartbeat data stored in #{path}")
       rescue ::Interrupt
         raise $!


### PR DESCRIPTION
1. `TTLS_CALLBACKS` was a typo. It is now `TLS_CALLBACKS`.
2. Make `heartbeat_length` configurable, default it to `65535`, and make sure it doesn't go over that.
3. `store_loot` all the Heartbleed datums.
