### PR TITLE
Fix portspec allowing port 0

### DIFF
--- a/lib/rex/socket.rb
+++ b/lib/rex/socket.rb
@@ -534,11 +534,11 @@ module Socket
     end
 
     if ports.empty? and not remove.empty? then
-      ports = 0.upto 65535
+      ports = 1.upto 65535
     end
 
     # Sort, and remove dups and invalid ports
-    ports.sort.uniq.delete_if { |p| p < 0 or p > 65535 or remove.include? p }
+    ports.sort.uniq.delete_if { |p| p < 1 or p > 65535 or remove.include? p }
   end
 
   #
@@ -551,7 +551,7 @@ module Socket
     lastp  = nil
 
     parr.uniq.sort{|a,b| a<=>b}.map{|a| a.to_i}.each do |n|
-      next if (n < 0 or n > 65535)
+      next if (n < 1 or n > 65535)
       if not lastp
         range = [n]
         lastp = n

--- a/spec/lib/rex/socket_spec.rb
+++ b/spec/lib/rex/socket_spec.rb
@@ -1,5 +1,6 @@
 # -*- coding:binary -*-
 require 'rex/socket/range_walker'
+require 'spec_helper'
 
 describe Rex::Socket do
 
@@ -166,30 +167,30 @@ describe Rex::Socket do
 
   describe '.portspec_to_portlist' do
 
-    portspec = '-1,0-10,!2-5,!7,65530-,65536'
-    context "'#{portspec}'" do
+    subject(:portlist) { described_class.portspec_to_portlist portspec_string}
+    let(:portspec_string) { '-1,0-10,!2-5,!7,65530-,65536' }
 
-      subject { described_class.portspec_to_portlist portspec } 
+    it 'does not include negative numbers' do
+      expect(portlist).to_not include '-1'
+    end
 
-      it { should be_a(Array) }
+    it 'does not include 0' do
+      expect(portlist).to_not include '0'
+    end
 
-      not_included = []
-      not_included << -1
-      not_included << 65536
-      not_included.concat (2..5).to_a
-      not_included << 7
-      not_included.each do |item|
-        it { should_not include item }
+    it 'does not include negated numbers' do
+      ['2', '3', '4', '5', '7'].each do |port|
+        expect(portlist).to_not include port
       end
+    end
 
-      included = []
-      included << -1
-      included.concat (0..10).to_a
-      included.concat (65530..65535).to_a
-      included << 65536
-      included = included - not_included
-      included.each do |item|
-        it { should include item }
+    it 'does not include any numbers above 65535' do
+      expect(portlist).to_not include '65536'
+    end
+
+    it 'expands open ended ranges' do
+      (65530..65535).each do |port|
+        expect(portlist).to include port
       end
     end
   end


### PR DESCRIPTION
A change was made to allow portspec to include 0. This was intentionally not allowed before. the RFC does not allow the use of port 0. We have code that depends on portspec not allowing it. Additionally no socket implementation allows you to bind to port 0. If you try to bind to port 0 it binds to a random available port, not port 0.
