### PR TITLE
Make the hash brace optional

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -485,7 +485,7 @@ class Msftidy
   end
 
   def check_vars_get
-    test = @source.scan(/send_request_(?:cgi|raw)\s*\(\s*\{\s*['"]uri['"]\s*=>\s*[^=\}]*?\?[^,\}]+/im)
+    test = @source.scan(/send_request_(?:cgi|raw)\s*\(\s*\{?\s*['"]uri['"]\s*=>\s*[^=\}]*?\?[^,\}]+/im)
     unless test.empty?
       test.each { |item|
         warn("Please use vars_get in send_request_cgi and send_request_raw: #{item}")

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -485,7 +485,7 @@ class Msftidy
   end
 
   def check_vars_get
-    test = @source.scan(/send_request_(?:cgi|raw)\s*\(\s*\{?\s*['"]uri['"]\s*=>\s*[^=\})]*?\?[^,\})]+/im)
+    test = @source.scan(/send_request_(?:cgi|raw)\s*\(\s*\{?\s*['"]uri['"]\s*=>\s*[^=})]*?\?[^,})]+/im)
     unless test.empty?
       test.each { |item|
         warn("Please use vars_get in send_request_cgi and send_request_raw: #{item}")

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -485,7 +485,7 @@ class Msftidy
   end
 
   def check_vars_get
-    test = @source.scan(/send_request_(?:cgi|raw)\s*\(\s*\{?\s*['"]uri['"]\s*=>\s*[^=\}]*?\?[^,\}]+/im)
+    test = @source.scan(/send_request_(?:cgi|raw)\s*\(\s*\{?\s*['"]uri['"]\s*=>\s*[^=\})]*?\?[^,\})]+/im)
     unless test.empty?
       test.each { |item|
         warn("Please use vars_get in send_request_cgi and send_request_raw: #{item}")


### PR DESCRIPTION
As per the Ruby style guide. This adds **zero** `msftidy` warnings.
- [ ] `tools/msftidy.rb modules | grep -c vars_get`
- [ ] `git checkout -q upstream/pr/3263 && !!`
- [ ] See that the number of warnings hasn't changed
