### PR TITLE
Remove double call to init_module_paths from msfconsole boot

### DIFF
--- a/lib/msf/base/simple/framework/module_paths.rb
+++ b/lib/msf/base/simple/framework/module_paths.rb
@@ -7,26 +7,32 @@ module Msf
         #
         # @return [void]
         def init_module_paths(opts={})
-          # Ensure the module cache is accurate
-          self.modules.refresh_cache_from_database
+          if @module_paths_inited
+            fail "Module paths already initialized.  To add more module paths call `modules.add_module_path`"
+          else
+            # Ensure the module cache is accurate
+            self.modules.refresh_cache_from_database
 
-          add_engine_module_paths(Rails.application, opts)
+            add_engine_module_paths(Rails.application, opts)
 
-          Rails.application.railties.engines.each do |engine|
-            add_engine_module_paths(engine, opts)
-          end
+            Rails.application.railties.engines.each do |engine|
+              add_engine_module_paths(engine, opts)
+            end
 
-          # Initialize the user module search path
-          if (Msf::Config.user_module_directory)
-            self.modules.add_module_path(Msf::Config.user_module_directory, opts)
-          end
+            # Initialize the user module search path
+            if (Msf::Config.user_module_directory)
+              self.modules.add_module_path(Msf::Config.user_module_directory, opts)
+            end
 
-          # If additional module paths have been defined globally, then load them.
-          # They should be separated by semi-colons.
-          if self.datastore['MsfModulePaths']
-            self.datastore['MsfModulePaths'].split(";").each { |path|
-              self.modules.add_module_path(path, opts)
-            }
+            # If additional module paths have been defined globally, then load them.
+            # They should be separated by semi-colons.
+            if self.datastore['MsfModulePaths']
+              self.datastore['MsfModulePaths'].split(";").each { |path|
+                self.modules.add_module_path(path, opts)
+              }
+            end
+
+            @module_paths_inited = true
           end
         end
 

--- a/lib/msf/ui/console/driver.rb
+++ b/lib/msf/ui/console/driver.rb
@@ -59,7 +59,10 @@ class Driver < Msf::Ui::Driver
     histfile = opts['HistFile'] || Msf::Config.history_file
 
     # Initialize attributes
-    self.framework = opts['Framework'] || Msf::Simple::Framework.create(opts)
+
+    # Defer loading of modules until paths from opts can be added below
+    framework_create_options = {'DeferModuleLoads' => true}.merge(opts)
+    self.framework = opts['Framework'] || Msf::Simple::Framework.create(framework_create_options)
 
     if self.framework.datastore['Prompt']
       prompt = self.framework.datastore['Prompt']


### PR DESCRIPTION
MSP-11672

`Msf::Simple::Framework#create` calls `framework.modules.init_module_paths` if `'DeferModuleLoads' => true` is not passed.  `msfconsole` calls `Msf::Ui::Console::Driver#initialize`, which calls `Msf::Simple::Create#create`, which caused the first `framework/modules.init_module_paths`.  Further in `Msf::Ui::Console::Driver#initialize`, it calls `framework.modules.init_modules_paths`.  Calling `init_module_paths` twice does no cause modules to be loaded twice: the mtime check in `load_module` prevents that, but just having to enumerate all the files under `modules` and get their mtime takes ~6 seconds on my machine.  Therefore, I removed the first call by passing `'DeferModuleLoads' => true` when `Driver#initialize` calls `Msf::Simple::Framework#create`.  I also added a flag to `fail` if `init_module_paths` is called multiple times in the future.  Real time for `msfconsole -q -x exit` dropped from 13.31 seconds to 6.98 seconds (-47.53%).  Times will differ on other machines where the balance of CPU to process the module code and disk speed to enumerate files and retrieve mtime for each file differs from my setup (I have an SSD for example).  Raw data is [available](https://docs.google.com/spreadsheets/d/1dmNo5M_vED1gO7wfnMtPC9KVJ17Y6ypQEFzqpZhT6MM/edit?usp=sharing)
![screen shot 2014-12-02 at 11 32 53 am](https://cloud.githubusercontent.com/assets/2230482/5267480/fc550244-7a16-11e4-8bf5-2104d4dd7a6b.png)
# Verification Steps
## Old time
- [x] `git checkout 394d132d33d1b87fd54bd1b73b21d7a8822e7095`
- [x] Use a `time` that will report realtime (zsh's builtin won't) and disable banners as printing them adds noise: `/usr/bin/time msfconsole -q -x` 
- [x] Record real time
## New time
- [x] `git checkout 90c6764426d9341c260f6d86408e0b7fcf08c5ca`
- [x] Use a `time` that will report realtime (zsh's builtin won't) and disable banners as printing them adds noise: `/usr/bin/time msfconsole -q -x` 
- [x] Record real time
- [x] Verify new time is faster.
## msfconsole boots with modules
- [x] `git checkout bugs/MSP-11672/double-init-module-paths`
- [x] `msfconsole`
- [x] VERIFY banner shows non-zero module counts
- [x] `use exploit/windows/smb/ms08_067_netapi`
- [x] VERIFY module was loaded without error
