### PR TITLE
Fix typos in the indeces_enum module

### DIFF
--- a/modules/auxiliary/scanner/elasticsearch/indeces_enum.rb
+++ b/modules/auxiliary/scanner/elasticsearch/indeces_enum.rb
@@ -13,9 +13,9 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'         => 'ElasticSearch Indeces Enumeration Utility',
+      'Name'         => 'ElasticSearch Indices Enumeration Utility',
       'Description'  => %q{
-        This module enumerates ElasticSearch Indeces. It uses the REST API
+        This module enumerates ElasticSearch Indices. It uses the REST API
         in order to make it.
       },
       'Author'         =>
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def run_host(ip)
-    vprint_status("#{peer} - Querying indeces...")
+    vprint_status("#{peer} - Querying indices...")
     begin
       res = send_request_raw({
         'uri'     => '/_aliases',
@@ -66,10 +66,10 @@ class Metasploit3 < Msf::Auxiliary
       :name  => 'elasticsearch'
     )
 
-    indeces = []
+    indices = []
 
     json_body.each do |index|
-      indeces.push(index[0])
+      indices.push(index[0])
       report_note(
         :host  => rhost,
         :port  => rport,
@@ -80,8 +80,8 @@ class Metasploit3 < Msf::Auxiliary
       )
     end
 
-    if indeces.length > 0
-      print_good("#{peer} - ElasticSearch Indeces found: #{indeces.join(", ")}")
+    if indices.length > 0
+      print_good("#{peer} - ElasticSearch Indices found: #{indices.join(", ")}")
     end
 
   end

--- a/modules/auxiliary/scanner/elasticsearch/indices_enum.rb
+++ b/modules/auxiliary/scanner/elasticsearch/indices_enum.rb
@@ -4,18 +4,12 @@
 ##
 
 require 'msf/core'
-require 'msf/core/module/deprecated'
 
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Scanner
   include Msf::Auxiliary::Report
-
-  include Msf::Module::Deprecated
-
-  DEPRECATION_DATE = Date.new(2014, 07, 29)
-  DEPRECATION_REPLACEMENT = 'auxiliary/scanner/elasticsearch/indices_enum'
 
   def initialize(info = {})
     super(update_info(info,


### PR DESCRIPTION
There is also a typo in the module name, harder to fix :\ sorry about that metasploit... :(
