### PR TITLE
Fix regression where msfconsole.rc wasn't loading

### DIFF
--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -15,12 +15,9 @@ module Msf
 module Ui
 module Console
 
-###
 #
-# This class implements a user interface driver on a console interface.
+# A user interface driver on a console interface.
 #
-###
-
 class Driver < Msf::Ui::Driver
 
   ConfigCore  = "framework/core"
@@ -44,21 +41,18 @@ class Driver < Msf::Ui::Driver
   # prompt character.  The optional hash can take extra values that will
   # serve to initialize the console driver.
   #
-  # The optional hash values can include:
-  #
-  # AllowCommandPassthru
-  #
-  # 	Whether or not unknown commands should be passed through and executed by
-  # 	the local system.
-  #
-  # RealReadline
-  #
-  # 	Whether or to use the system Readline or the RBReadline (default)
-  #
-  # HistFile
-  #
-  #	Name of a file to store command history
-  #
+  # @option opts [Boolean] 'AllowCommandPassthru' (true) Whether to allow
+  #   unrecognized commands to be executed by the system shell
+  # @option opts [Boolean] 'RealReadline' (false) Whether to use the system's
+  #   readline library instead of RBReadline
+  # @option opts [String] 'HistFile' (Msf::Config.history_file) Path to a file
+  #   where we can store command history
+  # @option opts [Array<String>] 'Resources' ([]) A list of resource files to
+  #   load. If no resources are given, will load the default resource script,
+  #   'msfconsole.rc' in the user's {Msf::Config.config_directory config
+  #   directory}
+  # @option opts [Boolean] 'SkipDatabaseInit' (false) Whether to skip
+  #   connecting to the database and running migrations
   def initialize(prompt = DefaultPrompt, prompt_char = DefaultPromptChar, opts = {})
 
     # Choose a readline library before calling the parent
@@ -253,14 +247,14 @@ class Driver < Msf::Ui::Driver
     # Process things before we actually display the prompt and get rocking
     on_startup(opts)
 
-    # Process the resource script
-    if opts['Resource'] and opts['Resource'].kind_of? Array
+    # Process any resource scripts
+    if opts['Resource'].empty?
+      # None given, load the default
+      load_resource(File.join(Msf::Config.config_directory, 'msfconsole.rc'))
+    else
       opts['Resource'].each { |r|
         load_resource(r)
       }
-    else
-      # If the opt is nil here, we load ~/.msf3/msfconsole.rc
-      load_resource(opts['Resource'])
     end
 
     # Process any additional startup commands
@@ -433,11 +427,11 @@ class Driver < Msf::Ui::Driver
     end
   end
 
+  # Processes a resource script file for the console.
   #
-  # Processes the resource script file for the console.
-  #
-  def load_resource(path=nil)
-    path ||= File.join(Msf::Config.config_directory, 'msfconsole.rc')
+  # @param path [String] Path to a resource file to run
+  # @return [void]
+  def load_resource(path)
     return if not ::File.readable?(path)
     resource_file = ::File.read(path)
 
@@ -605,9 +599,9 @@ class Driver < Msf::Ui::Driver
   # The framework instance associated with this driver.
   #
   attr_reader   :framework
-  #  
+  #
   # Whether or not to confirm before exiting
-  #  
+  #
   attr_reader   :confirm_exit
   #
   # Whether or not commands can be passed through.


### PR DESCRIPTION
Noticed by @kernelsmith and mentioned in IRC.
#### Verification
- [x] if you don't have an existing msfconsole.rc, `echo 'version' > ~/.msf4/msfconsole.rc`
- [x] start msfconsole
- [x] **VERIFY** you see output from `version` command
