### PR TITLE
Add template and better defaults for UDPScanner

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,11 @@ Metrics/MethodLength:
 Style/Encoding:
   Enabled: false
 
+# %q() is super useful for long strings split over multiple lines and
+# is very common in module constructors for things like descriptions
+Style/UnneededPercentQ:
+  Enabled: false
+
 Style/NumericLiterals:
   Enabled: false
   Description: 'This often hurts readability for exploit-ish code.'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@
 
 # inherit_from: .rubocop_todo.yml
 
-Style/ClassLength:
+Metrics/ClassLength:
   Description: 'Most Metasploit modules are quite large. This is ok.'
   Enabled: true
   Exclude:
@@ -25,14 +25,14 @@ Style/Encoding:
   Description: 'We prefer binary to UTF-8.'
   EnforcedStyle: 'when_needed'
 
-Style/LineLength:
+Metrics/LineLength:
   Description: >-
                   Metasploit modules often pattern match against very
                   long strings when identifying targets.
   Enabled: true
   Max: 180
 
-Style/MethodLength:
+Metrics/MethodLength:
   Enabled: true
   Description: >-
                   While the style guide suggests 10 lines, exploit definitions

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -244,7 +244,7 @@ def scanner_show_progress
   if(pct >= (@range_percent + @show_percent))
     @range_percent = @range_percent + @show_percent
     tdlen = @range_count.to_s.length
