### PR TITLE
Add preliminary module to cover 'Misfortune Cookie', CVE-2014-9222

### DIFF
--- a/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
+++ b/modules/auxiliary/scanner/http/allegro_rompager_misfortune_cookie.rb
@@ -1,0 +1,64 @@
+##
+# This module requires Metasploit: http://metasploit.com/download
+# Current source: https://github.com/rapid7/metasploit-framework
+##
+
+require 'msf/core'
+
+class Metasploit4 < Msf::Auxiliary
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Auxiliary::Scanner
+  include Msf::Auxiliary::Report
+
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name' => "Allegro Software RomPager 'Misfortune Cookie' (CVE-2014-9222) Scanner",
+      'Description' => %q(
+        This module scans for HTTP servers that appear to be vulnerable to the
+        'Misfortune Cookie' vulnerability which affects Allegro Software
+        Rompager versions before 4.34 and can allow attackers to authenticate
+        to the HTTP service as an administrator without providing valid
+        credentials, however more specifics are not yet known.
+      ),
+      'Author' => [
+        'Jon Hart <jon_hart[at]rapid7.com>', # metasploit module
+        'Lior Oppenheim' # CVE-2014-9222
+      ],
+      'References' => [
+        ['CVE', '2014-9222'],
+        ['URL', 'http://mis.fortunecook.ie']
+      ],
+      'DisclosureDate' => 'Dec 17 2014',
+      'License' => MSF_LICENSE
+    ))
+
+    register_options([
+      OptString.new('TARGETURI', [true, 'Path to fingerprint RomPager from', '/Allegro'])
+    ], self.class)
+  end
+
+  def check_host(ip)
+    res = send_request_cgi('uri' => normalize_uri(target_uri.path.to_s), 'method' => 'GET')
+    fp = http_fingerprint(response: res)
+    if /RomPager\/(?<version>[\d\.]+)$/ =~ fp
+      if Gem::Version.new(version) < Gem::Version.new('4.34')
+        report_vuln(
+          host: ip,
+          port: rport,
+          name: name,
+          refs: references
+        )
+        return Exploit::CheckCode::Appears
+      else
+        return Exploit::CheckCode::Detected
+      end
+    else
+      return Exploit::CheckCode::Safe
+    end
+  end
+
+  def run_host(ip)
+    print_good("#{peer} appears to be vulnerable") if check_host(ip) == Exploit::CheckCode::Appears
+  end
+end


### PR DESCRIPTION
The details are still largely missing, but we do know from public documentation that this affects RomPager < 4.34.

Validation involves tracking down or building a system that responds to `/Allegro` with a RomPager-like `Server` header.  Exactly what the `Server` header should look like can be seen in Recog [here](https://github.com/rapid7/recog/blob/master/xml/http_servers.xml#L2653-2665)

Against a supposedly vulnerable host:

```
msf auxiliary(allegro_rompager_misfortune_cookie) > check
[*] 10.0.1.34:8080 - The target appears to be vulnerable.
[*] Checked 1 of 1 hosts (100% complete)
msf auxiliary(allegro_rompager_misfortune_cookie) > run

[+] 10.0.1.34:8080 appears to be vulnerable
[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed
```

Against a supposedly invulnerable host:

```
msf auxiliary(allegro_rompager_misfortune_cookie) > check
[*] 10.4.25.240:8080 - The target service is running, but could not be validated.
[*] Checked 1 of 1 hosts (100% complete)
msf auxiliary(allegro_rompager_misfortune_cookie) > run

[*] Scanned 1 of 1 hosts (100% complete)
[*] Auxiliary module execution completed

```
