### PR TITLE
Fix Metasploit::Concern loading due to soft dependency on railties in gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,9 @@ group :db do
   gem 'activerecord', '>= 3.0.0', '< 4.0.0'
 
   # Metasploit::Credential database models
-  gem 'metasploit-credential', '>= 0.9.0'
+  gem 'metasploit-credential', '>= 0.10.1.pre.dep.pre.railties', '< 0.11'
   # Database models shared between framework and Pro.
-  gem 'metasploit_data_models', '~> 0.19'
+  gem 'metasploit_data_models', '~> 0.20.0'
   # Needed for module caching in Mdm::ModuleDetails
   gem 'pg', '>= 0.11'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,9 @@ group :db do
   gem 'activerecord', '>= 3.0.0', '< 4.0.0'
 
   # Metasploit::Credential database models
-  gem 'metasploit-credential', '>= 0.10.1.pre.dep.pre.railties', '< 0.11'
+  gem 'metasploit-credential', '~> 0.10.1'
   # Database models shared between framework and Pro.
-  gem 'metasploit_data_models', '~> 0.20.0'
+  gem 'metasploit_data_models', '~> 0.20.1'
   # Needed for module caching in Mdm::ModuleDetails
   gem 'pg', '>= 0.11'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,7 @@ gemspec
 group :db do
   # Needed for Msf::DbManager
   gem 'activerecord', '>= 3.0.0', '< 4.0.0'
-  # Metasploit::Concern hooks
-  gem 'metasploit-concern', '~> 0.1.1'
+
   # Metasploit::Credential database models
   gem 'metasploit-credential', '>= 0.9.0'
   # Database models shared between framework and Pro.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,8 @@ PATH
       activesupport (>= 3.0.0, < 4.0.0)
       bcrypt
       json
-      metasploit-model (~> 0.26.1)
+      metasploit-concern (~> 0.2.1)
+      metasploit-model (~> 0.27.0)
       meterpreter_bins (= 0.0.7)
       msgpack
       nokogiri
@@ -94,24 +95,28 @@ GEM
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    metasploit-concern (0.1.1)
+    metasploit-concern (0.2.1)
       activesupport (~> 3.0, >= 3.0.0)
-    metasploit-credential (0.9.0)
-      metasploit-concern (~> 0.1.0)
-      metasploit-model (~> 0.26.1)
-      metasploit_data_models (~> 0.19.4)
+      railties (< 4.0.0)
+    metasploit-credential (0.10.1.pre.dep.pre.railties)
+      metasploit-concern (~> 0.2.1)
+      metasploit-model (~> 0.27.0)
+      metasploit_data_models (~> 0.20.0)
       pg
+      railties (< 4.0.0)
       rubyntlm
       rubyzip (~> 1.1)
-    metasploit-model (0.26.1)
+    metasploit-model (0.27.0)
       activesupport
-    metasploit_data_models (0.19.4)
+      railties (< 4.0.0)
+    metasploit_data_models (0.20.0)
       activerecord (>= 3.2.13, < 4.0.0)
       activesupport
       arel-helpers
-      metasploit-concern (~> 0.1.0)
-      metasploit-model (~> 0.26.1)
+      metasploit-concern (~> 0.2.1)
+      metasploit-model (~> 0.27.0)
       pg
+      railties (< 4.0.0)
     meterpreter_bins (0.0.7)
     method_source (0.8.2)
     mime-types (1.25.1)
@@ -211,10 +216,9 @@ DEPENDENCIES
   factory_girl (>= 4.1.0)
   factory_girl_rails
   fivemat (= 1.2.1)
-  metasploit-concern (~> 0.1.1)
-  metasploit-credential (>= 0.9.0)
+  metasploit-credential (>= 0.10.1.pre.dep.pre.railties, < 0.11)
   metasploit-framework!
-  metasploit_data_models (~> 0.19)
+  metasploit_data_models (~> 0.20.0)
   network_interface (~> 0.0.1)
   pcaprub
   pg (>= 0.11)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       bcrypt
       json
       metasploit-concern (~> 0.2.1)
-      metasploit-model (~> 0.27.0)
+      metasploit-model (~> 0.27.1)
       meterpreter_bins (= 0.0.7)
       msgpack
       nokogiri
@@ -106,7 +106,7 @@ GEM
       railties (< 4.0.0)
       rubyntlm
       rubyzip (~> 1.1)
-    metasploit-model (0.27.0)
+    metasploit-model (0.27.1)
       activesupport
       railties (< 4.0.0)
     metasploit_data_models (0.20.0)
@@ -122,7 +122,7 @@ GEM
     mime-types (1.25.1)
     mini_portile (0.6.0)
     msgpack (0.5.8)
-    multi_json (1.0.3)
+    multi_json (1.0.4)
     network_interface (0.0.1)
     nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
     metasploit-concern (0.2.1)
       activesupport (~> 3.0, >= 3.0.0)
       railties (< 4.0.0)
