### PR TITLE
Fix disclosure date for recent Oracle module

### DIFF
--- a/modules/auxiliary/scanner/http/oracle_demantra_database_credentials_leak.rb
+++ b/modules/auxiliary/scanner/http/oracle_demantra_database_credentials_leak.rb
@@ -31,7 +31,7 @@ class Metasploit3 < Msf::Auxiliary
           'Oliver Gruskovnjak'
         ],
       'License'        => MSF_LICENSE,
-      'DisclosureDate' => "February 28 2014"
+      'DisclosureDate' => "Feb 28 2014"
     ))
 
     register_options(


### PR DESCRIPTION
## Verification steps
### Pre-fix:
- [x] Run `tools/msftidy.rb modules/auxiliary/scanner/http/oracle_demantra_database_credentials_leak.rb`
- [x] See the error: `[ERROR] Incorrect disclosure date format`
### Post-fix:
- [x] Run `tools/msftidy.rb modules/auxiliary/scanner/http/oracle_demantra_database_credentials_leak.rb`
- [x] See no error.
### Avoiding this in the future:
- [ ] Read the comment docs on [pre-commit-hook](https://github.com/rapid7/metasploit-framework/blob/master/tools/dev/pre-commit-hook.rb)
- [ ] Type `ln -sf ../../tools/dev/pre-commit-hook.rb .git/hooks/pre-commit` to catch errors before commits
- [ ] Type `ln -sf ../../tools/dev/pre-commit-hook.rb .git/hooks/post-merge` to catch errors after merge.

@jvazquez-r7 and @0x3fcoma, take note, since this came from #3197. How do I know? Behold:

```
$ git branch -r --contains $(git log --oneline modules/auxiliary/scanner/http/oracle_demantra_database_credentials_leak.rb | tail -1 | cut -f 1 -d " ") | grep pr
  upstream/pr/3197
```
