### PR TITLE
changes be_false to be_falsey in exe_spec

### DIFF
--- a/spec/lib/msf/util/exe_spec.rb
+++ b/spec/lib/msf/util/exe_spec.rb
@@ -26,7 +26,7 @@ describe Msf::Util::EXE do
 
   describe '.is_eicar_corrupted?' do
     it 'returns false' do
-      expect(described_class.is_eicar_corrupted?).to be_false
+      expect(described_class.is_eicar_corrupted?).to be_falsey
     end
   end
 


### PR DESCRIPTION
I didn't want to muddle the last commits by changing this at merge time.  This is a super simple change
## Verification
- [x] run rspec spec/lib/msf/util/exe_spec.rb and don't get a deprecation warning about be_false vs be_falsey.  You may get other, unrelated deprecation warnings.
