### PR TITLE
Remove STAGERNAME option in auxiliary/admin/http/jboss_bshdeployer

### DIFF
--- a/lib/msf/http/jboss/bean_shell.rb
+++ b/lib/msf/http/jboss/bean_shell.rb
@@ -18,6 +18,7 @@ module Msf::HTTP::JBoss::BeanShell
     end
 
     packages.each do |p|
+      print_status("Attempting to use '#{p}' as package")
       if deploy_package(bsh_script, p)
         return p
       end
@@ -34,7 +35,6 @@ module Msf::HTTP::JBoss::BeanShell
   def deploy_package(bsh_script, package)
     success = false
 
-    print_status("Attempting to use '#{package}' as package")
     res = invoke_bsh_script(bsh_script, package)
 
     if res.nil?


### PR DESCRIPTION
This option wasn't really required, the stager can be removed as
soon as the WAR is deployed. This commit does the modifications needed
to remove the stager right after the WAR deployment.
