### PR TITLE
HP System Management Homepage LoginScanner Upgrade

### DIFF
--- a/lib/metasploit/framework/login_scanner/smh.rb
+++ b/lib/metasploit/framework/login_scanner/smh.rb
@@ -18,12 +18,10 @@ module Metasploit
         CAN_GET_SESSION = true
 
 
-        #
         # Decides which login routine and returns the results
         #
         # @param credential [Metasploit::Framework::Credential] The credential object
         # @return [Result]
-        #
         def attempt_login(credential)
           result_opts = {
             credential: credential

--- a/lib/metasploit/framework/login_scanner/smh.rb
+++ b/lib/metasploit/framework/login_scanner/smh.rb
@@ -1,0 +1,65 @@
+
+require 'metasploit/framework/login_scanner/http'
+
+##
+#
+# This mixin is for HP System Management login tested on v6.3.1.24 upto v7.2.1.3 and 7.4
+#
+##
+
+module Metasploit
+  module Framework
+    module LoginScanner
+
+      class Smh < HTTP
+
+        DEFAULT_PORT  = 4848
+        PRIVATE_TYPES = [ :password ]
+
+        #
+        # Decides which login routine and returns the results
+        #
+        # @param credential [Metasploit::Framework::Credential] The credential object
+        # @return [Result]
+        #
+        def attempt_login(credential)
+          result_opts = {
+            credential: credential
+          }
+
+          req_opts = {
+            'method' => 'POST',
+            'uri'    => '/proxy/ssllogin',
+            'vars_post' => {
+              'redirecturl'         => '',
+              'redirectquerystring' => '',
+              'user'                => credential.public,
+              'password'            => credential.private
+            }
+          }
+
+          res = nil
+
+          begin
+            cli = Rex::Proto::Http::Client.new(host, port, {}, ssl, ssl_version)
+            cli.connect
+            req = cli.request_cgi(req_opts)
+            res = cli.send_recv(req)
+
+          rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, ::EOFError, ::Timeout::Error
+            result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
+          end
+
+          if res && res.headers['CpqElm-Login'].to_s =~ /success/
+            result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL)
+          else
+            result_opts.merge!(status: Metasploit::Model::Login::Status::INCORRECT)
+          end
+
+          Result.new(result_opts)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/metasploit/framework/login_scanner/smh.rb
+++ b/lib/metasploit/framework/login_scanner/smh.rb
@@ -15,6 +15,8 @@ module Metasploit
 
         DEFAULT_PORT  = 4848
         PRIVATE_TYPES = [ :password ]
+        CAN_GET_SESSION = true
+
 
         #
         # Decides which login routine and returns the results
@@ -48,6 +50,7 @@ module Metasploit
 
           rescue ::Rex::ConnectionError, Errno::ECONNREFUSED, ::EOFError, ::Timeout::Error
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
+            return Result.new(result_opts)
           end
 
           if res && res.headers['CpqElm-Login'].to_s =~ /success/

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -3,7 +3,10 @@
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 
+#load "/Users/wchen/rapid7/msf/lib/metasploit/framework/login_scanner/smh.rb"
+
 require 'msf/core'
+require 'metasploit/framework/login_scanner/smh'
 
 class Metasploit3 < Msf::Auxiliary
 
@@ -21,19 +24,15 @@ class Metasploit3 < Msf::Auxiliary
       },
       'License'        => MSF_LICENSE,
       'Author'         => [ 'sinn3r' ],
-      'DefaultOptions' => { 'SSL' => true }
+      'DefaultOptions' =>
+        {
+          'SSL' => true,
+          'RPORT' => 2381,
+          'USERPASS_FILE' => File.join(Msf::Config.data_directory, "wordlists", "http_default_userpass.txt"),
+          'USER_FILE' => File.join(Msf::Config.data_directory, "wordlists", "http_default_users.txt"),
+          'PASS_FILE' => File.join(Msf::Config.data_directory, "wordlists", "http_default_pass.txt")
+        }
     ))
-
-    register_options(
-      [
-        Opt::RPORT(2381),
-        OptPath.new('USERPASS_FILE',  [ false, "File containing users and passwords separated by space, one pair per line",
-          File.join(Msf::Config.data_directory, "wordlists", "http_default_userpass.txt") ]),
-        OptPath.new('USER_FILE',  [ false, "File containing users, one per line",
-          File.join(Msf::Config.data_directory, "wordlists", "http_default_users.txt") ]),
-        OptPath.new('PASS_FILE',  [ false, "File containing passwords, one per line",
-          File.join(Msf::Config.data_directory, "wordlists", "http_default_pass.txt") ]),
-      ], self.class)
   end
 
   def anonymous_access?
@@ -42,41 +41,29 @@ class Metasploit3 < Msf::Auxiliary
     false
   end
 
-  def do_login(user, pass)
-    begin
-      res = send_request_cgi({
-        'method' => 'POST',
-        'uri'    => '/proxy/ssllogin',
-        'vars_post' => {
-          'redirecturl'         => '',
-          'redirectquerystring' => '',
-          'user'                => user,
-          'password'            => pass
-        }
-      })
+  def init_loginscanner(ip)
+    @cred_collection = Metasploit::Framework::CredentialCollection.new(
+      blank_passwords: datastore['BLANK_PASSWORDS'],
+      pass_file:       datastore['PASS_FILE'],
+      password:        datastore['PASSWORD'],
+      user_file:       datastore['USER_FILE'],
+      userpass_file:   datastore['USERPASS_FILE'],
+      username:        datastore['USERNAME'],
+      user_as_pass:    datastore['USER_AS_PASS']
+    )
 
