### PR TITLE
Update to openssl_heartbleed to deal with SMTP RFC

### DIFF
--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -155,13 +155,13 @@ class Metasploit3 < Msf::Auxiliary
   def tls_smtp
     # https://tools.ietf.org/html/rfc3207
     sock.get_once
-    sock.put("EHLO #{Rex::Text.rand_text_alpha(10)}\n")
+    sock.put("EHLO #{Rex::Text.rand_text_alpha(10)}\r\n")
     res = sock.get_once
 
     unless res && res =~ /STARTTLS/
       return nil
     end
-    sock.put("STARTTLS\n")
+    sock.put("STARTTLS\r\n")
     sock.get_once
   end
 


### PR DESCRIPTION
Added CR character in order to have the commands match SMTP RFC 5321 2.3.8 for line termination. Some SMTP services, such as the Symantec Mail Gateway, require strict compliance or the connection will be dropped with the response  '550 esmtp: protocol deviation';

This has been seen during testing.

Reference:
   http://www.symantec.com/business/support/index?page=content&id=TECH96829
   http://tools.ietf.org/html/rfc5321#section-2.3.8
