### PR TITLE
Fix rspec-collection_matchers specs deprecation warnings

### DIFF
--- a/spec/lib/rex/socket/range_walker_spec.rb
+++ b/spec/lib/rex/socket/range_walker_spec.rb
@@ -15,13 +15,13 @@ describe Rex::Socket::RangeWalker do
     context "with a hostname" do
       let(:args) { "localhost" }
       it { should be_valid }
-      it { should have_at_least(1).address }
+      it { expect(subject.length).to be >= 1 }
     end
 
     context "with a hostname and CIDR" do
       let(:args) { "localhost/24" }
       it { should be_valid }
-      it { should have(256).addresses }
+      it { expect(subject.length).to eq(256) }
     end
 
     context "with an invalid hostname" do
@@ -55,7 +55,7 @@ describe Rex::Socket::RangeWalker do
     context "with mulitple ranges" do
       let(:args) { "1.1.1.1-2 2.1-2.2.2 3.1-2.1-2.1 " }
       it { should be_valid }
-      it { should have(8).addresses }
+      it { expect(subject.length).to eq(8) }
       it { should include("1.1.1.1") }
     end
 

--- a/spec/lib/rex/socket_spec.rb
+++ b/spec/lib/rex/socket_spec.rb
@@ -39,7 +39,7 @@ describe Rex::Socket do
 
     context 'with ipv6' do
       let(:try) { "fe80::1" }
-      it { expect(subject).to be_an(String) }
+      it { is_expected.to be_an(String) }
       it { expect(subject.bytes.count).to eq(16) }
       it "should be in the right order" do
         nbo.should == "\xfe\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01"
@@ -48,7 +48,7 @@ describe Rex::Socket do
 
     context 'with ipv4' do
       let(:try) { "127.0.0.1" }
-      it { expect(subject).to be_an(String) }
+      it { is_expected.to be_an(String) }
       it { expect(subject.bytes.count).to eq(4) }
       it "should be in the right order" do
         nbo.should == "\x7f\x00\x00\x01"
@@ -131,7 +131,7 @@ describe Rex::Socket do
       let(:response_afamily) { Socket::AF_INET }
       let(:response_addresses) { ["\x01\x01\x01\x01", "\x02\x02\x02\x02"] }
 
-      it { expect(subject).to be_an(Array) }
+      it { is_expected.to be_an(Array) }
       it { expect(subject.size).to eq(2) }
       it "should return the ASCII addresses" do
         subject.should include("1.1.1.1")
@@ -143,7 +143,7 @@ describe Rex::Socket do
       let(:response_afamily) { Socket::AF_INET6 }
       let(:response_addresses) { ["\xfe\x80"+("\x00"*13)+"\x01", "\xfe\x80"+("\x00"*13)+"\x02"] }
 
-      it { expect(subject).to be_an(Array) }
+      it { is_expected.to be_an(Array) }
       it { expect(subject.size).to eq(2) }
       it "should return the ASCII addresses" do
         subject.should include("fe80::1")
@@ -155,7 +155,7 @@ describe Rex::Socket do
       let(:response_afamily) { Socket::AF_INET }
       let(:response_addresses) { ["1.1.1.1", "2.2.2.2"] }
 
-      it { expect(subject).to be_an(Array) }
+      it { is_expected.to be_an(Array) }
       it { expect(subject.size).to eq(2) }
       it "should return the ASCII addresses" do
         subject.should include("1.1.1.1")

--- a/spec/lib/rex/socket_spec.rb
+++ b/spec/lib/rex/socket_spec.rb
@@ -39,8 +39,8 @@ describe Rex::Socket do
 
     context 'with ipv6' do
       let(:try) { "fe80::1" }
-      it { should be_a(String) }
-      it { should have(16).bytes }
+      it { expect(subject).to be_an(String) }
+      it { expect(subject.bytes.count).to eq(16) }
       it "should be in the right order" do
         nbo.should == "\xfe\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01"
       end
@@ -48,8 +48,8 @@ describe Rex::Socket do
 
     context 'with ipv4' do
       let(:try) { "127.0.0.1" }
-      it { should be_a(String) }
-      it { should have(4).bytes }
+      it { expect(subject).to be_an(String) }
+      it { expect(subject.bytes.count).to eq(4) }
       it "should be in the right order" do
         nbo.should == "\x7f\x00\x00\x01"
       end
@@ -131,8 +131,8 @@ describe Rex::Socket do
       let(:response_afamily) { Socket::AF_INET }
       let(:response_addresses) { ["\x01\x01\x01\x01", "\x02\x02\x02\x02"] }
 
-      it { should be_a(Array) }
-      it { should have(2).addresses }
+      it { expect(subject).to be_an(Array) }
+      it { expect(subject.size).to eq(2) }
       it "should return the ASCII addresses" do
         subject.should include("1.1.1.1")
         subject.should include("2.2.2.2")
@@ -143,8 +143,8 @@ describe Rex::Socket do
       let(:response_afamily) { Socket::AF_INET6 }
       let(:response_addresses) { ["\xfe\x80"+("\x00"*13)+"\x01", "\xfe\x80"+("\x00"*13)+"\x02"] }
 
-      it { should be_a(Array) }
-      it { should have(2).addresses }
+      it { expect(subject).to be_an(Array) }
+      it { expect(subject.size).to eq(2) }
       it "should return the ASCII addresses" do
         subject.should include("fe80::1")
         subject.should include("fe80::2")
@@ -155,8 +155,8 @@ describe Rex::Socket do
       let(:response_afamily) { Socket::AF_INET }
       let(:response_addresses) { ["1.1.1.1", "2.2.2.2"] }
 
-      it { should be_a(Array) }
-      it { should have(2).addresses }
+      it { expect(subject).to be_an(Array) }
+      it { expect(subject.size).to eq(2) }
       it "should return the ASCII addresses" do
         subject.should include("1.1.1.1")
         subject.should include("2.2.2.2")


### PR DESCRIPTION
There are several rspec 3 deprecation warnings related to collection matches, like the next one: 

```
`expect(collection).to have_at_least(1).address` is deprecated. Use the rspec-collection_matchers gem or replace your expectation with something like `expect(collection.length).to be >= 1` instead. Called from /metasploit-framework/spec/lib/rex/socket/range_walker_spec.rb:18:in `block (4 levels) in <top (required)>'.
```

This pull request tries to solve these warning by using the recommended syntax instead of using the   rspec-collection_matchers gem.
## Requirements
- [ ] Worths to land #3711 first to avoid conflicts here
## Verification
- [ ] Be sure travis is green!
