### PR TITLE
Fix #4323 - More undef 'payload_exe' in other modules

### DIFF
--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -332,7 +332,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
       # Save these file names for later deletion
       @exe_cmd_copy = exe_fname
-      @exe_payload = stager_instance.payload_exe
+      @exe_payload = stager_instance.payload_exe # Grab this info from CmdStagerTFTP
 
       # Just for good measure, we'll make a quick, direct request for the payload
       # Using the "start" method doesn't seem to make iis very happy :(

--- a/modules/exploits/windows/iis/msadc.rb
+++ b/modules/exploits/windows/iis/msadc.rb
@@ -332,12 +332,12 @@ class Metasploit3 < Msf::Exploit::Remote
 
       # Save these file names for later deletion
       @exe_cmd_copy = exe_fname
-      @exe_payload = payload_exe
+      @exe_payload = stager_instance.payload_exe
 
       # Just for good measure, we'll make a quick, direct request for the payload
       # Using the "start" method doesn't seem to make iis very happy :(
       print_status("Triggering the payload via a direct request...")
-      res = send_request_raw({ 'uri' => '/scripts/' + payload_exe, 'method' => 'GET' }, 1)
+      res = send_request_raw({ 'uri' => '/scripts/' + stager_instance.payload_exe, 'method' => 'GET' }, 1)
     end
 
     handler

--- a/modules/exploits/windows/misc/altiris_ds_sqli.rb
+++ b/modules/exploits/windows/misc/altiris_ds_sqli.rb
@@ -163,7 +163,7 @@ Processor-Speed=#{processor_speed}
   end
 
   def on_new_session(client)
-    return if not payload_exe
+    return if not stager_instance.payload_exe
 
     #can't scrub dropped payload while the process is still active so...
     #iterate through process list, find our process and the associated
@@ -174,7 +174,7 @@ Processor-Speed=#{processor_speed}
     #SeeRM#8365 https://http://dev.metasploit.com/redmine/issues/8365
 
     unless client.type == "meterpreter"
-      print_error("Automatic cleanup only available with meterpreter, please delete #{payload_exe} manually")
+      print_error("Automatic cleanup only available with meterpreter, please delete #{stager_instance.payload_exe} manually")
       return
     end
 
@@ -191,7 +191,7 @@ Processor-Speed=#{processor_speed}
     end
 
     win_temp = client.sys.config.getenv('TEMP')
-    win_file = "#{win_temp}\\#{payload_exe}"
+    win_file = "#{win_temp}\\#{stager_instance.payload_exe}"
     print_status("Attempting to delete #{win_file} ...")
     client.shell_command_token(%Q|attrib.exe -r #{win_file}|)
     client.fs.file.rm(win_file)


### PR DESCRIPTION
## Root cause

payload_exe is an accessor in the TFPT command stager mixin, you need stager_instance in order to retrieve that info.

This fixes #4323
