### PR TITLE
Fixed status in MSF db for Nessus

### DIFF
--- a/modules/auxiliary/scanner/nessus/nessus_xmlrpc_ping.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_xmlrpc_ping.rb
@@ -66,7 +66,7 @@ class Metasploit3 < Msf::Auxiliary
         :port => datastore['RPORT'],
         :name => "nessus-xmlrpc",
         :info => 'Nessus XMLRPC',
-        :state => 'UP'
+        :state => 'open'
       )
     else
       vprint_error("Wrong HTTP Server header: #{res.headers['Server'] || ''}")


### PR DESCRIPTION
This is a very tiny fix for the existing nessus_xmlrpc_ping scanner module.  It currently stores the results (if it indeed identifies the nessus service as existing) within the database as 'UP'.  For continuity sake with how other live services are stored within the database, this has been changed to store it as 'open'.
