### PR TITLE
Clarify filedropper error message

### DIFF
--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -122,7 +122,7 @@ module Exploit::FileDropper
     end
 
     @dropped_files.each do |f|
-      print_warning("This exploit may require manual cleanup on the target of: #{f}")
+      print_warning("This exploit may require manual cleanup of '#{f}' on the target")
     end
 
   end

--- a/lib/msf/core/exploit/file_dropper.rb
+++ b/lib/msf/core/exploit/file_dropper.rb
@@ -122,7 +122,7 @@ module Exploit::FileDropper
     end
 
     @dropped_files.each do |f|
-      print_warning("This exploit may require manual cleanup of: #{f}")
+      print_warning("This exploit may require manual cleanup on the target of: #{f}")
     end
 
   end


### PR DESCRIPTION
This PR changes the error message generated by the FileDropper mixin, because some users are confused of the output. This clarifies that the file to cleanup lies on the target machine.
If you have a better text just comment here and I will change it.
