### PR TITLE
Fix smb_login calling nonexistent method

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -129,7 +129,7 @@ class Metasploit3 < Msf::Auxiliary
     rescue ::Rex::Proto::SMB::Exceptions::LoginError => e
       status_code = e.error_reason
     rescue ::Rex::Proto::SMB::Exceptions::InvalidWordCount => e
-      status_code = e.error_reason
+      status_code = e.get_error(e.error_code)
     rescue ::Rex::Proto::SMB::Exceptions::NoReply
     ensure
       disconnect()


### PR DESCRIPTION
When a Rex::Proto::SMB::Exceptions::InvalidWordCount exception is thrown by this module, it attempts to call the nonexistent method error_reason and throws a NoMethodError:

Auxiliary failed: NoMethodError undefined method `error_reason' for #Rex::Proto::SMB::Exceptions::InvalidWordCount:0x007f48fcda0e48

This changes uses the built in method get_error to return an error code.

[-] x.x.x.x:445 SMB - [1/1] - \Domain - FAILED LOGIN (xxxxxxxx) xxxx : xxxxx [STATUS_WAIT_0]
