### PR TITLE
Drop the CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Changelog
-
-# Next Release
-* Enhancements
- * [#4045](https://github.com/rapid7/metasploit-framework/pull/4045): Reorganize Msf::Module into submodule of related methods to reduce file size and allow for easier understanding of functionality - [@limhoff-r7](https://github.com/limhoff-r7)
-* Bug Fixes
-* Deprecations
-* Incompatible Changes


### PR DESCRIPTION
Just use `git shortlog` instead if you're really interested in the changes from your arbitrary point in history.
## Verification
- [x] Witness the emptiness that used to contain CHANGELOG.md
- [x] Contemplate the corresponding emptiness found within your own being
