### PR TITLE
Fix hashes being stored as passwords in smb_login

### DIFF
--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -172,7 +172,9 @@ class Metasploit3 < Msf::Auxiliary
       module_fullname: self.fullname,
       origin_type: :service,
       private_data: result.credential.private,
-      private_type: :password,
+      private_type: (
+        Rex::Proto::NTLM::Utils.is_pass_ntlm_hash?(result.credential.private) ? :ntlm_hash : :password
+      ),
       username: result.credential.public,
     }.merge(service_data)
 


### PR DESCRIPTION
From @rsmudge in the [redmine bug](https://dev.metasploit.com/redmine/issues/8841):

> Steps to reproduce:
> 1. Dump password hashes on a Windows host
> 2. Create a userpass.txt file with one username/hash per line
> 3. Launch smb_login against the same host
> 4. observe the new "password" entries in the creds table.
