### PR TITLE
rescue exceptions in check_setup

### DIFF
--- a/lib/metasploit/framework/login_scanner/glassfish.rb
+++ b/lib/metasploit/framework/login_scanner/glassfish.rb
@@ -22,31 +22,35 @@ module Metasploit
 
         # (see Base#check_setup)
         def check_setup
-          res = send_request({'uri' => '/common/index.jsf'})
-          return "Connection failed" if res.nil?
-          if !([200, 302].include?(res.code))
-            return "Unexpected HTTP response code #{res.code} (is this really Glassfish?)"
-          end
-
-          # If remote login is enabled on 4.x, it redirects to https on the
-          # same port.
-          if !self.ssl && res.headers['Location'] =~ /^https:/
-            self.ssl = true
+          begin
             res = send_request({'uri' => '/common/index.jsf'})
-            if res.nil?
-              return "Connection failed after SSL redirection"
+            return "Connection failed" if res.nil?
+            if !([200, 302].include?(res.code))
+              return "Unexpected HTTP response code #{res.code} (is this really Glassfish?)"
             end
-            if res.code != 200
-              return "Unexpected HTTP response code #{res.code} after SSL redirection (is this really Glassfish?)"
+
+            # If remote login is enabled on 4.x, it redirects to https on the
+            # same port.
+            if !self.ssl && res.headers['Location'] =~ /^https:/
+              self.ssl = true
+              res = send_request({'uri' => '/common/index.jsf'})
+              if res.nil?
+                return "Connection failed after SSL redirection"
+              end
+              if res.code != 200
+                return "Unexpected HTTP response code #{res.code} after SSL redirection (is this really Glassfish?)"
+              end
             end
-          end
 
-          res = send_request({'uri' => '/login.jsf'})
-          return "Connection failed" if res.nil?
-          extract_version(res.headers['Server'])
+            res = send_request({'uri' => '/login.jsf'})
+            return "Connection failed" if res.nil?
+            extract_version(res.headers['Server'])
 
-          if @version.nil? || @version !~ /^[2349]/
-            return "Unsupported version ('#{@version}')"
+            if @version.nil? || @version !~ /^[2349]/
+              return "Unsupported version ('#{@version}')"
+            end
+          rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error
+            return "Unable to connect to target"
           end
 
           false
@@ -194,8 +198,8 @@ module Metasploit
         # @return [nil] If the banner did not match any of the expected values
         def extract_version(banner)
           # Set version.  Some GlassFish servers return banner "GlassFish v3".
-          if banner =~ /GlassFish Server(?: Open Source Edition)?[[:blank:]]*(\d\.\d)/
-            @version = $1
+          if banner =~ /(GlassFish Server|Open Source Edition)[[:blank:]]*(\d\.\d)/
+            @version = $2
           elsif banner =~ /GlassFish v(\d)/
             @version = $1
           elsif banner =~ /Sun GlassFish Enterprise Server v2/

--- a/lib/metasploit/framework/login_scanner/http.rb
+++ b/lib/metasploit/framework/login_scanner/http.rb
@@ -53,15 +53,22 @@ module Metasploit
             'uri' => uri,
             'method' => method
           )
-          # Use _send_recv instead of send_recv to skip automatiu
-          # authentication
-          response = http_client._send_recv(request)
+
+          begin
+            # Use _send_recv instead of send_recv to skip automatiu
+            # authentication
+            response = http_client._send_recv(request)
+          rescue ::EOFError, Errno::ETIMEDOUT, Rex::ConnectionError, ::Timeout::Error
+            error_message = "Unable to connect to target"
+          end
 
           if !(response && response.code == 401 && response.headers['WWW-Authenticate'])
-            "No authentication required"
+            error_message = "No authentication required"
           else
-            false
+            error_message = false
           end
+
+          error_message
         end
 
         # Attempt a single login with a single credential against the target.

--- a/lib/metasploit/framework/login_scanner/invalid.rb
+++ b/lib/metasploit/framework/login_scanner/invalid.rb
@@ -13,6 +13,7 @@ module Metasploit
           @model = model
 
           errors = @model.errors.full_messages.join(', ')
+          errors << " (#{model.class.to_s})"
           super(errors)
         end
       end

--- a/lib/metasploit/framework/login_scanner/mysql.rb
+++ b/lib/metasploit/framework/login_scanner/mysql.rb
@@ -16,64 +16,70 @@ module Metasploit
         include Metasploit::Framework::Tcp::Client
 
         DEFAULT_PORT         = 3306
-        LIKELY_PORTS         = [ 3306 ]
-        LIKELY_SERVICE_NAMES = [ 'mysql' ]
-        PRIVATE_TYPES        = [ :password ]
-        REALM_KEY           = nil
+        LIKELY_PORTS         = [3306]
+        LIKELY_SERVICE_NAMES = ['mysql']
+        PRIVATE_TYPES        = [:password]
+        REALM_KEY            = nil
 
         def attempt_login(credential)
           result_options = {
-              credential: credential,
-              host: host,
-              port: port,
-              protocol: 'tcp',
-              service_name: 'mysql'
+            credential:   credential,
+            host:         host,
+            port:         port,
+            protocol:     'tcp',
+            service_name: 'mysql'
           }
 
