### PR TITLE
Mark windows/misc/psh_web_delivery as deprecated

### DIFF
--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -20,13 +20,15 @@ class Metasploit3 < Msf::Exploit::Remote
         machine when the attacker has to manually type in the command himself, e.g. Command Injection,
         RDP Session, Local Access or maybe Remote Command Exec. This attack vector does not
         write to disk so it is less likely to trigger AV solutions and will allow privilege
-        escalations supplied by Meterpreter.
+        escalations supplied by Meterpreter. When using either of the PSH targets, ensure the
+        payload architecture matches the target computer or use SYSWOW64 powershell.exe to execute
+        x86 payloads on x64 machines.
       },
       'License'      => MSF_LICENSE,
       'Author'       =>
         [
           'Andrew Smith "jakx" <jakx.ppr@gmail.com>',
-          'Ben Campbell <eat_meatballs[at]hotmail.co.uk>',
+          'Ben Campbell',
           'Chris Campbell' #@obscuresec - Inspiration n.b. no relation!
         ],
       'DefaultOptions' =>

--- a/modules/exploits/windows/misc/psh_web_delivery.rb
+++ b/modules/exploits/windows/misc/psh_web_delivery.rb
@@ -10,6 +10,11 @@ class Metasploit3 < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpServer
 
+  include Msf::Module::Deprecated
+
+  DEPRECATION_DATE = Date.new(2014, 10, 23)
+  DEPRECATION_REPLACEMENT = 'exploit/multi/script/web_delivery'
+
   def initialize(info = {})
     super(update_info(info,
       'Name'		 => 'PowerShell Payload Web Delivery',


### PR DESCRIPTION
The new `exploit/multi/script/web_delivery` module supports Powershell execution like the original `exploit/windows/misc/psh_web_delivery` module which inspired it's creation. This PR marks the original as deprecated in favor of the new one which also supports Python and PHP.

Tasks:
- [x] Load the old `exploit/windows/misc/psh_web_delivery` module and see a deprecation notice
- [x] Load the new `exploit/multi/web_delivery` module and use it's PSH_\* targets to execute payloads with powershell
