### PR TITLE
msfconsole -n

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       activesupport (>= 3.0.0, < 4.0.0)
       bcrypt
       json
+      metasploit-model (~> 0.25.6)
       meterpreter_bins (= 0.0.6)
       msgpack
       nokogiri

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,11 @@
 #!/usr/bin/env rake
 require File.expand_path('../config/application', __FILE__)
+require 'metasploit/framework/require'
+
+# @note must be before `Metasploit::Framework::Application.load_tasks`
+#
+# define db rake tasks from activerecord if activerecord is in the bundle.  activerecord could be not in the bundle if
+# the user installs with `bundle install --without db`
+Metasploit::Framework::Require.optionally_active_record_railtie
 
 Metasploit::Framework::Application.load_tasks

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,30 +1,7 @@
 require 'rails'
 require File.expand_path('../boot', __FILE__)
 
-# only the parts of 'rails/all' that metasploit-framework actually uses
-begin
-  require 'active_record/railtie'
-rescue LoadError
-  warn "activerecord not in the bundle, so database support will be disabled."
-  warn "Bundle installed '--without #{Bundler.settings.without.join(' ')}'"
-  warn "To clear the without option do `bundle install --without ''` " \
-       "(the --without flag with an empty string) or " \
-       "`rm -rf .bundle` to remove the .bundle/config manually and " \
-       "then `bundle install`"
-end
-
-all_environments = [
-    :development,
-    :production,
-    :test
-]
-
-Bundler.require(
-    *Rails.groups(
-        db: all_environments,
-        pcap: all_environments
-    )
-)
+Bundler.require(*Rails.groups)
 
 #
 # Project

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,18 @@
 require 'rails'
 require File.expand_path('../boot', __FILE__)
 
-Bundler.require(*Rails.groups)
+all_environments = [
+    :development,
+    :production,
+    :test
+]
+
+Bundler.require(
+    *Rails.groups(
+        db: all_environments,
+        pcap: all_environments
+    )
+)
 
 #
 # Project

--- a/lib/metasploit/framework.rb
+++ b/lib/metasploit/framework.rb
@@ -9,6 +9,7 @@ require 'active_support'
 require 'bcrypt'
 require 'json'
 require 'msgpack'
+require 'metasploit/model'
 require 'nokogiri'
 require 'packetfu'
 # railties has not autorequire defined

--- a/lib/metasploit/framework/command.rb
+++ b/lib/metasploit/framework/command.rb
@@ -1,0 +1,22 @@
+#
+# Gems
+#
+
+# have to be exact so minimum is loaded prior to parsing arguments which could influence loading.
+require 'active_support/dependencies/autoload'
+
+# @note Must use the nested declaration of the {Metasploit::Framework::Command} namespace because commands need to be
+# able to be required directly without any other part of metasploit-framework besides config/boot so that the commands
+# can parse arguments, setup RAILS_ENV, and load config/application.rb correctly.
+module Metasploit
+  module Framework
+    module Command
+      # Namespace for commands for metasploit-framework.  There are corresponding classes in the
+      # {Metasploit::Framework::ParsedOptions} namespace, which handle for parsing the options for each command.
+      extend ActiveSupport::Autoload
+
+      autoload :Base
+      autoload :Console
+    end
+  end
+end

