### PR TITLE
Revert inadvertent fix for vars_get in msftidy

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -484,11 +484,11 @@ class Msftidy
     end
   end
 
-  def check_request_vars
+  def check_vars_get
     test = @source.scan(/send_request_(?:cgi|raw)\s*\(\s*\{\s*['"]uri['"]\s*=>\s*[^=\}]*?\?[^,\}]+/im)
     unless test.empty?
       test.each { |item|
-        warn("Please use vars_get or vars_post in send_request_cgi and send_request_raw: #{item}")
+        warn("Please use vars_get in send_request_cgi and send_request_raw: #{item}")
       }
     end
   end
@@ -536,7 +536,7 @@ def run_checks(full_filepath)
   tidy.check_snake_case_filename
   tidy.check_comment_splat
   tidy.check_vuln_codes
-  tidy.check_request_vars
+  tidy.check_vars_get
   return tidy
 end
 


### PR DESCRIPTION
Despite having seen `vars_post` used in a semantically different manner, my technical myopia while fixing all the warnings for a specific `msftidy` check caused me to ~~progressively procrastinate alternative models instead of compellingly engineering distinctive interfaces~~ make a mistake. Thanks to @jlee-r7 for ~~dramatically meshing competitive innovation~~ noticing!
- [x] Make sure it works
