### PR TITLE
Show available actions for info

### DIFF
--- a/lib/msf/base/serializer/readable_text.rb
+++ b/lib/msf/base/serializer/readable_text.rb
@@ -31,7 +31,7 @@ class ReadableText
       when MODULE_AUX
         return dump_auxiliary_module(mod, indent)
       when MODULE_POST
-        return dump_basic_module(mod, indent)
+        return dump_post_module(mod, indent)
       else
         return dump_generic_module(mod, indent)
     end
@@ -231,6 +231,57 @@ class ReadableText
       output << indent + author.to_s + "\n"
     }
     output << "\n"
+
+    # Actions
+    if mod.action
+      output << "Available actions:\n"
+      output << dump_module_actions(mod, indent)
+    end
+
+    # Options
+    if (mod.options.has_options?)
+      output << "Basic options:\n"
+      output << dump_options(mod, indent)
+      output << "\n"
+    end
+
+    # Description
+    output << "Description:\n"
+    output << word_wrap(Rex::Text.compress(mod.description))
+    output << "\n"
+
+    # References
+    output << dump_references(mod, indent)
+
+    return output
+  end
+
+  # Dumps information about a post module.
+  #
+  # @param mod [Msf::Post] the post module.
+  # @param indent [String] the indentation to use.
+  # @return [String] the string form of the information.
+  def self.dump_post_module(mod, indent = '')
+    output  = "\n"
+    output << "       Name: #{mod.name}\n"
+    output << "     Module: #{mod.fullname}\n"
+    output << "   Platform: #{mod.platform_to_s}\n"
+    output << "       Arch: #{mod.arch_to_s}\n"
+    output << "       Rank: #{mod.rank_to_s.capitalize}\n"
+    output << "\n"
+
+    # Authors
+    output << "Provided by:\n"
+    mod.each_author { |author|
+      output << indent + author.to_s + "\n"
+    }
+    output << "\n"
+
+    # Actions
+    if mod.action
+      output << "Available actions:\n"
+      output << dump_module_actions(mod, indent)
+    end
 
     # Options
     if (mod.options.has_options?)


### PR DESCRIPTION
**Feature description:**

`info` now displays available actions (and options) when an auxiliary or post module is being used. Previously, it would show only the available targets if an exploit module was being used.

This is related to #3962.

**Verification steps:**
- [x] `use` an auxiliary module with actions
- [x] `info` and see that available actions are displayed
- [x] `use` an auxiliary module without actions
- [x] `info` and see that no available actions are displayed
- [x] `use` a post module with actions
- [x] `info` and see that available actions are displayed
- [x] `use` a post module without actions
- [x] `info` and see that no available actions are displayed
- [x] `use` an exploit module
- [x] `info` and see that available targets are still displayed

**Sample run:**

```
msf auxiliary(chromecast_youtube) > info

       Name: Chromecast YouTube Remote Control
     Module: auxiliary/admin/chromecast/chromecast_youtube
    License: Metasploit Framework License (BSD)
       Rank: Normal

Provided by:
  wvu <wvu@metasploit.com>

Available actions:
  Name  Description
  ----  -----------
  Play  Play video
  Stop  Stop video

Basic options:
  Name     Current Setting  Required  Description
  ----     ---------------  --------  -----------
  Proxies                   no        Use a proxy chain
  RHOST                     yes       The target address
  RPORT    8008             yes       The target port
  VHOST                     no        HTTP server virtual host
  VID      kxopViU98Xo      yes       Video ID

Description:
  This module acts as a simple remote control for Chromecast YouTube.

References:
  http://www.google.com/intl/en/chrome/devices/chromecast/index.html

msf auxiliary(chromecast_youtube) > 
```
