### PR TITLE
Rescue http_header notes from getting truncated

### DIFF
--- a/modules/auxiliary/scanner/http/http_header.rb
+++ b/modules/auxiliary/scanner/http/http_header.rb
@@ -76,12 +76,12 @@ class Metasploit3 < Msf::Auxiliary
       header_string = "#{h[0]}: #{h[1]}"
       print_status "#{peer}: #{header_string}"
 
-      report_note({
-        :type => "http.#{rport.to_s}.header.#{counter.to_s}",
+      report_note(
+        :type => "http.header.#{rport.to_s}.#{counter.to_s}",
         :data => header_string,
         :host => ip,
         :port => rport
-      })
+      )
       counter = counter + 1
     end
     if counter == 0

--- a/modules/auxiliary/scanner/http/http_header.rb
+++ b/modules/auxiliary/scanner/http/http_header.rb
@@ -77,7 +77,7 @@ class Metasploit3 < Msf::Auxiliary
       print_status "#{peer}: #{header_string}"
 
       report_note({
-        :type => 'http.' << rport.to_s << '.header.' << counter.to_s,
+        :type => "http.#{rport.to_s}.header.#{counter.to_s}",
         :data => header_string,
         :host => ip,
         :port => rport

--- a/modules/auxiliary/scanner/http/http_header.rb
+++ b/modules/auxiliary/scanner/http/http_header.rb
@@ -77,7 +77,7 @@ class Metasploit3 < Msf::Auxiliary
       print_status "#{peer}: #{header_string}"
 
       report_note({
-        :type => 'HTTP header',
+        :type => 'http.' << rport.to_s << '.header.' << counter.to_s,
         :data => header_string,
         :host => ip,
         :port => rport

--- a/modules/auxiliary/scanner/http/http_header.rb
+++ b/modules/auxiliary/scanner/http/http_header.rb
@@ -77,7 +77,7 @@ class Metasploit3 < Msf::Auxiliary
       print_status "#{peer}: #{header_string}"
 
       report_note(
-        :type => "http.header.#{rport.to_s}.#{counter.to_s}",
+        :type => "http.header.#{rport}.#{counter}",
         :data => header_string,
         :host => ip,
         :port => rport


### PR DESCRIPTION
Seems that only one header line gets added to host notes, and the rest are thrown away. This adds the counter number to the type string, so that each header line entry is unique and correctly saved. I also added port in case you want headers from several ports on one host without the previous getting overwritten.

(scanning shodanhq.com)
----BEFORE----

```
msf auxiliary(http_header) > run -j
[*] Auxiliary module running as background job
msf auxiliary(http_header) > 
[*] 162.159.245.38:80: requesting / via HEAD
[*] 162.159.245.38:80: deleted header Expires
[*] 162.159.245.38:80: CF-RAY: 1485d013ca880773-EWR
[*] 162.159.245.38:80: CACHE-CONTROL: max-age=15
[*] 162.159.245.38:80: CONNECTION: keep-alive
[*] 162.159.245.38:80: CONTENT-TYPE: text/html; charset=UTF-8
[*] 162.159.245.38:80: DATE: Fri, 11 Jul 2014 14:50:20 GMT
[*] 162.159.245.38:80: SERVER: cloudflare-nginx
[*] 162.159.245.38:80: SET-COOKIE: __cfduid=d3914e07fc681306bb53129adb3e6b1d41405090220122; expires=Mon, 23-Dec-2019 23:50:00 GMT; path=/; HttpOnly
[+] 162.159.245.38:80: detected 7 headers
[*] Scanned 1 of 1 hosts (100% complete)

msf auxiliary(http_header) > notes
[*] Time: 2014-07-11 14:50:19 UTC Note: host=162.159.245.38 type=HTTP header data="SET-COOKIE: __cfduid=d3914e07fc681306bb53129adb3e6b1d41405090220122; expires=Mon, 23-Dec-2019 23:50:00 GMT; path=/; HttpOnly"
msf auxiliary(http_header) > 
```

----AFTER----

```
msf auxiliary(http_header) > run -j
[*] Auxiliary module running as background job
msf auxiliary(http_header) > 
[*] 162.159.245.38:80: requesting / via HEAD
[*] 162.159.245.38:80: CF-RAY: 14869ad5c0970f57-FRA
[*] 162.159.245.38:80: CACHE-CONTROL: max-age=15
[*] 162.159.245.38:80: CONNECTION: keep-alive
[*] 162.159.245.38:80: CONTENT-TYPE: text/html; charset=UTF-8
[*] 162.159.245.38:80: DATE: Fri, 11 Jul 2014 17:08:45 GMT
[*] 162.159.245.38:80: EXPIRES: Fri, 11 Jul 2014 17:09:00 GMT
[*] 162.159.245.38:80: SERVER: cloudflare-nginx
[*] 162.159.245.38:80: SET-COOKIE: __cfduid=db2918126c4b49780b4669e88b72580521405098525082; expires=Mon, 23-Dec-2019 23:50:00 GMT; path=/; HttpOnly
[+] 162.159.245.38:80: detected 8 headers
[*] Scanned 1 of 1 hosts (100% complete)

msf auxiliary(http_header) > notes
[*] Time: 2014-07-11 17:08:44 UTC Note: host=162.159.245.38 type=http.80.header.0 data="CF-RAY: 14869ad5c0970f57-FRA"
[*] Time: 2014-07-11 17:08:44 UTC Note: host=162.159.245.38 type=http.80.header.1 data="CACHE-CONTROL: max-age=15"
[*] Time: 2014-07-11 17:08:44 UTC Note: host=162.159.245.38 type=http.80.header.2 data="CONNECTION: keep-alive"
[*] Time: 2014-07-11 17:08:44 UTC Note: host=162.159.245.38 type=http.80.header.3 data="CONTENT-TYPE: text/html; charset=UTF-8"
[*] Time: 2014-07-11 17:08:44 UTC Note: host=162.159.245.38 type=http.80.header.4 data="DATE: Fri, 11 Jul 2014 17:08:45 GMT"
[*] Time: 2014-07-11 17:08:44 UTC Note: host=162.159.245.38 type=http.80.header.5 data="EXPIRES: Fri, 11 Jul 2014 17:09:00 GMT"
[*] Time: 2014-07-11 17:08:44 UTC Note: host=162.159.245.38 type=http.80.header.6 data="SERVER: cloudflare-nginx"
[*] Time: 2014-07-11 17:08:44 UTC Note: host=162.159.245.38 type=http.80.header.7 data="SET-COOKIE: __cfduid=db2918126c4b49780b4669e88b72580521405098525082; expires=Mon, 23-Dec-2019 23:50:00 GMT; path=/; HttpOnly"
msf auxiliary(http_header) >
```
