### PR TITLE
Glassfish LoginScanner update

### DIFF
--- a/spec/lib/metasploit/framework/login_scanner/glassfish_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/glassfish_spec.rb
@@ -47,20 +47,20 @@ describe Metasploit::Framework::LoginScanner::Glassfish do
         {'uri'=>'/', 'method'=>'GET'}
       end
 
-      it 'should return a Rex::Proto::Http::Response' do
+      it 'returns a Rex::Proto::Http::Response object' do
         allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).and_return(Rex::Proto::Http::Response.new(res_code))
-        http_scanner.send_request(req_opts).code.should eq(res_code)
+        expect(http_scanner.send_request(req_opts)).to be_kind_of(Rex::Proto::Http::Response)
       end
     end
 
     context '#is_secure_admin_disabled?' do
-      it 'should return true when Secure Admin is disabled' do
+      it 'returns true when Secure Admin is disabled' do
         res = Rex::Proto::Http::Response.new(res_code)
         res.stub(:body).and_return('Secure Admin must be enabled')
-        http_scanner.is_secure_admin_disabled?(res).should eq(true)
+        expect(http_scanner.is_secure_admin_disabled?(res)).to eq(true)
       end
 
-      it 'should return false when Secure Admin is enabled' do
+      it 'returns false when Secure Admin is enabled' do
         res = Rex::Proto::Http::Response.new(res_code)
         res.stub(:body).and_return('')
         http_scanner.is_secure_admin_disabled?(res).should eq(false)
@@ -68,19 +68,19 @@ describe Metasploit::Framework::LoginScanner::Glassfish do
     end
 
     context '#try_login' do
-      it 'should send a login request to /j_security_check' do
+      it 'sends a login request to /j_security_check' do
         http_scanner.should_receive(:send_request).with(hash_including('uri'=>'/j_security_check'))
         http_scanner.try_login(cred)
       end
 
-      it 'should send a login request containing the username and password' do
+      it 'sends a login request containing the username and password' do
         http_scanner.should_receive(:send_request).with(hash_including('data'=>"j_username=#{username}&j_password=#{password}&loginButton=Login"))
         http_scanner.try_login(cred)
       end
     end
 
     context '#try_glassfish_2' do
-      it 'should return status Metasploit::Model::Login::Status::SUCCESSFUL for a valid credential' do
+      it 'returns status Metasploit::Model::Login::Status::SUCCESSFUL for a valid credential' do
         good_auth_res = Rex::Proto::Http::Response.new(302)
         good_res = Rex::Proto::Http::Response.new(200)
         good_res.stub(:body).and_return('<title>Deploy Enterprise Applications/Modules</title>')
@@ -89,7 +89,7 @@ describe Metasploit::Framework::LoginScanner::Glassfish do
         http_scanner.try_glassfish_2(cred)[:status].should eq(Metasploit::Model::Login::Status::SUCCESSFUL)
       end
 
-      it 'should return Metasploit::Model::Login::Status::INCORRECT for an invalid credential' do
+      it 'returns Metasploit::Model::Login::Status::INCORRECT for an invalid credential' do
         bad_auth_res = Rex::Proto::Http::Response.new(200)
         http_scanner.should_receive(:try_login).with(cred).and_return(bad_auth_res)
         http_scanner.try_glassfish_2(cred)[:status].should eq(Metasploit::Model::Login::Status::INCORRECT)
@@ -97,7 +97,7 @@ describe Metasploit::Framework::LoginScanner::Glassfish do
     end
 
     context '#try_glassfish_3' do
-      it 'should return status Metasploit::Model::Login::Status::SUCCESSFUL for a valid credential' do
+      it 'returns status Metasploit::Model::Login::Status::SUCCESSFUL for a valid credential' do
         good_auth_res = Rex::Proto::Http::Response.new(302)
         good_res = Rex::Proto::Http::Response.new(200)
         good_res.stub(:body).and_return('<title>Deploy Applications or Modules</title>')
@@ -106,14 +106,14 @@ describe Metasploit::Framework::LoginScanner::Glassfish do
         http_scanner.try_glassfish_3(cred)[:status].should eq(Metasploit::Model::Login::Status::SUCCESSFUL)
       end
 
