### PR TITLE
Add Rex NTP code for future NTP work, NTP fuzzer

### DIFF
--- a/lib/rex/proto/ntp.rb
+++ b/lib/rex/proto/ntp.rb
@@ -1,0 +1,3 @@
+# -*- coding: binary -*-
+require 'rex/proto/ntp/constants'
+require 'rex/proto/ntp/modes'

--- a/lib/rex/proto/ntp/constants.rb
+++ b/lib/rex/proto/ntp/constants.rb
@@ -1,0 +1,12 @@
+# -*- coding: binary -*-
+module Rex
+module Proto
+module NTP
+VERSIONS = (0..7).to_a
+MODES = (0..7).to_a
+MODE_6_OPERATIONS = (0..31).to_a
+MODE_7_IMPLEMENTATIONS = (0..255).to_a
+MODE_7_REQUEST_CODES = (0..255).to_a
+end
+end
+end

--- a/lib/rex/proto/ntp/modes.rb
+++ b/lib/rex/proto/ntp/modes.rb
@@ -1,0 +1,114 @@
+# -*- coding: binary -*-
+module Rex
+module Proto
+module NTP
+
+  # A very generic NTP message
+  #
+  # Uses the common/similar parts from versions 1-4 and considers everything
+  # after to be just one big field.  For the particulars on the different versions,
+  # see:
+  #   http://tools.ietf.org/html/rfc958#appendix-B
+  #   http://tools.ietf.org/html/rfc1059#appendix-B
+  #   pages 45/48 of http://tools.ietf.org/pdf/rfc1119.pdf
+  #   http://tools.ietf.org/html/rfc1305#appendix-D
+  #   http://tools.ietf.org/html/rfc5905#page-19
+  class NTPGeneric < BitStruct
+    #    0                   1                   2                   3
+    #    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    #   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    #   |LI | VN  | mode|    Stratum    |      Poll     |   Precision   |
+    #   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    unsigned :li, 2,  default: 0
+    unsigned :version, 3,  default: 0
+    unsigned :mode, 3,  default: 0
+    unsigned :stratum, 8,  default: 0
+    unsigned :poll, 8,  default: 0
+    unsigned :precision, 8,  default: 0
+    char :payload, 352
+  end
+
+  # An NTP control message.  Control messages are only specified for NTP
+  # versions 2-4, but this is a fuzzer so why not try them all...
+  class NTPControl < BitStruct
+    #  0                   1                   2                   3
+    #  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    # |00 | VN  |   6 |R E M|  op     |     Sequence                  |
+    # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    # |              status           |      association id           |
+    # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    # |              offset           |     count                     |
+    # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    unsigned :reserved, 2, default: 0
+    unsigned :version, 3,  default: 0
+    unsigned :mode, 3,  default: 6
+    unsigned :response, 1,  default: 0
+    unsigned :error, 1,  default: 0
+    unsigned :more, 1,  default: 0
+    unsigned :operation, 5,  default: 0
+    unsigned :sequence, 16,  default: 0
+    unsigned :status, 16,  default: 0
+    unsigned :association_id, 16,  default: 0
+    # TODO: there *must* be bugs in the handling of these next two fields!
+    unsigned :payload_offset, 16,  default: 0
+    unsigned :payload_size, 16,  default: 0
+    rest :payload
+  end
+
+  # An NTP "private" message.  Private messages are only specified for NTP
+  # versions 2-4, but this is a fuzzer so why not try them all...
+  class NTPPrivate < BitStruct
+    #  0                   1                   2                   3
+    #  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    # |00 | VN  |   7 |A|                   Sequence                  |
+    # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    # | Implementation| request code  |
+    # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    unsigned :reserved, 2, default: 0
+    unsigned :version, 3,  default: 0
+    unsigned :mode, 3,  default: 7
+    unsigned :auth, 1, default: 0
+    unsigned :sequence, 7, default: 0
+    unsigned :implementation, 8, default: 0
+    unsigned :request_code, 8, default: 0
+    rest :payload
+  end
+
+  def self.ntp_control(version, operation, payload = nil)
+    n = NTPControl.new
+    n.version = version
+    n.operation = operation
+    if payload
+      n.payload_offset = 0
+      n.payload_size = payload.size
+      n.payload = payload
+    end
+    n.to_s
+  end
+
+  def self.ntp_private(version, implementation, request_code, payload = nil)
+    n = NTPPrivate.new
+    n.version = version
+    n.implementation = implementation
+    n.request_code = request_code
+    n.payload = payload if payload
+    n.to_s
+  end
+
+  def self.ntp_generic(version, mode)
+    n = NTPGeneric.new
+    n.version = version
+    n.mode = mode
+    n.to_s
+  end
+
+  # Parses the given message and provides a description about the NTP message inside
+  def self.describe(message)
+    ntp = NTPGeneric.new(message)
+    "#{message.size}-byte version #{ntp.version} mode #{ntp.mode} reply"
+  end
+end
+end
+end

