### PR TITLE
Patches UA and Proxy Settings in metsrv when running migrate

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -2,6 +2,7 @@
 require 'rex/io/stream_abstraction'
 require 'rex/sync/ref'
 require 'msf/core/handler/reverse_http/uri_checksum'
+require 'rex/payloads/meterpreter/patch'
 
 module Msf
 module Handler
@@ -223,87 +224,28 @@ protected
         })
 
       when /^\/A?INITM?/
-
-        url = ''
+        conn_id = generate_uri_checksum(URI_CHECKSUM_CONN) + "_" + Rex::Text.rand_text_alphanumeric(16)
+        url = payload_uri + conn_id + "/\x00"
 
         print_status("#{cli.peerhost}:#{cli.peerport} Staging connection for target #{req.relative_resource} received...")
         resp['Content-Type'] = 'application/octet-stream'
 
         blob = obj.stage_payload
 
-        # Replace the user agent string with our option
-        i = blob.index("METERPRETER_UA\x00")
-        if i
-          str = datastore['MeterpreterUserAgent'][0,255] + "\x00"
-          blob[i, str.length] = str
-          print_status("Patched user-agent at offset #{i}...")
-        end
-
-        # Activate a custom proxy
-        i = blob.index("METERPRETER_PROXY\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
-        if i
-          if datastore['PROXYHOST']
-            if datastore['PROXYHOST'].to_s != ""
-              proxyhost = datastore['PROXYHOST'].to_s
-              proxyport = datastore['PROXYPORT'].to_s || "8080"
-              proxyinfo = proxyhost + ":" + proxyport
-              if proxyport == "80"
-                proxyinfo = proxyhost
-              end
-              if datastore['PROXY_TYPE'].to_s == 'HTTP'
-                proxyinfo = 'http://' + proxyinfo
-              else #socks
-                proxyinfo = 'socks=' + proxyinfo
-              end
-              proxyinfo << "\x00"
-              blob[i, proxyinfo.length] = proxyinfo
-              print_status("Activated custom proxy #{proxyinfo}, patch at offset #{i}...")
-              #Optional authentification
-              unless (datastore['PROXY_USERNAME'].nil? or datastore['PROXY_USERNAME'].empty?) or
-                (datastore['PROXY_PASSWORD'].nil? or datastore['PROXY_PASSWORD'].empty?) or
-                datastore['PROXY_TYPE'] == 'SOCKS'
-
-                proxy_username_loc = blob.index("METERPRETER_USERNAME_PROXY\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
-                proxy_username = datastore['PROXY_USERNAME'] << "\x00"
-                blob[proxy_username_loc, proxy_username.length] = proxy_username
-
-                proxy_password_loc = blob.index("METERPRETER_PASSWORD_PROXY\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
-                proxy_password = datastore['PROXY_PASSWORD'] << "\x00"
-                blob[proxy_password_loc, proxy_password.length] = proxy_password
-              end
-            end
-          end
-        end
-
-        # Replace the transport string first (TRANSPORT_SOCKET_SSL)
-        i = blob.index("METERPRETER_TRANSPORT_SSL")
-        if i
-          str = "METERPRETER_TRANSPORT_HTTP#{ssl? ? "S" : ""}\x00"
-          blob[i, str.length] = str
-        end
-        print_status("Patched transport at offset #{i}...")
-
-        conn_id = generate_uri_checksum(URI_CHECKSUM_CONN) + "_" + Rex::Text.rand_text_alphanumeric(16)
-        i = blob.index("https://" + ("X" * 256))
-        if i
-          url = payload_uri + conn_id + "/\x00"
-          blob[i, url.length] = url
-        end
-        print_status("Patched URL at offset #{i}...")
-
-        i = blob.index([0xb64be661].pack("V"))
-        if i
-          str = [ datastore['SessionExpirationTimeout'] ].pack("V")
-          blob[i, str.length] = str
-        end
-        print_status("Patched Expiration Timeout at offset #{i}...")
-
-        i = blob.index([0xaf79257f].pack("V"))
-        if i
-          str = [ datastore['SessionCommunicationTimeout'] ].pack("V")
-          blob[i, str.length] = str
-        end
-        print_status("Patched Communication Timeout at offset #{i}...")
+        #
+        # Patch options into the payload
+        #
+        Rex::Payloads::Meterpreter::Patch.patch_passive_service! blob,
+          :ssl            => ssl?,
+          :url            => url,
+          :expiration     => datastore['SessionExpirationTimeout'],
+          :comm_timeout   => datastore['SessionCommunicationTimeout'],
+          :ua             => datastore['MeterpreterUserAgent'],
+          :proxyhost      => datastore['PROXYHOST'],
+          :proxyport      => datastore['PROXYPORT'],
+          :proxy_type     => datastore['PROXY_TYPE'],
+          :proxy_username => datastore['PROXY_USERNAME'],
+          :proxy_password => datastore['PROXY_PASSWORD']
 
         resp.body = encode_stage(blob)
 

--- a/lib/rex/payloads.rb
+++ b/lib/rex/payloads.rb
@@ -1,2 +1,3 @@
 # -*- coding: binary -*-
 require 'rex/payloads/win32'
+require 'rex/payloads/meterpreter'

--- a/lib/rex/payloads/meterpreter.rb
+++ b/lib/rex/payloads/meterpreter.rb
@@ -1,0 +1,2 @@
+# -*- coding: binary -*-
+require 'rex/payloads/meterpreter/patch'

--- a/lib/rex/payloads/meterpreter/patch.rb
+++ b/lib/rex/payloads/meterpreter/patch.rb
@@ -1,0 +1,103 @@
+# -*- coding: binary -*-
+
+module Rex
+  module Payloads
+    module Meterpreter
+      ###
+      #
+      # Provides methods to patch options into metsrv stagers
+      #
+      ###
+      module Patch
+
+	      # Replace the transport string
+	      def self.patch_transport blob, ssl, url, expiration, comm_timeout
+	        
+          i = blob.index("METERPRETER_TRANSPORT_SSL")
+          if i
+            str = ssl ? "METERPRETER_TRANSPORT_HTTPS\x00" : "METERPRETER_TRANSPORT_HTTP\x00"
+            blob[i, str.length] = str
+          end
+          
+          i = blob.index("https://" + ("X" * 256))
+          if i
+            str = url
+            blob[i, str.length] = str
+          end
+
+          i = blob.index([0xb64be661].pack("V"))
+          if i
+            str = [ expiration ].pack("V")
+            blob[i, str.length] = str
+          end
+
+          i = blob.index([0xaf79257f].pack("V"))
+          if i
+            str = [ comm_timeout ].pack("V")
+            blob[i, str.length] = str
+          end
+
+        return blob
+	      end
+
+        # Replace the user agent string with our option
+        def self.patch_ua blob, ua
+
+          i = blob.index("METERPRETER_UA\x00")
+          if i
+            blob[i, ua.length] = ua
+          end
+
+          return blob, i
+        end
+
+        # Activate a custom proxy
+        def self.patch_proxy blob, proxyhost, proxyport, proxy_type
+
+          i = blob.index("METERPRETER_PROXY\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+          if i
+            if proxyhost
+              if proxyhost.to_s != ""
+                proxyhost = proxyhost.to_s
+                proxyport = proxyport.to_s || "8080"
+                proxyinfo = proxyhost + ":" + proxyport
+                if proxyport == "80"
+                  proxyinfo = proxyhost
+                end
+                if proxy_type.to_s == 'HTTP'
+                  proxyinfo = 'http://' + proxyinfo
+                else #socks
+                  proxyinfo = 'socks=' + proxyinfo
+                end
+                proxyinfo << "\x00"
+                blob[i, proxyinfo.length] = proxyinfo
+              end
+            end
+          end
+
+        return blob, i, proxyinfo
+        end
+
+        # Proxy authentification
+        def self.patch_proxy_auth blob, proxy_username, proxy_password, proxy_type
+
+          unless (proxy_username.nil? or proxy_username.empty?) or
+            (proxy_password.nil? or proxy_password.empty?) or
+            proxy_type == 'SOCKS'
+
+            proxy_username_loc = blob.index("METERPRETER_USERNAME_PROXY\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+            proxy_username = proxy_username << "\x00"
+            blob[proxy_username_loc, proxy_username.length] = proxy_username
+
+            proxy_password_loc = blob.index("METERPRETER_PASSWORD_PROXY\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+            proxy_password = proxy_password << "\x00"
+            blob[proxy_password_loc, proxy_password.length] = proxy_password
+          end
+
+          return blob
+        end
+
+      end
+    end
+  end
+end

--- a/lib/rex/payloads/meterpreter/patch.rb
+++ b/lib/rex/payloads/meterpreter/patch.rb
@@ -11,7 +11,7 @@ module Rex
       module Patch
 
         # Replace the transport string
-        def patch_transport! blob, ssl
+        def self.patch_transport! blob, ssl
 
           i = blob.index("METERPRETER_TRANSPORT_SSL")
           if i
@@ -22,7 +22,7 @@ module Rex
         end
 
         # Replace the URL
-        def patch_url! blob, url
+        def self.patch_url! blob, url
 
           i = blob.index("https://" + ("X" * 256))
           if i
@@ -33,7 +33,7 @@ module Rex
         end
 
         # Replace the session expiration timeout
-        def patch_expiration! blob, expiration
+        def self.patch_expiration! blob, expiration
 
           i = blob.index([0xb64be661].pack("V"))
           if i
@@ -44,7 +44,7 @@ module Rex
         end
 
         # Replace the session communication timeout
-        def patch_comm_timeout! blob, comm_timeout
+        def self.patch_comm_timeout! blob, comm_timeout
 
           i = blob.index([0xaf79257f].pack("V"))
           if i
@@ -55,7 +55,7 @@ module Rex
         end
 
         # Replace the user agent string with our option
-        def patch_ua! blob, ua
+        def self.patch_ua! blob, ua
 
           ua = ua[0,255] + "\x00"
           i = blob.index("METERPRETER_UA\x00")
@@ -66,7 +66,7 @@ module Rex
         end
 
         # Activate a custom proxy
-        def patch_proxy! blob, proxyhost, proxyport, proxy_type
+        def self.patch_proxy! blob, proxyhost, proxyport, proxy_type
 
           i = blob.index("METERPRETER_PROXY\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
           if i
@@ -92,7 +92,7 @@ module Rex
         end
 
         # Proxy authentification
-        def patch_proxy_auth! blob, proxy_username, proxy_password, proxy_type
+        def self.patch_proxy_auth! blob, proxy_username, proxy_password, proxy_type
 
           unless (proxy_username.nil? or proxy_username.empty?) or
             (proxy_password.nil? or proxy_password.empty?) or
@@ -110,19 +110,19 @@ module Rex
         end
 
         # Patch options into metsrv for reverse HTTP payloads
-        def patch_passive_service! blob, options
+        def self.patch_passive_service! blob, options
 
-          blob.patch_transport! blob, options[:ssl]
-          blob.patch_url! blob, options[:url]
-          blob.patch_expiration! blob, options[:expiration]
-          blob.patch_comm_timeout! blob, options[:comm_timeout]
-          blob.patch_ua! blob, options[:ua]
-          blob.patch_proxy!(blob,
+          patch_transport! blob, options[:ssl]
+          patch_url! blob, options[:url]
+          patch_expiration! blob, options[:expiration]
+          patch_comm_timeout! blob, options[:comm_timeout]
+          patch_ua! blob, options[:ua]
+          patch_proxy!(blob,
             options[:proxyhost],
             options[:proxyport],
             options[:proxy_type]
           )
-          blob.patch_proxy_auth!(blob,
+          patch_proxy_auth!(blob,
             options[:proxy_username],
             options[:proxy_password],
             options[:proxy_type]

--- a/lib/rex/payloads/meterpreter/patch.rb
+++ b/lib/rex/payloads/meterpreter/patch.rb
@@ -11,7 +11,7 @@ module Rex
       module Patch
 
         # Replace the transport string
-        def self.patch_transport blob, ssl
+        def patch_transport! blob, ssl
 
           i = blob.index("METERPRETER_TRANSPORT_SSL")
           if i
@@ -23,7 +23,7 @@ module Rex
         end
 
         # Replace the URL
-        def self.patch_url blob, url
+        def patch_url! blob, url
 
           i = blob.index("https://" + ("X" * 256))
           if i
@@ -35,7 +35,7 @@ module Rex
         end
 
         # Replace the session expiration timeout
-        def self.patch_expiration blob, expiration
+        def patch_expiration! blob, expiration
 
           i = blob.index([0xb64be661].pack("V"))
           if i
@@ -47,7 +47,7 @@ module Rex
         end
 
         # Replace the session communication timeout
-        def self.patch_comm_timeout blob, comm_timeout
+        def patch_comm_timeout! blob, comm_timeout
 
           i = blob.index([0xaf79257f].pack("V"))
           if i
@@ -59,7 +59,7 @@ module Rex
         end
 
         # Replace the user agent string with our option
-        def self.patch_ua blob, ua
+        def patch_ua! blob, ua
 
           i = blob.index("METERPRETER_UA\x00")
           if i
@@ -70,7 +70,7 @@ module Rex
         end
 
         # Activate a custom proxy
-        def self.patch_proxy blob, proxyhost, proxyport, proxy_type
+        def patch_proxy! blob, proxyhost, proxyport, proxy_type
 
           i = blob.index("METERPRETER_PROXY\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
           if i
@@ -97,7 +97,7 @@ module Rex
         end
 
         # Proxy authentification
-        def self.patch_proxy_auth blob, proxy_username, proxy_password, proxy_type
+        def patch_proxy_auth! blob, proxy_username, proxy_password, proxy_type
 
           unless (proxy_username.nil? or proxy_username.empty?) or
             (proxy_password.nil? or proxy_password.empty?) or

--- a/lib/rex/payloads/meterpreter/patch.rb
+++ b/lib/rex/payloads/meterpreter/patch.rb
@@ -11,7 +11,7 @@ module Rex
       module Patch
 
         # Replace the transport string
-        def self.patch_transport blob, ssl, url, expiration, comm_timeout
+        def self.patch_transport blob, ssl
 
           i = blob.index("METERPRETER_TRANSPORT_SSL")
           if i
@@ -19,17 +19,35 @@ module Rex
             blob[i, str.length] = str
           end
 
+          return blob
+        end
+
+        # Replace the URL
+        def self.patch_url blob, url
+
           i = blob.index("https://" + ("X" * 256))
           if i
             str = url
             blob[i, str.length] = str
           end
 
+          return blob
+        end
+
+        # Replace the session expiration timeout
+        def self.patch_expiration blob, expiration
+
           i = blob.index([0xb64be661].pack("V"))
           if i
             str = [ expiration ].pack("V")
             blob[i, str.length] = str
           end
+
+          return blob
+        end
+
+        # Replace the session communication timeout
+        def self.patch_comm_timeout blob, comm_timeout
 
           i = blob.index([0xaf79257f].pack("V"))
           if i
@@ -48,7 +66,7 @@ module Rex
             blob[i, ua.length] = ua
           end
 
-          return blob, i
+          return blob
         end
 
         # Activate a custom proxy
@@ -75,7 +93,7 @@ module Rex
             end
           end
 
-          return blob, i, proxyinfo
+          return blob
         end
 
         # Proxy authentification

--- a/lib/rex/payloads/meterpreter/patch.rb
+++ b/lib/rex/payloads/meterpreter/patch.rb
@@ -10,15 +10,15 @@ module Rex
       ###
       module Patch
 
-	      # Replace the transport string
-	      def self.patch_transport blob, ssl, url, expiration, comm_timeout
-	        
+        # Replace the transport string
+        def self.patch_transport blob, ssl, url, expiration, comm_timeout
+
           i = blob.index("METERPRETER_TRANSPORT_SSL")
           if i
             str = ssl ? "METERPRETER_TRANSPORT_HTTPS\x00" : "METERPRETER_TRANSPORT_HTTP\x00"
             blob[i, str.length] = str
           end
-          
+
           i = blob.index("https://" + ("X" * 256))
           if i
             str = url
@@ -37,8 +37,8 @@ module Rex
             blob[i, str.length] = str
           end
 
-        return blob
-	      end
+          return blob
+        end
 
         # Replace the user agent string with our option
         def self.patch_ua blob, ua
@@ -75,7 +75,7 @@ module Rex
             end
           end
 
-        return blob, i, proxyinfo
+          return blob, i, proxyinfo
         end
 
         # Proxy authentification

--- a/lib/rex/payloads/meterpreter/patch.rb
+++ b/lib/rex/payloads/meterpreter/patch.rb
@@ -19,7 +19,6 @@ module Rex
             blob[i, str.length] = str
           end
 
-          return blob
         end
 
         # Replace the URL
@@ -31,7 +30,6 @@ module Rex
             blob[i, str.length] = str
           end
 
-          return blob
         end
 
         # Replace the session expiration timeout
@@ -43,7 +41,6 @@ module Rex
             blob[i, str.length] = str
           end
 
-          return blob
         end
 
         # Replace the session communication timeout
@@ -55,18 +52,17 @@ module Rex
             blob[i, str.length] = str
           end
 
-          return blob
         end
 
         # Replace the user agent string with our option
         def patch_ua! blob, ua
 
+          ua = ua[0,255] + "\x00"
           i = blob.index("METERPRETER_UA\x00")
           if i
             blob[i, ua.length] = ua
           end
 
-          return blob
         end
 
         # Activate a custom proxy
@@ -93,7 +89,6 @@ module Rex
             end
           end
 
-          return blob
         end
 
         # Proxy authentification
@@ -112,7 +107,27 @@ module Rex
             blob[proxy_password_loc, proxy_password.length] = proxy_password
           end
 
-          return blob
+        end
+
+        # Patch options into metsrv for reverse HTTP payloads
+        def patch_passive_service! blob, options
+
+          blob.patch_transport! blob, options[:ssl]
+          blob.patch_url! blob, options[:url]
+          blob.patch_expiration! blob, options[:expiration]
+          blob.patch_comm_timeout! blob, options[:comm_timeout]
+          blob.patch_ua! blob, options[:ua]
+          blob.patch_proxy!(blob,
+            options[:proxyhost],
+            options[:proxyport],
+            options[:proxy_type]
+          )
+          blob.patch_proxy_auth!(blob,
+            options[:proxy_username],
+            options[:proxy_password],
+            options[:proxy_type]
+          )
+
         end
 
       end

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -231,45 +231,35 @@ class ClientCore < Extension
 
     if client.passive_service
 
+      blob.extend(Rex::Payloads::Meterpreter::Patch)
+
       # Replace the transport string first (TRANSPORT_SOCKET_SSL)
-      blob = Rex::Payloads::Meterpreter::Patch.patch_transport(
-        blob,
-        client.ssl
-      )
+      blob.patch_transport!(blob, client.ssl)
 
       # Replace the URL
-      blob = Rex::Payloads::Meterpreter::Patch.patch_url(
-        blob,
-        self.client.url
-      )
+      blob.patch_url!(blob, self.client.url)
 
       # Replace the session expiration timeout
-      blob = Rex::Payloads::Meterpreter::Patch.patch_expiration(
-        blob,
-        self.client.expiration
-      ) 
+      blob.patch_expiration!(blob, self.client.expiration)
 
       # Replace the session communication timeout
-      blob = Rex::Payloads::Meterpreter::Patch.patch_comm_timeout(
-        blob,
-        self.client.comm_timeout
-      )
+      blob.patch_comm_timeout!(blob, self.client.comm_timeout)
 
       # Replace the user agent string with our option
-      blob, i = Rex::Payloads::Meterpreter::Patch.patch_ua(
+      blob.patch_ua!(
         blob,
         client.exploit_datastore['MeterpreterUserAgent'][0,255] + "\x00"
       )
 
       # Activate a custom proxy
-      blob, i = Rex::Payloads::Meterpreter::Patch.patch_proxy(
+      blob.patch_proxy!(
         blob,
         client.exploit_datastore['PROXYHOST'],
         client.exploit_datastore['PROXYPORT'],
         client.exploit_datastore['PROXY_TYPE']
       )
       # Proxy authentication
-      blob = Rex::Payloads::Meterpreter::Patch.patch_proxy_auth(
+      blob.patch_proxy_auth!(
         blob,
         client.exploit_datastore['PROXY_USERNAME'],
         client.exploit_datastore['PROXY_PASSWORD'],

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -8,7 +8,7 @@ require 'rex/post/meterpreter/client'
 # argument for moving the meterpreter client into the Msf namespace.
 require 'msf/core/payload/windows'
 
-# Provides methods to patch options into the metsrv stage.
+# Provides methods to patch options into the metsrv stager.
 require 'rex/payloads/meterpreter/patch'
 
 module Rex

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -231,42 +231,22 @@ class ClientCore < Extension
 
     if client.passive_service
 
-      blob.extend(Rex::Payloads::Meterpreter::Patch)
+      blob.extend Rex::Payloads::Meterpreter::Patch
 
-      # Replace the transport string first (TRANSPORT_SOCKET_SSL)
-      blob.patch_transport!(blob, client.ssl)
-
-      # Replace the URL
-      blob.patch_url!(blob, self.client.url)
-
-      # Replace the session expiration timeout
-      blob.patch_expiration!(blob, self.client.expiration)
-
-      # Replace the session communication timeout
-      blob.patch_comm_timeout!(blob, self.client.comm_timeout)
-
-      # Replace the user agent string with our option
-      blob.patch_ua!(
-        blob,
-        client.exploit_datastore['MeterpreterUserAgent'][0,255] + "\x00"
-      )
-
-      # Activate a custom proxy
-      blob.patch_proxy!(
-        blob,
-        client.exploit_datastore['PROXYHOST'],
-        client.exploit_datastore['PROXYPORT'],
-        client.exploit_datastore['PROXY_TYPE']
-      )
-      # Proxy authentication
-      blob.patch_proxy_auth!(
-        blob,
-        client.exploit_datastore['PROXY_USERNAME'],
-        client.exploit_datastore['PROXY_PASSWORD'],
-        client.exploit_datastore['PROXY_TYPE']
-      )
-
-      conn_id = self.client.conn_id
+      #
+      # Patch options into metsrv for reverse HTTP payloads
+      #
+      blob.patch_passive_service! blob,
+        :ssl  =>  client.ssl,
+        :url =>  self.client.url,
+        :expiration  => self.client.expiration,
+        :comm_timeout  =>  self.client.comm_timeout,
+        :ua  =>  client.exploit_datastore['MeterpreterUserAgent'],
+        :proxyhost =>  client.exploit_datastore['PROXYHOST'],
+        :proxyport =>  client.exploit_datastore['PROXYPORT'],
+        :proxy_type  =>  client.exploit_datastore['PROXY_TYPE'],
+        :proxy_username  =>  client.exploit_datastore['PROXY_USERNAME'],
+        :proxy_password  =>  client.exploit_datastore['PROXY_PASSWORD']
 
     end
 

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -234,9 +234,24 @@ class ClientCore < Extension
       # Replace the transport string first (TRANSPORT_SOCKET_SSL)
       blob = Rex::Payloads::Meterpreter::Patch.patch_transport(
         blob,
-        client.ssl,
-        self.client.url,
-        self.client.expiration,
+        client.ssl
+      )
+
+      # Replace the URL
+      blob = Rex::Payloads::Meterpreter::Patch.patch_url(
+        blob,
+        self.client.url
+      )
+
+      # Replace the session expiration timeout
+      blob = Rex::Payloads::Meterpreter::Patch.patch_expiration(
+        blob,
+        self.client.expiration
+      ) 
+
+      # Replace the session communication timeout
+      blob = Rex::Payloads::Meterpreter::Patch.patch_comm_timeout(
+        blob,
         self.client.comm_timeout
       )
 

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -231,12 +231,10 @@ class ClientCore < Extension
 
     if client.passive_service
 
-      blob.extend Rex::Payloads::Meterpreter::Patch
-
       #
       # Patch options into metsrv for reverse HTTP payloads
       #
-      blob.patch_passive_service! blob,
+      Rex::Payloads::Meterpreter::Patch.patch_passive_service! blob,
         :ssl  =>  client.ssl,
         :url =>  self.client.url,
         :expiration  => self.client.expiration,

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -235,16 +235,16 @@ class ClientCore < Extension
       # Patch options into metsrv for reverse HTTP payloads
       #
       Rex::Payloads::Meterpreter::Patch.patch_passive_service! blob,
-        :ssl  =>  client.ssl,
-        :url =>  self.client.url,
-        :expiration  => self.client.expiration,
-        :comm_timeout  =>  self.client.comm_timeout,
-        :ua  =>  client.exploit_datastore['MeterpreterUserAgent'],
-        :proxyhost =>  client.exploit_datastore['PROXYHOST'],
-        :proxyport =>  client.exploit_datastore['PROXYPORT'],
-        :proxy_type  =>  client.exploit_datastore['PROXY_TYPE'],
-        :proxy_username  =>  client.exploit_datastore['PROXY_USERNAME'],
-        :proxy_password  =>  client.exploit_datastore['PROXY_PASSWORD']
+        :ssl            =>  client.ssl,
+        :url            =>  self.client.url,
+        :expiration     => self.client.expiration,
+        :comm_timeout   =>  self.client.comm_timeout,
+        :ua             =>  client.exploit_datastore['MeterpreterUserAgent'],
+        :proxyhost      =>  client.exploit_datastore['PROXYHOST'],
+        :proxyport      =>  client.exploit_datastore['PROXYPORT'],
+        :proxy_type     =>  client.exploit_datastore['PROXY_TYPE'],
+        :proxy_username =>  client.exploit_datastore['PROXY_USERNAME'],
+        :proxy_password =>  client.exploit_datastore['PROXY_PASSWORD']
 
     end
 

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -269,7 +269,7 @@ class ClientCore < Extension
           end
         end
       end
-      
+
       # Replace the transport string first (TRANSPORT_SOCKET_SSL
       i = blob.index("METERPRETER_TRANSPORT_SSL")
       if i

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -228,48 +228,6 @@ class ClientCore < Extension
 
     if client.passive_service
 
-      # Replace the user agent string with our option
-      i = blob.index("METERPRETER_UA\x00")
-      if i
-        str = client.exploit_datastore['MeterpreterUserAgent'][0,255] + "\x00"
-        blob[i, str.length] = str
-      end
-
-      # Activate a custom proxy
-      i = blob.index("METERPRETER_PROXY\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
-      if i
-        if client.exploit_datastore['PROXYHOST']
-          if client.exploit_datastore['PROXYHOST'].to_s != ""
-            proxyhost = client.exploit_datastore['PROXYHOST'].to_s
-            proxyport = client.exploit_datastore['PROXYPORT'].to_s || "8080"
-            proxyinfo = proxyhost + ":" + proxyport
-            if proxyport == "80"
-              proxyinfo = proxyhost
-            end
-            if client.exploit_datastore['PROXY_TYPE'].to_s == 'HTTP'
-              proxyinfo = 'http://' + proxyinfo
-            else #socks
-              proxyinfo = 'socks=' + proxyinfo
-            end
-            proxyinfo << "\x00"
-            blob[i, proxyinfo.length] = proxyinfo
-            #Optional authentification
-            unless (client.exploit_datastore['PROXY_USERNAME'].nil? or datastore['PROXY_USERNAME'].empty?) or
-              (client.exploit_datastore['PROXY_PASSWORD'].nil? or datastore['PROXY_PASSWORD'].empty?) or
-              client.exploit_datastore['PROXY_TYPE'] == 'SOCKS'
-
-              proxy_username_loc = blob.index("METERPRETER_USERNAME_PROXY\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
-              proxy_username = client.exploit_datastore['PROXY_USERNAME'] << "\x00"
-              blob[proxy_username_loc, proxy_username.length] = proxy_username
-
-              proxy_password_loc = blob.index("METERPRETER_PASSWORD_PROXY\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
-              proxy_password = client.exploit_datastore['PROXY_PASSWORD'] << "\x00"
-              blob[proxy_password_loc, proxy_password.length] = proxy_password
-            end
-          end
-        end
-      end
-
       # Replace the transport string first (TRANSPORT_SOCKET_SSL
       i = blob.index("METERPRETER_TRANSPORT_SSL")
       if i


### PR DESCRIPTION
Earlier today, I saw that my User-Agent was changing to "METERPRETER_UA" after running "migrate" with windows/meterpreter/reverse_http.  It appeared that metsrv was not getting patched with MeterpreterUserAgent so I pulled the pertinent code (added the proxy stuff for completeness) from msf/core/handler/reverse_http.rb and dumped it here.
