### PR TITLE
Fixing Bug for field fuzz not sleeping

### DIFF
--- a/modules/auxiliary/fuzzers/http/http_form_field.rb
+++ b/modules/auxiliary/fuzzers/http/http_form_field.rb
@@ -26,7 +26,8 @@ class Metasploit3 < Msf::Auxiliary
       },
       'Author'  => [
         'corelanc0d3r',
-        'Paulino Calderon <calderon[at]websec.mx>' #Added cookie handling
+        'Paulino Calderon <calderon[at]websec.mx>', #Added cookie handling
+        'Nicholas Starke <starke.nicholas[at]gmail.com>' #Fixed bug with delay for fields
         ],
       'License'       => MSF_LICENSE,
       'References'    =>
@@ -252,7 +253,7 @@ class Metasploit3 < Msf::Auxiliary
       @send_data[:method] = form[:method].upcase
       response = send_fuzz(@send_data,datastr)
       if not process_response(response,field,"field")
-        return
+        @fuzzsize = @endsize+2
       end
       if datastore['DELAY'] > 0
         print_status("      (Sleeping for #{datastore['DELAY']} seconds...)")


### PR DESCRIPTION
Conditional logic was causing the sleep code from
ever being called by prematurely returning.  I updated
the code to do exactly what the header fuzz function
does in this scenario as a fix for this bug.
