### PR TITLE
Msftidy should merely INFO on datastore edits

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -11,6 +11,7 @@ require 'find'
 require 'time'
 
 CHECK_OLD_RUBIES = !!ENV['MSF_CHECK_OLD_RUBIES']
+SUPRESS_INFO_MESSAGES = !!ENV['MSF_SUPPRESS_INFO_MESSAGES']
 
 if CHECK_OLD_RUBIES
   require 'rvm'
@@ -91,6 +92,7 @@ class Msftidy
   # Display an info message. Info messages do not alter the exit status.
   #
   def info(txt, line=0)
+    return if SUPRESS_INFO_MESSAGES
     line_msg = (line>0) ? ":#{line}" : ''
     puts "#{@full_filepath}#{line_msg} - [#{'INFO'.cyan}] #{cleanup_text(txt)}"
   end

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -471,9 +471,12 @@ class Msftidy
         error("Writes to stdout", idx)
       end
 
-      # do not change datastore in code
+      # You should not change datastore in code. For reasons. See
+      # RM#8498 for discussion, starting at comment #16:
+      #
+      # https://dev.metasploit.com/redmine/issues/8498#note-16
       if ln =~ /(?<!\.)datastore\[["'][^"']+["']\]\s*=(?![=~>])/
-        error("datastore is modified in code: #{ln}", idx)
+        info("datastore is modified in code: #{ln}", idx)
       end
 
       # do not read Set-Cookie header (ignore commented lines)


### PR DESCRIPTION
See the redmine bug [note 16](https://dev.metasploit.com/redmine/issues/8498#note-16) for reasoning. I think it's sound. If I'm crazy (looking at you @limhoff-r7 and @jlee-r7) then please stop me and we'll go through and fix these datastore edits for real. I just don't any case where someone has complained of a module failing, under any circumstance, when the datastore is edited at runtime.

@jvazquez-r7 has a theory that some edits can mess up payload generation, but I expect those cases are only when rport/rhost/lport/lhost is modified at runtime. If that's true, we should tighten up the WARN rule just for that.
## Verification
- [x] Run `tools/msftidy modules | grep ERROR | wc -l` and see a large number (around 132, which is the current count).
- [x] Switch to this branch, or merge this branch, and run the same command, seeing a small number of errors (I count 2 right now)
- [x] Run `tools/msftidy modules |grep INFO | wc -l` and see a large number (156 right now).
- [x] Run `MSF_SUPPRESS_INFO_MESSAGES=1 tools/msftidy.rb modules/
  |grep INFO | wc -l` and see a large a smaller number (under 50).
- [x] Merge with a merge message in the body of `SeeRM 8498` in order to update the Redmine ticket.

Note that developers should not avoid the INFO message via environment vars, this change in behavior is pretty much just to keep travis log lines a little reasonable.
