### PR TITLE
Revert PR #3574

### DIFF
--- a/lib/msf/core/module/has_actions.rb
+++ b/lib/msf/core/module/has_actions.rb
@@ -16,23 +16,25 @@ module Msf::Module::HasActions
 
   def action
     sa = datastore['ACTION']
-    sa ? find_action(sa) : find_action(default_action)
+    return find_action(default_action) if not sa
+    return find_action(sa)
   end
 
   def find_action(name)
-    if name
-      actions.each do |a|
-        return a if a.name == name
-      end
+    return nil if not name
+    actions.each do |a|
+      return a if a.name == name
     end
+    return nil
   end
 
   #
   # Returns a boolean indicating whether this module should be run passively
   #
   def passive?
-    act = action
-    act ? passive_action?(act.name) : self.passive
+    act = action()
+    return passive_action?(act.name) if act
+    return self.passive
   end
 
   #


### PR DESCRIPTION
This reverts commit 96945442ffb78370253c8c4f233b6f6dcfd1ca7f.

With this PR, the following now appears in framework.log:

```
[07/30/2014 14:01:37] [e(0)] core: Error updating module details for
auxiliary/fuzzers/http/http_form_field: NoMethodError undefined method
`name' for []:Array
```

Without this PR, Framework.log is silent.
