### PR TITLE
Fix a crash when we can't connect to PG

### DIFF
--- a/lib/metasploit/framework/command/base.rb
+++ b/lib/metasploit/framework/command/base.rb
@@ -60,11 +60,6 @@ class Metasploit::Framework::Command::Base
     # the configuration from the parsed options.
     parsed_options.configure(Rails.application)
 
-    # support disabling the database
-    unless parsed_options.options.database.disable
-      Metasploit::Framework::Require.optionally_active_record_railtie
-    end
-
     Rails.application.require_environment!
 
     parsed_options

--- a/lib/metasploit/framework/require.rb
+++ b/lib/metasploit/framework/require.rb
@@ -34,31 +34,6 @@ module Metasploit
         end
       end
 
-      # Tries to `require 'active_record/railtie'` to define the activerecord Rails initializers and rake tasks.
-      #
-      # @example Optionally requiring 'active_record/railtie'
-      #   require 'metasploit/framework/require'
-      #
-      #   class MyClass
-      #     def setup
-      #       if database_enabled
-      #         Metasploit::Framework::Require.optionally_active_record_railtie
-      #       end
-      #     end
-      #   end
-      #
-      # @return [void]
-      def self.optionally_active_record_railtie
-        if ::File.exist?(Rails.application.config.paths['config/database'].first)
-          optionally(
-            'active_record/railtie',
-            'activerecord not in the bundle, so database support will be disabled.'
-          )
-        else
-          warn 'Could not find database.yml, so database support will be disabled.'
-        end
-      end
-
       # Tries to `require 'metasploit/credential/creation'` and include it in the `including_module`.
       #
       # @param including_module [Module] `Class` or `Module` that wants to `include Metasploit::Credential::Creation`.


### PR DESCRIPTION
The ActiveRecord railtie isn't really necessary as far as we can tell. This commit fixes all our currently known no-database woes by the simple expedient of rm'ing it.
#### Verification
- [x] have a database.yml, turn off postgres
  - [x] start msfconsole
  - [x] verify no explosion
  - [x] verify warning that we can't connect
- [x] have no database.yml
  - [x] start msfconsole
  - [x] verify no explosion
- [x] have a database.yml with bad user/pass
  - [x] start msfconsole
  - [x] verify no explosion
  - [x] verify warning that database support will be disabled
- [x] have accurate database.yml
  - [x] start msfconsole
  - [x] verify no explosion
