### PR TITLE
Fix null pointer dereference on sap_mgmt_con_instanceproperties.rb

### DIFF
--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb
@@ -237,7 +237,7 @@ class Metasploit4 < Msf::Auxiliary
         print_good("#{rhost}:#{rport} [SAP] Unprotected Webmethods :::")
         webmethods_arr.each do | webm |
           # Only add webmethods not found in protectedweb_arr
-          webmethods_output << webm if not protectedweb_arr.include?(webm)
+          webmethods_output << webm unless protectedweb_arr && protectedweb_arr.include?(webm)
         end
         print_status("#{webmethods_output.join(',')}") if webmethods_output
         report_note(:host => rhost,

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb
@@ -234,12 +234,14 @@ class Metasploit4 < Msf::Auxiliary
       if webmethods
         webmethods_output = [] # create empty webmethods array
         webmethods_arr = webmethods.split(",")
-        print_good("#{rhost}:#{rport} [SAP] Unprotected Webmethods :::")
         webmethods_arr.each do | webm |
           # Only add webmethods not found in protectedweb_arr
           webmethods_output << webm unless protectedweb_arr && protectedweb_arr.include?(webm)
         end
-        print_status("#{webmethods_output.join(',')}") if webmethods_output
+        if webmethods_output
+          print_good("#{rhost}:#{rport} [SAP] Unprotected Webmethods :::")
+          print_status("#{webmethods_output.join(',')}")
+        end
         report_note(:host => rhost,
               :proto => 'tcp',
               :port => rport,


### PR DESCRIPTION
Has been reported by email which a null pointer dereference can happen when trying to access protectedweb_arr:

```
In
https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb

In line 240 i added (if not protectedweb_arr or):
webmethods_output << webm if not protectedweb_arr or not
protectedweb_arr.include?(webm)

The array may be null, if the sap profile parameter
service/protectedwebmethods is set to none. This will crash the
module.
```

This patch fixes it.
