### PR TITLE
Support for Java Serialization on Rex

### DIFF
--- a/lib/rex/java.rb
+++ b/lib/rex/java.rb
@@ -1,1 +1,3 @@
+# -*- coding: binary -*-
+
 require 'rex/java/serialization'

--- a/lib/rex/java/serialization.rb
+++ b/lib/rex/java/serialization.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     # Include constants defining terminal and constant

--- a/lib/rex/java/serialization/model.rb
+++ b/lib/rex/java/serialization/model.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 require 'rex/java/serialization/model/element'
 require 'rex/java/serialization/model/null_reference'
 require 'rex/java/serialization/model/reference'

--- a/lib/rex/java/serialization/model/annotation.rb
+++ b/lib/rex/java/serialization/model/annotation.rb
@@ -18,7 +18,7 @@ module Rex
             self.contents = []
           end
 
-          # Deserializes a Java::Serialization::Model::Annotation
+          # Deserializes a Rex::Java::Serialization::Model::Annotation
           #
           # @param io [IO] the io to read from
           # @return [self] if deserialization succeeds
@@ -33,7 +33,7 @@ module Rex
             self
           end
 
-          # Serializes the Java::Serialization::Model::Annotation
+          # Serializes the Rex::Java::Serialization::Model::Annotation
           #
           # @return [String] if serialization suceeds
           # @raise [RuntimeError] if serialization doesn't succeed

--- a/lib/rex/java/serialization/model/annotation.rb
+++ b/lib/rex/java/serialization/model/annotation.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     module Serialization

--- a/lib/rex/java/serialization/model/block_data.rb
+++ b/lib/rex/java/serialization/model/block_data.rb
@@ -20,7 +20,7 @@ module Rex
             self.length = contents.length
           end
 
-          # Deserializes a Java::Serialization::Model::BlockData
+          # Deserializes a Rex::Java::Serialization::Model::BlockData
           #
           # @param io [IO] the io to read from
           # @return [self] if deserialization succeeds
@@ -52,7 +52,7 @@ module Rex
             "[ #{contents_hex.join(', ')} ]"
           end
 
-          # Serializes the Java::Serialization::Model::BlockData
+          # Serializes the Rex::Java::Serialization::Model::BlockData
           #
           # @return [String]
           def encode

--- a/lib/rex/java/serialization/model/block_data.rb
+++ b/lib/rex/java/serialization/model/block_data.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     module Serialization

--- a/lib/rex/java/serialization/model/block_data_long.rb
+++ b/lib/rex/java/serialization/model/block_data_long.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     module Serialization

--- a/lib/rex/java/serialization/model/block_data_long.rb
+++ b/lib/rex/java/serialization/model/block_data_long.rb
@@ -20,7 +20,7 @@ module Rex
             self.length = contents.length
           end
 
-          # Deserializes a Java::Serialization::Model::BlockDataLong
+          # Deserializes a Rex::Java::Serialization::Model::BlockDataLong
           #
           # @param io [IO] the io to read from
           # @return [self] if deserialization succeeds
@@ -44,7 +44,7 @@ module Rex
             self
           end
 
-          # Serializes the Java::Serialization::Model::BlockDataLong
+          # Serializes the Rex::Java::Serialization::Model::BlockDataLong
           #
           # @return [String]
           def encode

--- a/lib/rex/java/serialization/model/class_desc.rb
+++ b/lib/rex/java/serialization/model/class_desc.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     module Serialization

--- a/lib/rex/java/serialization/model/class_desc.rb
+++ b/lib/rex/java/serialization/model/class_desc.rb
@@ -15,7 +15,7 @@ module Rex
             self.description = nil
           end
 
-          # Deserializes a Java::Serialization::Model::ClassDesc
+          # Deserializes a Rex::Java::Serialization::Model::ClassDesc
           #
           # @param io [IO] the io to read from
           # @return [self] if deserialization succeeds
@@ -32,7 +32,7 @@ module Rex
             self
           end
 
-          # Serializes the Java::Serialization::Model::ClassDesc
+          # Serializes the Rex::Java::Serialization::Model::ClassDesc
           #
           # @return [String] if serialization succeeds
           # @raise [RuntimeError] if serialization doesn't succeed

--- a/lib/rex/java/serialization/model/contents.rb
+++ b/lib/rex/java/serialization/model/contents.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     module Serialization

--- a/lib/rex/java/serialization/model/element.rb
+++ b/lib/rex/java/serialization/model/element.rb
@@ -6,10 +6,10 @@ module Rex
 
           attr_accessor :stream
 
