### PR TITLE
Fix #3973 - Unneeded datastore option URI

### DIFF
--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -39,8 +39,8 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options(
       [
+        # There is no TARGETURI because when Glassfish is installed, the path is /
         Opt::RPORT(4848),
-        OptString.new('TARGETURI', [true, 'The URI path of the GlassFish Server', '/']),
         OptString.new('USERNAME',[true, 'A specific username to authenticate as','admin']),
         OptBool.new('SSL', [false, 'Negotiate SSL for outgoing connections', false]),
         OptEnum.new('SSLVersion', [false, 'Specify the version of SSL that should be used', 'TLS1', ['SSL2', 'SSL3', 'TLS1']])
@@ -97,7 +97,6 @@ class Metasploit3 < Msf::Auxiliary
     @scanner = Metasploit::Framework::LoginScanner::Glassfish.new(
       host:               ip,
       port:               rport,
-      uri:                datastore['URI'],
       proxies:            datastore["PROXIES"],
       cred_details:       @cred_collection,
       stop_on_success:    datastore['STOP_ON_SUCCESS'],


### PR DESCRIPTION
This fixes #3973.

When Glassfish is installed, the web root is always /, so there is no point to make this arbitrary.
## To set up Glassfish:
- [ ] Windows is the easiest to set up, so get a Windows VM up and ready. Windows 2003 SP2 or Win 7 should be fine.
- [ ] Download and install JDK8: http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
- [ ] Download Glassfish 4: http://download.java.net/glassfish/4.0/release/glassfish-4.0.zip
- [ ] Extract glassfish-4.0.zip
- [ ] In command prompt, go to directory glassfish4\bin\
- [ ] Run `asadmin`, which is the admin console.
- [ ] Enter `start-domain domain1`
- [ ] Open a browser, and then go to: http://localhost:4848
- [ ] Look at the menu on the left, there should be an item that says "Domain". Click on that.
- [ ] On the right, there should be an "Administrator Password" tab. Click on that, and go change your admin password. You need to do this for Secure Administration.
- [ ] Again, look at the menu on the left, click on "server(Admin Server)"
- [ ] You should see a button that says "Enable Secure Admin", click on that.
- [ ] After you enable Secure Admin, Glassfish will have to restart. Wait for a few seconds, and then go to command prompt, make sure port 4848 is up again. You can also try to login remotely to double check if you want.
## To test the module
- [ ] Start `msfconsole`
- [ ] `use auxiliary/scanner/http/glassfish_login`
- [ ] `set password [PASSWORD]`
- [ ] `set rhosts [IP]`
- [ ] `run`
- [ ] Make sure the module can login

An example for the above test should look like this:

```
msf auxiliary(glassfish_login) > run

[*] 192.168.1.106:4848 GLASSFISH - Checking if Glassfish requires a password...
[*] 192.168.1.106:4848 GLASSFISH - Glassfish is protected with a password
[+] 192.168.1.106:4848 GLASSFISH - Success: 'admin:asdf'
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
msf auxiliary(glassfish_login) >
```
