### PR TITLE
Updated to meterpreter_bins version 0.0.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       bcrypt
       json
       metasploit-model (~> 0.26.1)
-      meterpreter_bins (= 0.0.6)
+      meterpreter_bins (= 0.0.7)
       msgpack
       nokogiri
       packetfu (= 1.1.9)
@@ -78,7 +78,7 @@ GEM
       metasploit-concern (~> 0.1.0)
       metasploit-model (~> 0.26.1)
       pg
-    meterpreter_bins (0.0.6)
+    meterpreter_bins (0.0.7)
     method_source (0.8.2)
     mini_portile (0.6.0)
     msgpack (0.5.8)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 0.26.1'
   # Needed for Meterpreter on Windows, soon others.
-  spec.add_runtime_dependency 'meterpreter_bins', '0.0.6'
+  spec.add_runtime_dependency 'meterpreter_bins', '0.0.7'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # Needed by anemone crawler


### PR DESCRIPTION
This has been a long time coming! Kiwi has been broken for a while and this updated fixes that problem. Details of the binaries build date/commits are in the gemspec in the main `meterpreter_bins` repo.

The key area of success here is the kiwi extension now behaving correctly on patched Windows systems:

```
meterpreter > use kiwi
Loading extension kiwi...

  .#####.   mimikatz 2.0 alpha (x64/win64) release "Kiwi en C"
 .## ^ ##.
 ## / \ ##  /* * *
 ## \ / ##   Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )
 '## v ##'   http://blog.gentilkiwi.com/mimikatz             (oe.eo)
  '#####'    Ported to Metasploit by OJ Reeves `TheColonial` * * */

success.
meterpreter > creds_all
[+] Running as SYSTEM
[*] Retrieving all credentials
all credentials
===============

Domain           User              Password  Auth Id     LM Hash  NTLM Hash
------           ----              --------  -------     -------  ---------
WIN-S45GUQ5KGVK  OJ                <hidden>  0 ; 203898           
WIN-S45GUQ5KGVK  OJ                <hidden>  0 ; 203877           
WORKGROUP        WIN-S45GUQ5KGVK$            0 ; 996              
WORKGROUP        WIN-S45GUQ5KGVK$            0 ; 999              
```
## Verification
- [x] Run `bundle install` and make sure that the `meterpreter_bins` gem is updated to `0.0.7`.
- [x] Create an x86 Meterpreter session and make sure that "stuff continues to work". Preferably do this on a patched Windows system with KB2871997 installed so that the next step is easy to verify.
- [x] Use the `kiwi` extension, run `creds_all`. Watch this work instead of crashing.
- [x] Validate on x64 as well.