-          # Deserializes a Java::Serialization::Model::Element
+          # Deserializes a Rex::Java::Serialization::Model::Element
           #
           # @param io [IO] the io to read from
-          # @return [Java::Serialization::Model::Element] if deserialization succeeds
+          # @return [Rex::Java::Serialization::Model::Element] if deserialization succeeds
           # @return [nil] if deserialization doesn't succeed
           def self.decode(io, stream = nil)
             elem = self.new(stream)

--- a/lib/rex/java/serialization/model/element.rb
+++ b/lib/rex/java/serialization/model/element.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     module Serialization

--- a/lib/rex/java/serialization/model/end_block_data.rb
+++ b/lib/rex/java/serialization/model/end_block_data.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     module Serialization

--- a/lib/rex/java/serialization/model/field.rb
+++ b/lib/rex/java/serialization/model/field.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     module Serialization

--- a/lib/rex/java/serialization/model/field.rb
+++ b/lib/rex/java/serialization/model/field.rb
@@ -12,10 +12,10 @@ module Rex
           #   @return [String] The type of the field.
           attr_accessor :type
           # @!attribute name
-          #   @return [Java::Serialization::Model::Utf] The name of the field.
+          #   @return [Rex::Java::Serialization::Model::Utf] The name of the field.
           attr_accessor :name
           # @!attribute field_type
-          #   @return [Java::Serialization::Model::Utf] The type of the field on object types.
+          #   @return [Rex::Java::Serialization::Model::Utf] The type of the field on object types.
           attr_accessor :field_type
 
           # @param stream [Rex::Java::Serialization::Model::Stream] the stream where it belongs to
@@ -26,7 +26,7 @@ module Rex
             self.field_type = nil
           end
 
-          # Deserializes a Java::Serialization::Model::Field
+          # Deserializes a Rex::Java::Serialization::Model::Field
           #
           # @param io [IO] the io to read from
           # @return [self] if deserialization succeeds
@@ -48,12 +48,12 @@ module Rex
             self
           end
 
-          # Serializes the Java::Serialization::Model::Field
+          # Serializes the Rex::Java::Serialization::Model::Field
           #
           # @return [String] if serialization succeeds
           # @raise [RuntimeError] if serialization doesn't succeed
           def encode
-            unless name.class == Java::Serialization::Model::Utf
+            unless name.class == Rex::Java::Serialization::Model::Utf
               raise ::RuntimeError, 'Failed to serialize Field'
             end
 

--- a/lib/rex/java/serialization/model/long_utf.rb
+++ b/lib/rex/java/serialization/model/long_utf.rb
@@ -5,7 +5,7 @@ module Rex
         # This class provides a Long Utf string representation
         class LongUtf < Utf
 
-          # Deserializes a Java::Serialization::Model::LongUtf
+          # Deserializes a Rex::Java::Serialization::Model::LongUtf
           #
           # @param io [IO] the io to read from
           # @return [self] if deserialization succeeds
@@ -29,7 +29,7 @@ module Rex
             self
           end
 
-          # Serializes the Java::Serialization::Model::LongUtf
+          # Serializes the Rex::Java::Serialization::Model::LongUtf
           #
           # @return [String]
           def encode

--- a/lib/rex/java/serialization/model/long_utf.rb
+++ b/lib/rex/java/serialization/model/long_utf.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     module Serialization

--- a/lib/rex/java/serialization/model/new_array.rb
+++ b/lib/rex/java/serialization/model/new_array.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     module Serialization

--- a/lib/rex/java/serialization/model/new_array.rb
+++ b/lib/rex/java/serialization/model/new_array.rb
@@ -25,7 +25,7 @@ module Rex
             self.values = []
           end
 
-          # Deserializes a Java::Serialization::Model::NewArray
+          # Deserializes a Rex::Java::Serialization::Model::NewArray
           #
           # @param io [IO] the io to read from
           # @return [self] if deserialization succeeds
@@ -45,7 +45,7 @@ module Rex
             self
           end
 
-          # Serializes the Java::Serialization::Model::NewArray
+          # Serializes the Rex::Java::Serialization::Model::NewArray
           #
           # @return [String] if serialization succeeds
           # @raise [RuntimeError] if serialization doesn't succeed

--- a/lib/rex/java/serialization/model/new_class_desc.rb
+++ b/lib/rex/java/serialization/model/new_class_desc.rb
@@ -8,7 +8,7 @@ module Rex
           include Rex::Java::Serialization
 
           # @!attribute class_name
