### PR TITLE
Remove Msf::Framework::VersionAPI and Msf::Framework::VersionCore

### DIFF
--- a/lib/metasploit/framework/api.rb
+++ b/lib/metasploit/framework/api.rb
@@ -1,0 +1,7 @@
+module Metasploit
+  module Framework
+    module API
+
+    end
+  end
+end

--- a/lib/metasploit/framework/api/version.rb
+++ b/lib/metasploit/framework/api/version.rb
@@ -1,0 +1,16 @@
+module Metasploit
+  module Framework
+    module API
+      # @note This is a like.  The API version is not semantically version and it's version has actually never changed
+      #    even though API changes have occured.  DO NOT base compatibility on this version.
+      module Version
+        MAJOR = 1
+        MINOR = 0
+        PATCH = 0
+      end
+
+      VERSION = "#{Version::MAJOR}.#{Version::MINOR}.#{Version::PATCH}"
+      GEM_VERSION = Gem::Version.new(VERSION)
+    end
+  end
+end

--- a/lib/metasploit/framework/core.rb
+++ b/lib/metasploit/framework/core.rb
@@ -1,0 +1,7 @@
+module Metasploit
+  module Framework
+    module Core
+
+    end
+  end
+end

--- a/lib/metasploit/framework/core/version.rb
+++ b/lib/metasploit/framework/core/version.rb
@@ -1,0 +1,19 @@
+require 'metasploit/framework/version'
+
+module Metasploit
+  module Framework
+    # @note This is a lie.  The core libraries are not semantically versioned.  This is currently just linked to the
+    #   Metasploit::Framework::Version, which is also not semantically versioned.
+    module Core
+      module Version
+        MAJOR = Metasploit::Framework::Version::MAJOR
+        MINOR = Metasploit::Framework::Version::MINOR
+        PATCH = Metasploit::Framework::Version::PATCH
+        PRERELEASE = Metasploit::Framework::Version::PRERELEASE
+      end
+
+      VERSION = Metasploit::Framework::VERSION
+      GEM_VERSION = Gem::Version.new(Metasploit::Framework::GEM_VERSION)
+    end
+  end
+end

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -46,8 +46,7 @@ class Framework
   APIMajor = 1
   APIMinor = 0
 
-  # Base/API Version
-  VersionCore  = Major + (Minor / 10.0)
+  # API Version
   VersionAPI   = APIMajor + (APIMinor / 10.0)
 
   #

--- a/lib/msf/core/framework.rb
+++ b/lib/msf/core/framework.rb
@@ -42,13 +42,6 @@ class Framework
   # EICAR canary
   EICARCorrupted      = ::Msf::Util::EXE.is_eicar_corrupted?
 
-  # API Version
-  APIMajor = 1
-  APIMinor = 0
-
-  # API Version
-  VersionAPI   = APIMajor + (APIMinor / 10.0)
-
   #
   # Mixin meant to be included into all classes that can have instances that
   # should be tied to the framework, such as modules.

--- a/lib/msf/core/modules/namespace.rb
+++ b/lib/msf/core/modules/namespace.rb
@@ -57,10 +57,10 @@ module Msf::Modules::Namespace
     if const_defined?(:RequiredVersions)
       required_versions = const_get(:RequiredVersions)
       minimum_core_version = Gem::Version.new(required_versions[0].to_s)
-      minimum_api_version = required_versions[1]
+      minimum_api_version = Gem::Version.new(required_versions[1].to_s)
 
