### PR TITLE
Allow FTP server exploits pick a PASV port

### DIFF
--- a/lib/msf/core/exploit/ftpserver.rb
+++ b/lib/msf/core/exploit/ftpserver.rb
@@ -22,7 +22,8 @@ module Exploit::Remote::FtpServer
     # Register the options that all FTP exploits may make use of.
     register_options(
       [
-        OptPort.new('SRVPORT',    [ true, "The local port to listen on.", 21 ])
+        OptPort.new('SRVPORT',    [ true, "The local port to listen on.", 21 ]),
+        OptPort.new('PASVPORT',   [ false, "The local PASV data port to listen on (0 is random)", 0 ])
       ], Msf::Exploit::Remote::FtpServer)
   end
 
@@ -172,7 +173,7 @@ module Exploit::Remote::FtpServer
     if(not @state[c][:passive_sock])
       s = Rex::Socket::TcpServer.create(
         'LocalHost' => '0.0.0.0',
-        'LocalPort' => 0,
+        'LocalPort' => datastore['PASVPORT'].to_i,
         'Context'   => { 'Msf' => framework, 'MsfExploit' => self }
       )
 


### PR DESCRIPTION
This makes it somewhat easier to use FTP server exploit modules in somewhat more restrictive networks, where you might only have a few inbound ports to choose from.
## Verification
- [ ] secret for now :)
