### PR TITLE
Fix #3982 - Get rid of URI in hp_sys_mgmt_login because it's not used at all

### DIFF
--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -78,7 +78,6 @@ class Metasploit3 < Msf::Auxiliary
     @scanner = Metasploit::Framework::LoginScanner::Smh.new(
       host:               ip,
       port:               rport,
-      uri:                datastore['URI'],
       proxies:            datastore["PROXIES"],
       cred_details:       @cred_collection,
       stop_on_success:    datastore['STOP_ON_SUCCESS'],


### PR DESCRIPTION
The hp_sys_mgmt_login module will pass datastore['URI'] to Metasploit::Framework::LoginScanner::Smh, but Metasploit::Framework::LoginScanner::Smh does not care because this is what it does:

``` ruby
          req_opts = {
            'method' => 'POST',
            'uri'    => '/proxy/ssllogin',
            'vars_post' => {
              'redirecturl'         => '',
              'redirectquerystring' => '',
              'user'                => credential.public,
              'password'            => credential.private
            }
          }
```

See: https://github.com/rapid7/metasploit-framework/blob/master/lib/metasploit/framework/login_scanner/smh.rb

I don't think it's necessary to provide verification steps at all, because this is really easy.
