### PR TITLE
Added wpvulndb links

### DIFF
--- a/lib/msf/core/module/reference.rb
+++ b/lib/msf/core/module/reference.rb
@@ -108,7 +108,7 @@ class Msf::Module::SiteReference < Msf::Module::Reference
       self.site = "http://www.kb.cert.org/vuls/id/#{in_ctx_val}"
     elsif (in_ctx_id == 'ZDI')
       self.site = "http://www.zerodayinitiative.com/advisories/ZDI-#{in_ctx_val}"
-    elsif (in_ctx_id == 'WPVULNDBID')
+    elsif (in_ctx_id == 'WPVDB')
       self.site = "https://wpvulndb.com/vulnerabilities/#{in_ctx_val}"
     elsif (in_ctx_id == 'URL')
       self.site = in_ctx_val.to_s

--- a/lib/msf/core/module/reference.rb
+++ b/lib/msf/core/module/reference.rb
@@ -93,21 +93,23 @@ class Msf::Module::SiteReference < Msf::Module::Reference
     self.ctx_val = in_ctx_val
 
     if (in_ctx_id == 'OSVDB')
-      self.site = 'http://www.osvdb.org/' + in_ctx_val.to_s
+      self.site = "http://www.osvdb.org/#{in_ctx_val}"
     elsif (in_ctx_id == 'CVE')
-      self.site = "http://cvedetails.com/cve/#{in_ctx_val.to_s}/"
+      self.site = "http://cvedetails.com/cve/#{in_ctx_val}/"
     elsif (in_ctx_id == 'CWE')
-      self.site = "http://cwe.mitre.org/data/definitions/#{in_ctx_val.to_s}.html"
+      self.site = "http://cwe.mitre.org/data/definitions/#{in_ctx_val}.html"
     elsif (in_ctx_id == 'BID')
-      self.site = 'http://www.securityfocus.com/bid/' + in_ctx_val.to_s
+      self.site = "http://www.securityfocus.com/bid/#{in_ctx_val}"
     elsif (in_ctx_id == 'MSB')
-      self.site = 'http://technet.microsoft.com/en-us/security/bulletin/' + in_ctx_val.to_s
+      self.site = "http://technet.microsoft.com/en-us/security/bulletin/#{in_ctx_val}"
     elsif (in_ctx_id == 'EDB')
-      self.site = 'http://www.exploit-db.com/exploits/' + in_ctx_val.to_s
+      self.site = "http://www.exploit-db.com/exploits/#{in_ctx_val}"
     elsif (in_ctx_id == 'US-CERT-VU')
-      self.site = 'http://www.kb.cert.org/vuls/id/' + in_ctx_val.to_s
+      self.site = "http://www.kb.cert.org/vuls/id/#{in_ctx_val}"
     elsif (in_ctx_id == 'ZDI')
-      self.site = 'http://www.zerodayinitiative.com/advisories/ZDI-' + in_ctx_val.to_s
+      self.site = "http://www.zerodayinitiative.com/advisories/ZDI-#{in_ctx_val}"
+    elsif (in_ctx_id == 'WPVULNDBID')
+      self.site = "https://wpvulndb.com/vulnerabilities/#{in_ctx_val}"
     elsif (in_ctx_id == 'URL')
       self.site = in_ctx_val.to_s
     else

--- a/modules/auxiliary/admin/http/wp_custom_contact_forms.rb
+++ b/modules/auxiliary/admin/http/wp_custom_contact_forms.rb
@@ -25,7 +25,8 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           [ 'URL', 'http://blog.sucuri.net/2014/08/database-takeover-in-custom-contact-forms.html' ],
-          [ 'URL', 'https://plugins.trac.wordpress.org/changeset?old_path=%2Fcustom-contact-forms%2Ftags%2F5.1.0.3&old=997569&new_path=%2Fcustom-contact-forms%2Ftags%2F5.1.0.4&new=997569&sfp_email=&sfph_mail=' ]
+          [ 'URL', 'https://plugins.trac.wordpress.org/changeset?old_path=%2Fcustom-contact-forms%2Ftags%2F5.1.0.3&old=997569&new_path=%2Fcustom-contact-forms%2Ftags%2F5.1.0.4&new=997569&sfp_email=&sfph_mail=' ],
+          [ 'WPVULNDBID', '7542' ]
         ],
       'DisclosureDate' => 'Aug 07 2014'
       ))

