### PR TITLE
Update frontpage_login.rb

### DIFF
--- a/modules/auxiliary/scanner/http/frontpage_login.rb
+++ b/modules/auxiliary/scanner/http/frontpage_login.rb
@@ -48,7 +48,7 @@ class Metasploit3 < Msf::Auxiliary
     connect
 
     sock.put("GET /_vti_inf.html HTTP/1.1\r\n" + "TE: deflate,gzip;q=0.3\r\n" + "Keep-Alive: 300\r\n" +
-        "Connection: Keep-Alive, TE\r\n" + "Host: #{target_host}\r\n" + "User-Agent: " +
+        "Connection: Keep-Alive, TE\r\n" + "Host: #{vhost}\r\n" + "User-Agent: " +
         datastore['UserAgent'] + "\r\n\r\n")
 
     res = sock.get_once || ''
@@ -95,8 +95,9 @@ class Metasploit3 < Msf::Auxiliary
     method = "method=open+service:#{fpversion}&service_name=/"
 
     req = "POST /_vti_bin/_vti_aut/author.dll HTTP/1.1\r\n" + "TE: deflate,gzip;q=0.3\r\n" +
-      "Keep-Alive: 300\r\n" + "Connection: Keep-Alive, TE\r\n" + "Host: #{target_host}\r\n" +
+      "Keep-Alive: 300\r\n" + "Connection: Keep-Alive, TE\r\n" + "Host: #{vhost}\r\n" +
       "User-Agent: " + datastore['UserAgent'] + "\r\n" + "Content-Type: application/x-www-form-urlencoded\r\n" +
+      "X-Vermeer-Content-Type: application/x-www-form-urlencoded" + "\r\n" +
       "Content-Length: #{method.length}\r\n\r\n" + method + "\r\n\r\n"
 
     sock.put(req)


### PR DESCRIPTION
Vhost is now used if specified.
Added X-Vermeer-Content-Type header, which seems to be required for the RPC service otherwise server responds with:

```
method=
status=

status=262147
osstatus=0
msg=No "CONTENT_TYPE" on CGI environment.
osmsg=
```
