### PR TITLE
Add specs for Rex::Exploitation::HeapLib

### DIFF
--- a/lib/rex/exploitation/heaplib.rb
+++ b/lib/rex/exploitation/heaplib.rb
@@ -88,8 +88,10 @@ protected
 
     if opts[:newobfu]
       # Obfuscate the javascript using the new lexer method
-      @js = JSObfu.new(@js)
-      return @js.obfuscate
+      js_obfu = JSObfu.new(@js)
+      js_obfu.obfuscate
+      @js = js_obfu.to_s
+      return @js
     elsif opts[:noobfu]
       # Do not obfuscate, let the exploit do the work (useful to avoid double obfuscation)
       return @js

--- a/spec/lib/rex/exploitation/heaplib_spec.rb
+++ b/spec/lib/rex/exploitation/heaplib_spec.rb
@@ -1,0 +1,18 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
+require 'rex/exploitation/heaplib'
+
+describe Rex::Exploitation::HeapLib do
+
+  let(:custom_code) { "var test = 'metasploit';" }
+
+  subject(:heap_lib) do
+    described_class.allocate
+  end
+
+  describe '#initialize' do
+
+  end
+
+end

--- a/spec/lib/rex/exploitation/heaplib_spec.rb
+++ b/spec/lib/rex/exploitation/heaplib_spec.rb
@@ -6,13 +6,61 @@ require 'rex/exploitation/heaplib'
 describe Rex::Exploitation::HeapLib do
 
   let(:custom_code) { "var test = 'metasploit';" }
+  let(:plain_signature) { 'JavaScript Heap Exploitation library' }
+  let(:signature) { 'function(maxAlloc, heapBase)' }
+  let(:methods) {
+    [
+      'lookasideAddr',
+      'lookaside',
+      'flushOleaut32',
+      'freeOleaut32',
+      'allocOleaut32',
+      'paddingStr',
+      'debugBreak',
+      'debugHeap'
+    ]
+  }
 
-  subject(:heap_lib) do
+  subject(:heap_lib_class) do
     described_class.allocate
   end
 
-  describe '#initialize' do
+  subject(:heap_lib) do
+    described_class.new
+  end
 
+  describe "#initialize" do
+    it "returns an String" do
+      expect(heap_lib_class.send(:initialize)).to be_a(String)
+    end
+
+    it "returns the heap lib code" do
+      expect(heap_lib_class.send(:initialize)).to include(signature)
+    end
+
+    it "obfuscates with ObfuscateJS by default" do
+      methods.each do |m|
+        expect(heap_lib_class.send(:initialize)).to_not include(m)
+      end
+    end
+
+    it "allows to provide custom JS code as argument" do
+      expect(heap_lib_class.send(:initialize, custom_code)).to include(custom_code)
+    end
+
+    it "allows to disable obfuscation" do
+      expect(heap_lib_class.send(:initialize, '', {:noobfu => true})).to include(plain_signature)
+    end
+
+    it "allows to use JSObfu for obfuscation" do
+      expect(heap_lib_class.send(:initialize, '', {:newobfu => true})).to_not include(plain_signature)
+    end
+  end
+
+  describe "#to_s" do
+    it "returns the heap lib js code" do
+      expect(heap_lib.to_s).to include(signature)
+    end
   end
 
 end


### PR DESCRIPTION
Adds specs for `Rex::Exploitation::HeapLib`. While developing the specs noticed which the `load_js` behaviour isn't the expected if `opts[:newobfu]` is `true`. This pull request also fixes it.
## Verification
- [x] Use rspec to check new specs

```
$ rspec spec/lib/rex/exploitation/heaplib_spec.rb
Rex::Exploitation::HeapLib .......

Finished in 0.1104 seconds
7 examples, 0 failures

Randomized with seed 35759

Coverage report generated for RSpec to /metasploit-framework/coverage. 16179 / 91892 LOC (17.61%) covered.
```
- [x] Be sure which Travis is green
