### PR TITLE
Fix DateTime string/ActiveRecord agreement

### DIFF
--- a/spec/lib/msf/db_manager/export_spec.rb
+++ b/spec/lib/msf/db_manager/export_spec.rb
@@ -79,7 +79,7 @@ describe Msf::DBManager::Export do
           it 'should have Mdm::Module::Detail#disclosure_date from disclosure-date content' do
             node = module_detail_node.at_xpath('disclosure-date')
 
-            DateTime.parse(node.content.to_s).should == DateTime.parse(module_detail.disclosure_date.to_s)
+            Date.parse(node.content.to_s).should == Date.parse(module_detail.disclosure_date)
           end
         end
 

--- a/spec/lib/msf/db_manager/export_spec.rb
+++ b/spec/lib/msf/db_manager/export_spec.rb
@@ -79,7 +79,7 @@ describe Msf::DBManager::Export do
           it 'should have Mdm::Module::Detail#disclosure_date from disclosure-date content' do
             node = module_detail_node.at_xpath('disclosure-date')
 
-            DateTime.parse(node.content).should == module_detail.disclosure_date
+            DateTime.parse(node.content.to_s).should == DateTime.parse(module_detail.disclosure_date.to_s)
           end
         end
 


### PR DESCRIPTION
Without this, it appears that some systems (notably, Travis-CI) can end up parsing strings and DateTime objects slightly differently. The last failure was https://gist.github.com/todb-r7/6206b698cfbd39b82a2f :

```
Msf::DBManager::Export ....................F...
  1) Msf::DBManager::Export#extract_module_detail_info with Mdm::Module::Details module_detail /disclosure-date should have Mdm::Module::Detail#disclosure_date from disclosure-date content
     Failure/Error: DateTime.parse(node.content).should == module_detail.disclosure_date
       expected: Thu, 05 Jun 2014 00:00:00 UTC +00:00
            got: Wed, 04 Jun 2014 00:00:00 +0000 (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -Thu, 05 Jun 2014 00:00:00 UTC +00:00
       +Wed, 04 Jun 2014 00:00:00 +0000

     # ./spec/lib/msf/db_manager/export_spec.rb:82:in `block (6 levels) in <top (required)>'
```

Note the UTC vs no UTC business there.

per Travis job:

https://travis-ci.org/rapid7/metasploit-framework/jobs/41383222

on build 10222

This is fixed by ensuring both sides of the `.should ==` are normalized with `DateTime` (the explicit `.to_s` is required to avoid an ActiveRecord warning).
## Verification
- [ ] See a green travis build
