### PR TITLE
Smb datastore fixes

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
@@ -88,12 +88,20 @@ class Metasploit3 < Msf::Auxiliary
     accounts
   end
 
+  def rport
+    @rport || datastore['RPORT']
+  end
+
+  def smbdirect
+    @smbdirect || datastore['SMBDirect']
+  end
+
   def run_host(ip)
 
     [[139, false], [445, true]].each do |info|
 
-    datastore['RPORT'] = info[0]
-    datastore['SMBDirect'] = info[1]
+    @rport = info[0]
+    @smbdirect = info[1]
 
     begin
       connect()

--- a/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
@@ -92,7 +92,7 @@ class Metasploit3 < Msf::Auxiliary
     @rport || datastore['RPORT']
   end
 
-  def smbdirect
+  def smb_direct
     @smbdirect || datastore['SMBDirect']
   end
 

--- a/modules/auxiliary/scanner/smb/smb_lookupsid.rb
+++ b/modules/auxiliary/scanner/smb/smb_lookupsid.rb
@@ -60,7 +60,7 @@ class Metasploit3 < Msf::Auxiliary
     @rport || datastore['RPORT']
   end
 
-  def smbdirect
+  def smb_direct
     @smbdirect || datastore['SMBDirect']
   end
 

--- a/modules/auxiliary/scanner/smb/smb_lookupsid.rb
+++ b/modules/auxiliary/scanner/smb/smb_lookupsid.rb
@@ -56,6 +56,14 @@ class Metasploit3 < Msf::Auxiliary
   LSA_VERS     = '0.0'
   LSA_PIPES    = %W{ LSARPC NETLOGON SAMR BROWSER SRVSVC }
 
+  def rport
+    @rport || datastore['RPORT']
+  end
+
+  def smbdirect
+    @smbdirect || datastore['SMBDirect']
+  end
+
   # Locate an available SMB PIPE for the specified service
   def smb_find_dcerpc_pipe(uuid, vers, pipes)
     found_pipe   = nil
@@ -139,8 +147,8 @@ class Metasploit3 < Msf::Auxiliary
 
     [[139, false], [445, true]].each do |info|
 
-    datastore['RPORT'] = info[0]
-    datastore['SMBDirect'] = info[1]
+    @rport = info[0]
+    @smbdirect = info[1]
 
     lsa_pipe   = nil
     lsa_handle = nil
@@ -271,7 +279,7 @@ class Metasploit3 < Msf::Auxiliary
       report_note(
         :host => ip,
         :proto => 'tcp',
-        :port => datastore['RPORT'],
+        :port => rport,
         :type => 'smb.domain.lookupsid',
         :data => domain
       )

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Auxiliary
     @rport || datastore['RPORT']
   end
 
-  def smbdirect
+  def smb_direct
     @smbdirect || datastore['SMBDirect']
   end
 

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -36,12 +36,20 @@ class Metasploit3 < Msf::Auxiliary
     deregister_options('RPORT')
   end
 
+  def rport
+    @rport || datastore['RPORT']
+  end
+
+  def smbdirect
+    @smbdirect || datastore['SMBDirect']
+  end
+
   # Fingerprint a single host
   def run_host(ip)
     [[445, true], [139, false]].each do |info|
 
-    datastore['RPORT'] = info[0]
-    datastore['SMBDirect'] = info[1]
+    @rport = info[0]
+    @smbdirect = info[1]
     self.simple = nil
 
     begin


### PR DESCRIPTION
This patch should safely modify `rport` and `smbdirect` without writing to their datastore options. Same type of fix as #3630. If you guys feel this kind of fix is ok to correct direct datastore assignments, my next patch will attempt to fix them all instead of having a bunch of PRs.
