### PR TITLE
Add an animation to comfort the user

### DIFF
--- a/lib/metasploit/framework/command/console.rb
+++ b/lib/metasploit/framework/command/console.rb
@@ -25,7 +25,7 @@ class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::
     when :version
       $stderr.puts "Framework Version: #{Metasploit::Framework::VERSION}"
     else
-      spinner
+      spinner unless parsed_options.options.console.quiet
       driver.run
     end
   end

--- a/lib/metasploit/framework/command/console.rb
+++ b/lib/metasploit/framework/command/console.rb
@@ -11,11 +11,11 @@ class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::
   def spinner
     return if $msf_spinner_thread
     $msf_spinner_thread = Thread.new do
-      $stdout.print "[*] Starting the Metasploit Framework console..."
+      $stderr.print "[*] Starting the Metasploit Framework console..."
       loop do
         %q{/-\|}.each_char do |c|
-          $stdout.print c
-          $stdout.print "\b"
+          $stderr.print c
+          $stderr.print "\b"
         end
       end
     end

--- a/lib/metasploit/framework/command/console.rb
+++ b/lib/metasploit/framework/command/console.rb
@@ -11,6 +11,7 @@ class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::
   def spinner
     return if $msf_spinner_thread
     $msf_spinner_thread = Thread.new do
+      $stdout.print "[*] Starting the Metasploit Framework console..."
       loop do
         %q{/-\|}.each_char do |c|
           $stdout.print c

--- a/lib/metasploit/framework/command/console.rb
+++ b/lib/metasploit/framework/command/console.rb
@@ -8,7 +8,7 @@ require 'metasploit/framework/command/base'
 # Based on pattern used for lib/rails/commands in the railties gem.
 class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::Base
 
-  def spinner(bool=true)
+  def spinner
     return if $msf_spinner_thread
     $msf_spinner_thread = Thread.new do
       loop do

--- a/lib/metasploit/framework/command/console.rb
+++ b/lib/metasploit/framework/command/console.rb
@@ -7,11 +7,25 @@ require 'metasploit/framework/command/base'
 
 # Based on pattern used for lib/rails/commands in the railties gem.
 class Metasploit::Framework::Command::Console < Metasploit::Framework::Command::Base
+
+  def spinner(bool=true)
+    return if $msf_spinner_thread
+    $msf_spinner_thread = Thread.new do
+      loop do
+        %q{/-\|}.each_char do |c|
+          $stdout.print c
+          $stdout.print "\b"
+        end
+      end
+    end
+  end
+
   def start
     case parsed_options.options.subcommand
     when :version
       $stderr.puts "Framework Version: #{Metasploit::Framework::VERSION}"
     else
+      spinner
       driver.run
     end
   end

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -537,7 +537,7 @@ class Driver < Msf::Ui::Driver
 
     if $msf_spinner_thread
       $msf_spinner_thread.kill
-      $stdout.print "\n"
+      $stderr.print "\n"
     end
 
     run_single("banner") unless opts['DisableBanner']

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -535,6 +535,11 @@ class Driver < Msf::Ui::Driver
 
     framework.events.on_ui_start(Msf::Framework::Revision)
 
+    if $msf_spinner_thread
+      $msf_spinner_thread.kill
+      $stdout.print "\n"
+    end
+
     run_single("banner") unless opts['DisableBanner']
 
     opts["Plugins"].each do |plug|

--- a/msfconsole
+++ b/msfconsole
@@ -45,4 +45,6 @@ end
 require Pathname.new(__FILE__).realpath.expand_path.parent.join('config', 'boot')
 require 'metasploit/framework/command/console'
 
+$stdout.print "[*] Starting the Metasploit Framework console..."
 Metasploit::Framework::Command::Console.start
+$stdout.puts "[*] Metasploit Framework console session ended"

--- a/msfconsole
+++ b/msfconsole
@@ -46,4 +46,3 @@ require Pathname.new(__FILE__).realpath.expand_path.parent.join('config', 'boot'
 require 'metasploit/framework/command/console'
 
 Metasploit::Framework::Command::Console.start
-$stdout.puts "[*] Metasploit Framework console session ended"

--- a/msfconsole
+++ b/msfconsole
@@ -45,6 +45,5 @@ end
 require Pathname.new(__FILE__).realpath.expand_path.parent.join('config', 'boot')
 require 'metasploit/framework/command/console'
 
-$stdout.print "[*] Starting the Metasploit Framework console..."
 Metasploit::Framework::Command::Console.start
 $stdout.puts "[*] Metasploit Framework console session ended"


### PR DESCRIPTION
Sometimes msfconsole takes a little while to start. See #3725

This adds a fairly common ASCII spinner to the startup sequence, mainly to comfort the user that their machine isn't locked and things actually are happening while they're waiting to get hackin'.

I haven't spec'ed it, and the code organization isn't great, and there may be problems with printing to `$stdout` in the first place, so consider this PR more of a cry for help than something immediately landable.

That said, it works for me.
