### PR TITLE
Normalize on single quotes, msftidy error

### DIFF
--- a/modules/auxiliary/admin/chromecast/chromecast_youtube.rb
+++ b/modules/auxiliary/admin/chromecast/chromecast_youtube.rb
@@ -3,7 +3,7 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require "msf/core"
+require 'msf/core'
 
 class Metasploit4 < Msf::Auxiliary
 
@@ -11,35 +11,35 @@ class Metasploit4 < Msf::Auxiliary
 
   def initialize(info = {})
     super(update_info(info,
-      "Name" => "Chromecast YouTube Remote Control",
-      "Description" => %q{
+      'Name' => 'Chromecast YouTube Remote Control',
+      'Description' => %q{
         This module acts as a simple remote control for Chromecast YouTube.
       },
-      "Author" => ["wvu"],
-      "References" => [
-        ["URL", "https://en.wikipedia.org/wiki/Chromecast"]
+      'Author' => ['wvu'],
+      'References' => [
+        ['URL', 'https://en.wikipedia.org/wiki/Chromecast']
       ],
-      "License" => MSF_LICENSE,
-      "Actions" => [
-        ["Play", "Description" => "Play video"],
-        ["Stop", "Description" => "Stop video"]
+      'License' => MSF_LICENSE,
+      'Actions' => [
+        ['Play', 'Description' => 'Play video'],
+        ['Stop', 'Description' => 'Stop video']
       ],
-      "DefaultAction" => "Play"
+      'DefaultAction' => 'Play'
     ))
 
     register_options([
       Opt::RPORT(8008),
-      OptString.new("VID", [true, "Video ID", "kxopViU98Xo"])
+      OptString.new('VID', [true, 'Video ID', 'kxopViU98Xo'])
     ], self.class)
   end
 
   def run
-    vid = datastore["VID"]
+    vid = datastore['VID']
 
     case action.name
-    when "Play"
+    when 'Play'
       res = play(vid)
-    when "Stop"
+    when 'Stop'
       res = stop
     end
 
@@ -58,11 +58,11 @@ class Metasploit4 < Msf::Auxiliary
   def play(vid)
     begin
       send_request_cgi(
-        "method" => "POST",
-        "uri" => "/apps/YouTube",
-        "agent" => Rex::Text.rand_text_english(rand(42) + 1),
-        "vars_post" => {
-          "v" => vid
+        'method' => 'POST',
+        'uri' => '/apps/YouTube',
+        'agent' => Rex::Text.rand_text_english(rand(42) + 1),
+        'vars_post' => {
+          'v' => vid
         }
       )
     rescue Rex::ConnectionRefused, Rex::ConnectionTimeout,
@@ -76,9 +76,9 @@ class Metasploit4 < Msf::Auxiliary
   def stop
     begin
       send_request_raw(
-        "method" => "DELETE",
-        "uri" => "/apps/YouTube",
-        "agent" => Rex::Text.rand_text_english(rand(42) + 1)
+        'method' => 'DELETE',
+        'uri' => '/apps/YouTube',
+        'agent' => Rex::Text.rand_text_english(rand(42) + 1)
       )
     rescue Rex::ConnectionRefused, Rex::ConnectionTimeout,
            Rex::HostUnreachable => e

--- a/modules/auxiliary/gather/mongodb_js_inject_collection_enum.rb
+++ b/modules/auxiliary/gather/mongodb_js_inject_collection_enum.rb
@@ -6,7 +6,6 @@
 require 'msf/core'
 
 class Metasploit4 < Msf::Auxiliary
-  Rank = GoodRanking
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Auxiliary::Report


### PR DESCRIPTION
This PR fixes up two recent module submissions, the Chromecast module (PR #3438) and the MongoDB module (PR #3430). These changes shouldn't cause any change in normal functionality -- the first is just to favor single quotes over double in the `initialize` method (and the `send_request_raw` calls), and the second is to correct a msftidy warning.
## Verification
- [x] See that the affected modules load as normal
- [x] See that the info for the modules is unchanged.
