### PR TITLE
More .rubocop.yml exceptions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,12 @@
-# This list was created by analyzing the last three months (51 modules)
-# committed to Metasploit Framework. Many, many older modules will have
-# offenses, but this should at least provide a baseline for new modules.
+# This list was intially created by analyzing the last three months (51
+# modules) committed to Metasploit Framework. Many, many older modules
+# will have offenses, but this should at least provide a baseline for
+# new modules.
 #
-# Updates to this file should include a 'Description' parameter for
-# any explaination needed.
+# Updates to this file should include a 'Description' parameter for any
+# explaination needed.
 
-inherit_from: .rubocop_todo.yml
+# inherit_from: .rubocop_todo.yml
 
 Style/ClassLength:
   Description: 'Most Metasploit modules are quite large. This is ok.'
@@ -42,17 +43,14 @@ Style/NumericLiterals:
   Enabled: false
   Description: 'This often hurts readability for exploit-ish code.'
 
-Style/PercentLiteralDelimiters:
+Style/SpaceInsideBrackets:
   Enabled: false
-  Description: >-
-                  Metasploit devs tend to prefer [] over %w() for
-                  nearly all cases, since we often deal with funny
-                  looking arrays of nonwords. Consistency here is
-                  preferred over element type safety.
+  Description: 'Until module template are final, most modules will fail this.'
+
+Style/StringLiterals:
+  Enabled: false
+  Description: 'Single vs double quote fights are largely unproductive.'
 
 Style/WordArray:
   Enabled: false
-  Description: >-
-                  Metasploit devs have grown comforatble with curly
-                  braces over parens for %w. Disabling this check
-                  prefers consistency.
+  Description: 'Metasploit prefers consistent use of []'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ and Metasploit's [Common Coding Mistakes](https://github.com/rapid7/metasploit-f
 ## Code Contributions
 
 * **Do** stick to the [Ruby style guide](https://github.com/bbatsov/ruby-style-guide).
-* Similarly, **try** to get Rubocop passing or at least relatively quiet against the files added/modified as part of your contribution
+* *Do* get [Rubocop](https://rubygems.org/search?query=rubocop) relatively quiet against the code you are adding or modifying.
 * **Do** follow the [50/72 rule](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) for Git commit messages.
 * **Do** create a [topic branch](http://git-scm.com/book/en/Git-Branching-Branching-Workflows#Topic-Branches) to work on instead of working directly on `master`.
 


### PR DESCRIPTION
While we expect to remove Rubocop via PR rapid7#3639 , the Rubocop YAML
file is still useful for those developers that want to use Rubocop on
their own. Like me, for instance.
