### PR TITLE
Rework meterpreter SSL & pass datastore to handle_connection()

### DIFF
--- a/lib/msf/base/sessions/meterpreter.rb
+++ b/lib/msf/base/sessions/meterpreter.rb
@@ -30,10 +30,12 @@ class Meterpreter < Rex::Post::Meterpreter::Client
 
   include Msf::Session::Scriptable
 
-  # Override for server implementations that can't do ssl
+  # Override for server implementations that can't do SSL
   def supports_ssl?
     true
   end
+
+  # Override for server implementations that can't do zlib
   def supports_zlib?
     true
   end
@@ -49,10 +51,23 @@ class Meterpreter < Rex::Post::Meterpreter::Client
       :ssl => supports_ssl?,
       :zlib => supports_zlib?
     }
+
+    # The caller didn't request to skip ssl, so make sure we support it
     if not opts[:skip_ssl]
-      # the caller didn't request to skip ssl, so make sure we support it
       opts.merge!(:skip_ssl => (not supports_ssl?))
     end
+
+    #
+    # Parse options passed in via the datastore
+    #
+
+    # Extract the HandlerSSLCert option if specified by the user
+    if opts[:datastore] and opts[:datastore]['HandlerSSLCert']
+      opts[:ssl_cert] = opts[:datastore]['HandlerSSLCert']
+    end
+
+    # Don't pass the datastore into the init_meterpreter method
+    opts.delete(:datastore)
 
     #
     # Initialize the meterpreter client

--- a/lib/msf/base/sessions/meterpreter_options.rb
+++ b/lib/msf/base/sessions/meterpreter_options.rb
@@ -15,7 +15,8 @@ module MeterpreterOptions
         OptString.new('InitialAutoRunScript', [false, "An initial script to run on session creation (before AutoRunScript)", '']),
         OptString.new('AutoRunScript', [false, "A script to run automatically on session creation.", '']),
         OptBool.new('AutoSystemInfo', [true, "Automatically capture system information on initialization.", true]),
-        OptBool.new('EnableUnicodeEncoding', [true, "Automatically encode UTF-8 strings as hexadecimal", true])
+        OptBool.new('EnableUnicodeEncoding', [true, "Automatically encode UTF-8 strings as hexadecimal", true]),
+        OptPath.new('HandlerSSLCert', [false, "Path to a SSL certificate in unified PEM format, ignored for HTTP transports"])
       ], self.class)
   end
 

--- a/lib/msf/core/handler/bind_tcp.rb
+++ b/lib/msf/core/handler/bind_tcp.rb
@@ -146,7 +146,7 @@ module BindTcp
         # to implement the Stream interface.
         conn_threads << framework.threads.spawn("BindTcpHandlerSession", false, client) { |client_copy|
           begin
-            handle_connection(wrap_aes_socket(client_copy))
+            handle_connection(wrap_aes_socket(client_copy), { datastore: datastore })
           rescue
             elog("Exception raised from BindTcp.handle_connection: #{$!}")
           end

--- a/lib/msf/core/handler/find_port.rb
+++ b/lib/msf/core/handler/find_port.rb
@@ -55,7 +55,7 @@ module FindPort
     # If this is a multi-stage payload, then we just need to blindly
     # transmit the stage and create the session, hoping that it works.
     if (self.payload_type != Msf::Payload::Type::Single)
-      handle_connection(sock)
+      handle_connection(sock, { datastore: datastore })
     # Otherwise, check to see if we found a session.  We really need
     # to improve this, as we could create a session when the exploit
     # really didn't succeed.

--- a/lib/msf/core/handler/reverse_tcp.rb
+++ b/lib/msf/core/handler/reverse_tcp.rb
@@ -163,10 +163,10 @@ module ReverseTcp
         begin
           if datastore['ReverseListenerThreaded']
             self.conn_threads << framework.threads.spawn("ReverseTcpHandlerSession-#{local_port}-#{client.peerhost}", false, client) { | client_copy|
-              handle_connection(wrap_aes_socket(client_copy))
+              handle_connection(wrap_aes_socket(client_copy), { datastore: datastore })
             }
           else
-            handle_connection(wrap_aes_socket(client))
+            handle_connection(wrap_aes_socket(client), { datastore: datastore })
           end
         rescue ::Exception
           elog("Exception raised from handle_connection: #{$!.class}: #{$!}\n\n#{$@.join("\n")}")

--- a/lib/msf/core/handler/reverse_tcp_double.rb
+++ b/lib/msf/core/handler/reverse_tcp_double.rb
@@ -120,7 +120,7 @@ module ReverseTcpDouble
           begin
             sock_inp, sock_out = detect_input_output(client_a_copy, client_b_copy)
             chan = TcpReverseDoubleSessionChannel.new(framework, sock_inp, sock_out)
-            handle_connection(chan.lsock)
+            handle_connection(chan.lsock, { datastore: datastore })
           rescue
             elog("Exception raised from handle_connection: #{$!}\n\n#{$@.join("\n")}")
           end

--- a/lib/msf/core/handler/reverse_tcp_double_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_double_ssl.rb
@@ -121,7 +121,7 @@ module ReverseTcpDoubleSSL
           begin
             sock_inp, sock_out = detect_input_output(client_a_copy, client_b_copy)
             chan = TcpReverseDoubleSSLSessionChannel.new(framework, sock_inp, sock_out)
-            handle_connection(chan.lsock)
+            handle_connection(chan.lsock, { datastore: datastore })
           rescue
             elog("Exception raised from handle_connection: #{$!}\n\n#{$@.join("\n")}")
           end

--- a/lib/rex/post/meterpreter/client.rb
+++ b/lib/rex/post/meterpreter/client.rb
@@ -128,7 +128,7 @@ class Client
 
     # The SSL certificate is being passed down as a file path
     if opts[:ssl_cert]
-      if ! File.exists? opts[:ssl_cert]
+      if ! ::File.exists? opts[:ssl_cert]
         elog("SSL certificate at #{opts[:ssl_cert]} does not exist and will be ignored")
       else
         # Load the certificate the same way that SslTcpServer does it


### PR DESCRIPTION
This allows HandlerSSLCert to be used to pass a SSL certificate into the Meterpreter handler. The datastore has to be passed into handle_connection() for this to work, as SSL needs to be initialized on Session.new. This still doesn't pass the datastore into Meterpreter directly, but allows the Session::Meterpreter code to extract and pass down the :ssl_cert option if it was specified. This also fixes SSL certificate caching by expiring the cached cert from the class variables if the configuration has changed. A final change is to create a new SSL SessionID for each connection versus reusing the SSL context, which is incorrect and may lead to problems in the future (if not already).
