### PR TITLE
Fix usage of deprecated be_false in specs

### DIFF
--- a/spec/lib/active_record/connection_adapters/abstract_adapter/connection_pool_spec.rb
+++ b/spec/lib/active_record/connection_adapters/abstract_adapter/connection_pool_spec.rb
@@ -51,7 +51,7 @@ describe ActiveRecord::ConnectionAdapters::ConnectionPool do
       it 'should be false' do
         thread = Thread.new do
           Thread.current.should_not == main_thread
-          expect(active_connection?).to be_false
+          expect(active_connection?).to be_falsey
         end
 
         thread.join
@@ -129,7 +129,7 @@ describe ActiveRecord::ConnectionAdapters::ConnectionPool do
 
     context 'without active thread connection' do
       it 'should return false from #active_connection?' do
-        expect(connection_pool.active_connection?).to be_false
+        expect(connection_pool.active_connection?).to be_falsey
       end
 
       context 'with error' do

--- a/spec/lib/fastlib_spec.rb
+++ b/spec/lib/fastlib_spec.rb
@@ -69,7 +69,7 @@ describe FastLib do
         end
 
         it 'should create an archive' do
-          File.exist?(@destination_path).should be_false
+          File.exist?(@destination_path).should be_falsey
 
           described_class.dump(@destination_path, flag_string, base_path, *unarchived_paths)
 
@@ -127,7 +127,7 @@ describe FastLib do
         end
 
         it 'should create an archive' do
-          File.exist?(@destination_path).should be_false
+          File.exist?(@destination_path).should be_falsey
 
           described_class.dump(@destination_path, flag_string, base_path, *unarchived_paths)
 
@@ -138,8 +138,8 @@ describe FastLib do
           uncompressed_path = "#{@destination_path}.uncompressed"
           compressed_path = "#{@destination_path}.compressed"
 
-          File.exist?(uncompressed_path).should be_false
-          File.exist?(compressed_path).should be_false
+          File.exist?(uncompressed_path).should be_falsey
+          File.exist?(compressed_path).should be_falsey
 
           described_class.dump(uncompressed_path, '', base_path, *unarchived_paths)
           described_class.dump(compressed_path, flag_string, base_path, *unarchived_paths)
@@ -157,7 +157,7 @@ describe FastLib do
         end
 
         it 'should create an archive' do
-          File.exist?(@destination_path).should be_false
+          File.exist?(@destination_path).should be_falsey
 
           described_class.dump(@destination_path, flag_string, base_path, *unarchived_paths)
 
@@ -171,7 +171,7 @@ describe FastLib do
         end
 
         it 'should create an archive' do
-          File.exist?(@destination_path).should be_false
+          File.exist?(@destination_path).should be_falsey
 
           described_class.dump(@destination_path, flag_string, base_path, *unarchived_paths)
 

--- a/spec/lib/metasploit/framework/login_scanner/result_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/result_spec.rb
@@ -36,7 +36,7 @@ describe Metasploit::Framework::LoginScanner::Result do
     context 'when the status code is anything else' do
       let(:status) { :connection_error }
       it 'returns false' do
-        expect(login_result.success?).to be_false
+        expect(login_result.success?).to be_falsey
       end
     end
   end

--- a/spec/lib/msf/core/exploit/cmdstager_spec.rb
+++ b/spec/lib/msf/core/exploit/cmdstager_spec.rb
@@ -358,7 +358,7 @@ describe Msf::Exploit::CmdStager do
         end
 
         it "isn't compatible" do
-          expect(subject.compatible_flavor?(flavor)).to be_false
+          expect(subject.compatible_flavor?(flavor)).to be_falsey
         end
       end
     end
@@ -385,7 +385,7 @@ describe Msf::Exploit::CmdStager do
         end
 
         it "isn't compatible" do
-          expect(subject.compatible_flavor?(flavor)).to be_false
+          expect(subject.compatible_flavor?(flavor)).to be_falsey
         end
       end
     end
@@ -412,7 +412,7 @@ describe Msf::Exploit::CmdStager do
         end
 
         it "isn't compatible" do
