### PR TITLE
Error messages for the python meterpreter

### DIFF
--- a/data/meterpreter/ext_server_stdapi.py
+++ b/data/meterpreter/ext_server_stdapi.py
@@ -945,8 +945,7 @@ def stdapi_fs_delete_dir(request, response):
 @meterpreter.register_function
 def stdapi_fs_delete_file(request, response):
 	file_path = packet_get_tlv(request, TLV_TYPE_FILE_PATH)['value']
-	if os.path.exists(file_path):
-		os.unlink(file_path)
+	os.unlink(file_path)
 	return ERROR_SUCCESS, response
 
 @meterpreter.register_function

--- a/data/meterpreter/ext_server_stdapi.py
+++ b/data/meterpreter/ext_server_stdapi.py
@@ -690,10 +690,10 @@ def stdapi_sys_config_getenv(request, response):
 def stdapi_sys_config_getsid(request, response):
 	token = get_token_user(ctypes.windll.kernel32.GetCurrentProcess())
 	if not token:
-		return ERROR_FAILURE, response
+		return error_result_windows(), response
 	sid_str = ctypes.c_char_p()
 	if not ctypes.windll.advapi32.ConvertSidToStringSidA(token.User.Sid, ctypes.byref(sid_str)):
-		return ERROR_FAILURE, response
+		return error_result_windows(), response
 	sid_str = str(ctypes.string_at(sid_str))
 	response += tlv_pack(TLV_TYPE_SID, sid_str)
 	return ERROR_SUCCESS, response
@@ -705,10 +705,10 @@ def stdapi_sys_config_getuid(request, response):
 	elif has_windll:
 		token = get_token_user(ctypes.windll.kernel32.GetCurrentProcess())
 		if not token:
-			return ERROR_FAILURE, response
+			return error_result_windows(), response
 		username = get_username_from_token(token)
 		if not username:
-			return ERROR_FAILURE, response
+			return error_result_windows(), response
 	else:
 		username = getpass.getuser()
 	response += tlv_pack(TLV_TYPE_USER_NAME, username)
@@ -796,9 +796,9 @@ def stdapi_sys_process_kill(request, response):
 			k32 = ctypes.windll.kernel32
 			proc_h = k32.OpenProcess(PROCESS_TERMINATE, False, pid)
 			if not proc_h:
-				return ERROR_FAILURE, response
+				return error_result_windows(), response
 			if not k32.TerminateProcess(proc_h, 0):
-				return ERROR_FAILURE, response
+				return error_result_windows(), response
 		elif hasattr(os, 'kill'):
 			os.kill(pid, 9)
 		else:
@@ -865,7 +865,7 @@ def stdapi_sys_process_get_processes_via_windll(request, response):
 	proc_snap = k32.CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
 	result = k32.Process32First(proc_snap, ctypes.byref(pe32))
 	if not result:
-		return ERROR_FAILURE, response
+		return error_result_windows(), response
 	while result:
 		proc_h = k32.OpenProcess((PROCESS_QUERY_INFORMATION | PROCESS_VM_READ), False, pe32.th32ProcessID)
 		if not proc_h:
@@ -1348,10 +1348,10 @@ def stdapi_registry_create_key(request, response):
 	base_key = ctypes.create_string_buffer(bytes(base_key, 'UTF-8'))
 	permission = packet_get_tlv(request, TLV_TYPE_PERMISSION).get('value', winreg.KEY_ALL_ACCESS)
 	res_key = ctypes.c_void_p()
-	if ctypes.windll.advapi32.RegCreateKeyExA(root_key, ctypes.byref(base_key), 0, None, 0, permission, None, ctypes.byref(res_key), None) == ERROR_SUCCESS:
-		response += tlv_pack(TLV_TYPE_HKEY, res_key.value)
-		return ERROR_SUCCESS, response
-	return ERROR_FAILURE, response
+	if ctypes.windll.advapi32.RegCreateKeyExA(root_key, ctypes.byref(base_key), 0, None, 0, permission, None, ctypes.byref(res_key), None) != ERROR_SUCCESS:
+		return error_result_windows(), response
+	response += tlv_pack(TLV_TYPE_HKEY, res_key.value)
+	return ERROR_SUCCESS, response
 
 @meterpreter.register_function_windll
 def stdapi_registry_delete_key(request, response):
@@ -1442,21 +1442,20 @@ def stdapi_registry_open_key(request, response):
 	base_key = ctypes.create_string_buffer(bytes(base_key, 'UTF-8'))
 	permission = packet_get_tlv(request, TLV_TYPE_PERMISSION).get('value', winreg.KEY_ALL_ACCESS)
 	handle_id = ctypes.c_void_p()
