### PR TITLE
Bump metasploit-credential version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
     metasploit-concern (0.3.0)
       activesupport (~> 3.0, >= 3.0.0)
       railties (< 4.0.0)
-    metasploit-credential (0.13.3)
+    metasploit-credential (0.13.5)
       metasploit-concern (~> 0.3.0)
       metasploit-model (~> 0.28.0)
       metasploit_data_models (~> 0.21.0)


### PR DESCRIPTION
See rapid7/metasploit-credential#80

Fix to `metasploit-credential` ensures that we always record a `task_id` when creating credentials, if it's supplied.
## Verification steps
- [ ] Travis passes
