### PR TITLE
Update Gemspec for meterpreter 0.0.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
       pg
       railties (< 4.0.0)
       recog (~> 1.0)
-    meterpreter_bins (0.0.8)
+    meterpreter_bins (0.0.10)
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       json
       metasploit-concern (~> 0.3.0)
       metasploit-model (~> 0.28.0)
-      meterpreter_bins (= 0.0.7)
+      meterpreter_bins (= 0.0.8)
       msgpack
       nokogiri
       packetfu (= 1.1.9)
@@ -121,7 +121,7 @@ GEM
       pg
       railties (< 4.0.0)
       recog (~> 1.0)
-    meterpreter_bins (0.0.7)
+    meterpreter_bins (0.0.8)
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 0.28.0'
   # Needed for Meterpreter on Windows, soon others.
-  spec.add_runtime_dependency 'meterpreter_bins', '0.0.8'
+  spec.add_runtime_dependency 'meterpreter_bins', '0.0.10'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # Needed by anemone crawler

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 0.28.0'
   # Needed for Meterpreter on Windows, soon others.
-  spec.add_runtime_dependency 'meterpreter_bins', '0.0.7'
+  spec.add_runtime_dependency 'meterpreter_bins', '0.0.8'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # Needed by anemone crawler


### PR DESCRIPTION
Note, this is blocked by actually having meterpreter-0.0.8.gem available on RubyGems. Please don't land this until you can confirm that to be true.

This is related to rapid7/meterpreter#101 and rapid7/meterpreter#100
