### PR TITLE
Metasploit::Credential::Core association search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ group :db do
   # Needed for Msf::DbManager
   gem 'activerecord', '>= 3.0.0', '< 4.0.0'
   # Metasploit::Credential database models
-  gem 'metasploit-credential', '>= 0.7.9.pre.core.pre.search', '< 0.8'
+  gem 'metasploit-credential', '>= 0.7.10.pre.core.pre.search', '< 0.8'
   # Database models shared between framework and Pro.
-  gem 'metasploit_data_models', '>= 0.18.0', '< 0.19'
+  gem 'metasploit_data_models', '~> 0.19'
   # Needed for module caching in Mdm::ModuleDetails
   gem 'pg', '>= 0.11'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :db do
   # Needed for Msf::DbManager
   gem 'activerecord', '>= 3.0.0', '< 4.0.0'
   # Metasploit::Credential database models
-  gem 'metasploit-credential', '>= 0.7.9.pre.core.pre.search', '< 0.7.10'
+  gem 'metasploit-credential', '>= 0.7.9.pre.core.pre.search', '< 0.8'
   # Database models shared between framework and Pro.
   gem 'metasploit_data_models', '>= 0.18.0', '< 0.19'
   # Needed for module caching in Mdm::ModuleDetails

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :db do
   # Needed for Msf::DbManager
   gem 'activerecord', '>= 3.0.0', '< 4.0.0'
   # Metasploit::Credential database models
-  gem 'metasploit-credential', git: 'github-metasploit-credential:rapid7/metasploit-credential.git', tag: 'v0.7.1.pre.electro.pre.release'
+  gem 'metasploit-credential', '~> 0.7.8'
   # Database models shared between framework and Pro.
   gem 'metasploit_data_models', '>= 0.18.0', '< 0.19'
   # Needed for module caching in Mdm::ModuleDetails

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :db do
   # Needed for Msf::DbManager
   gem 'activerecord', '>= 3.0.0', '< 4.0.0'
   # Metasploit::Credential database models
-  gem 'metasploit-credential', '~> 0.7.8'
+  gem 'metasploit-credential', '>= 0.7.9.pre.core.pre.search', '< 0.7.10'
   # Database models shared between framework and Pro.
   gem 'metasploit_data_models', '>= 0.18.0', '< 0.19'
   # Needed for module caching in Mdm::ModuleDetails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,8 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     arel (3.0.3)
+    arel-helpers (2.0.0)
+      activerecord (>= 3.1.0, < 5)
     bcrypt (3.1.7)
     builder (3.0.4)
     coderay (1.1.0)
@@ -58,18 +60,19 @@ GEM
     json (1.8.1)
     metasploit-concern (0.1.1)
       activesupport (~> 3.0, >= 3.0.0)
-    metasploit-credential (0.7.9.pre.core.pre.search)
+    metasploit-credential (0.7.10.pre.core.pre.search)
       metasploit-concern (~> 0.1.0)
       metasploit-model (>= 0.25.6)
-      metasploit_data_models (>= 0.18.0.pre.compatibility, < 0.19)
+      metasploit_data_models (~> 0.19)
       pg
       rubyntlm
       rubyzip (~> 1.1)
     metasploit-model (0.25.6)
       activesupport
-    metasploit_data_models (0.18.0)
+    metasploit_data_models (0.19.0)
       activerecord (>= 3.2.13, < 4.0.0)
       activesupport
+      arel-helpers
       metasploit-concern (~> 0.1.0)
       metasploit-model (>= 0.25.1, < 0.26)
       pg
@@ -156,9 +159,9 @@ DEPENDENCIES
   factory_girl (>= 4.1.0)
   factory_girl_rails
   fivemat (= 1.2.1)
-  metasploit-credential (>= 0.7.9.pre.core.pre.search, < 0.8)
+  metasploit-credential (>= 0.7.10.pre.core.pre.search, < 0.8)
   metasploit-framework!
-  metasploit_data_models (>= 0.18.0, < 0.19)
+  metasploit_data_models (~> 0.19)
   network_interface (~> 0.0.1)
   pcaprub
   pg (>= 0.11)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
     json (1.8.1)
     metasploit-concern (0.1.1)
       activesupport (~> 3.0, >= 3.0.0)
-    metasploit-credential (0.7.8)
+    metasploit-credential (0.7.9.pre.core.pre.search)
       metasploit-concern (~> 0.1.0)
       metasploit-model (>= 0.25.6)
       metasploit_data_models (>= 0.18.0.pre.compatibility, < 0.19)
