### PR TITLE
Improve user experience on error message for ReverseAllowProxy

### DIFF
--- a/lib/msf/core/handler/reverse_tcp.rb
+++ b/lib/msf/core/handler/reverse_tcp.rb
@@ -70,7 +70,7 @@ module ReverseTcp
   #
   def setup_handler
     if datastore['Proxies'] and not datastore['ReverseAllowProxy']
-      raise RuntimeError, 'TCP connect-back payloads cannot be used with Proxies. Can be overriden by setting ReverseAllowProxy to true'
+      raise RuntimeError, "TCP connect-back payloads cannot be used with Proxies. Use 'set ReverseAllowProxy true' to override this behaviour."
     end
 
     ex = false


### PR DESCRIPTION
As I am using a exploit that does a check on the Server HTTP headers to identify the target I saw an error message that reads like this:

> The target server fingerprint "" does not match "(?-mix:(Jetty|JBoss))", use 'set FingerprintCheck false' to disable this check.

Then, while using a HTTP proxy to analyse the requests I am presented with an error that tells me to set another internal option to override a default behaviour. Although it should be pretty clear to everyone using the metasploit framework, I think it is more convenient if all error messages have the same format/way to present suggestions, in this case, presenting the full command the user needs to introduce in order to carry on with the execution of the exploit.
