### PR TITLE
TCP and TCPServer should use TLS1 by default

### DIFF
--- a/lib/msf/core/exploit/tcp.rb
+++ b/lib/msf/core/exploit/tcp.rb
@@ -64,7 +64,7 @@ module Exploit::Remote::Tcp
     register_advanced_options(
       [
         OptBool.new('SSL',        [ false, 'Negotiate SSL for outgoing connections', false]),
-        OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'SSL3', ['SSL2', 'SSL3', 'TLS1']]),
+        OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'TLS1', ['SSL2', 'SSL3', 'TLS1']]),
         OptEnum.new('SSLVerifyMode',  [ false, 'SSL verification method', 'PEER', %W{CLIENT_ONCE FAIL_IF_NO_PEER_CERT NONE PEER}]),
         OptString.new('SSLCipher',    [ false, 'String for SSL cipher - "DHE-RSA-AES256-SHA" or "ADH"']),
         Opt::Proxies,

--- a/lib/msf/core/exploit/tcp_server.rb
+++ b/lib/msf/core/exploit/tcp_server.rb
@@ -18,7 +18,7 @@ module Exploit::Remote::TcpServer
     register_options(
       [
         OptBool.new('SSL',        [ false, 'Negotiate SSL for incoming connections', false]),
-        OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'SSL3', ['SSL2', 'SSL3', 'TLS1']]),
+        OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'TLS1', ['SSL2', 'SSL3', 'TLS1']]),
         OptPath.new('SSLCert',    [ false, 'Path to a custom SSL certificate (default is randomly generated)']),
         OptAddress.new('SRVHOST', [ true, "The local host to listen on. This must be an address on the local machine or 0.0.0.0", '0.0.0.0' ]),
         OptPort.new('SRVPORT',    [ true, "The local port to listen on.", 8080 ]),


### PR DESCRIPTION
Looks like a couple SSLVersion options were missed in #4022 -- this should pick up the rest (used for non-HTTP TCP and TCPServer modules, mainly.
