### PR TITLE
Add specs for Rex::Exploitation::EncryptJS

### DIFF
--- a/spec/lib/rex/exploitation/encryptjs_spec.rb
+++ b/spec/lib/rex/exploitation/encryptjs_spec.rb
@@ -1,0 +1,35 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
+require 'rex/exploitation/encryptjs'
+
+describe Rex::Exploitation::EncryptJS do
+
+  let(:code) { "var test = 'metasploit';" }
+  let(:key) { "secret" }
+  let(:signature) { "metasploit" }
+  let(:loader_signature) { "location.search.substring(1);" }
+  let(:loader_key_words) { ['exploit', 'encoded', 'pass', 'decoded'] }
+
+  describe "Rex::Exploitation::EncryptJS.encrypt" do
+    it "returns an String" do
+      expect(Rex::Exploitation::EncryptJS.encrypt(code, key)).to be_an(String)
+    end
+
+    it "returns the JavaScript loader code" do
+      expect(Rex::Exploitation::EncryptJS.encrypt(code, key)).to include(loader_signature)
+    end
+
+    it "encrypts the code" do
+      expect(Rex::Exploitation::EncryptJS.encrypt(code, key)).to_not include(signature)
+    end
+
+    it "obfuscates the loader" do
+      loader_key_words.each do |key_word|
+        expect(Rex::Exploitation::EncryptJS.encrypt(code, key)).to_not include(key_word)
+      end
+    end
+
+  end
+
+end

--- a/spec/lib/rex/exploitation/encryptjs_spec.rb
+++ b/spec/lib/rex/exploitation/encryptjs_spec.rb
@@ -6,9 +6,9 @@ require 'rex/exploitation/encryptjs'
 describe Rex::Exploitation::EncryptJS do
 
   let(:code) { "var test = 'metasploit';" }
-  let(:key) { "secret" }
-  let(:signature) { "metasploit" }
-  let(:loader_signature) { "location.search.substring(1);" }
+  let(:key) { 'secret' }
+  let(:signature) { 'metasploit' }
+  let(:loader_signature) { 'location.search.substring(1);' }
   let(:loader_key_words) { ['exploit', 'encoded', 'pass', 'decoded'] }
 
   describe "Rex::Exploitation::EncryptJS.encrypt" do

--- a/spec/lib/rex/exploitation/encryptjs_spec.rb
+++ b/spec/lib/rex/exploitation/encryptjs_spec.rb
@@ -11,7 +11,7 @@ describe Rex::Exploitation::EncryptJS do
   let(:loader_signature) { 'location.search.substring(1);' }
   let(:loader_key_words) { ['exploit', 'encoded', 'pass', 'decoded'] }
 
-  describe "Rex::Exploitation::EncryptJS.encrypt" do
+  describe ".encrypt" do
     it "returns an String" do
       expect(Rex::Exploitation::EncryptJS.encrypt(code, key)).to be_an(String)
     end


### PR DESCRIPTION
## Verification
- [x] Run rspec for the new specs and ensure there aren't failures:

```
$ rspec spec/lib/rex/exploitation/encryptjs_spec.rb
Rex::Exploitation::EncryptJS ....

Finished in 0.01146 seconds
4 examples, 0 failures

Randomized with seed 40990

Coverage report generated for RSpec to /Users/jvazquez/Projects/Code/metasploit-framework/coverage. 16065 / 91890 LOC (17.48%) covered.
```
- [x] Be sure which Travis is green
