### PR TITLE
Add support for upgrading Linux shells to Meterpreter

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -45,7 +45,7 @@ class Core
     "-K" => [ false, "Terminate all sessions"                         ],
     "-s" => [ true,  "Run a script on the session given with -i, or all"],
     "-r" => [ false, "Reset the ring buffer for the session given with -i, or all"],
-    "-u" => [ true,  "Upgrade a win32 shell to a meterpreter session" ])
+    "-u" => [ true,  "Upgrade a shell to a meterpreter session on certain platforms" ])
 
   @@jobs_opts = Rex::Parser::Arguments.new(
     "-h" => [ false, "Help banner."                                   ],
@@ -1797,20 +1797,32 @@ class Core
         end
 
       when 'upexec'
-        if ((session = framework.sessions.get(sid)))
-          if (session.interactive?)
-            if (session.type == "shell") # XXX: check for windows?
-              session.init_ui(driver.input, driver.output)
-              session.execute_script('spawn_meterpreter', nil)
-              session.reset_ui
+        session_list = build_sessions_array(sid)
+        print_status("Executing 'post/multi/shell_to_meterpreter' on session(s): #{session_list}")
+        session_list.each do |sess|
+          if ((session = framework.sessions.get(sess)))
+            if (session.interactive?)
+              if (session.type == "shell")
+                session.init_ui(driver.input, driver.output)
+                session.execute_script('post/multi/shell_to_meterpreter')
+                session.reset_ui
+              else
+                print_error("Session #{sess} is not a command shell session, skipping...")
+                next
+              end
             else
-              print_error("Session #{sid} is not a command shell session.")
+              print_error("Session #{sess} is non-interactive, skipping...")
+              next
             end
           else
-            print_error("Session #{sid} is non-interactive.")
+            print_error("Invalid session identifier: #{sess}")
+            next
           end
-        else
-          print_error("Invalid session identifier: #{sid}")
+
+          if session_list.count > 1
+            print_status("Sleeping for up 5 seconds to allow the previous handler to finish..")
+            sleep(5)
+          end
         end
 
       when 'reset_ring'
@@ -3275,6 +3287,27 @@ class Core
     finish = line_num + after
     return all_lines.slice(start..finish)
   end
+
+  # Generate an array of session IDs when presented with input such as '1' or  '1,2,4-6,10' or '1,2,4..6,10'
+  def build_sessions_array(sid_list)
+    session_list = Array.new
+    temp_list = sid_list.split(",")
+
+    temp_list.each do |ele|
+      if ele.include? '-'
+        temp_array = (ele.split("-").inject {|s,e| s.to_i..e.to_i}).to_a
+        session_list.concat(temp_array)
+      elsif ele.include? '..'
+        temp_array = (ele.split("..").inject {|s,e| s.to_i..e.to_i}).to_a
+        session_list.concat(temp_array)
+      else
+        session_list.push(ele.to_i)
+      end
+    end
+
+    return session_list.uniq.sort
+  end
+
 end
 
 

--- a/lib/rex/exploitation/cmdstager/bourne.rb
+++ b/lib/rex/exploitation/cmdstager/bourne.rb
@@ -85,7 +85,7 @@ class CmdStagerBourne < CmdStagerBase
   def compress_commands(cmds, opts)
     # Make it all happen
     cmds << "chmod +x #{@tempdir}#{@var_decoded}.bin"
-    cmds << "#{@tempdir}#{@var_decoded}.bin"
+    cmds << "#{@tempdir}#{@var_decoded}.bin & sleep 5"
 
     # Clean up after unless requested not to..
     if (not opts[:nodelete])


### PR DESCRIPTION
These changes to spawn_meterpreter.rb add support for upgrading Linux shells to Meterpreter.

The change to bourne.rb supports this by allowing the stager to be launched, backgrounded, and then the cleanup commands still run.  This was needed during the shell upgrade process.  If the stager isn't backgrounded then it continues to run and tie up the original session while the new Meterpreter session is still open.  This isn't obvious when trying to use the original 'vanilla' linux shell, it just appears unresponsive until the Meterpreter session is exited.  Future attempts to launch Meterpreter from this shell will fail without providing information as to why.

The added side benefit is that the on disk stager files (on linux) are deleted 5 seconds after execution instead of after the Meterpreter session is closed.
