### PR TITLE
Little improvement on auxiliary/gather/dns_reverse_lookup.rb 

### DIFF
--- a/modules/auxiliary/gather/dns_reverse_lookup.rb
+++ b/modules/auxiliary/gather/dns_reverse_lookup.rb
@@ -12,26 +12,29 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'		   => 'DNS Reverse Lookup Enumeration',
-      'Description'	=> %q{
+      'Name'       => 'DNS Reverse Lookup Enumeration',
+      'Description' => %q{
           This module performs DNS reverse lookup against a given IP range in order to
         retrieve valid addresses and names.
       },
-      'Author'		=> [ 'Carlos Perez <carlos_perez[at]darkoperator.com>' ],
-      'License'		=> BSD_LICENSE
+      'Author'    => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>', # Base code 
+                       'Thanat0s <thanatos[at]trollprod[dot]org>'], # Output, Throttling & Db notes add 
+      'License'   => BSD_LICENSE
     ))
 
     register_options(
       [
         OptAddressRange.new('RANGE', [true, 'IP range to perform reverse lookup against.']),
-        OptAddress.new('NS', [ false, "Specify the nameserver to use for queries, otherwise use the system DNS." ])
+        OptAddress.new('NS', [ false, "Specify the nameserver to use for queries, otherwise use the system DNS." ]),
+        OptString.new('OUT_FILE', [ false, "Specify a CSV output file" ])
       ], self.class)
 
     register_advanced_options(
       [
         OptInt.new('RETRY', [ false, "Number of tries to resolve a record if no response is received.", 2]),
         OptInt.new('RETRY_INTERVAL', [ false, "Number of seconds to wait before doing a retry.", 2]),
-        OptInt.new('THREADS', [ true, "The number of concurrent threads.", 1])
+        OptInt.new('THREADS', [ true, "The number of concurrent threads.", 1]),
+        OptInt.new('THROTTLE', [ false, "Specify the resolution throttle in query per sec. 0 means unthrottled",0 ])
       ], self.class)
   end
 
@@ -55,21 +58,50 @@ class Metasploit3 < Msf::Auxiliary
     print_status("Running reverse lookup against IP range #{iprange}")
     ar = Rex::Socket::RangeWalker.new(iprange)
     tl = []
+    # Basic Throttling
+    sleep_time = 0.0
+    if (datastore['THROTTLE'] != 0)
+      sleep_time = (1.0/datastore['THROTTLE'])/datastore['THREADS']
+      print_status("Throttle set to #{datastore['THROTTLE']} queries per seconds") 
+    end
+    # Output..
+    if datastore['OUT_FILE']
+      print_status("Scan result saved in #{datastore['OUT_FILE']}")
+      open(datastore['OUT_FILE'], 'w') do |f|
+        f.puts "; IP, Host"
+      end
+    end
     while (true)
       # Spawn threads for each host
       while (tl.length <= @threadnum)
         ip = ar.next_ip
+        hosts = Array.new
         break if not ip
         tl << framework.threads.spawn("Module(#{self.refname})-#{ip}", false, ip.dup) do |tip|
           begin
+            sleep(sleep_time)
             query = @res.query(tip)
             query.each_ptr do |addresstp|
-              print_status("Host Name: #{addresstp}, IP Address: #{tip.to_s}")
+              print_status("#Host Name: #{addresstp}, IP Address: #{tip.to_s}")
+              if datastore['OUT_FILE']
+                open(datastore['OUT_FILE'], 'a') do |f|
+                  f.puts "#{tip.to_s},#{addresstp}"
+                end
+              end
               report_host(
                 :host => tip.to_s,
                 :name => addresstp
               )
+              hosts.push addresstp
             end
+            if !hosts.empty? 
+              report_note(
+                :host => tip.to_s,
+                :type => "RDNS_Record",
+                :data => hosts
+              )
+            end
+            hosts = Array.new
           rescue ::Interrupt
             raise $!
           rescue ::Rex::ConnectionError

--- a/modules/auxiliary/gather/dns_reverse_lookup.rb
+++ b/modules/auxiliary/gather/dns_reverse_lookup.rb
@@ -61,7 +61,7 @@ class Metasploit3 < Msf::Auxiliary
     # Basic Throttling
     sleep_time = 0.0
     if (datastore['THROTTLE'] != 0)
-      sleep_time = (1.0/datastore['THROTTLE'])/datastore['THREADS']
+      sleep_time = (1.0/datastore['THROTTLE'])*datastore['THREADS']
       print_status("Throttle set to #{datastore['THROTTLE']} queries per seconds")
     end
     # Output..

--- a/modules/auxiliary/gather/dns_reverse_lookup.rb
+++ b/modules/auxiliary/gather/dns_reverse_lookup.rb
@@ -73,9 +73,9 @@ class Metasploit3 < Msf::Auxiliary
     end
     while (true)
       # Spawn threads for each host
+      hosts = Hash.new
       while (tl.length <= @threadnum)
         ip = ar.next_ip
-        hosts = Array.new
         break if not ip
         tl << framework.threads.spawn("Module(#{self.refname})-#{ip}", false, ip.dup) do |tip|
           begin
@@ -92,16 +92,21 @@ class Metasploit3 < Msf::Auxiliary
                 :host => tip.to_s,
                 :name => addresstp
               )
-              hosts.push addresstp
+              if !hosts[tip] 
+                hosts[tip] = Array.new
+              end
+              hosts[tip].push addresstp
             end
