### PR TITLE
Fix HTTP Crawler Anemone::Page method error

### DIFF
--- a/modules/auxiliary/scanner/http/crawler.rb
+++ b/modules/auxiliary/scanner/http/crawler.rb
@@ -104,8 +104,8 @@ class Metasploit3 < Msf::Auxiliary
       info[:ctype] = page.headers['content-type']
     end
 
-    if !page.get_cookies.empty?
-      info[:cookie] = page.get_cookies
+    if !page.cookies.empty?
+      info[:cookie] = page.cookies
     end
 
     if page.headers['authorization']


### PR DESCRIPTION
Anemone::Page is not a Rex HTTP request/response, and uses the
:cookies method to return an array of cookies.
This resolves the method naming error, though it does break with
Rex naming convention since Anemone still uses a lot of non-Rex
methods for working with pages/traffic.
