### PR TITLE
Convert keys to symbols (fix encoding issue)

### DIFF
--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -244,8 +244,9 @@ class DBManager
   # anything at all here.
   #
   def create_db(opts)
+    opts = Hash[opts.map { |k, v| [k.to_sym, v] }] # Convert keys to symbols to avoid pesky encoding issues.
     begin
-      case opts["adapter"]
+      case opts[:adapter]
       when 'postgresql'
         # Try to force a connection to be made to the database, if it succeeds
         # then we know we don't need to create it :)
@@ -259,8 +260,8 @@ class DBManager
       errstr = e.to_s
       if errstr =~ /does not exist/i or errstr =~ /Unknown database/
         ilog("Database doesn't exist \"#{opts['database']}\", attempting to create it.")
-        ActiveRecord::Base.establish_connection(opts.merge('database' => nil))
-        ActiveRecord::Base.connection.create_database(opts['database'])
+        ActiveRecord::Base.establish_connection(opts.merge(:database => 'postgres'))
+        ActiveRecord::Base.connection.create_database(opts[:database])
       else
         ilog("Trying to continue despite failed database creation: #{e}")
       end


### PR DESCRIPTION
Another encoding issue is causing the retrieval of keys in create_db to fail. The reason is associated with the way ruby decides to inconsistently encode strings when processing strings from different I/O channels. In this case, when a user attempts to call the db.connect command via RPC, the creation of the database fails because `opt['database']` returns `nil`. This patch converts all keys in `opts` to symbols and gets rid of dealing with encoding. It might be better (not sure because I am not a ruby expert) to use this technique for the entire framework as this encoding issue has crept up in the past.  This solution has been tested on both msfconsole and msfrpcd and appears to work consistently.
