### PR TITLE
Fix #4253 - Print access level for snmp_login

### DIFF
--- a/modules/auxiliary/scanner/snmp/snmp_login.rb
+++ b/modules/auxiliary/scanner/snmp/snmp_login.rb
@@ -74,7 +74,7 @@ class Metasploit3 < Msf::Auxiliary
           credential_data[:core] = credential_core
           create_credential_login(credential_data)
 
-          print_good "#{ip}:#{rport} - LOGIN SUCCESSFUL: #{result.credential}"
+          print_good "#{ip}:#{rport} - LOGIN SUCCESSFUL: #{result.credential} (Access level: #{result.access_level})"
         else
           invalidate_login(credential_data)
           vprint_error "#{ip}:#{rport} - LOGIN FAILED: #{result.credential} (#{result.status}: #{result.proof})"


### PR DESCRIPTION
Fix #4253 - module should print the access level. Issue reported by @eelsivart

@eelsivart Could you please test this for the snmp_login issue you reported? Thanks.
