### PR TITLE
Credential Gem: LoginScanner - auxillary/scanner/ftp/anonymous.rb

### DIFF
--- a/modules/auxiliary/scanner/ftp/anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/anonymous.rb
@@ -35,40 +35,67 @@ class Metasploit3 < Msf::Auxiliary
 
     begin
 
-    res = connect_login(true, false)
+      res = connect_login(true, false)
 
-    banner.strip! if banner
+      banner.strip! if banner
 
-    dir = Rex::Text.rand_text_alpha(8)
-    if res
-      write_check = send_cmd( ['MKD', dir] , true)
+      dir = Rex::Text.rand_text_alpha(8)
+      if res
+        write_check = send_cmd(['MKD', dir] , true)
 
-      if (write_check and write_check =~ /^2/)
-        send_cmd( ['RMD', dir] , true)
+        if write_check && write_check =~ /^2/
+          send_cmd( ['RMD', dir] , true)
 
-        print_status("#{target_host}:#{rport} Anonymous READ/WRITE (#{banner})")
-        access_type = "rw"
-      else
-        print_status("#{target_host}:#{rport} Anonymous READ (#{banner})")
-        access_type = "ro"
+          print_good("#{target_host}:#{rport} - Anonymous READ/WRITE (#{banner})")
+          access_type = 'Read/Write'
+        else
+          print_good("#{target_host}:#{rport} - Anonymous READ (#{banner})")
+          access_type = 'Read-only'
+        end
+        register_creds(target_host, access_type)
       end
-      report_auth_info(
-        :host   => target_host,
-        :port   => rport,
-        :sname  => 'ftp',
-        :user   => datastore['FTPUSER'],
-        :pass   => datastore['FTPPASS'],
-        :type  => "password_#{access_type}",
-        :active => true
-      )
-    end
 
-    disconnect
+      disconnect
 
     rescue ::Interrupt
-      raise $!
+      raise $ERROR_INFO
     rescue ::Rex::ConnectionError, ::IOError
     end
+  end
 
+  def register_creds(target_host, access_type)
+    # Build service information
+    service_data = {
+      address: target_host,
+      port: datastore['RPORT'],
+      service_name: 'ftp',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    # Build credential information
+    credential_data = {
+      origin_type: :service,
+      module_fullname: self.fullname,
+      private_data: datastore['FTPPASS'],
+      private_type: :password,
+      username: datastore['FTPUSER'],
+      workspace_id: myworkspace_id
+    }
+
+    credential_data.merge!(service_data)
+    credential_core = create_credential(credential_data)
+
+    # Assemble the options hash for creating the Metasploit::Credential::Login object
+    login_data = {
+      access_level: access_type,
+      core: credential_core,
+      last_attempted_at: DateTime.now,
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      workspace_id: myworkspace_id
+    }
+
+    login_data.merge!(service_data)
+    create_credential_login(login_data)
   end
 end


### PR DESCRIPTION
Refactor 'auxillary/scanner/ftp/anonymous.rb' to support the Metasploit Credential gem

**Note:** If this module was properly rewritten it would look almost exactly like Tod's example ftp_login.  I chose to instead retrofit the Credential Gem onto the existing structure.  If it is desired, I can instead rewrite it to look like Tod's example but with default tuned for only anonymous login.  It might be better to remove the module altogether.

**Verification**
- [x] check out the metasploit-credential branch by using the instructions in the section 'Check out the electro-release branch' at the link below:
    https://github.com/rapid7/metasploit-framework/wiki/Metasploit-Loginpalooza
- [x] `msfconsole`
- [x] `use auxillary/scanner/ftp/anonymous`
- [x] `set RHOSTS <target_ftp_server>`
- [x] `run`
  - [ ]  Scan results should be printed
- [x]  `creds`
- [x]  **VERIFY** that successful credentials identified in the scan output are found in the results from creds
