### PR TITLE
Msfpayload doesn't work if ENCODER option is set

### DIFF
--- a/msfpayload
+++ b/msfpayload
@@ -82,7 +82,7 @@ end
 
 # Initialize the simplified framework instance.
 $framework = Msf::Simple::Framework.create(
-  :module_types => [ Msf::MODULE_PAYLOAD, Msf::MODULE_NOP ],
+  :module_types => [ Msf::MODULE_PAYLOAD, Msf::MODULE_ENCODER, Msf::MODULE_NOP ],
   'DisableDatabase' => true
 )
 

--- a/msfpayload
+++ b/msfpayload
@@ -82,7 +82,7 @@ end
 
 # Initialize the simplified framework instance.
 $framework = Msf::Simple::Framework.create(
-  :module_types => [ Msf::MODULE_PAYLOAD, Msf::MODULE_ENCODER, Msf::MODULE_NOP ],
+  :module_types => [ Msf::MODULE_PAYLOAD, Msf::MODULE_NOP ],
   'DisableDatabase' => true
 )
 
@@ -136,13 +136,11 @@ if (cmd =~ /^(p|y|r|d|c|h|j|x|b|v|w|n)$/)
   fmt = 'java'  if (cmd =~ /^b$/)
   fmt = 'raw' if (cmd =~ /^w$/)
   fmt = 'python' if (cmd =~ /^n$/)
-  enc = options['ENCODER']
 
   begin
     buf = payload.generate_simple(
         'Format'    => fmt,
-        'Options'   => options,
-        'Encoder'   => enc)
+        'Options'   => options)
   rescue
     $stderr.puts "Error generating payload: #{$!}"
     exit


### PR DESCRIPTION
I know nobody use msfpayload with ENCODER options but I'm working on some patch to allow multiple encoders to be set in 'encoder' payload option so we can use it in msfconsole to multiple encode payload and stage.

I saw msfpayload could get ENCODER options and use the same code as 'set StageEncoder' and 'set Encoder' (with msfconsole) but it doesn't work anymore

```
Error generating payload: undefined method `each_module_ranked' for nil:NilClass
```

It occurs because msfpayload doesn't load Msf::MODULE_ENCODER in the simplified framework instance.

Here is the little fix.
