### PR TITLE
Fix SNMP scanners on OS X/FreeBSD

### DIFF
--- a/lib/snmp/manager.rb
+++ b/lib/snmp/manager.rb
@@ -62,8 +62,9 @@ class RexUDPTransport
             @socket.sendto(data, host, port, flags)
         rescue NoMethodError
             @socket.send(data, 0, host, port)
+        rescue ::Errno::EISCONN
+            @socket.write(data)
         end
-
     end
 
     def recv(max_bytes)


### PR DESCRIPTION
Fixes the following error when running metasploit on OS X/FreeBSD:

![image](https://cloud.githubusercontent.com/assets/1184013/4492132/be1fc78c-4a3e-11e4-8f0b-dc7f7e030953.png)

Since the socket is already connected, we can just `write()` our data.
##### Verification steps

On an OS X or FreeBSD box:

```
msf> use auxiliary/scanner/snmp/snmp_enum
msf> set RHOSTS 192.168.1.1
msf> run
```
- [x] You should not see a `EISCONN` error
