### PR TITLE
Fix #4307 - Check action for nil for post modules

### DIFF
--- a/lib/msf/base/simple/auxiliary.rb
+++ b/lib/msf/base/simple/auxiliary.rb
@@ -55,7 +55,7 @@ module Auxiliary
 
     # Verify the ACTION
     if (mod.actions.length > 0 and not mod.action)
-      raise MissingActionError, "You must specify a valid Action", caller
+      raise MissingActionError, "Please use: #{mod.actions.collect {|e| e.name} * ", "}"
     end
 
     # Verify the options

--- a/lib/msf/core/exceptions.rb
+++ b/lib/msf/core/exceptions.rb
@@ -210,9 +210,15 @@ end
 ###
 class MissingActionError < ArgumentError
   include AuxiliaryError
+  attr_accessor :reason
+
+  def initialize(reason='')
+    self.reason = reason
+    super
+  end
 
   def to_s
-    "A valid action has not been selected."
+    "Invalid action: #{reason}"
   end
 end
 

--- a/lib/msf/core/post.rb
+++ b/lib/msf/core/post.rb
@@ -19,7 +19,13 @@ class Msf::Post < Msf::Module
 
   include Msf::PostMixin
 
-  def setup; end
+  def setup
+    m = replicant
+    action = datastore['ACTION']
+    if m.actions.length > 0 && !m.action
+      raise Msf::MissingActionError, "Please use: #{m.actions.collect {|e| e.name} * ", "}"
+    end
+  end
 
   def type
     Msf::MODULE_POST

--- a/lib/msf/core/post.rb
+++ b/lib/msf/core/post.rb
@@ -21,7 +21,6 @@ class Msf::Post < Msf::Module
 
   def setup
     m = replicant
-    action = datastore['ACTION']
     if m.actions.length > 0 && !m.action
       raise Msf::MissingActionError, "Please use: #{m.actions.collect {|e| e.name} * ", "}"
     end


### PR DESCRIPTION
Auxiliary modules already do this, but looks like we forgot to do the same for post modules.

I also changed the error to allow "reason" in order to be more informative about what the user should do.

Fix #4307
## Verification

This is for post modules:
- [ ] Generate a meterpreter payload (executable)
- [ ] Set up a Windows box
- [ ] Start msfconsole
- [ ] `use exploit/multi/handler`
- [ ] `run`
- [ ] Double click on your meterpreter payload to get a shell
- [ ] At the meterpreter prompt, do `run post/windows/manage/webcam action=asdf` (just make sure the action is something invalid)
- [ ] You should see: "Post failed: Msf::MissingActionError Invalid action: Please use: LIST, SNAPSHOT"
- [ ] This time, try: `run post/windows/manage/webcam action=LIST`
- [ ] You should a list of the webcams the module found

This is for auxiliary modules:
- [x] Start msfconsole
- [x] `use auxiliary/scanner/http/http_put`
- [x] `set rhosts [IP]` (it doesn't really matter if you have a valid IP or not)
- [x] `set action INVALID`
- [x] `run`
- [x] You should see: "Auxiliary failed: Msf::MissingActionError Invalid action: Please use: PUT, DELETE"
