### PR TITLE
Fix Msf::DBManager NameErrors

### DIFF
--- a/lib/msf/core/db_manager/host_tag.rb
+++ b/lib/msf/core/db_manager/host_tag.rb
@@ -3,11 +3,11 @@ module Msf::DBManager::HostTag
   # conditions and return hash as well.
   def report_host_tag(opts)
     name = opts.delete(:name)
-    raise DBImportError.new("Missing required option :name") unless name
+    raise Msf::DBImportError.new("Missing required option :name") unless name
     addr = opts.delete(:addr)
-    raise DBImportError.new("Missing required option :addr") unless addr
+    raise Msf::DBImportError.new("Missing required option :addr") unless addr
     wspace = opts.delete(:wspace)
-    raise DBImportError.new("Missing required option :wspace") unless wspace
+    raise Msf::DBImportError.new("Missing required option :wspace") unless wspace
   ::ActiveRecord::Base.connection_pool.with_connection {
     if wspace.kind_of? String
       wspace = find_workspace(wspace)

--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -115,7 +115,10 @@ module Msf::DBManager::Import
     else
       case data[0,4]
       when "PK\x03\x04"
-        data = Zip::File.open(filename)
+        # When Msf::DBManager::Import::MetasploitFramework is included, it's child namespace of
+        # Msf::DBManager::Import::MetasploitFramework::Zip becomes resolvable as Zip here, so need to use ::Zip so Zip
+        # is resolved as one from rubyzip gem.
+        data = ::Zip::File.open(filename)
       when "\xd4\xc3\xb2\xa1", "\xa1\xb2\xc3\xd4"
         data = PacketFu::PcapFile.new(:filename => filename)
       else
@@ -174,8 +177,10 @@ module Msf::DBManager::Import
   #
   # @raise [Msf::DBImportError] if the type can't be detected
   def import_filetype_detect(data)
-
-    if data and data.kind_of? Zip::File
+    # When Msf::DBManager::Import::MetasploitFramework is included, it's child namespace of
+    # Msf::DBManager::Import::MetasploitFramework::Zip becomes resolvable as Zip here, so need to use ::Zip so Zip
+    # is resolved as one from rubyzip gem.
+    if data and data.kind_of? ::Zip::File
       if data.entries.empty?
         raise Msf::DBImportError.new("The zip file provided is empty.")
       end

--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -107,7 +107,7 @@ module Msf::DBManager::Import
       data = f.read(Metasploit::Credential::Exporter::Pwdump::FILE_ID_STRING.size)
     end
     if data.nil?
-      raise DBImportError.new("Zero-length file")
+      raise Msf::DBImportError.new("Zero-length file")
     end
 
     if data.index(Metasploit::Credential::Exporter::Pwdump::FILE_ID_STRING)
@@ -172,12 +172,12 @@ module Msf::DBManager::Import
   #
   # If there is no match, an error is raised instead.
   #
-  # @raise DBImportError if the type can't be detected
+  # @raise [Msf::DBImportError] if the type can't be detected
   def import_filetype_detect(data)
 
     if data and data.kind_of? Zip::File
       if data.entries.empty?
-        raise DBImportError.new("The zip file provided is empty.")
+        raise Msf::DBImportError.new("The zip file provided is empty.")
       end
 
       @import_filedata ||= {}
@@ -194,7 +194,7 @@ module Msf::DBManager::Import
 
       # TODO This check for our zip export should be more extensive
       if xml_files.empty?
-        raise DBImportError.new("The zip file provided is not a Metasploit Zip Export")
+        raise Msf::DBImportError.new("The zip file provided is not a Metasploit Zip Export")
       end
 
       @import_filedata[:zip_xml] = xml_files.first
@@ -207,7 +207,7 @@ module Msf::DBManager::Import
       # Don't check for emptiness here because unlike other formats, we
       # haven't read any actual data in yet, only magic bytes to discover
       # that this is indeed a pcap file.
-      #raise DBImportError.new("The pcap file provided is empty.") if data.body.empty?
+      #raise Msf::DBImportError.new("The pcap file provided is empty.") if data.body.empty?
       @import_filedata ||= {}
       @import_filedata[:type] = "Libpcap Packet Capture"
       return :libpcap
@@ -222,7 +222,7 @@ module Msf::DBManager::Import
     # This is a text string, lets make sure its treated as binary
     data = data.unpack("C*").pack("C*")
     if data and data.to_s.strip.length == 0
-      raise DBImportError.new("The data provided to the import function was empty")
+      raise Msf::DBImportError.new("The data provided to the import function was empty")
     end
 
     # Parse the first line or 4k of data from the file
@@ -354,7 +354,7 @@ module Msf::DBManager::Import
       return :msf_pwdump
     end
 
-    raise DBImportError.new("Could not automatically determine file type")
+    raise Msf::DBImportError.new("Could not automatically determine file type")
   end
 
   # Handles timestamps from Metasploit Express/Pro imports.
@@ -440,7 +440,7 @@ module Msf::DBManager::Import
   def validate_import_file(data)
     begin
       import_filetype_detect(data)
-    rescue DBImportError
+    rescue Msf::DBImportError
       return false
     end
     return true

--- a/lib/msf/core/db_manager/import/acunetix.rb
+++ b/lib/msf/core/db_manager/import/acunetix.rb
@@ -27,7 +27,7 @@ module Msf::DBManager::Import::Acunetix
       end
       return true
     else # Sorry
-      raise DBImportError.new("Could not import due to missing Nokogiri parser. Try 'gem install nokogiri'.")
+      raise Msf::DBImportError.new("Could not import due to missing Nokogiri parser. Try 'gem install nokogiri'.")
     end
   end
 

--- a/lib/msf/core/db_manager/import/amap.rb
+++ b/lib/msf/core/db_manager/import/amap.rb
@@ -43,7 +43,7 @@ module Msf::DBManager::Import::Amap
     when :amap_mlog
       import_amap_mlog(args.merge(:data => data))
     else
-      raise DBImportError.new("Could not determine file type")
+      raise Msf::DBImportError.new("Could not determine file type")
     end
   end
 

--- a/lib/msf/core/db_manager/import/appscan.rb
+++ b/lib/msf/core/db_manager/import/appscan.rb
@@ -27,7 +27,7 @@ module Msf::DBManager::Import::Appscan
       end
       return true
     else # Sorry
-      raise DBImportError.new("Could not import due to missing Nokogiri parser. Try 'gem install nokogiri'.")
+      raise Msf::DBImportError.new("Could not import due to missing Nokogiri parser. Try 'gem install nokogiri'.")
     end
   end
 end

--- a/lib/msf/core/db_manager/import/burp.rb
+++ b/lib/msf/core/db_manager/import/burp.rb
@@ -28,7 +28,7 @@ module Msf::DBManager::Import::Burp
       end
       return true
     else # Sorry
-      raise DBImportError.new("Could not import due to missing Nokogiri parser. Try 'gem install nokogiri'.")
+      raise Msf::DBImportError.new("Could not import due to missing Nokogiri parser. Try 'gem install nokogiri'.")
     end
   end
 end

--- a/lib/msf/core/db_manager/import/ci.rb
+++ b/lib/msf/core/db_manager/import/ci.rb
@@ -27,7 +27,7 @@ module Msf::DBManager::Import::CI
       end
       return true
     else # Sorry
-      raise DBImportError.new("Could not import due to missing Nokogiri parser. Try 'gem install nokogiri'.")
+      raise Msf::DBImportError.new("Could not import due to missing Nokogiri parser. Try 'gem install nokogiri'.")
     end
   end
 end

--- a/lib/msf/core/db_manager/import/foundstone.rb
+++ b/lib/msf/core/db_manager/import/foundstone.rb
@@ -27,7 +27,7 @@ module Msf::DBManager::Import::Foundstone
       end
       return true
     else # Sorry
-      raise DBImportError.new("Could not import due to missing Nokogiri parser. Try 'gem install nokogiri'.")
+      raise Msf::DBImportError.new("Could not import due to missing Nokogiri parser. Try 'gem install nokogiri'.")
     end
   end
 end

--- a/lib/msf/core/db_manager/import/ip360/aspl.rb
+++ b/lib/msf/core/db_manager/import/ip360/aspl.rb
@@ -10,7 +10,7 @@ module Msf::DBManager::Import::IP360::ASPL
     bl = validate_ips(args[:blacklist]) ? args[:blacklist].split : []
 
     if not data.index("<ontology")
-      raise DBImportError.new("The ASPL file does not appear to be valid or may still be compressed")
+      raise Msf::DBImportError.new("The ASPL file does not appear to be valid or may still be compressed")
     end
 
     base = ::File.join(Msf::Config.config_directory, "data", "ncircle")

--- a/lib/msf/core/db_manager/import/ip360/v3.rb
+++ b/lib/msf/core/db_manager/import/ip360/v3.rb
@@ -39,7 +39,7 @@ module Msf::DBManager::Import::IP360::V3
     end
 
     if not aspl_path
-      raise DBImportError.new("The nCircle IP360 ASPL file is not present.\n    Download ASPL from nCircle VNE | Administer | Support | Resources, unzip it, and import it first")
+      raise Msf::DBImportError.new("The nCircle IP360 ASPL file is not present.\n    Download ASPL from nCircle VNE | Administer | Support | Resources, unzip it, and import it first")
     end
 
     # parse nCircle ASPL file

--- a/lib/msf/core/db_manager/import/mbsa.rb
+++ b/lib/msf/core/db_manager/import/mbsa.rb
@@ -27,7 +27,7 @@ module Msf::DBManager::Import::MBSA
       end
       return true
     else # Sorry
-      raise DBImportError.new("Could not import due to missing Nokogiri parser. Try 'gem install nokogiri'.")
+      raise Msf::DBImportError.new("Could not import due to missing Nokogiri parser. Try 'gem install nokogiri'.")
     end
   end
 end

--- a/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
+++ b/lib/msf/core/db_manager/import/metasploit_framework/zip.rb
@@ -32,7 +32,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
       m_ver = nil
     end
     unless m_ver and btag
-      raise DBImportError.new("Unsupported Metasploit XML document format")
+      raise Msf::DBImportError.new("Unsupported Metasploit XML document format")
     end
 
     host_info = {}
@@ -70,7 +70,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
         loot_file = ::File.split(loot_info[:orig_path]).last
         if ::File.exists? loot_dir
           unless (::File.directory?(loot_dir) && ::File.writable?(loot_dir))
-            raise DBImportError.new("Could not move files to #{loot_dir}")
+            raise Msf::DBImportError.new("Could not move files to #{loot_dir}")
           end
         else
           ::FileUtils.mkdir_p(loot_dir)
@@ -120,7 +120,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
         task_file = ::File.split(task_info[:orig_path]).last
         if ::File.exists? tasks_dir
           unless (::File.directory?(tasks_dir) && ::File.writable?(tasks_dir))
-            raise DBImportError.new("Could not move files to #{tasks_dir}")
+            raise Msf::DBImportError.new("Could not move files to #{tasks_dir}")
           end
         else
           ::FileUtils.mkdir_p(tasks_dir)
@@ -158,7 +158,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
     new_tmp = ::File.join(Dir::tmpdir,"msf","imp_#{Rex::Text::rand_text_alphanumeric(4)}",@import_filedata[:zip_basename])
     if ::File.exists? new_tmp
       unless (::File.directory?(new_tmp) && ::File.writable?(new_tmp))
-        raise DBImportError.new("Could not extract zip file to #{new_tmp}")
+        raise Msf::DBImportError.new("Could not extract zip file to #{new_tmp}")
       end
     else
       FileUtils.mkdir_p(new_tmp)
@@ -175,7 +175,7 @@ module Msf::DBManager::Import::MetasploitFramework::Zip
       if File.exists? tmp_subdirs
         unless (::File.directory?(tmp_subdirs) && File.writable?(tmp_subdirs))
           # if it exists but we can't write to it, give up
-          raise DBImportError.new("Could not extract zip file to #{tmp_subdirs}")
+          raise Msf::DBImportError.new("Could not extract zip file to #{tmp_subdirs}")
         end
       else
         ::FileUtils.mkdir(tmp_subdirs)

--- a/lib/msf/core/db_manager/import/open_vas.rb
+++ b/lib/msf/core/db_manager/import/open_vas.rb
@@ -29,6 +29,6 @@ module Msf::DBManager::Import::OpenVAS
     filename = args[:filename]
     wspace = args[:wspace] || workspace
 
-    raise DBImportError.new("No OpenVAS XML support. Please submit a patch to msfdev[at]metasploit.com")
+    raise Msf::DBImportError.new("No OpenVAS XML support. Please submit a patch to msfdev[at]metasploit.com")
   end
 end

--- a/lib/msf/core/db_manager/import/outpost24.rb
+++ b/lib/msf/core/db_manager/import/outpost24.rb
@@ -27,7 +27,7 @@ module Msf::DBManager::Import::Outpost24
       end
       return true
     else # Sorry
-      raise DBImportError.new("Could not import due to missing Nokogiri parser. Try 'gem install nokogiri'.")
+      raise Msf::DBImportError.new("Could not import due to missing Nokogiri parser. Try 'gem install nokogiri'.")
     end
   end
 end

--- a/lib/msf/core/db_manager/report.rb
+++ b/lib/msf/core/db_manager/report.rb
@@ -24,11 +24,11 @@ module Msf::DBManager::Report
     updated = opts.delete(:updated_at)
 
     unless File.exists? tmp_path
-      raise DBImportError 'Report artifact file to be imported does not exist.'
+      raise Msf::DBImportError 'Report artifact file to be imported does not exist.'
     end
 
     unless (File.directory?(artifacts_dir) && File.writable?(artifacts_dir))
-      raise DBImportError "Could not move report artifact file to #{artifacts_dir}."
+      raise Msf::DBImportError "Could not move report artifact file to #{artifacts_dir}."
     end
 
     if File.exists? new_path

--- a/lib/msf/core/db_manager/service.rb
+++ b/lib/msf/core/db_manager/service.rb
@@ -95,7 +95,7 @@ module Msf::DBManager::Service
         dlog("Unknown attribute for Service: #{k}")
       end
     }
