### PR TITLE
Fix #4304 - Blank password being tried when USER_AS_PASS is true

### DIFF
--- a/lib/msf/core/exploit/smb.rb
+++ b/lib/msf/core/exploit/smb.rb
@@ -54,7 +54,7 @@ module Exploit::Remote::SMB
     [
       OptBool.new('SMBDirect', [ true, 'The target port is a raw SMB service (not NetBIOS)', true ]),
       OptString.new('SMBUser', [ false, 'The username to authenticate as', '']),
-      OptString.new('SMBPass', [ false, 'The password for the specified username', '']),
+      OptString.new('SMBPass', [ false, 'The password for the specified username']),
       OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication', '.']),
       OptString.new('SMBName', [ true, 'The NetBIOS hostname (required for port 139 connections)', '*SMBSERVER']),
       OptBool.new('SMB::VerifySignature', [ true, "Enforces client-side verification of server response signatures", false]),

--- a/lib/msf/core/exploit/smb/authenticated.rb
+++ b/lib/msf/core/exploit/smb/authenticated.rb
@@ -13,7 +13,7 @@ module Exploit::Remote::SMB::Authenticated
     register_options(
       [
         OptString.new('SMBUser', [ false, 'The username to authenticate as', '']),
-        OptString.new('SMBPass', [ false, 'The password for the specified username', '']),
+        OptString.new('SMBPass', [ false, 'The password for the specified username']),
         OptString.new('SMBDomain',  [ false, 'The Windows domain to use for authentication', 'WORKGROUP']),
       ], Msf::Exploit::Remote::SMB::Authenticated)
   end

--- a/modules/exploits/windows/smb/psexec.rb
+++ b/modules/exploits/windows/smb/psexec.rb
@@ -118,7 +118,7 @@ class Metasploit3 < Msf::Exploit::Remote
       credential_data = {
           origin_type: :service,
           module_fullname: self.fullname,
-          private_data: datastore['SMBPass'],
+          private_data: datastore['SMBPass'].to_s, # Must be a string according to lib/metasploit/credential/creation.rb API doc
           username: datastore['SMBUser'].downcase
       }
 


### PR DESCRIPTION
Fix #4304
## Root Cause

This is kind of a design conflict between the BLANK_PASSWORDS option vs the SMB_PASS option.

If we allow BLANK_PASSWORDS, it implies we allow the user to decide whether there should be an empty string as the SMB password or not. But if we always set the default value of SMB_PASS to an empty string, we're actually not respecting the BLANK_PASSWORDS option. In other words, as long as the BLANK_PASSWORDS option exists, it is important to know SMB_PASS may be nil, not always a string.

Not respecting BLANK_PASSWORDS when false can result in account lockouts during a pentest.
