### PR TITLE
Add 'coding: binary' to all msf/rex library files

### DIFF
--- a/lib/msf/base/simple/framework/module_paths.rb
+++ b/lib/msf/base/simple/framework/module_paths.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf
   module Simple
     module Framework

--- a/lib/msf/core/auxiliary/web/analysis/differential.rb
+++ b/lib/msf/core/auxiliary/web/analysis/differential.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 ##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit

--- a/lib/msf/core/auxiliary/web/analysis/taint.rb
+++ b/lib/msf/core/auxiliary/web/analysis/taint.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 ##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit

--- a/lib/msf/core/auxiliary/web/analysis/timing.rb
+++ b/lib/msf/core/auxiliary/web/analysis/timing.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 ##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit

--- a/lib/msf/core/auxiliary/web/form.rb
+++ b/lib/msf/core/auxiliary/web/form.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # Framework web site for more information on licensing and terms of use.

--- a/lib/msf/core/auxiliary/web/fuzzable.rb
+++ b/lib/msf/core/auxiliary/web/fuzzable.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # Framework web site for more information on licensing and terms of use.

--- a/lib/msf/core/auxiliary/web/http.rb
+++ b/lib/msf/core/auxiliary/web/http.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 ##
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit

--- a/lib/msf/core/auxiliary/web/path.rb
+++ b/lib/msf/core/auxiliary/web/path.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # Framework web site for more information on licensing and terms of use.

--- a/lib/msf/core/auxiliary/web/target.rb
+++ b/lib/msf/core/auxiliary/web/target.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 # This file is part of the Metasploit Framework and may be subject to
 # redistribution and commercial restrictions. Please see the Metasploit
 # Framework web site for more information on licensing and terms of use.

--- a/lib/msf/core/db_manager/import_msf_xml.rb
+++ b/lib/msf/core/db_manager/import_msf_xml.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf
   class DBManager
     # Handles importing of the xml format exported by Pro.  The methods are in a

--- a/lib/msf/core/db_manager/migration.rb
+++ b/lib/msf/core/db_manager/migration.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf
   class DBManager
     module Migration

--- a/lib/msf/core/exe/segment_injector.rb
+++ b/lib/msf/core/exe/segment_injector.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf
 module Exe
 

--- a/lib/msf/core/exploit/local/compile_c.rb
+++ b/lib/msf/core/exploit/local/compile_c.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 
 module Msf
 module Exploit::Local::CompileC

--- a/lib/msf/core/exploit/local/linux.rb
+++ b/lib/msf/core/exploit/local/linux.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 require 'msf/core/exploit/local/compile_c'
 
 module Msf

--- a/lib/msf/core/exploit/local/linux_kernel.rb
+++ b/lib/msf/core/exploit/local/linux_kernel.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 require 'msf/core/exploit/local/compile_c'
 
 module Msf

--- a/lib/msf/core/exploit/postgres.rb
+++ b/lib/msf/core/exploit/postgres.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 require 'msf/core'
 
 module Msf

--- a/lib/msf/core/handler/reverse_http/uri_checksum.rb
+++ b/lib/msf/core/handler/reverse_http/uri_checksum.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf
   module Handler
     module ReverseHttp

--- a/lib/msf/core/handler/reverse_tcp_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_ssl.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 require 'rex/socket'
 require 'thread'
 

--- a/lib/msf/core/module/deprecated.rb
+++ b/lib/msf/core/module/deprecated.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 
 module Msf::Module::Deprecated
 

--- a/lib/msf/core/module_manager/cache.rb
+++ b/lib/msf/core/module_manager/cache.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 #
 # Gems
 #

--- a/lib/msf/core/module_manager/loading.rb
+++ b/lib/msf/core/module_manager/loading.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 #
 # Gems
 #

--- a/lib/msf/core/module_manager/module_paths.rb
+++ b/lib/msf/core/module_manager/module_paths.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 #
 # Gems
 #

--- a/lib/msf/core/module_manager/module_sets.rb
+++ b/lib/msf/core/module_manager/module_sets.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 #
 # Gems
 #

--- a/lib/msf/core/module_manager/reloading.rb
+++ b/lib/msf/core/module_manager/reloading.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 # Concerns reloading modules
 module Msf::ModuleManager::Reloading
   # Reloads the module specified in mod.  This can either be an instance of a module or a module class.

--- a/lib/msf/core/modules.rb
+++ b/lib/msf/core/modules.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 # Namespace for loading Metasploit modules
 module Msf::Modules
 

--- a/lib/msf/core/modules/error.rb
+++ b/lib/msf/core/modules/error.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 # Base error class for all error under {Msf::Modules}
 class Msf::Modules::Error < StandardError
   def initialize(attributes={})

--- a/lib/msf/core/modules/loader.rb
+++ b/lib/msf/core/modules/loader.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 require 'msf/core/modules'
 
 # Namespace for module loaders

--- a/lib/msf/core/modules/loader/archive.rb
+++ b/lib/msf/core/modules/loader/archive.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 require 'msf/core/modules/loader/base'
 
 # Concerns loading modules form fastlib archives

--- a/lib/msf/core/modules/loader/base.rb
+++ b/lib/msf/core/modules/loader/base.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 #
 # Project
 #

--- a/lib/msf/core/modules/loader/directory.rb
+++ b/lib/msf/core/modules/loader/directory.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 # Concerns loading module from a directory
 class Msf::Modules::Loader::Directory < Msf::Modules::Loader::Base
   # Returns true if the path is a directory

