### PR TITLE
modules living inside scanner should include the Scanner mixin

### DIFF
--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -10,6 +10,7 @@ class Metasploit3 < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::AuthBrute
+  include Msf::Auxiliary::Scanner
 
   def initialize(info={})
     super(update_info(info,
@@ -55,11 +56,11 @@ class Metasploit3 < Msf::Auxiliary
       })
 
       if not res
-        print_error("#{peer} - Connection timed out")
+        vprint_error("#{peer} - Connection timed out")
         return :abort
       end
     rescue ::Rex::ConnectionError, Errno::ECONNREFUSED
-      print_error("#{peer} - Failed to response")
+      vprint_error("#{peer} - Failed to response")
       return :abort
     end
 
@@ -79,7 +80,7 @@ class Metasploit3 < Msf::Auxiliary
   end
 
 
-  def run
+  def run_host(ip)
     if anonymous_access?
       print_status("#{peer} - No login necessary. Server allows anonymous access.")
       return


### PR DESCRIPTION
As @hmoore-r7 noticed, there are some modules living in `modules/auxiliary/scanner/` which doesn't include the `Scanner` mixin. This pull request tries to solve it. There are some exceptions / modules this pull request is forgetting:

modules/auxiliary/scanner/http/enum_wayback.rb: because it doesn't use RHOSTS neither RHOST at all, probably it shouldn't live in the `scanner` folder?
modules/auxiliary/scanner/http/crawler.rb: because I guess it is designed as a web crawler/**scanner**, because of that it's living under `scanner`
modules/auxiliary/scanner/http/smt_ipmi_cgi_scanner.rb: because @hmoore-r7 is taking care of it.
## Verification
- [x] Run msftidy against the modules. Verify there aren't warnings.
- [x] Get and install vulnerable applications for testing || be confident about your code review skill || or put a dummy web server just to verify the modules are running as before  for verification
