### PR TITLE
Fix its() rspec deprecation warnings

### DIFF
--- a/spec/lib/msf/db_manager_spec.rb
+++ b/spec/lib/msf/db_manager_spec.rb
@@ -350,14 +350,14 @@ describe Msf::DBManager do
                   Mdm::Vuln.last
                 end
 
-                its(:host) { should == Mdm::Host.last }
-                its(:refs) { should == [] }
-                its(:exploited_at) { should be_within(1.second).of(Time.now.utc) }
+                it { expect(subject.host).to eq(Mdm::Host.last) }
+                it { expect(subject.refs).to eq([]) }
+                it { expect(subject.exploited_at).to be_within(1.second).of(Time.now.utc) }
 
                 context "with session.via_exploit 'exploit/multi/handler'" do
                   context "with session.exploit_datastore['ParentModule']" do
-                    its(:info) { should == "Exploited by #{parent_module_fullname} to create Session #{mdm_session.id}" }
-                    its(:name) { should == parent_module_name }
+                    it { expect(subject.info).to eq("Exploited by #{parent_module_fullname} to create Session #{mdm_session.id}") }
+                    it { expect(subject.name).to eq(parent_module_name) }
                   end
                 end
 
@@ -390,8 +390,8 @@ describe Msf::DBManager do
                     session.via_exploit = "#{type}/#{reference_name}"
                   end
 
-                  its(:info) { should == "Exploited by #{session.via_exploit} to create Session #{mdm_session.id}"}
-                  its(:name) { should == reference_name }
+                  it { expect(subject.info).to eq("Exploited by #{session.via_exploit} to create Session #{mdm_session.id}") }
+                  it { expect(subject.name).to eq(reference_name) }
                 end
 
                 context 'with RPORT' do
@@ -410,11 +410,11 @@ describe Msf::DBManager do
                     )
                   end
 
-                  its(:service) { should == service }
+                  it { expect(subject.service).to eq(service) }
                 end
 
                 context 'without RPORT' do
-                  its(:service) { should be_nil }
+                  it { expect(subject.service).to be_nil }
                 end
               end
 
@@ -439,16 +439,16 @@ describe Msf::DBManager do
                   Mdm::ExploitAttempt.last
                 end
 
-                its(:attempted_at) { should be_within(1.second).of(Time.now.utc) }
+                it { expect(subject.attempted_at).to be_within(1.second).of(Time.now.utc) }
                 # @todo https://www.pivotaltracker.com/story/show/48362615
-                its(:session_id) { should == Mdm::Session.last.id }
-                its(:exploited) { should == true }
+                it { expect(subject.session_id).to eq(Mdm::Session.last.id) }
+                it { expect(subject.exploited).to be_truthy }
                 # @todo https://www.pivotaltracker.com/story/show/48362615
-                its(:vuln_id) { should == Mdm::Vuln.last.id }
+                it { expect(subject.vuln_id).to eq(Mdm::Vuln.last.id) }
 
                 context "with session.via_exploit 'exploit/multi/handler'" do
                   context "with session.datastore['ParentModule']" do
-                    its(:module) { should == parent_module_fullname }
+                    it { expect(subject.module).to eq(parent_module_fullname) }
                   end
                 end
 
@@ -457,7 +457,7 @@ describe Msf::DBManager do
                     session.via_exploit = parent_module_fullname
                   end
 
-                  its(:module) { should == session.via_exploit }
+                  it { expect(subject.module).to eq(session.via_exploit) }
                 end
               end
             end
@@ -504,16 +504,16 @@ describe Msf::DBManager do
                 session.via_exploit.should be_present
               end
 
-              its(:datastore) { should == session.exploit_datastore.to_h }
-              its(:desc) { should == session.info }
-              its(:host_id) { should == Mdm::Host.last.id }
-              its(:last_seen) { should be_within(1.second).of(Time.now.utc) }
-              its(:local_id) { should == session.sid }
-              its(:opened_at) { should be_within(1.second).of(Time.now.utc) }
-              its(:platform) { should == session.platform }
-              its(:routes) { should == [] }
-              its(:stype) { should == session.type }
-              its(:via_payload) { should == session.via_payload }
+              it { expect(subject.datastore).to eq(session.exploit_datastore.to_h) }
+              it { expect(subject.desc).to eq(session.info) }
+              it { expect(subject.host_id).to eq(Mdm::Host.last.id) }
+              it { expect(subject.last_seen).to be_within(1.second).of(Time.now.utc) }
+              it { expect(subject.local_id).to eq(session.sid) }
+              it { expect(subject.opened_at).to be_within(1.second).of(Time.now.utc) }
+              it { expect(subject.platform).to eq(session.platform) }
+              it { expect(subject.routes).to eq([]) }
+              it { expect(subject.stype).to eq(session.type) }
+              it { expect(subject.via_payload).to eq(session.via_payload) }
 
               context "with session.via_exploit 'exploit/multi/handler'" do
                 it "should have session.via_exploit of 'exploit/multi/handler'" do
@@ -525,7 +525,7 @@ describe Msf::DBManager do
                     session.exploit_datastore['ParentModule'].should_not be_nil
                   end
 
