### PR TITLE
Fix a typo for auxiliary/admin/smb/download_file.rb

### DIFF
--- a/modules/auxiliary/admin/smb/download_file.rb
+++ b/modules/auxiliary/admin/smb/download_file.rb
@@ -22,7 +22,7 @@ class Metasploit3 < Msf::Auxiliary
     super(
       'Name'        => 'SMB File Download Utility',
       'Description' => %Q{
-        This module deletes a file from a target share and path. The usual reason
+        This module downloads a file from a target share and path. The usual reason
       to use this module is to work around limitations in an existing SMB client that may not
       be able to take advantage of pass-the-hash style authentication.
       },


### PR DESCRIPTION
Downloading and deleting are two very different things. Typo probably because it was written based on the delete_file module.

Thanks Dan for spotting the issue.
