### PR TITLE
Fix #3822 - Support file:// syntax for check()

### DIFF
--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -125,13 +125,12 @@ module ModuleCommandDispatcher
     defanged?
 
     ip_range_arg = args.shift || mod.datastore['RHOSTS'] || framework.datastore['RHOSTS'] || ''
-    hosts = Rex::Socket::RangeWalker.new(ip_range_arg)
+    opt = Msf::OptAddressRange.new('RHOSTS')
 
     begin
-      if hosts.ranges.blank?
-        # Check a single rhost
-        check_simple
-      else
+      if !ip_range_arg.blank? && opt.valid?(ip_range_arg)
+        hosts = Rex::Socket::RangeWalker.new(opt.normalize(ip_range_arg))
+
         # Check multiple hosts
         last_rhost_opt = mod.rhost
         last_rhosts_opt = mod.datastore['RHOSTS']
@@ -144,7 +143,14 @@ module ModuleCommandDispatcher
           mod.datastore['RHOSTS'] = last_rhosts_opt
           mod.cleanup
         end
+      else
+        # Check a single rhost
+        unless Msf::OptAddress.new('RHOST').valid?(mod.datastore['RHOST'])
+          raise Msf::OptionValidateError.new(['RHOST'])
+        end
+        check_simple
       end
+
     rescue ::Interrupt
       # When the user sends interrupt trying to quit the task, some threads will still be active.
       # This means even though the console tells the user the task has aborted (or at least they


### PR DESCRIPTION
This patch addresses two things:
- It fixes #3822 - Basically supporting the `file://` syntax.
- Input validation for RHOST and RHOSTS
## Requirements for verifying this patch
- [x] A Windows XP SP3 machine without patches.
- [x] Load msfconsole with the patch
- [x] Generate an IP file like the following:

```
echo 192.168.1.79 > /tmp/ip.txt
echo 192.168.1.80 >> /tmp/ip.txt
echo 192.168.1.81 >> /tmp/ip.txt
```

Make sure one of the IPs is the vulnerable machine. In my case, 192.168.1.80 is my vulnerable box. You should change the IPs.
## Verification steps

**Scenario 1: Use an ip list (file)**
- [x] Do `use exploits/windows/smb/ms08_067_netapi`
- [x] Make sure the datastore options RHOST or RHOSTS aren't set. If they're set, you should use the unset command like this: `unset RHOSTS`
- [x] Do `check file://tmp/ip.txt`
- [x] You should see that check is scanning an IP range based on ip.txt

**Scenario 2: Supply a valid IP range as an argument**
- [x] Do `use exploits/windows/smb/ms08_067_netapi`
- [x] Make sure the datastore options RHOST or RHOSTS aren't set. If they're set, you should use the unset command like this: `unset RHOSTS`
- [x] Do `check [IP RANGE]`.
- [x] You should see that check is scanning the above IP range

**Scenario 3: Supply RHOSTS as a datastore option**
- [x] Do `use exploits/windows/smb/ms08_067_netapi`
- [x] Do `set RHOSTS [IP RANGE]`
- [x] Do `check`
- [x] You should see that check is scanning your IP range

**Scenario 4: Try to scan a single host (that's vulnerable) from an argument**
- [x] Do `use exploits/windows/smb/ms08_067_netapi`
- [x] Make sure the datastore options RHOST or RHOSTS aren't set. If they're set, you should use the unset command like this: `unset RHOSTS`
- [x] Do `check [IP]`
- [x] The check should flag your vulnerable host as vulnerable.

**Scenario 5: Try to scan a single host (that's vulnerable) from a datastore option**
- [x] Do `use exploits/windows/smb/ms08_067_netapi`
- [x] Do `set RHOST [IP]`
- [x] Do `check`
- [x] You should see that check is scanning your IP

**Scenario 6: Supply a bad IP as an argument**
- [x] Do `use exploits/windows/smb/ms08_067_netapi`
- [x] Do `set RHOST BADIP`
- [x] Do `check`
- [x] You should see an error: "Check failed: The following options failed to validate: RHOST."
