### PR TITLE
Fix handler deadlock in corner cases with dead clients

### DIFF
--- a/lib/msf/core/handler/reverse_tcp.rb
+++ b/lib/msf/core/handler/reverse_tcp.rb
@@ -162,7 +162,7 @@ module ReverseTcp
         client = self.handler_queue.pop
         begin
           if datastore['ReverseListenerThreaded']
-            self.conn_threads << framework.threads.spawn("ReverseTcpHandlerSession", false, client) { | client_copy|
+            self.conn_threads << framework.threads.spawn("ReverseTcpHandlerSession-#{local_port}-#{client.peerhost}", false, client) { | client_copy|
               handle_connection(wrap_aes_socket(client_copy))
             }
           else

--- a/lib/msf/core/handler/reverse_tcp.rb
+++ b/lib/msf/core/handler/reverse_tcp.rb
@@ -55,11 +55,12 @@ module ReverseTcp
         OptAddress.new('ReverseListenerBindAddress', [ false, 'The specific IP address to bind to on the local system']),
         OptInt.new('ReverseListenerBindPort', [ false, 'The port to bind to on the local system if different from LPORT' ]),
         OptString.new('ReverseListenerComm', [ false, 'The specific communication channel to use for this listener']),
-        OptBool.new('ReverseAllowProxy', [ true, 'Allow reverse tcp even with Proxies specified. Connect back will NOT go through proxy but directly to LHOST', false])
+        OptBool.new('ReverseAllowProxy', [ true, 'Allow reverse tcp even with Proxies specified. Connect back will NOT go through proxy but directly to LHOST', false]),
+        OptBool.new('ReverseListenerThreaded', [ true, 'Handle every connection in a new thread (experimental)', false])
       ], Msf::Handler::ReverseTcp)
 
-
     self.handler_queue = ::Queue.new
+    self.conn_threads = []
   end
 
   #
@@ -124,6 +125,12 @@ module ReverseTcp
   #
   def cleanup_handler
     stop_handler
+
+    # Kill any remaining handle_connection threads that might
+    # be hanging around
+    conn_threads.each { |thr|
+      thr.kill rescue nil
+    }
   end
 
   #
@@ -154,7 +161,13 @@ module ReverseTcp
       while true
         client = self.handler_queue.pop
         begin
-          handle_connection(wrap_aes_socket(client))
+          if datastore['ReverseListenerThreaded']
+            self.conn_threads << framework.threads.spawn("ReverseTcpHandlerSession", false, client) { | client_copy|
+              handle_connection(wrap_aes_socket(client_copy))
+            }
+          else
+            handle_connection(wrap_aes_socket(client))
+          end
         rescue ::Exception
           elog("Exception raised from handle_connection: #{$!.class}: #{$!}\n\n#{$@.join("\n")}")
         end
@@ -261,6 +274,7 @@ protected
   attr_accessor :listener_thread # :nodoc:
   attr_accessor :handler_thread # :nodoc:
   attr_accessor :handler_queue # :nodoc:
+  attr_accessor :conn_threads # :nodoc:
 end
 
 end

--- a/lib/msf/core/handler/reverse_tcp_double.rb
+++ b/lib/msf/core/handler/reverse_tcp_double.rb
@@ -48,7 +48,6 @@ module ReverseTcpDouble
     register_advanced_options(
       [
         OptBool.new('ReverseAllowProxy', [ true, 'Allow reverse tcp even with Proxies specified. Connect back will NOT go through proxy but directly to LHOST', false]),
-        OptBool.new('ReverseListenerThreaded', [ true, 'Handle every connection in a new thread', false])
       ], Msf::Handler::ReverseTcpDouble)
 
     self.conn_threads = []


### PR DESCRIPTION
This adds ReverseListenerThreaded to reverse_tcp and disables it by default. It is necessary in situations where a single "dead" client prevents the successful staging of other pending connections.

This also puts the input/output detection code of reverse_double into the connection thread (it already handles all connections as a new thread, but there is a chance of deadlock in the input/output detection).
