### PR TITLE
[SeeRM 8836] Change boot.ini to win.ini

### DIFF
--- a/modules/auxiliary/admin/backupexec/dump.rb
+++ b/modules/auxiliary/admin/backupexec/dump.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Auxiliary
           [
             true,
             "The remote filesystem path to download",
-            "C:\\boot.ini"
+            "C:\\Windows\\win.ini"
           ]
         ),
         OptString.new('LPATH',

--- a/modules/auxiliary/admin/http/axigen_file_access.rb
+++ b/modules/auxiliary/admin/http/axigen_file_access.rb
@@ -46,7 +46,7 @@ class Metasploit3 < Msf::Auxiliary
         OptString.new('TARGETURI',[ true, 'Path to Axigen WebAdmin', '/' ]),
         OptString.new('USERNAME', [ true, 'The user to authenticate as', 'admin' ]),
         OptString.new('PASSWORD', [ true, 'The password to authenticate with' ]),
-        OptString.new('PATH',     [ true, 'The file to read or delete', "\\boot.ini" ])
+        OptString.new('PATH',     [ true, 'The file to read or delete', "\\windows\\win.ini" ])
       ], self.class)
   end
 

--- a/modules/auxiliary/admin/officescan/tmlisten_traversal.rb
+++ b/modules/auxiliary/admin/officescan/tmlisten_traversal.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Auxiliary
 
     res = send_request_raw(
       {
-        'uri'     => '/activeupdate/../../../../../../../../../../../boot.ini',
+        'uri'     => '/activeupdate/../../../../../../../../../../../windows\\win.ini',
         'method'  => 'GET',
       }, 20)
 

--- a/modules/auxiliary/admin/scada/ge_proficy_substitute_traversal.rb
+++ b/modules/auxiliary/admin/scada/ge_proficy_substitute_traversal.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Auxiliary
       [
         Opt::RPORT(80),
         OptString.new('TARGETURI',[true, 'Path to CimWeb', '/CimWeb']),
-        OptString.new('FILEPATH', [true, 'The name of the file to download', '/boot.ini']),
+        OptString.new('FILEPATH', [true, 'The name of the file to download', '/windows\\win.ini']),
         # By default gefebt.exe installed on C:\Program Files\GE Fanuc\Proficy CIMPLICITY\WebPages\CimWeb
         OptInt.new('DEPTH', [true, 'Traversal depth', 5])
       ], self.class)

--- a/modules/auxiliary/scanner/ftp/titanftp_xcrc_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/titanftp_xcrc_traversal.rb
@@ -45,7 +45,7 @@ class Metasploit3 < Msf::Auxiliary
       [
         Opt::RPORT(21),
         OptString.new('TRAVERSAL', [ true, "String to traverse to the drive's root directory", "..\\..\\" ]),
-        OptString.new('PATH', [ true, "Path to the file to disclose, releative to the root dir.", 'boot.ini'])
+        OptString.new('PATH', [ true, "Path to the file to disclose, releative to the root dir.", 'windows\\win.ini'])
       ], self.class)
   end
 

--- a/modules/auxiliary/scanner/http/apache_activemq_traversal.rb
+++ b/modules/auxiliary/scanner/http/apache_activemq_traversal.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(8161),
-        OptString.new('FILEPATH', [true, 'The name of the file to download', '/boot.ini']),
+        OptString.new('FILEPATH', [true, 'The name of the file to download', '/windows\\win.ini']),
         OptInt.new('DEPTH', [false, 'Traversal depth if absolute is set to false', 4])
       ], self.class)
   end

--- a/modules/auxiliary/scanner/http/groupwise_agents_http_traversal.rb
+++ b/modules/auxiliary/scanner/http/groupwise_agents_http_traversal.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(7181), # Also 7180 can be used
-        OptString.new('FILEPATH', [true, 'The name of the file to download', '/boot.ini']),
+        OptString.new('FILEPATH', [true, 'The name of the file to download', '/windows\\win.ini']),
         OptInt.new('DEPTH', [true, 'Traversal depth if absolute is set to false', 10])
       ], self.class)
   end

