### PR TITLE
Banner updates for Pro free trial messaging

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -386,12 +386,15 @@ class Core
 
     if is_apt
       content = [
-        "Large pentest? List, sort, group, tag and search your hosts and services\nin Metasploit Pro -- type 'go_pro' to launch it now.",
-        "Frustrated with proxy pivoting? Upgrade to layer-2 VPN pivoting with\nMetasploit Pro -- type 'go_pro' to launch it now.",
-        "Save your shells from AV! Upgrade to advanced AV evasion using dynamic\nexe templates with Metasploit Pro -- type 'go_pro' to launch it now.",
-        "Easy phishing: Set up email templates, landing pages and listeners\nin Metasploit Pro's wizard -- type 'go_pro' to launch it now.",
-        "Using notepad to track pentests? Have Metasploit Pro report on hosts,\nservices, sessions and evidence -- type 'go_pro' to launch it now.",
-        "Tired of typing 'set RHOSTS'? Click & pwn with Metasploit Pro\n-- type 'go_pro' to launch it now."
+        "Trouble managing data? List, sort, group, tag and search your pentest data\nin Metasploit Pro -- learn more on http://rapid7.com/metasploit",
+        "Frustrated with proxy pivoting? Upgrade to layer-2 VPN pivoting with\nMetasploit Pro -- learn more on http://rapid7.com/metasploit",
+        "Payload caught by AV? Fly under the radar with Dynamic Payloads in\nMetasploit Pro -- learn more on http://rapid7.com/metasploit",
+        "Easy phishing: Set up email templates, landing pages and listeners\nin Metasploit Pro -- learn more on http://rapid7.com/metasploit",
+        "Taking notes in notepad? Have Metasploit Pro track & report\nyour progress and findings -- learn more on http://rapid7.com/metasploit",
+        "Tired of typing 'set RHOSTS'? Click & pwn with Metasploit Pro\n-- learn more on http://rapid7.com/metasploit",
+        "Love leveraging credentials? Check out bruteforcing\nin Metasploit Pro -- learn more on http://rapid7.com/metasploit",
+        "Save 45% of your time on large engagements with Metaspsloit Pro\n-- learn more on http://rapid7.com/metasploit",
+        "Validate lots of vulnerabilities to demonstrate exposure\nwith Metasploit Pro\n-- learn more on http://rapid7.com/metasploit"
       ]
       banner << content.sample # Ruby 1.9-ism!
       banner << "\n\n"

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -400,38 +400,24 @@ class Core
       banner << "\n\n"
     end
 
-    oldwarn = nil
     avdwarn = nil
 
     banner_trailers = {
       :version     => "%yelmetasploit v#{Msf::Framework::Version} [core:#{Msf::Framework::VersionCore} api:#{Msf::Framework::VersionAPI}]%clr",
       :exp_aux_pos => "#{framework.stats.num_exploits} exploits - #{framework.stats.num_auxiliary} auxiliary - #{framework.stats.num_post} post",
       :pay_enc_nop => "#{framework.stats.num_payloads} payloads - #{framework.stats.num_encoders} encoders - #{framework.stats.num_nops} nops",
-      :free_trial  => "Free Metasploit Pro trial: http://r-7.com/trymsp"
+      :free_trial  => "Free Metasploit Pro trial: http://r-7.co/trymsp"
     }
 
-    banner << ("       =[ %-57s]\n" % banner_trailers[:version])
-    banner << ("+ -- --=[ %-49s]\n" % banner_trailers[:exp_aux_pos])
-    banner << ("+ -- --=[ %-49s]\n" % banner_trailers[:pay_enc_nop])
+    banner << ("       =[ %-56s]\n" % banner_trailers[:version])
+    banner << ("+ -- --=[ %-48s]\n" % banner_trailers[:exp_aux_pos])
+    banner << ("+ -- --=[ %-48s]\n" % banner_trailers[:pay_enc_nop])
 
     # Direct the user to the 14-day free trial of Metasploit Pro unless
     # they are on an apt install or already using Metasploit Pro,
     # Express, or Community edition
     unless binary_install