--- a/modules/auxiliary/admin/http/wp_custom_contact_forms.rb
+++ b/modules/auxiliary/admin/http/wp_custom_contact_forms.rb
@@ -26,7 +26,7 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'URL', 'http://blog.sucuri.net/2014/08/database-takeover-in-custom-contact-forms.html' ],
           [ 'URL', 'https://plugins.trac.wordpress.org/changeset?old_path=%2Fcustom-contact-forms%2Ftags%2F5.1.0.3&old=997569&new_path=%2Fcustom-contact-forms%2Ftags%2F5.1.0.4&new=997569&sfp_email=&sfph_mail=' ],
-          [ 'WPVULNDBID', '7542' ]
+          [ 'WPVDB', '7542' ]
         ],
       'DisclosureDate' => 'Aug 07 2014'
       ))

--- a/modules/auxiliary/dos/http/wordpress_xmlrpc_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_xmlrpc_dos.rb
@@ -29,7 +29,8 @@ class Metasploit3 < Msf::Auxiliary
           ['URL', 'http://wordpress.org/news/2014/08/wordpress-3-9-2/'],
           ['URL', 'http://www.breaksec.com/?p=6362'],
           ['URL', 'http://mashable.com/2014/08/06/wordpress-xml-blowup-dos/'],
-          ['URL', 'https://core.trac.wordpress.org/changeset/29404']
+          ['URL', 'https://core.trac.wordpress.org/changeset/29404'],
+          ['WPVULNDBID', '7526']
         ],
       'DisclosureDate'=> 'Aug 6 2014'
     ))

--- a/modules/auxiliary/dos/http/wordpress_xmlrpc_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_xmlrpc_dos.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Auxiliary
           ['URL', 'http://www.breaksec.com/?p=6362'],
           ['URL', 'http://mashable.com/2014/08/06/wordpress-xml-blowup-dos/'],
           ['URL', 'https://core.trac.wordpress.org/changeset/29404'],
-          ['WPVULNDBID', '7526']
+          ['WPVDB', '7526']
         ],
       'DisclosureDate'=> 'Aug 6 2014'
     ))

