### PR TITLE
Add specs for Rex::ImageSource

### DIFF
--- a/lib/rex/image_source/image_source.rb
+++ b/lib/rex/image_source/image_source.rb
@@ -29,8 +29,12 @@ class ImageSource
     # FIXME, make me better
     string = ''
     loop do
-      char = read(offset, 1)
-      break if char == "\x00"
+      begin
+        char = read(offset, 1)
+      rescue RangeError
+        break
+      end
+      break if char.nil? || char == "\x00"
       offset += 1
       string << char
     end

--- a/spec/lib/rex/image_source/disk_spec.rb
+++ b/spec/lib/rex/image_source/disk_spec.rb
@@ -24,7 +24,7 @@ describe Rex::ImageSource::Disk do
       described_class.allocate
     end
 
-    context "when _len not send as argument" do
+    context "when _len not sent as argument" do
       let(:_file) { file }
 
       it "initializes size to file length" do
@@ -33,7 +33,7 @@ describe Rex::ImageSource::Disk do
       end
     end
 
-    context "when _offset not send argument" do
+    context "when _offset not sent as argument" do
       let(:_file) { file }
       it "initializes file_offset to 0" do
         disk_class.send(:initialize, file)
@@ -43,7 +43,7 @@ describe Rex::ImageSource::Disk do
   end
 
   describe "#read" do
-    context "when offset minor than 0" do
+    context "when offset less than 0" do
       let(:offset) { -1 }
       let(:len) { 20 }
 
@@ -52,7 +52,7 @@ describe Rex::ImageSource::Disk do
       end
     end
 
-    context "when offset plus len major than size" do
+    context "offset plus len greater than size" do
       let(:offset) { 0 }
       let(:len) { 16000 }
 

--- a/spec/lib/rex/image_source/disk_spec.rb
+++ b/spec/lib/rex/image_source/disk_spec.rb
@@ -13,23 +13,111 @@ describe Rex::ImageSource::Disk do
     File.new(path)
   end
 
+  subject do
+    described_class.new(file)
+  end
+
   describe "#initialize" do
     subject(:disk_class) do
       described_class.allocate
     end
 
+    context "when _len not send as argument" do
+      let(:_file) { file }
+
+      it "initializes size to file length" do
+        disk_class.send(:initialize, file)
+        expect(disk_class.size).to eq(4608)
+      end
+    end
+
+    context "when _offset not send argument" do
+      let(:_file) { file }
+      it "initializes file_offset to 0" do
+        disk_class.send(:initialize, file)
+        expect(disk_class.file_offset).to eq(0)
+      end
+    end
   end
 
   describe "#read" do
-    context "offset minor than 0" do
+    context "when offset minor than 0" do
       let(:offset) { -1 }
       let(:len) { 20 }
+
+      it "raises a RangeError" do
+        expect { subject.read(offset, len) }.to raise_error(RangeError)
+      end
     end
 
+    context "when offset plus len major than size" do
+      let(:offset) { 0 }
+      let(:len) { 16000 }
+
+      it "raises a RangeError" do
+        expect { subject.read(offset, len) }.to raise_error(RangeError)
+      end
+    end
+
+    context "when offset and len inside range" do
+      let(:offset) { 0 }
+      let(:len) { 2 }
+
+      it "returns file contents" do
+        expect(subject.read(offset, len)). to eq('MZ')
+      end
+    end
+
+    context "instance with tampered size" do
+      let(:tampered_size) { 6000 }
+
+      subject(:tampered) do
+        described_class.new(file, 0, tampered_size)
+      end
+
+      context "when reading offset after the real file length" do
+        let(:offset) { 5000 }
+        let(:len) { 2 }
+        it "returns nil" do
+          expect(tampered.read(offset, len)).to be_nil
+        end
+      end
+    end
   end
 
   describe "#index" do
+    let(:search) { 'MZ' }
 
+    it "returns index of first search occurrence" do
+      expect(subject.index(search)).to eq(0)
+    end
+
+    context "when offset out of range" do
+      it "returns nil" do
+        expect(subject.index(search, 6000)).to be_nil
+      end
+    end
+
+    context "when search string not found" do
+      it "returns nil" do
+        expect(subject.index(search, 4600)).to be_nil
+      end
+    end
+
+    context "instance with tampered size" do
+      let(:tampered_size) { 6000 }
+
+      subject(:tampered) do
+        described_class.new(file, 0, tampered_size)
+      end
+
+      context "when searching offset after the real file length" do
+        let(:offset) { 5000 }
+        it "raises NoMethodError" do
+          expect{ tampered.index(search, offset) }.to raise_error(NoMethodError)
+        end
+      end
+    end
   end
 
   describe "#subsource" do
