### PR TITLE
RAKP defines auth, not cipher-0 bypass, see below.

### DIFF
--- a/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize
     super(
-      'Name'        => 'IPMI 2.0 RAKP Cipher Zero Authentication Bypass Scanner',
+      'Name'        => 'IPMI 2.0 Cipher Zero Authentication Bypass Scanner',
       'Description' => %q|
         This module identifies IPMI 2.0 compatible systems that are vulnerable
         to an authentication bypass vulnerability through the use of cipher


### PR DESCRIPTION
Dan Farmer noted that the RAKP reference in the title was not correct
and that RAKP is a separate issue and protocol implementation than
the use of Cipher Zero to perform an authentication bypass.

Cosmetic only change
