### PR TITLE
Expose db and pcap groups as gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,9 +37,7 @@ group :development, :test do
 end
 
 group :pcap do
-  gem 'network_interface', '~> 0.0.1'
-  # For sniffer and raw socket modules
-  gem 'pcaprub'
+  gemspec name: 'metasploit-framework-pcap'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -1,20 +1,12 @@
 source 'https://rubygems.org'
 # Add default group gems to `metasploit-framework.gemspec`:
 #   spec.add_runtime_dependency '<name>', [<version requirements>]
-gemspec
+gemspec name: 'metasploit-framework'
 
 gem 'rb-readline', require: false
 
 group :db do
-  # Needed for Msf::DbManager
-  gem 'activerecord', '>= 3.0.0', '< 4.0.0'
-
-  # Metasploit::Credential database models
-  gem 'metasploit-credential', '~> 0.12.0'
-  # Database models shared between framework and Pro.
-  gem 'metasploit_data_models', '~> 0.21.1'
-  # Needed for module caching in Mdm::ModuleDetails
-  gem 'pg', '>= 0.11'
+  gemspec name: 'metasploit-framework-db'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,11 +21,9 @@ PATH
       sqlite3
       tzinfo
     metasploit-framework-db (4.10.1.pre.dev)
-      activerecord (< 4.0.0)
-      metasploit-credential (~> 0.12.0)
       metasploit-framework (= 4.10.1.pre.dev)
-      metasploit_data_models (~> 0.21.1)
-      pg (>= 0.11)
+      metasploit-framework-db (= 4.10.1.pre.dev)
+      metasploit-framework-pcap (= 4.10.1.pre.dev)
     metasploit-framework-pcap (4.10.1.pre.dev)
       metasploit-framework (= 4.10.1.pre.dev)
       network_interface (~> 0.0.1)
@@ -62,8 +60,6 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     arel (3.0.3)
-    arel-helpers (2.0.1)
-      activerecord (>= 3.1.0, < 5)
     aruba (0.6.1)
       childprocess (>= 0.3.6)
       cucumber (>= 1.1.1)
@@ -112,26 +108,9 @@ GEM
     metasploit-concern (0.3.0)
       activesupport (~> 3.0, >= 3.0.0)
       railties (< 4.0.0)
-    metasploit-credential (0.12.0)
-      metasploit-concern (~> 0.3.0)
-      metasploit-model (~> 0.28.0)
-      metasploit_data_models (~> 0.21.0)
-      pg
-      railties (< 4.0.0)
-      rubyntlm
-      rubyzip (~> 1.1)
     metasploit-model (0.28.0)
       activesupport
       railties (< 4.0.0)
-    metasploit_data_models (0.21.1)
-      activerecord (>= 3.2.13, < 4.0.0)
-      activesupport
-      arel-helpers
-      metasploit-concern (~> 0.3.0)
-      metasploit-model (~> 0.28.0)
-      pg
-      railties (< 4.0.0)
-      recog (~> 1.0)
     meterpreter_bins (0.0.10)
     method_source (0.8.2)
     mime-types (1.25.1)
@@ -143,7 +122,6 @@ GEM
       mini_portile (= 0.6.0)
     packetfu (1.1.9)
     pcaprub (0.11.3)
-    pg (0.17.1)
     polyglot (0.3.5)
     pry (0.10.0)
       coderay (~> 1.1.0)
@@ -199,7 +177,6 @@ GEM
       rspec-core (~> 2.99.0)
       rspec-expectations (~> 2.99.0)
       rspec-mocks (~> 2.99.0)
