### PR TITLE
Glassfish LoginScanner exception

### DIFF
--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -77,6 +77,14 @@ module Metasploit
             raise NotImplementedError
           end
 
+          # @abstract Override this to detect that the service is up, is the
+          #   right version, etc.
+          # @return [false] Indicates there were no errors
+          # @return [String] a human-readable error message describing why
+          #   this scanner can't run
+          def check_setup
+            false
+          end
 
           def each_credential
             cred_details.each do |raw_cred|
@@ -85,6 +93,11 @@ module Metasploit
               credential = raw_cred.to_credential
 
               if credential.realm.present? && self.class::REALM_KEY.present?
+                # The class's realm_key will always be the right thing for the
+                # service it knows how to login to. Override the credential's
+                # realm_key if one exists for the class. This can happen for
+                # example when we have creds for DB2 and want to try them
+                # against Postgres.
                 credential.realm_key = self.class::REALM_KEY
                 yield credential
               elsif credential.realm.blank? && self.class::REALM_KEY.present? && self.class::DEFAULT_REALM.present?
@@ -93,12 +106,14 @@ module Metasploit
                 yield credential
               elsif credential.realm.present? && self.class::REALM_KEY.blank?
                 second_cred = credential.dup
-                # Strip the realm off here, as we don't want it
+                # This service has no realm key, so the realm will be
+                # meaningless. Strip it off.
                 credential.realm = nil
                 credential.realm_key = nil
                 yield credential
                 # Some services can take a domain in the username like this even though
                 # they do not explicitly take a domain as part of the protocol.
+                # e.g., telnet
                 second_cred.public = "#{second_cred.realm}\\#{second_cred.public}"
                 second_cred.realm = nil
                 second_cred.realm_key = nil

--- a/lib/metasploit/framework/login_scanner/base.rb
+++ b/lib/metasploit/framework/login_scanner/base.rb
@@ -77,8 +77,8 @@ module Metasploit
             raise NotImplementedError
           end
 
-          # @abstract Override this to detect that the service is up, is the
-          #   right version, etc.
+          # @note Override this to detect that the service is up, is the right
+          #   version, etc.
           # @return [false] Indicates there were no errors
           # @return [String] a human-readable error message describing why
           #   this scanner can't run

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -20,6 +20,25 @@ module Metasploit
         #   @return [String] Cookie session
         attr_accessor :jsession
 
+        # @todo dat API
+        # (see Base#check_setup)
+        def check_setup
+          res = send_request({'uri' => '/common/index.jsf'})
+          return false if res.nil?
+          return false if !([200, 302].include?(res.code))
+
+          if !self.ssl && res.headers['Location'] =~ /^https:/
+            self.ssl = true
+            res = send_request({'uri' => '/common/index.jsf'})
+            return false if res.nil? || res.code != 200
+          end
+
+          res = send_request({'uri' => '/login.jsf'})
+          extract_version(res.headers['Server'])
+
+          true
+        end
+
         # Sends a HTTP request with Rex
         #
         # @param (see Rex::Proto::Http::Resquest#request_raw)

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -14,29 +14,42 @@ module Metasploit
 
         # @!attribute version
         #   @return [String] Glassfish version
-        attr_accessor :version
+        attr_reader :version
 
         # @!attribute jsession
         #   @return [String] Cookie session
         attr_accessor :jsession
 
-        # @todo dat API
         # (see Base#check_setup)
         def check_setup
           res = send_request({'uri' => '/common/index.jsf'})
-          return false if res.nil?
-          return false if !([200, 302].include?(res.code))
+          return "Connection failed" if res.nil?
+          if !([200, 302].include?(res.code))
+            return "Unexpected HTTP response code #{res.code} (is this really Glassfish?)"
+          end
 
+          # If remote login is enabled on 4.x, it redirects to https on the
+          # same port.
           if !self.ssl && res.headers['Location'] =~ /^https:/
             self.ssl = true
             res = send_request({'uri' => '/common/index.jsf'})