--- a/lib/metasploit/framework/command/base.rb
+++ b/lib/metasploit/framework/command/base.rb
@@ -1,0 +1,117 @@
+#
+# Gems
+#
+
+require 'active_support/core_ext/module/introspection'
+
+#
+# Project
+#
+
+require 'metasploit/framework/command'
+require 'metasploit/framework/parsed_options'
+
+# Based on pattern used for lib/rails/commands in the railties gem.
+class Metasploit::Framework::Command::Base
+  #
+  # Attributes
+  #
+
+  # @!attribute [r] application
+  #   The Rails application for metasploit-framework.
+  #
+  #   @return [Metasploit::Framework::Application]
+  attr_reader :application
+
+  # @!attribute [r] parsed_options
+  #   The parsed options from the command line.
+  #
+  #   @return (see parsed_options)
+  attr_reader :parsed_options
+
+  #
+  # Class Methods
+  #
+
+  # @note {require_environment!} should be called to load `config/application.rb` to so that the RAILS_ENV can be set
+  #   from the command line options in `ARGV` prior to `Rails.env` being set.
+  # @note After returning, `Rails.application` will be defined and configured.
+  #
+  # Parses `ARGV` for command line arguments to configure the `Rails.application`.
+  #
+  # @return (see parsed_options)
+  def self.require_environment!
+    parsed_options = self.parsed_options
+    # RAILS_ENV must be set before requiring 'config/application.rb'
+    parsed_options.environment!
+    ARGV.replace(parsed_options.positional)
+
+    # @see https://github.com/rails/rails/blob/v3.2.17/railties/lib/rails/commands.rb#L39-L40
+    require Pathname.new(__FILE__).parent.parent.parent.parent.parent.join('config', 'application')
+
+    # have to configure before requiring environment because config/environment.rb calls initialize! and the initializers
+    # will use the configuration from the parsed options.
+    parsed_options.configure(Rails.application)
+
+    # support disabling the database
+    unless parsed_options.options.database.disable
+      begin
+        require 'active_record/railtie'
+      rescue LoadError
+        warn "activerecord not in the bundle, so database support will be disabled."
+        warn "Bundle installed '--without #{Bundler.settings.without.join(' ')}'"
+        warn "To clear the without option do `bundle install --without ''` " \
+             "(the --without flag with an empty string) or " \
+             "`rm -rf .bundle` to remove the .bundle/config manually and " \
+             "then `bundle install`"
+      end
+
+      ENV['RAILS_GROUP'] = 'db,pcap'
+    end
+
+    Rails.application.require_environment!
+
+    parsed_options
+  end
+
+  def self.parsed_options
+    parsed_options_class.new
+  end
+
+  def self.parsed_options_class
+    @parsed_options_class ||= parsed_options_class_name.constantize
+  end
+
+  def self.parsed_options_class_name
+    @parsed_options_class_name ||= "#{parent.parent}::ParsedOptions::#{name.demodulize}"
+  end
+
+  def self.start
+    parsed_options = require_environment!
+    new(application: Rails.application, parsed_options: parsed_options).start
+  end
+
+  #
+  # Instance Methods
+  #
+
+  # @param attributes [Hash{Symbol => ActiveSupport::OrderedOptions,Rails::Application}]
+  # @option attributes [Rails::Application] :application
+  # @option attributes [ActiveSupport::OrderedOptions] :parsed_options
+  # @raise [KeyError] if :application is not given
+  # @raise [KeyError] if :parsed_options is not given
+  def initialize(attributes={})
+    @application = attributes.fetch(:application)
+    @parsed_options = attributes.fetch(:parsed_options)
+  end
+
+  # @abstract Use {#application} to start this command.
+  #
+  # Starts this command.
+  #
+  # @return [void]
+  # @raise [NotImplementedError]
+  def start
+    raise NotImplementedError
+  end
+end

--- a/lib/metasploit/framework/command/base.rb
+++ b/lib/metasploit/framework/command/base.rb
@@ -65,8 +65,6 @@ class Metasploit::Framework::Command::Base
              "`rm -rf .bundle` to remove the .bundle/config manually and " \
              "then `bundle install`"
       end
-
-      ENV['RAILS_GROUP'] = 'db,pcap'
     end
 
     Rails.application.require_environment!

--- a/lib/metasploit/framework/command/base.rb
+++ b/lib/metasploit/framework/command/base.rb
@@ -10,6 +10,7 @@ require 'active_support/core_ext/module/introspection'
 
 require 'metasploit/framework/command'
 require 'metasploit/framework/parsed_options'
+require 'metasploit/framework/require'
 
 # Based on pattern used for lib/rails/commands in the railties gem.
 class Metasploit::Framework::Command::Base
@@ -55,16 +56,7 @@ class Metasploit::Framework::Command::Base
 
     # support disabling the database
     unless parsed_options.options.database.disable
-      begin
-        require 'active_record/railtie'
-      rescue LoadError
-        warn "activerecord not in the bundle, so database support will be disabled."
-        warn "Bundle installed '--without #{Bundler.settings.without.join(' ')}'"
-        warn "To clear the without option do `bundle install --without ''` " \
-             "(the --without flag with an empty string) or " \
-             "`rm -rf .bundle` to remove the .bundle/config manually and " \
-             "then `bundle install`"
-      end
+      Metasploit::Framework::Require.optionally_active_record_railtie
     end
 
     Rails.application.require_environment!

