### PR TITLE
Spec Msf::Ui::Console::CommandDispatcher::Db

### DIFF
--- a/spec/lib/msf/ui/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/command_dispatcher/db_spec.rb
@@ -42,18 +42,59 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
     end
   end
 
-  describe "#cmd_workspace" do
+  describe "#cmd_db_export" do
     describe "-h" do
       it "should show a help message" do
-        db.cmd_workspace "-h"
+        db.cmd_db_export "-h"
         @output.should =~ [
           "Usage:",
-          "    workspace                  List workspaces",
-          "    workspace [name]           Switch workspace",
-          "    workspace -a [name] ...    Add workspace(s)",
-          "    workspace -d [name] ...    Delete workspace(s)",
-          "    workspace -r <old> <new>   Rename workspace",
-          "    workspace -h               Show this help information"
+          "    db_export -f <format> [-a] [filename]",
+          "    Format can be one of: xml, pwdump"
+        ]
+      end
+    end
+  end
+
+  describe "#cmd_db_import" do
+    describe "-h" do
+      it "should show a help message" do
+        db.cmd_db_import "-h"
+        @output.should =~ [
+          "Usage: db_import <filename> [file2...]",
+          "Filenames can be globs like *.xml, or **/*.xml which will search recursively",
+          "Currently supported file types include:",
+          "    Acunetix",
+          "    Amap Log",
+          "    Amap Log -m",
+          "    Appscan",
+          "    Burp Session XML",
+          "    CI",
+          "    Foundstone",
+          "    FusionVM XML",
+          "    IP Address List",
+          "    IP360 ASPL",
+          "    IP360 XML v3",
+          "    Libpcap Packet Capture",
+          "    Metasploit PWDump Export",
+          "    Metasploit XML",
+          "    Metasploit Zip Export",
+          "    Microsoft Baseline Security Analyzer",
+          "    NeXpose Simple XML",
+          "    NeXpose XML Report",
+          "    Nessus NBE Report",
+          "    Nessus XML (v1)",
+          "    Nessus XML (v2)",
+          "    NetSparker XML",
+          "    Nikto XML",
+          "    Nmap XML",
+          "    OpenVAS Report",
+          "    OpenVAS XML",
+          "    Outpost24 XML",
+          "    Qualys Asset XML",
+          "    Qualys Scan XML",
+          "    Retina XML",
+          "    Spiceworks CSV Export",
+          "    Wapiti XML"
         ]
       end
     end
@@ -78,6 +119,53 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
         ]
       end
     end
+  end
+
+  describe "#cmd_loot" do
+    describe "-h" do
+      it "should show a help message" do
+        db.cmd_loot "-h"
+        @output.should =~ [
+          "Usage: loot <options>",
+          " Info: loot [-h] [addr1 addr2 ...] [-t <type1,type2>]",
+          "  Add: loot -f [fname] -i [info] -a [addr1 addr2 ...] [-t [type]",
+          "  Del: loot -d [addr1 addr2 ...]",
+          "  -a,--add          Add loot to the list of addresses, instead of listing",
+          "  -d,--delete       Delete *all* loot matching host and type",
+          "  -f,--file         File with contents of the loot to add",
+          "  -i,--info         Info of the loot to add",
+          "  -t <type1,type2>  Search for a list of types",
+          "  -h,--help         Show this help information",
+          "  -S,--search       Search string to filter by"
+        ]
+      end
+    end
+
+  end
+
+  describe "#cmd_notes" do
+    describe "-h" do
+      it "should show a help message" do
+        db.cmd_notes "-h"
+        @output.should =~ [
+          "Usage: notes [-h] [-t <type1,type2>] [-n <data string>] [-a] [addr range]",
+          "  -a,--add                  Add a note to the list of addresses, instead of listing",
+          "  -d,--delete               Delete the hosts instead of searching",
+          "  -n,--note <data>          Set the data for a new note (only with -a)",
+          "  -t <type1,type2>          Search for a list of types",
+          "  -h,--help                 Show this help information",
+          "  -R,--rhosts               Set RHOSTS from the results of the search",
+          "  -S,--search               Regular expression to match for search",
+          "  --sort <field1,field2>    Fields to sort by (case sensitive)",
+          "Examples:",
+          "  notes --add -t apps -n 'winzip' 10.1.1.34 10.1.20.41",
+          "  notes -t smb.fingerprint 10.1.1.34 10.1.20.41",
+          "  notes -S 'nmap.nse.(http|rtsp)' --sort type,output"
+        ]
+
+      end
+    end
+
   end
 
   describe "#cmd_services" do
@@ -167,132 +255,18 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
 
   end
 
-  describe "#cmd_notes" do
+  describe "#cmd_workspace" do
     describe "-h" do
       it "should show a help message" do