-	if ctypes.windll.advapi32.RegOpenKeyExA(root_key, ctypes.byref(base_key), 0, permission, ctypes.byref(handle_id)) == ERROR_SUCCESS:
-		response += tlv_pack(TLV_TYPE_HKEY, handle_id.value)
-		return ERROR_SUCCESS, response
-	return ERROR_FAILURE, response
+	if ctypes.windll.advapi32.RegOpenKeyExA(root_key, ctypes.byref(base_key), 0, permission, ctypes.byref(handle_id)) != ERROR_SUCCESS:
+		return error_result_windows(), response
+	response += tlv_pack(TLV_TYPE_HKEY, handle_id.value)
+	return ERROR_SUCCESS, response
 
 @meterpreter.register_function_windll
 def stdapi_registry_open_remote_key(request, response):
 	target_host = packet_get_tlv(request, TLV_TYPE_TARGET_HOST)['value']
 	root_key = packet_get_tlv(request, TLV_TYPE_ROOT_KEY)['value']
 	result_key = ctypes.c_void_p()
-	result = ctypes.windll.advapi32.RegConnectRegistry(target_host, root_key, ctypes.byref(result_key))
-	if (result == ERROR_SUCCESS):
-		response += tlv_pack(TLV_TYPE_HKEY, result_key.value)
-		return ERROR_SUCCESS, response
-	return ERROR_FAILURE, response
+	if ctypes.windll.advapi32.RegConnectRegistry(target_host, root_key, ctypes.byref(result_key)) != ERROR_SUCCESS:
+		return error_result_windows(), response
+	response += tlv_pack(TLV_TYPE_HKEY, result_key.value)
+	return ERROR_SUCCESS, response
 
 @meterpreter.register_function_windll
 def stdapi_registry_query_class(request, response):
@@ -1464,11 +1463,10 @@ def stdapi_registry_query_class(request, response):
 	value_data = (ctypes.c_char * 4096)()
 	value_data_sz = ctypes.c_uint32()
 	value_data_sz.value = ctypes.sizeof(value_data)
-	result = ctypes.windll.advapi32.RegQueryInfoKeyA(hkey, value_data, ctypes.byref(value_data_sz), None, None, None, None, None, None, None, None, None)
-	if result == ERROR_SUCCESS:
-		response += tlv_pack(TLV_TYPE_VALUE_DATA, ctypes.string_at(value_data))
-		return ERROR_SUCCESS, response
-	return ERROR_FAILURE, response
+	if ctypes.windll.advapi32.RegQueryInfoKeyA(hkey, value_data, ctypes.byref(value_data_sz), None, None, None, None, None, None, None, None, None) != ERROR_SUCCESS:
+		return error_result_windows(), response
+	response += tlv_pack(TLV_TYPE_VALUE_DATA, ctypes.string_at(value_data))
+	return ERROR_SUCCESS, response
 
 @meterpreter.register_function_windll
 def stdapi_registry_query_value(request, response):
@@ -1496,7 +1494,7 @@ def stdapi_registry_query_value(request, response):
 		else:
 			response += tlv_pack(TLV_TYPE_VALUE_DATA, ctypes.string_at(value_data, value_data_sz.value))
 		return ERROR_SUCCESS, response
-	return ERROR_FAILURE, response
+	return error_result_windows(), response
 
 @meterpreter.register_function_windll
 def stdapi_registry_set_value(request, response):

--- a/lib/msf/base/sessions/meterpreter_python.rb
+++ b/lib/msf/base/sessions/meterpreter_python.rb
@@ -1,6 +1,7 @@
 # -*- coding: binary -*-
 
 require 'msf/base/sessions/meterpreter'
+require 'msf/windows_error'
 
 module Msf
 module Sessions
@@ -11,19 +12,109 @@ module Sessions
 #
 ###
 class Meterpreter_Python_Python < Msf::Sessions::Meterpreter
