### PR TITLE
Adds a spec to ensure HttpServer runs Concern hooks.

### DIFF
--- a/spec/lib/msf/core/exploit/http/server_spec.rb
+++ b/spec/lib/msf/core/exploit/http/server_spec.rb
@@ -6,10 +6,6 @@ require 'msf/core'
 require 'msf/core/exploit/http/server'
 
 describe Msf::Exploit::Remote::HttpServer do
-  # Ensure HttpServer allows Concerns for run-time refinement of the class  
-end
-
-describe Msf::Exploit::Remote::HttpServer do
 
   subject(:server_module) do
     mod = Msf::Exploit.allocate

--- a/spec/lib/msf/core/exploit/http/server_spec.rb
+++ b/spec/lib/msf/core/exploit/http/server_spec.rb
@@ -6,6 +6,11 @@ require 'msf/core'
 require 'msf/core/exploit/http/server'
 
 describe Msf::Exploit::Remote::HttpServer do
+  # Ensure HttpServer allows Concerns for run-time refinement of the class  
+end
+
+describe Msf::Exploit::Remote::HttpServer do
+
   subject(:server_module) do
     mod = Msf::Exploit.allocate
     mod.extend described_class
@@ -25,6 +30,8 @@ describe Msf::Exploit::Remote::HttpServer do
   before do
     Rex::ServiceManager.stub(:start => mock_service)
   end
+
+  it_should_behave_like 'Metasploit::Concern.run'
 
   describe "#add_resource" do
     it "should call the ServiceManager's add_resource" do

--- a/spec/lib/msf/core/exploit/http/server_spec.rb
+++ b/spec/lib/msf/core/exploit/http/server_spec.rb
@@ -27,6 +27,7 @@ describe Msf::Exploit::Remote::HttpServer do
     Rex::ServiceManager.stub(:start => mock_service)
   end
 
+  # Ensure the class is hooks Metasploit::Concern
   it_should_behave_like 'Metasploit::Concern.run'
 
   describe "#add_resource" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,10 +22,19 @@ require 'rspec/rails/mocks'
 
 FILE_FIXTURES_PATH = File.expand_path(File.dirname(__FILE__)) + '/file_fixtures/'
 
+# Load the shared examples from the following engines
+engines = [
+  Metasploit::Concern,
+  Rails
+]
+
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each do |f|
-  require f
+engines.each do |engine|
+  support_glob = engine.root.join('spec', 'support', '**', '*.rb')
+  Dir[support_glob].each { |f|
+    require f
+  }
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
MSP-11350

Also adds Metasploit::Concern shared_examples to the spec_helper so they can be used in any spec.
##### Verification
- [x] Travis passes.