-    metasploit-credential (0.10.1.pre.dep.pre.railties)
+    metasploit-credential (0.10.1)
       metasploit-concern (~> 0.2.1)
       metasploit-model (~> 0.27.0)
       metasploit_data_models (~> 0.20.0)
@@ -109,7 +109,7 @@ GEM
     metasploit-model (0.27.1)
       activesupport
       railties (< 4.0.0)
-    metasploit_data_models (0.20.0)
+    metasploit_data_models (0.20.1)
       activerecord (>= 3.2.13, < 4.0.0)
       activesupport
       arel-helpers
@@ -216,9 +216,9 @@ DEPENDENCIES
   factory_girl (>= 4.1.0)
   factory_girl_rails
   fivemat (= 1.2.1)
-  metasploit-credential (>= 0.10.1.pre.dep.pre.railties, < 0.11)
+  metasploit-credential (~> 0.10.1)
   metasploit-framework!
-  metasploit_data_models (~> 0.20.0)
+  metasploit_data_models (~> 0.20.1)
   network_interface (~> 0.0.1)
   pcaprub
   pg (>= 0.11)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140801150537) do
+ActiveRecord::Schema.define(:version => 20140905031549) do
 
   create_table "api_keys", :force => true do |t|
     t.text     "token"
@@ -125,6 +125,7 @@ ActiveRecord::Schema.define(:version => 20140801150537) do
     t.integer  "host_detail_count",                      :default => 0
     t.integer  "exploit_attempt_count",                  :default => 0
     t.integer  "cred_count",                             :default => 0
+    t.string   "detected_arch"
   end
 
   add_index "hosts", ["name"], :name => "index_hosts_on_name"

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -57,6 +57,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'bcrypt'
   # Needed for some admin modules (scrutinizer_add_user.rb)
   spec.add_runtime_dependency 'json'
+  # Metasploit::Concern hooks
+  spec.add_runtime_dependency 'metasploit-concern', '~> 0.1.1'
   # Things that would normally be part of the database model, but which
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 0.26.1'

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'metasploit-concern', '~> 0.2.1'
   # Things that would normally be part of the database model, but which
   # are needed when there's no database
-  spec.add_runtime_dependency 'metasploit-model', '~> 0.27.0'
+  spec.add_runtime_dependency 'metasploit-model', '~> 0.27.1'
   # Needed for Meterpreter on Windows, soon others.
   spec.add_runtime_dependency 'meterpreter_bins', '0.0.7'
   # Needed by msfgui and other rpc components

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -58,10 +58,10 @@ Gem::Specification.new do |spec|
   # Needed for some admin modules (scrutinizer_add_user.rb)
   spec.add_runtime_dependency 'json'
   # Metasploit::Concern hooks
-  spec.add_runtime_dependency 'metasploit-concern', '~> 0.1.1'
+  spec.add_runtime_dependency 'metasploit-concern', '~> 0.2.1'
   # Things that would normally be part of the database model, but which
   # are needed when there's no database
-  spec.add_runtime_dependency 'metasploit-model', '~> 0.26.1'
+  spec.add_runtime_dependency 'metasploit-model', '~> 0.27.0'
   # Needed for Meterpreter on Windows, soon others.
   spec.add_runtime_dependency 'meterpreter_bins', '0.0.7'
   # Needed by msfgui and other rpc components

--- a/spec/lib/msf/ui/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/command_dispatcher/db_spec.rb
@@ -74,7 +74,7 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
           "  -o <file>         Send output to a file in csv format",
           "  -R,--rhosts       Set RHOSTS from the results of the search",
           "  -S,--search       Search string to filter by",
-          "Available columns: address, arch, comm, comments, created_at, cred_count, exploit_attempt_count, host_detail_count, info, mac, name, note_count, os_flavor, os_lang, os_name, os_sp, purpose, scope, service_count, state, updated_at, virtual_host, vuln_count"
+          "Available columns: address, arch, comm, comments, created_at, cred_count, detected_arch, exploit_attempt_count, host_detail_count, info, mac, name, note_count, os_flavor, os_lang, os_name, os_sp, purpose, scope, service_count, state, updated_at, virtual_host, vuln_count"
         ]
       end
     end


### PR DESCRIPTION
MSP-11359
# Verification Steps
## Migrations
- [x] `rake db:drop db:create db:migrate`
- [x] VERIFY no errors
## Specs
- [x] `rake spec`
- [x] VERIFY no failures`
## Cucumber
- [x] `rake cucumber`
- [x] VERIFY no failures
## `msfconsole`
- [x] start msfconsole
- [x] `creds add-password bob P@ssw0rd contosso`
- [x] `creds`
- [x] **VERIFY** output contains the password you just added
