### PR TITLE
Allow INFO msftidy messages

### DIFF
--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -3,18 +3,15 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
-=begin
-Windows XP systems that are not part of a domain default to treating all
-network logons as if they were Guest. This prevents SMB relay attacks from
-gaining administrative access to these systems. This setting can be found
-under:
-
-  Local Security Settings >
-   Local Policies >
-    Security Options >
-     Network Access: Sharing and security model for local accounts
-=end
+# Windows XP systems that are not part of a domain default to treating all
+# network logons as if they were Guest. This prevents SMB relay attacks from
+# gaining administrative access to these systems. This setting can be found
+# under:
+#
+#  Local Security Settings >
+#   Local Policies >
+#    Security Options >
+#     Network Access: Sharing and security model for local accounts
 
 require 'msf/core'
 

--- a/tools/dev/pre-commit-hook.rb
+++ b/tools/dev/pre-commit-hook.rb
@@ -64,7 +64,7 @@ else
     msftidy_output= %x[ #{cmd} ]
     puts "#{fname} - msftidy check passed" if msftidy_output.empty?
     msftidy_output.each_line do |line|
-      valid = false
+      valid = false unless line['INFO']
       puts line
     end
   end


### PR DESCRIPTION
INFO level messages should not block commits or be complained about on
merges. They should merely inform the user.

This PR removes a begin comment block, converting it to a regular comment block (per Ruby style guide, here: https://github.com/rapid7/ruby-style-guide/blob/add-anchors/README.md#no-block-comments ) in order to trigger a Rubocop INFO message.
## Validation
- [ ] Ensure you can actually merge this without msftidy complaining.
