### PR TITLE
adds did-you-mean gem to dev & test groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,8 @@ group :development, :test do
   # Define `rake spec`.  Must be in development AND test so that its available by default as a rake test when the
   # environment is development
   gem 'rspec-rails' , '>= 2.12', '< 3.0.0'
+  # did you mean
+  gem 'did_you_mean'
 end
 
 group :pcap do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,8 @@ GEM
       cucumber (>= 1.1.1)
       rspec-expectations (>= 2.7.0)
     bcrypt (3.1.7)
+    binding_of_caller (0.7.2)
+      debug_inspector (>= 0.0.1)
     builder (3.0.4)
     capybara (2.4.1)
       mime-types (>= 1.16)
@@ -78,6 +80,9 @@ GEM
       cucumber (>= 1.2.0)
       nokogiri (>= 1.5.0)
       rails (>= 3.0.0)
+    debug_inspector (0.0.2)
+    did_you_mean (0.7.0)
+      binding_of_caller
     diff-lcs (1.2.5)
     erubis (2.7.0)
     factory_girl (4.4.0)
@@ -219,6 +224,7 @@ DEPENDENCIES
   activerecord (>= 3.0.0, < 4.0.0)
   aruba
   cucumber-rails
+  did_you_mean
   factory_girl (>= 4.1.0)
   factory_girl_rails
   fivemat (= 1.2.1)


### PR DESCRIPTION
This is quite useful during dev & test, most obviously when in the irb console w/in msfconsole etc.

e.g.

```
>> framework.init_module_path
NoMethodError: undefined method `init_module_path' for #<Msf::Framework:0x007faf8427c8c0>
     Did you mean? #init_module_paths
                              #init_module_paths

>> ::Msf::Util::EXE.is_eicar_corrupted
NoMethodError: undefined method `is_eicar_corrupted' for Msf::Util::EXE:Class
     Did you mean? .is_eicar_corrupted?
                              .is_eicar_corrupted?
```

Don't forget to bundle install.  I guess verification is:
- [ ] bundle install
- [ ] msfconsole -x irb # or tools/msf_irb_shell.rb
- [ ] run framework.init_module_path and see the "did you mean init_module_paths" error message
