### PR TITLE
Use correct variable name

### DIFF
--- a/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
+++ b/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
@@ -90,7 +90,7 @@ class Metasploit3 < Msf::Auxiliary
         key_md5 = ::Rex::Text.md5(key)
         hash_path = "/#{key_md5[0,1]}/#{key_md5[1,1]}/#{key_md5[2,1]}/#{key_md5}"
         url = normalize_uri(wordpress_url, datastore["WP_CONTENT_DIR"], "/w3tc/dbcache")
-        uri << hash_path
+        url << hash_path
 
         result = nil
         begin


### PR DESCRIPTION
Fixes an undefined local variable error in the W3TC hash extraction module.
