### PR TITLE
Fix #4089 for SMBPass undefined method `downcase' for nil:NilClass

### DIFF
--- a/lib/rex/proto/smb/simpleclient.rb
+++ b/lib/rex/proto/smb/simpleclient.rb
@@ -66,6 +66,10 @@ attr_accessor :socket, :client, :direct, :shares, :last_share
 
       self.client.spnopt = spnopt
 
+      # In case the user unsets the password option, we make sure this is
+      # always a string
+      pass ||= ''
+
       ok = self.client.session_setup(user, pass, domain)
     rescue ::Interrupt
       raise $!


### PR DESCRIPTION
This fixes an undefined method 'downcase' bug when the SMBPass datastore option is unset by the user.

Please see #4089 for verification steps.
