### PR TITLE
Add a failing spec for `is_eicar_corrupted`?

### DIFF
--- a/spec/lib/msf/util/exe_spec.rb
+++ b/spec/lib/msf/util/exe_spec.rb
@@ -24,6 +24,12 @@ describe Msf::Util::EXE do
     end
   end
 
+  describe '.is_eicar_corrupted?' do
+    it 'returns true' do
+      expect(described_class.is_eicar_corrupted?).to be_false
+    end
+  end
+
   describe '.to_executable_fmt' do
     it "should output nil when given a bogus format" do
       bin = subject.to_executable_fmt($framework, "", "", "", "does not exist", {})

--- a/spec/lib/msf/util/exe_spec.rb
+++ b/spec/lib/msf/util/exe_spec.rb
@@ -25,7 +25,7 @@ describe Msf::Util::EXE do
   end
 
   describe '.is_eicar_corrupted?' do
-    it 'returns true' do
+    it 'returns false' do
       expect(described_class.is_eicar_corrupted?).to be_false
     end
   end


### PR DESCRIPTION
This will let Travis catch problems with eicar check. The check should pass once #4068 is fixed.
