### PR TITLE
Comment out boot cucumber tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 env:
   - RAKE_TASK=cucumber
-  - RAKE_TASK=cucumber:boot
+# Commenting out the boot tests due to chronic timeouts.
+#  - RAKE_TASK=cucumber:boot
   - RAKE_TASK=spec SPEC_OPTS="--tag content"
   - RAKE_TASK=spec SPEC_OPTS="--tag ~content"
 


### PR DESCRIPTION
This is in response to the slowness noticed over the last few days and unrelated changes causing travis failures. For example:

https://github.com/rapid7/metasploit-framework/pull/4252#issuecomment-64923343
## Verification
- [x] See that this PR does not include the 30-60 minute cucumber boot tests, such as the ones on https://travis-ci.org/rapid7/metasploit-framework/builds/42627993
- [x] See that this PR is green.

/cc @lsanchez-r7 @limhoff-r7 