--- a/lib/rex/proto/ntp/modes.rb
+++ b/lib/rex/proto/ntp/modes.rb
@@ -66,19 +66,31 @@ module NTP
     #  0                   1                   2                   3
     #  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    # |R M| VN  |   7 |A|                   Sequence                  |
+    # |R M| VN  |   7 |A|  Sequence   | Implementation| Req code      |
     # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    # | Implementation| request code  |
-    # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    unsigned :response, 1,  default: 0
-    unsigned :more, 1,  default: 0
+    # |  err  | Number of data items  |  MBZ   |   Size of data item  |
+    # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    unsigned :response, 1, default: 0
+    unsigned :more, 1, default: 0
     unsigned :version, 3,  default: 0
     unsigned :mode, 3,  default: 7
     unsigned :auth, 1, default: 0
     unsigned :sequence, 7, default: 0
     unsigned :implementation, 8, default: 0
     unsigned :request_code, 8, default: 0
+    unsigned :error, 4, default: 0
+    unsigned :record_count, 12, default: 0
+    unsigned :mbz, 4, default: 0
+    unsigned :record_size, 12, default: 0
     rest :payload
+
+    def records
+      records = []
+      1.upto(record_count) do |record_num|
+        records << payload[record_size*(record_num-1), record_size]
+      end
+      records
+    end
   end
 
   def self.ntp_control(version, operation, payload = nil)

--- a/lib/rex/proto/ntp/modes.rb
+++ b/lib/rex/proto/ntp/modes.rb
@@ -1,4 +1,8 @@
 # -*- coding: binary -*-
+
+require 'rubygems'
+require 'bit-struct'
+
 module Rex
 module Proto
 module NTP
@@ -25,7 +29,7 @@ module NTP
     unsigned :stratum, 8,  default: 0
     unsigned :poll, 8,  default: 0
     unsigned :precision, 8,  default: 0
-    char :payload, 352
+    rest :payload
   end
 
   # An NTP control message.  Control messages are only specified for NTP
@@ -62,11 +66,12 @@ module NTP
     #  0                   1                   2                   3
     #  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
     # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    # |00 | VN  |   7 |A|                   Sequence                  |
+    # |R M| VN  |   7 |A|                   Sequence                  |
     # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     # | Implementation| request code  |
     # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    unsigned :reserved, 2, default: 0
+    unsigned :response, 1,  default: 0
+    unsigned :more, 1,  default: 0
     unsigned :version, 3,  default: 0
     unsigned :mode, 3,  default: 7
     unsigned :auth, 1, default: 0

--- a/lib/rex/proto/ntp/modes.rb
+++ b/lib/rex/proto/ntp/modes.rb
@@ -1,6 +1,5 @@
 # -*- coding: binary -*-
 
-require 'rubygems'
 require 'bit-struct'
 
 module Rex

--- a/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
@@ -10,8 +10,8 @@ require 'securerandom'
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Auxiliary::Fuzzer
-  include Msf::Auxiliary::Scanner
   include Msf::Exploit::Remote::Udp
+  include Msf::Auxiliary::Scanner
 
   NTP_VERSIONS = (0..7).to_a
   NTP_MODES = (0..7).to_a

--- a/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
@@ -183,8 +183,8 @@ class Metasploit3 < Msf::Auxiliary
 
   # Sends a series of NTP control messages
   def fuzz_control(host)
-    print_status("#{host}:#{rport} fuzzing control messages (mode 6)")
     @versions.map { |v| v.to_i }.each do |version|
+      print_status("#{host}:#{rport} fuzzing version #{version} control messages (mode 6)")
       0.upto(31) do |op|
         request = build_ntp_control(version, op)
         what = "#{request.size}-byte version #{version} mode 6 op #{op} message"
