### PR TITLE
Add sqlite3 to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,12 +10,14 @@ gem 'json'
 gem 'msgpack'
 # Needed by anemone crawler
 gem 'nokogiri'
+# Needed by db.rb and Msf::Exploit::Capture
+gem 'packetfu', '1.1.9'
 # Needed by JSObfu
 gem 'rkelly-remix', '0.0.6'
 # Needed by anemone crawler
 gem 'robots'
-# Needed by db.rb and Msf::Exploit::Capture
-gem 'packetfu', '1.1.9'
+# Needed for some post modules
+gem 'sqlite3'
 
 group :db do
   # Needed for Msf::DbManager

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
       multi_json (~> 1.0.3)
       simplecov-html (~> 0.5.3)
     simplecov-html (0.5.3)
+    sqlite3 (1.3.9)
     timecop (0.6.3)
     tzinfo (0.3.37)
     yard (0.8.7)
@@ -82,5 +83,6 @@ DEPENDENCIES
   rspec (>= 2.12)
   shoulda-matchers
   simplecov (= 0.5.4)
+  sqlite3
   timecop
   yard


### PR DESCRIPTION
Fixes all the post modules that require it to parse pilfered sqlite DB
files.

VERIFICATION
- [x] `bundle install`
- [x] launch msfconsole
- [x] get a windows meterpreter session, note its session ID
- [x] `use post/multi/gather/skype_enum`
- [x] `set SESSION` to the appropriate ID from above
- [x] `run`
- [x] **VERIFY**: no errors about missing sqlite3