-  def supports_ssl?
-    false
-  end
-  def supports_zlib?
-    false
-  end
+  ERROR_TYPE_UNKNOWN = 1
+  ERROR_TYPE_PYTHON = 2
+  ERROR_TYPE_WINDOWS = 3
+  # 16-bit CRC-CCITT XMODEM
+  PYTHON_ERROR_CRCS = {
+    0x02dd => 'NotImplementedError',
+    0x049a => 'RuntimeWarning',
+    0x09ae => 'IndentationError',
+    0x0bf4 => 'SystemExit',
+    0x1494 => 'GeneratorExit',
+    0x1511 => 'ConnectionRefusedError',
+    0x1765 => 'SyntaxWarning',
+    0x1f0e => 'SystemError',
+    0x33b1 => 'StandardError',
+    0x37b8 => 'IOError',
+    0x39df => 'PermissionError',
+    0x39e6 => 'AttributeError',
+    0x3b70 => 'ChildProcessError',
+    0x3c93 => 'UserWarning',
+    0x3ca3 => 'BufferError',
+    0x3e32 => 'StopIteration',
+    0x423c => 'NotADirectoryError',
+    0x42f1 => 'ConnectionError',
+    0x453b => 'UnboundLocalError',
+    0x470d => 'LookupError',
+    0x4cb2 => 'WindowsError',
+    0x4ecc => 'ResourceWarning',
+    0x532d => 'UnicodeEncodeError',
+    0x5dde => 'ConnectionAbortedError',
+    0x6011 => 'EOFError',
+    0x637f => 'UnicodeWarning',
+    0x6482 => 'RuntimeError',
+    0x6a75 => 'ArithmeticError',
+    0x6b73 => 'BlockingIOError',
+    0x70e0 => 'UnicodeDecodeError',
+    0x72b4 => 'AssertionError',
+    0x75a1 => 'TabError',
+    0x77c2 => 'ReferenceError',
+    0x7a4c => 'FutureWarning',
+    0x7a78 => 'Warning',
+    0x7ef9 => 'IsADirectoryError',
+    0x81dc => 'ConnectionResetError',
+    0x87fa => 'OSError',
+    0x8937 => 'KeyError',
+    0x8a80 => 'SyntaxError',
+    0x8f3e => 'TypeError',
+    0x9329 => 'MemoryError',
+    0x956e => 'ValueError',
+    0x96a1 => 'OverflowError',
+    0xa451 => 'InterruptedError',
+    0xa4d7 => 'FileExistsError',
+    0xb19a => 'ZeroDivisionError',
+    0xb27b => 'IndexError',
+    0xb628 => 'UnicodeError',
+    0xbb63 => 'TimeoutError',
+    0xbc91 => 'ImportWarning',
+    0xc18f => 'BrokenPipeError',
+    0xc3a0 => 'KeyboardInterrupt',
+    0xcbab => 'ImportError',
+    0xcd47 => 'NameError',
+    0xcd82 => 'ProcessLookupError',
+    0xdd4a => 'BaseException',
+    0xe5a3 => 'BytesWarning',
+    0xe97a => 'FileNotFoundError',
+    0xe98a => 'PendingDeprecationWarning',
+    0xf47c => 'DeprecationWarning',
+    0xf7c6 => 'Exception',
+    0xfa9d => 'EnvironmentError',
+    0xfcb4 => 'UnicodeTranslateError',
+    0xff8d => 'FloatingPointError'
+  }
+
   def initialize(rstream, opts={})
     super
     self.platform      = 'python/python'
     self.binary_suffix = 'py'
   end
-end
 
-end
-end
+  def lookup_error(error_code)
+    unknown_error = 'Unknown error'
+    error_type = error_code & 0x0f
+    return unknown_error if error_type == ERROR_TYPE_UNKNOWN
 
+    error_code &= 0xffff0000
+    error_code >>= 16
+
+    if error_type == ERROR_TYPE_PYTHON
+      python_error = PYTHON_ERROR_CRCS[error_code]
+      return "Python exception: #{python_error}" unless python_error.nil?
+    elsif error_type == ERROR_TYPE_WINDOWS
+      return "Windows error: #{Msf::WindowsError.description(error_code)}"
+    end
+
+    unknown_error
+  end
+
+  def supports_ssl?
+    false
+  end
+
+  def supports_zlib?
+    false
+  end
+end
+end
+end


### PR DESCRIPTION
This adds error messages for the Python meterpreter. Python exception names and Windows error numbers are caught and returned to the user to help them troubleshoot what might have gone wrong. This is an improvement over the current implementation which always returns an error number of 1 with no additional details.

Side note, Python 3.3 introduced some additional builtin exceptions. This means the same error-causing action may not always produce the same message depending on the version.

Testing procedure:
- [x] Open a Python meterpreter session on Linux and do things to cause errors
- [x] View an error message with the Python exception name
- [x] Open a Python meterpreter session on Windows and do more things to cause errors
- [x] View a Windows error message or a Python exception name depending on the error type

Examples:
Windows 7 Python 3.4

```
meterpreter > cat thisfiledoesnotexist
[-] stdapi_fs_stat: Operation failed: Python exception: FileNotFoundError
```

Windows 7 Python 2.7

```
meterpreter > cat thisfiledoesnotexist
[-] stdapi_fs_stat: Operation failed: Windows error: The system cannot find the file specified.
```

Linux Python 3.4

```
meterpreter > cat /etc/shadow
[-] core_channel_open: Operation failed: Python exception: PermissionError
```

Linux Python 3.1

```
meterpreter > cat /etc/shadow
[-] core_channel_open: Operation failed: Python exception: IOError
```
