### PR TITLE
Rex::Text::uri_encode - make 'hex-all' really mean all.

### DIFF
--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -58,7 +58,7 @@ module Exploit::Remote::HttpClient
 
     register_evasion_options(
       [
-        OptEnum.new('HTTP::uri_encode_mode', [false, 'Enable URI encoding', 'hex-normal', ['none', 'hex-normal', 'hex-all', 'hex-random', 'u-normal', 'u-all', 'u-random']]),
+        OptEnum.new('HTTP::uri_encode_mode', [false, 'Enable URI encoding', 'hex-normal', ['none', 'hex-normal', 'hex-noslashes', 'hex-random', 'hex-all', 'u-normal', 'u-all', 'u-random']]),
         OptBool.new('HTTP::uri_full_url', [false, 'Use the full URL for all HTTP requests', false]),
         OptInt.new('HTTP::pad_method_uri_count', [false, 'How many whitespace characters to use between the method and uri', 1]),
         OptInt.new('HTTP::pad_uri_version_count', [false, 'How many whitespace characters to use between the uri and version', 1]),

--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -40,7 +40,7 @@ class ClientRequest
     #
     'encode_params'          => true,
     'encode'                 => false,
-    'uri_encode_mode'        => 'hex-normal', # hex-noslashes, hex-random, u-normal, u-random, u-all
+    'uri_encode_mode'        => 'hex-normal', # hex-all, hex-noslashes, hex-random, u-all, u-noslashes, u-random
     'uri_encode_count'       => 1,       # integer
     'uri_full_url'           => false,   # bool
     'pad_method_uri_count'   => 1,       # integer

--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -40,7 +40,7 @@ class ClientRequest
     #
     'encode_params'          => true,
     'encode'                 => false,
-    'uri_encode_mode'        => 'hex-normal', # hex-all, hex-noslashes, hex-random, u-all, u-noslashes, u-random
+    'uri_encode_mode'        => 'hex-normal', # hex-normal, hex-all, hex-noslashes, hex-random, u-normal, u-all, u-noslashes, u-random
     'uri_encode_count'       => 1,       # integer
     'uri_full_url'           => false,   # bool
     'pad_method_uri_count'   => 1,       # integer

--- a/lib/rex/proto/http/client_request.rb
+++ b/lib/rex/proto/http/client_request.rb
@@ -40,7 +40,7 @@ class ClientRequest
     #
     'encode_params'          => true,
     'encode'                 => false,
-    'uri_encode_mode'        => 'hex-normal', # hex-all, hex-random, u-normal, u-random, u-all
+    'uri_encode_mode'        => 'hex-normal', # hex-noslashes, hex-random, u-normal, u-random, u-all
     'uri_encode_count'       => 1,       # integer
     'uri_full_url'           => false,   # bool
     'pad_method_uri_count'   => 1,       # integer

--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -788,15 +788,18 @@ module Text
 
     return str if mode == 'none' # fast track no encoding
 
-    all = /[^\/\\]+/
+    all = /./
+    noslashes = /[^\/\\]+/
     # http://tools.ietf.org/html/rfc3986#section-2.3
     normal = /[^a-zA-Z0-9\/\\\.\-_~]+/
 
     case mode
-    when 'hex-normal'
-      return str.gsub(normal) { |s| Rex::Text.to_hex(s, '%') }
     when 'hex-all'
       return str.gsub(all) { |s| Rex::Text.to_hex(s, '%') }
+    when 'hex-normal'
+      return str.gsub(normal) { |s| Rex::Text.to_hex(s, '%') }
+    when 'hex-noslashes'
+      return str.gsub(noslashes) { |s| Rex::Text.to_hex(s, '%') }
     when 'hex-random'
       res = ''
       str.each_byte do |c|

--- a/lib/rex/text.rb
+++ b/lib/rex/text.rb
@@ -809,10 +809,12 @@ module Text
           b.gsub(normal){ |s| Rex::Text.to_hex(s, '%') } )
       end
       return res
-    when 'u-normal'
-      return str.gsub(normal) { |s| Rex::Text.to_hex(Rex::Text.to_unicode(s, 'uhwtfms'), '%u', 2) }
     when 'u-all'
       return str.gsub(all) { |s| Rex::Text.to_hex(Rex::Text.to_unicode(s, 'uhwtfms'), '%u', 2) }
+    when 'u-normal'
+      return str.gsub(normal) { |s| Rex::Text.to_hex(Rex::Text.to_unicode(s, 'uhwtfms'), '%u', 2) }
+    when 'u-noslashes'
+      return str.gsub(noslashes) { |s| Rex::Text.to_hex(Rex::Text.to_unicode(s, 'uhwtfms'), '%u', 2) }
     when 'u-random'
       res = ''
       str.each_byte do |c|

--- a/modules/exploits/multi/http/gitorious_graph.rb
+++ b/modules/exploits/multi/http/gitorious_graph.rb
@@ -55,7 +55,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # Make sure the URI begins with a slash
     uri = normalize_uri(datastore['URI'])
 
-    command = Rex::Text.uri_encode(payload.raw, 'hex-all')
+    command = Rex::Text.uri_encode(payload.raw, 'hex-noslashes')
     command.gsub!("%20","%2520")
     res = send_request_cgi({
       'uri'     => "/api"+ uri + "/log/graph/%60#{command}%60",

--- a/modules/exploits/multi/http/php_cgi_arg_injection.rb
+++ b/modules/exploits/multi/http/php_cgi_arg_injection.rb
@@ -1,4 +1,4 @@
-s##
+##
 # This module requires Metasploit: http//metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##

--- a/modules/exploits/multi/http/php_cgi_arg_injection.rb
+++ b/modules/exploits/multi/http/php_cgi_arg_injection.rb
@@ -1,4 +1,4 @@
-##
+s##
 # This module requires Metasploit: http//metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
@@ -196,7 +196,7 @@ class Metasploit3 < Msf::Exploit::Remote
         max.times { chars << rand(string.length)}
       end
     end
-    chars.uniq.sort.reverse.each{|index|  string[index] = Rex::Text.uri_encode(string[index,1], "hex-all")}
+    chars.uniq.sort.reverse.each{|index|  string[index] = Rex::Text.uri_encode(string[index,1], "hex-noslashes")}
     string
   end
 

--- a/modules/exploits/multi/http/spree_search_exec.rb
+++ b/modules/exploits/multi/http/spree_search_exec.rb
@@ -51,7 +51,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    command = Rex::Text.uri_encode(payload.raw, 'hex-all')
+    command = Rex::Text.uri_encode(payload.raw, 'hex-noslashes')
     res = send_request_raw({
       'uri'     => normalize_uri(datastore['URI']) + "?search[send][]=eval&search[send][]=Kernel.fork%20do%60#{command}%60end",
       'method'  => 'GET',

--- a/modules/exploits/multi/http/spree_searchlogic_exec.rb
+++ b/modules/exploits/multi/http/spree_searchlogic_exec.rb
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    command = Rex::Text.uri_encode(payload.raw, 'hex-all')
+    command = Rex::Text.uri_encode(payload.raw, 'hex-noslashes')
 
     urlconfigdir = normalize_uri(datastore['URI']) + '/' + "api/orders.json?search[instance_eval]=Kernel.fork%20do%60#{command}%60end"
     res = send_request_raw({

--- a/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
+++ b/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
@@ -182,7 +182,7 @@ class Metasploit3 < Msf::Exploit::Remote
       sploit << self.send(my_target[:rop])
       sploit << p.encoded
 
-      resp['Location'] = request.uri + '.pdf?' + Rex::Text.uri_encode(sploit, 'hex-all')
+      resp['Location'] = request.uri + '.pdf?' + Rex::Text.uri_encode(sploit, 'hex-noslashes')
       cli.send_response(resp)
 
       # handle the payload

--- a/spec/lib/rex/proto/http/client_request_spec.rb
+++ b/spec/lib/rex/proto/http/client_request_spec.rb
@@ -247,10 +247,10 @@ describe Rex::Proto::Http::ClientRequest do
         let(:encode_mode) { 'hex-all' }
         it "should encode all chars" do
           str = client_request.to_s
-          str.should include("%66%6f%6f%5b%5d%3d%62%61%72")
-          str.should include("%62%61%72%3d%62%61%7a")
-          str.should include("%66%72%6f%62%6e%69%63%61%74%65%3d%74%68%65%20%66%72%6f%6f%7a%6c%65%3f")
-          str.should include("%66%6f%73%68%69%7a%7a%6c%65%3d%6d%79%2f%6e%69%7a%7a%6c%65")
+          str.should include("%66%6f%6f%5b%5d=%62%61%72")
+          str.should include("%62%61%72=%62%61%7a")
+          str.should include("%66%72%6f%62%6e%69%63%61%74%65=%74%68%65%20%66%72%6f%6f%7a%6c%65%3f")
+          str.should include("%66%6f%73%68%69%7a%7a%6c%65=%6d%79%2f%6e%69%7a%7a%6c%65")
         end
       end
 

--- a/spec/lib/rex/proto/http/client_request_spec.rb
+++ b/spec/lib/rex/proto/http/client_request_spec.rb
@@ -229,8 +229,8 @@ describe Rex::Proto::Http::ClientRequest do
         end
       end
 
-      context "and 'uri_encode_mode' = hex-all" do
-        let(:encode_mode) { 'hex-all' }
+      context "and 'uri_encode_mode' = hex-noslashes" do
+        let(:encode_mode) { 'hex-noslashes' }
         it "should encode all chars" do
           str = client_request.to_s
           str.should include("%66%6f%6f%5b%5d=%62%61%72")

--- a/spec/lib/rex/proto/http/client_request_spec.rb
+++ b/spec/lib/rex/proto/http/client_request_spec.rb
@@ -189,6 +189,7 @@ describe Rex::Proto::Http::ClientRequest do
         'foo[]'      => 'bar',
         'bar'        => 'baz',
         'frobnicate' => 'the froozle?',
+        'foshizzle'  => 'my/nizzle',
       }
     end
 
@@ -215,6 +216,7 @@ describe Rex::Proto::Http::ClientRequest do
         str.should include("foo[]=bar")
         str.should include("bar=baz")
         str.should include("frobnicate=the froozle?")
+        str.should include("foshizzle=my/nizzle")
       end
     end
 
@@ -226,6 +228,7 @@ describe Rex::Proto::Http::ClientRequest do
           str.should include("foo%5b%5d=bar")
           str.should include("bar=baz")
           str.should include("frobnicate=the%20froozle%3f")
+          str.should include("foshizzle=my/nizzle")
         end
       end
 
@@ -236,6 +239,18 @@ describe Rex::Proto::Http::ClientRequest do
           str.should include("%66%6f%6f%5b%5d=%62%61%72")
           str.should include("%62%61%72=%62%61%7a")
           str.should include("%66%72%6f%62%6e%69%63%61%74%65=%74%68%65%20%66%72%6f%6f%7a%6c%65%3f")
+          str.should include("%66%6f%73%68%69%7a%7a%6c%65=%6d%79/%6e%69%7a%7a%6c%65")
+        end
+      end
+
+      context "and 'uri_encode_mode' = hex-all" do
+        let(:encode_mode) { 'hex-all' }
+        it "should encode all chars" do
+          str = client_request.to_s
+          str.should include("%66%6f%6f%5b%5d%3d%62%61%72")
+          str.should include("%62%61%72%3d%62%61%7a")
+          str.should include("%66%72%6f%62%6e%69%63%61%74%65%3d%74%68%65%20%66%72%6f%6f%7a%6c%65%3f")
+          str.should include("%66%6f%73%68%69%7a%7a%6c%65%3d%6d%79%2f%6e%69%7a%7a%6c%65")
         end
       end
 


### PR DESCRIPTION
'hex-all' encoding was previously ignoring slashes.  For example "a/b" would return "%61/%62" rather than the expected "%61%2f%62".

This pull adds 'hex-noslashes' mode which carries forward the previous functionality, and replaces all existing references to 'hex-all' with 'hex-noslashes'  It then adds a replacement 'hex-all' mode, which really encodes _ALL_ characters.
