### PR TITLE
Update mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -76,25 +76,29 @@ m-1-k-3 <m-1-k-3@github>               m-1-k-3 <m1k3@s3cur1ty.de>
 m-1-k-3 <m-1-k-3@github>               m-1-k-3 <michael.messner@integralis.com>
 Meatballs1 <Meatballs1@github>         Ben Campbell <eat_meatballs@hotmail.co.uk>
 Meatballs1 <Meatballs1@github>         Meatballs <eat_meatballs@hotmail.co.uk>
-Meatballs1 <Meatballs1@github>         Meatballs1 <eat_meatballs@hotmail.co.uk> 
+Meatballs1 <Meatballs1@github>         Meatballs1 <eat_meatballs@hotmail.co.uk>
 mubix <mubix@github>                   Rob Fuller <jd.mubix@gmail.com>
 nevdull77 <nevdull77@github>           Patrik Karlsson <patrik@cqure.net>
-nmonkee <nmonkee@github>               nmonkee <dave@northern-monkee.co.uk> 
+nmonkee <nmonkee@github>               nmonkee <dave@northern-monkee.co.uk>
 nullbind <nullbind@github>             nullbind <scott.sutherland@nullbind.com>
+nullbind <nullbind@github>             Scott Sutherland <scott.sutherland@nullbind.com>
 ohdae <ohdae@github>                   ohdae <bindshell@live.com>
-OJ <oj@github>                         OJ Reeves <oj@buffered.io>
 OJ <oj@github>                         OJ <oj@buffered.io>
+OJ <oj@github>                         OJ Reeves <oj@buffered.io>
 r3dy <r3dy@github>                     Royce Davis <r3dy@Royces-MacBook-Pro.local>
 r3dy <r3dy@github>                     Royce Davis <royce.e.davis@gmail.com>
 Rick Flores <0xnanoquetz9l@gmail.com>  Rick Flores (nanotechz9l) <0xnanoquetz9l@gmail.com>
 rsmudge <rsmudge@github>               Raphael Mudge <rsmudge@gmail.com> # Aka `butane
 schierlm <schierlm@github>             Michael Schierl <schierlm@gmx.de> # Aka mihi
 scriptjunkie <scriptjunkie@github>     Matt Weeks <scriptjunkie@scriptjunkie.us>
+scriptjunkie <scriptjunkie@github>     scriptjunkie <scriptjunkie@scriptjunkie.us>
 skape <skape@???>                      Matt Miller <mmiller@hick.org>
 spoonm <spoonm@github>                 Spoon M <spoonm@gmail.com>
 swtornio <swtornio@github>             Steve Tornio <swtornio@gmail.com>
 Tasos Laskos <Tasos_Laskos@rapid7.com> Tasos Laskos <Tasos_Laskos@rapid7.com>
+timwr <timwr@github>                   Tim Wright <timrlw@gmail.com>
 TrustedSec <davek@trustedsec.com>      trustedsec <davek@trustedsec.com>
+zeroSteiner <zeroSteiner@github>       Spencer McIntyre <zeroSteiner@gmail.com>
 
 # Aliases for utility author names. Since they're fake, typos abound
 

--- a/.mailmap
+++ b/.mailmap
@@ -1,30 +1,40 @@
+bcook-r7 <bcook-r7@github>         Brent Cook <bcook@rapid7.com>
 bturner-r7 <bturner-r7@github>     Brandon Turner <brandon_turner@rapid7.com>
+dheiland-r7 <dheiland-r7@github>   Deral Heiland <dh@layereddefense.com>
+dmaloney-r7 <dmaloney-r7@github>   David Maloney <DMaloney@rapid7.com>
 dmaloney-r7 <dmaloney-r7@github>   David Maloney <David_Maloney@rapid7.com>