-      if not res
-        vprint_error("#{peer} - Connection timed out")
-        return :abort
-      end
-    rescue ::Rex::ConnectionError, Errno::ECONNREFUSED
-      vprint_error("#{peer} - Failed to response")
-      return :abort
-    end
+    @scanner = Metasploit::Framework::LoginScanner::Smh.new(
+      host:               ip,
+      port:               rport,
+      uri:                datastore['URI'],
+      proxies:            datastore["PROXIES"],
+      cred_details:       @cred_collection,
+      stop_on_success:    datastore['STOP_ON_SUCCESS'],
+      connection_timeout: 5
+    )
 
-    if res.headers['CpqElm-Login'].to_s =~ /success/
-      print_good("#{peer} - Successful login: '#{user}:#{pass}'")
-      report_auth_info({
-        :host  => rhost,
-        :port  => rport,
-        :sname => 'https',
-        :user  => user,
-        :pass  => pass,
-        :proof => "CpqElm-Login: #{res.headers['CpqElm-Login']}"
-      })
-
-      return :next_user
-    end
+    @scanner.ssl         = datastore['SSL']
+    @scanner.ssl_version = datastore['SSLVERSION']
   end
 
 
@@ -86,16 +73,11 @@ class Metasploit3 < Msf::Auxiliary
       return
     end
 
-    each_user_pass { |user, pass|
-      # Actually respect the BLANK_PASSWORDS option
-      next if not datastore['BLANK_PASSWORDS'] and pass.blank?
+    init_loginscanner(ip)
 
-      vprint_status("#{peer} - Trying: '#{user}:#{pass}'")
-      do_login(user, pass)
-    }
+    @scanner.scan! do |result|
+      print_debug(result.status)
+    end
   end
 end
 
-=begin
-Tested: v6.3.1.24 upto v7.2.1.3
-=end

--- a/spec/lib/metasploit/framework/login_scanner/smh_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/smh_spec.rb
@@ -18,18 +18,18 @@ describe Metasploit::Framework::LoginScanner::Smh do
       )
     end
 
-    it 'Rex::ConnectionError should result in status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
+    it 'returns status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect).and_raise(Rex::ConnectionError)
       expect(smh_cli.attempt_login(cred).status).to eq(Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
     end
 
-    it 'Timeout::Error should result in status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
+    it 'returns status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect).and_raise(Timeout::Error)
 
       expect(smh_cli.attempt_login(cred).status).to eq(Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
     end
 
-    it 'EOFError should result in status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
+    it 'returns status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
       allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect).and_raise(EOFError)
 
       expect(smh_cli.attempt_login(cred).status).to eq(Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)

--- a/spec/lib/metasploit/framework/login_scanner/smh_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/smh_spec.rb
@@ -7,4 +7,34 @@ describe Metasploit::Framework::LoginScanner::Smh do
   it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
   it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'
 
+  subject(:smh_cli) { described_class.new }
+
+  context "#attempt_login" do
+    let(:cred) do
+      Metasploit::Framework::Credential.new(
+        paired: true,
+        public: 'admin',
+        private: 'password'
+      )
+    end
+
+    it 'Rex::ConnectionError should result in status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
+      allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect).and_raise(Rex::ConnectionError)
+      expect(smh_cli.attempt_login(cred).status).to eq(Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
+    end
+
+    it 'Timeout::Error should result in status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
+      allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect).and_raise(Timeout::Error)
+
+      expect(smh_cli.attempt_login(cred).status).to eq(Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
+    end
+
+    it 'EOFError should result in status Metasploit::Model::Login::Status::UNABLE_TO_CONNECT' do
+      allow_any_instance_of(Rex::Proto::Http::Client).to receive(:connect).and_raise(EOFError)
+
+      expect(smh_cli.attempt_login(cred).status).to eq(Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
+    end
+
+  end
+
 end

--- a/spec/lib/metasploit/framework/login_scanner/smh_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/smh_spec.rb
@@ -1,0 +1,10 @@
+
+require 'spec_helper'
+require 'metasploit/framework/login_scanner/smh'
+
+describe Metasploit::Framework::LoginScanner::Smh do
+
+  it_behaves_like 'Metasploit::Framework::LoginScanner::Base',  has_realm_key: true, has_default_realm: false
+  it_behaves_like 'Metasploit::Framework::LoginScanner::RexSocket'
+
+end


### PR DESCRIPTION
This upgrades the hp_sys_mgmt_login.rb module to LoginScanner.
## Verification Steps:
- [x] Download **SMH 7.4 for Windows (x86)**: http://h18013.www1.hp.com/products/servers/management/agents/
- [x] Run the installer of HP System Management Homepage on a Windows box.
- [x] In the setup process, the group name is the host name which you can find in `ipconfig /all`
- [x] Choose a Trust mode. In my test box, I did "Trust All"
- [x] Leave the rest of the options default (basically you just keep pressing next until it starts installing)
- [x] After the installation is done, make sure SMH is up and running by browsing to: https://localhost:2381/
- [x] Start msfconsole
- [x] Use auxiliary/scanner/http/hp_sys_mgmt_login
- [ ] set a valid username and password, make sure you get a successful login attempt
- [x] Rerun with a bad password, this time you should get a failed login attempt
