### PR TITLE
Credential Gem: Post/Windows/Gather - enum_snmp

### DIFF
--- a/modules/post/windows/gather/enum_snmp.rb
+++ b/modules/post/windows/gather/enum_snmp.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Post
   def community_strings
     comm_str = []
     tbl = Rex::Ui::Text::Table.new(
-      'Header'  => "Comunity Strings",
+      'Header'  => "Community Strings",
       'Indent'  => 1,
       'Columns' =>
       [
@@ -63,33 +63,30 @@ class Metasploit3 < Msf::Post
     if not comm_str.nil? and not comm_str.empty?
       comm_str.each do |c|
 
+        #comm_type is for human display, access_type is passed to the credential
+        #code using labels consistent with the SNMP login scanner
         case registry_getvaldata(key,c)
         when 4
-          comm_type = "READ ONLY"
+          comm_type = 'READ ONLY'
+          access_type = 'read-only'
         when 1
-          comm_type = "DISABLED"
+          comm_type = 'DISABLED'
+          access_type = 'disabled'
         when 2
-          comm_type = "NOTIFY"
+          comm_type = 'NOTIFY'
+          access_type = 'notify'
         when 8
-          comm_type = "READ & WRITE"
+          comm_type = 'READ & WRITE'
+          access_type = 'read-write'
         when 16
-          comm_type = "READ CREATE"
+          comm_type = 'READ CREATE'
+          access_type = 'read-create'
         end
 
         # Save data to table
         tbl << [c,comm_type]
 
-        # Save Community Strings to DB
-        report_auth_info(
-          :host	=> session.sock.peerhost,
-          :port	=> 161,
-          :proto	=> 'udp',
-          :sname	=> 'snmp',
-          :user	=> '',
-          :pass	=> c,
-          :type	=> "snmp.community",
-          :duplicate_ok	=> true
-        )
+        register_creds(session.sock.peerhost, 161, '', c, 'snmp', access_type)
       end
       print_status("")
 
@@ -116,21 +113,13 @@ class Metasploit3 < Msf::Post
     if not trap_hosts.nil? and not trap_hosts.empty?
       trap_hosts.each do |c|
         print_status("Community Name: #{c}")
-        session.framework.db.report_auth_info(
-          :host	=> session.sock.peerhost,
-          :port	=> 161,
-          :proto	=> 'udp',
-          :sname	=> 'snmp',
-          :user	=> '',
-          :pass	=> c,
-          :type	=> "snmp.community",
-          :duplicate_ok	=> true
-        )
+
         t_comm_key = key+"\\"+c
         registry_enumvals(t_comm_key).each do |t|
-          print_status("\tDestination: " + registry_getvaldata(t_comm_key,t))
+          trap_dest = registry_getvaldata(t_comm_key,t)
+          print_status("\tDestination: #{trap_dest}")
+          register_creds(trap_dest, 162, '', c, 'snmptrap', 'trap')
         end
-
       end
     else
       print_status("No Traps are configured")
@@ -151,5 +140,41 @@ class Metasploit3 < Msf::Post
     else
       print_status("\tCommunity Strings can be accessed from any host")
     end
+  end
+
+  def register_creds(client_ip, client_port, user, pass, service_name, access_type)
+    # Build service information
+    service_data = {
+      address: client_ip,
+      port: client_port,
+      service_name: service_name,
+      protocol: 'udp',
+      workspace_id: myworkspace_id
+    }
+
+    # Build credential information
+    credential_data = {
+      access_level: access_type,
+      origin_type: :session,
+      post_reference_name: self.fullname,
+      private_data: pass,
+      private_type: :password,
+      username: user,
+      workspace_id: myworkspace_id
+    }
+
+    credential_data[:session_id] = session.db_record.id if !session.db_record.nil?
+    credential_data.merge!(service_data)
+    credential_core = create_credential(credential_data)
+
+    # Assemble the options hash for creating the Metasploit::Credential::Login object
+    login_data = {
+      core: credential_core,
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      workspace_id: myworkspace_id
+    }
+
+    login_data.merge!(service_data)
+    create_credential_login(login_data)
   end
 end

--- a/modules/post/windows/gather/enum_snmp.rb
+++ b/modules/post/windows/gather/enum_snmp.rb
@@ -157,7 +157,7 @@ class Metasploit3 < Msf::Post
       access_level: access_type,
       origin_type: :session,
       session_id: session_db_id,
-      post_reference_name: self.fullname,
+      post_reference_name: self.refname,
       private_data: pass,
       private_type: :password,
       username: user,

--- a/modules/post/windows/gather/enum_snmp.rb
+++ b/modules/post/windows/gather/enum_snmp.rb
@@ -63,8 +63,8 @@ class Metasploit3 < Msf::Post
     if not comm_str.nil? and not comm_str.empty?
       comm_str.each do |c|
 
-        #comm_type is for human display, access_type is passed to the credential
-        #code using labels consistent with the SNMP login scanner
+        # comm_type is for human display, access_type is passed to the credential
+        # code using labels consistent with the SNMP login scanner
         case registry_getvaldata(key,c)
         when 4
           comm_type = 'READ ONLY'
@@ -86,7 +86,7 @@ class Metasploit3 < Msf::Post
         # Save data to table
         tbl << [c,comm_type]
 
-        register_creds(session.sock.peerhost, 161, '', c, 'snmp', access_type)
+        register_creds(session.session_host, 161, '', c, 'snmp', access_type)
       end
       print_status("")
 
@@ -156,6 +156,7 @@ class Metasploit3 < Msf::Post
     credential_data = {
       access_level: access_type,
       origin_type: :session,
+      session_id: session_db_id,
       post_reference_name: self.fullname,
       private_data: pass,
       private_type: :password,
@@ -163,7 +164,6 @@ class Metasploit3 < Msf::Post
       workspace_id: myworkspace_id
     }
 
-    credential_data[:session_id] = session.db_record.id if !session.db_record.nil?
     credential_data.merge!(service_data)
     credential_core = create_credential(credential_data)
 


### PR DESCRIPTION
This is a refactor of 'post/windows/gather/enum_snmp.rb'  to support the Metasploit Credential gem as part of Loginpalooza.

Testing the PR requires a target that has SNMP installed and configured. The following links provide instructions on how to do this on Windows 2008 R2
1. Install SNMP
   a. From an Administrative command line run `Dism /online /enable-feature /featurename:SNMP`
2. Configure SNMP
   a. From the same command line, run `services.msc`
   b. Locate 'SNMP Service' in the list and double click on it
   c. On the Traps tab, type the name of a test trap in the Community Name field, click Add to list
   d. Click the Add button under Trap destinations, enter a destination IP, and click the Add button
   e. Click Apply
   f. On the Security tab, click the Add button under Accepted community names
   g. Select a level of access rights from the Community rights drop down
   h. Enter a test community name and click the Add button
   i. Repeat f through h as desired
   j. To add an additional destination click the Add button under Accept SNMP packets from these hosts
   k. Enter a destination IP and click Add
   l. Click Ok

**Verification**
- [ ] Verify that the database is connected
- [ ] Establish Meterpreter on Windows target running in context of target's platform and SYSTEM
- [ ] `use post/windows/gather/enum_snmp`
- [ ] `set SESSION <session_id_of_meterp_above>`
- [ ] `run`
  - [ ]  Results including human readable information about community strings and traps to remote hosts
- [ ]  `creds`
- [ ]  **VERIFY** that the community strings are all listed against the target host
- [ ]  **VERIFY** that the snmp traps are all listed against the destination host and show the correct string

My testing was performed using 'exploit/windows/smb/psexec' with 'windows/meterpreter/reverse_https' against Windows 2008 R2.