-          expect(subject.compatible_flavor?(flavor)).to be_false
+          expect(subject.compatible_flavor?(flavor)).to be_falsey
         end
       end
 

--- a/spec/lib/msf/core/exploit/powershell_spec.rb
+++ b/spec/lib/msf/core/exploit/powershell_spec.rb
@@ -108,7 +108,7 @@ describe Msf::Exploit::Powershell do
       it 'should substitute variables' do
         script = File.read(example_script)
         compressed = subject.compress_script(script)
-        decompress(compressed).include?('$hashes').should be_false
+        decompress(compressed).include?('$hashes').should be_falsey
       end
     end
 
@@ -132,7 +132,7 @@ describe Msf::Exploit::Powershell do
       it 'should substitute functions' do
         script = File.read(example_script)
         compressed = subject.compress_script(script)
-        decompress(compressed).include?('DumpHashes').should be_false
+        decompress(compressed).include?('DumpHashes').should be_falsey
       end
     end
 
@@ -228,7 +228,7 @@ describe Msf::Exploit::Powershell do
       end
       it 'shouldnt add a persistance loop' do
         code = subject.cmd_psh_payload(payload, arch)
-        decompress(code).include?('while(1){Start-Sleep -s ').should be_false
+        decompress(code).include?('while(1){Start-Sleep -s ').should be_falsey
       end
     end
 
@@ -250,7 +250,7 @@ describe Msf::Exploit::Powershell do
       end
       it 'shouldnt prepend sleep' do
         code = subject.cmd_psh_payload(payload, arch)
-        decompress(code).include?('Start-Sleep -s ').should be_false
+        decompress(code).include?('Start-Sleep -s ').should be_falsey
       end
     end
 
@@ -261,7 +261,7 @@ describe Msf::Exploit::Powershell do
       end
       it 'shouldnt prepend sleep' do
         code = subject.cmd_psh_payload(payload, arch)
-        decompress(code).include?('Start-Sleep -s ').should be_false
+        decompress(code).include?('Start-Sleep -s ').should be_falsey
       end
     end
 
@@ -365,15 +365,15 @@ describe Msf::Exploit::Powershell do
         it 'should contain a final payload with -e' do
           code = subject.cmd_psh_payload(payload, arch, {:encode_final_payload => true, :no_equals => false})
           code.include?(' -e ').should be_true
-          code.include?(' -c ').should be_false
+          code.include?(' -c ').should be_falsey
         end
       end
       context 'when no_equals is true' do
         it 'should contain a final payload with -e' do
           code = subject.cmd_psh_payload(payload, arch, {:encode_final_payload => true, :no_equals => true})
           code.include?(' -e ').should be_true
-          code.include?(' -c ').should be_false
-          code.include?('=').should be_false
+          code.include?(' -c ').should be_falsey
+          code.include?('=').should be_falsey
         end
       end
       context 'when encode_inner_payload is true' do
@@ -392,7 +392,7 @@ describe Msf::Exploit::Powershell do
     context 'when remove_comspec' do
       it 'shouldnt contain %COMSPEC%' do
         code = subject.cmd_psh_payload(payload, arch, {:remove_comspec => true})
-        code.include?('%COMSPEC%').should be_false
+        code.include?('%COMSPEC%').should be_falsey
       end
     end
 

--- a/spec/lib/msf/core/module_spec.rb
+++ b/spec/lib/msf/core/module_spec.rb
@@ -10,7 +10,7 @@ shared_examples "search_filter" do |opts|
   accept.each do |query|
     it "should accept a query containing '#{query}'" do
       # if the subject matches, search_filter returns false ("don't filter me out!")
-      subject.search_filter(query).should be_false
+      subject.search_filter(query).should be_falsey
     end
 
     unless opts.has_key?(:test_inverse) and not opts[:test_inverse]

--- a/spec/lib/msf/core/modules/loader/archive_spec.rb
+++ b/spec/lib/msf/core/modules/loader/archive_spec.rb
@@ -127,7 +127,7 @@ describe Msf::Modules::Loader::Archive do
       end
 
       it 'should ignore types that are not enabled' do
