### PR TITLE
auxiliary/scanner/http/soap_xml cleanup

### DIFF
--- a/modules/auxiliary/scanner/http/soap_xml.rb
+++ b/modules/auxiliary/scanner/http/soap_xml.rb
@@ -17,183 +17,188 @@ class Metasploit3 < Msf::Auxiliary
   def initialize(info = {})
     super(update_info(info,
       'Name'        => 'HTTP SOAP Verb/Noun Brute Force Scanner',
-      'Description' => %q{
+      'Description' => %q(
         This module attempts to brute force SOAP/XML requests to uncover
         hidden methods.
-      },
-      'Author'      => [ 'patrick' ],
+      ),
+      'Author'      => ['patrick'],
       'License'     => MSF_LICENSE))
 
     register_options(
       [
-        OptString.new('PATH', [ true,  "The path to test", '/']),
-        OptString.new('XMLNAMESPACE', [ true,  "XML Web Service Namespace", 'http://tempuri.org/']),
-        OptString.new('XMLINSTANCE', [ true,  "XML Schema Instance", 'http://www.w3.org/2001/XMLSchema-instance']),
-        OptString.new('XMLSCHEMA', [ true,  "XML Schema", 'http://www.w3.org/2001/XMLSchema']),
-        OptString.new('XMLSOAP', [ true,  "XML SOAP", 'http://schemas.xmlsoap.org/soap/envelope/']),
-        OptString.new('CONTENTTYPE', [ true,  "The HTTP Content-Type Header", 'application/x-www-form-urlencoded']),
-        OptInt.new('SLEEP', [true, "Sleep this many seconds between requests", 0 ]),
-        OptBool.new('DISPLAYHTML', [ true,  "Display HTML response", false ]),
-        OptBool.new('SSL', [ true,  "Use SSL", false ]),
-        OptBool.new('VERB_DELETE', [ false,  "Enable 'delete' verb", 'false'])
+        OptString.new('PATH', [true, 'The path to test', '/']),
+        OptString.new('XMLNAMESPACE', [true, 'XML Web Service Namespace', 'http://tempuri.org/']),
+        OptString.new('XMLINSTANCE', [true, 'XML Schema Instance', 'http://www.w3.org/2001/XMLSchema-instance']),
+        OptString.new('XMLSCHEMA', [true, 'XML Schema', 'http://www.w3.org/2001/XMLSchema']),
+        OptString.new('XMLSOAP', [true, 'XML SOAP', 'http://schemas.xmlsoap.org/soap/envelope/']),
+        OptString.new('CONTENTTYPE', [true, 'The HTTP Content-Type Header', 'application/x-www-form-urlencoded']),
+        OptInt.new('SLEEP', [true, 'Sleep this many milliseconds between requests', 0]),
+        OptBool.new('DISPLAYHTML', [true, 'Display HTML response', false]),
+        OptBool.new('SSL', [true, 'Use SSL', false]),
+        OptBool.new('VERB_DELETE', [false, 'Enable DELETE verb', false])
       ], self.class)
   end
 
   # Fingerprint a single host
   def run_host(ip)
+    verbs = %w(
+      get
+      active
+      activate
+      create
+      change
+      set
+      put
+      do
+      go
+      resolve
+      start
+      recover
+      initiate
+      negotiate
+      define
+      stop
+      begin
+      end
+      manage
+      administer
+      modify
+      register
+      log
+      add
+      list
+      query
+    )
 
-    verbs = [
-        'get',
-        'active',
-        'activate',
-        'create',
-        'change',
-        'set',
-        'put',
-        'do',
-        'go',
-        'resolve',
-        'start',
-        'recover',
-        'initiate',
-        'negotiate',
-        'define',
-        'stop',
-        'begin',
-        'end',
-        'manage',
-        'administer',
-        'modify',
-        'register',
-        'log',
-        'add',
-        'list',
-        'query',
-      ]
+    verbs << 'delete' if datastore['VERB_DELETE']
 
-    if (datastore['VERB_DELETE'])
-      verbs << 'delete'
-    end
+    nouns = %w(
+      password
+      task
+      tasks
+      pass
+      administration
+      account
+      accounts
+      admin
+      login
+      logins
+      token
+      tokens
+      credential
+      credentials
+      key
+      keys
+      guid
+      message
+      messages
+      user
+      users
+      username
+      usernames
+      load
+      list
+      name
+      names
+      file
+      files
+      path
+      paths
+      directory
+      directories
+      configuration
+      configurations
+      config
+      configs
+      setting
+      settings
+      registry
+      on
+      off
+    )
 
