### PR TITLE
Allow replicant objects to be extended by arbitrary Ruby code

### DIFF
--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -53,6 +53,10 @@ class Module
   include Msf::Module::UI
   include Msf::Module::UUID
 
+  # The key where a comma-separated list of Ruby module names will live in the
+  # datastore, consumed by #replicant to allow clean override of MSF module methods.
+  REPLICANT_EXTENSION_DS_KEY = 'ReplicantExtensions'
+
   # Make include public so we can runtime extend
   public_class_method :include
 
@@ -142,7 +146,6 @@ class Module
   # Creates a fresh copy of an instantiated module
   #
   def replicant
-
     obj = self.class.new
     self.instance_variables.each { |k|
       v = instance_variable_get(k)
@@ -154,7 +157,38 @@ class Module
     obj.user_input   = self.user_input
     obj.user_output  = self.user_output
     obj.module_store = self.module_store.clone
+
+    obj.perform_extensions
     obj
+  end
+
+  # Extends self with the constant list in the datastore
+  # @return [void]
+  def perform_extensions
+    if datastore[REPLICANT_EXTENSION_DS_KEY].present?
+      if datastore[REPLICANT_EXTENSION_DS_KEY].respond_to?(:each)
+        datastore[REPLICANT_EXTENSION_DS_KEY].each do |const_name|
+          self.extend(const_name.constantize)
+        end
+      else
+        fail "Invalid settings in datastore at key #{REPLICANT_EXTENSION_DS_KEY}"
+      end
+    end
+  end
+
+  # @overload register_extensions(name)
+  #   @param[String] name of Ruby module
+  #
+  # @overload register_extensions(name_array)
+  #   @param[Array<String>] name_array array of Ruby module names
+  #
+  # @return [void]
+  def register_extensions(*rb_modules)
+    datastore[REPLICANT_EXTENSION_DS_KEY] = [] unless datastore[REPLICANT_EXTENSION_DS_KEY].present?
+    rb_modules.each do |rb_mod|
+      name = rb_mod.name
+      datastore[REPLICANT_EXTENSION_DS_KEY] << name unless datastore[REPLICANT_EXTENSION_DS_KEY].include? name
+    end
   end
 
   #

--- a/lib/msf/core/module.rb
+++ b/lib/msf/core/module.rb
@@ -167,8 +167,8 @@ class Module
   def perform_extensions
     if datastore[REPLICANT_EXTENSION_DS_KEY].present?
       if datastore[REPLICANT_EXTENSION_DS_KEY].respond_to?(:each)
-        datastore[REPLICANT_EXTENSION_DS_KEY].each do |const_name|
-          self.extend(const_name.constantize)
+        datastore[REPLICANT_EXTENSION_DS_KEY].each do |const|
+          self.extend(const)
         end
       else
         fail "Invalid settings in datastore at key #{REPLICANT_EXTENSION_DS_KEY}"
@@ -176,18 +176,12 @@ class Module
     end
   end
 
-  # @overload register_extensions(name)
-  #   @param[String] name of Ruby module
-  #
-  # @overload register_extensions(name_array)
-  #   @param[Array<String>] name_array array of Ruby module names
-  #
+  # @param[Constant] One or more Ruby constants
   # @return [void]
   def register_extensions(*rb_modules)
     datastore[REPLICANT_EXTENSION_DS_KEY] = [] unless datastore[REPLICANT_EXTENSION_DS_KEY].present?
     rb_modules.each do |rb_mod|
-      name = rb_mod.name
-      datastore[REPLICANT_EXTENSION_DS_KEY] << name unless datastore[REPLICANT_EXTENSION_DS_KEY].include? name
+      datastore[REPLICANT_EXTENSION_DS_KEY] << rb_mod unless datastore[REPLICANT_EXTENSION_DS_KEY].include? rb_mod
     end
   end
 

--- a/spec/lib/msf/core/module_spec.rb
+++ b/spec/lib/msf/core/module_spec.rb
@@ -45,4 +45,50 @@ describe Msf::Module do
     it { is_expected.to respond_to :cached? }
     it { is_expected.to respond_to :is_usable }
   end
+
+  describe "cloning modules into replicants" do
+    module MsfExtensionTestFoo; def my_test1; true; end; end;
+    module MsfExtensionTestBar; def my_test2; true; end; end;
+
+    describe "#perform_extensions" do
+      describe "when there are extensions registered" do
+        before(:each) do
+          msf_module.register_extensions(MsfExtensionTestFoo, MsfExtensionTestBar)
+        end
+
+        it 'should extend the module replicant with the constants referenced in the datastore' do
+          expect(msf_module.replicant).to respond_to(:my_test1)
+          expect(msf_module.replicant).to respond_to(:my_test2)
+        end
+      end
+
+      describe "when the datastore key has invalid data" do
+        before(:each) do
+          msf_module.datastore[Msf::Module::REPLICANT_EXTENSION_DS_KEY] = "invalid"
+        end
+
+        it 'should raise an exception' do
+          expect{msf_module.replicant}.to raise_error(RuntimeError)
+        end
+      end
+    end
+
+    describe "#register_extensions" do
+      describe "with single module" do
+        it 'should place the named module in the datastore' do
+          msf_module.register_extensions(MsfExtensionTestFoo)
+          expect(msf_module.replicant.datastore[Msf::Module::REPLICANT_EXTENSION_DS_KEY]).to eql(["MsfExtensionTestFoo"])
+        end
+      end
+
+      describe "with multiple modules" do
+        it 'should place the named modules in the datastore' do
+          msf_module.register_extensions(MsfExtensionTestFoo, MsfExtensionTestBar)
+          expect(msf_module.replicant.datastore[Msf::Module::REPLICANT_EXTENSION_DS_KEY]).to eql(["MsfExtensionTestFoo", "MsfExtensionTestBar"])
+        end
+      end
+
+    end
+  end
+
 end

--- a/spec/lib/msf/core/module_spec.rb
+++ b/spec/lib/msf/core/module_spec.rb
@@ -77,14 +77,14 @@ describe Msf::Module do
       describe "with single module" do
         it 'should place the named module in the datastore' do
           msf_module.register_extensions(MsfExtensionTestFoo)
-          expect(msf_module.replicant.datastore[Msf::Module::REPLICANT_EXTENSION_DS_KEY]).to eql(["MsfExtensionTestFoo"])
+          expect(msf_module.replicant.datastore[Msf::Module::REPLICANT_EXTENSION_DS_KEY]).to eql([MsfExtensionTestFoo])
         end
       end
 
       describe "with multiple modules" do
         it 'should place the named modules in the datastore' do
           msf_module.register_extensions(MsfExtensionTestFoo, MsfExtensionTestBar)
-          expect(msf_module.replicant.datastore[Msf::Module::REPLICANT_EXTENSION_DS_KEY]).to eql(["MsfExtensionTestFoo", "MsfExtensionTestBar"])
+          expect(msf_module.replicant.datastore[Msf::Module::REPLICANT_EXTENSION_DS_KEY]).to eql([MsfExtensionTestFoo, MsfExtensionTestBar])
         end
       end
 


### PR DESCRIPTION
### Verification
- [x] Have some code that uses `run_simple` or `exploit_simple` and therefore calls `Msf::Module#replicant`
- [x] Write a Ruby module that overrides MSF psuedo-callback methods like `on_new_session` or `start_session`
- [x] Before calling `run_simple` or `exploit_simple` on a loaded module, use the `Msf::Module#register_extensions` method like this:

``` ruby
msf_module.register_extensions(MyCoolRubyModule)
```
- [x] Allow the call to `run_simple` or `exploit_simple` to run as normal
- [x] VERIFY: your method was called automatically and not the default implementation for the particular MSF module you are running.
