### PR TITLE
Switch from be_true to be_truthy

### DIFF
--- a/spec/lib/active_record/connection_adapters/abstract_adapter/connection_pool_spec.rb
+++ b/spec/lib/active_record/connection_adapters/abstract_adapter/connection_pool_spec.rb
@@ -44,7 +44,7 @@ describe ActiveRecord::ConnectionAdapters::ConnectionPool do
     end
 
     context 'in thread with connection' do
-      it { should be_true }
+      it { should be_truthy }
     end
 
     context 'in thread without connection' do
@@ -97,7 +97,7 @@ describe ActiveRecord::ConnectionAdapters::ConnectionPool do
       end
 
       it 'should return true from #active_connection?' do
-        expect(connection_pool.active_connection?).to be_true
+        expect(connection_pool.active_connection?).to be_truthy
       end
 
       context 'with error' do

--- a/spec/lib/fastlib_spec.rb
+++ b/spec/lib/fastlib_spec.rb
@@ -73,7 +73,7 @@ describe FastLib do
 
           described_class.dump(@destination_path, flag_string, base_path, *unarchived_paths)
 
-          File.exist?(@destination_path).should be_true
+          File.exist?(@destination_path).should be_truthy
         end
 
         context 'cache' do
@@ -114,7 +114,7 @@ describe FastLib do
 
               # make sure that the unarchived module exists and hasn't be deleted or renamed before expecting it to be
               # in the archive.
-              File.exist?(unarchived_path).should be_true
+              File.exist?(unarchived_path).should be_truthy
               cache[archived_path].should_not be_nil
             end
           end
@@ -131,7 +131,7 @@ describe FastLib do
 
           described_class.dump(@destination_path, flag_string, base_path, *unarchived_paths)
 
-          File.exist?(@destination_path).should be_true
+          File.exist?(@destination_path).should be_truthy
         end
 
         it 'should be smaller than the uncompressed archive' do
@@ -144,8 +144,8 @@ describe FastLib do
           described_class.dump(uncompressed_path, '', base_path, *unarchived_paths)
           described_class.dump(compressed_path, flag_string, base_path, *unarchived_paths)
 
-          File.exist?(uncompressed_path).should be_true
-          File.exist?(compressed_path).should be_true
+          File.exist?(uncompressed_path).should be_truthy
+          File.exist?(compressed_path).should be_truthy
 
           File.size(compressed_path).should < File.size(uncompressed_path)
         end
@@ -161,7 +161,7 @@ describe FastLib do
 
           described_class.dump(@destination_path, flag_string, base_path, *unarchived_paths)
 
-          File.exist?(@destination_path).should be_true
+          File.exist?(@destination_path).should be_truthy
         end
       end
 
@@ -175,7 +175,7 @@ describe FastLib do
 
           described_class.dump(@destination_path, flag_string, base_path, *unarchived_paths)
 
-          File.exist?(@destination_path).should be_true
+          File.exist?(@destination_path).should be_truthy
         end
       end
     end
@@ -194,7 +194,7 @@ describe FastLib do
       # ensure modules expected to be listed actually exist
       it 'should use existent unarchived modules' do
         unarchived_paths.each do |unarchived_path|
-          File.exist?(unarchived_path).should be_true
+          File.exist?(unarchived_path).should be_truthy
         end
       end
 

--- a/spec/lib/metasploit/framework/credential_spec.rb
+++ b/spec/lib/metasploit/framework/credential_spec.rb
@@ -22,7 +22,7 @@ describe Metasploit::Framework::Credential do
 
   describe "#paired" do
     it "defaults to true" do
-      expect(cred_detail.paired).to be_true
+      expect(cred_detail.paired).to be_truthy
     end
   end
 

--- a/spec/lib/metasploit/framework/login_scanner/result_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/result_spec.rb
@@ -29,14 +29,14 @@ describe Metasploit::Framework::LoginScanner::Result do
   context '#success?' do
     context 'when the status code is success' do
         it 'returns true' do
-          expect(login_result.success?).to be_true
+          expect(login_result.success?).to be_truthy
         end
     end
 
     context 'when the status code is anything else' do
       let(:status) { :connection_error }
       it 'returns false' do
-        expect(login_result.success?).to be_false
+        expect(login_result.success?).to be_truthy
       end
     end
   end

--- a/spec/lib/metasploit/framework/login_scanner/result_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/result_spec.rb
@@ -36,7 +36,7 @@ describe Metasploit::Framework::LoginScanner::Result do
     context 'when the status code is anything else' do
       let(:status) { :connection_error }
       it 'returns false' do
-        expect(login_result.success?).to be_truthy
+        expect(login_result.success?).to be_false
       end
     end
   end

--- a/spec/lib/msf/core/exploit/cmdstager_spec.rb
+++ b/spec/lib/msf/core/exploit/cmdstager_spec.rb
@@ -332,7 +332,7 @@ describe Msf::Exploit::CmdStager do
       end
 
       it "is compatible" do
-        expect(subject.compatible_flavor?(flavor)).to be_true
+        expect(subject.compatible_flavor?(flavor)).to be_truthy
       end
     end
 
@@ -348,7 +348,7 @@ describe Msf::Exploit::CmdStager do
         end
 
         it "is compatible" do
-          expect(subject.compatible_flavor?(flavor)).to be_true
+          expect(subject.compatible_flavor?(flavor)).to be_truthy
         end
       end
 
@@ -375,7 +375,7 @@ describe Msf::Exploit::CmdStager do
         end
 
         it "is compatible" do
-          expect(subject.compatible_flavor?(flavor)).to be_true
+          expect(subject.compatible_flavor?(flavor)).to be_truthy
         end
       end
 
@@ -402,7 +402,7 @@ describe Msf::Exploit::CmdStager do
         end
 
         it "is compatible" do
-          expect(subject.compatible_flavor?(flavor)).to be_true
+          expect(subject.compatible_flavor?(flavor)).to be_truthy
         end
       end
 

--- a/spec/lib/msf/core/exploit/powershell_spec.rb
+++ b/spec/lib/msf/core/exploit/powershell_spec.rb
@@ -43,13 +43,13 @@ describe Msf::Exploit::Powershell do
         script = File.read(example_script)
         compressed = subject.compress_script(script)
         compressed.length.should be < script.length