-          #   @return [Java::Serialization::Model::Utf] The name of the class
+          #   @return [Rex::Java::Serialization::Model::Utf] The name of the class
           attr_accessor :class_name
           # @!attribute name
           #   @return [Integer] The java class serial version
@@ -20,10 +20,10 @@ module Rex
           #   @return [Array] The java class fields
           attr_accessor :fields
           # @!attribute fields
-          #   @return [Java::Serialization::Model::Annotation] The java class annotations
+          #   @return [Rex::Java::Serialization::Model::Annotation] The java class annotations
           attr_accessor :class_annotation
           # @!attribute super_class
-          #   @return [Java::Serialization::Model::ClassDesc] The java class superclass description
+          #   @return [Rex::Java::Serialization::Model::ClassDesc] The java class superclass description
           attr_accessor :super_class
 
           # @param stream [Rex::Java::Serialization::Model::Stream] the stream where it belongs to
@@ -37,7 +37,7 @@ module Rex
             self.super_class = nil
           end
 
-          # Deserializes a Java::Serialization::Model::ClassDescription
+          # Deserializes a Rex::Java::Serialization::Model::ClassDescription
           #
           # @param io [IO] the io to read from
           # @return [self] if deserialization succeeds
@@ -59,14 +59,14 @@ module Rex
             self
           end
 
-          # Serializes the Java::Serialization::Model::ClassDescription
+          # Serializes the Rex::Java::Serialization::Model::ClassDescription
           #
           # @return [String] if serialization succeeds
           # @raise [RuntimeError] if serialization doesn't succeed
           def encode
-            unless class_name.class == Java::Serialization::Model::Utf &&
-                    class_annotation.class == Java::Serialization::Model::Annotation &&
-                    super_class.class == Java::Serialization::Model::ClassDesc
+            unless class_name.class == Rex::Java::Serialization::Model::Utf &&
+                    class_annotation.class == Rex::Java::Serialization::Model::Annotation &&
+                    super_class.class == Rex::Java::Serialization::Model::ClassDesc
               raise ::RuntimeError, 'Filed to serialize NewClassDesc'
             end
             encoded = ''

--- a/lib/rex/java/serialization/model/new_class_desc.rb
+++ b/lib/rex/java/serialization/model/new_class_desc.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     module Serialization

--- a/lib/rex/java/serialization/model/new_enum.rb
+++ b/lib/rex/java/serialization/model/new_enum.rb
@@ -8,10 +8,10 @@ module Rex
           include Rex::Java::Serialization::Model::Contents
 
           # @!attribute enum_description
-          #   @return [Java::Serialization::Model::ClassDescription] The description of the enum
+          #   @return [Rex::Java::Serialization::Model::ClassDescription] The description of the enum
           attr_accessor :enum_description
           # @!attribute constant_name
-          #   @return [Java::Serialization::Model::Utf] The constant value in the Java Enum
+          #   @return [Rex::Java::Serialization::Model::Utf] The constant value in the Java Enum
           attr_accessor :constant_name
 
           # @param stream [Rex::Java::Serialization::Model::Stream] the stream where it belongs to
@@ -21,7 +21,7 @@ module Rex
             self.constant_name = nil
           end
 
-          # Deserializes a Java::Serialization::Model::NewEnum
+          # Deserializes a Rex::Java::Serialization::Model::NewEnum
           #
           # @param io [IO] the io to read from
           # @return [self] if deserialization succeeds
@@ -34,7 +34,7 @@ module Rex
             self
           end
 
-          # Serializes the Java::Serialization::Model::NewEnum
+          # Serializes the Rex::Java::Serialization::Model::NewEnum
           #
           # @return [String] if serialization succeeds
           # @raise [RuntimeError] if serialization doesn't succeed

--- a/lib/rex/java/serialization/model/new_enum.rb
+++ b/lib/rex/java/serialization/model/new_enum.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     module Serialization

--- a/lib/rex/java/serialization/model/new_object.rb
+++ b/lib/rex/java/serialization/model/new_object.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     module Serialization

--- a/lib/rex/java/serialization/model/new_object.rb
+++ b/lib/rex/java/serialization/model/new_object.rb
@@ -21,7 +21,7 @@ module Rex
             self.class_data = []
           end
 
