### PR TITLE
Add @trosen-r7's alias for commits

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -18,6 +18,7 @@ todb-r7 <todb-r7@github>           Tod Beardsley <tod_beardsley@rapid7.com>
 todb-r7 <todb-r7@github>           Tod Beardsley <todb@metasploit.com>
 todb-r7 <todb-r7@github>           Tod Beardsley <todb@packetfu.com>
 trosen-r7 <trosen-r7@github>       Trevor Rosen <Trevor_Rosen@rapid7.com>
+trosen-r7 <trosen-r7@github>       Trevor Rosen <trevor@catapult-creative.com>
 wchen-r7 <wchen-r7@github>         sinn3r <msfsinn3r@gmail.com> # aka sinn3r
 wchen-r7 <wchen-r7@github>         sinn3r <wei_chen@rapid7.com>
 wchen-r7 <wchen-r7@github>         Wei Chen <Wei_Chen@rapid7.com>


### PR DESCRIPTION
Just so quick counts of contributors is slightly more accurate and
@trosen-r7 doesn't accidentally get double counted.
