### PR TITLE
Use native unpack for PDWORDs [FixRM: 8829]

### DIFF
--- a/lib/rex/post/meterpreter/extensions/stdapi/railgun/dll.rb
+++ b/lib/rex/post/meterpreter/extensions/stdapi/railgun/dll.rb
@@ -318,7 +318,7 @@ class DLL
       buffer = rec_out_only_buffers[buffer_item.addr, buffer_item.length_in_bytes]
       case buffer_item.datatype
         when "PDWORD"
-          return_hash[param_name] = buffer.unpack('V')[0]
+          return_hash[param_name] = buffer.unpack(native)[0]
         when "PCHAR"
           return_hash[param_name] = asciiz_to_str(buffer)
         when "PWCHAR"
@@ -338,7 +338,7 @@ class DLL
       buffer = rec_inout_buffers[buffer_item.addr, buffer_item.length_in_bytes]
       case buffer_item.datatype
         when "PDWORD"
-          return_hash[param_name] = buffer.unpack('V')[0]
+          return_hash[param_name] = buffer.unpack(native)[0]
         when "PCHAR"
           return_hash[param_name] = asciiz_to_str(buffer)
         when "PWCHAR"


### PR DESCRIPTION
In lib/rex/post/meterpreter/extensions/stdapi/railgun/dll.rb we expand the size of OUT PDWORDs to 8 bytes if x64:

```
      if param_desc[2] == "out"
        raise "error in param #{param_desc[1]}: Out-only buffers must be described by a number indicating their size in bytes " unless args[param_idx].class == Fixnum
        buffer_size = args[param_idx]
        if param_desc[0] == "PDWORD"
          # bump up the size for an x64 pointer
          if( native == 'Q' and buffer_size == 4 )
            args[param_idx] = 8
```

But we don't unpack them the same way:

```
    # process out-only buffers
    #puts "processing out-only buffers:"
    out_only_layout.each_pair do |param_name, buffer_item|
      #puts "   #{param_name}"
      buffer = rec_out_only_buffers[buffer_item.addr, buffer_item.length_in_bytes]
      case buffer_item.datatype
        when "PDWORD"
          return_hash[param_name] = buffer.unpack('V')[0]
```

NB: The first expansion only applies to OUT. Should it also apply to IN-OUT? 
