### PR TITLE
Fix #4414 & #4415 - exitfunc and proper null-terminated string for windows/messagebox

### DIFF
--- a/modules/payloads/singles/windows/messagebox.rb
+++ b/modules/payloads/singles/windows/messagebox.rb
@@ -86,13 +86,18 @@ EOS
   call [ebp+8]	;ExitProcess/Thread(0)
 EOS
 
-    # if exit is set to seh, overrule
+    # if exit is set to seh or none, overrule
     if datastore['EXITFUNC'].upcase.strip == "SEH"
       # routine to exit via exception
       doexit = <<EOS
   xor eax,eax
   call eax
 EOS
+      getexitfunc = ''
+    elsif datastore['EXITFUNC'].upcase.strip == "NONE"
+      doexit = <<-EOS
+      nop
+      EOS
       getexitfunc = ''
     end
 
@@ -232,6 +237,7 @@ start_main:
   push 0x41206c6c
   push 0x642e3233
   push 0x72657375    	;user32.dll
+  xor bl,bl           ;make sure we have a null byte
   mov [esp+0xA],bl		;null byte
   mov esi,esp			;put pointer to string on top of stack
   push esi


### PR DESCRIPTION
This patch fixes the following for messagebox.rb

**Issue 1 (#4415)**
When exitfunc is none, the payload will not be able to generate due to an "invalid opcode" error. Example of this issue:

```
$ ./msfvenom -p windows/messagebox exitfunc=none -f exe > /tmp/msg.exe
No platform was selected, choosing Msf::Module::Platform::Windows from the payload
No Arch selected, selecting Arch: x86 from the payload
invalid opcode near "ebx" at "\"<unk>\"" line 106
```

**Issue 2: (#4414)**
After "user32.dll" is pushed onto the stack for the LoadLibrary call, the payload does not actually ensure bl is a null byte, it just assumes it is and uses it to modify the stack to create the null-terminated string.

Fix #4414
Fix #4415 
## Verification
- [ ] Run this: `./msfvenom -p windows/messagebox exitfunc=none -f exe > /tmp/msg.exe`
- [ ] You should not see an error. Also, /tmp/msg.exe should not be an empty file.
- [ ] Drag msg.exe to a Windows XP box
- [ ] Double click on msg.exe, you should see "Hello, from MSF!" like the following:

![screen shot 2014-12-19 at 3 30 07 am](https://cloud.githubusercontent.com/assets/1170914/5502423/5f958e1c-872f-11e4-8513-e4a963bc4be3.png)