@@ -199,8 +199,8 @@ class Metasploit3 < Msf::Auxiliary
 
   # Sends a series of NTP private messages
   def fuzz_private(host)
-    print_status("#{host}:#{rport} fuzzing private messages (mode 7)")
     @versions.map { |v| v.to_i }.each do |version|
+      print_status("#{host}:#{rport} fuzzing version #{version} private messages (mode 7)")
       0.upto(255) do |implementation|
         0.upto(255) do |request_code|
           request = build_ntp_private(version, implementation, request_code)

--- a/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
@@ -10,7 +10,7 @@ require 'securerandom'
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Auxiliary::Fuzzer
-  #include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Scanner
   include Msf::Exploit::Remote::Udp
 
   NTP_VERSIONS = (0..7).to_a
@@ -161,7 +161,7 @@ class Metasploit3 < Msf::Auxiliary
     datastore['SLEEP'] / 1000.0
   end
 
-  def run
+  def run_host(ip)
     # parse and sanity check versions
     @versions = datastore['VERSIONS'].split(/[^\d]/).select { |v| !v.empty? }.map { |v| v.to_i }
     unsupported_versions = @versions - NTP_VERSIONS
@@ -172,12 +172,12 @@ class Metasploit3 < Msf::Auxiliary
     fail "Unsupported NTP modes: #{unsupported_modes}" unless unsupported_modes.empty?
 
     connect_udp
-    fuzz_version_mode(host)
-    fuzz_version_mode(host, true)
-    fuzz_short(host)
-    fuzz_random(host)
-    fuzz_control(host) if @modes.include?(6)
-    fuzz_private(host) if @modes.include?(7)
+    fuzz_version_mode(ip)
+    fuzz_version_mode(ip, true)
+    fuzz_short(ip)
+    fuzz_random(ip)
+    fuzz_control(ip) if @modes.include?(6)
+    fuzz_private(ip) if @modes.include?(7)
     disconnect_udp
   end
 

--- a/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('MODES', [true, 'Modes to fuzz', NTP_SUPPORTED_MODES]),
         OptString.new('MODE_6_OPERATIONS', [true, 'Mode 6 operations to fuzz', NTP_SUPPORTED_MODE_6_OPERATIONS]),
         OptString.new('MODE_7_IMPLEMENTATIONS', [true, 'Mode 7 implementations to fuzz', [3,2,0]]),
-        OptString.new('MODE_7_REQUEST_CODES', [true, 'Mode 7 request codes to fuzz', (0..255).to_a]),
+        OptString.new('MODE_7_REQUEST_CODES', [true, 'Mode 7 request codes to fuzz', NTP_SUPPORTED_MODE_7_REQUEST_CODES]),
         OptInt.new('SLEEP', [true, 'Sleep for this many ms between requests', 0]),
         OptInt.new('WAIT', [true, 'Wait this many ms for responses', 500])
       ], self.class)