-        compressed.include?('IO.Compression').should be_true
+        compressed.include?('IO.Compression').should be_truthy
       end
 
       it 'should create a compressed script with eof' do
         script = File.read(example_script)
         compressed = subject.compress_script(script, 'end_of_file')
-        compressed.include?('end_of_file').should be_true
+        compressed.include?('end_of_file').should be_truthy
       end
     end
 
@@ -120,7 +120,7 @@ describe Msf::Exploit::Powershell do
       it 'shouldnt substitute variables' do
         script = File.read(example_script)
         compressed = subject.compress_script(script)
-        decompress(compressed).include?('$hashes').should be_true
+        decompress(compressed).include?('$hashes').should be_truthy
       end
     end
 
@@ -144,7 +144,7 @@ describe Msf::Exploit::Powershell do
       it 'shouldnt substitute variables' do
         script = File.read(example_script)
         compressed = subject.compress_script(script)
-        decompress(compressed).include?('DumpHashes').should be_true
+        decompress(compressed).include?('DumpHashes').should be_truthy
       end
     end
   end
@@ -159,28 +159,28 @@ describe Msf::Exploit::Powershell do
     context 'when x86 payload' do
       it 'should generate code' do
         code = subject.run_hidden_psh(payload, arch, encoded)
-        code.include?('syswow64').should be_true
+        code.include?('syswow64').should be_truthy
       end
     end
 
     context 'when x64 payload' do
       it 'should generate code'  do
         code = subject.run_hidden_psh(payload, 'x86_64', encoded)
-        code.include?('sysnative').should be_true
+        code.include?('sysnative').should be_truthy
       end
     end
 
     context 'when encoded' do
       it 'should generate a code including an encoded command' do
         code = subject.run_hidden_psh(payload, arch, true)
-        code.include?('-nop -w hidden -e ').should be_true
+        code.include?('-nop -w hidden -e ').should be_truthy
       end
     end
 
     context 'when command' do
       it 'should generate code including a -c command' do
         code = subject.run_hidden_psh(payload, arch, encoded)
-        code.include?('-nop -w hidden -c ').should be_true
+        code.include?('-nop -w hidden -c ').should be_truthy
       end
     end
 
@@ -191,7 +191,7 @@ describe Msf::Exploit::Powershell do
       end
       it 'should generate a code including unshorted args' do
         code = subject.run_hidden_psh(payload, arch, encoded)
-        code.include?('-NoProfile -WindowStyle hidden -NoExit -Command ').should be_true
+        code.include?('-NoProfile -WindowStyle hidden -NoExit -Command ').should be_truthy
       end
     end
   end
@@ -206,7 +206,7 @@ describe Msf::Exploit::Powershell do
           except = true
         end
 
-        except.should be_true
+        except.should be_truthy
       end
     end
 
@@ -217,7 +217,7 @@ describe Msf::Exploit::Powershell do
       end
       it 'should add a persistance loop' do
         code = subject.cmd_psh_payload(payload, arch)
-        decompress(code).include?('while(1){Start-Sleep -s ').should be_true
+        decompress(code).include?('while(1){Start-Sleep -s ').should be_truthy
       end
     end
 
@@ -239,7 +239,7 @@ describe Msf::Exploit::Powershell do
       end
       it 'should prepend sleep' do
         code = subject.cmd_psh_payload(payload, arch)
-        decompress(code).include?('Start-Sleep -s ').should be_true
+        decompress(code).include?('Start-Sleep -s ').should be_truthy
       end
     end
 
@@ -272,15 +272,15 @@ describe Msf::Exploit::Powershell do
       end
       it 'should generate a command line' do
         code = subject.cmd_psh_payload(payload, arch)
-        decompress(code).include?('-namespace Win32Functions').should be_true
+        decompress(code).include?('-namespace Win32Functions').should be_truthy
       end
       it 'shouldnt shorten args' do
         code = subject.cmd_psh_payload(payload, arch)
-        code.include?('-NoProfile -WindowStyle hidden -Command').should be_true
+        code.include?('-NoProfile -WindowStyle hidden -Command').should be_truthy
       end
       it 'should include -NoExit' do
         code = subject.cmd_psh_payload(payload, arch)
-        code.include?('-NoProfile -WindowStyle hidden -NoExit -Command').should be_true
+        code.include?('-NoProfile -WindowStyle hidden -NoExit -Command').should be_truthy
       end
     end
 
@@ -291,7 +291,7 @@ describe Msf::Exploit::Powershell do
       end
       it 'should generate a command line' do
         code = subject.cmd_psh_payload(payload, arch)
-        decompress(code).include?('System.Runtime.InteropServices;').should be_true
+        decompress(code).include?('System.Runtime.InteropServices;').should be_truthy
       end
     end
 
@@ -302,7 +302,7 @@ describe Msf::Exploit::Powershell do
       end
       it 'should generate a command line' do
         code = subject.cmd_psh_payload(payload, arch)
-        decompress(code).include?('GlobalAssemblyCache').should be_true
+        decompress(code).include?('GlobalAssemblyCache').should be_truthy
       end
     end
 
@@ -318,7 +318,7 @@ describe Msf::Exploit::Powershell do
         rescue RuntimeError
           except = true
         end
-        except.should be_true
+        except.should be_truthy
       end
     end
 
@@ -333,7 +333,7 @@ describe Msf::Exploit::Powershell do
         rescue RuntimeError
           except = true
         end
-        except.should be_true
+        except.should be_truthy
       end
       after do
         subject.datastore['Powershell::method'] = 'reflection'
@@ -344,7 +344,7 @@ describe Msf::Exploit::Powershell do
     context 'when encode_inner_payload' do
       it 'should contain an inner payload with -e' do
           code = subject.cmd_psh_payload(payload, arch, {:encode_inner_payload => true})
-          code.include?(' -e ').should be_true
+          code.include?(' -e ').should be_truthy
       end
 
       context 'when no_equals is true' do
@@ -355,7 +355,7 @@ describe Msf::Exploit::Powershell do
           rescue RuntimeError
             except = true
           end
-          except.should be_true
+          except.should be_truthy
         end
       end
     end
