### PR TITLE
Add exploit for CVE-2014-5445, NetFlow Analyzer arbitrary download

### DIFF
--- a/modules/auxiliary/admin/http/netflow_file_download.rb
+++ b/modules/auxiliary/admin/http/netflow_file_download.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           [ 'CVE', '2014-5445' ],
-          [ 'OSVDB', '115341' ],
+          [ 'OSVDB', '115340' ],
           [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/ManageEngine/me_netflow_it360_file_dl.txt' ],
           [ 'URL', 'http://seclists.org/fulldisclosure/2014/Dec/9' ]
         ],

--- a/modules/auxiliary/admin/http/netflow_file_download.rb
+++ b/modules/auxiliary/admin/http/netflow_file_download.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Auxiliary
       'References'     =>
         [
           [ 'CVE', '2014-5445' ],
-          [ 'OSVDB', 'TODO' ],
+          [ 'OSVDB', '115341' ],
           [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/ManageEngine/me_netflow_it360_file_dl.txt' ],
           [ 'URL', 'http://seclists.org/fulldisclosure/2014/Dec/9' ]
         ],

--- a/modules/auxiliary/admin/http/netflow_file_download.rb
+++ b/modules/auxiliary/admin/http/netflow_file_download.rb
@@ -29,7 +29,7 @@ class Metasploit3 < Msf::Auxiliary
           [ 'CVE', '2014-5445' ],
           [ 'OSVDB', 'TODO' ],
           [ 'URL', 'https://raw.githubusercontent.com/pedrib/PoC/master/ManageEngine/me_netflow_it360_file_dl.txt' ],
-          [ 'URL', 'FULLDISC_URL' ]
+          [ 'URL', 'http://seclists.org/fulldisclosure/2014/Dec/9' ]
         ],
       'DisclosureDate' => 'Nov 30 2014'))
 


### PR DESCRIPTION
This PR adds an exploit for CVE-2014-5445, a 0-day vulnerability in ManageEngine NetFlow Analyzer that allows an unauthenticated user to download any file in the system. This works on both Linux and Windows, and has been tested extensively with all vulnerable versions (8.6 to 10.2).

All that is left is to add the OSVDB ID and the full disclosure URL, and as usual those come up in 2 or 3 days max. I will push those when they come up, please have a look and let me know what you think.
