### PR TITLE
Update cve 2014 3996 name; fix bug in PMP path

### DIFF
--- a/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
+++ b/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "ManageEngine Password Manager MetadataServlet.dat SQL Injection",
+      'Name'           => "ManageEngine Desktop Central / Password Manager LinkViewFetchServlet.dat SQL Injection",
       'Description'    => %q{
         This module exploits an unauthenticated blind SQL injection in LinkViewFetchServlet,
         which is exposed in ManageEngine Desktop Central v7 build 70200 to v9 build 90033 and

--- a/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
+++ b/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
@@ -216,7 +216,7 @@ class Metasploit3 < Msf::Exploit::Remote
     paths = desktop_central_db_paths
 
     if paths.empty?
-      paths = check_password_manager_pro
+      paths = password_manager_paths
     end
 
     paths


### PR DESCRIPTION
Corrects the servlet name (LinkViewFetchServlet) and adds a mention to Desktop Central. Also corrected a bug when finding PMP db paths.

The rest looks all good!
