### PR TITLE
POST module duplicate search results

### DIFF
--- a/lib/msf/core/db_manager.rb
+++ b/lib/msf/core/db_manager.rb
@@ -678,7 +678,7 @@ class DBManager
         union.or(condition)
       }
 
-      query = query.where(unioned_conditions).uniq
+      query = query.where(unioned_conditions).to_a.uniq { |m| m.fullname }
     end
 
     query

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -542,8 +542,9 @@ class Console::CommandDispatcher::Core
       # fall back to using the scripting interface.
       if (msf_loaded? and mod = client.framework.modules.create(script_name))
         original_mod = mod
+        reloaded_mod = client.framework.modules.reload_module(original_mod)
 
-        unless original_mod
+        unless reloaded_mod
           error = client.framework.modules.module_load_error_by_path[original_mod.file_path]
           print_error("Failed to reload module: #{error}")
 
@@ -551,7 +552,7 @@ class Console::CommandDispatcher::Core
         end
 
         opts = (args + [ "SESSION=#{client.sid}" ]).join(',')
-        original_mod.run_simple(
+        reloaded_mod.run_simple(
           #'RunAsJob' => true,
           'LocalInput'  => shell.input,
           'LocalOutput' => shell.output,

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -542,9 +542,8 @@ class Console::CommandDispatcher::Core
       # fall back to using the scripting interface.
       if (msf_loaded? and mod = client.framework.modules.create(script_name))
         original_mod = mod
-        reloaded_mod = client.framework.modules.reload_module(original_mod)
 
-        unless reloaded_mod
+        unless original_mod
           error = client.framework.modules.module_load_error_by_path[original_mod.file_path]
           print_error("Failed to reload module: #{error}")
 
@@ -552,7 +551,7 @@ class Console::CommandDispatcher::Core
         end
 
         opts = (args + [ "SESSION=#{client.sid}" ]).join(',')
-        reloaded_mod.run_simple(
+        original_mod.run_simple(
           #'RunAsJob' => true,
           'LocalInput'  => shell.input,
           'LocalOutput' => shell.output,


### PR DESCRIPTION
Running a POST module in meterpreter was causing duplicate search
results for the executed module.  For example, running
post/windows/gather/checkvm would produce duplicate results for that
module when executing “search checkvm” in msf.

Debugging revealed that the cmd_exec function in meterpreter’s ui
command_dispatcher core was creating the specified module, and then
promptly reloading it.  The reload function was causing the duplicate
module_detail record to be written to the msg postgres database
instance.  Further analysis revealed that the “original_mod” could be
used for running the post module, so the “reloaded_mod” was removed
and the “original_mod” used in it’s place to run the post module.

SeeRM #8754
