### PR TITLE
Fix #3914 - Inconsistent unicode names

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -676,6 +676,16 @@ module Exploit::Remote::HttpServer::HTML
 
   include Msf::Exploit::Remote::HttpServer
 
+  UTF_NONE         = 'none'
+  UTF_7            = 'utf-7'
+  UTF_7_ALL        = 'utf-7-all'
+  UTF_8            = 'utf-8'
+  UTF_16_LE        = 'utf-16le'
+  UTF_16_BE        = 'utf-16be'
+  UTF_16_BE_MARKER = 'utf-16be-marker'
+  UTF_32_LE        = 'utf-32le'
+  UTF_32_BE        = 'utf-32be'
+
 protected
 
   def initialize(info = {})
@@ -687,7 +697,7 @@ protected
         # most browsers.  as such, they are not added by default.  The
         # mixin supports encoding using them, however they are not
         # listed in the Option.
-        OptEnum.new('HTML::unicode', [false, 'Enable HTTP obfuscation via unicode', 'none', ['none', 'utf-16le', 'utf-16be', 'utf-16be-marker', 'utf-32le', 'utf-32be']]),
+        OptEnum.new('HTML::unicode', [false, 'Enable HTTP obfuscation via unicode', UTF_NONE, [UTF_NONE, UTF_16_LE, UTF_16_BE, UTF_16_BE_MARKER, UTF_32_LE, UTF_32_BE]]),
         OptEnum.new('HTML::base64', [false, 'Enable HTML obfuscation via an embeded base64 html object (IE not supported)', 'none', ['none', 'plain', 'single_pad', 'double_pad', 'random_space_injection']]),
         OptInt.new('HTML::javascript::escape', [false, 'Enable HTML obfuscation via HTML escaping (number of iterations)',  0]),
       ], Exploit::Remote::HttpServer::HTML)
@@ -881,19 +891,19 @@ protected
       }
     end
 
-    if ['utf-16le','utf-16be','utf32-le','utf32-be','utf-7','utf-8'].include?(datastore['HTML::unicode'])
+    if [UTF_16_LE,UTF_16_BE,UTF_32_LE,UTF_32_BE,UTF_7,UTF_8].include?(datastore['HTML::unicode'])
       headers['Content-Type'] = 'text/html; charset= ' + datastore['HTML::unicode']
       body = Rex::Text.to_unicode(body, datastore['HTML::unicode'])
     else
       # special cases
       case datastore['HTML::unicode']
-        when 'utf-16be-marker'
+        when UTF_16_BE_MARKER
           headers['Content-Type'] = 'text/html'
-          body = "\xFE\xFF" + Rex::Text.to_unicode(body, 'utf-16be')
-        when 'utf-7-all'
-          headers['Content-Type'] = 'text/html; charset=utf-7'
-          body = Rex::Text.to_unicode(body, 'utf-7', 'all')
-        when 'none'
+          body = "\xFE\xFF" + Rex::Text.to_unicode(body, UTF_16_BE)
+        when UTF_7_ALL
+          headers['Content-Type'] = "text/html; charset=#{UTF_7}"
+          body = Rex::Text.to_unicode(body, UTF_7, 'all')
+        when UTF_NONE
           # do nothing
         else
           raise RuntimeError, 'Invalid unicode.  how did you get here?'


### PR DESCRIPTION
This fixes https://github.com/rapid7/metasploit-framework/issues/3914

A few of the unicode names aren't defined correctly. For example: In the datastore option HTML::unicode, there is `utf-32le`. However, the `send_response_html` method is actually checking `utf32-le`, so if you choose that, you will trigger `Exploit failed: The following options failed to validate: HTML::unicode`
## To verify that all HTML::unicode options work:
- [x] You can try this test module and place it in a browser directory: https://gist.github.com/wchen-r7/13d2c259acabb0c3d453
- [x] Run `msfconsole`, load that module
- [x] Do `show evasion`, make sure you see the `HTML::unicode` option
- [x] As long as you're using one of those acceptable values, you should NEVER see: `Exploit failed: The following options failed to validate: HTML::unicode`