--- a/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
+++ b/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
@@ -26,7 +26,7 @@ class Metasploit3 < Msf::Auxiliary
         [
           ['OSVDB', '88744'],
           ['URL', 'http://seclists.org/fulldisclosure/2012/Dec/242'],
-          ['WPVULNDBID', '6621']
+          ['WPVDB', '6621']
         ],
       'Author'        =>
         [

--- a/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
+++ b/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
@@ -25,7 +25,8 @@ class Metasploit3 < Msf::Auxiliary
       'References'    =>
         [
           ['OSVDB', '88744'],
-          ['URL', 'http://seclists.org/fulldisclosure/2012/Dec/242']
+          ['URL', 'http://seclists.org/fulldisclosure/2012/Dec/242'],
+          ['WPVULNDBID', '6621']
         ],
       'Author'        =>
         [

--- a/modules/exploits/unix/webapp/open_flash_chart_upload_exec.rb
+++ b/modules/exploits/unix/webapp/open_flash_chart_upload_exec.rb
@@ -32,7 +32,13 @@ class Metasploit3 < Msf::Exploit::Remote
           ['BID',   '37314'],
           ['CVE',   '2009-4140'],
           ['OSVDB', '59051'],
-          ['EDB',   '10532']
+          ['EDB',   '10532'],
+          ['WPVULNDBID', '6787'],
+          ['WPVULNDBID', '6788'],
+          ['WPVULNDBID', '6789'],
+          ['WPVULNDBID', '6790'],
+          ['WPVULNDBID', '6791'],
+          ['WPVULNDBID', '6792']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/unix/webapp/open_flash_chart_upload_exec.rb
+++ b/modules/exploits/unix/webapp/open_flash_chart_upload_exec.rb
@@ -33,12 +33,12 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE',   '2009-4140'],
           ['OSVDB', '59051'],
           ['EDB',   '10532'],
-          ['WPVULNDBID', '6787'],
-          ['WPVULNDBID', '6788'],
-          ['WPVULNDBID', '6789'],
-          ['WPVULNDBID', '6790'],
-          ['WPVULNDBID', '6791'],
-          ['WPVULNDBID', '6792']
+          ['WPVDB', '6787'],
+          ['WPVDB', '6788'],
+          ['WPVDB', '6789'],
+          ['WPVDB', '6790'],
+          ['WPVDB', '6791'],
+          ['WPVDB', '6792']
         ],
       'Payload'        =>
         {

--- a/modules/exploits/unix/webapp/php_wordpress_foxypress.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_foxypress.rb
@@ -31,7 +31,8 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['EDB', '18991'],
           ['OSVDB' '82652'],
-          ['BID', '53805']
+          ['BID', '53805'],
+          ['WPVULNDBID', '6231']
         ],
       'Privileged'     => false,
       'Platform'       => 'php',

--- a/modules/exploits/unix/webapp/php_wordpress_foxypress.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_foxypress.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['EDB', '18991'],
           ['OSVDB' '82652'],
           ['BID', '53805'],
-          ['WPVULNDBID', '6231']
+          ['WPVDB', '6231']
         ],
       'Privileged'     => false,
       'Platform'       => 'php',

--- a/modules/exploits/unix/webapp/php_wordpress_lastpost.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_lastpost.rb
@@ -27,6 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE', '2005-2612'],
           ['OSVDB', '18672'],
           ['BID', '14533'],
+          ['WPVULNDBID', '6034']
         ],
       'Privileged'     => false,
       'Payload'        =>
@@ -34,9 +35,9 @@ class Metasploit3 < Msf::Exploit::Remote
           'DisableNops' => true,
           'Compat'      =>
             {
-              'ConnectionType' => 'find',
+              'ConnectionType' => 'find'
             },
-          'Space'       => 512,
+          'Space'       => 512
         },
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/unix/webapp/php_wordpress_lastpost.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_lastpost.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE', '2005-2612'],
           ['OSVDB', '18672'],
           ['BID', '14533'],
-          ['WPVULNDBID', '6034']
+          ['WPVDB', '6034']
         ],
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/unix/webapp/php_wordpress_optimizepress.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_optimizepress.rb
@@ -29,7 +29,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'         => MSF_LICENSE,
       'References'      =>
         [
-          [ 'URL', "http://www.osirt.com/2013/11/wordpress-optimizepress-hack-file-upload-vulnerability/" ]
+          [ 'URL', "http://www.osirt.com/2013/11/wordpress-optimizepress-hack-file-upload-vulnerability/" ],
+          [ 'WPVULNDBID', '7441' ]
         ],
       'Privileged'      => false,
       'Platform'        => ['php'],

--- a/modules/exploits/unix/webapp/php_wordpress_optimizepress.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_optimizepress.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'      =>
         [
           [ 'URL', "http://www.osirt.com/2013/11/wordpress-optimizepress-hack-file-upload-vulnerability/" ],
-          [ 'WPVULNDBID', '7441' ]
+          [ 'WPVDB', '7441' ]
         ],
       'Privileged'      => false,
       'Platform'        => ['php'],

--- a/modules/exploits/unix/webapp/php_wordpress_total_cache.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_total_cache.rb
@@ -38,7 +38,8 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'OSVDB', '92652' ],
           [ 'BID', '59316' ],
           [ 'URL', 'http://wordpress.org/support/topic/pwn3d' ],
-          [ 'URL', 'http://www.acunetix.com/blog/web-security-zone/wp-plugins-remote-code-execution/' ]
+          [ 'URL', 'http://www.acunetix.com/blog/web-security-zone/wp-plugins-remote-code-execution/' ],
+          [ 'WPVULNDBID', '6622' ]
         ],
       'Privileged'     => false,
       'Platform'       => ['php'],

