### PR TITLE
Fix post/test/* modules' loadpath

### DIFF
--- a/test/modules/post/test/extapi.rb
+++ b/test/modules/post/test/extapi.rb
@@ -2,7 +2,8 @@
 require 'msf/core'
 require 'rex'
 
-$:.push "test/lib" unless $:.include? "test/lib"
+lib = File.join(Msf::Config.install_root, "test", "lib")
+$:.push(lib) unless $:.include?(lib)
 require 'module_test'
 
 class Metasploit4 < Msf::Post

--- a/test/modules/post/test/file.rb
+++ b/test/modules/post/test/file.rb
@@ -1,5 +1,7 @@
+require 'msf/core'
 
-$:.push "test/lib" unless $:.include? "test/lib"
+lib = File.join(Msf::Config.install_root, "test", "lib")
+$:.push(lib) unless $:.include?(lib)
 require 'module_test'
 
 #load 'test/lib/module_test.rb'

--- a/test/modules/post/test/get_env.rb
+++ b/test/modules/post/test/get_env.rb
@@ -1,5 +1,6 @@
+require 'msf/core'
 
-$:.push "test/lib" unless $:.include? "test/lib"
+lib = File.join(Msf::Config.install_root, "test", "lib")
 require 'module_test'
 
 #load 'test/lib/module_test.rb'

--- a/test/modules/post/test/meterpreter.rb
+++ b/test/modules/post/test/meterpreter.rb
@@ -2,7 +2,8 @@
 require 'msf/core'
 require 'rex'
 
-$:.push "test/lib" unless $:.include? "test/lib"
+lib = File.join(Msf::Config.install_root, "test", "lib")
+$:.push(lib) unless $:.include?(lib)
 require 'module_test'
 
 class Metasploit4 < Msf::Post

--- a/test/modules/post/test/railgun_reverse_lookups.rb
+++ b/test/modules/post/test/railgun_reverse_lookups.rb
@@ -1,16 +1,15 @@
 
 ##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# Framework web site for more information on licensing and terms of use.
-# http://metasploit.com/framework/
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/railgun'
 
-$:.push "test/lib" unless $:.include? "test/lib"
+lib = File.join(Msf::Config.install_root, "test", "lib")
+$:.push(lib) unless $:.include?(lib)
 require 'module_test'
 
 class Metasploit3 < Msf::Post

--- a/test/modules/post/test/registry.rb
+++ b/test/modules/post/test/registry.rb
@@ -1,16 +1,15 @@
 
 ##
-# This file is part of the Metasploit Framework and may be subject to
-# redistribution and commercial restrictions. Please see the Metasploit
-# Framework web site for more information on licensing and terms of use.
-# http://metasploit.com/framework/
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
 ##
 
 require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/registry'
 
-$:.push "test/lib" unless $:.include? "test/lib"
+lib = File.join(Msf::Config.install_root, "test", "lib")
+$:.push(lib) unless $:.include?(lib)
 require 'module_test'
 
 class Metasploit3 < Msf::Post

--- a/test/modules/post/test/services.rb
+++ b/test/modules/post/test/services.rb
@@ -6,7 +6,8 @@ require 'msf/core'
 require 'rex'
 require 'msf/core/post/windows/services'
 
-$:.push "test/lib" unless $:.include? "test/lib"
+lib = File.join(Msf::Config.install_root, "test", "lib")
+$:.push(lib) unless $:.include?(lib)
 require 'module_test'
 
 class Metasploit3 < Msf::Post

--- a/test/modules/post/test/unix.rb
+++ b/test/modules/post/test/unix.rb
@@ -1,5 +1,7 @@
+require 'msf/core'
 
-$:.push "test/lib" unless $:.include? "test/lib"
+lib = File.join(Msf::Config.install_root, "test", "lib")
+$:.push(lib) unless $:.include?(lib)
 require 'module_test'
 
 #load 'test/lib/module_test.rb'


### PR DESCRIPTION
Allows loading when pwd is not framework's install root
### Verification
- [x] `msfconsole`
- [x] `cd /tmp/`
- [x] `loadpath /path/to/metasploit-framework/test/modules`
- [x] `use post/test/file`
- [x] **VERIFY** nothing exploded 
