### PR TITLE
Feature/msp 9641/cred rpc calls

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -4,6 +4,9 @@ module RPC
 class RPC_Db < RPC_Base
 
 private
+
+  include Metasploit::Credential::Creation
+
   def db
     self.framework.db.active
   end
@@ -87,6 +90,12 @@ private
   end
 
 public
+
+  def rpc_create_credential(xopts)
+    create_credential(xopts)
+  end
+
+
 
   def rpc_hosts(xopts)
   ::ActiveRecord::Base.connection_pool.with_connection {

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -542,24 +542,6 @@ public
   }
   end
 
-  def rpc_get_auth_info(xopts)
-  ::ActiveRecord::Base.connection_pool.with_connection {
-    opts, wspace = init_db_opts_workspace(xopts)
-    ret = {}
-    ret[:auth_info] = []
-    # XXX: This method doesn't exist...
-    ai = self.framework.db.get_auth_info(opts)
-    ai.each do |i|
-      info = {}
-      i.each do |k,v|
-        info[k.to_sym] = v
-      end
-      ret[:auth_info] << info
-    end
-    ret
-  }
-  end
-
   def rpc_get_ref(name)
   ::ActiveRecord::Base.connection_pool.with_connection {
     db_check

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -542,15 +542,6 @@ public
   }
   end
 
-  def rpc_report_auth_info(xopts)
-  ::ActiveRecord::Base.connection_pool.with_connection {
-    opts, wspace = init_db_opts_workspace(xopts)
-    res = self.framework.db.report_auth_info(opts)
-    return { :result => 'success' } if(res)
-    { :result => 'failed' }
-  }
-  end
-
   def rpc_get_auth_info(xopts)
   ::ActiveRecord::Base.connection_pool.with_connection {
     opts, wspace = init_db_opts_workspace(xopts)
@@ -880,42 +871,6 @@ public
   }
   end
 
-  # requires host, port, user, pass, ptype, and active
-  def rpc_report_cred(xopts)
-  ::ActiveRecord::Base.connection_pool.with_connection {
-    opts, wspace = init_db_opts_workspace(xopts)
-    res = framework.db.find_or_create_cred(opts)
-    return { :result => 'success' } if res
-    { :result => 'failed' }
-  }
-  end
-
-  #right now workspace is the only option supported
-  def rpc_creds(xopts)
-  ::ActiveRecord::Base.connection_pool.with_connection {
-    opts, wspace = init_db_opts_workspace(xopts)
-    limit = opts.delete(:limit) || 100
-    offset = opts.delete(:offset) || 0
-
-    ret = {}
-    ret[:creds] = []
-    ::Mdm::Cred.find(:all, :include => {:service => :host}, :conditions => ["hosts.workspace_id = ?",
-        framework.db.workspace.id ], :limit => limit, :offset => offset).each do |c|
-      cred = {}
-      cred[:host] = c.service.host.address if(c.service.host)
-      cred[:updated_at] = c.updated_at.to_i
-      cred[:port] = c.service.port
-      cred[:proto] = c.service.proto
-      cred[:sname] = c.service.name
-      cred[:type] = c.ptype
-      cred[:user] = c.user
-      cred[:pass] = c.pass
-      cred[:active] = c.active
-      ret[:creds] << cred
-    end
-    ret
-  }
-  end
 
   def rpc_import_data(xopts)
   ::ActiveRecord::Base.connection_pool.with_connection {


### PR DESCRIPTION
This PR adds the RPC calls for new credential creation

VERIFICATION STEPS
- [x] `msfconsole`
- [x] `irb`
- [x] `framework.db.workspace.id` Remember this value!
- [x] `exit`
- [x] `load msgrpc Pass=pass123`
- [x] VERIFY the rpc service starts up
- [x] in another terminal `rvmsudo ./msfrpc -P pass123 -a 127.0.0.1 -S`
- [x] when the rpc terminal opens, paste in the following code (replace the workspace id with the value you got above)

```
credential_data = {
    module_fullname: 'auxiliary/scanner/afp/afp_login',
    origin_type: :service,
    private_data: 'msfadmin',
    private_type: :password,
    username: 'msfadmin',
    last_attempted_at: DateTime.now.to_s,
    status: 'Successful',
    address: '99.99.99.99',
    port: 548,
    service_name: 'afp',
    protocol: 'tcp',
    workspace_id: 60
}

rpc.call('db.create_credential', credential_data)
```
- [x] VERIFY you get a hash back with details about the credential that was created
- [x] run `creds` in msfconsole
- [x] VERIFY you see the credential listed
