### PR TITLE
typo in description of upnp msearch module

### DIFF
--- a/modules/exploits/linux/upnp/dlink_upnp_msearch_exec.rb
+++ b/modules/exploits/linux/upnp/dlink_upnp_msearch_exec.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Name'        => 'D-Link Unauthenticated UPnP M-SEARCH Multicast Command Injection',
       'Description' => %q{
         Different D-Link Routers are vulnerable to OS command injection via UPnP Multicast
-        requests. This module has been tested on DIR-300 and DIR-645 devices. Zacharia Cutlip
+        requests. This module has been tested on DIR-300 and DIR-645 devices. Zachary Cutlip
         has initially reported the DIR-815 vulnerable. Probably there are other devices also
         affected.
       },


### PR DESCRIPTION
a little typo ...
