### PR TITLE
clarifies sessions -c command

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1655,7 +1655,6 @@ class Core
 
     # Now, perform the actual method
     case method
-<<<<<<< HEAD
       cmds.each do |cmd|
         if sid
           sessions = session_list

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -34,7 +34,7 @@ class Core
 
   # Session command options
   @@sessions_opts = Rex::Parser::Arguments.new(
-    "-c" => [ true,  "Run a command on the session given with -i, or all"],
+    "-c" => [ true,  "Run a shell command on the session (use with -i)"],
     "-h" => [ false, "Help banner"                                    ],
     "-i" => [ true,  "Interact with the supplied session ID"          ],
     "-l" => [ false, "List all active sessions"                       ],
@@ -1655,11 +1655,7 @@ class Core
 
     # Now, perform the actual method
     case method
-    when 'cmd'
-      if cmds.length < 1
-        print_error("No command specified!")
-        return false
-      end
+<<<<<<< HEAD
       cmds.each do |cmd|
         if sid
           sessions = session_list
@@ -1688,9 +1684,16 @@ class Core
                   'Channelized' => true,
                   'Hidden'      => true
                 })
-            rescue ::Rex::Post::Meterpreter::RequestError
-              print_error("Failed: #{$!.class} #{$!}")
+
+            rescue ::Rex::Post::Meterpreter::RequestError => e
+              if e.method == 'stdapi_sys_process_execute' &&
+                 e.result =~ /system cannot find the file specified/i
+                print_error("#{cmd} is not a valid shell command or binary path")
+              else
+                print_error("Failed: #{e.class} #{e.to_s}")
+              end
             end
+
             if process && process.channel
               data = process.channel.read
               print_line(data) if data

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1655,6 +1655,7 @@ class Core
 
     # Now, perform the actual method
     case method
+    when 'cmd'
       cmds.each do |cmd|
         if sid
           sessions = session_list


### PR DESCRIPTION
#4063 has landed, so this is ready.  It's been rebased to eliminate merge conflicts

This PR clarifies the sessions -c usage info and changes the session execute RequestError rescue to be more specific and informative
## Verification
- [ ] Get some sessions, preferably a shell and any native win meterpreter
- [ ] sessions -i ID -c calc.exe
- [ ] success on both sessions
- [ ] sessions -i ID -c pwd
- [ ] get: pwd is not a valid shell command or binary path
