### PR TITLE
Fix rake when cucumber gem is not present

### DIFF
--- a/lib/tasks/custom_cucumber.rake
+++ b/lib/tasks/custom_cucumber.rake
@@ -13,7 +13,12 @@ begin
       t.profile = 'boot'
     end
   end
-  
+
+rescue LoadError
+  desc 'cucumber rake task not available (cucumber not installed)'
+  task :cucumber do
+    abort 'Cucumber rake task is not available. Be sure to install cucumber as a gem or plugin'
+  end
 end
 
 end


### PR DESCRIPTION
Ensure `rake` works without the cucumber gem.
## Verification Steps
- [x] Run: `bundle install --without test`
- [x] VERIFY: `rake -T` lists tasks.  No stacktraces.
- [x] Run: `bundle config --delete without`
- [x] Run: `bundle install`
- [x] VERIFY: `rake -T` lists tasks.  No stacktraces.
