### PR TITLE
Added support for comments with # (start of line only)

### DIFF
--- a/lib/rex/ui/text/dispatcher_shell.rb
+++ b/lib/rex/ui/text/dispatcher_shell.rb
@@ -408,7 +408,7 @@ module DispatcherShell
       }
 
       if (found == false and error == false)
-        unknown_command(method, line)
+        unknown_command(method, line) unless method == "#"
       end
     end
 


### PR DESCRIPTION
This is a simple change, but it allows users to add a comment in the console by starting a line with "#". This can be nice when providing screenshots of how to do certain things from within the console. While a more robust commenting system would be nice, there very well may be legitimate reasons to include '#' elsewhere in other commands. This at least provides the ability to use basic comments.

![20141010-selection-03](https://cloud.githubusercontent.com/assets/2043879/4598375/20d7b1ee-50b8-11e4-8cea-1a502cf9f429.png)

Note to reviewer: It may make more sense to add a simple return statement near line 376. E.g:

``` ruby
return false if method == "#"
```

It seemed safer to add the check at the end (in case anyone wanted to do something weird with the dispatcher). If you disagree, just let me know, and I will make the change.
