### PR TITLE
Omitting timestamp from msfconsole search output

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -97,6 +97,8 @@ class Core
   # mode.
   DefangedProhibitedDataStoreElements = [ "MsfModulePaths" ]
 
+  # Constant for disclosure date formatting in search functions
+  DISCLOSURE_DATE_FORMAT = "%Y-%m-%d"
   # Returns the list of commands supported by this command dispatcher
   def commands
     {
@@ -1488,7 +1490,7 @@ class Core
         next if not o
 
         if not o.search_filter(match)
-          tbl << [ o.fullname, o.disclosure_date.strftime("%Y-%m-%d"), o.rank_to_s, o.name ]
+          tbl << [ o.fullname, o.disclosure_date.nil? ? "" : o.disclosure_date.strftime(DISCLOSURE_DATE_FORMAT), o.rank_to_s, o.name ]
         end
       end
     end
@@ -1503,7 +1505,7 @@ class Core
   def search_modules_sql(search_string)
     tbl = generate_module_table("Matching Modules")
     framework.db.search_modules(search_string).each do |o|
-      tbl << [ o.fullname, o.disclosure_date.strftime("%Y-%m-%d"), RankingName[o.rank].to_s, o.name ]
+      tbl << [ o.fullname, o.disclosure_date.nil? ? "" : o.disclosure_date.strftime(DISCLOSURE_DATE_FORMAT), RankingName[o.rank].to_s, o.name ]
     end
     print_line(tbl.to_s)
   end
@@ -3239,7 +3241,7 @@ class Core
             end
           end
           if (opts == nil or show == true)
-            tbl << [ refname, o.disclosure_date||"", o.rank_to_s, o.name ]
+            tbl << [ refname, o.disclosure_date.nil? ? "" : o.disclosure_date.strftime(DISCLOSURE_DATE_FORMAT), o.rank_to_s, o.name ]
           end
         end
       end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1488,7 +1488,7 @@ class Core
         next if not o
 
         if not o.search_filter(match)
-          tbl << [ o.fullname, o.disclosure_date.to_s, o.rank_to_s, o.name ]
+          tbl << [ o.fullname, o.disclosure_date.strftime("%Y-%m-%d"), o.rank_to_s, o.name ]
         end
       end
     end
@@ -1503,7 +1503,7 @@ class Core
   def search_modules_sql(search_string)
     tbl = generate_module_table("Matching Modules")
     framework.db.search_modules(search_string).each do |o|
-      tbl << [ o.fullname, o.disclosure_date.to_s, RankingName[o.rank].to_s, o.name ]
+      tbl << [ o.fullname, o.disclosure_date.strftime("%Y-%m-%d"), RankingName[o.rank].to_s, o.name ]
     end
     print_line(tbl.to_s)
   end

--- a/spec/lib/msf/ui/command_dispatcher/core_spec.rb
+++ b/spec/lib/msf/ui/command_dispatcher/core_spec.rb
@@ -82,7 +82,7 @@ describe Msf::Ui::Console::CommandDispatcher::Core do
         end
 
         it 'should have disclosure date in second column' do
-          cell(printed_table, 0, 1).should include(module_detail.disclosure_date.to_s)
+          cell(printed_table, 0, 1).should include(module_detail.disclosure_date.strftime("%Y-%m-%d"))
         end
 
         it 'should have rank name in third column' do


### PR DESCRIPTION
SeeRM #8795

The disclosure date field in the results from the search command
where returning with a timestamp that was almost always 00:00:00 UTC. 
I added a bit of date time formatting to only
include the year (4 digit), month (2 digit), and day (2 digit)
in the following format: Y-m-d.  This date time formatting
applies to both searches conducted through the database instance
as well as searches performed without a database (slow search).

Example output for a database search:

<pre>
msf > search freefloat

Matching Modules
================

   Name                                   Disclosure Date  Rank       Description
   ----                                   ---------------  ----       -----------
   exploit/windows/ftp/freefloatftp_user  2012-06-12       normal     Free Float FTP Server USER Command Buffer Overflow
   exploit/windows/ftp/freefloatftp_wbem  2012-12-07       excellent  FreeFloat FTP Server Arbitrary File Upload
</pre>


Example output for a non-database search:

<pre>
msf > search freefloat
[!] Database not connected or cache not built, using slow search

Matching Modules
================

   Name                                   Disclosure Date  Rank       Description
   ----                                   ---------------  ----       -----------
   exploit/windows/ftp/freefloatftp_user  2012-06-12       normal     Free Float FTP Server USER Command Buffer Overflow
   exploit/windows/ftp/freefloatftp_wbem  2012-12-07       excellent  FreeFloat FTP Server Arbitrary File Upload
</pre>
