### PR TITLE
Fixed annoying typo that shows up in validation screenshots

### DIFF
--- a/modules/auxiliary/scanner/ssl/openssl_ccs.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_ccs.rb
@@ -79,9 +79,9 @@ class Metasploit3 < Msf::Auxiliary
     super(
       'Name'           => 'OpenSSL Server-Side ChangeCipherSpec Injection Scanner',
       'Description'    => %q{
-        This module checks for the OpenSSL ChageCipherSpec (CCS)
+        This module checks for the OpenSSL ChangeCipherSpec (CCS)
         Injection vulnerability. The problem exists in the handling of early
-        CCS messages during session negotation. Vulnerable installations of OpenSSL accepts
+        CCS messages during session negotiation. Vulnerable installations of OpenSSL accepts
         them, while later implementations do not. If successful, an attacker can leverage this
         vulnerability to perform a man-in-the-middle (MITM) attack by downgrading the cipher spec
         between a client and server. This issue was first reported in early June, 2014.

--- a/modules/auxiliary/scanner/ssl/openssl_ccs.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_ccs.rb
@@ -131,7 +131,7 @@ class Metasploit3 < Msf::Auxiliary
     sock.put(ccs)
     alert = sock.get_once(-1, response_timeout)
     if alert.blank?
-      print_good("#{peer} - No alert after invalid CSS message, probably vulnerable")
+      print_good("#{peer} - No alert after invalid CCS message, probably vulnerable")
       report
     elsif alert.unpack("C").first == ALERT_RECORD_TYPE
       vprint_error("#{peer} - Alert record as response to the invalid CCS Message, probably not vulnerable")


### PR DESCRIPTION
This change is extremely minor, but it's annoying to show a "CCS" vulnerability to a client, and then in the validation screenshot it says "CSS". I have been forgetting to submit this for months, but finally got to it.
