### PR TITLE
Fix "text" ctype in smb_enumshares

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -415,10 +415,10 @@ class Metasploit3 < Msf::Auxiliary
         p = store_loot('smb.enumshares', 'text/csv', ip, detailed_tbl.to_csv)
         print_good("#{ip} - info saved in: #{p.to_s}")
       elsif datastore['LogSpider'] == '2'
-        p = store_loot('smb.enumshares', 'text', ip, detailed_tbl)
+        p = store_loot('smb.enumshares', 'text/plain', ip, detailed_tbl)
         print_good("#{ip} - info saved in: #{p.to_s}")
       elsif datastore['LogSpider'] == '3'
-        p = store_loot('smb.enumshares', 'text', ip, logdata)
+        p = store_loot('smb.enumshares', 'text/plain', ip, logdata)
         print_good("#{ip} - info saved in: #{p.to_s}")
       end
     end


### PR DESCRIPTION
"text" is not a valid ctype, should be text/plain.
- [x] Use auxiliary/scanner/smb/smb_enumshares
- [x] Have a valid username/pass
- [x] Set `SpiderShares` to true
- [x] Set `ShowFiles` to true
- [x] Set `LogSpider` between 1, 2 or 3
- [x] Run the module. It should list all the files found, and store the results with a store_loot as *.txt
