### PR TITLE
Python Chr encoder

### DIFF
--- a/modules/encoders/python/chr.rb
+++ b/modules/encoders/python/chr.rb
@@ -1,0 +1,46 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Encoder
+  Rank = ExcellentRanking
+
+  def initialize
+    super(
+      'Name'             => 'Python Chr Encoder',
+      'Description'      => %q{
+        This encodes bad chars with chr().
+      },
+      'Author'           => 'Ben Campbell',
+      'Arch'             => ARCH_PYTHON,
+      'Platform'         => 'python')
+  end
+
+
+  #
+  # Encodes the payload
+  #
+  def encode_block(state, buf)
+
+    if state.badchars.include? '"'
+      state.badchars.each_char do |c|
+        buf.gsub!(c,"'+chr(#{c.ord})+'")
+      end
+
+      encoded = "exec('#{buf}')"
+    else
+      state.badchars.each_char do |c|
+        buf.gsub!(c,"\"+chr(#{c.ord})+\"")
+      end
+
+      encoded = "exec(\"#{buf}\")"
+    end
+
+    encoded
+  end
+
+end
+


### PR DESCRIPTION
Encodes bad chars with chr(##)...

Set badchars to "\t\n" ftw! 
