### PR TITLE
support negation in portspec

### DIFF
--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -514,13 +514,13 @@ module Socket
 
     # Build ports array from port specification
     pspec.split(/,/).each do |item|
+      target = ports
+
       item.strip!
 
-      if item.starts_with? '!' then
-        negate = true
+      if item.start_with? '!'
         item.delete! '!'
-      else
-        negate = false
+        target = remove
       end
 
       start, stop = item.split(/-/).map { |p| p.to_i }
@@ -530,11 +530,7 @@ module Socket
 
       start, stop = stop, start if stop < start
 
-      if negate then
-        start.upto(stop) { |p| remove << p }
-      else
-        start.upto(stop) { |p| ports << p }
-      end
+      start.upto(stop) { |p| target << p }
     end
 
     if ports.empty? and not remove.empty? then

--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -505,14 +505,24 @@ module Socket
   end
 
   #
-  # Converts a port specification like "80,21-23,443" into a sorted,
-  # unique array of valid port numbers like [21,22,23,80,443]
+  # Converts a port specification like "80,21-25,!24,443" into a sorted,
+  # unique array of valid port numbers like [21,22,23,25,80,443]
   #
   def self.portspec_to_portlist(pspec)
     ports = []
+    remove = []
 
     # Build ports array from port specification
     pspec.split(/,/).each do |item|
+      item.strip!
+
+      if item.starts_with? '!' then
+        negate = true
+        item.delete! '!'
+      else
+        negate = false
+      end
+
       start, stop = item.split(/-/).map { |p| p.to_i }
 
       start ||= 0
@@ -520,11 +530,19 @@ module Socket
 
       start, stop = stop, start if stop < start
 
-      start.upto(stop) { |p| ports << p }
+      if negate then
+        start.upto(stop) { |p| remove << p }
+      else
+        start.upto(stop) { |p| ports << p }
+      end
+    end
+
+    if ports.empty? and not remove.empty? then
+      ports = 1.upto 65535
     end
 
     # Sort, and remove dups and invalid ports
-    ports.sort.uniq.delete_if { |p| p < 1 or p > 65535 }
+    ports.sort.uniq.delete_if { |p| p < 1 or p > 65535 or remove.include? p }
   end
 
   #

--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -538,11 +538,11 @@ module Socket
     end
 
     if ports.empty? and not remove.empty? then
-      ports = 1.upto 65535
+      ports = 0.upto 65535
     end
 
     # Sort, and remove dups and invalid ports
-    ports.sort.uniq.delete_if { |p| p < 1 or p > 65535 or remove.include? p }
+    ports.sort.uniq.delete_if { |p| p < 0 or p > 65535 or remove.include? p }
   end
 
   #
@@ -555,7 +555,7 @@ module Socket
     lastp  = nil
 
     parr.uniq.sort{|a,b| a<=>b}.map{|a| a.to_i}.each do |n|
-      next if (n < 1 or n > 65535)
+      next if (n < 0 or n > 65535)
       if not lastp
         range = [n]
         lastp = n

--- a/spec/lib/rex/socket_spec.rb
+++ b/spec/lib/rex/socket_spec.rb
@@ -163,4 +163,35 @@ describe Rex::Socket do
 
     end
   end
+
+  describe '.portspec_to_portlist' do
+
+    portspec = '-1,0-10,!2-5,!7,65530-,65536'
+    context "'#{portspec}'" do
+
+      subject { described_class.portspec_to_portlist portspec } 
+
+      it { should be_a(Array) }
+
+      not_included = []
+      not_included << -1
+      not_included << 65536
+      not_included.concat (2..5).to_a
+      not_included << 7
+      not_included.each do |item|
+        it { should_not include item }
+      end
+
+      included = []
+      included << -1
+      included.concat (0..10).to_a
+      included.concat (65530..65535).to_a
+      included << 65536
+      included = included - not_included
+      included.each do |item|
+        it { should include item }
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
When using the "services" command to get an overview over all services currently in the database, I found it useful to be able to exclude certain ports.
