### PR TITLE
Update to metasploit-credential to use gem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :db do
   # Needed for Msf::DbManager
   gem 'activerecord', '>= 3.0.0', '< 4.0.0'
   # Metasploit::Credential database models
-  gem 'metasploit-credential', git: 'github-metasploit-credential:rapid7/metasploit-credential.git', tag: 'v0.7.1.pre.electro.pre.release'
+  gem 'metasploit-credential', '~> 0.7.8'
   # Database models shared between framework and Pro.
   gem 'metasploit_data_models', '>= 0.18.0', '< 0.19'
   # Needed for module caching in Mdm::ModuleDetails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,3 @@
-GIT
-  remote: github-metasploit-credential:rapid7/metasploit-credential.git
-  revision: d5784729bf65a6419a05e2aaac1be217c4f93ff1
-  tag: v0.7.1.pre.electro.pre.release
-  specs:
-    metasploit-credential (0.7.1.pre.electro.pre.release)
-      metasploit-concern (~> 0.1.0)
-      metasploit-model (>= 0.25.6)
-      metasploit_data_models (>= 0.18.0.pre.compatibility, < 0.19)
-      rubyntlm
-      rubyzip (~> 1.1)
-
 PATH
   remote: .
   specs:
@@ -70,6 +58,13 @@ GEM
     json (1.8.1)
     metasploit-concern (0.1.1)
       activesupport (~> 3.0, >= 3.0.0)
+    metasploit-credential (0.7.8)
+      metasploit-concern (~> 0.1.0)
+      metasploit-model (>= 0.25.6)
+      metasploit_data_models (>= 0.18.0.pre.compatibility, < 0.19)
+      pg
+      rubyntlm
+      rubyzip (~> 1.1)
     metasploit-model (0.25.6)
       activesupport
     metasploit_data_models (0.18.0)
@@ -161,7 +156,7 @@ DEPENDENCIES
   factory_girl (>= 4.1.0)
   factory_girl_rails
   fivemat (= 1.2.1)
-  metasploit-credential!
+  metasploit-credential (~> 0.7.8)
   metasploit-framework!
   metasploit_data_models (>= 0.18.0, < 0.19)
   network_interface (~> 0.0.1)


### PR DESCRIPTION
[MSP-10808](https://jira.tor.rapid7.com/secure/RapidBoard.jspa?rapidView=84&view=detail&selectedIssue=MSP-10808)

The git gem didn't work on travis-ci because it doesn't know about our internal SSH aliases, so just switch to the released gems.
