### PR TITLE
Fix #4259 - Failure to parse ANSI codes for msf prompt on Winodws

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1556,9 +1556,9 @@ class Core
       # intentionally += and not << because we don't want to modify
       # datastore or the constant DefaultPrompt
       if Rex::Compat.is_windows
-        prompt += " #{active_module.type}(%bld%red#{active_module.shortname}%clr)"
-      else
         prompt += " #{active_module.type}(#{active_module.shortname})"
+      else
+        prompt += " #{active_module.type}(%bld%red#{active_module.shortname}%clr)"
       end
     end
     prompt_char = framework.datastore['PromptChar'] || Msf::Ui::Console::Driver::DefaultPromptChar
@@ -2401,9 +2401,9 @@ class Core
     prompt = framework.datastore['Prompt'] || Msf::Ui::Console::Driver::DefaultPrompt
     prompt_char = framework.datastore['PromptChar'] || Msf::Ui::Console::Driver::DefaultPromptChar
     if Rex::Compat.is_windows
-      driver.update_prompt("#{prompt} #{mod.type}(%bld%red#{mod.shortname}%clr) ", prompt_char, true)
-    else
       driver.update_prompt("#{prompt} #{mod.type}(#{mod.shortname}) ", prompt_char, true)
+    else
+      driver.update_prompt("#{prompt} #{mod.type}(%bld%red#{mod.shortname}%clr) ", prompt_char, true)
     end
   end
 

--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1555,7 +1555,11 @@ class Core
     if active_module
       # intentionally += and not << because we don't want to modify
       # datastore or the constant DefaultPrompt
-      prompt += " #{active_module.type}(%bld%red#{active_module.shortname}%clr)"
+      if Rex::Compat.is_windows
+        prompt += " #{active_module.type}(%bld%red#{active_module.shortname}%clr)"
+      else
+        prompt += " #{active_module.type}(#{active_module.shortname})"
+      end
     end
     prompt_char = framework.datastore['PromptChar'] || Msf::Ui::Console::Driver::DefaultPromptChar
     driver.update_prompt("#{prompt} ", prompt_char, true)
@@ -2396,7 +2400,11 @@ class Core
     # Update the command prompt
     prompt = framework.datastore['Prompt'] || Msf::Ui::Console::Driver::DefaultPrompt
     prompt_char = framework.datastore['PromptChar'] || Msf::Ui::Console::Driver::DefaultPromptChar
-    driver.update_prompt("#{prompt} #{mod.type}(%bld%red#{mod.shortname}%clr) ", prompt_char, true)
+    if Rex::Compat.is_windows
+      driver.update_prompt("#{prompt} #{mod.type}(%bld%red#{mod.shortname}%clr) ", prompt_char, true)
+    else
+      driver.update_prompt("#{prompt} #{mod.type}(#{mod.shortname}) ", prompt_char, true)
+    end
   end
 
   #

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -26,6 +26,11 @@ class Driver < Msf::Ui::Driver
   DefaultPrompt     = "%undmsf%clr"
   DefaultPromptChar = "%clr>"
 
+  if Rex::Compat.is_windows
+    DefaultPrompt     = "msf"
+    DefaultPromptChar = ">"
+  end
+
   #
   # The console driver processes various framework notified events.
   #

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -23,13 +23,8 @@ class Driver < Msf::Ui::Driver
   ConfigCore  = "framework/core"
   ConfigGroup = "framework/ui/console"
 
-  DefaultPrompt     = "%undmsf%clr"
-  DefaultPromptChar = "%clr>"
-
-  if Rex::Compat.is_windows
-    DefaultPrompt     = "msf"
-    DefaultPromptChar = ">"
-  end
+  DefaultPrompt     = Rex::Compat.is_windows ? "msf" : "%undmsf%clr"
+  DefaultPromptChar = Rex::Compat.is_windows ? ">" : "%clr>"
 
   #
   # The console driver processes various framework notified events.


### PR DESCRIPTION
Fix #4259.

On Windows, the msf prompt is unable to parse and render the color codes. It also causes the prompt to be almost unusable, as in you can't really see what you type. So this fix will not use ANSI codes for the default prompt for Windows.

Also:
- Kali doesn't seem to be affected by this.
- Only the msf prompt is having this issue. Other parts that use ANSI codes seem to be working fine.
## For users who are currently experiencing this issue

If you see stuff like `<[ 4m<-[0m<-[36mmsf-pro` on your console .... know that this fix does not actually fix that particular prompt. Instead, that is a Pro-specific prompt (not framework), so you will have to wait for Pro's fix to merge.

While waiting for the patches to be merged, as an user you can do the following at your prompt as a temporary workaround:

```
color false
```