-            return false if res.nil? || res.code != 200
+            if res.nil?
+              return "Connection failed after SSL redirection"
+            end
+            if res.code != 200
+              return "Unexpected HTTP response code #{res.code} after SSL redirection (is this really Glassfish?)"
+            end
           end
 
           res = send_request({'uri' => '/login.jsf'})
+          return "Connection failed" if res.nil?
           extract_version(res.headers['Server'])
 
-          true
+          if @version !~ /^[2349]/
+            return "Unsupported version ('#{@version}')"
+          end
+
+          false
         end
 
         # Sends a HTTP request with Rex

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -194,8 +194,8 @@ module Metasploit
         # @return [nil] If the banner did not match any of the expected values
         def extract_version(banner)
           # Set version.  Some GlassFish servers return banner "GlassFish v3".
-          if banner =~ /(GlassFish Server|Open Source Edition)[[:blank:]]*(\d\.\d)/
-            @version = $2
+          if banner =~ /GlassFish Server(?: Open Source Edition)?[[:blank:]]*(\d\.\d)/
+            @version = $1
           elsif banner =~ /GlassFish v(\d)/
             @version = $1
           elsif banner =~ /Sun GlassFish Enterprise Server v2/

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -45,7 +45,7 @@ module Metasploit
           return "Connection failed" if res.nil?
           extract_version(res.headers['Server'])
 
-          if @version !~ /^[2349]/
+          if @version.nil? || @version !~ /^[2349]/
             return "Unsupported version ('#{@version}')"
           end
 
@@ -202,6 +202,8 @@ module Metasploit
             @version = '2.x'
           elsif banner =~ /Sun Java System Application Server 9/
             @version = '9.x'
+          else
+            @version = nil
           end
 
           return @version

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -12,7 +12,7 @@ module Metasploit
         DEFAULT_PORT  = 4848
         PRIVATE_TYPES = [ :password ]
 
-        # @!attribute version
+        # @!attribute [r] version
         #   @return [String] Glassfish version
         attr_reader :version
 

--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -5,10 +5,6 @@ module Metasploit
   module Framework
     module LoginScanner
 
-      # I don't want to raise RuntimeError to be able to abort login
-      class GlassfishError < StandardError
-      end
-
       # The Glassfish HTTP LoginScanner class provides methods to do login routines
       # for Glassfish 2, 3 and 4.
       class Glassfish < HTTP
@@ -23,7 +19,6 @@ module Metasploit
         # @!attribute jsession
         #   @return [String] Cookie session
         attr_accessor :jsession
-
 
         # Sends a HTTP request with Rex
         #
@@ -126,9 +121,9 @@ module Metasploit
               return {:status => Metasploit::Model::Login::Status::SUCCESSFUL, :proof => res.body}
             end
           elsif res && is_secure_admin_disabled?(res)
-            return {:status => Metasploit::Model::Login::Status::SUCCESSFUL, :proof => res.body}
+            return {:status => Metasploit::Model::Login::Status::DENIED_ACCESS, :proof => res.body}
           elsif res && res.code == 400
-            raise GlassfishError, "400: Bad HTTP request from try_login"
+            return {:status => Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, :proof => res.body}
           end
 
           {:status => Metasploit::Model::Login::Status::INCORRECT, :proof => res.body}
@@ -146,12 +141,10 @@ module Metasploit
             case self.version
             when /^[29]\.x$/
               status = try_glassfish_2(credential)
-              result_opts.merge!(status: status[:status], proof:status[:proof])
+              result_opts.merge!(status)
             when /^[34]\./
               status = try_glassfish_3(credential)
-              result_opts.merge!(status: status[:status], proof:status[:proof])
-           else
-              raise GlassfishError, "Glassfish version '#{self.version}' not supported"
+              result_opts.merge!(status)
             end
           rescue ::EOFError, Rex::ConnectionError, ::Timeout::Error
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)
@@ -159,6 +152,29 @@ module Metasploit
 
           Result.new(result_opts)
         end
