### PR TITLE
Add the 'guest' IPMI user to the ipmi_users wordlist

### DIFF
--- a/data/wordlists/ipmi_users.txt
+++ b/data/wordlists/ipmi_users.txt
@@ -3,3 +3,4 @@ admin
 root
 Administrator
 USERID
+guest


### PR DESCRIPTION
The 'guest' IPMI user exists on many Cisco Unified Computing Server (UCS) implementations.
