### PR TITLE
Resolve #4408 - bad uncaught nil get_once

### DIFF
--- a/modules/auxiliary/scanner/misc/ib_service_mgr_info.rb
+++ b/modules/auxiliary/scanner/misc/ib_service_mgr_info.rb
@@ -154,7 +154,7 @@ class Metasploit3 < Msf::Auxiliary
 
       sock.put(buf)
 
-      response = sock.get_once
+      response = sock.get_once || ''
 
       # print(Rex::Text.to_hex_dump(response))
 
@@ -198,7 +198,7 @@ class Metasploit3 < Msf::Auxiliary
 
       sock.put(buf)
 
-      response = sock.get_once
+      response = sock.get_once || ''
 
       res = response.unpack('x28Z*Z*')
 

--- a/modules/auxiliary/scanner/misc/poisonivy_control_scanner.rb
+++ b/modules/auxiliary/scanner/misc/poisonivy_control_scanner.rb
@@ -66,9 +66,9 @@ class Metasploit3 < Msf::Auxiliary
             )
             r << [ip,port,"open",'Unknown']
             s.puts("\x00"*0x100,0) #Send 0x100 zeros, wait for answer
-            data = s.get_once(0x100)
+            data = s.get_once(0x100) || ''
             if data.length == 0x100
-              data = s.get_once(0x4)
+              data = s.get_once(0x4) || ''
               if data == "\xD0\x15\x00\x00" #Signature for PIVY C&C
                 print_status("#{ip}:#{port} - C&C Server Found")
                 r << [ip,port,"open",'Poison Ivy C&C']

--- a/modules/auxiliary/scanner/misc/zenworks_preboot_fileaccess.rb
+++ b/modules/auxiliary/scanner/misc/zenworks_preboot_fileaccess.rb
@@ -63,8 +63,20 @@ class Metasploit3 < Msf::Auxiliary
     sock.put(packet)
     sock.get_once(4, 1)
     length = sock.get_once(4, 1)
+
+    unless length
+      print_error("Unable to get length due to a timeout")
+      return
+    end
+
     sock.get_once(0x210-8, 1)
     contents = sock.get_once(length.unpack("V").first, 1)
+
+    unless contents
+      print_error("Unable to extract contents due to a timeout")
+      return
+    end
+
     disconnect
 
     print_status "File retrieved successfully!"

--- a/modules/auxiliary/scanner/rservices/rlogin_login.rb
+++ b/modules/auxiliary/scanner/rservices/rlogin_login.rb
@@ -218,7 +218,7 @@ class Metasploit3 < Msf::Auxiliary
     sock.put("\x00#{luser}\x00#{user}\x00#{datastore['TERM']}/#{datastore['SPEED']}\x00")
 
     # Read the expected nul byte response.
-    buf = sock.get_once(1)
+    buf = sock.get_once(1) || ''
     return :abort if buf != "\x00"
 
     # NOTE: We report this here, since we are awfully convinced now that this is really

--- a/modules/auxiliary/scanner/scada/sielco_winlog_fileaccess.rb
+++ b/modules/auxiliary/scanner/scada/sielco_winlog_fileaccess.rb
@@ -65,7 +65,7 @@ class Metasploit3 < Msf::Auxiliary
     packet << travs # Path traversal
     packet << "\x00"
     sock.put(packet)
-    response = sock.get_once(5, 1)
+    response = sock.get_once(5, 1) || ''
 
     if response.unpack("C").first != 0x78
       print_error "#{ip}:#{rport} - Error opening file"
@@ -84,7 +84,7 @@ class Metasploit3 < Msf::Auxiliary
     packet << stream # stream
     packet << "\x00" * 7
     sock.put(packet)
-    response = sock.get_once(5, 1)
+    response = sock.get_once(5, 1) || ''
 
     if response.unpack("C").first != 0x79
       print_error "#{ip}:#{rport} - Error getting the file length"
@@ -106,7 +106,7 @@ class Metasploit3 < Msf::Auxiliary
       response = ""
 
       while response.length < 0x7ac # Packets of 0x7ac (header (0x9) + block of data (0x7a3))
-        response << sock.get_once(0x7ac-response.length, 5)
+        response << sock.get_once(0x7ac-response.length, 5) || ''
       end
       if response.unpack("C").first != 0x98
         print_error "#{ip}:#{rport} - Error reading the file, anyway we're going to try to finish"
@@ -126,7 +126,7 @@ class Metasploit3 < Msf::Auxiliary
     packet << "\x7B"
     packet << "\x00" * 11
     sock.put(packet)
-    response = sock.get_once(-1, 1)
+    response = sock.get_once(-1, 1) || ''
     if response.unpack("C").first != 0x7B
       print_error "#{ip}:#{rport} - Error closing file file, anyway we're going to try to finish"
     end

--- a/modules/auxiliary/scanner/ssh/detect_kippo.rb
+++ b/modules/auxiliary/scanner/ssh/detect_kippo.rb
@@ -29,9 +29,9 @@ class Metasploit4 < Msf::Auxiliary
 
   def run_host(ip)
     connect
-    banner = sock.get_once
+    banner = sock.get_once || ''
     sock.put(banner + "\n" * 8)
-    response = sock.get_once
+    response = sock.get_once || ''
 
     if response =~ /(?:^Protocol mismatch\.\n$|bad packet length)/
       print_good("#{ip}:#{rport} - Kippo detected!")

--- a/modules/auxiliary/scanner/vmware/vmauthd_version.rb
+++ b/modules/auxiliary/scanner/vmware/vmauthd_version.rb
@@ -84,7 +84,7 @@ class Metasploit3 < Msf::Auxiliary
 
   def do_login(user, pass, nsock=self.sock)
     nsock.put("USER #{user}\r\n")
-    res = nsock.get_once
+    res = nsock.get_once || ''
     unless res.start_with? "331"
       ret_msg = "Unexpected reply to the USER command: #{res}"
       return ret_msg

--- a/modules/auxiliary/scanner/x11/open_x11.rb
+++ b/modules/auxiliary/scanner/x11/open_x11.rb
@@ -45,8 +45,11 @@ class Metasploit3 < Msf::Auxiliary
 
       disconnect
 
-      if(response)
+      if response
         success = response[0,1].unpack('C')[0]
+      else
+        print_error("No response received due to a timeout")
+        return
       end
 
 


### PR DESCRIPTION
Sometimes get_once can return nil, and if that's not handled, it can cause a backtrace. If there is a backtrace, it means one host that causes the backtrace can cause the entire scan to stop (and that you will probably never be able to scan the whole network with it).

The issue (ticket) explains better about this problem.
## Verification

This was all done by reviewing code. I don't actually all these machines to test. So I guess the verification steps are:
- [x] When you see a get_once, make sure nil is handled.