-    nouns = [
-        'password',
-        'task',
-        'tasks',
-        'pass',
-        'administration',
-        'account',
-        'accounts',
-        'admin',
-        'login',
-        'logins',
-        'token',
-        'tokens',
-        'credential',
-        'credentials',
-        'key',
-        'keys',
-        'guid',
-        'message',
-        'messages',
-        'user',
-        'users',
-        'username',
-        'usernames',
-        'load',
-        'list',
-        'name',
-        'names',
-        'file',
-        'files',
-        'path',
-        'paths',
-        'directory',
-        'directories',
-        'configuration',
-        'configurations',
-        'config',
-        'configs',
-        'setting',
-        'settings',
-        'registry',
-        'on',
-        'off',
-      ]
-
-    target_port = datastore['RPORT']
     vhost = datastore['VHOST'] || wmap_target_host || ip
 
     # regular expressions for common rejection messages
     reject_regexen = []
-    reject_regexen << Regexp.new("method \\S+ is not valid", true)
-    reject_regexen << Regexp.new("Method \\S+ not implemented", true)
-    reject_regexen << Regexp.new("unable to resolve WSDL method name", true)
+    reject_regexen << Regexp.new('method \\S+ is not valid', true)
+    reject_regexen << Regexp.new('Method \\S+ not implemented', true)
+    reject_regexen << Regexp.new('unable to resolve WSDL method name', true)
 
-    begin
-      verbs.each do |v|
-        nouns.each do |n|
+    verbs.each do |v|
+      nouns.each do |n|
+        begin
           data_parts = []
-          data_parts << "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+          data_parts << '<?xml version=\'1.0\' encoding=\'utf-8\'?>'
           data_parts << "<soap:Envelope xmlns:xsi=\"#{datastore['XMLINSTANCE']}\" xmlns:xsd=\"#{datastore['XMLSCHEMA']}\" xmlns:soap=\"#{datastore['XMLSOAP']}\">"
-          data_parts << "<soap:Body>"
+          data_parts << '<soap:Body>'
           data_parts << "<#{v}#{n} xmlns=\"#{datastore['XMLNAMESPACE']}\">"
           data_parts << "</#{v}#{n}>"
-          data_parts << "</soap:Body>"
-          data_parts << "</soap:Envelope>"
+          data_parts << '</soap:Body>'
+          data_parts << '</soap:Envelope>'
           data_parts << nil
           data_parts << nil
           data = data_parts.join("\r\n")
 
           uri = normalize_uri(datastore['PATH'])
-          vprint_status("Sending request #{uri}/#{v}#{n} to #{wmap_target_host}:#{datastore['RPORT']}")
+          uri += '/' unless uri =~ /^\/$/
+          uri += v + n
 
-          res = send_request_raw({
-            'uri'     => uri + '/' + v + n,
-            'method'  => 'POST',
-            'vhost'   => vhost,
-            'data'	  => data,
-            'headers' =>
-              {
-                'Content-Length' => data.length,
-                'SOAPAction'	 => '"' + datastore['XMLNAMESPACE'] + v + n + '"',
-                'Expect'	 => '100-continue',
-                'Content-Type'	 => datastore['CONTENTTYPE'],
-              }
-          }, 15)
+          vprint_status("Sending request #{uri} #{wmap_target_host}:#{datastore['RPORT']}")
 
-          if (res && !(res.body.empty?))
-            if ((not reject_regexen.select { |r| res.body =~ r }.empty?))
+          res = send_request_raw(
+            {
+              'uri'     => uri,
+              'method'  => 'POST',
+              'vhost'   => vhost,
+              'data'	  => data,
+              'headers' =>
+                {
+                  'Content-Length' => data.length,
+                  'SOAPAction'	 => '"' + datastore['XMLNAMESPACE'] + v + n + '"',
+                  'Expect'	 => '100-continue',
+                  'Content-Type'	 => datastore['CONTENTTYPE']
+                }
+            }, 15)
+
+          if res && !(res.body.empty?)
+            if reject_regexen.any? { |r| res.body =~ r }
               print_status("Server #{wmap_target_host}:#{datastore['RPORT']} rejected SOAPAction: #{v}#{n} with HTTP: #{res.code} #{res.message}.")
