### PR TITLE
Update db/schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140905031549) do
+ActiveRecord::Schema.define(:version => 20140922170030) do
 
   create_table "api_keys", :force => true do |t|
     t.text     "token"
@@ -272,6 +272,7 @@ ActiveRecord::Schema.define(:version => 20140905031549) do
     t.string   "username",   :null => false
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
+    t.string   "type",       :null => false
   end
 
   add_index "metasploit_credential_publics", ["username"], :name => "index_metasploit_credential_publics_on_username", :unique => true


### PR DESCRIPTION
MSP-11615

To get type column on metasploit_credential_publics.
# Verification Steps
## Migrations
- [x] `rake db:drop db:create db:migrate`
- [x] `git status`
- [x] VERIFY no changes to `db/schema.rb`
## specs
- [x] `rake spec`
- [x] VERIFY no failures due to change in `db/schema.rb`
