### PR TITLE
Fix up comment splats with the correct URI

### DIFF
--- a/modules/auxiliary/admin/2wire/xslt_password_reset.rb
+++ b/modules/auxiliary/admin/2wire/xslt_password_reset.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/appletv/appletv_display_image.rb
+++ b/modules/auxiliary/admin/appletv/appletv_display_image.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/appletv/appletv_display_video.rb
+++ b/modules/auxiliary/admin/appletv/appletv_display_video.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/backupexec/dump.rb
+++ b/modules/auxiliary/admin/backupexec/dump.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/backupexec/registry.rb
+++ b/modules/auxiliary/admin/backupexec/registry.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/chromecast/chromecast_reset.rb
+++ b/modules/auxiliary/admin/chromecast/chromecast_reset.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/chromecast/chromecast_youtube.rb
+++ b/modules/auxiliary/admin/chromecast/chromecast_youtube.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/cisco/cisco_secure_acs_bypass.rb
+++ b/modules/auxiliary/admin/cisco/cisco_secure_acs_bypass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/cisco/vpn_3000_ftp_bypass.rb
+++ b/modules/auxiliary/admin/cisco/vpn_3000_ftp_bypass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/db2/db2rcmd.rb
+++ b/modules/auxiliary/admin/db2/db2rcmd.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/edirectory/edirectory_dhost_cookie.rb
+++ b/modules/auxiliary/admin/edirectory/edirectory_dhost_cookie.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/edirectory/edirectory_edirutil.rb
+++ b/modules/auxiliary/admin/edirectory/edirectory_edirutil.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/emc/alphastor_devicemanager_exec.rb
+++ b/modules/auxiliary/admin/emc/alphastor_devicemanager_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/emc/alphastor_librarymanager_exec.rb
+++ b/modules/auxiliary/admin/emc/alphastor_librarymanager_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/hp/hp_data_protector_cmd.rb
+++ b/modules/auxiliary/admin/hp/hp_data_protector_cmd.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/hp/hp_imc_som_create_account.rb
+++ b/modules/auxiliary/admin/hp/hp_imc_som_create_account.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/axigen_file_access.rb
+++ b/modules/auxiliary/admin/http/axigen_file_access.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/cfme_manageiq_evm_pass_reset.rb
+++ b/modules/auxiliary/admin/http/cfme_manageiq_evm_pass_reset.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/contentkeeper_fileaccess.rb
+++ b/modules/auxiliary/admin/http/contentkeeper_fileaccess.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/dlink_dir_300_600_exec_noauth.rb
+++ b/modules/auxiliary/admin/http/dlink_dir_300_600_exec_noauth.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
+++ b/modules/auxiliary/admin/http/dlink_dir_645_password_extractor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/dlink_dsl320b_password_extractor.rb
+++ b/modules/auxiliary/admin/http/dlink_dsl320b_password_extractor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/foreman_openstack_satellite_priv_esc.rb
+++ b/modules/auxiliary/admin/http/foreman_openstack_satellite_priv_esc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/hp_web_jetadmin_exec.rb
+++ b/modules/auxiliary/admin/http/hp_web_jetadmin_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/iis_auth_bypass.rb
+++ b/modules/auxiliary/admin/http/iis_auth_bypass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/intersil_pass_reset.rb
+++ b/modules/auxiliary/admin/http/intersil_pass_reset.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/iomega_storcenterpro_sessionid.rb
+++ b/modules/auxiliary/admin/http/iomega_storcenterpro_sessionid.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/jboss_bshdeployer.rb
+++ b/modules/auxiliary/admin/http/jboss_bshdeployer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/jboss_seam_exec.rb
+++ b/modules/auxiliary/admin/http/jboss_seam_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/katello_satellite_priv_esc.rb
+++ b/modules/auxiliary/admin/http/katello_satellite_priv_esc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
+++ b/modules/auxiliary/admin/http/linksys_e1500_e2500_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/linksys_tmunblock_admin_reset_bof.rb
+++ b/modules/auxiliary/admin/http/linksys_tmunblock_admin_reset_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/linksys_wrt54gl_exec.rb
+++ b/modules/auxiliary/admin/http/linksys_wrt54gl_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/mutiny_frontend_read_delete.rb
+++ b/modules/auxiliary/admin/http/mutiny_frontend_read_delete.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/nexpose_xxe_file_read.rb
+++ b/modules/auxiliary/admin/http/nexpose_xxe_file_read.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/novell_file_reporter_filedelete.rb
+++ b/modules/auxiliary/admin/http/novell_file_reporter_filedelete.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/openbravo_xxe.rb
+++ b/modules/auxiliary/admin/http/openbravo_xxe.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/rails_devise_pass_reset.rb
+++ b/modules/auxiliary/admin/http/rails_devise_pass_reset.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/scrutinizer_add_user.rb
+++ b/modules/auxiliary/admin/http/scrutinizer_add_user.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/sophos_wpa_traversal.rb
+++ b/modules/auxiliary/admin/http/sophos_wpa_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/tomcat_administration.rb
+++ b/modules/auxiliary/admin/http/tomcat_administration.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/tomcat_utf8_traversal.rb
+++ b/modules/auxiliary/admin/http/tomcat_utf8_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/trendmicro_dlp_traversal.rb
+++ b/modules/auxiliary/admin/http/trendmicro_dlp_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2009_001.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/typo3_sa_2009_002.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2009_002.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/typo3_sa_2010_020.rb
+++ b/modules/auxiliary/admin/http/typo3_sa_2010_020.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/typo3_winstaller_default_enc_keys.rb
+++ b/modules/auxiliary/admin/http/typo3_winstaller_default_enc_keys.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/vbulletin_upgrade_admin.rb
+++ b/modules/auxiliary/admin/http/vbulletin_upgrade_admin.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/wp_custom_contact_forms.rb
+++ b/modules/auxiliary/admin/http/wp_custom_contact_forms.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/http/zyxel_admin_password_extractor.rb
+++ b/modules/auxiliary/admin/http/zyxel_admin_password_extractor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/maxdb/maxdb_cons_exec.rb
+++ b/modules/auxiliary/admin/maxdb/maxdb_cons_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/misc/sercomm_dump_config.rb
+++ b/modules/auxiliary/admin/misc/sercomm_dump_config.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/misc/wol.rb
+++ b/modules/auxiliary/admin/misc/wol.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/motorola/wr850g_cred.rb
+++ b/modules/auxiliary/admin/motorola/wr850g_cred.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/ms/ms08_059_his2006.rb
+++ b/modules/auxiliary/admin/ms/ms08_059_his2006.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/mssql/mssql_enum.rb
+++ b/modules/auxiliary/admin/mssql/mssql_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/mssql/mssql_escalate_dbowner.rb
+++ b/modules/auxiliary/admin/mssql/mssql_escalate_dbowner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/mssql/mssql_exec.rb
+++ b/modules/auxiliary/admin/mssql/mssql_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
+++ b/modules/auxiliary/admin/mssql/mssql_findandsampledata.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/mssql/mssql_idf.rb
+++ b/modules/auxiliary/admin/mssql/mssql_idf.rb
@@ -8,7 +8,7 @@
 ##
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/mssql/mssql_ntlm_stealer.rb
+++ b/modules/auxiliary/admin/mssql/mssql_ntlm_stealer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/mssql/mssql_ntlm_stealer_sqli.rb
+++ b/modules/auxiliary/admin/mssql/mssql_ntlm_stealer_sqli.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/mssql/mssql_sql.rb
+++ b/modules/auxiliary/admin/mssql/mssql_sql.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/mssql/mssql_sql_file.rb
+++ b/modules/auxiliary/admin/mssql/mssql_sql_file.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/mysql/mysql_enum.rb
+++ b/modules/auxiliary/admin/mysql/mysql_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/mysql/mysql_sql.rb
+++ b/modules/auxiliary/admin/mysql/mysql_sql.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/natpmp/natpmp_map.rb
+++ b/modules/auxiliary/admin/natpmp/natpmp_map.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/officescan/tmlisten_traversal.rb
+++ b/modules/auxiliary/admin/officescan/tmlisten_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/oracle/ora_ntlm_stealer.rb
+++ b/modules/auxiliary/admin/oracle/ora_ntlm_stealer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/oracle/oracle_login.rb
+++ b/modules/auxiliary/admin/oracle/oracle_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/oracle/oracle_sql.rb
+++ b/modules/auxiliary/admin/oracle/oracle_sql.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/oracle/oraenum.rb
+++ b/modules/auxiliary/admin/oracle/oraenum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/oracle/osb_execqr.rb
+++ b/modules/auxiliary/admin/oracle/osb_execqr.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/oracle/osb_execqr2.rb
+++ b/modules/auxiliary/admin/oracle/osb_execqr2.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/oracle/osb_execqr3.rb
+++ b/modules/auxiliary/admin/oracle/osb_execqr3.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/oracle/post_exploitation/win32exec.rb
+++ b/modules/auxiliary/admin/oracle/post_exploitation/win32exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/oracle/post_exploitation/win32upload.rb
+++ b/modules/auxiliary/admin/oracle/post_exploitation/win32upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/oracle/sid_brute.rb
+++ b/modules/auxiliary/admin/oracle/sid_brute.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/oracle/tnscmd.rb
+++ b/modules/auxiliary/admin/oracle/tnscmd.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/pop2/uw_fileretrieval.rb
+++ b/modules/auxiliary/admin/pop2/uw_fileretrieval.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/postgres/postgres_readfile.rb
+++ b/modules/auxiliary/admin/postgres/postgres_readfile.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/postgres/postgres_sql.rb
+++ b/modules/auxiliary/admin/postgres/postgres_sql.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/sap/sap_configservlet_exec_noauth.rb
+++ b/modules/auxiliary/admin/sap/sap_configservlet_exec_noauth.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/sap/sap_mgmt_con_osexec.rb
+++ b/modules/auxiliary/admin/sap/sap_mgmt_con_osexec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/scada/advantech_webaccess_dbvisitor_sqli.rb
+++ b/modules/auxiliary/admin/scada/advantech_webaccess_dbvisitor_sqli.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/scada/ge_proficy_substitute_traversal.rb
+++ b/modules/auxiliary/admin/scada/ge_proficy_substitute_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/scada/modicon_command.rb
+++ b/modules/auxiliary/admin/scada/modicon_command.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/scada/modicon_password_recovery.rb
+++ b/modules/auxiliary/admin/scada/modicon_password_recovery.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/scada/modicon_stux_transfer.rb
+++ b/modules/auxiliary/admin/scada/modicon_stux_transfer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/scada/multi_cip_command.rb
+++ b/modules/auxiliary/admin/scada/multi_cip_command.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/scada/yokogawa_bkbcopyd_client.rb
+++ b/modules/auxiliary/admin/scada/yokogawa_bkbcopyd_client.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/serverprotect/file.rb
+++ b/modules/auxiliary/admin/serverprotect/file.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/smb/check_dir_file.rb
+++ b/modules/auxiliary/admin/smb/check_dir_file.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/smb/delete_file.rb
+++ b/modules/auxiliary/admin/smb/delete_file.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/smb/download_file.rb
+++ b/modules/auxiliary/admin/smb/download_file.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/smb/list_directory.rb
+++ b/modules/auxiliary/admin/smb/list_directory.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/smb/psexec_command.rb
+++ b/modules/auxiliary/admin/smb/psexec_command.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
+++ b/modules/auxiliary/admin/smb/psexec_ntdsgrab.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/smb/samba_symlink_traversal.rb
+++ b/modules/auxiliary/admin/smb/samba_symlink_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/smb/upload_file.rb
+++ b/modules/auxiliary/admin/smb/upload_file.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
+++ b/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/tftp/tftp_transfer_util.rb
+++ b/modules/auxiliary/admin/tftp/tftp_transfer_util.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/tikiwiki/tikidblib.rb
+++ b/modules/auxiliary/admin/tikiwiki/tikidblib.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/vmware/poweroff_vm.rb
+++ b/modules/auxiliary/admin/vmware/poweroff_vm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/vmware/poweron_vm.rb
+++ b/modules/auxiliary/admin/vmware/poweron_vm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/vmware/tag_vm.rb
+++ b/modules/auxiliary/admin/vmware/tag_vm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/vmware/terminate_esx_sessions.rb
+++ b/modules/auxiliary/admin/vmware/terminate_esx_sessions.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/vnc/realvnc_41_bypass.rb
+++ b/modules/auxiliary/admin/vnc/realvnc_41_bypass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/vxworks/apple_airport_extreme_password.rb
+++ b/modules/auxiliary/admin/vxworks/apple_airport_extreme_password.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/vxworks/dlink_i2eye_autoanswer.rb
+++ b/modules/auxiliary/admin/vxworks/dlink_i2eye_autoanswer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/vxworks/wdbrpc_memory_dump.rb
+++ b/modules/auxiliary/admin/vxworks/wdbrpc_memory_dump.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/vxworks/wdbrpc_reboot.rb
+++ b/modules/auxiliary/admin/vxworks/wdbrpc_reboot.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/webmin/edit_html_fileaccess.rb
+++ b/modules/auxiliary/admin/webmin/edit_html_fileaccess.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/webmin/file_disclosure.rb
+++ b/modules/auxiliary/admin/webmin/file_disclosure.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/admin/zend/java_bridge.rb
+++ b/modules/auxiliary/admin/zend/java_bridge.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/analyze/jtr_aix.rb
+++ b/modules/auxiliary/analyze/jtr_aix.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/analyze/jtr_crack_fast.rb
+++ b/modules/auxiliary/analyze/jtr_crack_fast.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/analyze/jtr_linux.rb
+++ b/modules/auxiliary/analyze/jtr_linux.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/analyze/jtr_mssql_fast.rb
+++ b/modules/auxiliary/analyze/jtr_mssql_fast.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/analyze/jtr_mysql_fast.rb
+++ b/modules/auxiliary/analyze/jtr_mysql_fast.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/analyze/jtr_oracle_fast.rb
+++ b/modules/auxiliary/analyze/jtr_oracle_fast.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/analyze/jtr_postgres_fast.rb
+++ b/modules/auxiliary/analyze/jtr_postgres_fast.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/bnat/bnat_router.rb
+++ b/modules/auxiliary/bnat/bnat_router.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/bnat/bnat_scan.rb
+++ b/modules/auxiliary/bnat/bnat_scan.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/client/smtp/emailer.rb
+++ b/modules/auxiliary/client/smtp/emailer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/crawler/msfcrawler.rb
+++ b/modules/auxiliary/crawler/msfcrawler.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/docx/word_unc_injector.rb
+++ b/modules/auxiliary/docx/word_unc_injector.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/cisco/ios_http_percentpercent.rb
+++ b/modules/auxiliary/dos/cisco/ios_http_percentpercent.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/dhcp/isc_dhcpd_clientid.rb
+++ b/modules/auxiliary/dos/dhcp/isc_dhcpd_clientid.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/freebsd/nfsd/nfsd_mount.rb
+++ b/modules/auxiliary/dos/freebsd/nfsd/nfsd_mount.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/hp/data_protector_rds.rb
+++ b/modules/auxiliary/dos/hp/data_protector_rds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/http/3com_superstack_switch.rb
+++ b/modules/auxiliary/dos/http/3com_superstack_switch.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/http/apache_commons_fileupload_dos.rb
+++ b/modules/auxiliary/dos/http/apache_commons_fileupload_dos.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/http/apache_mod_isapi.rb
+++ b/modules/auxiliary/dos/http/apache_mod_isapi.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/http/apache_range_dos.rb
+++ b/modules/auxiliary/dos/http/apache_range_dos.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/http/apache_tomcat_transfer_encoding.rb
+++ b/modules/auxiliary/dos/http/apache_tomcat_transfer_encoding.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/http/canon_wireless_printer.rb
+++ b/modules/auxiliary/dos/http/canon_wireless_printer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/http/dell_openmanage_post.rb
+++ b/modules/auxiliary/dos/http/dell_openmanage_post.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/http/gzip_bomb_dos.rb
+++ b/modules/auxiliary/dos/http/gzip_bomb_dos.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/http/hashcollision_dos.rb
+++ b/modules/auxiliary/dos/http/hashcollision_dos.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/http/monkey_headers.rb
+++ b/modules/auxiliary/dos/http/monkey_headers.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/http/nodejs_pipelining.rb
+++ b/modules/auxiliary/dos/http/nodejs_pipelining.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/http/novell_file_reporter_heap_bof.rb
+++ b/modules/auxiliary/dos/http/novell_file_reporter_heap_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/http/rails_action_view.rb
+++ b/modules/auxiliary/dos/http/rails_action_view.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/http/rails_json_float_dos.rb
+++ b/modules/auxiliary/dos/http/rails_json_float_dos.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/http/sonicwall_ssl_format.rb
+++ b/modules/auxiliary/dos/http/sonicwall_ssl_format.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/http/webrick_regex.rb
+++ b/modules/auxiliary/dos/http/webrick_regex.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/http/wordpress_xmlrpc_dos.rb
+++ b/modules/auxiliary/dos/http/wordpress_xmlrpc_dos.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/mdns/avahi_portzero.rb
+++ b/modules/auxiliary/dos/mdns/avahi_portzero.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/misc/dopewars.rb
+++ b/modules/auxiliary/dos/misc/dopewars.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/misc/ibm_sametime_webplayer_dos.rb
+++ b/modules/auxiliary/dos/misc/ibm_sametime_webplayer_dos.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/misc/memcached.rb
+++ b/modules/auxiliary/dos/misc/memcached.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/ntp/ntpd_reserved_dos.rb
+++ b/modules/auxiliary/dos/ntp/ntpd_reserved_dos.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/pptp/ms02_063_pptp_dos.rb
+++ b/modules/auxiliary/dos/pptp/ms02_063_pptp_dos.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/samba/lsa_addprivs_heap.rb
+++ b/modules/auxiliary/dos/samba/lsa_addprivs_heap.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/samba/lsa_transnames_heap.rb
+++ b/modules/auxiliary/dos/samba/lsa_transnames_heap.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/samba/read_nttrans_ea_list.rb
+++ b/modules/auxiliary/dos/samba/read_nttrans_ea_list.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/sap/sap_soap_rfc_eps_delete_file.rb
+++ b/modules/auxiliary/dos/sap/sap_soap_rfc_eps_delete_file.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/scada/beckhoff_twincat.rb
+++ b/modules/auxiliary/dos/scada/beckhoff_twincat.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/scada/d20_tftp_overflow.rb
+++ b/modules/auxiliary/dos/scada/d20_tftp_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/scada/igss9_dataserver.rb
+++ b/modules/auxiliary/dos/scada/igss9_dataserver.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/scada/yokogawa_logsvr.rb
+++ b/modules/auxiliary/dos/scada/yokogawa_logsvr.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/smtp/sendmail_prescan.rb
+++ b/modules/auxiliary/dos/smtp/sendmail_prescan.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/solaris/lpd/cascade_delete.rb
+++ b/modules/auxiliary/dos/solaris/lpd/cascade_delete.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/ssl/dtls_changecipherspec.rb
+++ b/modules/auxiliary/dos/ssl/dtls_changecipherspec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/ssl/dtls_fragment_overflow.rb
+++ b/modules/auxiliary/dos/ssl/dtls_fragment_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/ssl/openssl_aesni.rb
+++ b/modules/auxiliary/dos/ssl/openssl_aesni.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/syslog/rsyslog_long_tag.rb
+++ b/modules/auxiliary/dos/syslog/rsyslog_long_tag.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/tcp/junos_tcp_opt.rb
+++ b/modules/auxiliary/dos/tcp/junos_tcp_opt.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/tcp/synflood.rb
+++ b/modules/auxiliary/dos/tcp/synflood.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/upnp/miniupnpd_dos.rb
+++ b/modules/auxiliary/dos/upnp/miniupnpd_dos.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/appian/appian_bpm.rb
+++ b/modules/auxiliary/dos/windows/appian/appian_bpm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/browser/ms09_065_eot_integer.rb
+++ b/modules/auxiliary/dos/windows/browser/ms09_065_eot_integer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/ftp/filezilla_admin_user.rb
+++ b/modules/auxiliary/dos/windows/ftp/filezilla_admin_user.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/ftp/filezilla_server_port.rb
+++ b/modules/auxiliary/dos/windows/ftp/filezilla_server_port.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/ftp/guildftp_cwdlist.rb
+++ b/modules/auxiliary/dos/windows/ftp/guildftp_cwdlist.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof.rb
+++ b/modules/auxiliary/dos/windows/ftp/iis75_ftpd_iac_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/ftp/iis_list_exhaustion.rb
+++ b/modules/auxiliary/dos/windows/ftp/iis_list_exhaustion.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/ftp/solarftp_user.rb
+++ b/modules/auxiliary/dos/windows/ftp/solarftp_user.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/ftp/titan626_site.rb
+++ b/modules/auxiliary/dos/windows/ftp/titan626_site.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/ftp/vicftps50_list.rb
+++ b/modules/auxiliary/dos/windows/ftp/vicftps50_list.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/ftp/winftp230_nlst.rb
+++ b/modules/auxiliary/dos/windows/ftp/winftp230_nlst.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/ftp/xmeasy560_nlst.rb
+++ b/modules/auxiliary/dos/windows/ftp/xmeasy560_nlst.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/ftp/xmeasy570_nlst.rb
+++ b/modules/auxiliary/dos/windows/ftp/xmeasy570_nlst.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/games/kaillera.rb
+++ b/modules/auxiliary/dos/windows/games/kaillera.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/http/ms10_065_ii6_asp_dos.rb
+++ b/modules/auxiliary/dos/windows/http/ms10_065_ii6_asp_dos.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/http/pi3web_isapi.rb
+++ b/modules/auxiliary/dos/windows/http/pi3web_isapi.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/llmnr/ms11_030_dnsapi.rb
+++ b/modules/auxiliary/dos/windows/llmnr/ms11_030_dnsapi.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/nat/nat_helper.rb
+++ b/modules/auxiliary/dos/windows/nat/nat_helper.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/rdp/ms12_020_maxchannelids.rb
+++ b/modules/auxiliary/dos/windows/rdp/ms12_020_maxchannelids.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/smb/ms05_047_pnp.rb
+++ b/modules/auxiliary/dos/windows/smb/ms05_047_pnp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/smb/ms06_035_mailslot.rb
+++ b/modules/auxiliary/dos/windows/smb/ms06_035_mailslot.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/smb/ms06_063_trans.rb
+++ b/modules/auxiliary/dos/windows/smb/ms06_063_trans.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/smb/ms09_001_write.rb
+++ b/modules/auxiliary/dos/windows/smb/ms09_001_write.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/smb/ms09_050_smb2_negotiate_pidhigh.rb
+++ b/modules/auxiliary/dos/windows/smb/ms09_050_smb2_negotiate_pidhigh.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/smb/ms09_050_smb2_session_logoff.rb
+++ b/modules/auxiliary/dos/windows/smb/ms09_050_smb2_session_logoff.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/smb/ms10_006_negotiate_response_loop.rb
+++ b/modules/auxiliary/dos/windows/smb/ms10_006_negotiate_response_loop.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/smb/ms10_054_queryfs_pool_overflow.rb
+++ b/modules/auxiliary/dos/windows/smb/ms10_054_queryfs_pool_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/smb/ms11_019_electbowser.rb
+++ b/modules/auxiliary/dos/windows/smb/ms11_019_electbowser.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/smb/rras_vls_null_deref.rb
+++ b/modules/auxiliary/dos/windows/smb/rras_vls_null_deref.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/smb/vista_negotiate_stop.rb
+++ b/modules/auxiliary/dos/windows/smb/vista_negotiate_stop.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/smtp/ms06_019_exchange.rb
+++ b/modules/auxiliary/dos/windows/smtp/ms06_019_exchange.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/ssh/sysax_sshd_kexchange.rb
+++ b/modules/auxiliary/dos/windows/ssh/sysax_sshd_kexchange.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/tftp/pt360_write.rb
+++ b/modules/auxiliary/dos/windows/tftp/pt360_write.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/windows/tftp/solarwinds.rb
+++ b/modules/auxiliary/dos/windows/tftp/solarwinds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/wireshark/capwap.rb
+++ b/modules/auxiliary/dos/wireshark/capwap.rb
@@ -1,5 +1,5 @@
 #
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/wireshark/chunked.rb
+++ b/modules/auxiliary/dos/wireshark/chunked.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/wireshark/cldap.rb
+++ b/modules/auxiliary/dos/wireshark/cldap.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/dos/wireshark/ldap.rb
+++ b/modules/auxiliary/dos/wireshark/ldap.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/dns/dns_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/dns/dns_fuzzer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/ftp/client_ftp.rb
+++ b/modules/auxiliary/fuzzers/ftp/client_ftp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 #
 # Fuzzer written by corelanc0d3r - <peter.ve [at] corelan.be>

--- a/modules/auxiliary/fuzzers/ftp/ftp_pre_post.rb
+++ b/modules/auxiliary/fuzzers/ftp/ftp_pre_post.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/http/http_form_field.rb
+++ b/modules/auxiliary/fuzzers/http/http_form_field.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/http/http_get_uri_long.rb
+++ b/modules/auxiliary/fuzzers/http/http_get_uri_long.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/http/http_get_uri_strings.rb
+++ b/modules/auxiliary/fuzzers/http/http_get_uri_strings.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/ntp/ntp_protocol_fuzzer.rb
@@ -1,6 +1,6 @@
 # encoding: UTF-8
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/smb/smb2_negotiate_corrupt.rb
+++ b/modules/auxiliary/fuzzers/smb/smb2_negotiate_corrupt.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/smb/smb_create_pipe.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_create_pipe.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/smb/smb_create_pipe_corrupt.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_create_pipe_corrupt.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/smb/smb_negotiate_corrupt.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_negotiate_corrupt.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/smb/smb_ntlm1_login_corrupt.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_ntlm1_login_corrupt.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/smb/smb_tree_connect.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_tree_connect.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/smb/smb_tree_connect_corrupt.rb
+++ b/modules/auxiliary/fuzzers/smb/smb_tree_connect_corrupt.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/smtp/smtp_fuzzer.rb
+++ b/modules/auxiliary/fuzzers/smtp/smtp_fuzzer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/ssh/ssh_kexinit_corrupt.rb
+++ b/modules/auxiliary/fuzzers/ssh/ssh_kexinit_corrupt.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/ssh/ssh_version_15.rb
+++ b/modules/auxiliary/fuzzers/ssh/ssh_version_15.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/ssh/ssh_version_2.rb
+++ b/modules/auxiliary/fuzzers/ssh/ssh_version_2.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/ssh/ssh_version_corrupt.rb
+++ b/modules/auxiliary/fuzzers/ssh/ssh_version_corrupt.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/tds/tds_login_corrupt.rb
+++ b/modules/auxiliary/fuzzers/tds/tds_login_corrupt.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/fuzzers/tds/tds_login_username.rb
+++ b/modules/auxiliary/fuzzers/tds/tds_login_username.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/alienvault_iso27001_sqli.rb
+++ b/modules/auxiliary/gather/alienvault_iso27001_sqli.rb
@@ -1,5 +1,5 @@
 ##
-## This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 ## Current source: https://github.com/rapid7/metasploit-framework
 ###
 

--- a/modules/auxiliary/gather/alienvault_newpolicyform_sqli.rb
+++ b/modules/auxiliary/gather/alienvault_newpolicyform_sqli.rb
@@ -1,5 +1,5 @@
 ##
-## This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 ## Current source: https://github.com/rapid7/metasploit-framework
 ###
 

--- a/modules/auxiliary/gather/android_htmlfileprovider.rb
+++ b/modules/auxiliary/gather/android_htmlfileprovider.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/android_stock_browser_uxss.rb
+++ b/modules/auxiliary/gather/android_stock_browser_uxss.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/apache_rave_creds.rb
+++ b/modules/auxiliary/gather/apache_rave_creds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
+++ b/modules/auxiliary/gather/apple_safari_webarchive_uxss.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/checkpoint_hostname.rb
+++ b/modules/auxiliary/gather/checkpoint_hostname.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/chromecast_wifi.rb
+++ b/modules/auxiliary/gather/chromecast_wifi.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/citrix_published_applications.rb
+++ b/modules/auxiliary/gather/citrix_published_applications.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/citrix_published_bruteforce.rb
+++ b/modules/auxiliary/gather/citrix_published_bruteforce.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/coldfusion_pwd_props.rb
+++ b/modules/auxiliary/gather/coldfusion_pwd_props.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/corpwatch_lookup_id.rb
+++ b/modules/auxiliary/gather/corpwatch_lookup_id.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/corpwatch_lookup_name.rb
+++ b/modules/auxiliary/gather/corpwatch_lookup_name.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/d20pass.rb
+++ b/modules/auxiliary/gather/d20pass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/dns_bruteforce.rb
+++ b/modules/auxiliary/gather/dns_bruteforce.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/dns_cache_scraper.rb
+++ b/modules/auxiliary/gather/dns_cache_scraper.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/dns_info.rb
+++ b/modules/auxiliary/gather/dns_info.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/dns_reverse_lookup.rb
+++ b/modules/auxiliary/gather/dns_reverse_lookup.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/dns_srv_enum.rb
+++ b/modules/auxiliary/gather/dns_srv_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/doliwamp_traversal_creds.rb
+++ b/modules/auxiliary/gather/doliwamp_traversal_creds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/drupal_openid_xxe.rb
+++ b/modules/auxiliary/gather/drupal_openid_xxe.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/eaton_nsm_creds.rb
+++ b/modules/auxiliary/gather/eaton_nsm_creds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/emc_cta_xxe.rb
+++ b/modules/auxiliary/gather/emc_cta_xxe.rb
@@ -1,4 +1,4 @@
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 ##
 # Current source: https://github.com/rapid7/metasploit-framework
 ##

--- a/modules/auxiliary/gather/enum_dns.rb
+++ b/modules/auxiliary/gather/enum_dns.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/external_ip.rb
+++ b/modules/auxiliary/gather/external_ip.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
+++ b/modules/auxiliary/gather/f5_bigip_cookie_disclosure.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/flash_rosetta_jsonp_url_disclosure.rb
+++ b/modules/auxiliary/gather/flash_rosetta_jsonp_url_disclosure.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/hp_enum_perfd.rb
+++ b/modules/auxiliary/gather/hp_enum_perfd.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/hp_snac_domain_creds.rb
+++ b/modules/auxiliary/gather/hp_snac_domain_creds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/ibm_sametime_enumerate_users.rb
+++ b/modules/auxiliary/gather/ibm_sametime_enumerate_users.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/ibm_sametime_room_brute.rb
+++ b/modules/auxiliary/gather/ibm_sametime_room_brute.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/ibm_sametime_version.rb
+++ b/modules/auxiliary/gather/ibm_sametime_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/impersonate_ssl.rb
+++ b/modules/auxiliary/gather/impersonate_ssl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/joomla_weblinks_sqli.rb
+++ b/modules/auxiliary/gather/joomla_weblinks_sqli.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/mantisbt_admin_sqli.rb
+++ b/modules/auxiliary/gather/mantisbt_admin_sqli.rb
@@ -1,5 +1,5 @@
 ##
-## This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 ## Current source: https://github.com/rapid7/metasploit-framework
 ###
 

--- a/modules/auxiliary/gather/mongodb_js_inject_collection_enum.rb
+++ b/modules/auxiliary/gather/mongodb_js_inject_collection_enum.rb
@@ -1,5 +1,5 @@
 ##
-## This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 ## Current source: https://github.com/rapid7/metasploit-framework
 ###
 

