### PR TITLE
Fix msftidy datastore errors

### DIFF
--- a/modules/auxiliary/scanner/http/http_traversal.rb
+++ b/modules/auxiliary/scanner/http/http_traversal.rb
@@ -106,7 +106,7 @@ class Metasploit3 < Msf::Auxiliary
       1.upto(depth) do |d|
         file_to_read.each do |f|
           trigger = base * d
-          p = datastore['PATH'] + trigger + f
+          p = normalize_uri(datastore['PATH']) + trigger + f
           req = ini_request(p)
           vprint_status("Trying: http://#{rhost}:#{rport}#{p}")
           res = send_request_cgi(req, 25)
@@ -187,7 +187,7 @@ class Metasploit3 < Msf::Auxiliary
     if datastore['TRIGGER'].empty?
       # Found trigger using fuzz()
       found = true if trigger
-      uri = datastore['PATH'] + trigger
+      uri = normalize_uri(datastore['PATH']) + trigger
     else
       # Manual check. meh.
       if datastore['FILE'].empty?
@@ -195,7 +195,7 @@ class Metasploit3 < Msf::Auxiliary
         return
       end
 
-      uri = datastore['PATH'] + trigger + datastore['FILE']
+      uri = normalize_uri(datastore['PATH']) + trigger + datastore['FILE']
       req = ini_request(uri)
       vprint_status("Trying: http://#{rhost}:#{rport}#{uri}")
       res = send_request_cgi(req, 25)
@@ -211,7 +211,7 @@ class Metasploit3 < Msf::Auxiliary
         :port     => rport,
         :vhost    => datastore['VHOST'],
         :path     => uri,
-        :params   => datastore['PATH'],
+        :params   => normalize_uri(datastore['PATH']),
         :pname    => trigger,
         :risk     => 3,
         :proof    => trigger,
@@ -234,7 +234,7 @@ class Metasploit3 < Msf::Auxiliary
       # Our trigger already puts us in '/', so our filename doesn't need to begin with that
       f = f[1,f.length] if f =~ /^\//
 
-      req = ini_request(uri = (datastore['PATH'] + trigger + f).chop)
+      req = ini_request(uri = (normalize_uri(datastore['PATH']) + trigger + f).chop)
       res = send_request_cgi(req, 25)
 
       vprint_status("#{res.code.to_s} for http://#{rhost}:#{rport}#{uri}") if res
@@ -261,7 +261,7 @@ class Metasploit3 < Msf::Auxiliary
       # Our trigger already puts us in '/', so our filename doesn't need to begin with that
       f = f[1,f.length] if f =~ /^\//
 
-      req = ini_request(uri = (datastore['PATH'] + "php://filter/read=convert.base64-encode/resource=" + f).chop)
+      req = ini_request(uri = (normalize_uri(datastore['PATH']) + "php://filter/read=convert.base64-encode/resource=" + f).chop)
       res = send_request_cgi(req, 25)
 
       vprint_status("#{res.code.to_s} for http://#{rhost}:#{rport}#{uri}") if res
@@ -294,7 +294,7 @@ class Metasploit3 < Msf::Auxiliary
 
     # Form the PUT request
     fname = Rex::Text.rand_text_alpha(rand(5) + 5) + '.txt'
-    uri = datastore['PATH'] + trigger + fname
+    uri = normalize_uri(datastore['PATH']) + trigger + fname
     vprint_status("Attempt to upload to: http://#{rhost}:#{rport}#{uri}")
     req = ini_request(uri)
 
@@ -331,11 +331,6 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run_host(ip)
-    # Make sure datastore['PATH] begins with a '/'
-    if datastore['PATH'] !~ /^\//
-      datastore['PATH'] = '/' + datastore['PATH']
-    end
-
     print_status("Running action: #{action.name}...")
 
     # And it's..... "SHOW TIME!!"

--- a/modules/auxiliary/scanner/http/http_traversal.rb
+++ b/modules/auxiliary/scanner/http/http_traversal.rb
@@ -336,9 +336,6 @@ class Metasploit3 < Msf::Auxiliary
       datastore['PATH'] = '/' + datastore['PATH']
     end
 
-    # Some webservers (ie. Apache) might not like the HTTP method to be lower-case
-    datastore['METHOD'] = datastore['METHOD'].upcase
-
     print_status("Running action: #{action.name}...")
 
     # And it's..... "SHOW TIME!!"

--- a/modules/auxiliary/scanner/http/http_traversal.rb
+++ b/modules/auxiliary/scanner/http/http_traversal.rb
@@ -331,6 +331,10 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run_host(ip)
+    # Warn if it's not a well-formed UPPERCASE method
+    if datastore['METHOD'] !~ /^[A-Z]+$/
+      print_warning("HTTP method #{datastore['METHOD']} is not Apache-compliant. Try only UPPERCASE letters.")
+    end
     print_status("Running action: #{action.name}...")
 
     # And it's..... "SHOW TIME!!"

--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -93,26 +93,7 @@ class Metasploit3 < Msf::Auxiliary
     deregister_options('BLANK_PASSWORDS', 'RHOSTS','PASSWORD','USERNAME')
   end
 
