### PR TITLE
fix for oracle_login not checking connection status

### DIFF
--- a/modules/auxiliary/admin/oracle/oracle_login.rb
+++ b/modules/auxiliary/admin/oracle/oracle_login.rb
@@ -44,16 +44,17 @@ class Metasploit3 < Msf::Auxiliary
     print_status("Starting brute force on #{datastore['RHOST']}:#{datastore['RPORT']}...")
 
     fd = CSV.foreach(list) do |brute|
+      datastore['DBUSER'] = brute[2].downcase
+      datastore['DBPASS'] = brute[3].downcase
 
-    datastore['DBUSER'] = brute[2].downcase
-    datastore['DBPASS'] = brute[3].downcase
-
-    begin
-      connect
-      disconnect
-    rescue ::OCIError => e
-      break if e.to_s =~ /^ORA-12170:\s/
-      unless e
+      begin
+        connect
+        disconnect
+      rescue ::OCIError => e
+        if e.to_s =~ /^ORA-12170:\s/
+          print_error("#{datastore['RHOST']}:#{datastore['RPORT']} Connection timed out")
+          break
+        else
           report_auth_info(
             :host  => "#{datastore['RHOST']}",
             :port  => "#{datastore['RPORT']}",
@@ -63,8 +64,8 @@ class Metasploit3 < Msf::Auxiliary
             :active => true
           )
           print_status("Found user/pass of: #{datastore['DBUSER']}/#{datastore['DBPASS']} on #{datastore['RHOST']} with sid #{datastore['SID']}")
+        end
       end
     end
-    end
   end
-end
+end #class

--- a/modules/auxiliary/admin/oracle/oracle_login.rb
+++ b/modules/auxiliary/admin/oracle/oracle_login.rb
@@ -52,10 +52,8 @@ class Metasploit3 < Msf::Auxiliary
       connect
       disconnect
     rescue ::OCIError => e
-      if (e.to_s == 'ORA-12170: TNS:Connect timeout occurred')
-        break
-      else
-        if (not e)
+      break if e.to_s =~ /^ORA-12170:\s/
+      unless e
           report_auth_info(
             :host  => "#{datastore['RHOST']}",
             :port  => "#{datastore['RPORT']}",
@@ -65,8 +63,7 @@ class Metasploit3 < Msf::Auxiliary
             :active => true
           )
           print_status("Found user/pass of: #{datastore['DBUSER']}/#{datastore['DBPASS']} on #{datastore['RHOST']} with sid #{datastore['SID']}")
-        end
-     end
+      end
     end
     end
   end

--- a/modules/auxiliary/admin/oracle/oracle_login.rb
+++ b/modules/auxiliary/admin/oracle/oracle_login.rb
@@ -68,4 +68,4 @@ class Metasploit3 < Msf::Auxiliary
       end
     end
   end
-end #class
+end

--- a/modules/auxiliary/admin/oracle/oracle_login.rb
+++ b/modules/auxiliary/admin/oracle/oracle_login.rb
@@ -52,6 +52,8 @@ class Metasploit3 < Msf::Auxiliary
       connect
       disconnect
     rescue ::OCIError => e
+      if (e.to_s == 'ORA-12170: TNS:Connect timeout occurred')
+        break
       else
         if (not e)
           report_auth_info(
@@ -64,6 +66,7 @@ class Metasploit3 < Msf::Auxiliary
           )
           print_status("Found user/pass of: #{datastore['DBUSER']}/#{datastore['DBPASS']} on #{datastore['RHOST']} with sid #{datastore['SID']}")
         end
+     end
     end
     end
   end

--- a/modules/auxiliary/admin/oracle/oracle_login.rb
+++ b/modules/auxiliary/admin/oracle/oracle_login.rb
@@ -54,7 +54,7 @@ class Metasploit3 < Msf::Auxiliary
         if e.to_s =~ /^ORA-12170:\s/
           print_error("#{datastore['RHOST']}:#{datastore['RPORT']} Connection timed out")
           break
-        else
+        elsif not e
           report_auth_info(
             :host  => "#{datastore['RHOST']}",
             :port  => "#{datastore['RPORT']}",


### PR DESCRIPTION
Was using my resource script (oracle_login.rc) and noticed that it was taking a very long time and in investigating why discovered that oracle_login.rb doesn't check for any Oracle error messages when it rescues, so if for example the connection times out on the first brute force try, it will try N times (and have to wait through N timeouts), where N is the number of usernames/passwords you have it guessing.

This patch just has it check to see if Oracle specifically states the connection was timed out and if so, break so that the rest of the usernames/passwords are not tried, resulting in a speed up when the host is down.
