### PR TITLE
Fix issue with execution of perl due to gsub not matching across newlines

### DIFF
--- a/modules/exploits/unix/smtp/exim4_string_format.rb
+++ b/modules/exploits/unix/smtp/exim4_string_format.rb
@@ -322,7 +322,7 @@ class Metasploit3 < Msf::Exploit::Remote
         buff << res if res
       end
 
-      perl_path = buff.gsub(token, "").gsub(/\/perl.*/, "/perl").strip
+      perl_path = buff.gsub(token, "").gsub(/\/perl.*/m, "/perl").strip
       print_status("Using Perl interpreter at #{perl_path}...")
 
       temp_conf = "/var/tmp/" + Rex::Text.rand_text_alpha(8)


### PR DESCRIPTION
When using, for example, the cmd/unix/reverse payload, this exploit was not working because the remote host was returning a value for the perl path that included newlines. Example:

```
/usr/bin/perl
jVUgZjLq
$
```

The gsub was not matching across newlines and therefore the exploit files written to /var/tmp contained 

```
/usr/bin/perl

$
```

as the interpreter and failed to run.

The simple fix is to match across newlines with the m modifier. Tested against Ubuntu 8.04 and Exim 4.69.