-                  its(:via_exploit) { should == parent_module_fullname }
+                  it { expect(subject.via_exploit).to eq(parent_module_fullname) }
                 end
               end
 
@@ -559,7 +559,7 @@ describe Msf::DBManager do
                   session.via_exploit.should_not == 'exploit/multi/handler'
                 end
 
-                its(:via_exploit) { should == session.via_exploit }
+                it { expect(subject.via_exploit).to eq(session.via_exploit) }
               end
             end
           end
@@ -647,20 +647,20 @@ describe Msf::DBManager do
                 report_session
               end
 
-              its(:close_reason) { should == close_reason }
-              its(:desc) { should == description }
-              its(:host) { should == host }
-              its(:platform) { should == platform }
-              its(:stype) { should == session_type }
-              its(:via_exploit) { should == exploit_full_name }
-              its(:via_payload) { should == payload_full_name }
+              it { expect(subject.close_reason).to eq(close_reason) }
+              it { expect(subject.desc).to eq(description) }
+              it { expect(subject.host).to eq(host) }
+              it { expect(subject.platform).to eq(platform) }
+              it { expect(subject.stype).to eq(session_type) }
+              it { expect(subject.via_exploit).to eq(exploit_full_name) }
+              it { expect(subject.via_payload).to eq(payload_full_name) }
 
               context 'with :last_seen' do
                 let(:last_seen) do
                   opened_at
                 end
 
-                its(:last_seen) { should == last_seen }
+                it { expect(subject.last_seen).to eq(last_seen) }
               end
 
               context 'with :closed_at' do
@@ -668,11 +668,11 @@ describe Msf::DBManager do
                   opened_at + 1.minute
                 end
 
-                its(:closed_at) { should == closed_at }
+                it { expect(subject.closed_at).to eq(closed_at) }
               end
 
               context 'without :closed_at' do
-                its(:closed_at) { should == nil }
+                it { expect(subject.closed_at).to be_nil }
               end
 
               context 'without :last_seen' do
@@ -681,11 +681,11 @@ describe Msf::DBManager do
                     opened_at + 1.minute
                   end
 
-                  its(:last_seen) { should == closed_at }
+                  it { expect(subject.last_seen).to eq(closed_at) }
                 end
 
                 context 'without :closed_at' do
-                  its(:last_seen) { should be_nil }
+                  it { expect(subject.last_seen).to be_nil }
                 end
               end
 
@@ -698,11 +698,11 @@ describe Msf::DBManager do
                   )
                 end
 
-                its(:routes) { should == routes }
+                it { expect(subject.routes).to eq(routes) }
               end
 
               context 'without :routes' do
-                its(:routes) { should == [] }
+                it { expect(subject.routes).to eq([]) }
               end
             end
           end
@@ -1504,12 +1504,12 @@ describe Msf::DBManager do
             update_module_details
           end
 
-          its(:mtype) { should == module_type }
-          its(:privileged) { should == privileged }
-          its(:rank) { should == rank }
-          its(:ready) { should == true }
-          its(:refname) { should == module_reference_name }
-          its(:stance) { should == stance }
+          it { expect(subject.mtype).to eq(module_type) }
+          it { expect(subject.privileged).to eq(privileged) }
+          it { expect(subject.rank).to eq(rank) }
+          it { expect(subject.ready).to be_truthy }
+          it { expect(subject.refname).to eq(module_reference_name) }
+          it { expect(subject.stance).to eq(stance) }
         end
 
         context 'with :bits' do
@@ -1554,7 +1554,7 @@ describe Msf::DBManager do
                 update_module_details
               end
 
-              its(:name) { should == name }
+              it { expect(subject.name).to eq(name) }
             end
           end
 
@@ -1591,7 +1591,7 @@ describe Msf::DBManager do
                 update_module_details
               end
 
-              its(:name) { should == name }
+              it { expect(subject.name).to eq(name) }
             end
           end
 
@@ -1633,8 +1633,8 @@ describe Msf::DBManager do
                 update_module_details
               end
 
-              its(:name) { should == name }
-              its(:email) { should == email }
+              it { expect(subject.name).to eq(name) }
+              it { expect(subject.email).to eq(email) }
             end
           end
 
@@ -1671,7 +1671,7 @@ describe Msf::DBManager do
                 update_module_details
               end
 
-              its(:name) { should == name }
+              it { expect(subject.name).to eq(name) }
             end
           end
 
@@ -1708,7 +1708,7 @@ describe Msf::DBManager do
                 update_module_details
               end
 
-              its(:name) { should == name }
+              it { expect(subject.name).to eq(name) }
             end
           end
 
@@ -1750,8 +1750,8 @@ describe Msf::DBManager do
                 update_module_details
               end
 
-              its(:index) { should == index }
-              its(:name) { should == name }
+              it { expect(subject.index).to eq(index) }
+              it { expect(subject.name).to eq(name) }
             end
           end
         end

--- a/spec/msfupdate_spec.rb
+++ b/spec/msfupdate_spec.rb
@@ -188,9 +188,9 @@ describe Msfupdate do
   context "in an apt installation" do
     let(:msfbase_dir) { dummy_apt_pathname }
 
