### PR TITLE
NAT-PMP modules improvement

### DIFF
--- a/lib/msf/core/auxiliary/natpmp.rb
+++ b/lib/msf/core/auxiliary/natpmp.rb
@@ -18,7 +18,9 @@ module Auxiliary::NATPMP
     register_options(
       [
         Opt::RPORT(Rex::Proto::NATPMP::DefaultPort),
-        Opt::CHOST
+        Opt::CHOST,
+        OptInt.new('LIFETIME', [true, "Time in ms to keep this port forwarded (set to 0 to destroy a mapping)", 3600000]),
+        OptEnum.new('PROTOCOL', [true, "Protocol to forward", 'TCP', %w(TCP UDP)])
       ],
       self.class
     )

--- a/lib/msf/core/auxiliary/natpmp.rb
+++ b/lib/msf/core/auxiliary/natpmp.rb
@@ -23,5 +23,13 @@ module Auxiliary::NATPMP
       self.class
     )
   end
+
+  def lifetime
+    @lifetime ||= datastore['LIFETIME']
+  end
+
+  def protocol
+    @protocol ||= datastore['PROTOCOL']
+  end
 end
 end

--- a/lib/rex/proto/natpmp/packet.rb
+++ b/lib/rex/proto/natpmp/packet.rb
@@ -3,8 +3,6 @@
 #
 # NAT-PMP protocol support
 #
-# by Jon Hart <jhart@spoofed.org>
-#
 ##
 
 module Rex
@@ -16,11 +14,40 @@ module NATPMP
     [ 0, 0 ].pack('nn')
   end
 
+  def get_external_address(udp_sock, host, port, timeout=1)
+    vprint_status("#{host}:#{port} - Probing NAT-PMP for external address")
+    udp_sock.sendto(external_address_request, host, port, 0)
+    external_address = nil
+    while (r = udp_sock.recvfrom(12, timeout) and r[1])
+      (ver, op, result, epoch, external_address) = parse_external_address_response(r[0])
+      if external_address
+        vprint_good("#{host}:#{port} - NAT-PMP external address is #{external_address}")
+        break
+      end
+    end
+    external_address
+  end
+
   # Parse a NAT-PMP external address response +resp+.
   # Returns the decoded parts of the response as an array.
   def parse_external_address_response(resp)
     (ver, op, result, epoch, addr) = resp.unpack("CCnNN")
     [ ver, op, result, epoch, Rex::Socket::addr_itoa(addr) ]
+  end
+
+  def map_port(udp_sock, host, port, int_port, ext_port, protocol, lifetime, timeout=1)
+    vprint_status("#{host}:#{port} - Sending NAT-PMP mapping request")
+    # build the mapping request
+    req = map_port_request(int_port, ext_port,
+      Rex::Proto::NATPMP.const_get(datastore['PROTOCOL']), datastore['LIFETIME'])
+    # send it
+    udp_sock.sendto(req, host, datastore['RPORT'], 0)
+    # handle the reply
+    while (r = udp_sock.recvfrom(16, timeout) and r[1])
+      (_, _, result, _, _, actual_ext_port, _) = parse_map_port_response(r[0])
+      return (result == 0 ? actual_ext_port : nil)
+    end
+    nil
   end
 
   # Return a NAT-PMP request to map remote port +rport+/+protocol+ to local port +lport+ for +lifetime+ ms
@@ -39,6 +66,7 @@ module NATPMP
   def parse_map_port_response(resp)
     resp.unpack("CCnNnnN")
   end
+
 end
 
 end

--- a/modules/auxiliary/admin/natpmp/natpmp_map.rb
+++ b/modules/auxiliary/admin/natpmp/natpmp_map.rb
@@ -23,9 +23,7 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         OptString.new('EXTERNAL_PORTS', [true, 'The external ports to foward from (0 to let the target choose)', 0]),
-        OptString.new('INTERNAL_PORTS', [true, 'The internal ports to forward to', '22,135-139,80,443,445']),
-        OptInt.new('LIFETIME', [true, "Time in ms to keep this port forwarded (set to 0 to destroy a mapping)", 3600000]),
-        OptEnum.new('PROTOCOL', [true, "Protocol to forward", 'TCP', %w(TCP UDP)]),
+        OptString.new('INTERNAL_PORTS', [true, 'The internal ports to forward to', '22,135-139,80,443,445'])
       ],
       self.class
     )
@@ -87,7 +85,7 @@ class Metasploit3 < Msf::Auxiliary
                               " -> " +
                               "#{map_target}:#{internal_port}/#{protocol}"
         if actual_ext_port
