### PR TITLE
Fix missing space in prompt for back and grep

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -344,7 +344,7 @@ class Core
       # Restore the prompt
       prompt = framework.datastore['Prompt'] || Msf::Ui::Console::Driver::DefaultPrompt
       prompt_char = framework.datastore['PromptChar'] || Msf::Ui::Console::Driver::DefaultPromptChar
-      driver.update_prompt("#{prompt}", prompt_char, true)
+      driver.update_prompt("#{prompt} ", prompt_char, true)
     end
   end
 
@@ -2609,7 +2609,7 @@ class Core
     if mod # if there is an active module, give them the fanciness they have come to expect
       driver.update_prompt("#{prompt} #{mod.type}(%bld%red#{mod.shortname}%clr) ", prompt_char, true)
     else
-      driver.update_prompt("#{prompt}", prompt_char, true)
+      driver.update_prompt("#{prompt} ", prompt_char, true)
     end
 
     # dump the command's output so we can grep it


### PR DESCRIPTION
**Problem description:**

This is a redux of #2161 without being quite as ambitious. See https://github.com/rapid7/metasploit-framework/pull/2161#issuecomment-21600253 for an example of the problem. This has been bugging me for a while.

**Verification steps:**
- [x] `use` a module
- [x] Run `back`
- [x] See that the prompt is `msf >` and not `msf>`
- [x] Run `grep grep grep`
- [x] See that the prompt is `msf >` and not `msf>`

**Sample run:**

```
msf > use exploit/windows/smb/ms08_067_netapi
msf exploit(ms08_067_netapi) > back
msf > grep grep grep
Usage: grep [options] pattern cmd
Grep the results of a console command (similar to Linux grep command)
msf >
```
