### PR TITLE
Fix modules that still use os_flavor to detect Windows version

### DIFF
--- a/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
+++ b/modules/exploits/windows/browser/ie_setmousecapture_uaf.rb
@@ -54,10 +54,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'BrowserRequirements' =>
         {
           :source    => /script/i,
-          :os_name   => OperatingSystems::WINDOWS,
+          :os_name   => 'Windows 7',
           :ua_name   => HttpClients::IE,
           :ua_ver    => "9.0",
-          :os_flavor => "7",
           :office    => /2007|2010/
         },
       'Targets'        =>

--- a/modules/exploits/windows/browser/ms13_059_cflatmarkuppointer.rb
+++ b/modules/exploits/windows/browser/ms13_059_cflatmarkuppointer.rb
@@ -58,10 +58,9 @@ class Metasploit3 < Msf::Exploit::Remote
       'BrowserRequirements' =>
         {
           :source       => /script/i,
-          :os_name      => OperatingSystems::WINDOWS,
+          :os_name      => 'Windows 7',
           :ua_name      => HttpClients::IE,
           :ua_ver       => "9.0",
-          :os_flavor    => "7",
           :java         => /1\.6|6\.0/,
           :mshtml_build => lambda { |ver| ver.to_i.between?(16446, 16490) } # May 17 mshtml to MS13-Jun
         },

--- a/modules/exploits/windows/browser/ms14_012_cmarkup_uaf.rb
+++ b/modules/exploits/windows/browser/ms14_012_cmarkup_uaf.rb
@@ -44,8 +44,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'BrowserRequirements' =>
         {
           :source      => /script|headers/i,
-          :os_name     => Msf::OperatingSystems::WINDOWS,
-          :os_flavor   => Msf::OperatingSystems::WindowsVersions::SEVEN,
+          :os_name     => 'Windows 7',
           :ua_name     => Msf::HttpClients::IE,
           :ua_ver      => '10.0',
           :mshtml_build => lambda { |ver| ver.to_i < 16843 },


### PR DESCRIPTION
This is for https://github.com/rapid7/metasploit-framework/issues/4283.

Since #3373, we no longer use os_flavor to detect Windows version. If we want to specify a Windows 7 target, then the module should set os_name to 'Windows 7'.

To verify:
- [x] Get a Win 7 box (unpatched). It does not actually matter what IE you have, or 3rd party DLL. You don't need to get a shell.
- [x] Start msfconsole
- [x] Before you test each module, make sure you `set verbose true`
- [x] Test ie_setmousecapture_uaf.rb against that Windows box, make sure you don't see os_flavor being an unmet requirement.
- [x] Test ms13_059_cflatmarkuppointer.rb against the same box, also make sure you don't see os_flavor being an unmet requirement.
- [x] Test ms14_012_cmarkup_uaf.rb, once again make sure you don't see os_flavor being an unmet requirement.
