### PR TITLE
fixes inverted EICAR corruption logic

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1931,15 +1931,19 @@ to_linux_x86_elf(framework, code, exeopts)
   # EICAR Canary: https://www.metasploit.com/redmine/projects/framework/wiki/EICAR
   #
   def self.is_eicar_corrupted?
-    path = ::File.expand_path(::File.join(::File.dirname(__FILE__), "..", "..", "..", "data", "eicar.com"))
-    ret = true
+    path = ::File.expand_path(::File.join(
+      ::File.dirname(__FILE__),"..", "..", "..", "data", "eicar.com")
+    )
+    return true unless ::File.exists?(path)
+    ret = false
     if ::File.exists?(path)
       begin
         data = ::File.read(path)
         unless Digest::SHA1.hexdigest(data) == "3395856ce81f2b7382dee72602f798b642f14140"
-          ret = false
+          ret = true
         end
       rescue ::Exception
+        ret = true
       end
     end
     ret


### PR DESCRIPTION
Urgent, fixes #4068
Fixes my inverted EICAR corruption logic.  Logic was inverted in f19b093529f3b3aacefb69f8133ab788859445d1

When landing, please commit message with Fixes #4068.

After this lands, I will land 4069 which is a spec @jvennix-r7, aka, "Da Man" wrote to cover this
## Verification

-[ ] On a fresh checkout, make sure msfconsole starts w/o erroring out.  Alternatively also pull the spec from 4069 and run that