@@ -364,14 +364,14 @@ describe Msf::Exploit::Powershell do
       context 'when no_equals is false' do
         it 'should contain a final payload with -e' do
           code = subject.cmd_psh_payload(payload, arch, {:encode_final_payload => true, :no_equals => false})
-          code.include?(' -e ').should be_true
+          code.include?(' -e ').should be_truthy
           code.include?(' -c ').should be_false
         end
       end
       context 'when no_equals is true' do
         it 'should contain a final payload with -e' do
           code = subject.cmd_psh_payload(payload, arch, {:encode_final_payload => true, :no_equals => true})
-          code.include?(' -e ').should be_true
+          code.include?(' -e ').should be_truthy
           code.include?(' -c ').should be_false
           code.include?('=').should be_false
         end
@@ -384,7 +384,7 @@ describe Msf::Exploit::Powershell do
           rescue RuntimeError
             except = true
           end
-          except.should be_true
+          except.should be_truthy
         end
       end
     end
@@ -399,7 +399,7 @@ describe Msf::Exploit::Powershell do
     context 'when use single quotes' do
       it 'should wrap in single quotes' do
         code = subject.cmd_psh_payload(payload, arch, {:use_single_quotes => true})
-        code.include?(' -c \'').should be_true
+        code.include?(' -c \'').should be_truthy
       end
     end
   end
@@ -408,27 +408,27 @@ describe Msf::Exploit::Powershell do
     it 'should contain no full stop when :no_full_stop' do
       opts = {:no_full_stop => true}
       command = subject.generate_psh_command_line(opts)
-      command.include?("powershell ").should be_true
+      command.include?("powershell ").should be_truthy
     end
 
     it 'should contain full stop unless :no_full_stop' do
       opts = {}
       command = subject.generate_psh_command_line(opts)
-      command.include?("powershell.exe ").should be_true
+      command.include?("powershell.exe ").should be_truthy
 
       opts = {:no_full_stop => false}
       command = subject.generate_psh_command_line(opts)
-      command.include?("powershell.exe ").should be_true
+      command.include?("powershell.exe ").should be_truthy
     end
 
     it 'should ensure the path should always ends with \\' do
       opts = {:path => "test"}
       command = subject.generate_psh_command_line(opts)
-      command.include?("test\\powershell.exe ").should be_true
+      command.include?("test\\powershell.exe ").should be_truthy
 
       opts = {:path => "test\\"}
       command = subject.generate_psh_command_line(opts)
-      command.include?("test\\powershell.exe ").should be_true
+      command.include?("test\\powershell.exe ").should be_truthy
     end
   end
 

--- a/spec/lib/msf/core/module_spec.rb
+++ b/spec/lib/msf/core/module_spec.rb
@@ -15,7 +15,7 @@ shared_examples "search_filter" do |opts|
 
     unless opts.has_key?(:test_inverse) and not opts[:test_inverse]
       it "should reject a query containing '-#{query}'" do
-        subject.search_filter("-#{query}").should be_true
+        subject.search_filter("-#{query}").should be_truthy
       end
     end
   end
@@ -23,12 +23,12 @@ shared_examples "search_filter" do |opts|
   reject.each do |query|
     it "should reject a query containing '#{query}'" do
       # if the subject doesn't matches, search_filter returns true ("filter me out!")
-      subject.search_filter(query).should be_true
+      subject.search_filter(query).should be_truthy
     end
 
     unless opts.has_key?(:test_inverse) and not opts[:test_inverse]
       it "should accept a query containing '-#{query}'" do
-        subject.search_filter("-#{query}").should be_true # what? why?
+        subject.search_filter("-#{query}").should be_truthy # what? why?
       end
     end
   end

--- a/spec/lib/msf/core/modules/loader/archive_spec.rb
+++ b/spec/lib/msf/core/modules/loader/archive_spec.rb
@@ -117,7 +117,7 @@ describe Msf::Modules::Loader::Archive do
 
       # this checks that the around(:each) is working
       it 'should have an existent FastLib' do
-        File.exist?(@archive_path).should be_true
+        File.exist?(@archive_path).should be_truthy
       end
 
       it 'should ignore .svn directories' do
@@ -141,7 +141,7 @@ describe Msf::Modules::Loader::Archive do
       end
 
       it 'should yield (parent_path, type, module_reference_name) with type equal to enabled type' do
-        module_manager.type_enabled?(enabled_type).should be_true
+        module_manager.type_enabled?(enabled_type).should be_truthy
 
         subject.send(:each_module_reference_name, @archive_path) do |parent_path, type, module_reference_name|
           type.should == enabled_type
@@ -172,7 +172,7 @@ describe Msf::Modules::Loader::Archive do
         path = "path/to/archive#{archive_extension}"
 
         File.extname(path).should == described_class::ARCHIVE_EXTENSION
-        subject.loadable?(path).should be_true
+        subject.loadable?(path).should be_truthy
       end
 
       it 'should return false if the path contains ARCHIVE_EXTENSION, but it is not the file extension' do
@@ -244,7 +244,7 @@ describe Msf::Modules::Loader::Archive do
       end
 
       it 'should read modules that exist' do
-        File.exist?(unarchived_path).should be_true
+        File.exist?(unarchived_path).should be_truthy
       end
 
       around(:each) do |example|

--- a/spec/lib/msf/core/modules/loader/base_spec.rb
+++ b/spec/lib/msf/core/modules/loader/base_spec.rb
@@ -52,7 +52,7 @@ describe Msf::Modules::Loader::Base do
       end
 
       it 'should be defined' do
-        described_class.const_defined?(:DIRECTORY_BY_TYPE).should be_true
+        described_class.const_defined?(:DIRECTORY_BY_TYPE).should be_truthy
       end
 
       it 'should map Msf::MODULE_AUX to auxiliary' do
@@ -335,7 +335,7 @@ describe Msf::Modules::Loader::Base do
 
           subject.stub(:read_module_content => module_content)
 
-          subject.load_module(parent_path, type, module_reference_name).should be_true
+          subject.load_module(parent_path, type, module_reference_name).should be_truthy
           namespace_module.parent_path.should == parent_path
         end
 
@@ -343,7 +343,7 @@ describe Msf::Modules::Loader::Base do
           module_manager.stub(:on_module_load)
 
           subject.should_receive(:read_module_content).with(parent_path, type, module_reference_name).and_return(module_content)
