### PR TITLE
Proposed fix for #4305

### DIFF
--- a/lib/msf/core/exploit/capture.rb
+++ b/lib/msf/core/exploit/capture.rb
@@ -37,8 +37,16 @@ module Msf
 
         register_advanced_options(
           [
-            OptInt.new('UDP_SECRET', [true, 'The 32-bit cookie for UDP probe requests.', 1297303091]),
-            OptAddress.new('GATEWAY', [false, 'The gateway IP address. This will be used rather than a random remote address for the UDP probe, if set.']),
+            OptInt.new('SECRET', [true, 'A 32-bit cookie for probe requests.', 'MSF!'.unpack('N')]),
+            OptAddress.new('GATEWAY_PROBE_HOST',
+                           [
+                             true,
+                             'Send a TTL=1 random UDP datagram to this host to discover the default gateway\'s MAC',
+                             'www.metasploit.com'])
+            OptPort.new('GATEWAY_PROBE_PORT',
+                        [
+                          false,
+                          'The port on GATEWAY_PROBE_HOST to send a random UDP probe to (random if 0 or unset)'])
           ], Msf::Exploit::Capture
         )
 
@@ -116,7 +124,7 @@ module Msf
           self.capture = ::Pcap.open_live(dev, len, true, tim)
           if do_arp
             self.arp_capture = ::Pcap.open_live(dev, 512, true, tim)
-            preamble         = datastore['UDP_SECRET'].to_i
+            preamble         = datastore['SECRET'].to_i
             arp_filter       = "arp[6:2] = 2 or (udp[8:4] = #{preamble})"
             self.arp_capture.setfilter(arp_filter)
           end
@@ -303,9 +311,9 @@ module Msf
       end
 
       def probe_gateway(addr)
-        dst_host = (datastore['GATEWAY'] || IPAddr.new((rand(16777216) + 2969567232), Socket::AF_INET).to_s)
-        dst_port = rand(30000)+1024
-        preamble = [datastore['UDP_SECRET']].pack("N")
+        dst_host = datastore['GATEWAY_PROBE_HOST']
+        dst_port = datastore['GATEWAY_PROBE_PORT'] == 0 ? rand(30000) + 1024 : datastore['GATEWAY_PROBE_PORT']
+        preamble = [datastore['SECRET']].pack("N")
         secret   = "#{preamble}#{Rex::Text.rand_text(rand(0xff)+1)}"
 
         begin
@@ -313,9 +321,8 @@ module Msf
             sock.setsockopt(::Socket::IPPROTO_IP, ::Socket::IP_TTL, 1)
             sock.send(secret, 0, dst_host, dst_port)
           end
-          #UDPSocket.open.send(secret, 0, dst_host, dst_port)
         rescue Errno::ENETUNREACH
-          # This happens on networks with no gatway. We'll need to use a
+          # This happens on networks with no gateway. We'll need to use a
           # fake source hardware address.
           self.arp_cache[Rex::Socket.source_address(addr)] = "00:00:00:00:00:00"
         end

--- a/lib/msf/core/exploit/capture.rb
+++ b/lib/msf/core/exploit/capture.rb
@@ -37,7 +37,7 @@ module Msf
 
         register_advanced_options(
           [
-            OptInt.new('SECRET', [true, 'A 32-bit cookie for probe requests.', 'MSF!'.unpack('N')]),
+            OptInt.new('SECRET', [true, 'A 32-bit cookie for probe requests.', 'MSF!'.unpack('N').first]),
             OptAddress.new('GATEWAY_PROBE_HOST',
                            [
                              true,

--- a/lib/msf/core/exploit/capture.rb
+++ b/lib/msf/core/exploit/capture.rb
@@ -309,7 +309,11 @@ module Msf
         secret   = "#{preamble}#{Rex::Text.rand_text(rand(0xff)+1)}"
 
         begin
-          UDPSocket.open.send(secret, 0, dst_host, dst_port)
+          UDPSocket.open do |sock|
+            sock.setsockopt(::Socket::IPPROTO_IP, ::Socket::IP_TTL, 1)
+            sock.send(secret, 0, dst_host, dst_port)
+          end
+          #UDPSocket.open.send(secret, 0, dst_host, dst_port)
         rescue Errno::ENETUNREACH
           # This happens on networks with no gatway. We'll need to use a
           # fake source hardware address.

--- a/lib/msf/core/exploit/capture.rb
+++ b/lib/msf/core/exploit/capture.rb
@@ -42,7 +42,7 @@ module Msf
                            [
                              true,
                              'Send a TTL=1 random UDP datagram to this host to discover the default gateway\'s MAC',
-                             'www.metasploit.com'])
+                             'www.metasploit.com']),
             OptPort.new('GATEWAY_PROBE_PORT',
                         [
                           false,

--- a/modules/auxiliary/scanner/discovery/arp_sweep.rb
+++ b/modules/auxiliary/scanner/discovery/arp_sweep.rb
@@ -30,7 +30,7 @@ class Metasploit3 < Msf::Auxiliary
       OptInt.new('TIMEOUT', [true, 'The number of seconds to wait for new data', 5]),
     ], self.class)
 
-    deregister_options('SNAPLEN', 'FILTER', 'PCAPFILE', 'UDP_SECRET', 'GATEWAY')
+    deregister_options('SNAPLEN', 'FILTER', 'PCAPFILE', 'SECRET', 'GATEWAY_PROBE_HOST', 'GATEWAY_PROBE_PORT')
   end
 
   def run_batch_size

--- a/modules/auxiliary/server/icmp_exfil.rb
+++ b/modules/auxiliary/server/icmp_exfil.rb
@@ -57,7 +57,7 @@ class Metasploit3 < Msf::Auxiliary
       OptAddress.new('LOCALIP', [false, 'The IP address of the local interface'])
     ], self.class)
 
