### PR TITLE
Update spec to reflect the correct version.

### DIFF
--- a/spec/lib/msf/core/framework_spec.rb
+++ b/spec/lib/msf/core/framework_spec.rb
@@ -6,7 +6,7 @@ require 'msf/core/framework'
 describe Msf::Framework do
 
   describe "#version" do
-    CURRENT_VERSION = "4.9.0-dev"
+    CURRENT_VERSION = "4.9.2-dev"
 
     subject do
       described_class.new


### PR DESCRIPTION
Release is now ahead of master in terms of version number. The spec needs to be updated to reflect this.

This PR should land to release (and is targeted as such) and then should be merged back into master.

I'd prefer if @bturner-r7 landed this since he updated release with 2f2692f4bf29fc9570ed84418aca99a45620e9dc.
