### PR TITLE
Check for INTERFACE or SMAC in dtp setup

### DIFF
--- a/modules/auxiliary/spoof/cisco/dtp.rb
+++ b/modules/auxiliary/spoof/cisco/dtp.rb
@@ -31,6 +31,13 @@ class Metasploit3 < Msf::Auxiliary
     deregister_options('RHOST', 'PCAPFILE')
   end
 
+  def setup
+    super
+    unless datastore['SMAC'] || datastore['INTERFACE']
+      raise ArgumentError, 'Must specify SMAC or INTERFACE'
+    end
+  end
+
   def build_dtp_frame
     p = PacketFu::EthPacket.new
     p.eth_daddr = '01:00:0c:cc:cc:cc'


### PR DESCRIPTION
The module requires one of these to be set, otherwise you get failures like:

```
[-] Auxiliary failed: TypeError wrong argument type nil (expected String)
[-] Call stack:
[-]   /home/jhart/labs/git/metasploit-framework/lib/msf/core/exploit/capture.rb:478:in `addresses'
[-]   /home/jhart/labs/git/metasploit-framework/lib/msf/core/exploit/capture.rb:478:in `get_mac'
[-]   /home/jhart/labs/git/metasploit-framework/modules/auxiliary/spoof/cisco/dtp.rb:59:in `smac'
[-]   /home/jhart/labs/git/metasploit-framework/modules/auxiliary/spoof/cisco/dtp.rb:64:in `run'
```
## Validation
- [ ] Use module before this PR, confirming that it fails when neither `INTERFACE` or `SMAC` are set
- [ ] Use module before this PR, confirming that it works properly when either `INTERFACE` or `SMAC` are set
- [ ] Use this module after this PR, confirming that the failure is more sane when `INTERFACE` or `SMAC` are not set
