### PR TITLE
Add an R in /Info for the trailer dictionary to make it readable

### DIFF
--- a/data/exploits/CVE-2010-1240/template.pdf
+++ b/data/exploits/CVE-2010-1240/template.pdf
@@ -48,7 +48,7 @@ trailer
 <<
 	/Root 1 0 R
 	/Size 5
-	/Info 0 0
+	/Info 0 0 R
 >>
 startxref
 429


### PR DESCRIPTION
Sorry @jvazquez-r7, it looks like I gave a corrupt PDF for the CVE-2010-1240 exploit. The exploit will work without this fix anyway, but if you just open the original template PDF, it's actually corrupt and the reader can't read it. This should fix that.

Verification steps should be the same as #4140.
