### PR TITLE
GPP Junk Padding Fix

### DIFF
--- a/spec/lib/rex/parser/group_policy_preferences_spec.rb
+++ b/spec/lib/rex/parser/group_policy_preferences_spec.rb
@@ -88,25 +88,25 @@ cpassword_normal = "j1Uyj3Vx8TY9LtLZil2uAuZkFQA/4latT76ZwgdHdhw"
 cpassword_bad = "blah"
 
 describe Rex::Parser::GPP do
-	GPP = Rex::Parser::GPP
-	
-	##
-	# Decrypt
-	##
-	it "Decrypt returns Local*P4ssword! for normal cpassword" do
-		result = GPP.decrypt(cpassword_normal) 
-		result.should eq("Local*P4ssword!")
-	end
+  GPP = Rex::Parser::GPP
+  
+  ##
+  # Decrypt
+  ##
+  it "Decrypt returns Local*P4ssword! for normal cpassword" do
+    result = GPP.decrypt(cpassword_normal) 
+    result.should eq("Local*P4ssword!")
+  end
 
-	it "Decrypt returns blank for bad cpassword" do
-		result = GPP.decrypt(cpassword_bad)
-		result.should eq("")
-	end
-	
-	it "Decrypt returns blank for nil cpassword" do
-		result = GPP.decrypt(nil)
-		result.should eq("")
-	end
+  it "Decrypt returns blank for bad cpassword" do
+    result = GPP.decrypt(cpassword_bad)
+    result.should eq("")
+  end
+  
+  it "Decrypt returns blank for nil cpassword" do
+    result = GPP.decrypt(nil)
+    result.should eq("")
+  end
 
   it 'Decrypts a cpassword containing junk padding' do
     cpassword_win2k8.each do |encrypted, expected|
@@ -115,51 +115,51 @@ describe Rex::Parser::GPP do
     end
   end
 
-	##
-	# Parse
-	##
+  ##
+  # Parse
+  ##
 
-	it "Parse returns empty [] for nil" do
-		GPP.parse(nil).should be_empty
-	end
+  it "Parse returns empty [] for nil" do
+    GPP.parse(nil).should be_empty
+  end
 
-	it "Parse returns results for xml_ms and password is empty" do
-		results = GPP.parse(xml_ms)
-		results.should_not be_empty
-		results[0][:PASS].should be_empty
-	end
+  it "Parse returns results for xml_ms and password is empty" do
+    results = GPP.parse(xml_ms)
+    results.should_not be_empty
+    results[0][:PASS].should be_empty
+  end
 
-	it "Parse returns results for xml_datasrc, and attributes, and password is test1" do
-		results = GPP.parse(xml_datasrc)
-		results.should_not be_empty
-		results[0].include?(:ATTRIBUTES).should be_true
-		results[0][:ATTRIBUTES].should_not be_empty
-		results[0][:PASS].should eq("test")
-	end
+  it "Parse returns results for xml_datasrc, and attributes, and password is test1" do
+    results = GPP.parse(xml_datasrc)
+    results.should_not be_empty
+    results[0].include?(:ATTRIBUTES).should be_true
+    results[0][:ATTRIBUTES].should_not be_empty
+    results[0][:PASS].should eq("test")
+  end
 
-	xmls = []
-	xmls << xml_group
-	xmls << xml_drive
-	xmls << xml_schd
-	xmls << xml_serv
-	xmls << xml_datasrc
+  xmls = []
+  xmls << xml_group
+  xmls << xml_drive
+  xmls << xml_schd
+  xmls << xml_serv
+  xmls << xml_datasrc
 
-	it "Parse returns results for all good xmls and passwords" do
-		xmls.each do |xml|
-			results = GPP.parse(xml)
-			results.should_not be_empty
-			results[0][:PASS].should_not be_empty
-		end
-	end
+  it "Parse returns results for all good xmls and passwords" do
+    xmls.each do |xml|
+      results = GPP.parse(xml)
+      results.should_not be_empty
+      results[0][:PASS].should_not be_empty
+    end
+  end
 
-	##
-	# Create_Tables
-	##
-	it "Create_tables returns tables for all good xmls" do
-		xmls.each do |xml|
-			results = GPP.parse(xml)
-			tables = GPP.create_tables(results, "test")
-			tables.should_not be_empty
-		end
-	end
+  ##
+  # Create_Tables
+  ##
+  it "Create_tables returns tables for all good xmls" do
+    xmls.each do |xml|
+      results = GPP.parse(xml)
+      tables = GPP.create_tables(results, "test")
+      tables.should_not be_empty
+    end
+  end
 end

