### PR TITLE
Fix #3808 - NoMethodError undefined method `map' for wordpress_login_enum

### DIFF
--- a/modules/auxiliary/scanner/http/wordpress_login_enum.rb
+++ b/modules/auxiliary/scanner/http/wordpress_login_enum.rb
@@ -90,7 +90,7 @@ class Metasploit3 < Msf::Auxiliary
       # Brute force previously found users
       if not usernames.empty?
         print_status("#{target_uri} - Brute-forcing previously found accounts...")
-        passwords = load_password_vars(datastore['PASS_FILE'])
+        passwords = load_password_vars
         usernames.each do |user|
           passwords.each do |pass|
             do_login(user, pass)


### PR DESCRIPTION
This fixes #3808.
## Root Cause

The problem is due to `load_password_vars` not being used correctly by wordpress_login_enum. The module tries to make sure the PASS_FILE datastore option is loaded, so it does this:

```
load_password_vars(datastore['PASS_FILE'])
```

But PASS_FILE is a string, and that's supposed to be an array, which is the reason why it's causing the backtrace. However, it doesn't really need to pass PASS_FILE like that. Because when you call `load_password_vars`, the method already does it for you (in auth_brute):

``` ruby
  def load_password_vars(credentials = nil)
    passwords = extract_words(datastore['PASS_FILE'])
...
```
### Verification Steps
- [x] Download Wordpress: https://wordpress.org/download/
- [x] Install Wordpress, and make sure you can login.
- [x] Open up a terminal, create a PASS_FILE like the following:

```
echo pass1 > /tmp/pass.txt
echo pass2 >> /tmp/pass.txt
echo pass3 >> /tmp/pass.txt
```
- [x] Load msfconsole
- [x] Set RHOSTS to your Wordpress box
- [x] Set PASS_FILE to /tmp/pass.txt
- [x] Run
- [x] You should not see the `NoMethodError undefined method `map'` error again.

An example of the output you should see should look like this:

```
msf auxiliary(wordpress_login_enum) > run

[*] /wordpress/ - WordPress Version 3.5 detected
[*] /wordpress/ - WordPress User-Enumeration - Running User Enumeration
[+] /wordpress/ - Found user 'admin' with id 1
[*] /wordpress/ - Usernames stored in: /Users/wchen/.msf4/loot/20141006155424_default_192.168.1.102_wordpress.users_776483.txt
[*] /wordpress/ - WordPress User-Validation - Running User Validation
[*] /wordpress/ - WordPress User-Validation - Checking Username:''
[-] /wordpress/ - WordPress User-Validation - Invalid Username: ''
[*] /wordpress/ - WordPress Brute Force - Running Bruteforce
[*] /wordpress/ - Brute-forcing previously found accounts...
[*] /wordpress/ - WordPress Brute Force - Trying username:'admin' with password:''
[-] /wordpress/ - WordPress Brute Force - Failed to login as 'admin'
[*] /wordpress/ - WordPress Brute Force - Trying username:'admin' with password:'pass1'
[-] /wordpress/ - WordPress Brute Force - Failed to login as 'admin'
[*] /wordpress/ - WordPress Brute Force - Trying username:'admin' with password:'pass2'
[-] /wordpress/ - WordPress Brute Force - Failed to login as 'admin'
[*] /wordpress/ - WordPress Brute Force - Trying username:'admin' with password:'pass3'
[-] /wordpress/ - WordPress Brute Force - Failed to login as 'admin'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```