-          # Deserializes a Java::Serialization::Model::NewObject
+          # Deserializes a Rex::Java::Serialization::Model::NewObject
           #
           # @param io [IO] the io to read from
           # @return [self] if deserialization succeeds
@@ -40,7 +40,7 @@ module Rex
             self
           end
 
-          # Serializes the Java::Serialization::Model::NewObject
+          # Serializes the Rex::Java::Serialization::Model::NewObject
           #
           # @return [String] if serialization succeeds
           # @raise [RuntimeError] if serialization doesn't succeed

--- a/lib/rex/java/serialization/model/null_reference.rb
+++ b/lib/rex/java/serialization/model/null_reference.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     module Serialization

--- a/lib/rex/java/serialization/model/reference.rb
+++ b/lib/rex/java/serialization/model/reference.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     module Serialization

--- a/lib/rex/java/serialization/model/reference.rb
+++ b/lib/rex/java/serialization/model/reference.rb
@@ -15,7 +15,7 @@ module Rex
             self.handle = 0
           end
 
-          # Deserializes a Java::Serialization::Model::Reference
+          # Deserializes a Rex::Java::Serialization::Model::Reference
           #
           # @param io [IO] the io to read from
           # @return [self] if deserialization succeeds
@@ -31,7 +31,7 @@ module Rex
             self
           end
 
-          # Serializes the Java::Serialization::Model::Reference
+          # Serializes the Rex::Java::Serialization::Model::Reference
           #
           # @return [String] if serialization succeeds
           # @raise [RuntimeError] if serialization doesn't succeed

--- a/lib/rex/java/serialization/model/reset.rb
+++ b/lib/rex/java/serialization/model/reset.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     module Serialization

--- a/lib/rex/java/serialization/model/stream.rb
+++ b/lib/rex/java/serialization/model/stream.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     module Serialization

--- a/lib/rex/java/serialization/model/stream.rb
+++ b/lib/rex/java/serialization/model/stream.rb
@@ -28,7 +28,7 @@ module Rex
             self.references = []
           end
 
-          # Deserializes a Java::Serialization::Model::Stream
+          # Deserializes a Rex::Java::Serialization::Model::Stream
           #
           # @param io [IO] the io to read from
           # @return [self] if deserialization succeeds
@@ -45,7 +45,7 @@ module Rex
             self
           end
 
-          # Serializes the Java::Serialization::Model::Stream
+          # Serializes the Rex::Java::Serialization::Model::Stream
           #
           # @return [String] if serialization succeeds
           # @raise [RuntimeError] if serialization doesn't succeed

--- a/lib/rex/java/serialization/model/utf.rb
+++ b/lib/rex/java/serialization/model/utf.rb
@@ -20,7 +20,7 @@ module Rex
             self.length = contents.length
           end
 
-          # Deserializes a Java::Serialization::Model::Utf
+          # Deserializes a Rex::Java::Serialization::Model::Utf
           #
           # @param io [IO] the io to read from
           # @return [self] if deserialization succeeds
@@ -44,7 +44,7 @@ module Rex
             self
           end
 
-          # Serializes the Java::Serialization::Model::Utf
+          # Serializes the Rex::Java::Serialization::Model::Utf
           #
           # @return [String]
           def encode

--- a/lib/rex/java/serialization/model/utf.rb
+++ b/lib/rex/java/serialization/model/utf.rb
@@ -1,3 +1,5 @@
+# -*- coding: binary -*-
+
 module Rex
   module Java
     module Serialization

--- a/spec/lib/rex/java/serialization/model/annotation_spec.rb
+++ b/spec/lib/rex/java/serialization/model/annotation_spec.rb
@@ -1,3 +1,6 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
 require 'rex/java'
 require 'stringio'
 

--- a/spec/lib/rex/java/serialization/model/block_data_long_spec.rb
+++ b/spec/lib/rex/java/serialization/model/block_data_long_spec.rb
@@ -1,3 +1,6 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
 require 'rex/java'
 require 'stringio'
 

--- a/spec/lib/rex/java/serialization/model/block_data_spec.rb
+++ b/spec/lib/rex/java/serialization/model/block_data_spec.rb
@@ -1,3 +1,6 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
 require 'rex/java'
 require 'stringio'
 

--- a/spec/lib/rex/java/serialization/model/class_desc_spec.rb
+++ b/spec/lib/rex/java/serialization/model/class_desc_spec.rb
@@ -1,3 +1,6 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
 require 'rex/java'
 require 'stringio'
 

