### PR TITLE
turn nil publics and privates into blanks

### DIFF
--- a/app/concerns/metasploit/credential/core/to_credential.rb
+++ b/app/concerns/metasploit/credential/core/to_credential.rb
@@ -9,8 +9,8 @@ module Metasploit::Credential::Core::ToCredential
     
     def to_credential
       Metasploit::Framework::Credential.new(
-        public:       public.try(:username), 
-        private:      private.try(:data), 
+        public:       public.try(:username) || '',
+        private:      private.try(:data)    || '',
         private_type: private.try(:type).try(:demodulize).try(:underscore).try(:to_sym), 
         realm:        realm.try(:value), 
         realm_key:    realm.try(:key),


### PR DESCRIPTION
don't pass nil into the credential object, pass an empty string instead
this is the expected behaviour and avoids stack traces

see ticket for verification steps