+
+        #
+        # Extract the target's glassfish version from the HTTP Server header
+        # (ex: Sun Java System Application Server 9.x)
+        #
+        # @param banner [String] `Server` header from a Glassfish service response
+        # @return [String] version string, e.g. '2.x'
+        # @return [nil] If the banner did not match any of the expected values
+        def extract_version(banner)
+          # Set version.  Some GlassFish servers return banner "GlassFish v3".
+          if banner =~ /(GlassFish Server|Open Source Edition)[[:blank:]]*(\d\.\d)/
+            @version = $2
+          elsif banner =~ /GlassFish v(\d)/
+            @version = $1
+          elsif banner =~ /Sun GlassFish Enterprise Server v2/
+            @version = '2.x'
+          elsif banner =~ /Sun Java System Application Server 9/
+            @version = '9.x'
+          end
+
+          return @version
+        end
+
 
       end
     end

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -35,6 +35,7 @@ module Metasploit
                   presence: true,
                   length: { minimum: 1 }
 
+        # (see Base#check_setup)
         def check_setup
           http_client = Rex::Proto::Http::Client.new(
             host, port, {}, ssl, ssl_version
@@ -48,10 +49,10 @@ module Metasploit
           response = http_client._send_recv(request)
 
           if !(response && response.code == 401 && response.headers['WWW-Authenticate'])
-            return "No authentication required"
+            "No authentication required"
+          else
+            false
           end
-
-          false
         end
 
         # Attempt a single login with a single credential against the target.

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -35,6 +35,25 @@ module Metasploit
                   presence: true,
                   length: { minimum: 1 }
 
+        def check_setup
+          http_client = Rex::Proto::Http::Client.new(
+            host, port, {}, ssl, ssl_version
+          )
+          request = http_client.request_cgi(
+            'uri' => uri,
+            'method' => method
+          )
+          # Use _send_recv instead of send_recv to skip automatiu
+          # authentication
+          response = http_client._send_recv(request)
+
+          if !(response && response.code == 401 && response.headers['WWW-Authenticate'])
+            return "No authentication required"
+          end
+
+          false
+        end
+
         # Attempt a single login with a single credential against the target.
         #
         # @param credential [Credential] The credential object to attempt to
@@ -73,20 +92,9 @@ module Metasploit
               'method' => method
             )
 
-            # First try to connect without logging in to make sure this
-            # resource requires authentication. We use #_send_recv for
-            # that instead of #send_recv.
-            response = http_client._send_recv(request)
-            if response && response.code == 401 && response.headers['WWW-Authenticate']
-              # Now send the creds
-              response = http_client.send_auth(
-                response, request.opts, connection_timeout, true
-              )
-              if response && response.code == 200
-                result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: response.headers)
-              end
-            else
-              result_opts.merge!(status: Metasploit::Model::Login::Status::NO_AUTH_REQUIRED)
+            response = http_client.send_recv(request)
+            if response && response.code == 200
+              result_opts.merge!(status: Metasploit::Model::Login::Status::SUCCESSFUL, proof: response.headers)
             end
           rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error
             result_opts.merge!(status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT)

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -182,8 +182,9 @@ class Metasploit3 < Msf::Auxiliary
   #
   def run_host(ip)
     init_loginscanner(ip)
-    if !@scanner.check_setup
-      print_brute :level => :error, :ip => rhost, :msg => "Not glassfish"
+    msg = @scanner.check_setup
+    if msg
+      print_brute :level => :error, :ip => rhost, :msg => msg
       return
     end
 

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -51,51 +51,10 @@ class Metasploit3 < Msf::Auxiliary
   # the LoginScanner class so the authentication can proceed properly
   #
 
-  def jsession
-    @jsession || ''
-  end
-
-  def set_jsession(res)
-    if res && res.get_cookies =~ /JSESSIONID=(\w*);/i
-      @scanner.jsession = $1
-    end
-  end
-
   # Overrides the ssl method from HttpClient
   def ssl
     @scanner.ssl || datastore['SSL']
   end
