### PR TITLE
Update UDPScanner to support RPORTS

### DIFF
--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -39,7 +39,14 @@ module Auxiliary::UDPScanner
   end
 
   def setup
+    if datastore['RPORTS'].blank?
+      fail ::ArgumentError, 'No RPORTS specified'
+    end
+
     @rports = Rex::Socket.portspec_crack(datastore['RPORTS'])
+    if @rports.empty?
+      fail ::ArgumentError, "No valid ports found from RPORTS '#{datastore['RPORTS']}'"
+    end
   end
 
   # Define our batch size

--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -21,7 +21,8 @@ module Auxiliary::UDPScanner
 
     register_options(
     [
-      Opt::RPORT,
+#      Opt::RPORT,
+      OptString.new('RPORTS', [false, 'Try these ports rather than the one port defined in RPORT']),
       OptInt.new('BATCHSIZE', [true, 'The number of hosts to probe in each set', 256]),
       OptInt.new('THREADS', [true, "The number of concurrent threads", 10])
     ], self.class)
@@ -36,6 +37,17 @@ module Auxiliary::UDPScanner
       OptInt.new('ScannerRecvWindow', [true, 'The number of seconds to wait post-scan to catch leftover replies', 15])
 
     ], self.class)
+  end
+
+  def setup
+    deregister_options('RPORT')
+    if datastore['RPORTS']
+      @rports ||= Rex::Socket.portspec_crack(datastore['RPORTS'])
+    else
+      @rports = nil
+    end
+
+    puts "rports = #{rports}"
   end
 
   # Define our batch size
@@ -167,6 +179,10 @@ module Auxiliary::UDPScanner
     datastore['RPORT']
   end
 
+  def rports
+    @rports
+  end
+
   #
   # The including module may override some of these methods
   #
@@ -177,6 +193,7 @@ module Auxiliary::UDPScanner
 
   # Called for each IP in the batch.  This will send all necessary probes.
   def scan_host(ip)
+
     scanner_send(build_probe, ip, rport)
   end
 

--- a/lib/msf/core/auxiliary/udp_scanner.rb
+++ b/lib/msf/core/auxiliary/udp_scanner.rb
@@ -21,8 +21,7 @@ module Auxiliary::UDPScanner
 
     register_options(
     [
-#      Opt::RPORT,
-      OptString.new('RPORTS', [false, 'Try these ports rather than the one port defined in RPORT']),
+      OptString.new('RPORTS', [true, 'Try these ports']),
       OptInt.new('BATCHSIZE', [true, 'The number of hosts to probe in each set', 256]),
       OptInt.new('THREADS', [true, "The number of concurrent threads", 10])
     ], self.class)
@@ -40,14 +39,7 @@ module Auxiliary::UDPScanner
   end
 
   def setup
-    deregister_options('RPORT')
-    if datastore['RPORTS']
-      @rports ||= Rex::Socket.portspec_crack(datastore['RPORTS'])
-    else
-      @rports = nil
-    end
-
-    puts "rports = #{rports}"
+    @rports = Rex::Socket.portspec_crack(datastore['RPORTS'])
   end
 
   # Define our batch size
@@ -175,10 +167,6 @@ module Auxiliary::UDPScanner
     datastore['CPORT']
   end
 
-  def rport
-    datastore['RPORT']
-  end
-
   def rports
     @rports
   end
@@ -194,7 +182,9 @@ module Auxiliary::UDPScanner
   # Called for each IP in the batch.  This will send all necessary probes.
   def scan_host(ip)
 
-    scanner_send(build_probe, ip, rport)
+    rports.each do |rport|
+      scanner_send(build_probe, ip, rport)
+    end
   end
 
   # Called for each response packet

--- a/modules/auxiliary/scanner/discovery/empty_udp.rb
+++ b/modules/auxiliary/scanner/discovery/empty_udp.rb
@@ -17,24 +17,16 @@ class Metasploit3 < Msf::Auxiliary
       'License'     => MSF_LICENSE
     )
     register_options([
-      OptString.new('PORTS', [true, 'Ports to probe', '1-1024,1194,2000,2049,4353,5060,5061,5351,8443'])
+      OptString.new('RPORTS', [true, 'Ports to probe', '1-1024,1194,2000,2049,4353,5060,5061,5351,8443'])
     ], self.class)
   end
 
-  def setup
-    super
-    @ports = Rex::Socket.portspec_crack(datastore['PORTS'])
-    raise Msf::OptionValidateError.new(['PORTS']) if @ports.empty?
-  end
-
   def scanner_prescan(batch)
-    print_status("Sending #{@ports.length} empty probes to #{batch[0]}->#{batch[-1]} (#{batch.length} hosts)")
+    print_status("Sending #{rports.length} empty probes to #{batch[0]}->#{batch[-1]} (#{batch.length} hosts)")
   end
 
-  def scan_host(ip)
-    @ports.each do |port|
-      scanner_send('', ip, port)
-    end
+  def build_probe
+    @probe ||= ''
   end
 
   def scanner_process(data, shost, sport)

--- a/modules/auxiliary/scanner/upnp/ssdp_amp.rb
+++ b/modules/auxiliary/scanner/upnp/ssdp_amp.rb
@@ -24,7 +24,7 @@ class Metasploit3 < Msf::Auxiliary
     )
 
     register_options([
-      Opt::RPORT(1900),
+      OptString.new('RPORTS', [true, 'Ports to probe', '1900']),
       OptBool.new('SHORT', [ false, "Does a shorter request, for a higher amplifier, not compatible with all devices", false])
     ], self.class)
   end


### PR DESCRIPTION
Many of the existing UDPScanner modules technically could/should be trying their probes against more than one port.  This is a bit of an experiment to see if people are OK with the idea, but the modifications to the mixin seem straight forward and the bigger effort is updating the handful of modules that use UDPScanner to use RPORTS instead -- I've done this for a few here as an example and it is straight forward.

This is not landable as-is because it will break all non-updated modules such that a user would have to specify an RPORTS even though it would be unused.  If there are no huge complaints here I'll update all of the modules and update this PR.
## Validation
- [ ] Ensure that all UDPScanner modules only define RPORTS, not RPORT
- [ ] Select a sample UDPScanner module.  Confirm that it correctly handles empty/invalid RPORTS values
- [ ] Select a sample UDPScanner module.  Confirm that when RPORTS contains one port, it only scans that one port
- [ ] Select a sample UDPScanner module.  Confirm that when RPORTS contains more than one port, it scans all of those ports
