### PR TITLE
Update adobe_pdf_embedded_exe  target description

### DIFF
--- a/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
+++ b/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Platform'	=> 'win',
       'Targets'	=>
         [
-          [ 'Adobe Reader v8.x, v9.x / Windows [XP SP3/Vista/7] (English/Spanish)', { 'Ret' => '' } ]
+          [ 'Adobe Reader v8.x, v9.x / Windows XP SP3 (English/Spanish) / Windows Vista/7 (English)', { 'Ret' => '' } ]
         ],
       'DefaultTarget'	=> 0))
 

--- a/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
+++ b/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Platform'	=> 'win',
       'Targets'	=>
         [
-          [ 'Adobe Reader v8.x, v9.x (Windows XP SP3 English/Spanish)', { 'Ret' => '' } ]
+          [ 'Adobe Reader v8.x, v9.x / Windows [XP SP3/Vista/7] (English/Spanish)', { 'Ret' => '' } ]
         ],
       'DefaultTarget'	=> 0))
 


### PR DESCRIPTION
As has been reported by Roy Chen, the target name is a little bit confusing. It only states Windows XP SP3 as target, but @jduck made it work on Windows Vista / 7. This pull request just updates the target description.
