### PR TITLE
Invalid default database name.

### DIFF
--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -259,7 +259,7 @@ class DBManager
       errstr = e.to_s
       if errstr =~ /does not exist/i or errstr =~ /Unknown database/
         ilog("Database doesn't exist \"#{opts['database']}\", attempting to create it.")
-        ActiveRecord::Base.establish_connection(opts.merge('database' => nil))
+        ActiveRecord::Base.establish_connection(opts.merge(:database => 'postgres'))
         ActiveRecord::Base.connection.create_database(opts['database'])
       else
         ilog("Trying to continue despite failed database creation: #{e}")


### PR DESCRIPTION
When calling create_db() via an RPC method, the default database name used is the name of the user running the msfrpcd process. Unfortunately, this database usually does not exist and an exception is raised resulting in a failed state. This patch forces a connection to the default postgres database; mimicking the behaviour of the postgres CLI, psql.
