### PR TITLE
Returns csv output to creds command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -906,7 +906,7 @@ class Db
       else
         # create the output file
         ::File.open(output_file, "wb") { |f| f.write(tbl.to_csv) }
-        print_status("Wrote services to #{output_file}")
+        print_status("Wrote creds to #{output_file}")
       end
       
       print_status("Deleted #{delete_count} creds") if delete_count > 0

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -669,6 +669,7 @@ class Db
     print_line
     print_line "General options"
     print_line "  -h,--help             Show this help information"
+    print_line "  -o <file>             Send output to a file in csv format"
     print_line
     print_line "Filter options for listing"
     print_line "  -P,--password <regex> List passwords that match this regex"
@@ -900,7 +901,14 @@ class Db
         end
       end
 
-      print_line(tbl.to_s)
+      if output_file.nil?
+        print_line(tbl.to_s)
+      else
+        # create the output file
+        ::File.open(output_file, "wb") { |f| f.write(tbl.to_csv) }
+        print_status("Wrote services to #{output_file}")
+      end
+      
       print_status("Deleted #{delete_count} creds") if delete_count > 0
     }
   end


### PR DESCRIPTION
commit 82b2c1deae1f122dee23f41d9b58efc980998aa6 removed the -o option
from the creds command. This returns it to its former glory!
