### PR TITLE
fixed msfcli with missing require

### DIFF
--- a/lib/rex/exploitation/powershell/script.rb
+++ b/lib/rex/exploitation/powershell/script.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 
 require 'rex'
+require 'forwardable'
 
 module Rex
 module Exploitation
@@ -13,7 +14,7 @@ module Powershell
     include Parser
     include Obfu
     # Pretend we are actually a string
-    extend Forwardable
+    extend ::Forwardable
     # In case someone messes with String we delegate based on its instance methods
     # eval %Q|def_delegators :@code, :#{::String.instance_methods[0..(String.instance_methods.index(:class)-1)].join(', :')}|
     def_delegators :@code, :each_line, :strip, :chars, :intern, :chr, :casecmp, :ascii_only?, :<, :tr_s,


### PR DESCRIPTION
msfcli was previously broken because of a missing require statement:

```
byt3bl33d3r@holeechit:/pentest/metasploit-framework$ ./msfcli 
/pentest/metasploit-framework/lib/rex/exploitation/powershell/script.rb:16:in `<class:Script>': uninitialized constant Rex::Exploitation::Powershell::Script::Forwardable (NameError)
    from /pentest/metasploit-framework/lib/rex/exploitation/powershell/script.rb:8:in `<module:Powershell>'
    from /pentest/metasploit-framework/lib/rex/exploitation/powershell/script.rb:7:in `<module:Exploitation>'
    from /pentest/metasploit-framework/lib/rex/exploitation/powershell/script.rb:6:in `<module:Rex>'
    from /pentest/metasploit-framework/lib/rex/exploitation/powershell/script.rb:5:in `<top (required)>'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /pentest/metasploit-framework/lib/rex/exploitation/powershell.rb:8:in `<top (required)>'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /pentest/metasploit-framework/lib/rex/text.rb:6:in `<top (required)>'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /pentest/metasploit-framework/lib/rex.rb:44:in `<top (required)>'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
    from ./msfcli:15:in `<main>'
```
