### PR TITLE
Fix Meterpreter PHP hop description

### DIFF
--- a/modules/payloads/stagers/windows/reverse_hop_http.rb
+++ b/modules/payloads/stagers/windows/reverse_hop_http.rb
@@ -15,9 +15,9 @@ module Metasploit3
   def initialize(info = {})
     super(merge_info(info,
       'Name'          => 'Reverse Hop HTTP Stager',
-      'Description'   => "Tunnel communication over an HTTP hop point (note you must first upload "+
-        "the hop.php found at #{File.expand_path("../../../../data/php/hop.php", __FILE__)} "+
-        "to the HTTP server you wish to use as a hop)",
+      'Description'   => %q{ Tunnel communication over an HTTP hop point. Note that you must first upload
+        data/hop/hop.php to the PHP server you wish to use as a hop.
+      },
       'Author'        =>
         [
          'scriptjunkie <scriptjunkie[at]scriptjunkie.us>',


### PR DESCRIPTION
If you interpret `File` locations for things in descriptions, you end up with wonky looking paths. For example:

http://www.rapid7.com/db/modules/payload/windows/meterpreter/reverse_hop_http

Incidentally, the canonical way to refer to paths of Metasploit assets are the methods in `Msf::Config`. That's how datastore directories are built, anyway (and still not really appropriate for descriptions).
## Verification Steps
- [x] Start `msfconsole`
- [x] Type `info payload/windows/meterpreter/reverse_hop_http`
## Not addressed

Note that every Meterpreter payload also is including the description from `meterpreter.rb`, for example:

`msf > info payload/windows/meterpreter/reverse_http`

```
Description:
  Tunnel communication over HTTP, Inject the meterpreter server DLL 
  via the Reflective Dll Injection payload (staged)
```

This looks like a bug to me. Will file momentarily.
