### PR TITLE
Fix #3985 - check command should elog

### DIFF
--- a/lib/msf/ui/console/module_command_dispatcher.rb
+++ b/lib/msf/ui/console/module_command_dispatcher.rb
@@ -188,16 +188,22 @@ module ModuleCommandDispatcher
           print_status("#{peer} - #{code[1]}")
         end
       else
-        print_error("#{peer} - Check failed: The state could not be determined.")
+        msg = "#{peer} - Check failed: The state could not be determined."
+        print_error(msg)
+        elog("#{msg}\n#{caller.join("\n")}")
       end
-    rescue ::Rex::ConnectionError, ::Rex::ConnectionProxyError, ::Errno::ECONNRESET, ::Errno::EINTR, ::Rex::TimeoutError, ::Timeout::Error
+    rescue ::Rex::ConnectionError, ::Rex::ConnectionProxyError, ::Errno::ECONNRESET, ::Errno::EINTR, ::Rex::TimeoutError, ::Timeout::Error => e
       # Connection issues while running check should be handled by the module
-    rescue ::RuntimeError
+      elog("#{e.message}\n#{e.backtrace.join("\n")}")
+    rescue ::RuntimeError => e
       # Some modules raise RuntimeError but we don't necessarily care about those when we run check()
+      elog("#{e.message}\n#{e.backtrace.join("\n")}")
     rescue Msf::OptionValidateError => e
       print_error("Check failed: #{e.message}")
+      elog("#{e.message}\n#{e.backtrace.join("\n")}")
     rescue ::Exception => e
       print_error("#{peer} - Check failed: #{e.class} #{e}")
+      elog("#{e.message}\n#{e.backtrace.join("\n")}")
     end
   end
 


### PR DESCRIPTION
This fixes https://github.com/rapid7/metasploit-framework/issues/3985
## To verify:

You will be testing the buggy version of durpal_views_user_enum. A fix for the drupal module is here: #3990
- [x] Set up a fake server: `ruby -run -e httpd . -p 8181` in a new terminal
- [x] Do `tail -f ~/.msf4/logs/framework.log` in a new terminal
- [x] Start msfconsole in a new terminal
- [x] `use auxiliary/scanner/http/drupal_views_user_enum`
- [x] `set rhosts [ip]`
- [x] `set rport 8181`
- [x] `check`
- [x] In your framework.log, you should see "error wrong number of arguments" with a backtrace for the drupal module
