### PR TITLE
Update pureftpd_bash_env_exec description about exploitable requirements

### DIFF
--- a/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
+++ b/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
@@ -15,8 +15,8 @@ class Metasploit4 < Msf::Exploit::Remote
     super(update_info(info,
       'Name'            => 'Pure-FTPd External Authentication Bash Environment Variable Code Injection',
       'Description'     => %q(
-        This module exploits the code injection flaw known as shellshock which
-        leverages specially crafted environment variables in Bash.
+        This module exploits the code injection flaw known as shellshock which leverages specially
+        crafted environment variables in Bash.
 
         Please note that this exploit specifically targets Pure-FTPd compiled with the --with-extauth
         flag, and an external bash program for authentication. If the server is not set up this way,

--- a/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
+++ b/modules/exploits/multi/ftp/pureftpd_bash_env_exec.rb
@@ -16,9 +16,12 @@ class Metasploit4 < Msf::Exploit::Remote
       'Name'            => 'Pure-FTPd External Authentication Bash Environment Variable Code Injection',
       'Description'     => %q(
         This module exploits the code injection flaw known as shellshock which
-        leverages specially crafted environment variables in Bash. This exploit
-        specifically targets Pure-FTPd when configured to use an external
-        program for authentication.
+        leverages specially crafted environment variables in Bash.
+
+        Please note that this exploit specifically targets Pure-FTPd compiled with the --with-extauth
+        flag, and an external bash program for authentication. If the server is not set up this way,
+        understand that even if the operating system is vulnerable to 'Shellshock', it cannot be
+        exploited via Pure-FTPd.
       ),
       'Author'          =>
         [
@@ -31,7 +34,8 @@ class Metasploit4 < Msf::Exploit::Remote
           ['CVE', '2014-6271'],
           ['OSVDB', '112004'],
           ['EDB', '34765'],
-          ['URL', 'https://gist.github.com/jedisct1/88c62ee34e6fa92c31dc']
+          ['URL', 'https://gist.github.com/jedisct1/88c62ee34e6fa92c31dc'],
+          ['URL', 'http://download.pureftpd.org/pub/pure-ftpd/doc/README.Authentication-Modules']
         ],
       'Payload'         =>
         {


### PR DESCRIPTION
I would like to update the description to make the exploitable requirements more obvious. Reason being I keep seeing the following question like this getting asked again and again:

https://community.rapid7.com/thread/5260