-dmaloney-r7 <dmaloney-r7@github>   David Maloney <DMaloney@rapid7.com> # aka TheLightCosine
+dmaloney-r7 <dmaloney-r7@github>   dmaloney-r7 <DMaloney@rapid7.com>
 ecarey-r7 <ecarey-r7@github>       Erran Carey <e@ipwnstuff.com>
 farias-r7 <farias-r7@github>       Fernando Arias <fernando_arias@rapid7.com>
 hmoore-r7 <hmoore-r7@github>       HD Moore <hd_moore@rapid7.com>
 hmoore-r7 <hmoore-r7@github>       HD Moore <hdm@digitaloffense.net>
-jlee-r7 <jlee-r7@github>           egypt <egypt@metasploit.com> # aka egypt
-jlee-r7 <jlee-r7@github>           James Lee <egypt@metasploit.com> # aka egypt
+jhart-r7 <jhart-r7@github>         Jon Hart <jon_hart@rapid7.com>
 jlee-r7 <jlee-r7@github>           James Lee <James_Lee@rapid7.com>
-joev-r7 <joev-r7@github>           joev <joev@metasploit.com>
+jlee-r7 <jlee-r7@github>           James Lee <egypt@metasploit.com> # aka egypt
+jlee-r7 <jlee-r7@github>           egypt <egypt@metasploit.com> # aka egypt
 joev-r7 <joev-r7@github>           Joe Vennix <Joe_Vennix@rapid7.com>
+joev-r7 <joev-r7@github>           joev <joev@metasploit.com>
 jvazquez-r7 <jvazquez-r7@github>   jvazquez-r7 <juan.vazquez@metasploit.com>
 jvazquez-r7 <jvazquez-r7@github>   jvazquez-r7 <juan_vazquez@rapid7.com>
 limhoff-r7 <limhoff-r7@github>     Luke Imhoff <luke_imhoff@rapid7.com>
+lsanchez-r7 <lsanchez-r7@github>   Lance Sanchez <lance.sanchez+github@gmail.com>
+lsanchez-r7 <lsanchez-r7@github>   darkbushido <lance.sanchez@gmail.com>
+mbuck-r7 <mbuck-r7@github>         Matt Buck <Matthew_Buck@rapid7.com>
+mbuck-r7 <mbuck-r7@github>         Matt Buck <techpeace@gmail.com>
+parzamendi-r7 <parzamendi-r7@github> parzamendi-r7 <peter_arzamendi@rapid7.com>
 shuckins-r7 <shuckins-r7@github>   Samuel Huckins <samuel_huckins@rapid7.com>
 todb-r7 <todb-r7@github>           Tod Beardsley <tod_beardsley@rapid7.com>
 todb-r7 <todb-r7@github>           Tod Beardsley <todb@metasploit.com>
 todb-r7 <todb-r7@github>           Tod Beardsley <todb@packetfu.com>
 trosen-r7 <trosen-r7@github>       Trevor Rosen <Trevor_Rosen@rapid7.com>
 trosen-r7 <trosen-r7@github>       Trevor Rosen <trevor@catapult-creative.com>
+wchen-r7 <wchen-r7@github>         Wei Chen <Wei_Chen@rapid7.com>
 wchen-r7 <wchen-r7@github>         sinn3r <msfsinn3r@gmail.com> # aka sinn3r
 wchen-r7 <wchen-r7@github>         sinn3r <wei_chen@rapid7.com>
-wchen-r7 <wchen-r7@github>         Wei Chen <Wei_Chen@rapid7.com>
 wvu-r7 <wvu-r7@github>             William Vu <William_Vu@rapid7.com>
 wvu-r7 <wvu-r7@github>             William Vu <wvu@metasploit.com>
 wvu-r7 <wvu-r7@github>             William Vu <wvu@nmt.edu>
+wvu-r7 <wvu-r7@github>             wvu-r7 <William_Vu@rapid7.com>
 
 # Above this line are current Rapid7 employees. Below this paragraph are
 # volunteers, former employees, and potential Rapid7 employees who, at


### PR DESCRIPTION
The .mailmap file is used for generating stats about committers that we find useful.
## Verification
- [x] `git log --format="%aN <%aE>" sprint-F00...HEAD | sort | uniq` should produce a list of people with commits without any obvious duplicates among the people listed in the `.mailmap` file.
- [x] Rapid7 employees should always be referenced by their Rapid7 GitHub username.