--- a/lib/metasploit/framework/command/console.rb
+++ b/lib/metasploit/framework/command/console.rb
@@ -1,0 +1,58 @@
+#
+# Project
+#
+
+require 'metasploit/framework/command'
+require 'metasploit/framework/command/base'
+
+# Based on pattern used for lib/rails/commands in the railties gem.
+class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::Base
+  def start
+    driver.run
+  end
+
+  private
+
+  # The console UI driver.
+  #
+  # @return [Msf::Ui::Console::Driver]
+  def driver
+    unless @driver
+      # require here so minimum loading is done before {start} is called.
+      require 'msf/ui'
+
+      @driver = Msf::Ui::Console::Driver.new(
+          Msf::Ui::Console::Driver::DefaultPrompt,
+          Msf::Ui::Console::Driver::DefaultPromptChar,
+          driver_options
+      )
+    end
+
+    @driver
+  end
+
+  def driver_options
+    unless @driver_options
+      options = parsed_options.options
+
+      driver_options = {}
+      driver_options['Config'] = options.framework.config
+      driver_options['DatabaseEnv'] = options.environment
+      driver_options['DatabaseMigrationPaths'] = options.database.migrations_paths
+      driver_options['DatabaseYAML'] = options.database.config
+      driver_options['Defanged'] = options.console.defanged
+      driver_options['DisableBanner'] = options.console.quiet
+      driver_options['DisableDatabase'] = options.database.disable
+      driver_options['LocalOutput'] = options.console.local_output
+      driver_options['ModulePath'] = options.modules.path
+      driver_options['Plugins'] = options.console.plugins
+      driver_options['RealReadline'] = options.console.real_readline
+      driver_options['Resource'] = options.console.resource
+      driver_options['XCommands'] = options.console.commands
+
+      @driver_options = driver_options
+    end
+
+    @driver_options
+  end
+end

--- a/lib/metasploit/framework/parsed_options.rb
+++ b/lib/metasploit/framework/parsed_options.rb
@@ -1,0 +1,24 @@
+#
+# Gems
+#
+
+require 'active_support/dependencies/autoload'
+
+# # @note Must use the nested declaration of the {Metasploit::Framework::ParsedOptions} namespace because commands,
+# which use parsed options, need to be able to be required directly without any other part of metasploit-framework
+# besides config/boot so that the commands can parse arguments, setup RAILS_ENV, and load config/application.rb
+# correctly.
+module Metasploit
+  module Framework
+    # Namespace for parsed options for {Metasploit::Framework::Command commands}.  The names of `Class`es in this
+    # namespace correspond to the name of the `Class` in the {Metasploit::Framework::Command} namespace for which this
+    # namespace's `Class` parses options.
+    module ParsedOptions
+      extend ActiveSupport::Autoload
+
+      autoload :Base
+      autoload :Console
+    end
+  end
+end
+

--- a/lib/metasploit/framework/parsed_options/base.rb
+++ b/lib/metasploit/framework/parsed_options/base.rb
@@ -76,9 +76,9 @@ class Metasploit::Framework::ParsedOptions::Base
       user_database_yaml = user_config_root.join('database.yml')
 
       if user_database_yaml.exist?
-        options.database.config = [user_database_yaml.to_path]
+        options.database.config = user_database_yaml.to_path
       else
-        options.database.config = ['config/database.yml']
+        options.database.config = 'config/database.yml'
       end
 
       options.database.disable = false

