### PR TITLE
Allow get_cookies to find comma separated cookies

### DIFF
--- a/lib/rex/proto/http/response.rb
+++ b/lib/rex/proto/http/response.rb
@@ -67,7 +67,7 @@ class Response < Packet
     cookies = ""
     if (self.headers.include?('Set-Cookie'))
       set_cookies = self.headers['Set-Cookie']
-      key_vals = set_cookies.scan(/\s?([^, ;]+?)=([^, ;]*?);/)
+      key_vals = set_cookies.scan(/\s?([^, ;]+?)=([^, ;]*?)[;,]/)
       key_vals.each do |k, v|
         # Dont downcase actual cookie name as may be case sensitive
         name = k.downcase

--- a/spec/lib/rex/proto/http/response_spec.rb
+++ b/spec/lib/rex/proto/http/response_spec.rb
@@ -116,6 +116,22 @@ describe Rex::Proto::Http::Response do
     HEREDOC
   end
 
+  def get_cookies_comma_separated
+    <<-HEREDOC.gsub(/^ {6}/, '')
+      HTTP/1.1 200 OK
+      Expires: Thu, 26 Oct 1978 00:00:00 GMT
+      Content-Length: 8556
+      Server: CherryPy/3.1.2
+      Date: Sun, 06 Jul 2014 20:09:28 GMT
+      Cache-Control: no-store, max-age=0, no-cache, must-revalidate
+      Content-Type: text/html;charset=utf-8
+      Set-Cookie: cval=880350187, session_id_8000=83466b1a1a7a27ce13d35f78155d40ca3a1e7a28; expires=Mon, 07 Jul 2014 20:09:28 GMT; httponly; Path=/, uid=348637C4-9B10-485A-BFA9-5E892432FCFD; expires=Fri, 05-Jul-2019 20:09:28 GMT
+
+      <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+      <!--[if lt IE 7]> <html xmlns="http://www.w3.org/1999/xhtml" xmlns:s="http://www.splunk.com/xhtml-extensions/1.0" xml:lang="en" lang="en" class="no-js lt-ie9 lt-ie8 lt-
+    HEREDOC
+  end
+
   def cookie_sanity_check(meth)
     resp = described_class.new()
     resp.parse(self.send meth)
@@ -180,6 +196,18 @@ describe Rex::Proto::Http::Response do
       expected_cookies = %w{
       wordpressuser_a97c5267613d6de70e821ff82dd1ab94=admin
       wordpresspass_a97c5267613d6de70e821ff82dd1ab94=c3284d0f94606de1fd2af172aba15bf3
+      }
+      expected_cookies.shuffle!
+      cookies_array.should include(*expected_cookies)
+    end
+
+    it 'parses comma separated cookies' do
+      cookies_array = cookie_sanity_check(:get_cookies_comma_separated)
+      cookies_array.count.should eq(3)
+      expected_cookies = %w{
+      cval=880350187
+      session_id_8000=83466b1a1a7a27ce13d35f78155d40ca3a1e7a28
+      uid=348637C4-9B10-485A-BFA9-5E892432FCFD
       }
       expected_cookies.shuffle!
       cookies_array.should include(*expected_cookies)


### PR DESCRIPTION
While reviewing #3463 I've found the actual `Rex::Proto::Http::Response::get_cookies` is failing to find comma separated cookies, as set by applications like Splunk 5.0.1 on Windows 7 (32 bits). Example:

```
Set-Cookie: cval=880350187, session_id_8000=83466b1a1a7a27ce13d35f78155d40ca3a1e7a28; expires=Mon, 07 Jul 2014 20:09:28 GMT; httponly; Path=/, uid=348637C4-9B10-485A-BFA9-5E892432FCFD; expires=Fri, 05-Jul-2019 20:09:28 GMT
```

In the case above, `get_cookies` fails to find the `cval` cookie, because it's separated with a comma from `session_id_8000`:

