### PR TITLE
Bug with HTTP POST requests (content type sent twice)

### DIFF
--- a/modules/auxiliary/server/http_ntlmrelay.rb
+++ b/modules/auxiliary/server/http_ntlmrelay.rb
@@ -269,11 +269,6 @@ class Metasploit3 < Msf::Auxiliary
     theaders = ('Authorization: NTLM ' << hash << "\r\n" <<
           "Connection: Keep-Alive\r\n" )
 
-    if (method == 'POST')
-      theaders << 'Content-Length: ' <<
-        (@finalputdata.length + 4).to_s()<< "\r\n"
-    end
-
     # HTTP_HEADERFILE is how this module supports cookies, multipart forms, etc
     if datastore['HTTP_HEADERFILE'] != nil
       print_status("Including extra headers from: #{datastore['HTTP_HEADERFILE']}")


### PR DESCRIPTION
At some point it seems HttpClient started adding content-length to POST requests (I don't think it used to). This resulted in content-length being sent twice, and sometimes broke POST request ntlm relaying 

e.g. in my testing asp.net gives a 500 when content-length is sent twice, and the module would return with an "#{rhost} is not requesting authentication." error
