### PR TITLE
Only depend on rb-readline on :ruby platform

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@ source 'https://rubygems.org'
 #   spec.add_runtime_dependency '<name>', [<version requirements>]
 gemspec
 
-gem 'rb-readline', require: false
-
 group :db do
   # Needed for Msf::DbManager
   gem 'activerecord', '>= 3.0.0', '< 4.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,7 +232,6 @@ DEPENDENCIES
   pg (>= 0.11)
   pry
   rake (>= 10.0.0)
-  rb-readline
   redcarpet
   rspec (>= 2.12, < 3.0.0)
   rspec-rails (>= 2.12, < 3.0.0)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -76,8 +76,14 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'railties'
   # required for OS fingerprinting
   spec.add_runtime_dependency 'recog', '~> 1.0'
-  # read... lines...
-  spec.add_runtime_dependency 'rb-readline'
+
+  # rb-readline doesn't work with Ruby Installer due to error with Fiddle:
+  #   NoMethodError undefined method `dlopen' for Fiddle:Module
+  unless Gem.win_platform?
+    # Command line editing, history, and tab completion in msfconsole
+    spec.add_runtime_dependency 'rb-readline'
+  end
+
   # Needed by anemone crawler
   spec.add_runtime_dependency 'robots'
   # Needed by some modules


### PR DESCRIPTION
MSP-11585
# Verification Steps
## Linux/OSX

On Linux or OS X.
### rb-readline installed
- [x] `bundle install`
- [x] VERIFY `rb-readline` is in `bundle list`
### msfconsole boots
- [x] VERIFY `msfconsole` boots.
## Windows

On Windows.
### rb-readline NOT installed
- [x] `bundle install`
- [x] VERIFY `rb-readline` is NOT in `bundle list`
### msfconsole boots
- [x] VERIFY `msfconsole` boots.
