### PR TITLE
Change max LogLevel to 3

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -3184,7 +3184,7 @@ class Core
       )
     [
       [ 'ConsoleLogging', framework.datastore['ConsoleLogging'] || "false", 'Log all console input and output' ],
-      [ 'LogLevel', framework.datastore['LogLevel'] || "0", 'Verbosity of logs (default 0, max 5)' ],
+      [ 'LogLevel', framework.datastore['LogLevel'] || "0", 'Verbosity of logs (default 0, max 3)' ],
       [ 'MinimumRank', framework.datastore['MinimumRank'] || "0", 'The minimum rank of exploits that will run without explicit confirmation' ],
       [ 'SessionLogging', framework.datastore['SessionLogging'] || "false", 'Log all input and output for sessions' ],
       [ 'TimestampOutput', framework.datastore['TimestampOutput'] || "false", 'Prefix all console output with a timestamp' ],


### PR DESCRIPTION
For a long time, we've been telling people to "setg LogLevel 5" for loggnig/debugging purposes. But if you look at how the log levels are defined in rex/constants.rb, you will see there are only 4 log levels: LEV_0, LEV_1, LEV_2, and LEV_3.
## To verify this claim:
- [ ] Look at rex/constants.rb and see it for yourself: https://github.com/rapid7/metasploit-framework/blob/master/lib/rex/constants.rb#L13
- [ ] You can also test this by first adding a `1/0` to an existing module's exploit method. And then you do `setg LogLevel 5`, do `tail -f ~/.msf4/logs/framework.log`, and you should never see a log level 5 message.

Note: if you don't know how to read the log, the format looks like this:
[date] [log level] [source] [error]

Take the following error for example:

```
[09/26/2014 14:20:28] [e(0)] core: Exploit failed (windows/browser/ie_cbutton_uaf): ZeroDivisionError divided by 0
```

e(0) means this is log level 0.
