### PR TITLE
Fix dangling reference to 'MODE'

### DIFF
--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -344,7 +344,7 @@ class Metasploit3 < Msf::Auxiliary
           :refs => self.references,
           :info => "Module #{self.fullname} successfully leaked info"
         })
-        if datastore['MODE'] == 'DUMP' # Check mode, dump if requested.
+        if action.name == 'DUMP' # Check action, dump if requested.
           pattern = datastore['DUMPFILTER']
           if pattern
             match_data = heartbeat_data.scan(pattern).join


### PR DESCRIPTION
Seems we missed one.  As it sits in master now, it won't loot with the 'DUMP' action.