@@ -39,5 +127,4 @@ describe Rex::ImageSource::Disk do
   describe "#close" do
 
   end
-
 end

--- a/spec/lib/rex/image_source/disk_spec.rb
+++ b/spec/lib/rex/image_source/disk_spec.rb
@@ -17,6 +17,8 @@ describe Rex::ImageSource::Disk do
     described_class.new(file)
   end
 
+  it_should_behave_like 'Rex::ImageSource::ImageSource'
+
   describe "#initialize" do
     subject(:disk_class) do
       described_class.allocate

--- a/spec/lib/rex/image_source/disk_spec.rb
+++ b/spec/lib/rex/image_source/disk_spec.rb
@@ -121,17 +121,35 @@ describe Rex::ImageSource::Disk do
   end
 
   describe "#subsource" do
-    let(:offset) { 0 }
+    let(:offset) { 2 }
     let(:len) { 512 }
 
     it "returns a new Rex::ImageSource::Disk" do
       expect(subject.subsource(offset, len)).to be_kind_of(described_class)
     end
 
-    
+    it "returns a new Rex::ImageSource::Disk with same file" do
+      expect(subject.subsource(offset, len).file).to eq(subject.file)
+    end
+
+    it "returns a new Rex::ImageSource::Disk with provided size" do
+      expect(subject.subsource(offset, len).size).to eq(len)
+    end
+
+    it "returns a new Rex::ImageSource::Disk with file_offset added to the original" do
+      expect(subject.subsource(offset, len).file_offset).to eq(offset + subject.file_offset)
+    end
   end
 
   describe "#close" do
+    it "returns nil" do
+      expect(subject.close).to be_nil
+    end
 
+    it "closes the associated file" do
+      expect(subject.file.closed?).to be_falsey
+      subject.close
+      expect(subject.file.closed?).to be_truthy
+    end
   end
 end

--- a/spec/lib/rex/image_source/disk_spec.rb
+++ b/spec/lib/rex/image_source/disk_spec.rb
@@ -1,0 +1,43 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
+require 'rex/image_source/disk'
+
+describe Rex::ImageSource::Disk do
+
+  let(:path) do
+    File.join(Msf::Config.data_directory, "templates", "template_x86_windows_old.exe")
+  end
+
+  let(:file) do
+    File.new(path)
+  end
+
+  describe "#initialize" do
+    subject(:disk_class) do
+      described_class.allocate
+    end
+
+  end
+
+  describe "#read" do
+    context "offset minor than 0" do
+      let(:offset) { -1 }
+      let(:len) { 20 }
+    end
+
+  end
+
+  describe "#index" do
+
+  end
+
+  describe "#subsource" do
+
+  end
+
+  describe "#close" do
+
+  end
+
+end

--- a/spec/lib/rex/image_source/disk_spec.rb
+++ b/spec/lib/rex/image_source/disk_spec.rb
@@ -121,7 +121,14 @@ describe Rex::ImageSource::Disk do
   end
 
   describe "#subsource" do
+    let(:offset) { 0 }
+    let(:len) { 512 }
 
+    it "returns a new Rex::ImageSource::Disk" do
+      expect(subject.subsource(offset, len)).to be_kind_of(described_class)
+    end
+
+    
   end
 
   describe "#close" do

--- a/spec/lib/rex/image_source/memory_spec.rb
+++ b/spec/lib/rex/image_source/memory_spec.rb
@@ -5,9 +5,31 @@ require 'rex/image_source/memory'
 
 describe Rex::ImageSource::Memory do
 
+  let(:raw_data) { "ABCDEFGHIJKLMNOP"}
+
+  subject do
+    described_class.new(raw_data)
+  end
+
   describe "#initialize" do
     subject(:memory_class) do
       described_class.allocate
+    end
+
+    it "initializes size to data length" do
+      memory_class.send(:initialize, raw_data)
+      expect(memory_class.size).to eq(raw_data.length)
+    end
+
+    it "initializes file_offset to 0 by default" do
+      memory_class.send(:initialize, raw_data)
+      expect(memory_class.file_offset).to eq(0)
+    end
+
+    context "when using nil as data" do
+      it "raises an error" do
+        expect { memory_class.send(:initialize, nil) }.to raise_error(NoMethodError)
+      end
     end
   end
 

