### PR TITLE
Add zsh completion definitions for Metasploit utilities

### DIFF
--- a/external/zsh/README.md
+++ b/external/zsh/README.md
@@ -1,0 +1,3 @@
+Metasploit completion definitions for zsh. The directory containing the
+completion files needs to be added to the ```$fpath``` environment variable,
+this is usually done in the ```~/.zshrc``` file.

--- a/external/zsh/_msfconsole
+++ b/external/zsh/_msfconsole
@@ -1,0 +1,39 @@
+#compdef msfconsole
+# ------------------------------------------------------------------------------
+# License
+# -------
+# This file is part of the Metasploit Framework and is released under the MSF
+# License, please see the COPYING file for more details.
+#
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+#  Completion script for the Metasploit Framework's msfconsole command
+#  (http://www.metasploit.com/).
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+#  * Spencer McIntyre
+#
+# ------------------------------------------------------------------------------
+
+_arguments \
+  {-a,--ask}"[Ask before exiting Metasploit or accept 'exit -y']" \
+  "-c[Load the specified configuration file]:configuration file:_files" \
+  {-d,--defanged}"[Execute the console as defanged]" \
+  {-E,--environment}"[Specify the database environment to load from the configuration]:environment:(production development)" \
+  {-h,--help}"[Show help text]" \
+  {-L,--real-readline}"[Use the system Readline library instead of RbReadline]" \
+  {-M,--migration-path}"[Specify a directory containing additional DB migrations]:directory:_files -/" \
+  {-m,--module-path}"[Specifies an additional module search path]:search path:_files -/" \
+  {-n,--no-database}"[Disable database support]" \
+  {-o,--output}"[Output to the specified file]:output file" \
+  {-p,--plugin}"[Load a plugin on startup]:plugin file:_files" \
+  {-q,--quiet}"[Do not print the banner on start up]" \
+  {-r,--resource}"[Execute the specified resource file]:resource file:_files" \
+  {-v,--version}"[Show version]" \
+  {-x,--execute-command}"[Execute the specified string as console commands]:commands" \
+  {-y,--yaml}"[Specify a YAML file containing database settings]:yaml file:_files"

--- a/external/zsh/_msfencode
+++ b/external/zsh/_msfencode
@@ -1,0 +1,82 @@
+#compdef msfencode
+# ------------------------------------------------------------------------------
+# License
+# -------
+# This file is part of the Metasploit Framework and is released under the MSF
+# License, please see the COPYING file for more details.
+#
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+#  Completion script for the Metasploit Framework's msfencode command
+#  (http://www.metasploit.com/).
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+#  * Spencer McIntyre
+#
+# ------------------------------------------------------------------------------
+
+_msfencode_encoders_list=(
+  'cmd/generic_sh'
+  'cmd/ifs'
+  'cmd/powershell_base64'
+  'cmd/printf_php_mq'
+  'generic/eicar'
+  'generic/none'
+  'mipsbe/byte_xori'
+  'mipsbe/longxor'
+  'mipsle/byte_xori'
+  'mipsle/longxor'
+  'php/base64'
+  'ppc/longxor'
+  'ppc/longxor_tag'
+  'sparc/longxor_tag'
+  'x64/xor'
+  'x86/add_sub'
+  'x86/alpha_mixed'
+  'x86/alpha_upper'
+  'x86/avoid_underscore_tolower'
+  'x86/avoid_utf8_tolower'
+  'x86/bloxor'
+  'x86/call4_dword_xor'
+  'x86/context_cpuid'
+  'x86/context_stat'
+  'x86/context_time'
+  'x86/countdown'
+  'x86/fnstenv_mov'
+  'x86/jmp_call_additive'
+  'x86/nonalpha'
+  'x86/nonupper'
+  'x86/opt_sub'
+  'x86/shikata_ga_nai'
+  'x86/single_static_bit'
+  'x86/unicode_mixed'
+  'x86/unicode_upper'
+)
+
+_msfencode_encoder() {
+  _describe -t encoders 'available encoders' _msfencode_encoders_list || compadd "$@"
+}
+
+_arguments \
+  "-a[The architecture to encode as]:architecture:(cmd generic mipsbe mipsle php ppc sparc x64 x86)" \
+  "-b[The list of characters to avoid, example: '\x00\xff']:bad characters" \
+  "-c[The number of times to encode the data]:times" \
+  "-d[Specify the directory in which to look for EXE templates]:template file:_files -/" \
+  "-e[The encoder to use]:encoder:_msfencode_encoder" \
+  "-h[Help banner]" \
+  "-i[Encode the contents of the supplied file path]:input file:_files" \
+  "-k[Keep template working; run payload in new thread (use with -x)]" \
+  "-l[List available encoders]" \
+  "-m[Specifies an additional module search path]:module path:_files -/" \
+  "-n[Dump encoder information]" \
+  "-o[The output file]:output file" \
+  "-p[The platform to encode for]:target platform:(android bsd bsdi java linux netware nodejs osx php python ruby solaris unix win)" \
+  "-s[The maximum size of the encoded data]:maximum size" \
+  "-t[The output format]:output format:(bash c csharp dw dword java js_be js_le num perl pl powershell ps1 py python raw rb ruby sh vbapplication vbscript asp aspx aspx-exe dll elf exe exe-only exe-service exe-small loop-vbs macho msi msi-nouac osx-app psh psh-net psh-reflection vba vba-exe vbs war)" \
+  "-v[Increase verbosity]" \
+  "-x[Specify an alternate executable template]:template file:_files"

