### PR TITLE
Rewire some snmp modules to use print_error instead of print_status.

### DIFF
--- a/modules/auxiliary/scanner/snmp/snmp_enum.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enum.rb
@@ -946,17 +946,17 @@ class Metasploit3 < Msf::Auxiliary
 
 
     rescue SNMP::RequestTimeout
-      vprint_status("#{ip} SNMP request timeout.")
+      print_error("#{ip} SNMP request timeout.")
     rescue Rex::ConnectionError
-      print_status("#{ip} Connection refused.")
+      print_error("#{ip} Connection refused.")
     rescue SNMP::InvalidIpAddress
-      print_status("#{ip} Invalid IP Address. Check it with 'snmpwalk tool'.")
+      print_error("#{ip} Invalid IP Address. Check it with 'snmpwalk tool'.")
     rescue SNMP::UnsupportedVersion
-      print_status("#{ip} Unsupported SNMP version specified. Select from '1' or '2c'.")
+      print_error("#{ip} Unsupported SNMP version specified. Select from '1' or '2c'.")
     rescue ::Interrupt
       raise $!
     rescue ::Exception => e
-      print_status("Unknown error: #{e.class} #{e}")
+      print_error("Unknown error: #{e.class} #{e}")
       elog("Unknown error: #{e.class} #{e}")
       elog("Call stack:\n#{e.backtrace.join "\n"}")
     ensure

--- a/modules/auxiliary/scanner/snmp/snmp_enum_hp_laserjet.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enum_hp_laserjet.rb
@@ -136,15 +136,15 @@ class Metasploit3 < Msf::Auxiliary
       disconnect_snmp
 
     rescue SNMP::RequestTimeout
-      vprint_status("#{ip}, SNMP request timeout.")
+      print_error("#{ip}, SNMP request timeout.")
     rescue Errno::ECONNREFUSED
-      vprint_status("#{ip}, Connection refused.")
+      print_error("#{ip}, Connection refused.")
     rescue SNMP::InvalidIpAddress
-      vprint_status("#{ip}, Invalid IP Address. Check it with 'snmpwalk tool'.")
+      print_error("#{ip}, Invalid IP Address. Check it with 'snmpwalk tool'.")
     rescue ::Interrupt
     raise $!
     rescue ::Exception => e
-      vprint_error("#{ip}, Unknown error: #{e.class} #{e}")
+      print_error("#{ip}, Unknown error: #{e.class} #{e}")
     end
   end
 end


### PR DESCRIPTION
This reworks some of the error handling in `snmp_enum` and `snmp_enum_hp_laserjet` so that errors show up in red and are never masked. Contributors often use `snmp_enum` as a template for snmp modules, so it would be useful to improve the error handling now.
