### PR TITLE
Add metasploit-park.txt banner to msfconsole

### DIFF
--- a/lib/msf/ui/banner.rb
+++ b/lib/msf/ui/banner.rb
@@ -24,6 +24,7 @@ module Banner
     wake-up-neo.txt
     workflow.txt
     3kom-superhack.txt
+    metasploit-park.txt
   }
 
   #

--- a/lib/msf/ui/logos/metasploit-park.txt
+++ b/lib/msf/ui/logos/metasploit-park.txt
@@ -1,0 +1,17 @@
+%clr
+  Metasploit Park, System Security Interface
+  Version 4.0.5, Alpha E
+  Ready...
+  > access security
+  access: PERMISSION DENIED.
+  > access security grid
+  access: PERMISSION DENIED.
+  > access main security grid
+  access: PERMISSION DENIED....and...
+  YOU DIDN'T SAY THE MAGIC WORD!
+  YOU DIDN'T SAY THE MAGIC WORD!
+  YOU DIDN'T SAY THE MAGIC WORD!
+  YOU DIDN'T SAY THE MAGIC WORD!
+  YOU DIDN'T SAY THE MAGIC WORD!
+  YOU DIDN'T SAY THE MAGIC WORD!
+  YOU DIDN'T SAY THE MAGIC WORD!


### PR DESCRIPTION
Obviously a homage to Jurassic Park. :)

[![Jurassic Park](https://img.youtube.com/vi/RfiQYRn7fBg/0.jpg)](https://www.youtube.com/watch?v=RfiQYRn7fBg)

**Verification steps:**
- [x] Watch Jurassic Park
- [ ] Run `banner` until you get this:

```
msf > banner 

  Metasploit Park, System Security Interface
  Version 4.0.5, Alpha E
  Ready...
  > access security
  access: PERMISSION DENIED.
  > access security grid
  access: PERMISSION DENIED.
  > access main security grid
  access: PERMISSION DENIED....and...
  YOU DIDN'T SAY THE MAGIC WORD!
  YOU DIDN'T SAY THE MAGIC WORD!
  YOU DIDN'T SAY THE MAGIC WORD!
  YOU DIDN'T SAY THE MAGIC WORD!
  YOU DIDN'T SAY THE MAGIC WORD!
  YOU DIDN'T SAY THE MAGIC WORD!
  YOU DIDN'T SAY THE MAGIC WORD!


       =[ metasploit v4.10.1-dev [core:4.10.1.pre.dev api:1.0.0]]
+ -- --=[ 1348 exploits - 742 auxiliary - 217 post        ]
+ -- --=[ 340 payloads - 35 encoders - 8 nops             ]
+ -- --=[ Free Metasploit Pro trial: http://r-7.co/trymsp ]

msf > 
```
- [ ] Make sure it looks good