@@ -156,7 +156,7 @@ DEPENDENCIES
   factory_girl (>= 4.1.0)
   factory_girl_rails
   fivemat (= 1.2.1)
-  metasploit-credential (~> 0.7.8)
+  metasploit-credential (>= 0.7.9.pre.core.pre.search, < 0.7.10)
   metasploit-framework!
   metasploit_data_models (>= 0.18.0, < 0.19)
   network_interface (~> 0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,3 @@
-GIT
-  remote: github-metasploit-credential:rapid7/metasploit-credential.git
-  revision: d5784729bf65a6419a05e2aaac1be217c4f93ff1
-  tag: v0.7.1.pre.electro.pre.release
-  specs:
-    metasploit-credential (0.7.1.pre.electro.pre.release)
-      metasploit-concern (~> 0.1.0)
-      metasploit-model (>= 0.25.6)
-      metasploit_data_models (>= 0.18.0.pre.compatibility, < 0.19)
-      rubyntlm
-      rubyzip (~> 1.1)
-
 PATH
   remote: .
   specs:
@@ -70,6 +58,13 @@ GEM
     json (1.8.1)
     metasploit-concern (0.1.1)
       activesupport (~> 3.0, >= 3.0.0)
+    metasploit-credential (0.7.8)
+      metasploit-concern (~> 0.1.0)
+      metasploit-model (>= 0.25.6)
+      metasploit_data_models (>= 0.18.0.pre.compatibility, < 0.19)
+      pg
+      rubyntlm
+      rubyzip (~> 1.1)
     metasploit-model (0.25.6)
       activesupport
     metasploit_data_models (0.18.0)
@@ -161,7 +156,7 @@ DEPENDENCIES
   factory_girl (>= 4.1.0)
   factory_girl_rails
   fivemat (= 1.2.1)
-  metasploit-credential!
+  metasploit-credential (~> 0.7.8)
   metasploit-framework!
   metasploit_data_models (>= 0.18.0, < 0.19)
   network_interface (~> 0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,7 +156,7 @@ DEPENDENCIES
   factory_girl (>= 4.1.0)
   factory_girl_rails
   fivemat (= 1.2.1)
-  metasploit-credential (>= 0.7.9.pre.core.pre.search, < 0.7.10)
+  metasploit-credential (>= 0.7.9.pre.core.pre.search, < 0.8)
   metasploit-framework!
   metasploit_data_models (>= 0.18.0, < 0.19)
   network_interface (~> 0.0.1)

--- a/spec/lib/msf/ui/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/command_dispatcher/db_spec.rb
@@ -73,9 +73,9 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
     describe "-p" do
       before(:each) do
         host = FactoryGirl.create(:mdm_host, :workspace => framework.db.workspace, :address => "192.168.0.1")
-        FactoryGirl.create(:mdm_service, :host => host, :port => 1024, name: 'Service1')
-        FactoryGirl.create(:mdm_service, :host => host, :port => 1025, name: 'Service2')
-        FactoryGirl.create(:mdm_service, :host => host, :port => 1026, name: 'Service3')
+        FactoryGirl.create(:mdm_service, :host => host, :port => 1024, name: 'Service1', proto: 'udp')
+        FactoryGirl.create(:mdm_service, :host => host, :port => 1025, name: 'Service2', proto: 'tcp')
+        FactoryGirl.create(:mdm_service, :host => host, :port => 1026, name: 'Service3', proto: 'udp')
       end
       it "should list services that are on a given port" do
         db.cmd_services "-p", "1024,1025"
@@ -85,8 +85,8 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
           "",
           "host         port  proto  name      state  info",
           "----         ----  -----  ----      -----  ----",
-          "192.168.0.1  1024  snmp   Service1  open   ",
-          "192.168.0.1  1025  snmp   Service2  open   "
+          "192.168.0.1  1024  udp    Service1  open   ",
+          "192.168.0.1  1025  tcp    Service2  open   "
         ]
       end
     end


### PR DESCRIPTION
[MSP-10029](https://jira.tor.rapid7.com/secure/RapidBoard.jspa?rapidView=84&view=detail&selectedIssue=MSP-10029)

Use `metasploit-credential` that supports searching associations on `Metasploit::Credential::Core` for https://github.com/rapid7/pro compatibility.
# Pre-Verification Steps
- [x] Release https://github.com/rapid7/metasploit-credential/pull/52
- [x] Update the Gemfile to use the released version of metasploit-credential
# Verification Steps
- [x] `bundle install`
## `rake spec`
- [x] `rake spec`
- [x] VERIFY no failures
# Post merge
- [ ] Merge https://github.com/rapid7/pro/pull/1407