-            elsif (res.message =~ /Cannot process the message because the content type/)
+            elsif res.message =~ /Cannot process the message because the content type/
               print_status("Server #{wmap_target_host}:#{datastore['RPORT']} rejected CONTENTTYPE: HTTP: #{res.code} #{res.message}.")
               res.message =~ /was not the expected type\s\'([^']+)'/
               print_status("Set CONTENTTYPE to \"#{$1}\"")
               return false
-            elsif (res.code == 404)
+            elsif res.code == 404
               print_status("Server #{wmap_target_host}:#{datastore['RPORT']} returned HTTP 404 for #{datastore['PATH']}.  Use a different one.")
               return false
             else
               print_status("Server #{wmap_target_host}:#{datastore['RPORT']} responded to SOAPAction: #{v}#{n} with HTTP: #{res.code} #{res.message}.")
               ## Add Report
               report_note(
-                :host  => ip,
-                :proto => 'tcp',
-                :sname => (ssl ? 'https' : 'http'),
-                :port  => rport,
-                :type  => "SOAPAction: #{v}#{n}",
-                :data  => "SOAPAction: #{v}#{n} with HTTP: #{res.code} #{res.message}."
+                host: ip,
+                proto: 'tcp',
+                sname: (ssl ? 'https' : 'http'),
+                port: rport,
+                type: "SOAPAction: #{v}#{n}",
+                data: "SOAPAction: #{v}#{n} with HTTP: #{res.code} #{res.message}."
               )
               if datastore['DISPLAYHTML']
-                print_status("The HTML content follows:")
+                print_status('The HTML content follows:')
                 print_status(res.body + "\r\n")
               end
             end
           end
-          select(nil, nil, nil, datastore['SLEEP']) if (datastore['SLEEP'] > 0)
+        rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE => e
+          print_error(e.message)
+        ensure
+          Rex.sleep(sleep_time)
         end
       end
-    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Timeout::Error, ::Errno::EPIPE => e
-      vprint_error(e.message)
     end
+  end
+
+  def sleep_time
+    datastore['SLEEP'] / 1000.0
   end
 end

--- a/modules/auxiliary/scanner/http/soap_xml.rb
+++ b/modules/auxiliary/scanner/http/soap_xml.rb
@@ -125,6 +125,7 @@ class Metasploit3 < Msf::Auxiliary
     reject_regexen << Regexp.new('Method \\S+ not implemented', true)
     reject_regexen << Regexp.new('unable to resolve WSDL method name', true)
 
+    print_status("Starting scan with #{datastore['SLEEP']}ms delay between requests")
     verbs.each do |v|
       nouns.each do |n|
         begin


### PR DESCRIPTION
During lunch I was poking at a device I have at home that has a SOAP interface.  It is very flaky and soap_xml wasn't being particularly nice about it.

This:
- Corrects Ruby style (most) everywhere
- Uses Rex's sleep, converts to milliseconds -- seconds are too granular
- Moves begin/rescue inside nested verb+noun loop
- Prints errors even if not in verbose mode
- Corrects URI construction when PATH ends with /

I don't currently have a positive test case (a target that this module will find anything useful on), but here are some steps to validate.

Without this, in non-verbose mode it finishes almost immediately and says nothing:

