### PR TITLE
Show selected module action

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -108,6 +108,28 @@ class ReadableText
     tbl.to_s + "\n"
   end
 
+  # Dumps the auxiliary's selected action
+  #
+  # @param mod [Msf::Auxiliary] the auxiliary module.
+  # @param indent [String] the indentation to use (only the length
+  #   matters)
+  # @param h [String] the string to display as the table heading.
+  # @return [String] the string form of the table.
+  def self.dump_auxiliary_action(mod, indent = '', h = nil)
+    tbl = Rex::Ui::Text::Table.new(
+      'Indent'  => indent.length,
+      'Header'  => h,
+      'Columns' =>
+        [
+          'Name',
+          'Description',
+        ])
+
+    tbl << [ mod.action.name || 'All', mod.action.description || '' ]
+
+    tbl.to_s + "\n"
+  end
+
   # Dumps the table of payloads that are compatible with the supplied
   # exploit.
   #

--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -84,14 +84,14 @@ class ReadableText
     tbl.to_s + "\n"
   end
 
-  # Dumps an auxiliary's actions
+  # Dumps a module's actions
   #
-  # @param mod [Msf::Auxiliary] the auxiliary module.
+  # @param mod [Msf::Module] the module.
   # @param indent [String] the indentation to use (only the length
   #   matters)
   # @param h [String] the string to display as the table heading.
   # @return [String] the string form of the table.
