### PR TITLE
Fix buggy calls to stop_service

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -1010,8 +1010,6 @@ module Exploit::Remote::HttpServer::PHPInclude
       ::IO.select(nil, nil, nil, 5)
     rescue ::Interrupt
       raise $!
-    ensure
-      stop_service
     end
   end
 

--- a/modules/exploits/multi/http/jboss_maindeployer.rb
+++ b/modules/exploits/multi/http/jboss_maindeployer.rb
@@ -217,9 +217,6 @@ class Metasploit3 < Msf::Exploit::Remote
       end
     end
 
-    print_status("Shutting down the web service...")
-    stop_service
-
 
     #
     # EXECUTE


### PR DESCRIPTION
These changes remove a couple of unnecessary calls to stop_service that do nothing but cause the module to false-positively fail (i.e., spits a failure message even when it actually worked) with "[-] Exploit failed: undefined method `remove_resource' for nil:NilClass" (e.g. http://stackoverflow.com/questions/23591269/metasploit-php-include-undefined-method-remove-resource-for-nilnilclass).

My understanding is that Exploit::Remote::TcpServer will stop the service anyway during its cleanup. If the inheriting module calls stop_service beforehand, then you'll have some null dereference when the module instance is destructed. I do not understand, however, how this conditions is not handled by the checks at tcp_server.rb:69 and tcp_server.rb:156. But that's because I never coded Ruby before and I don't care.

If one greps for 'stop_service' in the modules, they'll find a few more modules which are also potentially broken, but right now I don't have the availability to test all of them, so I'll leave it to someone who's up for the task.
