### PR TITLE
Make merged module descriptions more grammar.

### DIFF
--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -1139,7 +1139,7 @@ protected
   # Merges the module description.
   #
   def merge_info_description(info, val)
-    merge_info_string(info, 'Description', val, ".\n\n", true)
+    merge_info_string(info, 'Description', val, ". ", true)
   end
 
   #

--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -1139,7 +1139,7 @@ protected
   # Merges the module description.
   #
   def merge_info_description(info, val)
-    merge_info_string(info, 'Description', val)
+    merge_info_string(info, 'Description', val, ".\n\n", true)
   end
 
   #


### PR DESCRIPTION
This changes the behavior of description merging in Metasploit's console. Instead of having a trailing message of the merged description data, the data is now its own sentence. This seems to be the intent, anyway; there is no case where you'd want this to be a sentence fragment. This bug came up during #3509.
## Verification
- [x]  `msf > info payload/windows/meterpreter/reverse_hop_http`
- [x] See the grammaticalness:

```
Description:
  Inject the meterpreter server DLL via the Reflective Dll Injection 
  payload (staged). Tunnel communication over an HTTP hop point. Note 
  that you must first upload data/hop/hop.php to the PHP server you 
  wish to use as a hop.
```
## Merging reminder

If you merge this, remember to say `FixRM #8828` in the commit message somewhere.
