### PR TITLE
Release fixes: Minor caps, grammar, desc fixes

### DIFF
--- a/modules/auxiliary/analyze/jtr_postgres_fast.rb
+++ b/modules/auxiliary/analyze/jtr_postgres_fast.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Auxiliary
         print_status line.chomp
       end
 
-      print_status "Cracked Passwords this run:"
+      print_status "Cracked passwords this run:"
       cracker_instance.each_cracked_password do |password_line|
         password_line.chomp!
         next if password_line.blank?
@@ -113,7 +113,7 @@ class Metasploit3 < Msf::Auxiliary
       end
     end
     hashlist.close
-    print_status "Hashes Written out to #{hashlist.path}"
+    print_status "Hashes written out to #{hashlist.path}"
     hashlist.path
   end
 

--- a/modules/exploits/multi/http/gitlab_shell_exec.rb
+++ b/modules/exploits/multi/http/gitlab_shell_exec.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Exploit::Remote
         ssh keys in the gitlab-shell functionality of Gitlab. Versions
         of gitlab-shell prior to 1.7.4 used the ssh key provided directly
         in a system call resulting in a command injection vulnerability. As
-        this relies on adding an ssh key to an account valid credentials
+        this relies on adding an ssh key to an account, valid credentials
         are required to exploit this vulnerability.
       ),
       'Author'  =>

--- a/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
+++ b/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
@@ -14,7 +14,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'        => 'VMTurbo Operations Manager 4.6 vmtadmin.cgi Remote Command Execution',
+      'Name'        => 'VMTurbo Operations Manager vmtadmin.cgi Remote Command Execution',
       'Description' => %q{
           VMTurbo Operations Manager 4.6 and prior are vulnerable to unauthenticated
           OS Command injection in the web interface. Use reverse payloads for the most
@@ -93,6 +93,16 @@ class Metasploit3 < Msf::Exploit::Remote
       return Exploit::CheckCode::Unknown
     end
 
+    # NOTE (@todb): This PHP style comparison seems incorrect, since
+    # strings are being compared and not numbers. Example:
+    # 1.9.3p547 :001 > a = "4.6"
+    #  => "4.6"
+    # 1.9.3p547 :002 > b = "10.6"
+    #  => "10.6"
+    # 1.9.3p547 :003 > a <= b
+    #
+    # Also, the description says 4.5 is also vuln. This doesn't
+    # appear to care.
     if version and version <= "4.6" and build < "28657"
       return Exploit::CheckCode::Appears
     else

--- a/modules/exploits/windows/local/mqac_write.rb
+++ b/modules/exploits/windows/local/mqac_write.rb
@@ -160,7 +160,7 @@ class Metasploit3 < Msf::Exploit::Local
     session.railgun.ntdll.NtQueryIntervalProfile(1337, 4)
 
     unless is_system?
-      print_error('Exploit failed')
+      print_error('Did not get system, exploit failed')
       return
     end
 

--- a/modules/exploits/windows/local/virtual_box_opengl_escape.rb
+++ b/modules/exploits/windows/local/virtual_box_opengl_escape.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Local
       'Description'    => %q{
         This module exploits a vulnerability in the 3D Acceleration support for VirtualBox. The
         vulnerability exists in the remote rendering of OpenGL-based 3D graphics. By sending a
-        sequence of specially crafted of rendering messages, a virtual machine can exploit an out
+        sequence of specially crafted rendering messages, a virtual machine can exploit an out
         of bounds array access to corrupt memory and escape to the host. This module has been
         tested successfully on Windows 7 SP1 (64 bits) as Host running  Virtual Box 4.3.6.
       },

--- a/modules/post/linux/gather/gnome_commander_creds.rb
+++ b/modules/post/linux/gather/gnome_commander_creds.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Post
           vprint_line(str_file)
           #Store file
           p = store_loot("connections", "text/plain", session, str_file, connections_file, "Gnome-Commander connections")
-          print_good ("Connections file saved to #{p}")
+          print_good("Connections file saved to #{p}")
         rescue EOFError
           # If there's nothing in the file, we hit EOFError
           print_error("Nothing read from file: #{connections_file}, file may be empty")


### PR DESCRIPTION
Incidentally, I believe the `check` method on `modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb` is pretty broken, but not going to pull it or anything right now. It'll false positive on some versions, but doesn't look like it'll false negative on actually exploitable versions.

@wvu-r7 or @cdoughty-r7 please land this before release?
