### PR TITLE
Fix #4163 - Update merge_check_key to keep up with 2.1.4 change

### DIFF
--- a/lib/msf/core/module/module_info.rb
+++ b/lib/msf/core/module/module_info.rb
@@ -74,7 +74,7 @@ module Msf::Module::ModuleInfo
   # Checks and merges the supplied key/value pair in the supplied hash.
   #
   def merge_check_key(info, name, val)
-    if (self.respond_to?("merge_info_#{name.downcase}"))
+    if (self.respond_to?("merge_info_#{name.downcase}", true))
       eval("merge_info_#{name.downcase}(info, val)")
     else
       # If the info hash already has an entry for this name


### PR DESCRIPTION
This is for https://github.com/rapid7/metasploit-framework/issues/4163
## Root cause

The `merge_check_key` method (found in Msf::Module::ModuleInfo) uses `respond_to?` to check if our object includes a `merge_info_description` method before merging descriptions. The `respond_to?` method in 2.1.4 by default no longer checks private and protected methods, and this is breaking our `merge_check_key` method.

This is the documentation of respond_to? for Ruby 2.1.4:
http://ruby-doc.org/core-2.1.4/Object.html#method-i-respond_to-3F

This is the documentation of respond_to? for Ruby 1.9.3:
http://ruby-doc.org/core-1.9.3/Object.html#method-i-respond_to-3F
## Verification
- [x] In order to test this, you must be using ruby-2.1.4, which is the version framework will be using soon.
- [x] Without the patch, do: `./msfvenom -p windows/meterpreter/reverse_tcp -o`
- [x] You should see an "undefined method `gsub' for Array" error
- [x] With the patch, do the same command again: `./msfvenom -p windows/meterpreter/reverse_tcp -o`
- [x] This time, you should see the module information without any errors.
