### PR TITLE
Chain multiple encoders in msfconsole

### DIFF
--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -78,6 +78,8 @@ class EncodedPayload
 
           # Encode the payload with every encoders in the list
           encode()
+          # Encoded payload is now the raw payload to be encoded by the next encoder
+          self.raw = self.encoded
         end
       else
         # No specified encoder, let BadChars or ForceEncode do their job

--- a/lib/msf/core/encoded_payload.rb
+++ b/lib/msf/core/encoded_payload.rb
@@ -65,7 +65,6 @@ class EncodedPayload
       # Generate the raw version of the payload first
       generate_raw() if self.raw.nil?
 
-
       # If encoder is set, it could be an encoders list
       # The form is "<encoder>:<iteration>, <encoder2>:<iteration>"...
       if reqs['Encoder']
@@ -82,6 +81,8 @@ class EncodedPayload
           self.raw = self.encoded
         end
       else
+        self.iterations = reqs['Iterations'].to_i
+        self.iterations = 1 if self.iterations < 1
         # No specified encoder, let BadChars or ForceEncode do their job
         encode()
       end


### PR DESCRIPTION
As discussed https://github.com/rapid7/metasploit-framework/pull/3770#issuecomment-55819559 

Here is a new try to allow multiple encoding.

From msfconsole using set Encoder or set StageEncoder, it is possible to set multiple encoders with this syntax :

```
<encoder>:<iteration>, <encoder2>:<iteration>
```

This should not break compatibility.

Example :

```
msf exploit(psexec) > set Encoder x86/shikata_ga_nai:2, x86/fnstenv_mov, x86/shikata_ga_nai
```

should print in log :

```
[10/06/2014 15:46:03] [i(0)] core: windows/meterpreter/reverse_tcp: iteration 1: Successfully encoded with encoder x86/shikata_ga_nai (size is 320)
[10/06/2014 15:46:03] [i(0)] core: windows/meterpreter/reverse_tcp: iteration 2: Successfully encoded with encoder x86/shikata_ga_nai (size is 347)
[10/06/2014 15:46:03] [i(0)] core: windows/meterpreter/reverse_tcp: iteration 1: Successfully encoded with encoder x86/fnstenv_mov (size is 370)
[10/06/2014 15:46:03] [i(0)] core: windows/meterpreter/reverse_tcp: iteration 1: Successfully encoded with encoder x86/shikata_ga_nai (size is 397)
```
