### PR TITLE
Passing the Mdm::Task down the chain

### DIFF
--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -4222,7 +4222,10 @@ class DBManager
     parser = Rex::Parser::RetinaXMLStreamParser.new
     parser.on_found_host = Proc.new do |host|
       hobj = nil
-      data = {:workspace => wspace}
+      data = {
+        :workspace => wspace,
+        :task      => args[:task]
+      }
       addr = host['address']
       next if not addr
 

--- a/lib/msf/core/db_manager/import_msf_xml.rb
+++ b/lib/msf/core/db_manager/import_msf_xml.rb
@@ -204,6 +204,7 @@ module Msf
 
         doc.elements.each("/#{btag}/hosts/host") do |host|
           host_data = {}
+          host_data[:task] = args[:task]
           host_data[:workspace] = wspace
           host_data[:host] = nils_for_nulls(host.elements["address"].text.to_s.strip)
           if bl.include? host_data[:host]
@@ -247,6 +248,7 @@ module Msf
 
           host.elements.each('services/service') do |service|
             service_data = {}
+            service_data[:task] = args[:task]
             service_data[:workspace] = wspace
             service_data[:host] = hobj
             service_data[:port] = nils_for_nulls(service.elements["port"].text.to_s.strip).to_i


### PR DESCRIPTION
when reporting hosts from an Mdm::Task we need to pass the task all
the way down. this wasnt done for the metasploit import format.
- [x] in framework run db_import against an msf zip file.
- [x] it should finish without any problems.
