### PR TITLE
Pre-release fixup: set up a proper peer method

### DIFF
--- a/modules/exploits/linux/upnp/dlink_upnp_msearch_exec.rb
+++ b/modules/exploits/linux/upnp/dlink_upnp_msearch_exec.rb
@@ -104,13 +104,13 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("#{rhost}:#{rport} - Trying to access the device via UPnP ...")
+    print_status("#{peer} - Trying to access the device via UPnP ...")
 
     unless check == Exploit::CheckCode::Detected
-      fail_with(Failure::Unknown, "#{rhost}:#{rport} - Failed to access the vulnerable device")
+      fail_with(Failure::Unknown, "#{peer} - Failed to access the vulnerable device")
     end
 
-    print_status("#{rhost}:#{rport} - Exploiting...")
+    print_status("#{peer} - Exploiting...")
     execute_cmdstager(
       :flavor  => :echo,
       :linemax => 950
@@ -128,9 +128,8 @@ class Metasploit3 < Msf::Exploit::Remote
     add_socket(self.udp_sock)
   end
 
-  #
-  # Required since we aren't using the normal mixins
-  #
+  # Need to define our own rhost/rport/peer since we aren't
+  # using the normal mixins
 
   def rhost
     datastore['RHOST']
@@ -138,6 +137,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def rport
     datastore['RPORT']
+  end
+
+  def peer
+    "#{rhost}:#{rport}"
   end
 
   # Accessor for our UDP socket


### PR DESCRIPTION
While there aren't any of the usual grammar/description fixups, I did want to add an explicit method for `peer` to the one module that doesn't use the usual mixins.

This kind of thing should be much more universal since now it's odd not to find it. Some day we'll drop this into the more universal module mixin. Some day...
## Verification
- [x] Use the module as normal. Note that you don't need a target, just want to exercise a line that uses `peer` in its print statement. This will suffice:

```
msf > use exploit/linux/upnp/dlink_upnp_msearch_exec 
msf exploit(dlink_upnp_msearch_exec) > set rhost metasploit.com
rhost => metasploit.com
msf exploit(dlink_upnp_msearch_exec) > exploit

[*] Started reverse handler on 10.x.x.122:4444 
[*] metasploit.com:1900 - Trying to access the device via UPnP ...
[-] Exploit failed: metasploit.com:1900 - Failed to access the vulnerable device
```

ping @wvu-r7 and/or @cdoughty-r7
