### PR TITLE
A couple OSVDB updates for recent modules

### DIFF
--- a/modules/auxiliary/scanner/snmp/sbg6580_enum.rb
+++ b/modules/auxiliary/scanner/snmp/sbg6580_enum.rb
@@ -23,6 +23,7 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'URL', 'http://seclists.org/fulldisclosure/2014/May/79' ],
           [ 'URL', 'http://www.arrisi.com/modems/datasheet/SBG6580/SBG6580_UserGuide.pdf' ],
+          [ 'OSVDB', '110555']
         ],
       'Author'      => 'Matthew Kienow <mkienow[at]inokii.com>',
       'License'     => MSF_LICENSE

--- a/modules/exploits/windows/local/bthpan.rb
+++ b/modules/exploits/windows/local/bthpan.rb
@@ -54,7 +54,8 @@ class Metasploit3 < Msf::Exploit::Local
       'References'    =>
         [
           [ 'CVE', '2014-4971' ],
-          [ 'URL', 'https://www.korelogic.com/Resources/Advisories/KL-001-2014-002.txt' ]
+          [ 'URL', 'https://www.korelogic.com/Resources/Advisories/KL-001-2014-002.txt' ],
+          [ 'OSVDB', '109387' ]
         ],
       'DisclosureDate' => 'Jul 18 2014',
       'DefaultTarget'  => 0


### PR DESCRIPTION
## Verification steps
- [x] `info auxiliary/scanner/snmp/sbg6580_enum` from msfconsole should show an OSVDB reference.
- [x] `info exploit/windows/local/bthpan`  from msfconsole should show an OSVDB reference.
