### PR TITLE
Fix #4304 - Blank password is tried when it shouldn't happen

### DIFF
--- a/lib/metasploit/framework/credential_collection.rb
+++ b/lib/metasploit/framework/credential_collection.rb
@@ -107,7 +107,7 @@ class Metasploit::Framework::CredentialCollection
       File.open(user_file, 'r:binary') do |user_fd|
         user_fd.each_line do |user_from_file|
           user_from_file.chomp!
-          if password
+          if password.present?
             yield Metasploit::Framework::Credential.new(public: user_from_file, private: password, realm: realm, private_type: private_type(password) )
           end
           if user_as_pass


### PR DESCRIPTION
Fix #4304
## Verification
- [x] echo username > /tmp/users.txt
- [x] Set up a Windows box
- [x] Start msfconsole
- [x] `use auxiliary/scanner/smb/smb_login`
- [x] `set rhosts [IP]`
- [x] `set user_as_pass true`
- [x] `set user_file /tmp/users.txt`
- [x] Make sure blank_password is false
- [x] `run`
- [x] You should not see an empty password being used (basically there should be only one login attempt)
