### PR TITLE
Fix badchars usage in msfvenom

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -364,7 +364,9 @@ module Msf
       iterations.times do |x|
         shellcode = encoder_module.encode(shellcode.dup, badchars, nil, platform_list)
         cli_print "#{encoder_module.refname} succeeded with size #{shellcode.length} (iteration=#{x})"
-        raise EncoderSpaceViolation, "encoder has made a buffer that is too big" if shellcode.length > space
+        if shellcode.length > space
+          raise EncoderSpaceViolation, "encoder has made a buffer that is too big"
+        end
       end
       shellcode
     end

--- a/msfvenom
+++ b/msfvenom
@@ -99,7 +99,7 @@ require 'msf/core/payload_generator'
     end
 
     opt.on('-b', '--bad-chars  <list>', String, 'The list of characters to avoid example: \'\x00\xff\'') do |b|
-      opts[:badchars] = b
+      opts[:badchars] = Rex::Text.hex_to_raw(b)
     end
 
     opt.on('-i', '--iterations <count>', Integer, 'The number of times to encode the payload') do |i|


### PR DESCRIPTION
msfvenom was interpreting the badchar string "\x20\x00\x12" as containing '\' and 'x' literals. Not sure when this was introduced, but here is a fix.
##### Verification
- [x] Generate the MIPS bind payload for linux with some badchars using msfvenom.
  
  ```
  ./msfvenom -p linux/mipsle/shell_bind_tcp -f elf -a mipsle -b'\x20\x00\x12' --platform linux
  ```
