### PR TITLE
Fix direct datastore assignments to pass msftidy

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_enumusers.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Auxiliary
     @rport || datastore['RPORT']
   end
 
-  def smbdirect
+  def smb_direct
     @smbdirect || datastore['SMBDirect']
   end
 

--- a/modules/auxiliary/scanner/smb/smb_enumusers.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers.rb
@@ -33,6 +33,14 @@ class Metasploit3 < Msf::Auxiliary
     deregister_options('RPORT', 'RHOST')
   end
 
+  def rport
+    @rport || datastore['RPORT']
+  end
+
+  def smbdirect
+    @smbdirect || datastore['SMBDirect']
+  end
+
   # Locate an available SMB PIPE for the specified service
   def smb_find_dcerpc_pipe(uuid, vers, pipes)
     found_pipe   = nil
@@ -132,8 +140,8 @@ class Metasploit3 < Msf::Auxiliary
 
     [[139, false], [445, true]].each do |info|
 
-    datastore['RPORT'] = info[0]
-    datastore['SMBDirect'] = info[1]
+    @rport = info[0]
+    @smbdirect = info[1]
 
     sam_pipe   = nil
     sam_handle = nil
@@ -291,7 +299,7 @@ class Metasploit3 < Msf::Auxiliary
         report_note(
           :host => ip,
           :proto => 'tcp',
-          :port => datastore['RPORT'],
+          :port => rport,
           :type => 'smb.domain.enumusers',
           :data => domains[domain]
         )

--- a/modules/auxiliary/scanner/smb/smb_enumusers.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers.rb
@@ -34,11 +34,11 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def rport
-    @rport || datastore['RPORT']
+    @rport
   end
 
   def smb_direct
-    @smbdirect || datastore['SMBDirect']
+    @smbdirect
   end
 
   # Locate an available SMB PIPE for the specified service


### PR DESCRIPTION
This patch should allow `rport` and `smbdirect` to be modified at runtime without touching the actual datastore options.
- [ ] Test the module against a Windows SMB service