--- a/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
@@ -52,7 +52,7 @@ class Metasploit3 < Msf::Auxiliary
 
     register_advanced_options(
       [
-        OptString.new('VERSIONS', [false, 'Specific versions to fuzz (csv)', nil]),
+        OptString.new('VERSIONS', [false, 'Specific versions to fuzz (csv)', '2,3,4']),
         OptString.new('MODES', [false, 'Modes to fuzz (csv)', nil]),
         OptString.new('MODE_6_OPERATIONS', [false, 'Mode 6 operations to fuzz (csv)', nil]),
         OptString.new('MODE_7_IMPLEMENTATIONS', [false, 'Mode 7 implementations to fuzz (csv)', nil]),

--- a/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 ##
 # This module requires Metasploit: http//metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -8,7 +9,6 @@ require 'rex/proto/ntp'
 require 'securerandom'
 
 class Metasploit3 < Msf::Auxiliary
-
   include Msf::Auxiliary::Fuzzer
   include Msf::Exploit::Remote::Udp
   include Msf::Auxiliary::Scanner
@@ -73,7 +73,7 @@ class Metasploit3 < Msf::Auxiliary
       unsupported_things = instance_variable_get("@#{var_name}") - Rex::Proto::NTP.const_get(const_name)
       fail "Unsupported #{thing}: #{unsupported_things}" unless unsupported_things.empty?
     else
-      instance_variable_set("@#{var_name}", Rex::Proto::NTP::const_get(const_name))
+      instance_variable_set("@#{var_name}", Rex::Proto::NTP.const_get(const_name))
     end
   end
 
@@ -116,7 +116,7 @@ class Metasploit3 < Msf::Auxiliary
       print_status("#{host}:#{rport} fuzzing version #{version} private messages (mode 7)")
       @mode_7_implementations.each do |implementation|
         @mode_7_request_codes.each do |request_code|
-          request = Rex::Proto::NTP.ntp_private(version, implementation, request_code, "\x00"*188)
+          request = Rex::Proto::NTP.ntp_private(version, implementation, request_code, "\x00" * 188)
           what = "#{request.size}-byte version #{version} mode 7 imp #{implementation} req #{request_code} message"
           vprint_status("#{host}:#{rport} probing with #{request.size}-byte #{what}")
           responses = probe(host, datastore['RPORT'].to_i, request)
@@ -179,7 +179,7 @@ class Metasploit3 < Msf::Auxiliary
   def probe(host, port, message)
     replies = []
     udp_sock.sendto(message, host, port, 0)
-    while (r = udp_sock.recvfrom(65535, datastore['WAIT'] / 1000.0) and r[1])
+    while (r = udp_sock.recvfrom(65535, datastore['WAIT'] / 1000.0) && r[1])
       replies << r
     end
     replies

--- a/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
@@ -56,7 +56,7 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('MODES', [true, 'Modes to fuzz', NTP_SUPPORTED_MODES]),
         OptString.new('MODE_6_OPERATIONS', [true, 'Mode 6 operations to fuzz', NTP_SUPPORTED_MODE_6_OPERATIONS]),
         OptString.new('MODE_7_IMPLEMENTATIONS', [true, 'Mode 7 implementations to fuzz', [3,2,0]]),
-        OptString.new('MODE_7_REQUEST_CODES', [true, 'Mode 7 request codes to fuzz', (0..45).to_a]),
+        OptString.new('MODE_7_REQUEST_CODES', [true, 'Mode 7 request codes to fuzz', (0..255).to_a]),
         OptInt.new('SLEEP', [true, 'Sleep for this many ms between requests', 0]),
         OptInt.new('WAIT', [true, 'Wait this many ms for responses', 500])
       ], self.class)

