### PR TITLE
Resolved some msftidy warnings (Set-Cookie)

### DIFF
--- a/modules/auxiliary/admin/2wire/xslt_password_reset.rb
+++ b/modules/auxiliary/admin/2wire/xslt_password_reset.rb
@@ -130,7 +130,8 @@ class Metasploit3 < Msf::Auxiliary
       }, 25)
 
       if res and res.code == 200
-        if (res.headers['Set-Cookie'] and res.headers['Set-Cookie'].match(/(.*); path=\//))
+        cookies = res.get_cookies
+        if cookies && cookies.match(/(.*); path=\//)
           cookie= $1
           print_status("Got cookie #{cookie}. Password reset was successful!\n")
         end

--- a/modules/auxiliary/admin/http/axigen_file_access.rb
+++ b/modules/auxiliary/admin/http/axigen_file_access.rb
@@ -167,7 +167,7 @@ class Metasploit3 < Msf::Auxiliary
 
     if res and res.code == 303 and res.headers['Location'] =~ /_h=([a-f0-9]*)/
       @token = $1
-      if res.headers['Set-Cookie'] =~ /_hadmin=([a-f0-9]*)/
+      if res.get_cookies =~ /_hadmin=([a-f0-9]*)/
         @session = $1
         return true
       end

--- a/modules/auxiliary/admin/http/cfme_manageiq_evm_pass_reset.rb
+++ b/modules/auxiliary/admin/http/cfme_manageiq_evm_pass_reset.rb
@@ -113,7 +113,7 @@ class Metasploit4 < Msf::Auxiliary
       print_error($1)
       return
     else
-      session = $1 if res.headers['Set-Cookie'] =~ /_vmdb_session=(\h*)/
+      session = $1 if res.get_cookies =~ /_vmdb_session=(\h*)/
 
       if session.nil?
         print_error('Failed to retrieve the current session id')

--- a/modules/auxiliary/admin/http/foreman_openstack_satellite_priv_esc.rb
+++ b/modules/auxiliary/admin/http/foreman_openstack_satellite_priv_esc.rb
@@ -67,7 +67,7 @@ class Metasploit4 < Msf::Auxiliary
       print_error('Authentication failed')
       return
     else
-      session = $1 if res.headers['Set-Cookie'] =~ /_session_id=([0-9a-f]*)/
+      session = $1 if res.get_cookies =~ /_session_id=([0-9a-f]*)/
 
       if session.nil?
         print_error('Failed to retrieve the current session id')

--- a/modules/auxiliary/admin/http/mutiny_frontend_read_delete.rb
+++ b/modules/auxiliary/admin/http/mutiny_frontend_read_delete.rb
@@ -139,7 +139,7 @@ class Metasploit3 < Msf::Auxiliary
         'method' => 'GET'
       })
 
-    if res and res.code == 200 and res.headers['Set-Cookie'] =~ /JSESSIONID=(.*);/
+    if res and res.code == 200 and res.get_cookies =~ /JSESSIONID=(.*);/
       first_session = $1
     end
 
@@ -165,7 +165,7 @@ class Metasploit3 < Msf::Auxiliary
       'cookie' => "JSESSIONID=#{first_session}"
     })
 
-    if res and res.code == 200 and res.headers['Set-Cookie'] =~ /JSESSIONID=(.*);/
+    if res and res.code == 200 and res.get_cookies =~ /JSESSIONID=(.*);/
       @session = $1
       return true
     end

--- a/modules/auxiliary/admin/http/tomcat_administration.rb
+++ b/modules/auxiliary/admin/http/tomcat_administration.rb
@@ -73,9 +73,9 @@ class Metasploit3 < Msf::Auxiliary
               'uri'     => '/admin/',
             }, 25)
 
-            if (res and res.code == 200)
+            if res && res.code == 200
 
-              if (res.headers['Set-Cookie'] and res.headers['Set-Cookie'].match(/JSESSIONID=(.*);(.*)/i))
+              if res.get_cookies.match(/JSESSIONID=(.*);(.*)/i)
 
                 jsessionid = $1
 

