### PR TITLE
Fix VirtualAlloc call on PSH old template

### DIFF
--- a/data/templates/scripts/to_mem_old.ps1.template
+++ b/data/templates/scripts/to_mem_old.ps1.template
@@ -11,7 +11,7 @@ $%{var_win32_func} = Add-Type -memberDefinition $%{var_syscode} -Name "Win32" -n
 
 %{shellcode}
 
-$%{var_rwx} = $%{var_win32_func}::VirtualAlloc(0,0x1000,[Math]::Max($%{var_code}.Length, 0x1000),0x40)
+$%{var_rwx} = $%{var_win32_func}::VirtualAlloc(0,[Math]::Max($%{var_code}.Length, 0x1000),0x1000,0x40)
 
 for ($%{var_iter}=0;$%{var_iter} -le ($%{var_code}.Length-1);$%{var_iter}++) {
 	$%{var_win32_func}::memset([IntPtr]($%{var_rwx}.ToInt32()+$%{var_iter}), $%{var_code}[$%{var_iter}], 1) | Out-Null


### PR DESCRIPTION
Unless I'm misunderstanding something, second parameter when calling VirtualAlloc should be Size, and third AllocationType. I guess it was working because the size of the code uses to be less than 0x1000, so it resulted on `VirtualAlloc(0,0x1000,0x1000,0x40)` anyway.
