### PR TITLE
Use bundler/setup for more graceful bundler related failures, fixes #4222

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -23,14 +23,12 @@ unless ENV['BUNDLE_GEMFILE']
 end
 
 begin
-  require 'bundler'
+  require 'bundler/setup'
 rescue LoadError
   $stderr.puts "[*] Metasploit requires the Bundler gem to be installed"
   $stderr.puts "    $ gem install bundler"
-  exit(0)
+  exit(1)
 end
-
-Bundler.setup
 
 lib_path = root.join('lib').to_path
 


### PR DESCRIPTION
This seems to address #4222 
# Validation
- [x] Add some bogus change to the appropriate section of `Gemfile`, like bumping a version or adding some unrelated, uninstalled gem (try 'cats').
- [x] Run `msfconsole`, confirm the failure mode is now different and better than before
- [x] Undo `Gemfile` changes, redo step 2