--- a/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
@@ -1,0 +1,245 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'bit-struct'
+require 'securerandom'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Auxiliary::Fuzzer
+  #include Msf::Auxiliary::Scanner
+  include Msf::Exploit::Remote::Udp
+
+  NTP_VERSIONS = (0..7).to_a
+  NTP_MODES = (0..7).to_a
+
+  def initialize
+    super(
+      'Name'        => 'NTP Protocol Fuzzer',
+      'Description' => %q(
+        A simplistic fuzzer for the Network Time Protocol that sends the
+        following probes to understand NTP and look for anomalous NTP behavior:
+
+        * All possible combinations of NTP versions and modes, even if not
+          allowed or specified in the RFCs
+        * Short versions of the above
+        * Short, invalid datagrams
+        * Full-size, random datagrams
+        * All possible NTP control messages
+
+        This findings of this fuzzer are not necessarily indicative of bugs,
+        let alone vulnerabilities, rather they point out interesting things
+        that might deserve more attention.  Furthermore, this module is not
+        particularly intelligent and there are many more areas of NTP that
+        could be explored, including:
+
+        * Warn if the response is 100% identical to the request
+        * Warn if the "mode" (if applicable) doesn't align with what we expect,
+        * Filter out the 12-byte mode 6 unsupported opcode errors.
+        * Fuzz the control message payload offset/size/etc.  There be bugs
+      ),
+      'Author'      => 'Jon Hart <jon_hart[at]rapid7.com>',
+      'License'     => MSF_LICENSE
+      )
+
+    register_options(
+      [
+        Opt::RPORT(123),
+        OptString.new('VERSIONS', [true, 'Versions to fuzz', NTP_VERSIONS.join(',')]),
+        OptString.new('MODES', [true, 'Versions to fuzz', NTP_MODES.join(',')]),
+        OptInt.new('SLEEP', [true, 'Sleep for this many ms between requests', 0]),
+        OptInt.new('WAIT', [true, 'Wait this many ms for responses', 500])
+      ], self.class)
+  end
+
+  # A very generic NTP message
+  #
+  # Uses the common/similar parts from versions 1-4 and considers everything
+  # after to be just one big field.  For the particulars on the different versions,
+  # see:
+  #   http://tools.ietf.org/html/rfc958#appendix-B
+  #   http://tools.ietf.org/html/rfc1059#appendix-B
+  #   pages 45/48 of http://tools.ietf.org/pdf/rfc1119.pdf
+  #   http://tools.ietf.org/html/rfc1305#appendix-D
+  #   http://tools.ietf.org/html/rfc5905#page-19
+  class NTPGeneric < BitStruct
+    #    0                   1                   2                   3
+    #    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    #   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    #   |LI | VN  | mode|    Stratum    |      Poll     |   Precision   |
+    #   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    unsigned :li, 2,  default: 0
+    unsigned :version, 3,  default: 0
+    unsigned :mode, 3,  default: 0
+    unsigned :stratum, 8,  default: 0
+    unsigned :poll, 8,  default: 0
+    unsigned :precision, 8,  default: 0
+    char :payload, 352
+  end
+
+  # An NTP control message.  Control packets are only specified for NTP
+  # versions 2-4, but this is a fuzzer so why not try them all...
+  class NTPControl < BitStruct
+    #  0                   1                   2                   3
+    #  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    # |00 | VN  |   6 |R E M|  op     |     Sequence                  |
+    # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    # |              status           |      association id           |
+    # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    # |              offset           |     count                     |
+    # +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    unsigned :reserved, 2, default: 0
+    unsigned :version, 3,  default: 0
+    unsigned :mode, 3,  default: 6
+    unsigned :response, 1,  default: 0
+    unsigned :error, 1,  default: 0
+    unsigned :more, 1,  default: 0
+    unsigned :operation, 5,  default: 0
+    unsigned :sequence, 16,  default: 0
+    unsigned :status, 16,  default: 0
+    unsigned :association_id, 16,  default: 0
+    # TODO: there *must* be bugs in the handling of these next two fields!
+    unsigned :payload_offset, 16,  default: 0
+    unsigned :payload_size, 16,  default: 0
+    rest :payload
+  end
+
+  def build_ntp_control(version, operation, payload = nil)
+    n = NTPControl.new
+    n.version = version
+    n.operation = operation
+    if payload
+      n.payload_offset = 0
+      n.payload_size = payload.size
+      n.payload = payload
+    end
+    n.to_s
+  end
+
+  def build_ntp_generic(version, mode)
+    n = NTPGeneric.new
+    n.version = version
+    n.mode = mode
+    n.to_s
+  end
+
+  def sleep_time
+    datastore['SLEEP'] / 1000.0
+  end
+
+  def run
+    # parse and sanity check versions
+    @versions = datastore['VERSIONS'].split(/[^\d]/).select { |v| !v.empty? }.map { |v| v.to_i }
+    unsupported_versions = @versions - NTP_VERSIONS
+    fail "Unsupported NTP versions: #{unsupported_versions}" unless unsupported_versions.empty?
+    # parse and sanity check modes
+    @modes = datastore['MODES'].split(/[^\d]/).select { |m| !m.empty? }.map { |v| v.to_i }
+    unsupported_modes = @modes - NTP_MODES
+    fail "Unsupported NTP modes: #{unsupported_modes}" unless unsupported_modes.empty?
+
+    connect_udp
+    fuzz_version_mode(rhost)
+    fuzz_version_mode(rhost, true)
+    fuzz_short(rhost)
+    fuzz_random(rhost)
+    fuzz_control(rhost) if @modes.include?(6)
+    disconnect_udp
+  end
+
+  # Sends a series of NTP control messages
+  def fuzz_control(host)
+    print_status("#{host}:#{rport} fuzzing control messages (mode 6)")
+    @versions.map { |v| v.to_i }.each do |version|
+      0.upto(31) do |op|
+        request = build_ntp_control(version, op)
+        what = "#{request.size}-byte version #{version} mode 6 op #{op} packet"
+        vprint_status("#{host}:#{rport} probing with #{request.size}-byte #{what}")
+        probe(host, datastore['RPORT'].to_i, request).each do |reply|
+          handle_response(host, request, reply, what)
+        end
+        Rex.sleep(sleep_time)
+      end
+    end
+  end
+
+  # Sends a series of small, short datagrams, looking for a reply
+  def fuzz_short(host)
+    print_status("#{host}:#{rport} fuzzing short messages")
+    0.upto(4) do |size|
+      request = SecureRandom.random_bytes(size)
+      what = "Short #{request.size}-byte random packet"
+      vprint_status("#{host}:#{rport} probing with #{what}")
+      probe(host, datastore['RPORT'].to_i, request).each do |reply|
+        handle_response(host, request, reply, what)
+      end
+      Rex.sleep(sleep_time)
+    end
+  end
+
+  # Sends a series of random, full-sized datagrams, looking for a reply
+  def fuzz_random(host)
+    print_status("#{host}:#{rport} fuzzing random messages")
+    0.upto(5) do
+      request = SecureRandom.random_bytes(48)
+      what = "random #{request.size}-byte packet"
+      vprint_status("#{host}:#{rport} probing with #{what}")
+      probe(host, datastore['RPORT'].to_i, request).each do |reply|
+        handle_response(host, request, reply, what)
+      end
+      Rex.sleep(sleep_time)
+    end
+  end
+
+  # Sends a series of different version + mode combinations
+  def fuzz_version_mode(host, short=false)
+    print_status("#{host}:#{rport} fuzzing #{short ? 'short ' : nil}version and mode combinations")
+    @versions.map { |v| v.to_i }.each do |version|
+      @modes.map { |m| m.to_i }.each do |mode|
+        request = build_ntp_generic(version, mode)
+        request = request[0, 4] if short
+        what = "#{request.size}-byte #{short ? 'short ' : nil}version #{version} mode #{mode} packet"
+        vprint_status("#{host}:#{rport} probing with #{what}")
+        probe(host, datastore['RPORT'].to_i, request).each do |reply|
+          handle_response(host, request, reply, what)
+        end
+        Rex.sleep(sleep_time)
+      end
+    end
+  end
+
+  # Sends +packet+ to +host+ on UDP port +port+, returning all replies
+  def probe(host, port, packet)
+    replies = []
+    udp_sock.sendto(packet, host, port, 0)
+    while (r = udp_sock.recvfrom(65535, datastore['WAIT'] / 1000.0) and r[1])
+      replies << r
+    end
+    replies
+  end
+
+  # Parses the given packet and provides a description about the NTP message inside
+  def describe(packet)
+    ntp = NTPGeneric.new(packet)
+    "#{packet.size}-byte version #{ntp.version} mode #{ntp.mode} reply"
+  end
+
+  def handle_response(host, request, response, what)
+    return unless response[1]
+    data = response[0]
+    problems = []
+    problems << 'large response' if request.size < data.size
+    ntp_req = NTPGeneric.new(request)
+    ntp_resp = NTPGeneric.new(data)
+    problems << 'version mismatch' if ntp_req.version != ntp_resp.version
+
+    if problems.empty?
+      print_status("#{host}:#{rport} -- Received #{describe(data)} to #{what}")
+    else
+      print_good("#{host}:#{rport} -- Received #{describe(data)} to #{what}: #{problems.join(',')}")
+    end
+  end
+end

