### PR TITLE
Look for database.yml in installer location, too

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -41,8 +41,16 @@ module Metasploit
       user_config_root = Pathname.new(Msf::Config.get_config_root)
       user_database_yaml = user_config_root.join('database.yml')
 
+      # First try the user's configuration
       if user_database_yaml.exist?
         config.paths['config/database'] = [user_database_yaml.to_path]
+      else
+        # That didn't work out, try the config created by the installer.
+        install_root = Pathname.new(Msf::Config.install_root)
+        installer_database_yml = install_root.parent.join('ui').join('config').join('database.yml')
+        if installer_database_yml.exist?
+          config.paths['config/database'] = [installer_database_yaml.to_path]
+        end
       end
     end
   end


### PR DESCRIPTION
Note that this only fixes the immediate crash in the installed environment by allowing msfconsole to find `database.yml`. We still have the bigger problem that if there is no `database.yml` or if the database is not listening, we can't even parse options, which is tracked by MSP-10905.

MSP-10848
# Pre-verification Steps
- [x] Merge https://github.com/rapid7/metasploit-framework/pull/3615 to fix blocking bug on this same ticket
# Verification
- [ ] in an installer environment,
  - [ ] symlink this branch as /opt/metasploit/apps/pro/msf3
  - [ ] msfconsole
  - [ ] **Verify** No stack trace, msfconsole starts normally