--- a/lib/metasploit/framework/parsed_options/base.rb
+++ b/lib/metasploit/framework/parsed_options/base.rb
@@ -1,0 +1,182 @@
+#
+# Standard Library
+#
+
+require 'optparse'
+
+#
+# Gems
+#
+
+require 'active_support/ordered_options'
+
+#
+# Project
+#
+
+require 'metasploit/framework/parsed_options'
+require 'msf/base/config'
+
+# Options parsed from the command line that can be used to change the `Metasploit::Framework::Application.config` and
+# `Rails.env`
+class Metasploit::Framework::ParsedOptions::Base
+  #
+  # CONSTANTS
+  #
+
+  # msfconsole boots in production mode instead of the normal rails default of development.
+  DEFAULT_ENVIRONMENT = 'production'
+
+  #
+  # Attributes
+  #
+
+  attr_reader :positional
+
+  #
+  # Instance Methods
+  #
+
+  def initialize(arguments=ARGV)
+    @positional = option_parser.parse(arguments)
+  end
+
+  # Translates {#options} to the `application`'s config
+  #
+  # @param application [Rails::Application]
+  # @return [void]
+  def configure(application)
+    application.config['config/database'] = options.database.config
+  end
+
+  # Sets the `RAILS_ENV` environment variable.
+  #
+  # 1. If the -E/--environment option is given, then its value is used.
+  # 2. The default value, 'production', is used.
+  #
+  # @return [void]
+  def environment!
+    if defined?(Rails) && Rails.instance_variable_defined?(:@_env)
+      raise "#{self.class}##{__method__} called too late to set RAILS_ENV: Rails.env already memoized"
+    end
+
+    ENV['RAILS_ENV'] = options.environment
+  end
+
+  # Options parsed from
+  #
+  # @return [ActiveSupport::OrderedOptions]
+  def options
+    unless @options
+      options = ActiveSupport::OrderedOptions.new
+
+      options.database = ActiveSupport::OrderedOptions.new
+
+      user_config_root = Pathname.new(Msf::Config.get_config_root)
+      user_database_yaml = user_config_root.join('database.yml')
+
+      if user_database_yaml.exist?
+        options.database.config = [user_database_yaml.to_path]
+      else
+        options.database.config = ['config/database.yml']
+      end
+
+      options.database.disable = false
+      options.database.migrations_paths = []
+
+      options.framework = ActiveSupport::OrderedOptions.new
+      options.framework.config = nil
+
+      options.modules = ActiveSupport::OrderedOptions.new
+      options.modules.path = nil
+
+      options.environment = DEFAULT_ENVIRONMENT
+
+      @options = options
+    end
+
+    @options
+  end
+
+  private
+
+  # Parses arguments into {#options}.
+  #
+  # @return [OptionParser]
+  def option_parser
+    @option_parser ||= OptionParser.new { |option_parser|
+      option_parser.separator ''
+      option_parser.separator 'Common options'
+
+      option_parser.on(
+          '-E',
+          '--environment ENVIRONMENT',
+          %w{development production test},
+          "The Rails environment. Will use RAIL_ENV environment variable if that is set.  " \
+          "Defaults to production if neither option not RAILS_ENV environment variable is set."
+      ) do |environment|
+        options.environment = environment
+      end
+
+      option_parser.separator ''
+      option_parser.separator 'Database options'
+
+      option_parser.on(
+          '-M',
+          '--migration-path DIRECTORY',
+          'Specify a directory containing additional DB migrations'
+      ) do |directory|
+        options.database.migrations_paths << directory
+      end
+
+      option_parser.on('-n', '--no-database', 'Disable database support') do
+        options.database.disable = true
+      end
+
+      option_parser.on(
+          '-y',
+          '--yaml PATH',
+          'Specify a YAML file containing database settings'
+      ) do |path|
+        options.database.config = path
+      end
+
+      option_parser.separator ''
+      option_parser.separator 'Framework options'
+
+
+      option_parser.on('-c', '-c FILE', 'Load the specified configuration file') do |file|
+        options.framework.config = file
+      end
+
+      option_parser.on(
+          '-v',
+          '--version',
+          'Show version'
+      ) do
+        options.subcommand = :version
+      end
+
+      option_parser.separator ''
+      option_parser.separator 'Module options'
+
+      option_parser.on(
+          '-m',
+          '--module-path DIRECTORY',
+          'An additional module path'
+      ) do |directory|
+        options.modules.path = directory
+      end
+
+      #
+      # Tail
+      #
+
+      option_parser.separator ''
+      option_parser.on_tail('-h', '--help', 'Show this message') do
+        puts option_parser
+        exit
+      end
+    }
+  end
+end

--- a/lib/metasploit/framework/parsed_options/console.rb
+++ b/lib/metasploit/framework/parsed_options/console.rb
@@ -1,0 +1,73 @@
+# Parsed options for {Metasploit::Framework::Command::Console}
+class Metasploit::Framework::ParsedOptions::Console < Metasploit::Framework::ParsedOptions::Base
+  # Options parsed from msfconsole command-line.
+  #
+  # @return [ActiveSupport::OrderedOptions]
+  def options
+    unless @options
+      super.tap { |options|
+        options.console = ActiveSupport::OrderedOptions.new
+
+        options.console.commands = []
+        options.console.defanged = false
+        options.console.local_output = nil
+        options.console.plugins = []
+        options.console.quiet = false
+        options.console.real_readline = false
+        options.console.resources = []
+      }
+    end
+
+    @options
+  end
+
+  private
+
+  # Parses msfconsole arguments into {#options}.
+  #
+  # @return [OptionParser]
+  def option_parser
+    unless @option_parser
+      super.tap { |option_parser|
+        option_parser.banner = "Usage: #{option_parser.program_name} [options]"
+
+        option_parser.separator ''
+        option_parser.separator 'Console options:'
+
+        option_parser.on('-d', '--defanged', 'Execute the console as defanged') do
+          options.console.defanged = true
+        end
+
+        option_parser.on('-L', '--real-readline', 'Use the system Readline library instead of RbReadline') do
+          options.console.real_readline = true
+        end
+
+        option_parser.on('-o', '--output FILE', 'Output to the specified file') do |file|
+          options.console.local_output = file
+        end
+
+        option_parser.on('-p', '--plugin PLUGIN', 'Load a plugin on startup') do |plugin|
+          options.console.plugins << plugin
+        end
+
+        option_parser.on('-q', '--quiet', 'Do not print the banner on start up') do
+          options.console.quiet = true
+        end
+
+        option_parser.on('-r', '--resource FILE', 'Execute the specified resource file') do |file|
+          options.console.resources << file
+        end
+
+        option_parser.on(
+            '-x',
+            '--execute-command COMMAND',
+            'Execute the specified string as console commands (use ; for multiples)'
+        ) do |commands|
+          options.console.commands += commands.split(/\s*;\s*/)
+        end
+      }
+    end
+
+    @option_parser
+  end
+end

