### PR TITLE
Fix event handlers on ruby 2

### DIFF
--- a/lib/msf/core/event_dispatcher.rb
+++ b/lib/msf/core/event_dispatcher.rb
@@ -176,7 +176,7 @@ class EventDispatcher
     found = false
     case event
     when "on"
-      if respond_to?(subscribers)
+      if respond_to?(subscribers, true)
         found = true
         self.send(subscribers).each do |sub|
           next if not sub.respond_to?(name)
@@ -221,11 +221,11 @@ protected
     array.delete(subscriber)
   end
 
-  attr_accessor :general_event_subscribers # :nodoc:
   attr_accessor :custom_event_subscribers # :nodoc:
-  attr_accessor :exploit_event_subscribers # :nodoc:
-  attr_accessor :session_event_subscribers # :nodoc:
   attr_accessor :db_event_subscribers # :nodoc:
+  attr_accessor :exploit_event_subscribers # :nodoc:
+  attr_accessor :general_event_subscribers # :nodoc:
+  attr_accessor :session_event_subscribers # :nodoc:
   attr_accessor :ui_event_subscribers # :nodoc:
 
 end

--- a/lib/msf/core/payload.rb
+++ b/lib/msf/core/payload.rb
@@ -449,7 +449,6 @@ class Payload < Msf::Module
   #
   def on_session(session)
 
-
     # If this payload is associated with an exploit, inform the exploit
     # that a session has been created and potentially shut down any
     # open sockets. This allows active exploits to continue hammering

--- a/plugins/event_tester.rb
+++ b/plugins/event_tester.rb
@@ -21,17 +21,19 @@ class Plugin::EventTester < Msf::Plugin
   def initialize(framework, opts)
     super
     @subscriber = Subscriber.new
-    framework.events.add_exploit_subscriber(@subscriber)
-    framework.events.add_session_subscriber(@subscriber)
-    framework.events.add_general_subscriber(@subscriber)
+    framework.events.add_custom_subscriber(@subscriber)
     framework.events.add_db_subscriber(@subscriber)
+    framework.events.add_exploit_subscriber(@subscriber)
+    framework.events.add_general_subscriber(@subscriber)
+    framework.events.add_session_subscriber(@subscriber)
     framework.events.add_ui_subscriber(@subscriber)
   end
   def cleanup
-    framework.events.remove_exploit_subscriber(@subscriber)
-    framework.events.remove_session_subscriber(@subscriber)
-    framework.events.remove_general_subscriber(@subscriber)
+    framework.events.remove_custom_subscriber(@subscriber)
     framework.events.remove_db_subscriber(@subscriber)
+    framework.events.remove_exploit_subscriber(@subscriber)
+    framework.events.remove_general_subscriber(@subscriber)
+    framework.events.remove_session_subscriber(@subscriber)
     framework.events.remove_ui_subscriber(@subscriber)
   end
 end


### PR DESCRIPTION
Fixes #4219.

Because `#respond_to?` no longer returns true for protected methods, the block that actually calls all the event subscribers was dead code on Ruby 2.x
### Verification
- [x] Make sure you're using Ruby 2.1.x
- [x] Get a session
- [x] **Verify** Output contains:

```
[*] Command shell session 1 opened
```