--- a/modules/auxiliary/gather/mybb_db_fingerprint.rb
+++ b/modules/auxiliary/gather/mybb_db_fingerprint.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/natpmp_external_address.rb
+++ b/modules/auxiliary/gather/natpmp_external_address.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/search_email_collector.rb
+++ b/modules/auxiliary/gather/search_email_collector.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/shodan_search.rb
+++ b/modules/auxiliary/gather/shodan_search.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/vbulletin_vote_sqli.rb
+++ b/modules/auxiliary/gather/vbulletin_vote_sqli.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/windows_deployment_services_shares.rb
+++ b/modules/auxiliary/gather/windows_deployment_services_shares.rb
@@ -1,5 +1,5 @@
 #
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
+++ b/modules/auxiliary/gather/wp_w3_total_cache_hash_extract.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/xbmc_traversal.rb
+++ b/modules/auxiliary/gather/xbmc_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/parser/unattend.rb
+++ b/modules/auxiliary/parser/unattend.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/pdf/foxit/authbypass.rb
+++ b/modules/auxiliary/pdf/foxit/authbypass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/afp/afp_login.rb
+++ b/modules/auxiliary/scanner/afp/afp_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/afp/afp_server_info.rb
+++ b/modules/auxiliary/scanner/afp/afp_server_info.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/backdoor/energizer_duo_detect.rb
+++ b/modules/auxiliary/scanner/backdoor/energizer_duo_detect.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/chargen/chargen_probe.rb
+++ b/modules/auxiliary/scanner/chargen/chargen_probe.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/couchdb/couchdb_enum.rb
+++ b/modules/auxiliary/scanner/couchdb/couchdb_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/couchdb/couchdb_login.rb
+++ b/modules/auxiliary/scanner/couchdb/couchdb_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/db2/db2_auth.rb
+++ b/modules/auxiliary/scanner/db2/db2_auth.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/db2/db2_version.rb
+++ b/modules/auxiliary/scanner/db2/db2_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/db2/discovery.rb
+++ b/modules/auxiliary/scanner/db2/discovery.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/dcerpc/endpoint_mapper.rb
+++ b/modules/auxiliary/scanner/dcerpc/endpoint_mapper.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/dcerpc/hidden.rb
+++ b/modules/auxiliary/scanner/dcerpc/hidden.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/dcerpc/management.rb
+++ b/modules/auxiliary/scanner/dcerpc/management.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/dcerpc/tcp_dcerpc_auditor.rb
+++ b/modules/auxiliary/scanner/dcerpc/tcp_dcerpc_auditor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
+++ b/modules/auxiliary/scanner/dcerpc/windows_deployment_services.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/dect/call_scanner.rb
+++ b/modules/auxiliary/scanner/dect/call_scanner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/dect/station_scanner.rb
+++ b/modules/auxiliary/scanner/dect/station_scanner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/discovery/arp_sweep.rb
+++ b/modules/auxiliary/scanner/discovery/arp_sweep.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/discovery/empty_udp.rb
+++ b/modules/auxiliary/scanner/discovery/empty_udp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/discovery/ipv6_multicast_ping.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_multicast_ping.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
+++ b/modules/auxiliary/scanner/discovery/ipv6_neighbor_router_advertisement.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/discovery/udp_probe.rb
+++ b/modules/auxiliary/scanner/discovery/udp_probe.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/discovery/udp_sweep.rb
+++ b/modules/auxiliary/scanner/discovery/udp_sweep.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/dns/dns_amp.rb
+++ b/modules/auxiliary/scanner/dns/dns_amp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/elasticsearch/indices_enum.rb
+++ b/modules/auxiliary/scanner/elasticsearch/indices_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/emc/alphastor_devicemanager.rb
+++ b/modules/auxiliary/scanner/emc/alphastor_devicemanager.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/emc/alphastor_librarymanager.rb
+++ b/modules/auxiliary/scanner/emc/alphastor_librarymanager.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/finger/finger_users.rb
+++ b/modules/auxiliary/scanner/finger/finger_users.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ftp/anonymous.rb
+++ b/modules/auxiliary/scanner/ftp/anonymous.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ftp/ftp_login.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ftp/ftp_version.rb
+++ b/modules/auxiliary/scanner/ftp/ftp_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ftp/titanftp_xcrc_traversal.rb
+++ b/modules/auxiliary/scanner/ftp/titanftp_xcrc_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/h323/h323_version.rb
+++ b/modules/auxiliary/scanner/h323/h323_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/a10networks_ax_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/a10networks_ax_directory_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/adobe_xml_inject.rb
+++ b/modules/auxiliary/scanner/http/adobe_xml_inject.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/apache_activemq_source_disclosure.rb
+++ b/modules/auxiliary/scanner/http/apache_activemq_source_disclosure.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/apache_activemq_traversal.rb
+++ b/modules/auxiliary/scanner/http/apache_activemq_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
+++ b/modules/auxiliary/scanner/http/apache_mod_cgi_bash_env.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/apache_userdir_enum.rb
+++ b/modules/auxiliary/scanner/http/apache_userdir_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/appletv_login.rb
+++ b/modules/auxiliary/scanner/http/appletv_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/atlassian_crowd_fileaccess.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/axis_local_file_include.rb
+++ b/modules/auxiliary/scanner/http/axis_local_file_include.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/axis_login.rb
+++ b/modules/auxiliary/scanner/http/axis_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/backup_file.rb
+++ b/modules/auxiliary/scanner/http/backup_file.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/barracuda_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/barracuda_directory_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/bitweaver_overlay_type_traversal.rb
+++ b/modules/auxiliary/scanner/http/bitweaver_overlay_type_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/blind_sql_query.rb
+++ b/modules/auxiliary/scanner/http/blind_sql_query.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/brute_dirs.rb
+++ b/modules/auxiliary/scanner/http/brute_dirs.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/canon_wireless.rb
+++ b/modules/auxiliary/scanner/http/canon_wireless.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/cert.rb
+++ b/modules/auxiliary/scanner/http/cert.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/cisco_asa_asdm.rb
+++ b/modules/auxiliary/scanner/http/cisco_asa_asdm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/cisco_device_manager.rb
+++ b/modules/auxiliary/scanner/http/cisco_device_manager.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/cisco_ios_auth_bypass.rb
+++ b/modules/auxiliary/scanner/http/cisco_ios_auth_bypass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
+++ b/modules/auxiliary/scanner/http/cisco_ironport_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/cisco_nac_manager_traversal.rb
+++ b/modules/auxiliary/scanner/http/cisco_nac_manager_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/cisco_ssl_vpn.rb
+++ b/modules/auxiliary/scanner/http/cisco_ssl_vpn.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/clansphere_traversal.rb
+++ b/modules/auxiliary/scanner/http/clansphere_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/cold_fusion_version.rb
+++ b/modules/auxiliary/scanner/http/cold_fusion_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/coldfusion_locale_traversal.rb
+++ b/modules/auxiliary/scanner/http/coldfusion_locale_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/concrete5_member_list.rb
+++ b/modules/auxiliary/scanner/http/concrete5_member_list.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/copy_of_file.rb
+++ b/modules/auxiliary/scanner/http/copy_of_file.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/crawler.rb
+++ b/modules/auxiliary/scanner/http/crawler.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/dell_idrac.rb
+++ b/modules/auxiliary/scanner/http/dell_idrac.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/dir_listing.rb
+++ b/modules/auxiliary/scanner/http/dir_listing.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/dir_scanner.rb
+++ b/modules/auxiliary/scanner/http/dir_scanner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/dir_webdav_unicode_bypass.rb
+++ b/modules/auxiliary/scanner/http/dir_webdav_unicode_bypass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/dlink_dir_300_615_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_300_615_http_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_615h_http_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/dlink_dir_session_cgi_http_login.rb
+++ b/modules/auxiliary/scanner/http/dlink_dir_session_cgi_http_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/dlink_user_agent_backdoor.rb
+++ b/modules/auxiliary/scanner/http/dlink_user_agent_backdoor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/dolibarr_login.rb
+++ b/modules/auxiliary/scanner/http/dolibarr_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
+++ b/modules/auxiliary/scanner/http/drupal_views_user_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/ektron_cms400net.rb
+++ b/modules/auxiliary/scanner/http/ektron_cms400net.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/enum_wayback.rb
+++ b/modules/auxiliary/scanner/http/enum_wayback.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/error_sql_injection.rb
+++ b/modules/auxiliary/scanner/http/error_sql_injection.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/etherpad_duo_login.rb
+++ b/modules/auxiliary/scanner/http/etherpad_duo_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/file_same_name_dir.rb
+++ b/modules/auxiliary/scanner/http/file_same_name_dir.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/files_dir.rb
+++ b/modules/auxiliary/scanner/http/files_dir.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/frontpage_login.rb
+++ b/modules/auxiliary/scanner/http/frontpage_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/glassfish_login.rb
+++ b/modules/auxiliary/scanner/http/glassfish_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/groupwise_agents_http_traversal.rb
+++ b/modules/auxiliary/scanner/http/groupwise_agents_http_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/hp_imc_bims_downloadservlet_traversal.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_bims_downloadservlet_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/hp_imc_faultdownloadservlet_traversal.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_faultdownloadservlet_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/hp_imc_ictdownloadservlet_traversal.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_ictdownloadservlet_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/hp_imc_reportimgservlt_traversal.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_reportimgservlt_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/hp_imc_som_file_download.rb
+++ b/modules/auxiliary/scanner/http/hp_imc_som_file_download.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/hp_sitescope_getfileinternal_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_getfileinternal_fileaccess.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/hp_sitescope_getsitescopeconfiguration.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_getsitescopeconfiguration.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/hp_sitescope_loadfilecontent_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/hp_sitescope_loadfilecontent_fileaccess.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
+++ b/modules/auxiliary/scanner/http/hp_sys_mgmt_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/http_header.rb
+++ b/modules/auxiliary/scanner/http/http_header.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/http_hsts.rb
+++ b/modules/auxiliary/scanner/http/http_hsts.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/http_put.rb
+++ b/modules/auxiliary/scanner/http/http_put.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/http_traversal.rb
+++ b/modules/auxiliary/scanner/http/http_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/http_version.rb
+++ b/modules/auxiliary/scanner/http/http_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/httpbl_lookup.rb
+++ b/modules/auxiliary/scanner/http/httpbl_lookup.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/iis_internal_ip.rb
+++ b/modules/auxiliary/scanner/http/iis_internal_ip.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/infovista_enum.rb
+++ b/modules/auxiliary/scanner/http/infovista_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/jboss_status.rb
+++ b/modules/auxiliary/scanner/http/jboss_status.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/jboss_vulnscan.rb
+++ b/modules/auxiliary/scanner/http/jboss_vulnscan.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/jenkins_enum.rb
+++ b/modules/auxiliary/scanner/http/jenkins_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/jenkins_login.rb
+++ b/modules/auxiliary/scanner/http/jenkins_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/joomla_bruteforce_login.rb
+++ b/modules/auxiliary/scanner/http/joomla_bruteforce_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/joomla_pages.rb
+++ b/modules/auxiliary/scanner/http/joomla_pages.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 require 'msf/core'

--- a/modules/auxiliary/scanner/http/joomla_plugins.rb
+++ b/modules/auxiliary/scanner/http/joomla_plugins.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 require 'msf/core'

--- a/modules/auxiliary/scanner/http/joomla_version.rb
+++ b/modules/auxiliary/scanner/http/joomla_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 require 'msf/core'

--- a/modules/auxiliary/scanner/http/linksys_e1500_traversal.rb
+++ b/modules/auxiliary/scanner/http/linksys_e1500_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/litespeed_source_disclosure.rb
+++ b/modules/auxiliary/scanner/http/litespeed_source_disclosure.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/lucky_punch.rb
+++ b/modules/auxiliary/scanner/http/lucky_punch.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/majordomo2_directory_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/manageengine_deviceexpert_traversal.rb
+++ b/modules/auxiliary/scanner/http/manageengine_deviceexpert_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/manageengine_deviceexpert_user_creds.rb
+++ b/modules/auxiliary/scanner/http/manageengine_deviceexpert_user_creds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/manageengine_securitymanager_traversal.rb
+++ b/modules/auxiliary/scanner/http/manageengine_securitymanager_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/mediawiki_svg_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/mediawiki_svg_fileaccess.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/mod_negotiation_brute.rb
+++ b/modules/auxiliary/scanner/http/mod_negotiation_brute.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/mod_negotiation_scanner.rb
+++ b/modules/auxiliary/scanner/http/mod_negotiation_scanner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/ms09_020_webdav_unicode_bypass.rb
+++ b/modules/auxiliary/scanner/http/ms09_020_webdav_unicode_bypass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/netdecision_traversal.rb
+++ b/modules/auxiliary/scanner/http/netdecision_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/netgear_sph200d_traversal.rb
+++ b/modules/auxiliary/scanner/http/netgear_sph200d_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/nginx_source_disclosure.rb
+++ b/modules/auxiliary/scanner/http/nginx_source_disclosure.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/novell_file_reporter_fsfui_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/novell_file_reporter_fsfui_fileaccess.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/novell_file_reporter_srs_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/novell_file_reporter_srs_fileaccess.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/novell_mdm_creds.rb
+++ b/modules/auxiliary/scanner/http/novell_mdm_creds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/ntlm_info_enumeration.rb
+++ b/modules/auxiliary/scanner/http/ntlm_info_enumeration.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 require 'msf/core'

--- a/modules/auxiliary/scanner/http/open_proxy.rb
+++ b/modules/auxiliary/scanner/http/open_proxy.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/openmind_messageos_login.rb
+++ b/modules/auxiliary/scanner/http/openmind_messageos_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/options.rb
+++ b/modules/auxiliary/scanner/http/options.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/oracle_demantra_database_credentials_leak.rb
+++ b/modules/auxiliary/scanner/http/oracle_demantra_database_credentials_leak.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/oracle_demantra_file_retrieval.rb
+++ b/modules/auxiliary/scanner/http/oracle_demantra_file_retrieval.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/oracle_ilom_login.rb
+++ b/modules/auxiliary/scanner/http/oracle_ilom_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/owa_login.rb
+++ b/modules/auxiliary/scanner/http/owa_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/pocketpad_login.rb
+++ b/modules/auxiliary/scanner/http/pocketpad_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/prev_dir_same_name_file.rb
+++ b/modules/auxiliary/scanner/http/prev_dir_same_name_file.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/radware_appdirector_enum.rb
+++ b/modules/auxiliary/scanner/http/radware_appdirector_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/rails_json_yaml_scanner.rb
+++ b/modules/auxiliary/scanner/http/rails_json_yaml_scanner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/rails_mass_assignment.rb
+++ b/modules/auxiliary/scanner/http/rails_mass_assignment.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/rails_xml_yaml_scanner.rb
+++ b/modules/auxiliary/scanner/http/rails_xml_yaml_scanner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/replace_ext.rb
+++ b/modules/auxiliary/scanner/http/replace_ext.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/rewrite_proxy_bypass.rb
+++ b/modules/auxiliary/scanner/http/rewrite_proxy_bypass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/rfcode_reader_enum.rb
+++ b/modules/auxiliary/scanner/http/rfcode_reader_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/robots_txt.rb
+++ b/modules/auxiliary/scanner/http/robots_txt.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/s40_traversal.rb
+++ b/modules/auxiliary/scanner/http/s40_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/sap_businessobjects_user_brute.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_user_brute.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/sap_businessobjects_user_brute_web.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_user_brute_web.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/sap_businessobjects_user_enum.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_user_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/sap_businessobjects_version_enum.rb
+++ b/modules/auxiliary/scanner/http/sap_businessobjects_version_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/scraper.rb
+++ b/modules/auxiliary/scanner/http/scraper.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/sentry_cdu_enum.rb
+++ b/modules/auxiliary/scanner/http/sentry_cdu_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/sevone_enum.rb
+++ b/modules/auxiliary/scanner/http/sevone_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/simple_webserver_traversal.rb
+++ b/modules/auxiliary/scanner/http/simple_webserver_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/smt_ipmi_49152_exposure.rb
+++ b/modules/auxiliary/scanner/http/smt_ipmi_49152_exposure.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/smt_ipmi_cgi_scanner.rb
+++ b/modules/auxiliary/scanner/http/smt_ipmi_cgi_scanner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/smt_ipmi_static_cert_scanner.rb
+++ b/modules/auxiliary/scanner/http/smt_ipmi_static_cert_scanner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/smt_ipmi_url_redirect_traversal.rb
+++ b/modules/auxiliary/scanner/http/smt_ipmi_url_redirect_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/soap_xml.rb
+++ b/modules/auxiliary/scanner/http/soap_xml.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/sockso_traversal.rb
+++ b/modules/auxiliary/scanner/http/sockso_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/splunk_web_login.rb
+++ b/modules/auxiliary/scanner/http/splunk_web_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
+++ b/modules/auxiliary/scanner/http/squid_pivot_scanning.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/squiz_matrix_user_enum.rb
+++ b/modules/auxiliary/scanner/http/squiz_matrix_user_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/ssl.rb
+++ b/modules/auxiliary/scanner/http/ssl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/support_center_plus_directory_traversal.rb
+++ b/modules/auxiliary/scanner/http/support_center_plus_directory_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/svn_scanner.rb
+++ b/modules/auxiliary/scanner/http/svn_scanner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/svn_wcdb_scanner.rb
+++ b/modules/auxiliary/scanner/http/svn_wcdb_scanner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/sybase_easerver_traversal.rb
+++ b/modules/auxiliary/scanner/http/sybase_easerver_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/symantec_brightmail_logfile.rb
+++ b/modules/auxiliary/scanner/http/symantec_brightmail_logfile.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/titan_ftp_admin_pwd.rb
+++ b/modules/auxiliary/scanner/http/titan_ftp_admin_pwd.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/tomcat_enum.rb
+++ b/modules/auxiliary/scanner/http/tomcat_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
+++ b/modules/auxiliary/scanner/http/tomcat_mgr_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/tplink_traversal_noauth.rb
+++ b/modules/auxiliary/scanner/http/tplink_traversal_noauth.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/trace.rb
+++ b/modules/auxiliary/scanner/http/trace.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/trace_axd.rb
+++ b/modules/auxiliary/scanner/http/trace_axd.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/typo3_bruteforce.rb
+++ b/modules/auxiliary/scanner/http/typo3_bruteforce.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/vcms_login.rb
+++ b/modules/auxiliary/scanner/http/vcms_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/verb_auth_bypass.rb
+++ b/modules/auxiliary/scanner/http/verb_auth_bypass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/vhost_scanner.rb
+++ b/modules/auxiliary/scanner/http/vhost_scanner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/vmware_server_dir_trav.rb
+++ b/modules/auxiliary/scanner/http/vmware_server_dir_trav.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/vmware_update_manager_traversal.rb
+++ b/modules/auxiliary/scanner/http/vmware_update_manager_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/wangkongbao_traversal.rb
+++ b/modules/auxiliary/scanner/http/wangkongbao_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/web_vulndb.rb
+++ b/modules/auxiliary/scanner/http/web_vulndb.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/webdav_internal_ip.rb
+++ b/modules/auxiliary/scanner/http/webdav_internal_ip.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/webdav_scanner.rb
+++ b/modules/auxiliary/scanner/http/webdav_scanner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/webdav_website_content.rb
+++ b/modules/auxiliary/scanner/http/webdav_website_content.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/webpagetest_traversal.rb
+++ b/modules/auxiliary/scanner/http/webpagetest_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/wordpress_login_enum.rb
+++ b/modules/auxiliary/scanner/http/wordpress_login_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/wordpress_pingback_access.rb
+++ b/modules/auxiliary/scanner/http/wordpress_pingback_access.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/wordpress_scanner.rb
+++ b/modules/auxiliary/scanner/http/wordpress_scanner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
+++ b/modules/auxiliary/scanner/http/wordpress_xmlrpc_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/xpath.rb
+++ b/modules/auxiliary/scanner/http/xpath.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/yaws_traversal.rb
+++ b/modules/auxiliary/scanner/http/yaws_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/zenworks_assetmanagement_fileaccess.rb
+++ b/modules/auxiliary/scanner/http/zenworks_assetmanagement_fileaccess.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/http/zenworks_assetmanagement_getconfig.rb
+++ b/modules/auxiliary/scanner/http/zenworks_assetmanagement_getconfig.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/imap/imap_version.rb
+++ b/modules/auxiliary/scanner/imap/imap_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ip/ipidseq.rb
+++ b/modules/auxiliary/scanner/ip/ipidseq.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_cipher_zero.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_dumphashes.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ipmi/ipmi_version.rb
+++ b/modules/auxiliary/scanner/ipmi/ipmi_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_hashes.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/lotus/lotus_domino_login.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/lotus/lotus_domino_version.rb
+++ b/modules/auxiliary/scanner/lotus/lotus_domino_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/misc/cctv_dvr_login.rb
+++ b/modules/auxiliary/scanner/misc/cctv_dvr_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/misc/dvr_config_disclosure.rb
+++ b/modules/auxiliary/scanner/misc/dvr_config_disclosure.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/misc/ib_service_mgr_info.rb
+++ b/modules/auxiliary/scanner/misc/ib_service_mgr_info.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/misc/java_rmi_server.rb
+++ b/modules/auxiliary/scanner/misc/java_rmi_server.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/misc/oki_scanner.rb
+++ b/modules/auxiliary/scanner/misc/oki_scanner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/misc/poisonivy_control_scanner.rb
+++ b/modules/auxiliary/scanner/misc/poisonivy_control_scanner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/misc/raysharp_dvr_passwords.rb
+++ b/modules/auxiliary/scanner/misc/raysharp_dvr_passwords.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/misc/redis_server.rb
+++ b/modules/auxiliary/scanner/misc/redis_server.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/misc/rosewill_rxs3211_passwords.rb
+++ b/modules/auxiliary/scanner/misc/rosewill_rxs3211_passwords.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/misc/sercomm_backdoor_scanner.rb
+++ b/modules/auxiliary/scanner/misc/sercomm_backdoor_scanner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
+++ b/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/misc/zenworks_preboot_fileaccess.rb
+++ b/modules/auxiliary/scanner/misc/zenworks_preboot_fileaccess.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/mongodb/mongodb_login.rb
+++ b/modules/auxiliary/scanner/mongodb/mongodb_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/motorola/timbuktu_udp.rb
+++ b/modules/auxiliary/scanner/motorola/timbuktu_udp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/msf/msf_rpc_login.rb
+++ b/modules/auxiliary/scanner/msf/msf_rpc_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/msf/msf_web_login.rb
+++ b/modules/auxiliary/scanner/msf/msf_web_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_hashdump.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/mssql/mssql_login.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/mssql/mssql_ping.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_ping.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
+++ b/modules/auxiliary/scanner/mssql/mssql_schemadump.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_authbypass_hashdump.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_file_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_hashdump.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/mysql/mysql_login.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_schemadump.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/mysql/mysql_version.rb
+++ b/modules/auxiliary/scanner/mysql/mysql_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/natpmp/natpmp_portscan.rb
+++ b/modules/auxiliary/scanner/natpmp/natpmp_portscan.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/nessus/nessus_ntp_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_ntp_login.rb
@@ -2,7 +2,7 @@
 # nessus_ntp_login.rb
 ##
 
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/nessus/nessus_xmlrpc_login.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_xmlrpc_login.rb
@@ -3,7 +3,7 @@
 ##
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/nessus/nessus_xmlrpc_ping.rb
+++ b/modules/auxiliary/scanner/nessus/nessus_xmlrpc_ping.rb
@@ -3,7 +3,7 @@
 ##
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/netbios/nbname.rb
+++ b/modules/auxiliary/scanner/netbios/nbname.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/netbios/nbname_probe.rb
+++ b/modules/auxiliary/scanner/netbios/nbname_probe.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/nexpose/nexpose_api_login.rb
+++ b/modules/auxiliary/scanner/nexpose/nexpose_api_login.rb
@@ -3,7 +3,7 @@
 ##
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/nfs/nfsmount.rb
+++ b/modules/auxiliary/scanner/nfs/nfsmount.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ntp/ntp_monlist.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_monlist.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ntp/ntp_peer_list_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_peer_list_dos.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ntp/ntp_peer_list_sum_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_peer_list_sum_dos.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ntp/ntp_readvar.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_readvar.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ntp/ntp_req_nonce_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_req_nonce_dos.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ntp/ntp_reslist_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_reslist_dos.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ntp/ntp_unsettrap_dos.rb
+++ b/modules/auxiliary/scanner/ntp/ntp_unsettrap_dos.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/openvas/openvas_gsad_login.rb
+++ b/modules/auxiliary/scanner/openvas/openvas_gsad_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/openvas/openvas_omp_login.rb
+++ b/modules/auxiliary/scanner/openvas/openvas_omp_login.rb
@@ -1,4 +1,4 @@
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/openvas/openvas_otp_login.rb
+++ b/modules/auxiliary/scanner/openvas/openvas_otp_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/oracle/emc_sid.rb
+++ b/modules/auxiliary/scanner/oracle/emc_sid.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/oracle/isqlplus_login.rb
+++ b/modules/auxiliary/scanner/oracle/isqlplus_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/oracle/isqlplus_sidbrute.rb
+++ b/modules/auxiliary/scanner/oracle/isqlplus_sidbrute.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/oracle/oracle_hashdump.rb
+++ b/modules/auxiliary/scanner/oracle/oracle_hashdump.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/oracle/oracle_login.rb
+++ b/modules/auxiliary/scanner/oracle/oracle_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/oracle/sid_brute.rb
+++ b/modules/auxiliary/scanner/oracle/sid_brute.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/oracle/sid_enum.rb
+++ b/modules/auxiliary/scanner/oracle/sid_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/oracle/spy_sid.rb
+++ b/modules/auxiliary/scanner/oracle/spy_sid.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/oracle/tnslsnr_version.rb
+++ b/modules/auxiliary/scanner/oracle/tnslsnr_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/oracle/xdb_sid.rb
+++ b/modules/auxiliary/scanner/oracle/xdb_sid.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/oracle/xdb_sid_brute.rb
+++ b/modules/auxiliary/scanner/oracle/xdb_sid_brute.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/pcanywhere/pcanywhere_login.rb
+++ b/modules/auxiliary/scanner/pcanywhere/pcanywhere_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/pcanywhere/pcanywhere_tcp.rb
+++ b/modules/auxiliary/scanner/pcanywhere/pcanywhere_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/pcanywhere/pcanywhere_udp.rb
+++ b/modules/auxiliary/scanner/pcanywhere/pcanywhere_udp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/pop3/pop3_login.rb
+++ b/modules/auxiliary/scanner/pop3/pop3_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/pop3/pop3_version.rb
+++ b/modules/auxiliary/scanner/pop3/pop3_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/portscan/ack.rb
+++ b/modules/auxiliary/scanner/portscan/ack.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/portscan/ftpbounce.rb
+++ b/modules/auxiliary/scanner/portscan/ftpbounce.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/portscan/syn.rb
+++ b/modules/auxiliary/scanner/portscan/syn.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/portscan/tcp.rb
+++ b/modules/auxiliary/scanner/portscan/tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/portscan/xmas.rb
+++ b/modules/auxiliary/scanner/portscan/xmas.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/postgres/postgres_dbname_flag_injection.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_dbname_flag_injection.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/postgres/postgres_hashdump.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_hashdump.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/postgres/postgres_login.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/postgres/postgres_schemadump.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_schemadump.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/postgres/postgres_version.rb
+++ b/modules/auxiliary/scanner/postgres/postgres_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/printer/printer_download_file.rb
+++ b/modules/auxiliary/scanner/printer/printer_download_file.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/printer/printer_env_vars.rb
+++ b/modules/auxiliary/scanner/printer/printer_env_vars.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/printer/printer_list_dir.rb
+++ b/modules/auxiliary/scanner/printer/printer_list_dir.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/printer/printer_list_volumes.rb
+++ b/modules/auxiliary/scanner/printer/printer_list_volumes.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/printer/printer_ready_message.rb
+++ b/modules/auxiliary/scanner/printer/printer_ready_message.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/printer/printer_version_info.rb
+++ b/modules/auxiliary/scanner/printer/printer_version_info.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/rdp/ms12_020_check.rb
+++ b/modules/auxiliary/scanner/rdp/ms12_020_check.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/rogue/rogue_recv.rb
+++ b/modules/auxiliary/scanner/rogue/rogue_recv.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/rogue/rogue_send.rb
+++ b/modules/auxiliary/scanner/rogue/rogue_send.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/rservices/rexec_login.rb
+++ b/modules/auxiliary/scanner/rservices/rexec_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/rservices/rlogin_login.rb
+++ b/modules/auxiliary/scanner/rservices/rlogin_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/rservices/rsh_login.rb
+++ b/modules/auxiliary/scanner/rservices/rsh_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_ctc_verb_tampering_user_mgmt.rb
+++ b/modules/auxiliary/scanner/sap/sap_ctc_verb_tampering_user_mgmt.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_hostctrl_getcomputersystem.rb
+++ b/modules/auxiliary/scanner/sap/sap_hostctrl_getcomputersystem.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_icf_public_info.rb
+++ b/modules/auxiliary/scanner/sap/sap_icf_public_info.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_icm_urlscan.rb
+++ b/modules/auxiliary/scanner/sap/sap_icm_urlscan.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_abaplog.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_abaplog.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_brute_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_extractusers.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_extractusers.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getaccesspoints.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getaccesspoints.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getenv.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getenv.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getlogfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getlogfiles.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocesslist.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocesslist.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocessparameter.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_getprocessparameter.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_instanceproperties.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_listlogfiles.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_startprofile.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_startprofile.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_mgmt_con_version.rb
+++ b/modules/auxiliary/scanner/sap/sap_mgmt_con_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_router_info_request.rb
+++ b/modules/auxiliary/scanner/sap/sap_router_info_request.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_router_portscanner.rb
+++ b/modules/auxiliary/scanner/sap/sap_router_portscanner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_service_discovery.rb
+++ b/modules/auxiliary/scanner/sap/sap_service_discovery.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_smb_relay.rb
+++ b/modules/auxiliary/scanner/sap/sap_smb_relay.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_bapi_user_create1.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_brute_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_call_system_command_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_dbmcli_sxpg_command_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_eps_get_directory_listing.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_eps_get_directory_listing.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_pfl_check_os_file_existence.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_pfl_check_os_file_existence.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_ping.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_read_table.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_read_table.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_rzl_read_dir.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_rzl_read_dir.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_susr_rfc_user_interface.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_call_system_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_call_system_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_command_exec.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_sxpg_command_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_rfc_system_info.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_soap_th_saprel_disclosure.rb
+++ b/modules/auxiliary/scanner/sap/sap_soap_th_saprel_disclosure.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sap/sap_web_gui_brute_login.rb
+++ b/modules/auxiliary/scanner/sap/sap_web_gui_brute_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/scada/digi_addp_reboot.rb
+++ b/modules/auxiliary/scanner/scada/digi_addp_reboot.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/scada/digi_addp_version.rb
+++ b/modules/auxiliary/scanner/scada/digi_addp_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/scada/digi_realport_serialport_scan.rb
+++ b/modules/auxiliary/scanner/scada/digi_realport_serialport_scan.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/scada/digi_realport_version.rb
+++ b/modules/auxiliary/scanner/scada/digi_realport_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/scada/indusoft_ntwebserver_fileaccess.rb
+++ b/modules/auxiliary/scanner/scada/indusoft_ntwebserver_fileaccess.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/scada/koyo_login.rb
+++ b/modules/auxiliary/scanner/scada/koyo_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/scada/modbus_findunitid.rb
+++ b/modules/auxiliary/scanner/scada/modbus_findunitid.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/scada/modbusclient.rb
+++ b/modules/auxiliary/scanner/scada/modbusclient.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/scada/modbusdetect.rb
+++ b/modules/auxiliary/scanner/scada/modbusdetect.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/scada/sielco_winlog_fileaccess.rb
+++ b/modules/auxiliary/scanner/scada/sielco_winlog_fileaccess.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sip/enumerator.rb
+++ b/modules/auxiliary/scanner/sip/enumerator.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sip/enumerator_tcp.rb
+++ b/modules/auxiliary/scanner/sip/enumerator_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sip/options.rb
+++ b/modules/auxiliary/scanner/sip/options.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sip/options_tcp.rb
+++ b/modules/auxiliary/scanner/sip/options_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/sip/sipdroid_ext_enum.rb
+++ b/modules/auxiliary/scanner/sip/sipdroid_ext_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/smb/pipe_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_auditor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
+++ b/modules/auxiliary/scanner/smb/pipe_dcerpc_auditor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/smb/psexec_loggedin_users.rb
+++ b/modules/auxiliary/scanner/smb/psexec_loggedin_users.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/smb/smb2.rb
+++ b/modules/auxiliary/scanner/smb/smb2.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/smb/smb_enumshares.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumshares.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/smb/smb_enumusers.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
+++ b/modules/auxiliary/scanner/smb/smb_enumusers_domain.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/smb/smb_login.rb
+++ b/modules/auxiliary/scanner/smb/smb_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/smb/smb_lookupsid.rb
+++ b/modules/auxiliary/scanner/smb/smb_lookupsid.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/smb/smb_version.rb
+++ b/modules/auxiliary/scanner/smb/smb_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/smtp/smtp_enum.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/smtp/smtp_relay.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_relay.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/smtp/smtp_version.rb
+++ b/modules/auxiliary/scanner/smtp/smtp_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/snmp/aix_version.rb
+++ b/modules/auxiliary/scanner/snmp/aix_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/snmp/arris_dg950.rb
+++ b/modules/auxiliary/scanner/snmp/arris_dg950.rb
@@ -1,5 +1,5 @@
 #
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/snmp/brocade_enumhash.rb
+++ b/modules/auxiliary/scanner/snmp/brocade_enumhash.rb
@@ -1,5 +1,5 @@
 #
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/snmp/cisco_config_tftp.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_config_tftp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
+++ b/modules/auxiliary/scanner/snmp/cisco_upload_file.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/snmp/netopia_enum.rb
+++ b/modules/auxiliary/scanner/snmp/netopia_enum.rb
@@ -1,5 +1,5 @@
 #
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/snmp/sbg6580_enum.rb
+++ b/modules/auxiliary/scanner/snmp/sbg6580_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/snmp/snmp_enum.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/snmp/snmp_enum_hp_laserjet.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enum_hp_laserjet.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/snmp/snmp_enumshares.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enumshares.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/snmp/snmp_enumusers.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_enumusers.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/snmp/snmp_login.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/snmp/snmp_set.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_set.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/snmp/ubee_ddw3611.rb
+++ b/modules/auxiliary/scanner/snmp/ubee_ddw3611.rb
@@ -1,5 +1,5 @@
 #
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/snmp/xerox_workcentre_enumusers.rb
+++ b/modules/auxiliary/scanner/snmp/xerox_workcentre_enumusers.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ssh/cerberus_sftp_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/cerberus_sftp_enumusers.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_enumusers.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_identify_pubkeys.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ssh/ssh_login.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_login_pubkey.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ssh/ssh_version.rb
+++ b/modules/auxiliary/scanner/ssh/ssh_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ssl/openssl_ccs.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_ccs.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
+++ b/modules/auxiliary/scanner/ssl/openssl_heartbleed.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/telephony/wardial.rb
+++ b/modules/auxiliary/scanner/telephony/wardial.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/telnet/lantronix_telnet_password.rb
+++ b/modules/auxiliary/scanner/telnet/lantronix_telnet_password.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/telnet/lantronix_telnet_version.rb
+++ b/modules/auxiliary/scanner/telnet/lantronix_telnet_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/telnet/telnet_encrypt_overflow.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_encrypt_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/telnet/telnet_login.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/telnet/telnet_ruggedcom.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_ruggedcom.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/telnet/telnet_version.rb
+++ b/modules/auxiliary/scanner/telnet/telnet_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/tftp/ipswitch_whatsupgold_tftp.rb
+++ b/modules/auxiliary/scanner/tftp/ipswitch_whatsupgold_tftp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/tftp/netdecision_tftp.rb
+++ b/modules/auxiliary/scanner/tftp/netdecision_tftp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/tftp/tftpbrute.rb
+++ b/modules/auxiliary/scanner/tftp/tftpbrute.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/upnp/ssdp_amp.rb
+++ b/modules/auxiliary/scanner/upnp/ssdp_amp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/upnp/ssdp_msearch.rb
+++ b/modules/auxiliary/scanner/upnp/ssdp_msearch.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/vmware/esx_fingerprint.rb
+++ b/modules/auxiliary/scanner/vmware/esx_fingerprint.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/vmware/vmauthd_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmauthd_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/vmware/vmauthd_version.rb
+++ b/modules/auxiliary/scanner/vmware/vmauthd_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/vmware/vmware_enum_permissions.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_permissions.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/vmware/vmware_enum_sessions.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_sessions.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/vmware/vmware_enum_users.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_users.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/vmware/vmware_enum_vms.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_enum_vms.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/vmware/vmware_host_details.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_host_details.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/vmware/vmware_http_login.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_http_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/vmware/vmware_screenshot_stealer.rb
+++ b/modules/auxiliary/scanner/vmware/vmware_screenshot_stealer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/vnc/vnc_login.rb
+++ b/modules/auxiliary/scanner/vnc/vnc_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/vnc/vnc_none_auth.rb
+++ b/modules/auxiliary/scanner/vnc/vnc_none_auth.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/voice/recorder.rb
+++ b/modules/auxiliary/scanner/voice/recorder.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/vxworks/wdbrpc_bootline.rb
+++ b/modules/auxiliary/scanner/vxworks/wdbrpc_bootline.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/vxworks/wdbrpc_version.rb
+++ b/modules/auxiliary/scanner/vxworks/wdbrpc_version.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/winrm/winrm_auth_methods.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_auth_methods.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/winrm/winrm_cmd.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_cmd.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/winrm/winrm_login.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/winrm/winrm_wql.rb
+++ b/modules/auxiliary/scanner/winrm/winrm_wql.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/scanner/x11/open_x11.rb
+++ b/modules/auxiliary/scanner/x11/open_x11.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/capture/drda.rb
+++ b/modules/auxiliary/server/capture/drda.rb
@@ -1,7 +1,7 @@
 # -*- coding: binary -*-
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/capture/ftp.rb
+++ b/modules/auxiliary/server/capture/ftp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/capture/http.rb
+++ b/modules/auxiliary/server/capture/http.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/capture/http_basic.rb
+++ b/modules/auxiliary/server/capture/http_basic.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/capture/http_javascript_keylogger.rb
+++ b/modules/auxiliary/server/capture/http_javascript_keylogger.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/capture/http_ntlm.rb
+++ b/modules/auxiliary/server/capture/http_ntlm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/capture/imap.rb
+++ b/modules/auxiliary/server/capture/imap.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/capture/mssql.rb
+++ b/modules/auxiliary/server/capture/mssql.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/capture/mysql.rb
+++ b/modules/auxiliary/server/capture/mysql.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/capture/pop3.rb
+++ b/modules/auxiliary/server/capture/pop3.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/capture/postgresql.rb
+++ b/modules/auxiliary/server/capture/postgresql.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/capture/printjob_capture.rb
+++ b/modules/auxiliary/server/capture/printjob_capture.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/capture/sip.rb
+++ b/modules/auxiliary/server/capture/sip.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/capture/smb.rb
+++ b/modules/auxiliary/server/capture/smb.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/capture/smtp.rb
+++ b/modules/auxiliary/server/capture/smtp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/capture/telnet.rb
+++ b/modules/auxiliary/server/capture/telnet.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/capture/vnc.rb
+++ b/modules/auxiliary/server/capture/vnc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/dhclient_bash_env.rb
+++ b/modules/auxiliary/server/dhclient_bash_env.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/dhcp.rb
+++ b/modules/auxiliary/server/dhcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/dns/spoofhelper.rb
+++ b/modules/auxiliary/server/dns/spoofhelper.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/fakedns.rb
+++ b/modules/auxiliary/server/fakedns.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/ftp.rb
+++ b/modules/auxiliary/server/ftp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/http_ntlmrelay.rb
+++ b/modules/auxiliary/server/http_ntlmrelay.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/icmp_exfil.rb
+++ b/modules/auxiliary/server/icmp_exfil.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
+++ b/modules/auxiliary/server/openssl_heartbeat_client_memory.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/pxexploit.rb
+++ b/modules/auxiliary/server/pxexploit.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/socks4a.rb
+++ b/modules/auxiliary/server/socks4a.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/socks_unc.rb
+++ b/modules/auxiliary/server/socks_unc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/tftp.rb
+++ b/modules/auxiliary/server/tftp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/webkit_xslt_dropper.rb
+++ b/modules/auxiliary/server/webkit_xslt_dropper.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/server/wpad.rb
+++ b/modules/auxiliary/server/wpad.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/sniffer/psnuffle.rb
+++ b/modules/auxiliary/sniffer/psnuffle.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/spoof/arp/arp_poisoning.rb
+++ b/modules/auxiliary/spoof/arp/arp_poisoning.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/spoof/cisco/dtp.rb
+++ b/modules/auxiliary/spoof/cisco/dtp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/spoof/dns/bailiwicked_domain.rb
+++ b/modules/auxiliary/spoof/dns/bailiwicked_domain.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/spoof/dns/bailiwicked_host.rb
+++ b/modules/auxiliary/spoof/dns/bailiwicked_host.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/spoof/dns/compare_results.rb
+++ b/modules/auxiliary/spoof/dns/compare_results.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/spoof/llmnr/llmnr_response.rb
+++ b/modules/auxiliary/spoof/llmnr/llmnr_response.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/spoof/nbns/nbns_response.rb
+++ b/modules/auxiliary/spoof/nbns/nbns_response.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/spoof/replay/pcap_replay.rb
+++ b/modules/auxiliary/spoof/replay/pcap_replay.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/sqli/oracle/dbms_cdc_ipublish.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_cdc_ipublish.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/sqli/oracle/dbms_cdc_publish.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_cdc_publish.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/sqli/oracle/dbms_cdc_publish2.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_cdc_publish2.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/sqli/oracle/dbms_cdc_publish3.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_cdc_publish3.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/sqli/oracle/dbms_cdc_subscribe_activate_subscription.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_cdc_subscribe_activate_subscription.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/sqli/oracle/dbms_export_extension.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_export_extension.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/sqli/oracle/dbms_metadata_get_granted_xml.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_metadata_get_granted_xml.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/sqli/oracle/dbms_metadata_get_xml.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_metadata_get_xml.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/sqli/oracle/dbms_metadata_open.rb
+++ b/modules/auxiliary/sqli/oracle/dbms_metadata_open.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/sqli/oracle/droptable_trigger.rb
+++ b/modules/auxiliary/sqli/oracle/droptable_trigger.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/sqli/oracle/jvm_os_code_10g.rb
+++ b/modules/auxiliary/sqli/oracle/jvm_os_code_10g.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/sqli/oracle/jvm_os_code_11g.rb
+++ b/modules/auxiliary/sqli/oracle/jvm_os_code_11g.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/sqli/oracle/lt_compressworkspace.rb
+++ b/modules/auxiliary/sqli/oracle/lt_compressworkspace.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/sqli/oracle/lt_findricset_cursor.rb
+++ b/modules/auxiliary/sqli/oracle/lt_findricset_cursor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/sqli/oracle/lt_mergeworkspace.rb
+++ b/modules/auxiliary/sqli/oracle/lt_mergeworkspace.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/sqli/oracle/lt_removeworkspace.rb
+++ b/modules/auxiliary/sqli/oracle/lt_removeworkspace.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/sqli/oracle/lt_rollbackworkspace.rb
+++ b/modules/auxiliary/sqli/oracle/lt_rollbackworkspace.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/voip/asterisk_login.rb
+++ b/modules/auxiliary/voip/asterisk_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/voip/sip_deregister.rb
+++ b/modules/auxiliary/voip/sip_deregister.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/voip/sip_invite_spoof.rb
+++ b/modules/auxiliary/voip/sip_invite_spoof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/vsploit/malware/dns/dns_mariposa.rb
+++ b/modules/auxiliary/vsploit/malware/dns/dns_mariposa.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/vsploit/malware/dns/dns_query.rb
+++ b/modules/auxiliary/vsploit/malware/dns/dns_query.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/vsploit/malware/dns/dns_zeus.rb
+++ b/modules/auxiliary/vsploit/malware/dns/dns_zeus.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/vsploit/pii/email_pii.rb
+++ b/modules/auxiliary/vsploit/pii/email_pii.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/vsploit/pii/web_pii.rb
+++ b/modules/auxiliary/vsploit/pii/web_pii.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/cmd/generic_sh.rb
+++ b/modules/encoders/cmd/generic_sh.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/cmd/ifs.rb
+++ b/modules/encoders/cmd/ifs.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/cmd/powershell_base64.rb
+++ b/modules/encoders/cmd/powershell_base64.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/cmd/printf_php_mq.rb
+++ b/modules/encoders/cmd/printf_php_mq.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/generic/eicar.rb
+++ b/modules/encoders/generic/eicar.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/generic/none.rb
+++ b/modules/encoders/generic/none.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/mipsbe/byte_xori.rb
+++ b/modules/encoders/mipsbe/byte_xori.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/mipsbe/longxor.rb
+++ b/modules/encoders/mipsbe/longxor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/mipsle/byte_xori.rb
+++ b/modules/encoders/mipsle/byte_xori.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/mipsle/longxor.rb
+++ b/modules/encoders/mipsle/longxor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/php/base64.rb
+++ b/modules/encoders/php/base64.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/ppc/longxor.rb
+++ b/modules/encoders/ppc/longxor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/ppc/longxor_tag.rb
+++ b/modules/encoders/ppc/longxor_tag.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/sparc/longxor_tag.rb
+++ b/modules/encoders/sparc/longxor_tag.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x64/xor.rb
+++ b/modules/encoders/x64/xor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/add_sub.rb
+++ b/modules/encoders/x86/add_sub.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/alpha_mixed.rb
+++ b/modules/encoders/x86/alpha_mixed.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/alpha_upper.rb
+++ b/modules/encoders/x86/alpha_upper.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/avoid_underscore_tolower.rb
+++ b/modules/encoders/x86/avoid_underscore_tolower.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/avoid_utf8_tolower.rb
+++ b/modules/encoders/x86/avoid_utf8_tolower.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/bloxor.rb
+++ b/modules/encoders/x86/bloxor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/call4_dword_xor.rb
+++ b/modules/encoders/x86/call4_dword_xor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/context_cpuid.rb
+++ b/modules/encoders/x86/context_cpuid.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/context_stat.rb
+++ b/modules/encoders/x86/context_stat.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/context_time.rb
+++ b/modules/encoders/x86/context_time.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/countdown.rb
+++ b/modules/encoders/x86/countdown.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/fnstenv_mov.rb
+++ b/modules/encoders/x86/fnstenv_mov.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/jmp_call_additive.rb
+++ b/modules/encoders/x86/jmp_call_additive.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/nonalpha.rb
+++ b/modules/encoders/x86/nonalpha.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/nonupper.rb
+++ b/modules/encoders/x86/nonupper.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/opt_sub.rb
+++ b/modules/encoders/x86/opt_sub.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/shikata_ga_nai.rb
+++ b/modules/encoders/x86/shikata_ga_nai.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/single_static_bit.rb
+++ b/modules/encoders/x86/single_static_bit.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/unicode_mixed.rb
+++ b/modules/encoders/x86/unicode_mixed.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/encoders/x86/unicode_upper.rb
+++ b/modules/encoders/x86/unicode_upper.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/aix/local/ibstat_path.rb
+++ b/modules/exploits/aix/local/ibstat_path.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/aix/rpc_cmsd_opcode21.rb
+++ b/modules/exploits/aix/rpc_cmsd_opcode21.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/aix/rpc_ttdbserverd_realpath.rb
+++ b/modules/exploits/aix/rpc_ttdbserverd_realpath.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/android/browser/webview_addjavascriptinterface.rb
+++ b/modules/exploits/android/browser/webview_addjavascriptinterface.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/android/fileformat/adobe_reader_pdf_js_interface.rb
+++ b/modules/exploits/android/fileformat/adobe_reader_pdf_js_interface.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/apple_ios/browser/safari_libtiff.rb
+++ b/modules/exploits/apple_ios/browser/safari_libtiff.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/apple_ios/email/mobilemail_libtiff.rb
+++ b/modules/exploits/apple_ios/email/mobilemail_libtiff.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
+++ b/modules/exploits/apple_ios/ssh/cydia_default_ssh.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/bsdi/softcart/mercantec_softcart.rb
+++ b/modules/exploits/bsdi/softcart/mercantec_softcart.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/dialup/multi/login/manyargs.rb
+++ b/modules/exploits/dialup/multi/login/manyargs.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/firefox/local/exec_shellcode.rb
+++ b/modules/exploits/firefox/local/exec_shellcode.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/freebsd/ftp/proftp_telnet_iac.rb
+++ b/modules/exploits/freebsd/ftp/proftp_telnet_iac.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/freebsd/local/mmap.rb
+++ b/modules/exploits/freebsd/local/mmap.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/freebsd/samba/trans2open.rb
+++ b/modules/exploits/freebsd/samba/trans2open.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/freebsd/tacacs/xtacacsd_report.rb
+++ b/modules/exploits/freebsd/tacacs/xtacacsd_report.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/freebsd/telnet/telnet_encrypt_keyid.rb
+++ b/modules/exploits/freebsd/telnet/telnet_encrypt_keyid.rb
@@ -1,7 +1,7 @@
 # -*- coding: binary -*-
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/hpux/lpd/cleanup_exec.rb
+++ b/modules/exploits/hpux/lpd/cleanup_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/irix/lpd/tagprinter_exec.rb
+++ b/modules/exploits/irix/lpd/tagprinter_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/antivirus/escan_password_exec.rb
+++ b/modules/exploits/linux/antivirus/escan_password_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/browser/adobe_flashplayer_aslaunch.rb
+++ b/modules/exploits/linux/browser/adobe_flashplayer_aslaunch.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/ftp/proftp_sreplace.rb
+++ b/modules/exploits/linux/ftp/proftp_sreplace.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/ftp/proftp_telnet_iac.rb
+++ b/modules/exploits/linux/ftp/proftp_telnet_iac.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/games/ut2004_secure.rb
+++ b/modules/exploits/linux/games/ut2004_secure.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/alcatel_omnipcx_mastercgi_exec.rb
+++ b/modules/exploits/linux/http/alcatel_omnipcx_mastercgi_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/alienvault_sqli_exec.rb
+++ b/modules/exploits/linux/http/alienvault_sqli_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/astium_sqli_upload.rb
+++ b/modules/exploits/linux/http/astium_sqli_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/cfme_manageiq_evm_upload_exec.rb
+++ b/modules/exploits/linux/http/cfme_manageiq_evm_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/ddwrt_cgibin_exec.rb
+++ b/modules/exploits/linux/http/ddwrt_cgibin_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/dlink_authentication_cgi_bof.rb
+++ b/modules/exploits/linux/http/dlink_authentication_cgi_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/dlink_command_php_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_command_php_exec_noauth.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_diagnostic_exec_noauth.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/dlink_dir300_exec_telnet.rb
+++ b/modules/exploits/linux/http/dlink_dir300_exec_telnet.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/dlink_dir605l_captcha_bof.rb
+++ b/modules/exploits/linux/http/dlink_dir605l_captcha_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/dlink_dir615_up_exec.rb
+++ b/modules/exploits/linux/http/dlink_dir615_up_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/dlink_dspw215_info_cgi_bof.rb
+++ b/modules/exploits/linux/http/dlink_dspw215_info_cgi_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/dlink_hedwig_cgi_bof.rb
+++ b/modules/exploits/linux/http/dlink_hedwig_cgi_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/dlink_hnap_bof.rb
+++ b/modules/exploits/linux/http/dlink_hnap_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
+++ b/modules/exploits/linux/http/dlink_upnp_exec_noauth.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/dolibarr_cmd_exec.rb
+++ b/modules/exploits/linux/http/dolibarr_cmd_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/dreambox_openpli_shell.rb
+++ b/modules/exploits/linux/http/dreambox_openpli_shell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/esva_exec.rb
+++ b/modules/exploits/linux/http/esva_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/f5_icontrol_exec.rb
+++ b/modules/exploits/linux/http/f5_icontrol_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
+++ b/modules/exploits/linux/http/foreman_openstack_satellite_code_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/fritzbox_echo_exec.rb
+++ b/modules/exploits/linux/http/fritzbox_echo_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/gitlist_exec.rb
+++ b/modules/exploits/linux/http/gitlist_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/gpsd_format_string.rb
+++ b/modules/exploits/linux/http/gpsd_format_string.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/groundwork_monarch_cmd_exec.rb
+++ b/modules/exploits/linux/http/groundwork_monarch_cmd_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/hp_system_management.rb
+++ b/modules/exploits/linux/http/hp_system_management.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/kloxo_sqli.rb
+++ b/modules/exploits/linux/http/kloxo_sqli.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/lifesize_uvc_ping_rce.rb
+++ b/modules/exploits/linux/http/lifesize_uvc_ping_rce.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/linksys_apply_cgi.rb
+++ b/modules/exploits/linux/http/linksys_apply_cgi.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_e1500_apply_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/linksys_themoon_exec.rb
+++ b/modules/exploits/linux/http/linksys_themoon_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt110_cmd_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/linksys_wrt160nv2_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt160nv2_apply_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
+++ b/modules/exploits/linux/http/linksys_wrt54gl_apply_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/mutiny_frontend_upload.rb
+++ b/modules/exploits/linux/http/mutiny_frontend_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn1000b_setup_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
+++ b/modules/exploits/linux/http/netgear_dgn2200b_pppoe_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/netgear_readynas_exec.rb
+++ b/modules/exploits/linux/http/netgear_readynas_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/nginx_chunked_size.rb
+++ b/modules/exploits/linux/http/nginx_chunked_size.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/openfiler_networkcard_exec.rb
+++ b/modules/exploits/linux/http/openfiler_networkcard_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/pandora_fms_exec.rb
+++ b/modules/exploits/linux/http/pandora_fms_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/peercast_url.rb
+++ b/modules/exploits/linux/http/peercast_url.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/pineapp_ldapsyncnow_exec.rb
+++ b/modules/exploits/linux/http/pineapp_ldapsyncnow_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/pineapp_livelog_exec.rb
+++ b/modules/exploits/linux/http/pineapp_livelog_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/pineapp_test_li_conn_exec.rb
+++ b/modules/exploits/linux/http/pineapp_test_li_conn_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/piranha_passwd_exec.rb
+++ b/modules/exploits/linux/http/piranha_passwd_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/raidsonic_nas_ib5220_exec_noauth.rb
+++ b/modules/exploits/linux/http/raidsonic_nas_ib5220_exec_noauth.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/railo_cfml_rfi.rb
+++ b/modules/exploits/linux/http/railo_cfml_rfi.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/smt_ipmi_close_window_bof.rb
+++ b/modules/exploits/linux/http/smt_ipmi_close_window_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/sophos_wpa_iface_exec.rb
+++ b/modules/exploits/linux/http/sophos_wpa_iface_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/sophos_wpa_sblistpack_exec.rb
+++ b/modules/exploits/linux/http/sophos_wpa_sblistpack_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/symantec_web_gateway_exec.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_file_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/symantec_web_gateway_lfi.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_lfi.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/symantec_web_gateway_pbcontrol.rb
+++ b/modules/exploits/linux/http/symantec_web_gateway_pbcontrol.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/synology_dsm_sliceupload_exec_noauth.rb
+++ b/modules/exploits/linux/http/synology_dsm_sliceupload_exec_noauth.rb
@@ -1,5 +1,5 @@
 ##