--- a/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
@@ -179,8 +179,10 @@ class Metasploit3 < Msf::Auxiliary
   def probe(host, port, message)
     replies = []
     udp_sock.sendto(message, host, port, 0)
-    while (r = udp_sock.recvfrom(65535, datastore['WAIT'] / 1000.0) && r[1])
-      replies << r
+    reply = udp_sock.recvfrom(65535, datastore['WAIT'] / 1000.0)
+    while reply && reply[1]
+      replies << reply
+      reply = udp_sock.recvfrom(65535, datastore['WAIT'] / 1000.0)
     end
     replies
   end

--- a/spec/lib/rex/proto/ntp/modes_spec.rb
+++ b/spec/lib/rex/proto/ntp/modes_spec.rb
@@ -1,0 +1,83 @@
+# -*- coding: binary -*-
+#
+require 'rex/proto/ntp/modes'
+
+describe "Rex::Proto::NTP mode message handling" do
+  before do
+    @payload = 'R7' * 7
+  end
+
+  describe Rex::Proto::NTP::NTPControl do
+    before do
+      @control_raw = "\x1e\x05\x12\x34\x12\x34\x12\x34\x00\x00\x00\x0e" + @payload
+      @control = Rex::Proto::NTP::NTPControl.new
+      @control.version = 3
+      @control.response = 0
+      @control.more = 0
+      @control.operation = 5
+      @control.sequence = 0x1234
+      @control.association_id = 0x1234
+      @control.status = 0x1234
+      @control.payload_offset = 0
+      @control.payload_size = 14
+      @control.payload = @payload
+    end
+
+    it 'Generates control NTP messages correctly' do
+      @control_raw.should == @control.to_s
+    end
+
+    it 'Parses private NTP messages correctly' do
+      parsed_raw = Rex::Proto::NTP::NTPControl.new(@control_raw)
+      @control.should == parsed_raw
+    end
+  end
+
+  describe Rex::Proto::NTP::NTPGeneric do
+    before do
+      @generic_raw = "\xcc\x12\x34\x56" + @payload
+      @generic = Rex::Proto::NTP::NTPGeneric.new
+      @generic.li = 3
+      @generic.version = 1
+      @generic.mode = 4
+      @generic.stratum = 0x12
+      @generic.poll = 0x34
+      @generic.precision = 0x56
+      @generic.payload = @payload
+    end
+
+    it 'Generates generic NTP messages correctly' do
+      @generic_raw.should == @generic.to_s
+    end
+
+    it 'Parses private NTP messages correctly' do
+      parsed_raw = Rex::Proto::NTP::NTPGeneric.new(@generic_raw)
+      @generic.should == parsed_raw
+    end
+  end
+
+  describe Rex::Proto::NTP::NTPPrivate do
+    before do
+      @private_raw = "\x1f\x5a\x01\x99" + @payload
+      @private = Rex::Proto::NTP::NTPPrivate.new
+      @private.response = 0
+      @private.more = 0
+      @private.version = 3
+      @private.mode = 7
+      @private.auth = 0
+      @private.sequence = 90
+      @private.implementation = 1
+      @private.request_code = 153
+      @private.payload = @payload
+    end
+
+    it 'Generates private NTP messages correctly' do
+      @private_raw.should == @private.to_s
+    end
+
+    it 'Parses private NTP messages correctly' do
+      parsed_raw = Rex::Proto::NTP::NTPPrivate.new(@private_raw)
+      @private.should == parsed_raw
+    end
+  end
+end

