### PR TITLE
Wrong imagebase used when search for jmp <reg> in elf libs

### DIFF
--- a/lib/rex/elfparsey/elf.rb
+++ b/lib/rex/elfparsey/elf.rb
@@ -34,7 +34,7 @@ class Elf < ElfBase
         isource.read(offset, PROGRAM_HEADER_SIZE), ei_data
       )
 
-      if program_header[-1].p_type == PT_LOAD && base_addr == 0
+      if program_header[-1].p_type == PT_LOAD && program_header[-1].p_flags & PF_EXEC > 0
         base_addr = program_header[-1].p_vaddr
       end
 

--- a/lib/rex/elfparsey/elfbase.rb
+++ b/lib/rex/elfparsey/elfbase.rb
@@ -214,6 +214,15 @@ class ElfBase
     [ 'uint32n', 'p_align',  0 ]
   )
 
+  # p_flags  This member tells which permissions should have the segment
+
+  # Flags
+
+  PF_EXEC    = 1
+  PF_WRITE   = 2
+  PF_READ    = 4 
+
+
   #
   # p_type  This member tells what kind of segment this array element
   # describes or how to interpret the array element's information.


### PR DESCRIPTION
When uses msfelfscan or msfbinscan the vaddr of the wrong program_header was used as imagebase.
