### PR TITLE
Fix regression in webview exploit.

### DIFF
--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -148,6 +148,6 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def html(arch)
-    "<!doctype html><html><body><script>#{js(arch)}</script></body></html>"
+    "<!doctype html><html><body><script>#{add_javascript_interface_exploit_js(arch)}</script></body></html>"
   end
 end


### PR DESCRIPTION
I moved some code around for the android webview exploit in #3418 and forgot to update a call from `js` to the `add_javascript_interface_exploit_js` method in the mixin I created, which breaks the primary vector (serving html to a vulnerable browser).

Looking at the code it is apparent that this fixes a bug, but to be sure I verified against a 4.1.2. target.

Verify:
- [x] Run the `android/browser/webview_addjavascriptinterface`
- [x] Get a session by navigating an android browser directly to the URL served by the exploit