--- a/spec/lib/rex/java/serialization/model/field_spec.rb
+++ b/spec/lib/rex/java/serialization/model/field_spec.rb
@@ -1,3 +1,6 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
 require 'rex/java'
 require 'stringio'
 

--- a/spec/lib/rex/java/serialization/model/long_utf_spec.rb
+++ b/spec/lib/rex/java/serialization/model/long_utf_spec.rb
@@ -1,3 +1,6 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
 require 'rex/java'
 require 'stringio'
 

--- a/spec/lib/rex/java/serialization/model/new_array_spec.rb
+++ b/spec/lib/rex/java/serialization/model/new_array_spec.rb
@@ -1,3 +1,6 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
 require 'rex/java'
 require 'stringio'
 

--- a/spec/lib/rex/java/serialization/model/new_class_desc_spec.rb
+++ b/spec/lib/rex/java/serialization/model/new_class_desc_spec.rb
@@ -1,3 +1,6 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
 require 'rex/java'
 require 'stringio'
 

--- a/spec/lib/rex/java/serialization/model/new_enum_spec.rb
+++ b/spec/lib/rex/java/serialization/model/new_enum_spec.rb
@@ -1,3 +1,6 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
 require 'rex/java'
 require 'stringio'
 

--- a/spec/lib/rex/java/serialization/model/new_object_spec.rb
+++ b/spec/lib/rex/java/serialization/model/new_object_spec.rb
@@ -1,3 +1,6 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
 require 'rex/java'
 require 'stringio'
 

--- a/spec/lib/rex/java/serialization/model/stream_spec.rb
+++ b/spec/lib/rex/java/serialization/model/stream_spec.rb
@@ -1,3 +1,6 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
 require 'rex/java'
 require 'stringio'
 

--- a/spec/lib/rex/java/serialization/model/utf_spec.rb
+++ b/spec/lib/rex/java/serialization/model/utf_spec.rb
@@ -1,3 +1,6 @@
+# -*- coding:binary -*-
+require 'spec_helper'
+
 require 'rex/java'
 require 'stringio'
 

--- a/spec/tools/java_deserializer_spec.rb
+++ b/spec/tools/java_deserializer_spec.rb
@@ -47,25 +47,28 @@ describe JavaDeserializer do
     end
 
     context "when file contains a valid stream" do
-      it "returns an Stream" do
+      it "prints the stream contents" do
         expect(File).to receive(:new) do
           contents = valid_stream
           StringIO.new(contents)
         end
         deserializer.file = 'sample'
-        expect(deserializer.run).to be_an(Rex::Java::Serialization::Model::Stream)
+        deserializer.run
+        expect($stdout.string).to include('[7e0001] NewArray { char, ["97", "98"] }')
       end
     end
 
     context "when file contains an invalid stream" do
-      it "returns nil" do
+      it "prints the error while deserializing" do
         expect(File).to receive(:new) do
           contents = 'invalid_stream'
           StringIO.new(contents)
         end
         deserializer.file = 'sample'
-        expect(deserializer.run).to be_nil
+        deserializer.run
+        expect($stdout.string).to include('[-] Failed to unserialize Stream')
       end
     end
+
   end
 end


### PR DESCRIPTION
The format specs here: https://docs.oracle.com/javase/8/docs/platform/serialization/spec/protocol.html

The support here isn't complete, but is good enough for my purposes atm :) Probably I'll modify it in the next days/weeks. But I think it's good enough for PR. So I can get feedback if there are stoppers.
## Verification
- [x] Be sure travis is green
- [x] Run specs locally and ensure they pass

```
$ rspec spec/lib/rex/java/serialization/model/*
Rex::Java::Serialization::Model::Annotation ............
Rex::Java::Serialization::Model::Field ..............
Rex::Java::Serialization::Model::NewEnum ......
Rex::Java::Serialization::Model::NewClassDesc ...................
Rex::Java::Serialization::Model::ClassDesc .....
Rex::Java::Serialization::Model::Stream .................
Rex::Java::Serialization::Model::LongUtf .............
Rex::Java::Serialization::Model::Utf .............
Rex::Java::Serialization::Model::NewObject .......
Rex::Java::Serialization::Model::NewArray .........................................
Rex::Java::Serialization::Model::BlockDataLong .............
Rex::Java::Serialization::Model::BlockData .............

Finished in 0.20879 seconds
173 examples, 0 failures

Randomized with seed 22548

Coverage report generated for RSpec to /metasploit-framework/coverage. 18080 / 95914 LOC (18.85%) covered.
```