-        module_manager.type_enabled?(disabled_type).should be_false
+        module_manager.type_enabled?(disabled_type).should be_falsey
 
         subject.send(:each_module_reference_name, @archive_path) do |parent_path, type, module_reference_name|
           type.should_not == disabled_type
@@ -180,7 +180,7 @@ describe Msf::Modules::Loader::Archive do
 
         path.should include(described_class::ARCHIVE_EXTENSION)
         File.extname(path).should_not == described_class::ARCHIVE_EXTENSION
-        subject.loadable?(path).should be_false
+        subject.loadable?(path).should be_falsey
       end
     end
 

--- a/spec/lib/msf/core/modules/loader/base_spec.rb
+++ b/spec/lib/msf/core/modules/loader/base_spec.rb
@@ -268,7 +268,7 @@ describe Msf::Modules::Loader::Base do
         end
 
         it 'should return false if :force is false' do
-          subject.load_module(parent_path, type, module_reference_name, :force => false).should be_false
+          subject.load_module(parent_path, type, module_reference_name, :force => false).should be_falsey
         end
 
         it 'should not call #read_module_content' do
@@ -352,7 +352,7 @@ describe Msf::Modules::Loader::Base do
 
           # if the module eval error includes the module_path then the module_path was passed along correctly
           subject.should_receive(:elog).with(/#{Regexp.escape(module_path)}/)
-          subject.load_module(parent_path, type, module_reference_name, :reload => true).should be_false
+          subject.load_module(parent_path, type, module_reference_name, :reload => true).should be_falsey
         end
 
         context 'with empty module content' do
@@ -361,12 +361,12 @@ describe Msf::Modules::Loader::Base do
           end
 
           it 'should return false' do
-            subject.load_module(parent_path, type, module_reference_name).should be_false
+            subject.load_module(parent_path, type, module_reference_name).should be_falsey
           end
 
           it 'should not attempt to make a new namespace_module' do
             subject.should_not_receive(:namespace_module_transaction)
-            subject.load_module(parent_path, type, module_reference_name).should be_false
+            subject.load_module(parent_path, type, module_reference_name).should be_falsey
           end
         end
 
@@ -426,7 +426,7 @@ describe Msf::Modules::Loader::Base do
 
               it 'should record the load error using the original error' do
                 subject.should_receive(:load_error).with(module_path, error)
-                subject.load_module(parent_path, type, module_reference_name).should be_false
+                subject.load_module(parent_path, type, module_reference_name).should be_falsey
               end
             end
 
@@ -457,14 +457,14 @@ describe Msf::Modules::Loader::Base do
 
               it 'should record the load error using the Msf::Modules::VersionCompatibilityError' do
                 subject.should_receive(:load_error).with(module_path, version_compatibility_error)
-                subject.load_module(parent_path, type, module_reference_name).should be_false
+                subject.load_module(parent_path, type, module_reference_name).should be_falsey
               end
             end
 
             it 'should return false' do
               @namespace_module.stub(:version_compatible!).with(module_path, module_reference_name)
 
-              subject.load_module(parent_path, type, module_reference_name).should be_false
+              subject.load_module(parent_path, type, module_reference_name).should be_falsey
             end
           end
         end
@@ -520,11 +520,11 @@ describe Msf::Modules::Loader::Base do
 
             it 'should record the load error' do
               subject.should_receive(:load_error).with(module_path, version_compatibility_error)
-              subject.load_module(parent_path, type, module_reference_name).should be_false
+              subject.load_module(parent_path, type, module_reference_name).should be_falsey
             end
 
             it 'should return false' do
-              subject.load_module(parent_path, type, module_reference_name).should be_false
+              subject.load_module(parent_path, type, module_reference_name).should be_falsey
             end
 
             it 'should restore the old namespace module' do
@@ -558,15 +558,15 @@ describe Msf::Modules::Loader::Base do
                     module_path,
                     kind_of(Msf::Modules::MetasploitClassCompatibilityError)
                 )
-                subject.load_module(parent_path, type, module_reference_name).should be_false
+                subject.load_module(parent_path, type, module_reference_name).should be_falsey
               end
 
               it 'should return false' do