--- a/lib/metasploit/framework/require.rb
+++ b/lib/metasploit/framework/require.rb
@@ -1,0 +1,92 @@
+# @note needs to use explicit nesting. so this file can be loaded directly without loading 'metasploit/framework', this
+#   file can be used prior to Bundler.require.
+module Metasploit
+  module Framework
+    # Extension to `Kernel#require` behavior.
+    module Require
+      #
+      # Module Methods
+      #
+
+      # Tries to require `name`.  If a `LoadError` occurs, then `without_warning` is printed to standard error using
+      # `Kernel#warn`, along with instructions for reinstalling the bundle.  If a `LoadError` does not occur, then
+      # `with_block` is called.
+      #
+      # @param name [String] the name of the library to `Kernel#require`.
+      # @param without_warning [String] warning to print if `name` cannot be required.
+      # @yield block to run when `name` requires successfully
+      # @yieldreturn [void]
+      # @return [void]
+      def self.optionally(name, without_warning)
+        begin
+          require name
+        rescue LoadError
+          warn without_warning
+          warn "Bundle installed '--without #{Bundler.settings.without.join(' ')}'"
+          warn "To clear the without option do `bundle install --without ''` " \
+           "(the --without flag with an empty string) or " \
+           "`rm -rf .bundle` to remove the .bundle/config manually and " \
+           "then `bundle install`"
+        else
+          if block_given?
+            yield
+          end
+        end
+      end
+
+      # Tries to `require 'active_record/railtie'` to define the activerecord Rails initializers and rake tasks.
+      #
+      # @example Optionally requiring 'active_record/railtie'
+      #   require 'metasploit/framework/require'
+      #
+      #   class MyClass
+      #     def setup
+      #       if database_enabled
+      #         Metasploit::Framework::Require.optionally_active_record_railtie
+      #       end
+      #     end
+      #   end
+      #
+      # @return [void]
+      def self.optionally_active_record_railtie
+        optionally(
+            'active_record/railtie',
+            'activerecord not in the bundle, so database support will be disabled.'
+        )
+      end
+
+      # Tries to `require 'metasploit/credential/creation'` and include it in the `including_module`.
+      #
+      # @param including_module [Module] `Class` or `Module` that wants to `include Metasploit::Credential::Creation`.
+      # @return [void]
+      def self.optionally_include_metasploit_credential_creation(including_module)
+        optionally(
+            'metasploit/credential/creation',
+            "metasploit-credential not in the bundle, so Metasploit::Credential creation will fail for #{including_module.name}",
+        ) do
+          including_module.send(:include, Metasploit::Credential::Creation)
+        end
+      end
+
+      #
+      # Instance Methods
+      #
+
+      # Tries to `require 'metasploit/credential/creation'` and include it in this `Class` or `Module`.
+      #
+      # @example Using in a `Module`
+      #   require 'metasploit/framework/require'
+      #
+      #   module MyModule
+      #     extend Metasploit::Framework::Require
+      #
+      #     optionally_include_metasploit_credential_creation
+      #   end
+      #
+      # @return [void]
+      def optionally_include_metasploit_credential_creation
+        Metasploit::Framework::Require.optionally_include_metasploit_credential_creation(self)
+      end
+    end
+  end
+end

--- a/lib/msf/base/config.rb
+++ b/lib/msf/base/config.rb
@@ -10,7 +10,6 @@ require 'fileutils'
 # Project
 #
 
-require 'msf/core'
 require 'rex/compat'
 
 module Msf
@@ -37,16 +36,16 @@ class Config < Hash
     ['HOME', 'LOCALAPPDATA', 'APPDATA', 'USERPROFILE'].each do |dir|
       val = Rex::Compat.getenv(dir)
       if (val and File.directory?(val))
-        return File.join(val, ".msf#{Msf::Framework::Major}")
+        return File.join(val, ".msf#{Metasploit::Framework::Version::MAJOR}")
       end
     end
 
     begin
       # First we try $HOME/.msfx
-      File.expand_path("~#{FileSep}.msf#{Msf::Framework::Major}")
+      File.expand_path("~#{FileSep}.msf#{Metasploit::Framework::Version::MAJOR}")
     rescue ::ArgumentError
       # Give up and install root + ".msfx"
-      InstallRoot + ".msf#{Msf::Framework::Major}"
+      InstallRoot + ".msf#{Metasploit::Framework::Version::MAJOR}"
     end
   end
 

--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -8,18 +8,9 @@ module Msf
 ###
 
 module Auxiliary::Report
