### PR TITLE
Fix a bug where msfconsole -n was broken

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       activesupport (>= 3.0.0, < 4.0.0)
       bcrypt
       json
+      metasploit-model (~> 0.25)
       meterpreter_bins (= 0.0.6)
       msgpack
       nokogiri
@@ -82,7 +83,7 @@ GEM
     msgpack (0.5.8)
     multi_json (1.0.4)
     network_interface (0.0.1)
-    nokogiri (1.6.2.1)
+    nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)
     packetfu (1.1.9)
     pcaprub (0.11.3)

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,29 +1,36 @@
 require 'rails'
 require File.expand_path('../boot', __FILE__)
 
-# only the parts of 'rails/all' that metasploit-framework actually uses
-begin
-  require 'active_record/railtie'
-rescue LoadError
-  warn "activerecord not in the bundle, so database support will be disabled."
-  warn "Bundle installed '--without #{Bundler.settings.without.join(' ')}'"
-  warn "To clear the without option do `bundle install --without ''` " \
-       "(the --without flag with an empty string) or " \
-       "`rm -rf .bundle` to remove the .bundle/config manually and " \
-       "then `bundle install`"
+$msfconsole_options ||= {}
+
+# only attempt to load active_record if database support is enabled
+unless $msfconsole_options['DisableDatabase']
+  # only the parts of 'rails/all' that metasploit-framework actually uses
+  begin
+    require 'active_record/railtie'
+  rescue LoadError
+    warn "activerecord not in the bundle, so database support will be disabled."
+    warn "Bundle installed '--without #{Bundler.settings.without.join(' ')}'"
+    warn "To clear the without option do `bundle install --without ''` " \
+      "(the --without flag with an empty string) or " \
+      "`rm -rf .bundle` to remove the .bundle/config manually and " \
+      "then `bundle install`"
+  end
 end
 
 all_environments = [
-    :development,
-    :production,
-    :test
+  :development,
+  :production,
+  :test
 ]
 
+db_environments = ($msfconsole_options['DisableDatabase'] ? [] : all_environments)
+
 Bundler.require(
-    *Rails.groups(
-        db: all_environments,
-        pcap: all_environments
-    )
+  *Rails.groups(
+    db: db_environments,
+    pcap: all_environments
+  )
 )
 
 #
@@ -38,20 +45,25 @@ module Metasploit
     class Application < Rails::Application
       include Metasploit::Framework::CommonEngine
 
-      user_config_root = Pathname.new(Msf::Config.get_config_root)
-      user_database_yaml = user_config_root.join('database.yml')
-
-      # First try the user's configuration
-      if user_database_yaml.exist?
-        config.paths['config/database'] = [user_database_yaml.to_path]
+      if $msfconsole_options['DatabaseYAML'] && File.exists?($msfconsole_options['DatabaseYAML'])
+        config.paths['config/database'] = [ $msfconsole_options['DatabaseYAML'] ]
       else
-        # That didn't work out, try the config created by the installer.
-        install_root = Pathname.new(Msf::Config.install_root)
-        installer_database_yml = install_root.parent.join('ui').join('config').join('database.yml')
-        if installer_database_yml.exist?
-          config.paths['config/database'] = [installer_database_yaml.to_path]
+        user_config_root = Pathname.new(Msf::Config.get_config_root)
+        user_database_yaml = user_config_root.join('database.yml')
+
+        # First try the user's configuration
+        if user_database_yaml.exist?
+          config.paths['config/database'] = [ user_database_yaml.to_path ]
+        else
+          # That didn't work out, try the config created by the installer.
+          install_root = Pathname.new(Msf::Config.install_root)
+          installer_database_yml = install_root.parent.join('ui').join('config').join('database.yml')
+          if installer_database_yml.exist?
+            config.paths['config/database'] = [ installer_database_yaml.to_path ]
+          end
         end
       end
+
     end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,6 +45,8 @@ module Metasploit
     class Application < Rails::Application
       include Metasploit::Framework::CommonEngine
 
+      config.active_support.deprecation = :log
+
       if $msfconsole_options['DatabaseYAML'] && File.exists?($msfconsole_options['DatabaseYAML'])
         config.paths['config/database'] = [ $msfconsole_options['DatabaseYAML'] ]
       else

--- a/config/application.rb
+++ b/config/application.rb
@@ -41,8 +41,16 @@ module Metasploit
       user_config_root = Pathname.new(Msf::Config.get_config_root)
       user_database_yaml = user_config_root.join('database.yml')
 
+      # First try the user's configuration
       if user_database_yaml.exist?
         config.paths['config/database'] = [user_database_yaml.to_path]
