### PR TITLE
Fix http directory traversal

### DIFF
--- a/modules/auxiliary/scanner/http/http_traversal.rb
+++ b/modules/auxiliary/scanner/http/http_traversal.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('PATH',    [true, 'Vulnerable path. Ex: /foo/index.php?pg=', '/']),
         OptString.new('DATA',    [false,'HTTP body data', '']),
         OptInt.new('DEPTH',      [true, 'Traversal depth', 5]),
-        OptRegexp.new('PATTERN', [true, 'Regexp pattern to determine directory traversal', '^HTTP/1.1 200 OK']),
+        OptRegexp.new('PATTERN', [true, 'Regexp pattern to determine directory traversal', '^HTTP/\\d\\.\\d 200']),
         OptPath.new(
           'FILELIST',
           [


### PR DESCRIPTION
The regular expression used to determine if a directory traversal succeeded assumes the server will respond with 1.1 and an OK message which is not a safe assumption at all.  I've change this to look for any HTTP 200 response.

Validation was against a system known vulnerable to http://www.exploit-db.com/exploits/12308/ and validated by hand.  Without this patch, modules/auxiliary/scanner/http/http_traversal.rb does not find the vuln.  With it, it does.  
