### PR TITLE
[SeeRM #8803] Avoid false positives when checking fb_cnct_group

### DIFF
--- a/modules/exploits/windows/misc/fb_cnct_group.rb
+++ b/modules/exploits/windows/misc/fb_cnct_group.rb
@@ -92,7 +92,6 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     opcode = data.unpack("N*")[0]
-    version = data.unpack("N*")[1]
     if opcode == 3 # Accept
       return Exploit::CheckCode::Detected
     end

--- a/modules/exploits/windows/misc/fb_cnct_group.rb
+++ b/modules/exploits/windows/misc/fb_cnct_group.rb
@@ -94,9 +94,6 @@ class Metasploit3 < Msf::Exploit::Remote
     opcode = data.unpack("N*")[0]
     version = data.unpack("N*")[1]
     if opcode == 3 # Accept
-      if [ 0xffff800b, 0xffff800c ].include?(version)
-        return Exploit::CheckCode::Vulnerable
-      end
       return Exploit::CheckCode::Detected
     end
 


### PR DESCRIPTION
## Verification
- [x] Install Firebird-2.5.2.26540_0_Win32
- [x] Run the check from the module without this pull request, it should report the service as vulnerable

```
msf > use exploit/windows/misc/fb_cnct_group
msf exploit(fb_cnct_group) > show options

Module options (exploit/windows/misc/fb_cnct_group):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   RHOST                   yes       The target address
   RPORT  3050             yes       The target port


Exploit target:

   Id  Name
   --  ----
   0   Windows FB 2.5.2.26539


msf exploit(fb_cnct_group) > set rhost 172.16.158.157
rhost => 172.16.158.157
msf exploit(fb_cnct_group) > check
[+] 172.16.158.157:3050 - The target is vulnerable.
```
- [x] Try to exploit it with the Debug target, no crash, the service continues running

```
msf exploit(fb_cnct_group) > set target 4
target => 4
msf exploit(fb_cnct_group) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] 172.16.158.157:3050 - Sending Connection Request For C:\qQjFtirEcKHvQ.fdb
[*] Exploit completed, but no session was created.
msf exploit(fb_cnct_group) > check
[+] 172.16.158.157:3050 - The target is vulnerable.
```
- [x] Try to check with this pull request change applied, the service shouldn't be reported as vulnerable but detected:

```
msf exploit(fb_cnct_group) > check
[*] 172.16.158.157:3050 - The target service is running, but could not be validated.
```
