### PR TITLE
changing Credential == operator

### DIFF
--- a/lib/metasploit/framework/credential.rb
+++ b/lib/metasploit/framework/credential.rb
@@ -78,7 +78,9 @@ module Metasploit
       end
 
       def ==(other)
-        other.public == self.public && other.private == self.private && other.realm == self.realm
+        other.respond_to?(:public) && other.public == self.public &&
+        other.respond_to?(:private) && other.private == self.private &&
+        other.respond_to?(:realm) && other.realm == self.realm
       end
 
       def to_credential

--- a/spec/lib/metasploit/framework/credential_spec.rb
+++ b/spec/lib/metasploit/framework/credential_spec.rb
@@ -132,6 +132,11 @@ describe Metasploit::Framework::Credential do
         expect(other).not_to eq(cred_detail)
       end
     end
-
+    context "when comparing to a different object" do
+      let(:other) {'a string'}
+      specify do
+        expect(other).not_to eq(cred_detail)
+      end
+    end
   end
 end


### PR DESCRIPTION
it should no longer raise no method errors when comparing a credential to
an object that doesnt respond to public, private, or realm
# Verification steps
- [ ] Launch `msfconsole`
- [ ] `irb`
- [ ] `cred = Metasploit::Framework::Credential.new`
- [ ] `cred == cred` should return true
- [ ] `cred == 'string'` should return false
