### PR TITLE
Hide icon flash on taskbar during cmd_psh_payload

### DIFF
--- a/lib/msf/core/exploit/powershell.rb
+++ b/lib/msf/core/exploit/powershell.rb
@@ -359,7 +359,7 @@ EOS
     if opts[:remove_comspec]
       command = psh_command
     else
-      command = "%COMSPEC% /b /c start /min #{psh_command}"
+      command = "%COMSPEC% /b /c start /b /min #{psh_command}"
     end
 
     vprint_status("Powershell command length: #{command.length}")


### PR DESCRIPTION
When 'cmd_psh_payload' is run via 'cmd_exec' on a windows shell that is running in the context of an interactive user an icon will flash very quickly on the user's task bar.  This can be avoided (verified) by adding the /b switch to the start section of the command launcher text.  I have verified that this switch exists from Windows 2000 through Windows 2012 R2.