-        db.cmd_notes "-h"
-        @output.should =~ [
-          "Usage: notes [-h] [-t <type1,type2>] [-n <data string>] [-a] [addr range]",
-          "  -a,--add                  Add a note to the list of addresses, instead of listing",
-          "  -d,--delete               Delete the hosts instead of searching",
-          "  -n,--note <data>          Set the data for a new note (only with -a)",
-          "  -t <type1,type2>          Search for a list of types",
-          "  -h,--help                 Show this help information",
-          "  -R,--rhosts               Set RHOSTS from the results of the search",
-          "  -S,--search               Regular expression to match for search",
-          "  --sort <field1,field2>    Fields to sort by (case sensitive)",
-          "Examples:",
-          "  notes --add -t apps -n 'winzip' 10.1.1.34 10.1.20.41",
-          "  notes -t smb.fingerprint 10.1.1.34 10.1.20.41",
-          "  notes -S 'nmap.nse.(http|rtsp)' --sort type,output"
-        ]
-
-      end
-    end
-
-  end
-
-  describe "#cmd_loot" do
-    describe "-h" do
-      it "should show a help message" do
-        db.cmd_loot "-h"
-        @output.should =~ [
-          "Usage: loot <options>",
-          " Info: loot [-h] [addr1 addr2 ...] [-t <type1,type2>]",
-          "  Add: loot -f [fname] -i [info] -a [addr1 addr2 ...] [-t [type]",
-          "  Del: loot -d [addr1 addr2 ...]",
-          "  -a,--add          Add loot to the list of addresses, instead of listing",
-          "  -d,--delete       Delete *all* loot matching host and type",
-          "  -f,--file         File with contents of the loot to add",
-          "  -i,--info         Info of the loot to add",
-          "  -t <type1,type2>  Search for a list of types",
-          "  -h,--help         Show this help information",
-          "  -S,--search       Search string to filter by"
-        ]
-      end
-    end
-
-  end
-
-=begin
-  describe "#cmd_creds" do
-    describe "-h" do
-      it "should show a help message" do
-        db.cmd_creds "-h"
-        @output.should =~ [
-          "Usage: creds [addr range]",
-          "List credentials. If an address range is given, show only credentials with",
-          "logins on hosts within that range.",
-          "  -h,--help             Show this help information",
-          "  -c,--columns          Columns of interest",
-          "  -P,--password <regex> List passwords that match this regex",
-          "  -p,--port <portspec>  List creds with logins on services matching this port spec",
-          "  -s <svc names>        List creds matching comma-separated service names",
-          "  -u,--user <regex>     List users that match this regex",
-          "Examples:",
-          "  creds               # Default, returns all credentials",
-          "  creds 1.2.3.4/24    # nmap host specification",
-          "  creds -p 22-25,445  # nmap port specification",
-          "  creds -s ssh,smb    # All creds associated with a login on SSH or SMB services"
-        ]
-      end
-    end
-  end
-=end
-
-  describe "#cmd_db_import" do
-    describe "-h" do
-      it "should show a help message" do
-        db.cmd_db_import "-h"
-        @output.should =~ [
-          "Usage: db_import <filename> [file2...]",
-          "Filenames can be globs like *.xml, or **/*.xml which will search recursively",
-          "Currently supported file types include:",
-          "    Acunetix",
-          "    Amap Log",
-          "    Amap Log -m",
-          "    Appscan",
-          "    Burp Session XML",
-          "    CI",
-          "    Foundstone",
-          "    FusionVM XML",
-          "    IP Address List",
-          "    IP360 ASPL",
-          "    IP360 XML v3",
-          "    Libpcap Packet Capture",
-          "    Metasploit PWDump Export",
-          "    Metasploit XML",
-          "    Metasploit Zip Export",
-          "    Microsoft Baseline Security Analyzer",
-          "    NeXpose Simple XML",
-          "    NeXpose XML Report",
-          "    Nessus NBE Report",
-          "    Nessus XML (v1)",
-          "    Nessus XML (v2)",
-          "    NetSparker XML",
-          "    Nikto XML",
-          "    Nmap XML",
-          "    OpenVAS Report",
-          "    OpenVAS XML",
-          "    Outpost24 XML",
-          "    Qualys Asset XML",
-          "    Qualys Scan XML",
-          "    Retina XML",
-          "    Spiceworks CSV Export",
-          "    Wapiti XML"
-        ]
-      end
-    end
-  end
-
-  describe "#cmd_db_export" do
-    describe "-h" do
-      it "should show a help message" do
-        db.cmd_db_export "-h"
+        db.cmd_workspace "-h"
         @output.should =~ [
           "Usage:",
-          "    db_export -f <format> [-a] [filename]",
-          "    Format can be one of: xml, pwdump"
+          "    workspace                  List workspaces",
+          "    workspace [name]           Switch workspace",
+          "    workspace -a [name] ...    Add workspace(s)",
+          "    workspace -d [name] ...    Delete workspace(s)",
+          "    workspace -r <old> <new>   Rename workspace",
+          "    workspace -h               Show this help information"
         ]
       end
     end

