### PR TITLE
Be very clear about Redmine's existence.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,29 @@
-# Contributing to Metasploit
+# Hello, World!
 
 Thanks for your interest in making Metasploit -- and therefore, the
-world -- a better place! What you see here in CONTRIBUTING.md is a
-bullet-point list of the do's and don'ts of how to make sure *your*
-valuable contributions actually make it into Metasploit's master branch.
+world -- a better place!
+
+Are you about to report a bug? If so, please use our [Redmine Bug
+Tracker](https://dev.metasploit.com/redmine/projects/framework). An
+account is required but it only takes a minute or two.
+
+Are you about to report a security vulnerability in Metasploit?
+If so, please take a look at Rapid's [Vulnerability
+Disclosure Policy](https://www.rapid7.com/disclosure.jsp) policy.
+
+Are you about to contribute some new functionality, a bug fix, or a new
+Metasploit module? If so, read on...
+
+# Contributing to Metasploit
+
+What you see here in CONTRIBUTING.md is a bullet-point list of the do's
+and don'ts of how to make sure *your* valuable contributions actually
+make it into Metasploit's master branch.
 
 If you care not to follow these rules, your contribution **will** be
 closed (*Road House* style). Sorry!
 
-Incidentally, this is a **short** list. The
+This is intended to be a **short** list. The
 [wiki](https://github.com/rapid7/metasploit-framework/wiki) is much more
 exhaustive and reveals many mysteries. If you read nothing else, take a
 look at the standard [development environment setup
@@ -52,8 +67,8 @@ Pull requests [#2940](https://github.com/rapid7/metasploit-framework/pull/2940) 
 
 ## Bug Reports
 
-* **Do** report vulnerabilities in Rapid7 software to security@rapid7.com.
-* **Do** create a Redmine account and report your bug there.
+* **Do** report vulnerabilities in Rapid7 software directly to security@rapid7.com.
+* **Do** create a Redmine account and report your non-vulnerability bugs there.
 * **Do** write a detailed description of your bug and use a descriptive title.
 * **Do** include reproduction steps, stack traces, and anything else that might help us verify and fix your bug.
 * **Don't** file duplicate reports - search for your bug before filing a new report.


### PR DESCRIPTION
People sometimes get irritated when they open an issue in GitHub issues only to have it closed out.

This change hopes to point people at Redmine early on in the CONTRIBUTING.md, which pops up when people visit GitHub Issues.

I wish I could use blink and marquee tags on that too-subtle pointer of, "Please review the guidelines for contributing to this repository," but that won't happen any time soon.
## Verification
- [x] Read the first three paragraphs of CONTRIBUTING.md
- [x] Become convinced that Redmine is a thing
- [x] Click on the link and see that you're on the Framework project.
