### PR TITLE
Add CVE, IBM ref for SameTime modules

### DIFF
--- a/modules/auxiliary/gather/ibm_sametime_enumerate_users.rb
+++ b/modules/auxiliary/gather/ibm_sametime_enumerate_users.rb
@@ -24,6 +24,11 @@ class Metasploit3 < Msf::Auxiliary
         [
           'kicks4kittens' # Metasploit module
         ],
+      'References' =>
+        [
+          [ 'CVE', '2013-3975' ],
+          [ 'URL', 'http://www-01.ibm.com/support/docview.wss?uid=swg21671201']
+        ],
       'DefaultOptions' =>
         {
           'SSL' => true

--- a/modules/auxiliary/gather/ibm_sametime_room_brute.rb
+++ b/modules/auxiliary/gather/ibm_sametime_room_brute.rb
@@ -23,6 +23,11 @@ class Metasploit3 < Msf::Auxiliary
         [
           'kicks4kittens' # Metasploit module
         ],
+      'References' =>
+        [
+          [ 'CVE', '2013-3977' ],
+          [ 'URL', 'http://www-01.ibm.com/support/docview.wss?uid=swg21671201']
+        ],
       'DefaultOptions' =>
         {
           'SSL' => true

--- a/modules/auxiliary/gather/ibm_sametime_version.rb
+++ b/modules/auxiliary/gather/ibm_sametime_version.rb
@@ -70,6 +70,11 @@ class Metasploit3 < Msf::Auxiliary
         [
           'kicks4kittens' # Metasploit module
         ],
+      'References' =>
+        [
+          [ 'CVE', '2013-3982' ],
+          [ 'URL', 'http://www-01.ibm.com/support/docview.wss?uid=swg21671201']
+        ],
       'DefaultOptions' =>
         {
           'SSL' => true


### PR DESCRIPTION
## Verification
- [x] See the URL, http://www-01.ibm.com/support/docview.wss?uid=swg21671201
- [x] Confirm the CVEs that IBM claims are tied to particular vulnerabilities match up with the vulns exercised in @kicks4kittens's modules.
