### PR TITLE
Add post-exploitation module to get FW filtering rules

### DIFF
--- a/modules/post/windows/recon/outbound_ports.rb
+++ b/modules/post/windows/recon/outbound_ports.rb
@@ -118,7 +118,6 @@ class Metasploit3 < Msf::Post
   end
 
   def connections(remote, dst_port, h_icmp, h_tcp, to)
-    sock_addr = Rex::Socket.to_sockaddr(remote, dst_port)
     r = client.railgun.ws2_32.connect(h_tcp, "\x02\x00" << [dst_port].pack("n") << Rex::Socket.addr_aton(remote) << "\x00"*8 , 16)
 
     # A GetLastError == 1035 is expected since the socket is set to non-blocking mode

--- a/modules/post/windows/recon/outbound_ports.rb
+++ b/modules/post/windows/recon/outbound_ports.rb
@@ -130,7 +130,7 @@ class Metasploit3 < Msf::Post
 
     begin
       ::Timeout.timeout(to) do
-        r = client.railgun.ws2_32.recvfrom(h_icmp, "", 100, 0, from, 16)
+        r = client.railgun.ws2_32.recvfrom(h_icmp, "\x00" * 100, 100, 0, from, 16)
         hop = Rex::Socket.addr_ntoa(r['from'][4..7])
         return hop
       end

--- a/modules/post/windows/recon/outbound_ports.rb
+++ b/modules/post/windows/recon/outbound_ports.rb
@@ -50,12 +50,14 @@ class Metasploit3 < Msf::Post
       return nil
     end
     vprint_status("ICMP raw socket created successfully")
-    sockaddr = Rex::Socket.to_sockaddr(session.tunnel_peer.partition(':')[0], 0)
+
+    sockaddr = Rex::Socket.to_sockaddr(session.session_host, 0)
     r = client.railgun.ws2_32.bind(handler['return'],sockaddr,16)
     if r['GetLastError'] != 0
-      print_error("There was an error binding the ICMP socket; GetLastError: #{r['GetLastError']}")
+      print_error("There was an error binding the ICMP socket to #{session.session_host}; GetLastError: #{r['GetLastError']}")
       return nil
     end
+    vprint_status("ICMP socket successfully bound to #{session.session_host}")
 
     # int WSAIoctl(
     # _In_   SOCKET s,
@@ -85,6 +87,9 @@ class Metasploit3 < Msf::Post
       return nil
     end
     vprint_status("TCP socket created successfully")
+
+    # 0x8004667E = FIONBIO
+    # Enable non-blocking mode when *argp (third parameter in ioctlsocket) is set to a nonzero value
 
     cmd = 0x8004667E
     r = client.railgun.ws2_32.ioctlsocket(handler['return'], cmd, 1)


### PR DESCRIPTION
This module makes some kind of TCP traceroute to get outbound-filtering rules. It will try to make a TCP connection to a certain public IP address (this IP does not need to be under your control) using different TTL incremental values. This way if you get an ICMP "time exceeded" from a public device you can deduce that the port is not filtered. Example:

msf post(outbound_ports) > exploit

[*] ICMP firewall IN rule established: Aceptar

[_] Testing port 4444...
[+] 1 192.168.144.1
[-] 2 *
[+] 3 81.46.0.157
[+] 4 94.142.103.157
[+] 5 213.140.38.113
[+] 6 213.140.38.114
[+] 7 84.16.15.250
[+] 8 213.140.38.221
[+] 9 84.16.15.81
[+] 10 94.142.122.253
[_] Testing port 8080...
[+] 1 192.168.144.1
[-] 2 *
[+] 3 81.46.0.157
[+] 4 94.142.103.157
[+] 5 213.140.38.113
[+] 6 213.140.38.114
[+] 7 84.16.15.250
[+] 8 213.140.38.157
[+] 9 94.142.124.58
[+] 10 94.142.123.1
[*] Post module execution completed

If you set the STOP option to true when a public IP responds with an ICMP packet, the script will not continue launching more connections (generating minimum noise).

msf post(outbound_ports) > set stop true
stop => true
msf post(outbound_ports) > exploit

[*] ICMP firewall IN rule established: Aceptar

[_] Testing port 4444...
[+] 1 192.168.144.1
[-] 2 *
[+] 3 81.46.0.157
[+] Public IP reached. The port 4444 is not filtered
[_] Testing port 8080...
[+] 1 192.168.144.1
[+] 2 81.46.0.157
[+] Public IP reached. The port 8080 is not filtered
[*] Post module execution completed
