### PR TITLE
IN:SRV expansion for Fake DNS server

### DIFF
--- a/modules/auxiliary/server/fakedns.rb
+++ b/modules/auxiliary/server/fakedns.rb
@@ -204,7 +204,6 @@ class Metasploit3 < Msf::Auxiliary
               # if we are in bypass mode or we are in fake mode but the target didn't match,
               # just return the real response RRs
               answers << Resolv::DNS::Resource::IN::SRV.new(priority, weight, port, Resolv::DNS::Name.create(host))
-              additionals << [ host, Resolv::DNS.new().getaddress(host).to_s ]
               if (@log_console)
                 print_status("DNS bypass domain found: #{@match_name}")
                 print_status("SRV records listed for #{@match_name}")

--- a/modules/auxiliary/server/fakedns.rb
+++ b/modules/auxiliary/server/fakedns.rb
@@ -149,7 +149,7 @@ class Metasploit3 < Msf::Auxiliary
           # <hostname> SOA -> windows XP self hostname lookup
           #
 
-          answer = Resolv::DNS::Resource::IN::A.new(target_host() )
+          answer = Resolv::DNS::Resource::IN::A.new(target_host(src_addr))
 
           if (@match_target and not @bypass) or (not @match_target and @bypass)
             # Resolve FAKE response

--- a/modules/auxiliary/server/fakedns.rb
+++ b/modules/auxiliary/server/fakedns.rb
@@ -44,7 +44,7 @@ class Metasploit3 < Msf::Auxiliary
 
     register_advanced_options(
       [
-        OptInt.new('SRV_PORT', [ false, "The Port field in the SRV response for the FAKE action", 5060]),
+        OptPort.new('RR_SRV_PORT', [ false, "The port field in the SRV response when FAKE", 5060]),
         OptBool.new('LogConsole', [ false, "Determines whether to log all request to the console", true]),
         OptBool.new('LogDatabase', [ false, "Determines whether to log all request to the database", false]),
       ], self.class)
@@ -212,7 +212,7 @@ class Metasploit3 < Msf::Auxiliary
               answers << Resolv::DNS::Resource::IN::SRV.new(priority, weight, port, Resolv::DNS::Name.create(host))
             else
               # Prepare the FAKE response
-              answers << Resolv::DNS::Resource::IN::SRV.new(5,0,datastore['SRV_PORT'],Resolv::DNS::Name.create(name))
+              answers << Resolv::DNS::Resource::IN::SRV.new(5,0,datastore['RR_SRV_PORT'],Resolv::DNS::Name.create(name))
               additionals << [ host, @targ || ::Rex::Socket.source_address(addr[3].to_s) ]
               authorities << Resolv::DNS::Resource::IN::NS.new(Resolv::DNS::Name.create("dns.#{name}"))
             end

--- a/modules/auxiliary/server/fakedns.rb
+++ b/modules/auxiliary/server/fakedns.rb
@@ -20,7 +20,7 @@ class Metasploit3 < Msf::Auxiliary
         This module provides a DNS service that redirects
       all queries to a particular address.
       },
-      'Author'      => ['ddz', 'hdm', 'Fatih Ozavci <viproy.com/fozavci> (only for IN::SRV)'],
+      'Author'      => ['ddz', 'hdm', 'Fatih Ozavci <viproy.com/fozavci>'],
       'License'     => MSF_LICENSE,
       'Actions'     =>
         [


### PR DESCRIPTION
IN::SRV records are required for the VoIP and XMPP clients.
