### PR TITLE
This oracle scheduler exploit hangs if not vuln

### DIFF
--- a/modules/exploits/windows/oracle/extjob.rb
+++ b/modules/exploits/windows/oracle/extjob.rb
@@ -53,9 +53,13 @@ class Metasploit3 < Msf::Exploit::Remote
   end
 
   def exploit
-    print_status("Exploiting through \\\\#{datastore['RHOST']}\\orcljsex#{datastore['SID']} named pipe...")
-    execute_cmdstager({:linemax => 1500})
-    handler
+    if check == Exploit::CheckCode::Vulnerable
+      print_status("Exploiting through \\\\#{datastore['RHOST']}\\orcljsex#{datastore['SID']} named pipe...")
+      execute_cmdstager({:linemax => 1500})
+      handler
+    else
+      print_error "#{rhost} does not appear to be vulnerable!"
+    end
   end
 
   def execute_command(cmd, opts)


### PR DESCRIPTION
When this exploit gets run against a system that isn't vulnerable
it can hang for a signifigant ammount of time. This change uses the check
method on the exploit to see whether it should proceed. Don't try to exploit
the host if it's not vulnerable.

VERIFICATION STEPS
- [x] target any host with SMB up, not running the Oracle scheduler agent
- [x] launch the exploit
- [x] VERIFY that it gives a message that the target is not vulenrable and then exits