-      if (minimum_core_version > Metasploit::Framework::Core::GEM_VERSION or
-          minimum_api_version > ::Msf::Framework::VersionAPI)
+      if (minimum_core_version > Metasploit::Framework::Core::GEM_VERSION ||
+          minimum_api_version > Metasploit::Framework::API::GEM_VERSION)
         raise Msf::Modules::VersionCompatibilityError.new(
                   :module_path => module_path,
                   :module_reference_name => module_reference_name,

--- a/lib/msf/core/modules/namespace.rb
+++ b/lib/msf/core/modules/namespace.rb
@@ -1,3 +1,5 @@
+require 'metasploit/framework/core/version'
+
 # Concern for behavior that all namespace modules that wrap Msf::Modules must support like version checking and
 # grabbing the version specific-Metasploit* class.
 module Msf::Modules::Namespace
@@ -54,10 +56,10 @@ module Msf::Modules::Namespace
   def version_compatible!(module_path, module_reference_name)
     if const_defined?(:RequiredVersions)
       required_versions = const_get(:RequiredVersions)
-      minimum_core_version = required_versions[0]
+      minimum_core_version = Gem::Version.new(required_versions[0].to_s)
       minimum_api_version = required_versions[1]
 
-      if (minimum_core_version > ::Msf::Framework::VersionCore or
+      if (minimum_core_version > Metasploit::Framework::Core::GEM_VERSION or
           minimum_api_version > ::Msf::Framework::VersionAPI)
         raise Msf::Modules::VersionCompatibilityError.new(
                   :module_path => module_path,

--- a/lib/msf/core/modules/namespace.rb
+++ b/lib/msf/core/modules/namespace.rb
@@ -1,3 +1,4 @@
+require 'metasploit/framework/api/version'
 require 'metasploit/framework/core/version'
 
 # Concern for behavior that all namespace modules that wrap Msf::Modules must support like version checking and

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -408,7 +408,7 @@ class Core
     avdwarn = nil
 
     banner_trailers = {
-      :version     => "%yelmetasploit v#{Msf::Framework::Version} [core:#{Msf::Framework::VersionCore} api:#{Msf::Framework::VersionAPI}]%clr",
+      :version     => "%yelmetasploit v#{Msf::Framework::Version} [core:#{Metasploit::Framework::Core::GEM_VERSION} api:#{Msf::Framework::VersionAPI}]%clr",
       :exp_aux_pos => "#{framework.stats.num_exploits} exploits - #{framework.stats.num_auxiliary} auxiliary - #{framework.stats.num_post} post",
       :pay_enc_nop => "#{framework.stats.num_payloads} payloads - #{framework.stats.num_encoders} encoders - #{framework.stats.num_nops} nops",
       :free_trial  => "Free Metasploit Pro trial: http://r-7.co/trymsp",

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -408,7 +408,7 @@ class Core
     avdwarn = nil
 
     banner_trailers = {
-      :version     => "%yelmetasploit v#{Msf::Framework::Version} [core:#{Metasploit::Framework::Core::GEM_VERSION} api:#{Msf::Framework::VersionAPI}]%clr",
+      :version     => "%yelmetasploit v#{Msf::Framework::Version} [core:#{Metasploit::Framework::Core::GEM_VERSION} api:#{Metasploit::Framework::API::GEM_VERSION}]%clr",
       :exp_aux_pos => "#{framework.stats.num_exploits} exploits - #{framework.stats.num_auxiliary} auxiliary - #{framework.stats.num_post} post",
       :pay_enc_nop => "#{framework.stats.num_payloads} payloads - #{framework.stats.num_encoders} encoders - #{framework.stats.num_nops} nops",
       :free_trial  => "Free Metasploit Pro trial: http://r-7.co/trymsp",

--- a/spec/lib/msf/core/modules/namespace_spec.rb
+++ b/spec/lib/msf/core/modules/namespace_spec.rb
@@ -218,8 +218,8 @@ describe Msf::Modules::Namespace do
             2
           end
 
-          it 'should be > Msf::Framework::VersionAPI' do
-            minimum_api_version.should > Msf::Framework::VersionAPI
+          it 'should be > Metasploit::Framework::API::GEM_VERSION' do
+            minimum_api_version.should > Metasploit::Framework::API::GEM_VERSION
           end
 
           it_should_behave_like 'Msf::Modules::VersionCompatibilityError'
@@ -248,16 +248,16 @@ describe Msf::Modules::Namespace do
             2
           end
 
-          it 'should be > Msf::Framework::VersionAPI' do
-            minimum_api_version.should > Msf::Framework::VersionAPI
+          it 'should be > Metasploit::Framework::API::GEM_VERSION' do
+            minimum_api_version.should > Metasploit::Framework::API::GEM_VERSION
           end
 
           it_should_behave_like 'Msf::Modules::VersionCompatibilityError'
         end
 
         context 'with minimum API version' do
-          it 'should be <= Msf::Framework::VersionAPI' do
-            minimum_api_version <= Msf::Framework::VersionAPI
+          it 'should be <= Metasploit::Framework::API::GEM_VERSION' do
+            minimum_api_version <= Metasploit::Framework::API::GEM_VERSION
           end
 
           it_should_behave_like 'Msf::Modules::VersionCompatibilityError'

--- a/spec/lib/msf/core/modules/namespace_spec.rb
+++ b/spec/lib/msf/core/modules/namespace_spec.rb
@@ -209,8 +209,8 @@ describe Msf::Modules::Namespace do
       end
 
       context 'with minimum Core version' do
-        it 'should be <= Msf::Framework::VersionCore' do
-          minimum_core_version.should <= Msf::Framework::VersionCore
+        it 'should be <= Metasploit::Framework::Core::GEM_VERSION' do
+          minimum_core_version.should <= Metasploit::Framework::Core::GEM_VERSION
         end
 
         context 'without minimum API version' do
@@ -239,8 +239,8 @@ describe Msf::Modules::Namespace do
           5
         end
 
-        it 'should be > Msf::Framework::VersionCore' do
-          minimum_core_version.should > Msf::Framework::VersionCore
+        it 'should be > Metasploit::Framework::Core::GEM_VERSION' do
+          minimum_core_version.should > Metasploit::Framework::Core::GEM_VERSION
         end
 
         context 'without minimum API version' do

--- a/spec/lib/msf/core/modules/namespace_spec.rb
+++ b/spec/lib/msf/core/modules/namespace_spec.rb
@@ -209,8 +209,8 @@ describe Msf::Modules::Namespace do
       end
 
       context 'with minimum Core version' do
-        it 'should be <= Metasploit::Framework::Core::GEM_VERSION' do
-          minimum_core_version.should <= Metasploit::Framework::Core::GEM_VERSION
+        it 'is <= Metasploit::Framework::Core::GEM_VERSION when converted to Gem::Version' do
+          expect(Gem::Version.new(minimum_core_version.to_s)).to be <= Metasploit::Framework::Core::GEM_VERSION
         end
 
         context 'without minimum API version' do
@@ -218,8 +218,8 @@ describe Msf::Modules::Namespace do
             2
           end
 
-          it 'should be > Metasploit::Framework::API::GEM_VERSION' do
-            minimum_api_version.should > Metasploit::Framework::API::GEM_VERSION
+          it 'is > Metasploit::Framework::API::GEM_VERSION when converted to Gem::Version' do
+            expect(Gem::Version.new(minimum_api_version.to_s)).to be > Metasploit::Framework::API::GEM_VERSION
           end
 
           it_should_behave_like 'Msf::Modules::VersionCompatibilityError'
@@ -239,8 +239,8 @@ describe Msf::Modules::Namespace do
           5
         end
 
-        it 'should be > Metasploit::Framework::Core::GEM_VERSION' do
-          minimum_core_version.should > Metasploit::Framework::Core::GEM_VERSION
+        it 'is > Metasploit::Framework::Core::GEM_VERSION when converted to Gem::Version' do
+          expect(Gem::Version.new(minimum_core_version.to_s)).to be > Metasploit::Framework::Core::GEM_VERSION
         end
 
         context 'without minimum API version' do
@@ -248,16 +248,16 @@ describe Msf::Modules::Namespace do
             2
           end
 
-          it 'should be > Metasploit::Framework::API::GEM_VERSION' do
-            minimum_api_version.should > Metasploit::Framework::API::GEM_VERSION
+          it 'is > Metasploit::Framework::API::GEM_VERSION when converted to Gem::Version' do
+            expect(Gem::Version.new(minimum_api_version.to_s)).to be > Metasploit::Framework::API::GEM_VERSION
           end
 
           it_should_behave_like 'Msf::Modules::VersionCompatibilityError'
         end
 
         context 'with minimum API version' do
-          it 'should be <= Metasploit::Framework::API::GEM_VERSION' do
-            minimum_api_version <= Metasploit::Framework::API::GEM_VERSION
+          it 'is <= Metasploit::Framework::API::GEM_VERSION when converted to Gem::Version' do
+            expect(Gem::Version.new(minimum_api_version.to_s)).to be <= Metasploit::Framework::API::GEM_VERSION
           end
 
           it_should_behave_like 'Msf::Modules::VersionCompatibilityError'


### PR DESCRIPTION
[MSP-10998](https://jira.tor.rapid7.com/secure/RapidBoard.jspa?rapidView=84&view=detail&selectedIssue=MSP-10998)

Remove `Msf::Framework::VersionAPI` and `Msf::Framework::VersionCore` because they can't handle minor version being 10 or higher, which means `Msf::Framework::VersionCore` is incompatible with `4.10.0`.
