### PR TITLE
Heartbleed - Add autodetection of XMPP hostname

### DIFF
--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -102,7 +102,8 @@ class Metasploit3 < Msf::Auxiliary
         'Christian Mehlmauer', # Msf module
         'wvu', # Msf module
         'juan vazquez', # Msf module
-        'Sebastiano Di Paola' # Msf module
+        'Sebastiano Di Paola', # Msf module
+        'Tom Sellers' # Msf module
       ],
       'References'     =>
         [

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -193,7 +193,7 @@ class Metasploit3 < Msf::Auxiliary
     end
     res
   end
-  
+
   def jabber_connect_msg(hostname)
     # http://xmpp.org/extensions/xep-0035.html
     msg = "<stream:stream xmlns='jabber:client' "

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -226,8 +226,6 @@ class Metasploit3 < Msf::Auxiliary
     res
   end
 
-
-
   def tls_ftp
     # http://tools.ietf.org/html/rfc4217
     res = sock.get

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -203,26 +203,26 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def tls_jabber
-    sock.put( jabber_connect_msg(datastore['XMPPDOMAIN']) )
+    sock.put(jabber_connect_msg(datastore['XMPPDOMAIN']))
     res = sock.get
-    if res && res =~ /host-unknown/
+    if res && res.include?('host-unknown')
       jabber_host = res.match(/ from='([\w.]*)' /)
       if jabber_host && jabber_host[1]
         disconnect
         connect
         vprint_status("#{peer} - Connecting with autodetected remote XMPP hostname: #{jabber_host[1]}...")
-        sock.put( jabber_connect_msg(jabber_host[1]) )
+        sock.put(jabber_connect_msg(jabber_host[1]))
         res = sock.get
       end
     end
-    if res.nil? || res =~ /stream:error/ || res !~ /<starttls xmlns=['"]urn:ietf:params:xml:ns:xmpp-tls['"]/
-      vprint_error("#{peer} - Jabber host unknown. Please try changing the XMPPDOMAIN option.") if res && res =~ /<host-unknown/
+    if res.nil? || res.include?('stream:error') || res !~ /<starttls xmlns=['"]urn:ietf:params:xml:ns:xmpp-tls['"]/
+      vprint_error("#{peer} - Jabber host unknown. Please try changing the XMPPDOMAIN option.") if res && res.include?('host-unknown')
       return nil
     end
     msg = "<starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/>"
     sock.put(msg)
     res = sock.get
-    return nil if res.nil? || res !~ /<proceed/
+    return nil if res.nil? || !res.include?('<proceed')
     res
   end
 

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -201,6 +201,20 @@ class Metasploit3 < Msf::Auxiliary
     msg << "to='#{datastore['XMPPDOMAIN']}'>"
     sock.put(msg)
     res = sock.get
+    if res  && res =~ /host-unknown/
+      jabber_host = res.match(/ from='([\w.]*)' /)
+      if jabber_host
+        connect
+        vprint_status("#{peer} - Connecting with autodetected remote XMPP hostname: #{jabber_host[1]}...")
+        msg = "<stream:stream xmlns='jabber:client' "
+        msg << "xmlns:stream='http://etherx.jabber.org/streams' "
+        msg << "version='1.0' "
+        msg << "to='#{jabber_host[1]}'>"
+        sock.put(msg)
+        res = sock.get
+      end
+    end
+
     if res.nil? || res =~ /stream:error/ || res !~ /<starttls xmlns=['"]urn:ietf:params:xml:ns:xmpp-tls['"]/
       vprint_error("#{peer} - Jabber host unknown. Please try changing the XMPPDOMAIN option.") if res && res =~ /<host-unknown/
       return nil


### PR DESCRIPTION
Add the ability to scrape the hostname from the XMPP error message when connecting to an XMPP (Jabber) server.  This allows the connection to get far enough to negotiate a TLS tunnel with STARTTLS.  The manually specified domain, if present, will be used first and then the hostname autodetection will kick in if that fails.
