### PR TITLE
msftidy: Add ruby checks for warnings

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -64,7 +64,8 @@ class Msftidy
   #
   # @return status [Integer] Returns WARNINGS unless we already have an
   # error.
-  def warn(txt, line=0) line_msg = (line>0) ? ":#{line}" : ''
+  def warn(txt, line=0)
+    line_msg = (line>0) ? ":#{line}" : ''
     puts "#{@full_filepath}#{line_msg} - [#{'WARNING'.yellow}] #{cleanup_text(txt)}"
     @status == ERRORS ? @status = ERRORS : @status = WARNINGS
   end
@@ -504,6 +505,15 @@ class Msftidy
     end
   end
 
+  def check_ruby_warnings
+    res = %x{ruby -c -W2 #{@full_filepath} 2>&1}.split("\n").select {|msg| msg !~ /Syntax OK/}
+    res.each { |item|
+      # parse warnings
+      match = item.match(/(?<filename>.+):(?<linenumber>\d+):\s*(?<warning>.+)/)
+      warn(match[:warning], match[:linenumber].to_i)
+    }
+  end
+
   private
 
   def load_file(file)
@@ -548,6 +558,7 @@ def run_checks(full_filepath)
   tidy.check_comment_splat
   tidy.check_vuln_codes
   tidy.check_vars_get
+  tidy.check_ruby_warnings
   return tidy
 end
 

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -509,7 +509,7 @@ class Msftidy
     res = %x{ruby -c -W2 #{@full_filepath} 2>&1}.split("\n").select {|msg| msg !~ /Syntax OK/}
     res.each { |item|
       # parse warnings
-      match = item.match(/(?<filename>.+):(?<linenumber>\d+):\s*(?<warning>.+)/)
+      match = item.match(/(?<filename>.+?):(?<linenumber>\d+?):\s*(?<warning>.+)/)
       warn(match[:warning], match[:linenumber].to_i)
     }
   end


### PR DESCRIPTION
This adds ruby warning checks to msftidy

This generates a lot of additional warnings (3205), but it is handy to check new modules before commiting them, so no new warnings are generated.

```
find modules/ -type f -name "*.rb" -exec ruby -c -W2 {} \; 2>&1 | grep -v "Syntax OK" | wc -l
3205
```
