### PR TITLE
Fix #3975 - Register TARGETURI, not URI

### DIFF
--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -58,7 +58,7 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         Opt::RPORT(8080),
-        OptString.new('URI', [true, "URI for Manager login. Default is /manager/html", "/manager/html"]),
+        OptString.new('TARGETURI', [true, "URI for Manager login. Default is /manager/html", "/manager/html"]),
         OptPath.new('USERPASS_FILE',  [ false, "File containing users and passwords separated by space, one pair per line",
           File.join(Msf::Config.data_directory, "wordlists", "tomcat_mgr_default_userpass.txt") ]),
         OptPath.new('USER_FILE',  [ false, "File containing users, one per line",
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def run_host(ip)
     begin
-      uri = normalize_uri(datastore['URI'])
+      uri = normalize_uri(target_uri.path)
       res = send_request_cgi({
         'uri'     => uri,
         'method'  => 'GET',


### PR DESCRIPTION
This fixes https://github.com/rapid7/metasploit-framework/issues/3975

The module should register TARGETURI and call #target_uri for URI validation. It is based on this:
https://github.com/rapid7/metasploit-framework/wiki/How-to-Send-an-HTTP-Request-Using-HTTPClient#uri-parsing
## Verification steps:
- [x] Download tomcat: http://tomcat.apache.org/
- [x] Install tomcat: http://tomcat.apache.org/tomcat-7.0-doc/appdev/installation.html
- [x] Make sure the login path is: /manager/html
- [x] Start `msfconsole`
- [x] `set rhosts [ip]`
- [x] `set username [valid user]`
- [x] `set password [valid pass]`
- [x] `set STOP_ON_SUCCESS true`, but you don't have to if you don't want to.
- [x] Do `run`. You should see a successful login, the successful login also indicates the URI was parsed correctly.
