### PR TITLE
Add variables for meterpreter irb

### DIFF
--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -314,6 +314,8 @@ class Console::CommandDispatcher::Core
     print_status("Starting IRB shell")
     print_status("The 'client' variable holds the meterpreter client\n")
 
+    session = client
+    framework = client.framework
     Rex::Ui::Text::IrbShell.new(binding).run
   end
 


### PR DESCRIPTION
This adds the `session` and `framework` variables for use in the meterpreter IRB interface. Post modules are supposed to reference the session object through the `session` variables but it's defined in IRB as `client`. With this change it is easier to test snippets of code by copying and pasting without the need to set session to client.

Before patch:

```
msf4-git (S:0 J:0) exploit(handler) > exploit

[*] Started reverse handler on 192.168.90.1:4444 
[*] Starting the payload handler...
[*] Sending stage (17349 bytes) to 192.168.90.178
[*] Meterpreter session 1 opened (192.168.90.1:4444 -> 192.168.90.178:1043) at 2014-05-25 16:31:53 -0400

meterpreter > irb
[*] Starting IRB shell
[*] The 'client' variable holds the meterpreter client

>> client
=> #<Session:meterpreter 192.168.90.178:1043 (192.168.90.178) "Administrator @ noob-07797b4d0d">
>> session
NameError: undefined local variable or method `session' for #<Rex::Post::Meterpreter::Ui::Console::CommandDispatcher::Core:0x000000041106a8>
```

After patch:

```
msf4-git (S:0 J:0) exploit(handler) > exploit

[*] Started reverse handler on 192.168.90.1:4444 
[*] Starting the payload handler...
[*] Sending stage (17349 bytes) to 192.168.90.178
[*] Meterpreter session 1 opened (192.168.90.1:4444 -> 192.168.90.178:1042) at 2014-05-25 16:27:34 -0400

meterpreter > irb
[*] Starting IRB shell
[*] The 'client' variable holds the meterpreter client

>> client
=> #<Session:meterpreter 192.168.90.178:1042 (192.168.90.178) "Administrator @ noob-07797b4d0d">
>> session
=> #<Session:meterpreter 192.168.90.178:1042 (192.168.90.178) "Administrator @ noob-07797b4d0d">
>> framework
=> #<Framework (1 sessions, 0 jobs, 0 plugins, postgresql database active)>
>> 
```

Testing
- [x] Get a new meterpreter session
- [x] From the IRB shell check that the new session and framework variables are available
