### PR TITLE
Fix #4409 - Uncaught nil or empty return value for getting an expanded environment variable

### DIFF
--- a/modules/post/windows/escalate/ms10_073_kbdlayout.rb
+++ b/modules/post/windows/escalate/ms10_073_kbdlayout.rb
@@ -177,6 +177,9 @@ EOS
 
     # Create the malicious Keyboard Layout file...
     tmpdir = session.sys.config.getenv('TEMP')
+    unless tmpdir
+      fail_with(Failure::Unknown, "Unable to retrieve environment variable TEMP")
+    end
     fname = "p0wns.boom"
     dllpath = "#{tmpdir}\\#{fname}"
     fd = session.fs.file.new(dllpath, 'wb')

--- a/modules/post/windows/escalate/net_runtime_modify.rb
+++ b/modules/post/windows/escalate/net_runtime_modify.rb
@@ -42,6 +42,9 @@ class Metasploit3 < Msf::Post
     services = []
     vuln = ""
     @temp = session.sys.config.getenv('TEMP')
+    unless @temp
+      fail_with(Failure::Unknown, "Unable to retrieve environment variable TEMP")
+    end
 
     if init_railgun() == :error
       return

--- a/modules/post/windows/gather/credentials/skype.rb
+++ b/modules/post/windows/gather/credentials/skype.rb
@@ -146,6 +146,9 @@ puts hash.hexdigest
 
   def get_config_creds(salt)
     users = []
+    if expand_path("%AppData%").blank?
+      fail_with(Failure::Unknown, "Unable to retrieve %AppData%")
+    end
     appdatapath = expand_path("%AppData%") + "\\Skype"
     print_status ("Checking for config files in %APPDATA%")
     users = get_config_users(appdatapath)

--- a/modules/post/windows/gather/credentials/tortoisesvn.rb
+++ b/modules/post/windows/gather/credentials/tortoisesvn.rb
@@ -103,6 +103,9 @@ class Metasploit3 < Msf::Post
   def get_config_files
     # Determine if TortoiseSVN is installed and parse config files
     savedpwds = 0
+    if session.fs.file.expand_path("%APPDATA%").blank?
+      fail_with(Failure::Unknown, "Unable to retrieve %APPDATA%")
+    end
     path = session.fs.file.expand_path("%APPDATA%\\Subversion\\auth\\svn.simple\\")
     print_status("Checking for configuration files in: #{path}")
 

--- a/modules/post/windows/gather/credentials/winscp.rb
+++ b/modules/post/windows/gather/credentials/winscp.rb
@@ -184,6 +184,9 @@ class Metasploit3 < Msf::Post
 
   def run
     print_status("Looking for WinSCP.ini file storage...")
+    if expand_path("%PROGRAMFILES%").blank?
+      fail_with(Failure::Unknown, "Unable to retrieve %PROGRAMFILES%")
+    end
     get_ini(expand_path("%PROGRAMFILES%\\WinSCP\\WinSCP.ini"))
     print_status("Looking for Registry Storage...")
     get_reg()

--- a/modules/post/windows/gather/enum_db.rb
+++ b/modules/post/windows/gather/enum_db.rb
@@ -293,6 +293,9 @@ class Metasploit3 < Msf::Post
     end
 
     windir = session.sys.config.getenv('windir')
+    unless windir
+      fail_with(Failure::Unknown, "Unable to retrieve environment variable windir")
+    end
     getfile = session.fs.file.search(windir + "\\system32\\drivers\\etc\\","services.*",recurse=true,timeout=-1)
 
     data = nil

--- a/modules/post/windows/gather/enum_ie.rb
+++ b/modules/post/windows/gather/enum_ie.rb
@@ -258,6 +258,9 @@ class Metasploit3 < Msf::Post
     h_paths = []
     c_paths = []
     base = session.sys.config.getenv('USERPROFILE')
+    unless base
+      fail_with(Failure::Unknown, "Unable to retrieve environment variable USERPROFILE")
+    end
     if host['OS'] =~ /(Windows 7|2008|Vista)/
       h_paths << base + vist_h
       h_paths << base + vist_hlow

--- a/modules/post/windows/gather/enum_muicache.rb
+++ b/modules/post/windows/gather/enum_muicache.rb
@@ -138,6 +138,9 @@ class Metasploit3 < Msf::Post
   # the MUICache registry key.
   def process_hive(sys_path, user, muicache, hive_file)
     user_home_path = expand_path(sys_path)
+    if user_home_path.blank?
+      fail_with(Failure::Unknown, "Unable to retrieve #{sys_path}")
+    end
     hive_path = user_home_path + hive_file
     ntuser_status = file_exist?(hive_path)
 

--- a/modules/post/windows/manage/download_exec.rb
+++ b/modules/post/windows/manage/download_exec.rb
@@ -79,8 +79,14 @@ class Metasploit3 < Msf::Post
     path = datastore['DOWNLOAD_PATH']
     if path.blank?
       path = session.sys.config.getenv('TEMP')
