### PR TITLE
Cosmetic title/desc updates

### DIFF
--- a/modules/auxiliary/gather/xerox_pwd_extract.rb
+++ b/modules/auxiliary/gather/xerox_pwd_extract.rb
@@ -12,10 +12,10 @@ class Metasploit3 < Msf::Auxiliary
 
   def initialize(info={})
     super(update_info(info,
-      'Name'           => 'Xerox Administrator Console Password Extract',
-      'Description'    => %{
-        This module will extract the management consoles admin password from the Xerox file system
-        using firmware bootstrap injection.
+      'Name'           => 'Xerox Administrator Console Password Extractor',
+      'Description'    => %q{
+        This module will extract the management console's admin password from the
+        Xerox file system using firmware bootstrap injection.
       },
       'Author'         =>
         [

--- a/modules/auxiliary/gather/xerox_workcentre_5xxx_ldap.rb
+++ b/modules/auxiliary/gather/xerox_workcentre_5xxx_ldap.rb
@@ -14,8 +14,8 @@ class Metasploit3 < Msf::Auxiliary
   def initialize(info={})
     super(update_info(info,
       'Name'           => 'Xerox Workcentre 5735 LDAP Service Redential Extractor',
-      'Description'    => %{
-        This module extract the printers LDAP user and password from Xerox workcentre 5735.
+      'Description'    => %q{
+        This module extract the printer's LDAP username and password from Xerox Workcentre 5735.
       },
       'Author'         =>
         [

--- a/modules/auxiliary/scanner/http/buffalo_login.rb
+++ b/modules/auxiliary/scanner/http/buffalo_login.rb
@@ -16,7 +16,10 @@ class Metasploit3 < Msf::Auxiliary
   def initialize
     super(
       'Name'           => 'Buffalo NAS Login Utility',
-      'Description'    => 'This module simply attempts to login to a Buffalo NAS instance using a specific user/pass. It is confirmed to work with 1.68',
+      'Description'    => %q{
+        This module simply attempts to login to a Buffalo NAS instance using a specific
+        username and password. It has been confirmed to work on version 1.68
+      },
       'Author'         => [ 'Nicholas Starke <starke.nicholas[at]gmail.com>' ],
       'License'        => MSF_LICENSE
     )

--- a/modules/exploits/multi/http/cups_bash_env_exec.rb
+++ b/modules/exploits/multi/http/cups_bash_env_exec.rb
@@ -13,9 +13,9 @@ class Metasploit4 < Msf::Exploit::Remote
     super(update_info(info,
       'Name' => 'CUPS Filter Bash Environment Variable Code Injection',
       'Description' => %q{
-        This module exploits a post-auth code injection in specially crafted
-        environment variables in Bash, specifically targeting CUPS filters
-        through the PRINTER_INFO and PRINTER_LOCATION variables by default.
+        This module exploits Shellshock, a post-authentication code injection vulnerability
+        in specially crafted environment variables in Bash. It specifically targets
+        CUPS filters through the PRINTER_INFO and PRINTER_LOCATION variables by default.
       },
       'Author' => [
         'Stephane Chazelas', # Vulnerability discovery

--- a/modules/exploits/unix/misc/xerox_mfp.rb
+++ b/modules/exploits/unix/misc/xerox_mfp.rb
@@ -13,7 +13,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def initialize(info = {})
     super(update_info(info,
       'Name'            => 'Xerox Multifunction Printers (MFP) "Patch" DLM Vulnerability',
-      'Description'     => %{
+      'Description'     => %q{
         This module exploits a vulnerability found in Xerox Multifunction Printers (MFP). By
         supplying a modified Dynamic Loadable Module (DLM), it is possible to execute arbitrary
         commands under root priviages.


### PR DESCRIPTION
## Verification
- [x] See all modules still load (no missing commas, etc)
- [x] See all descriptions make slightly more sense

Also, I saw that @dheiland-r7's Xerox modules (PR #4091 and others) were using `%{}` for descriptions, instead of `%q{}`. While the two are interchangeable (since `%{}` defaults as `%q{}`), we still tend to prefer the explicit `%q`-ness for descriptions. Not sure where that q got dropped along the way.

/cc @kgray-r7 @cdoughty-r7 @wvu-r7
