### PR TITLE
Adds --ask option to confirm before exiting msfconsole

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -670,8 +670,15 @@ class Core
     if(framework.sessions.length > 0 and not forced)
       print_status("You have active sessions open, to exit anyway type \"exit -y\"")
       return
+    elsif(driver.confirm_exit and not forced)
+      print("Are you sure you want to exit Metasploit? [y/N]: ")
+      response = gets.downcase.chomp
+      if(response == "y" || response == "yes")
+        driver.stop
+      else
+        return
+      end
     end
-
     driver.stop
   end
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -679,6 +679,7 @@ class Core
         return
       end
     end
+
     driver.stop
   end
 

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -158,6 +158,9 @@ class Driver < Msf::Ui::Driver
     # Whether or not command passthru should be allowed
     self.command_passthru = (opts['AllowCommandPassthru'] == false) ? false : true
 
+    # Whether or not to confirm before exiting
+    self.confirm_exit = (opts['ConfirmExit'] == true) ? true : false
+
     # Disables "dangerous" functionality of the console
     @defanged = opts['Defanged'] == true
 
@@ -592,6 +595,10 @@ class Driver < Msf::Ui::Driver
   # The framework instance associated with this driver.
   #
   attr_reader   :framework
+  #  
+  # Whether or not to confirm before exiting
+  #  
+  attr_reader   :confirm_exit
   #
   # Whether or not commands can be passed through.
   #
@@ -628,6 +635,7 @@ class Driver < Msf::Ui::Driver
 protected
 
   attr_writer   :framework # :nodoc:
+  attr_writer   :confirm_exit # :nodoc:
   attr_writer   :command_passthru # :nodoc:
 
   #

--- a/msfconsole
+++ b/msfconsole
@@ -101,6 +101,10 @@ class OptsConsole
         options['DisableBanner'] = true
       end
 
+      opts.on("-a", "--ask", "Ask before exiting Metasploit or accept 'exit -y'") do |v|
+        options['ConfirmExit'] = true
+      end
+      
       opts.on("-x", "-x <command>", "Execute the specified string as console commands (use ; for multiples)") do |s|
         options['XCommands'] ||= []
         options['XCommands'] += s.split(/\s*;\s*/)


### PR DESCRIPTION
The goal is to help people when they forget where they are and accidently type "exit" on msfconsole.
New msfconsole -h entry:
-    -a, --ask                        Ask before exiting Metasploit or accept 'exit -y'

New prompt when typing 'exit' or 'quit' at msfconsole with --ask specified.  It accepts variations of y and yes, defaults to no, and is bypassed with 'exit -y':
-   Are you sure you want to exit Metasploit? [y/N]: 

Validated by testing "exit" and "exit -y" with and without the --ask option and with/without active sessions.