```
resource (/tmp/xml.rc)> use auxiliary/scanner/http/soap_xml
resource (/tmp/xml.rc)> set RHOSTS 192.168.1.100
RHOSTS => 192.168.1.100
resource (/tmp/xml.rc)> set RPORT 21309
RPORT => 21309
resource (/tmp/xml.rc)> run
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

But if you set verbose and run, you'll see that the paths are wrong, the exception is being hidden and the module is prematurely terminating:

```
msf auxiliary(soap_xml) > set VERBOSE true
VERBOSE => true
msf auxiliary(soap_xml) > run
[*] Sending request //getpassword to 192.168.1.100:21309
[*] Sending request //gettask to 192.168.1.100:21309
[*] Sending request //gettasks to 192.168.1.100:21309
[*] Sending request //getpass to 192.168.1.100:21309
[*] Sending request //getadministration to 192.168.1.100:21309
[*] Sending request //getaccount to 192.168.1.100:21309
[*] Sending request //getaccounts to 192.168.1.100:21309
[*] Sending request //getadmin to 192.168.1.100:21309
[*] Sending request //getlogin to 192.168.1.100:21309
[*] Sending request //getlogins to 192.168.1.100:21309
[*] Sending request //gettoken to 192.168.1.100:21309
[*] Sending request //gettokens to 192.168.1.100:21309
[*] Sending request //getcredential to 192.168.1.100:21309
[*] Sending request //getcredentials to 192.168.1.100:21309
[*] Sending request //getkey to 192.168.1.100:21309
[*] Sending request //getkeys to 192.168.1.100:21309
[*] Sending request //getguid to 192.168.1.100:21309
[*] Sending request //getmessage to 192.168.1.100:21309
[*] Sending request //getmessages to 192.168.1.100:21309
[*] Sending request //getuser to 192.168.1.100:21309
[*] Sending request //getusers to 192.168.1.100:21309
[*] Sending request //getusername to 192.168.1.100:21309
[*] Sending request //getusernames to 192.168.1.100:21309
[*] Sending request //getload to 192.168.1.100:21309
[*] Sending request //getlist to 192.168.1.100:21309
[*] Sending request //getname to 192.168.1.100:21309
[*] Sending request //getnames to 192.168.1.100:21309
[*] Sending request //getfile to 192.168.1.100:21309
[*] Sending request //getfiles to 192.168.1.100:21309
[*] Sending request //getpath to 192.168.1.100:21309
[*] Sending request //getpaths to 192.168.1.100:21309
[*] Sending request //getdirectory to 192.168.1.100:21309
[*] Sending request //getdirectories to 192.168.1.100:21309
[*] Sending request //getconfiguration to 192.168.1.100:21309
[*] Sending request //getconfigurations to 192.168.1.100:21309
[*] Sending request //getconfig to 192.168.1.100:21309
[*] Sending request //getconfigs to 192.168.1.100:21309
[*] Sending request //getsetting to 192.168.1.100:21309
[*] Sending request //getsettings to 192.168.1.100:21309
[*] Sending request //getregistry to 192.168.1.100:21309
[*] Sending request //geton to 192.168.1.100:21309
[*] Sending request //getoff to 192.168.1.100:21309
[*] Sending request //activepassword to 192.168.1.100:21309
[*] Sending request //activetask to 192.168.1.100:21309
[*] Sending request //activetasks to 192.168.1.100:21309
[-] The connection was refused by the remote host (192.168.1.100:21309).
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
- See that the URI requested has been corrected. 

```
msf auxiliary(soap_xml) > set VERBOSE true
VERBOSE => true
msf auxiliary(soap_xml) > run
[*] Sending request /getpassword 192.168.1.100:21309
[*] Sending request /gettask 192.168.1.100:21309
[*] Sending request /gettasks 192.168.1.100:21309
[*] Sending request /getpass 192.168.1.100:21309
...
```
- See that when the target gets upset (which it does frequently), the module continues:

```
...
[*] Sending request /activemessage 192.168.1.100:21309
[*] Sending request /activemessages 192.168.1.100:21309
[-] The connection was refused by the remote host (192.168.1.100:21309).
[*] Sending request /activeuser 192.168.1.100:21309
[-] The connection was refused by the remote host (192.168.1.100:21309).
[*] Sending request /activeusers 192.168.1.100:21309
[-] The connection was refused by the remote host (192.168.1.100:21309).
[*] Sending request /activeusername 192.168.1.100:21309
[-] The connection was refused by the remote host (192.168.1.100:21309).
[*] Sending request /activeusernames 192.168.1.100:21309
[-] The connection was refused by the remote host (192.168.1.100:21309).
[*] Sending request /activeload 192.168.1.100:21309
[-] The connection was refused by the remote host (192.168.1.100:21309).
[*] Sending request /activelist 192.168.1.100:21309
[-] The connection was refused by the remote host (192.168.1.100:21309).
[*] Sending request /activename 192.168.1.100:21309
[*] Sending request /activenames 192.168.1.100:21309
[*] Sending request /activefile 192.168.1.100:21309
[*] Sending request /activefiles 192.168.1.100:21309
[*] Sending request /activepath 192.168.1.100:21309
...
```
