### PR TITLE
[SeeRM #8815] struts_code_exec_parameters: Dont try to exploit when generate_payload_exe fails

### DIFF
--- a/modules/exploits/multi/http/struts_code_exec_parameters.rb
+++ b/modules/exploits/multi/http/struts_code_exec_parameters.rb
@@ -120,6 +120,9 @@ class Metasploit3 < Msf::Exploit::Remote
     #Set up generic values.
     payload_exe = rand_text_alphanumeric(4 + rand(4))
     pl_exe = generate_payload_exe
+    if pl_exe.nil?
+      fail_with(Failure::BadConfig, "#{peer} - Failed to generate an EXE payload, please select a correct payload")
+    end
     append = false
     #Now arch specific...
     case target['Platform']


### PR DESCRIPTION
Solves https://dev.metasploit.com/redmine/issues/8815, originally reported via #3462

When using the `Linux` target the `generic/shell_reverse_tcp` payload is selected automatically if you don't set up a payload manually. Unfortunately generate_payload_exe doesn't work with this payload, returning a nil, which is used later. This patch just fixes the module by failing if `generate_payload_exe` turns `nil`.
## Verification
- [x] use exploit/multi/http/struts_code_exec_parameters
- [x] set target 1
- [x] set rhost domain-name.com
- [x] set rport 80
- [x] set targeturi /xy/X.action
- [x] exploit

You shouldn't see the unhandled exception anymore:

```
[*] Reloading module...

[*] Started reverse handler on 10.6.0.82:4444
[*] 172.0.0.1:8181 - Uploading exploit to /tmp/IK9sa
[-] Exploit failed: NoMethodError undefined method `length' for nil:NilClass
```

But a more informative message:

```
msf exploit(struts_code_exec_parameters) > rexploit
[*] Reloading module...

[*] Started reverse handler on 10.6.0.82:4444
[-] Exploit failed [bad-config]: 172.0.0.1:8181 - Failed to generate an EXE payload, please select a correct payload
```
