### PR TITLE
Clarify about how BES uses os_flavor

### DIFF
--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -48,7 +48,6 @@ module Msf
       :ua_name,      # Example: MSIE
       :ua_ver,       # Example: 8.0, 9.0
       :os_name,      # Example: Windows 7, Linux
-      #:os_flavor,    # Example: Home, Enterprise: (currently not implemented in os detection)
       :os_device,    # Example: iPad, iPhone, etc
       :os_vendor,    # Example: Microsoft, Ubuntu, Apple, etc
       :os_sp,        # Example: SP2
@@ -214,8 +213,7 @@ module Msf
     # Returns the target profile based on the tag. Each profile has the following structure:
     # 'cookie_name' =>
     # {
-    #   :os_name   => 'Windows 7',
-    #   :os_flavor => 'Enterprise', # os_flavor is currently not implemented in os detection
+    #   :os_name   => 'Windows 7'
     #   ...... etc ......
     # }
     # A profile should at least have info about the following:
@@ -224,7 +222,6 @@ module Msf
     # :ua_name   : The name of the browser
     # :ua_ver    : The version of the browser (not yet implemented)
     # :os_name   : The name of the OS ("Windows XP")
-    # :os_flavor : The edition of the OS ("Home")
     # :language  : The system's language
     # :arch      : The system's arch
     # :proxy     : Indicates whether proxy is used

--- a/lib/msf/core/exploit/remote/browser_exploit_server.rb
+++ b/lib/msf/core/exploit/remote/browser_exploit_server.rb
@@ -48,7 +48,7 @@ module Msf
       :ua_name,      # Example: MSIE
       :ua_ver,       # Example: 8.0, 9.0
       :os_name,      # Example: Windows 7, Linux
-      :os_flavor,    # Example: Home, Enterprise
+      #:os_flavor,    # Example: Home, Enterprise: (currently not implemented in os detection)
       :os_device,    # Example: iPad, iPhone, etc
       :os_vendor,    # Example: Microsoft, Ubuntu, Apple, etc
       :os_sp,        # Example: SP2
@@ -215,14 +215,14 @@ module Msf
     # 'cookie_name' =>
     # {
     #   :os_name   => 'Windows 7',
-    #   :os_flavor => 'Enterprise',
+    #   :os_flavor => 'Enterprise', # os_flavor is currently not implemented in os detection
     #   ...... etc ......
     # }
     # A profile should at least have info about the following:
     # :source    : The data source. Either from 'script', or 'headers'. The 'script' source
     #              should be more accurate in some scenarios like browser compatibility mode
     # :ua_name   : The name of the browser
-    # :ua_ver    : The version of the browser
+    # :ua_ver    : The version of the browser (not yet implemented)
     # :os_name   : The name of the OS ("Windows XP")
     # :os_flavor : The edition of the OS ("Home")
     # :language  : The system's language
@@ -383,7 +383,6 @@ module Msf
         var osInfo = os_detect.getVersion();
         var d = {
           "os_name"     : osInfo.os_name,
-          "os_flavor"   : osInfo.os_flavor,
           "os_vendor"   : osInfo.os_vendor,
           "os_device"   : osInfo.os_device,
           "ua_name"     : osInfo.ua_name,

--- a/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
+++ b/spec/lib/msf/core/exploit/remote/browser_exploit_server_spec.rb
@@ -36,8 +36,7 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
   let(:expected_profile) do
     {
       :source=>'script',
-      :os_name=>'Microsoft Windows',
-      :os_flavor=>'XP',
+      :os_name=>'Windows XP',
       :ua_name=>'MSIE',
       :ua_ver=>'8.0',
       :arch=>'x86',
@@ -210,13 +209,13 @@ describe Msf::Exploit::Remote::BrowserExploitServer do
 
   describe "#extract_requirements" do
     it "finds all the recognizable keys" do
-      requirements = {:os_flavor=>"XP", :ua_name=>"MSIE", :ua_ver=>"8.0"}
+      requirements = {:os_name=>"Windows XP", :ua_name=>"MSIE", :ua_ver=>"8.0"}
       matches = server.extract_requirements(requirements)
       expect(matches).to eq(requirements)
     end
 
     it "makes sure the keys are always symbols" do
-      requirements = {'os_flavor'=>"XP", 'ua_name'=>"MSIE"}
+      requirements = {'os_name'=>"Windows XP", 'ua_name'=>"MSIE"}
       matches = server.extract_requirements(requirements)
       matches.each do |k,v|
         expect(k.class).to eq(Symbol)


### PR DESCRIPTION
We don't. We don't use os_flavor anymore because it is no longer implemented, therefore the mixin should not provide that information as a usable key in REQUIREMENT_KEY_SET. We get the information from os_name instead.

**Verification**
- [x] Make sure Travis is green
- [ ] Try testing a BES-powered exploit. You should either see it trying to serve the exploit, or it should at least flag the unmet requirements correctly.