--- a/spec/lib/rex/proto/ntp/modes_spec.rb
+++ b/spec/lib/rex/proto/ntp/modes_spec.rb
@@ -27,7 +27,7 @@ describe "Rex::Proto::NTP mode message handling" do
       @control_raw.should == @control.to_s
     end
 
-    it 'Parses private NTP messages correctly' do
+    it 'Parses control NTP messages correctly' do
       parsed_raw = Rex::Proto::NTP::NTPControl.new(@control_raw)
       @control.should == parsed_raw
     end
@@ -50,7 +50,7 @@ describe "Rex::Proto::NTP mode message handling" do
       @generic_raw.should == @generic.to_s
     end
 
-    it 'Parses private NTP messages correctly' do
+    it 'Parses generic NTP messages correctly' do
       parsed_raw = Rex::Proto::NTP::NTPGeneric.new(@generic_raw)
       @generic.should == parsed_raw
     end
@@ -58,7 +58,7 @@ describe "Rex::Proto::NTP mode message handling" do
 
   describe Rex::Proto::NTP::NTPPrivate do
     before do
-      @private_raw = "\x1f\x5a\x01\x99" + @payload
+      @private_raw = "\x1f\x5a\x01\x99\x00\x00\x00\x00" + @payload
       @private = Rex::Proto::NTP::NTPPrivate.new
       @private.response = 0
       @private.more = 0

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -133,9 +133,7 @@ class Msftidy
           break
         end
       else
