### PR TITLE
Fix missing require for jtr_oracle_fast

### DIFF
--- a/modules/auxiliary/analyze/jtr_oracle_fast.rb
+++ b/modules/auxiliary/analyze/jtr_oracle_fast.rb
@@ -5,6 +5,7 @@
 
 
 require 'msf/core'
+require 'msf/core/auxiliary/jtr'
 
 class Metasploit3 < Msf::Auxiliary
 


### PR DESCRIPTION
This fixes the following error on startup:

```
metasploit-framework/modules/auxiliary/analyze/jtr_oracle_fast.rb: NameError uninitialized constant Msf::Auxiliary::JohnTheRipper
```
