### PR TITLE
Update link for The Metasploit Development Environment

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -10,7 +10,7 @@ CONTRIBUTING.md
 in the same directory as this file, and to a lesser extent:
 
 The Metasploit Development Environment
-https://github.com/rapid7/metasploit-framework/wiki/Metasploit-Development-Environment
+https://github.com/rapid7/metasploit-framework/wiki/Setting-Up-a-Metasploit-Development-Environment
 
 Common Coding Mistakes
 https://github.com/rapid7/metasploit-framework/wiki/Common-Metasploit-Module-Coding-Mistakes


### PR DESCRIPTION
The HACKING file still uses the old link, which redirects to this one, why not just use this one?
