### PR TITLE
fix a few clarical errors and typos

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/kiwi.rb
@@ -146,9 +146,9 @@ class Console::CommandDispatcher::Kiwi
     "-u" => [ true,  "Name of the user to create the ticket for" ],
     "-i" => [ true,  "ID of the user to associate the ticket with" ],
     "-g" => [ true,  "Comma-separated list of group identifiers to include (eg: 501,502)" ],
-    "-d" => [ true,  "Name of the target domain" ],
-    "-k" => [ true,  "Kerberos ticket granting token" ],
-    "-t" => [ true,  "Path of the file to store the ticket in" ],
+    "-d" => [ true,  "Name of the target domain (FQDN)" ],
+    "-k" => [ true,  "krbtgt domain user NTLM hash" ],
+    "-t" => [ true,  "Local path of the file to store the ticket in" ],
     "-s" => [ true,  "SID of the domain" ]
   )
 
@@ -157,7 +157,7 @@ class Console::CommandDispatcher::Kiwi
   #
   def golden_ticket_create_usage
     print(
-      "\nUsage: kerberos_ticket_list [-h] -u <user> -d <domain> -k <tgt> -s <sid> [-i <id>] [-g <groups> -t <path>\n\n" +
+      "\nUsage: golden_ticket_create [-h] -u <user> -d <domain> -k <krbtgt_ntlm> -s <sid> -t <path> [-i <id>] [-g <groups>]\n\n" +
       "Create a golden kerberos ticket that expires in 10 years time.\n\n" +
       @@golden_ticket_create_opts.usage)
   end
@@ -304,7 +304,7 @@ class Console::CommandDispatcher::Kiwi
   # Invoke the kerberos ticket purging functionality on the target machine.
   #
   def cmd_kerberos_ticket_purge(*args)
-    client.kiwi.keberos_ticket_purge
+    client.kiwi.kerberos_ticket_purge
     print_good("Kerberos tickets purged")
   end
 


### PR DESCRIPTION
1. Thought it best to make sure people know this relies on FQDN
2. It's the `krbtgt` user's NTLM hash needed, not any ticket/token as far as I know, happy to be proven wrong on this one.
3. When I first read the path I thought it was on target since I was running in a meterpreter session, "local" just helps with a bit of confusion.
4. Think this was just a bad copy pasta job. Small fixes needed
5. Missing 'r' made purge error out with method not found.