-      banner << ("+ -- --=[ %-49s]\n" % banner_trailers[:free_trial])
-    end
-
-    if ( ::Msf::Framework::RepoRevision.to_i > 0 and ::Msf::Framework::RepoUpdatedDate)
-      tstamp = ::Msf::Framework::RepoUpdatedDate.strftime("%Y.%m.%d")
-      banner << "       =[ svn r#{::Msf::Framework::RepoRevision} updated #{::Msf::Framework::RepoUpdatedDaysNote} (#{tstamp})\n"
-      if(::Msf::Framework::RepoUpdatedDays > 7)
-        oldwarn = []
-        oldwarn << "Warning: This copy of the Metasploit Framework was last updated #{::Msf::Framework::RepoUpdatedDaysNote}."
-        oldwarn << "         We recommend that you update the framework at least every other day."
-        oldwarn << "         For information on updating your copy of Metasploit, please see:"
-        oldwarn << "             https://community.rapid7.com/docs/DOC-1306"
-        oldwarn << ""
-      end
+      banner << ("+ -- --=[ %-48s]\n" % banner_trailers[:free_trial])
     end
 
     if ::Msf::Framework::EICARCorrupted
@@ -443,21 +429,8 @@ class Core
       avdwarn << ""
     end
 
-    # We're running a two week survey to gather feedback from users.
-    # Let's make sure we reach regular msfconsole users.
-    # TODO: Get rid of this sometime after 2014-01-23
-    survey_expires = Time.new(2014,"Jan",22,23,59,59,"-05:00")
-    if Time.now.to_i < survey_expires.to_i
-      banner << "+ -- --=[ Answer Q's about Metasploit and win a WiFi Pineapple Mk5   ]\n"
-      banner << "+ -- --=[ http://bit.ly/msfsurvey (Expires #{survey_expires.ctime}) ]\n"
-    end
-
     # Display the banner
     print_line(banner)
-
-    if(oldwarn)
-      oldwarn.map{|line| print_line(line) }
-    end
 
     if(avdwarn)
       avdwarn.map{|line| print_error(line) }

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -397,21 +397,25 @@ class Core
       banner << "\n\n"
     end
 
-    banner << "       =[ %yelmetasploit v#{Msf::Framework::Version} [core:#{Msf::Framework::VersionCore} api:#{Msf::Framework::VersionAPI}]%clr ]\n"
-    banner << "+ -- --=[ "
-    banner << "#{framework.stats.num_exploits} exploits - #{framework.stats.num_auxiliary} auxiliary - #{framework.stats.num_post} post ]\n"
-    banner << "+ -- --=[ "
-
     oldwarn = nil
     avdwarn = nil
 
-    banner << "#{framework.stats.num_payloads} payloads - #{framework.stats.num_encoders} encoders - #{framework.stats.num_nops} nops      ]\n"
+    banner_trailers = {
+      :version     => "%yelmetasploit v#{Msf::Framework::Version} [core:#{Msf::Framework::VersionCore} api:#{Msf::Framework::VersionAPI}]%clr",
+      :exp_aux_pos => "#{framework.stats.num_exploits} exploits - #{framework.stats.num_auxiliary} auxiliary - #{framework.stats.num_post} post",
+      :pay_enc_nop => "#{framework.stats.num_payloads} payloads - #{framework.stats.num_encoders} encoders - #{framework.stats.num_nops} nops",
+      :free_trial  => "Free Metasploit Pro trial: http://r-7.com/trymsp"
+    }
+
+    banner << ("       =[ %-57s]\n" % banner_trailers[:version])
+    banner << ("+ -- --=[ %-49s]\n" % banner_trailers[:exp_aux_pos])
+    banner << ("+ -- --=[ %-49s]\n" % banner_trailers[:pay_enc_nop])
 
     # Direct the user to the 14-day free trial of Metasploit Pro unless
     # they are on an apt install or already using Metasploit Pro,
     # Express, or Community edition
     unless binary_install
-      banner << "+ -- --=[ 14-Day free trial: http://metasploit.pro ]"
+      banner << ("+ -- --=[ %-49s]\n" % banner_trailers[:free_trial])
     end
 
     if ( ::Msf::Framework::RepoRevision.to_i > 0 and ::Msf::Framework::RepoUpdatedDate)

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -384,6 +384,8 @@ class Core
   def cmd_banner(*args)
     banner  = "%cya" + Banner.to_s + "%clr\n\n"
 
