### PR TITLE
fix session.shell_upgrade after #3401

### DIFF
--- a/lib/msf/core/rpc/v10/rpc_session.rb
+++ b/lib/msf/core/rpc/v10/rpc_session.rb
@@ -73,7 +73,7 @@ class RPC_Session < RPC_Base
     s = _valid_session(sid,"shell")
     s.exploit_datastore['LHOST'] = lhost
     s.exploit_datastore['LPORT'] = lport
-    s.execute_script('spawn_meterpreter', nil)
+    s.execute_script('post/multi/manage/shell_to_meterpreter')
     { "result" => "success" }
   end
 


### PR DESCRIPTION
So I foolishly broke session.shell_upgrade after landing #3401 by deleting the original spawn_meterpreter script.
Before (after landing 3401):

```
msf > 
[-] The specified script could not be found: spawn_meterpreter
```

After:

```
[*] Upgrading session: 1
[*] Starting exploit multi handler
[*] Started reverse handler on 192.168.1.97:4433 
[*] Starting the payload handler...
[*] Sending stage (770048 bytes) to 192.168.1.3
[*] Meterpreter session 2 opened (192.168.1.97:4433 -> 192.168.1.3:49840) at 2014-10-22 21:21:30 +0100
[*] Stopping multi/handler
```

I'm using the following python script to test:

```
#!/usr/bin/env python

import sys
import msfrpc

client = msfrpc.Msfrpc({})
client.login('msf','r8PL3yTq')
res = client.call('session.shell_upgrade',[ 1, "192.168.1.97", 4488 ])

```

Apologies!
