### PR TITLE
Fix #4132 - msfvenom undefined method fullname for NilClass

### DIFF
--- a/msfvenom
+++ b/msfvenom
@@ -283,6 +283,12 @@ if __FILE__ == $0
 
   if generator_opts[:list_options]
     payload_mod = framework.payloads.create(generator_opts[:payload])
+
+    if payload_mod.nil?
+      $stderr.puts "Invalid payload: #{generator_opts[:payload]}"
+      exit
+    end
+
     $stderr.puts "Options for #{payload_mod.fullname}\n\n" + ::Msf::Serializer::ReadableText.dump_module(payload_mod,'    ')
     exit(0)
   end


### PR DESCRIPTION
See https://github.com/rapid7/metasploit-framework/issues/4132

The bug is caused by a bad payload name.
- [x] To verify: without the patch, if you do the following, you will get the undef method error:

```
./msfvenom -p payload/python/meterpreter/reverse_tcp -o LHOST=192.168.130.1 -f raw
```
- [x] With the patch, it should say invalid payload.
- [x] Now, try with a valid payload name: `./msfvenom -p python/meterpreter/reverse_tcp -o LHOST=192.168.130.1 -f raw`
- [x] It should show you the payload options this time.
