### PR TITLE
Fix lack of support for MetasploitV5 tag

### DIFF
--- a/lib/msf/core/db_manager/import.rb
+++ b/lib/msf/core/db_manager/import.rb
@@ -302,6 +302,9 @@ module Msf::DBManager::Import
         when /MetasploitV4/
           @import_filedata[:type] = "Metasploit XML"
           return :msf_xml
+        when /MetasploitV5/
+          @import_filedata[:type] = "Metasploit XML"
+          return :msf_xml
         when /netsparker/
           @import_filedata[:type] = "NetSparker XML"
           return :netsparker_xml


### PR DESCRIPTION
 #4184
- Appears to have been overlooked somehow in the pre-BlackHat crunch
- V5 will not support credentials
- We are implementing full-workspace zip import/export for credentials
## Verification
- [x] Use a workspace that contains hosts/services/etc data
- [x] `db_export -f xml /tmp/msf-export.xml`
- [ ] `workspace -a import-test`
- [ ] `db_import /tmp/msf-export.xml`
- [ ] VERIFY: import completes and all data is persisted from original workspace to new one
