### PR TITLE
Stage encoding is now SaveRegister aware

### DIFF
--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -23,7 +23,7 @@ class EncodedPayload
     p = EncodedPayload.new(pinst.framework, pinst, reqs)
 
     p.generate(reqs['Raw'])
-    
+
     return p
   end
 
@@ -59,7 +59,7 @@ class EncodedPayload
     if (priority == 0)
       Thread.current.priority = 1
     end
-    
+
     begin
       # First, validate
       pinst.validate()
@@ -75,8 +75,6 @@ class EncodedPayload
 
       # Finally, set the complete payload definition
       self.encoded = (self.nop_sled || '') + self.encoded
-    rescue NoEncodersSucceededError
-      self.encoded = nil
     ensure
       # Restore the thread priority
       Thread.current.priority = priority
@@ -241,7 +239,7 @@ class EncodedPayload
       # If the encoded payload is nil, raise an exception saying that we
       # suck at life.
       if (self.encoded == nil)
-        self.encoder = nil        
+        self.encoder = nil
         raise NoEncodersSucceededError,
           "#{pinst.refname}: All encoders failed to encode.",
           caller

--- a/lib/msf/core/payload/stager.rb
+++ b/lib/msf/core/payload/stager.rb
@@ -141,7 +141,9 @@ module Msf::Payload::Stager
         warning_msg << " (#{conn.peerhost})"  if conn.respond_to? :peerhost
         warning_msg << ": #{$!}"
         print_warning warning_msg
-        conn.close if conn.respond_to? :close
+        if conn.respond_to? :close && !conn.closed?
+          conn.close
+        end
         return
       end
 
@@ -256,7 +258,7 @@ module Msf::Payload::Stager
         'EncoderOptions'     => { 'SaveRegisters' => saved_registers },
         'ForceSaveRegisters' => true,
         'ForceEncode'        => true)
-      
+
       if encp.encoder
         print_status("Encoded stage with #{encp.encoder.refname}")
         estg = encp.encoded

--- a/modules/encoders/x86/shikata_ga_nai.rb
+++ b/modules/encoders/x86/shikata_ga_nai.rb
@@ -84,15 +84,9 @@ class Metasploit3 < Msf::Encoder::XorAdditiveFeedback
     ]
   end
 
-  # Always preserve these registers in our block generation
-  def preserved_registers
-    ([
-      # Never modify our stack pointer
-      Rex::Arch::X86::ESP,
-      # Never modify our counter register
-      Rex::Arch::X86::ECX
-      # Never modify user specified registers
-    ] + saved_registers).uniq
+  # Always blacklist these registers in our block generation
+  def block_generator_register_blacklist
+    [Rex::Arch::X86::ESP, Rex::Arch::X86::ECX] | saved_registers
   end
 
 protected
@@ -286,7 +280,7 @@ protected
 
     begin
       # Generate a permutation saving the ECX, ESP, and user defined registers
-      loop_inst.generate(preserved_registers, nil, state.badchars)
+      loop_inst.generate(block_generator_register_blacklist, nil, state.badchars)
     rescue RuntimeError => e
       raise EncodingError
     end


### PR DESCRIPTION
This change makes EnableStageEncoding reliable. Prior to this patch, there was no way to tell the encoder what registers to preserve, which led to shikata_ga_nai stepping on the EDI register when used with sockedi stagers. This patch now automatically determines what registers to preserve by scanning the Compatibility key and passes these, along with any set by the user, to the EncodedPayload class for the stage. The EncodedPayload class now looks for 'ForceSaveRegisters' set in `req[]` and then verifies that the encoder supports register preservation if `EncoderOptions['SaveRegisters']` is set. 

TL;DR: Backwards compatible and now limits stage encoding to compatible encoders when a stager is used that requires a register to be preserved. Future work would include making additional encoders compatible with register preservation (or at least check to see if they can support the given SaveRegisters).