--- a/modules/auxiliary/scanner/http/hp_imc_bims_downloadservlet_traversal.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_bims_downloadservlet_traversal.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Auxiliary
       [
         Opt::RPORT(8080),
         OptString.new('TARGETURI', [true, 'Path to HP Intelligent Management Center', '/imc']),
-        OptString.new('FILEPATH', [true, 'The name of the file to download', '/boot.ini']),
+        OptString.new('FILEPATH', [true, 'The name of the file to download', '/windows\\win.ini']),
         # By default files downloaded from C:\Program Files\iMC\client\web\apps\imc\
         OptInt.new('DEPTH', [true, 'Traversal depth', 6])
       ], self.class)

--- a/modules/auxiliary/scanner/http/hp_imc_faultdownloadservlet_traversal.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_faultdownloadservlet_traversal.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Auxiliary
       [
         Opt::RPORT(8080),
         OptString.new('TARGETURI', [true, 'Path to HP Intelligent Management Center', '/imc']),
-        OptString.new('FILEPATH', [true, 'The name of the file to download', '/windows\\boot.ini']),
+        OptString.new('FILEPATH', [true, 'The name of the file to download', '/windows\\win.ini']),
         # By default files downloaded from C:\Program Files\iMC\client\web\apps\imc\tmp\
         OptInt.new('DEPTH', [true, 'Traversal depth', 7])
       ], self.class)

--- a/modules/auxiliary/scanner/http/hp_imc_faultdownloadservlet_traversal.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_faultdownloadservlet_traversal.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Auxiliary
       [
         Opt::RPORT(8080),
         OptString.new('TARGETURI', [true, 'Path to HP Intelligent Management Center', '/imc']),
-        OptString.new('FILEPATH', [true, 'The name of the file to download', '/boot.ini']),
+        OptString.new('FILEPATH', [true, 'The name of the file to download', '/windows\\boot.ini']),
         # By default files downloaded from C:\Program Files\iMC\client\web\apps\imc\tmp\
         OptInt.new('DEPTH', [true, 'Traversal depth', 7])
       ], self.class)

--- a/modules/auxiliary/scanner/http/hp_imc_ictdownloadservlet_traversal.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_ictdownloadservlet_traversal.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Auxiliary
       [
         Opt::RPORT(8080),
         OptString.new('TARGETURI', [true, 'Path to HP Intelligent Management Center', '/imc']),
-        OptString.new('FILEPATH', [true, 'The name of the file to download', '/boot.ini']),
+        OptString.new('FILEPATH', [true, 'The name of the file to download', '/windows\\win.ini']),
         # By default files downloaded from C:\Program Files\iMC\client\web\apps\imc\tmp\
         OptInt.new('DEPTH', [true, 'Traversal depth', 7])
       ], self.class)

--- a/modules/auxiliary/scanner/http/hp_imc_reportimgservlt_traversal.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_reportimgservlt_traversal.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Auxiliary
       [
         Opt::RPORT(8080),
         OptString.new('TARGETURI', [true, 'Path to HP Intelligent Management Center', '/imc']),
-        OptString.new('FILEPATH', [true, 'The name of the file to download', '/boot.ini']),
+        OptString.new('FILEPATH', [true, 'The name of the file to download', '/windows\\win.ini']),
         # By default files downloaded from C:\Program Files\iMC\client\bin\
         OptInt.new('DEPTH', [true, 'Traversal depth', 4])
       ], self.class)

--- a/modules/auxiliary/scanner/http/hp_imc_som_file_download.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_som_file_download.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Auxiliary
       [
         Opt::RPORT(8080),
         OptString.new('TARGETURI', [true, 'Path to HP Intelligent Management Center', '/imc']),
-        OptString.new('FILEPATH', [true, 'The path of the file to download', 'c:\\boot.ini'])
+        OptString.new('FILEPATH', [true, 'The path of the file to download', 'c:\\windows\\win.ini'])
       ], self.class)
   end
 

