### PR TITLE
Bug/msp 11609/blank username failure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec name: 'metasploit-framework'
 
 group :db do
   gemspec name: 'metasploit-framework-db'
+  gem 'metasploit-credential', git: 'https://github.com/rapid7/metasploit-credential.git', branch: 'bug/MSP-11609/blank-username-failure'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,17 @@
+GIT
+  remote: https://github.com/rapid7/metasploit-credential.git
+  revision: b5c36d0df013969df64625cfe23bd9a0ab3d2ee6
+  branch: bug/MSP-11609/blank-username-failure
+  specs:
+    metasploit-credential (0.13.3.pre.blank.pre.username.pre.failure)
+      metasploit-concern (~> 0.3.0)
+      metasploit-model (~> 0.28.0)
+      metasploit_data_models (~> 0.21.0)
+      pg
+      railties (< 4.0.0)
+      rubyntlm
+      rubyzip (~> 1.1)
+
 PATH
   remote: .
   specs:
@@ -22,7 +36,7 @@ PATH
       tzinfo
     metasploit-framework-db (4.10.1.pre.dev)
       activerecord (< 4.0.0)
-      metasploit-credential (~> 0.13.0)
+      metasploit-credential
       metasploit-framework (= 4.10.1.pre.dev)
       metasploit_data_models (~> 0.21.1)
       pg (>= 0.11)
@@ -112,14 +126,6 @@ GEM
     metasploit-concern (0.3.0)
       activesupport (~> 3.0, >= 3.0.0)
       railties (< 4.0.0)
-    metasploit-credential (0.13.2)
-      metasploit-concern (~> 0.3.0)
-      metasploit-model (~> 0.28.0)
-      metasploit_data_models (~> 0.21.0)
-      pg
-      railties (< 4.0.0)
-      rubyntlm
-      rubyzip (~> 1.1)
     metasploit-model (0.28.0)
       activesupport
       railties (< 4.0.0)
@@ -233,6 +239,7 @@ DEPENDENCIES
   factory_girl (>= 4.1.0)
   factory_girl_rails
   fivemat (= 1.2.1)
+  metasploit-credential!
   metasploit-framework!
   metasploit-framework-db!
   metasploit-framework-pcap!

--- a/metasploit-framework-db.gemspec
+++ b/metasploit-framework-db.gemspec
@@ -31,7 +31,8 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activerecord', rails_version_constraint
   # Metasploit::Credential database models
-  spec.add_runtime_dependency 'metasploit-credential', '~> 0.13.0'
+  #spec.add_runtime_dependency 'metasploit-credential', '~> 0.13.3'
+  spec.add_runtime_dependency 'metasploit-credential'  # DELETE this before landing
   # Database models shared between framework and Pro.
   spec.add_runtime_dependency 'metasploit_data_models', '~> 0.21.1'
   # depend on metasploit-framewrok as the optional gems are useless with the actual code

--- a/spec/lib/msf/ui/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/command_dispatcher/db_spec.rb
@@ -25,7 +25,7 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
       context "when a core already exists" do
         before(:each) do
           priv = FactoryGirl.create(:metasploit_credential_password, data: password)
-          pub = FactoryGirl.create(:metasploit_credential_public, username: username)
+          pub = FactoryGirl.create(:metasploit_credential_username, username: username)
           core = FactoryGirl.create(:metasploit_credential_core,
                                     origin: FactoryGirl.create(:metasploit_credential_origin_import),
                                     private: priv,


### PR DESCRIPTION
this spec needs to use the username factory :metasploit-credential_public factory will randomly return either a Username or BlankUsername and thus is not appropriate for when you want to set an explicit Username. The :metasploit_credential_username factory should be used for this instead.

VERIFICATION STEPS
- [x] land https://github.com/rapid7/metasploit-credential/pull/79
- [x] remove `gem 'metasploit-credential', git: 'https://github.com/rapid7/metasploit-credential.git', branch: 'bug/MSP-11609/blank-username-failure'` from the Gemfile
- [x] DELETE the line from the framework-db gemspec that has the 'DELETE this' comment
- [x] uncomment the line above that in the gemspec
- [x] `bundle install`
- [x] `bundle update metasploit-credential`
- [x] `rake spec`
- [x] VERIFY no failures
