### PR TITLE
Datastore options should default to TLS1, not SSL3

### DIFF
--- a/lib/msf/core/auxiliary/crawler.rb
+++ b/lib/msf/core/auxiliary/crawler.rb
@@ -44,7 +44,7 @@ module Auxiliary::HttpCrawler
         OptString.new('HTTPAdditionalHeaders', [false, "A list of additional headers to send (separated by \\x01)"]),
         OptString.new('HTTPCookie', [false, "A HTTP cookie header to send with each request"]),
         OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', false]),
-        OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'SSL3', ['SSL2', 'SSL23', 'SSL3', 'TLS1']]),
+        OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'TLS1', ['SSL2', 'SSL23', 'SSL3', 'TLS1']]),
       ], self.class
     )
 

--- a/lib/msf/core/exploit/http/client.rb
+++ b/lib/msf/core/exploit/http/client.rb
@@ -50,7 +50,7 @@ module Exploit::Remote::HttpClient
         OptString.new('PASSWORD', [false, 'The HTTP password to specify for  authentication', '']),
         OptBool.new('DigestAuthIIS', [false, 'Conform to IIS, should work for most servers. Only set to false for non-IIS servers', true]),
         OptBool.new('SSL', [ false, 'Negotiate SSL for outgoing connections', false]),
-        OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'SSL3', ['SSL2', 'SSL3', 'TLS1']]),
+        OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'TLS1', ['SSL2', 'SSL3', 'TLS1']]),
         OptBool.new('FingerprintCheck', [ false, 'Conduct a pre-exploit fingerprint verification', true]),
         OptString.new('DOMAIN', [ true, 'The domain to use for windows authentification', 'WORKSTATION'])
       ], self.class

--- a/lib/msf/core/exploit/tcp.rb
+++ b/lib/msf/core/exploit/tcp.rb
@@ -62,7 +62,7 @@ module Exploit::Remote::Tcp
     register_advanced_options(
       [
         OptBool.new('SSL',        [ false, 'Negotiate SSL for outgoing connections', false]),
-        OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'SSL3', ['SSL2', 'SSL3', 'TLS1']]),
+        OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'TLS1', ['SSL2', 'SSL3', 'TLS1']]),
         OptEnum.new('SSLVerifyMode',  [ false, 'SSL verification method', 'PEER', %W{CLIENT_ONCE FAIL_IF_NO_PEER_CERT NONE PEER}]),
         OptString.new('SSLCipher',    [ false, 'String for SSL cipher - "DHE-RSA-AES256-SHA" or "ADH"']),
         Opt::Proxies,
@@ -290,7 +290,7 @@ module Exploit::Remote::TcpServer
     register_options(
       [
         OptBool.new('SSL',        [ false, 'Negotiate SSL for incoming connections', false]),
-        OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'SSL3', ['SSL2', 'SSL3', 'TLS1']]),
+        OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'TLS1', ['SSL2', 'SSL3', 'TLS1']]),
         OptPath.new('SSLCert',    [ false, 'Path to a custom SSL certificate (default is randomly generated)']),
         OptAddress.new('SRVHOST', [ true, "The local host to listen on. This must be an address on the local machine or 0.0.0.0", '0.0.0.0' ]),
         OptPort.new('SRVPORT',    [ true, "The local port to listen on.", 8080 ]),

--- a/lib/rex/socket/parameters.rb
+++ b/lib/rex/socket/parameters.rb
@@ -56,7 +56,7 @@ class Rex::Socket::Parameters
   # @option hash [Bool] 'Bool' Create a bare socket
   # @option hash [Bool] 'Server' Whether or not this should be a server
   # @option hash [Bool] 'SSL' Whether or not SSL should be used
-  # @option hash [String] 'SSLVersion' Specify SSL2, SSL3, or TLS1 (SSL3 is
+  # @option hash [String] 'SSLVersion' Specify SSL2, SSL3, or TLS1 (TLS1 is
   #   default)
   # @option hash [String] 'SSLCert' A file containing an SSL certificate (for
   #   server sockets)


### PR DESCRIPTION
Otherwise, we risk getting our connections killed by particularly aggressive DPI devices (IPS, firewalls, etc)

For more on POODLE, see the links at #4018.

Squashed commit of the following:

commit 5e203851d5c9dce1fe984b106ce3031a3653e54b
Author: Tod Beardsley tod_beardsley@rapid7.com
Date:   Wed Oct 15 10:19:04 2014 -0500

```
Whoops missed one
```

commit 477b15a08e06e74d725f1c45486b37e4b403e3c2
Author: Tod Beardsley tod_beardsley@rapid7.com
Date:   Wed Oct 15 10:16:59 2014 -0500

```
Other datastore options also want TLS1 as default
```

commit 8d397bd9b500ff6a8462170b4c39849228494795
Author: Tod Beardsley tod_beardsley@rapid7.com
Date:   Wed Oct 15 10:12:06 2014 -0500

```
TCP datastore opts default to TLS1

Old encryption is old. See also: POODLE
```
