### PR TITLE
Unique indices and validations that include realm_id

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :db do
   # Needed for Msf::DbManager
   gem 'activerecord', '>= 3.0.0', '< 4.0.0'
   # Metasploit::Credential database models
-  gem 'metasploit-credential', '~>0.8.2'
+  gem 'metasploit-credential', '>= 0.8.5.pre.realm.pre.uniqueness', '< 0.9'
   # Database models shared between framework and Pro.
   gem 'metasploit_data_models', '~> 0.19'
   # Needed for module caching in Mdm::ModuleDetails

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :db do
   # Needed for Msf::DbManager
   gem 'activerecord', '>= 3.0.0', '< 4.0.0'
   # Metasploit::Credential database models
-  gem 'metasploit-credential', '>= 0.8.5.pre.realm.pre.uniqueness', '< 0.9'
+  gem 'metasploit-credential', '>= 0.8.6.pre.realm.pre.uniqueness', '< 0.9'
   # Database models shared between framework and Pro.
   gem 'metasploit_data_models', '~> 0.19'
   # Needed for module caching in Mdm::ModuleDetails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
     json (1.8.1)
     metasploit-concern (0.1.1)
       activesupport (~> 3.0, >= 3.0.0)
-    metasploit-credential (0.8.5.pre.realm.pre.uniqueness)
+    metasploit-credential (0.8.6.pre.realm.pre.uniqueness)
       metasploit-concern (~> 0.1.0)
       metasploit-model (~> 0.26.1)
       metasploit_data_models (~> 0.19.4)
@@ -160,7 +160,7 @@ DEPENDENCIES
   factory_girl (>= 4.1.0)
   factory_girl_rails
   fivemat (= 1.2.1)
-  metasploit-credential (>= 0.8.5.pre.realm.pre.uniqueness, < 0.9)
+  metasploit-credential (>= 0.8.6.pre.realm.pre.uniqueness, < 0.9)
   metasploit-framework!
   metasploit_data_models (~> 0.19)
   network_interface (~> 0.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
     json (1.8.1)
     metasploit-concern (0.1.1)
       activesupport (~> 3.0, >= 3.0.0)
-    metasploit-credential (0.8.3)
+    metasploit-credential (0.8.5.pre.realm.pre.uniqueness)
       metasploit-concern (~> 0.1.0)
       metasploit-model (~> 0.26.1)
       metasploit_data_models (~> 0.19.4)
@@ -160,7 +160,7 @@ DEPENDENCIES
   factory_girl (>= 4.1.0)
   factory_girl_rails
   fivemat (= 1.2.1)
-  metasploit-credential (~> 0.8.2)
+  metasploit-credential (>= 0.8.5.pre.realm.pre.uniqueness, < 0.9)
   metasploit-framework!
   metasploit_data_models (~> 0.19)
   network_interface (~> 0.0.1)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140722174919) do
+ActiveRecord::Schema.define(:version => 20140801150537) do
 
   create_table "api_keys", :force => true do |t|
     t.text     "token"
@@ -193,6 +193,12 @@ ActiveRecord::Schema.define(:version => 20140722174919) do
   add_index "metasploit_credential_cores", ["private_id"], :name => "index_metasploit_credential_cores_on_private_id"
   add_index "metasploit_credential_cores", ["public_id"], :name => "index_metasploit_credential_cores_on_public_id"
   add_index "metasploit_credential_cores", ["realm_id"], :name => "index_metasploit_credential_cores_on_realm_id"
+  add_index "metasploit_credential_cores", ["workspace_id", "private_id"], :name => "unique_private_metasploit_credential_cores", :unique => true
+  add_index "metasploit_credential_cores", ["workspace_id", "public_id", "private_id"], :name => "unique_realmless_metasploit_credential_cores", :unique => true
+  add_index "metasploit_credential_cores", ["workspace_id", "public_id"], :name => "unique_public_metasploit_credential_cores", :unique => true
+  add_index "metasploit_credential_cores", ["workspace_id", "realm_id", "private_id"], :name => "unique_publicless_metasploit_credential_cores", :unique => true
+  add_index "metasploit_credential_cores", ["workspace_id", "realm_id", "public_id", "private_id"], :name => "unique_complete_metasploit_credential_cores", :unique => true
+  add_index "metasploit_credential_cores", ["workspace_id", "realm_id", "public_id"], :name => "unique_privateless_metasploit_credential_cores", :unique => true
   add_index "metasploit_credential_cores", ["workspace_id"], :name => "index_metasploit_credential_cores_on_workspace_id"
 
   create_table "metasploit_credential_logins", :force => true do |t|


### PR DESCRIPTION
[MSP-10963](https://jira.tor.rapid7.com/secure/RapidBoard.jspa?rapidView=84&view=detail&selectedIssue=MSP-10963)
# Pre-verification steps
- [x] Release https://github.com/rapid7/metasploit-credential/pull/69
- [x] Update `Gemfile` and `Gemfile.lock` to released metasploit-credential
# Verification Steps
## msfconsole
- [x] `./msfconsole --environment development`
- [x] `irb`
- [x] `Metasploit::Credential::Core.destroy_all`
- [x] `exit`
- [x] `creds add-password user password realm`
- [x] VERIFY `creds` shows added password: 

``` msfconsole
Credentials
===========

host  service  public  private   realm  private_type
----  -------  ------  -------   -----  ------------
               user    password  realm  Password
```
- [x] `creds add-password user password`
- [x] VERIFY `creds` shows credential with and without realm: 

``` msfconsole
Credentials
===========

host  service  public  private   realm  private_type
----  -------  ------  -------   -----  ------------
               user    password         Password
               user    password  realm  Password
```
## specs
- [x] `rake spec`
- [ ] VERIFY no failures
