### PR TITLE
Fix #3974 - Validate and normalize URI for axis_login

### DIFF
--- a/modules/auxiliary/scanner/http/axis_login.rb
+++ b/modules/auxiliary/scanner/http/axis_login.rb
@@ -40,21 +40,23 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options( [
       Opt::RPORT(8080),
-      OptString.new('URI', [false, 'Path to the Apache Axis Administration page', '/axis2/axis2-admin/login']),
+      OptString.new('TARGETURI', [false, 'Path to the Apache Axis Administration page', '/axis2/axis2-admin/login']),
     ], self.class)
   end
 
+  # For print_* methods
   def target_url
     "http://#{vhost}:#{rport}#{datastore['URI']}"
   end
 
   def run_host(ip)
+    uri = normalize_uri(target_uri.path)
 
     print_status("Verifying login exists at #{target_url}")
     begin
       send_request_cgi({
         'method'  => 'GET',
-        'uri'     => datastore['URI']
+        'uri'     => uri
       }, 20)
     rescue
       print_error("The Axis2 login page does not exist at #{target_url}")
@@ -78,7 +80,7 @@ class Metasploit3 < Msf::Auxiliary
     scanner = Metasploit::Framework::LoginScanner::Axis2.new(
       host: ip,
       port: rport,
-      uri: datastore['URI'],
+      uri: uri,
       proxies: datastore["PROXIES"],
       cred_details: cred_collection,
       stop_on_success: datastore['STOP_ON_SUCCESS'],


### PR DESCRIPTION
This fixes https://github.com/rapid7/metasploit-framework/issues/3974

It will validate and normalize the URI before using it in a request, based on the following wiki:
https://github.com/rapid7/metasploit-framework/wiki/How-to-Send-an-HTTP-Request-Using-HTTPClient#uri-parsing
## Verification:
- [x] Download Axis2: http://axis.apache.org/axis2/java/core/download.cgi
- [x] Install it: http://axis.apache.org/axis2/java/core/docs/installationguide.html#standalone1
- [x] Make sure the login part is working properly: /axis2/axis2-admin/login
- [x] Start `msfconsole`
- [x] `use auxiliary/scanner/http/axis_login`
- [x] `set rhosts [IP]`
- [x] `set username [valid user]`
- [x] `set password [valid pass]`
- [x] `set stop_on_success true`, but you don't have to if you don't want to.
- [x] `run`.
- [x] You should not see a "The Axis2 login page does not exist at xxx" error.