--- a/modules/auxiliary/scanner/http/hp_sitescope_getfileinternal_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_getfileinternal_fileaccess.rb
@@ -38,7 +38,7 @@ class Metasploit4 < Msf::Auxiliary
     register_options(
     [
       Opt::RPORT(8080),
-      OptString.new('RFILE', [true, 'Remote File', 'c:\\boot.ini']),
+      OptString.new('RFILE', [true, 'Remote File', 'c:\\windows\\win.ini']),
       OptString.new('TARGETURI', [true, 'Path to SiteScope', '/SiteScope/'])
     ], self.class)
 

--- a/modules/auxiliary/scanner/http/hp_sitescope_loadfilecontent_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_loadfilecontent_fileaccess.rb
@@ -38,7 +38,7 @@ class Metasploit4 < Msf::Auxiliary
     register_options(
     [
       Opt::RPORT(8080),
-      OptString.new('RFILE', [true, 'Remote File', 'c:\\windows\\boot.ini']),
+      OptString.new('RFILE', [true, 'Remote File', 'c:\\windows\\win.ini']),
       OptString.new('TARGETURI', [true, 'Path to SiteScope', '/SiteScope/']),
     ], self.class)
 

--- a/modules/auxiliary/scanner/http/hp_sitescope_loadfilecontent_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_loadfilecontent_fileaccess.rb
@@ -38,7 +38,7 @@ class Metasploit4 < Msf::Auxiliary
     register_options(
     [
       Opt::RPORT(8080),
-      OptString.new('RFILE', [true, 'Remote File', 'c:\\boot.ini']),
+      OptString.new('RFILE', [true, 'Remote File', 'c:\\windows\\boot.ini']),
       OptString.new('TARGETURI', [true, 'Path to SiteScope', '/SiteScope/']),
     ], self.class)
 

--- a/modules/auxiliary/scanner/http/http_traversal.rb
+++ b/modules/auxiliary/scanner/http/http_traversal.rb
@@ -106,7 +106,7 @@ class Metasploit3 < Msf::Auxiliary
 
     # Initialize the default file(s) we should try to read during fuzzing
     if datastore['FILE'].empty?
-      file_to_read = ['etc/passwd', 'boot.ini']
+      file_to_read = ['etc/passwd', 'boot.ini', 'windows\\win.ini']
     else
       file_to_read = [datastore['FILE']]
     end

--- a/modules/auxiliary/scanner/http/manageengine_deviceexpert_traversal.rb
+++ b/modules/auxiliary/scanner/http/manageengine_deviceexpert_traversal.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Auxiliary
       [
         Opt::RPORT(6060),
         OptBool.new('SSL',   [true, 'Use SSL', true]),
-        OptString.new('FILEPATH', [true, 'The name of the file to download', 'boot.ini'])
+        OptString.new('FILEPATH', [true, 'The name of the file to download', 'windows\\win.ini'])
       ], self.class)
 
     deregister_options('RHOST')

--- a/modules/auxiliary/scanner/http/novell_file_reporter_fsfui_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/novell_file_reporter_fsfui_fileaccess.rb
@@ -38,7 +38,7 @@ class Metasploit4 < Msf::Auxiliary
     [
       Opt::RPORT(3037),
       OptBool.new('SSL', [true, 'Use SSL', true]),
-      OptString.new('RFILE', [true, 'Remote File', 'boot.ini']),
+      OptString.new('RFILE', [true, 'Remote File', 'windows\\win.ini']),
       OptInt.new('DEPTH', [true, 'Traversal depth', 6])
     ], self.class)
 

