### PR TITLE
JBoss_Maindeployer: improve feedback against CVE-2010-0738

### DIFF
--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -315,9 +315,12 @@ class Metasploit3 < Msf::Exploit::Remote
         'uri'    => path
       }, 20)
 
+    if (res) && (res.code == 401)
+      fail_with(Failure::NoAccess,"Unable to bypass authentication.  Try changing the verb to HEAD to exploit CVE-2010-0738.")
+    end
+
     if (not res) or (res.code != 200)
-      print_error("Failed: Error requesting #{path}")
-      return nil
+      fail_with(Failure::Unknown,"Failed: Error requesting #{path}")
     end
 
     res


### PR DESCRIPTION
The exploit against CVE-2010-0738 won't work when using GET or POST.  In the existing code the request would fail and the function would return a nil.  This would be passed to detect_platform without being checked and cause the module to crash ungracefully with the error:

Exploit failed: NoMethodError undefined method `body' for nil:NilClass

The first changes detect a 401 authentication message and provide useful feedback.  Given that if, in any case, 'res' is not a valid or useful response the second change just terminates processing.

I've stayed with the module's coding style for consistency.
