### PR TITLE
Fix URIPATH / for BrowserExploitServer

### DIFF
--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -439,7 +439,7 @@ module Msf
     #
     def on_request_uri(cli, request)
       case request.uri
-      when get_resource.chomp("/")
+      when '/', get_resource.chomp("/")
         #
         # This is the information gathering stage
         #


### PR DESCRIPTION
This fixes a bug with request.uri being "" when URIPATH is set to /

It was originally reported here:
https://twitter.com/yadolee/status/469388288550109184

Redmine:
https://dev.metasploit.com/redmine/issues/8804

To verify the patch:
- [x] Use a browser exploit that uses the BrowserExploitServer mixin.
- [x] set URIPATH to /
- [x] Make sure you get a shell

Also verify:
- [x] Use the same or a different browser exploit that uses BrowserExploitServer
- [x] Make sure this time you don't modify URIPATH, so it should generate a random one for you.
- [x] Make sure you get a shell.
