### PR TITLE
Resolves #4275 - Configurable variable name as an option for msfvenom

### DIFF
--- a/lib/msf/base/simple/buffer.rb
+++ b/lib/msf/base/simple/buffer.rb
@@ -18,7 +18,9 @@ module Buffer
   # Serializes a buffer to a provided format.  The formats supported are raw,
   # num, dword, ruby, python, perl, bash, c, js_be, js_le, java and psh
   #
-  def self.transform(buf, fmt = "ruby")
+  def self.transform(buf, fmt = "ruby", var_name = 'buf')
+    default_wrap = 60
+
     case fmt
       when 'raw'
       when 'num'
@@ -26,29 +28,29 @@ module Buffer
       when 'dword', 'dw'
         buf = Rex::Text.to_dword(buf)
       when 'python', 'py'
-        buf = Rex::Text.to_python(buf)
+        buf = Rex::Text.to_python(buf, default_wrap, var_name)
       when 'ruby', 'rb'
-        buf = Rex::Text.to_ruby(buf)
+        buf = Rex::Text.to_ruby(buf, default_wrap, var_name)
       when 'perl', 'pl'
-        buf = Rex::Text.to_perl(buf)
+        buf = Rex::Text.to_perl(buf, default_wrap, var_name)
       when 'bash', 'sh'
-        buf = Rex::Text.to_bash(buf)
+        buf = Rex::Text.to_bash(buf, default_wrap, var_name)
       when 'c'
-        buf = Rex::Text.to_c(buf)
+        buf = Rex::Text.to_c(buf, default_wrap, var_name)
       when 'csharp'
-        buf = Rex::Text.to_csharp(buf)
+        buf = Rex::Text.to_csharp(buf, default_wrap, var_name)
       when 'js_be'
         buf = Rex::Text.to_unescape(buf, ENDIAN_BIG)
       when 'js_le'
         buf = Rex::Text.to_unescape(buf, ENDIAN_LITTLE)
       when 'java'
-        buf = Rex::Text.to_java(buf)
+        buf = Rex::Text.to_java(buf, var_name)
       when 'powershell', 'ps1'
-        buf = Rex::Text.to_powershell(buf)
+        buf = Rex::Text.to_powershell(buf, var_name)
       when 'vbscript'
-        buf = Rex::Text.to_vbscript(buf)
+        buf = Rex::Text.to_vbscript(buf, var_name)
       when 'vbapplication'
-        buf = Rex::Text.to_vbapplication(buf)
+        buf = Rex::Text.to_vbapplication(buf, var_name)
       else
         raise ArgumentError, "Unsupported buffer format: #{fmt}", caller
     end

--- a/lib/msf/core/payload_generator.rb
+++ b/lib/msf/core/payload_generator.rb
@@ -70,6 +70,9 @@ module Msf
     # @!attribute  template
     #   @return [String] The path to an executable template to use
     attr_accessor :template
+    # @!attribute  var_name
+    #   @return [String] The custom variable string for certain output formats
+    attr_accessor :var_name
 
 
     # @param opts [Hash] The options hash
@@ -105,6 +108,7 @@ module Msf
       @space      = opts.fetch(:space, 1.gigabyte)
       @stdin      = opts.fetch(:stdin, nil)
       @template   = opts.fetch(:template, '')
+      @var_name   = opts.fetch(:var_name, 'buf')
 
       @framework  = opts.fetch(:framework)
 
@@ -213,10 +217,10 @@ module Msf
           if Rex::Arch.endian(arch) != ENDIAN_BIG
             raise IncompatibleEndianess, "Big endian format selected for a non big endian payload"
           else
-            ::Msf::Simple::Buffer.transform(shellcode, format)
+            ::Msf::Simple::Buffer.transform(shellcode, format, @var_name)
           end
         when *::Msf::Simple::Buffer.transform_formats
-          ::Msf::Simple::Buffer.transform(shellcode, format)
+          ::Msf::Simple::Buffer.transform(shellcode, format, @var_name)
         when *::Msf::Util::EXE.to_executable_fmt_formats
           ::Msf::Util::EXE.to_executable_fmt(framework, arch, platform_list, shellcode, format, exe_options)
         else

--- a/msfvenom
+++ b/msfvenom
@@ -121,6 +121,10 @@ require 'msf/core/payload_generator'
       opts[:list_options] = true
     end
 
+    opt.on('-v', '--var-name <name>', String, 'Specify a custom variable name to use for certain output formats') do |x|
+      opts[:var_name] = x
+    end
+
     opt.on_tail('-h', '--help', 'Show this message') do
       raise UsageError, "#{opt}"
     end

--- a/spec/lib/msf/core/payload_generator_spec.rb
+++ b/spec/lib/msf/core/payload_generator_spec.rb
@@ -62,6 +62,7 @@ describe Msf::PayloadGenerator do
         reference_name: 'x86/shikata_ga_nai'
     )
   }
+  let(:var_name) { 'buf' }
 
   subject(:payload_generator) {
     described_class.new(generator_opts)
@@ -482,7 +483,7 @@ describe Msf::PayloadGenerator do
       let(:format) { 'c' }
 
       it 'applies the appropriate transform format' do
-        ::Msf::Simple::Buffer.should_receive(:transform).with(shellcode, format)
+        ::Msf::Simple::Buffer.should_receive(:transform).with(shellcode, format, var_name)
         payload_generator.format_payload(shellcode)
       end
     end


### PR DESCRIPTION
Resolves #4275

This allows the payload output to have a configurable variable name. Please note that not all formats have a variable name, the ones that actually do include: Python, Ruby, Perl, Bash, C, C#, Java, Powershell, VBScript, and VB Application.
## Verification

This one is just making sure I'm not messing up the the most basic part of msfvenom:
- [x] Do: `./msfvenom -p windows/meterpreter/bind_tcp -v myVarName -f raw`
- [x] You should not see "myVarName" in your payload's output

This following portion should test the actual feature. You need to test quite a few different formats, but they all  can be tested like the following example:

``` bash
echo AAAA | ./msfvenom -p - -a x86 --platform windows -v myVar -f java
Attempting to read payload from STDIN...
Found 0 compatible encoders
byte myVar[] = new byte[]
{
    (byte) 0x41, (byte) 0x41, (byte) 0x41, (byte) 0x41, (byte) 0x0a
};
```

You should also make sure there is always a default variable name (which should be "buf") when -v isn't specified:

```
echo AAAA | ./msfvenom -p - -a x86 --platform windows -f java
Attempting to read payload from STDIN...
Found 0 compatible encoders
byte buf[] = new byte[]
{
    (byte) 0x41, (byte) 0x41, (byte) 0x41, (byte) 0x41, (byte) 0x0a
};
```

Now, based on the above two examples, please test the following formats:
- [x] bash
- [x] c
- [x] csharp
- [x] perl
- [x] powershell
- [x] py
- [x] rb
- [x] sh
- [x] vbapplication
- [x] vbscript
