### PR TITLE
Fixes #3915 - NoMethodError private method `rhost'

### DIFF
--- a/lib/metasploit/framework/mssql/client.rb
+++ b/lib/metasploit/framework/mssql/client.rb
@@ -173,7 +173,7 @@ module Metasploit
             #Client time
             chall_MsvAvTimestamp = blob_data[:chall_MsvAvTimestamp] || ''
 
-            spnopt = {:use_spn => send_spn, :name =>  self.rhost}
+            spnopt = {:use_spn => send_spn, :name =>  rhost}
 
             resp_lm, resp_ntlm, client_challenge, ntlm_cli_challenge = NTLM_UTILS.create_lm_ntlm_responses(user, pass, challenge_key,
                                                                                                            domain_name, default_name, default_domain,


### PR DESCRIPTION
There's no self.rhost, but rhost is defined.
## Verification steps:

**You can verify this way:**
- [ ] Download SQL Server for testing: http://www.microsoft.com/en-us/server-cloud/products/sql-server/Try.aspx
- [ ] Run mssql_login against your SQL server, make sure you're testing the Windows auth part.

**Or you can verify this way (don't need to do both):**
- [x] Do a `puts rhost` in method #mssql_login in lib/metasploit/framework/mssql/client.rb
- [x] Do a `puts self.rhost` in the same method.
- [ ] You should trigger the same NoMethodError error for `self.rhost`. But the other one should print the rhost just fine.
- [ ] Make sure you restore your changes
