### PR TITLE
Force MDM to 0.17.4 as 0.17.5 breaks things

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :db do
   # Needed for Msf::DbManager
   gem 'activerecord', '>= 3.0.0', '< 4.0.0'
   # Database models shared between framework and Pro.
-  gem 'metasploit_data_models', '~> 0.17.0'
+  gem 'metasploit_data_models', '0.17.4'
   # Needed for module caching in Mdm::ModuleDetails
   gem 'pg', '>= 0.11'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,9 +22,15 @@ GEM
     fivemat (1.2.1)
     i18n (0.6.5)
     json (1.8.0)
-    metasploit_data_models (0.17.0)
-      activerecord (>= 3.2.13)
+    metasploit-concern (0.1.1)
+      activesupport (~> 3.0, >= 3.0.0)
+    metasploit-model (0.24.1)
       activesupport
+    metasploit_data_models (0.17.4)
+      activerecord (>= 3.2.13, < 4.0.0)
+      activesupport
+      metasploit-concern (~> 0.1.0)
+      metasploit-model (>= 0.24.1, < 0.25)
       pg
     mini_portile (0.5.1)
     msgpack (0.5.5)
@@ -69,7 +75,7 @@ DEPENDENCIES
   factory_girl (>= 4.1.0)
   fivemat (= 1.2.1)
   json
-  metasploit_data_models (~> 0.17.0)
+  metasploit_data_models (= 0.17.4)
   msgpack
   network_interface (~> 0.0.1)
   nokogiri


### PR DESCRIPTION
This is breaking new source-based installations with the following error:

```
ruby-1.9.3-p547@metasploit-framework/bundler/gems/metasploit_data_models-0b1fc5baf50c/app/models/metasploit_data_models/search/operator/multitext.rb:5:in `<top (required)>': uninitialized constant MetasploitDataModels::Search::Operator (NameError)
```

Fix MDM or merge this, either way.
