### PR TITLE
Add verbosity to Jenkins Enum

### DIFF
--- a/modules/auxiliary/scanner/http/jenkins_enum.rb
+++ b/modules/auxiliary/scanner/http/jenkins_enum.rb
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     version = res.headers['X-Jenkins']
-    vprint_status("#{peer} - Jenkins Version - #{version}")
+    print_status("#{peer} - Jenkins Version - #{version}")
     report_service(
       :host  => rhost,
       :port  => rport,
@@ -120,17 +120,17 @@ class Metasploit3 < Msf::Auxiliary
         )
       end
     when 403
-      vprint_status("#{peer} - #{uri_path} restricted (403)")
+      print_status("#{peer} - #{uri_path} restricted (403)")
     when 401
-      vprint_status("#{peer} - #{uri_path} requires authentication (401): #{res.headers['WWW-Authenticate']}")
+      print_status("#{peer} - #{uri_path} requires authentication (401): #{res.headers['WWW-Authenticate']}")
     when 404
-      vprint_status("#{peer} - #{uri_path} not found (404)")
+      print_status("#{peer} - #{uri_path} not found (404)")
     when 301
-      vprint_status("#{peer} - #{uri_path} is redirected (#{res.code}) to #{res.headers['Location']} (not following)")
+      print_status("#{peer} - #{uri_path} is redirected (#{res.code}) to #{res.headers['Location']} (not following)")
     when 302
-      vprint_status("#{peer} - #{uri_path} is redirected (#{res.code}) to #{res.headers['Location']} (not following)")
+      print_status("#{peer} - #{uri_path} is redirected (#{res.code}) to #{res.headers['Location']} (not following)")
     else
-      vprint_status("#{peer} - #{uri_path} Don't know how to handle response code #{res.code}")
+      print_status("#{peer} - #{uri_path} Don't know how to handle response code #{res.code}")
     end
   end
 


### PR DESCRIPTION
Currently this is what happens when I Jenkins box is found but doesn't allow the URLs requested:

```
msf auxiliary(jenkins_enum) > set RHOSTS 192.168.1.100
RHOSTS => 192.168.1.100
msf auxiliary(jenkins_enum) > set TARGETURI /
TARGETURI => /
msf auxiliary(jenkins_enum) > run

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Then here is the result of running it with VERBOSE to true:

```
msf auxiliary(jenkins_enum) > set VERBOSE true
VERBOSE => true
msf auxiliary(jenkins_enum) > run

[*] 192.168.1.100:80 - Jenkins Version - 1.5
[*] 192.168.1.100:80 - /script restricted (403)
[*] 192.168.1.100:80 - /view/All/newJob restricted (403)
[*] 192.168.1.100:80 - /asynchPeople/ restricted (403)
[*] 192.168.1.100:80 - /systemInfo restricted (403)
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

I think having a enum module give a bit of verbose output by default is a good thing.
