### PR TITLE
Fix #4293 - Use OperatingSystems::Match::WINDOWS

### DIFF
--- a/modules/exploits/windows/browser/adobe_flash_avm2.rb
+++ b/modules/exploits/windows/browser/adobe_flash_avm2.rb
@@ -68,7 +68,7 @@ class Metasploit3 < Msf::Exploit::Remote
           :source  => /script|headers/i,
           :clsid   => "{D27CDB6E-AE6D-11cf-96B8-444553540000}",
           :method  => "LoadMovie",
-          :os_name => Msf::OperatingSystems::WINDOWS,
+          :os_name => OperatingSystems::Match::WINDOWS,
           :ua_name => Msf::HttpClients::IE,
           :flash   => lambda { |ver| ver =~ /^11\./ }
         },

--- a/modules/exploits/windows/browser/adobe_flash_filters_type_confusion.rb
+++ b/modules/exploits/windows/browser/adobe_flash_filters_type_confusion.rb
@@ -53,7 +53,7 @@ class Metasploit3 < Msf::Exploit::Remote
           :source  => /script|headers/i,
           :clsid   => "{D27CDB6E-AE6D-11cf-96B8-444553540000}",
           :method  => "LoadMovie",
-          :os_name => Msf::OperatingSystems::WINDOWS,
+          :os_name => OperatingSystems::Match::WINDOWS,
           :ua_name => Msf::HttpClients::IE,
           :flash   => lambda { |ver| ver =~ /^11\.[7|8|9]/ && ver < '11.9.900.170' }
         },

--- a/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb
+++ b/modules/exploits/windows/browser/adobe_flash_pixel_bender_bof.rb
@@ -51,7 +51,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'BrowserRequirements' =>
         {
           :source  => /script|headers/i,
-          :os_name => Msf::OperatingSystems::WINDOWS,
+          :os_name => OperatingSystems::Match::WINDOWS,
           :ua_name => lambda { |ua| ua == Msf::HttpClients::IE || ua == Msf::HttpClients::FF || ua == Msf::HttpClients::SAFARI},
           :flash   => lambda { |ver| ver =~ /^11\./ || ver =~ /^12\./ || (ver =~ /^13\./ && ver <= '13.0.0.182') }
         },

--- a/modules/exploits/windows/browser/adobe_flash_regex_value.rb
+++ b/modules/exploits/windows/browser/adobe_flash_regex_value.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Exploit::Remote
           :source  => /script|headers/i,
           :clsid   => "{D27CDB6E-AE6D-11cf-96B8-444553540000}",
           :method  => "LoadMovie",
-          :os_name => Msf::OperatingSystems::WINDOWS,
+          :os_name => OperatingSystems::Match::WINDOWS,
           :ua_name => Msf::HttpClients::IE,
           :flash   => lambda { |ver| ver =~ /^11\.5/ && ver < '11.5.502.149' }
         },

--- a/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
+++ b/modules/exploits/windows/browser/advantech_webaccess_dvs_getcolor.rb
@@ -40,7 +40,7 @@ class Metasploit3 < Msf::Exploit::Remote
       'BrowserRequirements' =>
         {
           :source  => /script|headers/i,
-          :os_name => Msf::OperatingSystems::WINDOWS,
+          :os_name => OperatingSystems::Match::WINDOWS,
           :ua_name => /MSIE/i,
           :ua_ver  => lambda { |ver| Gem::Version.new(ver) <  Gem::Version.new('10') },
           :clsid   => "{5CE92A27-9F6A-11D2-9D3D-000001155641}",


### PR DESCRIPTION
Fix #4293. Modules should use OperatingSystems::Match::WINDOWS instead of Msf::OperatingSystems::WINDOWS, because the second won't match anything anymore.

To verify:

All the modules can be verified the same way. I'm just gonna use advantech_webaccess_dvs_getcolor as an example:
- [x] Set up a Windows box. In my test, I used a Windows 7.
- [x] Start msfconsole
- [x] Do: `use exploit/windows/browser/advantech_webaccess_dvs_getcolor`
- [x] Run the module
- [x] When your IE browser visits the malicious link, you should not see "os_name" being an unmet requirement.
