### PR TITLE
Module for detecting services which respond to empty UDP probes

### DIFF
--- a/modules/auxiliary/fuzzers/udp/empty_udp.rb
+++ b/modules/auxiliary/fuzzers/udp/empty_udp.rb
@@ -1,0 +1,48 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::UDPScanner
+
+  def initialize
+    super(
+      'Name'        => 'UDP Empty Prober',
+      'Description' => 'Detect UDP services that reply to empty probes',
+      'Author'      => 'jon_hart[at]rapid7.com',
+      'License'     => MSF_LICENSE
+    )
+    register_options([
+      OptString.new('PORTS', [true, "Ports to probe", "1-1024,1194,2000,2049,4353,5060,5061,5351,8443"])
+    ], self.class)
+  end
+
+  def setup
+    @ports = Rex::Socket.portspec_crack(datastore['PORTS'])
+    fail_with(Msf::OptionValidateError.new(['PORTS'])) if @ports.empty?
+  end
+
+  def scanner_prescan(batch)
+    print_status("Sending #{@ports.length} probes to #{batch[0]}->#{batch[-1]} (#{batch.length} hosts)")
+    @results = {}
+  end
+
+  def scan_host(ip)
+    @ports.each do |port|
+      scanner_send('', ip, port)
+    end
+  end
+
+  def scanner_postscan(_batch)
+    @results.each_key do |_k|
+    end
+  end
+
+  def scanner_process(data, shost, sport)
+    print_good("Received #{data.inspect} from #{shost}:#{sport}/udp")
+  end
+end

--- a/modules/auxiliary/scanner/discovery/empty_udp.rb
+++ b/modules/auxiliary/scanner/discovery/empty_udp.rb
@@ -17,7 +17,7 @@ class Metasploit3 < Msf::Auxiliary
       'License'     => MSF_LICENSE
     )
     register_options([
-      OptString.new('PORTS', [true, "Ports to probe", "1-1024,1194,2000,2049,4353,5060,5061,5351,8443"])
+      OptString.new('PORTS', [true, 'Ports to probe', '1-1024,1194,2000,2049,4353,5060,5061,5351,8443'])
     ], self.class)
   end
 
@@ -27,18 +27,12 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def scanner_prescan(batch)
-    print_status("Sending #{@ports.length} probes to #{batch[0]}->#{batch[-1]} (#{batch.length} hosts)")
-    @results = {}
+    print_status("Sending #{@ports.length} empty probes to #{batch[0]}->#{batch[-1]} (#{batch.length} hosts)")
   end
 
   def scan_host(ip)
     @ports.each do |port|
       scanner_send('', ip, port)
-    end
-  end
-
-  def scanner_postscan(_batch)
-    @results.each_key do |_k|
     end
   end
 

--- a/modules/auxiliary/scanner/discovery/empty_udp.rb
+++ b/modules/auxiliary/scanner/discovery/empty_udp.rb
@@ -38,5 +38,6 @@ class Metasploit3 < Msf::Auxiliary
 
   def scanner_process(data, shost, sport)
     print_good("Received #{data.inspect} from #{shost}:#{sport}/udp")
+    report_service(:host => shost, :port => sport, :proto => 'udp', :info => data.inspect)
   end
 end

--- a/modules/auxiliary/scanner/discovery/empty_udp.rb
+++ b/modules/auxiliary/scanner/discovery/empty_udp.rb
@@ -22,8 +22,9 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def setup
+    super
     @ports = Rex::Socket.portspec_crack(datastore['PORTS'])
-    fail_with(Msf::OptionValidateError.new(['PORTS'])) if @ports.empty?
+    raise Msf::OptionValidateError.new(['PORTS']) if @ports.empty?
   end
 
   def scanner_prescan(batch)


### PR DESCRIPTION
The summary says it all.  This module is as simple as it sounds.  I initially wrote this in an attempt to understand why some services were seemingly returning empty UDP responses to arbitrary UDP probes but then discovered that there are many services and situations out there that can result in replies being sent in response to UDP packets with no data.

While simply responding is absolutely not a vulnerability, it is interesting (IMO, anyway).  In a quick run in our various lab environments I found several services that respond to this module but not to anything else in framework.  I figured someone else out there may find this useful and am releasing it to perhaps spawn additional research.

Validation:
- [ ] Confirm that something useful happens when a service does _not_ respond to empty probes (try DNS)
- [ ] Confirm that something useful happens when a service does respond to empty probes

I admit that this isn't super reliable but I'm not 100% sure why.  Perhaps it is the large list of ports that I probe by default, flaky network/etc.  Suggestions are definitely welcome.

```
msf auxiliary(empty_udp) > run

[*] Sending 1 empty probes to a.b.c.d->a.b.c.d (1 hosts)
[+] Received "d\xB6\f\x80\x12\a\x00i\x00\x00\x00\x00\x00\x00\x00\x00\v\x10\x05\x00\x00\x00\x00\x00\x00\x00\x00(\x00\x00\x00\f\x00\x00\x00\x00\x01\x00\x00\x1E" from a.b.c.d:500/udp
```