-          subject.load_module(parent_path, type, module_reference_name).should be_true
+          subject.load_module(parent_path, type, module_reference_name).should be_truthy
         end
 
         it 'should call namespace_module.module_eval_with_lexical_scope with the module_path' do
@@ -567,7 +567,7 @@ describe Msf::Modules::Loader::Base do
 
               it 'should restore the old namespace module' do
                 subject.load_module(parent_path, type, module_reference_name).should be_false
-                Msf::Modules.const_defined?(relative_name).should be_true
+                Msf::Modules.const_defined?(relative_name).should be_truthy
                 Msf::Modules.const_get(relative_name).should == @original_namespace_module
               end
             end
@@ -583,7 +583,7 @@ describe Msf::Modules::Loader::Base do
 
               it 'should check if it is usable' do
                 subject.should_receive(:usable?).with(metasploit_class).and_return(true)
-                subject.load_module(parent_path, type, module_reference_name).should be_true
+                subject.load_module(parent_path, type, module_reference_name).should be_truthy
               end
 
               context 'without usable metasploit_class' do
@@ -602,7 +602,7 @@ describe Msf::Modules::Loader::Base do
 
                 it 'should restore the old namespace module' do
                   subject.load_module(parent_path, type, module_reference_name).should be_false
-                  Msf::Modules.const_defined?(relative_name).should be_true
+                  Msf::Modules.const_defined?(relative_name).should be_truthy
                   Msf::Modules.const_get(relative_name).should == @original_namespace_module
                 end
               end
@@ -615,7 +615,7 @@ describe Msf::Modules::Loader::Base do
 
                 it 'should log load information' do
                   subject.should_receive(:ilog).with(/#{module_reference_name}/, 'core', LEV_2)
-                  subject.load_module(parent_path, type, module_reference_name).should be_true
+                  subject.load_module(parent_path, type, module_reference_name).should be_truthy
                 end
 
                 it 'should delete any pre-existing load errors from module_manager.module_load_error_by_path' do
@@ -623,17 +623,17 @@ describe Msf::Modules::Loader::Base do
                   module_manager.module_load_error_by_path[module_path] = original_load_error
 
                   module_manager.module_load_error_by_path[module_path].should == original_load_error
-                  subject.load_module(parent_path, type, module_reference_name).should be_true
+                  subject.load_module(parent_path, type, module_reference_name).should be_truthy
                   module_manager.module_load_error_by_path[module_path].should be_nil
                 end
 
                 it 'should return true' do
-                  subject.load_module(parent_path, type, module_reference_name).should be_true
+                  subject.load_module(parent_path, type, module_reference_name).should be_truthy
                 end
 
                 it 'should call module_manager.on_module_load' do
                   module_manager.should_receive(:on_module_load)
-                  subject.load_module(parent_path, type, module_reference_name).should be_true
+                  subject.load_module(parent_path, type, module_reference_name).should be_truthy
                 end
 
                 context 'with :recalculate_by_type' do
@@ -645,8 +645,8 @@ describe Msf::Modules::Loader::Base do
                         type,
                         module_reference_name,
                         :recalculate_by_type => recalculate_by_type
-                    ).should be_true
-                    recalculate_by_type[type].should be_true
+                    ).should be_truthy
+                    recalculate_by_type[type].should be_truthy
                   end
                 end
 
@@ -660,7 +660,7 @@ describe Msf::Modules::Loader::Base do
                         type,
                         module_reference_name,
                         :count_by_type => count_by_type
-                    ).should be_true
+                    ).should be_truthy
                     count_by_type[type].should == 1
                   end
 
@@ -675,7 +675,7 @@ describe Msf::Modules::Loader::Base do
                         type,
                         module_reference_name,
                         :count_by_type => count_by_type
-                    ).should be_true
+                    ).should be_truthy
 
                     incremented_count = original_count + 1
                     count_by_type[type].should == incremented_count
@@ -864,7 +864,7 @@ describe Msf::Modules::Loader::Base do
       end
 
       it 'should return true otherwise' do
-        subject.send(:module_path?, module_path).should be_true
+        subject.send(:module_path?, module_path).should be_truthy
       end
     end
 
@@ -1043,7 +1043,7 @@ describe Msf::Modules::Loader::Base do
           it 'should return true' do
             subject.send(:namespace_module_transaction, module_full_name) { |namespace_module|
               true
-            }.should be_true
+            }.should be_truthy
           end
         end
       end
@@ -1081,7 +1081,7 @@ describe Msf::Modules::Loader::Base do
 
             begin
               subject.send(:namespace_module_transaction, module_full_name) do |namespace_module|
-                Msf::Module.const_defined?(relative_name).should be_true
+                Msf::Module.const_defined?(relative_name).should be_truthy
 
                 raise error_class, error_message
               end
@@ -1105,7 +1105,7 @@ describe Msf::Modules::Loader::Base do
             Msf::Modules.const_defined?(relative_name).should be_false
 
             subject.send(:namespace_module_transaction, module_full_name) do |namespace_module|
-              Msf::Modules.const_defined?(relative_name).should be_true
+              Msf::Modules.const_defined?(relative_name).should be_truthy
 
               false
             end
@@ -1127,21 +1127,21 @@ describe Msf::Modules::Loader::Base do
             created_namespace_module = nil
 
             subject.send(:namespace_module_transaction, module_full_name) do |namespace_module|
-              Msf::Modules.const_defined?(relative_name).should be_true
+              Msf::Modules.const_defined?(relative_name).should be_truthy
 
               created_namespace_module = namespace_module
 
               true
             end
 
-            Msf::Modules.const_defined?(relative_name).should be_true
+            Msf::Modules.const_defined?(relative_name).should be_truthy
             Msf::Modules.const_get(relative_name).should == created_namespace_module
           end
 
           it 'should return true' do
             subject.send(:namespace_module_transaction, module_full_name) { |namespace_module|
               true
-            }.should be_true
+            }.should be_truthy
           end
         end
       end
@@ -1240,14 +1240,14 @@ describe Msf::Modules::Loader::Base do
 
           context 'with the current constant being the namespace_module' do
             it 'should not change the constant' do
