### PR TITLE
Fix BrowserAutopwn JS ref error

### DIFF
--- a/modules/auxiliary/server/browser_autopwn.rb
+++ b/modules/auxiliary/server/browser_autopwn.rb
@@ -225,7 +225,7 @@ class Metasploit3 < Msf::Auxiliary
       }
 
       function bodyOnLoad() {
-        var detected_version = window.os_detect.getVersion();
+        var detected_version = os_detect.getVersion();
         //#{js_debug('detected_version')}
         report_and_get_exploits(detected_version);
       } // function bodyOnLoad


### PR DESCRIPTION
Looks like this was introduced whenever we bumped jsobfu. The BAP script was still referring to `window.os_detect`, instead of using the locally renamed variable.
#### Verification
- [ ] Pop a shell through BAP