-                subject.load_module(parent_path, type, module_reference_name).should be_false
+                subject.load_module(parent_path, type, module_reference_name).should be_falsey
               end
 
               it 'should restore the old namespace module' do
-                subject.load_module(parent_path, type, module_reference_name).should be_false
+                subject.load_module(parent_path, type, module_reference_name).should be_falsey
                 Msf::Modules.const_defined?(relative_name).should be_true
                 Msf::Modules.const_get(relative_name).should == @original_namespace_module
               end
@@ -593,15 +593,15 @@ describe Msf::Modules::Loader::Base do
 
                 it 'should log information' do
                   subject.should_receive(:ilog).with(/#{module_reference_name}/, 'core', LEV_1)
-                  subject.load_module(parent_path, type, module_reference_name).should be_false
+                  subject.load_module(parent_path, type, module_reference_name).should be_falsey
                 end
 
                 it 'should return false' do
-                  subject.load_module(parent_path, type, module_reference_name).should be_false
+                  subject.load_module(parent_path, type, module_reference_name).should be_falsey
                 end
 
                 it 'should restore the old namespace module' do
-                  subject.load_module(parent_path, type, module_reference_name).should be_false
+                  subject.load_module(parent_path, type, module_reference_name).should be_falsey
                   Msf::Modules.const_defined?(relative_name).should be_true
                   Msf::Modules.const_get(relative_name).should == @original_namespace_module
                 end
@@ -654,7 +654,7 @@ describe Msf::Modules::Loader::Base do
                   it 'should set the count to 1 if it does not exist' do
                     count_by_type = {}
 
-                    count_by_type.has_key?(type).should be_false
+                    count_by_type.has_key?(type).should be_falsey
                     subject.load_module(
                         parent_path,
                         type,
@@ -802,7 +802,7 @@ describe Msf::Modules::Loader::Base do
       end
 
       it 'should return nil if the module is not defined' do
-        Msf::Modules.const_defined?(relative_name).should be_false
+        Msf::Modules.const_defined?(relative_name).should be_falsey
         subject.send(:current_module, module_names).should be_nil
       end
 
@@ -838,7 +838,7 @@ describe Msf::Modules::Loader::Base do
       it 'should return false if path is hidden' do
         hidden_path = '.hidden/path/file.rb'
 
-        subject.send(:module_path?, hidden_path).should be_false
+        subject.send(:module_path?, hidden_path).should be_falsey
       end
 
       it 'should return false if the file extension is not MODULE_EXTENSION' do
@@ -846,7 +846,7 @@ describe Msf::Modules::Loader::Base do
         path = "path/with/wrong/extension#{non_module_extension}"
 
         non_module_extension.should_not == described_class::MODULE_EXTENSION
-        subject.send(:module_path?, path).should be_false
+        subject.send(:module_path?, path).should be_falsey
       end
 
       it 'should return false if the file is a unit test' do

--- a/spec/lib/msf/core/modules/loader/base_spec.rb
+++ b/spec/lib/msf/core/modules/loader/base_spec.rb
@@ -853,14 +853,14 @@ describe Msf::Modules::Loader::Base do
         unit_test_extension = '.rb.ut.rb'
         path = "path/to/unit_test#{unit_test_extension}"
 
-        subject.send(:module_path?, path).should be_false
+        subject.send(:module_path?, path).should be_falsey
       end
 
       it 'should return false if the file is a test suite' do
         test_suite_extension = '.rb.ts.rb'
         path = "path/to/test_suite#{test_suite_extension}"
 
-        subject.send(:module_path?, path).should be_false
+        subject.send(:module_path?, path).should be_falsey
       end
 
       it 'should return true otherwise' do
@@ -1022,7 +1022,7 @@ describe Msf::Modules::Loader::Base do
           it 'should return false' do
             subject.send(:namespace_module_transaction, module_full_name) { |namespace_module|
               false
-            }.should be_false
+            }.should be_falsey
           end
         end
 
@@ -1077,7 +1077,7 @@ describe Msf::Modules::Loader::Base do
           end
 
           it 'should remove the created namespace module' do
-            Msf::Modules.const_defined?(relative_name).should be_false
+            Msf::Modules.const_defined?(relative_name).should be_falsey
 
             begin
               subject.send(:namespace_module_transaction, module_full_name) do |namespace_module|
@@ -1088,7 +1088,7 @@ describe Msf::Modules::Loader::Base do
             rescue error_class
             end
 
-            Msf::Modules.const_defined?(relative_name).should be_false
+            Msf::Modules.const_defined?(relative_name).should be_falsey
           end
 
           it 'should re-raise the error' do
@@ -1102,7 +1102,7 @@ describe Msf::Modules::Loader::Base do
 
         context 'with the block returning false' do
           it 'should remove the created namespace module' do
-            Msf::Modules.const_defined?(relative_name).should be_false
+            Msf::Modules.const_defined?(relative_name).should be_falsey
 
             subject.send(:namespace_module_transaction, module_full_name) do |namespace_module|
               Msf::Modules.const_defined?(relative_name).should be_true
@@ -1110,19 +1110,19 @@ describe Msf::Modules::Loader::Base do
               false
             end
 
-            Msf::Modules.const_defined?(relative_name).should be_false
+            Msf::Modules.const_defined?(relative_name).should be_falsey
           end
 
           it 'should return false' do
             subject.send(:namespace_module_transaction, module_full_name) { |namespace_module|
               false
-            }.should be_false
+            }.should be_falsey
           end
         end
 
         context 'with the block returning true' do
           it 'should not restore the non-existent previous namespace module' do