-  def cleanup
-    # Restore the original settings
-    datastore['BLANK_PASSWORDS'] = @blank_passwords_setting
-    datastore['USER_AS_PASS']    = @user_as_pass_setting
-  end
-
   def run
-    # Store the original setting
-    @blank_passwords_setting = datastore['BLANK_PASSWORDS']
-
-    # OWA doesn't support blank passwords or usernames!
-    datastore['BLANK_PASSWORDS'] = false
-
-    # If there's a pre-defined username/password, we need to turn off USER_AS_PASS
-    # so that the module won't just try username:username, and then exit.
-    @user_as_pass_setting = datastore['USER_AS_PASS']
-    if not datastore['USERNAME'].nil? and not datastore['PASSWORD'].nil?
-      print_status("Disabling 'USER_AS_PASS' because you've specified an username/password")
-      datastore['USER_AS_PASS'] = false
-    end
 
     vhost = datastore['VHOST'] || datastore['RHOST']
 

--- a/modules/auxiliary/scanner/oracle/xdb_sid_brute.rb
+++ b/modules/auxiliary/scanner/oracle/xdb_sid_brute.rb
@@ -32,7 +32,6 @@ class Metasploit3 < Msf::Auxiliary
           OptString.new('CSVFILE', [ false, 'The file that contains a list of default accounts.', File.join(Msf::Config.install_root, 'data', 'wordlists', 'oracle_default_passwords.csv')]),
           Opt::RPORT(8080),
         ], self.class)
-    deregister_options('DBUSER','DBPASS')
   end
 
   def run_host(ip)
@@ -57,9 +56,9 @@ class Metasploit3 < Msf::Auxiliary
 
     fd = CSV.foreach(list) do |brute|
 
-      datastore['DBUSER'] = brute[2].downcase
-      datastore['DBPASS'] = brute[3].downcase
-      user_pass = "#{datastore['DBUSER']}:#{datastore['DBPASS']}"
+      dbuser = brute[2].downcase
+      dbpass = brute[3].downcase
+      user_pass = "#{dbuser}:#{dbpass}"
 
       res = send_request_raw({
         'uri'     => '/oradb/PUBLIC/GLOBAL_NAME',
@@ -72,7 +71,7 @@ class Metasploit3 < Msf::Auxiliary
       }, 10)
 
       if( not res )
-        vprint_error("Unable to retrieve SID for #{ip}:#{datastore['RPORT']} with #{datastore['DBUSER']} / #{datastore['DBPASS']}...")
+        vprint_error("Unable to retrieve SID for #{ip}:#{datastore['RPORT']} with #{dbuser} / #{dbpass}...")
         next
       end
       if (res.code == 200)
@@ -89,10 +88,10 @@ class Metasploit3 < Msf::Auxiliary
           :data => sid,
           :update => :unique_data
         )
-        print_good("Discovered SID: '#{sid[0]}' for host #{ip}:#{datastore['RPORT']} with #{datastore['DBUSER']} / #{datastore['DBPASS']}")
+        print_good("Discovered SID: '#{sid[0]}' for host #{ip}:#{datastore['RPORT']} with #{dbuser} / #{dbpass}")
         users.push(user_pass)
       else
-        vprint_error("Unable to retrieve SID for #{ip}:#{datastore['RPORT']} with #{datastore['DBUSER']} / #{datastore['DBPASS']}...")
+        vprint_error("Unable to retrieve SID for #{ip}:#{datastore['RPORT']} with #{dbuser} / #{dbpass}...")
       end
     end #fd.each
 

--- a/modules/exploits/multi/http/phpldapadmin_query_engine.rb
+++ b/modules/exploits/multi/http/phpldapadmin_query_engine.rb
@@ -87,13 +87,6 @@ class Metasploit3 < Msf::Exploit::Remote
     return res.get_cookies
   end
 
-  def cleanup
-    # We may not be using php/exe again, so clear the CMD option
-    if datastore['CMD']
-      datastore['CMD'] = nil
-    end
-  end
-
   def exploit
     # if we are using the exec CMD stager
     # important to check which php functions are disabled


### PR DESCRIPTION
See the redmine bug:

https://dev.metasploit.com/redmine/issues/8498

This should knock out 9 msftidy errors, as detailed here:

https://docs.google.com/spreadsheets/d/1ODtJBZpReYFQqoGRqBw9YFqYt8_SEOLH01jrHTeM36U

This PR also proves that I wasn't lying when I opened #3380. Most of these aren't too terribly hard; in most cases, the module simply fails to use the existing API, and in most of those cases, it's because the API wasn't available at the time of writing of the module.

I took a look at `git blame` for all the fixes and noted who was the committer who landed the original datastore edit. This is not for public shaming, but because that person, I figure, is the one best able to eyeball my work and ensure that I'm not missing anything subtle in these modules. Given their respective module output volumes, I expect @wchen-r7 and @jvazquez-r7 to be implicated more often than not on this branch, and that's okay -- a changing API doesn't guarantee 3 year old modules are updated to use it.
