### PR TITLE
Added @sensepost FTP implemenation

### DIFF
--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -79,7 +79,7 @@ class Metasploit3 < Msf::Auxiliary
     'IMAP'   => :tls_imap,
     'JABBER' => :tls_jabber,
     'POP3'   => :tls_pop3,
-    'FTP'   => :tls_ftp
+    'FTP'    => :tls_ftp
   }
 
   def initialize
@@ -200,6 +200,21 @@ class Metasploit3 < Msf::Auxiliary
     msg = "<starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>"
     sock.put(msg)
     sock.get_once
+  end
+
+  def tls_ftp
+    # http://tools.ietf.org/html/rfc4217
+    res = sock.get
+    return nil if res.nil?
+    sock.put("AUTH TLS\r\n")
+    res = sock.get_once
+    return nil if res.nil?
+    if res !~ /^234/
+      # res contains the error message
+      vprint_error("#{peer} - FTP error: #{res.strip}")
+      return nil
+    end
+    res
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -134,15 +134,6 @@ class Metasploit3 < Msf::Auxiliary
     "#{rhost}:#{rport}"
   end
 
-  def tls_ftp
-    res = sock.get_once
-    #unless res && res +~ /^220/
-        #return nil
-    #end
-    sock.put("AUTH TLS\r\n")
-    sock.get_once
-  end
-
   def tls_smtp
     # https://tools.ietf.org/html/rfc3207
     sock.get_once

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -78,7 +78,8 @@ class Metasploit3 < Msf::Auxiliary
     'SMTP'   => :tls_smtp,
     'IMAP'   => :tls_imap,
     'JABBER' => :tls_jabber,
-    'POP3'   => :tls_pop3
+    'POP3'   => :tls_pop3,
+    'FTP'   => :tls_ftp
   }
 
   def initialize
@@ -118,7 +119,7 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(443),
-        OptEnum.new('STARTTLS', [true, 'Protocol to use with STARTTLS, None to avoid STARTTLS ', 'None', [ 'None', 'SMTP', 'IMAP', 'JABBER', 'POP3' ]]),
+        OptEnum.new('STARTTLS', [true, 'Protocol to use with STARTTLS, None to avoid STARTTLS ', 'None', [ 'None', 'SMTP', 'IMAP', 'JABBER', 'POP3', 'FTP' ]]),
         OptEnum.new('TLSVERSION', [true, 'TLS version to use', '1.0', ['1.0', '1.1', '1.2']])
       ], self.class)
 
@@ -131,6 +132,15 @@ class Metasploit3 < Msf::Auxiliary
 
   def peer
     "#{rhost}:#{rport}"
+  end
+
+  def tls_ftp
+    res = sock.get_once
+    #unless res && res +~ /^220/
+        #return nil
+    #end
+    sock.put("AUTH TLS\r\n")
+    sock.get_once
   end
 
   def tls_smtp


### PR DESCRIPTION
See this https://github.com/rapid7/metasploit-framework/pull/3229 for more info.

This PR adds the FTP implemenation with a few more checks than in PR 3229

I tried it on my test server and got some data back, but it didn't show me some "real data" even when I set the server under pressure with a lot of ftp uploads.

Maybe @wvu-r7 and @sensepost can test and verify this implementation.
