### PR TITLE
Fix busted rake db, and busted msfconsole when it's a symlink

### DIFF
--- a/lib/metasploit/framework/command/base.rb
+++ b/lib/metasploit/framework/command/base.rb
@@ -60,11 +60,6 @@ class Metasploit::Framework::Command::Base
     # the configuration from the parsed options.
     parsed_options.configure(Rails.application)
 
-    # support disabling the database
-    unless parsed_options.options.database.disable
-      Metasploit::Framework::Require.optionally_active_record_railtie
-    end
-
     Rails.application.require_environment!
 
     parsed_options

--- a/lib/metasploit/framework/command/base.rb
+++ b/lib/metasploit/framework/command/base.rb
@@ -60,6 +60,11 @@ class Metasploit::Framework::Command::Base
     # the configuration from the parsed options.
     parsed_options.configure(Rails.application)
 
+    # support disabling the database
+    unless parsed_options.options.database.disable
+      Metasploit::Framework::Require.optionally_active_record_railtie
+    end
+
     Rails.application.require_environment!
 
     parsed_options

--- a/lib/metasploit/framework/require.rb
+++ b/lib/metasploit/framework/require.rb
@@ -34,6 +34,31 @@ module Metasploit
         end
       end
 
+      # Tries to `require 'active_record/railtie'` to define the activerecord Rails initializers and rake tasks.
+      #
+      # @example Optionally requiring 'active_record/railtie'
+      #   require 'metasploit/framework/require'
+      #
+      #   class MyClass
+      #     def setup
+      #       if database_enabled
+      #         Metasploit::Framework::Require.optionally_active_record_railtie
+      #       end
+      #     end
+      #   end
+      #
+      # @return [void]
+      def self.optionally_active_record_railtie
+        if ::File.exist?(Rails.application.config.paths['config/database'].first)
+          optionally(
+            'active_record/railtie',
+            'activerecord not in the bundle, so database support will be disabled.'
+          )
+        else
+          warn 'Could not find database.yml, so database support will be disabled.'
+        end
+      end
+
       # Tries to `require 'metasploit/credential/creation'` and include it in the `including_module`.
       #
       # @param including_module [Module] `Class` or `Module` that wants to `include Metasploit::Credential::Creation`.

--- a/msfconsole
+++ b/msfconsole
@@ -1,12 +1,8 @@
 #!/usr/bin/env ruby
 # -*- coding: binary -*-
 #
-# $Id$
-#
 # This user interface provides users with a command console interface to the
 # framework.
-#
-# $Revision$
 #
 
 #
@@ -20,7 +16,7 @@ require 'pathname'
 #
 
 # @see https://github.com/rails/rails/blob/v3.2.17/railties/lib/rails/generators/rails/app/templates/script/rails#L3-L5
-require Pathname.new(__FILE__).expand_path.parent.join('config', 'boot')
+require Pathname.new(__FILE__).realpath.expand_path.parent.join('config', 'boot')
 require 'metasploit/framework/command/console'
 
 Metasploit::Framework::Command::Console.start


### PR DESCRIPTION
Fixes two, count 'em _two_, msfconsole crashes.  This is a better fix for #3673.
