### PR TITLE
Add specs for Rex::Encoder::NonAlpha

### DIFF
--- a/lib/rex/encoder/nonalpha.rb
+++ b/lib/rex/encoder/nonalpha.rb
@@ -7,7 +7,7 @@ module Encoder
 
 class NonAlpha
 
-  def NonAlpha.gen_decoder()
+  def NonAlpha.gen_decoder
     decoder =
       "\x66\xB9\xFF\xFF" +
       "\xEB\x19"  +               # Jmp to table
@@ -28,13 +28,13 @@ class NonAlpha
   end
 
   def NonAlpha.encode_byte(block, table, tablelen)
-    if (tablelen > 255) or (block == 0x7B)
+    if tablelen > 255 || block == 0x7B
       raise RuntimeError, "BadChar"
     end
 
-    if (block >= 0x41 and block <= 0x5A) or (block >= 0x61 and block <= 0x7A)
+    if (block >= 0x41 && block <= 0x5A) || (block >= 0x61 && block <= 0x7A)
       # gen offset, return magic
-      offset = 0x7b - block;
+      offset = 0x7b - block
       table += offset.chr
       tablelen = tablelen + 1
       block = 0x7B

--- a/spec/lib/rex/encoder/nonalpha_spec.rb
+++ b/spec/lib/rex/encoder/nonalpha_spec.rb
@@ -42,7 +42,6 @@ describe Rex::Encoder::NonAlpha do
     subject { described_class.encode_byte(block, table, tablelen) }
 
     context "when tablelen > 255" do
-      let(:badchars) { "" }
       let(:block) { 0x20 }
       let(:table) { "" }
       let(:tablelen) { 256 }
@@ -53,7 +52,6 @@ describe Rex::Encoder::NonAlpha do
     end
 
     context "when block == 0x7b" do
-      let(:badchars) { "" }
       let(:block) { 0x7b }
       let(:table) { "" }
       let(:tablelen) { 0 }
@@ -63,8 +61,82 @@ describe Rex::Encoder::NonAlpha do
       end
     end
 
-    context "when block == 0x40" do
+    context "when block is an upcase letter char code" do
+      let(:block) { 0x42 }
+      let(:table) { "" }
+      let(:tablelen) { 0 }
 
+      it "returns an Array" do
+        is_expected.to be_kind_of(Array)
+      end
+
+      it "returns a 3 fields Array" do
+        expect(subject.length).to eq(3)
+      end
+
+      it "returns '{' char as block" do
+        expect(subject[0]).to eq('{')
+      end
+
+      it "appends offset to table" do
+        expect(subject[1]).to eq((0x7b - block).chr)
+      end
+
+      it "increments tablelen" do
+        expect(subject[2]).to eq(tablelen + 1)
+      end
+    end
+
+    context "when block is a downcase letter char code" do
+      let(:block) { 0x62 }
+      let(:table) { "" }
+      let(:tablelen) { 0 }
+
+      it "returns an Array" do
+        is_expected.to be_kind_of(Array)
+      end
+
+      it "returns a 3 fields Array" do
+        expect(subject.length).to eq(3)
+      end
+
+      it "returns '{' char as block" do
+        expect(subject[0]).to eq('{')
+      end
+
+      it "appends offset to table" do
+        expect(subject[1]).to eq((0x7b - block).chr)
+      end
+
+      it "increments tablelen" do
+        expect(subject[2]).to eq(tablelen + 1)
+      end
+    end
+
+    context "when block is another char code" do
+      let(:block) { 0x7c }
+      let(:table) { "" }
+      let(:tablelen) { 0 }
+
+      it "returns an Array" do
+        is_expected.to be_kind_of(Array)
+      end
+
+      it "returns a 3 fields Array" do
+        expect(subject.length).to eq(3)
+      end
+
+      it "returns same block char code" do
+        expect(subject[0]).to eq(block.chr)
+      end
+
+      it "doesn't modify table" do
+        expect(subject[1]).to eq(table)
+      end
+
+      it "doesn't modify tablelen" do
+        expect(subject[2]).to eq(tablelen)
+      end
     end
   end
 

--- a/spec/lib/rex/encoder/nonalpha_spec.rb
+++ b/spec/lib/rex/encoder/nonalpha_spec.rb
@@ -140,4 +140,49 @@ describe Rex::Encoder::NonAlpha do
     end
   end
 
