### PR TITLE
Add upper bound for active-* gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # Need 3+ for ActiveSupport::Concern
-gem 'activesupport', '>= 3.0.0'
+gem 'activesupport', '>= 3.0.0', '< 4.0.0'
 # Needed for some admin modules (cfme_manageiq_evm_pass_reset.rb)
 gem 'bcrypt'
 # Needed for some admin modules (scrutinizer_add_user.rb)
@@ -19,7 +19,7 @@ gem 'packetfu', '1.1.9'
 
 group :db do
   # Needed for Msf::DbManager
-  gem 'activerecord'
+  gem 'activerecord', '>= 3.0.0', '< 4.0.0'
   # Database models shared between framework and Pro.
   gem 'metasploit_data_models', '~> 0.17.0'
   # Needed for module caching in Mdm::ModuleDetails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,8 +61,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord
-  activesupport (>= 3.0.0)
+  activerecord (>= 3.0.0, < 4.0.0)
+  activesupport (>= 3.0.0, < 4.0.0)
   bcrypt
   database_cleaner
   factory_girl (>= 4.1.0)


### PR DESCRIPTION
We do not yet support ActiveRecord and ActiveSupport 4.x, so ensure our Gemfile declares this.

Reported by @ZeroChaos
## Verification Steps
- [x] Run bundler: `bundle install`
- [x] Ensure `Gemfile.lock` does not change
- [x] Run `./msfconsole`
- [x] `db_status` shows database is connected