-    rubyntlm (0.4.0)
     rubyzip (1.1.6)
     shoulda-matchers (2.6.2)
     simplecov (0.5.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,9 @@ PATH
       metasploit-framework (= 4.10.1.pre.dev)
       metasploit_data_models (~> 0.21.1)
       pg (>= 0.11)
+    metasploit-framework-pcap (4.10.1.pre.dev)
+      network_interface (~> 0.0.1)
+      pcaprub
 
 GEM
   remote: https://rubygems.org/
@@ -231,8 +234,7 @@ DEPENDENCIES
   fivemat (= 1.2.1)
   metasploit-framework!
   metasploit-framework-db!
-  network_interface (~> 0.0.1)
-  pcaprub
+  metasploit-framework-pcap!
   pry
   rake (>= 10.0.0)
   rb-readline

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,12 @@ PATH
       rubyzip (~> 1.1)
       sqlite3
       tzinfo
+    metasploit-framework-db (4.10.1.pre.dev)
+      activerecord (< 4.0.0)
+      metasploit-credential (~> 0.12.0)
+      metasploit-framework (= 4.10.1.pre.dev)
+      metasploit_data_models (~> 0.21.1)
+      pg (>= 0.11)
 
 GEM
   remote: https://rubygems.org/
@@ -218,18 +224,15 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (>= 3.0.0, < 4.0.0)
   aruba
   cucumber-rails
   factory_girl (>= 4.1.0)
   factory_girl_rails
   fivemat (= 1.2.1)
-  metasploit-credential (~> 0.12.0)
   metasploit-framework!
-  metasploit_data_models (~> 0.21.1)
+  metasploit-framework-db!
   network_interface (~> 0.0.1)
   pcaprub
-  pg (>= 0.11)
   pry
   rake (>= 10.0.0)
   rb-readline

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,9 +21,11 @@ PATH
       sqlite3
       tzinfo
     metasploit-framework-db (4.10.1.pre.dev)
+      activerecord (< 4.0.0)
+      metasploit-credential (~> 0.12.0)
       metasploit-framework (= 4.10.1.pre.dev)
-      metasploit-framework-db (= 4.10.1.pre.dev)
-      metasploit-framework-pcap (= 4.10.1.pre.dev)
+      metasploit_data_models (~> 0.21.1)
+      pg (>= 0.11)
     metasploit-framework-pcap (4.10.1.pre.dev)
       metasploit-framework (= 4.10.1.pre.dev)
       network_interface (~> 0.0.1)
@@ -60,6 +62,8 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     arel (3.0.3)
+    arel-helpers (2.0.1)
+      activerecord (>= 3.1.0, < 5)
     aruba (0.6.1)
       childprocess (>= 0.3.6)
       cucumber (>= 1.1.1)
@@ -108,9 +112,26 @@ GEM
     metasploit-concern (0.3.0)
       activesupport (~> 3.0, >= 3.0.0)
       railties (< 4.0.0)
+    metasploit-credential (0.12.0)
+      metasploit-concern (~> 0.3.0)
+      metasploit-model (~> 0.28.0)
+      metasploit_data_models (~> 0.21.0)
+      pg
+      railties (< 4.0.0)
+      rubyntlm
+      rubyzip (~> 1.1)
     metasploit-model (0.28.0)
       activesupport
       railties (< 4.0.0)
+    metasploit_data_models (0.21.1)
+      activerecord (>= 3.2.13, < 4.0.0)
+      activesupport
+      arel-helpers
+      metasploit-concern (~> 0.3.0)
+      metasploit-model (~> 0.28.0)
+      pg
+      railties (< 4.0.0)
+      recog (~> 1.0)
     meterpreter_bins (0.0.10)
     method_source (0.8.2)
     mime-types (1.25.1)
@@ -122,6 +143,7 @@ GEM
       mini_portile (= 0.6.0)
     packetfu (1.1.9)
     pcaprub (0.11.3)
+    pg (0.17.1)
     polyglot (0.3.5)
     pry (0.10.0)
       coderay (~> 1.1.0)
@@ -177,6 +199,7 @@ GEM
       rspec-core (~> 2.99.0)
       rspec-expectations (~> 2.99.0)
       rspec-mocks (~> 2.99.0)
+    rubyntlm (0.4.0)
     rubyzip (1.1.6)
     shoulda-matchers (2.6.2)
     simplecov (0.5.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ PATH
       metasploit_data_models (~> 0.21.1)
       pg (>= 0.11)
     metasploit-framework-pcap (4.10.1.pre.dev)
+      metasploit-framework (= 4.10.1.pre.dev)
       network_interface (~> 0.0.1)
       pcaprub
 

--- a/lib/metasploit/framework/require.rb
+++ b/lib/metasploit/framework/require.rb
@@ -80,13 +80,18 @@ module Metasploit
       # @return [void]
       def self.optionally_require_metasploit_db_gem_engines
         optionally(
-          'metasploit/credential/engine',
-          'metasploit-credential not in the bundle',
-        )
+            'metasploit/credential',
+            'metasploit-credential not in the bundle',
+        ) do
+          require 'metasploit/credential/engine'
+        end
+
         optionally(
-          'metasploit_data_models/engine',
-          'metaspoit_data_models not in the bundle'
-        )
+          'metasploit_data_models',
+          'metasploit_data_models not in the bundle'
+        ) do
+          require 'metasploit_data_models/engine'
+        end
       end
 
       #

