### PR TITLE
Fix report_note handling incorrect protocol names

### DIFF
--- a/lib/msf/core/db_manager/note.rb
+++ b/lib/msf/core/db_manager/note.rb
@@ -75,9 +75,10 @@ module Msf::DBManager::Note
       if (opts[:port])
         proto = nil
         sname = nil
-        case opts[:proto].to_s.downcase # Catch incorrect usages
+        proto_lower = opts[:proto].to_s.downcase # Catch incorrect usages
+        case proto_lower
         when 'tcp','udp'
-          proto = opts[:proto].to_s.downcase
+          proto = proto_lower
           sname = opts[:sname] if opts[:sname]
         when 'dns','snmp','dhcp'
           proto = 'udp'

--- a/lib/msf/core/db_manager/note.rb
+++ b/lib/msf/core/db_manager/note.rb
@@ -77,7 +77,7 @@ module Msf::DBManager::Note
         sname = nil
         case opts[:proto].to_s.downcase # Catch incorrect usages
         when 'tcp','udp'
-          proto = opts[:proto]
+          proto = opts[:proto].to_s.downcase
           sname = opts[:sname] if opts[:sname]
         when 'dns','snmp','dhcp'
           proto = 'udp'


### PR DESCRIPTION
As per the comment on line 78, the code was "catching" incorrect usages but not fixing them. This causes wayward modules to fail as in:

msf auxiliary(mssql_enum) > run

[_] Running MS SQL Server Enumeration...
[_] Version:
[_] Microsoft SQL Server 2008 R2 (SP1) - 10.50.2500.0 (Intel X86) 
[_]     Jun 17 2011 00:57:23 
[_]     Copyright (c) Microsoft Corporation
[_]     Express Edition with Advanced Services on Windows NT 6.1 <X86> (Build 7601: Service Pack 1)
[-] Auxiliary failed: ActiveRecord::RecordInvalid Validation failed: Proto is not included in the list
[-] Call stack:
[-]   /opt/metasploit/apps/pro/vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.17/lib/active_record/validations.rb:56:in `save!'
[-]   /opt/metasploit/apps/pro/vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.17/lib/active_record/attribute_methods/dirty.rb:33:in`save!'
[-]   /opt/metasploit/apps/pro/vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.17/lib/active_record/transactions.rb:264:in `block in save!'
[-]   /opt/metasploit/apps/pro/vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.17/lib/active_record/transactions.rb:313:in`block in with_transaction_returning_status'
[-]   /opt/metasploit/apps/pro/vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.17/lib/active_record/connection_adapters/abstract/database_statements.rb:192:in `transaction'
[-]   /opt/metasploit/apps/pro/vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.17/lib/active_record/transactions.rb:208:in`transaction'
[-]   /opt/metasploit/apps/pro/vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.17/lib/active_record/transactions.rb:311:in `with_transaction_returning_status'
[-]   /opt/metasploit/apps/pro/vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.17/lib/active_record/transactions.rb:264:in`save!'
[-]   /usr/share/metasploit-framework/lib/msf/core/db_manager/service.rb:103:in `block in report_service'
[-]   /opt/metasploit/apps/pro/vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.17/lib/active_record/connection_adapters/abstract/connection_pool.rb:129:in`with_connection'
[-]   /usr/share/metasploit-framework/lib/msf/core/db_manager/service.rb:49:in `report_service'
[-]   /usr/share/metasploit-framework/lib/msf/core/db_manager/note.rb:96:in`block in report_note'
[-]   /opt/metasploit/apps/pro/vendor/bundle/ruby/1.9.1/gems/activerecord-3.2.17/lib/active_record/connection_adapters/abstract/connection_pool.rb:129:in `with_connection'
[-]   /usr/share/metasploit-framework/lib/msf/core/db_manager/note.rb:57:in`report_note'
[-]   /usr/share/metasploit-framework/lib/msf/core/auxiliary/report.rb:125:in `report_note'
[-]   /usr/share/metasploit-framework/modules/auxiliary/admin/mssql/mssql_enum.rb:49:in`run'
[*] Auxiliary module execution completed