-## This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 ## Current source: https://github.com/rapid7/metasploit-framework
 ###
 

--- a/modules/exploits/linux/http/vcms_upload.rb
+++ b/modules/exploits/linux/http/vcms_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/wanem_exec.rb
+++ b/modules/exploits/linux/http/wanem_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/webcalendar_settings_exec.rb
+++ b/modules/exploits/linux/http/webcalendar_settings_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/webid_converter.rb
+++ b/modules/exploits/linux/http/webid_converter.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/zabbix_sqli.rb
+++ b/modules/exploits/linux/http/zabbix_sqli.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/zen_load_balancer_exec.rb
+++ b/modules/exploits/linux/http/zen_load_balancer_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
+++ b/modules/exploits/linux/http/zenoss_showdaemonxmlconfig_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/ids/alienvault_centerd_soap_exec.rb
+++ b/modules/exploits/linux/ids/alienvault_centerd_soap_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/ids/snortbopre.rb
+++ b/modules/exploits/linux/ids/snortbopre.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/imap/imap_uw_lsub.rb
+++ b/modules/exploits/linux/imap/imap_uw_lsub.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/local/hp_smhstart.rb
+++ b/modules/exploits/linux/local/hp_smhstart.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/local/kloxo_lxsuexec.rb
+++ b/modules/exploits/linux/local/kloxo_lxsuexec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/local/sock_sendpage.rb
+++ b/modules/exploits/linux/local/sock_sendpage.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/local/sophos_wpa_clear_keys.rb
+++ b/modules/exploits/linux/local/sophos_wpa_clear_keys.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/local/udev_netlink.rb
+++ b/modules/exploits/linux/local/udev_netlink.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/local/vmware_mount.rb
+++ b/modules/exploits/linux/local/vmware_mount.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/local/zpanel_zsudo.rb
+++ b/modules/exploits/linux/local/zpanel_zsudo.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/misc/accellion_fta_mpipe2.rb
+++ b/modules/exploits/linux/misc/accellion_fta_mpipe2.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/misc/drb_remote_codeexec.rb
+++ b/modules/exploits/linux/misc/drb_remote_codeexec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/misc/gld_postfix.rb
+++ b/modules/exploits/linux/misc/gld_postfix.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/misc/hp_data_protector_cmd_exec.rb
+++ b/modules/exploits/linux/misc/hp_data_protector_cmd_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/misc/hp_nnmi_pmd_bof.rb
+++ b/modules/exploits/linux/misc/hp_nnmi_pmd_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/misc/hp_vsa_login_bof.rb
+++ b/modules/exploits/linux/misc/hp_vsa_login_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/misc/hplip_hpssd_exec.rb
+++ b/modules/exploits/linux/misc/hplip_hpssd_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/misc/ib_inet_connect.rb
+++ b/modules/exploits/linux/misc/ib_inet_connect.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/misc/ib_jrd8_create_database.rb
+++ b/modules/exploits/linux/misc/ib_jrd8_create_database.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/misc/ib_open_marker_file.rb
+++ b/modules/exploits/linux/misc/ib_open_marker_file.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/misc/ib_pwd_db_aliased.rb
+++ b/modules/exploits/linux/misc/ib_pwd_db_aliased.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/misc/lprng_format_string.rb
+++ b/modules/exploits/linux/misc/lprng_format_string.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/misc/mongod_native_helper.rb
+++ b/modules/exploits/linux/misc/mongod_native_helper.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/misc/nagios_nrpe_arguments.rb
+++ b/modules/exploits/linux/misc/nagios_nrpe_arguments.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 #