-          map_target = Rex::Socket.source_address(host)
+          map_target = datastore['CHOST'] ? datastore['CHOST'] : Rex::Socket.source_address(host)
           actual_forwarding = "#{external_address}:#{actual_ext_port}/#{protocol}" +
                                 " -> " +
                                 "#{map_target}:#{internal_port}/#{protocol}"

--- a/modules/auxiliary/scanner/natpmp/natpmp_portscan.rb
+++ b/modules/auxiliary/scanner/natpmp/natpmp_portscan.rb
@@ -30,6 +30,48 @@ class Metasploit3 < Msf::Auxiliary
 
   def run_host(host)
     begin
+
+      udp_sock = Rex::Socket::Udp.create({
+        'LocalHost' => datastore['CHOST'] || nil,
+        'Context'   => {'Msf' => framework, 'MsfExploit' => self}
+      })
+      add_socket(udp_sock)
+
+      # new
+      external_address = get_external_address(udp_sock, host, datastore['RPORT']) || host
+      actual_ext_port = map_port(udp_sock, host, datastore['RPORT'], datastore['INTERNAL_PORT'], datastore['EXTERNAL_PORT'], Rex::Proto::NATPMP.const_get(datastore['PROTOCOL']), datastore['LIFETIME'])
+
+      if actual_ext_port
+        map_target = Rex::Socket.source_address(host)
+        if (datastore['EXTERNAL_PORT'] != actual_ext_port)
+          print_status(	"#{external_address} " +
+                  "#{datastore['EXTERNAL_PORT']}/#{datastore['PROTOCOL']} -> #{map_target} " +
+                  "#{datastore['INTERNAL_PORT']}/#{datastore['PROTOCOL']} couldn't be forwarded")
+        end
+        print_status(	"#{external_address} " +
+                "#{actual_ext_port}/#{datastore['PROTOCOL']} -> #{map_target} " +
+                "#{datastore['INTERNAL_PORT']}/#{datastore['PROTOCOL']} forwarded")
+
+        # report NAT-PMP as being open
+        report_service(
+          :host   => host,
+          :port   => datastore['RPORT'],
+          :proto  => 'udp',
+          :name  => 'natpmp',
+          :state => Msf::ServiceState::Open
+        )
+      end
+    rescue ::Interrupt
+      raise $!
+    rescue ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionRefused
+      nil
+    rescue ::Exception => e
+      print_error("Unknown error: #{e.class} #{e.backtrace}")
+    end
+  end
+
+  def run_host(host)
+    begin
       udp_sock = Rex::Socket::Udp.create({
         'LocalHost' => datastore['CHOST'] || nil,
         'Context'   => {'Msf' => framework, 'MsfExploit' => self} }

--- a/modules/auxiliary/scanner/natpmp/natpmp_portscan.rb
+++ b/modules/auxiliary/scanner/natpmp/natpmp_portscan.rb
@@ -23,8 +23,7 @@ class Metasploit3 < Msf::Auxiliary
 
     register_options(
       [
-        OptString.new('PORTS', [true, "Ports to scan (e.g. 22-25,80,110-900)", "1-1000"]),
-        OptEnum.new('PROTOCOL', [true, "Protocol to scan", 'TCP', %w(TCP UDP)]),
+        OptString.new('PORTS', [true, "Ports to scan (e.g. 22-25,80,110-900)", "1-1000"])
       ], self.class)
   end
 
@@ -47,7 +46,7 @@ class Metasploit3 < Msf::Auxiliary
       end
 
       # clear all mappings
-      map_port(udp_sock, host, datastore['RPORT'], 0, 0, Rex::Proto::NATPMP.const_get(protocol), lifetime)
+      map_port(udp_sock, host, datastore['RPORT'], 0, 0, Rex::Proto::NATPMP.const_get(protocol), 0)
 
       Rex::Socket.portspec_crack(datastore['PORTS']).each do |port|
         map_req = map_port_request(port, port, Rex::Proto::NATPMP.const_get(datastore['PROTOCOL']), 1)


### PR DESCRIPTION
There really isn't anything new here.  This is just a cleanup of the modules to make them faster, cleaner and more useful by default.  This was achieved by:
- Moving more of the core functionality into the NAT-PMP mixin
- Updating natpmp_map to support mapping multiple ports at once and providing a useful set of ports to start with
- Updating natpmp_portscan to destroy mappings once at the beginning rather than once per port to side-channel scan
- Updating natpm_portscan to only report_ open ports -- reporting the closed ports is largely useless and is just cruft in the db
- Cleanup of all console logging