-              parent_module.const_defined?(relative_name).should be_true
+              parent_module.const_defined?(relative_name).should be_truthy
 
               current_module = parent_module.const_get(relative_name)
               current_module.should == @current_namespace_module
 
               subject.send(:restore_namespace_module, parent_module, relative_name, @current_namespace_module)
 
-              parent_module.const_defined?(relative_name).should be_true
+              parent_module.const_defined?(relative_name).should be_truthy
               restored_module = parent_module.const_get(relative_name)
               restored_module.should == current_module
               restored_module.should == @current_namespace_module
@@ -1263,7 +1263,7 @@ describe Msf::Modules::Loader::Base do
 
           context 'without the current constant being the namespace_module' do
             it 'should remove relative_name from parent_module' do
-              parent_module.const_defined?(relative_name).should be_true
+              parent_module.const_defined?(relative_name).should be_truthy
               parent_module.should_receive(:remove_const).with(relative_name)
 
               subject.send(:restore_namespace_module, parent_module, relative_name, @original_namespace_module)
@@ -1285,7 +1285,7 @@ describe Msf::Modules::Loader::Base do
 
             subject.send(:restore_namespace_module, parent_module, relative_name, @original_namespace_module)
 
-            parent_module.const_defined?(relative_name).should be_true
+            parent_module.const_defined?(relative_name).should be_truthy
             parent_module.const_get(relative_name).should == @original_namespace_module
           end
         end
@@ -1307,7 +1307,7 @@ describe Msf::Modules::Loader::Base do
           metasploit_class = double('Metasploit Class')
           metasploit_class.should_not respond_to(:is_usable)
 
-          subject.send(:usable?, metasploit_class).should be_true
+          subject.send(:usable?, metasploit_class).should be_truthy
         end
       end
 

--- a/spec/lib/msf/core/modules/loader/directory_spec.rb
+++ b/spec/lib/msf/core/modules/loader/directory_spec.rb
@@ -51,7 +51,7 @@ describe Msf::Modules::Loader::Directory do
         end
 
         it 'should load a module that can be created' do
-          subject.load_module(parent_path, type, module_reference_name).should be_true
+          subject.load_module(parent_path, type, module_reference_name).should be_truthy
 
           created_module = module_manager.create(module_full_name)
 

--- a/spec/lib/msf/core/modules/namespace_spec.rb
+++ b/spec/lib/msf/core/modules/namespace_spec.rb
@@ -47,7 +47,7 @@ describe Msf::Modules::Namespace do
       end
 
       it 'should be defined' do
-        subject.const_defined?('Metasploit1').should be_true
+        subject.const_defined?('Metasploit1').should be_truthy
       end
 
       it 'should return the class' do
@@ -61,7 +61,7 @@ describe Msf::Modules::Namespace do
       end
 
       it 'should be defined' do
-        subject.const_defined?('Metasploit2').should be_true
+        subject.const_defined?('Metasploit2').should be_truthy
       end
 
       it 'should return the class' do
@@ -75,7 +75,7 @@ describe Msf::Modules::Namespace do
       end
 
       it 'should be defined' do
-        subject.const_defined?('Metasploit3').should be_true
+        subject.const_defined?('Metasploit3').should be_truthy
       end
 
       it 'should return the class' do
@@ -89,7 +89,7 @@ describe Msf::Modules::Namespace do
       end
 
       it 'should be defined' do
-        subject.const_defined?('Metasploit4').should be_true
+        subject.const_defined?('Metasploit4').should be_truthy
       end
 
       it 'should return the class' do
@@ -103,7 +103,7 @@ describe Msf::Modules::Namespace do
       end
 
       it 'should be defined' do
-        subject.const_defined?('Metasploit5').should be_true
+        subject.const_defined?('Metasploit5').should be_truthy
       end
 
       it 'should be newer than Msf::Framework::Major' do

--- a/spec/lib/msf/db_manager_spec.rb
+++ b/spec/lib/msf/db_manager_spec.rb
@@ -845,7 +845,7 @@ describe Msf::DBManager do
 
           module_details.all? { |module_detail|
             module_detail.stance == 'passive'
-          }.should be_true
+          }.should be_truthy
         end
       end
 
@@ -859,7 +859,7 @@ describe Msf::DBManager do
 
           module_details.all? { |module_detail|
             module_detail.stance == 'aggressive'
-          }.should be_true
+          }.should be_truthy
         end
       end
     end
@@ -890,7 +890,7 @@ describe Msf::DBManager do
             module_detail.authors.any? { |module_author|
               module_author.email == target_module_author.email
             }
-          }.should be_true
+          }.should be_truthy
         end
       end
 
@@ -907,7 +907,7 @@ describe Msf::DBManager do
             module_detail.authors.any? { |module_author|
               module_author.name == target_module_author.name
             }
-          }.should be_true
+          }.should be_truthy
         end
       end
     end
@@ -939,7 +939,7 @@ describe Msf::DBManager do
 
           module_details.all? { |module_detail|
             module_detail.fullname == target_module_detail.fullname
-          }.should be_true
+          }.should be_truthy
         end
       end
 
@@ -954,7 +954,7 @@ describe Msf::DBManager do
 
           module_details.all? { |module_detail|
             module_detail.name == target_module_detail.name
-          }.should be_true
+          }.should be_truthy
         end
       end
     end
@@ -991,7 +991,7 @@ describe Msf::DBManager do
             module_detail.refs.any? { |module_ref|
               module_ref.name == ref
             }
-          }.should be_true
+          }.should be_truthy
         end
       end
 
@@ -1029,7 +1029,7 @@ describe Msf::DBManager do
 
           module_details.all? { |module_detail|
             module_detail.mtype == type
-          }.should be_true
+          }.should be_truthy
         end
       end
 
@@ -1057,7 +1057,7 @@ describe Msf::DBManager do
             module_detail.actions.any? { |module_action|
               module_action.name == search_string
             }
-          }.should be_true
+          }.should be_truthy
         end
       end
 
@@ -1077,7 +1077,7 @@ describe Msf::DBManager do
             module_detail.archs.any? { |module_arch|
               module_arch.name == search_string
             }
-          }.should be_true
+          }.should be_truthy
         end
       end
 