--- a/modules/exploits/linux/misc/netsupport_manager_agent.rb
+++ b/modules/exploits/linux/misc/netsupport_manager_agent.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/misc/novell_edirectory_ncp_bof.rb
+++ b/modules/exploits/linux/misc/novell_edirectory_ncp_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/misc/sercomm_exec.rb
+++ b/modules/exploits/linux/misc/sercomm_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/misc/zabbix_server_exec.rb
+++ b/modules/exploits/linux/misc/zabbix_server_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/mysql/mysql_yassl_getname.rb
+++ b/modules/exploits/linux/mysql/mysql_yassl_getname.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/mysql/mysql_yassl_hello.rb
+++ b/modules/exploits/linux/mysql/mysql_yassl_hello.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/pop3/cyrus_pop3d_popsubfolders.rb
+++ b/modules/exploits/linux/pop3/cyrus_pop3d_popsubfolders.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/postgres/postgres_payload.rb
+++ b/modules/exploits/linux/postgres/postgres_payload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/pptp/poptop_negative_read.rb
+++ b/modules/exploits/linux/pptp/poptop_negative_read.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/proxy/squid_ntlm_authenticate.rb
+++ b/modules/exploits/linux/proxy/squid_ntlm_authenticate.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/samba/chain_reply.rb
+++ b/modules/exploits/linux/samba/chain_reply.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/samba/lsa_transnames_heap.rb
+++ b/modules/exploits/linux/samba/lsa_transnames_heap.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/samba/setinfopolicy_heap.rb
+++ b/modules/exploits/linux/samba/setinfopolicy_heap.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/samba/trans2open.rb
+++ b/modules/exploits/linux/samba/trans2open.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
+++ b/modules/exploits/linux/smtp/exim4_dovecot_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
+++ b/modules/exploits/linux/ssh/f5_bigip_known_privkey.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
+++ b/modules/exploits/linux/ssh/loadbalancerorg_enterprise_known_privkey.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
+++ b/modules/exploits/linux/ssh/quantum_dxi_known_privkey.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
+++ b/modules/exploits/linux/ssh/quantum_vmpro_backdoor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/ssh/symantec_smg_ssh.rb
+++ b/modules/exploits/linux/ssh/symantec_smg_ssh.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/telnet/telnet_encrypt_keyid.rb
+++ b/modules/exploits/linux/telnet/telnet_encrypt_keyid.rb
@@ -1,7 +1,7 @@
 # -*- coding: binary -*-
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/upnp/dlink_upnp_msearch_exec.rb
+++ b/modules/exploits/linux/upnp/dlink_upnp_msearch_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/linux/upnp/miniupnpd_soap_bof.rb
+++ b/modules/exploits/linux/upnp/miniupnpd_soap_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/firefox_escape_retval.rb
+++ b/modules/exploits/multi/browser/firefox_escape_retval.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
+++ b/modules/exploits/multi/browser/firefox_proto_crmfrequest.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/firefox_queryinterface.rb
+++ b/modules/exploits/multi/browser/firefox_queryinterface.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/firefox_svg_plugin.rb
+++ b/modules/exploits/multi/browser/firefox_svg_plugin.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/firefox_tostring_console_injection.rb
+++ b/modules/exploits/multi/browser/firefox_tostring_console_injection.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/firefox_webidl_injection.rb
+++ b/modules/exploits/multi/browser/firefox_webidl_injection.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
+++ b/modules/exploits/multi/browser/firefox_xpi_bootstrapped_addon.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/itms_overflow.rb
+++ b/modules/exploits/multi/browser/itms_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_atomicreferencearray.rb
+++ b/modules/exploits/multi/browser/java_atomicreferencearray.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_calendar_deserialize.rb
+++ b/modules/exploits/multi/browser/java_calendar_deserialize.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_getsoundbank_bof.rb
+++ b/modules/exploits/multi/browser/java_getsoundbank_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_jre17_driver_manager.rb
+++ b/modules/exploits/multi/browser/java_jre17_driver_manager.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_jre17_exec.rb
+++ b/modules/exploits/multi/browser/java_jre17_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_jre17_glassfish_averagerangestatisticimpl.rb
+++ b/modules/exploits/multi/browser/java_jre17_glassfish_averagerangestatisticimpl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_jre17_jaxws.rb
+++ b/modules/exploits/multi/browser/java_jre17_jaxws.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_jre17_jmxbean.rb
+++ b/modules/exploits/multi/browser/java_jre17_jmxbean.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_jre17_jmxbean_2.rb
+++ b/modules/exploits/multi/browser/java_jre17_jmxbean_2.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_jre17_method_handle.rb
+++ b/modules/exploits/multi/browser/java_jre17_method_handle.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_jre17_provider_skeleton.rb
+++ b/modules/exploits/multi/browser/java_jre17_provider_skeleton.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_jre17_reflection_types.rb
+++ b/modules/exploits/multi/browser/java_jre17_reflection_types.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_rhino.rb
+++ b/modules/exploits/multi/browser/java_rhino.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_rmi_connection_impl.rb
+++ b/modules/exploits/multi/browser/java_rmi_connection_impl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_setdifficm_bof.rb
+++ b/modules/exploits/multi/browser/java_setdifficm_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_signed_applet.rb
+++ b/modules/exploits/multi/browser/java_signed_applet.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_storeimagearray.rb
+++ b/modules/exploits/multi/browser/java_storeimagearray.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_trusted_chain.rb
+++ b/modules/exploits/multi/browser/java_trusted_chain.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/java_verifier_field_access.rb
+++ b/modules/exploits/multi/browser/java_verifier_field_access.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/mozilla_compareto.rb
+++ b/modules/exploits/multi/browser/mozilla_compareto.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/mozilla_navigatorjava.rb
+++ b/modules/exploits/multi/browser/mozilla_navigatorjava.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/opera_configoverwrite.rb
+++ b/modules/exploits/multi/browser/opera_configoverwrite.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/opera_historysearch.rb
+++ b/modules/exploits/multi/browser/opera_historysearch.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/browser/qtjava_pointer.rb
+++ b/modules/exploits/multi/browser/qtjava_pointer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/elasticsearch/script_mvel_rce.rb
+++ b/modules/exploits/multi/elasticsearch/script_mvel_rce.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/fileformat/adobe_u3d_meshcont.rb
+++ b/modules/exploits/multi/fileformat/adobe_u3d_meshcont.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/fileformat/maple_maplet.rb
+++ b/modules/exploits/multi/fileformat/maple_maplet.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/fileformat/nodejs_js_yaml_load_code_exec.rb
+++ b/modules/exploits/multi/fileformat/nodejs_js_yaml_load_code_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/fileformat/peazip_command_injection.rb
+++ b/modules/exploits/multi/fileformat/peazip_command_injection.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
+++ b/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/ftp/wuftpd_site_exec_format.rb
+++ b/modules/exploits/multi/ftp/wuftpd_site_exec_format.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/gdb/gdb_server_exec.rb
+++ b/modules/exploits/multi/gdb/gdb_server_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/handler.rb
+++ b/modules/exploits/multi/handler.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/activecollab_chat.rb
+++ b/modules/exploits/multi/http/activecollab_chat.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/ajaxplorer_checkinstall_exec.rb
+++ b/modules/exploits/multi/http/ajaxplorer_checkinstall_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
+++ b/modules/exploits/multi/http/apache_mod_cgi_bash_env_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/apache_roller_ognl_injection.rb
+++ b/modules/exploits/multi/http/apache_roller_ognl_injection.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/apprain_upload_exec.rb
+++ b/modules/exploits/multi/http/apprain_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/auxilium_upload_exec.rb
+++ b/modules/exploits/multi/http/auxilium_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/axis2_deployer.rb
+++ b/modules/exploits/multi/http/axis2_deployer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/cisco_dcnm_upload.rb
+++ b/modules/exploits/multi/http/cisco_dcnm_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/coldfusion_rds.rb
+++ b/modules/exploits/multi/http/coldfusion_rds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/cuteflow_upload_exec.rb
+++ b/modules/exploits/multi/http/cuteflow_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/dexter_casinoloader_exec.rb
+++ b/modules/exploits/multi/http/dexter_casinoloader_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/eaton_nsm_code_exec.rb
+++ b/modules/exploits/multi/http/eaton_nsm_code_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/eventlog_file_upload.rb
+++ b/modules/exploits/multi/http/eventlog_file_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/extplorer_upload_exec.rb
+++ b/modules/exploits/multi/http/extplorer_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/familycms_less_exec.rb
+++ b/modules/exploits/multi/http/familycms_less_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/freenas_exec_raw.rb
+++ b/modules/exploits/multi/http/freenas_exec_raw.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/gestioip_exec.rb
+++ b/modules/exploits/multi/http/gestioip_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/gitlab_shell_exec.rb
+++ b/modules/exploits/multi/http/gitlab_shell_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/gitorious_graph.rb
+++ b/modules/exploits/multi/http/gitorious_graph.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/glassfish_deployer.rb
+++ b/modules/exploits/multi/http/glassfish_deployer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/glossword_upload_exec.rb
+++ b/modules/exploits/multi/http/glossword_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/glpi_install_rce.rb
+++ b/modules/exploits/multi/http/glpi_install_rce.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/horde_href_backdoor.rb
+++ b/modules/exploits/multi/http/horde_href_backdoor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/hp_sitescope_issuesiebelcmd.rb
+++ b/modules/exploits/multi/http/hp_sitescope_issuesiebelcmd.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
+++ b/modules/exploits/multi/http/hp_sitescope_uploadfileshandler.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/hp_sys_mgmt_exec.rb
+++ b/modules/exploits/multi/http/hp_sys_mgmt_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/hyperic_hq_script_console.rb
+++ b/modules/exploits/multi/http/hyperic_hq_script_console.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/ispconfig_php_exec.rb
+++ b/modules/exploits/multi/http/ispconfig_php_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/jboss_bshdeployer.rb
+++ b/modules/exploits/multi/http/jboss_bshdeployer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
+++ b/modules/exploits/multi/http/jboss_deploymentfilerepository.rb
@@ -1,7 +1,7 @@
 # -*- coding: binary -*-
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/jboss_invoke_deploy.rb
+++ b/modules/exploits/multi/http/jboss_invoke_deploy.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/jenkins_script_console.rb
+++ b/modules/exploits/multi/http/jenkins_script_console.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/kordil_edms_upload_exec.rb
+++ b/modules/exploits/multi/http/kordil_edms_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/lcms_php_exec.rb
+++ b/modules/exploits/multi/http/lcms_php_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/log1cms_ajax_create_folder.rb
+++ b/modules/exploits/multi/http/log1cms_ajax_create_folder.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
+++ b/modules/exploits/multi/http/manage_engine_dc_pmp_sqli.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/manageengine_search_sqli.rb
+++ b/modules/exploits/multi/http/manageengine_search_sqli.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/mediawiki_thumb.rb
+++ b/modules/exploits/multi/http/mediawiki_thumb.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/mobilecartly_upload_exec.rb
+++ b/modules/exploits/multi/http/mobilecartly_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/moodle_cmd_exec.rb
+++ b/modules/exploits/multi/http/moodle_cmd_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/movabletype_upgrade_exec.rb
+++ b/modules/exploits/multi/http/movabletype_upgrade_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
+++ b/modules/exploits/multi/http/mutiny_subnetmask_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/nas4free_php_exec.rb
+++ b/modules/exploits/multi/http/nas4free_php_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/netwin_surgeftp_exec.rb
+++ b/modules/exploits/multi/http/netwin_surgeftp_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/op5_license.rb
+++ b/modules/exploits/multi/http/op5_license.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/op5_welcome.rb
+++ b/modules/exploits/multi/http/op5_welcome.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/openfire_auth_bypass.rb
+++ b/modules/exploits/multi/http/openfire_auth_bypass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/openmediavault_cmd_exec.rb
+++ b/modules/exploits/multi/http/openmediavault_cmd_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/openx_backdoor_php.rb
+++ b/modules/exploits/multi/http/openx_backdoor_php.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/opmanager_socialit_file_upload.rb
+++ b/modules/exploits/multi/http/opmanager_socialit_file_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/oracle_reports_rce.rb
+++ b/modules/exploits/multi/http/oracle_reports_rce.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/php_cgi_arg_injection.rb
+++ b/modules/exploits/multi/http/php_cgi_arg_injection.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/php_volunteer_upload_exec.rb
+++ b/modules/exploits/multi/http/php_volunteer_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/phpldapadmin_query_engine.rb
+++ b/modules/exploits/multi/http/phpldapadmin_query_engine.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/phpmyadmin_3522_backdoor.rb
+++ b/modules/exploits/multi/http/phpmyadmin_3522_backdoor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/phpmyadmin_preg_replace.rb
+++ b/modules/exploits/multi/http/phpmyadmin_preg_replace.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/phpscheduleit_start_date.rb
+++ b/modules/exploits/multi/http/phpscheduleit_start_date.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/phptax_exec.rb
+++ b/modules/exploits/multi/http/phptax_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/phpwiki_ploticus_exec.rb
+++ b/modules/exploits/multi/http/phpwiki_ploticus_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/plone_popen2.rb
+++ b/modules/exploits/multi/http/plone_popen2.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/pmwiki_pagelist.rb
+++ b/modules/exploits/multi/http/pmwiki_pagelist.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/polarcms_upload_exec.rb
+++ b/modules/exploits/multi/http/polarcms_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/processmaker_exec.rb
+++ b/modules/exploits/multi/http/processmaker_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/qdpm_upload_exec.rb
+++ b/modules/exploits/multi/http/qdpm_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/rails_json_yaml_code_exec.rb
+++ b/modules/exploits/multi/http/rails_json_yaml_code_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/rails_secret_deserialization.rb
+++ b/modules/exploits/multi/http/rails_secret_deserialization.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/rails_xml_yaml_code_exec.rb
+++ b/modules/exploits/multi/http/rails_xml_yaml_code_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/rocket_servergraph_file_requestor_rce.rb
+++ b/modules/exploits/multi/http/rocket_servergraph_file_requestor_rce.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/sflog_upload_exec.rb
+++ b/modules/exploits/multi/http/sflog_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/sit_file_upload.rb
+++ b/modules/exploits/multi/http/sit_file_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/snortreport_exec.rb
+++ b/modules/exploits/multi/http/snortreport_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/solarwinds_store_manager_auth_filter.rb
+++ b/modules/exploits/multi/http/solarwinds_store_manager_auth_filter.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/sonicwall_gms_upload.rb
+++ b/modules/exploits/multi/http/sonicwall_gms_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/splunk_mappy_exec.rb
+++ b/modules/exploits/multi/http/splunk_mappy_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/splunk_upload_app_exec.rb
+++ b/modules/exploits/multi/http/splunk_upload_app_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/spree_search_exec.rb
+++ b/modules/exploits/multi/http/spree_search_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/spree_searchlogic_exec.rb
+++ b/modules/exploits/multi/http/spree_searchlogic_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/struts_code_exec.rb
+++ b/modules/exploits/multi/http/struts_code_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/struts_code_exec_classloader.rb
+++ b/modules/exploits/multi/http/struts_code_exec_classloader.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
+++ b/modules/exploits/multi/http/struts_code_exec_exception_delegator.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/struts_code_exec_parameters.rb
+++ b/modules/exploits/multi/http/struts_code_exec_parameters.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/struts_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_default_action_mapper.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/struts_dev_mode.rb
+++ b/modules/exploits/multi/http/struts_dev_mode.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/struts_include_params.rb
+++ b/modules/exploits/multi/http/struts_include_params.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/stunshell_eval.rb
+++ b/modules/exploits/multi/http/stunshell_eval.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/stunshell_exec.rb
+++ b/modules/exploits/multi/http/stunshell_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/sun_jsws_dav_options.rb
+++ b/modules/exploits/multi/http/sun_jsws_dav_options.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/testlink_upload_exec.rb
+++ b/modules/exploits/multi/http/testlink_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/tomcat_mgr_deploy.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_deploy.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/tomcat_mgr_upload.rb
+++ b/modules/exploits/multi/http/tomcat_mgr_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/traq_plugin_exec.rb
+++ b/modules/exploits/multi/http/traq_plugin_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/uptime_file_upload.rb
+++ b/modules/exploits/multi/http/uptime_file_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/v0pcr3w_exec.rb
+++ b/modules/exploits/multi/http/v0pcr3w_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/vbseo_proc_deutf.rb
+++ b/modules/exploits/multi/http/vbseo_proc_deutf.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/vtiger_install_rce.rb
+++ b/modules/exploits/multi/http/vtiger_install_rce.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/vtiger_php_exec.rb
+++ b/modules/exploits/multi/http/vtiger_php_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/vtiger_soap_upload.rb
+++ b/modules/exploits/multi/http/vtiger_soap_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/webpagetest_upload_exec.rb
+++ b/modules/exploits/multi/http/webpagetest_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/wikka_spam_exec.rb
+++ b/modules/exploits/multi/http/wikka_spam_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/zabbix_script_exec.rb
+++ b/modules/exploits/multi/http/zabbix_script_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/http/zenworks_control_center_upload.rb
+++ b/modules/exploits/multi/http/zenworks_control_center_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/ids/snort_dce_rpc.rb
+++ b/modules/exploits/multi/ids/snort_dce_rpc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/misc/batik_svg_java.rb
+++ b/modules/exploits/multi/misc/batik_svg_java.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/misc/hp_vsa_exec.rb
+++ b/modules/exploits/multi/misc/hp_vsa_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/misc/indesign_server_soap.rb
+++ b/modules/exploits/multi/misc/indesign_server_soap.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/misc/java_jdwp_debugger.rb
+++ b/modules/exploits/multi/misc/java_jdwp_debugger.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/misc/openview_omniback_exec.rb
+++ b/modules/exploits/multi/misc/openview_omniback_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/misc/pbot_exec.rb
+++ b/modules/exploits/multi/misc/pbot_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/misc/ra1nx_pubcall_exec.rb
+++ b/modules/exploits/multi/misc/ra1nx_pubcall_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/misc/veritas_netbackup_cmdexec.rb
+++ b/modules/exploits/multi/misc/veritas_netbackup_cmdexec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/misc/wireshark_lwres_getaddrbyname.rb
+++ b/modules/exploits/multi/misc/wireshark_lwres_getaddrbyname.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/misc/wireshark_lwres_getaddrbyname_loop.rb
+++ b/modules/exploits/multi/misc/wireshark_lwres_getaddrbyname_loop.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/misc/zend_java_bridge.rb
+++ b/modules/exploits/multi/misc/zend_java_bridge.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/ntp/ntp_overflow.rb
+++ b/modules/exploits/multi/ntp/ntp_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/php/php_unserialize_zval_cookie.rb
+++ b/modules/exploits/multi/php/php_unserialize_zval_cookie.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/realserver/describe.rb
+++ b/modules/exploits/multi/realserver/describe.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/samba/nttrans.rb
+++ b/modules/exploits/multi/samba/nttrans.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/samba/usermap_script.rb
+++ b/modules/exploits/multi/samba/usermap_script.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
+++ b/modules/exploits/multi/sap/sap_mgmt_con_osexec_payload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_call_system_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/sap/sap_soap_rfc_sxpg_command_exec.rb
+++ b/modules/exploits/multi/sap/sap_soap_rfc_sxpg_command_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/script/web_delivery.rb
+++ b/modules/exploits/multi/script/web_delivery.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/ssh/sshexec.rb
+++ b/modules/exploits/multi/ssh/sshexec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/svn/svnserve_date.rb
+++ b/modules/exploits/multi/svn/svnserve_date.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/upnp/libupnp_ssdp_overflow.rb
+++ b/modules/exploits/multi/upnp/libupnp_ssdp_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/multi/wyse/hagent_untrusted_hsdata.rb
+++ b/modules/exploits/multi/wyse/hagent_untrusted_hsdata.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/netware/smb/lsass_cifs.rb
+++ b/modules/exploits/netware/smb/lsass_cifs.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/netware/sunrpc/pkernel_callit.rb
+++ b/modules/exploits/netware/sunrpc/pkernel_callit.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/afp/loginext.rb
+++ b/modules/exploits/osx/afp/loginext.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/arkeia/type77.rb
+++ b/modules/exploits/osx/arkeia/type77.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/browser/mozilla_mchannel.rb
+++ b/modules/exploits/osx/browser/mozilla_mchannel.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/browser/safari_file_policy.rb
+++ b/modules/exploits/osx/browser/safari_file_policy.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/browser/safari_metadata_archive.rb
+++ b/modules/exploits/osx/browser/safari_metadata_archive.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
+++ b/modules/exploits/osx/browser/safari_user_assisted_download_launch.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/browser/software_update.rb
+++ b/modules/exploits/osx/browser/software_update.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/email/mailapp_image_exec.rb
+++ b/modules/exploits/osx/email/mailapp_image_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/ftp/webstar_ftp_user.rb
+++ b/modules/exploits/osx/ftp/webstar_ftp_user.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/http/evocam_webserver.rb
+++ b/modules/exploits/osx/http/evocam_webserver.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/local/nfs_mount_root.rb
+++ b/modules/exploits/osx/local/nfs_mount_root.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/local/persistence.rb
+++ b/modules/exploits/osx/local/persistence.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/local/setuid_tunnelblick.rb
+++ b/modules/exploits/osx/local/setuid_tunnelblick.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/local/setuid_viscosity.rb
+++ b/modules/exploits/osx/local/setuid_viscosity.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/local/sudo_password_bypass.rb
+++ b/modules/exploits/osx/local/sudo_password_bypass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/local/vmware_bash_function_root.rb
+++ b/modules/exploits/osx/local/vmware_bash_function_root.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/mdns/upnp_location.rb
+++ b/modules/exploits/osx/mdns/upnp_location.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/misc/ufo_ai.rb
+++ b/modules/exploits/osx/misc/ufo_ai.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/rtsp/quicktime_rtsp_content_type.rb
+++ b/modules/exploits/osx/rtsp/quicktime_rtsp_content_type.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/samba/lsa_transnames_heap.rb
+++ b/modules/exploits/osx/samba/lsa_transnames_heap.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/osx/samba/trans2open.rb
+++ b/modules/exploits/osx/samba/trans2open.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/solaris/dtspcd/heap_noir.rb
+++ b/modules/exploits/solaris/dtspcd/heap_noir.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/solaris/lpd/sendmail_exec.rb
+++ b/modules/exploits/solaris/lpd/sendmail_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/solaris/samba/lsa_transnames_heap.rb
+++ b/modules/exploits/solaris/samba/lsa_transnames_heap.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/solaris/samba/trans2open.rb
+++ b/modules/exploits/solaris/samba/trans2open.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/solaris/sunrpc/sadmind_adm_build_path.rb
+++ b/modules/exploits/solaris/sunrpc/sadmind_adm_build_path.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/solaris/sunrpc/sadmind_exec.rb
+++ b/modules/exploits/solaris/sunrpc/sadmind_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/solaris/sunrpc/ypupdated_exec.rb
+++ b/modules/exploits/solaris/sunrpc/ypupdated_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/solaris/telnet/fuser.rb
+++ b/modules/exploits/solaris/telnet/fuser.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/solaris/telnet/ttyprompt.rb
+++ b/modules/exploits/solaris/telnet/ttyprompt.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/dhcp/bash_environment.rb
+++ b/modules/exploits/unix/dhcp/bash_environment.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
+++ b/modules/exploits/unix/ftp/proftpd_133c_backdoor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
+++ b/modules/exploits/unix/ftp/vsftpd_234_backdoor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/http/contentkeeperweb_mimencode.rb
+++ b/modules/exploits/unix/http/contentkeeperweb_mimencode.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/http/ctek_skyrouter.rb
+++ b/modules/exploits/unix/http/ctek_skyrouter.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/http/freepbx_callmenum.rb
+++ b/modules/exploits/unix/http/freepbx_callmenum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/http/lifesize_room.rb
+++ b/modules/exploits/unix/http/lifesize_room.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
+++ b/modules/exploits/unix/http/vmturbo_vmtadmin_exec_noauth.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
+++ b/modules/exploits/unix/irc/unreal_ircd_3281_backdoor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/local/setuid_nmap.rb
+++ b/modules/exploits/unix/local/setuid_nmap.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/misc/distcc_exec.rb
+++ b/modules/exploits/unix/misc/distcc_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/misc/qnx_qconn_exec.rb
+++ b/modules/exploits/unix/misc/qnx_qconn_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/misc/spamassassin_exec.rb
+++ b/modules/exploits/unix/misc/spamassassin_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/misc/zabbix_agent_exec.rb
+++ b/modules/exploits/unix/misc/zabbix_agent_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/smtp/clamav_milter_blackhole.rb
+++ b/modules/exploits/unix/smtp/clamav_milter_blackhole.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/smtp/exim4_string_format.rb
+++ b/modules/exploits/unix/smtp/exim4_string_format.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
+++ b/modules/exploits/unix/ssh/array_vxag_vapv_privkey_privesc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
+++ b/modules/exploits/unix/ssh/tectia_passwd_changereq.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/arkeia_upload_exec.rb
+++ b/modules/exploits/unix/webapp/arkeia_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/awstats_configdir_exec.rb
+++ b/modules/exploits/unix/webapp/awstats_configdir_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/awstats_migrate_exec.rb
+++ b/modules/exploits/unix/webapp/awstats_migrate_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/awstatstotals_multisort.rb
+++ b/modules/exploits/unix/webapp/awstatstotals_multisort.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/barracuda_img_exec.rb
+++ b/modules/exploits/unix/webapp/barracuda_img_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/base_qry_common.rb
+++ b/modules/exploits/unix/webapp/base_qry_common.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/basilic_diff_exec.rb
+++ b/modules/exploits/unix/webapp/basilic_diff_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/cacti_graphimage_exec.rb
+++ b/modules/exploits/unix/webapp/cacti_graphimage_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/cakephp_cache_corruption.rb
+++ b/modules/exploits/unix/webapp/cakephp_cache_corruption.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/carberp_backdoor_exec.rb
+++ b/modules/exploits/unix/webapp/carberp_backdoor_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/citrix_access_gateway_exec.rb
+++ b/modules/exploits/unix/webapp/citrix_access_gateway_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/clipbucket_upload_exec.rb
+++ b/modules/exploits/unix/webapp/clipbucket_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/coppermine_piceditor.rb
+++ b/modules/exploits/unix/webapp/coppermine_piceditor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/datalife_preview_exec.rb
+++ b/modules/exploits/unix/webapp/datalife_preview_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/dogfood_spell_exec.rb
+++ b/modules/exploits/unix/webapp/dogfood_spell_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/egallery_upload_exec.rb
+++ b/modules/exploits/unix/webapp/egallery_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/flashchat_upload_exec.rb
+++ b/modules/exploits/unix/webapp/flashchat_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/foswiki_maketext.rb
+++ b/modules/exploits/unix/webapp/foswiki_maketext.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/freepbx_config_exec.rb
+++ b/modules/exploits/unix/webapp/freepbx_config_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/generic_exec.rb
+++ b/modules/exploits/unix/webapp/generic_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/get_simple_cms_upload_exec.rb
+++ b/modules/exploits/unix/webapp/get_simple_cms_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
+++ b/modules/exploits/unix/webapp/google_proxystylesheet_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/graphite_pickle_exec.rb
+++ b/modules/exploits/unix/webapp/graphite_pickle_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/guestbook_ssi_exec.rb
+++ b/modules/exploits/unix/webapp/guestbook_ssi_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/hastymail_exec.rb
+++ b/modules/exploits/unix/webapp/hastymail_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/havalite_upload_exec.rb
+++ b/modules/exploits/unix/webapp/havalite_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/horde_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/horde_unserialize_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/hybridauth_install_php_exec.rb
+++ b/modules/exploits/unix/webapp/hybridauth_install_php_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/invision_pboard_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/invision_pboard_unserialize_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/joomla_comjce_imgmanager.rb
+++ b/modules/exploits/unix/webapp/joomla_comjce_imgmanager.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/joomla_media_upload_exec.rb
+++ b/modules/exploits/unix/webapp/joomla_media_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/joomla_tinybrowser.rb
+++ b/modules/exploits/unix/webapp/joomla_tinybrowser.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/kimai_sqli.rb
+++ b/modules/exploits/unix/webapp/kimai_sqli.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/libretto_upload_exec.rb
+++ b/modules/exploits/unix/webapp/libretto_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/mambo_cache_lite.rb
+++ b/modules/exploits/unix/webapp/mambo_cache_lite.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/mitel_awc_exec.rb
+++ b/modules/exploits/unix/webapp/mitel_awc_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/moinmoin_twikidraw.rb
+++ b/modules/exploits/unix/webapp/moinmoin_twikidraw.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/mybb_backdoor.rb
+++ b/modules/exploits/unix/webapp/mybb_backdoor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/nagios3_history_cgi.rb
+++ b/modules/exploits/unix/webapp/nagios3_history_cgi.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/nagios3_statuswml_ping.rb
+++ b/modules/exploits/unix/webapp/nagios3_statuswml_ping.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/nagios_graph_explorer.rb
+++ b/modules/exploits/unix/webapp/nagios_graph_explorer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/narcissus_backend_exec.rb
+++ b/modules/exploits/unix/webapp/narcissus_backend_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/open_flash_chart_upload_exec.rb
+++ b/modules/exploits/unix/webapp/open_flash_chart_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/openemr_sqli_privesc_upload.rb
+++ b/modules/exploits/unix/webapp/openemr_sqli_privesc_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/openemr_upload_exec.rb
+++ b/modules/exploits/unix/webapp/openemr_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/opensis_modname_exec.rb
+++ b/modules/exploits/unix/webapp/opensis_modname_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/openview_connectednodes_exec.rb
+++ b/modules/exploits/unix/webapp/openview_connectednodes_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/openx_banner_edit.rb
+++ b/modules/exploits/unix/webapp/openx_banner_edit.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/oracle_vm_agent_utl.rb
+++ b/modules/exploits/unix/webapp/oracle_vm_agent_utl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/oscommerce_filemanager.rb
+++ b/modules/exploits/unix/webapp/oscommerce_filemanager.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/pajax_remote_exec.rb
+++ b/modules/exploits/unix/webapp/pajax_remote_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/php_charts_exec.rb
+++ b/modules/exploits/unix/webapp/php_charts_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/php_eval.rb
+++ b/modules/exploits/unix/webapp/php_eval.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/php_include.rb
+++ b/modules/exploits/unix/webapp/php_include.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/php_vbulletin_template.rb
+++ b/modules/exploits/unix/webapp/php_vbulletin_template.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/php_wordpress_foxypress.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_foxypress.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/php_wordpress_infusionsoft.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_infusionsoft.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/php_wordpress_lastpost.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_lastpost.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/php_wordpress_optimizepress.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_optimizepress.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/php_wordpress_total_cache.rb
+++ b/modules/exploits/unix/webapp/php_wordpress_total_cache.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/php_xmlrpc_eval.rb
+++ b/modules/exploits/unix/webapp/php_xmlrpc_eval.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/phpbb_highlight.rb
+++ b/modules/exploits/unix/webapp/phpbb_highlight.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/phpmyadmin_config.rb
+++ b/modules/exploits/unix/webapp/phpmyadmin_config.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/projectpier_upload_exec.rb
+++ b/modules/exploits/unix/webapp/projectpier_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/qtss_parse_xml_exec.rb
+++ b/modules/exploits/unix/webapp/qtss_parse_xml_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/redmine_scm_exec.rb
+++ b/modules/exploits/unix/webapp/redmine_scm_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/seportal_sqli_exec.rb
+++ b/modules/exploits/unix/webapp/seportal_sqli_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/simple_e_document_upload_exec.rb
+++ b/modules/exploits/unix/webapp/simple_e_document_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/skybluecanvas_exec.rb
+++ b/modules/exploits/unix/webapp/skybluecanvas_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/sphpblog_file_upload.rb
+++ b/modules/exploits/unix/webapp/sphpblog_file_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/spip_connect_exec.rb
+++ b/modules/exploits/unix/webapp/spip_connect_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/squash_yaml_exec.rb
+++ b/modules/exploits/unix/webapp/squash_yaml_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/squirrelmail_pgp_plugin.rb
+++ b/modules/exploits/unix/webapp/squirrelmail_pgp_plugin.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/sugarcrm_unserialize_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/tikiwiki_graph_formula_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_graph_formula_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/tikiwiki_jhot_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_jhot_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/tikiwiki_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/tikiwiki_unserialize_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/trixbox_langchoice.rb
+++ b/modules/exploits/unix/webapp/trixbox_langchoice.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/twiki_history.rb
+++ b/modules/exploits/unix/webapp/twiki_history.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/twiki_maketext.rb
+++ b/modules/exploits/unix/webapp/twiki_maketext.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/twiki_search.rb
+++ b/modules/exploits/unix/webapp/twiki_search.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/vbulletin_vote_sqli_exec.rb
+++ b/modules/exploits/unix/webapp/vbulletin_vote_sqli_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/vicidial_manager_send_cmd_exec.rb
+++ b/modules/exploits/unix/webapp/vicidial_manager_send_cmd_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/webmin_show_cgi_exec.rb
+++ b/modules/exploits/unix/webapp/webmin_show_cgi_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/webtester_exec.rb
+++ b/modules/exploits/unix/webapp/webtester_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/wp_advanced_custom_fields_exec.rb
+++ b/modules/exploits/unix/webapp/wp_advanced_custom_fields_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/wp_asset_manager_upload_exec.rb
+++ b/modules/exploits/unix/webapp/wp_asset_manager_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/wp_google_document_embedder_exec.rb
+++ b/modules/exploits/unix/webapp/wp_google_document_embedder_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/wp_property_upload_exec.rb
+++ b/modules/exploits/unix/webapp/wp_property_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/wp_wptouch_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wptouch_file_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wysija_newsletters_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/xoda_file_upload.rb
+++ b/modules/exploits/unix/webapp/xoda_file_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/zeroshell_exec.rb
+++ b/modules/exploits/unix/webapp/zeroshell_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/zimbra_lfi.rb
+++ b/modules/exploits/unix/webapp/zimbra_lfi.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/zoneminder_packagecontrol_exec.rb
+++ b/modules/exploits/unix/webapp/zoneminder_packagecontrol_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/unix/webapp/zpanel_username_exec.rb
+++ b/modules/exploits/unix/webapp/zpanel_username_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/antivirus/ams_hndlrsvc.rb
+++ b/modules/exploits/windows/antivirus/ams_hndlrsvc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/antivirus/ams_xfr.rb
+++ b/modules/exploits/windows/antivirus/ams_xfr.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/antivirus/symantec_endpoint_manager_rce.rb
+++ b/modules/exploits/windows/antivirus/symantec_endpoint_manager_rce.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/antivirus/symantec_iao.rb
+++ b/modules/exploits/windows/antivirus/symantec_iao.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/antivirus/symantec_rtvscan.rb
+++ b/modules/exploits/windows/antivirus/symantec_rtvscan.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/antivirus/symantec_workspace_streaming_exec.rb
+++ b/modules/exploits/windows/antivirus/symantec_workspace_streaming_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/antivirus/trendmicro_serverprotect.rb
+++ b/modules/exploits/windows/antivirus/trendmicro_serverprotect.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/antivirus/trendmicro_serverprotect_createbinding.rb
+++ b/modules/exploits/windows/antivirus/trendmicro_serverprotect_createbinding.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/antivirus/trendmicro_serverprotect_earthagent.rb
+++ b/modules/exploits/windows/antivirus/trendmicro_serverprotect_earthagent.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/arkeia/type77.rb
+++ b/modules/exploits/windows/arkeia/type77.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/backdoor/energizer_duo_payload.rb
+++ b/modules/exploits/windows/backdoor/energizer_duo_payload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/backupexec/name_service.rb
+++ b/modules/exploits/windows/backupexec/name_service.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/backupexec/remote_agent.rb
+++ b/modules/exploits/windows/backupexec/remote_agent.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/ca_arcserve_342.rb
+++ b/modules/exploits/windows/brightstor/ca_arcserve_342.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/discovery_tcp.rb
+++ b/modules/exploits/windows/brightstor/discovery_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/discovery_udp.rb
+++ b/modules/exploits/windows/brightstor/discovery_udp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/etrust_itm_alert.rb
+++ b/modules/exploits/windows/brightstor/etrust_itm_alert.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/hsmserver.rb
+++ b/modules/exploits/windows/brightstor/hsmserver.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/lgserver.rb
+++ b/modules/exploits/windows/brightstor/lgserver.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/lgserver_multi.rb
+++ b/modules/exploits/windows/brightstor/lgserver_multi.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/lgserver_rxrlogin.rb
+++ b/modules/exploits/windows/brightstor/lgserver_rxrlogin.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/lgserver_rxssetdatagrowthscheduleandfilter.rb
+++ b/modules/exploits/windows/brightstor/lgserver_rxssetdatagrowthscheduleandfilter.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/lgserver_rxsuselicenseini.rb
+++ b/modules/exploits/windows/brightstor/lgserver_rxsuselicenseini.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/license_gcr.rb
+++ b/modules/exploits/windows/brightstor/license_gcr.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/mediasrv_sunrpc.rb
+++ b/modules/exploits/windows/brightstor/mediasrv_sunrpc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/message_engine.rb
+++ b/modules/exploits/windows/brightstor/message_engine.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/message_engine_72.rb
+++ b/modules/exploits/windows/brightstor/message_engine_72.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/message_engine_heap.rb
+++ b/modules/exploits/windows/brightstor/message_engine_heap.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/sql_agent.rb
+++ b/modules/exploits/windows/brightstor/sql_agent.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/tape_engine.rb
+++ b/modules/exploits/windows/brightstor/tape_engine.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/tape_engine_0x8a.rb
+++ b/modules/exploits/windows/brightstor/tape_engine_0x8a.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/brightstor/universal_agent.rb
+++ b/modules/exploits/windows/brightstor/universal_agent.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_cooltype_sing.rb
+++ b/modules/exploits/windows/browser/adobe_cooltype_sing.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_flash_avm2.rb
+++ b/modules/exploits/windows/browser/adobe_flash_avm2.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_flash_filters_type_confusion.rb
+++ b/modules/exploits/windows/browser/adobe_flash_filters_type_confusion.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_flash_mp4_cprt.rb
+++ b/modules/exploits/windows/browser/adobe_flash_mp4_cprt.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_flash_otf_font.rb
+++ b/modules/exploits/windows/browser/adobe_flash_otf_font.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb
+++ b/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_flash_regex_value.rb
+++ b/modules/exploits/windows/browser/adobe_flash_regex_value.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_flash_rtmp.rb
+++ b/modules/exploits/windows/browser/adobe_flash_rtmp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_flash_sps.rb
+++ b/modules/exploits/windows/browser/adobe_flash_sps.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_flashplayer_arrayindexing.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_arrayindexing.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_flashplayer_avm.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_avm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_flash10o.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_flashplayer_newfunction.rb
+++ b/modules/exploits/windows/browser/adobe_flashplayer_newfunction.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_flatedecode_predictor02.rb
+++ b/modules/exploits/windows/browser/adobe_flatedecode_predictor02.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_geticon.rb
+++ b/modules/exploits/windows/browser/adobe_geticon.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_jbig2decode.rb
+++ b/modules/exploits/windows/browser/adobe_jbig2decode.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_media_newplayer.rb
+++ b/modules/exploits/windows/browser/adobe_media_newplayer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_shockwave_rcsl_corruption.rb
+++ b/modules/exploits/windows/browser/adobe_shockwave_rcsl_corruption.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_toolbutton.rb
+++ b/modules/exploits/windows/browser/adobe_toolbutton.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/adobe_utilprintf.rb
+++ b/modules/exploits/windows/browser/adobe_utilprintf.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
+++ b/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/aim_goaway.rb
+++ b/modules/exploits/windows/browser/aim_goaway.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/aladdin_choosefilepath_bof.rb
+++ b/modules/exploits/windows/browser/aladdin_choosefilepath_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/amaya_bdo.rb
+++ b/modules/exploits/windows/browser/amaya_bdo.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/aol_ampx_convertfile.rb
+++ b/modules/exploits/windows/browser/aol_ampx_convertfile.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/aol_icq_downloadagent.rb
+++ b/modules/exploits/windows/browser/aol_icq_downloadagent.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/apple_itunes_playlist.rb
+++ b/modules/exploits/windows/browser/apple_itunes_playlist.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/apple_quicktime_marshaled_punk.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_marshaled_punk.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/apple_quicktime_mime_type.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_mime_type.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/apple_quicktime_rdrf.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_rdrf.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/apple_quicktime_rtsp.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_rtsp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/apple_quicktime_smil_debug.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_smil_debug.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb
+++ b/modules/exploits/windows/browser/apple_quicktime_texml_font_table.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ask_shortformat.rb
+++ b/modules/exploits/windows/browser/ask_shortformat.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/asus_net4switch_ipswcom.rb
+++ b/modules/exploits/windows/browser/asus_net4switch_ipswcom.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/athocgov_completeinstallation.rb
+++ b/modules/exploits/windows/browser/athocgov_completeinstallation.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/autodesk_idrop.rb
+++ b/modules/exploits/windows/browser/autodesk_idrop.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/aventail_epi_activex.rb
+++ b/modules/exploits/windows/browser/aventail_epi_activex.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/awingsoft_web3d_bof.rb
+++ b/modules/exploits/windows/browser/awingsoft_web3d_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/awingsoft_winds3d_sceneurl.rb
+++ b/modules/exploits/windows/browser/awingsoft_winds3d_sceneurl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/baofeng_storm_onbeforevideodownload.rb
+++ b/modules/exploits/windows/browser/baofeng_storm_onbeforevideodownload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/barcode_ax49.rb
+++ b/modules/exploits/windows/browser/barcode_ax49.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/blackice_downloadimagefileurl.rb
+++ b/modules/exploits/windows/browser/blackice_downloadimagefileurl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/c6_messenger_downloaderactivex.rb
+++ b/modules/exploits/windows/browser/c6_messenger_downloaderactivex.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ca_brightstor_addcolumn.rb
+++ b/modules/exploits/windows/browser/ca_brightstor_addcolumn.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/chilkat_crypt_writefile.rb
+++ b/modules/exploits/windows/browser/chilkat_crypt_writefile.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/cisco_anyconnect_exec.rb
+++ b/modules/exploits/windows/browser/cisco_anyconnect_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/cisco_playerpt_setsource.rb
+++ b/modules/exploits/windows/browser/cisco_playerpt_setsource.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/cisco_playerpt_setsource_surl.rb
+++ b/modules/exploits/windows/browser/cisco_playerpt_setsource_surl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/citrix_gateway_actx.rb
+++ b/modules/exploits/windows/browser/citrix_gateway_actx.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/clear_quest_cqole.rb
+++ b/modules/exploits/windows/browser/clear_quest_cqole.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/communicrypt_mail_activex.rb
+++ b/modules/exploits/windows/browser/communicrypt_mail_activex.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/creative_software_cachefolder.rb
+++ b/modules/exploits/windows/browser/creative_software_cachefolder.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/crystal_reports_printcontrol.rb
+++ b/modules/exploits/windows/browser/crystal_reports_printcontrol.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/dell_webcam_crazytalk.rb
+++ b/modules/exploits/windows/browser/dell_webcam_crazytalk.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/dxstudio_player_exec.rb
+++ b/modules/exploits/windows/browser/dxstudio_player_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ea_checkrequirements.rb
+++ b/modules/exploits/windows/browser/ea_checkrequirements.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ebook_flipviewer_fviewerloading.rb
+++ b/modules/exploits/windows/browser/ebook_flipviewer_fviewerloading.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/enjoysapgui_comp_download.rb
+++ b/modules/exploits/windows/browser/enjoysapgui_comp_download.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/enjoysapgui_preparetoposthtml.rb
+++ b/modules/exploits/windows/browser/enjoysapgui_preparetoposthtml.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/facebook_extractiptc.rb
+++ b/modules/exploits/windows/browser/facebook_extractiptc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
+++ b/modules/exploits/windows/browser/foxit_reader_plugin_url_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/gom_openurl.rb
+++ b/modules/exploits/windows/browser/gom_openurl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/greendam_url.rb
+++ b/modules/exploits/windows/browser/greendam_url.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/honeywell_hscremotedeploy_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_hscremotedeploy_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/honeywell_tema_exec.rb
+++ b/modules/exploits/windows/browser/honeywell_tema_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
+++ b/modules/exploits/windows/browser/hp_alm_xgo_setshapenodetype_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/hp_easy_printer_care_xmlcachemgr.rb
+++ b/modules/exploits/windows/browser/hp_easy_printer_care_xmlcachemgr.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/hp_easy_printer_care_xmlsimpleaccessor.rb
+++ b/modules/exploits/windows/browser/hp_easy_printer_care_xmlsimpleaccessor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/hp_loadrunner_addfile.rb
+++ b/modules/exploits/windows/browser/hp_loadrunner_addfile.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/hp_loadrunner_addfolder.rb
+++ b/modules/exploits/windows/browser/hp_loadrunner_addfolder.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/hp_loadrunner_writefilebinary.rb
+++ b/modules/exploits/windows/browser/hp_loadrunner_writefilebinary.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/hp_loadrunner_writefilestring.rb
+++ b/modules/exploits/windows/browser/hp_loadrunner_writefilestring.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/hpmqc_progcolor.rb
+++ b/modules/exploits/windows/browser/hpmqc_progcolor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/hyleos_chemviewx_activex.rb
+++ b/modules/exploits/windows/browser/hyleos_chemviewx_activex.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ibm_spss_c1sizer.rb
+++ b/modules/exploits/windows/browser/ibm_spss_c1sizer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ibm_tivoli_pme_activex_bof.rb
+++ b/modules/exploits/windows/browser/ibm_tivoli_pme_activex_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ibmegath_getxmlvalue.rb
+++ b/modules/exploits/windows/browser/ibmegath_getxmlvalue.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ibmlotusdomino_dwa_uploadmodule.rb
+++ b/modules/exploits/windows/browser/ibmlotusdomino_dwa_uploadmodule.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ie_cbutton_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cbutton_uaf.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ie_cgenericelement_uaf.rb
+++ b/modules/exploits/windows/browser/ie_cgenericelement_uaf.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ie_createobject.rb
+++ b/modules/exploits/windows/browser/ie_createobject.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ie_execcommand_uaf.rb
+++ b/modules/exploits/windows/browser/ie_execcommand_uaf.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ie_iscomponentinstalled.rb
+++ b/modules/exploits/windows/browser/ie_iscomponentinstalled.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
+++ b/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ie_unsafe_scripting.rb
+++ b/modules/exploits/windows/browser/ie_unsafe_scripting.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
+++ b/modules/exploits/windows/browser/imgeviewer_tifmergemultifiles.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb
+++ b/modules/exploits/windows/browser/indusoft_issymbol_internationalseparator.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/inotes_dwa85w_bof.rb
+++ b/modules/exploits/windows/browser/inotes_dwa85w_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/intrust_annotatex_add.rb
+++ b/modules/exploits/windows/browser/intrust_annotatex_add.rb
@@ -1,5 +1,5 @@
 ###
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/java_basicservice_impl.rb
+++ b/modules/exploits/windows/browser/java_basicservice_impl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/java_cmm.rb
+++ b/modules/exploits/windows/browser/java_cmm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/java_codebase_trust.rb
+++ b/modules/exploits/windows/browser/java_codebase_trust.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/java_docbase_bof.rb
+++ b/modules/exploits/windows/browser/java_docbase_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/java_mixer_sequencer.rb
+++ b/modules/exploits/windows/browser/java_mixer_sequencer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/java_ws_arginject_altjvm.rb
+++ b/modules/exploits/windows/browser/java_ws_arginject_altjvm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/java_ws_double_quote.rb
+++ b/modules/exploits/windows/browser/java_ws_double_quote.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/java_ws_vmargs.rb
+++ b/modules/exploits/windows/browser/java_ws_vmargs.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/juniper_sslvpn_ive_setupdll.rb
+++ b/modules/exploits/windows/browser/juniper_sslvpn_ive_setupdll.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/kazaa_altnet_heap.rb
+++ b/modules/exploits/windows/browser/kazaa_altnet_heap.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/keyhelp_launchtripane_exec.rb
+++ b/modules/exploits/windows/browser/keyhelp_launchtripane_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/logitechvideocall_start.rb
+++ b/modules/exploits/windows/browser/logitechvideocall_start.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/lpviewer_url.rb
+++ b/modules/exploits/windows/browser/lpviewer_url.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/macrovision_downloadandexecute.rb
+++ b/modules/exploits/windows/browser/macrovision_downloadandexecute.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/macrovision_unsafe.rb
+++ b/modules/exploits/windows/browser/macrovision_unsafe.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/maxthon_history_xcs.rb
+++ b/modules/exploits/windows/browser/maxthon_history_xcs.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/mcafee_mcsubmgr_vsprintf.rb
+++ b/modules/exploits/windows/browser/mcafee_mcsubmgr_vsprintf.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/mcafee_mvt_exec.rb
+++ b/modules/exploits/windows/browser/mcafee_mvt_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/mcafeevisualtrace_tracetarget.rb
+++ b/modules/exploits/windows/browser/mcafeevisualtrace_tracetarget.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/mirc_irc_url.rb
+++ b/modules/exploits/windows/browser/mirc_irc_url.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/mozilla_attribchildremoved.rb
+++ b/modules/exploits/windows/browser/mozilla_attribchildremoved.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/mozilla_firefox_onreadystatechange.rb
+++ b/modules/exploits/windows/browser/mozilla_firefox_onreadystatechange.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/mozilla_firefox_xmlserializer.rb
+++ b/modules/exploits/windows/browser/mozilla_firefox_xmlserializer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/mozilla_interleaved_write.rb
+++ b/modules/exploits/windows/browser/mozilla_interleaved_write.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/mozilla_mchannel.rb
+++ b/modules/exploits/windows/browser/mozilla_mchannel.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/mozilla_nssvgvalue.rb
+++ b/modules/exploits/windows/browser/mozilla_nssvgvalue.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/mozilla_nstreerange.rb
+++ b/modules/exploits/windows/browser/mozilla_nstreerange.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/mozilla_reduceright.rb
+++ b/modules/exploits/windows/browser/mozilla_reduceright.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms03_020_ie_objecttype.rb
+++ b/modules/exploits/windows/browser/ms03_020_ie_objecttype.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms05_054_onload.rb
+++ b/modules/exploits/windows/browser/ms05_054_onload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms06_001_wmf_setabortproc.rb
+++ b/modules/exploits/windows/browser/ms06_001_wmf_setabortproc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms06_013_createtextrange.rb
+++ b/modules/exploits/windows/browser/ms06_013_createtextrange.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms06_055_vml_method.rb
+++ b/modules/exploits/windows/browser/ms06_055_vml_method.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms06_057_webview_setslice.rb
+++ b/modules/exploits/windows/browser/ms06_057_webview_setslice.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms06_067_keyframe.rb
+++ b/modules/exploits/windows/browser/ms06_067_keyframe.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms06_071_xml_core.rb
+++ b/modules/exploits/windows/browser/ms06_071_xml_core.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms07_017_ani_loadimage_chunksize.rb
+++ b/modules/exploits/windows/browser/ms07_017_ani_loadimage_chunksize.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms08_041_snapshotviewer.rb
+++ b/modules/exploits/windows/browser/ms08_041_snapshotviewer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms08_053_mediaencoder.rb
+++ b/modules/exploits/windows/browser/ms08_053_mediaencoder.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms08_070_visual_studio_msmask.rb
+++ b/modules/exploits/windows/browser/ms08_070_visual_studio_msmask.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms08_078_xml_corruption.rb
+++ b/modules/exploits/windows/browser/ms08_078_xml_corruption.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms09_002_memory_corruption.rb
+++ b/modules/exploits/windows/browser/ms09_002_memory_corruption.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms09_043_owc_htmlurl.rb
+++ b/modules/exploits/windows/browser/ms09_043_owc_htmlurl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms09_043_owc_msdso.rb
+++ b/modules/exploits/windows/browser/ms09_043_owc_msdso.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms09_072_style_object.rb
+++ b/modules/exploits/windows/browser/ms09_072_style_object.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms10_002_aurora.rb
+++ b/modules/exploits/windows/browser/ms10_002_aurora.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms10_002_ie_object.rb
+++ b/modules/exploits/windows/browser/ms10_002_ie_object.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms10_018_ie_behaviors.rb
+++ b/modules/exploits/windows/browser/ms10_018_ie_behaviors.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms10_018_ie_tabular_activex.rb
+++ b/modules/exploits/windows/browser/ms10_018_ie_tabular_activex.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms10_022_ie_vbscript_winhlp32.rb
+++ b/modules/exploits/windows/browser/ms10_022_ie_vbscript_winhlp32.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms10_026_avi_nsamplespersec.rb
+++ b/modules/exploits/windows/browser/ms10_026_avi_nsamplespersec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms10_042_helpctr_xss_cmd_exec.rb
+++ b/modules/exploits/windows/browser/ms10_042_helpctr_xss_cmd_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms10_046_shortcut_icon_dllloader.rb
+++ b/modules/exploits/windows/browser/ms10_046_shortcut_icon_dllloader.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms10_090_ie_css_clip.rb
+++ b/modules/exploits/windows/browser/ms10_090_ie_css_clip.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms11_003_ie_css_import.rb
+++ b/modules/exploits/windows/browser/ms11_003_ie_css_import.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms11_050_mshtml_cobjectelement.rb
+++ b/modules/exploits/windows/browser/ms11_050_mshtml_cobjectelement.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms11_081_option.rb
+++ b/modules/exploits/windows/browser/ms11_081_option.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms11_093_ole32.rb
+++ b/modules/exploits/windows/browser/ms11_093_ole32.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms12_004_midi.rb
+++ b/modules/exploits/windows/browser/ms12_004_midi.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms12_037_ie_colspan.rb
+++ b/modules/exploits/windows/browser/ms12_037_ie_colspan.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms12_037_same_id.rb
+++ b/modules/exploits/windows/browser/ms12_037_same_id.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms13_009_ie_slayoutrun_uaf.rb
+++ b/modules/exploits/windows/browser/ms13_009_ie_slayoutrun_uaf.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms13_022_silverlight_script_object.rb
+++ b/modules/exploits/windows/browser/ms13_022_silverlight_script_object.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
+++ b/modules/exploits/windows/browser/ms13_037_svg_dashstyle.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms13_055_canchor.rb
+++ b/modules/exploits/windows/browser/ms13_055_canchor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms13_059_cflatmarkuppointer.rb
+++ b/modules/exploits/windows/browser/ms13_059_cflatmarkuppointer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms13_069_caret.rb
+++ b/modules/exploits/windows/browser/ms13_069_caret.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms13_080_cdisplaypointer.rb
+++ b/modules/exploits/windows/browser/ms13_080_cdisplaypointer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms13_090_cardspacesigninhelper.rb
+++ b/modules/exploits/windows/browser/ms13_090_cardspacesigninhelper.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms14_012_cmarkup_uaf.rb
+++ b/modules/exploits/windows/browser/ms14_012_cmarkup_uaf.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ms14_012_textrange.rb
+++ b/modules/exploits/windows/browser/ms14_012_textrange.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/msvidctl_mpeg2.rb
+++ b/modules/exploits/windows/browser/msvidctl_mpeg2.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/mswhale_checkforupdates.rb
+++ b/modules/exploits/windows/browser/mswhale_checkforupdates.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
+++ b/modules/exploits/windows/browser/msxml_get_definition_code_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/nctaudiofile2_setformatlikesample.rb
+++ b/modules/exploits/windows/browser/nctaudiofile2_setformatlikesample.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/nis2004_antispam.rb
+++ b/modules/exploits/windows/browser/nis2004_antispam.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/nis2004_get.rb
+++ b/modules/exploits/windows/browser/nis2004_get.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/notes_handler_cmdinject.rb
+++ b/modules/exploits/windows/browser/notes_handler_cmdinject.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/novell_groupwise_gwcls1_actvx.rb
+++ b/modules/exploits/windows/browser/novell_groupwise_gwcls1_actvx.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/novelliprint_callbackurl.rb
+++ b/modules/exploits/windows/browser/novelliprint_callbackurl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/novelliprint_datetime.rb
+++ b/modules/exploits/windows/browser/novelliprint_datetime.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/novelliprint_executerequest.rb
+++ b/modules/exploits/windows/browser/novelliprint_executerequest.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/novelliprint_executerequest_dbg.rb
+++ b/modules/exploits/windows/browser/novelliprint_executerequest_dbg.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/novelliprint_getdriversettings.rb
+++ b/modules/exploits/windows/browser/novelliprint_getdriversettings.rb
@@ -1,7 +1,7 @@
 # -*- coding: binary -*-
 
 ###
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/novelliprint_getdriversettings_2.rb
+++ b/modules/exploits/windows/browser/novelliprint_getdriversettings_2.rb
@@ -1,5 +1,5 @@
 ###
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/novelliprint_target_frame.rb
+++ b/modules/exploits/windows/browser/novelliprint_target_frame.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ntr_activex_check_bof.rb
+++ b/modules/exploits/windows/browser/ntr_activex_check_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ntr_activex_stopmodule.rb
+++ b/modules/exploits/windows/browser/ntr_activex_stopmodule.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/oracle_autovue_setmarkupmode.rb
+++ b/modules/exploits/windows/browser/oracle_autovue_setmarkupmode.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/oracle_dc_submittoexpress.rb
+++ b/modules/exploits/windows/browser/oracle_dc_submittoexpress.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/oracle_webcenter_checkoutandopen.rb
+++ b/modules/exploits/windows/browser/oracle_webcenter_checkoutandopen.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/orbit_connecting.rb
+++ b/modules/exploits/windows/browser/orbit_connecting.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ovftool_format_string.rb
+++ b/modules/exploits/windows/browser/ovftool_format_string.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/pcvue_func.rb
+++ b/modules/exploits/windows/browser/pcvue_func.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/persits_xupload_traversal.rb
+++ b/modules/exploits/windows/browser/persits_xupload_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/quickr_qp2_bof.rb
+++ b/modules/exploits/windows/browser/quickr_qp2_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/real_arcade_installerdlg.rb
+++ b/modules/exploits/windows/browser/real_arcade_installerdlg.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/realplayer_cdda_uri.rb
+++ b/modules/exploits/windows/browser/realplayer_cdda_uri.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/realplayer_console.rb
+++ b/modules/exploits/windows/browser/realplayer_console.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/realplayer_import.rb
+++ b/modules/exploits/windows/browser/realplayer_import.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/realplayer_qcp.rb
+++ b/modules/exploits/windows/browser/realplayer_qcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/realplayer_smil.rb
+++ b/modules/exploits/windows/browser/realplayer_smil.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/roxio_cineplayer.rb
+++ b/modules/exploits/windows/browser/roxio_cineplayer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/safari_xslt_output.rb
+++ b/modules/exploits/windows/browser/safari_xslt_output.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/samsung_neti_wiewer_backuptoavi_bof.rb
+++ b/modules/exploits/windows/browser/samsung_neti_wiewer_backuptoavi_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/sapgui_saveviewtosessionfile.rb
+++ b/modules/exploits/windows/browser/sapgui_saveviewtosessionfile.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/siemens_solid_edge_selistctrlx.rb
+++ b/modules/exploits/windows/browser/siemens_solid_edge_selistctrlx.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/softartisans_getdrivename.rb
+++ b/modules/exploits/windows/browser/softartisans_getdrivename.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/sonicwall_addrouteentry.rb
+++ b/modules/exploits/windows/browser/sonicwall_addrouteentry.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/symantec_altirisdeployment_downloadandinstall.rb
+++ b/modules/exploits/windows/browser/symantec_altirisdeployment_downloadandinstall.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/symantec_altirisdeployment_runcmd.rb
+++ b/modules/exploits/windows/browser/symantec_altirisdeployment_runcmd.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/symantec_appstream_unsafe.rb
+++ b/modules/exploits/windows/browser/symantec_appstream_unsafe.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/symantec_backupexec_pvcalendar.rb
+++ b/modules/exploits/windows/browser/symantec_backupexec_pvcalendar.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/symantec_consoleutilities_browseandsavefile.rb
+++ b/modules/exploits/windows/browser/symantec_consoleutilities_browseandsavefile.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/synactis_connecttosynactis_bof.rb
+++ b/modules/exploits/windows/browser/synactis_connecttosynactis_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/systemrequirementslab_unsafe.rb
+++ b/modules/exploits/windows/browser/systemrequirementslab_unsafe.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/teechart_pro.rb
+++ b/modules/exploits/windows/browser/teechart_pro.rb
@@ -1,5 +1,5 @@
 ###
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
+++ b/modules/exploits/windows/browser/tom_sawyer_tsgetx71ex552.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/trendmicro_extsetowner.rb
+++ b/modules/exploits/windows/browser/trendmicro_extsetowner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/trendmicro_officescan.rb
+++ b/modules/exploits/windows/browser/trendmicro_officescan.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/tumbleweed_filetransfer.rb
+++ b/modules/exploits/windows/browser/tumbleweed_filetransfer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ubisoft_uplay_cmd_exec.rb
+++ b/modules/exploits/windows/browser/ubisoft_uplay_cmd_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ultramjcam_openfiledig_bof.rb
+++ b/modules/exploits/windows/browser/ultramjcam_openfiledig_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/ultraoffice_httpupload.rb
+++ b/modules/exploits/windows/browser/ultraoffice_httpupload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/verypdf_pdfview.rb
+++ b/modules/exploits/windows/browser/verypdf_pdfview.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
+++ b/modules/exploits/windows/browser/viscom_movieplayer_drawtext.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/vlc_amv.rb
+++ b/modules/exploits/windows/browser/vlc_amv.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/vlc_mms_bof.rb
+++ b/modules/exploits/windows/browser/vlc_mms_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/webdav_dll_hijacker.rb
+++ b/modules/exploits/windows/browser/webdav_dll_hijacker.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/webex_ucf_newobject.rb
+++ b/modules/exploits/windows/browser/webex_ucf_newobject.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/wellintech_kingscada_kxclientdownload.rb
+++ b/modules/exploits/windows/browser/wellintech_kingscada_kxclientdownload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/winamp_playlist_unc.rb
+++ b/modules/exploits/windows/browser/winamp_playlist_unc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/winamp_ultravox.rb
+++ b/modules/exploits/windows/browser/winamp_ultravox.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/windvd7_applicationtype.rb
+++ b/modules/exploits/windows/browser/windvd7_applicationtype.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/winzip_fileview.rb
+++ b/modules/exploits/windows/browser/winzip_fileview.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/wmi_admintools.rb
+++ b/modules/exploits/windows/browser/wmi_admintools.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/xmplay_asx.rb
+++ b/modules/exploits/windows/browser/xmplay_asx.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/yahoomessenger_fvcom.rb
+++ b/modules/exploits/windows/browser/yahoomessenger_fvcom.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/yahoomessenger_server.rb
+++ b/modules/exploits/windows/browser/yahoomessenger_server.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/zenturiprogramchecker_unsafe.rb
+++ b/modules/exploits/windows/browser/zenturiprogramchecker_unsafe.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
+++ b/modules/exploits/windows/browser/zenworks_helplauncher_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/dcerpc/ms03_026_dcom.rb
+++ b/modules/exploits/windows/dcerpc/ms03_026_dcom.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/dcerpc/ms05_017_msmq.rb
+++ b/modules/exploits/windows/dcerpc/ms05_017_msmq.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/dcerpc/ms07_029_msdns_zonename.rb
+++ b/modules/exploits/windows/dcerpc/ms07_029_msdns_zonename.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/dcerpc/ms07_065_msmq.rb
+++ b/modules/exploits/windows/dcerpc/ms07_065_msmq.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/email/ms07_017_ani_loadimage_chunksize.rb
+++ b/modules/exploits/windows/email/ms07_017_ani_loadimage_chunksize.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/email/ms10_045_outlook_ref_only.rb
+++ b/modules/exploits/windows/email/ms10_045_outlook_ref_only.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/email/ms10_045_outlook_ref_resolve.rb
+++ b/modules/exploits/windows/email/ms10_045_outlook_ref_resolve.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/emc/alphastor_agent.rb
+++ b/modules/exploits/windows/emc/alphastor_agent.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/emc/networker_format_string.rb
+++ b/modules/exploits/windows/emc/networker_format_string.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/emc/replication_manager_exec.rb
+++ b/modules/exploits/windows/emc/replication_manager_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/a_pdf_wav_to_mp3.rb
+++ b/modules/exploits/windows/fileformat/a_pdf_wav_to_mp3.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/abbs_amp_lst.rb
+++ b/modules/exploits/windows/fileformat/abbs_amp_lst.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/acdsee_fotoslate_string.rb
+++ b/modules/exploits/windows/fileformat/acdsee_fotoslate_string.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/acdsee_xpm.rb
+++ b/modules/exploits/windows/fileformat/acdsee_xpm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/actfax_import_users_bof.rb
+++ b/modules/exploits/windows/fileformat/actfax_import_users_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/activepdf_webgrabber.rb
+++ b/modules/exploits/windows/fileformat/activepdf_webgrabber.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/adobe_collectemailinfo.rb
+++ b/modules/exploits/windows/fileformat/adobe_collectemailinfo.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/adobe_cooltype_sing.rb
+++ b/modules/exploits/windows/fileformat/adobe_cooltype_sing.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/adobe_flashplayer_button.rb
+++ b/modules/exploits/windows/fileformat/adobe_flashplayer_button.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/adobe_flashplayer_newfunction.rb
+++ b/modules/exploits/windows/fileformat/adobe_flashplayer_newfunction.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/adobe_flatedecode_predictor02.rb
+++ b/modules/exploits/windows/fileformat/adobe_flatedecode_predictor02.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/adobe_geticon.rb
+++ b/modules/exploits/windows/fileformat/adobe_geticon.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/adobe_illustrator_v14_eps.rb
+++ b/modules/exploits/windows/fileformat/adobe_illustrator_v14_eps.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/adobe_jbig2decode.rb
+++ b/modules/exploits/windows/fileformat/adobe_jbig2decode.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/adobe_libtiff.rb
+++ b/modules/exploits/windows/fileformat/adobe_libtiff.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/adobe_media_newplayer.rb
+++ b/modules/exploits/windows/fileformat/adobe_media_newplayer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
+++ b/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe_nojs.rb
+++ b/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe_nojs.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/adobe_reader_u3d.rb
+++ b/modules/exploits/windows/fileformat/adobe_reader_u3d.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/adobe_toolbutton.rb
+++ b/modules/exploits/windows/fileformat/adobe_toolbutton.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/adobe_u3d_meshdecl.rb
+++ b/modules/exploits/windows/fileformat/adobe_u3d_meshdecl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/adobe_utilprintf.rb
+++ b/modules/exploits/windows/fileformat/adobe_utilprintf.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/allplayer_m3u_bof.rb
+++ b/modules/exploits/windows/fileformat/allplayer_m3u_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/altap_salamander_pdb.rb
+++ b/modules/exploits/windows/fileformat/altap_salamander_pdb.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/aol_desktop_linktag.rb
+++ b/modules/exploits/windows/fileformat/aol_desktop_linktag.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/aol_phobos_bof.rb
+++ b/modules/exploits/windows/fileformat/aol_phobos_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/apple_quicktime_pnsize.rb
+++ b/modules/exploits/windows/fileformat/apple_quicktime_pnsize.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/apple_quicktime_rdrf.rb
+++ b/modules/exploits/windows/fileformat/apple_quicktime_rdrf.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/apple_quicktime_texml.rb
+++ b/modules/exploits/windows/fileformat/apple_quicktime_texml.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/audio_coder_m3u.rb
+++ b/modules/exploits/windows/fileformat/audio_coder_m3u.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/audio_wkstn_pls.rb
+++ b/modules/exploits/windows/fileformat/audio_wkstn_pls.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/audiotran_pls.rb
+++ b/modules/exploits/windows/fileformat/audiotran_pls.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/audiotran_pls_1424.rb
+++ b/modules/exploits/windows/fileformat/audiotran_pls_1424.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/aviosoft_plf_buf.rb
+++ b/modules/exploits/windows/fileformat/aviosoft_plf_buf.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/bacnet_csv.rb
+++ b/modules/exploits/windows/fileformat/bacnet_csv.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/beetel_netconfig_ini_bof.rb
+++ b/modules/exploits/windows/fileformat/beetel_netconfig_ini_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/blazedvd_hdtv_bof.rb
+++ b/modules/exploits/windows/fileformat/blazedvd_hdtv_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/blazedvd_plf.rb
+++ b/modules/exploits/windows/fileformat/blazedvd_plf.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/bsplayer_m3u.rb
+++ b/modules/exploits/windows/fileformat/bsplayer_m3u.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ca_cab.rb
+++ b/modules/exploits/windows/fileformat/ca_cab.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/cain_abel_4918_rdp.rb
+++ b/modules/exploits/windows/fileformat/cain_abel_4918_rdp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ccmplayer_m3u_bof.rb
+++ b/modules/exploits/windows/fileformat/ccmplayer_m3u_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/chasys_draw_ies_bmp_bof.rb
+++ b/modules/exploits/windows/fileformat/chasys_draw_ies_bmp_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/coolpdf_image_stream_bof.rb
+++ b/modules/exploits/windows/fileformat/coolpdf_image_stream_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/corelpdf_fusion_bof.rb
+++ b/modules/exploits/windows/fileformat/corelpdf_fusion_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/csound_getnum_bof.rb
+++ b/modules/exploits/windows/fileformat/csound_getnum_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/cutezip_bof.rb
+++ b/modules/exploits/windows/fileformat/cutezip_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/cyberlink_p2g_bof.rb
+++ b/modules/exploits/windows/fileformat/cyberlink_p2g_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/cytel_studio_cy3.rb
+++ b/modules/exploits/windows/fileformat/cytel_studio_cy3.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/deepburner_path.rb
+++ b/modules/exploits/windows/fileformat/deepburner_path.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/destinymediaplayer16.rb
+++ b/modules/exploits/windows/fileformat/destinymediaplayer16.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/digital_music_pad_pls.rb
+++ b/modules/exploits/windows/fileformat/digital_music_pad_pls.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/djstudio_pls_bof.rb
+++ b/modules/exploits/windows/fileformat/djstudio_pls_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/djvu_imageurl.rb
+++ b/modules/exploits/windows/fileformat/djvu_imageurl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/dvdx_plf_bof.rb
+++ b/modules/exploits/windows/fileformat/dvdx_plf_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/easycdda_pls_bof.rb
+++ b/modules/exploits/windows/fileformat/easycdda_pls_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/emc_appextender_keyworks.rb
+++ b/modules/exploits/windows/fileformat/emc_appextender_keyworks.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/erdas_er_viewer_bof.rb
+++ b/modules/exploits/windows/fileformat/erdas_er_viewer_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/erdas_er_viewer_rf_report_error.rb
+++ b/modules/exploits/windows/fileformat/erdas_er_viewer_rf_report_error.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/esignal_styletemplate_bof.rb
+++ b/modules/exploits/windows/fileformat/esignal_styletemplate_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/etrust_pestscan.rb
+++ b/modules/exploits/windows/fileformat/etrust_pestscan.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ezip_wizard_bof.rb
+++ b/modules/exploits/windows/fileformat/ezip_wizard_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/fatplayer_wav.rb
+++ b/modules/exploits/windows/fileformat/fatplayer_wav.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/fdm_torrent.rb
+++ b/modules/exploits/windows/fileformat/fdm_torrent.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/feeddemon_opml.rb
+++ b/modules/exploits/windows/fileformat/feeddemon_opml.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/foxit_reader_filewrite.rb
+++ b/modules/exploits/windows/fileformat/foxit_reader_filewrite.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/foxit_reader_launch.rb
+++ b/modules/exploits/windows/fileformat/foxit_reader_launch.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/foxit_title_bof.rb
+++ b/modules/exploits/windows/fileformat/foxit_title_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/free_mp3_ripper_wav.rb
+++ b/modules/exploits/windows/fileformat/free_mp3_ripper_wav.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/galan_fileformat_bof.rb
+++ b/modules/exploits/windows/fileformat/galan_fileformat_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/gsm_sim.rb
+++ b/modules/exploits/windows/fileformat/gsm_sim.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/gta_samp.rb
+++ b/modules/exploits/windows/fileformat/gta_samp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/hhw_hhp_compiledfile_bof.rb
+++ b/modules/exploits/windows/fileformat/hhw_hhp_compiledfile_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/hhw_hhp_contentfile_bof.rb
+++ b/modules/exploits/windows/fileformat/hhw_hhp_contentfile_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/hhw_hhp_indexfile_bof.rb
+++ b/modules/exploits/windows/fileformat/hhw_hhp_indexfile_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ht_mp3player_ht3_bof.rb
+++ b/modules/exploits/windows/fileformat/ht_mp3player_ht3_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ibm_forms_viewer_fontname.rb
+++ b/modules/exploits/windows/fileformat/ibm_forms_viewer_fontname.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ibm_pcm_ws.rb
+++ b/modules/exploits/windows/fileformat/ibm_pcm_ws.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/icofx_bof.rb
+++ b/modules/exploits/windows/fileformat/icofx_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ideal_migration_ipj.rb
+++ b/modules/exploits/windows/fileformat/ideal_migration_ipj.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/irfanview_jpeg2000_bof.rb
+++ b/modules/exploits/windows/fileformat/irfanview_jpeg2000_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ispvm_xcf_ispxcf.rb
+++ b/modules/exploits/windows/fileformat/ispvm_xcf_ispxcf.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/kingview_kingmess_kvl.rb
+++ b/modules/exploits/windows/fileformat/kingview_kingmess_kvl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/lattice_pac_bof.rb
+++ b/modules/exploits/windows/fileformat/lattice_pac_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/lotusnotes_lzh.rb
+++ b/modules/exploits/windows/fileformat/lotusnotes_lzh.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/magix_musikmaker_16_mmm.rb
+++ b/modules/exploits/windows/fileformat/magix_musikmaker_16_mmm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/mcafee_hercules_deletesnapshot.rb
+++ b/modules/exploits/windows/fileformat/mcafee_hercules_deletesnapshot.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/mcafee_showreport_exec.rb
+++ b/modules/exploits/windows/fileformat/mcafee_showreport_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/mediacoder_m3u.rb
+++ b/modules/exploits/windows/fileformat/mediacoder_m3u.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/mediajukebox.rb
+++ b/modules/exploits/windows/fileformat/mediajukebox.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/microp_mppl.rb
+++ b/modules/exploits/windows/fileformat/microp_mppl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/millenium_mp3_pls.rb
+++ b/modules/exploits/windows/fileformat/millenium_mp3_pls.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/mini_stream_pls_bof.rb
+++ b/modules/exploits/windows/fileformat/mini_stream_pls_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/mjm_coreplayer2011_s3m.rb
+++ b/modules/exploits/windows/fileformat/mjm_coreplayer2011_s3m.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/mjm_quickplayer_s3m.rb
+++ b/modules/exploits/windows/fileformat/mjm_quickplayer_s3m.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/moxa_mediadbplayback.rb
+++ b/modules/exploits/windows/fileformat/moxa_mediadbplayback.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/mplayer_m3u_bof.rb
+++ b/modules/exploits/windows/fileformat/mplayer_m3u_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/mplayer_sami_bof.rb
+++ b/modules/exploits/windows/fileformat/mplayer_sami_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ms09_067_excel_featheader.rb
+++ b/modules/exploits/windows/fileformat/ms09_067_excel_featheader.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ms10_004_textbytesatom.rb
+++ b/modules/exploits/windows/fileformat/ms10_004_textbytesatom.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ms10_038_excel_obj_bof.rb
+++ b/modules/exploits/windows/fileformat/ms10_038_excel_obj_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ms10_087_rtf_pfragments_bof.rb
+++ b/modules/exploits/windows/fileformat/ms10_087_rtf_pfragments_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ms11_006_createsizeddibsection.rb
+++ b/modules/exploits/windows/fileformat/ms11_006_createsizeddibsection.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ms11_021_xlb_bof.rb
+++ b/modules/exploits/windows/fileformat/ms11_021_xlb_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ms12_005.rb
+++ b/modules/exploits/windows/fileformat/ms12_005.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ms12_027_mscomctl_bof.rb
+++ b/modules/exploits/windows/fileformat/ms12_027_mscomctl_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ms13_071_theme.rb
+++ b/modules/exploits/windows/fileformat/ms13_071_theme.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ms14_017_rtf.rb
+++ b/modules/exploits/windows/fileformat/ms14_017_rtf.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ms_visual_basic_vbp.rb
+++ b/modules/exploits/windows/fileformat/ms_visual_basic_vbp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/mswin_tiff_overflow.rb
+++ b/modules/exploits/windows/fileformat/mswin_tiff_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/msworks_wkspictureinterface.rb
+++ b/modules/exploits/windows/fileformat/msworks_wkspictureinterface.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/mymp3player_m3u.rb
+++ b/modules/exploits/windows/fileformat/mymp3player_m3u.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/netop.rb
+++ b/modules/exploits/windows/fileformat/netop.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/nuance_pdf_launch_overflow.rb
+++ b/modules/exploits/windows/fileformat/nuance_pdf_launch_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/openoffice_ole.rb
+++ b/modules/exploits/windows/fileformat/openoffice_ole.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/orbit_download_failed_bof.rb
+++ b/modules/exploits/windows/fileformat/orbit_download_failed_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/orbital_viewer_orb.rb
+++ b/modules/exploits/windows/fileformat/orbital_viewer_orb.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ovf_format_string.rb
+++ b/modules/exploits/windows/fileformat/ovf_format_string.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/proshow_cellimage_bof.rb
+++ b/modules/exploits/windows/fileformat/proshow_cellimage_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/proshow_load_bof.rb
+++ b/modules/exploits/windows/fileformat/proshow_load_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/real_networks_netzip_bof.rb
+++ b/modules/exploits/windows/fileformat/real_networks_netzip_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/real_player_url_property_bof.rb
+++ b/modules/exploits/windows/fileformat/real_player_url_property_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
+++ b/modules/exploits/windows/fileformat/realplayer_ver_attribute_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/safenet_softremote_groupname.rb
+++ b/modules/exploits/windows/fileformat/safenet_softremote_groupname.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/sascam_get.rb
+++ b/modules/exploits/windows/fileformat/sascam_get.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/scadaphone_zip.rb
+++ b/modules/exploits/windows/fileformat/scadaphone_zip.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/shadow_stream_recorder_bof.rb
+++ b/modules/exploits/windows/fileformat/shadow_stream_recorder_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/somplplayer_m3u.rb
+++ b/modules/exploits/windows/fileformat/somplplayer_m3u.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/subtitle_processor_m3u_bof.rb
+++ b/modules/exploits/windows/fileformat/subtitle_processor_m3u_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/tfm_mmplayer_m3u_ppl_bof.rb
+++ b/modules/exploits/windows/fileformat/tfm_mmplayer_m3u_ppl_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/tugzip.rb
+++ b/modules/exploits/windows/fileformat/tugzip.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ultraiso_ccd.rb
+++ b/modules/exploits/windows/fileformat/ultraiso_ccd.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ultraiso_cue.rb
+++ b/modules/exploits/windows/fileformat/ultraiso_cue.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/ursoft_w32dasm.rb
+++ b/modules/exploits/windows/fileformat/ursoft_w32dasm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/varicad_dwb.rb
+++ b/modules/exploits/windows/fileformat/varicad_dwb.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/videolan_tivo.rb
+++ b/modules/exploits/windows/fileformat/videolan_tivo.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/videospirit_visprj.rb
+++ b/modules/exploits/windows/fileformat/videospirit_visprj.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/visio_dxf_bof.rb
+++ b/modules/exploits/windows/fileformat/visio_dxf_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 
 require 'msf/core'

