### PR TITLE
Add the ability to specify mode in Rex output file

### DIFF
--- a/lib/rex/ui/text/output/file.rb
+++ b/lib/rex/ui/text/output/file.rb
@@ -14,8 +14,8 @@ class Output::File < Rex::Ui::Text::Output
 
   attr_accessor :fd
 
-  def initialize(path)
-    self.fd = ::File.open(path, "wb")
+  def initialize(path, mode='wb')
+    self.fd = ::File.open(path, mode)
   end
 
   def supports_color?


### PR DESCRIPTION
- Because sometimes you might want to append
- Preserves original hardcoded 'wb' as default
- Now we can play all teh modez! http://pubs.opengroup.org/onlinepubs/009695399/functions/fopen.html
## Verification steps
### Append mode:
- [x] Go into msfconsole and drop into IRB
- [x] `foo = Rex::Ui::Text::Output::File.new("/tmp/mah_important_service.log", 'a')`
- [x] `foo.print_raw("something happened\n")`
- [x] `foo.close`
- [x] `bar = Rex::Ui::Text::Output::File.new("/tmp/mah_important_service.log", 'a')`
- [x] `bar.print_raw("something else happened!\n")`
- [x] `bar.close`
- [x] Verify both lines are present: `File.readlines("/tmp/mah_important_service.log")`
### Truncate/overwrite mode (default)
- [x] `foo = Rex::Ui::Text::Output::File.new("/tmp/some_file.txt")`
- [x] `foo.print_raw("some output")`
- [x] `foo.close`
- [x] `bar = Rex::Ui::Text::Output::File.new("/tmp/some_file.txt")`
- [x] `bar.print_raw("a thing that is completely different")`
- [x] `bar.close`
- [x] Verify only the most recent line is present: `File.readlines("/tmp/some_file.txt")`