-    deregister_options('SNAPLEN','FILTER','PCAPFILE','RHOST','UDP_SECRET','GATEWAY', 'TIMEOUT')
+    deregister_options('SNAPLEN','FILTER','PCAPFILE','RHOST','SECRET','GATEWAY_PROBE_HOST', 'GATEWAY_PROBE_PORT', 'TIMEOUT')
   end
 
   def run

--- a/modules/auxiliary/spoof/arp/arp_poisoning.rb
+++ b/modules/auxiliary/spoof/arp/arp_poisoning.rb
@@ -47,7 +47,7 @@ class Metasploit3 < Msf::Auxiliary
       OptBool.new(  'BROADCAST',    	[true, 'If set, the module will send replies on the broadcast address witout consideration of DHOSTS', false])
     ], self.class)
 
-    deregister_options('SNAPLEN', 'FILTER', 'PCAPFILE','RHOST','UDP_SECRET','GATEWAY')
+    deregister_options('SNAPLEN', 'FILTER', 'PCAPFILE','RHOST','SECRET','GATEWAY_PROBE_HOST','GATEWAY_PROBE_PORT')
   end
 
   def run

--- a/modules/auxiliary/spoof/replay/pcap_replay.rb
+++ b/modules/auxiliary/spoof/replay/pcap_replay.rb
@@ -27,7 +27,7 @@ class Metasploit3 < Msf::Auxiliary
       OptInt.new('PKT_DELAY', [true, "the delay in millisecond between each packet",0]),
     ], self.class)
 
-    deregister_options('SNAPLEN','FILTER','PCAPFILE','RHOST','TIMEOUT','UDP_SECRET','GATEWAY')
+    deregister_options('SNAPLEN','FILTER','PCAPFILE','RHOST','TIMEOUT','SECRET','GATEWAY_PROBE_HOST','GATEWAY_PROBE_PORT')
   end
 
   def run

--- a/modules/exploits/windows/misc/wireshark_packet_dect.rb
+++ b/modules/exploits/windows/misc/wireshark_packet_dect.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
     ], self.class)
 
-    deregister_options('FILTER','PCAPFILE','RHOST','SNAPLEN','TIMEOUT','UDP_SECRET','GATEWAY')
+    deregister_options('FILTER','PCAPFILE','RHOST','SNAPLEN','TIMEOUT','SECRET','GATEWAY_PROBE_HOST','GATEWAY_PROBE_PORT')
   end
 
   def junk


### PR DESCRIPTION
Instead of sending a probe to a random host in 177/8 to attempt to see what the source and destination MACs are (and, in turn, what the Capture module should use when using `capture_sendto`), this PR makes this process send a random UDP probe to www.metasploit.com but with a TTL of 1, thereby ensuring that it shouldn't make it past the first hop, if at all.  It also makes the probe host and port configurable, and cleans up the "secret".

Note that this is a diff against master but has the fix for #4306 from #4311 merged in.  Once #4311 is landed this should update.
# Defect and Fix Validation

Note that these steps can be used to both confirm that the defect is fixed but also to demonstrate the defect in the first place by running against a parent revision:
- [x] `use exploits/multi/ids/snort_dce_rpc`, set an `RHOST` for a live host in the same broadcast domain.  Run.  Confirm that no UDP traffic is sent to 177/8 and that the only traffic caused by this module is an ARP lookup for the RHOST followed by a single 139/TCP packet, and that the source MAC is from the system running msf and that the destination MAC is RHOST's.
- [x] `use exploits/multi/ids/snort_dce_rpc``, set an``RHOST`` for a live host _NOT_ in the same broadcast domain.  Run.  Confirm that no UDP traffic is sent to 177/8.  Confirm that a random UDP datagram is sent to www.metasploit.com with a TTL of 1, and that the source MAC is from the system running msf and that the destination MAC is the default gateway's.
- [x] Redo #1 and #2 but with an explicitly set `INTERFACE` on a system with multiple interfaces.  Overkill?
