### PR TITLE
IP Board Login Scanner Module

### DIFF
--- a/modules/auxiliary/scanner/http/ipboard_login.rb
+++ b/modules/auxiliary/scanner/http/ipboard_login.rb
@@ -48,7 +48,7 @@ class Metasploit3 < Msf::Auxiliary
       # into IP Board
       res = send_request_cgi({
         'uri'     => normalize_uri(target_uri.path),
-        'method'  => 'GET',
+        'method'  => 'GET'
         }, 10)
 
       unless res
@@ -73,7 +73,7 @@ class Metasploit3 < Msf::Auxiliary
         'vars_post'      => {
           'auth_key'     => server_nonce,
           'ips_username' => user,
-          'ips_password' => pass,
+          'ips_password' => pass
         }
         })
 
@@ -94,8 +94,8 @@ class Metasploit3 < Msf::Auxiliary
         register_creds(user, pass, ip)
         return :next_user
       else
-        print_error "Username: #{user} and Password: #{pass} are invalid credentials!"
-        return :skip_user
+        vprint_error "Username: #{user} and Password: #{pass} are invalid credentials!"
+        return nil
       end
 
     rescue ::Timeout::Error

--- a/modules/auxiliary/scanner/http/ipboard_login.rb
+++ b/modules/auxiliary/scanner/http/ipboard_login.rb
@@ -1,5 +1,4 @@
 
-require 'rex/proto/http'
 require 'msf/core'
 
 class Metasploit3 < Msf::Auxiliary
@@ -16,7 +15,7 @@ class Metasploit3 < Msf::Auxiliary
         This module attempts to validate user provided credentials against
         an IP Board web application.
         },
-      'Author'      => 'Christopher Truncer @ChrisTruncer',
+      'Author'      => 'Christopher Truncer chris@christophertruncer.com',
       'License'     => MSF_LICENSE
     )
 
@@ -52,7 +51,7 @@ class Metasploit3 < Msf::Auxiliary
         'method'  => 'GET',
         }, 10)
 
-      if not res
+      unless res
         print_error "No response when trying to connect to #{rhost_or_vhost}"
         return :connection_error
       end
@@ -72,9 +71,9 @@ class Metasploit3 < Msf::Auxiliary
         'uri'     => normalize_uri(target_uri.path, "index.php?app=core&module=global&section=login&do=process"),
         'method'  => 'POST',
         'vars_post'      => {
-          'auth_key' => "#{server_nonce}",
-          'ips_username' => "#{user}",
-          'ips_password' => "#{pass}",
+          'auth_key'     => server_nonce,
+          'ips_username' => user,
+          'ips_password' => pass,
         }
         })
 
@@ -84,10 +83,9 @@ class Metasploit3 < Msf::Auxiliary
       # Iterate over header response.  If the server is setting the ipsconnect and coppa cookie
       # then we were able to log in successfully.  If they are not set, invalid credentials were
       # provided.
-      res2.headers.each do |key, value|
-        if key.include? "Set-Cookie" and value.include? "ipsconnect" and value.include? "coppa"
-          valid_creds = true
-        end
+
+      if res2.get_cookies.include?('ipsconnect') && res2.get_cookies.include?('coppa')
+        valid_creds = true
       end
 
       # Inform the user if the user supplied credentials were valid or not

--- a/modules/auxiliary/scanner/http/ipboard_login.rb
+++ b/modules/auxiliary/scanner/http/ipboard_login.rb
@@ -24,14 +24,6 @@ class Metasploit3 < Msf::Auxiliary
       ], self.class)
   end
 
-  def rhost_or_vhost
-    if datastore['VHOST']
-      return datastore['VHOST']
-    else
-      return rhost
-    end
-  end
-
   def run_host(ip)
     connect
 
@@ -52,7 +44,7 @@ class Metasploit3 < Msf::Auxiliary
         }, 10)
 
       unless res
-        print_error "No response when trying to connect to #{rhost_or_vhost}"
+        print_error "No response when trying to connect to #{vhost}"
         return :connection_error
       end
 
@@ -62,7 +54,7 @@ class Metasploit3 < Msf::Auxiliary
         print_status "Server nonce found, attempting to log in..."
       else
         print_error "Server nonce not present, potentially not an IP Board install or bad URI."
-        print_error "Skipping #{rhost_or_vhost}.."
+        print_error "Skipping #{vhost}.."
         return :abort
       end
 
@@ -99,11 +91,11 @@ class Metasploit3 < Msf::Auxiliary
       end
 
     rescue ::Timeout::Error
-      print_error "Connection timed out while attempting to reach #{rhost_or_vhost}!"
+      print_error "Connection timed out while attempting to reach #{vhost}!"
       return :connection_error
 
     rescue ::Errno::EPIPE
-      print_error "Broken pipe error when connecting to #{rhost_or_vhost}!"
+      print_error "Broken pipe error when connecting to #{vhost}!"
       return :connection_error
     end
   end