--- a/lib/msf/core/modules/metasploit_class_compatibility_error.rb
+++ b/lib/msf/core/modules/metasploit_class_compatibility_error.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 require 'msf/core/modules/error'
 
 # Error raised by {Msf::Modules::Namespace#metasploit_class!} if it cannot the namespace_module does not have a constant

--- a/lib/msf/core/modules/namespace.rb
+++ b/lib/msf/core/modules/namespace.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 require 'metasploit/framework/api/version'
 require 'metasploit/framework/core/version'
 

--- a/lib/msf/core/modules/version_compatibility_error.rb
+++ b/lib/msf/core/modules/version_compatibility_error.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 require 'msf/core/modules/error'
 
 # Error raised by {Msf::Modules::Namespace#version_compatible!} on {Msf::Modules::Loader::Base#create_namespace_module}

--- a/lib/msf/core/payload/windows/prepend_migrate.rb
+++ b/lib/msf/core/payload/windows/prepend_migrate.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 require 'msf/core'
 
 ###

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 require 'active_support/core_ext/numeric/bytes'
 module Msf
 

--- a/lib/msf/core/post/linux.rb
+++ b/lib/msf/core/post/linux.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Post::Linux
   require 'msf/core/post/linux/priv'
   require 'msf/core/post/linux/system'

--- a/lib/msf/core/post/osx.rb
+++ b/lib/msf/core/post/osx.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 
 module Msf::Post::OSX
   require 'msf/core/post/osx/system'

--- a/lib/msf/core/post/osx/ruby_dl.rb
+++ b/lib/msf/core/post/osx/ruby_dl.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf
 class Post
 module OSX

--- a/lib/msf/core/post/solaris.rb
+++ b/lib/msf/core/post/solaris.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 module Msf::Post::Solaris
   require 'msf/core/post/solaris/priv'
   require 'msf/core/post/solaris/system'

--- a/lib/msf/core/post/windows.rb
+++ b/lib/msf/core/post/windows.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 
 module Msf::Post::Windows
   require 'msf/core/post/windows/error'

--- a/lib/msf/core/post/windows/error.rb
+++ b/lib/msf/core/post/windows/error.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 
 module Msf::Post::Windows::Error
   SUCCESS = 0x0000

--- a/lib/msf/ui/logos/test.rb
+++ b/lib/msf/ui/logos/test.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 
 here = File.expand_path(File.dirname(__FILE__))
 

--- a/lib/rex/encoder/bloxor/bloxor.rb
+++ b/lib/rex/encoder/bloxor/bloxor.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 
 require 'rex/poly/machine'
 

--- a/lib/rex/exploitation/ropdb.rb
+++ b/lib/rex/exploitation/ropdb.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 require 'rex/text'
 require 'rexml/document'
 

--- a/lib/rex/mac_oui.rb
+++ b/lib/rex/mac_oui.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 
 module Rex
 module Oui

--- a/lib/rex/parser/outpost24_nokogiri.rb
+++ b/lib/rex/parser/outpost24_nokogiri.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 require "rex/parser/nokogiri_doc_mixin"
 
 module Rex

--- a/lib/rex/poly/machine.rb
+++ b/lib/rex/poly/machine.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 
 module Rex
 

--- a/lib/rex/poly/machine/machine.rb
+++ b/lib/rex/poly/machine/machine.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 
 module Rex
 

--- a/lib/rex/poly/machine/x86.rb
+++ b/lib/rex/poly/machine/x86.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 
 module Rex
 

--- a/lib/rex/proto/ipmi/channel_auth_reply.rb
+++ b/lib/rex/proto/ipmi/channel_auth_reply.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 
 module Rex
 module Proto

--- a/lib/rex/proto/ipmi/open_session_reply.rb
+++ b/lib/rex/proto/ipmi/open_session_reply.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 
 module Rex
 module Proto

--- a/lib/rex/proto/ipmi/rakp2.rb
+++ b/lib/rex/proto/ipmi/rakp2.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 
 module Rex
 module Proto

--- a/lib/rex/proto/pjl.rb
+++ b/lib/rex/proto/pjl.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 # https://en.wikipedia.org/wiki/Printer_Job_Language
 # See external links for PJL spec
 

--- a/lib/rex/proto/pjl/client.rb
+++ b/lib/rex/proto/pjl/client.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 # https://en.wikipedia.org/wiki/Printer_Job_Language
 # See external links for PJL spec
 

--- a/lib/rex/random_identifier_generator.rb
+++ b/lib/rex/random_identifier_generator.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 
 # A quick way to produce unique random strings that follow the rules of
 # identifiers, i.e., begin with a letter and contain only alphanumeric

--- a/lib/rex/sslscan/result.rb
+++ b/lib/rex/sslscan/result.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 
 require 'rex/socket'
 require 'rex/ui/text/table'

--- a/lib/rex/sslscan/scanner.rb
+++ b/lib/rex/sslscan/scanner.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 require 'rex/socket'
 require 'rex/sslscan/result'
 

--- a/lib/rex/ui/text/output/buffer/stdout.rb
+++ b/lib/rex/ui/text/output/buffer/stdout.rb
@@ -1,3 +1,4 @@
+# -*- coding: binary -*-
 # make sure the classes are defined before opening it to define submodule
 require 'rex/ui/text/output'
 require 'rex/ui/text/output/buffer'


### PR DESCRIPTION
This fixes a huge number of hard-to-detect runtime bugs that occur when a default utf-8 string from one of these libraries is passed into a method expecting ascii-8bit. No code changes, just prepends the comment.