-          # manage our behind the scenes socket. Close any existing one and open a new one
-          disconnect if self.sock
-          connect
-
           begin
+            # manage our behind the scenes socket. Close any existing one and open a new one
+            disconnect if self.sock
+            connect
+
             ::RbMysql.connect({
-              :host           => host,
-              :port           => port,
-              :read_timeout   => 300,
-              :write_timeout  => 300,
-              :socket         => sock,
-              :user           => credential.public,
-              :password       => credential.private,
-              :db             => ''
+              :host          => host,
+              :port          => port,
+              :read_timeout  => 300,
+              :write_timeout => 300,
+              :socket        => sock,
+              :user          => credential.public,
+              :password      => credential.private,
+              :db            => ''
             })
-          rescue Errno::ECONNREFUSED
+
+          rescue Rex::HostUnreachable
             result_options.merge!({
               status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
-              proof: "Connection refused"
+              proof:  "Host was unreachable"
+            })
+          rescue Errno::ECONNREFUSED, Rex::ConnectionRefused
+            result_options.merge!({
+              status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
+              proof:  "Connection refused"
             })
           rescue RbMysql::ClientError
             result_options.merge!({
-                status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
-                proof: "Connection timeout"
+              status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
+              proof:  "Connection timeout"
             })
-          rescue Errno::ETIMEDOUT
+          rescue Errno::ETIMEDOUT, Rex::ConnectionTimeout
             result_options.merge!({
-                status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
-                proof: "Operation Timed out"
+              status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
+              proof:  "Operation Timed out"
             })
           rescue RbMysql::HostNotPrivileged
             result_options.merge!({
-                status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
-                proof: "Unable to login from this host due to policy"
+              status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
+              proof:  "Unable to login from this host due to policy"
             })
           rescue RbMysql::AccessDeniedError
             result_options.merge!({
-                status: Metasploit::Model::Login::Status::INCORRECT,
-                proof: "Access Denied"
+              status: Metasploit::Model::Login::Status::INCORRECT,
+              proof:  "Access Denied"
             })
           rescue RbMysql::HostIsBlocked
             result_options.merge!({
-                status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
-                proof: "Host blocked"
+              status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
+              proof:  "Host blocked"
             })
           end
 

--- a/lib/metasploit/framework/login_scanner/telnet.rb
+++ b/lib/metasploit/framework/login_scanner/telnet.rb
@@ -55,41 +55,45 @@ module Metasploit
               service_name: 'telnet'
           }
 
-          if connect_reset_safe == :refused
-            result_options[:status] = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-          else
-            if busy_message?
-              self.sock.close unless self.sock.closed?
+          begin
+            if connect_reset_safe == :refused
               result_options[:status] = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
-            end
-          end
-
-          unless result_options[:status]
-            unless password_prompt?
-              send_user(credential.public)
-            end
-
-            recvd_sample = @recvd.dup
-            # Allow for slow echos
-            1.upto(10) do
-              recv_telnet(self.sock, 0.10) unless @recvd.nil? or @recvd[/#{@password_prompt}/]
-            end
-
-            if password_prompt?(credential.public)
-              send_pass(credential.private)
-
-              # Allow for slow echos
-              1.upto(10) do
-                recv_telnet(self.sock, 0.10) if @recvd == recvd_sample
+            else
+              if busy_message?
+                self.sock.close unless self.sock.closed?
+                result_options[:status] = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
               end
             end
 
-            if login_succeeded?
-              result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL
-            else
-              result_options[:status] = Metasploit::Model::Login::Status::INCORRECT
-            end
+            unless result_options[:status]
+              unless password_prompt?
+                send_user(credential.public)
+              end
 
+              recvd_sample = @recvd.dup
+              # Allow for slow echos
+              1.upto(10) do
+                recv_telnet(self.sock, 0.10) unless @recvd.nil? or @recvd[/#{@password_prompt}/]
+              end
+
+              if password_prompt?(credential.public)
+                send_pass(credential.private)
+
+                # Allow for slow echos
+                1.upto(10) do
+                  recv_telnet(self.sock, 0.10) if @recvd == recvd_sample
+                end
+              end
+
+              if login_succeeded?
+                result_options[:status] = Metasploit::Model::Login::Status::SUCCESSFUL
+              else
+                result_options[:status] = Metasploit::Model::Login::Status::INCORRECT
+              end
+
+            end
+          rescue ::EOFError, Errno::ECONNRESET,  Rex::AddressInUse, Rex::ConnectionError, Rex::ConnectionTimeout, ::Timeout::Error
+            result_options[:status] = Metasploit::Model::Login::Status::UNABLE_TO_CONNECT
           end
 
           ::Metasploit::Framework::LoginScanner::Result.new(result_options)


### PR DESCRIPTION
Fixes a bug in the HTTP LoginScanners where a connection error during check_setup would cause an uncaught exception to be fired all the way up and cause a stack trace
