### PR TITLE
Fixes NoMethodError undefined method `each' for nil:NilClass

### DIFF
--- a/lib/metasploit/framework/credential_collection.rb
+++ b/lib/metasploit/framework/credential_collection.rb
@@ -16,6 +16,8 @@ class Metasploit::Framework::CredentialCollection
   #   @return [String]
   attr_accessor :password
 
+  attr_accessor :key_path
+
   # @!attribute prepended_creds
   #   List of credentials to be tried before any others
   #

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -247,6 +247,8 @@ class Metasploit3 < Msf::Auxiliary
       @key_path = opts.fetch(:key_path)
 
       valid!
+
+      super
     end
 
     def realm


### PR DESCRIPTION
Fixes NoMethodError undefined method `each' for nil:NilClass for ssh_login_pubkey. See https://github.com/rapid7/metasploit-framework/issues/3772
