### PR TITLE
A few tidies as a result of the Meterpreter gemification code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,31 +54,19 @@ external/source/exploits/**/Release
 
 # Avoid checking in Meterpreter binaries. These are supplied upstream by
 # the meterpreter_bins gem.
-data/meterpreter/elevator.x64.dll
-data/meterpreter/elevator.x86.dll
-data/meterpreter/ext_server_espia.x64.dll
-data/meterpreter/ext_server_espia.x86.dll
-data/meterpreter/ext_server_extapi.x64.dll
-data/meterpreter/ext_server_extapi.x86.dll
-data/meterpreter/ext_server_incognito.x64.dll
-data/meterpreter/ext_server_incognito.x86.dll
-data/meterpreter/ext_server_kiwi.x64.dll
-data/meterpreter/ext_server_kiwi.x86.dll
-data/meterpreter/ext_server_lanattacks.x64.dll
-data/meterpreter/ext_server_lanattacks.x86.dll
-data/meterpreter/ext_server_mimikatz.x64.dll
-data/meterpreter/ext_server_mimikatz.x86.dll
-data/meterpreter/ext_server_priv.x64.dll
-data/meterpreter/ext_server_priv.x86.dll
-data/meterpreter/ext_server_stdapi.x64.dll
-data/meterpreter/ext_server_stdapi.x86.dll
-data/meterpreter/metsrv.x64.dll
-data/meterpreter/metsrv.x86.dll
-data/meterpreter/screenshot.x64.dll
-data/meterpreter/screenshot.x86.dll
+data/meterpreter/elevator.*.dll
+data/meterpreter/ext_server_espia.*.dll
+data/meterpreter/ext_server_extapi.*.dll
+data/meterpreter/ext_server_incognito.*.dll
+data/meterpreter/ext_server_kiwi.*.dll
+data/meterpreter/ext_server_lanattacks.*.dll
+data/meterpreter/ext_server_mimikatz.*.dll
+data/meterpreter/ext_server_priv.*.dll
+data/meterpreter/ext_server_stdapi.*.dll
+data/meterpreter/metsrv.*.dll
+data/meterpreter/screenshot.*.dll
 
 # Avoid checking in Meterpreter libs that are built from
 # private source. If you're interested in this functionality,
 # check out Metasploit Pro: http://metasploit.com/download
-data/meterpreter/ext_server_pivot.x86.dll
-data/meterpreter/ext_server_pivot.x64.dll
+data/meterpreter/ext_server_pivot.*.dll

--- a/lib/rex/post/meterpreter/extensions/priv/priv.rb
+++ b/lib/rex/post/meterpreter/extensions/priv/priv.rb
@@ -45,7 +45,7 @@ class Priv < Extension
 
     elevator_name = Rex::Text.rand_text_alpha_lower( 6 )
 
-    elevator_path = MeterpreterBinaries.path(elevator, client.binary_suffix)
+    elevator_path = MeterpreterBinaries.path('elevator', client.binary_suffix)
 
     elevator_path = ::File.expand_path( elevator_path )
 

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -1,4 +1,5 @@
 # -*- coding: binary -*-
+require 'set'
 require 'rex/post/meterpreter'
 require 'rex/parser/arguments'
 
@@ -416,17 +417,17 @@ class Console::CommandDispatcher::Core
     @@load_opts.parse(args) { |opt, idx, val|
       case opt
       when "-l"
-        exts = []
+        exts = SortedSet.new
         msf_path = MeterpreterBinaries.metasploit_data_dir
         gem_path = MeterpreterBinaries.local_dir
         [msf_path, gem_path].each do |path|
           ::Dir.entries(path).each { |f|
             if (::File.file?(::File.join(path, f)) && f =~ /ext_server_(.*)\.#{client.binary_suffix}/ )
-              exts.push($1) unless exts.include?($1)
+              exts.add($1)
             end
           }
         end
-        print(exts.sort.join("\n") + "\n")
+        print(exts.to_a.join("\n") + "\n")
 
         return true
       when "-h"
@@ -464,19 +465,19 @@ class Console::CommandDispatcher::Core
   end
 
   def cmd_load_tabs(str, words)
-    tabs = []
+    tabs = SortedSet.new
     msf_path = MeterpreterBinaries.metasploit_data_dir
     gem_path = MeterpreterBinaries.local_dir
     [msf_path, gem_path].each do |path|
     ::Dir.entries(path).each { |f|
       if (::File.file?(::File.join(path, f)) && f =~ /ext_server_(.*)\.#{client.binary_suffix}/ )
         if (not extensions.include?($1))
-          tabs.push($1) unless tabs.include?($1)
+          tabs.add($1)
         end
       end
     }
     end
-    return tabs
+    return tabs.to_a
   end
 
   def cmd_use(*args)

--- a/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
+++ b/lib/rex/post/meterpreter/ui/console/command_dispatcher/core.rb
@@ -415,23 +415,23 @@ class Console::CommandDispatcher::Core
 
     @@load_opts.parse(args) { |opt, idx, val|
       case opt
-        when "-l"
-          exts = []
-          msf_path = MeterpreterBinaries.metasploit_data_dir
-          gem_path = MeterpreterBinaries.local_dir
-          [msf_path, gem_path].each do |path|
-            ::Dir.entries(path).each { |f|
-              if (::File.file?(::File.join(path, f)) && f =~ /ext_server_(.*)\.#{client.binary_suffix}/ )
-                exts.push($1) unless exts.include?($1)
-              end
-            }
-          end
-          print(exts.sort.join("\n") + "\n")
+      when "-l"
+        exts = []
+        msf_path = MeterpreterBinaries.metasploit_data_dir
+        gem_path = MeterpreterBinaries.local_dir
+        [msf_path, gem_path].each do |path|
+          ::Dir.entries(path).each { |f|
+            if (::File.file?(::File.join(path, f)) && f =~ /ext_server_(.*)\.#{client.binary_suffix}/ )
+              exts.push($1) unless exts.include?($1)
+            end
+          }
+        end
+        print(exts.sort.join("\n") + "\n")
 
-          return true
-        when "-h"
-          cmd_load_help
-          return true
+        return true
+      when "-h"
+        cmd_load_help
+        return true
       end
     }
 
@@ -736,10 +736,10 @@ class Console::CommandDispatcher::Core
 
     @@write_opts.parse(args) { |opt, idx, val|
       case opt
-        when "-f"
-          src_file = val
-        else
-          cid = val.to_i
+      when "-f"
+        src_file = val
+      else
+        cid = val.to_i
       end
     }
 


### PR DESCRIPTION
As noted in https://github.com/rapid7/metasploit-framework/pull/3466 there were a few small formatting/style issues that needed adjusting. They are:
- Use of `SortedSet` instead of arrays for generation of extension lists/tabs.
- Indentation of `when` statements in `case` blocks.
- Use of wildcards in the `.gitignore` for the ignored extensions.

There might be other things which will be adjusted down the track but this should be good to go short term.
