### PR TITLE
Fix #4119 - SMB lost search ID (sid) in find_first method

### DIFF
--- a/lib/rex/proto/smb/client.rb
+++ b/lib/rex/proto/smb/client.rb
@@ -1872,6 +1872,7 @@ NTLM_UTILS = Rex::Proto::NTLM::Utils
 
   # Enumerates a specific path on the mounted tree
   def find_first(path)
+    sid = nil
     files = { }
     parm = [
       26,  # Search for ALL files


### PR DESCRIPTION
This will fix issue #4119. A bug in the find_first method in rex SMB.

The fix turns out is very very simple, but since we are very sensitive with SMB breakage so I'm gonna explain about the bug in detail.
## Root Cause

When the SMB client requests a TRANS2_FIND_FIRST2 for retrieving information about what items a directory has, the server returns a response that contains an SID - a search identifier for the transaction. If the SMB client wants more data, it must send a TRANS2_FIND_NEXT2 request with the same SID. And then the server will continue sending more until it runs out.

The root cause of this bug is that after the first TRANS2_FIND_NEXT2 request is sent, our SMB's find_first method forgets the SID at the end of the loop (out of scope). Because of this, we only get 2 responses (each with 20 items), so there always seem to be 40 items max when there should be more.

You can read more about TRANS2_FIND_FIRST2 and TRANS2_FIND_NEXT2 here:
http://msdn.microsoft.com/en-us/library/ee441704.aspx
http://msdn.microsoft.com/en-us/library/ee441844.aspx
## Verification

I've tested against Windows XP SP3, Windows 7, Windows Server 2003, and Windows Server 2008 SP2. You can test them all if you want, but if you just want to be pick one, please try Windows Server 2008 because this is the setup @jabra- was testing against.

To set up a Win 2k8 box for testing, it's a bit easier than other Windows systems. IIRC, just do:
- [x] Disable firewall
- [x] Go to **My Computer**, right-click on **C**. Go to **Properties** -> **Sharing**. Click on "**Advanced Sharing**", and then check "**Share this folder**".
- [x] Make sure you know the password to user: Administrator

To test:
- [x] Download this testcase and save it as an auxiliary module: https://gist.github.com/wchen-r7/3f3ddc94b010ba2cb3d6 (I'm gonna call it auxiliary/gather/test.rb here)
- [x] Start msfconsole
- [x] `use auxiliary/gather/test.rb`
- [x] `set SMBUSER [valid username]`
- [x] `set SMBPASS [valid password]`
- [x] `set SMBSHARE C`
- [x] `set RHOST [IP]`
- [x] `set RPATH Windows\\System32\\*`
- [x] `run`
- [x] With the patch, you should see a lot of files (on a newly installed Win 2008 SP2, there's more than 2000 files). Without the patch, there's always 40 (because the SMB client only requests 20 items per response). 
