### PR TITLE
Fix jobs NilClass tab complete bug

### DIFF
--- a/lib/msf/ui/console/command_dispatcher/core.rb
+++ b/lib/msf/ui/console/command_dispatcher/core.rb
@@ -873,7 +873,7 @@ class Core
       return @@jobs_opts.fmt.keys
     end
 
-    if @@jobs_opts.fmt[words[1]][0] and (words.length == 2)
+    if words.length == 2 and (@@jobs_opts.fmt[words[1]] || [false])[0]
       return framework.jobs.keys
     end
 


### PR DESCRIPTION
The `jobs` command seems to suffer from the same NilClass bug that the `threads` command did that was addressed in #4418. When jobs is entered and tab completed with invalid values it exists msfconsole with a stack trace.

Before patch:

```
msf-git (S:0 J:0)> jobs show op/home/steiner/repos/msf-git/lib/msf/ui/console/command_dispatcher/core.rb:876:in `cmd_jobs_tabs': undefined method `[]' for nil:NilClass (NoMethodError)
    from /home/steiner/repos/msf-git/lib/rex/ui/text/dispatcher_shell.rb:357:in `tab_complete_helper'
    from /home/steiner/repos/msf-git/lib/rex/ui/text/dispatcher_shell.rb:317:in `block in tab_complete_stub'
    from /home/steiner/repos/msf-git/lib/rex/ui/text/dispatcher_shell.rb:306:in `each'
    from /home/steiner/repos/msf-git/lib/rex/ui/text/dispatcher_shell.rb:306:in `tab_complete_stub'
    from /home/steiner/repos/msf-git/lib/rex/ui/text/dispatcher_shell.rb:291:in `tab_complete'
    from /home/steiner/repos/msf-git/lib/rex/ui/text/shell.rb:59:in `block in init_tab_complete'
    from /home/steiner/repos/msf-git/lib/rex/ui/text/input/readline.rb:146:in `call'
    from /home/steiner/repos/msf-git/lib/rex/ui/text/input/readline.rb:146:in `readline'
    from /home/steiner/repos/msf-git/lib/rex/ui/text/input/readline.rb:146:in `readline_with_output'
    from /home/steiner/repos/msf-git/lib/rex/ui/text/input/readline.rb:86:in `pgets'
    from /home/steiner/repos/msf-git/lib/rex/ui/text/shell.rb:184:in `run'
    from /home/steiner/repos/msf-git/lib/metasploit/framework/command/console.rb:30:in `start'
    from /home/steiner/repos/msf-git/lib/metasploit/framework/command/base.rb:82:in `start'
    from ./msfconsole:48:in `<main>'
```

Verification steps:
- [x] Start msfconsole
- [x] Type in `jobs show op` and hit tab twice
- [x] Don't get kicked out of msfconsole with a stack trace

Did a quick grep for `_opts.fmt\[\S+\[1\]\]` to look for other occurrences and the only two instances I found are in jobs and threads which will be fixed once this is landed.