--- a/modules/auxiliary/admin/oracle/osb_execqr2.rb
+++ b/modules/auxiliary/admin/oracle/osb_execqr2.rb
@@ -49,9 +49,7 @@ class Metasploit3 < Msf::Auxiliary
         'method' => 'POST',
       }, 5)
 
-      if (res and res.headers['Set-Cookie'] and res.headers['Set-Cookie'].match(/PHPSESSID=(.*);(.*)/i))
-
-        sessionid = res.headers['Set-Cookie'].split(';')[0]
+      if res && res.get_cookies.match(/PHPSESSID=(.*);(.*)/i)
 
           print_status("Sending command: #{datastore['CMD']}...")
 
@@ -59,7 +57,7 @@ class Metasploit3 < Msf::Auxiliary
             {
               'uri'	=> '/property_box.php',
               'data'  => 'type=Sections&vollist=75' + Rex::Text.uri_encode("&" + cmd),
-              'cookie' => sessionid,
+              'cookie' => res.get_cookies,
               'method' => 'POST',
             }, 5)
 

--- a/modules/auxiliary/admin/oracle/osb_execqr3.rb
+++ b/modules/auxiliary/admin/oracle/osb_execqr3.rb
@@ -46,9 +46,7 @@ class Metasploit3 < Msf::Auxiliary
         'method' => 'POST',
       }, 5)
 
-      if (res and res.headers['Set-Cookie'] and res.headers['Set-Cookie'].match(/PHPSESSID=(.*);(.*)/i))
-
-        sessionid = res.headers['Set-Cookie'].split(';')[0]
+      if res && res.get_cookies.match(/PHPSESSID=(.*);(.*)/i)
 
           print_status("Sending command: #{datastore['CMD']}...")
 
@@ -56,7 +54,7 @@ class Metasploit3 < Msf::Auxiliary
             {
               'uri'	=> '/property_box.php',
               'data'  => 'type=Job&jlist=' + Rex::Text.uri_encode('&' + cmd),
-              'cookie' => sessionid,
+              'cookie' => res.get_cookies,
               'method' => 'POST',
             }, 5)
 

--- a/modules/auxiliary/admin/webmin/edit_html_fileaccess.rb
+++ b/modules/auxiliary/admin/webmin/edit_html_fileaccess.rb
@@ -68,8 +68,8 @@ class Metasploit3 < Msf::Auxiliary
         'data'    => data
       }, 25)
 
-    if res and res.code == 302 and res.headers['Set-Cookie'] =~ /sid/
-      session = res.headers['Set-Cookie'].scan(/sid\=(\w+)\;*/).flatten[0] || ''
+    if res and res.code == 302 and res.get_cookies =~ /sid/
+      session = res.get_cookies.scan(/sid\=(\w+)\;*/).flatten[0] || ''
       if session and not session.empty?
         print_good "#{peer} - Authentication successful"
       else

--- a/modules/auxiliary/fuzzers/http/http_form_field.rb
+++ b/modules/auxiliary/fuzzers/http/http_form_field.rb
@@ -455,21 +455,23 @@ class Metasploit3 < Msf::Auxiliary
       formidx = formidx + 1
       formcnt += 1
     end
+
     if forms.size > 0
       print_status("    Forms : ")
     end
+
     forms.each do | thisform |
       print_status("     - Name : #{thisform[:name]}, ID : #{thisform[:id]}, Action : #{thisform[:action]}, Method : #{thisform[:method]}")
     end
+
     return forms
   end
-  def extract_cookie(body)
-    return body["Set-Cookie"]
-  end
+
   def set_cookie(cookie)
     @get_data_headers["Cookie"]=cookie
     @send_data[:headers]["Cookie"]=cookie
   end
+
   def run
     init_fuzzdata()
     init_vars()
