### PR TITLE
Update NTP readvar module to detect DRDoS, UDPScanner to be faster

### DIFF
--- a/modules/auxiliary/scanner/ntp/ntp_readvar.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_readvar.rb
@@ -20,7 +20,11 @@ class Metasploit3 < Msf::Auxiliary
         potentially sensitive information, such as the NTP software version, operating
         system version, peers, and more.
       ),
-      'Author'         => [ 'Ewerson Guimaraes(Crash) <crash[at]dclabs.com.br>' ],
+      'Author'         =>
+        [
+          'Ewerson Guimaraes(Crash) <crash[at]dclabs.com.br>', # original Metasploit module
+          'Jon Hart <jon_hart[at]rapid7.com>' # UDPScanner version for faster scans
+        ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [

--- a/modules/auxiliary/scanner/ntp/ntp_readvar.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_readvar.rb
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Auxiliary
         proto: 'udp',
         port: rport,
         name: 'ntp',
-        info: @results[k].map { |r| r.payload }.join.inspect
+        info: @results[k].map { |r| r.payload.slice(0,r.payload_size) }.join.inspect
       )
 
       peer = "#{k}:#{rport}"

--- a/modules/auxiliary/scanner/ntp/ntp_readvar.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_readvar.rb
@@ -6,7 +6,6 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Auxiliary
-
   include Msf::Auxiliary::Report
   include Msf::Exploit::Remote::Udp
   include Msf::Auxiliary::UDPScanner
@@ -16,29 +15,29 @@ class Metasploit3 < Msf::Auxiliary
   def initialize(info = {})
     super(update_info(info,
       'Name'           => 'NTP Clock Variables Disclosure',
-      'Description'    => %q{
-          This module reads the system internal NTP variables. These variables contain
+      'Description'    => %q(
+        This module reads the system internal NTP variables. These variables contain
         potentially sensitive information, such as the NTP software version, operating
         system version, peers, and more.
-      },
+      ),
       'Author'         => [ 'Ewerson Guimaraes(Crash) <crash[at]dclabs.com.br>' ],
       'License'        => MSF_LICENSE,
       'References'     =>
         [
-          [ 'URL','http://www.rapid7.com/vulndb/lookup/ntp-clock-variables-disclosure' ],
+          [ 'URL', 'http://www.rapid7.com/vulndb/lookup/ntp-clock-variables-disclosure' ]
         ]
       )
     )
   end
 
   # Called for each response packet
-  def scanner_process(data, shost, sport)
+  def scanner_process(data, shost, _sport)
     @results[shost] ||= []
     @results[shost] << Rex::Proto::NTP::NTPControl.new(data)
   end
 
   # Called before the scan block
-  def scanner_prescan(batch)
+  def scanner_prescan(_batch)
     @results = {}
     @probe = Rex::Proto::NTP::NTPControl.new
     @probe.version = datastore['VERSION']
@@ -46,15 +45,15 @@ class Metasploit3 < Msf::Auxiliary
   end
 
   # Called after the scan block
-  def scanner_postscan(batch)
+  def scanner_postscan(_batch)
     @results.keys.each do |k|
       # TODO: check to see if any of the responses are actually NTP before reporting
       report_service(
-        :host  => k,
-        :proto => 'udp',
-        :port  => rport,
-        :name  => 'ntp',
-        :info => @results[k].map { |r| r.payload }.join.inspect
+        host: k,
+        proto: 'udp',
+        port: rport,
+        name: 'ntp',
+        info: @results[k].map { |r| r.payload }.join.inspect
       )
 
       peer = "#{k}:#{rport}"
@@ -63,17 +62,16 @@ class Metasploit3 < Msf::Auxiliary
       what = 'NTP Mode 6 READVAR DRDoS'
       if vulnerable
         print_good("#{peer} - Vulnerable to #{what}: #{proof}")
-        report_vuln({
-          :host  => k,
-          :port  => rport,
-          :proto => 'udp',
-          :name  => what,
-          :refs  => self.references
-        })
+        report_vuln(
+          host: k,
+          port: rport,
+          proto: 'udp',
+          name: what,
+          refs: references
+        )
       else
         vprint_status("#{peer} - Not vulnerable to #{what}: #{proof}")
       end
     end
   end
-
 end


### PR DESCRIPTION
NTP readvar came across my radar for a bit today, so I took a quick look at the msf coverage.  It is missing some of the UDP/NTP/etc improvements made elsewhere so I took the time to update it.  It is now faster, reports vulns and cleaner.

Since I basically rewrote the entire thing, should I update the authors?  Or is Authors the original authors only?  

To validate this, scan a host known to respond to readvar requests.  

Before, you'd see that it prints to the console but stores nothing:

```
msf auxiliary(ntp_readvar) > run

[*] Connecting target 10.4.30.25:123...
[*] Sending command
[+] 10.4.30.25:123 - system="cisco"
[+] 10.4.30.25:123 - leap=3
[+] 10.4.30.25:123 - stratum=16
[+] 10.4.30.25:123 - rootdelay=0.00
[+] 10.4.30.25:123 - rootdispersion=0.00
[+] 10.4.30.25:123 - peer=0
[+] 10.4.30.25:123 - refid=0.0.0.0
[+] 10.4.30.25:123 - reftime=0x00000000.00000000
[+] 10.4.30.25:123 - poll=4
[+] 10.4.30.25:123 - clock=0xAF5E1628.4D029033
[+] 10.4.30.25:123 - phase=0.000
[+] 10.4.30.25:123 - freq=0.00
[+] 10.4.30.25:123 - error=0.00
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(ntp_readvar) > services 

Services
========

host  port  proto  name  state  info
----  ----  -----  ----  -----  ----

msf auxiliary(ntp_readvar) > notes
msf auxiliary(ntp_readvar) > vulns 

```

After, you see:

```
msf auxiliary(ntp_readvar) > run

[+] a.b.c.d:123 - Vulnerable to NTP Mode 6 READVAR DRDoS: No packet amplification and a 17x, 200-byte bandwidth amplification
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(ntp_readvar) > services 

Services
========

host        port  proto  name  state  info
----        ----  -----  ----  -----  ----
a.b.c.d  123   udp    ntp   open   "system=\"cisco\", leap=3, stratum=16, rootdelay=0.00, rootdispersion=0.00,\r\npeer=0, refid=0.0.0.0, reftime=0x00000000.00000000, poll=4,\r\nclock=0xAF5E121E.7EE6D2DB, phase=0.000, freq=0.00, error=0.00\r\n"

msf auxiliary(ntp_readvar) > notes 
msf auxiliary(ntp_readvar) > vulns
[*] Time: 2014-10-03 20:16:29 UTC Vuln: host=a.b.c.d name=NTP Mode 6 READVAR DRDoS refs=URL-http://www.rapid7.com/vulndb/lookup/ntp-clock-variables-disclosure 
```
