### PR TITLE
Credential Parent References

### DIFF
--- a/lib/metasploit/framework/credential.rb
+++ b/lib/metasploit/framework/credential.rb
@@ -12,6 +12,9 @@ module Metasploit
       #   @return [Boolean] Whether BOTH a public and private are required
       #     (defaults to `true`)
       attr_accessor :paired
+      # @!attribute parent
+      #   @return [Object] the parent object that had .to_credential called on it to create this object
+      attr_accessor :parent
       # @!attribute private
       #   The private credential component (e.g. username)
       #


### PR DESCRIPTION
Have a Metasploit::Framework::Credential object remember a reference to it's parent

No real VERIFICATION STEPS here. Code review, then VERIFY https://github.com/rapid7/pro/pull/1433
