### PR TITLE
Fix #4430 - Add support for -o to save the payload to disk

### DIFF
--- a/msfvenom
+++ b/msfvenom
@@ -312,6 +312,9 @@ if __FILE__ == $0
     $stderr.puts e.message
   end
 
+  # No payload generated, no point to go on
+  exit(0) unless payload
+
   if generator_opts[:out]
     begin
       ::File.open(generator_opts[:out], 'wb') do |f|

--- a/msfvenom
+++ b/msfvenom
@@ -117,8 +117,12 @@ require 'msf/core/payload_generator'
       opts[:keep] = true
     end
 
-    opt.on('-o', '--options', "List the payload's standard options") do
+    opt.on('--payload-options', "List the payload's standard options") do
       opts[:list_options] = true
+    end
+
+    opt.on('-o', '--out   <path>', 'Save the payload') do |x|
+      opts[:out] = x
     end
 
     opt.on('-v', '--var-name <name>', String, 'Specify a custom variable name to use for certain output formats') do |x|
@@ -308,8 +312,21 @@ if __FILE__ == $0
     $stderr.puts e.message
   end
 
-  output_stream = $stdout
-  output_stream.binmode
-  output_stream.write payload
+  if generator_opts[:out]
+    begin
+      ::File.open(generator_opts[:out], 'wb') do |f|
+        f.write(payload)
+      end
+      $stderr.puts "Saved as: #{generator_opts[:out]}"
+    rescue ::Exception => e
+      # If I can't save it, then I can't save it. I don't think it matters what error.
+      elog("#{e.class} : #{e.message}\n#{e.backtrace * "\n"}")
+      $stderr.puts e.message
+    end
+  else
+    output_stream = $stdout
+    output_stream.binmode
+    output_stream.write payload
+  end
 
 end

--- a/msfvenom
+++ b/msfvenom
@@ -313,7 +313,7 @@ if __FILE__ == $0
   end
 
   # No payload generated, no point to go on
-  exit(0) unless payload
+  exit(-1) unless payload
 
   if generator_opts[:out]
     begin


### PR DESCRIPTION
Fix #4430 

This adds -o as a new flag to save the payload to disk.

@FireFart Let me know if this is how you like it.
## Verification

Try this:
- [x] Do `./msfvenom -p windows/meterpreter/bind_tcp -f exe -o /tmp/yoo.exe`
- [x] You should see that the payload is saved to /tmp/yoo.exe
- [x] And it does not print the payload on screen.

And then this:
- [x] Do `./msfvenom -p windows/meterpreter/bind_tcp -f exe > /tmp/test2.exe`
- [x] You should see that the payload is saved to /tmp/test2.exe
- [x] And it does not print the payload on screen

And then this:
- [x] Do `./msfvenom -p windows/meterpreter/bind_tcp -f exe`
- [x] It should print the payload on screen

And then this:
- [x] Do `./msfvenom -p windows/meterpreter/bind_tcp --payload-options`
- [x] It should dump windows/meterpreter/bind_tcp's options