-    service.state ||= ServiceState::Open
+    service.state ||= Msf::ServiceState::Open
     service.info  ||= ""
 
     if (service and service.changed?)
@@ -118,7 +118,7 @@ module Msf::DBManager::Service
   def services(wspace = workspace, only_up = false, proto = nil, addresses = nil, ports = nil, names = nil)
   ::ActiveRecord::Base.connection_pool.with_connection {
     conditions = {}
-    conditions[:state] = [ServiceState::Open] if only_up
+    conditions[:state] = [Msf::ServiceState::Open] if only_up
     conditions[:proto] = proto if proto
     conditions["hosts.address"] = addresses if addresses
     conditions[:port] = ports if ports

--- a/lib/msf/core/rpc/v10/rpc_db.rb
+++ b/lib/msf/core/rpc/v10/rpc_db.rb
@@ -181,7 +181,7 @@ public
     offset = opts.delete(:offset) || 0
 
     conditions = {}
-    conditions[:state] = [ServiceState::Open] if opts[:only_up]
+    conditions[:state] = [Msf::ServiceState::Open] if opts[:only_up]
     conditions[:proto] = opts[:proto] if opts[:proto]
     conditions["hosts.address"] = opts[:addresses] if opts[:addresses]
     conditions[:port] = Rex::Socket.portspec_to_portlist(opts[:ports]) if opts[:ports]
@@ -381,7 +381,7 @@ public
       sret = host.services.find_by_proto_and_port(opts[:proto], opts[:port])
     elsif(opts[:proto] && opts[:port])
       conditions = {}
-      conditions[:state] = [ServiceState::Open] if opts[:up]
+      conditions[:state] = [Msf::ServiceState::Open] if opts[:up]
       conditions[:proto] = opts[:proto] if opts[:proto]
       conditions[:port] = opts[:port] if opts[:port]
       conditions[:name] = opts[:names] if opts[:names]

--- a/lib/msf/ui/console/command_dispatcher/db.rb
+++ b/lib/msf/ui/console/command_dispatcher/db.rb
@@ -1463,7 +1463,7 @@ class Db
           print_error("Please note that there were #{warnings} warnings") if warnings > 1
           print_error("Please note that there was one warning") if warnings == 1
 
-        rescue DBImportError
+        rescue Msf::DBImportError
           print_error("Failed to import #{filename}: #{$!}")
           elog("Failed to import #{filename}: #{$!.class}: #{$!}")
           dlog("Call stack: #{$@.join("\n")}", LEV_3)

--- a/scripts/resource/auto_brute.rc
+++ b/scripts/resource/auto_brute.rc
@@ -72,7 +72,7 @@ end
 framework.db.hosts.each do |host|
 	host.services.each do |serv|
 		next if not serv.host
-		next if (serv.state != ServiceState::Open)
+		next if (serv.state != Msf::ServiceState::Open)
 
 		# for now we only brute force these services, you can add some more ...
 		next if not (serv.name =~ /smb/ or

--- a/scripts/resource/auto_cred_checker.rc
+++ b/scripts/resource/auto_cred_checker.rc
@@ -56,7 +56,7 @@ framework.db.creds.each do |creds|
 	framework.db.hosts.each do |host|
 		host.services.each do |serv|
 			next if not serv.host
-			next if (serv.state != ServiceState::Open)
+			next if (serv.state != Msf::ServiceState::Open)
 			# for now we only check these services, you can add some more ...
 			next if not (serv.name =~ /smb/ or 
 			             serv.name =~ /microsoft-ds/ or 

--- a/scripts/resource/auto_pass_the_hash.rc
+++ b/scripts/resource/auto_pass_the_hash.rc
@@ -80,7 +80,7 @@ framework.db.creds.each do |creds|	# just checking if we have any smb_hashes in 
 
 		host.services.each do |serv|
 			next if not serv.host
-			next if (serv.state != ServiceState::Open)
+			next if (serv.state != Msf::ServiceState::Open)
 			next if (serv.name !~ /smb/) 
 
 			print_line("using psexec - Pass the hash")

--- a/scripts/resource/autocrawler.rc
+++ b/scripts/resource/autocrawler.rc
@@ -34,7 +34,7 @@ end
 framework.db.workspace.hosts.each do |host|
 	host.services.each do |serv|
 		next if not serv.host
-		next if (serv.state != ServiceState::Open)
+		next if (serv.state != Msf::ServiceState::Open)
 		next if (serv.name !~ /http/)
 		
 		if(verbose == 1)

--- a/scripts/resource/basic_discovery.rc
+++ b/scripts/resource/basic_discovery.rc
@@ -114,7 +114,7 @@ run_single("unsetg RHOSTS") # we dont need it anymore
 framework.db.workspace.hosts.each do |host|
 	host.services.each do |serv|
 		next if not serv.host
-		next if (serv.state != ServiceState::Open)
+		next if (serv.state != Msf::ServiceState::Open)
 		#next if (serv.name =~ /smb/ or serv.name =~ /microsoft-ds/ or serv.name =~ /netbios/ or serv.port == 445 or serv.port == 139 or serv.port == 137 or serv.name =~ /smtp/ or serv.port == 25 or serv.name =~ /snmp/ or serv.port == 161 or serv.name =~ /ssh/ or serv.port == 22 or serv.name =~ /telnet/ or serv.port == 23)
 		if (serv.name =~ /smb/ or serv.name =~ /microsoft-ds/ or serv.name =~ /netbios/ or serv.port == 445 or serv.port == 139 or serv.port == 137)
 			if(serv.port == 445)

--- a/scripts/resource/port_cleaner.rc
+++ b/scripts/resource/port_cleaner.rc
@@ -16,7 +16,7 @@ counter = 0
 framework.db.hosts.each do |host|
 	host.services.each do |serv|
 		next if not serv.host
-		if (serv.state != ServiceState::Open)
+		if (serv.state != Msf::ServiceState::Open)
 			print_line("cleaning closed services (Port: #{serv.port.to_i} / Host: #{host.address})")
 			run_single("services -d -p #{serv.port.to_i} -r #{serv.proto} #{host.address}")
 			counter = counter + 1

--- a/scripts/resource/wmap_autotest.rc
+++ b/scripts/resource/wmap_autotest.rc
@@ -47,7 +47,7 @@ end
 framework.db.hosts.each do |host|
 	host.services.each do |serv|
 		next if not serv.host
-		next if (serv.state != ServiceState::Open)
+		next if (serv.state != Msf::ServiceState::Open)
 		next if (serv.name !~ /http/)
 
 		if(verbose == 1)

--- a/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/xml.rb
+++ b/spec/support/shared/examples/msf/db_manager/import/metasploit_framework/xml.rb
@@ -160,7 +160,7 @@ shared_examples_for 'Msf::DBManager::Import::MetasploitFramework::XML' do
     )
 
     context 'with other' do
-      it 'should raise DBImportError' do
+      it 'should raise Msf::DBImportError' do
         expect {
           metadata
         }.to raise_error(


### PR DESCRIPTION
MSP-11152

Fix `NameError`s introduced by #4026 that were only revealed by integration test in Pro.
# Verification Steps
## metasploit-framework
### specs
- [x] `rake spec`
- [x] VERIFY no failures
## pro
- [x] Ensure your msf3 symlink is pointing to this branch of metasploit-framework
### cucumber
#### DBImportError
- [x] cucumber -p cinightly features/import.feature:12 features/import.feature:38 features/import.feature:54 features/import/import_3rd_party.feature:8
- [x] VERIFY no error in task log.  Specifically, no `NameError` about `DBImportError`.
#### Zip::File
- [ ] cucumber -p cinightly features/discovery.feature:48
- [ ] VERIFY no error in task log.  Specifically, no `NameError` about `Zip::File`.
