### PR TITLE
Do not delete files that do not exist in rm_f

### DIFF
--- a/lib/msf/core/post/file.rb
+++ b/lib/msf/core/post/file.rb
@@ -310,7 +310,7 @@ module Msf::Post::File
   def rm_f(*remote_files)
     remote_files.each do |remote|
       if session.type == "meterpreter"
-        session.fs.file.delete(remote)
+        session.fs.file.delete(remote) if exist?(remote)
       else
         if session.platform =~ /win/
           cmd_exec("del /q /f #{remote}")


### PR DESCRIPTION
Once @bcook-r7's changes are landed from rapid7/meterpreter#106 the Linux meterpreter will throw errors correctly when trying to delete a file which does not exist. This is already the behavior of the Python and Windows meterpreters. The `rm_f` function should check that the file exists before trying to delete it to avoid throwing an error. This is more intuitive to what the shell command `rm -f` does (exiting with status 0 if the file does not exist). I opted to check with `exists?` because the shell version will fail when a directory is specified.

Without this change, calls to rm_f to delete files which do not exist, will throw unnecessary errors. See [sock_sendpage](https://github.com/rapid7/metasploit-framework/blob/master/modules/exploits/linux/local/sock_sendpage.rb#L446) for an example.

Verification steps:
- [x] Open a Python meterpreter (or Linux meterpreter if the aforementioned PR is landed first)
- [x] Use the `linux/local/sock_sendpage` exploit module
- [x] Do **not** get an error when the module calls rm_f and the file does not exist
- [x] The exploit will continue to work as intended
