### PR TITLE
return if no version response received

### DIFF
--- a/modules/auxiliary/scanner/rsync/modules_list.rb
+++ b/modules/auxiliary/scanner/rsync/modules_list.rb
@@ -32,6 +32,8 @@ class Metasploit3 < Msf::Auxiliary
     connect
     version = sock.get_once
 
+    return if version.blank?
+
     print_good("#{ip}:#{rport} - rsync #{version.strip} found")
     report_service(:host => ip, :port => rport, :proto => 'tcp', :name => 'rsync')
     report_note(


### PR DESCRIPTION
Add a small check for a version banner response; makes the scan a lot faster on non-responsive systems.
