### PR TITLE
Aux modules don't respect Rank anyway

### DIFF
--- a/modules/auxiliary/dos/hp/data_protector_rds.rb
+++ b/modules/auxiliary/dos/hp/data_protector_rds.rb
@@ -6,7 +6,6 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Auxiliary
-  Rank = ManualRanking
 
   include Msf::Exploit::Remote::Tcp
   include Msf::Auxiliary::Dos

--- a/modules/auxiliary/dos/tcp/junos_tcp_opt.rb
+++ b/modules/auxiliary/dos/tcp/junos_tcp_opt.rb
@@ -10,9 +10,6 @@ class Metasploit3 < Msf::Auxiliary
   include Msf::Exploit::Capture
   include Msf::Auxiliary::Dos
 
-  # The whole point is to cause a router crash.
-  Rank = ManualRanking
-
   def initialize
     super(
       'Name'        => 'Juniper JunOS Malformed TCP Option',

--- a/modules/auxiliary/dos/windows/smb/ms11_019_electbowser.rb
+++ b/modules/auxiliary/dos/windows/smb/ms11_019_electbowser.rb
@@ -4,7 +4,6 @@
 ##
 
 class Metasploit3 < Msf::Auxiliary
-  Rank = ManualRanking
 
   include Msf::Exploit::Remote::Udp
   #include Msf::Exploit::Remote::SMB


### PR DESCRIPTION
## Verification
- [x] Load the affected modules
- [x] Since Rank was a nop anyway, no other functionality is impacted.

See https://dev.metasploit.com/redmine/issues/8498

Landing this should have in the merge commit message:

`FixRM: #8498`
