### PR TITLE
Overhaul of OS fingerprinting with Recog support

### DIFF
--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -81,5 +81,5 @@ Gem::Specification.new do |spec|
   # required for Time::TZInfo in ActiveSupport
   spec.add_runtime_dependency 'tzinfo'
   # required for OS fingerprinting
-  spec.add_runtime_dependency 'recog', '~> 1.0.0'
+  spec.add_runtime_dependency 'recog', '~> 1.0'
 end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -81,5 +81,5 @@ Gem::Specification.new do |spec|
   # required for Time::TZInfo in ActiveSupport
   spec.add_runtime_dependency 'tzinfo'
   # required for OS fingerprinting
-  spec.add_runtime_dependency 'recog'
+  spec.add_runtime_dependency 'recog', '~> 1.0.0'
 end


### PR DESCRIPTION
This reimplements much of the OS fingerprinting within the Metasploit Framework. Client-side and server-side fingerprints can now take advantage of [Recog](https://github.com/rapid7/recog) and the Recog-enabled MDM gem. 

The changes are backwards-compatible, but they do change how os_name and os_flavor fields are handled. Previously, an OS match of "Windows XP" would be split into an os_name of "Windows" and an os_flavor of "XP". The new code would treat os_name as "Windows XP" and save os_flavor for the product edition (Home, Pro, etc). This change is cosmetic and mostly transparent given how most callers treat these fields (they merge them together for display).
