### PR TITLE
Session Management: Allow killing multiple specific sessions

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1613,7 +1613,7 @@ class Core
         method = 'killall'
       when "-d"
         method = 'detach'
-        sid = val || nil
+        sid = val
       # Run a script on all meterpreter sessions
       when "-s"
         unless script

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1677,7 +1677,6 @@ class Core
 
           if session.type == 'meterpreter'
             # If session.sys is nil, dont even try..
-            print_good "Checking if session.sys"
             unless session.sys
               print_error("Session #{s} does not have stdapi loaded, skipping...")
               next

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1613,7 +1613,7 @@ class Core
         method = 'killall'
       when "-d"
         method = 'detach'
-        sid = val
+        sid = val || nil
       # Run a script on all meterpreter sessions
       when "-s"
         unless script
@@ -1698,8 +1698,8 @@ class Core
         end
       end
     when 'kill'
+      print_status("Killing the following session(s): #{session_list.join(', ')}")
       session_list.each do |sess_id|
-        print_status("Killing the following session(s): #{session_list.join(', ')}")
         session = framework.sessions.get(sess_id)
         if session
           print_status("Killing session #{sess_id}")
@@ -2973,12 +2973,11 @@ class Core
   protected
 
   #
-  # verifies that a given session_id is valid and that the session is interactive
-  # interactive.  The various return values allow the caller to make better
-  # decisions on what action can & should be taken depending on the capabilities
-  # of the session and the caller's objective while making it simple to use in
-  # the nominal case where the caller needs session_id to match an interactive
-  # session
+  # verifies that a given session_id is valid and that the session is interactive.
+  # The various return values allow the caller to make better decisions on what
+  # action can & should be taken depending on the capabilities of the session
+  # and the caller's objective while making it simple to use in the nominal case
+  # where the caller needs session_id to match an interactive session
   #
   # @param session_id [String] A session id, which is an integer as a string
   # @param quiet [Boolean] True means the method will produce no error messages


### PR DESCRIPTION
The intent of this change is to allow the user to specify multiple sessions to kill when using the sessions -k switch.  This uses the `build_sessions_array` function added in PR #3401 which is now landed.

```
sessions -k <session id range> 
sessions -k 1,3,5-8
```

EDIT:
With the help and feedback from @kernelsmith and @wvu-r7 this PR has been expanded to support specifying ranges for the command, detach, and script options of `sessions` as well as the kill option of `jobs`.   There has been additional code cleanup performed in the areas of the module that were touched in this PR.

Here is an example that specifies a single session, a range, and an invalid session ID.

```
msf exploit(psexec) > sessions 

Active sessions
===============

  Id  Type                   Information                    Connection
  --  ----                   -----------                    ----------
  1   meterpreter x86/win32  NT AUTHORITY\SYSTEM @ WINDC01 192.168.180.102:8343 ->192.168.190.210:49526 (192.168.190.210)
  2   meterpreter x86/win32  NT AUTHORITY\SYSTEM @ WINDC01 192.168.180.102:8343 ->192.168.190.210:49528 (192.168.190.210)
  3   meterpreter x86/win32  NT AUTHORITY\SYSTEM @ WINDC01 192.168.180.102:8343 ->192.168.190.210:49529 (192.168.190.210)
  4   meterpreter x86/win32  NT AUTHORITY\SYSTEM @ WINDC01 192.168.180.102:8343 ->192.168.190.210:49530 (192.168.190.210)
  5   meterpreter x86/win32  NT AUTHORITY\SYSTEM @ WINDC01 192.168.180.102:8343 ->192.168.190.210:49532 (192.168.190.210)
  6   meterpreter x86/win32  NT AUTHORITY\SYSTEM @ WINDC01 192.168.180.102:8343 ->192.168.190.210:49533 (192.168.190.210)

msf exploit(psexec) > sessions -k 1,3-5,7
[*] Killing the following session(s): [1, 3, 4, 5, 7]
[*] Killing session 1
[*]192.168.190.210 - Meterpreter session 1 closed.
[*] Killing session 3
[*]192.168.190.210 - Meterpreter session 3 closed.
[*] Killing session 4
[*]192.168.190.210 - Meterpreter session 4 closed.
[*] Killing session 5
[*]192.168.190.210 - Meterpreter session 5 closed.
[-] Invalid session identifier: 7
msf exploit(psexec) > sessions 

Active sessions
===============

  Id  Type                   Information                    Connection
  --  ----                   -----------                    ----------
  2   meterpreter x86/win32  NT AUTHORITY\SYSTEM @ WINDC01 192.168.180.102:8343 ->192.168.190.210:49528 (192.168.190.210)
  6   meterpreter x86/win32  NT AUTHORITY\SYSTEM @ WINDC01 192.168.180.102:8343 ->192.168.190.210:49533 (192.168.190.210)
```
