### PR TITLE
Support active_module datastore options

### DIFF
--- a/scripts/shell/spawn_meterpreter.rb
+++ b/scripts/shell/spawn_meterpreter.rb
@@ -33,7 +33,7 @@ end
 #
 # Mimics what MSF alreayd does if the user doesn't manually select a payload and lhost
 #
-lhost = framework.datastore['LHOST']
+lhost = active_module.datastore['LHOST'] || framework.datastore['LHOST']
 unless lhost
   lhost = Rex::Socket.source_address
 end
@@ -43,7 +43,7 @@ end
 # by current sessions. This is possible if the user assumes module datastore options
 # are the same as framework datastore options.
 #
-lport = framework.datastore['LPORT']
+lport = active_module.datastore['LPORT'] || framework.datastore['LPORT']
 unless lport
   lport = 4444 # Default meterpreter port
   while is_port_used?(lport)


### PR DESCRIPTION
See #3302.

To verify:
- [ ] If you're on a module, when you set a LHOST or LPORT, the script should use that.
- [ ] If you're not on a module (that'd be the msf prompt), the script should fall back to framework's options instead.
- [ ] If Nothing is set, the script should automatically set a LHOST and/pr LPORT.
