### PR TITLE
removes unnecessary returns & uses of 'not' etc from lib/msf/core/module/has_actions.rb

### DIFF
--- a/lib/msf/core/module/has_actions.rb
+++ b/lib/msf/core/module/has_actions.rb
@@ -16,25 +16,23 @@ module Msf::Module::HasActions
 
   def action
     sa = datastore['ACTION']
-    return find_action(default_action) if not sa
-    return find_action(sa)
+    sa ? find_action(sa) : find_action(default_action)
   end
 
   def find_action(name)
-    return nil if not name
-    actions.each do |a|
-      return a if a.name == name
+    if name
+      actions.each do |a|
+        return a if a.name == name
+      end
     end
-    return nil
   end
 
   #
   # Returns a boolean indicating whether this module should be run passively
   #
   def passive?
-    act = action()
-    return passive_action?(act.name) if act
-    return self.passive
+    act = action
+    act ? passive_action?(act.name) : self.passive
   end
 
   #


### PR DESCRIPTION
Style cleanup for lib/msf/core/module/has_actions.rb.  To verify, run some modules that make use of the ACTION option, some possibilities are listed below:
- auxiliary/admin/http/typo3_winstaller_default_enc_keys.rb
- auxiliary/scanner/http/http_put.rb
- auxiliary/scanner/smb/smb_lookupsid.rb
- post/osx/manage/mount_share.rb
- post/osx/manage/record_mic.rb
- post/osx/manage/vpn.rb
- post/osx/manage/webcam.rb

**auxiliary/scanner/smb/smb_lookupsid** is an easy choice
### Verification
- [x] View the diff and check if the new code is functionally equivalent
- [x] Get a session if using a post module to test
- [x] Run the module, make sure to use the ACTION option (for smb_lookupsid do set ACTION LOCAL or DOMAIN)
### My Results

**note there is a bug in smb_lookupsid when DOMAIN used but no WORKGROUP domain avail**
https://dev.metasploit.com/redmine/issues/8838 @hdmoore-r7, assigned to you, looks like you wrote the module.  Easy fix, just didn't know which way you wanted to go w/it.

```
Module options (auxiliary/scanner/smb/smb_lookupsid):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   MaxRID     4000             no        Maximum RID to check
   RHOSTS     192.168.66.223   yes       The target address range or CIDR identifier
   SMBDomain  WORKGROUP        no        The Windows domain to use for authentication
   SMBPass    MyP@ssy      no        The password for the specified username
   SMBUser    monkey              no        The username to authenticate as
   THREADS    1                yes       The number of concurrent threads

msf auxiliary(smb_lookupsid) > run

[*] 192.168.66.223 PIPE(LSARPC) LOCAL(MSF-win7 - 5-21-4011639611-1599478835-3455376462) DOMAIN(WORKGROUP - )
[*] 192.168.66.223 USER=Administrator RID=500
[*] 192.168.66.223 USER=Guest RID=501
[*] 192.168.66.223 GROUP=None RID=513
[*] 192.168.66.223 TYPE=4 NAME=HomeUsers rid=1000
[*] 192.168.66.223 USER=monkey RID=1001
[*] 192.168.66.223 USER=HomeGroupUser$ RID=1002
^C[*] Caught interrupt from the console...
[*] Auxiliary module execution completed
msf auxiliary(smb_lookupsid) > ACTION DOMAIN
ACTION => DOMAIN
msf auxiliary(smb_lookupsid) > so

Module options (auxiliary/scanner/smb/smb_lookupsid):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   MaxRID     4000             no        Maximum RID to check
   RHOSTS     192.168.66.223   yes       The target address range or CIDR identifier
   SMBDomain  WORKGROUP        no        The Windows domain to use for authentication
   SMBPass    MyP@ssy      no        The password for the specified username
   SMBUser    monkey              no        The username to authenticate as
   THREADS    1                yes       The number of concurrent threads

msf auxiliary(smb_lookupsid) > run

[*] 192.168.66.223 PIPE(LSARPC) LOCAL(MSF-win7 - 5-21-4011639611-1599478835-3455376462) DOMAIN(WORKGROUP - )
Error: 192.168.66.223 NoMethodError undefined method `split' for nil:NilClass
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
