### PR TITLE
New "show missing" command to show empty required options

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -311,8 +311,9 @@ class ReadableText
   #
   # @param mod [Msf::Module] the module.
   # @param indent [String] the indentation to use.
+  # @param missing [Boolean] dump only empty required options.
   # @return [String] the string form of the information.
-  def self.dump_options(mod, indent = '')
+  def self.dump_options(mod, indent = '', missing = false)
     tbl = Rex::Ui::Text::Table.new(
       'Indent'  => indent.length,
       'Columns' =>
@@ -325,13 +326,13 @@ class ReadableText
 
     mod.options.sorted.each { |entry|
       name, opt = entry
+      val = mod.datastore[name] || opt.default
 
       next if (opt.advanced?)
       next if (opt.evasion?)
+      next if (missing && opt.valid?(val))
 
-      val_display = opt.display_value(mod.datastore[name] || opt.default)
-
-      tbl << [ name, val_display, opt.required? ? "yes" : "no", opt.desc ]
+      tbl << [ name, opt.display_value(val), opt.required? ? "yes" : "no", opt.desc ]
     }
 
     return tbl.to_s

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2070,7 +2070,7 @@ class Core
     global_opts = %w{all encoders nops exploits payloads auxiliary plugins options}
     print_status("Valid parameters for the \"show\" command are: #{global_opts.join(", ")}")
 
-    module_opts = %w{ advanced evasion targets actions }
+    module_opts = %w{ missing advanced evasion targets actions }
     print_status("Additional module-specific parameters are: #{module_opts.join(", ")}")
   end
 
@@ -2112,6 +2112,12 @@ class Core
             show_options(mod)
           else
             show_global_options
+          end
+        when 'missing'
+          if (mod)
+            show_missing(mod)
+          else
+            print_error("No module selected.")
           end
         when 'advanced'
           if (mod)
@@ -2167,7 +2173,7 @@ class Core
 
     res = %w{all encoders nops exploits payloads auxiliary post plugins options}
     if (active_module)
-      res.concat(%w{ advanced evasion targets actions })
+      res.concat(%w{ missing advanced evasion targets actions })
       if (active_module.respond_to? :compatible_sessions)
         res << "sessions"
       end
@@ -3142,6 +3148,29 @@ class Core
 
     # Uncomment this line if u want target like msf2 format
     #print("\nTarget: #{mod.target.name}\n\n")
+  end
+
+  def show_options(mod) # :nodoc:
+    mod_opt = Serializer::ReadableText.dump_options(mod, '   ', true)
+    print("\nModule options (#{mod.fullname}):\n\n#{mod_opt}\n") if (mod_opt and mod_opt.length > 0)
+
+    # If it's an exploit and a payload is defined, create it and
+    # display the payload's options
+    if (mod.exploit? and mod.datastore['PAYLOAD'])
+      p = framework.payloads.create(mod.datastore['PAYLOAD'])
+
+      if (!p)
+        print_error("Invalid payload defined: #{mod.datastore['PAYLOAD']}\n")
+        return
+      end
+
+      p.share_datastore(mod.datastore)
+
+      if (p)
+        p_opt = Serializer::ReadableText.dump_options(p, '   ', true)
+        print("\nPayload options (#{mod.datastore['PAYLOAD']}):\n\n#{p_opt}\n") if (p_opt and p_opt.length > 0)
+      end
+    end
   end
 
   def show_global_options

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -3150,7 +3150,7 @@ class Core
     #print("\nTarget: #{mod.target.name}\n\n")
   end
 
-  def show_options(mod) # :nodoc:
+  def show_missing(mod) # :nodoc:
     mod_opt = Serializer::ReadableText.dump_options(mod, '   ', true)
     print("\nModule options (#{mod.fullname}):\n\n#{mod_opt}\n") if (mod_opt and mod_opt.length > 0)
 

--- a/msfcli
+++ b/msfcli
@@ -44,6 +44,7 @@ class Msfcli
     tbl << ['(H)elp',        "You're looking at it baby!"]
     tbl << ['(S)ummary',     'Show information about this module']
     tbl << ['(O)ptions',     'Show available options for this module']
+    tbl << ['(M)issing',     'Show empty required options for this module']
     tbl << ['(A)dvanced',    'Show available advanced options for this module']
     tbl << ['(I)DS Evasion', 'Show available ids evasion options for this module']
     tbl << ['(P)ayloads',    'Show available payloads for this module']
@@ -385,6 +386,15 @@ class Msfcli
   end
 
 
+  def show_missing(m)
+    readable = Msf::Serializer::ReadableText
+    $stdout.puts("\n" + readable.dump_options(m[:module], @indent, true))
+    $stdout.puts("\nPayload:\n\n" + readable.dump_options(m[:payload], @indent, true)) if m[:payload]
+    $stdout.puts("\nEncoder:\n\n" + readable.dump_options(m[:encoder], @indent, true)) if m[:encoder]
+    $stdout.puts("\nNOP\n\n" + readable.dump_options(m[:nop], @indent, true))          if m[:nop]
+  end
+
+
   def show_advanced(m)
     readable = Msf::Serializer::ReadableText
     $stdout.puts("\n" + readable.dump_advanced_options(m[:module], @indent))
@@ -483,6 +493,8 @@ class Msfcli
       show_summary(modules)
     when "o"
       show_options(modules)
+    when "m"
+      show_missing(modules)
     when "a"
       show_advanced(modules)
     when "i"


### PR DESCRIPTION
```
msf > use auxiliary/scanner/smb/smb_login
msf auxiliary(smb_login) > show options

Module options (auxiliary/scanner/smb/smb_login):

   Name              Current Setting  Required  Description
   ----              ---------------  --------  -----------
   BLANK_PASSWORDS   false            no        Try blank passwords for all users
   BRUTEFORCE_SPEED  5                yes       How fast to bruteforce, from 0 to 5
   DB_ALL_CREDS      false            no        Try each user/password couple stored in the current database
   DB_ALL_PASS       false            no        Add all passwords in the current database to the list
   DB_ALL_USERS      false            no        Add all users in the current database to the list
   PASS_FILE                          no        File containing passwords, one per line
   PRESERVE_DOMAINS  true             no        Respect a username that contains a domain name.
   RECORD_GUEST      false            no        Record guest-privileged random logins to the database
   RHOSTS                             yes       The target address range or CIDR identifier
   RPORT             445              yes       Set the SMB service port
   SMBDomain                          no        SMB Domain
   SMBPass                            no        SMB Password
   SMBUser                            no        SMB Username
   STOP_ON_SUCCESS   false            yes       Stop guessing when a credential works for a host
   THREADS           1                yes       The number of concurrent threads
   USERPASS_FILE                      no        File containing users and passwords separated by space, one pair per line
   USER_AS_PASS      false            no        Try the username as the password for all users
   USER_FILE                          no        File containing usernames, one per line
   VERBOSE           true             yes       Whether to print output for all attempts

msf auxiliary(smb_login) > show missing

Module options (auxiliary/scanner/smb/smb_login):

   Name    Current Setting  Required  Description
   ----    ---------------  --------  -----------
   RHOSTS                   yes       The target address range or CIDR identifier

msf auxiliary(smb_login) >
```