-
-  #
-  # Return GlassFish's edition (Open Source or Commercial) and version (2.x, 3.0, 3.1, 9.x, 4.0) and
-  # banner (ex: Sun Java System Application Server 9.x)
-  #
-  def get_version(res)
-    # Extract banner from response
-    banner = res.headers['Server'] || ''
-
-    # Default value for edition and glassfish version
-    edition = 'Commercial'
-    version = 'Unknown'
-
-    # Set edition (Open Source or Commercial)
-    p = /(Open Source|Sun GlassFish Enterprise Server|Sun Java System Application Server)/
-    edition = 'Open Source' if banner =~ p
-
-    # Set version.  Some GlassFish servers return banner "GlassFish v3".
-    if banner =~ /(GlassFish Server|Open Source Edition)[[:blank:]]*(\d\.\d)/
-      version = $2
-    elsif banner =~ /GlassFish v(\d)/ && version.nil?
-      version = $1
-    elsif banner =~ /Sun GlassFish Enterprise Server v2/ && version == 'Unknown'
-      version = '2.x'
-    elsif banner =~ /Sun Java System Application Server 9/ && version == 'Unknown'
-      version = '9.x'
-    end
-
-    return edition, version, banner
-  end
-
 
   #
   # For a while, older versions of Glassfish didn't need to set a password for admin,
@@ -107,14 +66,12 @@ class Metasploit3 < Msf::Auxiliary
 
     if version =~ /^[29]\.x$/
       res = send_request_cgi({'uri'=>'/applications/upload.jsf'})
-      set_jsession(res)
       p = /<title>Deploy Enterprise Applications\/Modules/
       if (res && res.code.to_i == 200 && res.body.match(p) != nil)
         success = true
       end
     elsif version =~ /^3\./
       res = send_request_cgi({'uri'=>'/common/applications/uploadFrame.jsf'})
-      set_jsession(res)
       p = /<title>Deploy Applications or Modules/
       if (res && res.code.to_i == 200 && res.body.match(p) != nil)
         success = true
@@ -185,6 +142,10 @@ class Metasploit3 < Msf::Auxiliary
         print_brute :level => :good, :ip => ip, :msg => "Success: '#{result.credential}'"
         do_report(ip, rport, result)
         :next_user
+      when Metasploit::Model::Login::Status::DENIED_ACCESS
+        print_brute :level => :status, :ip => ip, :msg => "Correct credentials, but unable to login: '#{result.credential}'"
+        do_report(ip, rport, result)
+        :next_user
       when Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
         print_brute :level => :verror, :ip => ip, :msg => "Could not connect"
         invalidate_login(
@@ -220,21 +181,20 @@ class Metasploit3 < Msf::Auxiliary
     tried = false
 
     begin
-      print_status("Sending a request to /common/index.jsf...")
+      print_brute :level=>:status, :ip=>rhost, :msg=>"Sending a request to /common/index.jsf..."
       res = send_request_cgi({'uri'=>'/common/index.jsf'})
-      set_jsession(res)
 
       # Abort if res returns nil due to an exception (broken pipe or timeout)
       if res.nil?
-        print_error('Unable to get a response from the server.')
+        print_brute :level=>:error, :ip=>rhost, :msg=>'Unable to get a response from the server.'
         return
       end
 
       # Automatic HTTP to HTTPS transition (when needed)
       if @scanner.ssl == false && res && res.headers['Location'] =~ /^https:\/\//
-        print_status("Glassfish is asking us to use HTTPS")
-        print_status("SSL option automatically set to: true")
-        print_status("SSL version option automatically set to: #{datastore['SSLVersion']}")
+        print_brute :level=>:status, :ip=>rhost, :msg=>"Glassfish is asking us to use HTTPS"
+        print_brute :level=>:status, :ip=>rhost, :msg=>"SSL option automatically set to: true"
+        print_brute :level=>:status, :ip=>rhost, :msg=>"SSL version option automatically set to: #{datastore['SSLVersion']}"
         @scanner.ssl = true
         @scanner.ssl_version = datastore['SSLVersion']
         # Set the SSL options, and let the exception handler to resend the HTTP request
@@ -255,7 +215,6 @@ class Metasploit3 < Msf::Auxiliary
     # A normal client starts with /login.jsf, so we start with /login.jsf
     if res && res.code.to_i == 302
       res = send_request_cgi({'uri' => '/login.jsf'})
-      set_jsession(res)
     end
 
     res
@@ -268,21 +227,17 @@ class Metasploit3 < Msf::Auxiliary
   def run_host(ip)
     init_loginscanner(ip)
     res = init_bruteforce
-    edition, version, banner = get_version(res)
-    @scanner.version = version
+    return if res.nil?
+    @scanner.extract_version(res.headers['Server'])
 
-    print_status('Checking if Glassfish requires a password...')
-    if version =~ /^[239]\.x$/ && is_password_required?(version)
+    print_brute :level=>:status, :ip=>rhost, :msg=>('Checking if Glassfish requires a password...')
+    if @scanner.version =~ /^[239]\.x$/ && is_password_required?(@scanner.version)
       print_brute :level => :good, :ip => ip, :msg => "Note: This Glassfish does not require a password"
     else
-      print_status("Glassfish is protected with a password")
+      print_brute :level=>:status, :ip=>rhost, :msg=>("Glassfish is protected with a password")
     end
 
-    begin
-      bruteforce(ip) unless version.blank?
-    rescue ::Metasploit::Framework::LoginScanner::GlassfishError => e
-      print_error(e.message)
-    end
+    bruteforce(ip) unless @scanner.version.blank?
   end
 
 end

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -142,6 +142,12 @@ class Metasploit3 < Msf::Auxiliary
       connection_timeout: 5,
     )
 
