### PR TITLE
Explicitly require credential_collection

### DIFF
--- a/modules/auxiliary/scanner/http/appletv_login.rb
+++ b/modules/auxiliary/scanner/http/appletv_login.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'metasploit/framework/credential_collection'
 
 class Metasploit3 < Msf::Auxiliary
 

--- a/modules/auxiliary/scanner/http/axis_login.rb
+++ b/modules/auxiliary/scanner/http/axis_login.rb
@@ -6,6 +6,7 @@
 
 require 'msf/core'
 require 'metasploit/framework/login_scanner/axis2'
+require 'metasploit/framework/credential_collection'
 
 class Metasploit3 < Msf::Auxiliary
 

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -5,6 +5,7 @@
 
 require 'msf/core'
 require 'metasploit/framework/login_scanner/glassfish'
+require 'metasploit/framework/credential_collection'
 
 class Metasploit3 < Msf::Auxiliary
 

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -5,6 +5,7 @@
 
 require 'msf/core'
 require 'metasploit/framework/login_scanner/smh'
+require 'metasploit/framework/credential_collection'
 
 class Metasploit3 < Msf::Auxiliary
 

--- a/modules/auxiliary/scanner/http/ipboard_login.rb
+++ b/modules/auxiliary/scanner/http/ipboard_login.rb
@@ -1,6 +1,7 @@
 
 require 'msf/core'
 require 'metasploit/framework/login_scanner/ipboard'
+require 'metasploit/framework/credential_collection'
 
 class Metasploit3 < Msf::Auxiliary
 

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
@@ -7,7 +7,6 @@ require 'msf/core'
 require 'metasploit/framework/credential_collection'
 require 'metasploit/framework/login_scanner/wordpress_rpc'
 
-
 class Metasploit3 < Msf::Auxiliary
   include Msf::HTTP::Wordpress
   include Msf::Auxiliary::Scanner

--- a/modules/auxiliary/scanner/pop3/pop3_login.rb
+++ b/modules/auxiliary/scanner/pop3/pop3_login.rb
@@ -5,6 +5,7 @@
 
 require 'msf/core'
 require 'metasploit/framework/login_scanner/pop3'
+require 'metasploit/framework/credential_collection'
 
 class Metasploit3 < Msf::Auxiliary
 

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -6,6 +6,7 @@
 require 'msf/core'
 require 'net/ssh'
 require 'metasploit/framework/login_scanner/ssh'
+require 'metasploit/framework/credential_collection'
 
 class Metasploit3 < Msf::Auxiliary
 


### PR DESCRIPTION
Otherwise, you run into a require ordering problem on some platforms. This is not a great way to fix this, but it's a fast way, and possibly even a good way, since you're being explicit about what your module
requirements are.
## Verification steps
- [ ] Ensure all modules load, and no module generates a `NameError uninitialized constant Metasploit::Framework::CredentialCollection` error.

Note, this is race-ish condition and you may not run into this problem. It depends on some local system variances that I don't think we've ever been able to pin down, even in the era of post modules having the same problem.

For background on this kind of problem, see [this search](https://github.com/rapid7/metasploit-framework/pulls?q=is%3Aclosed+is%3Apr+%22uninitialized+constant%22+) and note all the errors fixed for post modules. @jlee-r7 had some clever fix for avoiding this, eventually, but I forget what it is.

/cc @kgray-r7 
