### PR TITLE
Improve check for BASH HTTP modules

### DIFF
--- a/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
+++ b/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
@@ -58,9 +58,24 @@ class Metasploit4 < Msf::Auxiliary
         :refs => self.references
       )
       Exploit::CheckCode::Vulnerable
+    elsif res
+      injected_res_code = res.code
     else
-      Exploit::CheckCode::Safe
+      Exploit::CheckCode::Unknown
     end
+
+    res = send_request_cgi({
+      'method' => datastore['METHOD'],
+      'uri' => normalize_uri(target_uri.path.to_s)
+    })
+
+    if res && injected_res_code == res.code
+      return Exploit::CheckCode::Safe
+    elsif res && injected_res_code != res.code
+      return Exploit::CheckCode::Appears
+    end
+
+    Exploit::CheckCode::Unknown
   end
 
   def run_host(ip)

--- a/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
+++ b/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
@@ -57,11 +57,11 @@ class Metasploit4 < Msf::Auxiliary
         :name => self.name,
         :refs => self.references
       )
-      Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable
     elsif res && res.code == 500
       injected_res_code = res.code
     else
-      Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Safe
     end
 
     res = send_request_cgi({

--- a/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
+++ b/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
@@ -58,10 +58,10 @@ class Metasploit4 < Msf::Auxiliary
         :refs => self.references
       )
       Exploit::CheckCode::Vulnerable
-    elsif res
+    elsif res && res.code == 500
       injected_res_code = res.code
     else
-      Exploit::CheckCode::Unknown
+      Exploit::CheckCode::Safe
     end
 
     res = send_request_cgi({
@@ -70,7 +70,7 @@ class Metasploit4 < Msf::Auxiliary
     })
 
     if res && injected_res_code == res.code
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Unknown
     elsif res && injected_res_code != res.code
       return Exploit::CheckCode::Appears
     end

--- a/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
+++ b/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
@@ -69,10 +69,25 @@ class Metasploit4 < Msf::Exploit::Remote
     res = req("echo #{marker}")
 
     if res && res.body.include?(marker * 3)
-      Exploit::CheckCode::Vulnerable
+      return Exploit::CheckCode::Vulnerable
+    elsif res
+      injected_res_code = res.code
     else
-      Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Unknown
     end
+
+    res = send_request_cgi({
+      'method' => datastore['METHOD'],
+      'uri' => normalize_uri(target_uri.path.to_s)
+    })
+
+    if res && injected_res_code == res.code
+      return Exploit::CheckCode::Safe
+    elsif res && injected_res_code != res.code
+      return Exploit::CheckCode::Appears
+    end
+
+    Exploit::CheckCode::Unknown
   end
 
   def exploit

--- a/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
+++ b/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
@@ -70,10 +70,10 @@ class Metasploit4 < Msf::Exploit::Remote
 
     if res && res.body.include?(marker * 3)
       return Exploit::CheckCode::Vulnerable
-    elsif res
+    elsif res && res.code == 500
       injected_res_code = res.code
     else
-      return Exploit::CheckCode::Unknown
+      return Exploit::CheckCode::Safe
     end
 
     res = send_request_cgi({
@@ -82,7 +82,7 @@ class Metasploit4 < Msf::Exploit::Remote
     })
 
     if res && injected_res_code == res.code
-      return Exploit::CheckCode::Safe
+      return Exploit::CheckCode::Unknown
     elsif res && injected_res_code != res.code
       return Exploit::CheckCode::Appears
     end


### PR DESCRIPTION
@wchen-r7 pointed which when targeting a #!/bin/bash cgi, something like:

```
#!/bin/bash

echo "Content-type: text/html";
echo ""
echo "hello"

```

Even when it should be vulnerable, the check on both modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb and modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb isn't reporting it. It's because the injection trashes the output generated by the CGI which makes Apache to fail and return an 500 error code:

```
[Fri Sep 26 15:54:18 2014] [error] [client 172.16.158.1] malformed header from script. Bad header=xziRzrHuWZFEc1MVfLYQxziRzrHuWZ: first.sh
```

This pull request tries to improve check method. If the original check fails, but the answer is a 500 result, it makes a second legit request, and compares res.code, returning `Appears` if the http code is different.

Feedback is welcome. I won't be hurt if the additional complexity to the check method doesn't worth and is discarded. I think is an interesting case, so here it's the proposed code :)

After this pull request, with the example CGI:

```
tmsf auxiliary(apache_mod_cgi_bash_env) > set targeturi /cgi-bin/first.sh
targeturi => /cgi-bin/first.sh
msf auxiliary(apache_mod_cgi_bash_env) > check
[*] 172.16.158.144:80 - The target appears to be vulnerable.
[*] Checked 1 of 1 hosts (100% complete)
msf auxiliary(apache_mod_cgi_bash_env) > exit -y
```
