### PR TITLE
Fix threads tab complete bug

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -1025,7 +1025,7 @@ class Core
       return @@threads_opts.fmt.keys
     end
 
-    if @@threads_opts.fmt[words[1]][0] and (words.length == 2)
+    if words.length == 2 and (@@threads_opts.fmt[words[1]] || [false])[0]
       return framework.threads.each_index.map{ |idx| idx.to_s }
     end
 


### PR DESCRIPTION
When tab completing the threads command with 2 arguments, msfconsole will crash if the first is not in the list of valid arguments.

Before this patch:

```
msf-git (S:0 J:0)> threads foobar /home/steiner/repos/msf-git/lib/msf/ui/console/command_dispatcher/core.rb:1028:in `cmd_threads_tabs': undefined method `[]' for nil:NilClass (NoMethodError)
    from /home/steiner/repos/msf-git/lib/rex/ui/text/dispatcher_shell.rb:357:in `tab_complete_helper'
    from /home/steiner/repos/msf-git/lib/rex/ui/text/dispatcher_shell.rb:317:in `block in tab_complete_stub'
    from /home/steiner/repos/msf-git/lib/rex/ui/text/dispatcher_shell.rb:306:in `each'
    from /home/steiner/repos/msf-git/lib/rex/ui/text/dispatcher_shell.rb:306:in `tab_complete_stub'
    from /home/steiner/repos/msf-git/lib/rex/ui/text/dispatcher_shell.rb:291:in `tab_complete'
    from /home/steiner/repos/msf-git/lib/rex/ui/text/shell.rb:59:in `block in init_tab_complete'
    from /home/steiner/.rvm/gems/ruby-2.1.4@metasploit-framework/gems/rb-readline-0.5.1/lib/readline.rb:136:in `call'
    from /home/steiner/.rvm/gems/ruby-2.1.4@metasploit-framework/gems/rb-readline-0.5.1/lib/readline.rb:136:in `readline_attempted_completion_function'
    from /home/steiner/.rvm/gems/ruby-2.1.4@metasploit-framework/gems/rb-readline-0.5.1/lib/rbreadline.rb:6277:in `gen_completion_matches'
    from /home/steiner/.rvm/gems/ruby-2.1.4@metasploit-framework/gems/rb-readline-0.5.1/lib/rbreadline.rb:6761:in `rl_complete_internal'
    from /home/steiner/.rvm/gems/ruby-2.1.4@metasploit-framework/gems/rb-readline-0.5.1/lib/rbreadline.rb:6851:in `rl_complete'
    from /home/steiner/.rvm/gems/ruby-2.1.4@metasploit-framework/gems/rb-readline-0.5.1/lib/rbreadline.rb:4322:in `_rl_dispatch_subseq'
    from /home/steiner/.rvm/gems/ruby-2.1.4@metasploit-framework/gems/rb-readline-0.5.1/lib/rbreadline.rb:4311:in `_rl_dispatch'
    from /home/steiner/.rvm/gems/ruby-2.1.4@metasploit-framework/gems/rb-readline-0.5.1/lib/rbreadline.rb:4727:in `readline_internal_charloop'
    from /home/steiner/.rvm/gems/ruby-2.1.4@metasploit-framework/gems/rb-readline-0.5.1/lib/rbreadline.rb:4801:in `readline_internal'
    from /home/steiner/.rvm/gems/ruby-2.1.4@metasploit-framework/gems/rb-readline-0.5.1/lib/rbreadline.rb:4823:in `readline'
    from /home/steiner/repos/msf-git/lib/rex/ui/text/input/readline.rb:132:in `readline_with_output'
    from /home/steiner/repos/msf-git/lib/rex/ui/text/input/readline.rb:86:in `pgets'
    from /home/steiner/repos/msf-git/lib/rex/ui/text/shell.rb:184:in `run'
    from /home/steiner/repos/msf-git/lib/metasploit/framework/command/console.rb:30:in `start'
    from /home/steiner/repos/msf-git/lib/metasploit/framework/command/base.rb:82:in `start'
    from ./msfconsole:48:in `<main>
```

Validation:
- [x] Start msfconsole
- [x] Type in `threads show options` and hit tab twice
- [x] Don't get kicked out of msfconsole with a stack trace