+    # These messages should /not/ show up when you're on a git checkout;
+    # you're a developer, so you already know all this.
     if (is_apt || binary_install)
       content = [
         "Trouble managing data? List, sort, group, tag and search your pentest data\nin Metasploit Pro -- learn more on http://rapid7.com/metasploit",
@@ -391,10 +393,10 @@ class Core
         "Payload caught by AV? Fly under the radar with Dynamic Payloads in\nMetasploit Pro -- learn more on http://rapid7.com/metasploit",
         "Easy phishing: Set up email templates, landing pages and listeners\nin Metasploit Pro -- learn more on http://rapid7.com/metasploit",
         "Taking notes in notepad? Have Metasploit Pro track & report\nyour progress and findings -- learn more on http://rapid7.com/metasploit",
-        "Tired of typing 'set RHOSTS'? Click & pwn with Metasploit Pro\n-- learn more on http://rapid7.com/metasploit",
+        "Tired of typing 'set RHOSTS'? Click & pwn with Metasploit Pro\nLearn more on http://rapid7.com/metasploit",
         "Love leveraging credentials? Check out bruteforcing\nin Metasploit Pro -- learn more on http://rapid7.com/metasploit",
-        "Save 45% of your time on large engagements with Metaspsloit Pro\n-- learn more on http://rapid7.com/metasploit",
-        "Validate lots of vulnerabilities to demonstrate exposure\nwith Metasploit Pro\n-- learn more on http://rapid7.com/metasploit"
+        "Save 45% of your time on large engagements with Metaspsloit Pro\nLearn more on http://rapid7.com/metasploit",
+        "Validate lots of vulnerabilities to demonstrate exposure\nwith Metasploit Pro -- Learn more on http://rapid7.com/metasploit"
       ]
       banner << content.sample # Ruby 1.9-ism!
       banner << "\n\n"
@@ -406,19 +408,18 @@ class Core
       :version     => "%yelmetasploit v#{Msf::Framework::Version} [core:#{Msf::Framework::VersionCore} api:#{Msf::Framework::VersionAPI}]%clr",
       :exp_aux_pos => "#{framework.stats.num_exploits} exploits - #{framework.stats.num_auxiliary} auxiliary - #{framework.stats.num_post} post",
       :pay_enc_nop => "#{framework.stats.num_payloads} payloads - #{framework.stats.num_encoders} encoders - #{framework.stats.num_nops} nops",
-      :free_trial  => "Free Metasploit Pro trial: http://r-7.co/trymsp"
+      :free_trial  => "Free Metasploit Pro trial: http://r-7.co/trymsp",
+      :padding     => 48
     }
 
-    banner << ("       =[ %-56s]\n" % banner_trailers[:version])
-    banner << ("+ -- --=[ %-48s]\n" % banner_trailers[:exp_aux_pos])
-    banner << ("+ -- --=[ %-48s]\n" % banner_trailers[:pay_enc_nop])
+    banner << ("       =[ %-#{banner_trailers[:padding]+8}s]\n" % banner_trailers[:version])
+    banner << ("+ -- --=[ %-#{banner_trailers[:padding]}s]\n" % banner_trailers[:exp_aux_pos])
+    banner << ("+ -- --=[ %-#{banner_trailers[:padding]}s]\n" % banner_trailers[:pay_enc_nop])
 
-    # Direct the user to the 14-day free trial of Metasploit Pro unless
-    # they are on an apt install or already using Metasploit Pro,
-    # Express, or Community edition
-    unless (is_apt || binary_install)
-      banner << ("+ -- --=[ %-48s]\n" % banner_trailers[:free_trial])
-    end
+    # TODO: People who are already on a Pro install shouldn't see this.
+    # It's hard for Framework to tell the difference though since
+    # license details are only in Pro -- we can't see them from here.
+    banner << ("+ -- --=[ %-#{banner_trailers[:padding]}s]\n" % banner_trailers[:free_trial])
 
     if ::Msf::Framework::EICARCorrupted
       avdwarn = []

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -395,7 +395,7 @@ class Core
         "Taking notes in notepad? Have Metasploit Pro track & report\nyour progress and findings -- learn more on http://rapid7.com/metasploit",
         "Tired of typing 'set RHOSTS'? Click & pwn with Metasploit Pro\nLearn more on http://rapid7.com/metasploit",
         "Love leveraging credentials? Check out bruteforcing\nin Metasploit Pro -- learn more on http://rapid7.com/metasploit",
