### PR TITLE
Update meterpreter_bins to 0.0.11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       json
       metasploit-concern (~> 0.3.0)
       metasploit-model (~> 0.28.0)
-      meterpreter_bins (= 0.0.10)
+      meterpreter_bins (= 0.0.11)
       msgpack
       nokogiri
       packetfu (= 1.1.9)
@@ -132,7 +132,7 @@ GEM
       pg
       railties (< 4.0.0)
       recog (~> 1.0)
-    meterpreter_bins (0.0.10)
+    meterpreter_bins (0.0.11)
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.6.0)
@@ -212,7 +212,7 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    sqlite3 (1.3.9)
+    sqlite3 (1.3.10)
     thor (0.19.1)
     tilt (1.4.1)
     timecop (0.7.1)

--- a/metasploit-framework.gemspec
+++ b/metasploit-framework.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |spec|
   # are needed when there's no database
   spec.add_runtime_dependency 'metasploit-model', '~> 0.28.0'
   # Needed for Meterpreter on Windows, soon others.
-  spec.add_runtime_dependency 'meterpreter_bins', '0.0.10'
+  spec.add_runtime_dependency 'meterpreter_bins', '0.0.11'
   # Needed by msfgui and other rpc components
   spec.add_runtime_dependency 'msgpack'
   # Needed by anemone crawler


### PR DESCRIPTION
This adds support for the `getsid` command in the Windows Meterpreter binaries.
## Sample run

```
msf exploit(handler) > exploit

[*] Started reverse handler on 10.1.10.40:8000 
[*] Starting the payload handler...
[*] Sending stage (770048 bytes) to 10.1.10.36
[*] Meterpreter session 2 opened (10.1.10.40:8000 -> 10.1.10.36:49262) at 2014-11-12 07:20:04 +1000

meterpreter > getsid
Server SID: S-1-5-21-2676972102-3618304068-1989523545-1000
meterpreter > irb
[*] Starting IRB shell
[*] The 'client' variable holds the meterpreter client

>> client.sys.config.is_system?
=> false
>> exit
meterpreter > getsystem
...got system (via technique 1).
meterpreter > getsid
Server SID: S-1-5-18
meterpreter > irb
[*] Starting IRB shell
[*] The 'client' variable holds the meterpreter client

>> client.sys.config.is_system?
=> true
```
## Verification
- [x] Make sure that `getsid` appears in the help menu.
- [x] Make sure `getsid` works.

The validation of the `is_system?` function in IRB is optional IMHO.
