### PR TITLE
Fix random bug when workstation_name is < 6 chars

### DIFF
--- a/lib/rex/proto/http/client.rb
+++ b/lib/rex/proto/http/client.rb
@@ -480,7 +480,7 @@ class Client
     opts['headers']||= {}
 
     ntlmssp_flags = ::Rex::Proto::NTLM::Utils.make_ntlm_flags(ntlm_options)
-    workstation_name = Rex::Text.rand_text_alpha(rand(8)+1)
+    workstation_name = Rex::Text.rand_text_alpha(rand(8)+6)
     domain_name = self.config['domain']
 
     b64_blob = Rex::Text::encode_base64(


### PR DESCRIPTION
When the local workstation name is less than 6 characters, remote
authentication against a Windows 2008r2 WinRM service always fails. This
doesn't seem to affect authentication against IIS's negotiate
implementation.

VERIFICATION
On a target system:
- [x] Set up winrm server as local admin
  - `winrm quickconfig`
  - `winrm set winrm/config/service @{AllowUnencrypted="true"}`
- [x] Add msfadmin if you don't already have one `net user /add msfadmin msfadmin` 
- [x] Add msfadmin to local admins `net localgroup administrators /add msfadmin`

On attack platform:
- [x] launch msfconsole
- [x] `use auxiliary/scanner/winrm/winrm_login`
- [x] set RHOST to the address of the Windows box you set up with the above
- [x] `set USERNAME msfadmin`
- [x] `set PASSWORD msfadmin`
- [x] `run` a bunch of times
- [x] VERIFY: **before** - intermittent failures with valid credentials; **after** - success every time