-  def self.dump_auxiliary_actions(mod, indent = '', h = nil)
+  def self.dump_module_actions(mod, indent = '', h = nil)
     tbl = Rex::Ui::Text::Table.new(
       'Indent'  => indent.length,
       'Header'  => h,
@@ -108,14 +108,14 @@ class ReadableText
     tbl.to_s + "\n"
   end
 
-  # Dumps the auxiliary's selected action
+  # Dumps the module's selected action
   #
-  # @param mod [Msf::Auxiliary] the auxiliary module.
+  # @param mod [Msf::Module] the module.
   # @param indent [String] the indentation to use (only the length
   #   matters)
   # @param h [String] the string to display as the table heading.
   # @return [String] the string form of the table.
-  def self.dump_auxiliary_action(mod, indent = '', h = nil)
+  def self.dump_module_action(mod, indent = '', h = nil)
     tbl = Rex::Ui::Text::Table.new(
       'Indent'  => indent.length,
       'Header'  => h,

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2152,7 +2152,7 @@ class Core
           if (mod and (mod.auxiliary? or mod.post?))
             show_actions(mod)
           else
-            print_error("No auxiliary module selected.")
+            print_error("No auxiliary or post module selected.")
           end
 
         else

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -3140,11 +3140,14 @@ class Core
       end
     end
 
-    # Print the selected target or action
+    # Print the selected target
     if (mod.exploit? and mod.target)
       mod_targ = Serializer::ReadableText.dump_exploit_target(mod, '   ')
       print("\nExploit target:\n\n#{mod_targ}\n") if (mod_targ and mod_targ.length > 0)
-    elsif mod.kind_of?(Msf::Module::HasActions)
+    end
+
+    # Print the selected action
+    if mod.kind_of?(Msf::Module::HasActions)
       mod_action = Serializer::ReadableText.dump_auxiliary_action(mod, '   ')
       print("\n#{mod.type.capitalize} action:\n\n#{mod_action}\n") if (mod_action and mod_action.length > 0)
     end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -3144,9 +3144,9 @@ class Core
     if (mod.exploit? and mod.target)
       mod_targ = Serializer::ReadableText.dump_exploit_target(mod, '   ')
       print("\nExploit target:\n\n#{mod_targ}\n") if (mod_targ and mod_targ.length > 0)
-    elsif ((mod.auxiliary? or mod.post?) and mod.action)
+    elsif mod.kind_of?(Msf::Module::HasActions)
       mod_action = Serializer::ReadableText.dump_auxiliary_action(mod, '   ')
-      print("\n#{mod.auxiliary? ? 'Auxiliary' : 'Post'} action:\n\n#{mod_action}\n") if (mod_action and mod_action.length > 0)
+      print("\n#{mod.type.capitalize} action:\n\n#{mod_action}\n") if (mod_action and mod_action.length > 0)
     end
 
     # Uncomment this line if u want target like msf2 format

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2009,7 +2009,7 @@ class Core
       res << 'ENCODER'
     end
 
-    if (mod.auxiliary?)
+    if (mod.auxiliary? or mod.post?)
       res << "ACTION"
     end
 
@@ -2721,8 +2721,8 @@ class Core
       return option_values_encoders() if opt.upcase == 'StageEncoder'
     end
 
-    # Well-known option names specific to auxiliaries
-    if (mod.auxiliary?)
+    # Well-known option names specific to auxiliaries and posts
+    if (mod.auxiliary? or mod.post?)
       return option_values_actions() if opt.upcase == 'ACTION'
     end
 
@@ -2869,7 +2869,7 @@ class Core
 
 
   #
-  # Provide valid action options for the current auxiliary module
+  # Provide valid action options for the current module
   #
   def option_values_actions
     res = []

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -3140,10 +3140,13 @@ class Core
       end
     end
 
-    # Print the selected target
+    # Print the selected target or action
     if (mod.exploit? and mod.target)
       mod_targ = Serializer::ReadableText.dump_exploit_target(mod, '   ')
       print("\nExploit target:\n\n#{mod_targ}\n") if (mod_targ and mod_targ.length > 0)
+    elsif (mod.auxiliary? and mod.action)
+      mod_action = Serializer::ReadableText.dump_auxiliary_action(mod, '   ')
+      print("\nAuxiliary action:\n\n#{mod_action}\n") if (mod_action and mod_action.length > 0)
     end
 
     # Uncomment this line if u want target like msf2 format

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2152,7 +2152,7 @@ class Core
           if mod && mod.kind_of?(Msf::Module::HasActions)
             show_actions(mod)
           else
-            print_error("No auxiliary or post module selected.")
+            print_error("No module with actions selected.")
           end
 
         else

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -2009,7 +2009,7 @@ class Core
       res << 'ENCODER'
     end
 
-    if (mod.auxiliary? or mod.post?)
+    if mod.kind_of?(Msf::Module::HasActions)
       res << "ACTION"
     end
 
@@ -2149,7 +2149,7 @@ class Core
             print_error("No exploit module selected.")
           end
         when "actions"
-          if (mod and (mod.auxiliary? or mod.post?))
+          if mod && mod.kind_of?(Msf::Module::HasActions)
             show_actions(mod)
           else
             print_error("No auxiliary or post module selected.")
@@ -2721,8 +2721,8 @@ class Core
       return option_values_encoders() if opt.upcase == 'StageEncoder'
     end
 
-    # Well-known option names specific to auxiliaries and posts
-    if (mod.auxiliary? or mod.post?)
+    # Well-known option names specific to modules with actions
+    if mod.kind_of?(Msf::Module::HasActions)
       return option_values_actions() if opt.upcase == 'ACTION'
     end
 
@@ -3147,7 +3147,7 @@ class Core
     end
 
     # Print the selected action
-    if mod.kind_of?(Msf::Module::HasActions)
+    if mod.kind_of?(Msf::Module::HasActions) && mod.action
       mod_action = Serializer::ReadableText.dump_module_action(mod, '   ')
       print("\n#{mod.type.capitalize} action:\n\n#{mod_action}\n") if (mod_action and mod_action.length > 0)
     end

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -3148,7 +3148,7 @@ class Core
 
     # Print the selected action
     if mod.kind_of?(Msf::Module::HasActions)
-      mod_action = Serializer::ReadableText.dump_auxiliary_action(mod, '   ')
+      mod_action = Serializer::ReadableText.dump_module_action(mod, '   ')
       print("\n#{mod.type.capitalize} action:\n\n#{mod_action}\n") if (mod_action and mod_action.length > 0)
     end
 
@@ -3208,8 +3208,8 @@ class Core
   end
 
   def show_actions(mod) # :nodoc:
-    mod_actions = Serializer::ReadableText.dump_auxiliary_actions(mod, '   ')
-    print("\nAuxiliary actions:\n\n#{mod_actions}\n") if (mod_actions and mod_actions.length > 0)
+    mod_actions = Serializer::ReadableText.dump_module_actions(mod, '   ')
+    print("\n#{mod.type.capitalize} actions:\n\n#{mod_actions}\n") if (mod_actions and mod_actions.length > 0)
   end
 
   def show_advanced_options(mod) # :nodoc:

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -3144,9 +3144,9 @@ class Core
     if (mod.exploit? and mod.target)
       mod_targ = Serializer::ReadableText.dump_exploit_target(mod, '   ')
       print("\nExploit target:\n\n#{mod_targ}\n") if (mod_targ and mod_targ.length > 0)
-    elsif (mod.auxiliary? and mod.action)
+    elsif ((mod.auxiliary? or mod.post?) and mod.action)
       mod_action = Serializer::ReadableText.dump_auxiliary_action(mod, '   ')
-      print("\nAuxiliary action:\n\n#{mod_action}\n") if (mod_action and mod_action.length > 0)
+      print("\n#{mod.auxiliary? ? 'Auxiliary' : 'Post'} action:\n\n#{mod_action}\n") if (mod_action and mod_action.length > 0)
     end
 
     # Uncomment this line if u want target like msf2 format

--- a/msfcli
+++ b/msfcli
@@ -428,7 +428,7 @@ class Msfcli
 
   def show_actions(m)
     readable = Msf::Serializer::ReadableText
-    $stdout.puts("\n" + readable.dump_auxiliary_actions(m[:module], @indent))
+    $stdout.puts("\n" + readable.dump_module_actions(m[:module], @indent))
   end
 
 


### PR DESCRIPTION
**Feature description:**

`show options` now displays the selected action when an auxiliary or post module is being used. Previously, it would show only the selected target if an exploit module was being used.

This PR also fixes tab completion for post module actions.

**Verification steps:**
- [x] `use` an auxiliary module with actions
- [x] `show options` and see that the selected action is displayed
- [x] `use` an auxiliary module without actions
- [x] `show options` and see that no selected action is displayed
- [x] `use` a post module with actions
- [x] `set` an action using tab completion and see that it now completes
- [x] `show options` and see that the selected action is displayed
- [x] `use` a post module without actions
- [x] `show options` and see that no selected action is displayed
- [x] `use` an exploit module
- [x] `show options` and see that the selected target is still displayed

**Sample run:**

```
msf > use auxiliary/admin/chromecast/chromecast_youtube
msf auxiliary(chromecast_youtube) > show options

Module options (auxiliary/admin/chromecast/chromecast_youtube):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        Use a proxy chain
   RHOST                     yes       The target address
   RPORT    8008             yes       The target port
   VHOST                     no        HTTP server virtual host
   VID      kxopViU98Xo      yes       Video ID


Auxiliary action:

   Name  Description
   ----  -----------
   Play  Play video


msf auxiliary(chromecast_youtube) > use post/linux/gather/enum_xchat 
msf post(enum_xchat) > show options 

Module options (post/linux/gather/enum_xchat):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   SESSION                   yes       The session to run this module on.


Post action:

   Name  Description
   ----  -----------
   ALL   Collect both the plists and chat logs


msf post(enum_xchat) >
```
