### PR TITLE
Favor MSF_DATABASE_CONFIG for paths['config/database']

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,11 +33,22 @@ module Metasploit
     class Application < Rails::Application
       include Metasploit::Framework::CommonEngine
 
-      user_config_root = Pathname.new(Msf::Config.get_config_root)
-      user_database_yaml = user_config_root.join('database.yml')
+      environment_database_yaml = ENV['MSF_DATABASE_CONFIG']
 
-      if user_database_yaml.exist?
-        config.paths['config/database'] = [user_database_yaml.to_path]
+      if environment_database_yaml
+        # DO NOT check if the path exists: if the environment variable is set, then the user meant to use this path
+        # and if it doesn't exist then an error should occur so the user knows the environment variable points to a
+        # non-existent file.
+        config.paths['config/database'] = environment_database_yaml
+      else
+        user_config_root = Pathname.new(Msf::Config.get_config_root)
+        user_database_yaml = user_config_root.join('database.yml')
+
+        # DO check if the path exists as in test environments there may be no config root, in which case the normal
+        # rails location, `config/database.yml`, should contain the database config.
+        if user_database_yaml.exist?
+          config.paths['config/database'] = [user_database_yaml.to_path]
+        end
       end
     end
   end


### PR DESCRIPTION
[MSP-10848](https://jira.tor.rapid7.com/secure/RapidBoard.jspa?rapidView=84&selectedIssue=MSP-10848)

This replaces https://github.com/rapid7/metasploit-framework/pull/3578
# Verification Steps
## msfconsole
### With MSF_DATABASE_CONFIG
- [x] `export MSF_DATABASE_CONFIG=${pro}/ui/config/database.yml` (`${pro}` should be set to the location of your pro repository)
- [x] `./msfconsole`
- [x] `db_status`
- [x] VERIFY msfconsole is connected to the pro database and not the metasploit-framework database (**NOTE: you should be using a different database for metasploit-framework and pro**) 

```
[*] postgresql connected to metasploit_pro_production
```
- [x] `exit`
- [x] `unset MSF_DATABASE_CONFIG`
### Without MSF_DATABASE_CONFIG
- [x] `./msfconsole`
- [x] `db_status`
- [x] VERIFY msfconsole is connected to the framework database defined in `~/.msf4/database.yml` (**NOTE: you should be using a different database for metasploit-framework and pro**) 

```
[*] postgresql connected to metasploit_framework_private_development
```
- [x] `exit`
## specs
- [x] `rake spec`
- [x] VERIFY no failures
