### PR TITLE
Support all text-based ctypes in store_loot

### DIFF
--- a/lib/msf/core/auxiliary/report.rb
+++ b/lib/msf/core/auxiliary/report.rb
@@ -215,7 +215,7 @@ module Auxiliary::Report
     end
 
     case ctype
-    when "text/plain"
+    when /^text\/[\w\.]+$/
       ext = "txt"
     end
     # This method is available even if there is no database, don't bother checking


### PR DESCRIPTION
This patch will treat all text-based ctypes as human-readable text files, not always bin.

To test:
- [ ] Use auxiliary/scanner/smb/smb_enumshares
- [ ] Have a valid username/pass
- [ ] Set `SpiderShares` to true
- [ ] Set `ShowFiles` to true
- [ ] Set `LogSpider` to 1
- [ ] Run the module. It should list all the files found, and store the results with a store_loot as *.txt