--- a/external/zsh/_msfvenom
+++ b/external/zsh/_msfvenom
@@ -1,0 +1,81 @@
+#compdef msfvenom
+# ------------------------------------------------------------------------------
+# License
+# -------
+# This file is part of the Metasploit Framework and is released under the MSF
+# License, please see the COPYING file for more details.
+#
+# ------------------------------------------------------------------------------
+# Description
+# -----------
+#
+#  Completion script for the Metasploit Framework's msfvenom command
+#  (http://www.metasploit.com/).
+#
+# ------------------------------------------------------------------------------
+# Authors
+# -------
+#
+#  * Spencer McIntyre
+#
+# ------------------------------------------------------------------------------
+
+_msfvenom_encoders_list=(
+  'cmd/generic_sh'
+  'cmd/ifs'
+  'cmd/powershell_base64'
+  'cmd/printf_php_mq'
+  'generic/eicar'
+  'generic/none'
+  'mipsbe/byte_xori'
+  'mipsbe/longxor'
+  'mipsle/byte_xori'
+  'mipsle/longxor'
+  'php/base64'
+  'ppc/longxor'
+  'ppc/longxor_tag'
+  'sparc/longxor_tag'
+  'x64/xor'
+  'x86/add_sub'
+  'x86/alpha_mixed'
+  'x86/alpha_upper'
+  'x86/avoid_underscore_tolower'
+  'x86/avoid_utf8_tolower'
+  'x86/bloxor'
+  'x86/call4_dword_xor'
+  'x86/context_cpuid'
+  'x86/context_stat'
+  'x86/context_time'
+  'x86/countdown'
+  'x86/fnstenv_mov'
+  'x86/jmp_call_additive'
+  'x86/nonalpha'
+  'x86/nonupper'
+  'x86/opt_sub'
+  'x86/shikata_ga_nai'
+  'x86/single_static_bit'
+  'x86/unicode_mixed'
+  'x86/unicode_upper'
+)
+
+_msfvenom_encoder() {
+  _describe -t encoders 'available encoders' _msfvenom_encoders_list || compadd "$@"
+}
+
+_arguments \
+  {-a,--arch}"[The architecture to encode as]:architecture:(cmd generic mipsbe mipsle php ppc sparc x64 x86)" \
+  {-b,--bad-chars}"[The list of characters to avoid, example: '\x00\xff']:bad characters" \
+  {-c,--add-code}"[Specify an additional win32 shellcode file to include]:shellcode file:_files" \
+  {-e,--encoder}"[The encoder to use]:encoder:_msfvenom_encoder" \
+  {-f,--format}"[Output format]:output format:(bash c csharp dw dword java js_be js_le num perl pl powershell ps1 py python raw rb ruby sh vbapplication vbscript asp aspx aspx-exe dll elf exe exe-only exe-service exe-small loop-vbs macho msi msi-nouac osx-app psh psh-net psh-reflection vba vba-exe vbs war)" \
+  "--help-formats[List available formats]" \
+  {-h,--help}"[Help banner]" \
+  {-i,--iterations}"[The number of times to encode the payload]:iterations" \
+  {-k,--keep}"[Preserve the template behavior and inject the payload as a new thread]" \
+  {-l,--list}"[List a module type]:module type:(all encoders nops payloads)" \
+  {-n,--nopsled}"[Prepend a nopsled of length size on to the payload]:nopsled length" \
+  {-o,--options}"[List the payload's standard options]" \
+  "--platform[The platform to encode for]:target platform:(android bsd bsdi java linux netware nodejs osx php python ruby solaris unix win)" \
+  {-p,--payload}"[Payload to use. Specify a '-' or stdin to use custom payloads]:payload" \
+  {-s,--space}"[The maximum size of the resulting payload]:length" \
+  {-x,--template}"[Specify an alternate executable template]:template file:_files"


### PR DESCRIPTION
This PR adds zsh completion definitions for the msfconsole, msfencode and msfvenom utilities. The list of encoders is included in them because it does not change as frequently as other module types. These have all been tested with zsh version 5.0.6. Steps to install additional zsh completion definitions can be found in the [zsh-users/zsh-completions repository](https://github.com/zsh-users/zsh-completions#manual-installation).
