### PR TITLE
Remove 2.0 Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ script: "bundle exec rake $RAKE_TASK"
 
 rvm:
   - '1.9.3'
-  - '2.0'
   - '2.1'
 
 notifications:


### PR DESCRIPTION
Fixes #4125 by removing the `2.0` from the list of rvm build targets.
## Verification
- [x] Travis is green and no longer tries to run 2.0 tests.
