### PR TITLE
Remove references to defunct method

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,10 +2,4 @@
 require File.expand_path('../config/application', __FILE__)
 require 'metasploit/framework/require'
 
-# @note must be before `Metasploit::Framework::Application.load_tasks`
-#
-# define db rake tasks from activerecord if activerecord is in the bundle.  activerecord could be not in the bundle if
-# the user installs with `bundle install --without db`
-Metasploit::Framework::Require.optionally_active_record_railtie
-
 Metasploit::Framework::Application.load_tasks


### PR DESCRIPTION
0c9dafff5460f93d28edfc34dc884b1660492856 removed
`optionally_activerecord_railtie`, but missed Rakefile's usage

See #3673
#### Verification
- [x] rake spec
