### PR TITLE
smb connection error not setting result properly

### DIFF
--- a/lib/metasploit/framework/login_scanner/smb.rb
+++ b/lib/metasploit/framework/login_scanner/smb.rb
@@ -149,7 +149,16 @@ module Metasploit
           begin
             connect
           rescue ::Rex::ConnectionError => e
-            return Result.new(credential:credential, status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT, proof: e)
+            result = Result.new(
+              credential:credential,
+              status: Metasploit::Model::Login::Status::UNABLE_TO_CONNECT,
+              proof: e,
+              host: host,
+              port: port,
+              protocol: 'tcp',
+              service_name: 'smb'
+            )
+            return result
           end
           proof = nil
 


### PR DESCRIPTION
if the initial connection from the SMB LoginScanner fails
it wouldn't set the target information on the result. this could cause
smb_login to throw a stack trace when it calls invalidate_login

VERIFICATION STEPS
- [x] start pro
- [x] create new workspace
- [x] import the zip attached in the ticket
- [x] go to bruteforce
- [x] enter credentials of msfadmin msfadmin
- [x] launch bruteforce
- [x] VERIFY no stack trace
