### PR TITLE
Deprecate msfpayload and msfencode

### DIFF
--- a/msfencode
+++ b/msfencode
@@ -5,6 +5,12 @@
 # $Revision$
 #
 
+$stderr.puts "[!] ************************************************************************"
+$stderr.puts "[!] *               The utility msfencode is deprecated!                   *"
+$stderr.puts "[!] *              It will be removed on or about 2015-06-08               *"
+$stderr.puts "[!] *                   Please use msfvenom instead                        *"
+$stderr.puts "[!] ************************************************************************"
+
 msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))

--- a/msfpayload
+++ b/msfpayload
@@ -5,6 +5,12 @@
 # $Revision$
 #
 
+$stderr.puts "[!] ************************************************************************"
+$stderr.puts "[!] *               The utility msfpayload is deprecated!                  *"
+$stderr.puts "[!] *              It will be removed on or about 2015-06-08               *"
+$stderr.puts "[!] *                   Please use msfvenom instead                        *"
+$stderr.puts "[!] ************************************************************************"
+
 msfbase = __FILE__
 while File.symlink?(msfbase)
   msfbase = File.expand_path(File.readlink(msfbase), File.dirname(msfbase))


### PR DESCRIPTION
See #4326, but it does not close it.

When you use msfencode, it will print the following message:

```
[!] ************************************************************************
[!] *               The utility msfencode is deprecated!                   *
[!] *              It will be removed on or about 2015-06-08               *
[!] *                   Please use msfvenom instead                        *
[!] ************************************************************************
```

For msfpayload:

```
[!] ************************************************************************
[!] *               The utility msfpayload is deprecated!                  *
[!] *              It will be removed on or about 2015-06-08               *
[!] *                   Please use msfvenom instead                        *
[!] ************************************************************************
```

But both remain functional.

Please make sure Travis is green.
