### PR TITLE
Fixes #3876 - Move pxeexploit to local directory

### DIFF
--- a/modules/exploits/windows/local/pxeexploit.rb
+++ b/modules/exploits/windows/local/pxeexploit.rb
@@ -6,17 +6,12 @@
 require 'msf/core'
 require 'rex/proto/tftp'
 require 'rex/proto/dhcp'
-require 'msf/core/module/deprecated'
 
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::TFTPServer
   include Msf::Auxiliary::Report
-  include Msf::Module::Deprecated
-
-  DEPRECATION_DATE = Date.new(2014, 10, 31)
-  DEPRECATION_REPLACEMENT = 'exploits/windows/local/pxeexploit'
 
   def initialize
     super(


### PR DESCRIPTION
The pxeexploit module uses a session and is an exploit, therefore it should go to the local directory. See #3876
## To check:
- [x] When you use exploit/windows/misc/pxexploit, you should see the following warning:

```
[!] ************************************************************************
[!] *           The module windows/misc/pxexploit is deprecated!           *
[!] *              It will be removed on or about 2014-10-31               *
[!] *            Use exploits/windows/local/pxeexploit instead             *
[!] ************************************************************************
```
- [x] You should be able to load exploits/windows/local/pxeexploit:

```
msf > use exploits/windows/local/pxeexploit
msf exploit(pxeexploit) >
```