-  begin
-    require 'metasploit/credential/creation'
-  rescue LoadError
-    warn "metasploit-credential not in the bundle, so Metasploit::Credential creation will fail for Msf::Auxiliary::Report."
-    warn "Bundle installed '--without #{Bundler.settings.without.join(' ')}'"
-    warn "To clear the without option do `bundle install --without ''` " \
-             "(the --without flag with an empty string) or " \
-             "`rm -rf .bundle` to remove the .bundle/config manually and " \
-             "then `bundle install`"
-  else
-    include Metasploit::Credential::Creation
-  end
+  extend Metasploit::Framework::Require
+
+  optionally_include_metasploit_credential_creation
 
   # This method overrides the method from Metasploit::Credential to check for an active db
   def active_db?

--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -1,4 +1,3 @@
-require 'metasploit/credential/creation'
 # -*- coding: binary -*-
 module Msf
 
@@ -9,8 +8,18 @@ module Msf
 ###
 
 module Auxiliary::Report
-
-  include Metasploit::Credential::Creation
+  begin
+    require 'metasploit/credential/creation'
+  rescue LoadError
+    warn "metasploit-credential not in the bundle, so Metasploit::Credential creation will fail for Msf::Auxiliary::Report."
+    warn "Bundle installed '--without #{Bundler.settings.without.join(' ')}'"
+    warn "To clear the without option do `bundle install --without ''` " \
+             "(the --without flag with an empty string) or " \
+             "`rm -rf .bundle` to remove the .bundle/config manually and " \
+             "then `bundle install`"
+  else
+    include Metasploit::Credential::Creation
+  end
 
   # This method overrides the method from Metasploit::Credential to check for an active db
   def active_db?

--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -56,7 +56,6 @@ require 'rex/parser/retina_xml'
 #
 
 require 'msf/core/db_manager/import_msf_xml'
-require 'metasploit/credential/creation'
 
 module Msf
 
@@ -157,7 +156,19 @@ end
 ###
 class DBManager
   include Msf::DBManager::ImportMsfXml
-  include Metasploit::Credential::Creation
+
+  begin
+    require 'metasploit/credential/creation'
+  rescue LoadError
+    warn "metasploit-credential not in the bundle, so Metasploit::Credential creation will fail for Msf::DBManager"
+    warn "Bundle installed '--without #{Bundler.settings.without.join(' ')}'"
+    warn "To clear the without option do `bundle install --without ''` " \
+             "(the --without flag with an empty string) or " \
+             "`rm -rf .bundle` to remove the .bundle/config manually and " \
+             "then `bundle install`"
+  else
+    include Metasploit::Credential::Creation
+  end
 
   def rfc3330_reserved(ip)
     case ip.class.to_s

--- a/lib/msf/core/db.rb
+++ b/lib/msf/core/db.rb
@@ -55,6 +55,7 @@ require 'rex/parser/retina_xml'
 # Project
 #
 
+require 'metasploit/framework/require'
 require 'msf/core/db_manager/import_msf_xml'
 
 module Msf
@@ -155,20 +156,10 @@ end
 #
 ###
 class DBManager
-  include Msf::DBManager::ImportMsfXml
+  extend Metasploit::Framework::Require
 
-  begin
-    require 'metasploit/credential/creation'
-  rescue LoadError
-    warn "metasploit-credential not in the bundle, so Metasploit::Credential creation will fail for Msf::DBManager"
-    warn "Bundle installed '--without #{Bundler.settings.without.join(' ')}'"
-    warn "To clear the without option do `bundle install --without ''` " \
-             "(the --without flag with an empty string) or " \
-             "`rm -rf .bundle` to remove the .bundle/config manually and " \
-             "then `bundle install`"
-  else
-    include Metasploit::Credential::Creation
-  end
+  include Msf::DBManager::ImportMsfXml
+  optionally_include_metasploit_credential_creation
 
   def rfc3330_reserved(ip)
     case ip.class.to_s

--- a/lib/msf/core/db_manager/import_msf_xml.rb
+++ b/lib/msf/core/db_manager/import_msf_xml.rb
@@ -1,5 +1,3 @@
-require 'metasploit/credential/creation'
-
 module Msf
   class DBManager
     # Handles importing of the xml format exported by Pro.  The methods are in a
@@ -8,7 +6,6 @@ module Msf
     # methods defined in a class cannot be overridden by including a module
     # (unless you're running Ruby 2.0 and can use prepend)
     module ImportMsfXml
-      include Metasploit::Credential::Creation
       #
       # CONSTANTS
       #

--- a/lib/msf/core/exploit/cmdstager.rb
+++ b/lib/msf/core/exploit/cmdstager.rb
@@ -2,6 +2,7 @@
 
 require 'rex/exploitation/cmdstager'
 require 'msf/core/exploit/exe'
+require 'msf/base/config'
 
 module Msf
 

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -55,6 +55,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'bcrypt'
   # Needed for some admin modules (scrutinizer_add_user.rb)
   spec.add_runtime_dependency 'json'