-        if line =~ /^\s*(require|load)\s+['"]nokogiri['"]/
-          has_nokogiri = true
-        end
+        has_nokogiri = line_has_require?(line, 'nokogiri')
       end
     end
     error(msg) if has_nokogiri_xml_parser
@@ -199,6 +197,23 @@ class Msftidy
         end
       end
     end
+  end
+
+  # See if 'require "rubygems"' or equivalent is used, and
+  # warn if so.  Since Ruby 1.9 this has not been necessary and
+  # the framework only suports 1.9+
+  def check_rubygems
+    @source.each_line do |line|
+      if line_has_require?(line, 'rubygems')
+        warn("Explicitly requiring/loading rubygems is not necessary")
+        break
+      end
+    end
+  end
+
+  # Does the given line contain a require/load of the specified library?
+  def line_has_require?(line, lib)
+    line =~ /^\s*(require|load)\s+['"]#{lib}['"]/
   end
 
   def check_snake_case_filename
@@ -551,6 +566,7 @@ def run_checks(full_filepath)
   tidy.check_mode
   tidy.check_shebang
   tidy.check_nokogiri
+  tidy.check_rubygems
   tidy.check_ref_identifiers
   tidy.check_old_keywords
   tidy.check_verbose_option


### PR DESCRIPTION
Justification:
- I wanted to understand NTP better
- Promote future research in NTP with Metasploit

Validation:
1. Run against a target running NTP that allows and responds to mode 6 or 7 requests.  I
2. Run against a target running NTP that doesn't allow or respond to mode 6 or 7 requests (ntpd on an updated Ubuntu target, Windows NTP clients and OpenNTP).  Aside from status output, the module should find nothing.

Sample output:

```
[*] cisco2620.vuln:123 fuzzing version and mode combinations
[*] cisco2620.vuln:123 -- Received 48-byte version 1 mode 4 reply to 48-byte version 1 mode 3 packet
[+] cisco2620.vuln:123 -- Received 8-byte version 3 mode 7 reply to 48-byte version 1 mode 7 packet: version mismatch
....
[*] cisco2620.vuln:123 -- Received 48-byte version 2 mode 2 reply to 48-byte version 2 mode 1 packet

[+] cisco2620.vuln:123 -- Received 8-byte version 3 mode 7 reply to 48-byte version 4 mode 7 packet: version mismatch
[*] cisco2620.vuln:123 -- Received 48-byte version 5 mode 4 reply to 48-byte version 5 mode 3 packet
[+] cisco2620.vuln:123 -- Received 8-byte version 3 mode 7 reply to 48-byte version 5 mode 7 packet: version mismatch
[*] cisco2620.vuln:123 -- Received 48-byte version 6 mode 2 reply to 48-byte version 6 mode 1 packet
[*] cisco2620.vuln:123 -- Received 48-byte version 6 mode 4 reply to 48-byte version 6 mode 3 packet
[+] cisco2620.vuln:123 -- Received 8-byte version 3 mode 7 reply to 48-byte version 6 mode 7 packet: version mismatch
[*] cisco2620.vuln:123 -- Received 48-byte version 7 mode 2 reply to 48-byte version 7 mode 1 packet
[*] cisco2620.vuln:123 -- Received 48-byte version 7 mode 4 reply to 48-byte version 7 mode 3 packet
[+] cisco2620.vuln:123 -- Received 8-byte version 3 mode 7 reply to 48-byte version 7 mode 7 packet: version mismatch
[*] cisco2620.vuln:123 fuzzing short version and mode combinations
[+] cisco2620.vuln:123 -- Received 8-byte version 3 mode 7 reply to 4-byte short version 1 mode 7 packet: large response,version mismatch
...
[*] cisco2620.vuln:123 fuzzing short messages
[+] cisco2620.vuln:123 -- Received 8-byte version 3 mode 7 reply to Short 0-byte random packet: large response,version mismatch
[+] cisco2620.vuln:123 -- Received 8-byte version 3 mode 7 reply to Short 2-byte random packet: large response,version mismatch
[*] cisco2620.vuln:123 fuzzing random messages
[+] cisco2620.vuln:123 -- Received 8-byte version 3 mode 7 reply to random 48-byte packet: version mismatch
[*] cisco2620.vuln:123 fuzzing control messages (mode 6)
[*] cisco2620.vuln:123 -- Received 12-byte version 1 mode 6 reply to 12-byte version 1 mode 6 op 0 packet
[+] cisco2620.vuln:123 -- Received 16-byte version 1 mode 6 reply to 12-byte version 1 mode 6 op 1 packet: large response
[+] cisco2620.vuln:123 -- Received 228-byte version 1 mode 6 reply to 12-byte version 1 mode 6 op 2 packet: large response
[*] cisco2620.vuln:123 -- Received 12-byte version 1 mode 6 reply to 12-byte version 1 mode 6 op 3 packet
```

Those large responses are effectively the monlist/CVE-2013-5211 being discovered using fuzzing. The bulk of the other findings are either minimal DoS conditions or potential protocol violations exhibited by the NTP endpoint in question.
