### PR TITLE
Revert "Fix a crash when we can't connect to PG"

### DIFF
--- a/lib/metasploit/framework/command/base.rb
+++ b/lib/metasploit/framework/command/base.rb
@@ -60,6 +60,11 @@ class Metasploit::Framework::Command::Base
     # the configuration from the parsed options.
     parsed_options.configure(Rails.application)
 
+    # support disabling the database
+    unless parsed_options.options.database.disable
+      Metasploit::Framework::Require.optionally_active_record_railtie
+    end
+
     Rails.application.require_environment!
 
     parsed_options

--- a/lib/metasploit/framework/require.rb
+++ b/lib/metasploit/framework/require.rb
@@ -34,6 +34,31 @@ module Metasploit
         end
       end
 
+      # Tries to `require 'active_record/railtie'` to define the activerecord Rails initializers and rake tasks.
+      #
+      # @example Optionally requiring 'active_record/railtie'
+      #   require 'metasploit/framework/require'
+      #
+      #   class MyClass
+      #     def setup
+      #       if database_enabled
+      #         Metasploit::Framework::Require.optionally_active_record_railtie
+      #       end
+      #     end
+      #   end
+      #
+      # @return [void]
+      def self.optionally_active_record_railtie
+        if ::File.exist?(Rails.application.config.paths['config/database'].first)
+          optionally(
+            'active_record/railtie',
+            'activerecord not in the bundle, so database support will be disabled.'
+          )
+        else
+          warn 'Could not find database.yml, so database support will be disabled.'
+        end
+      end
+
       # Tries to `require 'metasploit/credential/creation'` and include it in the `including_module`.
       #
       # @param including_module [Module] `Class` or `Module` that wants to `include Metasploit::Credential::Creation`.


### PR DESCRIPTION
This reverts commit b6deb6a342451e3628f5093bf1a3254500cc7ca3, which was
landed in PR #3673 and summarily busted all CI builds.

Obviously, this is a nonoptimal fix for this new error, but while a
proper fix is being worked on, I'd like to be able to build
successfully.

When the problem introduced by #3673 is fixed, feel free to revert this
commit and then apply the fix.

/cc @jlee-r7 @dmaloney-r7
