### PR TITLE
Fix description from tuleap_unserialize_exec

### DIFF
--- a/modules/exploits/unix/webapp/tuleap_unserialize_exec.rb
+++ b/modules/exploits/unix/webapp/tuleap_unserialize_exec.rb
@@ -18,7 +18,7 @@ class Metasploit3 < Msf::Exploit::Remote
         abused to allow authenticated users to execute arbitrary code with the permissions of the
         web server. The dangerous unserialize() call exists in the 'src/www/project/register.php'
         file. The exploit abuses the destructor method from the Jabbex class in order to reach a
-        call_user_func_array() call in the Jabbex class and call the fetchPostActions() method from
+        call_user_func_array() call in the Jabber class and call the fetchPostActions() method from
         the Transition_PostAction_FieldFactory class to execute PHP code through an eval() call. In
         order to work, the target must have the 'sys_create_project_in_one_step' option disabled.
       },


### PR DESCRIPTION
There is a typo according to the module author @EgiX. See coment at the end of https://github.com/rapid7/metasploit-framework/pull/4341