-            Msf::Modules.const_defined?(relative_name).should be_false
+            Msf::Modules.const_defined?(relative_name).should be_falsey
 
             created_namespace_module = nil
 
@@ -1281,7 +1281,7 @@ describe Msf::Modules::Loader::Base do
 
         context 'without relative_name being a defined constant' do
           it 'should set relative_name on parent_module to namespace_module' do
-            parent_module.const_defined?(relative_name).should be_false
+            parent_module.const_defined?(relative_name).should be_falsey
 
             subject.send(:restore_namespace_module, parent_module, relative_name, @original_namespace_module)
 
@@ -1340,7 +1340,7 @@ describe Msf::Modules::Loader::Base do
           end
 
           it 'should return false' do
-            subject.send(:usable?, metasploit_class).should be_false
+            subject.send(:usable?, metasploit_class).should be_falsey
           end
         end
       end

--- a/spec/lib/msf/core/modules/loader/directory_spec.rb
+++ b/spec/lib/msf/core/modules/loader/directory_spec.rb
@@ -74,7 +74,7 @@ describe Msf::Modules::Loader::Directory do
             end
 
             it 'should not load the module' do
-              subject.load_module(parent_path, type, module_reference_name).should be_false
+              subject.load_module(parent_path, type, module_reference_name).should be_falsey
             end
           end
 
@@ -89,7 +89,7 @@ describe Msf::Modules::Loader::Directory do
             end
 
             it 'should not load the module' do
-              subject.load_module(parent_path, type, module_reference_name).should be_false
+              subject.load_module(parent_path, type, module_reference_name).should be_falsey
             end
           end
         end
@@ -110,7 +110,7 @@ describe Msf::Modules::Loader::Directory do
         end
 
         it 'should not raise an error' do
