### PR TITLE
Update CVEs for RootedCon Yokogawa modules

### DIFF
--- a/modules/auxiliary/dos/scada/yokogawa_logsvr.rb
+++ b/modules/auxiliary/dos/scada/yokogawa_logsvr.rb
@@ -29,7 +29,8 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           [ 'URL', 'http://www.yokogawa.com/dcs/security/ysar/YSAR-14-0001E.pdf' ],
-          [ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2014/03/10/yokogawa-centum-cs3000-vulnerabilities' ]
+          [ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2014/03/10/yokogawa-centum-cs3000-vulnerabilities' ],
+          [ 'CVE', '2014-0781']
         ],
       'DisclosureDate' => 'Mar 10 2014',
     ))

--- a/modules/exploits/windows/scada/yokogawa_bkbcopyd_bof.rb
+++ b/modules/exploits/windows/scada/yokogawa_bkbcopyd_bof.rb
@@ -26,7 +26,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'URL', 'http://www.yokogawa.com/dcs/security/ysar/YSAR-14-0001E.pdf' ],
-          [ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2014/03/10/yokogawa-centum-cs3000-vulnerabilities' ]
+          [ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2014/03/10/yokogawa-centum-cs3000-vulnerabilities' ],
+          [ 'CVE', '2014-0784']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/windows/scada/yokogawa_bkhodeq_bof.rb
+++ b/modules/exploits/windows/scada/yokogawa_bkhodeq_bof.rb
@@ -28,7 +28,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           [ 'URL', 'http://www.yokogawa.com/dcs/security/ysar/YSAR-14-0001E.pdf' ],
-          [ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2014/03/10/yokogawa-centum-cs3000-vulnerabilities' ]
+          [ 'URL', 'https://community.rapid7.com/community/metasploit/blog/2014/03/10/yokogawa-centum-cs3000-vulnerabilities' ],
+          [ 'CVE', '2014-0783']
         ],
       'Payload'        =>
         {


### PR DESCRIPTION
Noticed they were nicely documented at

http://chemical-facility-security-news.blogspot.com/2014/03/ics-cert-publishes-yokogawa-advisory.html

We apparently never updated with CVE numbers.
## Verification steps
- [x] Check the `info` on the affected modules, see the new CVEs.