--- a/modules/exploits/windows/fileformat/visiwave_vwr_type.rb
+++ b/modules/exploits/windows/fileformat/visiwave_vwr_type.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/vlc_modplug_s3m.rb
+++ b/modules/exploits/windows/fileformat/vlc_modplug_s3m.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/vlc_realtext.rb
+++ b/modules/exploits/windows/fileformat/vlc_realtext.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/vlc_smb_uri.rb
+++ b/modules/exploits/windows/fileformat/vlc_smb_uri.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/vlc_webm.rb
+++ b/modules/exploits/windows/fileformat/vlc_webm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/vuplayer_cue.rb
+++ b/modules/exploits/windows/fileformat/vuplayer_cue.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/vuplayer_m3u.rb
+++ b/modules/exploits/windows/fileformat/vuplayer_m3u.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/winamp_maki_bof.rb
+++ b/modules/exploits/windows/fileformat/winamp_maki_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/winrar_name_spoofing.rb
+++ b/modules/exploits/windows/fileformat/winrar_name_spoofing.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/wireshark_mpeg_overflow.rb
+++ b/modules/exploits/windows/fileformat/wireshark_mpeg_overflow.rb
@@ -1,5 +1,5 @@
 #
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/wireshark_packet_dect.rb
+++ b/modules/exploits/windows/fileformat/wireshark_packet_dect.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/wm_downloader_m3u.rb
+++ b/modules/exploits/windows/fileformat/wm_downloader_m3u.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/xenorate_xpl_bof.rb
+++ b/modules/exploits/windows/fileformat/xenorate_xpl_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/xion_m3u_sehbof.rb
+++ b/modules/exploits/windows/fileformat/xion_m3u_sehbof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/xradio_xrl_sehbof.rb
+++ b/modules/exploits/windows/fileformat/xradio_xrl_sehbof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/fileformat/zinfaudioplayer221_pls.rb
+++ b/modules/exploits/windows/fileformat/zinfaudioplayer221_pls.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/firewall/blackice_pam_icq.rb
+++ b/modules/exploits/windows/firewall/blackice_pam_icq.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/firewall/kerio_auth.rb
+++ b/modules/exploits/windows/firewall/kerio_auth.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/32bitftp_list_reply.rb
+++ b/modules/exploits/windows/ftp/32bitftp_list_reply.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/3cdaemon_ftp_user.rb
+++ b/modules/exploits/windows/ftp/3cdaemon_ftp_user.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/aasync_list_reply.rb
+++ b/modules/exploits/windows/ftp/aasync_list_reply.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/ability_server_stor.rb
+++ b/modules/exploits/windows/ftp/ability_server_stor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/absolute_ftp_list_bof.rb
+++ b/modules/exploits/windows/ftp/absolute_ftp_list_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/cesarftp_mkd.rb
+++ b/modules/exploits/windows/ftp/cesarftp_mkd.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/comsnd_ftpd_fmtstr.rb
+++ b/modules/exploits/windows/ftp/comsnd_ftpd_fmtstr.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/dreamftp_format.rb
+++ b/modules/exploits/windows/ftp/dreamftp_format.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/easyfilesharing_pass.rb
+++ b/modules/exploits/windows/ftp/easyfilesharing_pass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/easyftp_cwd_fixret.rb
+++ b/modules/exploits/windows/ftp/easyftp_cwd_fixret.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/easyftp_list_fixret.rb
+++ b/modules/exploits/windows/ftp/easyftp_list_fixret.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/easyftp_mkd_fixret.rb
+++ b/modules/exploits/windows/ftp/easyftp_mkd_fixret.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/filecopa_list_overflow.rb
+++ b/modules/exploits/windows/ftp/filecopa_list_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/filewrangler_list_reply.rb
+++ b/modules/exploits/windows/ftp/filewrangler_list_reply.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/freefloatftp_user.rb
+++ b/modules/exploits/windows/ftp/freefloatftp_user.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/freefloatftp_wbem.rb
+++ b/modules/exploits/windows/ftp/freefloatftp_wbem.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/freeftpd_pass.rb
+++ b/modules/exploits/windows/ftp/freeftpd_pass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/freeftpd_user.rb
+++ b/modules/exploits/windows/ftp/freeftpd_user.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/ftpgetter_pwd_reply.rb
+++ b/modules/exploits/windows/ftp/ftpgetter_pwd_reply.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/ftppad_list_reply.rb
+++ b/modules/exploits/windows/ftp/ftppad_list_reply.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/ftpshell51_pwd_reply.rb
+++ b/modules/exploits/windows/ftp/ftpshell51_pwd_reply.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/ftpsynch_list_reply.rb
+++ b/modules/exploits/windows/ftp/ftpsynch_list_reply.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/gekkomgr_list_reply.rb
+++ b/modules/exploits/windows/ftp/gekkomgr_list_reply.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/globalscapeftp_input.rb
+++ b/modules/exploits/windows/ftp/globalscapeftp_input.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/goldenftp_pass_bof.rb
+++ b/modules/exploits/windows/ftp/goldenftp_pass_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/httpdx_tolog_format.rb
+++ b/modules/exploits/windows/ftp/httpdx_tolog_format.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/leapftp_list_reply.rb
+++ b/modules/exploits/windows/ftp/leapftp_list_reply.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/leapftp_pasv_reply.rb
+++ b/modules/exploits/windows/ftp/leapftp_pasv_reply.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/ms09_053_ftpd_nlst.rb
+++ b/modules/exploits/windows/ftp/ms09_053_ftpd_nlst.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/netterm_netftpd_user.rb
+++ b/modules/exploits/windows/ftp/netterm_netftpd_user.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/odin_list_reply.rb
+++ b/modules/exploits/windows/ftp/odin_list_reply.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/open_ftpd_wbem.rb
+++ b/modules/exploits/windows/ftp/open_ftpd_wbem.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/oracle9i_xdb_ftp_pass.rb
+++ b/modules/exploits/windows/ftp/oracle9i_xdb_ftp_pass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/oracle9i_xdb_ftp_unlock.rb
+++ b/modules/exploits/windows/ftp/oracle9i_xdb_ftp_unlock.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/pcman_stor.rb
+++ b/modules/exploits/windows/ftp/pcman_stor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/proftp_banner.rb
+++ b/modules/exploits/windows/ftp/proftp_banner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/quickshare_traversal_write.rb
+++ b/modules/exploits/windows/ftp/quickshare_traversal_write.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/ricoh_dl_bof.rb
+++ b/modules/exploits/windows/ftp/ricoh_dl_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/sami_ftpd_list.rb
+++ b/modules/exploits/windows/ftp/sami_ftpd_list.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/sami_ftpd_user.rb
+++ b/modules/exploits/windows/ftp/sami_ftpd_user.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/sasser_ftpd_port.rb
+++ b/modules/exploits/windows/ftp/sasser_ftpd_port.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/scriptftp_list.rb
+++ b/modules/exploits/windows/ftp/scriptftp_list.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/seagull_list_reply.rb
+++ b/modules/exploits/windows/ftp/seagull_list_reply.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/servu_chmod.rb
+++ b/modules/exploits/windows/ftp/servu_chmod.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/servu_mdtm.rb
+++ b/modules/exploits/windows/ftp/servu_mdtm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/slimftpd_list_concat.rb
+++ b/modules/exploits/windows/ftp/slimftpd_list_concat.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/trellian_client_pasv.rb
+++ b/modules/exploits/windows/ftp/trellian_client_pasv.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/turboftp_port.rb
+++ b/modules/exploits/windows/ftp/turboftp_port.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/vermillion_ftpd_port.rb
+++ b/modules/exploits/windows/ftp/vermillion_ftpd_port.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/warftpd_165_pass.rb
+++ b/modules/exploits/windows/ftp/warftpd_165_pass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/warftpd_165_user.rb
+++ b/modules/exploits/windows/ftp/warftpd_165_user.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/wftpd_size.rb
+++ b/modules/exploits/windows/ftp/wftpd_size.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
+++ b/modules/exploits/windows/ftp/wing_ftp_admin_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/wsftp_server_503_mkd.rb
+++ b/modules/exploits/windows/ftp/wsftp_server_503_mkd.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/wsftp_server_505_xmd5.rb
+++ b/modules/exploits/windows/ftp/wsftp_server_505_xmd5.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/xftp_client_pwd.rb
+++ b/modules/exploits/windows/ftp/xftp_client_pwd.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/xlink_client.rb
+++ b/modules/exploits/windows/ftp/xlink_client.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ftp/xlink_server.rb
+++ b/modules/exploits/windows/ftp/xlink_server.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/games/mohaa_getinfo.rb
+++ b/modules/exploits/windows/games/mohaa_getinfo.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/games/racer_503beta5.rb
+++ b/modules/exploits/windows/games/racer_503beta5.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/games/ut2004_secure.rb
+++ b/modules/exploits/windows/games/ut2004_secure.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/adobe_robohelper_authbypass.rb
+++ b/modules/exploits/windows/http/adobe_robohelper_authbypass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/altn_securitygateway.rb
+++ b/modules/exploits/windows/http/altn_securitygateway.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/altn_webadmin.rb
+++ b/modules/exploits/windows/http/altn_webadmin.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/amlibweb_webquerydll_app.rb
+++ b/modules/exploits/windows/http/amlibweb_webquerydll_app.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/apache_chunked.rb
+++ b/modules/exploits/windows/http/apache_chunked.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/apache_mod_rewrite_ldap.rb
+++ b/modules/exploits/windows/http/apache_mod_rewrite_ldap.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/apache_modjk_overflow.rb
+++ b/modules/exploits/windows/http/apache_modjk_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/avaya_ccr_imageupload_exec.rb
+++ b/modules/exploits/windows/http/avaya_ccr_imageupload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/badblue_ext_overflow.rb
+++ b/modules/exploits/windows/http/badblue_ext_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/badblue_passthru.rb
+++ b/modules/exploits/windows/http/badblue_passthru.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/bea_weblogic_jsessionid.rb
+++ b/modules/exploits/windows/http/bea_weblogic_jsessionid.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/bea_weblogic_post_bof.rb
+++ b/modules/exploits/windows/http/bea_weblogic_post_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/bea_weblogic_transfer_encoding.rb
+++ b/modules/exploits/windows/http/bea_weblogic_transfer_encoding.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/belkin_bulldog.rb
+++ b/modules/exploits/windows/http/belkin_bulldog.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/ca_arcserve_rpc_authbypass.rb
+++ b/modules/exploits/windows/http/ca_arcserve_rpc_authbypass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/ca_igateway_debug.rb
+++ b/modules/exploits/windows/http/ca_igateway_debug.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/ca_totaldefense_regeneratereports.rb
+++ b/modules/exploits/windows/http/ca_totaldefense_regeneratereports.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/cogent_datahub_command.rb
+++ b/modules/exploits/windows/http/cogent_datahub_command.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/cogent_datahub_request_headers_bof.rb
+++ b/modules/exploits/windows/http/cogent_datahub_request_headers_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/coldfusion_fckeditor.rb
+++ b/modules/exploits/windows/http/coldfusion_fckeditor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/cyclope_ess_sqli.rb
+++ b/modules/exploits/windows/http/cyclope_ess_sqli.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/desktopcentral_file_upload.rb
+++ b/modules/exploits/windows/http/desktopcentral_file_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/desktopcentral_statusupdate_upload.rb
+++ b/modules/exploits/windows/http/desktopcentral_statusupdate_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/easyftp_list.rb
+++ b/modules/exploits/windows/http/easyftp_list.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/edirectory_host.rb
+++ b/modules/exploits/windows/http/edirectory_host.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/edirectory_imonitor.rb
+++ b/modules/exploits/windows/http/edirectory_imonitor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/efs_easychatserver_username.rb
+++ b/modules/exploits/windows/http/efs_easychatserver_username.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/efs_fmws_userid_bof.rb
+++ b/modules/exploits/windows/http/efs_fmws_userid_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/ektron_xslt_exec.rb
+++ b/modules/exploits/windows/http/ektron_xslt_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/ericom_access_now_bof.rb
+++ b/modules/exploits/windows/http/ericom_access_now_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/ezserver_http.rb
+++ b/modules/exploits/windows/http/ezserver_http.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/fdm_auth_header.rb
+++ b/modules/exploits/windows/http/fdm_auth_header.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_autopass_license_traversal.rb
+++ b/modules/exploits/windows/http/hp_autopass_license_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_imc_bims_upload.rb
+++ b/modules/exploits/windows/http/hp_imc_bims_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_imc_mibfileupload.rb
+++ b/modules/exploits/windows/http/hp_imc_mibfileupload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_loadrunner_copyfiletoserver.rb
+++ b/modules/exploits/windows/http/hp_loadrunner_copyfiletoserver.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_mpa_job_acct.rb
+++ b/modules/exploits/windows/http/hp_mpa_job_acct.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_getnnmdata_hostname.rb
+++ b/modules/exploits/windows/http/hp_nnm_getnnmdata_hostname.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_getnnmdata_icount.rb
+++ b/modules/exploits/windows/http/hp_nnm_getnnmdata_icount.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_getnnmdata_maxage.rb
+++ b/modules/exploits/windows/http/hp_nnm_getnnmdata_maxage.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_nnmrptconfig_nameparams.rb
+++ b/modules/exploits/windows/http/hp_nnm_nnmrptconfig_nameparams.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_nnmrptconfig_schdparams.rb
+++ b/modules/exploits/windows/http/hp_nnm_nnmrptconfig_schdparams.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_openview5.rb
+++ b/modules/exploits/windows/http/hp_nnm_openview5.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_ovalarm_lang.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovalarm_lang.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_ovas.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovas.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_ovbuildpath_textfile.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovbuildpath_textfile.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_ovwebhelp.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovwebhelp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_main.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_main.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_ovutil.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_ovutil.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_uro.rb
+++ b/modules/exploits/windows/http/hp_nnm_ovwebsnmpsrv_uro.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_snmp.rb
+++ b/modules/exploits/windows/http/hp_nnm_snmp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_snmpviewer_actapp.rb
+++ b/modules/exploits/windows/http/hp_nnm_snmpviewer_actapp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_toolbar_01.rb
+++ b/modules/exploits/windows/http/hp_nnm_toolbar_01.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_toolbar_02.rb
+++ b/modules/exploits/windows/http/hp_nnm_toolbar_02.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_webappmon_execvp.rb
+++ b/modules/exploits/windows/http/hp_nnm_webappmon_execvp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_nnm_webappmon_ovjavalocale.rb
+++ b/modules/exploits/windows/http/hp_nnm_webappmon_ovjavalocale.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_openview_insight_backdoor.rb
+++ b/modules/exploits/windows/http/hp_openview_insight_backdoor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_pcm_snac_update_certificates.rb
+++ b/modules/exploits/windows/http/hp_pcm_snac_update_certificates.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_pcm_snac_update_domain.rb
+++ b/modules/exploits/windows/http/hp_pcm_snac_update_domain.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_power_manager_filename.rb
+++ b/modules/exploits/windows/http/hp_power_manager_filename.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_power_manager_login.rb
+++ b/modules/exploits/windows/http/hp_power_manager_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/hp_sitescope_runomagentcommand.rb
+++ b/modules/exploits/windows/http/hp_sitescope_runomagentcommand.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/httpdx_handlepeer.rb
+++ b/modules/exploits/windows/http/httpdx_handlepeer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/httpdx_tolog_format.rb
+++ b/modules/exploits/windows/http/httpdx_tolog_format.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/ia_webmail.rb
+++ b/modules/exploits/windows/http/ia_webmail.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/ibm_tivoli_endpoint_bof.rb
+++ b/modules/exploits/windows/http/ibm_tivoli_endpoint_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/ibm_tpmfosd_overflow.rb
+++ b/modules/exploits/windows/http/ibm_tpmfosd_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/ibm_tsm_cad_header.rb
+++ b/modules/exploits/windows/http/ibm_tsm_cad_header.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/icecast_header.rb
+++ b/modules/exploits/windows/http/icecast_header.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/integard_password_bof.rb
+++ b/modules/exploits/windows/http/integard_password_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/intersystems_cache.rb
+++ b/modules/exploits/windows/http/intersystems_cache.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/intrasrv_bof.rb
+++ b/modules/exploits/windows/http/intrasrv_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/ipswitch_wug_maincfgret.rb
+++ b/modules/exploits/windows/http/ipswitch_wug_maincfgret.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/jira_collector_traversal.rb
+++ b/modules/exploits/windows/http/jira_collector_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/kaseya_uploadimage_file_upload.rb
+++ b/modules/exploits/windows/http/kaseya_uploadimage_file_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/kolibri_http.rb
+++ b/modules/exploits/windows/http/kolibri_http.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/landesk_thinkmanagement_upload_asp.rb
+++ b/modules/exploits/windows/http/landesk_thinkmanagement_upload_asp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/mailenable_auth_header.rb
+++ b/modules/exploits/windows/http/mailenable_auth_header.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/manageengine_apps_mngr.rb
+++ b/modules/exploits/windows/http/manageengine_apps_mngr.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/maxdb_webdbm_database.rb
+++ b/modules/exploits/windows/http/maxdb_webdbm_database.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/maxdb_webdbm_get_overflow.rb
+++ b/modules/exploits/windows/http/maxdb_webdbm_get_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/mcafee_epolicy_source.rb
+++ b/modules/exploits/windows/http/mcafee_epolicy_source.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/mdaemon_worldclient_form2raw.rb
+++ b/modules/exploits/windows/http/mdaemon_worldclient_form2raw.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/minishare_get_overflow.rb
+++ b/modules/exploits/windows/http/minishare_get_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/miniweb_upload_wbem.rb
+++ b/modules/exploits/windows/http/miniweb_upload_wbem.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/navicopa_get_overflow.rb
+++ b/modules/exploits/windows/http/navicopa_get_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/netdecision_http_bof.rb
+++ b/modules/exploits/windows/http/netdecision_http_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/novell_imanager_upload.rb
+++ b/modules/exploits/windows/http/novell_imanager_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/novell_mdm_lfi.rb
+++ b/modules/exploits/windows/http/novell_mdm_lfi.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/novell_messenger_acceptlang.rb
+++ b/modules/exploits/windows/http/novell_messenger_acceptlang.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/nowsms.rb
+++ b/modules/exploits/windows/http/nowsms.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/oracle9i_xdb_pass.rb
+++ b/modules/exploits/windows/http/oracle9i_xdb_pass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/oracle_btm_writetofile.rb
+++ b/modules/exploits/windows/http/oracle_btm_writetofile.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/oracle_endeca_exec.rb
+++ b/modules/exploits/windows/http/oracle_endeca_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/oracle_event_processing_upload.rb
+++ b/modules/exploits/windows/http/oracle_event_processing_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/osb_uname_jlist.rb
+++ b/modules/exploits/windows/http/osb_uname_jlist.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/peercast_url.rb
+++ b/modules/exploits/windows/http/peercast_url.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/php_apache_request_headers_bof.rb
+++ b/modules/exploits/windows/http/php_apache_request_headers_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/privatewire_gateway.rb
+++ b/modules/exploits/windows/http/privatewire_gateway.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/psoproxy91_overflow.rb
+++ b/modules/exploits/windows/http/psoproxy91_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/rabidhamster_r4_log.rb
+++ b/modules/exploits/windows/http/rabidhamster_r4_log.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/rejetto_hfs_exec.rb
+++ b/modules/exploits/windows/http/rejetto_hfs_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/sambar6_search_results.rb
+++ b/modules/exploits/windows/http/sambar6_search_results.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
+++ b/modules/exploits/windows/http/sap_configservlet_exec_noauth.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/sap_host_control_cmd_exec.rb
+++ b/modules/exploits/windows/http/sap_host_control_cmd_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/sapdb_webtools.rb
+++ b/modules/exploits/windows/http/sapdb_webtools.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/savant_31_overflow.rb
+++ b/modules/exploits/windows/http/savant_31_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/servu_session_cookie.rb
+++ b/modules/exploits/windows/http/servu_session_cookie.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/shoutcast_format.rb
+++ b/modules/exploits/windows/http/shoutcast_format.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/shttpd_post.rb
+++ b/modules/exploits/windows/http/shttpd_post.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
+++ b/modules/exploits/windows/http/solarwinds_storage_manager_sql.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/sonicwall_scrutinizer_sqli.rb
+++ b/modules/exploits/windows/http/sonicwall_scrutinizer_sqli.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/steamcast_useragent.rb
+++ b/modules/exploits/windows/http/steamcast_useragent.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/sws_connection_bof.rb
+++ b/modules/exploits/windows/http/sws_connection_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/sybase_easerver.rb
+++ b/modules/exploits/windows/http/sybase_easerver.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/sysax_create_folder.rb
+++ b/modules/exploits/windows/http/sysax_create_folder.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/trackercam_phparg_overflow.rb
+++ b/modules/exploits/windows/http/trackercam_phparg_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/trendmicro_officescan.rb
+++ b/modules/exploits/windows/http/trendmicro_officescan.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/ultraminihttp_bof.rb
+++ b/modules/exploits/windows/http/ultraminihttp_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/umbraco_upload_aspx.rb
+++ b/modules/exploits/windows/http/umbraco_upload_aspx.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/vmware_vcenter_chargeback_upload.rb
+++ b/modules/exploits/windows/http/vmware_vcenter_chargeback_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/webster_http.rb
+++ b/modules/exploits/windows/http/webster_http.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/xampp_webdav_upload_php.rb
+++ b/modules/exploits/windows/http/xampp_webdav_upload_php.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/xitami_if_mod_since.rb
+++ b/modules/exploits/windows/http/xitami_if_mod_since.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/zenworks_assetmgmt_uploadservlet.rb
+++ b/modules/exploits/windows/http/zenworks_assetmgmt_uploadservlet.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/http/zenworks_uploadservlet.rb
+++ b/modules/exploits/windows/http/zenworks_uploadservlet.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
+++ b/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/iis/ms01_023_printer.rb
+++ b/modules/exploits/windows/iis/ms01_023_printer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/iis/ms01_026_dbldecode.rb
+++ b/modules/exploits/windows/iis/ms01_026_dbldecode.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/iis/ms01_033_idq.rb
+++ b/modules/exploits/windows/iis/ms01_033_idq.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/iis/ms02_018_htr.rb
+++ b/modules/exploits/windows/iis/ms02_018_htr.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/iis/ms02_065_msadc.rb
+++ b/modules/exploits/windows/iis/ms02_065_msadc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/iis/ms03_007_ntdll_webdav.rb
+++ b/modules/exploits/windows/iis/ms03_007_ntdll_webdav.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/imap/eudora_list.rb
+++ b/modules/exploits/windows/imap/eudora_list.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/imap/imail_delete.rb
+++ b/modules/exploits/windows/imap/imail_delete.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/imap/ipswitch_search.rb
+++ b/modules/exploits/windows/imap/ipswitch_search.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/imap/mailenable_login.rb
+++ b/modules/exploits/windows/imap/mailenable_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/imap/mailenable_status.rb
+++ b/modules/exploits/windows/imap/mailenable_status.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/imap/mailenable_w3c_select.rb
+++ b/modules/exploits/windows/imap/mailenable_w3c_select.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/imap/mdaemon_cram_md5.rb
+++ b/modules/exploits/windows/imap/mdaemon_cram_md5.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/imap/mdaemon_fetch.rb
+++ b/modules/exploits/windows/imap/mdaemon_fetch.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/imap/mercur_imap_select_overflow.rb
+++ b/modules/exploits/windows/imap/mercur_imap_select_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/imap/mercur_login.rb
+++ b/modules/exploits/windows/imap/mercur_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/imap/mercury_login.rb
+++ b/modules/exploits/windows/imap/mercury_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/imap/mercury_rename.rb
+++ b/modules/exploits/windows/imap/mercury_rename.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/imap/novell_netmail_append.rb
+++ b/modules/exploits/windows/imap/novell_netmail_append.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/imap/novell_netmail_auth.rb
+++ b/modules/exploits/windows/imap/novell_netmail_auth.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/imap/novell_netmail_status.rb
+++ b/modules/exploits/windows/imap/novell_netmail_status.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/imap/novell_netmail_subscribe.rb
+++ b/modules/exploits/windows/imap/novell_netmail_subscribe.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/isapi/ms00_094_pbserver.rb
+++ b/modules/exploits/windows/isapi/ms00_094_pbserver.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/isapi/ms03_022_nsiislog_post.rb
+++ b/modules/exploits/windows/isapi/ms03_022_nsiislog_post.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/isapi/ms03_051_fp30reg_chunked.rb
+++ b/modules/exploits/windows/isapi/ms03_051_fp30reg_chunked.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/isapi/rsa_webagent_redirect.rb
+++ b/modules/exploits/windows/isapi/rsa_webagent_redirect.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/isapi/w3who_query.rb
+++ b/modules/exploits/windows/isapi/w3who_query.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ldap/imail_thc.rb
+++ b/modules/exploits/windows/ldap/imail_thc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ldap/pgp_keyserver7.rb
+++ b/modules/exploits/windows/ldap/pgp_keyserver7.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/license/calicclnt_getconfig.rb
+++ b/modules/exploits/windows/license/calicclnt_getconfig.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/license/calicserv_getconfig.rb
+++ b/modules/exploits/windows/license/calicserv_getconfig.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/license/flexnet_lmgrd_bof.rb
+++ b/modules/exploits/windows/license/flexnet_lmgrd_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/license/sentinel_lm7_udp.rb
+++ b/modules/exploits/windows/license/sentinel_lm7_udp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/adobe_sandbox_adobecollabsync.rb
+++ b/modules/exploits/windows/local/adobe_sandbox_adobecollabsync.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/agnitum_outpost_acs.rb
+++ b/modules/exploits/windows/local/agnitum_outpost_acs.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/always_install_elevated.rb
+++ b/modules/exploits/windows/local/always_install_elevated.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/ask.rb
+++ b/modules/exploits/windows/local/ask.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/bthpan.rb
+++ b/modules/exploits/windows/local/bthpan.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/bypassuac.rb
+++ b/modules/exploits/windows/local/bypassuac.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/bypassuac_injection.rb
+++ b/modules/exploits/windows/local/bypassuac_injection.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/current_user_psexec.rb
+++ b/modules/exploits/windows/local/current_user_psexec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/ikeext_service.rb
+++ b/modules/exploits/windows/local/ikeext_service.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/mqac_write.rb
+++ b/modules/exploits/windows/local/mqac_write.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/ms10_015_kitrap0d.rb
+++ b/modules/exploits/windows/local/ms10_015_kitrap0d.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/ms10_092_schelevator.rb
+++ b/modules/exploits/windows/local/ms10_092_schelevator.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/ms11_080_afdjoinleaf.rb
+++ b/modules/exploits/windows/local/ms11_080_afdjoinleaf.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
+++ b/modules/exploits/windows/local/ms13_005_hwnd_broadcast.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/ms13_053_schlamperei.rb
+++ b/modules/exploits/windows/local/ms13_053_schlamperei.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/ms13_081_track_popup_menu.rb
+++ b/modules/exploits/windows/local/ms13_081_track_popup_menu.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/ms13_097_ie_registry_symlink.rb
+++ b/modules/exploits/windows/local/ms13_097_ie_registry_symlink.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/ms14_009_ie_dfsvc.rb
+++ b/modules/exploits/windows/local/ms14_009_ie_dfsvc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/ms_ndproxy.rb
+++ b/modules/exploits/windows/local/ms_ndproxy.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/novell_client_nicm.rb
+++ b/modules/exploits/windows/local/novell_client_nicm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/novell_client_nwfs.rb
+++ b/modules/exploits/windows/local/novell_client_nwfs.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/nvidia_nvsvc.rb
+++ b/modules/exploits/windows/local/nvidia_nvsvc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/payload_inject.rb
+++ b/modules/exploits/windows/local/payload_inject.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/persistence.rb
+++ b/modules/exploits/windows/local/persistence.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/powershell_cmd_upgrade.rb
+++ b/modules/exploits/windows/local/powershell_cmd_upgrade.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/ppr_flatten_rec.rb
+++ b/modules/exploits/windows/local/ppr_flatten_rec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/pxeexploit.rb
+++ b/modules/exploits/windows/local/pxeexploit.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/s4u_persistence.rb
+++ b/modules/exploits/windows/local/s4u_persistence.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/service_permissions.rb
+++ b/modules/exploits/windows/local/service_permissions.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/trusted_service_path.rb
+++ b/modules/exploits/windows/local/trusted_service_path.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/virtual_box_guest_additions.rb
+++ b/modules/exploits/windows/local/virtual_box_guest_additions.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/virtual_box_opengl_escape.rb
+++ b/modules/exploits/windows/local/virtual_box_opengl_escape.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/vss_persistence.rb
+++ b/modules/exploits/windows/local/vss_persistence.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/local/wmi.rb
+++ b/modules/exploits/windows/local/wmi.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/lotus/domino_http_accept_language.rb
+++ b/modules/exploits/windows/lotus/domino_http_accept_language.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/lotus/domino_icalendar_organizer.rb
+++ b/modules/exploits/windows/lotus/domino_icalendar_organizer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/lotus/domino_sametime_stmux.rb
+++ b/modules/exploits/windows/lotus/domino_sametime_stmux.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/lotus/lotusnotes_lzh.rb
+++ b/modules/exploits/windows/lotus/lotusnotes_lzh.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/lpd/hummingbird_exceed.rb
+++ b/modules/exploits/windows/lpd/hummingbird_exceed.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/lpd/niprint.rb
+++ b/modules/exploits/windows/lpd/niprint.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/lpd/saplpd.rb
+++ b/modules/exploits/windows/lpd/saplpd.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/lpd/wincomlpd_admin.rb
+++ b/modules/exploits/windows/lpd/wincomlpd_admin.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/actfax_raw_server_bof.rb
+++ b/modules/exploits/windows/misc/actfax_raw_server_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/agentxpp_receive_agentx.rb
+++ b/modules/exploits/windows/misc/agentxpp_receive_agentx.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/allmediaserver_bof.rb
+++ b/modules/exploits/windows/misc/allmediaserver_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/altiris_ds_sqli.rb
+++ b/modules/exploits/windows/misc/altiris_ds_sqli.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/apple_quicktime_rtsp_response.rb
+++ b/modules/exploits/windows/misc/apple_quicktime_rtsp_response.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/asus_dpcproxy_overflow.rb
+++ b/modules/exploits/windows/misc/asus_dpcproxy_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/avaya_winpmd_unihostrouter.rb
+++ b/modules/exploits/windows/misc/avaya_winpmd_unihostrouter.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/avidphoneticindexer.rb
+++ b/modules/exploits/windows/misc/avidphoneticindexer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/bakbone_netvault_heap.rb
+++ b/modules/exploits/windows/misc/bakbone_netvault_heap.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/bcaaa_bof.rb
+++ b/modules/exploits/windows/misc/bcaaa_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/bigant_server.rb
+++ b/modules/exploits/windows/misc/bigant_server.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/bigant_server_250.rb
+++ b/modules/exploits/windows/misc/bigant_server_250.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/bigant_server_dupf_upload.rb
+++ b/modules/exploits/windows/misc/bigant_server_dupf_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/bigant_server_sch_dupf_bof.rb
+++ b/modules/exploits/windows/misc/bigant_server_sch_dupf_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/bigant_server_usv.rb
+++ b/modules/exploits/windows/misc/bigant_server_usv.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/bomberclone_overflow.rb
+++ b/modules/exploits/windows/misc/bomberclone_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/bopup_comm.rb
+++ b/modules/exploits/windows/misc/bopup_comm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/borland_interbase.rb
+++ b/modules/exploits/windows/misc/borland_interbase.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/borland_starteam.rb
+++ b/modules/exploits/windows/misc/borland_starteam.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/citrix_streamprocess.rb
+++ b/modules/exploits/windows/misc/citrix_streamprocess.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/citrix_streamprocess_data_msg.rb
+++ b/modules/exploits/windows/misc/citrix_streamprocess_data_msg.rb
@@ -1,7 +1,7 @@
 # -*- coding: binary -*-
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/citrix_streamprocess_get_boot_record_request.rb
+++ b/modules/exploits/windows/misc/citrix_streamprocess_get_boot_record_request.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/citrix_streamprocess_get_footer.rb
+++ b/modules/exploits/windows/misc/citrix_streamprocess_get_footer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/citrix_streamprocess_get_objects.rb
+++ b/modules/exploits/windows/misc/citrix_streamprocess_get_objects.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/doubletake.rb
+++ b/modules/exploits/windows/misc/doubletake.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/eiqnetworks_esa.rb
+++ b/modules/exploits/windows/misc/eiqnetworks_esa.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/eiqnetworks_esa_topology.rb
+++ b/modules/exploits/windows/misc/eiqnetworks_esa_topology.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/enterasys_netsight_syslog_bof.rb
+++ b/modules/exploits/windows/misc/enterasys_netsight_syslog_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/eureka_mail_err.rb
+++ b/modules/exploits/windows/misc/eureka_mail_err.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/fb_cnct_group.rb
+++ b/modules/exploits/windows/misc/fb_cnct_group.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/fb_isc_attach_database.rb
+++ b/modules/exploits/windows/misc/fb_isc_attach_database.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/fb_isc_create_database.rb
+++ b/modules/exploits/windows/misc/fb_isc_create_database.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/fb_svc_attach.rb
+++ b/modules/exploits/windows/misc/fb_svc_attach.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/gimp_script_fu.rb
+++ b/modules/exploits/windows/misc/gimp_script_fu.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/hp_dataprotector_crs.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_crs.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/hp_dataprotector_dtbclslogin.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_dtbclslogin.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/hp_dataprotector_exec_bar.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_exec_bar.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/hp_dataprotector_new_folder.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_new_folder.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/hp_dataprotector_traversal.rb
+++ b/modules/exploits/windows/misc/hp_dataprotector_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/hp_imc_uam.rb
+++ b/modules/exploits/windows/misc/hp_imc_uam.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/hp_loadrunner_magentproc.rb
+++ b/modules/exploits/windows/misc/hp_loadrunner_magentproc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/hp_magentservice.rb
+++ b/modules/exploits/windows/misc/hp_magentservice.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/hp_omniinet_1.rb
+++ b/modules/exploits/windows/misc/hp_omniinet_1.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/hp_omniinet_2.rb
+++ b/modules/exploits/windows/misc/hp_omniinet_2.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/hp_omniinet_3.rb
+++ b/modules/exploits/windows/misc/hp_omniinet_3.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/hp_omniinet_4.rb
+++ b/modules/exploits/windows/misc/hp_omniinet_4.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/hp_operations_agent_coda_34.rb
+++ b/modules/exploits/windows/misc/hp_operations_agent_coda_34.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/hp_operations_agent_coda_8c.rb
+++ b/modules/exploits/windows/misc/hp_operations_agent_coda_8c.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/hp_ovtrace.rb
+++ b/modules/exploits/windows/misc/hp_ovtrace.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/ib_isc_attach_database.rb
+++ b/modules/exploits/windows/misc/ib_isc_attach_database.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/ib_isc_create_database.rb
+++ b/modules/exploits/windows/misc/ib_isc_create_database.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/ib_svc_attach.rb
+++ b/modules/exploits/windows/misc/ib_svc_attach.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/ibm_cognos_tm1admsd_bof.rb
+++ b/modules/exploits/windows/misc/ibm_cognos_tm1admsd_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/ibm_director_cim_dllinject.rb
+++ b/modules/exploits/windows/misc/ibm_director_cim_dllinject.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/ibm_tsm_cad_ping.rb
+++ b/modules/exploits/windows/misc/ibm_tsm_cad_ping.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/ibm_tsm_rca_dicugetidentify.rb
+++ b/modules/exploits/windows/misc/ibm_tsm_rca_dicugetidentify.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/itunes_extm3u_bof.rb
+++ b/modules/exploits/windows/misc/itunes_extm3u_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/landesk_aolnsrvr.rb
+++ b/modules/exploits/windows/misc/landesk_aolnsrvr.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/lianja_db_net.rb
+++ b/modules/exploits/windows/misc/lianja_db_net.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/mercury_phonebook.rb
+++ b/modules/exploits/windows/misc/mercury_phonebook.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/mini_stream.rb
+++ b/modules/exploits/windows/misc/mini_stream.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/mirc_privmsg_server.rb
+++ b/modules/exploits/windows/misc/mirc_privmsg_server.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/ms07_064_sami.rb
+++ b/modules/exploits/windows/misc/ms07_064_sami.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/ms10_104_sharepoint.rb
+++ b/modules/exploits/windows/misc/ms10_104_sharepoint.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/netcat110_nt.rb
+++ b/modules/exploits/windows/misc/netcat110_nt.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/nettransport.rb
+++ b/modules/exploits/windows/misc/nettransport.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/poisonivy_bof.rb
+++ b/modules/exploits/windows/misc/poisonivy_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/poppeeper_date.rb
+++ b/modules/exploits/windows/misc/poppeeper_date.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/poppeeper_uidl.rb
+++ b/modules/exploits/windows/misc/poppeeper_uidl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/psh_web_delivery.rb
+++ b/modules/exploits/windows/misc/psh_web_delivery.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/pxexploit.rb
+++ b/modules/exploits/windows/misc/pxexploit.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/realtek_playlist.rb
+++ b/modules/exploits/windows/misc/realtek_playlist.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/sap_2005_license.rb
+++ b/modules/exploits/windows/misc/sap_2005_license.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/sap_netweaver_dispatcher.rb
+++ b/modules/exploits/windows/misc/sap_netweaver_dispatcher.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/shixxnote_font.rb
+++ b/modules/exploits/windows/misc/shixxnote_font.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/solidworks_workgroup_pdmwservice_file_write.rb
+++ b/modules/exploits/windows/misc/solidworks_workgroup_pdmwservice_file_write.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/splayer_content_type.rb
+++ b/modules/exploits/windows/misc/splayer_content_type.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/stream_down_bof.rb
+++ b/modules/exploits/windows/misc/stream_down_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/talkative_response.rb
+++ b/modules/exploits/windows/misc/talkative_response.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/tiny_identd_overflow.rb
+++ b/modules/exploits/windows/misc/tiny_identd_overflow.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/trendmicro_cmdprocessor_addtask.rb
+++ b/modules/exploits/windows/misc/trendmicro_cmdprocessor_addtask.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/ufo_ai.rb
+++ b/modules/exploits/windows/misc/ufo_ai.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/windows_rsh.rb
+++ b/modules/exploits/windows/misc/windows_rsh.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/wireshark_lua.rb
+++ b/modules/exploits/windows/misc/wireshark_lua.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/misc/wireshark_packet_dect.rb
+++ b/modules/exploits/windows/misc/wireshark_packet_dect.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/mmsp/ms10_025_wmss_connect_funnel.rb
+++ b/modules/exploits/windows/mmsp/ms10_025_wmss_connect_funnel.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/motorola/timbuktu_fileupload.rb
+++ b/modules/exploits/windows/motorola/timbuktu_fileupload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/mssql/lyris_listmanager_weak_pass.rb
+++ b/modules/exploits/windows/mssql/lyris_listmanager_weak_pass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/mssql/ms02_039_slammer.rb
+++ b/modules/exploits/windows/mssql/ms02_039_slammer.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/mssql/ms02_056_hello.rb
+++ b/modules/exploits/windows/mssql/ms02_056_hello.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin.rb
+++ b/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin_sqli.rb
+++ b/modules/exploits/windows/mssql/ms09_004_sp_replwritetovarbin_sqli.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/mssql/mssql_linkcrawler.rb
+++ b/modules/exploits/windows/mssql/mssql_linkcrawler.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/mssql/mssql_payload.rb
+++ b/modules/exploits/windows/mssql/mssql_payload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/mssql/mssql_payload_sqli.rb
+++ b/modules/exploits/windows/mssql/mssql_payload_sqli.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/mysql/mysql_mof.rb
+++ b/modules/exploits/windows/mysql/mysql_mof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/mysql/mysql_payload.rb
+++ b/modules/exploits/windows/mysql/mysql_payload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/mysql/mysql_yassl_hello.rb
+++ b/modules/exploits/windows/mysql/mysql_yassl_hello.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
+++ b/modules/exploits/windows/mysql/scrutinizer_upload_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/nfs/xlink_nfsd.rb
+++ b/modules/exploits/windows/nfs/xlink_nfsd.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/nntp/ms05_030_nntp.rb
+++ b/modules/exploits/windows/nntp/ms05_030_nntp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/novell/file_reporter_fsfui_upload.rb
+++ b/modules/exploits/windows/novell/file_reporter_fsfui_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/novell/groupwisemessenger_client.rb
+++ b/modules/exploits/windows/novell/groupwisemessenger_client.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/novell/netiq_pum_eval.rb
+++ b/modules/exploits/windows/novell/netiq_pum_eval.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/novell/nmap_stor.rb
+++ b/modules/exploits/windows/novell/nmap_stor.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/novell/zenworks_desktop_agent.rb
+++ b/modules/exploits/windows/novell/zenworks_desktop_agent.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/novell/zenworks_preboot_op21_bof.rb
+++ b/modules/exploits/windows/novell/zenworks_preboot_op21_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/novell/zenworks_preboot_op4c_bof.rb
+++ b/modules/exploits/windows/novell/zenworks_preboot_op4c_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/novell/zenworks_preboot_op6_bof.rb
+++ b/modules/exploits/windows/novell/zenworks_preboot_op6_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/novell/zenworks_preboot_op6c_bof.rb
+++ b/modules/exploits/windows/novell/zenworks_preboot_op6c_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/oracle/client_system_analyzer_upload.rb
+++ b/modules/exploits/windows/oracle/client_system_analyzer_upload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/oracle/extjob.rb
+++ b/modules/exploits/windows/oracle/extjob.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/oracle/osb_ndmp_auth.rb
+++ b/modules/exploits/windows/oracle/osb_ndmp_auth.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/oracle/tns_arguments.rb
+++ b/modules/exploits/windows/oracle/tns_arguments.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/oracle/tns_auth_sesskey.rb
+++ b/modules/exploits/windows/oracle/tns_auth_sesskey.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/oracle/tns_service_name.rb
+++ b/modules/exploits/windows/oracle/tns_service_name.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/pop3/seattlelab_pass.rb
+++ b/modules/exploits/windows/pop3/seattlelab_pass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/postgres/postgres_payload.rb
+++ b/modules/exploits/windows/postgres/postgres_payload.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/proxy/bluecoat_winproxy_host.rb
+++ b/modules/exploits/windows/proxy/bluecoat_winproxy_host.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/proxy/ccproxy_telnet_ping.rb
+++ b/modules/exploits/windows/proxy/ccproxy_telnet_ping.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/proxy/proxypro_http_get.rb
+++ b/modules/exploits/windows/proxy/proxypro_http_get.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/proxy/qbik_wingate_wwwproxy.rb
+++ b/modules/exploits/windows/proxy/qbik_wingate_wwwproxy.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/abb_wserver_exec.rb
+++ b/modules/exploits/windows/scada/abb_wserver_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/citect_scada_odbc.rb
+++ b/modules/exploits/windows/scada/citect_scada_odbc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/codesys_gateway_server_traversal.rb
+++ b/modules/exploits/windows/scada/codesys_gateway_server_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 #   http://metasploit.com
 ##