--- a/metasploit-framework-db.gemspec
+++ b/metasploit-framework-db.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'metasploit-credential', '~> 0.12.0'
   # Database models shared between framework and Pro.
   spec.add_runtime_dependency 'metasploit_data_models', '~> 0.21.1'
+  # depend on metasploit-framewrok as the optional gems are useless with the actual code
   spec.add_runtime_dependency 'metasploit-framework', "= #{spec.version}"
   # Needed for module caching in Mdm::ModuleDetails
   spec.add_runtime_dependency 'pg', '>= 0.11'

--- a/metasploit-framework-db.gemspec
+++ b/metasploit-framework-db.gemspec
@@ -1,0 +1,40 @@
+# coding: utf-8
+
+# During build, the Gemfile is temporarily moved and
+# we must manually define the project root
+if ENV['MSF_ROOT']
+  lib = File.realpath(File.expand_path('lib', ENV['MSF_ROOT']))
+else
+  # have to use realpath as metasploit-framework is often loaded through a symlink and tools like Coverage and debuggers
+  # require realpaths.
+  lib = File.realpath(File.expand_path('../lib', __FILE__))
+end
+
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'metasploit/framework/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'metasploit-framework-db'
+  spec.version       = Metasploit::Framework::GEM_VERSION
+  spec.authors       = ['Metasploit Hackers']
+  spec.email         = ['metasploit-hackers@lists.sourceforge.net']
+  spec.summary       = 'metasploit-framework Database dependencies'
+  spec.description   = 'Gems needed to access the PostgreSQL database in metasploit-framework'
+  spec.homepage      = 'https://www.metasploit.com'
+  spec.license       = 'BSD-3-clause'
+
+  # no files, just dependencies
+  spec.files         = []
+
+  # The Metasploit ecosystem is not ready for Rails 4 as it uses features of Rails 3.X that are removed in Rails 4.
+  rails_version_constraint = '< 4.0.0'
+
+  spec.add_runtime_dependency 'activerecord', rails_version_constraint
+  # Metasploit::Credential database models
+  spec.add_runtime_dependency 'metasploit-credential', '~> 0.12.0'
+  # Database models shared between framework and Pro.
+  spec.add_runtime_dependency 'metasploit_data_models', '~> 0.21.1'
+  spec.add_runtime_dependency 'metasploit-framework', "= #{spec.version}"
+  # Needed for module caching in Mdm::ModuleDetails
+  spec.add_runtime_dependency 'pg', '>= 0.11'
+end

--- a/metasploit-framework-full.gemspec
+++ b/metasploit-framework-full.gemspec
@@ -1,0 +1,34 @@
+# coding: utf-8
+
+# During build, the Gemfile is temporarily moved and
+# we must manually define the project root
+if ENV['MSF_ROOT']
+  lib = File.realpath(File.expand_path('lib', ENV['MSF_ROOT']))
+else
+  # have to use realpath as metasploit-framework is often loaded through a symlink and tools like Coverage and debuggers
+  # require realpaths.
+  lib = File.realpath(File.expand_path('../lib', __FILE__))
+end
+
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'metasploit/framework/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'metasploit-framework-db'
+  spec.version       = Metasploit::Framework::GEM_VERSION
+  spec.authors       = ['Metasploit Hackers']
+  spec.email         = ['metasploit-hackers@lists.sourceforge.net']
+  spec.summary       = 'metasploit-framework with all optional dependencies'
+  spec.description   = 'Gems needed to access the PostgreSQL database anin metasploit-framework'
+  spec.homepage      = 'https://www.metasploit.com'
+  spec.license       = 'BSD-3-clause'
+
+  # no files, just dependencies
+  spec.files         = []
+
+  metasploit_framework_version_constraint = "= #{spec.version}"
+
+  spec.add_runtime_dependency 'metasploit-framework', metasploit_framework_version_constraint
+  spec.add_runtime_dependency 'metasploit-framework-db', metasploit_framework_version_constraint
+  spec.add_runtime_dependency 'metasploit-framework-pcap', metasploit_framework_version_constraint
+end

--- a/metasploit-framework-full.gemspec
+++ b/metasploit-framework-full.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Metasploit Hackers']
   spec.email         = ['metasploit-hackers@lists.sourceforge.net']
   spec.summary       = 'metasploit-framework with all optional dependencies'
-  spec.description   = 'Gems needed to access the PostgreSQL database anin metasploit-framework'
+  spec.description   = 'Gems needed to access the PostgreSQL database in metasploit-framework'
   spec.homepage      = 'https://www.metasploit.com'
   spec.license       = 'BSD-3-clause'
 