+      else
+        # That didn't work out, try the config created by the installer.
+        install_root = Pathname.new(Msf::Config.install_root)
+        installer_database_yml = install_root.parent.join('ui').join('config').join('database.yml')
+        if installer_database_yml.exist?
+          config.paths['config/database'] = [installer_database_yaml.to_path]
+        end
       end
     end
   end

--- a/lib/metasploit/framework.rb
+++ b/lib/metasploit/framework.rb
@@ -9,6 +9,7 @@ require 'active_support'
 require 'bcrypt'
 require 'json'
 require 'msgpack'
+require 'metasploit/model'
 require 'nokogiri'
 require 'packetfu'
 # railties has not autorequire defined

--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -1,5 +1,7 @@
 require 'metasploit/framework/login_scanner'
 
+require 'metasploit/model'
+
 module Metasploit
   module Framework
     module LoginScanner

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -55,6 +55,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'bcrypt'
   # Needed for some admin modules (scrutinizer_add_user.rb)
   spec.add_runtime_dependency 'json'
+  # Things that would normally be part of the database model, but which
+  # are needed when there's no database
+  spec.add_runtime_dependency 'metasploit-model', '~> 0.25'
   # Needed for Meterpreter on Windows, soon others.
   spec.add_runtime_dependency 'meterpreter_bins', '0.0.6'
   # Needed by msfgui and other rpc components

--- a/msfconsole
+++ b/msfconsole
@@ -1,26 +1,9 @@
 #!/usr/bin/env ruby
 # -*- coding: binary -*-
 #
-# $Id$
-#
 # This user interface provides users with a command console interface to the
 # framework.
 #
-# $Revision$
-#
-
-msfbase = __FILE__
-while File.symlink?(msfbase)
-  msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
-end
-
-@msfbase_dir = File.expand_path(File.dirname(msfbase))
-
-$:.unshift(File.expand_path(File.join(File.dirname(msfbase), 'lib')))
-require 'fastlib'
-require 'msfenv'
-
-$:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
 
 require 'optparse'
 
@@ -39,7 +22,7 @@ class OptsConsole
       'DeferModuleLoads' => true
     }
 
-    opts = OptionParser.new do |opts|
+    parser = OptionParser.new do |opts|
       opts.banner = "Usage: msfconsole [options]"
 
       opts.separator ""
@@ -116,7 +99,7 @@ class OptsConsole
     end
 
     begin
-      opts.parse!(args)
+      parser.parse!(args)
     rescue OptionParser::InvalidOption
       puts "Invalid option, try -h for usage"
       exit
@@ -126,12 +109,26 @@ class OptsConsole
   end
 end
 
-options = OptsConsole.parse(ARGV)
+$msfconsole_options = OptsConsole.parse(ARGV)
 
 #
-# NOTE: we don't require this until down here since we may not need it
-# when processing certain options (currently only -h)
+# NOTE: we don't require anything until down here since we may not need
+# it when processing certain options (currently only -h)
 #
+
+msfbase = __FILE__
+while File.symlink?(msfbase)
+  msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
+end
+
+@msfbase_dir = File.expand_path(File.dirname(msfbase))
+
+$:.unshift(File.expand_path(File.join(File.dirname(msfbase), 'lib')))
+require 'fastlib'
+require 'msfenv'
+
+$:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
+
 require 'rex'
 require 'msf/ui'
 
@@ -139,7 +136,7 @@ require 'msf/ui'
 # Everything below this line requires the framework.
 #
 
-if (options['Version'])
+if ($msfconsole_options['Version'])
   $stderr.puts 'Framework Version: ' + Msf::Framework::Version
   exit
 end
@@ -148,7 +145,7 @@ begin
   Msf::Ui::Console::Driver.new(
     Msf::Ui::Console::Driver::DefaultPrompt,
     Msf::Ui::Console::Driver::DefaultPromptChar,
-    options
+    $msfconsole_options
   ).run
 rescue Interrupt
 end


### PR DESCRIPTION
Land #3578 first.

MSP-10905
#### Verification
- [ ] `sudo service postgresql stop`
- [ ] `RAILS_ENV=production msfconsole -n`
- [ ] **VERIFY** msfconsole starts without errors. (The warning that the database is disabled is OK)
- [ ] `mv ~/.msf4/database.yml ~/`
- [ ] put bogus info in ~/.msf4/database.yml
- [ ] `msfconsole -y ~/database.yml`
- [ ] **VERIFY** msfconsole starts with no errors
- [ ] `db_status`
- [ ] **VERIFY** connected as expected
- [ ] `mv ~/database.yml ~/.msf4/`
