### PR TITLE
Use correct destination port for NBNS spoofer

### DIFF
--- a/modules/auxiliary/spoof/nbns/nbns_response.rb
+++ b/modules/auxiliary/spoof/nbns/nbns_response.rb
@@ -67,6 +67,7 @@ class Metasploit3 < Msf::Auxiliary
 
     while @run # Not exactly thrilled we can never turn this off XXX fix this sometime.
       packet, addr = @sock.recvfrom(512)
+      src_port = addr[1]
       rhost = addr[3]
 
       break if packet.length == 0
@@ -127,7 +128,7 @@ class Metasploit3 < Msf::Auxiliary
         p.ip_daddr = rhost
         p.ip_ttl = 255
         p.udp_sport = 137
-        p.udp_dport = 137
+        p.udp_dport = src_port
         p.payload = response
         p.recalc
 


### PR DESCRIPTION
When working on something unrelated, I was looking at this module to see how spoofing is done.  While testing it, I noticed that the destination port in the replies is hardcoded to 137.  In e89dcc5ab0a5cb8e56922bc81a61c688d79cef54, this was changed from 1337, which was even more wrong.  137 is only correct for systems that use this as their source port when sending the NBNS queries, which AFAIK is just Windows.  Samba (nmblookup), for example, does not use this port.  I've changed it to use the source port of the request.
# Validation
- [ ] Run nbns_response
- [ ] Validate that queries from Windows system are properly intercepted and the responses are correct
- [ ] Validate that queries from non-Windows system (nmblookup) are properly intercepted and the responses are correct