-        "Save 45% of your time on large engagements with Metaspsloit Pro\nLearn more on http://rapid7.com/metasploit",
+        "Save 45% of your time on large engagements with Metasploit Pro\nLearn more on http://rapid7.com/metasploit",
         "Validate lots of vulnerabilities to demonstrate exposure\nwith Metasploit Pro -- Learn more on http://rapid7.com/metasploit"
       ]
       banner << content.sample # Ruby 1.9-ism!

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -384,7 +384,7 @@ class Core
   def cmd_banner(*args)
     banner  = "%cya" + Banner.to_s + "%clr\n\n"
 
-    if is_apt
+    if (is_apt || binary_install)
       content = [
         "Trouble managing data? List, sort, group, tag and search your pentest data\nin Metasploit Pro -- learn more on http://rapid7.com/metasploit",
         "Frustrated with proxy pivoting? Upgrade to layer-2 VPN pivoting with\nMetasploit Pro -- learn more on http://rapid7.com/metasploit",
@@ -416,7 +416,7 @@ class Core
     # Direct the user to the 14-day free trial of Metasploit Pro unless
     # they are on an apt install or already using Metasploit Pro,
     # Express, or Community edition
-    unless binary_install
+    unless (is_apt || binary_install)
       banner << ("+ -- --=[ %-48s]\n" % banner_trailers[:free_trial])
     end
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -406,6 +406,14 @@ class Core
     avdwarn = nil
 
     banner << "#{framework.stats.num_payloads} payloads - #{framework.stats.num_encoders} encoders - #{framework.stats.num_nops} nops      ]\n"
+
+    # Direct the user to the 14-day free trial of Metasploit Pro unless
+    # they are on an apt install or already using Metasploit Pro,
+    # Express, or Community edition
+    unless binary_install
+      banner << "+ -- --=[ 14-Day free trial: http://metasploit.pro ]"
+    end
+
     if ( ::Msf::Framework::RepoRevision.to_i > 0 and ::Msf::Framework::RepoUpdatedDate)
       tstamp = ::Msf::Framework::RepoUpdatedDate.strftime("%Y.%m.%d")
       banner << "       =[ svn r#{::Msf::Framework::RepoRevision} updated #{::Msf::Framework::RepoUpdatedDaysNote} (#{tstamp})\n"
@@ -3038,6 +3046,18 @@ class Core
   # Determines if this is an apt-based install
   def is_apt
     File.exists?(File.expand_path(File.join(msfbase_dir, '.apt')))
+  end
+
+  # Determines if we're a Metasploit Pro/Community/Express
+  # installation or a tarball/git checkout
+  #
+  # @return [Boolean] true if we are a binary install
+  def binary_install
+    binary_paths = [
+      'C:/metasploit/apps/pro/msf3',
+      '/opt/metasploit/apps/pro/msf3'
+    ]
+    return binary_paths.include? Msf::Config.install_root
   end
 
   #


### PR DESCRIPTION
I like free software. I also like having the occasional paycheck so my kids don't complain about hunger pangs.
## Verification
### Rotating banner blurbs
- [x] Run `msfconsole`
- [x] **On a git source checkout**: You should **not** see the rotating blurbs
- [x] Copy `core.rb` to an installed binary version of Metasploit Community Edition on Windows, in `C:/metasploit/app/pro/msf3/lib/msf/ui/console/command_dispatcher/`
- [x] **On a Windows install**: You should see the rotating blurbs when you start `msfconsole`
- [x] Copy `core.rb` to an installed binary version of Metasploit Community Edition on Linux, in `/opt/metasploit/app/pro/msf3/lib/msf/ui/console/command_dispatcher/`
- [x] **On a Linux install**: You should see the rotating blurbs when you start `msfconsole`
### Static link to Metasploit Pro download
- [x] Run `msfconsole`
- [x] You should see the banner trailer with the shortlink:

```
       =[ metasploit v4.9.2-dev [core:4.9 api:1.0]        ]
+ -- --=[ 1294 exploits - 708 auxiliary - 204 post        ]
+ -- --=[ 335 payloads - 35 encoders - 8 nops             ]
+ -- --=[ Free Metasploit Pro trial: http://r-7.co/trymsp ]
```
- [x] Visiting the shortlink should lead to a Metasploit download page.
