### PR TITLE
Use the new bcrypt gem, not bcrypt-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Need 3+ for ActiveSupport::Concern
 gem 'activesupport', '>= 3.0.0'
 # Needed for some admin modules (cfme_manageiq_evm_pass_reset.rb)
-gem 'bcrypt-ruby'
+gem 'bcrypt'
 # Needed for some admin modules (scrutinizer_add_user.rb)
 gem 'json'
 # Needed by msfgui and other rpc components

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     arel (3.0.2)
-    bcrypt-ruby (3.1.2)
+    bcrypt (3.1.7)
     builder (3.0.4)
     database_cleaner (1.1.1)
     diff-lcs (1.2.4)
@@ -63,7 +63,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord
   activesupport (>= 3.0.0)
-  bcrypt-ruby
+  bcrypt
   database_cleaner
   factory_girl (>= 4.1.0)
   fivemat (= 1.2.1)

--- a/LICENSE
+++ b/LICENSE
@@ -176,7 +176,7 @@ Files: arel
 Copyright: 2007-2010 Nick Kallen, Bryan Helmkamp, Emilio Tagua, Aaron Patterson
 License: MIT
 
-Files: bcrypt-ruby
+Files: bcrypt
 Copyright: 2007-2011 Coda Hale
 License: MIT
 


### PR DESCRIPTION
See the change upstream at:

https://github.com/codahale/bcrypt-ruby/commit/273946f2ba549b9119868331388e8cf30d2af37c

Reported by @ZeroChaos
## Verification
- [x] Run `bundle install`
- [x]  See that the `bcrypt` gem is loaded (currently, version 3.1.7)
- [x] launch `./msfconsole`
- [x] See that the following error **does not** happen:

```
[-] WARNING! The following modules could not be loaded!
[-]     /home/todb/git/rapid7/metasploit-framework/modules/auxiliary/admin/http/cfme_manageiq_evm_pass_reset.rb: LoadError cannot load such file -- bcrypt
```

While the gem name is changed to `bcrypt` the old filename is unchanged from `bcrypt`. So, it's a good change, but sadly means that lots of people will accidentally be stuck on the old version until they notice the version drift.
