### PR TITLE
Spec all constants/classes/methods in msf/core/module.rb

### DIFF
--- a/spec/lib/msf/core/author_spec.rb
+++ b/spec/lib/msf/core/author_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe Msf::Author do
+  it 'is an alias for Msf::Module::Author' do
+    expect(described_class.name).to eq('Msf::Module::Author')
+  end
+end

--- a/spec/lib/msf/core/module/failure_spec.rb
+++ b/spec/lib/msf/core/module/failure_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper'
+
+describe Msf::Module::Failure do
+  context 'CONSTANTS' do
+    context 'None' do
+      subject(:none) {
+        described_class::None
+      }
+      it { is_expected.to eq('none') }
+    end
+
+    context 'Unknown' do
+      subject(:unknown) {
+        described_class::Unknown
+      }
+      it { is_expected.to eq('unknown') }
+    end
+    context 'Unreachable' do
+      subject(:unreachable) {
+        described_class::Unreachable
+      }
+      it { is_expected.to eq('unreachable') }
+    end
+
+    context 'BadConfig' do
+      subject(:bad_config) {
+        described_class::BadConfig
+      }
+      it { is_expected.to eq('bad-config') }
+    end
+
+    context 'Disconnected' do
+      subject(:disconnected) {
+        described_class::Disconnected
+      }
+      it { is_expected.to eq('disconnected') }
+    end
+
+    context 'NotFound' do
+      subject(:not_found) {
+        described_class::NotFound
+      }
+      it { is_expected.to eq('not-found') }
+    end
+
+    context 'UnexpectedReply' do
+      subject(:unexpected_reply) {
+        described_class::UnexpectedReply
+      }
+
+      it { is_expected.to eq('unexpected-reply') }
+    end
+
+    context 'TimeoutExpired' do
+      subject(:timeout_expired) {
+        described_class::TimeoutExpired
+      }
+
+      it { is_expected.to eq('timeout-expired') }
+    end
+
+    context 'UserInterrupt' do
+      subject(:user_interrupt) {
+        described_class::UserInterrupt
+      }
+
+      it { is_expected.to eq('user-interrupt') }
+    end
+
+    context 'NoAccess' do
+      subject(:no_access) {
+        described_class::NoAccess
+      }
+
+      it { is_expected.to eq('no-access') }
+    end
+
+    context 'NoTarget' do
+      subject(:no_target) {
+        described_class::NoTarget
+      }
+
+      it { is_expected.to eq('no-target') }
+    end
+
+    context 'NotVulnerable' do
+      subject(:not_vulnerable) {
+        described_class::NotVulnerable
+      }
+
+      it { is_expected.to eq('not-vulnerable') }
+    end
+
+    context 'PayloadFailed' do
+      subject(:payload_failed) {
+        described_class::PayloadFailed
+      }
+
+      it { is_expected.to eq('payload-failed') }
+    end
+  end
+end

--- a/spec/lib/msf/core/module_spec.rb
+++ b/spec/lib/msf/core/module_spec.rb
@@ -38,6 +38,101 @@ end
 REF_TYPES = %w(CVE BID OSVDB EDB)
 
 describe Msf::Module do
