### PR TITLE
Fix SpaceBeforeModifierKeyword Rubocop warning

### DIFF
--- a/modules/auxiliary/scanner/http/nginx_source_disclosure.rb
+++ b/modules/auxiliary/scanner/http/nginx_source_disclosure.rb
@@ -89,7 +89,7 @@ class Metasploit3 < Msf::Auxiliary
           save_source.puts(res.body.to_s)
           save_source.close
 
-          print_status("#{target_url} - nginx - File successfully saved: #{path_save}#{uri}")	if (File.exists?("#{path_save}#{uri}"))
+          print_status("#{target_url} - nginx - File successfully saved: #{path_save}#{uri}") if (File.exists?("#{path_save}#{uri}"))
 
         else
           print_error("http://#{vhost}:#{rport} - nginx - Unrecognized #{res.code} response")

--- a/modules/auxiliary/scanner/smtp/smtp_enum.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_enum.rb
@@ -70,11 +70,11 @@ class Metasploit3 < Msf::Auxiliary
 
   def run_host(ip)
     users_found = {}
-    result = nil							# temp for storing result of SMTP request
-    code = 0							# status code parsed from result
-    vrfy = true							# if vrfy allowed
-    expn = true							# if expn allowed
-    rcpt = true							# if rcpt allowed and useful
+    result = nil # temp for storing result of SMTP request
+    code = 0     # status code parsed from result
+    vrfy = true  # if vrfy allowed
+    expn = true  # if expn allowed
+    rcpt = true  # if rcpt allowed and useful
     usernames = extract_words(datastore['USER_FILE'])
 
     cmd = 'HELO' + " " + "localhost" + "\r\n"
@@ -94,20 +94,20 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     domain = result.split()[1]
-    domain = 'localhost' 					if(domain == '' or not domain or domain.downcase == 'hello')
+    domain = 'localhost' if(domain == '' or not domain or domain.downcase == 'hello')
 
 
     vprint_status("#{ip}:#{rport} Domain Name: #{domain}")
 
     result, code = smtp_send("VRFY root\r\n")
     vrfy = (code == 250)
-    users_found = do_enum('VRFY', usernames)		if (vrfy)
+    users_found = do_enum('VRFY', usernames) if (vrfy)
 
     if(users_found.empty?)
     # VRFY failed, lets try EXPN
       result, code = smtp_send("EXPN root\r\n")
       expn = (code == 250)
-      users_found = do_enum('EXPN', usernames)	if(expn)
+      users_found = do_enum('EXPN', usernames) if(expn)
     end
 
     if(users_found.empty?)

--- a/plugins/wmap.rb
+++ b/plugins/wmap.rb
@@ -2,13 +2,9 @@
 # Web assessment for the metasploit framework
 # Efrain Torres    - et[ ] metasploit.com  2012
 #
-# $Id$
-# $Revision$
-#
 
 require 'rabal/tree'
 require 'msf/core/rpc/v10/client'
-#require 'fileutils'
 
 module Msf
 
@@ -931,7 +927,7 @@ class Plugin::Wmap < Msf::Plugin
                     end
                   end
 
-                  datastr = temparr.join("&")	if (temparr and not temparr.empty?)
+                  datastr = temparr.join("&") if (temparr and not temparr.empty?)
 
                   if (utest_query.has_key?(signature(form.path,datastr)) == false)
 
@@ -1070,7 +1066,7 @@ class Plugin::Wmap < Msf::Plugin
                     end
                   end
 
-                  datastr = temparr.join("&")	if (temparr and not temparr.empty?)
+                  datastr = temparr.join("&") if (temparr and not temparr.empty?)
 
                   modopts['METHOD'] = req.method.upcase
                   modopts['PATH'] =  req.path

--- a/scripts/meterpreter/service_permissions_escalate.rb
+++ b/scripts/meterpreter/service_permissions_escalate.rb
@@ -78,8 +78,8 @@ handler.datastore['InitialAutoRunScript'] = "migrate -f"
 handler.datastore['ExitOnSession'] = false
 #start a handler to be ready
 handler.exploit_simple(
-  'Payload'	=> handler.datastore['PAYLOAD'],
-  'RunAsJob'       => true
+  'Payload'  => handler.datastore['PAYLOAD'],
+  'RunAsJob' => true
 )
 
 #attempt to make new service
@@ -132,7 +132,7 @@ service_list.each do |serv|
     moved = false
     configed = false
     #default path, but there should be an ImagePath registry key
-    source = "#{sysdir}\\system32\\#{serv}.exe")
+    source = "#{sysdir}\\system32\\#{serv}.exe"
     #get path to exe; parse out quotes and arguments
     sourceorig = registry_getvaldata("#{serviceskey}\\#{serv}","ImagePath").to_s
     sourcemaybe = client.fs.file.expand_path(sourceorig)


### PR DESCRIPTION
This also deals with some errant tabs where internal spaces should be,
as well as one syntax error which was preventing an old meterpreter
script from ever working correctly.

Some day, we need to get rid of those Meterpeter scripts. Srsly.

This is an experiment as a result of #3587. It's a small test, dealing with only a few issues. This is not blocked by #3587 at all, but if this lands, the `rubocop_todo.yml` should be updated to stop ignoring `SpaceBeforeModifierKeyword`.