@@ -1097,7 +1097,7 @@ describe Msf::DBManager do
             module_detail.authors.any? { |module_author|
               module_author.name == search_string
             }
-          }.should be_true
+          }.should be_truthy
         end
       end
 
@@ -1121,7 +1121,7 @@ describe Msf::DBManager do
 
             module_details.all? { |module_detail|
               module_detail.description == target_module_detail.description
-            }.should be_true
+            }.should be_truthy
           end
         end
 
@@ -1135,7 +1135,7 @@ describe Msf::DBManager do
 
             module_details.all? { |module_detail|
               module_detail.fullname == search_string
-            }.should be_true
+            }.should be_truthy
           end
         end
 
@@ -1150,7 +1150,7 @@ describe Msf::DBManager do
 
             module_details.all? { |module_detail|
               module_detail.name == target_module_detail.name
-            }.should be_true
+            }.should be_truthy
           end
         end
       end
@@ -1171,7 +1171,7 @@ describe Msf::DBManager do
             module_detail.platforms.any? { |module_platform|
               module_platform.name == search_string
             }
-          }.should be_true
+          }.should be_truthy
         end
       end
 
@@ -1191,7 +1191,7 @@ describe Msf::DBManager do
             module_detail.refs.any? { |module_ref|
               module_ref.name == search_string
             }
-          }.should be_true
+          }.should be_truthy
         end
       end
 
@@ -1211,7 +1211,7 @@ describe Msf::DBManager do
             module_detail.targets.any? { |module_target|
               module_target.name == search_string
             }
-          }.should be_true
+          }.should be_truthy
         end
       end
     end

--- a/spec/lib/rex/exploitation/powershell/function_spec.rb
+++ b/spec/lib/rex/exploitation/powershell/function_spec.rb
@@ -62,16 +62,16 @@ describe Rex::Exploitation::Powershell::Function do
       function = Rex::Exploitation::Powershell::Function.new(function_name, example_function_without_params)
       function.name.should eq function_name
       function.code.should eq example_function_without_params
-      function.to_s.include?("function #{function_name} #{example_function_without_params}").should be_true
+      function.to_s.include?("function #{function_name} #{example_function_without_params}").should be_truthy
       function.params.should be_kind_of Array
-      function.params.empty?.should be_true
+      function.params.empty?.should be_truthy
     end
 
     it 'should handle a function with params' do
       function = Rex::Exploitation::Powershell::Function.new(function_name, example_function_with_params)
       function.name.should eq function_name
       function.code.should eq example_function_with_params
-      function.to_s.include?("function #{function_name} #{example_function_with_params}").should be_true
+      function.to_s.include?("function #{function_name} #{example_function_with_params}").should be_truthy
       function.params.should be_kind_of Array
       function.params.length.should be == 5
       function.params[0].klass.should eq 'Type[]'

--- a/spec/lib/rex/exploitation/powershell/obfu_spec.rb
+++ b/spec/lib/rex/exploitation/powershell/obfu_spec.rb
@@ -180,7 +180,7 @@ lots \t of   whitespace
       subject.strip_whitespace
       subject.code.should be
       subject.code.should be_kind_of String
-      subject.code.include?('lots of whitespace').should be_true
+      subject.code.include?('lots of whitespace').should be_truthy
     end
   end
 
@@ -209,7 +209,7 @@ lots \t of   whitespace
       subject_no_literal.code.should be
       subject_no_literal.code.should be_kind_of String
       subject_no_literal.code.include?('Find-4624Logons').should be_false
-      subject_no_literal.code.include?('lots of whitespace').should be_true
+      subject_no_literal.code.include?('lots of whitespace').should be_truthy
       subject_no_literal.code.include?('$kernel32').should be_false
       subject_no_literal.code.include?('comment').should be_false
       res = (subject_no_literal.code =~ /\r\n\r\n/)

--- a/spec/lib/rex/exploitation/powershell/output_spec.rb
+++ b/spec/lib/rex/exploitation/powershell/output_spec.rb
@@ -38,7 +38,7 @@ describe Rex::Exploitation::Powershell::Output do
   describe "::deflate_code" do
     it 'should zlib the code and wrap in powershell in uncompression stub' do
       compressed = subject.deflate_code
-      compressed.include?('IO.Compression.DeflateStream').should be_true
+      compressed.include?('IO.Compression.DeflateStream').should be_truthy
       compressed =~ /FromBase64String\('([A-Za-z0-9\/+=]+)'\)/
       $1.size.should be < Rex::Text.encode_base64(example_script).size
       compressed.should eq subject.code
@@ -46,7 +46,7 @@ describe Rex::Exploitation::Powershell::Output do
 
     it 'should append an eof marker if specified' do
       compressed = subject.deflate_code(eof)
-      compressed.include?("echo '#{eof}';").should be_true
+      compressed.include?("echo '#{eof}';").should be_truthy
     end
   end
 
@@ -62,7 +62,7 @@ describe Rex::Exploitation::Powershell::Output do
   describe "::gzip_code" do
     it 'should gzip the code and wrap in powershell in uncompression stub' do
       compressed = subject.gzip_code
-      compressed.include?('IO.Compression.GzipStream').should be_true
+      compressed.include?('IO.Compression.GzipStream').should be_truthy
       compressed =~ /FromBase64String\('([A-Za-z0-9\/+=]+)'\)/
       $1.size.should be < Rex::Text.encode_base64(example_script).size
       compressed.should eq subject.code
@@ -70,24 +70,24 @@ describe Rex::Exploitation::Powershell::Output do
 
     it 'should append an eof marker if specified' do
       compressed = subject.gzip_code(eof)
-      compressed.include?("echo '#{eof}';").should be_true
+      compressed.include?("echo '#{eof}';").should be_truthy
     end
   end
 
   describe "::compress_code" do
     it 'should gzip by default' do
       compressed = subject.compress_code
-      compressed.include?('IO.Compression.GzipStream').should be_true
+      compressed.include?('IO.Compression.GzipStream').should be_truthy
     end
 
     it 'should deflate if gzip is false' do
       compressed = subject.compress_code(nil,false)
-      compressed.include?('IO.Compression.DeflateStream').should be_true
+      compressed.include?('IO.Compression.DeflateStream').should be_truthy
     end
 
     it 'should append an eof' do
       compressed = subject.compress_code(eof)
