### PR TITLE
Improve reliability of have_powershell

### DIFF
--- a/lib/msf/core/post/windows/powershell.rb
+++ b/lib/msf/core/post/windows/powershell.rb
@@ -19,7 +19,7 @@ module Powershell
   # Returns true if powershell is installed
   #
   def have_powershell?
-    cmd_out = cmd_exec("cmd.exe /c echo. | powershell get-host")
+    cmd_out = cmd_exec('cmd.exe /c "echo. | powershell get-host"')
     return true if cmd_out =~ /Name.*Version.*InstanceId/m
     return false
   end

--- a/lib/msf/core/post/windows/powershell.rb
+++ b/lib/msf/core/post/windows/powershell.rb
@@ -19,7 +19,7 @@ module Powershell
   # Returns true if powershell is installed
   #
   def have_powershell?
-    cmd_out = cmd_exec("echo. | powershell get-host")
+    cmd_out = cmd_exec("cmd.exe /c echo. | powershell get-host")
     return true if cmd_out =~ /Name.*Version.*InstanceId/m
     return false
   end

--- a/lib/msf/core/post/windows/powershell.rb
+++ b/lib/msf/core/post/windows/powershell.rb
@@ -19,7 +19,7 @@ module Powershell
   # Returns true if powershell is installed
   #
   def have_powershell?
-    cmd_out = cmd_exec("powershell get-host")
+    cmd_out = cmd_exec("echo. | powershell get-host")
     return true if cmd_out =~ /Name.*Version.*InstanceID/
     return false
   end

--- a/lib/msf/core/post/windows/powershell.rb
+++ b/lib/msf/core/post/windows/powershell.rb
@@ -20,7 +20,7 @@ module Powershell
   #
   def have_powershell?
     cmd_out = cmd_exec("echo. | powershell get-host")
-    return true if cmd_out =~ /Name.*Version.*InstanceID/
+    return true if cmd_out =~ /Name.*Version.*InstanceId/m
     return false
   end
 


### PR DESCRIPTION
I have a case where on a Windows 2008 R2 host with PowerShell 2.0 the **have_powershell** method times out.  When I interactively run the command I find that the output stops after the PowerShell command and the token from **cmd_exec** is NOT displayed.  When I hit return the shell then processes the '&echo <randomstring>' and generates the token that **cmd_exec** was looking for. 

 I tried various versions of the PowerShell command string such as 'Get-Host;Exit(0)', '$PSVErsionTable.PSVersion', and '-Command Get-Host' but was unable to change the behavior.  I found that adding 'echo. | ' simulated pressing enter and did not disrupt the results on this host or on another host where the **have_powershell** method functioned as expected. As a note, both shells were created using **exploit/windows/smb/psexec**.

There may be a better solution, but this was the only one that I could find.
