### PR TITLE
Rescue the correct exception: Rex::HostUnreachable

### DIFF
--- a/modules/auxiliary/gather/xerox_pwd_extract.rb
+++ b/modules/auxiliary/gather/xerox_pwd_extract.rb
@@ -150,7 +150,7 @@ class Metasploit3 < Msf::Auxiliary
     begin
       connect(true, 'RPORT' => jport)
       sock.put(remove_print_job)
-    rescue ::Timeout::Error, Rex::ConnectionError, Rex::ConnectionRefused, HostUnreachable, Rex::ConnectionTimeout, Rex::AddressInUse
+    rescue ::Timeout::Error, Rex::ConnectionError, Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::AddressInUse
       print_error("#{rhost}:#{jport} - Error removing print job from #{rhost}")
     ensure
       disconnect

--- a/modules/auxiliary/gather/xerox_pwd_extract.rb
+++ b/modules/auxiliary/gather/xerox_pwd_extract.rb
@@ -96,7 +96,7 @@ class Metasploit3 < Msf::Auxiliary
     begin
       connect(true, 'RPORT' => jport)
       sock.put(create_print_job)
-    rescue ::Timeout::Error, Rex::ConnectionError, Rex::ConnectionRefused, HostUnreachable, Rex::ConnectionTimeout, Rex::AddressInUse
+    rescue ::Timeout::Error, Rex::ConnectionError, Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::AddressInUse
       print_error("#{rhost}:#{jport} - Error connecting to #{rhost}")
     ensure
       disconnect
@@ -113,7 +113,7 @@ class Metasploit3 < Msf::Auxiliary
       res = sock.get_once || ''
       passwd = res.match(/\r\n\s(.+?)\n/)
       return passwd ? passwd[1] : ''
-    rescue ::EOFError, ::Timeout::Error, Rex::ConnectionError, Rex::ConnectionRefused, HostUnreachable, Rex::ConnectionTimeout, Rex::AddressInUse, EOFError
+    rescue ::EOFError, ::Timeout::Error, Rex::ConnectionError, Rex::ConnectionRefused, Rex::HostUnreachable, Rex::ConnectionTimeout, Rex::AddressInUse, EOFError
       print_error("#{rhost}:#{jport} - Error getting password from #{rhost}")
       return
     ensure


### PR DESCRIPTION
My fault to miss this mistake while reviewing the module.

To verify, this is where the exception is raised:
https://github.com/rapid7/metasploit-framework/blob/master/lib/rex/socket/comm/local.rb#L294
