### PR TITLE
Fix jcxz to jecxz for x86_64 in metasm

### DIFF
--- a/lib/metasm/metasm/cpu/x86_64/opcodes.rb
+++ b/lib/metasm/metasm/cpu/x86_64/opcodes.rb
@@ -61,7 +61,7 @@ class X86_64
 
     addop('movq',  [0x0F, 0x6E], :mrmmmx, {:d => [1, 4]}) { |o| o.args = [:modrm, :regmmx] ; o.props[:opsz] = o.props[:argsz] = 64 }
     addop('movq',  [0x0F, 0x6E], :mrmxmm, {:d => [1, 4]}) { |o| o.args = [:modrm, :regxmm] ; o.props[:opsz] = o.props[:argsz] = 64 ; o.props[:needpfx] = 0x66 }
-    addop('jcxz', [0xE3], nil, :setip, :i8) { |o| o.props[:adsz] = 32 }	# actually 16 (cx), but x64 in general says pfx 0x67 => adsz = 32
+    addop('jecxz', [0xE3], nil, :setip, :i8) { |o| o.props[:adsz] = 32 }	# actually 16 (cx), but x64 in general says pfx 0x67 => adsz = 32
     addop('jrcxz', [0xE3], nil, :setip, :i8) { |o| o.props[:adsz] = 64 }
   end
 


### PR DESCRIPTION
This fixes "invalid opcode near 'jecxz'" for x64 metasm encoding. The bug report for this is #4405, but I decided not to tag it because the best solution (based on @jlee-r7's feedback) is to create a gem for metasm. However before that happens, I think it's easier to just merge this patch first, that way we at least have a working x64 PrependMigrate.
## Verification

It's VERY easy to do.
- [x] Please just follow this demonstration:

```
$ ./msfconsole -q
msf > use exploit/multi/handler 
msf exploit(handler) > set payload windows/x64/meterpreter/reverse_tcp
payload => windows/x64/meterpreter/reverse_tcp
msf exploit(handler) > set lhost [IP]
lhost => [IP]
msf exploit(handler) > set prependmigrate true
prependmigrate => true
msf exploit(handler) > run
```
- [x] If you don't have the patch you will get: "Exploit failed: invalid opcode near "jecxz" at "\"<unk>\"" line 42"
- [x] If you have the patch, the listener should start.
