### PR TITLE
Easily prefer different rubies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ Gemfile.local.lock
 .rvmrc
 # Allow for a local choice of (unsupported / semi-supported) ruby versions
 # See PR #4136 for usage, but example usage:
-#   rvm --create --versions-conf use # 2.1.4@metasploit-framework
+#   rvm --create --versions-conf use 2.1.4@metasploit-framework
 .versions.conf
 # YARD cache directory
 .yardoc

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ Gemfile.local.lock
 .sublime-project
 # RVM control file, keep this to avoid backdooring Metasploit
 .rvmrc
+# Allow for a local choice of (unsupported / semi-supported) ruby versions
+# See PR #4136 for usage, but example usage:
+#   rvm --create --versions-conf use # 2.1.4@metasploit-framework
+.versions.conf
 # YARD cache directory
 .yardoc
 # Mac OS X files


### PR DESCRIPTION
By ignoring .versions.conf, we can allow users pick their own versions of ruby without having to jump through a bunch of hoops on keeping .ruby-version straight between local and remote branches.
## Verification
- [x] `rvm install 2.1.4` to get Ruby 2.1.4.
- [x] In the root of the metasploit-framework checkout, run the command, `rvm --create --versions-conf use 2.1.4@metasploit-framework`
- [x] `pushd ..; popd` to change directories and back again.
- [x] Notice that you are now using 2.1.4
- [x] Notice that `git status` is not complaining about untracked files.