-    its(:apt?) { should == true }
-    its(:binary_install?) { should == false }
-    its(:git?) { should == false }
+    it { expect(subject.apt?).to be_truthy }
+    it { expect(subject.binary_install?).to be_falsey }
+    it { expect(subject.git?).to be_falsey }
 
     context "#validate_args" do
       before(:each) do
@@ -199,22 +199,22 @@ describe Msfupdate do
 
       context "with no args" do
         let(:args) { [] }
-        its(:validate_args) { should == true }
+        it { expect(subject.validate_args).to be_truthy }
       end
 
       context "with --git-remote" do
         let(:args) { ['--git-remote', 'foo'] }
-        its(:validate_args) { should == false }
+        it { expect(subject.validate_args).to be_falsey }
       end
 
       context "with --git-branch" do
         let(:args) { ['--git-branch', 'foo'] }
-        its(:validate_args) { should == false }
+        it { expect(subject.validate_args).to be_falsey }
       end
 
       context "with --offline-file" do
         let(:args) { ['--offline-file', 'foo'] }
-        its(:validate_args) { should == false }
+        it { expect(subject.validate_args).to be_falsey }
       end
     end
 
@@ -241,9 +241,9 @@ describe Msfupdate do
   context "in a binary installation" do
     let(:msfbase_dir) { dummy_install_pathname }
 
-    its(:apt?) { should == false }
-    its(:binary_install?) { should == true }
-    its(:git?) { should == false }
+    it { expect(subject.apt?).to be_falsey }
+    it { expect(subject.binary_install?).to be_truthy }
+    it { expect(subject.git?).to be_falsey }
 
     context "#validate_args" do
       before(:each) do
@@ -252,22 +252,22 @@ describe Msfupdate do
 
       context "with no args" do
         let(:args) { [] }
-        its(:validate_args) { should == true }
+        it { expect(subject.validate_args).to be_truthy }
       end
 
       context "with --git-remote" do
         let(:args) { ['--git-remote', 'foo'] }
-        its(:validate_args) { should == false }
+        it { expect(subject.validate_args).to be_falsey }
       end
 
       context "with --git-branch" do
         let(:args) { ['--git-branch', 'foo'] }
-        its(:validate_args) { should == false }
+        it { expect(subject.validate_args).to be_falsey }
       end
 
       context "with --offline-file" do
         let(:args) { ['--offline-file', 'foo'] }
-        its(:validate_args) { should == true }
+        it { expect(subject.validate_args).to be_truthy }
       end
     end
 
@@ -294,9 +294,10 @@ describe Msfupdate do
   context "in a git installation" do
     let(:msfbase_dir) { dummy_git_pathname }
 
-    its(:apt?) { should == false }
-    its(:binary_install?) { should == false }
-    its(:git?) { should == true }
+    it { expect(subject.apt?).to be_falsey }
+    it { expect(subject.binary_install?).to be_falsey }
+    it { expect(subject.git?).to be_truthy }
+
 
     context "#validate_args" do
       before(:each) do
@@ -305,22 +306,22 @@ describe Msfupdate do
 
       context "with no args" do
         let(:args) { [] }
-        its(:validate_args) { should == true }
+        it { expect(subject.validate_args).to be_truthy }
       end
 
       context "with --git-remote" do
         let(:args) { ['--git-remote', 'foo'] }
-        its(:validate_args) { should == true }
+        it { expect(subject.validate_args).to be_truthy }
       end
 
       context "with --git-branch" do
         let(:args) { ['--git-branch', 'foo'] }
-        its(:validate_args) { should == true }
+        it { expect(subject.validate_args).to be_truthy }
       end
 
       context "with --offline-file" do
         let(:args) { ['--offline-file', 'foo'] }
-        its(:validate_args) { should == false }
+        it { expect(subject.validate_args).to be_falsey }
       end
     end
 

--- a/spec/support/shared/examples/msf/module_manager/cache.rb
+++ b/spec/support/shared/examples/msf/module_manager/cache.rb
@@ -403,10 +403,10 @@ shared_examples_for 'Msf::ModuleManager::Cache' do
             module_info_by_path_from_database!
           end
 
-          its([:modification_time]) { should be_within(1.second).of(pathname_modification_time) }
-          its([:parent_path]) { should == parent_path }
-          its([:reference_name]) { should == reference_name }
-          its([:type]) { should == type }
+          it { expect(subject[:modification_time]).to be_within(1.second).of(pathname_modification_time) }
+          it { expect(subject[:parent_path]).to eq(parent_path) }
+          it { expect(subject[:reference_name]).to eq(reference_name) }
+          it { expect(subject[:type]).to eq(type) }
         end
 
         context 'typed module set' do


### PR DESCRIPTION
When running rspec several `its()` deprecation warnings are shown. This pull requests avoids usage of `its()` by favoring `expects()` syntax.
## Requirements
- [ ] Worths to land #3711 and #3735 to avoid conflicts in this pull request.
## Verification
- [ ] Ensure travis is green before landing