--- a/modules/exploits/unix/webapp/php_wordpress_total_cache.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_total_cache.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'BID', '59316' ],
           [ 'URL', 'http://wordpress.org/support/topic/pwn3d' ],
           [ 'URL', 'http://www.acunetix.com/blog/web-security-zone/wp-plugins-remote-code-execution/' ],
-          [ 'WPVULNDBID', '6622' ]
+          [ 'WPVDB', '6622' ]
         ],
       'Privileged'     => false,
       'Platform'       => ['php'],

--- a/modules/exploits/unix/webapp/wp_advanced_custom_fields_exec.rb
+++ b/modules/exploits/unix/webapp/wp_advanced_custom_fields_exec.rb
@@ -23,13 +23,14 @@ class Metasploit3 < Msf::Exploit::Remote
       },
       'Author'         =>
         [
-          'Charlie Eriksen <charlie[at]ceriksen.com>',
+          'Charlie Eriksen <charlie[at]ceriksen.com>'
         ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
           ['OSVDB', '87353'],
           ['URL', 'http://secunia.com/advisories/51037/'],
+          ['WPVULNDBID', '6103']
         ],
       'Privileged'     => false,
       'Payload'        =>
@@ -37,8 +38,8 @@ class Metasploit3 < Msf::Exploit::Remote
           'DisableNops' => true,
           'Compat'      =>
             {
-              'ConnectionType' => 'find',
-            },
+              'ConnectionType' => 'find'
+            }
         },
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/unix/webapp/wp_advanced_custom_fields_exec.rb
+++ b/modules/exploits/unix/webapp/wp_advanced_custom_fields_exec.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['OSVDB', '87353'],
           ['URL', 'http://secunia.com/advisories/51037/'],
-          ['WPVULNDBID', '6103']
+          ['WPVDB', '6103']
         ],
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/unix/webapp/wp_asset_manager_upload_exec.rb
+++ b/modules/exploits/unix/webapp/wp_asset_manager_upload_exec.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['BID', '53809'],
           ['EDB', '18993'],
           ['URL', 'http://www.opensyscom.fr/Actualites/wordpress-plugins-asset-manager-shell-upload-vulnerability.html'],
-          ['WPVULNDBID', '6106']
+          ['WPVDB', '6106']
         ],
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/unix/webapp/wp_asset_manager_upload_exec.rb
+++ b/modules/exploits/unix/webapp/wp_asset_manager_upload_exec.rb
@@ -31,7 +31,8 @@ class Metasploit3 < Msf::Exploit::Remote
           ['OSVDB', '82653'],
           ['BID', '53809'],
           ['EDB', '18993'],
-          ['URL', 'http://www.opensyscom.fr/Actualites/wordpress-plugins-asset-manager-shell-upload-vulnerability.html']
+          ['URL', 'http://www.opensyscom.fr/Actualites/wordpress-plugins-asset-manager-shell-upload-vulnerability.html'],
+          ['WPVULNDBID', '6106']
         ],
       'Platform'       => 'php',
       'Arch'           => ARCH_PHP,

--- a/modules/exploits/unix/webapp/wp_google_document_embedder_exec.rb
+++ b/modules/exploits/unix/webapp/wp_google_document_embedder_exec.rb
@@ -34,7 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE', '2012-4915'],
           ['OSVDB', '88891'],
           ['URL', 'http://secunia.com/advisories/50832'],
-          ['WPVULNDBID', '6073']
+          ['WPVDB', '6073']
         ],
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/unix/webapp/wp_google_document_embedder_exec.rb
+++ b/modules/exploits/unix/webapp/wp_google_document_embedder_exec.rb
@@ -34,6 +34,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['CVE', '2012-4915'],
           ['OSVDB', '88891'],
           ['URL', 'http://secunia.com/advisories/50832'],
