### PR TITLE
require 'action_view/railtie' for pro compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     metasploit-framework (4.10.0.pre.dev)
+      actionpack (< 4.0.0)
       activesupport (>= 3.0.0, < 4.0.0)
       bcrypt
       json

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,13 @@ Bundler.require(
 )
 
 #
+# Railties
+#
+
+# For compatibility with jquery-rails (and other engines that need action_view) in pro
+require 'action_view/railtie'
+
+#
 # Project
 #
 

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -51,6 +51,8 @@ Gem::Specification.new do |spec|
 
   # Need 3+ for ActiveSupport::Concern
   spec.add_runtime_dependency 'activesupport', '>= 3.0.0', rails_version_constraint
+  # Needed for config.action_view for view plugin compatibility for Pro
+  spec.add_runtime_dependency 'actionpack', rails_version_constraint
   # Needed for some admin modules (cfme_manageiq_evm_pass_reset.rb)
   spec.add_runtime_dependency 'bcrypt'
   # Needed for some admin modules (scrutinizer_add_user.rb)


### PR DESCRIPTION
[MSP-10848](https://jira.tor.rapid7.com/secure/RapidBoard.jspa?rapidView=84&view=detail&selectedIssue=MSP-10848)

Other railties, like jquery-rails, need 'action_view/railtie', but don't
require it themselves, so require it explicitly in
`config/application.rb` to prevent msfconsole boot errors.
# Verification Steps
## msfconsole
### With pro's gems
- [x] `rvm use ruby-1.9.3@metasploit-pro` (or w/e you call your pro gemset)
- [x] `export BUNDLE_GEMFILE=${pro}/GEMFILE` (`${pro}` is the path to your pro repository)
- [x] `msfconsole`
- [x] VERIFY boot without backtraces
- [x] `irb`
- [x] VERIFY `Rails.application.config.action_view` is defined
- [x] VERIFY jquery-rails was loaded `$LOADED_FEATURES.select { |p| p.ends_with? 'jquery/rails/railtie.rb' }`
- [x] `exit`
- [x] `exit`
- [x] `unset BUNDLE_GEMFILE`
### With framework's gems
- [x] `rvm use ruby-1.9.3@metasploit-framework`
- [x] `msfconsole`
- [x] VERIFY boot without backtraces
- [x] `irb`
- [x] VERIFY `Rails.application.config.action_view` is defined
- [x] VERIFY jquery-rails was not loaded `$LOADED_FEATURES.select { |p| p.ends_with? 'jquery/rails/railtie.rb' }.empty?`
- [x] `exit`
- [x] `exit`
## Specs
- [x] `rake spec`
- [x] VERIFY no failures
# Post-merge steps
- [ ] Merge https://github.com/rapid7/metasploit-framework/pull/3578 since it is now unblocked
