### PR TITLE
Remove NETMASK option from Capture, fixing functionality on networks with a netmask other than /24

### DIFF
--- a/lib/msf/core/exploit/capture.rb
+++ b/lib/msf/core/exploit/capture.rb
@@ -39,7 +39,6 @@ module Msf
           [
             OptInt.new('UDP_SECRET', [true, 'The 32-bit cookie for UDP probe requests.', 1297303091]),
             OptAddress.new('GATEWAY', [false, 'The gateway IP address. This will be used rather than a random remote address for the UDP probe, if set.']),
-            OptInt.new('NETMASK', [false, 'The local network mask. This is used to decide if an address is in the local network.', 24]),
           ], Msf::Exploit::Capture
         )
 
@@ -402,9 +401,11 @@ module Msf
       def lookupnet
         check_pcaprub_loaded
         dev  = datastore['INTERFACE'] || ::Pcap.lookupdev
-        mask = datastore['NETMASK'] || 24
         begin
-          my_net = IPAddr.new("#{Pcap.lookupnet(dev).first}/#{mask}")
+          my_ip, my_mask = Pcap.lookupnet(dev)
+          # convert the netmask obtained from the relevant interface to CIDR
+          cidr_mask = my_mask.to_s(2).count('1')
+          my_net = IPAddr.new("#{my_ip}/#{cidr_mask}")
         rescue RuntimeError => e
           @pcaprub_error = e
           print_status("Cannot stat device: #{@pcaprub_error}")
@@ -414,10 +415,7 @@ module Msf
       end
 
       def should_arp?(ip)
-        @mydev  ||= datastore['INTERFACE'] || ::Pcap.lookupdev
-        @mymask ||= datastore['NETMASK'] || 24
-        @mynet  ||= lookupnet
-        @mynet.include?(IPAddr.new(ip))
+        lookupnet.include?(IPAddr.new(ip))
       end
 
       attr_accessor :capture, :arp_cache, :arp_capture, :dst_cache

--- a/modules/auxiliary/scanner/discovery/arp_sweep.rb
+++ b/modules/auxiliary/scanner/discovery/arp_sweep.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Auxiliary
       OptInt.new('TIMEOUT', [true, 'The number of seconds to wait for new data', 5]),
     ], self.class)
 
-    deregister_options('SNAPLEN', 'FILTER', 'PCAPFILE', 'UDP_SECRET', 'GATEWAY', 'NETMASK')
+    deregister_options('SNAPLEN', 'FILTER', 'PCAPFILE', 'UDP_SECRET', 'GATEWAY')
   end
 
   def run_batch_size

--- a/modules/auxiliary/server/icmp_exfil.rb
+++ b/modules/auxiliary/server/icmp_exfil.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Auxiliary
       OptAddress.new('LOCALIP', [false, 'The IP address of the local interface'])
     ], self.class)
 
-    deregister_options('SNAPLEN','FILTER','PCAPFILE','RHOST','UDP_SECRET','GATEWAY','NETMASK', 'TIMEOUT')
+    deregister_options('SNAPLEN','FILTER','PCAPFILE','RHOST','UDP_SECRET','GATEWAY', 'TIMEOUT')
   end
 
   def run

--- a/modules/auxiliary/spoof/arp/arp_poisoning.rb
+++ b/modules/auxiliary/spoof/arp/arp_poisoning.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Auxiliary
       OptBool.new(  'BROADCAST',    	[true, 'If set, the module will send replies on the broadcast address witout consideration of DHOSTS', false])
     ], self.class)
 
-    deregister_options('SNAPLEN', 'FILTER', 'PCAPFILE','RHOST','UDP_SECRET','GATEWAY','NETMASK')
+    deregister_options('SNAPLEN', 'FILTER', 'PCAPFILE','RHOST','UDP_SECRET','GATEWAY')
   end
 
   def run

--- a/modules/auxiliary/spoof/replay/pcap_replay.rb
+++ b/modules/auxiliary/spoof/replay/pcap_replay.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Auxiliary
       OptInt.new('PKT_DELAY', [true, "the delay in millisecond between each packet",0]),
     ], self.class)
 
