### PR TITLE
Use eq(false) instead of falsey-ness test in eicar check

### DIFF
--- a/spec/lib/msf/util/exe_spec.rb
+++ b/spec/lib/msf/util/exe_spec.rb
@@ -26,7 +26,7 @@ describe Msf::Util::EXE do
 
   describe '.is_eicar_corrupted?' do
     it 'returns false' do
-      expect(described_class.is_eicar_corrupted?).to be_false
+      expect(described_class.is_eicar_corrupted?).to eq(false)
     end
   end
 


### PR DESCRIPTION
I used `be_false` where I should have used `eq(false)`, to ensure that a boolean false value is returned. Oops.
#### Verification
- [x] Once Travis passes, this is fine to merge.
