### PR TITLE
Support deprecation information from constants

### DIFF
--- a/lib/msf/core/module/deprecated.rb
+++ b/lib/msf/core/module/deprecated.rb
@@ -33,18 +33,34 @@ module Msf::Module::Deprecated
   end
 
   # (see ClassMethods#replacement_module)
-  def replacement_module; self.class.replacement_module; end
+  def replacement_module
+    if self.class.instance_variable_defined?(:@replacement_module)
+      return self.class.replacement_module
+    elsif self.class.const_defined?(:DEPRECATION_REPLACEMENT)
+      return self.class.const_get(:DEPRECATION_REPLACEMENT)
+    end
+  end
+
   # (see ClassMethods#deprecation_date)
-  def deprecation_date; self.class.deprecation_date; end
+  def deprecation_date
+    if self.class.instance_variable_defined?(:@deprecation_date)
+      return self.class.deprecation_date
+    elsif self.class.const_defined?(:DEPRECATION_DATE)
+      return self.class.const_get(:DEPRECATION_DATE)
+    end
+  end
 
   # Extends with {ClassMethods}
   def self.included(base)
     base.extend(ClassMethods)
   end
 
-  def setup
+  # Print the module deprecation information
+  #
+  # @return [void]
+  def print_deprecation_warning
     print_warning("*"*72)
-    print_warning("*%red"+"This module is deprecated!".center(70)+"%clr*")
+    print_warning("*%red"+"The module #{refname} is deprecated!".center(70)+"%clr*")
     if deprecation_date
       print_warning("*"+"It will be removed on or about #{deprecation_date}".center(70)+"*")
     end
@@ -52,6 +68,15 @@ module Msf::Module::Deprecated
       print_warning("*"+"Use #{replacement_module} instead".center(70)+"*")
     end
     print_warning("*"*72)
+  end
+
+  def generate
+    print_deprecation_warning
+    super
+  end
+
+  def setup
+    print_deprecation_warning
     super
   end
 

--- a/modules/payloads/stagers/windows/reverse_ipv6_http.rb
+++ b/modules/payloads/stagers/windows/reverse_ipv6_http.rb
@@ -6,12 +6,16 @@
 
 require 'msf/core'
 require 'msf/core/handler/reverse_ipv6_http'
-
+require 'msf/core/module/deprecated'
 
 module Metasploit3
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows
+  include Msf::Module::Deprecated
+
+  DEPRECATION_DATE = Date.new(2014, 7, 30)
+  DEPRECATION_REPLACEMENT = 'windows/meterpreter/reverse_https'
 
   def initialize(info = {})
     super(merge_info(info,

--- a/modules/payloads/stagers/windows/reverse_ipv6_https.rb
+++ b/modules/payloads/stagers/windows/reverse_ipv6_https.rb
@@ -3,13 +3,19 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+
 require 'msf/core'
 require 'msf/core/handler/reverse_ipv6_https'
+require 'msf/core/module/deprecated'
 
 module Metasploit3
 
   include Msf::Payload::Stager
   include Msf::Payload::Windows
+  include Msf::Module::Deprecated
+
+  DEPRECATION_DATE = Date.new(2014, 7, 30)
+  DEPRECATION_REPLACEMENT = 'windows/meterpreter/reverse_https'
 
   def initialize(info = {})
     super(merge_info(info,


### PR DESCRIPTION
This changes the Deprecation mixin to support retrieving information from constants which allows things like payload modules to specify deprecation dates and replacement modules.

Example from deprecating reverse_ipv6_http and reverse_ipv6_https:

```
resource (/home/steiner/tmp.rc)> use exploit/multi/handler
resource (/home/steiner/tmp.rc)> set PAYLOAD windows/meterpreter/reverse_ipv6_https
PAYLOAD => windows/meterpreter/reverse_ipv6_https
resource (/home/steiner/tmp.rc)> set LHOST fe80::250:56ff:fec0:1
LHOST => fe80::250:56ff:fec0:1
msf exploit(handler) > set LPORT 8888
LPORT => 8888
msf exploit(handler) > exploit
[!] ************************************************************************
[!] *   The module windows/meterpreter/reverse_ipv6_https is deprecated!   *
[!] *              It will be removed on or about 2014-07-30               *
[!] *            Use windows/meterpreter/reverse_https instead             *
[!] ************************************************************************
[*] Started HTTPS reverse handler on https://:::8888/
[*] Starting the payload handler...
^C[-] Exploit failed: Interrupt 
msf exploit(handler) > use payload/windows/meterpreter/reverse_ipv6_https
msf payload(reverse_ipv6_https) > set LHOST fe80::250:56ff:fec0:1
LHOST => fe80::250:56ff:fec0:1
msf payload(reverse_ipv6_https) > generate -t raw

[!] ************************************************************************
[!] *   The module windows/meterpreter/reverse_ipv6_https is deprecated!   *
[!] *              It will be removed on or about 2014-07-30               *
[!] *            Use windows/meterpreter/reverse_https instead             *
[!] ************************************************************************
[RAW STUFF]
msf payload(reverse_ipv6_https) >
```

This is a proposed solution to the issues regarding the deprecation of payloads mentioned in PR #3270.