-    deregister_options('SNAPLEN','FILTER','PCAPFILE','RHOST','TIMEOUT','UDP_SECRET','GATEWAY','NETMASK')
+    deregister_options('SNAPLEN','FILTER','PCAPFILE','RHOST','TIMEOUT','UDP_SECRET','GATEWAY')
   end
 
   def run

--- a/modules/exploits/windows/misc/wireshark_packet_dect.rb
+++ b/modules/exploits/windows/misc/wireshark_packet_dect.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     ], self.class)
 
-    deregister_options('FILTER','PCAPFILE','RHOST','SNAPLEN','TIMEOUT','UDP_SECRET','NETMASK','GATEWAY')
+    deregister_options('FILTER','PCAPFILE','RHOST','SNAPLEN','TIMEOUT','UDP_SECRET','GATEWAY')
   end
 
   def junk


### PR DESCRIPTION
As explained in #4306, the `NETMASK` option has a suboptimal default value that causes many Capture modules to function improperly on some networks with a netmask larger (and perhaps smaller) than `/24`.  This simply removes this option entirely and calculates the correct netmask by getting it directly from Pcap.

To see this bug in action, and similarly to confirm it is fixed, you need two hosts (A and B) in the same broadcast domain with default gateway G (which is not A or B) and CIDR netmask N.  They have MACs MAC-A, MAC-B and MAC-G.  They do _not_ need to be running any particular services or be configured in any particular way -- simply responding to ARP requests is sufficient.
- [ ] Pick a module that utilizes `capture_sendto`.  For this example, I'm using `exploit/multi/ids/snort_dce_rpc`
- [ ] On `A`, run `tcpdump` with a filter that will only capture traffic from the module above -- `tcpdump -eni eth0 '(ether host MAC-A and arp) or ((ether host MAC-B or ether host MAC-G)' and port 139)'` (this will show any ARPs sent by A as well as any port 139 traffic supposedly sent by the module, however you should tune this if you would normally have port 139 traffic flowing between A and B or G)
- [ ] On `B`, run the same `tcpdump` 
- [ ] From `A`, set the appropriate module options (in this case, simply `RHOST`) and run the module.  Do _not_ set `NETMASK`
- [ ] Notice that both A and B's tcpdumps show several ARPs and that the destination MAC of the port 139 traffic is MAC-B.
- [ ] Set `NETMASK` to something  more restrictive than `N` (if it was originally 24, try 31).  Stop and restart the tcpdumps.  Re-run the module.
- [ ] Notice that the destination MAC of A's 139 traffic is MAC-G.  Depending on how G is configured, you may see this traffic forwarded on to B.  

By doing this you are simulating what is happening when the default `NETMASK` of 24 is smaller than the actual netmask in use (mine was a /20).

To confirm that this introduces no ill side effects and that the correct netmask is used regardless of what is actually configured (rather than just assuming /24), you'll need to recreate the previously described setup but with two different netmasks:
- [ ] Configure A, B and G with a netmask of 24.
- [ ] Pick a module that utilizes `capture_sendto`.  For this example, I'm using `exploit/multi/ids/snort_dce_rpc`
- [ ] On `A`, run `tcpdump` with a filter that will only capture traffic from the module above -- `tcpdump -eni eth0 '(ether host MAC-A and arp) or ((ether host MAC-B or ether host MAC-G)' and port 139)'` (this will show any ARPs sent by A as well as any port 139 traffic supposedly sent by the module, however you should tune this if you would normally have port 139 traffic flowing between A and B or G)
- [ ] On `B`, run the same `tcpdump` 
- [ ] From `A`, set the appropriate module options (in this case, simply `RHOST`) and run the module.
- [ ] Notice that both A and B's tcpdumps show several ARPs and that the destination MAC of the port 139 traffic is MAC-B.
- [ ] Reconfigure A, B and G with a netmask other than 24 that, when applied to the network in question, includes A, B and G.  Picking something less restrictive is easiest, like 20.  Redo steps 2-6.
