### PR TITLE
Fix #3976 - validate and normalize user-supplied URI for http_login.rb

### DIFF
--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -54,8 +54,17 @@ class Metasploit3 < Msf::Auxiliary
     register_autofilter_ports([ 80, 443, 8080, 8081, 8000, 8008, 8443, 8444, 8880, 8888 ])
   end
 
-  def find_auth_uri
+  def to_uri(uri)
+    begin
+      # In case TARGETURI is empty, at least we default to '/'
+      uri = "/" if uri.blank?
+      URI(uri)
+    rescue ::URI::InvalidURIError
+      raise RuntimeError, "Invalid URI: #{uri}"
+    end
+  end
 
+  def find_auth_uri
     if datastore['AUTH_URI'].present?
       paths = [datastore['AUTH_URI']]
     else
@@ -69,8 +78,20 @@ class Metasploit3 < Msf::Auxiliary
     end
 
     paths.each do |path|
+      uri = ''
+
+      begin
+        uri = to_uri(path)
+      rescue RuntimeError => e
+        # Bad URI so we will not try to request it
+        print_error(e.message)
+        next
+      end
+
+      uri = normalize_uri(uri.path)
+
       res = send_request_cgi({
-        'uri'     => path,
+        'uri'     => uri,
         'method'  => datastore['REQUESTTYPE'],
         'username' => '',
         'password' => ''


### PR DESCRIPTION
This fixes https://github.com/rapid7/metasploit-framework/issues/3976

URI should be validated and normalized before being used in an HTTP request.
## Recommended verification steps
- [x] Set up an HTTP server with basic authentication. I can't be very specific here on how you can set it up, but basically you can pick your favorite server, google for instructions.
- [x] Make sure your auth path is one of these: /, /admin/, /manager/, /Management.asp
- [x] Start `msfconsole`
- [x] `set username [valid username]`
- [x] `set password [valid password]`
- [x] `set rhosts [IP]`
- [x] `set stop_on_success true`, but you don't have to if you don't mind the noises.
- [x] Make sure you DO NOT set the AUTH_URI option, because when it's not set it will try its own default paths.
- [x] Do `run`, you should be able to a successful login
- [x] Now, `set AUTH_URI %`
- [x] `run` again. This time, it should say "[-] Invalid URI: %", and then no login attempts
- [x] Finally, `set AUTH_URI [valid auth path]`
- [x] It should tell you the login is successful again