--- a/metasploit-framework-full.gemspec
+++ b/metasploit-framework-full.gemspec
@@ -14,7 +14,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'metasploit/framework/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'metasploit-framework-db'
+  spec.name          = 'metasploit-framework-full'
   spec.version       = Metasploit::Framework::GEM_VERSION
   spec.authors       = ['Metasploit Hackers']
   spec.email         = ['metasploit-hackers@lists.sourceforge.net']

--- a/metasploit-framework-pcap.gemspec
+++ b/metasploit-framework-pcap.gemspec
@@ -26,7 +26,9 @@ Gem::Specification.new do |spec|
   # no files, just dependencies
   spec.files         = []
 
+  # depend on metasploit-framewrok as the optional gems are useless with the actual code
   spec.add_runtime_dependency 'metasploit-framework', "= #{spec.version}"
+  # get list of network interfaces, like eth* from OS.
   spec.add_runtime_dependency 'network_interface', '~> 0.0.1'
   # For sniffer and raw socket modules
   spec.add_runtime_dependency 'pcaprub'

--- a/metasploit-framework-pcap.gemspec
+++ b/metasploit-framework-pcap.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   # no files, just dependencies
   spec.files         = []
 
+  spec.add_runtime_dependency 'metasploit-framework', "= #{spec.version}"
   spec.add_runtime_dependency 'network_interface', '~> 0.0.1'
   # For sniffer and raw socket modules
   spec.add_runtime_dependency 'pcaprub'

--- a/metasploit-framework-pcap.gemspec
+++ b/metasploit-framework-pcap.gemspec
@@ -1,0 +1,32 @@
+# coding: utf-8
+
+# During build, the Gemfile is temporarily moved and
+# we must manually define the project root
+if ENV['MSF_ROOT']
+  lib = File.realpath(File.expand_path('lib', ENV['MSF_ROOT']))
+else
+  # have to use realpath as metasploit-framework is often loaded through a symlink and tools like Coverage and debuggers
+  # require realpaths.
+  lib = File.realpath(File.expand_path('../lib', __FILE__))
+end
+
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'metasploit/framework/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'metasploit-framework-pcap'
+  spec.version       = Metasploit::Framework::GEM_VERSION
+  spec.authors       = ['Metasploit Hackers']
+  spec.email         = ['metasploit-hackers@lists.sourceforge.net']
+  spec.summary       = 'metasploit-framework packet capture dependencies'
+  spec.description   = 'Gems needed to capture packets in metasploit-framework'
+  spec.homepage      = 'https://www.metasploit.com'
+  spec.license       = 'BSD-3-clause'
+
+  # no files, just dependencies
+  spec.files         = []
+
+  spec.add_runtime_dependency 'network_interface', '~> 0.0.1'
+  # For sniffer and raw socket modules
+  spec.add_runtime_dependency 'pcaprub'
+end


### PR DESCRIPTION
Add `metasploit-framework-db.gemspec` and use it in the `db` group in the `Gemfile`.  Likewise, add `metasploit-framework-pcap.gemspec` and use it in the `pcap` group in the `Gemfile`.  Add a `metasploit-framework-full.gemspec`, which depends on `metasploit-framework`, `metasploit-framework-db`, and `metasploit-framework-pcap`.  `metasploit-framework-full` can be used in Pro instead of `metasploit-framework` to ensure that Pro's version constraints on db and pcap gems are compatible with the version constraints in metasploit-framework.  This should prevent incompatible versions of `metasploit_data_models` and `metasploit-credential` between `metasploit-framework` and Pro.
# Verification Steps
## specs
- [x] `rake spec`
- [x] VERIFY no failures
## cucumber
- [x] `rake cucumber`
- [x] VERIFY no failures
## Without db
- [x] `bundle --without db`
- [x] `bundle list`
- [x] VERIFY `activerecord` is NOT in the list
- [x] VERIFY `metasploit-credential` is NOT in the list
- [x] VERIFY `metasploit_data_models` is NOT in the list
- [x] VERIFY `pg` is NOT in the list
## Without pcap
- [x] `bundle --without pcap`
- [x] `bundle list`
- [x] VERIFY `network_interface` is NOT in the list
- [x] VERIFY `pcaprub` is NOT in the list
## Without nothing
- [x] `bundle --without ''`
- [x] `bundle list`
- [x] VERIFY `activerecord` is in the list
- [x] VERIFY `metasploit-credential` is in the list
- [x] VERIFY `metasploit_data_models` is in the list
- [x] VERIFY `pg` is in the list
- [x] VERIFY `network_interface` is in the list
- [x] VERIFY `pcaprub` is in the list
