### PR TITLE
Create exploit for CVE-2014-8499 - PMP privesc + password disclosure

### DIFF
--- a/modules/auxiliary/admin/http/manageengine_pmp_privesc.rb
+++ b/modules/auxiliary/admin/http/manageengine_pmp_privesc.rb
@@ -33,7 +33,7 @@ class Metasploit3 < Msf::Auxiliary
       'References' =>
         [
           [ 'CVE', '2014-8499' ],
-          #[ 'OSVDB', 'TODO' ],
+          [ 'OSVDB', '114485' ],
           [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/ManageEngine/me_pmp_privesc.txt' ],
           [ 'URL', 'http://seclists.org/fulldisclosure/2014/Nov/18' ]
         ],


### PR DESCRIPTION
This is an exploit for an authenticated SQL injection in Password Manager Pro 6.8 to 7.1 build 7105. 
It allows a low privileged user (like a guest) to escalate privileges to "super administrator" and dump all the passwords in the system in cleartext. 
This module has been well tested in Windows and Linux with several versions between 6.8 and 7.1.
