### PR TITLE
Large pass_file hangs login modules

### DIFF
--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -330,6 +330,23 @@ module Auxiliary::AuthBrute
     end
 
     creds = [ [], [], [], [] ] # userpass, pass, user, rest
+    remaining_pairs = combined_array.length # counter for our occasional output
+    status = Thread.new do
+      loop do
+        # Ruby's sleep function is not terribly accurate.
+        # Since all we are trying to do is let the user know
+        # that the process is still working and giving them
+        # an estimate as to how many pairs are left,
+        # precision may not be of the utmost necessity
+        sleep 100
+        # Let the user know the combined pair list is still building
+        # and tell them how many pairs are left to process.
+        print_brute(
+          :level => :vstatus,
+          :msg => "Pair list is still building with #{remaining_pairs} pairs left to process"
+        )
+      end
+    end
     # Move datastore['USERNAME'] and datastore['PASSWORD'] to the front of the list.
     # Note that we cannot tell the user intention if USERNAME or PASSWORD is blank --
     # maybe (and it's often) they wanted a blank. One more credential won't kill
@@ -344,7 +361,9 @@ module Auxiliary::AuthBrute
       else
         creds[3] << pair
       end
+      remaining_pairs -= 1
     end
+    status.kill
     return creds[0] + creds[1] + creds[2] + creds[3]
   end
 

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -331,6 +331,8 @@ module Auxiliary::AuthBrute
 
     creds = [ [], [], [], [] ] # userpass, pass, user, rest
     remaining_pairs = combined_array.length # counter for our occasional output
+    interval = 60 # seconds between each remaining pair message reported to user
+    next_message_time = Time.now + interval # initial timing interval for user message
     # Move datastore['USERNAME'] and datastore['PASSWORD'] to the front of the list.
     # Note that we cannot tell the user intention if USERNAME or PASSWORD is blank --
     # maybe (and it's often) they wanted a blank. One more credential won't kill
@@ -345,11 +347,12 @@ module Auxiliary::AuthBrute
       else
         creds[3] << pair
       end
-      if remaining_pairs % 500000 == 0
+      if Time.now > next_message_time
         print_brute(
           :level => :vstatus,
           :msg => "Pair list is still building with #{remaining_pairs} pairs left to process"
         )
+        next_message_time = Time.now + interval
       end
       remaining_pairs -= 1
     end

--- a/lib/msf/core/auxiliary/auth_brute.rb
+++ b/lib/msf/core/auxiliary/auth_brute.rb
@@ -331,22 +331,6 @@ module Auxiliary::AuthBrute
 
     creds = [ [], [], [], [] ] # userpass, pass, user, rest
     remaining_pairs = combined_array.length # counter for our occasional output
-    status = Thread.new do
-      loop do
-        # Ruby's sleep function is not terribly accurate.
-        # Since all we are trying to do is let the user know
-        # that the process is still working and giving them
-        # an estimate as to how many pairs are left,
-        # precision may not be of the utmost necessity
-        sleep 100
-        # Let the user know the combined pair list is still building
-        # and tell them how many pairs are left to process.
-        print_brute(
-          :level => :vstatus,
-          :msg => "Pair list is still building with #{remaining_pairs} pairs left to process"
-        )
-      end
-    end
     # Move datastore['USERNAME'] and datastore['PASSWORD'] to the front of the list.
     # Note that we cannot tell the user intention if USERNAME or PASSWORD is blank --
     # maybe (and it's often) they wanted a blank. One more credential won't kill
@@ -361,9 +345,14 @@ module Auxiliary::AuthBrute
       else
         creds[3] << pair
       end
+      if remaining_pairs % 500000 == 0
+        print_brute(
+          :level => :vstatus,
+          :msg => "Pair list is still building with #{remaining_pairs} pairs left to process"
+        )
+      end
       remaining_pairs -= 1
     end
-    status.kill
     return creds[0] + creds[1] + creds[2] + creds[3]
   end
 


### PR DESCRIPTION
SeeRM #8704

When running a *_login module that contains a large PASS_FILE
the module appears to hang while it is creating the combinations over
such a large dataset.  The solution proposed in the Redmine task
requested that the user be alerted with some sort of progress feedback
if the process takes an excessive amount of time.

I have added a message that logs to the console that contains the
number of pairs left to be constructed before the module will continue.
The verbiage is fairly arbitrary and should probably be updated to
something that might be more descriptive.  Likewise, the sleep
interval may need to be adjusted.

For the interval length, I began with 5 minutes (300 seconds) because that is what the Redmine issue suggested.  When testing with 300 seconds, I noticed that the status update was being logged to console about every eight minutes in my local development environment.  Further research revealed that the ruby sleep function's timing can vary based on CPU type, architecture, etc.  Odds are that the interval value will need to be adjusted to suit the communities needs.
