### PR TITLE
enum_ad_* post module fixes

### DIFF
--- a/lib/msf/core/post/windows/ldap.rb
+++ b/lib/msf/core/post/windows/ldap.rb
@@ -149,7 +149,7 @@ module LDAP
       query_result = query_ldap(session_handle, "", 0, "(objectClass=computer)", ["defaultNamingContext"])
       first_entry_fields = query_result[:results].first
       # Value from First Attribute of First Entry
-      default_naming_context = first_entry_fields.first
+      default_naming_context = first_entry_fields.first[:value]
       vprint_status("Default naming context #{default_naming_context}")
       return default_naming_context
     end
@@ -231,7 +231,7 @@ module LDAP
         values_result = values.join(',') if values
         vprint_status("Values #{values}")
 
-        field_results << values_result
+        field_results << {:type => 'unknown', :value => values_result}
       end
 
       entry_results << field_results

--- a/modules/post/windows/gather/enum_ad_computers.rb
+++ b/modules/post/windows/gather/enum_ad_computers.rb
@@ -88,7 +88,7 @@ class Metasploit3 < Msf::Post
         if db && datastore['STORE_DB']
           case fields[i]
           when 'dNSHostName'
-            dns = field.value
+            dns = field
             report[:name] = dns
             hostnames << dns
           when 'operatingSystem'

--- a/modules/post/windows/gather/enum_ad_computers.rb
+++ b/modules/post/windows/gather/enum_ad_computers.rb
@@ -81,14 +81,14 @@ class Metasploit3 < Msf::Post
 
       report = {}
       0.upto(fields.length-1) do |i|
-        field = result[i] || ""
+        field = result[i][:value] || ""
 
         # Only perform these actions if the database is connected and we want
         # to store in the DB.
         if db && datastore['STORE_DB']
           case fields[i]
           when 'dNSHostName'
-            dns = field
+            dns = field.value
             report[:name] = dns
             hostnames << dns
           when 'operatingSystem'

--- a/modules/post/windows/gather/enum_ad_computers.rb
+++ b/modules/post/windows/gather/enum_ad_computers.rb
@@ -92,7 +92,7 @@ class Metasploit3 < Msf::Post
             report[:name] = dns
             hostnames << dns
           when 'operatingSystem'
-            report[:os_name] = field
+            report[:os_name] = field.gsub("\xAE",'')
           when 'distinguishedName'
             if field =~ /Domain Controllers/i
               # TODO: Find another way to mark a host as being a domain controller

--- a/modules/post/windows/gather/enum_ad_service_principal_names.rb
+++ b/modules/post/windows/gather/enum_ad_service_principal_names.rb
@@ -100,7 +100,7 @@ class Metasploit3 < Msf::Post
     row = []
 
     0.upto(fields.length-1) do |i|
-      field = (result[i].nil? ? "" : result[i])
+      field = (result[i][:value].nil? ? "" : result[i][:value])
 
       if fields[i] == 'servicePrincipalName'
         break if field.blank?

--- a/modules/post/windows/gather/enum_ad_to_wordlist.rb
+++ b/modules/post/windows/gather/enum_ad_to_wordlist.rb
@@ -26,7 +26,6 @@ class Metasploit3 < Msf::Post
     'company',
     'streetAddress',
     'sAMAccountName',
-    'userAccountControl',
     'comment',
     'description'
   ]
@@ -37,7 +36,7 @@ class Metasploit3 < Msf::Post
       'Description'  => %q{
         This module will gather information from the default Active Domain (AD) directory
         and use these words to seed a wordlist. By default it enumerates user accounts to
-        build the wordlist
+        build the wordlist.
       },
       'License'      => MSF_LICENSE,
       'Author'       => ['Thomas Ring'],
@@ -69,7 +68,7 @@ class Metasploit3 < Msf::Post
     @words_dict = {}
     q[:results].each do |result|
       result.each do |field|
-        search_words(field)
+        search_words(field[:value])
       end # result.each
     end # q.each
 

--- a/modules/post/windows/gather/enum_ad_user_comments.rb
+++ b/modules/post/windows/gather/enum_ad_user_comments.rb
@@ -65,10 +65,11 @@ class Metasploit3 < Msf::Post
 
       report = {}
       result.each do |field|
-        if field.nil?
+        if field[:value].nil?
           row << ""
         else
-          row << field
+          row << field[:value]
+
         end
       end
 


### PR DESCRIPTION
https://github.com/rapid7/metasploit-framework/pull/3175 broke enum_ad_\* post modules as it changed the return type from the ADSI queries. 

Fixes: https://github.com/rapid7/metasploit-framework/issues/4387

Poke @OJ @bcook-r7 

This also modifies the legacy Railgun LDAP implementation so it returns data in the same format. 
## Verification
- Run enum_ad_computers - results should be hashes :(
- Apply PR
- enum_ad_computers, enum_ad_user_comments, enum_ad_service_principal_names and enum_ad_to_wordlist - results should be as expected
