### PR TITLE
First little bit at Bug 8498

### DIFF
--- a/lib/msf/core/exploit/ftp.rb
+++ b/lib/msf/core/exploit/ftp.rb
@@ -43,7 +43,7 @@ module Exploit::Remote::Ftp
 
   #
   # This method establishes an FTP connection to host and port specified by
-  # the RHOST and RPORT options, respectively.  After connecting, the banner
+  # the 'rhost' and 'rport' methods. After connecting, the banner
   # message is read in and stored in the 'banner' attribute.
   #
   def connect(global = true, verbose = nil)

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -164,7 +164,7 @@ module Exploit::Remote::HttpClient
 
     # Configure the HTTP client with the supplied parameter
     nclient.set_config(
-      'vhost' => opts['vhost'] || self.vhost(),
+      'vhost' => opts['vhost'] || opts['rhost'] || self.vhost(),
       'agent' => datastore['UserAgent'],
       'uri_encode_mode'        => datastore['HTTP::uri_encode_mode'],
       'uri_full_url'           => datastore['HTTP::uri_full_url'],

--- a/modules/auxiliary/admin/misc/wol.rb
+++ b/modules/auxiliary/admin/misc/wol.rb
@@ -37,14 +37,6 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   #
-  # Restore the original rhost:rport
-  #
-  def cleanup
-    datastore['RHOST'] = @last_rhost
-    datastore['RPORT'] = @last_rport
-  end
-
-  #
   # Convert the MAC option to binary format
   #
   def get_mac_addr
@@ -85,6 +77,14 @@ class Metasploit3 < Msf::Auxiliary
     nil
   end
 
+  def wol_rhost
+    datastore['IPV6'] ? "ff:ff:ff:ff:ff:ff" : "255.255.255.255"
+  end
+
+  def wol_rport
+    9
+  end
+
   def run
     # If the MAC is bad, no point to continue
     mac = get_mac_addr
@@ -94,15 +94,6 @@ class Metasploit3 < Msf::Auxiliary
     pass = parse_password
     return if pass.nil?
 
-    # Save the original rhost:rport settings so we can restore them
-    # later once the module is done running
-    @last_rhost = rhost
-    @last_rport = rport
-
-    # Config to broadcast
-    datastore['RHOST'] = datastore['IPV6'] ? "ff:ff:ff:ff:ff:ff" : "255.255.255.255"
-    datastore['RPORT'] = 9
-
     # Craft the WOL packet
     wol_pkt = "\xff" * 6  #Sync stream (magic packet)
     wol_pkt << mac  * 16  #Mac address
@@ -110,7 +101,10 @@ class Metasploit3 < Msf::Auxiliary
 
     # Send out the packet
     print_status("Sending WOL packet...")
-    connect_udp
+    connect_udp( true, {
+      'RHOST' => wol_rhost,
+      'RPORT' => wol_rport
+    })
     udp_sock.put(wol_pkt)
     disconnect_udp
   end

--- a/modules/auxiliary/gather/corpwatch_lookup_id.rb
+++ b/modules/auxiliary/gather/corpwatch_lookup_id.rb
@@ -28,7 +28,7 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         OptString.new('CW_ID', [ true, "The CorpWatch ID of the company", ""]),
-        OptInt.new('YEAR', [ false, "Year to look up"]),
+        OptInt.new('YEAR', [ false, "Year to look up", Time.now.year-1]),
         OptBool.new('GET_LOCATIONS', [ false, "Get locations for company", true]),
         OptBool.new('GET_NAMES', [ false, "Get all registered names ofr the company", true]),
         OptBool.new('GET_FILINGS', [ false, "Get all filings", false ]),
@@ -40,19 +40,15 @@ class Metasploit3 < Msf::Auxiliary
     deregister_options('RHOST', 'RPORT', 'VHOST', 'Proxies')
   end
 
-  def cleanup
-    datastore['RHOST'] = @old_rhost
-    datastore['RPORT'] = @old_rport
+  def rhost_corpwatch
+    'api.corpwatch.org'
+  end
+
+  def rport_corpwatch
+    80
   end
 
   def run
-    # Save the original rhost/rport in case the user was exploiting something else
-    @old_rhost = datastore['RHOST']
-    @old_rport = datastore['RPORT']
-
-    # Initial api.corpwatch.org's rhost and rport for HttpClient
-    datastore['RHOST'] = 'api.corpwatch.org'
-    datastore['RPORT'] = 80
 
     loot = ""
     uri = "/"
@@ -60,6 +56,8 @@ class Metasploit3 < Msf::Auxiliary
     uri << ("/companies/" + datastore['CW_ID'])
 
     res = send_request_cgi({
+      'rhost'    => rhost_corpwatch,
+      'rport'    => rport_corpwatch,
       'uri'      => uri + ".xml",
       'method'   => 'GET'
     }, 25)
@@ -157,6 +155,8 @@ class Metasploit3 < Msf::Auxiliary
 
       res = send_request_cgi(
       {
+        'rhost'   => rhost_corpwatch,
+        'rport'   => rport_corpwatch,
         'uri'     => uri + "/locations.xml",
         'method'  => 'GET'
       }, 25)
@@ -227,6 +227,8 @@ class Metasploit3 < Msf::Auxiliary
 
       res = send_request_cgi(
       {
+        'rhost'   => rhost_corpwatch,
+        'rport'   => rport_corpwatch,
         'uri'     => uri + "/names.xml",
         'method'  => 'GET'
       }, 25)
@@ -287,6 +289,8 @@ class Metasploit3 < Msf::Auxiliary
 
       res = send_request_cgi(
       {
+        'rhost'   => rhost_corpwatch,
+        'rport'   => rport_corpwatch,
         'uri'     => uri + "/filings.xml",
         'method'  => 'GET'
       }, 25)
@@ -365,6 +369,8 @@ class Metasploit3 < Msf::Auxiliary
 
       res = send_request_cgi(
       {
+        'rhost'   => rhost_corpwatch,
+        'rport'   => rport_corpwatch,
         'uri'      => child_uri,
         'method'   => 'GET'
       }, 25)
@@ -444,6 +450,8 @@ class Metasploit3 < Msf::Auxiliary
     if datastore['GET_HISTORY']
 
       res = send_request_cgi({
+        'rhost'   => rhost_corpwatch,
+        'rport'   => rport_corpwatch,
         'uri'     => uri + "/history.xml",
         'method'  => 'GET'
       }, 25)

--- a/modules/auxiliary/gather/corpwatch_lookup_name.rb
+++ b/modules/auxiliary/gather/corpwatch_lookup_name.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         OptString.new('COMPANY_NAME', [ true, "Search for companies with this name", ""]),
-        OptInt.new('YEAR', [ false, "Limit results to a specific year"]),
+        OptInt.new('YEAR', [ false, "Year to look up", Time.now.year-1]),
         OptString.new('LIMIT', [ true, "Limit the number of results returned", "5"]),
         OptString.new('CORPWATCH_APIKEY', [ false, "Use this API key when getting the data", ""]),
       ], self.class)
