### PR TITLE
Add admin check to smb_login

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -32,7 +32,9 @@ class Metasploit3 < Msf::Auxiliary
       'Author'         =>
         [
           'tebo <tebo [at] attackresearch [dot] com>', # Original
-          'Ben Campbell' # Refactoring
+          'Ben Campbell', # Refactoring
+          'Brandon McCann "zeknox" <bmccann [at] accuvant.com>', # admin check
+          'Tom Sellers <tom <at> fadedcode.net>' # admin check/bug fix
         ],
       'References'     =>
         [
@@ -69,6 +71,7 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('SMBPass', [ false, "SMB Password" ]),
         OptString.new('SMBUser', [ false, "SMB Username" ]),
         OptString.new('SMBDomain', [ false, "SMB Domain", '']),
+        OptBool.new('CHECK_ADMIN', [ false, "Check for Admin rights", false]),
         OptBool.new('PRESERVE_DOMAINS', [ false, "Respect a username that contains a domain name.", true]),
         OptBool.new('RECORD_GUEST', [ false, "Record guest-privileged random logins to the database", false])
       ], self.class)
@@ -124,6 +127,27 @@ class Metasploit3 < Msf::Auxiliary
       # Windows SMB will return an error code during Session Setup, but nix Samba requires a Tree Connect:
       simple.connect("\\\\#{datastore['RHOST']}\\IPC$")
       status_code = 'STATUS_SUCCESS'
+
+      if datastore['CHECK_ADMIN']
+        status_code = :not_admin
+        # Drop the existing connection to IPC$ in order to connect to admin$
+        simple.disconnect("\\\\#{datastore['RHOST']}\\IPC$")
+        begin
+          simple.connect("\\\\#{datastore['RHOST']}\\admin$")
+          status_code = :admin_access
+          # Restore the orginal connection
+          simple.disconnect("\\\\#{datastore['RHOST']}\\admin$")
+          simple.connect("\\\\#{datastore['RHOST']}\\IPC$")
+        rescue
+          status_code = :not_admin
+        ensure
+          begin
+            simple.connect("\\\\#{datastore['RHOST']}\\IPC$")
+          rescue ::Rex::Proto::SMB::Exceptions::NoReply
+          end
+        end
+      end
+
     rescue ::Rex::Proto::SMB::Exceptions::ErrorCode => e
       status_code = e.get_error(e.error_code)
     rescue ::Rex::Proto::SMB::Exceptions::LoginError => e
@@ -187,7 +211,16 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def valid_credentials?(status)
-    return (status == "STATUS_SUCCESS" || @correct_credentials_status_codes.include?(status))
+
+    case status
+    when 'STATUS_SUCCESS', :admin_access, :not_admin
+      return true
+    when *@correct_credentials_status_codes
+      return true
+    else
+      return false
+    end
+
   end
 
   def try_user_pass(domain, user, pass)
@@ -214,7 +247,7 @@ class Metasploit3 < Msf::Auxiliary
     output_message << " (#{smb_peer_os}) #{user} : #{pass} [#{status}]".gsub('%', '%%')
 
     case status
-    when 'STATUS_SUCCESS'
+    when 'STATUS_SUCCESS', :admin_access, :not_admin
       # Auth user indicates if the login was as a guest or not
       if(simple.client.auth_user)
         print_good(output_message % "SUCCESSFUL LOGIN")
@@ -275,7 +308,7 @@ class Metasploit3 < Msf::Auxiliary
   def report_creds(domain,user,pass,active)
     login_name = ""
 
-    if accepts_bogus_domains?(user,pass,rhost)
+    if accepts_bogus_domains?(user,pass,rhost) || domain.blank?
       login_name = user
     else
       login_name = "#{domain}\\#{user}"

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -135,9 +135,7 @@ class Metasploit3 < Msf::Auxiliary
         begin
           simple.connect("\\\\#{datastore['RHOST']}\\admin$")
           status_code = :admin_access
-          # Restore the orginal connection
           simple.disconnect("\\\\#{datastore['RHOST']}\\admin$")
-          simple.connect("\\\\#{datastore['RHOST']}\\IPC$")
         rescue
           status_code = :not_admin
         ensure


### PR DESCRIPTION
The attached updates changes smb_login to detect if the newly discovered user is an administrator.  It is based on code from Brandon McCann "zeknox" submitted in PR #1373, the associated changes, and the newer PR #2656.
The changes should correct a few issues with PR #1373 and #2656 and address Redmine bug #8773.

Specifically it:
- Fixes the admin detection code by using simple.disconnect(<share>) instead of disconnect()
- Adds support for detecting if the remote host will allow connects using any domain name when one of the new status codes is returned
- Dealt with the issue in PR #2656 where the username was prefixed with a '\'

**Verification**
- [ ] Be connected to a database
- [ ] Run this against a machine with a known user and admin user
- [ ] See that the admin user is reported correctly
- [ ] See that the non-admin user is reported correctly
- [ ] Check the output of creds
- [ ] Select a target that requires a domain in order to authenticate
- [ ] In the stored credentials, with CHECK_ADMIN enabled, see that the domain name is, in fact, preserved in the reporting
- [ ] To validate that the remote domain ignores domain value use the following command from a windows system:

```
net use \\<hostip>\admin$ /user:<random_value>\<username>   <password>
```
