### PR TITLE
.to_credential now assigns a parent

### DIFF
--- a/app/concerns/metasploit/credential/core/to_credential.rb
+++ b/app/concerns/metasploit/credential/core/to_credential.rb
@@ -13,7 +13,8 @@ module Metasploit::Credential::Core::ToCredential
         private:      private.try(:data), 
         private_type: private.try(:type).try(:demodulize).try(:underscore).try(:to_sym), 
         realm:        realm.try(:value), 
-        realm_key:    realm.try(:key) 
+        realm_key:    realm.try(:key),
+        parent:       self
       )
     end
     

--- a/lib/metasploit/framework/credential.rb
+++ b/lib/metasploit/framework/credential.rb
@@ -87,7 +87,8 @@ module Metasploit
       end
 
       def to_credential
-        self
+        self.parent = self
+        self        
       end
 
       private

--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -83,7 +83,6 @@ module Metasploit
               # This could be a Credential object, or a Credential Core, or an Attempt object
               # so make sure that whatever it is, we end up with a Credential.
               credential = raw_cred.to_credential
-              credential.parent = raw_cred
 
               if credential.realm.present? && self.class::REALM_KEY.present?
                 credential.realm_key = self.class::REALM_KEY

--- a/spec/support/shared/examples/credential/core/to_credential.rb
+++ b/spec/support/shared/examples/credential/core/to_credential.rb
@@ -16,6 +16,11 @@ shared_examples_for 'Metasploit::Credential::Core::ToCredential' do
         ).to be_a Metasploit::Framework::Credential
       end
       
+      it "should set the parent to the credential object" do
+        expect(
+          crednetial_core.to_credential.parent
+        ).to eq(crednetial_core)
+      end
     end
   end
 end


### PR DESCRIPTION
## Validation steps
- [ ] launch msfconsole
- [ ] enter irb
- [ ] `core = Metasploit::Credential::Core.last`
- [ ] `cred = core.to_credential`
- [ ] `cred.parent == core` this should be true
- [ ] `cred = Metasploit::Framework::Credential.new(public: 'username', private: 'password')`
- [ ] `cred.parent.nil?` should be true
- [ ] `new_cred = cred.to_credential`
- [ ] `new_cred.parent == cred`
  since we are returning the same object instead of duplicating it and returning a new one
- [ ] `cred.parent == cred`