--- a/spec/lib/rex/image_source/memory_spec.rb
+++ b/spec/lib/rex/image_source/memory_spec.rb
@@ -149,7 +149,41 @@ describe Rex::ImageSource::Memory do
   end
 
   describe "#index" do
+    let(:found) { 'FG' }
+    let(:not_found) { 'XYZ' }
 
+    context "when search available substring" do
+      it "returns the index of the first occurrence" do
+        expect(subject.index(found)).to eq(5)
+      end
+
+      context "when using negative offset" do
+        let(:offset) { -14 }
+        it "returns the index of the first occurrence" do
+          expect(subject.index(found, offset)).to eq(5)
+        end
+      end
+
+      context "when using positive offset" do
+        let(:offset) { 1 }
+        it "returns the index of the first occurrence" do
+          expect(subject.index(found, offset)).to eq(5)
+        end
+      end
+    end
+
+    context "when search not available substring" do
+      it "returns nil" do
+        expect(subject.index(not_found)).to be_nil
+      end
+    end
+
+    context "when using negative offset" do
+      let(:offset) { -1 }
+      it "start to search from offset from the end of the string" do
+        expect(subject.index(found, offset)).to be_nil
+      end
+    end
   end
 
 end

--- a/spec/lib/rex/image_source/memory_spec.rb
+++ b/spec/lib/rex/image_source/memory_spec.rb
@@ -96,7 +96,9 @@ describe Rex::ImageSource::Memory do
   end
 
   describe "#close" do
-
+    it "returns nil" do
+      expect(subject.close).to be_nil
+    end
   end
 
   describe "#index" do

--- a/spec/lib/rex/image_source/memory_spec.rb
+++ b/spec/lib/rex/image_source/memory_spec.rb
@@ -92,7 +92,54 @@ describe Rex::ImageSource::Memory do
   end
 
   describe "#subsource" do
+    let(:offset) { 2 }
+    let(:len) { 10 }
 
+    it "returns a new Rex::ImageSource::Memory" do
+      expect(subject.subsource(offset, len)).to be_kind_of(described_class)
+    end
+
+    it "returns a new Rex::ImageSource::Memory with provided size" do
+      expect(subject.subsource(offset, len).size).to eq(len)
+    end
+
+    it "returns a new Rex::ImageSource::Memory with file_offset added to the original" do
+      expect(subject.subsource(offset, len).file_offset).to eq(offset + subject.file_offset)
+    end
+
+    it "returns a new Rex::ImageSource::Memory with rawdata from the original" do
+      expect(subject.subsource(offset, len).rawdata).to eq(subject.rawdata[offset, len])
+    end
+
+    context "when offset is out of range" do
+      let(:offset) { 20 }
+      let(:len) { 2 }
+
+      it "raises an error" do
+        expect { subject.subsource(offset, len) }.to raise_error(NoMethodError)
+      end
+    end
+
+    context "when len is bigger than source rawdata" do
+      let(:offset) { 2 }
+      let(:len) { 20 }
+
+      it "returns a new Rex::ImageSource::Memory" do
+        expect(subject.subsource(offset, len)).to be_kind_of(described_class)
+      end
+
+      it "returns a new Rex::ImageSource::Memory with provided size truncated" do
+        expect(subject.subsource(offset, len).size).to eq(14)
+      end
+
+      it "returns a new Rex::ImageSource::Memory with file_offset added to the original" do
+        expect(subject.subsource(offset, len).file_offset).to eq(offset + subject.file_offset)
+      end
+
+      it "returns a new Rex::ImageSource::Memory with rawdata truncated" do
+        expect(subject.subsource(offset, len).rawdata).to eq('CDEFGHIJKLMNOP')
+      end
+    end
   end
 
   describe "#close" do

--- a/spec/lib/rex/image_source/memory_spec.rb
+++ b/spec/lib/rex/image_source/memory_spec.rb
@@ -1,0 +1,30 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
+require 'rex/image_source/memory'
+
+describe Rex::ImageSource::Memory do
+
+  describe "#initialize" do
+    subject(:memory_class) do
+      described_class.allocate
+    end
+  end
+
+  describe "#read" do
+
+  end
+
+  describe "#subsource" do
+
+  end
+
+  describe "#close" do
+
+  end
+
+  describe "#index" do
+
+  end
+
+end

