### PR TITLE
Remove hash rocket from refs

### DIFF
--- a/modules/auxiliary/gather/doliwamp_traversal_creds.rb
+++ b/modules/auxiliary/gather/doliwamp_traversal_creds.rb
@@ -26,8 +26,8 @@ class Metasploit3 < Msf::Auxiliary
       'Author'         => 'Brendan Coles <bcoles[at]gmail.com>',
       'References'     =>
         [
-          ['URL'       => 'https://doliforge.org/tracker/?func=detail&aid=1212&group_id=144'],
-          ['URL'       => 'https://github.com/Dolibarr/dolibarr/commit/8642e2027c840752c4357c4676af32fe342dc0cb']
+          ['URL', 'https://doliforge.org/tracker/?func=detail&aid=1212&group_id=144'],
+          ['URL', 'https://github.com/Dolibarr/dolibarr/commit/8642e2027c840752c4357c4676af32fe342dc0cb']
         ],
       'DisclosureDate' => 'Jan 12 2014'))
     register_options(

--- a/modules/payloads/singles/cmd/windows/reverse_powershell.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_powershell.rb
@@ -25,7 +25,7 @@ module Metasploit3
         ],
       'References'    =>
         [
-          'URL' => 'https://github.com/trustedsec/social-engineer-toolkit/blob/master/src/powershell/reverse.powershell',
+          ['URL', 'https://github.com/trustedsec/social-engineer-toolkit/blob/master/src/powershell/reverse.powershell']
         ],
       # The powershell code is from SET, copyrighted by TrustedSEC, LLC and BSD licensed -- see https://github.com/trustedsec/social-engineer-toolkit/blob/master/readme/LICENSE
       'License'       => MSF_LICENSE,

--- a/modules/payloads/singles/linux/mipsbe/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/shell_reverse_tcp.rb
@@ -25,7 +25,7 @@ module Metasploit3
         ],
       'References'    =>
         [
-          'EDB' => '18226',
+          ['EDB', '18226']
         ],
       'License'       => MSF_LICENSE,
       'Platform'      => 'linux',


### PR DESCRIPTION
This PR cleans up a few more instances of rogue hash rockets in references arrays.
- Part of issue #3766
- See [RM #8776](https://dev.metasploit.com/redmine/issues/8776)

```
$ egrep -rn "'(URL|EDB|OSVDB|BID|ZDI|CVE|MSB|WPVDB)'\s*=>" modules/*
modules/auxiliary/gather/doliwamp_traversal_creds.rb:29:          ['URL'       => 'https://doliforge.org/tracker/?func=detail&aid=1212&group_id=144'],
modules/auxiliary/gather/doliwamp_traversal_creds.rb:30:          ['URL'       => 'https://github.com/Dolibarr/dolibarr/commit/8642e2027c840752c4357c4676af32fe342dc0cb']
modules/payloads/singles/linux/mipsbe/shell_reverse_tcp.rb:28:          'EDB' => '18226',
modules/payloads/singles/cmd/windows/reverse_powershell.rb:28:          'URL' => 'https://github.com/trustedsec/social-engineer-toolkit/blob/master/src/powershell/reverse.powershell',
```
