### PR TITLE
Include Hpricot for crawler modules (Was #3533)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem 'robots'
 # Needed for some post modules
 gem 'sqlite3'
 
+gem 'hpricot', :require => 'hpricot'
+
 group :db do
   # Needed for Msf::DbManager
   gem 'activerecord', '>= 3.0.0', '< 4.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ GEM
     factory_girl (4.2.0)
       activesupport (>= 3.0.0)
     fivemat (1.2.1)
+    hpricot (0.8.6)
     i18n (0.6.5)
     json (1.8.0)
     metasploit_data_models (0.17.0)
@@ -69,6 +70,7 @@ DEPENDENCIES
   database_cleaner
   factory_girl (>= 4.1.0)
   fivemat (= 1.2.1)
+  hpricot
   json
   metasploit_data_models (= 0.17.0)
   meterpreter_bins (= 0.0.6)


### PR DESCRIPTION
Since we are not actually including Hpricot, we have several failing components:

```
$ grep -ril hpricot data
data/exploits/capture/http/forms/extractforms.rb
data/exploits/capture/http/forms/grabforms.rb
data/msfcrawler/basic.rb
data/msfcrawler/frames.rb
data/msfcrawler/forms.rb
data/msfcrawler/link.rb
data/msfcrawler/image.rb
data/msfcrawler/objects.rb
data/msfcrawler/scripts.rb
```

Note that the failing components all live in `data`, not `modules`, thus the confusion. The msfcrawler module is quite old and hasn't got a lot of maintenance in the last couple years, but it should at least not crash on the require.

The alternative to this fix is to remove the nonworking msfcrawler module, since it can't have worked for at least a year.
## Verficiation

Verification steps were proposed by @FireFart and @jhart-r7 in #3533, here: https://github.com/rapid7/metasploit-framework/pull/3533#issuecomment-49211679
- [ ] Use the msfcrawler in the usual way with a test website.
- [ ] Notice the require does not crash the module.
