### PR TITLE
Support SRVHOST option for exploits/windows/browser/msvidctl_mpeg2.rb

### DIFF
--- a/modules/exploits/windows/browser/msvidctl_mpeg2.rb
+++ b/modules/exploits/windows/browser/msvidctl_mpeg2.rb
@@ -76,6 +76,8 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def get_lhost
+    # If the SRVHOST isn't the default 0.0.0.0, obviously the user wants to
+    # specify, so we will not force source_address()
     return datastore['SRVHOST'] if datastore['SRVHOST'] != '0.0.0.0'
     Rex::Socket.source_address(cli.peerhost)
   end

--- a/modules/exploits/windows/browser/msvidctl_mpeg2.rb
+++ b/modules/exploits/windows/browser/msvidctl_mpeg2.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
     @javascript_encode_key = rand_text_alpha(rand(10) + 10)
   end
 
-  def get_lhost
+  def get_srvhost
     # If the SRVHOST isn't the default 0.0.0.0, obviously the user wants to
     # specify, so we will not force source_address()
     return datastore['SRVHOST'] if datastore['SRVHOST'] != '0.0.0.0'
@@ -194,7 +194,7 @@ class Metasploit3 < Msf::Exploit::Remote
     j_memory     = rand_text_alpha(rand(100) + 1)
     j_counter    = rand_text_alpha(rand(30) + 2)
 
-    host = get_lhost + ":" + (datastore["SRVPORT"].to_s)
+    host = get_srvhost + ":" + (datastore["SRVPORT"].to_s)
     gif_uri = "http#{(datastore['SSL'] ? 's' : '')}://#{host}"
     if ("/" == get_resource[-1,1])
       gif_uri << get_resource[0, get_resource.length - 1]

--- a/modules/exploits/windows/browser/msvidctl_mpeg2.rb
+++ b/modules/exploits/windows/browser/msvidctl_mpeg2.rb
@@ -75,6 +75,11 @@ class Metasploit3 < Msf::Exploit::Remote
     @javascript_encode_key = rand_text_alpha(rand(10) + 10)
   end
 
+  def get_lhost
+    return datastore['SRVHOST'] if datastore['SRVHOST'] != '0.0.0.0'
+    Rex::Socket.source_address(cli.peerhost)
+  end
+
   def on_request_uri(cli, request)
 
     if (request.uri.match(/\.gif$/i))
@@ -187,7 +192,7 @@ class Metasploit3 < Msf::Exploit::Remote
     j_memory     = rand_text_alpha(rand(100) + 1)
     j_counter    = rand_text_alpha(rand(30) + 2)
 
-    host = Rex::Socket.source_address(cli.peerhost) + ":" + (datastore["SRVPORT"].to_s)
+    host = get_lhost + ":" + (datastore["SRVPORT"].to_s)
     gif_uri = "http#{(datastore['SSL'] ? 's' : '')}://#{host}"
     if ("/" == get_resource[-1,1])
       gif_uri << get_resource[0, get_resource.length - 1]


### PR DESCRIPTION
For https://github.com/rapid7/metasploit-framework/issues/4133

To verify this, this is what I did:
- [x] Put a `print_debug(host.inspect)` at line 198
- [x] Run the module
- [x] In another terminal, `curl -v` the exploit's uri
- [x] `curl -v` will tell you where you should redirect to. Just follow that and curl again.
- [x] The `print_debug` should trigger and print either SRVHOST or Rex::Socket.source_address depending on how you set it. If you change SRVHOST to something else other than 0.0.0.0, then the module will use that. Otherwise it will fall back to Rex::Socket.source_address.
- [x] When you're done testing, make sure you undo the code change before landing.