```
msf > irb
[*] Starting IRB shell...

>> res = Rex::Proto::Http::Response.new
=> HTTP/1.1 200 OK
Content-Length: 0
>>
?> response = <<-HEREDOC
HTTP/1.1 200 OK
Expires: Thu, 26 Oct 1978 00:00:00 GMT
Content-Length: 8556
Server: CherryPy/3.1.2
Date: Sun, 06 Jul 2014 20:09:28 GMT
Cache-Control: no-store, max-age=0, no-cache, must-revalidate
Content-Type: text/html;charset=utf-8
Set-Cookie: cval=880350187, session_id_8000=83466b1a1a7a27ce13d35f78155d40ca3a1e7a28; expires=Mon, 07 Jul 2014 20:09:28 GMT; httponly; Path=/, uid=348637C4-9B10-485A-BFA9-5E892432FCFD; expires=Fri, 05-Jul-2019 20:09:28 GMT
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<!--[if lt IE 7]> <html xmlns="http://www.w3.org/1999/xhtml" xmlns:s="http://www.splunk.com/xhtml-extensions/1.0" xml:lang="en" lang="en" class="no-js lt-ie9 lt-ie8 lt-
HEREDOC
=> "HTTP/1.1 200 OK\nExpires: Thu, 26 Oct 1978 00:00:00 GMT\nContent-Length: 8556\nServer: CherryPy/3.1.2\nDate: Sun, 06 Jul 2014 20:09:28 GMT\nCache-Control: no-store, max-age=0, no-cache, must-revalidate\nContent-Type: text/html;charset=utf-8\nSet-Cookie: cval=880350187, session_id_8000=83466b1a1a7a27ce13d35f78155d40ca3a1e7a28; expires=Mon, 07 Jul 2014 20:09:28 GMT; httponly; Path=/, uid=348637C4-9B10-485A-BFA9-5E892432FCFD; expires=Fri, 05-Jul-2019 20:09:28 GMT\n\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n<!--[if lt IE 7]> <html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:s=\"http://www.splunk.com/xhtml-extensions/1.0\" xml:lang=\"en\" lang=\"en\" class=\"no-js lt-ie9 lt-ie8 lt-\n"
>>
?> res.parse(response)
=> 2
>>
?> res.get_cookies
=> "session_id_8000=83466b1a1a7a27ce13d35f78155d40ca3a1e7a28; uid=348637C4-9B10-485A-BFA9-5E892432FCFD;"
```

This patch tries to find the comma separated cookies:

```
msf > irb
[*] Starting IRB shell...

>> res = Rex::Proto::Http::Response.new
=> HTTP/1.1 200 OK
Content-Length: 0


>>
?> response = <<-HEREDOC
HTTP/1.1 200 OK
Expires: Thu, 26 Oct 1978 00:00:00 GMT
Content-Length: 8556
Server: CherryPy/3.1.2
Date: Sun, 06 Jul 2014 20:09:28 GMT
Cache-Control: no-store, max-age=0, no-cache, must-revalidate
Content-Type: text/html;charset=utf-8
Set-Cookie: cval=880350187, session_id_8000=83466b1a1a7a27ce13d35f78155d40ca3a1e7a28; expires=Mon, 07 Jul 2014 20:09:28 GMT; httponly; Path=/, uid=348637C4-9B10-485A-BFA9-5E892432FCFD; expires=Fri, 05-Jul-2019 20:09:28 GMT
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
<!--[if lt IE 7]> <html xmlns="http://www.w3.org/1999/xhtml" xmlns:s="http://www.splunk.com/xhtml-extensions/1.0" xml:lang="en" lang="en" class="no-js lt-ie9 lt-ie8 lt-
HEREDOC
=> "HTTP/1.1 200 OK\nExpires: Thu, 26 Oct 1978 00:00:00 GMT\nContent-Length: 8556\nServer: CherryPy/3.1.2\nDate: Sun, 06 Jul 2014 20:09:28 GMT\nCache-Control: no-store, max-age=0, no-cache, must-revalidate\nContent-Type: text/html;charset=utf-8\nSet-Cookie: cval=880350187, session_id_8000=83466b1a1a7a27ce13d35f78155d40ca3a1e7a28; expires=Mon, 07 Jul 2014 20:09:28 GMT; httponly; Path=/, uid=348637C4-9B10-485A-BFA9-5E892432FCFD; expires=Fri, 05-Jul-2019 20:09:28 GMT\n\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n<!--[if lt IE 7]> <html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:s=\"http://www.splunk.com/xhtml-extensions/1.0\" xml:lang=\"en\" lang=\"en\" class=\"no-js lt-ie9 lt-ie8 lt-\n"
>>
?> res.parse(response)
=> 2
>>
?> res.get_cookies
=> "cval=880350187; session_id_8000=83466b1a1a7a27ce13d35f78155d40ca3a1e7a28; uid=348637C4-9B10-485A-BFA9-5E892432FCFD;"
```

This regular expression isn't perfect to find cookies still, specially because is not able to find correctly values including commas. But hopefully it's better than before. Feedback is welcome. 