--- a/modules/auxiliary/scanner/http/ipboard_login.rb
+++ b/modules/auxiliary/scanner/http/ipboard_login.rb
@@ -1,0 +1,143 @@
+
+require 'rex/proto/http'
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::AuthBrute
+  include Msf::Auxiliary::Scanner
+
+  def initialize
+    super(
+      'Name'        => 'IP Board Login Auxiliary Module',
+      'Description' => %q{
+        This module attempts to validate user provided credentials against
+        an IP Board web application.
+        },
+      'Author'      => 'Christopher Truncer @ChrisTruncer',
+      'License'     => MSF_LICENSE
+    )
+
+    register_options([
+        OptString.new('TARGETURI', [true, "The directory of the IP Board install", "/"]),
+      ], self.class)
+  end
+
+  def rhost_or_vhost
+    if datastore['VHOST']
+      return datastore['VHOST']
+    else
+      return ip
+    end
+  end
+
+  def run_host(ip)
+      connect
+
+      each_user_pass do |user, pass|
+        do_login(user, pass, ip)
+      end
+
+  end
+
+  def do_login(user, pass, ip)
+    begin
+      print_status "Connecting to target, searching for IP Board server nonce..."
+
+      # Perform the initial request and find the server nonce, which is required to log
+      # into IP Board
+      res = send_request_raw({
+        'uri'     => normalize_uri("#{datastore['TARGETURI']}"),
+        'method'  => 'GET',
+        }, 25)
+
+      if not res
+        print_error "Request failed..."
+        return
+      end
+
+      # Grab the key from within the body, or alert that it can't be found and exit out
+      if res.body =~ /name='auth_key'\s+value='.*?((?:[a-z0-9]*))'/i
+        server_nonce = $1
+        print_status "Server nonce found, attempting to log in..."
+      else
+        print_error "Server nonce not present, potentially not an IP Board install or bad URI."
+        print_error "Exiting.."
+        return
+      end
+
+      # With the server nonce found, try to log into IP Board with the user provided creds
+      res2 = send_request_cgi({
+        'uri'     => normalize_uri("#{datastore['TARGETURI']}", "index.php?app=core&module=global&section=login&do=process"),
+        'method'  => 'POST',
+        'vars_post'      => {
+          'auth_key' => "#{server_nonce}",
+          'ips_username' => "#{user}",
+          'ips_password' => "#{pass}",
+        }
+        })
+
+      # Default value of no creds found
+      valid_creds = false
+
+      # Iterate over header response.  If the server is setting the ipsconnect and coppa cookie
+      # then we were able to log in successfully.  If they are not set, invalid credentials were
+      # provided.
+      res2.headers.each do |key, value|
+        if key.include? "Set-Cookie" and value.include? "ipsconnect" and value.include? "coppa"
+          valid_creds = true
+        end
+      end
+
+      # Inform the user if the user supplied credentials were valid or not
+      if valid_creds
+        print_good "Username: #{user} and Password: #{pass} are valid credentials!"
+        register_creds(user, pass, ip)
+        return :next_user
+      else
+        print_error "Username: #{user} and Password: #{pass} are invalid credentials!"
+      end
+
+    rescue ::Timeout::Error, ::Errno::EPIPE
+    end
+  end
+
+  def register_creds(username, password, ipaddr)
+    # Build service information
+    service_data = {
+      address: ipaddr,
+      port: datastore['RPORT'],
+      service_name: 'http',
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    # Build credential information
+    credential_data = {
+      origin_type: :service,
+      module_fullname: self.fullname,
+      private_data: password,
+      private_type: :password,
+      username: username,
+      workspace_id: myworkspace_id
+    }
+
+    credential_data.merge!(service_data)
+    credential_core = create_credential(credential_data)
+
+    # Assemble the options hash for creating the Metasploit::Credential::Login object
+    login_data = {
+      access_level: "user",
+      core: credential_core,
+      last_attempted_at: DateTime.now,
+      status: Metasploit::Model::Login::Status::SUCCESSFUL,
+      workspace_id: myworkspace_id
+    }
+
+    login_data.merge!(service_data)
+    create_credential_login(login_data)
+  end
+
+end

--- a/modules/auxiliary/scanner/http/ipboard_login.rb
+++ b/modules/auxiliary/scanner/http/ipboard_login.rb
@@ -21,7 +21,7 @@ class Metasploit3 < Msf::Auxiliary
     )
 
     register_options([
-        OptString.new('TARGETURI', [true, "The directory of the IP Board install", "/"]),
+        OptString.new('TARGETURI', [true, "The directory of the IP Board install", "/forum/"]),
       ], self.class)
   end
 

--- a/modules/auxiliary/scanner/http/ipboard_login.rb
+++ b/modules/auxiliary/scanner/http/ipboard_login.rb
@@ -64,7 +64,7 @@ class Metasploit3 < Msf::Auxiliary
       else
         print_error "Server nonce not present, potentially not an IP Board install or bad URI."
         print_error "Skipping #{rhost_or_vhost}.."
-        return :skip_user
+        return :abort
       end
 
       # With the server nonce found, try to log into IP Board with the user provided creds

--- a/modules/auxiliary/scanner/http/ipboard_login.rb
+++ b/modules/auxiliary/scanner/http/ipboard_login.rb
@@ -25,21 +25,12 @@ class Metasploit3 < Msf::Auxiliary
       ], self.class)
   end
 
-  def rhost_or_vhost
-    if datastore['VHOST']
-      return datastore['VHOST']
-    else
-      return ip
-    end
-  end
-
   def run_host(ip)
-      connect
+    connect
 
-      each_user_pass do |user, pass|
-        do_login(user, pass, ip)
-      end
-
+    each_user_pass do |user, pass|
+      do_login(user, pass, ip)
+    end
   end
 
   def do_login(user, pass, ip)


### PR DESCRIPTION
This module is an aux module for testing/brute forcing credentials against an IP Board installation.  I based the credentials being stored in the backend db off of aux/scanner/ftp/anonymous.rb since that just landed a day ago.

Hope that this helps!
