### PR TITLE
Fix cmd_exec with Python Meterpreter on OS X

### DIFF
--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -111,7 +111,13 @@ module Msf::Post::Common
         o << d
       end
       o.chomp! if o
-      process.channel.close
+
+      begin
+        process.channel.close
+      rescue IOError => e
+        # Channel was already closed, but we got the cmd output, so let's soldier on.
+      end
+
       process.close
     when /shell/
       o = session.shell_command_token("#{cmd} #{args}", time_out)


### PR DESCRIPTION
Sometimes the channel is already closed on OSX, and attempting to re-close raises an IOError. I think it is okay to discard this error as at this point we have already buffered the command output.

This fixes issue #3887, and the repro steps are the same:
#### Verification
- [x] get an osx python meterpreter session
- [x] attempt to use the `check` method in `exploits/osx/local/vmware_bash_function_root`:
  
  ```
  msf> use exploits/osx/local/vmware_bash_function_root
  msf> set session 1 # this is a osx python meterpreter session
  msf> check
  ```
- [x] Verify it does not tell you: "Check failed: IOError closed stream", but instead gives you a vulnerable or nonvulnerable status
