### PR TITLE
Pin MDM gem to 0.17.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :db do
   # Needed for Msf::DbManager
   gem 'activerecord', '>= 3.0.0', '< 4.0.0'
   # Database models shared between framework and Pro.
-  gem 'metasploit_data_models', '0.17.0'
+  gem 'metasploit_data_models', '~> 0.17.0'
   # Needed for module caching in Mdm::ModuleDetails
   gem 'pg', '>= 0.11'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ DEPENDENCIES
   factory_girl (>= 4.1.0)
   fivemat (= 1.2.1)
   json
-  metasploit_data_models (= 0.17.0)
+  metasploit_data_models (~> 0.17.0)
   msgpack
   network_interface (~> 0.0.1)
   nokogiri


### PR DESCRIPTION
Several incompatible 0.17 MDM versions were released that required us to
pin MDM in framework.  The incompatible versions have been yanked from
RubyGems.  This restores the original version range for MDM.

For users who respect our Gemfile.lock file, this is a no-op.

See #3495.

This reverts commit 8f39590f0f56987acb1246604f956f70191add5f.

Reported by @ZeroChaos