--- a/modules/auxiliary/scanner/http/novell_file_reporter_srs_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/novell_file_reporter_srs_fileaccess.rb
@@ -38,7 +38,7 @@ class Metasploit4 < Msf::Auxiliary
     [
       Opt::RPORT(3037),
       OptBool.new('SSL', [true, 'Use SSL', true]),
-      OptString.new('RFILE', [true, 'Remote File', 'c:\\boot.ini'])
+      OptString.new('RFILE', [true, 'Remote File', 'c:\\windows\\win.ini'])
     ], self.class)
 
     register_autofilter_ports([ 3037 ])

--- a/modules/auxiliary/scanner/http/simple_webserver_traversal.rb
+++ b/modules/auxiliary/scanner/http/simple_webserver_traversal.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('FILEPATH', [true, 'The name of the file to download', 'boot.ini']),
+        OptString.new('FILEPATH', [true, 'The name of the file to download', 'windows\\win.ini']),
         OptInt.new('DEPTH',       [true, 'The max traversal depth', 8])
       ], self.class)
 

--- a/modules/auxiliary/scanner/http/vmware_update_manager_traversal.rb
+++ b/modules/auxiliary/scanner/http/vmware_update_manager_traversal.rb
@@ -38,7 +38,7 @@ class Metasploit3 < Msf::Auxiliary
       [
         Opt::RPORT(9084),
         OptString.new('URIPATH', [true, 'URI path to the downloads', '/vci/downloads/']),
-        OptString.new('FILE', [true, 'Define the remote file to download', 'boot.ini'])
+        OptString.new('FILE', [true, 'Define the remote file to download', 'windows\\win.ini'])
       ], self.class)
   end
 

--- a/modules/auxiliary/scanner/http/yaws_traversal.rb
+++ b/modules/auxiliary/scanner/http/yaws_traversal.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(8080),
-        OptString.new('FILEPATH', [false, 'The name of the file to download', 'boot.ini'])
+        OptString.new('FILEPATH', [false, 'The name of the file to download', 'windows\\win.ini'])
       ], self.class)
 
     deregister_options('RHOST')

--- a/modules/auxiliary/scanner/scada/indusoft_ntwebserver_fileaccess.rb
+++ b/modules/auxiliary/scanner/scada/indusoft_ntwebserver_fileaccess.rb
@@ -37,7 +37,7 @@ class Metasploit4 < Msf::Auxiliary
 
     register_options(
     [
-      OptString.new('RFILE', [true, 'Remote File', '/boot.ini']),
+      OptString.new('RFILE', [true, 'Remote File', '/windows\\win.ini']),
       OptInt.new('DEPTH', [true, 'Traversal depth', 3])
     ], self.class)
 

--- a/modules/auxiliary/scanner/tftp/ipswitch_whatsupgold_tftp.rb
+++ b/modules/auxiliary/scanner/tftp/ipswitch_whatsupgold_tftp.rb
@@ -37,7 +37,7 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(69),
-        OptString.new('FILENAME', [false, 'The file to loot', 'boot.ini']),
+        OptString.new('FILENAME', [false, 'The file to loot', 'windows\\win.ini']),
         OptBool.new('SAVE', [false, 'Save the downloaded file to disk', 'false'])
       ], self.class)
   end

--- a/modules/auxiliary/scanner/tftp/netdecision_tftp.rb
+++ b/modules/auxiliary/scanner/tftp/netdecision_tftp.rb
@@ -36,7 +36,7 @@ class Metasploit3 < Msf::Auxiliary
       [
         Opt::RPORT(69),
         OptInt.new('DEPTH', [false, "Levels to reach base directory",1]),
-        OptString.new('FILENAME', [false, 'The file to loot', 'boot.ini']),
+        OptString.new('FILENAME', [false, 'The file to loot', 'windows\\win.ini']),
       ], self.class)
   end
 


### PR DESCRIPTION
This is for the following redmine issue:
https://dev.metasploit.com/redmine/issues/8836

Notice I'm using backslashes instead of forward slashes. Newer Windows boxes are okay with both, but older ones only allow backslashes.
## To verify
- [ ] Make sure all changes point to C:\Windows\win.ini
- [ ] Try to recreate as many setups as possible for testing until either they're all covered, or you feel is enough.
