### PR TITLE
A few backward compatible fixes

### DIFF
--- a/lib/metasploit/framework/require.rb
+++ b/lib/metasploit/framework/require.rb
@@ -22,11 +22,13 @@ module Metasploit
           require name
         rescue LoadError
           warn without_warning
-          warn "Bundle installed '--without #{Bundler.settings.without.join(' ')}'"
-          warn "To clear the without option do `bundle install --without ''` " \
-           "(the --without flag with an empty string) or " \
-           "`rm -rf .bundle` to remove the .bundle/config manually and " \
-           "then `bundle install`"
+          if defined?(Bundler)
+            warn "Bundle installed '--without #{Bundler.settings.without.join(' ')}'"
+            warn "To clear the without option do `bundle install --without ''` " \
+             "(the --without flag with an empty string) or " \
+             "`rm -rf .bundle` to remove the .bundle/config manually and " \
+             "then `bundle install`"
+          end
         else
           if block_given?
             yield

--- a/lib/msf/base/simple/framework/module_paths.rb
+++ b/lib/msf/base/simple/framework/module_paths.rb
@@ -10,10 +10,15 @@ module Msf
           # Ensure the module cache is accurate
           self.modules.refresh_cache_from_database
 
-          add_engine_module_paths(Rails.application, opts)
+          # Initialize the default module search paths
+          if defined?(Rails) and not Rails.application.nil?
+            add_engine_module_paths(Rails.application, opts)
 
-          Rails.application.railties.engines.each do |engine|
-            add_engine_module_paths(engine, opts)
+            Rails.application.railties.engines.each do |engine|
+              add_engine_module_paths(engine, opts)
+            end
+          elsif (Msf::Config.module_directory)
+            self.modules.add_module_path(Msf::Config.module_directory, opts)
           end
 
           # Initialize the user module search path

--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -663,7 +663,9 @@ module Exploit::Remote::HttpServer
   end
 
   # allow this module to be patched at initialization-time
-  Metasploit::Concern.run(self)
+  if defined?(Metasploit::Concern)
+    Metasploit::Concern.run(self)
+  end
 end
 
 ###


### PR DESCRIPTION
These allow Metasploit to function in the absence of Rails and Bundler

cc @todb-r7 for the backward compatibility decision, and @limhoff-r7 for the module loading changes.
