### PR TITLE
Fix #3886 - Check runs even though there is no session

### DIFF
--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -123,6 +123,7 @@ module ModuleCommandDispatcher
   #
   def cmd_check(*args)
     defanged?
+    mod.setup
 
     ip_range_arg = args.shift || mod.datastore['RHOSTS'] || framework.datastore['RHOSTS'] || ''
     hosts = Rex::Socket::RangeWalker.new(ip_range_arg)


### PR DESCRIPTION
This fixes #3886: For post/local modules, the check method doesn't actually validate the session because that code is implemented in the setup method found in post_mixin.rb, and when you run check you don't hit that code path.
## Verification Steps
- [ ] Make sure the check command works when **RHOSTS** is set for an **exploit module**. I used ms08_067_netapi for this, here's an example:

```
msf exploit(ms08_067_netapi) > set rhosts 192.168.1.75-192.168.1.85
rhosts => 192.168.1.75-192.168.1.85
msf exploit(ms08_067_netapi) > check
[*] 192.168.1.75:445 - Cannot reliably check exploitability.
 ...
[+] 192.168.1.80:445 - The target is vulnerable.
[*] 192.168.1.81:445 - Cannot reliably check exploitability.
 ...
```
- [ ] Make sure the check command works when **RHOSTS** is set for an **auxiliary module**.  I used apache_mod_cgi_bash_env for this, here's an example:

```
msf auxiliary(apache_mod_cgi_bash_env) > set rhosts 192.168.1.112-192.168.1.114
rhosts => 192.168.1.112-192.168.1.114
msf auxiliary(apache_mod_cgi_bash_env) > set targeturi /cgi-bin/test.sh
targeturi => /cgi-bin/test.sh
msf auxiliary(apache_mod_cgi_bash_env) > check
[*] Checked 1 of 3 hosts (033% complete)
[*] Checked 2 of 3 hosts (066% complete)
[+] 192.168.1.114:80 - The target is vulnerable.
[*] Checked 3 of 3 hosts (100% complete)
```
- [ ] Make sure the check command works when **RHOST** is set for an exploit module. I used ms08_067_netapi again for this example:

```
msf exploit(ms08_067_netapi) > set rhost 192.168.1.80
rhost => 192.168.1.80
msf exploit(ms08_067_netapi) > check
[+] 192.168.1.80:445 - The target is vulnerable.
```
- [ ] Make sure the check command works for vmware_bash_function_root when a **valid** session is set. You should specifically try vmware_bash_function_root, because that's what the original bug report used. Here's an example of how it should be with the patch:

```
msf exploit(handler) > run -j
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.1.64:4444 
msf exploit(handler) > [*] Starting the payload handler...
[*] Command shell session 1 opened (192.168.1.64:4444 -> 192.168.1.64:49796) at 2014-09-30 15:27:32 -0500

msf exploit(handler) > use exploit/osx/local/vmware_bash_function_root 
msf exploit(vmware_bash_function_root) > set session 1
session => 1
msf exploit(vmware_bash_function_root) > check
[+] 192.168.1.64 - The target is vulnerable.
```
- [ ] Make sure the check command raises a validation error when an **invalid** session is set for the same vmware_bash_function_root module:

```
msf exploit(vmware_bash_function_root) > set session 2
session => 2
msf exploit(vmware_bash_function_root) > check
[-] Error while running command check: The following options failed to validate: SESSION.

Call stack:
/Users/wchen/rapid7/msf/lib/msf/core/post_mixin.rb:33:in `setup'
/Users/wchen/rapid7/msf/lib/msf/ui/console/module_command_dispatcher.rb:126:in `cmd_check'
/Users/wchen/rapid7/msf/lib/rex/ui/text/dispatcher_shell.rb:427:in `run_command'
/Users/wchen/rapid7/msf/lib/rex/ui/text/dispatcher_shell.rb:389:in `block in run_single'
/Users/wchen/rapid7/msf/lib/rex/ui/text/dispatcher_shell.rb:383:in `each'
/Users/wchen/rapid7/msf/lib/rex/ui/text/dispatcher_shell.rb:383:in `run_single'
/Users/wchen/rapid7/msf/lib/rex/ui/text/shell.rb:200:in `run'
/Users/wchen/rapid7/msf/lib/metasploit/framework/command/console.rb:15:in `start'
/Users/wchen/rapid7/msf/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:48:in `<main>'
```
