### PR TITLE
Default to TLSv1 for RPC connections

### DIFF
--- a/lib/msf/core/rpc/v10/client.rb
+++ b/lib/msf/core/rpc/v10/client.rb
@@ -21,7 +21,7 @@ class Client
       :port => 3790,
       :uri  => '/api/',
       :ssl  => true,
-      :ssl_version => 'SSLv3',
+      :ssl_version => 'TLS1',
       :context     => {}
     }.merge(info)
 


### PR DESCRIPTION
This ensures that the Metasploit client connections only use TLSv1 for RPC connections. The previous default was SSL3. Tested against all existing RPC server versions that enable SSL.
