### PR TITLE
Travis shouldnt test gh-pages and friends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,7 @@ data/meterpreter/screenshot.*.dll
 # private source. If you're interested in this functionality,
 # check out Metasploit Pro: http://metasploit.com/download
 data/meterpreter/ext_server_pivot.*.dll
+
+# Avoid checking in metakitty, the source for
+# https://rapid7.github.io/metasploit-framework. It's an orphan branch.
+/metakitty

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,9 @@ notifications:
 
 git:
   depth: 5
+
+# Blacklist certain branches from triggering travis builds
+branches:
+  except:
+    - gh-pages
+    - metakitty


### PR DESCRIPTION
This adds a blacklist of branches that Travis shouldn't run tests against.
## Verification
- [x] Builds like [this one](https://travis-ci.org/rapid7/metasploit-framework/builds/42902010) should cease to be.

gh-pages and metakitty are the builds and the source (respectively) for http://rapid7.github.io/metasploit-framework, and shouldn't be tested yet.