+          ['WPVULNDBID', '6073']
         ],
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/unix/webapp/wp_property_upload_exec.rb
+++ b/modules/exploits/unix/webapp/wp_property_upload_exec.rb
@@ -31,7 +31,8 @@ class Metasploit3 < Msf::Exploit::Remote
           ['OSVDB', '82656'],
           ['BID', '53787'],
           ['EDB', '18987'],
-          ['URL', 'http://www.opensyscom.fr/Actualites/wordpress-plugins-wp-property-shell-upload-vulnerability.html']
+          ['URL', 'http://www.opensyscom.fr/Actualites/wordpress-plugins-wp-property-shell-upload-vulnerability.html'],
+          ['WPVULNDBID', '6225']
         ],
       'Platform'       => 'php',
       'Arch'		     => ARCH_PHP,

--- a/modules/exploits/unix/webapp/wp_property_upload_exec.rb
+++ b/modules/exploits/unix/webapp/wp_property_upload_exec.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['BID', '53787'],
           ['EDB', '18987'],
           ['URL', 'http://www.opensyscom.fr/Actualites/wordpress-plugins-wp-property-shell-upload-vulnerability.html'],
-          ['WPVULNDBID', '6225']
+          ['WPVDB', '6225']
         ],
       'Platform'       => 'php',
       'Arch'		     => ARCH_PHP,

--- a/modules/exploits/unix/webapp/wp_wptouch_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wptouch_file_upload.rb
@@ -34,7 +34,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          ['URL', 'http://blog.sucuri.net/2014/07/disclosure-insecure-nonce-generation-in-wptouch.html']
+          ['URL', 'http://blog.sucuri.net/2014/07/disclosure-insecure-nonce-generation-in-wptouch.html'],
+          ['WPVULNDBID', '7118']
         ],
       'Privileged'     => false,
       'Platform'       => ['php'],

--- a/modules/exploits/unix/webapp/wp_wptouch_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wptouch_file_upload.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'References'     =>
         [
           ['URL', 'http://blog.sucuri.net/2014/07/disclosure-insecure-nonce-generation-in-wptouch.html'],
-          ['WPVULNDBID', '7118']
+          ['WPVDB', '7118']
         ],
       'Privileged'     => false,
       'Platform'       => ['php'],

--- a/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
@@ -38,7 +38,8 @@ class Metasploit3 < Msf::Exploit::Remote
         [
           ['URL', 'http://blog.sucuri.net/2014/07/remote-file-upload-vulnerability-on-mailpoet-wysija-newsletters.html'],
           ['URL', 'http://www.mailpoet.com/security-update-part-2/'],
-          ['URL', 'https://plugins.trac.wordpress.org/changeset/943427/wysija-newsletters/trunk/helpers/back.php']
+          ['URL', 'https://plugins.trac.wordpress.org/changeset/943427/wysija-newsletters/trunk/helpers/back.php'],
+          ['WPVULNDBID', '6680']
         ],
       'Privileged'     => false,
       'Platform'       => ['php'],

--- a/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
@@ -39,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
           ['URL', 'http://blog.sucuri.net/2014/07/remote-file-upload-vulnerability-on-mailpoet-wysija-newsletters.html'],
           ['URL', 'http://www.mailpoet.com/security-update-part-2/'],
           ['URL', 'https://plugins.trac.wordpress.org/changeset/943427/wysija-newsletters/trunk/helpers/back.php'],
-          ['WPVULNDBID', '6680']
+          ['WPVDB', '6680']
         ],
       'Privileged'     => false,
       'Platform'       => ['php'],


### PR DESCRIPTION
This PR adds some Links for Wordpress modules to https://wpvulndb.com/

Example output:

```
msf exploit(wp_google_document_embedder_exec) > info

       Name: WordPress Plugin Google Document Embedder Arbitrary File Disclosure
     Module: exploit/unix/webapp/wp_google_document_embedder_exec
   Platform: PHP
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Normal
....................................
References:
  http://cvedetails.com/cve/2012-4915/
  http://www.osvdb.org/88891
  http://secunia.com/advisories/50832
  https://wpvulndb.com/vulnerabilities/6073
```