--- a/spec/lib/msf/ui/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/command_dispatcher/db_spec.rb
@@ -11,6 +11,59 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
     described_class.new(driver)
   end
 
+  it { is_expected.to respond_to :active? }
+  it { is_expected.to respond_to :arg_host_range }
+  it { is_expected.to respond_to :arg_port_range }
+  it { is_expected.to respond_to :cmd_creds_help }
+  it { is_expected.to respond_to :cmd_creds_tabs }
+  it { is_expected.to respond_to :cmd_db_autopwn }
+  it { is_expected.to respond_to :cmd_db_autopwn_help }
+  it { is_expected.to respond_to :cmd_db_connect }
+  it { is_expected.to respond_to :cmd_db_connect_help }
+  it { is_expected.to respond_to :cmd_db_disconnect }
+  it { is_expected.to respond_to :cmd_db_disconnect_help }
+  it { is_expected.to respond_to :cmd_db_driver }
+  it { is_expected.to respond_to :cmd_db_driver_help }
+  it { is_expected.to respond_to :cmd_db_export_help }
+  it { is_expected.to respond_to :cmd_db_hosts_help }
+  it { is_expected.to respond_to :cmd_db_import_help }
+  it { is_expected.to respond_to :cmd_db_import_tabs }
+  it { is_expected.to respond_to :cmd_db_nmap }
+  it { is_expected.to respond_to :cmd_db_notes }
+  it { is_expected.to respond_to :cmd_db_notes_help }
+  it { is_expected.to respond_to :cmd_db_rebuild_cache }
+  it { is_expected.to respond_to :cmd_db_rebuild_cache_help }
+  it { is_expected.to respond_to :cmd_db_services }
+  it { is_expected.to respond_to :cmd_db_services_help }
+  it { is_expected.to respond_to :cmd_db_status }
+  it { is_expected.to respond_to :cmd_db_vulns }
+  it { is_expected.to respond_to :cmd_db_vulns_help }
+  it { is_expected.to respond_to :cmd_hosts }
+  it { is_expected.to respond_to :cmd_hosts_help }
+  it { is_expected.to respond_to :cmd_loot_help }
+  it { is_expected.to respond_to :cmd_notes_help }
+  it { is_expected.to respond_to :cmd_services_help }
+  it { is_expected.to respond_to :cmd_vulns_help }
+  it { is_expected.to respond_to :cmd_workspace_help }
+  it { is_expected.to respond_to :cmd_workspace_tabs }
+  it { is_expected.to respond_to :commands }
+  it { is_expected.to respond_to :creds_add }
+  it { is_expected.to respond_to :creds_add_non_replayable_hash }
+  it { is_expected.to respond_to :creds_add_ntlm_hash }
+  it { is_expected.to respond_to :creds_add_password }
+  it { is_expected.to respond_to :creds_add_ssh_key }
+  it { is_expected.to respond_to :creds_search }
+  it { is_expected.to respond_to :db_check_driver }
+  it { is_expected.to respond_to :db_connect_postgresql }
+  it { is_expected.to respond_to :db_find_tools }
+  it { is_expected.to respond_to :db_parse_db_uri_postgresql }
+  it { is_expected.to respond_to :deprecated_commands }
+  it { is_expected.to respond_to :each_host_range_chunk }
+  it { is_expected.to respond_to :make_sortable }
+  it { is_expected.to respond_to :name }
+  it { is_expected.to respond_to :report_store_local }
+  it { is_expected.to respond_to :set_rhosts_from_addrs }
+
   describe "#cmd_creds" do
     describe "add-password" do
       let(:username) { "username" }
@@ -270,13 +323,5 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
         ]
       end
     end
-  end
-
-  describe "#db_nmap" do
-    it "should have some specs describing its output"
-  end
-
-  describe "#db_rebuild_cache" do
-    it "should have some specs describing its output"
   end
 end


### PR DESCRIPTION
MSP-11622

Spec methods that `Msf::Ui::Console::CommandDispatcher::Db` responds to in order to ensure methods aren't dropped when `Msf::Ui::Console::CommandDispatcher::Db` is broken up for MSP-11128
# Verification Steps
## specs
- [x] `rake spec`
- [x] VERIFY no failures
- [x] VERIFY all public methods in `Msf::Ui::Console::CommandDispatcher::Db` have at a `respond_to` example.
