### PR TITLE
Credential Gem: Post/Windows/Gather - credential_collector

### DIFF
--- a/modules/post/windows/gather/credentials/credential_collector.rb
+++ b/modules/post/windows/gather/credentials/credential_collector.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Post
       credential_data = {
         origin_type: :session,
         session_id: session_db_id,
-        post_reference_name: self.fullname,
+        post_reference_name: self.refname,
         private_type: :ntlm_hash,
         private_data: hash.lanman + ":" + hash.ntlm,
         username: hash.user_name,


### PR DESCRIPTION
This is a refactor of 'post/windows/gather/credentials/credential_collector.rb'  to support the Metasploit Credential gem as part of Loginpalooza.

**Verification**
- [x] Verify that the database is connected
- [x] Establish Meterpreter on Windows target running in context of target's platform and SYSTEM
- [x] `use post/windows/gather/credentials/credential_collector`
- [x] `set SESSION <session_id_of_meterp_above>`
- [x] `run`
  - [x]  Results including password hashes should be printed to console
- [x]  `creds`
- [x]  **VERIFY** that hash information in the 'Collected hashes..' section of the console output is listed correctly in the output of `creds`

My testing was performed using 'exploit/windows/smb/psexec' with 'windows/meterpreter/reverse_https' against Windows 2008 R2 and Windows 2012 R2.