@@ -487,10 +489,11 @@ class Metasploit3 < Msf::Auxiliary
       print_error("No response")
       return
     end
+
     if datastore['HANDLECOOKIES']
-      cookie = extract_cookie(response.headers)
+      cookie = response.get_cookies
       set_cookie(cookie)
-      print_status("Set cookie:#{cookie}")
+      print_status("Set cookie: #{cookie}")
       print_status("Grabbing webpage #{datastore['URL']} from #{datastore['RHOST']} using cookies")
 
       response = send_request_raw(

--- a/modules/auxiliary/gather/apache_rave_creds.rb
+++ b/modules/auxiliary/gather/apache_rave_creds.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Auxiliary
       }
     })
 
-    if res and res.code == 302 and res.headers['Location'] !~ /authfail/ and res.headers['Set-Cookie'] =~ /JSESSIONID=(.*);/
+    if res and res.code == 302 and res.headers['Location'] !~ /authfail/ and res.get_cookies =~ /JSESSIONID=(.*);/
       return $1
     else
       return nil

--- a/modules/auxiliary/gather/doliwamp_traversal_creds.rb
+++ b/modules/auxiliary/gather/doliwamp_traversal_creds.rb
@@ -128,7 +128,7 @@ class Metasploit3 < Msf::Auxiliary
     })
     if !res
       print_error("#{peer} - Connection failed")
-    elsif res.code == 200 and res.headers["set-cookie"] =~ /DOLSESSID_([a-f0-9]{32})=/
+    elsif res.code == 200 and res.get_cookies =~ /DOLSESSID_([a-f0-9]{32})=/
       return "DOLSESSID_#{$1}=#{token}"
     else
       print_warning("#{peer} - Could not create session cookie")

--- a/modules/auxiliary/scanner/http/cisco_asa_asdm.rb
+++ b/modules/auxiliary/scanner/http/cisco_asa_asdm.rb
@@ -80,7 +80,7 @@ class Metasploit3 < Msf::Auxiliary
 
       if res &&
          res.code == 200 &&
-         res.headers['Set-Cookie'].match(/webvpn/)
+         res.get_cookies.include?('webvpn')
 
         return true
       else

--- a/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
+++ b/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
@@ -77,15 +77,15 @@ class Metasploit3 < Msf::Auxiliary
         'method'    => 'GET'
       })
 
-      if (res and res.headers['Set-Cookie'])
+      if res && res.get_cookies
 
-        cookie = res.headers['Set-Cookie'].split('; ')[0]
+        cookie = res.get_cookies
 
         res = send_request_cgi(
         {
           'uri'       => "/help/wwhelp/wwhimpl/common/html/default.htm",
           'method'    => 'GET',
-          'cookie'	   => '#{cookie}'
+          'cookie'	   => cookie
         })
 
         if (res and res.code == 200 and res.body.include?('Cisco IronPort AsyncOS'))
@@ -135,7 +135,7 @@ class Metasploit3 < Msf::Auxiliary
           }
       })
 
-      if (res and res.headers['Set-Cookie'].include?('authenticated='))
+      if res and res.get_cookies.include?('authenticated=')
         print_good("#{rhost}:#{rport} - SUCCESSFUL LOGIN - #{user.inspect}:#{pass.inspect}")
 
         report_hash = {

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -476,8 +476,8 @@ class Msftidy
         error("datastore is modified in code: #{ln}", idx)
       end
 
-      # do not read Set-Cookie header
-      if ln =~ /\[['"]Set-Cookie['"]\]/i
+      # do not read Set-Cookie header (ignore commented lines)
+      if ln =~ /^(?!\s*#).+\[['"]Set-Cookie['"]\]/i
         warn("Do not read Set-Cookie header directly, use res.get_cookies instead: #{ln}", idx)
       end
 


### PR DESCRIPTION
Title says it all.

BTW: The cisco_ironport_enum module never worked correctly because of single apostrophes:

```
'cookie'       => '#{cookie}'
```

I will have a look if we can check this.
