### PR TITLE
Fix prompt coloring on Windows

### DIFF
--- a/lib/rex/ui/text/input/readline.rb
+++ b/lib/rex/ui/text/input/readline.rb
@@ -83,7 +83,7 @@ begin
         Thread.current.priority = -20
 
         output.prompting
-        line = ::Readline.readline(prompt, true)
+        line = readline_with_output(prompt, true)
         ::Readline::HISTORY.pop if (line and line.empty?)
       ensure
         Thread.current.priority = orig || 0
@@ -115,6 +115,37 @@ begin
     # The output handle to use when displaying the prompt.
     #
     attr_accessor :output
+
+    private
+
+    def readline_with_output(prompt, add_history=false)
+      # rb-readlines's Readline.readline hardcodes the input and output to $stdin and $stdout, which means setting
+      # `Readline.input` or `Readline.ouput` has no effect when running `Readline.readline` with rb-readline, so need
+      # to reimplement []`Readline.readline`](https://github.com/luislavena/rb-readline/blob/ce4908dae45dbcae90a6e42e3710b8c3a1f2cd64/lib/readline.rb#L36-L58)
+      # for rb-readline to support setting input and output.  Output needs to be set so that colorization works for the
+      # prompt on Windows.
+      if defined? RbReadline
+        RbReadline.rl_instream = fd
+        RbReadline.rl_outstream = output
+
+        begin
+          line = RbReadline.readline(prompt)
+        rescue ::Exception => exception
+          RbReadline.rl_cleanup_after_signal()
+          RbReadline.rl_deprep_terminal()
+
+          raise exception
+        end
+
+        if add_history && line
+          RbReadline.add_history(line)
+        end
+
+        line.try(:dup)
+      else
+        ::Readline.readline(prompt, true)
+      end
+    end
 
   end
 rescue LoadError

--- a/lib/rex/ui/text/output/stdio.rb
+++ b/lib/rex/ui/text/output/stdio.rb
@@ -16,6 +16,76 @@ module Text
 #
 ###
 class Output::Stdio < Rex::Ui::Text::Output
+  #
+  # Attributes
+  #
+
+  # @!attribute io
+  #   The raw `IO` backing this Text output.  Defaults to `$stdout`
+  #
+  #   @return [#flush, #puts, #write]
+  attr_writer :io
+
+  #
+  # Constructor
+  #
+
+  # @param options [Hash{Symbol => IO}]
+  # @option options [IO]
+  def initialize(options={})
+    options.assert_valid_keys(:io)
+
+    super()
+
+    self.io = options[:io]
+  end
+
+  #
+  # Methods
+  #
+
+  def flush
+    io.flush
+  end
+
+  # IO to write to.
+  #
+  # @return [IO] Default to `$stdout`
+  def io
+    @io ||= $stdout
+  end
+
+  #
+  # Prints the supplied message to standard output.
+  #
+  def print_raw(msg = '')
+    if (Rex::Compat.is_windows and supports_color?)
+      WindowsConsoleColorSupport.new(io).write(msg)
+    else
+      io.print(msg)
+    end
+
+    io.flush
+
+    msg
+  end
+  alias_method :write, :print_raw
+
+  def puts(*args)
+    args.each do |argument|
+      line = argument.to_s
+      write(line)
+
+      unless line.ends_with? "\n"
+        # yes, this is output, but `IO#puts` uses `rb_default_rs`, which is
+        # [`$/`](https://github.com/ruby/ruby/blob/3af8e150aded9d162bfd41426aaaae0279e5a653/io.c#L12168-L12172),
+        # which is [`$INPUT_RECORD_SEPARATOR`](https://github.com/ruby/ruby/blob/3af8e150aded9d162bfd41426aaaae0279e5a653/lib/English.rb#L83)
+        write($INPUT_RECORD_SEPARATOR)
+      end
+    end
+
+    nil
+  end
 
   def supports_color?
     case config[:color]
@@ -30,20 +100,6 @@ class Output::Stdio < Rex::Ui::Text::Output
       term = Rex::Compat.getenv('TERM')
       return (term and term.match(/(?:vt10[03]|xterm(?:-color)?|linux|screen|rxvt)/i) != nil)
     end
-  end
-
-  #
-  # Prints the supplied message to standard output.
-  #
-  def print_raw(msg = '')
-    if (Rex::Compat.is_windows and supports_color?)
-      WindowsConsoleColorSupport.new($stdout).write(msg)
-    else
-      $stdout.print(msg)
-    end
-    $stdout.flush
-
-    msg
   end
 end
 


### PR DESCRIPTION
MSP-11669

Set output stream for RbReadline (rl_outstream) to the
Rex::Ui::Text::Output::Stdio, which will use translate the ANSI color
escapes to set_color calls in Windows.

![screen shot 2014-12-08 at 12 38 00 pm](https://cloud.githubusercontent.com/assets/2230482/5346980/9bc01c06-7eea-11e4-84d6-c9b5e7557539.png)
# Verification Steps
## Linux/OSX
### rb-readline
- [x] `msfconsole`
- [x] VERIFY prompt is colored
- [x] `use exploit/<TAB><TAB>`
- [x] `<y>`
- [x] VERIFY pager is displayed
- [x] VERIFY `--More--` is printed at bottom of page
- [x] `<SPACE>`
- [x] VERIFY next page is shown
- [x] `<q>`
- [x] VERIFY pager goes away and prompt restored with `use exploit/`
- [x] `use exploit/windows/smb/ms08_067_netapi`
- [x] VERIFY prompt changes to show shortname (ms08_067_netapi) in red in prompt.
- [x] `exit`
### GNU readline
- [x] `msfconsole -L`
- [x] VERIFY prompt is colored
- [x] `use exploit/<TAB><TAB>`
- [x] `<y>`
- [x] VERIFY pager is displayed
- [x] VERIFY `--More--` is printed at bottom of page
- [x] `<SPACE>`
- [x] VERIFY next page is shown
- [x] `<q>`
- [x] VERIFY pager goes away and prompt restored with `use exploit/`
- [x] `use exploit/windows/smb/ms08_067_netapi`
- [x] VERIFY prompt changes to show shortname (ms08_067_netapi) in red in prompt.
- [x] `exit`
## Windows
### Patch
- [ ] Upload lib/rex/ui/text/output/stdio.rb to C:\metasploit\apps\pro\msf3\lib\rex\ui\text\output\stdio.rb
- [ ] Upload lib/rex/ui/text/input/readline.rb to C:\metasploit\apps\pro\msf3\lib\rex\ui\text\input\readline.rb
### Test
- [x] Start > All Programms > Metasploit > Metasploit Console 
- [x] `msfconsole`
- [x] VERIFY prompt is colored
- [x] `use exploit/<TAB><TAB>`
- [x] `<y>`
- [x] VERIFY pager is displayed
- [x] VERIFY `--More--` is printed at bottom of page
- [x] `<SPACE>`
- [x] VERIFY next page is shown
- [x] `<q>`
- [x] VERIFY pager goes away and prompt restored with `use exploit/`
- [x] `use exploit/windows/smb/ms08_067_netapi`
- [x] VERIFY prompt changes to show shortname (ms08_067_netapi) in red in prompt.
- [x] `exit`
