### PR TITLE
Fix #3886 - Backtrace for #check when session is invalid

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -113,6 +113,8 @@ module Auxiliary
     # be normalized
     mod.validate
 
+    mod.setup
+
     # Run check
     mod.check
   end

--- a/lib/msf/base/simple/exploit.rb
+++ b/lib/msf/base/simple/exploit.rb
@@ -182,6 +182,8 @@ module Exploit
     # be normalized
     mod.validate
 
+    mod.setup
+
     # Run check
     mod.check
   end

--- a/lib/msf/core/post/common.rb
+++ b/lib/msf/core/post/common.rb
@@ -3,6 +3,8 @@
 module Msf::Post::Common
 
   def rhost
+    return nil unless session
+
     case session.type
     when 'meterpreter'
       session.sock.peerhost


### PR DESCRIPTION
If the user supplies an invalid session (as in not on the session list), it will cause a backtrace, because the setup method from Msf::PostMixin isn't actually called.

We have thought about implementing this in a new OptSession instead. But you can't use or even pass framework to option_container.rb, so this is NOT possible.

The original PR was #3956.
## Verification
- [x] Make sure the check command works when **RHOSTS** is set for an **exploit module**. I used ms08_067_netapi for this, here's an example:

```
msf exploit(ms08_067_netapi) > set rhosts 192.168.1.75-192.168.1.85
rhosts => 192.168.1.75-192.168.1.85
msf exploit(ms08_067_netapi) > check
[*] 192.168.1.75:445 - Cannot reliably check exploitability.
 ...
[+] 192.168.1.80:445 - The target is vulnerable.
[*] 192.168.1.81:445 - Cannot reliably check exploitability.
 ...
```
- [x] Make sure the check command works when **RHOSTS** is set for an **auxiliary module**.  I used apache_mod_cgi_bash_env for this, here's an example:

```
msf auxiliary(apache_mod_cgi_bash_env) > set rhosts 192.168.1.112-192.168.1.114
rhosts => 192.168.1.112-192.168.1.114
msf auxiliary(apache_mod_cgi_bash_env) > set targeturi /cgi-bin/test.sh
targeturi => /cgi-bin/test.sh
msf auxiliary(apache_mod_cgi_bash_env) > check
[*] Checked 1 of 3 hosts (033% complete)
[*] Checked 2 of 3 hosts (066% complete)
[+] 192.168.1.114:80 - The target is vulnerable.
[*] Checked 3 of 3 hosts (100% complete)
```
- [x] Make sure the check command works when **RHOST** is set for an exploit module. I used ms08_067_netapi again for this example:

```
msf exploit(ms08_067_netapi) > set rhost 192.168.1.80
rhost => 192.168.1.80
msf exploit(ms08_067_netapi) > check
[+] 192.168.1.80:445 - The target is vulnerable.
```
- [x] Make sure the check command works for vmware_bash_function_root when a **valid** session is set. You should specifically try vmware_bash_function_root, because that's what the original bug report used. Here's an example of how it should be with the patch:

```
msf exploit(handler) > run -j
[*] Exploit running as background job.

[*] Started reverse handler on 192.168.1.64:4444 
msf exploit(handler) > [*] Starting the payload handler...
[*] Command shell session 1 opened (192.168.1.64:4444 -> 192.168.1.64:49796) at 2014-09-30 15:27:32 -0500

msf exploit(handler) > use exploit/osx/local/vmware_bash_function_root 
msf exploit(vmware_bash_function_root) > set session 1
session => 1
msf exploit(vmware_bash_function_root) > check
[+] 192.168.1.64 - The target is vulnerable.
```
- [x] Make sure the check command raises a validation error when an **invalid** session is set for the same vmware_bash_function_root module:

```
msf exploit(vmware_bash_function_root) > set session 2
session => 2
msf exploit(vmware_bash_function_root) > check
[-] Error while running command check: The following options failed to validate: SESSION.
```
