### PR TITLE
Fix getuid for the python meterpreter

### DIFF
--- a/data/meterpreter/ext_server_stdapi.py
+++ b/data/meterpreter/ext_server_stdapi.py
@@ -675,8 +675,10 @@ def channel_open_stdapi_net_tcp_server(request, response):
 @meterpreter.register_function
 def stdapi_sys_config_getenv(request, response):
 	for env_var in packet_enum_tlvs(request, TLV_TYPE_ENV_VARIABLE):
-		pgroup = ''
-		env_var = env_var['value'].translate(None, '%$')
+		pgroup = bytes()
+		env_var = env_var['value']
+		env_var = env_var.replace('%', '')
+		env_var = env_var.replace('$', '')
 		env_val = os.environ.get(env_var)
 		if env_val:
 			pgroup += tlv_pack(TLV_TYPE_ENV_VARIABLE, env_var)

--- a/data/meterpreter/ext_server_stdapi.py
+++ b/data/meterpreter/ext_server_stdapi.py
@@ -698,7 +698,9 @@ def stdapi_sys_config_getsid(request, response):
 
 @meterpreter.register_function
 def stdapi_sys_config_getuid(request, response):
-	if has_windll:
+	if has_pwd:
+		username = pwd.getpwuid(os.getuid()).pw_name
+	elif has_windll:
 		token = get_token_user(ctypes.windll.kernel32.GetCurrentProcess())
 		if not token:
 			return ERROR_FAILURE, response


### PR DESCRIPTION
Currently on non-Windows systems the `getpass.getuser()` function provides the username for `stdapi_sys_config_getuid`. However this function will return an incorrect value when specific environment variables are set (LOGNAME, USER, LNAME, or USERNAME). This PR attempts to fix this by preferring the `pwd` module when it is available which will lookup the correct username based on the UID.

This also fixes an error with `stdapi_sys_config_getenv` when used on Python 3 due to a different implementation of the string `translate` method.

Verification steps:
- [x] Set one of the environment variables specified `export LOGNAME=groot`
- [x] Open a python meterpreter session
- [x] Verify that `getuid` returns the correct username and **not** the value of the environment variable
- [x] Verify that the `getenv` command works as expected from Python 3.x

Example output:

```
msf-git (S:0 J:0) exploit(handler) > exploit

[*] [2014.12.02-21:02:04] Started HTTP reverse handler on http://0.0.0.0:8080/
[*] [2014.12.02-21:02:04] Starting the payload handler...
[*] [2014.12.02-21:02:08] 192.168.90.1:40161 Request received for /QDrI...

meterpreter > getuid
Server username: steiner
meterpreter > getenv LOGNAME

Environment Variables
=====================

Variable  Value
--------  -----
LOGNAME   groot

meterpreter > 
```
