### PR TITLE
Remove references to Redmine in code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_install:
   - sudo apt-get install -qq libpcap-dev
   # Uncomment when we have fewer shipping msftidy warnings.
   # Merge committers will still be checking, just not autofailing.
-  # See https://dev.metasploit.com/redmine/issues/8498
   # - ln -sf ../../tools/dev/pre-commit-hook.rb ./.git/hooks/post-merge
   # - ls -la ./.git/hooks
   # - ./.git/hooks/post-merge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Pull requests [#2940](https://github.com/rapid7/metasploit-framework/pull/2940) 
 #### New Modules
 
 * **Do** run `tools/msftidy.rb` against your module and fix any errors or warnings that come up. Even better would be to set up `msftidy.rb` as a [pre-commit hook](https://github.com/rapid7/metasploit-framework/blob/master/tools/dev/pre-commit-hook.rb).
-* **Do** use the [many module mixin APIs](https://dev.metasploit.com/api/). Wheel improvements are welcome; wheel reinventions, not so much.
+* **Do** use the [many module mixin APIs](https://rapid7.github.io/metasploit-framework/api/). Wheel improvements are welcome; wheel reinventions, not so much.
 * **Don't** include more than one module per pull request.
 
 #### Library Code

--- a/README.md
+++ b/README.md
@@ -4,23 +4,20 @@ Metasploit [![Build Status](https://travis-ci.org/rapid7/metasploit-framework.pn
 The Metasploit Framework is released under a BSD-style license. See
 COPYING for more details.
 
-The latest version of this software is available from http://metasploit.com/
+The latest version of this software is available from https://metasploit.com/
 
 Bug tracking and development information can be found at:
- https://dev.metasploit.com/redmine/projects/framework/
-
-The public GitHub source repository can be found at:
  https://github.com/rapid7/metasploit-framework
 
+API documentation for writing modules can be found at:
+  https://rapid7.github.io/metasploit-framework/api
+
 Questions and suggestions can be sent to:
- msfdev(at)metasploit.com
+  https://lists.sourceforge.net/lists/listinfo/metasploit-hackers
 
-The framework mailing list is the place to discuss features and ask for help.
-To subscribe, visit the following web page:
- https://mail.metasploit.com/mailman/listinfo/framework
-
-The mailing list archives are available from:
- https://mail.metasploit.com/pipermail/framework/
+An up-to-date list of useful Metasploit development resources is
+maintained at:
+  https://metasploit.github.io
 
 Installing
 --

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 Metasploit [![Build Status](https://travis-ci.org/rapid7/metasploit-framework.png)](https://travis-ci.org/rapid7/metasploit-framework) [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/rapid7/metasploit-framework)
 ==
 The Metasploit Framework is released under a BSD-style license. See
@@ -15,10 +14,6 @@ API documentation for writing modules can be found at:
 Questions and suggestions can be sent to:
   https://lists.sourceforge.net/lists/listinfo/metasploit-hackers
 
-An up-to-date list of useful Metasploit development resources is
-maintained at:
-  https://metasploit.github.io
-
 Installing
 --
 
@@ -31,10 +26,8 @@ Using Metasploit
 --
 Metasploit can do all sorts of things. The first thing you'll want to do
 is start `msfconsole`, but after that, you'll probably be best served by
-reading some of the great tutorials online:
-
-  * [Metasploit Unleashed][unleashed]
-  * [The official Metasploit wiki on Github][wiki-start]
+reading [Metasploit Unleashed][unleashed], the [great community
+resources](https://metasploit.github.io), or the [wiki].
 
 Contributing
 --
@@ -45,6 +38,7 @@ pull request. For slightly more info, see
 [Contributing](https://github.com/rapid7/metasploit-framework/blob/master/CONTRIBUTING.md).
 
 
+[wiki]: https://github.com/rapid7/metasploit-framework/wiki
 [wiki-devenv]: https://github.com/rapid7/metasploit-framework/wiki/Setting-Up-a-Metasploit-Development-Environment "Metasploit Development Environment Setup"
 [wiki-start]: https://github.com/rapid7/metasploit-framework/wiki/ "Metasploit Wiki"
 [wiki-usage]: https://github.com/rapid7/metasploit-framework/wiki/Using-Metasploit "Using Metasploit"

--- a/data/meterpreter/meterpreter.php
+++ b/data/meterpreter/meterpreter.php
@@ -920,7 +920,7 @@ function read($resource, $len=null) {
         # whole php process will block waiting for data that may never come.
         # Unfortunately, selecting on pipes created with proc_open on Windows
         # always returns immediately.  Basically, shell interaction in Windows
-        # is hosed until this gets figured out.  See https://dev.metasploit.com/redmine/issues/2232
+        # is hosed until this gets figured out.
         $r = Array($resource);
         my_print("Calling select to see if there's data on $resource");
         while (true) {

--- a/lib/msf/core/exploit/oracle.rb
+++ b/lib/msf/core/exploit/oracle.rb
@@ -45,7 +45,7 @@ module Exploit::ORACLE
   def check_dependencies
     if not @oci8_loaded
       print_error("Failed to load the OCI library: #{@oci8_error}")
-      print_error("See http://www.metasploit.com/redmine/projects/framework/wiki/OracleUsage for installation instructions")
+      print_error("Try 'gem install ruby-oci8'")
       return false
     end
     return true

--- a/lib/msf/util/exe.rb
+++ b/lib/msf/util/exe.rb
@@ -1928,7 +1928,7 @@ to_linux_x86_elf(framework, code, exeopts)
   end
 
   #
-  # EICAR Canary: https://www.metasploit.com/redmine/projects/framework/wiki/EICAR
+  # EICAR Canary
   #
   def self.is_eicar_corrupted?
     path = ::File.expand_path(::File.join(

--- a/lib/rex/post/meterpreter/client_core.rb
+++ b/lib/rex/post/meterpreter/client_core.rb
@@ -280,7 +280,7 @@ class ClientCore < Extension
         # good bet that migration failed and the remote side is hung.
         # Since we have the comm_mutex here, we *must* release it to
         # keep from hanging the packet dispatcher thread, which results
-        # in blocking the entire process. See Redmine #8794
+        # in blocking the entire process.
         begin
           Timeout.timeout(60) do
             # Renegotiate SSL over this socket

--- a/modules/auxiliary/scanner/http/cisco_nac_manager_traversal.rb
+++ b/modules/auxiliary/scanner/http/cisco_nac_manager_traversal.rb
@@ -22,8 +22,7 @@ class Metasploit3 < Msf::Auxiliary
         [
           [ 'CVE', '2011-3305' ],
           [ 'OSVDB', '76080'],
-          [ 'URL', 'http://www.cisco.com/warp/public/707/cisco-sa-20111005-nac.shtml' ],
-          [ 'URL', 'http://dev.metasploit.com/redmine/issues/5673' ]
+          [ 'URL', 'http://www.cisco.com/warp/public/707/cisco-sa-20111005-nac.shtml' ]
         ],
       'Author'      => [ 'Nenad Stojanovski <nenad.stojanovski[at]gmail.com>' ],
       'License'     => MSF_LICENSE

--- a/modules/auxiliary/scanner/http/http_login.rb
+++ b/modules/auxiliary/scanner/http/http_login.rb
@@ -32,7 +32,7 @@ class Metasploit3 < Msf::Auxiliary
           [ 'CVE', '1999-0502'] # Weak password
         ],
       'License'        => MSF_LICENSE,
-      # See https://dev.metasploit.com/redmine/issues/8814
+      # See https://github.com/rapid7/metasploit-framework/issues/3811
       #'DefaultOptions' => {
       #  'USERPASS_FILE' => File.join(Msf::Config.data_directory, "wordlists", "http_default_userpass.txt"),
       #  'USER_FILE' => File.join(Msf::Config.data_directory, "wordlists", "http_default_users.txt"),

--- a/modules/exploits/linux/misc/hp_nnmi_pmd_bof.rb
+++ b/modules/exploits/linux/misc/hp_nnmi_pmd_bof.rb
@@ -88,7 +88,6 @@ class Metasploit3 < Msf::Exploit::Remote
     res = udp_sock.timed_read(8, 1)
     if res.blank?
       # To mitigate MacOSX udp sockets behavior
-      # see https://dev.metasploit.com/redmine/issues/7480
       udp_sock.put(pkt)
       res = udp_sock.timed_read(8)
     end
@@ -112,7 +111,6 @@ class Metasploit3 < Msf::Exploit::Remote
     res = udp_sock.timed_read(13964, 1)
     if res.blank?
       # To mitigate MacOSX udp sockets behavior
-      # see https://dev.metasploit.com/redmine/issues/7480
       udp_sock.put(proto_tbl_pkt)
       res = udp_sock.timed_read(13964)
     end

--- a/modules/exploits/multi/http/struts_default_action_mapper.rb
+++ b/modules/exploits/multi/http/struts_default_action_mapper.rb
@@ -107,7 +107,7 @@ class Metasploit3 < Msf::Exploit::Remote
 
   def start_http_service
     # do not use SSL for this part
-    # XXX: See https://dev.metasploit.com/redmine/issues/8498
+    # XXX: See https://github.com/rapid7/metasploit-framework/issues/3853
     # It must be possible to do this without directly editing the
     # datastore.
     if datastore['SSL']
@@ -133,7 +133,7 @@ class Metasploit3 < Msf::Exploit::Remote
     })
 
     # Restore SSL preference
-    # XXX: See https://dev.metasploit.com/redmine/issues/8498
+    # XXX: See https://github.com/rapid7/metasploit-framework/issues/3853
     # It must be possible to do this without directly editing the
     # datastore.
     datastore['SSL'] = true if ssl_restore

--- a/modules/exploits/unix/http/ctek_skyrouter.rb
+++ b/modules/exploits/unix/http/ctek_skyrouter.rb
@@ -20,7 +20,8 @@ class Metasploit3 < Msf::Exploit::Remote
       'Author'         => [ 'savant42' ],  #with module help from kos
       'License'        => MSF_LICENSE,
       'References'     => [
-                  ['URL', 'http://dev.metasploit.com/redmine/issues/5610']
+                  ['CVE', '2011-5010'],
+                  ['OSVDB', '77497']
                 ],
       'Privileged'     => false,
       'Payload'        =>

--- a/modules/exploits/windows/misc/altiris_ds_sqli.rb
+++ b/modules/exploits/windows/misc/altiris_ds_sqli.rb
@@ -170,8 +170,7 @@ Processor-Speed=#{processor_speed}
     #parent process ID, Kill the parent.
     #This module doesn't use FileDropper because of timing issues when
     #using migrate -f and FileDropper. On the other hand PrependMigrate
-    #has been avoided because of issues with reverse_https payload
-    #SeeRM#8365 https://http://dev.metasploit.com/redmine/issues/8365
+    #has been avoided because of older issues with reverse_https payload
 
     unless client.type == "meterpreter"
       print_error("Automatic cleanup only available with meterpreter, please delete #{stager_instance.payload_exe} manually")

--- a/modules/exploits/windows/scada/daq_factory_bof.rb
+++ b/modules/exploits/windows/scada/daq_factory_bof.rb
@@ -106,8 +106,7 @@ class Metasploit3 < Msf::Exploit::Remote
     sploit << rand_text_alpha_upper(finaloffset-egg.length)
 
     # The use of rand_text_alpha_upper() ensures we always get the same length for the
-    # first IP address. See the following for more details:
-    # http://dev.metasploit.com/redmine/issues/5453
+    # first IP address.
     sploit[12,4] = rand_text_alpha_upper(4)
 
     udp_sock.put(sploit)

--- a/spec/lib/msf/ui/command_dispatcher/db_spec.rb
+++ b/spec/lib/msf/ui/command_dispatcher/db_spec.rb
@@ -270,7 +270,7 @@ describe Msf::Ui::Console::CommandDispatcher::Db do
         FactoryGirl.create(:mdm_service, :host => host, :port => 1026)
       end
       it "should list services that are not on a given port" do
-        skip("refs redmine ticket #4821") {
+        skip {
           db.cmd_services "-np", "1024"
 
           @output.should =~ [

--- a/tools/msftidy.rb
+++ b/tools/msftidy.rb
@@ -532,10 +532,8 @@ class Msftidy
         error("Writes to stdout", idx)
       end
 
-      # You should not change datastore in code. For reasons. See
-      # RM#8498 for discussion, starting at comment #16:
-      #
-      # https://dev.metasploit.com/redmine/issues/8498#note-16
+      # You should not change datastore in code. See
+      # https://github.com/rapid7/metasploit-framework/issues/3853
       if ln =~ /(?<!\.)datastore\[["'][^"']+["']\]\s*(=|<<)(?![=~>])/
         info("datastore is modified in code with '#{Regexp.last_match(1)}': #{ln}", idx)
       end


### PR DESCRIPTION
See #4400. This should be all of them, except for, of course, the module that targets Redmine itself.

Note that this also updates the README.md with more current information as well.

We should not expect our Redmine instance to be up for much longer. If the bugs that say "See Remdine issue 1234" are not actually resolved yet, my guess is that those issues should be recreated on GitHub. However, if they haven't the bugs described are either resolved, or haven't been important enough to survive triage.
