### PR TITLE
Add Eventlog Analzyer exploit for CVE-2014-6038/6039

### DIFF
--- a/modules/auxiliary/gather/eventlog_cred_disclosure.rb
+++ b/modules/auxiliary/gather/eventlog_cred_disclosure.rb
@@ -32,8 +32,8 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'CVE', '2014-6038' ],
           [ 'CVE', '2014-6039' ],
-          [ 'OSVDB', 'TODO' ],
-          [ 'OSVDB', 'TODO' ],
+          [ 'OSVDB', '114342' ],
+          [ 'OSVDB', '114344' ],
           [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/ManageEngine/me_eventlog_info_disc.txt' ],
           [ 'URL', 'http://seclists.org/fulldisclosure/2014/Nov/12' ]
         ],


### PR DESCRIPTION
This adds an exploit for two zero day vulnerabilities in ManageEngine EventLog Analyzer. 
Versions 7 to 9.9 are vulnerable to a SQL database information disclosure (allowing you to dump any table from the database) and an information disclosure vulnerability that allows extracting the password for any managed Windows and AS/400 hosts.

This module has been thoroughly tested on Windows and Linux versions of EventLog Analyzer.
