### PR TITLE
Return instead of crashing if no challenge is received

### DIFF
--- a/lib/rex/proto/iax2/call.rb
+++ b/lib/rex/proto/iax2/call.rb
@@ -77,6 +77,11 @@ class Call
       chall = res[2][IAX_IE_CHALLENGE_DATA]
     end
 
+    if chall.nil?
+      dprint("REGAUTH: No challenge data received")
+      return
+    end
+
     self.client.send_regreq_chall_response(self, chall)
     res = wait_for( IAX_SUBTYPE_REGACK, IAX_SUBTYPE_REGREJ )
     return if not res


### PR DESCRIPTION
This fixes a warvox stack trace, but doesn't solve the actual protocol issue yet. Merge if convenient, warvox and a couple metasploit modules are the only consumers of this API.
