### PR TITLE
Avoid calling something in the dot-foo domain invalid

### DIFF
--- a/spec/lib/rex/socket/range_walker_spec.rb
+++ b/spec/lib/rex/socket/range_walker_spec.rb
@@ -25,12 +25,12 @@ describe Rex::Socket::RangeWalker do
     end
 
     context "with an invalid hostname" do
-      let(:args) { "@!*^&.foo." }
+      let(:args) { "@!*^&.invalid-hostname-really." }
       it { should_not be_valid }
     end
 
     context "with an invalid hostname and CIDR" do
-      let(:args) { "@!*^&.foo./24" }
+      let(:args) { "@!*^&.invalid-hostname-really./24" }
       it { should_not be_valid }
     end
 


### PR DESCRIPTION
The .foo domain is live now.

I still kinda hate these tests, though, since they fail in wildcard DNS
environments (like OpenDNS).
## Verification
- [ ] Let the spec test run. The invalid hostnames should be invalid