+  # Metasploit::Model constant used with and without database gems
+  spec.add_runtime_dependency 'metasploit-model', '~> 0.25.6'
   # Needed for Meterpreter on Windows, soon others.
   spec.add_runtime_dependency 'meterpreter_bins', '0.0.6'
   # Needed by msfgui and other rpc components

--- a/msfconsole
+++ b/msfconsole
@@ -9,146 +9,18 @@
 # $Revision$
 #
 
-msfbase = __FILE__
-while File.symlink?(msfbase)
-  msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))
-end
-
-@msfbase_dir = File.expand_path(File.dirname(msfbase))
-
-$:.unshift(File.expand_path(File.join(File.dirname(msfbase), 'lib')))
-require 'fastlib'
-require 'msfenv'
-
-$:.unshift(ENV['MSF_LOCAL_LIB']) if ENV['MSF_LOCAL_LIB']
-
-require 'optparse'
-
-if(RUBY_PLATFORM =~ /mswin32/)
-  $stderr.puts "[*] The msfconsole interface is not supported on the native Windows Ruby\n"
-  $stderr.puts "    interpreter. Things will break, exploits will fail, payloads will not\n"
-  $stderr.puts "    be handled correctly. Please install Cygwin or use Linux in VMWare.\n\n"
-end
-
-class OptsConsole
-  #
-  # Return a hash describing the options.
-  #
-  def self.parse(args)
-    options = {
-      'DeferModuleLoads' => true
-    }
-
-    opts = OptionParser.new do |opts|
-      opts.banner = "Usage: msfconsole [options]"
-
-      opts.separator ""
-      opts.separator "Specific options:"
-
-      opts.on("-d", "-d", "Execute the console as defanged") do
-        options['Defanged'] = true
-      end
-
-      opts.on("-r", "-r <filename>", "Execute the specified resource file") do |r|
-        options['Resource'] ||= []
-        options['Resource'] << r
-      end
-
-      opts.on("-o", "-o <filename>", "Output to the specified file") do |o|
-        options['LocalOutput'] = o
-      end
-
-      opts.on("-c", "-c <filename>", "Load the specified configuration file") do |c|
-        options['Config'] = c
-      end
-
-      opts.on("-m", "-m <directory>", "Specifies an additional module search path") do |m|
-        options['ModulePath'] = m
-      end
-
-      opts.on("-p", "-p <plugin>", "Load a plugin on startup") do |p|
-        options['Plugins'] ||= []
-        options['Plugins'] << p
-      end
-
-      opts.on("-y", "--yaml <database.yml>", "Specify a YAML file containing database settings") do |m|
-        options['DatabaseYAML'] = m
-      end
-
-      opts.on("-M", "--migration-path <dir>", "Specify a directory containing additional DB migrations") do |m|
-        options['DatabaseMigrationPaths'] ||= []
-        options['DatabaseMigrationPaths'] << m
-      end
-
-      opts.on("-e", "--environment <production|development>", "Specify the database environment to load from the YAML") do |m|
-        options['DatabaseEnv'] = m
-      end
-
-      # Boolean switches
-      opts.on("-v", "--version", "Show version") do |v|
-        options['Version'] = true
-      end
-
-      opts.on("-L", "--real-readline", "Use the system Readline library instead of RbReadline") do |v|
-        options['RealReadline'] = true
-      end
-
-      opts.on("-n", "--no-database", "Disable database support") do |v|
-        options['DisableDatabase'] = true
-      end
-
-      opts.on("-q", "--quiet", "Do not print the banner on start up") do |v|
-        options['DisableBanner'] = true
-      end
-
-      opts.on("-x", "-x <command>", "Execute the specified string as console commands (use ; for multiples)") do |s|
-        options['XCommands'] ||= []
-        options['XCommands'] += s.split(/\s*;\s*/)
-      end
-
-      opts.separator ""
-      opts.separator "Common options:"
-
-      opts.on_tail("-h", "--help", "Show this message") do
-        puts opts
-        exit
-      end
-    end
-
-    begin
-      opts.parse!(args)
-    rescue OptionParser::InvalidOption
-      puts "Invalid option, try -h for usage"
-      exit
-    end
-
-    options
-  end
-end
-
-options = OptsConsole.parse(ARGV)
-
 #
-# NOTE: we don't require this until down here since we may not need it
-# when processing certain options (currently only -h)
-#
-require 'rex'
-require 'msf/ui'
-
-#
-# Everything below this line requires the framework.
+# Standard Library
 #
 
-if (options['Version'])
-  $stderr.puts 'Framework Version: ' + Msf::Framework::Version
-  exit
-end
+require 'pathname'
 