+  it { is_expected.to respond_to :[] }
+  it { is_expected.to respond_to :[]= }
+  it { is_expected.to respond_to :alias }
+  it { is_expected.to respond_to :arch? }
+  it { is_expected.to respond_to :arch_to_s }
+  it { is_expected.to respond_to :author_to_s }
+  it { is_expected.to respond_to :auxiliary? }
+  it { is_expected.to respond_to :check }
+  it { is_expected.to respond_to :comm }
+  it { is_expected.to respond_to :compat }
+  it { is_expected.to respond_to :compatible? }
+  it { is_expected.to respond_to :debugging? }
+  it { is_expected.to respond_to :deregister_options }
+  it { is_expected.to respond_to :derived_implementor? }
+  it { is_expected.to respond_to :description }
+  it { is_expected.to respond_to :disclosure_date }
+  it { is_expected.to respond_to :each_arch }
+  it { is_expected.to respond_to :each_author }
+  it { is_expected.to respond_to :encoder? }
+  it { is_expected.to respond_to :exploit? }
+  it { is_expected.to respond_to :fail_with }
+  it { is_expected.to respond_to :file_path }
+  it { is_expected.to respond_to :framework }
+  it { is_expected.to respond_to :fullname }
+  it { is_expected.to respond_to :generate_uuid }
+  it { is_expected.to respond_to :import_defaults }
+  it { is_expected.to respond_to :info_fixups }
+  it { is_expected.to respond_to :init_compat }
+  it { is_expected.to respond_to :merge_check_key }
+  it { is_expected.to respond_to :merge_info }
+  it { is_expected.to respond_to :merge_info_advanced_options }
+  it { is_expected.to respond_to :merge_info_alias }
+  it { is_expected.to respond_to :merge_info_description }
+  it { is_expected.to respond_to :merge_info_evasion_options }
+  it { is_expected.to respond_to :merge_info_name }
+  it { is_expected.to respond_to :merge_info_options }
+  it { is_expected.to respond_to :merge_info_string }
+  it { is_expected.to respond_to :merge_info_version }
+  it { is_expected.to respond_to :name }
+  it { is_expected.to respond_to :nop? }
+  it { is_expected.to respond_to :orig_cls }
+  it { is_expected.to respond_to :owner }
+  it { is_expected.to respond_to :payload? }
+  it { is_expected.to respond_to :platform? }
+  it { is_expected.to respond_to :platform_to_s }
+  it { is_expected.to respond_to :post? }
+  it { is_expected.to respond_to :print_error }
+  it { is_expected.to respond_to :print_good }
+  it { is_expected.to respond_to :print_line }
+  it { is_expected.to respond_to :print_line_prefix }
+  it { is_expected.to respond_to :print_prefix }
+  it { is_expected.to respond_to :print_status }
+  it { is_expected.to respond_to :print_warning }
+  it { is_expected.to respond_to :privileged? }
+  it { is_expected.to respond_to :rank }
+  it { is_expected.to respond_to :rank_to_h }
+  it { is_expected.to respond_to :rank_to_s }
+  it { is_expected.to respond_to :refname }
+  it { is_expected.to respond_to :register_advanced_options }
+  it { is_expected.to respond_to :register_evasion_options }
+  it { is_expected.to respond_to :register_options }
+  it { is_expected.to respond_to :register_parent }
+  it { is_expected.to respond_to :replicant }
+  it { is_expected.to respond_to :set_defaults }
+  it { is_expected.to respond_to :share_datastore }
+  it { is_expected.to respond_to :shortname }
+  it { is_expected.to respond_to :support_ipv6? }
+  it { is_expected.to respond_to :target_host }
+  it { is_expected.to respond_to :target_port }
+  it { is_expected.to respond_to :type }
+  it { is_expected.to respond_to :update_info }
+  it { is_expected.to respond_to :validate }
+  it { is_expected.to respond_to :vprint_debug }
+  it { is_expected.to respond_to :vprint_error }
+  it { is_expected.to respond_to :vprint_good }
+  it { is_expected.to respond_to :vprint_line }
+  it { is_expected.to respond_to :vprint_status }
+  it { is_expected.to respond_to :vprint_warning }
+  it { is_expected.to respond_to :workspace }
+
+  context 'class' do
+    subject {
+      described_class
+    }
+
+    it { is_expected.to respond_to :cached? }
+    it { is_expected.to respond_to :fullname }
+    it { is_expected.to respond_to :is_usable }
+    it { is_expected.to respond_to :rank }
+    it { is_expected.to respond_to :rank_to_h }
+    it { is_expected.to respond_to :rank_to_s }
+    it { is_expected.to respond_to :shortname }
+    it { is_expected.to respond_to :type }
+  end
+
   describe '#search_filter' do
     let(:opts) { Hash.new }
     before { subject.stub(:fullname => '/module') }

--- a/spec/lib/msf/core/module_spec.rb
+++ b/spec/lib/msf/core/module_spec.rb
@@ -118,6 +118,16 @@ describe Msf::Module do
   it { is_expected.to respond_to :vprint_warning }
   it { is_expected.to respond_to :workspace }
 
+  context 'CONSTANTS' do
+    context 'UpdateableOptions' do
+      subject(:updateable_options) {
+        described_class::UpdateableOptions
+      }
+
+      it { is_expected.to match_array(%w{Name Description Alias PayloadCompat})}
+    end
+  end
+
   context 'class' do
     subject {
       described_class

--- a/spec/lib/msf/core/platform_spec.rb
+++ b/spec/lib/msf/core/platform_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe Msf::Platform do
+  it 'is an alias for Msf::Module::Platform' do
+    expect(described_class.name).to eq('Msf::Module::Platform')
+  end
+end

--- a/spec/lib/msf/core/reference_spec.rb
+++ b/spec/lib/msf/core/reference_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe Msf::Reference do
+  it 'is an alias for Msf::Module::Reference' do
+    expect(described_class.name).to eq('Msf::Module::Reference')
+  end
+end

--- a/spec/lib/msf/core/site_reference_spec.rb
+++ b/spec/lib/msf/core/site_reference_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe Msf::SiteReference do
+  it 'is an alias for Msf::Module::SiteReference' do
+    expect(described_class.name).to eq('Msf::Module::SiteReference')
+  end
+end

--- a/spec/lib/msf/core/target_spec.rb
+++ b/spec/lib/msf/core/target_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe Msf::Target do
+  it 'is an alias for Msf::Module::Target' do
+    expect(described_class.name).to eq('Msf::Module::Target')
+  end
+end


### PR DESCRIPTION
MSP-11496

In preparation for breaking up `lib/msf/core/module.rb` to lower its line count, spec all the classes/constants/methods reachable so that they can't be lost during the moves.  Methods are only specced by using respond_to since that's all that's necessary to detect deletion without insertion during the moves.
# Verification Steps
## specs
- [x] `rake spec`
- [x] VERIFY no failures