-    print_status("Scanned #{"%.#{tdlen}d" % @range_done} of #{@range_count} hosts (#{"%.3d" % pct.to_i}% complete)")
+    print_status("Scanned #{"%.#{tdlen}d" % @range_done} of #{@range_count} hosts (#{"%.3g" % pct}% complete)")
   end
 end
 

--- a/lib/msf/core/auxiliary/scanner.rb
+++ b/lib/msf/core/auxiliary/scanner.rb
@@ -241,10 +241,10 @@ end
 
 def scanner_show_progress
   pct = scanner_progress
-  if(pct >= (@range_percent + @show_percent))
+  if pct >= (@range_percent + @show_percent)
     @range_percent = @range_percent + @show_percent
     tdlen = @range_count.to_s.length
-    print_status("Scanned #{"%.#{tdlen}d" % @range_done} of #{@range_count} hosts (#{"%.3g" % pct}% complete)")
+    print_status(sprintf("Scanned %#{tdlen}d of %d hosts (%d%% complete)", @range_done, @range_count, pct))
   end
 end
 

--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -21,7 +21,7 @@ module Auxiliary::UDPScanner
     register_options(
     [
       Opt::RPORT,
-      OptInt.new('BATCHSIZE', [true, 'The number of hosts to probe in each set', 256])
+      OptInt.new('BATCHSIZE', [true, 'The number of hosts to probe in each set', 256]),
       OptInt.new('THREADS', [true, "The number of concurrent threads", 10])
     ], self.class)
 

--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -176,7 +176,7 @@ module Auxiliary::UDPScanner
 
   # Called for each IP in the batch.  This will send all necessary probes.
   def scan_host(ip)
-    scanner_send(@probe, ip, datastore['RPORT'])
+    scanner_send(@probe, ip, rport)
   end
 
   # Called for each response packet

--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -8,13 +8,17 @@ module Msf
 #
 ###
 module Auxiliary::UDPScanner
-
   include Auxiliary::Scanner
+
+  # A hash of results of a given batch run, keyed by host
+  attr_accessor :results
+
+  # A probe to be sent to each host
+  attr_accessor :probe
 
   #
   # Initializes an instance of an auxiliary module that scans UDP
   #
-
   def initialize(info = {})
     super
 
@@ -167,11 +171,12 @@ module Auxiliary::UDPScanner
   end
 
   #
-  # The including module override these methods
+  # The including module may override some of these methods
   #
 
-  # Called for each IP in the batch
+  # Called for each IP in the batch.  This will send all necessary probes.
   def scan_host(ip)
+    scanner_send(@probe, ip, datastore['RPORT'])
   end
 
   # Called for each response packet
@@ -180,11 +185,12 @@ module Auxiliary::UDPScanner
 
   # Called before the scan block
   def scanner_prescan(batch)
+    vprint_status("Sending probes to #{batch[0]}->#{batch[-1]} (#{batch.length} hosts)")
+    @results = {}
   end
 
   # Called after the scan block
   def scanner_postscan(batch)
   end
-
 end
 end

--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -20,20 +20,22 @@ module Auxiliary::UDPScanner
 
     register_options(
     [
-      Opt::CHOST,
-      OptInt.new('BATCHSIZE', [true, 'The number of hosts to probe in each set', 256]),
+      Opt::RPORT,
+      OptInt.new('BATCHSIZE', [true, 'The number of hosts to probe in each set', 256])
+      OptInt.new('THREADS', [true, "The number of concurrent threads", 10])
     ], self.class)
 
     register_advanced_options(
     [
+      Opt::CHOST,
+      Opt::CPORT,
       OptInt.new('ScannerRecvInterval', [true, 'The maximum numbers of sends before entering the processing loop', 30]),
       OptInt.new('ScannerMaxResends', [true, 'The maximum times to resend a packet when out of buffers', 10]),
       OptInt.new('ScannerRecvQueueLimit', [true, 'The maximum queue size before breaking out of the processing loop', 100]),
-      OptInt.new('ScannerRecvWindow', [true, 'The number of seconds to wait post-scan to catch leftover replies', 15]),
+      OptInt.new('ScannerRecvWindow', [true, 'The number of seconds to wait post-scan to catch leftover replies', 15])
 
     ], self.class)
   end
-
 
   # Define our batch size
   def run_batch_size
@@ -44,6 +46,7 @@ module Auxiliary::UDPScanner
   def run_batch(batch)
     @udp_sock = Rex::Socket::Udp.create({
       'LocalHost' => datastore['CHOST'] || nil,
+      'LocalPort' => datastore['CPORT'] || 0,
       'Context'   => { 'Msf' => framework, 'MsfExploit' => self }
     })
     add_socket(@udp_sock)
@@ -153,6 +156,14 @@ module Auxiliary::UDPScanner
     end
 
     queue.length
+  end
+
+  def cport
+    datastore['CPORT']
+  end
+
+  def rport
+    datastore['RPORT']
   end
 
   #

--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -13,9 +13,6 @@ module Auxiliary::UDPScanner
   # A hash of results of a given batch run, keyed by host
   attr_accessor :results
 
-  # A probe to be sent to each host
-  attr_accessor :probe
-
   #
   # Initializes an instance of an auxiliary module that scans UDP
   #
@@ -174,9 +171,13 @@ module Auxiliary::UDPScanner
   # The including module may override some of these methods
   #
 
+  # Builds and returns the probe to be sent
+  def build_probe
+  end
+
   # Called for each IP in the batch.  This will send all necessary probes.
   def scan_host(ip)
-    scanner_send(@probe, ip, rport)
+    scanner_send(build_probe, ip, rport)
   end
 
   # Called for each response packet

--- a/modules/auxiliary/scanner/udp_scanner_template.rb
+++ b/modules/auxiliary/scanner/udp_scanner_template.rb
@@ -8,7 +8,6 @@ require 'msf/core'
 class Metasploit3 < Msf::Auxiliary
 
   include Msf::Auxiliary::Report
-  include Msf::Exploit::Remote::Udp
   include Msf::Auxiliary::UDPScanner
 
   def initialize
@@ -25,11 +24,14 @@ class Metasploit3 < Msf::Auxiliary
       'DisclosureDate' => 'Mar 15 2014',
       'License'        => MSF_LICENSE
     )
+
     register_options(
     [
+      # TODO: change to the port you need to scan
       Opt::RPORT(12345)
     ], self.class)
 
+    # TODO: add any advanced, special options here, otherwise remove
     register_advanced_options(
     [
       OptBool.new('SPECIAL', [true, 'Try this special thing', false])
@@ -39,10 +41,9 @@ class Metasploit3 < Msf::Auxiliary
   # Called for each IP in the batch
   def scan_host(ip)
     if datastore['SPECIAL']
-      scanner_send("Please and thank you, #{ip}!", ip, rport)
-    else
-      scanner_send(@probe, ip, datastore['RPORT'])
+      @probe = "Please and thank you, #{ip}!"
     end
+    scanner_send(@probe, ip, datastore['RPORT'])
   end
 
   # Called for each response packet
@@ -60,6 +61,7 @@ class Metasploit3 < Msf::Auxiliary
   # Called after the scan block
   def scanner_postscan(batch)
     @results.each_pair do |host, responses|
+      peer = "#{host}:#{rport}"
 
       # consider confirming that any of the responses are actually
       # valid responses for this service before reporing it or
@@ -74,7 +76,7 @@ class Metasploit3 < Msf::Auxiliary
       if responses.any? { |response| response =~ /[a-z0-9]{5}/i }
         print_good("#{peer} - Vulnerable to something!")
         report_vuln(
-          host: k,
+          host: host,
           port: rport,
           proto: 'udp',
           name: 'something!',

--- a/modules/auxiliary/scanner/udp_scanner_template.rb
+++ b/modules/auxiliary/scanner/udp_scanner_template.rb
@@ -48,9 +48,11 @@ class Metasploit3 < Msf::Auxiliary
     super
     # TODO: do any sort of preliminary sanity checking, like perhaps validating some options
     # in the datastore, etc.
+  end
 
-    # TODO: build the appropriate probe here
-    @probe = 'abracadabra!'
+  # TODO: construct the appropriate probe here.
+  def build_probe
+    @probe ||= 'abracadabra!'
   end
 
   # TODO: this is called before the scan block for each batch of hosts.  Do any

--- a/modules/auxiliary/scanner/udp_scanner_template.rb
+++ b/modules/auxiliary/scanner/udp_scanner_template.rb
@@ -1,0 +1,88 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::Udp
+  include Msf::Auxiliary::UDPScanner
+
+  def initialize
+    super(
+      'Name'           => 'UDP Scanner Example',
+      'Description'    => %q(
+        This module does stuff
+      ),
+      'Author'         => 'Joe Contributor <joe_contributor[at]example.com>',
+      'References'     =>
+        [
+          ['URL', 'https://example.com/~jcontributor']
+        ],
+      'DisclosureDate' => 'Mar 15 2014',
+      'License'        => MSF_LICENSE
+    )
+    register_options(
+    [
+      Opt::RPORT(12345)
+    ], self.class)
+
+    register_advanced_options(
+    [
+      OptBool.new('SPECIAL', [true, 'Try this special thing', false])
+    ], self.class)
+  end
+
+  # Called for each IP in the batch
+  def scan_host(ip)
+    if datastore['SPECIAL']
+      scanner_send("Please and thank you, #{ip}!", ip, rport)
+    else
+      scanner_send(@probe, ip, datastore['RPORT'])
+    end
+  end
+
+  # Called for each response packet
+  def scanner_process(data, src_host, src_port)
+    @results[src_host] ||= []
+    @results[src_host] << data.inspect
+  end
+
+  # Called before the scan block
+  def scanner_prescan(batch)
+    @results = {}
+    @probe = "abracadabra!"
+  end
+
+  # Called after the scan block
+  def scanner_postscan(batch)
+    @results.each_pair do |host, responses|
+
+      # consider confirming that any of the responses are actually
+      # valid responses for this service before reporing it or
+      # examining the responses for signs of a vulnerability
+      report_service(
+        host: host,
+        proto:'udp',
+        port: rport,
+        name: 'example'
+      )
+
+      if responses.any? { |response| response =~ /[a-z0-9]{5}/i }
+        print_good("#{peer} - Vulnerable to something!")
+        report_vuln(
+          host: k,
+          port: rport,
+          proto: 'udp',
+          name: 'something!',
+          refs: references
+        )
+      else
+        vprint_status("#{peer} - Not vulnerable to something")
+      end
+    end
+  end
+end

--- a/modules/auxiliary/scanner/udp_scanner_template.rb
+++ b/modules/auxiliary/scanner/udp_scanner_template.rb
@@ -54,6 +54,7 @@ class Metasploit3 < Msf::Auxiliary
 
   # Called before the scan block
   def scanner_prescan(batch)
+    vprint_status("Sending probes to #{batch[0]}->#{batch[-1]} (#{batch.length} hosts)")
     @results = {}
     @probe = "abracadabra!"
   end

--- a/modules/auxiliary/scanner/udp_scanner_template.rb
+++ b/modules/auxiliary/scanner/udp_scanner_template.rb
@@ -6,15 +6,18 @@
 require 'msf/core'
 
 class Metasploit3 < Msf::Auxiliary
-
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::UDPScanner
 
   def initialize
     super(
+      # TODO: fill in all of this
       'Name'           => 'UDP Scanner Example',
       'Description'    => %q(
-        This module does stuff
+        This module is an example of how to send probes to UDP services
+        en-masse, analyze any responses, and then report on any discovered
+        hosts, services, vulnerabilities or otherwise noteworthy things.
+        Simply address any of the TODOs.
       ),
       'Author'         => 'Joe Contributor <joe_contributor[at]example.com>',
       'References'     =>
@@ -38,53 +41,77 @@ class Metasploit3 < Msf::Auxiliary
     ], self.class)
   end
 
-  # Called for each IP in the batch
+  def setup
+    super
+    # TODO: do any sort of preliminary sanity checking, like perhaps validating some options
+    # in the datastore, etc.
+
+    # TODO: build the appropriate probe here
+    @probe = 'abracadabra!'
+  end
+
+  # TODO: this is called before the scan block for each batch of hosts.  Do any
+  # per-batch setup here, otherwise remove it.
+  def scanner_prescan(batch)
+    super
+  end
+
+  # TODO: this is called for each IP in the batch.  This will send all of the
+  # necessary probes.  If something different must be done for each IP, do it
+  # here, otherwise remove it.
   def scan_host(ip)
-    if datastore['SPECIAL']
-      @probe = "Please and thank you, #{ip}!"
-    end
-    scanner_send(@probe, ip, datastore['RPORT'])
+    super
   end
 
   # Called for each response packet
-  def scanner_process(data, src_host, src_port)
+  def scanner_process(response, src_host, _src_port)
+    # TODO: inspect each response, perhaps confirming that it is a valid
+    # response for the service/protocol in question and/or analyzing it more
+    # closely.  In this case, we simply check to see that it is of reasonable
+    # size and storing a result for this host iff so.  Note that src_port may
+    # not actually be the same as the original RPORT for some services if they
+    # respond back from different ports
+    return unless response.size >= 42
     @results[src_host] ||= []
-    @results[src_host] << data.inspect
-  end
 
-  # Called before the scan block
-  def scanner_prescan(batch)
-    vprint_status("Sending probes to #{batch[0]}->#{batch[-1]} (#{batch.length} hosts)")
-    @results = {}
-    @probe = "abracadabra!"
+    # TODO: store something about this response, perhaps the response itself,
+    # some metadata obtained by analyzing it, the proof that it is vulnerable
+    # to something, etc.  In this example, we simply look for any response
+    # with a sequence of 5 useful ASCII characters and, iff found, we store
+    # that sequence
+    /(?<relevant>[\x20-\x7E]{5})/ =~ response && @results[src_host] << relevant
   end
 
   # Called after the scan block
-  def scanner_postscan(batch)
-    @results.each_pair do |host, responses|
+  def scanner_postscan(_batch)
+    @results.each_pair do |host, relevant_responses|
       peer = "#{host}:#{rport}"
 
-      # consider confirming that any of the responses are actually
-      # valid responses for this service before reporing it or
-      # examining the responses for signs of a vulnerability
+      # report on the host
+      report_host(host: host)
+
+      # report on the service, since it responded
       report_service(
         host: host,
-        proto:'udp',
+        proto: 'udp',
         port: rport,
-        name: 'example'
+        name: 'example',
+        # show at most 4 relevant responses
+        info: relevant_responses[0, 4].join(',')
       )
 
-      if responses.any? { |response| response =~ /[a-z0-9]{5}/i }
-        print_good("#{peer} - Vulnerable to something!")
+      if relevant_responses.empty?
+        vprint_status("#{peer} Not vulnerable to something")
+      else
+        print_good("#{peer} Vulnerable to something!")
         report_vuln(
           host: host,
           port: rport,
           proto: 'udp',
           name: 'something!',
+          info: "Got #{relevant_responses.size} response(s)",
           refs: references
         )
-      else
-        vprint_status("#{peer} - Not vulnerable to something")
       end
     end
   end

--- a/modules/auxiliary/scanner/udp_scanner_template.rb
+++ b/modules/auxiliary/scanner/udp_scanner_template.rb
@@ -9,23 +9,26 @@ class Metasploit3 < Msf::Auxiliary
   include Msf::Auxiliary::Report
   include Msf::Auxiliary::UDPScanner
 
-  def initialize
+  def initialize(info = {})
     super(
-      # TODO: fill in all of this
-      'Name'           => 'UDP Scanner Example',
-      'Description'    => %q(
-        This module is an example of how to send probes to UDP services
-        en-masse, analyze any responses, and then report on any discovered
-        hosts, services, vulnerabilities or otherwise noteworthy things.
-        Simply address any of the TODOs.
-      ),
-      'Author'         => 'Joe Contributor <joe_contributor[at]example.com>',
-      'References'     =>
-        [
-          ['URL', 'https://example.com/~jcontributor']
-        ],
-      'DisclosureDate' => 'Mar 15 2014',
-      'License'        => MSF_LICENSE
+      update_info(
+        info,
+        # TODO: fill in all of this
+        'Name'           => 'UDP Scanner Example',
+        'Description'    => %q(
+          This module is an example of how to send probes to UDP services
+          en-masse, analyze any responses, and then report on any discovered
+          hosts, services, vulnerabilities or otherwise noteworthy things.
+          Simply address any of the TODOs.
+        ),
+        'Author'         => 'Joe Contributor <joe_contributor[at]example.com>',
+        'References'     =>
+          [
+            ['URL', 'https://example.com/~jcontributor']
+          ],
+        'DisclosureDate' => 'Mar 15 2014',
+        'License'        => MSF_LICENSE
+      )
     )
 
     register_options(


### PR DESCRIPTION
This is based on [this email](http://sourceforge.net/p/metasploit/mailman/message/32648580/) where I suggested that someone start contributing example/template modules for specific types of tasks.  These example/template modules should be as perfect as possible, allowing contributors to quickly copy it, change a few things and be off and running.  The resulting code and experience should be as ideal as possible when starting with this code, and resulting PRs using these example modules should be considerably easier to write and far cleaner.

This just handles it for UDPScanner, which I happen to spend a lot of time writing/reviewing/using.

In addition to the template itself, I've made numerous other changes to related files.  Of note:
- I shut rubocop up even more.  It now has 0 complaints about the example module
- I bumped the default `THREADS` to 10.  This was based on some discussion internally around the default performance of `UDPScanner` and that in its default mode it only performs nicely when scanning a /24.  But, it isn't obvious that you may need to tweak `THREADS` if you are scanning larger networks, so I picked what I think is a reasonable default.  The thinking is that it will have no adverse affects on scanning smaller networks, but will have a positive impact when scanning networks larger than /24
- Moved most of the probing/reporting logic that 95% of all `UDPScanner` modules do into `UDPScanner` itself.  

The end result of this allows me to copy this example, change the defaults in `initialize`, and then simply set `@probe` and I have a nice scanner that works and is friendly
# Validation
- [ ] Critique everything about the example module
- [ ] Simulate the process a user would follow when copying from this module.  Is it as ideal as possible?
- [ ] Try other existing `UDPScanner` modules.  (I actually suspect some will have minor cosmetic regressions)