--- a/modules/exploits/windows/scada/codesys_web_server.rb
+++ b/modules/exploits/windows/scada/codesys_web_server.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/daq_factory_bof.rb
+++ b/modules/exploits/windows/scada/daq_factory_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/factorylink_csservice.rb
+++ b/modules/exploits/windows/scada/factorylink_csservice.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/factorylink_vrn_09.rb
+++ b/modules/exploits/windows/scada/factorylink_vrn_09.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/ge_proficy_cimplicity_gefebt.rb
+++ b/modules/exploits/windows/scada/ge_proficy_cimplicity_gefebt.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/iconics_genbroker.rb
+++ b/modules/exploits/windows/scada/iconics_genbroker.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/iconics_webhmi_setactivexguid.rb
+++ b/modules/exploits/windows/scada/iconics_webhmi_setactivexguid.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/igss9_igssdataserver_listall.rb
+++ b/modules/exploits/windows/scada/igss9_igssdataserver_listall.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/igss9_igssdataserver_rename.rb
+++ b/modules/exploits/windows/scada/igss9_igssdataserver_rename.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/igss9_misc.rb
+++ b/modules/exploits/windows/scada/igss9_misc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/igss_exec_17.rb
+++ b/modules/exploits/windows/scada/igss_exec_17.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/indusoft_webstudio_exec.rb
+++ b/modules/exploits/windows/scada/indusoft_webstudio_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/moxa_mdmtool.rb
+++ b/modules/exploits/windows/scada/moxa_mdmtool.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/procyon_core_server.rb
+++ b/modules/exploits/windows/scada/procyon_core_server.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/realwin.rb
+++ b/modules/exploits/windows/scada/realwin.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/realwin_on_fc_binfile_a.rb
+++ b/modules/exploits/windows/scada/realwin_on_fc_binfile_a.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/realwin_on_fcs_login.rb
+++ b/modules/exploits/windows/scada/realwin_on_fcs_login.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/realwin_scpc_initialize.rb
+++ b/modules/exploits/windows/scada/realwin_scpc_initialize.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/realwin_scpc_initialize_rf.rb
+++ b/modules/exploits/windows/scada/realwin_scpc_initialize_rf.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/realwin_scpc_txtevent.rb
+++ b/modules/exploits/windows/scada/realwin_scpc_txtevent.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/scadapro_cmdexe.rb
+++ b/modules/exploits/windows/scada/scadapro_cmdexe.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/sunway_force_control_netdbsrv.rb
+++ b/modules/exploits/windows/scada/sunway_force_control_netdbsrv.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/winlog_runtime.rb
+++ b/modules/exploits/windows/scada/winlog_runtime.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/winlog_runtime_2.rb
+++ b/modules/exploits/windows/scada/winlog_runtime_2.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/yokogawa_bkbcopyd_bof.rb
+++ b/modules/exploits/windows/scada/yokogawa_bkbcopyd_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/yokogawa_bkesimmgr_bof.rb
+++ b/modules/exploits/windows/scada/yokogawa_bkesimmgr_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/yokogawa_bkfsim_vhfd.rb
+++ b/modules/exploits/windows/scada/yokogawa_bkfsim_vhfd.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/scada/yokogawa_bkhodeq_bof.rb
+++ b/modules/exploits/windows/scada/yokogawa_bkhodeq_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/sip/aim_triton_cseq.rb
+++ b/modules/exploits/windows/sip/aim_triton_cseq.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/sip/sipxezphone_cseq.rb
+++ b/modules/exploits/windows/sip/sipxezphone_cseq.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/sip/sipxphone_cseq.rb
+++ b/modules/exploits/windows/sip/sipxphone_cseq.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/ms03_049_netapi.rb
+++ b/modules/exploits/windows/smb/ms03_049_netapi.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/ms04_007_killbill.rb
+++ b/modules/exploits/windows/smb/ms04_007_killbill.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/ms04_011_lsass.rb
+++ b/modules/exploits/windows/smb/ms04_011_lsass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/ms04_031_netdde.rb
+++ b/modules/exploits/windows/smb/ms04_031_netdde.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/ms05_039_pnp.rb
+++ b/modules/exploits/windows/smb/ms05_039_pnp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/ms06_025_rasmans_reg.rb
+++ b/modules/exploits/windows/smb/ms06_025_rasmans_reg.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/ms06_025_rras.rb
+++ b/modules/exploits/windows/smb/ms06_025_rras.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/ms06_040_netapi.rb
+++ b/modules/exploits/windows/smb/ms06_040_netapi.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/ms06_066_nwapi.rb
+++ b/modules/exploits/windows/smb/ms06_066_nwapi.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/ms06_066_nwwks.rb
+++ b/modules/exploits/windows/smb/ms06_066_nwwks.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/ms06_070_wkssvc.rb
+++ b/modules/exploits/windows/smb/ms06_070_wkssvc.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/ms07_029_msdns_zonename.rb
+++ b/modules/exploits/windows/smb/ms07_029_msdns_zonename.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/ms08_067_netapi.rb
+++ b/modules/exploits/windows/smb/ms08_067_netapi.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/ms09_050_smb2_negotiate_func_index.rb
+++ b/modules/exploits/windows/smb/ms09_050_smb2_negotiate_func_index.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/ms10_061_spoolss.rb
+++ b/modules/exploits/windows/smb/ms10_061_spoolss.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/netidentity_xtierrpcpipe.rb
+++ b/modules/exploits/windows/smb/netidentity_xtierrpcpipe.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/psexec_psh.rb
+++ b/modules/exploits/windows/smb/psexec_psh.rb
@@ -1,7 +1,7 @@
 # -*- coding: binary -*-
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/smb_relay.rb
+++ b/modules/exploits/windows/smb/smb_relay.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smb/timbuktu_plughntcommand_bof.rb
+++ b/modules/exploits/windows/smb/timbuktu_plughntcommand_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smtp/mailcarrier_smtp_ehlo.rb
+++ b/modules/exploits/windows/smtp/mailcarrier_smtp_ehlo.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smtp/mercury_cram_md5.rb
+++ b/modules/exploits/windows/smtp/mercury_cram_md5.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smtp/ms03_046_exchange2000_xexch50.rb
+++ b/modules/exploits/windows/smtp/ms03_046_exchange2000_xexch50.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smtp/njstar_smtp_bof.rb
+++ b/modules/exploits/windows/smtp/njstar_smtp_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smtp/wmailserver.rb
+++ b/modules/exploits/windows/smtp/wmailserver.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/smtp/ypops_overflow1.rb
+++ b/modules/exploits/windows/smtp/ypops_overflow1.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ssh/freeftpd_key_exchange.rb
+++ b/modules/exploits/windows/ssh/freeftpd_key_exchange.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ssh/freesshd_authbypass.rb
+++ b/modules/exploits/windows/ssh/freesshd_authbypass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ssh/freesshd_key_exchange.rb
+++ b/modules/exploits/windows/ssh/freesshd_key_exchange.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ssh/putty_msg_debug.rb
+++ b/modules/exploits/windows/ssh/putty_msg_debug.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ssh/securecrt_ssh1.rb
+++ b/modules/exploits/windows/ssh/securecrt_ssh1.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ssh/sysax_ssh_username.rb
+++ b/modules/exploits/windows/ssh/sysax_ssh_username.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/ssl/ms04_011_pct.rb
+++ b/modules/exploits/windows/ssl/ms04_011_pct.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/telnet/gamsoft_telsrv_username.rb
+++ b/modules/exploits/windows/telnet/gamsoft_telsrv_username.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/telnet/goodtech_telnet.rb
+++ b/modules/exploits/windows/telnet/goodtech_telnet.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/tftp/attftp_long_filename.rb
+++ b/modules/exploits/windows/tftp/attftp_long_filename.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/tftp/distinct_tftp_traversal.rb
+++ b/modules/exploits/windows/tftp/distinct_tftp_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/tftp/dlink_long_filename.rb
+++ b/modules/exploits/windows/tftp/dlink_long_filename.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/tftp/futuresoft_transfermode.rb
+++ b/modules/exploits/windows/tftp/futuresoft_transfermode.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/tftp/netdecision_tftp_traversal.rb
+++ b/modules/exploits/windows/tftp/netdecision_tftp_traversal.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/tftp/opentftp_error_code.rb
+++ b/modules/exploits/windows/tftp/opentftp_error_code.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/tftp/quick_tftp_pro_mode.rb
+++ b/modules/exploits/windows/tftp/quick_tftp_pro_mode.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/tftp/tftpd32_long_filename.rb
+++ b/modules/exploits/windows/tftp/tftpd32_long_filename.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/tftp/tftpdwin_long_filename.rb
+++ b/modules/exploits/windows/tftp/tftpdwin_long_filename.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/tftp/tftpserver_wrq_bof.rb
+++ b/modules/exploits/windows/tftp/tftpserver_wrq_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/tftp/threectftpsvc_long_mode.rb
+++ b/modules/exploits/windows/tftp/threectftpsvc_long_mode.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/unicenter/cam_log_security.rb
+++ b/modules/exploits/windows/unicenter/cam_log_security.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/vnc/realvnc_client.rb
+++ b/modules/exploits/windows/vnc/realvnc_client.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/vnc/ultravnc_client.rb
+++ b/modules/exploits/windows/vnc/ultravnc_client.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/vnc/ultravnc_viewer_bof.rb
+++ b/modules/exploits/windows/vnc/ultravnc_viewer_bof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/vnc/winvnc_http_get.rb
+++ b/modules/exploits/windows/vnc/winvnc_http_get.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/vpn/safenet_ike_11.rb
+++ b/modules/exploits/windows/vpn/safenet_ike_11.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/winrm/winrm_script_exec.rb
+++ b/modules/exploits/windows/winrm/winrm_script_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/exploits/windows/wins/ms04_045_wins.rb
+++ b/modules/exploits/windows/wins/ms04_045_wins.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/nops/armle/simple.rb
+++ b/modules/nops/armle/simple.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/nops/php/generic.rb
+++ b/modules/nops/php/generic.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/nops/ppc/simple.rb
+++ b/modules/nops/ppc/simple.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/nops/sparc/random.rb
+++ b/modules/nops/sparc/random.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/nops/tty/generic.rb
+++ b/modules/nops/tty/generic.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/nops/x64/simple.rb
+++ b/modules/nops/x64/simple.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/nops/x86/opty2.rb
+++ b/modules/nops/x86/opty2.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/nops/x86/single_byte.rb
+++ b/modules/nops/x86/single_byte.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/aix/ppc/shell_bind_tcp.rb
+++ b/modules/payloads/singles/aix/ppc/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/aix/ppc/shell_find_port.rb
+++ b/modules/payloads/singles/aix/ppc/shell_find_port.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/aix/ppc/shell_interact.rb
+++ b/modules/payloads/singles/aix/ppc/shell_interact.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/aix/ppc/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/aix/ppc/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/bsd/sparc/shell_bind_tcp.rb
+++ b/modules/payloads/singles/bsd/sparc/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/bsd/sparc/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/bsd/sparc/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/bsd/x86/exec.rb
+++ b/modules/payloads/singles/bsd/x86/exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/bsd/x86/metsvc_bind_tcp.rb
+++ b/modules/payloads/singles/bsd/x86/metsvc_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/bsd/x86/metsvc_reverse_tcp.rb
+++ b/modules/payloads/singles/bsd/x86/metsvc_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/bsd/x86/shell_bind_tcp.rb
+++ b/modules/payloads/singles/bsd/x86/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/bsd/x86/shell_bind_tcp_ipv6.rb
+++ b/modules/payloads/singles/bsd/x86/shell_bind_tcp_ipv6.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/bsd/x86/shell_find_port.rb
+++ b/modules/payloads/singles/bsd/x86/shell_find_port.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/bsd/x86/shell_find_tag.rb
+++ b/modules/payloads/singles/bsd/x86/shell_find_tag.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/bsd/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/bsd/x86/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/bsd/x86/shell_reverse_tcp_ipv6.rb
+++ b/modules/payloads/singles/bsd/x86/shell_reverse_tcp_ipv6.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/bsdi/x86/shell_bind_tcp.rb
+++ b/modules/payloads/singles/bsdi/x86/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/bsdi/x86/shell_find_port.rb
+++ b/modules/payloads/singles/bsdi/x86/shell_find_port.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/bsdi/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/bsdi/x86/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/bind_awk.rb
+++ b/modules/payloads/singles/cmd/unix/bind_awk.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/bind_inetd.rb
+++ b/modules/payloads/singles/cmd/unix/bind_inetd.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/bind_lua.rb
+++ b/modules/payloads/singles/cmd/unix/bind_lua.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/bind_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/bind_netcat_gaping.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat_gaping.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/bind_netcat_gaping_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_netcat_gaping_ipv6.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/bind_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/bind_nodejs.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/bind_perl.rb
+++ b/modules/payloads/singles/cmd/unix/bind_perl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/bind_perl_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_perl_ipv6.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/bind_ruby.rb
+++ b/modules/payloads/singles/cmd/unix/bind_ruby.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/bind_ruby_ipv6.rb
+++ b/modules/payloads/singles/cmd/unix/bind_ruby_ipv6.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/bind_zsh.rb
+++ b/modules/payloads/singles/cmd/unix/bind_zsh.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/generic.rb
+++ b/modules/payloads/singles/cmd/unix/generic.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/interact.rb
+++ b/modules/payloads/singles/cmd/unix/interact.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse.rb
+++ b/modules/payloads/singles/cmd/unix/reverse.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse_awk.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_awk.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse_bash.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_bash_telnet_ssl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse_lua.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_lua.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse_netcat.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse_netcat_gaping.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_netcat_gaping.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_nodejs.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse_openssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_openssl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse_perl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_perl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_perl_ssl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_php_ssl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse_python.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_python_ssl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse_ruby.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ruby.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse_ruby_ssl.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ruby_ssl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse_ssl_double_telnet.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_ssl_double_telnet.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/unix/reverse_zsh.rb
+++ b/modules/payloads/singles/cmd/unix/reverse_zsh.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/windows/adduser.rb
+++ b/modules/payloads/singles/cmd/windows/adduser.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/windows/bind_lua.rb
+++ b/modules/payloads/singles/cmd/windows/bind_lua.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/windows/bind_perl.rb
+++ b/modules/payloads/singles/cmd/windows/bind_perl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/windows/bind_perl_ipv6.rb
+++ b/modules/payloads/singles/cmd/windows/bind_perl_ipv6.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/windows/bind_ruby.rb
+++ b/modules/payloads/singles/cmd/windows/bind_ruby.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/windows/download_eval_vbs.rb
+++ b/modules/payloads/singles/cmd/windows/download_eval_vbs.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/windows/download_exec_vbs.rb
+++ b/modules/payloads/singles/cmd/windows/download_exec_vbs.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/windows/generic.rb
+++ b/modules/payloads/singles/cmd/windows/generic.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/windows/reverse_lua.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_lua.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/windows/reverse_perl.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_perl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/windows/reverse_powershell.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_powershell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/cmd/windows/reverse_ruby.rb
+++ b/modules/payloads/singles/cmd/windows/reverse_ruby.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/firefox/exec.rb
+++ b/modules/payloads/singles/firefox/exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/firefox/shell_bind_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/firefox/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/firefox/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/generic/custom.rb
+++ b/modules/payloads/singles/generic/custom.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/generic/debug_trap.rb
+++ b/modules/payloads/singles/generic/debug_trap.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/generic/shell_bind_tcp.rb
+++ b/modules/payloads/singles/generic/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/generic/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/generic/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/generic/tight_loop.rb
+++ b/modules/payloads/singles/generic/tight_loop.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/java/jsp_shell_bind_tcp.rb
+++ b/modules/payloads/singles/java/jsp_shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/java/jsp_shell_reverse_tcp.rb
+++ b/modules/payloads/singles/java/jsp_shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/java/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/java/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/armle/adduser.rb
+++ b/modules/payloads/singles/linux/armle/adduser.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/armle/exec.rb
+++ b/modules/payloads/singles/linux/armle/exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/armle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/armle/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/armle/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/armle/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/mipsbe/exec.rb
+++ b/modules/payloads/singles/linux/mipsbe/exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/mipsbe/reboot.rb
+++ b/modules/payloads/singles/linux/mipsbe/reboot.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/mipsbe/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/mipsbe/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsbe/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/mipsle/exec.rb
+++ b/modules/payloads/singles/linux/mipsle/exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/mipsle/reboot.rb
+++ b/modules/payloads/singles/linux/mipsle/reboot.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/mipsle/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/mipsle/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/ppc/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/ppc/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/ppc/shell_find_port.rb
+++ b/modules/payloads/singles/linux/ppc/shell_find_port.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/ppc/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/ppc64/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/ppc64/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/ppc64/shell_find_port.rb
+++ b/modules/payloads/singles/linux/ppc64/shell_find_port.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/ppc64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/ppc64/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/x64/exec.rb
+++ b/modules/payloads/singles/linux/x64/exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/x64/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/x64/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/x64/shell_bind_tcp_random_port.rb
+++ b/modules/payloads/singles/linux/x64/shell_bind_tcp_random_port.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/x64/shell_find_port.rb
+++ b/modules/payloads/singles/linux/x64/shell_find_port.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x64/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/x86/adduser.rb
+++ b/modules/payloads/singles/linux/x86/adduser.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/x86/chmod.rb
+++ b/modules/payloads/singles/linux/x86/chmod.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/x86/exec.rb
+++ b/modules/payloads/singles/linux/x86/exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/x86/metsvc_bind_tcp.rb
+++ b/modules/payloads/singles/linux/x86/metsvc_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/x86/metsvc_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/metsvc_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/x86/read_file.rb
+++ b/modules/payloads/singles/linux/x86/read_file.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/x86/shell_bind_ipv6_tcp.rb
+++ b/modules/payloads/singles/linux/x86/shell_bind_ipv6_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/x86/shell_bind_tcp.rb
+++ b/modules/payloads/singles/linux/x86/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/x86/shell_bind_tcp_random_port.rb
+++ b/modules/payloads/singles/linux/x86/shell_bind_tcp_random_port.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/x86/shell_find_port.rb
+++ b/modules/payloads/singles/linux/x86/shell_find_port.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/x86/shell_find_tag.rb
+++ b/modules/payloads/singles/linux/x86/shell_find_tag.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/linux/x86/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/linux/x86/shell_reverse_tcp2.rb
+++ b/modules/payloads/singles/linux/x86/shell_reverse_tcp2.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/nodejs/shell_bind_tcp.rb
+++ b/modules/payloads/singles/nodejs/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/nodejs/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/nodejs/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/nodejs/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/nodejs/shell_reverse_tcp_ssl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/osx/armle/shell_bind_tcp.rb
+++ b/modules/payloads/singles/osx/armle/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/osx/armle/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/armle/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/osx/armle/vibrate.rb
+++ b/modules/payloads/singles/osx/armle/vibrate.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/osx/ppc/shell_bind_tcp.rb
+++ b/modules/payloads/singles/osx/ppc/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/osx/ppc/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/ppc/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/osx/x64/exec.rb
+++ b/modules/payloads/singles/osx/x64/exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/osx/x64/say.rb
+++ b/modules/payloads/singles/osx/x64/say.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/osx/x64/shell_bind_tcp.rb
+++ b/modules/payloads/singles/osx/x64/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/osx/x64/shell_find_tag.rb
+++ b/modules/payloads/singles/osx/x64/shell_find_tag.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x64/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/osx/x86/exec.rb
+++ b/modules/payloads/singles/osx/x86/exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/osx/x86/shell_bind_tcp.rb
+++ b/modules/payloads/singles/osx/x86/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/osx/x86/shell_find_port.rb
+++ b/modules/payloads/singles/osx/x86/shell_find_port.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/osx/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x86/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/osx/x86/vforkshell_bind_tcp.rb
+++ b/modules/payloads/singles/osx/x86/vforkshell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/osx/x86/vforkshell_reverse_tcp.rb
+++ b/modules/payloads/singles/osx/x86/vforkshell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/php/bind_perl.rb
+++ b/modules/payloads/singles/php/bind_perl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/php/bind_perl_ipv6.rb
+++ b/modules/payloads/singles/php/bind_perl_ipv6.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/php/bind_php.rb
+++ b/modules/payloads/singles/php/bind_php.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/php/bind_php_ipv6.rb
+++ b/modules/payloads/singles/php/bind_php_ipv6.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/php/download_exec.rb
+++ b/modules/payloads/singles/php/download_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/php/exec.rb
+++ b/modules/payloads/singles/php/exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
+++ b/modules/payloads/singles/php/meterpreter_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/php/reverse_perl.rb
+++ b/modules/payloads/singles/php/reverse_perl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/php/reverse_php.rb
+++ b/modules/payloads/singles/php/reverse_php.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/php/shell_findsock.rb
+++ b/modules/payloads/singles/php/shell_findsock.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/python/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/python/shell_reverse_tcp_ssl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/ruby/shell_bind_tcp.rb
+++ b/modules/payloads/singles/ruby/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/ruby/shell_bind_tcp_ipv6.rb
+++ b/modules/payloads/singles/ruby/shell_bind_tcp_ipv6.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/ruby/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/ruby/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/ruby/shell_reverse_tcp_ssl.rb
+++ b/modules/payloads/singles/ruby/shell_reverse_tcp_ssl.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/solaris/sparc/shell_bind_tcp.rb
+++ b/modules/payloads/singles/solaris/sparc/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/solaris/sparc/shell_find_port.rb
+++ b/modules/payloads/singles/solaris/sparc/shell_find_port.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/solaris/sparc/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/solaris/sparc/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/solaris/x86/shell_bind_tcp.rb
+++ b/modules/payloads/singles/solaris/x86/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/solaris/x86/shell_find_port.rb
+++ b/modules/payloads/singles/solaris/x86/shell_find_port.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/solaris/x86/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/solaris/x86/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/tty/unix/interact.rb
+++ b/modules/payloads/singles/tty/unix/interact.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/windows/adduser.rb
+++ b/modules/payloads/singles/windows/adduser.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/windows/dns_txt_query_exec.rb
+++ b/modules/payloads/singles/windows/dns_txt_query_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/windows/download_exec.rb
+++ b/modules/payloads/singles/windows/download_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/windows/exec.rb
+++ b/modules/payloads/singles/windows/exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/windows/loadlibrary.rb
+++ b/modules/payloads/singles/windows/loadlibrary.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/windows/messagebox.rb
+++ b/modules/payloads/singles/windows/messagebox.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/windows/metsvc_bind_tcp.rb
+++ b/modules/payloads/singles/windows/metsvc_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/windows/metsvc_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/metsvc_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/windows/shell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/windows/shell_bind_tcp_xpfw.rb
+++ b/modules/payloads/singles/windows/shell_bind_tcp_xpfw.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/windows/shell_hidden_bind_tcp.rb
+++ b/modules/payloads/singles/windows/shell_hidden_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/windows/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/windows/speak_pwned.rb
+++ b/modules/payloads/singles/windows/speak_pwned.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/windows/x64/exec.rb
+++ b/modules/payloads/singles/windows/x64/exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/windows/x64/loadlibrary.rb
+++ b/modules/payloads/singles/windows/x64/loadlibrary.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/windows/x64/shell_bind_tcp.rb
+++ b/modules/payloads/singles/windows/x64/shell_bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/singles/windows/x64/shell_reverse_tcp.rb
+++ b/modules/payloads/singles/windows/x64/shell_reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/android/reverse_http.rb
+++ b/modules/payloads/stagers/android/reverse_http.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/android/reverse_https.rb
+++ b/modules/payloads/stagers/android/reverse_https.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/android/reverse_tcp.rb
+++ b/modules/payloads/stagers/android/reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/bsd/x86/bind_ipv6_tcp.rb
+++ b/modules/payloads/stagers/bsd/x86/bind_ipv6_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/bsd/x86/bind_tcp.rb
+++ b/modules/payloads/stagers/bsd/x86/bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/bsd/x86/find_tag.rb
+++ b/modules/payloads/stagers/bsd/x86/find_tag.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/bsd/x86/reverse_ipv6_tcp.rb
+++ b/modules/payloads/stagers/bsd/x86/reverse_ipv6_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/bsd/x86/reverse_tcp.rb
+++ b/modules/payloads/stagers/bsd/x86/reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/bsdi/x86/bind_tcp.rb
+++ b/modules/payloads/stagers/bsdi/x86/bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/bsdi/x86/reverse_tcp.rb
+++ b/modules/payloads/stagers/bsdi/x86/reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/java/bind_tcp.rb
+++ b/modules/payloads/stagers/java/bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/java/reverse_http.rb
+++ b/modules/payloads/stagers/java/reverse_http.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/java/reverse_https.rb
+++ b/modules/payloads/stagers/java/reverse_https.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/java/reverse_tcp.rb
+++ b/modules/payloads/stagers/java/reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/linux/armle/bind_tcp.rb
+++ b/modules/payloads/stagers/linux/armle/bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/linux/armle/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/armle/reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/linux/mipsbe/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/mipsbe/reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/linux/mipsle/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/mipsle/reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/linux/x64/bind_tcp.rb
+++ b/modules/payloads/stagers/linux/x64/bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/linux/x64/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/x64/reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/linux/x86/bind_ipv6_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/bind_ipv6_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/linux/x86/bind_nonx_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/bind_nonx_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/linux/x86/bind_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/linux/x86/find_tag.rb
+++ b/modules/payloads/stagers/linux/x86/find_tag.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/linux/x86/reverse_ipv6_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/reverse_ipv6_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/linux/x86/reverse_nonx_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/reverse_nonx_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/linux/x86/reverse_tcp.rb
+++ b/modules/payloads/stagers/linux/x86/reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/netware/reverse_tcp.rb
+++ b/modules/payloads/stagers/netware/reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/osx/armle/bind_tcp.rb
+++ b/modules/payloads/stagers/osx/armle/bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/osx/armle/reverse_tcp.rb
+++ b/modules/payloads/stagers/osx/armle/reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/osx/ppc/bind_tcp.rb
+++ b/modules/payloads/stagers/osx/ppc/bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/osx/ppc/find_tag.rb
+++ b/modules/payloads/stagers/osx/ppc/find_tag.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/osx/ppc/reverse_tcp.rb
+++ b/modules/payloads/stagers/osx/ppc/reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/osx/x64/bind_tcp.rb
+++ b/modules/payloads/stagers/osx/x64/bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/osx/x64/reverse_tcp.rb
+++ b/modules/payloads/stagers/osx/x64/reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/osx/x86/bind_tcp.rb
+++ b/modules/payloads/stagers/osx/x86/bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/osx/x86/reverse_tcp.rb
+++ b/modules/payloads/stagers/osx/x86/reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/php/bind_tcp.rb
+++ b/modules/payloads/stagers/php/bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/php/bind_tcp_ipv6.rb
+++ b/modules/payloads/stagers/php/bind_tcp_ipv6.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/php/reverse_tcp.rb
+++ b/modules/payloads/stagers/php/reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/python/bind_tcp.rb
+++ b/modules/payloads/stagers/python/bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/python/reverse_tcp.rb
+++ b/modules/payloads/stagers/python/reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/bind_ipv6_tcp.rb
+++ b/modules/payloads/stagers/windows/bind_ipv6_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/bind_nonx_tcp.rb
+++ b/modules/payloads/stagers/windows/bind_nonx_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/bind_tcp.rb
+++ b/modules/payloads/stagers/windows/bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/bind_tcp_rc4.rb
+++ b/modules/payloads/stagers/windows/bind_tcp_rc4.rb
@@ -1,6 +1,6 @@
 # -*- coding: binary -*-
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/findtag_ord.rb
+++ b/modules/payloads/stagers/windows/findtag_ord.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/reverse_hop_http.rb
+++ b/modules/payloads/stagers/windows/reverse_hop_http.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/reverse_http.rb
+++ b/modules/payloads/stagers/windows/reverse_http.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/reverse_https.rb
+++ b/modules/payloads/stagers/windows/reverse_https.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/reverse_https_proxy.rb
+++ b/modules/payloads/stagers/windows/reverse_https_proxy.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/reverse_ipv6_tcp.rb
+++ b/modules/payloads/stagers/windows/reverse_ipv6_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/reverse_nonx_tcp.rb
+++ b/modules/payloads/stagers/windows/reverse_nonx_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/reverse_ord_tcp.rb
+++ b/modules/payloads/stagers/windows/reverse_ord_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/reverse_tcp.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/reverse_tcp_allports.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp_allports.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/reverse_tcp_dns.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp_dns.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/reverse_tcp_rc4.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp_rc4.rb
@@ -1,6 +1,6 @@
 # -*- coding: binary -*-
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/reverse_tcp_rc4_dns.rb
+++ b/modules/payloads/stagers/windows/reverse_tcp_rc4_dns.rb
@@ -1,6 +1,6 @@
 # -*- coding: binary -*-
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/x64/bind_tcp.rb
+++ b/modules/payloads/stagers/windows/x64/bind_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/x64/reverse_https.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_https.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stagers/windows/x64/reverse_tcp.rb
+++ b/modules/payloads/stagers/windows/x64/reverse_tcp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/android/meterpreter.rb
+++ b/modules/payloads/stages/android/meterpreter.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/android/shell.rb
+++ b/modules/payloads/stages/android/shell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/bsd/x86/shell.rb
+++ b/modules/payloads/stages/bsd/x86/shell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/bsdi/x86/shell.rb
+++ b/modules/payloads/stages/bsdi/x86/shell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/java/meterpreter.rb
+++ b/modules/payloads/stages/java/meterpreter.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/java/shell.rb
+++ b/modules/payloads/stages/java/shell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/linux/armle/shell.rb
+++ b/modules/payloads/stages/linux/armle/shell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/linux/mipsbe/shell.rb
+++ b/modules/payloads/stages/linux/mipsbe/shell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/linux/mipsle/shell.rb
+++ b/modules/payloads/stages/linux/mipsle/shell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/linux/x64/shell.rb
+++ b/modules/payloads/stages/linux/x64/shell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/linux/x86/meterpreter.rb
+++ b/modules/payloads/stages/linux/x86/meterpreter.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/linux/x86/shell.rb
+++ b/modules/payloads/stages/linux/x86/shell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/netware/shell.rb
+++ b/modules/payloads/stages/netware/shell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/osx/armle/execute.rb
+++ b/modules/payloads/stages/osx/armle/execute.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/osx/armle/shell.rb
+++ b/modules/payloads/stages/osx/armle/shell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/osx/ppc/shell.rb
+++ b/modules/payloads/stages/osx/ppc/shell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/osx/x64/dupandexecve.rb
+++ b/modules/payloads/stages/osx/x64/dupandexecve.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/osx/x86/bundleinject.rb
+++ b/modules/payloads/stages/osx/x86/bundleinject.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/osx/x86/isight.rb
+++ b/modules/payloads/stages/osx/x86/isight.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/osx/x86/vforkshell.rb
+++ b/modules/payloads/stages/osx/x86/vforkshell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/php/meterpreter.rb
+++ b/modules/payloads/stages/php/meterpreter.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/python/meterpreter.rb
+++ b/modules/payloads/stages/python/meterpreter.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/windows/dllinject.rb
+++ b/modules/payloads/stages/windows/dllinject.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/windows/meterpreter.rb
+++ b/modules/payloads/stages/windows/meterpreter.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/windows/patchupdllinject.rb
+++ b/modules/payloads/stages/windows/patchupdllinject.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/windows/patchupmeterpreter.rb
+++ b/modules/payloads/stages/windows/patchupmeterpreter.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/windows/shell.rb
+++ b/modules/payloads/stages/windows/shell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/windows/upexec.rb
+++ b/modules/payloads/stages/windows/upexec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/windows/vncinject.rb
+++ b/modules/payloads/stages/windows/vncinject.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/windows/x64/meterpreter.rb
+++ b/modules/payloads/stages/windows/x64/meterpreter.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/windows/x64/shell.rb
+++ b/modules/payloads/stages/windows/x64/shell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/payloads/stages/windows/x64/vncinject.rb
+++ b/modules/payloads/stages/windows/x64/vncinject.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/aix/hashdump.rb
+++ b/modules/post/aix/hashdump.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/cisco/gather/enum_cisco.rb
+++ b/modules/post/cisco/gather/enum_cisco.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/firefox/gather/cookies.rb
+++ b/modules/post/firefox/gather/cookies.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/firefox/gather/history.rb
+++ b/modules/post/firefox/gather/history.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/firefox/gather/passwords.rb
+++ b/modules/post/firefox/gather/passwords.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/firefox/gather/xss.rb
+++ b/modules/post/firefox/gather/xss.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/firefox/manage/webcam_chat.rb
+++ b/modules/post/firefox/manage/webcam_chat.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/linux/gather/checkvm.rb
+++ b/modules/post/linux/gather/checkvm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/linux/gather/ecryptfs_creds.rb
+++ b/modules/post/linux/gather/ecryptfs_creds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/linux/gather/enum_configs.rb
+++ b/modules/post/linux/gather/enum_configs.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/linux/gather/enum_network.rb
+++ b/modules/post/linux/gather/enum_network.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/linux/gather/enum_protections.rb
+++ b/modules/post/linux/gather/enum_protections.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/linux/gather/enum_psk.rb
+++ b/modules/post/linux/gather/enum_psk.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/linux/gather/enum_system.rb
+++ b/modules/post/linux/gather/enum_system.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/linux/gather/enum_users_history.rb
+++ b/modules/post/linux/gather/enum_users_history.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/linux/gather/enum_xchat.rb
+++ b/modules/post/linux/gather/enum_xchat.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/linux/gather/gnome_commander_creds.rb
+++ b/modules/post/linux/gather/gnome_commander_creds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/linux/gather/hashdump.rb
+++ b/modules/post/linux/gather/hashdump.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/linux/gather/mount_cifs_creds.rb
+++ b/modules/post/linux/gather/mount_cifs_creds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/linux/gather/pptpd_chap_secrets.rb
+++ b/modules/post/linux/gather/pptpd_chap_secrets.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/linux/manage/download_exec.rb
+++ b/modules/post/linux/manage/download_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/escalate/cups_root_file_read.rb
+++ b/modules/post/multi/escalate/cups_root_file_read.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/escalate/metasploit_pcaplog.rb
+++ b/modules/post/multi/escalate/metasploit_pcaplog.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/apple_ios_backup.rb
+++ b/modules/post/multi/gather/apple_ios_backup.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/check_malware.rb
+++ b/modules/post/multi/gather/check_malware.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/dbvis_enum.rb
+++ b/modules/post/multi/gather/dbvis_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/dns_bruteforce.rb
+++ b/modules/post/multi/gather/dns_bruteforce.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/dns_reverse_lookup.rb
+++ b/modules/post/multi/gather/dns_reverse_lookup.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/dns_srv_lookup.rb
+++ b/modules/post/multi/gather/dns_srv_lookup.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/enum_vbox.rb
+++ b/modules/post/multi/gather/enum_vbox.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/env.rb
+++ b/modules/post/multi/gather/env.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/fetchmailrc_creds.rb
+++ b/modules/post/multi/gather/fetchmailrc_creds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/filezilla_client_cred.rb
+++ b/modules/post/multi/gather/filezilla_client_cred.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/find_vmx.rb
+++ b/modules/post/multi/gather/find_vmx.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/firefox_creds.rb
+++ b/modules/post/multi/gather/firefox_creds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/gpg_creds.rb
+++ b/modules/post/multi/gather/gpg_creds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/multi_command.rb
+++ b/modules/post/multi/gather/multi_command.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/netrc_creds.rb
+++ b/modules/post/multi/gather/netrc_creds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/pgpass_creds.rb
+++ b/modules/post/multi/gather/pgpass_creds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/pidgin_cred.rb
+++ b/modules/post/multi/gather/pidgin_cred.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/ping_sweep.rb
+++ b/modules/post/multi/gather/ping_sweep.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/resolve_hosts.rb
+++ b/modules/post/multi/gather/resolve_hosts.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/run_console_rc_file.rb
+++ b/modules/post/multi/gather/run_console_rc_file.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/skype_enum.rb
+++ b/modules/post/multi/gather/skype_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/ssh_creds.rb
+++ b/modules/post/multi/gather/ssh_creds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/thunderbird_creds.rb
+++ b/modules/post/multi/gather/thunderbird_creds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/gather/wlan_geolocate.rb
+++ b/modules/post/multi/gather/wlan_geolocate.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/general/close.rb
+++ b/modules/post/multi/general/close.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/general/execute.rb
+++ b/modules/post/multi/general/execute.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/manage/dbvis_add_db_admin.rb
+++ b/modules/post/multi/manage/dbvis_add_db_admin.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/manage/dbvis_query.rb
+++ b/modules/post/multi/manage/dbvis_query.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/manage/multi_post.rb
+++ b/modules/post/multi/manage/multi_post.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/manage/play_youtube.rb
+++ b/modules/post/multi/manage/play_youtube.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/manage/record_mic.rb
+++ b/modules/post/multi/manage/record_mic.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/manage/sudo.rb
+++ b/modules/post/multi/manage/sudo.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/multi/manage/system_session.rb
+++ b/modules/post/multi/manage/system_session.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/osx/admin/say.rb
+++ b/modules/post/osx/admin/say.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/osx/capture/keylog_recorder.rb
+++ b/modules/post/osx/capture/keylog_recorder.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/osx/capture/screen.rb
+++ b/modules/post/osx/capture/screen.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/osx/gather/autologin_password.rb
+++ b/modules/post/osx/gather/autologin_password.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/osx/gather/enum_adium.rb
+++ b/modules/post/osx/gather/enum_adium.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/osx/gather/enum_airport.rb
+++ b/modules/post/osx/gather/enum_airport.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/osx/gather/enum_chicken_vnc_profile.rb
+++ b/modules/post/osx/gather/enum_chicken_vnc_profile.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/osx/gather/enum_colloquy.rb
+++ b/modules/post/osx/gather/enum_colloquy.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/osx/gather/enum_keychain.rb
+++ b/modules/post/osx/gather/enum_keychain.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/osx/gather/enum_osx.rb
+++ b/modules/post/osx/gather/enum_osx.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/osx/gather/hashdump.rb
+++ b/modules/post/osx/gather/hashdump.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/osx/gather/password_prompt_spoof.rb
+++ b/modules/post/osx/gather/password_prompt_spoof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/osx/gather/safari_lastsession.rb
+++ b/modules/post/osx/gather/safari_lastsession.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/osx/manage/mount_share.rb
+++ b/modules/post/osx/manage/mount_share.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/osx/manage/record_mic.rb
+++ b/modules/post/osx/manage/record_mic.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/osx/manage/vpn.rb
+++ b/modules/post/osx/manage/vpn.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/osx/manage/webcam.rb
+++ b/modules/post/osx/manage/webcam.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/solaris/gather/checkvm.rb
+++ b/modules/post/solaris/gather/checkvm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/solaris/gather/enum_packages.rb
+++ b/modules/post/solaris/gather/enum_packages.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/solaris/gather/enum_services.rb
+++ b/modules/post/solaris/gather/enum_services.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/solaris/gather/hashdump.rb
+++ b/modules/post/solaris/gather/hashdump.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/capture/keylog_recorder.rb
+++ b/modules/post/windows/capture/keylog_recorder.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/capture/lockout_keylogger.rb
+++ b/modules/post/windows/capture/lockout_keylogger.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/escalate/droplnk.rb
+++ b/modules/post/windows/escalate/droplnk.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/escalate/getsystem.rb
+++ b/modules/post/windows/escalate/getsystem.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/escalate/ms10_073_kbdlayout.rb
+++ b/modules/post/windows/escalate/ms10_073_kbdlayout.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/escalate/net_runtime_modify.rb
+++ b/modules/post/windows/escalate/net_runtime_modify.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/escalate/screen_unlock.rb
+++ b/modules/post/windows/escalate/screen_unlock.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/arp_scanner.rb
+++ b/modules/post/windows/gather/arp_scanner.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/bitcoin_jacker.rb
+++ b/modules/post/windows/gather/bitcoin_jacker.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/cachedump.rb
+++ b/modules/post/windows/gather/cachedump.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/checkvm.rb
+++ b/modules/post/windows/gather/checkvm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/bulletproof_ftp.rb
+++ b/modules/post/windows/gather/credentials/bulletproof_ftp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/coreftp.rb
+++ b/modules/post/windows/gather/credentials/coreftp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/credential_collector.rb
+++ b/modules/post/windows/gather/credentials/credential_collector.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/dyndns.rb
+++ b/modules/post/windows/gather/credentials/dyndns.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/enum_cred_store.rb
+++ b/modules/post/windows/gather/credentials/enum_cred_store.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/enum_picasa_pwds.rb
+++ b/modules/post/windows/gather/credentials/enum_picasa_pwds.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/epo_sql.rb
+++ b/modules/post/windows/gather/credentials/epo_sql.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/filezilla_server.rb
+++ b/modules/post/windows/gather/credentials/filezilla_server.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/flashfxp.rb
+++ b/modules/post/windows/gather/credentials/flashfxp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/ftpnavigator.rb
+++ b/modules/post/windows/gather/credentials/ftpnavigator.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/ftpx.rb
+++ b/modules/post/windows/gather/credentials/ftpx.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/gpp.rb
+++ b/modules/post/windows/gather/credentials/gpp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/idm.rb
+++ b/modules/post/windows/gather/credentials/idm.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/imail.rb
+++ b/modules/post/windows/gather/credentials/imail.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/imvu.rb
+++ b/modules/post/windows/gather/credentials/imvu.rb
@@ -1,7 +1,7 @@
 # -*- coding: binary -*-
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/meebo.rb
+++ b/modules/post/windows/gather/credentials/meebo.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/mremote.rb
+++ b/modules/post/windows/gather/credentials/mremote.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/nimbuzz.rb
+++ b/modules/post/windows/gather/credentials/nimbuzz.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/outlook.rb
+++ b/modules/post/windows/gather/credentials/outlook.rb
@@ -1,7 +1,7 @@
 # -*- coding: binary -*-
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/razer_synapse.rb
+++ b/modules/post/windows/gather/credentials/razer_synapse.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/razorsql.rb
+++ b/modules/post/windows/gather/credentials/razorsql.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/rdc_manager_creds.rb
+++ b/modules/post/windows/gather/credentials/rdc_manager_creds.rb
@@ -1,7 +1,7 @@
 # -*- coding: binary -*-
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/skype.rb
+++ b/modules/post/windows/gather/credentials/skype.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/smartermail.rb
+++ b/modules/post/windows/gather/credentials/smartermail.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/smartftp.rb
+++ b/modules/post/windows/gather/credentials/smartftp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/spark_im.rb
+++ b/modules/post/windows/gather/credentials/spark_im.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/sso.rb
+++ b/modules/post/windows/gather/credentials/sso.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/steam.rb
+++ b/modules/post/windows/gather/credentials/steam.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/tortoisesvn.rb
+++ b/modules/post/windows/gather/credentials/tortoisesvn.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/total_commander.rb
+++ b/modules/post/windows/gather/credentials/total_commander.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/trillian.rb
+++ b/modules/post/windows/gather/credentials/trillian.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/vnc.rb
+++ b/modules/post/windows/gather/credentials/vnc.rb
@@ -1,7 +1,7 @@
 # post/windows/gather/enum_vnc_pw.rb
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/windows_autologin.rb
+++ b/modules/post/windows/gather/credentials/windows_autologin.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/winscp.rb
+++ b/modules/post/windows/gather/credentials/winscp.rb
@@ -1,7 +1,7 @@
 # post/windows/gather/enum_vnc_pw.rb
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/credentials/wsftp_client.rb
+++ b/modules/post/windows/gather/credentials/wsftp_client.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/dnscache_dump.rb
+++ b/modules/post/windows/gather/dnscache_dump.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/dumplinks.rb
+++ b/modules/post/windows/gather/dumplinks.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_ad_computers.rb
+++ b/modules/post/windows/gather/enum_ad_computers.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_ad_service_principal_names.rb
+++ b/modules/post/windows/gather/enum_ad_service_principal_names.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_ad_user_comments.rb
+++ b/modules/post/windows/gather/enum_ad_user_comments.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_applications.rb
+++ b/modules/post/windows/gather/enum_applications.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_artifacts.rb
+++ b/modules/post/windows/gather/enum_artifacts.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_chrome.rb
+++ b/modules/post/windows/gather/enum_chrome.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_computers.rb
+++ b/modules/post/windows/gather/enum_computers.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_db.rb
+++ b/modules/post/windows/gather/enum_db.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_devices.rb
+++ b/modules/post/windows/gather/enum_devices.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_dirperms.rb
+++ b/modules/post/windows/gather/enum_dirperms.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_domain.rb
+++ b/modules/post/windows/gather/enum_domain.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_domain_group_users.rb
+++ b/modules/post/windows/gather/enum_domain_group_users.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_domain_tokens.rb
+++ b/modules/post/windows/gather/enum_domain_tokens.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_domains.rb
+++ b/modules/post/windows/gather/enum_domains.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_files.rb
+++ b/modules/post/windows/gather/enum_files.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_hostfile.rb
+++ b/modules/post/windows/gather/enum_hostfile.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_ie.rb
+++ b/modules/post/windows/gather/enum_ie.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_logged_on_users.rb
+++ b/modules/post/windows/gather/enum_logged_on_users.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_ms_product_keys.rb
+++ b/modules/post/windows/gather/enum_ms_product_keys.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_muicache.rb
+++ b/modules/post/windows/gather/enum_muicache.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_patches.rb
+++ b/modules/post/windows/gather/enum_patches.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_powershell_env.rb
+++ b/modules/post/windows/gather/enum_powershell_env.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_prefetch.rb
+++ b/modules/post/windows/gather/enum_prefetch.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_proxy.rb
+++ b/modules/post/windows/gather/enum_proxy.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_services.rb
+++ b/modules/post/windows/gather/enum_services.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_shares.rb
+++ b/modules/post/windows/gather/enum_shares.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_snmp.rb
+++ b/modules/post/windows/gather/enum_snmp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_termserv.rb
+++ b/modules/post/windows/gather/enum_termserv.rb
@@ -1,7 +1,7 @@
 # post/windows/gather/enum_termserv.rb
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_tokens.rb
+++ b/modules/post/windows/gather/enum_tokens.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_tomcat.rb
+++ b/modules/post/windows/gather/enum_tomcat.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/enum_unattend.rb
+++ b/modules/post/windows/gather/enum_unattend.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/forensics/browser_history.rb
+++ b/modules/post/windows/gather/forensics/browser_history.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/forensics/duqu_check.rb
+++ b/modules/post/windows/gather/forensics/duqu_check.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/forensics/enum_drives.rb
+++ b/modules/post/windows/gather/forensics/enum_drives.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/forensics/imager.rb
+++ b/modules/post/windows/gather/forensics/imager.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/forensics/nbd_server.rb
+++ b/modules/post/windows/gather/forensics/nbd_server.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/forensics/recovery_files.rb
+++ b/modules/post/windows/gather/forensics/recovery_files.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/hashdump.rb
+++ b/modules/post/windows/gather/hashdump.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/local_admin_search_enum.rb
+++ b/modules/post/windows/gather/local_admin_search_enum.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/lsa_secrets.rb
+++ b/modules/post/windows/gather/lsa_secrets.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/memory_grep.rb
+++ b/modules/post/windows/gather/memory_grep.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/netlm_downgrade.rb
+++ b/modules/post/windows/gather/netlm_downgrade.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/resolve_sid.rb
+++ b/modules/post/windows/gather/resolve_sid.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/reverse_lookup.rb
+++ b/modules/post/windows/gather/reverse_lookup.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/screen_spy.rb
+++ b/modules/post/windows/gather/screen_spy.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/smart_hashdump.rb
+++ b/modules/post/windows/gather/smart_hashdump.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/tcpnetstat.rb
+++ b/modules/post/windows/gather/tcpnetstat.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/usb_history.rb
+++ b/modules/post/windows/gather/usb_history.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/win_privs.rb
+++ b/modules/post/windows/gather/win_privs.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/wmic_command.rb
+++ b/modules/post/windows/gather/wmic_command.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/gather/word_unc_injector.rb
+++ b/modules/post/windows/gather/word_unc_injector.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/add_user_domain.rb
+++ b/modules/post/windows/manage/add_user_domain.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/autoroute.rb
+++ b/modules/post/windows/manage/autoroute.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/change_password.rb
+++ b/modules/post/windows/manage/change_password.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/clone_proxy_settings.rb
+++ b/modules/post/windows/manage/clone_proxy_settings.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/delete_user.rb
+++ b/modules/post/windows/manage/delete_user.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/download_exec.rb
+++ b/modules/post/windows/manage/download_exec.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/driver_loader.rb
+++ b/modules/post/windows/manage/driver_loader.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/enable_rdp.rb
+++ b/modules/post/windows/manage/enable_rdp.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/ie_proxypac.rb
+++ b/modules/post/windows/manage/ie_proxypac.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/inject_ca.rb
+++ b/modules/post/windows/manage/inject_ca.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/inject_host.rb
+++ b/modules/post/windows/manage/inject_host.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/migrate.rb
+++ b/modules/post/windows/manage/migrate.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/mssql_local_auth_bypass.rb
+++ b/modules/post/windows/manage/mssql_local_auth_bypass.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/multi_meterpreter_inject.rb
+++ b/modules/post/windows/manage/multi_meterpreter_inject.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/nbd_server.rb
+++ b/modules/post/windows/manage/nbd_server.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/payload_inject.rb
+++ b/modules/post/windows/manage/payload_inject.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/portproxy.rb
+++ b/modules/post/windows/manage/portproxy.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/powershell/exec_powershell.rb
+++ b/modules/post/windows/manage/powershell/exec_powershell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/pptp_tunnel.rb
+++ b/modules/post/windows/manage/pptp_tunnel.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/pxexploit.rb
+++ b/modules/post/windows/manage/pxexploit.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/reflective_dll_inject.rb
+++ b/modules/post/windows/manage/reflective_dll_inject.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/remove_ca.rb
+++ b/modules/post/windows/manage/remove_ca.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/remove_host.rb
+++ b/modules/post/windows/manage/remove_host.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/rpcapd_start.rb
+++ b/modules/post/windows/manage/rpcapd_start.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/run_as.rb
+++ b/modules/post/windows/manage/run_as.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/sdel.rb
+++ b/modules/post/windows/manage/sdel.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/smart_migrate.rb
+++ b/modules/post/windows/manage/smart_migrate.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/vss_create.rb
+++ b/modules/post/windows/manage/vss_create.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/vss_list.rb
+++ b/modules/post/windows/manage/vss_list.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/vss_mount.rb
+++ b/modules/post/windows/manage/vss_mount.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/vss_set_storage.rb
+++ b/modules/post/windows/manage/vss_set_storage.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/vss_storage.rb
+++ b/modules/post/windows/manage/vss_storage.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/manage/webcam.rb
+++ b/modules/post/windows/manage/webcam.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/recon/computer_browser_discovery.rb
+++ b/modules/post/windows/recon/computer_browser_discovery.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/recon/resolve_ip.rb
+++ b/modules/post/windows/recon/resolve_ip.rb
@@ -1,7 +1,7 @@
 # -*- coding: binary -*-
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/wlan/wlan_bss_list.rb
+++ b/modules/post/windows/wlan/wlan_bss_list.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/wlan/wlan_current_connection.rb
+++ b/modules/post/windows/wlan/wlan_current_connection.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/wlan/wlan_disconnect.rb
+++ b/modules/post/windows/wlan/wlan_disconnect.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/post/windows/wlan/wlan_profile.rb
+++ b/modules/post/windows/wlan/wlan_profile.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/auxiliary/test/capture.rb
+++ b/test/modules/auxiliary/test/capture.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/auxiliary/test/check.rb
+++ b/test/modules/auxiliary/test/check.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/auxiliary/test/eth_spoof.rb
+++ b/test/modules/auxiliary/test/eth_spoof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/auxiliary/test/ftp_data.rb
+++ b/test/modules/auxiliary/test/ftp_data.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/auxiliary/test/heaplib2.rb
+++ b/test/modules/auxiliary/test/heaplib2.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/auxiliary/test/httpserver.rb
+++ b/test/modules/auxiliary/test/httpserver.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/auxiliary/test/ip_spoof.rb
+++ b/test/modules/auxiliary/test/ip_spoof.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/auxiliary/test/recon_passive.rb
+++ b/test/modules/auxiliary/test/recon_passive.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/auxiliary/test/scanner_batch.rb
+++ b/test/modules/auxiliary/test/scanner_batch.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/auxiliary/test/scanner_host.rb
+++ b/test/modules/auxiliary/test/scanner_host.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/auxiliary/test/scanner_range.rb
+++ b/test/modules/auxiliary/test/scanner_range.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/auxiliary/test/space-check.rb
+++ b/test/modules/auxiliary/test/space-check.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/exploits/test/aggressive.rb
+++ b/test/modules/exploits/test/aggressive.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/exploits/test/browserexploitserver.rb
+++ b/test/modules/exploits/test/browserexploitserver.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/exploits/test/check.rb
+++ b/test/modules/exploits/test/check.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/exploits/test/cmdweb.rb
+++ b/test/modules/exploits/test/cmdweb.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/exploits/test/dialup.rb
+++ b/test/modules/exploits/test/dialup.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/exploits/test/egghunter.rb
+++ b/test/modules/exploits/test/egghunter.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/exploits/test/explib2_ie11_drop_exec_test_case.rb
+++ b/test/modules/exploits/test/explib2_ie11_drop_exec_test_case.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/exploits/test/explib2_ie11_exec_test_case.rb
+++ b/test/modules/exploits/test/explib2_ie11_exec_test_case.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/exploits/test/exploitme.rb
+++ b/test/modules/exploits/test/exploitme.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/exploits/test/java_tester.rb
+++ b/test/modules/exploits/test/java_tester.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/exploits/test/kernel.rb
+++ b/test/modules/exploits/test/kernel.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/exploits/test/shell.rb
+++ b/test/modules/exploits/test/shell.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/post/test/railgun_reverse_lookups.rb
+++ b/test/modules/post/test/railgun_reverse_lookups.rb
@@ -1,6 +1,6 @@
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/test/modules/post/test/registry.rb
+++ b/test/modules/post/test/registry.rb
@@ -1,6 +1,6 @@
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/tools/cpassword_decrypt.rb
+++ b/tools/cpassword_decrypt.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/tools/dev/resplat.rb
+++ b/tools/dev/resplat.rb
@@ -22,7 +22,7 @@ end
 
 def resplat(line)
   if line =~ /This file is part of the Metasploit Framework/
-    return "# This module requires Metasploit: http//metasploit.com/download\n"
+# This module requires Metasploit: http://metasploit.com/download
   elsif line =~ /# redistribution and commercial restrictions\./
     return "# Current source: https://github.com/rapid7/metasploit-framework\n"
   else

--- a/tools/virustotal.rb
+++ b/tools/virustotal.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 


### PR DESCRIPTION
See the complaint on #4039. This doesn't fix that particular issue (it's somewhat unrelated), but does solve around a file parsing problem reported by @void-in.

The only non-module files changed were:

```
$ git diff HEAD~ --name-only | grep -v modules/
tools/cpassword_decrypt.rb
tools/dev/resplat.rb
tools/virustotal.rb
```
## Verification
- [ ] See that the new comment didn't add anything crazy.
