### PR TITLE
Fix JtR::Cracker's ability to find shipped bins

### DIFF
--- a/lib/metasploit/framework/jtr/cracker.rb
+++ b/lib/metasploit/framework/jtr/cracker.rb
@@ -199,11 +199,11 @@ module Metasploit
         # This method tries to identify the correct version of the pre-shipped
         # JtR binaries to use based on the platform.
         #
-        # @return [NilClass] if the correct bianry could not be determined
+        # @return [NilClass] if the correct binary could not be determined
         # @return [String] the path to the selected binary
         def select_shipped_binary
           cpuinfo_base = ::File.join(Msf::Config.data_directory, "cpuinfo")
-          runpath = nil
+          run_path = nil
           if File.directory?(cpuinfo_base)
             data = nil
 
@@ -215,11 +215,11 @@ module Metasploit
                 end
                 case data
                   when /sse2/
-                    run_path ||= "run.win32.sse2/john.exe"
+                    run_path ||= ::File.join(Msf::Config.data_directory, "john", "run.win32.sse2", "john.exe")
                   when /mmx/
-                    run_path ||= "run.win32.mmx/john.exe"
+                    run_path ||= ::File.join(Msf::Config.data_directory, "john", "run.win32.mmx", "john.exe")
                   else
-                    run_path ||= "run.win32.any/john.exe"
+                    run_path ||= ::File.join(Msf::Config.data_directory, "john", "run.win32.any", "john.exe")
                 end
               when /x86_64-linux/
                 fname = "#{cpuinfo_base}/cpuinfo.ia64.bin"
@@ -229,9 +229,9 @@ module Metasploit
                 end
                 case data
                   when /mmx/
-                    run_path ||= "run.linux.x64.mmx/john"
+                    run_path ||= ::File.join(Msf::Config.data_directory, "john", "run.linux.x64.mmx", "john")
                   else
-                    run_path ||= "run.linux.x86.any/john"
+                    run_path ||= ::File.join(Msf::Config.data_directory, "john", "run.linux.x86.any", "john")
                 end
               when /i[\d]86-linux/
                 fname = "#{cpuinfo_base}/cpuinfo.ia32.bin"
@@ -241,15 +241,15 @@ module Metasploit
                 end
                 case data
                   when /sse2/
-                    run_path ||= "run.linux.x86.sse2/john"
+                    run_path ||= ::File.join(Msf::Config.data_directory, "john", "run.linux.x86.sse2", "john")
                   when /mmx/
-                    run_path ||= "run.linux.x86.mmx/john"
+                    run_path ||= ::File.join(Msf::Config.data_directory, "john", "run.linux.x86.mmx", "john")
                   else
-                    run_path ||= "run.linux.x86.any/john"
+                    run_path ||= ::File.join(Msf::Config.data_directory, "john", "run.linux.x86.any", "john")
                 end
             end
           end
-          runpath
+          run_path
         end
 
 

--- a/lib/metasploit/framework/jtr/cracker.rb
+++ b/lib/metasploit/framework/jtr/cracker.rb
@@ -119,6 +119,8 @@ module Metasploit
 
           if config.present?
             cmd << ( "--config=" + config )
+          else
+            cmd << ( "--config=" + john_config_file )
           end
 
           if pot.present?
@@ -162,6 +164,13 @@ module Metasploit
           end
         end
 
+        # This method returns the path to a default john.conf file.
+        #
+        # @return [String] the path to the default john.conf file
+        def john_config_file
+          ::File.join( ::Msf::Config.data_directory, "john", "confs", "john.conf" )
+        end
+
         # This method returns the path to a default john.pot file.
         #
         # @return [String] the path to the default john.pot file
@@ -189,6 +198,8 @@ module Metasploit
 
           if config
             cmd << "--config=#{config}"
+          else
+            cmd << ( "--config=" + john_config_file )
           end
 
           cmd << hash_path

--- a/lib/msf/core/auxiliary/jtr.rb
+++ b/lib/msf/core/auxiliary/jtr.rb
@@ -41,6 +41,12 @@ module Auxiliary::JohnTheRipper
 
   end
 
+  # @param pwd [String] Password recovered from cracking an LM hash
+  # @param hash [String] NTLM hash for this password
+  # @return [String] `pwd` converted to the correct case to match the
+  #   given NTLM hash
+  # @return [nil] if no case matches the NT hash. This can happen when
+  #   `pwd` came from a john run that only cracked half of the LM hash
   def john_lm_upper_to_ntlm(pwd, hash)
     pwd  = pwd.upcase
     hash = hash.upcase

--- a/modules/auxiliary/analyze/jtr_crack_fast.rb
+++ b/modules/auxiliary/analyze/jtr_crack_fast.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Auxiliary
   def run
     cracker = new_john_cracker
 
-    #generate our wordlist and close the file handle
+    # generate our wordlist and close the file handle
     wordlist = wordlist_file
     wordlist.close
     print_status "Wordlist file written out to #{wordlist.path}"
@@ -53,10 +53,10 @@ class Metasploit3 < Msf::Auxiliary
       end
 
       if format == 'lm'
-        print_status "Cracking #{format} hashes in incremental mode (LanMan)..."
+        print_status "Cracking #{format} hashes in incremental mode (All4)..."
         cracker_instance.rules = nil
         cracker_instance.wordlist = nil
-        cracker_instance.incremental = 'LanMan'
+        cracker_instance.incremental = 'All4'
         cracker_instance.crack do |line|
           print_status line.chomp
         end

--- a/modules/auxiliary/analyze/jtr_crack_fast.rb
+++ b/modules/auxiliary/analyze/jtr_crack_fast.rb
@@ -98,6 +98,12 @@ class Metasploit3 < Msf::Auxiliary
             end
           end
           password = john_lm_upper_to_ntlm(password, nt_hash)
+          # password can be nil if the hash is broken (i.e., the NT and
+          # LM sides don't actually match) or if john was only able to
+          # crack one half of the LM hash. In the latter case, we'll
+          # have a line like:
+          #  username:???????WORD:...:...:::
+          next if password.nil?
         end
 
         print_good "#{username}:#{password}:#{core_id}"


### PR DESCRIPTION
### Verification

 _On a system for which Framework ships `john` binaries, i.e. Linux (x86 or x64) or Windows_:
- [x] `which john`
  - [x] **VERIFY** no john in your path
- [x] msfconsole
- [x] Get a system session on a windows box
- [x] `use post/windows/gather/hashdump`
- [x] `set SESSION 1`
- [x] `run`
- [x] `creds`
  - [x] **VERIFY** hashes show up
- [x] `use auxiliary/analyze/jtr_crack_fast`
- [x] `show options`
  - [x] **VERIFY** you have _not_ set JOHN_PATH (`unset JOHN_PATH` and/or `unsetg JOHN_PATH` if you have)
- [x] `run`
  - [x] **VERIFY** no stack trace
  - [x] **VERIFY** it takes no more than about 30 seconds
