### PR TITLE
Msfvenom should pass the datastore to encoders too

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -309,12 +309,14 @@ module Msf
         # Allow comma seperated list of encoders so users can choose several
         encoder.split(',').each do |chosen_encoder|
           e = framework.encoders.create(chosen_encoder)
+          e.datastore.import_options_from_hash(datastore)
           encoders << e if e
         end
         encoders.sort_by { |my_encoder| my_encoder.rank }.reverse
       elsif badchars.present?
         framework.encoders.each_module_ranked('Arch' => [arch], 'Platform' => platform_list) do |name, mod|
           e = framework.encoders.create(name)
+          e.datastore.import_options_from_hash(datastore)
           encoders << e if e
         end
         encoders.sort_by { |my_encoder| my_encoder.rank }.reverse


### PR DESCRIPTION
Currently it looks like datastore options are not set for encoders when used by msfvenom. This leads to invalid shellcode being created when an option for the encoder is specified.

For example generating alpha numeric shellcode often requires specifying a value for BufferRegister like this:
`./msfvenom -p windows/meterpreter/reverse_tcp LHOST=192.168.90.1 LPORT=4444 -a x86 -t raw -a x86 -e x86/alpha_mixed BufferRegister=EAX`

Testing:
- [x] Generate alphanumeric shellcode, relying on an encoder option being set correctly with msfvenom
- [x] Ensure that the encoder received the option and the result is valid
