### PR TITLE
Support RHOSTS for msfcli (C)heck mode

### DIFF
--- a/msfcli
+++ b/msfcli
@@ -424,17 +424,44 @@ class Msfcli
 
   def show_check(m)
     begin
-      if (code = m[:module].check_simple(
-        'LocalInput'    => Rex::Ui::Text::Input::Stdio.new,
-        'LocalOutput'   => Rex::Ui::Text::Output::Stdio.new))
-        stat = (code == Msf::Exploit::CheckCode::Vulnerable) ? '[+]' : '[*]'
-
-        $stdout.puts("#{stat} #{code[1]}")
+      if m[:module].datastore['RHOSTS']
+        module_check_multiple(m)
       else
-        $stdout.puts("Check failed: The state could not be determined.")
+        module_check_simple(m)
       end
     rescue
       $stdout.puts("Check failed: #{$!}")
+    end
+  end
+
+  def module_check_multiple(m)
+    rhost = m[:module].datastore['RHOST']
+    rhosts = m[:module].datastore['RHOSTS']
+    hosts = Rex::Socket::RangeWalker.new(rhosts)
+    $stdout.puts "[*] Checking #{(rhost ? "#{rhost}, " : "")}#{rhosts}"
+    if m[:module].datastore['RHOST']
+      module_check_simple(m)
+    end
+    hosts.each do |ip|
+      m[:module].datastore['RHOST'] = ip
+      module_check_simple(m)
+    end
+  end
+
+  def module_check_simple(m)
+    rhost = m[:module].datastore['RHOST']
+    rport = m[:module].datastore['RPORT']
+    peer = [rhost,rport].join(":")
+    opts = {
+      'LocalInput'    => Rex::Ui::Text::Input::Stdio.new,
+      'LocalOutput'   => Rex::Ui::Text::Output::Stdio.new
+    }
+    code = m[:module].check_simple(opts)
+    if code
+      stat = (code == Msf::Exploit::CheckCode::Vulnerable) ? '[+]' : '[*]'
+      $stdout.puts("#{stat} #{peer} - #{code[1]}")
+    else
+      $stdout.puts("[-] #{peer} - Check failed: The state could not be determined.")
     end
   end
 


### PR DESCRIPTION
One of my favorite users, @sho-luv, noticed that RHOSTS doesn't work when you want to run a (C)heck from msfcli.

I've addressed this by simply stomping on the RHOST field and iterating over the given RHOSTS option. Since msfcli is a oneshot, we don't need to worry about preserving RHOST after the run on the module.
## Verification

Run the following commands, using your own preferred IP addresses.
- [ ] Demonstrate concatination of RHOST and RHOSTS, and the nmap-style comma-seperated last octets.: `./msfcli exploit/windows/smb/ms08_067_netapi RHOST=10.1.1.1 RHOSTS=192.168.145.60,191,137 C` 
- [ ]  Demo CIDR notation: `./msfcli exploit/windows/smb/ms08_067_netapi RHOST=10.1.1.1 RHOSTS=192.168.145.60/30 C`
- [ ]  Demo that RHOST is not necessary to set (since we're doing it internally): `./msfcli exploit/windows/smb/ms08_067_netapi RHOSTS=192.168.145.60,137 C`
- [ ] Demos hyphen ranges: `./msfcli exploit/windows/smb/ms08_067_netapi RHOSTS=192.168.145.59-61 C`
## Expected Results:

```
[ruby-1.9.3-p484@metasploit-framework] (multicheck-msfcli-compat) 
todb@mazikeen:~/git/rapid7/metasploit-framework
$ ./msfcli exploit/windows/smb/ms08_067_netapi RHOST=10.1.1.1 RHOSTS=192.168.145.60,191,137 C
[*] Initializing modules...
[*] Checking 10.1.1.1, 192.168.145.60,191,137
[*] 10.1.1.1:445 - Cannot reliably check exploitability.
[+] 192.168.145.60:445 - The target is vulnerable.
[*] 192.168.145.137:445 - The target is not exploitable.
[*] 192.168.145.191:445 - The target is not exploitable.

[ruby-1.9.3-p484@metasploit-framework] (multicheck-msfcli-compat) 
todb@mazikeen:~/git/rapid7/metasploit-framework
$ ./msfcli exploit/windows/smb/ms08_067_netapi RHOST=10.1.1.1 RHOSTS=192.168.145.60/30 C
[*] Initializing modules...
[*] Checking 10.1.1.1, 192.168.145.60/30
[*] 10.1.1.1:445 - Cannot reliably check exploitability.
[+] 192.168.145.60:445 - The target is vulnerable.
[*] 192.168.145.61:445 - Cannot reliably check exploitability.
[*] 192.168.145.62:445 - Cannot reliably check exploitability.
[*] 192.168.145.63:445 - Cannot reliably check exploitability.

[ruby-1.9.3-p484@metasploit-framework] (multicheck-msfcli-compat) 
todb@mazikeen:~/git/rapid7/metasploit-framework
$ ./msfcli exploit/windows/smb/ms08_067_netapi RHOSTS=192.168.145.60,137 C
[*] Initializing modules...
[*] Checking 192.168.145.60,137
[+] 192.168.145.60:445 - The target is vulnerable.
[*] 192.168.145.137:445 - The target is not exploitable.

[ruby-1.9.3-p484@metasploit-framework] (multicheck-msfcli-compat) 
todb@mazikeen:~/git/rapid7/metasploit-framework
$ ./msfcli exploit/windows/smb/ms08_067_netapi RHOSTS=192.168.145.59-61 C
[*] Initializing modules...
[*] Checking 192.168.145.59-61
[*] 192.168.145.59:445 - Cannot reliably check exploitability.
[+] 192.168.145.60:445 - The target is vulnerable.
[*] 192.168.145.61:445 - Cannot reliably check exploitability.

[ruby-1.9.3-p484@metasploit-framework] (multicheck-msfcli-compat) 
todb@mazikeen:~/git/rapid7/metasploit-framework
$ 
```
## Caveats

the `file:/path/to/file` format is not supported in this mode -- but it's not supported in the usual `msfconsole` implementation either. So... not a new bug, no missing functionality.