-begin
-  Msf::Ui::Console::Driver.new(
-    Msf::Ui::Console::Driver::DefaultPrompt,
-    Msf::Ui::Console::Driver::DefaultPromptChar,
-    options
-  ).run
-rescue Interrupt
-end
+#
+# Project
+#
+
+# @see https://github.com/rails/rails/blob/v3.2.17/railties/lib/rails/generators/rails/app/templates/script/rails#L3-L5
+require Pathname.new(__FILE__).expand_path.parent.join('config', 'boot')
+require 'metasploit/framework/command/console'
+
+Metasploit::Framework::Command::Console.start

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,12 @@ ENV['RAILS_ENV'] = 'test'
 
 require 'simplecov'
 
+# @note must be before loading config/environment because railtie needs to be loaded before
+#   `Metasploit::Framework::Application.initialize!` is called.
+#
+# Must be explicit as activerecord is optional dependency
+require 'active_record/railtie'
+
 require File.expand_path('../../config/environment', __FILE__)
 
 # Don't `require 'rspec/rails'` as it includes support for pieces of rails that metasploit-framework doesn't use


### PR DESCRIPTION
[MSP-10905](https://jira.tor.rapid7.com/secure/RapidBoard.jspa?rapidView=84&view=detail&selectedIssue=MSP-10905)
# Verification Steps
## Full bundle
- [x] `bundle install --without ''`
### with database
- [x] `./msfconsole`
- [x] VERIFY no boot errors.
- [x] VERIFY prompt is displayed
- [x] `exit`
### without database
- [x] `./msfconsole -n`
- [x] VERIFY no boot errors.
- [x] VERIFY warning that database support is disabled
- [x] VERIFY prompt is displayed
- [x] `exit`
### rake
- [x] `rake -T db`
- [x] VERIFY database tasks from active_record/railtie are defined.
## bundle without db
- [x] `bundle install --without db development pcap test`
### with database
- [x] `./msfconsole`
- [x] VERIFY warning that `Msf::DBManager` cannot create `Metasploit::Credential` 

```
metasploit-credential not in the bundle, so Metasploit::Credential creation will fail for Msf::DBManager
Bundle installed '--without db development test pcap'
To clear the without option do `bundle install --without ''` (the --without flag with an empty string) or `rm -rf .bundle` to remove the .bundle/config manually and then `bundle install`
```
- [ ] VERIFY warning that `Msf::Auxiliary::Rport cannot create`Metasploit::Credential` 

```
metasploit-credential not in the bundle, so Metasploit::Credential creation will fail for Msf::Auxiliary::Report.
Bundle installed '--without db development test pcap'
To clear the without option do `bundle install --without ''` (the --without flag with an empty string) or `rm -rf .bundle` to remove the .bundle/config manually and then `bundle install`
```
- [ ] VERIFY warning that activerecord is not bundled so database support disabled:

```
activerecord not in the bundle, so database support will be disabled.
Bundle installed '--without db development test pcap'
To clear the without option do `bundle install --without ''` (the --without flag with an empty string) or `rm -rf .bundle` to remove the .bundle/config manually and then `bundle install`
```
- [ ] VERIFY  warning that there is no database support: 

```
[-] ***
[-] * WARNING: No database support: RuntimeError Bundle installed '--without db development test pcap'.  To clear the without option do `bundle install --without ''` (the --without flag with an empty string) or `rm -rf .bundle` to remove the .bundle/config manually and then `bundle install`
[-] ***
```
- [x] VERIFY prompt is displayed
- [x] `exit`
### without database
- [ ] `./msfconsole -n`
- [ ] VERIFY warning that `Msf::DBManager` cannot create `Metasploit::Credential` 

```
metasploit-credential not in the bundle, so Metasploit::Credential creation will fail for Msf::DBManager
Bundle installed '--without db development test pcap'
To clear the without option do `bundle install --without ''` (the --without flag with an empty string) or `rm -rf .bundle` to remove the .bundle/config manually and then `bundle install`
```
- [ ] VERIFY warning that `Msf::Auxiliary::Rport cannot create`Metasploit::Credential` 

```
metasploit-credential not in the bundle, so Metasploit::Credential creation will fail for Msf::Auxiliary::Report.
Bundle installed '--without db development test pcap'
To clear the without option do `bundle install --without ''` (the --without flag with an empty string) or `rm -rf .bundle` to remove the .bundle/config manually and then `bundle install`
```
- [ ] VERIFY warning that activerecord is not bundled is NOT shown.
- [x] VERIFY warning that there is no database support contains no error: 

```
[-] ***
[-] * WARNING: Database support has been disabled
[-] ***
```
- [x] VERIFY prompt is displayed
- [ ] `exit`
### rake
- [ ] `rake -T db`
- [ ] VERIFY warning that activerecord is not bundled is shown.
- [ ] VERIFY no tasks are printed
## specs
- [ ] `bundle install --without ''`
- [x] `rake spec`
