### PR TITLE
Fix port 0 bug in URIPORT

### DIFF
--- a/lib/msf/core/exploit/http/server.rb
+++ b/lib/msf/core/exploit/http/server.rb
@@ -476,7 +476,7 @@ module Exploit::Remote::HttpServer
       host = "[#{host}]"
     end
 
-    if datastore['URIPORT']
+    if datastore['URIPORT'] != 0
       port = ':' + datastore['URIPORT'].to_s
     elsif (ssl and datastore["SRVPORT"] == 443)
       port = ''


### PR DESCRIPTION
Fixes #4164.

```
###
#
# Network port option.
#   
### 
class OptPort < OptBase
  def type
    return 'port'
  end   

  def normalize(value)
    value.to_i
  end   

  def valid?(value)
    return false if empty_required_value?(value)

    if ((value != nil and value.to_s.empty? == false) and
        ((value.to_s.match(/^\d+$/) == nil or value.to_i < 0 or value.to_i > 65535)))
      return false
    end

    return super
  end
end
```