@@ -39,19 +39,15 @@ class Metasploit3 < Msf::Auxiliary
     deregister_options('RHOST', 'RPORT', 'Proxies', 'VHOST')
   end
 
-  def cleanup
-    datastore['RHOST'] = @old_rhost
-    datastore['RPORT'] = @old_rport
+  def rhost_corpwatch
+    'api.corpwatch.org'
+  end
+
+  def rport_corpwatch
+    80
   end
 
   def run
-    # Save the original rhost/rport in case the user was exploiting something else
-    @old_rhost = datastore['RHOST']
-    @old_rport = datastore['RPORT']
-
-    # Initial api.corpwatch.org's rhost and rport for HttpClient
-    datastore['RHOST'] = 'api.corpwatch.org'
-    datastore['RPORT'] = 80
 
     uri = "/"
     uri << (datastore['YEAR'].to_s + "/") if datastore['YEAR'].to_s != ""
@@ -59,6 +55,8 @@ class Metasploit3 < Msf::Auxiliary
 
     res = send_request_cgi(
     {
+      'rhost'    => rhost_corpwatch,
+      'rport'    => rport_corpwatch,
       'uri'      => uri,
       'method'   => 'GET',
       'vars_get' =>

--- a/modules/auxiliary/gather/shodan_search.rb
+++ b/modules/auxiliary/gather/shodan_search.rb
@@ -60,6 +60,8 @@ class Metasploit4 < Msf::Auxiliary
     uri = "/api/search?&q=" + Rex::Text.uri_encode(query) + "&key=" + apikey + "&page=" + page.to_s
     res = send_request_raw(
       {
+        'rhost'    => shodan_rhost,
+        'rport'    => shodan_rport,
         'method'   => 'GET',
         'uri'      => uri
     }, 25)
@@ -80,28 +82,25 @@ class Metasploit4 < Msf::Auxiliary
     print_status("Save results in #{datastore['OUTFILE']}")
   end
 
-  def cleanup
-    datastore['RHOST'] = @old_rhost
-    datastore['RPORT'] = @old_rport
-  end
-
-  def run
-    # create our Shodan request parameters
-    query = datastore['QUERY']
-    apikey = datastore['SHODAN_APIKEY']
-
+  def shodan_rhost
     @res = Net::DNS::Resolver.new()
     dns_query = @res.query("#{datastore['VHOST']}", "A")
     if dns_query.answer.length == 0
       print_error("Could not resolve #{datastore['VHOST']}")
-      return
-    else
-      # Make a copy of the original rhost
-      @old_rhost = datastore['RHOST']
-      @old_rport = datastore['RPORT']
-      datastore['RHOST'] = dns_query.answer[0].to_s.split(/[\s,]+/)[4]
-      datastore['RPORT'] = 80
+      raise ::Rex::ConnectError(vhost, shodan_port)
     end
+    dns_query.answer[0].to_s.split(/[\s,]+/)[4]
+  end
+
+  def shodan_rport
+    80
+  end
+
+  def run
+
+    # create our Shodan request parameters
+    query = datastore['QUERY']
+    apikey = datastore['SHODAN_APIKEY']
 
     page = 1
 

--- a/modules/auxiliary/gather/shodan_search.rb
+++ b/modules/auxiliary/gather/shodan_search.rb
@@ -62,6 +62,7 @@ class Metasploit4 < Msf::Auxiliary
       {
         'rhost'    => shodan_rhost,
         'rport'    => shodan_rport,
+        'vhost'    => vhost,
         'method'   => 'GET',
         'uri'      => uri
     }, 25)

--- a/modules/auxiliary/scanner/portscan/ftpbounce.rb
+++ b/modules/auxiliary/scanner/portscan/ftpbounce.rb
@@ -17,9 +17,7 @@ class Metasploit3 < Msf::Auxiliary
       'Name'        => 'FTP Bounce Port Scanner',
       'Description' => %q{
         Enumerate TCP services via the FTP bounce PORT/LIST
-        method, which can still come in handy every once in
-        a while (I know of a server that still allows this
-        just fine...).
+        method.
       },
       'Author'      => 'kris katterjohn',
       'License'     => MSF_LICENSE
@@ -39,15 +37,20 @@ class Metasploit3 < Msf::Auxiliary
     false
   end
 
+  def rhost
+    datastore['BOUNCEHOST']
+  end
+
+  def rport
+    datastore['BOUNCEPORT']
+  end
+
   def run_host(ip)
     ports = Rex::Socket.portspec_crack(datastore['PORTS'])
 
     if ports.empty?
       raise Msf::OptionValidateError.new(['PORTS'])
     end
-
-    datastore['RHOST'] = datastore['BOUNCEHOST']
-    datastore['RPORT'] = datastore['BOUNCEPORT']
 
     return if not connect_login
 

--- a/modules/exploits/multi/browser/java_atomicreferencearray.rb
+++ b/modules/exploits/multi/browser/java_atomicreferencearray.rb
@@ -123,7 +123,7 @@ class Metasploit3 < Msf::Exploit::Remote
           vprint_status("Sending java reverse shell")
         else
           port = datastore['LPORT']
-          datastore['RHOST'] = cli.peerhost
+          host = cli.peerhost
           vprint_status( "Java bind shell" )
         end
         if jar

--- a/modules/exploits/multi/browser/java_calendar_deserialize.rb
+++ b/modules/exploits/multi/browser/java_calendar_deserialize.rb
@@ -119,7 +119,7 @@ class Metasploit3 < Msf::Exploit::Remote
           print_status("Payload will be a Java reverse shell")
         else
           port = datastore['LPORT']
-          datastore['RHOST'] = cli.peerhost
+          host = cli.peerhost
           print_status("Payload will be a Java bind shell")
         end
         if jar

--- a/modules/exploits/multi/browser/java_verifier_field_access.rb
+++ b/modules/exploits/multi/browser/java_verifier_field_access.rb
@@ -122,7 +122,7 @@ class Metasploit3 < Msf::Exploit::Remote
           vprint_status("Sending java reverse shell")
         else
           port = datastore['LPORT']
-          datastore['RHOST'] = cli.peerhost
+          host = cli.peerhost
           vprint_status( "Java bind shell" )
         end
         if jar

--- a/spec/lib/msf/core/exploit/http/client_spec.rb
+++ b/spec/lib/msf/core/exploit/http/client_spec.rb
@@ -2,14 +2,47 @@
 require 'spec_helper'
 
 require 'msf/core'
+require 'msf/core/data_store'
 require 'msf/core/exploit/http/client'
 
 describe Msf::Exploit::Remote::HttpClient do
   subject do
-    mod = Module.new
+    mod = ::Msf::Module.new
     mod.extend described_class
-
     mod
+  end
+
+  describe '#vhost' do
+
+    let(:rhost) do
+      'rhost.example.com'
+    end
+
+    let(:vhost) do
+      'vhost.example.com'
+    end
+
+    context 'when vhost is defined' do
+      let(:cli_vhost) do
+        subject.datastore['VHOST'] = vhost
+        subject
+      end
+      it "should return the set vhost" do
+        cli_vhost.vhost.should == vhost
+      end
+    end
+
+    context 'when only rhost is defined' do
+      let(:cli_rhost) do
+        subject.datastore['RHOST'] = rhost
+        subject
+      end
+      it "should return the rhost as the vhost" do
+        cli_rhost.datastore['VHOST'].should be_nil
+        cli_rhost.vhost.should == rhost
+      end
+    end
+
   end
 
   describe '#normalize_uri' do

--- a/spec/lib/rex/proto/http/client_spec.rb
+++ b/spec/lib/rex/proto/http/client_spec.rb
@@ -30,8 +30,17 @@ describe Rex::Proto::Http::Client do
   end
 
   let(:ip) { "1.2.3.4" }
+
   subject(:cli) do
     Rex::Proto::Http::Client.new(ip)
+  end
+
+  describe "#set_config" do
+
+    it "should respond to #set_config" do
+      cli.set_config.should == {}
+    end
+
   end
 
   it "should respond to intialize" do


### PR DESCRIPTION
We have lots of datastore modified errors, usually to avoid defaults for HTTP clients. Turns out, you can pass rhost/rport directly to send_request_cgi. However, vhost was not keeping up -- it would default to datastore['RHOST'] if not set.

This fixes that, and also modifies two modules to take advantage of the fix. Also, those modules have slight updates to set a default year of last year.

@wchen-r7, do you see any problems with this? If not, I'll see about rspec'ing it (shouldn't be hard assuming we have existing HTTP client tests)
## Verification
- [x] `use auxiliary/gather/corpwatch_lookup_name` and set `COMPANY_NAME` to `Google`
- [x] Run the module and see correct results.
- [x] `use auxiliary/gather/corpwatch_lookup_name` and set `COMPANY_ID` to `cw_35783`
- [x] Run the module and see correct results

You can land this if you want, or wait until I hit all the similar modules. I just didn't want to go too far without some eyes on the vhost fix.

IOW, this is a PR in progress... I guess (but it is technically complete for these modules) :)