--- a/spec/lib/rex/image_source/memory_spec.rb
+++ b/spec/lib/rex/image_source/memory_spec.rb
@@ -34,7 +34,7 @@ describe Rex::ImageSource::Memory do
   end
 
   describe "#read" do
-    context "when offset and len inside range" do
+    context "when offset is positive" do
       let(:offset) { 1 }
       let(:len) { 10 }
 
@@ -46,8 +46,47 @@ describe Rex::ImageSource::Memory do
         expect(subject.read(offset, len).length).to eq(10)
       end
 
-      it "returns an String with contents starting at provided offset" do
+      it "returns an String with _raw_data contents starting at provided offset" do
         expect(subject.read(offset, len)).to start_with('BCD')
+      end
+    end
+
+    context "when offset is negative" do
+      let(:offset) { -5 }
+      let(:len) { 2 }
+
+      it "returns an String" do
+        expect(subject.read(offset, len)).to be_a_kind_of(String)
+      end
+
+      it "returns an String of provided length" do
+        expect(subject.read(offset, len).length).to eq(2)
+      end
+
+      it "offset is counted from the end of the _raw_data" do
+        expect(subject.read(offset, len)).to eq('LM')
+      end
+    end
+
+    context "when offset is out of range" do
+      let(:offset) { 20 }
+      let(:len) { 2 }
+
+      it "returns nil" do
+        expect(subject.read(offset, len)).to be_nil
+      end
+    end
+
+    context "when len is bigger than _raw_data" do
+      let(:offset) { 0 }
+      let(:len) { 20 }
+
+      it "returns an String" do
+        expect(subject.read(offset, len)).to be_a_kind_of(String)
+      end
+
+      it "returns an String truncated to available contents" do
+        expect(subject.read(offset, len).length).to eq(raw_data.length)
       end
     end
   end

--- a/spec/lib/rex/image_source/memory_spec.rb
+++ b/spec/lib/rex/image_source/memory_spec.rb
@@ -11,6 +11,8 @@ describe Rex::ImageSource::Memory do
     described_class.new(raw_data)
   end
 
+  it_should_behave_like 'Rex::ImageSource::ImageSource'
+
   describe "#initialize" do
     subject(:memory_class) do
       described_class.allocate

--- a/spec/lib/rex/image_source/memory_spec.rb
+++ b/spec/lib/rex/image_source/memory_spec.rb
@@ -5,7 +5,7 @@ require 'rex/image_source/memory'
 
 describe Rex::ImageSource::Memory do
 
-  let(:raw_data) { "ABCDEFGHIJKLMNOP"}
+  let(:raw_data) { 'ABCDEFGHIJKLMNOP' }
 
   subject do
     described_class.new(raw_data)
@@ -34,7 +34,22 @@ describe Rex::ImageSource::Memory do
   end
 
   describe "#read" do
+    context "when offset and len inside range" do
+      let(:offset) { 1 }
+      let(:len) { 10 }
 
+      it "returns an String" do
+        expect(subject.read(offset, len)).to be_a_kind_of(String)
+      end
+
+      it "returns an String of provided length" do
+        expect(subject.read(offset, len).length).to eq(10)
+      end
+
+      it "returns an String with contents starting at provided offset" do
+        expect(subject.read(offset, len)).to start_with('BCD')
+      end
+    end
   end
 
   describe "#subsource" do

--- a/spec/support/shared/examples/rex/image_source/image_source.rb
+++ b/spec/support/shared/examples/rex/image_source/image_source.rb
@@ -1,0 +1,23 @@
+shared_examples_for "Rex::ImageSource::ImageSource" do
+
+  describe "#read_asciiz" do
+    let(:offset) { 0 }
+
+    it "returns an String" do
+      expect(subject.read_asciiz(offset)).to be_kind_of(String)
+    end
+
+    it "returns a null free String" do
+      expect(subject.read_asciiz(offset)).to_not include("\x00")
+    end
+
+    context "when offset bigger than available data" do
+      let(:offset) { 12345678 }
+
+      it "returns an empty String" do
+        expect(subject.read_asciiz(offset)).to be_empty
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
And fix reading on `#read_asciiz`
## Verification
- [x] Be sure which travis is green
- [x] Run the specs locally and ensure all the tests pass

```
$ rspec spec/lib/rex/image_source/*
Rex::ImageSource::Disk ...................
Rex::ImageSource::Memory ..............................

Finished in 0.11164 seconds
49 examples, 0 failures

```
