### PR TITLE
Add check for newline at end of file

### DIFF
--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -523,6 +523,12 @@ class Msftidy
     end
   end
 
+  def check_newline_eof
+    if @source !~ /(?:\r\n|\n)\z/m
+      info('Please add a newline at the end of the file')
+    end
+  end
+
   private
 
   def load_file(file)
@@ -567,6 +573,7 @@ def run_checks(full_filepath)
   tidy.check_comment_splat
   tidy.check_vuln_codes
   tidy.check_vars_get
+  tidy.check_newline_eof
   return tidy
 end
 


### PR DESCRIPTION
This adds a check to msftidy for a newline at the end of a file. This is only codestyling so i made it an info.

```
firefart@mint ~/coding/metasploit-framework $ ruby tools/msftidy.rb modules/* | grep -i newline
modules/auxiliary/scanner/http/manageengine_deviceexpert_traversal.rb - [INFO] Please add a newline at the end of the file
modules/auxiliary/scanner/http/rails_json_yaml_scanner.rb - [INFO] Please add a newline at the end of the file
modules/auxiliary/scanner/sap/sap_smb_relay.rb - [INFO] Please add a newline at the end of the file
modules/auxiliary/scanner/scada/modbusclient.rb - [INFO] Please add a newline at the end of the file
modules/exploits/linux/ssh/symantec_smg_ssh.rb - [INFO] Please add a newline at the end of the file
modules/exploits/multi/http/log1cms_ajax_create_folder.rb - [INFO] Please add a newline at the end of the file
modules/exploits/unix/webapp/clipbucket_upload_exec.rb - [INFO] Please add a newline at the end of the file
modules/exploits/unix/webapp/havalite_upload_exec.rb - [INFO] Please add a newline at the end of the file
modules/exploits/unix/webapp/horde_unserialize_exec.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/browser/clear_quest_cqole.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/browser/crystal_reports_printcontrol.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/browser/hp_loadrunner_writefilebinary.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/browser/hp_loadrunner_writefilestring.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/browser/ibm_spss_c1sizer.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/browser/inotes_dwa85w_bof.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/browser/mcafee_mvt_exec.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/browser/ms13_090_cardspacesigninhelper.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/browser/novell_groupwise_gwcls1_actvx.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/browser/ntr_activex_stopmodule.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/browser/ovftool_format_string.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/browser/quickr_qp2_bof.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/fileformat/actfax_import_users_bof.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/fileformat/real_player_url_property_bof.rb - [INFO] Please add a newline at the end of the file
modules/exploits/windows/misc/hp_operations_agent_coda_34.rb - [INFO] Please add a newline at the end of the file
modules/payloads/stagers/android/reverse_http.rb - [INFO] Please add a newline at the end of the file
modules/post/multi/manage/record_mic.rb - [INFO] Please add a newline at the end of the file
```