-      compressed.include?("echo '#{eof}';").should be_true
+      compressed.include?("echo '#{eof}';").should be_truthy
     end
   end
 

--- a/spec/lib/rex/exploitation/powershell/param_spec.rb
+++ b/spec/lib/rex/exploitation/powershell/param_spec.rb
@@ -19,7 +19,7 @@ describe Rex::Exploitation::Powershell::Param do
       param.should be
       param.name.should eq param_name
       param.klass.should eq klass_name
-      param.to_s.include?("[#{klass_name}]$#{param_name}").should be_true
+      param.to_s.include?("[#{klass_name}]$#{param_name}").should be_truthy
     end
   end
 

--- a/spec/lib/rex/exploitation/powershell/parser_spec.rb
+++ b/spec/lib/rex/exploitation/powershell/parser_spec.rb
@@ -67,7 +67,7 @@ function Find-4624Logons
       vars.should be
       vars.should be_kind_of Array
       vars.length.should be > 0
-      vars.include?('$ResultObj').should be_true
+      vars.include?('$ResultObj').should be_truthy
     end
 
     it 'should not match upper or lowercase reserved names' do
@@ -86,7 +86,7 @@ function Find-4624Logons
       funcs.should be
       funcs.should be_kind_of Array
       funcs.length.should be > 0
-      funcs.include?('Find-4624Logons').should be_true
+      funcs.include?('Find-4624Logons').should be_truthy
     end
   end
 

--- a/spec/lib/rex/exploitation/powershell/psh_methods_spec.rb
+++ b/spec/lib/rex/exploitation/powershell/psh_methods_spec.rb
@@ -9,35 +9,35 @@ describe Rex::Exploitation::Powershell::PshMethods do
     it 'should return some powershell' do
       script = Rex::Exploitation::Powershell::PshMethods.download('a','b')
       script.should be
-      script.include?('WebClient').should be_true
+      script.include?('WebClient').should be_truthy
     end
   end
   describe "::uninstall" do
     it 'should return some powershell' do
       script = Rex::Exploitation::Powershell::PshMethods.uninstall('a')
       script.should be
-      script.include?('Win32_Product').should be_true
+      script.include?('Win32_Product').should be_truthy
     end
   end
   describe "::secure_string" do
     it 'should return some powershell' do
       script = Rex::Exploitation::Powershell::PshMethods.secure_string('a')
       script.should be
-      script.include?('AsPlainText').should be_true
+      script.include?('AsPlainText').should be_truthy
     end
   end
   describe "::who_locked_file" do
     it 'should return some powershell' do
       script = Rex::Exploitation::Powershell::PshMethods.who_locked_file('a')
       script.should be
-      script.include?('Get-Process').should be_true
+      script.include?('Get-Process').should be_truthy
     end
   end
   describe "::get_last_login" do
     it 'should return some powershell' do
       script = Rex::Exploitation::Powershell::PshMethods.get_last_login('a')
       script.should be
-      script.include?('Get-QADComputer').should be_true
+      script.include?('Get-QADComputer').should be_truthy
     end
   end
 end

--- a/spec/lib/rex/exploitation/powershell/script_spec.rb
+++ b/spec/lib/rex/exploitation/powershell/script_spec.rb
@@ -22,7 +22,7 @@ describe Rex::Exploitation::Powershell::Output do
       subject.code.should be
       subject.code.should be_kind_of String
       subject.code.empty?.should be_false
-      subject.functions.empty?.should be_true
+      subject.functions.empty?.should be_truthy
     end
   end
 
@@ -31,7 +31,7 @@ describe Rex::Exploitation::Powershell::Output do
       byte_array = Rex::Exploitation::Powershell::Script.to_byte_array("parp")
       byte_array.should be
       byte_array.should be_kind_of String
-      byte_array.include?('[Byte[]] $').should be_true
+      byte_array.include?('[Byte[]] $').should be_truthy
     end
   end
 