-            if !hosts.empty? 
-              report_note(
-                :host => tip.to_s,
-                :type => "RDNS_Record",
-                :data => hosts
-              )
+            
+            if hosts[tip] 
+              if !hosts[tip].empty? 
+                report_note(
+                 :host => tip.to_s,
+                 :type => "RDNS_Record",
+                 :data => hosts[tip]
+               )
+              end
             end
-            hosts = Array.new
           rescue ::Interrupt
             raise $!
           rescue ::Rex::ConnectionError

--- a/modules/auxiliary/gather/dns_reverse_lookup.rb
+++ b/modules/auxiliary/gather/dns_reverse_lookup.rb
@@ -17,8 +17,8 @@ class Metasploit3 < Msf::Auxiliary
           This module performs DNS reverse lookup against a given IP range in order to
         retrieve valid addresses and names.
       },
-      'Author'    => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>', # Base code 
-                       'Thanat0s <thanatos[at]trollprod[dot]org>'], # Output, Throttling & Db notes add 
+      'Author'    => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>', # Base code
+                       'Thanat0s <thanspam[at]trollprod[dot]org>'], # Output, Throttling & Db notes add
       'License'   => BSD_LICENSE
     ))
 
@@ -58,11 +58,11 @@ class Metasploit3 < Msf::Auxiliary
     print_status("Running reverse lookup against IP range #{iprange}")
     ar = Rex::Socket::RangeWalker.new(iprange)
     tl = []
-    # Basic Throttling
+    # Basic Throttling
     sleep_time = 0.0
     if (datastore['THROTTLE'] != 0)
       sleep_time = (1.0/datastore['THROTTLE'])/datastore['THREADS']
-      print_status("Throttle set to #{datastore['THROTTLE']} queries per seconds") 
+      print_status("Throttle set to #{datastore['THROTTLE']} queries per seconds")
     end
     # Output..
     if datastore['OUT_FILE']
@@ -79,10 +79,10 @@ class Metasploit3 < Msf::Auxiliary
         break if not ip
         tl << framework.threads.spawn("Module(#{self.refname})-#{ip}", false, ip.dup) do |tip|
           begin
-            sleep(sleep_time)
+            Rex.sleep(sleep_time)
             query = @res.query(tip)
             query.each_ptr do |addresstp|
-              print_status("#Host Name: #{addresstp}, IP Address: #{tip.to_s}")
+              print_status("Host Name: #{addresstp}, IP Address: #{tip.to_s}")
               if datastore['OUT_FILE']
                 open(datastore['OUT_FILE'], 'a') do |f|
                   f.puts "#{tip.to_s},#{addresstp}"
@@ -92,20 +92,17 @@ class Metasploit3 < Msf::Auxiliary
                 :host => tip.to_s,
                 :name => addresstp
               )
-              if !hosts[tip] 
+              if !hosts[tip]
                 hosts[tip] = Array.new
               end
               hosts[tip].push addresstp
             end
-            
-            if hosts[tip] 
-              if !hosts[tip].empty? 
-                report_note(
-                 :host => tip.to_s,
-                 :type => "RDNS_Record",
-                 :data => hosts[tip]
-               )
-              end
+            unless hosts[tip].nil? or hosts[tip].empty?
+              report_note(
+               :host => tip.to_s,
+               :type => "RDNS_Record",
+               :data => hosts[tip]
+              )
             end
           rescue ::Interrupt
             raise $!


### PR DESCRIPTION
Hi, 

I made this because I had needed it improvement on this module. Now it could be throttled, Could output to a CSV file and all PTR records are maintained in the DB, previousely we only have the last one. 

Be kind, it's my first push, and i'm not a rubyiste.

New options :

```
msf auxiliary(dns_reverse_lookup) > set RANGE 192.168.1.0/24
RANGE => 192.168.1.0/24
msf auxiliary(dns_reverse_lookup) > set OUT_FILE /tmp/rangerdns.csv
OUT_FILE => /tmp/rangerdns.csv
msf auxiliary(dns_reverse_lookup) > set THROTTLE 15
THROTTLE => 15
msf auxiliary(dns_reverse_lookup) > run
[*] Running reverse lookup against IP range 192.168.1.0/24
[*] Throttle set to 15 queries per seconds
[*] Scan result saved in /tmp/rangerdns.csv
[*] #Host Name: newhost.meuiutn.com., IP Address: 192.168.1.145
[*] #Host Name: newhost.miproutn.com., IP Address: 192.168.1.145
[*] #Host Name: newhost.miiiiiiiproutn.com., IP Address: 192.168.1.145
[*] #Host Name: newhost.miautn.com., IP Address: 192.168.1.145
[*] Auxiliary module execution completed


msf auxiliary(dns_reverse_lookup) > notes 192.168.1.145
[*] Time: 2014-04-15 15:36:40 UTC Note: host=192.168.1.145 type=RDNS_Record data=["newhost.miautn.com.", "newhost.meuiutn.com.", "newhost.miproutn.com.", "newhost.miiiiiiiproutn.com."]

[*] exec: cat /tmp/rangerdns.csv

; IP, Host
192.168.1.145,newhost.meuiutn.com.
192.168.1.145,newhost.miproutn.com.
192.168.1.145,newhost.miiiiiiiproutn.com.
192.168.1.145,newhost.miautn.com.
```