+    msg = scanner.check_setup
+    if msg
+      print_brute :level => :error, :ip => ip, :msg => "Verification failed: #{msg}"
+      return
+    end
+
     scanner.scan! do |result|
       credential_data = result.to_h
       credential_data.merge!(
@@ -162,9 +168,6 @@ class Metasploit3 < Msf::Auxiliary
       when Metasploit::Model::Login::Status::INCORRECT
         print_brute :level => :verror, :ip => ip, :msg => "Failed: '#{result.credential}'"
         invalidate_login(credential_data)
-      when Metasploit::Model::Login::Status::NO_AUTH_REQUIRED
-        print_brute :level => :error, :ip => ip, :msg => "Failed: '#{result.credential}'"
-        break
       end
     end
 

--- a/spec/lib/metasploit/framework/login_scanner/glassfish_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/glassfish_spec.rb
@@ -315,6 +315,11 @@ describe Metasploit::Framework::LoginScanner::Glassfish do
       it { is_expected.to start_with("3") }
     end
 
+    context 'with non-open-source header' do
+      let(:server_header) { "Oracle GlassFish Server 3.1.2.3" }
+      it { is_expected.to start_with("3") }
+    end
+
     context 'with 2.1 header' do
       let(:server_header) { "Sun GlassFish Enterprise Server v2.1" }
       it { is_expected.to start_with("2") }

--- a/spec/lib/metasploit/framework/login_scanner/glassfish_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/glassfish_spec.rb
@@ -63,7 +63,7 @@ describe Metasploit::Framework::LoginScanner::Glassfish do
   end
 
   before do
-    http_scanner.version = good_version
+    http_scanner.instance_variable_set(:@version, good_version)
   end
 
   context '#send_request' do
@@ -222,13 +222,6 @@ describe Metasploit::Framework::LoginScanner::Glassfish do
       end
     end
 
-    context 'when unsupported Glassfish version' do
-      it 'raises a GlassfishError exception' do
-        http_scanner.version = bad_version
-        expect { http_scanner.attempt_login(cred) }.to raise_exception(Metasploit::Framework::LoginScanner::GlassfishError)
-      end
-    end
-
     context 'when Glassfish version 2' do
       let(:login_ok_message) do
         '<title>Deploy Enterprise Applications/Modules</title>'
@@ -301,6 +294,15 @@ describe Metasploit::Framework::LoginScanner::Glassfish do
         expect(http_scanner.attempt_login(cred)).to be_kind_of(Metasploit::Framework::LoginScanner::Result)
       end
     end
+  end
+
+  context '#extract_version' do
+    let(:server_header) { "GlassFish Server Open Source Edition  4.0" }
+
+    specify do
+      expect(http_scanner.extract_version(server_header)).to eq("4.0")
+    end
+
   end
 
 end

--- a/spec/lib/metasploit/framework/login_scanner/glassfish_spec.rb
+++ b/spec/lib/metasploit/framework/login_scanner/glassfish_spec.rb
@@ -297,11 +297,34 @@ describe Metasploit::Framework::LoginScanner::Glassfish do
   end
 
   context '#extract_version' do
-    let(:server_header) { "GlassFish Server Open Source Edition  4.0" }
+    # Thanks to shodan for Server headers
+    subject(:extracted_version) { http_scanner.extract_version(server_header) }
 
-    specify do
-      expect(http_scanner.extract_version(server_header)).to eq("4.0")
+    context 'with 9.1 header' do
+      let(:server_header) { "Sun Java System Application Server 9.1_02" }
+      it { is_expected.to start_with("9") }
     end
+
+    context 'with 4.0 header' do
+      let(:server_header) { "GlassFish Server Open Source Edition  4.0" }
+      it { is_expected.to start_with("4") }
+    end
+
+    context 'with 3.0 header' do
+      let(:server_header) { "GlassFish Server Open Source Edition 3.0.1" }
+      it { is_expected.to start_with("3") }
+    end
+
+    context 'with 2.1 header' do
+      let(:server_header) { "Sun GlassFish Enterprise Server v2.1" }
+      it { is_expected.to start_with("2") }
+    end
+
+    context 'with bogus header' do
+      let(:server_header) { "Apache-Coyote/1.1" }
+      it { is_expected.to be_nil }
+    end
+
 
   end
 


### PR DESCRIPTION
`LoginScanner`s should _not_ raise exceptions unless something is broken.
## Verification
### Glassfish
- [x] see #3716 for how to install glassfish if you don't already have it
#### Test the module with Secure Admin off

By default, Secure Admin is off, so you cannot login remotely. Let's test this and make sure the module is aware of this condition:
- [x] Start msfconsole
- [x] `use auxiliary/scanner/http/glassfish_login`
- [x] Set the appropriate options (rhosts, username, and password)
- [x] `Run`
- [x] Make sure you see the message: "Correct credentials, but unable to login"
#### Test the module with Secure Admin on
- [x] On the Glassfish box, open a browser, and then go to: http://localhost:4848
- [x] Look at the menu on the left, those are the "Common Tasks". You should see an item that says "server (Admin Server)", click on that.
- [x] You should see a button that says "Enable Secure Admin", click on that. If your Glassfish does not have a password, it will ask you to set that first before enabling Secure Admin.
- [x] On the attack's box, use the browser to verify you can login remotely
- [x] Run the glassfish_login module with the correct username/password, you should see a successful login attempt message
- [x] Run the glassfish_login module with a bad password, you should NOT see the same successful login message
### HTTP
- [x] Create file:
  
  ```
   msfadmin badpassword
   msfadmin msfadmin
   asdfjkl doesntreallyexist
  ```
- [x] `use auxiliary/scanner/http/http_login`
- [x] `set USERPASS_FILE <path to created file>` 
- [x] `set PASS_FILE /dev/null`
- [x] `set USER_FILE /dev/null`
- [x] `set AUTH_URI /ntlm/` 
- [x] `run`
- [x] **VERIFY** success
- [x] `set AUTH_URI /negotiate/` 
- [x] `run`
- [x] **VERIFY** success
- [x] `set AUTH_URI /basic/` 
- [x] `run`
- [x] **VERIFY** success
- [x] `set AUTH_URI /dne/` 
- [x] `run`
- [x] **VERIFY** No auth required
- [x] `set AUTH_URI /` 
- [x] `run`
- [x] **VERIFY** No auth required