--- a/spec/lib/rex/exploitation/powershell_spec.rb
+++ b/spec/lib/rex/exploitation/powershell_spec.rb
@@ -39,7 +39,7 @@ DumpHashes"""
     it 'should substitute values in script' do
       script = described_class.make_subs(example_script,[['BitConverter','ParpConverter']])
       script.include?('BitConverter').should be_false
-      script.include?('ParpConverter').should be_true
+      script.include?('ParpConverter').should be_truthy
     end
   end
 

--- a/spec/lib/rex/exploitation/ropdb_spec.rb
+++ b/spec/lib/rex/exploitation/ropdb_spec.rb
@@ -16,19 +16,19 @@ describe Rex::Exploitation::RopDb do
 
     context ".has_rop?" do
       it "should find the msvcrt ROP database" do
-        ropdb.has_rop?("msvcrt").should be_true
+        ropdb.has_rop?("msvcrt").should be_truthy
       end
 
       it "should find the java ROP database" do
-        ropdb.has_rop?("java").should be_true
+        ropdb.has_rop?("java").should be_truthy
       end
 
       it "should find the hxds ROP database" do
-        ropdb.has_rop?("hxds").should be_true
+        ropdb.has_rop?("hxds").should be_truthy
       end
 
       it "should find the flash ROP database" do
-        ropdb.has_rop?("flash").should be_true
+        ropdb.has_rop?("flash").should be_truthy
       end
 
       it "should return false when I supply an invalid database" do

--- a/spec/lib/rex/parser/group_policy_preferences_spec.rb
+++ b/spec/lib/rex/parser/group_policy_preferences_spec.rb
@@ -132,7 +132,7 @@ describe Rex::Parser::GPP do
   it "Parse returns results for xml_datasrc, and attributes, and password is test1" do
     results = GPP.parse(xml_datasrc)
     results.should_not be_empty
-    results[0].include?(:ATTRIBUTES).should be_true
+    results[0].include?(:ATTRIBUTES).should be_truthy
     results[0][:ATTRIBUTES].should_not be_empty
     results[0][:PASS].should eq("test")
   end

--- a/spec/lib/rex/post/meterpreter/client_core_spec.rb
+++ b/spec/lib/rex/post/meterpreter/client_core_spec.rb
@@ -29,14 +29,14 @@ describe Rex::Post::Meterpreter::ClientCore do
     context 'with a gemified module' do
       let(:mod) {"kiwi"}
       it 'should be available' do
-        expect(client_core.use(mod)).to be_true
+        expect(client_core.use(mod)).to be_truthy
       end
     end
 
     context 'with a local module' do
       let(:mod) {"sniffer"}
       it 'should be available' do
-        expect(client_core.use(mod)).to be_true
+        expect(client_core.use(mod)).to be_truthy
       end
     end
 

--- a/spec/support/shared/examples/metasploit/framework/login_scanner/http.rb
+++ b/spec/support/shared/examples/metasploit/framework/login_scanner/http.rb
@@ -16,7 +16,7 @@ shared_examples_for 'Metasploit::Framework::LoginScanner::HTTP' do
     context "with ssl, without port" do
       subject(:http_scanner) { described_class.new(ssl:true) }
       it "should set :port to default ssl port (#{described_class::DEFAULT_SSL_PORT})" do
-        expect(http_scanner.ssl).to be_true
+        expect(http_scanner.ssl).to be_truthy
         expect(http_scanner.port).to eq(described_class::DEFAULT_SSL_PORT)
       end
     end
@@ -32,7 +32,7 @@ shared_examples_for 'Metasploit::Framework::LoginScanner::HTTP' do
     context "without ssl, with default SSL port" do
       subject(:http_scanner) { described_class.new(port:described_class::DEFAULT_SSL_PORT) }
       it "should set ssl to true" do
-        expect(http_scanner.ssl).to be_true
+        expect(http_scanner.ssl).to be_truthy
         expect(http_scanner.port).to eq(described_class::DEFAULT_SSL_PORT)
       end
     end

--- a/spec/support/shared/examples/msf/db_manager/search_modules/mdm_module_platform_name_or_mdm_module_target_name_keyword.rb
+++ b/spec/support/shared/examples/msf/db_manager/search_modules/mdm_module_platform_name_or_mdm_module_target_name_keyword.rb
@@ -25,7 +25,7 @@ shared_examples_for 'Msf::DBManager#search_modules Mdm::Module::Platform#name or
           module_detail.platforms.any? { |module_platform|
             module_platform.name == self.module_platform.name
           }
-        }.should be_true
+        }.should be_truthy
       end
     end
 
@@ -42,7 +42,7 @@ shared_examples_for 'Msf::DBManager#search_modules Mdm::Module::Platform#name or
           module_detail.targets.any? { |module_target|
             module_target.name == self.module_target.name
           }
-        }.should be_true
+        }.should be_truthy
       end
     end
   end

--- a/spec/support/shared/examples/msf/db_manager/search_modules/mdm_module_ref_name_keyword.rb
+++ b/spec/support/shared/examples/msf/db_manager/search_modules/mdm_module_ref_name_keyword.rb
@@ -31,7 +31,7 @@ shared_examples_for 'Msf::DBManager#search_modules Mdm::Module::Ref#name keyword
           module_detail.refs.any? { |module_ref|
             module_ref.name == name
           }
-        }.should be_true
+        }.should be_truthy
       end
     end
 

--- a/spec/support/shared/examples/msf/module_manager/cache.rb
+++ b/spec/support/shared/examples/msf/module_manager/cache.rb
@@ -44,7 +44,7 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
         {}
       end
 
-      it { should be_true }
+      it { should be_truthy }
     end
 
     context 'without empty' do
@@ -204,7 +204,7 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
             true
           end
 
-          it { should be_true }
+          it { should be_truthy }
         end
       end
     end
@@ -315,7 +315,7 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
           true
         end
 
-        it { should be_true }
+        it { should be_truthy }
       end
 
       context 'without migrated' do

--- a/spec/support/shared/examples/msf/module_manager/loading.rb
+++ b/spec/support/shared/examples/msf/module_manager/loading.rb
@@ -9,7 +9,7 @@ shared_examples_for 'Msf::ModuleManager::Loading' do
         module_path = tempfile.path
 
         subject.send(:module_info_by_path)[module_path].should be_nil
-        subject.file_changed?(module_path).should be_true
+        subject.file_changed?(module_path).should be_truthy
       end
     end
 
@@ -25,7 +25,7 @@ shared_examples_for 'Msf::ModuleManager::Loading' do
             :type => Msf::MODULE_PAYLOAD
         }
 
-        subject.file_changed?(module_path).should be_true
+        subject.file_changed?(module_path).should be_truthy
       end
     end
 
@@ -42,7 +42,7 @@ shared_examples_for 'Msf::ModuleManager::Loading' do
         tempfile.unlink
 
         File.exist?(module_path).should be_false
-        subject.file_changed?(module_path).should be_true
+        subject.file_changed?(module_path).should be_truthy
       end
 
       it 'should return true if modification time does not match the cached modification time' do
@@ -56,7 +56,7 @@ shared_examples_for 'Msf::ModuleManager::Loading' do
           }
 
           cached_modification_time.should_not == modification_time
-          subject.file_changed?(module_path).should be_true
+          subject.file_changed?(module_path).should be_truthy
         end
       end
 

--- a/spec/support/shared/examples/msf/module_manager/module_paths.rb
+++ b/spec/support/shared/examples/msf/module_manager/module_paths.rb
@@ -32,7 +32,7 @@ shared_examples_for 'Msf::ModuleManager::ModulePaths' do
         Tempfile.open(archive_basename) do |temporary_file|
           path = temporary_file.path
 
-          File.exist?(path).should be_true
+          File.exist?(path).should be_truthy
 
           module_manager.add_module_path(path)
 

--- a/spec/support/shared/examples/options.rb
+++ b/spec/support/shared/examples/options.rb
@@ -32,7 +32,7 @@ shared_examples_for "an option" do |valid_values, invalid_values, type|
       it "should be valid and normalize appropriately: #{valid_value}" do
         block = Proc.new {
           subject.normalize(valid_value).should == normalized_value
-          subject.valid?(valid_value).should be_true
+          subject.valid?(valid_value).should be_truthy
         }
         if vhash[:pending]
           pending(vhash[:pending], &block)


### PR DESCRIPTION
Switch from `be_true` to `be_truthy` in specs, according to rspec deprecation warnings.
## Verification
- [x] Be sure travis is green!
