### PR TITLE
Add more specs for Rex::OLE

### DIFF
--- a/spec/lib/rex/ole/clsid_spec.rb
+++ b/spec/lib/rex/ole/clsid_spec.rb
@@ -4,6 +4,9 @@ require 'spec_helper'
 require 'rex/ole'
 
 describe Rex::OLE::CLSID do
+  before(:each) do
+    Rex::OLE::Util.set_endian(Rex::OLE::LITTLE_ENDIAN)
+  end
 
   let(:sample_clsid) { "\x00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa\xbb\xcc\xdd\xee\xff" }
 
@@ -35,7 +38,6 @@ describe Rex::OLE::CLSID do
 
   describe "#to_s" do
     it "returns printable clsid" do
-      Rex::OLE::Util.set_endian(Rex::OLE::LITTLE_ENDIAN)
       expect(clsid.to_s).to eq('33221100-5544-7766-8899-aabbccddeeff')
     end
 

--- a/spec/lib/rex/ole/difat_spec.rb
+++ b/spec/lib/rex/ole/difat_spec.rb
@@ -4,6 +4,9 @@ require 'spec_helper'
 require 'rex/ole'
 
 describe Rex::OLE::DIFAT do
+  before(:each) do
+    Rex::OLE::Util.set_endian(Rex::OLE::LITTLE_ENDIAN)
+  end
 
   let(:storage) do
     Rex::OLE::Storage.new

--- a/spec/lib/rex/ole/direntry_spec.rb
+++ b/spec/lib/rex/ole/direntry_spec.rb
@@ -4,6 +4,9 @@ require 'spec_helper'
 require 'rex/ole'
 
 describe Rex::OLE::DirEntry do
+  before(:each) do
+    Rex::OLE::Util.set_endian(Rex::OLE::LITTLE_ENDIAN)
+  end
 
   let(:storage) do
     Rex::OLE::Storage.new

--- a/spec/lib/rex/ole/header_spec.rb
+++ b/spec/lib/rex/ole/header_spec.rb
@@ -4,6 +4,9 @@ require 'spec_helper'
 require 'rex/ole'
 
 describe Rex::OLE::Header do
+  before(:each) do
+    Rex::OLE::Util.set_endian(Rex::OLE::LITTLE_ENDIAN)
+  end
 
   subject(:header) do
     described_class.new
@@ -240,7 +243,7 @@ describe Rex::OLE::Header do
         hdr << 'A' * 16 # @_clid
         hdr << 'BB' # @_uMinorVersion
         hdr << 'CC' # @_uMajorVersion
-        hdr << 'DD' # @_uByteOrder
+        hdr << "\xfe\xff" # @_uByteOrder
         hdr << 'EE' # @_uSectorShift
         hdr << 'FF' # @_uMiniSectorShift
         hdr << '123456' # padding
@@ -275,7 +278,7 @@ describe Rex::OLE::Header do
 
       it "sets byte order from input" do
         header.read(correct_fd)
-        expect(header.instance_variable_get(:@_uByteOrder)).to eq(0x4444)
+        expect(header.instance_variable_get(:@_uByteOrder)).to eq(Rex::OLE::LITTLE_ENDIAN)
       end
 
       it "sets the size of sectors from input" do

--- a/spec/lib/rex/ole/minifat_spec.rb
+++ b/spec/lib/rex/ole/minifat_spec.rb
@@ -4,6 +4,9 @@ require 'spec_helper'
 require 'rex/ole'
 
 describe Rex::OLE::MiniFAT do
+  before(:each) do
+    Rex::OLE::Util.set_endian(Rex::OLE::LITTLE_ENDIAN)
+  end
 
   let(:storage) do
     Rex::OLE::Storage.new

--- a/spec/lib/rex/ole/util_spec.rb
+++ b/spec/lib/rex/ole/util_spec.rb
@@ -4,6 +4,9 @@ require 'spec_helper'
 require 'rex/ole'
 
 describe Rex::OLE::Util do
+  before(:each) do
+    Rex::OLE::Util.set_endian(Rex::OLE::LITTLE_ENDIAN)
+  end
 
   describe ".Hexify32array" do
     subject(:hex_array) { described_class.Hexify32array(arr) }


### PR DESCRIPTION
Adds specs for:
- Rex::OLE::Header class
- Rex::OLE::DIFAT 
- Rex::OLE::MiniFat
- Rex::OLE::DirEntry
## Verification steps
- [ ] Be sure which travis is green
- [ ] Run the specs locally one by one and ensure all the tests pass

```
$ rspec spec/lib/rex/ole/header_spec.rb
Rex::OLE::Header ..............................................................................

Finished in 0.08195 seconds
78 examples, 0 failures
```

```
$ rspec spec/lib/rex/ole/difat_spec.rb
Rex::OLE::DIFAT .....................................

Finished in 0.05008 seconds
37 examples, 0 failures

```

```
$ rspec spec/lib/rex/ole/minifat_spec.rb
Rex::OLE::MiniFAT ...........

Finished in 0.01647 seconds
11 examples, 0 failures

```

```
$ rspec spec/lib/rex/ole/direntry_spec.rb

Rex::OLE::DirEntry ...............................................

Finished in 0.05488 seconds
47 examples, 0 failures

```
- [ ] Also run all the Rex::OLE specs together and be sure they pass:

```
$ rspec spec/lib/rex/ole/*




Rex::OLE::Util ..........................................
Rex::OLE::MiniFAT ...........
Rex::OLE::DIFAT .....................................
Rex::OLE::Header ..............................................................................
Rex::OLE::CLSID ......
Rex::OLE::DirEntry ...............................................................

Finished in 0.3141 seconds
237 examples, 0 failures

```