+  describe ".encode" do
+    subject { described_class.encode(buf) }
+
+    context "when buf includes a badchar" do
+      let(:buf) { "ABCDEF{" }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(RuntimeError)
+      end
+    end
+
+    context "when buf includes Alpha chars" do
+      let(:buf) { "@#()" }
+
+      it "returns an String" do
+        is_expected.to be_an(String)
+      end
+
+      it "includes the decoder stub" do
+        is_expected.to match(decoder)
+      end
+
+      it "doesn't include the original buf" do
+        is_expected.to_not include(buf)
+      end
+    end
+
+    context "when buf doesn't include Alpha chars" do
+      let(:buf) { "ABCD" }
+
+      it "returns an String" do
+        is_expected.to be_an(String)
+      end
+
+      it "includes the decoder stub" do
+        is_expected.to match(decoder)
+      end
+
+      it "includes the original buf" do
+        is_expected.to include(buf)
+      end
+    end
+
+  end
+
 end

--- a/spec/lib/rex/encoder/nonalpha_spec.rb
+++ b/spec/lib/rex/encoder/nonalpha_spec.rb
@@ -33,7 +33,6 @@ describe Rex::Encoder::NonAlpha do
     end
 
     it "returns the decoder code" do
-      p "#{described_class.gen_decoder}"
       is_expected.to match(decoder)
     end
   end
@@ -138,51 +137,6 @@ describe Rex::Encoder::NonAlpha do
         expect(subject[2]).to eq(tablelen)
       end
     end
-  end
-
-  describe ".encode" do
-    subject { described_class.encode(buf) }
-
-    context "when buf includes a badchar" do
-      let(:buf) { "ABCDEF{" }
-
-      it "raises an error" do
-        expect { subject }.to raise_error(RuntimeError)
-      end
-    end
-
-    context "when buf includes Alpha chars" do
-      let(:buf) { "@#()" }
-
-      it "returns an String" do
-        is_expected.to be_an(String)
-      end
-
-      it "includes the decoder stub" do
-        is_expected.to match(decoder)
-      end
-
-      it "doesn't include the original buf" do
-        is_expected.to_not include(buf)
-      end
-    end
-
-    context "when buf doesn't include Alpha chars" do
-      let(:buf) { "ABCD" }
-
-      it "returns an String" do
-        is_expected.to be_an(String)
-      end
-
-      it "includes the decoder stub" do
-        is_expected.to match(decoder)
-      end
-
-      it "includes the original buf" do
-        is_expected.to include(buf)
-      end
-    end
-
   end
 
 end

--- a/spec/lib/rex/encoder/nonalpha_spec.rb
+++ b/spec/lib/rex/encoder/nonalpha_spec.rb
@@ -1,0 +1,71 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
+require 'rex/encoder/nonalpha'
+
+describe Rex::Encoder::NonAlpha do
+
+  let(:decoder) do
+    dec = "\x66\xB9\xFF\xFF" +
+        "\xEB\x19"  +
+        "\\\x5E"      +
+        "\x8B\xFE"  +
+        "\x83\xC7"  + "." +
+        "\x8B\xD7"  +
+        "\x3B\xF2"  +
+        "\\\x7D\x0B"  +
+        "\xB0\\\x7B"  +
+        "\xF2\xAE"  +
+        "\xFF\xCF"  +
+        "\xAC"      +
+        "\\\x28\x07"  +
+        "\xEB\xF1"  +
+        "\xEB"      + "." +
+        "\xE8\xE2\xFF\xFF\xFF"
+    Regexp.new(dec)
+  end
+
+  describe ".gen_decoder" do
+    subject { described_class.gen_decoder }
+
+    it "returns an String" do
+      is_expected.to be_kind_of(String)
+    end
+
+    it "returns the decoder code" do
+      p "#{described_class.gen_decoder}"
+      is_expected.to match(decoder)
+    end
+  end
+
+  describe ".encode_byte" do
+    subject { described_class.encode_byte(block, table, tablelen) }
+
+    context "when tablelen > 255" do
+      let(:badchars) { "" }
+      let(:block) { 0x20 }
+      let(:table) { "" }
+      let(:tablelen) { 256 }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(RuntimeError)
+      end
+    end
+
+    context "when block == 0x7b" do
+      let(:badchars) { "" }
+      let(:block) { 0x7b }
+      let(:table) { "" }
+      let(:tablelen) { 0 }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(RuntimeError)
+      end
+    end
+
+    context "when block == 0x40" do
+
+    end
+  end
+
+end


### PR DESCRIPTION
## Verification
- [x] Be sure which travis is green
- [x] Run the specs locally and ensure all the test pass

```
$ rspec spec/lib/rex/encoder/nonalpha_spec.rb


WARNING: Cucumber-rails required outside of env.rb.  The rest of loading is being defered until env.rb is called.
  To avoid this warning, move 'gem cucumber-rails' under only group :test in your Gemfile
Rex::Encoder::NonAlpha ...................

Finished in 0.02455 seconds
19 examples, 0 failures

Randomized with seed 28544

Coverage report generated for RSpec to /Users/jvazquez/Projects/Code/metasploit-framework/coverage. 16396 / 92819 LOC (17.66%) covered.
```