+      if path.blank?
+        fail_with(Failure::Unknown, "Unable to retrieve %TEMP%")
+      end
     else
       path = session.fs.file.expand_path(path)
+      if path.blank?
+        fail_with(Failure::Unknown, "Unable to retrieve #{path}")
+      end
     end
 
     outpath = path + '\\' + filename

--- a/modules/post/windows/manage/ie_proxypac.rb
+++ b/modules/post/windows/manage/ie_proxypac.rb
@@ -91,7 +91,7 @@ class Metasploit3 < Msf::Post
     unless appdata
       fail_with(Failure::Unknown, "Unable to retrieve environment variable APPDATA")
     end
-    pac_file = appdata << "\\" << Rex::Text.rand_text_alpha((rand(8)+6)) << ".pac"
+    pac_file = "#{appdata}\\#{Rex::Text.rand_text_alpha((rand(8)+6))}.pac"
     conf_pac = ""
 
     if ::File.exists?(local_pac)

--- a/modules/post/windows/manage/ie_proxypac.rb
+++ b/modules/post/windows/manage/ie_proxypac.rb
@@ -87,7 +87,11 @@ class Metasploit3 < Msf::Post
   end
 
   def create_pac(local_pac)
-    pac_file = session.sys.config.getenv("APPDATA") << "\\" << Rex::Text.rand_text_alpha((rand(8)+6)) << ".pac"
+    appdata = session.sys.config.getenv("APPDATA")
+    unless appdata
+      fail_with(Failure::Unknown, "Unable to retrieve environment variable APPDATA")
+    end
+    pac_file = appdata << "\\" << Rex::Text.rand_text_alpha((rand(8)+6)) << ".pac"
     conf_pac = ""
 
     if ::File.exists?(local_pac)

--- a/modules/post/windows/manage/payload_inject.rb
+++ b/modules/post/windows/manage/payload_inject.rb
@@ -160,6 +160,9 @@ class Metasploit3 < Msf::Post
   # Returns process PID
   def create_temp_proc(pay)
     windir = client.sys.config.getenv('windir')
+    unless
+      fail_with(Failure::Unknown, "Unable to retrieve environment variable windir")
+    end
     # Select path of executable to run depending the architecture
     if pay.arch.join == "x86" and client.platform =~ /x86/
       cmd = "#{windir}\\System32\\notepad.exe"

--- a/modules/post/windows/manage/pptp_tunnel.rb
+++ b/modules/post/windows/manage/pptp_tunnel.rb
@@ -78,6 +78,9 @@ class Metasploit3 < Msf::Post
 
   def create_pbk(mim,pbk_name)
     pbk_dir = expand_path("%TEMP%")
+    if pbk_dir.blank?
+      fail_with(Failure::Unknown, "Unable to retrieve %TEMP%")
+    end
     pbk_file = pbk_dir << "\\" << Rex::Text.rand_text_alpha((rand(8)+6)) << ".pbk"
 
     conf_conn = "[#{pbk_name}]\r\n\r\n"

--- a/modules/post/windows/manage/rpcapd_start.rb
+++ b/modules/post/windows/manage/rpcapd_start.rb
@@ -51,7 +51,7 @@ class Metasploit3 < Msf::Post
         unless pf
           fail_with(Failure::Unknown, "Unable to retrieve environment variable ProgramFiles")
         end
-        prog = pf << "\\winpcap\\rpcapd.exe"
+        prog =  "#{pf}\\winpcap\\rpcapd.exe"
         if reg != 2
           print_status("Setting rpcapd as 'auto' service")
           service_change_startup("rpcapd","auto")

--- a/modules/post/windows/manage/rpcapd_start.rb
+++ b/modules/post/windows/manage/rpcapd_start.rb
@@ -47,7 +47,11 @@ class Metasploit3 < Msf::Post
         print_status("Rpcap service found: #{serv['Name']}")
         reg=registry_getvaldata("HKLM\\SYSTEM\\CurrentControlSet\\Services\\rpcapd","Start")
         # TODO: check if this works on x64
-        prog=session.sys.config.getenv('ProgramFiles') << "\\winpcap\\rpcapd.exe"
+        pf = session.sys.config.getenv('ProgramFiles')
+        unless pf
+          fail_with(Failure::Unknown, "Unable to retrieve environment variable ProgramFiles")
+        end
+        prog = pf << "\\winpcap\\rpcapd.exe"
         if reg != 2
           print_status("Setting rpcapd as 'auto' service")
           service_change_startup("rpcapd","auto")


### PR DESCRIPTION
This patch mainly is meant for handling a nil (or empty) return value for the following environment variables:
- AppData
- Temp
- ProgramFiles

I also patched a few others that I find a little bit questionable, just in case, plus it never huts to check anyway.

There are two ways to get an environment variable. If it's using getenv, it's possible to get a nil if the variable isn't found. When using expand_path, it's a bit tricky, because it's possible to see an empty value due to the use of cmd_exec, or it could return nil due to a timeout.

So to verify, I guess here's what you do (by reviewing the code):
- [ ] If you see getenv is used, it should check nil
- [ ] If you see expand_path is sued, it should do `.blank?`
