### PR TITLE
Deprecate ff 17 svg exploit

### DIFF
--- a/modules/exploits/multi/browser/firefox_svg_plugin.rb
+++ b/modules/exploits/multi/browser/firefox_svg_plugin.rb
@@ -12,6 +12,10 @@ class Metasploit3 < Msf::Exploit::Remote
   include Msf::Exploit::EXE
   include Msf::Exploit::Remote::BrowserAutopwn
   include Msf::Exploit::Remote::FirefoxPrivilegeEscalation
+  include Msf::Module::Deprecated
+
+  DEPRECATION_DATE = Date.new(2014, 10, 17)
+  DEPRECATION_REPLACEMENT = 'exploit/multi/browser/firefox_tostring_console_injection'
 
   autopwn_info({
     :ua_name    => HttpClients::FF,

--- a/modules/exploits/multi/browser/firefox_svg_plugin.rb
+++ b/modules/exploits/multi/browser/firefox_svg_plugin.rb
@@ -10,20 +10,20 @@ class Metasploit3 < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::BrowserExploitServer
   include Msf::Exploit::EXE
-  include Msf::Exploit::Remote::BrowserAutopwn
+  # include Msf::Exploit::Remote::BrowserAutopwn
   include Msf::Exploit::Remote::FirefoxPrivilegeEscalation
   include Msf::Module::Deprecated
 
   DEPRECATION_DATE = Date.new(2014, 10, 17)
   DEPRECATION_REPLACEMENT = 'exploit/multi/browser/firefox_tostring_console_injection'
 
-  autopwn_info({
-    :ua_name    => HttpClients::FF,
-    :ua_minver  => "17.0",
-    :ua_maxver  => "17.0.1",
-    :javascript => true,
-    :rank       => NormalRanking
-  })
+  # autopwn_info({
+  #   :ua_name    => HttpClients::FF,
+  #   :ua_minver  => "17.0",
+  #   :ua_maxver  => "17.0.1",
+  #   :javascript => true,
+  #   :rank       => NormalRanking
+  # })
 
   def initialize(info = {})
     super(update_info(info,


### PR DESCRIPTION
The versions that this exploit supports are encompassed by the `exploit/multi/browser/firefox_tostring_console_injection` exploit.
##### Verification
- [x] Try to `use` the module in msfconsole
- [x] You should see correct deprecation