--- a/spec/lib/rex/parser/group_policy_preferences_spec.rb
+++ b/spec/lib/rex/parser/group_policy_preferences_spec.rb
@@ -77,7 +77,13 @@ xml_ms = '
 </Groups>
 '
 
-cpassword_utf7 = 'EqWFlA4kn2T6PHvGi09M7seHuqCYK/slkJWIl7mK+wFSuDccBEp/4l5EuKnwF0WS•ªH~AA'
+# Win2k8 appears to append some junk padding in some cases
+cpassword_win2k8 = []
+# Win2k8R2 -          EqWFlA4kn2T6PHvGi09M7seHuqCYK/slkJWIl7mK+wEMON8tIIslS6707RU1F7Bh
+cpassword_win2k8 << ['EqWFlA4kn2T6PHvGi09M7seHuqCYK/slkJWIl7mK+wEMON8tIIslS6707RU1F7BhTµkp', 'N3v3rGunnaG!veYo']
+cpassword_win2k8 << ['EqWFlA4kn2T6PHvGi09M7seHuqCYK/slkJWIl7mK+wGSwOI7Be//GJdxd5YYXUQHTµkp', 'N3v3rGunnaG!veYou']
+# Win2k8R2 -          EqWFlA4kn2T6PHvGi09M7seHuqCYK/slkJWIl7mK+wFSuDccBEp/4l5EuKnwF0WS
+cpassword_win2k8 << ['EqWFlA4kn2T6PHvGi09M7seHuqCYK/slkJWIl7mK+wFSuDccBEp/4l5EuKnwF0WS»YÂVAA', 'N3v3rGunnaG!veYouUp']
 cpassword_normal = "j1Uyj3Vx8TY9LtLZil2uAuZkFQA/4latT76ZwgdHdhw"
 cpassword_bad = "blah"
 
@@ -102,9 +108,11 @@ describe Rex::Parser::GPP do
 		result.should eq("")
 	end
 
-  it 'Decrypts a cpassword containing UTF7' do
-    result = GPP.decrypt(cpassword_utf7)
-    result.should eq('N3v3rGunnaG!veYouUp')
+  it 'Decrypts a cpassword containing junk padding' do
+    cpassword_win2k8.each do |encrypted, expected|
+      result = GPP.decrypt(encrypted)
+      result.should eq(expected)
+    end
   end
 
 	##

--- a/spec/lib/rex/parser/group_policy_preferences_spec.rb
+++ b/spec/lib/rex/parser/group_policy_preferences_spec.rb
@@ -1,3 +1,4 @@
+# encoding: binary
 require 'rex/parser/group_policy_preferences'
 
 xml_group = '
@@ -76,6 +77,7 @@ xml_ms = '
 </Groups>
 '
 
+cpassword_utf7 = 'EqWFlA4kn2T6PHvGi09M7seHuqCYK/slkJWIl7mK+wFSuDccBEp/4l5EuKnwF0WS•ªH~AA'
 cpassword_normal = "j1Uyj3Vx8TY9LtLZil2uAuZkFQA/4latT76ZwgdHdhw"
 cpassword_bad = "blah"
 
@@ -85,7 +87,7 @@ describe Rex::Parser::GPP do
 	##
 	# Decrypt
 	##
-	it "Decrypt returns Local*P4ssword! for normal cpassword" do 
+	it "Decrypt returns Local*P4ssword! for normal cpassword" do
 		result = GPP.decrypt(cpassword_normal) 
 		result.should eq("Local*P4ssword!")
 	end
@@ -95,10 +97,15 @@ describe Rex::Parser::GPP do
 		result.should eq("")
 	end
 	
-	it "Decrypt returns blank for nil cpassword" do 
+	it "Decrypt returns blank for nil cpassword" do
 		result = GPP.decrypt(nil)
 		result.should eq("")
 	end
+
+  it 'Decrypts a cpassword containing UTF7' do
+    result = GPP.decrypt(cpassword_utf7)
+    result.should eq('N3v3rGunnaG!veYouUp')
+  end
 
 	##
 	# Parse


### PR DESCRIPTION
So I came across a GPP password in Win2k8 test environment that appended Junk padding to the string. This may be what @carnal0wnage came across in http://carnal0wnage.attackresearch.com/2012/10/group-policy-preferences-and-getting.html

I tried to work out what was going on but it appears that the additional characters are junk and should be stripped. These characters did not occur on my Win2k8R2 machine. 

I have updated spec and the decryption code to be more robust when this occurs. I don't know the maximum amount of junk padding that could be appended but saw up to 6 chars in my testing. 