-      it 'should return status Metasploit::Model::Login::Status::SUCCESSFUL based on a disabled remote admin message' do
+      it 'returns status Metasploit::Model::Login::Status::SUCCESSFUL based on a disabled remote admin message' do
         good_auth_res = Rex::Proto::Http::Response.new(200)
         good_auth_res.stub(:body).and_return('Secure Admin must be enabled')
         http_scanner.should_receive(:try_login).with(cred).and_return(good_auth_res)
         http_scanner.try_glassfish_3(cred)[:status].should eq(Metasploit::Model::Login::Status::SUCCESSFUL)
       end
 
-      it 'should return status Metasploit::Model::Login::Status::INCORRECT for an invalid credential' do
+      it 'returns status Metasploit::Model::Login::Status::INCORRECT for an invalid credential' do
         bad_auth_res = Rex::Proto::Http::Response.new(200)
         http_scanner.should_receive(:try_login).with(cred).and_return(bad_auth_res)
         http_scanner.try_glassfish_3(cred)[:status].should eq(Metasploit::Model::Login::Status::INCORRECT)
@@ -121,25 +121,25 @@ describe Metasploit::Framework::LoginScanner::Glassfish do
     end
 
     context '#attempt_login' do
-      it 'Rex::ConnectionError should result in status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
+      it 'returns status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
         allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect).and_raise(Rex::ConnectionError)
 
         expect(http_scanner.attempt_login(cred).status).to eq(Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
       end
 
-      it 'Timeout::Error should result in status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
+      it 'returns status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
         allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect).and_raise(Timeout::Error)
 
         expect(http_scanner.attempt_login(cred).status).to eq(Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
       end
 
-      it 'EOFError should result in status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
+      it 'returns status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
         allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect).and_raise(EOFError)
 
         expect(http_scanner.attempt_login(cred).status).to eq(Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
       end
 
-      it 'Unsupported Glassfish version should result in a GlassfishError exception' do
+      it 'raises a GlassfishError exception due to an unsupported Glassfish version' do
         http_scanner.version = bad_version
         expect { http_scanner.attempt_login(cred) }.to raise_exception(Metasploit::Framework::LoginScanner::GlassfishError)
       end

--- a/spec/lib/metasploit/framework/login_scanner/glassfish_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/glassfish_spec.rb
@@ -9,144 +9,140 @@ describe Metasploit::Framework::LoginScanner::Glassfish do
 
   subject(:http_scanner) { described_class.new }
 
-  context 'Instance Methods' do
-    let(:good_version) do
-      '4.0'
-    end
-
-    let(:bad_version) do
-      'Unknown'
-    end
-
-    let(:username) do
-      'admin'
-    end
-
-    let(:password) do
-      'password'
-    end
-
-    let(:cred) do
-      Metasploit::Framework::Credential.new(
-        paired: true,
-        public: username,
-        private: password
-      )
-    end
-
-    let(:res_code) do
-      200
-    end
-
-    before do
-      http_scanner.version = good_version
-    end
-
-    context '#send_request' do
-      let(:req_opts) do
-        {'uri'=>'/', 'method'=>'GET'}
-      end
-
-      it 'returns a Rex::Proto::Http::Response object' do
-        allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).and_return(Rex::Proto::Http::Response.new(res_code))
-        expect(http_scanner.send_request(req_opts)).to be_kind_of(Rex::Proto::Http::Response)
-      end
-    end
-
-    context '#is_secure_admin_disabled?' do
-      it 'returns true when Secure Admin is disabled' do
-        res = Rex::Proto::Http::Response.new(res_code)
-        res.stub(:body).and_return('Secure Admin must be enabled')
-        expect(http_scanner.is_secure_admin_disabled?(res)).to eq(true)
-      end
-
-      it 'returns false when Secure Admin is enabled' do
-        res = Rex::Proto::Http::Response.new(res_code)
-        res.stub(:body).and_return('')
-        http_scanner.is_secure_admin_disabled?(res).should eq(false)
-      end
-    end
-
-    context '#try_login' do
-      it 'sends a login request to /j_security_check' do
-        http_scanner.should_receive(:send_request).with(hash_including('uri'=>'/j_security_check'))
-        http_scanner.try_login(cred)
-      end
-
-      it 'sends a login request containing the username and password' do
-        http_scanner.should_receive(:send_request).with(hash_including('data'=>"j_username=#{username}&j_password=#{password}&loginButton=Login"))
-        http_scanner.try_login(cred)
-      end
-    end
-
-    context '#try_glassfish_2' do
-      it 'returns status Metasploit::Model::Login::Status::SUCCESSFUL for a valid credential' do
-        good_auth_res = Rex::Proto::Http::Response.new(302)
-        good_res = Rex::Proto::Http::Response.new(200)
-        good_res.stub(:body).and_return('<title>Deploy Enterprise Applications/Modules</title>')
-        http_scanner.should_receive(:try_login).with(cred).and_return(good_auth_res)
-        http_scanner.should_receive(:send_request).with(kind_of(Hash)).and_return(good_res)
-        http_scanner.try_glassfish_2(cred)[:status].should eq(Metasploit::Model::Login::Status::SUCCESSFUL)
-      end
-
-      it 'returns Metasploit::Model::Login::Status::INCORRECT for an invalid credential' do
-        bad_auth_res = Rex::Proto::Http::Response.new(200)
-        http_scanner.should_receive(:try_login).with(cred).and_return(bad_auth_res)
-        http_scanner.try_glassfish_2(cred)[:status].should eq(Metasploit::Model::Login::Status::INCORRECT)
-      end
-    end
-
-    context '#try_glassfish_3' do
-      it 'returns status Metasploit::Model::Login::Status::SUCCESSFUL for a valid credential' do
-        good_auth_res = Rex::Proto::Http::Response.new(302)
-        good_res = Rex::Proto::Http::Response.new(200)
-        good_res.stub(:body).and_return('<title>Deploy Applications or Modules</title>')
-        http_scanner.should_receive(:try_login).with(cred).and_return(good_auth_res)
-        http_scanner.should_receive(:send_request).with(kind_of(Hash)).and_return(good_res)
-        http_scanner.try_glassfish_3(cred)[:status].should eq(Metasploit::Model::Login::Status::SUCCESSFUL)
-      end
-
-      it 'returns status Metasploit::Model::Login::Status::SUCCESSFUL based on a disabled remote admin message' do
-        good_auth_res = Rex::Proto::Http::Response.new(200)
-        good_auth_res.stub(:body).and_return('Secure Admin must be enabled')
-        http_scanner.should_receive(:try_login).with(cred).and_return(good_auth_res)
-        http_scanner.try_glassfish_3(cred)[:status].should eq(Metasploit::Model::Login::Status::SUCCESSFUL)
-      end
-
-      it 'returns status Metasploit::Model::Login::Status::INCORRECT for an invalid credential' do
-        bad_auth_res = Rex::Proto::Http::Response.new(200)
-        http_scanner.should_receive(:try_login).with(cred).and_return(bad_auth_res)
-        http_scanner.try_glassfish_3(cred)[:status].should eq(Metasploit::Model::Login::Status::INCORRECT)
-      end
-    end
-
-    context '#attempt_login' do
-      it 'returns status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
-        allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect).and_raise(Rex::ConnectionError)
-
-        expect(http_scanner.attempt_login(cred).status).to eq(Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
-      end
-
-      it 'returns status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
-        allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect).and_raise(Timeout::Error)
-
-        expect(http_scanner.attempt_login(cred).status).to eq(Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
-      end
-
-      it 'returns status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
-        allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect).and_raise(EOFError)
-
-        expect(http_scanner.attempt_login(cred).status).to eq(Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
-      end
-
-      it 'raises a GlassfishError exception due to an unsupported Glassfish version' do
-        http_scanner.version = bad_version
-        expect { http_scanner.attempt_login(cred) }.to raise_exception(Metasploit::Framework::LoginScanner::GlassfishError)
-      end
-    end
-
+  let(:good_version) do
+    '4.0'
   end
 
+  let(:bad_version) do
+    'Unknown'
+  end
+
+  let(:username) do
+    'admin'
+  end
+
+  let(:password) do
+    'password'
+  end
+
+  let(:cred) do
+    Metasploit::Framework::Credential.new(
+      paired: true,
+      public: username,
+      private: password
+    )
+  end
+
+  let(:res_code) do
+    200
+  end
+
+  before do
+    http_scanner.version = good_version
+  end
+
+  context '#send_request' do
+    let(:req_opts) do
+      {'uri'=>'/', 'method'=>'GET'}
+    end
+
+    it 'returns a Rex::Proto::Http::Response object' do
+      allow_any_instance_of(Rex::Proto::Http::Client).to receive(:send_recv).and_return(Rex::Proto::Http::Response.new(res_code))
+      expect(http_scanner.send_request(req_opts)).to be_kind_of(Rex::Proto::Http::Response)
+    end
+  end
+
+  context '#is_secure_admin_disabled?' do
+    it 'returns true when Secure Admin is disabled' do
+      res = Rex::Proto::Http::Response.new(res_code)
+      res.stub(:body).and_return('Secure Admin must be enabled')
+      expect(http_scanner.is_secure_admin_disabled?(res)).to eq(true)
+    end
+
+    it 'returns false when Secure Admin is enabled' do
+      res = Rex::Proto::Http::Response.new(res_code)
+      res.stub(:body).and_return('')
+      http_scanner.is_secure_admin_disabled?(res).should eq(false)
+    end
+  end
+
+  context '#try_login' do
+    it 'sends a login request to /j_security_check' do
+      http_scanner.should_receive(:send_request).with(hash_including('uri'=>'/j_security_check'))
+      http_scanner.try_login(cred)
+    end
+
+    it 'sends a login request containing the username and password' do
+      http_scanner.should_receive(:send_request).with(hash_including('data'=>"j_username=#{username}&j_password=#{password}&loginButton=Login"))
+      http_scanner.try_login(cred)
+    end
+  end
+
+  context '#try_glassfish_2' do
+    it 'returns status Metasploit::Model::Login::Status::SUCCESSFUL for a valid credential' do
+      good_auth_res = Rex::Proto::Http::Response.new(302)
+      good_res = Rex::Proto::Http::Response.new(200)
+      good_res.stub(:body).and_return('<title>Deploy Enterprise Applications/Modules</title>')
+      http_scanner.should_receive(:try_login).with(cred).and_return(good_auth_res)
+      http_scanner.should_receive(:send_request).with(kind_of(Hash)).and_return(good_res)
+      http_scanner.try_glassfish_2(cred)[:status].should eq(Metasploit::Model::Login::Status::SUCCESSFUL)
+    end
+
+    it 'returns Metasploit::Model::Login::Status::INCORRECT for an invalid credential' do
+      bad_auth_res = Rex::Proto::Http::Response.new(200)
+      http_scanner.should_receive(:try_login).with(cred).and_return(bad_auth_res)
+      http_scanner.try_glassfish_2(cred)[:status].should eq(Metasploit::Model::Login::Status::INCORRECT)
+    end
+  end
+
+  context '#try_glassfish_3' do
+    it 'returns status Metasploit::Model::Login::Status::SUCCESSFUL for a valid credential' do
+      good_auth_res = Rex::Proto::Http::Response.new(302)
+      good_res = Rex::Proto::Http::Response.new(200)
+      good_res.stub(:body).and_return('<title>Deploy Applications or Modules</title>')
+      http_scanner.should_receive(:try_login).with(cred).and_return(good_auth_res)
+      http_scanner.should_receive(:send_request).with(kind_of(Hash)).and_return(good_res)
+      http_scanner.try_glassfish_3(cred)[:status].should eq(Metasploit::Model::Login::Status::SUCCESSFUL)
+    end
+
+    it 'returns status Metasploit::Model::Login::Status::SUCCESSFUL based on a disabled remote admin message' do
+      good_auth_res = Rex::Proto::Http::Response.new(200)
+      good_auth_res.stub(:body).and_return('Secure Admin must be enabled')
+      http_scanner.should_receive(:try_login).with(cred).and_return(good_auth_res)
+      http_scanner.try_glassfish_3(cred)[:status].should eq(Metasploit::Model::Login::Status::SUCCESSFUL)
+    end
+
+    it 'returns status Metasploit::Model::Login::Status::INCORRECT for an invalid credential' do
+      bad_auth_res = Rex::Proto::Http::Response.new(200)
+      http_scanner.should_receive(:try_login).with(cred).and_return(bad_auth_res)
+      http_scanner.try_glassfish_3(cred)[:status].should eq(Metasploit::Model::Login::Status::INCORRECT)
+    end
+  end
+
+  context '#attempt_login' do
+    it 'returns status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
+      allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect).and_raise(Rex::ConnectionError)
+
+      expect(http_scanner.attempt_login(cred).status).to eq(Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
+    end
+
+    it 'returns status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
+      allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect).and_raise(Timeout::Error)
+
+      expect(http_scanner.attempt_login(cred).status).to eq(Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
+    end
+
+    it 'returns status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
+      allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect).and_raise(EOFError)
+
+      expect(http_scanner.attempt_login(cred).status).to eq(Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
+    end
+
+    it 'raises a GlassfishError exception due to an unsupported Glassfish version' do
+      http_scanner.version = bad_version
+      expect { http_scanner.attempt_login(cred) }.to raise_exception(Metasploit::Framework::LoginScanner::GlassfishError)
+    end
+  end
 
 end
 


### PR DESCRIPTION
This is an update for the Glassfish login module. Mainly it covers:
- New auth support for Glassfish 4
- Uses LoginScanner
- Can automatically switch from HTTP to HTTPS
- Updated information about the "authentication bypass"
- Other minor fixes

Targets tested during the update (Windows 2003, Windows 7, and Ubuntu):
- GlassFish Server Open Source Edition 4.0
- Oracle GlassFish Server 3.1
- Sun GlassFish Enterprise Server v2.1.1

Yes, it is a little annoying they sort of have different names.
## Verification steps for the latest version

**Setting up Glassfish:**
- [x] Windows is the easiest to set up, so get a Windows VM up and ready. Windows 2003 SP2 or Win 7 should be fine.
- [x] Download and install JDK8: http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
- [x] Download Glassfish 4: http://download.java.net/glassfish/4.0/release/glassfish-4.0.zip
- [x] Extract glassfish-4.0.zip
- [x] In command prompt, go to directory glassfish4\bin\
- [x] Run `asadmin`, which is the admin console.
- [x] Enter `start-domain domain1`
- [x] Make sure that there's a port listening at 4848

If you prefer to set up your own domain (but you don't really have to), in asadmin, do this:
1. `create-domain --adminport=4848 domain2`
2. You will be asked to set the username and password
3. `start-domain domain2` to start the domain.

To shut down a domain, here's how:

`stop-domain domain1`

**Test the module with Secure Admin off**

By default, Secure Admin is off, so you cannot login remotely. Let's test this and make sure the module is aware of this condition:
- [x] Start msfconsole
- [x] `use auxiliary/scanner/http/glassfish_login`
- [x] Set the appropriate options (rhosts, username, and password)
- [x] `Run`
- [ ] Make sure you see the message: "Secure Admin must be enabled to access the DAS remotely."

**Test the module with Secure Admin on**
- [x] On the Glassfish box, open a browser, and then go to: http://localhost:4848
- [x] Look at the menu on the left, those are the "Common Tasks". You should see an item that says "server (Admin Server)", click on that.
- [x] You should see a button that says "Enable Secure Admin", click on that. If your Glassfish does not have a password, it will ask you to set that first before enabling Secure Admin.
- [x] On the attack's box, use the browser to verify you can login remotely
- [x] Run the glassfish_login module with the correct username/password, you should see a successful login attempt message
- [x] Run the glassfish_login module with a bad password, you should NOT see the same successful login message
## Verification on an older version of Glassfish

If you want to verify on an older version, you can download them here:
https://glassfish.java.net/download-archive.html

Note that there's only 3.1.2.2 and 2.1.1. Version 3 ships with Java and is easier to install. Version 2 involves more manual work.

Since 2.1.1 involves more manual work, if you need the installation doc, you can get it here:
https://glassfish.java.net/downloads/v2.1.1-final.html
## Demo

```
msf auxiliary(glassfish_login) > run

[*] Sending a request to /common/index.jsf...
[*] Glassfish is asking us to use HTTPS
[*] SSL option automatically set to: true
[*] SSL version option automatically set to: TLS1
[*] Sending a request to /common/index.jsf...
[*] Checking if Glassfish requires a password...
[*] Glassfish is protected with a password
[+] 192.168.1.123:4848 GLASSFISH - Success: 'admin:yoyoyo'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