-          File.exist?(module_path).should be_false
+          File.exist?(module_path).should be_falsey
 
           expect {
             subject.load_module(parent_path, type, module_reference_name)
@@ -118,9 +118,9 @@ describe Msf::Modules::Loader::Directory do
         end
 
         it 'should return false' do
-          File.exist?(module_path).should be_false
+          File.exist?(module_path).should be_falsey
 
-          subject.load_module(parent_path, type, module_reference_name).should be_false
+          subject.load_module(parent_path, type, module_reference_name).should be_falsey
         end
       end
     end
@@ -138,7 +138,7 @@ describe Msf::Modules::Loader::Directory do
         # this ensures that the File.exist?(module_path) checks are checking the same path as the code under test
         it 'should attempt to open the expected module_path' do
           File.should_receive(:open).with(module_path, 'rb')
-          File.exist?(module_path).should be_false
+          File.exist?(module_path).should be_falsey
 
           subject.send(:read_module_content, parent_path, type, module_reference_name)
         end

--- a/spec/lib/msf/core/modules/namespace_spec.rb
+++ b/spec/lib/msf/core/modules/namespace_spec.rb
@@ -179,7 +179,7 @@ describe Msf::Modules::Namespace do
   context 'version_compatible!' do
     context 'without RequiredVersions' do
       it 'should not be defined' do
-        subject.const_defined?('RequiredVersions').should be_false
+        subject.const_defined?('RequiredVersions').should be_falsey
       end
 
       it 'should not raise an error' do

--- a/spec/lib/rex/exploitation/powershell/obfu_spec.rb
+++ b/spec/lib/rex/exploitation/powershell/obfu_spec.rb
@@ -209,7 +209,7 @@ lots \t of   whitespace
       subject_no_literal.code.should be
       subject_no_literal.code.should be_kind_of String
       subject_no_literal.code.include?('Find-4624Logons').should be_falsey
-      subject_no_literal.code.include?('lots of whitespace').should be_falsey
+      subject_no_literal.code.include?('lots of whitespace').should be_true
       subject_no_literal.code.include?('$kernel32').should be_falsey
       subject_no_literal.code.include?('comment').should be_falsey
       res = (subject_no_literal.code =~ /\r\n\r\n/)

--- a/spec/lib/rex/exploitation/powershell/obfu_spec.rb
+++ b/spec/lib/rex/exploitation/powershell/obfu_spec.rb
@@ -146,14 +146,14 @@ lots \t of   whitespace
       subject.strip_comments
       subject.code.should be
       subject.code.should be_kind_of String
-      subject.code.include?('comment').should be_false
+      subject.code.include?('comment').should be_falsey
     end
 
     it 'should strip a single line comment' do
       subject.strip_comments
       subject.code.should be
       subject.code.should be_kind_of String
-      subject.code.include?('#').should be_false
+      subject.code.include?('#').should be_falsey
     end
   end
 
@@ -163,7 +163,7 @@ lots \t of   whitespace
       subject.code.should be
       subject.code.should be_kind_of String
       res = (subject.code =~ /\r\n\r\n/)
-      res.should be_false
+      res.should be_falsey
     end
 
     it 'should strip extra unix new lines' do
@@ -171,7 +171,7 @@ lots \t of   whitespace
       subject.code.should be
       subject.code.should be_kind_of String
       res = (subject.code =~ /\n\n/)
-      res.should be_false
+      res.should be_falsey
     end
   end
 
@@ -189,8 +189,8 @@ lots \t of   whitespace
       subject.sub_vars
       subject.code.should be
       subject.code.should be_kind_of String
-      subject.code.include?('$kernel32').should be_false
-      subject.code.include?('$Logon').should be_false
+      subject.code.include?('$kernel32').should be_falsey
+      subject.code.include?('$Logon').should be_falsey
     end
   end
 
@@ -199,7 +199,7 @@ lots \t of   whitespace
       subject.sub_funcs
       subject.code.should be
       subject.code.should be_kind_of String
-      subject.code.include?('Find-4624Logons').should be_false
+      subject.code.include?('Find-4624Logons').should be_falsey
     end
   end
 
@@ -208,24 +208,24 @@ lots \t of   whitespace
       subject_no_literal.standard_subs
       subject_no_literal.code.should be
       subject_no_literal.code.should be_kind_of String
-      subject_no_literal.code.include?('Find-4624Logons').should be_false
-      subject_no_literal.code.include?('lots of whitespace').should be_true
-      subject_no_literal.code.include?('$kernel32').should be_false
-      subject_no_literal.code.include?('comment').should be_false
+      subject_no_literal.code.include?('Find-4624Logons').should be_falsey
+      subject_no_literal.code.include?('lots of whitespace').should be_falsey
+      subject_no_literal.code.include?('$kernel32').should be_falsey
+      subject_no_literal.code.include?('comment').should be_falsey
       res = (subject_no_literal.code =~ /\r\n\r\n/)
-      res.should be_false
+      res.should be_falsey
     end
 
     it 'should run all substitutions except strip whitespace when literals are present' do
       subject.standard_subs
       subject.code.should be
       subject.code.should be_kind_of String
-      subject.code.include?('Find-4624Logons').should be_false
-      subject.code.include?('lots of whitespace').should be_false
-      subject.code.include?('$kernel32').should be_false
-      subject.code.include?('comment').should be_false
+      subject.code.include?('Find-4624Logons').should be_falsey
+      subject.code.include?('lots of whitespace').should be_falsey
+      subject.code.include?('$kernel32').should be_falsey
+      subject.code.include?('comment').should be_falsey
       res = (subject.code =~ /\r\n\r\n/)
-      res.should be_false
+      res.should be_falsey
     end
   end
 end

--- a/spec/lib/rex/exploitation/powershell/parser_spec.rb
+++ b/spec/lib/rex/exploitation/powershell/parser_spec.rb
@@ -96,7 +96,7 @@ function Find-4624Logons
       literals.should be
       literals.should be_kind_of Array
       literals.length.should be > 0
-      literals[0].include?('parp').should be_false
+      literals[0].include?('parp').should be_falsey
     end
   end
 
@@ -152,7 +152,7 @@ function Find-4624Logons
 
     it 'should delete the function if delete is true' do
       function = subject.get_func('Find-4624Logons', true)
-      subject.code.include?('DllImport').should be_false
+      subject.code.include?('DllImport').should be_falsey
     end
   end
 end

--- a/spec/lib/rex/exploitation/powershell/script_spec.rb
+++ b/spec/lib/rex/exploitation/powershell/script_spec.rb
@@ -21,7 +21,7 @@ describe Rex::Exploitation::Powershell::Output do
       subject.rig.should be_kind_of Rex::RandomIdentifierGenerator
       subject.code.should be
       subject.code.should be_kind_of String
-      subject.code.empty?.should be_false
+      subject.code.empty?.should be_falsey
       subject.functions.empty?.should be_true
     end
   end
@@ -40,7 +40,7 @@ describe Rex::Exploitation::Powershell::Output do
       mods = Rex::Exploitation::Powershell::Script.code_modifiers
       mods.should be
       mods.should be_kind_of Array
-      mods.empty?.should be_false
+      mods.empty?.should be_falsey
     end
   end
 

--- a/spec/lib/rex/exploitation/powershell_spec.rb
+++ b/spec/lib/rex/exploitation/powershell_spec.rb
@@ -38,7 +38,7 @@ DumpHashes"""
   describe "::make_subs" do
     it 'should substitute values in script' do
       script = described_class.make_subs(example_script,[['BitConverter','ParpConverter']])
-      script.include?('BitConverter').should be_false
+      script.include?('BitConverter').should be_falsey
       script.include?('ParpConverter').should be_true
     end
   end

--- a/spec/lib/rex/exploitation/ropdb_spec.rb
+++ b/spec/lib/rex/exploitation/ropdb_spec.rb
@@ -32,7 +32,7 @@ describe Rex::Exploitation::RopDb do
       end
 
       it "should return false when I supply an invalid database" do
-        ropdb.has_rop?("sinn3r").should be_false
+        ropdb.has_rop?("sinn3r").should be_falsey
       end
     end
 

--- a/spec/lib/rex/proto/http/client_spec.rb
+++ b/spec/lib/rex/proto/http/client_spec.rb
@@ -51,7 +51,7 @@ describe Rex::Proto::Http::Client do
     cli.instance_variable_get(:@hostname).should == ip
     cli.instance_variable_get(:@port).should == 80
     cli.instance_variable_get(:@context).should == {}
-    cli.instance_variable_get(:@ssl).should be_false
+    cli.instance_variable_get(:@ssl).should be_falsey
     cli.instance_variable_get(:@proxies).should be_nil
     cli.instance_variable_get(:@username).should be_empty
     cli.instance_variable_get(:@password).should be_empty
@@ -202,7 +202,7 @@ describe Rex::Proto::Http::Client do
   end
 
   it "should test if a connection is valid" do
-    cli.conn?.should be_false
+    cli.conn?.should be_falsey
   end
 
   it "should tell if pipelining is enabled" do

--- a/spec/support/shared/examples/metasploit/framework/login_scanner/http.rb
+++ b/spec/support/shared/examples/metasploit/framework/login_scanner/http.rb
@@ -8,7 +8,7 @@ shared_examples_for 'Metasploit::Framework::LoginScanner::HTTP' do
 
     context "without ssl, without port" do
       it "should default :port to #{described_class::DEFAULT_PORT}" do
-        expect(http_scanner.ssl).to be_false
+        expect(http_scanner.ssl).to be_falsey
         expect(http_scanner.port).to eq(described_class::DEFAULT_PORT)
       end
     end
@@ -25,7 +25,7 @@ shared_examples_for 'Metasploit::Framework::LoginScanner::HTTP' do
       subject(:http_scanner) { described_class.new(port:described_class::DEFAULT_PORT) }
       it "should set ssl to false" do
         expect(http_scanner.port).to eq(described_class::DEFAULT_PORT)
-        expect(http_scanner.ssl).to be_false
+        expect(http_scanner.ssl).to be_falsey
       end
     end
 

--- a/spec/support/shared/examples/msf/module_manager/cache.rb
+++ b/spec/support/shared/examples/msf/module_manager/cache.rb
@@ -54,7 +54,7 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
         }
       end
 
-      it { should be_false }
+      it { should be_falsey }
     end
   end
 
@@ -196,7 +196,7 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
             false
           end
 
-          it { should be_false }
+          it { should be_falsey }
         end
 
         context 'with true' do
@@ -214,7 +214,7 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
         {}
       end
 
-      it { should be_false }
+      it { should be_falsey }
     end
   end
 
@@ -323,7 +323,7 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
           false
         end
 
-        it { should be_false }
+        it { should be_falsey }
       end
     end
 
@@ -332,7 +332,7 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
         framework.stub(:db => nil)
       end
 
-      it { should be_false }
+      it { should be_falsey }
     end
   end
 

--- a/spec/support/shared/examples/msf/module_manager/loading.rb
+++ b/spec/support/shared/examples/msf/module_manager/loading.rb
@@ -41,7 +41,7 @@ shared_examples_for 'Msf::ModuleManager::Loading' do
 
         tempfile.unlink
 
-        File.exist?(module_path).should be_false
+        File.exist?(module_path).should be_falsey
         subject.file_changed?(module_path).should be_true
       end
 
@@ -71,7 +71,7 @@ shared_examples_for 'Msf::ModuleManager::Loading' do
           }
 
           cached_modification_time.should == modification_time
-          subject.file_changed?(module_path).should be_false
+          subject.file_changed?(module_path).should be_falsey
         end
       end
     end

--- a/spec/support/shared/examples/msf/module_manager/module_paths.rb
+++ b/spec/support/shared/examples/msf/module_manager/module_paths.rb
@@ -21,7 +21,7 @@ shared_examples_for 'Msf::ModuleManager::ModulePaths' do
         path = file.path
         file.unlink
 
-        File.exist?(path).should be_false
+        File.exist?(path).should be_falsey
 
         expect {
           module_manager.add_module_path(path)

--- a/spec/support/shared/examples/options.rb
+++ b/spec/support/shared/examples/options.rb
@@ -47,7 +47,7 @@ shared_examples_for "an option" do |valid_values, invalid_values, type|
     invalid_values.each do |vhash|
       invalid_value = vhash[:value]
       it "should not be valid: #{invalid_value}" do
-        block = Proc.new { subject.valid?(invalid_value).should be_false }
+        block = Proc.new { subject.valid?(invalid_value).should be_falsey }
         if vhash[:pending]
           pending(vhash[:pending], &block)
         else


### PR DESCRIPTION
This pull request tries to switch from `be_false` to `be_falsey`, according to to rspec deprecation warnings.

Verification steps
- [x] Be sure travis is green!
