### PR TITLE
Adds ability to set lhost IP by specifying an interface name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem 'rkelly-remix', '0.0.6'
 gem 'robots'
 # Needed for some post modules
 gem 'sqlite3'
+# Blah
+gem 'system-getifaddrs'
 
 group :db do
   # Needed for Msf::DbManager

--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,10 @@ gem 'rkelly-remix', '0.0.6'
 gem 'robots'
 # Needed for some post modules
 gem 'sqlite3'
-# Needed by core.rb to automatically assign lhost
-gem 'system-getifaddrs', '0.2.1'
+# Needed by core.rb to automatically assign lhost on Linux
+if not Gem.win_platform?
+  gem 'system-getifaddrs', '0.2.1'
+end
 
 group :db do
   # Needed for Msf::DbManager

--- a/Gemfile
+++ b/Gemfile
@@ -21,9 +21,7 @@ gem 'robots'
 # Needed for some post modules
 gem 'sqlite3'
 # Needed by core.rb to automatically assign lhost on Linux
-if not Gem.win_platform?
-  gem 'system-getifaddrs', '0.2.1'
-end
+gem 'system-getifaddrs', '0.2.1' if not Gem.win_platform?
 
 group :db do
   # Needed for Msf::DbManager

--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,8 @@ gem 'rkelly-remix', '0.0.6'
 gem 'robots'
 # Needed for some post modules
 gem 'sqlite3'
-# Blah
-gem 'system-getifaddrs'
+# Needed by core.rb to automatically assign lhost
+gem 'system-getifaddrs', '0.2.1'
 
 group :db do
   # Needed for Msf::DbManager

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     simplecov-html (0.5.3)
     slop (3.5.0)
     sqlite3 (1.3.9)
+    system-getifaddrs (0.2.1)
     timecop (0.6.3)
     tzinfo (0.3.37)
     yard (0.8.7)
@@ -101,5 +102,6 @@ DEPENDENCIES
   shoulda-matchers
   simplecov (= 0.5.4)
   sqlite3
+  system-getifaddrs (= 0.2.1)
   timecop
   yard

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -16,7 +16,9 @@ require 'msf/ui/console/command_dispatcher/nop'
 require 'msf/ui/console/command_dispatcher/payload'
 require 'msf/ui/console/command_dispatcher/auxiliary'
 require 'msf/ui/console/command_dispatcher/post'
-require 'system/getifaddrs'
+if Gem.win_platform? == false
+  require 'system/getifaddrs'
+end
 
 module Msf
 module Ui
@@ -1945,11 +1947,11 @@ class Core
       # so we need to rebuild the payload list whenever the target
       # changes.
       @cache_payloads = nil
-    elsif (name.upcase == "LHOST" and args.length == 2)
+    elsif (name.upcase == "LHOST" and args.length == 2 and not Gem.win_platform?)
       # Attempt to automatically assign lhost to an interface's IP
       begin
-       iface = value	
-       value = System.get_ifaddrs[iface.intern][:inet_addr] 
+       iface = value
+       value = System.get_ifaddrs[iface.intern][:inet_addr]
        print_status("Setting lhost to address of interface " + iface)
       rescue NoMethodError
         # do nothing - get_ifaddr failed (not a valid interface)

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1218,7 +1218,7 @@ class Core
       Rex::Socket::SwitchBoard.flush_routes
 
     when "print"
-      tbl = Table.new(
+      tbl =	Table.new(
         Table::Style::Default,
         'Header'  => "Active Routing Table",
         'Prefix'  => "\n",

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -16,6 +16,7 @@ require 'msf/ui/console/command_dispatcher/nop'
 require 'msf/ui/console/command_dispatcher/payload'
 require 'msf/ui/console/command_dispatcher/auxiliary'
 require 'msf/ui/console/command_dispatcher/post'
+require 'system/getifaddrs'
 
 module Msf
 module Ui
@@ -1217,7 +1218,7 @@ class Core
       Rex::Socket::SwitchBoard.flush_routes
 
     when "print"
-      tbl =	Table.new(
+      tbl = Table.new(
         Table::Style::Default,
         'Header'  => "Active Routing Table",
         'Prefix'  => "\n",
@@ -1944,6 +1945,14 @@ class Core
       # so we need to rebuild the payload list whenever the target
       # changes.
       @cache_payloads = nil
+    elsif (name.upcase == "LHOST" and args.length == 2)
+      begin
+       iface = value.intern	
+       print_status("Just addressed respective ethernet device: " + value)    
+       value = System.get_ifaddrs[iface][:inet_addr] 
+     rescue NoMethodError
+       # do nothing
+     end
     end
 
     # Security check -- make sure the data store element they are setting

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1948,11 +1948,11 @@ class Core
     elsif (name.upcase == "LHOST" and args.length == 2)
       # Attempt to automatically assign lhost to an interface's IP
       begin
-       iface = value.intern	
-       print_status("Setting lhost to address of interface " + value)
-       value = System.get_ifaddrs[iface][:inet_addr] 
+       iface = value	
+       value = System.get_ifaddrs[iface.intern][:inet_addr] 
+       print_status("Setting lhost to address of interface " + iface)
       rescue NoMethodError
-        # do nothing - not a valid interface
+        # do nothing - get_ifaddr failed (not a valid interface)
       end
     end
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -16,9 +16,7 @@ require 'msf/ui/console/command_dispatcher/nop'
 require 'msf/ui/console/command_dispatcher/payload'
 require 'msf/ui/console/command_dispatcher/auxiliary'
 require 'msf/ui/console/command_dispatcher/post'
-if Gem.win_platform? == false
-  require 'system/getifaddrs'
-end
+require 'system/getifaddrs' if not Gem.win_platform?
 
 module Msf
 module Ui

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1946,13 +1946,14 @@ class Core
       # changes.
       @cache_payloads = nil
     elsif (name.upcase == "LHOST" and args.length == 2)
+      # Attempt to automatically assign lhost to an interface's IP
       begin
        iface = value.intern	
-       print_status("Just addressed respective ethernet device: " + value)    
+       print_status("Setting lhost to address of interface " + value)
        value = System.get_ifaddrs[iface][:inet_addr] 
-     rescue NoMethodError
-       # do nothing
-     end
+      rescue NoMethodError
+        # do nothing - not a valid interface
+      end
     end
 
     # Security check -- make sure the data store element they are setting


### PR DESCRIPTION
This pull allows a user to set their lhost by specifying a local interface.  It uses an added gem to attempt to automatically determine the interface's IP address.  It only applies when "set lhost" or "setg lhost" is used.  If the attempt to retrieve the IP address fails (eg. an actual IP address or an invalid interface), it proceeds as before.

Verification tests:
msf > set lhost eth0
[_] Setting lhost to address of interface eth0
lhost => 192.168.0.101
msf > set lhost 8.8.8.8
lhost => 8.8.8.8
msf > set lhost eth0:1
[_] Setting lhost to address of interface eth0:1
lhost => 192.168.10.4
msf > set lhost eth1
[_] Setting lhost to address of interface eth1
lhost => 192.168.8.3
msf > set lhost gibberish
lhost => gibberish
msf > set lhost eth0 junk
lhost => eth0 junk
msf > setg lhost eth0
[_] Setting lhost to address of interface eth0
lhost => 192.168.0.101
